### PR TITLE
fix: Apply `agg_fn` on `null` values in `pivot`

### DIFF
--- a/crates/polars-core/src/frame/group_by/expr.rs
+++ b/crates/polars-core/src/frame/group_by/expr.rs
@@ -4,7 +4,5 @@ pub trait PhysicalAggExpr {
     #[allow(clippy::ptr_arg)]
     fn evaluate_on_groups(&self, df: &DataFrame, groups: &GroupPositions) -> PolarsResult<Series>;
 
-    fn evaluate(&self, df: &DataFrame) -> PolarsResult<Column>;
-
     fn root_name(&self) -> PolarsResult<&PlSmallStr>;
 }

--- a/crates/polars-core/src/frame/group_by/expr.rs
+++ b/crates/polars-core/src/frame/group_by/expr.rs
@@ -2,7 +2,9 @@ use crate::prelude::*;
 
 pub trait PhysicalAggExpr {
     #[allow(clippy::ptr_arg)]
-    fn evaluate(&self, df: &DataFrame, groups: &GroupPositions) -> PolarsResult<Series>;
+    fn evaluate_on_groups(&self, df: &DataFrame, groups: &GroupPositions) -> PolarsResult<Series>;
+
+    fn evaluate(&self, df: &DataFrame) -> PolarsResult<Column>;
 
     fn root_name(&self) -> PolarsResult<&PlSmallStr>;
 }

--- a/crates/polars-core/src/frame/group_by/position.rs
+++ b/crates/polars-core/src/frame/group_by/position.rs
@@ -158,6 +158,15 @@ impl GroupsIdx {
         let all = self.all.get_unchecked(index);
         (first, all)
     }
+
+    // Create an 'empty group', containing 1 group of length 0
+    pub fn new_empty() -> Self {
+        Self {
+            sorted: false,
+            first: vec![0],
+            all: vec![vec![].into()],
+        }
+    }
 }
 
 impl FromIterator<IdxItem> for GroupsIdx {

--- a/crates/polars-lazy/src/frame/pivot.rs
+++ b/crates/polars-lazy/src/frame/pivot.rs
@@ -15,7 +15,13 @@ use polars_ops::pivot::PivotAgg;
 use crate::physical_plan::exotic::{contains_column_refs, prepare_expression_for_context};
 use crate::prelude::*;
 
-struct PivotExpr(Expr);
+pub struct PivotExpr(pub Expr);
+
+impl PivotExpr {
+    pub fn from_expr(expr: Expr) -> Self {
+        PivotExpr(expr)
+    }
+}
 
 impl PhysicalAggExpr for PivotExpr {
     fn evaluate_on_groups(&self, df: &DataFrame, groups: &GroupPositions) -> PolarsResult<Series> {

--- a/crates/polars-lazy/src/frame/pivot.rs
+++ b/crates/polars-lazy/src/frame/pivot.rs
@@ -38,18 +38,6 @@ impl PhysicalAggExpr for PivotExpr {
             .map(|mut ac| ac.aggregated().take_materialized_series())
     }
 
-    fn evaluate(&self, df: &DataFrame) -> PolarsResult<Column> {
-        let state = ExecutionState::new();
-        let dtype = df.get_columns()[0].dtype();
-        let phys_expr = prepare_expression_for_context(
-            PlSmallStr::EMPTY,
-            &self.0,
-            dtype,
-            Context::Aggregation,
-        )?;
-        phys_expr.evaluate(df, &state)
-    }
-
     fn root_name(&self) -> PolarsResult<&PlSmallStr> {
         Ok(PlSmallStr::EMPTY_REF)
     }

--- a/crates/polars-lazy/src/frame/pivot.rs
+++ b/crates/polars-lazy/src/frame/pivot.rs
@@ -79,7 +79,7 @@ where
         polars_bail!(InvalidOperation: "explicit column references are not allowed in aggregate_function");
     }
 
-    let agg_expr = agg_expr.map(|ae| PivotAgg::Expr(Arc::new(PivotExpr(ae))));
+    let agg_expr = agg_expr.map(|ae| PivotAgg(Arc::new(PivotExpr(ae))));
     polars_ops::pivot::pivot(df, on, index, values, sort_columns, agg_expr, separator)
 }
 
@@ -107,6 +107,6 @@ where
         polars_bail!(InvalidOperation: "explicit column references are not allowed in aggregate_function");
     }
 
