### PR TITLE
fix: Fix Categorical dtype lifetime in `csv_write`

### DIFF
--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2791,3 +2791,21 @@ def test_read_csv_decimal_header_only_200008() -> None:
 
     df = pl.read_csv(csv.encode(), schema={"a": pl.Decimal(scale=2), "b": pl.String})
     assert df.dtypes == [pl.Decimal(scale=2), pl.String]
+
+
+@pytest.mark.parametrize(
+    "dt",
+    [
+        pl.Enum(["a"]),
+        pl.Categorical(["a"]),
+    ],
+)
+def test_write_csv_categorical_23939(dt: pl.DataType) -> None:
+    n_rows = pl.thread_pool_size() * 1024 + 1
+    df = pl.DataFrame(
+        {
+            "b": pl.Series(["a"] * n_rows, dtype=dt),
+        }
+    )
+    expected = "b\n" + "a\n" * n_rows
+    assert df.write_csv() == expected

--- a/pyo3-polars/example/io_plugin/io_plugin/io_plugin/__init__.py
+++ b/pyo3-polars/example/io_plugin/io_plugin/io_plugin/__init__.py
@@ -5,6 +5,7 @@ import polars as pl
 
 __all__ = ["RandomSource", "new_bernoulli", "new_uniform", "scan_random"]
 
+
 def scan_random(samplers: list[Any], size: int = 1000) -> pl.LazyFrame:
     def source_generator(
         with_columns: list[str] | None,


### PR DESCRIPTION
fixes #23939

Per the issue description, the `Enum`/`Categorical` dtype allocates memory that gets used after free by the CSV serializer. This PR ensures the lifetime is correct, effectively taking any column `dtype` value out of the main `&cols` unsafe code path for the CSV serializer.

The PR would benefit from an in-depth review.