### PR TITLE
docs(python): Automatically register `doctest.ELLIPSIS` so we don't have to add the inline directive each time

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -9859,7 +9859,7 @@ class DataFrame:
         ...         "c": [True, True, False, None],
         ...     }
         ... )
-        >>> df.lazy()  # doctest: +ELLIPSIS
+        >>> df.lazy()
         <LazyFrame at ...>
         """
         return wrap_ldf(self._df.lazy())

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -407,7 +407,7 @@ class Expr:
         >>> import io
         >>> expr = pl.col("foo").sum().over("bar")
         >>> bytes = expr.meta.serialize()
-        >>> pl.Expr.deserialize(io.BytesIO(bytes))  # doctest: +ELLIPSIS
+        >>> pl.Expr.deserialize(io.BytesIO(bytes))
         <Expr ['col("foo").sum().over([col("ba…'] at ...>
         """
         if isinstance(source, StringIO):

--- a/py-polars/polars/expr/meta.py
+++ b/py-polars/polars/expr/meta.py
@@ -338,7 +338,7 @@ class ExprMetaNameSpace:
         The bytes can later be deserialized back into an `Expr` object.
 
         >>> import io
-        >>> pl.Expr.deserialize(io.BytesIO(bytes))  # doctest: +ELLIPSIS
+        >>> pl.Expr.deserialize(io.BytesIO(bytes))
         <Expr ['col("foo").sum().over([col("ba…'] at ...>
         """
         if format == "binary":

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1541,7 +1541,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...     lf.with_columns(pl.col("foo").cum_sum().alias("bar"))
         ...     .inspect()  # print the node before the filter
         ...     .filter(pl.col("bar") == pl.col("foo"))
-        ... )  # doctest: +ELLIPSIS
+        ... )
         <LazyFrame at ...>
         """
 
@@ -3611,7 +3611,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...         "c": [True, True, False, None],
         ...     }
         ... )
-        >>> lf.lazy()  # doctest: +ELLIPSIS
+        >>> lf.lazy()
         <LazyFrame at ...>
         """
         return self
@@ -3795,7 +3795,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...         "c": [True, True, False, None],
         ...     }
         ... )
-        >>> lf.clone()  # doctest: +ELLIPSIS
+        >>> lf.clone()
         <LazyFrame at ...>
         """
         return self._from_pyldf(self._ldf.clone())

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4815,7 +4815,7 @@ class Series:
         --------
         >>> s = pl.Series("a", [1, 2, 3])
         >>> s = s.to_arrow()
-        >>> s  # doctest: +ELLIPSIS
+        >>> s
         <pyarrow.lib.Int64Array object at ...>
         [
           1,

--- a/py-polars/polars/testing/asserts/frame.py
+++ b/py-polars/polars/testing/asserts/frame.py
@@ -99,7 +99,7 @@ def assert_frame_equal(
     >>> from polars.testing import assert_frame_equal
     >>> df1 = pl.DataFrame({"a": [1, 2, 3]})
     >>> df2 = pl.DataFrame({"a": [1, 5, 3]})
-    >>> assert_frame_equal(df1, df2)  # doctest: +ELLIPSIS
+    >>> assert_frame_equal(df1, df2)
     Traceback (most recent call last):
     ...
     AssertionError: DataFrames are different (value mismatch for column "a")

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -225,6 +225,11 @@ strict = true
 docstring-code-format = true
 
 [tool.pytest.ini_options]
+doctest_optionflags = [
+  "DONT_ACCEPT_TRUE_FOR_1",
+  "NORMALIZE_WHITESPACE",
+  "ELLIPSIS",
+]
 addopts = [
   "--tb=short",
   "--strict-config",

--- a/py-polars/tests/docs/run_doctest.py
+++ b/py-polars/tests/docs/run_doctest.py
@@ -142,9 +142,10 @@ if __name__ == "__main__":
 
     doctest.OutputChecker = IgnoreResultOutputChecker  # type: ignore[misc]
 
-    # We want to be relaxed about whitespace, but strict on True vs 1
+    # Want to be relaxed about whitespace, strict on True vs 1, and allow '...' pattern
     doctest.NORMALIZE_WHITESPACE = True
     doctest.DONT_ACCEPT_TRUE_FOR_1 = True
+    doctest.ELLIPSIS = True
 
     # If REPORT_NDIFF is turned on, it will report on line by line, character by
     # character, differences. The disadvantage is that you cannot just copy the output


### PR DESCRIPTION
Helps tidy some docstrings; no longer need to add an explicit `# doctest: +ELLIPSIS` to take advantage of the `"..."` pattern match; can just use it.