### PR TITLE
fix: Setting `compat_level=0` for `sink_ipc`

### DIFF
--- a/crates/polars-stream/src/nodes/io_sinks/ipc.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/ipc.rs
@@ -307,6 +307,7 @@ impl SinkNode for IpcSinkNode {
             let writer = BufWriter::new(&mut *file);
             let mut writer = IpcWriter::new(writer)
                 .with_compression(write_options.compression)
+                .with_compat_level(write_options.compat_level)
                 .with_parallel(false)
                 .batched(&input_schema)?;
 

--- a/py-polars/tests/unit/io/test_lazy_ipc.py
+++ b/py-polars/tests/unit/io/test_lazy_ipc.py
@@ -7,6 +7,7 @@ import pyarrow.ipc
 import pytest
 
 import polars as pl
+from polars.interchange.protocol import CompatLevel
 from polars.testing.asserts.frame import assert_frame_equal
 
 if TYPE_CHECKING:
@@ -116,8 +117,8 @@ def test_sink_ipc_compat_level_22930() -> None:
     f1 = io.BytesIO()
     f2 = io.BytesIO()
 
-    df.lazy().sink_ipc(f1, compat_level=0, engine="in-memory")
-    df.lazy().sink_ipc(f2, compat_level=0, engine="streaming")
+    df.lazy().sink_ipc(f1, compat_level=CompatLevel.oldest(), engine="in-memory")
+    df.lazy().sink_ipc(f2, compat_level=CompatLevel.oldest(), engine="streaming")
 
     f1.seek(0)
     f2.seek(0)


### PR DESCRIPTION
Fixes #22930.