### PR TITLE
refactor: Don't define CountStar as dyn OptimizationRule

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/count_star.rs
+++ b/crates/polars-plan/src/plans/optimizer/count_star.rs
@@ -12,9 +12,9 @@ impl CountStar {
     }
 }
 
-impl OptimizationRule for CountStar {
+impl CountStar {
     // Replace select count(*) from datasource with specialized map function.
-    fn optimize_plan(
+    pub(super) fn optimize_plan(
         &mut self,
         lp_arena: &mut Arena<IR>,
         expr_arena: &mut Arena<AExpr>,


### PR DESCRIPTION
`dyn OptimizationRule` are called in a tight loop. The `CountStar` optimization is called only once. This prevents confusion (I was already thinking this is too expensive for a tight loop).