### PR TITLE
fix: Sink batches early stop on in-memory engine

### DIFF
--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -291,7 +291,10 @@ fn create_physical_plan_impl(
                                 let df;
                                 (df, buffer) =
                                     buffer.split_at(buffer.height().min(chunk_size) as i64);
-                                function.call(df)?;
+                                let should_stop = function.call(df)?;
+                                if should_stop {
+                                    break;
+                                }
                             }
                             Ok(Some(DataFrame::empty()))
                         }),

--- a/crates/polars-stream/src/nodes/callback_sink.rs
+++ b/crates/polars-stream/src/nodes/callback_sink.rs
@@ -53,7 +53,7 @@ impl ComputeNode for CallbackSinkNode {
             recv[0] = PortState::Done;
 
             // Flush the last buffer
-            if !self.buffer.is_empty() {
+            if !self.buffer.is_empty() && !self.is_done {
                 let function = self.function.clone();
                 let df = std::mem::take(&mut self.buffer);
 

--- a/py-polars/tests/unit/io/test_sink_batches.py
+++ b/py-polars/tests/unit/io/test_sink_batches.py
@@ -21,8 +21,9 @@ def test_sink_batches(engine: EngineType) -> None:
     assert_frame_equal(pl.concat(frames), df)
 
 
-def test_sink_batches_early_stop() -> None:
-    df = pl.DataFrame({"a": range(100)})
+@pytest.mark.parametrize("engine", ["in-memory", "streaming"])
+def test_sink_batches_early_stop(engine: EngineType) -> None:
+    df = pl.DataFrame({"a": range(1000)})
     stopped = False
 
     def cb(_: pl.DataFrame) -> bool | None:
@@ -31,7 +32,8 @@ def test_sink_batches_early_stop() -> None:
         stopped = True
         return True
 
-    df.lazy().sink_batches(cb)  # type: ignore[call-overload]
+    df.lazy().sink_batches(cb, chunk_size=100, engine=engine)  # type: ignore[call-overload]
+    assert stopped
 
 
 def test_collect_batches() -> None:


### PR DESCRIPTION
The early stop only worked on the streaming engine.

@eitsupi 