### PR TITLE
refactor: Refactor `ApplyExpr` in `group_by` context on multiple inputs

### DIFF
--- a/crates/polars-core/src/frame/group_by/position.rs
+++ b/crates/polars-core/src/frame/group_by/position.rs
@@ -362,6 +362,10 @@ impl GroupsType {
         }
     }
 
+    pub fn is_rolling(&self) -> bool {
+        matches!(self, GroupsType::Slice { rolling: true, .. })
+    }
+
     pub fn take_group_firsts(self) -> Vec<IdxSize> {
         match self {
             GroupsType::Idx(mut groups) => std::mem::take(&mut groups.first),

--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -213,6 +213,27 @@ impl ApplyExpr {
         Ok(ac)
     }
 
+    // Fast-path when every AggState is a LiteralScalar. This path avoids calling aggregated()
+    // or groups(), and returns a LiteralScalar, on the implicit condition that the function
+    // is pure (which holds in the case of single element inputs).
+    fn apply_all_literal<'a>(
+        &self,
+        mut acs: Vec<AggregationContext<'a>>,
+    ) -> PolarsResult<AggregationContext<'a>> {
+        let mut cols = acs
+            .iter()
+            .map(|ac| ac.get_values().clone())
+            .collect::<Vec<_>>();
+        let out = self.function.call_udf(&mut cols)?;
+        polars_ensure!(
+            out.len() == 1,
+            ComputeError: "expression {:?} must return exactly one value on literals", &self.expr
+        );
+        let mut ac = acs.swap_remove(0);
+        ac.with_literal(out);
+        Ok(ac)
+    }
+
     fn apply_multiple_group_aware<'a>(
         &self,
         mut acs: Vec<AggregationContext<'a>>,
