### PR TITLE
fix: Fix cast on arithmetic with \'lit\'

### DIFF
--- a/crates/polars-plan/src/dsl/file_scan/mod.rs
+++ b/crates/polars-plan/src/dsl/file_scan/mod.rs
@@ -522,6 +522,13 @@ impl CastColumnsPolicy {
 
         debug_assert!(!target_dtype.is_nested());
 
+        // If we were to drop cast on an `Unknown` incoming_dtype, it could eventually
+        // lead to dtype errors. The reason is that the logic used by type coercion differs
+        // from the casting logic used by `materialize_unknown`.
+        if incoming_dtype.contains_unknown() {
+            return Ok(true);
+        }
+
         // Note: Only call this with non-nested types for performance
         let materialize_unknown = |dtype: &DataType| -> std::borrow::Cow<DataType> {
             dtype
@@ -531,7 +538,7 @@ impl CastColumnsPolicy {
                 .unwrap_or(std::borrow::Cow::Borrowed(incoming_dtype))
         };
 
-        let incoming_dtype = materialize_unknown(incoming_dtype);
+        let incoming_dtype = std::borrow::Cow::Borrowed(incoming_dtype);
         let target_dtype = materialize_unknown(target_dtype);
 
         if target_dtype == incoming_dtype {

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import operator
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Callable
@@ -1005,3 +1006,23 @@ def test_not_prune_necessary_cast() -> None:
     lf = pl.LazyFrame({"a": [1, 2, 3]}, schema={"a": pl.UInt16})
     result = lf.select(pl.col("a").cast(pl.UInt8))
     assert "strict_cast" in result.explain()
+
+
+def test_lit_cast_arithmetic_23677() -> None:
+    df = pl.DataFrame({"a": [1]}, schema={"a": pl.Float32})
+    q = df.lazy().select(pl.col("a") / pl.lit(1, pl.Int32))
+    expected = pl.Schema({"a": pl.Float64})
+    assert q.collect().schema == expected
+
+
+@pytest.mark.parametrize("col_dtype", NUMERIC_DTYPES)
+@pytest.mark.parametrize("lit_dtype", NUMERIC_DTYPES)
+@pytest.mark.parametrize("op", [operator.mul, operator.truediv])
+def test_lit_cast_arithmetic_matrix_schema(
+    col_dtype: PolarsDataType,
+    lit_dtype: PolarsDataType,
+    op: Callable[[pl.Series, pl.Series], pl.Series],
+) -> None:
+    df = pl.DataFrame({"a": [1]}, schema={"a": col_dtype})
+    q = df.lazy().select(op(pl.col("a"), pl.lit(1, lit_dtype)))
+    assert q.collect_schema() == q.collect().schema

--- a/pyo3-polars/example/io_plugin/io_plugin/io_plugin/__init__.py
+++ b/pyo3-polars/example/io_plugin/io_plugin/io_plugin/__init__.py
@@ -5,6 +5,7 @@ import polars as pl
 
 __all__ = ["RandomSource", "new_bernoulli", "new_uniform", "scan_random"]
 
+
 def scan_random(samplers: list[Any], size: int = 1000) -> pl.LazyFrame:
     def source_generator(
         with_columns: list[str] | None,


### PR DESCRIPTION
fixes #23677 

This partially reverts the optimizations introduced in https://github.com/pola-rs/polars/pull/23269, as they were too optimistic in the case of casting from `Unknown` type (see issue).

Note: draft for now, pending the following:
- Related to PR #23936 , which should be merged first to make all tests pass (rebase needed).
- Clarification whether we even need any `materialize_unknown` at all (i.e., can `target_dtype` be cast into `Unknown`?)
