### PR TITLE
feat: Build and test against Pyodide 0.28 (new `pyodide_2025_0` ABI), and build with WASM exception handling

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -336,7 +336,7 @@ jobs:
           sed -E -i "/^  \"(${FEATURES})\",$/d" crates/polars-python/Cargo.toml py-polars/Cargo.toml
 
       - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v14
+        uses: pyodide/setup-emsdk@v15
         with:
           # This should match the exact version of Emscripten used by Pyodide
           # UPDATE; set to latest due to breaking build

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -339,8 +339,9 @@ jobs:
         uses: pyodide/setup-emsdk@v15
         with:
           # This should match the exact version of Emscripten used by Pyodide
-          # UPDATE; set to latest due to breaking build
-          version: latest
+          # Pyodide 0.28 uses Emscripten 4.0.9:
+          # https://github.com/pyodide/pyodide/blob/0db5ff79f310694a7d72ae0b3279e9809ab836d6/Makefile.envs
+          version: 4.0.9
 
       - name: Set CFLAGS and RUSTFLAGS for wasm32
         run: |

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -345,7 +345,7 @@ jobs:
 
       - name: Set CFLAGS and RUSTFLAGS for wasm32
         run: |
-            echo "CFLAGS=-fPIC" >> $GITHUB_ENV
+            echo "CFLAGS=-fPIC -fwasm-exceptions" >> $GITHUB_ENV
             echo "RUSTFLAGS=-C link-self-contained=no" >> $GITHUB_ENV
 
       - name: Build wheel

--- a/.github/workflows/test-pyodide.yml
+++ b/.github/workflows/test-pyodide.yml
@@ -47,7 +47,7 @@ jobs:
           sed -E -i "/^  \"(${FEATURES})\",$/d" crates/polars-python/Cargo.toml py-polars/Cargo.toml
 
       - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v14
+        uses: pyodide/setup-emsdk@v15
         with:
           # This should match the exact version of Emscripten used by Pyodide
           version: 3.1.58

--- a/.github/workflows/test-pyodide.yml
+++ b/.github/workflows/test-pyodide.yml
@@ -59,8 +59,8 @@ jobs:
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 19
-          echo "EM_LLVM_ROOT=/usr/lib/llvm-19/bin" >> $GITHUB_ENV
+          sudo ./llvm.sh 20
+          echo "EM_LLVM_ROOT=/usr/lib/llvm-20/bin" >> $GITHUB_ENV
 
       - name: Build wheel
         uses: PyO3/maturin-action@v1
@@ -70,5 +70,5 @@ jobs:
           args: >
             --profile dev
             --manifest-path py-polars/Cargo.toml
-            --interpreter python3.10
+            --interpreter python3.13
           maturin-version: 1.7.4

--- a/.github/workflows/test-pyodide.yml
+++ b/.github/workflows/test-pyodide.yml
@@ -50,7 +50,9 @@ jobs:
         uses: pyodide/setup-emsdk@v15
         with:
           # This should match the exact version of Emscripten used by Pyodide
-          version: 3.1.58
+          # Pyodide 0.28 uses Emscripten 4.0.9:
+          # https://github.com/pyodide/pyodide/blob/0db5ff79f310694a7d72ae0b3279e9809ab836d6/Makefile.envs
+          version: 4.0.9
 
       - name: Install LLVM
         # This should match the major version of LLVM expected by Emscripten

--- a/.github/workflows/test-pyodide.yml
+++ b/.github/workflows/test-pyodide.yml
@@ -24,7 +24,7 @@ concurrency:
 
 env:
   RUSTFLAGS: -C link-self-contained=no -C debuginfo=0
-  CFLAGS: -fPIC
+  CFLAGS: -fPIC -fwasm-exceptions
 
 defaults:
   run:


### PR DESCRIPTION
> [!NOTE]
> This PR is a draft, and its description is a stub. It shall be updated when it is closer to a stage where it is ready for review.

This PR updates the Pyodide/Emscripten builds to use Emscripten 4.0.9 (setting to `latest` caused builds against Emscripten 4.0.12, which is higher than the version used for the `pyodide_2025_0` ABI introduced in Pyodide 0.28), and updates the test job accordingly.

We enabled `-fwasm-exceptions` in Pyodide 0.28 release, so that flag is now passed to `CFLAGS` as well.

cc: @ryanking13

xref https://github.com/pyodide/pyodide-recipes/issues/99, https://github.com/marimo-team/marimo/pull/5995
