### PR TITLE
perf: Lower int_range(len()) to with_row_index

### DIFF
--- a/crates/polars-lazy/Cargo.toml
+++ b/crates/polars-lazy/Cargo.toml
@@ -193,7 +193,10 @@ asof_join = ["polars-plan/asof_join", "polars-time", "polars-ops/asof_join", "po
 iejoin = ["polars-plan/iejoin"]
 business = ["polars-plan/business"]
 concat_str = ["polars-plan/concat_str"]
-range = ["polars-plan/range"]
+range = [
+  "polars-plan/range",
+  "polars-stream?/range",
+]
 mode = ["polars-plan/mode"]
 cum_agg = ["polars-plan/cum_agg"]
 interpolate = ["polars-plan/interpolate"]

--- a/crates/polars-stream/Cargo.toml
+++ b/crates/polars-stream/Cargo.toml
@@ -65,6 +65,7 @@ python = ["pyo3", "polars-plan/python", "polars-mem-engine/python", "polars-erro
 semi_anti_join = ["polars-plan/semi_anti_join", "polars-ops/semi_anti_join"]
 is_in = ["polars-ops/is_in", "polars-plan/is_in", "semi_anti_join"]
 replace = ["polars-ops/replace", "polars-plan/replace"]
+range = ["polars-plan/range"]
 
 # We need to specify default features here to match workspace defaults.
 # Otherwise we get warnings with cargo check/clippy.

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -1016,6 +1016,7 @@ fn lower_exprs_with_ctx(
             },
 
             // pl.row_index() maps to this.
+            #[cfg(feature = "range")]
             AExpr::Function {
                 input: ref inner_exprs,
                 function: IRFunctionExpr::Range(IRRangeFunction::IntRange { step: 1, dtype }),


### PR DESCRIPTION
Not really happy with the implementation, this shouldn't be done recursively but as a separate pass. Right now `pl.row_index()` are evaluated on their own and zipped back which is not ideal:

```python
lf = pl.LazyFrame({"a": [1, 2, 3, 4, 5]})
(lf.select(pl.col.a, pl.row_index(), (pl.col.a * pl.row_index()).alias("b"))
   .show_graph(engine="streaming", plan_stage="physical"))
```

Currently outputs:

<img width="971" height="966" alt="image" src="https://github.com/user-attachments/assets/61d42412-5d32-4518-bc84-cde41ba22dac" />


What I'd like:

<img width="973" height="830" alt="image" src="https://github.com/user-attachments/assets/a8e78051-cd3a-40e1-a8f8-5fa81fb36431" />

