### PR TITLE
fix: rolling_mean handle centered weights with len(values) < window_size

### DIFF
--- a/crates/polars-compute/src/rolling/no_nulls/mean.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/mean.rs
@@ -69,6 +69,7 @@ where
                 offset_fn,
                 no_nulls::compute_mean_weights,
                 &wts,
+                center,
             )
         },
     }

--- a/crates/polars-compute/src/rolling/no_nulls/min_max.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/min_max.rs
@@ -60,6 +60,7 @@ macro_rules! rolling_minmax_func {
                         offset_fn,
                         weighted_min_max::<T, $policy>,
                         &weights,
+                        center,
                     )
                 },
             }

--- a/crates/polars-compute/src/rolling/no_nulls/mod.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/mod.rs
@@ -94,7 +94,12 @@ where
             let (start, end) = det_offsets_fn(idx, window_size, len);
             let vals = unsafe { values.get_unchecked(start..end) };
             let win_len = end - start;
-            let weights_slice = if start == 0 {
+            let weights_slice = if start == 0 && end == len {
+                // Edge case
+                let slice_start = weights.len() - win_len - idx;
+                let slice_end = slice_start + win_len;
+                &weights[slice_start..slice_end]
+            } else if start == 0 {
                 // Truncated at the start: take the last win_len weights
                 &weights[weights.len() - win_len..]
             } else if end == len {

--- a/crates/polars-compute/src/rolling/no_nulls/moment.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/moment.rs
@@ -123,6 +123,7 @@ where
                 offset_fn,
                 compute_var_weights,
                 &wts,
+                center,
             )
         },
     }

--- a/crates/polars-compute/src/rolling/no_nulls/sum.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/sum.rs
@@ -160,6 +160,7 @@ where
                 det_offsets_center,
                 no_nulls::compute_sum_weights,
                 &weights,
+                center,
             )
         },
         (false, Some(weights)) => {
@@ -171,6 +172,7 @@ where
                 det_offsets,
                 no_nulls::compute_sum_weights,
                 &weights,
+                center,
             )
         },
     }

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -1638,6 +1638,14 @@ def test_wtd_min_periods_less_window() -> None:
 
     assert_frame_equal(df, expected)
 
+    df = pl.DataFrame({"a": [1, 2]}).with_columns(
+        pl.col("a").rolling_mean(window_size=3, weights=[0.25, 0.5, 0.25], min_samples=2, center=True).alias("kernel_mean")
+    )
+    # At row 0: available = [1,2], weights = [0.5, 0.25] => (0.5*1 + 0.25*2)/(0.5+0.25) = 1.333333
+    # At row 1: available = [1,2], weights = [0.25, 0.5] => (0.25*1 + 0.5*2)/(0.25+0.5) = 1.666667
+    expected = pl.DataFrame({"a": [1, 2], "kernel_mean": [1.333333, 1.666667]})
+    assert_frame_equal(df, expected)
+
 
 def test_rolling_median_23480() -> None:
     vals = [None] * 17 + [3262645.8, 856191.4, 1635379.0, 34707156.0]

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -1639,12 +1639,26 @@ def test_wtd_min_periods_less_window() -> None:
     assert_frame_equal(df, expected)
 
     df = pl.DataFrame({"a": [1, 2]}).with_columns(
-        pl.col("a").rolling_mean(window_size=3, weights=[0.25, 0.5, 0.25], min_samples=2, center=True).alias("kernel_mean")
+        pl.col("a")
+        .rolling_mean(
+            window_size=3, weights=[0.25, 0.5, 0.25], min_samples=2, center=True
+        )
+        .alias("kernel_mean")
     )
-    # At row 0: available = [1,2], weights = [0.5, 0.25] => (0.5*1 + 0.25*2)/(0.5+0.25) = 1.333333
-    # At row 1: available = [1,2], weights = [0.25, 0.5] => (0.25*1 + 0.5*2)/(0.25+0.5) = 1.666667
+
+    # Handle edge case where the window size is larger than the number of elements
     expected = pl.DataFrame({"a": [1, 2], "kernel_mean": [1.333333, 1.666667]})
     assert_frame_equal(df, expected)
+
+    df = pl.DataFrame({"a": [1, 2]}).with_columns(
+        pl.col("a")
+        .rolling_mean(
+            window_size=3, weights=[0.25, 0.25, 0.5], min_samples=1, center=False
+        )
+        .alias("kernel_mean")
+    )
+
+    expected = pl.DataFrame({"a": [1, 2], "kernel_mean": [1.0, 2 * 2 / 3 + 1 * 1 / 3]})
 
 
 def test_rolling_median_23480() -> None:


### PR DESCRIPTION
Fixed #24126

Handle the edge case where the number of elements in the values array is less than the window size, and we are trying to use centered weights.