### PR TITLE
feat: Use `scan_parquet().collect_schema()` for `read_parquet_schema`

### DIFF
--- a/crates/polars-python/src/functions/io.rs
+++ b/crates/polars-python/src/functions/io.rs
@@ -30,24 +30,6 @@ pub fn read_ipc_schema(py: Python<'_>, py_f: PyObject) -> PyResult<Bound<'_, PyD
 
 #[cfg(feature = "parquet")]
 #[pyfunction]
-pub fn read_parquet_schema(py: Python<'_>, py_f: PyObject) -> PyResult<Bound<'_, PyDict>> {
-    use polars_parquet::read::{infer_schema, read_metadata};
-
-    let metadata = match get_either_file(py_f, false)? {
-        EitherRustPythonFile::Rust(r) => {
-            read_metadata(&mut BufReader::new(r)).map_err(PyPolarsErr::from)?
-        },
-        EitherRustPythonFile::Py(mut r) => read_metadata(&mut r).map_err(PyPolarsErr::from)?,
-    };
-    let arrow_schema = infer_schema(&metadata).map_err(PyPolarsErr::from)?;
-
-    let dict = PyDict::new(py);
-    fields_to_pydict(&arrow_schema, &dict)?;
-    Ok(dict)
-}
-
-#[cfg(feature = "parquet")]
-#[pyfunction]
 pub fn read_parquet_metadata(py: Python, py_f: PyObject) -> PyResult<Bound<PyDict>> {
     use polars_parquet::read::read_metadata;
     use polars_parquet::read::schema::read_custom_key_value_metadata;

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -32,7 +32,6 @@ from polars.io.scan_options._options import ScanOptions
 with contextlib.suppress(ImportError):
     from polars.polars import PyLazyFrame
     from polars.polars import read_parquet_metadata as _read_parquet_metadata
-    from polars.polars import read_parquet_schema as _read_parquet_schema
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -341,6 +340,10 @@ def read_parquet_schema(source: str | Path | IO[bytes] | bytes) -> dict[str, Dat
     """
     Get the schema of a Parquet file without reading data.
 
+    If you would like to read the schema of a cloud file with authentication
+    configuration, it is recommended use `scan_parquet` - e.g.
+    `scan_parquet(..., storage_options=...).collect_schema()`.
+
     Parameters
     ----------
     source
@@ -353,11 +356,12 @@ def read_parquet_schema(source: str | Path | IO[bytes] | bytes) -> dict[str, Dat
     -------
     dict
         Dictionary mapping column names to datatypes
-    """
-    if isinstance(source, (str, Path)):
-        source = normalize_filepath(source, check_not_directory=False)
 
-    return _read_parquet_schema(source)
+    See Also
+    --------
+    scan_parquet
+    """
+    return scan_parquet(source).collect_schema()
 
 
 def read_parquet_metadata(source: str | Path | IO[bytes] | bytes) -> dict[str, str]:

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -246,9 +246,6 @@ fn polars(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(functions::read_ipc_schema))
         .unwrap();
     #[cfg(feature = "parquet")]
-    m.add_wrapped(wrap_pyfunction!(functions::read_parquet_schema))
-        .unwrap();
-    #[cfg(feature = "parquet")]
     m.add_wrapped(wrap_pyfunction!(functions::read_parquet_metadata))
         .unwrap();
     #[cfg(feature = "clipboard")]


### PR DESCRIPTION
* ref https://github.com/pola-rs/polars/issues/23346

This will make `read_parquet_schema()` work with cloud paths.
