### PR TITLE
refactor: Use UUID for UniqueID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3684,6 +3684,7 @@ dependencies = [
  "slotmap",
  "stacker",
  "sysinfo",
+ "uuid",
  "version_check",
 ]
 

--- a/crates/polars-expr/src/state/execution_state.rs
+++ b/crates/polars-expr/src/state/execution_state.rs
@@ -225,7 +225,7 @@ impl ExecutionState {
                 let mut guard = self.df_cache.write().unwrap();
 
                 guard
-                    .entry(key.clone())
+                    .entry(*key)
                     .or_insert_with(|| {
                         Arc::new((AtomicI64::new(cache_hits as i64), OnceLock::new()))
                     })

--- a/crates/polars-lazy/src/tests/cse.rs
+++ b/crates/polars-lazy/src/tests/cse.rs
@@ -162,7 +162,7 @@ fn test_cse_union2_4925() -> PolarsResult<()> {
             match lp {
                 Cache { id, cache_hits, .. } => {
                     assert_eq!(*cache_hits, 1);
-                    Some(id.clone())
+                    Some(*id)
                 },
                 _ => None,
             }
@@ -222,7 +222,7 @@ fn test_cse_joins_4954() -> PolarsResult<()> {
                     assert_eq!(*cache_hits, 1);
                     assert!(matches!(lp_arena.get(*input), IR::SimpleProjection { .. }));
 
-                    Some(id.clone())
+                    Some(*id)
                 },
                 _ => None,
             }
@@ -282,7 +282,7 @@ fn test_cache_with_partial_projection() -> PolarsResult<()> {
         .flat_map(|(_, lp)| {
             use IR::*;
             match lp {
-                Cache { id, .. } => Some(id.clone()),
+                Cache { id, .. } => Some(*id),
                 _ => None,
             }
         })

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -52,6 +52,7 @@ pub fn to_alp(
         cache_file_info: Default::default(),
         pushdown_maintain_errors: optimizer::pushdown_maintain_errors(),
         verbose: verbose(),
+        cache_id_for_arc_ptr: Default::default(),
     };
 
     match to_alp_impl(lp, &mut ctxt) {
@@ -429,7 +430,11 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             return run_conversion(lp, ctxt, "sort").map_err(|e| e.context(failed_here!(sort)));
         },
         DslPlan::Cache { input } => {
-            let id = UniqueId::from_arc(input.clone());
+            let id = ctxt
+                .cache_id_for_arc_ptr
+                .entry(Arc::as_ptr(&input).addr())
+                .or_insert_with(UniqueId::new)
+                .to_owned();
             let input =
                 to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_here!(cache)))?;
             IR::Cache {

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/utils.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/utils.rs
@@ -10,6 +10,7 @@ pub(super) struct DslConversionContext<'a> {
     pub(super) cache_file_info: SourcesToFileInfo,
     pub(super) pushdown_maintain_errors: bool,
     pub(super) verbose: bool,
+    pub(super) cache_id_for_arc_ptr: PlHashMap<usize, UniqueId>,
 }
 
 pub(super) fn expand_expressions(

--- a/crates/polars-plan/src/plans/ir/dot.rs
+++ b/crates/polars-plan/src/plans/ir/dot.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use polars_core::schema::Schema;
 use polars_utils::pl_str::PlSmallStr;
+use polars_utils::unique_id::UniqueId;
 
 use super::format::ExprIRSliceDisplay;
 use crate::constants::UNLIMITED_CACHE;
@@ -18,7 +19,7 @@ const INDENT: &str = "  ";
 #[derive(Clone, Copy)]
 enum DotNode {
     Plain(usize),
-    Cache(usize),
+    Cache(UniqueId),
 }
 
 impl fmt::Display for DotNode {
@@ -79,7 +80,7 @@ impl<'a> IRDotDisplay<'a> {
 
         let root = self.lp.root();
         let id = if let IR::Cache { id, .. } = root {
-            DotNode::Cache(id.to_usize())
+            DotNode::Cache(*id)
         } else {
             *last += 1;
             DotNode::Plain(*last)

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -797,8 +797,8 @@ pub fn write_ir_non_recursive(
             cache_hits,
         } => write!(
             f,
-            "{:indent$}CACHE[id: {:x}, cache_hits: {}]",
-            "", id, *cache_hits
+            "{:indent$}CACHE[id: {}, cache_hits: {}]",
+            "", *id, *cache_hits
         ),
         IR::GroupBy {
             input: _,

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -798,7 +798,7 @@ pub fn write_ir_non_recursive(
         } => write!(
             f,
             "{:indent$}CACHE[id: {:x}, cache_hits: {}]",
-            "", *id, *cache_hits
+            "", id, *cache_hits
         ),
         IR::GroupBy {
             input: _,

--- a/crates/polars-plan/src/plans/ir/inputs.rs
+++ b/crates/polars-plan/src/plans/ir/inputs.rs
@@ -79,7 +79,7 @@ impl IR {
             },
             Cache { id, cache_hits, .. } => Cache {
                 input: inputs[0],
-                id: id.clone(),
+                id: *id,
                 cache_hits: *cache_hits,
             },
             Distinct { options, .. } => Distinct {

--- a/crates/polars-plan/src/plans/ir/tree_format.rs
+++ b/crates/polars-plan/src/plans/ir/tree_format.rs
@@ -244,7 +244,7 @@ impl<'a> TreeFmtNode<'a> {
                     } => ND(
                         wh(
                             h,
-                            &format!("CACHE[id: {:x}, cache_hits: {}]", id, *cache_hits),
+                            &format!("CACHE[id: {}, cache_hits: {}]", id, *cache_hits),
                         ),
                         vec![self.lp_node(None, *input)],
                     ),

--- a/crates/polars-plan/src/plans/optimizer/cache_states.rs
+++ b/crates/polars-plan/src/plans/optimizer/cache_states.rs
@@ -186,7 +186,7 @@ pub(super) fn set_cache_states(
                 // change the schema
 
                 let v = cache_schema_and_children
-                    .entry(id.clone())
+                    .entry(*id)
                     .or_insert_with(Value::default);
                 v.children.push(*input);
                 v.parents.push(frame.parent);
@@ -237,7 +237,7 @@ pub(super) fn set_cache_states(
                     v.names_union.extend(schema.iter_names_cloned());
                 }
             }
-            frame.cache_id = Some(id.clone());
+            frame.cache_id = Some(*id);
         };
 
         // Shift parents.

--- a/crates/polars-plan/src/plans/optimizer/collapse_and_project.rs
+++ b/crates/polars-plan/src/plans/optimizer/collapse_and_project.rs
@@ -118,7 +118,7 @@ impl OptimizationRule for SimpleProjectionAndCollapse {
                 {
                     Ok(Some(Cache {
                         input: *prev_input,
-                        id: id.clone(),
+                        id: *id,
                         // ensure the counts are updated
                         cache_hits: cache_hits.saturating_add(*outer_cache_hits),
                     }))

--- a/crates/polars-plan/src/plans/optimizer/cse/cse_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/cse_lp.rs
@@ -90,12 +90,17 @@ mod identifier_impl {
 }
 use identifier_impl::*;
 
-#[derive(Default)]
 struct IdentifierMap<V> {
     inner: PlHashMap<Identifier, V>,
 }
 
 impl<V> IdentifierMap<V> {
+    fn new() -> Self {
+        Self {
+            inner: Default::default(),
+        }
+    }
+
     fn get(&self, id: &Identifier, lp_arena: &Arena<IR>, expr_arena: &Arena<AExpr>) -> Option<&V> {
         self.inner
             .raw_entry()
@@ -122,6 +127,12 @@ impl<V> IdentifierMap<V> {
                 v
             },
         }
+    }
+}
+
+impl<V> Default for IdentifierMap<V> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -332,15 +343,14 @@ impl RewritingVisitor for CommonSubPlanRewriter<'_> {
             self.visited_idx += 1;
         }
 
-        let cache_id = self
+        let cache_id = *self
             .cache_id
-            .entry(id.clone(), UniqueId::default, &arena.0, &arena.1)
-            .clone();
+            .entry(id.clone(), UniqueId::new, &arena.0, &arena.1);
         let cache_count = self.sp_count.get(id, &arena.0, &arena.1).unwrap().1;
 
         let cache_node = IR::Cache {
             input: node.node(),
-            id: cache_id.clone(),
+            id: cache_id,
             cache_hits: cache_count - 1,
         };
         node.assign(cache_node, &mut arena.0);

--- a/crates/polars-plan/src/plans/prune.rs
+++ b/crates/polars-plan/src/plans/prune.rs
@@ -127,7 +127,7 @@ impl<'a> CopyContext<'a> {
         // If this is a cache, reset the hit count and store the dst node.
         if let IR::Cache { cache_hits, id, .. } = self.dst_ir.get_mut(dst_node) {
             *cache_hits = 0;
-            let prev = self.dst_caches.insert(id.clone(), dst_node);
+            let prev = self.dst_caches.insert(*id, dst_node);
             assert!(prev.is_none(), "cache {id} was traversed twice");
         }
 
@@ -340,7 +340,7 @@ mod tests {
 
             let cache = ir_arena.add(IR::Cache {
                 input: filter,
-                id: UniqueId::Plain(0),
+                id: UniqueId::new(),
                 cache_hits: 1,
             });
 

--- a/crates/polars-python/src/lazyframe/visit.rs
+++ b/crates/polars-python/src/lazyframe/visit.rs
@@ -58,7 +58,7 @@ impl NodeTraverser {
     // Increment major on breaking changes to the IR (e.g. renaming
     // fields, reordering tuples), minor on backwards compatible
     // changes (e.g. exposing a new expression node).
-    const VERSION: Version = (8, 0);
+    const VERSION: Version = (9, 0);
 
     pub fn new(root: Node, lp_arena: Arena<IR>, expr_arena: Arena<AExpr>) -> Self {
         Self {

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -229,7 +229,7 @@ pub struct Cache {
     #[pyo3(get)]
     input: usize,
     #[pyo3(get)]
-    id_: usize,
+    id_: u128,
     #[pyo3(get)]
     cache_hits: u32,
 }
@@ -489,7 +489,7 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
             cache_hits,
         } => Cache {
             input: input.0,
-            id_: id.to_usize(),
+            id_: id.as_u128(),
             cache_hits: *cache_hits,
         }
         .into_py_any(py),

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -791,7 +791,7 @@ pub fn lower_ir(
             id,
             cache_hits: _,
         } => {
-            let id = id.clone();
+            let id = *id;
             if let Some(cached) = cache_nodes.get(&id) {
                 return Ok(*cached);
             }

--- a/crates/polars-utils/Cargo.toml
+++ b/crates/polars-utils/Cargo.toml
@@ -34,6 +34,7 @@ serde_json = { workspace = true, optional = true }
 slotmap = { workspace = true }
 stacker = { workspace = true }
 sysinfo = { version = "0.33", default-features = false, features = ["system"], optional = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }
@@ -53,6 +54,7 @@ serde = [
   "dep:bincode",
   "dep:flate2",
   "dep:serde_json",
+  "uuid/serde",
 ]
 dsl-schema = ["dep:schemars"]
 polars_cloud_server = ["dep:serde_ignored"]

--- a/crates/polars-utils/src/unique_id.rs
+++ b/crates/polars-utils/src/unique_id.rs
@@ -1,194 +1,32 @@
-use std::any::Any;
 use std::fmt::LowerHex;
-use std::sync::Arc;
 
-/// Unique identifier potentially backed by an `Arc` address to protect against collisions.
-///
-/// Note that a serialization roundtrip will force this to become a [`UniqueId::Plain`] variant.
-#[derive(Clone)]
-pub enum UniqueId {
-    /// ID that derives from the memory address of an `Arc` to protect against collisions.
-    /// Note that it internally stores as a `dyn Any` to allow it to re-use an existing `Arc` holding
-    /// any type.
-    MemoryRef(Arc<dyn Any + Send + Sync>),
+use uuid::Uuid;
 
-    /// Stores a plain `usize`. Unlike the `MemoryRef` variant, there is no internal protection against
-    /// collisions - this must handled separately.
-    ///
-    /// Note: This repr may also be constructed as the result of a serialization round-trip.
-    Plain(usize),
-}
+/// Unique identifier.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct UniqueId(Uuid);
 
 impl UniqueId {
+    #[expect(clippy::new_without_default)]
     #[inline]
-    pub fn to_usize(&self) -> usize {
-        match self {
-            Self::MemoryRef(v) => Arc::as_ptr(v) as *const () as usize,
-            Self::Plain(v) => *v,
-        }
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
     }
 
-    /// Use an existing `Arc<T>` as backing for an ID.
-    pub fn from_arc<T: Any + Send + Sync>(arc: Arc<T>) -> Self {
-        Self::MemoryRef(arc.clone())
-    }
-
-    /// Downcasts to a concrete Arc type. Returns None `Self` is `Plain`.
-    ///
-    /// # Panics
-    /// On a debug build, panics if `Self` is an `Arc` but does not contain `T`. On a release build
-    /// this will instead `None`.
-    pub fn downcast_arc<T: Any>(self) -> Option<Arc<T>> {
-        match self {
-            Self::MemoryRef(inner) => {
-                // Note, ref type here must match exactly with T.
-                let v: &dyn Any = inner.as_ref();
-
-                if v.type_id() != std::any::TypeId::of::<T>() {
-                    if cfg!(debug_assertions) {
-                        panic!("invalid downcast of UniqueId")
-                    } else {
-                        // Just return None on release.
-                        return None;
-                    }
-                }
-
-                // Safety: Type IDs checked above.
-                let ptr: *const dyn Any = Arc::into_raw(inner);
-                let ptr: *const T = ptr as _;
-                Some(unsafe { Arc::from_raw(ptr) })
-            },
-
-            Self::Plain(_) => None,
-        }
-    }
-}
-
-impl Default for UniqueId {
-    fn default() -> Self {
-        Self::MemoryRef(Arc::new(()))
-    }
-}
-
-impl PartialEq for UniqueId {
-    fn eq(&self, other: &Self) -> bool {
-        self.to_usize() == other.to_usize()
-    }
-}
-
-impl Eq for UniqueId {}
-
-impl PartialOrd for UniqueId {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(Ord::cmp(self, other))
-    }
-}
-
-impl Ord for UniqueId {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        Ord::cmp(&self.to_usize(), &other.to_usize())
-    }
-}
-
-impl std::hash::Hash for UniqueId {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.to_usize().hash(state)
+    pub fn as_u128(&self) -> u128 {
+        self.0.as_u128()
     }
 }
 
 impl std::fmt::Display for UniqueId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self.to_usize(), f)
-    }
-}
-
-impl std::fmt::Debug for UniqueId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        use UniqueId::*;
-
-        write!(
-            f,
-            "UniqueId::{}({})",
-            match self {
-                MemoryRef(_) => "MemoryRef",
-                Plain(_) => "Plain",
-            },
-            self.to_usize()
-        )
+        write!(f, "{}", self.0.as_hyphenated())
     }
 }
 
 impl LowerHex for UniqueId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        LowerHex::fmt(&self.to_usize(), f)
-    }
-}
-
-#[cfg(feature = "serde")]
-mod _serde_impl {
-    use super::UniqueId;
-
-    impl serde::ser::Serialize for UniqueId {
-        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: serde::Serializer,
-        {
-            usize::serialize(&self.to_usize(), serializer)
-        }
-    }
-
-    impl<'de> serde::de::Deserialize<'de> for UniqueId {
-        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: serde::Deserializer<'de>,
-        {
-            usize::deserialize(deserializer).map(Self::Plain)
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::any::Any;
-    use std::sync::Arc;
-
-    use super::UniqueId;
-
-    #[test]
-    fn test_unique_id() {
-        let id = UniqueId::default();
-
-        assert!(matches!(id, UniqueId::MemoryRef(_)));
-
-        assert_eq!(id, id);
-        assert_ne!(id, UniqueId::default());
-
-        assert_eq!(id, UniqueId::Plain(id.to_usize()));
-
-        // Following code shows the memory layout
-        let UniqueId::MemoryRef(arc_ref) = &id else {
-            unreachable!()
-        };
-        let inner_ref: &dyn Any = arc_ref.as_ref();
-
-        assert_eq!(std::mem::size_of_val(inner_ref), 0);
-        assert_eq!(std::mem::size_of::<Arc<dyn Any>>(), 16);
-
-        assert_eq!(
-            Arc::as_ptr(arc_ref) as *const () as usize,
-            inner_ref as *const _ as *const () as usize,
-        );
-    }
-
-    #[test]
-    fn test_unique_id_downcast() {
-        let id = UniqueId::default();
-        let _: Arc<()> = id.downcast_arc().unwrap();
-
-        let inner: Arc<usize> = Arc::new(37);
-        let id = UniqueId::from_arc(inner);
-
-        let out: Arc<usize> = id.downcast_arc().unwrap();
-        assert_eq!(*out.as_ref(), 37);
+        write!(f, "{:x}", self.0.as_simple())
     }
 }

--- a/crates/polars-utils/src/unique_id.rs
+++ b/crates/polars-utils/src/unique_id.rs
@@ -1,5 +1,3 @@
-use std::fmt::LowerHex;
-
 use uuid::Uuid;
 
 /// Unique identifier.
@@ -22,11 +20,5 @@ impl UniqueId {
 impl std::fmt::Display for UniqueId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0.as_hyphenated())
-    }
-}
-
-impl LowerHex for UniqueId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:x}", self.0.as_simple())
     }
 }


### PR DESCRIPTION
This PR switches `UniqueID` to use UUID internally. This ensures uniqueness and preserves the ability to generate new unique IDs even after deserialization.

@wence- This changes the Python IR interface. The `Cache::id_` field changes from `usize` to `u128` since the ids now use 128 bits. I bumped the `VERSION`.

Closes #23674