### PR TITLE
fix: Relabel duplicate sequence IDs in distributor

### DIFF
--- a/crates/polars-stream/src/execute.rs
+++ b/crates/polars-stream/src/execute.rs
@@ -1,3 +1,6 @@
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+
 use polars_core::POOL;
 use polars_core::frame::DataFrame;
 use polars_error::PolarsResult;
@@ -122,12 +125,18 @@ fn run_subgraph(
     graph: &mut Graph,
     nodes: &PlHashSet<GraphNodeKey>,
     pipes: &[LogicalPipeKey],
+    pipe_seq_offsets: &mut SecondaryMap<LogicalPipeKey, Arc<AtomicU64>>,
     state: &StreamingExecutionState,
 ) -> PolarsResult<()> {
     // Construct physical pipes for the logical pipes we'll use.
     let mut physical_pipes = SecondaryMap::new();
     for pipe_key in pipes.iter().copied() {
-        physical_pipes.insert(pipe_key, PhysicalPipe::new(state.num_pipelines));
+        let seq_offset = pipe_seq_offsets
+            .entry(pipe_key)
+            .unwrap()
+            .or_default()
+            .clone();
+        physical_pipes.insert(pipe_key, PhysicalPipe::new(state.num_pipelines, seq_offset));
     }
 
     // We do a topological sort of the graph: we want to spawn each node,
@@ -281,6 +290,7 @@ pub fn execute_graph(
         }
     }
 
