### PR TITLE
chore: Remove insert_error_function

### DIFF
--- a/pyo3-polars/pyo3-polars-derive/src/lib.rs
+++ b/pyo3-polars/pyo3-polars-derive/src/lib.rs
@@ -1,8 +1,6 @@
 mod attr;
 mod keywords;
 
-use std::sync::atomic::{AtomicBool, Ordering};
-
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, FnArg};


### PR DESCRIPTION
The `pub use` of `_polars_plugin_get_last_error_message` shouldn't be necessary, it should already be exported by nature of being marked `#[no_mangle] extern "C"`.