### PR TITLE
refactor(rust): Drop New from RowEncodingCategoricalContext

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/row_encode.rs
+++ b/crates/polars-core/src/chunked_array/ops/row_encode.rs
@@ -97,10 +97,10 @@ pub fn get_row_encoding_context(dtype: &DataType) -> Option<RowEncodingContext> 
 
         #[cfg(feature = "dtype-categorical")]
         DataType::Categorical(_, mapping) | DataType::Enum(_, mapping) => {
-            use polars_row::NewRowEncodingCategoricalContext;
+            use polars_row::RowEncodingCategoricalContext;
 
             Some(RowEncodingContext::Categorical(
-                NewRowEncodingCategoricalContext {
+                RowEncodingCategoricalContext {
                     is_enum: matches!(dtype, DataType::Enum(_, _)),
                     mapping: mapping.clone(),
                 },

--- a/crates/polars-row/src/decode.rs
+++ b/crates/polars-row/src/decode.rs
@@ -7,7 +7,7 @@ use arrow::types::NativeType;
 use polars_dtype::categorical::CatNative;
 
 use self::encode::fixed_size;
-use self::row::{NewRowEncodingCategoricalContext, RowEncodingOptions};
+use self::row::{RowEncodingCategoricalContext, RowEncodingOptions};
 use self::variable::utf8::decode_str;
 use super::*;
 use crate::fixed::numeric::{FixedLengthEncoding, FromSlice};
@@ -198,7 +198,7 @@ fn rows_for_fixed_size_list<'a>(
 unsafe fn decode_cat<T: NativeType + FixedLengthEncoding + CatNative>(
     rows: &mut [&[u8]],
     opt: RowEncodingOptions,
-    ctx: &NewRowEncodingCategoricalContext,
+    ctx: &RowEncodingCategoricalContext,
 ) -> PrimitiveArray<T>
 where
     T::Encoded: FromSlice,

--- a/crates/polars-row/src/encode.rs
+++ b/crates/polars-row/src/encode.rs
@@ -16,7 +16,7 @@ use crate::row::{RowEncodingOptions, RowsEncoded};
 use crate::variable::{binary, no_order, utf8};
 use crate::widths::RowWidths;
 use crate::{
-    ArrayRef, NewRowEncodingCategoricalContext, RowEncodingContext, with_match_arrow_primitive_type,
+    ArrayRef, RowEncodingCategoricalContext, RowEncodingContext, with_match_arrow_primitive_type,
 };
 
 pub fn convert_columns(
@@ -588,7 +588,7 @@ unsafe fn encode_cat_array<T: NativeType + FixedLengthEncoding + CatNative>(
     buffer: &mut [MaybeUninit<u8>],
     keys: &PrimitiveArray<T>,
     opt: RowEncodingOptions,
-    ctx: &NewRowEncodingCategoricalContext,
+    ctx: &RowEncodingCategoricalContext,
     offsets: &mut [usize],
 ) {
     if ctx.is_enum || !opt.is_ordered() {

--- a/crates/polars-row/src/lib.rs
+++ b/crates/polars-row/src/lib.rs
@@ -285,5 +285,5 @@ pub use encode::{
     convert_columns_no_order,
 };
 pub use row::{
-    NewRowEncodingCategoricalContext, RowEncodingContext, RowEncodingOptions, RowsEncoded,
+    RowEncodingCategoricalContext, RowEncodingContext, RowEncodingOptions, RowsEncoded,
 };

--- a/crates/polars-row/src/row.rs
+++ b/crates/polars-row/src/row.rs
@@ -19,13 +19,13 @@ const BOOLEAN_FALSE_SENTINEL: u8 = 0x02;
 pub enum RowEncodingContext {
     Struct(Vec<Option<RowEncodingContext>>),
     /// Categorical / Enum
-    Categorical(NewRowEncodingCategoricalContext),
+    Categorical(RowEncodingCategoricalContext),
     /// Decimal with given precision
     Decimal(usize),
 }
 
 #[derive(Debug, Clone)]
-pub struct NewRowEncodingCategoricalContext {
+pub struct RowEncodingCategoricalContext {
     pub is_enum: bool,
     pub mapping: Arc<CategoricalMapping>,
 }


### PR DESCRIPTION
This was a temporary name during https://github.com/pola-rs/polars/pull/23016 accidentally left in.