### PR TITLE
fix: Panic in inexact date(time) conversion

### DIFF
--- a/crates/polars-time/src/chunkedarray/string/mod.rs
+++ b/crates/polars-time/src/chunkedarray/string/mod.rs
@@ -2,8 +2,6 @@ pub mod infer;
 use chrono::DateTime;
 mod patterns;
 mod strptime;
-use chrono::ParseError;
-use chrono::format::ParseErrorKind;
 pub use patterns::Pattern;
 #[cfg(feature = "dtype-time")]
 use polars_core::chunked_array::temporal::time_to_time64ns;

--- a/crates/polars-time/src/chunkedarray/string/mod.rs
+++ b/crates/polars-time/src/chunkedarray/string/mod.rs
@@ -122,7 +122,7 @@ pub trait StringMethods: AsString {
                         let mut it = s.chars();
                         it.next();
                         s = it.as_str();
-                    }
+                    },
                 }
             }
 

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
@@ -289,3 +289,20 @@ def test_to_datetime_fallible_predicate_pushdown() -> None:
         assert_frame_equal(
             q.collect(), q.collect(optimizations=pl.QueryOptFlags.none())
         )
+
+def test_to_date_inexact_overlong_24263() -> None:
+    df = pl.DataFrame({"a": ['15/03/2024', '2024-02-29 00:00:00']})
+    out = df.with_columns(pl.col("a").str.to_date("%d/%m/%Y", strict=False, exact=False))
+    assert_frame_equal(out, pl.DataFrame({"a": [date(2024, 3, 15), None]}))
+
+
+def test_to_date_inexact_unicode_multibyte() -> None:
+    df = pl.DataFrame({"a": ['你好15/03/2024你好', '你好']})
+    out = df.with_columns(pl.col("a").str.to_date("%d/%m/%Y", strict=False, exact=False))
+    assert_frame_equal(out, pl.DataFrame({"a": [date(2024, 3, 15), None]}))
+
+
+def test_to_datetime_inexact_unicode_multibyte() -> None:
+    df = pl.DataFrame({"a": ['你好2020-02-03 12:53:11你好', '你好']})
+    out = df.with_columns(pl.col("a").str.to_datetime("%Y-%m-%d %H:%M:%S", strict=False, exact=False))
+    assert_frame_equal(out, pl.DataFrame({"a": [datetime(2020, 2, 3, 12, 53, 11), None]}))

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
@@ -290,19 +290,28 @@ def test_to_datetime_fallible_predicate_pushdown() -> None:
             q.collect(), q.collect(optimizations=pl.QueryOptFlags.none())
         )
 
+
 def test_to_date_inexact_overlong_24263() -> None:
-    df = pl.DataFrame({"a": ['15/03/2024', '2024-02-29 00:00:00']})
-    out = df.with_columns(pl.col("a").str.to_date("%d/%m/%Y", strict=False, exact=False))
+    df = pl.DataFrame({"a": ["15/03/2024", "2024-02-29 00:00:00"]})
+    out = df.with_columns(
+        pl.col("a").str.to_date("%d/%m/%Y", strict=False, exact=False)
+    )
     assert_frame_equal(out, pl.DataFrame({"a": [date(2024, 3, 15), None]}))
 
 
 def test_to_date_inexact_unicode_multibyte() -> None:
-    df = pl.DataFrame({"a": ['你好15/03/2024你好', '你好']})
-    out = df.with_columns(pl.col("a").str.to_date("%d/%m/%Y", strict=False, exact=False))
+    df = pl.DataFrame({"a": ["你好15/03/2024你好", "你好"]})
+    out = df.with_columns(
+        pl.col("a").str.to_date("%d/%m/%Y", strict=False, exact=False)
+    )
     assert_frame_equal(out, pl.DataFrame({"a": [date(2024, 3, 15), None]}))
 
 
 def test_to_datetime_inexact_unicode_multibyte() -> None:
-    df = pl.DataFrame({"a": ['你好2020-02-03 12:53:11你好', '你好']})
-    out = df.with_columns(pl.col("a").str.to_datetime("%Y-%m-%d %H:%M:%S", strict=False, exact=False))
-    assert_frame_equal(out, pl.DataFrame({"a": [datetime(2020, 2, 3, 12, 53, 11), None]}))
+    df = pl.DataFrame({"a": ["你好2020-02-03 12:53:11你好", "你好"]})
+    out = df.with_columns(
+        pl.col("a").str.to_datetime("%Y-%m-%d %H:%M:%S", strict=False, exact=False)
+    )
+    assert_frame_equal(
+        out, pl.DataFrame({"a": [datetime(2020, 2, 3, 12, 53, 11), None]})
+    )


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/24263.

Also fixes an as-of-yet unreported bug where there are multibyte unicode characters in the string. A bit faster of an algorithm to boot as the suffix is directly chopped off using `parse_and_remainder`.