### PR TITLE
fix: Allow subclasses in type equality checking

### DIFF
--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -736,6 +736,8 @@ def require_same_type(current: Any, other: Any) -> None:
     """
     Raise an error if the two arguments are not of the same type.
 
+    The check will not raise an error if one object is of a subclass of the other.
+
     Parameters
     ----------
     current
@@ -743,7 +745,7 @@ def require_same_type(current: Any, other: Any) -> None:
     other
         An object that has to be of the same type.
     """
-    if not isinstance(other, type(current)):
+    if not isinstance(other, type(current)) and not isinstance(current, type(other)):
         msg = (
             f"expected `other` to be a {qualified_type_name(current)!r}, "
             f"not {qualified_type_name(other)!r}"

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1590,11 +1590,9 @@ def test_join_bad_input_type() -> None:
     class DummyDataFrameSubclass(pl.DataFrame):
         pass
 
-    a = DummyDataFrameSubclass(left)
-    b = DummyDataFrameSubclass(right)
+    right = DummyDataFrameSubclass(right)
 
-    expected = pl.DataFrame({"a": [1, 2, 3]})
-    assert_frame_equal(a.join(b, on="a"), expected)
+    left.join(right, on="a")
 
 
 def test_join_where() -> None:
@@ -1676,29 +1674,13 @@ def test_join_where_bad_input_type() -> None:
     class DummyDataFrameSubclass(pl.DataFrame):
         pass
 
-    a = DummyDataFrameSubclass(east)
-    b = DummyDataFrameSubclass(west)
+    west = DummyDataFrameSubclass(west)
 
-    out = a.join_where(
-        b,
+    east.join_where(
+        west,
         pl.col("dur") < pl.col("time"),
         pl.col("rev") < pl.col("cost"),
     )
-
-    expected = pl.DataFrame(
-        {
-            "id": [100, 100, 100, 101, 101],
-            "dur": [120, 120, 120, 140, 140],
-            "rev": [12, 12, 12, 14, 14],
-            "cores": [2, 2, 2, 8, 8],
-            "t_id": [498, 676, 742, 676, 742],
-            "time": [130, 150, 170, 150, 170],
-            "cost": [13, 15, 16, 15, 16],
-            "cores_right": [2, 1, 4, 1, 4],
-        }
-    )
-
-    assert_frame_equal(out, expected)
 
 
 def test_str_concat() -> None:

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1587,6 +1587,15 @@ def test_join_bad_input_type() -> None:
     ):
         left.join(pl.Series([1, 2, 3]), on="a")  # type: ignore[arg-type]
 
+    class DummyDataFrameSubclass(pl.DataFrame):
+        pass
+
+    a = DummyDataFrameSubclass(left)
+    b = DummyDataFrameSubclass(right)
+
+    expected = pl.DataFrame({"a": [1, 2, 3]})
+    assert_frame_equal(a.join(b, on="a"), expected)
+
 
 def test_join_where() -> None:
     east = pl.DataFrame(
@@ -1663,6 +1672,33 @@ def test_join_where_bad_input_type() -> None:
             pl.col("dur") < pl.col("time"),
             pl.col("rev") < pl.col("cost"),
         )
+
+    class DummyDataFrameSubclass(pl.DataFrame):
+        pass
+
+    a = DummyDataFrameSubclass(east)
+    b = DummyDataFrameSubclass(west)
+
+    out = a.join_where(
+        b,
+        pl.col("dur") < pl.col("time"),
+        pl.col("rev") < pl.col("cost"),
+    )
+
+    expected = pl.DataFrame(
+        {
+            "id": [100, 100, 100, 101, 101],
+            "dur": [120, 120, 120, 140, 140],
+            "rev": [12, 12, 12, 14, 14],
+            "cores": [2, 2, 2, 8, 8],
+            "t_id": [498, 676, 742, 676, 742],
+            "time": [130, 150, 170, 150, 170],
+            "cost": [13, 15, 16, 15, 16],
+            "cores_right": [2, 1, 4, 1, 4],
+        }
+    )
+
+    assert_frame_equal(out, expected)
 
 
 def test_str_concat() -> None:
@@ -2420,6 +2456,13 @@ def test_asof_bad_input_type() -> None:
         match="expected `other` .*to be a 'DataFrame'.* not 'Series'",
     ):
         lhs.join_asof(pl.Series([1, 2, 3]), on="a")  # type: ignore[arg-type]
