### PR TITLE
feat: Allow customizing explain output for debugging custom io sources

### DIFF
--- a/crates/polars-lazy/src/frame/python.rs
+++ b/crates/polars-lazy/src/frame/python.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use either::Either;
 use polars_core::schema::SchemaRef;
+use polars_utils::pl_str::PlSmallStr;
 use pyo3::{Py, PyAny};
 
 use self::python_dsl::{PythonOptionsDsl, PythonScanSource};
@@ -15,6 +16,8 @@ impl LazyFrame {
         // Validate that the source gives the proper schema
         validate_schema: bool,
         is_pure: bool,
+        explain_name: Option<PlSmallStr>,
+        explain_detail: Option<PlSmallStr>,
     ) -> Self {
         DslPlan::PythonScan {
             options: PythonOptionsDsl {
@@ -28,6 +31,8 @@ impl LazyFrame {
                 },
                 validate_schema,
                 is_pure,
+                explain_name,
+                explain_detail,
             },
         }
         .into()

--- a/crates/polars-plan/dsl-schema-hashes.json
+++ b/crates/polars-plan/dsl-schema-hashes.json
@@ -133,7 +133,7 @@
   "PythonDatasetProvider": "be8b6230b70d3ccadd37f595986b05682043b1adca57ecf7f9714bfcb56b0979",
   "PythonKeyValueMetadataFunction": "5bbddd4f899afa592c318b20bb8d0bdfe2877fa5bf1a63d9cd0da908ac3aec0e",
   "PythonObject": "5bbddd4f899afa592c318b20bb8d0bdfe2877fa5bf1a63d9cd0da908ac3aec0e",
-  "PythonOptionsDsl": "7502c38c0b63b907ca28f364b78f61445de925567fea6d49467f3aa409d7fb0b",
+  "PythonOptionsDsl": "a5d46c08dcab27f2018b184b8cf8d7f09ce821511dd7f7bbe317ef2279ae2d3c",
   "PythonScanSource": "939b16ad4782d9a974b13f9f6ebccec13bb1e444dfa82a575429e5be6c02217f",
   "QuantileMethod": "dc652061779e61c57da55126eba9439c15aa7d283d2bdac00d3d07726c29f11c",
   "QuoteStyle": "be86ae062d16fca3258876ecd98e6825fcaa5f8459f1ac7a932b72513e08f9db",

--- a/crates/polars-plan/src/dsl/python_dsl/source.rs
+++ b/crates/polars-plan/src/dsl/python_dsl/source.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use either::Either;
 use polars_core::error::{PolarsResult, polars_err};
 use polars_core::schema::SchemaRef;
+use polars_utils::pl_str::PlSmallStr;
 use polars_utils::python_function::PythonFunction;
 use pyo3::prelude::*;
 #[cfg(feature = "serde")]
@@ -22,6 +23,10 @@ pub struct PythonOptionsDsl {
     pub python_source: PythonScanSource,
     pub validate_schema: bool,
     pub is_pure: bool,
+    /// Optional custom name to display in explain output, eg: PYTHON[<name>].
+    pub explain_name: Option<PlSmallStr>,
+    /// Optional single-line detail to include under the scan header.
+    pub explain_detail: Option<PlSmallStr>,
 }
 
 impl PythonOptionsDsl {

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -184,6 +184,8 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 python_source,
                 validate_schema,
                 is_pure,
+                explain_name,
+                explain_detail,
             } = options;
 
             IR::PythonScan {
@@ -197,6 +199,8 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                     n_rows: Default::default(),
                     predicate: Default::default(),
                     is_pure,
+                    explain_name,
+                    explain_detail,
                 },
             }
         },

