### PR TITLE
fix: Panic on quantile over nulls in rolling window

### DIFF
--- a/crates/polars-compute/src/rolling/nulls/quantile.rs
+++ b/crates/polars-compute/src/rolling/nulls/quantile.rs
@@ -94,7 +94,7 @@ impl<
                     )
                 }
             },
-            _ => Some(self.sorted.get(idx).unwrap()),
+            _ => Some(self.sorted.get(idx + null_count).unwrap()),
         }
     }
 


### PR DESCRIPTION
fixes #22781

Minor change. Addresses panic, with test coverage expanded.

Kindly review the expected value in the test.