### PR TITLE
fix(python): Ensure `read_database_uri` with ADBC works as expected with DuckDB URIs

### DIFF
--- a/py-polars/polars/io/database/_utils.py
+++ b/py-polars/polars/io/database/_utils.py
@@ -126,7 +126,7 @@ def _open_adbc_connection(connection_uri: str) -> Any:
     adbc_driver = _import_optional_adbc_driver(module_name)
 
     # some backends require the driver name to be stripped from the URI
-    if driver_name in ("sqlite", "snowflake"):
+    if driver_name in ("duckdb", "snowflake", "sqlite"):
         connection_uri = re.sub(f"^{driver_name}:/{{,3}}", "", connection_uri)
 
     return adbc_driver.connect(connection_uri)


### PR DESCRIPTION
Closes #23129; validated the fix locally. 

Note that we don't currently have a `duckdb` dependency in unit tests - do we want one? (Ideally we would have a more extensive database testing framework for CI [^1] 😅)

[^1]: https://github.com/pola-rs/polars/issues/12815