### PR TITLE
feat: Lower row-separable functions in streaming engine

### DIFF
--- a/crates/polars-plan/src/plans/options.rs
+++ b/crates/polars-plan/src/plans/options.rs
@@ -132,6 +132,10 @@ impl FunctionFlags {
     pub fn is_elementwise(self) -> bool {
         self.contains(Self::ROW_SEPARABLE | Self::LENGTH_PRESERVING)
     }
+    
+    pub fn is_row_separable(self) -> bool {
+        self.contains(Self::ROW_SEPARABLE)
+    }
 
     pub fn is_length_preserving(self) -> bool {
         self.contains(Self::LENGTH_PRESERVING)
@@ -196,6 +200,10 @@ impl FunctionOptions {
 
     pub fn is_length_preserving(&self) -> bool {
         self.flags.contains(FunctionFlags::LENGTH_PRESERVING)
+    }
+    
+    pub fn is_row_separable(&self) -> bool {
+        self.flags.is_row_separable()
     }
 
     pub fn returns_scalar(&self) -> bool {

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -736,6 +736,7 @@ fn lower_exprs_with_ctx(
                 transformed_exprs.push(ctx.expr_arena.add(AExpr::Column(out_name)));
             },
 
+            // Lower arbitrary elementwise functions.
             ref node @ AExpr::Function {
                 input: ref inner_exprs,
                 options,
@@ -766,6 +767,32 @@ fn lower_exprs_with_ctx(
                 }
                 input_streams.insert(trans_input);
                 transformed_exprs.push(ctx.expr_arena.add(new_node));
+            },
+
+            // Lower arbitrary row-separable functions.
+            ref node @ AExpr::Function { input: ref inner_exprs, ref function, options } if options.is_row_separable() && !is_fake_elementwise_function(node) => {
+                // While these functions are streamable, they are not elementwise, so we
+                // have to transform them to a select node.
+                let inner_nodes = inner_exprs.iter().map(|x| x.node()).collect_vec();
+                let (trans_input, trans_exprs) = lower_exprs_with_ctx(input, &inner_nodes, ctx)?;
+                let out_name = unique_column_name();
+                let trans_inner = ctx.expr_arena.add(AExpr::Function {
+                    input: trans_exprs.iter().map(|node| ExprIR::from_node(*node, &ctx.expr_arena)).collect(),
+                    function: function.clone(),
+                    options
+                });
+                let func_expr =
+                    ExprIR::new(trans_inner, OutputName::Alias(out_name.clone()));
+                let output_schema =
+                    schema_for_select(trans_input, std::slice::from_ref(&func_expr), ctx)?;
+                let node_kind = PhysNodeKind::Select {
+                    input: trans_input,
+                    selectors: vec![func_expr.clone()],
+                    extend_original: false,
+                };
+                let node_key = ctx.phys_sm.insert(PhysNode::new(output_schema, node_kind));
+                input_streams.insert(PhysStream::first(node_key));
+                transformed_exprs.push(ctx.expr_arena.add(AExpr::Column(out_name)));
             },
 
             AExpr::BinaryExpr { left, op, right } => {


### PR DESCRIPTION
This should cover a lot of generic row-separable functions, such as `drop_nulls` or `drop_nans`.