### PR TITLE
fix: Planner output type for `mean` with strange output type

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
@@ -509,17 +509,21 @@ impl<'a> FieldsMapper<'a> {
 
     pub fn moment_dtype(&self) -> PolarsResult<Field> {
         let map_inner = |dt: &DataType| match dt {
+            DataType::Boolean => DataType::Float64,
+            DataType::Float32 => DataType::Float32,
+            DataType::Float64 => DataType::Float64,
+            dt if dt.is_primitive_numeric() => DataType::Float64,
             #[cfg(feature = "dtype-datetime")]
             dt @ DataType::Datetime(_, _) => dt.clone(),
             #[cfg(feature = "dtype-duration")]
             dt @ DataType::Duration(_) => dt.clone(),
             #[cfg(feature = "dtype-time")]
             dt @ DataType::Time => dt.clone(),
-            DataType::Float32 => DataType::Float32,
             #[cfg(feature = "dtype-decimal")]
             DataType::Decimal(..) => DataType::Float64,
-            DataType::Boolean => DataType::Float64,
-            _ => DataType::Float64,
+
+            // All other types get mapped to a single `null` of the same type.
+            dt => dt.clone(),
         };
 
         self.map_dtype(|dt| match dt {

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -368,3 +368,9 @@ def test_scalar_agg_schema_20044() -> None:
         .group_by("c")
         .agg(pl.col("d").mean())
     ).schema == pl.Schema([("c", pl.String), ("d", pl.Float64)])
+
+
+def test_mean_on_invalid_type_24008() -> None:
+    df = pl.DataFrame({"s": ["bob", "foo"]})
+    q = df.lazy().select(pl.col("s").mean())
+    assert q.collect_schema() == q.collect().schema


### PR DESCRIPTION
Fixes #24008.