### PR TITLE
fix: Accept another zlib "magic header" file signature

### DIFF
--- a/crates/polars-io/src/utils/compression.rs
+++ b/crates/polars-io/src/utils/compression.rs
@@ -12,18 +12,20 @@ pub enum SupportedCompression {
 
 impl SupportedCompression {
     /// If the given byte slice starts with the "magic" bytes for a supported compression family, return
-    /// that family, for unsupported/uncompressed slices, return None
+    /// that family, for unsupported/uncompressed slices, return None.
+    /// Based on <https://en.wikipedia.org/wiki/List_of_file_signatures>.
     pub fn check(bytes: &[u8]) -> Option<Self> {
         if bytes.len() < 4 {
             // not enough bytes to perform prefix checks
             return None;
         }
         match bytes[..4] {
-            [31, 139, _, _]          => Some(Self::GZIP),
-            [0x78, 0x01, _, _] | // ZLIB0
-            [0x78, 0x9C, _, _] | // ZLIB1
-            [0x78, 0xDA, _, _]   // ZLIB2
-                                     => Some(Self::ZLIB),
+            [0x1f, 0x8B, _, _] => Some(Self::GZIP),
+            // Different zlib compression levels without preset dictionary.
+            [0x78, 0x01, _, _] => Some(Self::ZLIB),
+            [0x78, 0x5E, _, _] => Some(Self::ZLIB),
+            [0x78, 0x9C, _, _] => Some(Self::ZLIB),
+            [0x78, 0xDA, _, _] => Some(Self::ZLIB),
             [0x28, 0xB5, 0x2F, 0xFD] => Some(Self::ZSTD),
             _ => None,
         }

--- a/crates/polars-io/src/utils/compression.rs
+++ b/crates/polars-io/src/utils/compression.rs
@@ -20,13 +20,13 @@ impl SupportedCompression {
             return None;
         }
         match bytes[..4] {
-            [0x1f, 0x8B, _, _] => Some(Self::GZIP),
+            [0x1f, 0x8b, _, _] => Some(Self::GZIP),
             // Different zlib compression levels without preset dictionary.
             [0x78, 0x01, _, _] => Some(Self::ZLIB),
-            [0x78, 0x5E, _, _] => Some(Self::ZLIB),
-            [0x78, 0x9C, _, _] => Some(Self::ZLIB),
-            [0x78, 0xDA, _, _] => Some(Self::ZLIB),
-            [0x28, 0xB5, 0x2F, 0xFD] => Some(Self::ZSTD),
+            [0x78, 0x5e, _, _] => Some(Self::ZLIB),
+            [0x78, 0x9c, _, _] => Some(Self::ZLIB),
+            [0x78, 0xda, _, _] => Some(Self::ZLIB),
+            [0x28, 0xb5, 0x2f, 0xfd] => Some(Self::ZSTD),
             _ => None,
         }
     }

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -620,6 +620,16 @@ def test_compressed_csv(io_files_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     )
     assert_frame_equal(out, expected)
 
+    # different levels of zlib create different magic strings,
+    # try to cover them all.
+    for level in range(10):
+        csv_bytes = zlib.compress(csv.encode(), level=level)
+        out = pl.read_csv(csv_bytes)
+        expected = pl.DataFrame(
+            {"a": [1, 2, 3], "b": ["a", "b", "c"], "c": [1.0, 2.0, 3.0]}
+        )
+        assert_frame_equal(out, expected)
+
     # zstd compression
     csv_bytes = zstandard.compress(csv.encode())
     out = pl.read_csv(csv_bytes)


### PR DESCRIPTION
The library accpeted three possible zlib signatures, but https://en.wikipedia.org/wiki/List_of_file_signatures contains four options that have no preset dictionary,
based on compression levels. Some zlib-ng implementations seem to create only `0x78 0x5E` signatures, which was the one not polars, but it works fine.