### PR TITLE
refactor(rust): Remove incorrect `DeletionFilesList::slice`

### DIFF
--- a/crates/polars-plan/src/dsl/file_scan/deletion.rs
+++ b/crates/polars-plan/src/dsl/file_scan/deletion.rs
@@ -13,7 +13,7 @@ pub enum DeletionFilesList {
     // * There may be data files without deletion files.
     // * A single data file may have multiple associated deletion files.
     //
-    // Note that this uses `PlIndexMap` instead of `PlHashMap` for schemars compatiblity.
+    // Note that this uses `PlIndexMap` instead of `PlHashMap` for schemars compatibility.
     //
     // Other possible options:
     // * ListArray(inner: Utf8Array)


### PR DESCRIPTION
This is just incorrect - not every scan source has an entry in the map so the physical positions do not match 1-1 with the files.
