### PR TITLE
refactor(rust): Explicit match to right join in projection pushdown optimizer

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/joins.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/joins.rs
@@ -239,24 +239,23 @@ pub(super) fn process_join(
             let dest_columns: &[ExprIR];
             let pushdown_dest: &mut Vec<ColumnNode>;
             let names_dest: &mut PlHashSet<PlSmallStr>;
-            if matches!(
-                options.args.how,
-                JoinType::Left | JoinType::Inner | JoinType::Full
-            ) {
-                src_columns = &left_on;
-                pushdown_src = &mut pushdown_left;
-                names_src = &mut names_left;
-                dest_columns = &right_on;
-                pushdown_dest = &mut pushdown_right;
-                names_dest = &mut names_right;
-            } else {
+
+            if let JoinType::Right = options.args.how {
                 src_columns = &right_on;
                 pushdown_src = &mut pushdown_right;
                 names_src = &mut names_right;
                 dest_columns = &left_on;
                 pushdown_dest = &mut pushdown_left;
                 names_dest = &mut names_left;
+            } else {
+                src_columns = &left_on;
+                pushdown_src = &mut pushdown_left;
+                names_src = &mut names_left;
+                dest_columns = &right_on;
+                pushdown_dest = &mut pushdown_right;
+                names_dest = &mut names_right;
             }
+
             for e in src_columns {
                 if !local_projected_names.insert(e.output_name().clone()) {
                     // A join can have multiple leaf names, so we must still ensure all leaf names are projected.


### PR DESCRIPTION
* Follow-up on https://github.com/pola-rs/polars/pull/22603

The linked PR introduced a parametrized codepath that flips the variables on the right-join. I made an oversight in review and didn't realize the if statement also flipped the variables on semi/anti/IE/cross join.

I haven't fully reasoned about the behavior of accidentally doing this - it managed to pass CI but correctly we should only flip the variables when handling a right join.
