### PR TITLE
feat: Add user guide section on AWS role assumption

### DIFF
--- a/docs/source/polars-cloud/providers/aws/permissions.md
+++ b/docs/source/polars-cloud/providers/aws/permissions.md
@@ -15,10 +15,14 @@ Here you can adjust the permissions of the workspace for instance:
 - [Narrow down the S3 access to certain buckets](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_s3_deny-except-bucket.html)
 - [Provide IAM access to rds database](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.IAMPolicy.html)
 
-
 ## Assuming a different role
 
-To use a different IAM role with Polars Cloud beyond the default `polars-<WORKSPACE_NAME>-IAMWorkerRole-<slug>`, you need to configure cross-account role assumption. Set up your target role's trust policy to allow the Polars Cloud role to assume it by following the [AWS cross-account role documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies-cross-account-resource-access.html#access_policies-cross-account-using-roles). After configuring the trust relationship, specify the role ARN in the storage_options parameter when reading or writing data to have Polars assume that role for the operation.
+To use a different IAM role with Polars Cloud beyond the default
+`polars-<WORKSPACE_NAME>-IAMWorkerRole-<slug>`, you need to configure cross-account role assumption.
+Set up your target role's trust policy to allow the Polars Cloud role to assume it by following the
+[AWS cross-account role documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies-cross-account-resource-access.html#access_policies-cross-account-using-roles).
+After configuring the trust relationship, specify the role ARN in the storage_options parameter when
+reading or writing data to have Polars assume that role for the operation.
 
 ```python
 import polars_cloud as pc

--- a/docs/source/polars-cloud/providers/aws/permissions.md
+++ b/docs/source/polars-cloud/providers/aws/permissions.md
@@ -14,3 +14,24 @@ Here you can adjust the permissions of the workspace for instance:
 
 - [Narrow down the S3 access to certain buckets](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_s3_deny-except-bucket.html)
 - [Provide IAM access to rds database](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.IAMPolicy.html)
+
+
+## Assuming a different role
+
+To use a different IAM role with Polars Cloud beyond the default `polars-<WORKSPACE_NAME>-IAMWorkerRole-<slug>`, you need to configure cross-account role assumption. Set up your target role's trust policy to allow the Polars Cloud role to assume it by following the [AWS cross-account role documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies-cross-account-resource-access.html#access_policies-cross-account-using-roles). After configuring the trust relationship, specify the role ARN in the storage_options parameter when reading or writing data to have Polars assume that role for the operation.
+
+```python
+import polars_cloud as pc
+import polars as pl
+
+ctx = pc.ComputeContext(cpus=1, memory=1)
+lf = pl.scan_parquet(
+    "s3://your-bucket/foo.parquet",
+    credential_provider=pl.CredentialProviderAWS(
+        assume_role={
+            "RoleArn": "<INSERT-DESIRED-ARN-HERE>"
+            "RoleSessionName": "AssumedRole"
+        },
+    ),
+)
+```


### PR DESCRIPTION
This PR adds a section on the Polars Cloud user guide which explains how to assume a different role (See https://github.com/pola-rs/polars-cloud-client/issues/3)