+    let mut pipe_seq_offsets = SecondaryMap::new();
     loop {
         if polars_core::config::verbose() {
             eprintln!("polars-stream: updating graph state");
@@ -298,7 +308,7 @@ pub fn execute_graph(
         if nodes.is_empty() {
             break;
         }
-        run_subgraph(graph, &nodes, &pipes, &state)?;
+        run_subgraph(graph, &nodes, &pipes, &mut pipe_seq_offsets, &state)?;
         if polars_core::config::verbose() {
             eprintln!("polars-stream: done running graph phase");
         }

--- a/crates/polars-stream/src/morsel.rs
+++ b/crates/polars-stream/src/morsel.rs
@@ -43,6 +43,10 @@ impl MorselSeq {
         Self(self.0 + offset.0)
     }
 
+    pub fn offset_by_u64(self, offset: u64) -> Self {
+        Self(self.0 + 2 * offset)
+    }
+
     pub fn to_u64(self) -> u64 {
         self.0
     }

--- a/crates/polars-stream/src/pipe.rs
+++ b/crates/polars-stream/src/pipe.rs
@@ -1,4 +1,6 @@
 use std::cmp::Reverse;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use polars_error::PolarsResult;
 use polars_utils::priority::Priority;
@@ -11,14 +13,37 @@ use crate::async_primitives::wait_group::WaitGroup;
 use crate::morsel::{Morsel, MorselSeq};
 use crate::{DEFAULT_DISTRIBUTOR_BUFFER_SIZE, DEFAULT_LINEARIZER_BUFFER_SIZE};
 
-pub enum PhysicalPipe {
-    Uninit(usize),
-    /// (_, _, maintain_order)
-    SerialReceiver(usize, Sender<Morsel>, bool),
-    ParallelReceiver(Vec<Sender<Morsel>>),
-    /// (_, _, maintain_order)
-    NeedsLinearizer(Vec<Receiver<Morsel>>, Sender<Morsel>, bool),
-    NeedsDistributor(Receiver<Morsel>, Vec<Sender<Morsel>>),
+pub struct PhysicalPipe {
+    state: State,
+    seq_offset: Arc<AtomicU64>,
+}
+
+enum State {
+    Invalid,
+    Uninit {
+        num_pipelines: usize,
+    },
+    SerialReceiver {
+        num_pipelines: usize,
+        send: Sender<Morsel>,
+        maintain_order: bool,
+    },
+    ParallelReceiver {
+        senders: Vec<Sender<Morsel>>,
+    },
+    NeedsLinearizer {
+        receivers: Vec<Receiver<Morsel>>,
+        send: Sender<Morsel>,
+        maintain_order: bool,
+    },
+    NeedsDistributor {
+        recv: Receiver<Morsel>,
+        senders: Vec<Sender<Morsel>>,
+    },
+    NeedsOffset {
+        senders: Vec<Sender<Morsel>>,
+        receivers: Vec<Receiver<Morsel>>,
+    },
     Initialized,
 }
 
@@ -31,21 +56,25 @@ impl RecvPort<'_> {
     }
 
     pub fn serial_with_maintain_order(self, maintain_order: bool) -> Receiver<Morsel> {
-        let PhysicalPipe::Uninit(num_pipelines) = self.0 else {
+        let State::Uninit { num_pipelines } = self.0.state else {
             unreachable!()
         };
         let (send, recv) = connector();
-        *self.0 = PhysicalPipe::SerialReceiver(*num_pipelines, send, maintain_order);
+        self.0.state = State::SerialReceiver {
+            num_pipelines,
+            send,
+            maintain_order,
+        };
         recv
     }
 
     pub fn parallel(self) -> Vec<Receiver<Morsel>> {
-        let PhysicalPipe::Uninit(num_pipelines) = self.0 else {
+        let State::Uninit { num_pipelines } = self.0.state else {
             unreachable!()
         };
         let (senders, receivers): (Vec<Sender<Morsel>>, Vec<Receiver<Morsel>>) =
-            (0..*num_pipelines).map(|_| connector()).unzip();
-        *self.0 = PhysicalPipe::ParallelReceiver(senders);
+            (0..num_pipelines).map(|_| connector()).unzip();
+        self.0.state = State::ParallelReceiver { senders };
         receivers
     }
 }
@@ -53,18 +82,27 @@ impl RecvPort<'_> {
 impl SendPort<'_> {
     #[allow(unused)]
     pub fn is_receiver_serial(&self) -> bool {
-        matches!(self.0, PhysicalPipe::SerialReceiver(..))
+        matches!(self.0.state, State::SerialReceiver { .. })
     }
 
     pub fn serial(self) -> Sender<Morsel> {
-        match core::mem::replace(self.0, PhysicalPipe::Uninit(0)) {
-            PhysicalPipe::SerialReceiver(_, send, _) => {
-                *self.0 = PhysicalPipe::Initialized;
-                send
+        match core::mem::replace(&mut self.0.state, State::Invalid) {
+            State::SerialReceiver { send, .. } => {
+                if self.0.seq_offset.load(Ordering::Relaxed) == 0 {
+                    self.0.state = State::Initialized;
+                    send
+                } else {
+                    let (offset_send, offset_recv) = connector();
+                    self.0.state = State::NeedsOffset {
+                        senders: vec![send],
+                        receivers: vec![offset_recv],
+                    };
+                    offset_send
+                }
             },
-            PhysicalPipe::ParallelReceiver(senders) => {
+            State::ParallelReceiver { senders } => {
                 let (send, recv) = connector();
-                *self.0 = PhysicalPipe::NeedsDistributor(recv, senders);
+                self.0.state = State::NeedsDistributor { recv, senders };
                 send
             },
             _ => unreachable!(),
@@ -72,16 +110,36 @@ impl SendPort<'_> {
     }
 
     pub fn parallel(self) -> Vec<Sender<Morsel>> {
-        match core::mem::replace(self.0, PhysicalPipe::Uninit(0)) {
-            PhysicalPipe::SerialReceiver(num_pipelines, send, maintain_order) => {
+        match core::mem::replace(&mut self.0.state, State::Invalid) {
+            State::SerialReceiver {
+                num_pipelines,
+                send,
+                maintain_order,
+            } => {
                 let (senders, receivers): (Vec<Sender<Morsel>>, Vec<Receiver<Morsel>>) =
                     (0..num_pipelines).map(|_| connector()).unzip();
-                *self.0 = PhysicalPipe::NeedsLinearizer(receivers, send, maintain_order);
+                self.0.state = State::NeedsLinearizer {
+                    receivers,
+                    send,
+                    maintain_order,
+                };
                 senders
             },
-            PhysicalPipe::ParallelReceiver(senders) => {
-                *self.0 = PhysicalPipe::Initialized;
-                senders
+            State::ParallelReceiver { senders } => {
+                if self.0.seq_offset.load(Ordering::Relaxed) == 0 {
+                    self.0.state = State::Initialized;
+                    senders
+                } else {
+                    let (offset_senders, offset_receivers): (
+                        Vec<Sender<Morsel>>,
+                        Vec<Receiver<Morsel>>,
+                    ) = senders.iter().map(|_| connector()).unzip();
+                    self.0.state = State::NeedsOffset {
+                        senders,
+                        receivers: offset_receivers,
+                    };
+                    offset_senders
+                }
             },
             _ => unreachable!(),
         }
@@ -89,13 +147,16 @@ impl SendPort<'_> {
 }
 
 impl PhysicalPipe {
-    pub fn new(num_pipelines: usize) -> Self {
-        Self::Uninit(num_pipelines)
+    pub fn new(num_pipelines: usize, seq_offset: Arc<AtomicU64>) -> Self {
+        Self {
+            state: State::Uninit { num_pipelines },
+            seq_offset,
+        }
     }
 
     pub fn recv_port(&mut self) -> RecvPort<'_> {
         assert!(
-            matches!(self, Self::Uninit(_)),
+            matches!(self.state, State::Uninit { .. }),
             "PhysicalPipe::recv_port can only be called on an uninitialized pipe"
         );
         RecvPort(self)
@@ -103,7 +164,10 @@ impl PhysicalPipe {
 
     pub fn send_port(&mut self) -> SendPort<'_> {
         assert!(
-            matches!(self, Self::SerialReceiver(..) | Self::ParallelReceiver(..)),
+            matches!(
+                self.state,
+                State::SerialReceiver { .. } | State::ParallelReceiver { .. }
+            ),
             "PhysicalPipe::send_port must be called on a pipe which only has its receive port initialized"
         );
         SendPort(self)
@@ -114,14 +178,21 @@ impl PhysicalPipe {
         scope: &'s TaskScope<'s, 'env>,
         handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
-        match core::mem::replace(self, Self::Initialized) {
-            Self::Uninit(_) | Self::SerialReceiver(_, _, _) | Self::ParallelReceiver(_) => {
+        match core::mem::replace(&mut self.state, State::Initialized) {
+            State::Invalid
+            | State::Uninit { .. }
+            | State::SerialReceiver { .. }
+            | State::ParallelReceiver { .. } => {
                 panic!("PhysicalPipe::spawn called on (partially) initialized pipe");
             },
 
-            Self::Initialized => {},
+            State::Initialized => {},
 
-            Self::NeedsLinearizer(receivers, mut sender, maintain_order) => {
+            State::NeedsLinearizer {
+                receivers,
+                mut send,
+                maintain_order,
+            } => {
                 let num_pipelines = receivers.len();
                 let (mut linearizer, inserters) =
                     Linearizer::<Priority<Reverse<MorselSeq>, Morsel>>::new_with_maintain_order(
@@ -130,9 +201,11 @@ impl PhysicalPipe {
                         maintain_order,
                     );
 
+                let seq_offset = self.seq_offset.load(Ordering::Relaxed);
                 handles.push(scope.spawn_task(TaskPriority::High, async move {
-                    while let Some(morsel) = linearizer.get().await {
-                        if sender.send(morsel.1).await.is_err() {
+                    while let Some(Priority(_, mut morsel)) = linearizer.get().await {
+                        morsel.set_seq(morsel.seq().offset_by_u64(seq_offset));
+                        if send.send(morsel).await.is_err() {
                             break;
                         }
                     }
@@ -161,13 +234,26 @@ impl PhysicalPipe {
                 }
             },
 
-            Self::NeedsDistributor(mut receiver, senders) => {
+            State::NeedsDistributor { mut recv, senders } => {
                 let num_pipelines = senders.len();
                 let (mut distributor, distr_receivers) =
                     distributor_channel(num_pipelines, *DEFAULT_DISTRIBUTOR_BUFFER_SIZE);
 
+                let arc_seq_offset = self.seq_offset.clone();
                 handles.push(scope.spawn_task(TaskPriority::High, async move {
-                    while let Ok(mut morsel) = receiver.recv().await {
+                    let mut seq_offset = arc_seq_offset.load(Ordering::Relaxed);
+                    let mut prev_orig_seq = None;
+
+                    while let Ok(mut morsel) = recv.recv().await {
+                        // We have to relabel sequence ids to be unique before distributing.
+                        // Normally within a single pipeline consecutive ids may repeat but
+                        // when distributing this would destroy the order.
+                        if Some(morsel.seq()) == prev_orig_seq {
+                            seq_offset += 1;
+                        }
+                        prev_orig_seq = Some(morsel.seq());
+                        morsel.set_seq(morsel.seq().offset_by_u64(seq_offset));
+
                         // Important: we have to drop the consume token before
                         // going into the buffered distributor.
                         drop(morsel.take_consume_token());
@@ -175,6 +261,8 @@ impl PhysicalPipe {
                             break;
                         }
                     }
+
+                    arc_seq_offset.store(seq_offset, Ordering::Relaxed);
 
                     Ok(())
                 }));
@@ -190,6 +278,21 @@ impl PhysicalPipe {
                             wait_group.wait().await;
                         }
 
+                        Ok(())
+                    }));
+                }
+            },
+
+            State::NeedsOffset { senders, receivers } => {
+                let seq_offset = self.seq_offset.load(Ordering::Relaxed);
+                for (mut send, mut recv) in senders.into_iter().zip(receivers) {
+                    handles.push(scope.spawn_task(TaskPriority::High, async move {
+                        while let Ok(mut morsel) = recv.recv().await {
+                            morsel.set_seq(morsel.seq().offset_by_u64(seq_offset));
+                            if send.send(morsel).await.is_err() {
+                                break;
+                            }
+                        }
                         Ok(())
                     }));
                 }


### PR DESCRIPTION
Normally within a single pipeline consecutive ids may repeat but when distributing this would destroy the order, so we have to relabel them. Unfortunately this means that pipes become stateful to track the relabeling offset so I had to rework that system a bit.