### PR TITLE
refactor(rust): Improve Series equality functionality and prepare for Python integration

### DIFF
--- a/crates/polars-testing/src/asserts/series.rs
+++ b/crates/polars-testing/src/asserts/series.rs
@@ -96,7 +96,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "data type mismatch")]
+    #[should_panic(expected = "dtype mismatch")]
     fn test_series_dtype_mismatch() {
         let s1 = Series::new("".into(), &[1, 2, 3]);
         let s2 = Series::new("".into(), &["1", "2", "3"]);

--- a/crates/polars-testing/src/asserts/utils.rs
+++ b/crates/polars-testing/src/asserts/utils.rs
@@ -335,7 +335,17 @@ pub fn assert_series_values_equal(
         (left.clone(), right.clone())
     };
 
-    let unequal = left.not_equal_missing(&right)?;
+    let unequal = match left.not_equal_missing(&right) {
+        Ok(result) => result,
+        Err(_) => {
+            return Err(polars_err!(
+                assertion_error = "Series",
+                "incompatible data types",
+                left.dtype(),
+                right.dtype()
+            ));
+        },
+    };
 
     if comparing_nested_floats(left.dtype(), right.dtype()) {
         let filtered_left = left.filter(&unequal)?;
@@ -349,9 +359,7 @@ pub fn assert_series_values_equal(
             atol,
             categorical_as_str,
         ) {
-            Ok(_) => {
-                return Ok(());
-            },
+            Ok(_) => return Ok(()),
             Err(_) => {
                 return Err(polars_err!(
                     assertion_error = "Series",
@@ -456,13 +464,16 @@ pub fn assert_series_nested_values_equal(
         let ls = left.struct_()?.clone().unnest();
         let rs = right.struct_()?.clone().unnest();
 
-        let ls_cols = ls.get_columns();
-        let rs_cols = rs.get_columns();
+        for col_name in ls.get_column_names() {
+            let s1_column = ls.column(col_name)?;
+            let s2_column = rs.column(col_name)?;
 
-        for (s1, s2) in ls_cols.iter().zip(rs_cols.iter()) {
+            let s1_series = s1_column.as_materialized_series();
+            let s2_series = s2_column.as_materialized_series();
+
             match assert_series_values_equal(
-                s1.as_series().unwrap(),
-                s2.as_series().unwrap(),
+                s1_series,
+                s2_series,
                 true,
                 check_exact,
                 rtol,
@@ -538,7 +549,7 @@ pub fn assert_series_equal(
     if options.check_dtypes && left.dtype() != right.dtype() {
         return Err(polars_err!(
             assertion_error = "Series",
-            "data type mismatch",
+            "dtype mismatch",
             left.dtype(),
             right.dtype()
         ));


### PR DESCRIPTION
@coastalwhite This is in preparation for making the connection to the Rust `assert_series_equal()` to Python using PyO3. 

I made the connection (in a different branch), tested it, and discovered  some of the Python tests were failing due to some minor issues in the Rust back-end. I fixed the issues, added some extra error handling functionality that was not present before, and a small tweak to match the Python functionality. 

With these adjustments, all the Python tests will pass when the connection is made and it still maintains the logic and integrity of the code in Rust (all tests pass). 

Once this is merged, I can make the first PR for connecting the Rust and Python functionality. 