-    let agg_expr = agg_expr.map(|ae| PivotAgg::Expr(Arc::new(PivotExpr(ae))));
+    let agg_expr = agg_expr.map(|ae| PivotAgg(Arc::new(PivotExpr(ae))));
     polars_ops::pivot::pivot_stable(df, on, index, values, sort_columns, agg_expr, separator)
 }

--- a/crates/polars-lazy/src/frame/pivot.rs
+++ b/crates/polars-lazy/src/frame/pivot.rs
@@ -15,7 +15,7 @@ use polars_ops::pivot::PivotAgg;
 use crate::physical_plan::exotic::{contains_column_refs, prepare_expression_for_context};
 use crate::prelude::*;
 
-pub struct PivotExpr(pub Expr);
+pub struct PivotExpr(Expr);
 
 impl PivotExpr {
     pub fn from_expr(expr: Expr) -> Self {

--- a/crates/polars-ops/src/frame/pivot/positioning.rs
+++ b/crates/polars-ops/src/frame/pivot/positioning.rs
@@ -110,9 +110,8 @@ pub(super) fn position_aggregates_numeric<T: PolarsNumericType>(
     value_agg_phys: &ChunkedArray<T>,
     logical_type: &DataType,
     headers: &StringChunked,
-    default_val: &AnyValue,
+    default_val: Option<T::Native>,
 ) -> Vec<Column> {
-    let default_val = default_val.extract();
     let mut buf = vec![default_val; n_rows * n_cols];
     let start_ptr = buf.as_mut_ptr() as usize;
 

--- a/crates/polars-ops/src/frame/pivot/positioning.rs
+++ b/crates/polars-ops/src/frame/pivot/positioning.rs
@@ -8,6 +8,7 @@ use polars_utils::total_ord::{ToTotalOrd, TotalEq, TotalHash};
 
 use super::*;
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn position_aggregates(
     n_rows: usize,
     n_cols: usize,
@@ -16,8 +17,9 @@ pub(super) fn position_aggregates(
     value_agg_phys: &Series,
     logical_type: &DataType,
     headers: &StringChunked,
+    default_val: &AnyValue,
 ) -> Vec<Column> {
-    let mut buf = vec![AnyValue::Null; n_rows * n_cols];
+    let mut buf = vec![default_val.clone(); n_rows * n_cols];
     let start_ptr = buf.as_mut_ptr() as usize;
 
     let n_threads = POOL.current_num_threads();
@@ -99,6 +101,7 @@ pub(super) fn position_aggregates(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn position_aggregates_numeric<T: PolarsNumericType>(
     n_rows: usize,
     n_cols: usize,
@@ -107,8 +110,10 @@ pub(super) fn position_aggregates_numeric<T: PolarsNumericType>(
     value_agg_phys: &ChunkedArray<T>,
     logical_type: &DataType,
     headers: &StringChunked,
+    default_val: &AnyValue,
 ) -> Vec<Column> {
-    let mut buf = vec![None; n_rows * n_cols];
+    let default_val = default_val.extract();
+    let mut buf = vec![default_val; n_rows * n_cols];
     let start_ptr = buf.as_mut_ptr() as usize;
 
     let n_threads = POOL.current_num_threads();

--- a/crates/polars/tests/it/core/pivot.rs
+++ b/crates/polars/tests/it/core/pivot.rs
@@ -20,10 +20,7 @@ fn test_pivot_date_() -> PolarsResult<()> {
         Some(["index"]),
         Some(["values2"]),
         true,
-        // Some(PivotAgg::Count),
-        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
-            col("").count(),
-        )))),
+        Some(PivotAgg(Arc::new(PivotExpr::from_expr(col("").count())))),
         None,
     )?;
 
@@ -41,10 +38,7 @@ fn test_pivot_date_() -> PolarsResult<()> {
         Some(["index"]),
         Some(["values1"]),
         true,
-        // Some(PivotAgg::First),
-        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
-            col("").first(),
-        )))),
+        Some(PivotAgg(Arc::new(PivotExpr::from_expr(col("").first())))),
         None,
     )?;
     out.try_apply("1", |s| {
@@ -74,10 +68,7 @@ fn test_pivot_old() {
         Some(["index"]),
         Some(["values"]),
         false,
-        // Some(PivotAgg::Sum),
-        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
-            col("").sum(),
-        )))),
+        Some(PivotAgg(Arc::new(PivotExpr::from_expr(col("").sum())))),
         None,
     )
     .unwrap();
