### PR TITLE
docs: Update GPU docs for RAPIDS CUDA 11 deprecation

### DIFF
--- a/docs/source/user-guide/gpu-support.md
+++ b/docs/source/user-guide/gpu-support.md
@@ -8,7 +8,8 @@ available in Open Beta and is undergoing rapid development.
 
 - NVIDIA Volta™ or higher GPU with [compute capability](https://developer.nvidia.com/cuda-gpus) 7.0+
 - CUDA 12 (CUDA 11 support ends with RAPIDS v25.06; see
-  [RSN 48](https://docs.rapids.ai/notices/rsn0048/))
+  [RSN 48](https://docs.rapids.ai/notices/rsn0048/); if you're using CUDA 11,
+  see the installation note below)
 - Linux or Windows Subsystem for Linux 2 (WSL2)
 
 See the [RAPIDS installation guide](https://docs.rapids.ai/install#system-req) for full details.
@@ -26,13 +27,13 @@ pip install polars[gpu]
 
 !!! note Installation on a CUDA 11 system
 
-    RAPIDS cuDF will **drop CUDA 11 support** starting with version **v25.08**.
+    RAPIDS cuDF will **drop CUDA 11 support** starting with version **25.08**.
     If you are using CUDA 11, you must pin to `cudf-polars-cu11==25.06`.
     See the official [deprecation notice (RSN 48)](https://docs.rapids.ai/notices/rsn0048/) for details.
 
     === ":fontawesome-brands-python: Python"
     ```bash
-    pip install --extra-index-url=https://pypi.nvidia.com polars cudf-polars-cu11
+    pip install polars cudf-polars-cu11
     ```
 
 ### Usage

--- a/docs/source/user-guide/gpu-support.md
+++ b/docs/source/user-guide/gpu-support.md
@@ -8,8 +8,8 @@ available in Open Beta and is undergoing rapid development.
 
 - NVIDIA Volta™ or higher GPU with [compute capability](https://developer.nvidia.com/cuda-gpus) 7.0+
 - CUDA 12 (CUDA 11 support ends with RAPIDS v25.06; see
-  [RSN 48](https://docs.rapids.ai/notices/rsn0048/); if you're using CUDA 11,
-  see the installation note below)
+  [RSN 48](https://docs.rapids.ai/notices/rsn0048/); if you're using CUDA 11, see the installation
+  note below)
 - Linux or Windows Subsystem for Linux 2 (WSL2)
 
 See the [RAPIDS installation guide](https://docs.rapids.ai/install#system-req) for full details.

--- a/docs/source/user-guide/gpu-support.md
+++ b/docs/source/user-guide/gpu-support.md
@@ -7,7 +7,7 @@ available in Open Beta and is undergoing rapid development.
 ### System Requirements
 
 - NVIDIA Volta™ or higher GPU with [compute capability](https://developer.nvidia.com/cuda-gpus) 7.0+
-- CUDA 11 or CUDA 12
+- CUDA 12 (CUDA 11 support ends with RAPIDS v25.06; see [RSN 48](https://docs.rapids.ai/notices/rsn0048/))
 - Linux or Windows Subsystem for Linux 2 (WSL2)
 
 See the [RAPIDS installation guide](https://docs.rapids.ai/install#system-req) for full details.
@@ -25,7 +25,9 @@ pip install polars[gpu]
 
 !!! note Installation on a CUDA 11 system
 
-    If you have CUDA 11, the installation line also needs the NVIDIA package index to get the CUDA 11 package.
+    RAPIDS cuDF will **drop CUDA 11 support** starting with version **v25.08**.
+    If you are using CUDA 11, you must pin to `cudf-polars-cu11==25.06`.
+    See the official [deprecation notice (RSN 48)](https://docs.rapids.ai/notices/rsn0048/) for details.
 
     === ":fontawesome-brands-python: Python"
     ```bash

--- a/docs/source/user-guide/gpu-support.md
+++ b/docs/source/user-guide/gpu-support.md
@@ -7,7 +7,8 @@ available in Open Beta and is undergoing rapid development.
 ### System Requirements
 
 - NVIDIA Volta™ or higher GPU with [compute capability](https://developer.nvidia.com/cuda-gpus) 7.0+
-- CUDA 12 (CUDA 11 support ends with RAPIDS v25.06; see [RSN 48](https://docs.rapids.ai/notices/rsn0048/))
+- CUDA 12 (CUDA 11 support ends with RAPIDS v25.06; see
+  [RSN 48](https://docs.rapids.ai/notices/rsn0048/))
 - Linux or Windows Subsystem for Linux 2 (WSL2)
 
 See the [RAPIDS installation guide](https://docs.rapids.ai/install#system-req) for full details.

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -226,7 +226,7 @@ def _gpu_engine_callback(
             "Please install using the command "
             "`pip install cudf-polars-cu12` "
             "(CUDA 12 is required for RAPIDS cuDF v25.08 and later). "
-            "If your system uses CUDA 11, install with "
+            "If your system has a CUDA 11 driver, install with "
             "`pip install --extra-index-url=https://pypi.nvidia.com cudf-polars-cu11==25.06` "
         ),
     )

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -225,8 +225,9 @@ def _gpu_engine_callback(
         install_message=(
             "Please install using the command "
             "`pip install cudf-polars-cu12` "
-            "(or `pip install --extra-index-url=https://pypi.nvidia.com cudf-polars-cu11` "
-            "if your system has a CUDA 11 driver)."
+            "(CUDA 12 is required for RAPIDS cuDF v25.08 and later). "
+            "If your system uses CUDA 11, install with "
+            "`pip install --extra-index-url=https://pypi.nvidia.com cudf-polars-cu11==25.06` "
         ),
     )
     if not is_config_obj:

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -227,7 +227,7 @@ def _gpu_engine_callback(
             "`pip install cudf-polars-cu12` "
             "(CUDA 12 is required for RAPIDS cuDF v25.08 and later). "
             "If your system has a CUDA 11 driver, install with "
-            "`pip install --extra-index-url=https://pypi.nvidia.com cudf-polars-cu11==25.06` "
+            "`pip install cudf-polars-cu11==25.06` "
         ),
     )
     if not is_config_obj:


### PR DESCRIPTION
RAPIDS CUDA 11 deprecation announcement: https://docs.rapids.ai/notices/rsn0048/