### PR TITLE
build: Actually disable `ir_serde` by default

### DIFF
--- a/crates/polars-python/Cargo.toml
+++ b/crates/polars-python/Cargo.toml
@@ -251,7 +251,7 @@ optimizations = [
 ]
 
 polars_cloud_client = ["polars/polars_cloud_client"]
-polars_cloud_server = ["polars/polars_cloud_server", "polars/ir_serde"]
+polars_cloud_server = ["polars/polars_cloud_server"]
 
 # also includes simd
 nightly = ["polars/nightly"]

--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -436,7 +436,6 @@ docs-selection = [
   "unique_counts",
   "polars_cloud_client",
   "serde",
-  "ir_serde",
   "cloud",
   "async",
 ]


### PR DESCRIPTION
Actually disable `ir_serde` in regular polars distributions. Completes #22969

Removes `polars/ir_serde` feature from `polars/docs-selection`, which is activated by `polars/full`.