@@ -92,10 +83,7 @@ fn test_pivot_old() {
         Some(["index"]),
         Some(["values"]),
         false,
-        // Some(PivotAgg::Min),
-        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
-            col("").min(),
-        )))),
+        Some(PivotAgg(Arc::new(PivotExpr::from_expr(col("").min())))),
         None,
     )
     .unwrap();
@@ -109,10 +97,7 @@ fn test_pivot_old() {
         Some(["index"]),
         Some(["values"]),
         false,
-        // Some(PivotAgg::Max),
-        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
-            col("").max(),
-        )))),
+        Some(PivotAgg(Arc::new(PivotExpr::from_expr(col("").max())))),
         None,
     )
     .unwrap();
@@ -126,10 +111,7 @@ fn test_pivot_old() {
         Some(["index"]),
         Some(["values"]),
         false,
-        // Some(PivotAgg::Mean),
-        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
-            col("").mean(),
-        )))),
+        Some(PivotAgg(Arc::new(PivotExpr::from_expr(col("").mean())))),
         None,
     )
     .unwrap();
@@ -143,10 +125,7 @@ fn test_pivot_old() {
         Some(["index"]),
         Some(["values"]),
         false,
-        // Some(PivotAgg::Count),
-        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
-            col("").len(),
-        )))),
+        Some(PivotAgg(Arc::new(PivotExpr::from_expr(col("").len())))),
         None,
     )
     .unwrap();
@@ -174,10 +153,7 @@ fn test_pivot_categorical() -> PolarsResult<()> {
         Some(["index"]),
         Some(["values"]),
         true,
-        // Some(PivotAgg::Count),
-        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
-            col("").len(),
-        )))),
+        Some(PivotAgg(Arc::new(PivotExpr::from_expr(col("").len())))),
         None,
     )?;
     assert_eq!(out.get_column_names(), &["index", "a", "b", "c"]);
