### PR TITLE
refactor(rust): Use RelaxedCell for fully relaxed atomics

### DIFF
--- a/crates/polars-arrow/src/array/binview/ffi.rs
+++ b/crates/polars-arrow/src/array/binview/ffi.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use polars_error::PolarsResult;
 
@@ -48,7 +47,7 @@ unsafe impl<T: ViewType + ?Sized> ToFfi for BinaryViewArrayGeneric<T> {
             views: self.views.clone(),
             buffers: self.buffers.clone(),
             phantom: Default::default(),
-            total_bytes_len: AtomicU64::new(self.total_bytes_len.load(Ordering::Relaxed)),
+            total_bytes_len: self.total_bytes_len.clone(),
             total_buffer_len: self.total_buffer_len,
         }
     }

--- a/crates/polars-arrow/src/array/binview/mod.rs
+++ b/crates/polars-arrow/src/array/binview/mod.rs
@@ -15,9 +15,9 @@ use std::any::Any;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use polars_error::*;
+use polars_utils::relaxed_cell::RelaxedCell;
 
 use crate::array::Array;
 use crate::bitmap::Bitmap;
@@ -136,7 +136,7 @@ pub struct BinaryViewArrayGeneric<T: ViewType + ?Sized> {
     validity: Option<Bitmap>,
     phantom: PhantomData<T>,
     /// Total bytes length if we would concatenate them all.
-    total_bytes_len: AtomicU64,
+    total_bytes_len: RelaxedCell<u64>,
     /// Total bytes in the buffer (excluding remaining capacity)
     total_buffer_len: usize,
 }
@@ -155,7 +155,7 @@ impl<T: ViewType + ?Sized> Clone for BinaryViewArrayGeneric<T> {
             buffers: self.buffers.clone(),
             validity: self.validity.clone(),
             phantom: Default::default(),
-            total_bytes_len: AtomicU64::new(self.total_bytes_len.load(Ordering::Relaxed)),
+            total_bytes_len: self.total_bytes_len.clone(),
             total_buffer_len: self.total_buffer_len,
         }
     }
@@ -223,7 +223,7 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
             buffers,
             validity,
             phantom: Default::default(),
-            total_bytes_len: AtomicU64::new(total_bytes_len as u64),
+            total_bytes_len: RelaxedCell::from(total_bytes_len as u64),
             total_buffer_len,
         }
     }
@@ -285,7 +285,7 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
             views,
             buffers,
             validity,
-            self.total_bytes_len.load(Ordering::Relaxed) as usize,
+            self.total_bytes_len.load() as usize,
             self.total_buffer_len,
         )
     }
@@ -440,10 +440,10 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
 
     /// Get the total length of bytes that it would take to concatenate all binary/str values in this array.
     pub fn total_bytes_len(&self) -> usize {
-        let total = self.total_bytes_len.load(Ordering::Relaxed);
+        let total = self.total_bytes_len.load();
         if total == UNKNOWN_LEN {
             let total = self.len_iter().map(|v| v as usize).sum::<usize>();
-            self.total_bytes_len.store(total as u64, Ordering::Relaxed);
+            self.total_bytes_len.store(total as u64);
             total
         } else {
             total as usize
@@ -542,7 +542,7 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
         let validity = self.validity.map(|bitmap| bitmap.make_mut());
 
         // We need to know the total_bytes_len if we are going to mutate it.
-        let mut total_bytes_len = self.total_bytes_len.load(Ordering::Relaxed);
+        let mut total_bytes_len = self.total_bytes_len.load();
         if total_bytes_len == UNKNOWN_LEN {
             total_bytes_len = views.iter().map(|view| view.length as u64).sum();
         }
@@ -584,7 +584,7 @@ impl BinaryViewArray {
             self.views.clone(),
             self.buffers.clone(),
             self.validity.clone(),
-            self.total_bytes_len.load(Ordering::Relaxed) as usize,
+            self.total_bytes_len.load() as usize,
             self.total_buffer_len,
         )
     }
@@ -599,7 +599,7 @@ impl Utf8ViewArray {
                 self.views.clone(),
                 self.buffers.clone(),
                 self.validity.clone(),
-                self.total_bytes_len.load(Ordering::Relaxed) as usize,
+                self.total_bytes_len.load() as usize,
                 self.total_buffer_len,
             )
         }
@@ -654,7 +654,7 @@ impl<T: ViewType + ?Sized> Array for BinaryViewArrayGeneric<T> {
             .map(|bitmap| bitmap.sliced_unchecked(offset, length))
             .filter(|bitmap| bitmap.unset_bits() > 0);
         self.views.slice_unchecked(offset, length);
-        self.total_bytes_len.store(UNKNOWN_LEN, Ordering::Relaxed)
+        self.total_bytes_len.store(UNKNOWN_LEN)
     }
 
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {

--- a/crates/polars-arrow/src/bitmap/immutable.rs
+++ b/crates/polars-arrow/src/bitmap/immutable.rs
@@ -107,7 +107,11 @@ impl Bitmap {
             storage: SharedStorage::from_vec(bytes),
             length,
             offset: 0,
-            unset_bit_count_cache: RelaxedCell::from(if length == 0 { 0 } else { UNKNOWN_BIT_COUNT }),
+            unset_bit_count_cache: RelaxedCell::from(if length == 0 {
+                0
+            } else {
+                UNKNOWN_BIT_COUNT
+            }),
         })
     }
 
