### PR TITLE
fix: Honor `n=0` in all cases of `str.replace`

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/function_expr/strings.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/strings.rs
@@ -989,6 +989,12 @@ fn replace_n<'a>(
             if n > 1 {
                 polars_bail!(ComputeError: "multivalue replacement with 'n > 1' not yet supported")
             }
+
+            if n == 0 {
+                return Ok(ca.clone());
+            };
+
+            // from here on, we know that n == 1
             let mut pat = get_pat(pat)?.to_string();
             polars_ensure!(
                 len_val == ca.len(),
@@ -1006,16 +1012,10 @@ fn replace_n<'a>(
             let reg = polars_utils::regex_cache::compile_regex(&pat)?;
 
             let f = |s: &'a str, val: &'a str| {
-                match n {
-                    0 => Cow::Borrowed(s),
-                    1 => {
-                        if literal {
-                            reg.replace(s, NoExpand(val))
-                        } else {
-                            reg.replace(s, val)
-                        }
-                    },
-                    _n => unreachable!(), // not supported, would leverage `reg.replacen(s, n, val)`
+                if literal {
+                    reg.replace(s, NoExpand(val))
+                } else {
+                    reg.replace(s, val)
                 }
             };
 

--- a/crates/polars-plan/src/plans/aexpr/function_expr/strings.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/strings.rs
@@ -1005,28 +1005,6 @@ fn replace_n<'a>(
 
             let reg = polars_utils::regex_cache::compile_regex(&pat)?;
 
-            // (A) PRIOR, FIXED
-            let _f = |s: &'a str, val: &'a str| {
-                if lit && (s.len() <= 32) {
-                    Cow::Owned(s.replacen(&pat, val, n))
-                } else {
-                    match n {
-                        0 => Cow::Borrowed(s),
-                        1 => {
-                            // According to the docs for replace
-                            // when literal = True then capture groups are ignored.
-                            if literal {
-                                reg.replace(s, NoExpand(val))
-                            } else {
-                                reg.replace(s, val)
-                            }
-                        },
-                        _n => unreachable!(), // not supported, would be: reg.replacen(s, n, val)
-                    }
-                }
-            };
-
-            // (B) PROPOSED NEW, see https://github.com/pola-rs/polars/pull/6777
             let f = |s: &'a str, val: &'a str| {
                 match n {
                     0 => Cow::Borrowed(s),

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -2089,3 +2089,18 @@ def test_replace_many_mapping_in_list() -> None:
         ),
         pl.Series([[1, 2]]),
     )
+
+
+def test_str_replace_n_zero_23570() -> None:
+    # more than 32 bytes
+    abc_long = "abc " * 20 + "abc"
+    df = pl.DataFrame(
+        {"a": [abc_long, "abc abc abc", "abc ghi"], "b": ["jkl", "pqr", "xyz"]}
+    )
+    expected = df
+
+    out = df.with_columns(pl.col("a").str.replace("abc", "XYZ", n=0))
+    assert_frame_equal(out, expected)
+
+    out = df.with_columns(pl.col("a").str.replace("abc", pl.col("b"), n=0))
+    assert_frame_equal(out, expected)


### PR DESCRIPTION
fixes #23570

In addition, this PR has proposed code simplification similar to https://github.com/pola-rs/polars/pull/6777

Code is pending selection of preferred implementation option and review. 
*Edit: ready for review.