### PR TITLE
ci: Fix hive partition string encoding in CI by upgrading `deltalake`

### DIFF
--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -43,7 +43,7 @@ openpyxl
 xlsx2csv
 xlsxwriter
 # Other I/O
-deltalake>=1.0.0
+deltalake>=1.1.4
 # Csv
 zstandard
 # Plotting

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -1070,3 +1070,37 @@ print("OK", end="")
     )
 
     assert out == b"OK"
+
+
+def test_hive_decode_reserved_ascii_23241(tmp_path: Path) -> None:
+    partitioned_tbl_uri = (tmp_path / "partitioned_data").resolve()
+    start, stop = 32, 127
+    df = pl.DataFrame(
+        {
+            "a": list(range(start, stop)),
+            "strings": [chr(i) for i in range(start, stop)],
+        }
+    )
+    df.write_delta(partitioned_tbl_uri, delta_write_options={"partition_by": "strings"})
+    out = pl.read_delta(str(partitioned_tbl_uri)).sort("a").select(pl.col("strings"))
+
+    assert_frame_equal(df.sort(by=pl.col("a")).select(pl.col("strings")), out)
+
+
+def test_hive_decode_utf8_23241(tmp_path: Path) -> None:
+    df = pl.DataFrame(
+        {
+            "strings": [
+                "Türkiye And Egpyt",
+                "résumé père forêt Noël",
+                "😊",
+                "北极熊",  # a polar bear perhaps ?!
+            ],
+            "a": [10, 20, 30, 40],
+        }
+    )
+    partitioned_tbl_uri = (tmp_path / "partitioned_data").resolve()
+    df.write_delta(partitioned_tbl_uri, delta_write_options={"partition_by": "strings"})
+    out = pl.read_delta(str(partitioned_tbl_uri)).sort("a").select(pl.col("strings"))
+
+    assert_frame_equal(df.sort(by=pl.col("a")).select(pl.col("strings")), out)


### PR DESCRIPTION
Closes #23367 

The proper fix is to upgrade the client environment to deltalake v1.1.4 or higher, at which point any newly created hive partitions will be correctly encoded. See https://github.com/delta-io/delta-rs/pull/3661#issuecomment-3172833487 for the fixing PR.

This PR includes:
- Update deltalake in CI to the minimum version.
- Tests to catch any regression.