### PR TITLE
docs: Fix a few typos in the "Streaming" section

### DIFF
--- a/docs/source/user-guide/concepts/streaming.md
+++ b/docs/source/user-guide/concepts/streaming.md
@@ -5,18 +5,18 @@
 One additional benefit of the lazy API is that it allows queries to be executed in a streaming
 manner. Instead of processing all the data at once, Polars can execute the query in batches allowing
 you to process datasets that do not fit in memory. Besides memory pressure, the streaming engine
-also is more performant than Polar's in-memory engine.
+also is more performant than Polars' in-memory engine.
 
 To tell Polars we want to execute a query in streaming mode we pass the `engine="streaming"`
-argument to `collect`
+argument to `collect`:
 
 {{code_block('user-guide/concepts/streaming','streaming',['collect'])}}
 
 ## Inspecting a streaming query
 
-Polars can run many operations in a streaming manner. Some operation are inherently non-streaming,
+Polars can run many operations in a streaming manner. Some operations are inherently non-streaming,
 or are not implemented in a streaming manner (yet). In the latter case, Polars will fall back to the
-in-memory engine for that operation. A user doesn't have to know about this, but it can be
+in-memory engine for those operations. A user doesn't have to know about this, but it can be
 interesting for debugging memory or performance issues.
 
 To inspect the physical plan of streaming query, you can plot the physical graph. The legend shows


### PR DESCRIPTION
Side note: I don't see the new "Streaming" page on the user guide. In the search bar, typing "streaming" leads to the old https://docs.pola.rs/user-guide/concepts/_streaming/ (note the "_streaming" instead of "streaming" in the URL).