### PR TITLE
docs(python): Add example of `Series` as predicate

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -3178,6 +3178,18 @@ class Series:
                 1
                 3
         ]
+
+        Filter based on a predicate:
+        
+        >>> s = pl.Series("a", [1, 2, 3])
+        >>> s.filter(s==2)
+        shape: (1,)
+        Series: 'a' [i64]
+        [
+                2
+        ]
+
+        
         """
         if not isinstance(predicate, Series):
             predicate = Series("", predicate)


### PR DESCRIPTION
This PR adds an example to the docstring of `polars.Series.filter` that uses the series values as a predicate, which I have to imagine is at least as common as using a predefined filter mask.

I was also wondering if the following way to do the same operation should be implemented:
```python
s = pl.Series([1,2,3])
s.filter(pl.element()==2)
```

It at least _feels_ like it should work, and I see no reason not to. Also, there is a functional advantage in that this would allow filtering by the elements of a series that is not bound to a variable, such as
```python
filtered_series = df["my_column"].filter(pl.element()==2)
```