### PR TITLE
fix: Add support for arr.sum() on small integer Array dtypes containing nulls

### DIFF
--- a/crates/polars-ops/src/chunked_array/array/sum_mean.rs
+++ b/crates/polars-ops/src/chunked_array/array/sum_mean.rs
@@ -59,11 +59,24 @@ pub(super) fn sum_array_numerical(ca: &ArrayChunked, inner_type: &DataType) -> S
 
 pub(super) fn sum_with_nulls(ca: &ArrayChunked, inner_dtype: &DataType) -> PolarsResult<Series> {
     use DataType::*;
-    // TODO: add fast path for smaller ints?
     let mut out = {
         match inner_dtype {
             Boolean => {
                 let out: IdxCa = ca
+                    .amortized_iter()
+                    .map(|s| s.and_then(|s| s.as_ref().sum().ok()))
+                    .collect();
+                out.into_series()
+            },
+            UInt8 => {
+                let out: Int64Chunked = ca
+                    .amortized_iter()
+                    .map(|s| s.and_then(|s| s.as_ref().sum().ok()))
+                    .collect();
+                out.into_series()
+            },
+            UInt16 => {
+                let out: Int64Chunked = ca
                     .amortized_iter()
                     .map(|s| s.and_then(|s| s.as_ref().sum().ok()))
                     .collect();
@@ -78,6 +91,20 @@ pub(super) fn sum_with_nulls(ca: &ArrayChunked, inner_dtype: &DataType) -> Polar
             },
             UInt64 => {
                 let out: UInt64Chunked = ca
+                    .amortized_iter()
+                    .map(|s| s.and_then(|s| s.as_ref().sum().ok()))
+                    .collect();
+                out.into_series()
+            },
+            Int8 => {
+                let out: Int64Chunked = ca
+                    .amortized_iter()
+                    .map(|s| s.and_then(|s| s.as_ref().sum().ok()))
+                    .collect();
+                out.into_series()
+            },
+            Int16 => {
+                let out: Int64Chunked = ca
                     .amortized_iter()
                     .map(|s| s.and_then(|s| s.as_ref().sum().ok()))
                     .collect();

--- a/py-polars/tests/unit/datatypes/test_array.py
+++ b/py-polars/tests/unit/datatypes/test_array.py
@@ -240,6 +240,24 @@ def test_arr_std(data_dispersion: pl.DataFrame) -> None:
     assert_frame_equal(result, expected)
 
 
+def test_arr_sum(data_dispersion: pl.DataFrame) -> None:
+    df = data_dispersion
+
+    result = df.select(
+        pl.col("int").arr.sum().name.suffix("_sum"),
+        pl.col("float").arr.sum().name.suffix("_sum"),
+    )
+
+    expected = pl.DataFrame(
+        [
+            pl.Series("int_sum", [15], dtype=pl.Int64),
+            pl.Series("float_sum", [15.0], dtype=pl.Float64),
+        ]
+    )
+
+    assert_frame_equal(result, expected)
+
+
 def test_arr_mean(data_dispersion: pl.DataFrame) -> None:
     df = data_dispersion
 
@@ -427,3 +445,23 @@ def test_sort() -> None:
     tc([[2], [1]], [[1], [2]], 1)
     tc([[2, 1]], [[2, 1]], 2)
     tc([[2, 1], [1, 2]], [[1, 2], [2, 1]], 2)
+
+
+def test_array_sum_with_nulls() -> None:
+    for dt_in, dt_out in [
+        (pl.Int8, pl.Int64),
+        (pl.Int16, pl.Int64),
+        (pl.Int32, pl.Int32),
+        (pl.Int64, pl.Int64),
+        (pl.Int128, pl.Int128),
+        (pl.UInt8, pl.Int64),
+        (pl.UInt16, pl.Int64),
+        (pl.UInt32, pl.UInt32),
+        (pl.UInt64, pl.UInt64),
+        (pl.Float32, pl.Float32),
+        (pl.Float64, pl.Float64),
+    ]:
+        s = pl.Series("a", [[1, 2, 3], None, [4, None, 6]], pl.Array(dt_in, 3))
+        result = s.arr.sum()
+        expected = pl.Series("a", [6, None, 10], dt_out)
+        assert_series_equal(result, expected)


### PR DESCRIPTION
close #24477 