### PR TITLE
fix: Update AWS cloud documentation

### DIFF
--- a/docs/source/polars-cloud/providers/aws/infra.md
+++ b/docs/source/polars-cloud/providers/aws/infra.md
@@ -3,17 +3,17 @@
 Polars Cloud manages the hardware for you by spinning up and down raw EC2 instances. In order to do
 this it needs permissions in your own cloud environment. None of the resources below have costs
 associated with them. While no compute clusters are running Polars Cloud will not create any AWS
-costs. The recommended way of doing this is running `pc workspace setup`.
+costs. The recommended way of doing this is running `pc setup`.
 
 ## Recommended setup
 
 When you deploy Polars Cloud the following infrastructure is setup.
 
 <figure markdown="span">
-![AWS infrastructure](https://raw.githubusercontent.com/pola-rs/polars-static/refs/heads/master/polars_cloud/aws-infra.png)
+![AWS infrastructure](https://raw.githubusercontent.com/pola-rs/polars-static/refs/heads/master/polars_cloud/aws-architecture.png)
 </figure>
 
-1. A `VPC` and `subnet` in which Polars EC2 workers can run.
+1. A `VPC` and two `subnets` in which Polars EC2 workers can run.
 1. Two `security groups`. One for batch mode, which does not have any public ports, and one for
    interactive mode, which allows direct communication between your local environment and the
    cluster.
@@ -54,18 +54,32 @@ The list below show an overview of the required permissions for each of the role
     - ec2:DeleteFleets
     - sts:GetCallerIdentity
     - sts:TagSession
-    - cloudwatch:GetMetricData
-    - logs:GetLogEvents
-    - logs:FilterLogEvents
-    - logs:DescribeLogStreams
 
 ??? Worker
 
-    - logs:CreateLogGroup 
-    - logs:PutRetentionPolicy 
-    - cloudwatch:PutMetricData
+    - s3:PutObject 
+    - s3:GetObject
+    - s3:ListBucket
 
-## Custom setup
+The permissions of the worker role and S3 access can be scoped to certain buckets, by adjusting the
+role within AWS.
+
+## Bring your own network
+
+<figure markdown="span">
+![AWS Bring your own Network](https://raw.githubusercontent.com/pola-rs/polars-static/refs/heads/master/polars_cloud/connect-cloud/workspace-bring-your-own-network.png)
+</figure>
+
+By default, Polars Cloud is deployed within its own dedicated network (including VPC, subnets, and
+related resources). However, you can choose to use your own network configuration by selecting the
+"Deploy with custom template" option. This allows you to deploy into an existing VPC and subnets of
+your choice.
+
+You can configure these subnets to align with your business requirements. For batch mode, outbound
+traffic must be allowed. For interactive mode, the Python client accessing Polars Cloud must have
+access, so the subnet must be public, but allows for access controls such as IP-whitelisting.
+
+## Custom requirements
 
 Depending on your enterprise needs or existing infrastructure, you may not require certain
 components (e.g. VPC, subnet) of the default setup of Polars Cloud. Or you have additional security


### PR DESCRIPTION
This PR adds a section on the AWS infrastructure detailing how to use your own network configuration (VPC, subnets, ...) and changes the image to include multiple subnets