### PR TITLE
perf: Do ordering simplification step after common sub-plan elimination

### DIFF
--- a/py-polars/tests/unit/test_queries.py
+++ b/py-polars/tests/unit/test_queries.py
@@ -399,3 +399,33 @@ def test_temporal_time_casts() -> None:
             time(0, 0, 0, 0),
             time(0, 0, 0, 1),
         ]
+
+
+def assert_unopt_frame_equal(
+    lf: pl.LazyFrame, *, check_row_order: bool = False
+) -> None:
+    assert_frame_equal(
+        lf.collect(),
+        lf.collect(optimizations=pl.QueryOptFlags.none()),
+        check_row_order=check_row_order,
+    )
+
+
+def test_order_queries() -> None:
+    lf = pl.LazyFrame({"a": range(100), "b": range(100)})
+
+    q = lf.group_by(["a", "b"], maintain_order=True).agg([]).cache()
+    q1 = q.with_columns(pl.col.a.cum_sum())
+    q2 = q.with_columns(pl.col.b + 1).unique("a")
+
+    assert_unopt_frame_equal(pl.concat([q1, q]), check_row_order=True)
+    assert_unopt_frame_equal(pl.concat([q1, q]).unique(), check_row_order=False)
+    assert_unopt_frame_equal(pl.concat([q1, q2]).unique(), check_row_order=False)
+
+    q = lf.cache()
+    q1 = q.with_columns(pl.col.a.cum_sum())
+    q2 = q.with_columns(pl.col.b + 1).unique("a")
+
+    assert_unopt_frame_equal(pl.concat([q1, q]), check_row_order=True)
+    assert_unopt_frame_equal(pl.concat([q1, q]).unique(), check_row_order=False)
+    assert_unopt_frame_equal(pl.concat([q1, q2]).unique(), check_row_order=False)


### PR DESCRIPTION
This came up a lot in plans where it would decide to split an order observing operation into the order obsering and non-order observing variant because CSE was done afterwards.