### PR TITLE
feat: Add per partition sort and finish callback to sinks

### DIFF
--- a/crates/polars-expr/src/reduce/mod.rs
+++ b/crates/polars-expr/src/reduce/mod.rs
@@ -15,6 +15,7 @@ use std::marker::PhantomData;
 use arrow::array::{Array, PrimitiveArray, StaticArray};
 use arrow::bitmap::{Bitmap, BitmapBuilder, MutableBitmap};
 pub use convert::into_reduction;
+pub use min_max::{new_min_reduction, new_max_reduction};
 use polars_core::prelude::*;
 
 use crate::EvictIdx;

--- a/crates/polars-expr/src/reduce/mod.rs
+++ b/crates/polars-expr/src/reduce/mod.rs
@@ -15,7 +15,7 @@ use std::marker::PhantomData;
 use arrow::array::{Array, PrimitiveArray, StaticArray};
 use arrow::bitmap::{Bitmap, BitmapBuilder, MutableBitmap};
 pub use convert::into_reduction;
-pub use min_max::{new_min_reduction, new_max_reduction};
+pub use min_max::{new_max_reduction, new_min_reduction};
 use polars_core::prelude::*;
 
 use crate::EvictIdx;

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -1089,6 +1089,8 @@ impl LazyFrame {
         options: ParquetWriteOptions,
         cloud_options: Option<polars_io::cloud::CloudOptions>,
         sink_options: SinkOptions,
+        per_partition_preprocess: PerPartitionPreprocess,
+        finish_callback: Option<SinkFinishCallback>,
     ) -> PolarsResult<Self> {
         self.sink(SinkType::Partition(PartitionSinkType {
             base_path,
@@ -1097,6 +1099,8 @@ impl LazyFrame {
             variant,
             file_type: FileType::Parquet(options),
             cloud_options,
+            per_partition_preprocess,
+            finish_callback,
         }))
     }
 
@@ -1112,6 +1116,8 @@ impl LazyFrame {
         options: IpcWriterOptions,
         cloud_options: Option<polars_io::cloud::CloudOptions>,
         sink_options: SinkOptions,
+        per_partition_preprocess: PerPartitionPreprocess,
+        finish_callback: Option<SinkFinishCallback>,
     ) -> PolarsResult<Self> {
         self.sink(SinkType::Partition(PartitionSinkType {
             base_path,
@@ -1120,6 +1126,8 @@ impl LazyFrame {
             variant,
             file_type: FileType::Ipc(options),
             cloud_options,
+            per_partition_preprocess,
+            finish_callback,
         }))
     }
 
@@ -1135,6 +1143,8 @@ impl LazyFrame {
         options: CsvWriterOptions,
         cloud_options: Option<polars_io::cloud::CloudOptions>,
         sink_options: SinkOptions,
+        per_partition_preprocess: PerPartitionPreprocess,
+        finish_callback: Option<SinkFinishCallback>,
     ) -> PolarsResult<Self> {
         self.sink(SinkType::Partition(PartitionSinkType {
             base_path,
@@ -1143,6 +1153,8 @@ impl LazyFrame {
             variant,
             file_type: FileType::Csv(options),
             cloud_options,
+            per_partition_preprocess,
+            finish_callback,
         }))
     }
 
@@ -1158,6 +1170,8 @@ impl LazyFrame {
         options: JsonWriterOptions,
         cloud_options: Option<polars_io::cloud::CloudOptions>,
         sink_options: SinkOptions,
+        per_partition_preprocess: PerPartitionPreprocess,
+        finish_callback: Option<SinkFinishCallback>,
     ) -> PolarsResult<Self> {
         self.sink(SinkType::Partition(PartitionSinkType {
             base_path,
@@ -1166,6 +1180,8 @@ impl LazyFrame {
             variant,
             file_type: FileType::Json(options),
             cloud_options,
+            per_partition_preprocess,
+            finish_callback,
         }))
     }
 

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -1081,6 +1081,7 @@ impl LazyFrame {
     /// final result doesn't fit into memory. This methods will return an error if the query cannot
     /// be completely done in a streaming fashion.
     #[cfg(feature = "parquet")]
+    #[allow(clippy::too_many_arguments)]
     pub fn sink_parquet_partitioned(
         self,
         base_path: Arc<PathBuf>,
@@ -1108,6 +1109,7 @@ impl LazyFrame {
     /// final result doesn't fit into memory. This methods will return an error if the query cannot
     /// be completely done in a streaming fashion.
     #[cfg(feature = "ipc")]
+    #[allow(clippy::too_many_arguments)]
     pub fn sink_ipc_partitioned(
         self,
         base_path: Arc<PathBuf>,
@@ -1135,6 +1137,7 @@ impl LazyFrame {
     /// result doesn't fit into memory. This methods will return an error if the query cannot be
     /// completely done in a streaming fashion.
     #[cfg(feature = "csv")]
+    #[allow(clippy::too_many_arguments)]
     pub fn sink_csv_partitioned(
         self,
         base_path: Arc<PathBuf>,
@@ -1162,6 +1165,7 @@ impl LazyFrame {
     /// result doesn't fit into memory. This methods will return an error if the query cannot be
     /// completely done in a streaming fashion.
     #[cfg(feature = "json")]
+    #[allow(clippy::too_many_arguments)]
     pub fn sink_json_partitioned(
         self,
         base_path: Arc<PathBuf>,

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -1089,7 +1089,7 @@ impl LazyFrame {
         options: ParquetWriteOptions,
         cloud_options: Option<polars_io::cloud::CloudOptions>,
         sink_options: SinkOptions,
-        per_partition_preprocess: PerPartitionPreprocess,
+        per_partition_sort_by: Option<Vec<SortColumn>>,
         finish_callback: Option<SinkFinishCallback>,
     ) -> PolarsResult<Self> {
         self.sink(SinkType::Partition(PartitionSinkType {
@@ -1099,7 +1099,7 @@ impl LazyFrame {
             variant,
             file_type: FileType::Parquet(options),
             cloud_options,
-            per_partition_preprocess,
+            per_partition_sort_by,
             finish_callback,
         }))
     }
@@ -1116,7 +1116,7 @@ impl LazyFrame {
         options: IpcWriterOptions,
         cloud_options: Option<polars_io::cloud::CloudOptions>,
         sink_options: SinkOptions,
-        per_partition_preprocess: PerPartitionPreprocess,
+        per_partition_sort_by: Option<Vec<SortColumn>>,
         finish_callback: Option<SinkFinishCallback>,
     ) -> PolarsResult<Self> {
         self.sink(SinkType::Partition(PartitionSinkType {
@@ -1126,7 +1126,7 @@ impl LazyFrame {
             variant,
             file_type: FileType::Ipc(options),
             cloud_options,
-            per_partition_preprocess,
+            per_partition_sort_by,
             finish_callback,
         }))
     }
@@ -1143,7 +1143,7 @@ impl LazyFrame {
         options: CsvWriterOptions,
         cloud_options: Option<polars_io::cloud::CloudOptions>,
         sink_options: SinkOptions,
-        per_partition_preprocess: PerPartitionPreprocess,
+        per_partition_sort_by: Option<Vec<SortColumn>>,
         finish_callback: Option<SinkFinishCallback>,
     ) -> PolarsResult<Self> {
         self.sink(SinkType::Partition(PartitionSinkType {
@@ -1153,7 +1153,7 @@ impl LazyFrame {
             variant,
             file_type: FileType::Csv(options),
             cloud_options,
-            per_partition_preprocess,
+            per_partition_sort_by,
             finish_callback,
         }))
     }
@@ -1170,7 +1170,7 @@ impl LazyFrame {
         options: JsonWriterOptions,
         cloud_options: Option<polars_io::cloud::CloudOptions>,
         sink_options: SinkOptions,
-        per_partition_preprocess: PerPartitionPreprocess,
+        per_partition_sort_by: Option<Vec<SortColumn>>,
         finish_callback: Option<SinkFinishCallback>,
     ) -> PolarsResult<Self> {
         self.sink(SinkType::Partition(PartitionSinkType {
@@ -1180,7 +1180,7 @@ impl LazyFrame {
             variant,
             file_type: FileType::Json(options),
             cloud_options,
-            per_partition_preprocess,
+            per_partition_sort_by,
             finish_callback,
         }))
     }

--- a/crates/polars-plan/src/dsl/options/sink.rs
+++ b/crates/polars-plan/src/dsl/options/sink.rs
@@ -100,6 +100,13 @@ impl SinkTarget {
             )),
         }
     }
+
+    pub fn to_display_string(&self) -> String {
+        match self {
+            Self::Path(p) => p.display().to_string(),
+            Self::Dyn(_) => "dynamic-target".to_string(),
+        }
+    }
 }
 
 impl fmt::Debug for SinkTarget {

--- a/crates/polars-plan/src/dsl/options/sink.rs
+++ b/crates/polars-plan/src/dsl/options/sink.rs
@@ -500,6 +500,7 @@ pub enum PartitionVariantIR {
     },
 }
 
+#[cfg(feature = "cse")]
 impl SinkTypeIR {
     pub(crate) fn traverse_and_hash<H: Hasher>(&self, expr_arena: &Arena<AExpr>, state: &mut H) {
         std::mem::discriminant(self).hash(state);

--- a/crates/polars-plan/src/dsl/options/sink.rs
+++ b/crates/polars-plan/src/dsl/options/sink.rs
@@ -417,14 +417,14 @@ pub struct SortColumnIR {
 #[derive(Clone, Debug, PartialEq)]
 pub struct PerPartitionPreprocess {
     pub sort_by: Option<Vec<SortColumn>>,
-    pub gather: Option<Vec<Expr>>,
+    pub reductions: Option<Vec<Expr>>,
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct PerPartitionPreprocessIR {
     pub sort_by: Option<Vec<SortColumnIR>>,
-    pub gather: Option<Vec<ExprIR>>,
+    pub reductions: Option<Vec<ExprIR>>,
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -436,7 +436,7 @@ pub struct PartitionSinkType {
     pub sink_options: SinkOptions,
     pub variant: PartitionVariant,
     pub cloud_options: Option<polars_io::cloud::CloudOptions>,
-    pub per_partition_preprocess: Option<PerPartitionPreprocess>,
+    pub per_partition_preprocess: PerPartitionPreprocess,
     pub finish_callback: Option<SinkFinishCallback>,
 }
 
@@ -449,7 +449,7 @@ pub struct PartitionSinkTypeIR {
     pub sink_options: SinkOptions,
     pub variant: PartitionVariantIR,
     pub cloud_options: Option<polars_io::cloud::CloudOptions>,
-    pub per_partition_preprocess: Option<PerPartitionPreprocessIR>,
+    pub per_partition_preprocess: PerPartitionPreprocessIR,
     pub finish_callback: Option<SinkFinishCallback>,
 }
 
@@ -509,10 +509,7 @@ impl PartitionSinkTypeIR {
         self.sink_options.hash(state);
         self.variant.traverse_and_hash(expr_arena, state);
         self.cloud_options.hash(state);
-        std::mem::discriminant(&self.per_partition_preprocess);
-        if let Some(per_partition_preprocess) = &self.per_partition_preprocess {
-            per_partition_preprocess.traverse_and_hash(expr_arena, state);
-        }
+        self.per_partition_preprocess.traverse_and_hash(expr_arena, state);
     }
 }
 
@@ -528,8 +525,8 @@ impl PerPartitionPreprocessIR {
             }
         }
 
-        std::mem::discriminant(&self.gather).hash(state);
-        if let Some(gather) = &self.gather {
+        std::mem::discriminant(&self.reductions).hash(state);
+        if let Some(gather) = &self.reductions {
             for e in gather {
                 e.traverse_and_hash(expr_arena, state);
             }

--- a/crates/polars-plan/src/dsl/options/sink.rs
+++ b/crates/polars-plan/src/dsl/options/sink.rs
@@ -339,7 +339,7 @@ impl serde::Serialize for SinkFinishCallback {
             return v.serialize(_serializer);
         }
 
-        Err(S::Error::custom(format!("cannot serialize {:?}", self)))
+        Err(S::Error::custom(format!("cannot serialize {self:?}")))
     }
 }
 
@@ -362,6 +362,21 @@ impl<'de> serde::Deserialize<'de> for SinkFinishCallback {
                 "cannot deserialize PartitionOutputCallback",
             ))
         }
+    }
+}
+
+#[cfg(feature = "dsl-schema")]
+impl schemars::JsonSchema for SinkFinishCallback {
+    fn schema_name() -> String {
+        "PartitionTargetCallback".to_owned()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed(concat!(module_path!(), "::", "SinkFinishCallback"))
+    }
+
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        Vec::<u8>::json_schema(generator)
     }
 }
 
@@ -437,6 +452,7 @@ pub struct SortColumnIR {
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct PartitionSinkType {
     pub base_path: Arc<PathBuf>,

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -1143,10 +1143,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 schema: Arc::new(schema),
             }
         },
-        DslPlan::Sink {
-            input,
-            payload,
-        } => {
+        DslPlan::Sink { input, payload } => {
             let input =
                 to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_here!(sink)))?;
             let payload = match payload {
@@ -1189,42 +1186,35 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                         },
                     },
                     cloud_options: f.cloud_options,
-                    per_partition_preprocess: match f.per_partition_preprocess {
-                        None => None,
-
-                        Some(f) => Some(PerPartitionPreprocessIR {
-                            sort_by: match f.sort_by {
-                                None => None,
-                                Some(sort_by) => Some(
-                                    sort_by
-                                        .into_iter()
-                                        .map(|s| {
-                                            let expr = to_expr_ir(s.expr, ctxt.expr_arena)?;
-                                            ctxt.conversion_optimizer
-                                                .push_scratch(expr.node(), ctxt.expr_arena);
-                                            Ok(SortColumnIR {
-                                                expr,
-                                                descending: s.descending,
-                                                nulls_last: s.nulls_last,
-                                            })
+                    per_partition_preprocess: PerPartitionPreprocessIR {
+                        sort_by: match f.per_partition_preprocess.sort_by {
+                            None => None,
+                            Some(sort_by) => Some(
+                                sort_by
+                                    .into_iter()
+                                    .map(|s| {
+                                        let expr = to_expr_ir(s.expr, ctxt.expr_arena)?;
+                                        ctxt.conversion_optimizer
+                                            .push_scratch(expr.node(), ctxt.expr_arena);
+                                        Ok(SortColumnIR {
+                                            expr,
+                                            descending: s.descending,
+                                            nulls_last: s.nulls_last,
                                         })
-                                        .collect::<PolarsResult<Vec<_>>>()?,
-                                ),
-                            },
-                            gather: match f.gather {
-                                None => None,
-                                Some(gather) => Some(to_expr_irs(gather, ctxt.expr_arena)?),
-                            },
-                        }),
+                                    })
+                                    .collect::<PolarsResult<Vec<_>>>()?,
+                            ),
+                        },
+                        reductions: match f.per_partition_preprocess.reductions {
+                            None => None,
+                            Some(gather) => Some(to_expr_irs(gather, ctxt.expr_arena)?),
+                        },
                     },
                     finish_callback: f.finish_callback,
                 }),
             };
 
-            let lp = IR::Sink {
-                input,
-                payload,
-            };
+            let lp = IR::Sink { input, payload };
             return run_conversion(lp, ctxt, "sink");
         },
         DslPlan::SinkMultiple { inputs } => {

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -1186,29 +1186,23 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                         },
                     },
                     cloud_options: f.cloud_options,
-                    per_partition_preprocess: PerPartitionPreprocessIR {
-                        sort_by: match f.per_partition_preprocess.sort_by {
-                            None => None,
-                            Some(sort_by) => Some(
-                                sort_by
-                                    .into_iter()
-                                    .map(|s| {
-                                        let expr = to_expr_ir(s.expr, ctxt.expr_arena)?;
-                                        ctxt.conversion_optimizer
-                                            .push_scratch(expr.node(), ctxt.expr_arena);
-                                        Ok(SortColumnIR {
-                                            expr,
-                                            descending: s.descending,
-                                            nulls_last: s.nulls_last,
-                                        })
+                    per_partition_sort_by: match f.per_partition_sort_by {
+                        None => None,
+                        Some(sort_by) => Some(
+                            sort_by
+                                .into_iter()
+                                .map(|s| {
+                                    let expr = to_expr_ir(s.expr, ctxt.expr_arena)?;
+                                    ctxt.conversion_optimizer
+                                        .push_scratch(expr.node(), ctxt.expr_arena);
+                                    Ok(SortColumnIR {
+                                        expr,
+                                        descending: s.descending,
+                                        nulls_last: s.nulls_last,
                                     })
-                                    .collect::<PolarsResult<Vec<_>>>()?,
-                            ),
-                        },
-                        reductions: match f.per_partition_preprocess.reductions {
-                            None => None,
-                            Some(gather) => Some(to_expr_irs(gather, ctxt.expr_arena)?),
-                        },
+                                })
+                                .collect::<PolarsResult<Vec<_>>>()?,
+                        ),
                     },
                     finish_callback: f.finish_callback,
                 }),

--- a/crates/polars-plan/src/plans/conversion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/mod.rs
@@ -302,22 +302,16 @@ impl IR {
                             },
                         },
                         cloud_options: f.cloud_options,
-                        per_partition_preprocess: PerPartitionPreprocess {
-                            sort_by: f.per_partition_preprocess.sort_by.map(|sort_by| {
-                                sort_by
-                                    .into_iter()
-                                    .map(|s| SortColumn {
-                                        expr: s.expr.to_expr(expr_arena),
-                                        descending: s.descending,
-                                        nulls_last: s.descending,
-                                    })
-                                    .collect()
-                            }),
-                            reductions: f
-                                .per_partition_preprocess
-                                .reductions
-                                .map(|gather| expr_irs_to_exprs(gather, expr_arena)),
-                        },
+                        per_partition_sort_by: f.per_partition_sort_by.map(|sort_by| {
+                            sort_by
+                                .into_iter()
+                                .map(|s| SortColumn {
+                                    expr: s.expr.to_expr(expr_arena),
+                                    descending: s.descending,
+                                    nulls_last: s.descending,
+                                })
+                                .collect()
+                        }),
                         finish_callback: f.finish_callback,
                     }),
                 };

--- a/crates/polars-plan/src/plans/conversion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/mod.rs
@@ -302,6 +302,24 @@ impl IR {
                             },
                         },
                         cloud_options: f.cloud_options,
+                        per_partition_preprocess: f.per_partition_preprocess.map(|f| {
+                            PerPartitionPreprocess {
+                                sort_by: f.sort_by.map(|sort_by| {
+                                    sort_by
+                                        .into_iter()
+                                        .map(|s| SortColumn {
+                                            expr: s.expr.to_expr(expr_arena),
+                                            descending: s.descending,
+                                            nulls_last: s.descending,
+                                        })
+                                        .collect()
+                                }),
+                                gather: f
+                                    .gather
+                                    .map(|gather| expr_irs_to_exprs(gather, expr_arena)),
+                            }
+                        }),
+                        finish_callback: f.finish_callback,
                     }),
                 };
                 DslPlan::Sink { input, payload }

