### PR TITLE
chore: Added more descriptive error message by replacing `FixedSizeList` with `Array`

### DIFF
--- a/crates/polars-arrow/src/array/static_array_collect.rs
+++ b/crates/polars-arrow/src/array/static_array_collect.rs
@@ -862,9 +862,7 @@ impl ArrayFromIterDtype<Option<Box<dyn Array>>> for FixedSizeListArray {
         #[cfg(feature = "dtype-array")]
         {
             let ArrowDataType::FixedSizeList(_, width) = &dtype else {
-                panic!(
-                    "FixedSizeListArray::arr_from_iter_with_dtype called with non-Array dtype"
-                );
+                panic!("FixedSizeListArray::arr_from_iter_with_dtype called with non-Array dtype");
             };
             let iter_values: Vec<_> = iter.into_iter().collect();
             let mut builder = AnonymousFixedSizeListArrayBuilder::new(iter_values.len(), *width);

--- a/crates/polars-arrow/src/array/static_array_collect.rs
+++ b/crates/polars-arrow/src/array/static_array_collect.rs
@@ -863,7 +863,7 @@ impl ArrayFromIterDtype<Option<Box<dyn Array>>> for FixedSizeListArray {
         {
             let ArrowDataType::FixedSizeList(_, width) = &dtype else {
                 panic!(
-                    "FixedSizeListArray::arr_from_iter_with_dtype called with non-FixedSizeList dtype"
+                    "FixedSizeListArray::arr_from_iter_with_dtype called with non-Array dtype"
                 );
             };
             let iter_values: Vec<_> = iter.into_iter().collect();

--- a/crates/polars-core/src/series/ops/downcast.rs
+++ b/crates/polars-core/src/series/ops/downcast.rs
@@ -332,7 +332,7 @@ impl Series {
     #[cfg(feature = "dtype-array")]
     pub fn array(&self) -> PolarsResult<&ArrayChunked> {
         self.try_array()
-            .ok_or_else(|| unpack_chunked_err!(self => "FixedSizeList"))
+            .ok_or_else(|| unpack_chunked_err!(self => "Array"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype [`DataType::Categorical`]


### PR DESCRIPTION
### Context: 

> Can the `FixedSizeList` in error messages be changed to `array[...]` or similar?
> 
> ```python
> pl.Series([["foo", "bar"]]).arr.first()
> # SchemaError: invalid series dtype: expected `FixedSizeList`, got `list[str]` for series with name ``
> ```
> 
> People are still finding old code from when `.arr` was the list namespace[^1]  and it's a bit confusing.
> 
> [^1]: https://stackoverflow.com/questions/79609395/ 

 _Originally posted by @cmdlineluser in [#21302](https://github.com/pola-rs/polars/issues/21302#issuecomment-2868531809)_