### PR TITLE
fix: Ensure time unit upcast for temporal `is_in`

### DIFF
--- a/crates/polars-core/src/datatypes/temporal/time_unit.rs
+++ b/crates/polars-core/src/datatypes/temporal/time_unit.rs
@@ -1,14 +1,16 @@
 use crate::prelude::ArrowTimeUnit;
 
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(
     any(feature = "serde-lazy", feature = "serde"),
     derive(serde::Serialize, serde::Deserialize)
 )]
+
+// These must be listed from smallest to largest for Ord/PartialOrd to derive proper ordering.
 pub enum TimeUnit {
-    Nanoseconds,
-    Microseconds,
     Milliseconds,
+    Microseconds,
+    Nanoseconds,
 }
 
 impl From<&ArrowTimeUnit> for TimeUnit {

--- a/crates/polars-core/src/datatypes/temporal/time_unit.rs
+++ b/crates/polars-core/src/datatypes/temporal/time_unit.rs
@@ -1,12 +1,11 @@
 use crate::prelude::ArrowTimeUnit;
 
+// These must be listed from smallest to largest for Ord/PartialOrd to derive proper ordering.
 #[derive(Copy, Clone, Debug, PartialEq, Ord, PartialOrd, Eq, Hash)]
 #[cfg_attr(
     any(feature = "serde-lazy", feature = "serde"),
     derive(serde::Serialize, serde::Deserialize)
 )]
-
-// These must be listed from smallest to largest for Ord/PartialOrd to derive proper ordering.
 pub enum TimeUnit {
     Milliseconds,
     Microseconds,

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -565,16 +565,16 @@ def test_empty_inputs_error() -> None:
         (
             "d",
             pl.datetime_range(
-                datetime.now(),
-                datetime.now(),
-                interval="2345ns",
-                time_unit="ns",
+                datetime(2025, 1, 1),
+                datetime(2025, 1, 2),
+                interval="1h",
+                time_unit="ms",
                 eager=True,
             ),
             None,
         ),
         ("d", [time(10, 30)], None),
-        ("e", [datetime(1999, 12, 31, 10, 30)], None),
+        ("e", [datetime(1999, 12, 31, 0, 0)], [False, True, None]),
         ("f", ["xx", "zz"], None),
     ],
 )

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -659,7 +659,7 @@ def test_invalid_is_in_dtypes(
                 )
             assert len(records) == len(warnings)
             for record, expected_warning in zip(records, warnings):
-                assert record.category == expected_warning[0]  # warning type
+                assert record.category == expected_warning[0]  # type: ignore[comparison-overlap]
                 assert (
                     record.message.args[0] == expected_warning[1]  # type: ignore[union-attr]
                 )

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -658,7 +658,7 @@ def test_invalid_is_in_dtypes(
                     == expected
                 )
             assert len(records) == len(warnings)
-            for record, expected_warning in zip(records, warnings, strict=True):
+            for record, expected_warning in zip(records, warnings):
                 assert record.category == expected_warning[0]  # warning type
                 assert (
                     record.message.args[0] == expected_warning[1]  # type: ignore[union-attr]

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -24,6 +24,8 @@ from polars.exceptions import (
 from tests.unit.conftest import TEMPORAL_DTYPES
 
 if TYPE_CHECKING:
+    from warnings import WarningMessage
+
     from polars._typing import ConcatMethod
 
 
@@ -630,7 +632,7 @@ def test_invalid_is_in_dtypes(
     colname: str,
     values: list[Any],
     expected: list[Any] | None,
-    warnings: list[Warning, str] | None,
+    warnings: list[tuple[WarningMessage, str]] | None,
 ) -> None:
     df = pl.DataFrame(
         {
@@ -658,7 +660,9 @@ def test_invalid_is_in_dtypes(
             assert len(records) == len(warnings)
             for record, expected_warning in zip(records, warnings, strict=True):
                 assert record.category == expected_warning[0]  # warning type
-                assert record.message.args[0] == expected_warning[1]  # warning message
+                assert (
+                    record.message.args[0] == expected_warning[1]  # type: ignore[union-attr]
+                )
 
         else:
             assert (


### PR DESCRIPTION
Partially closes some issues related to #22824. Note that the actual issue looks like it's intended behavior, the reason being the comment [here](https://github.com/pola-rs/polars/blob/5be0a9b21cd84f0a9f6c3e159c8668584d81608e/crates/polars-plan/src/plans/conversion/type_coercion/is_in.rs#L123-L124) which says:

```rust
// can't check for more granular time_unit in less-granular time_unit data,
// or we'll cast away valid/necessary precision (eg: nanosecs to millisecs)
```

meaning that calling `x("ns").is_in(y("us"))` will still raise. I am not sure that I agree with this--I think that both sides should simply be upcast--but that can be another issue to resolve if others agree with me, or can be left alone if not. But note that this is the new behavior, which I find a little confusing but is nonetheless logically consistent:

```python
import polars as pl
from datetime import datetime

s_milli = pl.Series([datetime(2025, 1, 1), datetime(2025, 1, 2)], dtype=pl.Datetime("ms"))
s_micro = pl.Series([datetime(2025, 1, 1), datetime(2025, 1, 2)], dtype=pl.Datetime("us"))
s_nano = pl.Series([datetime(2025, 1, 1), datetime(2025, 1, 2)], dtype=pl.Datetime("ns"))

s_milli.is_in([datetime(2025, 1, 1)])  # OK -- LHS less precise than right
s_micro.is_in([datetime(2025, 1, 1)])  # OK -- same time unit
s_nano.is_in([datetime(2025, 1, 1)])   # ERROR: LHS more precise than right
```

---

Regardless, when looking into this, I discovered two other issues that this PR addresses:

1. The `TimeUnit` class ([see here](https://github.com/pola-rs/polars/blob/5be0a9b21cd84f0a9f6c3e159c8668584d81608e/crates/polars-core/src/datatypes/temporal/time_unit.rs#L8C4-L13)) derives the `Ord` and `PartialOrd`. The derive macro assigns ordering from top to bottom as smallest to largest, so our time unit ordering was completely reversed, e.g. `TimeUnit::Nanoseconds < TimeUnit::Microseconds`. So any comparisons throughout the codebase using time unit comparisons were wrong. Fortunately I don't think there are many.

2. When temporals were compared but have different time units, they were never cast to the same time unit. So their physicals were off by factors of 1000, resulting in incorrect `is_in` results.