### PR TITLE
fix: Fix index out of bounds panic filtering parquet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3663,6 +3663,7 @@ dependencies = [
  "bytemuck",
  "bytes",
  "compact_str",
+ "either",
  "flate2",
  "foldhash",
  "hashbrown 0.15.4",

--- a/crates/polars-stream/src/async_primitives/opt_spawned_future.rs
+++ b/crates/polars-stream/src/async_primitives/opt_spawned_future.rs
@@ -52,7 +52,7 @@ where
     }
 }
 
-/// Parallelizes an iterator of futures across the computational async runtime.
+/// Parallelizes futures across the computational async runtime.
 ///
 /// As an optimization for cache access, the first future is kept on the current thread. If there
 /// is only 1 future, then all data is kept on the current thread and spawn is not called at all.
@@ -61,9 +61,6 @@ where
 ///
 /// Note that dropping the iterator will call abort on all spawned futures, as this is intended to be
 /// used for compute.
-///
-/// # Panics
-/// Panics if the iterator has less than `futures_iter_length` items.
 pub fn parallelize_first_to_local<I, F, O>(
     futures_iter: I,
 ) -> impl ExactSizeIterator<Item = impl Future<Output = O> + Send + 'static>

--- a/crates/polars-stream/src/async_primitives/opt_spawned_future.rs
+++ b/crates/polars-stream/src/async_primitives/opt_spawned_future.rs
@@ -1,17 +1,41 @@
 use pin_project_lite::pin_project;
