### PR TITLE
fix: Fix `unpivot` panic when `index=` column not found

### DIFF
--- a/crates/polars-ops/src/frame/pivot/unpivot.rs
+++ b/crates/polars-ops/src/frame/pivot/unpivot.rs
@@ -111,7 +111,7 @@ pub trait UnpivotDF: IntoDf {
                 let variable_col = Column::new_empty(variable_name, &DataType::String);
                 let value_col = Column::new_empty(value_name, &DataType::Null);
 
-                let mut out = self_.select(index).unwrap().clear().take_columns();
+                let mut out = self_.select(index)?.clear().take_columns();
 
                 out.push(variable_col);
                 out.push(value_col);

--- a/py-polars/tests/unit/operations/test_unpivot.py
+++ b/py-polars/tests/unit/operations/test_unpivot.py
@@ -111,3 +111,8 @@ def test_unpivot_categorical() -> None:
         "variable": ["1", "1", "2", "2"],
         "value": ["a", "b", "b", "c"],
     }
+
+
+def test_unpivot_index_not_found_23165() -> None:
+    with pytest.raises(pl.exceptions.ColumnNotFoundError):
+        pl.DataFrame({"a": [1]}).unpivot(index="b")


### PR DESCRIPTION
Fixes #23165

Propagates the `ColumnNotFoundError` instead of a panic.