### PR TITLE
docs(python): Add hint to use `DataFrame/Series` constructors in `from_arrow` docstring

### DIFF
--- a/py-polars/polars/convert/general.py
+++ b/py-polars/polars/convert/general.py
@@ -476,6 +476,9 @@ def from_arrow(
     This operation will be zero copy for the most part. Types that are not
     supported by Polars may be cast to the closest supported type.
 
+    Hint: You can also directly pass arrow tables to `pl.DataFrame()` / arrow
+    arrays to `pl.Series()` to avoid typing issues.
+
     Parameters
     ----------
     data : :class:`pyarrow.Table`, :class:`pyarrow.Array`, one or more :class:`pyarrow.RecordBatch`

--- a/py-polars/polars/convert/general.py
+++ b/py-polars/polars/convert/general.py
@@ -477,7 +477,7 @@ def from_arrow(
     supported by Polars may be cast to the closest supported type.
 
     Hint: You can also directly pass arrow tables to `pl.DataFrame()` / arrow
-    arrays to `pl.Series()` to avoid typing issues.
+    arrays to `pl.Series()` if the output type is known to avoid typing issues.
 
     Parameters
     ----------


### PR DESCRIPTION
* ref https://github.com/pola-rs/polars/issues/22921

Leaves a hint to directly use `pl.DataFrame()`/`pl.Series()` in the docstring of `from_arrow()`, which can avoid typing issues due to `from_arrow()` cannot be typed properly - (https://github.com/pola-rs/polars/pull/8011/files#diff-4c94e013bf5cbe1352b49c01958d0a6d58948f0abf030bf26f6f6c9089e4706eR426-R430).
