### PR TITLE
fix: Fix dtype for `slice` on `Literal` in agg context

### DIFF
--- a/crates/polars-expr/src/expressions/mod.rs
+++ b/crates/polars-expr/src/expressions/mod.rs
@@ -393,7 +393,7 @@ impl<'a> AggregationContext<'a> {
         }
     }
 
-    /// Aggregate into `ListChunked.
+    /// Aggregate into `ListChunked`.
     pub fn aggregated_as_list<'b>(&'b mut self) -> Cow<'b, ListChunked> {
         self.aggregated();
         let out = self.get_values();
@@ -439,6 +439,7 @@ impl<'a> AggregationContext<'a> {
                 let s = s.new_from_index(0, rows);
                 let s = s.into_column();
                 self.state = AggState::AggregatedList(s.clone());
+                self.with_update_groups(UpdateGroups::WithSeriesLen);
                 s.clone()
             },
         }

--- a/crates/polars-expr/src/expressions/slice.rs
+++ b/crates/polars-expr/src/expressions/slice.rs
@@ -118,6 +118,13 @@ impl PhysicalExpr for SliceExpr {
         let mut ac_length = results.pop().unwrap();
         let mut ac_offset = results.pop().unwrap();
 
+        // Fast path:
+        // When `input` (ac) is a LiteralValue, and both `offset` and `length` are LiteralScalar,
+        // we slice the LiteralValue and avoid calling groups() or aggregated().
+        // TODO: When `input` (ac) is a LiteralValue, and `offset` or `length` is not a LiteralScalar,
+        // we can simplify the groups calculation since we have a List containing one scalar for
+        // each group.
+
         use AggState::*;
         let groups = match (&ac_offset.state, &ac_length.state) {
             (LiteralScalar(offset), LiteralScalar(length)) => {
@@ -125,7 +132,8 @@ impl PhysicalExpr for SliceExpr {
 
                 if let LiteralScalar(s) = ac.agg_state() {
                     let s1 = s.slice(offset, length);
-                    ac.with_literal(s1);
+                    let s1 = s1.implode()?;
+                    ac.with_literal(s1.into_column());
                     return Ok(ac);
                 }
                 let groups = ac.groups();
@@ -151,6 +159,9 @@ impl PhysicalExpr for SliceExpr {
                 }
             },
             (LiteralScalar(offset), _) => {
+                if matches!(ac.state, LiteralScalar(_)) {
+                    ac.aggregated();
+                }
                 let groups = ac.groups();
                 let offset = extract_offset(offset, &self.expr)?;
                 let length = ac_length.aggregated();
@@ -186,6 +197,9 @@ impl PhysicalExpr for SliceExpr {
                 }
             },
             (_, LiteralScalar(length)) => {
+                if matches!(ac.state, LiteralScalar(_)) {
+                    ac.aggregated();
+                }
                 let groups = ac.groups();
                 let length = extract_length(length, &self.expr)?;
                 let offset = ac_offset.aggregated();
@@ -221,6 +235,10 @@ impl PhysicalExpr for SliceExpr {
                 }
             },
             _ => {
+                if matches!(ac.state, LiteralScalar(_)) {
+                    ac.aggregated();
+                }
+
                 let groups = ac.groups();
                 let length = ac_length.aggregated();
                 let offset = ac_offset.aggregated();

--- a/crates/polars-expr/src/expressions/slice.rs
+++ b/crates/polars-expr/src/expressions/slice.rs
@@ -120,7 +120,7 @@ impl PhysicalExpr for SliceExpr {
 
         // Fast path:
         // When `input` (ac) is a LiteralValue, and both `offset` and `length` are LiteralScalar,
-        // we slice the LiteralValue and avoid calling groups() or aggregated().
+        // we slice the LiteralValue and avoid calling groups().
         // TODO: When `input` (ac) is a LiteralValue, and `offset` or `length` is not a LiteralScalar,
         // we can simplify the groups calculation since we have a List containing one scalar for
         // each group.

--- a/crates/polars-expr/src/expressions/slice.rs
+++ b/crates/polars-expr/src/expressions/slice.rs
@@ -132,8 +132,8 @@ impl PhysicalExpr for SliceExpr {
 
                 if let LiteralScalar(s) = ac.agg_state() {
                     let s1 = s.slice(offset, length);
-                    let s1 = s1.implode()?;
-                    ac.with_literal(s1.into_column());
+                    ac.with_literal(s1);
+                    ac.aggregated();
                     return Ok(ac);
                 }
                 let groups = ac.groups();

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -284,7 +284,7 @@ fn test_lazy_query_4() -> PolarsResult<()> {
         .agg([
             col("day").alias("day"),
             col("cumcases")
-                .apply(|s: Column| (&s - &(s.shift(1))), |_, f| Ok(f.clone()))
+                .apply(|s: Column| &s - &(s.shift(1)), |_, f| Ok(f.clone()))
                 .alias("diff_cases"),
         ])
         .explode(by_name(["day", "diff_cases"], true))

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_expr.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_expr.rs
@@ -35,14 +35,6 @@ impl OptimizationRule for SlicePushDown {
                     let new_input = pushdown(input, offset, length, expr_arena);
                     Some(ae.replace_inputs(&[new_input]))
                 },
-                Literal(lv) => {
-                    match lv {
-                        LiteralValue::Series(_) => None,
-                        LiteralValue::Range { .. } => None,
-                        // no need to slice a literal value of unit length
-                        lv => Some(Literal(lv.clone())),
-                    }
-                },
                 BinaryExpr { left, right, op } => {
                     let left = *left;
                     let right = *right;

--- a/py-polars/tests/unit/operations/test_slice.py
+++ b/py-polars/tests/unit/operations/test_slice.py
@@ -368,3 +368,142 @@ def test_slice_slice_pushdown() -> None:
                         .slice(outer_offset, outer_len)
                         .collect(),
                     )
+
+
+@pytest.mark.parametrize("groupby", [True, False])
+@pytest.mark.parametrize(
+    "len",
+    [
+        0,
+        pl.lit(0),
+        pl.col("b").first(),
+    ],
+)
+@pytest.mark.parametrize(
+    "offset",
+    [
+        0,
+        pl.lit(0),
+        pl.col("a").first(),
+    ],
+)
+@pytest.mark.parametrize(
+    "lit",
+    [
+        pl.lit(7),
+        pl.lit([7]),
+        pl.lit([[7]]),
+        pl.lit(pl.Series([7, 8, 9])),
+        pl.col("c"),  # baseline, no literal
+    ],
+)
+def test_schema_slice_on_literal_23999(
+    lit: pl.Expr, offset: pl.Expr, len: pl.Expr, groupby: bool
+) -> None:
+    df = pl.DataFrame(
+        {
+            "g": [10, 10, 10, 20, 20, 30],
+            "a": [0, 0, 0, 0, 0, 0],
+            "b": [1, 1, 1, 1, 1, 1],
+            "c": [11, 12, 13, 21, 22, 31],
+        }
+    )
+
+    # slice
+    if not groupby:
+        q = df.lazy().select(lit.slice(offset, len))
+    else:
+        q = df.lazy().group_by("g").agg(lit.slice(offset, len))
+    assert q.collect_schema() == q.collect().schema
+
+
+@pytest.mark.parametrize("groupby", [True, False])
+@pytest.mark.parametrize(
+    "idx",
+    [
+        0,
+        pl.lit(0),
+        pl.col("a").first(),
+    ],
+)
+@pytest.mark.parametrize(
+    "lit",
+    [
+        pl.lit(7),
+        pl.lit([7]),
+        pl.lit([[7]]),
+        pl.lit(pl.Series([7, 8, 9])),
+        pl.col("c"),  # baseline, no literal
+    ],
+)
+def test_schema_gather_get_on_literal_24101(
+    lit: pl.Expr, idx: pl.Expr, groupby: bool
+) -> None:
+    df = pl.DataFrame(
+        {
+            "g": [10, 10, 10, 20, 20, 30],
+            "a": [0, 0, 0, 0, 0, 0],
+            "b": [1, 1, 1, 1, 1, 1],
+            "c": [11, 12, 13, 21, 22, 31],
+        }
+    )
+
+    # gather
+    if not groupby:
+        q = df.lazy().select(lit.gather(idx))
+    else:
+        q = df.lazy().group_by("g").agg(lit.gather(idx))
+    assert q.collect_schema() == q.collect().schema
+
+    # get
+    if not groupby:
+        q = df.lazy().select(lit.get(idx))
+    else:
+        q = df.lazy().group_by("g").agg(lit.get(idx))
+    assert q.collect_schema() == q.collect().schema
+
+
+@pytest.mark.parametrize("groupby", [True, False])
+@pytest.mark.parametrize(
+    "len",
+    [
+        1,
+        pl.lit(1),
+        pl.col("b").first(),
+    ],
+)
+@pytest.mark.parametrize(
+    "lit",
+    [
+        pl.lit(7),
+        pl.lit([7]),
+        pl.lit([[7]]),
+        pl.lit(pl.Series([7, 8, 9])),
+        pl.col("c"),  # baseline, no literal
+    ],
+)
+def test_schema_head_tail_on_literal_24102(
+    lit: pl.Expr, len: pl.Expr, groupby: bool
+) -> None:
+    df = pl.DataFrame(
+        {
+            "g": [10, 10, 10, 20, 20, 30],
+            "a": [0, 0, 0, 0, 0, 0],
+            "b": [1, 1, 1, 1, 1, 1],
+            "c": [11, 12, 13, 21, 22, 31],
+        }
+    )
+
+    # head
+    if not groupby:
+        q = df.lazy().select(lit.head(len))
+    else:
+        q = df.lazy().group_by("g").agg(lit.head(len))
+    assert q.collect_schema() == q.collect().schema
+
+    # tail
+    if not groupby:
+        q = df.lazy().select(lit.tail(len))
+    else:
+        q = df.lazy().group_by("g").agg(lit.tail(len))
+    assert q.collect_schema() == q.collect().schema


### PR DESCRIPTION
fixes #23999
fixes #24102

Note (!), this PR changes the output dtype of the engine when `slice` is called on a `Literal` value, since `slice` does not meet the `is_scalar` criteria.

Overview of changes:
- Do not drop `Slice` on Literal in the optimizer.
- Triggerr aggregation for `LiteralScalar` in `slice.rs`.
- Adjust groups logic in `aggregated()`, from (*)
- Fix older test.
- Parametric type tests for `slice`, `gather`, `get`, `head` and `tail`. 

Builds upon: https://github.com/pola-rs/polars/pull/24078 (*)

Note that `slice` on an aggregated scalar value will raise per current behavior, but imo this could and should succeed with at most some minor changes.

More optimizations are possible.

*edit:
- Fixed regression in `sortby`
- clippy change

ping @coastalwhite