### PR TITLE
fix: Fix `Series.__arrow_c_stream__` for Decimal and other logical types

### DIFF
--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -1082,3 +1082,84 @@ def test_schema_constructor_from_schema_capsule() -> None:
 def test_to_arrow_24142() -> None:
     df = pl.DataFrame({"a": object(), "b": "any string or bytes"})
     df.to_arrow(compat_level=CompatLevel.oldest())
+
+
+def test_comprehensive_pycapsule_interface() -> None:
+    """Test all data types via Arrow C Stream PyCapsule interface."""
+    from datetime import date, datetime, time, timedelta
+    from decimal import Decimal
+
+    class PyCapsuleStreamWrap:
+        def __init__(self, v: Any) -> None:
+            self.capsule = v.__arrow_c_stream__()
+
+        def __arrow_c_stream__(self, requested_schema: object | None = None) -> object:
+            return self.capsule
+
+    def roundtrip_series_pycapsule(s: pl.Series) -> pl.Series:
+        return pl.Series(PyCapsuleStreamWrap(s))
+
+    df = pl.DataFrame(
+        {
+            "bool": [True, False, None],
+            "int8": pl.Series([1, 2, None], dtype=pl.Int8),
+            "int16": pl.Series([1, 2, None], dtype=pl.Int16),
+            "int32": pl.Series([1, 2, None], dtype=pl.Int32),
+            "int64": pl.Series([1, 2, None], dtype=pl.Int64),
+            "uint8": pl.Series([1, 2, None], dtype=pl.UInt8),
+            "uint16": pl.Series([1, 2, None], dtype=pl.UInt16),
+            "uint32": pl.Series([1, 2, None], dtype=pl.UInt32),
+            "uint64": pl.Series([1, 2, None], dtype=pl.UInt64),
+            "float32": pl.Series([1.1, 2.2, None], dtype=pl.Float32),
+            "float64": pl.Series([1.1, 2.2, None], dtype=pl.Float64),
+            "string": ["hello", "world", None],
+            "binary": [b"hello", b"world", None],
+            "decimal": pl.Series(
+                [Decimal("1.23"), Decimal("4.56"), None], dtype=pl.Decimal(10, 2)
+            ),
+            "date": [date(2023, 1, 1), date(2023, 1, 2), None],
+            "datetime": [
+                datetime(2023, 1, 1, 12, 0),
+                datetime(2023, 1, 2, 13, 30),
+                None,
+            ],
+            "time": [time(12, 0, 0), time(13, 30, 0), None],
+            "duration_us": pl.Series(
+                [timedelta(days=1), timedelta(hours=2), None], dtype=pl.Duration("us")
+            ),
+            "duration_ms": pl.Series(
+                [timedelta(milliseconds=100), timedelta(microseconds=500), None],
+                dtype=pl.Duration("ms"),
+            ),
+            "duration_ns": pl.Series(
+                [timedelta(seconds=1), timedelta(microseconds=1000), None],
+                dtype=pl.Duration("ns"),
+            ),
+            "categorical": pl.Series(
+                ["apple", "banana", "apple"], dtype=pl.Categorical
+            ),
+            "list_duration": [
+                [timedelta(days=1), timedelta(hours=2)],
+                [timedelta(minutes=30)],
+                None,
+            ],
+            "struct_with_duration": [
+                {"x": timedelta(days=1), "y": 1},
+                {"x": timedelta(hours=2), "y": 2},
+                None,
+            ],
+        }
+    ).cast(
+        {
+            "list_duration": pl.List(pl.Duration("us")),
+            "struct_with_duration": pl.Struct({"x": pl.Duration("ns"), "y": pl.Int32}),
+        }
+    )
+
+    df_roundtrip = df.map_columns(pl.selectors.all(), roundtrip_series_pycapsule)
+
+    assert_frame_equal(df_roundtrip, df)
+
+    df_roundtrip_direct = pl.DataFrame(PyCapsuleStreamWrap(df))
+
+    assert_frame_equal(df_roundtrip_direct, df)


### PR DESCRIPTION
Closes #23467

Export logical types (Decimal, Date, Datetime, Time, Categorical) with proper Arrow schema conversion instead of raw physical chunks to prevent "data type mismatch" errors in Arrow C Stream interface