### PR TITLE
fix: Fix incorrect results with `group_by` aggregation on empty groups

### DIFF
--- a/crates/polars-expr/src/expressions/mod.rs
+++ b/crates/polars-expr/src/expressions/mod.rs
@@ -503,7 +503,7 @@ impl<'a> AggregationContext<'a> {
             AggState::AggregatedScalar(c) => (c, groups),
             AggState::Literal(c) => (c, groups),
             AggState::AggregatedList(c) => {
-                let flattened = c.explode(false).unwrap();
+                let flattened = c.explode(true).unwrap();
                 let groups = groups.into_owned();
                 // unroll the possible flattened state
                 // say we have groups with overlapping windows:


### PR DESCRIPTION
fixes #23338

The underlying bug comes from the fact that empty lists `[]` get exploded to `null` values when flattening, while the group indices and offsets stay as-is.

Kindly review, also in context of the history of `explode()`.

Ping @coastalwhite