### PR TITLE
fix(rust): Fix cum_min and cum_max does not preserve inf or -inf values at series start

### DIFF
--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -57,6 +57,15 @@ def test_cum_agg_with_nulls() -> None:
     assert_series_equal(s.cum_prod(), pl.Series("a", [None, 2, None, 14, 112, None]))
 
 
+def test_cum_agg_with_infs() -> None:
+    # confirm that inf values are handled correctly
+    s = pl.Series([float("inf"), 0.0, 1.0])
+    assert_series_equal(s.cum_min(), pl.Series([float("inf"), 0.0, 0.0]))
+
+    s = pl.Series([float("-inf"), 0.0, 1.0])
+    assert_series_equal(s.cum_max(), pl.Series([float("-inf"), 0.0, 1.0]))
+
+
 def test_cum_min_max_bool() -> None:
     s = pl.Series("a", [None, True, True, None, False, None, True, False, False, None])
     assert_series_equal(s.cum_min().cast(pl.Int32), s.cast(pl.Int32).cum_min())


### PR DESCRIPTION
## What’s Changed
Separate float implementations for cum_min / cum_max

Added two new functions, cum_min_float and cum_max_float, that are specialized for f32/f64.

These initialize the running accumulator to T::Native::INFINITY (for cum_min) and T::Native::NEG_INFINITY (for cum_max), so that an initial Inf or -Inf value is handled correctly, rather than being clamped to 1.7977e308.

Also added NaN-aware comparisons from polars_utils::min_max::MinMax. This ensures that NaN values in the series do not break the cumulative aggregation.

## Added Test
```python
def test_cum_agg_with_infs() -> None:
    # confirm that inf values are handled correctly
    s = pl.Series([float("inf"), 0.0, 1.0])
    assert_series_equal(s.cum_min(), pl.Series([float("inf"), 0.0, 0.0]))

    s = pl.Series([float("-inf"), 0.0, 1.0])
    assert_series_equal(s.cum_max(), pl.Series([float("-inf"), 0.0, 1.0]))
```
Would close the issue #22855 
