### PR TITLE
perf: Use specialized decoding for all predicates for Parquet dictionary encoding

### DIFF
--- a/crates/polars-parquet/src/arrow/read/deserialize/binview/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binview/mod.rs
@@ -496,7 +496,7 @@ impl utils::Decoder for BinViewDecoder {
     fn evaluate_predicate(
         &mut self,
         state: &utils::State<'_, Self>,
-        predicate: &SpecializedParquetColumnExpr,
+        predicate: Option<&SpecializedParquetColumnExpr>,
         pred_true_mask: &mut BitmapBuilder,
         dict_mask: Option<&Bitmap>,
     ) -> ParquetResult<bool> {
@@ -514,6 +514,10 @@ impl utils::Decoder for BinViewDecoder {
             )?;
             return Ok(true);
         }
+
+        let Some(predicate) = predicate else {
+            return Ok(false);
+        };
 
         use {SpecializedParquetColumnExpr as Spce, StateTranslation as St};
         match (&state.translation, predicate) {

--- a/crates/polars-parquet/src/arrow/read/deserialize/boolean.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/boolean.rs
@@ -330,7 +330,7 @@ impl Decoder for BooleanDecoder {
     fn evaluate_predicate(
         &mut self,
         _state: &utils::State<'_, Self>,
-        _predicate: &SpecializedParquetColumnExpr,
+        _predicate: Option<&SpecializedParquetColumnExpr>,
         _pred_true_mask: &mut BitmapBuilder,
         _dict_mask: Option<&Bitmap>,
     ) -> ParquetResult<bool> {

--- a/crates/polars-parquet/src/arrow/read/deserialize/categorical.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/categorical.rs
@@ -79,7 +79,7 @@ impl<T: DictionaryKey + IndexMapping<Output = T::AlignedBytes>> utils::Decoder
     fn evaluate_predicate(
         &mut self,
         state: &utils::State<'_, Self>,
-        _predicate: &SpecializedParquetColumnExpr,
+        _predicate: Option<&SpecializedParquetColumnExpr>,
         pred_true_mask: &mut BitmapBuilder,
         dict_mask: Option<&Bitmap>,
     ) -> ParquetResult<bool> {

--- a/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary.rs
@@ -548,7 +548,7 @@ impl Decoder for BinaryDecoder {
     fn evaluate_predicate(
         &mut self,
         _state: &utils::State<'_, Self>,
-        _predicate: &SpecializedParquetColumnExpr,
+        _predicate: Option<&SpecializedParquetColumnExpr>,
         _pred_true_mask: &mut BitmapBuilder,
         _dict_mask: Option<&Bitmap>,
     ) -> ParquetResult<bool> {

--- a/crates/polars-parquet/src/arrow/read/deserialize/null.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/null.rs
@@ -73,7 +73,7 @@ impl utils::Decoder for NullDecoder {
     fn evaluate_predicate(
         &mut self,
         _state: &utils::State<'_, Self>,
-        _predicate: &SpecializedParquetColumnExpr,
+        _predicate: Option<&SpecializedParquetColumnExpr>,
         _pred_true_mask: &mut BitmapBuilder,
         _dict_mask: Option<&Bitmap>,
     ) -> ParquetResult<bool> {

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/float.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/float.rs
@@ -164,7 +164,7 @@ where
     fn evaluate_predicate(
         &mut self,
         state: &utils::State<'_, Self>,
-        _predicate: &SpecializedParquetColumnExpr,
+        _predicate: Option<&SpecializedParquetColumnExpr>,
         pred_true_mask: &mut BitmapBuilder,
         dict_mask: Option<&Bitmap>,
     ) -> ParquetResult<bool> {

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/integer.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/integer.rs
@@ -197,6 +197,11 @@ where
         pred_true_mask: &mut BitmapBuilder,
         dict_mask: Option<&Bitmap>,
     ) -> ParquetResult<bool> {
+        // @Performance: This should be added
+        if state.page_validity.is_some() {
+            return Ok(false);
+        }
+
         if let StateTranslation::Dictionary(values) = &state.translation {
             let dict_mask = dict_mask.unwrap();
             super::super::dictionary_encoded::predicate::decode(
@@ -208,11 +213,6 @@ where
         }
 
         if !D::CAN_TRANSMUTE || D::NEED_TO_DECODE {
-            return Ok(false);
-        }
-
-        // @Performance: This should be added
-        if state.page_validity.is_some() {
             return Ok(false);
         }
 

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/integer.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/integer.rs
@@ -193,7 +193,7 @@ where
     fn evaluate_predicate(
         &mut self,
         state: &utils::State<'_, Self>,
-        predicate: &SpecializedParquetColumnExpr,
+        predicate: Option<&SpecializedParquetColumnExpr>,
         pred_true_mask: &mut BitmapBuilder,
         dict_mask: Option<&Bitmap>,
     ) -> ParquetResult<bool> {
@@ -215,6 +215,10 @@ where
         if state.page_validity.is_some() {
             return Ok(false);
         }
+
+        let Some(predicate) = predicate else {
+            return Ok(false);
+        };
 
         use SpecializedParquetColumnExpr as S;
         match (&state.translation, predicate) {


### PR DESCRIPTION
Fixes a small regression in Q16 caused by #24401.