@@ -350,13 +371,13 @@ impl PhysicalExpr for ApplyExpr {
             // - Any presence of LiteralScalar is immaterial as it gets broadcasted in the UDF.
             // - Combination of AggregatedScalar and AggregatedList => NOT allowed for elementwise.
             // - Combination of AggregatedScalar and NotAggregated => NOT allowed for elementwise.
-            // - Any other combination => allowed for elementwise.
+            // - Any other combination => allowed for elementwise, if groups are not rolling; this
+            //   may require aggregation and must check the groups
 
-            // Consequently, these dfollow the elementwise path (not exhaustive):
+            // Consequently, these follow the elementwise path (not exhaustive):
             // - All AggregatedScalar
             // - Any combination of AggregatedList(s) and NotAggregated(s)
-            // - All of the above with or without LiteralScalar
-            // Groups must match
+            // - Either of the above with or without LiteralScalar
 
             match self.flags.is_elementwise() {
                 false => self.apply_multiple_group_aware(acs, df),
@@ -364,16 +385,28 @@ impl PhysicalExpr for ApplyExpr {
                     let mut has_agg_list = false;
                     let mut has_agg_scalar = false;
                     let mut has_not_agg = false;
+                    let mut has_rolling_groups = false;
+                    // TBD - can NotAgg have rolling groups?
                     for ac in &acs {
                         match ac.state {
-                            AggState::AggregatedList(_) => has_agg_list = true,
+                            AggState::AggregatedList(_) => {
+                                has_agg_list = true;
+                                has_rolling_groups |= ac.groups.is_rolling()
+                            },
                             AggState::AggregatedScalar(_) => has_agg_scalar = true,
-                            AggState::NotAggregated(_) => has_not_agg = true,
+                            AggState::NotAggregated(_) => {
+                                has_not_agg = true;
+                                has_rolling_groups |= ac.groups.is_rolling()
+                            },
                             _ => {},
                         }
                     }
 
-                    if has_agg_scalar && (has_agg_list || has_not_agg) {
+                    if !(has_agg_list || has_agg_scalar || has_not_agg) {
+                        self.apply_all_literal(acs)
+                    } else if (has_agg_scalar && (has_agg_list || has_not_agg))
+                        || has_rolling_groups
+                    {
                         self.apply_multiple_group_aware(acs, df)
                     } else {
                         apply_multiple_elementwise(
@@ -412,67 +445,30 @@ fn apply_multiple_elementwise<'a>(
     check_lengths: bool,
     returns_scalar: bool,
 ) -> PolarsResult<AggregationContext<'a>> {
-    // Fast-path when every AggState is LiteralScalar. This path avoids calling groups()
-    // or aggregated(), and returns a LiteralScalar, on the implicit condition that the function
-    // is pure (which holds in the case of single element inputs).
-    let all_literal = acs
-        .iter()
-        .all(|ac| matches!(ac.state, AggState::LiteralScalar(_)));
-
-    if all_literal {
-        let mut cols = acs
-            .iter()
-            // TODO: which is more idiomatic (get_values)?
-            // .map(|ac| ac.flat_naive().into_owned())
-            .map(|ac| ac.get_values().clone())
-            .collect::<Vec<_>>();
-        let out = function.call_udf(&mut cols)?;
-        let mut ac = acs.swap_remove(0);
-        ac.with_literal(out);
-        return Ok(ac);
-    }
-
     // At this stage, we either have (with or without LiteralScalars):
     // - one or more AggregatedLists or NotAggregated ACs
     // - one or more AggregatedScalars ACs
 
-    // Collect the aggstate statistics
-    let mut has_agg_list = false;
-    let mut has_not_agg_with_len_modified = false;
-    for ac in &acs {
-        match ac.state {
-            AggState::AggregatedList(_) => {
-                has_agg_list = true;
-            },
-            AggState::NotAggregated(_) => {
-                if !ac.original_len {
-                    has_not_agg_with_len_modified = true;
-                }
-            },
-            _ => {},
-        }
-    }
-
     // Aggregate when needed. Update and check groups when needed.
-    // This includes two fast-paths (ignoring LiteralScalars): (i) when we have one or more
-    // NotAggregated ACs, all with original_len = true, and no AggregatedList, and (ii) when we
-    // one ore more AggregatedScalars
-
-    //TODO - depending on the invariants we can rely on, we should check all groups if we want
-    // to be strict
     let mut previous = None;
     for ac in acs.iter_mut() {
-        if ac.is_literal() {
+        if matches!(
+            ac.state,
+            AggState::LiteralScalar(_) | AggState::AggregatedScalar(_)
+        ) {
             continue;
         }
-        if has_agg_list || has_not_agg_with_len_modified {
-            ac.aggregated();
 
-            if let Some(p) = previous {
-                check_groups(ac.groups(), p)?;
-            }
-            previous = Some(ac.groups());
+        // For now, we aggregate every AC.
+        // TODO: Future optimization - when every AC is NotAggregated with equal groups
+        // (e.g. because the length and order is not modified), there is no need to
+        // call aggregated()
+        ac.aggregated();
+
+        if let Some(p) = previous {
+            check_groups(ac.groups(), p)?;
         }
+        previous = Some(ac.groups());
     }
 
     // The first non-LiteralScalar AC will be used as the base AC to retain the context
@@ -522,75 +518,6 @@ fn apply_multiple_elementwise<'a>(
 
             let mut ac = acs.swap_remove(base_ac_idx);
             ac.with_values_and_args(out, aggregated, Some(expr), false, returns_scalar)?;
-            Ok(ac)
-        },
-    }
-}
-
-fn apply_multiple_elementwise_old<'a>(
-    mut acs: Vec<AggregationContext<'a>>,
-    function: &dyn ColumnsUdf,
-    expr: &Expr,
-    check_lengths: bool,
-    returns_scalar: bool,
-) -> PolarsResult<AggregationContext<'a>> {
-    match acs.first().unwrap().agg_state() {
-        // A fast path that doesn't drop groups of the first arg.
-        // This doesn't require group re-computation.
-        AggState::AggregatedList(s) => {
-            let ca = s.list().unwrap();
-
-            let other = acs[1..]
-                .iter()
-                .map(|ac| ac.flat_naive().into_owned())
-                .collect::<Vec<_>>();
-
-            let out = ca.apply_to_inner(&|s| {
-                let mut args = Vec::with_capacity(other.len() + 1);
-                args.push(s.into());
-                args.extend_from_slice(&other);
-                Ok(function
-                    .call_udf(&mut args)?
-                    .as_materialized_series()
-                    .clone())
-            })?;
-            let mut ac = acs.swap_remove(0);
-            ac.with_values(out.into_column(), true, None)?;
-            Ok(ac)
-        },
-        first_as => {
-            let check_lengths = check_lengths && !matches!(first_as, AggState::LiteralScalar(_));
-            let aggregated = acs.iter().all(|ac| ac.is_aggregated() | ac.is_literal())
-                && acs.iter().any(|ac| ac.is_aggregated());
-            let mut c = acs
-                .iter_mut()
-                .enumerate()
-                .map(|(i, ac)| {
-                    // Make sure the groups are updated because we are about to throw away
-                    // the series length information, only on the first iteration.
-                    if let (0, UpdateGroups::WithSeriesLen) = (i, &ac.update_groups) {
-                        ac.groups();
-                    }
-
-                    ac.flat_naive().into_owned()
-                })
-                .collect::<Vec<_>>();
-
-            let input_len = c[0].len();
-            let c = function.call_udf(&mut c)?;
-            if check_lengths {
-                check_map_output_len(input_len, c.len(), expr)?;
-            }
-
-            let all_literal = acs
-                .iter()
-                .all(|ac| matches!(ac.state, AggState::LiteralScalar(_)));
-
-            // Take the first aggregation context that as that is the input series.
-            let mut ac = acs.swap_remove(0);
-
-            // TODO - add condition that for F(lit) => lit, F must be pure (deterministic & no side-effects)
-            ac.with_values_and_args(c, aggregated, None, all_literal, returns_scalar)?;
             Ok(ac)
         },
     }

--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -8,6 +8,7 @@ use polars_core::chunked_array::from_iterator_par::{
 use polars_core::prelude::*;
 use rayon::prelude::*;
 
+use super::sortby::check_groups;
 use super::*;
 use crate::expressions::{
     AggState, AggregationContext, PartitionedAggregation, PhysicalExpr, UpdateGroups,
@@ -339,6 +340,24 @@ impl PhysicalExpr for ApplyExpr {
         } else {
             let acs = self.prepare_multiple_inputs(df, groups, state)?;
 
+            // Implementation dispatch:
+            // The current implementation of `apply_multiple_elementwise` requires the
+            // multiple inputs to have a compatible data layout as it invokes `flat_naive()`.
+            // Compatible means matching as-is, or matching after aggregation,
+            // or matching after an implicit broadcast by the function.
+            //
+            // The dispatch logic between the implementations depends on the combination of aggstates:
+            // - Any presence of LiteralScalar is immaterial as it gets broadcasted in the UDF.
+            // - Combination of AggregatedScalar and AggregatedList => NOT allowed for elementwise.
+            // - Combination of AggregatedScalar and NotAggregated => NOT allowed for elementwise.
+            // - Any other combination => allowed for elementwise.
+
+            // Consequently, these dfollow the elementwise path (not exhaustive):
+            // - All AggregatedScalar
+            // - Any combination of AggregatedList(s) and NotAggregated(s)
+            // - All of the above with or without LiteralScalar
+            // Groups must match
+
             match self.flags.is_elementwise() {
                 false => self.apply_multiple_group_aware(acs, df),
                 true => {
@@ -353,7 +372,8 @@ impl PhysicalExpr for ApplyExpr {
                             _ => {},
                         }
                     }
-                    if has_agg_list || (has_agg_scalar && has_not_agg) {
+
+                    if has_agg_scalar && (has_agg_list || has_not_agg) {
                         self.apply_multiple_group_aware(acs, df)
                     } else {
                         apply_multiple_elementwise(
@@ -386,6 +406,128 @@ impl PhysicalExpr for ApplyExpr {
 }
 
 fn apply_multiple_elementwise<'a>(
+    mut acs: Vec<AggregationContext<'a>>,
+    function: &dyn ColumnsUdf,
+    expr: &Expr,
+    check_lengths: bool,
+    returns_scalar: bool,
+) -> PolarsResult<AggregationContext<'a>> {
+    // Fast-path when every AggState is LiteralScalar. This path avoids calling groups()
+    // or aggregated(), and returns a LiteralScalar, on the implicit condition that the function
+    // is pure (which holds in the case of single element inputs).
+    let all_literal = acs
+        .iter()
+        .all(|ac| matches!(ac.state, AggState::LiteralScalar(_)));
+
+    if all_literal {
+        let mut cols = acs
+            .iter()
+            // TODO: which is more idiomatic (get_values)?
+            // .map(|ac| ac.flat_naive().into_owned())
+            .map(|ac| ac.get_values().clone())
+            .collect::<Vec<_>>();
+        let out = function.call_udf(&mut cols)?;
+        let mut ac = acs.swap_remove(0);
+        ac.with_literal(out);
+        return Ok(ac);
+    }
+
+    // At this stage, we either have (with or without LiteralScalars):
+    // - one or more AggregatedLists or NotAggregated ACs
+    // - one or more AggregatedScalars ACs
+
+    // Collect the aggstate statistics
+    let mut has_agg_list = false;
+    let mut has_not_agg_with_len_modified = false;
+    for ac in &acs {
+        match ac.state {
+            AggState::AggregatedList(_) => {
+                has_agg_list = true;
+            },
+            AggState::NotAggregated(_) => {
+                if !ac.original_len {
+                    has_not_agg_with_len_modified = true;
+                }
+            },
+            _ => {},
+        }
+    }
+
+    // Aggregate when needed. Update and check groups when needed.
+    // This includes two fast-paths (ignoring LiteralScalars): (i) when we have one or more
+    // NotAggregated ACs, all with original_len = true, and no AggregatedList, and (ii) when we
+    // one ore more AggregatedScalars
+
+    //TODO - depending on the invariants we can rely on, we should check all groups if we want
+    // to be strict
+    let mut previous = None;
+    for ac in acs.iter_mut() {
+        if ac.is_literal() {
+            continue;
+        }
+        if has_agg_list || has_not_agg_with_len_modified {
+            ac.aggregated();
+
+            if let Some(p) = previous {
+                check_groups(ac.groups(), p)?;
+            }
+            previous = Some(ac.groups());
+        }
+    }
+
+    // The first non-LiteralScalar AC will be used as the base AC to retain the context
+    let base_ac_idx = acs.iter().position(|ac| !ac.is_literal()).unwrap();
+
+    match acs[base_ac_idx].agg_state() {
+        AggState::AggregatedList(s) => {
+            let aggregated = acs.iter().any(|ac| ac.is_aggregated());
+            debug_assert!(!returns_scalar);
+            let ca = s.list().unwrap();
+            let input_len = s.len();
+
+            let out = ca.apply_to_inner(&|_| {
+                let mut cols = acs
+                    .iter()
+                    .map(|ac| ac.flat_naive().into_owned())
+                    .collect::<Vec<_>>();
+                Ok(function
+                    .call_udf(&mut cols)?
+                    .as_materialized_series()
+                    .clone())
+            })?;
+
+            let out = out.into_column();
+            if check_lengths {
+                check_map_output_len(input_len, out.len(), expr)?;
+            }
+
+            let mut ac = acs.swap_remove(base_ac_idx);
+            ac.with_values_and_args(out, aggregated, Some(expr), false, returns_scalar)?;
+            Ok(ac)
+        },
+        _ => {
+            let aggregated = acs.iter().any(|ac| ac.is_aggregated());
+            debug_assert!(aggregated == returns_scalar);
+
+            let mut cols = acs
+                .iter()
+                .map(|ac| ac.flat_naive().into_owned())
+                .collect::<Vec<_>>();
+
+            let input_len = cols[base_ac_idx].len();
+            let out = function.call_udf(&mut cols)?;
+            if check_lengths {
+                check_map_output_len(input_len, out.len(), expr)?;
+            }
+
+            let mut ac = acs.swap_remove(base_ac_idx);
+            ac.with_values_and_args(out, aggregated, Some(expr), false, returns_scalar)?;
+            Ok(ac)
+        },
+    }
+}
+
+fn apply_multiple_elementwise_old<'a>(
     mut acs: Vec<AggregationContext<'a>>,
     function: &dyn ColumnsUdf,
     expr: &Expr,

--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -213,9 +213,8 @@ impl ApplyExpr {
         Ok(ac)
     }
 
-    // Fast-path when every AggState is a LiteralScalar. This path avoids calling aggregated()
-    // or groups(), and returns a LiteralScalar, on the implicit condition that the function
-    // is pure (which holds in the case of single element inputs).
+    // Fast-path when every AggState is a LiteralScalar. This path avoids calling aggregated() or
+    // groups(), and returns a LiteralScalar, on the implicit condition that the function is pure.
     fn apply_all_literal<'a>(
         &self,
         mut acs: Vec<AggregationContext<'a>>,
@@ -446,12 +445,13 @@ fn apply_multiple_elementwise<'a>(
     returns_scalar: bool,
 ) -> PolarsResult<AggregationContext<'a>> {
     // At this stage, we either have (with or without LiteralScalars):
-    // - one or more AggregatedLists or NotAggregated ACs
-    // - one or more AggregatedScalars ACs
+    // - one or more AggregatedList or NotAggregated ACs
+    // - one or more AggregatedScalar ACs
 
     // Aggregate when needed. Update and check groups when needed.
     let mut previous = None;
     for ac in acs.iter_mut() {
+        // TBD: If we want to be strict, we would check all groups
         if matches!(
             ac.state,
             AggState::LiteralScalar(_) | AggState::AggregatedScalar(_)

--- a/crates/polars-expr/src/expressions/sortby.rs
+++ b/crates/polars-expr/src/expressions/sortby.rs
@@ -44,9 +44,9 @@ fn prepare_bool_vec(values: &[bool], by_len: usize) -> Vec<bool> {
     }
 }
 
-static ERR_MSG: &str = "expressions in 'sort_by' must have matching group lengths";
+static ERR_MSG: &str = "expressions must have matching group lengths";
 
-fn check_groups(a: &GroupsType, b: &GroupsType) -> PolarsResult<()> {
+pub(super) fn check_groups(a: &GroupsType, b: &GroupsType) -> PolarsResult<()> {
     polars_ensure!(a.iter().zip(b.iter()).all(|(a, b)| {
         a.len() == b.len()
     }), ComputeError: ERR_MSG);

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -1357,3 +1357,12 @@ def test_struct_null_propagation_23955() -> None:
     )
     df = df.with_columns(d=pl.col("c").struct.field("b")).select(pl.col("d"))
     assert_frame_equal(df, pl.DataFrame({"d": [10, None]}, schema={"d": pl.Int32}))
+
+
+def test_struct_from_partial_sort_24499() -> None:
+    df = pl.DataFrame({"g": [10, 10, 10], "a": [2, 1, 3], "b": [4, 5, 6]})
+    out = df.group_by("g").agg(pl.struct(pl.col("a").sort(), pl.col("b")))
+    expected = pl.DataFrame(
+        {"g": [10], "a": [[{"a": 1, "b": 4}, {"a": 2, "b": 5}, {"a": 3, "b": 6}]]}
+    )
+    assert_frame_equal(out, expected)

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -1359,9 +1359,25 @@ def test_struct_null_propagation_23955() -> None:
     assert_frame_equal(df, pl.DataFrame({"d": [10, None]}, schema={"d": pl.Int32}))
 
 
-def test_struct_from_partial_sort_24499() -> None:
-    df = pl.DataFrame({"g": [10, 10, 10], "a": [2, 1, 3], "b": [4, 5, 6]})
+def test_struct_notagg_partial_sort_24499() -> None:
+    df = pl.DataFrame({"g": [10, 10, 10], "a": [2, 1, 3], "b": [5, 4, 6]})
+
+    # lhs
     out = df.group_by("g").agg(pl.struct(pl.col("a").sort(), pl.col("b")))
+    expected = pl.DataFrame(
+        {"g": [10], "a": [[{"a": 1, "b": 5}, {"a": 2, "b": 4}, {"a": 3, "b": 6}]]}
+    )
+    assert_frame_equal(out, expected)
+
+    # rhs
+    out = df.group_by("g").agg(pl.struct(pl.col("a"), pl.col("b").sort()))
+    expected = pl.DataFrame(
+        {"g": [10], "a": [[{"a": 2, "b": 4}, {"a": 1, "b": 5}, {"a": 3, "b": 6}]]}
+    )
+    assert_frame_equal(out, expected)
+
+    # both
+    out = df.group_by("g").agg(pl.struct(pl.col("a").sort(), pl.col("b").sort()))
     expected = pl.DataFrame(
         {"g": [10], "a": [[{"a": 1, "b": 4}, {"a": 2, "b": 5}, {"a": 3, "b": 6}]]}
     )

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -762,3 +762,24 @@ def test_shift_with_null_deprecated_24105(fill_value: Any) -> None:
         pl.DataFrame({"x": [None, None, None]}),
         check_dtypes=False,
     )
+
+
+def test_raies_on_mismatch_column_length_24500() -> None:
+    df = pl.DataFrame(
+        {
+            "a": [10, 10, 10, 20, 20, 20],
+            "b": [2, 2, 99, 3, 3, 3],
+            "c": [3, 3, 3, 2, 2, 99],
+        }
+    )
+
+    with pytest.raises(
+        ComputeError,
+        match="expressions must have matching group lengths",
+    ):
+        df.group_by("a").agg(
+            pl.struct(
+                pl.col("b").head(pl.col("b").first()),
+                pl.col("c").head(pl.col("c").first()),
+            )
+        )


### PR DESCRIPTION
fixes #24499
fixes #24500

This PR refactors the `ApplyExpr` code path so that more aggstate combinations follow the `apply_multiple_elementwise()` path. In the case of 2 inputs, this increases from 5 to 8 (or 7 in edge case) out of 10 possible combinations.

For review:
- UDFs are expected to broadcast on multiple inputs; do we want to document that explicitly?
- We could decide to be more strict and always check groups at a small expense.
- Error messaging could be made more granular (missing a short display name for `Expr`).
- Note - `dynamic_group_by` does not have the `rolling` flag set; a different `overlapping` flag would fix this. Future work.

Pending benchmarking checks.