### PR TITLE
fix: Properly handle non-finite floats in rolling_sum/mean

### DIFF
--- a/crates/polars-compute/src/rolling/no_nulls/mean.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/mean.rs
@@ -18,7 +18,8 @@ where
         + Div<Output = T>
         + NumCast
         + Add<Output = T>
-        + Sub<Output = T>,
+        + Sub<Output = T>
+        + PartialOrd,
 {
     fn new(
         slice: &'a [T],

--- a/crates/polars-compute/src/rolling/no_nulls/sum.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/sum.rs
@@ -107,14 +107,12 @@ where
         self.last_end = end;
         if self.non_finite_count == 0 {
             NumCast::from(self.sum)
+        } else if self.non_finite_count == self.pos_inf_count {
+            Some(T::pos_inf_value())
+        } else if self.non_finite_count == self.neg_inf_count {
+            Some(T::neg_inf_value())
         } else {
-            if self.non_finite_count == self.pos_inf_count {
-                Some(T::pos_inf_value())
-            } else if self.non_finite_count == self.neg_inf_count {
-                Some(T::neg_inf_value())
-            } else {
-                Some(T::nan_value())
-            }
+            Some(T::nan_value())
         }
     }
 }

--- a/crates/polars-compute/src/rolling/no_nulls/sum.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/sum.rs
@@ -1,58 +1,39 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 use super::*;
 
-fn sum_kahan<
-    T: NativeType
-        + IsFloat
-        + std::iter::Sum
-        + AddAssign
-        + SubAssign
-        + Sub<Output = T>
-        + Add<Output = T>,
->(
-    vals: &[T],
-) -> (T, T) {
-    if T::is_float() {
-        let mut sum = T::zeroed();
-        let mut err = T::zeroed();
-
-        for val in vals.iter().copied() {
-            if val.is_finite() {
-                let y = val - err;
-                let new_sum = sum + y;
-                err = (new_sum - sum) - y;
-                sum = new_sum;
-            } else {
-                sum += val
-            }
-        }
-        (sum, err)
-    } else {
-        (vals.iter().copied().sum::<T>(), T::zeroed())
-    }
-}
-
 pub struct SumWindow<'a, T, S> {
     slice: &'a [T],
     sum: S,
     err: S,
+    non_finite_count: usize, // NaN or infinity.
+    pos_inf_count: usize,
+    neg_inf_count: usize,
     last_start: usize,
     last_end: usize,
 }
 
 impl<T, S> SumWindow<'_, T, S>
 where
