### PR TITLE
docs: Add missing reference to `LazyFrame.pipe_with_schema()` on the website

### DIFF
--- a/py-polars/docs/source/reference/lazyframe/miscellaneous.rst
+++ b/py-polars/docs/source/reference/lazyframe/miscellaneous.rst
@@ -15,6 +15,7 @@ Miscellaneous
     LazyFrame.lazy
     LazyFrame.map_batches
     LazyFrame.pipe
+    LazyFrame.pipe_with_schema
     LazyFrame.profile
     LazyFrame.remote
 


### PR DESCRIPTION
This was forgotten in #24075.

I'm not very familiar with the Python ecosystem, but isn't there a tool to detect those missing references? Just asking because in R, usually the docs CI will error if some functions that are available in the public API are not listed in the website config file.
