### PR TITLE
ci: Fix pyodide features

### DIFF
--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -927,6 +927,7 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                     StructFunction::SuffixFields(prefix) => {
                         (PyStructFunction::SuffixFields, prefix.as_str()).into_py_any(py)
                     },
+                    #[cfg(feature = "json")]
                     StructFunction::JsonEncode => (PyStructFunction::JsonEncode,).into_py_any(py),
                     StructFunction::WithFields => {
                         return Err(PyNotImplementedError::new_err("with_fields"));


### PR DESCRIPTION
This needs a feature gate in `polars-python` because `json` is disabled on `pyodide` - https://github.com/pola-rs/polars/blob/ef2160208b6f23586b4006f33020f4d8b91172b1/.github/workflows/test-pyodide.yml#L40-L43