+use polars_utils::enum_unit_vec::EnumUnitVec;
 
 use crate::async_executor::{AbortOnDropHandle, TaskPriority, spawn};
 
 pin_project! {
-    /// Represents a potentially spawned future.
-    #[project = OptSpawnedFutureProj]
-    pub enum OptSpawnedFuture<F, O> {
+    /// Represents a future that may either be local or spawned.
+    #[project = LocalOrSpawnedFutureProj]
+    pub enum LocalOrSpawnedFuture<F, O> {
         Local { #[pin] fut: F },
         Spawned { #[pin] handle: AbortOnDropHandle<O> }
     }
 }
 
-impl<F, O> Future for OptSpawnedFuture<F, O>
+impl<F, O> LocalOrSpawnedFuture<F, O>
+where
+    F: Future<Output = O>,
+{
+    /// Wraps the future in a `Local` variant.
+    pub fn new_local(fut: F) -> Self {
+        LocalOrSpawnedFuture::Local { fut }
+    }
+}
+
+impl<F, O> LocalOrSpawnedFuture<F, O>
+where
+    F: Future<Output = O> + Send + 'static,
+    O: Send + 'static,
+{
+    /// Spawns the future onto the async executor.
+    pub fn new_spawned(fut: F) -> Self {
+        LocalOrSpawnedFuture::Spawned {
+            handle: AbortOnDropHandle::new(spawn(TaskPriority::Low, fut)),
+        }
+    }
+}
+
+impl<F, O> Future for LocalOrSpawnedFuture<F, O>
 where
     F: Future<Output = O>,
 {
@@ -22,8 +46,8 @@ where
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Self::Output> {
         match self.project() {
-            OptSpawnedFutureProj::Local { fut } => fut.poll(cx),
-            OptSpawnedFutureProj::Spawned { handle } => handle.poll(cx),
+            LocalOrSpawnedFutureProj::Local { fut } => fut.poll(cx),
+            LocalOrSpawnedFutureProj::Spawned { handle } => handle.poll(cx),
         }
     }
 }
@@ -33,31 +57,49 @@ where
 /// As an optimization for cache access, the first future is kept on the current thread. If there
 /// is only 1 future, then all data is kept on the current thread and spawn is not called at all.
 ///
-/// Note this means the first future in the returned Vec does not run until polled.
+/// Note this means the first future in the returned iterator does not run until polled.
 ///
-/// Note that dropping the Vec will call abort on all spawned futures, as this is intended to be
+/// Note that dropping the iterator will call abort on all spawned futures, as this is intended to be
 /// used for compute.
 ///
 /// # Panics
 /// Panics if the iterator has less than `futures_iter_length` items.
-pub fn parallelize_first_to_local<I, F, O>(mut futures_iter: I) -> Vec<OptSpawnedFuture<F, O>>
+pub fn parallelize_first_to_local<I, F, O>(
+    futures_iter: I,
+) -> impl ExactSizeIterator<Item = impl Future<Output = O> + Send + 'static>
 where
     I: Iterator<Item = F>,
     F: Future<Output = O> + Send + 'static,
     O: Send + 'static,
 {
-    let mut futures = Vec::with_capacity(futures_iter.size_hint().1.unwrap_or(0));
+    parallelize_first_to_local_impl(futures_iter).into_iter()
+}
 
+fn parallelize_first_to_local_impl<I, F, O>(
+    mut futures_iter: I,
+) -> EnumUnitVec<LocalOrSpawnedFuture<F, O>>
+where
+    I: Iterator<Item = F>,
+    F: Future<Output = O> + Send + 'static,
+    O: Send + 'static,
+{
     let Some(first_fut) = futures_iter.next() else {
-        return futures;
+        return EnumUnitVec::new();
     };
 
-    // The local future must come first to ensure we don't block polling it.
-    futures.push(OptSpawnedFuture::Local { fut: first_fut });
+    let first_fut = LocalOrSpawnedFuture::new_local(first_fut);
 
-    futures.extend(futures_iter.map(|fut| OptSpawnedFuture::Spawned {
-        handle: AbortOnDropHandle::new(spawn(TaskPriority::Low, fut)),
-    }));
+    let Some(second_fut) = futures_iter.next() else {
+        return EnumUnitVec::new_single(first_fut);
+    };
 
-    futures
+    let mut futures = Vec::with_capacity(2 + futures_iter.size_hint().0);
+
+    // Note:
+    // * The local future must come first to ensure we don't block polling it.
+    // * Remaining futures must all be spawned upfront into the Vec for them to run parallel.
+    futures.extend([first_fut, LocalOrSpawnedFuture::new_spawned(second_fut)]);
+    futures.extend(futures_iter.map(LocalOrSpawnedFuture::new_spawned));
+
+    EnumUnitVec::from(futures)
 }

--- a/crates/polars-stream/src/async_primitives/opt_spawned_future.rs
+++ b/crates/polars-stream/src/async_primitives/opt_spawned_future.rs
@@ -28,7 +28,7 @@ where
     O: Send + 'static,
 {
     /// Spawns the future onto the async executor.
-    pub fn new_spawned(fut: F) -> Self {
+    pub fn spawn(fut: F) -> Self {
         LocalOrSpawnedFuture::Spawned {
             handle: AbortOnDropHandle::new(spawn(TaskPriority::Low, fut)),
         }
@@ -98,8 +98,8 @@ where
     // Note:
     // * The local future must come first to ensure we don't block polling it.
     // * Remaining futures must all be spawned upfront into the Vec for them to run parallel.
-    futures.extend([first_fut, LocalOrSpawnedFuture::new_spawned(second_fut)]);
-    futures.extend(futures_iter.map(LocalOrSpawnedFuture::new_spawned));
+    futures.extend([first_fut, LocalOrSpawnedFuture::spawn(second_fut)]);
+    futures.extend(futures_iter.map(LocalOrSpawnedFuture::spawn));
 
     EnumUnitVec::from(futures)
 }

--- a/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
@@ -237,7 +237,7 @@ impl ParquetReadImpl {
     pub(super) fn init_row_group_decoder(&mut self) -> RowGroupDecoder {
         let projected_arrow_fields = self.projected_arrow_fields.clone();
         let row_index = self.row_index.clone();
-        let min_values_per_thread = self.config.min_values_per_thread;
+        let target_values_per_thread = self.config.target_values_per_thread;
         let predicate = self.predicate.clone();
 
         let mut use_prefiltered = matches!(self.options.parallel, ParallelStrategy::Prefiltered);
@@ -298,7 +298,7 @@ impl ParquetReadImpl {
             use_prefiltered,
             predicate_field_indices,
             non_predicate_field_indices,
-            min_values_per_thread,
+            target_values_per_thread,
         }
     }
 }

--- a/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
@@ -209,10 +209,7 @@ impl FileReader for ParquetFileReader {
         let target_values_per_thread =
             std::env::var("POLARS_PARQUET_DECODE_TARGET_VALUES_PER_THREAD")
                 .map(|x| x.parse::<usize>().expect("integer").max(1))
-                .unwrap_or(
-                    // ((1 << 24) + (1 << 23)) // 2
-                    12_582_912,
-                );
+                .unwrap_or(16_777_216);
 
         let is_full_projection = projected_arrow_fields.len() == file_schema.len();
 

--- a/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
@@ -206,9 +206,13 @@ impl FileReader for ParquetFileReader {
         let row_group_prefetch_size = polars_core::config::get_rg_prefetch_size();
 
         // This can be set to 1 to force column-per-thread parallelism, e.g. for bug reproduction.
-        let min_values_per_thread = std::env::var("POLARS_MIN_VALUES_PER_THREAD")
-            .map(|x| x.parse::<usize>().expect("integer").max(1))
-            .unwrap_or(16_777_216);
+        let target_values_per_thread =
+            std::env::var("POLARS_PARQUET_DECODE_TARGET_VALUES_PER_THREAD")
+                .map(|x| x.parse::<usize>().expect("integer").max(1))
+                .unwrap_or(
+                    // ((1 << 24) + (1 << 23)) // 2
+                    12_582_912,
+                );
 
         let is_full_projection = projected_arrow_fields.len() == file_schema.len();
 
@@ -245,7 +249,7 @@ impl FileReader for ParquetFileReader {
             config: io_sources::parquet::Config {
                 num_pipelines,
                 row_group_prefetch_size,
-                min_values_per_thread,
+                target_values_per_thread,
             },
             verbose,
             memory_prefetch_func,
@@ -343,7 +347,7 @@ struct Config {
     row_group_prefetch_size: usize,
     /// Minimum number of values for a parallel spawned task to process to amortize
     /// parallelism overhead.
-    min_values_per_thread: usize,
+    target_values_per_thread: usize,
 }
 
 impl ParquetReadImpl {

--- a/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
@@ -336,9 +336,10 @@ fn calc_cols_per_thread(n_rows_per_col: usize, target_n_rows_per_thread: usize) 
     }
 
     let n = target_n_rows_per_thread / n_rows_per_col;
-    let distance = target_n_rows_per_thread % n_rows_per_col;
+    let floor_distance = target_n_rows_per_thread % n_rows_per_col;
+    let ceil_distance = n_rows_per_col - floor_distance;
 
-    if distance <= n_rows_per_col - distance {
+    if floor_distance <= ceil_distance {
         n.max(1)
     } else {
         n + 1

--- a/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
@@ -15,6 +15,7 @@ use polars_io::prelude::_internal::calc_prefilter_cost;
 use polars_io::prelude::try_set_sorted_flag;
 use polars_parquet::read::{Filter, ParquetType, PredicateFilter, PrimitiveLogicalType};
 use polars_utils::IdxSize;
+use polars_utils::enum_unit_vec::EnumUnitVec;
 use polars_utils::pl_str::PlSmallStr;
 
 use super::row_group_data_fetch::RowGroupData;
@@ -33,7 +34,7 @@ pub(super) struct RowGroupDecoder {
     pub(super) predicate_field_indices: Arc<[usize]>,
     /// Indices into `projected_arrow_fields. This must be sorted.
     pub(super) non_predicate_field_indices: Arc<[usize]>,
-    pub(super) min_values_per_thread: usize,
+    pub(super) target_values_per_thread: usize,
 }
 
 impl RowGroupDecoder {
@@ -97,7 +98,8 @@ impl RowGroupDecoder {
             let mask = mask.bool().unwrap();
 
             let filtered =
-                unsafe { filter_cols(df.take_columns(), mask, self.min_values_per_thread) }.await?;
+                unsafe { filter_cols(df.take_columns(), mask, self.target_values_per_thread) }
+                    .await?;
 
             let height = if let Some(fst) = filtered.first() {
                 fst.len()
@@ -172,31 +174,10 @@ impl RowGroupDecoder {
             }
         };
 
-        let Some((cols_per_thread, _)) = calc_cols_per_thread(
+        let cols_per_thread = calc_cols_per_thread(
             row_group_data.row_group_metadata.num_rows(),
-            projected_arrow_fields.len(),
-            self.min_values_per_thread,
-        ) else {
-            // Single-threaded
-            for s in (0..projected_arrow_fields.len()).map(|i| {
-                let projection = &projected_arrow_fields[get_projected_field_at_output_index(i)];
-
-                let (col, pred_true_mask) = decode_column(
-                    projection.arrow_field(),
-                    row_group_data,
-                    filter.clone(),
-                    expected_num_rows,
-                )?;
-
-                let col = projection.apply_transform(col)?;
-
-                PolarsResult::Ok((col, pred_true_mask))
-            }) {
-                out_vec.push(s?.0)
-            }
-
-            return Ok(());
-        };
+            self.target_values_per_thread,
+        );
 
         let projected_arrow_fields = projected_arrow_fields.clone();
         let row_group_data_2 = row_group_data.clone();
@@ -236,7 +217,7 @@ impl RowGroupDecoder {
 
                                     Ok((col, pred_true_mask))
                                 })
-                                .collect::<PolarsResult<Vec<_>>>()
+                                .collect::<PolarsResult<EnumUnitVec<_>>>()
                         }
                     }),
             )
@@ -314,24 +295,15 @@ fn decode_column(
 /// # Safety
 /// All series in `cols` have the same length.
 async unsafe fn filter_cols(
-    mut cols: Vec<Column>,
+    cols: Vec<Column>,
     mask: &BooleanChunked,
-    min_values_per_thread: usize,
+    target_values_per_thread: usize,
 ) -> PolarsResult<Vec<Column>> {
     if cols.is_empty() {
         return Ok(cols);
     }
 
-    let Some((cols_per_thread, _)) =
-        calc_cols_per_thread(cols[0].len(), cols.len(), min_values_per_thread)
-    else {
-        for s in cols.iter_mut() {
-            *s = s.filter(mask)?;
-        }
-
-        return Ok(cols);
-    };
-
+    let cols_per_thread = calc_cols_per_thread(cols[0].len(), target_values_per_thread);
     let mut out_vec = Vec::with_capacity(cols.len());
     let cols = Arc::new(cols);
     let mask = mask.clone();
@@ -344,9 +316,9 @@ async unsafe fn filter_cols(
             let cols = cols.clone();
             let mask = mask.clone();
             async move {
-                (offset..offset + cols_per_thread)
+                (offset..offset.saturating_add(cols_per_thread).min(cols.len()))
                     .map(|i| cols[i].filter(&mask))
-                    .collect::<PolarsResult<Vec<_>>>()
+                    .collect::<PolarsResult<EnumUnitVec<_>>>()
             }
         }))
     };
@@ -358,25 +330,19 @@ async unsafe fn filter_cols(
     Ok(out_vec)
 }
 
-/// Returns `Some((n_cols_per_thread, n_remainder))` if at least 2 tasks with >= `min_values_per_thread` can be created.
-fn calc_cols_per_thread(
-    n_rows_per_col: usize,
-    n_cols: usize,
-    min_values_per_thread: usize,
-) -> Option<(usize, usize)> {
-    let cols_per_thread = 1 + min_values_per_thread / n_rows_per_col.max(1);
+fn calc_cols_per_thread(n_rows_per_col: usize, target_n_rows_per_thread: usize) -> usize {
+    if n_rows_per_col == 0 {
+        return usize::MAX;
+    }
 
-    let cols_per_thread = if n_rows_per_col >= min_values_per_thread {
-        1
+    let n = target_n_rows_per_thread / n_rows_per_col;
+    let distance = target_n_rows_per_thread % n_rows_per_col;
+
+    if distance <= n_rows_per_col - distance {
+        n.max(1)
     } else {
-        cols_per_thread
-    };
-
-    // At least 2 fully saturated tasks according to floordiv.
-    let parallel = n_cols / cols_per_thread >= 2;
-    let remainder = n_cols % cols_per_thread;
-
-    parallel.then_some((cols_per_thread, remainder))
+        n + 1
+    }
 }
 
 // Pre-filtered
@@ -509,7 +475,7 @@ impl RowGroupDecoder {
 
                                     Ok((col, pred_true_mask))
                                 })
-                                .collect::<PolarsResult<Vec<_>>>()
+                                .collect::<PolarsResult<EnumUnitVec<_>>>()
                         }
                     }),
             )
@@ -566,7 +532,7 @@ impl RowGroupDecoder {
             }
 
             let filtered =
-                unsafe { filter_cols(live_df.take_columns(), mask, self.min_values_per_thread) }
+                unsafe { filter_cols(live_df.take_columns(), mask, self.target_values_per_thread) }
                     .await?;
 
             let filtered_height = if let Some(fst) = filtered.first() {
@@ -618,12 +584,12 @@ impl RowGroupDecoder {
                     let projected_arrow_fields = projected_arrow_fields.clone();
                     let mask = mask.clone();
                     let mask_bitmap = mask_bitmap.clone();
-                    let max_col = offset
-                        .saturating_add(cols_per_thread)
-                        .min(non_predicate_len);
 
                     async move {
-                        (offset..max_col)
+                        (offset
+                            ..offset
+                                .saturating_add(cols_per_thread)
+                                .min(non_predicate_len))
                             .map(|i| {
                                 let projection =
                                     &projected_arrow_fields[non_predicate_field_indices[i]];
@@ -640,7 +606,7 @@ impl RowGroupDecoder {
 
                                 projection.apply_transform(col)
                             })
-                            .collect::<PolarsResult<Vec<_>>>()
+                            .collect::<PolarsResult<EnumUnitVec<_>>>()
                     }
                 },
             ))
@@ -731,17 +697,34 @@ mod tests {
     fn test_calc_cols_per_thread() {
         use super::calc_cols_per_thread;
 
-        let n_rows = 3;
-        let n_cols = 11;
-        let min_vals = 5;
-        assert_eq!(calc_cols_per_thread(n_rows, n_cols, min_vals), Some((2, 1)));
+        assert_eq!(
+            [
+                calc_cols_per_thread(0, 5),
+                calc_cols_per_thread(1, 5),
+                calc_cols_per_thread(2, 5),
+                calc_cols_per_thread(3, 5),
+                calc_cols_per_thread(4, 5),
+                calc_cols_per_thread(5, 5),
+            ],
+            [usize::MAX, 5, 2, 2, 1, 1]
+        );
 
-        let n_rows = 6;
-        let n_cols = 11;
-        let min_vals = 5;
-        assert_eq!(calc_cols_per_thread(n_rows, n_cols, min_vals), Some((1, 0)));
+        assert_eq!(
+            [
+                calc_cols_per_thread(11_184_810, 16_777_216),
+                calc_cols_per_thread(11_184_811 + 1, 16_777_216),
+            ],
+            [2, 1]
+        );
 
-        calc_cols_per_thread(0, 1, 1);
-        calc_cols_per_thread(1, 0, 1);
+        assert_eq!(
+            [
+                calc_cols_per_thread(0, 0),
+                calc_cols_per_thread(0, 99),
+                calc_cols_per_thread(99, 0),
+                calc_cols_per_thread(99, 99),
+            ],
+            [usize::MAX, usize::MAX, 1, 1],
+        )
     }
 }

--- a/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
@@ -98,8 +98,7 @@ impl RowGroupDecoder {
             let mask = mask.bool().unwrap();
 
             let filtered =
-                unsafe { filter_cols(df.take_columns(), mask, self.target_values_per_thread) }
-                    .await?;
+                filter_cols(df.take_columns(), mask, self.target_values_per_thread).await?;
 
             let height = if let Some(fst) = filtered.first() {
                 fst.len()
@@ -292,9 +291,8 @@ fn decode_column(
     Ok((series.into_column(), pred_true_mask))
 }
 
-/// # Safety
-/// All series in `cols` have the same length.
-async unsafe fn filter_cols(
+/// Filters columns, in parallel depending number of rows / columns.
+async fn filter_cols(
     cols: Vec<Column>,
     mask: &BooleanChunked,
     target_values_per_thread: usize,
@@ -533,8 +531,7 @@ impl RowGroupDecoder {
             }
 
             let filtered =
-                unsafe { filter_cols(live_df.take_columns(), mask, self.target_values_per_thread) }
-                    .await?;
+                filter_cols(live_df.take_columns(), mask, self.target_values_per_thread).await?;
 
             let filtered_height = if let Some(fst) = filtered.first() {
                 fst.len()

--- a/crates/polars-utils/Cargo.toml
+++ b/crates/polars-utils/Cargo.toml
@@ -13,6 +13,7 @@ bincode = { workspace = true, optional = true }
 bytemuck = { workspace = true }
 bytes = { workspace = true }
 compact_str = { workspace = true }
+either = { workspace = true }
 flate2 = { workspace = true, default-features = true, optional = true }
 foldhash = { workspace = true }
 hashbrown = { workspace = true }

--- a/crates/polars-utils/src/enum_unit_vec.rs
+++ b/crates/polars-utils/src/enum_unit_vec.rs
@@ -1,0 +1,74 @@
+use either::Either;
+
+/// List of items where a single item is stored on the stack.
+/// Similar to UnitVec, but without size / alignment limitations.
+#[derive(Debug, Clone)]
+pub struct EnumUnitVec<T>(Either<[T; 1], Vec<T>>);
+
+impl<T> EnumUnitVec<T> {
+    pub const fn new() -> Self {
+        Self(Either::Right(Vec::new()))
+    }
+
+    pub fn new_single(value: T) -> Self {
+        Self(Either::Left([value]))
+    }
+}
+
+impl<T> Default for EnumUnitVec<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> std::ops::Deref for EnumUnitVec<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        AsRef::as_ref(&self.0)
+    }
+}
+
+impl<T> std::ops::DerefMut for EnumUnitVec<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        AsMut::as_mut(&mut self.0)
+    }
+}
+
+impl<T> From<Vec<T>> for EnumUnitVec<T> {
+    fn from(value: Vec<T>) -> Self {
+        Self(Either::Right(value))
+    }
+}
+
+impl<T> IntoIterator for EnumUnitVec<T> {
+    type IntoIter = Either<<[T; 1] as IntoIterator>::IntoIter, <Vec<T> as IntoIterator>::IntoIter>;
+    type Item = T;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self.0 {
+            Either::Left(v) => Either::Left(v.into_iter()),
+            Either::Right(v) => Either::Right(v.into_iter()),
+        }
+    }
+}
+
+impl<T> FromIterator<T> for EnumUnitVec<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut iter = iter.into_iter();
+
+        let Some(first) = iter.next() else {
+            return Self::new();
+        };
+
+        let Some(second) = iter.next() else {
+            return Self::new_single(first);
+        };
+
+        let mut vec = Vec::with_capacity(iter.size_hint().0 + 2);
+        vec.push(first);
+        vec.push(second);
+        vec.extend(iter);
+        Self::from(vec)
+    }
+}

