### PR TITLE
fix: Restore `concat_arr` inputs expansion

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/function_expr/array.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/array.rs
@@ -86,6 +86,8 @@ impl IRArrayFunction {
             A::Contains { nulls_equal: _ } => FunctionOptions::elementwise(),
             #[cfg(feature = "array_count")]
             A::CountMatches => FunctionOptions::elementwise(),
+            A::Concat => FunctionOptions::elementwise()
+                .with_flags(|f| f | FunctionFlags::INPUT_WILDCARD_EXPANSION),
             A::Length
             | A::Min
             | A::Max
@@ -100,7 +102,6 @@ impl IRArrayFunction {
             | A::Reverse
             | A::ArgMin
             | A::ArgMax
-            | A::Concat
             | A::Get(_)
             | A::Join(_)
             | A::Shift => FunctionOptions::elementwise(),

--- a/crates/polars-plan/src/plans/conversion/expr_expansion.rs
+++ b/crates/polars-plan/src/plans/conversion/expr_expansion.rs
@@ -552,7 +552,6 @@ fn expand_function_inputs(
             let mut input_wildcard_expansion = matches!(function, F::Boolean(BooleanFunction::AnyHorizontal | BooleanFunction::AllHorizontal)
                 | F::Coalesce
                 | F::ListExpr(ListFunction::Concat)
-                | F::ArrayExpr(ArrayFunction::Concat)
                 | F::ConcatExpr(_)
                 | F::MinHorizontal
                 | F::MaxHorizontal
@@ -564,6 +563,10 @@ fn expand_function_inputs(
                 F::Boolean(BooleanFunction::AnyHorizontal | BooleanFunction::AllHorizontal)
                 | F::DropNulls
             );
+            #[cfg(feature = "dtype-array")]
+            {
+                input_wildcard_expansion |= matches!(function, F::ArrayExpr(ArrayFunction::Concat));
+            }
             #[cfg(feature = "dtype-struct")]
             {
                 input_wildcard_expansion |= matches!(function, F::AsStruct);

--- a/crates/polars-plan/src/plans/conversion/expr_expansion.rs
+++ b/crates/polars-plan/src/plans/conversion/expr_expansion.rs
@@ -552,6 +552,7 @@ fn expand_function_inputs(
             let mut input_wildcard_expansion = matches!(function, F::Boolean(BooleanFunction::AnyHorizontal | BooleanFunction::AllHorizontal)
                 | F::Coalesce
                 | F::ListExpr(ListFunction::Concat)
+                | F::ArrayExpr(ArrayFunction::Concat)
                 | F::ConcatExpr(_)
                 | F::MinHorizontal
                 | F::MaxHorizontal

--- a/py-polars/tests/unit/functions/as_datatype/test_concat_arr.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_concat_arr.py
@@ -185,3 +185,10 @@ def test_concat_arr_scalar() -> None:
 
     out = df.with_columns(out=pl.concat_arr(pl.first(), pl.first()))
     assert out._to_metadata()["repr"].to_list() == ["scalar", "scalar"]
+
+
+def test_concat_arr_expansion_23267() -> None:
+    df = pl.select(x=1, y=2).cast(pl.Int64)
+    out = df.select(z=pl.concat_arr(pl.all())).to_series()
+
+    assert_series_equal(out, pl.Series("z", [[1, 2]], dtype=pl.Array(pl.Int64, 2)))


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/23267

I think this is all that is required @coastalwhite?