### PR TITLE
fix: Correctly handle null values when comparing structs

### DIFF
--- a/crates/polars-core/src/chunked_array/comparison/mod.rs
+++ b/crates/polars-core/src/chunked_array/comparison/mod.rs
@@ -842,8 +842,8 @@ where
 
             let mut a = a.into_owned();
             a.zip_outer_validity(&b);
-            let mut new_null_count = 0;
             unsafe {
+                let mut new_null_count = 0;
                 for (arr, a) in out.downcast_iter_mut().zip(a.downcast_iter()) {
                     arr.set_validity(a.validity().cloned());
                     new_null_count += arr.null_count();

--- a/crates/polars-core/src/chunked_array/comparison/mod.rs
+++ b/crates/polars-core/src/chunked_array/comparison/mod.rs
@@ -842,10 +842,13 @@ where
 
             let mut a = a.into_owned();
             a.zip_outer_validity(&b);
+            let mut new_null_count = 0;
             unsafe {
                 for (arr, a) in out.downcast_iter_mut().zip(a.downcast_iter()) {
-                    arr.set_validity(a.validity().cloned())
+                    arr.set_validity(a.validity().cloned());
+                    new_null_count += arr.null_count();
                 }
+                out.set_null_count(new_null_count);
             }
         }
 

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -1282,3 +1282,13 @@ def test_struct_cast_string_multiple_chunks_21650() -> None:
     result = df.select(pl.col("a").cast(pl.String))
     expected = pl.DataFrame({"a": ["{1,2}", "{1,2}"]})
     assert_frame_equal(result, expected)
+
+
+def test_struct_nulls_in_equality_23527() -> None:
+    df = pl.DataFrame({"a": [False, False, False, None, True, True]})
+    df_struct = df.with_columns(pl.struct(["a"]).alias("a"))
+    out = df_struct.with_columns(
+        (pl.col("a") == pl.col("a").shift(1)).fill_null(False).alias("a")
+    )
+    expected = pl.DataFrame({"a": [False, True, True, False, False, True]})
+    assert_frame_equal(out, expected)


### PR DESCRIPTION
fixes #23527

Kindly review. 