### PR TITLE
fix(python): Don't throw away type information for NumPy numeric values

### DIFF
--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -9,6 +9,7 @@ from zoneinfo import ZoneInfo
 import polars._reexport as pl
 from polars._utils.wrap import wrap_expr
 from polars.datatypes import Date, Datetime, Duration
+from polars.datatypes.convert import DataTypeMappings
 from polars.dependencies import (
     _check_for_numpy,
     _check_for_pytz,
@@ -196,6 +197,14 @@ def lit(
             if dtype_name.startswith("timedelta64["):
                 time_unit = dtype_name[len("timedelta64[") : -1]  # type: ignore[assignment]
                 return lit(item).cast(Duration(time_unit))
+
+        # handle numeric values
+        if isinstance(value, np.number):
+            dtype = DataTypeMappings.NUMPY_KIND_AND_ITEMSIZE_TO_DTYPE.get(
+                (value.dtype.kind, value.dtype.itemsize)
+            )
+            if dtype is not None:
+                return lit(value, dtype=dtype)
     else:
         item = value
 

--- a/py-polars/tests/unit/functions/test_lit.py
+++ b/py-polars/tests/unit/functions/test_lit.py
@@ -245,3 +245,23 @@ def test_lit_decimal_parametric(s: pl.Series) -> None:
 )
 def test_lit_structs(item: Any) -> None:
     assert pl.select(pl.lit(item)).to_dict(as_series=False) == {"literal": [item]}
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_dtype"),
+    [
+        (np.float32(1.2), pl.Float32),
+        (np.float64(1.2), pl.Float64),
+        (np.int8(1), pl.Int8),
+        (np.uint8(1), pl.UInt8),
+        (np.int16(1), pl.Int16),
+        (np.uint16(1), pl.UInt16),
+        (np.int32(1), pl.Int32),
+        (np.uint32(1), pl.UInt32),
+        (np.int64(1), pl.Int64),
+        (np.uint64(1), pl.UInt64),
+    ],
+)
+def test_numpy_lit(value: np.number, expected_dtype: PolarsDataType) -> None:
+    result = pl.select(pl.lit(value)).get_column("literal")
+    assert result.dtype == expected_dtype


### PR DESCRIPTION
When calling `pl.lit()` on a NumPy numeric value, in HEAD most of the type information is thrown away, resulting in a `UnknownKind::Float` for example for `float32`. For example, current state:

```python
>>> pl.lit(np.float32(1.2))
<Expr ['dyn float: 1.2000000476837158'] at 0x7A44F3753B50>
```

Notice the `dyn float`.

However, the type _is_ known here, there's no reason to throw this information away, it should be preserved. That's what this PR accomplishes:

```python
>>> pl.lit(np.float32(1.2))
<Expr ['1.2.strict_cast(Float32)'] at 0x73D63BBE4350>
```