### PR TITLE
perf: Cache FileInfo upon DSL -> IR conversion

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use arrow::datatypes::ArrowSchemaRef;
 use either::Either;
 use expr_expansion::{is_regex_projection, rewrite_projections};
@@ -81,6 +83,7 @@ pub fn to_alp(
         opt_flags,
         nodes_scratch: &mut unitvec![],
         pushdown_maintain_errors: optimizer::pushdown_maintain_errors(),
+        cache_file_info: Default::default(),
     };
 
     match to_alp_impl(lp, &mut ctxt) {
@@ -114,6 +117,31 @@ pub fn to_alp(
     }
 }
 
+#[derive(Default)]
+struct SourcesToFileInfo {
+    inner: PlHashMap<Arc<[PathBuf]>, FileInfo>,
+}
+
+impl SourcesToFileInfo {
+    fn insert(&mut self, source: &ScanSources, info: &FileInfo) {
+        match source {
+            ScanSources::Paths(paths) => {
+                self.inner.insert(paths.clone(), info.clone());
+            },
+            ScanSources::Files(_) | ScanSources::Buffers(_) => {
+                // don't save the files or buffers
+            },
+        }
+    }
+
+    fn get(&self, source: &ScanSources) -> Option<&FileInfo> {
+        match source {
+            ScanSources::Paths(paths) => self.inner.get(paths),
+            _ => None,
+        }
+    }
+}
+
 pub(super) struct DslConversionContext<'a> {
     pub(super) expr_arena: &'a mut Arena<AExpr>,
     pub(super) lp_arena: &'a mut Arena<IR>,
@@ -121,6 +149,7 @@ pub(super) struct DslConversionContext<'a> {
     pub(super) opt_flags: &'a mut OptFlags,
     pub(super) nodes_scratch: &'a mut UnitVec<Node>,
     pub(super) pushdown_maintain_errors: bool,
+    cache_file_info: SourcesToFileInfo,
 }
 
 pub(super) fn run_conversion(
@@ -200,116 +229,160 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                         FileScanDsl::Anonymous { .. } => sources,
                     };
 
