### PR TITLE
fix(rust): Fix assert_frame_equal with check_dtypes=False for all-null series with different types

### DIFF
--- a/py-polars/tests/unit/testing/test_assert_frame_equal.py
+++ b/py-polars/tests/unit/testing/test_assert_frame_equal.py
@@ -404,6 +404,25 @@ def test_assert_frame_equal_check_dtype_deprecated() -> None:
         assert_frame_not_equal(df1, df3, check_dtype=False)  # type: ignore[call-arg]
 
 
+def test_assert_dataframe_equal_all_nulls_passes_when_ignoring_dtypes() -> None:
+    x = pl.from_dict({"A": [None, None, None]})
+    y = pl.from_dict(
+        {"A": [None, None, None]}, schema_overrides={"A": pl.List(pl.Float64())}
+    )
+
+    assert_frame_equal(x, y, check_dtypes=False)
+
+
+def test_assert_dataframe_equal_all_nulls_fails_when_checking_dtypes() -> None:
+    x = pl.from_dict({"A": [None, None, None]})
+    y = pl.from_dict(
+        {"A": [None, None, None]}, schema_overrides={"A": pl.List(pl.Float64())}
+    )
+
+    with pytest.raises(AssertionError, match="dtypes do not match"):
+        assert_frame_equal(x, y, check_dtypes=True)
+
+
 def test_tracebackhide(testdir: pytest.Testdir) -> None:
     testdir.makefile(
         ".py",

--- a/py-polars/tests/unit/testing/test_assert_series_equal.py
+++ b/py-polars/tests/unit/testing/test_assert_series_equal.py
@@ -596,17 +596,26 @@ def test_assert_series_equal_nested_struct_float() -> None:
         assert_series_equal(s1, s2)
 
 
-def test_assert_series_equal_full_null_incompatible_dtypes_raises() -> None:
+def test_assert_series_equal_all_null_different_dtypes_fails_with_check_dtypes_true() -> (
+    None
+):
     s1 = pl.Series([None, None], dtype=pl.Categorical)
     s2 = pl.Series([None, None], dtype=pl.Int16)
 
-    # You could argue this should pass, but it's rare enough not to warrant the
-    # additional check
     with pytest.raises(
         AssertionError,
-        match="incompatible data types",
+        match="dtype mismatch",
     ):
-        assert_series_equal(s1, s2, check_dtypes=False)
+        assert_series_equal(s1, s2, check_dtypes=True)
+
+
+def test_assert_series_equal_all_null_different_dtypes_passes_with_check_dtypes_false() -> (
+    None
+):
+    s1 = pl.Series([None, None], dtype=pl.Categorical)
+    s2 = pl.Series([None, None], dtype=pl.Int16)
+
+    assert_series_equal(s1, s2, check_dtypes=False)
 
 
 def test_assert_series_equal_full_null_nested_list() -> None:


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/23927.

Fixes assertion failure when comparing all-null series with different data types. Updated Python tests to match the new functionality and test both behaviors. 

If `check_dtypes` is `false` and all Series values are `null` and they have different data types, the assertion will not fail. 

If `check_dtypes` is `true` and all Series values are `null` and they have different data types, the assertion will fail.