### PR TITLE
fix: Sort and Scan `with_exprs_and_input`

### DIFF
--- a/crates/polars-plan/src/plans/expr_ir.rs
+++ b/crates/polars-plan/src/plans/expr_ir.rs
@@ -60,7 +60,7 @@ impl OutputName {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "ir_serde", derive(Serialize, Deserialize))]
 pub struct ExprIR {
     /// Output name of this expression.
@@ -78,21 +78,6 @@ impl Eq for ExprIR {}
 impl PartialEq for ExprIR {
     fn eq(&self, other: &Self) -> bool {
         self.node == other.node && self.output_name == other.output_name
-    }
-}
-
-impl Clone for ExprIR {
-    fn clone(&self) -> Self {
-        let output_dtype = OnceLock::new();
-        if let Some(dt) = self.output_dtype.get() {
-            output_dtype.set(dt.clone()).unwrap()
-        }
-
-        ExprIR {
-            output_name: self.output_name.clone(),
-            node: self.node,
-            output_dtype,
-        }
     }
 }
 

--- a/crates/polars-plan/src/plans/ir/inputs.rs
+++ b/crates/polars-plan/src/plans/ir/inputs.rs
@@ -68,13 +68,12 @@ impl IR {
                 options: options.clone(),
             },
             Sort {
-                by_column,
                 slice,
                 sort_options,
                 ..
             } => Sort {
                 input: inputs[0],
-                by_column: by_column.clone(),
+                by_column: exprs,
                 slice: *slice,
                 sort_options: sort_options.clone(),
             },
@@ -104,22 +103,15 @@ impl IR {
                 unified_scan_args,
                 scan_type,
                 id: _,
-            } => {
-                let mut new_predicate = None;
-                if predicate.is_some() {
-                    new_predicate = exprs.pop()
-                }
-
-                Scan {
-                    sources: sources.clone(),
-                    file_info: file_info.clone(),
-                    hive_parts: hive_parts.clone(),
-                    output_schema: output_schema.clone(),
-                    unified_scan_args: unified_scan_args.clone(),
-                    predicate: new_predicate,
-                    scan_type: scan_type.clone(),
-                    id: Default::default(),
-                }
+            } => Scan {
+                sources: sources.clone(),
+                file_info: file_info.clone(),
+                hive_parts: hive_parts.clone(),
+                output_schema: output_schema.clone(),
+                unified_scan_args: unified_scan_args.clone(),
+                predicate: predicate.is_some().then(|| exprs.pop().unwrap()),
+                scan_type: scan_type.clone(),
+                id: Default::default(),
             },
             DataFrameScan {
                 df,


### PR DESCRIPTION
This PR:
- fix `with_exprs_and_input` for Sort not using the new expressions
- fix `with_exprs_and_input` for Scan not requiring a new predicate expr when the old is `Some`
- remove manual `Clone` impl for `ExprIR`, it does the same thing as derived