### PR TITLE
fix(python): Fix deadlock on `collect_async`

### DIFF
--- a/crates/polars-io/src/pl_async.rs
+++ b/crates/polars-io/src/pl_async.rs
@@ -331,34 +331,6 @@ impl RuntimeManager {
     {
         self.rt.spawn_blocking(f)
     }
-
-    /// Run a task on the rayon threadpool. To avoid deadlocks, if the current thread is already a
-    /// rayon thread, the task is executed on the current thread after tokio's `block_in_place` is
-    /// used to spawn another thread to poll futures.
-    pub async fn spawn_rayon<F, O>(&self, func: F) -> O
-    where
-        F: FnOnce() -> O + Send + Sync + 'static,
-        O: Send + Sync + 'static,
-    {
-        if POOL.current_thread_index().is_some() {
-            // We are a rayon thread, so we can't use POOL.spawn as it would mean we spawn a task and block until
-            // another rayon thread executes it - we would deadlock if all rayon threads did this.
-            // Safety: The tokio runtime flavor is multi-threaded.
-            tokio::task::block_in_place(func)
-        } else {
-            let (tx, rx) = tokio::sync::oneshot::channel();
-
-            let func = move || {
-                let out = func();
-                // Don't unwrap send attempt - async task could be cancelled.
-                let _ = tx.send(out);
-            };
-
-            POOL.spawn(func);
-
-            rx.await.unwrap()
-        }
-    }
 }
 
 static RUNTIME: LazyLock<RuntimeManager> = LazyLock::new(RuntimeManager::new);

--- a/crates/polars-io/src/utils/mod.rs
+++ b/crates/polars-io/src/utils/mod.rs
@@ -15,3 +15,22 @@ pub const URL_ENCODE_CHAR_SET: &percent_encoding::AsciiSet = &percent_encoding::
     .add(b':')
     .add(b' ')
     .add(b'%');
+
+/// Spawns a blocking task to a background thread.
+///
+/// This uses `pl_async::get_runtime().spawn_blocking` if the `async` feature enabled. It uses
+/// `std::thread::spawn` otherwise.
+pub fn spawn_blocking<F, R>(func: F)
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    #[cfg(feature = "async")]
+    {
+        crate::pl_async::get_runtime().spawn_blocking(func);
+    }
+    #[cfg(not(feature = "async"))]
+    {
+        std::thread::spawn(func);
+    }
+}

