### PR TITLE
feat: User-friendly error message on empty path expansion

### DIFF
--- a/crates/polars-plan/src/dsl/scan_sources.rs
+++ b/crates/polars-plan/src/dsl/scan_sources.rs
@@ -263,7 +263,7 @@ impl ScanSources {
 
     pub fn first_or_empty_expand_err(
         &self,
-        failed_operation_name: &'static str,
+        failed_message: &'static str,
         sources_before_expansion: &ScanSources,
         glob: bool,
         hint: &'static str,
@@ -273,15 +273,14 @@ impl ScanSources {
         self.first().ok_or_else(|| match self {
             Self::Paths(_) if !sources_before_expansion.is_empty() => polars_err!(
                 ComputeError:
-                "failed {}: at least 1 source is needed. \
-                However, path expansion resulted in no files \
+                "{}: expanded paths were empty \
                 (path expansion input: '{:?}', glob: {}).{}{}",
-                failed_operation_name, sources_before_expansion, glob, hint_padding, hint
+                failed_message, sources_before_expansion, glob, hint_padding, hint
             ),
             _ => polars_err!(
                 ComputeError:
-                "failed {}: at least 1 source is needed (input sources: {:?}).{}{}",
-                failed_operation_name, self, hint_padding, hint
+                "{}: empty input: {:?}.{}{}",
+                failed_message, self, hint_padding, hint
             ),
         })
     }

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -820,9 +820,17 @@ def test_parquet_schema_arg(
         lf.collect(engine="streaming" if streaming else "in-memory")
 
 
-def test_scan_parquet_schema_specified_with_empty_files_list(tmp_path: Path) -> None:
+def test_scan_parquet_empty_path_expansion(tmp_path: Path) -> None:
     tmp_path.mkdir(exist_ok=True)
 
+    with pytest.raises(
+        ComputeError,
+        match="failed infer_parquet_schema: at least 1 source is needed"
+        ".*Hint: passing a schema can allow this scan to succeed with an empty DataFrame",
+    ):
+        pl.scan_parquet(tmp_path).collect()
+
+    # Scan succeeds when schema is provided
     assert_frame_equal(
         pl.scan_parquet(tmp_path, schema={"x": pl.Int64}).collect(),
         pl.DataFrame(schema={"x": pl.Int64}),

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -825,7 +825,8 @@ def test_scan_parquet_empty_path_expansion(tmp_path: Path) -> None:
 
     with pytest.raises(
         ComputeError,
-        match="failed parquet_file_info: at least 1 source is needed"
+        match=r"failed to retrieve first file schema \(parquet\): "
+        r"expanded paths were empty \(path expansion input: "
         ".*Hint: passing a schema can allow this scan to succeed with an empty DataFrame",
     ):
         pl.scan_parquet(tmp_path).collect()

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -825,7 +825,7 @@ def test_scan_parquet_empty_path_expansion(tmp_path: Path) -> None:
 
     with pytest.raises(
         ComputeError,
-        match="failed infer_parquet_schema: at least 1 source is needed"
+        match="failed parquet_file_info: at least 1 source is needed"
         ".*Hint: passing a schema can allow this scan to succeed with an empty DataFrame",
     ):
         pl.scan_parquet(tmp_path).collect()

--- a/py-polars/tests/unit/io/test_scan.py
+++ b/py-polars/tests/unit/io/test_scan.py
@@ -1104,18 +1104,27 @@ def test_scan_no_glob_special_chars_23292(tmp_path: Path) -> None:
 
 @pytest.mark.write_disk
 @pytest.mark.parametrize(
-    ("scan_function", "failed_message"),
+    ("scan_function", "failed_message", "name_in_context"),
     [
-        (pl.scan_parquet, "failed to retrieve first file schema (parquet)"),
-        (pl.scan_ipc, "failed to retrieve first file schema (ipc)"),
-        (pl.scan_csv, "failed to retrieve file schemas (csv)"),
-        (pl.scan_ndjson, "failed to retrieve first file schema (ndjson)"),
+        (
+            pl.scan_parquet,
+            "failed to retrieve first file schema (parquet)",
+            "'parquet scan'",
+        ),
+        (pl.scan_ipc, "failed to retrieve first file schema (ipc)", "'ipc scan'"),
+        (pl.scan_csv, "failed to retrieve file schemas (csv)", "'csv scan'"),
+        (
+            pl.scan_ndjson,
+            "failed to retrieve first file schema (ndjson)",
+            "'ndjson scan'",
+        ),
     ],
 )
 def test_scan_empty_paths_friendly_error(
     tmp_path: Path,
     scan_function: Any,
     failed_message: str,
+    name_in_context: str,
 ) -> None:
     q = scan_function(tmp_path)
 
@@ -1131,6 +1140,13 @@ def test_scan_empty_paths_friendly_error(
 
     assert "glob: true)." in exc_str
     assert exc_str.count(tmp_path.name) == 1
+
+    assert (
+        name_in_context
+        in exc_str.split(
+            "This error occurred with the following context stack:", maxsplit=1
+        )[1]
+    )
 
     if scan_function is pl.scan_parquet:
         assert (

--- a/py-polars/tests/unit/io/test_scan.py
+++ b/py-polars/tests/unit/io/test_scan.py
@@ -1104,18 +1104,18 @@ def test_scan_no_glob_special_chars_23292(tmp_path: Path) -> None:
 
 @pytest.mark.write_disk
 @pytest.mark.parametrize(
-    ("scan_function", "expected_operation_name"),
+    ("scan_function", "failed_message"),
     [
-        (pl.scan_parquet, "infer_parquet_schema"),
-        (pl.scan_ipc, "infer_ipc_schema"),
-        (pl.scan_csv, "infer_csv_schema"),
-        (pl.scan_ndjson, "infer_ndjson_schema"),
+        (pl.scan_parquet, "failed to retrieve first file schema (parquet)"),
+        (pl.scan_ipc, "failed to retrieve first file schema (ipc)"),
+        (pl.scan_csv, "failed to retrieve file schemas (csv)"),
+        (pl.scan_ndjson, "failed to retrieve first file schema (ndjson)"),
     ],
 )
 def test_scan_empty_paths_friendly_error(
     tmp_path: Path,
     scan_function: Any,
-    expected_operation_name: str,
+    failed_message: str,
 ) -> None:
     q = scan_function(tmp_path)
 
@@ -1125,8 +1125,7 @@ def test_scan_empty_paths_friendly_error(
     exc_str = exc.exconly()
 
     assert (
-        f"ComputeError: failed {expected_operation_name}: at least 1 source is needed. "
-        "However, path expansion resulted in no files "
+        f"ComputeError: {failed_message}: expanded paths were empty "
         "(path expansion input: 'paths: [Local"
     ) in exc_str
 
@@ -1148,8 +1147,7 @@ def test_scan_empty_paths_friendly_error(
     exc_str = exc.exconly()
 
     assert (
-        f"ComputeError: failed {expected_operation_name}: at least 1 source is needed. "
-        "However, path expansion resulted in no files "
+        f"ComputeError: {failed_message}: expanded paths were empty "
         "(path expansion input: 'paths: [Local"
     ) in exc_str
 
@@ -1166,10 +1164,7 @@ def test_scan_empty_paths_friendly_error(
 
     # There is no "path expansion resulted in" for this error message as the
     # original input sources were empty.
-    assert (
-        f"ComputeError: failed {expected_operation_name}: at least 1 source is needed (input sources: paths: [])."
-        in exc_str
-    )
+    assert f"ComputeError: {failed_message}: empty input: paths: []" in exc_str
 
     if scan_function is pl.scan_parquet:
         assert (

--- a/py-polars/tests/unit/io/test_scan.py
+++ b/py-polars/tests/unit/io/test_scan.py
@@ -775,15 +775,6 @@ def test_scan_stringio(method: str) -> None:
     assert_frame_equal(df.vstack(df), result)
 
 
-@pytest.mark.parametrize(
-    "method",
-    [pl.scan_parquet, pl.scan_csv, pl.scan_ipc, pl.scan_ndjson],
-)
-def test_empty_list(method: Callable[[list[str]], pl.LazyFrame]) -> None:
-    with pytest.raises(pl.exceptions.ComputeError, match="expected at least 1 source"):
-        _ = (method)([]).collect()
-
-
 def test_scan_double_collect_row_index_invalidates_cached_ir_18892() -> None:
     lf = pl.scan_csv(io.BytesIO(b"a\n1\n2\n3"))
 


### PR DESCRIPTION
* Supercedes https://github.com/pola-rs/polars/pull/24322

```python
pl.scan_parquet("*non_existent*").collect()
### Before
ComputeError: expected at least 1 source
### After
ComputeError: failed to retrieve first file schema (parquet):
expanded paths were empty (path expansion input: 'paths: [Local("*non_existent*")]', glob: true).
Hint: passing a schema can allow this scan to succeed with an empty DataFrame.

pl.scan_parquet([]).collect()
### Before
ComputeError: expected at least 1 source
### After
ComputeError: failed to retrieve first file schema (parquet): empty input: paths: [].
Hint: passing a schema can allow this scan to succeed with an empty DataFrame.

```

Note, scanning empty list with a specified schema is only supported / (the hint printed) for parquet.
