### PR TITLE
feat(python): Load AWS `endpoint_url` using boto3

### DIFF
--- a/crates/polars-core/src/config.rs
+++ b/crates/polars-core/src/config.rs
@@ -40,11 +40,7 @@ pub fn get_engine_affinity() -> String {
 /// Prints a log message if sensitive verbose logging has been enabled.
 pub fn verbose_print_sensitive<F: Fn() -> String>(create_log_message: F) {
     fn do_log(create_log_message: &dyn Fn() -> String) {
-        if std::env::var("POLARS_VERBOSE_SENSITIVE")
-            .as_deref()
-            .unwrap_or("")
-            == "1"
-        {
+        if std::env::var("POLARS_VERBOSE_SENSITIVE").as_deref() == Ok("1") {
             // Force the message to be a single line.
             let msg = create_log_message().replace('\n', "");
             eprintln!("[SENSITIVE]: {}", msg)

--- a/crates/polars-io/src/cloud/credential_provider.rs
+++ b/crates/polars-io/src/cloud/credential_provider.rs
@@ -14,6 +14,7 @@ pub use object_store::azure::AzureCredential;
 pub use object_store::gcp::GcpCredential;
 use polars_core::config;
 use polars_error::{PolarsResult, polars_bail};
+use polars_utils::pl_str::PlSmallStr;
 #[cfg(feature = "python")]
 use polars_utils::python_function::PythonObject;
 #[cfg(feature = "python")]
@@ -148,6 +149,10 @@ pub trait IntoCredentialProvider: Sized {
     fn into_gcp_provider(self) -> object_store::gcp::GcpCredentialProvider {
         unimplemented!()
     }
+
+    /// Note, technically shouldn't be under the `IntoCredentialProvider` trait, but it's here
+    /// for convenience.
+    fn storage_update_options(&self) -> PolarsResult<Vec<(PlSmallStr, PlSmallStr)>>;
 }
 
 impl IntoCredentialProvider for PlCredentialProvider {
@@ -175,6 +180,14 @@ impl IntoCredentialProvider for PlCredentialProvider {
             Self::Function(v) => v.into_gcp_provider(),
             #[cfg(feature = "python")]
             Self::Python(v) => v.into_gcp_provider(),
+        }
+    }
+
+    fn storage_update_options(&self) -> PolarsResult<Vec<(PlSmallStr, PlSmallStr)>> {
+        match self {
+            Self::Function(v) => v.storage_update_options(),
+            #[cfg(feature = "python")]
+            Self::Python(v) => v.storage_update_options(),
         }
     }
 }
@@ -297,6 +310,10 @@ impl IntoCredentialProvider for CredentialProviderFunction {
                 bearer: String::new(),
             })),
         ))
+    }
+
+    fn storage_update_options(&self) -> PolarsResult<Vec<(PlSmallStr, PlSmallStr)>> {
+        Ok(vec![])
     }
 }
 
@@ -462,6 +479,7 @@ mod python_impl {
     use std::sync::Arc;
 
     use polars_error::{PolarsError, PolarsResult};
+    use polars_utils::pl_str::PlSmallStr;
     use polars_utils::python_function::PythonObject;
     use pyo3::Python;
     use pyo3::exceptions::PyValueError;
@@ -524,6 +542,13 @@ mod python_impl {
         }
 
         fn unwrap_as_provider(self) -> Arc<PythonObject> {
+            match self {
+                Self::Builder(_) => panic!(),
+                Self::Provider(v) => v,
+            }
+        }
+
+        pub(crate) fn unwrap_as_provider_ref(&self) -> &Arc<PythonObject> {
             match self {
                 Self::Builder(_) => panic!(),
                 Self::Provider(v) => v,
@@ -734,6 +759,31 @@ mod python_impl {
                 })
             }))
             .into_gcp_provider()
+        }
+
+        /// # Panics
+        /// Panics if `self` is not an initialized provider.
+        fn storage_update_options(&self) -> PolarsResult<Vec<(PlSmallStr, PlSmallStr)>> {
+            let py_object = self.unwrap_as_provider_ref();
+
+            Python::with_gil(|py| {
+                py_object
+                    .getattr(py, "_storage_update_options")
+                    .map_or(Ok(vec![]), |f| {
+                        let v = f.call0(py)?.extract::<pyo3::Bound<'_, PyDict>>(py)?;
+
+                        let mut out = Vec::with_capacity(v.len());
+
+                        for dict_item in v.call_method0("items")?.try_iter()? {
+                            let (key, value) =
+                                dict_item?.extract::<(PyBackedStr, PyBackedStr)>()?;
+
+                            out.push(((&*key).into(), (&*value).into()))
+                        }
+
+                        Ok(out)
+                    })
+            })
         }
     }
 

