### PR TITLE
fix(rust): Emit proper tuple for Log in expression nodes

### DIFF
--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -1260,7 +1260,7 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                 IRFunctionExpr::Entropy { base, normalize } => {
                     ("entropy", base, normalize).into_py_any(py)
                 },
-                IRFunctionExpr::Log => ("log").into_py_any(py),
+                IRFunctionExpr::Log => ("log",).into_py_any(py),
                 IRFunctionExpr::Log1p => ("log1p",).into_py_any(py),
                 IRFunctionExpr::Exp => ("exp",).into_py_any(py),
                 IRFunctionExpr::Unique(maintain_order) => {


### PR DESCRIPTION
Fix a small oversight in #24226 