### PR TITLE
fix: Remaining bugs in `with_exprs_and_input` and pruning

### DIFF
--- a/crates/polars-plan/src/plans/ir/inputs.rs
+++ b/crates/polars-plan/src/plans/ir/inputs.rs
@@ -63,6 +63,7 @@ impl IR {
             Join {
                 schema,
                 left_on,
+                right_on,
                 options,
                 ..
             } => Join {
@@ -70,8 +71,16 @@ impl IR {
                 input_right: inputs[1],
                 schema: schema.clone(),
                 left_on: exprs[..left_on.len()].to_vec(),
-                right_on: exprs[left_on.len()..].to_vec(),
-                options: options.clone(),
+                right_on: exprs[left_on.len()..][..right_on.len()].to_vec(),
+                options: {
+                    let mut options = options.clone();
+                    if let Some(JoinTypeOptionsIR::Cross { predicate }) =
+                        &mut Arc::make_mut(&mut options).options
+                    {
+                        *predicate = exprs[left_on.len() + right_on.len()].clone();
+                    }
+                    options
+                },
             },
             Sort {
                 slice,
@@ -196,10 +205,16 @@ impl IR {
                 container.extend(iter)
             },
             Join {
-                left_on, right_on, ..
+                left_on,
+                right_on,
+                options,
+                ..
             } => {
                 let iter = left_on.iter().cloned().chain(right_on.iter().cloned());
-                container.extend(iter)
+                container.extend(iter);
+                if let Some(JoinTypeOptionsIR::Cross { predicate }) = &options.options {
+                    container.push(predicate.clone());
+                }
             },
             HStack { exprs, .. } => container.extend_from_slice(exprs),
             Scan { predicate, .. } => {

--- a/crates/polars-plan/src/plans/prune.rs
+++ b/crates/polars-plan/src/plans/prune.rs
@@ -155,7 +155,15 @@ impl<'a> CopyContext<'a> {
         }
         inputs.reverse();
 
-        self.dst_expr.add(expr.clone().replace_inputs(&inputs))
+        let mut dst_expr = expr.clone().replace_inputs(&inputs);
+
+        // Fix up eval, the evaluation subtree is not treated as an input,
+        // so it needs to be copied manually.
+        if let AExpr::Eval { evaluation, .. } = &mut dst_expr {
+            *evaluation = self.copy_expr(*evaluation);
+        }
+
+        self.dst_expr.add(dst_expr)
     }
 }
 


### PR DESCRIPTION
This PR:
- fixes `PythonScan` `PythonPredicate::Polars` being ignored
- fixes `JoinTypeOptionsIR::Cross` predicate being ignored
- fixes `AExpr::Eval` not being pruned properly, `evaluation` is not treated as an input, but contains references to the arena, so it is copied explicitly after visiting inputs