### PR TITLE
fix: Fix planner schema for dividing `pl.Float32` by int

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -762,6 +762,7 @@ fn get_truediv_dtype(left_dtype: &DataType, right_dtype: &DataType) -> PolarsRes
         (Float32, UInt8 | Int8) => Float32,
         #[cfg(feature = "dtype-u16")]
         (Float32, UInt16 | Int16) => Float32,
+        (Float32, Unknown(UnknownKind::Int(_))) => Float32,
         (Float32, other) if other.is_integer() => Float64,
         (Float32, Float64) => Float64,
         (Float32, _) => Float32,


### PR DESCRIPTION
fixes #24375

Scope: add the default `Unknown(Int)` path to the planner schema and update the test matrix. This extends the scope from  https://github.com/pola-rs/polars/pull/23941.

Note, the case of cast to `pl.Unknown` (pseudocode: `Unknown(Any)`) is deferred as the engine behavior shows a minor inconsistency (see https://github.com/pola-rs/polars/issues/24431).

