### PR TITLE
fix: Fix confusing error message on duplicate row_index

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -269,11 +269,19 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                             polars_bail!(ComputeError: "DATASET_PROVIDER_VTABLE (python) not initialized")
                         }
 
-                        let schema = dataset_object.schema()?;
+                        let mut schema = dataset_object.schema()?;
+                        let reader_schema = schema.clone();
+
+                        if let Some(row_index) = &unified_scan_args.row_index {
+                            insert_row_index_to_schema(
+                                Arc::make_mut(&mut schema),
+                                row_index.name.clone(),
+                            )?;
+                        }
 
                         FileInfo {
-                            schema: schema.clone(),
-                            reader_schema: Some(either::Either::Right(schema)),
+                            schema,
+                            reader_schema: Some(either::Either::Right(reader_schema)),
                             row_estimation: (None, usize::MAX),
                         }
                     },

--- a/crates/polars-plan/src/plans/conversion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/mod.rs
@@ -7,7 +7,8 @@ mod ir_to_dsl;
     feature = "ipc",
     feature = "parquet",
     feature = "csv",
-    feature = "json"
+    feature = "json",
+    feature = "python"
 ))]
 mod scans;
 mod stack_opt;
@@ -26,7 +27,8 @@ use recursive::recursive;
     feature = "ipc",
     feature = "parquet",
     feature = "csv",
-    feature = "json"
+    feature = "json",
+    feature = "python"
 ))]
 pub use scans::*;
 mod functions;

--- a/py-polars/tests/unit/io/test_multiscan.py
+++ b/py-polars/tests/unit/io/test_multiscan.py
@@ -673,6 +673,26 @@ def test_row_index_filter_22612(scan: Any, write: Any) -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("scan", "write"),
+    [
+        (pl.scan_ipc, pl.DataFrame.write_ipc),
+        (pl.scan_parquet, pl.DataFrame.write_parquet),
+        (pl.scan_csv, pl.DataFrame.write_csv),
+        (pl.scan_ndjson, pl.DataFrame.write_ndjson),
+    ],
+)
+def test_row_index_name_in_file(scan: Any, write: Any) -> None:
+    f = io.BytesIO()
+    write(pl.DataFrame({"index": 1}), f)
+
+    with pytest.raises(
+        pl.exceptions.DuplicateError,
+        match="cannot add row_index with name 'index': column already exists in file",
+    ):
+        scan(f).with_row_index().collect()
+
+
 def test_extra_columns_not_ignored_22218() -> None:
     dfs = [pl.DataFrame({"a": 1, "b": 1}), pl.DataFrame({"a": 2, "c": 2})]
 


### PR DESCRIPTION
```python
# Before
polars.exceptions.SchemaError: extra column in file outside of expected schema: index
# After
polars.exceptions.DuplicateError: cannot add row_index with name 'index': column already exists in file.
```
