### PR TITLE
fix: Expose FieldsMapper

### DIFF
--- a/crates/polars-plan/src/plans/mod.rs
+++ b/crates/polars-plan/src/plans/mod.rs
@@ -27,7 +27,7 @@ pub use python::*;
 mod schema;
 pub mod visitor;
 
-pub use aexpr::{FieldsMapper, *};
+pub use aexpr::*;
 pub use anonymous_scan::*;
 pub use apply::*;
 pub use builder_ir::*;


### PR DESCRIPTION
This type is needed by pyo3-polars but was not expose in the API when the file `schema.rs` was moved. 