### PR TITLE
fix(rust): Fix incorrect `size_hint()` for `FlatIter`

### DIFF
--- a/crates/polars-expr/src/expressions/group_iter.rs
+++ b/crates/polars-expr/src/expressions/group_iter.rs
@@ -183,6 +183,6 @@ impl Iterator for FlatIter {
         }
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len, Some(self.offset))
+        (self.len - self.offset, Some(self.len - self.offset))
     }
 }


### PR DESCRIPTION
Running the tests with a standard library that has debug assertions enabled currently triggers an assertion failure [here](https://github.com/rust-lang/rust/blob/6de3a733122a82d9b3c3427c7ee16a1e1a022718/library/core/src/iter/traits/iterator.rs#L2024) due to a malformed `size_hint()`. Example:
```
thread 'polars-1' panicked at [...]/library/core/src/iter/traits/iterator.rs:2024:13:
Malformed size_hint (3, Some(0))
test tests::aggregations::test_binary_agg_context_2 ... FAILED
```

This can also be reproduced by adding a well-formedness assertion (`assert!(self.len <= self.offset)`, i.e. the lower bound must not be greater than the upper bound) here:
https://github.com/pola-rs/polars/blob/ba1293c27632dd366c69a7727fd99cc837edd99b/crates/polars-expr/src/expressions/group_iter.rs#L185-L187

My understanding is that `self.offset` is increased in every `next()` call up to `self.len`, so the correct remaining length should be `self.len - self.offset`. This makes the tests pass even with debug assertions enabled.