### PR TITLE
fix: Align `map_elements` with and without `return_dtype`

### DIFF
--- a/crates/polars-python/src/series/map.rs
+++ b/crates/polars-python/src/series/map.rs
@@ -258,7 +258,11 @@ impl PySeries {
                         PyCFunction::new_closure(py, None, None, move |args, _kwargs| {
                             Python::with_gil(|py| {
                                 let out = function_owned.call1(py, args)?;
-                                pl_series(py).call1(py, ("", out, &dtype_py))
+                                if out.is_none(py) {
+                                    Ok(py.None())
+                                } else {
+                                    pl_series(py).call1(py, ("", out, &dtype_py))
+                                }
                             })
                         })?
                         .into_any()

--- a/py-polars/tests/unit/operations/map/test_map_elements.py
+++ b/py-polars/tests/unit/operations/map/test_map_elements.py
@@ -387,3 +387,14 @@ def test_map_elements_list_of_named_tuple_15425() -> None:
     )
     expected = pl.DataFrame({"a": [[], [{"x": 0}], [{"x": 0}, {"x": 1}]]})
     assert_frame_equal(result, expected)
+
+
+def test_map_elements_list_dtype_24006() -> None:
+    values = [None, [1, 2], [2, 3]]
+    dtype = pl.List(pl.Int64)
+
+    s1 = pl.Series([0, 1, 2]).map_elements(lambda x: values[x])
+    s2 = pl.Series([0, 1, 2]).map_elements(lambda x: values[x], return_dtype=dtype)
+
+    assert_series_equal(s1, s2)
+    assert_series_equal(s1, pl.Series(values, dtype=dtype))


### PR DESCRIPTION
Fixes #24006.