### PR TITLE
fix: Ignore null values in `bitwise` aggregation on bools

### DIFF
--- a/crates/polars-compute/src/bitwise/mod.rs
+++ b/crates/polars-compute/src/bitwise/mod.rs
@@ -215,7 +215,7 @@ impl BitwiseKernel for BooleanArray {
         } else if !self.has_nulls() {
             Some(self.values().unset_bits() == 0)
         } else {
-            Some((self.values() & self.validity().unwrap()).unset_bits() == 0)
+            Some((self.values() | &!self.validity().unwrap()).unset_bits() == 0)
         }
     }
 

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -304,48 +304,39 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
     }
     fn and_reduce(&self) -> PolarsResult<Scalar> {
         let dt = DataType::Boolean;
-        if self.0.null_count() > 0 {
-            return Ok(Scalar::new(dt, AnyValue::Null));
-        }
 
         Ok(Scalar::new(
             dt,
             self.0
                 .downcast_iter()
                 .filter(|arr| !arr.is_empty())
-                .map(|arr| polars_compute::bitwise::BitwiseKernel::reduce_and(arr).unwrap())
+                .filter_map(polars_compute::bitwise::BitwiseKernel::reduce_and)
                 .reduce(|a, b| a & b)
                 .map_or(AnyValue::Null, Into::into),
         ))
     }
     fn or_reduce(&self) -> PolarsResult<Scalar> {
         let dt = DataType::Boolean;
-        if self.0.null_count() > 0 {
-            return Ok(Scalar::new(dt, AnyValue::Null));
-        }
 
         Ok(Scalar::new(
             dt,
             self.0
                 .downcast_iter()
                 .filter(|arr| !arr.is_empty())
-                .map(|arr| polars_compute::bitwise::BitwiseKernel::reduce_or(arr).unwrap())
+                .filter_map(polars_compute::bitwise::BitwiseKernel::reduce_or)
                 .reduce(|a, b| a | b)
                 .map_or(AnyValue::Null, Into::into),
         ))
     }
     fn xor_reduce(&self) -> PolarsResult<Scalar> {
         let dt = DataType::Boolean;
-        if self.0.null_count() > 0 {
-            return Ok(Scalar::new(dt, AnyValue::Null));
-        }
 
         Ok(Scalar::new(
             dt,
             self.0
                 .downcast_iter()
                 .filter(|arr| !arr.is_empty())
-                .map(|arr| polars_compute::bitwise::BitwiseKernel::reduce_xor(arr).unwrap())
+                .filter_map(polars_compute::bitwise::BitwiseKernel::reduce_xor)
                 .reduce(|a, b| a ^ b)
                 .map_or(AnyValue::Null, Into::into),
         ))

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -10875,7 +10875,7 @@ class Expr:
         return self._from_pyexpr(self._pyexpr.bitwise_trailing_zeros())
 
     def bitwise_and(self) -> Expr:
-        """Perform an aggregation of bitwise ANDs.
+        """Perform an aggregation of bitwise ANDs. Null values will be ignored.
 
         Examples
         --------
@@ -10906,7 +10906,7 @@ class Expr:
         return self._from_pyexpr(self._pyexpr.bitwise_and())
 
     def bitwise_or(self) -> Expr:
-        """Perform an aggregation of bitwise ORs.
+        """Perform an aggregation of bitwise ORs. Null values will be ignored.
 
         Examples
         --------
@@ -10937,7 +10937,7 @@ class Expr:
         return self._from_pyexpr(self._pyexpr.bitwise_or())
 
     def bitwise_xor(self) -> Expr:
-        """Perform an aggregation of bitwise XORs.
+        """Perform an aggregation of bitwise XORs. Null values will be ignored.
 
         Examples
         --------


### PR DESCRIPTION
fixes #23314

Kindly review. Keep the doc update?

Ping @orlp.