### PR TITLE
build: Patch pyo3 to disable recompilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ target/
 # Project
 /docs/assets/data/
 /docs/assets/people.md
+
+# User specific source setups
+# You can put anything here that needs to be done to prepare your env.
+.user_env.*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3930,8 +3930,7 @@ dependencies = [
 [[package]]
 name = "pyo3"
 version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+source = "git+https://github.com/pola-rs/pyo3?branch=build_config_0.24.2#4106d8ffb993bf3da30aa79197f6fe454f46357f"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -3951,8 +3950,7 @@ dependencies = [
 [[package]]
 name = "pyo3-build-config"
 version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
+source = "git+https://github.com/pola-rs/pyo3?branch=build_config_0.24.2#4106d8ffb993bf3da30aa79197f6fe454f46357f"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -3961,8 +3959,7 @@ dependencies = [
 [[package]]
 name = "pyo3-ffi"
 version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+source = "git+https://github.com/pola-rs/pyo3?branch=build_config_0.24.2#4106d8ffb993bf3da30aa79197f6fe454f46357f"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3971,8 +3968,7 @@ dependencies = [
 [[package]]
 name = "pyo3-macros"
 version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+source = "git+https://github.com/pola-rs/pyo3?branch=build_config_0.24.2#4106d8ffb993bf3da30aa79197f6fe454f46357f"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3983,8 +3979,7 @@ dependencies = [
 [[package]]
 name = "pyo3-macros-backend"
 version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+source = "git+https://github.com/pola-rs/pyo3?branch=build_config_0.24.2#4106d8ffb993bf3da30aa79197f6fe454f46357f"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,10 @@ features = [
 # packed_simd_2 = { git = "https://github.com/rust-lang/packed_simd", rev = "e57c7ba11386147e6d2cbad7c88f376aab4bdc86" }
 # simd-json = { git = "https://github.com/ritchie46/simd-json", branch = "alignment" }
 tikv-jemallocator = { git = "https://github.com/pola-rs/jemallocator", rev = "c7991e5bb6b3e9f79db6b0f48dcda67c5c3d2936" }
+pyo3-build-config = { git = "https://github.com/pola-rs/pyo3", branch = "build_config_0.24.2" }
+pyo3 = { git = "https://github.com/pola-rs/pyo3", branch = "build_config_0.24.2" }
+pyo3-macros-backend = { git = "https://github.com/pola-rs/pyo3", branch = "build_config_0.24.2" }
+pyo3-ffi = { git = "https://github.com/pola-rs/pyo3", branch = "build_config_0.24.2" }
 
 [profile.mindebug-dev]
 inherits = "dev"


### PR DESCRIPTION
A patch to enable this: https://github.com/PyO3/pyo3/issues/4834

It has become insufferable in my setup. Every code change triggers a full recompilation and because we use pyo3 at the error crate, it triggers a full recompilation of all our crates. This can now be turned of by setting `export PYO3_NO_RECOMPILE=1`. 

If you get compilation issues, this must be resolved by a cargo clean or unsetting `PYO3_NO_RECOMPILE`. This almost never happens and thus is totally worth it in saved time IMO.