### PR TITLE
fix: Preserve row order within partition when sinking parquet

### DIFF
--- a/crates/polars-stream/src/nodes/io_sinks/partition/max_size.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/max_size.rs
@@ -6,7 +6,7 @@ use futures::stream::FuturesUnordered;
 use polars_core::config;
 use polars_core::prelude::Column;
 use polars_core::schema::SchemaRef;
-use polars_error::PolarsResult;
+use polars_error::{PolarsResult, polars_ensure};
 use polars_plan::dsl::{PartitionTargetCallback, SinkFinishCallback, SinkOptions};
 use polars_utils::IdxSize;
 use polars_utils::pl_str::PlSmallStr;
@@ -95,7 +95,8 @@ fn default_file_path_cb(
     _columns: Option<&[Column]>,
     _separator: char,
 ) -> PolarsResult<String> {
-    Ok(format!("{file_idx}.{ext}"))
+    polars_ensure!(file_idx < 1<<(7*4), ComputeError: "exceeded maximum file count (268,435,455)");
+    Ok(format!("{file_idx:07X}.{ext}"))
 }
 
 impl SinkNode for MaxSizePartitionSinkNode {

--- a/crates/polars-stream/src/nodes/io_sinks/partition/max_size.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/max_size.rs
@@ -97,7 +97,7 @@ fn default_file_path_cb(
 ) -> PolarsResult<String> {
     polars_ensure!(file_idx < u32::MAX as usize,
         ComputeError: "exceeded maximum file count within a partition of {}", u32::MAX);
-    Ok(format!("{file_idx:08X}.{ext}"))
+    Ok(format!("{file_idx:08x}.{ext}"))
 }
 
 impl SinkNode for MaxSizePartitionSinkNode {

--- a/crates/polars-stream/src/nodes/io_sinks/partition/max_size.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/max_size.rs
@@ -95,8 +95,9 @@ fn default_file_path_cb(
     _columns: Option<&[Column]>,
     _separator: char,
 ) -> PolarsResult<String> {
-    polars_ensure!(file_idx < 1<<(7*4), ComputeError: "exceeded maximum file count (268,435,455)");
-    Ok(format!("{file_idx:07X}.{ext}"))
+    polars_ensure!(file_idx < u32::MAX as usize,
+        ComputeError: "exceeded maximum file count within a partition of {}", u32::MAX);
+    Ok(format!("{file_idx:08X}.{ext}"))
 }
 
 impl SinkNode for MaxSizePartitionSinkNode {

--- a/py-polars/tests/unit/io/test_partition.py
+++ b/py-polars/tests/unit/io/test_partition.py
@@ -71,7 +71,7 @@ def test_max_size_partition(
 
     i = 0
     while length > 0:
-        assert (io_type["scan"])(tmp_path / f"{i:07x}.{io_type['ext']}").select(
+        assert (io_type["scan"])(tmp_path / f"{i:08x}.{io_type['ext']}").select(
             pl.len()
         ).collect()[0, 0] == min(max_size, length)
 
@@ -106,7 +106,7 @@ def test_max_size_partition_lambda(
 
     i = 0
     while length > 0:
-        assert (io_type["scan"])(tmp_path / f"abc-{i:07x}.{io_type['ext']}").select(
+        assert (io_type["scan"])(tmp_path / f"abc-{i:08x}.{io_type['ext']}").select(
             pl.len()
         ).collect()[0, 0] == min(max_size, length)
 
@@ -357,7 +357,7 @@ def test_max_size_partition_collect_files(tmp_path: Path) -> None:
         sync_on_close="data",
     )
 
-    assert output_files == [tmp_path / f"{i:07x}.{io_type['ext']}" for i in range(6)]
+    assert output_files == [tmp_path / f"{i:08x}.{io_type['ext']}" for i in range(6)]
 
 
 @pytest.mark.parametrize(("io_type"), io_types)

--- a/py-polars/tests/unit/io/test_partition.py
+++ b/py-polars/tests/unit/io/test_partition.py
@@ -71,7 +71,7 @@ def test_max_size_partition(
 
     i = 0
     while length > 0:
-        assert (io_type["scan"])(tmp_path / f"{i}.{io_type['ext']}").select(
+        assert (io_type["scan"])(tmp_path / f"{i:07x}.{io_type['ext']}").select(
             pl.len()
         ).collect()[0, 0] == min(max_size, length)
 


### PR DESCRIPTION
closes #23376

Note: file count within partition limited to an arbitrary 2^28