### PR TITLE
feat(python): add ScanCastOptions to Delta tables read and scan to avoid INT96 issue 

### DIFF
--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -34,6 +34,7 @@ def read_delta(
     delta_table_options: dict[str, Any] | None = None,
     use_pyarrow: bool = False,
     pyarrow_options: dict[str, Any] | None = None,
+    cast_options: ScanCastOptions | None = None,
 ) -> DataFrame:
     """
     Reads into a DataFrame from a Delta lake table.
@@ -75,6 +76,13 @@ def read_delta(
         Flag to enable pyarrow dataset reads.
     pyarrow_options
         Keyword arguments while converting a Delta lake Table to pyarrow table.
+    cast_options
+        Configuration for column type-casting during scans. Useful for datasets
+        containing files that have differing schemas.
+
+        .. warning::
+            This functionality is considered **unstable**. It may be changed
+            at any point without it being considered a breaking change.
 
     Returns
     -------
@@ -172,6 +180,7 @@ def scan_delta(
     use_pyarrow: bool = False,
     pyarrow_options: dict[str, Any] | None = None,
     rechunk: bool | None = None,
+    cast_options: ScanCastOptions | None = None,
 ) -> LazyFrame:
     """
     Lazily read from a Delta lake table.
@@ -213,6 +222,13 @@ def scan_delta(
     rechunk
         Make sure that all columns are contiguous in memory by
         aggregating the chunks into a single array.
+    cast_options
+        Configuration for column type-casting during scans. Useful for datasets
+        containing files that have differing schemas.
+
+        .. warning::
+            This functionality is considered **unstable**. It may be changed
+            at any point without it being considered a breaking change.
 
     Returns
     -------

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
     from polars import DataFrame, DataType, LazyFrame
     from polars.io.cloud import CredentialProviderFunction
+    from polars.io.scan_options import ScanCastOptions
 
 
 def read_delta(
@@ -163,6 +164,7 @@ def read_delta(
         use_pyarrow=use_pyarrow,
         pyarrow_options=pyarrow_options,
         rechunk=rechunk,
+        cast_options=cast_options,
     )
 
     if columns is not None:
@@ -425,6 +427,7 @@ def scan_delta(
         storage_options=storage_options,
         credential_provider=credential_provider_builder,  # type: ignore[arg-type]
         rechunk=rechunk or False,
+        cast_options=cast_options,
     )
 
 

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -544,10 +544,13 @@ def test_cast_on_read_spark_ts(tmp_path: Path) -> None:
     with pytest.raises(pl.exceptions.SchemaError) as err:
         pl.read_delta(str(delta_path))
     expected = (
-        "dtypes differ for column ts_nano: "
-        "Timestamp(Nanosecond, None) != Timestamp(Microsecond, None)"
+        "data type mismatch for column ts_nano: incoming: "
+        "Datetime(Nanoseconds, None) != target: Datetime(Microseconds, None)"
     )
     assert expected in str(err.value)
 
     # Fix read with explicit cast
-    pl.read_delta(str(delta_path), cast_options=pl.ScanCastOptions(datetime_cast='nanosecond-downcast'))
+    pl.read_delta(
+        str(delta_path),
+        cast_options=pl.ScanCastOptions(datetime_cast="nanosecond-downcast"),
+    )


### PR DESCRIPTION
This adds new ScanCastOptions parameter to Delta tables read/scan to avoid INT96 issue 

It fixes issue described here:
https://github.com/pola-rs/polars/issues/20863

Closes
https://github.com/pola-rs/polars/issues/20159
and
https://github.com/pola-rs/polars/issues/20863

Issue happens when we read delta tables saved by Spark/Databricks. 

Delta stores timestamp in microsecond precision adjusted to UTC as defined in the protocol:
https://github.com/delta-io/delta/blob/master/PROTOCOL.md?plain=1#L2007

But Spark stores as nanosecond by default (due to historic reasons). When Polars resolves schema through DeltaLake library it uses default behaviour as per Delta protocol and that causes incorrectness as Spark violates protocol in this instance. 

To overcome this issue users can instruct explicit downcast through param to read_delta/scan_delta.

For example:

Spark
``` python
df = spark.range(1).withColumn("ts", expr("current_timestamp()"))
df.write.format("delta").mode("append").save("tmp/spark_write_delta")
```

Polars
``` python
# This causes error
pl.read_delta("tmp/spark_write_delta")
... 
polars.exceptions.SchemaError: data type mismatch for column ts: incoming: Datetime(Nanoseconds, None) != target: Datetime(Microseconds, Some("UTC")), hint: pass cast_options=pl.ScanCastOptions(datetime_cast='nanosecond-downcast')
```

After adding new param it works as usual:
```python
# All good now
pl.read_delta("tmp/spark_write_delta", cast_options=pl.ScanCastOptions(datetime_cast='nanosecond-downcast'))

shape: (1, 2)
┌─────┬────────────────────────────────┐
│ id  ┆ ts                             │
│ --- ┆ ---                            │
│ i64 ┆ datetime[μs, UTC]              │
╞═════╪════════════════════════════════╡
│ 0   ┆ 2025-02-06 19:23:30.123456 UTC │
└─────┴────────────────────────────────┘

```
