### PR TITLE
refactor(rust): Remove Default for StreamingExecutionState

### DIFF
--- a/crates/polars-expr/src/state/execution_state.rs
+++ b/crates/polars-expr/src/state/execution_state.rs
@@ -102,10 +102,11 @@ impl From<u8> for StateFlags {
 type CachedValue = Arc<(AtomicI64, OnceLock<DataFrame>)>;
 
 /// State/ cache that is maintained during the Execution of the physical plan.
+#[derive(Clone)]
 pub struct ExecutionState {
     // cached by a `.cache` call and kept in memory for the duration of the plan.
     df_cache: Arc<RwLock<PlHashMap<UniqueId, CachedValue>>>,
-    pub schema_cache: RwLock<Option<SchemaRef>>,
+    pub schema_cache: Arc<RwLock<Option<SchemaRef>>>,
     /// Used by Window Expressions to cache intermediate state
     pub window_cache: Arc<WindowCache>,
     // every join/union split gets an increment to distinguish between schema state
@@ -293,21 +294,5 @@ impl ExecutionState {
 impl Default for ExecutionState {
     fn default() -> Self {
         ExecutionState::new()
-    }
-}
-
-impl Clone for ExecutionState {
-    /// clones, but clears no state.
-    fn clone(&self) -> Self {
-        Self {
-            df_cache: self.df_cache.clone(),
-            schema_cache: self.schema_cache.read().unwrap().clone().into(),
-            window_cache: self.window_cache.clone(),
-            branch_idx: self.branch_idx,
-            flags: self.flags.clone(),
-            ext_contexts: self.ext_contexts.clone(),
-            node_timer: self.node_timer.clone(),
-            stop: self.stop.clone(),
-        }
     }
 }

--- a/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
+++ b/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
@@ -186,18 +186,14 @@ impl OptimizationRule for ExpandDatasets {
                             (ir, None)
                         },
 
-                        DslPlan::PythonScan { options } => {
-                            assert!(options.scan_fn.is_some());
-
-                            (
-                                ir.clone(),
-                                Some((
-                                    dataset_object.name(),
-                                    options.scan_fn.expect("scan_fn is required"),
-                                    options.python_source,
-                                )),
-                            )
-                        },
+                        DslPlan::PythonScan { options } => (
+                            ir.clone(),
+                            Some(ExpandedPythonScan {
+                                name: dataset_object.name(),
+                                scan_fn: options.scan_fn.unwrap(),
+                                variant: options.python_source,
+                            }),
+                        ),
 
                         dsl => {
                             polars_bail!(
@@ -237,13 +233,21 @@ pub struct ExpandedDataset {
 
     /// Fallback python scan
     #[cfg(feature = "python")]
-    python_scan: Option<(PlSmallStr, PythonObject, PythonScanSource)>,
+    python_scan: Option<ExpandedPythonScan>,
+}
+
+#[cfg(feature = "python")]
+#[derive(Clone)]
+pub struct ExpandedPythonScan {
+    pub name: PlSmallStr,
+    pub scan_fn: PythonObject,
+    pub variant: PythonScanSource,
 }
 
 impl ExpandedDataset {
     #[cfg(feature = "python")]
-    pub fn python_scan(&self) -> Option<(&PlSmallStr, &PythonObject, &PythonScanSource)> {
-        self.python_scan.as_ref().map(|(a, b, c)| (a, b, c))
+    pub fn python_scan(&self) -> Option<&ExpandedPythonScan> {
+        self.python_scan.as_ref()
     }
 }
 
@@ -264,9 +268,15 @@ impl Debug for ExpandedDataset {
             resolved_ir,
 
             #[cfg(feature = "python")]
-            python_scan: python_scan.as_ref().map(|(name, _, scan_type)| {
-                format_pl_smallstr!("python-scan[{} @ {:?}]", name, scan_type)
-            }),
+            python_scan: python_scan.as_ref().map(
+                |ExpandedPythonScan {
+                     name,
+                     scan_fn: _,
+                     variant,
+                 }| {
+                    format_pl_smallstr!("python-scan[{} @ {:?}]", name, variant)
+                },
+            ),
         }
         .fmt(f);
 

--- a/crates/polars-plan/src/plans/optimizer/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/mod.rs
@@ -18,6 +18,8 @@ mod fused;
 mod join_utils;
 pub(crate) use join_utils::ExprOrigin;
 mod expand_datasets;
+#[cfg(feature = "python")]
+pub use expand_datasets::ExpandedPythonScan;
 mod predicate_pushdown;
 mod projection_pushdown;
 mod set_order;

--- a/crates/polars-stream/src/execute.rs
+++ b/crates/polars-stream/src/execute.rs
@@ -21,15 +21,6 @@ pub struct StreamingExecutionState {
     pub in_memory_exec_state: ExecutionState,
 }
 
-impl Default for StreamingExecutionState {
-    fn default() -> Self {
-        Self {
-            num_pipelines: POOL.current_num_threads(),
-            in_memory_exec_state: ExecutionState::default(),
-        }
-    }
-}
-
 /// Finds all runnable pipeline blockers in the graph, that is, nodes which:
 ///  - Only have blocked output ports.
 ///  - Have at least one ready input port connected to a ready output port.

--- a/crates/polars-stream/src/nodes/io_sources/batch.rs
+++ b/crates/polars-stream/src/nodes/io_sources/batch.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use polars_core::frame::DataFrame;
 use polars_core::schema::SchemaRef;
 use polars_error::{PolarsResult, polars_err};
+use polars_io::pl_async::get_runtime;
 use polars_utils::IdxSize;
 use polars_utils::pl_str::PlSmallStr;
 
@@ -18,12 +19,12 @@ use crate::nodes::io_sources::multi_file_reader::reader_interface::{
 };
 
 pub mod builder {
-
     use std::sync::{Arc, Mutex};
 
     use polars_utils::pl_str::PlSmallStr;
 
     use super::BatchFnReader;
+    use crate::execute::StreamingExecutionState;
     use crate::nodes::io_sources::multi_file_reader::reader_interface::FileReader;
     use crate::nodes::io_sources::multi_file_reader::reader_interface::builder::FileReaderBuilder;
     use crate::nodes::io_sources::multi_file_reader::reader_interface::capabilities::ReaderCapabilities;
@@ -31,6 +32,7 @@ pub mod builder {
     pub struct BatchFnReaderBuilder {
         pub name: PlSmallStr,
         pub reader: Mutex<Option<BatchFnReader>>,
+        pub execution_state: Mutex<Option<StreamingExecutionState>>,
     }
 
     impl FileReaderBuilder for BatchFnReaderBuilder {
@@ -42,6 +44,10 @@ pub mod builder {
             ReaderCapabilities::empty()
         }
 
+        fn set_execution_state(&self, execution_state: &StreamingExecutionState) {
+            *self.execution_state.lock().unwrap() = Some(execution_state.clone());
+        }
+
         fn build_file_reader(
             &self,
             _source: polars_plan::prelude::ScanSource,
@@ -50,13 +56,16 @@ pub mod builder {
         ) -> Box<dyn FileReader> {
             assert_eq!(scan_source_idx, 0);
 
-            Box::new(
-                self.reader
-                    .try_lock()
-                    .unwrap()
-                    .take()
-                    .expect("BatchFnReaderBuilder called more than once"),
-            ) as Box<dyn FileReader>
+            let mut reader = self
+                .reader
+                .try_lock()
+                .unwrap()
+                .take()
+                .expect("BatchFnReaderBuilder called more than once");
+
+            reader.execution_state = Some(self.execution_state.lock().unwrap().clone().unwrap());
+
+            Box::new(reader) as Box<dyn FileReader>
         }
     }
 
@@ -107,6 +116,7 @@ pub struct BatchFnReader {
     pub name: PlSmallStr,
     pub output_schema: Option<SchemaRef>,
     pub get_batch_state: Option<GetBatchState>,
+    pub execution_state: Option<StreamingExecutionState>,
     pub verbose: bool,
 }
 
@@ -138,9 +148,11 @@ impl FileReader for BatchFnReader {
             panic!("unsupported args: {:?}", &args)
         };
 
+        let execution_state = self.execution_state().clone();
+
         // Must send this first before we `take()` the GetBatchState.
         if let Some(mut file_schema_tx) = file_schema_tx {
-            _ = file_schema_tx.try_send(self._file_schema()?);
+            _ = file_schema_tx.try_send(self._file_schema(&execution_state)?);
         }
 
         let mut get_batch_state = self
@@ -148,9 +160,6 @@ impl FileReader for BatchFnReader {
             .take()
             // If this is ever needed we can buffer
             .expect("unimplemented: BatchFnReader called more than once");
-
-        // FIXME: Propagate this from BeginReadArgs.
-        let exec_state = StreamingExecutionState::default();
 
         let verbose = self.verbose;
 
@@ -167,7 +176,26 @@ impl FileReader for BatchFnReader {
 
             let mut n_rows_seen: usize = 0;
 
-            while let Some(df) = get_batch_state.next(&exec_state)? {
+            loop {
+                let (_get_batch_state, opt_df) = get_runtime()
+                    .spawn_blocking({
+                        let execution_state = execution_state.clone();
+
+                        move || {
+                            get_batch_state
+                                .next(&execution_state)
+                                .map(|x| (get_batch_state, x))
+                        }
+                    })
+                    .await
+                    .unwrap()?;
+
+                get_batch_state = _get_batch_state;
+
+                let Some(df) = opt_df else {
+                    break;
+                };
+
                 n_rows_seen = n_rows_seen.saturating_add(df.height());
 
                 if morsel_sender
@@ -192,7 +220,7 @@ impl FileReader for BatchFnReader {
                     eprintln!("[BatchFnReader]: read to end for full row count");
                 }
 
-                while let Some(df) = get_batch_state.next(&exec_state)? {
+                while let Some(df) = get_batch_state.next(&execution_state)? {
                     n_rows_seen = n_rows_seen.saturating_add(df.height());
                 }
 
@@ -210,16 +238,27 @@ impl FileReader for BatchFnReader {
 }
 
 impl BatchFnReader {
-    pub fn _file_schema(&mut self) -> PolarsResult<SchemaRef> {
-        if self.output_schema.is_none() {
-            let exec_state = StreamingExecutionState::default();
+    /// # Panics
+    /// Panics if `self.execution_state` is `None`.
+    fn execution_state(&self) -> &StreamingExecutionState {
+        self.execution_state.as_ref().unwrap()
+    }
 
-            let schema =
-                if let Some(df) = self.get_batch_state.as_mut().unwrap().peek(&exec_state)? {
-                    df.schema().clone()
-                } else {
-                    SchemaRef::default()
-                };
+    fn _file_schema(
+        &mut self,
+        execution_state: &StreamingExecutionState,
+    ) -> PolarsResult<SchemaRef> {
+        if self.output_schema.is_none() {
+            let schema = if let Some(df) = self
+                .get_batch_state
+                .as_mut()
+                .unwrap()
+                .peek(execution_state)?
+            {
+                df.schema().clone()
+            } else {
+                SchemaRef::default()
+            };
 
             self.output_schema = Some(schema);
         }

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/builder.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/builder.rs
@@ -8,11 +8,15 @@ use polars_plan::dsl::ScanSource;
 
 use super::FileReader;
 use super::capabilities::ReaderCapabilities;
+use crate::execute::StreamingExecutionState;
 
 pub trait FileReaderBuilder: Debug + Send + Sync + 'static {
     fn reader_name(&self) -> &str;
 
     fn reader_capabilities(&self) -> ReaderCapabilities;
+
+    /// Used by readers that need access to `StreamingExecutionState`.
+    fn set_execution_state(&self, _execution_state: &StreamingExecutionState) {}
 
     fn build_file_reader(
         &self,

--- a/crates/polars-stream/src/physical_plan/io/python_dataset.rs
+++ b/crates/polars-stream/src/physical_plan/io/python_dataset.rs
@@ -1,10 +1,8 @@
 use std::sync::{Arc, Mutex};
 
 use polars_core::config;
-use polars_plan::dsl::python_dsl::PythonScanSource;
-use polars_plan::plans::python_df_to_rust;
+use polars_plan::plans::{ExpandedPythonScan, python_df_to_rust};
 use polars_utils::format_pl_smallstr;
-use polars_utils::python_function::PythonObject;
 
 use crate::execute::StreamingExecutionState;
 use crate::nodes::io_sources::batch::GetBatchFn;
@@ -12,21 +10,19 @@ use crate::nodes::io_sources::multi_file_reader::reader_interface::builder::File
 
 /// Note: Currently used for iceberg fallback.
 pub fn python_dataset_scan_to_reader_builder(
-    reader_name: &str,
-    scan_fn: PythonObject,
-    python_source_type: &PythonScanSource,
+    expanded_scan: &ExpandedPythonScan,
 ) -> Arc<dyn FileReaderBuilder> {
     use polars_plan::dsl::python_dsl::PythonScanSource as S;
     use pyo3::prelude::*;
 
-    let (name, get_batch_fn) = match python_source_type {
+    let (name, get_batch_fn) = match &expanded_scan.variant {
         S::Pyarrow => {
             // * Pyarrow is a oneshot function call.
             // * Arc / Mutex because because closure cannot be FnOnce
-            let python_scan_function = Arc::new(Mutex::new(Some(scan_fn)));
+            let python_scan_function = Arc::new(Mutex::new(Some(expanded_scan.scan_fn.clone())));
 
             (
-                format_pl_smallstr!("python[{} @ pyarrow]", reader_name),
+                format_pl_smallstr!("python[{} @ pyarrow]", &expanded_scan.name),
                 Box::new(move |_state: &StreamingExecutionState| {
                     Python::with_gil(|py| {
                         let Some(python_scan_function) =
@@ -56,11 +52,13 @@ pub fn python_dataset_scan_to_reader_builder(
         name: name.clone(),
         output_schema: None,
         get_batch_state: Some(GetBatchState::from(get_batch_fn)),
+        execution_state: None,
         verbose: config::verbose(),
     };
 
     Arc::new(BatchFnReaderBuilder {
         name: name.clone(),
         reader: std::sync::Mutex::new(Some(reader)),
+        execution_state: Default::default(),
     }) as Arc<dyn FileReaderBuilder>
 }

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -541,17 +541,13 @@ pub fn lower_ir(
                         use crate::physical_plan::io::python_dataset::python_dataset_scan_to_reader_builder;
                         let guard = cached_ir.lock().unwrap();
 
-                        let (scan_name, scan_fn, python_source_type) = guard
+                        let expanded_scan = guard
                             .as_ref()
                             .expect("python dataset should be resolved")
                             .python_scan()
                             .expect("should be python scan");
 
-                        python_dataset_scan_to_reader_builder(
-                            scan_name,
-                            scan_fn.clone(),
-                            python_source_type,
-                        )
+                        python_dataset_scan_to_reader_builder(expanded_scan)
                     },
 
                     FileScanIR::Anonymous { .. } => todo!("unimplemented: AnonymousScan"),

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -996,22 +996,21 @@ fn to_graph_rec<'a>(
             use crate::nodes::io_sources::batch::{BatchFnReader, GetBatchState};
             use crate::nodes::io_sources::multi_file_reader::initialization::projection::ProjectionBuilder;
 
-            let mut reader = BatchFnReader {
+            let reader = BatchFnReader {
                 name: name.clone(),
                 // If validate_schema is false, the schema of the morsels may not match the
                 // configured schema. In this case we set this to `None` and the reader will
                 // retrieve the schema from the first morsel.
                 output_schema: validate_schema.then(|| output_schema.clone()),
                 get_batch_state: Some(GetBatchState::from(get_batch_fn)),
+                execution_state: None,
                 verbose: config::verbose(),
             };
-
-            // Note: This will potentially override the output schema if `validate_schema` is `false`.
-            let output_schema = reader._file_schema()?;
 
             let file_reader_builder = Arc::new(BatchFnReaderBuilder {
                 name,
                 reader: std::sync::Mutex::new(Some(reader)),
+                execution_state: Default::default(),
             }) as Arc<dyn FileReaderBuilder>;
 
             // Give multiscan a single scan source. (It doesn't actually read from this).

--- a/py-polars/tests/unit/io/test_io_plugin.py
+++ b/py-polars/tests/unit/io/test_io_plugin.py
@@ -236,12 +236,11 @@ def test_reordered_columns_22731(validate: bool) -> None:
 
 
 def test_io_plugin_reentrant_deadlock() -> None:
-    try:
-        out = subprocess.check_output(
-            [
-                sys.executable,
-                "-c",
-                """\
+    out = subprocess.check_output(
+        [
+            sys.executable,
+            "-c",
+            """\
 from __future__ import annotations
 
 import os
@@ -279,13 +278,9 @@ register_io_source(io_source=reentrant, schema={"x": pl.Int64}).collect()
 
 print("OK", end="", file=sys.stderr)
 """,
-            ],
-            stderr=subprocess.STDOUT,
-            timeout=7,
-        )
-    except subprocess.CalledProcessError as e:
-        print((e.stdout or b"").decode())
-        print((e.stderr or b"").decode())
-        raise
+        ],
+        stderr=subprocess.STDOUT,
+        timeout=7,
+    )
 
     assert out == b"OK"

--- a/py-polars/tests/unit/io/test_io_plugin.py
+++ b/py-polars/tests/unit/io/test_io_plugin.py
@@ -236,12 +236,11 @@ def test_reordered_columns_22731(validate: bool) -> None:
 
 
 def test_io_plugin_reentrant_deadlock() -> None:
-    try:
-        out = subprocess.check_output(
-            [
-                sys.executable,
-                "-c",
-                """\
+    out = subprocess.check_output(
+        [
+            sys.executable,
+            "-c",
+            """\
 from __future__ import annotations
 
 import os
@@ -259,31 +258,28 @@ i = 0
 
 
 def reentrant(
-    with_columns: list[str] | None,
-    predicate: pl.Expr | None,
-    n_rows: int | None,
-    batch_size: int | None,
+with_columns: list[str] | None,
+predicate: pl.Expr | None,
+n_rows: int | None,
+batch_size: int | None,
 ):
-    global i
+global i
 
-    df = pl.DataFrame({"x": 1})
+df = pl.DataFrame({"x": 1})
 
-    if i < n:
-        i += 1
-        yield register_io_source(io_source=reentrant, schema={"x": pl.Int64}).collect()
+if i < n:
+    i += 1
+    yield register_io_source(io_source=reentrant, schema={"x": pl.Int64}).collect()
 
-    yield df
+yield df
 
 
 register_io_source(io_source=reentrant, schema={"x": pl.Int64}).collect()
 print("OK", end="", file=sys.stderr)
 """,
-            ],
-            stderr=subprocess.STDOUT,
-            timeout=7,
-        )
-    except subprocess.CalledProcessError as e:
-        print(e.stdout.decode())
-        raise
+        ],
+        stderr=subprocess.STDOUT,
+        timeout=7,
+    )
 
     assert out == b"OK"

--- a/py-polars/tests/unit/io/test_io_plugin.py
+++ b/py-polars/tests/unit/io/test_io_plugin.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import datetime
 import io
+import subprocess
+import sys
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -43,13 +45,7 @@ def test_io_plugin_predicate_no_serialization_21130() -> None:
     ).collect().to_dict(as_series=False) == {"json_val": ['{"a":"1"}']}
 
 
-def test_defer() -> None:
-    lf = pl.defer(
-        lambda: pl.DataFrame({"a": np.ones(3)}),
-        schema={"a": pl.Boolean},
-        validate_schema=False,
-    )
-    assert lf.collect().to_dict(as_series=False) == {"a": [1.0, 1.0, 1.0]}
+def test_defer_validate_true() -> None:
     lf = pl.defer(
         lambda: pl.DataFrame({"a": np.ones(3)}),
         schema={"a": pl.Boolean},
@@ -57,6 +53,16 @@ def test_defer() -> None:
     )
     with pytest.raises(pl.exceptions.SchemaError):
         lf.collect()
+
+
+@pytest.mark.may_fail_auto_streaming  # IO plugin validate=False schema mismatch
+def test_defer_validate_false() -> None:
+    lf = pl.defer(
+        lambda: pl.DataFrame({"a": np.ones(3)}),
+        schema={"a": pl.Boolean},
+        validate_schema=False,
+    )
+    assert lf.collect().to_dict(as_series=False) == {"a": [1.0, 1.0, 1.0]}
 
 
 def test_empty_iterator_io_plugin() -> None:
@@ -130,6 +136,7 @@ This allows it to read into multiple rows.
     )
 
 
+@pytest.mark.may_fail_auto_streaming  # IO plugin validate=False schema mismatch
 def test_datetime_io_predicate_pushdown_21790() -> None:
     recorded: dict[str, pl.Expr | None] = {"predicate": None}
     df = pl.DataFrame(
@@ -226,3 +233,57 @@ def test_reordered_columns_22731(validate: bool) -> None:
     assert_frame_equal(
         my_scan().with_columns("b", "a").collect(), expected_with_columns
     )
+
+
+def test_io_plugin_reentrant_deadlock() -> None:
+    try:
+        out = subprocess.check_output(
+            [
+                sys.executable,
+                "-c",
+                """\
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ["POLARS_MAX_THREADS"] = "1"
+
+import polars as pl
+from polars.io.plugins import register_io_source
+
+assert pl.thread_pool_size() == 1
+
+n = 3
+i = 0
+
+
+def reentrant(
+    with_columns: list[str] | None,
+    predicate: pl.Expr | None,
+    n_rows: int | None,
+    batch_size: int | None,
+):
+    global i
+
+    df = pl.DataFrame({"x": 1})
+
+    if i < n:
+        i += 1
+        yield register_io_source(io_source=reentrant, schema={"x": pl.Int64}).collect()
+
+    yield df
+
+
+register_io_source(io_source=reentrant, schema={"x": pl.Int64}).collect()
+print("OK", end="", file=sys.stderr)
+""",
+            ],
+            stderr=subprocess.STDOUT,
+            timeout=7,
+        )
+    except subprocess.CalledProcessError as e:
+        print(e.stdout.decode())
+        raise
+
+    assert out == b"OK"

--- a/py-polars/tests/unit/io/test_io_plugin.py
+++ b/py-polars/tests/unit/io/test_io_plugin.py
@@ -236,11 +236,12 @@ def test_reordered_columns_22731(validate: bool) -> None:
 
 
 def test_io_plugin_reentrant_deadlock() -> None:
-    out = subprocess.check_output(
-        [
-            sys.executable,
-            "-c",
-            """\
+    try:
+        out = subprocess.check_output(
+            [
+                sys.executable,
+                "-c",
+                """\
 from __future__ import annotations
 
 import os
@@ -258,28 +259,33 @@ i = 0
 
 
 def reentrant(
-with_columns: list[str] | None,
-predicate: pl.Expr | None,
-n_rows: int | None,
-batch_size: int | None,
+    with_columns: list[str] | None,
+    predicate: pl.Expr | None,
+    n_rows: int | None,
+    batch_size: int | None,
 ):
-global i
+    global i
 
-df = pl.DataFrame({"x": 1})
+    df = pl.DataFrame({"x": 1})
 
-if i < n:
-    i += 1
-    yield register_io_source(io_source=reentrant, schema={"x": pl.Int64}).collect()
+    if i < n:
+        i += 1
+        yield register_io_source(io_source=reentrant, schema={"x": pl.Int64}).collect()
 
-yield df
+    yield df
 
 
 register_io_source(io_source=reentrant, schema={"x": pl.Int64}).collect()
+
 print("OK", end="", file=sys.stderr)
 """,
-        ],
-        stderr=subprocess.STDOUT,
-        timeout=7,
-    )
+            ],
+            stderr=subprocess.STDOUT,
+            timeout=7,
+        )
+    except subprocess.CalledProcessError as e:
+        print((e.stdout or b"").decode())
+        print((e.stderr or b"").decode())
+        raise
 
     assert out == b"OK"

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -1136,6 +1136,7 @@ def test_predicate_pushdown_auto_disable_strict() -> None:
     assert plan.index("FILTER") > plan.index("MARKER")
 
 
+@pytest.mark.may_fail_auto_streaming  # IO plugin validate=False schema mismatch
 def test_predicate_pushdown_map_elements_io_plugin_22860() -> None:
     def generator(
         with_columns: list[str] | None,


### PR DESCRIPTION
* Needed for https://github.com/pola-rs/polars/pull/23725

Properly propagates the `StreamingExecutionState` passed to `<MultiFileReader as ComputeNode>::spawn` to the IO plugin reader.

**Note**
This PR will change the behavior when scanning IO sources on the new-streaming engine with `validate=False` to raise an error instead of succeeding if the schema of the returned morsels do not match the schema provided to. It currently succeeds by calling `GetBatchFn` to retrieve the first morsel, and overriding the `output_schema` when `validate=False`. This relied on `StreamingExecutionState::default()` as it is done in `to_graph.rs`.

Existing tests that use `validate=False` failing on new-streaming after this PR (3 total):

```
FAILED tests/unit/io/test_io_plugin.py::test_defer - polars.exceptions.SchemaError: data type mismatch for column a: incoming: Float64 != target: Boolean
FAILED tests/unit/io/test_io_plugin.py::test_datetime_io_predicate_pushdown_21790 - polars.exceptions.SchemaError: data type mismatch for column timestamp: incoming: Datetime(Microseconds, None) != target: Datetime(Nanoseconds, None)
FAILED tests/unit/test_predicates.py::test_predicate_pushdown_map_elements_io_plugin_22860 - polars.exceptions.ColumnNotFoundError: did not find column x, consider passing `missing_columns='insert'`
```

cc @orlp 
