### PR TITLE
feat: Add `DataFrame.map_columns` for eager evaluation

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6512,7 +6512,12 @@ class DataFrame:
         **kwargs: P.kwargs,
     ) -> DataFrame:
         """
-        Apply a user-defined function (UDF) to columns.
+        Apply eager functions to columns of a DataFrame.
+
+        Users should always prefer :meth:`with_columns` unless they are using
+        expressions that are only possible on `Series` and not on `Expr`. This is almost
+        never the case, except for a very select few functions that cannot know the
+        output datatype without looking at the data.
 
         Parameters
         ----------
@@ -6573,6 +6578,10 @@ class DataFrame:
         │ {"b"}     ┆ {2,false} │
         │ null      ┆ null      │
         └───────────┴───────────┘
+
+        See Also
+        --------
+        with_columns
         """
         c_names: list[str]
         if isinstance(column_names, (pl.Selector, pl.Expr)):

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6504,6 +6504,70 @@ class DataFrame:
         """
         return function(self, *args, **kwargs)
 
+    def pipe_columns(
+        self,
+        column_names: str | Sequence[str],
+        function: Callable[Series, Series],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> DataFrame:
+        """
+        Apply a user-defined function (UDF) to columns.
+
+        Parameters
+        ----------
+        column_names
+            The columns to apply the UDF to.
+        function
+            Callable; will receive a column series as the first parameter,
+            followed by any given args/kwargs.
+        *args
+            Arguments to pass to the UDF.
+        **kwargs
+            Keyword arguments to pass to the UDF.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"a": [1, 2, 3, 4], "b": ["10", "20", "30", "40"]})
+        >>> df.pipe_columns("a", lambda s: s.shrink_dtype())
+        shape: (4, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i8  ┆ str │
+        ╞═════╪═════╡
+        │ 1   ┆ 10  │
+        │ 2   ┆ 20  │
+        │ 3   ┆ 30  │
+        │ 4   ┆ 40  │
+        └─────┴─────┘
+
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": ['{"x":"a"}', None, '{"x":"b"}', None],
+        ...         "b": ['{"a":1, "b": true}', None, '{"a":2, "b": false}', None],
+        ...     }
+        ... )
+        >>> df.pipe_columns(["a", "b"], lambda s: s.str.json_decode())
+        shape: (4, 2)
+        ┌───────────┬───────────┐
+        │ a         ┆ b         │
+        │ ---       ┆ ---       │
+        │ struct[1] ┆ struct[2] │
+        ╞═══════════╪═══════════╡
+        │ {"a"}     ┆ {1,true}  │
+        │ null      ┆ null      │
+        │ {"b"}     ┆ {2,false} │
+        │ null      ┆ null      │
+        └───────────┴───────────┘
+        """
+        if isinstance(column_names, str):
+            column_names = [column_names]
+
+        return self.with_columns(
+            **{c: function(self[c], *args, **kwargs) for c in column_names}
+        )
+
     def with_row_index(self, name: str = "index", offset: int = 0) -> DataFrame:
         """
         Add a row index as the first column in the DataFrame.

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6507,7 +6507,7 @@ class DataFrame:
     def pipe_columns(
         self,
         column_names: str | Sequence[str],
-        function: Callable[Series, Series],
+        function: Callable[[Series], Series],
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> DataFrame:

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6578,7 +6578,7 @@ class DataFrame:
         if isinstance(column_names, (pl.Selector, pl.Expr)):
             from polars.selectors import expand_selector
 
-            c_names = expand_selector(self, column_names)
+            c_names = list(expand_selector(self, column_names))
         elif isinstance(column_names, str):
             c_names = [column_names]
         else:


### PR DESCRIPTION
This patch adds the `pipe_columns` method for `DataFrame`. This method makes it easy to chain eager-only operations on `Series` and does so in connection to make sure that changes related to #23625 are left with good alternatives.

```python
>>> import polars as pl
>>> df = pl.DataFrame({
...     "a": ['{"x":"a"}', None, '{"x":"b"}', None],
...     "b": ['{"a":1, "b": true}', None, '{"a":2, "b": false}', None],
... })
>>> df.map_columns(["a", "b"], lambda s: s.str.json_decode())
shape: (4, 2)
┌───────────┬───────────┐
│ a         ┆ b         │
│ ---       ┆ ---       │
│ struct[1] ┆ struct[2] │
╞═══════════╪═══════════╡
│ {"a"}     ┆ {1,true}  │
│ null      ┆ null      │
│ {"b"}     ┆ {2,false} │
│ null      ┆ null      │
└───────────┴───────────┘
```