### PR TITLE
perf: Basic de-duplication of filter expressions

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/mod.rs
+++ b/crates/polars-plan/src/plans/aexpr/mod.rs
@@ -90,7 +90,6 @@ impl Hash for IRAggExpr {
     }
 }
 
-#[cfg(feature = "cse")]
 impl IRAggExpr {
     pub(super) fn equal_nodes(&self, other: &IRAggExpr) -> bool {
         use IRAggExpr::*;

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
@@ -229,7 +229,7 @@ pub(super) fn process_join(
         init_hashmap(Some(acc_predicates.len()));
     let mut local_predicates = Vec::with_capacity(acc_predicates.len());
 
-    for (predicate_key, predicate) in acc_predicates {
+    for (_, predicate) in acc_predicates {
         let mut push_left = true;
         let mut push_right = true;
 

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
@@ -321,7 +321,7 @@ pub(super) fn process_join(
         if push_left {
             let mut predicate = predicate.clone();
             map_column_references(&mut predicate, expr_arena, &output_key_to_left_input_map);
-            pushdown_left.insert(predicate_key.clone(), predicate);
+            insert_predicate_dedup(&mut pushdown_left, &predicate, expr_arena);
         }
 
         if push_right {
@@ -333,7 +333,7 @@ pub(super) fn process_join(
                 &schema_right,
                 options.args.suffix(),
             );
-            pushdown_right.insert(predicate_key, predicate);
+            insert_predicate_dedup(&mut pushdown_right, &predicate, expr_arena);
         }
     }
 

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -172,11 +172,7 @@ impl PredicatePushDown<'_> {
                     for (_, predicate) in acc_predicates.iter() {
                         // we can pushdown the predicate
                         if check_input_node(predicate.node(), &input_schema, expr_arena) {
-                            insert_and_combine_predicate(
-                                &mut pushdown_predicates,
-                                predicate,
-                                expr_arena,
-                            )
+                            insert_predicate_dedup(&mut pushdown_predicates, predicate, expr_arena)
                         }
                         // we cannot pushdown the predicate we do it here
                         else {
@@ -310,7 +306,7 @@ impl PredicatePushDown<'_> {
                 };
 
                 if let Some(predicate) = acc_predicates.remove(&tmp_key) {
-                    insert_and_combine_predicate(&mut acc_predicates, &predicate, expr_arena);
+                    insert_predicate_dedup(&mut acc_predicates, &predicate, expr_arena);
                 }
 
                 let alp = lp_arena.take(input);

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
@@ -15,7 +15,7 @@ fn combine_by_and(left: Node, right: Node, arena: &mut Arena<AExpr>) -> Node {
     })
 }
 
-/// Inserts a predicate into the map.
+/// Inserts a predicate into the map, with some basic de-duplication.
 ///
 /// The map is keyed in a way that may cause some predicates to fall into the same bucket. In that
 /// case the predicate is AND'ed with the existing node in that bucket.

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
@@ -1,8 +1,11 @@
 use polars_core::prelude::*;
 use polars_utils::idx_vec::UnitVec;
+use polars_utils::unitvec;
 
 use super::keys::*;
-use crate::plans::visitor::{AexprNode, RewriteRecursion, RewritingVisitor, TreeWalker};
+use crate::plans::visitor::{
+    AExprArena, AexprNode, RewriteRecursion, RewritingVisitor, TreeWalker,
+};
 use crate::prelude::*;
 fn combine_by_and(left: Node, right: Node, arena: &mut Arena<AExpr>) -> Node {
     arena.add(AExpr::BinaryExpr {
@@ -12,19 +15,48 @@ fn combine_by_and(left: Node, right: Node, arena: &mut Arena<AExpr>) -> Node {
     })
 }
 
-/// Don't overwrite predicates but combine them.
-pub(super) fn insert_and_combine_predicate(
+/// Inserts a predicate into the map.
+///
+/// The map is keyed in a way that may cause some predicates to fall into the same bucket. In that
+/// case the predicate is AND'ed with the existing node in that bucket.
+pub(super) fn insert_predicate_dedup(
     acc_predicates: &mut PlHashMap<PlSmallStr, ExprIR>,
     predicate: &ExprIR,
-    arena: &mut Arena<AExpr>,
+    expr_arena: &mut Arena<AExpr>,
 ) {
-    let name = predicate_to_key(predicate.node(), arena);
+    let name = predicate_to_key(predicate.node(), expr_arena);
+
+    let mut new_min_terms = unitvec![];
 
     acc_predicates
         .entry(name)
         .and_modify(|existing_predicate| {
-            let node = combine_by_and(predicate.node(), existing_predicate.node(), arena);
-            existing_predicate.set_node(node)
+            let mut out_node = existing_predicate.node();
+
+            new_min_terms.clear();
+            new_min_terms.extend(MintermIter::new(predicate.node(), expr_arena));
+
+            // Limit the number of existing min-terms that we check against so that we have linear-time performance.
+            // Without this limit the loop below will be quadratic. The side effect is that we may not perfectly
+            // identify duplicates when there are large amounts of filter expressions.
+            const CHECK_LIMIT: usize = 32;
+
+            'next_new_min_term: for new_predicate in new_min_terms {
+                let new_min_term_eq_wrap = AExprArena::new(new_predicate, expr_arena);
+
+                if MintermIter::new(existing_predicate.node(), expr_arena)
+                    .take(CHECK_LIMIT)
+                    .any(|existing_min_term| {
+                        new_min_term_eq_wrap == AExprArena::new(existing_min_term, expr_arena)
+                    })
+                {
+                    continue 'next_new_min_term;
+                }
+
+                out_node = combine_by_and(new_predicate, out_node, expr_arena);
+            }
+
+            existing_predicate.set_node(out_node)
         })
         .or_insert_with(|| predicate.clone());
 }

--- a/crates/polars-plan/src/plans/visitor/expr.rs
+++ b/crates/polars-plan/src/plans/visitor/expr.rs
@@ -1,6 +1,4 @@
-use std::fmt::Debug;
-#[cfg(feature = "cse")]
-use std::fmt::Formatter;
+use std::fmt::{Debug, Formatter};
 
 use polars_core::prelude::{Field, Schema};
 use polars_utils::unitvec;
@@ -127,12 +125,10 @@ impl AexprNode {
         self.node = node;
     }
 
-    #[cfg(feature = "cse")]
     pub(crate) fn is_leaf(&self, arena: &Arena<AExpr>) -> bool {
         matches!(self.to_aexpr(arena), AExpr::Column(_) | AExpr::Literal(_))
     }
 
-    #[cfg(feature = "cse")]
     pub(crate) fn hashable_and_cmp<'a>(&self, arena: &'a Arena<AExpr>) -> AExprArena<'a> {
         AExprArena {
             node: self.node,
@@ -141,13 +137,11 @@ impl AexprNode {
     }
 }
 
-#[cfg(feature = "cse")]
 pub struct AExprArena<'a> {
     node: Node,
     arena: &'a Arena<AExpr>,
 }
 
-#[cfg(feature = "cse")]
 impl Debug for AExprArena<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "AexprArena: {}", self.node.0)
@@ -155,7 +149,6 @@ impl Debug for AExprArena<'_> {
 }
 
 impl AExpr {
-    #[cfg(feature = "cse")]
     fn is_equal_node(&self, other: &Self) -> bool {
         use AExpr::*;
         match (self, other) {
@@ -229,7 +222,6 @@ impl AExpr {
     }
 }
 
-#[cfg(feature = "cse")]
 impl<'a> AExprArena<'a> {
     pub fn new(node: Node, arena: &'a Arena<AExpr>) -> Self {
         Self { node, arena }
@@ -246,7 +238,6 @@ impl<'a> AExprArena<'a> {
     }
 }
 
-#[cfg(feature = "cse")]
 impl PartialEq for AExprArena<'_> {
     fn eq(&self, other: &Self) -> bool {
         let mut scratch1 = unitvec![];


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/23243

Renames `insert_and_combine_predicate` to `insert_predicate_dedup` and adds basic de-duplication by comparing  `<AExprArena as PartialEq>`.

#### Before/After
```python
q = lf.filter(pl.col("x") == 2, pl.col("x") == 2)

### Before
FILTER [([(col("x")) == (2)]) & ([(col("x")) == (2)])]
FROM
  DF ["x"]; PROJECT */1 COLUMNS

### After
FILTER [(col("x")) == (2)]
FROM
  DF ["x"]; PROJECT */1 COLUMNS
```

```python
q = (
    pl.LazyFrame({"x": [1, 2, 3]})
    .join(pl.LazyFrame({"x": [1, 2, 3]}), on="x", how="inner", coalesce=False)
    .filter(
        pl.col("x") == 2,
        pl.col("x_right") == 2,
    )
)

### Before
INNER JOIN:
LEFT PLAN ON: [col("x")]
  FILTER [([(col("x")) == (2)]) & ([(col("x")) == (2)])]
  FROM
    DF ["x"]; PROJECT */1 COLUMNS
RIGHT PLAN ON: [col("x")]
  FILTER [([(col("x")) == (2)]) & ([(col("x")) == (2)])]
  FROM
    DF ["x"]; PROJECT */1 COLUMNS
END INNER JOIN

### After
INNER JOIN:
LEFT PLAN ON: [col("x")]
  FILTER [(col("x")) == (2)]
  FROM
    DF ["x"]; PROJECT */1 COLUMNS
RIGHT PLAN ON: [col("x")]
  FILTER [(col("x")) == (2)]
  FROM
    DF ["x"]; PROJECT */1 COLUMNS
END INNER JOIN
```
