### PR TITLE
docs(python): Update example code in pandas migration guide

### DIFF
--- a/docs/source/user-guide/migration/pandas.md
+++ b/docs/source/user-guide/migration/pandas.md
@@ -130,7 +130,7 @@ by a value column (`v1`). In pandas this would be:
 
 ```python
 df = pd.read_csv(csv_file, usecols=["id1","v1"])
-grouped_df = df.loc[:,["id1","v1"]].groupby("id1").sum("v1")
+grouped_df = df.loc[:,["id1","v1"]].groupby("id1").sum()
 ```
 
 In Polars you can build this query in lazy mode with query optimization and evaluate it by replacing


### PR DESCRIPTION
The original code `sum("v1")` worked but was not technically correct—`pandas.DataFrameGroupBy.sum()` does not accept column names. Instead, it sums all numeric columns in the group. Since we already filtered to `["id1", "v1"]` with `.loc`, using `.sum()` is both correct and cleaner.  

If we want to sum `"v1"` column without selecting columns here, a clearer alternative is `df.groupby("id1")["v1"].sum()`.

Reference: https://pandas.pydata.org/docs/reference/api/pandas.core.groupby.DataFrameGroupBy.sum.html#pandas.core.groupby.DataFrameGroupBy.sum