### PR TITLE
fix: Make type annotation of `cast()` accept `dict[str, pl.DataType]`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -8442,6 +8442,7 @@ class DataFrame:
             Mapping[
                 ColumnNameOrSelector | PolarsDataType, PolarsDataType | PythonDataType
             ]
+            | Mapping[str, PolarsDataType | PythonDataType]
             | PolarsDataType
         ),
         *,

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3560,6 +3560,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Mapping[
                 ColumnNameOrSelector | PolarsDataType, PolarsDataType | PythonDataType
             ]
+            | Mapping[str, PolarsDataType | PythonDataType]
             | PolarsDataType
             | pl.DataTypeExpr
         ),

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -683,7 +683,10 @@ def test_read_enum_from_csv() -> None:
     df.write_csv(f)
     f.seek(0)
 
-    schema = {"foo": pl.Enum(["ham", "and", "such", "spam"]), "bar": pl.String()}
+    schema: dict[str, pl.DataType] = {
+        "foo": pl.Enum(["ham", "and", "such", "spam"]),
+        "bar": pl.String(),
+    }
     read = pl.read_csv(f, schema=schema)
     assert read.schema == schema
-    assert_frame_equal(df.cast(schema), read)  # type: ignore[arg-type]
+    assert_frame_equal(df.cast(schema), read)


### PR DESCRIPTION
At runtime, this was already accepted, but the type annotations didn't reflect that.

The issue is that

```python
            Mapping[
                ColumnNameOrSelector | PolarsDataType, PolarsDataType | PythonDataType
            ]
```

isn't compatible with

```python
            Mapping[
                str, PolarsDataType | PythonDataType
            ]
```
even though `ColumnNameOrSelector` is a union which contains `str`. The reason it isn't compatible is that if you have a key of type `Selector` then you cannot use it with `Mapping[str, PolarsDataType | PythonDataType]`.

There was an instance in the tests where a `type: ignore` was needed because of this, which I removed in this PR.