### PR TITLE
docs(python): Fix `str.replace_many` examples trigger deprecation warning

### DIFF
--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -2615,8 +2615,8 @@ class ExprStringNameSpace:
         │ Can you feel the love tonight                      ┆ Can me feel the love tonight                      │
         └────────────────────────────────────────────────────┴───────────────────────────────────────────────────┘
 
-        Broadcast a replacement for many patterns by passing a string or a sequence of
-        length 1 to the `replace_with` parameter.
+        Broadcast a replacement for many patterns by passing sequence of length 1 to the
+        `replace_with` parameter.
 
         >>> _ = pl.Config.set_fmt_str_lengths(100)
         >>> df = pl.DataFrame(
@@ -2632,7 +2632,7 @@ class ExprStringNameSpace:
         ...     pl.col("lyrics")
         ...     .str.replace_many(
         ...         ["me", "you", "they"],
-        ...         "",
+        ...         [""],
         ...     )
         ...     .alias("removes_pronouns")
         ... )

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -1986,8 +1986,8 @@ class StringNameSpace:
             "Can me feel the love tonight"
         ]
 
-        Broadcast a replacement for many patterns by passing a string or a sequence of
-        length 1 to the `replace_with` parameter.
+        Broadcast a replacement for many patterns by passing a sequence of length 1 to
+        the `replace_with` parameter.
 
         >>> _ = pl.Config.set_fmt_str_lengths(100)
         >>> s = pl.Series(
@@ -1998,7 +1998,7 @@ class StringNameSpace:
         ...         "Can you feel the love tonight",
         ...     ],
         ... )
-        >>> s.str.replace_many(["me", "you", "they"], "")
+        >>> s.str.replace_many(["me", "you", "they"], [""])
         shape: (3,)
         Series: 'lyrics' [str]
         [


### PR DESCRIPTION
closes: #23517 