### PR TITLE
fix: Add type equality checking for relevant methods

### DIFF
--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -730,3 +730,22 @@ def qualified_type_name(obj: Any, *, qualify_polars: bool = False) -> str:
         return name
 
     return f"{module}.{name}"
+
+
+def require_same_type(current: Any, other: Any) -> None:
+    """
+    Raise an error if the two arguments are not of the same type.
+
+    Parameters
+    ----------
+    current
+        The object the type of which is being checked against.
+    other
+        An object that has to be of the same type.
+    """
+    if not isinstance(other, type(current)):
+        msg = (
+            f"expected `other` to be a {qualified_type_name(current)!r}, "
+            f"not {qualified_type_name(other)!r}"
+        )
+        raise TypeError(msg)

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -58,6 +58,7 @@ from polars._utils.various import (
     normalize_filepath,
     parse_version,
     qualified_type_name,
+    require_same_type,
     scale_bytes,
     warn_null_comparison,
 )
@@ -5938,6 +5939,7 @@ class DataFrame:
         >>> df1.equals(df2)
         False
         """
+        require_same_type(self, other)
         return self._df.equals(other._df, null_equal=null_equal)
 
     def slice(self, offset: int, length: int | None = None) -> DataFrame:
@@ -7553,9 +7555,7 @@ class DataFrame:
         │ Netherlands ┆ 2019-01-01 ┆ 17.4       ┆ 910  │
         └─────────────┴────────────┴────────────┴──────┘
         """
-        if not isinstance(other, DataFrame):
-            msg = f"expected `other` join table to be a DataFrame, not {qualified_type_name(other)!r}"
-            raise TypeError(msg)
+        require_same_type(self, other)
 
         if on is not None:
             if not isinstance(on, (str, pl.Expr)):
@@ -7821,9 +7821,7 @@ class DataFrame:
         -----
         For joining on columns with categorical data, see :class:`polars.StringCache`.
         """
-        if not isinstance(other, DataFrame):
-            msg = f"expected `other` join table to be a DataFrame, not {qualified_type_name(other)!r}"
-            raise TypeError(msg)
+        require_same_type(self, other)
 
         from polars.lazyframe.opt_flags import QueryOptFlags
 
@@ -7912,9 +7910,7 @@ class DataFrame:
         │ 101 ┆ 140 ┆ 14  ┆ 8     ┆ 742  ┆ 170  ┆ 16   ┆ 4           │
         └─────┴─────┴─────┴───────┴──────┴──────┴──────┴─────────────┘
         """
-        if not isinstance(other, DataFrame):
-            msg = f"expected `other` join table to be a DataFrame, not {qualified_type_name(other)!r}"
-            raise TypeError(msg)
+        require_same_type(self, other)
 
         from polars.lazyframe.opt_flags import QueryOptFlags
 
@@ -8117,6 +8113,7 @@ class DataFrame:
         │ 4   ┆ 9   ┆ d   │
         └─────┴─────┴─────┘
         """
+        require_same_type(self, other)
         if in_place:
             try:
                 self._df.vstack_mut(other._df)
@@ -8184,6 +8181,7 @@ class DataFrame:
         │ 30  ┆ 60  │
         └─────┴─────┘
         """
+        require_same_type(self, other)
         try:
             self._df.extend(other._df)
         except RuntimeError as exc:
@@ -11828,6 +11826,8 @@ class DataFrame:
         """
         from polars.lazyframe.opt_flags import QueryOptFlags
 
+        require_same_type(self, other)
+
         return (
             self.lazy()
             .merge_sorted(other.lazy(), key)
@@ -12011,6 +12011,7 @@ class DataFrame:
         """
         from polars.lazyframe.opt_flags import QueryOptFlags
 
