### PR TITLE
fix(rust): Enable serde feature with python in `polars-mem-engine`

### DIFF
--- a/crates/polars-plan/Cargo.toml
+++ b/crates/polars-plan/Cargo.toml
@@ -52,7 +52,7 @@ version_check = { workspace = true }
 [features]
 # debugging utility
 debugging = []
-python = ["dep:pyo3", "polars-utils/python", "polars-ffi", "polars-core/object"]
+python = ["dep:pyo3", "polars-utils/python", "polars-ffi", "polars-core/object", "serde"]
 serde = [
   "dep:serde",
   "polars-core/serde-lazy",


### PR DESCRIPTION
Currently attempting to run a `#[test]` in `polars-stream` fails due to this:

```rust
   Compiling polars-mem-engine v0.48.1 (/Users/nxs/git/polars/crates/polars-mem-engine)
error[E0425]: cannot find function `serialize` in module `polars_plan::plans::python::predicate`
   --> crates/polars-mem-engine/src/planner/lp.rs:188:75
    |
188 |             predicate_serialized = polars_plan::plans::python::predicate::serialize(&dsl_expr)?;
    |                                                                           ^^^^^^^^^ not found in `polars_plan::plans::python::predicate`
    |
note: found an item that was configured out
   --> /Users/nxs/git/polars/crates/polars-plan/src/plans/python/predicate.rs:6:8
    |
6   | pub fn serialize(expr: &Expr) -> PolarsResult<Option<Vec<u8>>> {
    |        ^^^^^^^^^
note: the item is gated behind the `serde` feature
   --> /Users/nxs/git/polars/crates/polars-plan/src/plans/python/predicate.rs:5:7
    |
5   | #[cfg(feature = "serde")]
    |       ^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0425`.
error: could not compile `polars-mem-engine` (lib) due to 1 previous error
```