### PR TITLE
refactor: IR inputs and exprs iterators

### DIFF
--- a/crates/polars-lazy/src/physical_plan/exotic.rs
+++ b/crates/polars-lazy/src/physical_plan/exotic.rs
@@ -46,12 +46,12 @@ pub(crate) fn prepare_expression_for_context(
     let optimized = lf.optimize(&mut lp_arena, &mut expr_arena)?;
     let lp = lp_arena.get(optimized);
     let aexpr = lp
-        .get_exprs()
-        .pop()
+        .exprs()
+        .next()
         .ok_or_else(|| polars_err!(ComputeError: "expected expressions in the context"))?;
 
     create_physical_expr(
-        &aexpr,
+        aexpr,
         ctxt,
         &expr_arena,
         &input_schema,

--- a/crates/polars-lazy/src/tests/cse.rs
+++ b/crates/polars-lazy/src/tests/cse.rs
@@ -5,7 +5,7 @@ use super::*;
 fn cached_before_root(q: LazyFrame) {
     let (mut expr_arena, mut lp_arena) = get_arenas();
     let lp = q.optimize(&mut lp_arena, &mut expr_arena).unwrap();
-    for input in lp_arena.get(lp).get_inputs_vec() {
+    for input in lp_arena.get(lp).inputs() {
         assert!(matches!(lp_arena.get(input), IR::Cache { .. }));
     }
 }

--- a/crates/polars-lazy/src/tests/optimization_checks.rs
+++ b/crates/polars-lazy/src/tests/optimization_checks.rs
@@ -396,8 +396,7 @@ fn test_string_addition_to_concat_str() -> PolarsResult<()> {
     let (mut expr_arena, mut lp_arena) = get_arenas();
     let root = q.clone().optimize(&mut lp_arena, &mut expr_arena)?;
     let lp = lp_arena.get(root);
-    let mut exprs = lp.get_exprs();
-    let e = exprs.pop().unwrap();
+    let e = lp.exprs().next().unwrap();
     if let AExpr::Function { input, .. } = expr_arena.get(e.node()) {
         // the concat_str has the 4 expressions as input
         assert_eq!(input.len(), 4);

--- a/crates/polars-plan/src/plans/builder_ir.rs
+++ b/crates/polars-plan/src/plans/builder_ir.rs
@@ -43,7 +43,7 @@ impl<'a> IRBuilder<'a> {
 
         // Run the optimizer
         let mut conversion_optimizer = ConversionOptimizer::new(true, true, true);
-        conversion_optimizer.fill_scratch(&b.lp_arena.get(b.root).get_exprs(), b.expr_arena);
+        conversion_optimizer.fill_scratch(b.lp_arena.get(b.root).exprs(), b.expr_arena);
         conversion_optimizer
             .optimize_exprs(b.expr_arena, b.lp_arena, b.root, false)
             .map_err(|e| e.context(format!("optimizing '{ir_name}' failed").into()))?;

--- a/crates/polars-plan/src/plans/conversion/stack_opt.rs
+++ b/crates/polars-plan/src/plans/conversion/stack_opt.rs
@@ -70,7 +70,11 @@ impl ConversionOptimizer {
         });
     }
 
-    pub fn fill_scratch<N: Borrow<Node>>(&mut self, exprs: &[N], expr_arena: &Arena<AExpr>) {
+    pub fn fill_scratch<I, N>(&mut self, exprs: I, expr_arena: &Arena<AExpr>)
+    where
+        I: IntoIterator<Item = N>,
+        N: Borrow<Node>,
+    {
         for e in exprs {
             let node = *e.borrow();
             self.push_scratch(node, expr_arena);

--- a/crates/polars-plan/src/plans/expr_ir.rs
+++ b/crates/polars-plan/src/plans/expr_ir.rs
@@ -87,6 +87,12 @@ impl Borrow<Node> for ExprIR {
     }
 }
 
+impl Borrow<Node> for &ExprIR {
+    fn borrow(&self) -> &Node {
+        &self.node
+    }
+}
+
 impl ExprIR {
     pub fn new(node: Node, output_name: OutputName) -> Self {
         debug_assert!(!output_name.is_none());

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -253,8 +253,8 @@ impl<'a> IRDisplay<'a> {
             },
             ir_node => {
                 write_ir_non_recursive(f, ir_node, self.lp.expr_arena, output_schema, indent)?;
-                for input in ir_node.get_inputs().iter() {
-                    self.with_root(*input)._format(f, sub_indent)?;
+                for input in ir_node.inputs() {
+                    self.with_root(input)._format(f, sub_indent)?;
                 }
                 Ok(())
             },

--- a/crates/polars-plan/src/plans/ir/inputs.rs
+++ b/crates/polars-plan/src/plans/ir/inputs.rs
@@ -1,261 +1,282 @@
+use std::iter;
+
 use super::*;
 
 impl IR {
-    /// Takes the expressions of an LP node and the inputs of that node and reconstruct
-    pub fn with_exprs_and_input(&self, mut exprs: Vec<ExprIR>, mut inputs: Vec<Node>) -> IR {
-        use IR::*;
+    /// Returns a node with updated expressions.
+    ///
+    /// Panics if the expression count doesn't match
+    /// [`Self::exprs`]/[`Self::exprs_mut`]/[`Self::copy_exprs`].
+    pub fn with_exprs<E>(mut self, exprs: E) -> Self
+    where
+        E: IntoIterator<Item = ExprIR>,
+    {
+        let mut exprs_mut = self.exprs_mut();
+        let mut new_exprs = exprs.into_iter();
 
+        for (expr, new_expr) in exprs_mut.by_ref().zip(new_exprs.by_ref()) {
+            *expr = new_expr;
+        }
+
+        assert!(exprs_mut.next().is_none(), "not enough exprs");
+        assert!(new_exprs.next().is_none(), "too many exprs");
+
+        drop(exprs_mut);
+
+        self
+    }
+
+    /// Returns a node with updated inputs.
+    ///
+    /// Panics if the input count doesn't match
+    /// [`Self::inputs`]/[`Self::inputs_mut`]/[`Self::copy_inputs`]/[`Self::get_inputs`].
+    pub fn with_inputs<I>(mut self, inputs: I) -> Self
+    where
+        I: IntoIterator<Item = Node>,
+    {
+        let mut inputs_mut = self.inputs_mut();
+        let mut new_inputs = inputs.into_iter();
+
+        for (input, new_input) in inputs_mut.by_ref().zip(new_inputs.by_ref()) {
+            *input = new_input;
+        }
+
+        assert!(inputs_mut.next().is_none(), "not enough inputs");
+        assert!(new_inputs.next().is_none(), "too many inputs");
+
+        drop(inputs_mut);
+
+        self
+    }
+
+    pub fn exprs(&'_ self) -> Exprs<'_> {
+        use IR::*;
         match self {
+            Slice { .. } => Exprs::Empty,
+            Cache { .. } => Exprs::Empty,
+            Distinct { .. } => Exprs::Empty,
+            Union { .. } => Exprs::Empty,
+            MapFunction { .. } => Exprs::Empty,
+            DataFrameScan { .. } => Exprs::Empty,
+            HConcat { .. } => Exprs::Empty,
+            ExtContext { .. } => Exprs::Empty,
+            SimpleProjection { .. } => Exprs::Empty,
+            SinkMultiple { .. } => Exprs::Empty,
+            #[cfg(feature = "merge_sorted")]
+            MergeSorted { .. } => Exprs::Empty,
+
             #[cfg(feature = "python")]
-            PythonScan { options } => PythonScan {
-                options: {
-                    let mut options = options.clone();
-                    if let PythonPredicate::Polars(pred) = &mut options.predicate {
-                        *pred = exprs.pop().unwrap();
-                    }
-                    options
-                },
+            PythonScan { options } => match &options.predicate {
+                PythonPredicate::Polars(predicate) => Exprs::single(predicate),
+                _ => Exprs::Empty,
             },
-            Union { options, .. } => Union {
-                inputs,
-                options: *options,
+
+            Scan { predicate, .. } => match predicate {
+                Some(predicate) => Exprs::single(predicate),
+                _ => Exprs::Empty,
             },
-            HConcat {
-                schema, options, ..
-            } => HConcat {
-                inputs,
-                schema: schema.clone(),
-                options: *options,
-            },
-            Slice { offset, len, .. } => Slice {
-                input: inputs[0],
-                offset: *offset,
-                len: *len,
-            },
-            Filter { .. } => Filter {
-                input: inputs[0],
-                predicate: exprs.pop().unwrap(),
-            },
-            Select {
-                schema, options, ..
-            } => Select {
-                input: inputs[0],
-                expr: exprs,
-                schema: schema.clone(),
-                options: *options,
-            },
-            GroupBy {
-                keys,
-                schema,
-                apply,
-                maintain_order,
-                options: dynamic_options,
-                ..
-            } => GroupBy {
-                input: inputs[0],
-                keys: exprs[..keys.len()].to_vec(),
-                aggs: exprs[keys.len()..].to_vec(),
-                schema: schema.clone(),
-                apply: apply.clone(),
-                maintain_order: *maintain_order,
-                options: dynamic_options.clone(),
-            },
+
+            Filter { predicate, .. } => Exprs::single(predicate),
+
+            Sort { by_column, .. } => Exprs::slice(by_column),
+            Select { expr, .. } => Exprs::slice(expr),
+            HStack { exprs, .. } => Exprs::slice(exprs),
+
+            GroupBy { keys, aggs, .. } => Exprs::double_slice(keys, aggs),
+
             Join {
-                schema,
                 left_on,
                 right_on,
                 options,
                 ..
-            } => Join {
-                input_left: inputs[0],
-                input_right: inputs[1],
-                schema: schema.clone(),
-                left_on: exprs[..left_on.len()].to_vec(),
-                right_on: exprs[left_on.len()..][..right_on.len()].to_vec(),
-                options: {
-                    let mut options = options.clone();
-                    if let Some(JoinTypeOptionsIR::Cross { predicate }) =
-                        &mut Arc::make_mut(&mut options).options
-                    {
-                        *predicate = exprs[left_on.len() + right_on.len()].clone();
+            } => match &options.options {
+                Some(JoinTypeOptionsIR::Cross { predicate }) => Exprs::Boxed(Box::new(
+                    left_on
+                        .iter()
+                        .chain(right_on.iter())
+                        .chain(iter::once(predicate)),
+                )),
+                _ => Exprs::double_slice(left_on, right_on),
+            },
+
+            Sink { payload, .. } => match payload {
+                SinkTypeIR::Memory => Exprs::Empty,
+                SinkTypeIR::File(_) => Exprs::Empty,
+                SinkTypeIR::Partition(p) => {
+                    let key_iter = match &p.variant {
+                        PartitionVariantIR::Parted { key_exprs, .. }
+                        | PartitionVariantIR::ByKey { key_exprs, .. } => key_exprs.iter(),
+                        _ => [].iter(),
+                    };
+                    let sort_by_iter = match &p.per_partition_sort_by {
+                        Some(sort_by) => sort_by.iter(),
+                        _ => [].iter(),
                     }
-                    options
+                    .map(|s| &s.expr);
+                    Exprs::Boxed(Box::new(key_iter.chain(sort_by_iter)))
                 },
             },
-            Sort {
-                slice,
-                sort_options,
-                ..
-            } => Sort {
-                input: inputs[0],
-                by_column: exprs,
-                slice: *slice,
-                sort_options: sort_options.clone(),
-            },
-            Cache { id, cache_hits, .. } => Cache {
-                input: inputs[0],
-                id: *id,
-                cache_hits: *cache_hits,
-            },
-            Distinct { options, .. } => Distinct {
-                input: inputs[0],
-                options: options.clone(),
-            },
-            HStack {
-                schema, options, ..
-            } => HStack {
-                input: inputs[0],
-                exprs,
-                schema: schema.clone(),
-                options: *options,
-            },
-            Scan {
-                sources,
-                file_info,
-                hive_parts,
-                output_schema,
-                predicate,
-                unified_scan_args,
-                scan_type,
-            } => Scan {
-                sources: sources.clone(),
-                file_info: file_info.clone(),
-                hive_parts: hive_parts.clone(),
-                output_schema: output_schema.clone(),
-                unified_scan_args: unified_scan_args.clone(),
-                predicate: predicate.is_some().then(|| exprs.pop().unwrap()),
-                scan_type: scan_type.clone(),
-            },
-            DataFrameScan {
-                df,
-                schema,
-                output_schema,
-            } => DataFrameScan {
-                df: df.clone(),
-                schema: schema.clone(),
-                output_schema: output_schema.clone(),
-            },
-            MapFunction { function, .. } => MapFunction {
-                input: inputs[0],
-                function: function.clone(),
-            },
-            ExtContext { schema, .. } => ExtContext {
-                input: inputs.pop().unwrap(),
-                contexts: inputs,
-                schema: schema.clone(),
-            },
-            Sink { payload, .. } => {
-                let mut payload = payload.clone();
-                if let SinkTypeIR::Partition(p) = &mut payload {
-                    if let Some(sort_by) = &mut p.per_partition_sort_by {
-                        assert!(exprs.len() >= sort_by.len());
-                        let exprs = exprs.drain(exprs.len() - sort_by.len()..);
-                        for (s, expr) in sort_by.iter_mut().zip(exprs) {
-                            s.expr = expr;
-                        }
-                    }
-                    match &mut p.variant {
-                        PartitionVariantIR::Parted { key_exprs, .. }
-                        | PartitionVariantIR::ByKey { key_exprs, .. } => {
-                            assert_eq!(key_exprs.len(), exprs.len());
-                            *key_exprs = exprs;
-                        },
-                        _ => (),
-                    }
-                }
-                Sink {
-                    input: inputs.pop().unwrap(),
-                    payload,
-                }
-            },
-            SinkMultiple { .. } => SinkMultiple { inputs },
-            SimpleProjection { columns, .. } => SimpleProjection {
-                input: inputs.pop().unwrap(),
-                columns: columns.clone(),
-            },
+
+            Invalid => unreachable!(),
+        }
+    }
+
+    pub fn exprs_mut(&'_ mut self) -> ExprsMut<'_> {
+        use IR::*;
+        match self {
+            Slice { .. } => ExprsMut::Empty,
+            Cache { .. } => ExprsMut::Empty,
+            Distinct { .. } => ExprsMut::Empty,
+            Union { .. } => ExprsMut::Empty,
+            MapFunction { .. } => ExprsMut::Empty,
+            DataFrameScan { .. } => ExprsMut::Empty,
+            HConcat { .. } => ExprsMut::Empty,
+            ExtContext { .. } => ExprsMut::Empty,
+            SimpleProjection { .. } => ExprsMut::Empty,
+            SinkMultiple { .. } => ExprsMut::Empty,
             #[cfg(feature = "merge_sorted")]
-            MergeSorted {
-                input_left: _,
-                input_right: _,
-                key,
-            } => MergeSorted {
-                input_left: inputs[0],
-                input_right: inputs[1],
-                key: key.clone(),
+            MergeSorted { .. } => ExprsMut::Empty,
+
+            #[cfg(feature = "python")]
+            PythonScan { options } => match &mut options.predicate {
+                PythonPredicate::Polars(predicate) => ExprsMut::single(predicate),
+                _ => ExprsMut::Empty,
             },
+
+            Scan { predicate, .. } => match predicate {
+                Some(predicate) => ExprsMut::single(predicate),
+                _ => ExprsMut::Empty,
+            },
+
+            Filter { predicate, .. } => ExprsMut::single(predicate),
+
+            Sort { by_column, .. } => ExprsMut::slice(by_column),
+            Select { expr, .. } => ExprsMut::slice(expr),
+            HStack { exprs, .. } => ExprsMut::slice(exprs),
+
+            GroupBy { keys, aggs, .. } => ExprsMut::double_slice(keys, aggs),
+
+            Join {
+                left_on,
+                right_on,
+                options,
+                ..
+            } => match Arc::make_mut(options).options.as_mut() {
+                Some(JoinTypeOptionsIR::Cross { predicate }) => ExprsMut::Boxed(Box::new(
+                    left_on
+                        .iter_mut()
+                        .chain(right_on.iter_mut())
+                        .chain(iter::once(predicate)),
+                )),
+                _ => ExprsMut::double_slice(left_on, right_on),
+            },
+
+            Sink { payload, .. } => match payload {
+                SinkTypeIR::Memory => ExprsMut::Empty,
+                SinkTypeIR::File(_) => ExprsMut::Empty,
+                SinkTypeIR::Partition(p) => {
+                    let key_iter = match &mut p.variant {
+                        PartitionVariantIR::Parted { key_exprs, .. }
+                        | PartitionVariantIR::ByKey { key_exprs, .. } => key_exprs.iter_mut(),
+                        _ => [].iter_mut(),
+                    };
+                    let sort_by_iter = match &mut p.per_partition_sort_by {
+                        Some(sort_by) => sort_by.iter_mut(),
+                        _ => [].iter_mut(),
+                    }
+                    .map(|s| &mut s.expr);
+                    ExprsMut::Boxed(Box::new(key_iter.chain(sort_by_iter)))
+                },
+            },
+
             Invalid => unreachable!(),
         }
     }
 
     /// Copy the exprs in this LP node to an existing container.
-    pub fn copy_exprs(&self, container: &mut Vec<ExprIR>) {
+    pub fn copy_exprs<T>(&self, container: &mut T)
+    where
+        T: Extend<ExprIR>,
+    {
+        container.extend(self.exprs().cloned())
+    }
+
+    pub fn inputs(&'_ self) -> Inputs<'_> {
         use IR::*;
         match self {
-            Slice { .. }
-            | Cache { .. }
-            | Distinct { .. }
-            | Union { .. }
-            | MapFunction { .. }
-            | SinkMultiple { .. } => {},
-            Sort { by_column, .. } => container.extend_from_slice(by_column),
-            Filter { predicate, .. } => container.push(predicate.clone()),
-            Select { expr, .. } => container.extend_from_slice(expr),
-            GroupBy { keys, aggs, .. } => {
-                let iter = keys.iter().cloned().chain(aggs.iter().cloned());
-                container.extend(iter)
+            Union { inputs, .. } | HConcat { inputs, .. } | SinkMultiple { inputs } => {
+                Inputs::slice(inputs)
             },
+            Slice { input, .. } => Inputs::single(*input),
+            Filter { input, .. } => Inputs::single(*input),
+            Select { input, .. } => Inputs::single(*input),
+            SimpleProjection { input, .. } => Inputs::single(*input),
+            Sort { input, .. } => Inputs::single(*input),
+            Cache { input, .. } => Inputs::single(*input),
+            GroupBy { input, .. } => Inputs::single(*input),
             Join {
-                left_on,
-                right_on,
-                options,
+                input_left,
+                input_right,
                 ..
-            } => {
-                let iter = left_on.iter().cloned().chain(right_on.iter().cloned());
-                container.extend(iter);
-                if let Some(JoinTypeOptionsIR::Cross { predicate }) = &options.options {
-                    container.push(predicate.clone());
-                }
-            },
-            HStack { exprs, .. } => container.extend_from_slice(exprs),
-            Scan { predicate, .. } => {
-                if let Some(pred) = predicate {
-                    container.push(pred.clone())
-                }
-            },
-            DataFrameScan { .. } => {},
+            } => Inputs::double(*input_left, *input_right),
+            HStack { input, .. } => Inputs::single(*input),
+            Distinct { input, .. } => Inputs::single(*input),
+            MapFunction { input, .. } => Inputs::single(*input),
+            Sink { input, .. } => Inputs::single(*input),
+            ExtContext {
+                input, contexts, ..
+            } => Inputs::Boxed(Box::new(iter::once(*input).chain(contexts.iter().copied()))),
+            Scan { .. } => Inputs::Empty,
+            DataFrameScan { .. } => Inputs::Empty,
             #[cfg(feature = "python")]
-            PythonScan { options } => {
-                if let PythonPredicate::Polars(pred) = &options.predicate {
-                    container.push(pred.clone())
-                }
-            },
-            Sink { payload, .. } => {
-                if let SinkTypeIR::Partition(p) = payload {
-                    match &p.variant {
-                        PartitionVariantIR::Parted { key_exprs, .. }
-                        | PartitionVariantIR::ByKey { key_exprs, .. } => {
-                            container.extend_from_slice(key_exprs);
-                        },
-                        _ => (),
-                    }
-                    if let Some(sort_by) = &p.per_partition_sort_by {
-                        container.extend(sort_by.iter().map(|s| s.expr.clone()));
-                    }
-                }
-            },
-            HConcat { .. } => {},
-            ExtContext { .. } | SimpleProjection { .. } => {},
+            PythonScan { .. } => Inputs::Empty,
             #[cfg(feature = "merge_sorted")]
-            MergeSorted { .. } => {},
+            MergeSorted {
+                input_left,
+                input_right,
+                ..
+            } => Inputs::double(*input_left, *input_right),
             Invalid => unreachable!(),
         }
     }
 
-    /// Get expressions in this node.
-    pub fn get_exprs(&self) -> Vec<ExprIR> {
-        let mut exprs = Vec::new();
-        self.copy_exprs(&mut exprs);
-        exprs
+    pub fn inputs_mut(&'_ mut self) -> InputsMut<'_> {
+        use IR::*;
+        match self {
+            Union { inputs, .. } | HConcat { inputs, .. } | SinkMultiple { inputs } => {
+                InputsMut::slice(inputs)
+            },
+            Slice { input, .. } => InputsMut::single(input),
+            Filter { input, .. } => InputsMut::single(input),
+            Select { input, .. } => InputsMut::single(input),
+            SimpleProjection { input, .. } => InputsMut::single(input),
+            Sort { input, .. } => InputsMut::single(input),
+            Cache { input, .. } => InputsMut::single(input),
+            GroupBy { input, .. } => InputsMut::single(input),
+            Join {
+                input_left,
+                input_right,
+                ..
+            } => InputsMut::double(input_left, input_right),
+            HStack { input, .. } => InputsMut::single(input),
+            Distinct { input, .. } => InputsMut::single(input),
+            MapFunction { input, .. } => InputsMut::single(input),
+            Sink { input, .. } => InputsMut::single(input),
+            ExtContext {
+                input, contexts, ..
+            } => InputsMut::Boxed(Box::new(iter::once(input).chain(contexts.iter_mut()))),
+            Scan { .. } => InputsMut::Empty,
+            DataFrameScan { .. } => InputsMut::Empty,
+            #[cfg(feature = "python")]
+            PythonScan { .. } => InputsMut::Empty,
+            #[cfg(feature = "merge_sorted")]
+            MergeSorted {
+                input_left,
+                input_right,
+                ..
+            } => InputsMut::double(input_left, input_right),
+            Invalid => unreachable!(),
+        }
     }
 
     /// Push inputs of the LP in of this node to an existing container.
@@ -265,70 +286,158 @@ impl IR {
     where
         T: Extend<Node>,
     {
-        use IR::*;
-        let input = match self {
-            Union { inputs, .. } | HConcat { inputs, .. } | SinkMultiple { inputs } => {
-                container.extend(inputs.iter().cloned());
-                return;
-            },
-            Slice { input, .. } => *input,
-            Filter { input, .. } => *input,
-            Select { input, .. } => *input,
-            SimpleProjection { input, .. } => *input,
-            Sort { input, .. } => *input,
-            Cache { input, .. } => *input,
-            GroupBy { input, .. } => *input,
-            Join {
-                input_left,
-                input_right,
-                ..
-            } => {
-                container.extend([*input_left, *input_right]);
-                return;
-            },
-            HStack { input, .. } => *input,
-            Distinct { input, .. } => *input,
-            MapFunction { input, .. } => *input,
-            Sink { input, .. } => *input,
-            ExtContext {
-                input, contexts, ..
-            } => {
-                container.extend(contexts.iter().cloned());
-                *input
-            },
-            Scan { .. } => return,
-            DataFrameScan { .. } => return,
-            #[cfg(feature = "python")]
-            PythonScan { .. } => return,
-            #[cfg(feature = "merge_sorted")]
-            MergeSorted {
-                input_left,
-                input_right,
-                ..
-            } => {
-                container.extend([*input_left, *input_right]);
-                return;
-            },
-            Invalid => unreachable!(),
-        };
-        container.extend([input])
+        container.extend(self.inputs())
     }
 
     pub fn get_inputs(&self) -> UnitVec<Node> {
-        let mut inputs: UnitVec<Node> = unitvec!();
-        self.copy_inputs(&mut inputs);
-        inputs
-    }
-
-    pub fn get_inputs_vec(&self) -> Vec<Node> {
-        let mut inputs = vec![];
-        self.copy_inputs(&mut inputs);
-        inputs
+        self.inputs().collect()
     }
 
     pub(crate) fn get_input(&self) -> Option<Node> {
-        let mut inputs: UnitVec<Node> = unitvec!();
-        self.copy_inputs(&mut inputs);
-        inputs.first().copied()
+        self.inputs().next()
+    }
+}
+
+pub enum Inputs<'a> {
+    Empty,
+    Single(iter::Once<Node>),
+    Double(std::array::IntoIter<Node, 2>),
+    Slice(iter::Copied<std::slice::Iter<'a, Node>>),
+    Boxed(Box<dyn Iterator<Item = Node> + 'a>),
+}
+
+impl<'a> Inputs<'a> {
+    fn single(node: Node) -> Self {
+        Self::Single(iter::once(node))
+    }
+
+    fn double(left: Node, right: Node) -> Self {
+        Self::Double([left, right].into_iter())
+    }
+
+    fn slice(inputs: &'a [Node]) -> Self {
+        Self::Slice(inputs.iter().copied())
+    }
+}
+
+impl<'a> Iterator for Inputs<'a> {
+    type Item = Node;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Empty => None,
+            Self::Single(it) => it.next(),
+            Self::Double(it) => it.next(),
+            Self::Slice(it) => it.next(),
+            Self::Boxed(it) => it.next(),
+        }
+    }
+}
+
+pub enum InputsMut<'a> {
+    Empty,
+    Single(iter::Once<&'a mut Node>),
+    Double(std::array::IntoIter<&'a mut Node, 2>),
+    Slice(std::slice::IterMut<'a, Node>),
+    Boxed(Box<dyn Iterator<Item = &'a mut Node> + 'a>),
+}
+
+impl<'a> InputsMut<'a> {
+    fn single(node: &'a mut Node) -> Self {
+        Self::Single(iter::once(node))
+    }
+
+    fn double(left: &'a mut Node, right: &'a mut Node) -> Self {
+        Self::Double([left, right].into_iter())
+    }
+
+    fn slice(inputs: &'a mut [Node]) -> Self {
+        Self::Slice(inputs.iter_mut())
+    }
+}
+
+impl<'a> Iterator for InputsMut<'a> {
+    type Item = &'a mut Node;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Empty => None,
+            Self::Single(it) => it.next(),
+            Self::Double(it) => it.next(),
+            Self::Slice(it) => it.next(),
+            Self::Boxed(it) => it.next(),
+        }
+    }
+}
+
+pub enum Exprs<'a> {
+    Empty,
+    Single(iter::Once<&'a ExprIR>),
+    Slice(std::slice::Iter<'a, ExprIR>),
+    DoubleSlice(iter::Chain<std::slice::Iter<'a, ExprIR>, std::slice::Iter<'a, ExprIR>>),
+    Boxed(Box<dyn Iterator<Item = &'a ExprIR> + 'a>),
+}
+
+impl<'a> Exprs<'a> {
+    fn single(expr: &'a ExprIR) -> Self {
+        Self::Single(iter::once(expr))
+    }
+
+    fn slice(inputs: &'a [ExprIR]) -> Self {
+        Self::Slice(inputs.iter())
+    }
+
+    fn double_slice(left: &'a [ExprIR], right: &'a [ExprIR]) -> Self {
+        Self::DoubleSlice(left.iter().chain(right.iter()))
+    }
+}
+
+impl<'a> Iterator for Exprs<'a> {
+    type Item = &'a ExprIR;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Empty => None,
+            Self::Single(it) => it.next(),
+            Self::Slice(it) => it.next(),
+            Self::DoubleSlice(it) => it.next(),
+            Self::Boxed(it) => it.next(),
+        }
+    }
+}
+
+pub enum ExprsMut<'a> {
+    Empty,
+    Single(iter::Once<&'a mut ExprIR>),
+    Slice(std::slice::IterMut<'a, ExprIR>),
+    DoubleSlice(iter::Chain<std::slice::IterMut<'a, ExprIR>, std::slice::IterMut<'a, ExprIR>>),
+    Boxed(Box<dyn Iterator<Item = &'a mut ExprIR> + 'a>),
+}
+
+impl<'a> ExprsMut<'a> {
+    fn single(expr: &'a mut ExprIR) -> Self {
+        Self::Single(iter::once(expr))
+    }
+
+    fn slice(inputs: &'a mut [ExprIR]) -> Self {
+        Self::Slice(inputs.iter_mut())
+    }
+
+    fn double_slice(left: &'a mut [ExprIR], right: &'a mut [ExprIR]) -> Self {
+        Self::DoubleSlice(left.iter_mut().chain(right.iter_mut()))
+    }
+}
+
+impl<'a> Iterator for ExprsMut<'a> {
+    type Item = &'a mut ExprIR;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Empty => None,
+            Self::Single(it) => it.next(),
+            Self::Slice(it) => it.next(),
+            Self::DoubleSlice(it) => it.next(),
+            Self::Boxed(it) => it.next(),
+        }
     }
 }

--- a/crates/polars-plan/src/plans/ir/mod.rs
+++ b/crates/polars-plan/src/plans/ir/mod.rs
@@ -12,7 +12,6 @@ pub use format::{ExprIRDisplay, IRDisplay, write_group_by, write_ir_non_recursiv
 use polars_core::prelude::*;
 use polars_utils::idx_vec::UnitVec;
 use polars_utils::unique_id::UniqueId;
-use polars_utils::unitvec;
 #[cfg(feature = "ir_serde")]
 use serde::{Deserialize, Serialize};
 use strum_macros::IntoStaticStr;

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -5,6 +5,7 @@ mod utils;
 
 use polars_core::datatypes::PlHashMap;
 use polars_core::prelude::*;
+use polars_utils::idx_vec::UnitVec;
 use recursive::recursive;
 use utils::*;
 
@@ -106,20 +107,21 @@ impl PredicatePushDown<'_> {
         expr_arena: &mut Arena<AExpr>,
         has_projections: bool,
     ) -> PolarsResult<IR> {
-        let inputs = lp.get_inputs_vec();
-        let exprs = lp.get_exprs();
-
         if has_projections {
-            // projections should only have a single input.
-            if inputs.len() > 1 {
-                // except for ExtContext
-                assert!(matches!(lp, IR::ExtContext { .. }));
-            }
-            let input = inputs[inputs.len() - 1];
+            let input = {
+                let mut inputs = lp.inputs();
+                let input = inputs.next().unwrap();
+                // projections should only have a single input.
+                if inputs.next().is_some() {
+                    // except for ExtContext
+                    assert!(matches!(lp, IR::ExtContext { .. }));
+                }
+                input
+            };
 
             let maintain_errors = self.maintain_errors;
             let (eligibility, alias_rename_map) = pushdown_eligibility(
-                &exprs,
+                &lp.exprs().cloned().collect::<Vec<_>>(),
                 &[],
                 &acc_predicates,
                 expr_arena,
@@ -152,15 +154,16 @@ impl PredicatePushDown<'_> {
             let alp = self.push_down(alp, acc_predicates, lp_arena, expr_arena)?;
             lp_arena.replace(input, alp);
 
-            let lp = lp.with_exprs_and_input(exprs, inputs);
             Ok(self.optional_apply_predicate(lp, local_predicates, lp_arena, expr_arena))
         } else {
             let mut local_predicates = Vec::with_capacity(acc_predicates.len());
 
+            let inputs = lp.get_inputs();
+
             // determine new inputs by pushing down predicates
             let new_inputs = inputs
-                .iter()
-                .map(|&node| {
+                .into_iter()
+                .map(|node| {
                     // first we check if we are able to push down the predicate passed this node
                     // it could be that this node just added the column where we base the predicate on
                     let input_schema = lp_arena.get(node).schema(lp_arena);
@@ -186,9 +189,9 @@ impl PredicatePushDown<'_> {
                     lp_arena.replace(node, alp);
                     Ok(node)
                 })
-                .collect::<PolarsResult<Vec<_>>>()?;
+                .collect::<PolarsResult<UnitVec<_>>>()?;
 
-            let lp = lp.with_exprs_and_input(exprs, new_inputs);
+            let lp = lp.with_inputs(new_inputs);
             Ok(self.optional_apply_predicate(lp, local_predicates, lp_arena, expr_arena))
         }
     }
@@ -201,12 +204,10 @@ impl PredicatePushDown<'_> {
         lp_arena: &mut Arena<IR>,
         expr_arena: &mut Arena<AExpr>,
     ) -> PolarsResult<IR> {
-        let inputs = lp.get_inputs();
-        let exprs = lp.get_exprs();
+        let inputs = lp.inputs();
 
         let new_inputs = inputs
-            .iter()
-            .map(|&node| {
+            .map(|node| {
                 let alp = lp_arena.take(node);
                 let alp = self.push_down(
                     alp,
@@ -218,7 +219,7 @@ impl PredicatePushDown<'_> {
                 Ok(node)
             })
             .collect::<PolarsResult<Vec<_>>>()?;
-        let lp = lp.with_exprs_and_input(exprs, new_inputs);
+        let lp = lp.with_inputs(new_inputs);
 
         // all predicates are done locally
         let local_predicates = acc_predicates.into_values().collect::<Vec<_>>();

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/generic.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/generic.rs
@@ -1,3 +1,5 @@
+use polars_utils::idx_vec::UnitVec;
+
 use super::*;
 
 #[allow(clippy::too_many_arguments)]
@@ -9,14 +11,14 @@ pub(super) fn process_generic(
     expr_arena: &mut Arena<AExpr>,
 ) -> PolarsResult<IR> {
     let inputs = lp.get_inputs();
-    let exprs = lp.get_exprs();
+    let input_count = inputs.len();
 
     // let mut first_schema = None;
     // let mut names = None;
 
     let new_inputs = inputs
-        .iter()
-        .map(|&node| {
+        .into_iter()
+        .map(|node| {
             let alp = lp_arena.take(node);
             let mut alp = proj_pd.push_down(alp, ctx.clone(), lp_arena, expr_arena)?;
 
@@ -35,7 +37,7 @@ pub(super) fn process_generic(
             // df3 => a, b
             // df1 => a
             // so we ensure we do the 'a' projection again before we concatenate
-            if !ctx.acc_projections.is_empty() && inputs.len() > 1 {
+            if !ctx.acc_projections.is_empty() && input_count > 1 {
                 alp = IRBuilder::from_lp(alp, expr_arena, lp_arena)
                     .project_simple_nodes(ctx.acc_projections.iter().map(|e| e.0))
                     .unwrap()
@@ -44,7 +46,7 @@ pub(super) fn process_generic(
             lp_arena.replace(node, alp);
             Ok(node)
         })
-        .collect::<PolarsResult<Vec<_>>>()?;
+        .collect::<PolarsResult<UnitVec<_>>>()?;
 
-    Ok(lp.with_exprs_and_input(exprs, new_inputs))
+    Ok(lp.with_inputs(new_inputs))
 }

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -148,11 +148,10 @@ impl SlicePushDown {
         expr_arena: &mut Arena<AExpr>,
     ) -> PolarsResult<IR> {
         let inputs = lp.get_inputs();
-        let exprs = lp.get_exprs();
 
         let new_inputs = inputs
-            .iter()
-            .map(|&node| {
+            .into_iter()
+            .map(|node| {
                 let alp = lp_arena.take(node);
                 // No state, so we do not push down the slice here.
                 let state = None;
@@ -160,8 +159,8 @@ impl SlicePushDown {
                 lp_arena.replace(node, alp);
                 Ok(node)
             })
-            .collect::<PolarsResult<Vec<_>>>()?;
-        let lp = lp.with_exprs_and_input(exprs, new_inputs);
+            .collect::<PolarsResult<UnitVec<_>>>()?;
+        let lp = lp.with_inputs(new_inputs);
 
         self.no_pushdown_finish_opt(lp, state, lp_arena)
     }
@@ -175,18 +174,17 @@ impl SlicePushDown {
         expr_arena: &mut Arena<AExpr>,
     ) -> PolarsResult<IR> {
         let inputs = lp.get_inputs();
-        let exprs = lp.get_exprs();
 
         let new_inputs = inputs
-            .iter()
-            .map(|&node| {
+            .into_iter()
+            .map(|node| {
                 let alp = lp_arena.take(node);
                 let alp = self.pushdown(alp, state, lp_arena, expr_arena)?;
                 lp_arena.replace(node, alp);
                 Ok(node)
             })
-            .collect::<PolarsResult<Vec<_>>>()?;
-        Ok(lp.with_exprs_and_input(exprs, new_inputs))
+            .collect::<PolarsResult<UnitVec<_>>>()?;
+        Ok(lp.with_inputs(new_inputs))
     }
 
     #[recursive]

--- a/crates/polars-plan/src/plans/visitor/lp.rs
+++ b/crates/polars-plan/src/plans/visitor/lp.rs
@@ -83,11 +83,9 @@ impl TreeWalker for IRNode {
         arena: &mut Self::Arena,
     ) -> PolarsResult<Self> {
         let mut inputs = vec![];
-        let mut exprs = vec![];
 
         let lp = arena.0.get(self.node);
         lp.copy_inputs(&mut inputs);
-        lp.copy_exprs(&mut exprs);
 
         // rewrite the nodes
         for node in &mut inputs {
@@ -96,7 +94,7 @@ impl TreeWalker for IRNode {
             *node = op(lp_node, arena)?.node;
         }
         let lp = arena.0.get(self.node);
-        let lp = lp.with_exprs_and_input(exprs, inputs);
+        let lp = lp.clone().with_inputs(inputs);
         if self.mutate {
             arena.0.replace(self.node, lp);
             Ok(self)


### PR DESCRIPTION
The goal of this PR is to make traversing and replacing inputs and exprs of `IR` more maintainable and to avoid unnecessary allocations while doing so. For example, the iterator-based approach allows pruning to replace the inputs and exprs of IR nodes without allocating any intermediate `Vec`s.

In particular:
- updates `UnitVec` to make sure `FromIterator` only allocates on heap when there are multiple elements
- implements `IntoIterator` for `UnitVec`
- replaces `IR::with_exprs_and_input()` with `IR::with_exprs()` and `IR::with_inputs()`
- adds `IR::exprs()`, `IR::exprs_mut()`, `IR::inputs()`, `IR::inputs_mut()` iterators that should be easier to maintain and avoid allocating Vecs and cloning `ExprIRs`
- updates `IR::with_exprs_and_input()` call sites to use `IR::with_inputs()` (only pruning uses `IR::with_exprs()`), removes unnecessary IR cloning, and when necessary collects inputs to a `UnitVec` instead of a `Vec` to avoid heap allocations, since most nodes have only one input
