### PR TITLE
fix: Enable all integer dtypes for `by` parameter in `join_asof`

### DIFF
--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -276,6 +276,16 @@ where
 
                 use BitRepr as B;
                 match (left_by, right_by) {
+                    (B::U8(left_by), B::U8(right_by)) => {
+                        asof_join_by_numeric::<T, UInt8Type, A, F>(
+                            &left_by, &right_by, left_asof, right_asof, filter, allow_eq,
+                        )?
+                    },
+                    (B::U16(left_by), B::U16(right_by)) => {
+                        asof_join_by_numeric::<T, UInt16Type, A, F>(
+                            &left_by, &right_by, left_asof, right_asof, filter, allow_eq,
+                        )?
+                    },
                     (B::U32(left_by), B::U32(right_by)) => {
                         asof_join_by_numeric::<T, UInt32Type, A, F>(
                             &left_by, &right_by, left_asof, right_asof, filter, allow_eq,

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -8,7 +8,6 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.datatypes.group import INTEGER_DTYPES
 from polars.exceptions import DuplicateError, InvalidOperationError
 from polars.testing import assert_frame_equal
 
@@ -1434,7 +1433,10 @@ def test_join_asof_planner_schema_24000() -> None:
     assert q.collect().schema == q.collect_schema()
 
 
-@pytest.mark.parametrize("dtype", list(INTEGER_DTYPES))
+@pytest.mark.parametrize(
+    "dtype",
+    [pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64, pl.Int8, pl.Int16, pl.Int32, pl.Int64],
+)
 def test_join_asof_int_dtypes_24383(dtype: PolarsIntegerType) -> None:
     lf1 = pl.LazyFrame(
         {

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.datatypes.group import INTEGER_DTYPES
 from polars.exceptions import DuplicateError, InvalidOperationError
 from polars.testing import assert_frame_equal
 
@@ -1431,3 +1432,37 @@ def test_join_asof_planner_schema_24000() -> None:
     q = a.lazy().join_asof(b.lazy(), left_on="index", right_on="index_right")
 
     assert q.collect().schema == q.collect_schema()
+
+
+@pytest.mark.parametrize("dtype", INTEGER_DTYPES)
+def test_join_asof_int_dtypes_24383(dtype: PolarsIntegerType) -> None:
+    lf1 = pl.LazyFrame(
+        {
+            "id": pl.Series([1], dtype=dtype),
+            "date": pl.Series([date(2025, 12, 31)], dtype=pl.Date),
+        }
+    )
+
+    lf2 = pl.LazyFrame(
+        {
+            "id": pl.Series([1], dtype=dtype),
+            "date": pl.Series([date(2025, 12, 31)], dtype=pl.Date),
+            "value": pl.Series([2.5], dtype=pl.Float32),
+        }
+    )
+
+    result = lf1.join_asof(
+        other=lf2,
+        on="date",
+        by="id",
+        check_sortedness=False,
+    )
+    expected = pl.DataFrame(
+        {
+            "id": pl.Series([1], dtype=dtype),
+            "date": pl.Series([date(2025, 12, 31)], dtype=pl.Date),
+            "value": pl.Series([2.5], dtype=pl.Float32),
+        }
+    )
+    assert result.collect_schema() == expected.schema
+    assert_frame_equal(result.collect(), expected)

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -1434,7 +1434,7 @@ def test_join_asof_planner_schema_24000() -> None:
     assert q.collect().schema == q.collect_schema()
 
 
-@pytest.mark.parametrize("dtype", INTEGER_DTYPES)
+@pytest.mark.parametrize("dtype", list(INTEGER_DTYPES))
 def test_join_asof_int_dtypes_24383(dtype: PolarsIntegerType) -> None:
     lf1 = pl.LazyFrame(
         {


### PR DESCRIPTION
Closes #24383

Fixed issue:

```python
from datetime import date
import polars as pl

lf1 = pl.LazyFrame(
    data={"id": [1], "date": [date(2025, 12, 31)]},
    schema={"id": pl.Int16, "date": pl.Date},
).sort("id", "date")

lf2 = pl.LazyFrame(
    data={"id": [1], "date": [date(2025, 12, 31)], "value": [2.5]},
    schema={"id": pl.Int16, "date": pl.Date, "value": pl.Float32},
).sort("id", "date")

lf1.join_asof(
    other=lf2,
    on="date",
    by="id",
    check_sortedness=False,
).collect()
# shape: (1, 3)
# ┌─────┬────────────┬───────┐
# │ id  ┆ date       ┆ value │
# │ --- ┆ ---        ┆ ---   │
# │ i16 ┆ date       ┆ f32   │
# ╞═════╪════════════╪═══════╡
# │ 1   ┆ 2025-12-31 ┆ 2.5   │
# └─────┴────────────┴───────┘
```