--- a/crates/polars-plan/src/plans/conversion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/mod.rs
@@ -302,23 +302,22 @@ impl IR {
                             },
                         },
                         cloud_options: f.cloud_options,
-                        per_partition_preprocess: f.per_partition_preprocess.map(|f| {
-                            PerPartitionPreprocess {
-                                sort_by: f.sort_by.map(|sort_by| {
-                                    sort_by
-                                        .into_iter()
-                                        .map(|s| SortColumn {
-                                            expr: s.expr.to_expr(expr_arena),
-                                            descending: s.descending,
-                                            nulls_last: s.descending,
-                                        })
-                                        .collect()
-                                }),
-                                gather: f
-                                    .gather
-                                    .map(|gather| expr_irs_to_exprs(gather, expr_arena)),
-                            }
-                        }),
+                        per_partition_preprocess: PerPartitionPreprocess {
+                            sort_by: f.per_partition_preprocess.sort_by.map(|sort_by| {
+                                sort_by
+                                    .into_iter()
+                                    .map(|s| SortColumn {
+                                        expr: s.expr.to_expr(expr_arena),
+                                        descending: s.descending,
+                                        nulls_last: s.descending,
+                                    })
+                                    .collect()
+                            }),
+                            reductions: f
+                                .per_partition_preprocess
+                                .reductions
+                                .map(|gather| expr_irs_to_exprs(gather, expr_arena)),
+                        },
                         finish_callback: f.finish_callback,
                     }),
                 };

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -845,6 +845,8 @@ impl PyLazyFrame {
                     options,
                     cloud_options,
                     sink_options.0,
+                    partition.per_partition_preprocess,
+                    partition.finish_callback,
                 ),
             }
             .into()
