### PR TITLE
fix(python): Enable manual commits for `write_database` with the ADBC engine

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4402,7 +4402,6 @@ class DataFrame:
                         mode=mode,
                         **(engine_options or {}),
                     )
-                conn.commit()
             return n_rows
 
         elif engine == "sqlalchemy":

--- a/py-polars/polars/io/database/_utils.py
+++ b/py-polars/polars/io/database/_utils.py
@@ -141,4 +141,4 @@ def _open_adbc_connection(connection_uri: str) -> Any:
     if driver_name in ("duckdb", "snowflake", "sqlite"):
         connection_uri = re.sub(f"^{driver_name}:/{{,3}}", "", connection_uri)
 
-    return adbc_driver.connect(connection_uri)
+    return adbc_driver.connect(connection_uri, autocommit=True)


### PR DESCRIPTION
Closes #24558.

For example, this PR enables the to write to the database multiple times within the same transaction:
```python
import adbc_driver_postgresql.dbapi as pg_dbapi
import polars as pl

conn_str ="postgresql://username:password@host:port/database"

df = pl.DataFrame({"a": [1], "b": [4]})

conn = pg_dbapi.connect(conn_str, autocommit=False)
print(f"Inspect autocommit status: {conn.adbc_connection.get_option("adbc.connection.autocommit")}")

df.write_database("public.table1", connection=conn, engine="adbc")
(df*2).write_database("public.table2", connection=conn, engine="adbc")
conn.commit()
```