### PR TITLE
chore: Remove unnecessary may_fail_auto_streaming

### DIFF
--- a/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
+++ b/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
@@ -396,7 +396,6 @@ def test_fallback_with_dtype_strict_failure_decimal_precision() -> None:
         PySeries.new_from_any_values_and_dtype("", values, dtype, strict=True)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_categorical_lit_18874() -> None:
     assert_frame_equal(
         pl.DataFrame(

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2123,7 +2123,6 @@ def test_empty_projection() -> None:
     assert empty_df.shape == (0, 0)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_fill_null() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": [3, None]})
     assert_frame_equal(df.fill_null(4), pl.DataFrame({"a": [1, 2], "b": [3, 4]}))

--- a/py-polars/tests/unit/dataframe/test_serde.py
+++ b/py-polars/tests/unit/dataframe/test_serde.py
@@ -42,7 +42,6 @@ def test_df_serde_roundtrip_json(df: pl.DataFrame) -> None:
     assert_frame_equal(result, df, categorical_as_str=True)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_df_serde(df: pl.DataFrame) -> None:
     serialized = df.serialize()
     assert isinstance(serialized, bytes)
@@ -50,7 +49,6 @@ def test_df_serde(df: pl.DataFrame) -> None:
     assert_frame_equal(result, df)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_df_serde_json_stringio(df: pl.DataFrame) -> None:
     serialized = df.serialize(format="json")
     assert isinstance(serialized, str)

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -83,7 +83,6 @@ def test_cat_to_dummies() -> None:
     }
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_categorical_is_in_list() -> None:
     # this requires type coercion to cast.
     # we should not cast within the function as this would be expensive within a
@@ -513,7 +512,6 @@ def test_categorical_fill_null_existing_category() -> None:
     assert result.to_dict(as_series=False) == expected
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_categorical_fill_null() -> None:
     df = pl.LazyFrame(
         {"index": [1, 2, 3], "cat": ["a", "b", None]},

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -672,7 +672,6 @@ def test_init_series_from_int_enum(EnumBase: tuple[type, ...]) -> None:
     assert_series_equal(expected, s)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_read_enum_from_csv() -> None:
     df = pl.DataFrame(
         {

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -824,7 +824,6 @@ def test_list_list_sum_exception_12935() -> None:
         pl.Series([[1], [2]]).sum()
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_null_list_categorical_16405() -> None:
     df = pl.DataFrame(
         [(None, "foo")],

--- a/py-polars/tests/unit/functions/as_datatype/test_concat_arr.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_concat_arr.py
@@ -176,6 +176,7 @@ def test_concat_arr_zero_fields() -> None:
     )
 
 
+@pytest.mark.may_fail_auto_streaming
 def test_concat_arr_scalar() -> None:
     lit = pl.lit([b"A"], dtype=pl.Array(pl.Binary, 1))
     df = pl.select(pl.repeat(lit, 10))

--- a/py-polars/tests/unit/functions/as_datatype/test_concat_arr.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_concat_arr.py
@@ -176,7 +176,6 @@ def test_concat_arr_zero_fields() -> None:
     )
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_concat_arr_scalar() -> None:
     lit = pl.lit([b"A"], dtype=pl.Array(pl.Binary, 1))
     df = pl.select(pl.repeat(lit, 10))

--- a/py-polars/tests/unit/functions/test_when_then.py
+++ b/py-polars/tests/unit/functions/test_when_then.py
@@ -233,7 +233,6 @@ def test_object_when_then_4702() -> None:
     }
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_comp_categorical_lit_dtype() -> None:
     df = pl.DataFrame(
         data={"column": ["a", "b", "e"], "values": [1, 5, 9]},

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -362,7 +362,6 @@ def test_str_find_escaped_chars() -> None:
     )
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_str_find_wrong_length() -> None:
     df = pl.DataFrame({"num": ["-10", "-1", "0"]})
     with pytest.raises(ShapeError):

--- a/py-polars/tests/unit/operations/test_hist.py
+++ b/py-polars/tests/unit/operations/test_hist.py
@@ -310,7 +310,6 @@ def test_hist() -> None:
     assert_frame_equal(out, expected)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_hist_all_null() -> None:
     s = pl.Series([None], dtype=pl.Float64)
     out = s.hist()
@@ -342,7 +341,6 @@ def test_hist_all_null() -> None:
 
 @pytest.mark.parametrize("n_null", [0, 5])
 @pytest.mark.parametrize("n_values", [3, 10, 250])
-@pytest.mark.may_fail_auto_streaming
 def test_hist_rand(n_values: int, n_null: int) -> None:
     s_rand = pl.Series([None] * n_null, dtype=pl.Int64)
     s_values = pl.Series(np.random.randint(0, 100, n_values), dtype=pl.Int64)
@@ -422,7 +420,6 @@ def test_hist_max_boundary_20133() -> None:
     assert result["count"].sum() == 2
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_hist_same_values_20030() -> None:
     out = pl.Series([1, 1]).hist(bin_count=2)
     expected = pl.DataFrame(
@@ -435,7 +432,6 @@ def test_hist_same_values_20030() -> None:
     assert_frame_equal(out, expected)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_hist_breakpoint_accuracy() -> None:
     s = pl.Series([1, 2, 3, 4])
     out = s.hist(bin_count=3)

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -303,7 +303,6 @@ def test_is_in_invalid_shape() -> None:
         pl.Series("a", [1, 2, 3]).is_in([[], []])
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_is_in_list_rhs() -> None:
     assert_series_equal(
         pl.Series([1, 2, 3, 4, 5]).is_in(pl.Series([[1], [2, 9], [None], None, None])),
@@ -513,7 +512,7 @@ def test_is_in_with_wildcard_13809() -> None:
 @pytest.mark.parametrize(
     "dtype",
     [
-        pytest.param(pl.Categorical, marks=pytest.mark.may_fail_auto_streaming),
+        pl.Categorical,
         pl.Enum(["a", "b", "c", "d"]),
     ],
 )
@@ -528,7 +527,6 @@ def test_cat_is_in_from_str(dtype: pl.DataType) -> None:
 
 
 @pytest.mark.parametrize("dtype", [pl.Categorical, pl.Enum(["a", "b", "c", "d"])])
-@pytest.mark.may_fail_auto_streaming
 def test_cat_list_is_in_from_cat(dtype: pl.DataType) -> None:
     df = pl.DataFrame(
         [
@@ -554,7 +552,6 @@ def test_cat_list_is_in_from_cat(dtype: pl.DataType) -> None:
         ("e", [False, False, False, None, False]),
     ],
 )
-@pytest.mark.may_fail_auto_streaming
 def test_cat_list_is_in_from_cat_single(val: str | None, expected: list[bool]) -> None:
     df = pl.Series(
         "li",

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -65,7 +65,6 @@ def test_semi_anti_join() -> None:
     }
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_join_same_cat_src() -> None:
     df = pl.DataFrame(
         data={"column": ["a", "a", "b"], "more": [1, 2, 3]},

--- a/py-polars/tests/unit/operations/test_merge_sorted.py
+++ b/py-polars/tests/unit/operations/test_merge_sorted.py
@@ -71,7 +71,6 @@ def test_merge_sorted_categorical() -> None:
     assert_frame_equal(left.merge_sorted(right, "a"), expected.to_frame())
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_merge_sorted_categorical_lexical() -> None:
     left = pl.Series("a", ["b", "a"], pl.Categorical("lexical")).sort().to_frame()
     right = pl.Series("a", ["b", "b", "a"], pl.Categorical("lexical")).sort().to_frame()

--- a/py-polars/tests/unit/operations/test_shift.py
+++ b/py-polars/tests/unit/operations/test_shift.py
@@ -77,7 +77,6 @@ def test_shift_expr() -> None:
     assert out.to_dict(as_series=False) == {"a": [5, 5, 1, 2, 3], "b": [5, 5, 1, 2, 3]}
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_shift_categorical() -> None:
     df = pl.Series("a", ["a", "b"], dtype=pl.Categorical).to_frame()
 

--- a/py-polars/tests/unit/operations/test_transpose.py
+++ b/py-polars/tests/unit/operations/test_transpose.py
@@ -12,7 +12,6 @@ from polars.exceptions import (
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_transpose_supertype() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": ["foo", "bar", "ham"]})
     result = df.transpose()
@@ -26,7 +25,6 @@ def test_transpose_supertype() -> None:
     assert_frame_equal(result, expected)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_transpose_tz_naive_and_tz_aware() -> None:
     df = pl.DataFrame(
         {
@@ -42,7 +40,6 @@ def test_transpose_tz_naive_and_tz_aware() -> None:
         df.transpose()
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_transpose_struct() -> None:
     df = pl.DataFrame(
         {
@@ -84,7 +81,6 @@ def test_transpose_struct() -> None:
     assert_frame_equal(result, expected)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_transpose_arguments() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]})
     expected = pl.DataFrame(
@@ -139,7 +135,6 @@ def test_transpose_arguments() -> None:
     assert_frame_equal(expected, out)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_transpose_categorical_data() -> None:
     df = pl.DataFrame(
         [
@@ -160,7 +155,6 @@ def test_transpose_categorical_data() -> None:
     assert_frame_equal(df_transposed, expected)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_transpose_logical_data() -> None:
     df = pl.DataFrame(
         {
@@ -179,7 +173,6 @@ def test_transpose_logical_data() -> None:
     assert_frame_equal(result, expected)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_err_transpose_object() -> None:
     class CustomObject:
         pass
@@ -188,14 +181,12 @@ def test_err_transpose_object() -> None:
         pl.DataFrame([CustomObject()]).transpose()
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_transpose_name_from_column_13777() -> None:
     csv_file = io.BytesIO(b"id,kc\nhi,3")
     df = pl.read_csv(csv_file).transpose(column_names="id")
     assert_series_equal(df.to_series(0), pl.Series("hi", [3]))
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_transpose_multiple_chunks() -> None:
     df = pl.DataFrame({"a": ["1"]})
     expected = pl.DataFrame({"column_0": ["1"], "column_1": ["1"]})

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -776,7 +776,6 @@ def test_init_nested_tuple() -> None:
     assert s3.dtype == pl.List(pl.Int32)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_fill_null() -> None:
     s = pl.Series("a", [1, 2, None])
     assert_series_equal(s.fill_null(strategy="forward"), pl.Series("a", [1, 2, 2]))

--- a/py-polars/tests/unit/streaming/test_streaming_unique.py
+++ b/py-polars/tests/unit/streaming/test_streaming_unique.py
@@ -39,7 +39,6 @@ def test_streaming_out_of_core_unique(
     # assert "OOC group_by started" in err
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_streaming_unique() -> None:
     df = pl.DataFrame({"a": [1, 2, 2, 2], "b": [3, 4, 4, 4], "c": [5, 6, 7, 7]})
     q = df.lazy().unique(subset=["a", "c"], maintain_order=False).sort(["a", "b", "c"])

--- a/py-polars/tests/unit/test_datatypes.py
+++ b/py-polars/tests/unit/test_datatypes.py
@@ -138,7 +138,6 @@ def test_repr(dtype: PolarsDataType, representation: str) -> None:
     assert repr(dtype) == representation
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_conversion_dtype() -> None:
     df = (
         pl.DataFrame(


### PR DESCRIPTION
Various improvements (usually the Categorical rework) made this `may_fail_auto_streaming` markers unnecessary.