### PR TITLE
refactor: Move scan parameter parsing for parquet to reusable function

### DIFF
--- a/crates/polars-python/src/conversion/mod.rs
+++ b/crates/polars-python/src/conversion/mod.rs
@@ -1239,6 +1239,7 @@ impl<'py> FromPyObject<'py> for Wrap<SetOperation> {
     }
 }
 
+// Conversion from ScanCastOptions class from the Python side.
 impl<'py> FromPyObject<'py> for Wrap<CastColumnsPolicy> {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         if ob.is_none() {

--- a/crates/polars-python/src/conversion/mod.rs
+++ b/crates/polars-python/src/conversion/mod.rs
@@ -1243,7 +1243,7 @@ impl<'py> FromPyObject<'py> for Wrap<CastColumnsPolicy> {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         if ob.is_none() {
             // Initialize the default ScanCastOptions from Python.
-            static DEFAULT: GILOnceCell<CastColumnsPolicy> = GILOnceCell::new();
+            static DEFAULT: GILOnceCell<Wrap<CastColumnsPolicy>> = GILOnceCell::new();
 
             let out = DEFAULT.get_or_try_init(ob.py(), || {
                 let ob = PyModule::import(ob.py(), "polars.io.scan_options.cast_options")
@@ -1258,10 +1258,10 @@ impl<'py> FromPyObject<'py> for Wrap<CastColumnsPolicy> {
                 // The default policy should match ERROR_ON_MISMATCH (but this can change).
                 debug_assert_eq!(&out.0, &CastColumnsPolicy::ERROR_ON_MISMATCH);
 
-                PyResult::Ok(out.0)
+                PyResult::Ok(out)
             })?;
 
-            return Ok(Wrap(out.clone()));
+            return Ok(out.clone());
         }
 
         let py = ob.py();

--- a/crates/polars-python/src/io/mod.rs
+++ b/crates/polars-python/src/io/mod.rs
@@ -29,23 +29,22 @@ impl PyScanOptions<'_> {
         first_path: Option<&PathBuf>,
     ) -> PyResult<UnifiedScanArgs> {
         #[derive(FromPyObject)]
-        #[rustfmt::skip]
         struct Extract {
-            row_index            : Option<(Wrap<PlSmallStr>, IdxSize)>,
-            pre_slice            : Option<(i64, usize)>               ,
-            cast_options         : Wrap<CastColumnsPolicy>            ,
-            extra_columns        : Wrap<ExtraColumnsPolicy>           ,
-            missing_columns      : Wrap<MissingColumnsPolicy>         ,
-            include_file_paths   : Option<Wrap<PlSmallStr>>           ,
-            glob                 : bool                               ,
-            hive_partitioning    : Option<bool>                       ,
-            hive_schema          : Option<Wrap<Schema>>               ,
-            try_parse_hive_dates : bool                               ,
-            rechunk              : bool                               ,
-            cache                : bool                               ,
-            storage_options      : Option<Vec<(String, String)>>      ,
-            credential_provider  : Option<PyObject>                   ,
-            retries              : usize                              ,
+            row_index: Option<(Wrap<PlSmallStr>, IdxSize)>,
+            pre_slice: Option<(i64, usize)>,
+            cast_options: Wrap<CastColumnsPolicy>,
+            extra_columns: Wrap<ExtraColumnsPolicy>,
+            missing_columns: Wrap<MissingColumnsPolicy>,
+            include_file_paths: Option<Wrap<PlSmallStr>>,
+            glob: bool,
+            hive_partitioning: Option<bool>,
+            hive_schema: Option<Wrap<Schema>>,
+            try_parse_hive_dates: bool,
+            rechunk: bool,
+            cache: bool,
+            storage_options: Option<Vec<(String, String)>>,
+            credential_provider: Option<PyObject>,
+            retries: usize,
         }
 
         let Extract {

--- a/crates/polars-python/src/io/mod.rs
+++ b/crates/polars-python/src/io/mod.rs
@@ -5,7 +5,6 @@ use polars::prelude::{
     CastColumnsPolicy, ExtraColumnsPolicy, MissingColumnsPolicy, PlSmallStr, Schema,
     UnifiedScanArgs,
 };
-use polars_io::cloud::credential_provider::PlCredentialProvider;
 use polars_io::{HiveOptions, RowIndex};
 use polars_utils::IdxSize;
 use polars_utils::slice_enum::Slice;
@@ -72,11 +71,13 @@ impl PyScanOptions<'_> {
         let cloud_options = if let Some(first_path) = first_path {
             #[cfg(feature = "cloud")]
             {
+                use polars_io::cloud::credential_provider::PlCredentialProvider;
+
+                use crate::prelude::parse_cloud_options;
+
                 let first_path_url = first_path.to_string_lossy();
-                let cloud_options = crate::prelude::parse_cloud_options(
-                    &first_path_url,
-                    cloud_options.unwrap_or_default(),
-                )?;
+                let cloud_options =
+                    parse_cloud_options(&first_path_url, cloud_options.unwrap_or_default())?;
 
                 Some(
                     cloud_options

--- a/crates/polars-python/src/io/mod.rs
+++ b/crates/polars-python/src/io/mod.rs
@@ -12,7 +12,7 @@ use polars_utils::slice_enum::Slice;
 use pyo3::types::PyAnyMethods;
 use pyo3::{Bound, FromPyObject, PyObject, PyResult};
 
-use crate::prelude::{Wrap, parse_cloud_options};
+use crate::prelude::Wrap;
 
 /// Interface to `class ScanOptions` on the Python side
 pub struct PyScanOptions<'py>(Bound<'py, pyo3::PyAny>);
@@ -73,8 +73,10 @@ impl PyScanOptions<'_> {
             #[cfg(feature = "cloud")]
             {
                 let first_path_url = first_path.to_string_lossy();
-                let cloud_options =
-                    parse_cloud_options(&first_path_url, cloud_options.unwrap_or_default())?;
+                let cloud_options = crate::prelude::parse_cloud_options(
+                    &first_path_url,
+                    cloud_options.unwrap_or_default(),
+                )?;
 
                 Some(
                     cloud_options

--- a/crates/polars-python/src/io/mod.rs
+++ b/crates/polars-python/src/io/mod.rs
@@ -108,6 +108,8 @@ impl PyScanOptions<'_> {
         };
 
         let unified_scan_args = UnifiedScanArgs {
+            // Schema is currently still stored inside the options per scan type, but we do eventually
+            // want to put it here instead.
             schema: None,
             cloud_options,
             hive_options,

--- a/crates/polars-python/src/io/mod.rs
+++ b/crates/polars-python/src/io/mod.rs
@@ -1,9 +1,18 @@
-use polars::prelude::{CastColumnsPolicy, ExtraColumnsPolicy, MissingColumnsPolicy};
-use pyo3::exceptions::PyValueError;
-use pyo3::pybacked::PyBackedStr;
-use pyo3::sync::GILOnceCell;
-use pyo3::types::{PyAnyMethods, PyModule};
-use pyo3::{Bound, FromPyObject, PyAny, PyResult, intern};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use polars::prelude::{
+    CastColumnsPolicy, ExtraColumnsPolicy, MissingColumnsPolicy, PlSmallStr, Schema,
+    UnifiedScanArgs,
+};
+use polars_io::cloud::credential_provider::PlCredentialProvider;
+use polars_io::{HiveOptions, RowIndex};
+use polars_utils::IdxSize;
+use polars_utils::slice_enum::Slice;
+use pyo3::types::PyAnyMethods;
+use pyo3::{Bound, FromPyObject, PyObject, PyResult};
+
+use crate::prelude::{Wrap, parse_cloud_options};
 
 /// Interface to `class ScanOptions` on the Python side
 pub struct PyScanOptions<'py>(Bound<'py, pyo3::PyAny>);
@@ -15,187 +24,105 @@ impl<'py> FromPyObject<'py> for PyScanOptions<'py> {
 }
 
 impl PyScanOptions<'_> {
-    pub fn extra_columns_policy(&self) -> PyResult<ExtraColumnsPolicy> {
-        let py = self.0.py();
-
-        Ok(
-            match &*self
-                .0
-                .getattr(intern!(py, "extra_columns"))?
-                .extract::<PyBackedStr>()?
-            {
-                "ignore" => ExtraColumnsPolicy::Ignore,
-                "raise" => ExtraColumnsPolicy::Raise,
-                v => {
-                    return Err(PyValueError::new_err(format!(
-                        "unknown option for extra_columns: {v}"
-                    )));
-                },
-            },
-        )
-    }
-
-    pub fn missing_columns_policy(&self) -> PyResult<MissingColumnsPolicy> {
-        let py = self.0.py();
-
-        Ok(
-            match &*self
-                .0
-                .getattr(intern!(py, "missing_columns"))?
-                .extract::<PyBackedStr>()?
-            {
-                "insert" => MissingColumnsPolicy::Insert,
-                "raise" => MissingColumnsPolicy::Raise,
-                v => {
-                    return Err(PyValueError::new_err(format!(
-                        "unknown option for missing_columns: {v}"
-                    )));
-                },
-            },
-        )
-    }
-
-    pub fn extract_cast_options(&self) -> PyResult<CastColumnsPolicy> {
-        let py = self.0.py();
-        let ob = self.0.getattr(intern!(py, "cast_options"))?;
-
-        if ob.is_none() {
-            // Initialize the default ScanCastOptions from Python.
-            static DEFAULT: GILOnceCell<CastColumnsPolicy> = GILOnceCell::new();
-
-            let out = DEFAULT.get_or_try_init(ob.py(), || {
-                let ob = PyModule::import(ob.py(), "polars.io.scan_options.cast_options")
-                    .unwrap()
-                    .getattr("ScanCastOptions")
-                    .unwrap()
-                    .call_method0("_default")
-                    .unwrap();
-
-                let out = extract_cast_options_impl(ob)?;
-
-                // The default policy should match ERROR_ON_MISMATCH (but this can change).
-                debug_assert_eq!(&out, &CastColumnsPolicy::ERROR_ON_MISMATCH);
-
-                PyResult::Ok(out)
-            })?;
-
-            return Ok(out.clone());
+    pub fn extract_unified_scan_args(
+        &self,
+        // For cloud_options init
+        first_path: Option<&PathBuf>,
+    ) -> PyResult<UnifiedScanArgs> {
+        #[derive(FromPyObject)]
+        #[rustfmt::skip]
+        struct Extract {
+            row_index            : Option<(Wrap<PlSmallStr>, IdxSize)>,
+            pre_slice            : Option<(i64, usize)>               ,
+            cast_options         : Wrap<CastColumnsPolicy>            ,
+            extra_columns        : Wrap<ExtraColumnsPolicy>           ,
+            missing_columns      : Wrap<MissingColumnsPolicy>         ,
+            include_file_paths   : Option<Wrap<PlSmallStr>>           ,
+            glob                 : bool                               ,
+            hive_partitioning    : Option<bool>                       ,
+            hive_schema          : Option<Wrap<Schema>>               ,
+            try_parse_hive_dates : bool                               ,
+            rechunk              : bool                               ,
+            cache                : bool                               ,
+            storage_options      : Option<Vec<(String, String)>>      ,
+            credential_provider  : Option<PyObject>                   ,
+            retries              : usize                              ,
         }
 
-        extract_cast_options_impl(ob)
-    }
-}
+        let Extract {
+            row_index,
+            pre_slice,
+            cast_options,
+            extra_columns,
+            missing_columns,
+            include_file_paths,
+            glob,
+            hive_partitioning,
+            hive_schema,
+            try_parse_hive_dates,
+            rechunk,
+            cache,
+            storage_options,
+            credential_provider,
+            retries,
+        } = self.0.extract()?;
 
-fn extract_cast_options_impl(ob: Bound<'_, PyAny>) -> PyResult<CastColumnsPolicy> {
-    let py = ob.py();
+        let cloud_options = storage_options;
 
-    let integer_upcast = match &*ob
-        .getattr(intern!(py, "integer_cast"))?
-        .extract::<PyBackedStr>()?
-    {
-        "upcast" => true,
-        "forbid" => false,
-        v => {
-            return Err(PyValueError::new_err(format!(
-                "unknown option for integer_cast: {v}"
-            )));
-        },
-    };
+        let cloud_options = if let Some(first_path) = first_path {
+            #[cfg(feature = "cloud")]
+            {
+                let first_path_url = first_path.to_string_lossy();
+                let cloud_options =
+                    parse_cloud_options(&first_path_url, cloud_options.unwrap_or_default())?;
 
-    let mut float_upcast = false;
-    let mut float_downcast = false;
+                Some(
+                    cloud_options
+                        .with_max_retries(retries)
+                        .with_credential_provider(
+                            credential_provider.map(PlCredentialProvider::from_python_builder),
+                        ),
+                )
+            }
 
-    let float_cast_object = ob.getattr(intern!(py, "float_cast"))?;
-
-    parse_multiple_options("float_cast", float_cast_object, |v| {
-        match v {
-            "forbid" => {},
-            "upcast" => float_upcast = true,
-            "downcast" => float_downcast = true,
-            v => {
-                return Err(PyValueError::new_err(format!(
-                    "unknown option for float_cast: {v}"
-                )));
-            },
-        }
-
-        Ok(())
-    })?;
-
-    let mut datetime_nanoseconds_downcast = false;
-    let mut datetime_convert_timezone = false;
-
-    let datetime_cast_object = ob.getattr(intern!(py, "datetime_cast"))?;
-
-    parse_multiple_options("datetime_cast", datetime_cast_object, |v| {
-        match v {
-            "forbid" => {},
-            "nanosecond-downcast" => datetime_nanoseconds_downcast = true,
-            "convert-timezone" => datetime_convert_timezone = true,
-            v => {
-                return Err(PyValueError::new_err(format!(
-                    "unknown option for datetime_cast: {v}"
-                )));
-            },
+            #[cfg(not(feature = "cloud"))]
+            {
+                None
+            }
+        } else {
+            None
         };
 
-        Ok(())
-    })?;
+        let hive_schema = hive_schema.map(|s| Arc::new(s.0));
 
-    let missing_struct_fields = match &*ob
-        .getattr(intern!(py, "missing_struct_fields"))?
-        .extract::<PyBackedStr>()?
-    {
-        "insert" => MissingColumnsPolicy::Insert,
-        "raise" => MissingColumnsPolicy::Raise,
-        v => {
-            return Err(PyValueError::new_err(format!(
-                "unknown option for missing_struct_fields: {v}"
-            )));
-        },
-    };
+        let row_index = row_index.map(|(name, offset)| RowIndex {
+            name: name.0,
+            offset,
+        });
 
-    let extra_struct_fields = match &*ob
-        .getattr(intern!(py, "extra_struct_fields"))?
-        .extract::<PyBackedStr>()?
-    {
-        "ignore" => ExtraColumnsPolicy::Ignore,
-        "raise" => ExtraColumnsPolicy::Raise,
-        v => {
-            return Err(PyValueError::new_err(format!(
-                "unknown option for extra_struct_fields: {v}"
-            )));
-        },
-    };
+        let hive_options = HiveOptions {
+            enabled: hive_partitioning,
+            hive_start_idx: 0,
+            schema: hive_schema,
+            try_parse_dates: try_parse_hive_dates,
+        };
 
-    Ok(CastColumnsPolicy {
-        integer_upcast,
-        float_upcast,
-        float_downcast,
-        datetime_nanoseconds_downcast,
-        datetime_microseconds_downcast: false,
-        datetime_convert_timezone,
-        missing_struct_fields,
-        extra_struct_fields,
-    })
-}
+        let unified_scan_args = UnifiedScanArgs {
+            schema: None,
+            cloud_options,
+            hive_options,
+            rechunk,
+            cache,
+            glob,
+            projection: None,
+            row_index,
+            pre_slice: pre_slice.map(Slice::from),
+            cast_columns_policy: cast_options.0,
+            missing_columns_policy: missing_columns.0,
+            extra_columns_policy: extra_columns.0,
+            include_file_paths: include_file_paths.map(|x| x.0),
+        };
 
-fn parse_multiple_options(
-    parameter_name: &'static str,
-    py_object: Bound<'_, PyAny>,
-    mut parser_func: impl FnMut(&str) -> PyResult<()>,
-) -> PyResult<()> {
-    if let Ok(v) = py_object.extract::<PyBackedStr>() {
-        parser_func(&v)?;
-    } else if let Ok(v) = py_object.try_iter() {
-        for v in v {
-            parser_func(&v?.extract::<PyBackedStr>()?)?;
-        }
-    } else {
-        return Err(PyValueError::new_err(format!(
-            "unknown type for {parameter_name}: {py_object}"
-        )));
+        Ok(unified_scan_args)
     }
-
-    Ok(())
 }

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -302,34 +302,16 @@ impl PyLazyFrame {
     #[cfg(feature = "parquet")]
     #[staticmethod]
     #[pyo3(signature = (
-        source, sources, n_rows, cache, parallel, rechunk, row_index, low_memory, cloud_options,
-        credential_provider, use_statistics, hive_partitioning, schema, hive_schema,
-        try_parse_hive_dates, retries, glob, include_file_paths, scan_options,
+        sources, schema, scan_options, parallel, low_memory, use_statistics
     ))]
     fn new_from_parquet(
-        source: Option<PyObject>,
         sources: Wrap<ScanSources>,
-        n_rows: Option<usize>,
-        cache: bool,
-        parallel: Wrap<ParallelStrategy>,
-        rechunk: bool,
-        row_index: Option<(String, IdxSize)>,
-        low_memory: bool,
-        cloud_options: Option<Vec<(String, String)>>,
-        credential_provider: Option<PyObject>,
-        use_statistics: bool,
-        hive_partitioning: Option<bool>,
         schema: Option<Wrap<Schema>>,
-        hive_schema: Option<Wrap<Schema>>,
-        try_parse_hive_dates: bool,
-        retries: usize,
-        glob: bool,
-        include_file_paths: Option<String>,
         scan_options: PyScanOptions,
+        parallel: Wrap<ParallelStrategy>,
+        low_memory: bool,
+        use_statistics: bool,
     ) -> PyResult<Self> {
-        use cloud::credential_provider::PlCredentialProvider;
-        use polars_utils::slice_enum::Slice;
-
         use crate::utils::to_py_err;
 
         let parallel = parallel.0;
@@ -342,64 +324,9 @@ impl PyLazyFrame {
         };
 
         let sources = sources.0;
-        let (first_path, sources) = match source {
-            None => (sources.first_path().map(|p| p.to_path_buf()), sources),
-            Some(source) => pyobject_to_first_path_and_scan_sources(source)?,
-        };
+        let first_path = sources.first_path().map(|p| p.to_path_buf());
 
-        let cloud_options = if let Some(first_path) = first_path {
-            #[cfg(feature = "cloud")]
-            {
-                let first_path_url = first_path.to_string_lossy();
-                let cloud_options =
-                    parse_cloud_options(&first_path_url, cloud_options.unwrap_or_default())?;
-
-                Some(
-                    cloud_options
-                        .with_max_retries(retries)
-                        .with_credential_provider(
-                            credential_provider.map(PlCredentialProvider::from_python_builder),
-                        ),
-                )
-            }
-
-            #[cfg(not(feature = "cloud"))]
-            {
-                None
-            }
-        } else {
-            None
-        };
-
-        let hive_schema = hive_schema.map(|s| Arc::new(s.0));
-
-        let row_index = row_index.map(|(name, offset)| RowIndex {
-            name: name.into(),
-            offset,
-        });
-
-        let hive_options = HiveOptions {
-            enabled: hive_partitioning,
-            hive_start_idx: 0,
-            schema: hive_schema,
-            try_parse_dates: try_parse_hive_dates,
-        };
-
-        let unified_scan_args = UnifiedScanArgs {
-            schema: None,
-            cloud_options,
-            hive_options,
-            rechunk,
-            cache,
-            glob,
-            projection: None,
-            row_index,
-            pre_slice: n_rows.map(|len| Slice::Positive { offset: 0, len }),
-            cast_columns_policy: scan_options.extract_cast_options()?,
-            missing_columns_policy: scan_options.missing_columns_policy()?,
-            extra_columns_policy: scan_options.extra_columns_policy()?,
-            include_file_paths: include_file_paths.map(|x| x.into()),
-        };
+        let unified_scan_args = scan_options.extract_unified_scan_args(first_path.as_ref())?;
 
         let lf: LazyFrame = DslBuilder::scan_parquet(sources, options, unified_scan_args)
             .map_err(to_py_err)?

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -615,6 +615,9 @@ def scan_parquet(
     pylf = PyLazyFrame.new_from_parquet(
         sources=sources,
         schema=schema,
+        parallel=parallel,
+        low_memory=low_memory,
+        use_statistics=use_statistics,
         scan_options=ScanOptions(
             row_index=(
                 (row_index_name, row_index_offset)
@@ -638,9 +641,6 @@ def scan_parquet(
             credential_provider=credential_provider_builder,
             retries=retries,
         ),
-        parallel=parallel,
-        low_memory=low_memory,
-        use_statistics=use_statistics,
     )
 
     return wrap_ldf(pylf)

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import io
+from collections.abc import Sequence
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any
 
@@ -605,7 +606,11 @@ def scan_parquet(
 
         missing_columns = "insert" if allow_missing_columns else "raise"
 
-    sources = source if isinstance(source, list) else [source]
+    sources = (
+        [source]
+        if not isinstance(source, Sequence) or isinstance(source, (str, bytes))
+        else source
+    )
 
     pylf = PyLazyFrame.new_from_parquet(
         sources=sources,

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -583,6 +583,16 @@ def scan_parquet(
         msg = "The `cast_options` parameter of `scan_parquet` is considered unstable."
         issue_unstable_warning(msg)
 
+    if allow_missing_columns is not None:
+        issue_deprecation_warning(
+            "the parameter `allow_missing_columns` for `scan_parquet` is deprecated. "
+            "Use the parameter `missing_columns` instead and pass one of "
+            "`('insert', 'raise')`.",
+            version="1.30.0",
+        )
+
+        missing_columns = "insert" if allow_missing_columns else "raise"
+
     if isinstance(source, (str, Path)):
         source = normalize_filepath(source, check_not_directory=False)
     elif is_path_or_str_sequence(source):
@@ -595,16 +605,6 @@ def scan_parquet(
     )
 
     del credential_provider
-
-    if allow_missing_columns is not None:
-        issue_deprecation_warning(
-            "the parameter `allow_missing_columns` for `scan_parquet` is deprecated. "
-            "Use the parameter `missing_columns` instead and pass one of "
-            "`('insert', 'raise')`.",
-            version="1.30.0",
-        )
-
-        missing_columns = "insert" if allow_missing_columns else "raise"
 
     sources = (
         [source]

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -629,7 +629,7 @@ def scan_parquet(
             rechunk=rechunk,
             cache=cache,
             storage_options=(
-                [*storage_options.items()] if storage_options is not None else None
+                list(storage_options.items()) if storage_options is not None else None
             ),
             credential_provider=credential_provider_builder,
             retries=retries,

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -616,7 +616,11 @@ def scan_parquet(
         sources=sources,
         schema=schema,
         scan_options=ScanOptions(
-            row_index=(row_index_name, row_index_offset) if row_index_name else None,
+            row_index=(
+                (row_index_name, row_index_offset)
+                if row_index_name is not None
+                else None
+            ),
             pre_slice=(0, n_rows) if n_rows is not None else None,
             cast_options=cast_options,
             extra_columns=extra_columns,

--- a/py-polars/polars/io/scan_options/_options.py
+++ b/py-polars/polars/io/scan_options/_options.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:

--- a/py-polars/polars/io/scan_options/_options.py
+++ b/py-polars/polars/io/scan_options/_options.py
@@ -3,19 +3,42 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
+    from polars._typing import SchemaDict
+    from polars.io.cloud.credential_provider._builder import CredentialProviderBuilder
     from polars.io.scan_options.cast_options import ScanCastOptions
 
+from dataclasses import dataclass
 
+
+@dataclass(kw_only=True)
 class ScanOptions:
-    """Holds options for UnifiedScanArgs."""
+    """
+    Holds scan options that are generic over scan type.
 
-    def __init__(
-        self,
-        *,
-        cast_options: ScanCastOptions | None,
-        extra_columns: Literal["ignore", "raise"],
-        missing_columns: Literal["insert", "raise"] = "raise",
-    ) -> None:
-        self.cast_options = cast_options
-        self.extra_columns = extra_columns
-        self.missing_columns = missing_columns
+    For internal use. Most of the options will parse into `UnifiedScanArgs`.
+    """
+
+    row_index: tuple[str, int] | None = None
+    # (i64, usize)
+    pre_slice: tuple[int, int] | None = None
+    cast_options: ScanCastOptions | None
+    extra_columns: Literal["ignore", "raise"]
+    missing_columns: Literal["insert", "raise"] = "raise"
+    include_file_paths: str | None = None
+
+    # For path expansion
+    glob: bool = True
+
+    # Hive
+    # Note: `None` means auto.
+    hive_partitioning: bool | None = None
+    hive_schema: SchemaDict | None = None
+    try_parse_hive_dates: bool = True
+
+    rechunk: bool = False
+    cache: bool = True
+
+    # Cloud
+    storage_options: list[tuple[str, str]] | None = None
+    credential_provider: CredentialProviderBuilder | None = None
+    retries: int = 2

--- a/py-polars/polars/io/scan_options/_options.py
+++ b/py-polars/polars/io/scan_options/_options.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
@@ -9,8 +10,10 @@ if TYPE_CHECKING:
 
 from dataclasses import dataclass
 
+decorator = dataclass(kw_only=True) if sys.version_info >= (3, 10) else dataclass()
 
-@dataclass(kw_only=True)
+
+@decorator
 class ScanOptions:
     """
     Holds scan options that are generic over scan type.
@@ -22,7 +25,7 @@ class ScanOptions:
     # (i64, usize)
     pre_slice: tuple[int, int] | None = None
     cast_options: ScanCastOptions | None
-    extra_columns: Literal["ignore", "raise"]
+    extra_columns: Literal["ignore", "raise"] = "raise"
     missing_columns: Literal["insert", "raise"] = "raise"
     include_file_paths: str | None = None
 

--- a/py-polars/polars/io/scan_options/_options.py
+++ b/py-polars/polars/io/scan_options/_options.py
@@ -22,7 +22,7 @@ class ScanOptions:
     row_index: tuple[str, int] | None = None
     # (i64, usize)
     pre_slice: tuple[int, int] | None = None
-    cast_options: ScanCastOptions | None
+    cast_options: ScanCastOptions | None = None
     extra_columns: Literal["ignore", "raise"] = "raise"
     missing_columns: Literal["insert", "raise"] = "raise"
     include_file_paths: str | None = None

--- a/py-polars/polars/io/scan_options/_options.py
+++ b/py-polars/polars/io/scan_options/_options.py
@@ -10,10 +10,9 @@ if TYPE_CHECKING:
 
 from dataclasses import dataclass
 
-decorator = dataclass(kw_only=True) if sys.version_info >= (3, 10) else dataclass()
 
-
-@decorator
+# TODO: Add `kw_only=True` after 3.9 support dropped
+@dataclass()
 class ScanOptions:
     """
     Holds scan options that are generic over scan type.

--- a/py-polars/polars/io/scan_options/_options.py
+++ b/py-polars/polars/io/scan_options/_options.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 
 
 # TODO: Add `kw_only=True` after 3.9 support dropped
-@dataclass()
+@dataclass
 class ScanOptions:
     """
     Holds scan options that are generic over scan type.


### PR DESCRIPTION
Eventually should allow us to de-duplicate a lot of parameter parsing logic across scan types as well as supporting more parameters for them.
