### PR TITLE
Fix/sample shuffle behavior

### DIFF
--- a/crates/polars-core/src/chunked_array/random.rs
+++ b/crates/polars-core/src/chunked_array/random.rs
@@ -302,3 +302,93 @@ impl BooleanChunked {
         Ok(builder.finish())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_sample() {
+        let df = df![
+            "foo" => &[1, 2, 3, 4, 5]
+        ]
+        .unwrap();
+
+        // Default samples are random and don't require seeds.
+        assert!(
+            df.sample_n(
+                &Series::new(PlSmallStr::from_static("s"), &[3]),
+                false,
+                false,
+                None
+            )
+            .is_ok()
+        );
+        assert!(
+            df.sample_frac(
+                &Series::new(PlSmallStr::from_static("frac"), &[0.4]),
+                false,
+                false,
+                None
+            )
+            .is_ok()
+        );
+        // With seeding.
+        assert!(
+            df.sample_n(
+                &Series::new(PlSmallStr::from_static("s"), &[3]),
+                false,
+                false,
+                Some(0)
+            )
+            .is_ok()
+        );
+        assert!(
+            df.sample_frac(
+                &Series::new(PlSmallStr::from_static("frac"), &[0.4]),
+                false,
+                false,
+                Some(0)
+            )
+            .is_ok()
+        );
+        // Without replacement can not sample more than 100%.
+        assert!(
+            df.sample_frac(
+                &Series::new(PlSmallStr::from_static("frac"), &[2.0]),
+                false,
+                false,
+                Some(0)
+            )
+            .is_err()
+        );
+        assert!(
+            df.sample_n(
+                &Series::new(PlSmallStr::from_static("s"), &[3]),
+                true,
+                false,
+                Some(0)
+            )
+            .is_ok()
+        );
+        assert!(
+            df.sample_frac(
+                &Series::new(PlSmallStr::from_static("frac"), &[0.4]),
+                true,
+                false,
+                Some(0)
+            )
+            .is_ok()
+        );
+        // With replacement can sample more than 100%.
+        assert!(
+            df.sample_frac(
+                &Series::new(PlSmallStr::from_static("frac"), &[2.0]),
+                true,
+                false,
+                Some(0)
+            )
+            .is_ok()
+        );
+    }
+}

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -386,12 +386,12 @@ def test_list_drop_nulls() -> None:
 def test_list_sample() -> None:
     s = pl.Series("values", [[1, 2, 3, None], [None, None], [1, 2], None])
 
-    expected_sample_n = pl.Series("values", [[None, 3], [None], [2], None])
+    expected_sample_n = pl.Series("values", [[1, 2], [None], [1], None])
     assert_series_equal(
         s.list.sample(n=pl.Series([2, 1, 1, 1]), seed=1), expected_sample_n
     )
 
-    expected_sample_frac = pl.Series("values", [[None, 3], [None], [1, 2], None])
+    expected_sample_frac = pl.Series("values", [[1, 2], [None], [1, 2], None])
     assert_series_equal(
         s.list.sample(fraction=pl.Series([0.5, 0.5, 1.0, 0.3]), seed=1),
         expected_sample_frac,
@@ -410,8 +410,8 @@ def test_list_sample() -> None:
     )
     expected_df = pl.DataFrame(
         {
-            "sample_n": [[None, 3], [None], [3, 4]],
-            "sample_frac": [[None, 3], [None], [3, 4]],
+            "sample_n": [[1, 2], [None], [3, 4]],
+            "sample_frac": [[1, 2], [None], [3, 4]],
         }
     )
     assert_frame_equal(df, expected_df)

--- a/py-polars/tests/unit/operations/test_random.py
+++ b/py-polars/tests/unit/operations/test_random.py
@@ -35,7 +35,9 @@ def test_sample_expr() -> None:
     assert out.unique().shape == (10,)
     assert set(out).issubset(set(a))
 
-    out = pl.select(pl.lit(a).sample(n=10, with_replacement=False, shuffle=True, seed=1)).to_series()
+    out = pl.select(
+        pl.lit(a).sample(n=10, with_replacement=False, shuffle=True, seed=1)
+    ).to_series()
     assert out.shape == (10,)
     assert out.to_list() != out.sort().to_list()
     assert out.unique().shape == (10,)
@@ -115,12 +117,16 @@ def test_sample_series() -> None:
     # unless you use with_replacement=True
     assert len(s.sample(n=10, with_replacement=True, seed=0)) == 10
 
+
 def test_sample_order_shuffle_false() -> None:
     df = pl.DataFrame({"a": [1, 2, 3, 4]})
     n = 3
     for i in range(10):
         out = df.sample(n=n, shuffle=False, seed=i)
-        assert out["a"].to_list() == [1, 2, 3], f"shuffle=False should preserve order, got {out['a'].to_list()}"
+        assert out["a"].to_list() == [1, 2, 3], (
+            f"shuffle=False should preserve order, got {out['a'].to_list()}"
+        )
+
 
 def test_sample_order_shuffle_true() -> None:
     df = pl.DataFrame({"a": [1, 2, 3, 4]})
@@ -130,6 +136,7 @@ def test_sample_order_shuffle_true() -> None:
         out = df.sample(n=n, shuffle=True, seed=i)
         seen.add(tuple(out["a"].to_list()))
     assert len(seen) > 1, "shuffle=True should produce different orderings"
+
 
 def test_shuffle_expr() -> None:
     # pl.set_random_seed should lead to reproducible results.


### PR DESCRIPTION
Fixes: #23537
Fixes: #13685

Now, if shuffle is false, we will always return the first n rows.