### PR TITLE
ci: Automatically label a few more types of PR

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -48,9 +48,39 @@ autolabeler:
   - label: fix
     title:
       - '/^fix/'
-  - label: sql
+  - label: A-sql
     title:
       - '/\bsql\b/i'
+  - label: A-io-avro
+    title:
+      - '/\bavro\b/i'
+  - label: A-io-catalog
+    title:
+      - '/catalog/i'
+  - label: A-io-csv
+    title:
+      - '/\bcsv\b/i'
+  - label: A-io-database
+    title:
+      - '/database/i'
+  - label: A-io-iceberg
+    title:
+      - '/iceberg/i'
+  - label: A-io-json
+    title:
+      - '/json/i'
+  - label: A-io-parquet
+    title:
+      - '/parquet/i'
+  - label: A-io-spreadsheet
+    title:
+      - '/spreadsheet|excel/i'
+  - label: A-interop-numpy
+    title:
+      - '/numpy/i'
+  - label: A-interop-pandas
+    title:
+      - '/pandas/i'
   - label: performance
     title:
       - '/^perf/'


### PR DESCRIPTION
Fixes the earlier SQL autolabel (#23816 was missing the leading `A-` for the label name 😅) and adds a few more common patterns for convenience.