### PR TITLE
fix: Fix index calculation for `nearest` interpolation

### DIFF
--- a/crates/polars-compute/src/rolling/no_nulls/quantile.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/quantile.rs
@@ -84,7 +84,7 @@ impl<
                 };
             },
             Nearest => {
-                let idx = ((length as f64) * self.prob) as usize;
+                let idx = (((length as f64) - 1.0) * self.prob).round() as usize;
                 std::cmp::min(idx, length - 1)
             },
             Lower => ((length as f64 - 1.0) * self.prob).floor() as usize,

--- a/crates/polars-compute/src/rolling/nulls/quantile.rs
+++ b/crates/polars-compute/src/rolling/nulls/quantile.rs
@@ -56,7 +56,7 @@ impl<
         // Nulls are guaranteed to be at the front
         length -= null_count;
         let mut idx = match self.method {
-            QuantileMethod::Nearest => ((length as f64) * self.prob) as usize,
+            QuantileMethod::Nearest => (((length as f64) - 1.0) * self.prob).round() as usize,
             QuantileMethod::Lower | QuantileMethod::Midpoint | QuantileMethod::Linear => {
                 ((length as f64 - 1.0) * self.prob).floor() as usize
             },

--- a/crates/polars-compute/src/rolling/quantile_filter.rs
+++ b/crates/polars-compute/src/rolling/quantile_filter.rs
@@ -633,7 +633,7 @@ where
                 }
             },
             Nearest => {
-                let idx = (valid_length_f * self.quantile) as usize;
+                let idx = ((valid_length_f - 1.0) * self.quantile).round() as usize;
                 let idx = std::cmp::min(idx, valid_length - 1);
                 self.inner.get(idx + null_count)
             },

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -6378,10 +6378,10 @@ class Series:
         [
                 null
                 null
-                1.0
                 2.0
                 3.0
                 4.0
+                6.0
         ]
         >>> s.rolling_quantile(quantile=0.33, interpolation="linear", window_size=3)
         shape: (6,)

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -1535,8 +1535,9 @@ def test_rolling_quantile_with_nulls_22781(method: QuantileMethod) -> None:
 def test_rolling_quantile_nearest_23392() -> None:
     base = range(11)
     s = pl.Series(range(11))
-    random.shuffle(list(base))
-    s_shuffled = pl.Series(base)
+    shuffle_base = list(base)
+    random.shuffle(shuffle_base)
+    s_shuffled = pl.Series(shuffle_base)
     for q in np.arange(0, 1.0, 0.02):
         out = s.rolling_quantile(q, interpolation="nearest", window_size=11)
 

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -1533,7 +1533,10 @@ def test_rolling_quantile_with_nulls_22781(method: QuantileMethod) -> None:
 
 
 def test_rolling_quantile_nearest_23392() -> None:
+    base = range(11)
     s = pl.Series(range(11))
+    random.shuffle(list(base))
+    s_shuffled = pl.Series(base)
     for q in np.arange(0, 1.0, 0.02):
         out = s.rolling_quantile(q, interpolation="nearest", window_size=11)
 
@@ -1545,9 +1548,8 @@ def test_rolling_quantile_nearest_23392() -> None:
         equiv = s.quantile(q, interpolation="nearest")
         assert out.last() == equiv
 
-        # randomized:
-        random.shuffle(s)
-        out = s.rolling_quantile(q, interpolation="nearest", window_size=11)
+        # shuffled:
+        out = s_shuffled.rolling_quantile(q, interpolation="nearest", window_size=11)
         assert_series_equal(out, expected)
 
 

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -1535,15 +1535,16 @@ def test_rolling_quantile_with_nulls_22781(method: QuantileMethod) -> None:
 def test_rolling_quantile_nearest_23392() -> None:
     base = range(11)
     s = pl.Series(base)
+
     shuffle_base = list(base)
     random.shuffle(shuffle_base)
     s_shuffled = pl.Series(shuffle_base)
-    for q in np.arange(0, 1.0, 0.02):
-        q = float(q)
+
+    for q in np.arange(0, 1.0, 0.02, dtype=float):
         out = s.rolling_quantile(q, interpolation="nearest", window_size=11)
 
         # explicit:
