### PR TITLE
chore: Hardcode cryptography version to 44.0.3

### DIFF
--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -68,6 +68,7 @@ pytest-xdist==3.6.1
 
 # Need moto.server to mock s3fs - see: https://github.com/aio-libs/aiobotocore/issues/755
 moto[s3]==5.0.9
+cryptography==44.0.3 # see https://github.com/pola-rs/polars/issues/22804
 flask
 flask-cors
 


### PR DESCRIPTION
Closes #22804

There is a CI failure after release of cryptography 45.0.1 that might be preventing full pass for some PRs. For that reason, hardcode cryptography version to 44.0.3 until the issue is fully resolved. This package is required by moto.