### PR TITLE
chore: Remove StringCache from the test suite

### DIFF
--- a/py-polars/polars/testing/parametric/strategies/core.py
+++ b/py-polars/polars/testing/parametric/strategies/core.py
@@ -12,7 +12,6 @@ from polars._utils.deprecation import issue_deprecation_warning
 from polars.dataframe import DataFrame
 from polars.datatypes import Array, Boolean, DataType, DataTypeClass, List, Null, Struct
 from polars.series import Series
-from polars.string_cache import StringCache
 from polars.testing.parametric.strategies._utils import flexhash
 from polars.testing.parametric.strategies.data import data
 from polars.testing.parametric.strategies.dtype import _instantiate_dtype, dtypes
@@ -494,27 +493,26 @@ def dataframes(
 
     allow_series_chunks = draw(st.booleans()) if allow_chunks else False
 
-    with StringCache():
-        data = {
-            c.name: draw(
-                series(
-                    name=c.name,
-                    dtype=c.dtype,
-                    min_size=size,
-                    max_size=size,
-                    strategy=c.strategy,
-                    allow_null=c.allow_null,  # type: ignore[arg-type]
-                    allow_chunks=allow_series_chunks,
-                    allow_masked_out=allow_masked_out,
-                    unique=c.unique,
-                    allowed_dtypes=allowed_dtypes,
-                    excluded_dtypes=excluded_dtypes,
-                    allow_time_zones=allow_time_zones,
-                    **kwargs,
-                )
+    data = {
+        c.name: draw(
+            series(
+                name=c.name,
+                dtype=c.dtype,
+                min_size=size,
+                max_size=size,
+                strategy=c.strategy,
+                allow_null=c.allow_null,  # type: ignore[arg-type]
+                allow_chunks=allow_series_chunks,
+                allow_masked_out=allow_masked_out,
+                unique=c.unique,
+                allowed_dtypes=allowed_dtypes,
+                excluded_dtypes=excluded_dtypes,
+                allow_time_zones=allow_time_zones,
+                **kwargs,
             )
-            for c in cols
-        }
+        )
+        for c in cols
+    }
 
     df = DataFrame(data)
 

--- a/py-polars/tests/docs/run_doctest.py
+++ b/py-polars/tests/docs/run_doctest.py
@@ -76,7 +76,6 @@ for mod, methods in OPTIONAL_MODULES_AND_METHODS.items():
 def doctest_teardown(d: doctest.DocTest) -> None:
     # don't let config changes or string cache state leak between tests
     pl.Config.restore_defaults()
-    pl.disable_string_cache()
 
 
 def modules_in_path(p: Path) -> Iterator[ModuleType]:

--- a/py-polars/tests/unit/conftest.py
+++ b/py-polars/tests/unit/conftest.py
@@ -6,7 +6,6 @@ import random
 import string
 import sys
 from contextlib import contextmanager
-from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable, cast
 
 import numpy as np

--- a/py-polars/tests/unit/conftest.py
+++ b/py-polars/tests/unit/conftest.py
@@ -251,25 +251,6 @@ def memory_usage_without_pyarrow() -> Generator[MemoryUsage, Any, Any]:
     #     tracemalloc.stop()
 
 
-@pytest.fixture(params=[True, False])
-def test_global_and_local(
-    request: FixtureRequest,
-) -> Generator[Any, Any, Any]:
-    """
-    Setup fixture which runs each test with and without global string cache.
-
-    Usage: @pytest.mark.usefixtures("test_global_and_local")
-    """
-    use_global = request.param
-    if use_global:
-        with pl.StringCache():
-            # Pre-fill some global items to ensure physical repr isn't 0..n.
-            pl.Series(["eapioejf", "2m4lmv", "3v3v9dlf"], dtype=pl.Categorical)
-            yield
-    else:
-        yield
-
-
 @contextmanager
 def mock_module_import(
     name: str, module: ModuleType, *, replace_if_exists: bool = False
@@ -298,23 +279,6 @@ def mock_module_import(
                 sys.modules[name] = original
             else:
                 del sys.modules[name]
-
-
-# The new streaming engine currently only works if you keep the same string cache
-# alive the entire time.
-def with_string_cache_if_auto_streaming(f: Any) -> Any:
-    if (
-        os.getenv("POLARS_AUTO_NEW_STREAMING", os.getenv("POLARS_FORCE_NEW_STREAMING"))
-        != "1"
-    ):
-        return f
-
-    @wraps(f)
-    def with_cache(*args: Any, **kwargs: Any) -> Any:
-        with pl.StringCache():
-            return f(*args, **kwargs)
-
-    return with_cache
 
 
 def time_func(func: Callable[[], Any], *, iterations: int = 3) -> float:

--- a/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
+++ b/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
@@ -396,7 +396,6 @@ def test_fallback_with_dtype_strict_failure_decimal_precision() -> None:
         PySeries.new_from_any_values_and_dtype("", values, dtype, strict=True)
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 @pytest.mark.may_fail_auto_streaming
 def test_categorical_lit_18874() -> None:
     assert_frame_equal(

--- a/py-polars/tests/unit/dataframe/test_extend.py
+++ b/py-polars/tests/unit/dataframe/test_extend.py
@@ -8,46 +8,45 @@ from polars.testing import assert_frame_equal
 
 
 def test_extend_various_dtypes() -> None:
-    with pl.StringCache():
-        df1 = pl.DataFrame(
-            {
-                "foo": [1, 2],
-                "bar": [True, False],
-                "ham": ["a", "b"],
-                "cat": ["A", "B"],
-                "dates": [datetime(2021, 1, 1), datetime(2021, 2, 1)],
-            },
-            schema_overrides={"cat": pl.Categorical},
-        )
-        df2 = pl.DataFrame(
-            {
-                "foo": [3, 4],
-                "bar": [True, None],
-                "ham": ["c", "d"],
-                "cat": ["C", "B"],
-                "dates": [datetime(2022, 9, 1), datetime(2021, 2, 1)],
-            },
-            schema_overrides={"cat": pl.Categorical},
-        )
+    df1 = pl.DataFrame(
+        {
+            "foo": [1, 2],
+            "bar": [True, False],
+            "ham": ["a", "b"],
+            "cat": ["A", "B"],
+            "dates": [datetime(2021, 1, 1), datetime(2021, 2, 1)],
+        },
+        schema_overrides={"cat": pl.Categorical},
+    )
+    df2 = pl.DataFrame(
+        {
+            "foo": [3, 4],
+            "bar": [True, None],
+            "ham": ["c", "d"],
+            "cat": ["C", "B"],
+            "dates": [datetime(2022, 9, 1), datetime(2021, 2, 1)],
+        },
+        schema_overrides={"cat": pl.Categorical},
+    )
 
-        df1.extend(df2)
+    df1.extend(df2)
 
-        expected = pl.DataFrame(
-            {
-                "foo": [1, 2, 3, 4],
-                "bar": [True, False, True, None],
-                "ham": ["a", "b", "c", "d"],
-                "cat": ["A", "B", "C", "B"],
-                "dates": [
-                    datetime(2021, 1, 1),
-                    datetime(2021, 2, 1),
-                    datetime(2022, 9, 1),
-                    datetime(2021, 2, 1),
-                ],
-            },
-            schema_overrides={"cat": pl.Categorical},
-        )
-        assert_frame_equal(df1, expected)
+    expected = pl.DataFrame(
+        {
+            "foo": [1, 2, 3, 4],
+            "bar": [True, False, True, None],
+            "ham": ["a", "b", "c", "d"],
+            "cat": ["A", "B", "C", "B"],
+            "dates": [
+                datetime(2021, 1, 1),
+                datetime(2021, 2, 1),
+                datetime(2022, 9, 1),
+                datetime(2021, 2, 1),
+            ],
+        },
+        schema_overrides={"cat": pl.Categorical},
+    )
+    assert_frame_equal(df1, expected)
 
 
 def test_extend_slice_offset_8745() -> None:

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -7,12 +7,10 @@ from typing import Callable
 import pytest
 
 import polars as pl
-from polars import StringCache
 from polars.testing import assert_frame_equal, assert_series_equal
-from tests.unit.conftest import with_string_cache_if_auto_streaming
 
 
-@StringCache()
+
 def test_categorical_full_outer_join() -> None:
     df1 = pl.DataFrame(
         [
@@ -64,7 +62,6 @@ def test_categorical_full_outer_join() -> None:
     assert df["key_right"].cast(pl.String).to_list() == ["bar", "baz", None]
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_read_csv_categorical() -> None:
     f = io.BytesIO()
     f.write(b"col1,col2,col3,col4,col5,col6\n'foo',2,3,4,5,6\n'bar',8,9,10,11,12")
@@ -73,7 +70,6 @@ def test_read_csv_categorical() -> None:
     assert df["col1"].dtype == pl.Categorical
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_cat_to_dummies() -> None:
     df = pl.DataFrame({"foo": [1, 2, 3, 4], "bar": ["a", "b", "a", "c"]})
     df = df.with_columns(pl.col("bar").cast(pl.Categorical))
@@ -89,7 +85,6 @@ def test_cat_to_dummies() -> None:
 
 
 @pytest.mark.may_fail_auto_streaming
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_is_in_list() -> None:
     # this requires type coercion to cast.
     # we should not cast within the function as this would be expensive within a
@@ -105,8 +100,6 @@ def test_categorical_is_in_list() -> None:
     }
 
 
-@pytest.mark.usefixtures("test_global_and_local")
-@with_string_cache_if_auto_streaming
 def test_unset_sorted_on_append() -> None:
     df1 = pl.DataFrame(
         [
@@ -133,7 +126,6 @@ def test_unset_sorted_on_append() -> None:
         (pl.Series.eq_missing, pl.Series([True, True, True, False, False, False])),
     ],
 )
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_equality(
     op: Callable[[pl.Series, pl.Series], pl.Series], expected: pl.Series
 ) -> None:
@@ -152,7 +144,7 @@ def test_categorical_equality(
         (pl.Series.ne_missing, pl.Series([True, True, True, True, True, True])),
     ],
 )
-@StringCache()
+
 def test_categorical_equality_global_fastpath(
     op: Callable[[pl.Series, pl.Series], pl.Series], expected: pl.Series
 ) -> None:
@@ -183,7 +175,7 @@ def test_categorical_equality_global_fastpath(
         ),
     ],
 )
-@StringCache()
+
 def test_categorical_global_ordering(
     op: Callable[[pl.Series, pl.Series], pl.Series],
     expected_lexical: pl.Series,
@@ -209,7 +201,7 @@ def test_categorical_global_ordering(
         (operator.gt, pl.Series([True, False, True])),
     ],
 )
-@StringCache()
+
 def test_categorical_global_ordering_broadcast_rhs(
     op: Callable[[pl.Series, pl.Series], pl.Series],
     expected_lexical: pl.Series,
@@ -236,7 +228,7 @@ def test_categorical_global_ordering_broadcast_rhs(
         ),
     ],
 )
-@StringCache()
+
 def test_categorical_global_ordering_broadcast_lhs(
     op: Callable[[pl.Series, pl.Series], pl.Series],
     expected_lexical: pl.Series,
@@ -260,7 +252,6 @@ def test_categorical_global_ordering_broadcast_lhs(
         (operator.gt, pl.Series([False, False, False, True, False, False])),
     ],
 )
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_ordering(
     op: Callable[[pl.Series, pl.Series], pl.Series], expected: pl.Series
 ) -> None:
@@ -278,7 +269,6 @@ def test_categorical_ordering(
         (operator.gt, pl.Series([None, False, False, False, False, False])),
     ],
 )
-@pytest.mark.usefixtures("test_global_and_local")
 def test_compare_categorical(
     op: Callable[[pl.Series, pl.Series], pl.Series], expected: pl.Series
 ) -> None:
@@ -301,7 +291,6 @@ def test_compare_categorical(
         (pl.Series.ne_missing, pl.Series([True, True, False, True, False, True])),
     ],
 )
-@pytest.mark.usefixtures("test_global_and_local")
 def test_compare_categorical_single(
     op: Callable[[pl.Series, pl.Series], pl.Series], expected: pl.Series
 ) -> None:
@@ -324,7 +313,7 @@ def test_compare_categorical_single(
         (pl.Series.eq_missing, pl.Series([False, False, False, False, False, False])),
     ],
 )
-@StringCache()
+
 def test_compare_categorical_single_non_existent(
     op: Callable[[pl.Series, pl.Series], pl.Series], expected: pl.Series
 ) -> None:
@@ -367,7 +356,7 @@ def test_compare_categorical_single_non_existent(
         (pl.Series.eq_missing, pl.Series([True, False, False, False, False, False])),
     ],
 )
-@StringCache()
+
 def test_compare_categorical_single_none(
     op: Callable[[pl.Series, pl.Series], pl.Series], expected: pl.Series
 ) -> None:
@@ -387,14 +376,13 @@ def test_categorical_cmp_noteq() -> None:
     assert len(df_cat.filter(pl.col("a_cat") == pl.col("b_cat"))) == 0
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_cast_null_to_categorical() -> None:
     assert pl.DataFrame().with_columns(
         pl.lit(None).cast(pl.Categorical).alias("nullable_enum")
     ).dtypes == [pl.Categorical]
 
 
