### PR TITLE
perf: Improve boolean bitwise aggregate performance

### DIFF
--- a/crates/polars-arrow/src/bitmap/bitmap_ops.rs
+++ b/crates/polars-arrow/src/bitmap/bitmap_ops.rs
@@ -279,6 +279,16 @@ pub fn num_intersections_with(lhs: &Bitmap, rhs: &Bitmap) -> usize {
     )
 }
 
+pub fn intersects_with(lhs: &Bitmap, rhs: &Bitmap) -> bool {
+    binary_fold(
+        lhs,
+        rhs,
+        |lhs, rhs| lhs & rhs != 0,
+        false,
+        |lhs, rhs| lhs || rhs,
+    )
+}
+
 pub fn intersects_with_mut(lhs: &MutableBitmap, rhs: &MutableBitmap) -> bool {
     binary_fold_mut(
         lhs,

--- a/crates/polars-compute/src/bitwise/mod.rs
+++ b/crates/polars-compute/src/bitwise/mod.rs
@@ -1,6 +1,7 @@
 use std::convert::identity;
 
 use arrow::array::{Array, BooleanArray, PrimitiveArray};
+use arrow::bitmap::{binary_fold, intersects_with};
 use arrow::datatypes::ArrowDataType;
 use arrow::legacy::utils::CustomIterTools;
 
@@ -215,7 +216,14 @@ impl BitwiseKernel for BooleanArray {
         } else if !self.has_nulls() {
             Some(self.values().unset_bits() == 0)
         } else {
-            Some((self.values() | &!self.validity().unwrap()).unset_bits() == 0)
+            let false_found = binary_fold(
+                self.values(),
+                self.validity().unwrap(),
+                |lhs, rhs| (!lhs & rhs) != 0,
+                false,
+                |a, b| a || b,
+            );
+            Some(!false_found)
         }
     }
 
@@ -225,7 +233,7 @@ impl BitwiseKernel for BooleanArray {
         } else if !self.has_nulls() {
             Some(self.values().set_bits() > 0)
         } else {
-            Some((self.values() & self.validity().unwrap()).set_bits() > 0)
+            Some(intersects_with(self.values(), self.validity().unwrap()))
         }
     }
 
@@ -235,7 +243,14 @@ impl BitwiseKernel for BooleanArray {
         } else if !self.has_nulls() {
             Some(self.values().set_bits() % 2 == 1)
         } else {
-            Some((self.values() & self.validity().unwrap()).set_bits() % 2 == 1)
+            let nonnull_parity = binary_fold(
+                self.values(),
+                self.validity().unwrap(),
+                |lhs, rhs| lhs & rhs,
+                0,
+                |a, b| a ^ b,
+            );
+            Some(nonnull_parity.count_ones() % 2 == 1)
         }
     }
 


### PR DESCRIPTION
These kernels don't allocate intermediate results and directly aggregate, possibly short-circuiting.

CC @kdn36 