### PR TITLE
fix: Casting unused columns in to_torch

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2456,7 +2456,8 @@ class DataFrame:
             # return a torch Dataset object
             from polars.ml.torch import PolarsDataset
 
-            return PolarsDataset(frame, label=label, features=features)
+            pds_label = None if label is None else label_frame.columns
+            return PolarsDataset(frame, label=pds_label, features=features)
         else:
             valid_torch_types = ", ".join(get_args(TorchExportType))
             msg = f"invalid `return_type`: {return_type!r}\nExpected one of: {valid_torch_types}"

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2431,8 +2431,8 @@ class DataFrame:
             frame = F.concat([label_frame, features_frame], how="horizontal")
         else:
             frame = (self.select(features) if features is not None else self).cast(
-                to_dtype
-            )  # type: ignore[arg-type]
+                to_dtype  # type: ignore[arg-type]
+            )
 
         if return_type == "tensor":
             # note: torch tensors are not immutable, so we must consider them writable

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2411,6 +2411,7 @@ class DataFrame:
 
         torch = import_optional("torch")
 
+        # Cast columns.
         if dtype in (UInt16, UInt32, UInt64):
             msg = f"PyTorch does not support u16, u32, or u64 dtypes; given {dtype}"
             raise ValueError(msg)
@@ -2419,18 +2420,19 @@ class DataFrame:
 
         if label is not None:
             label_frame = self.select(label)
+            # Avoid casting the label if it's an expression.
             if not isinstance(label, pl.Expr):
-                label_frame = label_frame.cast(to_dtype)
+                label_frame = label_frame.cast(to_dtype)  # type: ignore[arg-type]
             features_frame = (
                 self.select(features)
                 if features is not None
                 else self.drop(*label_frame.columns)
-            ).cast(to_dtype)
+            ).cast(to_dtype)  # type: ignore[arg-type]
             frame = F.concat([label_frame, features_frame], how="horizontal")
         else:
             frame = (self.select(features) if features is not None else self).cast(
                 to_dtype
-            )
+            )  # type: ignore[arg-type]
 
         if return_type == "tensor":
             # note: torch tensors are not immutable, so we must consider them writable


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/23579.

Also fixes something from the documentation we weren't actually respecting:

> Unify the dtype of all returned tensors; this casts any column that is not of the required dtype before converting to Tensor. This includes the label column **unless the label is an expression (such as pl.col("label_column").cast(pl.Int16))**.