### PR TITLE
fix: Fix cloud iceberg scan DATASET_PROVIDER_VTABLE error

### DIFF
--- a/crates/polars-plan/src/dsl/file_scan/mod.rs
+++ b/crates/polars-plan/src/dsl/file_scan/mod.rs
@@ -94,7 +94,6 @@ pub enum FileScanIR {
     #[cfg(feature = "python")]
     PythonDataset {
         dataset_object: Arc<python_dataset::PythonDatasetProvider>,
-        #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(skip, default))]
         cached_ir: Arc<Mutex<Option<ExpandedDataset>>>,
     },
 

--- a/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
+++ b/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
@@ -219,6 +219,8 @@ impl OptimizationRule for ExpandDatasets {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct ExpandedDataset {
     version: PlSmallStr,
     limit: Option<usize>,
@@ -231,6 +233,8 @@ pub struct ExpandedDataset {
 }
 
 #[cfg(feature = "python")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone)]
 pub struct ExpandedPythonScan {
     pub name: PlSmallStr,

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -418,14 +418,6 @@ impl PyLazyFrame {
         dataset_object
     ))]
     fn new_from_dataset_object(dataset_object: PyObject) -> PyResult<Self> {
-        use crate::dataset::dataset_provider_funcs;
-
-        polars_plan::dsl::DATASET_PROVIDER_VTABLE.get_or_init(|| PythonDatasetProviderVTable {
-            name: dataset_provider_funcs::name,
-            schema: dataset_provider_funcs::schema,
-            to_dataset_scan: dataset_provider_funcs::to_dataset_scan,
-        });
-
         let lf =
             LazyFrame::from(DslBuilder::scan_python_dataset(PythonObject(dataset_object)).build())
                 .into();

--- a/crates/polars-python/src/on_startup.rs
+++ b/crates/polars-python/src/on_startup.rs
@@ -201,6 +201,15 @@ pub unsafe fn register_startup_deps(catch_keyboard_interrupt: bool) {
             pyobject_converter,
             physical_dtype,
         );
+
+        use crate::dataset::dataset_provider_funcs;
+
+        polars_plan::dsl::DATASET_PROVIDER_VTABLE.get_or_init(|| PythonDatasetProviderVTable {
+            name: dataset_provider_funcs::name,
+            schema: dataset_provider_funcs::schema,
+            to_dataset_scan: dataset_provider_funcs::to_dataset_scan,
+        });
+
         // Register SERIES UDF.
         python_dsl::CALL_COLUMNS_UDF_PYTHON = Some(python_function_caller_series);
         // Register DATAFRAME UDF.


### PR DESCRIPTION
Fixes `ComputeError: DATASET_PROVIDER_VTABLE (python) not initialized`

Note: This issue is only present when using polars cloud