-    T: NativeType + IsFloat + Sub<Output = T> + NumCast,
+    T: NativeType + IsFloat + Sub<Output = T> + NumCast + PartialOrd,
     S: NativeType + AddAssign + SubAssign + Sub<Output = S> + Add<Output = S> + NumCast,
 {
-    // Kahan summation
+    fn add_finite_kahan(&mut self, val: T) {
+        let val: S = NumCast::from(val).unwrap();
+        let y = val - self.err;
+        let new_sum = self.sum + y;
+        self.err = (new_sum - self.sum) - y;
+        self.sum = new_sum;
+    }
+
     fn add(&mut self, val: T) {
-        if T::is_float() && val.is_finite() {
-            let val: S = NumCast::from(val).unwrap();
-            let y = val - self.err;
-            let new_sum = self.sum + y;
-            self.err = (new_sum - self.sum) - y;
-            self.sum = new_sum;
+        if T::is_float() {
+            if val.is_finite() {
+                self.add_finite_kahan(val);
+            } else {
+                self.non_finite_count += 1;
+                self.pos_inf_count += (val > T::zeroed()) as usize;
+                self.neg_inf_count += (val < T::zeroed()) as usize;
+            }
         } else {
             let val: S = NumCast::from(val).unwrap();
             self.sum += val;
@@ -61,7 +42,13 @@ where
 
     fn sub(&mut self, val: T) {
         if T::is_float() {
-            self.add(T::zeroed() - val)
+            if val.is_finite() {
+                self.add_finite_kahan(T::zeroed() - val);
+            } else {
+                self.non_finite_count -= 1;
+                self.pos_inf_count -= (val > T::zeroed()) as usize;
+                self.neg_inf_count -= (val < T::zeroed()) as usize;
+            }
         } else {
             let val: S = NumCast::from(val).unwrap();
             self.sum -= val;
@@ -71,14 +58,7 @@ where
 
 impl<'a, T, S> RollingAggWindowNoNulls<'a, T> for SumWindow<'a, T, S>
 where
-    T: NativeType
-        + IsFloat
-        + Sub<Output = T>
-        + std::iter::Sum
-        + AddAssign
-        + SubAssign
-        + Add<Output = T>
-        + NumCast,
+    T: NativeType + IsFloat + Sub<Output = T> + NumCast + PartialOrd,
     S: NativeType + AddAssign + SubAssign + Sub<Output = S> + Add<Output = S> + NumCast,
 {
     fn new(
@@ -88,55 +68,54 @@ where
         _params: Option<RollingFnParams>,
         _window_size: Option<usize>,
     ) -> Self {
-        let (sum, err) = sum_kahan(&slice[start..end]);
-        Self {
+        let mut out = Self {
             slice,
-            sum: NumCast::from(sum).unwrap(),
-            err: NumCast::from(err).unwrap(),
-            last_start: start,
-            last_end: end,
-        }
+            sum: S::zeroed(),
+            err: S::zeroed(),
+            non_finite_count: 0,
+            pos_inf_count: 0,
+            neg_inf_count: 0,
+            last_start: 0,
+            last_end: 0,
+        };
+        unsafe { out.update(start, end) };
+        out
     }
 
+    // # Safety
+    // The start, end range must be in-bounds.
     unsafe fn update(&mut self, start: usize, end: usize) -> Option<T> {
-        // if we exceed the end, we have a completely new window
-        // so we recompute
-        let recompute_sum = if start >= self.last_end {
-            true
-        } else {
-            // remove elements that should leave the window
-            let mut recompute_sum = false;
-            for idx in self.last_start..start {
-                // SAFETY:
-                // we are in bounds
-                let leaving_value = self.slice.get_unchecked(idx);
+        if start >= self.last_end {
+            self.sum = S::zeroed();
+            self.err = S::zeroed();
+            self.non_finite_count = 0;
+            self.pos_inf_count = 0;
+            self.neg_inf_count = 0;
+            self.last_start = start;
+            self.last_end = start;
+        }
 
-                if T::is_float() && !leaving_value.is_finite() {
-                    recompute_sum = true;
-                    break;
-                }
+        for val in &self.slice[self.last_start..start] {
+            self.sub(*val);
+        }
 
-                self.sub(*leaving_value);
-            }
-            recompute_sum
-        };
+        for val in &self.slice[self.last_end..end] {
+            self.add(*val);
+        }
+
         self.last_start = start;
-
-        // we traverse all values and compute
-        if recompute_sum {
-            let vals = self.slice.get_unchecked(start..end);
-            let (sum, err) = sum_kahan(vals);
-            self.sum = NumCast::from(sum).unwrap();
-            self.err = NumCast::from(err).unwrap();
-        }
-        // add entering values.
-        else {
-            for idx in self.last_end..end {
-                self.add(*self.slice.get_unchecked(idx))
+        self.last_end = end;
+        if self.non_finite_count == 0 {
+            NumCast::from(self.sum)
+        } else {
+            if self.non_finite_count == self.pos_inf_count {
+                Some(T::pos_inf_value())
+            } else if self.non_finite_count == self.neg_inf_count {
+                Some(T::neg_inf_value())
+            } else {
+                Some(T::nan_value())
             }
         }
-        self.last_end = end;
-        NumCast::from(self.sum)
     }
 }
 
@@ -156,7 +135,8 @@ where
         + AddAssign
         + SubAssign
         + IsFloat
-        + Num,
+        + Num
+        + PartialOrd,
 {
     match (center, weights) {
         (true, None) => rolling_apply_agg_window::<SumWindow<T, T>, _, _>(

--- a/crates/polars-compute/src/rolling/nulls/mean.rs
+++ b/crates/polars-compute/src/rolling/nulls/mean.rs
@@ -14,7 +14,8 @@ impl<
         + NumCast
         + Div<Output = T>
         + AddAssign
-        + SubAssign,
+        + SubAssign
+        + PartialOrd,
 > RollingAggWindowNulls<'a, T> for MeanWindow<'a, T>
 {
     unsafe fn new(

--- a/crates/polars-compute/src/rolling/nulls/sum.rs
+++ b/crates/polars-compute/src/rolling/nulls/sum.rs
@@ -1,79 +1,66 @@
 #![allow(unsafe_op_in_unsafe_fn)]
-
 use super::*;
 
 pub struct SumWindow<'a, T, S> {
     slice: &'a [T],
     validity: &'a Bitmap,
-    sum: Option<S>,
+    sum: S,
     err: S,
+    non_finite_count: usize, // NaN or infinity.
+    pos_inf_count: usize,
+    neg_inf_count: usize,
+    pub(super) null_count: usize,
     last_start: usize,
     last_end: usize,
-    pub(super) null_count: usize,
 }
 
 impl<T, S> SumWindow<'_, T, S>
 where
-    T: NativeType + IsFloat + Sub<Output = T> + NumCast,
+    T: NativeType + IsFloat + Sub<Output = T> + NumCast + PartialOrd,
     S: NativeType + AddAssign + SubAssign + Sub<Output = S> + Add<Output = S> + NumCast,
 {
-    // Kahan summation
+    fn add_finite_kahan(&mut self, val: T) {
+        let val: S = NumCast::from(val).unwrap();
+        let y = val - self.err;
+        let new_sum = self.sum + y;
+        self.err = (new_sum - self.sum) - y;
+        self.sum = new_sum;
+    }
+
     fn add(&mut self, val: T) {
-        if T::is_float() && val.is_finite() {
-            self.sum = self.sum.map(|sum| {
-                let val: S = NumCast::from(val).unwrap();
-                let y = val - self.err;
-                let new_sum = sum + y;
-                self.err = (new_sum - sum) - y;
-                new_sum
-            });
+        if T::is_float() {
+            if val.is_finite() {
+                self.add_finite_kahan(val);
+            } else {
+                self.non_finite_count += 1;
+                self.pos_inf_count += (val > T::zeroed()) as usize;
+                self.neg_inf_count += (val < T::zeroed()) as usize;
+            }
         } else {
             let val: S = NumCast::from(val).unwrap();
-            self.sum = self.sum.map(|v| v + val)
+            self.sum += val;
         }
     }
 
     fn sub(&mut self, val: T) {
-        if T::is_float() && val.is_finite() {
-            self.add(T::zeroed() - val)
+        if T::is_float() {
+            if val.is_finite() {
+                self.add_finite_kahan(T::zeroed() - val);
+            } else {
+                self.non_finite_count -= 1;
+                self.pos_inf_count -= (val > T::zeroed()) as usize;
+                self.neg_inf_count -= (val < T::zeroed()) as usize;
+            }
         } else {
             let val: S = NumCast::from(val).unwrap();
-            self.sum = self.sum.map(|v| v - val)
+            self.sum -= val;
         }
-    }
-}
-
-impl<T, S> SumWindow<'_, T, S>
-where
-    T: NativeType + IsFloat + Sub<Output = T> + NumCast,
-    S: NativeType + AddAssign + SubAssign + Sub<Output = S> + Add<Output = S> + NumCast,
-{
-    // compute sum from the entire window
-    unsafe fn compute_sum_and_null_count(&mut self, start: usize, end: usize) -> Option<S> {
-        let mut sum = None;
-        let mut idx = start;
-        self.null_count = 0;
-        for value in &self.slice[start..end] {
-            let value: S = NumCast::from(*value).unwrap();
-            let valid = self.validity.get_bit_unchecked(idx);
-            if valid {
-                match sum {
-                    None => sum = Some(value),
-                    Some(current) => sum = Some(value + current),
-                }
-            } else {
-                self.null_count += 1;
-            }
-            idx += 1;
-        }
-        self.sum = sum;
-        sum
     }
 }
 
 impl<'a, T, S> RollingAggWindowNulls<'a, T> for SumWindow<'a, T, S>
 where
-    T: NativeType + IsFloat + Sub<Output = T> + NumCast,
+    T: NativeType + IsFloat + Sub<Output = T> + NumCast + PartialOrd,
     S: NativeType + AddAssign + SubAssign + Sub<Output = S> + Add<Output = S> + NumCast,
 {
     unsafe fn new(
@@ -87,75 +74,64 @@ where
         let mut out = Self {
             slice,
             validity,
-            sum: None,
+            sum: S::zeroed(),
             err: S::zeroed(),
-            last_start: start,
-            last_end: end,
+            non_finite_count: 0,
+            pos_inf_count: 0,
+            neg_inf_count: 0,
+            last_start: 0,
+            last_end: 0,
             null_count: 0,
         };
-        out.compute_sum_and_null_count(start, end);
+        out.update(start, end);
         out
     }
 
+    // # Safety
+    // The start, end range must be in-bounds.
     unsafe fn update(&mut self, start: usize, end: usize) -> Option<T> {
-        // if we exceed the end, we have a completely new window
-        // so we recompute
-        let recompute_sum = if start >= self.last_end {
-            true
-        } else {
-            // remove elements that should leave the window
-            let mut recompute_sum = false;
-            for idx in self.last_start..start {
-                // SAFETY:
-                // we are in bounds
-                let valid = self.validity.get_bit_unchecked(idx);
-                if valid {
-                    let leaving_value = self.slice.get_unchecked(idx);
+        if start >= self.last_end {
+            self.sum = S::zeroed();
+            self.err = S::zeroed();
+            self.non_finite_count = 0;
+            self.pos_inf_count = 0;
+            self.neg_inf_count = 0;
+            self.null_count = 0;
+            self.last_start = start;
+            self.last_end = start;
+        }
 
-                    // if the leaving value is nan we need to recompute the window
-                    if T::is_float() && !leaving_value.is_finite() {
-                        recompute_sum = true;
-                        break;
-                    }
-                    self.sub(*leaving_value);
-                } else {
-                    // null value leaving the window
-                    self.null_count -= 1;
-
-                    // self.sum is None and the leaving value is None
-                    // if the entering value is valid, we might get a new sum.
-                    if self.sum.is_none() {
-                        recompute_sum = true;
-                        break;
-                    }
-                }
-            }
-            recompute_sum
-        };
-
-        self.last_start = start;
-
-        // we traverse all values and compute
-        if recompute_sum {
-            self.compute_sum_and_null_count(start, end);
-        } else {
-            for idx in self.last_end..end {
-                let valid = self.validity.get_bit_unchecked(idx);
-
-                if valid {
-                    let value = *self.slice.get_unchecked(idx);
-                    match self.sum {
-                        None => self.sum = NumCast::from(value),
-                        _ => self.add(value),
-                    }
-                } else {
-                    // null value entering the window
-                    self.null_count += 1;
-                }
+        for idx in self.last_start..start {
+            let valid = self.validity.get_bit_unchecked(idx);
+            if valid {
+                self.sub(unsafe { *self.slice.get_unchecked(idx) });
+            } else {
+                self.null_count -= 1;
             }
         }
+
+        for idx in self.last_end..end {
+            let valid = self.validity.get_bit_unchecked(idx);
+            if valid {
+                self.add(unsafe { *self.slice.get_unchecked(idx) });
+            } else {
+                self.null_count += 1;
+            }
+        }
+
+        self.last_start = start;
         self.last_end = end;
-        self.sum.and_then(NumCast::from).or(Some(T::zeroed()))
+        if self.non_finite_count == 0 {
+            NumCast::from(self.sum)
+        } else {
+            if self.non_finite_count == self.pos_inf_count {
+                Some(T::pos_inf_value())
+            } else if self.non_finite_count == self.neg_inf_count {
+                Some(T::neg_inf_value())
+            } else {
+                Some(T::nan_value())
+            }
+        }
     }
 
     fn is_valid(&self, min_periods: usize) -> bool {

--- a/crates/polars-compute/src/rolling/nulls/sum.rs
+++ b/crates/polars-compute/src/rolling/nulls/sum.rs
@@ -123,14 +123,12 @@ where
         self.last_end = end;
         if self.non_finite_count == 0 {
             NumCast::from(self.sum)
+        } else if self.non_finite_count == self.pos_inf_count {
+            Some(T::pos_inf_value())
+        } else if self.non_finite_count == self.neg_inf_count {
+            Some(T::neg_inf_value())
         } else {
-            if self.non_finite_count == self.pos_inf_count {
-                Some(T::pos_inf_value())
-            } else if self.non_finite_count == self.neg_inf_count {
-                Some(T::neg_inf_value())
-            } else {
-                Some(T::nan_value())
-            }
+            Some(T::nan_value())
         }
     }
 

--- a/crates/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
@@ -238,7 +238,8 @@ where
         + SubAssign
         + IsFloat
         + Sub<Output = T>
-        + Add<Output = T>,
+        + Add<Output = T>
+        + PartialOrd,
 {
     let offset_iter = match tz {
         #[cfg(feature = "timezones")]

--- a/crates/polars-utils/src/float.rs
+++ b/crates/polars-utils/src/float.rs
@@ -17,6 +17,14 @@ pub unsafe trait IsFloat: private::Sealed + Sized {
         unimplemented!()
     }
 
+    fn pos_inf_value() -> Self {
+        unimplemented!()
+    }
+    
+    fn neg_inf_value() -> Self {
+        unimplemented!()
+    }
+
     #[allow(clippy::wrong_self_convention)]
     fn is_nan(&self) -> bool
     where
@@ -84,6 +92,14 @@ macro_rules! impl_is_float {
 
             fn nan_value() -> Self {
                 Self::NAN
+            }
+            
+            fn pos_inf_value() -> Self {
+                Self::INFINITY
+            }
+            
+            fn neg_inf_value() -> Self {
+                Self::NEG_INFINITY
             }
 
             #[inline]

--- a/crates/polars-utils/src/float.rs
+++ b/crates/polars-utils/src/float.rs
@@ -20,7 +20,7 @@ pub unsafe trait IsFloat: private::Sealed + Sized {
     fn pos_inf_value() -> Self {
         unimplemented!()
     }
-    
+
     fn neg_inf_value() -> Self {
         unimplemented!()
     }
@@ -93,11 +93,11 @@ macro_rules! impl_is_float {
             fn nan_value() -> Self {
                 Self::NAN
             }
-            
+
             fn pos_inf_value() -> Self {
                 Self::INFINITY
             }
-            
+
             fn neg_inf_value() -> Self {
                 Self::NEG_INFINITY
             }

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -1598,6 +1598,7 @@ def test_rolling_quantile_nearest_with_nulls_23932() -> None:
     assert_series_equal(out["a"], expected)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("with_nulls", [True, False])
 def test_rolling_sum_non_finite_23115(with_nulls: bool) -> None:
     values: list[float | None] = [

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -1596,3 +1596,25 @@ def test_rolling_quantile_nearest_with_nulls_23932() -> None:
     )
     expected = pl.Series("a", [None, None, 1.0, 2.0, 2.0, 3.0, 3.0])
     assert_series_equal(out["a"], expected)
+
+
+@pytest.mark.parametrize("with_nulls", [True, False])
+def test_rolling_sum_non_finite_23115(with_nulls: bool) -> None:
+    values: list[float | None] = [
+        0.0,
+        float("nan"),
+        float("inf"),
+        -float("inf"),
+        42.0,
+        -3.0,
+    ]
+    if with_nulls:
+        values.append(None)
+    data = random.choices(values, k=1000)
+    naive = [
+        sum(0 if x is None else x for x in data[max(0, i + 1 - 4) : i + 1])
+        if sum(x is not None for x in data[max(0, i + 1 - 4) : i + 1]) >= 2
+        else None
+        for i in range(1000)
+    ]
+    assert_series_equal(pl.Series(data).rolling_sum(4, min_samples=2), pl.Series(naive))


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/23115.

Replaced the rolling sum kernels with ones that properly keep track of the number of non-finite values in the window such that any combinations of infinities/nans get correctly handled without ever having to recompute the window (which is actually quadratic in the worst case, although it's never been reported as an issue).