@@ -909,6 +911,8 @@ impl PyLazyFrame {
                     options,
                     cloud_options,
                     sink_options.0,
+                    partition.per_partition_preprocess,
+                    partition.finish_callback,
                 ),
             }
         })
@@ -1001,6 +1005,8 @@ impl PyLazyFrame {
                     options,
                     cloud_options,
                     sink_options.0,
+                    partition.per_partition_preprocess,
+                    partition.finish_callback,
                 ),
             }
         })
@@ -1052,6 +1058,8 @@ impl PyLazyFrame {
                     options,
                     cloud_options,
                     sink_options.0,
+                    partition.per_partition_preprocess,
+                    partition.finish_callback,
                 ),
             }
         })

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -845,7 +845,7 @@ impl PyLazyFrame {
                     options,
                     cloud_options,
                     sink_options.0,
-                    partition.per_partition_preprocess,
+                    partition.per_partition_sort_by,
                     partition.finish_callback,
                 ),
             }
@@ -911,7 +911,7 @@ impl PyLazyFrame {
                     options,
                     cloud_options,
                     sink_options.0,
-                    partition.per_partition_preprocess,
+                    partition.per_partition_sort_by,
                     partition.finish_callback,
                 ),
             }
@@ -1005,7 +1005,7 @@ impl PyLazyFrame {
                     options,
                     cloud_options,
                     sink_options.0,
-                    partition.per_partition_preprocess,
+                    partition.per_partition_sort_by,
                     partition.finish_callback,
                 ),
             }
@@ -1058,7 +1058,7 @@ impl PyLazyFrame {
                     options,
                     cloud_options,
                     sink_options.0,
-                    partition.per_partition_preprocess,
+                    partition.per_partition_sort_by,
                     partition.finish_callback,
                 ),
             }

--- a/crates/polars-python/src/lazyframe/sink.rs
+++ b/crates/polars-python/src/lazyframe/sink.rs
@@ -2,7 +2,10 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use polars::prelude::sync_on_close::SyncOnCloseType;
-use polars::prelude::{PartitionVariant, SinkOptions, SpecialEq};
+use polars::prelude::{
+    PartitionVariant, PerPartitionPreprocess, SinkFinishCallback, SinkOptions, SortColumn,
+    SpecialEq,
+};
 use polars_utils::IdxSize;
 use polars_utils::python_function::{PythonFunction, PythonObject};
 use pyo3::exceptions::PyValueError;
@@ -26,23 +29,48 @@ pub struct PyPartitioning {
     pub base_path: PathBuf,
     pub file_path_cb: Option<PythonFunction>,
     pub variant: PartitionVariant,
+    pub per_partition_preprocess: PerPartitionPreprocess,
+    pub finish_callback: Option<SinkFinishCallback>,
 }
 
 #[cfg(feature = "pymethods")]
 #[pymethods]
 impl PyPartitioning {
     #[staticmethod]
-    #[pyo3(signature = (base_path, file_path_cb, max_size))]
+    #[pyo3(signature = (base_path, file_path_cb, max_size, per_partition_sort_by, per_partition_reductions, finish_callback))]
     pub fn new_max_size(
         base_path: PathBuf,
         file_path_cb: Option<PyObject>,
         max_size: IdxSize,
+        per_partition_sort_by: Option<Vec<PyExpr>>,
+        per_partition_reductions: Option<Vec<PyExpr>>,
+        finish_callback: Option<PyObject>,
     ) -> PyPartitioning {
         let file_path_cb = file_path_cb.map(|f| PythonObject(f.into_any()));
+
+        let per_partition_preprocess = PerPartitionPreprocess {
+            sort_by: per_partition_sort_by.map(|exprs| {
+                exprs
+                    .into_iter()
+                    .map(|e| SortColumn {
+                        expr: e.inner,
+                        descending: false,
+                        nulls_last: false,
+                    })
+                    .collect()
+            }),
+            reductions: per_partition_reductions
+                .map(|exprs| exprs.into_iter().map(|e| e.inner).collect()),
+        };
+
+        let finish_callback =
+            finish_callback.map(|f| SinkFinishCallback::Python(PythonObject(f.into_any())));
         PyPartitioning {
             base_path,
             file_path_cb,
             variant: PartitionVariant::MaxSize(max_size),
+            per_partition_preprocess,
+            finish_callback,
         }
     }
 
@@ -62,6 +90,11 @@ impl PyPartitioning {
                 key_exprs: by.into_iter().map(|e| e.inner).collect(),
                 include_key,
             },
+            per_partition_preprocess: PerPartitionPreprocess {
+                sort_by: None,
+                reductions: None,
+            },
+            finish_callback: None,
         }
     }
 
@@ -81,6 +114,11 @@ impl PyPartitioning {
                 key_exprs: by.into_iter().map(|e| e.inner).collect(),
                 include_key,
             },
+            per_partition_preprocess: PerPartitionPreprocess {
+                sort_by: None,
+                reductions: None,
+            },
+            finish_callback: None,
         }
     }
 }

--- a/crates/polars-python/src/on_startup.rs
+++ b/crates/polars-python/src/on_startup.rs
@@ -137,6 +137,11 @@ pub unsafe fn register_startup_deps(catch_keyboard_interrupt: bool) {
                     })
                 }),
             },
+            to_py: polars_utils::python_convert_registry::ToPythonConvertRegistry {
+                df: Arc::new(|df| {
+                    Python::with_gil(|py| PyDataFrame::new(*df.downcast().unwrap()).into_py_any(py))
+                }),
+            },
         });
 
         let object_size = size_of::<ObjectValue>();

--- a/crates/polars-stream/src/nodes/io_sinks/ipc.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/ipc.rs
@@ -1,5 +1,6 @@
 use std::cmp::Reverse;
 use std::io::BufWriter;
+use std::sync::{Arc, Mutex};
 
 use polars_core::schema::{SchemaExt, SchemaRef};
 use polars_core::utils::arrow;
