### PR TITLE
fix(python): Guard against invalid nested objects in 'map_elements'

### DIFF
--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -1259,6 +1259,10 @@ fn fmt_struct(f: &mut Formatter<'_>, vals: &[AnyValue]) -> fmt::Result {
 
 impl Series {
     pub fn fmt_list(&self) -> String {
+        assert!(
+            !self.dtype().is_object(),
+            "nested Objects are not allowed\n\nYou probably got here by not setting a `return_dtype` on a UDF on Objects."
+        );
         if self.is_empty() {
             return "[]".to_owned();
         }

--- a/crates/polars-python/src/map/mod.rs
+++ b/crates/polars-python/src/map/mod.rs
@@ -10,6 +10,7 @@ use polars::prelude::*;
 use polars_core::POOL;
 use polars_core::utils::CustomIterTools;
 use polars_utils::pl_str::PlSmallStr;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
 use pyo3::types::PyDict;
@@ -33,6 +34,16 @@ impl PyPolarsNumericType for Int64Type {}
 impl PyPolarsNumericType for Int128Type {}
 impl PyPolarsNumericType for Float32Type {}
 impl PyPolarsNumericType for Float64Type {}
+
+pub(super) fn check_nested_object(dt: &DataType) -> PyResult<()> {
+    if dt.contains_objects() {
+        Err(PyValueError::new_err(
+            "nested objects are not allowed\n\nSet `return_dtype=polars.Object` to use Python's native nesting.",
+        ))
+    } else {
+        Ok(())
+    }
+}
 
 fn iterator_to_struct<'py>(
     py: Python<'py>,

--- a/crates/polars-python/src/map/series.rs
+++ b/crates/polars-python/src/map/series.rs
@@ -52,6 +52,7 @@ fn infer_and_finish<'py, A: ApplyLambda<'py>>(
         let series = py_pyseries.extract::<PySeries>(py).unwrap().series;
 
         let dt = series.dtype();
+        check_nested_object(dt)?;
 
         // Null dtype may be incorrect, fall back to AnyValues logic.
         if dt.is_nested_null() {
@@ -90,6 +91,11 @@ fn infer_and_finish<'py, A: ApplyLambda<'py>>(
         }
     } else if out.is_instance_of::<PyDict>() {
         let first = out.extract::<Wrap<AnyValue<'_>>>()?;
+        let dt = DataType::from(&first.0);
+        if dt.is_nested() {
+            check_nested_object(&dt)?;
+        }
+
         applyer.apply_into_struct(py, lambda, null_count, first.0)
     }
     // this succeeds for numpy ints as well, where checking if it is pyint fails
@@ -105,6 +111,10 @@ fn infer_and_finish<'py, A: ApplyLambda<'py>>(
             )
             .map(|ca| ca.into_series().into())
     } else if let Ok(av) = out.extract::<Wrap<AnyValue>>() {
+        let dt = DataType::from(&av.0);
+        if dt.is_nested() {
+            check_nested_object(&dt)?;
+        }
         applyer
             .apply_extract_any_values(py, lambda, null_count, av.0)
             .map(|s| s.into())

--- a/py-polars/tests/unit/datatypes/test_object.py
+++ b/py-polars/tests/unit/datatypes/test_object.py
@@ -261,3 +261,17 @@ def test_object_polars_dtypes_20572() -> None:
         }
     )
     assert all(dt.is_object() for dt in df.schema.dtypes())
+
+
+def test_err_nested_object() -> None:
+    a = object()
+    df = pl.DataFrame({"obj": [a]})
+
+    def mapper(x: object) -> list[object]:
+        return [x]
+
+    with pytest.raises(ValueError):
+        df.select(pl.col("obj").map_elements(mapper))
+
+    with pytest.raises(ValueError):
+        df.select(pl.col("obj").map_elements(mapper, return_dtype=pl.List(pl.Object)))


### PR DESCRIPTION
#8493