### PR TITLE
refactor(rust): Remove some transmutes

### DIFF
--- a/crates/polars-arrow/src/array/primitive/mod.rs
+++ b/crates/polars-arrow/src/array/primitive/mod.rs
@@ -458,13 +458,11 @@ impl<T: NativeType> PrimitiveArray<T> {
         let PrimitiveArray {
             values, validity, ..
         } = self;
-
-        // SAFETY: this is fine, we checked size and alignment, and NativeType
-        // is always Pod.
-        assert_eq!(size_of::<T>(), size_of::<U>());
-        assert_eq!(align_of::<T>(), align_of::<U>());
-        let new_values = unsafe { std::mem::transmute::<Buffer<T>, Buffer<U>>(values) };
-        PrimitiveArray::new(U::PRIMITIVE.into(), new_values, validity)
+        PrimitiveArray::new(
+            U::PRIMITIVE.into(),
+            Buffer::try_transmute::<U>(values).unwrap(),
+            validity,
+        )
     }
 
     /// Fills this entire array with the given value, leaving the validity mask intact.

--- a/crates/polars-arrow/src/types/native.rs
+++ b/crates/polars-arrow/src/types/native.rs
@@ -28,7 +28,6 @@ pub trait NativeType:
     + TotalOrd
     + IsNull
     + MinMax
