### PR TITLE
fix(rust): Fix ignore_errors for NDJSON

### DIFF
--- a/crates/polars-io/src/ndjson/core.rs
+++ b/crates/polars-io/src/ndjson/core.rs
@@ -397,7 +397,11 @@ pub fn json_lines(bytes: &[u8]) -> impl Iterator<Item = &[u8]> {
     })
 }
 
-fn parse_lines(bytes: &[u8], buffers: &mut PlIndexMap<BufferKey, Buffer>, ignore_errors: bool) -> PolarsResult<()> {
+fn parse_lines(
+    bytes: &[u8],
+    buffers: &mut PlIndexMap<BufferKey, Buffer>,
+    ignore_errors: bool,
+) -> PolarsResult<()> {
     let mut scratch = Scratch::default();
 
     let iter = json_lines(bytes);

--- a/crates/polars-io/src/ndjson/core.rs
+++ b/crates/polars-io/src/ndjson/core.rs
@@ -404,7 +404,7 @@ fn parse_lines(bytes: &[u8], buffers: &mut PlIndexMap<BufferKey, Buffer>, ignore
     for bytes in iter {
         match parse_impl(bytes, buffers, &mut scratch) {
             Ok(_) => {},
-            Err(e) if ignore_errors => {
+            Err(e) if !ignore_errors => {
                 return Err(e);
             },
             Err(_) => {},

--- a/crates/polars-io/src/ndjson/core.rs
+++ b/crates/polars-io/src/ndjson/core.rs
@@ -397,12 +397,18 @@ pub fn json_lines(bytes: &[u8]) -> impl Iterator<Item = &[u8]> {
     })
 }
 
-fn parse_lines(bytes: &[u8], buffers: &mut PlIndexMap<BufferKey, Buffer>) -> PolarsResult<()> {
+fn parse_lines(bytes: &[u8], buffers: &mut PlIndexMap<BufferKey, Buffer>, ignore_errors: bool) -> PolarsResult<()> {
     let mut scratch = Scratch::default();
 
     let iter = json_lines(bytes);
     for bytes in iter {
-        parse_impl(bytes, buffers, &mut scratch)?;
+        match parse_impl(bytes, buffers, &mut scratch) {
+            Ok(_) => {},
+            Err(e) if ignore_errors => {
+                return Err(e);
+            },
+            Err(_) => {},
+        }
     }
     Ok(())
 }
@@ -416,7 +422,7 @@ pub fn parse_ndjson(
     let capacity = n_rows_hint.unwrap_or_else(|| estimate_n_lines_in_chunk(bytes));
 
     let mut buffers = init_buffers(schema, capacity, ignore_errors)?;
-    parse_lines(bytes, &mut buffers)?;
+    parse_lines(bytes, &mut buffers, ignore_errors)?;
 
     DataFrame::new(
         buffers

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -201,6 +201,17 @@ def test_ndjson_nested_null() -> None:
     assert df.to_dict(as_series=False) == {"foo": [{"bar": [{}]}]}
 
 
+def test_ndjson_with_ignore_error() -> None:
+    json_payload = """{"Column1": "Value0"}
+        {"Column1":"Value1"}{}
+        {"Column1": "Value2"}"""
+    df = pl.read_ndjson(
+        io.StringIO(json_payload), infer_schema_length=1, ignore_errors=True
+    )
+    expected = pl.DataFrame({"Column1": ["Value0", "Value2"]})
+    assert_frame_equal(df, expected)
+
+
 def test_ndjson_nested_string_int() -> None:
     ndjson = """{"Accumulables":[{"Value":32395888},{"Value":"539454"}]}"""
     assert pl.read_ndjson(io.StringIO(ndjson)).to_dict(as_series=False) == {


### PR DESCRIPTION
Fixes #13768.

Previously, `ignore_errors` was not respected by the parser implementation. This passes the flag along and handles the error case.

Note that this can still fail if the error is within the window of lines used to determine the schema. Set `infer_schema_length` to a lower number or explicitly set the schema if this happens in your case.