### PR TITLE
ci: Automatically tag PRs mentioning "SQL" with the appropriate label

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -48,6 +48,9 @@ autolabeler:
   - label: fix
     title:
       - '/^fix/'
+  - label: sql
+    title:
+      - '/\bsql\b/i'
   - label: performance
     title:
       - '/^perf/'


### PR DESCRIPTION
Minor quality of life update; automatically add the `sql` label if we see "SQL" in the PR title.

(Could probably benefit from a few more of these; might add some other ones later 🤔)