-        expected = pl.Series([None] * 10 + [float(round(q * 10))])
+        expected = pl.Series([None] * 10 + [float(round(q * 10.0))])
         assert_series_equal(out, expected)
 
         # equivalence:

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import random
 import sys
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING
@@ -1522,11 +1523,70 @@ def test_rolling_quantile_with_nulls_22781(method: QuantileMethod) -> None:
             "a": [None, None, 1.0, None, None, 1.0, 1.0, None, None],
         }
     )
-    method = "nearest"
     out = (
         lf.rolling("index", period="2i")
         .agg(pl.col("a").quantile(0.5, interpolation=method))
         .collect()
     )
     expected = pl.Series("a", [None, None, 1.0, 1.0, None, 1.0, 1.0, 1.0, None])
+    assert_series_equal(out["a"], expected)
+
+
+def test_rolling_quantile_nearest_23392() -> None:
+    s = pl.Series(range(11))
+    for q in np.arange(0, 1.0, 0.02):
+        out = s.rolling_quantile(q, interpolation="nearest", window_size=11)
+
+        # explicit:
+        expected = pl.Series([None] * 10 + [float(round(q * 10))])
+        assert_series_equal(out, expected)
+
+        # equivalence:
+        equiv = s.quantile(q, interpolation="nearest")
+        assert out.last() == equiv
+
+        # randomized:
+        random.shuffle(s)
+        out = s.rolling_quantile(q, interpolation="nearest", window_size=11)
+        assert_series_equal(out, expected)
+
+
+def test_rolling_quantile_nearest_kernel_23392() -> None:
+    df = pl.DataFrame(
+        {
+            "dt": [
+                datetime(2021, 1, 1),
+                datetime(2021, 1, 2),
+                datetime(2021, 1, 4),
+                datetime(2021, 1, 5),
+                datetime(2021, 1, 7),
+            ],
+            "values": pl.arange(0, 5, eager=True),
+        }
+    )
+    # values (period="3d", quantile=0.7) are chosen to trigger index rounding
+    out = (
+        df.set_sorted("dt")
+        .rolling("dt", period="3d", closed="both")
+        .agg([pl.col("values").quantile(quantile=0.7).alias("quantile")])
+        .select("quantile")
+    )
+    expected = pl.DataFrame({"quantile": [0.0, 1.0, 1.0, 2.0, 3.0]})
+    assert_frame_equal(out, expected)
+
+
+def test_rolling_quantile_nearest_with_nulls_23932() -> None:
+    lf = pl.LazyFrame(
+        {
+            "index": [0, 1, 2, 3, 4, 5, 6],
+            "a": [None, None, 1.0, 2.0, 3.0, None, None],
+        }
+    )
+    # values (period="3i", quantile=0.7) are chosen to trigger index rounding
+    out = (
+        lf.rolling("index", period="3i")
+        .agg(pl.col("a").quantile(0.7, interpolation="nearest"))
+        .collect()
+    )
+    expected = pl.Series("a", [None, None, 1.0, 2.0, 2.0, 3.0, 3.0])
     assert_series_equal(out["a"], expected)

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -1534,11 +1534,12 @@ def test_rolling_quantile_with_nulls_22781(method: QuantileMethod) -> None:
 
 def test_rolling_quantile_nearest_23392() -> None:
     base = range(11)
-    s = pl.Series(range(11))
+    s = pl.Series(base)
     shuffle_base = list(base)
     random.shuffle(shuffle_base)
     s_shuffled = pl.Series(shuffle_base)
     for q in np.arange(0, 1.0, 0.02):
+        q = float(q)
         out = s.rolling_quantile(q, interpolation="nearest", window_size=11)
 
         # explicit:


### PR DESCRIPTION
fixes #23392

In total, there are 4 instances of the `nearest` indexing logic, 3 of which were incorrect and are now fixed in this PR. The 4th instance was already addressed in https://github.com/pola-rs/polars/pull/13058.

*edit: (!) the example in the python documentation is also changed per doctest, please review

This PR also removes an erroneous `method` overwrite in a prior test case (PR #22781).

Kindly review, including the expected outcome of the respective new test cases.