### PR TITLE
fix: Upcast to `i128` when calling `diff` on `u64` series

### DIFF
--- a/crates/polars-ops/src/series/ops/diff.rs
+++ b/crates/polars-ops/src/series/ops/diff.rs
@@ -2,22 +2,13 @@ use polars_core::prelude::*;
 use polars_core::series::ops::NullBehavior;
 
 pub fn diff(s: &Series, n: i64, null_behavior: NullBehavior) -> PolarsResult<Series> {
-    use DataType::*;
-    let s = match s.dtype() {
-        UInt8 => s.cast(&Int16)?,
-        UInt16 => s.cast(&Int32)?,
-        UInt32 => s.cast(&Int64)?,
-        UInt64 => s.cast(&Int128)?,
-        _ => s.clone(),
-    };
-
     match null_behavior {
-        NullBehavior::Ignore => &s - &s.shift(n),
+        NullBehavior::Ignore => s.clone() - s.shift(n),
         NullBehavior::Drop => {
             polars_ensure!(n > 0, InvalidOperation: "only positive integer allowed if nulls are dropped in 'diff' operation");
             let n = n as usize;
             let len = s.len() - n;
-            &s.slice(n as i64, len) - &s.slice(0, len)
+            s.slice(n as i64, len) - s.slice(0, len)
         },
     }
 }

--- a/crates/polars-ops/src/series/ops/diff.rs
+++ b/crates/polars-ops/src/series/ops/diff.rs
@@ -6,7 +6,8 @@ pub fn diff(s: &Series, n: i64, null_behavior: NullBehavior) -> PolarsResult<Ser
     let s = match s.dtype() {
         UInt8 => s.cast(&Int16)?,
         UInt16 => s.cast(&Int32)?,
-        UInt32 | UInt64 => s.cast(&Int64)?,
+        UInt32 => s.cast(&Int64)?,
+        UInt64 => s.cast(&Int128)?,
         _ => s.clone(),
     };
 

--- a/crates/polars-plan/src/plans/aexpr/function_expr/list.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/list.rs
@@ -99,15 +99,16 @@ impl IRListFunction {
                 };
 
                 let inner_dt = match inner.as_ref() {
-                    #[cfg(feature = "dtype-datetime")]
-                    DataType::Datetime(tu, _) => DataType::Duration(*tu),
+                    DataType::UInt8 => DataType::Int16,
+                    DataType::UInt16 => DataType::Int32,
+                    DataType::UInt32 => DataType::Int64,
+                    DataType::UInt64 => DataType::Int128,
                     #[cfg(feature = "dtype-date")]
                     DataType::Date => DataType::Duration(TimeUnit::Microseconds),
+                    #[cfg(feature = "dtype-datetime")]
+                    DataType::Datetime(tu, _) => DataType::Duration(*tu),
                     #[cfg(feature = "dtype-time")]
                     DataType::Time => DataType::Duration(TimeUnit::Nanoseconds),
-                    DataType::UInt64 | DataType::UInt32 => DataType::Int64,
-                    DataType::UInt16 => DataType::Int32,
-                    DataType::UInt8 => DataType::Int16,
                     inner_dt => inner_dt.clone(),
                 };
 

--- a/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
@@ -203,15 +203,16 @@ impl IRFunctionExpr {
             },
             #[cfg(feature = "diff")]
             Diff(_) => mapper.map_dtype(|dt| match dt {
-                #[cfg(feature = "dtype-datetime")]
-                DataType::Datetime(tu, _) => DataType::Duration(*tu),
+                DataType::UInt8 => DataType::Int16,
+                DataType::UInt16 => DataType::Int32,
+                DataType::UInt32 => DataType::Int64,
+                DataType::UInt64 => DataType::Int128,
                 #[cfg(feature = "dtype-date")]
                 DataType::Date => DataType::Duration(TimeUnit::Microseconds),
+                #[cfg(feature = "dtype-datetime")]
+                DataType::Datetime(tu, _) => DataType::Duration(*tu),
                 #[cfg(feature = "dtype-time")]
                 DataType::Time => DataType::Duration(TimeUnit::Nanoseconds),
-                DataType::UInt64 | DataType::UInt32 => DataType::Int64,
-                DataType::UInt16 => DataType::Int32,
-                DataType::UInt8 => DataType::Int16,
                 dt => dt.clone(),
             }),
             #[cfg(feature = "pct_change")]

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -1010,7 +1010,7 @@ def test_list_agg_all_null(
         (pl.Datetime("us"), pl.Duration("us")),
         (pl.Date(), pl.Duration("us")),
         (pl.Time(), pl.Duration("ns")),
-        (pl.UInt64(), pl.Int64()),
+        (pl.UInt64(), pl.Int128()),
         (pl.UInt32(), pl.Int64()),
         (pl.UInt8(), pl.Int16()),
         (pl.Int8(), pl.Int8()),

--- a/py-polars/tests/unit/operations/test_diff.py
+++ b/py-polars/tests/unit/operations/test_diff.py
@@ -32,3 +32,10 @@ def test_diff_scalarity() -> None:
 
     result = df.select(pl.col("a").diff(2))
     assert_frame_equal(result, expected)
+
+
+def test_diff_u64() -> None:
+    lf = pl.LazyFrame({"a": pl.Series([1, 2**63 + 10], dtype=pl.UInt64)})
+    expected = pl.DataFrame({"a": pl.Series([None, 2**63 + 9], dtype=pl.Int128)})
+    assert_frame_equal(lf.collect(), expected)
+    assert lf.collect_schema() == expected.schema

--- a/py-polars/tests/unit/operations/test_diff.py
+++ b/py-polars/tests/unit/operations/test_diff.py
@@ -36,6 +36,7 @@ def test_diff_scalarity() -> None:
 
 def test_diff_u64() -> None:
     lf = pl.LazyFrame({"a": pl.Series([1, 2**63 + 10], dtype=pl.UInt64)})
+    result = lf.select(pl.col("a").diff())
     expected = pl.DataFrame({"a": pl.Series([None, 2**63 + 9], dtype=pl.Int128)})
-    assert_frame_equal(lf.collect(), expected)
-    assert lf.collect_schema() == expected.schema
+    assert_frame_equal(result.collect(), expected)
+    assert result.collect_schema() == expected.schema

--- a/py-polars/tests/unit/operations/test_ewm.py
+++ b/py-polars/tests/unit/operations/test_ewm.py
@@ -217,9 +217,8 @@ def test_ewm_with_multiple_chunks() -> None:
     )
     assert df0.n_chunks() == 1
 
-    # NOTE: We aren't testing whether `select` creates two chunks;
-    # we just need two chunks to properly test `ewm_mean`
-    df1 = df0.select(["ld_b", "ld_c"])
+    # We need two chunks to properly test `ewm_mean`
+    df1 = pl.concat((df0[:-1], df0[-1:])).select("ld_b", "ld_c")
     assert df1.n_chunks() == 2
 
     ewm_std = df1.with_columns(


### PR DESCRIPTION
Fixes #24080. i128 might not be ideal but I don't see any other way around this, aside from checking the min/max values and seeing if we *could* do a diff in a smaller dtype.

Also moved casting to IR.