### PR TITLE
feat(rust): Add and test DataFrame equality functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3515,6 +3515,7 @@ name = "polars-testing"
 version = "0.48.1"
 dependencies = [
  "polars-core",
+ "polars-lazy",
  "polars-ops",
 ]
 

--- a/crates/polars-testing/Cargo.toml
+++ b/crates/polars-testing/Cargo.toml
@@ -10,4 +10,5 @@ description = "Testing suite for the Polars DataFrame library"
 
 [dependencies]
 polars-core = { workspace = true, features = ["dtype-array", "dtype-categorical", "dtype-struct"] }
+polars-lazy = { workspace = true }
 polars-ops = { workspace = true, features = ["abs"] }

--- a/crates/polars-testing/src/asserts/frame.rs
+++ b/crates/polars-testing/src/asserts/frame.rs
@@ -1,0 +1,598 @@
+#[macro_export]
+macro_rules! assert_dataframe_equal {
+    ($left:expr, $right:expr $(, $options:expr)?) => {
+        #[allow(unused_assignments)]
+        #[allow(unused_mut)]
+        let mut options = $crate::asserts::DataFrameEqualOptions::default();
+        $(options = $options;)?
+
+        match $crate::asserts::assert_dataframe_equal($left, $right, options) {
+            Ok(_) => {},
+            Err(e) => panic!("{}", e),
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    #[allow(unused_imports)]
+    use polars_core::prelude::*;
+    use polars_core::{disable_string_cache, enable_string_cache};
+
+    // Testing default struct implementation
+    #[test]
+    fn test_dataframe_equal_options() {
+        let options = crate::asserts::DataFrameEqualOptions::default();
+
+        assert!(options.check_row_order);
+        assert!(options.check_column_order);
+        assert!(options.check_dtypes);
+        assert!(!options.check_exact);
+        assert_eq!(options.rtol, 1e-5);
+        assert_eq!(options.atol, 1e-8);
+        assert!(!options.categorical_as_str);
+    }
+
+    // Testing dataframe schema equality parameters
+    #[test]
+    #[should_panic(expected = "height (row count) mismatch")]
+    fn test_dataframe_height_mismatch() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1, 2]).into(),
+            Series::new("col2".into(), &["a", "b"]).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1, 2, 3]).into(),
+            Series::new("col2".into(), &["a", "b", "c"]).into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    #[test]
+    #[should_panic(expected = "columns mismatch")]
+    fn test_dataframe_column_mismatch() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1, 2, 3]).into(),
+            Series::new("col2".into(), &["a", "b", "c"]).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1, 2, 3]).into(),
+            Series::new("different_col".into(), &["a", "b", "c"]).into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    #[test]
+    #[should_panic(expected = "data types do not match")]
+    fn test_dataframe_dtype_mismatch() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1, 2, 3]).into(),
+            Series::new("col2".into(), &["a", "b", "c"]).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1.0, 2.0, 3.0]).into(),
+            Series::new("col2".into(), &["a", "b", "c"]).into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    #[test]
+    fn test_dataframe_dtype_mismatch_ignored() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1, 2, 3]).into(),
+            Series::new("col2".into(), &["a", "b", "c"]).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1.0, 2.0, 3.0]).into(),
+            Series::new("col2".into(), &["a", "b", "c"]).into(),
+        ])
+        .unwrap();
+
+        let options = crate::asserts::DataFrameEqualOptions::default().with_check_dtypes(false);
+        assert_dataframe_equal!(&df1, &df2, options);
+    }
+
+    #[test]
+    #[should_panic(expected = "columns are not in the same order")]
+    fn test_dataframe_column_order_mismatch() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1, 2, 3]).into(),
+            Series::new("col2".into(), &["a", "b", "c"]).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("col2".into(), &["a", "b", "c"]).into(),
+            Series::new("col1".into(), &[1, 2, 3]).into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    #[test]
+    fn test_dataframe_column_order_mismatch_ignored() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1, 2, 3]).into(),
+            Series::new("col2".into(), &["a", "b", "c"]).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("col2".into(), &["a", "b", "c"]).into(),
+            Series::new("col1".into(), &[1, 2, 3]).into(),
+        ])
+        .unwrap();
+
+        let options =
+            crate::asserts::DataFrameEqualOptions::default().with_check_column_order(false);
+        assert_dataframe_equal!(&df1, &df2, options);
+    }
+
+    #[test]
+    #[should_panic(expected = "columns mismatch: [\"col3\"] in left, but not in right")]
+    fn test_dataframe_left_has_extra_column() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1, 2, 3]).into(),
+            Series::new("col2".into(), &["a", "b", "c"]).into(),
+            Series::new("col3".into(), &[true, false, true]).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1, 2, 3]).into(),
+            Series::new("col2".into(), &["a", "b", "c"]).into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    #[test]
+    #[should_panic(expected = "columns mismatch: [\"col3\"] in right, but not in left")]
+    fn test_dataframe_right_has_extra_column() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1, 2, 3]).into(),
+            Series::new("col2".into(), &["a", "b", "c"]).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1, 2, 3]).into(),
+            Series::new("col2".into(), &["a", "b", "c"]).into(),
+            Series::new("col3".into(), &[true, false, true]).into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    // Testing basic equality
+    #[test]
+    #[should_panic(expected = "value mismatch for column")]
+    fn test_dataframe_value_mismatch() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1, 2, 3]).into(),
+            Series::new("col2".into(), &["a", "b", "c"]).into(),
+            Series::new("col3".into(), &[true, false, true]).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1, 2, 3]).into(),
+            Series::new("col2".into(), &["a", "b", "changed"]).into(),
+            Series::new("col3".into(), &[true, false, true]).into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    #[test]
+    fn test_dataframe_equal() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1, 2, 3]).into(),
+            Series::new("col2".into(), &["a", "b", "c"]).into(),
+            Series::new("col3".into(), &[true, false, true]).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1, 2, 3]).into(),
+            Series::new("col2".into(), &["a", "b", "c"]).into(),
+            Series::new("col3".into(), &[true, false, true]).into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    #[test]
+    #[should_panic(expected = "value mismatch")]
+    fn test_dataframe_row_order_mismatch() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1, 2, 3]).into(),
+            Series::new("col2".into(), &["a", "b", "c"]).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("col1".into(), &[3, 1, 2]).into(),
+            Series::new("col2".into(), &["c", "a", "b"]).into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    #[test]
+    fn test_dataframe_row_order_ignored() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1, 2, 3]).into(),
+            Series::new("col2".into(), &["a", "b", "c"]).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("col1".into(), &[3, 1, 2]).into(),
+            Series::new("col2".into(), &["c", "a", "b"]).into(),
+        ])
+        .unwrap();
+
+        let options = crate::asserts::DataFrameEqualOptions::default().with_check_row_order(false);
+        assert_dataframe_equal!(&df1, &df2, options);
+    }
+
+    // Testing more comprehensive equality
+    #[test]
+    #[should_panic(expected = "value mismatch")]
+    fn test_dataframe_complex_mismatch() {
+        let df1 = DataFrame::new(vec![
+            Series::new("integers".into(), &[1, 2, 3, 4, 5]).into(),
+            Series::new("floats".into(), &[1.1, 2.2, 3.3, 4.4, 5.5]).into(),
+            Series::new("strings".into(), &["a", "b", "c", "d", "e"]).into(),
+            Series::new("booleans".into(), &[true, false, true, false, true]).into(),
+            Series::new("opt_ints".into(), &[Some(1), None, Some(3), Some(4), None]).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("integers".into(), &[1, 2, 99, 4, 5]).into(),
+            Series::new("floats".into(), &[1.1, 2.2, 3.3, 9.9, 5.5]).into(),
+            Series::new("strings".into(), &["a", "b", "c", "CHANGED", "e"]).into(),
+            Series::new("booleans".into(), &[true, false, false, false, true]).into(),
+            Series::new("opt_ints".into(), &[Some(1), None, Some(3), None, None]).into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    #[test]
+    fn test_dataframe_complex_match() {
+        let df1 = DataFrame::new(vec![
+            Series::new("integers".into(), &[1, 2, 3, 4, 5]).into(),
+            Series::new("floats".into(), &[1.1, 2.2, 3.3, 4.4, 5.5]).into(),
+            Series::new("strings".into(), &["a", "b", "c", "d", "e"]).into(),
+            Series::new("booleans".into(), &[true, false, true, false, true]).into(),
+            Series::new("opt_ints".into(), &[Some(1), None, Some(3), Some(4), None]).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("integers".into(), &[1, 2, 3, 4, 5]).into(),
+            Series::new("floats".into(), &[1.1, 2.2, 3.3, 4.4, 5.5]).into(),
+            Series::new("strings".into(), &["a", "b", "c", "d", "e"]).into(),
+            Series::new("booleans".into(), &[true, false, true, false, true]).into(),
+            Series::new("opt_ints".into(), &[Some(1), None, Some(3), Some(4), None]).into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    // Testing float value precision equality
+    #[test]
+    #[should_panic(expected = "value mismatch")]
+    fn test_dataframe_numeric_exact_fail() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1.0000001, 2.0000002, 3.0000003]).into(),
+        ])
+        .unwrap();
+
+        let df2 =
+            DataFrame::new(vec![Series::new("col1".into(), &[1.0, 2.0, 3.0]).into()]).unwrap();
+
+        let options = crate::asserts::DataFrameEqualOptions::default().with_check_exact(true);
+        assert_dataframe_equal!(&df1, &df2, options);
+    }
+
+    #[test]
+    fn test_dataframe_numeric_tolerance_pass() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1.0000001, 2.0000002, 3.0000003]).into(),
+        ])
+        .unwrap();
+
+        let df2 =
+            DataFrame::new(vec![Series::new("col1".into(), &[1.0, 2.0, 3.0]).into()]).unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    // Testing equality with special values
+    #[test]
+    fn test_empty_dataframe_equal() {
+        let df1 = DataFrame::default();
+        let df2 = DataFrame::default();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    #[test]
+    fn test_empty_dataframe_schema_equal() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &Vec::<i32>::new()).into(),
+            Series::new("col2".into(), &Vec::<String>::new()).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("col1".into(), &Vec::<i32>::new()).into(),
+            Series::new("col2".into(), &Vec::<String>::new()).into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    #[test]
+    #[should_panic(expected = "value mismatch")]
+    fn test_dataframe_single_row_mismatch() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &[42]).into(),
+            Series::new("col2".into(), &["value"]).into(),
+            Series::new("col3".into(), &[true]).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("col1".into(), &[42]).into(),
+            Series::new("col2".into(), &["different"]).into(),
+            Series::new("col3".into(), &[true]).into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    #[test]
+    fn test_dataframe_single_row_match() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &[42]).into(),
+            Series::new("col2".into(), &["value"]).into(),
+            Series::new("col3".into(), &[true]).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("col1".into(), &[42]).into(),
+            Series::new("col2".into(), &["value"]).into(),
+            Series::new("col3".into(), &[true]).into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    #[test]
+    #[should_panic(expected = "value mismatch")]
+    fn test_dataframe_null_values_mismatch() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &[Some(1), None, Some(3)]).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("col1".into(), &[Some(1), Some(2), None]).into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    #[test]
+    fn test_dataframe_null_values_match() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &[Some(1), None, Some(3)]).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("col1".into(), &[Some(1), None, Some(3)]).into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    #[test]
+    #[should_panic(expected = "value mismatch")]
+    fn test_dataframe_nan_values_mismatch() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1.0, f64::NAN, 3.0]).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1.0, 2.0, f64::NAN]).into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    #[test]
+    fn test_dataframe_nan_values_match() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1.0, f64::NAN, 3.0]).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1.0, f64::NAN, 3.0]).into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    #[test]
+    #[should_panic(expected = "value mismatch")]
+    fn test_dataframe_infinity_values_mismatch() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1.0, f64::INFINITY, 3.0]).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1.0, f64::NEG_INFINITY, 3.0]).into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    #[test]
+    fn test_dataframe_infinity_values_match() {
+        let df1 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1.0, f64::INFINITY, 3.0]).into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("col1".into(), &[1.0, f64::INFINITY, 3.0]).into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    // Testing categorical operations
+    #[test]
+    #[should_panic(expected = "data types do not match")]
+    fn test_dataframe_categorical_as_string_mismatch() {
+        enable_string_cache();
+
+        let mut categorical = Series::new("categories".into(), &["a", "b", "c", "a"]);
+        categorical = categorical
+            .cast(&DataType::Categorical(None, Default::default()))
+            .unwrap();
+
+        let df1 = DataFrame::new(vec![categorical.into()]).unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new("categories".into(), &["a", "b", "c", "a"]).into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+
+        disable_string_cache();
+    }
+
+    #[test]
+    fn test_dataframe_categorical_as_string_match() {
+        enable_string_cache();
+
+        let mut categorical1 = Series::new("categories".into(), &["a", "b", "c", "a"]);
+        categorical1 = categorical1
+            .cast(&DataType::Categorical(None, Default::default()))
+            .unwrap();
+        let df1 = DataFrame::new(vec![categorical1.into()]).unwrap();
+
+        let mut categorical2 = Series::new("categories".into(), &["a", "b", "c", "a"]);
+        categorical2 = categorical2
+            .cast(&DataType::Categorical(None, Default::default()))
+            .unwrap();
+        let df2 = DataFrame::new(vec![categorical2.into()]).unwrap();
+
+        let options =
+            crate::asserts::DataFrameEqualOptions::default().with_categorical_as_str(true);
+        assert_dataframe_equal!(&df1, &df2, options);
+
+        disable_string_cache();
+    }
+
+    // Testing nested types
+    #[test]
+    #[should_panic(expected = "value mismatch")]
+    fn test_dataframe_nested_values_mismatch() {
+        let df1 = DataFrame::new(vec![
+            Series::new(
+                "list_col".into(),
+                &[
+                    Some(vec![1, 2, 3]),
+                    Some(vec![4, 5, 6]),
+                    None,
+                    Some(vec![7, 8, 9]),
+                ],
+            )
+            .into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new(
+                "list_col".into(),
+                &[
+                    Some(vec![1, 2, 3]),
+                    Some(vec![4, 5, 99]),
+                    None,
+                    Some(vec![7, 8, 9]),
+                ],
+            )
+            .into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+
+    #[test]
+    fn test_dataframe_nested_values_match() {
+        let df1 = DataFrame::new(vec![
+            Series::new(
+                "list_col".into(),
+                &[Some(vec![1, 2, 3]), Some(vec![]), None, Some(vec![7, 8, 9])],
+            )
+            .into(),
+        ])
+        .unwrap();
+
+        let df2 = DataFrame::new(vec![
+            Series::new(
+                "list_col".into(),
+                &[Some(vec![1, 2, 3]), Some(vec![]), None, Some(vec![7, 8, 9])],
+            )
+            .into(),
+        ])
+        .unwrap();
+
+        assert_dataframe_equal!(&df1, &df2);
+    }
+}

--- a/crates/polars-testing/src/asserts/mod.rs
+++ b/crates/polars-testing/src/asserts/mod.rs
@@ -1,4 +1,7 @@
+pub mod frame;
 pub mod series;
 mod utils;
 
-pub use utils::{SeriesEqualOptions, assert_series_equal};
+pub use utils::{
+    DataFrameEqualOptions, SeriesEqualOptions, assert_dataframe_equal, assert_series_equal,
+};


### PR DESCRIPTION
Final pull request needed to resolve https://github.com/pola-rs/polars/issues/21388. Tagging @coastalwhite because he is overseeing my work on this. 

As with the previous pull request for adding `assert_series_equal()`, there are in-line comments where I felt unsure and some guidance might be needed and where changes are marked, meaning they deviate from the Python code (the reason is outlined in the change). Like before, once comments are added and resolved, I will add proper documentation and examples to the code via a new commit.

Any suggestions for shortening and making the code more efficient are welcome. Thank you!