### PR TITLE
feat(python): Support named arguments in `pl.format()`

### DIFF
--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -839,7 +839,7 @@ def format(f_string: str, *args: Expr | str, **kwargs: Expr | str) -> Expr:
     matches = list(Formatter().parse(f_string))
 
     n_unnamed_placeholders = len([m for m in matches if m[1] == ""])
-    n_named_placeholders = len([m for m in matches if m[1] not in (None, "")])
+    n_named_placeholders = len({m[1] for m in matches if m[1] not in (None, "")})
 
     if n_unnamed_placeholders != len(args):
         error = (

--- a/py-polars/tests/unit/functions/as_datatype/test_format.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_format.py
@@ -28,8 +28,10 @@ def test_format_with_no_placeholders() -> None:
 def test_format_with_only_placeholders() -> None:
     df = pl.DataFrame({"a": ["a", "b", "c"], "b": [1, 2, 3]})
 
-    out = df.select([pl.format("{a}", a=pl.col("a")).alias("fmt")])
-    assert out["fmt"].to_list() == ["a", "b", "c"]
+    out = df.select(
+        [pl.format("{a}_{b}_{a}", a=pl.col("a"), b=pl.col("b")).alias("fmt")]
+    )
+    assert out["fmt"].to_list() == ["a_1_a", "b_2_b", "c_3_c"]
 
 
 def test_format_literal_brackets() -> None:
@@ -44,6 +46,13 @@ def test_format_empty_literal_brackets() -> None:
 
     out = df.with_columns([pl.format("test{{}}").alias("fmt")])
     assert out["fmt"].to_list() == ["test{}", "test{}", "test{}"]
+
+
+def test_format_literal_brackets_and_placeholders() -> None:
+    df = pl.DataFrame({"a": ["a", "b", "c"]})
+
+    out = df.select([pl.format("test{{a}}_{a}", a=pl.col("a")).alias("fmt")])
+    assert out["fmt"].to_list() == ["test{a}_a", "test{a}_b", "test{a}_c"]
 
 
 def test_format_raises_on_wrong_number_of_named_arguments() -> None:

--- a/py-polars/tests/unit/functions/as_datatype/test_format.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_format.py
@@ -1,3 +1,5 @@
+import pytest
+
 import polars as pl
 
 
@@ -6,3 +8,57 @@ def test_format() -> None:
 
     out = df.select([pl.format("foo_{}_bar_{}", pl.col("a"), "b").alias("fmt")])
     assert out["fmt"].to_list() == ["foo_a_bar_1", "foo_b_bar_2", "foo_c_bar_3"]
+
+
+def test_format_with_names() -> None:
+    df = pl.DataFrame({"a": ["a", "b", "c"], "b": [1, 2, 3]})
+
+    out = df.select([pl.format("foo_{}_bar_{b}", pl.col("a"), b="b").alias("fmt")])
+    assert out["fmt"].to_list() == ["foo_a_bar_1", "foo_b_bar_2", "foo_c_bar_3"]
+
+
+def test_format_with_no_placeholders() -> None:
+    df = pl.DataFrame({"a": ["a", "b", "c"], "b": [1, 2, 3]})
+
+    # Need with_columns instead of select, because all formatted strings are the same
+    out = df.with_columns([pl.format("foo").alias("fmt")])
+    assert out["fmt"].to_list() == ["foo", "foo", "foo"]
+
+
+def test_format_with_only_placeholders() -> None:
+    df = pl.DataFrame({"a": ["a", "b", "c"], "b": [1, 2, 3]})
+
+    out = df.select([pl.format("{a}", a=pl.col("a")).alias("fmt")])
+    assert out["fmt"].to_list() == ["a", "b", "c"]
+
+
+def test_format_raises_on_wrong_number_of_named_arguments() -> None:
+    with pytest.raises(
+        ValueError,
+        match="Expected 2 named placeholders, but got 1 keyword arguments.",
+    ):
+        pl.format("foo_{a}_bar_{b}", a=pl.col("a"))
+
+
+def test_format_raises_on_wrong_number_of_unnamed_arguments() -> None:
+    with pytest.raises(
+        ValueError,
+        match="Expected 1 unnamed placeholders, but got 0 arguments.",
+    ):
+        pl.format("foo_{}_bar_{b}", a=pl.col("a"), b=pl.col("b"))
+
+
+def test_format_specifiers_unsupported() -> None:
+    with pytest.raises(
+        ValueError,
+        match="Formatting specifiers and conversion flags are not supported in polars.format()",
+    ):
+        pl.format("foo_{a:s}", a=pl.col("a"))
+
+
+def test_format_conversion_flags_unsupported() -> None:
+    with pytest.raises(
+        ValueError,
+        match="Formatting specifiers and conversion flags are not supported in polars.format()",
+    ):
+        pl.format("foo_{a!r}", a=pl.col("a"))

--- a/py-polars/tests/unit/functions/as_datatype/test_format.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_format.py
@@ -32,6 +32,20 @@ def test_format_with_only_placeholders() -> None:
     assert out["fmt"].to_list() == ["a", "b", "c"]
 
 
+def test_format_literal_brackets() -> None:
+    df = pl.DataFrame({"a": ["a", "b", "c"]})
+
+    out = df.with_columns([pl.format("test{{a}}").alias("fmt")])
+    assert out["fmt"].to_list() == ["test{a}", "test{a}", "test{a}"]
+
+
+def test_format_empty_literal_brackets() -> None:
+    df = pl.DataFrame({"a": ["a", "b", "c"]})
+
+    out = df.with_columns([pl.format("test{{}}").alias("fmt")])
+    assert out["fmt"].to_list() == ["test{}", "test{}", "test{}"]
+
+
 def test_format_raises_on_wrong_number_of_named_arguments() -> None:
     with pytest.raises(
         ValueError,


### PR DESCRIPTION
This implements #23038. This probably makes existing calls to `pl.format` a little slower, because it uses `Formatter().parse(f_string)` instead of `f_string.split("{}")`.