### PR TITLE
fix(python): Guard against dictionaries being passed to `with_columns`

### DIFF
--- a/py-polars/polars/_utils/parse/expr.py
+++ b/py-polars/polars/_utils/parse/expr.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING, Any
 
 import polars._reexport as pl
@@ -119,6 +119,18 @@ def _parse_inputs_as_iterable(
 ) -> Iterable[Any]:
     if not inputs:
         return []
+
+    # Ensures that the outermost element cannot be a Dictionary (as an iterable)
+    if len(inputs) == 1 and isinstance(inputs[0], Mapping):
+        msg = (
+            "Cannot pass a dictionary as a single positional argument.\n"
+            "If you merely want the *keys*, use:\n"
+            "  • df.method(*your_dict.keys())\n"
+            "If you need the key–value pairs, use one of:\n"
+            "  • unpack as keywords:    df.method(**your_dict)\n"
+            "  • build expressions:     df.method(expr.alias(k) for k, expr in your_dict.items())"
+        )
+        raise TypeError(msg)
 
     # Treat elements of a single iterable as separate inputs
     if len(inputs) == 1 and _is_iterable(inputs[0]):

--- a/py-polars/polars/_utils/parse/expr.py
+++ b/py-polars/polars/_utils/parse/expr.py
@@ -126,7 +126,7 @@ def _parse_inputs_as_iterable(
             "Cannot pass a dictionary as a single positional argument.\n"
             "If you merely want the *keys*, use:\n"
             "  • df.method(*your_dict.keys())\n"
-            "If you need the key–value pairs, use one of:\n"
+            "If you need the key value pairs, use one of:\n"
             "  • unpack as keywords:    df.method(**your_dict)\n"
             "  • build expressions:     df.method(expr.alias(k) for k, expr in your_dict.items())"
         )

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -5851,16 +5851,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 4   ┆ 13.0 ┆ {1,3.0}     │
         └─────┴──────┴─────────────┘
         """
-        # Ensures that the outermost element cannot be a Dictionary (as an iterable)
-        if len(exprs) == 1 and isinstance(exprs[0], Mapping):
-            msg = (
-                "Cannot pass a Dictionary as an argument to `with_columns`.\n"
-                "To utilize key-value information from a dictionary, use either:\n"
-                "  - `with_columns(**your_dict)`\n"
-                "  - `with_columns(expr.alias(name) for name, expr in your_dict.items())`"
-            )
-            raise TypeError(msg)
-
         structify = bool(int(os.environ.get("POLARS_AUTO_STRUCTIFY", 0)))
 
         pyexprs = parse_into_list_of_expressions(

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -5851,16 +5851,15 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 4   ┆ 13.0 ┆ {1,3.0}     │
         └─────┴──────┴─────────────┘
         """
-        # Ensures that Dictionaries (as an iterable) cannot be passed in
-        for expr in exprs:
-            if isinstance(expr, dict):
-                msg = (
-                    "Cannot pass a Dictionary as an argument to `with_columns`.\n"
-                    "To utilize key-value information from a dictionary, use either:\n"
-                    "  - `with_columns(**your_dict)`\n"
-                    "  - `with_columns(expr.alias(name) for name, expr in your_dict.items())`"
-                )
-                raise TypeError(msg)
+        # Ensures that the outermost element cannot be a Dictionary (as an iterable)
+        if len(exprs) == 1 and isinstance(exprs[0], Mapping):
+            msg = (
+                "Cannot pass a Dictionary as an argument to `with_columns`.\n"
+                "To utilize key-value information from a dictionary, use either:\n"
+                "  - `with_columns(**your_dict)`\n"
+                "  - `with_columns(expr.alias(name) for name, expr in your_dict.items())`"
+            )
+            raise TypeError(msg)
 
         structify = bool(int(os.environ.get("POLARS_AUTO_STRUCTIFY", 0)))
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -5854,12 +5854,13 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         # Ensures that Dictionaries (as an iterable) cannot be passed in
         for expr in exprs:
             if isinstance(expr, dict):
