### PR TITLE
feat: Added output type for `to_dummies()`

### DIFF
--- a/crates/polars-ops/src/frame/mod.rs
+++ b/crates/polars-ops/src/frame/mod.rs
@@ -70,7 +70,12 @@ pub trait DataFrameOps: IntoDf {
     ///  +------+------+------+--------+--------+--------+---------+---------+---------+
     /// ```
     #[cfg(feature = "to_dummies")]
-    fn to_dummies(&self, separator: Option<&str>, drop_first: bool, output_type: &Option<DataType>) -> PolarsResult<DataFrame> {
+    fn to_dummies(
+        &self,
+        separator: Option<&str>,
+        drop_first: bool,
+        output_type: &Option<DataType>,
+    ) -> PolarsResult<DataFrame> {
         self._to_dummies(None, separator, drop_first, output_type)
     }
 
@@ -105,7 +110,7 @@ pub trait DataFrameOps: IntoDf {
 
         if let Some(output_type) = output_type {
             if !output_type.is_primitive_numeric() && !output_type.is_bool() {
-                polars_bail!(InvalidOperation: 
+                polars_bail!(InvalidOperation:
                     "output_type must be numeric or boolean for to_dummies"
                 );
             }
@@ -115,7 +120,10 @@ pub trait DataFrameOps: IntoDf {
             df.get_columns()
                 .par_iter()
                 .map(|s| match (set.contains(s.name().as_str()), output_type) {
-                    (true, _) => s.as_materialized_series().to_dummies(separator, drop_first, output_type),
+                    (true, _) => {
+                        s.as_materialized_series()
+                            .to_dummies(separator, drop_first, output_type)
+                    },
                     (false, Some(dt)) => Ok(s.cast(dt)?.into_frame()),
                     (false, None) => Ok(s.clone().into_frame()),
                 })

--- a/crates/polars-ops/src/frame/mod.rs
+++ b/crates/polars-ops/src/frame/mod.rs
@@ -70,8 +70,8 @@ pub trait DataFrameOps: IntoDf {
     ///  +------+------+------+--------+--------+--------+---------+---------+---------+
     /// ```
     #[cfg(feature = "to_dummies")]
-    fn to_dummies(&self, separator: Option<&str>, drop_first: bool) -> PolarsResult<DataFrame> {
-        self._to_dummies(None, separator, drop_first)
+    fn to_dummies(&self, separator: Option<&str>, drop_first: bool, output_type: &Option<DataType>) -> PolarsResult<DataFrame> {
+        self._to_dummies(None, separator, drop_first, output_type)
     }
 
     #[cfg(feature = "to_dummies")]
@@ -80,8 +80,9 @@ pub trait DataFrameOps: IntoDf {
         columns: Vec<&str>,
         separator: Option<&str>,
         drop_first: bool,
+        output_type: &Option<DataType>,
     ) -> PolarsResult<DataFrame> {
-        self._to_dummies(Some(columns), separator, drop_first)
+        self._to_dummies(Some(columns), separator, drop_first, output_type)
     }
 
     #[cfg(feature = "to_dummies")]
@@ -90,6 +91,7 @@ pub trait DataFrameOps: IntoDf {
         columns: Option<Vec<&str>>,
         separator: Option<&str>,
         drop_first: bool,
+        output_type: &Option<DataType>,
     ) -> PolarsResult<DataFrame> {
         use crate::series::ToDummies;
 
@@ -101,12 +103,21 @@ pub trait DataFrameOps: IntoDf {
             PlHashSet::from_iter(df.iter().map(|s| s.name().as_str()))
         };
 
+        if let Some(output_type) = output_type {
+            if !output_type.is_primitive_numeric() && !output_type.is_bool() {
+                polars_bail!(InvalidOperation: 
+                    "output_type must be numeric or boolean for to_dummies"
+                );
+            }
+        }
+
         let cols = POOL.install(|| {
             df.get_columns()
                 .par_iter()
-                .map(|s| match set.contains(s.name().as_str()) {
-                    true => s.as_materialized_series().to_dummies(separator, drop_first),
-                    false => Ok(s.clone().into_frame()),
+                .map(|s| match (set.contains(s.name().as_str()), output_type) {
+                    (true, _) => s.as_materialized_series().to_dummies(separator, drop_first, output_type),
+                    (false, Some(dt)) => Ok(s.cast(dt)?.into_frame()),
+                    (false, None) => Ok(s.clone().into_frame()),
                 })
                 .collect::<PolarsResult<Vec<_>>>()
         })?;

--- a/crates/polars-ops/src/series/ops/to_dummies.rs
+++ b/crates/polars-ops/src/series/ops/to_dummies.rs
@@ -13,18 +13,28 @@ type DummyType = i32;
 type DummyCa = Int32Chunked;
 
 pub trait ToDummies {
-    fn to_dummies(&self, separator: Option<&str>, drop_first: bool, output_type: &Option<DataType>) -> PolarsResult<DataFrame>;
+    fn to_dummies(
+        &self,
+        separator: Option<&str>,
+        drop_first: bool,
+        output_type: &Option<DataType>,
+    ) -> PolarsResult<DataFrame>;
 }
 
 impl ToDummies for Series {
-    fn to_dummies(&self, separator: Option<&str>, drop_first: bool, output_type: &Option<DataType>) -> PolarsResult<DataFrame> {
+    fn to_dummies(
+        &self,
+        separator: Option<&str>,
+        drop_first: bool,
+        output_type: &Option<DataType>,
+    ) -> PolarsResult<DataFrame> {
         let sep = separator.unwrap_or("_");
         let col_name = self.name();
         let groups = self.group_tuples(true, drop_first)?;
 
         if let Some(output_type) = output_type {
             if !output_type.is_primitive_numeric() && !output_type.is_bool() {
-                polars_bail!(InvalidOperation: 
+                polars_bail!(InvalidOperation:
                     "output_type must be numeric or boolean for to_dummies"
                 );
             }
@@ -51,8 +61,8 @@ impl ToDummies for Series {
                     },
                 };
                 match output_type {
-                    Some(dt) => ca.cast(&dt).unwrap().into_column(),
-                    None => ca.into_column()
+                    Some(dt) => ca.cast(dt).unwrap().into_column(),
+                    None => ca.into_column(),
                 }
             })
             .collect::<Vec<_>>();

--- a/crates/polars-python/src/dataframe/general.rs
+++ b/crates/polars-python/src/dataframe/general.rs
@@ -449,21 +449,24 @@ impl PyDataFrame {
         self.df.clone().lazy().into()
     }
 
-    #[pyo3(signature = (columns, separator, drop_first=false))]
+    #[pyo3(signature = (columns, separator, drop_first=false, output_type=None))]
     pub fn to_dummies(
         &self,
         py: Python<'_>,
         columns: Option<Vec<String>>,
         separator: Option<&str>,
         drop_first: bool,
+        output_type: Option<Wrap<DataType>>,
     ) -> PyResult<Self> {
+        let output_type = output_type.map(|dt| dt.0);
         py.enter_polars_df(|| match columns {
             Some(cols) => self.df.columns_to_dummies(
                 cols.iter().map(|x| x as &str).collect(),
                 separator,
                 drop_first,
+                &output_type,
             ),
-            None => self.df.to_dummies(separator, drop_first),
+            None => self.df.to_dummies(separator, drop_first, &output_type),
         })
     }
 

--- a/crates/polars-python/src/series/general.rs
+++ b/crates/polars-python/src/series/general.rs
@@ -299,14 +299,16 @@ impl PySeries {
         py.enter_polars_series(|| self.series.zip_with(mask, &other.series))
     }
 
-    #[pyo3(signature = (separator, drop_first=false))]
+    #[pyo3(signature = (separator, drop_first=false, output_type=None))]
     fn to_dummies(
         &self,
         py: Python<'_>,
         separator: Option<&str>,
         drop_first: bool,
+        output_type: Option<Wrap<DataType>>,
     ) -> PyResult<PyDataFrame> {
-        py.enter_polars_df(|| self.series.to_dummies(separator, drop_first))
+        let output_type = output_type.map(|dt| dt.0);
+        py.enter_polars_df(|| self.series.to_dummies(separator, drop_first, &output_type))
     }
 
     fn get_list(&self, index: usize) -> Option<Self> {

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -10449,6 +10449,7 @@ class DataFrame:
         *,
         separator: str = "_",
         drop_first: bool = False,
+        output_type: PolarsDataType | None = None,
     ) -> DataFrame:
         """
         Convert categorical variables into dummy/indicator variables.
@@ -10462,6 +10463,8 @@ class DataFrame:
             Separator/delimiter used when generating column names.
         drop_first
             Remove the first category from the variables being encoded.
+        output_type
+            Data type of the dummy variables. By default, the type is `u8`.
 
         Examples
         --------
@@ -10519,7 +10522,7 @@ class DataFrame:
         """
         if columns is not None:
             columns = _expand_selectors(self, columns)
-        return self._from_pydf(self._df.to_dummies(columns, separator, drop_first))
+        return self._from_pydf(self._df.to_dummies(columns, separator, drop_first, output_type))
 
     def unique(
         self,

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -10522,7 +10522,9 @@ class DataFrame:
         """
         if columns is not None:
             columns = _expand_selectors(self, columns)
-        return self._from_pydf(self._df.to_dummies(columns, separator, drop_first, output_type))
+        return self._from_pydf(
+            self._df.to_dummies(columns, separator, drop_first, output_type)
+        )
 
     def unique(
         self,

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -2272,7 +2272,7 @@ class Series:
         drop_first
             Remove the first category from the variable being encoded.
         output_type
-            Data type of the dummy columns. By default, the data type is u8
+            Data type of the dummy variables. By default, the output type is `u8`.
 
         Examples
         --------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -2256,7 +2256,11 @@ class Series:
         return self._s.quantile(quantile, interpolation)
 
     def to_dummies(
-        self, *, separator: str = "_", drop_first: bool = False, output_type: PolarsDataType | None = None
+        self,
+        *,
+        separator: str = "_",
+        drop_first: bool = False,
+        output_type: PolarsDataType | None = None,
     ) -> DataFrame:
         """
         Get dummy/indicator variables.

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -2256,7 +2256,7 @@ class Series:
         return self._s.quantile(quantile, interpolation)
 
     def to_dummies(
-        self, *, separator: str = "_", drop_first: bool = False
+        self, *, separator: str = "_", drop_first: bool = False, output_type: PolarsDataType | None = None
     ) -> DataFrame:
         """
         Get dummy/indicator variables.
@@ -2267,6 +2267,8 @@ class Series:
             Separator/delimiter used when generating column names.
         drop_first
             Remove the first category from the variable being encoded.
+        output_type
+            Data type of the dummy columns. By default, the data type is u8
 
         Examples
         --------
@@ -2295,7 +2297,7 @@ class Series:
         │ 0   ┆ 1   │
         └─────┴─────┘
         """
-        return wrap_df(self._s.to_dummies(separator, drop_first))
+        return wrap_df(self._s.to_dummies(separator, drop_first, output_type))
 
     @unstable()
     def cut(

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -773,22 +773,35 @@ def test_to_dummies() -> None:
     assert_frame_equal(result, expected)
 
 
-@pytest.mark.parametrize("dtype", [pl.Boolean,
-    pl.Int8, pl.Int16, pl.Int32, pl.Int64,
-    pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
-    pl.Float32, pl.Float64])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pl.Boolean,
+        pl.Int8,
+        pl.Int16,
+        pl.Int32,
+        pl.Int64,
+        pl.UInt8,
+        pl.UInt16,
+        pl.UInt32,
+        pl.UInt64,
+        pl.Float32,
+        pl.Float64,
+    ],
+)
 def test_dataframe_to_dummies_respects_output_type(dtype: pl.DataType) -> None:
-    df0 = pl.DataFrame({
-        "cat": ["x", "y", "x"],
-        "value": [10, 20, 10],
-    })
+    df0 = pl.DataFrame(
+        {
+            "cat": ["x", "y", "x"],
+            "value": [10, 20, 10],
+        }
+    )
     df = df0.to_dummies(columns=["cat"], output_type=dtype)
     expected_dummy = {"cat_x", "cat_y"}
     assert set(df.columns) == expected_dummy.union({"value"})
     for col in expected_dummy:
         assert df[col].dtype == dtype
     assert df["value"].dtype == dtype
-
 
 
 def test_to_dummies_drop_first() -> None:

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -773,6 +773,24 @@ def test_to_dummies() -> None:
     assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize("dtype", [pl.Boolean,
+    pl.Int8, pl.Int16, pl.Int32, pl.Int64,
+    pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
+    pl.Float32, pl.Float64])
+def test_dataframe_to_dummies_respects_output_type(dtype: pl.DataType) -> None:
+    df0 = pl.DataFrame({
+        "cat": ["x", "y", "x"],
+        "value": [10, 20, 10],
+    })
+    df = df0.to_dummies(columns=["cat"], output_type=dtype)
+    expected_dummy = {"cat_x", "cat_y"}
+    assert set(df.columns) == expected_dummy.union({"value"})
+    for col in expected_dummy:
+        assert df[col].dtype == dtype
+    assert df["value"].dtype == dtype
+
+
+
 def test_to_dummies_drop_first() -> None:
     df = pl.DataFrame(
         {

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1359,6 +1359,20 @@ def test_to_dummies() -> None:
     )
     assert_frame_equal(result, expected)
 
+@pytest.mark.parametrize("dtype", [pl.Boolean,
+    pl.Int8, pl.Int16, pl.Int32, pl.Int64,
+    pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
+    pl.Float32, pl.Float64])
+def test_series_to_dummies_respects_output_type(dtype: pl.DataType) -> None:
+    s = pl.Series("letter", ["a", "b", "a", "c"])
+    df = s.to_dummies(output_type=dtype)
+
+    expected_cols = {"letter_a", "letter_b", "letter_c"}
+    assert set(df.columns) == expected_cols
+
+    for col in expected_cols:
+        assert df[col].dtype == dtype
+
 
 def test_to_dummies_drop_first() -> None:
     s = pl.Series("a", [1, 2, 3])

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1359,10 +1359,23 @@ def test_to_dummies() -> None:
     )
     assert_frame_equal(result, expected)
 
-@pytest.mark.parametrize("dtype", [pl.Boolean,
-    pl.Int8, pl.Int16, pl.Int32, pl.Int64,
-    pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
-    pl.Float32, pl.Float64])
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pl.Boolean,
+        pl.Int8,
+        pl.Int16,
+        pl.Int32,
+        pl.Int64,
+        pl.UInt8,
+        pl.UInt16,
+        pl.UInt32,
+        pl.UInt64,
+        pl.Float32,
+        pl.Float64,
+    ],
+)
 def test_series_to_dummies_respects_output_type(dtype: pl.DataType) -> None:
     s = pl.Series("letter", ["a", "b", "a", "c"])
     df = s.to_dummies(output_type=dtype)


### PR DESCRIPTION
### Description 

This adds an optional `output_type` to `to_dummies()` and thereby resolves #22629. 

Example: 

```python 
import polars as pl 

df = pl.DataFrame({
    "a": [1, 2, 3],
})

print(df.to_dummies(output_type=pl.Boolean))
```

Output: 
```bash
shape: (3, 3)
┌───────┬───────┬───────┐
│ a_1   ┆ a_2   ┆ a_3   │
│ ---   ┆ ---   ┆ ---   │
│ bool  ┆ bool  ┆ bool  │
╞═══════╪═══════╪═══════╡
│ true  ┆ false ┆ false │
│ false ┆ true  ┆ false │
│ false ┆ false ┆ true  │
└───────┴───────┴───────┘
```