### PR TITLE
feat(python): Add PyCapsule `__arrow_c_schema__` interface to `pl.Schema`

### DIFF
--- a/crates/polars-arrow/src/ffi/generated.rs
+++ b/crates/polars-arrow/src/ffi/generated.rs
@@ -15,6 +15,8 @@ pub struct ArrowSchema {
     pub(super) private_data: *mut ::std::os::raw::c_void,
 }
 
+unsafe impl Send for ArrowSchema {}
+
 /// ABI-compatible struct for [`ArrowArray`](https://arrow.apache.org/docs/format/CDataInterface.html#structure-definitions)
 #[repr(C)]
 #[derive(Debug)]

--- a/crates/polars-python/src/c_api/mod.rs
+++ b/crates/polars-python/src/c_api/mod.rs
@@ -237,6 +237,10 @@ pub fn polars(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
         crate::interop::arrow::polars_schema_field_from_arrow_c_schema
     ))
     .unwrap();
+    m.add_wrapped(wrap_pyfunction!(
+        crate::interop::arrow::to_py::polars_schema_to_pycapsule
+    ))
+    .unwrap();
 
     // Functions: other
     m.add_wrapped(wrap_pyfunction!(functions::check_length))

--- a/crates/polars-python/src/interop/arrow/to_py.rs
+++ b/crates/polars-python/src/interop/arrow/to_py.rs
@@ -90,6 +90,7 @@ pub(crate) fn dataframe_to_stream<'py>(
     PyCapsule::new(py, stream, Some(stream_capsule_name))
 }
 
+#[cfg(feature = "c_api")]
 #[pyfunction]
 pub(crate) fn polars_schema_to_pycapsule<'py>(
     py: Python<'py>,

--- a/crates/polars-python/src/interop/arrow/to_py.rs
+++ b/crates/polars-python/src/interop/arrow/to_py.rs
@@ -5,15 +5,13 @@ use arrow::ffi;
 use arrow::record_batch::RecordBatch;
 use polars::datatypes::CompatLevel;
 use polars::frame::DataFrame;
-use polars::prelude::{ArrayRef, ArrowField, PlSmallStr, Schema, SchemaExt};
+use polars::prelude::{ArrayRef, ArrowField, PlSmallStr, SchemaExt};
 use polars::series::Series;
 use polars_core::utils::arrow;
 use polars_error::PolarsResult;
 use pyo3::ffi::Py_uintptr_t;
 use pyo3::prelude::*;
 use pyo3::types::PyCapsule;
