### PR TITLE
feat(python): Change typing for `.remote()` from `LazyFrameExt` to `LazyFrameRemote`

### DIFF
--- a/docs/source/_build/API_REFERENCE_LINKS.yml
+++ b/docs/source/_build/API_REFERENCE_LINKS.yml
@@ -186,7 +186,7 @@ python:
   write_parquet: https://docs.pola.rs/api/python/stable/reference/api/polars.DataFrame.write_parquet.html
   Workspace: https://docs.cloud.pola.rs/reference/workspace/workspace.html
   ComputeContext: https://docs.cloud.pola.rs/reference/compute/compute.html
-  LazyFrameExt: https://docs.cloud.pola.rs/reference/query/lazyframeext.html
+  LazyFrameRemote: https://docs.cloud.pola.rs/reference/query/lazyframe_remote.html
   QueryResult: https://docs.cloud.pola.rs/reference/query/query_result.html
   InteractiveQuery: https://docs.cloud.pola.rs/reference/query/interactive_query.html
   BatchQuery: https://docs.cloud.pola.rs/reference/query/batch_query.html

--- a/docs/source/polars-cloud/index.md
+++ b/docs/source/polars-cloud/index.md
@@ -40,7 +40,7 @@ pip install polars polars_cloud
 To run your query in the cloud, simply write Polars queries like you are used to, but call
 `LazyFrame.remote()` to indicate that the query should be run remotely.
 
-{{code_block('polars-cloud/index','index',['ComputeContext','LazyFrameExt'])}}
+{{code_block('polars-cloud/index','index',['ComputeContext','LazyFrameRemote'])}}
 
 ## Sign up today and start for free
 

--- a/docs/source/polars-cloud/quickstart.md
+++ b/docs/source/polars-cloud/quickstart.md
@@ -37,4 +37,4 @@ Now that we are done with the setup, we can start running queries. You can write
 used and to only need to call `.remote()` on your `LazyFrame`. In the following example we create a
 compute cluster and run a simple Polars query.
 
-{{code_block('polars-cloud/quickstart','general',['ComputeContext','LazyFrameExt'])}}
+{{code_block('polars-cloud/quickstart','general',['ComputeContext','LazyFrameRemote'])}}

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -7957,7 +7957,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         self,
         context: pc.ComputeContext | None = None,
         plan_type: pc._typing.PlanTypePreference = "dot",
-    ) -> pc.LazyFrameExt:
+    ) -> pc.LazyFrameRemote:
         """
         Run a query remotely on Polars Cloud.
 
@@ -8010,7 +8010,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └──────────┘
 
         """
-        return pc.LazyFrameExt(lf=self, context=context, plan_type=plan_type)
+        return pc.LazyFrameRemote(lf=self, context=context, plan_type=plan_type)
 
     @unstable()
     def match_to_schema(


### PR DESCRIPTION
Fixes type hints.
