### PR TITLE
perf: Lower .sort(maintain_order=True).head() to streaming top_k

### DIFF
--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -432,10 +432,13 @@ pub fn lower_ir(
             slice,
             sort_options,
         } => {
-            let by_column = by_column.clone();
             let slice = *slice;
-            let sort_options = sort_options.clone();
+            let mut by_column = by_column.clone();
+            let mut sort_options = sort_options.clone();
             let phys_input = lower_ir!(*input)?;
+
+            let mut cur_out_schema = (*output_schema).clone();
+            let mut with_row_idx = None;
 
             // See if we can insert a top k.
             let mut limit = u64::MAX;
@@ -447,7 +450,28 @@ pub fn lower_ir(
                 limit = limit.min(l as u64);
             };
 
-            let sort_in_stream = if limit < u64::MAX && !sort_options.maintain_order {
+            let mut stream = phys_input;
+            if limit < u64::MAX {
+                // If we need to maintain order augment with row index.
+                if sort_options.maintain_order {
+                    let row_idx_name = unique_column_name();
+                    with_row_idx = Some(row_idx_name.clone());
+                    cur_out_schema
+                        .insert_at_index(0, row_idx_name.clone(), DataType::IDX_DTYPE)
+                        .unwrap();
+                    stream = PhysStream::first(phys_sm.insert(PhysNode {
+                        output_schema: Arc::new(cur_out_schema.clone()),
+                        kind: PhysNodeKind::WithRowIndex {
+                            input: stream,
+                            name: row_idx_name.clone(),
+                            offset: None,
+                        },
+                    }));
+
+                    // No longer needed for the actual sort itself, handled by row index.
+                    sort_options.maintain_order = false;
+                }
+
                 let k_node =
                     expr_arena.add(AExpr::Literal(LiteralValue::Scalar(Scalar::from(limit))));
                 let k_selector = ExprIR::from_node(k_node, expr_arena);
@@ -460,27 +484,52 @@ pub fn lower_ir(
                     },
                 ));
 
-                let node = phys_sm.insert(PhysNode {
-                    output_schema: output_schema.clone(),
+                stream = PhysStream::first(phys_sm.insert(PhysNode {
+                    output_schema: Arc::new(cur_out_schema.clone()),
                     kind: PhysNodeKind::TopK {
-                        input: phys_input,
+                        input: stream,
                         k: PhysStream::first(k_node),
                         by_column: by_column.clone(),
                         reverse: sort_options.descending.iter().map(|x| !x).collect(),
                         nulls_last: sort_options.nulls_last.clone(),
                     },
-                });
-                PhysStream::first(node)
-            } else {
-                phys_input
-            };
-
-            PhysNodeKind::Sort {
-                input: sort_in_stream,
-                by_column,
-                slice,
-                sort_options,
+                }));
             }
+
+            // Add row index to sort-by columns if we introduced one.
+            if let Some(row_idx_name) = &with_row_idx {
+                let row_idx_node = expr_arena.add(AExpr::Column(row_idx_name.clone()));
+                by_column.push(ExprIR::new(
+                    row_idx_node,
+                    OutputName::ColumnLhs(row_idx_name.clone()),
+                ));
+                sort_options.descending.push(false);
+                sort_options.nulls_last.push(true);
+            }
+
+            stream = PhysStream::first(phys_sm.insert(PhysNode {
+                output_schema: Arc::new(cur_out_schema),
+                kind: PhysNodeKind::Sort {
+                    input: stream,
+                    by_column,
+                    slice,
+                    sort_options,
+                },
+            }));
+
+            // Remove the temporary row index column we added.
+            if with_row_idx.is_some() {
+                let exprs: Vec<_> = output_schema
+                    .iter_names()
+                    .map(|name| {
+                        let node = expr_arena.add(AExpr::Column(name.clone()));
+                        ExprIR::new(node, OutputName::ColumnLhs(name.clone()))
+                    })
+                    .collect();
+                stream = build_select_stream(stream, &exprs, expr_arena, phys_sm, expr_cache, ctx)?;
+            }
+
+            return Ok(stream);
         },
 
         IR::Union { inputs, options } => {

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -468,6 +468,15 @@ pub fn lower_ir(
                         },
                     }));
 
+                    // Add row index to sort columns.
+                    let row_idx_node = expr_arena.add(AExpr::Column(row_idx_name.clone()));
+                    by_column.push(ExprIR::new(
+                        row_idx_node,
+                        OutputName::ColumnLhs(row_idx_name.clone()),
+                    ));
+                    sort_options.descending.push(false);
+                    sort_options.nulls_last.push(true);
+
                     // No longer needed for the actual sort itself, handled by row index.
                     sort_options.maintain_order = false;
                 }
@@ -494,17 +503,6 @@ pub fn lower_ir(
                         nulls_last: sort_options.nulls_last.clone(),
                     },
                 }));
-            }
-
-            // Add row index to sort-by columns if we introduced one.
-            if let Some(row_idx_name) = &with_row_idx {
-                let row_idx_node = expr_arena.add(AExpr::Column(row_idx_name.clone()));
-                by_column.push(ExprIR::new(
-                    row_idx_node,
-                    OutputName::ColumnLhs(row_idx_name.clone()),
-                ));
-                sort_options.descending.push(false);
-                sort_options.nulls_last.push(true);
             }
 
             stream = PhysStream::first(phys_sm.insert(PhysNode {

--- a/py-polars/tests/unit/operations/test_top_k.py
+++ b/py-polars/tests/unit/operations/test_top_k.py
@@ -576,3 +576,12 @@ def test_bottom_k_by() -> None:
     assert_series_equal(
         s.bottom_k_by("a", 4), pl.Series("a", [3, 2, 1, 5]), check_order=False
     )
+
+
+def test_sort_head_maintain_order() -> None:
+    df = pl.DataFrame(
+        {"x": [2, 0, 8, 0, 0, 0, 7, 0, 9, 0], "y": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}
+    )
+    expected = pl.DataFrame({"x": [0, 0, 0, 0], "y": [1, 3, 4, 5]})
+    q = df.lazy().sort(by="x", maintain_order=True).head(4)
+    assert_frame_equal(q.collect(), expected)


### PR DESCRIPTION
Follow-up from https://github.com/pola-rs/polars/pull/23979. Augments with a row index before applying the `top_k` if `maintain_order` is set.