### PR TITLE
fix(python): PartitionParted is mapped correctly

### DIFF
--- a/py-polars/polars/io/partition.py
+++ b/py-polars/polars/io/partition.py
@@ -478,7 +478,7 @@ class PartitionParted(PartitioningScheme):
 
         lowered_by = _lower_by(by)
         super().__init__(
-            PyPartitioning.new_by_key(
+            PyPartitioning.new_parted(
                 base_path=base_path,
                 file_path_cb=_cast_keyed_file_path_cb(file_path),
                 by=lowered_by,


### PR DESCRIPTION
Due to a mistake, `PartitionParted` had exactly the same content as `PartitionByKey`.

This means that the current test case for PartitionParted would also pass for PartitionByKey, but I do not understand the correct behavior of PartitionParted, so the test case remains as is for now.