### PR TITLE
fix(python): Narrow return type for `DataType.is_`, improve Pyright's type completeness from 69% to 95%

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from collections.abc import Mapping
 from datetime import tzinfo
 from inspect import isclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar
 
 import polars._reexport as pl
 import polars.datatypes
@@ -29,12 +29,20 @@ if TYPE_CHECKING:
     )
 
 
-class classinstmethod(classmethod):  # type: ignore[type-arg]
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+class classinstmethod(Generic[R]):
     """Decorator that allows a method to be called from the class OR instance."""
 
-    def __get__(self, instance: Any, type_: type) -> Any:  # type: ignore[override]
-        get = super().__get__ if instance is None else self.__func__.__get__
-        return get(instance, type_)
+    def __init__(self, func: Callable[..., R]) -> None:
+        self.func = func
+
+    def __get__(self, instance: Any, type_: Any) -> Callable[..., R]:
+        if instance is not None:
+            return self.func.__get__(instance, type_)
+        return self.func.__get__(type_, type_)
 
 
 class DataTypeClass(type):
@@ -135,7 +143,7 @@ class DataType(metaclass=DataTypeClass):
         """
         return cls
 
-    @classinstmethod  # type: ignore[arg-type]
+    @classinstmethod
     def is_(self, other: PolarsDataType) -> bool:
         """
         Check if this DataType is the same as another DataType.
@@ -227,7 +235,7 @@ class DataType(metaclass=DataTypeClass):
 
         return parse_into_dtype(py_type)
 
-    @classinstmethod  # type: ignore[arg-type]
+    @classinstmethod
     def to_python(self) -> PythonDataType:
         """
         Return the Python type corresponding to this Polars data type.

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -34,6 +34,8 @@ if TYPE_CHECKING:
     else:
         from typing_extensions import Self
 
+    from typing_extensions import assert_type
+
 
 # -----------------------------------------------------------------------------------
 # nested dataclasses, models, namedtuple classes (can't be defined inside test func)
@@ -1111,6 +1113,9 @@ def test_init_only_columns() -> None:
         assert_frame_equal(df, expected)
         assert df.dtypes == [pl.Date, pl.UInt64, pl.Int8, pl.List]
         assert pl.List(pl.UInt8).is_(df.schema["d"])
+
+        if TYPE_CHECKING:
+            assert_type(pl.List(pl.UInt8).is_(df.schema["d"]), bool)
 
         dfe = df.clear()
         assert len(dfe) == 0


### PR DESCRIPTION
Currently, `pl.Int64.is_(pl.Int64)` is revealed as `Any`, as opposed to `bool`. This PR fixes that

@alexander-beedie fancy taking a look?

I spotted this while trying out `pyright --verifytypes polars --ignoreexternal` ([pyright-cov](https://github.com/MarcoGorelli/pyright-cov)), and this simple change is enough to bring PyRight's reported type completeness up by 26 percentage points (from 69% to 95%). Separately from this, do we want to enforce a minimum type completeness in CI, to ensure this doesn't regress?