### PR TITLE
docs(python): Update resampling.md

### DIFF
--- a/docs/source/user-guide/transformations/time-series/resampling.md
+++ b/docs/source/user-guide/transformations/time-series/resampling.md
@@ -9,7 +9,7 @@ We can resample by either:
 ## Downsampling to a lower frequency
 
 Polars views downsampling as a special case of the **group_by** operation and you can do this with
-`group_by_dynamic` and `group_by_rolling` -
+`group_by_dynamic` and `rolling` -
 [see the temporal group by page for examples](rolling.md).
 
 ## Upsampling to a higher frequency


### PR DESCRIPTION
`group_by_rolling` is not used anymore, and replaced by `rolling` in API v1

Partial fix for  #23777 