### PR TITLE
feat: Support `unique` / `n_unique` / `arg_unique` for `array` columns

### DIFF
--- a/crates/polars-core/src/series/implementations/array.rs
+++ b/crates/polars-core/src/series/implementations/array.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 use self::compare_inner::{TotalEqInner, TotalOrdInner};
 use self::sort::arg_sort_row_fmt;
 use super::{IsSorted, StatisticsFlags, private};
+use crate::POOL;
 use crate::chunked_array::AsSinglePtr;
 use crate::chunked_array::cast::CastOptions;
 use crate::chunked_array::comparison::*;
@@ -221,6 +222,52 @@ impl SeriesTrait for SeriesWrap<ArrayChunked> {
 
     fn has_nulls(&self) -> bool {
         self.0.has_nulls()
+    }
+
+    #[cfg(feature = "algorithm_group_by")]
+    fn unique(&self) -> PolarsResult<Series> {
+        if !self.inner_dtype().is_primitive_numeric() {
+            polars_bail!(opq = unique, self.dtype());
+        }
+        // this can be called in aggregation, so this fast path can be worth a lot
+        if self.len() < 2 {
+            return Ok(self.0.clone().into_series());
+        }
+        let main_thread = POOL.current_thread_index().is_none();
+        let groups = self.group_tuples(main_thread, false);
+        // SAFETY:
+        // groups are in bounds
+        Ok(unsafe { self.0.clone().into_series().agg_first(&groups?) })
+    }
+
+    #[cfg(feature = "algorithm_group_by")]
+    fn n_unique(&self) -> PolarsResult<usize> {
+        // this can be called in aggregation, so this fast path can be worth a lot
+        match self.len() {
+            0 => Ok(0),
+            1 => Ok(1),
+            _ => {
+                let main_thread = POOL.current_thread_index().is_none();
+                let groups = self.group_tuples(main_thread, false)?;
+                Ok(groups.len())
+            },
+        }
+    }
+
+    #[cfg(feature = "algorithm_group_by")]
+    fn arg_unique(&self) -> PolarsResult<IdxCa> {
+        if !self.inner_dtype().is_primitive_numeric() {
+            polars_bail!(opq = arg_unique, self.dtype());
+        }
+        // this can be called in aggregation, so this fast path can be worth a lot
+        if self.len() == 1 {
+            return Ok(IdxCa::new_vec(self.name().clone(), vec![0 as IdxSize]));
+        }
+        let main_thread = POOL.current_thread_index().is_none();
+        // arg_unique requires a stable order
+        let groups = self.group_tuples(main_thread, true)?;
+        let first = groups.take_group_firsts();
+        Ok(IdxCa::from_vec(self.name().clone(), first))
     }
 
     fn is_null(&self) -> BooleanChunked {

--- a/py-polars/tests/unit/operations/unique/test_n_unique.py
+++ b/py-polars/tests/unit/operations/unique/test_n_unique.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numpy as np
 import pytest
 
 import polars as pl
@@ -60,3 +61,19 @@ def test_n_unique_list_of_struct_20341() -> None:
     )
     assert df.select("a").n_unique() == 2
     assert df["a"].n_unique() == 2
+
+
+def test_n_unique_array() -> None:
+    df = pl.DataFrame(
+        {
+            "arr": [
+                np.array([1, 2]),
+                np.array([2, 3]),
+                np.array([3, 4]),
+                np.array([3, 4]),
+            ],
+        }
+    )
+    assert df["arr"].dtype == pl.Array
+    assert df.select(pl.col("arr")).n_unique() == 3
+    assert df.select(pl.col("arr").n_unique()).item() == 3

--- a/py-polars/tests/unit/operations/unique/test_unique.py
+++ b/py-polars/tests/unit/operations/unique/test_unique.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import date
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
 import pytest
 
 import polars as pl
@@ -64,6 +65,23 @@ def test_unique_on_list_df() -> None:
 def test_list_unique() -> None:
     s = pl.Series("a", [[1, 2], [3], [1, 2], [4, 5], [2], [2]])
     assert s.unique(maintain_order=True).to_list() == [[1, 2], [3], [4, 5], [2]]
+    assert s.arg_unique().to_list() == [0, 1, 3, 4]
+    assert s.n_unique() == 4
+
+
+def test_array_unique() -> None:
+    s = pl.Series(
+        "a",
+        [
+            np.array([1, 2]),
+            np.array([3, 1]),
+            np.array([1, 2]),
+            np.array([4, 5]),
+            np.array([2, 2]),
+            np.array([2, 2]),
+        ],
+    )
+    assert s.unique(maintain_order=True).to_list() == [[1, 2], [3, 1], [4, 5], [2, 2]]
     assert s.arg_unique().to_list() == [0, 1, 3, 4]
     assert s.n_unique() == 4
 


### PR DESCRIPTION
Resolves #24389 

Basically mirror implementation of `*_unique` for `list` columns to `array`, with unit test.