### PR TITLE
docs(python): Fix a typo in "lazy/execution" user-guide page

### DIFF
--- a/docs/source/user-guide/lazy/execution.md
+++ b/docs/source/user-guide/lazy/execution.md
@@ -82,7 +82,7 @@ It is very common that a query diverges at one point. In these cases it is recom
 # Some expensive LazyFrame
 lf: LazyFrame
 
-lf_1 = LazyFrame.select(pl.all().sum())
+lf_1 = lf.select(pl.all().sum())
 
 lf_2 = lf.some_other_computation()
 


### PR DESCRIPTION
Just a small correction in user guide.