### PR TITLE
perf: Push more filters past joins

### DIFF
--- a/crates/polars-ops/src/frame/join/args.rs
+++ b/crates/polars-ops/src/frame/join/args.rs
@@ -47,8 +47,9 @@ pub enum JoinType {
     Left,
     Right,
     Full,
+    // Box is okay because this is inside a `Arc<JoinOptionsIR>`
     #[cfg(feature = "asof_join")]
-    AsOf(AsOfOptions),
+    AsOf(Box<AsOfOptions>),
     #[cfg(feature = "semi_anti_join")]
     Semi,
     #[cfg(feature = "semi_anti_join")]

--- a/crates/polars-plan/src/plans/optimizer/collapse_joins.rs
+++ b/crates/polars-plan/src/plans/optimizer/collapse_joins.rs
@@ -127,6 +127,7 @@ pub fn optimize(
                             left_schema,
                             right_schema,
                             suffix.as_str(),
+                            None,
                         )
                         .unwrap();
                         let right_origin = ExprOrigin::get_expr_origin(
@@ -135,6 +136,7 @@ pub fn optimize(
                             left_schema,
                             right_schema,
                             suffix.as_str(),
+                            None,
                         )
                         .unwrap();
 

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
@@ -1,101 +1,7 @@
+use polars_utils::format_pl_smallstr;
+
 use super::*;
 use crate::plans::optimizer::join_utils::remove_suffix;
-
-// Information concerning individual sides of a join.
-#[derive(PartialEq, Eq)]
-struct LeftRight<T>(T, T);
-
-fn should_block_join_specific(
-    ae: &AExpr,
-    how: &JoinType,
-    on_names: &PlHashSet<PlSmallStr>,
-    expr_arena: &Arena<AExpr>,
-    schema_left: &Schema,
-    schema_right: &Schema,
-) -> LeftRight<bool> {
-    use AExpr::*;
-    match ae {
-        // joins can produce null values
-        Function {
-            function:
-                IRFunctionExpr::Boolean(IRBooleanFunction::IsNotNull)
-                | IRFunctionExpr::Boolean(IRBooleanFunction::IsNull)
-                | IRFunctionExpr::FillNull,
-            ..
-        } => join_produces_null(how),
-        #[cfg(feature = "is_in")]
-        Function {
-            function: IRFunctionExpr::Boolean(IRBooleanFunction::IsIn { .. }),
-            ..
-        } => join_produces_null(how),
-        // joins can produce duplicates
-        #[cfg(feature = "is_unique")]
-        Function {
-            function:
-                IRFunctionExpr::Boolean(IRBooleanFunction::IsUnique)
-                | IRFunctionExpr::Boolean(IRBooleanFunction::IsDuplicated),
-            ..
-        } => LeftRight(true, true),
-        #[cfg(feature = "is_first_distinct")]
-        Function {
-            function: IRFunctionExpr::Boolean(IRBooleanFunction::IsFirstDistinct),
-            ..
-        } => LeftRight(true, true),
-        // any operation that checks for equality or ordering can be wrong because
-        // the join can produce null values
-        // TODO! check if we can be less conservative here
-        BinaryExpr {
-            op: Operator::Eq | Operator::NotEq,
-            left,
-            right,
-        } => {
-            let LeftRight(bleft, bright) = join_produces_null(how);
-
-            let l_name = aexpr_output_name(*left, expr_arena).unwrap();
-            let r_name = aexpr_output_name(*right, expr_arena).unwrap();
-
-            let is_in_on = on_names.contains(&l_name) || on_names.contains(&r_name);
-
-            let block_left =
-                is_in_on && (schema_left.contains(&l_name) || schema_left.contains(&r_name));
-            let block_right =
-                is_in_on && (schema_right.contains(&l_name) || schema_right.contains(&r_name));
-            LeftRight(block_left | bleft, block_right | bright)
-        },
-        _ => join_produces_null(how),
-    }
-}
-
-/// Returns a tuple indicating whether predicates should be blocked for either side based on the
-/// join type.
-///
-/// * `true` indicates that predicates must not be pushed to that side
-fn join_produces_null(how: &JoinType) -> LeftRight<bool> {
-    match how {
-        JoinType::Left => LeftRight(false, true),
-        JoinType::Right => LeftRight(true, false),
-
-        JoinType::Full => LeftRight(true, true),
-        JoinType::Cross => LeftRight(true, true),
-        #[cfg(feature = "asof_join")]
-        JoinType::AsOf(_) => LeftRight(true, true),
-
-        JoinType::Inner => LeftRight(false, false),
-        #[cfg(feature = "semi_anti_join")]
-        JoinType::Semi | JoinType::Anti => LeftRight(false, false),
-        #[cfg(feature = "iejoin")]
-        JoinType::IEJoin => LeftRight(false, false),
-    }
-}
-
-fn all_pred_cols_in_left_on(
-    predicate: &ExprIR,
-    expr_arena: &mut Arena<AExpr>,
-    left_on: &[ExprIR],
-) -> bool {
-    aexpr_to_leaf_names_iter(predicate.node(), expr_arena)
-        .all(|pred_column_name| left_on.iter().any(|e| e.output_name() == &pred_column_name))
-}
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn process_join(
@@ -110,135 +16,296 @@ pub(super) fn process_join(
     options: Arc<JoinOptionsIR>,
     acc_predicates: PlHashMap<PlSmallStr, ExprIR>,
 ) -> PolarsResult<IR> {
-    use IR::*;
     let schema_left = lp_arena.get(input_left).schema(lp_arena);
     let schema_right = lp_arena.get(input_right).schema(lp_arena);
 
-    let on_names = left_on
-        .iter()
-        .flat_map(|e| aexpr_to_leaf_names_iter(e.node(), expr_arena))
-        .chain(
-            right_on
-                .iter()
-                .flat_map(|e| aexpr_to_leaf_names_iter(e.node(), expr_arena)),
-        )
-        .collect::<PlHashSet<_>>();
+    // This is always lowered to cross join + filter.
+    // The translation to IEJoin happens in collapse_joins, which runs after this function.
+    #[cfg(feature = "iejoin")]
+    assert!(!matches!(&options.args.how, JoinType::IEJoin));
 
-    let mut pushdown_left = init_hashmap(Some(acc_predicates.len()));
-    let mut pushdown_right = init_hashmap(Some(acc_predicates.len()));
-    let mut local_predicates = Vec::with_capacity(acc_predicates.len());
+    if acc_predicates.is_empty()
+        || match &options.args.how {
+            // Full-join with no coalesce. We can only push filters if they do not remove NULLs, but
+            // we don't have a reliable way to guarantee this.
+            JoinType::Full => !options.args.should_coalesce(),
 
-    for (_, predicate) in acc_predicates {
-        let column_origins = ExprOrigin::get_expr_origin(
-            predicate.node(),
-            expr_arena,
-            &schema_left,
-            &schema_right,
-            options.args.suffix(),
-        )
-        .unwrap_or_else(|e| {
-            if cfg!(debug_assertions) {
-                panic!("{e:?}")
-            } else {
-                ExprOrigin::None
-            }
-        });
+            _ => false,
+        }
+    {
+        let lp = IR::Join {
+            input_left,
+            input_right,
+            left_on,
+            right_on,
+            schema,
+            options,
+        };
 
-        // Cross joins produce a cartesian product, so if a predicate combines columns from both tables, we should not push down.
-        // Inequality joins logically produce a cartesian product, so the same logic applies.
-        if (options.args.how.is_cross() || options.args.how.is_ie())
-            && column_origins == ExprOrigin::Both
-        {
-            local_predicates.push(predicate);
-            continue;
+        return opt.no_pushdown_restart_opt(lp, acc_predicates, lp_arena, expr_arena);
+    }
+
+    // AsOf has the equality join keys under `asof_options.left/right_by`. This code builds an
+    // iterator to address these generically without creating a `Box<dyn Iterator>`.
+    let get_lhs_column_keys_iter = || {
+        let len = match &options.args.how {
+            #[cfg(feature = "asof_join")]
+            JoinType::AsOf(asof_options) => {
+                asof_options.left_by.as_deref().unwrap_or_default().len()
+            },
+            _ => left_on.len(),
+        };
+
+        (0..len).map(|i| match &options.args.how {
+            #[cfg(feature = "asof_join")]
+            JoinType::AsOf(asof_options) => Some(
+                asof_options
+                    .left_by
+                    .as_deref()
+                    .unwrap_or_default()
+                    .get(i)
+                    .unwrap(),
+            ),
+            _ => {
+                let expr = left_on.get(i).unwrap();
+
+                if let AExpr::Column(name) = expr_arena.get(expr.node()) {
+                    Some(name)
+                } else {
+                    None
+                }
+            },
+        })
+    };
+
+    let get_rhs_column_keys_iter = || {
+        let len = match &options.args.how {
+            #[cfg(feature = "asof_join")]
+            JoinType::AsOf(asof_options) => {
+                asof_options.right_by.as_deref().unwrap_or_default().len()
+            },
+            _ => right_on.len(),
+        };
+
+        (0..len).map(|i| match &options.args.how {
+            #[cfg(feature = "asof_join")]
+            JoinType::AsOf(asof_options) => Some(
+                asof_options
+                    .right_by
+                    .as_deref()
+                    .unwrap_or_default()
+                    .get(i)
+                    .unwrap(),
+            ),
+            _ => {
+                let expr = right_on.get(i).unwrap();
+
+                if let AExpr::Column(name) = expr_arena.get(expr.node()) {
+                    Some(name)
+                } else {
+                    None
+                }
+            },
+        })
+    };
+
+    if cfg!(debug_assertions) && options.args.should_coalesce() {
+        match &options.args.how {
+            #[cfg(feature = "asof_join")]
+            JoinType::AsOf(_) => {},
+
+            _ => {
+                assert!(get_lhs_column_keys_iter().len() > 0);
+                assert!(get_rhs_column_keys_iter().len() > 0);
+            },
         }
 
-        // check if predicate can pass the joins node
-        let allow_pushdown_left = !has_aexpr(predicate.node(), expr_arena, |ae| {
-            should_block_join_specific(
-                ae,
-                &options.args.how,
-                &on_names,
-                expr_arena,
+        assert!(get_lhs_column_keys_iter().all(|x| x.is_some()));
+        assert!(get_rhs_column_keys_iter().all(|x| x.is_some()));
+    }
+
+    // Key columns of the left table that are coalesced into an output column of the right table.
+    let coalesced_to_right: PlHashSet<PlSmallStr> =
+        if matches!(&options.args.how, JoinType::Right) && options.args.should_coalesce() {
+            get_lhs_column_keys_iter()
+                .map(|x| x.unwrap().clone())
+                .collect()
+        } else {
+            Default::default()
+        };
+
+    let mut output_key_to_left_input_map: PlHashMap<PlSmallStr, PlSmallStr> =
+        PlHashMap::with_capacity(get_lhs_column_keys_iter().len());
+    let mut output_key_to_right_input_map: PlHashMap<PlSmallStr, PlSmallStr> =
+        PlHashMap::with_capacity(get_rhs_column_keys_iter().len());
+
+    for (lhs_input_key, rhs_input_key) in get_lhs_column_keys_iter().zip(get_rhs_column_keys_iter())
+    {
+        let (Some(lhs_input_key), Some(rhs_input_key)) = (lhs_input_key, rhs_input_key) else {
+            continue;
+        };
+
+        // lhs_input_key: Column name within the left table.
+        use JoinType::*;
+        // Map output name of an LHS join key output to an input key column of the right table.
+        if match &options.args.how {
+            Left | Inner | Full => true,
+
+            #[cfg(feature = "asof_join")]
+            AsOf(_) => true,
+            #[cfg(feature = "semi_anti_join")]
+            Semi | Anti => true,
+
+            // NOTE: Right-join is excluded.
+            Right => false,
+
+            #[cfg(feature = "iejoin")]
+            IEJoin => unreachable!(),
+            Cross => unreachable!(),
+        } {
+            // Note: `lhs_input_key` maintains its name in the output column for all cases except
+            // for a coalescing right-join.
+            output_key_to_right_input_map.insert(lhs_input_key.clone(), rhs_input_key.clone());
+        }
+
+        // Map output name of an RHS join key output to a key column of the left table.
+        if match &options.args.how {
+            JoinType::Right => true,
+            // Non-coalesced output columns of an inner join are equivalent between LHS and RHS.
+            JoinType::Inner => !options.args.should_coalesce(),
+            _ => false,
+        } {
+            let rhs_output_key: PlSmallStr = if schema_left.contains(rhs_input_key.as_str())
+                && !coalesced_to_right.contains(rhs_input_key.as_str())
+            {
+                format_pl_smallstr!("{}{}", rhs_input_key, options.args.suffix())
+            } else {
+                rhs_input_key.clone()
+            };
+
+            assert!(schema.contains(&rhs_output_key));
+
+            output_key_to_left_input_map.insert(rhs_output_key.clone(), lhs_input_key.clone());
+        }
+    }
+
+    let mut pushdown_left: PlHashMap<PlSmallStr, ExprIR> = init_hashmap(Some(acc_predicates.len()));
+    let mut pushdown_right: PlHashMap<PlSmallStr, ExprIR> =
+        init_hashmap(Some(acc_predicates.len()));
+    let mut local_predicates = Vec::with_capacity(acc_predicates.len());
+
+    for (predicate_key, predicate) in acc_predicates {
+        let mut push_left = true;
+        let mut push_right = true;
+
+        for col_name in aexpr_to_leaf_names_iter(predicate.node(), expr_arena) {
+            let origin: ExprOrigin = ExprOrigin::get_column_origin(
+                col_name.as_str(),
                 &schema_left,
                 &schema_right,
+                options.args.suffix(),
+                Some(&|name| coalesced_to_right.contains(name)),
             )
-            .0
-        });
+            .unwrap();
 
-        let allow_pushdown_right = !has_aexpr(predicate.node(), expr_arena, |ae| {
-            should_block_join_specific(
-                ae,
-                &options.args.how,
-                &on_names,
-                expr_arena,
-                &schema_left,
-                &schema_right,
-            )
-            .1
-        });
+            push_left &= matches!(origin, ExprOrigin::Left)
+                || output_key_to_left_input_map.contains_key(&col_name);
 
-        // these indicate to which tables we are going to push down the predicate
-        let mut filter_left = false;
-        let mut filter_right = false;
+            push_right &= matches!(origin, ExprOrigin::Right)
+                || output_key_to_right_input_map.contains_key(&col_name);
+        }
 
-        if allow_pushdown_left && column_origins == ExprOrigin::Left {
-            filter_left = true;
+        // Note: If `push_left` and `push_right` are both `true`, it means the predicate refers only
+        // to the join key columns.
 
-            insert_and_combine_predicate(&mut pushdown_left, &predicate, expr_arena);
-            // If we push down to the left and all predicate columns are also
-            // join columns, we also push down right for inner, left or semi join
-            if all_pred_cols_in_left_on(&predicate, expr_arena, &left_on) {
-                filter_right = match &options.args.how {
-                    // TODO! if join_on right has a different name
-                    // we can set this to `true` IFF we rename the predicate
-                    JoinType::Inner | JoinType::Left => {
-                        check_input_node(predicate.node(), &schema_right, expr_arena)
-                    },
-                    #[cfg(feature = "semi_anti_join")]
-                    JoinType::Semi => check_input_node(predicate.node(), &schema_right, expr_arena),
-                    _ => false,
-                }
-            }
-        // this is `else if` because if the predicate is in the left hand side
-        // the right hand side should be renamed with the suffix.
-        // in that case we should not push down as the user wants to filter on `x`
-        // not on `x_rhs`.
-        } else if allow_pushdown_right && column_origins == ExprOrigin::Right {
-            filter_right = true;
+        let has_residual = match &options.args.how {
+            // Pushing to a single side is enough to observe the full effect of the filter.
+            JoinType::Inner => !(push_left || push_right),
 
+            // Left-join: Pushing filters to the left table is enough to observe the effect of the
+            // filter. Pushing filters to the right is optional, but can only be done if the
+            // filter is also pushed to the left (if this is the case it means the filter only
+            // references join key columns).
+            JoinType::Left => {
+                push_right &= push_left;
+                !push_left
+            },
+
+            // Same as left-join, just flipped around.
+            JoinType::Right => {
+                push_left &= push_right;
+                !push_right
+            },
+
+            // Full-join: Filters must strictly apply only to coalesced output key columns.
+            JoinType::Full => {
+                assert!(options.args.should_coalesce());
+
+                let push = push_left && push_right;
+                push_left = push;
+                push_right = push;
+
+                !push
+            },
+
+            JoinType::Cross => {
+                // Predicate should only refer to a single side.
+                assert!(output_key_to_left_input_map.is_empty());
+                assert!(output_key_to_right_input_map.is_empty());
+                !(push_left || push_right)
+            },
+
+            // Behaves similarly to left-join on "by" columns (takes a single match instead of
+            // all matches according to asof strategy).
+            #[cfg(feature = "asof_join")]
+            JoinType::AsOf(_) => {
+                push_right &= push_left;
+                !push_left
+            },
+
+            // Same as inner-join
+            #[cfg(feature = "semi_anti_join")]
+            JoinType::Semi => !(push_left || push_right),
+
+            // Anti-join is an exclusion of key tuples that exist in the right table, meaning that
+            // filters can only be pushed to the right table if they are also pushed to the left.
+            #[cfg(feature = "semi_anti_join")]
+            JoinType::Anti => {
+                push_right &= push_left;
+                !push_left
+            },
+
+            #[cfg(feature = "iejoin")]
+            JoinType::IEJoin => unreachable!(),
+        };
+
+        if has_residual {
+            local_predicates.push(predicate.clone())
+        }
+
+        if push_left {
             let mut predicate = predicate.clone();
+            map_column_references(&mut predicate, expr_arena, &output_key_to_left_input_map);
+            pushdown_left.insert(predicate_key.clone(), predicate);
+        }
+
+        if push_right {
+            let mut predicate = predicate;
+            map_column_references(&mut predicate, expr_arena, &output_key_to_right_input_map);
             remove_suffix(
                 &mut predicate,
                 expr_arena,
                 &schema_right,
                 options.args.suffix(),
             );
-
-            insert_and_combine_predicate(&mut pushdown_right, &predicate, expr_arena);
-        }
-
-        match (filter_left, filter_right, &options.args.how) {
-            // if not pushed down on one of the tables we have to do it locally.
-            (false, false, _) |
-            // if left join and predicate only available in right table,
-            // 'we should not filter right, because that would lead to
-            // invalid results.
-            // see: #2057
-            (false, true, JoinType::Left)
-            => {
-                local_predicates.push(predicate);
-                continue;
-            },
-            // business as usual
-            _ => {}
+            pushdown_right.insert(predicate_key, predicate);
         }
     }
 
     opt.pushdown_and_assign(input_left, pushdown_left, lp_arena, expr_arena)?;
     opt.pushdown_and_assign(input_right, pushdown_right, lp_arena, expr_arena)?;
 
-    let lp = Join {
+    let lp = IR::Join {
         input_left,
         input_right,
         left_on,

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
@@ -472,6 +472,8 @@ pub(crate) fn ir_removes_rows(ir: &IR) -> bool {
 
 /// Maps column references within an expression. Used to handle column renaming when pushing
 /// predicates.
+///
+/// This will not mutate the underlying nodes.
 pub(super) fn map_column_references(
     expr: &mut ExprIR,
     expr_arena: &mut Arena<AExpr>,

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -1129,7 +1129,7 @@ impl PyLazyFrame {
             .allow_parallel(allow_parallel)
             .force_parallel(force_parallel)
             .coalesce(coalesce)
-            .how(JoinType::AsOf(AsOfOptions {
+            .how(JoinType::AsOf(Box::new(AsOfOptions {
                 strategy: strategy.0,
                 left_by: left_by.map(strings_to_pl_smallstr),
                 right_by: right_by.map(strings_to_pl_smallstr),
@@ -1137,7 +1137,7 @@ impl PyLazyFrame {
                 tolerance_str: tolerance_str.map(|s| s.into()),
                 allow_eq,
                 check_sortedness,
-            }))
+            })))
             .suffix(suffix)
             .finish()
             .into())

--- a/py-polars/tests/unit/lazyframe/test_optimizations.py
+++ b/py-polars/tests/unit/lazyframe/test_optimizations.py
@@ -246,15 +246,6 @@ def test_collapse_joins() -> None:
         check_row_order=False,
     )
 
-    no_literals = cross.filter(pl.col.x == 2)
-    e = no_literals.explain()
-    assert "NESTED LOOP JOIN" in e
-    assert_frame_equal(
-        no_literals.collect(optimizations=pl.QueryOptFlags(collapse_joins=False)),
-        no_literals.collect(),
-        check_row_order=False,
-    )
-
     iejoin = cross.filter(pl.col.x >= pl.col.a)
     e = iejoin.explain()
     assert "IEJOIN" in e


### PR DESCRIPTION
* ref https://github.com/pola-rs/polars/issues/23133
* Fixes https://github.com/pola-rs/polars/issues/23185

Refactors the filter pushdown code to allow more filters to be pushed.

#### Changes
* Filters on join key columns are now pushed to both sides instead of just 1 side, for inner/left/right/full/semi/anti join.
  * Also handles joins with differing `left_on` / `right_on` names, both coalesce and non-coalesce. Non-column join key expressions are also properly identified and block pushdowns.
* Filters referring only to a single input side for cross-joins and iejoins (join_where) are now pushed to that side.
* AsOf join:
  * Filters on "by" columns are now pushed to both sides
  * Filters referring only to columns originating from the left side are now pushed to the left side.

<details>
<summary>Example - Inner join</summary>

```python
import polars as pl

lhs = pl.LazyFrame(
    {"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, 4, None], "c": ["a", "b", "c", "d", "e"]}
)
rhs = pl.LazyFrame(
    {"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, None, 5], "c": ["A", "B", "C", "D", "E"]}
)
q = lhs.join(
    rhs,
    left_on=["a"],
    right_on=["b"],
    how="inner",
    coalesce=False,
).filter(
    pl.col("a") == 1,
    pl.col("b") >= 1,
    pl.col("a_right") <= 1,
    pl.col("b_right") >= 0,
)

print(q.explain())


# Before
FILTER [(col("a")) == (1)]
FROM
  INNER JOIN:
  LEFT PLAN ON: [col("a")]
    FILTER [(col("b")) >= (1)]
    FROM
      DF ["a", "b", "c"]; PROJECT */3 COLUMNS
  RIGHT PLAN ON: [col("b")]
    FILTER [([(col("a")) <= (1)]) & ([(col("b")) >= (0)])]
    FROM
      DF ["a", "b", "c"]; PROJECT */3 COLUMNS
  END INNER JOIN

# After
INNER JOIN:
LEFT PLAN ON: [col("a")]
  FILTER [([([(col("b")) >= (1)]) & ([(col("a")) == (1)])]) & ([(col("a")) >= (0)])]
  FROM
    DF ["a", "b", "c"]; PROJECT */3 COLUMNS
RIGHT PLAN ON: [col("b")]
  FILTER [([([(col("b")) == (1)]) & ([(col("a")) <= (1)])]) & ([(col("b")) >= (0)])]
  FROM
    DF ["a", "b", "c"]; PROJECT */3 COLUMNS
END INNER JOIN
```
</details>

<details>
<summary>Example - AsOf join</summary>

```python

lhs = pl.LazyFrame(
    {"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, 4, None], "c": ["a", "b", "c", "d", "e"]}
)
rhs = pl.LazyFrame(
    {"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, None, 5], "c": ["A", "B", "C", "D", "E"]}
)

q = lhs.join_asof(
    rhs,
    on="a",
    tolerance=0,
    by="b",
).filter(
    pl.col("a") >= 2,
    pl.col("b") >= 3,
    pl.col("c") >= "A",
)

print(q.explain())

# Before
FILTER [([([(col("b")) >= (3)]) & ([(col("c")) >= ("A")])]) & ([(col("a")) >= (2)])]
FROM
  ASOF JOIN:
  LEFT PLAN ON: [col("a")]
    DF ["a", "b", "c"]; PROJECT */3 COLUMNS
  RIGHT PLAN ON: [col("a")]
    DF ["a", "b", "c"]; PROJECT */3 COLUMNS
  END ASOF JOIN

# After
ASOF JOIN:
LEFT PLAN ON: [col("a")]
  FILTER [([([(col("a")) >= (2)]) & ([(col("c")) >= ("A")])]) & ([(col("b")) >= (3)])]
  FROM
    DF ["a", "b", "c"]; PROJECT */3 COLUMNS
RIGHT PLAN ON: [col("a")]
  FILTER [(col("b")) >= (3)]
  FROM
    DF ["a", "b", "c"]; PROJECT */3 COLUMNS

```

</details>

<details>
<summary>Example - iejoin (join_where), equality (==)</summary>

```python
lhs = pl.LazyFrame(
    {"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, 4, None], "c": ["a", "b", "c", "d", "e"]}
)
rhs = pl.LazyFrame(
    {"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, None, 5], "c": ["A", "B", "C", "D", "E"]}
)

q = lhs.join_where(
    rhs,
    pl.col("a") >= 1,
    pl.col("a") == pl.col("a_right"),
    pl.col("c_right") <= "B",
)

# Before
FILTER [([(col("c_right")) <= ("B")]) & ([(col("a")) >= (1)])]
FROM
  INNER JOIN:
  LEFT PLAN ON: [col("a")]
    DF ["a", "b", "c"]; PROJECT */3 COLUMNS
  RIGHT PLAN ON: [col("a")]
    DF ["a", "b", "c"]; PROJECT */3 COLUMNS
  END INNER JOIN

# After
INNER JOIN:
LEFT PLAN ON: [col("a")]
  FILTER [(col("a")) >= (1)]
  FROM
    DF ["a", "b", "c"]; PROJECT */3 COLUMNS
RIGHT PLAN ON: [col("a")]
  FILTER [(col("c")) <= ("B")]
  FROM
    DF ["a", "b", "c"]; PROJECT */3 COLUMNS
END INNER JOIN
```

</details>


<details>
<summary>Example - iejoin (join_where), inequality (>=)</summary>

```python
lhs = pl.LazyFrame(
    {"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, 4, None], "c": ["a", "b", "c", "d", "e"]}
)
rhs = pl.LazyFrame(
    {"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, None, 5], "c": ["A", "B", "C", "D", "E"]}
)

q = lhs.join_where(
    rhs,
    pl.col("a") >= 1,
    pl.col("a") >= pl.col("a_right"),
    pl.col("c_right") <= "B",
)

# Before
FILTER [([(col("a")) >= (1)]) & ([(col("c_right")) <= ("B")])]
FROM
  IEJOIN JOIN:
  LEFT PLAN ON: [col("a")]
    DF ["a", "b", "c"]; PROJECT */3 COLUMNS
  RIGHT PLAN ON: [col("a")]
    DF ["a", "b", "c"]; PROJECT */3 COLUMNS
  END IEJOIN JOIN

# After
IEJOIN JOIN:
LEFT PLAN ON: [col("a")]
  FILTER [(col("a")) >= (1)]
  FROM
    DF ["a", "b", "c"]; PROJECT */3 COLUMNS
RIGHT PLAN ON: [col("a")]
  FILTER [(col("c")) <= ("B")]
  FROM
    DF ["a", "b", "c"]; PROJECT */3 COLUMNS
END IEJOIN JOIN
```

</details>