--- a/py-polars/polars/_utils/logging.py
+++ b/py-polars/polars/_utils/logging.py
@@ -1,11 +1,11 @@
 import os
 import sys
-from functools import partial
+from typing import Any
 
 
 def verbose() -> bool:
     return os.getenv("POLARS_VERBOSE") == "1"
 
 
-def eprint(*a, **kw):
+def eprint(*a: Any, **kw: Any) -> None:
     return print(*a, file=sys.stderr, **kw)

--- a/py-polars/polars/_utils/logging.py
+++ b/py-polars/polars/_utils/logging.py
@@ -7,4 +7,5 @@ def verbose() -> bool:
     return os.getenv("POLARS_VERBOSE") == "1"
 
 
-eprint = partial(print, file=sys.stderr)
+def eprint(*a, **kw):
+    return print(*a, file=sys.stderr, **kw)

--- a/py-polars/polars/io/cloud/credential_provider/_builder.py
+++ b/py-polars/polars/io/cloud/credential_provider/_builder.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import abc
-from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import polars._utils.logging
 from polars._utils.logging import eprint, verbose
@@ -178,43 +177,6 @@ class AutoInit(CredentialProviderBuilderImpl):
         return self.cls.__name__
 
 
-# AWS auto-init needs its own class for a bit of extra logic.
-class AutoInitAWS(CredentialProviderBuilderImpl):
-    def __init__(
-        self,
-        initializer: Callable[[], CredentialProviderAWS],
-    ) -> None:
-        self.initializer = initializer
-        self.profile_name = initializer.keywords["profile_name"]  # type: ignore[attr-defined]
-
-    def __call__(self) -> CredentialProviderAWS | None:
-        try:
-            provider = self.initializer()
-            provider()  # call it to potentially catch EmptyCredentialError
-
-        except (ImportError, CredentialProviderAWS.EmptyCredentialError) as e:
-            # Check it is ImportError, EmptyCredentialError could be because the
-            # profile was loaded but did not contain any credentials.
-            if isinstance(e, ImportError) and self.profile_name:
-                # Hard error as we are unable to load the requested profile
-                # without CredentialProviderAWS (the rust-side does not load
-                # aws_profile).
-                msg = f"cannot load requested aws_profile '{self.profile_name}': {e!r}"
-                raise polars.exceptions.ComputeError(msg) from e
-
-            if verbose():
-                eprint(f"failed to auto-initialize {self.provider_repr}: {e!r}")
-
-        else:
-            return provider
-
-        return None
-
-    @property
-    def provider_repr(self) -> str:
-        return "CredentialProviderAWS"
-
-
 class UserProvidedGCPToken(CredentialProvider):
     """User-provided GCP token in storage_options."""
 
