### PR TITLE
fix(python): Fix from_repr parsing of negative durations

### DIFF
--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -331,7 +331,7 @@ def _cast_repr_strings_with_schema(
             if td is None
             else sum(
                 int(value) * duration_scaling[unit.strip()]
-                for value, unit in re.findall(r"(\d+)(\D+)", td)
+                for value, unit in re.findall(r"([+-]?\d+)(\D+)", td)
             )
         )
 

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, datetime, time, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from typing import Any, cast
 
 import numpy as np
@@ -583,6 +583,37 @@ def test_dataframe_from_repr() -> None:
         "ident": pl.String,
         "timestamp": pl.Datetime("us", "Asia/Tokyo"),
     }
+
+
+def test_dataframe_from_repr_24110() -> None:
+    df = cast(
+        pl.DataFrame,
+        pl.from_repr("""
+            shape: (7, 1)
+            ┌──────────────┐
+            │ time_offset  │
+            │ ---          │
+            │ duration[μs] │
+            ╞══════════════╡
+            │ -2h          │
+            │ 0µs          │
+            │ 2h           │
+            │ +2h          │
+            └──────────────┘
+    """),
+    )
+    expected = pl.DataFrame(
+        {
+            "time_offset": [
+                timedelta(hours=-2),
+                timedelta(),
+                timedelta(hours=2),
+                timedelta(hours=2),
+            ]
+        },
+        schema={"time_offset": pl.Duration("us")},
+    )
+    assert_frame_equal(df, expected)
 
 
 def test_dataframe_from_duckdb_repr() -> None:


### PR DESCRIPTION
* Fix the parsing of negative durations in `pl.from_repr()`
* Add a regression test for #24110

Fixes #24110
