### PR TITLE
fix(python): Pass DeltaTable._storage_options if no storage_options are provided

### DIFF
--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -305,7 +305,7 @@ def scan_delta(
     )
 
     if isinstance(source, DeltaTable) and storage_options is None:
-        storage_options = source._storage_options  # type: ignore[arg-type]
+        storage_options = source._storage_options  # type: ignore
     if not isinstance(source, DeltaTable):
         credential_provider_builder = _init_credential_provider_builder(
             credential_provider, source, storage_options, "scan_delta"

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -304,6 +304,8 @@ def scan_delta(
         _get_credentials_from_provider_expiry_aware,
     )
 
+    if isinstance(source, DeltaTable) and storage_options is None:
+        storage_options = source._storage_options  # type: ignore[arg-type]
     if not isinstance(source, DeltaTable):
         credential_provider_builder = _init_credential_provider_builder(
             credential_provider, source, storage_options, "scan_delta"

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -305,7 +305,7 @@ def scan_delta(
     )
 
     if isinstance(source, DeltaTable) and storage_options is None:
-        storage_options = source._storage_options  # type: ignore
+        storage_options = source._storage_options
     if not isinstance(source, DeltaTable):
         credential_provider_builder = _init_credential_provider_builder(
             credential_provider, source, storage_options, "scan_delta"


### PR DESCRIPTION
While upgrading to `deltalake=1.0.2` and `dagster-delta==0.5.0`, realized that `pl.scan_delta(DeltaTable).sql().collect()` would not inherit the storage_options from the DeltaTable definition but would instead require storage_options to be passed explicitly.

To solve this I have passed the storage options from the table to the local scope in case of the source being a DeltaTable and the storage_options not being explicitely provided to the `pl.scan_delta()` function.

This fixes [#23064](https://github.com/pola-rs/polars/issues/23064)