### PR TITLE
fix(rust): Fix incorrect equality on `UniqueId`

### DIFF
--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -501,7 +501,7 @@ fn create_physical_plan_impl(
                     state.has_cache_parent = true;
                     state.has_cache_child = true;
 
-                    // Safety: We do not drop the `scan_mem_id` (i.e. the IR) during physical plan creation.
+                    // Safety: We do not drop the `scan_mem_id` (i.e. the IR::Scan) during physical plan creation.
                     let scan_mem_id: usize = scan_mem_id.to_usize();
 
                     if !cache_nodes.contains_key(&scan_mem_id) {

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -501,7 +501,7 @@ fn create_physical_plan_impl(
                     state.has_cache_parent = true;
                     state.has_cache_child = true;
 
-                    // Safety: We do not drop the `scan_mem_id` (i.e. the IR::Scan) during physical plan creation.
+                    // Safety: We do not drop the `scan_mem_id` (i.e. the `IR::Scan`) during physical plan creation.
                     let scan_mem_id: usize = scan_mem_id.to_usize();
 
                     if !cache_nodes.contains_key(&scan_mem_id) {

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -501,6 +501,7 @@ fn create_physical_plan_impl(
                     state.has_cache_parent = true;
                     state.has_cache_child = true;
 
+                    // Safety: We do not drop the `scan_mem_id` (i.e. the IR) during physical plan creation.
                     let scan_mem_id: usize = scan_mem_id.to_usize();
 
                     if !cache_nodes.contains_key(&scan_mem_id) {

--- a/crates/polars-utils/src/unique_id.rs
+++ b/crates/polars-utils/src/unique_id.rs
@@ -50,9 +50,9 @@ mod tests {
 
     #[test]
     fn test_unique_id() {
-        let a = UniqueId::default();
-        let b = UniqueId::default();
+        let id = UniqueId::default();
 
-        assert_ne!(a, b);
+        assert_eq!(id, id);
+        assert_ne!(id, UniqueId::default());
     }
 }

--- a/crates/polars-utils/src/unique_id.rs
+++ b/crates/polars-utils/src/unique_id.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 /// Unique ref-counted identifier.
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct UniqueId(
     // We use an Arc to reserve a memory address rather than a static atomic counter, as the latter
     // may cause duplicate IDs on wrap-around.
@@ -11,6 +11,7 @@ pub struct UniqueId(
 );
 
 impl UniqueId {
+    #[inline]
     pub fn to_usize(&self) -> usize {
         Arc::as_ptr(&self.0) as usize
     }
@@ -19,5 +20,30 @@ impl UniqueId {
 impl Default for UniqueId {
     fn default() -> Self {
         Self(Arc::new(()))
+    }
+}
+
+impl PartialEq for UniqueId {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_usize() == other.to_usize()
+    }
+}
+
+impl std::hash::Hash for UniqueId {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.to_usize().hash(state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::UniqueId;
+
+    #[test]
+    fn test_unique_id() {
+        let a = UniqueId::default();
+        let b = UniqueId::default();
+
+        assert_ne!(a, b);
     }
 }

--- a/crates/polars-utils/src/unique_id.rs
+++ b/crates/polars-utils/src/unique_id.rs
@@ -1,14 +1,23 @@
 use std::sync::Arc;
 
+/// Intentionally a custom inner type to prevent deriving eq / hash, as that would not be correct.
+struct Inner;
+
 /// Unique ref-counted identifier.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct UniqueId(
     // We use an Arc to reserve a memory address rather than a static atomic counter, as the latter
     // may cause duplicate IDs on wrap-around.
     //
     // Note, this inner repr is a private implementation detail.
-    Arc<()>,
+    Arc<Inner>,
 );
+
+impl std::fmt::Debug for UniqueId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "UniqueId({})", self.to_usize())
+    }
+}
 
 impl UniqueId {
     #[inline]
@@ -19,7 +28,7 @@ impl UniqueId {
 
 impl Default for UniqueId {
     fn default() -> Self {
-        Self(Arc::new(()))
+        Self(Arc::new(Inner {}))
     }
 }
 


### PR DESCRIPTION
This cannot be a derive, as that causes equality on the value, whereas what we want is equality on the `Arc` address.

Currently this doesn't cause any problems, we have 1 place in the codebase that compares the `UniqueId` but that does so after calling `to_usize()`.