-@StringCache()
+
 def test_merge_lit_under_global_cache_4491() -> None:
     df = pl.DataFrame(
         [
@@ -409,7 +397,6 @@ def test_merge_lit_under_global_cache_4491() -> None:
     ).to_dict(as_series=False) == {"label": [None, "bar"], "value": [3, 9]}
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_in_struct_nulls() -> None:
     s = pl.Series(
         "job", ["doctor", "waiter", None, None, None, "doctor"], pl.Categorical
@@ -423,16 +410,14 @@ def test_categorical_in_struct_nulls() -> None:
 
 
 @pytest.mark.slow
-def test_stringcache() -> None:
+def test_large_cat_cast() -> None:
     N = 1_500
-    with pl.StringCache():
-        # create a large enough column that the categorical map is reallocated
-        df = pl.DataFrame({"cats": pl.arange(0, N, eager=True)}).select(
-            pl.col("cats").cast(pl.String).cast(pl.Categorical)
-        )
-        assert df.filter(pl.col("cats").is_in(["1", "2"])).to_dict(as_series=False) == {
-            "cats": ["1", "2"]
-        }
+    df = pl.DataFrame({"cats": pl.arange(0, N, eager=True)}).select(
+        pl.col("cats").cast(pl.String).cast(pl.Categorical)
+    )
+    assert df.filter(pl.col("cats").is_in(["1", "2"])).to_dict(as_series=False) == {
+        "cats": ["1", "2"]
+    }
 
 
 def test_categorical_sort_single() -> None:
@@ -482,14 +467,12 @@ def test_categorical_asof_join_by_arg() -> None:
     assert_frame_equal(out1, out2.with_columns(cat=pl.col.cat.cast(pl.Categorical)))
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_list_get_item() -> None:
     out = pl.Series([["a"]]).cast(pl.List(pl.Categorical)).item()
     assert isinstance(out, pl.Series)
     assert out.dtype == pl.Categorical
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_nested_categorical_aggregation_7848() -> None:
     # a double categorical aggregation
     assert pl.DataFrame(
@@ -507,7 +490,6 @@ def test_nested_categorical_aggregation_7848() -> None:
     }
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_nested_categorical_cast() -> None:
     values = [["x"], ["y"], ["x"]]
     dtype = pl.List(pl.Categorical)
@@ -516,7 +498,6 @@ def test_nested_categorical_cast() -> None:
     assert s.to_list() == values
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_struct_categorical_nesting() -> None:
     # this triggers a lot of materialization
     df = pl.DataFrame(
@@ -540,9 +521,8 @@ def test_categorical_fill_null_existing_category() -> None:
     assert result.to_dict(as_series=False) == expected
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 @pytest.mark.may_fail_auto_streaming
-def test_categorical_fill_null_stringcache() -> None:
+def test_categorical_fill_null() -> None:
     df = pl.LazyFrame(
         {"index": [1, 2, 3], "cat": ["a", "b", None]},
         schema={"index": pl.Int64(), "cat": pl.Categorical()},
@@ -553,22 +533,19 @@ def test_categorical_fill_null_stringcache() -> None:
     assert a.dtypes == [pl.Categorical]
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_fast_unique_flag_from_arrow() -> None:
-    with pl.StringCache():
-        df = pl.DataFrame(
-            {
-                "colB": ["1", "2", "3", "4", "5", "5", "5", "5"],
-            }
-        ).with_columns([pl.col("colB").cast(pl.Categorical)])
+    df = pl.DataFrame(
+        {
+            "colB": ["1", "2", "3", "4", "5", "5", "5", "5"],
+        }
+    ).with_columns([pl.col("colB").cast(pl.Categorical)])
 
-        filtered = df.to_arrow().filter(
-            [True, False, True, True, False, True, True, True]
-        )
-        assert pl.from_arrow(filtered).select(pl.col("colB").n_unique()).item() == 4  # type: ignore[union-attr]
+    filtered = df.to_arrow().filter(
+        [True, False, True, True, False, True, True, True]
+    )
+    assert pl.from_arrow(filtered).select(pl.col("colB").n_unique()).item() == 4  # type: ignore[union-attr]
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_construct_with_null() -> None:
     # Example from https://github.com/pola-rs/polars/issues/7188
     df = pl.from_dicts([{"A": None}, {"A": "foo"}], schema={"A": pl.Categorical})
@@ -578,10 +555,9 @@ def test_construct_with_null() -> None:
     assert s.to_list() == [{"struct_A": None}]
 
 
-def test_categorical_concat_string_cached() -> None:
-    with pl.StringCache():
-        df1 = pl.DataFrame({"x": ["A"]}).with_columns(pl.col("x").cast(pl.Categorical))
-        df2 = pl.DataFrame({"x": ["B"]}).with_columns(pl.col("x").cast(pl.Categorical))
+def test_categorical_concat() -> None:
+    df1 = pl.DataFrame({"x": ["A"]}).with_columns(pl.col("x").cast(pl.Categorical))
+    df2 = pl.DataFrame({"x": ["B"]}).with_columns(pl.col("x").cast(pl.Categorical))
 
     out = pl.concat([df1, df2])
     assert out.dtypes == [pl.Categorical]
@@ -589,17 +565,15 @@ def test_categorical_concat_string_cached() -> None:
 
 
 def test_list_builder_different_categorical_rev_maps() -> None:
-    with pl.StringCache():
-        # built with different values, so different rev-map
-        s1 = pl.Series(["a", "b"], dtype=pl.Categorical)
-        s2 = pl.Series(["c", "d"], dtype=pl.Categorical)
+    # built with different values, so different rev-map
+    s1 = pl.Series(["a", "b"], dtype=pl.Categorical)
+    s2 = pl.Series(["c", "d"], dtype=pl.Categorical)
 
     assert pl.DataFrame({"c": [s1, s2]}).to_dict(as_series=False) == {
         "c": [["a", "b"], ["c", "d"]]
     }
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_collect_11408() -> None:
     df = pl.DataFrame(
         data={"groups": ["a", "b", "c"], "cats": ["a", "b", "c"], "amount": [1, 2, 3]},
@@ -614,17 +588,14 @@ def test_categorical_collect_11408() -> None:
     }
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_nested_cast_unchecked() -> None:
     s = pl.Series("cat", [["cat"]]).cast(pl.List(pl.Categorical))
     assert pl.Series([s]).to_list() == [[["cat"]]]
 
 
 def test_categorical_update_lengths() -> None:
-    with pl.StringCache():
-        s1 = pl.Series(["", ""], dtype=pl.Categorical)
-        s2 = pl.Series([None, "", ""], dtype=pl.Categorical)
-
+    s1 = pl.Series(["", ""], dtype=pl.Categorical)
+    s2 = pl.Series([None, "", ""], dtype=pl.Categorical)
     s = pl.concat([s1, s2], rechunk=False)
     assert s.null_count() == 1
     assert s.len() == 5
@@ -680,7 +651,6 @@ def test_categorical_vstack() -> None:
     }
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_shift_over_13041() -> None:
     df = pl.DataFrame(
         {
@@ -720,14 +690,12 @@ def test_sort_categorical_retain_none() -> None:
     ]
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_cat_preserve_lexical_ordering_on_clear() -> None:
     s = pl.Series("a", ["a", "b"], dtype=pl.Categorical(ordering="lexical"))
     s2 = s.clear()
     assert s.dtype == s2.dtype
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_cat_preserve_lexical_ordering_on_concat() -> None:
     dtype = pl.Categorical(ordering="lexical")
 
@@ -736,7 +704,6 @@ def test_cat_preserve_lexical_ordering_on_concat() -> None:
     assert df2["x"].dtype == dtype
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 @pytest.mark.may_fail_auto_streaming
 def test_cat_append_lexical_sorted_flag() -> None:
     df = pl.DataFrame({"x": [0, 1, 1], "y": ["B", "B", "A"]}).with_columns(
@@ -756,7 +723,6 @@ def test_cat_append_lexical_sorted_flag() -> None:
     assert not (s1.is_sorted())
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_get_cat_categories_multiple_chunks() -> None:
     df = pl.DataFrame(
         [
@@ -789,8 +755,6 @@ def test_nested_categorical_concat(
     )
 
 
-@with_string_cache_if_auto_streaming
-@pytest.mark.usefixtures("test_global_and_local")
 def test_perfect_group_by_19452() -> None:
     n = 40
     df2 = pl.DataFrame(
@@ -803,7 +767,6 @@ def test_perfect_group_by_19452() -> None:
     assert df2.with_columns(a=(pl.col("b")).over(pl.col("a")))["a"].is_sorted()
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_perfect_group_by_19950() -> None:
     dtype = pl.Enum(categories=["a", "b", "c"])
 
@@ -815,51 +778,45 @@ def test_perfect_group_by_19950() -> None:
     }
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_unique() -> None:
-    with pl.StringCache():
-        s = pl.Series(["a", "b", None], dtype=pl.Categorical)
-        assert s.n_unique() == 3
-        assert s.unique().sort().to_list() == [None, "a", "b"]
+    s = pl.Series(["a", "b", None], dtype=pl.Categorical)
+    assert s.n_unique() == 3
+    assert s.unique().sort().to_list() == [None, "a", "b"]
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_unique_20539() -> None:
-    with pl.StringCache():
-        df = pl.DataFrame(
-            {"number": [1, 1, 2, 2, 3], "letter": ["a", "b", "b", "c", "c"]}
+    df = pl.DataFrame(
+        {"number": [1, 1, 2, 2, 3], "letter": ["a", "b", "b", "c", "c"]}
+    )
+
+    result = (
+        df.cast({"letter": pl.Categorical})
+        .group_by("number")
+        .agg(
+            unique=pl.col("letter").unique(maintain_order=True),
+            unique_with_order=pl.col("letter").unique(maintain_order=True),
         )
+    )
 
-        result = (
-            df.cast({"letter": pl.Categorical})
-            .group_by("number")
-            .agg(
-                unique=pl.col("letter").unique(maintain_order=True),
-                unique_with_order=pl.col("letter").unique(maintain_order=True),
-            )
-        )
-
-        assert result.sort("number").to_dict(as_series=False) == {
-            "number": [1, 2, 3],
-            "unique": [["a", "b"], ["b", "c"], ["c"]],
-            "unique_with_order": [["a", "b"], ["b", "c"], ["c"]],
-        }
+    assert result.sort("number").to_dict(as_series=False) == {
+        "number": [1, 2, 3],
+        "unique": [["a", "b"], ["b", "c"], ["c"]],
+        "unique_with_order": [["a", "b"], ["b", "c"], ["c"]],
+    }
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_prefill() -> None:
-    with pl.StringCache():
-        # https://github.com/pola-rs/polars/pull/20547#issuecomment-2569473443
-        # test_compare_categorical_single
-        assert (pl.Series(["a"], dtype=pl.Categorical) < "a").to_list() == [False]
+    # https://github.com/pola-rs/polars/pull/20547#issuecomment-2569473443
+    # test_compare_categorical_single
+    assert (pl.Series(["a"], dtype=pl.Categorical) < "a").to_list() == [False]
 
-        # test_unique_categorical
-        a = pl.Series(["a"], dtype=pl.Categorical)
-        assert a.unique().to_list() == ["a"]
+    # test_unique_categorical
+    a = pl.Series(["a"], dtype=pl.Categorical)
+    assert a.unique().to_list() == ["a"]
 
-        s = pl.Series(["1", "2", "3"], dtype=pl.Categorical)
-        s = s.filter([True, False, True])
-        assert s.n_unique() == 2
+    s = pl.Series(["1", "2", "3"], dtype=pl.Categorical)
+    s = s.filter([True, False, True])
+    assert s.n_unique() == 2
 
 
 def test_categorical_min_max() -> None:

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -10,7 +10,6 @@ import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
-
 def test_categorical_full_outer_join() -> None:
     df1 = pl.DataFrame(
         [
@@ -144,7 +143,6 @@ def test_categorical_equality(
         (pl.Series.ne_missing, pl.Series([True, True, True, True, True, True])),
     ],
 )
-
 def test_categorical_equality_global_fastpath(
     op: Callable[[pl.Series, pl.Series], pl.Series], expected: pl.Series
 ) -> None:
@@ -175,7 +173,6 @@ def test_categorical_equality_global_fastpath(
         ),
     ],
 )
-
 def test_categorical_global_ordering(
     op: Callable[[pl.Series, pl.Series], pl.Series],
     expected_lexical: pl.Series,
@@ -201,7 +198,6 @@ def test_categorical_global_ordering(
         (operator.gt, pl.Series([True, False, True])),
     ],
 )
-
 def test_categorical_global_ordering_broadcast_rhs(
     op: Callable[[pl.Series, pl.Series], pl.Series],
     expected_lexical: pl.Series,
@@ -228,7 +224,6 @@ def test_categorical_global_ordering_broadcast_rhs(
         ),
     ],
 )
-
 def test_categorical_global_ordering_broadcast_lhs(
     op: Callable[[pl.Series, pl.Series], pl.Series],
     expected_lexical: pl.Series,
@@ -313,7 +308,6 @@ def test_compare_categorical_single(
         (pl.Series.eq_missing, pl.Series([False, False, False, False, False, False])),
     ],
 )
-
 def test_compare_categorical_single_non_existent(
     op: Callable[[pl.Series, pl.Series], pl.Series], expected: pl.Series
 ) -> None:
@@ -356,7 +350,6 @@ def test_compare_categorical_single_non_existent(
         (pl.Series.eq_missing, pl.Series([True, False, False, False, False, False])),
     ],
 )
-
 def test_compare_categorical_single_none(
     op: Callable[[pl.Series, pl.Series], pl.Series], expected: pl.Series
 ) -> None:
@@ -380,7 +373,6 @@ def test_cast_null_to_categorical() -> None:
     assert pl.DataFrame().with_columns(
         pl.lit(None).cast(pl.Categorical).alias("nullable_enum")
     ).dtypes == [pl.Categorical]
-
 
 
 def test_merge_lit_under_global_cache_4491() -> None:
@@ -540,9 +532,7 @@ def test_fast_unique_flag_from_arrow() -> None:
         }
     ).with_columns([pl.col("colB").cast(pl.Categorical)])
 
-    filtered = df.to_arrow().filter(
-        [True, False, True, True, False, True, True, True]
-    )
+    filtered = df.to_arrow().filter([True, False, True, True, False, True, True, True])
     assert pl.from_arrow(filtered).select(pl.col("colB").n_unique()).item() == 4  # type: ignore[union-attr]
 
 
@@ -785,9 +775,7 @@ def test_categorical_unique() -> None:
 
 
 def test_categorical_unique_20539() -> None:
-    df = pl.DataFrame(
-        {"number": [1, 1, 2, 2, 3], "letter": ["a", "b", "b", "c", "c"]}
-    )
+    df = pl.DataFrame({"number": [1, 1, 2, 2, 3], "letter": ["a", "b", "b", "c", "c"]})
 
     result = (
         df.cast({"letter": pl.Categorical})

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -13,7 +13,6 @@ from typing import Any, Callable
 import pytest
 
 import polars as pl
-from polars import StringCache
 from polars.exceptions import (
     InvalidOperationError,
     SchemaError,
@@ -268,7 +267,7 @@ def test_casting_to_an_enum_from_categorical_nonexistent() -> None:
         pl.Series([None, "a", "b", "c"], dtype=pl.Categorical).cast(pl.Enum(["a", "b"]))
 
 
-@StringCache()
+
 def test_casting_to_an_enum_from_global_categorical() -> None:
     dtype = pl.Enum(["a", "b", "c"])
     s = pl.Series([None, "a", "b", "c"], dtype=pl.Categorical)
@@ -279,7 +278,7 @@ def test_casting_to_an_enum_from_global_categorical() -> None:
     assert_series_equal(s2, expected)
 
 
-@StringCache()
+
 def test_casting_to_an_enum_from_global_categorical_nonexistent() -> None:
     with pytest.raises(
         InvalidOperationError,
@@ -298,7 +297,7 @@ def test_casting_from_an_enum_to_local() -> None:
     assert_series_equal(s2, expected)
 
 
-@StringCache()
+
 def test_casting_from_an_enum_to_global() -> None:
     dtype = pl.Enum(["a", "b", "c"])
     s = pl.Series([None, "a", "b", "c"], dtype=dtype)

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -267,7 +267,6 @@ def test_casting_to_an_enum_from_categorical_nonexistent() -> None:
         pl.Series([None, "a", "b", "c"], dtype=pl.Categorical).cast(pl.Enum(["a", "b"]))
 
 
-
 def test_casting_to_an_enum_from_global_categorical() -> None:
     dtype = pl.Enum(["a", "b", "c"])
     s = pl.Series([None, "a", "b", "c"], dtype=pl.Categorical)
@@ -276,7 +275,6 @@ def test_casting_to_an_enum_from_global_categorical() -> None:
     assert s2.null_count() == 1
     expected = pl.Series([None, "a", "b", "c"], dtype=dtype)
     assert_series_equal(s2, expected)
-
 
 
 def test_casting_to_an_enum_from_global_categorical_nonexistent() -> None:
@@ -295,7 +293,6 @@ def test_casting_from_an_enum_to_local() -> None:
     s2 = s.cast(pl.Categorical)
     expected = pl.Series([None, "a", "b", "c"], dtype=pl.Categorical)
     assert_series_equal(s2, expected)
-
 
 
 def test_casting_from_an_enum_to_global() -> None:

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -65,7 +65,6 @@ def test_dtype() -> None:
     ]
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical() -> None:
     # https://github.com/pola-rs/polars/issues/2038
     df = pl.DataFrame(

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -878,16 +878,15 @@ def test_struct_field_recognized_as_renaming_expr_16480() -> None:
 
 
 def test_struct_filter_chunked_16498() -> None:
-    with pl.StringCache():
-        N = 5
-        df_orig1 = pl.DataFrame({"cat_a": ["remove"] * N, "cat_b": ["b"] * N})
+    N = 5
+    df_orig1 = pl.DataFrame({"cat_a": ["remove"] * N, "cat_b": ["b"] * N})
 
-        df_orig2 = pl.DataFrame({"cat_a": ["a"] * N, "cat_b": ["b"] * N})
+    df_orig2 = pl.DataFrame({"cat_a": ["a"] * N, "cat_b": ["b"] * N})
 
-        df = pl.concat([df_orig1, df_orig2], rechunk=False).cast(pl.Categorical)
-        df = df.select(pl.struct(pl.all()).alias("s"))
-        df = df.filter(pl.col("s").struct.field("cat_a") != pl.lit("remove"))
-        assert df.shape == (5, 1)
+    df = pl.concat([df_orig1, df_orig2], rechunk=False).cast(pl.Categorical)
+    df = df.select(pl.struct(pl.all()).alias("s"))
+    df = df.filter(pl.col("s").struct.field("cat_a") != pl.lit("remove"))
+    assert df.shape == (5, 1)
 
 
 def test_struct_field_dynint_nullable_16243() -> None:

--- a/py-polars/tests/unit/functions/as_datatype/test_concat_list.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_concat_list.py
@@ -96,14 +96,12 @@ def test_list_concat_supertype() -> None:
     ].to_list() == [[1, 10000], [2, 20000]]
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_list_concat_4762() -> None:
     df = pl.DataFrame({"x": "a"})
     expected = {"x": [["a", "a"]]}
 
     q = df.lazy().select([pl.concat_list([pl.col("x").cast(pl.Categorical)] * 2)])
-    with pl.StringCache():
-        assert q.collect().to_dict(as_series=False) == expected
+    assert q.collect().to_dict(as_series=False) == expected
 
 
 def test_list_concat_rolling_window() -> None:

--- a/py-polars/tests/unit/functions/as_datatype/test_struct.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_struct.py
@@ -63,112 +63,111 @@ def test_eager_struct() -> None:
 
 def test_struct_from_schema_only() -> None:
     # Workaround for new streaming engine.
-    with pl.StringCache():
-        # we create a dataframe with default types
-        df = pl.DataFrame(
-            {
-                "str": ["a", "b", "c", "d", "e"],
-                "u8": [1, 2, 3, 4, 5],
-                "i32": [1, 2, 3, 4, 5],
-                "f64": [1, 2, 3, 4, 5],
-                "cat": ["a", "b", "c", "d", "e"],
-                "datetime": pl.Series(
-                    [
-                        date(2023, 1, 1),
-                        date(2023, 1, 2),
-                        date(2023, 1, 3),
-                        date(2023, 1, 4),
-                        date(2023, 1, 5),
-                    ]
-                ),
-                "bool": [1, 0, 1, 1, 0],
-                "list[u8]": [[1], [2], [3], [4], [5]],
+    # we create a dataframe with default types
+    df = pl.DataFrame(
+        {
+            "str": ["a", "b", "c", "d", "e"],
+            "u8": [1, 2, 3, 4, 5],
+            "i32": [1, 2, 3, 4, 5],
+            "f64": [1, 2, 3, 4, 5],
+            "cat": ["a", "b", "c", "d", "e"],
+            "datetime": pl.Series(
+                [
+                    date(2023, 1, 1),
+                    date(2023, 1, 2),
+                    date(2023, 1, 3),
+                    date(2023, 1, 4),
+                    date(2023, 1, 5),
+                ]
+            ),
+            "bool": [1, 0, 1, 1, 0],
+            "list[u8]": [[1], [2], [3], [4], [5]],
+        }
+    )
+
+    # specify a schema with specific dtypes
+    s = df.select(
+        pl.struct(
+            schema={
+                "str": pl.String,
+                "u8": pl.UInt8,
+                "i32": pl.Int32,
+                "f64": pl.Float64,
+                "cat": pl.Categorical,
+                "datetime": pl.Datetime("ms"),
+                "bool": pl.Boolean,
+                "list[u8]": pl.List(pl.UInt8),
             }
-        )
+        ).alias("s")
+    )["s"]
 
-        # specify a schema with specific dtypes
-        s = df.select(
-            pl.struct(
-                schema={
-                    "str": pl.String,
-                    "u8": pl.UInt8,
-                    "i32": pl.Int32,
-                    "f64": pl.Float64,
-                    "cat": pl.Categorical,
-                    "datetime": pl.Datetime("ms"),
-                    "bool": pl.Boolean,
-                    "list[u8]": pl.List(pl.UInt8),
-                }
-            ).alias("s")
-        )["s"]
-
-        # check dtypes
-        assert s.dtype == pl.Struct(
-            [
-                pl.Field("str", pl.String),
-                pl.Field("u8", pl.UInt8),
-                pl.Field("i32", pl.Int32),
-                pl.Field("f64", pl.Float64),
-                pl.Field("cat", pl.Categorical),
-                pl.Field("datetime", pl.Datetime("ms")),
-                pl.Field("bool", pl.Boolean),
-                pl.Field("list[u8]", pl.List(pl.UInt8)),
-            ]
-        )
-
-        # check values
-        assert s.to_list() == [
-            {
-                "str": "a",
-                "u8": 1,
-                "i32": 1,
-                "f64": 1.0,
-                "cat": "a",
-                "datetime": datetime(2023, 1, 1, 0, 0),
-                "bool": True,
-                "list[u8]": [1],
-            },
-            {
-                "str": "b",
-                "u8": 2,
-                "i32": 2,
-                "f64": 2.0,
-                "cat": "b",
-                "datetime": datetime(2023, 1, 2, 0, 0),
-                "bool": False,
-                "list[u8]": [2],
-            },
-            {
-                "str": "c",
-                "u8": 3,
-                "i32": 3,
-                "f64": 3.0,
-                "cat": "c",
-                "datetime": datetime(2023, 1, 3, 0, 0),
-                "bool": True,
-                "list[u8]": [3],
-            },
-            {
-                "str": "d",
-                "u8": 4,
-                "i32": 4,
-                "f64": 4.0,
-                "cat": "d",
-                "datetime": datetime(2023, 1, 4, 0, 0),
-                "bool": True,
-                "list[u8]": [4],
-            },
-            {
-                "str": "e",
-                "u8": 5,
-                "i32": 5,
-                "f64": 5.0,
-                "cat": "e",
-                "datetime": datetime(2023, 1, 5, 0, 0),
-                "bool": False,
-                "list[u8]": [5],
-            },
+    # check dtypes
+    assert s.dtype == pl.Struct(
+        [
+            pl.Field("str", pl.String),
+            pl.Field("u8", pl.UInt8),
+            pl.Field("i32", pl.Int32),
+            pl.Field("f64", pl.Float64),
+            pl.Field("cat", pl.Categorical),
+            pl.Field("datetime", pl.Datetime("ms")),
+            pl.Field("bool", pl.Boolean),
+            pl.Field("list[u8]", pl.List(pl.UInt8)),
         ]
+    )
+
+    # check values
+    assert s.to_list() == [
+        {
+            "str": "a",
+            "u8": 1,
+            "i32": 1,
+            "f64": 1.0,
+            "cat": "a",
+            "datetime": datetime(2023, 1, 1, 0, 0),
+            "bool": True,
+            "list[u8]": [1],
+        },
+        {
+            "str": "b",
+            "u8": 2,
+            "i32": 2,
+            "f64": 2.0,
+            "cat": "b",
+            "datetime": datetime(2023, 1, 2, 0, 0),
+            "bool": False,
+            "list[u8]": [2],
+        },
+        {
+            "str": "c",
+            "u8": 3,
+            "i32": 3,
+            "f64": 3.0,
+            "cat": "c",
+            "datetime": datetime(2023, 1, 3, 0, 0),
+            "bool": True,
+            "list[u8]": [3],
+        },
+        {
+            "str": "d",
+            "u8": 4,
+            "i32": 4,
+            "f64": 4.0,
+            "cat": "d",
+            "datetime": datetime(2023, 1, 4, 0, 0),
+            "bool": True,
+            "list[u8]": [4],
+        },
+        {
+            "str": "e",
+            "u8": 5,
+            "i32": 5,
+            "f64": 5.0,
+            "cat": "e",
+            "datetime": datetime(2023, 1, 5, 0, 0),
+            "bool": False,
+            "list[u8]": [5],
+        },
+    ]
 
 
 def test_struct_broadcasting() -> None:

--- a/py-polars/tests/unit/functions/test_repeat.py
+++ b/py-polars/tests/unit/functions/test_repeat.py
@@ -165,32 +165,31 @@ def test_ones_zeros_misc() -> None:
 
 
 def test_repeat_by_logical_dtype() -> None:
-    with pl.StringCache():
-        df = pl.DataFrame(
-            {
-                "repeat": [1, 2, 3],
-                "date": [date(2021, 1, 1)] * 3,
-                "cat": ["a", "b", "c"],
-            },
-            schema={"repeat": pl.Int32, "date": pl.Date, "cat": pl.Categorical},
-        )
-        out = df.select(
-            pl.col("date").repeat_by("repeat"), pl.col("cat").repeat_by("repeat")
-        )
+    df = pl.DataFrame(
+        {
+            "repeat": [1, 2, 3],
+            "date": [date(2021, 1, 1)] * 3,
+            "cat": ["a", "b", "c"],
+        },
+        schema={"repeat": pl.Int32, "date": pl.Date, "cat": pl.Categorical},
+    )
+    out = df.select(
+        pl.col("date").repeat_by("repeat"), pl.col("cat").repeat_by("repeat")
+    )
 
-        expected_df = pl.DataFrame(
-            {
-                "date": [
-                    [date(2021, 1, 1)],
-                    [date(2021, 1, 1), date(2021, 1, 1)],
-                    [date(2021, 1, 1), date(2021, 1, 1), date(2021, 1, 1)],
-                ],
-                "cat": [["a"], ["b", "b"], ["c", "c", "c"]],
-            },
-            schema={"date": pl.List(pl.Date), "cat": pl.List(pl.Categorical)},
-        )
+    expected_df = pl.DataFrame(
+        {
+            "date": [
+                [date(2021, 1, 1)],
+                [date(2021, 1, 1), date(2021, 1, 1)],
+                [date(2021, 1, 1), date(2021, 1, 1), date(2021, 1, 1)],
+            ],
+            "cat": [["a"], ["b", "b"], ["c", "c", "c"]],
+        },
+        schema={"date": pl.List(pl.Date), "cat": pl.List(pl.Categorical)},
+    )
 
-        assert_frame_equal(out, expected_df)
+    assert_frame_equal(out, expected_df)
 
 
 def test_repeat_by_list() -> None:

--- a/py-polars/tests/unit/interchange/test_from_dataframe.py
+++ b/py-polars/tests/unit/interchange/test_from_dataframe.py
@@ -343,7 +343,6 @@ def test_string_column_to_series_no_offsets() -> None:
         _string_column_to_series(col, allow_copy=True)
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_column_to_series_non_dictionary() -> None:
     s = pl.Series(["a", "b", None, "a"], dtype=pl.Categorical)
 

--- a/py-polars/tests/unit/interchange/test_roundtrip.py
+++ b/py-polars/tests/unit/interchange/test_roundtrip.py
@@ -56,8 +56,7 @@ def test_to_dataframe_pyarrow_parametric(df: pl.DataFrame) -> None:
     dfi = df.__dataframe__()
     df_pa = pa.interchange.from_dataframe(dfi)
 
-    with pl.StringCache():
-        result: pl.DataFrame = pl.from_arrow(df_pa)  # type: ignore[assignment]
+    result: pl.DataFrame = pl.from_arrow(df_pa)  # type: ignore[assignment]
     assert_frame_equal(result, df, categorical_as_str=True)
 
 

--- a/py-polars/tests/unit/interop/test_from_pandas.py
+++ b/py-polars/tests/unit/interop/test_from_pandas.py
@@ -10,7 +10,6 @@ import pytest
 import polars as pl
 from polars.testing import assert_frame_equal
 from polars.testing.asserts.series import assert_series_equal
-from tests.unit.conftest import with_string_cache_if_auto_streaming
 
 if TYPE_CHECKING:
     from polars._typing import PolarsDataType
@@ -324,7 +323,6 @@ def test_from_pandas_null_struct_6412() -> None:
     }
 
 
-@with_string_cache_if_auto_streaming
 def test_untrusted_categorical_input() -> None:
     df_pd = pd.DataFrame({"x": pd.Categorical(["x"], ["x", "y"])})
     df = pl.from_pandas(df_pd)

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -331,23 +331,22 @@ def test_from_empty_arrow() -> None:
 
 
 def test_cat_int_types_3500() -> None:
-    with pl.StringCache():
-        # Create an enum / categorical / dictionary typed pyarrow array
-        # Most simply done by creating a pandas categorical series first
-        categorical_s = pd.Series(["a", "a", "b"], dtype="category")
-        pyarrow_array = pa.Array.from_pandas(categorical_s)
+    # Create an enum / categorical / dictionary typed pyarrow array
+    # Most simply done by creating a pandas categorical series first
+    categorical_s = pd.Series(["a", "a", "b"], dtype="category")
+    pyarrow_array = pa.Array.from_pandas(categorical_s)
 
-        # The in-memory representation of each category can either be a signed or
-        # unsigned 8-bit integer. Pandas uses Int8...
-        int_dict_type = pa.dictionary(index_type=pa.int8(), value_type=pa.utf8())
-        # ... while DuckDB uses UInt8
-        uint_dict_type = pa.dictionary(index_type=pa.uint8(), value_type=pa.utf8())
+    # The in-memory representation of each category can either be a signed or
+    # unsigned 8-bit integer. Pandas uses Int8...
+    int_dict_type = pa.dictionary(index_type=pa.int8(), value_type=pa.utf8())
+    # ... while DuckDB uses UInt8
+    uint_dict_type = pa.dictionary(index_type=pa.uint8(), value_type=pa.utf8())
 
-        for t in [int_dict_type, uint_dict_type]:
-            s = cast(pl.Series, pl.from_arrow(pyarrow_array.cast(t)))
-            assert_series_equal(
-                s, pl.Series(["a", "a", "b"]).cast(pl.Categorical), check_names=False
-            )
+    for t in [int_dict_type, uint_dict_type]:
+        s = cast(pl.Series, pl.from_arrow(pyarrow_array.cast(t)))
+        assert_series_equal(
+            s, pl.Series(["a", "a", "b"]).cast(pl.Categorical), check_names=False
+        )
 
 
 def test_from_pyarrow_chunked_array() -> None:
@@ -397,43 +396,42 @@ def test_from_fixed_size_binary_list() -> None:
 
 def test_dataframe_from_repr() -> None:
     # round-trip various types
-    with pl.StringCache():
-        frame = (
-            pl.LazyFrame(
-                {
-                    "a": [1, 2, None],
-                    "b": [4.5, 5.5, 6.5],
-                    "c": ["x", "y", "z"],
-                    "d": [True, False, True],
-                    "e": [None, "", None],
-                    "f": [date(2022, 7, 5), date(2023, 2, 5), date(2023, 8, 5)],
-                    "g": [time(0, 0, 0, 1), time(12, 30, 45), time(23, 59, 59, 999000)],
-                    "h": [
-                        datetime(2022, 7, 5, 10, 30, 45, 4560),
-                        datetime(2023, 10, 12, 20, 3, 8, 11),
-                        None,
-                    ],
-                },
-            )
-            .with_columns(
-                pl.col("c").cast(pl.Categorical),
-                pl.col("h").cast(pl.Datetime("ns")),
-            )
-            .collect()
+    frame = (
+        pl.LazyFrame(
+            {
+                "a": [1, 2, None],
+                "b": [4.5, 5.5, 6.5],
+                "c": ["x", "y", "z"],
+                "d": [True, False, True],
+                "e": [None, "", None],
+                "f": [date(2022, 7, 5), date(2023, 2, 5), date(2023, 8, 5)],
+                "g": [time(0, 0, 0, 1), time(12, 30, 45), time(23, 59, 59, 999000)],
+                "h": [
+                    datetime(2022, 7, 5, 10, 30, 45, 4560),
+                    datetime(2023, 10, 12, 20, 3, 8, 11),
+                    None,
+                ],
+            },
         )
+        .with_columns(
+            pl.col("c").cast(pl.Categorical),
+            pl.col("h").cast(pl.Datetime("ns")),
+        )
+        .collect()
+    )
 
-        assert frame.schema == {
-            "a": pl.Int64,
-            "b": pl.Float64,
-            "c": pl.Categorical(ordering="lexical"),
-            "d": pl.Boolean,
-            "e": pl.String,
-            "f": pl.Date,
-            "g": pl.Time,
-            "h": pl.Datetime("ns"),
-        }
-        df = cast(pl.DataFrame, pl.from_repr(repr(frame)))
-        assert_frame_equal(frame, df)
+    assert frame.schema == {
+        "a": pl.Int64,
+        "b": pl.Float64,
+        "c": pl.Categorical(ordering="lexical"),
+        "d": pl.Boolean,
+        "e": pl.String,
+        "f": pl.Date,
+        "g": pl.Time,
+        "h": pl.Datetime("ns"),
+    }
+    df = cast(pl.DataFrame, pl.from_repr(repr(frame)))
+    assert_frame_equal(frame, df)
 
     # empty frame; confirm schema is inferred
     df = cast(
@@ -624,34 +622,33 @@ def test_dataframe_from_duckdb_repr() -> None:
 
 
 def test_series_from_repr() -> None:
-    with pl.StringCache():
-        frame = (
-            pl.LazyFrame(
-                {
-                    "a": [1, 2, None],
-                    "b": [4.5, 5.5, 6.5],
-                    "c": ["x", "y", "z"],
-                    "d": [True, False, True],
-                    "e": [None, "", None],
-                    "f": [date(2022, 7, 5), date(2023, 2, 5), date(2023, 8, 5)],
-                    "g": [time(0, 0, 0, 1), time(12, 30, 45), time(23, 59, 59, 999000)],
-                    "h": [
-                        datetime(2022, 7, 5, 10, 30, 45, 4560),
-                        datetime(2023, 10, 12, 20, 3, 8, 11),
-                        None,
-                    ],
-                },
-            )
-            .with_columns(
-                pl.col("c").cast(pl.Categorical),
-                pl.col("h").cast(pl.Datetime("ns")),
-            )
-            .collect()
+    frame = (
+        pl.LazyFrame(
+            {
+                "a": [1, 2, None],
+                "b": [4.5, 5.5, 6.5],
+                "c": ["x", "y", "z"],
+                "d": [True, False, True],
+                "e": [None, "", None],
+                "f": [date(2022, 7, 5), date(2023, 2, 5), date(2023, 8, 5)],
+                "g": [time(0, 0, 0, 1), time(12, 30, 45), time(23, 59, 59, 999000)],
+                "h": [
+                    datetime(2022, 7, 5, 10, 30, 45, 4560),
+                    datetime(2023, 10, 12, 20, 3, 8, 11),
+                    None,
+                ],
+            },
         )
+        .with_columns(
+            pl.col("c").cast(pl.Categorical),
+            pl.col("h").cast(pl.Datetime("ns")),
+        )
+        .collect()
+    )
 
-        for col in frame.columns:
-            s = cast(pl.Series, pl.from_repr(repr(frame[col])))
-            assert_series_equal(s, frame[col])
+    for col in frame.columns:
+        s = cast(pl.Series, pl.from_repr(repr(frame[col])))
+        assert_series_equal(s, frame[col])
 
     s = cast(
         pl.Series,
@@ -918,13 +915,12 @@ def test_arrow_roundtrip_lex_cat_20288() -> None:
     assert dt.ordering == "lexical"
 
 
-def test_from_arrow_string_cache_20271() -> None:
-    with pl.StringCache():
-        df = pl.from_arrow(
-            pa.table({"b": pa.DictionaryArray.from_arrays([0, 1], ["D", "E"])})
-        )
-        assert isinstance(df, pl.DataFrame)
-        assert_series_equal(df.to_series(), pl.Series("b", ["D", "E"], pl.Categorical))
+def test_from_arrow_20271() -> None:
+    df = pl.from_arrow(
+        pa.table({"b": pa.DictionaryArray.from_arrays([0, 1], ["D", "E"])})
+    )
+    assert isinstance(df, pl.DataFrame)
+    assert_series_equal(df.to_series(), pl.Series("b", ["D", "E"], pl.Categorical))
 
 
 def test_to_arrow_empty_chunks_20627() -> None:

--- a/py-polars/tests/unit/interop/test_to_init_repr.py
+++ b/py-polars/tests/unit/interop/test_to_init_repr.py
@@ -9,47 +9,46 @@ from polars.testing import assert_frame_equal
 
 def test_to_init_repr() -> None:
     # round-trip various types
-    with pl.StringCache():
-        df = (
-            pl.LazyFrame(
-                {
-                    "a": [1, 2, None],
-                    "b": [4.5, 5.5, 6.5],
-                    "c": ["x", "y", "z"],
-                    "d": [True, False, True],
-                    "e": [None, "", None],
-                    "f": [date(2022, 7, 5), date(2023, 2, 5), date(2023, 8, 5)],
-                    "g": [time(0, 0, 0, 1), time(12, 30, 45), time(23, 59, 59, 999000)],
-                    "h": [
-                        datetime(2022, 7, 5, 10, 30, 45, 4560),
-                        datetime(2023, 10, 12, 20, 3, 8, 11),
-                        None,
-                    ],
-                    "i": [
-                        datetime(2022, 7, 5, 10, 30, 45, 4560),
-                        datetime(2023, 10, 12, 20, 3, 8, 11),
-                        None,
-                    ],
-                    "null": [None, None, None],
-                    "enum": ["a", "b", "c"],
-                    "duration": [timedelta(days=1), timedelta(days=2), None],
-                    "binary": [bytes([0]), bytes([0, 1]), bytes([0, 1, 2])],
-                    "object": [timezone.utc, timezone.utc, timezone.utc],
-                },
-            )
-            .with_columns(
-                pl.col("c").cast(pl.Categorical),
-                pl.col("h").cast(pl.Datetime("ns")),
-                pl.col("i").dt.replace_time_zone("Australia/Melbourne"),
-                pl.col("enum").cast(pl.Enum(["a", "b", "c"])),
-            )
-            .collect()
+    df = (
+        pl.LazyFrame(
+            {
+                "a": [1, 2, None],
+                "b": [4.5, 5.5, 6.5],
+                "c": ["x", "y", "z"],
+                "d": [True, False, True],
+                "e": [None, "", None],
+                "f": [date(2022, 7, 5), date(2023, 2, 5), date(2023, 8, 5)],
+                "g": [time(0, 0, 0, 1), time(12, 30, 45), time(23, 59, 59, 999000)],
+                "h": [
+                    datetime(2022, 7, 5, 10, 30, 45, 4560),
+                    datetime(2023, 10, 12, 20, 3, 8, 11),
+                    None,
+                ],
+                "i": [
+                    datetime(2022, 7, 5, 10, 30, 45, 4560),
+                    datetime(2023, 10, 12, 20, 3, 8, 11),
+                    None,
+                ],
+                "null": [None, None, None],
+                "enum": ["a", "b", "c"],
+                "duration": [timedelta(days=1), timedelta(days=2), None],
+                "binary": [bytes([0]), bytes([0, 1]), bytes([0, 1, 2])],
+                "object": [timezone.utc, timezone.utc, timezone.utc],
+            },
         )
+        .with_columns(
+            pl.col("c").cast(pl.Categorical),
+            pl.col("h").cast(pl.Datetime("ns")),
+            pl.col("i").dt.replace_time_zone("Australia/Melbourne"),
+            pl.col("enum").cast(pl.Enum(["a", "b", "c"])),
+        )
+        .collect()
+    )
 
-        result = eval(df.to_init_repr().replace("datetime.", ""))
-        expected = df
-        # drop "object" because it can not be compared by assert_frame_equal
-        assert_frame_equal(result.drop("object"), expected.drop("object"))
+    result = eval(df.to_init_repr().replace("datetime.", ""))
+    expected = df
+    # drop "object" because it can not be compared by assert_frame_equal
+    assert_frame_equal(result.drop("object"), expected.drop("object"))
 
 
 def test_to_init_repr_nested_dtype() -> None:

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -466,7 +466,6 @@ def test_unsupported_dtypes(tmp_path: Path) -> None:
     reason="upstream bug in delta-rs causing categorical to be written as categorical in parquet"
 )
 @pytest.mark.write_disk
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_becomes_string(tmp_path: Path) -> None:
     df = pl.DataFrame({"a": ["A", "B", "A"]}, schema={"a": pl.Categorical})
     df.write_delta(tmp_path)

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -69,7 +69,6 @@ def test_row_index_len_16543(foods_parquet_path: Path) -> None:
 
 
 @pytest.mark.write_disk
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_parquet_statistics(tmp_path: Path) -> None:
     tmp_path.mkdir(exist_ok=True)
 
@@ -273,7 +272,6 @@ def test_parquet_statistics(monkeypatch: Any, capfd: Any, tmp_path: Path) -> Non
 
 
 @pytest.mark.write_disk
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical(tmp_path: Path) -> None:
     tmp_path.mkdir(exist_ok=True)
 
@@ -287,19 +285,18 @@ def test_categorical(tmp_path: Path) -> None:
     file_path = tmp_path / "categorical.parquet"
     df.write_parquet(file_path)
 
-    with pl.StringCache():
-        result = (
-            pl.scan_parquet(file_path)
-            .group_by("name")
-            .agg(pl.col("amount").sum())
-            .collect()
-            .sort("name")
-        )
-        expected = pl.DataFrame(
-            {"name": ["Alice", "Bob"], "amount": [200, 400]},
-            schema_overrides={"name": pl.Categorical},
-        )
-        assert_frame_equal(result, expected)
+    result = (
+        pl.scan_parquet(file_path)
+        .group_by("name")
+        .agg(pl.col("amount").sum())
+        .collect()
+        .sort("name")
+    )
+    expected = pl.DataFrame(
+        {"name": ["Alice", "Bob"], "amount": [200, 400]},
+        schema_overrides={"name": pl.Categorical},
+    )
+    assert_frame_equal(result, expected)
 
 
 def test_glob_n_rows(io_files_path: Path) -> None:

--- a/py-polars/tests/unit/io/test_other.py
+++ b/py-polars/tests/unit/io/test_other.py
@@ -99,7 +99,6 @@ def test_copy() -> None:
     assert_series_equal(copy.deepcopy(a), a)
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_round_trip() -> None:
     df = pl.DataFrame({"ints": [1, 2, 3], "cat": ["a", "b", "c"]})
     df = df.with_columns(pl.col("cat").cast(pl.Categorical))

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -321,19 +321,18 @@ def test_recursive_logical_type() -> None:
 
 
 def test_nested_dictionary() -> None:
-    with pl.StringCache():
-        df = (
-            pl.DataFrame({"str": ["A", "B", "A", "B", "C"], "group": [1, 1, 2, 1, 2]})
-            .with_columns(pl.col("str").cast(pl.Categorical))
-            .group_by("group")
-            .agg([pl.col("str").alias("cat_list")])
-        )
-        f = io.BytesIO()
-        df.write_parquet(f)
-        f.seek(0)
+    df = (
+        pl.DataFrame({"str": ["A", "B", "A", "B", "C"], "group": [1, 1, 2, 1, 2]})
+        .with_columns(pl.col("str").cast(pl.Categorical))
+        .group_by("group")
+        .agg([pl.col("str").alias("cat_list")])
+    )
+    f = io.BytesIO()
+    df.write_parquet(f)
+    f.seek(0)
 
-        read_df = pl.read_parquet(f)
-        assert_frame_equal(df, read_df)
+    read_df = pl.read_parquet(f)
+    assert_frame_equal(df, read_df)
 
 
 def test_row_group_size_saturation() -> None:
@@ -432,16 +431,15 @@ def test_parquet_nested_dictionaries_6217() -> None:
 
     table = pa.table({"Col1": col1})
 
-    with pl.StringCache():
-        df = pl.from_arrow(table)
+    df = pl.from_arrow(table)
 
-        f = io.BytesIO()
-        import pyarrow.parquet as pq
+    f = io.BytesIO()
+    import pyarrow.parquet as pq
 
-        pq.write_table(table, f, compression="snappy")
-        f.seek(0)
-        read = pl.read_parquet(f)
-        assert_frame_equal(read, df)  # type: ignore[arg-type]
+    pq.write_table(table, f, compression="snappy")
+    f.seek(0)
+    read = pl.read_parquet(f)
+    assert_frame_equal(read, df)  # type: ignore[arg-type]
 
 
 @pytest.mark.write_disk
@@ -534,7 +532,7 @@ def test_parquet_nested_list_pandas() -> None:
     assert df.to_dict(as_series=False) == {"listcol": [[]]}
 
 
-def test_parquet_string_cache() -> None:
+def test_parquet_cat_roundtrip() -> None:
     f = io.BytesIO()
 
     df = pl.DataFrame({"a": ["a", "b", "c", "d"]}).with_columns(
@@ -542,11 +540,8 @@ def test_parquet_string_cache() -> None:
     )
 
     df.write_parquet(f, row_group_size=2)
-
-    # this file has 2 row groups and a categorical column
-    # so polars should automatically set string cache
     f.seek(0)
-    assert_series_equal(pl.read_parquet(f)["a"].cast(str), df["a"].cast(str))
+    assert_series_equal(pl.read_parquet(f)["a"], df["a"])
 
 
 def test_tz_aware_parquet_9586(io_files_path: Path) -> None:
@@ -671,8 +666,7 @@ def test_parquet_struct_categorical(tmp_path: Path) -> None:
     file_path = tmp_path / "categorical.parquet"
     df.write_parquet(file_path)
 
-    with pl.StringCache():
-        out = pl.read_parquet(file_path).select(pl.col("b").value_counts())
+    out = pl.read_parquet(file_path).select(pl.col("b").value_counts())
     assert out.to_dict(as_series=False) == {"b": [{"b": "foo", "count": 1}]}
 
 
@@ -2496,7 +2490,6 @@ def test_dict_masked(
     )
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 @pytest.mark.may_fail_auto_streaming
 def test_categorical_sliced_20017() -> None:
     f = io.BytesIO()
@@ -2523,15 +2516,14 @@ def test_categorical_sliced_20017() -> None:
 def test_categorical_parametric_masked(s: pl.Series, mask: pl.Series) -> None:
     f = io.BytesIO()
 
-    with pl.StringCache():
-        df = pl.DataFrame([s, mask]).with_columns(pl.col.a.cast(pl.Categorical))
-        df.write_parquet(f)
+    df = pl.DataFrame([s, mask]).with_columns(pl.col.a.cast(pl.Categorical))
+    df.write_parquet(f)
 
-        f.seek(0)
-        assert_frame_equal(
-            pl.scan_parquet(f, parallel="prefiltered").filter(pl.col.mask).collect(),
-            df.filter(pl.col.mask),
-        )
+    f.seek(0)
+    assert_frame_equal(
+        pl.scan_parquet(f, parallel="prefiltered").filter(pl.col.mask).collect(),
+        df.filter(pl.col.mask),
+    )
 
 
 @given(
@@ -2544,15 +2536,14 @@ def test_categorical_parametric_sliced(s: pl.Series, start: int, length: int) ->
 
     f = io.BytesIO()
 
-    with pl.StringCache():
-        df = s.to_frame().with_columns(pl.col.a.cast(pl.Categorical))
-        df.write_parquet(f)
+    df = s.to_frame().with_columns(pl.col.a.cast(pl.Categorical))
+    df.write_parquet(f)
 
-        f.seek(0)
-        assert_frame_equal(
-            pl.scan_parquet(f).slice(start, length).collect(),
-            df.slice(start, length),
-        )
+    f.seek(0)
+    assert_frame_equal(
+        pl.scan_parquet(f).slice(start, length).collect(),
+        df.slice(start, length),
+    )
 
 
 @pytest.mark.write_disk
@@ -2715,15 +2706,14 @@ def test_parquet_roundtrip_lex_cat_20288() -> None:
     assert dt.ordering == "lexical"
 
 
-def test_from_parquet_string_cache_20271() -> None:
-    with pl.StringCache():
-        f = io.BytesIO()
-        df = pl.Series("b", ["D", "E"], pl.Categorical).to_frame()
-        df.write_parquet(f)
-        del df
-        f.seek(0)
-        df = pl.read_parquet(f)
-        assert_series_equal(df.to_series(), pl.Series("b", ["D", "E"], pl.Categorical))
+def test_from_parquet_20271() -> None:
+    f = io.BytesIO()
+    df = pl.Series("b", ["D", "E"], pl.Categorical).to_frame()
+    df.write_parquet(f)
+    del df
+    f.seek(0)
+    df = pl.read_parquet(f)
+    assert_series_equal(df.to_series(), pl.Series("b", ["D", "E"], pl.Categorical))
 
 
 def test_boolean_slice_pushdown_20314() -> None:

--- a/py-polars/tests/unit/io/test_pyarrow_dataset.py
+++ b/py-polars/tests/unit/io/test_pyarrow_dataset.py
@@ -176,9 +176,7 @@ def test_pyarrow_dataset_source(df: pl.DataFrame, tmp_path: Path) -> None:
     )
     helper_dataset_test(
         file_path,
-        lambda lf: lf.filter(pl.col("cat").is_in([])).select(
-            "bools", "floats", "date"
-        ),
+        lambda lf: lf.filter(pl.col("cat").is_in([])).select("bools", "floats", "date"),
         n_expected=0,
     )
     helper_dataset_test(

--- a/py-polars/tests/unit/io/test_pyarrow_dataset.py
+++ b/py-polars/tests/unit/io/test_pyarrow_dataset.py
@@ -174,21 +174,19 @@ def test_pyarrow_dataset_source(df: pl.DataFrame, tmp_path: Path) -> None:
         n_expected=3,
         check_predicate_pushdown=True,
     )
-    # TODO: remove string cache
-    with pl.StringCache():
-        helper_dataset_test(
-            file_path,
-            lambda lf: lf.filter(pl.col("cat").is_in([])).select(
-                "bools", "floats", "date"
-            ),
-            n_expected=0,
-        )
-        helper_dataset_test(
-            file_path,
-            lambda lf: lf.select(pl.exclude("enum")),
-            batch_size=2,
-            n_expected=3,
-        )
+    helper_dataset_test(
+        file_path,
+        lambda lf: lf.filter(pl.col("cat").is_in([])).select(
+            "bools", "floats", "date"
+        ),
+        n_expected=0,
+    )
+    helper_dataset_test(
+        file_path,
+        lambda lf: lf.select(pl.exclude("enum")),
+        batch_size=2,
+        n_expected=3,
+    )
 
     # direct filter
     helper_dataset_test(

--- a/py-polars/tests/unit/operations/namespaces/test_categorical.py
+++ b/py-polars/tests/unit/operations/namespaces/test_categorical.py
@@ -6,7 +6,6 @@ import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_lexical_sort() -> None:
     df = pl.DataFrame(
         {"cats": ["z", "z", "k", "a", "b"], "vals": [3, 1, 2, 2, 3]}
@@ -42,7 +41,6 @@ def test_categorical_lexical_sort() -> None:
     ]
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_lexical_ordering_after_concat() -> None:
     ldf1 = (
         pl.DataFrame([pl.Series("key1", [8, 5]), pl.Series("key2", ["fox", "baz"])])
@@ -63,7 +61,6 @@ def test_categorical_lexical_ordering_after_concat() -> None:
     }
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_sort_categoricals_6014_lexical() -> None:
     # create lexically-ordered categorical
     df = pl.DataFrame({"key": ["bbb", "aaa", "ccc"]}).with_columns(
@@ -74,7 +71,6 @@ def test_sort_categoricals_6014_lexical() -> None:
     assert out.to_dict(as_series=False) == {"key": ["aaa", "bbb", "ccc"]}
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_get_categories() -> None:
     s = pl.Series("cats", ["foo", "bar", "foo", "foo", "ham"], dtype=pl.Categorical)
     assert set(s.cat.get_categories().to_list()) >= {"foo", "bar", "ham"}
@@ -85,7 +81,6 @@ def test_cat_to_local() -> None:
     assert_series_equal(s, s.cat.to_local())
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_cat_uses_lexical_ordering() -> None:
     s = pl.Series(["a", "b", None, "b"]).cast(pl.Categorical)
     assert s.cat.uses_lexical_ordering()
@@ -97,7 +92,6 @@ def test_cat_uses_lexical_ordering() -> None:
     assert s.cat.uses_lexical_ordering()
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_cat_len_bytes() -> None:
     # test Series
     s = pl.Series("a", ["Café", None, "Café", "345", "東京"], dtype=pl.Categorical)
@@ -134,7 +128,6 @@ def test_cat_len_bytes() -> None:
     assert_frame_equal(result_df, expected_df)
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_cat_len_chars() -> None:
     # test Series
     s = pl.Series("a", ["Café", None, "Café", "345", "東京"], dtype=pl.Categorical)
@@ -171,7 +164,6 @@ def test_cat_len_chars() -> None:
     assert_frame_equal(result_df, expected_df)
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_starts_ends_with() -> None:
     s = pl.Series(
         "a",

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -767,7 +767,6 @@ def test_overflowing_cast_literals_21023() -> None:
         pl.Series(["a", "b"], dtype=pl.Categorical).dtype,
     ],
 )
-@pytest.mark.usefixtures("test_global_and_local")
 def test_invalid_bool_to_cat(value: bool, dtype: PolarsDataType) -> None:
     # Enum
     with pytest.raises(

--- a/py-polars/tests/unit/operations/test_cut.py
+++ b/py-polars/tests/unit/operations/test_cut.py
@@ -4,7 +4,6 @@ import pytest
 
 import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
-from tests.unit.conftest import with_string_cache_if_auto_streaming
 
 inf = float("inf")
 
@@ -107,7 +106,6 @@ def test_cut_bin_name_in_agg_context() -> None:
         ),
     ],
 )
-@with_string_cache_if_auto_streaming
 def test_cut_fast_unique_15981(
     breaks: list[int],
     expected_labels: pl.Series,

--- a/py-polars/tests/unit/operations/test_filter.py
+++ b/py-polars/tests/unit/operations/test_filter.py
@@ -230,9 +230,7 @@ def test_filter_logical_type_13194() -> None:
         ],
     }
 
-    df = pl.DataFrame(data).with_columns(
-        pl.col("cat").cast(pl.List(pl.Categorical()))
-    )
+    df = pl.DataFrame(data).with_columns(pl.col("cat").cast(pl.List(pl.Categorical())))
 
     df = df.filter(pl.col("id") == pl.col("id").shift(1))
     expected_df = pl.DataFrame(

--- a/py-polars/tests/unit/operations/test_filter.py
+++ b/py-polars/tests/unit/operations/test_filter.py
@@ -153,7 +153,6 @@ def test_binary_simplification_5971() -> None:
     ]
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_string_comparison_6283() -> None:
     scores = pl.DataFrame(
         {
@@ -217,39 +216,38 @@ def test_agg_function_of_filter_10565() -> None:
 
 
 def test_filter_logical_type_13194() -> None:
-    with pl.StringCache():
-        data = {
-            "id": [1, 1, 2],
-            "date": [
-                [datetime(year=2021, month=1, day=1)],
-                [datetime(year=2021, month=1, day=1)],
-                [datetime(year=2025, month=1, day=30)],
-            ],
-            "cat": [
-                ["a", "b", "c"],
-                ["a", "b", "c"],
-                ["d", "e", "f"],
-            ],
-        }
+    data = {
+        "id": [1, 1, 2],
+        "date": [
+            [datetime(year=2021, month=1, day=1)],
+            [datetime(year=2021, month=1, day=1)],
+            [datetime(year=2025, month=1, day=30)],
+        ],
+        "cat": [
+            ["a", "b", "c"],
+            ["a", "b", "c"],
+            ["d", "e", "f"],
+        ],
+    }
 
-        df = pl.DataFrame(data).with_columns(
-            pl.col("cat").cast(pl.List(pl.Categorical()))
-        )
+    df = pl.DataFrame(data).with_columns(
+        pl.col("cat").cast(pl.List(pl.Categorical()))
+    )
 
-        df = df.filter(pl.col("id") == pl.col("id").shift(1))
-        expected_df = pl.DataFrame(
-            {
-                "id": [1],
-                "date": [[datetime(year=2021, month=1, day=1)]],
-                "cat": [["a", "b", "c"]],
-            },
-            schema={
-                "id": pl.Int64,
-                "date": pl.List(pl.Datetime),
-                "cat": pl.List(pl.Categorical),
-            },
-        )
-        assert_frame_equal(df, expected_df)
+    df = df.filter(pl.col("id") == pl.col("id").shift(1))
+    expected_df = pl.DataFrame(
+        {
+            "id": [1],
+            "date": [[datetime(year=2021, month=1, day=1)]],
+            "cat": [["a", "b", "c"]],
+        },
+        schema={
+            "id": pl.Int64,
+            "date": pl.List(pl.Datetime),
+            "cat": pl.List(pl.Categorical),
+        },
+    )
+    assert_frame_equal(df, expected_df)
 
 
 def test_filter_horizontal_selector_15428() -> None:

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -938,7 +938,6 @@ def test_group_by_multiple_null_cols_15623() -> None:
 
 
 @pytest.mark.release
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_vs_str_group_by() -> None:
     # this triggers the perfect hash table
     s = pl.Series("a", np.random.randint(0, 50, 100))

--- a/py-polars/tests/unit/operations/test_hist.py
+++ b/py-polars/tests/unit/operations/test_hist.py
@@ -10,7 +10,6 @@ from polars.testing import assert_frame_equal
 inf = float("inf")
 
 
-
 def test_hist_empty_data_no_inputs() -> None:
     s = pl.Series([], dtype=pl.UInt8)
 
@@ -42,7 +41,6 @@ def test_hist_empty_data_no_inputs() -> None:
     assert_frame_equal(result, expected)
 
 
-
 def test_hist_empty_data_empty_bins() -> None:
     s = pl.Series([], dtype=pl.UInt8)
 
@@ -56,7 +54,6 @@ def test_hist_empty_data_empty_bins() -> None:
     )
     result = s.hist(bins=[])
     assert_frame_equal(result, expected)
-
 
 
 def test_hist_empty_data_single_bin_edge() -> None:
@@ -74,7 +71,6 @@ def test_hist_empty_data_single_bin_edge() -> None:
     assert_frame_equal(result, expected)
 
 
-
 def test_hist_empty_data_valid_edges() -> None:
     s = pl.Series([], dtype=pl.UInt8)
 
@@ -90,19 +86,16 @@ def test_hist_empty_data_valid_edges() -> None:
     assert_frame_equal(result, expected)
 
 
-
 def test_hist_empty_data_invalid_edges() -> None:
     s = pl.Series([], dtype=pl.UInt8)
     with pytest.raises(ComputeError, match="bins must increase monotonically"):
         s.hist(bins=[1, 0])  # invalid order
 
 
-
 def test_hist_empty_data_bad_bin_count() -> None:
     s = pl.Series([], dtype=pl.UInt8)
     with pytest.raises(OverflowError, match="can't convert negative int to unsigned"):
         s.hist(bin_count=-1)  # invalid order
-
 
 
 def test_hist_empty_data_zero_bin_count() -> None:
@@ -118,7 +111,6 @@ def test_hist_empty_data_zero_bin_count() -> None:
     assert_frame_equal(result, expected)
 
 
-
 def test_hist_empty_data_single_bin_count() -> None:
     s = pl.Series([], dtype=pl.UInt8)
     expected = pl.DataFrame(
@@ -130,7 +122,6 @@ def test_hist_empty_data_single_bin_count() -> None:
     )
     result = s.hist(bin_count=1)
     assert_frame_equal(result, expected)
-
 
 
 def test_hist_empty_data_valid_bin_count() -> None:
@@ -155,19 +146,16 @@ def test_hist_empty_data_valid_bin_count() -> None:
     assert_frame_equal(result, expected)
 
 
-
 def test_hist_invalid_bin_count() -> None:
     s = pl.Series([-5, 2, 0, 1, 99], dtype=pl.Int32)
     with pytest.raises(OverflowError, match="can't convert negative int to unsigned"):
         s.hist(bin_count=-1)  # invalid order
 
 
-
 def test_hist_invalid_bins() -> None:
     s = pl.Series([-5, 2, 0, 1, 99], dtype=pl.Int32)
     with pytest.raises(ComputeError, match="bins must increase monotonically"):
         s.hist(bins=[1, 0])  # invalid order
-
 
 
 def test_hist_bin_outside_data() -> None:
@@ -183,7 +171,6 @@ def test_hist_bin_outside_data() -> None:
     assert_frame_equal(result, expected)
 
 
-
 def test_hist_bins_between_data() -> None:
     s = pl.Series([-5, 2, 0, 1, 99], dtype=pl.Int32)
     result = s.hist(bins=[4.5, 10.5])
@@ -197,7 +184,6 @@ def test_hist_bins_between_data() -> None:
     assert_frame_equal(result, expected)
 
 
-
 def test_hist_bins_first_edge() -> None:
     s = pl.Series([-5, 2, 0, 1, 99], dtype=pl.Int32)
     result = s.hist(bins=[2, 3, 4])
@@ -209,7 +195,6 @@ def test_hist_bins_first_edge() -> None:
         }
     )
     assert_frame_equal(result, expected)
-
 
 
 def test_hist_bins_last_edge() -> None:
@@ -232,7 +217,6 @@ def test_hist_bins_last_edge() -> None:
     assert_frame_equal(result, expected)
 
 
-
 def test_hist_single_value_single_bin_count() -> None:
     s = pl.Series([1], dtype=pl.Int32)
     result = s.hist(bin_count=1)
@@ -246,7 +230,6 @@ def test_hist_single_value_single_bin_count() -> None:
     assert_frame_equal(result, expected)
 
 
-
 def test_hist_single_bin_count() -> None:
     s = pl.Series([-5, 2, 0, 1, 99], dtype=pl.Int32)
     result = s.hist(bin_count=1)
@@ -258,7 +241,6 @@ def test_hist_single_bin_count() -> None:
         }
     )
     assert_frame_equal(result, expected)
-
 
 
 def test_hist_partial_covering() -> None:
@@ -276,7 +258,6 @@ def test_hist_partial_covering() -> None:
     assert_frame_equal(result, expected)
 
 
-
 def test_hist_full_covering() -> None:
     s = pl.Series([-5, 2, 0, 1, 99], dtype=pl.Int32)
     result = s.hist(bins=[-5.5, 2.5, 50, 105])
@@ -290,7 +271,6 @@ def test_hist_full_covering() -> None:
         }
     )
     assert_frame_equal(result, expected)
-
 
 
 def test_hist_more_bins_than_data() -> None:
@@ -312,7 +292,6 @@ def test_hist_more_bins_than_data() -> None:
         }
     )
     assert_frame_equal(result, expected)
-
 
 
 def test_hist() -> None:

--- a/py-polars/tests/unit/operations/test_hist.py
+++ b/py-polars/tests/unit/operations/test_hist.py
@@ -4,47 +4,45 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars import StringCache
 from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 
 inf = float("inf")
 
 
-@StringCache()
+
 def test_hist_empty_data_no_inputs() -> None:
-    with pl.StringCache():
-        s = pl.Series([], dtype=pl.UInt8)
+    s = pl.Series([], dtype=pl.UInt8)
 
-        # No bins or edges specified: 10 bins around unit interval
-        expected = pl.DataFrame(
-            {
-                "breakpoint": pl.Series(
-                    [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0], dtype=pl.Float64
-                ),
-                "category": pl.Series(
-                    [
-                        "[0.0, 0.1]",
-                        "(0.1, 0.2]",
-                        "(0.2, 0.3]",
-                        "(0.3, 0.4]",
-                        "(0.4, 0.5]",
-                        "(0.5, 0.6]",
-                        "(0.6, 0.7]",
-                        "(0.7, 0.8]",
-                        "(0.8, 0.9]",
-                        "(0.9, 1.0]",
-                    ],
-                    dtype=pl.Categorical,
-                ),
-                "count": pl.Series([0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=pl.UInt32),
-            }
-        )
-        result = s.hist()
-        assert_frame_equal(result, expected)
+    # No bins or edges specified: 10 bins around unit interval
+    expected = pl.DataFrame(
+        {
+            "breakpoint": pl.Series(
+                [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0], dtype=pl.Float64
+            ),
+            "category": pl.Series(
+                [
+                    "[0.0, 0.1]",
+                    "(0.1, 0.2]",
+                    "(0.2, 0.3]",
+                    "(0.3, 0.4]",
+                    "(0.4, 0.5]",
+                    "(0.5, 0.6]",
+                    "(0.6, 0.7]",
+                    "(0.7, 0.8]",
+                    "(0.8, 0.9]",
+                    "(0.9, 1.0]",
+                ],
+                dtype=pl.Categorical,
+            ),
+            "count": pl.Series([0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=pl.UInt32),
+        }
+    )
+    result = s.hist()
+    assert_frame_equal(result, expected)
 
 
-@StringCache()
+
 def test_hist_empty_data_empty_bins() -> None:
     s = pl.Series([], dtype=pl.UInt8)
 
@@ -60,7 +58,7 @@ def test_hist_empty_data_empty_bins() -> None:
     assert_frame_equal(result, expected)
 
 
-@StringCache()
+
 def test_hist_empty_data_single_bin_edge() -> None:
     s = pl.Series([], dtype=pl.UInt8)
 
@@ -76,7 +74,7 @@ def test_hist_empty_data_single_bin_edge() -> None:
     assert_frame_equal(result, expected)
 
 
-@StringCache()
+
 def test_hist_empty_data_valid_edges() -> None:
     s = pl.Series([], dtype=pl.UInt8)
 
@@ -92,21 +90,21 @@ def test_hist_empty_data_valid_edges() -> None:
     assert_frame_equal(result, expected)
 
 
-@StringCache()
+
 def test_hist_empty_data_invalid_edges() -> None:
     s = pl.Series([], dtype=pl.UInt8)
     with pytest.raises(ComputeError, match="bins must increase monotonically"):
         s.hist(bins=[1, 0])  # invalid order
 
 
-@StringCache()
+
 def test_hist_empty_data_bad_bin_count() -> None:
     s = pl.Series([], dtype=pl.UInt8)
     with pytest.raises(OverflowError, match="can't convert negative int to unsigned"):
         s.hist(bin_count=-1)  # invalid order
 
 
-@StringCache()
+
 def test_hist_empty_data_zero_bin_count() -> None:
     s = pl.Series([], dtype=pl.UInt8)
     expected = pl.DataFrame(
@@ -120,7 +118,7 @@ def test_hist_empty_data_zero_bin_count() -> None:
     assert_frame_equal(result, expected)
 
 
-@StringCache()
+
 def test_hist_empty_data_single_bin_count() -> None:
     s = pl.Series([], dtype=pl.UInt8)
     expected = pl.DataFrame(
@@ -134,7 +132,7 @@ def test_hist_empty_data_single_bin_count() -> None:
     assert_frame_equal(result, expected)
 
 
-@StringCache()
+
 def test_hist_empty_data_valid_bin_count() -> None:
     s = pl.Series([], dtype=pl.UInt8)
     expected = pl.DataFrame(
@@ -157,21 +155,21 @@ def test_hist_empty_data_valid_bin_count() -> None:
     assert_frame_equal(result, expected)
 
 
-@StringCache()
+
 def test_hist_invalid_bin_count() -> None:
     s = pl.Series([-5, 2, 0, 1, 99], dtype=pl.Int32)
     with pytest.raises(OverflowError, match="can't convert negative int to unsigned"):
         s.hist(bin_count=-1)  # invalid order
 
 
-@StringCache()
+
 def test_hist_invalid_bins() -> None:
     s = pl.Series([-5, 2, 0, 1, 99], dtype=pl.Int32)
     with pytest.raises(ComputeError, match="bins must increase monotonically"):
         s.hist(bins=[1, 0])  # invalid order
 
 
-@StringCache()
+
 def test_hist_bin_outside_data() -> None:
     s = pl.Series([-5, 2, 0, 1, 99], dtype=pl.Int32)
     result = s.hist(bins=[-10, -9])
@@ -185,7 +183,7 @@ def test_hist_bin_outside_data() -> None:
     assert_frame_equal(result, expected)
 
 
-@StringCache()
+
 def test_hist_bins_between_data() -> None:
     s = pl.Series([-5, 2, 0, 1, 99], dtype=pl.Int32)
     result = s.hist(bins=[4.5, 10.5])
@@ -199,7 +197,7 @@ def test_hist_bins_between_data() -> None:
     assert_frame_equal(result, expected)
 
 
-@StringCache()
+
 def test_hist_bins_first_edge() -> None:
     s = pl.Series([-5, 2, 0, 1, 99], dtype=pl.Int32)
     result = s.hist(bins=[2, 3, 4])
@@ -213,7 +211,7 @@ def test_hist_bins_first_edge() -> None:
     assert_frame_equal(result, expected)
 
 
-@StringCache()
+
 def test_hist_bins_last_edge() -> None:
     s = pl.Series([-5, 2, 0, 1, 99], dtype=pl.Int32)
     result = s.hist(bins=[-4, 0, 99, 100])
@@ -234,7 +232,7 @@ def test_hist_bins_last_edge() -> None:
     assert_frame_equal(result, expected)
 
 
-@StringCache()
+
 def test_hist_single_value_single_bin_count() -> None:
     s = pl.Series([1], dtype=pl.Int32)
     result = s.hist(bin_count=1)
@@ -248,7 +246,7 @@ def test_hist_single_value_single_bin_count() -> None:
     assert_frame_equal(result, expected)
 
 
-@StringCache()
+
 def test_hist_single_bin_count() -> None:
     s = pl.Series([-5, 2, 0, 1, 99], dtype=pl.Int32)
     result = s.hist(bin_count=1)
@@ -262,7 +260,7 @@ def test_hist_single_bin_count() -> None:
     assert_frame_equal(result, expected)
 
 
-@StringCache()
+
 def test_hist_partial_covering() -> None:
     s = pl.Series([-5, 2, 0, 1, 99], dtype=pl.Int32)
     result = s.hist(bins=[-1.5, 2.5, 50, 105])
@@ -278,7 +276,7 @@ def test_hist_partial_covering() -> None:
     assert_frame_equal(result, expected)
 
 
-@StringCache()
+
 def test_hist_full_covering() -> None:
     s = pl.Series([-5, 2, 0, 1, 99], dtype=pl.Int32)
     result = s.hist(bins=[-5.5, 2.5, 50, 105])
@@ -294,7 +292,7 @@ def test_hist_full_covering() -> None:
     assert_frame_equal(result, expected)
 
 
-@StringCache()
+
 def test_hist_more_bins_than_data() -> None:
     s = pl.Series([-5, 2, 0, 1, 99], dtype=pl.Int32)
     result = s.hist(bin_count=8)
@@ -316,7 +314,7 @@ def test_hist_more_bins_than_data() -> None:
     assert_frame_equal(result, expected)
 
 
-@StringCache()
+
 def test_hist() -> None:
     s = pl.Series("a", [1, 3, 8, 8, 2, 1, 3])
     out = s.hist(bin_count=4)
@@ -476,65 +474,62 @@ def test_hist_breakpoint_accuracy() -> None:
 
 def test_hist_ensure_max_value_20879() -> None:
     s = pl.Series([-1 / 3, 0, 1, 2, 3, 7])
-    with pl.StringCache():
-        result = s.hist(bin_count=3)
-        expected = pl.DataFrame(
-            {
-                "breakpoint": pl.Series(
-                    [
-                        2.0 + 1 / 9,
-                        4.0 + 5 / 9,
-                        7.0,
-                    ],
-                    dtype=pl.Float64,
-                ),
-                "category": pl.Series(
-                    [
-                        "[-0.333333, 2.111111]",
-                        "(2.111111, 4.555556]",
-                        "(4.555556, 7.0]",
-                    ],
-                    dtype=pl.Categorical,
-                ),
-                "count": pl.Series([4, 1, 1], dtype=pl.get_index_type()),
-            }
-        )
+    result = s.hist(bin_count=3)
+    expected = pl.DataFrame(
+        {
+            "breakpoint": pl.Series(
+                [
+                    2.0 + 1 / 9,
+                    4.0 + 5 / 9,
+                    7.0,
+                ],
+                dtype=pl.Float64,
+            ),
+            "category": pl.Series(
+                [
+                    "[-0.333333, 2.111111]",
+                    "(2.111111, 4.555556]",
+                    "(4.555556, 7.0]",
+                ],
+                dtype=pl.Categorical,
+            ),
+            "count": pl.Series([4, 1, 1], dtype=pl.get_index_type()),
+        }
+    )
     assert_frame_equal(result, expected)
 
 
 def test_hist_ignore_nans_21082() -> None:
     s = pl.Series([0.0, float("nan"), 0.5, float("nan"), 1.0])
-    with pl.StringCache():
-        result = s.hist(bins=[-0.001, 0.25, 0.5, 0.75, 1.0])
-        expected = pl.DataFrame(
-            {
-                "breakpoint": pl.Series([0.25, 0.5, 0.75, 1.0], dtype=pl.Float64),
-                "category": pl.Series(
-                    [
-                        "[-0.001, 0.25]",
-                        "(0.25, 0.5]",
-                        "(0.5, 0.75]",
-                        "(0.75, 1.0]",
-                    ],
-                    dtype=pl.Categorical,
-                ),
-                "count": pl.Series([1, 1, 0, 1], dtype=pl.get_index_type()),
-            }
-        )
+    result = s.hist(bins=[-0.001, 0.25, 0.5, 0.75, 1.0])
+    expected = pl.DataFrame(
+        {
+            "breakpoint": pl.Series([0.25, 0.5, 0.75, 1.0], dtype=pl.Float64),
+            "category": pl.Series(
+                [
+                    "[-0.001, 0.25]",
+                    "(0.25, 0.5]",
+                    "(0.5, 0.75]",
+                    "(0.75, 1.0]",
+                ],
+                dtype=pl.Categorical,
+            ),
+            "count": pl.Series([1, 1, 0, 1], dtype=pl.get_index_type()),
+        }
+    )
     assert_frame_equal(result, expected)
 
 
 def test_hist_include_lower_22056() -> None:
     s = pl.Series("a", [1, 5])
-    with pl.StringCache():
-        result = s.hist(bins=[1, 5], include_category=True)
-        expected = pl.DataFrame(
-            {
-                "breakpoint": pl.Series([5.0], dtype=pl.Float64),
-                "category": pl.Series(["[1.0, 5.0]"], dtype=pl.Categorical),
-                "count": pl.Series([2], dtype=pl.get_index_type()),
-            }
-        )
+    result = s.hist(bins=[1, 5], include_category=True)
+    expected = pl.DataFrame(
+        {
+            "breakpoint": pl.Series([5.0], dtype=pl.Float64),
+            "category": pl.Series(["[1.0, 5.0]"], dtype=pl.Categorical),
+            "count": pl.Series([2], dtype=pl.get_index_type()),
+        }
+    )
     assert_frame_equal(result, expected)
 
 

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 import pytest
 
 import polars as pl
-from polars import StringCache
 from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
@@ -427,7 +426,7 @@ def test_is_in_date_range() -> None:
     assert out.to_list() == [False, True, True]
 
 
-@StringCache()
+
 @pytest.mark.parametrize("dtype", [pl.Categorical, pl.Enum(["a", "b", "c"])])
 @pytest.mark.parametrize("nulls_equal", [False, True])
 def test_cat_is_in_series(dtype: pl.DataType, nulls_equal: bool) -> None:
@@ -441,7 +440,6 @@ def test_cat_is_in_series(dtype: pl.DataType, nulls_equal: bool) -> None:
     assert_series_equal(s.is_in(s2_str, nulls_equal=nulls_equal), expected)
 
 
-@StringCache()
 @pytest.mark.parametrize("nulls_equal", [False, True])
 def test_cat_is_in_series_non_existent(nulls_equal: bool) -> None:
     dtype = pl.Categorical
@@ -475,7 +473,6 @@ def test_enum_is_in_series_non_existent(nulls_equal: bool) -> None:
     assert_series_equal(out, expected)
 
 
-@StringCache()
 @pytest.mark.parametrize("dtype", [pl.Categorical, pl.Enum(["a", "b", "c"])])
 @pytest.mark.parametrize("nulls_equal", [False, True])
 def test_cat_is_in_with_lit_str(dtype: pl.DataType, nulls_equal: bool) -> None:
@@ -487,7 +484,6 @@ def test_cat_is_in_with_lit_str(dtype: pl.DataType, nulls_equal: bool) -> None:
     assert_series_equal(s.is_in(lit, nulls_equal=nulls_equal), expected)
 
 
-@StringCache()
 @pytest.mark.parametrize("nulls_equal", [False, True])
 def test_cat_is_in_with_lit_str_non_existent(nulls_equal: bool) -> None:
     dtype = pl.Categorical()
@@ -499,7 +495,6 @@ def test_cat_is_in_with_lit_str_non_existent(nulls_equal: bool) -> None:
     assert_series_equal(s.is_in(lit, nulls_equal=nulls_equal), expected)
 
 
-@StringCache()
 @pytest.mark.parametrize("dtype", [pl.Categorical, pl.Enum(["a", "b", "c"])])
 def test_cat_is_in_with_lit_str_cache_setup(dtype: pl.DataType) -> None:
     # init the global cache
@@ -533,7 +528,6 @@ def test_cat_is_in_from_str(dtype: pl.DataType) -> None:
     )
 
 
-@pl.StringCache()
 @pytest.mark.parametrize("dtype", [pl.Categorical, pl.Enum(["a", "b", "c", "d"])])
 @pytest.mark.may_fail_auto_streaming
 def test_cat_list_is_in_from_cat(dtype: pl.DataType) -> None:
@@ -553,7 +547,6 @@ def test_cat_list_is_in_from_cat(dtype: pl.DataType) -> None:
     assert_frame_equal(res, expected_df)
 
 
-@pl.StringCache()
 @pytest.mark.parametrize(
     ("val", "expected"),
     [
@@ -574,7 +567,6 @@ def test_cat_list_is_in_from_cat_single(val: str | None, expected: list[bool]) -
     assert_frame_equal(res, expected_df)
 
 
-@pl.StringCache()
 def test_cat_list_is_in_from_str() -> None:
     df = pl.DataFrame(
         [
@@ -592,7 +584,6 @@ def test_cat_list_is_in_from_str() -> None:
     assert_frame_equal(res, expected_df)
 
 
-@pl.StringCache()
 @pytest.mark.parametrize(
     ("val", "expected"),
     [
@@ -709,7 +700,6 @@ def test_null_propagate_all_paths(nulls_equal: bool) -> None:
     assert_series_equal(result, expected)
 
 
-@pytest.mark.usefixtures("test_global_and_local")
 @pytest.mark.parametrize("nulls_equal", [False, True])
 def test_null_propagate_all_paths_cat(nulls_equal: bool) -> None:
     # No nulls in either

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -426,7 +426,6 @@ def test_is_in_date_range() -> None:
     assert out.to_list() == [False, True, True]
 
 
-
 @pytest.mark.parametrize("dtype", [pl.Categorical, pl.Enum(["a", "b", "c"])])
 @pytest.mark.parametrize("nulls_equal", [False, True])
 def test_cat_is_in_series(dtype: pl.DataType, nulls_equal: bool) -> None:

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -18,7 +18,7 @@ from polars.exceptions import (
     SchemaError,
 )
 from polars.testing import assert_frame_equal, assert_series_equal
-from tests.unit.conftest import time_func, with_string_cache_if_auto_streaming
+from tests.unit.conftest import time_func
 
 if TYPE_CHECKING:
     from polars._typing import JoinStrategy, PolarsDataType
@@ -1259,7 +1259,6 @@ def test_array_explode_join_19763() -> None:
     assert_frame_equal(q.collect().sort("k"), pl.DataFrame({"k": [1, 2]}))
 
 
-@with_string_cache_if_auto_streaming
 def test_join_full_19814() -> None:
     schema = {"a": pl.Int64, "c": pl.Categorical}
     a = pl.LazyFrame({"a": [1], "c": [None]}, schema=schema)
@@ -1967,36 +1966,35 @@ def test_join_null_equal(order: Literal["none", "left_right", "right_left"]) -> 
 
 
 def test_join_categorical_21815() -> None:
-    with pl.StringCache():
-        left = pl.DataFrame({"x": ["a", "b", "c", "d"]}).with_columns(
-            xc=pl.col.x.cast(pl.Categorical)
-        )
-        right = pl.DataFrame({"x": ["c", "d", "e", "f"]}).with_columns(
-            xc=pl.col.x.cast(pl.Categorical)
-        )
+    left = pl.DataFrame({"x": ["a", "b", "c", "d"]}).with_columns(
+        xc=pl.col.x.cast(pl.Categorical)
+    )
+    right = pl.DataFrame({"x": ["c", "d", "e", "f"]}).with_columns(
+        xc=pl.col.x.cast(pl.Categorical)
+    )
 
-        # As key.
-        cat_key = left.join(right, on="xc", how="full")
+    # As key.
+    cat_key = left.join(right, on="xc", how="full")
 
-        # As payload.
-        cat_payload = left.join(right, on="x", how="full")
+    # As payload.
+    cat_payload = left.join(right, on="x", how="full")
 
-        expected = pl.DataFrame(
-            {
-                "x": ["a", "b", "c", "d", None, None],
-                "x_right": [None, None, "c", "d", "e", "f"],
-            }
-        ).with_columns(
-            xc=pl.col.x.cast(pl.Categorical),
-            xc_right=pl.col.x_right.cast(pl.Categorical),
-        )
+    expected = pl.DataFrame(
+        {
+            "x": ["a", "b", "c", "d", None, None],
+            "x_right": [None, None, "c", "d", "e", "f"],
+        }
+    ).with_columns(
+        xc=pl.col.x.cast(pl.Categorical),
+        xc_right=pl.col.x_right.cast(pl.Categorical),
+    )
 
-        assert_frame_equal(
-            cat_key, expected, check_row_order=False, check_column_order=False
-        )
-        assert_frame_equal(
-            cat_payload, expected, check_row_order=False, check_column_order=False
-        )
+    assert_frame_equal(
+        cat_key, expected, check_row_order=False, check_column_order=False
+    )
+    assert_frame_equal(
+        cat_payload, expected, check_row_order=False, check_column_order=False
+    )
 
 
 def test_join_where_nested_boolean() -> None:

--- a/py-polars/tests/unit/operations/test_merge_sorted.py
+++ b/py-polars/tests/unit/operations/test_merge_sorted.py
@@ -232,45 +232,43 @@ def test_merge_time() -> None:
 
 
 def test_merge_sorted_categorical_global_lexical() -> None:
-    with pl.StringCache():
-        df1 = pl.DataFrame(
-            {"a": pl.Series(["a", "e", "f"], dtype=pl.Categorical("lexical"))}
-        )
-        df2 = pl.DataFrame(
-            {"a": pl.Series(["a", "c", "d"], dtype=pl.Categorical("lexical"))}
-        )
-        expected = pl.DataFrame(
-            {
-                "a": pl.Series(
-                    (["a", "a", "c", "d", "e", "f"]),
-                    dtype=pl.Categorical("lexical"),
-                )
-            }
-        )
+    df1 = pl.DataFrame(
+        {"a": pl.Series(["a", "e", "f"], dtype=pl.Categorical("lexical"))}
+    )
+    df2 = pl.DataFrame(
+        {"a": pl.Series(["a", "c", "d"], dtype=pl.Categorical("lexical"))}
+    )
+    expected = pl.DataFrame(
+        {
+            "a": pl.Series(
+                (["a", "a", "c", "d", "e", "f"]),
+                dtype=pl.Categorical("lexical"),
+            )
+        }
+    )
     result = df1.merge_sorted(df2, key="a")
     assert_frame_equal(result, expected)
 
 
 def test_merge_sorted_categorical_21952() -> None:
-    with pl.StringCache():
-        df1 = pl.DataFrame({"a": ["a", "b", "c"]}).cast(pl.Categorical("lexical"))
-        df2 = pl.DataFrame({"a": ["a", "b", "d"]}).cast(pl.Categorical("lexical"))
-        df = df1.merge_sorted(df2, key="a")
-        assert repr(df) == (
-            "shape: (6, 1)\n"
-            "┌─────┐\n"
-            "│ a   │\n"
-            "│ --- │\n"
-            "│ cat │\n"
-            "╞═════╡\n"
-            "│ a   │\n"
-            "│ a   │\n"
-            "│ b   │\n"
-            "│ b   │\n"
-            "│ c   │\n"
-            "│ d   │\n"
-            "└─────┘"
-        )
+    df1 = pl.DataFrame({"a": ["a", "b", "c"]}).cast(pl.Categorical("lexical"))
+    df2 = pl.DataFrame({"a": ["a", "b", "d"]}).cast(pl.Categorical("lexical"))
+    df = df1.merge_sorted(df2, key="a")
+    assert repr(df) == (
+        "shape: (6, 1)\n"
+        "┌─────┐\n"
+        "│ a   │\n"
+        "│ --- │\n"
+        "│ cat │\n"
+        "╞═════╡\n"
+        "│ a   │\n"
+        "│ a   │\n"
+        "│ b   │\n"
+        "│ b   │\n"
+        "│ c   │\n"
+        "│ d   │\n"
+        "└─────┘"
+    )
 
 
 @pytest.mark.parametrize("streaming", [False, True])

--- a/py-polars/tests/unit/operations/test_replace.py
+++ b/py-polars/tests/unit/operations/test_replace.py
@@ -48,7 +48,6 @@ def test_replace_enum_to_str() -> None:
     assert_series_equal(result, expected)
 
 
-@pl.StringCache()
 def test_replace_cat_to_cat(str_mapping: dict[str | None, str]) -> None:
     lf = pl.LazyFrame(
         {"country_code": ["FR", None, "ES", "DE"]},

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -1168,7 +1168,6 @@ def test_sort_bool_nulls_last() -> None:
     )
 
 
-@pl.StringCache()
 @pytest.mark.parametrize(
     "dtype",
     [

--- a/py-polars/tests/unit/operations/unique/test_unique.py
+++ b/py-polars/tests/unit/operations/unique/test_unique.py
@@ -8,7 +8,6 @@ import pytest
 import polars as pl
 from polars.exceptions import ColumnNotFoundError
 from polars.testing import assert_frame_equal, assert_series_equal
-from tests.unit.conftest import with_string_cache_if_auto_streaming
 
 if TYPE_CHECKING:
     from polars._typing import PolarsDataType
@@ -144,17 +143,15 @@ def test_unique_null(maintain_order: bool) -> None:
         ([None, "a", "b", "b"], [None, "a", "b"]),
     ],
 )
-@pytest.mark.usefixtures("test_global_and_local")
 def test_unique_categorical(input: list[str | None], output: list[str | None]) -> None:
-    with pl.StringCache():
-        s = pl.Series(input, dtype=pl.Categorical)
-        result = s.unique(maintain_order=True)
-        expected = pl.Series(output, dtype=pl.Categorical)
-        assert_series_equal(result, expected)
+    s = pl.Series(input, dtype=pl.Categorical)
+    result = s.unique(maintain_order=True)
+    expected = pl.Series(output, dtype=pl.Categorical)
+    assert_series_equal(result, expected)
 
-        result = s.unique(maintain_order=False)
-        expected = pl.Series(output, dtype=pl.Categorical)
-        assert_series_equal(result, expected, check_order=False)
+    result = s.unique(maintain_order=False)
+    expected = pl.Series(output, dtype=pl.Categorical)
+    assert_series_equal(result, expected, check_order=False)
 
 
 def test_unique_with_null() -> None:
@@ -199,8 +196,6 @@ def test_unique_with_bad_subset(
         df.unique(subset=subset)
 
 
-@pytest.mark.usefixtures("test_global_and_local")
-@with_string_cache_if_auto_streaming
 def test_categorical_unique_19409() -> None:
     df = pl.DataFrame({"x": [str(n % 50) for n in range(127)]}).cast(pl.Categorical)
     uniq = df.unique()
@@ -210,16 +205,15 @@ def test_categorical_unique_19409() -> None:
 
 
 def test_categorical_updated_revmap_unique_20233() -> None:
-    with pl.StringCache():
-        s = pl.Series("a", ["A"], pl.Categorical)
+    s = pl.Series("a", ["A"], pl.Categorical)
 
-        s = (
-            pl.select(a=pl.when(True).then(pl.lit("C", pl.Categorical)))
-            .select(a=pl.when(True).then(pl.lit("D", pl.Categorical)))
-            .to_series()
-        )
+    s = (
+        pl.select(a=pl.when(True).then(pl.lit("C", pl.Categorical)))
+        .select(a=pl.when(True).then(pl.lit("D", pl.Categorical)))
+        .to_series()
+    )
 
-        assert_series_equal(s.unique(), pl.Series("a", ["D"], pl.Categorical))
+    assert_series_equal(s.unique(), pl.Series("a", ["D"], pl.Categorical))
 
 
 def test_unique_check_order_20480() -> None:

--- a/py-polars/tests/unit/series/test_append.py
+++ b/py-polars/tests/unit/series/test_append.py
@@ -116,15 +116,14 @@ def test_append_null_series() -> None:
     assert a.n_chunks() == 2
 
 
-def test_append_enum_with_stringcache_22764() -> None:
+def test_append_enum_22764() -> None:
     f = io.BytesIO()
     g = io.BytesIO()
-    with pl.StringCache():
-        pl.DataFrame({"someletter": ["A", "B"]}).write_csv(f)
+    pl.DataFrame({"someletter": ["A", "B"]}).write_csv(f)
 
-        schema = pl.Schema(
-            {
-                "someletter": pl.Enum(["A", "B"]),
-            }
-        )
-        pl.scan_csv(f, schema=schema).sink_parquet(g)
+    schema = pl.Schema(
+        {
+            "someletter": pl.Enum(["A", "B"]),
+        }
+    )
+    pl.scan_csv(f, schema=schema).sink_parquet(g)

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -363,7 +363,6 @@ def test_date_agg() -> None:
         (pl.Series(["c", "b", "a"], dtype=pl.Enum(["c", "b", "a", "d"])), "c", "a"),
     ],
 )
-@pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_agg(s: pl.Series, min: str | None, max: str | None) -> None:
     assert s.min() == min
     assert s.max() == max
@@ -1611,11 +1610,10 @@ def test_cast_datetime_to_time(unit: TimeUnit) -> None:
 
 
 def test_init_categorical() -> None:
-    with pl.StringCache():
-        for values in [[None], ["foo", "bar"], [None, "foo", "bar"]]:
-            expected = pl.Series("a", values, dtype=pl.String).cast(pl.Categorical)
-            a = pl.Series("a", values, dtype=pl.Categorical)
-            assert_series_equal(a, expected)
+    for values in [[None], ["foo", "bar"], [None, "foo", "bar"]]:
+        expected = pl.Series("a", values, dtype=pl.String).cast(pl.Categorical)
+        a = pl.Series("a", values, dtype=pl.Categorical)
+        assert_series_equal(a, expected)
 
 
 def test_iter_nested_list() -> None:

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -19,24 +19,23 @@ pytestmark = pytest.mark.xdist_group("streaming")
 
 
 def test_streaming_categoricals_5921() -> None:
-    with pl.StringCache():
-        out_lazy = (
-            pl.DataFrame({"X": ["a", "a", "a", "b", "b"], "Y": [2, 2, 2, 1, 1]})
-            .lazy()
-            .with_columns(pl.col("X").cast(pl.Categorical))
-            .group_by("X")
-            .agg(pl.col("Y").min())
-            .sort("Y", descending=True)
-            .collect(engine="streaming")
-        )
+    out_lazy = (
+        pl.DataFrame({"X": ["a", "a", "a", "b", "b"], "Y": [2, 2, 2, 1, 1]})
+        .lazy()
+        .with_columns(pl.col("X").cast(pl.Categorical))
+        .group_by("X")
+        .agg(pl.col("Y").min())
+        .sort("Y", descending=True)
+        .collect(engine="streaming")
+    )
 
-        out_eager = (
-            pl.DataFrame({"X": ["a", "a", "a", "b", "b"], "Y": [2, 2, 2, 1, 1]})
-            .with_columns(pl.col("X").cast(pl.Categorical))
-            .group_by("X")
-            .agg(pl.col("Y").min())
-            .sort("Y", descending=True)
-        )
+    out_eager = (
+        pl.DataFrame({"X": ["a", "a", "a", "b", "b"], "Y": [2, 2, 2, 1, 1]})
+        .with_columns(pl.col("X").cast(pl.Categorical))
+        .group_by("X")
+        .agg(pl.col("Y").min())
+        .sort("Y", descending=True)
+    )
 
     for out in [out_eager, out_lazy]:
         assert out.dtypes == [pl.Categorical, pl.Int64]

--- a/py-polars/tests/unit/streaming/test_streaming_categoricals.py
+++ b/py-polars/tests/unit/streaming/test_streaming_categoricals.py
@@ -6,17 +6,16 @@ pytestmark = pytest.mark.xdist_group("streaming")
 
 
 def test_streaming_nested_categorical() -> None:
-    with pl.StringCache():
-        assert (
-            pl.LazyFrame({"numbers": [1, 1, 2], "cat": [["str"], ["foo"], ["bar"]]})
-            .with_columns(pl.col("cat").cast(pl.List(pl.Categorical)))
-            .group_by("numbers")
-            .agg(pl.col("cat").first())
-            .sort("numbers")
-        ).collect(engine="streaming").to_dict(as_series=False) == {
-            "numbers": [1, 2],
-            "cat": [["str"], ["bar"]],
-        }
+    assert (
+        pl.LazyFrame({"numbers": [1, 1, 2], "cat": [["str"], ["foo"], ["bar"]]})
+        .with_columns(pl.col("cat").cast(pl.List(pl.Categorical)))
+        .group_by("numbers")
+        .agg(pl.col("cat").first())
+        .sort("numbers")
+    ).collect(engine="streaming").to_dict(as_series=False) == {
+        "numbers": [1, 2],
+        "cat": [["str"], ["bar"]],
+    }
 
 
 def test_streaming_cat_14933() -> None:

--- a/py-polars/tests/unit/streaming/test_streaming_group_by.py
+++ b/py-polars/tests/unit/streaming/test_streaming_group_by.py
@@ -335,27 +335,26 @@ def test_streaming_group_by_all_numeric_types_stability_8570() -> None:
 
 
 def test_streaming_group_by_categorical_aggregate() -> None:
-    with pl.StringCache():
-        out = (
-            pl.LazyFrame(
-                {
-                    "a": pl.Series(
-                        ["a", "a", "b", "b", "c", "c", None, None], dtype=pl.Categorical
-                    ),
-                    "b": pl.Series(
-                        pl.date_range(
-                            date(2023, 4, 28),
-                            date(2023, 5, 5),
-                            eager=True,
-                        ).to_list(),
-                        dtype=pl.Date,
-                    ),
-                }
-            )
-            .group_by(["a", "b"])
-            .agg([pl.col("a").first().alias("sum")])
-            .collect(engine="streaming")
+    out = (
+        pl.LazyFrame(
+            {
+                "a": pl.Series(
+                    ["a", "a", "b", "b", "c", "c", None, None], dtype=pl.Categorical
+                ),
+                "b": pl.Series(
+                    pl.date_range(
+                        date(2023, 4, 28),
+                        date(2023, 5, 5),
+                        eager=True,
+                    ).to_list(),
+                    dtype=pl.Date,
+                ),
+            }
         )
+        .group_by(["a", "b"])
+        .agg([pl.col("a").first().alias("sum")])
+        .collect(engine="streaming")
+    )
 
     assert out.sort("b").to_dict(as_series=False) == {
         "a": ["a", "a", "b", "b", "c", "c", None, None],

--- a/py-polars/tests/unit/streaming/test_streaming_io.py
+++ b/py-polars/tests/unit/streaming/test_streaming_io.py
@@ -59,10 +59,9 @@ def test_sink_parquet(io_files_path: Path, tmp_path: Path) -> None:
     df_scanned = pl.scan_parquet(file)
     df_scanned.sink_parquet(file_path)
 
-    with pl.StringCache():
-        result = pl.read_parquet(file_path)
-        df_read = pl.read_parquet(file)
-        assert_frame_equal(result, df_read)
+    result = pl.read_parquet(file_path)
+    df_read = pl.read_parquet(file)
+    assert_frame_equal(result, df_read)
 
 
 @pytest.mark.write_disk
@@ -101,10 +100,9 @@ def test_sink_ipc(io_files_path: Path, tmp_path: Path) -> None:
     df_scanned = pl.scan_parquet(file)
     df_scanned.sink_ipc(file_path)
 
-    with pl.StringCache():
-        result = pl.read_ipc(file_path)
-        df_read = pl.read_parquet(file)
-        assert_frame_equal(result, df_read)
+    result = pl.read_ipc(file_path)
+    df_read = pl.read_parquet(file)
+    assert_frame_equal(result, df_read)
 
 
 @pytest.mark.write_disk
@@ -114,10 +112,9 @@ def test_sink_csv(io_files_path: Path, tmp_path: Path) -> None:
 
     pl.scan_parquet(source_file).sink_csv(target_file)
 
-    with pl.StringCache():
-        source_data = pl.read_parquet(source_file)
-        target_data = pl.read_csv(target_file)
-        assert_frame_equal(target_data, source_data)
+    source_data = pl.read_parquet(source_file)
+    target_data = pl.read_csv(target_file)
+    assert_frame_equal(target_data, source_data)
 
 
 @pytest.mark.write_disk

--- a/py-polars/tests/unit/test_config.py
+++ b/py-polars/tests/unit/test_config.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 @pytest.fixture(autouse=True)
 def _environ() -> Iterator[None]:
     """Fixture to restore the environment after/during tests."""
-    with pl.StringCache(), pl.Config(restore_defaults=True):
+    with pl.Config(restore_defaults=True):
         yield
 
 

--- a/py-polars/tests/unit/test_serde.py
+++ b/py-polars/tests/unit/test_serde.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta
 import pytest
 
 import polars as pl
-from polars import StringCache
 from polars.exceptions import SchemaError
 from polars.testing import assert_frame_equal, assert_series_equal
 
@@ -160,7 +159,6 @@ def test_pickle_lazyframe_nested_function_udf() -> None:
     assert q.collect()["a"].to_list() == [2, 4, 6]
 
 
-@StringCache()
 def test_serde_categorical_series_10586() -> None:
     s = pl.Series(["a", "b", "b", "a", "c"], dtype=pl.Categorical)
     loaded_s = pickle.loads(pickle.dumps(s))


### PR DESCRIPTION
The `StringCache` is deprecated and does nothing anymore, no point in having it littered around our test suite anymore.