### PR TITLE
docs: Improve StackOverflow links in contributing guide

### DIFF
--- a/docs/source/development/contributing/index.md
+++ b/docs/source/development/contributing/index.md
@@ -236,7 +236,8 @@ your solution, feel free to open a draft pull request and ask for help.
 The most important components of Polars documentation are the
 [user guide](https://docs.pola.rs/user-guide/), the
 [API references](https://docs.pola.rs/api/python/stable/reference/index.html), and the database of
-questions on [StackOverflow](https://stackoverflow.com/).
+questions on Stack Overflow for [Python Polars](https://stackoverflow.com/questions/tagged/python-polars) and
+[Rust Polars](https://stackoverflow.com/questions/tagged/rust-polars).
 
 ### User guide
 

--- a/docs/source/development/contributing/index.md
+++ b/docs/source/development/contributing/index.md
@@ -236,7 +236,8 @@ your solution, feel free to open a draft pull request and ask for help.
 The most important components of Polars documentation are the
 [user guide](https://docs.pola.rs/user-guide/), the
 [API references](https://docs.pola.rs/api/python/stable/reference/index.html), and the database of
-questions on Stack Overflow for [Python Polars](https://stackoverflow.com/questions/tagged/python-polars) and
+questions on Stack Overflow for
+[Python Polars](https://stackoverflow.com/questions/tagged/python-polars) and
 [Rust Polars](https://stackoverflow.com/questions/tagged/rust-polars).
 
 ### User guide


### PR DESCRIPTION
This pull request updates the index.md file in the contributing documentation to improve links for Stack Overflow.

The current documentation links to the general Stack Overflow homepage, even though it later mentions that there are separate, language-specific tags for Python and Rust Polars.

This change replaces the general link with direct links to the relevant Stack Overflow pages for [Python Polars](https://stackoverflow.com/questions/tagged/python-polars) and [Rust Polars](https://stackoverflow.com/questions/tagged/rust-polars). 