### PR TITLE
fix: Allow encoding of `pl.Enum` with smaller physicals

### DIFF
--- a/crates/polars-json/src/json/write/serialize.rs
+++ b/crates/polars-json/src/json/write/serialize.rs
@@ -491,6 +491,20 @@ pub(crate) fn new_serializer<'a>(
             list_serializer::<i64>(array.as_any().downcast_ref().unwrap(), offset, take)
         },
         ArrowDataType::Dictionary(k, v, _) => match (k, &**v) {
+            (IntegerType::UInt8, ArrowDataType::Utf8View) => {
+                let array = array
+                    .as_any()
+                    .downcast_ref::<DictionaryArray<u8>>()
+                    .unwrap();
+                dictionary_utf8view_serializer::<u8>(array, offset, take)
+            },
+            (IntegerType::UInt16, ArrowDataType::Utf8View) => {
+                let array = array
+                    .as_any()
+                    .downcast_ref::<DictionaryArray<u16>>()
+                    .unwrap();
+                dictionary_utf8view_serializer::<u16>(array, offset, take)
+            },
             (IntegerType::UInt32, ArrowDataType::Utf8View) => {
                 let array = array
                     .as_any()

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -20,7 +20,7 @@ import pytest
 
 import polars as pl
 from polars.exceptions import ComputeError
-from polars.testing import assert_frame_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 
 def test_write_json() -> None:
@@ -632,3 +632,11 @@ def test_ndjson_22229() -> None:
     ]
 
     assert pl.read_ndjson(io.StringIO("\n".join(li))).to_dict(as_series=False)
+
+
+def test_json_encode_enum_23826() -> None:
+    s = pl.Series("a", ["b"], dtype=pl.Enum(["b"]))
+    assert_series_equal(
+        s.to_frame().select(c=pl.struct("a").struct.json_encode()).to_series(),
+        pl.Series("c", ['{"a":"0"}'], pl.String),
+    )


### PR DESCRIPTION
Fixes #23826.

It still produces a weird result because nested casting is broken, but at least it doesn't panic.