### PR TITLE
fix: Cache id is not a valid dot node id

### DIFF
--- a/crates/polars-plan/src/plans/ir/dot.rs
+++ b/crates/polars-plan/src/plans/ir/dot.rs
@@ -26,7 +26,7 @@ impl fmt::Display for DotNode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             DotNode::Plain(n) => write!(f, "p{n}"),
-            DotNode::Cache(n) => write!(f, "c{n}"),
+            DotNode::Cache(n) => write!(f, "\"{n}\""),
         }
     }
 }


### PR DESCRIPTION
Fixes cache to have a valid dot graph id.

- broken in #23704

Before:
```dot
graph  polars_query {
  c7e2e5b86-a92c-4b63-8baf-b397a32ad8f2 -- p1
  p1[label="TABLE\nπ */1"]
  c7e2e5b86-a92c-4b63-8baf-b397a32ad8f2[label="CACHE"]
}
```

After:
```dot
graph  polars_query {
  "7e2e5b86-a92c-4b63-8baf-b397a32ad8f2" -- p1
  p1[label="TABLE\nπ */1"]
  "7e2e5b86-a92c-4b63-8baf-b397a32ad8f2"[label="CACHE"]
}
```