### PR TITLE
fix(python): Remove AXIS ticks in `show_graph`

### DIFF
--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -697,9 +697,10 @@ def display_dot_graph(
         import matplotlib.image as mpimg
         import matplotlib.pyplot as plt
 
-        plt.figure(figsize=figsize)
+        fig = plt.figure(figsize=figsize)
         img = mpimg.imread(BytesIO(graph))
         plt.imshow(img)
+        fig.gca().set(xticks=[], yticks=[])
         plt.show()
         return None
 


### PR DESCRIPTION
Super minor improvement (IMO). Old `show_graph` showed tick marks with pixels that add no useful information to the graph:

![image](https://github.com/user-attachments/assets/990185a9-9164-49f1-8efb-bd11a24e3396)

This update removes the ticks:

![image](https://github.com/user-attachments/assets/0ca391f9-c024-4217-89e3-88643bb52f70)

It's easy to remove the box as well, should we do that too? e.g.:

![image](https://github.com/user-attachments/assets/08d1937d-59b1-4a3c-99d3-3963f0fe98e0)
