### PR TITLE
perf: Lower any() and all() to streaming engine

### DIFF
--- a/crates/polars-core/src/series/from.rs
+++ b/crates/polars-core/src/series/from.rs
@@ -20,6 +20,16 @@ use crate::chunked_array::object::registry::get_object_builder;
 use crate::prelude::*;
 
 impl Series {
+    pub fn from_array<A: ParameterFreeDtypeStaticArray>(name: PlSmallStr, array: A) -> Self {
+        unsafe {
+            Self::from_chunks_and_dtype_unchecked(
+                name,
+                vec![Box::new(array)],
+                &DataType::from_arrow_dtype(&A::get_dtype()),
+            )
+        }
+    }
+
     pub fn from_chunk_and_dtype(
         name: PlSmallStr,
         chunk: ArrayRef,

--- a/crates/polars-expr/src/reduce/any_all.rs
+++ b/crates/polars-expr/src/reduce/any_all.rs
@@ -1,0 +1,462 @@
+use arrow::array::BooleanArray;
+use arrow::bitmap::binary_assign_mut;
+
+use super::*;
+
+pub fn new_any_reduction(ignore_nulls: bool) -> Box<dyn GroupedReduction> {
+    if ignore_nulls {
+        Box::new(AnyIgnoreNullGroupedReduction::default())
+    } else {
+        Box::new(AnyKleeneNullGroupedReduction::default())
+    }
+}
+
+pub fn new_all_reduction(ignore_nulls: bool) -> Box<dyn GroupedReduction> {
+    if ignore_nulls {
+        Box::new(AllIgnoreNullGroupedReduction::default())
+    } else {
+        Box::new(AllKleeneNullGroupedReduction::default())
+    }
+}
+
+#[derive(Default)]
+struct AnyIgnoreNullGroupedReduction {
+    values: MutableBitmap,
+    evicted_values: BitmapBuilder,
+}
+
+impl GroupedReduction for AnyIgnoreNullGroupedReduction {
+    fn new_empty(&self) -> Box<dyn GroupedReduction> {
+        Box::new(Self::default())
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        self.values.reserve(additional);
+    }
+
+    fn resize(&mut self, num_groups: IdxSize) {
+        self.values.resize(num_groups as usize, false);
+    }
+
+    fn update_group(
+        &mut self,
+        values: &Column,
+        group_idx: IdxSize,
+        _seq_id: u64,
+    ) -> PolarsResult<()> {
+        assert!(values.dtype() == &DataType::Boolean);
+        let values = values.as_materialized_series_maintain_scalar();
+        let ca: &BooleanChunked = values.as_ref().as_ref();
+        if ca.any() {
+            self.values.set(group_idx as usize, true);
+        }
+        Ok(())
+    }
+
+    unsafe fn update_groups_while_evicting(
+        &mut self,
+        values: &Column,
+        subset: &[IdxSize],
+        group_idxs: &[EvictIdx],
+        _seq_id: u64,
+    ) -> PolarsResult<()> {
+        assert!(values.dtype() == &DataType::Boolean);
+        assert!(subset.len() == group_idxs.len());
+        let values = values.as_materialized_series(); // @scalar-opt
+        let ca: &BooleanChunked = values.as_ref().as_ref();
+        let arr = ca.downcast_as_array();
+        unsafe {
+            // SAFETY: indices are in-bounds guaranteed by trait.
+            for (i, g) in subset.iter().zip(group_idxs) {
+                let ov = arr.get_unchecked(*i as usize);
+                if g.should_evict() {
+                    self.evicted_values.push(self.values.get_unchecked(g.idx()));
+                    self.values.set_unchecked(g.idx(), ov.unwrap_or(false));
+                } else {
+                    self.values.or_pos_unchecked(g.idx(), ov.unwrap_or(false));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    unsafe fn combine_subset(
+        &mut self,
+        other: &dyn GroupedReduction,
+        subset: &[IdxSize],
+        group_idxs: &[IdxSize],
+    ) -> PolarsResult<()> {
+        let other = other.as_any().downcast_ref::<Self>().unwrap();
+        assert!(subset.len() == group_idxs.len());
+        unsafe {
+            // SAFETY: indices are in-bounds guaranteed by trait.
+            for (i, g) in subset.iter().zip(group_idxs) {
+                self.values
+                    .or_pos_unchecked(*g as usize, other.values.get_unchecked(*i as usize));
+            }
+        }
+        Ok(())
+    }
+
+    fn take_evictions(&mut self) -> Box<dyn GroupedReduction> {
+        Box::new(Self {
+            values: core::mem::take(&mut self.evicted_values).into_mut(),
+            evicted_values: BitmapBuilder::new(),
+        })
+    }
+
+    fn finalize(&mut self) -> PolarsResult<Series> {
+        let v = core::mem::take(&mut self.values);
+        let arr = BooleanArray::from(v.freeze());
+        Ok(Series::from_array(PlSmallStr::EMPTY, arr))
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[derive(Default)]
+struct AllIgnoreNullGroupedReduction {
+    values: MutableBitmap,
+    evicted_values: BitmapBuilder,
+}
+
+impl GroupedReduction for AllIgnoreNullGroupedReduction {
+    fn new_empty(&self) -> Box<dyn GroupedReduction> {
+        Box::new(Self::default())
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        self.values.reserve(additional);
+    }
+
+    fn resize(&mut self, num_groups: IdxSize) {
+        self.values.resize(num_groups as usize, true);
+    }
+
+    fn update_group(
+        &mut self,
+        values: &Column,
+        group_idx: IdxSize,
+        _seq_id: u64,
+    ) -> PolarsResult<()> {
+        assert!(values.dtype() == &DataType::Boolean);
+        let values = values.as_materialized_series_maintain_scalar();
+        let ca: &BooleanChunked = values.as_ref().as_ref();
+        if !ca.all() {
+            self.values.set(group_idx as usize, false);
+        }
+        Ok(())
+    }
+
+    unsafe fn update_groups_while_evicting(
+        &mut self,
+        values: &Column,
+        subset: &[IdxSize],
+        group_idxs: &[EvictIdx],
+        _seq_id: u64,
+    ) -> PolarsResult<()> {
+        assert!(values.dtype() == &DataType::Boolean);
+        assert!(subset.len() == group_idxs.len());
+        let values = values.as_materialized_series(); // @scalar-opt
+        let ca: &BooleanChunked = values.as_ref().as_ref();
+        let arr = ca.downcast_as_array();
+        unsafe {
+            // SAFETY: indices are in-bounds guaranteed by trait.
+            for (i, g) in subset.iter().zip(group_idxs) {
+                let ov = arr.get_unchecked(*i as usize);
+                if g.should_evict() {
+                    self.evicted_values.push(self.values.get_unchecked(g.idx()));
+                    self.values.set_unchecked(g.idx(), ov.unwrap_or(true));
+                } else {
+                    self.values.and_pos_unchecked(g.idx(), ov.unwrap_or(true));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    unsafe fn combine_subset(
+        &mut self,
+        other: &dyn GroupedReduction,
+        subset: &[IdxSize],
+        group_idxs: &[IdxSize],
+    ) -> PolarsResult<()> {
+        let other = other.as_any().downcast_ref::<Self>().unwrap();
+        assert!(subset.len() == group_idxs.len());
+        unsafe {
+            // SAFETY: indices are in-bounds guaranteed by trait.
+            for (i, g) in subset.iter().zip(group_idxs) {
+                self.values
+                    .and_pos_unchecked(*g as usize, other.values.get_unchecked(*i as usize));
+            }
+        }
+        Ok(())
+    }
+
+    fn take_evictions(&mut self) -> Box<dyn GroupedReduction> {
+        Box::new(Self {
+            values: core::mem::take(&mut self.evicted_values).into_mut(),
+            evicted_values: BitmapBuilder::new(),
+        })
+    }
+
+    fn finalize(&mut self) -> PolarsResult<Series> {
+        let v = core::mem::take(&mut self.values);
+        let arr = BooleanArray::from(v.freeze());
+        Ok(Series::from_array(PlSmallStr::EMPTY, arr))
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[derive(Default)]
+struct AnyKleeneNullGroupedReduction {
+    seen_true: MutableBitmap,
+    seen_null: MutableBitmap,
+    evicted_values: BitmapBuilder,
+    evicted_mask: BitmapBuilder,
+}
+
+impl GroupedReduction for AnyKleeneNullGroupedReduction {
+    fn new_empty(&self) -> Box<dyn GroupedReduction> {
+        Box::new(Self::default())
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        self.seen_true.reserve(additional);
+        self.seen_null.reserve(additional)
+    }
+
+    fn resize(&mut self, num_groups: IdxSize) {
+        self.seen_true.resize(num_groups as usize, false);
+        self.seen_null.resize(num_groups as usize, false);
+    }
+
+    fn update_group(
+        &mut self,
+        values: &Column,
+        group_idx: IdxSize,
+        _seq_id: u64,
+    ) -> PolarsResult<()> {
+        assert!(values.dtype() == &DataType::Boolean);
+        let values = values.as_materialized_series_maintain_scalar();
+        let ca: &BooleanChunked = values.as_ref().as_ref();
+        if ca.any() {
+            self.seen_true.set(group_idx as usize, true);
+        }
+        if ca.len() != ca.null_count() {
+            self.seen_null.set(group_idx as usize, true);
+        }
+        Ok(())
+    }
+
+    unsafe fn update_groups_while_evicting(
+        &mut self,
+        values: &Column,
+        subset: &[IdxSize],
+        group_idxs: &[EvictIdx],
+        _seq_id: u64,
+    ) -> PolarsResult<()> {
+        assert!(values.dtype() == &DataType::Boolean);
+        assert!(subset.len() == group_idxs.len());
+        let values = values.as_materialized_series(); // @scalar-opt
+        let ca: &BooleanChunked = values.as_ref().as_ref();
+        let arr = ca.downcast_as_array();
+        unsafe {
+            // SAFETY: indices are in-bounds guaranteed by trait.
+            for (i, g) in subset.iter().zip(group_idxs) {
+                let ov = arr.get_unchecked(*i as usize);
+                if g.should_evict() {
+                    self.evicted_values
+                        .push(self.seen_true.get_unchecked(g.idx()));
+                    self.evicted_mask
+                        .push(self.seen_null.get_unchecked(g.idx()));
+                    self.seen_true.set_unchecked(g.idx(), ov.unwrap_or(false));
+                    self.seen_null.set_unchecked(g.idx(), ov.is_none());
+                } else {
+                    self.seen_true
+                        .or_pos_unchecked(g.idx(), ov.unwrap_or(false));
+                    self.seen_null.or_pos_unchecked(g.idx(), ov.is_none());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    unsafe fn combine_subset(
+        &mut self,
+        other: &dyn GroupedReduction,
+        subset: &[IdxSize],
+        group_idxs: &[IdxSize],
+    ) -> PolarsResult<()> {
+        let other = other.as_any().downcast_ref::<Self>().unwrap();
+        assert!(subset.len() == group_idxs.len());
+        unsafe {
+            // SAFETY: indices are in-bounds guaranteed by trait.
+            for (i, g) in subset.iter().zip(group_idxs) {
+                self.seen_true
+                    .or_pos_unchecked(*g as usize, other.seen_true.get_unchecked(*i as usize));
+                self.seen_null
+                    .or_pos_unchecked(*g as usize, other.seen_null.get_unchecked(*i as usize));
+            }
+        }
+        Ok(())
+    }
+
+    fn take_evictions(&mut self) -> Box<dyn GroupedReduction> {
+        Box::new(Self {
+            seen_true: core::mem::take(&mut self.evicted_values).into_mut(),
+            seen_null: core::mem::take(&mut self.evicted_mask).into_mut(),
+            evicted_values: BitmapBuilder::new(),
+            evicted_mask: BitmapBuilder::new(),
+        })
+    }
+
+    fn finalize(&mut self) -> PolarsResult<Series> {
+        let seen_true = core::mem::take(&mut self.seen_true);
+        let mut mask = core::mem::take(&mut self.seen_null);
+        binary_assign_mut(&mut mask, &seen_true, |mi: u64, ti: u64| mi & !ti);
+        let arr = BooleanArray::from(seen_true.freeze())
+            .with_validity(Some(mask.freeze()))
+            .boxed();
+        Ok(unsafe {
+            Series::from_chunks_and_dtype_unchecked(
+                PlSmallStr::EMPTY,
+                vec![arr],
+                &DataType::Boolean,
+            )
+        })
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[derive(Default)]
+struct AllKleeneNullGroupedReduction {
+    seen_false: MutableBitmap,
+    seen_null: MutableBitmap,
+    evicted_values: BitmapBuilder,
+    evicted_mask: BitmapBuilder,
+}
+
+impl GroupedReduction for AllKleeneNullGroupedReduction {
+    fn new_empty(&self) -> Box<dyn GroupedReduction> {
+        Box::new(Self::default())
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        self.seen_false.reserve(additional);
+        self.seen_null.reserve(additional)
+    }
+
+    fn resize(&mut self, num_groups: IdxSize) {
+        self.seen_false.resize(num_groups as usize, false);
+        self.seen_null.resize(num_groups as usize, false);
+    }
+
+    fn update_group(
+        &mut self,
+        values: &Column,
+        group_idx: IdxSize,
+        _seq_id: u64,
+    ) -> PolarsResult<()> {
+        assert!(values.dtype() == &DataType::Boolean);
+        let values = values.as_materialized_series_maintain_scalar();
+        let ca: &BooleanChunked = values.as_ref().as_ref();
+        if !ca.all() {
+            self.seen_false.set(group_idx as usize, true);
+        }
+        if ca.len() != ca.null_count() {
+            self.seen_null.set(group_idx as usize, true);
+        }
+        Ok(())
+    }
+
+    unsafe fn update_groups_while_evicting(
+        &mut self,
+        values: &Column,
+        subset: &[IdxSize],
+        group_idxs: &[EvictIdx],
+        _seq_id: u64,
+    ) -> PolarsResult<()> {
+        assert!(values.dtype() == &DataType::Boolean);
+        assert!(subset.len() == group_idxs.len());
+        let values = values.as_materialized_series(); // @scalar-opt
+        let ca: &BooleanChunked = values.as_ref().as_ref();
+        let arr = ca.downcast_as_array();
+        unsafe {
+            // SAFETY: indices are in-bounds guaranteed by trait.
+            for (i, g) in subset.iter().zip(group_idxs) {
+                let ov = arr.get_unchecked(*i as usize);
+                if g.should_evict() {
+                    self.evicted_values
+                        .push(self.seen_false.get_unchecked(g.idx()));
+                    self.evicted_mask
+                        .push(self.seen_null.get_unchecked(g.idx()));
+                    self.seen_false.set_unchecked(g.idx(), !ov.unwrap_or(true));
+                    self.seen_null.set_unchecked(g.idx(), ov.is_none());
+                } else {
+                    self.seen_false
+                        .or_pos_unchecked(g.idx(), !ov.unwrap_or(true));
+                    self.seen_null.or_pos_unchecked(g.idx(), ov.is_none());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    unsafe fn combine_subset(
+        &mut self,
+        other: &dyn GroupedReduction,
+        subset: &[IdxSize],
+        group_idxs: &[IdxSize],
+    ) -> PolarsResult<()> {
+        let other = other.as_any().downcast_ref::<Self>().unwrap();
+        assert!(subset.len() == group_idxs.len());
+        unsafe {
+            // SAFETY: indices are in-bounds guaranteed by trait.
+            for (i, g) in subset.iter().zip(group_idxs) {
+                self.seen_false
+                    .or_pos_unchecked(*g as usize, other.seen_false.get_unchecked(*i as usize));
+                self.seen_null
+                    .or_pos_unchecked(*g as usize, other.seen_null.get_unchecked(*i as usize));
+            }
+        }
+        Ok(())
+    }
+
+    fn take_evictions(&mut self) -> Box<dyn GroupedReduction> {
+        Box::new(Self {
+            seen_false: core::mem::take(&mut self.evicted_values).into_mut(),
+            seen_null: core::mem::take(&mut self.evicted_mask).into_mut(),
+            evicted_values: BitmapBuilder::new(),
+            evicted_mask: BitmapBuilder::new(),
+        })
+    }
+
+    fn finalize(&mut self) -> PolarsResult<Series> {
+        let seen_false = core::mem::take(&mut self.seen_false);
+        let mut mask = core::mem::take(&mut self.seen_null);
+        binary_assign_mut(&mut mask, &seen_false, |mi: u64, fi: u64| mi & !fi);
+        let arr = BooleanArray::from((!seen_false).freeze())
+            .with_validity(Some(mask.freeze()))
+            .boxed();
+        Ok(unsafe {
+            Series::from_chunks_and_dtype_unchecked(
+                PlSmallStr::EMPTY,
+                vec![arr],
+                &DataType::Boolean,
+            )
+        })
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/crates/polars-expr/src/reduce/bitwise.rs
+++ b/crates/polars-expr/src/reduce/bitwise.rs
@@ -131,7 +131,7 @@ where
 }
 
 #[derive(Default)]
-pub struct BoolXorGroupedReduction {
+struct BoolXorGroupedReduction {
     values: MutableBitmap,
     mask: MutableBitmap,
     evicted_values: BitmapBuilder,
@@ -236,16 +236,8 @@ impl GroupedReduction for BoolXorGroupedReduction {
     fn finalize(&mut self) -> PolarsResult<Series> {
         let v = core::mem::take(&mut self.values);
         let m = core::mem::take(&mut self.mask);
-        let arr = BooleanArray::from(v.freeze())
-            .with_validity(Some(m.freeze()))
-            .boxed();
-        Ok(unsafe {
-            Series::from_chunks_and_dtype_unchecked(
-                PlSmallStr::EMPTY,
-                vec![arr],
-                &DataType::Boolean,
-            )
-        })
+        let arr = BooleanArray::from(v.freeze()).with_validity(Some(m.freeze()));
+        Ok(Series::from_array(PlSmallStr::EMPTY, arr))
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/crates/polars-expr/src/reduce/min_max.rs
+++ b/crates/polars-expr/src/reduce/min_max.rs
@@ -388,16 +388,8 @@ impl GroupedReduction for BoolMinGroupedReduction {
     fn finalize(&mut self) -> PolarsResult<Series> {
         let v = core::mem::take(&mut self.values);
         let m = core::mem::take(&mut self.mask);
-        let arr = BooleanArray::from(v.freeze())
-            .with_validity(Some(m.freeze()))
-            .boxed();
-        Ok(unsafe {
-            Series::from_chunks_and_dtype_unchecked(
-                PlSmallStr::EMPTY,
-                vec![arr],
-                &DataType::Boolean,
-            )
-        })
+        let arr = BooleanArray::from(v.freeze()).with_validity(Some(m.freeze()));
+        Ok(Series::from_array(PlSmallStr::EMPTY, arr))
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -510,16 +502,8 @@ impl GroupedReduction for BoolMaxGroupedReduction {
     fn finalize(&mut self) -> PolarsResult<Series> {
         let v = core::mem::take(&mut self.values);
         let m = core::mem::take(&mut self.mask);
-        let arr = BooleanArray::from(v.freeze())
-            .with_validity(Some(m.freeze()))
-            .boxed();
-        Ok(unsafe {
-            Series::from_chunks_and_dtype_unchecked(
-                PlSmallStr::EMPTY,
-                vec![arr],
-                &DataType::Boolean,
-            )
-        })
+        let arr = BooleanArray::from(v.freeze()).with_validity(Some(m.freeze()));
+        Ok(Series::from_array(PlSmallStr::EMPTY, arr))
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/crates/polars-expr/src/reduce/mod.rs
+++ b/crates/polars-expr/src/reduce/mod.rs
@@ -1,4 +1,5 @@
 #![allow(unsafe_op_in_unsafe_fn)]
+mod any_all;
 #[cfg(feature = "bitwise")]
 mod bitwise;
 mod convert;

--- a/crates/polars-stream/src/physical_plan/lower_group_by.rs
+++ b/crates/polars-stream/src/physical_plan/lower_group_by.rs
@@ -172,13 +172,14 @@ fn try_lower_elementwise_scalar_agg_expr(
         #[cfg(feature = "bitwise")]
         AExpr::Function {
             input: inner_exprs,
-            function: IRFunctionExpr::Bitwise(inner_fn),
+            function:
+                IRFunctionExpr::Bitwise(
+                    inner_fn @ (IRBitwiseFunction::And
+                    | IRBitwiseFunction::Or
+                    | IRBitwiseFunction::Xor),
+                ),
             options,
-        } if matches!(
-            inner_fn,
-            IRBitwiseFunction::And | IRBitwiseFunction::Or | IRBitwiseFunction::Xor
-        ) =>
-        {
+        } => {
             assert!(inner_exprs.len() == 1);
 
             let input = inner_exprs[0].clone().node();
@@ -208,6 +209,60 @@ fn try_lower_elementwise_scalar_agg_expr(
                     let trans_agg_node = expr_arena.add(AExpr::Function {
                         input: vec![ExprIR::from_node(input_col_node, expr_arena)],
                         function: IRFunctionExpr::Bitwise(inner_fn),
+                        options,
+                    });
+
+                    // Add to aggregation expressions and replace with a reference to its output.
+                    let agg_expr = if let Some(name) = outer_name {
+                        ExprIR::new(trans_agg_node, OutputName::Alias(name))
+                    } else {
+                        ExprIR::new(trans_agg_node, OutputName::Alias(unique_column_name()))
+                    };
+                    agg_exprs.push(agg_expr.clone());
+                    agg_expr.output_name().clone()
+                })
+                .clone();
+            let result_node = expr_arena.add(AExpr::Column(name));
+            Some(result_node)
+        },
+
+        AExpr::Function {
+            input: inner_exprs,
+            function:
+                IRFunctionExpr::Boolean(
+                    inner_fn @ (IRBooleanFunction::Any { .. } | IRBooleanFunction::All { .. }),
+                ),
+            options,
+        } => {
+            assert!(inner_exprs.len() == 1);
+
+            let input = inner_exprs[0].clone().node();
+            let inner_fn = inner_fn.clone();
+            let options = *options;
+
+            if is_input_independent(input, expr_arena, expr_cache) {
+                // TODO: we could simply return expr here, but we first need an is_scalar function, because if
+                // it is not a scalar we need to return expr.implode().
+                return None;
+            }
+
+            if !is_elementwise_rec_cached(input, expr_arena, expr_cache) {
+                return None;
+            }
+
+            let agg_id = expr_merger.get_uniq_id(expr).unwrap();
+            let name = uniq_agg_exprs
+                .entry(agg_id)
+                .or_insert_with(|| {
+                    let input_id = expr_merger.get_uniq_id(input).unwrap();
+                    let input_col = uniq_input_exprs
+                        .entry(input_id)
+                        .or_insert_with(unique_column_name)
+                        .clone();
+                    let input_col_node = expr_arena.add(AExpr::Column(input_col.clone()));
+                    let trans_agg_node = expr_arena.add(AExpr::Function {
+                        input: vec![ExprIR::from_node(input_col_node, expr_arena)],
+                        function: IRFunctionExpr::Boolean(inner_fn),
                         options,
                     });
 


### PR DESCRIPTION
These now have proper streaming aggregates using bitmaps, rather than dispatching to the in-memory engine in a blocking fashion.