### PR TITLE
perf: Move row index materialization in post-apply to occur after slicing

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUSTFLAGS: -C debuginfo=0  # Do not produce debug symbols to keep memory usage down
+  RUSTFLAGS: -C debuginfo=0 # Do not produce debug symbols to keep memory usage down
   RUST_BACKTRACE: 1
   PYTHONUTF8: 1
 
@@ -113,6 +113,13 @@ jobs:
           POLARS_FORCE_ASYNC: 1
           POLARS_TIMEOUT_MS: 60000
         run: pytest -n auto -m "not release and not benchmark and not docs" tests/unit/io/
+
+      - name: Run tests multiscan force empty capabilities
+        if: github.ref_name != 'main' && matrix.python-version != '3.13t'
+        env:
+          POLARS_FORCE_EMPTY_READER_CAPABILITIES: 1
+          POLARS_TIMEOUT_MS: 60000
+        run: pytest -n auto -m "not release and not benchmark and not docs" tests/unit/io/test_multiscan.py
 
       - name: Check import without optional dependencies
         if: github.ref_name != 'main' && matrix.os == 'ubuntu-latest' && (matrix.python-version == '3.13' || matrix.python-version == '3.13t')

--- a/crates/polars-stream/src/nodes/io_sources/csv.rs
+++ b/crates/polars-stream/src/nodes/io_sources/csv.rs
@@ -153,11 +153,17 @@ impl FileReader for CsvFileReader {
         };
 
         match &pre_slice {
+            Some(Slice::Negative { .. }) => unimplemented!(),
+
             // We don't account for comments when slicing lines. We should never hit this panic -
             // the FileReaderBuilder does not indicate PRE_SLICE support when we have a comment
             // prefix.
-            Some(..) if self.options.parse_options.comment_prefix.is_some() => panic!(),
-            Some(Slice::Negative { .. }) => unimplemented!(),
+            Some(pre_slice)
+                if self.options.parse_options.comment_prefix.is_some() && pre_slice.len() > 0 =>
+            {
+                panic!("{pre_slice:?}")
+            },
+
             _ => {},
         }
 