--- a/crates/polars-plan/src/plans/ir/equality.rs
+++ b/crates/polars-plan/src/plans/ir/equality.rs
@@ -59,6 +59,8 @@ impl IR {
                     predicate: l_predicate,
                     validate_schema: l_validate_schema,
                     is_pure: l_is_pure,
+                    explain_name: _,
+                    explain_detail: _,
                 } = l_options;
                 let PythonOptions {
                     scan_fn: r_scan_fn,
@@ -70,6 +72,8 @@ impl IR {
                     predicate: r_predicate,
                     validate_schema: r_validate_schema,
                     is_pure: r_is_pure,
+                    explain_name: _,
+                    explain_detail: _,
                 } = r_options;
 
                 let scan_fn_eq = l_scan_fn.as_ref().map(|l| l.0.as_ptr())

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -816,10 +816,15 @@ pub fn write_ir_non_recursive(
                 PythonPredicate::PyArrow { .. } => None,
                 PythonPredicate::None => None,
             };
+            let header_name = if let Some(name) = &options.explain_name {
+                format!("PYTHON[{name}]")
+            } else {
+                "PYTHON".to_string()
+            };
 
             write_scan(
                 f,
-                "PYTHON",
+                &header_name,
                 &ScanSources::default(),
                 indent,
                 n_columns,
@@ -831,7 +836,13 @@ pub fn write_ir_non_recursive(
                     .map(|len| polars_utils::slice_enum::Slice::Positive { offset: 0, len }),
                 None,
                 None,
-            )
+            )?;
+
+            if let Some(detail) = &options.explain_detail {
+                write!(f, "\n{:indent$}INFO: {}", "", detail)?;
+            }
+
+            Ok(())
         },
         IR::Slice {
             input: _,

--- a/crates/polars-plan/src/plans/ir/hash.rs
+++ b/crates/polars-plan/src/plans/ir/hash.rs
@@ -39,6 +39,8 @@ impl IR {
                         predicate,
                         validate_schema,
                         is_pure,
+                        explain_name: _,
+                        explain_detail: _,
                     },
             } => {
                 // Hash the Python function object using the pointer to the object.

--- a/crates/polars-plan/src/plans/python/source.rs
+++ b/crates/polars-plan/src/plans/python/source.rs
@@ -31,6 +31,10 @@ pub struct PythonOptions {
     pub validate_schema: bool,
     /// Whether this scan is free of side effects (allows for CSE when that is the case).
     pub is_pure: bool,
+    /// Optional custom name for explain header.
+    pub explain_name: Option<PlSmallStr>,
+    /// Optional single-line detail to include in explain.
+    pub explain_detail: Option<PlSmallStr>,
 }
 
 #[derive(Clone, PartialEq, Debug, Default)]

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -424,12 +424,15 @@ impl PyLazyFrame {
     }
 
     #[staticmethod]
+    #[pyo3(signature = (schema, scan_fn, pyarrow, validate_schema, is_pure, *, explain_name=None, explain_detail=None))]
     fn scan_from_python_function_arrow_schema(
         schema: &Bound<'_, PyList>,
         scan_fn: Py<PyAny>,
         pyarrow: bool,
         validate_schema: bool,
         is_pure: bool,
+        explain_name: Option<PyBackedStr>,
+        explain_detail: Option<PyBackedStr>,
     ) -> PyResult<Self> {
         let schema = Arc::new(pyarrow_schema_to_rust(schema)?);
 
@@ -439,17 +442,22 @@ impl PyLazyFrame {
             pyarrow,
             validate_schema,
             is_pure,
+            explain_name.as_deref().map(Into::into),
+            explain_detail.as_deref().map(Into::into),
         )
         .into())
     }
 
     #[staticmethod]
