### PR TITLE
fix(rust): Fix compilation failure with `--no-default-features` and `--features lazy,strings`

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/function_expr/strings.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/strings.rs
@@ -255,6 +255,7 @@ impl IRStringFunction {
             S::Reverse => FunctionOptions::elementwise(),
             #[cfg(feature = "temporal")]
             S::Strptime(_, options) if options.format.is_some() => FunctionOptions::elementwise(),
+            #[cfg(feature = "temporal")]
             S::Strptime(_, _) => FunctionOptions::elementwise_with_infer(),
             S::Split(_) => FunctionOptions::elementwise(),
             #[cfg(feature = "nightly")]


### PR DESCRIPTION
Prior to this change, the `polars` crate would fail to compile with `cargo check --no-default-features --features lazy,strings`. After this change, that compilation failure no longer occurs.