### PR TITLE
feat: Support cum_prod for `Decimal` dtype

### DIFF
--- a/crates/polars-ops/src/series/ops/cum_agg.rs
+++ b/crates/polars-ops/src/series/ops/cum_agg.rs
@@ -244,6 +244,13 @@ pub fn cum_prod_with_init(
         Int128 => cum_prod_numeric(s.i128()?, reverse, init.extract()).into_series(),
         Float32 => cum_prod_numeric(s.f32()?, reverse, init.extract()).into_series(),
         Float64 => cum_prod_numeric(s.f64()?, reverse, init.extract()).into_series(),
+        #[cfg(feature = "dtype-decimal")]
+        Decimal(precision, scale) => {
+            let ca = s.decimal().unwrap().physical();
+            cum_prod_numeric(ca, reverse, init.clone().to_physical().extract())
+                .into_decimal_unchecked(*precision, scale.unwrap())
+                .into_series()
+        },
         dt => polars_bail!(opq = cum_prod, dt),
     };
     Ok(out)

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -376,12 +376,14 @@ def test_decimal_cumulative_aggregations() -> None:
     df = pl.Series("a", [D("2.2"), D("1.1"), D("3.3")]).to_frame()
     result = df.select(
         pl.col("a").cum_sum().alias("cum_sum"),
+        pl.col("a").cum_prod().alias("cum_prod"),
         pl.col("a").cum_min().alias("cum_min"),
         pl.col("a").cum_max().alias("cum_max"),
     )
     expected = pl.DataFrame(
         {
             "cum_sum": [D("2.2"), D("3.3"), D("6.6")],
+            "cum_prod": [D("2.2"), D("2.42"), D("7.986")],
             "cum_min": [D("2.2"), D("1.1"), D("1.1")],
             "cum_max": [D("2.2"), D("2.2"), D("3.3")],
         }


### PR DESCRIPTION
Building upon https://github.com/pola-rs/polars/pull/20802, this PR adds `cum_prod` support for the `Decimal` dtype.