### PR TITLE
chore: Fix typos path

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -7,7 +7,7 @@ extend-exclude = [
   "**/images/*",
   "**/py-polars/polars/_utils/nest_asyncio.py",
   "*.nix",
-  "crates/polars-plan/dsl-schema-hashes.json",
+  "**/crates/polars-plan/dsl-schema-hashes.json",
 ]
 ignore-hidden = false
 


### PR DESCRIPTION
`typos` doesn't use paths relative to repository root so `**` is needed when in a subdirectory.