### PR TITLE
perf: Optimise low-level `null` scans and `arg_max` for bools (when chunked)

### DIFF
--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -10,7 +10,6 @@ mod schema;
 
 pub use any_value::*;
 use arrow::bitmap::Bitmap;
-use arrow::bitmap::bitmask::BitMask;
 pub use arrow::legacy::utils::*;
 pub use arrow::trusted_len::TrustMyLength;
 use flatten::*;
@@ -1200,43 +1199,44 @@ pub(crate) fn index_to_chunked_index_rev<
     )
 }
 
-pub(crate) fn first_non_null<'a, I>(iter: I) -> Option<usize>
+pub fn first_non_null<'a, I>(iter: I) -> Option<usize>
 where
     I: Iterator<Item = Option<&'a Bitmap>>,
 {
-    let mut offset = 0;
+    let mut index = 0;
     for validity in iter {
-        if let Some(validity) = validity {
-            let mask = BitMask::from_bitmap(validity);
-            if let Some(n) = mask.nth_set_bit_idx(0, 0) {
-                return Some(offset + n);
+        if let Some(mask) = validity {
+            let len_mask = mask.len();
+            let n = mask.leading_zeros();
+            if n < len_mask {
+                return Some(index + n);
             }
-            offset += validity.len()
+            index += len_mask
         } else {
-            return Some(offset);
+            return Some(index);
         }
     }
     None
 }
 
-pub(crate) fn last_non_null<'a, I>(iter: I, len: usize) -> Option<usize>
+pub fn last_non_null<'a, I>(iter: I, len: usize) -> Option<usize>
 where
     I: DoubleEndedIterator<Item = Option<&'a Bitmap>>,
 {
     if len == 0 {
         return None;
     }
-    let mut offset = 0;
+    let mut index = 0;
     for validity in iter.rev() {
-        if let Some(validity) = validity {
-            let mask = BitMask::from_bitmap(validity);
-            if let Some(n) = mask.nth_set_bit_idx_rev(0, mask.len()) {
-                let mask_start = len - offset - mask.len();
-                return Some(mask_start + n);
+        if let Some(mask) = validity {
+            let len_mask = mask.len();
+            let n = mask.trailing_zeros();
+            if n < len_mask {
+                return Some(len - index - n - 1);
             }
-            offset += validity.len()
+            index += len_mask;
         } else {
-            return Some(len - 1 - offset);
+            return Some(len - index - 1);
         }
     }
     None

--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -1203,17 +1203,17 @@ pub fn first_non_null<'a, I>(iter: I) -> Option<usize>
 where
     I: Iterator<Item = Option<&'a Bitmap>>,
 {
-    let mut index = 0;
+    let mut offset = 0;
     for validity in iter {
         if let Some(mask) = validity {
             let len_mask = mask.len();
             let n = mask.leading_zeros();
             if n < len_mask {
-                return Some(index + n);
+                return Some(offset + n);
             }
-            index += len_mask
+            offset += len_mask
         } else {
-            return Some(index);
+            return Some(offset);
         }
     }
     None
@@ -1226,17 +1226,17 @@ where
     if len == 0 {
         return None;
     }
-    let mut index = 0;
+    let mut offset = 0;
     for validity in iter.rev() {
         if let Some(mask) = validity {
             let len_mask = mask.len();
             let n = mask.trailing_zeros();
             if n < len_mask {
-                return Some(len - index - n - 1);
+                return Some(len - offset - n - 1);
             }
-            index += len_mask;
+            offset += len_mask;
         } else {
-            return Some(len - index - 1);
+            return Some(len - offset - 1);
         }
     }
     None

--- a/crates/polars-ops/src/series/ops/index_of.rs
+++ b/crates/polars-ops/src/series/ops/index_of.rs
@@ -80,6 +80,12 @@ pub fn index_of(series: &Series, needle: Scalar) -> PolarsResult<Option<usize>> 
 
     // Series is not null, and the value is null:
     if needle.is_null() {
+        let null_count = series.null_count();
+        if null_count == 0 {
+            return Ok(None);
+        } else if null_count == series.len() {
+            return Ok(Some(0));
+        }
         let mut index = 0;
         for chunk in series.chunks() {
             let length = chunk.len();

--- a/py-polars/tests/unit/operations/test_index_of.py
+++ b/py-polars/tests/unit/operations/test_index_of.py
@@ -11,10 +11,11 @@ from hypothesis import strategies as st
 
 import polars as pl
 from polars.exceptions import InvalidOperationError
+from polars.testing import assert_frame_equal
+from polars.testing.parametric import series
 
 if TYPE_CHECKING:
     from polars._typing import IntoExpr
-from polars.testing import assert_frame_equal
 
 
 def isnan(value: object) -> bool:
@@ -351,3 +352,14 @@ def test_categorical(convert_to_literal: bool) -> None:
     ]:
         for value in expected_values:
             assert_index_of(s, value, convert_to_literal=convert_to_literal)
+
+
+@given(s=series(name="s", allow_chunks=True, max_size=10))
+def test_index_of_null_parametric(s: pl.Series) -> None:
+    idx_null = s.index_of(None)
+    if s.len() == 0:
+        assert idx_null is None
+    elif s.null_count() == 0:
+        assert idx_null is None
+    elif s.null_count() == len(s):
+        assert idx_null == 0

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1437,18 +1437,16 @@ def test_arg_sort() -> None:
         (pl.Series(["c", "b", "a"], dtype=pl.Categorical), 0, 2),
         (pl.Series([None, "c", "b", None, "a"], dtype=pl.Categorical), 1, 4),
         (pl.Series(["c", "b", "a"], dtype=pl.Categorical(ordering="lexical")), 2, 0),
-        (
-            pl.Series(
-                [None, "c", "b", None, "a"], dtype=pl.Categorical(ordering="lexical")
-            ),
-            4,
-            1,
-        ),
+        (pl.Series("s", [None, "c", "b", None, "a"], pl.Categorical("lexical")), 4, 1),
     ],
 )
 def test_arg_min_arg_max(series: pl.Series, argmin: int, argmax: int) -> None:
-    assert series.arg_min() == argmin
-    assert series.arg_max() == argmax
+    assert series.arg_min() == argmin, (
+        f"values: {series.to_list()}, expected {argmin} got {series.arg_min()}"
+    )
+    assert series.arg_max() == argmax, (
+        f"values: {series.to_list()}, expected {argmax} got {series.arg_max()}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -2216,7 +2214,6 @@ def test_construction_large_nested_u64_17231() -> None:
 
     values = [{"f0": [9223372036854775808]}]
     dtype = pl.Struct({"f0": pl.List(pl.UInt64)})
-
     assert pl.Series(values, dtype=dtype).to_list() == values
 
 


### PR DESCRIPTION
## Optimisations 

Spotted some nice speedups for the lower-level `first_not_null` and `last_non_null` validity/bitmap scans while working on #22880; breaking them out as a standalone PR so we can take advantage while deciding on a better API for that one.

So, switching out the following offset calculations...
```rust
mask = BitMask::from_bitmap(validity) 
Some(n) = mask.nth_set_bit_idx(0, 0)               // first non-null
Some(n) = mask.nth_set_bit_idx_rev(0, mask.len())  // last non-null
```
...for (more or less)...
```rust
validity.leading_zeros() < validity.len()   // first non-null
validity.trailing_zeros() < validity.len()  // last non-null
```
...and adjusting the surrounding code slightly allows us to get the required result directly from the validity bitmap _without_ mediating via `BitMask` and `nth_set_bit_idx`.

### Speedup:

* These scans get about **3-5x** faster (measured by their impact on the performance of the first/last non-null index methods in the originating PR, as compiled with `build-dist-release`) 🚀

### Also:

* Generalised the single-chunk fast path in `arg_max_bool` to handle "n" chunks.
* Added some fast early-exit conditions for `.index_of(None)`, and an associated small parametric test to improve edge-case coverage.