### PR TITLE
fix(python): Fix `write_xlsx()` typing and unpin xlsxwriter version

### DIFF
--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -41,7 +41,7 @@ s3fs[boto3]
 fastexcel>=0.11.5
 openpyxl
 xlsx2csv
-xlsxwriter<=3.2.5
+xlsxwriter
 # Other I/O
 deltalake>=1.1.4
 # Csv


### PR DESCRIPTION
XlsxWriter v3.2.6+ added type annotations to the `Workbook()` constructor which triggered a CI failure.

This issue was fixed in #24485 by pinning the XlsxWriter version to v3.2.5 before the type annotations were added.

This change fixes the issue by having the same `workbook` type annotation in Polars `write_excel()` and the interal function `_xl_setup_workbook()`.

It also unpins the xlsxwriter version to allow future updates.

See also: https://github.com/jmcnamara/XlsxWriter/issues/1154#

CC @coastalwhite 