### PR TITLE
feat: Support row group skipping with filters when `cast_options` is given

### DIFF
--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/cast_columns.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/cast_columns.rs
@@ -1,9 +1,10 @@
 use polars_core::chunked_array::cast::CastOptions;
 use polars_core::frame::DataFrame;
 use polars_core::prelude::DataType;
-use polars_core::schema::SchemaRef;
+use polars_core::schema::{Schema, SchemaRef};
 use polars_error::PolarsResult;
 use polars_plan::dsl::CastColumnsPolicy;
+use polars_utils::format_pl_smallstr;
 
 #[derive(Debug)]
 pub struct CastColumns {
@@ -49,7 +50,7 @@ impl CastColumns {
         for (i, (name, incoming_dtype)) in incoming_schema_iter.enumerate() {
             let target_dtype = get_target_dtype(name);
 
-            if PolicyWrap(policy).should_cast_column(name, target_dtype, incoming_dtype)? {
+            if policy.should_cast_column(name, target_dtype, incoming_dtype)? {
                 casting_list.push(ColumnCast {
                     index: i,
                     dtype: target_dtype.clone(),
@@ -79,30 +80,43 @@ impl CastColumns {
 
         Ok(())
     }
-}
 
-struct PolicyWrap<'a>(&'a CastColumnsPolicy);
-
-impl std::ops::Deref for PolicyWrap<'_> {
-    type Target = CastColumnsPolicy;
-
-    fn deref(&self) -> &Self::Target {
-        self.0
-    }
-}
-
-impl PolicyWrap<'_> {
-    /// # Returns
-    /// * Ok(true): Cast needed to target dtype
-    /// * Ok(false): No casting needed
-    /// * Err(_): Forbidden by configuration, or incompatible types.
-    pub fn should_cast_column(
+    /// `DataFrame` containing `{column_name}_min`, `{column_name}_max`.
+    ///
+    /// # Panics
+    /// Panics if there is a cast for a column whose statistics are not present in `statistics_df`.
+    /// This can happen e.g. if `incoming_schema` at initialization contained non-live predicate columns.
+    pub fn apply_cast_to_statistics(
         &self,
-        column_name: &str,
-        target_dtype: &DataType,
-        incoming_dtype: &DataType,
-    ) -> PolarsResult<bool> {
-        self.0
-            .should_cast_column(column_name, target_dtype, incoming_dtype)
+        statistics_df: &mut DataFrame,
+        // Schema of the file that the statistics are built from.
+        incoming_schema: &Schema,
+    ) -> PolarsResult<()> {
+        let statistics_schema = statistics_df.schema().clone();
+        statistics_df.clear_schema();
+
+        let columns = unsafe { statistics_df.get_columns_mut() };
+
+        for ColumnCast { index, dtype } in &self.casting_list {
+            let column_name = incoming_schema.get_at_index(*index).unwrap().0;
+
+            let i = statistics_schema
+                .index_of(&format_pl_smallstr!("{column_name}_min"))
+                .unwrap();
+
+            // Note: Currently casting in scans do not allow any casts that
+            // would raise errors, so we use `strict_cast` here.
+            *columns.get_mut(i).unwrap() =
+                columns[i].cast_with_options(dtype, CastOptions::Strict)?;
+
+            let i = statistics_schema
+                .index_of(&format_pl_smallstr!("{column_name}_max"))
+                .unwrap();
+
+            *columns.get_mut(i).unwrap() =
+                columns[i].cast_with_options(dtype, CastOptions::Strict)?;
+        }
+
+        Ok(())
     }
 }

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/capabilities.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/capabilities.rs
@@ -32,7 +32,15 @@ bitflags! {
         /// `PARTIAL_FILTER` should also be enabled if this is enabled.
         const FULL_FILTER = 1 << 4;
 
+        /// Same as `PARTIAL_FILTER` but with support for column casting (i.e. `cast_columns_policy != ERROR_ON_MISMATCH`).
+        /// `PRE_CAST` indicates that this filtering is done before casting, meaning that the
+        /// output morsels will still be in the original type. This is usually the result of a
+        /// reader skipping blocks of data based on statistics.
+        ///
+        /// A reader indicating this capability should also indicate `PARTIAL_FILTER`.
+        const PARTIAL_FILTER_PRE_CAST = 1 << 5;
+
         /// Supports applying an external filter mask.
-        const EXTERNAL_FILTER_MASK = 1 << 5;
+        const EXTERNAL_FILTER_MASK = 1 << 6;
     }
 }

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/mod.rs
@@ -200,8 +200,8 @@ impl std::fmt::Debug for FileReaderCallbacks {
         f.write_str(&format!(
             "\
         FileReaderCallbacks: \
-        file_schema_tx: {:?} \
-        n_rows_in_file_tx: {:?} \
+        file_schema_tx: {:?}, \
+        n_rows_in_file_tx: {:?}, \
         row_position_on_end_tx: {:?} \
         ",
             file_schema_tx.as_ref().map(|_| ""),

--- a/crates/polars-stream/src/nodes/io_sources/parquet/builder.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/builder.rs
@@ -25,8 +25,11 @@ impl FileReaderBuilder for ParquetReaderBuilder {
     fn reader_capabilities(&self) -> ReaderCapabilities {
         use ReaderCapabilities as RC;
 
-        let mut capabilities =
-            RC::ROW_INDEX | RC::PRE_SLICE | RC::NEGATIVE_PRE_SLICE | RC::PARTIAL_FILTER;
+        let mut capabilities = RC::ROW_INDEX
+            | RC::PRE_SLICE
+            | RC::NEGATIVE_PRE_SLICE
+            | RC::PARTIAL_FILTER
+            | RC::PARTIAL_FILTER_PRE_CAST;
         if matches!(
             self.options.parallel,
             ParallelStrategy::Auto | ParallelStrategy::Prefiltered

--- a/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
@@ -27,6 +27,7 @@ use crate::nodes::io_sources::parquet::PredicateApplyMode;
 use crate::nodes::{MorselSeq, TaskPriority};
 use crate::utils::task_handles_ext::{self, AbortOnDropHandle};
 
+#[expect(clippy::too_many_arguments)]
 async fn calculate_row_group_pred_pushdown_skip_mask(
     row_group_slice: Range<usize>,
     use_statistics: bool,

--- a/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use arrow::datatypes::ArrowDataType;
 use polars_core::frame::DataFrame;
 use polars_core::prelude::{Column, DataType, IDX_DTYPE, IntoColumn};
+use polars_core::schema::SchemaRef;
 use polars_core::series::Series;
 use polars_core::utils::arrow::bitmap::Bitmap;
 use polars_core::utils::arrow::datatypes::ArrowSchemaRef;
@@ -20,7 +21,9 @@ use super::row_group_decode::RowGroupDecoder;
 use super::{AsyncTaskData, ParquetReadImpl};
 use crate::async_executor;
 use crate::morsel::{Morsel, SourceToken, get_ideal_morsel_size};
+use crate::nodes::io_sources::multi_file_reader::extra_ops::cast_columns::CastColumns;
 use crate::nodes::io_sources::multi_file_reader::reader_interface::output::FileReaderOutputSend;
+use crate::nodes::io_sources::parquet::PredicateApplyMode;
 use crate::nodes::{MorselSeq, TaskPriority};
 use crate::utils::task_handles_ext::{self, AbortOnDropHandle};
 
@@ -31,6 +34,7 @@ async fn calculate_row_group_pred_pushdown_skip_mask(
     metadata: &Arc<FileMetadata>,
     reader_schema: &ArrowSchemaRef,
     mut row_index: Option<RowIndex>,
+    cast_columns: Option<(CastColumns, SchemaRef)>,
     verbose: bool,
 ) -> PolarsResult<Option<Bitmap>> {
     if !use_statistics {
@@ -49,6 +53,9 @@ async fn calculate_row_group_pred_pushdown_skip_mask(
     let metadata = metadata.clone();
     let live_columns = predicate.live_columns.clone();
     let reader_schema = reader_schema.clone();
+
+    // Note: We are spawning here onto the computational async runtime because the caller is being run
+    // on a tokio async thread.
     let skip_row_group_mask = async_executor::spawn(TaskPriority::High, async move {
         if let Some(ri) = &mut row_index {
             for md in metadata.row_groups[0..row_group_slice.start].iter() {
@@ -129,7 +136,12 @@ async fn calculate_row_group_pred_pushdown_skip_mask(
             columns.extend([min, max, nc]);
         }
 
-        let statistics_df = DataFrame::new_with_height(num_row_groups, columns)?;
+        let mut statistics_df = DataFrame::new_with_height(num_row_groups, columns)?;
+
+        if let Some((cast_columns, file_schema)) = cast_columns {
+            cast_columns.apply_cast_to_statistics(&mut statistics_df, &file_schema)?;
+        }
+
         sbp.evaluate_with_stat_df(&statistics_df)
     })
     .await?;
@@ -192,6 +204,7 @@ impl ParquetReadImpl {
             tokio::sync::mpsc::channel(row_group_prefetch_size);
 
         let row_index = self.row_index.clone();
+        let live_filter_columns_cast = self.live_filter_columns_cast.take();
 
         let prefetch_task = AbortOnDropHandle(io_runtime.spawn(async move {
             polars_ensure!(
@@ -255,6 +268,7 @@ impl ParquetReadImpl {
                 &metadata,
                 &reader_schema,
                 row_index,
+                live_filter_columns_cast,
                 verbose,
             )
             .await?;
@@ -365,18 +379,23 @@ impl ParquetReadImpl {
     /// This must be called AFTER the following have been initialized:
     /// * `self.projected_arrow_schema`
     /// * `self.physical_predicate`
-    pub(super) fn init_row_group_decoder(&self) -> RowGroupDecoder {
+    pub(super) fn init_row_group_decoder(&mut self) -> RowGroupDecoder {
         let projected_arrow_schema = self.projected_arrow_schema.clone();
         let row_index = self.row_index.clone();
         let min_values_per_thread = self.config.min_values_per_thread;
 
+        let predicate = match self.predicate_apply_mode {
+            PredicateApplyMode::StatisticsOnly => None,
+            PredicateApplyMode::Full => self.predicate.clone(),
+        };
+
         let mut use_prefiltered = matches!(self.options.parallel, ParallelStrategy::Prefiltered);
         use_prefiltered |=
-            self.predicate.is_some() && matches!(self.options.parallel, ParallelStrategy::Auto);
+            predicate.is_some() && matches!(self.options.parallel, ParallelStrategy::Auto);
 
         let mut predicate_arrow_field_indices = vec![];
         if use_prefiltered {
-            if let Some(predicate) = self.predicate.as_ref() {
+            if let Some(predicate) = predicate.as_ref() {
                 predicate_arrow_field_indices = predicate
                     .live_columns
                     .iter()
@@ -413,7 +432,7 @@ impl ParquetReadImpl {
             num_pipelines: self.config.num_pipelines,
             projected_arrow_schema,
             row_index,
-            predicate: self.predicate.clone(),
+            predicate,
             use_prefiltered,
             predicate_arrow_field_indices,
             non_predicate_arrow_field_indices,

--- a/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
@@ -223,29 +223,37 @@ impl FileReader for ParquetFileReader {
             )
         }
 
+        let predicate_apply_mode = if cast_columns_policy != CastColumnsPolicy::ERROR_ON_MISMATCH {
+            PredicateApplyMode::StatisticsOnly
+        } else {
+            PredicateApplyMode::Full
+        };
+
         // If are handling predicates we apply missing / cast columns policy here as those need to
         // happen before filtering. Otherwise we leave it to post.
-        if let Some(predicate) = predicate.as_mut() {
-            if cast_columns_policy != CastColumnsPolicy::ERROR_ON_MISMATCH {
-                unimplemented!("column casting w/ predicate in parquet")
-            }
-
-            // Note: This currently could return a Some(_) for the case where
-            // there are struct fields ordered differently, but that should not
-            // affect predicates.
-            CastColumns::try_init_from_policy_from_iter(
-                &cast_columns_policy,
-                &projected_schema,
-                &mut self
-                    ._file_schema()
+        let live_filter_columns_cast = if let Some(predicate) = predicate.as_mut() {
+            let live_schema: SchemaRef = Arc::new(
+                self._file_schema()
                     .iter()
                     .filter(|(name, _)| predicate.live_columns.contains(*name))
-                    .map(|(name, dtype)| (name.as_ref(), dtype)),
+                    .map(|(name, dtype)| (name.clone(), dtype.clone()))
+                    .collect(),
+            );
+
+            let cast_columns = CastColumns::try_init_from_policy(
+                &cast_columns_policy,
+                &projected_schema,
+                &live_schema,
             )?;
-        }
+
+            cast_columns.map(|x| (x, live_schema))
+        } else {
+            None
+        };
 
         let (output_recv, handle) = ParquetReadImpl {
             predicate,
+            predicate_apply_mode,
             // TODO: Refactor to avoid full clone
             options: Arc::unwrap_or_clone(self.config.clone()),
             byte_source: byte_source.clone(),
@@ -264,6 +272,7 @@ impl FileReader for ParquetFileReader {
             projected_arrow_schema,
             memory_prefetch_func,
             row_index,
+            live_filter_columns_cast,
         }
         .run();
 
@@ -328,6 +337,7 @@ type AsyncTaskData = (
 
 struct ParquetReadImpl {
     predicate: Option<ScanIOPredicate>,
+    predicate_apply_mode: PredicateApplyMode,
     options: ParquetOptions,
     byte_source: Arc<DynByteSource>,
     normalized_pre_slice: Option<(usize, usize)>,
@@ -339,6 +349,7 @@ struct ParquetReadImpl {
     projected_arrow_schema: Arc<ArrowSchema>,
     memory_prefetch_func: fn(&[u8]) -> (),
     row_index: Option<RowIndex>,
+    live_filter_columns_cast: Option<(CastColumns, SchemaRef)>,
 }
 
 #[derive(Debug)]
@@ -359,4 +370,12 @@ impl ParquetReadImpl {
 
         self.init_morsel_distributor()
     }
+}
+
+enum PredicateApplyMode {
+    /// Only row-group skipping via statistics. Used when type casting is needed.
+    StatisticsOnly,
+    /// Row-group skipping as well as full row filtering of the row groups that
+    /// are read in.
+    Full,
 }


### PR DESCRIPTION
We do this by casting the statistics table. This is currently fairly simple to reason about as we don't allow fallible casts (e.g. downcasting integers).

This will allow for row group skipping in native `scan_iceberg` as well as allowing type casting to be enabled by default in `scan_delta`.
