### PR TITLE
fix: Improve consistency between `read_csv` and `scan_csv`

### DIFF
--- a/crates/polars-io/src/csv/read/parser.rs
+++ b/crates/polars-io/src/csv/read/parser.rs
@@ -913,6 +913,8 @@ pub(super) fn skip_this_line_naive(input: &[u8], eol_char: u8) -> &[u8] {
 /// * `projection` - Indices of the columns to project.
 /// * `buffers` - Parsed output will be written to these buffers. Except for UTF8 data. The offsets of the
 ///   fields are written to the buffers. The UTF8 data will be parsed later.
+///
+/// Returns the number of bytes parsed successfully.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn parse_lines(
     mut bytes: &[u8],

--- a/crates/polars-io/src/csv/read/splitfields.rs
+++ b/crates/polars-io/src/csv/read/splitfields.rs
@@ -44,7 +44,7 @@ mod inner {
             Some((self.v, need_escaping))
         }
 
-        fn eof_oel(&self, current_ch: u8) -> bool {
+        fn eof_eol(&self, current_ch: u8) -> bool {
             current_ch == self.separator || current_ch == self.eol_char
         }
     }
@@ -89,7 +89,7 @@ mod inner {
                         in_field = !in_field;
                     }
 
-                    if !in_field && self.eof_oel(c) {
+                    if !in_field && self.eof_eol(c) {
                         if c == self.eol_char {
                             // SAFETY:
                             // we are in bounds
@@ -109,7 +109,7 @@ mod inner {
 
                 idx as usize
             } else {
-                match self.v.iter().position(|&c| self.eof_oel(c)) {
+                match self.v.iter().position(|&c| self.eof_eol(c)) {
                     None => return self.finish(needs_escaping),
                     Some(idx) => unsafe {
                         // SAFETY:
@@ -139,6 +139,7 @@ mod inner {
 mod inner {
     use std::simd::prelude::*;
 
+    use polars_error::polars_warn;
     use polars_utils::clmul::prefix_xorsum_inclusive;
 
     const SIMD_SIZE: usize = 64;
@@ -202,8 +203,12 @@ mod inner {
             Some((self.v, need_escaping))
         }
 
-        fn eof_oel(&self, current_ch: u8) -> bool {
+        fn eof_eol(&self, current_ch: u8) -> bool {
             current_ch == self.separator || current_ch == self.eol_char
+        }
+
+        fn is_quote(&self, current_ch: u8) -> bool {
+            current_ch == self.quote_char
         }
     }
 
@@ -255,6 +260,7 @@ mod inner {
             // SAFETY:
             // we have checked bounds
             let pos = if self.quoting && unsafe { *self.v.get_unchecked(0) } == self.quote_char {
+                // Start of an enclosed field
                 let mut total_idx = 0;
                 needs_escaping = true;
                 let mut not_in_field_previous_iter = true;
@@ -324,7 +330,7 @@ mod inner {
                                 in_field = !in_field;
                             }
 
-                            if !in_field && self.eof_oel(c) {
+                            if !in_field && self.eof_eol(c) {
                                 if c == self.eol_char {
                                     // SAFETY:
                                     // we are in bounds
@@ -352,6 +358,7 @@ mod inner {
                 }
                 total_idx
             } else {
+                // Start of an unenclosed field
                 let mut total_idx = 0;
 
                 loop {
@@ -369,6 +376,23 @@ mod inner {
                         let has_separator = simd_bytes.simd_eq(self.simd_separator);
                         let has_any_mask = (has_separator | has_eol_char).to_bitmask();
 
+                        // check malformed: quotes are not allowed in unenclosed fields
+                        if self.quoting {
+                            let has_quote_mask =
+                                simd_bytes.simd_eq(self.simd_quote_char).to_bitmask();
+                            let malformed = match (has_quote_mask, has_any_mask) {
+                                (q, e) if q > 0 && e > 0 => q.trailing_zeros() < e.trailing_zeros(),
+                                // (q, e) if q > 0 && e > 0 => !q > !e, // trailing_zeroes() equivalent
+                                (q, 0) if q > 0 => true,
+                                _ => false,
+                            };
+                            if malformed {
+                                polars_warn!(
+                                    "CSV data malformed: quote character in an unenclosed field"
+                                );
+                            }
+                        }
+
                         if has_any_mask != 0 {
                             total_idx += has_any_mask.trailing_zeros() as usize;
                             break;
@@ -376,7 +400,27 @@ mod inner {
                             total_idx += SIMD_SIZE;
                         }
                     } else {
-                        match bytes.iter().position(|&c| self.eof_oel(c)) {
+                        let eof_eol_idx = bytes.iter().position(|&c| self.eof_eol(c));
+
+                        // check malformed: quotes are not allowed in unenclosed fields
+                        if self.quoting {
+                            let quote_idx = match eof_eol_idx {
+                                Some(e) => bytes[..e].iter().position(|&c| self.is_quote(c)),
+                                None => bytes.iter().position(|&c| self.is_quote(c)),
+                            };
+                            // let malformed = match (quote_idx, eof_eol_idx) {
+                            //     (Some(q), Some(e)) => q < e,
+                            //     (Some(_), None) => true,
+                            //     _ => false,
+                            // };
+                            if quote_idx.is_some() {
+                                polars_warn!(
+                                    "CSV data malformed: quote character in an unenclosed field"
+                                );
+                            }
+                        }
+
+                        match eof_eol_idx {
                             None => return self.finish(needs_escaping),
                             Some(idx) => {
                                 total_idx += idx;

--- a/crates/polars-stream/src/nodes/io_sources/csv.rs
+++ b/crates/polars-stream/src/nodes/io_sources/csv.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use polars_core::StringCacheHolder;
 use polars_core::prelude::{Column, Field};
 use polars_core::schema::{SchemaExt, SchemaRef};
-use polars_error::{PolarsResult, polars_bail, polars_err};
+use polars_error::{PolarsResult, polars_bail, polars_err, polars_warn};
 use polars_io::RowIndex;
 use polars_io::cloud::CloudOptions;
 use polars_io::prelude::_csv_read_internal::{
@@ -678,6 +678,9 @@ impl ChunkReader {
 
         let height = df.height();
         let n_lines_is_correct = df.height() == n_lines;
+        if df.height() > n_lines {
+            polars_warn!("CSV data malformed: line count mismatch in chunk");
+        }
 
         if slice != NO_SLICE {
             assert!(slice != SLICE_ENDED);

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -88,6 +88,9 @@ def read_csv(
     r"""
     Read a CSV file into a DataFrame.
 
+    Polars expects CSV data to strictly conform to RFC 4180, unless documented
+    otherwise. Malformed data, though common, may lead to undefined behavior.
+
     .. versionchanged:: 0.20.31
         The `dtypes` parameter was renamed `schema_overrides`.
     .. versionchanged:: 0.20.4


### PR DESCRIPTION
fixes #22395

This commit improves consistency between `read_csv()` and `scan_csv()` for some types of malformed CSV data. It will issue a warning for some types of malformed CSV data.  A decision is needed on the scope as this may impact performance, see below.

In scope:
a) (Cheap) Return warning instead of panic when `read_chunk()` returns more lines than `CountLines` found. Add a similar warning to `scan_csv()`. This makes `read_csv` consistent with `scan_csv`. We may want to error instead?
b) Updated documentation.
c) Added tests.

TBD in/out of scope (currently in):
d) (Not cheap) Lazy_quotes_1: Looks for quotes unenclosed fields in `SplitFields` iterator: detect and warn when quotes are found in unenclosed field, except for columns to the RHS of last projected column.

Out of scope:
e) Allow lazy_quotes_1 with projection, specifically when columns to the RHS of the last projected column have an odd number of quotes.
f) Lazy_quotes_2: Does not check for single-quotes in enclosed fields (yet) as this is more ambiguous and further impacts performance. Exception is the line count above.
g) Leading whitespace in fields.

Performance regression (for unenclosed fields lazy_quotes_1 check, d above) observed. Caveat, my dev machine is not good for benchmarking, it is a lightweight portable laptop running Windows + WSL. It shows some performance regression on a single large CSV file (NYC dataset, 24M records, short fields, unenclosed) in the order of +9% on number of instructions, +15% on wall-time.

<details>
<summary>Details: (non-representative) performance assessment</summary>

(with malformed check)
(nodebug-release)
commit 1d60b0488b29fe6c7d4292a7f49da6e1f025ca23 

```
denecker@DESKTOP-V7KT63E:~/my-polars/issue_22395$ ~/poop/zig-out/bin/poop 'python nyc_read.py'
Benchmark 1 (3 runs): python nyc_read.py
  measurement          mean ± σ            min … max           outliers
  wall_time          6.14s  ±  723ms    5.47s  … 6.91s           0 ( 0%)
  peak_rss           8.43GB ± 6.33MB    8.43GB … 8.44GB          0 ( 0%)
  cpu_cycles          102G  ±  487M      101G  …  102G           0 ( 0%)
  instructions        141G  ±  395K      141G  …  141G           0 ( 0%)
  cache_references    561M  ± 34.0M      541M  …  600M           0 ( 0%)
  cache_misses        333M  ± 4.69M      327M  …  336M           0 ( 0%)
  branch_misses       306M  ± 9.31M      298M  …  316M           0 ( 0%)
```

(without malformed check)
(nodebug-release)
commit 5be0a9b21cd84f0a9f6c3e159c8668584d81608e

```
denecker@DESKTOP-V7KT63E:~/my-polars/issue_22395$ ~/poop/zig-out/bin/poop 'python nyc_read.py'
Benchmark 1 (3 runs): python nyc_read.py
  measurement          mean ± σ            min … max           outliers
  wall_time          5.33s  ±  169ms    5.22s  … 5.53s           0 ( 0%)
  peak_rss           8.43GB ±  967KB    8.43GB … 8.44GB          0 ( 0%)
  cpu_cycles         90.0G  ±  332M     89.7G  … 90.4G           0 ( 0%)
  instructions        129G  ±  463K      129G  …  129G           0 ( 0%)
  cache_references    540M  ± 17.3M      526M  …  560M           0 ( 0%)
  cache_misses        331M  ± 1.67M      329M  …  333M           0 ( 0%)
  branch_misses       288M  ± 14.1M      280M  …  305M           0 ( 0%)
```
</details>

General notes on performance. I suspect overall, some improvements are still possible for `read_csv` if we consider the following:
(A) Internal
1. Use bounded queue between pass-1 and pass-2 to provide back-pressure. This should keep passes in sync and keep cache hot (requires investigation).
2. Review L3 cache size optimization (individual chunks are 16 MB, per thread?)
3. In pass 2, consider collecting character indices for further processing rather than re-starting 'next()` for every field. Relevant when fields are short.
4. I noticed SIMD_SIZE is hardcoded as 64 bytes (AVX-512) but many Intel laptops only support 32 bytes (AVX-2). (Fwiw, hardcoding SIMD_SIZE to 32 bytes showed some improvement on my machine).

(B) User facing:
1. Introduce a `fast-mode` option to end users in `read_csv()`. When enabled, polars assert wellformed data  and ignores all quotes.
2. Introduce feature flag(s) for lazyquotes options with separate code path. This protects the performance on wellformed CSV. Consider memchr to manage code complexity.
Combined, this would present 3 approaches: (i) fast-mode (expects well-formed, no quotes, no checks), (ii) default mode (expects well-formed including quotes, limited checking), (iii) forgiving mode (feature flags to allow RFC exceptions).

Kindly review:
- Issue `warning` vs `error`. My take is to start with `warning` now and move to `error` when forgiving feature flags are available.
- Scope: how much performance impact is acceptable to detect malformed data? Imo, the next step would be a reliable benchmark on a dedicated machine.