### PR TITLE
fix: Fix error on empty range requests

### DIFF
--- a/crates/polars-io/src/cloud/polars_object_store.rs
+++ b/crates/polars-io/src/cloud/polars_object_store.rs
@@ -154,6 +154,10 @@ impl PolarsObjectStore {
     + TryStreamExt<Ok = Bytes, Error = PolarsError, Item = PolarsResult<Bytes>>
     + use<'a, T> {
         futures::stream::iter(ranges.map(move |range| async move {
+            if range.is_empty() {
+                return Ok(Bytes::new());
+            }
+
             let out = store
                 .get_range(path, range.start as u64..range.end as u64)
                 .await?;
@@ -164,6 +168,10 @@ impl PolarsObjectStore {
     }
 
     pub async fn get_range(&self, path: &Path, range: Range<usize>) -> PolarsResult<Bytes> {
+        if range.is_empty() {
+            return Ok(Bytes::new());
+        }
+
         self.try_exec_rebuild_on_err(move |store| {
             let range = range.clone();
             let st = store.clone();


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/23832

Return empty Bytes object if the range is empty. I've also opened an issue upstream at https://github.com/apache/arrow-rs-object-store/issues/453.

Note that I cannot reproduce the Python MRE in the issue, but I've tested this in the Rust side:

```
---- cloud::polars_object_store::tests::test_ stdout ----
[crates/polars-io/src/cloud/polars_object_store.rs:552:13] store.1.get_range(&object_path_from_str("iris.parquet").unwrap(), 0..0).await = Ok(
    b"",
)
[crates/polars-io/src/cloud/polars_object_store.rs:559:13] store.1.get_range(&object_path_from_str("iris.parquet").unwrap(), i32::MAX as usize..i32::MAX as usize).await = Ok(
    b"",
)
[crates/polars-io/src/cloud/polars_object_store.rs:566:13] store.1.get_ranges_sort(&object_path_from_str("iris.parquet").unwrap(), &mut
[0..0, 0..0]).await = Ok(
    {
        0: MemSlice {
            slice: [],
            inner: Bytes(
                b"",
            ),
        },
    },
)
```
