### PR TITLE
fix(rust): Panic in `create_multiple_physical_plans` when branching from a single cache node

### DIFF
--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -231,8 +231,9 @@ fn create_physical_plan_impl(
     let logical_plan = if state.has_cache_parent
         || matches!(
             lp_arena.get(root),
-            IR::Scan { .. }
-                | IR::Sink {
+            IR::Scan { .. } // Needed for the streaming impl
+                | IR::Cache { .. } // Needed for plans branching from the same cache node
+                | IR::Sink { // Needed for the streaming impl
                     payload: SinkTypeIR::Partition(_),
                     ..
                 }


### PR DESCRIPTION
During planning, the nodes are removed when encountered, however when the plan branches from a single cache node, the cache needs to stay present, otherwise other branches will run into the removed cache node (now `Invalid`) and panic.