### PR TITLE
fix: Logic of broadcast_rhs in binary functions to correct list.set_intersection for list[str] columns

### DIFF
--- a/crates/polars-ops/src/chunked_array/list/sets.rs
+++ b/crates/polars-ops/src/chunked_array/list/sets.rs
@@ -279,9 +279,6 @@ fn binary(
     let mut offsets = Vec::with_capacity(std::cmp::max(offsets_a.len(), offsets_b.len()));
     offsets.push(0i64);
 
-    if broadcast_rhs {
-        set2.extend(b);
-    }
     let offsets_slice = if offsets_a.len() > offsets_b.len() {
         offsets_a
     } else {
@@ -291,6 +288,16 @@ fn binary(
     let second_a = offsets_a[1];
     let first_b = offsets_b[0];
     let second_b = offsets_b[1];
+
+    if broadcast_rhs {
+        // set2.extend(b_iter)
+        set2.extend(
+            b.into_iter()
+                .skip(first_b as usize)
+                .take(second_b as usize - first_b as usize),
+        );
+    }
+
     for i in 1..offsets_slice.len() {
         // If we go OOB we take the first element as we are then broadcasting.
         let start_a = *offsets_a.get(i - 1).unwrap_or(&first_a) as usize;

--- a/py-polars/tests/unit/operations/namespaces/list/test_set_operations.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_set_operations.py
@@ -119,6 +119,23 @@ def test_list_set_operations() -> None:
     assert r1 == exp
     assert r2 == exp
 
+    # check that broadcast_rhs works correctly
+    df = pl.DataFrame(
+        {
+            "a": [["a"], []],
+            "b": [[], ["a"]],
+        }
+    )
+    df_broadcast_rhs = df.join(pl.DataFrame({"c": [True]}), how="cross").filter("c")
+
+    assert df_broadcast_rhs.select(pl.col("a").list.set_intersection("b")).to_dict(
+        as_series=False
+    ) == {"a": [[], []]}
+
+    assert df_broadcast_rhs.select(
+        pl.col("a").list.set_symmetric_difference("b")
+    ).to_dict(as_series=False) == {"a": [["a"], ["a"]]}
+
 
 def test_list_set_operations_broadcast() -> None:
     df = pl.DataFrame(


### PR DESCRIPTION
This PR addresses issue #23551 by fixing an error in the [binary-function](https://github.com/pola-rs/polars/blob/11643a6ca6250d9c81f643acc31e63f27201cdb5/crates/polars-ops/src/chunked_array/list/sets.rs#L261) implementation that mishandled the case when `broadcast_rhs=True` on `list[str]` columns. As a result of that bug, `pl.Expr.list.set_intersection` and `pl.Expr.list.set_symmetric_difference` sometimes return incorrect outputs.

new unit tests in tests/unit/operations/namespaces/list/test_set_operations.py verify reproducible examples described in [#23551](https://github.com/pola-rs/polars/issues/23551#issuecomment-3069912640)

close #23551 