### PR TITLE
fix: Fix `to_datetime()` fallible identification

### DIFF
--- a/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
@@ -11,6 +11,7 @@ from hypothesis import given
 import polars as pl
 from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_series_equal
+from polars.testing.asserts.frame import assert_frame_equal
 
 if TYPE_CHECKING:
     from hypothesis.strategies import DrawFn
@@ -197,3 +198,94 @@ def test_to_datetime_two_digit_year_17213(
 ) -> None:
     result = pl.Series([inputs]).str.to_date(format=format).item()
     assert result == expected
+
+
+def test_to_datetime_column_input_to_ambiguous() -> None:
+    q = pl.LazyFrame(
+        {
+            "a": ["2020-01-01 01:00Z", "2020-01-01 02:00Z"],
+            "b": ["raise", "earliest"],
+        }
+    ).select(pl.col.a.str.to_datetime("%Y-%m-%d %H:%M%#z", ambiguous=pl.col.b))
+
+    expect = pl.DataFrame(
+        [
+            pl.Series(
+                "a",
+                [
+                    datetime(2020, 1, 1, 1, 0, tzinfo=ZoneInfo(key="UTC")),
+                    datetime(2020, 1, 1, 2, 0, tzinfo=ZoneInfo(key="UTC")),
+                ],
+                dtype=pl.Datetime(time_unit="us", time_zone="UTC"),
+            ),
+        ]
+    )
+
+    assert_frame_equal(q.collect(), expect)
+
+
+def test_to_datetime_fallible_predicate_pushdown() -> None:
+    df = pl.DataFrame({"x": ["2020-10-25 01:00", "X"]})
+
+    c = pl.first()
+
+    expect_fail = [
+        c.str.to_datetime(
+            "%Y-%m-%d %H:%M",
+            time_zone="Europe/London",
+            ambiguous="raise",
+            strict=False,
+        ),
+        c.str.to_datetime(
+            "%Y-%m-%d %H:%M",
+            time_zone="Europe/London",
+            ambiguous="null",
+            strict=True,
+        ),
+        c.str.to_datetime("%Y-%m-%d %H:%M", strict=True),
+    ]
+
+    expect_pass = [
+        c.str.to_datetime(
+            "%Y-%m-%d %H:%M",
+            time_zone="Europe/London",
+            ambiguous="null",
+            strict=False,
+        ),
+        c.str.to_datetime(
+            "%Y-%m-%d %H:%M",
+            time_zone="Europe/London",
+            ambiguous="earliest",
+            strict=False,
+        ),
+        c.str.to_datetime(
+            "%Y-%m-%d %H:%M",
+            time_zone="Europe/London",
+            ambiguous="latest",
+            strict=False,
+        ),
+    ]
+
+    for expr in expect_fail:
+        with pytest.raises(Exception):  # noqa: B017
+            df.select(expr)
+
+    for expr in expect_pass:
+        df.select(expr)
+
+    lf = df.with_columns(false=False).lazy().filter("false")
+
+    for e in expect_pass:
+        q = lf.filter(e.is_not_null())
+        plan = q.explain()
+        assert plan.count("FILTER") == 1
+        assert_frame_equal(
+            q.collect(), q.collect(optimizations=pl.QueryOptFlags.none())
+        )
+
+    for e in expect_fail:
+        q = lf.filter(e.is_not_null())
+        plan = q.explain()
+        assert_frame_equal(
+            q.collect(), q.collect(optimizations=pl.QueryOptFlags.none())
+        )


### PR DESCRIPTION
Existing code (from me) was just plain wrong.
