### PR TITLE
fix: Change ufunc type computation

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1532,7 +1532,7 @@ class Series:
         else:
             dtype_char = match_in_out_types(
                 ufunc.types,
-                args=args,  #
+                args=args,
             )
         f = get_ffi_func("apply_ufunc_<>", numpy_char_code_to_dtype(dtype_char), s)
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1532,7 +1532,7 @@ class Series:
         else:
             dtype_char = match_in_out_types(
                 ufunc.types,
-                args=args,
+                args=args,  #
             )
         f = get_ffi_func("apply_ufunc_<>", numpy_char_code_to_dtype(dtype_char), s)
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -81,7 +81,6 @@ from polars.datatypes import (
     maybe_cast,
     numpy_char_code_to_dtype,
     parse_into_dtype,
-    supported_numpy_char_code,
 )
 from polars.datatypes._utils import dtype_to_init_repr
 from polars.dependencies import (
@@ -108,7 +107,7 @@ from polars.series.list import ListNameSpace
 from polars.series.plotting import SeriesPlot
 from polars.series.string import StringNameSpace
 from polars.series.struct import StructNameSpace
-from polars.series.utils import expr_dispatch, get_ffi_func
+from polars.series.utils import expr_dispatch, get_ffi_func, match_in_out_types
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyDataFrame, PySeries
@@ -1481,113 +1480,88 @@ class Series:
 
         s = self._s
 
-        if method == "__call__":
-            if ufunc.nout != 1:
-                msg = "only ufuncs that return one 1D array are supported"
-                raise NotImplementedError(msg)
-
-            args: list[int | float | np.ndarray[Any, Any]] = []
-            for arg in inputs:
-                if isinstance(arg, (int, float, np.ndarray)):
-                    args.append(arg)
-                elif isinstance(arg, Series):
-                    phys_arg = arg.to_physical()
-                    if phys_arg._s.n_chunks() > 1:
-                        phys_arg._s.rechunk(in_place=True)
-                    args.append(phys_arg._s.to_numpy_view())
-                else:
-                    msg = f"unsupported type {qualified_type_name(arg)!r} for {arg!r}"
-                    raise TypeError(msg)
-
-            # Get minimum dtype needed to be able to cast all input arguments to the
-            # same dtype.
-            dtype_char_minimum: str = np.result_type(*args).char
-
-            # Get all possible output dtypes for ufunc.
-            # Input dtypes and output dtypes seem to always match for ufunc.types,
-            # so pick all the different output dtypes.
-            dtypes_ufunc = [
-                input_output_type[-1]
-                for input_output_type in ufunc.types
-                if supported_numpy_char_code(input_output_type[-1])
-            ]
-
-            # Get the first ufunc dtype from all possible ufunc dtypes for which
-            # the input arguments can be safely cast to that ufunc dtype.
-            for dtype_ufunc in dtypes_ufunc:
-                if np.can_cast(dtype_char_minimum, dtype_ufunc):
-                    dtype_char_minimum = dtype_ufunc
-                    break
-
-            # Override minimum dtype if requested.
-            dtype_char = (
-                np.dtype(kwargs.pop("dtype")).char
-                if "dtype" in kwargs
-                else dtype_char_minimum
-            )
-
-            # Only generalized ufuncs have a signature set:
-            is_generalized_ufunc = bool(ufunc.signature)
-
-            if is_generalized_ufunc:
-                # Generalized ufuncs will operate on the whole array, so
-                # missing data can corrupt the results.
-                if self.has_nulls():
-                    msg = "can't pass a Series with missing data to a generalized ufunc, as it might give unexpected results. See https://docs.pola.rs/user-guide/expressions/missing-data/ for suggestions on how to remove or fill in missing data."
-                    raise ComputeError(msg)
-                # If the input and output are the same size, e.g. "(n)->(n)" we
-                # can allocate ourselves and save a copy. If they're different,
-                # we let the ufunc do the allocation, since only it knows the
-                # output size.
-                assert ufunc.signature is not None  # pacify MyPy
-                ufunc_input, ufunc_output = ufunc.signature.split("->")
-                if ufunc_output == "()":
-                    # If the result a scalar, just let the function do its
-                    # thing, no need for any song and dance involving
-                    # allocation:
-                    return ufunc(*args, dtype=dtype_char, **kwargs)
-                else:
-                    allocate_output = ufunc_input == ufunc_output
-            else:
-                allocate_output = True
-
-            f = get_ffi_func("apply_ufunc_<>", numpy_char_code_to_dtype(dtype_char), s)
-
-            if f is None:
-                msg = (
-                    "could not find "
-                    f"`apply_ufunc_{numpy_char_code_to_dtype(dtype_char)}`"
-                )
-                raise NotImplementedError(msg)
-
-            series = f(
-                lambda out: ufunc(*args, out=out, dtype=dtype_char, **kwargs),
-                allocate_output,
-            )
-
-            result = self._from_pyseries(series)
-            if is_generalized_ufunc:
-                # In this case we've disallowed passing in missing data, so no
-                # further processing is needed.
-                return result
-
-            # We're using a regular ufunc, that operates value by value. That
-            # means we allowed missing data in the input, so filter it out:
-            validity_mask = self.is_not_null()
-            for arg in inputs:
-                if isinstance(arg, Series):
-                    validity_mask &= arg.is_not_null()
-            return (
-                result.to_frame()
-                .select(F.when(validity_mask).then(F.col(self.name)))
-                .to_series(0)
-            )
-        else:
+        if method != "__call__":
             msg = (
                 "only `__call__` is implemented for numpy ufuncs on a Series, got "
                 f"`{method!r}`"
             )
             raise NotImplementedError(msg)
+        if ufunc.nout != 1:
+            msg = "only ufuncs that return one 1D array are supported"
+            raise NotImplementedError(msg)
+
+        args: list[int | float | np.ndarray[Any, Any]] = []
+        for arg in inputs:
+            if isinstance(arg, (int, float, np.ndarray)):
+                args.append(arg)
+            elif isinstance(arg, Series):
+                phys_arg = arg.to_physical()
+                if phys_arg._s.n_chunks() > 1:
+                    phys_arg._s.rechunk(in_place=True)
+                args.append(phys_arg._s.to_numpy_view())
+            else:
+                msg = f"unsupported type {qualified_type_name(arg)!r} for {arg!r}"
+                raise TypeError(msg)
+
+        # Only generalized ufuncs have a signature set:
+        is_generalized_ufunc = bool(ufunc.signature)
+
+        if is_generalized_ufunc:
+            # Generalized ufuncs will operate on the whole array, so
+            # missing data can corrupt the results.
+            if self.has_nulls():
+                msg = "can't pass a Series with missing data to a generalized ufunc, as it might give unexpected results. See https://docs.pola.rs/user-guide/expressions/missing-data/ for suggestions on how to remove or fill in missing data."
+                raise ComputeError(msg)
+            # If the input and output are the same size, e.g. "(n)->(n)" we
+            # can allocate ourselves and save a copy. If they're different,
+            # we let the ufunc do the allocation, since only it knows the
+            # output size.
+            assert ufunc.signature is not None  # pacify MyPy
+            ufunc_input, ufunc_output = ufunc.signature.split("->")
+            if ufunc_output == "()":
+                # If the result a scalar, just let the function do its
+                # thing, no need for any song and dance involving
+                # allocation:
+                return ufunc(*args, **kwargs)
+            else:
+                allocate_output = ufunc_input == ufunc_output
+        else:
+            allocate_output = True
+        if "dtype" in kwargs:
+            dtype_char = kwargs.pop("dtype")
+        else:
+            dtype_char = match_in_out_types(
+                ufunc.types,
+                args=args,
+            )
+        f = get_ffi_func("apply_ufunc_<>", numpy_char_code_to_dtype(dtype_char), s)
+
+        if f is None:
+            msg = f"could not find `apply_ufunc_{numpy_char_code_to_dtype(dtype_char)}`"
+            raise NotImplementedError(msg)
+
+        series = f(
+            lambda out: ufunc(*args, out=out, **kwargs),
+            allocate_output,
+        )
+
+        result = self._from_pyseries(series)
+        if is_generalized_ufunc:
+            # In this case we've disallowed passing in missing data, so no
+            # further processing is needed.
+            return result
+
+        # We're using a regular ufunc, that operates value by value. That
+        # means we allowed missing data in the input, so filter it out:
+        validity_mask = self.is_not_null()
+        for arg in inputs:
+            if isinstance(arg, Series):
+                validity_mask &= arg.is_not_null()
+        return (
+            result.to_frame()
+            .select(F.when(validity_mask).then(F.col(self.name)))
+            .to_series(0)
+        )
 
     def __arrow_c_stream__(self, requested_schema: object | None = None) -> object:
         """

--- a/py-polars/polars/series/utils.py
+++ b/py-polars/polars/series/utils.py
@@ -5,12 +5,11 @@ import sys
 from functools import reduce, wraps
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
-import numpy as np
-
 import polars._reexport as pl
 from polars import functions as F
 from polars._utils.wrap import wrap_s
 from polars.datatypes import dtype_to_ffiname
+from polars.dependencies import numpy as np
 
 if TYPE_CHECKING:
     from collections.abc import Sequence

--- a/py-polars/polars/series/utils.py
+++ b/py-polars/polars/series/utils.py
@@ -230,7 +230,9 @@ def match_in_out_types(
                 elif arg.dtype.char in ["d", "f"]:
                     prefer_float = arg.dtype.char
                 args_types.append(arg.dtype.char)
-    in_out = {(splt := typ.split("->", maxsplit=1))[0]: splt[1] for typ in ufunc_types}
+    in_out = {
+        (splt := _type.split("->", maxsplit=1))[0]: splt[1] for _type in ufunc_types
+    }
     assert args_types is not None
     args_str = "".join(args_types)
     if args_str in in_out:

--- a/py-polars/polars/series/utils.py
+++ b/py-polars/polars/series/utils.py
@@ -239,6 +239,7 @@ def match_in_out_types(
     elif len(set(in_out.values())) == 1:
         return next(iter(in_out.values()))
     elif all(v not in NP_INTs for v in in_out.values()):
+        print("v not in", args_types)  # windows runner info
         if any(x == "f" for x in args_types) and all(x != "d" for x in args_types):
             return "f"
         else:
@@ -255,6 +256,7 @@ def match_in_out_types(
     ):
         super_in = np_common(*args_types)
         super_in_repeated = [super_in for _ in range(num_ins)]
+        print("super", super_in_repeated)  # windows runner info
         return match_in_out_types(ufunc_types, args_types=super_in_repeated)
     else:
         msg = "no matching input to output dtype combination found. Try manually setting dtype"

--- a/py-polars/tests/unit/interop/numpy/test_ufunc_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_ufunc_series.py
@@ -76,6 +76,9 @@ def test_ufunc() -> None:
         cast(pl.Series, np.power(s_uint64, 2)),
         pl.Series("a", [1, 4, 9, 16], dtype=pl.UInt64),
     )
+    print(np.power.types)  # windows runner info
+    print(s_uint64._s.to_numpy_view().dtype.char)  # windows runner info
+    print(s_uint64.to_numpy().dtype.char)  # windows runner info
     assert_series_equal(
         cast(pl.Series, np.power(s_uint64, 2.0)),
         pl.Series("a", [1.0, 4.0, 9.0, 16.0], dtype=pl.Float64),

--- a/py-polars/tests/unit/interop/numpy/test_ufunc_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_ufunc_series.py
@@ -192,3 +192,31 @@ def test_generalized_ufunc_different_output_size() -> None:
         divide_by_sum(series2, series),
         pl.Series("s2", [1.0 / 56, 3.0 / 56], dtype=pl.Float64),
     )
+
+
+def test_numba_mixed_types() -> None:
+    nb = pytest.importorskip("numba")
+
+    @nb.guvectorize([(nb.int64[:], nb.int64[:], nb.uint64[:])], "(n),(n)->(n)")  # type: ignore[misc]
+    def int_uint(arr: Any, arr2: Any, result: Any) -> None:
+        for i in range(len(arr)):
+            result[i] = np.uint(arr[i] + arr2[i])
+
+    x = pl.Series([1, 2, 3], dtype=pl.Int64)
+    y = pl.Series([2, 3, 4], dtype=pl.Int64)
+
+    result = int_uint(x, y)
+    expected = pl.Series([3, 5, 7], dtype=pl.UInt64)
+    assert_series_equal(result, expected)
+
+    @nb.guvectorize([(nb.float64[:], nb.float64[:], nb.uint64[:])], "(n),(n)->(n)")  # type: ignore[misc]
+    def float_uint(arr: Any, arr2: Any, result: Any) -> None:
+        for i in range(len(arr)):
+            result[i] = np.uint(arr[i] + arr2[i])
+
+    x = pl.Series([1.0, 2.1, 3.2], dtype=pl.Float64)
+    y = pl.Series([2.3, 3.4, 4.5], dtype=pl.Float64)
+
+    result = float_uint(x, y)
+    expected = pl.Series([3, 5, 7], dtype=pl.UInt64)
+    assert_series_equal(result, expected)


### PR DESCRIPTION
fixes https://github.com/pola-rs/polars/issues/23513.

Unfortunately using `np.can_cast` isn't a very reliable way of discerning what types can go together. I couldn't find a quick way to do it because even numpy's own supertype finding methods returned supertypes that we don't want to use. For instance it would say the combination of an int and a float is a float64 when existing tests (and logic) expect it to be a float32 so it ended up being pretty manual.
