### PR TITLE
ci: Add a CI check for the DSL schema

### DIFF
--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -145,3 +145,22 @@ jobs:
       - name: Check wasm
         working-directory: crates
         run: make check-wasm
+
+  check-dsl-schema:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        run: rustup show
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref_name == 'main' }}
+
+      - name: Build DSL schema check
+        run: cargo build --all-features
+
+      - name: Run DSL schema check
+        run: ./target/debug/dsl-schema check

--- a/.typos.toml
+++ b/.typos.toml
@@ -7,6 +7,7 @@ extend-exclude = [
   "**/images/*",
   "**/py-polars/polars/_utils/nest_asyncio.py",
   "*.nix",
+  "crates/polars-plan/dsl-schema.json",
 ]
 ignore-hidden = false
 

--- a/Makefile
+++ b/Makefile
@@ -137,13 +137,17 @@ fmt:  ## Run autoformatting and linting
 	cargo fmt --all
 	dprint fmt
 	$(VENV_BIN)/typos
-	
+
 .PHONY: fix
 fix:
-	cargo clippy --workspace --all-targets --all-features --fix 
+	cargo clippy --workspace --all-targets --all-features --fix
 	@# Good chance the fixing introduced formatting issues, best to just do a quick format.
 	cargo fmt --all
-	
+
+.PHONY: update-dsl-schema
+update-dsl-schema:  ## Update the DSL schema file
+	cargo build --all-features
+	./target/debug/dsl-schema update
 
 .PHONY: pre-commit
 pre-commit: fmt clippy clippy-default  ## Run all code quality checks

