### PR TITLE
fix: Incorrect first/last aggregate in streaming engine

### DIFF
--- a/crates/polars-expr/src/hot_groups/fixed_index_table.rs
+++ b/crates/polars-expr/src/hot_groups/fixed_index_table.rs
@@ -64,6 +64,7 @@ impl<K> FixedIndexTable<K> {
         &mut self,
         hash: u64,
         key: Q,
+        force_insert: bool,
         mut eq: E,
         mut insert: I,
         mut evict_insert: V,
@@ -145,7 +146,8 @@ impl<K> FixedIndexTable<K> {
             let hr = select_unpredictable(self.prng >> 63 != 0, h1, h2);
             self.prng = self.prng.wrapping_add(hash);
             let slot = self.slots.get_unchecked_mut(hr);
-            if slot.last_access_tag == tag {
+
+            if (slot.last_access_tag == tag) | force_insert {
                 slot.tag = tag;
                 let evict_key = self.keys.get_unchecked_mut(slot.key_index as usize);
                 evict_insert(key, evict_key);

--- a/crates/polars-expr/src/hot_groups/mod.rs
+++ b/crates/polars-expr/src/hot_groups/mod.rs
@@ -29,6 +29,7 @@ pub trait HotGrouper: Any + Send + Sync {
         hot_idxs: &mut Vec<IdxSize>,
         hot_group_idxs: &mut Vec<EvictIdx>,
         cold_idxs: &mut Vec<IdxSize>,
+        force_hot: bool,
     );
 
     /// Get all the current hot keys, in group order.

--- a/crates/polars-expr/src/hot_groups/row_encoded.rs
+++ b/crates/polars-expr/src/hot_groups/row_encoded.rs
@@ -42,6 +42,7 @@ impl HotGrouper for RowEncodedHashHotGrouper {
         hot_idxs: &mut Vec<IdxSize>,
         hot_group_idxs: &mut Vec<EvictIdx>,
         cold_idxs: &mut Vec<IdxSize>,
+        force_hot: bool,
     ) {
         let HashKeys::RowEncoded(keys) = keys else {
             unreachable!()
@@ -58,6 +59,7 @@ impl HotGrouper for RowEncodedHashHotGrouper {
                     let opt_g = self.table.insert_key(
                         h,
                         key,
+                        force_hot,
                         |a, b| *a == b.1,
                         |k| (h, k.to_owned()),
                         |k, ev_k| {

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -1534,3 +1534,24 @@ def test_slice_group_by_offset_24259() -> None:
         "x": [[3, 5], [6], [1, 2, 4], []],
         "tail": [[5], [6], [4], []],
     }
+
+
+def test_group_by_first_nondet_24278() -> None:
+    values = [
+        96, 86, 0, 86, 43, 50, 9, 14, 98, 39, 93, 7, 71, 1, 93, 41, 56,
+        56, 93, 41, 58, 91, 81, 29, 81, 68, 5, 9, 32, 93, 78, 34, 17, 40,
+        14, 2, 52, 77, 81, 4, 56, 42, 64, 12, 29, 58, 71, 98, 32, 49, 34,
+        86, 29, 94, 37, 21, 41, 36, 9, 72, 23, 28, 71, 9, 66, 72, 84, 81,
+        23, 12, 64, 57, 99, 15, 77, 38, 95, 64, 13, 91, 43, 61, 70, 47,
+        39, 75, 47, 93, 45, 1, 95, 55, 29, 5, 83, 8, 3, 6, 45, 84,
+    ]  # fmt: skip
+    q = (
+        pl.LazyFrame({"a": values, "idx": range(100)})
+        .group_by("a")
+        .agg(pl.col.idx.first())
+        .select(a=pl.col.idx)
+    )
+
+    fst_value = q.collect().to_series().sum()
+    for _ in range(10):
+        assert q.collect().to_series().sum() == fst_value


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/24278.

This is more of a temporary workaround than a proper fix, but the hot/cold key paradigm I introduced in the streaming group-by has a problem with order-sensitive aggregates.

In my original design we had the guarantee that reducers are called within one dataframe in the correct order, which allows us to write order-sensitive reducers so long as we have the sequence id of the morsel. However, with the hot key cache we now bypass cold keys from the reducer entirely until later, violating this assumption.

For now I've just ensured that every key is always marked as hot if we have an order-sensitive aggregate. This means we have more evictions if this is the case. I'll have to do some more thinking about a proper solution later.