### PR TITLE
fix: Match output dtype to engine for `cum_sum_horizontal`

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -575,6 +575,10 @@ fn get_arithmetic_field(
                 (Struct(_), Struct(_)) => {
                     return Ok(left_field);
                 },
+                #[cfg(feature = "dtype-struct")]
+                (Struct(_), r) if r.is_primitive_numeric() => {
+                    return Ok(left_field);
+                },
                 (Datetime(_, _), _)
                 | (_, Datetime(_, _))
                 | (Time, _)

--- a/py-polars/polars/functions/aggregation/horizontal.py
+++ b/py-polars/polars/functions/aggregation/horizontal.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 import polars.functions as F
 from polars._utils.parse import parse_into_list_of_expressions
 from polars._utils.wrap import wrap_expr
-from polars.datatypes import UInt32
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars.polars as plr
@@ -292,7 +291,8 @@ def cum_sum_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     pyexprs = parse_into_list_of_expressions(*exprs)
     exprs_wrapped = [wrap_expr(e) for e in pyexprs]
 
-    # (Expr): use u32 as that will not cast to float as eagerly
-    return F.cum_fold(F.lit(0).cast(UInt32), lambda a, b: a + b, exprs_wrapped).alias(
-        "cum_sum"
-    )
+    return F.cum_fold(
+        F.lit(0).cast(F.dtype_of(F.sum_horizontal(exprs))),
+        lambda a, b: a + b,
+        exprs_wrapped,
+    ).alias("cum_sum")

--- a/py-polars/tests/unit/operations/aggregation/test_horizontal.py
+++ b/py-polars/tests/unit/operations/aggregation/test_horizontal.py
@@ -364,6 +364,9 @@ def test_cum_sum_horizontal() -> None:
     expected = pl.DataFrame({"cum_sum": [{"a": 1, "c": 6}, {"a": 2, "c": 8}]})
     assert_frame_equal(result, expected)
 
+    q = df.lazy().select(pl.cum_sum_horizontal("a", "c"))
+    assert q.collect_schema() == q.collect().schema
+
 
 def test_sum_dtype_12028() -> None:
     result = pl.select(

--- a/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
@@ -70,13 +70,14 @@ def test_arithmetic_sub(
 
 
 def test_struct_arithmetic() -> None:
-    df = pl.DataFrame(
+    df0 = pl.DataFrame(
         {
             "a": [1, 2],
             "b": [3, 4],
             "c": [5, 6],
         }
-    ).select(pl.cum_sum_horizontal("a", "c"))
+    )
+    df = df0.select(pl.cum_sum_horizontal("a", "c"))
     assert df.select(pl.col("cum_sum") * 2).to_dict(as_series=False) == {
         "cum_sum": [{"a": 2, "c": 12}, {"a": 4, "c": 16}]
     }
@@ -97,6 +98,9 @@ def test_struct_arithmetic() -> None:
     assert pl.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]}).select(
         pl.cum_sum_horizontal("a", "c") * 3
     ).to_dict(as_series=False) == {"cum_sum": [{"a": 3, "c": 18}, {"a": 6, "c": 24}]}
+
+    q = df0.lazy().select(pl.cum_sum_horizontal("a", "c") * 3)
+    assert q.collect_schema() == q.collect().schema
 
 
 def test_simd_float_sum_determinism() -> None:


### PR DESCRIPTION
Partial fix for #23663.
