### PR TITLE
fix: Fix output for `str.extract_groups` with empty string pattern

### DIFF
--- a/crates/polars-ops/src/chunked_array/strings/extract.rs
+++ b/crates/polars-ops/src/chunked_array/strings/extract.rs
@@ -48,12 +48,8 @@ pub(super) fn extract_groups(
     let reg = polars_utils::regex_cache::compile_regex(pat)?;
     let n_fields = reg.captures_len();
     if n_fields == 1 {
-        return StructChunked::from_series(
-            ca.name().clone(),
-            ca.len(),
-            [Series::new_null(ca.name().clone(), ca.len())].iter(),
-        )
-        .map(|ca| ca.into_series());
+        return StructChunked::from_series(ca.name().clone(), ca.len(), [].iter())
+            .map(|ca| ca.into_series());
     }
 
     let arrow_dtype = dtype.try_to_arrow(CompatLevel::newest())?;

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -1497,7 +1497,10 @@ def test_extract_groups() -> None:
 
     assert df.select(pl.col("iso_code").str.extract_groups("")).to_dict(
         as_series=False
-    ) == {"iso_code": [{"iso_code": None}, {"iso_code": None}]}
+    ) == {"iso_code": [{}, {}]}
+
+    q = df.lazy().select(pl.col("iso_code").str.extract_groups(""))
+    assert q.collect_schema() == q.collect().schema
 
     assert df.select(
         pl.col("iso_code").str.extract_groups(r"\A(ISO\S*).*?(\d+)")


### PR DESCRIPTION
Partial fix for #23663.

The engine was modified: for the empty string pattern (""), it now generates an empty Struct, rather than a Struct containing the 'missing' value.