### PR TITLE
docs(python): Add `arr.len()` on the website

### DIFF
--- a/py-polars/docs/source/reference/expressions/array.rst
+++ b/py-polars/docs/source/reference/expressions/array.rst
@@ -20,6 +20,7 @@ The following methods are available under the `expr.arr` attribute.
     Expr.arr.get
     Expr.arr.join
     Expr.arr.last
+    Expr.arr.len
     Expr.arr.max
     Expr.arr.mean
     Expr.arr.median

--- a/py-polars/docs/source/reference/series/array.rst
+++ b/py-polars/docs/source/reference/series/array.rst
@@ -20,6 +20,7 @@ The following methods are available under the `Series.arr` attribute.
     Series.arr.get
     Series.arr.join
     Series.arr.last
+    Series.arr.len
     Series.arr.max
     Series.arr.median
     Series.arr.min


### PR DESCRIPTION
Was added in https://github.com/pola-rs/polars/pull/21618 but not listed on the website.