### PR TITLE
fix: Fix incorrect output on `with_columns(sort()).unique(maintain_order=True)`

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/set_order.rs
+++ b/crates/polars-plan/src/plans/optimizer/set_order.rs
@@ -73,6 +73,7 @@ impl PortOrder {
 fn simplify_edge(tx: bool, rx: InputOrder) -> (bool, InputOrder) {
     use InputOrder as I;
     match (tx, rx) {
+        (o, I::Observing) => (o, I::Observing),
         (false, _) | (_, I::Unordered) => (false, I::Unordered),
         (o, i) => (o, i),
     }


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/24386
