### PR TITLE
feat: Execute bitwise reductions in streaming engine

### DIFF
--- a/crates/polars-arrow/src/bitmap/mutable.rs
+++ b/crates/polars-arrow/src/bitmap/mutable.rs
@@ -188,6 +188,15 @@ impl MutableBitmap {
             (0xFE | u8::from(value)).rotate_left(index as u32);
     }
 
+    /// Sets the position `index` to the XOR of its original value and `value`.
+    ///
+    /// # Safety
+    /// It's undefined behavior if index >= self.len().
+    #[inline]
+    pub unsafe fn xor_pos_unchecked(&mut self, index: usize, value: bool) {
+        *self.buffer.get_unchecked_mut(index / 8) ^= (value as u8) << (index % 8);
+    }
+
     /// constructs a new iterator over the bits of [`MutableBitmap`].
     pub fn iter(&self) -> BitmapIter<'_> {
         BitmapIter::new(&self.buffer, 0, self.length)

--- a/crates/polars-expr/src/reduce/bitwise.rs
+++ b/crates/polars-expr/src/reduce/bitwise.rs
@@ -33,7 +33,7 @@ pub fn new_bitwise_or_reduction(dtype: DataType) -> Box<dyn GroupedReduction> {
                 Box::new(VMGR::new(dtype, NumReducer::<BitwiseOr<$T>>::new()))
             })
         },
-        _ => todo!(),
+        _ => unimplemented!(),
     }
 }
 
@@ -47,7 +47,7 @@ pub fn new_bitwise_xor_reduction(dtype: DataType) -> Box<dyn GroupedReduction> {
                 Box::new(VMGR::new(dtype, NumReducer::<BitwiseXor<$T>>::new()))
             })
         },
-        _ => todo!(),
+        _ => unimplemented!(),
     }
 }
 

--- a/crates/polars-expr/src/reduce/bitwise.rs
+++ b/crates/polars-expr/src/reduce/bitwise.rs
@@ -16,10 +16,10 @@ pub fn new_bitwise_and_reduction(dtype: DataType) -> Box<dyn GroupedReduction> {
         Boolean => Box::new(BoolMinGroupedReduction::default()),
         _ if dtype.is_integer() => {
             with_match_physical_integer_polars_type!(dtype.to_physical(), |$T| {
-                    Box::new(VMGR::new(dtype, NumReducer::<BitwiseAnd<$T>>::new()))
+                Box::new(VMGR::new(dtype, NumReducer::<BitwiseAnd<$T>>::new()))
             })
         },
-        _ => todo!(),
+        _ => unimplemented!(),
     }
 }
 
