### PR TITLE
chore: Add `default_alloc` feature to `py-polars`

### DIFF
--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -111,6 +111,7 @@ all = [
   "performant",
 ]
 
+default_alloc = []
 default = ["all", "nightly"]
 
 [lints]

--- a/py-polars/src/allocator.rs
+++ b/py-polars/src/allocator.rs
@@ -1,6 +1,7 @@
 #[cfg(all(
     not(allocator = "mimalloc"),
     not(allocator = "default"),
+    not(feature = "default_alloc"),
     target_family = "unix",
     not(target_os = "emscripten"),
 ))]
@@ -9,6 +10,7 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[cfg(all(
     not(allocator = "default"),
+    not(feature = "default_alloc"),
     any(
         not(target_family = "unix"),
         target_os = "emscripten",


### PR DESCRIPTION
This can be used to build python polars for memory debugging.