### PR TITLE
fix: Allocator capsule fallback panic

### DIFF
--- a/pyo3-polars/pyo3-polars/src/alloc.rs
+++ b/pyo3-polars/pyo3-polars/src/alloc.rs
@@ -70,9 +70,10 @@ impl PolarsAllocator {
             let r = (unsafe { Py_IsInitialized() } != 0)
                 .then(|| {
                     Python::with_gil(|_| unsafe {
-                        let capsule = (PyCapsule_Import(ALLOCATOR_CAPSULE_NAME.as_ptr() as *const c_char, 0)
-                            as *const AllocatorCapsule)
-                            .as_ref();
+                        let capsule =
+                            (PyCapsule_Import(ALLOCATOR_CAPSULE_NAME.as_ptr() as *const c_char, 0)
+                                as *const AllocatorCapsule)
+                                .as_ref();
                         if capsule.is_none() {
                             pyo3::ffi::PyErr_Clear();
                         }


### PR DESCRIPTION
Another fix for https://github.com/pola-rs/polars/issues/23965 so if we don't expose an allocator capsule (or under a new name) we don't get a hard error but simply use the fallback.
