### PR TITLE
fix: Update lf.remote to use `ClientContext`

### DIFF
--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -8101,7 +8101,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     @unstable()
     def remote(
         self,
-        context: pc.ComputeContext | None = None,
+        context: pc.ClientContext | None = None,
         plan_type: pc._typing.PlanTypePreference = "dot",
     ) -> pc.LazyFrameExt:
         """
@@ -8156,7 +8156,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └──────────┘
 
         """
-        return pc.LazyFrameExt(lf=self, context=context, plan_type=plan_type)
+        return pc.LazyFrameExt(lf=self, context=context, plan_type=plan_type)  # type: ignore[arg-type]
 
     @unstable()
     def match_to_schema(


### PR DESCRIPTION
This updates the remote method to use `ClientContext` rather than `ComputeContext`.