### PR TITLE
fix(python): Support native DuckDB connection in read_database

### DIFF
--- a/py-polars/polars/io/database/_executor.py
+++ b/py-polars/polars/io/database/_executor.py
@@ -380,6 +380,21 @@ class ConnectionExecutor:
         except ImportError:
             return False
 
+    @staticmethod
+    def _is_alchemy_result(result: Any) -> bool:
+        """Check if the given result is a SQLAlchemy Result object."""
+        try:
+            from sqlalchemy.engine import CursorResult
+
+            if isinstance(result, CursorResult):
+                return True
+
+            from sqlalchemy.ext.asyncio import AsyncResult
+
+            return isinstance(result, AsyncResult)
+        except ImportError:
+            return False
+
     def _normalise_cursor(self, conn: Any) -> Cursor:
         """Normalise a connection object such that we have the query executor."""
         if self.driver_name == "sqlalchemy":
@@ -507,7 +522,7 @@ class ConnectionExecutor:
 
         # note: some cursors execute in-place, some access results via a property
         result = self.cursor if (result is None or result is True) else result
-        if self.driver_name == "duckdb":
+        if self.driver_name == "duckdb" and self._is_alchemy_result(result):
             result = result.cursor
 
         self.result = result


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/24176

Running
```python
import duckdb
import polars as pl
conn = duckdb.connect()
print(pl.read_database("SELECT 1", conn))
```
Polars 1.32.3: `AttributeError: 'builtin_function_or_method' object has no attribute 'fetch_arrow_table'`
With this PR:
```
shape: (1, 1)
┌─────┐
│ 1   │
│ --- │
│ i32 │
╞═════╡
│ 1   │
└─────┘
```


SQLAlchemy TextClause and Selectable also continue to work (the PR that cause this regression implemented that).
Produces expected output both before and after PR

```python
from sqlalchemy import create_engine, select, text
import polars as pl

engine = create_engine("duckdb:///:memory:")
with engine.connect() as conn:
    stmt = select(1)
    df = pl.read_database(stmt, connection=conn)
    print(df)

    stmt = text("SELECT 1")
    df = pl.read_database(stmt, connection=conn)
    print(df)
```