+        require_same_type(self, other)
         return (
             self.lazy()
             .update(

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -53,6 +53,7 @@ from polars._utils.various import (
     normalize_filepath,
     parse_percentiles,
     qualified_type_name,
+    require_same_type,
 )
 from polars._utils.wrap import wrap_df, wrap_expr
 from polars.datatypes import (
@@ -5281,9 +5282,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ Netherlands ┆ 2019-01-01 ┆ 17.4       ┆ 910  │
         └─────────────┴────────────┴────────────┴──────┘
         """
-        if not isinstance(other, LazyFrame):
-            msg = f"expected `other` join table to be a LazyFrame, not {qualified_type_name(other)!r}"
-            raise TypeError(msg)
+        require_same_type(self, other)
 
         if isinstance(on, (str, pl.Expr)):
             left_on = on
@@ -5551,9 +5550,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 3   ┆ 8.0 ┆ c   ┆ z     ┆ d         │
         └─────┴─────┴─────┴───────┴───────────┘
         """
-        if not isinstance(other, LazyFrame):
-            msg = f"expected `other` join table to be a LazyFrame, not {qualified_type_name(other)!r}"
-            raise TypeError(msg)
+        require_same_type(self, other)
 
         if maintain_order is None:
             maintain_order = "none"
@@ -5696,9 +5693,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 101 ┆ 140 ┆ 14  ┆ 8     ┆ 742  ┆ 170  ┆ 16   ┆ 4           │
         └─────┴─────┴─────┴───────┴──────┴──────┴──────┴─────────────┘
         """
-        if not isinstance(other, LazyFrame):
-            msg = f"expected `other` join table to be a LazyFrame, not {qualified_type_name(other)!r}"
-            raise TypeError(msg)
+        require_same_type(self, other)
 
         pyexprs = parse_into_list_of_expressions(*predicates)
 
@@ -7696,6 +7691,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         The key must be sorted in ascending order.
         """
+        require_same_type(self, other)
         return self._from_pyldf(self._ldf.merge_sorted(other._ldf, key))
 
     def set_sorted(
@@ -7872,6 +7868,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 5   ┆ -66  │
         └─────┴──────┘
         """
+        require_same_type(self, other)
         if how in ("outer", "outer_coalesce"):
             how = "full"
             issue_deprecation_warning(

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -49,6 +49,7 @@ from polars._utils.various import (
     no_default,
     parse_version,
     qualified_type_name,
+    require_same_type,
     scale_bytes,
     sphinx_accessor,
     warn_null_comparison,
@@ -3055,6 +3056,7 @@ class Series:
         >>> a.n_chunks()
         2
         """
+        require_same_type(self, other)
         try:
             self._s.append(other._s)
         except RuntimeError as exc:
@@ -3118,6 +3120,7 @@ class Series:
         >>> a.n_chunks()
         1
         """
+        require_same_type(self, other)
         try:
             self._s.extend(other._s)
         except RuntimeError as exc:
@@ -4126,6 +4129,7 @@ class Series:
         >>> s1.equals(s2)
         False
         """
+        require_same_type(self, other)
         return self._s.equals(
             other._s,
             check_dtypes=check_dtypes,
@@ -5705,6 +5709,7 @@ class Series:
                 5
         ]
         """
+        require_same_type(self, other)
         return self._from_pyseries(self._s.zip_with(mask._s, other._s))
 
     @deprecate_renamed_parameter("min_periods", "min_samples", version="1.21.0")

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1579,13 +1579,13 @@ def test_join_bad_input_type() -> None:
         TypeError,
         match="expected `other` .*to be a 'DataFrame'.* not 'LazyFrame'",
     ):
-        left.join(right.lazy(), on="a")
+        left.join(right.lazy(), on="a")  # type: ignore[arg-type]
 
     with pytest.raises(
         TypeError,
         match="expected `other` .*to be a 'DataFrame'.* not 'Series'",
     ):
-        left.join(pl.Series([1, 2, 3]), on="a")
+        left.join(pl.Series([1, 2, 3]), on="a")  # type: ignore[arg-type]
 
 
 def test_join_where() -> None:
@@ -1649,7 +1649,7 @@ def test_join_where_bad_input_type() -> None:
         match="expected `other` .*to be a 'DataFrame'.* not 'LazyFrame'",
     ):
         east.join_where(
-            west.lazy(),
+            west.lazy(),  # type: ignore[arg-type]
             pl.col("dur") < pl.col("time"),
             pl.col("rev") < pl.col("cost"),
         )
@@ -1659,7 +1659,7 @@ def test_join_where_bad_input_type() -> None:
         match="expected `other` .*to be a 'DataFrame'.* not 'Series'",
     ):
         east.join_where(
-            pl.Series(west),
+            pl.Series(west),  # type: ignore[arg-type]
             pl.col("dur") < pl.col("time"),
             pl.col("rev") < pl.col("cost"),
         )
@@ -2413,13 +2413,13 @@ def test_asof_bad_input_type() -> None:
         TypeError,
         match="expected `other` .*to be a 'DataFrame'.* not 'LazyFrame'",
     ):
-        lhs.join_asof(rhs.lazy(), on="a")
+        lhs.join_asof(rhs.lazy(), on="a")  # type: ignore[arg-type]
 
     with pytest.raises(
         TypeError,
         match="expected `other` .*to be a 'DataFrame'.* not 'Series'",
     ):
-        lhs.join_asof(pl.Series([1, 2, 3]), on="a")
+        lhs.join_asof(pl.Series([1, 2, 3]), on="a")  # type: ignore[arg-type]
 
 
 def test_list_of_list_of_struct() -> None:

--- a/py-polars/tests/unit/dataframe/test_equals.py
+++ b/py-polars/tests/unit/dataframe/test_equals.py
@@ -1,3 +1,5 @@
+import pytest
+
 import polars as pl
 
 
@@ -45,3 +47,20 @@ def test_equals() -> None:
     # The null_equal parameter determines if None values are considered equal
     assert df.equals(df) is True
     assert df.equals(df, null_equal=False) is False
+
+
+def test_equals_bad_input_type() -> None:
+    df1 = pl.DataFrame({"a": [1, 2, 3]})
+    df2 = pl.DataFrame({"a": [1, 2, 3]})
+
+    with pytest.raises(
+        TypeError,
+        match="expected `other` .*to be a 'DataFrame'.* not 'LazyFrame'",
+    ):
+        df1.equals(df2.lazy())
+
+    with pytest.raises(
+        TypeError,
+        match="expected `other` .*to be a 'DataFrame'.* not 'Series'",
+    ):
+        df1.equals(pl.Series([1, 2, 3]))

--- a/py-polars/tests/unit/dataframe/test_equals.py
+++ b/py-polars/tests/unit/dataframe/test_equals.py
@@ -57,10 +57,10 @@ def test_equals_bad_input_type() -> None:
         TypeError,
         match="expected `other` .*to be a 'DataFrame'.* not 'LazyFrame'",
     ):
-        df1.equals(df2.lazy())
+        df1.equals(df2.lazy())  # type: ignore[arg-type]
 
     with pytest.raises(
         TypeError,
         match="expected `other` .*to be a 'DataFrame'.* not 'Series'",
     ):
-        df1.equals(pl.Series([1, 2, 3]))
+        df1.equals(pl.Series([1, 2, 3]))  # type: ignore[arg-type]

--- a/py-polars/tests/unit/dataframe/test_extend.py
+++ b/py-polars/tests/unit/dataframe/test_extend.py
@@ -95,3 +95,20 @@ def test_initialize_df_18736() -> None:
     assert df.with_columns(s_0).shape == (0, 1)
     assert df.with_columns(s_1).shape == (1, 1)
     assert df.with_columns(s_2).shape == (2, 1)
+
+
+def test_extend_bad_input_type() -> None:
+    a = pl.DataFrame({"x": [1, 2, 3]})
+    b = pl.DataFrame({"x": [4, 5, 6]})
+
+    with pytest.raises(
+        TypeError,
+        match="expected `other` .*to be a 'DataFrame'.* not 'Series'",
+    ):
+        a.extend(pl.Series(b))
+
+    with pytest.raises(
+        TypeError,
+        match="expected `other` .*to be a 'DataFrame'.* not 'LazyFrame'",
+    ):
+        a.extend(b.lazy())

--- a/py-polars/tests/unit/dataframe/test_extend.py
+++ b/py-polars/tests/unit/dataframe/test_extend.py
@@ -105,10 +105,10 @@ def test_extend_bad_input_type() -> None:
         TypeError,
         match="expected `other` .*to be a 'DataFrame'.* not 'Series'",
     ):
-        a.extend(pl.Series(b))
+        a.extend(pl.Series(b))  # type: ignore[arg-type]
 
     with pytest.raises(
         TypeError,
         match="expected `other` .*to be a 'DataFrame'.* not 'LazyFrame'",
     ):
-        a.extend(b.lazy())
+        a.extend(b.lazy())  # type: ignore[arg-type]

--- a/py-polars/tests/unit/dataframe/test_merge_sorted.py
+++ b/py-polars/tests/unit/dataframe/test_merge_sorted.py
@@ -39,10 +39,10 @@ def test_merge_sorted_bad_input_type() -> None:
         TypeError,
         match="expected `other` .*to be a 'DataFrame'.* not 'Series'",
     ):
-        a.merge_sorted(pl.Series(b), key="x")
+        a.merge_sorted(pl.Series(b), key="x")  # type: ignore[arg-type]
 
     with pytest.raises(
         TypeError,
         match="expected `other` .*to be a 'DataFrame'.* not 'LazyFrame'",
     ):
-        a.merge_sorted(b.lazy(), key="x")
+        a.merge_sorted(b.lazy(), key="x")  # type: ignore[arg-type]

--- a/py-polars/tests/unit/dataframe/test_merge_sorted.py
+++ b/py-polars/tests/unit/dataframe/test_merge_sorted.py
@@ -1,0 +1,48 @@
+import pytest
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+
+def test_merge_sorted_valid_inputs() -> None:
+    df0 = pl.DataFrame(
+        {
+            "name": ["steve", "elise", "bob"],
+            "age": [42, 44, 18],
+        },
+    ).sort("age")
+
+    df1 = pl.DataFrame(
+        {
+            "name": ["anna", "megan", "steve", "thomas"],
+            "age": [21, 33, 42, 20],
+        },
+    ).sort("age")
+
+    out = df0.merge_sorted(df1, key="age")
+
+    expected = pl.DataFrame(
+        {
+            "name": ["bob", "thomas", "anna", "megan", "steve", "steve", "elise"],
+            "age": [18, 20, 21, 33, 42, 42, 44],
+        },
+    )
+
+    assert_frame_equal(out, expected)
+
+
+def test_merge_sorted_bad_input_type() -> None:
+    a = pl.DataFrame({"x": [1, 2, 3]})
+    b = pl.DataFrame({"x": [4, 5, 6]})
+
+    with pytest.raises(
+        TypeError,
+        match="expected `other` .*to be a 'DataFrame'.* not 'Series'",
+    ):
+        a.merge_sorted(pl.Series(b), key="x")
+
+    with pytest.raises(
+        TypeError,
+        match="expected `other` .*to be a 'DataFrame'.* not 'LazyFrame'",
+    ):
+        a.merge_sorted(b.lazy(), key="x")

--- a/py-polars/tests/unit/dataframe/test_vstack.py
+++ b/py-polars/tests/unit/dataframe/test_vstack.py
@@ -81,3 +81,20 @@ def test_vstack_with_nested_nulls() -> None:
     out = a.vstack(b)
     expected = pl.DataFrame({"x": [[3.5], [None]]}, schema={"x": pl.List(pl.Float32)})
     assert_frame_equal(out, expected)
+
+
+def test_vstack_bad_input_type() -> None:
+    a = pl.DataFrame({"x": [1, 2, 3]})
+    b = pl.DataFrame({"x": [4, 5, 6]})
+
+    with pytest.raises(
+        TypeError,
+        match="expected `other` .*to be a 'DataFrame'.* not 'Series'",
+    ):
+        a.vstack(pl.Series(b))
+
+    with pytest.raises(
+        TypeError,
+        match="expected `other` .*to be a 'DataFrame'.* not 'LazyFrame'",
+    ):
+        a.vstack(b.lazy())

--- a/py-polars/tests/unit/dataframe/test_vstack.py
+++ b/py-polars/tests/unit/dataframe/test_vstack.py
@@ -91,10 +91,10 @@ def test_vstack_bad_input_type() -> None:
         TypeError,
         match="expected `other` .*to be a 'DataFrame'.* not 'Series'",
     ):
-        a.vstack(pl.Series(b))
+        a.vstack(pl.Series(b))  # type: ignore[arg-type]
 
     with pytest.raises(
         TypeError,
         match="expected `other` .*to be a 'DataFrame'.* not 'LazyFrame'",
     ):
-        a.vstack(b.lazy())
+        a.vstack(b.lazy())  # type: ignore[arg-type]

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -1491,3 +1491,109 @@ def test_unique_length_multiple_columns() -> None:
         }
     )
     assert lf.unique().select(pl.len()).collect().item() == 4
+
+
+def test_asof_cross_join() -> None:
+    left = pl.LazyFrame({"a": [-10, 5, 10], "left_val": ["a", "b", "c"]}).with_columns(
+        pl.col("a").set_sorted()
+    )
+    right = pl.LazyFrame(
+        {"a": [1, 2, 3, 6, 7], "right_val": [1, 2, 3, 6, 7]}
+    ).with_columns(pl.col("a").set_sorted())
+
+    out = left.join_asof(right, on="a").collect()
+    assert out.shape == (3, 3)
+
+
+def test_join_bad_input_type() -> None:
+    left = pl.LazyFrame({"a": [1, 2, 3]})
+    right = pl.LazyFrame({"a": [1, 2, 3]})
+
+    with pytest.raises(
+        TypeError,
+        match="expected `other` .*to be a 'LazyFrame'.* not 'DataFrame'",
+    ):
+        left.join(right.collect(), on="a")
+
+    with pytest.raises(
+        TypeError,
+        match="expected `other` .*to be a 'LazyFrame'.* not 'Series'",
+    ):
+        left.join(pl.Series([1, 2, 3]), on="a")
+
+
+def test_join_where() -> None:
+    east = pl.LazyFrame(
+        {
+            "id": [100, 101, 102],
+            "dur": [120, 140, 160],
+            "rev": [12, 14, 16],
+            "cores": [2, 8, 4],
+        }
+    )
+    west = pl.LazyFrame(
+        {
+            "t_id": [404, 498, 676, 742],
+            "time": [90, 130, 150, 170],
+            "cost": [9, 13, 15, 16],
+            "cores": [4, 2, 1, 4],
+        }
+    )
+    out = east.join_where(
+        west,
+        pl.col("dur") < pl.col("time"),
+        pl.col("rev") < pl.col("cost"),
+    ).collect()
+
+    expected = pl.DataFrame(
+        {
+            "id": [100, 100, 100, 101, 101],
+            "dur": [120, 120, 120, 140, 140],
+            "rev": [12, 12, 12, 14, 14],
+            "cores": [2, 2, 2, 8, 8],
+            "t_id": [498, 676, 742, 676, 742],
+            "time": [130, 150, 170, 150, 170],
+            "cost": [13, 15, 16, 15, 16],
+            "cores_right": [2, 1, 4, 1, 4],
+        }
+    )
+
+    assert_frame_equal(out, expected)
+
+
+def test_join_where_bad_input_type() -> None:
+    east = pl.LazyFrame(
+        {
+            "id": [100, 101, 102],
+            "dur": [120, 140, 160],
+            "rev": [12, 14, 16],
+            "cores": [2, 8, 4],
+        }
+    )
+    west = pl.LazyFrame(
+        {
+            "t_id": [404, 498, 676, 742],
+            "time": [90, 130, 150, 170],
+            "cost": [9, 13, 15, 16],
+            "cores": [4, 2, 1, 4],
+        }
+    )
+    with pytest.raises(
+        TypeError,
+        match="expected `other` .*to be a 'LazyFrame'.* not 'DataFrame'",
+    ):
+        east.join_where(
+            west.collect(),
+            pl.col("dur") < pl.col("time"),
+            pl.col("rev") < pl.col("cost"),
+        )
+
+    with pytest.raises(
+        TypeError,
+        match="expected `other` .*to be a 'LazyFrame'.* not 'Series'",
+    ):
+        east.join_where(
+            pl.Series(west.collect()),
+            pl.col("dur") < pl.col("time"),
+            pl.col("rev") < pl.col("cost"),
+        )

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -1513,13 +1513,13 @@ def test_join_bad_input_type() -> None:
         TypeError,
         match="expected `other` .*to be a 'LazyFrame'.* not 'DataFrame'",
     ):
-        left.join(right.collect(), on="a")
+        left.join(right.collect(), on="a")  # type: ignore[arg-type]
 
     with pytest.raises(
         TypeError,
         match="expected `other` .*to be a 'LazyFrame'.* not 'Series'",
     ):
-        left.join(pl.Series([1, 2, 3]), on="a")
+        left.join(pl.Series([1, 2, 3]), on="a")  # type: ignore[arg-type]
 
 
 def test_join_where() -> None:
@@ -1583,7 +1583,7 @@ def test_join_where_bad_input_type() -> None:
         match="expected `other` .*to be a 'LazyFrame'.* not 'DataFrame'",
     ):
         east.join_where(
-            west.collect(),
+            west.collect(),  # type: ignore[arg-type]
             pl.col("dur") < pl.col("time"),
             pl.col("rev") < pl.col("cost"),
         )
@@ -1593,7 +1593,7 @@ def test_join_where_bad_input_type() -> None:
         match="expected `other` .*to be a 'LazyFrame'.* not 'Series'",
     ):
         east.join_where(
-            pl.Series(west.collect()),
+            pl.Series(west.collect()),  # type: ignore[arg-type]
             pl.col("dur") < pl.col("time"),
             pl.col("rev") < pl.col("cost"),
         )

--- a/py-polars/tests/unit/lazyframe/test_merged_sorted.py
+++ b/py-polars/tests/unit/lazyframe/test_merged_sorted.py
@@ -1,0 +1,48 @@
+import pytest
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+
+def test_merge_sorted_valid_inputs() -> None:
+    df0 = pl.LazyFrame(
+        {
+            "name": ["steve", "elise", "bob"],
+            "age": [42, 44, 18],
+        },
+    ).sort("age")
+
+    df1 = pl.LazyFrame(
+        {
+            "name": ["anna", "megan", "steve", "thomas"],
+            "age": [21, 33, 42, 20],
+        },
+    ).sort("age")
+
+    out = df0.merge_sorted(df1, key="age").collect()
+
+    expected = pl.DataFrame(
+        {
+            "name": ["bob", "thomas", "anna", "megan", "steve", "steve", "elise"],
+            "age": [18, 20, 21, 33, 42, 42, 44],
+        },
+    )
+
+    assert_frame_equal(out, expected)
+
+
+def test_merge_sorted_bad_input_type() -> None:
+    a = pl.LazyFrame({"x": [1, 2, 3]})
+    b = pl.LazyFrame({"x": [4, 5, 6]})
+
+    with pytest.raises(
+        TypeError,
+        match="expected `other` .*to be a 'LazyFrame'.* not 'Series'",
+    ):
+        a.merge_sorted(pl.Series(b.collect()), key="x")
+
+    with pytest.raises(
+        TypeError,
+        match="expected `other` .*to be a 'LazyFrame'.* not 'DataFrame'",
+    ):
+        a.merge_sorted(b.collect(), key="x")

--- a/py-polars/tests/unit/lazyframe/test_merged_sorted.py
+++ b/py-polars/tests/unit/lazyframe/test_merged_sorted.py
@@ -39,10 +39,10 @@ def test_merge_sorted_bad_input_type() -> None:
         TypeError,
         match="expected `other` .*to be a 'LazyFrame'.* not 'Series'",
     ):
-        a.merge_sorted(pl.Series(b.collect()), key="x")
+        a.merge_sorted(pl.Series(b.collect()), key="x")  # type: ignore[arg-type]
 
     with pytest.raises(
         TypeError,
         match="expected `other` .*to be a 'LazyFrame'.* not 'DataFrame'",
     ):
-        a.merge_sorted(b.collect(), key="x")
+        a.merge_sorted(b.collect(), key="x")  # type: ignore[arg-type]

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -632,13 +632,13 @@ def test_join_frame_consistency() -> None:
     df = pl.DataFrame({"A": [1, 2, 3]})
     ldf = pl.DataFrame({"A": [1, 2, 5]}).lazy()
 
-    with pytest.raises(TypeError, match="expected `other`.* LazyFrame"):
+    with pytest.raises(TypeError, match="expected `other`.*LazyFrame"):
         _ = ldf.join(df, on="A")  # type: ignore[arg-type]
-    with pytest.raises(TypeError, match="expected `other`.* DataFrame"):
+    with pytest.raises(TypeError, match="expected `other`.*DataFrame"):
         _ = df.join(ldf, on="A")  # type: ignore[arg-type]
-    with pytest.raises(TypeError, match="expected `other`.* LazyFrame"):
+    with pytest.raises(TypeError, match="expected `other`.*LazyFrame"):
         _ = ldf.join_asof(df, on="A")  # type: ignore[arg-type]
-    with pytest.raises(TypeError, match="expected `other`.* DataFrame"):
+    with pytest.raises(TypeError, match="expected `other`.*DataFrame"):
         _ = df.join_asof(ldf, on="A")  # type: ignore[arg-type]
 
 

--- a/py-polars/tests/unit/series/test_append.py
+++ b/py-polars/tests/unit/series/test_append.py
@@ -33,8 +33,17 @@ def test_append_bad_input() -> None:
     a = pl.Series("a", [1, 2])
     b = a.to_frame()
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(
+        TypeError,
+        match="expected `other` .*to be a 'Series'.* not 'DataFrame'",
+    ):
         a.append(b)  # type: ignore[arg-type]
+
+    with pytest.raises(
+        TypeError,
+        match="expected `other` .*to be a 'Series'.* not 'LazyFrame'",
+    ):
+        a.append(b.lazy())  # type: ignore[arg-type]
 
 
 def test_struct_schema_on_append_extend_3452() -> None:

--- a/py-polars/tests/unit/series/test_equals.py
+++ b/py-polars/tests/unit/series/test_equals.py
@@ -30,6 +30,18 @@ def test_equals() -> None:
     assert s3.equals(s4, null_equal=False) is False
     assert s3.dt.convert_time_zone("Asia/Tokyo").equals(s4) is True
 
+    with pytest.raises(
+        TypeError,
+        match="expected `other` to be a 'Series'.* not 'DataFrame'",
+    ):
+        s1.equals(pl.DataFrame(s2), check_names=False)
+
+    with pytest.raises(
+        TypeError,
+        match="expected `other` to be a 'Series'.* not 'LazyFrame'",
+    ):
+        s1.equals(pl.DataFrame(s2).lazy(), check_names=False)
+
 
 def test_series_equals_check_names() -> None:
     s1 = pl.Series("foo", [1, 2, 3])

--- a/py-polars/tests/unit/series/test_equals.py
+++ b/py-polars/tests/unit/series/test_equals.py
@@ -34,13 +34,13 @@ def test_equals() -> None:
         TypeError,
         match="expected `other` to be a 'Series'.* not 'DataFrame'",
     ):
-        s1.equals(pl.DataFrame(s2), check_names=False)
+        s1.equals(pl.DataFrame(s2), check_names=False)  # type: ignore[arg-type]
 
     with pytest.raises(
         TypeError,
         match="expected `other` to be a 'Series'.* not 'LazyFrame'",
     ):
-        s1.equals(pl.DataFrame(s2).lazy(), check_names=False)
+        s1.equals(pl.DataFrame(s2).lazy(), check_names=False)  # type: ignore[arg-type]
 
 
 def test_series_equals_check_names() -> None:

--- a/py-polars/tests/unit/series/test_extend.py
+++ b/py-polars/tests/unit/series/test_extend.py
@@ -30,8 +30,17 @@ def test_extend_bad_input() -> None:
     a = pl.Series("a", [1, 2])
     b = a.to_frame()
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(
+        TypeError,
+        match="expected `other` .*to be a 'Series'.* not 'DataFrame'",
+    ):
         a.extend(b)  # type: ignore[arg-type]
+
+    with pytest.raises(
+        TypeError,
+        match="expected `other` .*to be a 'Series'.* not 'LazyFrame'",
+    ):
+        a.extend(b.lazy())  # type: ignore[arg-type]
 
 
 def test_extend_with_null_series() -> None:

--- a/py-polars/tests/unit/series/test_zip_with.py
+++ b/py-polars/tests/unit/series/test_zip_with.py
@@ -1,0 +1,78 @@
+import pytest
+
+import polars as pl
+from polars.testing import assert_series_equal
+
+
+def test_zip_with_all_true_mask() -> None:
+    s1 = pl.Series([1, 2, 3])
+    s2 = pl.Series([4, 5, 6])
+    mask = pl.Series([True, True, True])
+
+    result = s1.zip_with(mask, s2)
+    assert_series_equal(result, s1)
+
+
+def test_zip_with_all_false_mask() -> None:
+    s1 = pl.Series([1, 2, 3])
+    s2 = pl.Series([4, 5, 6])
+    mask = pl.Series([False, False, False])
+
+    result = s1.zip_with(mask, s2)
+    assert_series_equal(result, s2)
+
+
+def test_zip_with_mixed_mask() -> None:
+    s1 = pl.Series([1, 2, 3, 4, 5])
+    s2 = pl.Series([5, 4, 3, 2, 1])
+    mask = pl.Series([True, False, True, False, True])
+
+    result = s1.zip_with(mask, s2)
+    expected = pl.Series([1, 4, 3, 2, 5])
+    assert_series_equal(result, expected)
+
+
+def test_zip_with_series_comparison() -> None:
+    s1 = pl.Series([1, 2, 3, 4, 5])
+    s2 = pl.Series([5, 4, 3, 2, 1])
+
+    result = s1.zip_with(s1 < s2, s2)
+    expected = pl.Series([1, 2, 3, 2, 1])
+    assert_series_equal(result, expected)
+
+
+def test_zip_with_null_values() -> None:
+    s1 = pl.Series([1, None, 3, 4])
+    s2 = pl.Series([5, 6, None, 8])
+    mask = pl.Series([True, True, False, False])
+
+    result = s1.zip_with(mask, s2)
+    expected = pl.Series([1, None, None, 8])
+    assert_series_equal(result, expected)
+
+
+def test_zip_with_length_mismatch() -> None:
+    s1 = pl.Series([1, 2, 3])
+    s2 = pl.Series([4, 5])
+    mask = pl.Series([True, False, True])
+
+    with pytest.raises(pl.exceptions.ShapeError):
+        s1.zip_with(mask, s2)
+
+
+def test_zip_with_bad_input_type() -> None:
+    s1 = pl.Series([1, 2, 3])
+    s2 = pl.Series([4, 5, 6])
+    mask = pl.Series([True, True, True])
+
+    with pytest.raises(
+        TypeError,
+        match="expected `other` .*to be a 'Series'.* not 'DataFrame'",
+    ):
+        s1.zip_with(mask, pl.DataFrame(s2))  # type: ignore[arg-type]
+
+    with pytest.raises(
+        TypeError,
+        match="expected `other` .*to be a 'Series'.* not 'LazyFrame'",
+    ):
+        s1.zip_with(mask, pl.DataFrame(s2).lazy())  # type: ignore[arg-type]

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -137,19 +137,19 @@ def test_join_lazy_on_df() -> None:
 
     with pytest.raises(
         TypeError,
-        match="expected `other` .* to be a LazyFrame.* not 'DataFrame'",
+        match="expected `other` .*to be a 'LazyFrame'.* not 'DataFrame'",
     ):
         df_left.lazy().join(df_right, on="Id")  # type: ignore[arg-type]
 
     with pytest.raises(
         TypeError,
-        match="expected `other` .* to be a LazyFrame.* not 'DataFrame'",
+        match="expected `other` .*to be a 'LazyFrame'.* not 'DataFrame'",
     ):
         df_left.lazy().join_asof(df_right, on="Id")  # type: ignore[arg-type]
 
     with pytest.raises(
         TypeError,
-        match="expected `other` .* to be a LazyFrame.* not 'pandas.core.frame.DataFrame'",
+        match="expected `other` .*to be a 'LazyFrame'.* not 'pandas.core.frame.DataFrame'",
     ):
         df_left.lazy().join_asof(df_right.to_pandas(), on="Id")  # type: ignore[arg-type]
 


### PR DESCRIPTION
Closes #22677 

Add a simple util function to confirm two objects are of the same type. Raise TypeError if that's not the case. There are two targets with this change:
* Easier onboarding of beginners to polars.
* Quicker inspection of this tedious error.

Also add several unit tests for affected methods