### PR TITLE
feat: Add a deprecation warning for pl.Series.shift(Null)

### DIFF
--- a/crates/polars-error/src/warning.rs
+++ b/crates/polars-error/src/warning.rs
@@ -27,14 +27,14 @@ pub enum PolarsWarning {
 
 #[macro_export]
 macro_rules! polars_warn {
-    ($variant:ident, $fmt:literal $(, $arg:tt)*) => {
+    ($variant:ident, $fmt:literal $(, $arg:expr)* $(,)?) => {
         {{
         let func = $crate::get_warning_function();
         let warn = $crate::PolarsWarning::$variant;
         func(format!($fmt, $($arg)*).as_ref(), warn)
         }}
     };
-    ($fmt:literal, $($arg:tt)+) => {
+    ($fmt:literal, $($arg:expr)+) => {
         {{
         let func = $crate::get_warning_function();
         func(format!($fmt, $($arg)+).as_ref(), $crate::PolarsWarning::UserWarning)

--- a/crates/polars-plan/src/plans/aexpr/function_expr/shift_and_fill.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/shift_and_fill.rs
@@ -113,11 +113,18 @@ pub fn shift(args: &[Column]) -> PolarsResult<Column> {
     ComputeError: "n must be a single value."
     );
 
-    let n_s = n_s.cast(&DataType::Int64)?;
-    let n = n_s.i64()?;
+    let n_cast_s = n_s.cast(&DataType::Int64)?;
+    let n = n_cast_s.i64()?;
 
     match n.get(0) {
         Some(n) => Ok(s.shift(n)),
-        None => Ok(Column::full_null(s.name().clone(), s.len(), s.dtype())),
+        None => {
+            polars_warn!(
+                Deprecation, // @2.0
+                "shift value `n` is not a valid integer ({:?}), which currently returns a column of null values. This will become an error in the future.",
+                &n_s.get(0)?,
+            );
+            Ok(Column::full_null(s.name().clone(), s.len(), s.dtype()))
+        },
     }
 }

--- a/crates/polars-plan/src/plans/aexpr/function_expr/shift_and_fill.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/shift_and_fill.rs
@@ -113,18 +113,12 @@ pub fn shift(args: &[Column]) -> PolarsResult<Column> {
     ComputeError: "n must be a single value."
     );
 
-    let n_cast_s = n_s.cast(&DataType::Int64)?;
-    let n = n_cast_s.i64()?;
+    let n_s = n_s.cast(&DataType::Int64)?;
+    let n = n_s.i64()?;
 
     match n.get(0) {
         Some(n) => Ok(s.shift(n)),
-        None => {
-            polars_warn!(
-                Deprecation, // @2.0
-                "shift value `n` is not a valid integer ({:?}), which currently returns a column of null values. This will become an error in the future.",
-                &n_s.get(0)?,
-            );
-            Ok(Column::full_null(s.name().clone(), s.len(), s.dtype()))
-        },
+        // @2.0: Non-numeric fill values are deprecated, and this branch should become an error.
+        None => Ok(Column::full_null(s.name().clone(), s.len(), s.dtype())),
     }
 }

--- a/crates/polars-plan/src/plans/aexpr/function_expr/shift_and_fill.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/shift_and_fill.rs
@@ -101,11 +101,15 @@ pub(super) fn shift_and_fill(args: &[Column]) -> PolarsResult<Column> {
             dt => polars_bail!(opq = shift_and_fill, dt),
         }
     } else {
+        polars_warn!(
+            Deprecation, // @2.0
+            "shift value 'n' is null, which currently returns a column of null values. This will become an error in the future.",
+        );
         Ok(Column::full_null(s.name().clone(), s.len(), s.dtype()))
     }
 }
 
-pub fn shift(args: &[Column]) -> PolarsResult<Column> {
+pub(super) fn shift(args: &[Column]) -> PolarsResult<Column> {
     let s = &args[0];
     let n_s = &args[1];
     polars_ensure!(
@@ -118,7 +122,12 @@ pub fn shift(args: &[Column]) -> PolarsResult<Column> {
 
     match n.get(0) {
         Some(n) => Ok(s.shift(n)),
-        // @2.0: Non-numeric fill values are deprecated, and this branch should become an error.
-        None => Ok(Column::full_null(s.name().clone(), s.len(), s.dtype())),
+        None => {
+            polars_warn!(
+                Deprecation, // @2.0
+                "shift value 'n' is null, which currently returns a column of null values. This will become an error in the future.",
+            );
+            Ok(Column::full_null(s.name().clone(), s.len(), s.dtype()))
+        },
     }
 }

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
@@ -733,23 +733,14 @@ pub(super) fn convert_functions(
             }
         },
         F::Append { upcast } => I::Append { upcast },
-        shift_function @ (F::ShiftAndFill | F::Shift) => {
+        F::ShiftAndFill => {
             polars_ensure!(&e[1].is_scalar(ctx.arena), ShapeMismatch: "'n' must be a scalar value");
-            let n_dtype = e[1].dtype(ctx.schema, ctx.arena)?;
-            // @2.0: This should become an error in 2.0.
-            if !n_dtype.is_numeric() {
-                polars_warn!(
-                    Deprecation,
-                    "'n' is not a valid integer (but of type {:?}), which currently returns a column of null values. This will become an error in the future.",
-                    n_dtype
-                );
-            }
-            if shift_function == F::ShiftAndFill {
-                polars_ensure!(&e[2].is_scalar(ctx.arena), ShapeMismatch: "'fill_value' must be a scalar value");
-                I::ShiftAndFill
-            } else {
-                I::Shift
-            }
+            polars_ensure!(&e[2].is_scalar(ctx.arena), ShapeMismatch: "'fill_value' must be a scalar value");
+            I::ShiftAndFill
+        },
+        F::Shift => {
+            polars_ensure!(&e[1].is_scalar(ctx.arena), ShapeMismatch: "'n' must be a scalar value");
+            I::Shift
         },
         F::DropNans => I::DropNans,
         F::DropNulls => I::DropNulls,

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
@@ -735,7 +735,7 @@ pub(super) fn convert_functions(
         F::Append { upcast } => I::Append { upcast },
         shift_function @ (F::ShiftAndFill | F::Shift) => {
             polars_ensure!(&e[1].is_scalar(ctx.arena), ShapeMismatch: "'n' must be a scalar value");
-            let n_dtype = e[1].dtype(&ctx.schema, &ctx.arena)?;
+            let n_dtype = e[1].dtype(ctx.schema, ctx.arena)?;
             // @2.0: This should become an error in 2.0.
             if !n_dtype.is_numeric() {
                 polars_warn!(

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
@@ -32,7 +32,7 @@ pub(super) fn convert_functions(
         let struct_node = struct_input.node();
         let struct_schema = Schema::from_iter(fields.iter().cloned());
 
-        let mut e: Vec<ExprIR> = Vec::with_capacity(input.len());
+        let mut e = Vec::with_capacity(input.len());
         e.push(struct_input);
 
         let prev = ctx.with_fields.replace((struct_node, struct_schema));

--- a/crates/polars-stream/src/nodes/shift.rs
+++ b/crates/polars-stream/src/nodes/shift.rs
@@ -191,8 +191,12 @@ impl ComputeNode for ShiftNode {
                 polars_ensure!(offset_frame.height() == 1, ComputeError: "got more than one value for 'n' in shift");
                 let offset_item = offset_frame.get_columns()[0].get(0)?;
                 let offset = if offset_item.is_null() {
-                    // Currently we require the entire output to become null if the
-                    // shift is null, simulate this with an infinite negative shift.
+                    polars_warn!(
+                        Deprecation, // @2.0
+                        "shift value 'n' is null, which currently returns a column of null values. This will become an error in the future.",
+                    );
+                    // @2.0: Currently we still require the entire output to become null
+                    // if the shift is null, simulate this with an infinite negative shift.
                     *fill = None;
                     i64::MIN
                 } else {

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -748,6 +748,6 @@ def test_raise_on_different_results_20104() -> None:
 
 def test_shift_with_null_deprecated_24105() -> None:
     with pytest.deprecated_call(
-        match=r"shift value `n` is not a valid integer \(Null\), which currently returns a column of null values. This will become an error in the future.",
+        match=r"'n' is not a valid integer \(but of type Null\), which currently returns a column of null values. This will become an error in the future."
     ):
         pl.Series([1, 2, 3]).shift(None)

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -744,3 +744,10 @@ def test_raise_on_different_results_20104() -> None:
             .gather_every(2, offset=1)
             .map_batches(pl.Series.min, return_dtype=pl.Float64)
         )
+
+
+def test_shift_with_null_deprecated_24105() -> None:
+    with pytest.deprecated_call(
+        match=r"shift value `n` is not a valid integer \(Null\), which currently returns a column of null values. This will become an error in the future.",
+    ):
+        pl.Series([1, 2, 3]).shift(None)

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import io
 from datetime import date, datetime, time, tzinfo
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pandas as pd
@@ -750,4 +750,4 @@ def test_shift_with_null_deprecated_24105() -> None:
     with pytest.deprecated_call(
         match=r"'n' is not a valid integer \(but of type Null\), which currently returns a column of null values. This will become an error in the future."
     ):
-        pl.Series([1, 2, 3]).shift(None)
+        pl.Series([1, 2, 3]).shift(cast(int, None))

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -746,9 +746,19 @@ def test_raise_on_different_results_20104() -> None:
         )
 
 
-def test_shift_with_null_deprecated_24105() -> None:
-    with pytest.deprecated_call(
-        match=r"'n' is not a valid integer \(but of type Null\), which currently returns a column of null values. This will become an error in the future."
+@pytest.mark.parametrize("fill_value", [None, -1])
+def test_shift_with_null_deprecated_24105(fill_value: Any) -> None:
+    df = pl.DataFrame({"x": [1, 2, 3]})
+    df_shift = None
+    with pytest.deprecated_call(  # @2.0
+        match=r"shift value 'n' is null, which currently returns a column of null values. This will become an error in the future.",
     ):
-        df = pl.DataFrame({"x": [1, 2, 3]})
-        df.select(pl.col.x.shift(pl.col.x.filter(pl.col.x > 3).first()))
+        df_shift = df.select(
+            pl.col.x.shift(pl.col.x.filter(pl.col.x > 3).first(), fill_value=fill_value)
+        )
+    # Check that the result is a column of nulls, even if the fill_value is different
+    assert_frame_equal(
+        df_shift,
+        pl.DataFrame({"x": [None, None, None]}),
+        check_dtypes=False,
+    )

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import io
 from datetime import date, datetime, time, tzinfo
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
@@ -750,4 +750,5 @@ def test_shift_with_null_deprecated_24105() -> None:
     with pytest.deprecated_call(
         match=r"'n' is not a valid integer \(but of type Null\), which currently returns a column of null values. This will become an error in the future."
     ):
-        pl.Series([1, 2, 3]).shift(cast(int, None))
+        df = pl.DataFrame({"x": [1, 2, 3]})
+        df.select(pl.col.x.shift(pl.col.x.filter(pl.col.x > 3).first()))


### PR DESCRIPTION
Add a deprecation warning whenever shifting with a non-numeric value (e.g. `pl.Series([1, 2, 3]).shift(None)`) results in a new column consisting of only Null values.

Unfortunately, it is still possible to shift with data types that can be cast to i64, but are still very unreasonable values for shifting.  This includes non-integer floats, pl.Datetime, etc. We defer fixing this to when we have dtype signatures for all functions. (Cc @coastalwhite)

Fixes #24105