### PR TITLE
fix: Fix panic scanning from AWS legacy global endpoint URL

### DIFF
--- a/crates/polars-io/src/path_utils/mod.rs
+++ b/crates/polars-io/src/path_utils/mod.rs
@@ -419,7 +419,7 @@ pub fn expand_paths_hive(
 
                         let bucket_end = after_scheme.find(".s3.")?;
                         let offset = bucket_end + 4;
-                        // Note: `.region-code.` section may be omitted in legacy global endpoint URLs.
+                        // Search after offset to prevent matching `.s3.amazonaws.com` (legacy global endpoint URL without region).
                         let region_end = offset + after_scheme[offset..].find(".amazonaws.com/")?;
 
                         if after_scheme[..region_end].contains('/') {


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/24438

Note, we do not perform conversion from this URL to a `s3://` path, as the user has reported that older versions of polars were already able to scan from this URL.

ref https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#deprecated-global-endpoint
<img width="1094" height="188" alt="image" src="https://github.com/user-attachments/assets/2268c43c-f092-4923-a0ff-e9d4cd8a7e9b" />

