### PR TITLE
build: Add missing features

### DIFF
--- a/crates/polars-error/Cargo.toml
+++ b/crates/polars-error/Cargo.toml
@@ -9,7 +9,7 @@ repository = { workspace = true }
 description = "Error definitions for the Polars DataFrame library"
 
 [dependencies]
-arrow-format = { workspace = true, optional = true }
+arrow-format = { workspace = true, optional = true, features = ["ipc"] }
 avro-schema = { workspace = true, optional = true }
 object_store = { workspace = true, optional = true }
 parking_lot = { workspace = true }

--- a/crates/polars-parquet/Cargo.toml
+++ b/crates/polars-parquet/Cargo.toml
@@ -66,7 +66,7 @@ lz4_flex = ["dep:lz4_flex"]
 
 async = ["async-stream", "futures", "polars-parquet-format/async"]
 bloom_filter = ["xxhash-rust"]
-serde_types = ["serde"]
+serde = ["dep:serde", "polars-utils/serde"]
 simd = ["polars-compute/simd"]
 
 proptest = ["dep:proptest", "arrow/proptest"]

--- a/crates/polars-parquet/src/parquet/metadata/column_chunk_metadata.rs
+++ b/crates/polars-parquet/src/parquet/metadata/column_chunk_metadata.rs
@@ -6,7 +6,7 @@ use crate::parquet::error::{ParquetError, ParquetResult};
 use crate::parquet::schema::types::PhysicalType;
 use crate::parquet::statistics::Statistics;
 
-#[cfg(feature = "serde_types")]
+#[cfg(feature = "serde")]
 mod serde_types {
     pub use std::io::Cursor;
 
@@ -17,7 +17,7 @@ mod serde_types {
     pub use serde::ser::Error as SerializeError;
     pub use serde::{Deserialize, Deserializer, Serialize, Serializer};
 }
-#[cfg(feature = "serde_types")]
+#[cfg(feature = "serde")]
 use serde_types::*;
 
 /// Metadata for a column chunk.
@@ -27,21 +27,18 @@ use serde_types::*;
 ///
 /// This struct is intentionally not `Clone`, as it is a huge struct.
 #[derive(Debug)]
-#[cfg_attr(feature = "serde_types", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct ColumnChunkMetadata {
+    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_column_chunk"))]
     #[cfg_attr(
-        feature = "serde_types",
-        serde(serialize_with = "serialize_column_chunk")
-    )]
-    #[cfg_attr(
-        feature = "serde_types",
+        feature = "serde",
         serde(deserialize_with = "deserialize_column_chunk")
     )]
     column_chunk: ColumnChunk,
     column_descr: ColumnDescriptor,
 }
 
-#[cfg(feature = "serde_types")]
+#[cfg(feature = "serde")]
 fn serialize_column_chunk<S>(
     column_chunk: &ColumnChunk,
     serializer: S,
@@ -58,7 +55,7 @@ where
     serializer.serialize_bytes(&buf)
 }
 
-#[cfg(feature = "serde_types")]
+#[cfg(feature = "serde")]
 fn deserialize_column_chunk<'de, D>(deserializer: D) -> std::result::Result<ColumnChunk, D::Error>
 where
     D: Deserializer<'de>,

--- a/crates/polars-parquet/src/parquet/metadata/column_descriptor.rs
+++ b/crates/polars-parquet/src/parquet/metadata/column_descriptor.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use polars_utils::pl_str::PlSmallStr;
-#[cfg(feature = "serde_types")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::parquet::schema::types::{ParquetType, PrimitiveType};
@@ -10,7 +10,7 @@ use crate::parquet::schema::types::{ParquetType, PrimitiveType};
 /// A descriptor of a parquet column. It contains the necessary information to deserialize
 /// a parquet column.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde_types", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Descriptor {
     /// The [`PrimitiveType`] of this column
     pub primitive_type: PrimitiveType,
@@ -23,7 +23,7 @@ pub struct Descriptor {
 }
 
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde_types", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum BaseType {
     Owned(ParquetType),
     Arc(Arc<ParquetType>),
