### PR TITLE
fix(rust): Fix `write_csv` ignoring `decimal_comma` flag for `Decimal` type columns

### DIFF
--- a/crates/polars-io/src/csv/write/write_impl/serializer.rs
+++ b/crates/polars-io/src/csv/write/write_impl/serializer.rs
@@ -680,6 +680,7 @@ pub(super) fn serializer_for<'a>(
                 QuoteStyle::Never => false,
             }
         },
+        #[cfg(feature = "dtype-decimal")]
         DataType::Decimal(_, scale) => {
             // Similar to logic for float data-types, but need to consider scale rather than precision
             let should_quote =

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2797,13 +2797,14 @@ def test_write_csv_decimal_type_decimal_comma(
         "c": pl.Int64,
     }
 
+    # TODO: Look at type hints for `schema` argument of `pl.DataFrame`, as this works
     df = pl.DataFrame(
         data={
             "a": [123.75],
             "b": [60.0],
             "c": [9],
         },
-        schema=schema,
+        schema=schema,  # type: ignore
     )
 
     buf = io.BytesIO()


### PR DESCRIPTION
## Description

Fixes a bug where the `decimal_comma` parameter in `write_csv()` was being ignored for `Decimal` type columns, while working correctly for `Float32` and `Float64` columns.

Closes #23932

## Changes

- Added `decimal_serializer_decimal_comma()` function that converts decimal points to commas in Decimal column output
- Updated `serializer_for()` to choose between regular and decimal comma serializers for `Decimal` data types based on the `decimal_comma` option
- Added proper quoting logic for Decimal types when `decimal_comma=true` and `separator=","` to handle potential ambiguity
- Updated tests to comprehensively cover `decimal_comma` functionality for both Float and Decimal types

**Before:**

```python
pl.DataFrame({"s": ["3.14"]}).with_columns(
    [
        pl.col("s").cast(pl.Decimal(10, 2)).alias("d"),
        pl.col("s").cast(pl.Float64).alias("f")
    ]
).write_csv(separator=";", decimal_comma=True)

# Incorrect, `Decimal` type column does not have comma decimal point
# 's;d;f\n3.14;3.14;3,14\n'
```

**After:**

```python
pl.DataFrame({"s": ["3.14"]}).with_columns(
    [
        pl.col("s").cast(pl.Decimal(10, 2)).alias("d"),
        pl.col("s").cast(pl.Float64).alias("f")
    ]
).write_csv(separator=";", decimal_comma=True)

# Correct, `Decimal` type column does have comma decimal point
# 's;d;f\n3.14;3,14;3,14\n'
```

The fix ensures consistent behavior between `Float32`, `Float64`, and `Decimal` types that support decimal separators.