### PR TITLE
fix: Fix `sort_by` for `group_by_dynamic` context

### DIFF
--- a/crates/polars-expr/src/expressions/sortby.rs
+++ b/crates/polars-expr/src/expressions/sortby.rs
@@ -44,7 +44,7 @@ fn prepare_bool_vec(values: &[bool], by_len: usize) -> Vec<bool> {
     }
 }
 
-static ERR_MSG: &str = "expressions in 'sort_by' produced a different number of groups";
+static ERR_MSG: &str = "expressions in 'sort_by' must have matching group lengths";
 
 fn check_groups(a: &GroupsType, b: &GroupsType) -> PolarsResult<()> {
     polars_ensure!(a.iter().zip(b.iter()).all(|(a, b)| {
@@ -305,6 +305,19 @@ impl PhysicalExpr for SortByExpr {
             .iter()
             .map(|e| e.evaluate_on_groups(df, groups, state))
             .collect::<PolarsResult<Vec<_>>>()?;
+
+        assert!(
+            ac_sort_by
+                .iter()
+                .all(|ac_sort_by| ac_sort_by.groups.len() == ac_in.groups.len())
+        );
+
+        for ac in ac_sort_by.iter_mut() {
+            if matches!(ac.state, AggState::LiteralScalar(_)) {
+                ac.aggregated();
+            }
+        }
+
         let mut sort_by_s = ac_sort_by
             .iter()
             .map(|c| {
@@ -320,14 +333,6 @@ impl PhysicalExpr for SortByExpr {
                 }
             })
             .collect::<Vec<_>>();
-
-        // A check up front to ensure the input expressions have the same number of total elements.
-        for sort_by_s in &sort_by_s {
-            polars_ensure!(
-                sort_by_s.len() == ac_in.flat_naive().len(), expr = self.expr, ComputeError:
-                "the expression in `sort_by` argument must result in the same length"
-            );
-        }
 
         let ordered_by_group_operation = matches!(
             ac_sort_by[0].update_groups,

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -383,7 +383,7 @@ def test_sort_by_different_lengths() -> None:
     )
     with pytest.raises(
         ComputeError,
-        match=r"the expression in `sort_by` argument must result in the same length",
+        match=r"expressions in 'sort_by' must have matching group lengths",
     ):
         df.group_by("group").agg(
             [
@@ -393,7 +393,7 @@ def test_sort_by_different_lengths() -> None:
 
     with pytest.raises(
         ComputeError,
-        match=r"the expression in `sort_by` argument must result in the same length",
+        match=r"expressions in 'sort_by' must have matching group lengths",
     ):
         df.group_by("group").agg(
             [
@@ -613,7 +613,7 @@ def test_sort_by_error() -> None:
 
     with pytest.raises(
         ComputeError,
-        match="expressions in 'sort_by' produced a different number of groups",
+        match="expressions in 'sort_by' must have matching group lengths",
     ):
         df.group_by("id", maintain_order=True).agg(
             pl.col("cost").filter(pl.col("type") == "A").sort_by("number")


### PR DESCRIPTION
fixes #24057

Summary of changes:
- removed false positive check which was incorrect for overlapping groups
- added regression test
- added code fix for `literal`
- improved error message feedback