@@ -59,7 +59,7 @@ impl Deref for BaseType {
 /// This encapsulates information such as definition and repetition levels and is used to
 /// re-assemble nested data.
 #[derive(Debug, PartialEq, Clone)]
-#[cfg_attr(feature = "serde_types", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct ColumnDescriptor {
     /// The descriptor this columns' leaf.
     pub descriptor: Descriptor,

--- a/crates/polars-parquet/src/parquet/metadata/column_order.rs
+++ b/crates/polars-parquet/src/parquet/metadata/column_order.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "serde_types")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use super::sort::SortOrder;
@@ -9,7 +9,7 @@ use super::sort::SortOrder;
 /// If column order is undefined, then it is the legacy behaviour and all values should
 /// be compared as signed values/bytes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "serde_types", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum ColumnOrder {
     /// Column uses the order defined by its logical or physical type
     /// (if there is no logical type), parquet-format 2.4.0+.

--- a/crates/polars-parquet/src/parquet/metadata/schema_descriptor.rs
+++ b/crates/polars-parquet/src/parquet/metadata/schema_descriptor.rs
@@ -1,6 +1,6 @@
 use polars_parquet_format::SchemaElement;
 use polars_utils::pl_str::PlSmallStr;
-#[cfg(feature = "serde_types")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use super::column_descriptor::{BaseType, ColumnDescriptor, Descriptor};
@@ -12,7 +12,7 @@ use crate::parquet::schema::types::{FieldInfo, ParquetType};
 /// A schema descriptor. This encapsulates the top-level schemas for all the columns,
 /// as well as all descriptors for all the primitive columns.
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde_types", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct SchemaDescriptor {
     name: PlSmallStr,
     // The top-level schema (the "message" type).

