### PR TITLE
feat(python): Drop PyArrow requirement for `write_database` with the ADBC engine

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4279,6 +4279,12 @@ class DataFrame:
             )
 
             driver_manager = import_optional("adbc_driver_manager")
+
+            # base class for ADBC connections
+            if not isinstance(conn, driver_manager.dbapi.Connection):
+                msg = f"unrecognised connection type {connection!r}"
+                raise TypeError(msg)
+
             driver_manager_str_version = getattr(driver_manager, "__version__", "0.0")
             driver_manager_version = parse_version(driver_manager_str_version)
 
@@ -4398,8 +4404,8 @@ class DataFrame:
             elif isinstance(connection, Connectable):
                 sa_object = connection
             else:
-                error_msg = f"unexpected connection type {type(connection)}"
-                raise TypeError(error_msg)
+                msg = f"unrecognised connection type {connection!r}"
+                raise TypeError(msg)
 
             catalog, db_schema, unpacked_table_name = unpack_table_name(table_name)
             if catalog:

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4334,13 +4334,14 @@ class DataFrame:
                         cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
                         mode = "create"
 
+                # As of adbc_driver_manager 1.6.0, adbc_ingest can take a Polars
+                # DataFrame via the PyCapsule interface
+                data = self if driver_manager_version >= (1, 6) else self.to_arrow()
+
                 # use of schema-qualified table names was released in
                 # adbc-driver-manager 0.7.0 and is working without bugs from driver
                 # version (e.g., adbc-driver-postgresql) version 0.8.0
                 if driver_manager_version >= (0, 7) and adbc_driver_version >= (0, 8):
-                    # As of adbc_driver_manager 1.6.0, adbc_ingest can take a Polars
-                    # DataFrame via the PyCapsule interface
-                    data = self if driver_manager_version >= (1, 6) else self.to_arrow()
                     n_rows = cursor.adbc_ingest(
                         unpacked_table_name,
                         data=data,
@@ -4365,7 +4366,7 @@ class DataFrame:
                 else:
                     n_rows = cursor.adbc_ingest(
                         table_name=unpacked_table_name,
-                        data=self.to_arrow(),
+                        data=data,
                         mode=mode,
                         **(engine_options or {}),
                     )

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4310,8 +4310,8 @@ class DataFrame:
                 raise ValueError(msg)
 
             with (
-                conn if can_close_conn else contextlib.nullcontext(),  # type: ignore[union-attr]
-                conn.cursor() as cursor,  # type: ignore[union-attr]
+                conn if can_close_conn else contextlib.nullcontext(),
+                conn.cursor() as cursor,
             ):
                 catalog, db_schema, unpacked_table_name = unpack_table_name(table_name)
                 n_rows: int
@@ -4376,7 +4376,7 @@ class DataFrame:
                         mode=mode,
                         **(engine_options or {}),
                     )
-                conn.commit()  # type: ignore[union-attr]
+                conn.commit()
             return n_rows
 
         elif engine == "sqlalchemy":

--- a/py-polars/polars/io/database/_utils.py
+++ b/py-polars/polars/io/database/_utils.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import re
+from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
 from polars._utils.various import parse_version
 from polars.convert import from_arrow
 from polars.dependencies import import_optional