--- a/crates/polars-utils/src/enum_unit_vec.rs
+++ b/crates/polars-utils/src/enum_unit_vec.rs
@@ -10,7 +10,7 @@ impl<T> EnumUnitVec<T> {
         Self(Either::Right(Vec::new()))
     }
 
-    pub fn new_single(value: T) -> Self {
+    pub const fn new_single(value: T) -> Self {
         Self(Either::Left([value]))
     }
 }

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -16,6 +16,7 @@ pub mod chunks;
 pub mod clmul;
 mod config;
 pub mod cpuid;
+pub mod enum_unit_vec;
 pub mod error;
 pub mod floor_divmod;
 pub mod functions;

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -1172,3 +1172,20 @@ def test_prefilter_with_n_rows_23790() -> None:
             }
         ),
     )
+
+
+def test_scan_parquet_filter_index_panic_23849(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POLARS_PARQUET_DECODE_TARGET_VALUES_PER_THREAD", "5")
+    num_rows = 3
+    num_cols = 5
+
+    f = io.BytesIO()
+
+    pl.select(
+        **{f"col_{i}": pl.int_range(0, num_rows) for i in range(num_cols)}
+    ).write_parquet(f)
+
+    for parallel in ["auto", "columns", "row_groups", "prefiltered", "none"]:
+        pl.scan_parquet(f, parallel=parallel).filter(
+            pl.col("col_0").ge(0) & pl.col("col_0").lt(num_rows + 1)
+        ).collect()

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -1182,10 +1182,10 @@ def test_scan_parquet_filter_index_panic_23849(monkeypatch: pytest.MonkeyPatch) 
     f = io.BytesIO()
 
     pl.select(
-        **{f"col_{i}": pl.int_range(0, num_rows) for i in range(num_cols)}
+        pl.int_range(0, num_rows).alias(f"col_{i}") for i in range(num_cols)
     ).write_parquet(f)
 
     for parallel in ["auto", "columns", "row_groups", "prefiltered", "none"]:
-        pl.scan_parquet(f, parallel=parallel).filter(
+        pl.scan_parquet(f, parallel=parallel).filter(  # type: ignore[arg-type]
             pl.col("col_0").ge(0) & pl.col("col_0").lt(num_rows + 1)
         ).collect()


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/23849

We currently have different codepaths depending on the amount of rows. One of these codepaths contained the bug in the issue.

This PR removes the extra row count dependent codepaths. The original motivation was to reduce task spawns / Vec allocations for small data sizes, but after this PR the overhead should be fairly minimal as we are using `parallelize_first_to_local` (added in https://github.com/pola-rs/polars/pull/22458) with a newly added `EnumUnitVec`.

#### `EnumUnitVec`
A new `EnumUnitVec` is added that stores length-1 lists on the stack. This is used instead of a `Vec` and reduces allocations when e.g.:
* There is only a single future from `parallelize_first_to_local`
* Decoding / filtering tasks each return only a single column

Note that the existing `UnitVec` could not be used due to the size limitation on `T`.

#### Other changes
* Simplified the logic in `calc_cols_per_thread()`. It now simply chooses between the floor or ceiling division based on the abs_diff to the target number of rows we want per-thread.
  * The `POLARS_MIN_VALUES_PER_THREAD` environment variable has been changed to `POLARS_PARQUET_DECODE_TARGET_VALUES_PER_THREAD`
  * `min_values_*` etc. have been renamed to `target_values*`.
