### PR TITLE
build(rust): Update object_store to 0.12.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ memmap = { package = "memmap2", version = "0.9" }
 ndarray = { version = "0.16", default-features = false }
 num-traits = "0.2"
 numpy = "0.25"
-object_store = { version = "0.12", default-features = false, features = ["fs"] }
+object_store = { version = "0.12.1", default-features = false, features = ["fs"] }
 parking_lot = "0.12"
 percent-encoding = "2.3"
 pin-project-lite = "0.2"


### PR DESCRIPTION
fixes https://github.com/pola-rs/polars/issues/23596

It was an issue with object_store 0.12.0 reported here https://github.com/apache/arrow-rs-object-store/issues/326

And it was fixed here https://github.com/apache/arrow-rs-object-store/pull/334

which is in 0.12.1