### PR TITLE
feat: Lower `unique_counts` and `value_counts` to streaming engine

### DIFF
--- a/crates/polars-stream/Cargo.toml
+++ b/crates/polars-stream/Cargo.toml
@@ -36,9 +36,9 @@ polars-core = { workspace = true, features = ["partition_by"] }
 polars-error = { workspace = true }
 polars-expr = { workspace = true }
 polars-mem-engine = { workspace = true }
-polars-ops = { workspace = true, features = ["rle"] }
+polars-ops = { workspace = true, features = ["rle", "unique_counts"] }
 polars-parquet = { workspace = true }
-polars-plan = { workspace = true, features = ["cse", "rle"] }
+polars-plan = { workspace = true, features = ["cse", "rle", "unique_counts"] }
 
 [build-dependencies]
 version_check = { workspace = true }

--- a/crates/polars-stream/Cargo.toml
+++ b/crates/polars-stream/Cargo.toml
@@ -36,9 +36,9 @@ polars-core = { workspace = true, features = ["partition_by"] }
 polars-error = { workspace = true }
 polars-expr = { workspace = true }
 polars-mem-engine = { workspace = true }
-polars-ops = { workspace = true, features = ["rle", "unique_counts"] }
+polars-ops = { workspace = true, features = ["rle", "unique_counts", "dtype-struct"] }
 polars-parquet = { workspace = true }
-polars-plan = { workspace = true, features = ["cse", "rle", "unique_counts"] }
+polars-plan = { workspace = true, features = ["cse", "rle", "unique_counts", "dtype-struct"] }
 
 [build-dependencies]
 version_check = { workspace = true }

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use polars_core::chunked_array::cast::CastOptions;
 use polars_core::frame::DataFrame;
-use polars_core::prelude::{DataType, Field, InitHashMaps, PlHashMap, PlHashSet};
+use polars_core::prelude::{DataType, Field, IDX_DTYPE, InitHashMaps, PlHashMap, PlHashSet};
 use polars_core::schema::{Schema, SchemaExt};
 use polars_error::PolarsResult;
 use polars_expr::state::ExecutionState;
@@ -735,6 +735,133 @@ fn lower_exprs_with_ctx(
                 )?;
                 input_streams.insert(group_by_stream);
                 transformed_exprs.push(ctx.expr_arena.add(AExpr::Column(tmp_name)));
+            },
+
+            AExpr::Function {
+                input: ref inner_exprs,
+                function: IRFunctionExpr::UniqueCounts,
+                options: _,
+            } => {
+                // Transform:
+                //    expr.unique_counts().alias(name)
+                //      ->
+                //    .select(expr.alias(name))
+                //    .group_by(_ = name, maintain_order=True)
+                //      .agg(name = pl.len())
+                //    .select(name)
+
+                assert_eq!(inner_exprs.len(), 1);
+
+                let input_schema = &ctx.phys_sm[input.node].output_schema;
+
+                let input_expr = &inner_exprs[0];
+                let key_name = unique_column_name();
+                let output_dtype = input_expr.dtype(input_schema, ctx.expr_arena)?.clone();
+                let output_name = inner_exprs[0].output_name();
+                let group_by_output_schema = Arc::new(Schema::from_iter([
+                    (key_name.clone(), output_dtype),
+                    (output_name.clone(), IDX_DTYPE),
+                ]));
+
+                let keys = [input_expr.with_alias(key_name)];
+                let aggs = [ExprIR::new(
+                    ctx.expr_arena.add(AExpr::Len),
+                    OutputName::Alias(output_name.clone()),
+                )];
+
+                let stream = build_group_by_stream(
+                    input,
+                    &keys,
+                    &aggs,
+                    group_by_output_schema,
+                    true,
+                    Default::default(),
+                    None,
+                    ctx.expr_arena,
+                    ctx.phys_sm,
+                    ctx.cache,
+                    StreamingLowerIRContext {
+                        prepare_visualization: ctx.prepare_visualization,
+                    },
+                )?;
+                transformed_exprs.push(ctx.expr_arena.add(AExpr::Column(output_name.clone())));
+                input_streams.insert(stream);
+            },
+            AExpr::Function {
+                input: ref inner_exprs,
+                function:
+                    IRFunctionExpr::ValueCounts {
+                        sort: false,
+                        parallel: _,
+                        name: count_name,
+                        normalize: false,
+                    },
+                options: _,
+            } => {
+                // Transform:
+                //    expr.value_counts(
+                //      sort=False,
+                //      parallel=_,
+                //      name=count_name,
+                //      normalize=False
+                //    ).alias(name)
+                //      ->
+                //    .select(expr.alias(name))
+                //    .group_by(name)
+                //      .agg(count_name = pl.len())
+                //    .select(pl.struct([name, count_name]))
+
+                assert_eq!(inner_exprs.len(), 1);
+
+                let input_schema = &ctx.phys_sm[input.node].output_schema;
+
+                let input_expr = &inner_exprs[0];
+                let output_field = input_expr.field(input_schema, ctx.expr_arena)?;
+                let group_by_output_schema = Arc::new(Schema::from_iter([
+                    output_field.clone(),
+                    Field::new(count_name.clone(), IDX_DTYPE),
+                ]));
+
+                let aggs = [ExprIR::new(
+                    ctx.expr_arena.add(AExpr::Len),
+                    OutputName::Alias(count_name.clone()),
+                )];
+
+                let stream = build_group_by_stream(
+                    input,
+                    inner_exprs,
+                    &aggs,
+                    group_by_output_schema,
+                    false,
+                    Default::default(),
+                    None,
+                    ctx.expr_arena,
+                    ctx.phys_sm,
+                    ctx.cache,
+                    StreamingLowerIRContext {
+                        prepare_visualization: ctx.prepare_visualization,
+                    },
+                )?;
+
+                let value = ExprIR::new(
+                    ctx.expr_arena
+                        .add(AExpr::Column(output_field.name().clone())),
+                    OutputName::Alias(output_field.name),
+                );
+                let count = ExprIR::new(
+                    ctx.expr_arena.add(AExpr::Column(count_name.clone())),
+                    OutputName::Alias(count_name.clone()),
+                );
+
+                transformed_exprs.push(
+                    AExprBuilder::function(
+                        vec![value, count],
+                        IRFunctionExpr::AsStruct,
+                        ctx.expr_arena,
+                    )
+                    .node(),
+                );
+                input_streams.insert(stream);
             },
 
             #[cfg(feature = "is_in")]


### PR DESCRIPTION
Small break from the types work.

- `unique_counts` gets lowered to an ordered group-by (not yet natively streaming)
- `value_counts` gets lowered to an unordered group-by

xref: #20947.

```python
df = pl.LazyFrame(
    {"color": ["red", "blue", "red", "green", "blue", "blue"]}
).select(pl.col("color").value_counts()).collect(engine='streaming')
```

![value_counts](https://github.com/user-attachments/assets/aafff934-4499-4de9-ac73-ff412b55aa7c)
