### PR TITLE
fix: `list.eval` with unknown output type

### DIFF
--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -605,6 +605,21 @@ impl DataType {
         }
     }
 
+    pub fn contains_unknown_recursive(&self) -> bool {
+        use DataType as D;
+        match self {
+            D::Unknown(_) => true,
+            D::List(inner) => inner.contains_list_recursive(),
+            #[cfg(feature = "dtype-array")]
+            D::Array(inner, _) => inner.contains_list_recursive(),
+            #[cfg(feature = "dtype-struct")]
+            D::Struct(fields) => fields
+                .iter()
+                .any(|field| field.dtype.contains_list_recursive()),
+            _ => false,
+        }
+    }
+
     /// Check if type is sortable
     pub fn is_ord(&self) -> bool {
         #[cfg(feature = "dtype-categorical")]

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -369,7 +369,8 @@ impl AExpr {
                 let field = ctx.arena.get(*expr).to_field_impl(ctx, agg_list)?;
 
                 let element_dtype = variant.element_dtype(field.dtype())?;
-                let schema = Schema::from_iter([(PlSmallStr::EMPTY, element_dtype.clone())]);
+                let element_dtype = element_dtype.clone().materialize_unknown(false)?;
+                let schema = Schema::from_iter([(PlSmallStr::EMPTY, element_dtype)]);
 
                 let mut ctx = ToFieldContext {
                     schema: &schema,

--- a/crates/polars-plan/src/plans/conversion/expr_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/expr_to_ir.rs
@@ -371,6 +371,20 @@ pub(super) fn to_aexpr_impl(
                 },
             }
 
+            // Materialize the output datatype.
+            let dtype = arena
+                .get(evaluation)
+                .get_type(schema, Context::Default, arena)?;
+            let mut evaluation = evaluation;
+            if dtype.contains_unknown_recursive() {
+                let materialized = dtype.materialize_unknown(false)?;
+                evaluation = arena.add(AExpr::Cast {
+                    expr: evaluation,
+                    dtype: materialized,
+                    options: polars_core::chunked_array::cast::CastOptions::Strict,
+                });
+            }
+
             (
                 AExpr::Eval {
                     expr,

--- a/py-polars/tests/unit/operations/namespaces/list/test_eval.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_eval.py
@@ -130,3 +130,10 @@ def test_list_eval_list_output_18510(data: dict[str, Any], expr: pl.Expr) -> Non
     df = pl.DataFrame(data)
     result = df.select(pl.col("a").list.eval(pl.lit("")))
     assert result.to_series().dtype == pl.List(pl.String)
+
+
+def test_list_eval_unknown_dtype_23089() -> None:
+    assert_series_equal(
+        pl.Series([[1, 2]]).list.eval(pl.when(pl.int_range(pl.len()) > 0).then(42)),
+        pl.Series([[None, 42]], dtype=pl.List(pl.Int32)),
+    )


### PR DESCRIPTION
Fixes #23089.