### PR TITLE
chore: Relax constraint on maximum Python version for `numba`

### DIFF
--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -18,7 +18,7 @@ pip
 polars-cloud
 # Interop
 numpy
-numba >= 0.54; python_version < '3.13'  # Numba can lag Python releases
+numba >= 0.54; python_version < '3.14'  # Numba can lag Python releases
 pandas
 pyarrow
 pydantic>=2.0.0


### PR DESCRIPTION
We didn't update this after `numba` added support for py3.13; can relax the constraint now.