### PR TITLE
fix: Incorrect output when using `sort` with `group_by` and `cum_sum`

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/set_order.rs
+++ b/crates/polars-plan/src/plans/optimizer/set_order.rs
@@ -2,62 +2,78 @@ use polars_utils::unitvec;
 
 use super::*;
 
-// Can give false positives.
-fn is_order_dependent_top_level(ae: &AExpr, _ctx: Context) -> bool {
-    match ae {
-        AExpr::Agg(agg) => match agg {
-            IRAggExpr::Min { .. } => false,
-            IRAggExpr::Max { .. } => false,
-            IRAggExpr::Median(_) => false,
-            IRAggExpr::NUnique(_) => false,
-            IRAggExpr::First(_) => true,
-            IRAggExpr::Last(_) => true,
-            IRAggExpr::Mean(_) => false,
-            IRAggExpr::Implode(_) => true,
-            IRAggExpr::Quantile { .. } => false,
-            IRAggExpr::Sum(_) => false,
-            IRAggExpr::Count(_, _) => false,
-            IRAggExpr::Std(_, _) => false,
-            IRAggExpr::Var(_, _) => false,
-            IRAggExpr::AggGroups(_) => true,
-        },
-        AExpr::Column(_) => false, //For review - does Aggregation Context matter?
-        _ => true,
+// Check if the aggregate expression depends on the order of the data.
+fn is_order_independent_agg(agg: &IRAggExpr) -> bool {
+    match agg {
+        IRAggExpr::Min { .. } => true,
+        IRAggExpr::Max { .. } => true,
+        IRAggExpr::Median(_) => true,
+        IRAggExpr::NUnique(_) => true,
+        IRAggExpr::First(_) => false,
+        IRAggExpr::Last(_) => false,
+        IRAggExpr::Mean(_) => true,
+        IRAggExpr::Implode(_) => false,
+        IRAggExpr::Quantile { .. } => true,
+        IRAggExpr::Sum(_) => true,
+        IRAggExpr::Count(_, _) => true,
+        IRAggExpr::Std(_, _) => true,
+        IRAggExpr::Var(_, _) => true,
+        IRAggExpr::AggGroups(_) => false,
     }
 }
 
-// Check if the given node, or, recursively, any of its input nodes in its input
-// dependency tree contains an order_dependent operation.
-// Return true if an order_dependent node is found.
-// Can give false positives.
-fn is_order_dependent_rec(node: Node, expr_arena: &Arena<AExpr>, ctx: Context) -> bool {
+// Check if the expression is a data source (e.g., Column), or keeps the underlying
+// data set unmodified, i.e., set(f(data)) == set(data).
+// Not exhaustive, e.g. changing the order would fall in here
+fn is_source_or_set_invariant(ae: &AExpr) -> bool {
+    matches!(ae, AExpr::Column(_))
+}
+
+// Check if the given node, or, recursively, any of its input nodes contains an
+// order_dependent operation. Return true if the output does not depend on ordering.
+// Can give false negatives.
+fn is_order_independent_rec(node: Node, expr_arena: &Arena<AExpr>) -> bool {
+    let mut contains_safe_aggregate = false;
+
     let mut stack = unitvec![];
     stack.push(node);
 
     while let Some(node) = stack.pop() {
-        if is_order_dependent_top_level(expr_arena.get(node), ctx) {
-            return true;
+        let ae = expr_arena.get(node);
+
+        // we need at least one 'safe' (order_independent) aggregation
+        if let AExpr::Agg(agg) = ae {
+            if is_order_independent_agg(agg) {
+                contains_safe_aggregate = true;
+            } else {
+                return false;
+            }
+        } else {
+            // intermediate data modification is not allowed, hence
+            // only data sources or set-invariant expressions are allowed
+            if !is_source_or_set_invariant(ae) {
+                return false;
+            }
         }
 
-        let ae = expr_arena.get(node);
         ae.inputs_rev(&mut stack);
     }
 
-    false
+    contains_safe_aggregate
 }
 
-// Can give false negatives.
+// Not exhaustive - can give false negatives.
 pub(crate) fn all_order_independent<'a, N>(
     nodes: &'a [N],
     expr_arena: &Arena<AExpr>,
-    ctx: Context,
+    _ctx: Context,
 ) -> bool
 where
     Node: From<&'a N>,
 {
-    !nodes
+    nodes
         .iter()
-        .any(|n| is_order_dependent_rec(n.into(), expr_arena, ctx))
+        .all(|n| is_order_independent_rec(n.into(), expr_arena))
 }
 
 // Should run before slice pushdown.

--- a/py-polars/tests/unit/lazyframe/test_order_observability.py
+++ b/py-polars/tests/unit/lazyframe/test_order_observability.py
@@ -1,3 +1,5 @@
+import pytest
+
 import polars as pl
 from polars.testing import assert_frame_equal
 
@@ -53,3 +55,31 @@ def test_double_sort_maintain_order_18558() -> None:
     )
 
     assert_frame_equal(lf.collect(), expect)
+
+
+@pytest.mark.parametrize(
+    ("func", "result"),
+    [
+        (pl.col("val").cum_sum(), 16),  # (3  + (3+10)) after sort
+        (pl.col("val").cum_prod(), 33),  # (3  + (3*10)) after sort
+        (pl.col("val").cum_min(), 6),  # (3  + 3) after sort
+        (pl.col("val").cum_max(), 13),  # (3  + 10) after sort
+    ],
+)
+def test_sort_agg_with_nested_windowing_22918(func: pl.Expr, result: int) -> None:
+    # target pattern: df.sort().group_by().agg(_fooexpr()._barexpr())
+    # where _fooexpr is order dependent (e.g., cum_sum)
+    # and _barexpr is not order dependent (e.g., sum)
+
+    lf = pl.DataFrame(
+        data=[
+            {"val": 10, "id": 1, "grp": 0},
+            {"val": 3, "id": 0, "grp": 0},
+        ]
+    ).lazy()
+
+    out = lf.sort("id").group_by("grp").agg(func.sum())
+    expected = pl.DataFrame({"grp": 0, "val": result})  # (3  + (3+10)) after sort
+
+    assert_frame_equal(out.collect(), expected)
+    assert "SORT" in out.explain()


### PR DESCRIPTION
fixes #22918

**edit: updated after refactoring the core logic related to handling `Column(_)`

This introduces three changes in the `CHECK_ORDER_OBSERVE` optimization step:
(1) the `all_order_independent` function now recurses through the expression input graph (tree?) in `agg`
(2) consistency in the boolean logic of the property (the property that enables optimization must be true for optimization to proceed)
(3) break out expressions between aggregate, source and intermediate/other; note that the `Context::Aggregation` is no longer used (is this correct)?

Additional tests: issue MRE plus regression safety checks.

Note: more optimizations are possible (all expressions to be mapped out; look for argument of upstream sort - key columns can be dropped while agg columns cannot, see test comment).

I lack a broad and deep enough understanding of all possible order/sort expression expectations (including nesting etc) and related optimizations to conclude this fix. Kindly review the logic and test cases.
