### PR TITLE
perf: Truncate IR plan on `filter(False)`

### DIFF
--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -738,7 +738,7 @@ pub fn write_ir_non_recursive(
             )
         },
         IR::DataFrameScan {
-            df: _,
+            df,
             schema,
             output_schema,
         } => {
@@ -751,10 +751,14 @@ pub fn write_ir_non_recursive(
             } else {
                 ("*".to_string(), "".to_string())
             };
+
+            let zero_rows = if df.height() == 0 { "[0 rows]" } else { "" };
+
             write!(
                 f,
-                "{:indent$}DF {}; PROJECT{} {}/{} COLUMNS",
+                "{:indent$}DF{} {}; PROJECT{} {}/{} COLUMNS",
                 "",
+                zero_rows,
                 format_list_truncated!(schema.iter_names(), 4, '"'),
                 projected,
                 n_columns,

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -752,14 +752,12 @@ pub fn write_ir_non_recursive(
                 ("*".to_string(), "".to_string())
             };
 
-            let zero_rows = if df.height() == 0 { "[0 rows]" } else { "" };
-
             write!(
                 f,
-                "{:indent$}DF{} {}; PROJECT{} {}/{} COLUMNS",
+                "{:indent$}DF {}, {} rows; PROJECT{} {}/{} COLUMNS",
                 "",
-                zero_rows,
                 format_list_truncated!(schema.iter_names(), 4, '"'),
+                df.height(),
                 projected,
                 n_columns,
                 total_columns,

--- a/crates/polars-plan/src/plans/optimizer/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/mod.rs
@@ -262,7 +262,13 @@ pub fn optimize(
     // Note: ExpandDatasets must run after slice and predicate pushdown.
     rules.push(Box::new(expand_datasets::ExpandDatasets {}) as Box<dyn OptimizationRule>);
 
-    lp_top = opt.optimize_loop(&mut rules, expr_arena, lp_arena, lp_top)?;
+    lp_top = opt.optimize_loop(
+        &mut rules,
+        expr_arena,
+        lp_arena,
+        lp_top,
+        pushdown_maintain_errors,
+    )?;
 
     if opt_flags.cluster_with_columns() {
         cluster_with_columns::optimize(lp_top, lp_arena, expr_arena)


### PR DESCRIPTION
Upon encountering an `IR::Filter { predicate: lit(false) }`, replaces the entire IR subtree with `IR::DataFrameScan { df: DataFrame::empty_with_schema(..) }`.

Note that this can be disabled by setting `POLARS_PUSHDOWN_OPT_MAINTAIN_ERRORS=1`

#### E.g.
```python
q = (
    pl.LazyFrame({"x": [1, 2, 3]})
    .join(pl.LazyFrame({"x": [1, 2, 3]}), on="x", how="full")
    .filter(pl.lit(1) != 1)
)

print(q.explain())
### Before
FILTER false
FROM
  FULL JOIN:
  LEFT PLAN ON: [col("x")]
    DF ["x"]; PROJECT */1 COLUMNS
  RIGHT PLAN ON: [col("x")]
    DF ["x"]; PROJECT */1 COLUMNS
  END FULL JOIN

### After
DF ["x", "x_right"], 0 rows; PROJECT */2 COLUMNS
```

Note, the code to do this was inserted to take place after expression simplification so that `pl.lit(1) != 1` could be identified, but since expression simplification happens after predicate pushdown, the replaced subtree might not be exactly where the filter was typed by the user:

```python
q = (
    pl.LazyFrame({"x": [1, 2, 3]})
    .join(pl.LazyFrame({"x": [1, 2, 3]}), how="cross")
    .filter(pl.lit(1) != 1)
)

print(q.explain())
### Before
CROSS JOIN:
LEFT PLAN ON: []
  FILTER false
  FROM
    DF ["x"]; PROJECT */1 COLUMNS
RIGHT PLAN ON: []
  FILTER false
  FROM
    DF ["x"]; PROJECT */1 COLUMNS
END CROSS JOIN

### After
CROSS JOIN:
LEFT PLAN ON: []
  DF ["x"], 0 rows; PROJECT */1 COLUMNS
RIGHT PLAN ON: []
  DF ["x"], 0 rows; PROJECT */1 COLUMNS
END CROSS JOIN
```
