### PR TITLE
feat: Log pyarrow predicate conversion result in sensitive verbose logs

### DIFF
--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -164,11 +164,25 @@ pub fn python_scan_predicate(
     let predicate = if let PythonPredicate::Polars(e) = &options.predicate {
         // Convert to a pyarrow eval string.
         if matches!(options.python_source, PythonScanSource::Pyarrow) {
-            if let Some(eval_str) = polars_plan::plans::python::pyarrow::predicate_to_pa(
+            use polars_core::config::verbose_print_sensitive;
+
+            let predicate_pa = polars_plan::plans::python::pyarrow::predicate_to_pa(
                 e.node(),
                 expr_arena,
                 Default::default(),
-            ) {
+            );
+
+            verbose_print_sensitive(|| {
+                format!(
+                    "python_scan_predicate: \
+                    predicate node: {}, \
+                    converted pyarrow predicate: {}",
+                    ExprIRDisplay::display_node(e.node(), expr_arena),
+                    &predicate_pa.as_deref().unwrap_or("<conversion failed>")
+                )
+            });
+
+            if let Some(eval_str) = predicate_pa {
                 options.predicate = PythonPredicate::PyArrow(eval_str);
                 // We don't have to use a physical expression as pyarrow deals with the filter.
                 None


### PR DESCRIPTION
* ref https://github.com/pola-rs/polars/issues/24093

Set `POLARS_VERBOSE_SENSITIVE=1` in the environment:

```
pl.scan_pyarrow_dataset(dset).filter(pl.col("a") < 3).collect()

[SENSITIVE]: python_scan_predicate: predicate node: [(col("a")) < (3)], converted pyarrow predicate: (pa.compute.field('a') < 3)
```
