### PR TITLE
fix: Parse parquet footer length into unsigned integer

### DIFF
--- a/crates/polars-parquet/src/parquet/read/metadata.rs
+++ b/crates/polars-parquet/src/parquet/read/metadata.rs
@@ -8,8 +8,8 @@ use super::super::metadata::FileMetadata;
 use super::super::{DEFAULT_FOOTER_READ_SIZE, FOOTER_SIZE, HEADER_SIZE, PARQUET_MAGIC};
 use crate::parquet::error::{ParquetError, ParquetResult};
 
-pub(super) fn metadata_len(buffer: &[u8], len: usize) -> i32 {
-    i32::from_le_bytes(buffer[len - 8..len - 4].try_into().unwrap())
+pub(super) fn metadata_len(buffer: &[u8], len: usize) -> u32 {
+    u32::from_le_bytes(buffer[len - 8..len - 4].try_into().unwrap())
 }
 
 // see (unstable) Seek::stream_len
@@ -59,9 +59,8 @@ pub fn read_metadata_with_size<R: Read + Seek>(
         return Err(ParquetError::oos("The file must end with PAR1"));
     }
 
-    let metadata_len = metadata_len(&buffer, default_end_len);
-
-    let metadata_len: u64 = metadata_len.try_into()?;
+    let metadata_len: u32 = metadata_len(&buffer, default_end_len);
+    let metadata_len: u64 = metadata_len as u64;
 
     let footer_len = FOOTER_SIZE + metadata_len;
     if footer_len > file_size {

--- a/crates/polars-parquet/src/parquet/read/stream.rs
+++ b/crates/polars-parquet/src/parquet/read/stream.rs
@@ -53,8 +53,8 @@ pub async fn read_metadata<R: AsyncRead + AsyncSeek + Send + std::marker::Unpin>
         return Err(ParquetError::oos("Invalid Parquet file. Corrupt footer"));
     }
 
-    let metadata_len = metadata_len(&buffer, default_end_len);
-    let metadata_len: u64 = metadata_len.try_into()?;
+    let metadata_len: u32 = metadata_len(&buffer, default_end_len);
+    let metadata_len: u64 = metadata_len as u64;
 
     let footer_len = FOOTER_SIZE + metadata_len;
     if footer_len > file_size {

--- a/crates/polars-stream/src/nodes/io_sources/parquet/metadata_utils.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/metadata_utils.rs
@@ -36,20 +36,13 @@ pub async fn read_parquet_metadata_bytes(
     let footer_header_bytes = bytes.slice((bytes.len() - FOOTER_HEADER_SIZE)..bytes.len());
 
     let (v, remaining) = footer_header_bytes.split_at(4);
-    let footer_size = i32::from_le_bytes(v.try_into().unwrap());
+    let footer_size = u32::from_le_bytes(v.try_into().unwrap());
 
     if remaining != PARQUET_MAGIC {
         return Err(ParquetError::OutOfSpec(format!(
             r#"expected parquet magic bytes "{}" in footer, got "{}" instead"#,
             std::str::from_utf8(&PARQUET_MAGIC).unwrap(),
             String::from_utf8_lossy(remaining)
-        ))
-        .into());
-    }
-
-    if footer_size < 0 {
-        return Err(ParquetError::OutOfSpec(format!(
-            "expected positive footer size, got {footer_size} instead"
         ))
         .into());
     }
@@ -68,7 +61,7 @@ pub async fn read_parquet_metadata_bytes(
         if verbose {
             eprintln!(
                 "[ParquetFileReader]: Extra {} bytes need to be fetched for metadata \
-            (initial estimate = {}, actual size = {})",
+                (initial estimate = {}, actual size = {})",
                 footer_size - estimated_metadata_size,
                 bytes.len(),
                 footer_size,


### PR DESCRIPTION
* ref https://github.com/pola-rs/polars/issues/23162

Locally I still cannot read a sample file - after this PR I instead get `ComputeError: parquet: File out of specification: Invalid thrift: maximum skip depth reached`. But at least we are able to progress past the length reading.

```python
import polars as pl

name_len = 2147483647 // 10

df = pl.DataFrame(
    {
        name_len * column_name: 1
        for column_name in ["A", "B", "C", "D", "E", "F", "G", "H", "I"]
    }
)

print(df)

df.write_parquet(".env/A.parquet")

from pathlib import Path

p = Path(".env/A.parquet")
total_len = p.stat().st_size

with p.open("rb") as f:
    f.seek(total_len - 8)
    size = int.from_bytes(f.read(4), byteorder="little")
    print("metadata size:", size)
    assert size > 2147483647

q = pl.scan_parquet(".env/A.parquet")
q.collect()

# On 1.31.0
# polars.exceptions.ComputeError: parquet: File out of specification: Number must be zero or positive: out of range integral type conversion attempted
# This PR:
# polars.exceptions.ComputeError: parquet: File out of specification: Invalid thrift: maximum skip depth reached
```
