### PR TITLE
build: Update aws-lc-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b756939cb2f8dc900aa6dcd505e6e2428e9cae7ff7b028c49e3946efa70878"
+checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa9b6986f250236c27e5a204062434a773a13243d2ffc2955f37bdba4c5c6a1"
+checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
 dependencies = [
  "bindgen",
  "cc",


### PR DESCRIPTION
Check if this fixes the python tests on Windows: https://github.com/pola-rs/polars/actions/runs/15390834723/job/43299688389#step:7:7661

```
 c11.c
DEBUG   C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\include\vcruntime_c11_stdatomic.h(16): fatal error C1189: #error:  "C atomics require C11 or later"
DEBUG   cargo:warning=Compilation of 'c11.c' failed - Err(Error { kind: ToolExecError, message: "command did not execute successfully (status code exit code: 2): \"C:\\\\Program Files\\\\Microsoft Visual Studio\\\\2022\\\\Enterprise\\\\VC\\\\Tools\\\\MSVC\\\\14.43.34808\\\\bin\\\\HostX64\\\\x64\\\\cl.exe\" \"-nologo\" \"-MD\" \"-O2\" \"-Brepro\" \"-WX\" \"-W4\" \"-FoC:\\\\Users\\\\runneradmin\\\\AppData\\\\Local\\\\uv\\\\cache\\\\sdists-v9\\\\pypi\\\\deltalake\\\\1.0.2\\\\0tYFT1NPjnr1A8_Mr9O8M\\\\src\\\\target\\\\release\\\\build\\\\aws-lc-sys-d3d6db1ba5db93a8\\\\out\\\\out-c11\\\\e1bacabfea35bee3-c11.o\" \"-c\" \"C:\\\\Users\\\\runneradmin\\\\.cargo\\\\registry\\\\src\\\\index.crates.io-1949cf8c6b5b557f\\\\aws-lc-sys-0.29.0\\\\aws-lc\\\\tests\\\\compiler_features_tests\\\\c11.c\"" }).
```