### PR TITLE
chore(rust): Update Rust Polars versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "polars"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "apache-avro",
  "avro-schema",
@@ -3062,7 +3062,7 @@ dependencies = [
 
 [[package]]
 name = "polars-arrow"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "async-stream",
  "atoi_simd",
@@ -3112,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "polars-compute"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "atoi_simd",
  "bytemuck",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "polars-core"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "bincode",
  "bitflags",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "polars-doc-examples"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",
@@ -3189,7 +3189,7 @@ dependencies = [
 
 [[package]]
 name = "polars-dtype"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "boxcar",
  "hashbrown 0.15.4",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "polars-dylib"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "polars",
  "polars-arrow",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "polars-error"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "avro-schema",
  "object_store",
@@ -3231,7 +3231,7 @@ dependencies = [
 
 [[package]]
 name = "polars-expr"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.4",
@@ -3253,7 +3253,7 @@ dependencies = [
 
 [[package]]
 name = "polars-ffi"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "polars-arrow",
  "polars-core",
@@ -3261,7 +3261,7 @@ dependencies = [
 
 [[package]]
 name = "polars-io"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "async-trait",
  "atoi_simd",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "polars-json"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "polars-lazy"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "bitflags",
  "chrono",
@@ -3359,7 +3359,7 @@ dependencies = [
 
 [[package]]
 name = "polars-mem-engine"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "futures",
  "memmap2",
@@ -3381,7 +3381,7 @@ dependencies = [
 
 [[package]]
 name = "polars-ops"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "aho-corasick",
  "argminmax",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "polars-parquet"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -3463,7 +3463,7 @@ dependencies = [
 
 [[package]]
 name = "polars-plan"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "polars-python"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "arboard",
  "bincode",
@@ -3545,7 +3545,7 @@ dependencies = [
 
 [[package]]
 name = "polars-row"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "polars-schema"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "indexmap 2.10.0",
  "polars-error",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "polars-sql"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "bitflags",
  "hex",
@@ -3590,7 +3590,7 @@ dependencies = [
 
 [[package]]
 name = "polars-stream"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3626,7 +3626,7 @@ dependencies = [
 
 [[package]]
 name = "polars-testing"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "polars-core",
  "polars-ops",
@@ -3634,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "polars-time"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "atoi_simd",
  "bytemuck",
@@ -3657,7 +3657,7 @@ dependencies = [
 
 [[package]]
 name = "polars-utils"
-version = "0.49.1"
+version = "0.50.0"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -3875,7 +3875,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-polars"
-version = "0.21.0"
+version = "0.23.0"
 dependencies = [
  "libc",
  "once_cell",
@@ -3896,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-polars-derive"
-version = "0.15.0"
+version = "0.17.0"
 dependencies = [
  "polars-arrow",
  "polars-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.49.1"
+version = "0.50.0"
 authors = ["Ritchie Vink <ritchie46@gmail.com>"]
 edition = "2024"
 homepage = "https://www.pola.rs/"
@@ -102,31 +102,31 @@ version_check = "0.9.4"
 xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
 zstd = "0.13"
 
-polars = { version = "0.49.1", path = "crates/polars", default-features = false }
-polars-compute = { version = "0.49.1", path = "crates/polars-compute", default-features = false }
-polars-core = { version = "0.49.1", path = "crates/polars-core", default-features = false }
-polars-dtype = { version = "0.49.1", path = "crates/polars-dtype", default-features = false }
-polars-dylib = { version = "0.49.1", path = "crates/polars-dylib", default-features = false }
-polars-error = { version = "0.49.1", path = "crates/polars-error", default-features = false }
-polars-expr = { version = "0.49.1", path = "crates/polars-expr", default-features = false }
-polars-ffi = { version = "0.49.1", path = "crates/polars-ffi", default-features = false }
-polars-io = { version = "0.49.1", path = "crates/polars-io", default-features = false }
-polars-json = { version = "0.49.1", path = "crates/polars-json", default-features = false }
-polars-lazy = { version = "0.49.1", path = "crates/polars-lazy", default-features = false }
-polars-mem-engine = { version = "0.49.1", path = "crates/polars-mem-engine", default-features = false }
-polars-ops = { version = "0.49.1", path = "crates/polars-ops", default-features = false }
-polars-parquet = { version = "0.49.1", path = "crates/polars-parquet", default-features = false }
-polars-plan = { version = "0.49.1", path = "crates/polars-plan", default-features = false }
-polars-python = { version = "0.49.1", path = "crates/polars-python", default-features = false }
-polars-row = { version = "0.49.1", path = "crates/polars-row", default-features = false }
-polars-schema = { version = "0.49.1", path = "crates/polars-schema", default-features = false }
-polars-sql = { version = "0.49.1", path = "crates/polars-sql", default-features = false }
-polars-stream = { version = "0.49.1", path = "crates/polars-stream", default-features = false }
-polars-testing = { version = "0.49.1", path = "crates/polars-testing", default-features = false }
-polars-time = { version = "0.49.1", path = "crates/polars-time", default-features = false }
-polars-utils = { version = "0.49.1", path = "crates/polars-utils", default-features = false }
-pyo3-polars = { version = "0.21.0", path = "pyo3-polars/pyo3-polars" }
-pyo3-polars-derive = { version = "0.15.0", path = "pyo3-polars/pyo3-polars-derive" }
+polars = { version = "0.50.0", path = "crates/polars", default-features = false }
+polars-compute = { version = "0.50.0", path = "crates/polars-compute", default-features = false }
+polars-core = { version = "0.50.0", path = "crates/polars-core", default-features = false }
+polars-dtype = { version = "0.50.0", path = "crates/polars-dtype", default-features = false }
+polars-dylib = { version = "0.50.0", path = "crates/polars-dylib", default-features = false }
+polars-error = { version = "0.50.0", path = "crates/polars-error", default-features = false }
+polars-expr = { version = "0.50.0", path = "crates/polars-expr", default-features = false }
+polars-ffi = { version = "0.50.0", path = "crates/polars-ffi", default-features = false }
+polars-io = { version = "0.50.0", path = "crates/polars-io", default-features = false }
+polars-json = { version = "0.50.0", path = "crates/polars-json", default-features = false }
+polars-lazy = { version = "0.50.0", path = "crates/polars-lazy", default-features = false }
+polars-mem-engine = { version = "0.50.0", path = "crates/polars-mem-engine", default-features = false }
+polars-ops = { version = "0.50.0", path = "crates/polars-ops", default-features = false }
+polars-parquet = { version = "0.50.0", path = "crates/polars-parquet", default-features = false }
+polars-plan = { version = "0.50.0", path = "crates/polars-plan", default-features = false }
+polars-python = { version = "0.50.0", path = "crates/polars-python", default-features = false }
+polars-row = { version = "0.50.0", path = "crates/polars-row", default-features = false }
+polars-schema = { version = "0.50.0", path = "crates/polars-schema", default-features = false }
+polars-sql = { version = "0.50.0", path = "crates/polars-sql", default-features = false }
+polars-stream = { version = "0.50.0", path = "crates/polars-stream", default-features = false }
+polars-testing = { version = "0.50.0", path = "crates/polars-testing", default-features = false }
+polars-time = { version = "0.50.0", path = "crates/polars-time", default-features = false }
+polars-utils = { version = "0.50.0", path = "crates/polars-utils", default-features = false }
+pyo3-polars = { version = "0.23.0", path = "pyo3-polars/pyo3-polars" }
+pyo3-polars-derive = { version = "0.17.0", path = "pyo3-polars/pyo3-polars-derive" }
 
 [workspace.dependencies.arrow-format]
 package = "polars-arrow-format"
@@ -134,7 +134,7 @@ version = "0.2.0"
 
 [workspace.dependencies.arrow]
 package = "polars-arrow"
-version = "0.49.1"
+version = "0.50.0"
 path = "crates/polars-arrow"
 default-features = false
 features = [

--- a/crates/Makefile
+++ b/crates/Makefile
@@ -114,6 +114,7 @@ publish:  ## Publish Polars crates
 	cargo publish --allow-dirty -p polars-schema
 	cargo publish --allow-dirty -p polars-arrow
 	cargo publish --allow-dirty -p polars-compute
+	cargo publish --allow-dirty -p polars-dtype
 	cargo publish --allow-dirty -p polars-row
 	cargo publish --allow-dirty -p polars-json
 	cargo publish --allow-dirty -p polars-core

--- a/crates/polars-testing/README.md
+++ b/crates/polars-testing/README.md
@@ -9,7 +9,7 @@ To use `polars-testing`, add it as a dependency to your Rust project's `Cargo.to
 
 ```toml
 [dependencies]
-polars-testing = "0.49.1"
+polars-testing = "0.50.0"
 ```
 
 You can then import the crate in your Rust code using:

--- a/pyo3-polars/pyo3-polars-derive/Cargo.toml
+++ b/pyo3-polars/pyo3-polars-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-polars-derive"
-version = "0.15.0"
+version = "0.17.0"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/pyo3-polars/pyo3-polars/Cargo.toml
+++ b/pyo3-polars/pyo3-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-polars"
-version = "0.21.0"
+version = "0.23.0"
 edition = "2021"
 license = "MIT"
 readme = "../README.md"


### PR DESCRIPTION
The pyo3-polars versions jumped because an older version seems to have been vendored. 