### PR TITLE
fix: Match output type to engine for `Struct` arithmetic

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -703,7 +703,12 @@ fn get_truediv_dtype(left_dtype: &DataType, right_dtype: &DataType) -> PolarsRes
                 "div", a.len(), b.len()
             );
             let mut fields = Vec::with_capacity(a.len());
-            for (left, right) in a.iter().zip(b) {
+            let b_iter: Box<dyn Iterator<Item = &Field>> = if b.len() == 1 {
+                Box::new(std::iter::repeat_n(&b[0], a.len()))
+            } else {
+                Box::new(b.iter())
+            };
+            for (left, right) in a.iter().zip(b_iter) {
                 let name = left.name.clone();
                 let (left, right) = (left.dtype(), right.dtype());
                 if !(left.is_numeric() && right.is_numeric()) {

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -703,11 +703,8 @@ fn get_truediv_dtype(left_dtype: &DataType, right_dtype: &DataType) -> PolarsRes
                 "div", a.len(), b.len()
             );
             let mut fields = Vec::with_capacity(a.len());
-            let b_iter: Box<dyn Iterator<Item = &Field>> = if b.len() == 1 {
-                Box::new(std::iter::repeat_n(&b[0], a.len()))
-            } else {
-                Box::new(b.iter())
-            };
+            // In case b.len() == 1, we broadcast the first field (b[0])
+            let b_iter = b.iter().cycle().take(a.len());
             for (left, right) in a.iter().zip(b_iter) {
                 let name = left.name.clone();
                 let (left, right) = (left.dtype(), right.dtype());

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -703,8 +703,9 @@ fn get_truediv_dtype(left_dtype: &DataType, right_dtype: &DataType) -> PolarsRes
                 "div", a.len(), b.len()
             );
             let mut fields = Vec::with_capacity(a.len());
-            // In case b.len() == 1, we broadcast the first field (b[0])
-            let b_iter = b.iter().cycle().take(a.len());
+            // In case b.len() == 1, we broadcast the first field (b[0]).
+            // Safety is assured by the constraints above.
+            let b_iter = (0..a.len()).map(|i| b.get(i.min(b.len() - 1)).unwrap());
             for (left, right) in a.iter().zip(b_iter) {
                 let name = left.name.clone();
                 let (left, right) = (left.dtype(), right.dtype());

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -433,6 +433,11 @@ fn get_arithmetic_field(
                 (Struct(_), Struct(_)) => {
                     return Ok(left_field);
                 },
+                // This matches the engine output. TODO: revisit pending resolution of GH issue #23797
+                #[cfg(feature = "dtype-struct")]
+                (Struct(_), r) if r.is_numeric() => {
+                    return Ok(left_field);
+                },
                 (Duration(_), Datetime(_, _))
                 | (Datetime(_, _), Duration(_))
                 | (Duration(_), Date)
@@ -497,6 +502,15 @@ fn get_arithmetic_field(
         Operator::Plus => {
             let right_type = right_ae.to_field_impl(ctx)?.dtype;
             match (&left_field.dtype, &right_type) {
+                #[cfg(feature = "dtype-struct")]
+                (Struct(_), Struct(_)) => {
+                    return Ok(left_field);
+                },
+                // This matches the engine output. TODO: revisit pending resolution of GH issue #23797
+                #[cfg(feature = "dtype-struct")]
+                (Struct(_), r) if r.is_numeric() => {
+                    return Ok(left_field);
+                },
                 (Duration(_), Datetime(_, _))
                 | (Datetime(_, _), Duration(_))
                 | (Duration(_), Date)
@@ -554,6 +568,11 @@ fn get_arithmetic_field(
             match (&left_field.dtype, &right_type) {
                 #[cfg(feature = "dtype-struct")]
                 (Struct(_), Struct(_)) => {
+                    return Ok(left_field);
+                },
+                // This matches the engine output. TODO: revisit pending resolution of GH issue #23797
+                #[cfg(feature = "dtype-struct")]
+                (Struct(_), r) if r.is_numeric() => {
                     return Ok(left_field);
                 },
                 (Datetime(_, _), _)
@@ -677,6 +696,40 @@ fn get_truediv_dtype(left_dtype: &DataType, right_dtype: &DataType) -> PolarsRes
     // TODO: Re-investigate this. A lot of "_" is being used on the RHS match because this code
     // originally (mostly) only looked at the LHS dtype.
     let out_type = match (left_dtype, right_dtype) {
+        (Struct(a), Struct(b)) => {
+            polars_ensure!(a.len() == b.len() || b.len() == 1,
+                InvalidOperation: "cannot {} two structs of different length (left: {}, right: {})",
+                "div", a.len(), b.len()
+            );
+            let mut fields = Vec::with_capacity(a.len());
+            for (left, right) in a.iter().zip(b) {
+                let name = left.name.clone();
+                let (left, right) = (left.dtype(), right.dtype());
+                if !(left.is_numeric() && right.is_numeric()) {
+                    polars_bail!(InvalidOperation:
+                        "cannot {} two structs with non-numeric fields: (left: {}, right: {})",
+                        "div", left, right,)
+                };
+                let field = Field::new(name, get_truediv_dtype(left, right)?);
+                fields.push(field);
+            }
+            Struct(fields)
+        },
+        (Struct(a), n) if n.is_numeric() => {
+            let mut fields = Vec::with_capacity(a.len());
+            for left in a.iter() {
+                let name = left.name.clone();
+                let left = left.dtype();
+                if !(left.is_numeric()) {
+                    polars_bail!(InvalidOperation:
+                        "cannot {} a struct with non-numeric field: (left: {})",
+                        "div", left)
+                };
+                let field = Field::new(name, get_truediv_dtype(left, n)?);
+                fields.push(field);
+            }
+            Struct(fields)
+        },
         (l @ List(a), r @ List(b))
             if ![a, b]
                 .into_iter()

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -696,6 +696,7 @@ fn get_truediv_dtype(left_dtype: &DataType, right_dtype: &DataType) -> PolarsRes
     // TODO: Re-investigate this. A lot of "_" is being used on the RHS match because this code
     // originally (mostly) only looked at the LHS dtype.
     let out_type = match (left_dtype, right_dtype) {
+        #[cfg(feature = "dtype-struct")]
         (Struct(a), Struct(b)) => {
             polars_ensure!(a.len() == b.len() || b.len() == 1,
                 InvalidOperation: "cannot {} two structs of different length (left: {}, right: {})",
@@ -715,6 +716,7 @@ fn get_truediv_dtype(left_dtype: &DataType, right_dtype: &DataType) -> PolarsRes
             }
             Struct(fields)
         },
+        #[cfg(feature = "dtype-struct")]
         (Struct(a), n) if n.is_numeric() => {
             let mut fields = Vec::with_capacity(a.len());
             for left in a.iter() {

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -842,18 +842,18 @@ def test_struct_arithmetic_schema() -> None:
 
 
 @pytest.mark.parametrize(
-    "lf",
+    "df",
     [
-        pl.LazyFrame({"a": [10], "b": [20]}),
-        pl.LazyFrame({"a": [10.0], "b": [20.0]}),
+        pl.DataFrame({"a": [10], "b": [20], "c": [30]}),
+        pl.DataFrame({"a": [10.0], "b": [20.0], "c": [30.0]}),
     ],
 )
 @pytest.mark.parametrize(
     "rhs",
     [
-        pl.struct("b"),
-        pl.lit(3),
-        pl.lit(3.0),
+        pl.struct("c"),
+        pl.lit(7),
+        pl.lit(7.0),
     ],
 )
 @pytest.mark.parametrize(
@@ -868,12 +868,19 @@ def test_struct_arithmetic_schema() -> None:
     ],
 )
 def test_struct_arithmetic_schema_match(
-    lf: pl.LazyFrame,
+    df: pl.DataFrame,
     rhs: pl.Expr,
     op: Any,
 ) -> None:
+    # 1 field on the LHS struct
     lhs = pl.struct("a")
-    q = lf.select(op(lhs, rhs))
+    q = df.lazy().select(op(lhs, rhs))
+    assert q.collect_schema() == q.collect().schema
+
+    # 2 fields on the LHS struct
+    df = df.with_columns(pl.struct(pl.all()).alias("ab"))
+    lhs = pl.col("ab")
+    q = df.lazy().select(op(lhs, rhs))
     assert q.collect_schema() == q.collect().schema
 
 

--- a/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
@@ -77,21 +77,41 @@ def test_struct_arithmetic() -> None:
             "c": [5, 6],
         }
     ).select(pl.cum_sum_horizontal("a", "c"))
-    assert df.select(pl.col("cum_sum") * 2).to_dict(as_series=False) == {
+
+    q = df.lazy().select(pl.col("cum_sum") * 2)
+    out = q.collect()
+    assert out.to_dict(as_series=False) == {
         "cum_sum": [{"a": 2, "c": 12}, {"a": 4, "c": 16}]
     }
-    assert df.select(pl.col("cum_sum") - 2).to_dict(as_series=False) == {
+    assert q.collect_schema() == out.schema
+
+    q = df.lazy().select(pl.col("cum_sum") - 2)
+    out = q.collect()
+    assert out.to_dict(as_series=False) == {
         "cum_sum": [{"a": -1, "c": 4}, {"a": 0, "c": 6}]
     }
-    assert df.select(pl.col("cum_sum") + 2).to_dict(as_series=False) == {
+    assert q.collect_schema() == out.schema
+
+    q = df.lazy().select(pl.col("cum_sum") + 2)
+    out = q.collect()
+    assert out.to_dict(as_series=False) == {
         "cum_sum": [{"a": 3, "c": 8}, {"a": 4, "c": 10}]
     }
-    assert df.select(pl.col("cum_sum") / 2).to_dict(as_series=False) == {
+    assert q.collect_schema() == out.schema
+
+    q = df.lazy().select(pl.col("cum_sum") / 2)
+    out = q.collect()
+    assert out.to_dict(as_series=False) == {
         "cum_sum": [{"a": 0.5, "c": 3.0}, {"a": 1.0, "c": 4.0}]
     }
-    assert df.select(pl.col("cum_sum") // 2).to_dict(as_series=False) == {
+    assert q.collect_schema() == out.schema
+
+    q = df.lazy().select(pl.col("cum_sum") // 2)
+    out = q.collect()
+    assert out.to_dict(as_series=False) == {
         "cum_sum": [{"a": 0, "c": 3}, {"a": 1, "c": 4}]
     }
+    assert q.collect_schema() == out.schema
 
     # inline, this checks cum_sum reports the right output type
     assert pl.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]}).select(


### PR DESCRIPTION
Partial fix for #23663.

*edit: Ready for review and merge.

Notes:
- In this PR, `collect_schema()` will match the engine output for `Struct` arithmetic. The intended output datatype might change in the future (see https://github.com/pola-rs/polars/issues/23797).
- Decimal works on some (e.g., `add`) but not all operations (e.g. `floordiv`). Given that Decimal arithmetic may change, no effort was put into resolving it now.

Ping @coastalwhite 
