### PR TITLE
refactor(rust): Add new (Frozen)Categories and CategoricalMapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,6 +837,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "boxcar"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66bb12751a83493ef4b8da1120451a262554e216a247f14b48cb5e8fe7ed8bdf"
+
+[[package]]
 name = "brotli"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3049,6 +3055,7 @@ version = "0.48.1"
 dependencies = [
  "bincode",
  "bitflags",
+ "boxcar",
  "bytemuck",
  "chrono",
  "chrono-tz",
@@ -3074,6 +3081,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum_macros",
+ "uuid",
  "version_check",
  "xxhash-rust",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ avro-schema = { version = "0.3" }
 base64 = "0.22.0"
 bincode = "1.3.3"
 bitflags = "2"
+boxcar = "0.2.12"
 bytemuck = { version = "1.22", features = ["derive", "extern_crate_alloc"] }
 bytes = { version = "1.10" }
 chrono = { version = "0.4.31", default-features = false, features = ["std"] }

--- a/crates/polars-arrow/src/array/binview/mod.rs
+++ b/crates/polars-arrow/src/array/binview/mod.rs
@@ -40,6 +40,8 @@ use crate::array::iterator::NonNullValuesIter;
 use crate::bitmap::utils::{BitmapIter, ZipValidity};
 pub type BinaryViewArray = BinaryViewArrayGeneric<[u8]>;
 pub type Utf8ViewArray = BinaryViewArrayGeneric<str>;
+pub type BinaryViewArrayBuilder = BinaryViewArrayGenericBuilder<[u8]>;
+pub type Utf8ViewArrayBuilder = BinaryViewArrayGenericBuilder<str>;
 pub use view::{View, validate_utf8_views};
 
 use super::Splitable;

--- a/crates/polars-arrow/src/array/mod.rs
+++ b/crates/polars-arrow/src/array/mod.rs
@@ -686,8 +686,9 @@ pub use binary::{
     BinaryArray, BinaryArrayBuilder, BinaryValueIter, MutableBinaryArray, MutableBinaryValuesArray,
 };
 pub use binview::{
-    BinaryViewArray, BinaryViewArrayGeneric, BinaryViewArrayGenericBuilder, MutableBinaryViewArray,
-    MutablePlBinary, MutablePlString, Utf8ViewArray, View, ViewType,
+    BinaryViewArray, BinaryViewArrayBuilder, BinaryViewArrayGeneric, BinaryViewArrayGenericBuilder,
+    MutableBinaryViewArray, MutablePlBinary, MutablePlString, Utf8ViewArray, Utf8ViewArrayBuilder,
+    View, ViewType,
 };
 pub use boolean::{BooleanArray, BooleanArrayBuilder, MutableBooleanArray};
 pub use dictionary::{DictionaryArray, DictionaryKey, MutableDictionaryArray};

--- a/crates/polars-core/Cargo.toml
+++ b/crates/polars-core/Cargo.toml
@@ -17,6 +17,7 @@ polars-utils = { workspace = true }
 
 arrow = { workspace = true }
 bitflags = { workspace = true }
+boxcar = { workspace = true }
 bytemuck = { workspace = true }
 chrono = { workspace = true, optional = true }
 chrono-tz = { workspace = true, optional = true }
@@ -37,6 +38,7 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 strum_macros = { workspace = true }
+uuid = { workspace = true }
 xxhash-rust = { workspace = true }
 
 [dev-dependencies]

--- a/crates/polars-core/src/datatypes/categories/mapping.rs
+++ b/crates/polars-core/src/datatypes/categories/mapping.rs
@@ -1,0 +1,105 @@
+use std::hash::BuildHasher;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use polars_utils::aliases::PlSeedableRandomStateQuality;
+use polars_utils::parma::raw::RawTable;
+
+#[derive(Default)]
+pub struct CategoricalMapping {
+    str_to_cat: RawTable<str, u32>,
+    cat_to_str: boxcar::Vec<&'static str>,
+    upper_bound: AtomicUsize,
+    hasher: PlSeedableRandomStateQuality,
+}
+
+impl CategoricalMapping {
+    pub fn with_hasher(hasher: PlSeedableRandomStateQuality) -> Self {
+        Self {
+            str_to_cat: RawTable::default(),
+            cat_to_str: boxcar::Vec::default(),
+            upper_bound: AtomicUsize::new(0),
+            hasher,
+        }
+    }
+
+    #[inline(always)]
+    pub fn hasher(&self) -> &PlSeedableRandomStateQuality {
+        &self.hasher
+    }
+
+    /// Try to convert a string to a categorical id, but don't insert it if it is missing.
+    #[inline(always)]
+    pub fn get_cat(&self, s: &str) -> Option<u32> {
+        let hash = self.hasher.hash_one(s);
+        self.get_cat_with_hash(s, hash)
+    }
+
+    /// Same as get_cat, but with the hash pre-computed.
+    #[inline(always)]
+    pub fn get_cat_with_hash(&self, s: &str, hash: u64) -> Option<u32> {
+        self.str_to_cat.get(hash, |k| k == s).copied()
+    }
+
+    /// Convert a string to a categorical id.
+    #[inline(always)]
+    pub fn insert_cat(&self, s: &str) -> u32 {
+        let hash = self.hasher.hash_one(s);
+        self.insert_cat_with_hash(s, hash)
+    }
+
+    /// Same as to_cat, but with the hash pre-computed.
+    #[inline(always)]
+    pub fn insert_cat_with_hash(&self, s: &str, hash: u64) -> u32 {
+        *self.str_to_cat.get_or_insert_with(
+            hash,
+            s,
+            |k| k == s,
+            |k| {
+                self.upper_bound.fetch_add(1, Ordering::Relaxed);
+                let idx = self
+                    .cat_to_str
+                    .push(unsafe { core::mem::transmute::<&str, &'static str>(k) });
+                if idx >= (u32::MAX - 1) as usize {
+                    panic!("more than 2^32 - 1 entries in a categorical");
+                }
+                idx as u32
+            },
+        )
+    }
+
+    /// Try to convert a categorical id to its corresponding string, returning
+    /// None if the string is not in the data structure.
+    #[inline(always)]
+    pub fn cat_to_str(&self, cat: u32) -> Option<&str> {
+        self.cat_to_str.get(cat as usize).copied()
+    }
+
+    /// Get the string corresponding to a categorical id.
+    ///
+    /// # Safety
+    /// The categorical id must have been returned from `to_cat`, and you must
+    /// have synchronized with the call which inserted it.
+    #[inline(always)]
+    pub unsafe fn cat_to_str_unchecked(&self, cat: u32) -> &str {
+        unsafe { self.cat_to_str.get_unchecked(cat as usize) }
+    }
+
+    /// Returns an upper bound such that all strings inserted into the CategoricalMapping
+    /// have a categorical id less than it. Note that due to parallel inserts which
+    /// you have not synchronized with, there may be gaps when using `from_cat`.
+    #[inline(always)]
+    pub fn num_cats_upper_bound(&self) -> usize {
+        self.upper_bound.load(Ordering::Relaxed)
+    }
+
+    /// Returns the number of categories in this mapping.
+    #[inline(always)]
+    pub fn len(&mut self) -> usize {
+        *self.upper_bound.get_mut()
+    }
+
+    #[inline(always)]
+    pub fn is_empty(&mut self) -> bool {
+        self.len() == 0
+    }
+}

--- a/crates/polars-core/src/datatypes/categories/mod.rs
+++ b/crates/polars-core/src/datatypes/categories/mod.rs
@@ -1,0 +1,224 @@
+use std::hash::{BuildHasher, Hasher};
+use std::sync::{Arc, LazyLock, Mutex, Weak};
+
+use arrow::array::builder::StaticArrayBuilder;
+use arrow::array::{Utf8ViewArray, Utf8ViewArrayBuilder};
+use hashbrown::HashTable;
+use hashbrown::hash_table::Entry;
+use polars_error::{PolarsResult, polars_ensure};
+use polars_utils::pl_str::PlSmallStr;
+use uuid::Uuid;
+
+use crate::prelude::*;
+
+mod mapping;
+
+pub use mapping::CategoricalMapping;
+
+// Used to maintain a 1:1 mapping between Categories' UUID and the Categories objects themselves.
+// This is important for serialization.
+static CATEGORIES_REGISTRY: LazyLock<Mutex<PlHashMap<Uuid, Weak<Categories>>>> =
+    LazyLock::new(|| Mutex::new(PlHashMap::new()));
+
+// Used to make FrozenCategories unique based on their content. This allows comparison of datatypes
+// in constant time by comparing pointers.
+#[expect(clippy::type_complexity)]
+static FROZEN_CATEGORIES_REGISTRY: LazyLock<Mutex<HashTable<(u64, Weak<FrozenCategories>)>>> =
+    LazyLock::new(|| Mutex::new(HashTable::new()));
+
+static FROZEN_CATEGORIES_HASHER: LazyLock<PlSeedableRandomStateQuality> =
+    LazyLock::new(PlSeedableRandomStateQuality::random);
+
+static GLOBAL_CATEGORIES: LazyLock<Arc<Categories>> = LazyLock::new(|| {
+    let categories = Arc::new(Categories {
+        name: PlSmallStr::from_static("__POLARS_GLOBAL_CATEGORIES"),
+        uuid: Uuid::nil(),
+        mapping: MaybeGcMapping::Gc(Mutex::new(Weak::new())),
+    });
+    CATEGORIES_REGISTRY
+        .lock()
+        .unwrap()
+        .insert(Uuid::nil(), Arc::downgrade(&categories));
+    categories
+});
+
+/// A (named) object which is used to indicate which categorical data types
+/// have the same mapping. The underlying mapping is dynamic, and if gc is true
+/// may be automatically cleared when the last reference to it goes away.
+pub struct Categories {
+    name: PlSmallStr,
+    uuid: Uuid,
+    mapping: MaybeGcMapping,
+}
+
+enum MaybeGcMapping {
+    Gc(Mutex<Weak<CategoricalMapping>>),
+    Persistent(Arc<CategoricalMapping>),
+}
+
+impl Categories {
+    /// Creates a new Categories object with the given name.
+    ///
+    /// If gc is true the underlying categories will automatically get cleaned
+    /// up when the last CategoricalMapping reference goes away, otherwise they
+    /// are persistent.
+    pub fn new(name: PlSmallStr, gc: bool) -> Arc<Self> {
+        Self::new_with_registry(name, gc, &mut CATEGORIES_REGISTRY.lock().unwrap())
+    }
+
+    /// Returns the Categories object with the given UUID. If the UUID is unknown a new one is created.
+    pub fn from_uuid(name: PlSmallStr, gc: bool, uuid: Uuid) -> Arc<Self> {
+        if uuid.is_nil() {
+            return Self::global();
+        }
+
+        let mut registry = CATEGORIES_REGISTRY.lock().unwrap();
+        if let Some(cats_ref) = registry.get(&uuid) {
+            if let Some(cats) = cats_ref.upgrade() {
+                return cats;
+            }
+        }
+        Self::new_with_registry(name, gc, &mut registry)
+    }
+
+    /// Returns the global Categories.
+    pub fn global() -> Arc<Self> {
+        GLOBAL_CATEGORIES.clone()
+    }
+
+    fn new_with_registry(
+        name: PlSmallStr,
+        gc: bool,
+        registry: &mut PlHashMap<Uuid, Weak<Categories>>,
+    ) -> Arc<Categories> {
+        let uuid = Uuid::new_v4();
+
+        let mapping = if gc {
+            MaybeGcMapping::Gc(Mutex::new(Weak::new()))
+        } else {
+            MaybeGcMapping::Persistent(Arc::new(CategoricalMapping::default()))
+        };
+
+        let slf = Arc::new(Self {
+            name,
+            uuid,
+            mapping,
+        });
+        registry.insert(uuid, Arc::downgrade(&slf));
+        slf
+    }
+
+    /// The name of this Categories object (not unique).
+    pub fn name(&self) -> &PlSmallStr {
+        &self.name
+    }
+
+    /// The mapping for this Categories object. If no mapping currently exists
+    /// it creates a new empty mapping.
+    pub fn mapping(&self) -> Arc<CategoricalMapping> {
+        match &self.mapping {
+            MaybeGcMapping::Gc(weak) => {
+                let mut guard = weak.lock().unwrap();
+                if let Some(arc) = guard.upgrade() {
+                    return arc;
+                }
+                let arc = Arc::new(CategoricalMapping::default());
+                *guard = Arc::downgrade(&arc);
+                arc
+            },
+            MaybeGcMapping::Persistent(arc) => arc.clone(),
+        }
+    }
+
+    pub fn freeze(&self) -> Arc<FrozenCategories> {
+        let mapping = self.mapping();
+        let n = mapping.num_cats_upper_bound();
+        FrozenCategories::new((0..n).flat_map(|i| mapping.cat_to_str(i as u32))).unwrap()
+    }
+}
+
+impl Drop for Categories {
+    fn drop(&mut self) {
+        CATEGORIES_REGISTRY.lock().unwrap().remove(&self.uuid);
+    }
+}
+
+/// An ordered collection of unique strings with an associated pre-computed
+/// mapping to go from string <-> index.
+///
+/// FrozenCategories are globally unique to facilitate constant-time comparison.
+pub struct FrozenCategories {
+    combined_hash: u64,
+    categories: Utf8ViewArray,
+    mapping: Arc<CategoricalMapping>,
+}
+
+impl FrozenCategories {
+    /// Creates a new FrozenCategories object (or returns a reference to an existing one
+    /// in case these are already known). Returns an error if the categories are not unique.
+    /// It is guaranteed that the nth string ends up with category n (0-indexed).
+    pub fn new<'a, I: Iterator<Item = &'a str>>(strings: I) -> PolarsResult<Arc<Self>> {
+        let hasher = *FROZEN_CATEGORIES_HASHER;
+        let mut mapping = CategoricalMapping::with_hasher(hasher);
+        let mut builder = Utf8ViewArrayBuilder::new(ArrowDataType::Utf8);
+        builder.reserve(strings.size_hint().0);
+
+        let hasher = PlFixedStateQuality::default();
+        let mut combined_hasher = hasher.build_hasher();
+        for s in strings {
+            let hash = hasher.hash_one(s);
+            combined_hasher.write_u64(hash);
+            mapping.insert_cat_with_hash(s, hash);
+            builder.push_value_ignore_validity(s);
+            polars_ensure!(mapping.len() == builder.len(), ComputeError: "FrozenCategories must contain unique strings; found duplicate '{s}'");
+        }
+
+        let combined_hash = combined_hasher.finish();
+        let categories = builder.freeze();
+
+        let mut registry = FROZEN_CATEGORIES_REGISTRY.lock().unwrap();
+        let mut last_compared = None; // We have to store the strong reference to avoid a race condition.
+        match registry.entry(
+            combined_hash,
+            |(hash, weak)| {
+                *hash == combined_hash && {
+                    if let Some(frozen_cats) = weak.upgrade() {
+                        let cmp = frozen_cats.categories == categories;
+                        last_compared = Some(frozen_cats);
+                        cmp
+                    } else {
+                        false
+                    }
+                }
+            },
+            |(hash, _weak)| *hash,
+        ) {
+            Entry::Occupied(_) => Ok(last_compared.unwrap()),
+            Entry::Vacant(v) => {
+                let slf = Arc::new(Self {
+                    combined_hash,
+                    categories,
+                    mapping: Arc::new(mapping),
+                });
+                v.insert((combined_hash, Arc::downgrade(&slf)));
+                Ok(slf)
+            },
+        }
+    }
+
+    /// The mapping for this FrozenCategories object.
+    pub fn mapping(&self) -> &Arc<CategoricalMapping> {
+        &self.mapping
+    }
+}
+
+impl Drop for FrozenCategories {
+    fn drop(&mut self) {
+        let mut registry = FROZEN_CATEGORIES_REGISTRY.lock().unwrap();
+        while let Ok(entry) =
+            registry.find_entry(self.combined_hash, |(_, weak)| weak.strong_count() == 0)
+        {
+            entry.remove();
+        }
+    }
+}

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -10,6 +10,8 @@
 mod _serde;
 mod aliases;
 mod any_value;
+#[cfg(feature = "dtype-categorical")]
+mod categories;
 mod dtype;
 mod field;
 mod into_scalar;
@@ -32,6 +34,8 @@ pub use arrow::datatypes::reshape::*;
 pub use arrow::datatypes::{ArrowDataType, TimeUnit as ArrowTimeUnit};
 use arrow::types::NativeType;
 use bytemuck::Zeroable;
+#[cfg(feature = "dtype-categorical")]
+pub use categories::{CategoricalMapping, Categories, FrozenCategories};
 pub use dtype::*;
 pub use field::*;
 pub use into_scalar::*;

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -25,6 +25,7 @@ pub mod idx_mapper;
 pub mod idx_vec;
 pub mod mem;
 pub mod min_max;
+pub mod parma;
 pub mod pl_str;
 pub mod priority;
 pub mod regex_cache;

--- a/crates/polars-utils/src/parma/mod.rs
+++ b/crates/polars-utils/src/parma/mod.rs
@@ -1,0 +1,4 @@
+//! A fast concurrent hash map, with a focus on read performance.
+
+/// The low-level raw table implementation.
+pub mod raw;

--- a/crates/polars-utils/src/parma/raw/key.rs
+++ b/crates/polars-utils/src/parma/raw/key.rs
@@ -1,0 +1,116 @@
+/// A low-level trait for keys.
+///
+/// This is used to allow unsized types such as [`str`] for keys.
+pub trait Key {
+    /// The alignment necessary for the key. Must return a power of two.
+    fn align() -> usize;
+
+    /// The size of the key in bytes.
+    fn size(&self) -> usize;
+
+    /// Initialize the key in the given memory location.
+    ///
+    /// # Safety
+    /// The memory location must satisfy the specified size and alignment.
+    unsafe fn init(&self, ptr: *mut u8);
+
+    /// Get a reference to the key from the given memory location.
+    ///
+    /// # Safety
+    /// The pointer must be valid and initialized with [`Key::init`].
+    unsafe fn get<'a>(ptr: *const u8) -> &'a Self;
+
+    /// Drop the key in place.
+    ///
+    /// # Safety
+    /// The pointer must be valid and initialized with [`Key::init`].
+    unsafe fn drop_in_place(ptr: *mut u8);
+}
+
+impl<T: Copy> Key for [T] {
+    #[inline(always)]
+    fn align() -> usize {
+        align_of::<usize>().max(align_of::<T>())
+    }
+
+    #[inline(always)]
+    fn size(&self) -> usize {
+        size_of::<usize>().next_multiple_of(align_of::<T>()) + self.len()
+    }
+
+    #[inline(always)]
+    unsafe fn init(&self, ptr: *mut u8) {
+        unsafe {
+            let p_len = ptr.cast::<usize>();
+            let p_data = ptr.add(size_of::<usize>().next_multiple_of(align_of::<T>()));
+            let len = self.len();
+            p_len.write(len);
+            std::ptr::copy_nonoverlapping(self.as_ptr(), p_data.cast(), len)
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn get<'a>(ptr: *const u8) -> &'a Self {
+        unsafe {
+            let p_len = ptr.cast::<usize>();
+            let p_data = ptr.add(size_of::<usize>().next_multiple_of(align_of::<T>()));
+            let len = p_len.read();
+            core::slice::from_raw_parts(p_data.cast(), len)
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn drop_in_place(_ptr: *mut u8) {}
+}
+
+impl Key for str {
+    #[inline(always)]
+    fn align() -> usize {
+        <[u8] as Key>::align()
+    }
+
+    #[inline(always)]
+    fn size(&self) -> usize {
+        <[u8] as Key>::size(self.as_bytes())
+    }
+
+    #[inline(always)]
+    unsafe fn init(&self, ptr: *mut u8) {
+        unsafe { <[u8] as Key>::init(self.as_bytes(), ptr) }
+    }
+
+    #[inline(always)]
+    unsafe fn get<'a>(ptr: *const u8) -> &'a Self {
+        unsafe { core::str::from_utf8_unchecked(<[u8] as Key>::get(ptr)) }
+    }
+
+    #[inline(always)]
+    unsafe fn drop_in_place(_ptr: *mut u8) {}
+}
+
+impl<T: Clone + Sized> Key for T {
+    fn align() -> usize {
+        align_of::<T>()
+    }
+
+    fn size(&self) -> usize {
+        size_of::<T>()
+    }
+
+    #[inline(always)]
+    unsafe fn init(&self, ptr: *mut u8) {
+        unsafe {
+            ptr.cast::<T>().write(self.clone());
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn get<'a>(ptr: *const u8) -> &'a Self {
+        unsafe { &*ptr.cast::<T>() }
+    }
+
+    #[inline(always)]
+    unsafe fn drop_in_place(ptr: *mut u8) {
+        unsafe { ptr.cast::<T>().drop_in_place() }
+    }
+}

--- a/crates/polars-utils/src/parma/raw/mod.rs
+++ b/crates/polars-utils/src/parma/raw/mod.rs
@@ -1,0 +1,785 @@
+use std::alloc::Layout;
+use std::marker::PhantomData;
+use std::mem::MaybeUninit;
+use std::ptr::without_provenance_mut;
+use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
+use std::sync::{Condvar, Mutex, MutexGuard, RwLock};
+
+mod key;
+mod probe;
+
+pub use key::Key;
+use probe::{Prober, TagGroup};
+
+#[repr(C)]
+struct AllocHeader<K: ?Sized, V> {
+    num_entries: usize,
+    num_deletions: AtomicUsize,
+
+    // Must be decremented when starting an insertion, waiting for a new
+    // allocation if the counter is zero.
+    claim_start_semaphore: AtomicUsize,
+
+    // Must be decremented when an insertion has claimed a slot in the entry table,
+    // used to ensure all entries are up-to-date before starting the rehashing process.
+    claim_done_barrier: AtomicUsize,
+
+    marker: PhantomData<(Box<K>, V)>,
+    align: [TagGroup; 0],
+}
+
+impl<K: ?Sized, V> AllocHeader<K, V> {
+    fn layout(num_entries: usize) -> Layout {
+        // Layout: AllocHeader [tags] [entries]
+        assert!(num_entries.is_power_of_two() && num_entries >= size_of::<TagGroup>());
+        let mut layout = Layout::new::<Self>();
+        layout = layout
+            .extend(Layout::array::<TagGroup>(num_entries / size_of::<TagGroup>()).unwrap())
+            .unwrap()
+            .0;
+        layout = layout
+            .extend(Layout::array::<AtomicPtr<EntryHeader<K, V>>>(num_entries).unwrap())
+            .unwrap()
+            .0;
+        layout
+    }
+
+    #[inline(always)]
+    unsafe fn tags(&self, alloc: *mut Self) -> &[TagGroup] {
+        unsafe {
+            let p = alloc.byte_add(size_of::<Self>());
+            core::slice::from_raw_parts(p.cast(), self.num_entries / size_of::<TagGroup>())
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn entries(&self, alloc: *mut Self) -> &[AtomicPtr<EntryHeader<K, V>>] {
+        unsafe {
+            let p = alloc.byte_add(size_of::<Self>() + self.num_entries);
+            core::slice::from_raw_parts(p.cast(), self.num_entries)
+        }
+    }
+
+    #[inline(always)]
+    #[allow(clippy::mut_from_ref)] // Does not borrow from &self, but from alloc.
+    unsafe fn tags_mut(&self, alloc: *mut Self) -> &mut [TagGroup] {
+        unsafe {
+            let p = alloc.byte_add(size_of::<Self>());
+            core::slice::from_raw_parts_mut(p.cast(), self.num_entries / size_of::<TagGroup>())
+        }
+    }
+
+    #[inline(always)]
+    #[allow(clippy::mut_from_ref)] // Does not borrow from &self, but from alloc.
+    unsafe fn entries_mut(&self, alloc: *mut Self) -> &mut [AtomicPtr<EntryHeader<K, V>>] {
+        unsafe {
+            let p = alloc.byte_add(size_of::<Self>() + self.num_entries);
+            core::slice::from_raw_parts_mut(p.cast(), self.num_entries)
+        }
+    }
+
+    fn new(num_entries: usize) -> *mut Self {
+        let layout = Self::layout(num_entries);
+        unsafe {
+            let alloc = std::alloc::alloc(layout).cast::<Self>();
+            if alloc.is_null() {
+                std::alloc::handle_alloc_error(layout);
+            }
+
+            let max_load = probe::max_load(num_entries);
+            alloc.write(Self {
+                num_entries,
+                num_deletions: AtomicUsize::new(0),
+                claim_start_semaphore: AtomicUsize::new(max_load),
+                claim_done_barrier: AtomicUsize::new(max_load),
+                marker: PhantomData,
+                align: [],
+            });
+
+            let tags_p = alloc.byte_add(size_of::<Self>()) as *mut u8;
+            let tags: &mut [MaybeUninit<TagGroup>] =
+                core::slice::from_raw_parts_mut(tags_p.cast(), num_entries / size_of::<TagGroup>());
+            tags.fill_with(|| MaybeUninit::new(TagGroup::all_empty()));
+
+            let entries_p = alloc.byte_add(size_of::<Self>() + num_entries);
+            let entries: &mut [MaybeUninit<AtomicPtr<u8>>] =
+                core::slice::from_raw_parts_mut(entries_p.cast(), num_entries);
+            entries
+                .fill_with(|| MaybeUninit::new(AtomicPtr::new(without_provenance_mut(UNCLAIMED))));
+
+            alloc
+        }
+    }
+
+    unsafe fn free(slf: *mut Self) {
+        unsafe {
+            if slf != &raw const EMPTY_ALLOC_LOC as _ {
+                let layout = Self::layout((*slf).num_entries);
+                std::alloc::dealloc(slf.cast(), layout);
+            }
+        }
+    }
+
+    // Returns true if you may proceed with the insert attempt, false if you
+    // should wait for reallocation to occur.
+    fn start_claim_attempt(&self) -> bool {
+        self.claim_start_semaphore
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |attempts_left| {
+                attempts_left.checked_sub(1)
+            })
+            .is_ok()
+    }
+
+    fn abort_claim_attempt(
+        &self,
+        alloc_lock: &Mutex<TableLockState<K, V>>,
+        waiting_for_alloc: &Condvar,
+    ) {
+        let old = self.claim_start_semaphore.fetch_add(1, Ordering::Relaxed);
+        if old == 0 {
+            // We need to acquire the lock before notifying to prevent the race
+            // condition [r:check -> w:notify -> r:wait].
+            drop(alloc_lock.lock());
+            waiting_for_alloc.notify_all();
+        }
+    }
+
+    fn finish_claim_attempt(
+        &self,
+        alloc_lock: &Mutex<TableLockState<K, V>>,
+        waiting_for_alloc: &Condvar,
+    ) {
+        let old = self.claim_done_barrier.fetch_sub(1, Ordering::Release);
+        if old == 1 {
+            // We need to hold the lock while notifying to prevent the race
+            // condition [r:check -> w:notify -> r:wait].
+            drop(alloc_lock.lock());
+            waiting_for_alloc.notify_all();
+        }
+    }
+}
+
+// A pointer to an entry in the table must be in one of three states:
+//     0               = unclaimed entry
+//     p               = claimed entry
+//     usize::MAX      = claimed entry, now deleted
+// The only valid transitions are those which move down the above list.
+const UNCLAIMED: usize = 0;
+const DELETED: usize = usize::MAX;
+
+// The state field inside an entry is determined by the bottom three bits.
+// If the DELETE_BIT is set then the entry is considered to be deleted and the
+// upper bits contain the next pointer in the freelist. For this reason entries
+// have to be aligned to at least 8 bytes. Otherwise, the top bits contain
+// the hash.
+const INIT_BIT: usize = 0b001;
+const WAIT_BIT: usize = 0b010;
+const DELETE_BIT: usize = 0b100;
+
+#[repr(C, align(8))]
+struct EntryHeader<K: ?Sized, V> {
+    state: AtomicPtr<EntryHeader<K, V>>,
+    value: MaybeUninit<V>,
+    marker: PhantomData<K>,
+}
+
+impl<K: Key + ?Sized, V> EntryHeader<K, V> {
+    fn layout(key: &K) -> Layout {
+        let key_layout = Layout::from_size_align(key.size(), K::align()).unwrap();
+        Layout::new::<EntryHeader<K, V>>()
+            .extend(key_layout)
+            .unwrap()
+            .0
+    }
+
+    #[inline(always)]
+    fn state_ptr(entry: *mut Self) -> *mut AtomicPtr<EntryHeader<K, V>> {
+        unsafe { &raw mut (*entry).state }
+    }
+
+    #[inline(always)]
+    fn val_ptr(entry: *mut Self) -> *mut V {
+        unsafe { (&raw mut (*entry).value).cast() }
+    }
+
+    #[inline(always)]
+    unsafe fn key_ptr(entry: *mut Self) -> *mut u8 {
+        unsafe {
+            entry
+                .byte_add(size_of::<EntryHeader<K, V>>().next_multiple_of(K::align()))
+                .cast()
+        }
+    }
+
+    fn new(hash: usize, key: &K) -> *mut Self {
+        let layout = Self::layout(key);
+        unsafe {
+            let p = std::alloc::alloc(layout).cast::<Self>();
+            if p.is_null() {
+                std::alloc::handle_alloc_error(layout);
+            }
+            let state = without_provenance_mut(hash & !(INIT_BIT | WAIT_BIT | DELETE_BIT));
+            Self::state_ptr(p).write(AtomicPtr::new(state));
+            key.init(Self::key_ptr(p));
+            p
+        }
+    }
+
+    unsafe fn free(entry: *mut Self) {
+        unsafe {
+            let key = K::get(Self::key_ptr(entry));
+            let layout = Self::layout(key);
+            std::alloc::dealloc(entry.cast(), layout);
+        }
+    }
+
+    // Waits for this entry to be initialized. Returns true if successful, false
+    // if the value was deleted.
+    unsafe fn wait_for_init(
+        entry: *mut Self,
+        init_lock: &Mutex<()>,
+        waiting_for_init: &Condvar,
+    ) -> bool {
+        unsafe {
+            let state_loc = &*Self::state_ptr(entry);
+            let mut state = state_loc.load(Ordering::Acquire);
+            if state.addr() & (DELETE_BIT | INIT_BIT) != 0 {
+                return state.addr() & DELETE_BIT == 0;
+            }
+
+            // First acquire the lock then try setting the wait bit.
+            let mut guard = init_lock.lock().unwrap();
+            if let Err(new_state) = state_loc.compare_exchange(
+                state,
+                state.map_addr(|p| p | WAIT_BIT),
+                Ordering::Relaxed,
+                Ordering::Acquire,
+            ) {
+                state = new_state;
+            }
+
+            // Wait until init is complete.
+            loop {
+                if state.addr() & (DELETE_BIT | INIT_BIT) != 0 {
+                    return state.addr() & DELETE_BIT == 0;
+                }
+
+                guard = waiting_for_init.wait(guard).unwrap();
+                state = state_loc.load(Ordering::Acquire);
+            }
+        }
+    }
+}
+
+/// A concurrent hash table.
+#[repr(align(128))] // To avoid false sharing.
+pub struct RawTable<K: Key + ?Sized, V> {
+    cur_alloc: AtomicPtr<AllocHeader<K, V>>,
+    freelist_head: AtomicPtr<EntryHeader<K, V>>,
+    alloc_lock: Mutex<TableLockState<K, V>>,
+    waiting_for_alloc: Condvar,
+    init_lock: Mutex<()>,
+    waiting_for_init: Condvar,
+    rehash_lock: RwLock<()>,
+    marker: PhantomData<(Box<K>, V)>,
+}
+
+unsafe impl<K: Key + Send + ?Sized, V: Send> Send for RawTable<K, V> {}
+unsafe impl<K: Key + Send + Sync + ?Sized, V: Send + Sync> Sync for RawTable<K, V> {}
+
+struct TableLockState<K: ?Sized, V> {
+    old_allocs: Vec<*mut AllocHeader<K, V>>,
+}
+
+impl<K: Key + ?Sized, V> RawTable<K, V> {
+    /// Creates a new [`RawTable`].
+    pub const fn new() -> Self {
+        Self {
+            cur_alloc: AtomicPtr::new(&raw const EMPTY_ALLOC_LOC as _),
+            freelist_head: AtomicPtr::new(core::ptr::null_mut()),
+            alloc_lock: Mutex::new(TableLockState {
+                old_allocs: Vec::new(),
+            }),
+            waiting_for_alloc: Condvar::new(),
+            init_lock: Mutex::new(()),
+            waiting_for_init: Condvar::new(),
+            rehash_lock: RwLock::new(()),
+            marker: PhantomData,
+        }
+    }
+
+    /// Creates a new [`RawTable`] that will not reallocate before `capacity` insertions are done.
+    pub fn with_capacity(capacity: usize) -> Self {
+        if capacity == 0 {
+            return Self::new();
+        }
+        Self {
+            cur_alloc: AtomicPtr::new(AllocHeader::new(probe::min_entries_for_load(capacity))),
+            freelist_head: AtomicPtr::new(core::ptr::null_mut()),
+            alloc_lock: Mutex::new(TableLockState {
+                old_allocs: Vec::new(),
+            }),
+            waiting_for_alloc: Condvar::new(),
+            init_lock: Mutex::new(()),
+            waiting_for_init: Condvar::new(),
+            rehash_lock: RwLock::new(()),
+            marker: PhantomData,
+        }
+    }
+
+    fn start_insert_attempt(&self) -> *mut AllocHeader<K, V> {
+        unsafe {
+            let alloc = self.cur_alloc.load(Ordering::Acquire);
+            if (*alloc).start_claim_attempt() {
+                return alloc;
+            }
+
+            let mut guard = self.alloc_lock.lock().unwrap();
+            loop {
+                let alloc = self.cur_alloc.load(Ordering::Acquire);
+                let header = &*alloc;
+                if header.start_claim_attempt() {
+                    return alloc;
+                }
+
+                let barrier = header.claim_done_barrier.load(Ordering::Acquire);
+                if barrier == 0 {
+                    guard = self.realloc(guard);
+                } else {
+                    guard = self.waiting_for_alloc.wait(guard).unwrap();
+                }
+            }
+        }
+    }
+
+    unsafe fn realloc<'a>(
+        &'a self,
+        mut alloc_guard: MutexGuard<'a, TableLockState<K, V>>,
+    ) -> MutexGuard<'a, TableLockState<K, V>> {
+        unsafe {
+            let old_alloc = self.cur_alloc.load(Ordering::Relaxed);
+            let old_header = &*old_alloc;
+            let upper_bound_len = probe::max_load(old_header.num_entries)
+                - old_header.num_deletions.load(Ordering::Acquire);
+
+            let num_entries = (upper_bound_len * 2).next_power_of_two().max(32);
+            let alloc = AllocHeader::<K, V>::new(num_entries);
+            let header = &*alloc;
+
+            // Rehash old entries. We must hold the rehash lock exclusively to prevent those operations
+            // which may not occur during rehashing.
+            let rehash_guard = self.rehash_lock.write();
+            let mut entries_reinserted = 0;
+            for entry in old_header.entries(old_alloc) {
+                let entry_ptr = entry.load(Ordering::Relaxed);
+                if entry_ptr.addr() != DELETED && entry_ptr.addr() != UNCLAIMED {
+                    let state = (*EntryHeader::state_ptr(entry_ptr)).load(Ordering::Relaxed);
+                    if state.addr() & DELETE_BIT == 0 {
+                        Self::insert_uniq_entry_exclusive(alloc, state.addr(), entry_ptr);
+                        entries_reinserted += 1;
+                    }
+                }
+            }
+
+            // Publish the new allocation.
+            header
+                .claim_start_semaphore
+                .fetch_sub(entries_reinserted, Ordering::Relaxed);
+            header
+                .claim_done_barrier
+                .fetch_sub(entries_reinserted, Ordering::Relaxed);
+            alloc_guard.old_allocs.push(old_alloc);
+            self.cur_alloc.store(alloc, Ordering::Release);
+            drop(rehash_guard);
+            self.waiting_for_alloc.notify_all();
+            alloc_guard
+        }
+    }
+
+    unsafe fn init_entry_val(
+        &self,
+        hash: usize,
+        header: &AllocHeader<K, V>,
+        entry: &AtomicPtr<EntryHeader<K, V>>,
+        new_entry_ptr: *mut EntryHeader<K, V>,
+        val_f: impl FnOnce(&K) -> V,
+    ) -> *mut EntryHeader<K, V> {
+        unsafe {
+            let r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let key_ptr = EntryHeader::key_ptr(new_entry_ptr);
+                let key = K::get(key_ptr);
+                EntryHeader::val_ptr(new_entry_ptr).write(val_f(key));
+            }));
+            let state = &*EntryHeader::state_ptr(new_entry_ptr);
+            let old_state;
+            if r.is_err() {
+                let old_head = self.freelist_head.swap(new_entry_ptr, Ordering::AcqRel);
+                old_state = state.swap(old_head.map_addr(|a| a | DELETE_BIT), Ordering::Release);
+                entry.store(without_provenance_mut(DELETED), Ordering::Relaxed);
+                header.num_deletions.fetch_add(1, Ordering::Release);
+            } else {
+                old_state = state.swap(
+                    without_provenance_mut((hash & !(WAIT_BIT | DELETE_BIT)) | INIT_BIT),
+                    Ordering::Release,
+                )
+            };
+
+            if old_state.addr() & WAIT_BIT != 0 {
+                // We need to hold the lock while notifying to prevent the race
+                // condition [r:check -> w:notify -> r:wait].
+                drop(self.init_lock.lock());
+                self.waiting_for_init.notify_all();
+            }
+
+            if let Err(panic) = r {
+                std::panic::resume_unwind(panic)
+            } else {
+                new_entry_ptr
+            }
+        }
+    }
+
+    fn find_impl(
+        alloc: *mut AllocHeader<K, V>,
+        hash: usize,
+        mut eq: impl FnMut(&K) -> bool,
+    ) -> Result<(*mut EntryHeader<K, V>, usize), Prober> {
+        unsafe {
+            let mut prober = Prober::new(hash);
+
+            let header = &*alloc;
+            let tags = header.tags(alloc);
+            let entries = header.entries(alloc);
+            let group_mask = TagGroup::idx_mask(header.num_entries);
+            let mut needle = TagGroup::all_occupied(hash);
+            loop {
+                let group_idx = prober.get() & group_mask;
+                let mut tag_group = TagGroup::load(tags.get_unchecked(group_idx));
+                let mut matches = tag_group.matches(&mut needle);
+                while matches.has_matches() {
+                    let idx_in_group = matches.get();
+                    let entry_idx = size_of::<TagGroup>() * group_idx + idx_in_group;
+                    let entry_ptr = entries.get_unchecked(entry_idx).load(Ordering::Acquire);
+
+                    // Matching tag but unclaimed, racy insert in process but definitely missing.
+                    if entry_ptr.addr() == UNCLAIMED {
+                        return Err(prober);
+                    }
+
+                    if entry_ptr.addr() != DELETED {
+                        let state = (*EntryHeader::state_ptr(entry_ptr)).load(Ordering::Acquire);
+                        if state.addr() & DELETE_BIT == 0
+                            && eq(K::get(EntryHeader::<K, V>::key_ptr(entry_ptr)))
+                        {
+                            // Not deleted and a key hit, either a racy insert or a hit.
+                            return if state.addr() & INIT_BIT != 0 {
+                                Ok((entry_ptr, entry_idx))
+                            } else {
+                                Err(prober)
+                            };
+                        }
+                    }
+                    matches.advance();
+                }
+
+                if tag_group.empties().has_matches() {
+                    return Err(prober);
+                }
+
+                prober.advance();
+            }
+        }
+    }
+
+    fn find_or_insert_impl(
+        &self,
+        orig_probe_alloc: *mut AllocHeader<K, V>,
+        mut prober: Prober,
+        hash: usize,
+        key: &K,
+        val_f: impl FnOnce(&K) -> V,
+        mut eq: impl FnMut(&K) -> bool,
+    ) -> *mut EntryHeader<K, V> {
+        unsafe {
+            let new_entry_ptr = EntryHeader::<K, V>::new(hash, key);
+
+            let alloc = self.start_insert_attempt();
+            if alloc != orig_probe_alloc {
+                prober = Prober::new(hash);
+            }
+
+            let header = &*alloc;
+            let tags = header.tags(alloc);
+            let entries = header.entries(alloc);
+            let group_mask = TagGroup::idx_mask(header.num_entries);
+            let mut needle = TagGroup::all_occupied(hash);
+
+            'probe_loop: loop {
+                let group_idx = prober.get() & group_mask;
+                let mut tag_group = TagGroup::load(tags.get_unchecked(group_idx));
+                let matches = tag_group.matches(&mut needle);
+                let empties = tag_group.empties();
+                let mut insert_locs = matches | empties;
+                while insert_locs.has_matches() {
+                    let idx_in_group = insert_locs.get();
+
+                    // Insert a new tag if this insert location.
+                    if empties.has_match_at(idx_in_group) {
+                        if !tags.get_unchecked(group_idx).try_occupy(
+                            &mut tag_group,
+                            idx_in_group,
+                            hash,
+                        ) {
+                            continue 'probe_loop;
+                        }
+                    }
+
+                    let entry_idx = size_of::<TagGroup>() * group_idx + idx_in_group;
+                    let entry = entries.get_unchecked(entry_idx);
+                    let mut entry_ptr = entry.load(Ordering::Acquire);
+                    if entry_ptr.addr() == UNCLAIMED {
+                        // Try to claim this entry.
+                        match entry.compare_exchange(
+                            entry_ptr,
+                            new_entry_ptr,
+                            Ordering::Release,
+                            Ordering::Acquire,
+                        ) {
+                            Ok(_) => {
+                                header.finish_claim_attempt(
+                                    &self.alloc_lock,
+                                    &self.waiting_for_alloc,
+                                );
+                                return self.init_entry_val(
+                                    hash,
+                                    header,
+                                    entry,
+                                    new_entry_ptr,
+                                    val_f,
+                                );
+                            },
+                            Err(ev) => entry_ptr = ev,
+                        }
+                    }
+
+                    // We couldn't claim the entry, see if our key is the same as
+                    // whoever claimed this entry, assuming it's not deleted.
+                    if entry_ptr.addr() != DELETED {
+                        let entry_key = K::get(EntryHeader::key_ptr(entry_ptr));
+                        if eq(entry_key) {
+                            if EntryHeader::wait_for_init(
+                                entry_ptr,
+                                &self.init_lock,
+                                &self.waiting_for_init,
+                            ) {
+                                EntryHeader::free(new_entry_ptr);
+                                header
+                                    .abort_claim_attempt(&self.alloc_lock, &self.waiting_for_alloc);
+                                return entry_ptr;
+                            }
+                        }
+                    }
+
+                    insert_locs.advance();
+                }
+
+                prober.advance();
+            }
+        }
+    }
+
+    unsafe fn insert_uniq_entry_exclusive(
+        alloc: *mut AllocHeader<K, V>,
+        hash: usize,
+        uniq_entry_ptr: *mut EntryHeader<K, V>,
+    ) {
+        unsafe {
+            let header = &mut *alloc;
+            let tags = header.tags_mut(alloc);
+            let entries = header.entries_mut(alloc);
+            let group_mask = TagGroup::idx_mask(header.num_entries);
+
+            let mut prober = Prober::new(hash);
+            loop {
+                let group_idx = prober.get() & group_mask;
+                let tag_group = tags.get_unchecked_mut(group_idx);
+                let empties = tag_group.empties();
+                if empties.has_matches() {
+                    let idx_in_group = empties.get();
+                    tag_group.occupy_mut(idx_in_group, hash);
+                    let entry_idx = size_of::<TagGroup>() * group_idx + idx_in_group;
+                    *entries.get_unchecked_mut(entry_idx).get_mut() = uniq_entry_ptr;
+                    return;
+                }
+
+                prober.advance();
+            }
+        }
+    }
+
+    /// Free any resources which are no longer necessary.
+    ///
+    /// # Safety
+    /// Until drop_guard gets called, there may not be any alive references
+    /// returned by the [`RawTable`], or concurrent other operations.
+    pub unsafe fn gc<F: FnOnce()>(&self, drop_guard: F) {
+        let mut freelist_head = self
+            .freelist_head
+            .swap(core::ptr::null_mut(), Ordering::Acquire);
+        let old_allocs = core::mem::take(&mut self.alloc_lock.lock().unwrap().old_allocs);
+        drop_guard();
+
+        unsafe {
+            while !freelist_head.is_null() {
+                let state = *(*EntryHeader::state_ptr(freelist_head)).get_mut();
+                if state.addr() & INIT_BIT != 0 {
+                    core::ptr::drop_in_place(EntryHeader::val_ptr(freelist_head));
+                }
+                K::drop_in_place(EntryHeader::key_ptr(freelist_head));
+                EntryHeader::free(freelist_head);
+                freelist_head = state.map_addr(|a| a & !(INIT_BIT | WAIT_BIT | DELETE_BIT));
+            }
+
+            for alloc in old_allocs {
+                AllocHeader::free(alloc);
+            }
+        }
+    }
+
+    /// Finds the value corresponding to a key with the given hash and equality function.
+    pub fn get(&self, hash: u64, eq: impl FnMut(&K) -> bool) -> Option<&V> {
+        unsafe {
+            let cur_alloc = self.cur_alloc.load(Ordering::Acquire);
+            let entry_ptr = Self::find_impl(cur_alloc, hash as usize, eq).ok()?.0;
+            Some(&*EntryHeader::val_ptr(entry_ptr))
+        }
+    }
+
+    /// Finds the value corresponding to a key with the given hash and equality function, or insert
+    /// a new one if the key does not exist.
+    ///
+    /// `val_f` is guaranteed to only be called when inserting a new key not currently found in the
+    /// table, even if multiple concurrent inserts occur. The key reference passed to `val_f` lives
+    /// as long as the new entry will.
+    pub fn get_or_insert_with(
+        &self,
+        hash: u64,
+        key: &K,
+        mut eq: impl FnMut(&K) -> bool,
+        val_f: impl FnOnce(&K) -> V,
+    ) -> &V {
+        unsafe {
+            let cur_alloc = self.cur_alloc.load(Ordering::Acquire);
+            match Self::find_impl(cur_alloc, hash as usize, &mut eq) {
+                Ok((entry_ptr, _)) => &*EntryHeader::val_ptr(entry_ptr),
+                Err(prober) => {
+                    let entry_ptr =
+                        self.find_or_insert_impl(cur_alloc, prober, hash as usize, key, val_f, eq);
+                    &*EntryHeader::val_ptr(entry_ptr)
+                },
+            }
+        }
+    }
+
+    /// Finds and removes the value corresponding to a key with the given hash and equality function.
+    ///
+    /// Note that the value is not dropped until [`RawTable::gc`] is called or the [`RawTable`] is dropped.
+    pub fn remove(&self, hash: u64, eq: impl FnMut(&K) -> bool) -> Option<&V> {
+        unsafe {
+            // TODO: perhaps deletions could be done during a rehash by synchronizing on state?
+            let _rehash_guard = self.rehash_lock.read();
+            let alloc = self.cur_alloc.load(Ordering::Acquire);
+            let header = &*alloc;
+            let (entry_ptr, entry_idx) = Self::find_impl(alloc, hash as usize, eq).ok()?;
+
+            let state = &(*entry_ptr).state;
+            let old_state = state
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |s| {
+                    if s.addr() & DELETE_BIT != 0 {
+                        return None;
+                    }
+
+                    Some(s.map_addr(|a| a | DELETE_BIT))
+                })
+                .ok()?;
+
+            let group_idx = entry_idx / size_of::<TagGroup>();
+            let idx_in_group = entry_idx % size_of::<TagGroup>();
+            let old_head = self.freelist_head.swap(entry_ptr, Ordering::AcqRel);
+            state.store(
+                old_head.map_addr(|a| a | (old_state.addr() & INIT_BIT)),
+                Ordering::Release,
+            );
+            header
+                .entries(alloc)
+                .get_unchecked(entry_idx)
+                .store(without_provenance_mut(DELETED), Ordering::Relaxed);
+            header
+                .tags(alloc)
+                .get_unchecked(group_idx)
+                .delete(idx_in_group);
+            header.num_deletions.fetch_add(1, Ordering::Release);
+            Some(&*EntryHeader::val_ptr(entry_ptr))
+        }
+    }
+}
+
+impl<K: Key + ?Sized, V> Default for RawTable<K, V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K: Key + ?Sized, V> Drop for RawTable<K, V> {
+    fn drop(&mut self) {
+        unsafe {
+            self.gc(|| {});
+
+            let alloc = *self.cur_alloc.get_mut();
+            let header = &*alloc;
+            for entry in header.entries_mut(alloc) {
+                let entry_ptr = *(*entry).get_mut();
+                if entry_ptr.is_null() || entry_ptr.addr() == DELETED {
+                    continue;
+                }
+
+                let state = (*EntryHeader::state_ptr(entry_ptr)).get_mut();
+                if state.addr() & INIT_BIT != 0 {
+                    core::ptr::drop_in_place(EntryHeader::val_ptr(entry_ptr));
+                }
+                K::drop_in_place(EntryHeader::key_ptr(entry_ptr));
+                EntryHeader::free(entry_ptr);
+            }
+            AllocHeader::free(alloc);
+        }
+    }
+}
+
+#[repr(C)]
+struct DummyAlloc {
+    header: AllocHeader<(), ()>,
+    tags: [TagGroup; 1],
+    entries: [AtomicPtr<EntryHeader<(), ()>>; size_of::<TagGroup>()],
+}
+
+static EMPTY_ALLOC_LOC: DummyAlloc = DummyAlloc {
+    header: AllocHeader {
+        num_entries: size_of::<TagGroup>(),
+        num_deletions: AtomicUsize::new(0),
+        claim_start_semaphore: AtomicUsize::new(0),
+        claim_done_barrier: AtomicUsize::new(0),
+        marker: PhantomData,
+        align: [],
+    },
+    tags: [TagGroup::all_empty()],
+    entries: [
+        AtomicPtr::new(without_provenance_mut(UNCLAIMED)),
+        AtomicPtr::new(without_provenance_mut(UNCLAIMED)),
+        AtomicPtr::new(without_provenance_mut(UNCLAIMED)),
+        AtomicPtr::new(without_provenance_mut(UNCLAIMED)),
+        AtomicPtr::new(without_provenance_mut(UNCLAIMED)),
+        AtomicPtr::new(without_provenance_mut(UNCLAIMED)),
+        AtomicPtr::new(without_provenance_mut(UNCLAIMED)),
+        AtomicPtr::new(without_provenance_mut(UNCLAIMED)),
+    ],
+};

--- a/crates/polars-utils/src/parma/raw/probe.rs
+++ b/crates/polars-utils/src/parma/raw/probe.rs
@@ -1,0 +1,157 @@
+/*
+    To speed up probing we group table entries into groups of 8, and use
+    one-byte tags to quickly skip irrelevant entries. Each tag has the following
+    bit patterns:
+
+        1000_0000 = EMPTY
+        1111_1111 = DELETED
+        0hhh_hhhh = OCCUPIED (with 7 bits of key hash)
+
+    For the purposes of parallel probes, we allow false-positive probes (key
+    doesn't exist or is deleted but tag is set), but not false-negative probes
+    (key exists but tag is not set).
+*/
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const fn tag(hash: usize) -> u8 {
+    (hash >> (usize::BITS - 7)) as u8
+}
+
+#[inline(always)]
+const fn repeat(tag: u8) -> u64 {
+    (tag as u64) * 0x01010101_01010101
+}
+
+#[repr(transparent)]
+pub struct TagGroup(AtomicU64);
+
+impl TagGroup {
+    #[inline(always)]
+    pub const fn all_empty() -> Self {
+        Self(AtomicU64::new(repeat(0x80)))
+    }
+
+    #[inline(always)]
+    pub fn all_occupied(hash: usize) -> Self {
+        Self(AtomicU64::new(repeat(tag(hash))))
+    }
+
+    #[inline(always)]
+    pub const fn idx_mask(num_entries: usize) -> usize {
+        num_entries / 8 - 1
+    }
+
+    #[inline(always)]
+    pub fn load(loc: &Self) -> Self {
+        Self(AtomicU64::new(loc.0.load(Ordering::Relaxed)))
+    }
+
+    #[inline(always)]
+    pub fn try_occupy(&self, cur: &mut Self, idx: usize, hash: usize) -> bool {
+        let shift = 8 * idx;
+        let update = ((0x80 | tag(hash)) as u64) << shift;
+        let cur_val = *cur.0.get_mut();
+        self.0
+            .compare_exchange(
+                cur_val,
+                cur_val ^ update,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            )
+            .is_ok()
+    }
+
+    #[inline(always)]
+    pub fn occupy_mut(&mut self, idx: usize, hash: usize) {
+        *self.0.get_mut() ^= (0x80 | tag(hash) as u64) << (8 * idx);
+    }
+
+    pub fn delete(&self, idx: usize) {
+        self.0.fetch_or(0xff << (8 * idx), Ordering::Relaxed);
+    }
+
+    #[inline(always)]
+    pub fn empties(&mut self) -> TagMatches {
+        let t = *self.0.get_mut();
+        TagMatches(t & t.wrapping_add(repeat(1)) & repeat(0x80))
+    }
+
+    #[inline(always)]
+    pub fn matches(&mut self, other: &mut TagGroup) -> TagMatches {
+        let self_tags = *self.0.get_mut();
+        let other_tags = *other.0.get_mut();
+        TagMatches(((self_tags ^ other_tags).wrapping_sub(repeat(1))) & !self_tags & repeat(0x80))
+    }
+}
+
+#[repr(transparent)]
+#[derive(Copy, Clone)]
+pub struct TagMatches(u64);
+
+impl TagMatches {
+    #[inline(always)]
+    pub fn has_matches(&self) -> bool {
+        self.0 != 0
+    }
+
+    #[inline(always)]
+    pub fn get(&self) -> usize {
+        (self.0.trailing_zeros() / 8) as usize
+    }
+
+    pub fn has_match_at(&self, idx: usize) -> bool {
+        (self.0 >> (idx * 8)) & 0x80 != 0
+    }
+
+    #[inline(always)]
+    pub fn advance(&mut self) {
+        self.0 &= self.0 - 1;
+    }
+}
+
+impl std::ops::BitOr for TagMatches {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+/// A quadratic prober meant for power-of-two hash tables.
+///
+/// Does not reduce the index to be in-bounds, that's the responsibility of the
+/// caller.
+pub struct Prober {
+    idx: usize,
+    step: usize,
+}
+
+impl Prober {
+    #[inline(always)]
+    pub fn new(hash: usize) -> Self {
+        Self {
+            idx: hash >> 3,
+            step: 0,
+        }
+    }
+
+    #[inline(always)]
+    pub fn get(&self) -> usize {
+        self.idx
+    }
+
+    #[inline(always)]
+    pub fn advance(&mut self) {
+        self.step = self.step.wrapping_add(1);
+        self.idx = self.idx.wrapping_add(self.step);
+    }
+}
+
+pub fn max_load(num_entries: usize) -> usize {
+    num_entries * 3 / 4
+}
+
+pub fn min_entries_for_load(load: usize) -> usize {
+    (load * 4 / 3 + 1).next_power_of_two().max(8)
+}


### PR DESCRIPTION
These are the core data types that will be used in the Categorical rework, so they're currently not used in this PR but formed a nice cut-off point for a PR.

This PR also vendored a new parallel hashmap implementation I've been working on in `polars-utils`, the plan is to make that a proper dependency once I've release it as a standalone crate.