@@ -202,10 +178,7 @@ fn test_pivot_new() -> PolarsResult<()> {
         Some(["index1", "index2"]),
         Some(["values1"]),
         true,
-        // Some(PivotAgg::Sum),
-        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
-            col("").sum(),
-        )))),
+        Some(PivotAgg(Arc::new(PivotExpr::from_expr(col("").sum())))),
         None,
     ))?;
     let expected = df![
@@ -222,10 +195,7 @@ fn test_pivot_new() -> PolarsResult<()> {
         Some(["index1", "index2"]),
         Some(["values1"]),
         true,
-        // Some(PivotAgg::Sum),
-        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
-            col("").sum(),
-        )))),
+        Some(PivotAgg(Arc::new(PivotExpr::from_expr(col("").sum())))),
         None,
     )?;
     let expected = df![
@@ -256,10 +226,7 @@ fn test_pivot_2() -> PolarsResult<()> {
         Some(["index"]),
         Some(["values"]),
         false,
-        // Some(PivotAgg::First),
-        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
-            col("").first(),
-        )))),
+        Some(PivotAgg(Arc::new(PivotExpr::from_expr(col("").first())))),
         None,
     )?;
     let expected = df![
@@ -292,10 +259,7 @@ fn test_pivot_datetime() -> PolarsResult<()> {
         Some(["index"]),
         Some(["values"]),
         false,
-        // Some(PivotAgg::Sum),
-        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
-            col("").sum(),
-        )))),
+        Some(PivotAgg(Arc::new(PivotExpr::from_expr(col("").sum())))),
         None,
     )?;
     let expected = df![

--- a/crates/polars/tests/it/core/pivot.rs
+++ b/crates/polars/tests/it/core/pivot.rs
@@ -1,5 +1,6 @@
 use chrono::NaiveDate;
 use polars::prelude::*;
+use polars_lazy::frame::pivot::PivotExpr;
 use polars_ops::pivot::{PivotAgg, pivot, pivot_stable};
 
 #[test]
@@ -19,7 +20,10 @@ fn test_pivot_date_() -> PolarsResult<()> {
         Some(["index"]),
         Some(["values2"]),
         true,
-        Some(PivotAgg::Count),
+        // Some(PivotAgg::Count),
+        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
+            col("").count(),
+        )))),
         None,
     )?;
 
@@ -37,7 +41,10 @@ fn test_pivot_date_() -> PolarsResult<()> {
         Some(["index"]),
         Some(["values1"]),
         true,
-        Some(PivotAgg::First),
+        // Some(PivotAgg::First),
+        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
+            col("").first(),
+        )))),
         None,
     )?;
     out.try_apply("1", |s| {
@@ -67,14 +74,17 @@ fn test_pivot_old() {
         Some(["index"]),
         Some(["values"]),
         false,
-        Some(PivotAgg::Sum),
+        // Some(PivotAgg::Sum),
+        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
+            col("").sum(),
+        )))),
         None,
     )
     .unwrap();
     assert_eq!(pvt.get_column_names(), &["index", "k", "l", "m"]);
     assert_eq!(
         Vec::from(&pvt.column("m").unwrap().i32().unwrap().sort(false)),
-        &[None, None, Some(6)]
+        &[Some(0), Some(0), Some(6)]
     );
     let pvt = pivot(
         &df,
@@ -82,7 +92,10 @@ fn test_pivot_old() {
         Some(["index"]),
         Some(["values"]),
         false,
-        Some(PivotAgg::Min),
+        // Some(PivotAgg::Min),
+        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
+            col("").min(),
+        )))),
         None,
     )
     .unwrap();
@@ -96,7 +109,10 @@ fn test_pivot_old() {
         Some(["index"]),
         Some(["values"]),
         false,
-        Some(PivotAgg::Max),
+        // Some(PivotAgg::Max),
+        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
+            col("").max(),
+        )))),
         None,
     )
     .unwrap();
@@ -110,7 +126,10 @@ fn test_pivot_old() {
         Some(["index"]),
         Some(["values"]),
         false,
-        Some(PivotAgg::Mean),
+        // Some(PivotAgg::Mean),
+        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
+            col("").mean(),
+        )))),
         None,
     )
     .unwrap();
@@ -124,13 +143,16 @@ fn test_pivot_old() {
         Some(["index"]),
         Some(["values"]),
         false,
-        Some(PivotAgg::Count),
+        // Some(PivotAgg::Count),
+        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
+            col("").len(),
+        )))),
         None,
     )
     .unwrap();
     assert_eq!(
         Vec::from(&pvt.column("m").unwrap().idx().unwrap().sort(false)),
-        &[None, None, Some(2)]
+        &[Some(0), Some(0), Some(2)]
     );
 }
 
