### PR TITLE
feat: Added `drop_nulls` option to `to_dummies`

### DIFF
--- a/crates/polars-ops/src/frame/mod.rs
+++ b/crates/polars-ops/src/frame/mod.rs
@@ -70,7 +70,12 @@ pub trait DataFrameOps: IntoDf {
     ///  +------+------+------+--------+--------+--------+---------+---------+---------+
     /// ```
     #[cfg(feature = "to_dummies")]
-    fn to_dummies(&self, separator: Option<&str>, drop_first: bool, drop_nulls: bool) -> PolarsResult<DataFrame> {
+    fn to_dummies(
+        &self,
+        separator: Option<&str>,
+        drop_first: bool,
+        drop_nulls: bool,
+    ) -> PolarsResult<DataFrame> {
         self._to_dummies(None, separator, drop_first, drop_nulls)
     }
 
@@ -107,7 +112,9 @@ pub trait DataFrameOps: IntoDf {
             df.get_columns()
                 .par_iter()
                 .map(|s| match set.contains(s.name().as_str()) {
-                    true => s.as_materialized_series().to_dummies(separator, drop_first, drop_nulls),
+                    true => s
+                        .as_materialized_series()
+                        .to_dummies(separator, drop_first, drop_nulls),
                     false => Ok(s.clone().into_frame()),
                 })
                 .collect::<PolarsResult<Vec<_>>>()

--- a/crates/polars-ops/src/frame/mod.rs
+++ b/crates/polars-ops/src/frame/mod.rs
@@ -41,7 +41,7 @@ pub trait DataFrameOps: IntoDf {
     ///       "code" => &["X1", "X2", "X3", "X3", "X2", "X2", "X1", "X1"]
     ///   }.unwrap();
     ///
-    ///   let dummies = df.to_dummies(None, false).unwrap();
+    ///   let dummies = df.to_dummies(None, false, false).unwrap();
     ///   println!("{}", dummies);
     /// # }
     /// ```
@@ -70,8 +70,8 @@ pub trait DataFrameOps: IntoDf {
     ///  +------+------+------+--------+--------+--------+---------+---------+---------+
     /// ```
     #[cfg(feature = "to_dummies")]
-    fn to_dummies(&self, separator: Option<&str>, drop_first: bool) -> PolarsResult<DataFrame> {
-        self._to_dummies(None, separator, drop_first)
+    fn to_dummies(&self, separator: Option<&str>, drop_first: bool, drop_nulls: bool) -> PolarsResult<DataFrame> {
+        self._to_dummies(None, separator, drop_first, drop_nulls)
     }
 
     #[cfg(feature = "to_dummies")]
@@ -80,8 +80,9 @@ pub trait DataFrameOps: IntoDf {
         columns: Vec<&str>,
         separator: Option<&str>,
         drop_first: bool,
+        drop_nulls: bool,
     ) -> PolarsResult<DataFrame> {
-        self._to_dummies(Some(columns), separator, drop_first)
+        self._to_dummies(Some(columns), separator, drop_first, drop_nulls)
     }
 
     #[cfg(feature = "to_dummies")]
@@ -90,6 +91,7 @@ pub trait DataFrameOps: IntoDf {
         columns: Option<Vec<&str>>,
         separator: Option<&str>,
         drop_first: bool,
+        drop_nulls: bool,
     ) -> PolarsResult<DataFrame> {
         use crate::series::ToDummies;
 
@@ -105,7 +107,7 @@ pub trait DataFrameOps: IntoDf {
             df.get_columns()
                 .par_iter()
                 .map(|s| match set.contains(s.name().as_str()) {
-                    true => s.as_materialized_series().to_dummies(separator, drop_first),
+                    true => s.as_materialized_series().to_dummies(separator, drop_first, drop_nulls),
                     false => Ok(s.clone().into_frame()),
                 })
                 .collect::<PolarsResult<Vec<_>>>()

--- a/crates/polars-ops/src/series/ops/to_dummies.rs
+++ b/crates/polars-ops/src/series/ops/to_dummies.rs
@@ -13,11 +13,11 @@ type DummyType = i32;
 type DummyCa = Int32Chunked;
 
 pub trait ToDummies {
-    fn to_dummies(&self, separator: Option<&str>, drop_first: bool) -> PolarsResult<DataFrame>;
+    fn to_dummies(&self, separator: Option<&str>, drop_first: bool, drop_nulls: bool) -> PolarsResult<DataFrame>;
 }
 
 impl ToDummies for Series {
-    fn to_dummies(&self, separator: Option<&str>, drop_first: bool) -> PolarsResult<DataFrame> {
+    fn to_dummies(&self, separator: Option<&str>, drop_first: bool, drop_nulls: bool) -> PolarsResult<DataFrame> {
         let sep = separator.unwrap_or("_");
         let col_name = self.name();
         let groups = self.group_tuples(true, drop_first)?;
@@ -26,7 +26,7 @@ impl ToDummies for Series {
         let columns = unsafe { self.agg_first(&groups) };
         let columns = columns.iter().zip(groups.iter()).skip(drop_first as usize);
         let columns = columns
-            .map(|(av, group)| {
+            .filter_map(|(av, group)| {
                 // strings are formatted with extra \" \" in polars, so we
                 // extract the string
                 let name = if let Some(s) = av.get_str() {
@@ -36,13 +36,17 @@ impl ToDummies for Series {
                     format_pl_smallstr!("{col_name}{sep}{av}")
                 };
 
+                if av.is_null() && drop_nulls {
+                    return None;
+                }
+
                 let ca = match group {
                     GroupsIndicator::Idx((_, group)) => dummies_helper_idx(group, self.len(), name),
                     GroupsIndicator::Slice([offset, len]) => {
                         dummies_helper_slice(offset, len, self.len(), name)
                     },
                 };
-                ca.into_column()
+                Some(ca.into_column())
             })
             .collect::<Vec<_>>();
 

--- a/crates/polars-ops/src/series/ops/to_dummies.rs
+++ b/crates/polars-ops/src/series/ops/to_dummies.rs
@@ -13,11 +13,21 @@ type DummyType = i32;
 type DummyCa = Int32Chunked;
 
 pub trait ToDummies {
-    fn to_dummies(&self, separator: Option<&str>, drop_first: bool, drop_nulls: bool) -> PolarsResult<DataFrame>;
+    fn to_dummies(
+        &self,
+        separator: Option<&str>,
+        drop_first: bool,
+        drop_nulls: bool,
+    ) -> PolarsResult<DataFrame>;
 }
 
 impl ToDummies for Series {
-    fn to_dummies(&self, separator: Option<&str>, drop_first: bool, drop_nulls: bool) -> PolarsResult<DataFrame> {
+    fn to_dummies(
+        &self,
+        separator: Option<&str>,
+        drop_first: bool,
+        drop_nulls: bool,
+    ) -> PolarsResult<DataFrame> {
         let sep = separator.unwrap_or("_");
         let col_name = self.name();
         let groups = self.group_tuples(true, drop_first)?;

--- a/crates/polars-python/src/dataframe/general.rs
+++ b/crates/polars-python/src/dataframe/general.rs
@@ -449,21 +449,23 @@ impl PyDataFrame {
         self.df.clone().lazy().into()
     }
 
-    #[pyo3(signature = (columns, separator, drop_first=false))]
+    #[pyo3(signature = (columns, separator, drop_first=false, drop_nulls=false))]
     pub fn to_dummies(
         &self,
         py: Python<'_>,
         columns: Option<Vec<String>>,
         separator: Option<&str>,
         drop_first: bool,
+        drop_nulls: bool,
     ) -> PyResult<Self> {
         py.enter_polars_df(|| match columns {
             Some(cols) => self.df.columns_to_dummies(
                 cols.iter().map(|x| x as &str).collect(),
                 separator,
                 drop_first,
+                drop_nulls
             ),
-            None => self.df.to_dummies(separator, drop_first),
+            None => self.df.to_dummies(separator, drop_first, drop_nulls),
         })
     }
 

--- a/crates/polars-python/src/dataframe/general.rs
+++ b/crates/polars-python/src/dataframe/general.rs
@@ -463,7 +463,7 @@ impl PyDataFrame {
                 cols.iter().map(|x| x as &str).collect(),
                 separator,
                 drop_first,
-                drop_nulls
+                drop_nulls,
             ),
             None => self.df.to_dummies(separator, drop_first, drop_nulls),
         })

--- a/crates/polars-python/src/series/general.rs
+++ b/crates/polars-python/src/series/general.rs
@@ -299,14 +299,15 @@ impl PySeries {
         py.enter_polars_series(|| self.series.zip_with(mask, &other.series))
     }
 
-    #[pyo3(signature = (separator, drop_first=false))]
+    #[pyo3(signature = (separator, drop_first=false, drop_nulls=false))]
     fn to_dummies(
         &self,
         py: Python<'_>,
         separator: Option<&str>,
         drop_first: bool,
+        drop_nulls: bool,
     ) -> PyResult<PyDataFrame> {
-        py.enter_polars_df(|| self.series.to_dummies(separator, drop_first))
+        py.enter_polars_df(|| self.series.to_dummies(separator, drop_first, drop_nulls))
     }
 
     fn get_list(&self, index: usize) -> Option<Self> {

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -10529,6 +10529,7 @@ class DataFrame:
         *,
         separator: str = "_",
         drop_first: bool = False,
+        drop_nulls: bool = False,
     ) -> DataFrame:
         """
         Convert categorical variables into dummy/indicator variables.
@@ -10542,6 +10543,8 @@ class DataFrame:
             Separator/delimiter used when generating column names.
         drop_first
             Remove the first category from the variables being encoded.
+        drop_nulls
+            If there are `None` values in the series, a `null` column is not generated
 
         Examples
         --------
@@ -10599,7 +10602,7 @@ class DataFrame:
         """
         if columns is not None:
             columns = _expand_selectors(self, columns)
-        return self._from_pydf(self._df.to_dummies(columns, separator, drop_first))
+        return self._from_pydf(self._df.to_dummies(columns, separator, drop_first, drop_nulls))
 
     def unique(
         self,

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -10602,7 +10602,9 @@ class DataFrame:
         """
         if columns is not None:
             columns = _expand_selectors(self, columns)
-        return self._from_pydf(self._df.to_dummies(columns, separator, drop_first, drop_nulls))
+        return self._from_pydf(
+            self._df.to_dummies(columns, separator, drop_first, drop_nulls)
+        )
 
     def unique(
         self,

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -2269,7 +2269,11 @@ class Series:
         return self._s.quantile(quantile, interpolation)
 
     def to_dummies(
-        self, *, separator: str = "_", drop_first: bool = False, drop_nulls = False,
+        self,
+        *,
+        separator: str = "_",
+        drop_first: bool = False,
+        drop_nulls: bool = False,
     ) -> DataFrame:
         """
         Get dummy/indicator variables.

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -2269,7 +2269,7 @@ class Series:
         return self._s.quantile(quantile, interpolation)
 
     def to_dummies(
-        self, *, separator: str = "_", drop_first: bool = False
+        self, *, separator: str = "_", drop_first: bool = False, drop_nulls = False,
     ) -> DataFrame:
         """
         Get dummy/indicator variables.
@@ -2280,6 +2280,8 @@ class Series:
             Separator/delimiter used when generating column names.
         drop_first
             Remove the first category from the variable being encoded.
+        drop_nulls
+            If there are `None` values in the series, a `null` column is not generated
 
         Examples
         --------
@@ -2308,7 +2310,7 @@ class Series:
         │ 0   ┆ 1   │
         └─────┴─────┘
         """
-        return wrap_df(self._s.to_dummies(separator, drop_first))
+        return wrap_df(self._s.to_dummies(separator, drop_first, drop_nulls))
 
     @unstable()
     def cut(

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -793,6 +793,7 @@ def test_to_dummies_drop_first() -> None:
         (0, 1, 0, 1, 0, 1),
     ]
 
+
 def test_to_dummies_drop_nulls() -> None:
     df = pl.DataFrame(
         {
@@ -804,21 +805,23 @@ def test_to_dummies_drop_nulls() -> None:
 
     dm = df.to_dummies(drop_nulls=True)
 
-    expected = pl.DataFrame({
-        "foo_0": [1, 0, 0],
-        "foo_1": [0, 1, 0],
-        "bar_3": [1, 0, 0],
-        "bar_5": [0, 0, 1],
-        "baz_y": [0, 1, 0],
-        "baz_z": [0, 0, 1],
-    }, schema={
-        "foo_0": pl.UInt8,
-        "foo_1": pl.UInt8,
-        "bar_3": pl.UInt8,
-        "bar_5": pl.UInt8,
-        "baz_y": pl.UInt8,
-        "baz_z": pl.UInt8,
-    }
+    expected = pl.DataFrame(
+        {
+            "foo_0": [1, 0, 0],
+            "foo_1": [0, 1, 0],
+            "bar_3": [1, 0, 0],
+            "bar_5": [0, 0, 1],
+            "baz_y": [0, 1, 0],
+            "baz_z": [0, 0, 1],
+        },
+        schema={
+            "foo_0": pl.UInt8,
+            "foo_1": pl.UInt8,
+            "bar_3": pl.UInt8,
+            "bar_5": pl.UInt8,
+            "baz_y": pl.UInt8,
+            "baz_z": pl.UInt8,
+        },
     )
     assert_frame_equal(dm, expected)
 

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -793,6 +793,35 @@ def test_to_dummies_drop_first() -> None:
         (0, 1, 0, 1, 0, 1),
     ]
 
+def test_to_dummies_drop_nulls() -> None:
+    df = pl.DataFrame(
+        {
+            "foo": [0, 1, None],
+            "bar": [3, None, 5],
+            "baz": [None, "y", "z"],
+        }
+    )
+
+    dm = df.to_dummies(drop_nulls=True)
+
+    expected = pl.DataFrame({
+        "foo_0": [1, 0, 0],
+        "foo_1": [0, 1, 0],
+        "bar_3": [1, 0, 0],
+        "bar_5": [0, 0, 1],
+        "baz_y": [0, 1, 0],
+        "baz_z": [0, 0, 1],
+    }, schema={
+        "foo_0": pl.UInt8,
+        "foo_1": pl.UInt8,
+        "bar_3": pl.UInt8,
+        "bar_5": pl.UInt8,
+        "baz_y": pl.UInt8,
+        "baz_z": pl.UInt8,
+    }
+    )
+    assert_frame_equal(dm, expected)
+
 
 def test_to_pandas(df: pl.DataFrame) -> None:
     # pyarrow cannot deal with unsigned dictionary integer yet.

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1378,6 +1378,7 @@ def test_to_dummies_drop_first() -> None:
     )
     assert_frame_equal(result, expected)
 
+
 def test_to_dummies_drop_nulls() -> None:
     s = pl.Series("a", [1, 2, None])
     result = s.to_dummies(drop_nulls=True)

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1378,6 +1378,15 @@ def test_to_dummies_drop_first() -> None:
     )
     assert_frame_equal(result, expected)
 
+def test_to_dummies_drop_nulls() -> None:
+    s = pl.Series("a", [1, 2, None])
+    result = s.to_dummies(drop_nulls=True)
+    expected = pl.DataFrame(
+        {"a_1": [1, 0, 0], "a_2": [0, 1, 0]},
+        schema={"a_1": pl.UInt8, "a_2": pl.UInt8},
+    )
+    assert_frame_equal(result, expected)
+
 
 def test_to_dummies_null_clash_19096() -> None:
     with pytest.raises(


### PR DESCRIPTION
### Motivation 
I felt like it would be very useful to have this option, instead of manually dropping resulting `null` columns after calling `to_dummies`. One advantage also is that the `null` column is not materialized at all.  

Edit: This also fixes https://github.com/pola-rs/polars/issues/19095. After reading through https://github.com/pola-rs/polars/issues/19325, I'm not sure if this PR is actually worthwhile moving forward. Imho I think adding this optional parameter makes a lot of sense, but let me know if you feel differently

Example: 

```python
import polars as pl

s = pl.Series("a", [1, 2, None])

print("Keep Null Column", s.to_dummies()) # current and default behavior
print("Drop Null Column", s.to_dummies(drop_nulls=True))
```

```
Keep Null Column shape: (3, 3)
┌─────┬─────┬────────┐
│ a_1 ┆ a_2 ┆ a_null │
│ --- ┆ --- ┆ ---    │
│ u8  ┆ u8  ┆ u8     │
╞═════╪═════╪════════╡
│ 1   ┆ 0   ┆ 0      │
│ 0   ┆ 1   ┆ 0      │
│ 0   ┆ 0   ┆ 1      │
└─────┴─────┴────────┘

Drop Null Column shape: (3, 2)
┌─────┬─────┐
│ a_1 ┆ a_2 │
│ --- ┆ --- │
│ u8  ┆ u8  │
╞═════╪═════╡
│ 1   ┆ 0   │
│ 0   ┆ 1   │
│ 0   ┆ 0   │
└─────┴─────┘
```

