### PR TITLE
chore: Fix `nix build`

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -6,6 +6,7 @@ extend-exclude = [
   "dists.dss",
   "**/images/*",
   "**/py-polars/polars/_utils/nest_asyncio.py",
+  "*.nix",
 ]
 ignore-hidden = false
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744309437,
-        "narHash": "sha256-QZnNHM823am8apCqKSPdtnzPGTy2ZB4zIXOVoBp5+W0=",
-        "owner": "nixos",
+        "lastModified": 1747602429,
+        "narHash": "sha256-hmtobkNi+5N9mMTCof1dgHh2c8gvqmRo3AlUEEyujYU=",
+        "owner": "LucioFranco",
         "repo": "nixpkgs",
-        "rev": "f9ebe33a928b5d529c895202263a5ce46bdf12f7",
+        "rev": "07b0811ae7cf3f57e3d25a4b3b37e0df59aec7dc",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-24.11",
+        "owner": "LucioFranco",
+        "ref": "lucio/nixos-24.11-patched-f9ebe33",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A basic Nix Flake for eachDefaultSystem";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:LucioFranco/nixpkgs/lucio/nixos-24.11-patched-f9ebe33";
     utils.url = "github:numtide/flake-utils";
     pyproject-nix = {
       url = "github:pyproject-nix/pyproject.nix";
@@ -925,6 +925,10 @@
             src = ./.;
             cargoDeps = pkgs.rustPlatform.importCargoLock {
               lockFile = ./Cargo.lock;
+              outputHashes = {
+                  "pyo3-0.24.2" = "sha256-0V4cT3DstG9mZvdIVZXzoQlNyvtBuLOvlMe1XDZp3/0=";
+                  "tikv-jemalloc-sys-0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7" = "sha256-nvXKBd5tKSe4hPTtMKriYhlgAML9gdDHZG8nNRzgjXM=";
+              };
             };
           };
       }


### PR DESCRIPTION
Updates the `importCargoLock` outputHashses for the git based dependencies and uses my fork of nixpkgs while we wait for upstream https://github.com/NixOS/nixpkgs/pull/408174 to be merged.

cc @coastalwhite 