### PR TITLE
feat: Native implementation for Iceberg positional deletes

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -119,7 +119,9 @@ jobs:
         env:
           POLARS_FORCE_EMPTY_READER_CAPABILITIES: 1
           POLARS_TIMEOUT_MS: 60000
-        run: pytest -n auto -m "not release and not benchmark and not docs" tests/unit/io/test_multiscan.py
+        run: |
+          pytest -n auto -m "not release and not benchmark and not docs" tests/unit/io/test_multiscan.py
+          pytest -n auto -m "not release and not benchmark and not docs" tests/unit/io/test_scan_row_deletion.py
 
       - name: Check import without optional dependencies
         if: github.ref_name != 'main' && matrix.os == 'ubuntu-latest' && (matrix.python-version == '3.13' || matrix.python-version == '3.13t')

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
@@ -36,8 +36,7 @@ pub enum ApplyExtraOps {
         scan_source: ScanSource,
         scan_source_idx: usize,
         hive_parts: Option<Arc<HivePartitionsDf>>,
-        /// E.g. Iceberg deletion files. This should begin from the physical row position of the
-        /// first morsel sent by the reader.
+        /// E.g. Iceberg deletion files.
         external_filter_mask: Option<ExternalFilterMask>,
     },
 
@@ -275,7 +274,7 @@ impl ApplyExtraOps {
         if let Some(ri) = row_index {
             // Adjustment needed for `current_row_position`.
             let local_offset_adjustment = RowCounter::new(
-                // Number of physical rows skipped
+                // Number of physical rows skipped in the current function
                 local_slice_offset,
                 // How many of those skipped rows were deleted
                 external_filter_mask.as_ref().map_or(0, |mask| {

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
@@ -11,7 +11,6 @@ use polars_io::RowIndex;
 use polars_io::predicates::ScanIOPredicate;
 use polars_plan::dsl::ScanSource;
 use polars_plan::plans::hive::HivePartitionsDf;
-use polars_utils::IdxSize;
 use polars_utils::slice_enum::Slice;
 
 use super::ExtraOperations;
@@ -288,12 +287,9 @@ impl ApplyExtraOps {
             );
 
             let offset = ri.offset.saturating_add(
-                IdxSize::try_from(
-                    current_row_position
-                        .add(local_offset_adjustment)
-                        .num_rows()?,
-                )
-                .unwrap_or(IdxSize::MAX),
+                current_row_position
+                    .add(local_offset_adjustment)
+                    .num_rows_idxsize_saturating()?,
             );
 
             unsafe {

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/deletion_files.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/deletion_files.rs
@@ -313,7 +313,7 @@ impl ExternalFilterMask {
     pub fn slice(&self, offset: usize, len: usize) -> Self {
         match self {
             Self::IcebergPositionDelete { mask } => {
-                // This is not a valid index, it's also a sentinel value from `RowCounter::MAX`.
+                // This is not a valid offset, it's also a sentinel value from `RowCounter::MAX`.
                 assert_ne!(offset, usize::MAX);
                 let offset = offset.min(mask.len());
                 let len = len.min(mask.len() - offset);

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/mod.rs
@@ -1,4 +1,3 @@
-#[expect(unused)]
 pub mod deletion_files;
 pub mod predicate;
 pub mod projection;

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/slice.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/slice.rs
@@ -1,26 +1,33 @@
 use std::collections::VecDeque;
 
 use futures::StreamExt;
+use polars_core::prelude::{InitHashMaps, PlHashMap};
 use polars_error::PolarsResult;
 use polars_io::RowIndex;
-use polars_utils::IdxSize;
 use polars_utils::slice_enum::Slice;
 
+use super::deletion_files::{DeletionFilesProvider, ExternalFilterMask};
 use crate::async_executor::{self, AbortOnDropHandle, TaskPriority};
 use crate::nodes::io_sources::multi_file_reader::MultiFileReaderConfig;
 use crate::nodes::io_sources::multi_file_reader::reader_interface::FileReader;
+use crate::nodes::io_sources::multi_file_reader::row_counter::RowCounter;
 
 pub struct ResolvedSliceInfo {
+    /// In the negative slice case this can be a non-zero starting position.
     pub scan_source_idx: usize,
+    /// In the negative slice case this will hold a row index with the offset adjusted.
     pub row_index: Option<RowIndex>,
-    /// This should always be positive slice.
+    /// Resolved positive slice.
     pub pre_slice: Option<Slice>,
     /// If we resolved a negative slice we keep the initialized readers here (with a limit). For
     /// Parquet this can save a duplicate metadata fetch/decode.
     ///
     /// This will be in-order - i.e. `pop_front()` corresponds to the next reader.
+    ///
+    /// `Option(scan_source_idx, Deque(file_reader, n_rows))`
     #[expect(clippy::type_complexity)]
-    pub initialized_readers: Option<(usize, VecDeque<(Box<dyn FileReader>, IdxSize)>)>,
+    pub initialized_readers: Option<(usize, VecDeque<(Box<dyn FileReader>, RowCounter)>)>,
+    pub row_deletions: PlHashMap<usize, ExternalFilterMask>,
 }
 
 pub async fn resolve_to_positive_slice(
@@ -32,6 +39,7 @@ pub async fn resolve_to_positive_slice(
             row_index: config.row_index.clone(),
             pre_slice: None,
             initialized_readers: None,
+            row_deletions: Default::default(),
         }),
 
         pre_slice @ Some(Slice::Positive { .. }) => Ok(ResolvedSliceInfo {
@@ -39,6 +47,7 @@ pub async fn resolve_to_positive_slice(
             row_index: config.row_index.clone(),
             pre_slice,
             initialized_readers: None,
+            row_deletions: Default::default(),
         }),
 
         Some(_) => resolve_negative_slice(config).await,
@@ -74,14 +83,21 @@ async fn resolve_negative_slice(config: &MultiFileReaderConfig) -> PolarsResult<
             row_index: config.row_index.clone(),
             pre_slice: Some(Slice::Positive { offset: 0, len: 0 }),
             initialized_readers: None,
+            row_deletions: Default::default(),
         });
     }
 
-    let mut initialized_readers = VecDeque::with_capacity(
+    let deletion_files_provider = DeletionFilesProvider::new(config.deletion_files.clone());
+    let num_pipelines = config.num_pipelines();
+
+    let mut initialized_readers =
+        VecDeque::with_capacity(config.sources.len().min(num_pipelines.saturating_add(4)));
+    let mut file_row_deletions = PlHashMap::with_capacity(
         config
-            .sources
-            .len()
-            .min(config.num_pipelines().saturating_add(4)),
+            .deletion_files
+            .as_ref()
+            .map_or(0, |x| x.num_files_with_deletions())
+            .min(num_pipelines.saturating_add(4)),
     );
 
     let mut readers_init_iter = futures::stream::iter((0..config.sources.len()).rev())
@@ -89,6 +105,7 @@ async fn resolve_negative_slice(config: &MultiFileReaderConfig) -> PolarsResult<
             let sources = config.sources.clone();
             let cloud_options = config.cloud_options.clone();
             let file_reader_builder = config.file_reader_builder.clone();
+            let deletion_files_provider = deletion_files_provider.clone();
 
             AbortOnDropHandle::new(async_executor::spawn(TaskPriority::Low, async move {
                 let mut reader =
@@ -108,59 +125,80 @@ async fn resolve_negative_slice(config: &MultiFileReaderConfig) -> PolarsResult<
                     eprintln!("resolve_negative_slice(): init scan source {scan_source_idx}");
                 }
 
+                let row_deletions = deletion_files_provider.spawn_row_deletions_init(
+                    scan_source_idx,
+                    cloud_options,
+                    num_pipelines,
+                    verbose,
+                );
+
                 reader.initialize().await?;
-                PolarsResult::Ok(reader)
+                PolarsResult::Ok((scan_source_idx, reader, row_deletions))
             }))
         })
         .buffered(config.n_readers_pre_init());
 
-    let n_rows_needed = IdxSize::try_from(offset_from_end).unwrap();
-    let slice_len_idxsize = IdxSize::try_from(slice_len).unwrap_or(IdxSize::MAX);
+    let n_rows_needed: usize = offset_from_end;
 
-    let mut n_rows_seen: IdxSize = 0;
-    let mut n_rows_trimmed: IdxSize = 0;
+    let mut n_rows_seen: RowCounter = RowCounter::default();
+    let mut n_rows_trimmed: RowCounter = RowCounter::default();
     let mut n_files_from_end: usize = 0;
 
-    while let Some(mut file_reader) = readers_init_iter.next().await.transpose()? {
+    while let Some((scan_source_idx, mut file_reader, row_deletions)) =
+        readers_init_iter.next().await.transpose()?
+    {
         let n_rows = file_reader.n_rows_in_file().await?;
 
+        let n_rows_deleted = if let Some(row_deletions) = row_deletions {
+            let mask = row_deletions.into_external_filter_mask().await?;
+            let n_rows_deleted = mask.num_deleted_rows();
+
+            file_row_deletions.insert(scan_source_idx, mask.clone());
+
+            n_rows_deleted
+        } else {
+            0
+        };
+
+        let n_rows_this_file = RowCounter::new(n_rows, n_rows_deleted);
+
         // push_front: we are walking in reverse
-        initialized_readers.push_front((file_reader, n_rows));
+        initialized_readers.push_front((file_reader, n_rows_this_file));
 
-        n_rows_seen = n_rows_seen.saturating_add(n_rows);
+        n_rows_seen = n_rows_seen.add(n_rows_this_file);
         n_files_from_end += 1;
-
-        let n_rows_this_file = n_rows;
 
         // Trim readers from end that are already past slice_len.
         while initialized_readers.len() > 1 {
             // `current_rows_held` we exclude the latest file, as the slice offset could begin
             // from any position within that file, meaning that the file could have extra rows
             // that do not contribute to the slice_len.
-            let current_rows_held = n_rows_seen - n_rows_trimmed.saturating_add(n_rows_this_file);
-            let extra_rows_held = current_rows_held.saturating_sub(slice_len_idxsize);
+            let current_rows_held = n_rows_seen.sub(n_rows_this_file.add(n_rows_trimmed));
+            let extra_rows_held = current_rows_held.num_rows()?.saturating_sub(slice_len);
 
-            if extra_rows_held < initialized_readers.back().unwrap().1 {
+            if extra_rows_held < initialized_readers.back().unwrap().1.num_rows()? {
                 break;
             }
 
-            n_rows_trimmed =
-                n_rows_trimmed.saturating_add(initialized_readers.pop_back().unwrap().1)
+            let (_reader, row_counter) = initialized_readers.pop_back().unwrap();
+
+            n_rows_trimmed = n_rows_trimmed.add(row_counter)
         }
 
-        if n_rows_seen >= n_rows_needed {
+        if n_rows_seen.num_rows()? >= n_rows_needed {
             break;
         }
     }
 
     let scan_source_idx = config.sources.len() - n_files_from_end;
     let initialized_readers = Some((scan_source_idx, initialized_readers));
-    let resolved_slice = pre_slice.restrict_to_bounds(usize::try_from(n_rows_seen).unwrap());
+    let resolved_slice = pre_slice.restrict_to_bounds(n_rows_seen.num_rows()?);
 
     if verbose {
         eprintln!(
-            "resolve_negative_slice(): resolved to {:?}",
-            &resolved_slice,
+            "resolve_negative_slice(): \
+            resolved to {resolved_slice:?}, \
+            n_rows_seen: {n_rows_seen:?}"
         );
     }
 
@@ -170,6 +208,7 @@ async fn resolve_negative_slice(config: &MultiFileReaderConfig) -> PolarsResult<
             row_index: config.row_index.clone(),
             pre_slice: Some(Slice::Positive { offset: 0, len: 0 }),
             initialized_readers: None,
+            row_deletions: Default::default(),
         });
     }
 
@@ -180,15 +219,29 @@ async fn resolve_negative_slice(config: &MultiFileReaderConfig) -> PolarsResult<
             eprintln!("resolve_negative_slice(): continuing scan to resolve row index");
         }
 
-        let mut n_rows_skipped_from_start: IdxSize = 0;
+        let mut n_rows_skipped_from_start = RowCounter::default();
 
         // Fully traverse to the beginning to update the row index offset.
-        while let Some(mut reader) = readers_init_iter.next().await.transpose()? {
+        while let Some((_scan_source_idx, mut reader, row_deletions)) =
+            readers_init_iter.next().await.transpose()?
+        {
             let n_rows = reader.n_rows_in_file().await?;
-            n_rows_skipped_from_start = n_rows_skipped_from_start.saturating_add(n_rows);
+
+            let row_deletions = if let Some(row_deletions) = row_deletions {
+                Some(row_deletions.into_external_filter_mask().await?)
+            } else {
+                None
+            };
+
+            let n_rows_deleted = row_deletions.map_or(0, |x| x.num_deleted_rows());
+
+            n_rows_skipped_from_start =
+                n_rows_skipped_from_start.add(RowCounter::new(n_rows, n_rows_deleted));
         }
 
-        row_index.offset = row_index.offset.saturating_add(n_rows_skipped_from_start);
+        row_index.offset = row_index
+            .offset
+            .saturating_add(n_rows_skipped_from_start.num_rows_idxsize_saturating()?);
     }
 
     Ok(ResolvedSliceInfo {
@@ -196,5 +249,6 @@ async fn resolve_negative_slice(config: &MultiFileReaderConfig) -> PolarsResult<
         row_index,
         pre_slice: Some(resolved_slice),
         initialized_readers,
+        row_deletions: file_row_deletions,
     })
 }

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/mod.rs
@@ -4,7 +4,6 @@ pub mod initialization;
 pub mod post_apply_pipeline;
 pub mod reader_interface;
 pub mod reader_pipelines;
-#[expect(unused)]
 pub mod row_counter;
 
 use std::sync::atomic::AtomicUsize;
@@ -17,6 +16,7 @@ use polars_error::PolarsResult;
 use polars_io::cloud::CloudOptions;
 use polars_io::predicates::ScanIOPredicate;
 use polars_io::{RowIndex, pl_async};
+use polars_plan::dsl::deletion::DeletionFilesList;
 use polars_plan::dsl::{CastColumnsPolicy, ExtraColumnsPolicy, MissingColumnsPolicy, ScanSources};
 use polars_plan::plans::hive::HivePartitionsDf;
 use polars_utils::format_pl_smallstr;
@@ -56,6 +56,7 @@ pub struct MultiFileReaderConfig {
     pub missing_columns_policy: MissingColumnsPolicy,
     pub extra_columns_policy: ExtraColumnsPolicy,
     pub cast_columns_policy: CastColumnsPolicy,
+    pub deletion_files: Option<DeletionFilesList>,
 
     pub num_pipelines: AtomicUsize,
     /// Number of readers to initialize concurrently. e.g. Parquet will want to fetch metadata in this

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/post_apply_pipeline/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/post_apply_pipeline/mod.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
 use polars_error::PolarsResult;
-use polars_utils::IdxSize;
+use polars_utils::slice_enum::Slice;
 
+use super::row_counter::RowCounter;
 use crate::async_executor::{self, AbortOnDropHandle, TaskPriority};
 use crate::async_primitives::distributor_channel::distributor_channel;
 use crate::async_primitives::morsel_linearizer::MorselLinearizer;
@@ -10,88 +11,135 @@ use crate::morsel::Morsel;
 use crate::nodes::io_sources::multi_file_reader::extra_ops::apply::ApplyExtraOps;
 use crate::nodes::io_sources::multi_file_reader::reader_interface::output::FileReaderOutputRecv;
 
-pub fn spawn_post_apply_pipeline(
-    mut reader_port: FileReaderOutputRecv,
-    ops_applier: Arc<ApplyExtraOps>,
-    // We have this because initialization of `ops_applier` causes `reader_port` to have the
-    // first morsel consumed.
-    first_morsel: Morsel,
-    num_pipelines: usize,
-) -> (MorselLinearizer, AbortOnDropHandle<PolarsResult<()>>) {
-    let (mut distr_tx, distr_receivers) = distributor_channel(num_pipelines, 1);
+pub struct PostApplyPipeline {
+    pub reader_output_port: FileReaderOutputRecv,
+    pub ops_applier: Arc<ApplyExtraOps>,
+    /// We have this because initialization of `ops_applier` causes `reader_output_port` to have the
+    /// first morsel consumed.
+    pub first_morsel: Morsel,
+    pub first_morsel_position: RowCounter,
+    pub num_pipelines: usize,
+}
 
-    // Distributor
-    {
-        let ops_applier = ops_applier.clone();
-        async_executor::spawn(TaskPriority::Low, async move {
-            // Number of rows received from this reader.
-            let mut n_rows_received: IdxSize = 0;
+impl PostApplyPipeline {
+    pub fn run(self) -> (MorselLinearizer, AbortOnDropHandle<PolarsResult<()>>) {
+        let PostApplyPipeline {
+            mut reader_output_port,
+            ops_applier,
+            first_morsel,
+            first_morsel_position,
+            num_pipelines,
+        } = self;
 
-            let mut morsel = first_morsel;
+        let (mut distr_tx, distr_receivers) = distributor_channel(num_pipelines, 1);
 
-            // Should only run the pipeline if we have an operation we need to apply.
-            let ApplyExtraOps::Initialized { pre_slice, .. } = ops_applier.as_ref() else {
-                unreachable!();
-            };
+        // Distributor
+        {
+            let ops_applier = ops_applier.clone();
+            async_executor::spawn(TaskPriority::Low, async move {
+                // Position tracking
+                let mut row_counter: RowCounter = first_morsel_position;
 
-            loop {
-                let h = morsel.df().height();
-                let h = IdxSize::try_from(h).unwrap_or(IdxSize::MAX);
+                let mut morsel = first_morsel;
 
-                // We hit this if a reader does not support PRE_SLICE.
-                if pre_slice.clone().is_some_and(|x| {
-                    x.offsetted(usize::try_from(n_rows_received).unwrap()).len() == 0
-                }) {
-                    // Note: We do not return any flag indicating that we have reached end of slice
-                    // from this context. The read should be stopped on a higher level by using
-                    // the `row_position_on_end_tx` callback from the reader.
-                    break;
-                }
-
-                if distr_tx.send((morsel, n_rows_received)).await.is_err() {
-                    break;
-                }
-
-                n_rows_received = n_rows_received.saturating_add(h);
-
-                let Ok(v) = reader_port.recv().await else {
-                    break;
+                // Should only run the pipeline if we have an operation we need to apply.
+                let ApplyExtraOps::Initialized {
+                    physical_pre_slice,
+                    external_filter_mask,
+                    ..
+                } = ops_applier.as_ref()
+                else {
+                    unreachable!();
                 };
 
-                morsel = v;
-            }
-        })
-    };
+                assert!(
+                    physical_pre_slice
+                        .as_ref()
+                        .is_none_or(|x| matches!(x, Slice::Positive { .. }))
+                );
 
-    let (rx, senders) = MorselLinearizer::new(num_pipelines, 4);
+                loop {
+                    // Note that we technically won't have the real physical / deleted counts if the
+                    // reader has already performed row deletions, we would instead have:
+                    // * physical_rows: (actual_physical_rows - deleted_rows)
+                    // * deleted_rows: 0
+                    //
+                    // But that's perfectly fine, as the `RowCounter` will still give the correct
+                    // `num_rows()`. The downstream pipeline in this case will behave as if there
+                    // were no row deletions at all, which should still give the correct result.
+                    let row_count_this_morsel = {
+                        let physical_rows = morsel.df().height();
+                        let deleted_rows = external_filter_mask.as_ref().map_or(0, |mask| {
+                            let Slice::Positive { offset, len } = Slice::Positive {
+                                offset: row_counter.num_physical_rows(),
+                                len: morsel.df().height(),
+                            }
+                            .restrict_to_bounds(mask.len()) else {
+                                unreachable!()
+                            };
 
-    let worker_handles = distr_receivers
-        .into_iter()
-        .zip(senders)
-        .map(|(mut morsel_rx, mut morsel_tx)| {
-            let ops_applier = ops_applier.clone();
+                            mask.slice(offset, len).num_deleted_rows()
+                        });
 
-            AbortOnDropHandle::new(async_executor::spawn(TaskPriority::Low, async move {
-                while let Ok((mut morsel, row_offset)) = morsel_rx.recv().await {
-                    ops_applier.apply_to_df(morsel.df_mut(), row_offset)?;
+                        RowCounter::new(physical_rows, deleted_rows)
+                    };
 
-                    if morsel_tx.insert(morsel).await.is_err() {
+                    // We hit this if a reader does not support PRE_SLICE.
+                    if physical_pre_slice
+                        .clone()
+                        .is_some_and(|x| x.offsetted(row_counter.num_physical_rows()).len() == 0)
+                    {
+                        // Note: We do not return any flag indicating that we have reached end of slice
+                        // from this context. The read should be stopped on a higher level by using
+                        // the `row_position_on_end_tx` callback from the reader.
                         break;
                     }
+
+                    if distr_tx.send((morsel, row_counter)).await.is_err() {
+                        break;
+                    }
+
+                    row_counter = row_counter.add(row_count_this_morsel);
+
+                    let Ok(v) = reader_output_port.recv().await else {
+                        break;
+                    };
+
+                    morsel = v;
                 }
+            })
+        };
 
-                PolarsResult::Ok(())
-            }))
-        })
-        .collect::<Vec<_>>();
+        let (rx, senders) = MorselLinearizer::new(num_pipelines, 4);
 
-    let handle = AbortOnDropHandle::new(async_executor::spawn(TaskPriority::Low, async move {
-        for handle in worker_handles {
-            handle.await?;
-        }
+        let worker_handles = distr_receivers
+            .into_iter()
+            .zip(senders)
+            .map(|(mut morsel_rx, mut morsel_tx)| {
+                let ops_applier = ops_applier.clone();
 
-        Ok(())
-    }));
+                AbortOnDropHandle::new(async_executor::spawn(TaskPriority::Low, async move {
+                    while let Ok((mut morsel, row_offset)) = morsel_rx.recv().await {
+                        ops_applier.apply_to_df(morsel.df_mut(), row_offset)?;
 
-    (rx, handle)
+                        if morsel_tx.insert(morsel).await.is_err() {
+                            break;
+                        }
+                    }
+
+                    PolarsResult::Ok(())
+                }))
+            })
+            .collect::<Vec<_>>();
+
+        let handle = AbortOnDropHandle::new(async_executor::spawn(TaskPriority::Low, async move {
+            for handle in worker_handles {
+                handle.await?;
+            }
+
+            Ok(())
+        }));
+
+        (rx, handle)
+    }
 }

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/mod.rs
@@ -65,7 +65,6 @@ pub trait FileReader: Send + Sync {
     }
 
     /// Returns `Some(_)` if the row count is cheaply retrievable.
-    #[expect(unused)]
     async fn fast_n_rows_in_file(&mut self) -> PolarsResult<Option<IdxSize>> {
         Ok(None)
     }

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
@@ -433,7 +433,8 @@ impl ReaderStarter {
                         PhysicalSlice::new(pre_slice, external_filter_mask.as_ref())
                     },
 
-                    // This is hit here for NDJSON single file negative slice
+                    // This is hit here for NDJSON single file negative slice, we just passthrough
+                    // in this case.
                     Slice::Negative { .. } => {
                         if external_filter_mask.is_some() {
                             unimplemented!(

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
@@ -513,16 +513,6 @@ impl ReaderStarter {
                 ..extra_ops.clone()
             };
 
-            let (row_position_on_end_tx, row_position_on_end_rx) = if n_rows_in_file.is_none()
-                && extra_ops.has_row_index_or_slice()
-                && n_sources - scan_source_idx > 1
-            {
-                let (tx, rx) = connector::connector();
-                (Some(tx), Some(rx))
-            } else {
-                (None, None)
-            };
-
             let mut skip_read = false;
 
             // `fast_n_rows_in_file()` we know the exact row count here already.
@@ -557,6 +547,16 @@ impl ReaderStarter {
                     skip_read = true;
                 }
             }
+
+            let (row_position_on_end_tx, row_position_on_end_rx) = if n_rows_in_file.is_none()
+                && extra_ops.has_row_index_or_slice()
+                && n_sources - scan_source_idx > 1
+            {
+                let (tx, rx) = connector::connector();
+                (Some(tx), Some(rx))
+            } else {
+                (None, None)
+            };
 
             if skip_read {
                 if started_reader_tx.is_closed() {

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
@@ -1080,7 +1080,17 @@ struct PhysicalSlice {
 impl PhysicalSlice {
     fn new(slice: Slice, external_filter_mask: Option<&ExternalFilterMask>) -> Self {
         if let Slice::Negative { .. } = slice {
-            Self::_new_negative(slice, external_filter_mask)
+            if external_filter_mask.is_some() {
+                unimplemented!(
+                    "{slice:?} {}",
+                    ExternalFilterMask::log_display(external_filter_mask)
+                )
+            }
+
+            PhysicalSlice {
+                slice,
+                slice_start_position: RowCounter::default(),
+            }
         } else if let Some(external_filter_mask) = external_filter_mask {
             let requested_offset = slice.positive_offset();
 
@@ -1102,21 +1112,6 @@ impl PhysicalSlice {
                 slice,
                 slice_start_position,
             }
-        }
-    }
-
-    #[cold]
-    fn _new_negative(slice: Slice, external_filter_mask: Option<&ExternalFilterMask>) -> Self {
-        if external_filter_mask.is_some() {
-            unimplemented!(
-                "{slice:?} {}",
-                ExternalFilterMask::log_display(external_filter_mask)
-            )
-        }
-
-        PhysicalSlice {
-            slice,
-            slice_start_position: RowCounter::default(),
         }
     }
 }

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
@@ -523,6 +523,7 @@ impl ReaderStarter {
 
             let mut skip_read = false;
 
+            // `fast_n_rows_in_file()` we know the exact row count here already.
             if let Some(n_rows_in_file) = n_rows_in_file.as_mut() {
                 if let Some(external_filter_mask) = external_filter_mask.as_ref() {
                     unsafe {

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
@@ -1007,7 +1007,9 @@ impl ReaderOperationPushdown<'_> {
         let unsupported_external_filter_mask = external_filter_mask.is_some()
             && !reader_capabilities.contains(ReaderCapabilities::EXTERNAL_FILTER_MASK);
 
-        // Note, the order in which we do this is important here.
+        // Notes
+        // * If there is both a slice and deletions, DO NOT push deletions to the reader without
+        //   pushing the slice.
 
         let row_index = if !unsupported_external_filter_mask
             && reader_capabilities.contains(ReaderCapabilities::ROW_INDEX)

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
@@ -492,7 +492,8 @@ impl ReaderStarter {
                 if verbose {
                     eprintln!(
                         "[ReaderStarter]: scan_source_idx: {scan_source_idx}: \
-                        skip read ({skip_read_reason}): {n_rows_in_file:?}, \
+                        skip read ({skip_read_reason}): \
+                        n_rows_in_file: {n_rows_in_file:?}, \
                         pre_slice: {pre_slice_this_file:?}"
                     )
                 }

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
@@ -592,8 +592,8 @@ impl ReaderStarter {
             if verbose {
                 eprintln!(
                     "[ReaderStarter]: scan_source_idx: {scan_source_idx}: \
-                        pre_slice_to_reader: {pre_slice:?}, \
-                        external_filter_mask: {}",
+                    pre_slice_to_reader: {pre_slice:?}, \
+                    external_filter_mask: {}",
                     ExternalFilterMask::log_display(external_filter_mask.as_ref()),
                 )
             }

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
@@ -648,6 +648,7 @@ impl ReaderStarter {
                         break;
                     };
 
+                    // Note, can be None on the last scan source.
                     let Some(mut rx) = row_position_on_end_rx else {
                         break;
                     };

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
@@ -536,11 +536,21 @@ impl ReaderStarter {
                 }
 
                 // Potentially skip reading the file entirely if all of the rows are deleted.
-                if n_rows_in_file.num_rows()? == 0 {
+                if n_rows_in_file.num_rows()? == 0
+                    || pre_slice_this_file.as_ref().is_some_and(|phys_slice| {
+                        phys_slice
+                            .slice
+                            .clone()
+                            .restrict_to_bounds(n_rows_in_file.num_physical_rows())
+                            .len()
+                            == 0
+                    })
+                {
                     if verbose {
                         eprintln!(
                             "[ReaderStarter]: scan_source_idx: {scan_source_idx}: \
-                            skip read (0 rows): {n_rows_in_file:?}"
+                            skip read (0 rows): {n_rows_in_file:?}, \"
+                            pre_slice: {pre_slice_this_file:?}"
                         )
                     }
 

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
@@ -492,7 +492,7 @@ impl ReaderStarter {
                 if verbose {
                     eprintln!(
                         "[ReaderStarter]: scan_source_idx: {scan_source_idx}: \
-                        skip read ({skip_read_reason}): {n_rows_in_file:?}, \"
+                        skip read ({skip_read_reason}): {n_rows_in_file:?}, \
                         pre_slice: {pre_slice_this_file:?}"
                     )
                 }

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/row_counter.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/row_counter.rs
@@ -150,6 +150,7 @@ impl RowCounter {
     }
 
     #[inline]
+    #[expect(unused)]
     pub fn num_physical_rows_idxsize_saturating(&self) -> IdxSize {
         IdxSize::try_from(self.physical_rows).unwrap_or(IdxSize::MAX)
     }

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/row_counter.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/row_counter.rs
@@ -70,6 +70,10 @@ impl RowCounter {
         self.num_rows().unwrap();
     }
 
+    /// Performs a saturating add if there are no deleted rows, otherwise performs a checked add.
+    ///
+    /// # Panics
+    /// Panics if there are deleted rows and addition overflows.
     #[inline]
     pub fn add(self, other: Self) -> Self {
         (|| {

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -556,13 +556,6 @@ fn to_graph_rec<'a>(
             let cast_columns_policy = cast_columns_policy.clone();
             let deletion_files = deletion_files.clone();
 
-            if deletion_files.is_some() {
-                polars_bail!(
-                    ComputeError: "not implemented: deletion files {:?}",
-                    deletion_files
-                )
-            }
-
             let verbose = config::verbose();
 
             ctx.graph.add_node(
@@ -582,6 +575,7 @@ fn to_graph_rec<'a>(
                         missing_columns_policy,
                         extra_columns_policy,
                         cast_columns_policy,
+                        deletion_files,
                         // Initialized later
                         num_pipelines: AtomicUsize::new(0),
                         n_readers_pre_init: AtomicUsize::new(0),
@@ -1014,6 +1008,7 @@ fn to_graph_rec<'a>(
             let missing_columns_policy = MissingColumnsPolicy::Raise;
             let extra_columns_policy = ExtraColumnsPolicy::Ignore;
             let cast_columns_policy = CastColumnsPolicy::ERROR_ON_MISMATCH;
+            let deletion_files = None;
             let verbose = config::verbose();
 
             ctx.graph.add_node(
@@ -1033,6 +1028,7 @@ fn to_graph_rec<'a>(
                         missing_columns_policy,
                         extra_columns_policy,
                         cast_columns_policy,
+                        deletion_files,
                         // Initialized later
                         num_pipelines: AtomicUsize::new(0),
                         n_readers_pre_init: AtomicUsize::new(0),

--- a/py-polars/tests/unit/io/test_scan_row_deletion.py
+++ b/py-polars/tests/unit/io/test_scan_row_deletion.py
@@ -280,7 +280,7 @@ def test_scan_row_deletion_single_large(
 
     deletion_positions_path = write_position_deletes(positions)
 
-    script_args = [
+    script_args: list[str] = [
         str(ideal_morsel_size),
         "1" if force_empty_capabilities else "0",
         str(path),

--- a/py-polars/tests/unit/io/test_scan_row_deletion.py
+++ b/py-polars/tests/unit/io/test_scan_row_deletion.py
@@ -256,6 +256,7 @@ def test_scan_row_deletions(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.write_disk
 @pytest.mark.parametrize("ideal_morsel_size", [999, 50, 33])
 @pytest.mark.parametrize("force_empty_capabilities", [True, False])

--- a/py-polars/tests/unit/io/test_scan_row_deletion.py
+++ b/py-polars/tests/unit/io/test_scan_row_deletion.py
@@ -346,7 +346,7 @@ print("OK", end="")
 
 
 @pytest.mark.write_disk
-def test_scan_row_deletion_file_read_skipped_if_all_rows_deleted(
+def test_scan_row_deletion_skips_file_with_all_rows_deleted(
     tmp_path: Path,
     write_position_deletes: WritePositionDeletes,
 ) -> None:

--- a/py-polars/tests/unit/io/test_scan_row_deletion.py
+++ b/py-polars/tests/unit/io/test_scan_row_deletion.py
@@ -1,0 +1,433 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(scope="session")
+def data_files_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Creates: 5 parquet files, 5 rows each."""
+    tmp_path = tmp_path_factory.mktemp("data-files")
+    _create_data_files(tmp_path)
+
+    return tmp_path
+
+
+@pytest.fixture
+def write_position_deletes(tmp_path: Path) -> WritePositionDeletes:
+    return WritePositionDeletes(tmp_path=tmp_path)
+
+
+class WritePositionDeletes:  # noqa: D101
+    def __init__(self, *, tmp_path: Path) -> None:
+        self.tmp_path = tmp_path
+        self.i = 0
+
+    def __call__(self, positions: pl.Series) -> str:
+        path = self.tmp_path / f"{self.i}"
+
+        (
+            positions.alias("pos")
+            .to_frame()
+            .select(pl.lit("").alias("file_path"), "pos")
+            .write_parquet(path)
+        )
+
+        self.i += 1
+
+        return str(path)
+
+
+# 5 files x 5 rows each. Contains `physical_index` [0, 1, .., 24].
+def _create_data_files(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True, parents=True)
+    df = pl.select(physical_index=pl.int_range(25, dtype=pl.UInt32))
+
+    parts = []
+
+    for i in [0, 5, 10, 15, 20]:
+        O = "0" if i < 10 else ""  # noqa: E741
+        path = tmp_path / f"offset={O}{i}/data.parquet"
+        path.parent.mkdir(exist_ok=True, parents=True)
+
+        part_df = df.slice(i, 5)
+        part_df.write_parquet(path)
+
+        parts.append(part_df.with_columns(offset=pl.lit(i, dtype=pl.Int64)))
+
+    assert_frame_equal(pl.scan_parquet(tmp_path).collect(), pl.concat(parts))
+
+
+@pytest.mark.parametrize("row_index_offset", [0, 27, 38, 73])
+def test_scan_row_deletions(
+    data_files_path: Path,
+    write_position_deletes: WritePositionDeletes,
+    row_index_offset: int,
+) -> None:
+    deletion_files = (
+        "iceberg-position-delete",
+        {
+            0: [
+                write_position_deletes(pl.Series([1, 2])),
+            ],
+            1: [
+                write_position_deletes(pl.Series([0, 1, 2])),
+            ],
+            4: [
+                write_position_deletes(pl.Series([2, 3])),
+            ],
+        },
+    )
+
+    def apply_row_index_offset(values: list[int]) -> list[int]:
+        return [x + row_index_offset for x in values]
+
+    q = pl.scan_parquet(
+        data_files_path,
+        _deletion_files=deletion_files,  # type: ignore[arg-type]
+        hive_partitioning=False,
+    ).with_row_index(offset=row_index_offset)
+
+    assert q.select(pl.len()).collect().item() == 18
+
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            {
+                "index": apply_row_index_offset([
+                    0, 1, 2,
+                    3, 4,
+                    5, 6, 7, 8, 9,
+                    10, 11, 12, 13, 14,
+                    15, 16, 17
+                ]),
+                "physical_index": [
+                    0, 3, 4,
+                    8, 9,
+                    10, 11, 12, 13, 14,
+                    15, 16, 17, 18, 19,
+                    20, 21, 24
+                ],
+            },
+            schema={"index": pl.get_index_type(), "physical_index": pl.UInt32},
+        )
+    )  # fmt: skip
+
+    # head()
+
+    assert_frame_equal(
+        q.head(3).collect(),
+        pl.DataFrame(
+            {
+                "index": apply_row_index_offset([0, 1, 2]),
+                "physical_index": [0, 3, 4],
+            },
+            schema={"index": pl.get_index_type(), "physical_index": pl.UInt32},
+        ),
+    )
+
+    assert_frame_equal(
+        q.head(10).collect(),
+        pl.DataFrame(
+            {
+                "index": apply_row_index_offset([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+                "physical_index": [0, 3, 4, 8, 9, 10, 11, 12, 13, 14],
+            },
+            schema={"index": pl.get_index_type(), "physical_index": pl.UInt32},
+        ),
+    )
+
+    # tail()
+
+    assert_frame_equal(
+        q.tail(3).collect(),
+        pl.DataFrame(
+            {
+                "index": apply_row_index_offset([15, 16, 17]),
+                "physical_index": [20, 21, 24],
+            },
+            schema={"index": pl.get_index_type(), "physical_index": pl.UInt32},
+        ),
+    )
+
+    assert_frame_equal(
+        q.tail(10).collect(),
+        pl.DataFrame(
+            {
+                "index": apply_row_index_offset(
+                    [8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
+                ),
+                "physical_index": [
+                    13, 14, 15, 16, 17, 18, 19, 20, 21,
+                    24
+                ],
+            },
+            schema={"index": pl.get_index_type(), "physical_index": pl.UInt32},
+        ),
+    )  # fmt: skip
+
+    # slice(positive_offset)
+
+    assert_frame_equal(
+        q.slice(2, 10).collect(),
+        pl.DataFrame(
+            {
+                "index": apply_row_index_offset([2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+                "physical_index": [4, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+            },
+            schema={"index": pl.get_index_type(), "physical_index": pl.UInt32},
+        ),
+    )
+
+    assert_frame_equal(
+        q.slice(5, 10).collect(),
+        pl.DataFrame(
+            {
+                "index": apply_row_index_offset([5, 6, 7, 8, 9, 10, 11, 12, 13, 14]),
+                "physical_index": [10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
+            },
+            schema={"index": pl.get_index_type(), "physical_index": pl.UInt32},
+        ),
+    )
+
+    assert_frame_equal(
+        q.slice(10, 10).collect(),
+        pl.DataFrame(
+            {
+                "index": apply_row_index_offset([10, 11, 12, 13, 14, 15, 16, 17]),
+                "physical_index": [15, 16, 17, 18, 19, 20, 21, 24],
+            },
+            schema={"index": pl.get_index_type(), "physical_index": pl.UInt32},
+        ),
+    )
+
+    # slice(negative_offset)
+    assert_frame_equal(
+        q.slice(-3, 2).collect(),
+        pl.DataFrame(
+            {
+                "index": apply_row_index_offset([15, 16]),
+                "physical_index": [20, 21],
+            },
+            schema={"index": pl.get_index_type(), "physical_index": pl.UInt32},
+        ),
+    )
+
+    assert_frame_equal(
+        q.slice(-23, 10).collect(),
+        pl.DataFrame(
+            {
+                "index": apply_row_index_offset([0, 1, 2, 3, 4]),
+                "physical_index": [0, 3, 4, 8, 9],
+            },
+            schema={"index": pl.get_index_type(), "physical_index": pl.UInt32},
+        ),
+    )
+
+    # filter: skip_files
+    q = pl.scan_parquet(
+        data_files_path,
+        _deletion_files=deletion_files,  # type: ignore[arg-type]
+    ).with_row_index(offset=row_index_offset)
+
+    assert_frame_equal(
+        q.filter(pl.col("offset").is_in([10, 20])).collect(),
+        pl.DataFrame(
+            {
+                "index": apply_row_index_offset([5, 6, 7, 8, 9, 15, 16, 17]),
+                "physical_index": [10, 11, 12, 13, 14, 20, 21, 24],
+                "offset": [10, 10, 10, 10, 10, 20, 20, 20],
+            },
+            schema={
+                "index": pl.get_index_type(),
+                "physical_index": pl.UInt32,
+                "offset": pl.Int64,
+            },
+        ),
+    )
+
+
+@pytest.mark.write_disk
+@pytest.mark.parametrize("ideal_morsel_size", [999, 50, 33])
+@pytest.mark.parametrize("force_empty_capabilities", [True, False])
+def test_scan_row_deletion_single_large(
+    tmp_path: Path,
+    write_position_deletes: WritePositionDeletes,
+    ideal_morsel_size: int,
+    force_empty_capabilities: bool,
+) -> None:
+    path = tmp_path / "data.parquet"
+    pl.DataFrame({"physical_index": range(100)}).write_parquet(path)
+
+    positions = pl.Series([
+        0,   1,  2,  3,  4,  5,  6,  7,  8, 22,
+        23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+        33, 45, 46, 47, 48, 49, 50, 51, 52, 53,
+        54, 64, 65, 66, 67, 68, 69, 70, 71, 79,
+        80, 81, 82, 83, 84, 90, 91, 92, 93, 97,
+        98
+    ])  # fmt: skip
+
+    deletion_positions_path = write_position_deletes(positions)
+
+    # Use a process to ensure ideal morsel size is set correctly.
+    out = subprocess.check_output(
+        [
+            sys.executable,
+            "-c",
+            f"""\
+import os
+
+os.environ["POLARS_MAX_THREADS"] = "1"
+os.environ["POLARS_IDEAL_MORSEL_SIZE"] = "{ideal_morsel_size}"
+os.environ["POLARS_FORCE_EMPTY_READER_CAPABILITIES"] = "{1 if force_empty_capabilities else 0}"
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+full_expected_physical = [
+     9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+    19, 20, 21, 34, 35, 36, 37, 38, 39, 40,
+    41, 42, 43, 44, 55, 56, 57, 58, 59, 60,
+    61, 62, 63, 72, 73, 74, 75, 76, 77, 78,
+    85, 86, 87, 88, 89, 94, 95, 96, 99
+]  # fmt: skip
+
+deletion_files = (
+    "iceberg-position-delete",
+    {{0: ["{deletion_positions_path}"]}},
+)
+
+q = pl.scan_parquet("{path}", _deletion_files=deletion_files).with_row_index()
+
+assert_frame_equal(
+    q.collect(),
+    pl.DataFrame({{"physical_index": full_expected_physical}}).with_row_index(),
+)
+
+assert_frame_equal(
+    q.tail(999).collect(),
+    pl.DataFrame({{"physical_index": full_expected_physical}}).with_row_index(),
+)
+
+# Note: The negative slice is important here. Otherwise row_index does not get
+# lowered into the post-apply pipeline.
+for negative_offset in range(1, 49):
+    assert_frame_equal(
+        q.tail(negative_offset).collect(),
+        pl.DataFrame(
+            {{"physical_index": full_expected_physical[-negative_offset:]}}
+        ).with_row_index(offset=49 - negative_offset),
+    )
+
+assert_frame_equal(
+    q.slice(20).collect(),
+    pl.DataFrame({{"physical_index": full_expected_physical[20:]}}).with_row_index(
+        offset=20
+    ),
+)
+
+print("OK", end="")
+    """,
+        ],
+        stderr=subprocess.STDOUT,
+    )
+
+    assert out == b"OK"
+
+
+@pytest.mark.write_disk
+def test_scan_row_deletion_file_read_skipped_if_all_rows_deleted(
+    tmp_path: Path,
+    write_position_deletes: WritePositionDeletes,
+) -> None:
+    # Create our own copy because we mutate one of the data files
+    data_files_path = tmp_path / "data-files"
+    _create_data_files(data_files_path)
+
+    # Corrupt a parquet file
+    def remove_data(path: Path) -> None:
+        v = path.read_bytes()
+        metadata_and_footer_len = 8 + int.from_bytes(v[-8:][:4], "little")
+        path.write_bytes(b"\x00" * (len(v) - metadata_and_footer_len))
+        path.write_bytes(v[-metadata_and_footer_len:])
+
+    remove_data(data_files_path / "offset=05/data.parquet")
+
+    q = pl.scan_parquet(
+        data_files_path / "offset=05/data.parquet", hive_partitioning=False
+    )
+
+    # Baseline: The metadata is readable but the row groups are not
+
+    assert q.collect_schema() == {"physical_index": pl.UInt32}
+    assert q.select(pl.len()).collect().item() == 5
+
+    with pytest.raises(pl.exceptions.ComputeError, match="Invalid thrift"):
+        q.collect()
+
+    q = pl.scan_parquet(data_files_path, hive_partitioning=False)
+
+    with pytest.raises(pl.exceptions.ComputeError, match="Invalid thrift"):
+        q.collect()
+
+    q = pl.scan_parquet(
+        data_files_path,
+        _deletion_files=(
+            "iceberg-position-delete",
+            {
+                1: [
+                    write_position_deletes(pl.Series([0, 1, 2])),
+                    write_position_deletes(pl.Series([3, 4])),
+                ]
+            },
+        ),
+        hive_partitioning=False,
+    )
+
+    expect = pl.DataFrame(
+        {
+            "index": [
+                0, 1, 2, 3, 4,
+                5, 6, 7, 8, 9,
+                10, 11, 12, 13, 14,
+                15, 16, 17, 18, 19,
+            ],
+            "physical_index": [
+                0, 1, 2, 3, 4,
+                10, 11, 12, 13, 14,
+                15, 16, 17, 18, 19,
+                20, 21, 22, 23, 24,
+            ],
+        },
+        schema={"index": pl.get_index_type(), "physical_index": pl.UInt32},
+    )  # fmt: skip
+
+    assert_frame_equal(q.collect(), expect.drop("index"))
+    assert_frame_equal(q.with_row_index().collect(), expect)
+
+    expect = pl.DataFrame(
+        {
+            "index": [
+                10, 11, 12, 13, 14,
+                15, 16, 17, 18, 19,
+            ],
+            "physical_index": [
+                15, 16, 17, 18, 19,
+                20, 21, 22, 23, 24,
+            ],
+        },
+        schema={"index": pl.get_index_type(), "physical_index": pl.UInt32},
+    )  # fmt: skip
+
+    assert_frame_equal(q.slice(10).collect(), expect.drop("index"))
+    assert_frame_equal(q.with_row_index().slice(10).collect(), expect)


### PR DESCRIPTION
Finishes adding support for Iceberg position deletes. Internally, this adds generic logic for performing row deletions to the new-streaming multi-scan using a filter mask, which should allow for code re-use for other formats e.g. Iceberg V3 deletion vectors / Delta deletion vectors.

### Changes
* Changed the semantics of the row count being sent to the post-apply pipeline (`current_row_position` parameter to `ApplyExtraOps::apply_to_df()`).
  * Before - `current_row_position: 0` points to the first morsel, and `row_index.offset` is mutated during initialization to account for skipped rows (i.e. non-zero offset slice pushed to reader).
  * After - `current_row_position: 0` points to the start of the file, and we do not mutate `row_index.offset`. This is preferred, as the old approach would require us to also slice the filter mask for row deletions, which can be error prone.
    * This is done by passing a new `first_morsel_position` during initialization.
* In general, we replace plain `usize` counters with `RowCounter` in multiple places.
* Micro-optimization - avoid calling `begin_read()` for parquet files that are fully sliced out

### Pipeline operation modes

The pipeline code is designed operate correctly with different combinations of slice / deletion pushdown.

The behavior of the variables in each case can be seen below. The key observation is to see how `row_index.offset` (near bottom right) is correctly calculated to 1, despite each case having a different physical/deleted value in `first_morsel_position` - 

<details>
<summary>Slice pushed to reader, deletions in post-apply (default for parquet / iceberg)</summary>

![image](https://github.com/user-attachments/assets/4a53d1af-f2eb-41ac-a968-753569d66f4d)

</details>

<details>
<summary>Slice and deletions in post-apply (readers without slice support, or for testing)</summary>

![image](https://github.com/user-attachments/assets/4d25d22c-05e9-467d-a743-43e23b129f75)

</details>

<details>
<summary>Slice and deletions pushed to reader (planned for parquet)</summary>

![image](https://github.com/user-attachments/assets/c4893105-f7ce-4b3c-9c39-6a025cb18033)

</details>
