### PR TITLE
fix(rust): Fix time zone handling in `dt.iso_year` and `dt.is_leap_year`

### DIFF
--- a/crates/polars-time/src/chunkedarray/datetime.rs
+++ b/crates/polars-time/src/chunkedarray/datetime.rs
@@ -46,7 +46,18 @@ pub trait DatetimeMethods: AsDatetime {
             TimeUnit::Microseconds => datetime_to_is_leap_year_us,
             TimeUnit::Milliseconds => datetime_to_is_leap_year_ms,
         };
-        ca.apply_kernel_cast::<BooleanType>(&f)
+        let ca_local = match ca.dtype() {
+            #[cfg(feature = "timezones")]
+            DataType::Datetime(_, Some(_)) => &polars_ops::chunked_array::replace_time_zone(
+                ca,
+                None,
+                &StringChunked::new("".into(), ["raise"]),
+                NonExistent::Raise,
+            )
+            .expect("Removing time zone is infallible"),
+            _ => ca,
+        };
+        ca_local.apply_kernel_cast::<BooleanType>(&f)
     }
 
     fn iso_year(&self) -> Int32Chunked {
@@ -56,7 +67,18 @@ pub trait DatetimeMethods: AsDatetime {
             TimeUnit::Microseconds => datetime_to_iso_year_us,
             TimeUnit::Milliseconds => datetime_to_iso_year_ms,
         };
-        ca.apply_kernel_cast::<Int32Type>(&f)
+        let ca_local = match ca.dtype() {
+            #[cfg(feature = "timezones")]
+            DataType::Datetime(_, Some(_)) => &polars_ops::chunked_array::replace_time_zone(
+                ca,
+                None,
+                &StringChunked::new("".into(), ["raise"]),
+                NonExistent::Raise,
+            )
+            .expect("Removing time zone is infallible"),
+            _ => ca,
+        };
+        ca_local.apply_kernel_cast::<Int32Type>(&f)
     }
 
     /// Extract quarter from underlying NaiveDateTime representation.

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -799,6 +799,42 @@ def test_combine_lazy_schema_date(time_unit: TimeUnit) -> None:
         (pl.date_range, date, {}),
     ],
 )
+def test_iso_year(
+    range_fn: Callable[..., pl.Series], value_type: type, kwargs: dict[str, str]
+) -> None:
+    assert range_fn(
+        value_type(1990, 1, 1), value_type(2004, 1, 1), "1y", **kwargs, eager=True
+    ).dt.iso_year().to_list() == [
+        1990,
+        1991,
+        1992,
+        1992,
+        1993,
+        1994,
+        1996,
+        1997,
+        1998,
+        1998,
+        1999,
+        2001,
+        2002,
+        2003,
+        2004,
+    ]
+
+
+@pytest.mark.parametrize(
+    ("range_fn", "value_type", "kwargs"),
+    [
+        (pl.datetime_range, datetime, {"time_unit": "ns"}),
+        (pl.datetime_range, datetime, {"time_unit": "ns", "time_zone": "CET"}),
+        (pl.datetime_range, datetime, {"time_unit": "us"}),
+        (pl.datetime_range, datetime, {"time_unit": "us", "time_zone": "CET"}),
+        (pl.datetime_range, datetime, {"time_unit": "ms"}),
+        (pl.datetime_range, datetime, {"time_unit": "ms", "time_zone": "CET"}),
+        (pl.date_range, date, {}),
+    ],
+)
 def test_is_leap_year(
     range_fn: Callable[..., pl.Series], value_type: type, kwargs: dict[str, str]
 ) -> None:

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -791,8 +791,11 @@ def test_combine_lazy_schema_date(time_unit: TimeUnit) -> None:
     ("range_fn", "value_type", "kwargs"),
     [
         (pl.datetime_range, datetime, {"time_unit": "ns"}),
+        (pl.datetime_range, datetime, {"time_unit": "ns", "time_zone": "CET"}),
         (pl.datetime_range, datetime, {"time_unit": "us"}),
+        (pl.datetime_range, datetime, {"time_unit": "us", "time_zone": "CET"}),
         (pl.datetime_range, datetime, {"time_unit": "ms"}),
+        (pl.datetime_range, datetime, {"time_unit": "ms", "time_zone": "CET"}),
         (pl.date_range, date, {}),
     ],
 )

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -29,7 +29,9 @@ def series_of_str_dates() -> pl.Series:
 
 
 def test_dt_to_string(series_of_int_dates: pl.Series) -> None:
-    expected_str_dates = pl.Series(["1993-01-01", "1997-05-19", "2024-10-04", "2052-02-20"])
+    expected_str_dates = pl.Series(
+        ["1993-01-01", "1997-05-19", "2024-10-04", "2052-02-20"]
+    )
 
     assert series_of_int_dates.dtype == pl.Date
     assert_series_equal(series_of_int_dates.dt.to_string("%F"), expected_str_dates)

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from datetime import date, datetime, time, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -787,9 +787,18 @@ def test_combine_lazy_schema_date(time_unit: TimeUnit) -> None:
     assert result.collect_schema().dtypes() == expected_dtypes
 
 
