### PR TITLE
fix: Correct `.rolling()` output type for non-aggregations

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -98,7 +98,7 @@ impl AExpr {
                 let e = ctx.arena.get(*function);
                 let mut field = e.to_field_impl(ctx)?;
 
-                if let WindowType::Over(WindowMapping::Join) = options {
+                if let WindowType::Over(WindowMapping::Join) | WindowType::Rolling(_) = options {
                     if !is_scalar_ae(*function, ctx.arena) {
                         field.dtype = DataType::List(Box::new(field.dtype));
                     }

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -739,3 +739,10 @@ def test_rolling_max_23066() -> None:
             {"data": [None, None, None, None, None, 40.0, 40.0, 10.0, 30.0, None]}
         ),
     )
+
+
+def test_rolling_non_aggregation_24012() -> None:
+    df = pl.DataFrame({"idx": [1, 2], "value": ["a", "b"]})
+    q = df.lazy().select(pl.col("value").rolling("idx", period="2i"))
+
+    assert q.collect_schema() == q.collect().schema


### PR DESCRIPTION
Fixes #24012.