+
+    class DummyDataFrameSubclass(pl.DataFrame):
+        pass
+
+    rhs = DummyDataFrameSubclass(rhs)
+
+    lhs.join_asof(rhs, on="a")
 
 
 def test_list_of_list_of_struct() -> None:

--- a/py-polars/tests/unit/dataframe/test_equals.py
+++ b/py-polars/tests/unit/dataframe/test_equals.py
@@ -64,3 +64,10 @@ def test_equals_bad_input_type() -> None:
         match="expected `other` .*to be a 'DataFrame'.* not 'Series'",
     ):
         df1.equals(pl.Series([1, 2, 3]))  # type: ignore[arg-type]
+
+    class DummyDataFrameSubclass(pl.DataFrame):
+        pass
+
+    df2 = DummyDataFrameSubclass(df2)
+
+    assert df1.equals(df2) is True

--- a/py-polars/tests/unit/dataframe/test_extend.py
+++ b/py-polars/tests/unit/dataframe/test_extend.py
@@ -119,6 +119,3 @@ def test_extend_bad_input_type() -> None:
     b = DummyDataFrameSubclass({"x": [4, 5, 6]})
 
     a.extend(b)
-
-    expected = pl.DataFrame({"x": [1, 2, 3, 4, 5, 6]})
-    assert_frame_equal(a, expected)

--- a/py-polars/tests/unit/dataframe/test_extend.py
+++ b/py-polars/tests/unit/dataframe/test_extend.py
@@ -112,3 +112,13 @@ def test_extend_bad_input_type() -> None:
         match="expected `other` .*to be a 'DataFrame'.* not 'LazyFrame'",
     ):
         a.extend(b.lazy())  # type: ignore[arg-type]
+
+    class DummyDataFrameSubclass(pl.DataFrame):
+        pass
+
+    b = DummyDataFrameSubclass({"x": [4, 5, 6]})
+
+    a.extend(b)
+
+    expected = pl.DataFrame({"x": [1, 2, 3, 4, 5, 6]})
+    assert_frame_equal(a, expected)

--- a/py-polars/tests/unit/dataframe/test_merge_sorted.py
+++ b/py-polars/tests/unit/dataframe/test_merge_sorted.py
@@ -52,7 +52,4 @@ def test_merge_sorted_bad_input_type() -> None:
 
     b = DummyDataFrameSubclass(b)
 
-    out = a.merge_sorted(b, key="x")
-
-    expected = pl.DataFrame({"x": [1, 2, 3, 4, 5, 6]})
-    assert_frame_equal(out, expected)
+    a.merge_sorted(b, key="x")

--- a/py-polars/tests/unit/dataframe/test_merge_sorted.py
+++ b/py-polars/tests/unit/dataframe/test_merge_sorted.py
@@ -46,3 +46,13 @@ def test_merge_sorted_bad_input_type() -> None:
         match="expected `other` .*to be a 'DataFrame'.* not 'LazyFrame'",
     ):
         a.merge_sorted(b.lazy(), key="x")  # type: ignore[arg-type]
+
+    class DummyDataFrameSubclass(pl.DataFrame):
+        pass
+
+    b = DummyDataFrameSubclass(b)
+
+    out = a.merge_sorted(b, key="x")
+
+    expected = pl.DataFrame({"x": [1, 2, 3, 4, 5, 6]})
+    assert_frame_equal(out, expected)

