### PR TITLE
chore: Use .venv instead of venv in pyo3-polars examples

### DIFF
--- a/pyo3-polars/example/derive_expression/Makefile
+++ b/pyo3-polars/example/derive_expression/Makefile
@@ -1,25 +1,25 @@
 
 SHELL=/bin/bash
 
-venv:  ## Set up virtual environment
-	python3 -m venv venv
-	venv/bin/pip install -r requirements.txt
+.venv:  ## Set up virtual environment
+	python3 -m venv .venv
+	.venv/bin/pip install -r requirements.txt
 
-install: venv
+install: .venv
 	unset CONDA_PREFIX && \
-	source venv/bin/activate && maturin develop -m expression_lib/Cargo.toml
+	source .venv/bin/activate && maturin develop -m expression_lib/Cargo.toml
 
-install-release: venv
+install-release: .venv
 	unset CONDA_PREFIX && \
-	source venv/bin/activate && maturin develop --release -m expression_lib/Cargo.toml
+	source .venv/bin/activate && maturin develop --release -m expression_lib/Cargo.toml
 
 clean:
-	-@rm -r venv
+	-@rm -r .venv
 	-@cd expression_lib && cargo clean
 
 
 run: install
-	source venv/bin/activate && python run.py
+	source .venv/bin/activate && python run.py
 
 run-release: install-release
-	source venv/bin/activate && python run.py
+	source .venv/bin/activate && python run.py

--- a/pyo3-polars/example/extend_polars_python_dispatch/Makefile
+++ b/pyo3-polars/example/extend_polars_python_dispatch/Makefile
@@ -1,19 +1,19 @@
 
 SHELL=/bin/bash
 
-venv:  ## Set up virtual environment
-	python3 -m venv venv
-	venv/bin/pip install -r requirements.txt
+.venv:  ## Set up virtual environment
+	python3 -m venv .venv
+	.venv/bin/pip install -r requirements.txt
 
-install: venv
+install: .venv
 	unset CONDA_PREFIX && \
-	source venv/bin/activate && maturin develop -m extend_polars/Cargo.toml
+	source .venv/bin/activate && maturin develop -m extend_polars/Cargo.toml
 	cd ../../../py-polars && maturin develop
 
 clean:
-	-@rm -r venv
+	-@rm -r .venv
 	-@cd extend_polars && cargo clean
 
 
 run: install
-	source venv/bin/activate && python run.py
+	source .venv/bin/activate && python run.py

--- a/pyo3-polars/example/io_plugin/Makefile
+++ b/pyo3-polars/example/io_plugin/Makefile
@@ -1,19 +1,19 @@
 
 SHELL=/bin/bash
 
-venv:  ## Set up virtual environment
-	python3 -m venv venv
-	venv/bin/pip install -r requirements.txt
+.venv:  ## Set up virtual environment
+	python3 -m venv .venv
+	.venv/bin/pip install -r requirements.txt
 
-install: venv
+install: .venv
 	unset CONDA_PREFIX && \
-	source venv/bin/activate && maturin develop -m io_plugin/Cargo.toml
+	source .venv/bin/activate && maturin develop -m io_plugin/Cargo.toml
 	cd ../../../py-polars && maturin develop
 
 clean:
-	-@rm -r venv
+	-@rm -r .venv
 	-@cd extend_polars && cargo clean
 
 
 run: install
-	source venv/bin/activate && python run.py
+	source .venv/bin/activate && python run.py


### PR DESCRIPTION
This ensures our repository-wide .gitignore ignores these.