### PR TITLE
docs: Fix formatting of Series.value_counts examples

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -2694,6 +2694,7 @@ class Series:
         └───────┴─────┘
 
         Return the count as a relative frequency, normalized to 1.0:
+
         >>> s.value_counts(sort=True, normalize=True, name="fraction")
         shape: (3, 2)
         ┌───────┬──────────┐


### PR DESCRIPTION
This PR fixes a broken example in the value_counts documentation where the “relative frequency” snippet was rendered inline.
https://docs.pola.rs/api/python/stable/reference/series/api/polars.Series.value_counts.html