--- a/py-polars/tests/unit/dataframe/test_vstack.py
+++ b/py-polars/tests/unit/dataframe/test_vstack.py
@@ -98,3 +98,12 @@ def test_vstack_bad_input_type() -> None:
         match="expected `other` .*to be a 'DataFrame'.* not 'LazyFrame'",
     ):
         a.vstack(b.lazy())  # type: ignore[arg-type]
+
+    class DummyDataFrameSubclass(pl.DataFrame):
+        pass
+
+    b = DummyDataFrameSubclass(b)
+
+    a = a.vstack(b)
+    expected = pl.DataFrame({"x": [1, 2, 3, 4, 5, 6]})
+    assert_frame_equal(a, expected)

--- a/py-polars/tests/unit/dataframe/test_vstack.py
+++ b/py-polars/tests/unit/dataframe/test_vstack.py
@@ -105,5 +105,3 @@ def test_vstack_bad_input_type() -> None:
     b = DummyDataFrameSubclass(b)
 
     a = a.vstack(b)
-    expected = pl.DataFrame({"x": [1, 2, 3, 4, 5, 6]})
-    assert_frame_equal(a, expected)

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -1521,10 +1521,7 @@ def test_join_bad_input_type() -> None:
     a = DummyLazyFrameSubclass(left.collect())
     b = DummyLazyFrameSubclass(right.collect())
 
-    out = a.join(b, on="a").collect()
-    expected = pl.DataFrame({"a": [1, 2, 3]})
-    assert_frame_equal(out, expected)
-
+    a.join(b, on="a").collect()
 
 def test_join_where() -> None:
     east = pl.LazyFrame(
@@ -1608,23 +1605,9 @@ def test_join_where_bad_input_type() -> None:
     a = DummyLazyFrameSubclass(east.collect())
     b = DummyLazyFrameSubclass(west.collect())
 
-    out = a.join_where(
+    a.join_where(
         b,
         pl.col("dur") < pl.col("time"),
         pl.col("rev") < pl.col("cost"),
     ).collect()
 
-    expected = pl.DataFrame(
-        {
-            "id": [100, 100, 100, 101, 101],
-            "dur": [120, 120, 120, 140, 140],
-            "rev": [12, 12, 12, 14, 14],
-            "cores": [2, 2, 2, 8, 8],
-            "t_id": [498, 676, 742, 676, 742],
-            "time": [130, 150, 170, 150, 170],
-            "cost": [13, 15, 16, 15, 16],
-            "cores_right": [2, 1, 4, 1, 4],
-        }
-    )
-
-    assert_frame_equal(out, expected)

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -1523,6 +1523,7 @@ def test_join_bad_input_type() -> None:
 
     a.join(b, on="a").collect()
 
+
 def test_join_where() -> None:
     east = pl.LazyFrame(
         {
@@ -1610,4 +1611,3 @@ def test_join_where_bad_input_type() -> None:
         pl.col("dur") < pl.col("time"),
         pl.col("rev") < pl.col("cost"),
     ).collect()
-

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -1515,6 +1515,16 @@ def test_join_bad_input_type() -> None:
     ):
         left.join(pl.Series([1, 2, 3]), on="a")  # type: ignore[arg-type]
 
+    class DummyLazyFrameSubclass(pl.LazyFrame):
+        pass
+
+    a = DummyLazyFrameSubclass(left.collect())
+    b = DummyLazyFrameSubclass(right.collect())
+
+    out = a.join(b, on="a").collect()
+    expected = pl.DataFrame({"a": [1, 2, 3]})
+    assert_frame_equal(out, expected)
+
 
 def test_join_where() -> None:
     east = pl.LazyFrame(
@@ -1591,3 +1601,30 @@ def test_join_where_bad_input_type() -> None:
             pl.col("dur") < pl.col("time"),
             pl.col("rev") < pl.col("cost"),
         )
+
+    class DummyLazyFrameSubclass(pl.LazyFrame):
+        pass
+
+    a = DummyLazyFrameSubclass(east.collect())
+    b = DummyLazyFrameSubclass(west.collect())
+
+    out = a.join_where(
+        b,
+        pl.col("dur") < pl.col("time"),
+        pl.col("rev") < pl.col("cost"),
+    ).collect()
+
+    expected = pl.DataFrame(
+        {
+            "id": [100, 100, 100, 101, 101],
+            "dur": [120, 120, 120, 140, 140],
+            "rev": [12, 12, 12, 14, 14],
+            "cores": [2, 2, 2, 8, 8],
+            "t_id": [498, 676, 742, 676, 742],
+            "time": [130, 150, 170, 150, 170],
+            "cost": [13, 15, 16, 15, 16],
+            "cores_right": [2, 1, 4, 1, 4],
+        }
+    )
+
+    assert_frame_equal(out, expected)

--- a/py-polars/tests/unit/lazyframe/test_merged_sorted.py
+++ b/py-polars/tests/unit/lazyframe/test_merged_sorted.py
@@ -46,3 +46,9 @@ def test_merge_sorted_bad_input_type() -> None:
         match="expected `other` .*to be a 'LazyFrame'.* not 'DataFrame'",
     ):
         a.merge_sorted(b.collect(), key="x")  # type: ignore[arg-type]
+
+    class DummyLazyFrameSubclass(pl.LazyFrame):
+        pass
+
+    b = DummyLazyFrameSubclass(b.collect())
+    a.merge_sorted(b, key="x")

--- a/py-polars/tests/unit/series/test_equals.py
+++ b/py-polars/tests/unit/series/test_equals.py
@@ -42,6 +42,13 @@ def test_equals() -> None:
     ):
         s1.equals(pl.DataFrame(s2).lazy(), check_names=False)  # type: ignore[arg-type]
 