+    #[pyo3(signature = (schema, scan_fn, pyarrow, validate_schema, is_pure, *, explain_name=None, explain_detail=None))]
     fn scan_from_python_function_pl_schema(
         schema: Vec<(PyBackedStr, Wrap<DataType>)>,
         scan_fn: Py<PyAny>,
         pyarrow: bool,
         validate_schema: bool,
         is_pure: bool,
+        explain_name: Option<PyBackedStr>,
+        explain_detail: Option<PyBackedStr>,
     ) -> PyResult<Self> {
         let schema = Arc::new(Schema::from_iter(
             schema
@@ -462,16 +470,21 @@ impl PyLazyFrame {
             pyarrow,
             validate_schema,
             is_pure,
+            explain_name.as_deref().map(Into::into),
+            explain_detail.as_deref().map(Into::into),
         )
         .into())
     }
 
     #[staticmethod]
+    #[pyo3(signature = (schema_fn, scan_fn, validate_schema, is_pure, *, explain_name=None, explain_detail=None))]
     fn scan_from_python_function_schema_function(
         schema_fn: Py<PyAny>,
         scan_fn: Py<PyAny>,
         validate_schema: bool,
         is_pure: bool,
+        explain_name: Option<PyBackedStr>,
+        explain_detail: Option<PyBackedStr>,
     ) -> PyResult<Self> {
         Ok(LazyFrame::scan_from_python_function(
             Either::Left(schema_fn),
@@ -479,6 +492,8 @@ impl PyLazyFrame {
             false,
             validate_schema,
             is_pure,
+            explain_name.as_deref().map(Into::into),
+            explain_detail.as_deref().map(Into::into),
         )
         .into())
     }

--- a/crates/polars-python/src/lazyframe/visit.rs
+++ b/crates/polars-python/src/lazyframe/visit.rs
@@ -169,6 +169,8 @@ impl NodeTraverser {
                 n_rows: None,
                 validate_schema: false,
                 is_pure,
+                explain_name: None,
+                explain_detail: None,
             },
         };
         lp_arena.replace(self.root, ir);

--- a/py-polars/src/polars/_plr.pyi
+++ b/py-polars/src/polars/_plr.pyi
@@ -900,7 +900,14 @@ class PyLazyFrame:
     def new_from_dataset_object(dataset_object: Any) -> PyLazyFrame: ...
     @staticmethod
     def scan_from_python_function_arrow_schema(
-        schema: Any, scan_fn: Any, pyarrow: bool, validate_schema: bool, is_pure: bool
+        schema: Any,
+        scan_fn: Any,
+        pyarrow: bool,
+        validate_schema: bool,
+        is_pure: bool,
+        *,
+        explain_name: str | None = None,
+        explain_detail: str | None = None,
     ) -> PyLazyFrame: ...
     @staticmethod
     def scan_from_python_function_pl_schema(
@@ -909,10 +916,19 @@ class PyLazyFrame:
         pyarrow: bool,
         validate_schema: bool,
         is_pure: bool,
+        *,
+        explain_name: str | None = None,
+        explain_detail: str | None = None,
     ) -> PyLazyFrame: ...
     @staticmethod
     def scan_from_python_function_schema_function(
-        schema_fn: Any, scan_fn: Any, validate_schema: bool, is_pure: bool
+        schema_fn: Any,
+        scan_fn: Any,
+        validate_schema: bool,
+        is_pure: bool,
+        *,
+        explain_name: str | None = None,
+        explain_detail: str | None = None,
     ) -> PyLazyFrame: ...
     def pipe_with_schema(
         self, callback: Callable[[tuple[PyLazyFrame, Schema]], PyLazyFrame]

--- a/py-polars/src/polars/io/plugins.py
+++ b/py-polars/src/polars/io/plugins.py
@@ -24,6 +24,8 @@ def register_io_source(
     schema: Callable[[], SchemaDict] | SchemaDict,
     validate_schema: bool = False,
     is_pure: bool = False,
+    explain_name: str | None = None,
+    explain_detail: str | None = None,
 ) -> LazyFrame:
     """
     Register your IO plugin and initialize a LazyFrame.
@@ -66,6 +68,13 @@ def register_io_source(
         Whether the IO source is pure. Repeated occurrences of same IO source in
         a LazyFrame plan can be de-duplicated during optimization if they are
         pure.
+    explain_name
+        Custom label for the scan node in the query plan produced by ``explain``,
+        shown as
+        ``PYTHON[<name>] SCAN ...``.
+    explain_detail
+        Short, single-line detail appended under the scan header in the query plan
+        produced by ``explain`` (for example, a summary of source configuration).
 
     Returns
     -------
@@ -101,6 +110,8 @@ def register_io_source(
         pyarrow=False,
         validate_schema=validate_schema,
         is_pure=is_pure,
+        explain_name=explain_name,
+        explain_detail=explain_detail,
     )
 
 

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -393,6 +393,8 @@ class LazyFrame:
         pyarrow: bool = False,
         validate_schema: bool = False,
         is_pure: bool = False,
+        explain_name: str | None = None,
+        explain_detail: str | None = None,
     ) -> LazyFrame:
         self = cls.__new__(cls)
         if isinstance(schema, Mapping):
@@ -402,6 +404,8 @@ class LazyFrame:
                 pyarrow=pyarrow,
                 validate_schema=validate_schema,
                 is_pure=is_pure,
+                explain_name=explain_name,
+                explain_detail=explain_detail,
             )
         elif _PYARROW_AVAILABLE and isinstance(schema, pa.Schema):
             self._ldf = PyLazyFrame.scan_from_python_function_arrow_schema(
@@ -410,10 +414,17 @@ class LazyFrame:
                 pyarrow=pyarrow,
                 validate_schema=validate_schema,
                 is_pure=is_pure,
+                explain_name=explain_name,
+                explain_detail=explain_detail,
             )
         else:
             self._ldf = PyLazyFrame.scan_from_python_function_schema_function(
-                schema, scan_fn, validate_schema=validate_schema, is_pure=is_pure
+                schema,
+                scan_fn,
+                validate_schema=validate_schema,
+                is_pure=is_pure,
+                explain_name=explain_name,
+                explain_detail=explain_detail,
             )
         return self
 

--- a/py-polars/tests/unit/io/test_io_plugin.py
+++ b/py-polars/tests/unit/io/test_io_plugin.py
@@ -184,6 +184,53 @@ def test_datetime_io_predicate_pushdown_21790() -> None:
     assert str(column) == str(pl.col("timestamp"))
 
 
+def test_io_plugin_custom_explain() -> None:
+    def _source(
+        with_columns: list[str] | None,
+        predicate: pl.Expr | None,
+        n_rows: int | None,
+        batch_size: int | None,
+    ) -> Iterator[pl.DataFrame]:
+        yield pl.DataFrame({"a": [1, 2, 3]})
+
+    default_plan = register_io_source(
+        io_source=_source,
+        schema={"a": pl.Int64},
+    ).explain()
+    assert "PYTHON SCAN" in default_plan
+    assert "PYTHON[" not in default_plan
+    assert "INFO:" not in default_plan
+
+    left = register_io_source(
+        io_source=_source,
+        schema={"a": pl.Int64},
+        explain_name="left",
+        explain_detail="left detail",
+    )
+    right = register_io_source(
+        io_source=_source,
+        schema={"a": pl.Int64},
+        explain_name="right",
+        explain_detail="right detail",
+    )
+
+    plan = left.explain()
+    assert "PYTHON[left] SCAN" in plan
+    assert "PROJECT */1 COLUMNS" in plan
+    assert "INFO: left detail" in plan
+
+    plans = {
+        "INNER JOIN": left.join(right, on="a").explain(),
+        "UNION": pl.concat([left, right]).explain(),
+    }
+    for operation, plan in plans.items():
+        assert operation in plan
+        assert "PYTHON[left] SCAN" in plan
+        assert "INFO: left detail" in plan
+        assert "PYTHON[right] SCAN" in plan
+        assert "INFO: right detail" in plan
+
+
 @pytest.mark.parametrize(("validate"), [(True), (False)])
 def test_reordered_columns_22731(validate: bool) -> None:
     def my_scan() -> pl.LazyFrame:


### PR DESCRIPTION
Currently, the explain for custom io sources is not very helpful, (it just says PYTHON SCAN) and when custom io sources wrap other polars lazyframes (such as for predicate manipulation,) or there exist multiple different io sources, it can be hard to get useful information from the explain.

This PR adds 2 new optional parameters to custom io sources to allow exposing more information when calling explain. I used gpt 5.6 sol to help me write the code but reviewed it all myself