### PR TITLE
fix: Do not schema-match structs with different field counts

### DIFF
--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -909,6 +909,9 @@ impl DataType {
             },
             #[cfg(feature = "dtype-struct")]
             (DataType::Struct(l), DataType::Struct(r)) => {
+                if l.len() != r.len() {
+                    polars_bail!(SchemaMismatch: "structs have different number of fields: {} vs {}", l.len(), r.len());
+                }
                 let mut must_cast = false;
                 for (l, r) in l.iter().zip(r.iter()) {
                     must_cast |= l.dtype.matches_schema_type(&r.dtype)?;

--- a/py-polars/tests/unit/series/test_append.py
+++ b/py-polars/tests/unit/series/test_append.py
@@ -88,6 +88,22 @@ def test_struct_schema_on_append_extend_3452() -> None:
         housing1.extend(housing2)
 
 
+def test_append_mismatching_struct_with_null_22639() -> None:
+    a = pl.Series([{"x": "foo", "y": "bar"}])
+    b = pl.Series([{"z": "baz"}])
+    c = pl.Series([{"z": None}])
+    with pytest.raises(
+        SchemaError,
+    ):
+        a.append(b)
+    with pytest.raises(
+        SchemaError,
+    ):
+        a.append(c)
+
+    assert_series_equal(b.append(c), pl.Series([{"z": "baz"}, {"z": None}]))
+
+
 def test_append_null_series() -> None:
     a = pl.Series("a", [1, 2], pl.Int64)
     b = pl.Series("b", [None, None], pl.Null)


### PR DESCRIPTION
I took a small liberty to take a stab at https://github.com/pola-rs/polars/issues/22639.

This patch changes the behavior of `DataType::matches_schema_type` such that structs wit different numbers of fields are not considered to match, not even with a cast.