### PR TITLE
fix: Allow DataType expressions with selectors

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -19,7 +19,7 @@ mod functions;
 mod join;
 mod scans;
 mod utils;
-pub use expr_expansion::{is_regex_projection, prepare_projection};
+pub use expr_expansion::{expand_expression, is_regex_projection, prepare_projection};
 pub use expr_to_ir::{ExprToIRContext, to_expr_ir};
 use expr_to_ir::{to_expr_ir_materialized_lit, to_expr_irs};
 use utils::DslConversionContext;

--- a/py-polars/tests/unit/test_datatype_exprs.py
+++ b/py-polars/tests/unit/test_datatype_exprs.py
@@ -276,3 +276,28 @@ def test_struct() -> None:
                 dtype_expr.struct["a"].collect_dtype({})
             with pytest.raises(pl.exceptions.InvalidOperationError):
                 pl.select(dtype_expr.struct.field_names())
+
+
+def test_dtype_of_with_selector_23719() -> None:
+    assert_frame_equal(
+        pl.select(x=1).select(pl.cum_sum_horizontal(pl.all())),
+        pl.select(x=1).select(cum_sum=pl.struct("x")),
+    )
+
+
+def test_dtype_of_with_multi_expr() -> None:
+    with pytest.raises(
+        pl.exceptions.InvalidOperationError,
+        match="DataType expression are not allowed to expand to more than 1 expression",
+    ):
+        pl.dtype_of(pl.all()).collect_dtype(
+            pl.Schema({"x": pl.Boolean, "y": pl.Boolean})
+        )
+
+
+def test_dtype_of_with_unknown_type() -> None:
+    with pytest.raises(
+        pl.exceptions.InvalidOperationError,
+        match="DataType expression is not allowed to instantiate",
+    ):
+        pl.dtype_of("x").collect_dtype(pl.Schema({"x": pl.Unknown}))


### PR DESCRIPTION
Now we allow datatype expressions with selectors that expand to a single expression.

Fixes #23719.