### PR TITLE
feat: Derive DSL schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1699,7 +1699,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1718,7 +1718,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1734,6 +1734,12 @@ dependencies = [
  "hashbrown 0.14.5",
  "serde",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2139,6 +2145,17 @@ checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2977,6 +2994,7 @@ dependencies = [
  "polars-utils",
  "proptest",
  "rand 0.8.5",
+ "schemars",
  "serde",
  "simdutf8",
  "streaming-iterator",
@@ -3016,6 +3034,7 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "ryu",
+ "schemars",
  "serde",
  "skiplist",
  "strength_reduce",
@@ -3036,7 +3055,7 @@ dependencies = [
  "either",
  "hashbrown 0.14.5",
  "hashbrown 0.15.3",
- "indexmap",
+ "indexmap 2.9.0",
  "itoa",
  "ndarray",
  "num-traits",
@@ -3050,6 +3069,7 @@ dependencies = [
  "rand_distr",
  "rayon",
  "regex",
+ "schemars",
  "serde",
  "serde_json",
  "strum_macros",
@@ -3165,6 +3185,7 @@ dependencies = [
  "regex",
  "reqwest",
  "ryu",
+ "schemars",
  "serde",
  "serde_json",
  "simd-json",
@@ -3186,7 +3207,7 @@ dependencies = [
  "chrono-tz",
  "fallible-streaming-iterator",
  "hashbrown 0.15.3",
- "indexmap",
+ "indexmap 2.9.0",
  "itoa",
  "num-traits",
  "polars-arrow",
@@ -3262,7 +3283,7 @@ dependencies = [
  "either",
  "hashbrown 0.15.3",
  "hex",
- "indexmap",
+ "indexmap 2.9.0",
  "jsonpath_lib_polars_vendor",
  "libm",
  "memchr",
@@ -3279,6 +3300,7 @@ dependencies = [
  "rayon",
  "regex",
  "regex-syntax",
+ "schemars",
  "serde",
  "serde_json",
  "strum_macros",
@@ -3311,6 +3333,7 @@ dependencies = [
  "polars-utils",
  "proptest",
  "rand 0.8.5",
+ "schemars",
  "serde",
  "simdutf8",
  "snap",
@@ -3384,6 +3407,7 @@ dependencies = [
  "rayon",
  "recursive",
  "regex",
+ "schemars",
  "serde",
  "serde_json",
  "strum_macros",
@@ -3448,9 +3472,10 @@ dependencies = [
 name = "polars-schema"
 version = "0.48.1"
 dependencies = [
- "indexmap",
+ "indexmap 2.9.0",
  "polars-error",
  "polars-utils",
+ "schemars",
  "serde",
  "version_check",
 ]
@@ -3536,6 +3561,7 @@ dependencies = [
  "polars-utils",
  "rayon",
  "regex",
+ "schemars",
  "serde",
  "strum_macros",
 ]
@@ -3551,7 +3577,7 @@ dependencies = [
  "flate2",
  "foldhash",
  "hashbrown 0.15.3",
- "indexmap",
+ "indexmap 2.9.0",
  "libc",
  "memmap2",
  "num-traits",
@@ -3562,6 +3588,7 @@ dependencies = [
  "rayon",
  "regex",
  "rmp-serde",
+ "schemars",
  "serde",
  "serde_ignored",
  "serde_json",
@@ -4311,6 +4338,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "either",
+ "indexmap 1.9.3",
+ "indexmap 2.9.0",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4412,6 +4466,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "serde_ignored"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4426,7 +4491,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap",
+ "indexmap 2.9.0",
  "itoa",
  "memchr",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ regex-syntax = "0.8.5"
 reqwest = { version = "0.12", default-features = false }
 rmp-serde = "1.3"
 ryu = "1.0.13"
+schemars = { version = "0.8.22", features = ["preserve_order"] }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
 serde_ignored = "0.1.12"
 serde_json = "1"

--- a/crates/polars-arrow/Cargo.toml
+++ b/crates/polars-arrow/Cargo.toml
@@ -25,6 +25,7 @@ num-traits = { workspace = true }
 polars-error = { workspace = true }
 polars-schema = { workspace = true }
 polars-utils = { workspace = true }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 simdutf8 = { workspace = true }
 
@@ -113,6 +114,7 @@ compute = [
   "compute_temporal",
 ]
 serde = ["dep:serde", "polars-schema/serde", "polars-utils/serde"]
+dsl-schema = ["dep:schemars", "polars-schema/dsl-schema", "polars-utils/dsl-schema"]
 simd = []
 
 # polars-arrow

--- a/crates/polars-arrow/src/datatypes/field.rs
+++ b/crates/polars-arrow/src/datatypes/field.rs
@@ -19,6 +19,7 @@ pub static DTYPE_CATEGORICAL: &str = "_PL_CATEGORICAL";
 /// to be serialized.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct Field {
     /// Its name
     pub name: PlSmallStr,

--- a/crates/polars-arrow/src/datatypes/mod.rs
+++ b/crates/polars-arrow/src/datatypes/mod.rs
@@ -30,6 +30,7 @@ pub(crate) type Extension = Option<(PlSmallStr, Option<PlSmallStr>)>;
 /// Use `to_logical_type` to desugar such type and return its corresponding logical type.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum ArrowDataType {
     /// Null type
     #[default]
@@ -171,12 +172,13 @@ pub enum ArrowDataType {
     Unknown,
     /// A nested datatype that can represent slots of differing types.
     /// Third argument represents mode
-    #[cfg_attr(feature = "serde", serde(skip))]
+    #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(skip))]
     Union(Box<UnionType>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct ExtensionType {
     pub name: PlSmallStr,
     pub inner: ArrowDataType,
@@ -221,6 +223,7 @@ impl UnionMode {
 /// The time units defined in Arrow.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum TimeUnit {
     /// Time in seconds.
     Second,
@@ -235,6 +238,7 @@ pub enum TimeUnit {
 /// Interval units defined in Arrow
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum IntervalUnit {
     /// The number of elapsed whole months.
     YearMonth,

--- a/crates/polars-arrow/src/datatypes/physical_type.rs
+++ b/crates/polars-arrow/src/datatypes/physical_type.rs
@@ -67,6 +67,7 @@ impl PhysicalType {
 /// Each type corresponds to a variant of [`crate::array::DictionaryArray`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum IntegerType {
     /// A signed 8-bit integer.
     Int8,

--- a/crates/polars-arrow/src/datatypes/reshape.rs
+++ b/crates/polars-arrow/src/datatypes/reshape.rs
@@ -4,6 +4,7 @@ use std::num::NonZeroU64;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Dimension(NonZeroU64);
 
@@ -12,6 +13,7 @@ pub struct Dimension(NonZeroU64);
 /// Any dimension smaller than 0 is seen as an `infer`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum ReshapeDimension {
     Infer,
     Specified(Dimension),

--- a/crates/polars-arrow/src/legacy/kernels/ewm/mod.rs
+++ b/crates/polars-arrow/src/legacy/kernels/ewm/mod.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 pub use variance::*;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[must_use]
 pub struct EWMOptions {

--- a/crates/polars-arrow/src/legacy/kernels/time.rs
+++ b/crates/polars-arrow/src/legacy/kernels/time.rs
@@ -35,6 +35,7 @@ impl FromStr for Ambiguous {
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, IntoStaticStr)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[strum(serialize_all = "snake_case")]
 pub enum NonExistent {
     Null,

--- a/crates/polars-compute/Cargo.toml
+++ b/crates/polars-compute/Cargo.toml
@@ -22,6 +22,7 @@ polars-error = { workspace = true }
 polars-utils = { workspace = true }
 rand = { workspace = true }
 ryu = { workspace = true, optional = true }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 skiplist = { workspace = true }
 strength_reduce = { workspace = true }
@@ -53,3 +54,4 @@ approx_unique = []
 dtype-array = []
 dtype-decimal = ["arrow/dtype-decimal", "dtype-i128"]
 dtype-i128 = []
+dsl-schema = ["dep:schemars"]

--- a/crates/polars-compute/src/rolling/mod.rs
+++ b/crates/polars-compute/src/rolling/mod.rs
@@ -25,6 +25,7 @@ type Len = usize;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default, Hash, IntoStaticStr)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[strum(serialize_all = "snake_case")]
 pub enum QuantileMethod {
     #[default]
@@ -41,6 +42,7 @@ pub type QuantileInterpolOptions = QuantileMethod;
 
 #[derive(Clone, Copy, Debug, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum RollingFnParams {
     Quantile(RollingQuantileParams),
     Var(RollingVarParams),
@@ -102,12 +104,14 @@ where
 // Parameters allowed for rolling operations.
 #[derive(Clone, Copy, Debug, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct RollingVarParams {
     pub ddof: u8,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct RollingQuantileParams {
     pub prob: f64,
     pub method: QuantileMethod,

--- a/crates/polars-core/Cargo.toml
+++ b/crates/polars-core/Cargo.toml
@@ -32,6 +32,7 @@ rand = { workspace = true, optional = true, features = ["small_rng", "std"] }
 rand_distr = { workspace = true, optional = true }
 rayon = { workspace = true }
 regex = { workspace = true, optional = true }
+schemars = { workspace = true, optional = true }
 # activate if you want serde support for Series and DataFrames
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -131,6 +132,13 @@ serde = [
   "serde_json",
 ]
 serde-lazy = ["serde", "arrow/serde", "indexmap/serde", "chrono/serde"]
+dsl-schema = [
+  "serde",
+  "dep:schemars",
+  "polars-schema/dsl-schema",
+  "polars-utils/dsl-schema",
+  "polars-compute/dsl-schema",
+]
 
 docs-selection = [
   "ndarray",

--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -13,6 +13,7 @@ use crate::prelude::*;
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Hash, Eq)]
 #[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[repr(u8)]
 pub enum CastOptions {
     /// Raises on overflow

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -408,6 +408,7 @@ pub type FillNullLimit = Option<IdxSize>;
 
 #[derive(Copy, Clone, Debug, PartialEq, Hash)]
 #[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum FillNullStrategy {
     /// previous value in array
     Backward(FillNullLimit),

--- a/crates/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/crates/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "rolling_window", derive(PartialEq))]
 pub struct RollingOptionsFixedWindow {
     /// The length of the window.
@@ -18,7 +19,7 @@ pub struct RollingOptionsFixedWindow {
     /// Set the labels at the center of the window.
     pub center: bool,
     /// Optional parameters for the rolling
-    #[cfg_attr(feature = "serde", serde(default))]
+    #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(default))]
     pub fn_params: Option<RollingFnParams>,
 }
 

--- a/crates/polars-core/src/chunked_array/ops/search_sorted.rs
+++ b/crates/polars-core/src/chunked_array/ops/search_sorted.rs
@@ -7,6 +7,7 @@ use crate::prelude::*;
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum SearchSortedSide {
     #[default]
     Any,

--- a/crates/polars-core/src/chunked_array/ops/sort/options.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/options.rs
@@ -28,6 +28,7 @@ use crate::prelude::*;
 /// ```
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 #[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct SortOptions {
     /// If true sort in descending order.
     /// Default `false`.
@@ -80,6 +81,7 @@ pub struct SortOptions {
 /// # }
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct SortMultipleOptions {
     /// Order of the columns. Default all `false``.
     ///

--- a/crates/polars-core/src/datatypes/_serde.rs
+++ b/crates/polars-core/src/datatypes/_serde.rs
@@ -29,6 +29,21 @@ impl Serialize for DataType {
     }
 }
 
+#[cfg(feature = "dsl-schema")]
+impl schemars::JsonSchema for DataType {
+    fn schema_name() -> String {
+        SerializableDataType::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        SerializableDataType::schema_id()
+    }
+
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        SerializableDataType::json_schema(generator)
+    }
+}
+
 #[cfg(feature = "dtype-categorical")]
 struct Wrap<T>(T);
 
@@ -75,6 +90,8 @@ impl<'de> serde::Deserialize<'de> for Wrap<Utf8ViewArray> {
 }
 
 #[derive(Serialize, Deserialize)]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
+#[serde(rename = "DataType")]
 enum SerializableDataType {
     Boolean,
     UInt8,

--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -185,8 +185,8 @@ mod _serde {
         /// A binary true or false.
         Boolean(bool),
         /// A UTF8 encoded string type.
-        String(&'a str),
-        Binary(&'a [u8]),
+        String(Cow<'a, str>),
+        Binary(Cow<'a, [u8]>),
 
         /// A 32-bit date representing the elapsed time since UNIX epoch (1970-01-01)
         /// in days (32 bits).
@@ -233,10 +233,10 @@ mod _serde {
                 AnyValue::Float64(v) => Self::Float64(*v),
                 AnyValue::List(series) => Self::List(Cow::Borrowed(series)),
                 AnyValue::Boolean(v) => Self::Boolean(*v),
-                AnyValue::String(v) => Self::String(v),
-                AnyValue::StringOwned(v) => Self::String(v.as_str()),
-                AnyValue::Binary(v) => Self::Binary(v),
-                AnyValue::BinaryOwned(v) => Self::Binary(v),
+                AnyValue::String(v) => Self::String(Cow::Borrowed(v)),
+                AnyValue::StringOwned(v) => Self::String(Cow::Borrowed(v.as_str())),
+                AnyValue::Binary(v) => Self::Binary(Cow::Borrowed(v)),
+                AnyValue::BinaryOwned(v) => Self::Binary(Cow::Borrowed(v)),
 
                 #[cfg(feature = "dtype-date")]
                 AnyValue::Date(v) => Self::Date(*v),
@@ -303,8 +303,11 @@ mod _serde {
                 S::Float64(v) => Self::Float64(v),
                 S::List(v) => Self::List(v.into_owned()),
                 S::Boolean(v) => Self::Boolean(v),
-                S::String(v) => Self::StringOwned(PlSmallStr::from_str(v)),
-                S::Binary(v) => Self::BinaryOwned(v.to_vec()),
+                S::String(v) => Self::StringOwned(match v {
+                    Cow::Borrowed(v) => PlSmallStr::from(v),
+                    Cow::Owned(v) => PlSmallStr::from(v),
+                }),
+                S::Binary(v) => Self::BinaryOwned(v.into_owned()),
                 #[cfg(feature = "dtype-date")]
                 S::Date(v) => Self::Date(v),
                 #[cfg(feature = "dtype-datetime")]

--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -111,259 +111,216 @@ pub enum AnyValue<'a> {
 }
 
 #[cfg(feature = "serde")]
-impl Serialize for AnyValue<'_> {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let name = "AnyValue";
-        match self {
-            AnyValue::Null => serializer.serialize_unit_variant(name, 0, "Null"),
+mod _serde {
+    use serde::{Deserialize, Serialize};
 
-            AnyValue::Int8(v) => serializer.serialize_newtype_variant(name, 1, "Int8", v),
-            AnyValue::Int16(v) => serializer.serialize_newtype_variant(name, 2, "Int16", v),
-            AnyValue::Int32(v) => serializer.serialize_newtype_variant(name, 3, "Int32", v),
-            AnyValue::Int64(v) => serializer.serialize_newtype_variant(name, 4, "Int64", v),
-            AnyValue::Int128(v) => serializer.serialize_newtype_variant(name, 5, "Int128", v),
-            AnyValue::UInt8(v) => serializer.serialize_newtype_variant(name, 6, "UInt8", v),
-            AnyValue::UInt16(v) => serializer.serialize_newtype_variant(name, 7, "UInt16", v),
-            AnyValue::UInt32(v) => serializer.serialize_newtype_variant(name, 8, "UInt32", v),
-            AnyValue::UInt64(v) => serializer.serialize_newtype_variant(name, 9, "UInt64", v),
-            AnyValue::Float32(v) => serializer.serialize_newtype_variant(name, 10, "Float32", v),
-            AnyValue::Float64(v) => serializer.serialize_newtype_variant(name, 11, "Float64", v),
-            AnyValue::List(v) => serializer.serialize_newtype_variant(name, 12, "List", v),
-            AnyValue::Boolean(v) => serializer.serialize_newtype_variant(name, 13, "Bool", v),
+    use super::*;
 
-            // both variants same number
-            AnyValue::String(v) => serializer.serialize_newtype_variant(name, 14, "StringOwned", v),
-            AnyValue::StringOwned(v) => {
-                serializer.serialize_newtype_variant(name, 14, "StringOwned", v.as_str())
-            },
-
-            // both variants same number
-            AnyValue::Binary(v) => serializer.serialize_newtype_variant(name, 15, "BinaryOwned", v),
-            AnyValue::BinaryOwned(v) => {
-                serializer.serialize_newtype_variant(name, 15, "BinaryOwned", v)
-            },
-
-            #[cfg(feature = "dtype-date")]
-            AnyValue::Date(v) => serializer.serialize_newtype_variant(name, 16, "Date", v),
-            // both variants same number
-            #[cfg(feature = "dtype-datetime")]
-            AnyValue::Datetime(v, tu, tz) => serializer.serialize_newtype_variant(
-                name,
-                17,
-                "DatetimeOwned",
-                &(*v, *tu, tz.map(|v| v.as_str())),
-            ),
-            #[cfg(feature = "dtype-datetime")]
-            AnyValue::DatetimeOwned(v, tu, tz) => serializer.serialize_newtype_variant(
-                name,
-                17,
-                "DatetimeOwned",
-                &(*v, *tu, tz.as_deref().map(|v| v.as_str())),
-            ),
-            #[cfg(feature = "dtype-duration")]
-            AnyValue::Duration(v, tu) => {
-                serializer.serialize_newtype_variant(name, 18, "Duration", &(*v, *tu))
-            },
-            #[cfg(feature = "dtype-time")]
-            AnyValue::Time(v) => serializer.serialize_newtype_variant(name, 19, "Time", v),
-
-            // Not 100% sure how to deal with these.
-            #[cfg(feature = "dtype-categorical")]
-            AnyValue::Categorical(..) | AnyValue::CategoricalOwned(..) => Err(
-                serde::ser::Error::custom("Cannot serialize categorical value."),
-            ),
-            #[cfg(feature = "dtype-categorical")]
-            AnyValue::Enum(..) | AnyValue::EnumOwned(..) => {
-                Err(serde::ser::Error::custom("Cannot serialize enum value."))
-            },
-
-            #[cfg(feature = "dtype-array")]
-            AnyValue::Array(v, width) => {
-                serializer.serialize_newtype_variant(name, 22, "Array", &(v, *width))
-            },
-            #[cfg(feature = "object")]
-            AnyValue::Object(_) | AnyValue::ObjectOwned(_) => {
-                Err(serde::ser::Error::custom("Cannot serialize object value."))
-            },
-            #[cfg(feature = "dtype-struct")]
-            AnyValue::Struct(_, _, _) | AnyValue::StructOwned(_) => {
-                Err(serde::ser::Error::custom("Cannot serialize struct value."))
-            },
-            #[cfg(feature = "dtype-decimal")]
-            AnyValue::Decimal(v, scale) => {
-                serializer.serialize_newtype_variant(name, 25, "Decimal", &(*v, *scale))
-            },
+    impl Serialize for AnyValue<'_> {
+        fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            SerializableAnyValue::try_from(self)
+                .map_err(serde::ser::Error::custom)?
+                .serialize(serializer)
         }
     }
-}
 
-#[cfg(feature = "serde")]
-impl<'a> Deserialize<'a> for AnyValue<'static> {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'a>,
-    {
-        macro_rules! define_av_field {
-            ($($variant:ident,)+) => {
-                #[derive(Deserialize, Serialize)]
-                enum AvField {
-                    $($variant,)+
-                }
-                const VARIANTS: &'static [&'static str] = &[
-                    $(stringify!($variant),)+
-                ];
+    impl<'a> Deserialize<'a> for AnyValue<'static> {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: Deserializer<'a>,
+        {
+            SerializableAnyValue::deserialize(deserializer).map(Self::from)
+        }
+    }
+
+    #[cfg(feature = "dsl-schema")]
+    impl schemars::JsonSchema for AnyValue<'_> {
+        fn schema_name() -> String {
+            SerializableAnyValue::schema_name()
+        }
+
+        fn schema_id() -> std::borrow::Cow<'static, str> {
+            SerializableAnyValue::schema_id()
+        }
+
+        fn json_schema(
+            generator: &mut schemars::r#gen::SchemaGenerator,
+        ) -> schemars::schema::Schema {
+            SerializableAnyValue::json_schema(generator)
+        }
+    }
+
+    #[derive(Serialize, Deserialize)]
+    #[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
+    #[serde(rename = "AnyValue")]
+    pub enum SerializableAnyValue<'a> {
+        Null,
+        /// An 8-bit integer number.
+        Int8(i8),
+        /// A 16-bit integer number.
+        Int16(i16),
+        /// A 32-bit integer number.
+        Int32(i32),
+        /// A 64-bit integer number.
+        Int64(i64),
+        /// A 128-bit integer number.
+        Int128(i128),
+        /// An unsigned 8-bit integer number.
+        UInt8(u8),
+        /// An unsigned 16-bit integer number.
+        UInt16(u16),
+        /// An unsigned 32-bit integer number.
+        UInt32(u32),
+        /// An unsigned 64-bit integer number.
+        UInt64(u64),
+        /// A 32-bit floating point number.
+        Float32(f32),
+        /// A 64-bit floating point number.
+        Float64(f64),
+        /// Nested type, contains arrays that are filled with one of the datatypes.
+        List(Cow<'a, Series>),
+        /// A binary true or false.
+        Boolean(bool),
+        /// A UTF8 encoded string type.
+        String(&'a str),
+        Binary(&'a [u8]),
+
+        /// A 32-bit date representing the elapsed time since UNIX epoch (1970-01-01)
+        /// in days (32 bits).
+        #[cfg(feature = "dtype-date")]
+        Date(i32),
+
+        /// A 64-bit date representing the elapsed time since UNIX epoch (1970-01-01)
+        /// in nanoseconds (64 bits).
+        #[cfg(feature = "dtype-datetime")]
+        Datetime(i64, TimeUnit, Option<Cow<'a, TimeZone>>),
+
+        /// A 64-bit integer representing difference between date-times in [`TimeUnit`]
+        #[cfg(feature = "dtype-duration")]
+        Duration(i64, TimeUnit),
+
+        /// A 64-bit time representing the elapsed time since midnight in nanoseconds
+        #[cfg(feature = "dtype-time")]
+        Time(i64),
+
+        #[cfg(feature = "dtype-array")]
+        Array(Cow<'a, Series>, usize),
+
+        /// A 128-bit fixed point decimal number with a scale.
+        #[cfg(feature = "dtype-decimal")]
+        Decimal(i128, usize),
+    }
+
+    impl<'a, 'data: 'a> TryFrom<&'a AnyValue<'data>> for SerializableAnyValue<'a> {
+        type Error = &'static str;
+
+        fn try_from(value: &'a AnyValue<'data>) -> Result<Self, Self::Error> {
+            let out = match value {
+                AnyValue::Null => Self::Null,
+                AnyValue::Int8(v) => Self::Int8(*v),
+                AnyValue::Int16(v) => Self::Int16(*v),
+                AnyValue::Int32(v) => Self::Int32(*v),
+                AnyValue::Int64(v) => Self::Int64(*v),
+                AnyValue::Int128(v) => Self::Int128(*v),
+                AnyValue::UInt8(v) => Self::UInt8(*v),
+                AnyValue::UInt16(v) => Self::UInt16(*v),
+                AnyValue::UInt32(v) => Self::UInt32(*v),
+                AnyValue::UInt64(v) => Self::UInt64(*v),
+                AnyValue::Float32(v) => Self::Float32(*v),
+                AnyValue::Float64(v) => Self::Float64(*v),
+                AnyValue::List(series) => Self::List(Cow::Borrowed(series)),
+                AnyValue::Boolean(v) => Self::Boolean(*v),
+                AnyValue::String(v) => Self::String(v),
+                AnyValue::StringOwned(v) => Self::String(v.as_str()),
+                AnyValue::Binary(v) => Self::Binary(v),
+                AnyValue::BinaryOwned(v) => Self::Binary(v),
+
+                #[cfg(feature = "dtype-date")]
+                AnyValue::Date(v) => Self::Date(*v),
+
+                #[cfg(feature = "dtype-datetime")]
+                AnyValue::Datetime(v, tu, tz) => Self::Datetime(*v, *tu, tz.map(Cow::Borrowed)),
+                #[cfg(feature = "dtype-datetime")]
+                AnyValue::DatetimeOwned(v, time_unit, time_zone) => Self::Datetime(
+                    *v,
+                    *time_unit,
+                    time_zone.as_ref().map(|t| Cow::Borrowed(t.as_ref())),
+                ),
+
+                #[cfg(feature = "dtype-duration")]
+                AnyValue::Duration(v, time_unit) => Self::Duration(*v, *time_unit),
+
+                #[cfg(feature = "dtype-time")]
+                AnyValue::Time(v) => Self::Time(*v),
+
+                #[cfg(feature = "dtype-categorical")]
+                AnyValue::Categorical(..) | AnyValue::CategoricalOwned(..) => {
+                    return Err("Cannot serialize categorical value.");
+                },
+                #[cfg(feature = "dtype-categorical")]
+                AnyValue::Enum(..) | AnyValue::EnumOwned(..) => {
+                    return Err("Cannot serialize enum value.");
+                },
+
+                #[cfg(feature = "dtype-array")]
+                AnyValue::Array(v, width) => Self::Array(Cow::Borrowed(v), *width),
+
+                #[cfg(feature = "object")]
+                AnyValue::Object(..) | AnyValue::ObjectOwned(..) => {
+                    return Err("Cannot serialize object value.");
+                },
+
+                #[cfg(feature = "dtype-struct")]
+                AnyValue::Struct(..) | AnyValue::StructOwned(..) => {
+                    return Err("Cannot serialize struct value.");
+                },
+
+                #[cfg(feature = "dtype-decimal")]
+                AnyValue::Decimal(v, scale) => Self::Decimal(*v, *scale),
             };
+            Ok(out)
         }
-        define_av_field! {
-            Null,
-            Int8,
-            Int16,
-            Int32,
-            Int64,
-            Int128,
-            UInt8,
-            UInt16,
-            UInt32,
-            UInt64,
-            Float32,
-            Float64,
-            List,
-            Bool,
-            StringOwned,
-            BinaryOwned,
-            Date,
-            DatetimeOwned,
-            Duration,
-            Time,
-            CategoricalOwned,
-            EnumOwned,
-            Array,
-            Object,
-            Struct,
-            Decimal,
-        };
+    }
 
-        struct OuterVisitor;
-
-        impl<'b> Visitor<'b> for OuterVisitor {
-            type Value = AnyValue<'static>;
-
-            fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
-                write!(formatter, "enum AnyValue")
-            }
-
-            fn visit_enum<A>(self, data: A) -> std::result::Result<Self::Value, A::Error>
-            where
-                A: EnumAccess<'b>,
-            {
-                let out = match data.variant()? {
-                    (AvField::Null, _variant) => AnyValue::Null,
-                    (AvField::Int8, variant) => {
-                        let value = variant.newtype_variant()?;
-                        AnyValue::Int8(value)
-                    },
-                    (AvField::Int16, variant) => {
-                        let value = variant.newtype_variant()?;
-                        AnyValue::Int16(value)
-                    },
-                    (AvField::Int32, variant) => {
-                        let value = variant.newtype_variant()?;
-                        AnyValue::Int32(value)
-                    },
-                    (AvField::Int64, variant) => {
-                        let value = variant.newtype_variant()?;
-                        AnyValue::Int64(value)
-                    },
-                    (AvField::Int128, variant) => {
-                        let value = variant.newtype_variant()?;
-                        AnyValue::Int128(value)
-                    },
-                    (AvField::UInt8, variant) => {
-                        let value = variant.newtype_variant()?;
-                        AnyValue::UInt8(value)
-                    },
-                    (AvField::UInt16, variant) => {
-                        let value = variant.newtype_variant()?;
-                        AnyValue::UInt16(value)
-                    },
-                    (AvField::UInt32, variant) => {
-                        let value = variant.newtype_variant()?;
-                        AnyValue::UInt32(value)
-                    },
-                    (AvField::UInt64, variant) => {
-                        let value = variant.newtype_variant()?;
-                        AnyValue::UInt64(value)
-                    },
-                    (AvField::Float32, variant) => {
-                        let value = variant.newtype_variant()?;
-                        AnyValue::Float32(value)
-                    },
-                    (AvField::Float64, variant) => {
-                        let value = variant.newtype_variant()?;
-                        AnyValue::Float64(value)
-                    },
-                    (AvField::Bool, variant) => {
-                        let value = variant.newtype_variant()?;
-                        AnyValue::Boolean(value)
-                    },
-                    (AvField::List, variant) => {
-                        let value = variant.newtype_variant()?;
-                        AnyValue::List(value)
-                    },
-                    (AvField::StringOwned, variant) => {
-                        let value: PlSmallStr = variant.newtype_variant()?;
-                        AnyValue::StringOwned(value)
-                    },
-                    (AvField::BinaryOwned, variant) => {
-                        let value = variant.newtype_variant()?;
-                        AnyValue::BinaryOwned(value)
-                    },
-                    (AvField::Date, variant) => feature_gated!("dtype-date", {
-                        let value = variant.newtype_variant()?;
-                        AnyValue::Date(value)
-                    }),
-                    (AvField::DatetimeOwned, variant) => feature_gated!("dtype-datetime", {
-                        let (value, time_unit, time_zone) = variant.newtype_variant()?;
-                        AnyValue::DatetimeOwned(value, time_unit, time_zone)
-                    }),
-                    (AvField::Duration, variant) => feature_gated!("dtype-duration", {
-                        let (value, time_unit) = variant.newtype_variant()?;
-                        AnyValue::Duration(value, time_unit)
-                    }),
-                    (AvField::Time, variant) => feature_gated!("dtype-time", {
-                        let value = variant.newtype_variant()?;
-                        AnyValue::Time(value)
-                    }),
-                    (AvField::CategoricalOwned, _) => feature_gated!("dtype-categorical", {
-                        return Err(serde::de::Error::custom(
-                            "unable to deserialize categorical",
-                        ));
-                    }),
-                    (AvField::EnumOwned, _) => feature_gated!("dtype-categorical", {
-                        return Err(serde::de::Error::custom("unable to deserialize enum"));
-                    }),
-                    (AvField::Array, variant) => feature_gated!("dtype-array", {
-                        let (s, width) = variant.newtype_variant()?;
-                        AnyValue::Array(s, width)
-                    }),
-                    (AvField::Object, _) => feature_gated!("object", {
-                        return Err(serde::de::Error::custom("unable to deserialize object"));
-                    }),
-                    (AvField::Struct, _) => feature_gated!("dtype-struct", {
-                        return Err(serde::de::Error::custom("unable to deserialize struct"));
-                    }),
-                    (AvField::Decimal, variant) => feature_gated!("dtype-decimal", {
-                        let (v, scale) = variant.newtype_variant()?;
-                        AnyValue::Decimal(v, scale)
-                    }),
-                };
-                Ok(out)
+    impl<'a> From<SerializableAnyValue<'a>> for AnyValue<'static> {
+        fn from(value: SerializableAnyValue<'a>) -> Self {
+            type S<'b> = SerializableAnyValue<'b>;
+            match value {
+                S::Null => Self::Null,
+                S::Int8(v) => Self::Int8(v),
+                S::Int16(v) => Self::Int16(v),
+                S::Int32(v) => Self::Int32(v),
+                S::Int64(v) => Self::Int64(v),
+                S::Int128(v) => Self::Int128(v),
+                S::UInt8(v) => Self::UInt8(v),
+                S::UInt16(v) => Self::UInt16(v),
+                S::UInt32(v) => Self::UInt32(v),
+                S::UInt64(v) => Self::UInt64(v),
+                S::Float32(v) => Self::Float32(v),
+                S::Float64(v) => Self::Float64(v),
+                S::List(v) => Self::List(v.into_owned()),
+                S::Boolean(v) => Self::Boolean(v),
+                S::String(v) => Self::StringOwned(PlSmallStr::from_str(v)),
+                S::Binary(v) => Self::BinaryOwned(v.to_vec()),
+                #[cfg(feature = "dtype-date")]
+                S::Date(v) => Self::Date(v),
+                #[cfg(feature = "dtype-datetime")]
+                S::Datetime(v, time_unit, time_zone) => {
+                    Self::DatetimeOwned(v, time_unit, time_zone.map(Cow::into_owned).map(Arc::new))
+                },
+                #[cfg(feature = "dtype-duration")]
+                S::Duration(v, time_unit) => Self::Duration(v, time_unit),
+                #[cfg(feature = "dtype-time")]
+                S::Time(v) => Self::Time(v),
+                #[cfg(feature = "dtype-array")]
+                S::Array(v, width) => Self::Array(v.into_owned(), width),
+                #[cfg(feature = "dtype-decimal")]
+                S::Decimal(v, scale) => Self::Decimal(v, scale),
             }
         }
-        deserializer.deserialize_enum("AnyValue", VARIANTS, OuterVisitor)
     }
 }
 

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -55,6 +55,7 @@ impl IntoMetadata for Metadata {
     any(feature = "serde", feature = "serde-lazy"),
     derive(Serialize, Deserialize)
 )]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum UnknownKind {
     // Hold the value to determine the concrete size.
     Int(i128),
@@ -82,6 +83,7 @@ impl UnknownKind {
     any(feature = "serde-lazy", feature = "serde"),
     derive(Serialize, Deserialize)
 )]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[strum(serialize_all = "snake_case")]
 pub enum CategoricalOrdering {
     #[default]
@@ -1112,6 +1114,7 @@ pub fn create_enum_dtype(categories: Utf8ViewArray) -> DataType {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct CompatLevel(pub(crate) u16);
 
 impl CompatLevel {

--- a/crates/polars-core/src/datatypes/field.rs
+++ b/crates/polars-core/src/datatypes/field.rs
@@ -10,6 +10,7 @@ pub static EXTENSION_NAME: &str = "POLARS_EXTENSION_TYPE";
     any(feature = "serde", feature = "serde-lazy"),
     derive(Serialize, Deserialize)
 )]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct Field {
     pub name: PlSmallStr,
     pub dtype: DataType,

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -45,7 +45,7 @@ use polars_utils::nulls::IsNull;
 use polars_utils::total_ord::TotalHash;
 pub use schema::SchemaExtPl;
 #[cfg(feature = "serde")]
-use serde::de::{EnumAccess, VariantAccess, Visitor};
+use serde::de::Visitor;
 #[cfg(any(feature = "serde", feature = "serde-lazy"))]
 use serde::{Deserialize, Serialize};
 #[cfg(any(feature = "serde", feature = "serde-lazy"))]

--- a/crates/polars-core/src/datatypes/temporal/time_unit.rs
+++ b/crates/polars-core/src/datatypes/temporal/time_unit.rs
@@ -5,6 +5,7 @@ use crate::prelude::ArrowTimeUnit;
     any(feature = "serde-lazy", feature = "serde"),
     derive(serde::Serialize, serde::Deserialize)
 )]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum TimeUnit {
     Nanoseconds,
     Microseconds,

--- a/crates/polars-core/src/datatypes/temporal/time_zone.rs
+++ b/crates/polars-core/src/datatypes/temporal/time_zone.rs
@@ -5,6 +5,7 @@ use crate::config;
 
 #[derive(Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct TimeZone {
     /// Private inner to ensure canonical / parsed time zone repr at construction.
     inner: PlSmallStr,

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -49,6 +49,7 @@ use crate::series::IsSorted;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Hash, IntoStaticStr)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[strum(serialize_all = "snake_case")]
 pub enum UniqueKeepStrategy {
     /// Keep the first unique row.

--- a/crates/polars-core/src/scalar/mod.rs
+++ b/crates/polars-core/src/scalar/mod.rs
@@ -15,6 +15,7 @@ use crate::prelude::{Column, Series};
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct Scalar {
     dtype: DataType,
     value: AnyValue<'static>,

--- a/crates/polars-core/src/serde/df.rs
+++ b/crates/polars-core/src/serde/df.rs
@@ -172,3 +172,18 @@ impl<'de> Deserialize<'de> for DataFrame {
         .map_err(D::Error::custom)
     }
 }
+
+#[cfg(feature = "dsl-schema")]
+impl schemars::JsonSchema for DataFrame {
+    fn schema_name() -> String {
+        "DataFrame".to_owned()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed(concat!(module_path!(), "::", "DataFrame"))
+    }
+
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        Vec::<u8>::json_schema(generator)
+    }
+}

--- a/crates/polars-core/src/serde/series.rs
+++ b/crates/polars-core/src/serde/series.rs
@@ -64,3 +64,18 @@ impl<'de> Deserialize<'de> for Series {
         .map_err(D::Error::custom)
     }
 }
+
+#[cfg(feature = "dsl-schema")]
+impl schemars::JsonSchema for Series {
+    fn schema_name() -> String {
+        "Series".to_owned()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed(concat!(module_path!(), "::", "Series"))
+    }
+
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        Vec::<u8>::json_schema(generator)
+    }
+}

--- a/crates/polars-core/src/series/ops/mod.rs
+++ b/crates/polars-core/src/series/ops/mod.rs
@@ -7,6 +7,7 @@ mod reshape;
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum NullBehavior {
     /// drop nulls
     Drop,

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -13,6 +13,7 @@ use crate::prelude::*;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum IsSorted {
     Ascending,
     Descending,

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -40,6 +40,7 @@ rayon = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, optional = true, features = ["json"] }
 ryu = { workspace = true, optional = true }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["rc"], optional = true }
 serde_json = { version = "1", optional = true }
 simd-json = { workspace = true, optional = true }
@@ -70,6 +71,7 @@ json = [
   "csv",
 ]
 serde = ["dep:serde", "polars-core/serde-lazy", "polars-parquet/serde", "polars-utils/serde"]
+dsl-schema = ["dep:schemars", "polars-core/dsl-schema", "polars-parquet/dsl-schema", "polars-utils/dsl-schema"]
 # support for arrows ipc file parsing
 ipc = ["arrow/io_ipc", "arrow/io_ipc_compression"]
 # support for arrows streaming ipc file parsing

--- a/crates/polars-io/src/cloud/credential_provider.rs
+++ b/crates/polars-io/src/cloud/credential_provider.rs
@@ -25,7 +25,7 @@ pub enum PlCredentialProvider {
     /// Prefer using [`PlCredentialProvider::from_func`] instead of constructing this directly
     Function(CredentialProviderFunction),
     #[cfg(feature = "python")]
-    Python(python_impl::PythonCredentialProvider),
+    Python(PythonCredentialProvider),
 }
 
 impl PlCredentialProvider {
@@ -378,6 +378,21 @@ impl serde::Serialize for PlCredentialProvider {
     }
 }
 
+#[cfg(feature = "dsl-schema")]
+impl schemars::JsonSchema for PlCredentialProvider {
+    fn schema_name() -> String {
+        "PlCredentialProvider".to_owned()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed(concat!(module_path!(), "::", "PlCredentialProvider"))
+    }
+
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        Vec::<u8>::json_schema(generator)
+    }
+}
+
 /// Avoids calling the credential provider function if we have not yet passed the expiry time.
 #[derive(Debug)]
 struct FetchedCredentialsCache<C>(tokio::sync::Mutex<(C, u64)>);
@@ -490,6 +505,7 @@ mod python_impl {
 
     #[derive(Clone, Debug)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
     pub enum PythonCredentialProvider {
         #[cfg_attr(
             feature = "serde",

--- a/crates/polars-io/src/cloud/credential_provider.rs
+++ b/crates/polars-io/src/cloud/credential_provider.rs
@@ -505,7 +505,6 @@ mod python_impl {
 
     #[derive(Clone, Debug)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    #[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
     pub enum PythonCredentialProvider {
         #[cfg_attr(
             feature = "serde",

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -54,19 +54,30 @@ type Configs<T> = Vec<(T, String)>;
 
 #[derive(Clone, Debug, PartialEq, Hash, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub(crate) enum CloudConfig {
     #[cfg(feature = "aws")]
-    Aws(Configs<AmazonS3ConfigKey>),
+    Aws(
+        #[cfg_attr(feature = "dsl-schema", schemars(with = "Vec<(String, String)>"))]
+        Configs<AmazonS3ConfigKey>,
+    ),
     #[cfg(feature = "azure")]
-    Azure(Configs<AzureConfigKey>),
+    Azure(
+        #[cfg_attr(feature = "dsl-schema", schemars(with = "Vec<(String, String)>"))]
+        Configs<AzureConfigKey>,
+    ),
     #[cfg(feature = "gcp")]
-    Gcp(Configs<GoogleConfigKey>),
+    Gcp(
+        #[cfg_attr(feature = "dsl-schema", schemars(with = "Vec<(String, String)>"))]
+        Configs<GoogleConfigKey>,
+    ),
     #[cfg(feature = "http")]
     Http { headers: Vec<(String, String)> },
 }
 
 #[derive(Clone, Debug, PartialEq, Hash, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 /// Options to connect to various cloud providers.
 pub struct CloudOptions {
     pub max_retries: usize,

--- a/crates/polars-io/src/csv/read/options.rs
+++ b/crates/polars-io/src/csv/read/options.rs
@@ -13,6 +13,7 @@ use crate::RowIndex;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct CsvReadOptions {
     pub path: Option<PathBuf>,
     // Performance related options
@@ -45,6 +46,7 @@ pub struct CsvReadOptions {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct CsvParseOptions {
     pub separator: u8,
     pub quote_char: Option<u8>,
@@ -330,6 +332,7 @@ impl CsvParseOptions {
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum CsvEncoding {
     /// Utf8 encoding.
     #[default]
@@ -340,6 +343,7 @@ pub enum CsvEncoding {
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum CommentPrefix {
     /// A single byte character that indicates the start of a comment line.
     Single(u8),
@@ -378,6 +382,7 @@ impl From<&str> for CommentPrefix {
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum NullValues {
     /// A single value that's used for all columns
     AllColumnsSingle(PlSmallStr),

--- a/crates/polars-io/src/csv/write/options.rs
+++ b/crates/polars-io/src/csv/write/options.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 /// Options for writing CSV files.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct CsvWriterOptions {
     pub include_bom: bool,
     pub include_header: bool,
@@ -29,6 +30,7 @@ impl Default for CsvWriterOptions {
 /// The default is to format times and dates as `chrono` crate formats them.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct SerializeOptions {
     /// Used for [`DataType::Date`](polars_core::datatypes::DataType::Date).
     pub date_format: Option<String>,
@@ -72,6 +74,7 @@ impl Default for SerializeOptions {
 /// Quote style indicating when to insert quotes around a field.
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum QuoteStyle {
     /// Quote fields only when necessary.
     ///

--- a/crates/polars-io/src/ipc/ipc_file.rs
+++ b/crates/polars-io/src/ipc/ipc_file.rs
@@ -51,6 +51,7 @@ use crate::shared::{ArrowReader, finish_reader};
 
 #[derive(Clone, Debug, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct IpcScanOptions;
 
 /// Read Arrows IPC format into a DataFrame

--- a/crates/polars-io/src/ipc/write.rs
+++ b/crates/polars-io/src/ipc/write.rs
@@ -11,6 +11,7 @@ use crate::shared::schema_to_arrow_checked;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct IpcWriterOptions {
     /// Data page compression
     pub compression: Option<IpcCompression>,
@@ -197,6 +198,7 @@ impl<W: Write> BatchedWriter<W> {
 /// Compression codec
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum IpcCompression {
     /// LZ4 (framed)
     LZ4,

--- a/crates/polars-io/src/json/mod.rs
+++ b/crates/polars-io/src/json/mod.rs
@@ -82,6 +82,7 @@ use crate::prelude::*;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct JsonWriterOptions {}
 
 /// The format to use to write the DataFrame to JSON: `Json` (a JSON array)

--- a/crates/polars-io/src/options.rs
+++ b/crates/polars-io/src/options.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct RowIndex {
     pub name: PlSmallStr,
     pub offset: IdxSize,
@@ -14,6 +15,7 @@ pub struct RowIndex {
 /// Options for Hive partitioning.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct HiveOptions {
     /// This can be `None` to automatically enable for single directory scans
     /// and disable otherwise. However it should be initialized if it is inside

--- a/crates/polars-io/src/parquet/read/options.rs
+++ b/crates/polars-io/src/parquet/read/options.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct ParquetOptions {
     pub schema: Option<SchemaRef>,
     pub parallel: ParallelStrategy,
@@ -13,6 +14,7 @@ pub struct ParquetOptions {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum ParallelStrategy {
     /// Don't parallelize
     None,

--- a/crates/polars-io/src/parquet/write/key_value_metadata.rs
+++ b/crates/polars-io/src/parquet/write/key_value_metadata.rs
@@ -19,6 +19,7 @@ pub struct ParquetMetadataContext<'a> {
 /// Key/value pairs that can be attached to a Parquet file as file-level metadtaa.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum KeyValueMetadata {
     /// Static key value metadata.
     Static(
@@ -29,9 +30,14 @@ pub enum KeyValueMetadata {
                 deserialize_with = "deserialize_vec_key_value"
             )
         )]
+        #[cfg_attr(
+            feature = "dsl-schema",
+            schemars(with = "Vec<(String, Option<String>)>")
+        )]
         Vec<KeyValue>,
     ),
     /// Rust function to dynamically compute key value metadata.
+    #[cfg_attr(feature = "dsl-schema", schemars(skip))]
     DynamicRust(RustKeyValueMetadataFunction),
     /// Python function to dynamically compute key value metadata.
     #[cfg(feature = "python")]
@@ -164,6 +170,7 @@ mod python_impl {
 
     #[derive(Clone, Debug, PartialEq, Eq)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    #[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
     pub struct PythonKeyValueMetadataFunction(
         #[cfg(feature = "python")]
         #[cfg_attr(

--- a/crates/polars-io/src/parquet/write/key_value_metadata.rs
+++ b/crates/polars-io/src/parquet/write/key_value_metadata.rs
@@ -180,6 +180,7 @@ mod python_impl {
                 deserialize_with = "PythonObject::deserialize_with_pyversion"
             )
         )]
+        #[cfg_attr(feature = "dsl-schema", schemars(with = "Vec<u8>"))]
         pub Arc<polars_utils::python_function::PythonFunction>,
     );
 

--- a/crates/polars-io/src/parquet/write/options.rs
+++ b/crates/polars-io/src/parquet/write/options.rs
@@ -11,6 +11,7 @@ use super::KeyValueMetadata;
 
 #[derive(Clone, Debug, PartialEq, Eq, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct ParquetWriteOptions {
     /// Data page compression
     pub compression: ParquetCompression,
@@ -29,6 +30,7 @@ pub struct ParquetWriteOptions {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum ChildFieldOverwrites {
     /// Flat datatypes
     None,
@@ -39,6 +41,7 @@ pub enum ChildFieldOverwrites {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct MetadataKeyValue {
     pub key: PlSmallStr,
     pub value: Option<PlSmallStr>,
@@ -46,6 +49,7 @@ pub struct MetadataKeyValue {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct ParquetFieldOverwrites {
     pub name: Option<PlSmallStr>,
     pub children: ChildFieldOverwrites,
@@ -56,6 +60,7 @@ pub struct ParquetFieldOverwrites {
 /// The compression strategy to use for writing Parquet files.
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum ParquetCompression {
     Uncompressed,
     Snappy,
@@ -75,6 +80,7 @@ impl Default for ParquetCompression {
 /// A valid Gzip compression level.
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct GzipLevel(u8);
 
 impl GzipLevel {
@@ -87,6 +93,7 @@ impl GzipLevel {
 /// A valid Brotli compression level.
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct BrotliLevel(u32);
 
 impl BrotliLevel {
@@ -99,6 +106,7 @@ impl BrotliLevel {
 /// A valid Zstandard compression level.
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct ZstdLevel(i32);
 
 impl ZstdLevel {

--- a/crates/polars-io/src/utils/sync_on_close.rs
+++ b/crates/polars-io/src/utils/sync_on_close.rs
@@ -2,6 +2,7 @@ use std::{fs, io};
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum SyncOnCloseType {
     /// Don't call sync on close.
     #[default]

--- a/crates/polars-ops/Cargo.toml
+++ b/crates/polars-ops/Cargo.toml
@@ -35,6 +35,7 @@ rand_distr = { workspace = true, optional = true }
 rayon = { workspace = true }
 regex = { workspace = true }
 regex-syntax = { workspace = true }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 strum_macros = { workspace = true }
@@ -88,6 +89,13 @@ random = ["rand", "rand_distr"]
 rank = ["rand"]
 find_many = ["aho-corasick"]
 serde = ["dep:serde", "polars-core/serde", "polars-utils/serde", "polars-schema/serde", "polars-compute/serde"]
+dsl-schema = [
+  "dep:schemars",
+  "polars-core/dsl-schema",
+  "polars-utils/dsl-schema",
+  "polars-schema/dsl-schema",
+  "polars-compute/dsl-schema",
+]
 
 # extra utilities for BinaryChunked
 binary_encoding = ["base64", "hex"]

--- a/crates/polars-ops/src/chunked_array/list/sets.rs
+++ b/crates/polars-ops/src/chunked_array/list/sets.rs
@@ -110,6 +110,7 @@ fn copied_wrapper_opt<T: Copy + TotalEq + TotalHash>(
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum SetOperation {
     Intersection,
     Union,

--- a/crates/polars-ops/src/chunked_array/list/to_struct.rs
+++ b/crates/polars-ops/src/chunked_array/list/to_struct.rs
@@ -7,10 +7,13 @@ use super::*;
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum ListToStructArgs {
     FixedWidth(Arc<[PlSmallStr]>),
     InferWidth {
         infer_field_strategy: ListToStructWidthStrategy,
+        // Can serialize only when None (null), so we override to `()` which serializes to null.
+        #[cfg_attr(feature = "dsl-schema", schemars(with = "()"))]
         get_index_name: Option<NameGenerator>,
         /// If this is None, it means unbounded.
         max_fields: Option<usize>,
@@ -19,6 +22,7 @@ pub enum ListToStructArgs {
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum ListToStructWidthStrategy {
     FirstNonNull,
     MaxWidth,

--- a/crates/polars-ops/src/chunked_array/strings/normalize.rs
+++ b/crates/polars-ops/src/chunked_array/strings/normalize.rs
@@ -3,6 +3,7 @@ use unicode_normalization::UnicodeNormalization;
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum UnicodeForm {
     NFC,
     NFKC,

--- a/crates/polars-ops/src/frame/join/args.rs
+++ b/crates/polars-ops/src/frame/join/args.rs
@@ -21,6 +21,7 @@ use strum_macros::IntoStaticStr;
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct JoinArgs {
     pub how: JoinType,
     pub validation: JoinValidation,
@@ -39,6 +40,7 @@ impl JoinArgs {
 
 #[derive(Clone, PartialEq, Eq, Hash, Default, IntoStaticStr)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum JoinType {
     #[default]
     Inner,
@@ -60,6 +62,7 @@ pub enum JoinType {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum JoinCoalesce {
     #[default]
     JoinSpecific,
@@ -91,6 +94,7 @@ impl JoinCoalesce {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, Default, IntoStaticStr)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[strum(serialize_all = "snake_case")]
 pub enum MaintainOrderJoin {
     #[default]
@@ -300,6 +304,7 @@ impl JoinType {
 
 #[derive(Copy, Clone, PartialEq, Eq, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum JoinValidation {
     /// No unique checks
     #[default]

--- a/crates/polars-ops/src/frame/join/asof/mod.rs
+++ b/crates/polars-ops/src/frame/join/asof/mod.rs
@@ -186,6 +186,7 @@ impl<T: NumericNative> AsofJoinState<T> for AsofJoinNearestState {
 
 #[derive(Clone, Debug, PartialEq, Eq, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct AsOfOptions {
     pub strategy: AsofStrategy,
     /// A tolerance in the same unit as the asof column
@@ -242,6 +243,7 @@ fn check_asof_columns(
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum AsofStrategy {
     /// selects the last row in the right DataFrame whose ‘on’ key is less than or equal to the left’s key
     #[default]

--- a/crates/polars-ops/src/frame/join/iejoin/mod.rs
+++ b/crates/polars-ops/src/frame/join/iejoin/mod.rs
@@ -26,6 +26,7 @@ use crate::frame::_finish_join;
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum InequalityOperator {
     #[default]
     Lt,
@@ -41,6 +42,7 @@ impl InequalityOperator {
 }
 #[derive(Clone, Debug, PartialEq, Eq, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct IEJoinOptions {
     pub operator1: InequalityOperator,
     pub operator2: Option<InequalityOperator>,

--- a/crates/polars-ops/src/series/ops/business.rs
+++ b/crates/polars-ops/src/series/ops/business.rs
@@ -13,6 +13,7 @@ use crate::prelude::replace_time_zone;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum Roll {
     Forward,
     Backward,

--- a/crates/polars-ops/src/series/ops/interpolation/interpolate.rs
+++ b/crates/polars-ops/src/series/ops/interpolation/interpolate.rs
@@ -204,6 +204,7 @@ where
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum InterpolationMethod {
     Linear,
     Nearest,

--- a/crates/polars-ops/src/series/ops/linear_space.rs
+++ b/crates/polars-ops/src/series/ops/linear_space.rs
@@ -6,6 +6,7 @@ use strum_macros::IntoStaticStr;
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Default, IntoStaticStr)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[strum(serialize_all = "snake_case")]
 pub enum ClosedInterval {
     #[default]

--- a/crates/polars-ops/src/series/ops/rank.rs
+++ b/crates/polars-ops/src/series/ops/rank.rs
@@ -10,6 +10,7 @@ use crate::prelude::SeriesSealed;
 
 #[derive(Copy, Clone, Debug, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum RankMethod {
     Average,
     Min,
@@ -23,6 +24,7 @@ pub enum RankMethod {
 // We might want to add a `nulls_last` or `null_behavior` field.
 #[derive(Copy, Clone, Debug, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct RankOptions {
     pub method: RankMethod,
     pub descending: bool,

--- a/crates/polars-ops/src/series/ops/round.rs
+++ b/crates/polars-ops/src/series/ops/round.rs
@@ -8,6 +8,7 @@ use crate::series::ops::SeriesSealed;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoStaticStr)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[strum(serialize_all = "snake_case")]
 #[derive(Default)]
 pub enum RoundMode {

--- a/crates/polars-parquet/Cargo.toml
+++ b/crates/polars-parquet/Cargo.toml
@@ -35,6 +35,7 @@ brotli = { version = "^7.0", optional = true }
 flate2 = { workspace = true, optional = true }
 lz4 = { version = "1.24", optional = true }
 lz4_flex = { version = "0.11", optional = true }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 snap = { version = "^1.1", optional = true }
 zstd = { workspace = true, optional = true }
@@ -67,6 +68,7 @@ lz4_flex = ["dep:lz4_flex"]
 async = ["async-stream", "futures", "polars-parquet-format/async"]
 bloom_filter = ["xxhash-rust"]
 serde = ["dep:serde", "polars-utils/serde"]
+dsl-schema = ["dep:schemars"]
 simd = ["polars-compute/simd"]
 
 proptest = ["dep:proptest", "arrow/proptest"]

--- a/crates/polars-parquet/src/arrow/write/mod.rs
+++ b/crates/polars-parquet/src/arrow/write/mod.rs
@@ -52,6 +52,7 @@ pub use crate::parquet::{FallibleStreamingIterator, fallible_streaming_iterator}
 /// The statistics to write
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct StatisticsOptions {
     pub min_value: bool,
     pub max_value: bool,

--- a/crates/polars-plan/Cargo.toml
+++ b/crates/polars-plan/Cargo.toml
@@ -39,6 +39,7 @@ pyo3 = { workspace = true, optional = true }
 rayon = { workspace = true }
 recursive = { workspace = true }
 regex = { workspace = true, optional = true }
+schemars = { workspace = true, features = ["either"], optional = true }
 serde = { workspace = true, features = ["rc"], optional = true }
 serde_json = { workspace = true, optional = true }
 strum_macros = { workspace = true }
@@ -107,6 +108,18 @@ string_encoding = ["polars-ops/string_encoding"]
 true_div = []
 nightly = ["polars-utils/nightly", "polars-ops/nightly"]
 extract_jsonpath = ["polars-ops/extract_jsonpath"]
+dsl-schema = [
+  "dep:schemars",
+  "dep:serde_json",
+  "serde",
+  "arrow/dsl-schema",
+  "polars-core/dsl-schema",
+  "polars-time/dsl-schema",
+  "polars-io/dsl-schema",
+  "polars-ops/dsl-schema",
+  "polars-utils/dsl-schema",
+  "polars-compute/dsl-schema",
+]
 
 # operations
 bitwise = ["polars-core/bitwise", "polars-ops/bitwise"]

--- a/crates/polars-plan/src/dsl/expr/mod.rs
+++ b/crates/polars-plan/src/dsl/expr/mod.rs
@@ -19,6 +19,7 @@ use crate::prelude::*;
 
 #[derive(PartialEq, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum AggExpr {
     Min {
         input: Arc<Expr>,
@@ -77,6 +78,7 @@ impl AsRef<Expr> for AggExpr {
 #[derive(Clone, PartialEq)]
 #[must_use]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum Expr {
     Alias(Arc<Expr>, PlSmallStr),
     Column(PlSmallStr),
@@ -154,10 +156,6 @@ pub enum Expr {
     Len,
     /// Take the nth column in the `DataFrame`
     Nth(i64),
-    RenameAlias {
-        function: SpecialEq<Arc<dyn RenameAliasFn>>,
-        expr: Arc<Expr>,
-    },
     #[cfg(feature = "dtype-struct")]
     Field(Arc<[PlSmallStr]>),
     AnonymousFunction {
@@ -177,6 +175,11 @@ pub enum Expr {
     /// `Expr::Wildcard`
     /// `Expr::Exclude`
     Selector(super::selector::Selector),
+    #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(skip))]
+    RenameAlias {
+        function: SpecialEq<Arc<dyn RenameAliasFn>>,
+        expr: Arc<Expr>,
+    },
 }
 
 #[derive(Clone)]
@@ -378,6 +381,7 @@ impl Default for Expr {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum Excluded {
     Name(PlSmallStr),
     Dtype(DataType),
@@ -476,6 +480,7 @@ impl Expr {
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum Operator {
     Eq,
     EqValidity,

--- a/crates/polars-plan/src/dsl/expr/serde_expr.rs
+++ b/crates/polars-plan/src/dsl/expr/serde_expr.rs
@@ -81,6 +81,21 @@ impl<'a, T: Deserialize<'a> + Clone> Deserialize<'a> for LazySerde<T> {
     }
 }
 
+#[cfg(feature = "dsl-schema")]
+impl<T: schemars::JsonSchema + Clone> schemars::JsonSchema for LazySerde<T> {
+    fn schema_name() -> String {
+        T::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        T::schema_id()
+    }
+
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        Vec::<u8>::json_schema(generator)
+    }
+}
+
 pub(super) fn deserialize_column_udf(buf: &[u8]) -> PolarsResult<Arc<dyn ColumnsUdf>> {
     #[cfg(feature = "python")]
     if buf.starts_with(crate::dsl::python_dsl::PYTHON_SERDE_MAGIC_BYTE_MARK) {
@@ -113,6 +128,21 @@ impl<'a> Deserialize<'a> for SpecialEq<Arc<dyn ColumnsUdf>> {
                 .map_err(|e| D::Error::custom(format!("{e}")))
                 .map(SpecialEq::new)
         })?
+    }
+}
+
+#[cfg(feature = "dsl-schema")]
+impl schemars::JsonSchema for SpecialEq<Arc<dyn ColumnsUdf>> {
+    fn schema_name() -> String {
+        "ColumnsUdf".to_owned()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed(concat!(module_path!(), "::", "ColumnsUdf"))
+    }
+
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        Vec::<u8>::json_schema(generator)
     }
 }
 
@@ -182,29 +212,18 @@ impl<'a> Deserialize<'a> for GetOutput {
     }
 }
 
-impl Serialize for SpecialEq<Arc<dyn RenameAliasFn>> {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        use serde::ser::Error;
-        let mut buf = vec![];
-        self.as_ref()
-            .try_serialize(&mut buf)
-            .map_err(|e| S::Error::custom(format!("{e}")))?;
-        serializer.serialize_bytes(&buf)
+#[cfg(feature = "dsl-schema")]
+impl schemars::JsonSchema for GetOutput {
+    fn schema_name() -> String {
+        "GetOutput".to_owned()
     }
-}
 
-impl<'a> Deserialize<'a> for SpecialEq<Arc<dyn RenameAliasFn>> {
-    fn deserialize<D>(_deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'a>,
-    {
-        use serde::de::Error;
-        Err(D::Error::custom(
-            "deserialization not supported for this renaming function",
-        ))
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed(std::concat!(std::module_path!(), "::", "GetOutput"))
+    }
+
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        Vec::<u8>::json_schema(generator)
     }
 }
 
@@ -228,6 +247,21 @@ impl<'a> Deserialize<'a> for SpecialEq<Series> {
     }
 }
 
+#[cfg(feature = "dsl-schema")]
+impl schemars::JsonSchema for SpecialEq<Series> {
+    fn schema_name() -> String {
+        Series::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        Series::schema_id()
+    }
+
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        Series::json_schema(generator)
+    }
+}
+
 impl<T: Serialize> Serialize for SpecialEq<Arc<T>> {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
@@ -245,5 +279,20 @@ impl<'a, T: Deserialize<'a>> Deserialize<'a> for SpecialEq<Arc<T>> {
     {
         let t = T::deserialize(deserializer)?;
         Ok(SpecialEq::new(Arc::new(t)))
+    }
+}
+
+#[cfg(feature = "dsl-schema")]
+impl<T: schemars::JsonSchema> schemars::JsonSchema for SpecialEq<Arc<T>> {
+    fn schema_name() -> String {
+        T::schema_name()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        T::schema_id()
+    }
+
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        T::json_schema(generator)
     }
 }

--- a/crates/polars-plan/src/dsl/file_scan/mod.rs
+++ b/crates/polars-plan/src/dsl/file_scan/mod.rs
@@ -33,6 +33,7 @@ bitflags::bitflags! {
 
 #[derive(Clone, Debug, IntoStaticStr)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 // TODO: Arc<> some of the options and the cloud options.
 pub enum FileScan {
     #[cfg(feature = "csv")]
@@ -44,14 +45,14 @@ pub enum FileScan {
     #[cfg(feature = "parquet")]
     Parquet {
         options: ParquetOptions,
-        #[cfg_attr(feature = "serde", serde(skip))]
+        #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(skip))]
         metadata: Option<FileMetadataRef>,
     },
 
     #[cfg(feature = "ipc")]
     Ipc {
         options: IpcScanOptions,
-        #[cfg_attr(feature = "serde", serde(skip))]
+        #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(skip))]
         metadata: Option<Arc<arrow::io::ipc::read::FileMetadata>>,
     },
 
@@ -59,11 +60,11 @@ pub enum FileScan {
     PythonDataset {
         dataset_object: Arc<python_dataset::PythonDatasetProvider>,
 
-        #[cfg_attr(feature = "serde", serde(skip, default))]
+        #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(skip, default))]
         cached_ir: Arc<Mutex<Option<ExpandedDataset>>>,
     },
 
-    #[cfg_attr(feature = "serde", serde(skip))]
+    #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(skip))]
     Anonymous {
         options: Arc<AnonymousScanOptions>,
         function: Arc<dyn AnonymousScan>,
@@ -117,6 +118,7 @@ impl FileScan {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum MissingColumnsPolicy {
     #[default]
     Raise,
@@ -127,6 +129,7 @@ pub enum MissingColumnsPolicy {
 /// Used by scans.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct CastColumnsPolicy {
     /// Allow casting when target dtype is lossless supertype
     pub integer_upcast: bool,
@@ -171,6 +174,7 @@ impl Default for CastColumnsPolicy {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum ExtraColumnsPolicy {
     /// Error if there are extra columns outside the target schema.
     #[default]
@@ -181,6 +185,7 @@ pub enum ExtraColumnsPolicy {
 /// Scan arguments shared across different scan types.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct UnifiedScanArgs {
     /// User-provided schema of the file. Will be inferred during IR conversion
     /// if None.

--- a/crates/polars-plan/src/dsl/file_scan/python_dataset.rs
+++ b/crates/polars-plan/src/dsl/file_scan/python_dataset.rs
@@ -34,6 +34,7 @@ pub fn dataset_provider_vtable() -> Result<&'static PythonDatasetProviderVTable,
 /// Currently intended only for Iceberg support
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct PythonDatasetProvider {
     dataset_object: PythonObject,
 }

--- a/crates/polars-plan/src/dsl/function_expr/array.rs
+++ b/crates/polars-plan/src/dsl/function_expr/array.rs
@@ -5,6 +5,7 @@ use crate::{map, map_as_slice};
 
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum ArrayFunction {
     Length,
     Min,

--- a/crates/polars-plan/src/dsl/function_expr/binary.rs
+++ b/crates/polars-plan/src/dsl/function_expr/binary.rs
@@ -5,6 +5,7 @@ use super::*;
 use crate::{map, map_as_slice};
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone, PartialEq, Debug, Eq, Hash)]
 pub enum BinaryFunction {
     Contains,

--- a/crates/polars-plan/src/dsl/function_expr/bitwise.rs
+++ b/crates/polars-plan/src/dsl/function_expr/bitwise.rs
@@ -9,6 +9,7 @@ use crate::dsl::{FieldsMapper, FunctionOptions};
 use crate::map;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone, Copy, PartialEq, Debug, Eq, Hash, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum BitwiseFunction {

--- a/crates/polars-plan/src/dsl/function_expr/boolean.rs
+++ b/crates/polars-plan/src/dsl/function_expr/boolean.rs
@@ -9,6 +9,7 @@ use crate::wrap;
 use crate::{map, map_as_slice};
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone, PartialEq, Debug, Eq, Hash)]
 pub enum BooleanFunction {
     Any {

--- a/crates/polars-plan/src/dsl/function_expr/business.rs
+++ b/crates/polars-plan/src/dsl/function_expr/business.rs
@@ -11,6 +11,7 @@ use crate::map_as_slice;
 use crate::prelude::{ColumnsUdf, FunctionFlags};
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone, PartialEq, Debug, Eq, Hash)]
 pub enum BusinessFunction {
     BusinessDayCount {

--- a/crates/polars-plan/src/dsl/function_expr/cat.rs
+++ b/crates/polars-plan/src/dsl/function_expr/cat.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::map;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone, PartialEq, Debug, Eq, Hash)]
 pub enum CategoricalFunction {
     GetCategories,

--- a/crates/polars-plan/src/dsl/function_expr/correlation.rs
+++ b/crates/polars-plan/src/dsl/function_expr/correlation.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use super::*;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Copy, Clone, PartialEq, Debug, Hash)]
 pub enum CorrelationMethod {
     Pearson,

--- a/crates/polars-plan/src/dsl/function_expr/datetime.rs
+++ b/crates/polars-plan/src/dsl/function_expr/datetime.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use super::*;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone, PartialEq, Debug, Eq, Hash)]
 pub enum TemporalFunction {
     Millennium,

--- a/crates/polars-plan/src/dsl/function_expr/fused.rs
+++ b/crates/polars-plan/src/dsl/function_expr/fused.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use super::*;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Copy, Clone, PartialEq, Debug, Hash)]
 pub enum FusedOperator {
     MultiplyAdd,

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -6,6 +6,7 @@ use crate::{map, map_as_slice, wrap};
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum ListFunction {
     Concat,
     #[cfg(feature = "is_in")]

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -119,6 +119,7 @@ pub use self::trigonometry::TrigonometricFunction;
 use super::*;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone, PartialEq, Debug)]
 pub enum FunctionExpr {
     // Namespaces

--- a/crates/polars-plan/src/dsl/function_expr/pow.rs
+++ b/crates/polars-plan/src/dsl/function_expr/pow.rs
@@ -6,6 +6,7 @@ use polars_core::with_match_physical_integer_type;
 use super::*;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone, Copy, PartialEq, Debug, Eq, Hash)]
 pub enum PowFunction {
     Generic,

--- a/crates/polars-plan/src/dsl/function_expr/random.rs
+++ b/crates/polars-plan/src/dsl/function_expr/random.rs
@@ -6,6 +6,7 @@ use strum_macros::IntoStaticStr;
 use super::*;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Copy, Clone, PartialEq, Debug, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum RandomMethod {

--- a/crates/polars-plan/src/dsl/function_expr/range/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range/mod.rs
@@ -24,6 +24,7 @@ use crate::map_as_slice;
 use crate::prelude::{ColumnsUdf, FunctionFlags};
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone, PartialEq, Debug, Eq, Hash)]
 pub enum RangeFunction {
     IntRange {

--- a/crates/polars-plan/src/dsl/function_expr/rolling.rs
+++ b/crates/polars-plan/src/dsl/function_expr/rolling.rs
@@ -10,6 +10,7 @@ use crate::dsl::pow::pow;
 
 #[derive(Clone, PartialEq, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum RollingFunction {
     Min(RollingOptionsFixedWindow),
     Max(RollingOptionsFixedWindow),

--- a/crates/polars-plan/src/dsl/function_expr/rolling_by.rs
+++ b/crates/polars-plan/src/dsl/function_expr/rolling_by.rs
@@ -4,6 +4,7 @@ use super::*;
 
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum RollingFunctionBy {
     MinBy(RollingOptionsDynamicWindow),
     MaxBy(RollingOptionsDynamicWindow),

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -18,6 +18,7 @@ polars_utils::regex_cache::cached_regex! {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone, PartialEq, Debug, Eq, Hash)]
 pub enum StringFunction {
     #[cfg(feature = "concat_str")]

--- a/crates/polars-plan/src/dsl/function_expr/struct_.rs
+++ b/crates/polars-plan/src/dsl/function_expr/struct_.rs
@@ -6,6 +6,7 @@ use crate::{map, map_as_slice};
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum StructFunction {
     FieldByIndex(i64),
     FieldByName(PlSmallStr),

--- a/crates/polars-plan/src/dsl/function_expr/trigonometry.rs
+++ b/crates/polars-plan/src/dsl/function_expr/trigonometry.rs
@@ -4,6 +4,7 @@ use polars_core::chunked_array::ops::arity::broadcast_binary_elementwise;
 use super::*;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone, Copy, PartialEq, Debug, Eq, Hash)]
 pub enum TrigonometricFunction {
     Cos,

--- a/crates/polars-plan/src/dsl/match_to_schema.rs
+++ b/crates/polars-plan/src/dsl/match_to_schema.rs
@@ -2,6 +2,7 @@ use super::{Expr, ExtraColumnsPolicy, MissingColumnsPolicy};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum MissingColumnsPolicyOrExpr {
     Insert,
     Raise,
@@ -10,6 +11,7 @@ pub enum MissingColumnsPolicyOrExpr {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum UpcastOrForbid {
     Upcast,
     Forbid,
@@ -17,6 +19,7 @@ pub enum UpcastOrForbid {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct MatchToSchemaPerColumn {
     pub missing_columns: MissingColumnsPolicyOrExpr,
     pub missing_struct_fields: MissingColumnsPolicy,

--- a/crates/polars-plan/src/dsl/options/mod.rs
+++ b/crates/polars-plan/src/dsl/options/mod.rs
@@ -36,6 +36,7 @@ use crate::dsl::Selector;
 
 #[derive(Copy, Clone, PartialEq, Debug, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct RollingCovOptions {
     pub window_size: IdxSize,
     pub min_periods: IdxSize,
@@ -44,6 +45,7 @@ pub struct RollingCovOptions {
 
 #[derive(Clone, PartialEq, Debug, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct StrptimeOptions {
     /// Formatting string
     pub format: Option<PlSmallStr>,
@@ -69,11 +71,18 @@ impl Default for StrptimeOptions {
 
 #[derive(Clone, PartialEq, Eq, IntoStaticStr, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[strum(serialize_all = "snake_case")]
 pub enum JoinTypeOptionsIR {
     #[cfg(feature = "iejoin")]
     IEJoin(IEJoinOptions),
-    #[cfg_attr(all(feature = "serde", not(feature = "ir_serde")), serde(skip))]
+    #[cfg_attr(
+        all(
+            any(feature = "serde", feature = "dsl-schema"),
+            not(feature = "ir_serde")
+        ),
+        serde(skip)
+    )]
     // Fused cross join and filter (only in in-memory engine)
     Cross { predicate: ExprIR },
 }
@@ -109,6 +118,7 @@ impl JoinTypeOptionsIR {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct JoinOptions {
     pub allow_parallel: bool,
     pub force_parallel: bool,
@@ -136,6 +146,7 @@ impl Default for JoinOptions {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum WindowType {
     /// Explode the aggregated list and just do a hstack instead of a join
     /// this requires the groups to be sorted to make any sense
@@ -158,6 +169,7 @@ impl Default for WindowType {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Hash, IntoStaticStr)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[strum(serialize_all = "snake_case")]
 pub enum WindowMapping {
     /// Map the group values to the position
@@ -181,6 +193,7 @@ pub enum NestedType {
 
 #[derive(Clone, Default, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct UnpivotArgsDSL {
     pub on: Vec<Selector>,
     pub index: Vec<Selector>,
@@ -243,12 +256,14 @@ pub struct UnionOptions {
 
 #[derive(Clone, Debug, Copy, Default, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct HConcatOptions {
     pub parallel: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct GroupbyOptions {
     #[cfg(feature = "dynamic_group_by")]
     pub dynamic: Option<DynamicGroupOptions>,
@@ -284,6 +299,7 @@ impl GroupbyOptions {
 
 #[derive(Clone, Debug, Eq, PartialEq, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct DistinctOptionsDSL {
     /// Subset of columns that will be taken into account.
     pub subset: Option<Vec<Selector>>,
@@ -314,6 +330,7 @@ pub struct AnonymousScanOptions {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum FileType {
     #[cfg(feature = "parquet")]
@@ -347,6 +364,7 @@ impl FileType {
 //
 // Arguments given to `concat`. Differs from `UnionOptions` as the latter is IR state.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct UnionArgs {
     pub parallel: bool,
@@ -387,6 +405,7 @@ impl From<UnionArgs> for UnionOptions {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[cfg(feature = "json")]
 pub struct NDJsonReadOptions {
     pub n_threads: Option<usize>,

--- a/crates/polars-plan/src/dsl/options/sink.rs
+++ b/crates/polars-plan/src/dsl/options/sink.rs
@@ -19,6 +19,7 @@ use crate::dsl::{AExpr, Expr, SpecialEq};
 /// Options that apply to all sinks.
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct SinkOptions {
     /// Call sync when closing the file.
     pub sync_on_close: SyncOnCloseType,
@@ -145,7 +146,23 @@ impl<'de> serde::Deserialize<'de> for SinkTarget {
     }
 }
 
+#[cfg(feature = "dsl-schema")]
+impl schemars::JsonSchema for SinkTarget {
+    fn schema_name() -> String {
+        "SinkTarget".to_owned()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed(concat!(module_path!(), "::", "SinkTarget"))
+    }
+
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        PathBuf::json_schema(generator)
+    }
+}
+
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct FileSinkType {
     pub target: SinkTarget,
@@ -299,7 +316,23 @@ impl serde::Serialize for PartitionTargetCallback {
     }
 }
 
+#[cfg(feature = "dsl-schema")]
+impl schemars::JsonSchema for PartitionTargetCallback {
+    fn schema_name() -> String {
+        "PartitionTargetCallback".to_owned()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed(concat!(module_path!(), "::", "PartitionTargetCallback"))
+    }
+
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        Vec::<u8>::json_schema(generator)
+    }
+}
+
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct PartitionSinkType {
     pub base_path: Arc<PathBuf>,
@@ -322,6 +355,7 @@ pub struct PartitionSinkTypeIR {
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum SinkType {
     Memory,
@@ -330,6 +364,7 @@ pub enum SinkType {
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum PartitionVariant {
     MaxSize(IdxSize),

--- a/crates/polars-plan/src/dsl/plan.rs
+++ b/crates/polars-plan/src/dsl/plan.rs
@@ -48,10 +48,11 @@ use super::*;
 // - changing a name, type, or meaning of a field or an enum variant
 // - changing a default value of a field or a default enum variant
 // - restricting the range of allowed values a field can have
-pub static DSL_VERSION: (u16, u16) = (4, 1);
+pub static DSL_VERSION: (u16, u16) = (5, 0);
 static DSL_MAGIC_BYTES: &[u8] = b"DSL_VERSION";
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum DslPlan {
     #[cfg(feature = "python")]
     PythonScan {
@@ -76,7 +77,7 @@ pub enum DslPlan {
         /// Local use cases often repeatedly collect the same `LazyFrame` (e.g. in interactive notebook use-cases),
         /// so we cache the IR conversion here, as the path expansion can be quite slow (especially for cloud paths).
         /// We don't have the arena, as this is always a source node.
-        #[cfg_attr(feature = "serde", serde(skip))]
+        #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(skip))]
         cached_ir: Arc<Mutex<Option<IR>>>,
     },
     // we keep track of the projection and selection as it is cheaper to first project and then filter
@@ -98,7 +99,7 @@ pub enum DslPlan {
         aggs: Vec<Expr>,
         maintain_order: bool,
         options: Arc<GroupbyOptions>,
-        #[cfg_attr(feature = "serde", serde(skip))]
+        #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(skip))]
         apply: Option<(Arc<dyn DataFrameUdf>, SchemaRef)>,
     },
     /// Join operation
@@ -185,7 +186,7 @@ pub enum DslPlan {
         // Keep the original Dsl around as we need that for serialization.
         dsl: Arc<DslPlan>,
         version: u32,
-        #[cfg_attr(feature = "serde", serde(skip))]
+        #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(skip))]
         node: Option<Node>,
     },
 }
@@ -346,5 +347,39 @@ impl DslPlan {
         }
 
         Ok(dsl)
+    }
+
+    #[cfg(feature = "dsl-schema")]
+    pub fn dsl_schema() -> schemars::schema::RootSchema {
+        use schemars::r#gen::SchemaSettings;
+        use schemars::schema::SchemaObject;
+        use schemars::visit::{Visitor, visit_schema_object};
+
+        #[derive(Clone, Copy, Debug)]
+        struct MyVisitor;
+
+        impl Visitor for MyVisitor {
+            fn visit_schema_object(&mut self, schema: &mut SchemaObject) {
+                // Remove descriptions auto-generated from doc comments
+                if schema.metadata.is_some() {
+                    schema.metadata().description = None;
+                }
+
+                visit_schema_object(self, schema);
+            }
+        }
+
+        let mut schema = SchemaSettings::default()
+            .with_visitor(MyVisitor)
+            .into_generator()
+            .into_root_schema_for::<DslPlan>();
+
+        // Add DSL version as a top level field
+        schema.schema.extensions.insert(
+            "version".into(),
+            format!("{}.{}", DSL_VERSION.0, DSL_VERSION.1).into(),
+        );
+
+        schema
     }
 }

--- a/crates/polars-plan/src/dsl/python_dsl/source.rs
+++ b/crates/polars-plan/src/dsl/python_dsl/source.rs
@@ -12,6 +12,7 @@ use crate::dsl::SpecialEq;
 
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct PythonOptionsDsl {
     /// A function that returns a Python Generator.
     /// The generator should produce Polars DataFrame's.
@@ -39,6 +40,7 @@ impl PythonOptionsDsl {
 
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum PythonScanSource {
     Pyarrow,
     Cuda,

--- a/crates/polars-plan/src/dsl/scan_sources.rs
+++ b/crates/polars-plan/src/dsl/scan_sources.rs
@@ -20,13 +20,14 @@ use super::UnifiedScanArgs;
 /// This can either be a list of paths to files, opened files or in-memory buffers. Mixing of
 /// buffers is not currently possible.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone)]
 pub enum ScanSources {
     Paths(Arc<[PathBuf]>),
 
-    #[cfg_attr(feature = "serde", serde(skip))]
+    #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(skip))]
     Files(Arc<[File]>),
-    #[cfg_attr(feature = "serde", serde(skip))]
+    #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(skip))]
     Buffers(Arc<[MemSlice]>),
 }
 

--- a/crates/polars-plan/src/dsl/selector.rs
+++ b/crates/polars-plan/src/dsl/selector.rs
@@ -7,6 +7,7 @@ use super::*;
 
 #[derive(Clone, PartialEq, Hash, Debug, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum Selector {
     Add(Box<Selector>, Box<Selector>),
     Sub(Box<Selector>, Box<Selector>),

--- a/crates/polars-plan/src/plans/expr_ir.rs
+++ b/crates/polars-plan/src/plans/expr_ir.rs
@@ -13,6 +13,7 @@ use crate::constants::{get_len_name, get_literal_name};
 
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(feature = "ir_serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum OutputName {
     /// No not yet set.
     #[default]
@@ -51,6 +52,7 @@ impl OutputName {
 
 #[derive(Debug)]
 #[cfg_attr(feature = "ir_serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct ExprIR {
     /// Output name of this expression.
     output_name: OutputName,
@@ -58,7 +60,7 @@ pub struct ExprIR {
     /// Reduced expression.
     /// This expression is pruned from `alias` and already expanded.
     node: Node,
-    #[cfg_attr(feature = "ir_serde", serde(skip))]
+    #[cfg_attr(any(feature = "ir_serde", feature = "dsl-schema"), serde(skip))]
     output_dtype: OnceLock<DataType>,
 }
 

--- a/crates/polars-plan/src/plans/functions/dsl.rs
+++ b/crates/polars-plan/src/plans/functions/dsl.rs
@@ -5,6 +5,7 @@ use super::*;
 
 #[cfg(feature = "python")]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone)]
 pub struct OpaquePythonUdf {
     pub function: PythonFunction,
@@ -20,6 +21,7 @@ pub struct OpaquePythonUdf {
 // Except for Opaque functions, this only has the DSL name of the function.
 #[derive(Clone, IntoStaticStr)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum DslFunction {
     RowIndex {
@@ -48,12 +50,13 @@ pub enum DslFunction {
     FillNan(Expr),
     Drop(DropFunction),
     // Function that is already converted to IR.
-    #[cfg_attr(feature = "serde", serde(skip))]
+    #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(skip))]
     FunctionIR(FunctionIR),
 }
 
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct DropFunction {
     /// Columns that are going to be dropped
     pub(crate) to_drop: Vec<Selector>,
@@ -64,6 +67,7 @@ pub struct DropFunction {
 
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum StatsFunction {
     Var {
         ddof: u8,

--- a/crates/polars-plan/src/plans/lit.rs
+++ b/crates/polars-plan/src/plans/lit.rs
@@ -14,6 +14,7 @@ use crate::prelude::*;
 
 #[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum DynLiteralValue {
     Str(PlSmallStr),
     Int(i128),
@@ -22,6 +23,7 @@ pub enum DynLiteralValue {
 }
 #[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum DynListLiteralValue {
     Str(Box<[Option<PlSmallStr>]>),
     Int(Box<[Option<i128>]>),
@@ -57,6 +59,7 @@ impl Hash for DynListLiteralValue {
 
 #[derive(Clone, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct RangeLiteralValue {
     pub low: i128,
     pub high: i128,
@@ -64,6 +67,7 @@ pub struct RangeLiteralValue {
 }
 #[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum LiteralValue {
     /// A dynamically inferred literal value. This needs to be materialized into a specific type.
     Dyn(DynLiteralValue),

--- a/crates/polars-plan/src/plans/options.rs
+++ b/crates/polars-plan/src/plans/options.rs
@@ -25,10 +25,41 @@ pub struct DistinctOptionsIR {
 // a boolean that can only be set to `false` safely
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct UnsafeBool(bool);
 impl Default for UnsafeBool {
     fn default() -> Self {
         UnsafeBool(true)
+    }
+}
+
+#[cfg(feature = "dsl-schema")]
+impl schemars::JsonSchema for FunctionFlags {
+    fn schema_name() -> String {
+        "FunctionFlags".to_owned()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed(concat!(module_path!(), "::", "FunctionFlags"))
+    }
+
+    fn json_schema(_generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        use serde_json::{Map, Value};
+
+        let name_to_bits: Map<String, Value> = Self::all()
+            .iter_names()
+            .map(|(name, flag)| (name.to_owned(), flag.bits().into()))
+            .collect();
+
+        schemars::schema::Schema::Object(schemars::schema::SchemaObject {
+            instance_type: Some(schemars::schema::InstanceType::String.into()),
+            format: Some("bitflags".to_owned()),
+            extensions: schemars::Map::from_iter([
+                // Add a map of flag names and bit patterns to detect schema changes
+                ("bitflags".to_owned(), Value::Object(name_to_bits)),
+            ]),
+            ..Default::default()
+        })
     }
 }
 
@@ -128,6 +159,7 @@ impl CastingRules {
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 #[cfg_attr(any(feature = "serde"), derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct FunctionOptions {
     // Validate the output of a `map`.
     // this should always be true or we could OOB
@@ -135,10 +167,10 @@ pub struct FunctionOptions {
     pub flags: FunctionFlags,
 
     // used for formatting, (only for anonymous functions)
-    #[cfg_attr(feature = "serde", serde(skip))]
+    #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(skip))]
     pub fmt_str: &'static str,
     /// Options used when deciding how to cast the arguments of the function.
-    #[cfg_attr(feature = "serde", serde(skip))]
+    #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(skip))]
     pub cast_options: Option<CastingRules>,
 }
 
@@ -236,6 +268,7 @@ impl Default for FunctionOptions {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct ProjectionOptions {
     pub run_parallel: bool,

--- a/crates/polars-plan/src/plans/schema.rs
+++ b/crates/polars-plan/src/plans/schema.rs
@@ -31,6 +31,7 @@ impl DslPlan {
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct FileInfo {
     /// Schema of the physical file.
     ///

--- a/crates/polars-schema/Cargo.toml
+++ b/crates/polars-schema/Cargo.toml
@@ -12,6 +12,7 @@ description = "Private crate for schema utilities for the Polars DataFrame libra
 indexmap = { workspace = true }
 polars-error = { workspace = true }
 polars-utils = { workspace = true }
+schemars = { workspace = true, features = ["indexmap2"], optional = true }
 serde = { workspace = true, optional = true }
 
 [build-dependencies]
@@ -20,3 +21,4 @@ version_check = { workspace = true }
 [features]
 nightly = []
 serde = ["dep:serde", "serde/derive", "polars-utils/serde"]
+dsl-schema = ["dep:schemars", "polars-utils/dsl-schema"]

--- a/crates/polars-schema/src/schema.rs
+++ b/crates/polars-schema/src/schema.rs
@@ -8,6 +8,7 @@ use polars_utils::pl_str::PlSmallStr;
 
 #[derive(Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct Schema<D> {
     fields: PlIndexMap<PlSmallStr, D>,
 }

--- a/crates/polars-time/Cargo.toml
+++ b/crates/polars-time/Cargo.toml
@@ -24,6 +24,7 @@ now = { version = "0.1" }
 num-traits = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 strum_macros = { workspace = true }
 
@@ -47,6 +48,7 @@ rolling_window = ["polars-core/rolling_window"]
 rolling_window_by = ["polars-core/rolling_window_by", "dtype-duration"]
 fmt = ["polars-core/fmt"]
 serde = ["dep:serde", "polars-utils/serde", "polars-compute/serde"]
+dsl-schema = ["dep:schemars", "polars-utils/dsl-schema", "polars-compute/dsl-schema"]
 temporal = ["polars-core/temporal"]
 timezones = ["chrono-tz", "dtype-datetime", "polars-core/timezones", "arrow/timezones", "polars-ops/timezones"]
 

--- a/crates/polars-time/src/chunkedarray/rolling_window/mod.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/mod.rs
@@ -14,6 +14,7 @@ use crate::prelude::*;
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "rolling_window_by", derive(PartialEq))]
 pub struct RollingOptionsDynamicWindow {
     /// The length of the window.
@@ -23,6 +24,6 @@ pub struct RollingOptionsDynamicWindow {
     /// Which side windows should be closed.
     pub closed_window: ClosedWindow,
     /// Optional parameters for the rolling
-    #[cfg_attr(feature = "serde", serde(default))]
+    #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(default))]
     pub fn_params: Option<RollingFnParams>,
 }

--- a/crates/polars-time/src/group_by/dynamic.rs
+++ b/crates/polars-time/src/group_by/dynamic.rs
@@ -18,6 +18,7 @@ struct Wrap<T>(pub T);
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct DynamicGroupOptions {
     /// Time or index column.
     pub index_column: PlSmallStr,
@@ -52,6 +53,7 @@ impl Default for DynamicGroupOptions {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct RollingGroupOptions {
     /// Time or index column.
     pub index_column: PlSmallStr,

--- a/crates/polars-time/src/windows/duration.rs
+++ b/crates/polars-time/src/windows/duration.rs
@@ -28,6 +28,7 @@ use crate::windows::calendar::{DAYS_PER_MONTH, is_leap_year};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct Duration {
     // the number of months for the duration
     months: i64,

--- a/crates/polars-time/src/windows/group_by.rs
+++ b/crates/polars-time/src/windows/group_by.rs
@@ -13,6 +13,7 @@ use crate::prelude::*;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoStaticStr)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[strum(serialize_all = "snake_case")]
 pub enum ClosedWindow {
     Left,
@@ -23,6 +24,7 @@ pub enum ClosedWindow {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoStaticStr)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[strum(serialize_all = "snake_case")]
 pub enum Label {
     Left,
@@ -32,6 +34,7 @@ pub enum Label {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoStaticStr)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[strum(serialize_all = "snake_case")]
 pub enum StartBy {
     WindowBound,

--- a/crates/polars-utils/Cargo.toml
+++ b/crates/polars-utils/Cargo.toml
@@ -27,6 +27,7 @@ raw-cpuid = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
 rmp-serde = { workspace = true, optional = true }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_ignored = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -54,4 +55,5 @@ serde = [
   "dep:serde_json",
   "dep:serde_ignored",
 ]
+dsl-schema = ["dep:schemars"]
 python = ["pyo3", "polars-error/python"]

--- a/crates/polars-utils/src/arena.rs
+++ b/crates/polars-utils/src/arena.rs
@@ -24,6 +24,7 @@ fn index_of<T>(slice: &[T], item: &T) -> Option<usize> {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 #[repr(transparent)]
 #[cfg_attr(feature = "ir_serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct Node(pub usize);
 
 impl Default for Node {

--- a/crates/polars-utils/src/pl_str.rs
+++ b/crates/polars-utils/src/pl_str.rs
@@ -22,6 +22,23 @@ type Inner = compact_str::CompactString;
 )]
 pub struct PlSmallStr(Inner);
 
+#[cfg(feature = "dsl-schema")]
+impl schemars::JsonSchema for PlSmallStr {
+    fn is_referenceable() -> bool {
+        false
+    }
+
+    fn schema_name() -> std::string::String {
+        String::schema_name()
+    }
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        String::schema_id()
+    }
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(generator)
+    }
+}
+
 impl PlSmallStr {
     pub const EMPTY: Self = Self::from_static("");
     pub const EMPTY_REF: &'static Self = &Self::from_static("");

--- a/crates/polars-utils/src/python_function.rs
+++ b/crates/polars-utils/src/python_function.rs
@@ -76,6 +76,21 @@ impl PartialEq for PythonObject {
     }
 }
 
+#[cfg(feature = "dsl-schema")]
+impl schemars::JsonSchema for PythonObject {
+    fn schema_name() -> String {
+        "PythonObject".to_owned()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed(concat!(module_path!(), "::", "PythonObject"))
+    }
+
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        Vec::<u8>::json_schema(generator)
+    }
+}
+
 #[cfg(feature = "serde")]
 mod _serde_impls {
     use super::{PySerializeWrap, PythonObject, TrySerializeToBytes, serde_wrap};

--- a/crates/polars-utils/src/slice_enum.rs
+++ b/crates/polars-utils/src/slice_enum.rs
@@ -3,6 +3,7 @@ use std::ops::Range;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum Slice {
     /// Or zero
     Positive {

--- a/py-polars/tests/unit/cloud/test_prepare_cloud_plan.py
+++ b/py-polars/tests/unit/cloud/test_prepare_cloud_plan.py
@@ -102,5 +102,7 @@ def test_prepare_cloud_plan_fail_on_local_data_source(lf: pl.LazyFrame) -> None:
     ],
 )
 def test_prepare_cloud_plan_fail_on_serialization(lf: pl.LazyFrame) -> None:
-    with pytest.raises(ComputeError, match="serialization not supported"):
+    with pytest.raises(
+        ComputeError, match="cannot be serialized|serialization not supported"
+    ):
         prepare_cloud_plan(lf)


### PR DESCRIPTION
This PR adds a `DslPlan::dsl_schema` method to generate the serialization schema of the DslPlan. This will be used in a follow-up PR to make changes to the schema visible and remind the contributors and reviewers that the `DSL_VERSION` might need to be incremented.