### PR TITLE
perf: Switch eligible casts to non-strict in optimizer

### DIFF
--- a/crates/polars-plan/src/dsl/file_scan/mod.rs
+++ b/crates/polars-plan/src/dsl/file_scan/mod.rs
@@ -323,23 +323,18 @@ impl CastColumnsPolicy {
         target_dtype: &DataType,
         incoming_dtype: &DataType,
     ) -> PolarsResult<bool> {
-        let mismatch_err = {
-            let incoming_dtype = incoming_dtype;
-            let target_dtype = target_dtype;
+        let mismatch_err = |hint: &str| {
+            let hint_spacing = if hint.is_empty() { "" } else { ", " };
 
-            move |hint: &str| {
-                let hint_spacing = if hint.is_empty() { "" } else { ", " };
-
-                polars_bail!(
-                    SchemaMismatch:
-                    "data type mismatch for column {}: incoming: {:?} != target: {:?}{}{}",
-                    column_name,
-                    incoming_dtype,
-                    target_dtype,
-                    hint_spacing,
-                    hint,
-                )
-            }
+            polars_bail!(
+                SchemaMismatch:
+                "data type mismatch for column {}: incoming: {:?} != target: {:?}{}{}",
+                column_name,
+                incoming_dtype,
+                target_dtype,
+                hint_spacing,
+                hint,
+            )
         };
 
         // We intercept the nested types first to prevent an expensive recursive eq - recursion

--- a/crates/polars-plan/src/dsl/file_scan/mod.rs
+++ b/crates/polars-plan/src/dsl/file_scan/mod.rs
@@ -509,7 +509,7 @@ impl CastColumnsPolicy {
                     }
                 },
 
-                (l, r) => panic!("unreachable: ({}, {})", l, r),
+                _ => unreachable!(),
             };
         }
 

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -785,6 +785,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                             float_upcast: per_column.float_cast == UpcastOrForbid::Upcast,
                             float_downcast: false,
                             datetime_nanoseconds_downcast: false,
+                            datetime_microseconds_downcast: false,
                             datetime_convert_timezone: false,
                             missing_struct_fields: per_column.missing_struct_fields,
                             extra_struct_fields: per_column.extra_struct_fields,

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -127,6 +127,7 @@ impl OptimizationRule for TypeCoercionRule {
                         }
                         .should_cast_column("", cast_to, &cast_from);
 
+                        #[expect(clippy::single_match)]
                         match v {
                             // No casting needed
                             // TODO: Enable after release 1.30.0

--- a/crates/polars-python/src/conversion/mod.rs
+++ b/crates/polars-python/src/conversion/mod.rs
@@ -1360,6 +1360,7 @@ impl<'py> FromPyObject<'py> for Wrap<CastColumnsPolicy> {
             float_upcast,
             float_downcast,
             datetime_nanoseconds_downcast,
+            datetime_microseconds_downcast: false,
             datetime_convert_timezone,
             missing_struct_fields,
             extra_struct_fields,

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -952,3 +952,14 @@ def test_nested_struct_cast_22744() -> None:
         ),
         expected,
     )
+
+
+def test_cast_to_self_is_pruned() -> None:
+    q = pl.LazyFrame({"x": 1}, schema={"x": pl.Int64}).with_columns(
+        y=pl.col("x").cast(pl.Int64)
+    )
+
+    plan = q.explain()
+    assert 'col("x").alias("y")' in plan
+
+    assert_frame_equal(q.collect(), pl.DataFrame({"x": 1, "y": 1}))

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -954,6 +954,7 @@ def test_nested_struct_cast_22744() -> None:
     )
 
 
+@pytest.mark.xfail(reason="disabled until after release 1.30.0")
 def test_cast_to_self_is_pruned() -> None:
     q = pl.LazyFrame({"x": 1}, schema={"x": pl.Int64}).with_columns(
         y=pl.col("x").cast(pl.Int64)


### PR DESCRIPTION
~~Also ensures the cast is removed for `E.cast(<dtype>)` if `E` is already the same type.~~
* I will split this to a separate PR to avoid regressions (this remove casts, meaning it relies on IR schema correctness).

.
* Fixes https://github.com/pola-rs/polars/issues/22668
* Fixes https://github.com/pola-rs/polars/issues/22849