@@ -152,7 +174,10 @@ fn test_pivot_categorical() -> PolarsResult<()> {
         Some(["index"]),
         Some(["values"]),
         true,
-        Some(PivotAgg::Count),
+        // Some(PivotAgg::Count),
+        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
+            col("").len(),
+        )))),
         None,
     )?;
     assert_eq!(out.get_column_names(), &["index", "a", "b", "c"]);
@@ -177,13 +202,16 @@ fn test_pivot_new() -> PolarsResult<()> {
         Some(["index1", "index2"]),
         Some(["values1"]),
         true,
-        Some(PivotAgg::Sum),
+        // Some(PivotAgg::Sum),
+        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
+            col("").sum(),
+        )))),
         None,
     ))?;
     let expected = df![
         "index1" => ["foo", "foo", "bar", "bar"],
         "index2" => ["one", "two", "one", "two"],
-        "large" => [Some(4), None, Some(4), Some(7)],
+        "large" => [Some(4), Some(0), Some(4), Some(7)],
         "small" => [1, 6, 5, 6],
     ]?;
     assert!(out.equals_missing(&expected));
@@ -194,17 +222,20 @@ fn test_pivot_new() -> PolarsResult<()> {
         Some(["index1", "index2"]),
         Some(["values1"]),
         true,
-        Some(PivotAgg::Sum),
+        // Some(PivotAgg::Sum),
+        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
+            col("").sum(),
+        )))),
         None,
     )?;
     let expected = df![
         "index1" => ["foo", "foo", "bar", "bar"],
         "index2" => ["one", "two", "one", "two"],
-        "{\"large\",\"egg\"}" => [Some(4), None, None, None],
-        "{\"large\",\"jam\"}" => [None, None, Some(4), Some(7)],
-        "{\"small\",\"egg\"}" => [None, Some(3), None, None],
-        "{\"small\",\"jam\"}" => [Some(1), Some(3), None, Some(6)],
-        "{\"small\",\"potato\"}" => [None, None, Some(5), None],
+        "{\"large\",\"egg\"}" => [Some(4), Some(0), Some(0), Some(0)],
+        "{\"large\",\"jam\"}" => [Some(0), Some(0), Some(4), Some(7)],
+        "{\"small\",\"egg\"}" => [Some(0), Some(3), Some(0), Some(0)],
+        "{\"small\",\"jam\"}" => [Some(1), Some(3), Some(0), Some(6)],
+        "{\"small\",\"potato\"}" => [Some(0), Some(0), Some(5), Some(0)],
     ]?;
     assert!(out.equals_missing(&expected));
 
@@ -225,7 +256,10 @@ fn test_pivot_2() -> PolarsResult<()> {
         Some(["index"]),
         Some(["values"]),
         false,
-        Some(PivotAgg::First),
+        // Some(PivotAgg::First),
+        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
+            col("").first(),
+        )))),
         None,
     )?;
     let expected = df![
@@ -258,7 +292,10 @@ fn test_pivot_datetime() -> PolarsResult<()> {
         Some(["index"]),
         Some(["values"]),
         false,
-        Some(PivotAgg::Sum),
+        // Some(PivotAgg::Sum),
+        Some(PivotAgg::Expr(Arc::new(PivotExpr::from_expr(
+            col("").sum(),
+        )))),
         None,
     )?;
     let expected = df![


### PR DESCRIPTION
fixes #23408

This PR will insert the result of the `agg_fn` on an empty column as the default value in the final pivot, as opposed to simply inserting `null` values. This is applicable for any combination of `index` value and `on` value for which there is no entry in the df.

*edited:
Notes for review:
1. This PR will change the behavior for `agg_fn` such as `sum` and `len`, for which the result is `0` rather than `null`. See also the modifications to a number of tests. This may impact existing workflows.
2. Included: refactor of `PivotAgg` variants into a single tuple struct. Update Rust integration tests.
3. As usual, code to be reviewed properly (thanks).

Excluded (future):
1. Refactor `pivot` and `pivot_stable` such that lowering from `PhysicalAggExpr` to `PhysicalExpr` happens upfront, outside the `values` loop.