### PR TITLE
Revert "fix(python): Don't call unnest for objects implementing `__arrow_c_array__`"

### DIFF
--- a/py-polars/polars/_utils/pycapsule.py
+++ b/py-polars/polars/_utils/pycapsule.py
@@ -28,8 +28,11 @@ def pycapsule_to_frame(
 ) -> DataFrame:
     """Convert PyCapsule object to DataFrame."""
     if hasattr(obj, "__arrow_c_array__"):
+        # This uses the fact that PySeries.from_arrow_c_array will create a
+        # struct-typed Series. Then we unpack that to a DataFrame.
+        tmp_col_name = ""
         s = wrap_s(PySeries.from_arrow_c_array(obj))
-        df = s.to_frame()
+        df = s.to_frame(tmp_col_name).unnest(tmp_col_name)
 
     elif hasattr(obj, "__arrow_c_stream__"):
         # This uses the fact that PySeries.from_arrow_c_stream will create a

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -1728,7 +1728,7 @@ def test_pycapsule_interface(df: pl.DataFrame) -> None:
     # RecordBatch via C array interface
     pyarrow_record_batch = pyarrow_table.to_batches()[0]
     round_trip_df = pl.DataFrame(PyCapsuleArrayHolder(pyarrow_record_batch))
-    assert df.equals(round_trip_df.unnest(""))
+    assert df.equals(round_trip_df)
 
     # ChunkedArray via C stream interface
     pyarrow_chunked_array = pyarrow_table["bools"]

--- a/py-polars/tests/unit/interchange/test_from_dataframe.py
+++ b/py-polars/tests/unit/interchange/test_from_dataframe.py
@@ -122,7 +122,7 @@ def test_from_dataframe_pyarrow_recordbatch_zero_copy() -> None:
 
     batch = pa.record_batch([a, b], names=["a", "b"])
     with pytest.deprecated_call(match="`allow_copy` is deprecated"):
-        result = pl.from_dataframe(batch, allow_copy=False).unnest("")
+        result = pl.from_dataframe(batch, allow_copy=False)
 
     expected = pl.DataFrame({"a": [1, 2], "b": [3.0, 4.0]})
     assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -938,17 +938,3 @@ def test_from_arrow_string_cache_20271() -> None:
 def test_to_arrow_empty_chunks_20627() -> None:
     df = pl.concat(2 * [pl.Series([1])]).filter(pl.Series([False, True])).to_frame()
     assert df.to_arrow().shape == (1, 1)
-
-
-def test_arrow_c_array_object_no_unnest_23068() -> None:
-    class ArrowLike:
-        def __init__(self, pa_array: pa.Array) -> None:
-            self.pa_array = pa_array
-
-        def __arrow_c_array__(self, requested_schema: Any = None) -> Any:
-            return self.pa_array.__arrow_c_array__(requested_schema)
-
-    data = [1, 2, 3]
-    result = cast(pl.DataFrame, pl.from_arrow(ArrowLike(pa.array(data)))).to_series()
-    expected = pl.Series(data)
-    assert_series_equal(result, expected)


### PR DESCRIPTION
Reverts pola-rs/polars#23069