### PR TITLE
fix: Correct allocator name in `PyCapsule`

### DIFF
--- a/crates/polars-python/src/c_api/allocator.rs
+++ b/crates/polars-python/src/c_api/allocator.rs
@@ -56,7 +56,7 @@ static ALLOCATOR_CAPSULE: AllocatorCapsule = AllocatorCapsule {
     realloc,
 };
 
-static ALLOCATOR_CAPSULE_NAME: &[u8] = b"polars._plr._allocator\0";
+static ALLOCATOR_CAPSULE_NAME: &[u8] = b"polars.polars._allocator\0";
 
 pub fn create_allocator_capsule(py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
     unsafe {

--- a/py-polars/requirements-ci.txt
+++ b/py-polars/requirements-ci.txt
@@ -6,3 +6,4 @@ torch
 jax[cpu]
 pyiceberg>=0.7.1
 pyiceberg-core
+polars-ds==0.10.0

--- a/py-polars/tests/unit/test_ds_plugin.py
+++ b/py-polars/tests/unit/test_ds_plugin.py
@@ -1,0 +1,21 @@
+import pytest
+
+import polars as pl
+from polars.dependencies import _lazy_import
+from polars.testing import assert_frame_equal
+
+# don't import polars_ds until an actual test is triggered (the decorator already
+# ensures the tests aren't run locally; this avoids premature local import)
+pds, _ = _lazy_import("polars_ds")
+
+pytestmark = pytest.mark.ci_only
+
+
+def test_basic_operation() -> None:
+    # We are mostly interested in making sure that we can actually still call the plugin
+    # properly.
+    df = pl.DataFrame({"name": ["a", "b", "c"]})
+    assert_frame_equal(
+        df.select(pds.str_leven("name", pl.lit("che"))),
+        pl.Series("name", [3, 3, 2], pl.UInt32).to_frame(),
+    )

--- a/pyo3-polars/pyo3-polars/src/alloc.rs
+++ b/pyo3-polars/pyo3-polars/src/alloc.rs
@@ -45,7 +45,7 @@ static FALLBACK_ALLOCATOR_CAPSULE: AllocatorCapsule = AllocatorCapsule {
     realloc: fallback_realloc,
 };
 
-static ALLOCATOR_CAPSULE_NAME: &[u8] = b"polars._plr._allocator\0";
+static ALLOCATOR_CAPSULE_NAME: &[u8] = b"polars.polars._allocator\0";
 
 /// A memory allocator that relays allocations to the allocator used by Polars.
 ///
@@ -58,7 +58,7 @@ static ALLOCATOR_CAPSULE_NAME: &[u8] = b"polars._plr._allocator\0";
 /// static ALLOC: PolarsAllocator = PolarsAllocator::new();
 /// ```
 ///
-/// If the allocator capsule (`polars._plr._allocator`) is not available,
+/// If the allocator capsule (`polars.polars._allocator`) is not available,
 /// this allocator fallbacks to [`std::alloc::System`].
 pub struct PolarsAllocator(OnceRef<'static, AllocatorCapsule>);
 


### PR DESCRIPTION
Fixes #23965.

Also adds this to the CI to ensure no more future regressions here.