### PR TITLE
refactor(rust): Optimize equality comparisons and fix error handling

### DIFF
--- a/py-polars/tests/unit/testing/test_assert_series_equal.py
+++ b/py-polars/tests/unit/testing/test_assert_series_equal.py
@@ -70,12 +70,13 @@ def test_assert_series_equal_check_order() -> None:
 
 
 def test_assert_series_equal_check_order_unsortable_type() -> None:
-    s = pl.Series([object(), object()])
+    s1 = pl.Series([object(), object()])
+    s2 = pl.Series([object(), object()])
     with pytest.raises(
         InvalidOperationError,
         match="`sort_with` operation not supported for dtype `object`",
     ):
-        assert_series_equal(s, s, check_order=False)
+        assert_series_equal(s1, s2, check_order=False)
 
 
 def test_compare_series_nans_assert_equal() -> None:


### PR DESCRIPTION
@coastalwhite 

Mentioned I wanted to look into some optimizations for the code.

* Added pointer equality check for same object comparisons (`if std::ptr::eq()`) to short-circuit when comparing identical objects.
* Updated `categorical_series_to_string()` to return a `PolarsResult<>` so it would not panic on `.unwrap()` if the cast failed.
* Renamed data type comparison functions to be more clear.
* Replaced temporary Series creation with direct scalar operations for better performance.

The Python test needed to be updated with the new pointer equality check, since it compared the same exact Series to itself (`s` and `s`). I just made them separate objects for the comparison (`s1` and `s2`).

If you had any other ideas or suggestions, let me know. Thanks!