-                raise TypeError(
+                msg = (
                     "Cannot pass a Dictionary as an argument to `with_columns`.\n"
-                    "To utilise key-value information from a dictionary, use either:\n"
+                    "To utilize key-value information from a dictionary, use either:\n"
                     "  - `with_columns(**your_dict)`\n"
                     "  - `with_columns(expr.alias(name) for name, expr in your_dict.items())`"
                 )
+                raise TypeError(msg)
 
         structify = bool(int(os.environ.get("POLARS_AUTO_STRUCTIFY", 0)))
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -5851,6 +5851,16 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 4   ┆ 13.0 ┆ {1,3.0}     │
         └─────┴──────┴─────────────┘
         """
+        # Ensures that Dictionaries (as an iterable) cannot be passed in
+        for expr in exprs:
+            if isinstance(expr, dict):
+                raise TypeError(
+                    "Cannot pass a Dictionary as an argument to `with_columns`.\n"
+                    "To utilise key-value information from a dictionary, use either:\n"
+                    "  - `with_columns(**your_dict)`\n"
+                    "  - `with_columns(expr.alias(name) for name, expr in your_dict.items())`"
+                )
+
         structify = bool(int(os.environ.get("POLARS_AUTO_STRUCTIFY", 0)))
 
         pyexprs = parse_into_list_of_expressions(

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -3228,21 +3228,24 @@ def test_nan_to_null() -> None:
 
 # Below 3 tests for https://github.com/pola-rs/polars/issues/17879
 
-def test_with_columns_dict_direct_typeerror():
+
+def test_with_columns_dict_direct_typeerror() -> None:
     data = {"a": pl.col("a") * 2}
     df = pl.select(a=1)
-    with pytest.raises(TypeError, match="Cannot pass a Dictionary as an argument to `with_columns`"):
+    with pytest.raises(
+        TypeError, match="Cannot pass a Dictionary as an argument to `with_columns`"
+    ):
         df.with_columns(data)
 
 
-def test_with_columns_dict_unpacking():
+def test_with_columns_dict_unpacking() -> None:
     data = {"a": pl.col("a") * 2}
     df = pl.select(a=1).with_columns(**data)
     expected = pl.DataFrame({"a": [2]})
     assert df.equals(expected)
 
 
-def test_with_columns_generator_alias():
+def test_with_columns_generator_alias() -> None:
     data = {"a": pl.col("a") * 2}
     df = pl.select(a=1).with_columns(expr.alias(name) for name, expr in data.items())
     expected = pl.DataFrame({"a": [2]})

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -3233,7 +3233,7 @@ def test_with_columns_dict_direct_typeerror() -> None:
     data = {"a": pl.col("a") * 2}
     df = pl.select(a=1)
     with pytest.raises(
-        TypeError, match="Cannot pass a Dictionary as an argument to `with_columns`"
+        TypeError, match="Cannot pass a dictionary as a single positional argument"
     ):
         df.with_columns(data)
 

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -3224,3 +3224,26 @@ def test_nan_to_null() -> None:
     )
 
     assert_frame_equal(df1, df2)
+
+
+# Below 3 tests for https://github.com/pola-rs/polars/issues/17879
+
+def test_with_columns_dict_direct_typeerror():
+    data = {"a": pl.col("a") * 2}
+    df = pl.select(a=1)
+    with pytest.raises(TypeError, match="Cannot pass a Dictionary as an argument to `with_columns`"):
+        df.with_columns(data)
+
+
+def test_with_columns_dict_unpacking():
+    data = {"a": pl.col("a") * 2}
+    df = pl.select(a=1).with_columns(**data)
+    expected = pl.DataFrame({"a": [2]})
+    assert df.equals(expected)
+
+
+def test_with_columns_generator_alias():
+    data = {"a": pl.col("a") * 2}
+    df = pl.select(a=1).with_columns(expr.alias(name) for name, expr in data.items())
+    expected = pl.DataFrame({"a": [2]})
+    assert df.equals(expected)

--- a/py-polars/tests/unit/test_projections.py
+++ b/py-polars/tests/unit/test_projections.py
@@ -356,7 +356,7 @@ def test_projection_join_names_9955() -> None:
         how="inner",
     )
 
-    q = q.select(batting.collect_schema())
+    q = q.select(*batting.collect_schema().keys())
 
     assert q.collect().schema == {
         "playerID": pl.String,


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/17879

## Rationale

This enables dictionary information (which is a raw python `iterable` type under the hood) to not be passed to the `with_columns` operator. 

By guarding at the python level, this prevents it ever hitting the query planner and doing further work. 

Information in the format of a dictionary should be explicitly stated to meet the API requirements. 

## Changes

- [x] Adds guard in the core `with_columns` method with an instructional error message

## Tests

- [x] 3 tests added to `test_df.py` (if there's a better place to put these let me know)
- [x] Existing `make tests` test suite passes 
- [x] `make pre-commit` run before PR


