### PR TITLE
fix: Remove accidental todo! in repeat node

### DIFF
--- a/crates/polars-stream/src/nodes/repeat.rs
+++ b/crates/polars-stream/src/nodes/repeat.rs
@@ -128,7 +128,7 @@ impl ComputeNode for RepeatNode {
                         }
                         wait_group.wait().await;
                     }
-                    
+
                     Ok(())
                 }));
             },

--- a/crates/polars-stream/src/nodes/repeat.rs
+++ b/crates/polars-stream/src/nodes/repeat.rs
@@ -128,8 +128,8 @@ impl ComputeNode for RepeatNode {
                         }
                         wait_group.wait().await;
                     }
-
-                    todo!()
+                    
+                    Ok(())
                 }));
             },
         }


### PR DESCRIPTION
Silly mistake by me, not caught because we still use `POLARS_AUTO_NEW_STREAMING` which automatically defers `todo!`s to the in-memory engine.