### PR TITLE
fix: Fix hive partition pruning not filtering out `__HIVE_DEFAULT_PARTITION__`

### DIFF
--- a/crates/polars-io/src/predicates.rs
+++ b/crates/polars-io/src/predicates.rs
@@ -458,7 +458,13 @@ pub struct ScanIOPredicate {
 
     /// A predicate that gets given statistics and evaluates whether a batch can be skipped.
     pub column_predicates: Arc<ColumnPredicates>,
+
+    /// Predicate parts only referring to hive columns.
+    pub hive_predicate: Option<Arc<dyn PhysicalIoExpr>>,
+
+    pub hive_predicate_is_full_predicate: bool,
 }
+
 impl ScanIOPredicate {
     pub fn set_external_constant_columns(&mut self, constant_columns: Vec<(PlSmallStr, Scalar)>) {
         if constant_columns.is_empty() {

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -472,6 +472,7 @@ fn create_physical_plan_impl(
                         &predicate,
                         expr_arena,
                         output_schema.as_ref().unwrap_or(&file_info.schema),
+                        None, // hive_schema
                         &mut expr_conversion_state,
                         create_skip_batch_predicate,
                         false,
@@ -898,12 +899,90 @@ pub fn create_scan_predicate(
     predicate: &ExprIR,
     expr_arena: &mut Arena<AExpr>,
     schema: &Arc<Schema>,
+    hive_schema: Option<&Schema>,
     state: &mut ExpressionConversionState,
     create_skip_batch_predicate: bool,
     create_column_predicates: bool,
 ) -> PolarsResult<ScanPredicate> {
+    let mut predicate = predicate.clone();
+
+    let mut hive_predicate = None;
+    let mut hive_predicate_is_full_predicate = false;
+
+    #[expect(clippy::never_loop)]
+    loop {
+        let Some(hive_schema) = hive_schema else {
+            break;
+        };
+
+        let mut hive_predicate_parts = vec![];
+        let mut non_hive_predicate_parts = vec![];
+
+        for predicate_part in MintermIter::new(predicate.node(), expr_arena) {
+            if aexpr_to_leaf_names_iter(predicate_part, expr_arena)
+                .all(|name| hive_schema.contains(&name))
+            {
+                hive_predicate_parts.push(predicate_part)
+            } else {
+                non_hive_predicate_parts.push(predicate_part)
+            }
+        }
+
+        if hive_predicate_parts.is_empty() {
+            break;
+        }
+
+        if non_hive_predicate_parts.is_empty() {
+            hive_predicate_is_full_predicate = true;
+            break;
+        }
+
+        {
+            let mut iter = hive_predicate_parts.into_iter();
+            let mut node = iter.next().unwrap();
+
+            for next_node in iter {
+                node = expr_arena.add(AExpr::BinaryExpr {
+                    left: node,
+                    op: Operator::And,
+                    right: next_node,
+                });
+            }
+
+            hive_predicate = Some(create_physical_expr(
+                &ExprIR::from_node(node, expr_arena),
+                Context::Default,
+                expr_arena,
+                schema,
+                state,
+            )?)
+        }
+
+        {
+            let mut iter = non_hive_predicate_parts.into_iter();
+            let mut node = iter.next().unwrap();
+
+            for next_node in iter {
+                node = expr_arena.add(AExpr::BinaryExpr {
+                    left: node,
+                    op: Operator::And,
+                    right: next_node,
+                });
+            }
+
+            predicate = ExprIR::from_node(node, expr_arena);
+        }
+
+        break;
+    }
+
     let phys_predicate =
-        create_physical_expr(predicate, Context::Default, expr_arena, schema, state)?;
+        create_physical_expr(&predicate, Context::Default, expr_arena, schema, state)?;
+
+    if hive_predicate_is_full_predicate {
+        hive_predicate = Some(phys_predicate.clone());
+    }
+
     let live_columns = Arc::new(PlIndexSet::from_iter(aexpr_to_leaf_names_iter(
         predicate.node(),
         expr_arena,
@@ -995,5 +1074,7 @@ pub fn create_scan_predicate(
         live_columns,
         skip_batch_predicate,
         column_predicates,
+        hive_predicate,
+        hive_predicate_is_full_predicate,
     })
 }

--- a/crates/polars-mem-engine/src/predicate.rs
+++ b/crates/polars-mem-engine/src/predicate.rs
@@ -33,6 +33,10 @@ pub struct ScanPredicate {
 
     /// Partial predicates for each column for filter when loading columnar formats.
     pub column_predicates: PhysicalColumnPredicates,
+
+    /// Predicate only referring to hive columns.
+    pub hive_predicate: Option<Arc<dyn PhysicalExpr>>,
+    pub hive_predicate_is_full_predicate: bool,
 }
 
 impl fmt::Debug for ScanPredicate {
@@ -162,7 +166,9 @@ impl ScanPredicate {
             live_columns: Arc::new(live_columns),
             skip_batch_predicate,
             column_predicates: self.column_predicates.clone(), // Q? Maybe this should cull
-                                                               // predicates.
+            // predicates.
+            hive_predicate: None,
+            hive_predicate_is_full_predicate: false,
         }
     }
 
@@ -198,6 +204,8 @@ impl ScanPredicate {
                     .collect(),
                 is_sumwise_complete: self.column_predicates.is_sumwise_complete,
             }),
+            hive_predicate: self.hive_predicate.clone().map(phys_expr_to_io_expr),
+            hive_predicate_is_full_predicate: self.hive_predicate_is_full_predicate,
         }
     }
 }

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/predicate.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/predicate.rs
@@ -1,13 +1,6 @@
 use arrow::bitmap::Bitmap;
-use polars_core::frame::DataFrame;
-use polars_core::prelude::{Column, IDX_DTYPE};
-use polars_core::scalar::Scalar;
-use polars_core::schema::Schema;
 use polars_error::PolarsResult;
 use polars_io::predicates::ScanIOPredicate;
-use polars_plan::plans::hive::HivePartitionsDf;
-use polars_utils::pl_str::PlSmallStr;
-use polars_utils::{IdxSize, format_pl_smallstr};
 
 use super::MultiScanTaskInitializer;
 
@@ -19,13 +12,35 @@ impl MultiScanTaskInitializer {
     pub fn initialize_predicate(&self) -> PolarsResult<(Option<Bitmap>, Option<&ScanIOPredicate>)> {
         if let Some(predicate) = &self.config.predicate {
             if let Some(hive_parts) = self.config.hive_parts.as_ref() {
-                let (skip_files_mask, need_pred_for_inner_readers) = scan_predicate_to_mask(
-                    predicate,
-                    self.config.projected_file_schema.as_ref(),
-                    hive_parts.schema(),
-                    hive_parts,
-                    self.config.verbose,
-                )?;
+                let mut skip_files_mask = None;
+
+                if let Some(predicate) = &predicate.hive_predicate {
+                    let mask = predicate
+                        .evaluate_io(hive_parts.df())?
+                        .bool()?
+                        .rechunk()
+                        .into_owned()
+                        .downcast_into_iter()
+                        .next()
+                        .unwrap()
+                        .values()
+                        .clone();
+
+                    // TODO: Optimize to avoid doing this
+                    let mask = !&mask;
+
+                    if self.config.verbose {
+                        eprintln!(
+                            "[MultiScan]: Predicate pushdown allows skipping {} / {} files",
+                            mask.set_bits(),
+                            mask.len()
+                        );
+                    }
+
+                    skip_files_mask = Some(mask);
+                }
+
+                let need_pred_for_inner_readers = !predicate.hive_predicate_is_full_predicate;
 
                 return Ok((
                     skip_files_mask,
@@ -36,92 +51,4 @@ impl MultiScanTaskInitializer {
 
         Ok((None, self.config.predicate.as_ref()))
     }
-}
-
-fn scan_predicate_to_mask(
-    scan_predicate: &ScanIOPredicate,
-    file_schema: &Schema,
-    hive_schema: &Schema,
-    hive_parts: &HivePartitionsDf,
-    verbose: bool,
-) -> PolarsResult<(Option<Bitmap>, bool)> {
-    let Some(sbp) = scan_predicate.skip_batch_predicate.as_ref() else {
-        return Ok((None, true));
-    };
-
-    let non_hive_live_columns = scan_predicate
-        .live_columns
-        .iter()
-        .filter(|lc| !hive_schema.contains(lc))
-        .collect::<Vec<_>>();
-
-    if non_hive_live_columns.len() == scan_predicate.live_columns.len() {
-        return Ok((None, true));
-    }
-
-    let mut statistics_columns =
-        Vec::with_capacity(1 + 3 * hive_schema.len() + 3 * non_hive_live_columns.len());
-
-    // We don't know the sizes of the files here yet.
-    statistics_columns.push(Column::new_scalar(
-        "len".into(),
-        Scalar::null(IDX_DTYPE),
-        hive_parts.df().height(),
-    ));
-    for column in hive_parts.df().get_columns() {
-        let c = column.name();
-
-        // If the hive value is not null, we know we have 0 nulls for the hive column in the file
-        // otherwise we don't know. Same reasoning as with the `len`.
-        let mut nc = Column::new_scalar(
-            format_pl_smallstr!("{c}_nc"),
-            (0 as IdxSize).into(),
-            hive_parts.df().height(),
-        );
-        if column.has_nulls() {
-            nc = nc.zip_with_same_type(
-                &column.is_null(),
-                &Column::new_scalar(PlSmallStr::EMPTY, Scalar::null(IDX_DTYPE), 1),
-            )?;
-        }
-
-        statistics_columns.extend([
-            column.clone().with_name(format_pl_smallstr!("{c}_min")),
-            column.clone().with_name(format_pl_smallstr!("{c}_max")),
-            nc,
-        ]);
-    }
-    for c in &non_hive_live_columns {
-        let dtype = file_schema.try_get(c)?;
-        statistics_columns.extend([
-            Column::full_null(
-                format_pl_smallstr!("{c}_min"),
-                hive_parts.df().height(),
-                dtype,
-            ),
-            Column::full_null(
-                format_pl_smallstr!("{c}_max"),
-                hive_parts.df().height(),
-                dtype,
-            ),
-            Column::full_null(
-                format_pl_smallstr!("{c}_nc"),
-                hive_parts.df().height(),
-                &IDX_DTYPE,
-            ),
-        ]);
-    }
-
-    let statistics_df = DataFrame::new(statistics_columns)?;
-    let mask = sbp.evaluate_with_stat_df(&statistics_df)?;
-
-    if verbose {
-        eprintln!(
-            "[MultiScan]: Predicate pushdown allows skipping {} / {} files",
-            mask.set_bits(),
-            mask.len()
-        );
-    }
-
-    Ok((Some(mask), !non_hive_live_columns.is_empty()))
 }

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -528,6 +528,7 @@ fn to_graph_rec<'a>(
                         pred,
                         ctx.expr_arena,
                         output_schema,
+                        hive_parts.as_ref().map(|hp| hp.df().schema().as_ref()),
                         &mut ctx.expr_conversion_state,
                         true, // create_skip_batch_predicate
                         file_reader_builder

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -740,6 +740,9 @@ def test_hive_partition_dates(tmp_path: Path) -> None:
             df.with_columns(pl.col("date1", "date2").cast(pl.String)),
         )
 
+        lf = pl.scan_parquet(root).filter(pl.col("date1") == datetime(2024, 1, 1))
+        assert_frame_equal(lf.collect(), df.head(1))
+
 
 @pytest.mark.parametrize(
     ("scan_func", "write_func"),

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -740,8 +740,48 @@ def test_hive_partition_dates(tmp_path: Path) -> None:
             df.with_columns(pl.col("date1", "date2").cast(pl.String)),
         )
 
-        lf = pl.scan_parquet(root).filter(pl.col("date1") == datetime(2024, 1, 1))
-        assert_frame_equal(lf.collect(), df.head(1))
+
+@pytest.mark.write_disk
+def test_hive_partition_filter_null_23005(tmp_path: Path) -> None:
+    root = tmp_path
+
+    df = pl.DataFrame(
+        {
+            "date1": [
+                datetime(2024, 1, 1),
+                datetime(2024, 2, 1),
+                datetime(2024, 3, 1),
+                None,
+            ],
+            "date2": [
+                datetime(2023, 1, 1),
+                datetime(2023, 2, 1),
+                None,
+                datetime(2023, 3, 1),
+            ],
+            "x": [1, 2, 3, 4],
+        },
+        schema={"date1": pl.Date, "date2": pl.Datetime, "x": pl.Int32},
+    )
+
+    df.write_parquet(root, partition_by=["date1", "date2"])
+
+    q = pl.scan_parquet(root, include_file_paths="path")
+
+    full = q.collect()
+
+    assert (
+        full.select(
+            (
+                pl.any_horizontal(pl.col("date1", "date2").is_null())
+                & pl.col("path").str.contains("__HIVE_DEFAULT_PARTITION__")
+            ).sum()
+        ).item()
+        == 2
+    )
+
+    lf = pl.scan_parquet(root).filter(pl.col("date1") == datetime(2024, 1, 1))
+    assert_frame_equal(lf.collect(), df.head(1))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/23005

We currently evaluate hive predicates using a `skip_batch_predicate` that was designed for parquet statistics. This is essentially an expression that operates on a `DataFrame` containing `{column}_min`, `{column}_max` columns.

The hive partitions were converted to such a `DataFrame`, however this is not compatible as `skip_batch_predicate` interprets NULL as "statistics are missing" and indicates that the data must be read, whereas in hive a NULL indicates that the actual row values are all NULL.

This PR changes it to directly use the original predicate expression. It is more of a quick fix as I am expecting to do larger refactors around predicate handling in the future for iceberg.
