### PR TITLE
feat: IR pruning

### DIFF
--- a/crates/polars-plan/src/plans/mod.rs
+++ b/crates/polars-plan/src/plans/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod options;
 pub mod python;
 #[cfg(feature = "python")]
 pub use python::*;
+pub mod prune;
 mod schema;
 pub mod visitor;
 

--- a/crates/polars-plan/src/plans/prune.rs
+++ b/crates/polars-plan/src/plans/prune.rs
@@ -1,0 +1,422 @@
+//! IR pruning. Pruning copies the reachable IR and expressions into a set of destination arenas.
+
+use polars_core::prelude::{InitHashMaps as _, PlHashMap};
+use polars_utils::arena::{Arena, Node};
+use polars_utils::unique_id::UniqueId;
+use recursive::recursive;
+
+use crate::plans::{AExpr, IR, IRPlan, IRPlanRef};
+
+/// Returns a pruned copy of this plan with new arenas (without unreachable nodes).
+///
+/// The cache hit count is updated based on the number of consumers in the pruned plan.
+///
+/// The original plan and arenas are not modified.
+pub fn prune_plan(ir_plan: IRPlanRef<'_>) -> IRPlan {
+    let mut ir_arena = Arena::new();
+    let mut expr_arena = Arena::new();
+    let [root] = prune(
+        &[ir_plan.lp_top],
+        ir_plan.lp_arena,
+        ir_plan.expr_arena,
+        &mut ir_arena,
+        &mut expr_arena,
+    )
+    .try_into()
+    .unwrap();
+    IRPlan {
+        lp_top: root,
+        lp_arena: ir_arena,
+        expr_arena,
+    }
+}
+
+/// Prunes a subgraph reachable from the supplied nodes into the supplied arenas.
+///
+/// The returned nodes point to the pruned copies of the supplied nodes in the same order.
+///
+/// The cache hit count is updated based on the number of consumers in the pruned subgraph.
+///
+/// The original plan and arenas are not modified.
+pub fn prune(
+    nodes: &[Node],
+    src_ir: &Arena<IR>,
+    src_expr: &Arena<AExpr>,
+    dst_ir: &mut Arena<IR>,
+    dst_expr: &mut Arena<AExpr>,
+) -> Vec<Node> {
+    let mut ctx = CopyContext {
+        src_ir,
+        src_expr,
+        dst_ir,
+        dst_expr,
+        dst_caches: PlHashMap::new(),
+        roots: PlHashMap::from_iter(nodes.iter().map(|node| (*node, None))),
+    };
+
+    let dst_nodes: Vec<Node> = nodes.iter().map(|&root| ctx.copy_ir(root)).collect();
+
+    assert!(ctx.roots.values().all(|v| v.is_some()));
+
+    for (_, cache_node) in ctx.dst_caches {
+        // Any root nodes that directly point to this cache will be included in the cache hits.
+        // Subtract them, so that the number of hits is equal to the number of consumers in the
+        // pruned subgraph, minus one (this is a cache thing).
+        let count = dst_nodes.iter().filter(|&&n| n == cache_node).count();
+        let IR::Cache { cache_hits, .. } = ctx.dst_ir.get_mut(cache_node) else {
+            unreachable!();
+        };
+        *cache_hits = cache_hits.saturating_sub(count as u32);
+    }
+
+    dst_nodes
+}
+
+struct CopyContext<'a> {
+    src_ir: &'a Arena<IR>,
+    src_expr: &'a Arena<AExpr>,
+    dst_ir: &'a mut Arena<IR>,
+    dst_expr: &'a mut Arena<AExpr>,
+    // Caches and the matching dst nodes.
+    dst_caches: PlHashMap<UniqueId, Node>,
+    // Root nodes and the matching dst nodes. Needed to ensure they are visited only once,
+    // in case they are reachable from other root nodes.
+    roots: PlHashMap<Node, Option<Node>>,
+}
+
+impl<'a> CopyContext<'a> {
+    // Copies the IR subgraph from src to dst.
+    #[recursive]
+    fn copy_ir(&mut self, src_node: Node) -> Node {
+        // If this cache was already visited, bump the cache hits and don't traverse it.
+        // This is before the root node check, so that the hit count gets bumped for every visit.
+        if let IR::Cache { id, .. } = self.src_ir.get(src_node) {
+            if let Some(cache) = self.dst_caches.get(id) {
+                let IR::Cache { cache_hits, .. } = self.dst_ir.get_mut(*cache) else {
+                    unreachable!()
+                };
+                *cache_hits += 1;
+                return *cache;
+            }
+        }
+
+        // If this is one of the root nodes and was already visited, don't visit again, just return
+        // the matching dst node. This is useful for tracking IR nodes across copying.
+        if let Some(&Some(root_node)) = self.roots.get(&src_node) {
+            return root_node;
+        }
+
+        let src_ir = self.src_ir.get(src_node);
+
+        // Recurse into inputs
+        let mut inputs = src_ir.get_inputs_vec();
+        for input in &mut inputs {
+            *input = self.copy_ir(*input);
+        }
+
+        // Recurse into expressions
+        let mut exprs = src_ir.get_exprs();
+        for expr in &mut exprs {
+            expr.set_node(self.copy_expr(expr.node()));
+        }
+
+        // Copy this node
+        let dst_ir = src_ir.with_exprs_and_input(exprs, inputs);
+        let dst_node = self.dst_ir.add(dst_ir);
+
+        // If this is a cache, reset the hit count and store the dst node.
+        if let IR::Cache { cache_hits, id, .. } = self.dst_ir.get_mut(dst_node) {
+            *cache_hits = 0;
+            let prev = self.dst_caches.insert(id.clone(), dst_node);
+            assert!(prev.is_none(), "cache {id} was traversed twice");
+        }
+
+        // If this is one of the root nodes, store the dst node.
+        self.roots.entry(src_node).and_modify(|e| {
+            assert!(
+                e.replace(dst_node).is_none(),
+                "root node was traversed twice"
+            )
+        });
+
+        dst_node
+    }
+
+    /// Copies the expression subgraph from src to dst.
+    #[recursive]
+    fn copy_expr(&mut self, node: Node) -> Node {
+        let expr = self.src_expr.get(node);
+
+        let mut inputs = vec![];
+        expr.inputs_rev(&mut inputs);
+
+        for input in &mut inputs {
+            *input = self.copy_expr(*input);
+        }
+        inputs.reverse();
+
+        self.dst_expr.add(expr.clone().replace_inputs(&inputs))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use polars_core::prelude::*;
+
+    use super::*;
+    use crate::dsl::{SinkTypeIR, col, lit};
+    use crate::plans::{ArenaLpIter as _, to_expr_ir};
+
+    //           SINK[right]
+    //               |
+    // SINK[left]   SORT   SINK[extra]
+    //     |        /        /
+    //   CACHE ----+--------+
+    //     |
+    //  FILTER
+    //     |
+    //   SCAN
+    struct BranchedPlan {
+        ir_arena: Arena<IR>,
+        expr_arena: Arena<AExpr>,
+        scan: Node,
+        filter: Node,
+        cache: Node,
+        left_sink: Node,
+        sort: Node,
+        right_sink: Node,
+        extra_sink: Node,
+    }
+
+    #[test]
+    fn test_pruned_subgraph_matches() {
+        let p = BranchedPlan::new();
+
+        #[rustfmt::skip]
+        let cases: &[&[Node]] = &[
+            // Single
+            &[p.scan],
+            &[p.cache],
+            &[p.left_sink],
+            &[p.right_sink],
+            // Multiple
+            &[p.left_sink, p.right_sink],
+            &[p.left_sink, p.right_sink, p.extra_sink],
+            // Duplicate
+            &[p.left_sink, p.left_sink],
+            &[p.cache, p.cache],
+            // A mess
+            &[p.filter, p.scan, p.left_sink, p.cache, p.right_sink, p.sort, p.cache, p.right_sink],
+        ];
+
+        for &case in cases.iter() {
+            let (pruned, arenas) = p.prune(case);
+            for (&orig, pruned) in case.iter().zip(pruned) {
+                let orig_plan = p.plan(orig);
+                let pruned_plan = arenas.plan(pruned);
+                assert!(
+                    plans_equal(orig_plan, pruned_plan),
+                    "orig: {}, pruned: {}",
+                    orig_plan.display(),
+                    pruned_plan.display()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_pruned_arena_size() {
+        let p = BranchedPlan::new();
+
+        #[rustfmt::skip]
+        let cases: &[(&[Node], usize)] = &[
+            (&[p.scan], 1),
+            (&[p.cache], 3),
+            (&[p.cache, p.cache], 3),
+            (&[p.left_sink], 4),
+            (&[p.left_sink, p.left_sink], 4),
+            (&[p.right_sink], 5),
+            (&[p.left_sink, p.right_sink], 6),
+            (&[p.filter, p.scan, p.left_sink, p.cache, p.right_sink, p.sort, p.cache, p.right_sink], 6),
+            (&[p.left_sink, p.right_sink, p.extra_sink], 7),
+        ];
+
+        for (i, &(case, expected_arena_size)) in cases.iter().enumerate() {
+            let (_, arenas) = p.prune(case);
+            assert_eq!(
+                arenas.ir.len(),
+                expected_arena_size,
+                "case: {i}, pruned_ir: {:?}",
+                arenas.ir
+            );
+        }
+    }
+
+    #[test]
+    fn test_pruned_cache_hit_count() {
+        let p = BranchedPlan::new();
+
+        #[rustfmt::skip]
+        let cases: &[(&[Node], u32)] = &[
+            (&[p.cache], 0),
+            (&[p.left_sink], 0),
+            (&[p.left_sink, p.right_sink], 1),
+            (&[p.left_sink, p.right_sink, p.extra_sink], 2),
+            (&[p.cache, p.cache], 0),
+            (&[p.left_sink, p.left_sink], 0),
+            (&[p.left_sink, p.cache], 0),
+            (&[p.cache, p.left_sink], 0),
+            (&[p.cache, p.left_sink, p.right_sink], 1),
+            (&[p.left_sink, p.cache, p.right_sink], 1),
+            (&[p.left_sink, p.right_sink, p.cache], 1),
+            (&[p.left_sink, p.right_sink, p.left_sink], 1),
+            (&[p.left_sink, p.cache, p.left_sink, p.right_sink, p.cache], 1),
+            (&[p.cache, p.left_sink, p.cache, p.right_sink], 1),
+        ];
+
+        for (i, &(nodes, expected_cache_hits)) in cases.iter().enumerate() {
+            let (pruned, arenas) = p.prune(nodes);
+            assert_eq!(
+                cache_hits(arenas.plan(pruned[0])).unwrap(),
+                expected_cache_hits,
+                "test case {i}"
+            );
+        }
+
+        /// Returns cache hits of the first reachable cache node
+        fn cache_hits(plan: IRPlanRef<'_>) -> Option<u32> {
+            for (_, ir) in plan.lp_arena.iter(plan.lp_top) {
+                if let &IR::Cache { cache_hits, .. } = ir {
+                    return Some(cache_hits);
+                }
+            }
+            None
+        }
+    }
+
+    fn plans_equal(a: IRPlanRef<'_>, b: IRPlanRef<'_>) -> bool {
+        let iter_a = a.lp_arena.iter(a.lp_top);
+        let iter_b = b.lp_arena.iter(b.lp_top);
+        for ((_, ir_a), (_, ir_b)) in iter_a.zip(iter_b) {
+            if std::mem::discriminant(ir_a) != std::mem::discriminant(ir_b)
+                || !exprs_equal(ir_a, a.expr_arena, ir_b, b.expr_arena)
+            {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn exprs_equal(ir_a: &IR, arena_a: &Arena<AExpr>, ir_b: &IR, arena_b: &Arena<AExpr>) -> bool {
+        let [a, b] = [(ir_a, arena_a), (ir_b, arena_b)].map(|(ir, arena)| {
+            ir.get_exprs()
+                .into_iter()
+                .map(|e| (e.output_name_inner().clone(), e.to_expr(arena)))
+        });
+        a.eq(b)
+    }
+
+    impl BranchedPlan {
+        pub fn new() -> Self {
+            let mut ir_arena = Arena::new();
+            let mut expr_arena = Arena::new();
+            let schema = Schema::from_iter([Field::new("a".into(), DataType::UInt8)]);
+
+            let scan = ir_arena.add(IR::DataFrameScan {
+                df: Arc::new(DataFrame::empty_with_schema(&schema)),
+                schema: Arc::new(schema.clone()),
+                output_schema: None,
+            });
+
+            let filter = ir_arena.add(IR::Filter {
+                input: scan,
+                predicate: to_expr_ir(col("a").gt_eq(lit(10)), &mut expr_arena, &schema).unwrap(),
+            });
+
+            // Throw in an unreachable node
+            ir_arena.add(IR::Invalid);
+
+            let cache = ir_arena.add(IR::Cache {
+                input: filter,
+                id: UniqueId::Plain(0),
+                cache_hits: 1,
+            });
+
+            let left_sink = ir_arena.add(IR::Sink {
+                input: cache,
+                payload: SinkTypeIR::Memory,
+            });
+
+            // Throw in an unreachable node
+            ir_arena.add(IR::Invalid);
+
+            let sort = ir_arena.add(IR::Sort {
+                input: cache,
+                by_column: vec![to_expr_ir(col("a"), &mut expr_arena, &schema).unwrap()],
+                slice: None,
+                sort_options: Default::default(),
+            });
+
+            let right_sink = ir_arena.add(IR::Sink {
+                input: sort,
+                payload: SinkTypeIR::Memory,
+            });
+
+            // Throw in an unused sink
+            let extra_sink = ir_arena.add(IR::Sink {
+                input: cache,
+                payload: SinkTypeIR::Memory,
+            });
+
+            Self {
+                ir_arena,
+                expr_arena,
+                scan,
+                filter,
+                cache,
+                left_sink,
+                sort,
+                right_sink,
+                extra_sink,
+            }
+        }
+
+        pub fn prune(&self, nodes: &[Node]) -> (Vec<Node>, Arenas) {
+            let mut arenas = Arenas {
+                ir: Arena::new(),
+                expr: Arena::new(),
+            };
+            let pruned = prune(
+                nodes,
+                &self.ir_arena,
+                &self.expr_arena,
+                &mut arenas.ir,
+                &mut arenas.expr,
+            );
+            (pruned, arenas)
+        }
+
+        pub fn plan(&'_ self, node: Node) -> IRPlanRef<'_> {
+            IRPlanRef {
+                lp_top: node,
+                lp_arena: &self.ir_arena,
+                expr_arena: &self.expr_arena,
+            }
+        }
+    }
+
+    struct Arenas {
+        ir: Arena<IR>,
+        expr: Arena<AExpr>,
+    }
+
+    impl Arenas {
+        pub fn plan(&'_ self, root: Node) -> IRPlanRef<'_> {
+            IRPlanRef {
+                lp_top: root,
+                lp_arena: &self.ir,
+                expr_arena: &self.expr,
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a prune function that can copy the reachable IR and expressions into another set of arenas. The cache hit count is updated.

`prune_plan` is a convenience for simple plans. `prune` is much more powerful and allows multiple roots and keeping track of interior nodes across pruning.