### PR TITLE
refactor(rust): Remove unneeded allocations when creating `PlPath`

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
@@ -57,7 +57,7 @@ pub(super) fn dsl_to_ir(
             FileScanDsl::PythonDataset { .. } => {
                 // There are a lot of places that short-circuit if the paths is empty,
                 // so we just give a dummy path here.
-                ScanSources::Paths(Arc::from([PlPath::from_string("dummy".to_string())]))
+                ScanSources::Paths(Arc::from([PlPath::from_str("dummy")]))
             },
             FileScanDsl::Anonymous { .. } => sources,
         };

--- a/crates/polars-sql/src/table_functions.rs
+++ b/crates/polars-sql/src/table_functions.rs
@@ -126,7 +126,7 @@ impl PolarsTableFunctions {
         match arg {
             FunctionArg::Unnamed(FunctionArgExpr::Expr(SQLExpr::Value(
                 SQLValue::SingleQuotedString(s),
-            ))) => Ok(PlPath::from_str(&s)),
+            ))) => Ok(PlPath::from_str(s)),
             _ => polars_bail!(
                 SQLSyntax:
                 "expected a valid file path as a single-quoted string; found: {}", arg,

--- a/crates/polars-sql/src/table_functions.rs
+++ b/crates/polars-sql/src/table_functions.rs
@@ -84,7 +84,6 @@ impl PolarsTableFunctions {
 
         use polars_lazy::frame::LazyFileListReader;
         let path = self.get_file_path_from_arg(&args[0])?;
-        let path = PlPath::from_string(path);
         let lf = LazyCsvReader::new(path.clone())
             .with_try_parse_dates(true)
             .with_missing_is_null(true)
@@ -97,7 +96,6 @@ impl PolarsTableFunctions {
         polars_ensure!(args.len() == 1, SQLSyntax: "`read_parquet` expects a single file path; found {:?} arguments", args.len());
 
         let path = self.get_file_path_from_arg(&args[0])?;
-        let path = PlPath::from_string(path);
         let lf = LazyFrame::scan_parquet(path.clone(), Default::default())?;
         Ok((path, lf))
     }
@@ -107,7 +105,6 @@ impl PolarsTableFunctions {
         polars_ensure!(args.len() == 1, SQLSyntax: "`read_ipc` expects a single file path; found {:?} arguments", args.len());
 
         let path = self.get_file_path_from_arg(&args[0])?;
-        let path = PlPath::from_string(path);
         let lf = LazyFrame::scan_ipc(path.clone(), Default::default())?;
         Ok((path, lf))
     }
@@ -119,18 +116,17 @@ impl PolarsTableFunctions {
         use polars_lazy::prelude::LazyJsonLineReader;
 
         let path = self.get_file_path_from_arg(&args[0])?;
-        let path = PlPath::from_string(path);
         let lf = LazyJsonLineReader::new(path.clone()).finish()?;
         Ok((path, lf))
     }
 
     #[allow(dead_code)]
-    fn get_file_path_from_arg(&self, arg: &FunctionArg) -> PolarsResult<String> {
+    fn get_file_path_from_arg(&self, arg: &FunctionArg) -> PolarsResult<PlPath> {
         use sqlparser::ast::{Expr as SQLExpr, Value as SQLValue};
         match arg {
             FunctionArg::Unnamed(FunctionArgExpr::Expr(SQLExpr::Value(
                 SQLValue::SingleQuotedString(s),
-            ))) => Ok(s.to_string()),
+            ))) => Ok(PlPath::from_str(&s)),
             _ => polars_bail!(
                 SQLSyntax:
                 "expected a valid file path as a single-quoted string; found: {}", arg,

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -995,9 +995,7 @@ fn to_graph_rec<'a>(
             }) as Arc<dyn FileReaderBuilder>;
 
             // Give multiscan a single scan source. (It doesn't actually read from this).
-            let sources = ScanSources::Paths(Arc::from([PlPath::from_string(
-                "python-scan-0".to_string(),
-            )]));
+            let sources = ScanSources::Paths(Arc::from([PlPath::from_str("python-scan-0")]));
             let cloud_options = None;
             let final_output_schema = output_schema.clone();
             let projected_file_schema = output_schema.clone();

--- a/crates/polars-utils/src/plpath.rs
+++ b/crates/polars-utils/src/plpath.rs
@@ -365,6 +365,10 @@ impl PlPath {
         self.as_ref().is_cloud_url()
     }
 
+    pub fn from_str(uri: &str) -> Self {
+        Self::new(uri)
+    }
+
     pub fn from_string(uri: String) -> Self {
         Self::new(&uri)
     }

--- a/crates/polars-utils/src/plpath.rs
+++ b/crates/polars-utils/src/plpath.rs
@@ -365,6 +365,8 @@ impl PlPath {
         self.as_ref().is_cloud_url()
     }
 
+    // We don't want FromStr since we are infallible.
+    #[expect(clippy::should_implement_trait)]
     pub fn from_str(uri: &str) -> Self {
         Self::new(uri)
     }


### PR DESCRIPTION
Note that constructing `PlPath` from an owned string doesn't actually re-use the allocation, it always gets copied because `PlPath` stores either `Arc<Path>` or `Arc<str>`.

fyi @kdn36 
