### PR TITLE
perf: Stop caching Parquet metadata after 8 files

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use either::Either;
 use polars_io::RowIndex;
 #[cfg(feature = "cloud")]
@@ -254,6 +256,20 @@ pub(super) fn parquet_file_info(
     );
 
     Ok((file_info, metadata))
+}
+
+pub fn max_metadata_scan_cached() -> usize {
+    static MAX_SCANS_METADATA_CACHED: LazyLock<usize> = LazyLock::new(|| {
+        let value = std::env::var("POLARS_MAX_CACHED_METADATA_SCANS").map_or(8, |v| {
+            v.parse::<usize>()
+                .expect("invalid `POLARS_MAX_CACHED_METADATA_SCANS` value")
+        });
+        if value == 0 {
+            return usize::MAX;
+        }
+        value
+    });
+    *MAX_SCANS_METADATA_CACHED
 }
 
 // TODO! return metadata arced
@@ -555,11 +571,15 @@ passing a schema can allow \
 this scan to succeed with an empty DataFrame.",
                         )?;
 
-                        let (file_info, metadata) = scans::parquet_file_info(
+                        let (file_info, mut metadata) = scans::parquet_file_info(
                             first_scan_source,
                             unified_scan_args.row_index.as_ref(),
                             cloud_options,
                         )?;
+
+                        if self.inner.len() > max_metadata_scan_cached() {
+                            _ = metadata.take();
+                        }
 
                         PolarsResult::Ok((file_info, FileScanIR::Parquet { options, metadata }))
                     })()


### PR DESCRIPTION
This PR adds the `POLARS_MAX_CACHED_METADATA_SCANS` environment variable to control the amount of cached Parquet metadata structs in the IR plan.

This can massively reduce the memory consumption for queries with a lot of scans, but will harm performance as the metadata will need to be resolved twice.

With 100 large file scans this was the outcome:

```shell
$ export POLARS_MAX_CACHED_METADATA_SCANS=1
$ time -f %M python3 100-scans.py
278436  # =  271 MB
$ export POLARS_MAX_CACHED_METADATA_SCANS=0 # turn off pruning
$ time -f %M python3 100-scans.py
3331172 # = 3253 MB
$ export POLARS_MAX_CACHED_METADATA_SCANS=8 # default value
$ time -f %M python3 100-scans.py
503148  # =  491 MB
```

This is a temporary solution until we can probably compress the metadata somehow.

Fixes #22366.