### PR TITLE
docs(python): Add missing `top_k_by` and `bottom_k_by` to `Series` reference

### DIFF
--- a/py-polars/docs/source/reference/series/modify_select.rst
+++ b/py-polars/docs/source/reference/series/modify_select.rst
@@ -12,6 +12,7 @@ Manipulation/selection
     Series.arg_sort
     Series.backward_fill
     Series.bottom_k
+    Series.bottom_k_by
     Series.cast
     Series.ceil
     Series.clear
@@ -58,5 +59,6 @@ Manipulation/selection
     Series.tail
     Series.to_dummies
     Series.top_k
+    Series.top_k_by
     Series.unique
     Series.zip_with


### PR DESCRIPTION
i think this was forgotten in https://github.com/pola-rs/polars/pull/22902/files