### PR TITLE
feat: Add `index_of_first_not_null` and `index_of_last_not_null` Expr and Series methods

### DIFF
--- a/crates/polars-ops/src/series/ops/mod.rs
+++ b/crates/polars-ops/src/series/ops/mod.rs
@@ -88,7 +88,7 @@ pub use fused::*;
 pub use horizontal::*;
 pub use index::*;
 #[cfg(feature = "index_of")]
-pub use index_of::*;
+pub use index_of::IndexOf;
 pub use int_range::*;
 #[cfg(feature = "interpolate")]
 pub use interpolation::interpolate::*;

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -159,6 +159,10 @@ pub enum FunctionExpr {
     ArgWhere,
     #[cfg(feature = "index_of")]
     IndexOf,
+    #[cfg(feature = "index_of")]
+    IndexOfFirstNotNull,
+    #[cfg(feature = "index_of")]
+    IndexOfLastNotNull,
     #[cfg(feature = "search_sorted")]
     SearchSorted {
         side: SearchSortedSide,
@@ -401,6 +405,10 @@ impl Hash for FunctionExpr {
             Pow(f) => f.hash(state),
             #[cfg(feature = "index_of")]
             IndexOf => {},
+            #[cfg(feature = "index_of")]
+            IndexOfFirstNotNull => {},
+            #[cfg(feature = "index_of")]
+            IndexOfLastNotNull => {},
             #[cfg(feature = "search_sorted")]
             SearchSorted { side, descending } => {
                 side.hash(state);
@@ -654,6 +662,10 @@ impl Display for FunctionExpr {
             ArgWhere => "arg_where",
             #[cfg(feature = "index_of")]
             IndexOf => "index_of",
+            #[cfg(feature = "index_of")]
+            IndexOfFirstNotNull => "index_of_first_not_null",
+            #[cfg(feature = "index_of")]
+            IndexOfLastNotNull => "index_of_last_not_null",
             #[cfg(feature = "search_sorted")]
             SearchSorted { .. } => "search_sorted",
             #[cfg(feature = "range")]
@@ -944,6 +956,14 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn ColumnsUdf>> {
             #[cfg(feature = "index_of")]
             IndexOf => {
                 map_as_slice!(index_of::index_of)
+            },
+            #[cfg(feature = "index_of")]
+            IndexOfFirstNotNull => {
+                map_as_slice!(index_of::index_of_first_not_null)
+            },
+            #[cfg(feature = "index_of")]
+            IndexOfLastNotNull => {
+                map_as_slice!(index_of::index_of_last_not_null)
             },
             #[cfg(feature = "search_sorted")]
             SearchSorted { side, descending } => {
@@ -1264,6 +1284,10 @@ impl FunctionExpr {
             F::IndexOf => {
                 FunctionOptions::aggregation().with_casting_rules(CastingRules::FirstArgLossless)
             },
+            #[cfg(feature = "index_of")]
+            F::IndexOfFirstNotNull => FunctionOptions::aggregation(),
+            #[cfg(feature = "index_of")]
+            F::IndexOfLastNotNull => FunctionOptions::aggregation(),
             #[cfg(feature = "search_sorted")]
             F::SearchSorted { .. } => FunctionOptions::groupwise().with_supertyping(
                 (SuperTypeFlags::default() & !SuperTypeFlags::ALLOW_PRIMITIVE_TO_STRING).into(),

--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -48,6 +48,10 @@ impl FunctionExpr {
             ArgWhere => mapper.with_dtype(IDX_DTYPE),
             #[cfg(feature = "index_of")]
             IndexOf => mapper.with_dtype(IDX_DTYPE),
+            #[cfg(feature = "index_of")]
+            IndexOfFirstNotNull => mapper.with_dtype(IDX_DTYPE),
+            #[cfg(feature = "index_of")]
+            IndexOfLastNotNull => mapper.with_dtype(IDX_DTYPE),
             #[cfg(feature = "search_sorted")]
             SearchSorted { .. } => mapper.with_dtype(IDX_DTYPE),
             #[cfg(feature = "range")]

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -374,6 +374,18 @@ impl Expr {
         self.map_binary(FunctionExpr::IndexOf, element.into())
     }
 
+    #[cfg(feature = "index_of")]
+    /// Find the index of the first non-null value.
+    pub fn index_of_first_not_null(self) -> Expr {
+        self.map_unary(FunctionExpr::IndexOfFirstNotNull)
+    }
+
+    #[cfg(feature = "index_of")]
+    /// Find the index of the last non-null value.
+    pub fn index_of_last_not_null(self) -> Expr {
+        self.map_unary(FunctionExpr::IndexOfLastNotNull)
+    }
+
     #[cfg(feature = "search_sorted")]
     /// Find indices where elements should be inserted to maintain order.
     pub fn search_sorted<E: Into<Expr>>(

--- a/crates/polars-python/src/expr/general.rs
+++ b/crates/polars-python/src/expr/general.rs
@@ -327,6 +327,16 @@ impl PyExpr {
         self.inner.clone().index_of(element.inner).into()
     }
 
+    #[cfg(feature = "index_of")]
+    fn index_of_first_not_null(&self) -> Self {
+        self.inner.clone().index_of_first_not_null().into()
+    }
+
+    #[cfg(feature = "index_of")]
+    fn index_of_last_not_null(&self) -> Self {
+        self.inner.clone().index_of_last_not_null().into()
+    }
+
     #[cfg(feature = "search_sorted")]
     #[pyo3(signature = (element, side, descending=false))]
     fn search_sorted(&self, element: Self, side: Wrap<SearchSortedSide>, descending: bool) -> Self {

--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -1055,6 +1055,10 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                 FunctionExpr::ArgWhere => ("argwhere",).into_py_any(py),
                 #[cfg(feature = "index_of")]
                 FunctionExpr::IndexOf => ("index_of",).into_py_any(py),
+                #[cfg(feature = "index_of")]
+                FunctionExpr::IndexOfFirstNotNull => ("index_of_first_not_null",).into_py_any(py),
+                #[cfg(feature = "index_of")]
+                FunctionExpr::IndexOfLastNotNull => ("index_of_last_not_null",).into_py_any(py),
                 #[cfg(feature = "search_sorted")]
                 FunctionExpr::SearchSorted { side, descending } => (
                     "search_sorted",

--- a/crates/polars-python/src/series/general.rs
+++ b/crates/polars-python/src/series/general.rs
@@ -152,6 +152,16 @@ impl PySeries {
         self.get_index(py, index)
     }
 
+    #[cfg(feature = "index_of")]
+    fn index_of_first_not_null(&self) -> Option<usize> {
+        self.series.index_of_first_not_null()
+    }
+
+    #[cfg(feature = "index_of")]
+    fn index_of_last_not_null(&self) -> Option<usize> {
+        self.series.index_of_last_not_null()
+    }
+
     fn bitand(&self, py: Python<'_>, other: &PySeries) -> PyResult<Self> {
         py.enter_polars_series(|| &self.series & &other.series)
     }

--- a/py-polars/docs/source/reference/expressions/computation.rst
+++ b/py-polars/docs/source/reference/expressions/computation.rst
@@ -43,6 +43,8 @@ Computation
     Expr.hash
     Expr.hist
     Expr.index_of
+    Expr.index_of_first_not_null
+    Expr.index_of_last_not_null
     Expr.kurtosis
     Expr.log
     Expr.log10

--- a/py-polars/docs/source/reference/series/computation.rst
+++ b/py-polars/docs/source/reference/series/computation.rst
@@ -7,6 +7,7 @@ Computation
    :toctree: api/
 
     Series.abs
+    Series.approx_n_unique
     Series.arccos
     Series.arccosh
     Series.arcsin
@@ -15,7 +16,6 @@ Computation
     Series.arctanh
     Series.arg_true
     Series.arg_unique
-    Series.approx_n_unique
     Series.bitwise_count_ones
     Series.bitwise_count_zeros
     Series.bitwise_leading_ones
@@ -47,6 +47,8 @@ Computation
     Series.hash
     Series.hist
     Series.index_of
+    Series.index_of_first_not_null
+    Series.index_of_last_not_null
     Series.is_between
     Series.kurtosis
     Series.last

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2376,6 +2376,11 @@ class Expr:
         element
             Value to find.
 
+        See Also
+        --------
+        index_of_first_not_null : Get the index of the first value that is not null.
+        index_of_last_not_null : Get the index of the last value that is not null.
+
         Examples
         --------
         >>> df = pl.DataFrame({"a": [1, None, 17]})
@@ -2397,6 +2402,68 @@ class Expr:
         """
         element = parse_into_expression(element, str_as_lit=True)
         return self._from_pyexpr(self._pyexpr.index_of(element))
+
+    def index_of_first_not_null(self) -> Expr:
+        """
+        Get the index of the first value that is not null.
+
+        See Also
+        --------
+        index_of : Get the index of the first occurrence of a value.
+        index_of_last_not_null : Get the index of the last value that is not null.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": [None, 10.5, 25.0],
+        ...         "b": [None, None, "zz"],
+        ...         "c": [9999, 8888, 7777],
+        ...         "d": [None, None, None],
+        ...     }
+        ... )
+        >>> df.select(pl.all().index_of_first_not_null())
+        shape: (1, 4)
+        ┌─────┬─────┬─────┬──────┐
+        │ a   ┆ b   ┆ c   ┆ d    │
+        │ --- ┆ --- ┆ --- ┆ ---  │
+        │ u32 ┆ u32 ┆ u32 ┆ u32  │
+        ╞═════╪═════╪═════╪══════╡
+        │ 1   ┆ 2   ┆ 0   ┆ null │
+        └─────┴─────┴─────┴──────┘
+        """
+        return self._from_pyexpr(self._pyexpr.index_of_first_not_null())
+
+    def index_of_last_not_null(self) -> Expr:
+        """
+        Get the index of the last value that is not null.
+
+        See Also
+        --------
+        index_of : Get the index of the first occurrence of a value.
+        index_of_first_not_null : Get the index of the first value that is not null.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": [-5.0, 10.5, None],
+        ...         "b": ["xx", None, None],
+        ...         "c": [9999, 8888, 7777],
+        ...         "d": [None, None, None],
+        ...     }
+        ... )
+        >>> df.select(pl.all().index_of_last_not_null())
+        shape: (1, 4)
+        ┌─────┬─────┬─────┬──────┐
+        │ a   ┆ b   ┆ c   ┆ d    │
+        │ --- ┆ --- ┆ --- ┆ ---  │
+        │ u32 ┆ u32 ┆ u32 ┆ u32  │
+        ╞═════╪═════╪═════╪══════╡
+        │ 1   ┆ 0   ┆ 2   ┆ null │
+        └─────┴─────┴─────┴──────┘
+        """
+        return self._from_pyexpr(self._pyexpr.index_of_last_not_null())
 
     def search_sorted(
         self,

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -2556,8 +2556,9 @@ class ExprStringNameSpace:
         Replace many patterns by passing sequences of equal length to the `patterns` and
         `replace_with` parameters.
 
-        >>> _ = pl.Config.set_fmt_str_lengths(100)
-        >>> _ = pl.Config.set_tbl_width_chars(110)
+        >>> pl.Config(
+        ...     fmt_str_lengths=100, tbl_width_chars=110
+        ... )  # doctest: +IGNORE_RESULT
         >>> df = pl.DataFrame(
         ...     {
         ...         "lyrics": [
@@ -2589,7 +2590,7 @@ class ExprStringNameSpace:
         Broadcast a replacement for many patterns by passing a string or a sequence of
         length 1 to the `replace_with` parameter.
 
-        >>> _ = pl.Config.set_fmt_str_lengths(100)
+        >>> pl.Config.set_fmt_str_lengths(100)  # doctest: +IGNORE_RESULT
         >>> df = pl.DataFrame(
         ...     {
         ...         "lyrics": [
@@ -2602,27 +2603,28 @@ class ExprStringNameSpace:
         >>> df.with_columns(
         ...     pl.col("lyrics")
         ...     .str.replace_many(
-        ...         ["me", "you", "they"],
-        ...         "",
+        ...         ["me ", "you ", "they "],
+        ...         ["", "", ""],
         ...     )
         ...     .alias("removes_pronouns")
         ... )
         shape: (3, 2)
-        ┌────────────────────────────────────────────────────┬────────────────────────────────────────────┐
-        │ lyrics                                             ┆ removes_pronouns                           │
-        │ ---                                                ┆ ---                                        │
-        │ str                                                ┆ str                                        │
-        ╞════════════════════════════════════════════════════╪════════════════════════════════════════════╡
-        │ Everybody wants to rule the world                  ┆ Everybody wants to rule the world          │
-        │ Tell me what you want, what you really really want ┆ Tell  what  want, what  really really want │
-        │ Can you feel the love tonight                      ┆ Can  feel the love tonight                 │
-        └────────────────────────────────────────────────────┴────────────────────────────────────────────┘
+        ┌────────────────────────────────────────────────────┬─────────────────────────────────────────┐
+        │ lyrics                                             ┆ removes_pronouns                        │
+        │ ---                                                ┆ ---                                     │
+        │ str                                                ┆ str                                     │
+        ╞════════════════════════════════════════════════════╪═════════════════════════════════════════╡
+        │ Everybody wants to rule the world                  ┆ Everybody wants to rule the world       │
+        │ Tell me what you want, what you really really want ┆ Tell what want, what really really want │
+        │ Can you feel the love tonight                      ┆ Can feel the love tonight               │
+        └────────────────────────────────────────────────────┴─────────────────────────────────────────┘
 
         Passing a mapping with patterns and replacements is also supported as syntactic
         sugar.
 
-        >>> _ = pl.Config.set_fmt_str_lengths(100)
-        >>> _ = pl.Config.set_tbl_width_chars(110)
+        >>> pl.Config(
+        ...     fmt_str_lengths=100, tbl_width_chars=110
+        ... )  # doctest: +IGNORE_RESULT
         >>> df = pl.DataFrame(
         ...     {
         ...         "lyrics": [

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4007,7 +4007,7 @@ class Series:
         --------
         >>> s = pl.Series("a", [1, 2, 3])
         >>> s2 = pl.Series("b", [2, 4, None])
-        >>> s2.is_in(s)
+        >>> s2.is_in(s.to_list())
         shape: (3,)
         Series: 'b' [bool]
         [
@@ -4016,7 +4016,7 @@ class Series:
                 null
         ]
         >>> # when nulls_equal=True, None is treated as a distinct value
-        >>> s2.is_in(s, nulls_equal=True)
+        >>> s2.is_in(s.to_list(), nulls_equal=True)
         shape: (3,)
         Series: 'b' [bool]
         [
@@ -5019,6 +5019,11 @@ class Series:
         element
             Value to find.
 
+        See Also
+        --------
+        index_of_first_not_null : Get the index of the first value that is not null.
+        index_of_last_not_null : Get the index of the last value that is not null.
+
         Examples
         --------
         >>> s = pl.Series("a", [1, None, 17])
@@ -5030,6 +5035,52 @@ class Series:
         True
         """
         return F.select(F.lit(self).index_of(element)).item()
+
+    def index_of_first_not_null(self) -> Expr:
+        """
+        Get the index of the first value that is not null.
+
+        See Also
+        --------
+        index_of : Get the index of the first occurrence of a value.
+        index_of_last_not_null : Get the index of the last value that is not null.
+
+        Examples
+        --------
+        >>> s = pl.Series([None, "zz", None, None])
+        >>> s.index_of_first_not_null()
+        1
+        >>> s = pl.Series([9999, 8888, 7777, 6666])
+        >>> s.index_of_first_not_null()
+        0
+        >>> s = pl.Series([None, None, None, None])
+        >>> s.index_of_first_not_null() is None
+        True
+        """
+        return self._s.index_of_first_not_null()
+
+    def index_of_last_not_null(self) -> Expr:
+        """
+        Get the index of the last value that is not null.
+
+        See Also
+        --------
+        index_of : Get the index of the first occurrence of a value.
+        index_of_first_not_null : Get the index of the first value that is not null.
+
+        Examples
+        --------
+        >>> s = pl.Series([None, None, "zz", None])
+        >>> s.index_of_last_not_null()
+        2
+        >>> s = pl.Series([9999, 8888, 7777, 6666])
+        >>> s.index_of_last_not_null()
+        3
+        >>> s = pl.Series([None, None, None, None])
+        >>> s.index_of_last_not_null() is None
+        True
+        """
+        return self._s.index_of_last_not_null()
 
     def clear(self, n: int = 0) -> Series:
         """

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -1959,7 +1959,7 @@ class StringNameSpace:
         Replace many patterns by passing lists of equal length to the `patterns` and
         `replace_with` parameters.
 
-        >>> _ = pl.Config.set_fmt_str_lengths(100)
+        >>> pl.Config.set_fmt_str_lengths(100)  # doctest: +IGNORE_RESULT
         >>> s = pl.Series(
         ...     "lyrics",
         ...     [
@@ -1980,7 +1980,7 @@ class StringNameSpace:
         Broadcast a replacement for many patterns by passing a string or a sequence of
         length 1 to the `replace_with` parameter.
 
-        >>> _ = pl.Config.set_fmt_str_lengths(100)
+        >>> pl.Config.set_fmt_str_lengths(100)  # doctest: +IGNORE_RESULT
         >>> s = pl.Series(
         ...     "lyrics",
         ...     [
@@ -1989,19 +1989,19 @@ class StringNameSpace:
         ...         "Can you feel the love tonight",
         ...     ],
         ... )
-        >>> s.str.replace_many(["me", "you", "they"], "")
+        >>> s.str.replace_many(["me ", "you ", "they "], ["", "", ""])
         shape: (3,)
         Series: 'lyrics' [str]
         [
             "Everybody wants to rule the world"
-            "Tell  what  want, what  really really want"
-            "Can  feel the love tonight"
+            "Tell what want, what really really want"
+            "Can feel the love tonight"
         ]
 
         Passing a mapping with patterns and replacements is also supported as syntactic
         sugar.
 
-        >>> _ = pl.Config.set_fmt_str_lengths(100)
+        >>> pl.Config.set_fmt_str_lengths(100)  # doctest: +IGNORE_RESULT
         >>> s = pl.Series(
         ...     "lyrics",
         ...     [


### PR DESCRIPTION
## New Expr/Series Methods

* `.index_of_first_not_null()`: returns the index of the *first* value that is *not* null. 
* `.index_of_last_not_null()`: returns the index of the *last* value that is *not* null. 

The first can be constructed from existing expressions as `.is_not_null().arg_max()`, but has an edge case (if _all_ values are null it will return 0 instead of None). The second doesn't have an obvious/clean clean construction (arguably the first isn't _that_ obvious). We can get faster performance (and be clearer, and correct in _all_ cases) with dedicated functionality.

## 🚀 Core Performance Optimisations 

_Moved to a separate PR (#22897) while we decide on the API here._

---

## 🕐 Timings (vs Pandas) 

### Setup

Create some 10,000,000 element `Series` with different characteristics...
**Note:** equivalent Pandas methods are `first_valid_index`[^1] and `last_valid_index`[^2].

```python
import polars as pl

# all null
s1 = pl.Series([None], dtype=pl.Int64).extend_constant(None, 9_999_999)

# all not-null
s2 = pl.Series(range(10_000_000), dtype=pl.Int64)

# only the first value is null
s3 = pl.Series([None], dtype=pl.Int64).extend_constant(0, 9_999_999)

# only the last value is null
s4 = pl.Series(range(9_999_999), dtype=pl.Int64).extend_constant(None, 1)

# only non-null value is halfway through
s5 = (
    pl.Series([None], dtype=pl.Int64)
      .extend_constant(None, 4_999_998)
      .extend_constant(1, 1)
      .extend_constant(None, 5_000_000)
)
for s in (s1, s2, s3, s4, s5):
    ps = s.to_pandas()
    
    %timeit ps.first_valid_index()
    %timeit s.index_of_first_not_null()
    %timeit ps.last_valid_index()
    %timeit s.index_of_last_not_null()
```

### Results

You can see that for the first four series we have _really_ good fast-paths, executing in nanoseconds where Pandas takes milliseconds; only the final Series requires any real work, and there we are still ~100x faster on 10,000,000 elements.

series | operation  | pandas (ns) | polars (ns) | speedup
-- | -- | -- | -- | --
s1 | first not null | 1,380,000 | 45.5 | 30,330x
s1 | last not null | 4,090,000 | 46.8 | 87,393x
s2 | first not null | 2,650,000 | 44.9 | 59,020x
s2 | last not null | 2,960,000 | 52.2 | 56,705x
s3 | first not null | 1,290,000 | 55.9 | 23,077x
s3 | last not null | 4,450,000 | 60.9 | 73,071x
s4 | first not null | 1,340,000 | 55.8 | 24,014x
s4 | last not null | 4,160,000 | 61.1 | 68,085x
s5 | first not null | 1,400,000 | 21,600 | 65x
s5 | last not null | 4,320,000 | 25,400 | 170x

_**Test machine:** Apple Silicon M3 Max._
_Results normalised to nanoseconds; Pandas was reporting in `ms`, and Polars `μs`,`ns`._

## Unit Tests

Added lots of new test coverage, both  for the new functions and for `index_of` and `arg_max`, since they have new fast-paths. Includes a parametric test (which I ran for 10s of thousands of iterations before committing, just to be on the safe side ;)

[^1]: [pandas.DataFrame.first_valid_index](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.first_valid_index.html)
[^2]: [pandas.DataFrame.last_valid_index](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.last_valid_index.html)