### PR TITLE
fix: Allow join on Decimal in in-memory engine

### DIFF
--- a/crates/polars-core/src/series/implementations/decimal.rs
+++ b/crates/polars-core/src/series/implementations/decimal.rs
@@ -11,7 +11,7 @@ unsafe impl IntoSeries for DecimalChunked {
 
 impl private::PrivateSeriesNumeric for SeriesWrap<DecimalChunked> {
     fn bit_repr(&self) -> Option<BitRepr> {
-        None
+        Some(self.0.physical().to_bit_repr())
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/24020.