@@ -101,6 +102,7 @@ impl SinkNode for IpcSinkNode {
             dist_tx,
             chunk_size as usize,
             self.input_schema.clone(),
+            Arc::new(Mutex::new(None)),
         ));
 
         // Encoding tasks.

--- a/crates/polars-stream/src/nodes/io_sinks/metrics.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/metrics.rs
@@ -65,7 +65,7 @@ impl WriteMetrics {
             if c.dtype().is_float() {
                 let nan_count = c.is_nan()?.sum().unwrap_or_default();
                 has_non_null_non_nan_values = nan_count as usize + null_count < df.height();
-                w.nan_count += nan_count;
+                w.nan_count += nan_count as u64;
             }
 
             if has_non_null_non_nan_values {

--- a/crates/polars-stream/src/nodes/io_sinks/metrics.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/metrics.rs
@@ -1,0 +1,163 @@
+use arrow::array::builder::ShareStrategy;
+use polars_core::frame::DataFrame;
+use polars_core::prelude::{
+    ChunkedBuilder, DataType, IntoColumn, PrimitiveChunkedBuilder, StringChunkedBuilder,
+    StructChunked, UInt64Type,
+};
+use polars_core::schema::Schema;
+use polars_core::series::IntoSeries;
+use polars_core::series::builder::SeriesBuilder;
+use polars_error::PolarsResult;
+use polars_expr::reduce::{GroupedReduction, new_max_reduction, new_min_reduction};
+use polars_utils::format_pl_smallstr;
+use polars_utils::pl_str::PlSmallStr;
+
+/// Metrics that relate to a written file.
+pub struct WriteMetrics {
+    /// Stringified path to the file.
+    pub path: String,
+    /// Number of rows in the file.
+    pub num_rows: u64,
+    /// Size of written file in bytes.
+    pub file_size: u64,
+    /// Metrics for each column.
+    pub columns: Vec<WriteMetricsColumn>,
+}
+
+/// Metrics in a written file for a specific column.
+pub struct WriteMetricsColumn {
+    /// Number of missing values in the column.
+    pub null_count: u64,
+    /// Number of NaN values in the column.
+    pub nan_count: u64,
+    /// The minimum value in the column.
+    ///
+    /// `NaN`s are always ignored and `None` is the default value.
+    pub lower_bound: Box<dyn GroupedReduction>,
+    /// The maximum value in the column.
+    ///
+    /// `NaN`s are always ignored and `None` is the default value.
+    pub upper_bound: Box<dyn GroupedReduction>,
+}
+
+impl WriteMetrics {
+    pub fn new(path: String, schema: &Schema) -> Self {
+        Self {
+            path,
+            file_size: 0,
+            num_rows: 0,
+            columns: schema
+                .iter_values()
+                .cloned()
+                .map(WriteMetricsColumn::new)
+                .collect(),
+        }
+    }
+
+    pub fn append(&mut self, df: &DataFrame) -> PolarsResult<()> {
+        assert_eq!(self.columns.len(), df.width());
+        self.num_rows += df.height() as u64;
+        for (w, c) in self.columns.iter_mut().zip(df.get_columns()) {
+            let null_count = c.null_count();
+            w.null_count += c.null_count() as u64;
+
+            let mut has_non_null_non_nan_values = df.height() != null_count;
+            if c.dtype().is_float() {
+                let nan_count = c.is_nan()?.sum().unwrap_or_default() as u64;
+                has_non_null_non_nan_values = nan_count as usize + null_count < df.height();
+                w.nan_count += nan_count;
+            }
+
+            if has_non_null_non_nan_values {
+                w.lower_bound.update_group(&c, 0, 0)?;
+                w.upper_bound.update_group(&c, 0, 0)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn collapse_to_df(metrics: Vec<Self>, input_schema: &Schema) -> DataFrame {
+        let num_metrics = metrics.len();
+
+        let mut path = StringChunkedBuilder::new(PlSmallStr::from_static("path"), num_metrics);
+        let mut num_rows = PrimitiveChunkedBuilder::<UInt64Type>::new(
+            PlSmallStr::from_static("num_rows"),
+            num_metrics,
+        );
+        let mut file_size = PrimitiveChunkedBuilder::<UInt64Type>::new(
+            PlSmallStr::from_static("file_size"),
+            num_metrics,
+        );
+        let mut columns = input_schema
+            .iter_values()
+            .map(|dtype| {
+                let null_count = PrimitiveChunkedBuilder::<UInt64Type>::new(
+                    PlSmallStr::from_static("null_count"),
+                    num_metrics,
+                );
+                let nan_count = PrimitiveChunkedBuilder::<UInt64Type>::new(
+                    PlSmallStr::from_static("nan_count"),
+                    num_metrics,
+                );
+                let mut lower_bound = SeriesBuilder::new(dtype.clone());
+                let mut upper_bound = SeriesBuilder::new(dtype.clone());
+                lower_bound.reserve(num_metrics);
+                upper_bound.reserve(num_metrics);
+
+                (null_count, nan_count, lower_bound, upper_bound)
+            })
+            .collect::<Vec<_>>();
+
+        for m in metrics {
+            path.append_value(m.path);
+            num_rows.append_value(m.num_rows);
+            file_size.append_value(m.file_size);
+
+            for (mut w, c) in m.columns.into_iter().zip(columns.iter_mut()) {
+                c.0.append_value(w.null_count);
+                c.1.append_value(w.nan_count);
+                c.2.extend(&w.lower_bound.finalize().unwrap(), ShareStrategy::Always);
+                c.3.extend(&w.upper_bound.finalize().unwrap(), ShareStrategy::Always);
+            }
+        }
+
+        let mut df_columns = Vec::with_capacity(3 + input_schema.len());
+        df_columns.push(path.finish().into_column());
+        df_columns.push(num_rows.finish().into_column());
+        df_columns.push(file_size.finish().into_column());
+        for (name, column) in input_schema.iter_names().zip(columns) {
+            let struct_ca = StructChunked::from_series(
+                format_pl_smallstr!("{name}_stats"),
+                num_metrics,
+                [
+                    column.0.finish().into_series(),
+                    column.1.finish().into_series(),
+                    column.2.freeze(PlSmallStr::from_static("lower_bound")),
+                    column.3.freeze(PlSmallStr::from_static("upper_bound")),
+                ]
+                .iter(),
+            )
+            .unwrap();
+            df_columns.push(struct_ca.into_column());
+        }
+
+        DataFrame::new_with_height(num_metrics, df_columns).unwrap()
+    }
+}
+
+impl WriteMetricsColumn {
+    pub fn new(dtype: DataType) -> Self {
+        let mut lower_bound = new_min_reduction(dtype.clone(), false);
+        let mut upper_bound = new_max_reduction(dtype, false);
+
+        lower_bound.resize(1);
+        upper_bound.resize(1);
+
+        Self {
+            null_count: 0,
+            nan_count: 0,
+            lower_bound,
+            upper_bound,
+        }
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sinks/metrics.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/metrics.rs
@@ -63,14 +63,14 @@ impl WriteMetrics {
 
             let mut has_non_null_non_nan_values = df.height() != null_count;
             if c.dtype().is_float() {
-                let nan_count = c.is_nan()?.sum().unwrap_or_default() as u64;
+                let nan_count = c.is_nan()?.sum().unwrap_or_default();
                 has_non_null_non_nan_values = nan_count as usize + null_count < df.height();
                 w.nan_count += nan_count;
             }
 
             if has_non_null_non_nan_values {
-                w.lower_bound.update_group(&c, 0, 0)?;
-                w.upper_bound.update_group(&c, 0, 0)?;
+                w.lower_bound.update_group(c, 0, 0)?;
+                w.upper_bound.update_group(c, 0, 0)?;
             }
         }
         Ok(())

--- a/crates/polars-stream/src/nodes/io_sinks/metrics.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/metrics.rs
@@ -9,7 +9,7 @@ use polars_core::series::IntoSeries;
 use polars_core::series::builder::SeriesBuilder;
 use polars_error::PolarsResult;
 use polars_expr::reduce::{GroupedReduction, new_max_reduction, new_min_reduction};
-use polars_utils::{format_pl_smallstr, IdxSize};
+use polars_utils::format_pl_smallstr;
 use polars_utils::pl_str::PlSmallStr;
 
 /// Metrics that relate to a written file.
@@ -65,7 +65,10 @@ impl WriteMetrics {
             if c.dtype().is_float() {
                 let nan_count = c.is_nan()?.sum().unwrap_or_default();
                 has_non_null_non_nan_values = nan_count as usize + null_count < df.height();
-                w.nan_count += nan_count as IdxSize;
+                #[allow(clippy::useless_conversion)]
+                {
+                    w.nan_count += u64::from(nan_count);
+                }
             }
 
             if has_non_null_non_nan_values {

--- a/crates/polars-stream/src/nodes/io_sinks/metrics.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/metrics.rs
@@ -9,7 +9,7 @@ use polars_core::series::IntoSeries;
 use polars_core::series::builder::SeriesBuilder;
 use polars_error::PolarsResult;
 use polars_expr::reduce::{GroupedReduction, new_max_reduction, new_min_reduction};
-use polars_utils::format_pl_smallstr;
+use polars_utils::{format_pl_smallstr, IdxSize};
 use polars_utils::pl_str::PlSmallStr;
 
 /// Metrics that relate to a written file.
@@ -65,7 +65,7 @@ impl WriteMetrics {
             if c.dtype().is_float() {
                 let nan_count = c.is_nan()?.sum().unwrap_or_default();
                 has_non_null_non_nan_values = nan_count as usize + null_count < df.height();
-                w.nan_count += nan_count as u64;
+                w.nan_count += nan_count as IdxSize;
             }
 
             if has_non_null_non_nan_values {

--- a/crates/polars-stream/src/nodes/io_sinks/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/mod.rs
@@ -178,6 +178,10 @@ pub trait SinkNode {
         state: &StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     );
+
+    fn finish(&self) -> PolarsResult<()> {
+        Ok(())
+    }
 }
 
 /// The state needed to manage a spawned [`SinkNode`].
@@ -294,5 +298,10 @@ impl ComputeNode for SinkComputeNode {
 
             Ok(())
         }));
+    }
+
+    fn get_output(&mut self) -> PolarsResult<Option<DataFrame>> {
+        self.sink.finish()?;
+        Ok(None)
     }
 }

--- a/crates/polars-stream/src/nodes/io_sinks/partition/by_key.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/by_key.rs
@@ -41,6 +41,7 @@ pub struct PartitionByKeySinkNode {
     ext: PlSmallStr,
 
     sink_options: SinkOptions,
+        finish_callback: Option<SinkFinishCallback>,
 }
 
 impl PartitionByKeySinkNode {
@@ -54,6 +55,7 @@ impl PartitionByKeySinkNode {
         ext: PlSmallStr,
         sink_options: SinkOptions,
         include_key: bool,
+        finish_callback: Option<SinkFinishCallback>,
     ) -> Self {
         assert!(!key_cols.is_empty());
 
@@ -89,6 +91,7 @@ impl PartitionByKeySinkNode {
             create_new,
             ext,
             sink_options,
+            finish_callback,
         }
     }
 }

--- a/crates/polars-stream/src/nodes/io_sinks/partition/by_key.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/by_key.rs
@@ -10,7 +10,7 @@ use polars_core::prelude::{Column, PlHashSet, PlIndexMap, row_encode};
 use polars_core::schema::SchemaRef;
 use polars_core::utils::arrow::buffer::Buffer;
 use polars_error::PolarsResult;
-use polars_plan::dsl::{PartitionTargetCallback, SinkOptions};
+use polars_plan::dsl::{PartitionTargetCallback, SinkFinishCallback, SinkOptions};
 use polars_utils::pl_str::PlSmallStr;
 use polars_utils::priority::Priority;
 
@@ -41,7 +41,7 @@ pub struct PartitionByKeySinkNode {
     ext: PlSmallStr,
 
     sink_options: SinkOptions,
-        finish_callback: Option<SinkFinishCallback>,
+    finish_callback: Option<SinkFinishCallback>,
 }
 
 impl PartitionByKeySinkNode {
@@ -242,6 +242,7 @@ impl SinkNode for PartitionByKeySinkNode {
                                         ext.as_str(),
                                         verbose,
                                         &state,
+                                        None,
                                     ).await?;
                                     file_idx += 1;
 
@@ -300,7 +301,8 @@ impl SinkNode for PartitionByKeySinkNode {
                             "by-key",
                             ext.as_str(),
                             verbose,
-                            &state
+                            &state,
+                            None,
                         ).await?;
                         file_idx += 1;
                         let Some((mut join_handles, mut sender)) = result else {

--- a/crates/polars-stream/src/nodes/io_sinks/partition/max_size.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/max_size.rs
@@ -50,6 +50,7 @@ pub struct MaxSizePartitionSinkNode {
 
 const DEFAULT_RETIRE_TASKS: usize = 1;
 impl MaxSizePartitionSinkNode {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         input_schema: SchemaRef,
         max_size: IdxSize,

--- a/crates/polars-stream/src/nodes/io_sinks/partition/max_size.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/max_size.rs
@@ -8,7 +8,7 @@ use polars_core::config;
 use polars_core::prelude::Column;
 use polars_core::schema::SchemaRef;
 use polars_error::PolarsResult;
-use polars_plan::dsl::{PartitionTargetCallback, SinkOptions};
+use polars_plan::dsl::{PartitionTargetCallback, SinkFinishCallback, SinkOptions};
 use polars_utils::IdxSize;
 use polars_utils::pl_str::PlSmallStr;
 
@@ -41,6 +41,8 @@ pub struct MaxSizePartitionSinkNode {
     ///
     /// This is somewhat proportional to the amount of files open at any given point.
     num_retire_tasks: usize,
+
+    finish_callback: Option<SinkFinishCallback>,
 }
 
 const DEFAULT_RETIRE_TASKS: usize = 1;
@@ -53,6 +55,7 @@ impl MaxSizePartitionSinkNode {
         create_new: CreateNewSinkFn,
         ext: PlSmallStr,
         sink_options: SinkOptions,
+        finish_callback: Option<SinkFinishCallback>,
     ) -> Self {
         assert!(max_size > 0);
         let num_retire_tasks =
@@ -71,6 +74,7 @@ impl MaxSizePartitionSinkNode {
             ext,
             sink_options,
             num_retire_tasks,
+            finish_callback,
         }
     }
 }

--- a/crates/polars-stream/src/nodes/io_sinks/partition/max_size.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/max_size.rs
@@ -1,11 +1,10 @@
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex};
 
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
 use polars_core::config;
-use polars_core::frame::DataFrame;
 use polars_core::prelude::Column;
 use polars_core::schema::SchemaRef;
 use polars_error::PolarsResult;
@@ -44,7 +43,7 @@ pub struct MaxSizePartitionSinkNode {
     num_retire_tasks: usize,
 
     per_partition_sort_by: Option<PerPartitionSortBy>,
-    written_partitions: Arc<OnceLock<DataFrame>>,
+    written_partitions: Arc<Mutex<Vec<Vec<WrittenPartition>>>>,
     finish_callback: Option<SinkFinishCallback>,
 }
 
@@ -80,7 +79,7 @@ impl MaxSizePartitionSinkNode {
             sink_options,
             num_retire_tasks,
             per_partition_sort_by,
-            written_partitions: Arc::new(OnceLock::new()),
+            written_partitions: Arc::new(Mutex::new(Vec::with_capacity(num_retire_tasks))),
             finish_callback,
         }
     }
@@ -108,14 +107,6 @@ impl SinkNode for MaxSizePartitionSinkNode {
         self.sink_options.maintain_order
     }
 
-    fn finish(&self) -> PolarsResult<()> {
-        if let Some(finish_callback) = &self.finish_callback {
-            let df = self.written_partitions.get().unwrap();
-            finish_callback.call(df.clone())?;
-        }
-        Ok(())
-    }
-
     fn spawn_sink(
         &mut self,
         mut recv_port_recv: Receiver<(PhaseOutcome, SinkInputPort)>,
@@ -140,19 +131,17 @@ impl SinkNode for MaxSizePartitionSinkNode {
         let ext = self.ext.clone();
         let per_partition_sort_by = self.per_partition_sort_by.clone();
         let retire_error = has_error_occurred.clone();
-        let output_written_partitions = self.written_partitions.clone();
-        let needs_written_partitions = self.finish_callback.is_some();
         join_handles.push(spawn(TaskPriority::High, async move {
             struct CurrentSink {
                 sender: SinkSender,
                 join_handles: FuturesUnordered<AbortOnDropHandle<PolarsResult<()>>>,
                 num_remaining: IdxSize,
+                finish: Box<dyn FnOnce() -> PolarsResult<Option<WrittenPartition>> + Send + Sync>,
             }
 
             let verbose = config::verbose();
             let mut file_idx = 0;
             let mut current_sink_opt = None;
-            let mut written_partitions = Vec::new();
 
             while let Ok((outcome, recv_port)) = recv_port_recv.recv().await {
                 let mut recv_port = recv_port.serial();
@@ -183,29 +172,21 @@ impl SinkNode for MaxSizePartitionSinkNode {
                                 )
                                 .await?;
                                 file_idx += 1;
-                                let Some((path, join_handles, sender)) = result else {
+                                let Some((join_handles, sender, finish)) = result else {
                                     return Ok(());
                                 };
-
-                                if needs_written_partitions {
-                                    written_partitions
-                                        .push(WrittenPartition::new(path, &input_schema));
-                                }
 
                                 current_sink_opt.insert(CurrentSink {
                                     sender,
                                     num_remaining: max_size,
                                     join_handles,
+                                    finish,
                                 })
                             },
                         };
 
                         // If we can send the whole morsel into sink, do that.
                         if morsel.df().height() < current_sink.num_remaining as usize {
-                            if let Some(wp) = written_partitions.last_mut() {
-                                wp.append(morsel.df())?;
-                            }
-
                             current_sink.num_remaining -= morsel.df().height() as IdxSize;
 
                             // This sends the consume token along so that we don't start buffering here
@@ -230,17 +211,17 @@ impl SinkNode for MaxSizePartitionSinkNode {
                         let final_sink_morsel =
                             Morsel::new(final_sink_df, seq, source_token.clone());
 
-                        if let Some(wp) = written_partitions.last_mut() {
-                            wp.append(final_sink_morsel.df())?;
-                        }
-
                         if current_sink.sender.send(final_sink_morsel).await.is_err() {
                             return Ok(());
                         };
 
-                        let join_handles = std::mem::take(&mut current_sink.join_handles);
-                        drop(current_sink_opt.take());
-                        if retire_tx.send(join_handles).await.is_err() {
+                        let current_sink = current_sink_opt.take().unwrap();
+                        drop(current_sink.sender);
+                        if retire_tx
+                            .send((current_sink.join_handles, current_sink.finish))
+                            .await
+                            .is_err()
+                        {
                             return Ok(());
                         };
 
@@ -254,15 +235,17 @@ impl SinkNode for MaxSizePartitionSinkNode {
                 outcome.stopped();
             }
 
-            if let Some(mut current_sink) = current_sink_opt.take() {
+            if let Some(current_sink) = current_sink_opt.take() {
                 drop(current_sink.sender);
-                while let Some(res) = current_sink.join_handles.next().await {
-                    res?;
-                }
+                if retire_tx
+                    .send((current_sink.join_handles, current_sink.finish))
+                    .await
+                    .is_err()
+                {
+                    return Ok(());
+                };
             }
 
-            let df = written_partitions_to_df(written_partitions, &input_schema);
-            output_written_partitions.set(df).unwrap();
             Ok(())
         }));
 
@@ -273,18 +256,43 @@ impl SinkNode for MaxSizePartitionSinkNode {
         // but it can be scaled up using an environment variable.
         let has_error_occurred = &has_error_occurred;
         join_handles.extend(retire_rxs.into_iter().map(|mut retire_rx| {
+            let output_written_partitions = self.written_partitions.clone();
             let has_error_occurred = has_error_occurred.clone();
             spawn(TaskPriority::High, async move {
-                while let Ok(mut join_handles) = retire_rx.recv().await {
+                let mut written_partitions = Vec::new();
+
+                while let Ok((mut join_handles, finish)) = retire_rx.recv().await {
                     while let Some(ret) = join_handles.next().await {
                         ret.inspect_err(|_| {
                             has_error_occurred.store(true, Ordering::Relaxed);
                         })?;
                     }
+                    if let Some(metrics) = finish()? {
+                        written_partitions.push(metrics);
+                    }
+                }
+
+                {
+                    let mut output_written_partitions = output_written_partitions.lock().unwrap();
+                    output_written_partitions.push(written_partitions);
                 }
 
                 Ok(())
             })
         }));
+    }
+
+    fn finish(&self) -> PolarsResult<Option<WrittenPartition>> {
+        if let Some(finish_callback) = &self.finish_callback {
+            let mut written_partitions = self.written_partitions.lock().unwrap();
+            let written_partitions =
+                std::mem::take::<Vec<Vec<WrittenPartition>>>(written_partitions.as_mut())
+                    .into_iter()
+                    .flatten()
+                    .collect();
+            let df = written_partitions_to_df(written_partitions, &self.input_schema);
+            finish_callback.call(df)?;
+        }
+        Ok(None)
     }
 }

--- a/crates/polars-stream/src/nodes/io_sinks/partition/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/mod.rs
@@ -300,7 +300,7 @@ async fn open_new_sink(
     let file_path = default_file_path_cb(ext, file_idx, part_idx, in_part_idx, keys)?;
     let path = base_path.join(file_path.as_path());
 
-    let output_path = path.to_string_lossy().into_owned();
+    let mut output_path = path.to_string_lossy().into_owned();
     // If the user provided their own callback, modify the path to that.
     let target = if let Some(file_path_cb) = file_path_cb {
         let keys = keys.map_or(Vec::new(), |keys| {
@@ -322,7 +322,11 @@ async fn open_new_sink(
         })?;
         // Offset the given path by the base_path.
         match target {
-            SinkTarget::Path(p) => SinkTarget::Path(Arc::new(base_path.join(p.as_path()))),
+            SinkTarget::Path(p) => {
+                let path = base_path.join(p.as_path());
+                output_path = path.to_string_lossy().into_owned();
+                SinkTarget::Path(Arc::new(path))
+            },
             target => target,
         }
     } else {

--- a/crates/polars-stream/src/nodes/io_sinks/partition/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/mod.rs
@@ -1,28 +1,51 @@
+use std::cmp::Reverse;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
-use polars_core::prelude::{Column, DataType};
+use polars_core::prelude::{Column, DataType, SortMultipleOptions};
 use polars_core::scalar::Scalar;
 use polars_core::schema::SchemaRef;
 use polars_error::PolarsResult;
+use polars_expr::reduce::GroupedReduction;
 use polars_io::cloud::CloudOptions;
 use polars_plan::dsl::{
     FileType, PartitionTargetCallback, PartitionTargetContext, SinkOptions, SinkTarget,
 };
+use polars_utils::format_pl_smallstr;
+use polars_utils::priority::Priority;
 
-use super::{DEFAULT_SINK_DISTRIBUTOR_BUFFER_SIZE, SinkInputPort, SinkNode};
+use super::{
+    DEFAULT_SINK_DISTRIBUTOR_BUFFER_SIZE, DEFAULT_SINK_LINEARIZER_BUFFER_SIZE, SinkInputPort,
+    SinkNode,
+};
 use crate::async_executor::{AbortOnDropHandle, spawn};
+use crate::async_primitives::linearizer::Linearizer;
 use crate::async_primitives::wait_group::WaitGroup;
 use crate::async_primitives::{connector, distributor_channel};
 use crate::execute::StreamingExecutionState;
+use crate::expression::StreamExpr;
+use crate::morsel::{MorselSeq, SourceToken};
 use crate::nodes::io_sinks::phase::PhaseOutcome;
 use crate::nodes::{Morsel, TaskPriority};
 
 pub mod by_key;
 pub mod max_size;
 pub mod parted;
+
+pub struct PerPartitionReductions {
+    selectors: Vec<StreamExpr>,
+    reductions: Vec<Box<dyn GroupedReduction>>,
+}
+
+#[derive(Clone)]
+pub struct PerPartitionSortBy {
+    pub selectors: Vec<StreamExpr>,
+    pub descending: Vec<bool>,
+    pub nulls_last: Vec<bool>,
+    pub maintain_order: bool,
+}
 
 pub type CreateNewSinkFn = Arc<
     dyn Send + Sync + Fn(SchemaRef, SinkTarget) -> PolarsResult<Box<dyn SinkNode + Send + Sync>>,
@@ -148,6 +171,7 @@ async fn open_new_sink(
     ext: &str,
     verbose: bool,
     state: &StreamingExecutionState,
+    per_partition_sort_by: Option<&PerPartitionSortBy>,
 ) -> PolarsResult<
     Option<(
         FuturesUnordered<AbortOnDropHandle<PolarsResult<()>>>,
@@ -197,7 +221,7 @@ async fn open_new_sink(
 
     let mut node = (create_new_sink)(sink_input_schema.clone(), target)?;
     let mut join_handles = Vec::new();
-    let (sink_input, sender) = if node.is_sink_input_parallel() {
+    let (sink_input, mut sender) = if node.is_sink_input_parallel() {
         let (tx, dist_rxs) = distributor_channel::distributor_channel(
             state.num_pipelines,
             *DEFAULT_SINK_DISTRIBUTOR_BUFFER_SIZE,
@@ -221,6 +245,60 @@ async fn open_new_sink(
         let (tx, rx) = connector::connector();
         (SinkInputPort::Serial(rx), SinkSender::Connector(tx))
     };
+
+    // Handle sorting per partition.
+    if let Some(per_partition_sort_by) = per_partition_sort_by {
+        let num_selectors = per_partition_sort_by.selectors.len();
+        let (tx, mut rx) = connector::connector();
+
+        let state = state.in_memory_exec_state.split();
+        let selectors = per_partition_sort_by.selectors.clone();
+        let descending = per_partition_sort_by.descending.clone();
+        let nulls_last = per_partition_sort_by.nulls_last.clone();
+        let maintain_order = per_partition_sort_by.maintain_order;
+
+        let mut old_sender =
+            std::mem::replace(&mut sender, SinkSender::Connector(tx));
+
+        // This all happens in a single thread per partition. Acceptable for now, not the best idea
+        // for the future.
+        join_handles.push(spawn(TaskPriority::High, async move {
+            let Ok(morsel) = rx.recv().await else {
+                return Ok(());
+            };
+
+            let mut df = morsel.into_df();
+            while let Ok(next_morsel) = rx.recv().await {
+                df.vstack_mut_owned(next_morsel.into_df())?;
+            }
+
+            let mut names = Vec::with_capacity(num_selectors);
+            for (i, s) in selectors.into_iter().enumerate() {
+                // @NOTE: This evaluation cannot be done as chunks come in since it might contain
+                // non-elementwise expressions.
+                let c = s.evaluate(&df, &state).await?;
+                let name = format_pl_smallstr!("__POLARS_PART_SORT_COL{i}");
+                names.push(name.clone());
+                df.with_column(c.with_name(name))?;
+            }
+            df.sort_in_place(
+                names,
+                SortMultipleOptions {
+                    descending,
+                    nulls_last,
+                    multithreaded: false,
+                    maintain_order,
+                    limit: None,
+                },
+            )?;
+            df = df.select_by_range(0..df.width() - num_selectors)?;
+
+            _ = old_sender
+                .send(Morsel::new(df, MorselSeq::default(), SourceToken::new()))
+                .await;
+            Ok(())
+        }));
+    }
 
     let (mut sink_input_tx, sink_input_rx) = connector::connector();
     node.spawn_sink(sink_input_rx, state, &mut join_handles);

--- a/crates/polars-stream/src/nodes/io_sinks/partition/parted.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/parted.rs
@@ -9,7 +9,7 @@ use polars_core::prelude::row_encode::_get_rows_encoded_ca_unordered;
 use polars_core::prelude::{AnyValue, IntoColumn, PlHashSet};
 use polars_core::schema::SchemaRef;
 use polars_error::PolarsResult;
-use polars_plan::dsl::{PartitionTargetCallback, SinkOptions};
+use polars_plan::dsl::{PartitionTargetCallback, SinkFinishCallback, SinkOptions};
 use polars_utils::pl_str::PlSmallStr;
 
 use super::CreateNewSinkFn;
@@ -213,6 +213,7 @@ impl SinkNode for PartedPartitionSinkNode {
                                     ext.as_str(),
                                     verbose,
                                     &state,
+                                    None,
                                 )
                                 .await?;
                                 file_idx += 1;

--- a/crates/polars-stream/src/nodes/io_sinks/partition/parted.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/parted.rs
@@ -44,6 +44,7 @@ pub struct PartedPartitionSinkNode {
     ///
     /// This is somewhat proportional to the amount of files open at any given point.
     num_retire_tasks: usize,
+    finish_callback: Option<SinkFinishCallback>,
 }
 
 const DEFAULT_RETIRE_TASKS: usize = 1;
@@ -58,6 +59,7 @@ impl PartedPartitionSinkNode {
         ext: PlSmallStr,
         sink_options: SinkOptions,
         include_key: bool,
+        finish_callback: Option<SinkFinishCallback>,
     ) -> Self {
         assert!(!key_cols.is_empty());
 
@@ -93,6 +95,7 @@ impl PartedPartitionSinkNode {
             sink_options,
             num_retire_tasks,
             include_key,
+            finish_callback,
         }
     }
 }

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -3,13 +3,16 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 use polars_core::config;
 use polars_core::frame::{DataFrame, UniqueKeepStrategy};
-use polars_core::prelude::{DataType, InitHashMaps, PlHashMap, PlHashSet, PlIndexMap};
+use polars_core::prelude::{
+    DataType, InitHashMaps, PlHashMap, PlHashSet, PlIndexMap, SortMultipleOptions,
+};
 use polars_core::schema::Schema;
 use polars_error::{PolarsResult, polars_bail};
 use polars_expr::state::ExecutionState;
 use polars_mem_engine::create_physical_plan;
 use polars_plan::dsl::{
-    ExtraColumnsPolicy, FileScan, FileSinkType, PartitionSinkTypeIR, PartitionVariantIR, SinkTypeIR,
+    ExtraColumnsPolicy, FileScan, FileSinkType, Operator, PartitionSinkTypeIR, PartitionVariantIR,
+    SinkTypeIR,
 };
 use polars_plan::plans::expr_ir::{ExprIR, OutputName};
 use polars_plan::plans::{
@@ -276,6 +279,8 @@ pub fn lower_ir(
                 variant,
                 file_type,
                 cloud_options,
+                per_partition_preprocess,
+                finish_callback,
             }) => {
                 let base_path = base_path.clone();
                 let file_path_cb = file_path_cb.clone();
@@ -323,14 +328,111 @@ pub fn lower_ir(
                     },
                 };
 
+                let mut input = input;
+                let mut variant = variant;
+                let mut gather_input = None;
+                let mut per_partition_sort_by = None;
+                if let Some(per_partition_preprocess) = per_partition_preprocess {
+                    if let Some(gather) = per_partition_preprocess.gather {
+                        let multiplexer_key = phys_sm.insert(PhysNode::new(
+                            output_schema,
+                            PhysNodeKind::Multiplexer { input },
+                        ));
+                        input = PhysStream::first(multiplexer_key);
+                        let mut group_by_input = PhysStream::new(multiplexer_key, 1);
+
+                        let (key_exprs, include_key, maintain_order) = match &variant {
+                            PartitionVariantIR::Parted { key_exprs, .. }
+                            | PartitionVariantIR::ByKey { key_exprs, .. } => {
+                                (key_exprs.clone(), true, false)
+                            },
+                            PartitionVariantIR::MaxSize(size) => {
+                                let row_index_name = unique_column_name();
+                                let with_row_index_key = phys_sm.insert(PhysNode::new(
+                                    output_schema,
+                                    PhysNodeKind::WithRowIndex {
+                                        input: group_by_input,
+                                        name: row_index_name.clone(),
+                                        offset: None,
+                                    },
+                                ));
+                                group_by_input = PhysStream::first(with_row_index_key);
+
+                                let row_index = expr_arena.add(AExpr::Column(row_index_name));
+                                let size = expr_arena
+                                    .add(AExpr::Literal(LiteralValue::new_idxsize(*size)));
+                                let row_index_div_size = expr_arena.add(AExpr::BinaryExpr {
+                                    left: row_index,
+                                    op: Operator::FloorDivide,
+                                    right: size,
+                                });
+
+                                let expr = ExprIR::from_node(row_index_div_size, expr_arena);
+
+                                (vec![expr], false, true)
+                            },
+                        };
+
+                        let group_by_key = phys_sm.insert(PhysNode::new(
+                            output_schema,
+                            PhysNodeKind::GroupBy {
+                                input: group_by_input,
+                                key: key_exprs.clone(),
+                                aggs: gather,
+                            },
+                        ));
+                        gather_input = Some(PhysStream::first(group_by_key));
+                    }
+
+                    if let Some(sort_by) = per_partition_preprocess.sort_by {
+                        match variant {
+                            PartitionVariantIR::MaxSize(_) | PartitionVariantIR::Parted { .. } => {
+                            },
+                            PartitionVariantIR::ByKey {
+                                key_exprs,
+                                include_key,
+                            } => {
+                                let (descending, nulls_last) = sort_by
+                                    .iter()
+                                    .map(|s| (s.descending, s.nulls_last))
+                                    .collect();
+                                let by_column = sort_by.into_iter().map(|s| s.expr).collect();
+                                let sort_key = phys_sm.insert(PhysNode::new(
+                                    output_schema,
+                                    PhysNodeKind::Sort {
+                                        input,
+                                        by_column,
+                                        slice: None,
+                                        sort_options: SortMultipleOptions {
+                                            descending,
+                                            nulls_last,
+                                            multithreaded: false,
+                                            maintain_order: true,
+                                            limit: None,
+                                        },
+                                    },
+                                ));
+                                input = PhysStream::first(sort_key);
+                                variant = PartitionVariantIR::Parted {
+                                    key_exprs,
+                                    include_key,
+                                };
+                            },
+                        }
+                    }
+                }
+
                 PhysNodeKind::PartitionSink {
+                    input,
+                    gather_input,
                     base_path,
                     file_path_cb,
                     sink_options,
                     variant,
                     file_type,
-                    input,
                     cloud_options,
+                    per_partition_sort_by,
+                    finish_callback,
                 }
             },
         },

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -3,16 +3,13 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 use polars_core::config;
 use polars_core::frame::{DataFrame, UniqueKeepStrategy};
-use polars_core::prelude::{
-    DataType, InitHashMaps, PlHashMap, PlHashSet, PlIndexMap, SortMultipleOptions,
-};
+use polars_core::prelude::{DataType, InitHashMaps, PlHashMap, PlHashSet, PlIndexMap};
 use polars_core::schema::Schema;
 use polars_error::{PolarsResult, polars_bail};
 use polars_expr::state::ExecutionState;
 use polars_mem_engine::create_physical_plan;
 use polars_plan::dsl::{
-    ExtraColumnsPolicy, FileScan, FileSinkType, Operator, PartitionSinkTypeIR, PartitionVariantIR,
-    SinkTypeIR,
+    ExtraColumnsPolicy, FileScan, FileSinkType, PartitionSinkTypeIR, PartitionVariantIR, SinkTypeIR,
 };
 use polars_plan::plans::expr_ir::{ExprIR, OutputName};
 use polars_plan::plans::{
@@ -279,7 +276,7 @@ pub fn lower_ir(
                 variant,
                 file_type,
                 cloud_options,
-                per_partition_preprocess,
+                per_partition_sort_by,
                 finish_callback,
             }) => {
                 let base_path = base_path.clone();
@@ -288,7 +285,7 @@ pub fn lower_ir(
                 let variant = variant.clone();
                 let file_type = file_type.clone();
                 let cloud_options = cloud_options.clone();
-                let per_partition_preprocess = per_partition_preprocess.clone();
+                let per_partition_sort_by = per_partition_sort_by.clone();
                 let finish_callback = finish_callback.clone();
 
                 let mut input = lower_ir!(*input)?;
@@ -338,7 +335,7 @@ pub fn lower_ir(
                     variant,
                     file_type,
                     cloud_options,
-                    per_partition_preprocess,
+                    per_partition_sort_by,
                     finish_callback,
                 }
             },

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -9,7 +9,9 @@ use polars_io::RowIndex;
 use polars_io::cloud::CloudOptions;
 use polars_ops::frame::JoinArgs;
 use polars_plan::dsl::{
-    CastColumnsPolicy, JoinTypeOptionsIR, MissingColumnsPolicy, PartitionTargetCallback, PartitionVariantIR, PerPartitionPreprocessIR, ScanSources, SinkFinishCallback, SinkOptions, SinkTarget, SortColumnIR
+    CastColumnsPolicy, JoinTypeOptionsIR, MissingColumnsPolicy, PartitionTargetCallback,
+    PartitionVariantIR, PerPartitionPreprocessIR, ScanSources, SinkFinishCallback, SinkOptions,
+    SinkTarget,
 };
 use polars_plan::plans::hive::HivePartitionsDf;
 use polars_plan::plans::{AExpr, DataFrameUdf, IR};
@@ -147,14 +149,13 @@ pub enum PhysNodeKind {
 
     PartitionSink {
         input: PhysStream,
-        gather_input: Option<PhysStream>,
         base_path: Arc<PathBuf>,
         file_path_cb: Option<PartitionTargetCallback>,
         sink_options: SinkOptions,
         variant: PartitionVariantIR,
         file_type: FileType,
         cloud_options: Option<CloudOptions>,
-        per_partition_sort_by: Option<SortColumnIR>,
+        per_partition_preprocess: PerPartitionPreprocessIR,
         finish_callback: Option<SinkFinishCallback>,
     },
 

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -10,8 +10,7 @@ use polars_io::cloud::CloudOptions;
 use polars_ops::frame::JoinArgs;
 use polars_plan::dsl::{
     CastColumnsPolicy, JoinTypeOptionsIR, MissingColumnsPolicy, PartitionTargetCallback,
-    PartitionVariantIR, PerPartitionPreprocessIR, ScanSources, SinkFinishCallback, SinkOptions,
-    SinkTarget,
+    PartitionVariantIR, ScanSources, SinkFinishCallback, SinkOptions, SinkTarget, SortColumnIR,
 };
 use polars_plan::plans::hive::HivePartitionsDf;
 use polars_plan::plans::{AExpr, DataFrameUdf, IR};
@@ -155,7 +154,7 @@ pub enum PhysNodeKind {
         variant: PartitionVariantIR,
         file_type: FileType,
         cloud_options: Option<CloudOptions>,
-        per_partition_preprocess: PerPartitionPreprocessIR,
+        per_partition_sort_by: Option<Vec<SortColumnIR>>,
         finish_callback: Option<SinkFinishCallback>,
     },
 

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -9,8 +9,7 @@ use polars_io::RowIndex;
 use polars_io::cloud::CloudOptions;
 use polars_ops::frame::JoinArgs;
 use polars_plan::dsl::{
-    CastColumnsPolicy, JoinTypeOptionsIR, MissingColumnsPolicy, PartitionTargetCallback,
-    PartitionVariantIR, ScanSources, SinkOptions, SinkTarget,
+    CastColumnsPolicy, JoinTypeOptionsIR, MissingColumnsPolicy, PartitionTargetCallback, PartitionVariantIR, PerPartitionPreprocessIR, ScanSources, SinkFinishCallback, SinkOptions, SinkTarget, SortColumnIR
 };
 use polars_plan::plans::hive::HivePartitionsDf;
 use polars_plan::plans::{AExpr, DataFrameUdf, IR};
@@ -147,13 +146,16 @@ pub enum PhysNodeKind {
     },
 
     PartitionSink {
+        input: PhysStream,
+        gather_input: Option<PhysStream>,
         base_path: Arc<PathBuf>,
         file_path_cb: Option<PartitionTargetCallback>,
         sink_options: SinkOptions,
         variant: PartitionVariantIR,
         file_type: FileType,
-        input: PhysStream,
         cloud_options: Option<CloudOptions>,
+        per_partition_sort_by: Option<SortColumnIR>,
+        finish_callback: Option<SinkFinishCallback>,
     },
 
     SinkMultiple {

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -336,7 +336,7 @@ fn to_graph_rec<'a>(
                 None => None,
                 Some(c) => {
                     let (selectors, descending, nulls_last) = c
-                        .into_iter()
+                        .iter()
                         .map(|c| {
                             Ok((
                                 create_stream_expr(&c.expr, ctx, &input_schema)?,

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -383,6 +383,7 @@ fn to_graph_rec<'a>(
                         ext,
                         sink_options.clone(),
                         *include_key,
+                        per_partition_sort_by,
                         finish_callback.clone(),
                     ),
                 ),
@@ -390,8 +391,6 @@ fn to_graph_rec<'a>(
                     key_exprs,
                     include_key,
                 } => {
-                    // At the moment, this is needed.
-                    assert!(per_partition_sort_by.is_none());
                     SinkComputeNode::from(
                         nodes::io_sinks::partition::by_key::PartitionByKeySinkNode::new(
                             input_schema,
@@ -402,6 +401,7 @@ fn to_graph_rec<'a>(
                             ext,
                             sink_options.clone(),
                             *include_key,
+                            per_partition_sort_by,
                             finish_callback.clone(),
                         ),
                     )

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -281,6 +281,7 @@ fn to_graph_rec<'a>(
                         sink_options,
                         parquet_writer_options,
                         cloud_options.clone(),
+                        false,
                     )?),
                     [(input_key, input.port)],
                 ),
@@ -328,6 +329,7 @@ fn to_graph_rec<'a>(
                 file_type.clone(),
                 sink_options.clone(),
                 cloud_options.clone(),
+                finish_callback.is_some(),
             );
 
             let per_partition_sort_by = match per_partition_sort_by.as_ref() {

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -2,7 +2,7 @@
     all(target_arch = "aarch64", feature = "nightly"),
     feature(stdarch_aarch64_prefetch)
 )]
-#![cfg_attr(feature = "nightly", feature(core_intrinsics))] // For algebraic ops, select_unpredicable.
+#![cfg_attr(feature = "nightly", feature(core_intrinsics))] // For algebraic ops, select_unpredictable.
 #![cfg_attr(feature = "nightly", allow(internal_features))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 pub mod abs_diff;

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -2,7 +2,7 @@
     all(target_arch = "aarch64", feature = "nightly"),
     feature(stdarch_aarch64_prefetch)
 )]
-#![cfg_attr(feature = "nightly", feature(core_intrinsics))] // For algebraic ops.
+#![cfg_attr(feature = "nightly", feature(core_intrinsics))] // For algebraic ops, select_unpredicable.
 #![cfg_attr(feature = "nightly", allow(internal_features))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 pub mod abs_diff;

--- a/crates/polars-utils/src/python_convert_registry.rs
+++ b/crates/polars-utils/src/python_convert_registry.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, LazyLock, RwLock};
 use pyo3::{Py, PyAny, PyResult};
 
 pub type PythonToSinkTarget = Arc<dyn Fn(Py<PyAny>) -> PyResult<Box<dyn Any>> + Send + Sync>;
+pub type DataFrameToPython = Arc<dyn Fn(Box<dyn Any>) -> PyResult<Py<PyAny>> + Send + Sync>;
 
 #[derive(Clone)]
 pub struct FromPythonConvertRegistry {
@@ -12,8 +13,14 @@ pub struct FromPythonConvertRegistry {
 }
 
 #[derive(Clone)]
+pub struct ToPythonConvertRegistry {
+    pub df: DataFrameToPython,
+}
+
+#[derive(Clone)]
 pub struct PythonConvertRegistry {
     pub from_py: FromPythonConvertRegistry,
+    pub to_py: ToPythonConvertRegistry,
 }
 
 static PYTHON_CONVERT_REGISTRY: LazyLock<RwLock<Option<PythonConvertRegistry>>> =


### PR DESCRIPTION
This adds 2 items to partition sinks

- `per_partition_sort_by` which sorts a partition before writing by certain expressions
- `finish_callback` which gets called with information about all the written files in the partition

These are needed for better Iceberg support.