### PR TITLE
refactor(rust): Remove unnecessary stable_features for AVX512

### DIFF
--- a/crates/polars-compute/src/lib.rs
+++ b/crates/polars-compute/src/lib.rs
@@ -1,10 +1,4 @@
 #![cfg_attr(feature = "simd", feature(portable_simd))]
-// TODO: Remove the allow and cfg_attr once Rust 1.89 is stable
-#![allow(stable_features)]
-#![cfg_attr(
-    all(feature = "simd", target_arch = "x86_64"),
-    feature(stdarch_x86_avx512)
-)]
 
 use arrow::types::NativeType;
 


### PR DESCRIPTION
This is now in stable Rust.