@@ -318,6 +280,7 @@ def _init_credential_provider_builder(
             profile = None
             default_region = None
             unhandled_key = None
+            has_endpoint_url = False
 
             if storage_options is not None:
                 for k, v in storage_options.items():
@@ -330,11 +293,17 @@ def _init_credential_provider_builder(
                         default_region = v
                     elif k in {"aws_profile", "profile"}:
                         profile = v
+                    elif k in {
+                        "aws_endpoint",
+                        "aws_endpoint_url",
+                        "endpoint",
+                        "endpoint_url",
+                    }:
+                        has_endpoint_url = True
                     elif k in OBJECT_STORE_CLIENT_OPTIONS:
                         continue
                     else:
-                        # We assume some sort of access key was given, so we
-                        # just dispatch to the rust side.
+                        # We assume this is some sort of access key
                         unhandled_key = k
 
             if unhandled_key is not None:
@@ -345,15 +314,13 @@ def _init_credential_provider_builder(
                     )
                     raise ValueError(msg)
 
-                return None
-
             return CredentialProviderBuilder(
-                AutoInitAWS(
-                    partial(
-                        CredentialProviderAWS,
-                        profile_name=profile,
-                        region_name=region or default_region,
-                    )
+                AutoInit(
+                    CredentialProviderAWS,
+                    profile_name=profile,
+                    region_name=region or default_region,
+                    _auto_init_unhandled_key=unhandled_key,
+                    _storage_options_has_endpoint_url=has_endpoint_url,
                 )
             )
 

--- a/py-polars/tests/unit/io/cloud/test_credential_provider.py
+++ b/py-polars/tests/unit/io/cloud/test_credential_provider.py
@@ -145,6 +145,7 @@ def test_credential_provider_aws_import_error_with_requested_profile(
         raise ImportError(msg)
 
     monkeypatch.setattr(pl.CredentialProviderAWS, "_session", _session)
+    monkeypatch.setenv("AWS_REGION", "eu-west-1")
 
     q = pl.scan_parquet(
         "s3://.../...",
@@ -161,7 +162,6 @@ def test_credential_provider_aws_import_error_with_requested_profile(
 
     q = pl.scan_parquet(
         "s3://.../...",
-        credential_provider=pl.CredentialProviderAWS(profile_name="test_profile"),
         storage_options={"aws_profile": "test_profile"},
     )
 

--- a/py-polars/tests/unit/io/cloud/test_credential_provider.py
+++ b/py-polars/tests/unit/io/cloud/test_credential_provider.py
@@ -186,7 +186,6 @@ def test_credential_provider_aws_endpoint_url_scan_no_parameters(
     _set_default_credentials(tmp_path, monkeypatch)
     cfg_file_path = tmp_path / "config"
 
-    monkeypatch.setenv("AWS_REGION", "eu-west-1")
     monkeypatch.setenv("AWS_CONFIG_FILE", str(cfg_file_path))
     monkeypatch.setenv("POLARS_VERBOSE", "1")
 
@@ -255,7 +254,6 @@ def test_credential_provider_aws_endpoint_url_with_storage_options(
     _set_default_credentials(tmp_path, monkeypatch)
     cfg_file_path = tmp_path / "config"
 
-    monkeypatch.setenv("AWS_REGION", "eu-west-1")
     monkeypatch.setenv("AWS_CONFIG_FILE", str(cfg_file_path))
     monkeypatch.setenv("POLARS_VERBOSE", "1")
 

--- a/py-polars/tests/unit/io/cloud/test_credential_provider.py
+++ b/py-polars/tests/unit/io/cloud/test_credential_provider.py
@@ -186,6 +186,7 @@ def test_credential_provider_aws_endpoint_url_scan_no_parameters(
     _set_default_credentials(tmp_path, monkeypatch)
     cfg_file_path = tmp_path / "config"
 
+    monkeypatch.setenv("AWS_REGION", "eu-west-1")
     monkeypatch.setenv("AWS_CONFIG_FILE", str(cfg_file_path))
     monkeypatch.setenv("POLARS_VERBOSE", "1")
 
@@ -254,6 +255,7 @@ def test_credential_provider_aws_endpoint_url_with_storage_options(
     _set_default_credentials(tmp_path, monkeypatch)
     cfg_file_path = tmp_path / "config"
 
+    monkeypatch.setenv("AWS_REGION", "eu-west-1")
     monkeypatch.setenv("AWS_CONFIG_FILE", str(cfg_file_path))
     monkeypatch.setenv("POLARS_VERBOSE", "1")
 

--- a/py-polars/tests/unit/io/cloud/test_credential_provider.py
+++ b/py-polars/tests/unit/io/cloud/test_credential_provider.py
@@ -1,5 +1,6 @@
 import io
 import pickle
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -45,13 +46,6 @@ def test_credential_provider_scan(
         # Passing `None` should disable the automatic instantiation of
         # `CredentialProviderAWS`
         io_func("s3://bucket/path", credential_provider=None)
-        # Passing `storage_options` should disable the automatic instantiation of
-        # `CredentialProviderAWS`
-        io_func(
-            "s3://bucket/path",
-            credential_provider="auto",
-            storage_options={"aws_access_key_id": "polars"},
-        )
 
     err_magic = "err_magic_7"
 
@@ -126,7 +120,7 @@ def test_credential_provider_serialization_custom_provider() -> None:
         lf.collect()
 
 
-def test_credential_provider_skips_google_config_autoload(
+def test_credential_provider_gcp_skips_config_autoload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("GOOGLE_SERVICE_ACCOUNT_PATH", "__non_existent")
@@ -141,3 +135,185 @@ def test_credential_provider_skips_google_config_autoload(
 
     with pytest.raises(AssertionError, match=err_magic):
         pl.scan_parquet("gs://.../...", credential_provider=raises).collect()
+
+
+def test_credential_provider_aws_import_error_with_requested_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _session(self: Any) -> None:
+        msg = "err_magic_3"
+        raise ImportError(msg)
+
+    monkeypatch.setattr(pl.CredentialProviderAWS, "_session", _session)
+
+    q = pl.scan_parquet(
+        "s3://.../...",
+        credential_provider=pl.CredentialProviderAWS(profile_name="test_profile"),
+    )
+
+    with pytest.raises(
+        pl.exceptions.ComputeError,
+        match=(
+            "cannot load requested aws_profile 'test_profile': ImportError: err_magic_3"
+        ),
+    ):
+        q.collect()
+
+    q = pl.scan_parquet(
+        "s3://.../...",
+        storage_options={"aws_profile": "test_profile"},
+    )
+
+    with pytest.raises(
+        pl.exceptions.ComputeError,
+        match=(
+            "cannot load requested aws_profile 'test_profile': ImportError: err_magic_3"
+        ),
+    ):
+        q.collect()
+
+
+@pytest.mark.slow
+@pytest.mark.write_disk
+def test_credential_provider_aws_endpoint_url_scan_no_parameters(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    tmp_path.mkdir(exist_ok=True)
+
+    cfg_file_path = tmp_path / "config"
+
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(cfg_file_path))
+    monkeypatch.setenv("POLARS_VERBOSE", "1")
+
+    cfg_file_path.write_text("""\
+[default]
+endpoint_url = http://localhost:333
+""")
+
+    # Scan with no parameters should load via CredentialProviderAWS
+    q = pl.scan_parquet("s3://.../...")
+
+    capfd.readouterr()
+
+    with pytest.raises(IOError, match=r"Error performing HEAD http://localhost:333"):
+        q.collect()
+
+    capture = capfd.readouterr().err
+    lines = capture.splitlines()
+
+    assert "[CredentialProviderAWS]: Loaded endpoint_url: http://localhost:333" in lines
+
+
+@pytest.mark.slow
+@pytest.mark.write_disk
+def test_credential_provider_aws_endpoint_url_serde(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    tmp_path.mkdir(exist_ok=True)
+
+    cfg_file_path = tmp_path / "config"
+
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(cfg_file_path))
+    monkeypatch.setenv("POLARS_VERBOSE", "1")
+
+    cfg_file_path.write_text("""\
+[default]
+endpoint_url = http://localhost:333
+""")
+
+    q = pl.scan_parquet("s3://.../...")
+    q = pickle.loads(pickle.dumps(q))
+
+    cfg_file_path.write_text("""\
+[default]
+endpoint_url = http://localhost:777
+""")
+
+    capfd.readouterr()
+
+    with pytest.raises(IOError, match=r"Error performing HEAD http://localhost:777"):
+        q.collect()
+
+
+@pytest.mark.slow
+@pytest.mark.write_disk
+def test_credential_provider_aws_endpoint_url_with_storage_options(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    tmp_path.mkdir(exist_ok=True)
+
+    cfg_file_path = tmp_path / "config"
+
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(cfg_file_path))
+    monkeypatch.setenv("POLARS_VERBOSE", "1")
+
+    cfg_file_path.write_text("""\
+[default]
+endpoint_url = http://localhost:333
+""")
+
+    # Previously we would not initialize a credential provider at all if secrets
+    # were given under `storage_options`. Now we always initialize so that we
+    # can load the `endpoint_url`, but we decide at the very last second whether
+    # to also retrieve secrets using the credential provider.
+    q = pl.scan_parquet(
+        "s3://.../...",
+        storage_options={
+            "aws_access_key_id": "...",
+            "aws_secret_access_key": "...",
+        },
+    )
+
+    with pytest.raises(IOError, match=r"Error performing HEAD http://localhost:333"):
+        q.collect()
+
+    capture = capfd.readouterr().err
+    lines = capture.splitlines()
+
+    assert (
+        "[CredentialProviderAWS]: Will not be used as a provider: unhandled key "
+        "in storage_options: 'aws_secret_access_key'"
+    ) in lines
+    assert "[CredentialProviderAWS]: Loaded endpoint_url: http://localhost:333" in lines
+
+
+@pytest.mark.parametrize(
+    "storage_options",
+    [
+        {"aws_endpoint_url": "http://localhost:777"},
+        {
+            "aws_access_key_id": "...",
+            "aws_secret_access_key": "...",
+            "aws_endpoint_url": "http://localhost:777",
+        },
+    ],
+)
+@pytest.mark.slow
+@pytest.mark.write_disk
+def test_credential_provider_aws_endpoint_url_passed_in_storage_options(
+    storage_options: dict[str, str],
+    tmp_path: Path,
+) -> None:
+    tmp_path.mkdir(exist_ok=True)
+
+    cfg_file_path = tmp_path / "config"
+
+    cfg_file_path.write_text("""\
+[default]
+endpoint_url = http://localhost:333
+""")
+
+    # An endpoint_url passed in `storage_options` should take precedence.
+    q = pl.scan_parquet(
+        "s3://.../...",
+        storage_options=storage_options,
+    )
+
+    with pytest.raises(IOError, match=r"Error performing HEAD http://localhost:777"):
+        q.collect()

--- a/py-polars/tests/unit/io/cloud/test_credential_provider.py
+++ b/py-polars/tests/unit/io/cloud/test_credential_provider.py
@@ -161,6 +161,7 @@ def test_credential_provider_aws_import_error_with_requested_profile(
 
     q = pl.scan_parquet(
         "s3://.../...",
+        credential_provider=pl.CredentialProviderAWS(profile_name="test_profile"),
         storage_options={"aws_profile": "test_profile"},
     )
 


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/21784
* Fixes https://github.com/pola-rs/polars/issues/18420

Note, this will require `boto3` to be installed on the system that executes the query. It is not compatible with:
* Passing a custom credential provider to `credential_provider` (or passing `None`)