-    + AlignedBytesCast<Self::AlignedBytes>
 {
     /// The corresponding variant of [`PrimitiveType`].
     const PRIMITIVE: PrimitiveType;

--- a/crates/polars-core/src/chunked_array/ops/bit_repr.rs
+++ b/crates/polars-core/src/chunked_array/ops/bit_repr.rs
@@ -14,10 +14,7 @@ fn reinterpret_chunked_array<T: PolarsNumericType, U: PolarsNumericType>(
 
     let chunks = ca.downcast_iter().map(|array| {
         let buf = array.values().clone();
-        // SAFETY: we checked that the size and alignment matches.
-        #[allow(clippy::transmute_undefined_repr)]
-        let reinterpreted_buf =
-            unsafe { std::mem::transmute::<Buffer<T::Native>, Buffer<U::Native>>(buf) };
+        let reinterpreted_buf = Buffer::try_transmute::<U::Native>(buf).unwrap();
         PrimitiveArray::from_data_default(reinterpreted_buf, array.validity().cloned())
     });
 
@@ -39,11 +36,8 @@ fn reinterpret_list_chunked<T: PolarsNumericType, U: PolarsNumericType>(
             .as_any()
             .downcast_ref::<PrimitiveArray<T::Native>>()
             .unwrap();
-        // SAFETY: we checked that the size and alignment matches.
-        #[allow(clippy::transmute_undefined_repr)]
-        let reinterpreted_buf = unsafe {
-            std::mem::transmute::<Buffer<T::Native>, Buffer<U::Native>>(inner_arr.values().clone())
-        };
+        let reinterpreted_buf =
+            Buffer::try_transmute::<U::Native>(inner_arr.values().clone()).unwrap();
         let pa =
             PrimitiveArray::from_data_default(reinterpreted_buf, inner_arr.validity().cloned());
         LargeListArray::new(
@@ -110,11 +104,8 @@ where
             16 => {
                 feature_gated!("dtype-i128", {
                     if matches!(self.dtype(), DataType::Int128) {
-                        let ca = self.clone();
-                        // Convince the compiler we are this type. This keeps flags.
-                        return BitRepr::I128(unsafe {
-                            std::mem::transmute::<ChunkedArray<T>, Int128Chunked>(ca)
-                        });
+                        let ca: &Int128Chunked = self.as_any().downcast_ref().unwrap();
+                        return BitRepr::I128(ca.clone());
                     }
 
                     BitRepr::I128(reinterpret_chunked_array(self))
@@ -123,11 +114,8 @@ where
 
             8 => {
                 if matches!(self.dtype(), DataType::UInt64) {
-                    let ca = self.clone();
-                    // Convince the compiler we are this type. This keeps flags.
-                    return BitRepr::U64(unsafe {
-                        std::mem::transmute::<ChunkedArray<T>, UInt64Chunked>(ca)
-                    });
+                    let ca: &UInt64Chunked = self.as_any().downcast_ref().unwrap();
+                    return BitRepr::U64(ca.clone());
                 }
 
                 BitRepr::U64(reinterpret_chunked_array(self))
@@ -138,11 +126,8 @@ where
 
                 BitRepr::U32(if byte_size == 4 {
                     if matches!(self.dtype(), DataType::UInt32) {
-                        let ca = self.clone();
-                        // Convince the compiler we are this type. This preserves flags.
-                        return BitRepr::U32(unsafe {
-                            std::mem::transmute::<ChunkedArray<T>, UInt32Chunked>(ca)
-                        });
+                        let ca: &UInt32Chunked = self.as_any().downcast_ref().unwrap();
+                        return BitRepr::U32(ca.clone());
                     }
 
                     reinterpret_chunked_array(self)

--- a/crates/polars-parquet/src/parquet/types.rs
+++ b/crates/polars-parquet/src/parquet/types.rs
@@ -1,12 +1,10 @@
-use arrow::types::{
-    AlignedBytes, AlignedBytesCast, Bytes4Alignment4, Bytes8Alignment8, Bytes12Alignment4,
-};
+use arrow::types::{AlignedBytes, Bytes4Alignment4, Bytes8Alignment8, Bytes12Alignment4};
 
 use crate::parquet::schema::types::PhysicalType;
 
 /// A physical native representation of a Parquet fixed-sized type.
 pub trait NativeType:
-    std::fmt::Debug + Send + Sync + 'static + Copy + Clone + AlignedBytesCast<Self::AlignedBytes>
+    std::fmt::Debug + Send + Sync + 'static + Copy + Clone + bytemuck::Pod
 {
     type Bytes: AsRef<[u8]>
         + bytemuck::Pod

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -42,6 +42,7 @@ pub mod sync;
 pub mod sys;
 pub mod total_ord;
 pub mod unique_id;
+pub mod with_drop;
 
 pub use functions::*;
 pub mod file;

--- a/crates/polars-utils/src/with_drop.rs
+++ b/crates/polars-utils/src/with_drop.rs
@@ -1,0 +1,91 @@
+// A copy from the yet unstable library/core/src/mem/drop_guard.rs.
+
+use core::fmt::{self, Debug};
+use core::mem::ManuallyDrop;
+use core::ops::{Deref, DerefMut};
+
+pub struct WithDrop<T, F>
+where
+    F: FnOnce(T),
+{
+    inner: ManuallyDrop<T>,
+    f: ManuallyDrop<F>,
+}
+
+impl<T, F> WithDrop<T, F>
+where
+    F: FnOnce(T),
+{
+    #[must_use]
+    pub const fn new(inner: T, f: F) -> Self {
+        Self {
+            inner: ManuallyDrop::new(inner),
+            f: ManuallyDrop::new(f),
+        }
+    }
+
+    #[inline]
+    pub fn into_inner(guard: Self) -> T {
+        // First we ensure that dropping the guard will not trigger
+        // its destructor
+        let mut guard = ManuallyDrop::new(guard);
+
+        // Next we manually read the stored value from the guard.
+        //
+        // SAFETY: this is safe because we've taken ownership of the guard.
+        let value = unsafe { ManuallyDrop::take(&mut guard.inner) };
+
+        // Finally we drop the stored closure. We do this *after* having read
+        // the value, so that even if the closure's `drop` function panics,
+        // unwinding still tries to drop the value.
+        //
+        // SAFETY: this is safe because we've taken ownership of the guard.
+        unsafe { ManuallyDrop::drop(&mut guard.f) };
+        value
+    }
+}
+
+impl<T, F> Deref for WithDrop<T, F>
+where
+    F: FnOnce(T),
+{
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T, F> DerefMut for WithDrop<T, F>
+where
+    F: FnOnce(T),
+{
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+impl<T, F> Drop for WithDrop<T, F>
+where
+    F: FnOnce(T),
+{
+    fn drop(&mut self) {
+        // SAFETY: `WithDrop` is in the process of being dropped.
+        let inner = unsafe { ManuallyDrop::take(&mut self.inner) };
+
+        // SAFETY: `WithDrop` is in the process of being dropped.
+        let f = unsafe { ManuallyDrop::take(&mut self.f) };
+
+        f(inner);
+    }
+}
+
+impl<T, F> Debug for WithDrop<T, F>
+where
+    T: Debug,
+    F: FnOnce(T),
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}


### PR DESCRIPTION
Also adds a stable shim for the utility `WithDrop` recently accepted into the standard library.