-                let (mut file_info, scan_type_ir) = match *scan_type.clone() {
-                    #[cfg(feature = "parquet")]
-                    FileScanDsl::Parquet { options } => {
-                        if let Some(schema) = &options.schema {
-                            // We were passed a schema, we don't have to call `parquet_file_info`,
-                            // but this does mean we don't have `row_estimation` and `first_metadata`.
-                            (
-                                FileInfo {
-                                    schema: schema.clone(),
-                                    reader_schema: Some(either::Either::Left(Arc::new(
-                                        schema.to_arrow(CompatLevel::newest()),
-                                    ))),
-                                    row_estimation: (None, 0),
-                                },
-                                FileScanIR::Parquet {
-                                    options,
-                                    metadata: None,
-                                },
-                            )
-                        } else {
-                            let (file_info, metadata) = scans::parquet_file_info(
-                                &sources,
-                                unified_scan_args.row_index.as_ref(),
-                                cloud_options,
-                            )
-                            .map_err(|e| e.context(failed_here!(parquet scan)))?;
-
-                            (file_info, FileScanIR::Parquet { options, metadata })
-                        }
-                    },
-                    #[cfg(feature = "ipc")]
-                    FileScanDsl::Ipc { options } => {
-                        let (file_info, md) = scans::ipc_file_info(
-                            &sources,
-                            unified_scan_args.row_index.as_ref(),
-                            cloud_options,
-                        )
-                        .map_err(|e| e.context(failed_here!(ipc scan)))?;
-                        (
-                            file_info,
-                            FileScanIR::Ipc {
-                                options,
-                                metadata: Some(Arc::new(md)),
-                            },
-                        )
-                    },
-                    #[cfg(feature = "csv")]
-                    FileScanDsl::Csv { mut options } => {
-                        // TODO: This is a hack. We conditionally set `allow_missing_columns` to
-                        // mimic existing behavior, but this should be taken from a user provided
-                        // parameter instead.
-                        if options.schema.is_some() && options.has_header {
-                            unified_scan_args.missing_columns_policy = MissingColumnsPolicy::Insert;
-                        }
-
-                        (
-                            scans::csv_file_info(
-                                &sources,
-                                unified_scan_args.row_index.as_ref(),
-                                &mut options,
-                                cloud_options,
-                            )
-                            .map_err(|e| e.context(failed_here!(csv scan)))?,
-                            FileScanIR::Csv { options },
-                        )
-                    },
-                    #[cfg(feature = "json")]
-                    FileScanDsl::NDJson { options } => (
-                        scans::ndjson_file_info(
-                            &sources,
-                            unified_scan_args.row_index.as_ref(),
-                            &options,
-                            cloud_options,
-                        )
-                        .map_err(|e| e.context(failed_here!(ndjson scan)))?,
-                        FileScanIR::NDJson { options },
-                    ),
-                    #[cfg(feature = "python")]
-                    FileScanDsl::PythonDataset { dataset_object } => {
-                        if crate::dsl::DATASET_PROVIDER_VTABLE.get().is_none() {
-                            polars_bail!(ComputeError: "DATASET_PROVIDER_VTABLE (python) not initialized")
-                        }
-
-                        let mut schema = dataset_object.schema()?;
-                        let reader_schema = schema.clone();
-
-                        if let Some(row_index) = &unified_scan_args.row_index {
-                            insert_row_index_to_schema(
-                                Arc::make_mut(&mut schema),
-                                row_index.name.clone(),
-                            )?;
-                        }
-
-                        (
-                            FileInfo {
-                                schema,
-                                reader_schema: Some(either::Either::Right(reader_schema)),
-                                row_estimation: (None, usize::MAX),
-                            },
+                // For cloud we must deduplicate files. Serialization/deserialization leads to Arc's losing there
+                // sharing.
+                // First we check if we have a cache `FileInfo`, if not we load the metadata and
+                // insert in the cache. Loading metadata can be expensive, and comprise of multiple
+                // Gb's
+                let (mut file_info, scan_type_ir) = if let Some(file_info) =
+                    ctxt.cache_file_info.get(&sources)
+                {
+                    let scan_type_ir = match *scan_type.clone() {
+                        #[cfg(feature = "csv")]
+                        FileScanDsl::Csv { options } => FileScanIR::Csv { options },
+                        #[cfg(feature = "json")]
+                        FileScanDsl::NDJson { options } => FileScanIR::NDJson { options },
+                        #[cfg(feature = "parquet")]
+                        FileScanDsl::Parquet { options } => FileScanIR::Parquet {
+                            options,
+                            metadata: None,
+                        },
+                        #[cfg(feature = "ipc")]
+                        FileScanDsl::Ipc { options } => FileScanIR::Ipc {
+                            options,
+                            metadata: None,
+                        },
+                        #[cfg(feature = "python")]
+                        FileScanDsl::PythonDataset { dataset_object } => {
                             FileScanIR::PythonDataset {
                                 dataset_object,
                                 cached_ir: Default::default(),
-                            },
-                        )
-                    },
-                    FileScanDsl::Anonymous {
-                        file_info,
-                        options,
-                        function,
-                    } => (file_info, FileScanIR::Anonymous { options, function }),
+                            }
+                        },
+                        FileScanDsl::Anonymous {
+                            options,
+                            function,
+                            file_info: _,
+                        } => FileScanIR::Anonymous { options, function },
+                    };
+                    (file_info.clone(), scan_type_ir)
+                } else {
+                    let (file_info, scan_type_ir) = match *scan_type.clone() {
+                        #[cfg(feature = "parquet")]
+                        FileScanDsl::Parquet { options } => {
+                            if let Some(schema) = &options.schema {
+                                // We were passed a schema, we don't have to call `parquet_file_info`,
+                                // but this does mean we don't have `row_estimation` and `first_metadata`.
+                                (
+                                    FileInfo {
+                                        schema: schema.clone(),
+                                        reader_schema: Some(either::Either::Left(Arc::new(
+                                            schema.to_arrow(CompatLevel::newest()),
+                                        ))),
+                                        row_estimation: (None, 0),
+                                    },
+                                    FileScanIR::Parquet {
+                                        options,
+                                        metadata: None,
+                                    },
+                                )
+                            } else {
+                                let (file_info, metadata) = scans::parquet_file_info(
+                                    &sources,
+                                    unified_scan_args.row_index.as_ref(),
+                                    cloud_options,
+                                )
+                                .map_err(|e| e.context(failed_here!(parquet scan)))?;
+
+                                (file_info, FileScanIR::Parquet { options, metadata })
+                            }
+                        },
+                        #[cfg(feature = "ipc")]
+                        FileScanDsl::Ipc { options } => {
+                            let (file_info, md) = scans::ipc_file_info(
+                                &sources,
+                                unified_scan_args.row_index.as_ref(),
+                                cloud_options,
+                            )
+                            .map_err(|e| e.context(failed_here!(ipc scan)))?;
+                            (
+                                file_info,
+                                FileScanIR::Ipc {
+                                    options,
+                                    metadata: Some(Arc::new(md)),
+                                },
+                            )
+                        },
+                        #[cfg(feature = "csv")]
+                        FileScanDsl::Csv { mut options } => {
+                            // TODO: This is a hack. We conditionally set `allow_missing_columns` to
+                            // mimic existing behavior, but this should be taken from a user provided
+                            // parameter instead.
+                            if options.schema.is_some() && options.has_header {
+                                unified_scan_args.missing_columns_policy =
+                                    MissingColumnsPolicy::Insert;
+                            }
+
+                            (
+                                scans::csv_file_info(
+                                    &sources,
+                                    unified_scan_args.row_index.as_ref(),
+                                    &mut options,
+                                    cloud_options,
+                                )
+                                .map_err(|e| e.context(failed_here!(csv scan)))?,
+                                FileScanIR::Csv { options },
+                            )
+                        },
+                        #[cfg(feature = "json")]
+                        FileScanDsl::NDJson { options } => (
+                            scans::ndjson_file_info(
+                                &sources,
+                                unified_scan_args.row_index.as_ref(),
+                                &options,
+                                cloud_options,
+                            )
+                            .map_err(|e| e.context(failed_here!(ndjson scan)))?,
+                            FileScanIR::NDJson { options },
+                        ),
+                        #[cfg(feature = "python")]
+                        FileScanDsl::PythonDataset { dataset_object } => {
+                            if crate::dsl::DATASET_PROVIDER_VTABLE.get().is_none() {
+                                polars_bail!(ComputeError: "DATASET_PROVIDER_VTABLE (python) not initialized")
+                            }
+
+                            let mut schema = dataset_object.schema()?;
+                            let reader_schema = schema.clone();
+
+                            if let Some(row_index) = &unified_scan_args.row_index {
+                                insert_row_index_to_schema(
+                                    Arc::make_mut(&mut schema),
+                                    row_index.name.clone(),
+                                )?;
+                            }
+
+                            (
+                                FileInfo {
+                                    schema,
+                                    reader_schema: Some(either::Either::Right(reader_schema)),
+                                    row_estimation: (None, usize::MAX),
+                                },
+                                FileScanIR::PythonDataset {
+                                    dataset_object,
+                                    cached_ir: Default::default(),
+                                },
+                            )
+                        },
+                        FileScanDsl::Anonymous {
+                            file_info,
+                            options,
+                            function,
+                        } => (file_info, FileScanIR::Anonymous { options, function }),
+                    };
+
+                    // Insert so that the files are deduplicated.
+                    ctxt.cache_file_info.insert(&sources, &file_info);
+                    (file_info, scan_type_ir)
                 };
 
                 if unified_scan_args.hive_options.enabled.is_none() {

--- a/py-polars/tests/unit/io/test_lazy_ipc.py
+++ b/py-polars/tests/unit/io/test_lazy_ipc.py
@@ -130,3 +130,16 @@ def test_sink_ipc_compat_level_22930() -> None:
     t2 = pyarrow.ipc.open_file(f2)
     assert "large_string" in str(t2.schema)
     assert_frame_equal(pl.DataFrame(t2.read_all()), df)
+
+
+def test_scan_file_info_cache(
+    capfd: Any, monkeypatch: Any, foods_ipc_path: Path
+) -> None:
+    monkeypatch.setenv("POLARS_VERBOSE", "1")
+    a = pl.scan_ipc(foods_ipc_path)
+    b = pl.scan_ipc(foods_ipc_path)
+
+    a.join(b, how="cross").explain()
+
+    captured = capfd.readouterr().err
+    assert "FILE_INFO CACHE HIT" in captured


### PR DESCRIPTION
Deduplicate scans to the same files. Metadata parsing can be expensive and memory intensive, so trigger that if needed.