### PR TITLE
fix: Add `include_nulls` to `Agg::Count` CSE check

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/mod.rs
+++ b/crates/polars-plan/src/plans/aexpr/mod.rs
@@ -70,6 +70,7 @@ impl Hash for IRAggExpr {
                 method: interpol, ..
             } => interpol.hash(state),
             Self::Std(_, v) | Self::Var(_, v) => v.hash(state),
+            Self::Count(_, include_nulls) => include_nulls.hash(state),
             _ => {},
         }
     }

--- a/py-polars/tests/unit/dataframe/test_null_count.py
+++ b/py-polars/tests/unit/dataframe/test_null_count.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from hypothesis import example, given
 
 import polars as pl
+from polars.testing.asserts.frame import assert_frame_equal
 from polars.testing.parametric import dataframes
 
 
@@ -26,3 +27,34 @@ def test_null_count(df: pl.DataFrame) -> None:
     assert null_count.shape == (1, ncols)
     for idx, count in enumerate(null_count.rows()[0]):
         assert count == sum(v is None for v in df.to_series(idx).to_list())
+
+
+def test_null_count_optimization_23031() -> None:
+    df = pl.DataFrame(data=[None, 2, None, 4, None, 6], schema={"col": pl.Int64})
+
+    expected = pl.DataFrame([
+        pl.Series("count_all", [3], pl.UInt32()),
+        pl.Series("sum_all", [12], pl.Int64()),
+    ])
+
+    assert_frame_equal(
+        df.select(
+            count_all=pl.col("col").count(),
+            sum_all=pl.when(pl.col("col").is_not_null().any()).then(
+                pl.col("col").sum()
+            ),
+        ),
+        expected,
+    )
+
+    assert_frame_equal(
+        df.lazy()
+        .select(
+            count_all=pl.col("col").count(),
+            sum_all=pl.when(pl.col("col").is_not_null().any()).then(
+                pl.col("col").sum()
+            ),
+        )
+        .collect(),
+        expected,
+    )


### PR DESCRIPTION
Fixes #23031.

Why do we even have `AggExpr::Count` if we have a `len`? And is `.is_not_null().any()` actually always worse then `.null_count() < pl.len()`?