### PR TITLE
build: Drop binary support for macos_x86-64

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -91,9 +91,7 @@ jobs:
       fail-fast: false
       matrix:
         package: [polars, polars-lts-cpu, polars-u64-idx]
-        # macos-13 is x86-64
-        # macos-15 is aarch64
-        os: [ubuntu-latest, macos-13, macos-15, windows-latest, windows-11-arm]
+        os: [ubuntu-latest, macos-15, windows-latest, windows-11-arm]
         architecture: [x86-64, aarch64]
         exclude:
           - os: windows-latest
@@ -102,8 +100,6 @@ jobs:
             architecture: x86-64
           - os: macos-15
             architecture: x86-64
-          - os: macos-13
-            architecture: aarch64
 
     env:
       SED_INPLACE: ${{ startsWith(matrix.os, 'macos') && '-i ''''' || '-i' }}


### PR DESCRIPTION
Github has dropped support for macos_x86-64 runners. As cross-compiling did lead to many issues in the past, we will drop binary support for this target as well.

From source compilation will remain supported. 