### PR TITLE
fix: Support `skip_lines` for `scan_csv` with `pl.len()`

### DIFF
--- a/crates/polars-io/src/csv/read/parser.rs
+++ b/crates/polars-io/src/csv/read/parser.rs
@@ -15,10 +15,12 @@ use super::options::{CommentPrefix, NullValuesCompiled};
 use super::splitfields::SplitFields;
 use super::utils::get_file_chunks;
 use crate::path_utils::is_cloud_url;
+use crate::prelude::_csv_read_internal::find_starting_point;
 use crate::utils::compression::maybe_decompress_bytes;
 
 /// Read the number of rows without parsing columns
 /// useful for count(*) queries
+#[allow(clippy::too_many_arguments)]
 pub fn count_rows(
     path: &Path,
     separator: u8,
@@ -26,6 +28,9 @@ pub fn count_rows(
     comment_prefix: Option<&CommentPrefix>,
     eol_char: u8,
     has_header: bool,
+    skip_lines: usize,
+    skip_rows_before_header: usize,
+    skip_rows_after_header: usize,
 ) -> PolarsResult<usize> {
     let file = if is_cloud_url(path) || config::force_async() {
         feature_gated!("cloud", {
@@ -50,11 +55,15 @@ pub fn count_rows(
         comment_prefix,
         eol_char,
         has_header,
+        skip_lines,
+        skip_rows_before_header,
+        skip_rows_after_header,
     )
 }
 
 /// Read the number of rows without parsing columns
 /// useful for count(*) queries
+#[allow(clippy::too_many_arguments)]
 pub fn count_rows_from_slice_par(
     mut bytes: &[u8],
     separator: u8,
@@ -62,6 +71,9 @@ pub fn count_rows_from_slice_par(
     comment_prefix: Option<&CommentPrefix>,
     eol_char: u8,
     has_header: bool,
+    skip_lines: usize,
+    skip_rows_before_header: usize,
+    skip_rows_after_header: usize,
 ) -> PolarsResult<usize> {
     for _ in 0..bytes.len() {
         if bytes[0] != eol_char {
@@ -70,6 +82,26 @@ pub fn count_rows_from_slice_par(
 
         bytes = &bytes[1..];
     }
+
+    // Skip lines and jump past header
+
+    let start_offset = find_starting_point(
+        bytes,
+        quote_char,
+        eol_char,
+        // schema_len
+        // NOTE: schema_len is normally required to differentiate handling a leading blank line
+        // between case (a) when schema_len == 1 (as an empty string) vs case (b) when
+        // schema_len > 1 (as a blank line to be ignored).
+        // We skip blank lines, even when UFT8-BOM is present and schema_len == 1.
+        usize::MAX,
+        skip_lines,
+        skip_rows_before_header,
+        skip_rows_after_header,
+        comment_prefix,
+        has_header,
+    )?;
+    bytes = &bytes[start_offset..];
 
     const MIN_ROWS_PER_THREAD: usize = 1024;
     let max_threads = POOL.current_num_threads();
@@ -90,7 +122,7 @@ pub fn count_rows_from_slice_par(
     .unwrap_or(1);
 
     if n_threads == 1 {
-        return count_rows_from_slice(bytes, quote_char, comment_prefix, eol_char, has_header);
+        return count_rows_from_slice(bytes, quote_char, comment_prefix, eol_char, false);
     }
 
     let file_chunks: Vec<(usize, usize)> =
@@ -111,7 +143,7 @@ pub fn count_rows_from_slice_par(
 
     let n: usize = POOL.install(|| iter.sum());
 
-    Ok(n - (has_header as usize))
+    Ok(n)
 }
 
 /// Read the number of rows without parsing columns

--- a/crates/polars-plan/src/plans/functions/count.rs
+++ b/crates/polars-plan/src/plans/functions/count.rs
@@ -88,6 +88,9 @@ fn count_all_rows_csv(
                 parse_options.comment_prefix.as_ref(),
                 parse_options.eol_char,
                 options.has_header,
+                options.skip_lines,
+                options.skip_rows,
+                options.skip_rows_after_header,
             ),
             _ => {
                 let memslice = source.to_memslice()?;
@@ -99,6 +102,9 @@ fn count_all_rows_csv(
                     parse_options.comment_prefix.as_ref(),
                     parse_options.eol_char,
                     options.has_header,
+                    options.skip_lines,
+                    options.skip_rows,
+                    options.skip_rows_after_header,
                 )
             },
         })

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2605,14 +2605,3 @@ def test_csv_write_scalar_empty_chunk_20273(filter_value: int, expected: str) ->
     df2 = pl.DataFrame({"c": [99]})
     df3 = df1.join(df2, how="cross").filter(pl.col("a").eq(filter_value))
     assert df3.write_csv() == expected
-
-
-def test_csv_scan_skip_lines_len_22889() -> None:
-    bb = b"col\n1\n2\n3"
-    expected = pl.DataFrame({"len": [1]}, schema={"len": pl.UInt32})
-
-    out = pl.scan_csv(bb, skip_lines=2).select(pl.len()).collect()
-    assert_frame_equal(expected, out)
-
-    out = pl.scan_csv(bb, skip_lines=2).collect().select(pl.len())
-    assert_frame_equal(expected, out)

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2605,3 +2605,14 @@ def test_csv_write_scalar_empty_chunk_20273(filter_value: int, expected: str) ->
     df2 = pl.DataFrame({"c": [99]})
     df3 = df1.join(df2, how="cross").filter(pl.col("a").eq(filter_value))
     assert df3.write_csv() == expected
+
+
+def test_csv_scan_skip_lines_len_22889() -> None:
+    bb = b"col\n1\n2\n3"
+    expected = pl.DataFrame({"len": [1]}, schema={"len": pl.UInt32})
+
+    out = pl.scan_csv(bb, skip_lines=2).select(pl.len()).collect()
+    assert_frame_equal(expected, out)
+
+    out = pl.scan_csv(bb, skip_lines=2).collect().select(pl.len())
+    assert_frame_equal(expected, out)


### PR DESCRIPTION
fixes #22889

(Sorry @nameexhaustion , I did not realize you already self-assigned this, just seeing it now, my bad)

Submitting as draft to get feedback, as I lack some context on the multiple CSV routines, their history and potential performance tradeoffs. This issue involves FastCount, introduced for `count(*)` performance, see https://github.com/pola-rs/polars/pull/14574

* Is this the right place to fix it?
* On `schema_len` (see code): there is a minor inconsistency in the code on how we handle a leading blank line in case there is an UTF8-BOM and `schema_len == 1`. That said inferring schema may have a negative performance effect, as by default 100 rows will be parsed. Let me know if we want to infer schema_length consistently, that should not be hard. 

On a related note, is the following correct?
[let infer_schema_length = if self.options.has_header {](https://github.com/kdn36/polars/blob/f3c9406429d5baab869561c77e6d07e03e422add/crates/polars-stream/src/nodes/io_sources/csv.rs#L165-L166)
If I am not mistaken, the code is intended to parse multiple rows (default 100) to infer schema, including dealing with a mix of Int and Float. The fact that a header is present should not drop the latter functionality?



