### PR TITLE
fix: Ensure `collect()` native Iceberg always scans latest when no `snapshot_id` is given

### DIFF
--- a/crates/polars-plan/src/dsl/file_scan/python_dataset.rs
+++ b/crates/polars-plan/src/dsl/file_scan/python_dataset.rs
@@ -20,9 +20,10 @@ pub struct PythonDatasetProviderVTable {
     #[expect(clippy::type_complexity)]
     pub to_dataset_scan: fn(
         dataset_object: &PythonObject,
+        existing_resolved_version_key: Option<&str>,
         limit: Option<usize>,
         projection: Option<&[PlSmallStr]>,
-    ) -> PolarsResult<DslPlan>,
+    ) -> PolarsResult<Option<(DslPlan, PlSmallStr)>>,
 }
 
 pub fn dataset_provider_vtable() -> Result<&'static PythonDatasetProviderVTable, &'static str> {
@@ -54,11 +55,13 @@ impl PythonDatasetProvider {
 
     pub fn to_dataset_scan(
         &self,
+        existing_resolved_version_key: Option<&str>,
         limit: Option<usize>,
         projection: Option<&[PlSmallStr]>,
-    ) -> PolarsResult<DslPlan> {
+    ) -> PolarsResult<Option<(DslPlan, PlSmallStr)>> {
         (dataset_provider_vtable().unwrap().to_dataset_scan)(
             &self.dataset_object,
+            existing_resolved_version_key,
             limit,
             projection,
         )

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -329,8 +329,10 @@ def test_scan_iceberg_row_index_renamed(tmp_path: Path) -> None:
 
 
 @pytest.mark.write_disk
+@pytest.mark.parametrize("reader_override", ["pyiceberg", "native"])
 def test_scan_iceberg_collect_without_version_scans_latest(
     tmp_path: Path,
+    reader_override: str,
     capfd: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -351,7 +353,7 @@ def test_scan_iceberg_collect_without_version_scans_latest(
 
     tbl = catalog.load_table("namespace.table")
 
-    q = pl.scan_iceberg(tbl, reader_override="native")
+    q = pl.scan_iceberg(tbl, reader_override=reader_override)  # type: ignore[arg-type]
 
     assert_frame_equal(q.collect(), pl.DataFrame(schema={"a": pl.Int64}))
 
@@ -363,7 +365,11 @@ def test_scan_iceberg_collect_without_version_scans_latest(
     assert snapshot is not None
     snapshot_id = snapshot.snapshot_id
 
-    q_with_id = pl.scan_iceberg(tbl, reader_override="native", snapshot_id=snapshot_id)
+    q_with_id = pl.scan_iceberg(
+        tbl,
+        reader_override=reader_override,  # type: ignore[arg-type]
+        snapshot_id=snapshot_id,
+    )
 
     assert_frame_equal(q_with_id.collect(), pl.DataFrame({"a": 1}))
 


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/23905
* PR depends on https://github.com/pola-rs/polars/pull/23900

Note, that after a serialization roundtrip `q = pickle.loads(pickle.dumps))`, collection of the roundtripped LazyFrame will no longer see any modifications on the original Iceberg table object. This is due to the underlying table inside of the `IcebergDataset` becoming a separate object in memory.
