### PR TITLE
feat(python): Add cast_options args to delta scan/read

### DIFF
--- a/py-polars/polars/catalog/unity/client.py
+++ b/py-polars/polars/catalog/unity/client.py
@@ -235,6 +235,13 @@ class Catalog:
                 at any point without it being considered a breaking change.
         retries
             Number of retries if accessing a cloud instance fails.
+        cast_options
+            Configuration for column type-casting during scans. Useful for datasets
+            containing files that have differing schemas.
+
+            .. warning::
+                This functionality is considered **unstable**. It may be changed
+                at any point without it being considered a breaking change.
 
         """
         table_info = self.get_table_info(catalog_name, namespace, table_name)

--- a/py-polars/polars/catalog/unity/client.py
+++ b/py-polars/polars/catalog/unity/client.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
         CredentialProviderFunctionReturn,
     )
     from polars.io.cloud.credential_provider._builder import CredentialProviderBuilder
+    from polars.io.scan_options.cast_options import ScanCastOptions
     from polars.lazyframe import LazyFrame
 
 with contextlib.suppress(ImportError):
@@ -189,6 +190,7 @@ class Catalog:
             CredentialProviderFunction | Literal["auto"] | None
         ) = "auto",
         retries: int = 2,
+        cast_options: ScanCastOptions | None = None,
     ) -> LazyFrame:
         """
         Retrieve the metadata of the specified table.
@@ -257,6 +259,7 @@ class Catalog:
                 delta_table_options=delta_table_options,
                 storage_options=storage_options,
                 credential_provider=credential_provider,
+                cast_options=cast_options,
             )
 
         if delta_table_version is not None:

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -12,7 +12,6 @@ from polars.dependencies import _DELTALAKE_AVAILABLE, deltalake
 from polars.io.cloud._utils import _get_path_scheme
 from polars.io.parquet import scan_parquet
 from polars.io.pyarrow_dataset.functions import scan_pyarrow_dataset
-from polars.io.scan_options.cast_options import ScanCastOptions
 from polars.schema import Schema
 
 if TYPE_CHECKING:
@@ -22,6 +21,7 @@ if TYPE_CHECKING:
 
     from polars import DataFrame, DataType, LazyFrame
     from polars.io.cloud import CredentialProviderFunction
+    from polars.io.scan_options.cast_options import ScanCastOptions
 
 
 def read_delta(
@@ -35,6 +35,7 @@ def read_delta(
     delta_table_options: dict[str, Any] | None = None,
     use_pyarrow: bool = False,
     pyarrow_options: dict[str, Any] | None = None,
+    cast_options: ScanCastOptions | None = None,
 ) -> DataFrame:
     """
     Reads into a DataFrame from a Delta lake table.
@@ -156,6 +157,7 @@ def read_delta(
         use_pyarrow=use_pyarrow,
         pyarrow_options=pyarrow_options,
         rechunk=rechunk,
+        cast_options=cast_options,
     )
 
     if columns is not None:
@@ -173,6 +175,7 @@ def scan_delta(
     use_pyarrow: bool = False,
     pyarrow_options: dict[str, Any] | None = None,
     rechunk: bool | None = None,
+    cast_options: ScanCastOptions | None = None,
 ) -> LazyFrame:
     """
     Lazily read from a Delta lake table.
@@ -407,7 +410,7 @@ def scan_delta(
         file_uris,
         schema=main_schema,
         hive_schema=hive_schema if len(partition_columns) > 0 else None,
-        cast_options=ScanCastOptions._default_iceberg(),
+        cast_options=cast_options,
         missing_columns="insert",
         extra_columns="ignore",
         hive_partitioning=len(partition_columns) > 0,

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -77,6 +77,13 @@ def read_delta(
         Flag to enable pyarrow dataset reads.
     pyarrow_options
         Keyword arguments while converting a Delta lake Table to pyarrow table.
+    cast_options
+        Configuration for column type-casting during scans. Useful for datasets
+        containing files that have differing schemas.
+
+        .. warning::
+            This functionality is considered **unstable**. It may be changed
+            at any point without it being considered a breaking change.
 
     Returns
     -------
@@ -217,6 +224,13 @@ def scan_delta(
     rechunk
         Make sure that all columns are contiguous in memory by
         aggregating the chunks into a single array.
+    cast_options
+        Configuration for column type-casting during scans. Useful for datasets
+        containing files that have differing schemas.
+
+        .. warning::
+            This functionality is considered **unstable**. It may be changed
+            at any point without it being considered a breaking change.
 
     Returns
     -------


### PR DESCRIPTION
the cast_options arg can be necessary when reading a delta table: I ran into a SchemaError trying to read a delta table from a Databricks+AWS stack:
```
polars.exceptions.SchemaError: data type mismatch for column ts: 
incoming: Datetime(Nanoseconds, None) != target: Datetime(Microseconds, Some("UTC")), 
hint: pass cast_options=pl.ScanCastOptions(datetime_cast='nanosecond-downcast')
```

Was there a specific reason to default to the `_default_iceberg` option set in `scan_delta`?