--- a/crates/polars-plan/Cargo.toml
+++ b/crates/polars-plan/Cargo.toml
@@ -3,6 +3,7 @@ name = "polars-plan"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+exclude = ["dsl-schema.json"]
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
@@ -111,6 +112,7 @@ extract_jsonpath = ["polars-ops/extract_jsonpath"]
 dsl-schema = [
   "dep:schemars",
   "dep:serde_json",
+  "serde_json/preserve_order",
   "serde",
   "arrow/dsl-schema",
   "polars-core/dsl-schema",

--- a/crates/polars-plan/dsl-schema.json
+++ b/crates/polars-plan/dsl-schema.json
@@ -1,0 +1,10761 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DslPlan",
+  "oneOf": [
+    {
+      "type": "object",
+      "required": [
+        "PythonScan"
+      ],
+      "properties": {
+        "PythonScan": {
+          "type": "object",
+          "required": [
+            "options"
+          ],
+          "properties": {
+            "options": {
+              "$ref": "#/definitions/PythonOptionsDsl"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "Filter"
+      ],
+      "properties": {
+        "Filter": {
+          "type": "object",
+          "required": [
+            "input",
+            "predicate"
+          ],
+          "properties": {
+            "input": {
+              "$ref": "#/definitions/DslPlan"
+            },
+            "predicate": {
+              "$ref": "#/definitions/Expr"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "Cache"
+      ],
+      "properties": {
+        "Cache": {
+          "type": "object",
+          "required": [
+            "id",
+            "input"
+          ],
+          "properties": {
+            "input": {
+              "$ref": "#/definitions/DslPlan"
+            },
+            "id": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "Scan"
+      ],
+      "properties": {
+        "Scan": {
+          "type": "object",
+          "required": [
+            "scan_type",
+            "sources",
+            "unified_scan_args"
+          ],
+          "properties": {
+            "sources": {
+              "$ref": "#/definitions/ScanSources"
+            },
+            "file_info": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/FileInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "unified_scan_args": {
+              "$ref": "#/definitions/UnifiedScanArgs"
+            },
+            "scan_type": {
+              "$ref": "#/definitions/FileScan"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "DataFrameScan"
+      ],
+      "properties": {
+        "DataFrameScan": {
+          "type": "object",
+          "required": [
+            "df",
+            "schema"
+          ],
+          "properties": {
+            "df": {
+              "$ref": "#/definitions/DataFrame"
+            },
+            "schema": {
+              "$ref": "#/definitions/Schema_for_DataType"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "Select"
+      ],
+      "properties": {
+        "Select": {
+          "type": "object",
+          "required": [
+            "expr",
+            "input",
+            "options"
+          ],
+          "properties": {
+            "expr": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Expr"
+              }
+            },
+            "input": {
+              "$ref": "#/definitions/DslPlan"
+            },
+            "options": {
+              "$ref": "#/definitions/ProjectionOptions"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "GroupBy"
+      ],
+      "properties": {
+        "GroupBy": {
+          "type": "object",
+          "required": [
+            "aggs",
+            "input",
+            "keys",
+            "maintain_order",
+            "options"
+          ],
+          "properties": {
+            "input": {
+              "$ref": "#/definitions/DslPlan"
+            },
+            "keys": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Expr"
+              }
+            },
+            "aggs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Expr"
+              }
+            },
+            "maintain_order": {
+              "type": "boolean"
+            },
+            "options": {
+              "$ref": "#/definitions/GroupbyOptions"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "Join"
+      ],
+      "properties": {
+        "Join": {
+          "type": "object",
+          "required": [
+            "input_left",
+            "input_right",
+            "left_on",
+            "options",
+            "predicates",
+            "right_on"
+          ],
+          "properties": {
+            "input_left": {
+              "$ref": "#/definitions/DslPlan"
+            },
+            "input_right": {
+              "$ref": "#/definitions/DslPlan"
+            },
+            "left_on": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Expr"
+              }
+            },
+            "right_on": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Expr"
+              }
+            },
+            "predicates": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Expr"
+              }
+            },
+            "options": {
+              "$ref": "#/definitions/JoinOptions"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "HStack"
+      ],
+      "properties": {
+        "HStack": {
+          "type": "object",
+          "required": [
+            "exprs",
+            "input",
+            "options"
+          ],
+          "properties": {
+            "input": {
+              "$ref": "#/definitions/DslPlan"
+            },
+            "exprs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Expr"
+              }
+            },
+            "options": {
+              "$ref": "#/definitions/ProjectionOptions"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "MatchToSchema"
+      ],
+      "properties": {
+        "MatchToSchema": {
+          "type": "object",
+          "required": [
+            "extra_columns",
+            "input",
+            "match_schema",
+            "per_column"
+          ],
+          "properties": {
+            "input": {
+              "$ref": "#/definitions/DslPlan"
+            },
+            "match_schema": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Schema_for_DataType"
+                }
+              ]
+            },
+            "per_column": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/MatchToSchemaPerColumn"
+              }
+            },
+            "extra_columns": {
+              "$ref": "#/definitions/ExtraColumnsPolicy"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "Distinct"
+      ],
+      "properties": {
+        "Distinct": {
+          "type": "object",
+          "required": [
+            "input",
+            "options"
+          ],
+          "properties": {
+            "input": {
+              "$ref": "#/definitions/DslPlan"
+            },
+            "options": {
+              "$ref": "#/definitions/DistinctOptionsDSL"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "Sort"
+      ],
+      "properties": {
+        "Sort": {
+          "type": "object",
+          "required": [
+            "by_column",
+            "input",
+            "sort_options"
+          ],
+          "properties": {
+            "input": {
+              "$ref": "#/definitions/DslPlan"
+            },
+            "by_column": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Expr"
+              }
+            },
+            "slice": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": [
+                {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            },
+            "sort_options": {
+              "$ref": "#/definitions/SortMultipleOptions"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "Slice"
+      ],
+      "properties": {
+        "Slice": {
+          "type": "object",
+          "required": [
+            "len",
+            "offset"
+          ],
+          "properties": {
+            "input": {
+              "$ref": "#/definitions/DslPlan"
+            },
+            "offset": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "len": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "MapFunction"
+      ],
+      "properties": {
+        "MapFunction": {
+          "type": "object",
+          "required": [
+            "function",
+            "input"
+          ],
+          "properties": {
+            "input": {
+              "$ref": "#/definitions/DslPlan"
+            },
+            "function": {
+              "$ref": "#/definitions/DslFunction"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "Union"
+      ],
+      "properties": {
+        "Union": {
+          "type": "object",
+          "required": [
+            "args",
+            "inputs"
+          ],
+          "properties": {
+            "inputs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/DslPlan"
+              }
+            },
+            "args": {
+              "$ref": "#/definitions/UnionArgs"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "HConcat"
+      ],
+      "properties": {
+        "HConcat": {
+          "type": "object",
+          "required": [
+            "inputs",
+            "options"
+          ],
+          "properties": {
+            "inputs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/DslPlan"
+              }
+            },
+            "options": {
+              "$ref": "#/definitions/HConcatOptions"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "ExtContext"
+      ],
+      "properties": {
+        "ExtContext": {
+          "type": "object",
+          "required": [
+            "contexts",
+            "input"
+          ],
+          "properties": {
+            "input": {
+              "$ref": "#/definitions/DslPlan"
+            },
+            "contexts": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/DslPlan"
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "Sink"
+      ],
+      "properties": {
+        "Sink": {
+          "type": "object",
+          "required": [
+            "input",
+            "payload"
+          ],
+          "properties": {
+            "input": {
+              "$ref": "#/definitions/DslPlan"
+            },
+            "payload": {
+              "$ref": "#/definitions/SinkType"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "SinkMultiple"
+      ],
+      "properties": {
+        "SinkMultiple": {
+          "type": "object",
+          "required": [
+            "inputs"
+          ],
+          "properties": {
+            "inputs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/DslPlan"
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "MergeSorted"
+      ],
+      "properties": {
+        "MergeSorted": {
+          "type": "object",
+          "required": [
+            "input_left",
+            "input_right",
+            "key"
+          ],
+          "properties": {
+            "input_left": {
+              "$ref": "#/definitions/DslPlan"
+            },
+            "input_right": {
+              "$ref": "#/definitions/DslPlan"
+            },
+            "key": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "IR"
+      ],
+      "properties": {
+        "IR": {
+          "type": "object",
+          "required": [
+            "dsl",
+            "version"
+          ],
+          "properties": {
+            "dsl": {
+              "$ref": "#/definitions/DslPlan"
+            },
+            "version": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "version": "5.0",
+  "definitions": {
+    "PythonOptionsDsl": {
+      "type": "object",
+      "required": [
+        "python_source",
+        "validate_schema"
+      ],
+      "properties": {
+        "scan_fn": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PythonObject"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "schema_fn": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Either_PythonObject_or_Schema_for_DataType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "python_source": {
+          "$ref": "#/definitions/PythonScanSource"
+        },
+        "validate_schema": {
+          "type": "boolean"
+        }
+      }
+    },
+    "PythonObject": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "format": "uint8",
+        "minimum": 0.0
+      }
+    },
+    "Either_PythonObject_or_Schema_for_DataType": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PythonObject"
+        },
+        {
+          "$ref": "#/definitions/Schema_for_DataType"
+        }
+      ]
+    },
+    "Schema_for_DataType": {
+      "type": "object",
+      "required": [
+        "fields"
+      ],
+      "properties": {
+        "fields": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/DataType"
+          }
+        }
+      }
+    },
+    "DataType": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Boolean",
+            "UInt8",
+            "UInt16",
+            "UInt32",
+            "UInt64",
+            "Int8",
+            "Int16",
+            "Int32",
+            "Int64",
+            "Int128",
+            "Float32",
+            "Float64",
+            "String",
+            "Binary",
+            "BinaryOffset",
+            "Null"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Date"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "Datetime"
+          ],
+          "properties": {
+            "Datetime": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/TimeUnit"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/TimeZone"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Duration"
+          ],
+          "properties": {
+            "Duration": {
+              "$ref": "#/definitions/TimeUnit"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Time"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "List"
+          ],
+          "properties": {
+            "List": {
+              "$ref": "#/definitions/DataType"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Array"
+          ],
+          "properties": {
+            "Array": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/DataType"
+                },
+                {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Struct"
+          ],
+          "properties": {
+            "Struct": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Field"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Unknown"
+          ],
+          "properties": {
+            "Unknown": {
+              "$ref": "#/definitions/UnknownKind"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Categorical"
+          ],
+          "properties": {
+            "Categorical": {
+              "type": "array",
+              "items": [
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Series"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/CategoricalOrdering"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Decimal"
+          ],
+          "properties": {
+            "Decimal": {
+              "type": "array",
+              "items": [
+                {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "format": "uint",
+                  "minimum": 0.0
+                },
+                {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "format": "uint",
+                  "minimum": 0.0
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Enum"
+          ],
+          "properties": {
+            "Enum": {
+              "type": "array",
+              "items": [
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Series"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/CategoricalOrdering"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Object"
+          ],
+          "properties": {
+            "Object": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "TimeUnit": {
+      "type": "string",
+      "enum": [
+        "Nanoseconds",
+        "Microseconds",
+        "Milliseconds"
+      ]
+    },
+    "TimeZone": {
+      "type": "object",
+      "required": [
+        "inner"
+      ],
+      "properties": {
+        "inner": {
+          "type": "string"
+        }
+      }
+    },
+    "Field": {
+      "type": "object",
+      "required": [
+        "dtype",
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "dtype": {
+          "$ref": "#/definitions/DataType"
+        }
+      }
+    },
+    "UnknownKind": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Float",
+            "Str",
+            "Any"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "Int"
+          ],
+          "properties": {
+            "Int": {
+              "type": "integer",
+              "format": "int128"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Series": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "format": "uint8",
+        "minimum": 0.0
+      }
+    },
+    "CategoricalOrdering": {
+      "type": "string",
+      "enum": [
+        "Physical",
+        "Lexical"
+      ]
+    },
+    "PythonScanSource": {
+      "type": "string",
+      "enum": [
+        "Pyarrow",
+        "Cuda",
+        "IOPlugin"
+      ]
+    },
+    "DslPlan": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "PythonScan"
+          ],
+          "properties": {
+            "PythonScan": {
+              "type": "object",
+              "required": [
+                "options"
+              ],
+              "properties": {
+                "options": {
+                  "$ref": "#/definitions/PythonOptionsDsl"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Filter"
+          ],
+          "properties": {
+            "Filter": {
+              "type": "object",
+              "required": [
+                "input",
+                "predicate"
+              ],
+              "properties": {
+                "input": {
+                  "$ref": "#/definitions/DslPlan"
+                },
+                "predicate": {
+                  "$ref": "#/definitions/Expr"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Cache"
+          ],
+          "properties": {
+            "Cache": {
+              "type": "object",
+              "required": [
+                "id",
+                "input"
+              ],
+              "properties": {
+                "input": {
+                  "$ref": "#/definitions/DslPlan"
+                },
+                "id": {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Scan"
+          ],
+          "properties": {
+            "Scan": {
+              "type": "object",
+              "required": [
+                "scan_type",
+                "sources",
+                "unified_scan_args"
+              ],
+              "properties": {
+                "sources": {
+                  "$ref": "#/definitions/ScanSources"
+                },
+                "file_info": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/FileInfo"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "unified_scan_args": {
+                  "$ref": "#/definitions/UnifiedScanArgs"
+                },
+                "scan_type": {
+                  "$ref": "#/definitions/FileScan"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "DataFrameScan"
+          ],
+          "properties": {
+            "DataFrameScan": {
+              "type": "object",
+              "required": [
+                "df",
+                "schema"
+              ],
+              "properties": {
+                "df": {
+                  "$ref": "#/definitions/DataFrame"
+                },
+                "schema": {
+                  "$ref": "#/definitions/Schema_for_DataType"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Select"
+          ],
+          "properties": {
+            "Select": {
+              "type": "object",
+              "required": [
+                "expr",
+                "input",
+                "options"
+              ],
+              "properties": {
+                "expr": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Expr"
+                  }
+                },
+                "input": {
+                  "$ref": "#/definitions/DslPlan"
+                },
+                "options": {
+                  "$ref": "#/definitions/ProjectionOptions"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "GroupBy"
+          ],
+          "properties": {
+            "GroupBy": {
+              "type": "object",
+              "required": [
+                "aggs",
+                "input",
+                "keys",
+                "maintain_order",
+                "options"
+              ],
+              "properties": {
+                "input": {
+                  "$ref": "#/definitions/DslPlan"
+                },
+                "keys": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Expr"
+                  }
+                },
+                "aggs": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Expr"
+                  }
+                },
+                "maintain_order": {
+                  "type": "boolean"
+                },
+                "options": {
+                  "$ref": "#/definitions/GroupbyOptions"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Join"
+          ],
+          "properties": {
+            "Join": {
+              "type": "object",
+              "required": [
+                "input_left",
+                "input_right",
+                "left_on",
+                "options",
+                "predicates",
+                "right_on"
+              ],
+              "properties": {
+                "input_left": {
+                  "$ref": "#/definitions/DslPlan"
+                },
+                "input_right": {
+                  "$ref": "#/definitions/DslPlan"
+                },
+                "left_on": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Expr"
+                  }
+                },
+                "right_on": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Expr"
+                  }
+                },
+                "predicates": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Expr"
+                  }
+                },
+                "options": {
+                  "$ref": "#/definitions/JoinOptions"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "HStack"
+          ],
+          "properties": {
+            "HStack": {
+              "type": "object",
+              "required": [
+                "exprs",
+                "input",
+                "options"
+              ],
+              "properties": {
+                "input": {
+                  "$ref": "#/definitions/DslPlan"
+                },
+                "exprs": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Expr"
+                  }
+                },
+                "options": {
+                  "$ref": "#/definitions/ProjectionOptions"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "MatchToSchema"
+          ],
+          "properties": {
+            "MatchToSchema": {
+              "type": "object",
+              "required": [
+                "extra_columns",
+                "input",
+                "match_schema",
+                "per_column"
+              ],
+              "properties": {
+                "input": {
+                  "$ref": "#/definitions/DslPlan"
+                },
+                "match_schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Schema_for_DataType"
+                    }
+                  ]
+                },
+                "per_column": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/MatchToSchemaPerColumn"
+                  }
+                },
+                "extra_columns": {
+                  "$ref": "#/definitions/ExtraColumnsPolicy"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Distinct"
+          ],
+          "properties": {
+            "Distinct": {
+              "type": "object",
+              "required": [
+                "input",
+                "options"
+              ],
+              "properties": {
+                "input": {
+                  "$ref": "#/definitions/DslPlan"
+                },
+                "options": {
+                  "$ref": "#/definitions/DistinctOptionsDSL"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Sort"
+          ],
+          "properties": {
+            "Sort": {
+              "type": "object",
+              "required": [
+                "by_column",
+                "input",
+                "sort_options"
+              ],
+              "properties": {
+                "input": {
+                  "$ref": "#/definitions/DslPlan"
+                },
+                "by_column": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Expr"
+                  }
+                },
+                "slice": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": [
+                    {
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    {
+                      "type": "integer",
+                      "format": "uint",
+                      "minimum": 0.0
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2
+                },
+                "sort_options": {
+                  "$ref": "#/definitions/SortMultipleOptions"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Slice"
+          ],
+          "properties": {
+            "Slice": {
+              "type": "object",
+              "required": [
+                "input",
+                "len",
+                "offset"
+              ],
+              "properties": {
+                "input": {
+                  "$ref": "#/definitions/DslPlan"
+                },
+                "offset": {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "len": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "MapFunction"
+          ],
+          "properties": {
+            "MapFunction": {
+              "type": "object",
+              "required": [
+                "function",
+                "input"
+              ],
+              "properties": {
+                "input": {
+                  "$ref": "#/definitions/DslPlan"
+                },
+                "function": {
+                  "$ref": "#/definitions/DslFunction"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Union"
+          ],
+          "properties": {
+            "Union": {
+              "type": "object",
+              "required": [
+                "args",
+                "inputs"
+              ],
+              "properties": {
+                "inputs": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/DslPlan"
+                  }
+                },
+                "args": {
+                  "$ref": "#/definitions/UnionArgs"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "HConcat"
+          ],
+          "properties": {
+            "HConcat": {
+              "type": "object",
+              "required": [
+                "inputs",
+                "options"
+              ],
+              "properties": {
+                "inputs": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/DslPlan"
+                  }
+                },
+                "options": {
+                  "$ref": "#/definitions/HConcatOptions"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "ExtContext"
+          ],
+          "properties": {
+            "ExtContext": {
+              "type": "object",
+              "required": [
+                "contexts",
+                "input"
+              ],
+              "properties": {
+                "input": {
+                  "$ref": "#/definitions/DslPlan"
+                },
+                "contexts": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/DslPlan"
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Sink"
+          ],
+          "properties": {
+            "Sink": {
+              "type": "object",
+              "required": [
+                "input",
+                "payload"
+              ],
+              "properties": {
+                "input": {
+                  "$ref": "#/definitions/DslPlan"
+                },
+                "payload": {
+                  "$ref": "#/definitions/SinkType"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "SinkMultiple"
+          ],
+          "properties": {
+            "SinkMultiple": {
+              "type": "object",
+              "required": [
+                "inputs"
+              ],
+              "properties": {
+                "inputs": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/DslPlan"
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "MergeSorted"
+          ],
+          "properties": {
+            "MergeSorted": {
+              "type": "object",
+              "required": [
+                "input_left",
+                "input_right",
+                "key"
+              ],
+              "properties": {
+                "input_left": {
+                  "$ref": "#/definitions/DslPlan"
+                },
+                "input_right": {
+                  "$ref": "#/definitions/DslPlan"
+                },
+                "key": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "IR"
+          ],
+          "properties": {
+            "IR": {
+              "type": "object",
+              "required": [
+                "dsl",
+                "version"
+              ],
+              "properties": {
+                "dsl": {
+                  "$ref": "#/definitions/DslPlan"
+                },
+                "version": {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Expr": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Wildcard",
+            "Len"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "Alias"
+          ],
+          "properties": {
+            "Alias": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/Expr"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Column"
+          ],
+          "properties": {
+            "Column": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Columns"
+          ],
+          "properties": {
+            "Columns": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "DtypeColumn"
+          ],
+          "properties": {
+            "DtypeColumn": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/DataType"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "IndexColumn"
+          ],
+          "properties": {
+            "IndexColumn": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Literal"
+          ],
+          "properties": {
+            "Literal": {
+              "$ref": "#/definitions/LiteralValue"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "BinaryExpr"
+          ],
+          "properties": {
+            "BinaryExpr": {
+              "type": "object",
+              "required": [
+                "left",
+                "op",
+                "right"
+              ],
+              "properties": {
+                "left": {
+                  "$ref": "#/definitions/Expr"
+                },
+                "op": {
+                  "$ref": "#/definitions/Operator"
+                },
+                "right": {
+                  "$ref": "#/definitions/Expr"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Cast"
+          ],
+          "properties": {
+            "Cast": {
+              "type": "object",
+              "required": [
+                "dtype",
+                "expr",
+                "options"
+              ],
+              "properties": {
+                "expr": {
+                  "$ref": "#/definitions/Expr"
+                },
+                "dtype": {
+                  "$ref": "#/definitions/DataType"
+                },
+                "options": {
+                  "$ref": "#/definitions/CastOptions"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Sort"
+          ],
+          "properties": {
+            "Sort": {
+              "type": "object",
+              "required": [
+                "expr",
+                "options"
+              ],
+              "properties": {
+                "expr": {
+                  "$ref": "#/definitions/Expr"
+                },
+                "options": {
+                  "$ref": "#/definitions/SortOptions"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Gather"
+          ],
+          "properties": {
+            "Gather": {
+              "type": "object",
+              "required": [
+                "expr",
+                "idx",
+                "returns_scalar"
+              ],
+              "properties": {
+                "expr": {
+                  "$ref": "#/definitions/Expr"
+                },
+                "idx": {
+                  "$ref": "#/definitions/Expr"
+                },
+                "returns_scalar": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "SortBy"
+          ],
+          "properties": {
+            "SortBy": {
+              "type": "object",
+              "required": [
+                "by",
+                "expr",
+                "sort_options"
+              ],
+              "properties": {
+                "expr": {
+                  "$ref": "#/definitions/Expr"
+                },
+                "by": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Expr"
+                  }
+                },
+                "sort_options": {
+                  "$ref": "#/definitions/SortMultipleOptions"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Agg"
+          ],
+          "properties": {
+            "Agg": {
+              "$ref": "#/definitions/AggExpr"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Ternary"
+          ],
+          "properties": {
+            "Ternary": {
+              "type": "object",
+              "required": [
+                "falsy",
+                "predicate",
+                "truthy"
+              ],
+              "properties": {
+                "predicate": {
+                  "$ref": "#/definitions/Expr"
+                },
+                "truthy": {
+                  "$ref": "#/definitions/Expr"
+                },
+                "falsy": {
+                  "$ref": "#/definitions/Expr"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Function"
+          ],
+          "properties": {
+            "Function": {
+              "type": "object",
+              "required": [
+                "function",
+                "input",
+                "options"
+              ],
+              "properties": {
+                "input": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Expr"
+                  }
+                },
+                "function": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/FunctionExpr"
+                    }
+                  ]
+                },
+                "options": {
+                  "$ref": "#/definitions/FunctionOptions"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Explode"
+          ],
+          "properties": {
+            "Explode": {
+              "type": "object",
+              "required": [
+                "input",
+                "skip_empty"
+              ],
+              "properties": {
+                "input": {
+                  "$ref": "#/definitions/Expr"
+                },
+                "skip_empty": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Filter"
+          ],
+          "properties": {
+            "Filter": {
+              "type": "object",
+              "required": [
+                "by",
+                "input"
+              ],
+              "properties": {
+                "input": {
+                  "$ref": "#/definitions/Expr"
+                },
+                "by": {
+                  "$ref": "#/definitions/Expr"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Window"
+          ],
+          "properties": {
+            "Window": {
+              "type": "object",
+              "required": [
+                "function",
+                "options",
+                "partition_by"
+              ],
+              "properties": {
+                "function": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Expr"
+                    }
+                  ]
+                },
+                "partition_by": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Expr"
+                  }
+                },
+                "order_by": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": [
+                    {
+                      "$ref": "#/definitions/Expr"
+                    },
+                    {
+                      "$ref": "#/definitions/SortOptions"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2
+                },
+                "options": {
+                  "$ref": "#/definitions/WindowType"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Slice"
+          ],
+          "properties": {
+            "Slice": {
+              "type": "object",
+              "required": [
+                "input",
+                "length",
+                "offset"
+              ],
+              "properties": {
+                "input": {
+                  "$ref": "#/definitions/Expr"
+                },
+                "offset": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/Expr"
+                    }
+                  ]
+                },
+                "length": {
+                  "$ref": "#/definitions/Expr"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Exclude"
+          ],
+          "properties": {
+            "Exclude": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/Expr"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Excluded"
+                  }
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "KeepName"
+          ],
+          "properties": {
+            "KeepName": {
+              "$ref": "#/definitions/Expr"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Nth"
+          ],
+          "properties": {
+            "Nth": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Field"
+          ],
+          "properties": {
+            "Field": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "AnonymousFunction"
+          ],
+          "properties": {
+            "AnonymousFunction": {
+              "type": "object",
+              "required": [
+                "function",
+                "input",
+                "options",
+                "output_type"
+              ],
+              "properties": {
+                "input": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Expr"
+                  }
+                },
+                "function": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/ColumnsUdf"
+                    }
+                  ]
+                },
+                "output_type": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/GetOutput"
+                    }
+                  ]
+                },
+                "options": {
+                  "$ref": "#/definitions/FunctionOptions"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "SubPlan"
+          ],
+          "properties": {
+            "SubPlan": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/DslPlan"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Selector"
+          ],
+          "properties": {
+            "Selector": {
+              "$ref": "#/definitions/Selector"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "LiteralValue": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "Dyn"
+          ],
+          "properties": {
+            "Dyn": {
+              "$ref": "#/definitions/DynLiteralValue"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Scalar"
+          ],
+          "properties": {
+            "Scalar": {
+              "$ref": "#/definitions/Scalar"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Series"
+          ],
+          "properties": {
+            "Series": {
+              "$ref": "#/definitions/Series"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Range"
+          ],
+          "properties": {
+            "Range": {
+              "$ref": "#/definitions/RangeLiteralValue"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "DynLiteralValue": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "Str"
+          ],
+          "properties": {
+            "Str": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Int"
+          ],
+          "properties": {
+            "Int": {
+              "type": "integer",
+              "format": "int128"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Float"
+          ],
+          "properties": {
+            "Float": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "List"
+          ],
+          "properties": {
+            "List": {
+              "$ref": "#/definitions/DynListLiteralValue"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "DynListLiteralValue": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "Str"
+          ],
+          "properties": {
+            "Str": {
+              "type": "array",
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Int"
+          ],
+          "properties": {
+            "Int": {
+              "type": "array",
+              "items": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "int128"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Float"
+          ],
+          "properties": {
+            "Float": {
+              "type": "array",
+              "items": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "format": "double"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "List"
+          ],
+          "properties": {
+            "List": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/DynListLiteralValue"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Scalar": {
+      "type": "object",
+      "required": [
+        "dtype",
+        "value"
+      ],
+      "properties": {
+        "dtype": {
+          "$ref": "#/definitions/DataType"
+        },
+        "value": {
+          "$ref": "#/definitions/AnyValue"
+        }
+      }
+    },
+    "AnyValue": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Null"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "Int8"
+          ],
+          "properties": {
+            "Int8": {
+              "type": "integer",
+              "format": "int8"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Int16"
+          ],
+          "properties": {
+            "Int16": {
+              "type": "integer",
+              "format": "int16"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Int32"
+          ],
+          "properties": {
+            "Int32": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Int64"
+          ],
+          "properties": {
+            "Int64": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Int128"
+          ],
+          "properties": {
+            "Int128": {
+              "type": "integer",
+              "format": "int128"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "UInt8"
+          ],
+          "properties": {
+            "UInt8": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "UInt16"
+          ],
+          "properties": {
+            "UInt16": {
+              "type": "integer",
+              "format": "uint16",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "UInt32"
+          ],
+          "properties": {
+            "UInt32": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "UInt64"
+          ],
+          "properties": {
+            "UInt64": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Float32"
+          ],
+          "properties": {
+            "Float32": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Float64"
+          ],
+          "properties": {
+            "Float64": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "List"
+          ],
+          "properties": {
+            "List": {
+              "$ref": "#/definitions/Series"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Boolean"
+          ],
+          "properties": {
+            "Boolean": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "String"
+          ],
+          "properties": {
+            "String": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Binary"
+          ],
+          "properties": {
+            "Binary": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "uint8",
+                "minimum": 0.0
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Date"
+          ],
+          "properties": {
+            "Date": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Datetime"
+          ],
+          "properties": {
+            "Datetime": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                {
+                  "$ref": "#/definitions/TimeUnit"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/TimeZone"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              ],
+              "maxItems": 3,
+              "minItems": 3
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Duration"
+          ],
+          "properties": {
+            "Duration": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                {
+                  "$ref": "#/definitions/TimeUnit"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Time"
+          ],
+          "properties": {
+            "Time": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Array"
+          ],
+          "properties": {
+            "Array": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/Series"
+                },
+                {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Decimal"
+          ],
+          "properties": {
+            "Decimal": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "integer",
+                  "format": "int128"
+                },
+                {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "RangeLiteralValue": {
+      "type": "object",
+      "required": [
+        "dtype",
+        "high",
+        "low"
+      ],
+      "properties": {
+        "low": {
+          "type": "integer",
+          "format": "int128"
+        },
+        "high": {
+          "type": "integer",
+          "format": "int128"
+        },
+        "dtype": {
+          "$ref": "#/definitions/DataType"
+        }
+      }
+    },
+    "Operator": {
+      "type": "string",
+      "enum": [
+        "Eq",
+        "EqValidity",
+        "NotEq",
+        "NotEqValidity",
+        "Lt",
+        "LtEq",
+        "Gt",
+        "GtEq",
+        "Plus",
+        "Minus",
+        "Multiply",
+        "Divide",
+        "TrueDivide",
+        "FloorDivide",
+        "Modulus",
+        "And",
+        "Or",
+        "Xor",
+        "LogicalAnd",
+        "LogicalOr"
+      ]
+    },
+    "CastOptions": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Strict"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "NonStrict"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Overflowing"
+          ]
+        }
+      ]
+    },
+    "SortOptions": {
+      "type": "object",
+      "required": [
+        "descending",
+        "maintain_order",
+        "multithreaded",
+        "nulls_last"
+      ],
+      "properties": {
+        "descending": {
+          "type": "boolean"
+        },
+        "nulls_last": {
+          "type": "boolean"
+        },
+        "multithreaded": {
+          "type": "boolean"
+        },
+        "maintain_order": {
+          "type": "boolean"
+        },
+        "limit": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
+    },
+    "SortMultipleOptions": {
+      "type": "object",
+      "required": [
+        "descending",
+        "maintain_order",
+        "multithreaded",
+        "nulls_last"
+      ],
+      "properties": {
+        "descending": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "nulls_last": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "multithreaded": {
+          "type": "boolean"
+        },
+        "maintain_order": {
+          "type": "boolean"
+        },
+        "limit": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
+    },
+    "AggExpr": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "Min"
+          ],
+          "properties": {
+            "Min": {
+              "type": "object",
+              "required": [
+                "input",
+                "propagate_nans"
+              ],
+              "properties": {
+                "input": {
+                  "$ref": "#/definitions/Expr"
+                },
+                "propagate_nans": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Max"
+          ],
+          "properties": {
+            "Max": {
+              "type": "object",
+              "required": [
+                "input",
+                "propagate_nans"
+              ],
+              "properties": {
+                "input": {
+                  "$ref": "#/definitions/Expr"
+                },
+                "propagate_nans": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Median"
+          ],
+          "properties": {
+            "Median": {
+              "$ref": "#/definitions/Expr"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "NUnique"
+          ],
+          "properties": {
+            "NUnique": {
+              "$ref": "#/definitions/Expr"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "First"
+          ],
+          "properties": {
+            "First": {
+              "$ref": "#/definitions/Expr"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Last"
+          ],
+          "properties": {
+            "Last": {
+              "$ref": "#/definitions/Expr"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Mean"
+          ],
+          "properties": {
+            "Mean": {
+              "$ref": "#/definitions/Expr"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Implode"
+          ],
+          "properties": {
+            "Implode": {
+              "$ref": "#/definitions/Expr"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Count"
+          ],
+          "properties": {
+            "Count": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/Expr"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Quantile"
+          ],
+          "properties": {
+            "Quantile": {
+              "type": "object",
+              "required": [
+                "expr",
+                "method",
+                "quantile"
+              ],
+              "properties": {
+                "expr": {
+                  "$ref": "#/definitions/Expr"
+                },
+                "quantile": {
+                  "$ref": "#/definitions/Expr"
+                },
+                "method": {
+                  "$ref": "#/definitions/QuantileMethod"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Sum"
+          ],
+          "properties": {
+            "Sum": {
+              "$ref": "#/definitions/Expr"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "AggGroups"
+          ],
+          "properties": {
+            "AggGroups": {
+              "$ref": "#/definitions/Expr"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Std"
+          ],
+          "properties": {
+            "Std": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/Expr"
+                },
+                {
+                  "type": "integer",
+                  "format": "uint8",
+                  "minimum": 0.0
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Var"
+          ],
+          "properties": {
+            "Var": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/Expr"
+                },
+                {
+                  "type": "integer",
+                  "format": "uint8",
+                  "minimum": 0.0
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "QuantileMethod": {
+      "type": "string",
+      "enum": [
+        "Nearest",
+        "Lower",
+        "Higher",
+        "Midpoint",
+        "Linear",
+        "Equiprobable"
+      ]
+    },
+    "FunctionExpr": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Abs",
+            "Negate",
+            "NullCount",
+            "ArgWhere",
+            "IndexOf",
+            "Atan2",
+            "Sign",
+            "FillNull",
+            "ShiftAndFill",
+            "Shift",
+            "DropNans",
+            "DropNulls",
+            "Mode",
+            "RepeatBy",
+            "ArgUnique",
+            "Repeat",
+            "AsStruct",
+            "Reverse",
+            "UniqueCounts",
+            "ApproxNUnique",
+            "Coalesce",
+            "ShrinkType",
+            "PctChange",
+            "InterpolateBy",
+            "Log1p",
+            "Exp",
+            "Floor",
+            "Ceil",
+            "UpperBound",
+            "LowerBound",
+            "PeakMin",
+            "PeakMax",
+            "RLE",
+            "RLEID",
+            "ToPhysical",
+            "MaxHorizontal",
+            "MinHorizontal",
+            "Replace",
+            "ExtendConstant"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "ArrayExpr"
+          ],
+          "properties": {
+            "ArrayExpr": {
+              "$ref": "#/definitions/ArrayFunction"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "BinaryExpr"
+          ],
+          "properties": {
+            "BinaryExpr": {
+              "$ref": "#/definitions/BinaryFunction"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Categorical"
+          ],
+          "properties": {
+            "Categorical": {
+              "$ref": "#/definitions/CategoricalFunction"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "ListExpr"
+          ],
+          "properties": {
+            "ListExpr": {
+              "$ref": "#/definitions/ListFunction"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "StringExpr"
+          ],
+          "properties": {
+            "StringExpr": {
+              "$ref": "#/definitions/StringFunction"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "StructExpr"
+          ],
+          "properties": {
+            "StructExpr": {
+              "$ref": "#/definitions/StructFunction"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "TemporalExpr"
+          ],
+          "properties": {
+            "TemporalExpr": {
+              "$ref": "#/definitions/TemporalFunction"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Bitwise"
+          ],
+          "properties": {
+            "Bitwise": {
+              "$ref": "#/definitions/BitwiseFunction"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Boolean"
+          ],
+          "properties": {
+            "Boolean": {
+              "$ref": "#/definitions/BooleanFunction"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Business"
+          ],
+          "properties": {
+            "Business": {
+              "$ref": "#/definitions/BusinessFunction"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Hist"
+          ],
+          "properties": {
+            "Hist": {
+              "type": "object",
+              "required": [
+                "include_breakpoint",
+                "include_category"
+              ],
+              "properties": {
+                "bin_count": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "format": "uint",
+                  "minimum": 0.0
+                },
+                "include_category": {
+                  "type": "boolean"
+                },
+                "include_breakpoint": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Pow"
+          ],
+          "properties": {
+            "Pow": {
+              "$ref": "#/definitions/PowFunction"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Hash"
+          ],
+          "properties": {
+            "Hash": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                },
+                {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                },
+                {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                },
+                {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              ],
+              "maxItems": 4,
+              "minItems": 4
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "SearchSorted"
+          ],
+          "properties": {
+            "SearchSorted": {
+              "$ref": "#/definitions/SearchSortedSide"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Range"
+          ],
+          "properties": {
+            "Range": {
+              "$ref": "#/definitions/RangeFunction"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Trigonometry"
+          ],
+          "properties": {
+            "Trigonometry": {
+              "$ref": "#/definitions/TrigonometricFunction"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "FillNullWithStrategy"
+          ],
+          "properties": {
+            "FillNullWithStrategy": {
+              "$ref": "#/definitions/FillNullStrategy"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "RollingExpr"
+          ],
+          "properties": {
+            "RollingExpr": {
+              "$ref": "#/definitions/RollingFunction"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "RollingExprBy"
+          ],
+          "properties": {
+            "RollingExprBy": {
+              "$ref": "#/definitions/RollingFunctionBy"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Skew"
+          ],
+          "properties": {
+            "Skew": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Kurtosis"
+          ],
+          "properties": {
+            "Kurtosis": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Reshape"
+          ],
+          "properties": {
+            "Reshape": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ReshapeDimension"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Rank"
+          ],
+          "properties": {
+            "Rank": {
+              "type": "object",
+              "required": [
+                "options"
+              ],
+              "properties": {
+                "options": {
+                  "$ref": "#/definitions/RankOptions"
+                },
+                "seed": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Clip"
+          ],
+          "properties": {
+            "Clip": {
+              "type": "object",
+              "required": [
+                "has_max",
+                "has_min"
+              ],
+              "properties": {
+                "has_min": {
+                  "type": "boolean"
+                },
+                "has_max": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "TopK"
+          ],
+          "properties": {
+            "TopK": {
+              "type": "object",
+              "required": [
+                "descending"
+              ],
+              "properties": {
+                "descending": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "TopKBy"
+          ],
+          "properties": {
+            "TopKBy": {
+              "type": "object",
+              "required": [
+                "descending"
+              ],
+              "properties": {
+                "descending": {
+                  "type": "array",
+                  "items": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "CumCount"
+          ],
+          "properties": {
+            "CumCount": {
+              "type": "object",
+              "required": [
+                "reverse"
+              ],
+              "properties": {
+                "reverse": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "CumSum"
+          ],
+          "properties": {
+            "CumSum": {
+              "type": "object",
+              "required": [
+                "reverse"
+              ],
+              "properties": {
+                "reverse": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "CumProd"
+          ],
+          "properties": {
+            "CumProd": {
+              "type": "object",
+              "required": [
+                "reverse"
+              ],
+              "properties": {
+                "reverse": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "CumMin"
+          ],
+          "properties": {
+            "CumMin": {
+              "type": "object",
+              "required": [
+                "reverse"
+              ],
+              "properties": {
+                "reverse": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "CumMax"
+          ],
+          "properties": {
+            "CumMax": {
+              "type": "object",
+              "required": [
+                "reverse"
+              ],
+              "properties": {
+                "reverse": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "ValueCounts"
+          ],
+          "properties": {
+            "ValueCounts": {
+              "type": "object",
+              "required": [
+                "name",
+                "normalize",
+                "parallel",
+                "sort"
+              ],
+              "properties": {
+                "sort": {
+                  "type": "boolean"
+                },
+                "parallel": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "normalize": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Diff"
+          ],
+          "properties": {
+            "Diff": {
+              "$ref": "#/definitions/NullBehavior"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Interpolate"
+          ],
+          "properties": {
+            "Interpolate": {
+              "$ref": "#/definitions/InterpolationMethod"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Entropy"
+          ],
+          "properties": {
+            "Entropy": {
+              "type": "object",
+              "required": [
+                "base",
+                "normalize"
+              ],
+              "properties": {
+                "base": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "normalize": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Log"
+          ],
+          "properties": {
+            "Log": {
+              "type": "object",
+              "required": [
+                "base"
+              ],
+              "properties": {
+                "base": {
+                  "type": "number",
+                  "format": "double"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Unique"
+          ],
+          "properties": {
+            "Unique": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Round"
+          ],
+          "properties": {
+            "Round": {
+              "type": "object",
+              "required": [
+                "decimals",
+                "mode"
+              ],
+              "properties": {
+                "decimals": {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "mode": {
+                  "$ref": "#/definitions/RoundMode"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "RoundSF"
+          ],
+          "properties": {
+            "RoundSF": {
+              "type": "object",
+              "required": [
+                "digits"
+              ],
+              "properties": {
+                "digits": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Fused"
+          ],
+          "properties": {
+            "Fused": {
+              "$ref": "#/definitions/FusedOperator"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "ConcatExpr"
+          ],
+          "properties": {
+            "ConcatExpr": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Correlation"
+          ],
+          "properties": {
+            "Correlation": {
+              "type": "object",
+              "required": [
+                "method"
+              ],
+              "properties": {
+                "method": {
+                  "$ref": "#/definitions/CorrelationMethod"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Cut"
+          ],
+          "properties": {
+            "Cut": {
+              "type": "object",
+              "required": [
+                "breaks",
+                "include_breaks",
+                "left_closed"
+              ],
+              "properties": {
+                "breaks": {
+                  "type": "array",
+                  "items": {
+                    "type": "number",
+                    "format": "double"
+                  }
+                },
+                "labels": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "left_closed": {
+                  "type": "boolean"
+                },
+                "include_breaks": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "QCut"
+          ],
+          "properties": {
+            "QCut": {
+              "type": "object",
+              "required": [
+                "allow_duplicates",
+                "include_breaks",
+                "left_closed",
+                "probs"
+              ],
+              "properties": {
+                "probs": {
+                  "type": "array",
+                  "items": {
+                    "type": "number",
+                    "format": "double"
+                  }
+                },
+                "labels": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "left_closed": {
+                  "type": "boolean"
+                },
+                "allow_duplicates": {
+                  "type": "boolean"
+                },
+                "include_breaks": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Random"
+          ],
+          "properties": {
+            "Random": {
+              "type": "object",
+              "required": [
+                "method"
+              ],
+              "properties": {
+                "method": {
+                  "$ref": "#/definitions/RandomMethod"
+                },
+                "seed": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "SetSortedFlag"
+          ],
+          "properties": {
+            "SetSortedFlag": {
+              "$ref": "#/definitions/IsSorted"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "FfiPlugin"
+          ],
+          "properties": {
+            "FfiPlugin": {
+              "type": "object",
+              "required": [
+                "flags",
+                "kwargs",
+                "lib",
+                "symbol"
+              ],
+              "properties": {
+                "flags": {
+                  "$ref": "#/definitions/FunctionOptions"
+                },
+                "lib": {
+                  "type": "string"
+                },
+                "symbol": {
+                  "type": "string"
+                },
+                "kwargs": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0.0
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "SumHorizontal"
+          ],
+          "properties": {
+            "SumHorizontal": {
+              "type": "object",
+              "required": [
+                "ignore_nulls"
+              ],
+              "properties": {
+                "ignore_nulls": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "MeanHorizontal"
+          ],
+          "properties": {
+            "MeanHorizontal": {
+              "type": "object",
+              "required": [
+                "ignore_nulls"
+              ],
+              "properties": {
+                "ignore_nulls": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "EwmMean"
+          ],
+          "properties": {
+            "EwmMean": {
+              "type": "object",
+              "required": [
+                "options"
+              ],
+              "properties": {
+                "options": {
+                  "$ref": "#/definitions/EWMOptions"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "EwmMeanBy"
+          ],
+          "properties": {
+            "EwmMeanBy": {
+              "type": "object",
+              "required": [
+                "half_life"
+              ],
+              "properties": {
+                "half_life": {
+                  "$ref": "#/definitions/Duration"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "EwmStd"
+          ],
+          "properties": {
+            "EwmStd": {
+              "type": "object",
+              "required": [
+                "options"
+              ],
+              "properties": {
+                "options": {
+                  "$ref": "#/definitions/EWMOptions"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "EwmVar"
+          ],
+          "properties": {
+            "EwmVar": {
+              "type": "object",
+              "required": [
+                "options"
+              ],
+              "properties": {
+                "options": {
+                  "$ref": "#/definitions/EWMOptions"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "ReplaceStrict"
+          ],
+          "properties": {
+            "ReplaceStrict": {
+              "type": "object",
+              "properties": {
+                "return_dtype": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/DataType"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "GatherEvery"
+          ],
+          "properties": {
+            "GatherEvery": {
+              "type": "object",
+              "required": [
+                "n",
+                "offset"
+              ],
+              "properties": {
+                "n": {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                },
+                "offset": {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Reinterpret"
+          ],
+          "properties": {
+            "Reinterpret": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "ArrayFunction": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Length",
+            "Min",
+            "Max",
+            "Sum",
+            "ToList",
+            "NUnique",
+            "Median",
+            "Any",
+            "All",
+            "Reverse",
+            "ArgMin",
+            "ArgMax",
+            "CountMatches",
+            "Shift",
+            "Concat"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "Unique"
+          ],
+          "properties": {
+            "Unique": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Std"
+          ],
+          "properties": {
+            "Std": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Var"
+          ],
+          "properties": {
+            "Var": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Sort"
+          ],
+          "properties": {
+            "Sort": {
+              "$ref": "#/definitions/SortOptions"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Get"
+          ],
+          "properties": {
+            "Get": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Join"
+          ],
+          "properties": {
+            "Join": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Contains"
+          ],
+          "properties": {
+            "Contains": {
+              "type": "object",
+              "required": [
+                "nulls_equal"
+              ],
+              "properties": {
+                "nulls_equal": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Explode"
+          ],
+          "properties": {
+            "Explode": {
+              "type": "object",
+              "required": [
+                "skip_empty"
+              ],
+              "properties": {
+                "skip_empty": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "BinaryFunction": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Contains",
+            "StartsWith",
+            "EndsWith",
+            "HexEncode",
+            "Base64Encode",
+            "Size"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "HexDecode"
+          ],
+          "properties": {
+            "HexDecode": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Base64Decode"
+          ],
+          "properties": {
+            "Base64Decode": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "FromBuffer"
+          ],
+          "properties": {
+            "FromBuffer": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/DataType"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "CategoricalFunction": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "GetCategories",
+            "LenBytes",
+            "LenChars"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "StartsWith"
+          ],
+          "properties": {
+            "StartsWith": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "EndsWith"
+          ],
+          "properties": {
+            "EndsWith": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Slice"
+          ],
+          "properties": {
+            "Slice": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "format": "uint",
+                  "minimum": 0.0
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "ListFunction": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Concat",
+            "DropNulls",
+            "Slice",
+            "Shift",
+            "GatherEvery",
+            "CountMatches",
+            "Sum",
+            "Length",
+            "Max",
+            "Min",
+            "Mean",
+            "Median",
+            "ArgMin",
+            "ArgMax",
+            "Reverse",
+            "NUnique",
+            "Any",
+            "All"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "Contains"
+          ],
+          "properties": {
+            "Contains": {
+              "type": "object",
+              "required": [
+                "nulls_equal"
+              ],
+              "properties": {
+                "nulls_equal": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Sample"
+          ],
+          "properties": {
+            "Sample": {
+              "type": "object",
+              "required": [
+                "is_fraction",
+                "shuffle",
+                "with_replacement"
+              ],
+              "properties": {
+                "is_fraction": {
+                  "type": "boolean"
+                },
+                "with_replacement": {
+                  "type": "boolean"
+                },
+                "shuffle": {
+                  "type": "boolean"
+                },
+                "seed": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Get"
+          ],
+          "properties": {
+            "Get": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Gather"
+          ],
+          "properties": {
+            "Gather": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Std"
+          ],
+          "properties": {
+            "Std": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Var"
+          ],
+          "properties": {
+            "Var": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Diff"
+          ],
+          "properties": {
+            "Diff": {
+              "type": "object",
+              "required": [
+                "n",
+                "null_behavior"
+              ],
+              "properties": {
+                "n": {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "null_behavior": {
+                  "$ref": "#/definitions/NullBehavior"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Sort"
+          ],
+          "properties": {
+            "Sort": {
+              "$ref": "#/definitions/SortOptions"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Unique"
+          ],
+          "properties": {
+            "Unique": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "SetOperation"
+          ],
+          "properties": {
+            "SetOperation": {
+              "$ref": "#/definitions/SetOperation"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Join"
+          ],
+          "properties": {
+            "Join": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "ToArray"
+          ],
+          "properties": {
+            "ToArray": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "ToStruct"
+          ],
+          "properties": {
+            "ToStruct": {
+              "$ref": "#/definitions/ListToStructArgs"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "NullBehavior": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Drop"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Ignore"
+          ]
+        }
+      ]
+    },
+    "SetOperation": {
+      "type": "string",
+      "enum": [
+        "Intersection",
+        "Union",
+        "Difference",
+        "SymmetricDifference"
+      ]
+    },
+    "ListToStructArgs": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "FixedWidth"
+          ],
+          "properties": {
+            "FixedWidth": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "InferWidth"
+          ],
+          "properties": {
+            "InferWidth": {
+              "type": "object",
+              "required": [
+                "get_index_name",
+                "infer_field_strategy"
+              ],
+              "properties": {
+                "infer_field_strategy": {
+                  "$ref": "#/definitions/ListToStructWidthStrategy"
+                },
+                "get_index_name": {
+                  "type": "null"
+                },
+                "max_fields": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "format": "uint",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "ListToStructWidthStrategy": {
+      "type": "string",
+      "enum": [
+        "FirstNonNull",
+        "MaxWidth"
+      ]
+    },
+    "StringFunction": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "EndsWith",
+            "ExtractAll",
+            "LenBytes",
+            "LenChars",
+            "Lowercase",
+            "JsonPathMatch",
+            "Reverse",
+            "Slice",
+            "Head",
+            "Tail",
+            "HexEncode",
+            "Base64Encode",
+            "StartsWith",
+            "StripChars",
+            "StripCharsStart",
+            "StripCharsEnd",
+            "StripPrefix",
+            "StripSuffix",
+            "Titlecase",
+            "Uppercase",
+            "ZFill",
+            "EscapeRegex"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "ConcatHorizontal"
+          ],
+          "properties": {
+            "ConcatHorizontal": {
+              "type": "object",
+              "required": [
+                "delimiter",
+                "ignore_nulls"
+              ],
+              "properties": {
+                "delimiter": {
+                  "type": "string"
+                },
+                "ignore_nulls": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "ConcatVertical"
+          ],
+          "properties": {
+            "ConcatVertical": {
+              "type": "object",
+              "required": [
+                "delimiter",
+                "ignore_nulls"
+              ],
+              "properties": {
+                "delimiter": {
+                  "type": "string"
+                },
+                "ignore_nulls": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Contains"
+          ],
+          "properties": {
+            "Contains": {
+              "type": "object",
+              "required": [
+                "literal",
+                "strict"
+              ],
+              "properties": {
+                "literal": {
+                  "type": "boolean"
+                },
+                "strict": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "CountMatches"
+          ],
+          "properties": {
+            "CountMatches": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Extract"
+          ],
+          "properties": {
+            "Extract": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "ExtractGroups"
+          ],
+          "properties": {
+            "ExtractGroups": {
+              "type": "object",
+              "required": [
+                "dtype",
+                "pat"
+              ],
+              "properties": {
+                "dtype": {
+                  "$ref": "#/definitions/DataType"
+                },
+                "pat": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Find"
+          ],
+          "properties": {
+            "Find": {
+              "type": "object",
+              "required": [
+                "literal",
+                "strict"
+              ],
+              "properties": {
+                "literal": {
+                  "type": "boolean"
+                },
+                "strict": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "ToInteger"
+          ],
+          "properties": {
+            "ToInteger": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "JsonDecode"
+          ],
+          "properties": {
+            "JsonDecode": {
+              "type": "object",
+              "properties": {
+                "dtype": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/DataType"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "infer_schema_len": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "format": "uint",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Replace"
+          ],
+          "properties": {
+            "Replace": {
+              "type": "object",
+              "required": [
+                "literal",
+                "n"
+              ],
+              "properties": {
+                "n": {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "literal": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Normalize"
+          ],
+          "properties": {
+            "Normalize": {
+              "type": "object",
+              "required": [
+                "form"
+              ],
+              "properties": {
+                "form": {
+                  "$ref": "#/definitions/UnicodeForm"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "PadStart"
+          ],
+          "properties": {
+            "PadStart": {
+              "type": "object",
+              "required": [
+                "fill_char",
+                "length"
+              ],
+              "properties": {
+                "length": {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                },
+                "fill_char": {
+                  "type": "string",
+                  "maxLength": 1,
+                  "minLength": 1
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "PadEnd"
+          ],
+          "properties": {
+            "PadEnd": {
+              "type": "object",
+              "required": [
+                "fill_char",
+                "length"
+              ],
+              "properties": {
+                "length": {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                },
+                "fill_char": {
+                  "type": "string",
+                  "maxLength": 1,
+                  "minLength": 1
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "HexDecode"
+          ],
+          "properties": {
+            "HexDecode": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Base64Decode"
+          ],
+          "properties": {
+            "Base64Decode": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "SplitExact"
+          ],
+          "properties": {
+            "SplitExact": {
+              "type": "object",
+              "required": [
+                "inclusive",
+                "n"
+              ],
+              "properties": {
+                "n": {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                },
+                "inclusive": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "SplitN"
+          ],
+          "properties": {
+            "SplitN": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Strptime"
+          ],
+          "properties": {
+            "Strptime": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/DataType"
+                },
+                {
+                  "$ref": "#/definitions/StrptimeOptions"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Split"
+          ],
+          "properties": {
+            "Split": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "ToDecimal"
+          ],
+          "properties": {
+            "ToDecimal": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "ContainsAny"
+          ],
+          "properties": {
+            "ContainsAny": {
+              "type": "object",
+              "required": [
+                "ascii_case_insensitive"
+              ],
+              "properties": {
+                "ascii_case_insensitive": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "ReplaceMany"
+          ],
+          "properties": {
+            "ReplaceMany": {
+              "type": "object",
+              "required": [
+                "ascii_case_insensitive"
+              ],
+              "properties": {
+                "ascii_case_insensitive": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "ExtractMany"
+          ],
+          "properties": {
+            "ExtractMany": {
+              "type": "object",
+              "required": [
+                "ascii_case_insensitive",
+                "overlapping"
+              ],
+              "properties": {
+                "ascii_case_insensitive": {
+                  "type": "boolean"
+                },
+                "overlapping": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "FindMany"
+          ],
+          "properties": {
+            "FindMany": {
+              "type": "object",
+              "required": [
+                "ascii_case_insensitive",
+                "overlapping"
+              ],
+              "properties": {
+                "ascii_case_insensitive": {
+                  "type": "boolean"
+                },
+                "overlapping": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "UnicodeForm": {
+      "type": "string",
+      "enum": [
+        "NFC",
+        "NFKC",
+        "NFD",
+        "NFKD"
+      ]
+    },
+    "StrptimeOptions": {
+      "type": "object",
+      "required": [
+        "cache",
+        "exact",
+        "strict"
+      ],
+      "properties": {
+        "format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "strict": {
+          "type": "boolean"
+        },
+        "exact": {
+          "type": "boolean"
+        },
+        "cache": {
+          "type": "boolean"
+        }
+      }
+    },
+    "StructFunction": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "JsonEncode",
+            "WithFields"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "FieldByIndex"
+          ],
+          "properties": {
+            "FieldByIndex": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "FieldByName"
+          ],
+          "properties": {
+            "FieldByName": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "RenameFields"
+          ],
+          "properties": {
+            "RenameFields": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "PrefixFields"
+          ],
+          "properties": {
+            "PrefixFields": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "SuffixFields"
+          ],
+          "properties": {
+            "SuffixFields": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "MultipleFields"
+          ],
+          "properties": {
+            "MultipleFields": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "TemporalFunction": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Millennium",
+            "Century",
+            "Year",
+            "IsLeapYear",
+            "IsoYear",
+            "Quarter",
+            "Month",
+            "Week",
+            "WeekDay",
+            "Day",
+            "OrdinalDay",
+            "Time",
+            "Date",
+            "Datetime",
+            "Hour",
+            "Minute",
+            "Second",
+            "Millisecond",
+            "Microsecond",
+            "Nanosecond",
+            "TotalDays",
+            "TotalHours",
+            "TotalMinutes",
+            "TotalSeconds",
+            "TotalMilliseconds",
+            "TotalMicroseconds",
+            "TotalNanoseconds",
+            "Truncate",
+            "OffsetBy",
+            "MonthStart",
+            "MonthEnd",
+            "BaseUtcOffset",
+            "DSTOffset",
+            "Round",
+            "Replace"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "Duration"
+          ],
+          "properties": {
+            "Duration": {
+              "$ref": "#/definitions/TimeUnit"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "ToString"
+          ],
+          "properties": {
+            "ToString": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "CastTimeUnit"
+          ],
+          "properties": {
+            "CastTimeUnit": {
+              "$ref": "#/definitions/TimeUnit"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "WithTimeUnit"
+          ],
+          "properties": {
+            "WithTimeUnit": {
+              "$ref": "#/definitions/TimeUnit"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "ConvertTimeZone"
+          ],
+          "properties": {
+            "ConvertTimeZone": {
+              "$ref": "#/definitions/TimeZone"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "TimeStamp"
+          ],
+          "properties": {
+            "TimeStamp": {
+              "$ref": "#/definitions/TimeUnit"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "ReplaceTimeZone"
+          ],
+          "properties": {
+            "ReplaceTimeZone": {
+              "type": "array",
+              "items": [
+                {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/TimeZone"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/NonExistent"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Combine"
+          ],
+          "properties": {
+            "Combine": {
+              "$ref": "#/definitions/TimeUnit"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "DatetimeFunction"
+          ],
+          "properties": {
+            "DatetimeFunction": {
+              "type": "object",
+              "required": [
+                "time_unit"
+              ],
+              "properties": {
+                "time_unit": {
+                  "$ref": "#/definitions/TimeUnit"
+                },
+                "time_zone": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/TimeZone"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "NonExistent": {
+      "type": "string",
+      "enum": [
+        "Null",
+        "Raise"
+      ]
+    },
+    "BitwiseFunction": {
+      "type": "string",
+      "enum": [
+        "CountOnes",
+        "CountZeros",
+        "LeadingOnes",
+        "LeadingZeros",
+        "TrailingOnes",
+        "TrailingZeros",
+        "And",
+        "Or",
+        "Xor"
+      ]
+    },
+    "BooleanFunction": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "IsNull",
+            "IsNotNull",
+            "IsFinite",
+            "IsInfinite",
+            "IsNan",
+            "IsNotNan",
+            "IsFirstDistinct",
+            "IsLastDistinct",
+            "IsUnique",
+            "IsDuplicated",
+            "AllHorizontal",
+            "AnyHorizontal",
+            "Not"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "Any"
+          ],
+          "properties": {
+            "Any": {
+              "type": "object",
+              "required": [
+                "ignore_nulls"
+              ],
+              "properties": {
+                "ignore_nulls": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "All"
+          ],
+          "properties": {
+            "All": {
+              "type": "object",
+              "required": [
+                "ignore_nulls"
+              ],
+              "properties": {
+                "ignore_nulls": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "IsBetween"
+          ],
+          "properties": {
+            "IsBetween": {
+              "type": "object",
+              "required": [
+                "closed"
+              ],
+              "properties": {
+                "closed": {
+                  "$ref": "#/definitions/ClosedInterval"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "IsIn"
+          ],
+          "properties": {
+            "IsIn": {
+              "type": "object",
+              "required": [
+                "nulls_equal"
+              ],
+              "properties": {
+                "nulls_equal": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "ClosedInterval": {
+      "type": "string",
+      "enum": [
+        "Both",
+        "Left",
+        "Right",
+        "None"
+      ]
+    },
+    "BusinessFunction": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "BusinessDayCount"
+          ],
+          "properties": {
+            "BusinessDayCount": {
+              "type": "object",
+              "required": [
+                "holidays",
+                "week_mask"
+              ],
+              "properties": {
+                "week_mask": {
+                  "type": "array",
+                  "items": {
+                    "type": "boolean"
+                  },
+                  "maxItems": 7,
+                  "minItems": 7
+                },
+                "holidays": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "AddBusinessDay"
+          ],
+          "properties": {
+            "AddBusinessDay": {
+              "type": "object",
+              "required": [
+                "holidays",
+                "roll",
+                "week_mask"
+              ],
+              "properties": {
+                "week_mask": {
+                  "type": "array",
+                  "items": {
+                    "type": "boolean"
+                  },
+                  "maxItems": 7,
+                  "minItems": 7
+                },
+                "holidays": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                },
+                "roll": {
+                  "$ref": "#/definitions/Roll"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "IsBusinessDay"
+          ],
+          "properties": {
+            "IsBusinessDay": {
+              "type": "object",
+              "required": [
+                "holidays",
+                "week_mask"
+              ],
+              "properties": {
+                "week_mask": {
+                  "type": "array",
+                  "items": {
+                    "type": "boolean"
+                  },
+                  "maxItems": 7,
+                  "minItems": 7
+                },
+                "holidays": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Roll": {
+      "type": "string",
+      "enum": [
+        "Forward",
+        "Backward",
+        "Raise"
+      ]
+    },
+    "PowFunction": {
+      "type": "string",
+      "enum": [
+        "Generic",
+        "Sqrt",
+        "Cbrt"
+      ]
+    },
+    "SearchSortedSide": {
+      "type": "string",
+      "enum": [
+        "Any",
+        "Left",
+        "Right"
+      ]
+    },
+    "RangeFunction": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "IntRanges"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "IntRange"
+          ],
+          "properties": {
+            "IntRange": {
+              "type": "object",
+              "required": [
+                "dtype",
+                "step"
+              ],
+              "properties": {
+                "step": {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "dtype": {
+                  "$ref": "#/definitions/DataType"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "LinearSpace"
+          ],
+          "properties": {
+            "LinearSpace": {
+              "type": "object",
+              "required": [
+                "closed"
+              ],
+              "properties": {
+                "closed": {
+                  "$ref": "#/definitions/ClosedInterval"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "LinearSpaces"
+          ],
+          "properties": {
+            "LinearSpaces": {
+              "type": "object",
+              "required": [
+                "closed"
+              ],
+              "properties": {
+                "closed": {
+                  "$ref": "#/definitions/ClosedInterval"
+                },
+                "array_width": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "format": "uint",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "DateRange"
+          ],
+          "properties": {
+            "DateRange": {
+              "type": "object",
+              "required": [
+                "closed",
+                "interval"
+              ],
+              "properties": {
+                "interval": {
+                  "$ref": "#/definitions/Duration"
+                },
+                "closed": {
+                  "$ref": "#/definitions/ClosedWindow"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "DateRanges"
+          ],
+          "properties": {
+            "DateRanges": {
+              "type": "object",
+              "required": [
+                "closed",
+                "interval"
+              ],
+              "properties": {
+                "interval": {
+                  "$ref": "#/definitions/Duration"
+                },
+                "closed": {
+                  "$ref": "#/definitions/ClosedWindow"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "DatetimeRange"
+          ],
+          "properties": {
+            "DatetimeRange": {
+              "type": "object",
+              "required": [
+                "closed",
+                "interval"
+              ],
+              "properties": {
+                "interval": {
+                  "$ref": "#/definitions/Duration"
+                },
+                "closed": {
+                  "$ref": "#/definitions/ClosedWindow"
+                },
+                "time_unit": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/TimeUnit"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "time_zone": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/TimeZone"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "DatetimeRanges"
+          ],
+          "properties": {
+            "DatetimeRanges": {
+              "type": "object",
+              "required": [
+                "closed",
+                "interval"
+              ],
+              "properties": {
+                "interval": {
+                  "$ref": "#/definitions/Duration"
+                },
+                "closed": {
+                  "$ref": "#/definitions/ClosedWindow"
+                },
+                "time_unit": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/TimeUnit"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "time_zone": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/TimeZone"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "TimeRange"
+          ],
+          "properties": {
+            "TimeRange": {
+              "type": "object",
+              "required": [
+                "closed",
+                "interval"
+              ],
+              "properties": {
+                "interval": {
+                  "$ref": "#/definitions/Duration"
+                },
+                "closed": {
+                  "$ref": "#/definitions/ClosedWindow"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "TimeRanges"
+          ],
+          "properties": {
+            "TimeRanges": {
+              "type": "object",
+              "required": [
+                "closed",
+                "interval"
+              ],
+              "properties": {
+                "interval": {
+                  "$ref": "#/definitions/Duration"
+                },
+                "closed": {
+                  "$ref": "#/definitions/ClosedWindow"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Duration": {
+      "type": "object",
+      "required": [
+        "days",
+        "months",
+        "negative",
+        "nsecs",
+        "parsed_int",
+        "weeks"
+      ],
+      "properties": {
+        "months": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "weeks": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "days": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "nsecs": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "negative": {
+          "type": "boolean"
+        },
+        "parsed_int": {
+          "type": "boolean"
+        }
+      }
+    },
+    "ClosedWindow": {
+      "type": "string",
+      "enum": [
+        "Left",
+        "Right",
+        "Both",
+        "None"
+      ]
+    },
+    "TrigonometricFunction": {
+      "type": "string",
+      "enum": [
+        "Cos",
+        "Cot",
+        "Sin",
+        "Tan",
+        "ArcCos",
+        "ArcSin",
+        "ArcTan",
+        "Cosh",
+        "Sinh",
+        "Tanh",
+        "ArcCosh",
+        "ArcSinh",
+        "ArcTanh",
+        "Degrees",
+        "Radians"
+      ]
+    },
+    "FillNullStrategy": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "Backward"
+          ],
+          "properties": {
+            "Backward": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Forward"
+          ],
+          "properties": {
+            "Forward": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Mean"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Min"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Max"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Zero"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "One"
+          ]
+        }
+      ]
+    },
+    "RollingFunction": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "Min"
+          ],
+          "properties": {
+            "Min": {
+              "$ref": "#/definitions/RollingOptionsFixedWindow"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Max"
+          ],
+          "properties": {
+            "Max": {
+              "$ref": "#/definitions/RollingOptionsFixedWindow"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Mean"
+          ],
+          "properties": {
+            "Mean": {
+              "$ref": "#/definitions/RollingOptionsFixedWindow"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Sum"
+          ],
+          "properties": {
+            "Sum": {
+              "$ref": "#/definitions/RollingOptionsFixedWindow"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Quantile"
+          ],
+          "properties": {
+            "Quantile": {
+              "$ref": "#/definitions/RollingOptionsFixedWindow"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Var"
+          ],
+          "properties": {
+            "Var": {
+              "$ref": "#/definitions/RollingOptionsFixedWindow"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Std"
+          ],
+          "properties": {
+            "Std": {
+              "$ref": "#/definitions/RollingOptionsFixedWindow"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Skew"
+          ],
+          "properties": {
+            "Skew": {
+              "$ref": "#/definitions/RollingOptionsFixedWindow"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Kurtosis"
+          ],
+          "properties": {
+            "Kurtosis": {
+              "$ref": "#/definitions/RollingOptionsFixedWindow"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "CorrCov"
+          ],
+          "properties": {
+            "CorrCov": {
+              "type": "object",
+              "required": [
+                "corr_cov_options",
+                "is_corr",
+                "rolling_options"
+              ],
+              "properties": {
+                "rolling_options": {
+                  "$ref": "#/definitions/RollingOptionsFixedWindow"
+                },
+                "corr_cov_options": {
+                  "$ref": "#/definitions/RollingCovOptions"
+                },
+                "is_corr": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "RollingOptionsFixedWindow": {
+      "type": "object",
+      "required": [
+        "center",
+        "min_periods",
+        "window_size"
+      ],
+      "properties": {
+        "window_size": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "min_periods": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "weights": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "center": {
+          "type": "boolean"
+        },
+        "fn_params": {
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RollingFnParams"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "RollingFnParams": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "Quantile"
+          ],
+          "properties": {
+            "Quantile": {
+              "$ref": "#/definitions/RollingQuantileParams"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Var"
+          ],
+          "properties": {
+            "Var": {
+              "$ref": "#/definitions/RollingVarParams"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Skew"
+          ],
+          "properties": {
+            "Skew": {
+              "type": "object",
+              "required": [
+                "bias"
+              ],
+              "properties": {
+                "bias": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Kurtosis"
+          ],
+          "properties": {
+            "Kurtosis": {
+              "type": "object",
+              "required": [
+                "bias",
+                "fisher"
+              ],
+              "properties": {
+                "fisher": {
+                  "type": "boolean"
+                },
+                "bias": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "RollingQuantileParams": {
+      "type": "object",
+      "required": [
+        "method",
+        "prob"
+      ],
+      "properties": {
+        "prob": {
+          "type": "number",
+          "format": "double"
+        },
+        "method": {
+          "$ref": "#/definitions/QuantileMethod"
+        }
+      }
+    },
+    "RollingVarParams": {
+      "type": "object",
+      "required": [
+        "ddof"
+      ],
+      "properties": {
+        "ddof": {
+          "type": "integer",
+          "format": "uint8",
+          "minimum": 0.0
+        }
+      }
+    },
+    "RollingCovOptions": {
+      "type": "object",
+      "required": [
+        "ddof",
+        "min_periods",
+        "window_size"
+      ],
+      "properties": {
+        "window_size": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "min_periods": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "ddof": {
+          "type": "integer",
+          "format": "uint8",
+          "minimum": 0.0
+        }
+      }
+    },
+    "RollingFunctionBy": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "MinBy"
+          ],
+          "properties": {
+            "MinBy": {
+              "$ref": "#/definitions/RollingOptionsDynamicWindow"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "MaxBy"
+          ],
+          "properties": {
+            "MaxBy": {
+              "$ref": "#/definitions/RollingOptionsDynamicWindow"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "MeanBy"
+          ],
+          "properties": {
+            "MeanBy": {
+              "$ref": "#/definitions/RollingOptionsDynamicWindow"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "SumBy"
+          ],
+          "properties": {
+            "SumBy": {
+              "$ref": "#/definitions/RollingOptionsDynamicWindow"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "QuantileBy"
+          ],
+          "properties": {
+            "QuantileBy": {
+              "$ref": "#/definitions/RollingOptionsDynamicWindow"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "VarBy"
+          ],
+          "properties": {
+            "VarBy": {
+              "$ref": "#/definitions/RollingOptionsDynamicWindow"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "StdBy"
+          ],
+          "properties": {
+            "StdBy": {
+              "$ref": "#/definitions/RollingOptionsDynamicWindow"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "RollingOptionsDynamicWindow": {
+      "type": "object",
+      "required": [
+        "closed_window",
+        "min_periods",
+        "window_size"
+      ],
+      "properties": {
+        "window_size": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/Duration"
+            }
+          ]
+        },
+        "min_periods": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "closed_window": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ClosedWindow"
+            }
+          ]
+        },
+        "fn_params": {
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RollingFnParams"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "ReshapeDimension": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Infer"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "Specified"
+          ],
+          "properties": {
+            "Specified": {
+              "$ref": "#/definitions/Dimension"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Dimension": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 1.0
+    },
+    "RankOptions": {
+      "type": "object",
+      "required": [
+        "descending",
+        "method"
+      ],
+      "properties": {
+        "method": {
+          "$ref": "#/definitions/RankMethod"
+        },
+        "descending": {
+          "type": "boolean"
+        }
+      }
+    },
+    "RankMethod": {
+      "type": "string",
+      "enum": [
+        "Average",
+        "Min",
+        "Max",
+        "Dense",
+        "Ordinal",
+        "Random"
+      ]
+    },
+    "InterpolationMethod": {
+      "type": "string",
+      "enum": [
+        "Linear",
+        "Nearest"
+      ]
+    },
+    "RoundMode": {
+      "type": "string",
+      "enum": [
+        "HalfToEven",
+        "HalfAwayFromZero"
+      ]
+    },
+    "FusedOperator": {
+      "type": "string",
+      "enum": [
+        "MultiplyAdd",
+        "SubMultiply",
+        "MultiplySub"
+      ]
+    },
+    "CorrelationMethod": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Pearson"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "SpearmanRank"
+          ],
+          "properties": {
+            "SpearmanRank": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Covariance"
+          ],
+          "properties": {
+            "Covariance": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "RandomMethod": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Shuffle"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "Sample"
+          ],
+          "properties": {
+            "Sample": {
+              "type": "object",
+              "required": [
+                "is_fraction",
+                "shuffle",
+                "with_replacement"
+              ],
+              "properties": {
+                "is_fraction": {
+                  "type": "boolean"
+                },
+                "with_replacement": {
+                  "type": "boolean"
+                },
+                "shuffle": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "IsSorted": {
+      "type": "string",
+      "enum": [
+        "Ascending",
+        "Descending",
+        "Not"
+      ]
+    },
+    "FunctionOptions": {
+      "type": "object",
+      "required": [
+        "check_lengths",
+        "flags"
+      ],
+      "properties": {
+        "check_lengths": {
+          "$ref": "#/definitions/UnsafeBool"
+        },
+        "flags": {
+          "$ref": "#/definitions/FunctionFlags"
+        }
+      }
+    },
+    "UnsafeBool": {
+      "type": "boolean"
+    },
+    "FunctionFlags": {
+      "type": "string",
+      "format": "bitflags",
+      "bitflags": {
+        "ALLOW_GROUP_AWARE": 1,
+        "ALLOW_RENAME": 4,
+        "PASS_NAME_TO_APPLY": 8,
+        "INPUT_WILDCARD_EXPANSION": 16,
+        "RETURNS_SCALAR": 32,
+        "OPTIONAL_RE_ENTRANT": 64,
+        "ALLOW_EMPTY_INPUTS": 128,
+        "ROW_SEPARABLE": 256,
+        "LENGTH_PRESERVING": 512,
+        "APPLY_LIST": 1024
+      }
+    },
+    "EWMOptions": {
+      "type": "object",
+      "required": [
+        "adjust",
+        "alpha",
+        "bias",
+        "ignore_nulls",
+        "min_periods"
+      ],
+      "properties": {
+        "alpha": {
+          "type": "number",
+          "format": "double"
+        },
+        "adjust": {
+          "type": "boolean"
+        },
+        "bias": {
+          "type": "boolean"
+        },
+        "min_periods": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "ignore_nulls": {
+          "type": "boolean"
+        }
+      }
+    },
+    "WindowType": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "Over"
+          ],
+          "properties": {
+            "Over": {
+              "$ref": "#/definitions/WindowMapping"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Rolling"
+          ],
+          "properties": {
+            "Rolling": {
+              "$ref": "#/definitions/RollingGroupOptions"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "WindowMapping": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "GroupsToRows"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Explode"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Join"
+          ]
+        }
+      ]
+    },
+    "RollingGroupOptions": {
+      "type": "object",
+      "required": [
+        "closed_window",
+        "index_column",
+        "offset",
+        "period"
+      ],
+      "properties": {
+        "index_column": {
+          "type": "string"
+        },
+        "period": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/Duration"
+            }
+          ]
+        },
+        "offset": {
+          "$ref": "#/definitions/Duration"
+        },
+        "closed_window": {
+          "$ref": "#/definitions/ClosedWindow"
+        }
+      }
+    },
+    "Excluded": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "Name"
+          ],
+          "properties": {
+            "Name": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Dtype"
+          ],
+          "properties": {
+            "Dtype": {
+              "$ref": "#/definitions/DataType"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "ColumnsUdf": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "format": "uint8",
+        "minimum": 0.0
+      }
+    },
+    "GetOutput": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "format": "uint8",
+        "minimum": 0.0
+      }
+    },
+    "Selector": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "Add"
+          ],
+          "properties": {
+            "Add": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/Selector"
+                },
+                {
+                  "$ref": "#/definitions/Selector"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Sub"
+          ],
+          "properties": {
+            "Sub": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/Selector"
+                },
+                {
+                  "$ref": "#/definitions/Selector"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "ExclusiveOr"
+          ],
+          "properties": {
+            "ExclusiveOr": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/Selector"
+                },
+                {
+                  "$ref": "#/definitions/Selector"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Intersect"
+          ],
+          "properties": {
+            "Intersect": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/Selector"
+                },
+                {
+                  "$ref": "#/definitions/Selector"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Root"
+          ],
+          "properties": {
+            "Root": {
+              "$ref": "#/definitions/Expr"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "ScanSources": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "Paths"
+          ],
+          "properties": {
+            "Paths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "FileInfo": {
+      "type": "object",
+      "required": [
+        "row_estimation",
+        "schema"
+      ],
+      "properties": {
+        "schema": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/Schema_for_DataType"
+            }
+          ]
+        },
+        "reader_schema": {
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Schema_for_Field"
+                },
+                {
+                  "$ref": "#/definitions/Schema_for_DataType"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "row_estimation": {
+          "type": "array",
+          "items": [
+            {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint",
+              "minimum": 0.0
+            },
+            {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0.0
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2
+        }
+      }
+    },
+    "Schema_for_Field": {
+      "type": "object",
+      "required": [
+        "fields"
+      ],
+      "properties": {
+        "fields": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Field2"
+          }
+        }
+      }
+    },
+    "Field2": {
+      "type": "object",
+      "required": [
+        "dtype",
+        "is_nullable",
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "dtype": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ArrowDataType"
+            }
+          ]
+        },
+        "is_nullable": {
+          "type": "boolean"
+        },
+        "metadata": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ArrowDataType": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Null"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Boolean"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Int8"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Int16"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Int32"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Int64"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Int128"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "UInt8"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "UInt16"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "UInt32"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "UInt64"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Float16"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Float32"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Float64"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "Timestamp"
+          ],
+          "properties": {
+            "Timestamp": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/TimeUnit2"
+                },
+                {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Date32"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Date64"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "Time32"
+          ],
+          "properties": {
+            "Time32": {
+              "$ref": "#/definitions/TimeUnit2"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Time64"
+          ],
+          "properties": {
+            "Time64": {
+              "$ref": "#/definitions/TimeUnit2"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Duration"
+          ],
+          "properties": {
+            "Duration": {
+              "$ref": "#/definitions/TimeUnit2"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Interval"
+          ],
+          "properties": {
+            "Interval": {
+              "$ref": "#/definitions/IntervalUnit"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Binary"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "FixedSizeBinary"
+          ],
+          "properties": {
+            "FixedSizeBinary": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "string",
+          "enum": [
+            "LargeBinary"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Utf8"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "LargeUtf8"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "List"
+          ],
+          "properties": {
+            "List": {
+              "$ref": "#/definitions/Field2"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "FixedSizeList"
+          ],
+          "properties": {
+            "FixedSizeList": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/Field2"
+                },
+                {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "LargeList"
+          ],
+          "properties": {
+            "LargeList": {
+              "$ref": "#/definitions/Field2"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Struct"
+          ],
+          "properties": {
+            "Struct": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Field2"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Map"
+          ],
+          "properties": {
+            "Map": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/Field2"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Dictionary"
+          ],
+          "properties": {
+            "Dictionary": {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/IntegerType"
+                },
+                {
+                  "$ref": "#/definitions/ArrowDataType"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "maxItems": 3,
+              "minItems": 3
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Decimal"
+          ],
+          "properties": {
+            "Decimal": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                },
+                {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Decimal256"
+          ],
+          "properties": {
+            "Decimal256": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                },
+                {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Extension"
+          ],
+          "properties": {
+            "Extension": {
+              "$ref": "#/definitions/ExtensionType"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "string",
+          "enum": [
+            "BinaryView"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Utf8View"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Unknown"
+          ]
+        }
+      ]
+    },
+    "TimeUnit2": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Second"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Millisecond"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Microsecond"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Nanosecond"
+          ]
+        }
+      ]
+    },
+    "IntervalUnit": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "YearMonth"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "DayTime"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "MonthDayNano"
+          ]
+        }
+      ]
+    },
+    "IntegerType": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Int8"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Int16"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Int32"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Int64"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Int128"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "UInt8"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "UInt16"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "UInt32"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "UInt64"
+          ]
+        }
+      ]
+    },
+    "ExtensionType": {
+      "type": "object",
+      "required": [
+        "inner",
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "inner": {
+          "$ref": "#/definitions/ArrowDataType"
+        },
+        "metadata": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "UnifiedScanArgs": {
+      "type": "object",
+      "required": [
+        "cache",
+        "cast_columns_policy",
+        "glob",
+        "hive_options",
+        "missing_columns_policy",
+        "rechunk"
+      ],
+      "properties": {
+        "schema": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Schema_for_DataType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cloud_options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CloudOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hive_options": {
+          "$ref": "#/definitions/HiveOptions"
+        },
+        "rechunk": {
+          "type": "boolean"
+        },
+        "cache": {
+          "type": "boolean"
+        },
+        "glob": {
+          "type": "boolean"
+        },
+        "projection": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "row_index": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RowIndex"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pre_slice": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Slice"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cast_columns_policy": {
+          "$ref": "#/definitions/CastColumnsPolicy"
+        },
+        "missing_columns_policy": {
+          "$ref": "#/definitions/MissingColumnsPolicy"
+        },
+        "include_file_paths": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "CloudOptions": {
+      "type": "object",
+      "required": [
+        "file_cache_ttl",
+        "max_retries"
+      ],
+      "properties": {
+        "max_retries": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "file_cache_ttl": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CloudConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "credential_provider": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PlCredentialProvider"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "CloudConfig": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "Aws"
+          ],
+          "properties": {
+            "Aws": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Azure"
+          ],
+          "properties": {
+            "Azure": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Gcp"
+          ],
+          "properties": {
+            "Gcp": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Http"
+          ],
+          "properties": {
+            "Http": {
+              "type": "object",
+              "required": [
+                "headers"
+              ],
+              "properties": {
+                "headers": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "maxItems": 2,
+                    "minItems": 2
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "PlCredentialProvider": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "format": "uint8",
+        "minimum": 0.0
+      }
+    },
+    "HiveOptions": {
+      "type": "object",
+      "required": [
+        "hive_start_idx",
+        "try_parse_dates"
+      ],
+      "properties": {
+        "enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "hive_start_idx": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "schema": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Schema_for_DataType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "try_parse_dates": {
+          "type": "boolean"
+        }
+      }
+    },
+    "RowIndex": {
+      "type": "object",
+      "required": [
+        "name",
+        "offset"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "offset": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
+    },
+    "Slice": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "Positive"
+          ],
+          "properties": {
+            "Positive": {
+              "type": "object",
+              "required": [
+                "len",
+                "offset"
+              ],
+              "properties": {
+                "offset": {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                },
+                "len": {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Negative"
+          ],
+          "properties": {
+            "Negative": {
+              "type": "object",
+              "required": [
+                "len",
+                "offset_from_end"
+              ],
+              "properties": {
+                "offset_from_end": {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                },
+                "len": {
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "CastColumnsPolicy": {
+      "type": "object",
+      "required": [
+        "datetime_convert_timezone",
+        "datetime_microseconds_downcast",
+        "datetime_nanoseconds_downcast",
+        "extra_struct_fields",
+        "float_downcast",
+        "float_upcast",
+        "integer_upcast",
+        "missing_struct_fields"
+      ],
+      "properties": {
+        "integer_upcast": {
+          "type": "boolean"
+        },
+        "float_upcast": {
+          "type": "boolean"
+        },
+        "float_downcast": {
+          "type": "boolean"
+        },
+        "datetime_nanoseconds_downcast": {
+          "type": "boolean"
+        },
+        "datetime_microseconds_downcast": {
+          "type": "boolean"
+        },
+        "datetime_convert_timezone": {
+          "type": "boolean"
+        },
+        "missing_struct_fields": {
+          "$ref": "#/definitions/MissingColumnsPolicy"
+        },
+        "extra_struct_fields": {
+          "$ref": "#/definitions/ExtraColumnsPolicy"
+        }
+      }
+    },
+    "MissingColumnsPolicy": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Raise"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Insert"
+          ]
+        }
+      ]
+    },
+    "ExtraColumnsPolicy": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Ignore"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Raise"
+          ]
+        }
+      ]
+    },
+    "FileScan": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "Csv"
+          ],
+          "properties": {
+            "Csv": {
+              "type": "object",
+              "required": [
+                "options"
+              ],
+              "properties": {
+                "options": {
+                  "$ref": "#/definitions/CsvReadOptions"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "NDJson"
+          ],
+          "properties": {
+            "NDJson": {
+              "type": "object",
+              "required": [
+                "options"
+              ],
+              "properties": {
+                "options": {
+                  "$ref": "#/definitions/NDJsonReadOptions"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Parquet"
+          ],
+          "properties": {
+            "Parquet": {
+              "type": "object",
+              "required": [
+                "options"
+              ],
+              "properties": {
+                "options": {
+                  "$ref": "#/definitions/ParquetOptions"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Ipc"
+          ],
+          "properties": {
+            "Ipc": {
+              "type": "object",
+              "required": [
+                "options"
+              ],
+              "properties": {
+                "options": {
+                  "$ref": "#/definitions/IpcScanOptions"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "PythonDataset"
+          ],
+          "properties": {
+            "PythonDataset": {
+              "type": "object",
+              "required": [
+                "dataset_object"
+              ],
+              "properties": {
+                "dataset_object": {
+                  "$ref": "#/definitions/PythonDatasetProvider"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "CsvReadOptions": {
+      "type": "object",
+      "required": [
+        "chunk_size",
+        "fields_to_cast",
+        "has_header",
+        "ignore_errors",
+        "low_memory",
+        "parse_options",
+        "raise_if_empty",
+        "rechunk",
+        "skip_lines",
+        "skip_rows",
+        "skip_rows_after_header"
+      ],
+      "properties": {
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rechunk": {
+          "type": "boolean"
+        },
+        "n_threads": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "low_memory": {
+          "type": "boolean"
+        },
+        "n_rows": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "row_index": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RowIndex"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "columns": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "projection": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0.0
+          }
+        },
+        "schema": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Schema_for_DataType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "schema_overwrite": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Schema_for_DataType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dtype_overwrite": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/DataType"
+          }
+        },
+        "parse_options": {
+          "$ref": "#/definitions/CsvParseOptions"
+        },
+        "has_header": {
+          "type": "boolean"
+        },
+        "chunk_size": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "skip_rows": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "skip_lines": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "skip_rows_after_header": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "infer_schema_length": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "raise_if_empty": {
+          "type": "boolean"
+        },
+        "ignore_errors": {
+          "type": "boolean"
+        },
+        "fields_to_cast": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Field"
+          }
+        }
+      }
+    },
+    "CsvParseOptions": {
+      "type": "object",
+      "required": [
+        "decimal_comma",
+        "encoding",
+        "eol_char",
+        "missing_is_null",
+        "separator",
+        "truncate_ragged_lines",
+        "try_parse_dates"
+      ],
+      "properties": {
+        "separator": {
+          "type": "integer",
+          "format": "uint8",
+          "minimum": 0.0
+        },
+        "quote_char": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint8",
+          "minimum": 0.0
+        },
+        "eol_char": {
+          "type": "integer",
+          "format": "uint8",
+          "minimum": 0.0
+        },
+        "encoding": {
+          "$ref": "#/definitions/CsvEncoding"
+        },
+        "null_values": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NullValues"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "missing_is_null": {
+          "type": "boolean"
+        },
+        "truncate_ragged_lines": {
+          "type": "boolean"
+        },
+        "comment_prefix": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CommentPrefix"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "try_parse_dates": {
+          "type": "boolean"
+        },
+        "decimal_comma": {
+          "type": "boolean"
+        }
+      }
+    },
+    "CsvEncoding": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Utf8"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "LossyUtf8"
+          ]
+        }
+      ]
+    },
+    "NullValues": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "AllColumnsSingle"
+          ],
+          "properties": {
+            "AllColumnsSingle": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "AllColumns"
+          ],
+          "properties": {
+            "AllColumns": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Named"
+          ],
+          "properties": {
+            "Named": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "CommentPrefix": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "Single"
+          ],
+          "properties": {
+            "Single": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Multi"
+          ],
+          "properties": {
+            "Multi": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "NDJsonReadOptions": {
+      "type": "object",
+      "required": [
+        "chunk_size",
+        "ignore_errors",
+        "low_memory"
+      ],
+      "properties": {
+        "n_threads": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "infer_schema_length": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 1.0
+        },
+        "chunk_size": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 1.0
+        },
+        "low_memory": {
+          "type": "boolean"
+        },
+        "ignore_errors": {
+          "type": "boolean"
+        },
+        "schema": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Schema_for_DataType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "schema_overwrite": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Schema_for_DataType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "ParquetOptions": {
+      "type": "object",
+      "required": [
+        "low_memory",
+        "parallel",
+        "use_statistics"
+      ],
+      "properties": {
+        "schema": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Schema_for_DataType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "parallel": {
+          "$ref": "#/definitions/ParallelStrategy"
+        },
+        "low_memory": {
+          "type": "boolean"
+        },
+        "use_statistics": {
+          "type": "boolean"
+        }
+      }
+    },
+    "ParallelStrategy": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "None"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Columns"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "RowGroups"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Prefiltered"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Auto"
+          ]
+        }
+      ]
+    },
+    "IpcScanOptions": {
+      "type": "null"
+    },
+    "PythonDatasetProvider": {
+      "type": "object",
+      "required": [
+        "dataset_object"
+      ],
+      "properties": {
+        "dataset_object": {
+          "$ref": "#/definitions/PythonObject"
+        }
+      }
+    },
+    "DataFrame": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "format": "uint8",
+        "minimum": 0.0
+      }
+    },
+    "ProjectionOptions": {
+      "type": "object",
+      "required": [
+        "duplicate_check",
+        "run_parallel",
+        "should_broadcast"
+      ],
+      "properties": {
+        "run_parallel": {
+          "type": "boolean"
+        },
+        "duplicate_check": {
+          "type": "boolean"
+        },
+        "should_broadcast": {
+          "type": "boolean"
+        }
+      }
+    },
+    "GroupbyOptions": {
+      "type": "object",
+      "properties": {
+        "dynamic": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DynamicGroupOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "rolling": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RollingGroupOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "slice": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": [
+            {
+              "type": "integer",
+              "format": "int64"
+            },
+            {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0.0
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2
+        }
+      }
+    },
+    "DynamicGroupOptions": {
+      "type": "object",
+      "required": [
+        "closed_window",
+        "every",
+        "include_boundaries",
+        "index_column",
+        "label",
+        "offset",
+        "period",
+        "start_by"
+      ],
+      "properties": {
+        "index_column": {
+          "type": "string"
+        },
+        "every": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/Duration"
+            }
+          ]
+        },
+        "period": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/Duration"
+            }
+          ]
+        },
+        "offset": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/Duration"
+            }
+          ]
+        },
+        "label": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/Label"
+            }
+          ]
+        },
+        "include_boundaries": {
+          "type": "boolean"
+        },
+        "closed_window": {
+          "$ref": "#/definitions/ClosedWindow"
+        },
+        "start_by": {
+          "$ref": "#/definitions/StartBy"
+        }
+      }
+    },
+    "Label": {
+      "type": "string",
+      "enum": [
+        "Left",
+        "Right",
+        "DataPoint"
+      ]
+    },
+    "StartBy": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "WindowBound",
+            "DataPoint",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday",
+            "Saturday",
+            "Sunday"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Monday"
+          ]
+        }
+      ]
+    },
+    "JoinOptions": {
+      "type": "object",
+      "required": [
+        "allow_parallel",
+        "args",
+        "force_parallel",
+        "rows_left",
+        "rows_right"
+      ],
+      "properties": {
+        "allow_parallel": {
+          "type": "boolean"
+        },
+        "force_parallel": {
+          "type": "boolean"
+        },
+        "args": {
+          "$ref": "#/definitions/JoinArgs"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/JoinTypeOptionsIR"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "rows_left": {
+          "type": "array",
+          "items": [
+            {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint",
+              "minimum": 0.0
+            },
+            {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0.0
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2
+        },
+        "rows_right": {
+          "type": "array",
+          "items": [
+            {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint",
+              "minimum": 0.0
+            },
+            {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0.0
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2
+        }
+      }
+    },
+    "JoinArgs": {
+      "type": "object",
+      "required": [
+        "coalesce",
+        "how",
+        "maintain_order",
+        "nulls_equal",
+        "validation"
+      ],
+      "properties": {
+        "how": {
+          "$ref": "#/definitions/JoinType"
+        },
+        "validation": {
+          "$ref": "#/definitions/JoinValidation"
+        },
+        "suffix": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "slice": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": [
+            {
+              "type": "integer",
+              "format": "int64"
+            },
+            {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0.0
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2
+        },
+        "nulls_equal": {
+          "type": "boolean"
+        },
+        "coalesce": {
+          "$ref": "#/definitions/JoinCoalesce"
+        },
+        "maintain_order": {
+          "$ref": "#/definitions/MaintainOrderJoin"
+        }
+      }
+    },
+    "JoinType": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Inner",
+            "Left",
+            "Right",
+            "Full",
+            "Semi",
+            "Anti",
+            "IEJoin",
+            "Cross"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "AsOf"
+          ],
+          "properties": {
+            "AsOf": {
+              "$ref": "#/definitions/AsOfOptions"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "AsOfOptions": {
+      "type": "object",
+      "required": [
+        "allow_eq",
+        "check_sortedness",
+        "strategy"
+      ],
+      "properties": {
+        "strategy": {
+          "$ref": "#/definitions/AsofStrategy"
+        },
+        "tolerance": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AnyValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tolerance_str": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "left_by": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "right_by": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "allow_eq": {
+          "type": "boolean"
+        },
+        "check_sortedness": {
+          "type": "boolean"
+        }
+      }
+    },
+    "AsofStrategy": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Backward"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Forward"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Nearest"
+          ]
+        }
+      ]
+    },
+    "JoinValidation": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "ManyToMany"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "ManyToOne"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "OneToMany"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "OneToOne"
+          ]
+        }
+      ]
+    },
+    "JoinCoalesce": {
+      "type": "string",
+      "enum": [
+        "JoinSpecific",
+        "CoalesceColumns",
+        "KeepColumns"
+      ]
+    },
+    "MaintainOrderJoin": {
+      "type": "string",
+      "enum": [
+        "None",
+        "Left",
+        "Right",
+        "LeftRight",
+        "RightLeft"
+      ]
+    },
+    "JoinTypeOptionsIR": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "IEJoin"
+          ],
+          "properties": {
+            "IEJoin": {
+              "$ref": "#/definitions/IEJoinOptions"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Cross"
+          ],
+          "properties": {
+            "Cross": {
+              "type": "object",
+              "required": [
+                "predicate"
+              ],
+              "properties": {
+                "predicate": {
+                  "$ref": "#/definitions/ExprIR"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "IEJoinOptions": {
+      "type": "object",
+      "required": [
+        "operator1"
+      ],
+      "properties": {
+        "operator1": {
+          "$ref": "#/definitions/InequalityOperator"
+        },
+        "operator2": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InequalityOperator"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "InequalityOperator": {
+      "type": "string",
+      "enum": [
+        "Lt",
+        "LtEq",
+        "Gt",
+        "GtEq"
+      ]
+    },
+    "ExprIR": {
+      "type": "object",
+      "required": [
+        "node",
+        "output_name"
+      ],
+      "properties": {
+        "output_name": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/OutputName"
+            }
+          ]
+        },
+        "node": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/Node"
+            }
+          ]
+        }
+      }
+    },
+    "OutputName": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "None"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "LiteralLhs"
+          ],
+          "properties": {
+            "LiteralLhs": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "ColumnLhs"
+          ],
+          "properties": {
+            "ColumnLhs": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Alias"
+          ],
+          "properties": {
+            "Alias": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Field"
+          ],
+          "properties": {
+            "Field": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Node": {
+      "type": "integer",
+      "format": "uint",
+      "minimum": 0.0
+    },
+    "MatchToSchemaPerColumn": {
+      "type": "object",
+      "required": [
+        "extra_struct_fields",
+        "float_cast",
+        "integer_cast",
+        "missing_columns",
+        "missing_struct_fields"
+      ],
+      "properties": {
+        "missing_columns": {
+          "$ref": "#/definitions/MissingColumnsPolicyOrExpr"
+        },
+        "missing_struct_fields": {
+          "$ref": "#/definitions/MissingColumnsPolicy"
+        },
+        "extra_struct_fields": {
+          "$ref": "#/definitions/ExtraColumnsPolicy"
+        },
+        "integer_cast": {
+          "$ref": "#/definitions/UpcastOrForbid"
+        },
+        "float_cast": {
+          "$ref": "#/definitions/UpcastOrForbid"
+        }
+      }
+    },
+    "MissingColumnsPolicyOrExpr": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Insert",
+            "Raise"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "InsertWith"
+          ],
+          "properties": {
+            "InsertWith": {
+              "$ref": "#/definitions/Expr"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "UpcastOrForbid": {
+      "type": "string",
+      "enum": [
+        "Upcast",
+        "Forbid"
+      ]
+    },
+    "DistinctOptionsDSL": {
+      "type": "object",
+      "required": [
+        "keep_strategy",
+        "maintain_order"
+      ],
+      "properties": {
+        "subset": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Selector"
+          }
+        },
+        "maintain_order": {
+          "type": "boolean"
+        },
+        "keep_strategy": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/UniqueKeepStrategy"
+            }
+          ]
+        }
+      }
+    },
+    "UniqueKeepStrategy": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "First"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Last"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "None"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Any"
+          ]
+        }
+      ]
+    },
+    "DslFunction": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "RowIndex"
+          ],
+          "properties": {
+            "RowIndex": {
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "offset": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "OpaquePython"
+          ],
+          "properties": {
+            "OpaquePython": {
+              "$ref": "#/definitions/OpaquePythonUdf"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Explode"
+          ],
+          "properties": {
+            "Explode": {
+              "type": "object",
+              "required": [
+                "allow_empty",
+                "columns"
+              ],
+              "properties": {
+                "columns": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Selector"
+                  }
+                },
+                "allow_empty": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Unpivot"
+          ],
+          "properties": {
+            "Unpivot": {
+              "type": "object",
+              "required": [
+                "args"
+              ],
+              "properties": {
+                "args": {
+                  "$ref": "#/definitions/UnpivotArgsDSL"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Rename"
+          ],
+          "properties": {
+            "Rename": {
+              "type": "object",
+              "required": [
+                "existing",
+                "new",
+                "strict"
+              ],
+              "properties": {
+                "existing": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "new": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "strict": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Unnest"
+          ],
+          "properties": {
+            "Unnest": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Selector"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Stats"
+          ],
+          "properties": {
+            "Stats": {
+              "$ref": "#/definitions/StatsFunction"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "FillNan"
+          ],
+          "properties": {
+            "FillNan": {
+              "$ref": "#/definitions/Expr"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Drop"
+          ],
+          "properties": {
+            "Drop": {
+              "$ref": "#/definitions/DropFunction"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "OpaquePythonUdf": {
+      "type": "object",
+      "required": [
+        "function",
+        "predicate_pd",
+        "projection_pd",
+        "streamable",
+        "validate_output"
+      ],
+      "properties": {
+        "function": {
+          "$ref": "#/definitions/PythonObject"
+        },
+        "schema": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Schema_for_DataType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "predicate_pd": {
+          "type": "boolean"
+        },
+        "projection_pd": {
+          "type": "boolean"
+        },
+        "streamable": {
+          "type": "boolean"
+        },
+        "validate_output": {
+          "type": "boolean"
+        }
+      }
+    },
+    "UnpivotArgsDSL": {
+      "type": "object",
+      "required": [
+        "index",
+        "on"
+      ],
+      "properties": {
+        "on": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Selector"
+          }
+        },
+        "index": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Selector"
+          }
+        },
+        "variable_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "StatsFunction": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Median",
+            "Mean",
+            "Sum",
+            "Min",
+            "Max"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "Var"
+          ],
+          "properties": {
+            "Var": {
+              "type": "object",
+              "required": [
+                "ddof"
+              ],
+              "properties": {
+                "ddof": {
+                  "type": "integer",
+                  "format": "uint8",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Std"
+          ],
+          "properties": {
+            "Std": {
+              "type": "object",
+              "required": [
+                "ddof"
+              ],
+              "properties": {
+                "ddof": {
+                  "type": "integer",
+                  "format": "uint8",
+                  "minimum": 0.0
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Quantile"
+          ],
+          "properties": {
+            "Quantile": {
+              "type": "object",
+              "required": [
+                "method",
+                "quantile"
+              ],
+              "properties": {
+                "quantile": {
+                  "$ref": "#/definitions/Expr"
+                },
+                "method": {
+                  "$ref": "#/definitions/QuantileMethod"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "DropFunction": {
+      "type": "object",
+      "required": [
+        "strict",
+        "to_drop"
+      ],
+      "properties": {
+        "to_drop": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Selector"
+          }
+        },
+        "strict": {
+          "type": "boolean"
+        }
+      }
+    },
+    "UnionArgs": {
+      "type": "object",
+      "required": [
+        "diagonal",
+        "from_partitioned_ds",
+        "maintain_order",
+        "parallel",
+        "rechunk",
+        "to_supertypes"
+      ],
+      "properties": {
+        "parallel": {
+          "type": "boolean"
+        },
+        "rechunk": {
+          "type": "boolean"
+        },
+        "to_supertypes": {
+          "type": "boolean"
+        },
+        "diagonal": {
+          "type": "boolean"
+        },
+        "from_partitioned_ds": {
+          "type": "boolean"
+        },
+        "maintain_order": {
+          "type": "boolean"
+        }
+      }
+    },
+    "HConcatOptions": {
+      "type": "object",
+      "required": [
+        "parallel"
+      ],
+      "properties": {
+        "parallel": {
+          "type": "boolean"
+        }
+      }
+    },
+    "SinkType": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Memory"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "File"
+          ],
+          "properties": {
+            "File": {
+              "$ref": "#/definitions/FileSinkType"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Partition"
+          ],
+          "properties": {
+            "Partition": {
+              "$ref": "#/definitions/PartitionSinkType"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "FileSinkType": {
+      "type": "object",
+      "required": [
+        "file_type",
+        "sink_options",
+        "target"
+      ],
+      "properties": {
+        "target": {
+          "$ref": "#/definitions/SinkTarget"
+        },
+        "file_type": {
+          "$ref": "#/definitions/FileType"
+        },
+        "sink_options": {
+          "$ref": "#/definitions/SinkOptions"
+        },
+        "cloud_options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CloudOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "SinkTarget": {
+      "type": "string"
+    },
+    "FileType": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "Parquet"
+          ],
+          "properties": {
+            "Parquet": {
+              "$ref": "#/definitions/ParquetWriteOptions"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Ipc"
+          ],
+          "properties": {
+            "Ipc": {
+              "$ref": "#/definitions/IpcWriterOptions"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Csv"
+          ],
+          "properties": {
+            "Csv": {
+              "$ref": "#/definitions/CsvWriterOptions"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Json"
+          ],
+          "properties": {
+            "Json": {
+              "$ref": "#/definitions/JsonWriterOptions"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "ParquetWriteOptions": {
+      "type": "object",
+      "required": [
+        "compression",
+        "field_overwrites",
+        "statistics"
+      ],
+      "properties": {
+        "compression": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ParquetCompression"
+            }
+          ]
+        },
+        "statistics": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/StatisticsOptions"
+            }
+          ]
+        },
+        "row_group_size": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "data_page_size": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "key_value_metadata": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/KeyValueMetadata"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "field_overwrites": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ParquetFieldOverwrites"
+          }
+        }
+      }
+    },
+    "ParquetCompression": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Uncompressed",
+            "Snappy",
+            "Lzo",
+            "Lz4Raw"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "Gzip"
+          ],
+          "properties": {
+            "Gzip": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/GzipLevel"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Brotli"
+          ],
+          "properties": {
+            "Brotli": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/BrotliLevel"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Zstd"
+          ],
+          "properties": {
+            "Zstd": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ZstdLevel"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "GzipLevel": {
+      "type": "integer",
+      "format": "uint8",
+      "minimum": 0.0
+    },
+    "BrotliLevel": {
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0.0
+    },
+    "ZstdLevel": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "StatisticsOptions": {
+      "type": "object",
+      "required": [
+        "distinct_count",
+        "max_value",
+        "min_value",
+        "null_count"
+      ],
+      "properties": {
+        "min_value": {
+          "type": "boolean"
+        },
+        "max_value": {
+          "type": "boolean"
+        },
+        "distinct_count": {
+          "type": "boolean"
+        },
+        "null_count": {
+          "type": "boolean"
+        }
+      }
+    },
+    "KeyValueMetadata": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "Static"
+          ],
+          "properties": {
+            "Static": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                ],
+                "maxItems": 2,
+                "minItems": 2
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "DynamicPython"
+          ],
+          "properties": {
+            "DynamicPython": {
+              "$ref": "#/definitions/PythonKeyValueMetadataFunction"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "PythonKeyValueMetadataFunction": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "format": "uint8",
+        "minimum": 0.0
+      }
+    },
+    "ParquetFieldOverwrites": {
+      "type": "object",
+      "required": [
+        "children"
+      ],
+      "properties": {
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "children": {
+          "$ref": "#/definitions/ChildFieldOverwrites"
+        },
+        "field_id": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int32"
+        },
+        "metadata": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/MetadataKeyValue"
+          }
+        }
+      }
+    },
+    "ChildFieldOverwrites": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "None"
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "ListLike"
+          ],
+          "properties": {
+            "ListLike": {
+              "$ref": "#/definitions/ParquetFieldOverwrites"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Struct"
+          ],
+          "properties": {
+            "Struct": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ParquetFieldOverwrites"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "MetadataKeyValue": {
+      "type": "object",
+      "required": [
+        "key"
+      ],
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "IpcWriterOptions": {
+      "type": "object",
+      "required": [
+        "chunk_size",
+        "compat_level"
+      ],
+      "properties": {
+        "compression": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/IpcCompression"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "compat_level": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/CompatLevel"
+            }
+          ]
+        },
+        "chunk_size": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
+    },
+    "IpcCompression": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "LZ4"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "ZSTD"
+          ]
+        }
+      ]
+    },
+    "CompatLevel": {
+      "type": "integer",
+      "format": "uint16",
+      "minimum": 0.0
+    },
+    "CsvWriterOptions": {
+      "type": "object",
+      "required": [
+        "batch_size",
+        "include_bom",
+        "include_header",
+        "serialize_options"
+      ],
+      "properties": {
+        "include_bom": {
+          "type": "boolean"
+        },
+        "include_header": {
+          "type": "boolean"
+        },
+        "batch_size": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 1.0
+        },
+        "serialize_options": {
+          "$ref": "#/definitions/SerializeOptions"
+        }
+      }
+    },
+    "SerializeOptions": {
+      "type": "object",
+      "required": [
+        "line_terminator",
+        "null",
+        "quote_char",
+        "quote_style",
+        "separator"
+      ],
+      "properties": {
+        "date_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "time_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "datetime_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "float_scientific": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "float_precision": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "separator": {
+          "type": "integer",
+          "format": "uint8",
+          "minimum": 0.0
+        },
+        "quote_char": {
+          "type": "integer",
+          "format": "uint8",
+          "minimum": 0.0
+        },
+        "null": {
+          "type": "string"
+        },
+        "line_terminator": {
+          "type": "string"
+        },
+        "quote_style": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/QuoteStyle"
+            }
+          ]
+        }
+      }
+    },
+    "QuoteStyle": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "Necessary"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Always"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "NonNumeric"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Never"
+          ]
+        }
+      ]
+    },
+    "JsonWriterOptions": {
+      "type": "object"
+    },
+    "SinkOptions": {
+      "type": "object",
+      "required": [
+        "maintain_order",
+        "mkdir",
+        "sync_on_close"
+      ],
+      "properties": {
+        "sync_on_close": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/SyncOnCloseType"
+            }
+          ]
+        },
+        "maintain_order": {
+          "type": "boolean"
+        },
+        "mkdir": {
+          "type": "boolean"
+        }
+      }
+    },
+    "SyncOnCloseType": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "None"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "Data"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "All"
+          ]
+        }
+      ]
+    },
+    "PartitionSinkType": {
+      "type": "object",
+      "required": [
+        "base_path",
+        "file_type",
+        "sink_options",
+        "variant"
+      ],
+      "properties": {
+        "base_path": {
+          "type": "string"
+        },
+        "file_path_cb": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PartitionTargetCallback"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "file_type": {
+          "$ref": "#/definitions/FileType"
+        },
+        "sink_options": {
+          "$ref": "#/definitions/SinkOptions"
+        },
+        "variant": {
+          "$ref": "#/definitions/PartitionVariant"
+        },
+        "cloud_options": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CloudOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "PartitionTargetCallback": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "format": "uint8",
+        "minimum": 0.0
+      }
+    },
+    "PartitionVariant": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "MaxSize"
+          ],
+          "properties": {
+            "MaxSize": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Parted"
+          ],
+          "properties": {
+            "Parted": {
+              "type": "object",
+              "required": [
+                "include_key",
+                "key_exprs"
+              ],
+              "properties": {
+                "key_exprs": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Expr"
+                  }
+                },
+                "include_key": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "ByKey"
+          ],
+          "properties": {
+            "ByKey": {
+              "type": "object",
+              "required": [
+                "include_key",
+                "key_exprs"
+              ],
+              "properties": {
+                "key_exprs": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Expr"
+                  }
+                },
+                "include_key": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    }
+  }
+}

--- a/crates/polars-plan/src/bin/dsl-schema.rs
+++ b/crates/polars-plan/src/bin/dsl-schema.rs
@@ -1,0 +1,99 @@
+//! A tool for working with DSL schema.
+//!
+//! This tool can
+//! - update the schema stored in the schema file,
+//! - check that the schema in the file matches the code.
+//!
+//! The generated schema is affected by active features. To use a complete schema, first build
+//! the whole workspace with all features:
+//! ```sh
+//! cargo build --all-features
+//! ./target/debug/dsl-check update
+//! ./target/debug/dsl-check check
+//! ```
+
+fn main() {
+    #[cfg(not(feature = "dsl-schema"))]
+    panic!("this tool requires the `dsl-schema` feature");
+
+    #[cfg(feature = "dsl-schema")]
+    {
+        impls::run();
+    }
+}
+
+#[cfg(feature = "dsl-schema")]
+mod impls {
+    use std::fs::File;
+    use std::io::Write as _;
+    use std::path::Path;
+
+    use polars_plan::dsl::DslPlan;
+    use schemars::schema::RootSchema;
+
+    const DEFAULT_PATH: &str = "crates/polars-plan/dsl-schema.json";
+
+    pub fn run() {
+        let mut args = std::env::args();
+
+        let _ = args.next();
+        let cmd = args.next().expect("missing command [update, check]");
+        let path_arg = args.next().unwrap_or(DEFAULT_PATH.to_owned());
+
+        if let Some(unknown) = args.next() {
+            panic!("unknown argument: `{unknown}`");
+        }
+
+        let path = Path::new(&path_arg);
+        match cmd.as_str() {
+            "update" => {
+                update(path);
+            },
+            "check" => {
+                check(path);
+            },
+            unknown => {
+                panic!("unknown command: `{unknown}`");
+            },
+        }
+    }
+
+    /// Generates serializes the current DSL schema into a file at the given path.
+    ///
+    /// Any existing file at the path is overwritten.
+    fn update(path: &Path) {
+        let schema = DslPlan::dsl_schema();
+
+        let mut file = File::create(path).expect("failed to create a writable schema file");
+        serde_json::to_writer_pretty(&mut file, &schema).expect("failed to serialize the schema");
+        writeln!(&mut file).expect("failed to write the last newline");
+        file.flush().expect("failed to flush the schema file");
+
+        eprintln!("the DSL schema file was updated");
+    }
+
+    /// Checks that the current schema matches the schema in the file.
+    fn check(path: &Path) {
+        let schema: RootSchema = {
+            // Do a serialization round trip, because `schemars` has a quirk where serializing some
+            // fields with a value of `Some(Default::default())` gets deserialized as `None`. Both
+            // values mean the same thing, but `PartialEq` treats them as not equal.
+            // The serialization round trip normalizes all these fields to `None`, so that
+            // `PartialEq` works as expected.
+            let json = serde_json::to_string(&DslPlan::dsl_schema())
+                .expect("failed to serialize the current schema");
+            serde_json::from_str(&json).expect("failed to deserialize the current schema")
+        };
+
+        let mut file = File::open(path).expect("failed to open the schema file");
+        let schema_file: RootSchema =
+            serde_json::from_reader(&mut file).expect("failed to deserialize the schema");
+
+        if schema != schema_file {
+            eprintln!("the schema is not up to date, please run `make update-dsl-schema`");
+            std::process::exit(1);
+        }
+
+        eprintln!("the DSL schema is up to date");
+    }
+}

--- a/dprint.json
+++ b/dprint.json
@@ -9,6 +9,7 @@
   "excludes": [
     ".venv/",
     "**/target/",
+    "crates/polars-plan/dsl-schema.json",
     "py-polars/.hypothesis/",
     "py-polars/.mypy_cache/",
     "py-polars/.pytest_cache/",


### PR DESCRIPTION
This PR builds on top of #22866 and adds a CI check that the DSL schema file matches the current DSL schema. This will highlight any DSL changes in PR diffs, which is useful to prevent unintentional changes, and to make sure `DSL_VERSION` was incremented if needed.