### PR TITLE
fix: Fix panic loading from arrow `Map` containing timestamps

### DIFF
--- a/crates/polars-core/src/series/from.rs
+++ b/crates/polars-core/src/series/from.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "dtype-categorical")]
 use arrow::compute::concatenate::concatenate_unchecked;
 use arrow::datatypes::Metadata;
+use arrow::offset::OffsetsBuffer;
 #[cfg(any(
     feature = "dtype-date",
     feature = "dtype-datetime",
@@ -520,31 +521,49 @@ impl Series {
                 let chunks = cast_chunks(&chunks, &DataType::Binary, CastOptions::NonStrict)?;
                 Ok(BinaryChunked::from_chunks(name, chunks).into_series())
             },
-            ArrowDataType::Map(_, _) => map_arrays_to_series(name, chunks),
+            ArrowDataType::Map(field, _is_ordered) => {
+                let struct_arrays = chunks
+                    .iter()
+                    .map(|arr| {
+                        let arr = arr.as_any().downcast_ref::<MapArray>().unwrap();
+                        arr.field().clone()
+                    })
+                    .collect::<Vec<_>>();
+
+                let (phys_struct_arrays, dtype) =
+                    to_physical_and_dtype(struct_arrays, field.metadata.as_deref());
+
+                let chunks = chunks
+                    .iter()
+                    .zip(phys_struct_arrays)
+                    .map(|(arr, values)| {
+                        let arr = arr.as_any().downcast_ref::<MapArray>().unwrap();
+                        let offsets: &OffsetsBuffer<i32> = arr.offsets();
+
+                        let validity = values.validity().cloned();
+
+                        Box::from(ListArray::<i64>::new(
+                            ListArray::<i64>::default_datatype(values.dtype().clone()),
+                            OffsetsBuffer::<i64>::from(offsets),
+                            values,
+                            validity,
+                        )) as ArrayRef
+                    })
+                    .collect();
+
+                unsafe {
+                    let out = ListChunked::from_chunks_and_dtype_unchecked(
+                        name,
+                        chunks,
+                        DataType::List(Box::new(dtype)),
+                    );
+
+                    Ok(out.into_series())
+                }
+            },
             dt => polars_bail!(ComputeError: "cannot create series from {:?}", dt),
         }
     }
-}
-
-fn map_arrays_to_series(name: PlSmallStr, chunks: Vec<ArrayRef>) -> PolarsResult<Series> {
-    let chunks = chunks
-        .iter()
-        .map(|arr| {
-            // we convert the map to the logical type: List<struct<key, value>>
-            let arr = arr.as_any().downcast_ref::<MapArray>().unwrap();
-            let inner = arr.field().clone();
-
-            // map has i32 offsets
-            let dtype = ListArray::<i32>::default_datatype(inner.dtype().clone());
-            Box::new(ListArray::<i32>::new(
-                dtype,
-                arr.offsets().clone(),
-                inner,
-                arr.validity().cloned(),
-            )) as ArrayRef
-        })
-        .collect::<Vec<_>>();
-    Series::try_from((name, chunks))
 }
 
 fn convert<F: Fn(&dyn Array) -> ArrayRef>(arr: &[ArrayRef], f: F) -> Vec<ArrayRef> {
@@ -700,7 +719,8 @@ unsafe fn to_physical_and_dtype(
         | ArrowDataType::Timestamp(_, _)
         | ArrowDataType::Date32
         | ArrowDataType::Decimal(_, _)
-        | ArrowDataType::Date64) => {
+        | ArrowDataType::Date64
+        | ArrowDataType::Map(_, _)) => {
             let dt = dt.clone();
             let mut s = Series::_try_from_arrow_unchecked(PlSmallStr::EMPTY, arrays, &dt).unwrap();
             let dtype = s.dtype().clone();

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -496,7 +496,7 @@ impl Series {
     ///
     /// This can lead to invalid memory access in downstream code.
     pub unsafe fn from_physical_unchecked(&self, dtype: &DataType) -> PolarsResult<Self> {
-        debug_assert!(!self.dtype().is_logical());
+        debug_assert!(!self.dtype().is_logical(), "{:?}", self.dtype());
 
         if self.dtype() == dtype {
             return Ok(self.clone());


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/23658

Fixes 2 issues:
* Recursion did not convert the nested key/value struct value arrays to physical
* Offsets were not converted to i64
