### PR TITLE
fix(rust): Fix schema consistency for `Categorical` in when-then expressions

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -282,6 +282,18 @@ impl AExpr {
                 let st = if let DataType::Null = *truthy.dtype() {
                     falsy.dtype().clone()
                 } else {
+                    // Special handling for Categorical types to preserve them over String
+                    #[cfg(feature = "dtype-categorical")]
+                    match (truthy.dtype(), falsy.dtype()) {
+                        (DataType::Categorical(categories, mapping), DataType::String) => {
+                            DataType::Categorical(categories.clone(), mapping.clone())
+                        },
+                        (DataType::String, DataType::Categorical(categories, mapping)) => {
+                            DataType::Categorical(categories.clone(), mapping.clone())
+                        },
+                        _ => try_get_supertype(truthy.dtype(), falsy.dtype())?,
+                    }
+                    #[cfg(not(feature = "dtype-categorical"))]
                     try_get_supertype(truthy.dtype(), falsy.dtype())?
                 };
 

--- a/py-polars/tests/unit/functions/test_when_then.py
+++ b/py-polars/tests/unit/functions/test_when_then.py
@@ -828,8 +828,8 @@ def test_when_then_in_group_by_aggregated_22922() -> None:
 
 
 def test_categorical_when_then_schema_consistency() -> None:
-    """Test that when-then expressions preserve Categorical types and have consistent schemas.
-    
+    """Test when-then expressions preserve Categorical types with consistent schemas.
+
     Regression test for issue #23733: df.collect_schema() and df.collect().schema
     should return the same schema when using when-then with Categorical columns.
     """
@@ -844,11 +844,11 @@ def test_categorical_when_then_schema_consistency() -> None:
         .otherwise(pl.col("column"))
         .alias("column")
     )
-    
+
     # Check schema inference vs actual execution consistency
     planner_schema = df_lazy.collect_schema()
     actual_schema = df_lazy.collect().schema
-    
+
     # Both should be Categorical and consistent
     assert planner_schema["column"] == pl.Categorical
     assert actual_schema["column"] == pl.Categorical
@@ -856,29 +856,32 @@ def test_categorical_when_then_schema_consistency() -> None:
 
 
 def test_when_then_schema_consistency_across_types() -> None:
-    """Test that when-then expressions have consistent schemas across different data types.
-    
+    """Test when-then expressions have consistent schemas across data types.
+
     Regression test to ensure no schema inconsistencies exist for any data type
     when mixed with String in when-then expressions.
     """
     from datetime import date, datetime
-    
+
     test_cases = [
         ("Int64", [1, 2, 3]),
         ("Float64", [1.1, 2.2, 3.3]),
         ("Boolean", [True, False, True]),
         ("Date", [date(2023, 1, 1), date(2023, 1, 2), date(2023, 1, 3)]),
-        ("Datetime", [datetime(2023, 1, 1), datetime(2023, 1, 2), datetime(2023, 1, 3)]),
+        (
+            "Datetime",
+            [datetime(2023, 1, 1), datetime(2023, 1, 2), datetime(2023, 1, 3)],
+        ),
         ("String", ["a", "b", "c"]),
         ("Categorical", pl.Series(["a", "b", "c"], dtype=pl.Categorical)),
     ]
-    
+
     for type_name, data in test_cases:
         if isinstance(data, pl.Series):
             df = pl.DataFrame({"col": data, "values": [1, 2, 3]})
         else:
             df = pl.DataFrame({"col": data, "values": [1, 2, 3]})
-        
+
         # Test: logical_type.then(string).otherwise(logical_type)
         df_lazy = df.lazy().with_columns(
             pl.when(pl.col("values") == 2)
@@ -886,28 +889,28 @@ def test_when_then_schema_consistency_across_types() -> None:
             .otherwise(pl.col("col"))
             .alias("result")
         )
-        
+
         planner_schema = df_lazy.collect_schema()
         actual_schema = df_lazy.collect().schema
-        
+
         # Should always be consistent
         assert planner_schema["result"] == actual_schema["result"], (
             f"{type_name}: Schema mismatch! "
             f"Planner: {planner_schema['result']}, "
             f"Actual: {actual_schema['result']}"
         )
-        
-        # Test reverse: string.then(logical_type).otherwise(string) 
+
+        # Test reverse: string.then(logical_type).otherwise(string)
         df_lazy_reverse = df.lazy().with_columns(
             pl.when(pl.col("values") == 2)
             .then(pl.col("col"))
             .otherwise(pl.lit("string_value"))
             .alias("result")
         )
-        
+
         planner_schema_rev = df_lazy_reverse.collect_schema()
         actual_schema_rev = df_lazy_reverse.collect().schema
-        
+
         # Should always be consistent
         assert planner_schema_rev["result"] == actual_schema_rev["result"], (
             f"{type_name} (reverse): Schema mismatch! "


### PR DESCRIPTION
Fixes #23733.

This PR fixes a schema inference inconsistency when using when-then expressions involving `Categorical` columns and `string` literals. 
I updated the ternary schema inference logic to preserve `Categorical`, ensuring consistent behavior across planning and execution.
Happy to make any changes!