### PR TITLE
docs(python): Document aggregations that return identity when there's no non-null values, suggest workaround for those who want SQL-standard behaviour

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -475,11 +475,12 @@ class Expr:
         Parameters
         ----------
         ignore_nulls
-            Ignore null values (default).
 
-            If set to `False`, `Kleene logic`_ is used to deal with nulls:
-            if the column contains any null values and no `True` values,
-            the output is null.
+            * If set to `True` (default), null values are ignored. If there
+              are no non-null values, the output is `False`.
+            * If set to `False`, `Kleene logic`_ is used to deal with nulls:
+              if the column contains any null values and no `True` values,
+              the output is null.
 
             .. _Kleene logic: https://en.wikipedia.org/wiki/Three-valued_logic
 
@@ -534,11 +535,12 @@ class Expr:
         Parameters
         ----------
         ignore_nulls
-            Ignore null values (default).
 
-            If set to `False`, `Kleene logic`_ is used to deal with nulls:
-            if the column contains any null values and no `False` values,
-            the output is null.
+            * If set to `True` (default), null values are ignored. If there
+              are no non-null values, the output is `True`.
+            * If set to `False`, `Kleene logic`_ is used to deal with nulls:
+              if the column contains any null values and no `False` values,
+              the output is null.
 
             .. _Kleene logic: https://en.wikipedia.org/wiki/Three-valued_logic
 
@@ -3145,8 +3147,12 @@ class Expr:
 
         Notes
         -----
-        Dtypes in {Int8, UInt8, Int16, UInt16} are cast to
-        Int64 before summing to prevent overflow issues.
+        * Dtypes in {Int8, UInt8, Int16, UInt16} are cast to
+          Int64 before summing to prevent overflow issues.
+        * If there are no non-null values, then the output is `0`.
+          If you would prefer empty sums to return `None`, you can
+          use `pl.when(expr.count()>0).then(expr.sum())` instead
+          of `expr.sum()`.
 
         Examples
         --------
@@ -3204,6 +3210,13 @@ class Expr:
     def product(self) -> Expr:
         """
         Compute the product of an expression.
+
+        Notes
+        -----
+        If there are no non-null values, then the output is `1`.
+        If you would prefer empty products to return `None`, you can
+        use `pl.when(expr.count()>0).then(expr.product())` instead
+        of `expr.product()`.
 
         Examples
         --------

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -36,6 +36,10 @@ class ExprListNameSpace:
         """
         Evaluate whether all boolean values in a list are true.
 
