### PR TITLE
fix: `read_csv` respect Decimal schema for header-only data

### DIFF
--- a/crates/polars-io/src/csv/read/read_impl.rs
+++ b/crates/polars-io/src/csv/read/read_impl.rs
@@ -345,6 +345,9 @@ impl<'a> CoreReader<'a> {
                         .collect::<Schema>(),
                 )
             };
+
+            cast_columns(&mut df, &self.to_cast, false, self.ignore_errors)?;
+
             if let Some(ref row_index) = self.row_index {
                 df.insert_column(0, Series::new_empty(row_index.name.clone(), &IDX_DTYPE))?;
             }

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2784,3 +2784,10 @@ def test_stop_split_fields_simd_23651() -> None:
     df = pl.read_csv(buf, truncate_ragged_lines=True, has_header=False, schema=schema)
     assert df.shape == (7, 27)
     assert df["column_26"].null_count() == 7
+
+
+def test_read_csv_decimal_header_only_200008() -> None:
+    csv = "a,b"
+
+    df = pl.read_csv(csv.encode(), schema={"a": pl.Decimal(scale=2), "b": pl.String})
+    assert df.dtypes == [pl.Decimal(scale=2), pl.String]


### PR DESCRIPTION
Fixes #20008

The codepath for header-only data does not account for `to_cast` which leads to a schema mismatch.

Before:

```python
pl.read_csv(b"a,b", schema={"a": pl.Decimal(scale=2), "b": pl.String})
# shape: (0, 2)
# ┌─────┬─────┐
# │ a   ┆ b   │
# │ --- ┆ --- │
# │ str ┆ str │
# ╞═════╪═════╡
# └─────┴─────┘
```

After:

```python
pl.read_csv(b"a,b", schema={"a": pl.Decimal(scale=2), "b": pl.String})
# shape: (0, 2)
# ┌──────────────┬─────┐
# │ a            ┆ b   │
# │ ---          ┆ --- │
# │ decimal[*,2] ┆ str │
# ╞══════════════╪═════╡
# └──────────────┴─────┘
```
