### PR TITLE
Fix panic in gather inside groupby with invalid indices

### DIFF
--- a/crates/polars-expr/src/expressions/gather.rs
+++ b/crates/polars-expr/src/expressions/gather.rs
@@ -77,7 +77,12 @@ impl PhysicalExpr for GatherExpr {
                     s.cast_with_options(&IDX_DTYPE, CastOptions::Overflowing)
                 }
             },
-            _ => unreachable!(),
+            _ => Err(PolarsError::InvalidOperation(
+                format!(
+                    "Invalid dtype {:?} for gather indices; expected integer type",
+                    s.dtype()
+                ).into()
+            )),
         })?;
 
         let taken = if idx.inner_dtype() == &IDX_DTYPE {

--- a/py-polars/tests/unit/operations/test_gather.py
+++ b/py-polars/tests/unit/operations/test_gather.py
@@ -376,3 +376,8 @@ def test_gather_group_by_23696(maintain_order: bool) -> None:
     )
 
     assert_frame_equal(df, expected, check_row_order=maintain_order)
+
+def test_gather_invalid_indices_groupby():
+    df = pl.DataFrame({"x": [1, 2]})
+    with pytest.raises(pl.exceptions.InvalidOperationError):
+        df.group_by(True).agg(pl.col("x").gather(pl.lit("y")))


### PR DESCRIPTION
gather panics when called with invalid args in a group by context.

Expected behavior

No panic.