### PR TITLE
fix: Remove nonsensical duration variance

### DIFF
--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -518,21 +518,6 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
         ))
     }
 
-    fn var_reduce(&self, ddof: u8) -> PolarsResult<Scalar> {
-        // Why do we go via MilliSeconds here? Seems wrong to me.
-        // I think we should fix/inspect the tests that fail if we remain on the time-unit here.
-        let sc = self
-            .0
-            .cast_time_unit(TimeUnit::Milliseconds)
-            .physical()
-            .var_reduce(ddof);
-        let to = self.dtype().to_physical();
-        let v = sc.value().cast(&to);
-        Ok(Scalar::new(
-            DataType::Duration(TimeUnit::Milliseconds),
-            v.as_duration(TimeUnit::Milliseconds),
-        ))
-    }
     fn median_reduce(&self) -> PolarsResult<Scalar> {
         let v: AnyValue = self.median().map(|v| v as i64).into();
         let to = self.dtype().to_physical();

--- a/crates/polars-ops/src/chunked_array/list/dispersion.rs
+++ b/crates/polars-ops/src/chunked_array/list/dispersion.rs
@@ -58,39 +58,22 @@ pub(super) fn std_with_nulls(ca: &ListChunked, ddof: u8) -> Series {
     }
 }
 
-pub(super) fn var_with_nulls(ca: &ListChunked, ddof: u8) -> Series {
+pub(super) fn var_with_nulls(ca: &ListChunked, ddof: u8) -> PolarsResult<Series> {
     match ca.inner_dtype() {
         DataType::Float32 => {
             let out: Float32Chunked = ca
                 .apply_amortized_generic(|s| s.and_then(|s| s.as_ref().var(ddof).map(|v| v as f32)))
                 .with_name(ca.name().clone());
-            out.into_series()
+            Ok(out.into_series())
         },
-        #[cfg(feature = "dtype-duration")]
-        DataType::Duration(TimeUnit::Milliseconds) => {
-            let out: Int64Chunked = ca
-                .apply_amortized_generic(|s| s.and_then(|s| s.as_ref().var(ddof).map(|v| v as i64)))
-                .with_name(ca.name().clone());
-            out.into_duration(TimeUnit::Milliseconds).into_series()
-        },
-        #[cfg(feature = "dtype-duration")]
-        DataType::Duration(TimeUnit::Microseconds | TimeUnit::Nanoseconds) => {
-            let out: Int64Chunked = ca
-                .cast(&DataType::List(Box::new(DataType::Duration(
-                    TimeUnit::Milliseconds,
-                ))))
-                .unwrap()
-                .list()
-                .unwrap()
-                .apply_amortized_generic(|s| s.and_then(|s| s.as_ref().var(ddof).map(|v| v as i64)))
-                .with_name(ca.name().clone());
-            out.into_duration(TimeUnit::Milliseconds).into_series()
+        dt if dt.is_temporal() => {
+            polars_bail!(InvalidOperation: "variance of type {dt} is not supported")
         },
         _ => {
             let out: Float64Chunked = ca
                 .apply_amortized_generic(|s| s.and_then(|s| s.as_ref().var(ddof)))
                 .with_name(ca.name().clone());
-            out.into_series()
+            Ok(out.into_series())
         },
     }
 }

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -229,7 +229,7 @@ pub trait ListNameSpaceImpl: AsList {
         dispersion::std_with_nulls(ca, ddof)
     }
 
-    fn lst_var(&self, ddof: u8) -> Series {
+    fn lst_var(&self, ddof: u8) -> PolarsResult<Series> {
         let ca = self.as_list();
         dispersion::var_with_nulls(ca, ddof)
     }

--- a/crates/polars-plan/src/plans/aexpr/function_expr/list.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/list.rs
@@ -728,7 +728,7 @@ pub(super) fn std(s: &Column, ddof: u8) -> PolarsResult<Column> {
 }
 
 pub(super) fn var(s: &Column, ddof: u8) -> PolarsResult<Column> {
-    Ok(s.list()?.lst_var(ddof).into())
+    Ok(s.list()?.lst_var(ddof)?.into())
 }
 
 pub(super) fn arg_min(s: &Column) -> PolarsResult<Column> {

--- a/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
@@ -476,12 +476,13 @@ impl<'a> FieldsMapper<'a> {
     pub fn var_dtype(&self) -> PolarsResult<Field> {
         if self.fields[0].dtype().leaf_dtype().is_duration() {
             let map_inner = |dt: &DataType| match dt {
-                #[cfg(feature = "dtype-duration")]
-                DataType::Duration(_) => DataType::Duration(TimeUnit::Milliseconds),
-                dt => dt.clone(),
+                dt if dt.is_temporal() => {
+                    polars_bail!(InvalidOperation: "variance of type {dt} is not supported")
+                },
+                dt => Ok(dt.clone()),
             };
 
-            self.map_dtype(|dt| match dt {
+            self.try_map_dtype(|dt| match dt {
                 #[cfg(feature = "dtype-array")]
                 DataType::Array(inner, _) => map_inner(inner),
                 DataType::List(inner) => map_inner(inner),

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -243,7 +243,7 @@ impl AExpr {
                     Var(expr, _) => {
                         let field = [ctx.arena.get(*expr).to_field_impl(ctx)?];
                         let mapper = FieldsMapper::new(&field);
-                        mapper.moment_dtype()
+                        mapper.var_dtype()
                     },
                     NUnique(expr) => {
                         let mut field = ctx.arena.get(*expr).to_field_impl(ctx)?;

--- a/py-polars/tests/unit/datatypes/test_array.py
+++ b/py-polars/tests/unit/datatypes/test_array.py
@@ -204,18 +204,12 @@ def test_arr_var(data_dispersion: pl.DataFrame) -> None:
     result = df.select(
         pl.col("int").arr.var().name.suffix("_var"),
         pl.col("float").arr.var().name.suffix("_var"),
-        pl.col("duration").arr.var().name.suffix("_var"),
     )
 
     expected = pl.DataFrame(
         [
             pl.Series("int_var", [2.5], dtype=pl.Float64),
             pl.Series("float_var", [2.5], dtype=pl.Float64),
-            pl.Series(
-                "duration_var",
-                [timedelta(microseconds=2000)],
-                dtype=pl.Duration(time_unit="ms"),
-            ),
         ]
     )
 

--- a/py-polars/tests/unit/datatypes/test_duration.py
+++ b/py-polars/tests/unit/datatypes/test_duration.py
@@ -138,17 +138,11 @@ def test_duration_std_var() -> None:
     )
 
     result = df.select(
-        pl.col("duration").var().name.suffix("_var"),
         pl.col("duration").std().name.suffix("_std"),
     )
 
     expected = pl.DataFrame(
         [
-            pl.Series(
-                "duration_var",
-                [timedelta(microseconds=4000)],
-                dtype=pl.Duration(time_unit="ms"),
-            ),
             pl.Series(
                 "duration_std",
                 [timedelta(microseconds=2000)],
@@ -159,16 +153,14 @@ def test_duration_std_var() -> None:
 
     assert_frame_equal(result, expected)
 
+    with pytest.raises(pl.exceptions.InvalidOperationError):
+        df.select(pl.col("duration").var())
+
 
 def test_series_duration_std_var() -> None:
     s = pl.Series([timedelta(days=1), timedelta(days=2), timedelta(days=4)])
     assert s.std() == timedelta(days=1, seconds=45578, microseconds=180014)
-    assert s.var() == timedelta(days=201600000)
-
-
-def test_series_duration_var_overflow() -> None:
-    s = pl.Series([timedelta(days=10), timedelta(days=20), timedelta(days=40)])
-    with pytest.raises(OverflowError):
+    with pytest.raises(pl.exceptions.InvalidOperationError):
         s.var()
 
 

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -682,30 +682,6 @@ def data_dispersion() -> pl.DataFrame:
     )
 
 
-def test_list_var(data_dispersion: pl.DataFrame) -> None:
-    df = data_dispersion
-
-    result = df.select(
-        pl.col("int").list.var().name.suffix("_var"),
-        pl.col("float").list.var().name.suffix("_var"),
-        pl.col("duration").list.var().name.suffix("_var"),
-    )
-
-    expected = pl.DataFrame(
-        [
-            pl.Series("int_var", [2.5], dtype=pl.Float64),
-            pl.Series("float_var", [2.5], dtype=pl.Float64),
-            pl.Series(
-                "duration_var",
-                [timedelta(microseconds=2000)],
-                dtype=pl.Duration(time_unit="ms"),
-            ),
-        ]
-    )
-
-    assert_frame_equal(result, expected)
-
-
 def test_list_std(data_dispersion: pl.DataFrame) -> None:
     df = data_dispersion
 


### PR DESCRIPTION
The unit of a variance is input unit squared.

So a variance of data in `m` is `m^2`. Given that we don't have a datatype with `s^2`, doing a variance on duration is non-sensical.

This will remove that implementation.