@@ -208,8 +212,7 @@ impl Bitmap {
     pub fn unset_bits(&self) -> usize {
         self.lazy_unset_bits().unwrap_or_else(|| {
             let zeros = count_zeros(&self.storage, self.offset, self.length);
-            self.unset_bit_count_cache
-                .store(zeros as u64);
+            self.unset_bit_count_cache.store(zeros as u64);
             zeros
         })
     }
@@ -230,8 +233,7 @@ impl Bitmap {
     pub unsafe fn update_bit_count(&mut self, bits_set: usize) {
         assert!(bits_set <= self.length);
         let zeros = self.length - bits_set;
-        self.unset_bit_count_cache
-            .store(zeros as u64);
+        self.unset_bit_count_cache.store(zeros as u64);
     }
 
     /// Slices `self`, offsetting by `offset` and truncating up to `length` bits.

--- a/crates/polars-arrow/src/bitmap/immutable.rs
+++ b/crates/polars-arrow/src/bitmap/immutable.rs
@@ -1,10 +1,10 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 use std::ops::Deref;
 use std::sync::LazyLock;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use either::Either;
 use polars_error::{PolarsResult, polars_bail};
+use polars_utils::relaxed_cell::RelaxedCell;
 
 use super::utils::{self, BitChunk, BitChunks, BitmapIter, count_zeros, fmt, get_bit_unchecked};
 use super::{IntoIter, MutableBitmap, chunk_iter_to_vec, num_intersections_with};
@@ -52,7 +52,7 @@ const UNKNOWN_BIT_COUNT: u64 = u64::MAX;
 /// // when sliced (or cloned), it is no longer possible to `into_mut`.
 /// let same: Bitmap = sliced.into_mut().left().unwrap();
 /// ```
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Bitmap {
     storage: SharedStorage<u8>,
     // Both offset and length are measured in bits. They are used to bound the
@@ -64,25 +64,12 @@ pub struct Bitmap {
     // If it is u64::MAX, we have no known value at all.
     // Other bit patterns where the top bit is set is reserved for future use.
     // If the top bit is not set we have an exact count.
-    unset_bit_count_cache: AtomicU64,
+    unset_bit_count_cache: RelaxedCell<u64>,
 }
 
 #[inline(always)]
 fn has_cached_unset_bit_count(ubcc: u64) -> bool {
     ubcc >> 63 == 0
-}
-
-impl Clone for Bitmap {
-    fn clone(&self) -> Self {
-        Self {
-            storage: self.storage.clone(),
-            offset: self.offset,
-            length: self.length,
-            unset_bit_count_cache: AtomicU64::new(
-                self.unset_bit_count_cache.load(Ordering::Relaxed),
-            ),
-        }
-    }
 }
 
 impl std::fmt::Debug for Bitmap {
@@ -120,7 +107,7 @@ impl Bitmap {
             storage: SharedStorage::from_vec(bytes),
             length,
             offset: 0,
-            unset_bit_count_cache: AtomicU64::new(if length == 0 { 0 } else { UNKNOWN_BIT_COUNT }),
+            unset_bit_count_cache: RelaxedCell::from(if length == 0 { 0 } else { UNKNOWN_BIT_COUNT }),
         })
     }
 
@@ -222,7 +209,7 @@ impl Bitmap {
         self.lazy_unset_bits().unwrap_or_else(|| {
             let zeros = count_zeros(&self.storage, self.offset, self.length);
             self.unset_bit_count_cache
-                .store(zeros as u64, Ordering::Relaxed);
+                .store(zeros as u64);
             zeros
         })
     }
@@ -231,7 +218,7 @@ impl Bitmap {
     ///
     /// Guaranteed to be `<= self.len()`.
     pub fn lazy_unset_bits(&self) -> Option<usize> {
-        let cache = self.unset_bit_count_cache.load(Ordering::Relaxed);
+        let cache = self.unset_bit_count_cache.load();
         has_cached_unset_bit_count(cache).then_some(cache as usize)
     }
 
@@ -244,7 +231,7 @@ impl Bitmap {
         assert!(bits_set <= self.length);
         let zeros = self.length - bits_set;
         self.unset_bit_count_cache
-            .store(zeros as u64, Ordering::Relaxed);
+            .store(zeros as u64);
     }
 
     /// Slices `self`, offsetting by `offset` and truncating up to `length` bits.
@@ -416,7 +403,7 @@ impl Bitmap {
             storage,
             offset: 0,
             length,
-            unset_bit_count_cache: AtomicU64::new(length as u64),
+            unset_bit_count_cache: RelaxedCell::from(length as u64),
         }
     }
 
@@ -484,9 +471,9 @@ impl Bitmap {
         debug_assert!(check(&storage[..], offset, length).is_ok());
 
         let unset_bit_count_cache = if let Some(n) = unset_bits {
-            AtomicU64::new(n as u64)
+            RelaxedCell::from(n as u64)
         } else {
-            AtomicU64::new(UNKNOWN_BIT_COUNT)
+            RelaxedCell::from(UNKNOWN_BIT_COUNT)
         };
         Self {
             storage,
@@ -725,7 +712,7 @@ impl Splitable for Bitmap {
             return (self.clone(), Self::new());
         }
 
-        let ubcc = self.unset_bit_count_cache.load(Ordering::Relaxed);
+        let ubcc = self.unset_bit_count_cache.load();
 
         let lhs_length = offset;
         let rhs_length = self.length - offset;
@@ -768,13 +755,13 @@ impl Splitable for Bitmap {
                 storage: self.storage.clone(),
                 offset: self.offset,
                 length: lhs_length,
-                unset_bit_count_cache: AtomicU64::new(lhs_ubcc),
+                unset_bit_count_cache: RelaxedCell::from(lhs_ubcc),
             },
             Self {
                 storage: self.storage.clone(),
                 offset: self.offset + offset,
                 length: rhs_length,
-                unset_bit_count_cache: AtomicU64::new(rhs_ubcc),
+                unset_bit_count_cache: RelaxedCell::from(rhs_ubcc),
             },
         )
     }

--- a/crates/polars-arrow/src/compute/decimal.rs
+++ b/crates/polars-arrow/src/compute/decimal.rs
@@ -1,14 +1,13 @@
-use std::sync::atomic::{AtomicBool, Ordering};
-
 use num_traits::Euclid;
+use polars_utils::relaxed_cell::RelaxedCell;
 
-static TRIM_DECIMAL_ZEROS: AtomicBool = AtomicBool::new(false);
+static TRIM_DECIMAL_ZEROS: RelaxedCell<bool> = RelaxedCell::new_bool(false);
 
 pub fn get_trim_decimal_zeros() -> bool {
-    TRIM_DECIMAL_ZEROS.load(Ordering::Relaxed)
+    TRIM_DECIMAL_ZEROS.load()
 }
 pub fn set_trim_decimal_zeros(trim: Option<bool>) {
-    TRIM_DECIMAL_ZEROS.store(trim.unwrap_or(false), Ordering::Relaxed)
+    TRIM_DECIMAL_ZEROS.store(trim.unwrap_or(false))
 }
 
 /// Assuming bytes are a well-formed decimal number (with or without a separator),

--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -4,7 +4,6 @@ use std::borrow::Cow;
 use std::fmt::{Debug, Display, Formatter, Write};
 use std::str::FromStr;
 use std::sync::RwLock;
-use std::sync::atomic::{AtomicU8, Ordering};
 use std::{fmt, str};
 
 #[cfg(any(

--- a/crates/polars-expr/src/idx_table/binview.rs
+++ b/crates/polars-expr/src/idx_table/binview.rs
@@ -1,13 +1,12 @@
 #![allow(clippy::unnecessary_cast)] // Clippy doesn't recognize that IdxSize and u64 can be different.
 #![allow(unsafe_op_in_unsafe_fn)]
 
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-
 use arrow::array::{Array, View};
 use arrow::buffer::Buffer;
 use polars_compute::binview_index_map::{BinaryViewIndexMap, Entry};
 use polars_utils::idx_vec::UnitVec;
 use polars_utils::itertools::Itertools;
+use polars_utils::relaxed_cell::RelaxedCell;
 use polars_utils::unitvec;
 
 use super::*;
@@ -16,10 +15,10 @@ use crate::hash_keys::HashKeys;
 pub struct BinviewKeyIdxTable {
     // These AtomicU64s actually are IdxSizes, but we use the top bit of the
     // first index in each to mark keys during probing.
-    idx_map: BinaryViewIndexMap<UnitVec<AtomicU64>>,
+    idx_map: BinaryViewIndexMap<UnitVec<RelaxedCell<u64>>>,
     idx_offset: IdxSize,
     null_keys: Vec<IdxSize>,
-    nulls_emitted: AtomicBool,
+    nulls_emitted: RelaxedCell<bool>,
 }
 
 impl BinviewKeyIdxTable {
@@ -28,7 +27,7 @@ impl BinviewKeyIdxTable {
             idx_map: BinaryViewIndexMap::default(),
             idx_offset: 0,
             null_keys: Vec::new(),
-            nulls_emitted: AtomicBool::new(false),
+            nulls_emitted: RelaxedCell::from(false),
         }
     }
 
@@ -47,7 +46,7 @@ impl BinviewKeyIdxTable {
         if let Some(idxs) = unsafe { self.idx_map.get_view(hash, key, buffers) } {
             for idx in &idxs[..] {
                 // Create matches, making sure to clear top bit.
-                table_match.push((idx.load(Ordering::Relaxed) & !(1 << 63)) as IdxSize);
+                table_match.push((idx.load() & !(1 << 63)) as IdxSize);
                 probe_match.push(key_idx);
             }
 
@@ -55,9 +54,9 @@ impl BinviewKeyIdxTable {
             // atomic fetch_or to do it atomically.
             if MARK_MATCHES {
                 let first_idx = unsafe { idxs.get_unchecked(0) };
-                let first_idx_val = first_idx.load(Ordering::Relaxed);
+                let first_idx_val = first_idx.load();
                 if first_idx_val >> 63 == 0 {
-                    first_idx.store(first_idx_val | (1 << 63), Ordering::Relaxed);
+                    first_idx.store(first_idx_val | (1 << 63));
                 }
             }
             true
@@ -97,8 +96,8 @@ impl BinviewKeyIdxTable {
                     table_match.push(*idx);
                     probe_match.push(key_idx);
                 }
-                if MARK_MATCHES && !self.nulls_emitted.load(Ordering::Relaxed) {
-                    self.nulls_emitted.store(true, Ordering::Relaxed);
+                if MARK_MATCHES && !self.nulls_emitted.load() {
+                    self.nulls_emitted.store(true);
                 }
                 !self.null_keys.is_empty()
             } else {
@@ -223,10 +222,10 @@ impl IdxTable for BinviewKeyIdxTable {
                     if validity.get_bit_unchecked(*subset_idx as usize) {
                         match self.idx_map.entry_view(hash, *key, buffers) {
                             Entry::Occupied(o) => {
-                                o.into_mut().push(AtomicU64::new(idx as u64));
+                                o.into_mut().push(RelaxedCell::from(idx as u64));
                             },
                             Entry::Vacant(v) => {
-                                v.insert(unitvec![AtomicU64::new(idx as u64)]);
+                                v.insert(unitvec![RelaxedCell::from(idx as u64)]);
                             },
                         }
                     } else if track_unmatchable | hash_keys.null_is_valid {
@@ -240,10 +239,10 @@ impl IdxTable for BinviewKeyIdxTable {
                     let idx = self.idx_offset + i;
                     match self.idx_map.entry_view(hash, *key, buffers) {
                         Entry::Occupied(o) => {
-                            o.into_mut().push(AtomicU64::new(idx as u64));
+                            o.into_mut().push(RelaxedCell::from(idx as u64));
                         },
                         Entry::Vacant(v) => {
-                            v.insert(unitvec![AtomicU64::new(idx as u64)]);
+                            v.insert(unitvec![RelaxedCell::from(idx as u64)]);
                         },
                     }
                 }
@@ -336,7 +335,7 @@ impl IdxTable for BinviewKeyIdxTable {
         out.clear();
 
         let mut keys_processed = 0;
-        if !self.nulls_emitted.load(Ordering::Relaxed) {
+        if !self.nulls_emitted.load() {
             if (offset as usize) < self.null_keys.len() {
                 out.extend(
                     self.null_keys[offset as usize..]
@@ -355,10 +354,10 @@ impl IdxTable for BinviewKeyIdxTable {
 
         while let Some((_, _, idxs)) = self.idx_map.get_index(offset) {
             let first_idx = unsafe { idxs.get_unchecked(0) };
-            let first_idx_val = first_idx.load(Ordering::Relaxed);
+            let first_idx_val = first_idx.load();
             if first_idx_val >> 63 == 0 {
                 for idx in &idxs[..] {
-                    out.push((idx.load(Ordering::Relaxed) & !(1 << 63)) as IdxSize);
+                    out.push((idx.load() & !(1 << 63)) as IdxSize);
                 }
             }
 

--- a/crates/polars-expr/src/state/execution_state.rs
+++ b/crates/polars-expr/src/state/execution_state.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU8, Ordering};
+use std::sync::atomic::AtomicI64;
 use std::sync::{Mutex, OnceLock, RwLock};
 use std::time::Duration;
 

--- a/crates/polars-io/src/cloud/polars_object_store.rs
+++ b/crates/polars-io/src/cloud/polars_object_store.rs
@@ -74,8 +74,7 @@ mod inner {
         ) -> PolarsResult<Arc<dyn ObjectStore>> {
             let mut current_store = self.inner.store.lock().await;
 
-            self.rebuilt
-                .store(true);
+            self.rebuilt.store(true);
 
             // If this does not eq, then `inner` was already re-built by another thread.
             if Arc::ptr_eq(&*current_store, from_version) {

--- a/crates/polars-io/src/cloud/polars_object_store.rs
+++ b/crates/polars-io/src/cloud/polars_object_store.rs
@@ -18,11 +18,11 @@ use crate::pl_async::{
 mod inner {
     use std::future::Future;
     use std::sync::Arc;
-    use std::sync::atomic::AtomicBool;
 
     use object_store::ObjectStore;
     use polars_core::config;
     use polars_error::PolarsResult;
+    use polars_utils::relaxed_cell::RelaxedCell;
 
     use crate::cloud::PolarsObjectStoreBuilder;
 
@@ -33,24 +33,14 @@ mod inner {
     }
 
     /// Polars wrapper around [`ObjectStore`] functionality. This struct is cheaply cloneable.
-    #[derive(Debug)]
+    #[derive(Clone, Debug)]
     pub struct PolarsObjectStore {
         inner: Arc<Inner>,
         /// Avoid contending the Mutex `lock()` until the first re-build.
         initial_store: std::sync::Arc<dyn ObjectStore>,
         /// Used for interior mutability. Doesn't need to be shared with other threads so it's not
         /// inside `Arc<>`.
-        rebuilt: AtomicBool,
-    }
-
-    impl Clone for PolarsObjectStore {
-        fn clone(&self) -> Self {
-            Self {
-                inner: self.inner.clone(),
-                initial_store: self.initial_store.clone(),
-                rebuilt: AtomicBool::new(self.rebuilt.load(std::sync::atomic::Ordering::Relaxed)),
-            }
-        }
+        rebuilt: RelaxedCell<bool>,
     }
 
     impl PolarsObjectStore {
@@ -65,13 +55,13 @@ mod inner {
                     builder,
                 }),
                 initial_store,
-                rebuilt: AtomicBool::new(false),
+                rebuilt: RelaxedCell::from(false),
             }
         }
 
         /// Gets the underlying [`ObjectStore`] implementation.
         pub async fn to_dyn_object_store(&self) -> Arc<dyn ObjectStore> {
-            if !self.rebuilt.load(std::sync::atomic::Ordering::Relaxed) {
+            if !self.rebuilt.load() {
                 self.initial_store.clone()
             } else {
                 self.inner.store.lock().await.clone()
@@ -85,7 +75,7 @@ mod inner {
             let mut current_store = self.inner.store.lock().await;
 
             self.rebuilt
-                .store(true, std::sync::atomic::Ordering::Relaxed);
+                .store(true);
 
             // If this does not eq, then `inner` was already re-built by another thread.
             if Arc::ptr_eq(&*current_store, from_version) {

--- a/crates/polars-io/src/pl_async.rs
+++ b/crates/polars-io/src/pl_async.rs
@@ -2,7 +2,6 @@ use std::error::Error;
 use std::future::Future;
 use std::ops::Deref;
 use std::sync::LazyLock;
-use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 
 use polars_core::POOL;
 use polars_core::config::{self, verbose};

--- a/crates/polars-io/src/pl_async.rs
+++ b/crates/polars-io/src/pl_async.rs
@@ -124,10 +124,8 @@ impl SemaphoreTuner {
     }
 
     fn add_stats(&self, downloaded_bytes: u64, download_time: u64) {
-        self.downloaded
-            .fetch_add(downloaded_bytes);
-        self.download_time
-            .fetch_add(download_time);
+        self.downloaded.fetch_add(downloaded_bytes);
+        self.download_time.fetch_add(download_time);
     }
 
     fn increment(&mut self, semaphore: &Semaphore) {

--- a/crates/polars-io/src/pl_async.rs
+++ b/crates/polars-io/src/pl_async.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 
 use polars_core::POOL;
 use polars_core::config::{self, verbose};
+use polars_utils::relaxed_cell::RelaxedCell;
 use tokio::runtime::{Builder, Runtime};
 use tokio::sync::Semaphore;
 
@@ -98,8 +99,8 @@ enum Optimization {
 struct SemaphoreTuner {
     previous_download_speed: u64,
     last_tune: std::time::Instant,
-    downloaded: AtomicU64,
-    download_time: AtomicU64,
+    downloaded: RelaxedCell<u64>,
+    download_time: RelaxedCell<u64>,
     opt_state: Optimization,
     increments: u32,
 }
@@ -109,8 +110,8 @@ impl SemaphoreTuner {
         Self {
             previous_download_speed: 0,
             last_tune: std::time::Instant::now(),
-            downloaded: AtomicU64::new(0),
-            download_time: AtomicU64::new(0),
+            downloaded: RelaxedCell::from(0),
+            download_time: RelaxedCell::from(0),
             opt_state: Optimization::Step,
             increments: 0,
         }
@@ -124,9 +125,9 @@ impl SemaphoreTuner {
 
     fn add_stats(&self, downloaded_bytes: u64, download_time: u64) {
         self.downloaded
-            .fetch_add(downloaded_bytes, Ordering::Relaxed);
+            .fetch_add(downloaded_bytes);
         self.download_time
-            .fetch_add(download_time, Ordering::Relaxed);
+            .fetch_add(download_time);
     }
 
     fn increment(&mut self, semaphore: &Semaphore) {
@@ -135,8 +136,8 @@ impl SemaphoreTuner {
     }
 
     fn tune(&mut self, semaphore: &'static Semaphore) -> bool {
-        let bytes_downloaded = self.downloaded.fetch_add(0, Ordering::Relaxed);
-        let time_elapsed = self.download_time.fetch_add(0, Ordering::Relaxed);
+        let bytes_downloaded = self.downloaded.load();
+        let time_elapsed = self.download_time.load();
         let download_speed = bytes_downloaded
             .checked_div(time_elapsed)
             .unwrap_or_default();
@@ -158,7 +159,7 @@ impl SemaphoreTuner {
                 // Decline the step
                 else {
                     self.opt_state = Optimization::Finished;
-                    FINISHED_TUNING.store(true, Ordering::Relaxed);
+                    FINISHED_TUNING.store(true);
                     if verbose() {
                         eprintln!(
                             "concurrency tuner finished after adding {} steps",
@@ -176,8 +177,8 @@ impl SemaphoreTuner {
         false
     }
 }
-static INCR: AtomicU8 = AtomicU8::new(0);
-static FINISHED_TUNING: AtomicBool = AtomicBool::new(false);
+static INCR: RelaxedCell<u64> = RelaxedCell::new_u64(0);
+static FINISHED_TUNING: RelaxedCell<bool> = RelaxedCell::new_bool(false);
 static PERMIT_STORE: std::sync::OnceLock<tokio::sync::RwLock<SemaphoreTuner>> =
     std::sync::OnceLock::new();
 
@@ -186,7 +187,7 @@ fn get_semaphore() -> &'static (Semaphore, u32) {
         let permits = std::env::var("POLARS_CONCURRENCY_BUDGET")
             .map(|s| {
                 let budget = s.parse::<usize>().expect("integer");
-                FINISHED_TUNING.store(true, Ordering::Relaxed);
+                FINISHED_TUNING.store(true);
                 budget
             })
             .unwrap_or_else(|_| std::cmp::max(POOL.current_num_threads(), MAX_BUDGET_PER_REQUEST));
@@ -216,7 +217,7 @@ where
     let now = std::time::Instant::now();
     let res = callable().await;
 
-    if FINISHED_TUNING.load(Ordering::Relaxed) || res.size() == 0 {
+    if FINISHED_TUNING.load() || res.size() == 0 {
         return res;
     }
 
@@ -237,7 +238,7 @@ where
     drop(tuner);
 
     // Reduce locking by letting only 1 in 5 tasks lock the tuner
-    if (INCR.fetch_add(1, Ordering::Relaxed) % 5) != 0 {
+    if (INCR.fetch_add(1) % 5) != 0 {
         return res;
     }
     // Never lock as we will deadlock. This can run under rayon

--- a/crates/polars-stream/src/async_executor/mod.rs
+++ b/crates/polars-stream/src/async_executor/mod.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::marker::PhantomData;
 use std::panic::{AssertUnwindSafe, Location};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock, OnceLock, Weak};
 use std::time::Duration;
 
@@ -251,9 +251,7 @@ impl Executor {
                 if let Some(t) = last_block_start.take() {
                     if TRACK_WAIT_STATISTICS.load() {
                         let ns: u64 = t.elapsed().as_nanos().try_into().unwrap();
-                        task.metadata()
-                            .ns_spent_blocked
-                            .fetch_add(ns);
+                        task.metadata().ns_spent_blocked.fetch_add(ns);
                     }
                 }
                 worker.recruit_next();

--- a/crates/polars-stream/src/async_executor/mod.rs
+++ b/crates/polars-stream/src/async_executor/mod.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::marker::PhantomData;
 use std::panic::{AssertUnwindSafe, Location};
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, OnceLock, Weak};
 use std::time::Duration;
 
@@ -16,15 +16,16 @@ use crossbeam_deque::{Injector, Steal, Stealer, Worker as WorkQueue};
 use crossbeam_utils::CachePadded;
 use park_group::ParkGroup;
 use parking_lot::Mutex;
+use polars_utils::relaxed_cell::RelaxedCell;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 use slotmap::SlotMap;
 pub use task::{AbortOnDropHandle, JoinHandle};
 use task::{CancelHandle, Runnable};
 
-static NUM_EXECUTOR_THREADS: AtomicUsize = AtomicUsize::new(0);
+static NUM_EXECUTOR_THREADS: RelaxedCell<usize> = RelaxedCell::new_usize(0);
 pub fn set_num_threads(t: usize) {
-    NUM_EXECUTOR_THREADS.store(t, Ordering::Relaxed);
+    NUM_EXECUTOR_THREADS.store(t);
 }
 
 static GLOBAL_SCHEDULER: OnceLock<Executor> = OnceLock::new();
@@ -37,10 +38,10 @@ thread_local!(
 static NS_SPENT_BLOCKED: LazyLock<Mutex<HashMap<&'static Location<'static>, u64>>> =
     LazyLock::new(Mutex::default);
 
-static TRACK_WAIT_STATISTICS: AtomicBool = AtomicBool::new(false);
+static TRACK_WAIT_STATISTICS: RelaxedCell<bool> = RelaxedCell::new_bool(false);
 
 pub fn track_task_wait_statistics(should_track: bool) {
-    TRACK_WAIT_STATISTICS.store(should_track, Ordering::Relaxed);
+    TRACK_WAIT_STATISTICS.store(should_track);
 }
 
 pub fn get_task_wait_statistics() -> Vec<(&'static Location<'static>, Duration)> {
@@ -74,7 +75,7 @@ struct ScopedTaskMetadata {
 
 struct TaskMetadata {
     spawn_location: &'static Location<'static>,
-    ns_spent_blocked: AtomicU64,
+    ns_spent_blocked: RelaxedCell<u64>,
     priority: TaskPriority,
     freshly_spawned: AtomicBool,
     scoped: Option<ScopedTaskMetadata>,
@@ -85,7 +86,7 @@ impl Drop for TaskMetadata {
         *NS_SPENT_BLOCKED
             .lock()
             .entry(self.spawn_location)
-            .or_default() += self.ns_spent_blocked.load(Ordering::Relaxed);
+            .or_default() += self.ns_spent_blocked.load();
         if let Some(scoped) = &self.scoped {
             if let Some(completed_tasks) = scoped.completed_tasks.upgrade() {
                 completed_tasks.lock().push(scoped.task_key);
@@ -239,7 +240,7 @@ impl Executor {
                     return Some(task);
                 }
 
-                if last_block_start.is_none() && TRACK_WAIT_STATISTICS.load(Ordering::Relaxed) {
+                if last_block_start.is_none() && TRACK_WAIT_STATISTICS.load() {
                     last_block_start = Some(std::time::Instant::now());
                 }
                 park.park();
@@ -248,11 +249,11 @@ impl Executor {
 
             if let Some(task) = task {
                 if let Some(t) = last_block_start.take() {
-                    if TRACK_WAIT_STATISTICS.load(Ordering::Relaxed) {
+                    if TRACK_WAIT_STATISTICS.load() {
                         let ns: u64 = t.elapsed().as_nanos().try_into().unwrap();
                         task.metadata()
                             .ns_spent_blocked
-                            .fetch_add(ns, Ordering::Relaxed);
+                            .fetch_add(ns);
                     }
                 }
                 worker.recruit_next();
@@ -263,7 +264,7 @@ impl Executor {
 
     fn global() -> &'static Executor {
         GLOBAL_SCHEDULER.get_or_init(|| {
-            let mut n_threads = NUM_EXECUTOR_THREADS.load(Ordering::Relaxed);
+            let mut n_threads = NUM_EXECUTOR_THREADS.load();
             if n_threads == 0 {
                 n_threads = std::thread::available_parallelism()
                     .map(|n| n.get())
@@ -348,7 +349,7 @@ impl<'scope> TaskScope<'scope, '_> {
                     on_wake,
                     TaskMetadata {
                         spawn_location,
-                        ns_spent_blocked: AtomicU64::new(0),
+                        ns_spent_blocked: RelaxedCell::new_u64(0),
                         priority,
                         freshly_spawned: AtomicBool::new(true),
                         scoped: Some(ScopedTaskMetadata {
@@ -406,7 +407,7 @@ where
         on_wake,
         TaskMetadata {
             spawn_location,
-            ns_spent_blocked: AtomicU64::new(0),
+            ns_spent_blocked: RelaxedCell::new_u64(0),
             priority,
             freshly_spawned: AtomicBool::new(true),
             scoped: None,

--- a/crates/polars-stream/src/execute.rs
+++ b/crates/polars-stream/src/execute.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
 
 use polars_core::POOL;
 use polars_core::frame::DataFrame;
 use polars_error::PolarsResult;
 use polars_expr::state::ExecutionState;
 use polars_utils::aliases::PlHashSet;
+use polars_utils::relaxed_cell::RelaxedCell;
 use slotmap::{SecondaryMap, SparseSecondaryMap};
 
 use crate::async_executor;
@@ -125,7 +125,7 @@ fn run_subgraph(
     graph: &mut Graph,
     nodes: &PlHashSet<GraphNodeKey>,
     pipes: &[LogicalPipeKey],
-    pipe_seq_offsets: &mut SecondaryMap<LogicalPipeKey, Arc<AtomicU64>>,
+    pipe_seq_offsets: &mut SecondaryMap<LogicalPipeKey, Arc<RelaxedCell<u64>>>,
     state: &StreamingExecutionState,
 ) -> PolarsResult<()> {
     // Construct physical pipes for the logical pipes we'll use.

--- a/crates/polars-stream/src/morsel.rs
+++ b/crates/polars-stream/src/morsel.rs
@@ -1,8 +1,8 @@
 use std::future::Future;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use polars_core::frame::DataFrame;
+use polars_utils::relaxed_cell::RelaxedCell;
 
 use crate::async_primitives::wait_group::WaitToken;
 
@@ -57,22 +57,22 @@ impl MorselSeq {
 /// to stop with passing new morsels this execution phase.
 #[derive(Clone, Debug)]
 pub struct SourceToken {
-    stop: Arc<AtomicBool>,
+    stop: Arc<RelaxedCell<bool>>,
 }
 
 impl SourceToken {
     pub fn new() -> Self {
         Self {
-            stop: Arc::new(AtomicBool::new(false)),
+            stop: Arc::default(),
         }
     }
 
     pub fn stop(&self) {
-        self.stop.store(true, Ordering::Relaxed);
+        self.stop.store(true);
     }
 
     pub fn stop_requested(&self) -> bool {
-        self.stop.load(Ordering::Relaxed)
+        self.stop.load()
     }
 }
 

--- a/crates/polars-stream/src/nodes/io_sinks/parquet.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/parquet.rs
@@ -1,6 +1,5 @@
 use std::cmp::Reverse;
 use std::io::BufWriter;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use polars_core::prelude::{ArrowSchema, CompatLevel};

--- a/crates/polars-stream/src/nodes/io_sinks/partition/max_size.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/max_size.rs
@@ -1,4 +1,3 @@
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use futures::StreamExt;
@@ -8,10 +7,10 @@ use polars_core::prelude::Column;
 use polars_core::schema::SchemaRef;
 use polars_error::{PolarsResult, polars_ensure};
 use polars_plan::dsl::{PartitionTargetCallback, SinkFinishCallback, SinkOptions};
-use polars_utils::relaxed_cell::RelaxedCell;
 use polars_utils::IdxSize;
 use polars_utils::pl_str::PlSmallStr;
 use polars_utils::plpath::PlPath;
+use polars_utils::relaxed_cell::RelaxedCell;
 
 use super::{CreateNewSinkFn, PerPartitionSortBy};
 use crate::async_executor::{AbortOnDropHandle, spawn};

--- a/crates/polars-stream/src/nodes/io_sinks/partition/parted.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/parted.rs
@@ -11,6 +11,7 @@ use polars_error::PolarsResult;
 use polars_plan::dsl::{PartitionTargetCallback, SinkFinishCallback, SinkOptions};
 use polars_utils::pl_str::PlSmallStr;
 use polars_utils::plpath::PlPath;
+use polars_utils::relaxed_cell::RelaxedCell;
 
 use super::{CreateNewSinkFn, PerPartitionSortBy};
 use crate::async_executor::{AbortOnDropHandle, spawn};
@@ -131,7 +132,7 @@ impl SinkNode for PartedPartitionSinkNode {
         let (mut retire_tx, retire_rxs) = distributor_channel(self.num_retire_tasks, 1);
 
         // Whether an error has been observed in the retire tasks.
-        let has_error_occurred = Arc::new(AtomicBool::new(false));
+        let has_error_occurred = Arc::new(RelaxedCell::from(false));
 
         // Main Task.
         //
@@ -180,7 +181,7 @@ impl SinkNode for PartedPartitionSinkNode {
                     polars_ops::series::rle_lengths(&c, &mut lengths)?;
 
                     for &length in &lengths {
-                        if retire_error.load(Ordering::Relaxed) {
+                        if retire_error.load() {
                             return Ok(());
                         }
 
@@ -300,7 +301,7 @@ impl SinkNode for PartedPartitionSinkNode {
                 while let Ok((mut join_handles, node, keys)) = retire_rx.recv().await {
                     while let Some(ret) = join_handles.next().await {
                         ret.inspect_err(|_| {
-                            has_error_occurred.store(true, Ordering::Relaxed);
+                            has_error_occurred.store(true);
                         })?;
                     }
                     if let Some(mut metrics) = node.get_metrics()? {

--- a/crates/polars-stream/src/nodes/io_sinks/partition/parted.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/parted.rs
@@ -1,4 +1,3 @@
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use futures::StreamExt;

--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -1,7 +1,7 @@
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use arrow::array::builder::ShareStrategy;
 use polars_core::frame::builder::DataFrameBuilder;

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -30,6 +30,7 @@ pub mod pl_str;
 pub mod plpath;
 pub mod priority;
 pub mod regex_cache;
+pub mod relaxed_cell;
 pub mod select;
 pub mod slice;
 pub mod slice_enum;

--- a/crates/polars-utils/src/pl_str.rs
+++ b/crates/polars-utils/src/pl_str.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
-use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::relaxed_cell::RelaxedCell;
 
 #[macro_export]
 macro_rules! format_pl_smallstr {
@@ -301,7 +302,7 @@ impl core::fmt::Display for PlSmallStr {
 }
 
 pub fn unique_column_name() -> PlSmallStr {
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
-    let idx = COUNTER.fetch_add(1, Ordering::Relaxed);
+    static COUNTER: RelaxedCell<u64> = RelaxedCell::new_u64(0);
+    let idx = COUNTER.fetch_add(1);
     format_pl_smallstr!("_POLARS_TMP_{idx}")
 }

--- a/crates/polars-utils/src/relaxed_cell.rs
+++ b/crates/polars-utils/src/relaxed_cell.rs
@@ -1,0 +1,129 @@
+use std::sync::atomic::*;
+use std::fmt;
+
+#[derive(Default)]
+#[repr(transparent)]
+pub struct RelaxedCell<T: AtomicNative>(T::Atomic);
+
+impl<T: AtomicNative> RelaxedCell<T> {
+    #[inline(always)]
+    pub fn load(&self) -> T {
+        T::load(&self.0)
+    }
+
+    #[inline(always)]
+    pub fn store(&self, value: T) {
+        T::store(&self.0, value)
+    }
+
+    #[inline(always)]
+    pub fn fetch_add(&self, value: T) -> T {
+        T::fetch_add(&self.0, value)
+    }
+
+    #[inline(always)]
+    pub fn get_mut(&mut self) -> &mut T {
+        T::get_mut(&mut self.0)
+    }
+}
+
+impl<T: AtomicNative> From<T> for RelaxedCell<T> {
+    #[inline(always)]
+    fn from(value: T) -> Self {
+        RelaxedCell(T::Atomic::from(value))
+    }
+}
+
+impl<T: AtomicNative> Clone for RelaxedCell<T> {
+    fn clone(&self) -> Self {
+        Self(T::Atomic::from(self.load()))
+    }
+}
+
+impl<T: AtomicNative> fmt::Debug for RelaxedCell<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("RelaxedCell").field(&self.load()).finish()
+    }
+}
+
+pub trait AtomicNative : Sized + Default + fmt::Debug {
+    type Atomic: From<Self>;
+    
+    fn load(atomic: &Self::Atomic) -> Self;
+    fn store(atomic: &Self::Atomic, val: Self);
+    fn fetch_add(atomic: &Self::Atomic, val: Self) -> Self;
+    fn get_mut(atomic: &mut Self::Atomic) -> &mut Self;
+}
+
+
+macro_rules! impl_relaxed_cell {
+    ($T:ty, $new:ident, $A:ty) => {
+        impl RelaxedCell<$T> {
+            // Not part of the trait as it should be const.
+            pub const fn $new(value: $T) -> Self {
+                Self(<$A>::new(value))
+            }
+        }
+
+        impl AtomicNative for $T {
+            type Atomic = $A;
+
+            #[inline(always)]
+            fn load(atomic: &Self::Atomic) -> Self {
+                atomic.load(Ordering::Relaxed)
+            }
+
+            #[inline(always)]
+            fn store(atomic: &Self::Atomic, val: Self) {
+                atomic.store(val, Ordering::Relaxed);
+            }
+
+            #[inline(always)]
+            fn fetch_add(atomic: &Self::Atomic, val: Self) -> Self {
+                atomic.fetch_add(val, Ordering::Relaxed)
+            }
+
+            #[inline(always)]
+            fn get_mut(atomic: &mut Self::Atomic) -> &mut Self {
+                atomic.get_mut()
+            }
+        }
+    };
+}
+
+impl_relaxed_cell!(u8, new_u8, AtomicU8);
+impl_relaxed_cell!(u32, new_u32, AtomicU32);
+impl_relaxed_cell!(u64, new_u64, AtomicU64);
+impl_relaxed_cell!(usize, new_usize, AtomicUsize);
+
+
+impl RelaxedCell<bool> {
+    // Not part of the trait as it should be const.
+    pub const fn new_bool(value: bool) -> Self {
+        Self(AtomicBool::new(value))
+    }
+}
+
+impl AtomicNative for bool {
+    type Atomic = AtomicBool;
+
+    #[inline(always)]
+    fn load(atomic: &Self::Atomic) -> Self {
+        atomic.load(Ordering::Relaxed)
+    }
+
+    #[inline(always)]
+    fn store(atomic: &Self::Atomic, val: Self) {
+        atomic.store(val, Ordering::Relaxed);
+    }
+
+    #[inline(always)]
+    fn fetch_add(_atomic: &Self::Atomic, _val: Self) -> Self {
+        unimplemented!()
+    }
+
+    #[inline(always)]
+    fn get_mut(atomic: &mut Self::Atomic) -> &mut Self {
+        atomic.get_mut()
+    }
+}

--- a/crates/polars-utils/src/relaxed_cell.rs
+++ b/crates/polars-utils/src/relaxed_cell.rs
@@ -1,5 +1,5 @@
-use std::sync::atomic::*;
 use std::fmt;
+use std::sync::atomic::*;
 
 #[derive(Default)]
 #[repr(transparent)]
@@ -46,15 +46,14 @@ impl<T: AtomicNative> fmt::Debug for RelaxedCell<T> {
     }
 }
 
-pub trait AtomicNative : Sized + Default + fmt::Debug {
+pub trait AtomicNative: Sized + Default + fmt::Debug {
     type Atomic: From<Self>;
-    
+
     fn load(atomic: &Self::Atomic) -> Self;
     fn store(atomic: &Self::Atomic, val: Self);
     fn fetch_add(atomic: &Self::Atomic, val: Self) -> Self;
     fn get_mut(atomic: &mut Self::Atomic) -> &mut Self;
 }
-
 
 macro_rules! impl_relaxed_cell {
     ($T:ty, $new:ident, $A:ty) => {
@@ -95,7 +94,6 @@ impl_relaxed_cell!(u8, new_u8, AtomicU8);
 impl_relaxed_cell!(u32, new_u32, AtomicU32);
 impl_relaxed_cell!(u64, new_u64, AtomicU64);
 impl_relaxed_cell!(usize, new_usize, AtomicUsize);
-
 
 impl RelaxedCell<bool> {
     // Not part of the trait as it should be const.


### PR DESCRIPTION
This should make it easier at a glance to determine whether an atomic is being used for synchronization, or just for interior mutability / non-synchronizing signaling.