### PR TITLE
fix: Schema mismatch for 'log' operation

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
@@ -227,7 +227,14 @@ impl IRFunctionExpr {
             #[cfg(feature = "interpolate_by")]
             InterpolateBy => mapper.map_numeric_to_float_dtype(true),
             #[cfg(feature = "log")]
-            Entropy { .. } | Log | Log1p | Exp => mapper.map_to_float_dtype(),
+            Entropy { .. } | Log1p | Exp => mapper.map_to_float_dtype(),
+            #[cfg(feature = "log")]
+            Log => mapper.with_dtype(
+                match args_to_supertype(fields)? {
+                    DataType::Float32 => DataType::Float32,
+                    _ => DataType::Float64,
+                }
+            ),
             Unique(_) => mapper.with_same_dtype(),
             #[cfg(feature = "round_series")]
             Round { .. } | RoundSF { .. } | Floor | Ceil => mapper.with_same_dtype(),

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -5,6 +5,7 @@ from itertools import permutations
 from typing import TYPE_CHECKING, Any, cast
 from zoneinfo import ZoneInfo
 
+import numpy as np
 import pytest
 
 import polars as pl
@@ -135,6 +136,99 @@ def test_entropy() -> None:
         {"group": ["A", "B", "C"], "id": [1.0397207708399179, 1.371381017771811, 0.0]}
     )
     assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pl.Float64,
+        pl.Float32,
+    ],
+)
+def test_log_broadcast(dtype: pl.DataType) -> None:
+    a = pl.Series("a", [1, 3, 9, 27, 81], dtype=dtype)
+    b = pl.Series("a", [3, 3, 9, 3, 9], dtype=dtype)
+
+    assert_series_equal(a.log(b), pl.Series("a", [0, 1, 1, 3, 2], dtype=dtype))
+    assert_series_equal(
+        a.log(pl.Series("a", [3], dtype=dtype)),
+        pl.Series("a", [0, 1, 2, 3, 4], dtype=dtype),
+    )
+    assert_series_equal(
+        pl.Series("a", [81], dtype=dtype).log(b),
+        pl.Series("a", [4, 4, 2, 4, 2], dtype=dtype),
+    )
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pl.Float32,
+        pl.Int32,
+        pl.Int64,
+    ],
+)
+def test_log_broadcast_upcasting(dtype: pl.DataType) -> None:
+    a = pl.Series("a", [1, 3, 9, 27, 81], dtype=dtype)
+    b = pl.Series("a", [3, 3, 9, 3, 9], dtype=dtype)
+    expected = pl.Series("a", [0, 1, 1, 3, 2], dtype=pl.Float64)
+
+    assert_series_equal(a.log(b.cast(pl.Float64)), expected)
+    assert_series_equal(a.cast(pl.Float64).log(b), expected)
+
+
+@pytest.mark.parametrize(
+    ("dtype_a", "dtype_base", "dtype_out"),
+    [
+        (pl.UInt8, pl.UInt8, pl.Float64),
+        (pl.Int32, pl.Int32, pl.Float64),
+        (pl.Decimal(21, 3), pl.Decimal(21, 3), pl.Float64),
+        (pl.Float32, pl.Float32, pl.Float32),
+        (pl.Float32, pl.Float64, pl.Float64),
+        (pl.Float64, pl.Float32, pl.Float64),
+        (pl.Float64, pl.Float64, pl.Float64),
+    ],
+)
+def test_log(
+    dtype_a: PolarsDataType,
+    dtype_base: PolarsDataType,
+    dtype_out: PolarsDataType,
+) -> None:
+    a = pl.Series("a", [1, 3, 9, 27, 81], dtype=dtype_a)
+    base = pl.Series("base", [3, 3, 9, 3, 9], dtype=dtype_base)
+    lf = pl.LazyFrame([a, base])
+
+    # log
+    result = lf.select(pl.col("a").log("base"))
+    expected = pl.DataFrame({"a": pl.Series([0, 1, 1, 3, 2], dtype=dtype_out)})
+
+    assert_frame_equal(result.collect(), expected)
+    assert result.collect_schema() == expected.schema
+
+
+@pytest.mark.parametrize(
+    ("dtype_in", "dtype_out"),
+    [
+        (pl.Int32, pl.Float64),
+        (pl.Float32, pl.Float32),
+        (pl.Float64, pl.Float64),
+    ],
+)
+def test_exp_log1p(dtype_in: PolarsDataType, dtype_out: PolarsDataType) -> None:
+    a = pl.Series("a", [1, 3, 9, 4, 10], dtype=dtype_in)
+    lf = pl.LazyFrame([a])
+
+    # exp
+    result = lf.select(pl.col("a").exp())
+    expected = pl.Series("a", np.exp(a.to_numpy())).cast(dtype_out).to_frame()
+    assert_frame_equal(result.collect(), expected)
+    assert result.collect_schema() == expected.schema
+
+    # log1p
+    result = lf.select(pl.col("a").log1p())
+    expected = pl.Series("a", np.log1p(a.to_numpy())).cast(dtype_out).to_frame()
+    assert_frame_equal(result.collect(), expected)
+    assert result.collect_schema() == expected.schema
 
 
 def test_dot_in_group_by() -> None:

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1685,68 +1685,6 @@ def test_nested_list_types_preserved(dtype: pl.DataType) -> None:
         assert srs_nested.dtype == dtype
 
 