+from polars.exceptions import ModuleUpgradeRequiredError
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine
@@ -65,22 +67,63 @@ def _read_sql_adbc(
     return from_arrow(tbl, schema_overrides=schema_overrides)  # type: ignore[return-value]
 
 
-def _open_adbc_connection(connection_uri: str) -> Any:
+def _get_adbc_driver_name_from_uri(connection_uri: str) -> str:
     driver_name = connection_uri.split(":", 1)[0].lower()
+    # map uri prefix to ADBC name when not 1:1
+    driver_suffix_map: dict[str, str] = {"postgres": "postgresql"}
+    return driver_suffix_map.get(driver_name, driver_name)
 
-    # map uri prefix to module when not 1:1
-    module_suffix_map: dict[str, str] = {
-        "postgres": "postgresql",
-    }
-    module_suffix = module_suffix_map.get(driver_name, driver_name)
-    module_name = f"adbc_driver_{module_suffix}.dbapi"
 
+def _get_adbc_module_name_from_uri(connection_uri: str) -> str:
+    driver_name = _get_adbc_driver_name_from_uri(connection_uri)
+    return f"adbc_driver_{driver_name}"
+
+
+def _import_optional_adbc_driver(
+    module_name: str,
+    *,
+    dbapi_submodule: bool = True,
+) -> Any:
+    # Always import top level module first. This will surface a better error for users
+    # if the module does not exist. It doesn't negatively impact performance given the
+    # dbapi submodule would also load it.
     adbc_driver = import_optional(
         module_name,
         err_prefix="ADBC",
         err_suffix="driver not detected",
-        install_message=f"If ADBC supports this database, please run: pip install adbc-driver-{driver_name} pyarrow",
+        install_message=(
+            "If ADBC supports this database, please run: pip install "
+            f"{module_name.replace('_', '-')}"
+        ),
     )
+    if not dbapi_submodule:
+        return adbc_driver
+    # Importing the dbapi without pyarrow before adbc_driver_manager 1.6.0
+    # raises ImportError: PyArrow is required for the DBAPI-compatible interface
+    # Use importlib.import_module because Polars' import_optional clobbers this error
+    try:
+        adbc_driver_dbapi = import_module(f"{module_name}.dbapi")
+    except ImportError as e:
+        if "PyArrow is required for the DBAPI-compatible interface" in (str(e)):
+            adbc_driver_manager = import_optional("adbc_driver_manager")
+            adbc_str_version = getattr(adbc_driver_manager, "__version__", "0.0")
+
+            msg = (
+                "pyarrow is required for adbc-driver-manager < 1.6.0, found "
+                f"{adbc_str_version}.\nEither upgrade `adbc-driver-manager` (suggested) or "
+                "install `pyarrow`"
+            )
+            raise ModuleUpgradeRequiredError(msg) from None
+        # if the error message was something different, re-raise it
+        raise
+    else:
+        return adbc_driver_dbapi
+
+
+def _open_adbc_connection(connection_uri: str) -> Any:
+    driver_name = _get_adbc_driver_name_from_uri(connection_uri)
+    module_name = _get_adbc_module_name_from_uri(connection_uri)
+    adbc_driver = _import_optional_adbc_driver(module_name)
 
     # some backends require the driver name to be stripped from the URI
     if driver_name in ("sqlite", "snowflake"):

--- a/py-polars/tests/unit/io/database/test_read.py
+++ b/py-polars/tests/unit/io/database/test_read.py
@@ -806,7 +806,7 @@ def test_read_database_mocked(
                 query="SELECT * FROM test_data",
                 protocol="mysql",
                 errclass=ModuleNotFoundError,
-                errmsg="ADBC 'adbc_driver_mysql.dbapi' driver not detected.",
+                errmsg="ADBC 'adbc_driver_mysql' driver not detected.",
                 engine="adbc",
             ),
             id="Unavailable adbc driver",

--- a/py-polars/tests/unit/io/database/test_write.py
+++ b/py-polars/tests/unit/io/database/test_write.py
@@ -232,9 +232,9 @@ class TestWriteDatabase:
 
         with pytest.raises(
             TypeError,
-            match="unrecognised connection type",
+            match="unrecognised connection type.*",
         ):
-            df.write_database(connection=True, table_name="misc")  # type: ignore[arg-type]
+            df.write_database(connection=True, table_name="misc", engine=engine)  # type: ignore[arg-type]
 
     def test_write_database_adbc_missing_driver_error(
         self, engine: DbWriteEngine, uri_connection: bool, tmp_path: Path
@@ -249,7 +249,7 @@ class TestWriteDatabase:
             df.write_database(
                 table_name="my_schema.my_table",
                 connection="mysql:///:memory:",
-                engine="adbc",
+                engine=engine,
             )
 
 

--- a/py-polars/tests/unit/io/database/test_write.py
+++ b/py-polars/tests/unit/io/database/test_write.py
@@ -236,6 +236,22 @@ class TestWriteDatabase:
         ):
             df.write_database(connection=True, table_name="misc")  # type: ignore[arg-type]
 
+    def test_write_database_adbc_missing_driver_error(
+        self, engine: DbWriteEngine, uri_connection: bool, tmp_path: Path
+    ) -> None:
+        # Skip for sqlalchemy
+        if engine == "sqlalchemy":
+            return
+        df = pl.DataFrame({"colx": [1, 2, 3]})
+        with pytest.raises(
+            ModuleNotFoundError, match="ADBC 'adbc_driver_mysql' driver not detected."
+        ):
+            df.write_database(
+                table_name="my_schema.my_table",
+                connection="mysql:///:memory:",
+                engine="adbc",
+            )
+
 
 @pytest.mark.write_disk
 def test_write_database_using_sa_session(tmp_path: str) -> None:


### PR DESCRIPTION
Relates to https://github.com/pola-rs/polars/issues/22745
Fixes https://github.com/pola-rs/polars/issues/24117
Closes https://github.com/pola-rs/polars/issues/24118

From version 1.6.0, ADBC's `adbc_ingest` accepts a Polars DataFrame (specifically, an object implementing the PyCapsule Protocol) and does not require PyArrow to be installed. This implementation leverages that, and passes in a Polars df rather than a PyArrow table.

This is kind of hard to test in CI (suggestions welcome) given PyArrow is installed there, but I have tested it locally with the below script.

<details>

<summary> Demo: </summary>

```python
import polars as pl

df = pl.DataFrame({"a": 1})
try:
    rows_written = df.write_database("test", "sqlite:///:memory:", engine="adbc")
except Exception as e:
    print(f"{type(e).__name__}: {e}")
else:
    print(f"{rows_written = }")
```

```bash
# Driver manager is < 1.6 and PyArrow isn't installed
$ uv run --no-project --isolated --with polars --with adbc-driver-sqlite==1.5.0 --with adbc-driver-manager==1.5.0  demo.py
ModuleUpgradeRequiredError: pyarrow is required for adbc-driver-manager < 1.6.0, found 1.5.0.
Either upgrade `adbc-driver-manager` (suggested) or install `pyarrow`

# Suggested option: Upgrade adbc-driver-manager (no PyArrow)
$ uv run --no-project --isolated --with polars --with adbc-driver-sqlite==1.5.0 --with adbc-driver-manager==1.6.0  demo.py
rows_written = 1

# Or install PyArrow
$ uv run --no-project --isolated --with polars --with adbc-driver-sqlite==1.5.0 --with adbc-driver-manager==1.5.0 --with pyarrow  demo.py
rows_written = 1


# Not adding the ADBC driver will tell you to install it (fix for #24118)
$ uv run --no-project --isolated --with polars demo.py
ModuleNotFoundError: ADBC 'adbc_driver_sqlite' driver not detected.
If ADBC supports this database, please run: pip install adbc-driver-sqlite

# Which, works (the matching version of adbc-driver-manager) is automatically pulled
$ uv run --no-project --isolated --with polars --with adbc-driver-sqlite demo.py
rows_written = 1
```
</details>


