### PR TITLE
fix: Fix group_by mean and median returning all nulls for Decimal dtype

### DIFF
--- a/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
@@ -140,6 +140,8 @@ impl Series {
             Float32 => SeriesWrap(s.f32().unwrap().clone()).agg_mean(groups),
             Float64 => SeriesWrap(s.f64().unwrap().clone()).agg_mean(groups),
             dt if dt.is_primitive_numeric() => apply_method_physical_integer!(s, agg_mean, groups),
+            #[cfg(feature = "dtype-decimal")]
+            Decimal(_, _) => self.cast(&Float64).unwrap().agg_mean(groups),
             #[cfg(feature = "dtype-datetime")]
             dt @ Datetime(_, _) => self
                 .to_physical_repr()
@@ -194,6 +196,8 @@ impl Series {
             dt if dt.is_primitive_numeric() => {
                 apply_method_physical_integer!(s, agg_median, groups)
             },
+            #[cfg(feature = "dtype-decimal")]
+            Decimal(_, _) => self.cast(&Float64).unwrap().agg_median(groups),
             #[cfg(feature = "dtype-datetime")]
             dt @ Datetime(_, _) => self
                 .to_physical_repr()

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -303,16 +303,24 @@ def test_decimal_aggregations() -> None:
         "a": [[D("0.1"), D("10.1")], [D("100.01"), D("9000.12")]],
     }
 
-    assert df.group_by("g", maintain_order=True).agg(
+    result = df.group_by("g", maintain_order=True).agg(
         sum=pl.sum("a"),
         min=pl.min("a"),
         max=pl.max("a"),
-    ).to_dict(as_series=False) == {
-        "g": [1, 2],
-        "sum": [D("10.20"), D("9100.13")],
-        "min": [D("0.10"), D("100.01")],
-        "max": [D("10.10"), D("9000.12")],
-    }
+        mean=pl.mean("a"),
+        median=pl.median("a"),
+    )
+    expected = pl.DataFrame(
+        {
+            "g": [1, 2],
+            "sum": [D("10.20"), D("9100.13")],
+            "min": [D("0.10"), D("100.01")],
+            "max": [D("10.10"), D("9000.12")],
+            "mean": [5.1, 4550.065],
+            "median": [5.1, 4550.065],
+        }
+    )
+    assert_frame_equal(result, expected)
 
     res = df.select(
         sum=pl.sum("a"),


### PR DESCRIPTION
This is the same PR as https://github.com/pola-rs/polars/pull/21306 by @lukemanley . I unfortunately can't merge/reopen that one anymore as it has been closed.

While we'd like decimal mean to be type-preserving in the future, for the moment we might as well merge this fix so we don't arbitrarily return nulls.

Fixes https://github.com/pola-rs/polars/issues/21304.