-@pytest.mark.parametrize(
-    "dtype",
-    [
-        pl.Float64,
-        pl.Int32,
-        pl.Decimal(21, 3),
-    ],
-)
-def test_log_exp(dtype: pl.DataType) -> None:
-    a = pl.Series("a", [1, 100, 1000], dtype=dtype)
-    b = pl.Series("a", [0, 2, 3], dtype=dtype)
-    assert_series_equal(a.log10(), b.cast(pl.Float64))
-
-    expected = pl.Series("a", np.log(a.cast(pl.Float64).to_numpy()))
-    assert_series_equal(a.log(), expected)
-
-    expected = pl.Series("a", np.exp(b.cast(pl.Float64).to_numpy()))
-    assert_series_equal(b.exp(), expected)
-
-    expected = pl.Series("a", np.log1p(a.cast(pl.Float64).to_numpy()))
-    assert_series_equal(a.log1p(), expected)
-
-
-@pytest.mark.parametrize(
-    "dtype",
-    [
-        pl.Float64,
-        pl.Float32,
-    ],
-)
-def test_log_broadcast(dtype: pl.DataType) -> None:
-    a = pl.Series("a", [1, 3, 9, 27, 81], dtype=dtype)
-    b = pl.Series("a", [3, 3, 9, 3, 9], dtype=dtype)
-
-    assert_series_equal(a.log(b), pl.Series("a", [0, 1, 1, 3, 2], dtype=dtype))
-    assert_series_equal(
-        a.log(pl.Series("a", [3], dtype=dtype)),
-        pl.Series("a", [0, 1, 2, 3, 4], dtype=dtype),
-    )
-    assert_series_equal(
-        pl.Series("a", [81], dtype=dtype).log(b),
-        pl.Series("a", [4, 4, 2, 4, 2], dtype=dtype),
-    )
-
-
-@pytest.mark.parametrize(
-    "dtype",
-    [
-        pl.Float32,
-        pl.Int32,
-        pl.Int64,
-    ],
-)
-def test_log_broadcast_upcasting(dtype: pl.DataType) -> None:
-    a = pl.Series("a", [1, 3, 9, 27, 81], dtype=dtype)
-    b = pl.Series("a", [3, 3, 9, 3, 9], dtype=dtype)
-    expected = pl.Series("a", [0, 1, 1, 3, 2], dtype=Float64)
-
-    assert_series_equal(a.log(b.cast(Float64)), expected)
-    assert_series_equal(a.cast(Float64).log(b), expected)
-
-
 def test_to_physical() -> None:
     # casting an int result in an int
     s = pl.Series("a", [1, 2, 3])


### PR DESCRIPTION
Closes #24290.

```
import polars as pl

dtype = pl.Float32

a = pl.Series("a", [1, 3, 9, 27, 81], dtype=dtype)
b = pl.Series("a", [3, 3, 9, 3, 9], dtype=dtype)

q = pl.select(pl.lit(a).log(pl.lit(b).cast(pl.Float64())), eager=False)

print(q.collect().schema == q.collect_schema())
# True
```