@@ -680,7 +686,7 @@ impl ChunkReader {
 
         if slice != NO_SLICE {
             assert!(slice != SLICE_ENDED);
-            assert!(n_lines_is_correct);
+            assert!(n_lines_is_correct || slice.1 == 0);
 
             df = df.slice(i64::try_from(slice.0).unwrap(), slice.1);
         }

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
@@ -235,6 +235,15 @@ impl ApplyExtraOps {
         // Note: This branch is hit if we have negative slice or predicate + row index and the reader
         // does not support them.
         if let Some(ri) = row_index {
+            // REMOVE
+            // For debugging
+            loop {
+                if local_slice_offset != 0 {
+                    panic!()
+                }
+                break;
+            }
+
             unsafe {
                 df.with_column_unchecked(Column::new_row_index(
                     ri.name.clone(),

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
@@ -232,6 +232,8 @@ impl ApplyExtraOps {
             *df = df.slice(i64::try_from(offset).unwrap(), len)
         }
 
+        // Note: This branch is hit if we have negative slice + row index and the reader does not
+        // support them.
         if let Some(ri) = row_index {
             unsafe {
                 df.with_column_unchecked(Column::new_row_index(

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
@@ -232,8 +232,8 @@ impl ApplyExtraOps {
             *df = df.slice(i64::try_from(offset).unwrap(), len)
         }
 
-        // Note: This branch is hit if we have negative slice + row index and the reader does not
-        // support them.
+        // Note: This branch is hit if we have negative slice or predicate + row index and the reader
+        // does not support them.
         if let Some(ri) = row_index {
             unsafe {
                 df.with_column_unchecked(Column::new_row_index(

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
@@ -235,15 +235,6 @@ impl ApplyExtraOps {
         // Note: This branch is hit if we have negative slice or predicate + row index and the reader
         // does not support them.
         if let Some(ri) = row_index {
-            // REMOVE
-            // For debugging
-            loop {
-                if local_slice_offset != 0 {
-                    panic!()
-                }
-                break;
-            }
-
             unsafe {
                 df.with_column_unchecked(Column::new_row_index(
                     ri.name.clone(),

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
@@ -217,15 +217,7 @@ impl ApplyExtraOps {
             unreachable!();
         };
 
-        if let Some(ri) = row_index {
-            unsafe {
-                df.with_column_unchecked(Column::new_row_index(
-                    ri.name.clone(),
-                    ri.offset.saturating_add(current_row_position),
-                    df.height(),
-                )?)
-            };
-        }
+        let mut local_slice_offset: IdxSize = 0;
 
         if let Some(pre_slice) = pre_slice.clone() {
             let Slice::Positive { offset, len } = pre_slice
@@ -235,7 +227,21 @@ impl ApplyExtraOps {
                 unreachable!()
             };
 
+            local_slice_offset = IdxSize::try_from(offset).unwrap_or(IdxSize::MAX);
+
             *df = df.slice(i64::try_from(offset).unwrap(), len)
+        }
+
+        if let Some(ri) = row_index {
+            unsafe {
+                df.with_column_unchecked(Column::new_row_index(
+                    ri.name.clone(),
+                    ri.offset
+                        .saturating_add(current_row_position)
+                        .saturating_add(local_slice_offset),
+                    df.height(),
+                )?)
+            };
         }
 
         if let Some(cast_columns) = cast_columns {

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/mod.rs
@@ -39,7 +39,7 @@ impl MultiScanTaskInitializer {
                 "[MultiScanTaskInitializer]: spawn_background_tasks(), {} sources, reader name: {}, {:?}",
                 self.config.sources.len(),
                 self.config.file_reader_builder.reader_name(),
-                self.config.file_reader_builder.reader_capabilities(),
+                self.config.reader_capabilities(),
             );
 
             eprintln!(

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/mod.rs
@@ -21,6 +21,7 @@ use polars_utils::format_pl_smallstr;
 use polars_utils::pl_str::PlSmallStr;
 use polars_utils::slice_enum::Slice;
 use reader_interface::builder::FileReaderBuilder;
+use reader_interface::capabilities::ReaderCapabilities;
 
 use crate::async_executor::{self, AbortOnDropHandle, TaskPriority};
 use crate::async_primitives::connector;
@@ -77,6 +78,14 @@ impl MultiFileReaderConfig {
     fn max_concurrent_scans(&self) -> usize {
         self.max_concurrent_scans
             .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    fn reader_capabilities(&self) -> ReaderCapabilities {
+        if std::env::var("POLARS_FORCE_EMPTY_READER_CAPABILITIES").as_deref() == Ok("1") {
+            ReaderCapabilities::empty()
+        } else {
+            self.file_reader_builder.reader_capabilities()
+        }
     }
 }
 

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
@@ -42,7 +42,7 @@ impl MultiScanTaskInitializer {
         predicate: Option<ScanIOPredicate>,
     ) -> PolarsResult<JoinHandle<PolarsResult<()>>> {
         let verbose = self.config.verbose;
-        let reader_capabilities = self.config.file_reader_builder.reader_capabilities();
+        let reader_capabilities = self.config.reader_capabilities();
 
         // Row index should only be pushed if we have a predicate or negative slice as there is a
         // serial synchronization cost.

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -491,3 +491,13 @@ a,b,c
             schema=schema,
         ),
     )
+
+
+def test_csv_negative_slice_comment_char_22996() -> None:
+    f = b"""\
+a,b
+1,1
+"""
+
+    q = pl.scan_csv(2 * [f], comment_prefix="#").tail(100)
+    assert_frame_equal(q.collect(), pl.DataFrame({"a": [1, 1], "b": [1, 1]}))

--- a/py-polars/tests/unit/io/test_multiscan.py
+++ b/py-polars/tests/unit/io/test_multiscan.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
 import io
-import os
-import subprocess
-import sys
 from typing import IO, TYPE_CHECKING, Any, Callable
 
 import pyarrow.parquet as pq

--- a/py-polars/tests/unit/io/test_multiscan.py
+++ b/py-polars/tests/unit/io/test_multiscan.py
@@ -700,30 +700,3 @@ def test_extra_columns_not_ignored_22218() -> None:
         .collect(),
         pl.DataFrame({"a": [1, 2], "b": [1, None]}),
     )
-
-
-@pytest.mark.slow
-def test_all_force_empty_reader_capabilities(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Runs this whole file with all operations forced to the post-apply pipeline."""
-    if os.getenv("POLARS_FORCE_EMPTY_READER_CAPABILITIES") == "1":
-        pytest.skip("recursion")
-        return
-
-    monkeypatch.setenv("POLARS_FORCE_EMPTY_READER_CAPABILITIES", "1")
-
-    print()  # Put 'test session starts' to new line
-
-    retcode = subprocess.Popen(
-        [
-            sys.executable,
-            "-m",
-            "pytest",
-            "-m",
-            "",
-            __file__,
-        ],
-        stdout=sys.stdout,
-        stderr=sys.stderr,
-    ).wait()
-
-    assert retcode == 0

--- a/py-polars/tests/unit/io/test_multiscan.py
+++ b/py-polars/tests/unit/io/test_multiscan.py
@@ -702,6 +702,7 @@ def test_extra_columns_not_ignored_22218() -> None:
     )
 
 
+@pytest.mark.slow
 def test_all_force_empty_reader_capabilities(monkeypatch: pytest.MonkeyPatch) -> None:
     """Runs this whole file with all operations forced to the post-apply pipeline."""
     if os.getenv("POLARS_FORCE_EMPTY_READER_CAPABILITIES") == "1":

--- a/py-polars/tests/unit/io/test_multiscan.py
+++ b/py-polars/tests/unit/io/test_multiscan.py
@@ -722,7 +722,6 @@ def test_all_force_empty_reader_capabilities(monkeypatch: pytest.MonkeyPatch) ->
             "",
             __file__,
         ],
-        stdin=sys.stdin,
         stdout=sys.stdout,
         stderr=sys.stderr,
     ).wait()

--- a/py-polars/tests/unit/io/test_multiscan.py
+++ b/py-polars/tests/unit/io/test_multiscan.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import io
+import os
+import subprocess
+import sys
 from typing import IO, TYPE_CHECKING, Any, Callable
 
 import pyarrow.parquet as pq
@@ -697,3 +700,30 @@ def test_extra_columns_not_ignored_22218() -> None:
         .collect(),
         pl.DataFrame({"a": [1, 2], "b": [1, None]}),
     )
+
+
+def test_all_force_empty_reader_capabilities(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Runs this whole file with all operations forced to the post-apply pipeline."""
+    if os.getenv("POLARS_FORCE_EMPTY_READER_CAPABILITIES") == "1":
+        pytest.skip("recursion")
+        return
+
+    monkeypatch.setenv("POLARS_FORCE_EMPTY_READER_CAPABILITIES", "1")
+
+    print()  # Put 'test session starts' to new line
+
+    retcode = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-m",
+            "",
+            __file__,
+        ],
+        stdin=sys.stdin,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+    ).wait()
+
+    assert retcode == 0


### PR DESCRIPTION
Instead of before, as it would end up sliced out anyway.

* Adds `POLARS_FORCE_EMPTY_READER_CAPABILITIES` for test coverage, this forces all operations to be applied in post
* Drive-by - fixes https://github.com/pola-rs/polars/issues/22996
