### PR TITLE
fix(python): Fix pycapsule conversion for non-struct series

### DIFF
--- a/py-polars/src/polars/_utils/pycapsule.py
+++ b/py-polars/src/polars/_utils/pycapsule.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, Any
 
 from polars._utils.construction.dataframe import dataframe_to_pydf
 from polars._utils.wrap import wrap_df, wrap_s
+from polars.datatypes import Struct
+from polars.exceptions import SchemaError
 
 with contextlib.suppress(ImportError):
     from polars._plr import PySeries
@@ -28,21 +30,22 @@ def pycapsule_to_frame(
 ) -> DataFrame:
     """Convert PyCapsule object to DataFrame."""
     if hasattr(obj, "__arrow_c_array__"):
-        # This uses the fact that PySeries.from_arrow_c_array will create a
-        # struct-typed Series. Then we unpack that to a DataFrame.
-        tmp_col_name = ""
         s = wrap_s(PySeries.from_arrow_c_array(obj))
-        df = s.to_frame(tmp_col_name).unnest(tmp_col_name)
-
     elif hasattr(obj, "__arrow_c_stream__"):
-        # This uses the fact that PySeries.from_arrow_c_stream will create a
-        # struct-typed Series. Then we unpack that to a DataFrame.
-        tmp_col_name = ""
         s = wrap_s(PySeries.from_arrow_c_stream(obj))
-        df = s.to_frame(tmp_col_name).unnest(tmp_col_name)
     else:
         msg = f"object does not support PyCapsule interface; found {obj!r} "
         raise TypeError(msg)
+
+    if isinstance(s.dtype, Struct):
+        tmp_col_name = ""
+        df = s.to_frame(tmp_col_name).unnest(tmp_col_name)
+    else:
+        msg = (
+            f"Cannot create DataFrame from single column data (got {s.dtype}). "
+            f"Use series.to_frame('column_name') or pl.DataFrame({{'col': series}}) instead."
+        )
+        raise SchemaError(msg)
 
     if rechunk:
         df = df.rechunk()

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -15,6 +15,7 @@ from polars.exceptions import (
     ComputeError,
     DuplicateError,
     PanicException,
+    SchemaError,
     UnstableWarning,
 )
 from polars.interchange.protocol import CompatLevel
@@ -1350,3 +1351,50 @@ def test_month_day_nano_from_ffi_15969(monkeypatch: pytest.MonkeyPatch) -> None:
     # TODO: Add Parquet round-trip test if this starts working.
     with pytest.raises(pa.ArrowNotImplementedError):
         pq.write_table(arrow_tbl, f)
+
+
+# https://github.com/pola-rs/polars/issues/21660
+def test_pycapsule_struct_vs_non_struct() -> None:
+    import pytest
+
+    from polars._utils.pycapsule import pycapsule_to_frame
+
+    s_int = pl.Series("test_col", [1, 2, 3])
+    int_arrow_array = s_int.to_arrow()
+    with pytest.raises(
+        SchemaError, match="Cannot create DataFrame from single column data"
+    ):
+        pycapsule_to_frame(int_arrow_array)
+
+    class ArrowStreamOnly:
+        def __init__(self, stream: object) -> None:
+            self.stream = stream
+
+        def __arrow_c_stream__(self, requested_schema: object | None = None) -> object:
+            return self.stream
+
+    int_stream_only = ArrowStreamOnly(s_int.__arrow_c_stream__())
+    with pytest.raises(
+        SchemaError, match="Cannot create DataFrame from single column data"
+    ):
+        pycapsule_to_frame(int_stream_only)
+
+    struct_series = pl.Series(
+        "struct_col",
+        [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}],
+        dtype=pl.Struct({"a": pl.Int64, "b": pl.String}),
+    )
+    struct_arrow_array = struct_series.to_arrow()
+    result_struct_array = pycapsule_to_frame(struct_arrow_array)
+    assert result_struct_array.shape == (2, 2)
+
+    struct_stream_only = ArrowStreamOnly(struct_series.__arrow_c_stream__())
+    result_struct_stream = pycapsule_to_frame(struct_stream_only)
+    assert result_struct_stream.shape == (2, 2)
+
+    class NotPyCapsuleObject:
+        pass
+
+    not_pycapsule_obj = NotPyCapsuleObject()
+    with pytest.raises(TypeError, match="does not support PyCapsule interface"):
+        pycapsule_to_frame(not_pycapsule_obj)


### PR DESCRIPTION
Add type checking in pycapsule_to_frame() to only unnest series with Struct dtype

closes https://github.com/pola-rs/polars/issues/21660  

`Series.__arrow_c_stream__` needs to be fixed first, see  https://github.com/pola-rs/polars/pull/24120