### PR TITLE
feat: Add peak_{min,max} support for booleans

### DIFF
--- a/crates/polars-ops/src/chunked_array/peaks.rs
+++ b/crates/polars-ops/src/chunked_array/peaks.rs
@@ -11,6 +11,11 @@ pub fn peak_min_max(
     let column = column.to_physical_repr();
     let column = column.as_materialized_series();
     match column.dtype() {
+        dt if dt.is_bool() => {
+            let series = column.cast(&DataType::Int8)?;
+            let column = series.into_column();
+            peak_min_max(&column, start, end, is_peak_max)
+        },
         dt if dt.is_primitive_numeric() => {
             with_match_physical_numeric_polars_type!(dt, |$T| {
                 let ca: &ChunkedArray<$T> = column.as_ref().as_ref().as_ref();

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1562,14 +1562,30 @@ def test_dot() -> None:
         s1 @ [4, 5, 6, 7, 8]
 
 
-def test_peak_max_peak_min() -> None:
-    s = pl.Series("a", [4, 1, 3, 2, 5])
+@pytest.mark.parametrize(
+    ("dtype"),
+    [pl.Int8, pl.Int16, pl.Int32, pl.Float32, pl.Float64],
+)
+def test_peak_max_peak_min(dtype: pl.DataType) -> None:
+    s = pl.Series("a", [4, 1, 3, 2, 5], dtype=dtype)
+
     result = s.peak_min()
     expected = pl.Series("a", [False, True, False, True, False])
     assert_series_equal(result, expected)
 
     result = s.peak_max()
     expected = pl.Series("a", [True, False, True, False, True])
+    assert_series_equal(result, expected)
+
+
+def test_peak_max_peak_min_bool() -> None:
+    s = pl.Series("a", [False, True, False, True, True, False], dtype=pl.Boolean)
+    result = s.peak_min()
+    expected = pl.Series("a", [False, False, True, False, False, False])
+    assert_series_equal(result, expected)
+
+    result = s.peak_max()
+    expected = pl.Series("a", [False, True, False, False, False, False])
     assert_series_equal(result, expected)
 
 


### PR DESCRIPTION
This patch adds `peak_min` and `peak_max` support for boolean types.

The behavior of the patch is the same as for the integer types: On edge values, it is assumed that the out-of-bounds neighbor is equal to `False` (vs `0`).

Example:

```python
s = pl.Series("a", [False, True, False, True, True, False], dtype=pl.Boolean)
result = s.peak_min()
expected = pl.Series("a", [False, False, True, False, False, False])
assert_series_equal(result, expected)

result = s.peak_max()
expected = pl.Series("a", [False, True, False, False, False, False])
assert_series_equal(result, expected)
```