### PR TITLE
refactor(rust): Expose `PlPathRef` via polars::prelude

### DIFF
--- a/crates/polars/src/prelude.rs
+++ b/crates/polars/src/prelude.rs
@@ -8,4 +8,4 @@ pub use polars_lazy::prelude::*;
 pub use polars_ops::prelude::*;
 #[cfg(feature = "temporal")]
 pub use polars_time::prelude::*;
-pub use polars_utils::plpath::PlPath;
+pub use polars_utils::plpath::{PlPath, PlPathRef};


### PR DESCRIPTION
If `PlPathRef` is exposed here, downstream users will no longer need to use `polars_utils` in Cargo.toml.
Ref: pola-rs/r-polars#1452