### PR TITLE
fix: Do not allow inferring (`-1`) the dimension on any `Expr.reshape` dimension except the first

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
@@ -56,8 +56,10 @@ impl IRFunctionExpr {
             #[cfg(feature = "trigonometry")]
             Atan2 => mapper.map_to_float_dtype(),
             #[cfg(feature = "sign")]
-            Sign => mapper.ensure_satisfies(|_, dtype| dtype.is_primitive_numeric(), "sign")?.with_same_dtype(),
-            FillNull  => mapper.map_to_supertype(),
+            Sign => mapper
+                .ensure_satisfies(|_, dtype| dtype.is_primitive_numeric(), "sign")?
+                .with_same_dtype(),
+            FillNull => mapper.map_to_supertype(),
             #[cfg(feature = "rolling_window")]
             RollingExpr { function, options } => {
                 use IRRollingFunction::*;
@@ -67,7 +69,7 @@ impl IRFunctionExpr {
                     Var => mapper.var_dtype(),
                     Sum => mapper.sum_dtype(),
                     #[cfg(feature = "cov")]
-                    CorrCov {..} => mapper.map_to_float_dtype(),
+                    CorrCov { .. } => mapper.map_to_float_dtype(),
                     #[cfg(feature = "moment")]
                     Skew | Kurtosis => mapper.map_to_float_dtype(),
                     Map(_) => mapper.try_map_field(|field| {
@@ -84,20 +86,22 @@ impl IRFunctionExpr {
                 }
             },
             #[cfg(feature = "rolling_window_by")]
-            RollingExprBy{function_by, ..} => {
+            RollingExprBy { function_by, .. } => {
                 use IRRollingFunctionBy::*;
                 match function_by {
                     MinBy | MaxBy => mapper.with_same_dtype(),
-                    MeanBy | QuantileBy | StdBy=> mapper.moment_dtype(),
+                    MeanBy | QuantileBy | StdBy => mapper.moment_dtype(),
                     VarBy => mapper.var_dtype(),
                     SumBy => mapper.sum_dtype(),
                 }
             },
             Rechunk => mapper.with_same_dtype(),
-            Append { upcast } => if *upcast {
-                mapper.map_to_supertype()
-            } else {
-                mapper.with_same_dtype()
+            Append { upcast } => {
+                if *upcast {
+                    mapper.map_to_supertype()
+                } else {
+                    mapper.with_same_dtype()
+                }
             },
             ShiftAndFill => mapper.with_same_dtype(),
             DropNans => mapper.with_same_dtype(),
@@ -131,10 +135,16 @@ impl IRFunctionExpr {
             #[cfg(feature = "dtype-struct")]
             AsStruct => {
                 let mut field_names = PlHashSet::with_capacity(fields.len() - 1);
-                let struct_fields = fields.iter().map(|f| {
-                    polars_ensure!(field_names.insert(f.name.as_str()), duplicate_field = f.name());
-                    Ok(f.clone())
-                }).collect::<PolarsResult<Vec<_>>>()?;
+                let struct_fields = fields
+                    .iter()
+                    .map(|f| {
+                        polars_ensure!(
+                            field_names.insert(f.name.as_str()),
+                            duplicate_field = f.name()
+                        );
+                        Ok(f.clone())
+                    })
+                    .collect::<PolarsResult<Vec<_>>>()?;
                 Ok(Field::new(
                     fields[0].name().clone(),
                     DataType::Struct(struct_fields),
@@ -323,37 +333,56 @@ impl IRFunctionExpr {
                 Some(dtype) => mapper.with_dtype(dtype.clone()),
             },
             #[cfg(feature = "dtype-struct")]
-            CumReduceHorizontal {
-                return_dtype, ..
-            }=> match return_dtype {
+            CumReduceHorizontal { return_dtype, .. } => match return_dtype {
                 None => mapper.with_dtype(DataType::Struct(fields.to_vec())),
-                Some(dtype) => mapper.with_dtype(DataType::Struct(fields.iter().map(|f| Field::new(f.name().clone(), dtype.clone())).collect())),
+                Some(dtype) => mapper.with_dtype(DataType::Struct(
+                    fields
+                        .iter()
+                        .map(|f| Field::new(f.name().clone(), dtype.clone()))
+                        .collect(),
+                )),
             },
             #[cfg(feature = "dtype-struct")]
-            CumFoldHorizontal { return_dtype, include_init, .. } => match return_dtype {
-                None => mapper.with_dtype(DataType::Struct(fields.iter().skip(usize::from(!include_init)).map(|f| Field::new(f.name().clone(), fields[0].dtype().clone())).collect())),
-                Some(dtype) => mapper.with_dtype(DataType::Struct(fields.iter().skip(usize::from(!include_init)).map(|f| Field::new(f.name().clone(), dtype.clone())).collect())),
+            CumFoldHorizontal {
+                return_dtype,
+                include_init,
+                ..
+            } => match return_dtype {
+                None => mapper.with_dtype(DataType::Struct(
+                    fields
+                        .iter()
+                        .skip(usize::from(!include_init))
+                        .map(|f| Field::new(f.name().clone(), fields[0].dtype().clone()))
+                        .collect(),
+                )),
+                Some(dtype) => mapper.with_dtype(DataType::Struct(
+                    fields
+                        .iter()
+                        .skip(usize::from(!include_init))
+                        .map(|f| Field::new(f.name().clone(), dtype.clone()))
+                        .collect(),
+                )),
             },
 
             MaxHorizontal => mapper.map_to_supertype(),
             MinHorizontal => mapper.map_to_supertype(),
-            SumHorizontal { .. } => {
-                mapper.map_to_supertype().map(|mut f| {
-                    if f.dtype == DataType::Boolean {
-                        f.dtype = IDX_DTYPE;
-                    }
-                    f
-                })
-            },
-            MeanHorizontal { .. } => {
-                mapper.map_to_supertype().map(|mut f| {
-                    match f.dtype {
-                        dt @ DataType::Float32 => { f.dtype = dt; },
-                        _ => { f.dtype = DataType::Float64; },
-                    };
-                    f
-                })
-            }
+            SumHorizontal { .. } => mapper.map_to_supertype().map(|mut f| {
+                if f.dtype == DataType::Boolean {
+                    f.dtype = IDX_DTYPE;
+                }
+                f
+            }),
+            MeanHorizontal { .. } => mapper.map_to_supertype().map(|mut f| {
+                match f.dtype {
+                    dt @ DataType::Float32 => {
+                        f.dtype = dt;
+                    },
+                    _ => {
+                        f.dtype = DataType::Float64;
+                    },
+                };
+                f
+            }),
             #[cfg(feature = "ewma")]
             EwmMean { .. } => mapper.map_numeric_to_float_dtype(true),
             #[cfg(feature = "ewma_by")]
@@ -379,7 +408,12 @@ impl IRFunctionExpr {
             },
             ExtendConstant => mapper.with_same_dtype(),
 
-            RowEncode(..) => mapper.try_map_field(|_| Ok(Field::new(PlSmallStr::from_static("row_encoded"), DataType::BinaryOffset))),
+            RowEncode(..) => mapper.try_map_field(|_| {
+                Ok(Field::new(
+                    PlSmallStr::from_static("row_encoded"),
+                    DataType::BinaryOffset,
+                ))
+            }),
             #[cfg(feature = "dtype-struct")]
             RowDecode(fields, _) => mapper.with_dtype(DataType::Struct(fields.to_vec())),
         }

--- a/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
@@ -276,12 +276,15 @@ impl IRFunctionExpr {
                     return Ok(dtype);
                 }
 
-                let num_infers = dims.iter().filter(|d| matches!(d, ReshapeDimension::Infer)).count();
+                let infers = dims.iter().enumerate().filter(|(_, d)| matches!(d, ReshapeDimension::Infer)).collect::<Vec<_>>();
 
-                polars_ensure!(num_infers <= 1, InvalidOperation: "can only specify one inferred dimension");
+                polars_ensure!(infers.len() <= 1, InvalidOperation: "can only specify one inferred dimension");
+                if infers.len() == 1 {
+                    polars_ensure!(infers[0].0 == 0, InvalidOperation: "can only infer the first dimension");
+                }
 
                 let mut inferred_size = 0;
-                if num_infers == 1 {
+                if infers.len() == 1 {
                     let mut total_size = 1u64;
                     let mut current = dt;
                     while let DataType::Array(dt, width) = current {

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -9469,8 +9469,10 @@ Consider using {self}.implode() instead"""
         Parameters
         ----------
         dimensions
-            Tuple of the dimension sizes. If a -1 is used in any of the dimensions, that
-            dimension is inferred.
+            Tuple of the dimension sizes. If -1 is used as the value for the
+            first dimension, that dimension is inferred.
+            Because the size of the Column may not be known in advance, it is
+            only possible to use -1 for the first dimension.
 
         Returns
         -------

--- a/py-polars/tests/unit/operations/test_reshape.py
+++ b/py-polars/tests/unit/operations/test_reshape.py
@@ -54,6 +54,13 @@ def test_reshape() -> None:
     ):
         df.select(pl.col("a").reshape((2, -1)))
 
+    df = pl.DataFrame({"a": list(range(2 * 3 * 5 * 7))})
+    q1 = df.lazy().select(pl.col("a").reshape((3, 5, 7, 2)))
+    q2 = df.lazy().select(pl.col("a").reshape((-1, 5, 7, 2)))
+    assert q1.collect_schema() == q1.collect().schema
+    assert q2.collect_schema() == q2.collect().schema
+    assert q1.collect_schema() == q2.collect_schema()
+
 
 @pytest.mark.parametrize("shape", [(1, 3), (5, 1), (-1, 5), (3, -1)])
 def test_reshape_invalid_dimension_size(shape: tuple[int, ...]) -> None:

--- a/py-polars/tests/unit/operations/test_reshape.py
+++ b/py-polars/tests/unit/operations/test_reshape.py
@@ -14,7 +14,8 @@ def display_shape(shape: tuple[int, ...]) -> str:
 
 
 def test_reshape() -> None:
-    s = pl.Series("a", [1, 2, 3, 4])
+    df = pl.DataFrame({"a": [1, 2, 3, 4]})
+    s = df.to_series()
     out = s.reshape((-1, 2))
     expected = pl.Series("a", [[1, 2], [3, 4]], dtype=pl.Array(pl.Int64, 2))
     assert_series_equal(out, expected)
@@ -46,6 +47,12 @@ def test_reshape() -> None:
         InvalidOperationError, match="at least one dimension must be specified"
     ):
         s.reshape(())
+
+    # expr inferred dimension on non-first dimension
+    with pytest.raises(
+        InvalidOperationError, match="can only infer the first dimension"
+    ):
+        df.select(pl.col("a").reshape((2, -1)))
 
 
 @pytest.mark.parametrize("shape", [(1, 3), (5, 1), (-1, 5), (3, -1)])


### PR DESCRIPTION
Related issue: #24536
Sibling PR: #24590

Cc @coastalwhite 