--- a/crates/polars-parquet/src/parquet/metadata/sort.rs
+++ b/crates/polars-parquet/src/parquet/metadata/sort.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "serde_types")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::parquet::schema::types::{
@@ -14,7 +14,7 @@ use crate::parquet::schema::types::{
 /// See reference in
 /// <https://github.com/apache/parquet-cpp/blob/master/src/parquet/types.h>
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "serde_types", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum SortOrder {
     /// Signed (either value or legacy byte-wise) comparison.
     Signed,

--- a/crates/polars-parquet/src/parquet/parquet_bridge.rs
+++ b/crates/polars-parquet/src/parquet/parquet_bridge.rs
@@ -1,6 +1,6 @@
 // Bridges structs from thrift-generated code to rust enums.
 
-#[cfg(feature = "serde_types")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use super::thrift_format::{
@@ -13,7 +13,7 @@ use crate::parquet::error::ParquetError;
 
 /// The repetition of a parquet field
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
-#[cfg_attr(feature = "serde_types", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Repetition {
     /// When the field has no null values
     Required,
@@ -47,7 +47,7 @@ impl From<Repetition> for FieldRepetitionType {
 }
 
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
-#[cfg_attr(feature = "serde_types", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Compression {
     Uncompressed,
     Snappy,
@@ -436,7 +436,7 @@ impl DataPageHeaderExt for DataPageHeaderV2 {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde_types", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum TimeUnit {
     Milliseconds,
     Microseconds,
@@ -465,7 +465,7 @@ impl From<TimeUnit> for ParquetTimeUnit {
 
 /// Enum of all valid logical integer types
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde_types", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum IntegerType {
     Int8,
     Int16,
@@ -478,7 +478,7 @@ pub enum IntegerType {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde_types", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum PrimitiveLogicalType {
     String,
     Enum,
@@ -501,7 +501,7 @@ pub enum PrimitiveLogicalType {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde_types", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum GroupLogicalType {
     Map,
     List,

--- a/crates/polars-parquet/src/parquet/schema/types/basic_type.rs
+++ b/crates/polars-parquet/src/parquet/schema/types/basic_type.rs
@@ -1,12 +1,12 @@
 use polars_utils::pl_str::PlSmallStr;
-#[cfg(feature = "serde_types")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use super::super::Repetition;
 
 /// Common type information.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde_types", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct FieldInfo {
     /// The field name
     pub name: PlSmallStr,

--- a/crates/polars-parquet/src/parquet/schema/types/converted_type.rs
+++ b/crates/polars-parquet/src/parquet/schema/types/converted_type.rs
@@ -1,11 +1,11 @@
 use polars_parquet_format::ConvertedType;
-#[cfg(feature = "serde_types")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::parquet::error::ParquetError;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde_types", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum PrimitiveConvertedType {
     Utf8,
     /// an enum is converted into a binary field
@@ -87,7 +87,7 @@ pub enum PrimitiveConvertedType {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde_types", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum GroupConvertedType {
     /// a map is converted as an optional field containing a repeated key/value pair
     Map,

--- a/crates/polars-parquet/src/parquet/schema/types/parquet_type.rs
+++ b/crates/polars-parquet/src/parquet/schema/types/parquet_type.rs
@@ -1,7 +1,7 @@
 // see https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
 use polars_utils::aliases::*;
 use polars_utils::pl_str::PlSmallStr;
-#[cfg(feature = "serde_types")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use super::super::Repetition;
@@ -13,7 +13,7 @@ use crate::parquet::error::ParquetResult;
 
 /// The complete description of a parquet column
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde_types", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct PrimitiveType {
     /// The fields' generic information
     pub field_info: FieldInfo,
@@ -45,7 +45,7 @@ impl PrimitiveType {
 /// Representation of a Parquet type describing primitive and nested fields,
 /// including the top-level schema of the parquet file.
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde_types", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum ParquetType {
     PrimitiveType(PrimitiveType),
     GroupType {

--- a/crates/polars-parquet/src/parquet/schema/types/physical_type.rs
+++ b/crates/polars-parquet/src/parquet/schema/types/physical_type.rs
@@ -1,12 +1,12 @@
 use polars_parquet_format::Type;
-#[cfg(feature = "serde_types")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::parquet::error::ParquetError;
 
 /// The set of all physical types representable in Parquet
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde_types", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum PhysicalType {
     Boolean,
     Int32,

--- a/crates/polars-plan/Cargo.toml
+++ b/crates/polars-plan/Cargo.toml
@@ -49,7 +49,7 @@ version_check = { workspace = true }
 [features]
 # debugging utility
 debugging = []
-python = ["dep:pyo3", "polars-utils/python", "polars-ffi"]
+python = ["dep:pyo3", "polars-utils/python", "polars-ffi", "polars-core/object"]
 serde = [
   "ir_serde",
   "dep:serde",
@@ -144,7 +144,7 @@ pct_change = ["polars-ops/pct_change"]
 moment = ["polars-ops/moment"]
 abs = ["polars-ops/abs"]
 random = ["polars-core/random"]
-dynamic_group_by = ["polars-core/dynamic_group_by"]
+dynamic_group_by = ["polars-core/dynamic_group_by", "dtype-date", "dtype-datetime"]
 ewma = ["polars-ops/ewma"]
 ewma_by = ["polars-ops/ewma_by"]
 dot_diagram = []

--- a/crates/polars-plan/src/dsl/dt.rs
+++ b/crates/polars-plan/src/dsl/dt.rs
@@ -282,30 +282,35 @@ impl DateLikeNameSpace {
     }
 
     /// Express a Duration in terms of its total number of integer days.
+    #[cfg(feature = "dtype-duration")]
     pub fn total_days(self) -> Expr {
         self.0
             .map_unary(FunctionExpr::TemporalExpr(TemporalFunction::TotalDays))
     }
 
     /// Express a Duration in terms of its total number of integer hours.
+    #[cfg(feature = "dtype-duration")]
     pub fn total_hours(self) -> Expr {
         self.0
             .map_unary(FunctionExpr::TemporalExpr(TemporalFunction::TotalHours))
     }
 
     /// Express a Duration in terms of its total number of integer minutes.
+    #[cfg(feature = "dtype-duration")]
     pub fn total_minutes(self) -> Expr {
         self.0
             .map_unary(FunctionExpr::TemporalExpr(TemporalFunction::TotalMinutes))
     }
 
     /// Express a Duration in terms of its total number of integer seconds.
+    #[cfg(feature = "dtype-duration")]
     pub fn total_seconds(self) -> Expr {
         self.0
             .map_unary(FunctionExpr::TemporalExpr(TemporalFunction::TotalSeconds))
     }
 
     /// Express a Duration in terms of its total number of milliseconds.
+    #[cfg(feature = "dtype-duration")]
     pub fn total_milliseconds(self) -> Expr {
         self.0.map_unary(FunctionExpr::TemporalExpr(
             TemporalFunction::TotalMilliseconds,
@@ -313,6 +318,7 @@ impl DateLikeNameSpace {
     }
 
     /// Express a Duration in terms of its total number of microseconds.
+    #[cfg(feature = "dtype-duration")]
     pub fn total_microseconds(self) -> Expr {
         self.0.map_unary(FunctionExpr::TemporalExpr(
             TemporalFunction::TotalMicroseconds,
@@ -320,6 +326,7 @@ impl DateLikeNameSpace {
     }
 
     /// Express a Duration in terms of its total number of nanoseconds.
+    #[cfg(feature = "dtype-duration")]
     pub fn total_nanoseconds(self) -> Expr {
         self.0.map_unary(FunctionExpr::TemporalExpr(
             TemporalFunction::TotalNanoseconds,

--- a/crates/polars-plan/src/dsl/function_expr/datetime.rs
+++ b/crates/polars-plan/src/dsl/function_expr/datetime.rs
@@ -30,6 +30,7 @@ pub enum TemporalFunction {
     Time,
     Date,
     Datetime,
+    #[cfg(feature = "dtype-duration")]
     Duration(TimeUnit),
     Hour,
     Minute,
@@ -37,12 +38,19 @@ pub enum TemporalFunction {
     Millisecond,
     Microsecond,
     Nanosecond,
+    #[cfg(feature = "dtype-duration")]
     TotalDays,
+    #[cfg(feature = "dtype-duration")]
     TotalHours,
+    #[cfg(feature = "dtype-duration")]
     TotalMinutes,
+    #[cfg(feature = "dtype-duration")]
     TotalSeconds,
+    #[cfg(feature = "dtype-duration")]
     TotalMilliseconds,
+    #[cfg(feature = "dtype-duration")]
     TotalMicroseconds,
+    #[cfg(feature = "dtype-duration")]
     TotalNanoseconds,
     ToString(String),
     CastTimeUnit(TimeUnit),
@@ -83,6 +91,7 @@ impl TemporalFunction {
                 mapper.with_dtype(DataType::Int8)
             },
             Millisecond | Microsecond | Nanosecond => mapper.with_dtype(DataType::Int32),
+            #[cfg(feature = "dtype-duration")]
             TotalDays | TotalHours | TotalMinutes | TotalSeconds | TotalMilliseconds
             | TotalMicroseconds | TotalNanoseconds => mapper.with_dtype(DataType::Int64),
             ToString(_) => mapper.with_dtype(DataType::String),
@@ -100,6 +109,7 @@ impl TemporalFunction {
             TimeStamp(_) => mapper.with_dtype(DataType::Int64),
             IsLeapYear => mapper.with_dtype(DataType::Boolean),
             Time => mapper.with_dtype(DataType::Time),
+            #[cfg(feature = "dtype-duration")]
             Duration(tu) => mapper.with_dtype(DataType::Duration(*tu)),
             Date => mapper.with_dtype(DataType::Date),
             Datetime => mapper.try_map_dtype(|dt| match dt {
@@ -161,17 +171,18 @@ impl TemporalFunction {
             | T::Millisecond
             | T::Microsecond
             | T::Nanosecond
-            | T::TotalDays
+            | T::ToString(_)
+            | T::TimeStamp(_)
+            | T::CastTimeUnit(_)
+            | T::WithTimeUnit(_) => FunctionOptions::elementwise(),
+            #[cfg(feature = "dtype-duration")]
+            T::TotalDays
             | T::TotalHours
             | T::TotalMinutes
             | T::TotalSeconds
             | T::TotalMilliseconds
             | T::TotalMicroseconds
-            | T::TotalNanoseconds
-            | T::ToString(_)
-            | T::TimeStamp(_)
-            | T::CastTimeUnit(_)
-            | T::WithTimeUnit(_) => FunctionOptions::elementwise(),
+            | T::TotalNanoseconds => FunctionOptions::elementwise(),
             #[cfg(feature = "timezones")]
             T::ConvertTimeZone(_) => FunctionOptions::elementwise(),
             #[cfg(feature = "month_start")]
@@ -185,6 +196,7 @@ impl TemporalFunction {
             T::OffsetBy => FunctionOptions::elementwise(),
             T::Round => FunctionOptions::elementwise(),
             T::Replace => FunctionOptions::elementwise(),
+            #[cfg(feature = "dtype-duration")]
             T::Duration(_) => FunctionOptions::elementwise(),
             #[cfg(feature = "timezones")]
             T::ReplaceTimeZone(_, _) => FunctionOptions::elementwise(),
@@ -214,6 +226,7 @@ impl Display for TemporalFunction {
             Time => "time",
             Date => "date",
             Datetime => "datetime",
+            #[cfg(feature = "dtype-duration")]
             Duration(_) => "duration",
             Hour => "hour",
             Minute => "minute",
@@ -221,12 +234,19 @@ impl Display for TemporalFunction {
             Millisecond => "millisecond",
             Microsecond => "microsecond",
             Nanosecond => "nanosecond",
+            #[cfg(feature = "dtype-duration")]
             TotalDays => "total_days",
+            #[cfg(feature = "dtype-duration")]
             TotalHours => "total_hours",
+            #[cfg(feature = "dtype-duration")]
             TotalMinutes => "total_minutes",
+            #[cfg(feature = "dtype-duration")]
             TotalSeconds => "total_seconds",
+            #[cfg(feature = "dtype-duration")]
             TotalMilliseconds => "total_milliseconds",
+            #[cfg(feature = "dtype-duration")]
             TotalMicroseconds => "total_microseconds",
+            #[cfg(feature = "dtype-duration")]
             TotalNanoseconds => "total_nanoseconds",
             ToString(_) => "to_string",
             #[cfg(feature = "timezones")]

--- a/crates/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/crates/polars-plan/src/dsl/function_expr/temporal.rs
@@ -14,6 +14,7 @@ impl From<TemporalFunction> for SpecialEq<Arc<dyn ColumnsUdf>> {
             Quarter => map!(datetime::quarter),
             Week => map!(datetime::week),
             WeekDay => map!(datetime::weekday),
+            #[cfg(feature = "dtype-duration")]
             Duration(tu) => map_as_slice!(impl_duration, tu),
             Day => map!(datetime::day),
             OrdinalDay => map!(datetime::ordinal_day),
@@ -26,12 +27,19 @@ impl From<TemporalFunction> for SpecialEq<Arc<dyn ColumnsUdf>> {
             Millisecond => map!(datetime::millisecond),
             Microsecond => map!(datetime::microsecond),
             Nanosecond => map!(datetime::nanosecond),
+            #[cfg(feature = "dtype-duration")]
             TotalDays => map!(datetime::total_days),
+            #[cfg(feature = "dtype-duration")]
             TotalHours => map!(datetime::total_hours),
+            #[cfg(feature = "dtype-duration")]
             TotalMinutes => map!(datetime::total_minutes),
+            #[cfg(feature = "dtype-duration")]
             TotalSeconds => map!(datetime::total_seconds),
+            #[cfg(feature = "dtype-duration")]
             TotalMilliseconds => map!(datetime::total_milliseconds),
+            #[cfg(feature = "dtype-duration")]
             TotalMicroseconds => map!(datetime::total_microseconds),
+            #[cfg(feature = "dtype-duration")]
             TotalNanoseconds => map!(datetime::total_nanoseconds),
             ToString(format) => map!(datetime::to_string, &format),
             TimeStamp(tu) => map!(datetime::timestamp, tu),

--- a/crates/polars-plan/src/dsl/functions/temporal.rs
+++ b/crates/polars-plan/src/dsl/functions/temporal.rs
@@ -410,6 +410,7 @@ impl DurationArgs {
 }
 
 /// Construct a column of [`Duration`] from the provided [`DurationArgs`]
+#[cfg(feature = "dtype-duration")]
 pub fn duration(args: DurationArgs) -> Expr {
     if let Some(e) = args.as_literal() {
         return e;

--- a/crates/polars-plan/src/dsl/python_dsl/python_udf.rs
+++ b/crates/polars-plan/src/dsl/python_dsl/python_udf.rs
@@ -21,9 +21,9 @@ pub static mut CALL_DF_UDF_PYTHON: Option<
     fn(s: DataFrame, lambda: &PyObject) -> PolarsResult<DataFrame>,
 > = None;
 
-pub use polars_utils::python_function::{
-    PYTHON_SERDE_MAGIC_BYTE_MARK, PYTHON3_VERSION, PythonFunction,
-};
+pub use polars_utils::python_function::PythonFunction;
+#[cfg(feature = "serde")]
+pub use polars_utils::python_function::{PYTHON_SERDE_MAGIC_BYTE_MARK, PYTHON3_VERSION};
 
 pub struct PythonUdfExpression {
     python_function: PyObject,

--- a/crates/polars-plan/src/plans/aexpr/properties.rs
+++ b/crates/polars-plan/src/plans/aexpr/properties.rs
@@ -228,7 +228,7 @@ impl ExprPushdownGroup {
                         ..
                     } => true,
 
-                    #[cfg(feature = "temporal")]
+                    #[cfg(all(feature = "strings", feature = "temporal"))]
                     AExpr::Function {
                         input,
                         function:

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -433,7 +433,7 @@ impl OptimizationRule for TypeCoercionRule {
                     options,
                 })
             },
-            #[cfg(feature = "temporal")]
+            #[cfg(all(feature = "temporal", feature = "dtype-duration"))]
             AExpr::Function {
                 function: ref function @ FunctionExpr::TemporalExpr(TemporalFunction::Duration(_)),
                 ref input,

--- a/crates/polars-plan/src/plans/python/predicate.rs
+++ b/crates/polars-plan/src/plans/python/predicate.rs
@@ -1,5 +1,4 @@
 use polars_core::prelude::{AnyValue, PolarsResult};
-use polars_utils::pl_serialize;
 use recursive::recursive;
 
 use crate::prelude::*;
@@ -42,12 +41,13 @@ fn accept_as_io_predicate(e: &Expr) -> bool {
     }
 }
 
+#[cfg(feature = "serde")]
 pub fn serialize(expr: &Expr) -> PolarsResult<Option<Vec<u8>>> {
     if !accept_as_io_predicate(expr) {
         return Ok(None);
     }
     let mut buf = vec![];
-    pl_serialize::serialize_into_writer::<_, _, true>(&mut buf, expr)?;
+    polars_utils::pl_serialize::serialize_into_writer::<_, _, true>(&mut buf, expr)?;
 
     Ok(Some(buf))
 }

--- a/crates/polars-plan/src/plans/python/pyarrow.rs
+++ b/crates/polars-plan/src/plans/python/pyarrow.rs
@@ -45,16 +45,23 @@ pub fn predicate_to_pa(
                 let mut list_repr = String::with_capacity(s.len() * 5);
                 list_repr.push('[');
                 for av in s.rechunk().iter() {
-                    if let AnyValue::Boolean(v) = av {
-                        let s = if v { "True" } else { "False" };
-                        write!(list_repr, "{},", s).unwrap();
-                    } else if let AnyValue::Datetime(v, tu, tz) = av {
-                        let dtm = to_py_datetime(v, &tu, tz);
-                        write!(list_repr, "{dtm},").unwrap();
-                    } else if let AnyValue::Date(v) = av {
-                        write!(list_repr, "to_py_date({v}),").unwrap();
-                    } else {
-                        write!(list_repr, "{av},").unwrap();
+                    match av {
+                        AnyValue::Boolean(v) => {
+                            let s = if v { "True" } else { "False" };
+                            write!(list_repr, "{},", s).unwrap();
+                        },
+                        #[cfg(feature = "dtype-datetime")]
+                        AnyValue::Datetime(v, tu, tz) => {
+                            let dtm = to_py_datetime(v, &tu, tz);
+                            write!(list_repr, "{dtm},").unwrap();
+                        },
+                        #[cfg(feature = "dtype-date")]
+                        AnyValue::Date(v) => {
+                            write!(list_repr, "to_py_date({v}),").unwrap();
+                        },
+                        _ => {
+                            write!(list_repr, "{av},").unwrap();
+                        },
                     }
                 }
                 // pop last comma

--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -806,6 +806,7 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                     StringFunction::Replace { n, literal } => {
                         (PyStringFunction::Replace, n, literal).into_py_any(py)
                     },
+                    #[cfg(feature = "string_normalize")]
                     StringFunction::Normalize { form } => (
                         PyStringFunction::Normalize,
                         match form {

--- a/crates/polars-stream/Cargo.toml
+++ b/crates/polars-stream/Cargo.toml
@@ -47,7 +47,11 @@ version_check = { workspace = true }
 nightly = []
 bitwise = ["polars-core/bitwise", "polars-plan/bitwise", "polars-expr/bitwise"]
 merge_sorted = ["polars-plan/merge_sorted", "polars-mem-engine/merge_sorted"]
-dynamic_group_by = []
+dynamic_group_by = [
+  "polars-plan/dynamic_group_by",
+  "polars-expr/dynamic_group_by",
+  "polars-mem-engine/dynamic_group_by",
+]
 strings = []
 ipc = ["polars-mem-engine/ipc", "polars-plan/ipc", "polars-io/ipc"]
 parquet = ["polars-mem-engine/parquet", "polars-plan/parquet", "cloud"]
@@ -57,7 +61,7 @@ cloud = ["polars-mem-engine/cloud", "polars-plan/cloud", "polars-io/cloud"]
 dtype-array = ["polars-core/dtype-array"]
 dtype-categorical = ["polars-core/dtype-categorical", "polars-plan/dtype-categorical"]
 object = ["polars-ops/object"]
-python = ["pyo3", "polars-plan/python", "polars-error/python"]
+python = ["pyo3", "polars-plan/python", "polars-mem-engine/python", "polars-error/python"]
 semi_anti_join = ["polars-plan/semi_anti_join", "polars-ops/semi_anti_join"]
 is_in = ["polars-ops/is_in", "polars-plan/is_in", "semi_anti_join"]
 replace = ["polars-ops/replace", "polars-plan/replace"]

--- a/crates/polars-testing/Cargo.toml
+++ b/crates/polars-testing/Cargo.toml
@@ -9,5 +9,5 @@ repository = { workspace = true }
 description = "Testing suite for the Polars DataFrame library"
 
 [dependencies]
-polars-core = { workspace = true }
-polars-ops = { workspace = true }
+polars-core = { workspace = true, features = ["dtype-array", "dtype-categorical", "dtype-struct"] }
+polars-ops = { workspace = true, features = ["abs"] }


### PR DESCRIPTION
This PR adds missing features that prevent each crate from building on its own.

- `polars-error`: requires `arrow-format/ipc`
- `polars-parquet`: renamed `serde_types` feature to `serde`, requires `polars-utils/serde`
- `polars-plan`
  - `python` requires `polars-core/object`
  - `dynamic_group_by` requires either `dtype-date` or `dtype-datetime`, added dependency on both to prevent complex `cfg` attributes within the crate
  - added missing `#[cfg(feature = "dtype-duration")]` within the crate
  - added missing `#[cfg(feature = "string_normalize")]` within the crate
- `polars-stream`
  - `dynamic_group_by` requires `polars-plan/dynamic_group_by`, `polars-expr/dynamic_group_by` and `polars-mem-engine/dynamic_group_by`
  - `python` requires `polars-mem-engine/python`
- `polars-testing`
  - requires `polars-core/dtype-array`, `/dtype-categorical`, and `/dtype-struct`
  - requires `polars-ops/abs`