### PR TITLE
feat: Add scalar checks to range expressions

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
@@ -582,15 +582,22 @@ pub(super) fn convert_functions(
         F::Range(range_function) => I::Range(match range_function {
             RangeFunction::IntRange { step, dtype } => {
                 let dtype = dtype.into_datatype(ctx.schema)?;
-                polars_ensure!(dtype.is_integer(), ComputeError: "non-integer `dtype` passed to `int_range`: '{dtype}'");
+                polars_ensure!(e[0].is_scalar(ctx.arena), ShapeMismatch: "non-scalar start passed to `int_range`");
+                polars_ensure!(e[1].is_scalar(ctx.arena), ShapeMismatch: "non-scalar stop passed to `int_range`");
+                polars_ensure!(dtype.is_integer(), SchemaMismatch: "non-integer `dtype` passed to `int_range`: '{dtype}'");
                 IRRangeFunction::IntRange { step, dtype }
             },
             RangeFunction::IntRanges { dtype } => {
                 let dtype = dtype.into_datatype(ctx.schema)?;
-                polars_ensure!(dtype.is_integer(), ComputeError: "non-integer `dtype` passed to `int_ranges`: '{dtype}'");
+                polars_ensure!(dtype.is_integer(), SchemaMismatch: "non-integer `dtype` passed to `int_ranges`: '{dtype}'");
                 IRRangeFunction::IntRanges { dtype }
             },
-            RangeFunction::LinearSpace { closed } => IRRangeFunction::LinearSpace { closed },
+            RangeFunction::LinearSpace { closed } => {
+                polars_ensure!(e[0].is_scalar(ctx.arena), ShapeMismatch: "non-scalar start passed to `linear_space`");
+                polars_ensure!(e[1].is_scalar(ctx.arena), ShapeMismatch: "non-scalar end passed to `linear_space`");
+                polars_ensure!(e[2].is_scalar(ctx.arena), ShapeMismatch: "non-scalar num_samples passed to `linear_space`");
+                IRRangeFunction::LinearSpace { closed }
+            },
             RangeFunction::LinearSpaces {
                 closed,
                 array_width,
@@ -600,6 +607,8 @@ pub(super) fn convert_functions(
             },
             #[cfg(feature = "dtype-date")]
             RangeFunction::DateRange { interval, closed } => {
+                polars_ensure!(e[0].is_scalar(ctx.arena), ShapeMismatch: "non-scalar start passed to `date_range`");
+                polars_ensure!(e[1].is_scalar(ctx.arena), ShapeMismatch: "non-scalar end passed to `date_range`");
                 IRRangeFunction::DateRange { interval, closed }
             },
             #[cfg(feature = "dtype-date")]
@@ -612,11 +621,15 @@ pub(super) fn convert_functions(
                 closed,
                 time_unit,
                 time_zone,
-            } => IRRangeFunction::DatetimeRange {
-                interval,
-                closed,
-                time_unit,
-                time_zone,
+            } => {
+                polars_ensure!(e[0].is_scalar(ctx.arena), ShapeMismatch: "non-scalar start passed to `datetime_range`");
+                polars_ensure!(e[1].is_scalar(ctx.arena), ShapeMismatch: "non-scalar end passed to `datetime_range`");
+                IRRangeFunction::DatetimeRange {
+                    interval,
+                    closed,
+                    time_unit,
+                    time_zone,
+                }
             },
             #[cfg(feature = "dtype-datetime")]
             RangeFunction::DatetimeRanges {
@@ -632,6 +645,8 @@ pub(super) fn convert_functions(
             },
             #[cfg(feature = "dtype-time")]
             RangeFunction::TimeRange { interval, closed } => {
+                polars_ensure!(e[0].is_scalar(ctx.arena), ShapeMismatch: "non-scalar start passed to `time_range`");
+                polars_ensure!(e[1].is_scalar(ctx.arena), ShapeMismatch: "non-scalar end passed to `time_range`");
                 IRRangeFunction::TimeRange { interval, closed }
             },
             #[cfg(feature = "dtype-time")]

--- a/crates/polars-python/src/functions/range.rs
+++ b/crates/polars-python/src/functions/range.rs
@@ -36,7 +36,7 @@ pub fn eager_int_range(
 
     if !dtype.is_integer() {
         return Err(PyPolarsErr::from(
-            polars_err!(ComputeError: "non-integer `dtype` passed to `int_range`: '{}'", dtype),
+            polars_err!(SchemaMismatch: "non-integer `dtype` passed to `int_range`: '{}'", dtype),
         )
         .into());
     }

--- a/py-polars/tests/unit/functions/range/test_int_range.py
+++ b/py-polars/tests/unit/functions/range/test_int_range.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError, InvalidOperationError
+from polars.exceptions import ComputeError, InvalidOperationError, ShapeError, SchemaError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -164,17 +164,11 @@ def test_int_range_input_shape_empty() -> None:
     empty = pl.Series(dtype=pl.Time)
     single = pl.Series([5])
 
-    with pytest.raises(
-        ComputeError, match="`start` must contain exactly one value, got 0 values"
-    ):
+    with pytest.raises(ShapeError):
         pl.int_range(empty, single, eager=True)
-    with pytest.raises(
-        ComputeError, match="`end` must contain exactly one value, got 0 values"
-    ):
+    with pytest.raises(ShapeError):
         pl.int_range(single, empty, eager=True)
-    with pytest.raises(
-        ComputeError, match="`start` must contain exactly one value, got 0 values"
-    ):
+    with pytest.raises(ShapeError):
         pl.int_range(empty, empty, eager=True)
 
 
@@ -182,17 +176,11 @@ def test_int_range_input_shape_multiple_values() -> None:
     single = pl.Series([5])
     multiple = pl.Series([10, 15])
 
-    with pytest.raises(
-        ComputeError, match="`start` must contain exactly one value, got 2 values"
-    ):
+    with pytest.raises(ShapeError):
         pl.int_range(multiple, single, eager=True)
-    with pytest.raises(
-        ComputeError, match="`end` must contain exactly one value, got 2 values"
-    ):
+    with pytest.raises(ShapeError):
         pl.int_range(single, multiple, eager=True)
-    with pytest.raises(
-        ComputeError, match="`start` must contain exactly one value, got 2 values"
-    ):
+    with pytest.raises(ShapeError):
         pl.int_range(multiple, multiple, eager=True)
 
 
@@ -217,7 +205,7 @@ def test_int_range_invalid_conversion() -> None:
 
 def test_int_range_non_integer_dtype() -> None:
     with pytest.raises(
-        ComputeError, match="non-integer `dtype` passed to `int_range`: 'f64'"
+        SchemaError, match="non-integer `dtype` passed to `int_range`: 'f64'"
     ):
         pl.select(pl.int_range(3, -1, -1, dtype=pl.Float64))  # type: ignore[arg-type]
 
@@ -267,7 +255,7 @@ def test_int_ranges_broadcasting() -> None:
 # https://github.com/pola-rs/polars/issues/15307
 def test_int_range_non_int_dtype() -> None:
     with pytest.raises(
-        ComputeError, match="non-integer `dtype` passed to `int_range`: 'str'"
+        SchemaError, match="non-integer `dtype` passed to `int_range`: 'str'"
     ):
         pl.int_range(0, 3, dtype=pl.String, eager=True)  # type: ignore[arg-type]
 
@@ -275,7 +263,7 @@ def test_int_range_non_int_dtype() -> None:
 # https://github.com/pola-rs/polars/issues/15307
 def test_int_ranges_non_int_dtype() -> None:
     with pytest.raises(
-        ComputeError, match="non-integer `dtype` passed to `int_ranges`: 'str'"
+        SchemaError, match="non-integer `dtype` passed to `int_ranges`: 'str'"
     ):
         pl.int_ranges(0, 3, dtype=pl.String, eager=True)  # type: ignore[arg-type]
 

--- a/py-polars/tests/unit/functions/range/test_int_range.py
+++ b/py-polars/tests/unit/functions/range/test_int_range.py
@@ -5,7 +5,12 @@ from typing import Any
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError, InvalidOperationError, ShapeError, SchemaError
+from polars.exceptions import (
+    ComputeError,
+    InvalidOperationError,
+    SchemaError,
+    ShapeError,
+)
 from polars.testing import assert_frame_equal, assert_series_equal
 
 

--- a/py-polars/tests/unit/functions/range/test_linear_space.py
+++ b/py-polars/tests/unit/functions/range/test_linear_space.py
@@ -208,9 +208,7 @@ def test_linear_space_num_samples_expr() -> None:
 
 def test_linear_space_invalid_num_samples_expr() -> None:
     lf = pl.LazyFrame({"x": [1, 2, 3]})
-    with pytest.raises(
-        ComputeError, match="`num_samples` must contain exactly one value, got 3 values"
-    ):
+    with pytest.raises(ShapeError):
         lf.select(pl.linear_space(0, 1, pl.col("x"))).collect()
 
 


### PR DESCRIPTION
These functions should only accept scalars for their parameters, this prevents misuse.