### PR TITLE
docs(python): Add docs of Expr.list.filter and Series.list.filter

### DIFF
--- a/py-polars/docs/source/reference/expressions/list.rst
+++ b/py-polars/docs/source/reference/expressions/list.rst
@@ -20,6 +20,7 @@ The following methods are available under the `expr.list` attribute.
     Expr.list.drop_nulls
     Expr.list.eval
     Expr.list.explode
+    Expr.list.filter
     Expr.list.first
     Expr.list.gather
     Expr.list.gather_every

--- a/py-polars/docs/source/reference/series/list.rst
+++ b/py-polars/docs/source/reference/series/list.rst
@@ -20,6 +20,7 @@ The following methods are available under the `Series.list` attribute.
     Series.list.drop_nulls
     Series.list.eval
     Series.list.explode
+    Series.list.filter
     Series.list.first
     Series.list.gather
     Series.list.gather_every


### PR DESCRIPTION
This PR adds API reference documentation for Expr.list.filter and Series.list.filter methods in the Python bindings.
I ran make html locally and confirmed that the documentation pages build correctly and the new entries appear as expected. 

close #23555 