### PR TITLE
fix: Correct `int_ranges` to raise error on invalid inputs

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -105,7 +105,7 @@ pub use self::cat::CategoricalFunction;
 pub use self::datetime::TemporalFunction;
 pub use self::pow::PowFunction;
 #[cfg(feature = "range")]
-pub(super) use self::range::RangeFunction;
+pub use self::range::RangeFunction;
 #[cfg(feature = "rolling_window")]
 pub(super) use self::rolling::RollingFunction;
 #[cfg(feature = "rolling_window_by")]

--- a/crates/polars-plan/src/dsl/function_expr/range/int_range.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range/int_range.rs
@@ -47,9 +47,9 @@ pub(super) fn int_ranges(s: &[Column]) -> PolarsResult<Column> {
     let end = &s[1];
     let step = &s[2];
 
-    let start = start.cast(&DataType::Int64)?;
-    let end = end.cast(&DataType::Int64)?;
-    let step = step.cast(&DataType::Int64)?;
+    let start = start.strict_cast(&DataType::Int64)?;
+    let end = end.strict_cast(&DataType::Int64)?;
+    let step = step.strict_cast(&DataType::Int64)?;
 
     let start = start.i64()?;
     let end = end.i64()?;

--- a/crates/polars-plan/src/dsl/function_expr/range/int_range.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range/int_range.rs
@@ -7,22 +7,16 @@ use super::utils::{ensure_range_bounds_contain_exactly_one_value, numeric_ranges
 const CAPACITY_FACTOR: usize = 5;
 
 pub(super) fn int_range(s: &[Column], step: i64, dtype: DataType) -> PolarsResult<Column> {
-    let mut start = &s[0];
-    let mut end = &s[1];
+    let start = &s[0];
+    let end = &s[1];
     let name = start.name();
 
     ensure_range_bounds_contain_exactly_one_value(start, end)?;
-    polars_ensure!(dtype.is_integer(), ComputeError: "non-integer `dtype` passed to `int_range`: {:?}", dtype);
 
-    let (start_storage, end_storage);
-    if *start.dtype() != dtype {
-        start_storage = start.strict_cast(&dtype)?;
-        start = &start_storage;
-    }
-    if *end.dtype() != dtype {
-        end_storage = end.strict_cast(&dtype)?;
-        end = &end_storage;
-    }
+    // Done by type coercion
+    assert!(dtype.is_integer());
+    assert_eq!(start.dtype(), &dtype);
+    assert_eq!(end.dtype(), &dtype);
 
     with_match_physical_integer_polars_type!(dtype, |$T| {
         let start_v = get_first_series_value::<$T>(start)?;
@@ -46,10 +40,6 @@ pub(super) fn int_ranges(s: &[Column]) -> PolarsResult<Column> {
     let start = &s[0];
     let end = &s[1];
     let step = &s[2];
-
-    let start = start.strict_cast(&DataType::Int64)?;
-    let end = end.strict_cast(&DataType::Int64)?;
-    let step = step.strict_cast(&DataType::Int64)?;
 
     let start = start.i64()?;
     let end = end.i64()?;

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -720,7 +720,7 @@ See https://github.com/pola-rs/polars/issues/22149 for more information."
 
                 if [&type_start, &type_end]
                     .into_iter()
-                    .all(|arg_dtype| arg_dtype != dtype)
+                    .all(|arg_dtype| arg_dtype == dtype)
                 {
                     return Ok(None);
                 }
@@ -769,7 +769,7 @@ See https://github.com/pola-rs/polars/issues/22149 for more information."
 
                 if [&type_start, &type_end, &type_step]
                     .into_iter()
-                    .all(|dtype| dtype != &DataType::Int64)
+                    .all(|dtype| dtype == &DataType::Int64)
                 {
                     return Ok(None);
                 }

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -763,7 +763,7 @@ See https://github.com/pola-rs/polars/issues/22149 for more information."
                 ));
                 let (_, type_step) = unpack!(get_aexpr_and_type(
                     expr_arena,
-                    input[1].node(),
+                    input[2].node(),
                     &input_schema
                 ));
 

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -697,6 +697,101 @@ See https://github.com/pola-rs/polars/issues/22149 for more information."
 
                 None
             },
+            #[cfg(feature = "range")]
+            AExpr::Function {
+                function:
+                    ref function @ FunctionExpr::Range(RangeFunction::IntRange { step: _, ref dtype }),
+                ref input,
+                options,
+            } => {
+                polars_ensure!(dtype.is_integer(), ComputeError: "non-integer `dtype` passed to `int_range`: {:?}", dtype);
+
+                let input_schema = get_schema(lp_arena, lp_node);
+                let (_, type_start) = unpack!(get_aexpr_and_type(
+                    expr_arena,
+                    input[0].node(),
+                    &input_schema
+                ));
+                let (_, type_end) = unpack!(get_aexpr_and_type(
+                    expr_arena,
+                    input[1].node(),
+                    &input_schema
+                ));
+
+                if [&type_start, &type_end]
+                    .into_iter()
+                    .all(|arg_dtype| arg_dtype != dtype)
+                {
+                    return Ok(None);
+                }
+
+                let function = function.clone();
+                let dtype = dtype.clone();
+                let mut input = input.clone();
+                for (i, arg_dtype) in [type_start, type_end].into_iter().enumerate() {
+                    cast_expr_ir(
+                        &mut input[i],
+                        &arg_dtype,
+                        &dtype,
+                        expr_arena,
+                        CastOptions::Strict,
+                    )?;
+                }
+
+                Some(AExpr::Function {
+                    function,
+                    input,
+                    options,
+                })
+            },
+            #[cfg(feature = "range")]
+            AExpr::Function {
+                function: ref function @ FunctionExpr::Range(RangeFunction::IntRanges),
+                ref input,
+                options,
+            } => {
+                let input_schema = get_schema(lp_arena, lp_node);
+                let (_, type_start) = unpack!(get_aexpr_and_type(
+                    expr_arena,
+                    input[0].node(),
+                    &input_schema
+                ));
+                let (_, type_end) = unpack!(get_aexpr_and_type(
+                    expr_arena,
+                    input[1].node(),
+                    &input_schema
+                ));
+                let (_, type_step) = unpack!(get_aexpr_and_type(
+                    expr_arena,
+                    input[1].node(),
+                    &input_schema
+                ));
+
+                if [&type_start, &type_end, &type_step]
+                    .into_iter()
+                    .all(|dtype| dtype != &DataType::Int64)
+                {
+                    return Ok(None);
+                }
+
+                let function = function.clone();
+                let mut input = input.clone();
+                for (i, dtype) in [type_start, type_end, type_step].into_iter().enumerate() {
+                    cast_expr_ir(
+                        &mut input[i],
+                        &dtype,
+                        &DataType::Int64,
+                        expr_arena,
+                        CastOptions::Strict,
+                    )?;
+                }
+
+                Some(AExpr::Function {
+                    function,
+                    input,
+                    options,
+                })
+            },
             AExpr::Slice { offset, length, .. } => {
                 let input_schema = get_schema(lp_arena, lp_node);
                 let (_, offset_dtype) =

--- a/py-polars/tests/unit/functions/range/test_int_range.py
+++ b/py-polars/tests/unit/functions/range/test_int_range.py
@@ -278,3 +278,17 @@ def test_int_ranges_non_int_dtype() -> None:
         ComputeError, match="non-integer `dtype` passed to `int_ranges`: String"
     ):
         pl.int_ranges(0, 3, dtype=pl.String, eager=True)  # type: ignore[arg-type]
+
+# https://github.com/pola-rs/polars/issues/22640
+def test_int_ranges_non_numeric_input_should_error() -> None:
+    df = pl.DataFrame(
+        {
+            "start": ["a", "b"],
+            "end": ["c", "d"],
+        }
+    )
+
+    with pytest.raises(pl.exceptions.InvalidOperationError) as excinfo:
+        _ = df.select(pl.int_ranges("start", "end"))
+
+    assert "conversion from `str` to `i64` failed" in str(excinfo.value)

--- a/py-polars/tests/unit/functions/range/test_int_range.py
+++ b/py-polars/tests/unit/functions/range/test_int_range.py
@@ -279,6 +279,7 @@ def test_int_ranges_non_int_dtype() -> None:
     ):
         pl.int_ranges(0, 3, dtype=pl.String, eager=True)  # type: ignore[arg-type]
 
+
 # https://github.com/pola-rs/polars/issues/22640
 def test_int_ranges_non_numeric_input_should_error() -> None:
     df = pl.DataFrame(

--- a/py-polars/tests/unit/functions/range/test_int_range.py
+++ b/py-polars/tests/unit/functions/range/test_int_range.py
@@ -210,7 +210,7 @@ def test_int_range_null_input() -> None:
 
 def test_int_range_invalid_conversion() -> None:
     with pytest.raises(
-        InvalidOperationError, match="conversion from `i32` to `u32` failed"
+        InvalidOperationError, match="conversion from `i128` to `u32` failed"
     ):
         pl.select(pl.int_range(3, -1, -1, dtype=pl.UInt32))
 


### PR DESCRIPTION
As mentioned in https://github.com/pola-rs/polars/issues/22640, `int_ranges` would silently cast non-integer inputs to null.

By doing a `strict_cast`, we ensure that output message throws correctly indicating an invalid input. 

## Rationale

The `strict_cast` is ideal in this scenario because any unrepresentable value will have been set to null which would trigger a polars error. 

## Changes

- [x] Modified underlying `.rs` file (Python API unaffected) 

## Testing Done

- [x] Added Example Test
- [x] Checked all previously passing tests still pass via `make test`