### PR TITLE
refactor: Simpify arena iterators

### DIFF
--- a/crates/polars-lazy/src/tests/cse.rs
+++ b/crates/polars-lazy/src/tests/cse.rs
@@ -14,7 +14,7 @@ fn count_caches(q: LazyFrame) -> usize {
     let IRPlan {
         lp_top, lp_arena, ..
     } = q.to_alp_optimized().unwrap();
-    (&lp_arena)
+    lp_arena
         .iter(lp_top)
         .filter(|(_node, lp)| matches!(lp, IR::Cache { .. }))
         .count()
@@ -56,7 +56,7 @@ fn test_cse_unions() -> PolarsResult<()> {
     let (mut expr_arena, mut lp_arena) = get_arenas();
     let lp = lf.clone().optimize(&mut lp_arena, &mut expr_arena).unwrap();
     let mut cache_count = 0;
-    assert!((&lp_arena).iter(lp).all(|(_, lp)| {
+    assert!(lp_arena.iter(lp).all(|(_, lp)| {
         use IR::*;
         match lp {
             Cache { .. } => {
@@ -101,7 +101,7 @@ fn test_cse_cache_union_projection_pd() -> PolarsResult<()> {
     let (mut expr_arena, mut lp_arena) = get_arenas();
     let lp = q.optimize(&mut lp_arena, &mut expr_arena).unwrap();
     let mut cache_count = 0;
-    assert!((&lp_arena).iter(lp).all(|(_, lp)| {
+    assert!(lp_arena.iter(lp).all(|(_, lp)| {
         use IR::*;
         match lp {
             Cache { .. } => {
@@ -155,7 +155,7 @@ fn test_cse_union2_4925() -> PolarsResult<()> {
 
     // ensure we get two different caches
     // and ensure that every cache only has 1 hit.
-    let cache_ids = (&lp_arena)
+    let cache_ids = lp_arena
         .iter(lp)
         .flat_map(|(_, lp)| {
             use IR::*;
@@ -208,7 +208,7 @@ fn test_cse_joins_4954() -> PolarsResult<()> {
 
     // Ensure we get only one cache and it is not above the join
     // and ensure that every cache only has 1 hit.
-    let cache_ids = (&lp_arena)
+    let cache_ids = lp_arena
         .iter(lp)
         .flat_map(|(_, lp)| {
             use IR::*;
@@ -277,7 +277,7 @@ fn test_cache_with_partial_projection() -> PolarsResult<()> {
 
     // ensure we get two different caches
     // and ensure that every cache only has 1 hit.
-    let cache_ids = (&lp_arena)
+    let cache_ids = lp_arena
         .iter(lp)
         .flat_map(|(_, lp)| {
             use IR::*;

--- a/crates/polars-lazy/src/tests/io.rs
+++ b/crates/polars-lazy/src/tests/io.rs
@@ -399,7 +399,7 @@ fn test_scan_parquet_limit_9001() {
     let IRPlan {
         lp_top, lp_arena, ..
     } = q.to_alp_optimized().unwrap();
-    (&lp_arena).iter(lp_top).all(|(_, lp)| match lp {
+    lp_arena.iter(lp_top).all(|(_, lp)| match lp {
         IR::Union { options, .. } => {
             let sliced = options.slice.unwrap();
             sliced.1 == 3
@@ -439,7 +439,7 @@ fn test_ipc_globbing() -> PolarsResult<()> {
 }
 
 fn slice_at_union(lp_arena: &Arena<IR>, lp: Node) -> bool {
-    (&lp_arena).iter(lp).all(|(_, lp)| {
+    lp_arena.iter(lp).all(|(_, lp)| {
         if let IR::Union { options, .. } = lp {
             options.slice.is_some()
         } else {

--- a/crates/polars-lazy/src/tests/pdsh.rs
+++ b/crates/polars-lazy/src/tests/pdsh.rs
@@ -94,7 +94,7 @@ fn test_q2() -> PolarsResult<()> {
         lp_top, lp_arena, ..
     } = q.clone().to_alp_optimized().unwrap();
     assert_eq!(
-        (&lp_arena)
+        lp_arena
             .iter(lp_top)
             .filter(|(_, alp)| matches!(alp, IR::Cache { .. }))
             .count(),

--- a/crates/polars-lazy/src/tests/predicate_queries.rs
+++ b/crates/polars-lazy/src/tests/predicate_queries.rs
@@ -18,7 +18,7 @@ fn test_multiple_roots() -> PolarsResult<()> {
     assert!(predicate_at_scan(lf));
     // and that we don't have any filter node
     assert!(
-        !(&lp_arena)
+        !lp_arena
             .iter(root)
             .any(|(_, lp)| matches!(lp, IR::Filter { .. }))
     );

--- a/crates/polars-lazy/src/tests/projection_queries.rs
+++ b/crates/polars-lazy/src/tests/projection_queries.rs
@@ -166,7 +166,7 @@ fn test_coalesce_toggle_projection_pushdown() -> PolarsResult<()> {
     let node = plan.lp_top;
     let lp_arena = plan.lp_arena;
 
-    assert!((&lp_arena).iter(node).all(|(_, plan)| match plan {
+    assert!(lp_arena.iter(node).all(|(_, plan)| match plan {
         IR::Join { options, .. } => options.args.should_coalesce(),
         _ => true,
     }));

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -677,7 +677,7 @@ fn create_physical_plan_impl(
             // We first check if we can partition the group_by on the latest moment.
             let partitionable = partitionable_gb(&keys, &aggs, &input_schema, expr_arena, &apply);
             if partitionable {
-                let from_partitioned_ds = (&*lp_arena).iter(input).any(|(_, lp)| {
+                let from_partitioned_ds = lp_arena.iter(input).any(|(_, lp)| {
                     if let Union { options, .. } = lp {
                         options.from_partitioned_ds
                     } else {

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_to_ir.rs
@@ -370,7 +370,7 @@ pub(super) fn to_aexpr_impl(
 
             match variant {
                 EvalVariant::List => {
-                    for (_, e) in ArenaExprIter::iter(&&*ctx.arena, evaluation) {
+                    for (_, e) in ArenaExprIter::iter(ctx.arena, evaluation) {
                         if let AExpr::Column(name) = e {
                             polars_ensure!(
                                 name.is_empty(),
@@ -400,7 +400,7 @@ pub(super) fn to_aexpr_impl(
         Expr::Len => (AExpr::Len, get_len_name()),
         Expr::KeepName(expr) => {
             let (expr, _) = to_aexpr_impl(owned(expr), ctx)?;
-            let name = ArenaExprIter::iter(&&*ctx.arena, expr).find_map(|e| match e.1 {
+            let name = ArenaExprIter::iter(ctx.arena, expr).find_map(|e| match e.1 {
                 AExpr::Column(name) => Some(name.clone()),
                 #[cfg(feature = "dtype-struct")]
                 AExpr::Function {

--- a/crates/polars-plan/src/plans/iterator.rs
+++ b/crates/polars-plan/src/plans/iterator.rs
@@ -189,11 +189,11 @@ impl<'a> Iterator for AExprIter<'a> {
 }
 
 pub trait ArenaExprIter<'a> {
-    fn iter(&self, root: Node) -> AExprIter<'a>;
+    fn iter(&'a self, root: Node) -> AExprIter<'a>;
 }
 
-impl<'a> ArenaExprIter<'a> for &'a Arena<AExpr> {
-    fn iter(&self, root: Node) -> AExprIter<'a> {
+impl<'a> ArenaExprIter<'a> for Arena<AExpr> {
+    fn iter(&'a self, root: Node) -> AExprIter<'a> {
         let stack = unitvec![root];
         AExprIter {
             stack,
@@ -208,11 +208,11 @@ pub struct AlpIter<'a> {
 }
 
 pub trait ArenaLpIter<'a> {
-    fn iter(&self, root: Node) -> AlpIter<'a>;
+    fn iter(&'a self, root: Node) -> AlpIter<'a>;
 }
 
-impl<'a> ArenaLpIter<'a> for &'a Arena<IR> {
-    fn iter(&self, root: Node) -> AlpIter<'a> {
+impl<'a> ArenaLpIter<'a> for Arena<IR> {
+    fn iter(&'a self, root: Node) -> AlpIter<'a> {
         let stack = unitvec![root];
         AlpIter { stack, arena: self }
     }

--- a/crates/polars-plan/src/plans/optimizer/delay_rechunk.rs
+++ b/crates/polars-plan/src/plans/optimizer/delay_rechunk.rs
@@ -31,7 +31,7 @@ impl OptimizationRule for DelayRechunk {
 
                 use IR::*;
                 let mut input_node = None;
-                for (node, lp) in (&*lp_arena).iter(*input) {
+                for (node, lp) in lp_arena.iter(*input) {
                     match lp {
                         Scan { .. } => {
                             input_node = Some(node);


### PR DESCRIPTION
Although this changes the public API, the existing  `ArenaLpIter` user code should still compile, just with `clippy::needless_borrow` warnings. The existing `ArenaExprIter::iter` user calls might need fixing.