### PR TITLE
fix: Support Datetime broadcast in `list.concat`

### DIFF
--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -726,20 +726,17 @@ pub trait ListNameSpaceImpl: AsList {
         // this path will not expand the series, so saves memory
         let out = if other.iter().all(|s| s.len() == 1) && ca.len() != 1 {
             cast_rhs(&mut other, &inner_super_type, dtype, length, false)?;
-            let mut to_append = other
+            let to_append = other
                 .iter()
-                .flat_map(|s| {
+                .filter_map(|s| {
                     let lst = s.list().unwrap();
-                    lst.get_as_series(0)
+                    // SAFETY: previous rhs_cast ensures the type is correct
+                    unsafe {
+                        lst.get_as_series(0)
+                            .map(|s| s.from_physical_unchecked(&inner_super_type).unwrap())
+                    }
                 })
                 .collect::<Vec<_>>();
-
-            // we may need to recast back from physical dtype
-            for s in &mut to_append {
-                if *s.dtype() != inner_super_type {
-                    unsafe { *s = s.from_physical_unchecked(&inner_super_type)? }
-                }
-            }
 
             // there was a None, so all values will be None
             if to_append.len() != other_len {

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -737,7 +737,7 @@ pub trait ListNameSpaceImpl: AsList {
             // we may need to recast back from physical dtype
             for s in &mut to_append {
                 if *s.dtype() != inner_super_type {
-                    *s = s.cast(&inner_super_type)?
+                    unsafe { *s = s.from_physical_unchecked(&inner_super_type)? }
                 }
             }
 

--- a/py-polars/tests/unit/functions/as_datatype/test_concat_list.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_concat_list.py
@@ -201,36 +201,20 @@ def test_cross_join_concat_list_18587() -> None:
 
 def test_datetime_broadcast_concat_list_23102() -> None:
     df = pl.DataFrame(
-        {
-            "timestamps": [
-                [datetime(2024, 1, 1).replace(tzinfo=None)],
-                [datetime(2024, 1, 2).replace(tzinfo=None)],
-            ]
-        },
-        schema={"timestamps": pl.List(pl.Datetime(time_unit="ms", time_zone=None))},
+        {"timestamps": [[datetime(2024, 1, 1)], [datetime(2024, 1, 2)]]},
+        schema={"timestamps": pl.List(pl.Datetime())},
     )
 
-    new_timestamp = pl.lit(
-        [
-            datetime(2024, 2, 1).replace(tzinfo=None),
-        ],
-        dtype=pl.List(pl.Datetime(time_unit="ms", time_zone=None)),
-    )
+    new_timestamp = pl.lit([datetime(2024, 2, 1)], dtype=pl.List(pl.Datetime()))
 
     out = df.with_columns(pl.col("timestamps").list.concat(new_timestamp))
     expected = pl.DataFrame(
         {
             "timestamps": [
-                [
-                    datetime(2024, 1, 1).replace(tzinfo=None),
-                    datetime(2024, 2, 1).replace(tzinfo=None),
-                ],
-                [
-                    datetime(2024, 1, 2).replace(tzinfo=None),
-                    datetime(2024, 2, 1).replace(tzinfo=None),
-                ],
+                [datetime(2024, 1, 1), datetime(2024, 2, 1)],
+                [datetime(2024, 1, 2), datetime(2024, 2, 1)],
             ]
         },
-        schema={"timestamps": pl.List(pl.Datetime(time_unit="ms", time_zone=None))},
+        schema={"timestamps": pl.List(pl.Datetime())},
     )
     assert_frame_equal(out, expected)

--- a/py-polars/tests/unit/functions/as_datatype/test_concat_list.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_concat_list.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 
 import polars as pl
@@ -195,3 +197,40 @@ def test_cross_join_concat_list_18587() -> None:
     expected = [[a, b, c] for a in vals for b in vals for c in vals]
 
     assert result["1"].to_list() == expected
+
+
+def test_datetime_broadcast_concat_list_23102() -> None:
+    df = pl.DataFrame(
+        {
+            "timestamps": [
+                [datetime(2024, 1, 1).replace(tzinfo=None)],
+                [datetime(2024, 1, 2).replace(tzinfo=None)],
+            ]
+        },
+        schema={"timestamps": pl.List(pl.Datetime(time_unit="ms", time_zone=None))},
+    )
+
+    new_timestamp = pl.lit(
+        [
+            datetime(2024, 2, 1).replace(tzinfo=None),
+        ],
+        dtype=pl.List(pl.Datetime(time_unit="ms", time_zone=None)),
+    )
+
+    out = df.with_columns(pl.col("timestamps").list.concat(new_timestamp))
+    expected = pl.DataFrame(
+        {
+            "timestamps": [
+                [
+                    datetime(2024, 1, 1).replace(tzinfo=None),
+                    datetime(2024, 2, 1).replace(tzinfo=None),
+                ],
+                [
+                    datetime(2024, 1, 2).replace(tzinfo=None),
+                    datetime(2024, 2, 1).replace(tzinfo=None),
+                ],
+            ]
+        },
+        schema={"timestamps": pl.List(pl.Datetime(time_unit="ms", time_zone=None))},
+    )
+    assert_frame_equal(out, expected)


### PR DESCRIPTION
fixes #23102

Pending review, see issue for solution strategies.

Works for Datetime and Duration, but not for Decimal as cast behaves differently. Should we use `from_physical_unchecked` instead?

*edit: latest commit uses `from_physical_unchecked` and works for Decimal as well.