### PR TITLE
fix: update `cat` namespace functions for cat phys logic

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/function_expr/cat.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/cat.rs
@@ -104,13 +104,15 @@ fn _get_cat_phys_map(col: &Column) -> (StringChunked, Series) {
     let mapping = col.dtype().cat_mapping().unwrap();
     let cats =
         unsafe { StringChunked::from_chunks(col.name().clone(), vec![mapping.to_arrow(true)]) };
-    let phys = col.to_physical_repr().as_materialized_series().clone();
+    let mut phys = col.to_physical_repr().as_materialized_series().clone();
+    if phys.dtype() != &IDX_DTYPE {
+        phys = phys.cast(&IDX_DTYPE).unwrap();
+    }
     (cats, phys)
 }
 
 /// Fast path: apply a string function to the categories of a categorical column and broadcast the
 /// result back to the array.
-// fn apply_to_cats<F, T>(ca: &CategoricalChunked, mut op: F) -> PolarsResult<Column>
 fn apply_to_cats<F, T>(c: &Column, mut op: F) -> PolarsResult<Column>
 where
     F: FnMut(StringChunked) -> ChunkedArray<T>,

--- a/pyo3-polars/pyo3-polars/src/export.rs
+++ b/pyo3-polars/pyo3-polars/src/export.rs
@@ -1,1 +1,1 @@
-pub use {polars_core, polars_ffi, polars_plan, arrow as polars_arrow, polars_error};
+pub use {arrow as polars_arrow, polars_core, polars_error, polars_ffi, polars_plan};


### PR DESCRIPTION
Closes #23923.

Very simple fix, before we could always get an idxtype array from cat physical without issue, but now we sometimes get back u8 or u16 so we have to manually cast.