### PR TITLE
feat(python): Return empty DataFrame when reading empty CSV file

### DIFF
--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
 @deprecate_renamed_parameter("dtypes", "schema_overrides", version="0.20.31")
 @deprecate_renamed_parameter("row_count_name", "row_index_name", version="0.20.4")
 @deprecate_renamed_parameter("row_count_offset", "row_index_offset", version="0.20.4")
+
 def read_csv(
     source: str | Path | IO[str] | IO[bytes] | bytes,
     *,
@@ -279,6 +280,11 @@ def read_csv(
 
     projection, columns = parse_columns_arg(columns)
     storage_options = storage_options or {}
+
+    if isinstance(source, (str, Path)):
+        path = Path(source)
+        if path.is_file() and path.stat().st_size == 0:
+            return pl.DataFrame()
 
     if columns and not has_header:
         for column in columns:

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -4,12 +4,14 @@ import gzip
 import io
 import os
 import sys
+import tempfile
 import textwrap
 import zlib
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal as D
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, TypedDict
+from pathlib import Path
 
 import numpy as np
 import pyarrow as pa
@@ -32,6 +34,18 @@ if TYPE_CHECKING:
 @pytest.fixture
 def foods_file_path(io_files_path: Path) -> Path:
     return io_files_path / "foods1.csv"
+
+def test_read_csv_returns_empty_df_on_empty_file():
+    # Create a temporary empty CSV file
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp:
+        empty_path = Path(tmp.name)
+
+    # Call the read_csv function
+    df = pl.read_csv(empty_path)
+
+    # Assertions
+    assert isinstance(df, pl.DataFrame), "Expected result to be a polars DataFrame"
+    assert df.shape == (0, 0), f"Expected empty DataFrame, got shape {df.shape}"
 
 
 def test_quoted_date() -> None:


### PR DESCRIPTION
This pull request addresses an issue where calling read_csv on an empty file could result in an error or unexpected behavior.
The fix ensures that if the input file is empty, a valid empty polars.DataFrame is returned instead of raising an exception.