--- a/crates/polars-lazy/src/frame/exitable.rs
+++ b/crates/polars-lazy/src/frame/exitable.rs
@@ -14,20 +14,10 @@ impl LazyFrame {
         let token = state.cancel_token();
 
         if physical_plan.is_cache_prefiller() {
-            #[cfg(feature = "async")]
-            {
-                polars_io::pl_async::get_runtime().spawn_blocking(move || {
-                    let result = physical_plan.execute(&mut state);
-                    tx.send(result).unwrap();
-                });
-            }
-            #[cfg(not(feature = "async"))]
-            {
-                std::thread::spawn(move || {
-                    let result = physical_plan.execute(&mut state);
-                    tx.send(result).unwrap();
-                });
-            }
+            polars_io::utils::spawn_blocking(move || {
+                let result = physical_plan.execute(&mut state);
+                tx.send(result).unwrap();
+            });
         } else {
             POOL.spawn_fifo(move || {
                 let result = physical_plan.execute(&mut state);

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -631,15 +631,15 @@ impl PyLazyFrame {
         py.enter_polars_ok(|| {
             let ldf = self.ldf.read().clone();
 
-            polars_core::POOL.spawn(move || {
-                let result = ldf
-                    .collect_with_engine(engine.0)
-                    .map(PyDataFrame::new)
-                    .map_err(PyPolarsErr::from);
+            polars_io::utils::spawn_blocking(move || {
+                let result = ldf.collect_with_engine(engine.0).map_err(PyPolarsErr::from);
 
                 Python::attach(|py| match result {
                     Ok(df) => {
-                        lambda.call1(py, (df,)).map_err(|err| err.restore(py)).ok();
+                        lambda
+                            .call1(py, (PyDataFrame::new(df),))
+                            .map_err(|err| err.restore(py))
+                            .ok();
                     },
                     Err(err) => {
                         lambda

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -631,7 +631,7 @@ impl PyLazyFrame {
         py.enter_polars_ok(|| {
             let ldf = self.ldf.read().clone();
 
-            polars_io::utils::spawn_blocking(move || {
+            std::thread::spawn(move || {
                 let result = ldf.collect_with_engine(engine.0).map_err(PyPolarsErr::from);
 
                 Python::attach(|py| match result {


### PR DESCRIPTION
#### Do not merge
This is known to cause segfaults in CI. This cannot be merged before the cause is known / resolved (any help with this is welcome).

* Fixes https://github.com/pola-rs/polars/issues/24329

Cannot spawn the executor on rayon - otherwise a CachePrefiller may block the rayon thread while also running a task that depends on the rayon threadpool, leading to deadlock (ref https://github.com/pola-rs/polars/pull/22672).

<details>
<summary>SIGSEGV logs</summary>

Got SIGSEGV in some CI test runs, unsure why atm. Only seen on the benchmark task so far.

```
=================================== FAILURES ===================================
________ test_scan_parquet_in_mem_to_streaming_dispatch_deadlock_22641 _________
[gw0] linux -- Python 3.13.7 /home/runner/work/polars/polars/.venv/bin/python3
tests/unit/io/test_lazy_parquet.py:951: in test_scan_parquet_in_mem_to_streaming_dispatch_deadlock_22641
    out = subprocess.check_output(
/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/subprocess.py:472: in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/subprocess.py:577: in run
    raise CalledProcessError(retcode, process.args,
E   subprocess.CalledProcessError: Command '['/home/runner/work/polars/polars/.venv/bin/python3', '-c', 'import os\n\nos.environ["POLARS_MAX_THREADS"] = "1"\nos.environ["POLARS_VERBOSE"] = "1"\n\nimport asyncio\nimport io\nimport sys\nfrom threading import Thread\n\nimport polars as pl\n\nassert pl.thread_pool_size() == 1\n\nf = io.BytesIO()\npl.DataFrame({"x": 1}).write_parquet(f)\n\nq = (\n    pl.scan_parquet(f)\n    .filter(pl.sum_horizontal(pl.col("x"), pl.col("x"), pl.col("x")) >= 0)\n    .join(pl.scan_parquet(f), on="x", how="left")\n)\n\nresults = [\n    pl.DataFrame(),\n    pl.DataFrame(),\n    pl.DataFrame(),\n    pl.DataFrame(),\n    pl.DataFrame(),\n    pl.DataFrame(),\n]\n\n\ndef run():\n    # Also test just a single scan\n    pl.scan_parquet(f).collect()\n\n    print("QUERY-FENCE", file=sys.stderr)\n\n    results[0] = q.collect()\n\n    print("QUERY-FENCE", file=sys.stderr)\n\n    results[1] = pl.concat([q, q, q]).collect().head(1)\n\n    print("QUERY-FENCE", file=sys.stderr)\n\n    results[2] = pl.collect_all([q, q, q])[0]\n\n    print("QUERY-FENCE", file=sys.stderr)\n\n    results[3] = pl.collect_all(3 * [pl.concat(3 * [q])])[0].head(1)\n\n    print("QUERY-FENCE", file=sys.stderr)\n\n    results[4] = q.collect(background=True).fetch_blocking()\n\n    print("QUERY-FENCE", file=sys.stderr)\n\n    async def collect_async():\n        return await q.collect_async()\n\n    results[5] = asyncio.run(collect_async())\n\n\nt = Thread(target=run, daemon=True)\nt.start()\nt.join(5)\n\nassert [x.equals(pl.DataFrame({"x": 1})) for x in results] == [\n    True,\n    True,\n    True,\n    True,\n    True,\n    True,\n]\n\nprint("OK", end="", file=sys.stderr)\n']' died with <Signals.SIGSEGV: 11>.
=========================== short test summary info ============================
FAILED tests/unit/io/test_lazy_parquet.py::test_scan_parquet_in_mem_to_streaming_dispatch_deadlock_22641 - subprocess.CalledProcessError: Command '['/home/runner/work/polars/polars/.venv/bin/python3', '-c', 'import os\n\nos.environ["POLARS_MAX_THREADS"] = "1"\nos.environ["POLARS_VERBOSE"] = "1"\n\nimport asyncio\nimport io\nimport sys\nfrom threading import Thread\n\nimport polars as pl\n\nassert pl.thread_pool_size() == 1\n\nf = io.BytesIO()\npl.DataFrame({"x": 1}).write_parquet(f)\n\nq = (\n    pl.scan_parquet(f)\n    .filter(pl.sum_horizontal(pl.col("x"), pl.col("x"), pl.col("x")) >= 0)\n    .join(pl.scan_parquet(f), on="x", how="left")\n)\n\nresults = [\n    pl.DataFrame(),\n    pl.DataFrame(),\n    pl.DataFrame(),\n    pl.DataFrame(),\n    pl.DataFrame(),\n    pl.DataFrame(),\n]\n\n\ndef run():\n    # Also test just a single scan\n    pl.scan_parquet(f).collect()\n\n    print("QUERY-FENCE", file=sys.stderr)\n\n    results[0] = q.collect()\n\n    print("QUERY-FENCE", file=sys.stderr)\n\n    results[1] = pl.concat([q, q, q]).collect().head(1)\n\n    print("QUERY-FENCE", file=sys.stderr)\n\n    results[2] = pl.collect_all([q, q, q])[0]\n\n    print("QUERY-FENCE", file=sys.stderr)\n\n    results[3] = pl.collect_all(3 * [pl.concat(3 * [q])])[0].head(1)\n\n    print("QUERY-FENCE", file=sys.stderr)\n\n    results[4] = q.collect(background=True).fetch_blocking()\n\n    print("QUERY-FENCE", file=sys.stderr)\n\n    async def collect_async():\n        return await q.collect_async()\n\n    results[5] = asyncio.run(collect_async())\n\n\nt = Thread(target=run, daemon=True)\nt.start()\nt.join(5)\n\nassert [x.equals(pl.DataFrame({"x": 1})) for x in results] == [\n    True,\n    True,\n    True,\n    True,\n    True,\n    True,\n]\n\nprint("OK", end="", file=sys.stderr)\n']' died with <Signals.SIGSEGV: 11>.
============ 1 failed, 12481 passed, 6 skipped, 7 xfailed in 36.33s ============
```

<img width="1106" height="476" alt="image" src="https://github.com/user-attachments/assets/849709f7-37a9-448c-bd5c-abb0d452ffc2" />

<img width="877" height="380" alt="image" src="https://github.com/user-attachments/assets/e7cb3add-f237-489c-9932-6ef2e177381f" />


</details>
