### PR TITLE
fix: Correct size limits for Decimal cast

### DIFF
--- a/crates/polars-compute/src/cast/primitive_to.rs
+++ b/crates/polars-compute/src/cast/primitive_to.rs
@@ -229,12 +229,12 @@ pub fn integer_to_decimal<T: NativeType + AsPrimitive<i128>>(
     to_precision: usize,
     to_scale: usize,
 ) -> PrimitiveArray<i128> {
-    let multiplier = 10_i128.pow(to_scale as u32);
+    assert!(to_precision <= 38);
+    assert!(to_scale <= 38);
 
-    let min_for_precision = 9_i128
-        .saturating_pow(1 + to_precision as u32)
-        .saturating_neg();
-    let max_for_precision = 9_i128.saturating_pow(1 + to_precision as u32);
+    let multiplier = 10_i128.pow(to_scale as u32);
+    let max_for_precision = 10_i128.pow(to_precision as u32) - 1;
+    let min_for_precision = -max_for_precision;
 
     let values = from.iter().map(|x| {
         x.and_then(|x| {
@@ -274,13 +274,13 @@ where
     T: NativeType + Float + ToPrimitive,
     f64: AsPrimitive<T>,
 {
+    assert!(to_precision <= 38);
+    assert!(to_scale <= 38);
+
     // 1.2 => 12
     let multiplier: T = (10_f64).powi(to_scale as i32).as_();
-
-    let min_for_precision = 9_i128
-        .saturating_pow(1 + to_precision as u32)
-        .saturating_neg();
-    let max_for_precision = 9_i128.saturating_pow(1 + to_precision as u32);
+    let max_for_precision = 10_i128.pow(to_precision as u32) - 1;
+    let min_for_precision = -max_for_precision;
 
     let values = from.iter().map(|x| {
         x.and_then(|x| {

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -13,6 +13,7 @@ import pyarrow as pa
 import pytest
 
 import polars as pl
+from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -758,3 +759,15 @@ def test_decimal32_decimal64_22946() -> None:
             ]
         ),
     )
+
+
+def test_decimal_cast_limit() -> None:
+    fits = pl.Series([10**38 - 1, -(10**38 - 1)])
+    assert_series_equal(fits.cast(pl.Decimal(38, 0)).cast(pl.Int128), fits)
+
+    too_large1 = pl.Series([10**38])
+    too_large2 = pl.Series([-10**38])
+    with pytest.raises(InvalidOperationError):
+        too_large1.cast(pl.Decimal(38, 0))
+    with pytest.raises(InvalidOperationError):
+        too_large2.cast(pl.Decimal(38, 0))

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -769,7 +769,7 @@ def test_decimal_cast_limit() -> None:
         fits.cast(pl.Decimal(39, 0))
 
     too_large1 = pl.Series([10**38])
-    too_large2 = pl.Series([-10**38])
+    too_large2 = pl.Series([-(10**38)])
     with pytest.raises(InvalidOperationError):
         too_large1.cast(pl.Decimal(38, 0))
     with pytest.raises(InvalidOperationError):

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -765,6 +765,9 @@ def test_decimal_cast_limit() -> None:
     fits = pl.Series([10**38 - 1, -(10**38 - 1)])
     assert_series_equal(fits.cast(pl.Decimal(38, 0)).cast(pl.Int128), fits)
 
+    with pytest.raises(InvalidOperationError):
+        fits.cast(pl.Decimal(39, 0))
+
     too_large1 = pl.Series([10**38])
     too_large2 = pl.Series([-10**38])
     with pytest.raises(InvalidOperationError):


### PR DESCRIPTION
These were using powers of 9 rather than 10 for some reason.