### PR TITLE
chore(rust): Enable dependabot updates for rust toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,21 @@ updates:
         patterns:
           - '*'
 
+  - package-ecosystem: rust-toolchain
+    directory: '/'
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
+    commit-message:
+      prefix: chore(rust)
+    labels: ['skip changelog']
+    groups:
+      documentation:
+        patterns:
+          - '*'
+
   # Python Polars
   - package-ecosystem: pip
     directory: py-polars


### PR DESCRIPTION
This change allows Dependabot to update the Rust toolchain version defined in `rust-toolchain.toml`. See [Dependabot now supports Rust toolchain updates - GitHub Changelog](https://github.blog/changelog/2025-08-19-dependabot-now-supports-rust-toolchain-updates/) for more details.