### PR TITLE
refactor: Check Arrow FFI pointers with an assert

### DIFF
--- a/crates/polars-arrow/src/ffi/array.rs
+++ b/crates/polars-arrow/src/ffi/array.rs
@@ -255,6 +255,8 @@ unsafe fn create_buffer_known_len<T: NativeType>(
     index: usize,
 ) -> PolarsResult<Buffer<T>> {
     if len == 0 {
+        // Zero-length arrays might have invalid pointers for zero-length slices in Rust,
+        // so this is more than just an optimization.
         return Ok(Buffer::new());
     }
     let ptr: *mut T = get_buffer_ptr(array, dtype, index)?;
@@ -276,6 +278,8 @@ unsafe fn create_buffer<T: NativeType>(
     let len = buffer_len(array, dtype, index)?;
 
     if len == 0 {
+        // Zero-length arrays might have invalid pointers for zero-length slices in Rust,
+        // so this is more than just an optimization.
         return Ok(Buffer::new());
     }
 
@@ -312,6 +316,8 @@ unsafe fn create_bitmap(
 ) -> PolarsResult<Bitmap> {
     let len: usize = array.length.try_into().expect("length to fit in `usize`");
     if len == 0 {
+        // Zero-length arrays might have invalid pointers for zero-length slices in Rust,
+        // so this is more than just an optimization.
         return Ok(Bitmap::new());
     }
     let ptr = get_buffer_ptr(array, dtype, index)?;

--- a/crates/polars-arrow/src/storage.rs
+++ b/crates/polars-arrow/src/storage.rs
@@ -163,7 +163,11 @@ impl<T> SharedStorage<T> {
         }
     }
 
-    pub fn from_internal_arrow_array(ptr: *const T, len: usize, arr: InternalArrowArray) -> Self {
+    /// # Safety
+    /// The range [ptr, ptr+len) needs to be valid and aligned for T.
+    /// ptr may not be null.
+    pub unsafe fn from_internal_arrow_array(ptr: *const T, len: usize, arr: InternalArrowArray) -> Self {
+        assert!(!ptr.is_null() && ptr.is_aligned());
         let inner = SharedStorageInner {
             ref_count: AtomicU64::new(1),
             ptr: ptr.cast_mut(),


### PR DESCRIPTION
`from_internal_arrow_array` wasn't marked unsafe, and although I believe we were using it correctly I added some comments and an assert to make sure.