### PR TITLE
refactor: Remove cache hits, clean up in-mem prefill

### DIFF
--- a/crates/polars-lazy/src/tests/cse.rs
+++ b/crates/polars-lazy/src/tests/cse.rs
@@ -160,10 +160,7 @@ fn test_cse_union2_4925() -> PolarsResult<()> {
         .flat_map(|(_, lp)| {
             use IR::*;
             match lp {
-                Cache { id, cache_hits, .. } => {
-                    assert_eq!(*cache_hits, 1);
-                    Some(*id)
-                },
+                Cache { id, .. } => Some(*id),
                 _ => None,
             }
         })
@@ -213,13 +210,7 @@ fn test_cse_joins_4954() -> PolarsResult<()> {
         .flat_map(|(_, lp)| {
             use IR::*;
             match lp {
-                Cache {
-                    id,
-                    cache_hits,
-                    input,
-                    ..
-                } => {
-                    assert_eq!(*cache_hits, 1);
+                Cache { id, input, .. } => {
                     assert!(matches!(lp_arena.get(*input), IR::SimpleProjection { .. }));
 
                     Some(*id)

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -209,7 +209,7 @@ fn create_physical_plan_impl(
     expr_arena: &mut Arena<AExpr>,
     state: &mut ConversionState,
     // Cache nodes in order of discovery
-    cache_nodes: &mut PlIndexMap<UniqueId, Box<executors::CacheExec>>,
+    cache_nodes: &mut PlIndexMap<UniqueId, executors::CachePrefill>,
     build_streaming_executor: Option<StreamingExecutorBuilder>,
 ) -> PolarsResult<Box<dyn Executor>> {
     use IR::*;
@@ -360,31 +360,16 @@ fn create_physical_plan_impl(
                         input, builder, root, lp_arena, expr_arena,
                     ));
 
-                    let id = UniqueId::new();
-
                     // Use cache so that this runs during the cache pre-filling stage and not on the
                     // thread pool, it could deadlock since the streaming engine uses the thread
                     // pool internally.
-                    let existing = cache_nodes.insert(
-                        id,
-                        Box::new(executors::CacheExec {
-                            input: Some(executor),
-                            id,
-                            count: 0,
-                            is_new_streaming_scan: false,
-                        }),
-                    );
+                    let mut prefill = executors::CachePrefill::new_sink(executor);
+                    let exec = prefill.make_exec();
+                    let existing = cache_nodes.insert(prefill.id(), prefill);
 
                     assert!(existing.is_none());
 
-                    Ok(Box::new(executors::CacheExec {
-                        id,
-                        // Rest of the fields don't matter - the actual node was inserted into
-                        // `cache_nodes`.
-                        input: None,
-                        count: Default::default(),
-                        is_new_streaming_scan: false,
-                    }))
+                    Ok(Box::new(exec))
                 },
             }
         },
@@ -507,36 +492,14 @@ fn create_physical_plan_impl(
 
                     let executor = build_func(root, lp_arena, expr_arena)?;
 
-                    // Generate a unique ID for this scan. Currently this scan can be visited only
-                    // once, since common subplans are always behind a cache, which prevents
-                    // multiple traversals of the common subplan.
-                    //
-                    // If this property changes in the future, the same scan could be visited
-                    // and executed multiple times. It is a responsibility of the caller to
-                    // insert a cache if multiple executions are not desirable.
-                    let id = UniqueId::new();
+                    let mut prefill = executors::CachePrefill::new_scan(executor);
+                    let exec = prefill.make_exec();
 
-                    let existing = cache_nodes.insert(
-                        id,
-                        Box::new(executors::CacheExec {
-                            input: Some(executor),
-                            id,
-                            // This is (n_hits - 1), because the drop logic is `fetch_sub(1) == 0`.
-                            count: 0,
-                            is_new_streaming_scan: true,
-                        }),
-                    );
+                    let existing = cache_nodes.insert(prefill.id(), prefill);
 
                     assert!(existing.is_none());
 
-                    Ok(Box::new(executors::CacheExec {
-                        id,
-                        // Rest of the fields don't matter - the actual node was inserted into
-                        // `cache_nodes`.
-                        input: None,
-                        count: Default::default(),
-                        is_new_streaming_scan: true,
-                    }))
+                    Ok(Box::new(exec))
                 },
                 #[allow(unreachable_patterns)]
                 _ => unreachable!(),
@@ -607,33 +570,22 @@ fn create_physical_plan_impl(
                 sort_options,
             }))
         },
-        Cache {
-            input,
-            id,
-            cache_hits,
-        } => {
+        Cache { input, id } => {
             state.has_cache_parent = true;
             state.has_cache_child = true;
 
-            if !cache_nodes.contains_key(&id) {
+            if let Some(cache) = cache_nodes.get_mut(&id) {
+                Ok(Box::new(cache.make_exec()))
+            } else {
                 let input = recurse!(input, state)?;
 
-                let cache = Box::new(executors::CacheExec {
-                    id,
-                    input: Some(input),
-                    count: cache_hits,
-                    is_new_streaming_scan: false,
-                });
+                let mut prefill = executors::CachePrefill::new_cache(input, id);
+                let exec = prefill.make_exec();
 
-                cache_nodes.insert(id, cache);
+                cache_nodes.insert(id, prefill);
+
+                Ok(Box::new(exec))
             }
-
-            Ok(Box::new(executors::CacheExec {
-                id,
-                input: None,
-                count: cache_hits,
-                is_new_streaming_scan: false,
-            }))
         },
         Distinct { input, options } => {
             let input = recurse!(input, state)?;
@@ -1104,7 +1056,6 @@ mod tests {
         let cache = ir.add(IR::Cache {
             input: scan,
             id: UniqueId::new(),
-            cache_hits: 1,
         });
 
         let left_sink = ir.add(IR::Sink {

--- a/crates/polars-plan/src/constants.rs
+++ b/crates/polars-plan/src/constants.rs
@@ -7,7 +7,6 @@ pub static POLARS_TMP_PREFIX: &str = "_POLARS_";
 pub static POLARS_PLACEHOLDER: &str = "_POLARS_<>";
 pub const LEN: &str = "len";
 const LITERAL_NAME: &str = "literal";
-pub const UNLIMITED_CACHE: u32 = u32::MAX;
 
 // Cache the often used LITERAL and LEN constants
 static LITERAL_NAME_INIT: OnceLock<PlSmallStr> = OnceLock::new();

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -436,11 +436,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 .to_owned();
             let input =
                 to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_here!(cache)))?;
-            IR::Cache {
-                input,
-                id,
-                cache_hits: crate::constants::UNLIMITED_CACHE,
-            }
+            IR::Cache { input, id }
         },
         DslPlan::GroupBy {
             input,

--- a/crates/polars-plan/src/plans/ir/dot.rs
+++ b/crates/polars-plan/src/plans/ir/dot.rs
@@ -6,7 +6,6 @@ use polars_utils::pl_str::PlSmallStr;
 use polars_utils::unique_id::UniqueId;
 
 use super::format::ExprIRSliceDisplay;
-use crate::constants::UNLIMITED_CACHE;
 use crate::prelude::ir::format::ColumnsDisplay;
 use crate::prelude::*;
 
@@ -106,16 +105,10 @@ impl<'a> IRDotDisplay<'a> {
 
                 write_label(f, id, |f| f.write_str("HCONCAT"))?;
             },
-            Cache {
-                input, cache_hits, ..
-            } => {
+            Cache { input, .. } => {
                 self.with_root(*input)._format(f, Some(id), last)?;
 
-                if *cache_hits == UNLIMITED_CACHE {
-                    write_label(f, id, |f| f.write_str("CACHE"))?;
-                } else {
-                    write_label(f, id, |f| write!(f, "CACHE: {cache_hits} times"))?;
-                };
+                write_label(f, id, |f| f.write_str("CACHE"))?;
             },
             Filter { predicate, input } => {
                 self.with_root(*input)._format(f, Some(id), last)?;

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -792,15 +792,7 @@ pub fn write_ir_non_recursive(
             };
             write!(f, "{:indent$}SORT BY {by_column}", "")
         },
-        IR::Cache {
-            input: _,
-            id,
-            cache_hits,
-        } => write!(
-            f,
-            "{:indent$}CACHE[id: {}, cache_hits: {}]",
-            "", *id, *cache_hits
-        ),
+        IR::Cache { input: _, id } => write!(f, "{:indent$}CACHE[id: {id}]", ""),
         IR::GroupBy {
             input: _,
             keys,

--- a/crates/polars-plan/src/plans/ir/mod.rs
+++ b/crates/polars-plan/src/plans/ir/mod.rs
@@ -93,8 +93,6 @@ pub enum IR {
         input: Node,
         /// This holds the `Arc<DslPlan>` to guarantee uniqueness.
         id: UniqueId,
-        /// How many hits the cache must be saved in memory.
-        cache_hits: u32,
     },
     GroupBy {
         input: Node,

--- a/crates/polars-plan/src/plans/ir/tree_format.rs
+++ b/crates/polars-plan/src/plans/ir/tree_format.rs
@@ -237,15 +237,8 @@ impl<'a> TreeFmtNode<'a> {
                             .map(|(i, lp_root)| self.lp_node(Some(format!("PLAN {i}:")), *lp_root))
                             .collect(),
                     ),
-                    Cache {
-                        input,
-                        id,
-                        cache_hits,
-                    } => ND(
-                        wh(
-                            h,
-                            &format!("CACHE[id: {}, cache_hits: {}]", id, *cache_hits),
-                        ),
+                    Cache { input, id } => ND(
+                        wh(h, &format!("CACHE[id: {id}]")),
                         vec![self.lp_node(None, *input)],
                     ),
                     Filter { input, predicate } => ND(

--- a/crates/polars-plan/src/plans/optimizer/collapse_and_project.rs
+++ b/crates/polars-plan/src/plans/optimizer/collapse_and_project.rs
@@ -105,22 +105,15 @@ impl OptimizationRule for SimpleProjectionAndCollapse {
                 }
             },
             // if there are 2 subsequent caches, flatten them and only take the inner
-            Cache {
-                input,
-                cache_hits: outer_cache_hits,
-                ..
-            } if !self.eager => {
+            Cache { input, .. } if !self.eager => {
                 if let Cache {
                     input: prev_input,
                     id,
-                    cache_hits,
                 } = lp_arena.get(*input)
                 {
                     Ok(Some(Cache {
                         input: *prev_input,
                         id: *id,
-                        // ensure the counts are updated
-                        cache_hits: cache_hits.saturating_add(*outer_cache_hits),
                     }))
                 } else {
                     Ok(None)

--- a/crates/polars-plan/src/plans/optimizer/cse/cse_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/cse_lp.rs
@@ -351,7 +351,6 @@ impl RewritingVisitor for CommonSubPlanRewriter<'_> {
         let cache_node = IR::Cache {
             input: node.node(),
             id: cache_id,
-            cache_hits: cache_count - 1,
         };
         node.assign(cache_node, &mut arena.0);
         let (_count, nodes) = self

--- a/crates/polars-plan/src/plans/visitor/hash.rs
+++ b/crates/polars-plan/src/plans/visitor/hash.rs
@@ -182,13 +182,8 @@ impl Hash for HashableEqLP<'_> {
                 payload.traverse_and_hash(self.expr_arena, state);
             },
             IR::SinkMultiple { .. } => {},
-            IR::Cache {
-                input: _,
-                id,
-                cache_hits,
-            } => {
+            IR::Cache { input: _, id } => {
                 id.hash(state);
-                cache_hits.hash(state);
             },
             #[cfg(feature = "merge_sorted")]
             IR::MergeSorted {

--- a/crates/polars-python/src/lazyframe/visit.rs
+++ b/crates/polars-python/src/lazyframe/visit.rs
@@ -58,7 +58,7 @@ impl NodeTraverser {
     // Increment major on breaking changes to the IR (e.g. renaming
     // fields, reordering tuples), minor on backwards compatible
     // changes (e.g. exposing a new expression node).
-    const VERSION: Version = (9, 0);
+    const VERSION: Version = (9, 1);
 
     pub fn new(root: Node, lp_arena: Arena<IR>, expr_arena: Arena<AExpr>) -> Self {
         Self {

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -230,8 +230,6 @@ pub struct Cache {
     input: usize,
     #[pyo3(get)]
     id_: u128,
-    #[pyo3(get)]
-    cache_hits: u32,
 }
 
 #[pyclass]
@@ -483,14 +481,9 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
             slice: *slice,
         }
         .into_py_any(py),
-        IR::Cache {
-            input,
-            id,
-            cache_hits,
-        } => Cache {
+        IR::Cache { input, id } => Cache {
             input: input.0,
             id_: id.as_u128(),
-            cache_hits: *cache_hits,
         }
         .into_py_any(py),
         IR::GroupBy {

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -843,11 +843,7 @@ pub fn lower_ir(
             options: options.clone(),
         },
 
-        IR::Cache {
-            input,
-            id,
-            cache_hits: _,
-        } => {
+        IR::Cache { input, id } => {
             let id = *id;
             if let Some(cached) = cache_nodes.get(&id) {
                 return Ok(*cached);


### PR DESCRIPTION
Cache hits are error-prone to manage when transforming the plan, and the executors can infer them while lowering the IR.