+    s5 = pl.Series("a", [1, 2, 3])
+
+    class DummySeriesSubclass(pl.Series):
+        pass
+
+    assert s5.equals(DummySeriesSubclass(s5)) is True
+
 
 def test_series_equals_check_names() -> None:
     s1 = pl.Series("foo", [1, 2, 3])

--- a/py-polars/tests/unit/series/test_zip_with.py
+++ b/py-polars/tests/unit/series/test_zip_with.py
@@ -84,6 +84,4 @@ def test_zip_with_bad_input_type() -> None:
     s2 = DummySeriesSubclass(s2)
     mask = DummySeriesSubclass(mask)
 
-    out = s1.zip_with(mask, s2)
-    expected = pl.Series([1, 5, 3])
-    assert_series_equal(out, expected)
+    s1.zip_with(mask, s2)

--- a/py-polars/tests/unit/series/test_zip_with.py
+++ b/py-polars/tests/unit/series/test_zip_with.py
@@ -63,7 +63,7 @@ def test_zip_with_length_mismatch() -> None:
 def test_zip_with_bad_input_type() -> None:
     s1 = pl.Series([1, 2, 3])
     s2 = pl.Series([4, 5, 6])
-    mask = pl.Series([True, True, True])
+    mask = pl.Series([True, False, True])
 
     with pytest.raises(
         TypeError,
@@ -76,3 +76,14 @@ def test_zip_with_bad_input_type() -> None:
         match="expected `other` .*to be a 'Series'.* not 'LazyFrame'",
     ):
         s1.zip_with(mask, pl.DataFrame(s2).lazy())  # type: ignore[arg-type]
+
+    class DummySeriesSubclass(pl.Series):
+        pass
+
+    s1 = DummySeriesSubclass(s1)
+    s2 = DummySeriesSubclass(s2)
+    mask = DummySeriesSubclass(mask)
+
+    out = s1.zip_with(mask, s2)
+    expected = pl.Series([1, 5, 3])
+    assert_series_equal(out, expected)


### PR DESCRIPTION
Closes #22914.

In #22802, I added a check for methods that expect an argument of the same type. The check raised if the `other` argument was not of the same type as the object itself. However, this check is too restrictive, as sometimes we want to provide objects that are subclassed. For that reason, modify the check to be less restrictive and allow for that flow.

Also modify `bad_input_type` types of unittests add add sub-tests that do not raise when subclassed objects are used.