-def test_is_leap_year() -> None:
-    assert pl.datetime_range(
-        datetime(1990, 1, 1), datetime(2004, 1, 1), "1y", eager=True
+@pytest.mark.parametrize(
+    ("range_fn", "value_type", "kwargs"),
+    [
+        (pl.datetime_range, datetime, {"time_unit": "ns"}),
+        (pl.datetime_range, datetime, {"time_unit": "us"}),
+        (pl.datetime_range, datetime, {"time_unit": "ms"}),
+        (pl.date_range,     date,     {}),
+    ]
+)
+def test_is_leap_year(range_fn: Callable, value_type: type, kwargs: dict) -> None:
+    assert range_fn(
+        value_type(1990, 1, 1), value_type(2004, 1, 1), "1y", **kwargs, eager=True
     ).dt.is_leap_year().to_list() == [
         False,
         False,

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 @pytest.fixture
 def series_of_int_dates() -> pl.Series:
-    return pl.Series([10000, 20000, 30000], dtype=pl.Date)
+    return pl.Series([8401, 10000, 20000, 30000], dtype=pl.Date)
 
 
 @pytest.fixture
@@ -29,7 +29,7 @@ def series_of_str_dates() -> pl.Series:
 
 
 def test_dt_to_string(series_of_int_dates: pl.Series) -> None:
-    expected_str_dates = pl.Series(["1997-05-19", "2024-10-04", "2052-02-20"])
+    expected_str_dates = pl.Series(["1993-01-01", "1997-05-19", "2024-10-04", "2052-02-20"])
 
     assert series_of_int_dates.dtype == pl.Date
     assert_series_equal(series_of_int_dates.dt.to_string("%F"), expected_str_dates)
@@ -41,16 +41,16 @@ def test_dt_to_string(series_of_int_dates: pl.Series) -> None:
 @pytest.mark.parametrize(
     ("unit_attr", "expected"),
     [
-        ("millennium", pl.Series(values=[2, 3, 3], dtype=pl.Int32)),
-        ("century", pl.Series(values=[20, 21, 21], dtype=pl.Int32)),
-        ("year", pl.Series(values=[1997, 2024, 2052], dtype=pl.Int32)),
-        ("iso_year", pl.Series(values=[1997, 2024, 2052], dtype=pl.Int32)),
-        ("quarter", pl.Series(values=[2, 4, 1], dtype=pl.Int8)),
-        ("month", pl.Series(values=[5, 10, 2], dtype=pl.Int8)),
-        ("week", pl.Series(values=[21, 40, 8], dtype=pl.Int8)),
-        ("day", pl.Series(values=[19, 4, 20], dtype=pl.Int8)),
-        ("weekday", pl.Series(values=[1, 5, 2], dtype=pl.Int8)),
-        ("ordinal_day", pl.Series(values=[139, 278, 51], dtype=pl.Int16)),
+        ("millennium", pl.Series(values=[2, 2, 3, 3], dtype=pl.Int32)),
+        ("century", pl.Series(values=[20, 20, 21, 21], dtype=pl.Int32)),
+        ("year", pl.Series(values=[1993, 1997, 2024, 2052], dtype=pl.Int32)),
+        ("iso_year", pl.Series(values=[1992, 1997, 2024, 2052], dtype=pl.Int32)),
+        ("quarter", pl.Series(values=[1, 2, 4, 1], dtype=pl.Int8)),
+        ("month", pl.Series(values=[1, 5, 10, 2], dtype=pl.Int8)),
+        ("week", pl.Series(values=[53, 21, 40, 8], dtype=pl.Int8)),
+        ("day", pl.Series(values=[1, 19, 4, 20], dtype=pl.Int8)),
+        ("weekday", pl.Series(values=[5, 1, 5, 2], dtype=pl.Int8)),
+        ("ordinal_day", pl.Series(values=[1, 139, 278, 51], dtype=pl.Int16)),
     ],
 )
 @pytest.mark.parametrize("time_zone", ["Asia/Kathmandu", None])

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -793,10 +793,12 @@ def test_combine_lazy_schema_date(time_unit: TimeUnit) -> None:
         (pl.datetime_range, datetime, {"time_unit": "ns"}),
         (pl.datetime_range, datetime, {"time_unit": "us"}),
         (pl.datetime_range, datetime, {"time_unit": "ms"}),
-        (pl.date_range,     date,     {}),
-    ]
+        (pl.date_range, date, {}),
+    ],
 )
-def test_is_leap_year(range_fn: Callable, value_type: type, kwargs: dict) -> None:
+def test_is_leap_year(
+    range_fn: Callable[..., pl.Series], value_type: type, kwargs: dict[str, str]
+) -> None:
     assert range_fn(
         value_type(1990, 1, 1), value_type(2004, 1, 1), "1y", **kwargs, eager=True
     ).dt.is_leap_year().to_list() == [


### PR DESCRIPTION
I found that the test cases for `is_leap_year` of `datetime`, which has a non-default time unit, and `date` are missing while working on #23119.
This change covers these missing cases directly.
