### PR TITLE
fix: Fix incorrect `join_asof` with `by` followed by `head/slice`

### DIFF
--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -485,17 +485,15 @@ pub trait AsofJoinBy: IntoDf {
         allow_eq: bool,
         check_sortedness: bool,
     ) -> PolarsResult<DataFrame> {
-        let (self_sliced_slot, other_sliced_slot, left_slice_s, right_slice_s); // Keeps temporaries alive.
+        let (self_sliced_slot, left_slice_s); // Keeps temporaries alive.
         let (self_df, other_df, left_key, right_key);
         if let Some((offset, len)) = slice {
             self_sliced_slot = self.to_df().slice(offset, len);
-            other_sliced_slot = other.slice(offset, len);
             left_slice_s = left_on.slice(offset, len);
-            right_slice_s = right_on.slice(offset, len);
             left_key = &left_slice_s;
-            right_key = &right_slice_s;
+            right_key = right_on;
             self_df = &self_sliced_slot;
-            other_df = &other_sliced_slot;
+            other_df = other;
         } else {
             self_df = self.to_df();
             other_df = other;

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import warnings
 from datetime import date, datetime, timedelta
 from typing import Any

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -2,15 +2,17 @@ from __future__ import annotations
 
 import warnings
 from datetime import date, datetime, timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pytest
 
 import polars as pl
-from polars._typing import AsofJoinStrategy, PolarsIntegerType
 from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal
+
+if TYPE_CHECKING:
+    from polars._typing import AsofJoinStrategy, PolarsIntegerType
 
 
 def test_asof_join_singular_right_11966() -> None:

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -1329,7 +1329,8 @@ def test_join_asof_large_int_21276(
     assert_frame_equal(result, expected)
 
 
-def test_join_asof_slice_23583() -> None:
+@pytest.mark.parametrize("by", ["constant", None])
+def test_join_asof_slice_23583(by: str | None) -> None:
     lhs = pl.LazyFrame(
         {
             "index": [0],
@@ -1346,7 +1347,11 @@ def test_join_asof_slice_23583() -> None:
         },
     ).set_sorted("date")
 
-    q = lhs.join_asof(rhs, on="date", by="constant", check_sortedness=False).head(1)
+    q = (
+        lhs.join_asof(rhs, on="date", by=by, check_sortedness=False)
+        .head(1)
+        .select(pl.exclude("constant_right"))
+    )
 
     expect = pl.DataFrame(
         {


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/23583
* Regression from https://github.com/pola-rs/polars/pull/11854
  * Bug was first introduced in version 0.19.10, and has existed since then 👀

RHS table was incorrectly sliced at execution. Note that using `join_asof` without the `by` argument is not affected.
