### PR TITLE
chore: Remove `deserialize_with_unknown_fields`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3679,7 +3679,6 @@ dependencies = [
  "rmp-serde",
  "schemars",
  "serde",
- "serde_ignored",
  "serde_json",
  "slotmap",
  "stacker",
@@ -4626,15 +4625,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
-]
-
-[[package]]
-name = "serde_ignored"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b516445dac1e3535b6d658a7b528d771153dfb272ed4180ca4617a20550365ff"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,6 @@ rmp-serde = "1.3"
 ryu = "1.0.13"
 schemars = { version = "0.8.22", features = ["preserve_order"] }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
-serde_ignored = "0.1.12"
 serde_json = "1"
 sha2 = "0.10"
 simd-json = { version = "0.15", features = ["known-key"] }

--- a/crates/polars-plan/Cargo.toml
+++ b/crates/polars-plan/Cargo.toml
@@ -211,7 +211,7 @@ allow_unused = ["polars-io/allow_unused", "polars-ops/allow_unused", "polars-tim
 
 bigidx = ["polars-core/bigidx", "polars-utils/bigidx"]
 polars_cloud_client = ["serde"]
-polars_cloud_server = ["serde", "polars-utils/polars_cloud_server"]
+polars_cloud_server = ["serde"]
 ir_serde = ["serde", "polars-utils/ir_serde"]
 
 [package.metadata.docs.rs]

--- a/crates/polars-utils/Cargo.toml
+++ b/crates/polars-utils/Cargo.toml
@@ -29,7 +29,6 @@ regex = { workspace = true }
 rmp-serde = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
-serde_ignored = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 slotmap = { workspace = true }
 stacker = { workspace = true }
@@ -57,7 +56,6 @@ serde = [
   "uuid/serde",
 ]
 dsl-schema = ["dep:schemars"]
-polars_cloud_server = ["dep:serde_ignored"]
 python = ["pyo3", "polars-error/python"]
 
 [lints]

--- a/crates/polars-utils/src/pl_serialize.rs
+++ b/crates/polars-utils/src/pl_serialize.rs
@@ -38,21 +38,6 @@ where
     }
 }
 
-#[cfg(feature = "polars_cloud_server")]
-/// Deserializes the value and collects paths to all unknown fields.
-fn deserialize_with_unknown_fields<T, R>(reader: R) -> PolarsResult<(T, Vec<String>)>
-where
-    T: serde::de::DeserializeOwned,
-    R: std::io::Read,
-{
-    let mut de = rmp_serde::Deserializer::new(reader);
-    let mut unknown_fields = Vec::new();
-    let t = serde_ignored::deserialize(&mut de, |path| {
-        unknown_fields.push(path.to_string());
-    });
-    t.map(|t| (t, unknown_fields)).map_err(to_compute_err)
-}
-
 /// Mainly used to enable compression when serializing the final outer value.
 /// For intermediate serialization steps, the function in the module should
 /// be used instead.
@@ -92,25 +77,6 @@ impl SerializeOptions {
             deserialize_impl::<_, _, FC>(flate2::read::ZlibDecoder::new(reader))
         } else {
             deserialize_impl::<_, _, FC>(reader)
-        }
-    }
-
-    /// Deserializes the value and collects paths to all unknown fields.
-    ///
-    /// Supports only the future-compatible format (`FC: true`).
-    #[cfg(feature = "polars_cloud_server")]
-    pub fn deserialize_from_reader_with_unknown_fields<T, R>(
-        &self,
-        reader: R,
-    ) -> PolarsResult<(T, Vec<String>)>
-    where
-        T: serde::de::DeserializeOwned,
-        R: std::io::Read,
-    {
-        if self.compression {
-            deserialize_with_unknown_fields(flate2::read::ZlibDecoder::new(reader))
-        } else {
-            deserialize_with_unknown_fields(reader)
         }
     }
 
@@ -326,41 +292,5 @@ mod tests {
             .unwrap();
 
         assert_eq!(r, v);
-    }
-
-    #[cfg(feature = "polars_cloud_server")]
-    #[test]
-    fn test_serde_collect_unknown_fields() {
-        #[derive(Clone, Copy, serde::Serialize)]
-        struct A {
-            x: bool,
-            u: u8,
-        }
-
-        #[derive(serde::Serialize)]
-        enum E {
-            V { val: A, ch: char },
-        }
-
-        #[derive(serde::Deserialize)]
-        struct B {
-            u: u8,
-        }
-
-        #[derive(serde::Deserialize)]
-        enum F {
-            V { val: B },
-        }
-
-        let a = A { u: 42, x: true };
-        let e = E::V { val: a, ch: 'x' };
-
-        let buf: Vec<u8> = super::serialize_to_bytes::<_, true>(&e).unwrap();
-        let (f, unknown) = super::deserialize_with_unknown_fields::<F, _>(buf.as_slice()).unwrap();
-
-        let F::V { val: b } = f;
-
-        assert_eq!(a.u, b.u);
-        assert_eq!(unknown.as_slice(), &["val.x", "ch"]);
     }
 }


### PR DESCRIPTION
Not used anymore since #23709, now we check for the exact schema match.