### PR TITLE
fix: Remove sleep for credential refresh

### DIFF
--- a/crates/polars-io/src/cloud/credential_provider.rs
+++ b/crates/polars-io/src/cloud/credential_provider.rs
@@ -3,7 +3,7 @@ use std::future::Future;
 use std::hash::Hash;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 #[cfg(feature = "aws")]

--- a/crates/polars-io/src/cloud/credential_provider.rs
+++ b/crates/polars-io/src/cloud/credential_provider.rs
@@ -431,15 +431,7 @@ impl<C: Clone> FetchedCredentialsCache<C> {
             .unwrap()
             .as_secs();
 
-        // Ensure the credential is valid for at least this many seconds to
-        // accommodate for latency.
-        const MIN_REMAINING_TIME: u64 = 3;
-
-        let remaining = last_fetched_expiry.saturating_sub(current_time);
-
-        if remaining < MIN_REMAINING_TIME {
-            tokio::time::sleep(Duration::from_secs(MIN_REMAINING_TIME)).await;
-
+        if *last_fetched_expiry <= current_time {
             if verbose {
                 eprintln!(
                     "[FetchedCredentialsCache]: \


### PR DESCRIPTION
* Fixes regression from https://github.com/pola-rs/polars/pull/23730 which caused a 3-second sleep on initialization of credential providers.

This happened as `last_fetched_expiry` is always initialized as `0`.

This PR completely removes `MIN_REMAINING_TIME` / `sleep`s from the Rust-side. They shouldn't be needed since we already have object store rebuild-on-error logic.

Note however that rebuilds do not take place in cloud sinks as they use `object_store::buffered::BufWriter`, which directly uses `dyn ObjectStore` instead of `PolarsObjectStore`.
