### PR TITLE
fix: Fix errors on native `scan_iceberg`

### DIFF
--- a/crates/polars-parquet/src/arrow/read/schema/convert.rs
+++ b/crates/polars-parquet/src/arrow/read/schema/convert.rs
@@ -1,5 +1,8 @@
 //! This module has entry points, [`parquet_to_arrow_schema`] and the more configurable [`parquet_to_arrow_schema_with_options`].
-use arrow::datatypes::{ArrowDataType, ArrowSchema, Field, IntervalUnit, TimeUnit};
+use std::sync::Arc;
+
+use arrow::datatypes::{ArrowDataType, ArrowSchema, Field, IntervalUnit, Metadata, TimeUnit};
+use polars_utils::format_pl_smallstr;
 use polars_utils::pl_str::PlSmallStr;
 
 use crate::arrow::read::schema::SchemaInferenceOptions;
@@ -309,11 +312,27 @@ pub(crate) fn is_nullable(field_info: &FieldInfo) -> bool {
 /// Returns `None` iff the parquet type has no associated primitive types,
 /// i.e. if it is a column-less group type.
 fn to_field(type_: &ParquetType, options: &SchemaInferenceOptions) -> Option<Field> {
-    Some(Field::new(
-        type_.get_field_info().name.clone(),
+    let field_info = type_.get_field_info();
+
+    let metadata: Option<Arc<Metadata>> = field_info.id.map(|x| {
+        Arc::new(
+            [(
+                PlSmallStr::from_static("PARQUET:field_id"),
+                format_pl_smallstr!("{x}"),
+            )]
+            .into(),
+        )
+    });
+
+    let mut arrow_field = Field::new(
+        field_info.name.clone(),
         to_dtype(type_, options)?,
         is_nullable(type_.get_field_info()),
-    ))
+    );
+
+    arrow_field.metadata = metadata;
+
+    Some(arrow_field)
 }
 
 /// Converts a parquet list to arrow list.

--- a/crates/polars-parquet/src/arrow/read/schema/convert.rs
+++ b/crates/polars-parquet/src/arrow/read/schema/convert.rs
@@ -314,7 +314,7 @@ pub(crate) fn is_nullable(field_info: &FieldInfo) -> bool {
 fn to_field(type_: &ParquetType, options: &SchemaInferenceOptions) -> Option<Field> {
     let field_info = type_.get_field_info();
 
-    let metadata: Option<Arc<Metadata>> = field_info.id.map(|x| {
+    let metadata: Option<Arc<Metadata>> = field_info.id.map(|x: i32| {
         Arc::new(
             [(
                 PlSmallStr::from_static("PARQUET:field_id"),

--- a/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
+++ b/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
@@ -29,6 +29,9 @@ impl OptimizationRule for ExpandDatasets {
         _expr_arena: &mut Arena<crate::prelude::AExpr>,
         node: Node,
     ) -> PolarsResult<Option<IR>> {
+        // # Note
+        // This function mutates the IR node in-place rather than returning the new IR - the
+        // StackOptimizer will re-call this function otherwise.
         if let IR::Scan {
             sources,
             scan_type,

--- a/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
+++ b/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
@@ -140,12 +140,11 @@ impl OptimizationRule for ExpandDatasets {
                             };
 
                             unified_scan_args.cloud_options = cloud_options.clone();
-                            unified_scan_args.rechunk = rechunk.clone();
-                            unified_scan_args.cache = cache.clone();
+                            unified_scan_args.rechunk = *rechunk;
+                            unified_scan_args.cache = *cache;
                             unified_scan_args.cast_columns_policy = cast_columns_policy.clone();
-                            unified_scan_args.missing_columns_policy =
-                                missing_columns_policy.clone();
-                            unified_scan_args.extra_columns_policy = extra_columns_policy.clone();
+                            unified_scan_args.missing_columns_policy = *missing_columns_policy;
+                            unified_scan_args.extra_columns_policy = *extra_columns_policy;
                             unified_scan_args.deletion_files = deletion_files.clone();
                             unified_scan_args.column_mapping = column_mapping.clone();
 

--- a/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
+++ b/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use polars_core::config;
@@ -269,13 +269,10 @@ impl Debug for ExpandedDataset {
         .fmt(f);
 
         mod display {
-            use std::fmt::{Debug, Display};
+            use std::fmt::Debug;
             use std::sync::Arc;
 
             use polars_utils::pl_str::PlSmallStr;
-
-            use crate::dsl::DslPlan;
-            use crate::prelude::IR;
 
             #[derive(Debug)]
             #[expect(unused)]

--- a/py-polars/polars/io/iceberg/dataset.py
+++ b/py-polars/polars/io/iceberg/dataset.py
@@ -113,10 +113,6 @@ class IcebergDataset:
         fallback_reason = (
             "forced reader_override='pyiceberg'"
             if reader_override == "pyiceberg"
-            # TODO: Enable native scans by default after we have type casting support,
-            # currently it may fail if the dataset has changed types.
-            else "native scans disabled by default"
-            if reader_override != "native"
             else None
         )
 

--- a/py-polars/polars/io/iceberg/dataset.py
+++ b/py-polars/polars/io/iceberg/dataset.py
@@ -113,6 +113,10 @@ class IcebergDataset:
         fallback_reason = (
             "forced reader_override='pyiceberg'"
             if reader_override == "pyiceberg"
+            # TODO: Enable native scans by default after we have type casting support,
+            # currently it may fail if the dataset has changed types.
+            else "native scans disabled by default"
+            if reader_override != "native"
             else None
         )
 

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -53,18 +53,18 @@ class TestIcebergScanIO:
     """Test coverage for `iceberg` scan ops."""
 
     def test_scan_iceberg_plain(self, iceberg_path: str) -> None:
-        df = pl.scan_iceberg(iceberg_path)
-        assert len(df.collect()) == 3
-        assert df.collect_schema() == {
+        q = pl.scan_iceberg(iceberg_path)
+        assert len(q.collect()) == 3
+        assert q.collect_schema() == {
             "id": pl.Int32,
             "str": pl.String,
             "ts": pl.Datetime(time_unit="us", time_zone=None),
         }
 
     def test_scan_iceberg_snapshot_id(self, iceberg_path: str) -> None:
-        df = pl.scan_iceberg(iceberg_path, snapshot_id=7051579356916758811)
-        assert len(df.collect()) == 3
-        assert df.collect_schema() == {
+        q = pl.scan_iceberg(iceberg_path, snapshot_id=7051579356916758811)
+        assert len(q.collect()) == 3
+        assert q.collect_schema() == {
             "id": pl.Int32,
             "str": pl.String,
             "ts": pl.Datetime(time_unit="us", time_zone=None),
@@ -476,7 +476,7 @@ def test_scan_iceberg_column_deletion(tmp_path: Path) -> None:
     )
 
     assert_frame_equal(
-        pl.scan_iceberg(tbl, reader_override="native").collect(),
+        pl.scan_iceberg(tbl).collect(),
         expect,
     )
 
@@ -687,7 +687,7 @@ def test_scan_iceberg_nested_column_cast_deletion_rename(tmp_path: Path) -> None
     tbl.append(arrow_tbl)
 
     assert_frame_equal(pl.scan_iceberg(tbl, reader_override="pyiceberg").collect(), df)
-    assert_frame_equal(pl.scan_iceberg(tbl, reader_override="native").collect(), df)
+    assert_frame_equal(pl.scan_iceberg(tbl).collect(), df)
 
     # Change schema
     # Note: Iceberg doesn't allow modifying the "key" part of the Map type.
@@ -802,7 +802,8 @@ def test_scan_iceberg_nested_column_cast_deletion_rename(tmp_path: Path) -> None
     assert_frame_equal(
         pl.scan_iceberg(tbl, reader_override="pyiceberg").collect(), expect
     )
-    assert_frame_equal(pl.scan_iceberg(tbl, reader_override="native").collect(), expect)
+    assert_frame_equal(pl.scan_iceberg(tbl).collect(), expect)
+    assert_frame_equal(pl.scan_iceberg(tbl).collect(), expect)
 
 
 @pytest.mark.write_disk
@@ -951,7 +952,7 @@ def test_scan_iceberg_nulls_multiple_nesting(tmp_path: Path) -> None:
     tbl.append(arrow_tbl)
 
     assert_frame_equal(pl.scan_iceberg(tbl, reader_override="pyiceberg").collect(), df)
-    assert_frame_equal(pl.scan_iceberg(tbl, reader_override="native").collect(), df)
+    assert_frame_equal(pl.scan_iceberg(tbl).collect(), df)
 
 
 @pytest.mark.write_disk
@@ -1017,7 +1018,7 @@ def test_scan_iceberg_nulls_nested(tmp_path: Path) -> None:
     tbl.append(arrow_tbl)
 
     assert_frame_equal(pl.scan_iceberg(tbl, reader_override="pyiceberg").collect(), df)
-    assert_frame_equal(pl.scan_iceberg(tbl, reader_override="native").collect(), df)
+    assert_frame_equal(pl.scan_iceberg(tbl).collect(), df)
 
 
 def test_scan_iceberg_parquet_prefilter_with_column_mapping(
@@ -1087,7 +1088,7 @@ def test_scan_iceberg_parquet_prefilter_with_column_mapping(
         sch.move_first("column_1")
 
     assert_frame_equal(
-        pl.scan_iceberg(tbl, reader_override="native").collect().sort("column_3"),
+        pl.scan_iceberg(tbl).collect().sort("column_3"),
         pl.DataFrame(
             {
                 "column_1": ["P", "Q", "R", "S", "T", "U"],
@@ -1096,7 +1097,7 @@ def test_scan_iceberg_parquet_prefilter_with_column_mapping(
         ),
     )
 
-    q = pl.scan_iceberg(tbl, reader_override="native").filter(pl.col("column_3") == 5)
+    q = pl.scan_iceberg(tbl).filter(pl.col("column_3") == 5)
 
     with monkeypatch.context() as cx:
         cx.setenv("POLARS_VERBOSE", "1")

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -476,7 +476,7 @@ def test_scan_iceberg_column_deletion(tmp_path: Path) -> None:
     )
 
     assert_frame_equal(
-        pl.scan_iceberg(tbl).collect(),
+        pl.scan_iceberg(tbl, reader_override="native").collect(),
         expect,
     )
 
@@ -687,7 +687,7 @@ def test_scan_iceberg_nested_column_cast_deletion_rename(tmp_path: Path) -> None
     tbl.append(arrow_tbl)
 
     assert_frame_equal(pl.scan_iceberg(tbl, reader_override="pyiceberg").collect(), df)
-    assert_frame_equal(pl.scan_iceberg(tbl).collect(), df)
+    assert_frame_equal(pl.scan_iceberg(tbl, reader_override="native").collect(), df)
 
     # Change schema
     # Note: Iceberg doesn't allow modifying the "key" part of the Map type.
@@ -802,8 +802,7 @@ def test_scan_iceberg_nested_column_cast_deletion_rename(tmp_path: Path) -> None
     assert_frame_equal(
         pl.scan_iceberg(tbl, reader_override="pyiceberg").collect(), expect
     )
-    assert_frame_equal(pl.scan_iceberg(tbl).collect(), expect)
-    assert_frame_equal(pl.scan_iceberg(tbl).collect(), expect)
+    assert_frame_equal(pl.scan_iceberg(tbl, reader_override="native").collect(), expect)
 
 
 @pytest.mark.write_disk
@@ -952,7 +951,7 @@ def test_scan_iceberg_nulls_multiple_nesting(tmp_path: Path) -> None:
     tbl.append(arrow_tbl)
 
     assert_frame_equal(pl.scan_iceberg(tbl, reader_override="pyiceberg").collect(), df)
-    assert_frame_equal(pl.scan_iceberg(tbl).collect(), df)
+    assert_frame_equal(pl.scan_iceberg(tbl, reader_override="native").collect(), df)
 
 
 @pytest.mark.write_disk
@@ -1018,7 +1017,7 @@ def test_scan_iceberg_nulls_nested(tmp_path: Path) -> None:
     tbl.append(arrow_tbl)
 
     assert_frame_equal(pl.scan_iceberg(tbl, reader_override="pyiceberg").collect(), df)
-    assert_frame_equal(pl.scan_iceberg(tbl).collect(), df)
+    assert_frame_equal(pl.scan_iceberg(tbl, reader_override="native").collect(), df)
 
 
 def test_scan_iceberg_parquet_prefilter_with_column_mapping(
@@ -1088,7 +1087,7 @@ def test_scan_iceberg_parquet_prefilter_with_column_mapping(
         sch.move_first("column_1")
 
     assert_frame_equal(
-        pl.scan_iceberg(tbl).collect().sort("column_3"),
+        pl.scan_iceberg(tbl, reader_override="native").collect().sort("column_3"),
         pl.DataFrame(
             {
                 "column_1": ["P", "Q", "R", "S", "T", "U"],
@@ -1097,7 +1096,7 @@ def test_scan_iceberg_parquet_prefilter_with_column_mapping(
         ),
     )
 
-    q = pl.scan_iceberg(tbl).filter(pl.col("column_3") == 5)
+    q = pl.scan_iceberg(tbl, reader_override="native").filter(pl.col("column_3") == 5)
 
     with monkeypatch.context() as cx:
         cx.setenv("POLARS_VERBOSE", "1")


### PR DESCRIPTION
### Changes
* Fixes https://github.com/pola-rs/polars/issues/23841
  * The IR was not overwritten on the 2nd execution of the query
* Fixes https://github.com/pola-rs/polars/issues/23842
  * This file did not have `ARROW:schema`, causing us to go into a separate codepath for constructing the schema. This codepath has been updated in this PR to load the field IDs.
