### PR TITLE
fix: Parquet filtering on multiple RGs with literal predicate

### DIFF
--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -3513,3 +3513,13 @@ def test_write_nested_categoricals() -> None:
 
     f.seek(0)
     assert_frame_equal(pl.read_parquet(f), df)
+
+
+def test_literal_predicate_23901() -> None:
+    df = pl.DataFrame({"x": range(10)})
+
+    f = io.BytesIO()
+    df.write_parquet(f, row_group_size=1)
+
+    f.seek(0)
+    assert_frame_equal(pl.scan_parquet(f).filter(pl.lit(1) == 1).collect(), df)


### PR DESCRIPTION
The predicate result needed to be broadcast.

Fixes #23901.