### PR TITLE
fix: Fix `truediv` dtypes so `cast` in `list.eval` is not dropped

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -694,6 +694,11 @@ fn get_truediv_dtype(left_dtype: &DataType, right_dtype: &DataType) -> PolarsRes
             let dtype = get_truediv_dtype(list_dtype.leaf_dtype(), other_dtype.leaf_dtype())?;
             list_dtype.cast_leaf(dtype)
         },
+        #[cfg(feature = "dtype-u8")]
+        (Float32, UInt8 | Int8) => Float32,
+        #[cfg(feature = "dtype-u16")]
+        (Float32, UInt16 | Int16) => Float32,
+        (Float32, other) if other.is_integer() => Float64,
         (Float32, Float64) => Float64,
         (Float32, _) => Float32,
         #[cfg(feature = "dtype-decimal")]

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import operator
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Callable
@@ -1005,3 +1006,24 @@ def test_not_prune_necessary_cast() -> None:
     lf = pl.LazyFrame({"a": [1, 2, 3]}, schema={"a": pl.UInt16})
     result = lf.select(pl.col("a").cast(pl.UInt8))
     assert "strict_cast" in result.explain()
+
+
+@pytest.mark.parametrize("target_dtype", NUMERIC_DTYPES)
+@pytest.mark.parametrize("inner_dtype", NUMERIC_DTYPES)
+@pytest.mark.parametrize("op", [operator.mul, operator.truediv])
+def test_cast_optimizer_in_list_eval_23924(
+    inner_dtype: PolarsDataType,
+    target_dtype: PolarsDataType,
+    op: Callable[[pl.Series, pl.Series], pl.Series],
+) -> None:
+    print(inner_dtype, target_dtype)
+    if target_dtype in INTEGER_DTYPES:
+        df = pl.Series("a", [[1]], dtype=pl.List(target_dtype)).to_frame()
+    else:
+        df = pl.Series("a", [[1.0]], dtype=pl.List(target_dtype)).to_frame()
+    q = df.lazy().select(
+        pl.col("a").list.eval(
+            (op(pl.element(), pl.element().cast(inner_dtype))).cast(target_dtype)
+        )
+    )
+    assert q.collect_schema() == q.collect().schema

--- a/pyo3-polars/example/io_plugin/io_plugin/io_plugin/__init__.py
+++ b/pyo3-polars/example/io_plugin/io_plugin/io_plugin/__init__.py
@@ -5,6 +5,7 @@ import polars as pl
 
 __all__ = ["RandomSource", "new_bernoulli", "new_uniform", "scan_random"]
 
+
 def scan_random(samplers: list[Any], size: int = 1000) -> pl.LazyFrame:
     def source_generator(
         with_columns: list[str] | None,


### PR DESCRIPTION
fixes #23924