### PR TITLE
refactor: Base the `meta` expressions on the DSL instead of the IR

### DIFF
--- a/crates/polars-plan/src/dsl/expr/mod.rs
+++ b/crates/polars-plan/src/dsl/expr/mod.rs
@@ -476,6 +476,135 @@ impl Expr {
             options,
         }
     }
+
+    pub fn inputs_rev<'a>(&'a self, inputs: &'_ mut Vec<&'a Expr>) {
+        match self {
+            Expr::Column(_)
+            | Expr::Columns(_)
+            | Expr::DtypeColumn(_)
+            | Expr::IndexColumn(_)
+            | Expr::Literal(_)
+            | Expr::Wildcard
+            | Expr::Len
+            | Expr::Nth(_)
+            | Expr::Selector(_)
+            | Expr::Field(_)
+            | Expr::SubPlan(_, _) => {},
+            Expr::BinaryExpr { left, op: _, right } => {
+                inputs.extend([right.as_ref(), left.as_ref()])
+            },
+            Expr::Cast {
+                expr,
+                dtype: _,
+                options: _,
+            } => {
+                inputs.push(expr.as_ref());
+            },
+            Expr::Alias(expr, _)
+            | Expr::Sort { expr, options: _ }
+            | Expr::Explode {
+                input: expr,
+                skip_empty: _,
+            }
+            | Expr::KeepName(expr)
+            | Expr::Exclude(expr, _)
+            | Expr::RenameAlias { function: _, expr } => {
+                inputs.push(expr.as_ref());
+            },
+            Expr::Gather {
+                expr,
+                idx,
+                returns_scalar: _,
+            } => inputs.extend([idx.as_ref(), expr.as_ref()]),
+            Expr::SortBy {
+                expr,
+                by,
+                sort_options: _,
+            } => {
+                inputs.extend(by.iter().rev());
+                inputs.push(expr.as_ref());
+            },
+            Expr::Agg(agg_expr) => match agg_expr {
+                AggExpr::Min {
+                    input: expr,
+                    propagate_nans: _,
+                }
+                | AggExpr::Max {
+                    input: expr,
+                    propagate_nans: _,
+                }
+                | AggExpr::Median(expr)
+                | AggExpr::NUnique(expr)
+                | AggExpr::First(expr)
+                | AggExpr::Last(expr)
+                | AggExpr::Mean(expr)
+                | AggExpr::Implode(expr)
+                | AggExpr::Count(expr, _)
+                | AggExpr::Sum(expr)
+                | AggExpr::AggGroups(expr)
+                | AggExpr::Std(expr, _)
+                | AggExpr::Var(expr, _) => inputs.push(expr.as_ref()),
+                AggExpr::Quantile {
+                    expr,
+                    quantile,
+                    method: _,
+                } => {
+                    inputs.extend([quantile.as_ref(), expr.as_ref()]);
+                },
+            },
+            Expr::Ternary {
+                predicate,
+                truthy,
+                falsy,
+            } => inputs.extend([falsy.as_ref(), truthy.as_ref(), predicate.as_ref()]),
+            Expr::Function {
+                input,
+                function: _,
+                options: _,
+            }
+            | Expr::AnonymousFunction {
+                input,
+                function: _,
+                output_type: _,
+                options: _,
+            } => inputs.extend(input.iter().rev()),
+            Expr::Filter { input, by } => inputs.extend([by.as_ref(), input.as_ref()]),
+            Expr::Window {
+                function,
+                partition_by,
+                order_by,
+                options: _,
+            } => {
+                if let Some(order_by) = order_by {
+                    inputs.push(order_by.0.as_ref());
+                }
+                inputs.extend(partition_by.iter().rev());
+                inputs.push(function.as_ref());
+            },
+            Expr::Slice {
+                input,
+                offset,
+                length,
+            } => {
+                inputs.extend([length.as_ref(), offset.as_ref(), input.as_ref()]);
+            },
+        }
+    }
+
+    pub(crate) fn is_simple_projection(&self) -> bool {
+        let mut inputs = Vec::new();
+        inputs.push(self);
+        while let Some(input) = inputs.pop() {
+            match input {
+                Expr::Column(_) => {},
+                Expr::Alias(_, _) => {},
+                _ => return false,
+            }
+
+            input.inputs_rev(&mut inputs);
+        }
+        true
+    }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -44,14 +44,6 @@ pub(crate) fn is_scan(plan: &IR) -> bool {
     matches!(plan, IR::Scan { .. } | IR::DataFrameScan { .. })
 }
 
-/// A projection that only takes a column or a column + alias.
-#[cfg(feature = "meta")]
-pub(crate) fn aexpr_is_simple_projection(current_node: Node, arena: &Arena<AExpr>) -> bool {
-    arena
-        .iter(current_node)
-        .all(|(_node, e)| matches!(e, AExpr::Column(_) | AExpr::Alias(_, _)))
-}
-
 pub fn has_aexpr<F>(current_node: Node, arena: &Arena<AExpr>, matches: F) -> bool
 where
     F: Fn(&AExpr) -> bool,


### PR DESCRIPTION
This is part of working towards #22780.