-
-use crate::prelude::Wrap;
 
 /// Arrow array to Python.
 pub(crate) fn to_py_array(
@@ -94,7 +92,7 @@ pub(crate) fn dataframe_to_stream<'py>(
 #[pyfunction]
 pub(crate) fn polars_schema_to_pycapsule<'py>(
     py: Python<'py>,
-    schema: Wrap<Schema>,
+    schema: crate::prelude::Wrap<polars::prelude::Schema>,
 ) -> PyResult<Bound<'py, PyCapsule>> {
     let schema: arrow::ffi::ArrowSchema = arrow::ffi::export_field_to_c(&ArrowField::new(
         PlSmallStr::EMPTY,

--- a/crates/polars-python/src/interop/arrow/to_py.rs
+++ b/crates/polars-python/src/interop/arrow/to_py.rs
@@ -93,6 +93,7 @@ pub(crate) fn dataframe_to_stream<'py>(
 pub(crate) fn polars_schema_to_pycapsule<'py>(
     py: Python<'py>,
     schema: crate::prelude::Wrap<polars::prelude::Schema>,
+    compat_level: crate::prelude::PyCompatLevel,
 ) -> PyResult<Bound<'py, PyCapsule>> {
     let schema: arrow::ffi::ArrowSchema = arrow::ffi::export_field_to_c(&ArrowField::new(
         PlSmallStr::EMPTY,
@@ -100,7 +101,7 @@ pub(crate) fn polars_schema_to_pycapsule<'py>(
             schema
                 .0
                 .iter_fields()
-                .map(|x| x.to_arrow(CompatLevel::newest()))
+                .map(|x| x.to_arrow(compat_level.0))
                 .collect(),
         ),
         false,

--- a/py-polars/polars/io/iceberg/functions.py
+++ b/py-polars/polars/io/iceberg/functions.py
@@ -39,7 +39,9 @@ def scan_iceberg(
     reader_override
         Overrides the reader used to read the data.
 
-        Warning: This parameter is considered unstable, and is subject to change.
+        .. warning::
+            This functionality is considered **unstable**. It may be changed
+            at any point without it being considered a breaking change.
 
         Note that this parameter should not be necessary outside of testing, as
         polars will by default automatically select the best reader.

--- a/py-polars/polars/schema.py
+++ b/py-polars/polars/schema.py
@@ -69,7 +69,8 @@ class Schema(BaseSchema):
     schema
         The schema definition given by column names and their associated
         Polars data type. Accepts a mapping, or an iterable of tuples, or any
-        object implementing `__arrow_c_schema__` (e.g. pyarrow schemas).
+        object implementing the  `__arrow_c_schema__` PyCapsule interface
+        (e.g. pyarrow schemas).
 
     Examples
     --------

--- a/py-polars/polars/schema.py
+++ b/py-polars/polars/schema.py
@@ -7,10 +7,8 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Union, overload
 
 from polars._typing import PythonDataType
-from polars._utils.unstable import unstable
 from polars.datatypes import DataType, DataTypeClass, is_polars_dtype
 from polars.datatypes._parse import parse_into_dtype
-from polars.dependencies import _PYARROW_AVAILABLE
 from polars.exceptions import DuplicateError
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
@@ -22,8 +20,6 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-
-    import pyarrow as pa
 
     from polars import DataFrame, LazyFrame
     from polars._typing import ArrowSchemaExportable

--- a/py-polars/polars/schema.py
+++ b/py-polars/polars/schema.py
@@ -11,6 +11,7 @@ from polars._utils.unstable import unstable
 from polars.datatypes import DataType, DataTypeClass, is_polars_dtype
 from polars.datatypes._parse import parse_into_dtype
 from polars.exceptions import DuplicateError
+from polars.interchange.protocol import CompatLevel
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import (
@@ -256,4 +257,9 @@ class Schema(BaseSchema):
 
     @unstable()
     def __arrow_c_schema__(self) -> object:
-        return polars_schema_to_pycapsule(self)
+        """
+        Export a Schema via the Arrow PyCapsule Interface.
+
+        https://arrow.apache.org/docs/dev/format/CDataInterface/PyCapsuleInterface.html
+        """
+        return polars_schema_to_pycapsule(self, CompatLevel.newest())

--- a/py-polars/polars/schema.py
+++ b/py-polars/polars/schema.py
@@ -262,4 +262,4 @@ class Schema(BaseSchema):
 
         https://arrow.apache.org/docs/dev/format/CDataInterface/PyCapsuleInterface.html
         """
-        return polars_schema_to_pycapsule(self, CompatLevel.newest())
+        return polars_schema_to_pycapsule(self, CompatLevel.newest()._version)

--- a/py-polars/polars/schema.py
+++ b/py-polars/polars/schema.py
@@ -101,6 +101,7 @@ class Schema(BaseSchema):
 
     Import a pyarrow schema.
 
+    >>> import pyarrow as pa
     >>> pl.Schema(pa.schema([pa.field("x", pa.int32())]))
     Schema({'x': Int32})
 

--- a/py-polars/polars/schema.py
+++ b/py-polars/polars/schema.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, Union, overload
 
 from polars._typing import PythonDataType
+from polars._utils.unstable import unstable
 from polars.datatypes import DataType, DataTypeClass, is_polars_dtype
 from polars.datatypes._parse import parse_into_dtype
 from polars.exceptions import DuplicateError
@@ -251,5 +252,6 @@ class Schema(BaseSchema):
         """
         return {name: tp.to_python() for name, tp in self.items()}
 
+    @unstable()
     def __arrow_c_schema__(self) -> object:
         return polars_schema_to_pycapsule(self)

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -1053,6 +1053,11 @@ def test_schema_constructor_from_schema_capsule() -> None:
         "test": pl.List(pl.Struct({"key": pl.Int32, "value": pl.Datetime("ms")}))
     }
 
+    # Test __arrow_c_schema__ implementation on `pl.Schema`
+    assert pa.schema(pl.Schema({"x": pl.Int32})) == pa.schema(
+        [pa.field("x", pa.int32())]
+    )
+
     arrow_schema = pa.schema([pa.field("a", pa.int32()), pa.field("a", pa.int32())])
 
     with pytest.raises(


### PR DESCRIPTION
* ref https://github.com/pola-rs/polars/issues/15563

This will allow e.g. -
```python
>>> pa.schema(pl.Schema({"x": pl.Int32}))
x: int32
```

Compared to doing:
```python
>>> pl.DataFrame(schema=pl.Schema({"x": pl.Int32})).to_arrow().schema
x: int32
```
