### PR TITLE
fix: Correct dtype for cum_agg in streaming engine

### DIFF
--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -1071,7 +1071,7 @@ fn lower_exprs_with_ctx(
             },
 
             #[cfg(feature = "cum_agg")]
-            AExpr::Function {
+            ref agg_expr @ AExpr::Function {
                 input: ref inner_exprs,
                 function:
                     ref function @ (IRFunctionExpr::CumMin { reverse }
@@ -1088,7 +1088,7 @@ fn lower_exprs_with_ctx(
                 let input_schema = &ctx.phys_sm[input.node].output_schema;
 
                 let value_key = unique_column_name();
-                let value_dtype = inner_exprs[0].dtype(input_schema, ctx.expr_arena)?;
+                let value_dtype = agg_expr.to_dtype(input_schema, ctx.expr_arena)?;
 
                 let input = build_select_stream_with_ctx(
                     input,

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -1560,4 +1560,5 @@ def test_group_by_first_nondet_24278() -> None:
 def test_group_by_cum_sum_key_24489() -> None:
     df = pl.LazyFrame({"x": [1, 2]})
     out = df.group_by((pl.col.x > 1).cum_sum()).agg().collect()
-    assert_frame_equal(out, pl.DataFrame({"x": [0, 1]}), check_row_order=False)
+    expected = pl.DataFrame({"x": [0, 1]}, schema={"x": pl.UInt32})
+    assert_frame_equal(out, expected, check_row_order=False)

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -1555,3 +1555,9 @@ def test_group_by_first_nondet_24278() -> None:
     fst_value = q.collect().to_series().sum()
     for _ in range(10):
         assert q.collect().to_series().sum() == fst_value
+
+
+def test_group_by_cum_sum_key_24489() -> None:
+    df = pl.LazyFrame({"x": [1, 2]})
+    out = df.group_by((pl.col.x > 1).cum_sum()).agg().collect()
+    assert_frame_equal(out, pl.DataFrame({"x": [0, 1]}), check_row_order=False)


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/24489.