### PR TITLE
fix(python): Fix incorrect `_get_path_scheme`

### DIFF
--- a/py-polars/polars/io/cloud/_utils.py
+++ b/py-polars/polars/io/cloud/_utils.py
@@ -23,7 +23,7 @@ def _first_scan_path(
 def _get_path_scheme(path: str | Path) -> str | None:
     splitted = str(path).split("://", maxsplit=1)
 
-    return None if not splitted else splitted[0]
+    return None if len(splitted) < 2 else splitted[0]
 
 
 def _is_aws_cloud(scheme: str) -> bool:

--- a/py-polars/polars/io/cloud/_utils.py
+++ b/py-polars/polars/io/cloud/_utils.py
@@ -21,9 +21,10 @@ def _first_scan_path(
 
 
 def _get_path_scheme(path: str | Path) -> str | None:
-    splitted = str(path).split("://", maxsplit=1)
+    path_str = str(path)
+    i = path_str.find("://")
 
-    return None if len(splitted) < 2 else splitted[0]
+    return None if i == -1 else path_str[:i]
 
 
 def _is_aws_cloud(scheme: str) -> bool:

--- a/py-polars/polars/io/cloud/_utils.py
+++ b/py-polars/polars/io/cloud/_utils.py
@@ -24,7 +24,7 @@ def _get_path_scheme(path: str | Path) -> str | None:
     path_str = str(path)
     i = path_str.find("://")
 
-    return None if i == -1 else path_str[:i]
+    return path_str[:i] if i >= 0 else None
 
 
 def _is_aws_cloud(scheme: str) -> bool:

--- a/py-polars/tests/unit/io/test_utils.py
+++ b/py-polars/tests/unit/io/test_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from polars.io.cloud._utils import _get_path_scheme
 import pytest
 
 import polars as pl
@@ -69,3 +70,10 @@ def test_looks_like_url(url: str, result: bool) -> None:
 def test_filename_in_err(scan: Any) -> None:
     with pytest.raises(FileNotFoundError, match=r".*does not exist"):
         scan("does not exist").collect()
+
+
+def test_get_path_scheme() -> None:
+    assert _get_path_scheme("") is None
+    assert _get_path_scheme("A") is None
+    assert _get_path_scheme("scheme://") == "scheme"
+    assert _get_path_scheme("://") == ""

--- a/py-polars/tests/unit/io/test_utils.py
+++ b/py-polars/tests/unit/io/test_utils.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from polars.io.cloud._utils import _get_path_scheme
 import pytest
 
 import polars as pl
 from polars.io._utils import looks_like_url, parse_columns_arg, parse_row_index_args
+from polars.io.cloud._utils import _get_path_scheme
 
 if TYPE_CHECKING:
     from collections.abc import Sequence

--- a/py-polars/tests/unit/io/test_utils.py
+++ b/py-polars/tests/unit/io/test_utils.py
@@ -77,3 +77,4 @@ def test_get_path_scheme() -> None:
     assert _get_path_scheme("A") is None
     assert _get_path_scheme("scheme://") == "scheme"
     assert _get_path_scheme("://") == ""
+    assert _get_path_scheme("://...") == ""


### PR DESCRIPTION
Currently `_get_path_scheme("A")` incorrectly returns "A", after this PR it will correctly return `None`.

No existing releases are affected as they always matched the extracted scheme against specific cloud schemes.