@@ -30,7 +30,7 @@ pub fn new_bitwise_or_reduction(dtype: DataType) -> Box<dyn GroupedReduction> {
         Boolean => Box::new(BoolMaxGroupedReduction::default()),
         _ if dtype.is_integer() => {
             with_match_physical_integer_polars_type!(dtype.to_physical(), |$T| {
-                    Box::new(VMGR::new(dtype, NumReducer::<BitwiseOr<$T>>::new()))
+                Box::new(VMGR::new(dtype, NumReducer::<BitwiseOr<$T>>::new()))
             })
         },
         _ => todo!(),
@@ -44,7 +44,7 @@ pub fn new_bitwise_xor_reduction(dtype: DataType) -> Box<dyn GroupedReduction> {
         Boolean => Box::new(BoolXorGroupedReduction::default()),
         _ if dtype.is_integer() => {
             with_match_physical_integer_polars_type!(dtype.to_physical(), |$T| {
-                    Box::new(VMGR::new(dtype, NumReducer::<BitwiseXor<$T>>::new()))
+                Box::new(VMGR::new(dtype, NumReducer::<BitwiseXor<$T>>::new()))
             })
         },
         _ => todo!(),
@@ -193,7 +193,7 @@ impl GroupedReduction for BoolXorGroupedReduction {
                 if g.should_evict() {
                     self.evicted_values.push(self.values.get_unchecked(g.idx()));
                     self.evicted_mask.push(self.mask.get_unchecked(g.idx()));
-                    self.values.xor_pos_unchecked(g.idx(), ov.unwrap_or(false));
+                    self.values.set_unchecked(g.idx(), ov.unwrap_or(false));
                     self.mask.set_unchecked(g.idx(), ov.is_some());
                 } else {
                     self.values.xor_pos_unchecked(g.idx(), ov.unwrap_or(false));

--- a/crates/polars-expr/src/reduce/bitwise.rs
+++ b/crates/polars-expr/src/reduce/bitwise.rs
@@ -1,0 +1,254 @@
+use std::ops::{BitAnd, BitOr, BitXor, Not};
+
+use arrow::array::BooleanArray;
+use arrow::types::NativeType;
+use num_traits::Zero;
+use polars_compute::bitwise::BitwiseKernel;
+use polars_core::with_match_physical_integer_polars_type;
+
+use super::*;
+use crate::reduce::min_max::{BoolMaxGroupedReduction, BoolMinGroupedReduction};
+
+pub fn new_bitwise_and_reduction(dtype: DataType) -> Box<dyn GroupedReduction> {
+    use DataType::*;
+    use VecMaskGroupedReduction as VMGR;
+    match dtype {
+        Boolean => Box::new(BoolMinGroupedReduction::default()),
+        _ if dtype.is_integer() => {
+            with_match_physical_integer_polars_type!(dtype.to_physical(), |$T| {
+                    Box::new(VMGR::new(dtype, NumReducer::<BitwiseAnd<$T>>::new()))
+            })
+        },
+        _ => todo!(),
+    }
+}
+
+pub fn new_bitwise_or_reduction(dtype: DataType) -> Box<dyn GroupedReduction> {
+    use DataType::*;
+    use VecMaskGroupedReduction as VMGR;
+    match dtype {
+        Boolean => Box::new(BoolMaxGroupedReduction::default()),
+        _ if dtype.is_integer() => {
+            with_match_physical_integer_polars_type!(dtype.to_physical(), |$T| {
+                    Box::new(VMGR::new(dtype, NumReducer::<BitwiseOr<$T>>::new()))
+            })
+        },
+        _ => todo!(),
+    }
+}
+
+pub fn new_bitwise_xor_reduction(dtype: DataType) -> Box<dyn GroupedReduction> {
+    use DataType::*;
+    use VecMaskGroupedReduction as VMGR;
+    match dtype {
+        Boolean => Box::new(BoolXorGroupedReduction::default()),
+        _ if dtype.is_integer() => {
+            with_match_physical_integer_polars_type!(dtype.to_physical(), |$T| {
+                    Box::new(VMGR::new(dtype, NumReducer::<BitwiseXor<$T>>::new()))
+            })
+        },
+        _ => todo!(),
+    }
+}
+
+struct BitwiseAnd<T>(PhantomData<T>);
+struct BitwiseOr<T>(PhantomData<T>);
+struct BitwiseXor<T>(PhantomData<T>);
+
+impl<T> NumericReduction for BitwiseAnd<T>
+where
+    T: PolarsNumericType,
+    T::Native: BitAnd<Output = T::Native> + Not<Output = T::Native> + Zero,
+    T::Native: NativeType,
+    PrimitiveArray<T::Native>: BitwiseKernel<Scalar = T::Native>,
+{
+    type Dtype = T;
+
+    #[inline(always)]
+    fn init() -> T::Native {
+        !T::Native::zero() // all_ones(), the identity element
+    }
+
+    #[inline(always)]
+    fn combine(a: T::Native, b: T::Native) -> T::Native {
+        a & b
+    }
+
+    #[inline(always)]
+    fn reduce_ca(ca: &ChunkedArray<Self::Dtype>) -> Option<T::Native> {
+        ca.and_reduce()
+    }
+}
+
+impl<T> NumericReduction for BitwiseOr<T>
+where
+    T: PolarsNumericType,
+    T::Native: BitOr<Output = T::Native> + Zero,
+    T::Native: NativeType,
+    PrimitiveArray<T::Native>: BitwiseKernel<Scalar = T::Native>,
+{
+    type Dtype = T;
+
+    #[inline(always)]
+    fn init() -> T::Native {
+        T::Native::zero() // all_zeroes(), the identity element
+    }
+
+    #[inline(always)]
+    fn combine(a: T::Native, b: T::Native) -> T::Native {
+        a | b
+    }
+
+    #[inline(always)]
+    fn reduce_ca(ca: &ChunkedArray<Self::Dtype>) -> Option<T::Native> {
+        ca.or_reduce()
+    }
+}
+
+impl<T> NumericReduction for BitwiseXor<T>
+where
+    T: PolarsNumericType,
+    T::Native: BitXor<Output = T::Native> + Zero,
+    T::Native: NativeType,
+    PrimitiveArray<T::Native>: BitwiseKernel<Scalar = T::Native>,
+{
+    type Dtype = T;
+
+    #[inline(always)]
+    fn init() -> T::Native {
+        T::Native::zero() // all_zeroes(), the identity element
+    }
+
+    #[inline(always)]
+    fn combine(a: T::Native, b: T::Native) -> T::Native {
+        a ^ b
+    }
+
+    #[inline(always)]
+    fn reduce_ca(ca: &ChunkedArray<Self::Dtype>) -> Option<T::Native> {
+        ca.xor_reduce()
+    }
+}
+
+#[derive(Default)]
+pub struct BoolXorGroupedReduction {
+    values: MutableBitmap,
+    mask: MutableBitmap,
+    evicted_values: BitmapBuilder,
+    evicted_mask: BitmapBuilder,
+}
+
+impl GroupedReduction for BoolXorGroupedReduction {
+    fn new_empty(&self) -> Box<dyn GroupedReduction> {
+        Box::new(Self::default())
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        self.values.reserve(additional);
+        self.mask.reserve(additional)
+    }
+
+    fn resize(&mut self, num_groups: IdxSize) {
+        self.values.resize(num_groups as usize, false);
+        self.mask.resize(num_groups as usize, false);
+    }
+
+    fn update_group(
+        &mut self,
+        values: &Column,
+        group_idx: IdxSize,
+        _seq_id: u64,
+    ) -> PolarsResult<()> {
+        assert!(values.dtype() == &DataType::Boolean);
+        let values = values.as_materialized_series_maintain_scalar();
+        let ca: &BooleanChunked = values.as_ref().as_ref();
+        if let Some(value) = ca.xor_reduce() {
+            // SAFETY: indices are in-bounds guaranteed by trait
+            unsafe {
+                self.values.xor_pos_unchecked(group_idx as usize, value);
+            }
+        }
+        if ca.len() != ca.null_count() {
+            self.mask.set(group_idx as usize, true);
+        }
+        Ok(())
+    }
+
+    unsafe fn update_groups_while_evicting(
+        &mut self,
+        values: &Column,
+        subset: &[IdxSize],
+        group_idxs: &[EvictIdx],
+        _seq_id: u64,
+    ) -> PolarsResult<()> {
+        assert!(values.dtype() == &DataType::Boolean);
+        assert!(subset.len() == group_idxs.len());
+        let values = values.as_materialized_series(); // @scalar-opt
+        let ca: &BooleanChunked = values.as_ref().as_ref();
+        let arr = ca.downcast_as_array();
+        unsafe {
+            // SAFETY: indices are in-bounds guaranteed by trait.
+            for (i, g) in subset.iter().zip(group_idxs) {
+                let ov = arr.get_unchecked(*i as usize);
+                if g.should_evict() {
+                    self.evicted_values.push(self.values.get_unchecked(g.idx()));
+                    self.evicted_mask.push(self.mask.get_unchecked(g.idx()));
+                    self.values.xor_pos_unchecked(g.idx(), ov.unwrap_or(false));
+                    self.mask.set_unchecked(g.idx(), ov.is_some());
+                } else {
+                    self.values.xor_pos_unchecked(g.idx(), ov.unwrap_or(false));
+                    self.mask.or_pos_unchecked(g.idx(), ov.is_some());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    unsafe fn combine_subset(
+        &mut self,
+        other: &dyn GroupedReduction,
+        subset: &[IdxSize],
+        group_idxs: &[IdxSize],
+    ) -> PolarsResult<()> {
+        let other = other.as_any().downcast_ref::<Self>().unwrap();
+        assert!(subset.len() == group_idxs.len());
+        unsafe {
+            // SAFETY: indices are in-bounds guaranteed by trait.
+            for (i, g) in subset.iter().zip(group_idxs) {
+                self.values
+                    .xor_pos_unchecked(*g as usize, other.values.get_unchecked(*i as usize));
+                self.mask
+                    .or_pos_unchecked(*g as usize, other.mask.get_unchecked(*i as usize));
+            }
+        }
+        Ok(())
+    }
+
+    fn take_evictions(&mut self) -> Box<dyn GroupedReduction> {
+        Box::new(Self {
+            values: core::mem::take(&mut self.evicted_values).into_mut(),
+            mask: core::mem::take(&mut self.evicted_mask).into_mut(),
+            evicted_values: BitmapBuilder::new(),
+            evicted_mask: BitmapBuilder::new(),
+        })
+    }
+
+    fn finalize(&mut self) -> PolarsResult<Series> {
+        let v = core::mem::take(&mut self.values);
+        let m = core::mem::take(&mut self.mask);
+        let arr = BooleanArray::from(v.freeze())
+            .with_validity(Some(m.freeze()))
+            .boxed();
+        Ok(unsafe {
+            Series::from_chunks_and_dtype_unchecked(
+                PlSmallStr::EMPTY,
+                vec![arr],
+                &DataType::Boolean,
+            )
+        })
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/crates/polars-expr/src/reduce/convert.rs
+++ b/crates/polars-expr/src/reduce/convert.rs
@@ -3,6 +3,7 @@ use polars_plan::prelude::*;
 use polars_utils::arena::{Arena, Node};
 
 use super::*;
+#[cfg(feature = "bitwise")]
 use crate::reduce::bitwise::{
     new_bitwise_and_reduction, new_bitwise_or_reduction, new_bitwise_xor_reduction,
 };
@@ -87,7 +88,7 @@ pub fn into_reduction(
                 IRBitwiseFunction::And => (new_bitwise_and_reduction(get_dt(input)?), input),
                 IRBitwiseFunction::Or => (new_bitwise_or_reduction(get_dt(input)?), input),
                 IRBitwiseFunction::Xor => (new_bitwise_xor_reduction(get_dt(input)?), input),
-                _ => todo!(),
+                _ => unreachable!(),
             }
         },
         _ => unreachable!(),

--- a/crates/polars-expr/src/reduce/convert.rs
+++ b/crates/polars-expr/src/reduce/convert.rs
@@ -3,6 +3,9 @@ use polars_plan::prelude::*;
 use polars_utils::arena::{Arena, Node};
 
 use super::*;
+use crate::reduce::bitwise::{
+    new_bitwise_and_reduction, new_bitwise_or_reduction, new_bitwise_xor_reduction,
+};
 use crate::reduce::count::CountReduce;
 use crate::reduce::first_last::{new_first_reduction, new_last_reduction};
 use crate::reduce::len::LenReduce;
@@ -70,6 +73,21 @@ pub fn into_reduction(
                 let expr = expr_arena.add(AExpr::Len);
 
                 (out, expr)
+            }
+        },
+        #[cfg(feature = "bitwise")]
+        AExpr::Function {
+            input: inner_exprs,
+            function: IRFunctionExpr::Bitwise(inner_fn),
+            options: _,
+        } => {
+            assert!(inner_exprs.len() == 1);
+            let input = inner_exprs[0].node();
+            match inner_fn {
+                IRBitwiseFunction::And => (new_bitwise_and_reduction(get_dt(input)?), input),
+                IRBitwiseFunction::Or => (new_bitwise_or_reduction(get_dt(input)?), input),
+                IRBitwiseFunction::Xor => (new_bitwise_xor_reduction(get_dt(input)?), input),
+                _ => todo!(),
             }
         },
         _ => unreachable!(),

--- a/crates/polars-expr/src/reduce/mod.rs
+++ b/crates/polars-expr/src/reduce/mod.rs
@@ -1,4 +1,5 @@
 #![allow(unsafe_op_in_unsafe_fn)]
+#[cfg(feature = "bitwise")]
 mod bitwise;
 mod convert;
 mod count;

--- a/crates/polars-expr/src/reduce/mod.rs
+++ b/crates/polars-expr/src/reduce/mod.rs
@@ -1,4 +1,5 @@
 #![allow(unsafe_op_in_unsafe_fn)]
+mod bitwise;
 mod convert;
 mod count;
 mod first_last;

--- a/crates/polars-stream/src/physical_plan/lower_group_by.rs
+++ b/crates/polars-stream/src/physical_plan/lower_group_by.rs
@@ -7,8 +7,10 @@ use polars_error::{PolarsResult, polars_err};
 use polars_expr::state::ExecutionState;
 use polars_mem_engine::create_physical_plan;
 use polars_plan::plans::expr_ir::{ExprIR, OutputName};
-use polars_plan::plans::{AExpr, DataFrameUdf, IR, IRAggExpr, NaiveExprMerger, write_group_by};
-use polars_plan::prelude::GroupbyOptions;
+use polars_plan::plans::{
+    AExpr, DataFrameUdf, IR, IRAggExpr, IRFunctionExpr, NaiveExprMerger, write_group_by,
+};
+use polars_plan::prelude::{GroupbyOptions, *};
 use polars_utils::arena::{Arena, Node};
 use polars_utils::pl_str::PlSmallStr;
 use polars_utils::unique_column_name;
@@ -165,6 +167,51 @@ fn try_lower_elementwise_scalar_agg_expr(
                 truthy,
                 falsy,
             }))
+        },
+
+        #[cfg(feature = "bitwise")]
+        AExpr::Function {
+            input: inner_exprs,
+            function: IRFunctionExpr::Bitwise(inner_fn),
+            options,
+        } if matches!(
+            inner_fn,
+            IRBitwiseFunction::And | IRBitwiseFunction::Or | IRBitwiseFunction::Xor
+        ) =>
+        {
+            assert!(inner_exprs.len() == 1);
+            let inner_expr = inner_exprs[0].clone();
+            let inner_fn = *inner_fn;
+            let options = *options;
+            let agg_id = expr_merger.get_uniq_id(expr).unwrap();
+            let name = uniq_agg_exprs
+                .entry(agg_id)
+                .or_insert_with(|| {
+                    let input_node = inner_expr.node();
+                    let input_id = expr_merger.get_uniq_id(input_node).unwrap();
+                    let input_col = uniq_input_exprs
+                        .entry(input_id)
+                        .or_insert_with(unique_column_name)
+                        .clone();
+                    let input_col_node = expr_arena.add(AExpr::Column(input_col.clone()));
+                    let trans_agg_node = expr_arena.add(AExpr::Function {
+                        input: vec![ExprIR::from_node(input_col_node, expr_arena)],
+                        function: IRFunctionExpr::Bitwise(inner_fn),
+                        options,
+                    });
+
+                    // Add to aggregation expressions and replace with a reference to its output.
+                    let agg_expr = if let Some(name) = outer_name {
+                        ExprIR::new(trans_agg_node, OutputName::Alias(name))
+                    } else {
+                        ExprIR::new(trans_agg_node, OutputName::Alias(unique_column_name()))
+                    };
+                    agg_exprs.push(agg_expr.clone());
+                    agg_expr.output_name().clone()
+                })
+                .clone();
+            let result_node = expr_arena.add(AExpr::Column(name));
+            Some(result_node)
         },
 
         node @ AExpr::Function { input, options, .. }


### PR DESCRIPTION
closes #23042

This PR moves the execution of bitwise reductions {`Expr.bitwise_and`, `Expr.bitwise_or` and `Expr.bitwise_xor`) into the streaming engine. Scope includes integer and Boolean dtypes, including null values.

Needs a proper review, ping @orlp .
