### PR TITLE
feat(python): Add unstable `pl.Config.set_default_credential_provider`

### DIFF
--- a/docs/source/src/python/user-guide/io/cloud-storage.py
+++ b/docs/source/src/python/user-guide/io/cloud-storage.py
@@ -33,7 +33,7 @@ df = pl.scan_parquet(source, storage_options=storage_options).collect()
 lf = pl.scan_parquet(
     "s3://.../...",
     credential_provider=pl.CredentialProviderAWS(
-        profile_name="..."
+        profile_name="...",
         assume_role={
             "RoleArn": f"...",
             "RoleSessionName": "...",
@@ -43,6 +43,18 @@ lf = pl.scan_parquet(
 
 df = lf.collect()
 # --8<-- [end:credential_provider_class]
+
+# --8<-- [start:credential_provider_class_global_default]
+pl.Config.set_credential_provider(
+    pl.CredentialProviderAWS(
+        profile_name="...",
+        assume_role={
+            "RoleArn": f"...",
+            "RoleSessionName": "...",
+        },
+    )
+)
+# --8<-- [end:credential_provider_class_global_default]
 
 # --8<-- [start:credential_provider_custom_func]
 def get_credentials() -> pl.CredentialProviderFunctionReturn:

--- a/docs/source/src/python/user-guide/io/cloud-storage.py
+++ b/docs/source/src/python/user-guide/io/cloud-storage.py
@@ -45,7 +45,7 @@ df = lf.collect()
 # --8<-- [end:credential_provider_class]
 
 # --8<-- [start:credential_provider_class_global_default]
-pl.Config.set_credential_provider(
+pl.Config.set_default_credential_provider(
     pl.CredentialProviderAWS(
         profile_name="...",
         assume_role={

--- a/docs/source/src/rust/user-guide/io/cloud-storage.rs
+++ b/docs/source/src/rust/user-guide/io/cloud-storage.rs
@@ -36,6 +36,9 @@ async fn main() {
 // --8<-- [start:credential_provider_class]
 // --8<-- [end:credential_provider_class]
 
+// --8<-- [start:credential_provider_class_global_default]
+// --8<-- [end:credential_provider_class_global_default]
+
 // --8<-- [start:credential_provider_custom_func]
 // --8<-- [end:credential_provider_custom_func]
 

--- a/docs/source/user-guide/io/cloud-storage.md
+++ b/docs/source/user-guide/io/cloud-storage.md
@@ -68,9 +68,9 @@ use for authentication. This can be done in a few ways:
 
 ### Set a default credential provider to use
 
-- In the case where there are many cloud I/O operations that use the same credential provider, it is
-  possible to globally configure this as the default credential provider, so that it does not need
-  to be passed on every call:
+- It is possible to globally configure a default credential provider, so that it does not need to
+  be passed to every I/O function call. This can be convenient in the case where there are many
+  cloud I/O operations that use the same credential provider.
 
 {{code_block('user-guide/io/cloud-storage','credential_provider_class_global_default',['scan_parquet',
 'CredentialProviderAWS'])}}

--- a/docs/source/user-guide/io/cloud-storage.md
+++ b/docs/source/user-guide/io/cloud-storage.md
@@ -66,6 +66,15 @@ use for authentication. This can be done in a few ways:
 {{code_block('user-guide/io/cloud-storage','credential_provider_custom_func_azure',['scan_parquet',
 'CredentialProviderAzure'])}}
 
+### Set a default credential provider to use
+
+- In the case where there are many cloud I/O operations that use the same credential provider, it is
+  possible to globally configure this as the default credential provider, so that it does not need
+  to be passed on every call:
+
+{{code_block('user-guide/io/cloud-storage','credential_provider_class_global_default',['scan_parquet',
+'CredentialProviderAWS'])}}
+
 ## Scanning with PyArrow
 
 We can also scan from cloud storage using PyArrow. This is particularly useful for partitioned

--- a/docs/source/user-guide/io/cloud-storage.md
+++ b/docs/source/user-guide/io/cloud-storage.md
@@ -68,9 +68,9 @@ use for authentication. This can be done in a few ways:
 
 ### Set a default credential provider to use
 
-- It is possible to globally configure a default credential provider, so that it does not need to
-  be passed to every I/O function call. This can be convenient in the case where there are many
-  cloud I/O operations that use the same credential provider.
+- It is possible to globally configure a default credential provider, so that it does not need to be
+  passed to every I/O function call. This can be convenient in the case where there are many cloud
+  I/O operations that use the same credential provider.
 
 {{code_block('user-guide/io/cloud-storage','credential_provider_class_global_default',['scan_parquet',
 'CredentialProviderAWS'])}}

--- a/py-polars/docs/source/reference/config.rst
+++ b/py-polars/docs/source/reference/config.rst
@@ -11,8 +11,8 @@ Config options
 
     Config.set_ascii_tables
     Config.set_auto_structify
-    Config.set_credential_provider
     Config.set_decimal_separator
+    Config.set_default_credential_provider
     Config.set_engine_affinity
     Config.set_float_precision
     Config.set_fmt_float

--- a/py-polars/docs/source/reference/config.rst
+++ b/py-polars/docs/source/reference/config.rst
@@ -11,6 +11,7 @@ Config options
 
     Config.set_ascii_tables
     Config.set_auto_structify
+    Config.set_credential_provider
     Config.set_decimal_separator
     Config.set_engine_affinity
     Config.set_float_precision

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -1527,7 +1527,7 @@ class Config(contextlib.ContextDecorator):
 
     @classmethod
     @unstable()
-    def set_credential_provider(
+    def set_default_credential_provider(
         cls, credential_provider: CredentialProviderFunction | Literal["auto"] | None
     ) -> type[Config]:
         """
@@ -1552,7 +1552,7 @@ class Config(contextlib.ContextDecorator):
 
         Examples
         --------
-        >>> pl.Config.set_credential_provider(
+        >>> pl.Config.set_default_credential_provider(
         ...     pl.CredentialProviderAWS(
         ...         assume_role={"RoleArn": "...", "RoleSessionName": "..."}
         ...     )

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Literal, TypedDict, get_args
 
 from polars._typing import EngineType
 from polars._utils.deprecation import deprecated
+from polars._utils.unstable import unstable
 from polars._utils.various import normalize_filepath
 from polars.dependencies import json
 from polars.lazyframe.engine_config import GPUEngine
@@ -16,6 +17,9 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     from polars._typing import FloatFmt
+    from polars.io.cloud.credential_provider._providers import (
+        CredentialProviderFunction,
+    )
 
     if sys.version_info >= (3, 10):
         from typing import TypeAlias
@@ -1519,4 +1523,49 @@ class Config(contextlib.ContextDecorator):
             os.environ.pop("POLARS_ENGINE_AFFINITY", None)
         else:
             os.environ["POLARS_ENGINE_AFFINITY"] = engine
+        return cls
+
+    @classmethod
+    @unstable()
+    def set_credential_provider(
+        cls, credential_provider: CredentialProviderFunction | Literal["auto"] | None
+    ) -> type[Config]:
+        """
+        Set a default credential provider.
+
+        Sets the default credential provider to be used for functions that
+        read / write to cloud storage.
+
+        .. warning::
+            This functionality is considered **unstable**. It may be changed
+            at any point without it being considered a breaking change.
+
+        Parameters
+        ----------
+        credential_provider
+            Provide a function that can be called to provide cloud storage
+            credentials. The function is expected to return a dictionary of
+            credential keys along with an optional credential expiry time.
+
+            Can also be set to None, which globally disables auto-initialization
+            of credential providers, or "auto" (the default behavior).
+
+        Examples
+        --------
+        >>> pl.Config.set_credential_provider(
+        ...     pl.CredentialProviderAWS(
+        ...         assume_role={"RoleArn": "...", "RoleSessionName": "..."}
+        ...     )
+        ... )
+        <class 'polars.config.Config'>
+        """
+        import polars.io.cloud.credential_provider._builder
+
+        if isinstance(credential_provider, str) and credential_provider != "auto":
+            raise ValueError(credential_provider)
+
+        polars.io.cloud.credential_provider._builder.DEFAULT_CREDENTIAL_PROVIDER = (
+            credential_provider
+        )
+
         return cls

--- a/py-polars/tests/unit/io/cloud/test_credential_provider.py
+++ b/py-polars/tests/unit/io/cloud/test_credential_provider.py
@@ -829,7 +829,7 @@ def test_credential_provider_global_config(monkeypatch: pytest.MonkeyPatch) -> N
         )
     )
 
-    pl.Config.set_credential_provider(provider)
+    pl.Config.set_default_credential_provider(provider)
 
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "...")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "...")
@@ -864,7 +864,7 @@ def test_credential_provider_global_config(monkeypatch: pytest.MonkeyPatch) -> N
 
     assert provider.call_count == 3
 
-    pl.Config.set_credential_provider("auto")
+    pl.Config.set_default_credential_provider("auto")
 
     with pytest.raises(OSError, match="http://localhost:333"):
         get_q().collect()
@@ -881,7 +881,7 @@ def test_credential_provider_global_config(monkeypatch: pytest.MonkeyPatch) -> N
     with pytest.raises(AssertionError, match=err_magic):
         get_q().collect()
 
-    pl.Config.set_credential_provider(None)
+    pl.Config.set_default_credential_provider(None)
 
     with pytest.raises(OSError, match="http://localhost:333"):
         get_q().collect()

--- a/py-polars/tests/unit/io/cloud/test_credential_provider.py
+++ b/py-polars/tests/unit/io/cloud/test_credential_provider.py
@@ -809,3 +809,79 @@ def test_cache_user_credential_provider(monkeypatch: pytest.MonkeyPatch) -> None
         get_q().collect()
 
     assert user_provider.call_count == 5
+
+
+@pytest.mark.slow
+def test_credential_provider_global_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    import polars as pl
+    import polars.io.cloud.credential_provider._builder
+
+    monkeypatch.setattr(
+        polars.io.cloud.credential_provider._builder,
+        "DEFAULT_CREDENTIAL_PROVIDER",
+        None,
+    )
+
+    provider = Mock(
+        return_value=(
+            {"aws_access_key_id": "...", "aws_secret_access_key": "..."},
+            None,
+        )
+    )
+
+    pl.Config.set_credential_provider(provider)
+
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "...")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "...")
+
+    def get_q() -> pl.LazyFrame:
+        return pl.scan_parquet(
+            "s3://.../...",
+            storage_options={"aws_endpoint_url": "http://localhost:333"},
+        )
+
+    def get_q_disable_cred_provider() -> pl.LazyFrame:
+        return pl.scan_parquet(
+            "s3://.../...",
+            credential_provider=None,
+            storage_options={"aws_endpoint_url": "http://localhost:333"},
+        )
+
+    assert provider.call_count == 0
+
+    with pytest.raises(OSError, match="http://localhost:333"):
+        get_q().collect()
+
+    assert provider.call_count == 2
+
+    with pytest.raises(OSError, match="http://localhost:333"):
+        get_q_disable_cred_provider().collect()
+
+    assert provider.call_count == 2
+
+    with pytest.raises(OSError, match="http://localhost:333"):
+        get_q().collect()
+
+    assert provider.call_count == 3
+
+    pl.Config.set_credential_provider("auto")
+
+    with pytest.raises(OSError, match="http://localhost:333"):
+        get_q().collect()
+
+    assert provider.call_count == 3
+
+    err_magic = "err_magic_3"
+
+    def raises(*_: None, **__: None) -> None:
+        raise AssertionError(err_magic)
+
+    monkeypatch.setattr(CredentialProviderBuilder, "__init__", raises)
+
+    with pytest.raises(AssertionError, match=err_magic):
+        get_q().collect()
+
+    pl.Config.set_credential_provider(None)
+
+    with pytest.raises(OSError, match="http://localhost:333"):
+        get_q().collect()


### PR DESCRIPTION
Mainly for interactive environments, this makes it so that users do not need to pass `credential_provider` on every scan/sink call.

```python
def credential_provider():
    raise Exception("hello world")


pl.Config.set_default_credential_provider(credential_provider)
pl.scan_parquet("s3://.../...").collect()
#   File "...", line 17, in credential_provider
#     raise Exception("hello world")
# Exception: hello world (store: credential-provider-aws)

```
