### PR TITLE
fix: Invalid output for `fill_null` after `when.then` on structs

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/zip.rs
+++ b/crates/polars-core/src/chunked_array/ops/zip.rs
@@ -303,13 +303,13 @@ impl ChunkZip<StructType> for StructChunked {
             for (chunk_length, validity) in iter {
                 if let Some(validity) = validity {
                     if validity.unset_bits() > 0 {
-                        rechunked_validity
-                            .get_or_insert_with(|| {
-                                let mut bm = BitmapBuilder::with_capacity(total_length);
-                                bm.extend_constant(rechunked_length, true);
-                                bm
-                            })
-                            .extend_from_bitmap(&validity);
+                        let v = rechunked_validity.get_or_insert_with(|| {
+                            let mut bm = BitmapBuilder::with_capacity(total_length);
+                            bm.extend_constant(rechunked_length, true);
+                            bm
+                        });
+                        v.extend_constant(rechunked_length - v.len(), true);
+                        v.extend_from_bitmap(&validity);
                     }
                 }
 

--- a/py-polars/tests/unit/functions/test_when_then.py
+++ b/py-polars/tests/unit/functions/test_when_then.py
@@ -755,3 +755,24 @@ def test_when_then_to_decimal_18375() -> None:
         schema={"a": pl.String, "b": pl.Decimal, "c": pl.Decimal},
     )
     assert_frame_equal(result, expected)
+
+
+def test_when_then_chunked_fill_null_22794() -> None:
+    df = pl.DataFrame(
+        {
+            "node": [{"x": "a", "y": "a"}, {"x": "b", "y": "b"}, {"x": "c", "y": "c"}],
+            "level": [0, 1, 2],
+        }
+    )
+
+    out = pl.concat([df.slice(0, 1), df.slice(1, 1), df.slice(2, 1)]).with_columns(
+        pl.when(level=1).then("node").forward_fill()
+    )
+    expected = pl.DataFrame(
+        {
+            "node": [None, {"x": "b", "y": "b"}, {"x": "b", "y": "b"}],
+            "level": [0, 1, 2],
+        }
+    )
+
+    assert_frame_equal(out, expected)


### PR DESCRIPTION
Fixes #22794.