### PR TITLE
chore(python): Fix CI for latest pandas-stubs release

### DIFF
--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -1109,7 +1109,9 @@ def pandas_to_pydf(
     if convert_index:
         for idxcol in data.index.names:
             arrow_dict[str(idxcol)] = plc.pandas_series_to_arrow(
-                data.index.get_level_values(idxcol),
+                # get_level_values accepts `int | str`
+                # but `index.names` returns `Hashable`
+                data.index.get_level_values(idxcol),  # type: ignore[arg-type, unused-ignore]
                 nan_to_null=nan_to_null,
                 length=length,
             )


### PR DESCRIPTION
I think the pandas stubs aren't quite correct here, as `Hashable` is allowed, not just `int | str`:

```python
In [1]: import pandas as pd

In [2]: from datetime import datetime, date

In [3]: pd.DataFrame({date(2020,1,1): [1,2,3], date(2020,1,2): [2,3,4]}).set_index([date(2020,1,1), date(2020,1,2)]).index.get_level_values(date(2020,1,1))
Out[3]: Index([1, 2, 3], dtype='int64', name=2020-01-01)
```

So, I think it's ok to type ignore