### PR TITLE
fix(python): Only call unnest for objects implementing __arrow_c_array__ if a pyarrow.RecordBatch

### DIFF
--- a/py-polars/polars/_utils/pycapsule.py
+++ b/py-polars/polars/_utils/pycapsule.py
@@ -28,11 +28,8 @@ def pycapsule_to_frame(
 ) -> DataFrame:
     """Convert PyCapsule object to DataFrame."""
     if hasattr(obj, "__arrow_c_array__"):
-        # This uses the fact that PySeries.from_arrow_c_array will create a
-        # struct-typed Series. Then we unpack that to a DataFrame.
-        tmp_col_name = ""
         s = wrap_s(PySeries.from_arrow_c_array(obj))
-        df = s.to_frame(tmp_col_name).unnest(tmp_col_name)
+        df = s.to_frame()
 
     elif hasattr(obj, "__arrow_c_stream__"):
         # This uses the fact that PySeries.from_arrow_c_stream will create a

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -1728,7 +1728,7 @@ def test_pycapsule_interface(df: pl.DataFrame) -> None:
     # RecordBatch via C array interface
     pyarrow_record_batch = pyarrow_table.to_batches()[0]
     round_trip_df = pl.DataFrame(PyCapsuleArrayHolder(pyarrow_record_batch))
-    assert df.equals(round_trip_df.unnest(""))
+    assert df.equals(round_trip_df)
 
     # ChunkedArray via C stream interface
     pyarrow_chunked_array = pyarrow_table["bools"]

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -1728,7 +1728,7 @@ def test_pycapsule_interface(df: pl.DataFrame) -> None:
     # RecordBatch via C array interface
     pyarrow_record_batch = pyarrow_table.to_batches()[0]
     round_trip_df = pl.DataFrame(PyCapsuleArrayHolder(pyarrow_record_batch))
-    assert df.equals(round_trip_df)
+    assert df.equals(round_trip_df.unnest(""))
 
     # ChunkedArray via C stream interface
     pyarrow_chunked_array = pyarrow_table["bools"]

--- a/py-polars/tests/unit/interchange/test_from_dataframe.py
+++ b/py-polars/tests/unit/interchange/test_from_dataframe.py
@@ -122,7 +122,7 @@ def test_from_dataframe_pyarrow_recordbatch_zero_copy() -> None:
 
     batch = pa.record_batch([a, b], names=["a", "b"])
     with pytest.deprecated_call(match="`allow_copy` is deprecated"):
-        result = pl.from_dataframe(batch, allow_copy=False).unnest("")
+        result = pl.from_dataframe(batch, allow_copy=False)
 
     expected = pl.DataFrame({"a": [1, 2], "b": [3.0, 4.0]})
     assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/interchange/test_from_dataframe.py
+++ b/py-polars/tests/unit/interchange/test_from_dataframe.py
@@ -122,7 +122,7 @@ def test_from_dataframe_pyarrow_recordbatch_zero_copy() -> None:
 
     batch = pa.record_batch([a, b], names=["a", "b"])
     with pytest.deprecated_call(match="`allow_copy` is deprecated"):
-        result = pl.from_dataframe(batch, allow_copy=False)
+        result = pl.from_dataframe(batch, allow_copy=False).unnest("")
 
     expected = pl.DataFrame({"a": [1, 2], "b": [3.0, 4.0]})
     assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -940,19 +940,15 @@ def test_to_arrow_empty_chunks_20627() -> None:
     assert df.to_arrow().shape == (1, 1)
 
 
-def test_from_arrow_recorbatch() -> None:
-    n_legs = pa.array([2, 2, 4, 4, 5, 100])
-    animals = pa.array(
-        ["Flamingo", "Parrot", "Dog", "Horse", "Brittle stars", "Centipede"]
-    )
-    names = ["n_legs", "animals"]
-    record_batch = pa.RecordBatch.from_arrays([n_legs, animals], names=names)
-    assert_frame_equal(
-        pl.DataFrame(record_batch),
-        pl.DataFrame(
-            {
-                "n_legs": n_legs,
-                "animals": animals,
-            }
-        ),
-    )
+def test_arrow_c_array_object_no_unnest_23068() -> None:
+    class ArrowLike:
+        def __init__(self, pa_array: pa.Array) -> None:
+            self.pa_array = pa_array
+
+        def __arrow_c_array__(self, requested_schema: Any = None) -> Any:
+            return self.pa_array.__arrow_c_array__(requested_schema)
+
+    data = [1, 2, 3]
+    result = cast(pl.DataFrame, pl.from_arrow(ArrowLike(pa.array(data)))).to_series()
+    expected = pl.Series(data)
+    assert_series_equal(result, expected)

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -952,3 +952,21 @@ def test_arrow_c_array_object_no_unnest_23068() -> None:
     result = cast(pl.DataFrame, pl.from_arrow(ArrowLike(pa.array(data)))).to_series()
     expected = pl.Series(data)
     assert_series_equal(result, expected)
+
+
+def test_from_arrow_recorbatch() -> None:
+    n_legs = pa.array([2, 2, 4, 4, 5, 100])
+    animals = pa.array(
+        ["Flamingo", "Parrot", "Dog", "Horse", "Brittle stars", "Centipede"]
+    )
+    names = ["n_legs", "animals"]
+    record_batch = pa.RecordBatch.from_arrays([n_legs, animals], names=names)
+    assert_frame_equal(
+        pl.DataFrame(record_batch),
+        pl.DataFrame(
+            {
+                "n_legs": n_legs,
+                "animals": animals,
+            }
+        ),
+    )


### PR DESCRIPTION
closes https://github.com/pola-rs/polars/issues/23068

Redo of https://github.com/pola-rs/polars/pull/23069 based of the feedback of https://github.com/pola-rs/polars/issues/23194, only calls `unnest` if the object is a `pyarrow.RecordBatch`

For context in `cudf_polars`, we'd like the ability to perform `pl.from_arrow(cudf_object)` that implements `__arrow_c_array__`