+        Notes
+        -----
+        If there are no non-null elements in a row, the output is `True`.
+
         Examples
         --------
         >>> df = pl.DataFrame(
@@ -61,6 +65,10 @@ class ExprListNameSpace:
     def any(self) -> Expr:
         """
         Evaluate whether any boolean value in a list is true.
+
+        Notes
+        -----
+        If there are no non-null elements in a row, the output is `False`.
 
         Examples
         --------
@@ -195,6 +203,10 @@ class ExprListNameSpace:
     def sum(self) -> Expr:
         """
         Sum all the lists in the array.
+
+        Notes
+        -----
+        If there are no non-null elements in a row, the output is `0`.
 
         Examples
         --------

--- a/py-polars/polars/functions/aggregation/vertical.py
+++ b/py-polars/polars/functions/aggregation/vertical.py
@@ -20,11 +20,12 @@ def all(*names: str, ignore_nulls: bool = True) -> Expr:
     *names
         Name(s) of the columns to use in the aggregation.
     ignore_nulls
-        Ignore null values (default).
 
-        If set to `False`, `Kleene logic`_ is used to deal with nulls:
-        if the column contains any null values and no `False` values,
-        the output is null.
+        * If set to `True` (default), null values are ignored. If there
+          are no non-null values, the output is `True`.
+        * If set to `False`, `Kleene logic`_ is used to deal with nulls:
+          if the column contains any null values and no `False` values,
+          the output is null.
 
         .. _Kleene logic: https://en.wikipedia.org/wiki/Three-valued_logic
 
@@ -85,11 +86,12 @@ def any(*names: str, ignore_nulls: bool = True) -> Expr | bool | None:
     *names
         Name(s) of the columns to use in the aggregation.
     ignore_nulls
-        Ignore null values (default).
 
-        If set to `False`, `Kleene logic`_ is used to deal with nulls:
-        if the column contains any null values and no `True` values,
-        the output is null.
+        * If set to `True` (default), null values are ignored. If there
+          are no non-null values, the output is `False`.
+        * If set to `False`, `Kleene logic`_ is used to deal with nulls:
+          if the column contains any null values and no `True` values,
+          the output is null.
 
         .. _Kleene logic: https://en.wikipedia.org/wiki/Three-valued_logic
 
@@ -244,6 +246,13 @@ def sum(*names: str) -> Expr:
     ----------
     *names
         Name(s) of the columns to use in the aggregation.
+
+    Notes
+    -----
+    If there are no non-null values, then the output is `0`.
+    If you would prefer empty sums to return `None`, you can
+    use `pl.when(pl.col(name).count()>0).then(pl.sum(name))` instead
+    of `pl.sum(name)`.
 
     See Also
     --------

--- a/py-polars/polars/series/array.py
+++ b/py-polars/polars/series/array.py
@@ -59,6 +59,10 @@ class ArrayNameSpace:
         """
         Compute the sum values of the sub-arrays.
 
+        Notes
+        -----
+        If there are no non-null elements in a row, the output is `0`.
+
         Examples
         --------
         >>> s = pl.Series([[1, 2], [4, 3]], dtype=pl.Array(pl.Int64, 2))
@@ -191,6 +195,10 @@ class ArrayNameSpace:
         Series
             Series of data type :class:`Boolean`.
 
+        Notes
+        -----
+        If there are no non-null elements in a row, the output is `False`.
+
         Examples
         --------
         >>> s = pl.Series(
@@ -238,6 +246,10 @@ class ArrayNameSpace:
         -------
         Series
             Series of data type :class:`Boolean`.
+
+        Notes
+        -----
+        If there are no non-null elements in a row, the output is `True`.
 
         Examples
         --------

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -37,6 +37,10 @@ class ListNameSpace:
         Series
             Series of data type :class:`Boolean`.
 
+        Notes
+        -----
+        If there are no non-null elements in a row, the output is `True`.
+
         Examples
         --------
         >>> s = pl.Series(
@@ -64,6 +68,10 @@ class ListNameSpace:
         -------
         Series
             Series of data type :class:`Boolean`.
+
+        Notes
+        -----
+        If there are no non-null elements in a row, the output is `False`.
 
         Examples
         --------
@@ -168,6 +176,10 @@ class ListNameSpace:
     def sum(self) -> Series:
         """
         Sum all the arrays in the list.
+
+        Notes
+        -----
+        If there are no non-null elements in a row, the output is `0`.
 
         Examples
         --------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1732,11 +1732,12 @@ class Series:
         Parameters
         ----------
         ignore_nulls
-            Ignore null values (default).
 
-            If set to `False`, `Kleene logic`_ is used to deal with nulls:
-            if the column contains any null values and no `True` values,
-            the output is `None`.
+            * If set to `True` (default), null values are ignored. If there
+              are no non-null values, the output is `False`.
+            * If set to `False`, `Kleene logic`_ is used to deal with nulls:
+              if the column contains any null values and no `True` values,
+              the output is `None`.
 
             .. _Kleene logic: https://en.wikipedia.org/wiki/Three-valued_logic
 
@@ -1774,11 +1775,12 @@ class Series:
         Parameters
         ----------
         ignore_nulls
-            Ignore null values (default).
 
-            If set to `False`, `Kleene logic`_ is used to deal with nulls:
-            if the column contains any null values and no `False` values,
-            the output is `None`.
+            * If set to `True` (default), null values are ignored. If there
+              are no non-null values, the output is `True`.
+            * If set to `False`, `Kleene logic`_ is used to deal with nulls:
+              if the column contains any null values and no `False` values,
+              the output is `None`.
 
             .. _Kleene logic: https://en.wikipedia.org/wiki/Three-valued_logic
 
@@ -2043,8 +2045,12 @@ class Series:
 
         Notes
         -----
-        Dtypes in {Int8, UInt8, Int16, UInt16} are cast to
-        Int64 before summing to prevent overflow issues.
+        * Dtypes in {Int8, UInt8, Int16, UInt16} are cast to
+          Int64 before summing to prevent overflow issues.
+        * If there are no non-null values, then the output is `0`.
+          If you would prefer empty sums to return `None`, you can
+          use `s.sum() if s.count() else None` instead
+          of `s.sum()`.
 
         Examples
         --------
@@ -2069,6 +2075,13 @@ class Series:
     def product(self) -> int | float:
         """
         Reduce this Series to the product value.
+
+        Notes
+        -----
+        If there are no non-null values, then the output is `1`.
+        If you would prefer empty products to return `None`, you can
+        use `s.product() if s.count() else None` instead
+        of `s.product()`.
 
         Examples
         --------


### PR DESCRIPTION
The question about empty sums comes up some times, with some people angrily commenting that they want the databases behaviour

So i think it's worthwhile to document it + show that the workaround is indeed very simple