### PR TITLE
feat: Drop superfluous casts from optimized plan

### DIFF
--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -170,8 +170,9 @@ impl PartialEq for DataType {
             match (self, other) {
                 #[cfg(feature = "dtype-categorical")]
                 // Don't include rev maps in comparisons
-                // TODO: include ordering in comparison
-                (Categorical(_, _ordering_l), Categorical(_, _ordering_r)) => true,
+                (Categorical(_, ordering_l), Categorical(_, ordering_r)) => {
+                    ordering_l == ordering_r
+                },
                 #[cfg(feature = "dtype-categorical")]
                 // None means select all Enum dtypes. This is for operation `pl.col(pl.Enum)`
                 (Enum(None, _), Enum(_, _)) | (Enum(_, _), Enum(None, _)) => true,

--- a/crates/polars-plan/src/dsl/file_scan/mod.rs
+++ b/crates/polars-plan/src/dsl/file_scan/mod.rs
@@ -397,11 +397,6 @@ impl CastColumnsPolicy {
             )
         };
 
-        // If either data type is unknown, casting is always needed.
-        if incoming_dtype.is_unknown() || target_dtype.is_unknown() {
-            return Ok(true);
-        }
-
         // We intercept the nested types first to prevent an expensive recursive eq - recursion
         // is instead done manually through this function.
 

--- a/crates/polars-plan/src/dsl/file_scan/mod.rs
+++ b/crates/polars-plan/src/dsl/file_scan/mod.rs
@@ -397,6 +397,11 @@ impl CastColumnsPolicy {
             )
         };
 
+        // If either data type is unknown, casting is always needed.
+        if incoming_dtype.is_unknown() || target_dtype.is_unknown() {
+            return Ok(true);
+        }
+
         // We intercept the nested types first to prevent an expensive recursive eq - recursion
         // is instead done manually through this function.
 

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -126,7 +126,6 @@ impl OptimizationRule for TypeCoercionRule {
                         }
                         .should_cast_column("", cast_to, &cast_from);
 
-                        #[expect(clippy::single_match)]
                         match v {
                             // No casting needed
                             Ok(false) => {

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -871,7 +871,10 @@ fn try_inline_literal_cast(
             let s = s.cast_with_options(dtype, options)?;
             LiteralValue::Series(SpecialEq::new(s))
         },
-        LiteralValue::Dyn(dyn_value) => dyn_value.clone().try_materialize_to_dtype(dtype)?.into(),
+        LiteralValue::Dyn(dyn_value) => dyn_value
+            .clone()
+            .try_materialize_to_dtype(dtype, options)?
+            .into(),
         lv if lv.is_null() => match dtype {
             DataType::Unknown(UnknownKind::Float | UnknownKind::Int(_) | UnknownKind::Str) => {
                 LiteralValue::untyped_null()

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -129,11 +129,10 @@ impl OptimizationRule for TypeCoercionRule {
                         #[expect(clippy::single_match)]
                         match v {
                             // No casting needed
-                            // TODO: Enable after release 1.30.0
-                            // Ok(false) => {
-                            //     return Ok(Some(expr_arena.get(input_expr).clone()));
-                            // },
-                            Ok(true | false) => {
+                            Ok(false) => {
+                                return Ok(Some(expr_arena.get(input_expr).clone()));
+                            },
+                            Ok(true) => {
                                 let options = if cast_from.is_primitive_numeric()
                                     && cast_to.is_primitive_numeric()
                                 {

--- a/py-polars/polars/datatypes/group.py
+++ b/py-polars/polars/datatypes/group.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from polars.datatypes.classes import (
     Array,
+    Categorical,
     DataType,
     DataTypeClass,
     Date,
@@ -100,6 +101,14 @@ INTEGER_DTYPES: frozenset[PolarsIntegerType] = (
 FLOAT_DTYPES: frozenset[PolarsDataType] = DataTypeGroup([Float32, Float64])
 NUMERIC_DTYPES: frozenset[PolarsDataType] = DataTypeGroup(
     FLOAT_DTYPES | INTEGER_DTYPES | frozenset([Decimal])
+)
+
+CATEGORICAL_DTYPES: frozenset[PolarsDataType] = DataTypeGroup(
+    [
+        Categorical,
+        Categorical("physical"),
+        Categorical("lexical"),
+    ]
 )
 
 DATETIME_DTYPES: frozenset[PolarsDataType] = DataTypeGroup(

--- a/py-polars/polars/functions/col.py
+++ b/py-polars/polars/functions/col.py
@@ -7,8 +7,15 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 from polars._utils.wrap import wrap_expr
-from polars.datatypes import Datetime, Duration, is_polars_dtype, parse_into_dtype
+from polars.datatypes import (
+    Categorical,
+    Datetime,
+    Duration,
+    is_polars_dtype,
+    parse_into_dtype,
+)
 from polars.datatypes.group import (
+    CATEGORICAL_DTYPES,
     DATETIME_DTYPES,
     DURATION_DTYPES,
     FLOAT_DTYPES,
@@ -114,6 +121,8 @@ def _polars_dtype_match(tp: PolarsDataType) -> list[PolarsDataType]:
         return list(DATETIME_DTYPES)
     elif Duration.is_(tp):
         return list(DURATION_DTYPES)
+    elif Categorical.is_(tp):
+        return list(CATEGORICAL_DTYPES)
     return [tp]
 
 

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -954,7 +954,6 @@ def test_nested_struct_cast_22744() -> None:
     )
 
 
-@pytest.mark.xfail(reason="disabled until after release 1.30.0")
 def test_cast_to_self_is_pruned() -> None:
     q = pl.LazyFrame({"x": 1}, schema={"x": pl.Int64}).with_columns(
         y=pl.col("x").cast(pl.Int64)

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -8,11 +8,10 @@ import pytest
 
 import polars as pl
 from polars._utils.constants import MS_PER_SECOND, NS_PER_SECOND, US_PER_SECOND
-from polars.datatypes.group import NUMERIC_DTYPES
 from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal
 from polars.testing.asserts.series import assert_series_equal
-from tests.unit.conftest import INTEGER_DTYPES
+from tests.unit.conftest import INTEGER_DTYPES, NUMERIC_DTYPES
 
 if TYPE_CHECKING:
     from polars._typing import PolarsDataType, PythonDataType


### PR DESCRIPTION
# Motivation

I realized that, in 1.31, polars does not currently drop superfluous casts in the optimized plan. Namely, something like the following keeps the `cast` in the plan:

```python
lf = pl.LazyFrame({"a": [1]}, schema={"a": pl.Int64})
lf.select(pl.col("a").cast(pl.Int64))
```

While going through the code, I realized that the relevant code path already existed, it was simply commented out with a comment to enable it after 1.30. As there's no further information, I couldn't tell for sure whether it is actually fine to enable now but it does what it should in my local tests.