### PR TITLE
chore: Rename pl.dependencies to pl._dependencies

### DIFF
--- a/py-polars/polars/_dependencies.py
+++ b/py-polars/polars/_dependencies.py
@@ -272,7 +272,7 @@ def import_optional(
 
     Examples
     --------
-    >>> from polars.dependencies import import_optional
+    >>> from polars._dependencies import import_optional
     >>> import_optional(
     ...     "definitely_a_real_module",
     ...     err_prefix="super-important package",

--- a/py-polars/polars/_typing.py
+++ b/py-polars/polars/_typing.py
@@ -24,11 +24,11 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from polars import DataFrame, Expr, LazyFrame, Series
+    from polars._dependencies import numpy as np
+    from polars._dependencies import pandas as pd
+    from polars._dependencies import pyarrow as pa
+    from polars._dependencies import torch
     from polars.datatypes import DataType, DataTypeClass, IntegerType, TemporalType
-    from polars.dependencies import numpy as np
-    from polars.dependencies import pandas as pd
-    from polars.dependencies import pyarrow as pa
-    from polars.dependencies import torch
     from polars.lazyframe.engine_config import GPUEngine
     from polars.selectors import Selector
 

--- a/py-polars/polars/_utils/async_.py
+++ b/py-polars/polars/_utils/async_.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from collections.abc import Awaitable
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
+from polars._dependencies import _GEVENT_AVAILABLE
 from polars._utils.wrap import wrap_df
-from polars.dependencies import _GEVENT_AVAILABLE
 
 if TYPE_CHECKING:
     from asyncio.futures import Future

--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -15,6 +15,16 @@ from typing import (
 import polars._reexport as pl
 import polars._utils.construction as plc
 from polars import functions as F
+from polars._dependencies import (
+    _NUMPY_AVAILABLE,
+    _PYARROW_AVAILABLE,
+    _check_for_numpy,
+    _check_for_pandas,
+    dataclasses,
+)
+from polars._dependencies import numpy as np
+from polars._dependencies import pandas as pd
+from polars._dependencies import pyarrow as pa
 from polars._utils.construction.utils import (
     contains_nested,
     get_first_non_none,
@@ -42,16 +52,6 @@ from polars.datatypes import (
     parse_into_dtype,
     try_parse_into_dtype,
 )
-from polars.dependencies import (
-    _NUMPY_AVAILABLE,
-    _PYARROW_AVAILABLE,
-    _check_for_numpy,
-    _check_for_pandas,
-    dataclasses,
-)
-from polars.dependencies import numpy as np
-from polars.dependencies import pandas as pd
-from polars.dependencies import pyarrow as pa
 from polars.exceptions import DataOrientationWarning, ShapeError
 from polars.meta import thread_pool_size
 

--- a/py-polars/polars/_utils/construction/other.py
+++ b/py-polars/polars/_utils/construction/other.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from polars._dependencies import pyarrow as pa
 from polars._utils.construction.utils import get_first_non_none
-from polars.dependencies import pyarrow as pa
 
 if TYPE_CHECKING:
-    from polars.dependencies import pandas as pd
+    from polars._dependencies import pandas as pd
 
 
 def pandas_series_to_arrow(

--- a/py-polars/polars/_utils/construction/series.py
+++ b/py-polars/polars/_utils/construction/series.py
@@ -13,6 +13,14 @@ from typing import (
 
 import polars._reexport as pl
 import polars._utils.construction as plc
+from polars._dependencies import (
+    _PYARROW_AVAILABLE,
+    _check_for_numpy,
+    dataclasses,
+)
+from polars._dependencies import numpy as np
+from polars._dependencies import pandas as pd
+from polars._dependencies import pyarrow as pa
 from polars._utils.construction.dataframe import _sequence_of_dict_to_pydf
 from polars._utils.construction.utils import (
     get_first_non_none,
@@ -53,14 +61,6 @@ from polars.datatypes.constructor import (
     polars_type_to_constructor,
     py_type_to_constructor,
 )
-from polars.dependencies import (
-    _PYARROW_AVAILABLE,
-    _check_for_numpy,
-    dataclasses,
-)
-from polars.dependencies import numpy as np
-from polars.dependencies import pandas as pd
-from polars.dependencies import pyarrow as pa
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars._plr import PySeries
@@ -69,8 +69,8 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
     from polars import DataFrame, Series
+    from polars._dependencies import pandas as pd
     from polars._typing import PolarsDataType
-    from polars.dependencies import pandas as pd
 
 
 def sequence_to_pyseries(

--- a/py-polars/polars/_utils/construction/utils.py
+++ b/py-polars/polars/_utils/construction/utils.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Callable, get_type_hints
 
-from polars.dependencies import _check_for_pydantic, pydantic
+from polars._dependencies import _check_for_pydantic, pydantic
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/py-polars/polars/_utils/getitem.py
+++ b/py-polars/polars/_utils/getitem.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, Any, NoReturn, overload
 
 import polars._reexport as pl
 import polars.functions as F
+from polars._dependencies import _check_for_numpy
+from polars._dependencies import numpy as np
 from polars._utils.constants import U32_MAX
 from polars._utils.slice import PolarsSlice
 from polars._utils.various import qualified_type_name, range_to_slice
@@ -18,8 +20,6 @@ from polars.datatypes.classes import (
     UInt32,
     UInt64,
 )
-from polars.dependencies import _check_for_numpy
-from polars.dependencies import numpy as np
 from polars.meta.index_type import get_index_type
 
 if TYPE_CHECKING:

--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -28,6 +28,8 @@ from typing import (
 
 import polars as pl
 from polars import functions as F
+from polars._dependencies import _check_for_numpy, import_optional, subprocess
+from polars._dependencies import numpy as np
 from polars.datatypes import (
     Boolean,
     Date,
@@ -39,8 +41,6 @@ from polars.datatypes import (
     Time,
 )
 from polars.datatypes.group import FLOAT_DTYPES, INTEGER_DTYPES
-from polars.dependencies import _check_for_numpy, import_optional, subprocess
-from polars.dependencies import numpy as np
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, MutableMapping, Reversible

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -5,11 +5,11 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, TypedDict, get_args
 
+from polars._dependencies import json
 from polars._typing import EngineType
 from polars._utils.deprecation import deprecated
 from polars._utils.unstable import unstable
 from polars._utils.various import normalize_filepath
-from polars.dependencies import json
 from polars.lazyframe.engine_config import GPUEngine
 
 if TYPE_CHECKING:

--- a/py-polars/polars/convert/general.py
+++ b/py-polars/polars/convert/general.py
@@ -8,6 +8,9 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 
 import polars._reexport as pl
 from polars import functions as F
+from polars._dependencies import _check_for_pyarrow
+from polars._dependencies import pandas as pd
+from polars._dependencies import pyarrow as pa
 from polars._utils.construction.dataframe import (
     arrow_to_pydf,
     dict_to_pydf,
@@ -28,15 +31,14 @@ from polars._utils.various import (
 )
 from polars._utils.wrap import wrap_df, wrap_s
 from polars.datatypes import N_INFER_DEFAULT, Categorical, String
-from polars.dependencies import _check_for_pyarrow
-from polars.dependencies import pandas as pd
-from polars.dependencies import pyarrow as pa
 from polars.exceptions import NoDataError
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from polars import DataFrame, Series
+    from polars._dependencies import numpy as np
+    from polars._dependencies import torch
     from polars._typing import (
         ArrowArrayExportable,
         ArrowStreamExportable,
@@ -45,8 +47,6 @@ if TYPE_CHECKING:
         SchemaDefinition,
         SchemaDict,
     )
-    from polars.dependencies import numpy as np
-    from polars.dependencies import torch
     from polars.interchange.protocol import SupportsInterchange
 
 

--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -7,7 +7,7 @@ import re
 from textwrap import dedent
 from typing import TYPE_CHECKING
 
-from polars.dependencies import html
+from polars._dependencies import html
 
 if TYPE_CHECKING:
     from collections.abc import Iterable

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -30,6 +30,23 @@ from typing import (
 
 import polars._reexport as pl
 from polars import functions as F
+from polars._dependencies import (
+    _ALTAIR_AVAILABLE,
+    _GREAT_TABLES_AVAILABLE,
+    _PANDAS_AVAILABLE,
+    _PYARROW_AVAILABLE,
+    _check_for_numpy,
+    _check_for_pandas,
+    _check_for_pyarrow,
+    _check_for_torch,
+    altair,
+    great_tables,
+    import_optional,
+    torch,
+)
+from polars._dependencies import numpy as np
+from polars._dependencies import pandas as pd
+from polars._dependencies import pyarrow as pa
 from polars._typing import DbWriteMode, JaxExportType, TorchExportType
 from polars._utils.construction import (
     arrow_to_pydf,
@@ -82,23 +99,6 @@ from polars.datatypes import (
     UInt64,
 )
 from polars.datatypes.group import INTEGER_DTYPES
-from polars.dependencies import (
-    _ALTAIR_AVAILABLE,
-    _GREAT_TABLES_AVAILABLE,
-    _PANDAS_AVAILABLE,
-    _PYARROW_AVAILABLE,
-    _check_for_numpy,
-    _check_for_pandas,
-    _check_for_pyarrow,
-    _check_for_torch,
-    altair,
-    great_tables,
-    import_optional,
-    torch,
-)
-from polars.dependencies import numpy as np
-from polars.dependencies import pandas as pd
-from polars.dependencies import pyarrow as pa
 from polars.exceptions import (
     ColumnNotFoundError,
     InvalidOperationError,

--- a/py-polars/polars/dataframe/plotting.py
+++ b/py-polars/polars/dataframe/plotting.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 from typing import TYPE_CHECKING, Callable, Union
 
-from polars.dependencies import altair as alt
+from polars._dependencies import altair as alt
 
 if TYPE_CHECKING:
     import sys

--- a/py-polars/polars/datatypes/constructor.py
+++ b/py-polars/polars/datatypes/constructor.py
@@ -5,7 +5,7 @@ from decimal import Decimal as PyDecimal
 from typing import TYPE_CHECKING, Any, Callable
 
 from polars import datatypes as dt
-from polars.dependencies import numpy as np
+from polars._dependencies import numpy as np
 
 # Module not available when building docs
 try:

--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -9,6 +9,8 @@ from datetime import date, datetime, time, timedelta
 from decimal import Decimal as PyDecimal
 from typing import TYPE_CHECKING, Any, Optional, Union
 
+from polars._dependencies import numpy as np
+from polars._dependencies import pyarrow as pa
 from polars.datatypes.classes import (
     Array,
     Binary,
@@ -42,8 +44,6 @@ from polars.datatypes.classes import (
     UInt128,
     Unknown,
 )
-from polars.dependencies import numpy as np
-from polars.dependencies import pyarrow as pa
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars._plr import dtype_str_repr as _dtype_str_repr

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -21,6 +21,8 @@ from typing import (
 
 import polars._reexport as pl
 from polars import functions as F
+from polars._dependencies import _check_for_numpy
+from polars._dependencies import numpy as np
 from polars._utils.convert import negate_duration_string, parse_as_duration_string
 from polars._utils.deprecation import (
     deprecate_renamed_parameter,
@@ -47,8 +49,6 @@ from polars.datatypes import (
     Int64,
     parse_into_datatype_expr,
 )
-from polars.dependencies import _check_for_numpy
-from polars.dependencies import numpy as np
 from polars.exceptions import (
     CustomUFuncWarning,
     OutOfBoundsError,

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, Any, Callable, overload
 import polars._reexport as pl
 import polars.functions as F
 import polars.selectors as cs
+from polars._dependencies import _check_for_numpy
+from polars._dependencies import numpy as np
 from polars._utils.async_ import _AioDataFrameResult, _GeventDataFrameResult
 from polars._utils.deprecation import (
     deprecate_renamed_parameter,
@@ -22,8 +24,6 @@ from polars._utils.various import extend_bool, qualified_type_name
 from polars._utils.wrap import wrap_df, wrap_expr, wrap_s
 from polars.datatypes import DTYPE_TEMPORAL_UNITS, Date, Datetime, Int64
 from polars.datatypes._parse import parse_into_datatype_expr
-from polars.dependencies import _check_for_numpy
-from polars.dependencies import numpy as np
 from polars.lazyframe.opt_flags import (
     DEFAULT_QUERY_OPT_FLAGS,
     forward_old_opt_flags,

--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -7,17 +7,17 @@ from typing import TYPE_CHECKING, Any
 from zoneinfo import ZoneInfo
 
 import polars._reexport as pl
-from polars._utils.wrap import wrap_expr
-from polars.datatypes import Date, Datetime, Duration
-from polars.datatypes.convert import DataTypeMappings
-from polars.dependencies import (
+from polars._dependencies import (
     _check_for_numpy,
     _check_for_pytz,
     _check_for_torch,
     pytz,
     torch,
 )
-from polars.dependencies import numpy as np
+from polars._dependencies import numpy as np
+from polars._utils.wrap import wrap_expr
+from polars.datatypes import Date, Datetime, Duration
+from polars.datatypes.convert import DataTypeMappings
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars._plr as plr

--- a/py-polars/polars/io/_utils.py
+++ b/py-polars/polars/io/_utils.py
@@ -7,12 +7,12 @@ from io import BytesIO, StringIO
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, overload
 
+from polars._dependencies import _FSSPEC_AVAILABLE, fsspec
 from polars._utils.various import (
     is_int_sequence,
     is_str_sequence,
     normalize_filepath,
 )
-from polars.dependencies import _FSSPEC_AVAILABLE, fsspec
 from polars.exceptions import NoDataError
 
 if TYPE_CHECKING:

--- a/py-polars/polars/io/cloud/credential_provider/_providers.py
+++ b/py-polars/polars/io/cloud/credential_provider/_providers.py
@@ -23,7 +23,7 @@ from polars._utils.logging import eprint, verbose
 from polars.io.cloud._utils import NoPickleOption
 
 if TYPE_CHECKING:
-    from polars.dependencies import boto3
+    from polars._dependencies import boto3
 
     if sys.version_info >= (3, 10):
         from typing import TypeAlias

--- a/py-polars/polars/io/database/_cursor_proxies.py
+++ b/py-polars/polars/io/database/_cursor_proxies.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from polars.dependencies import import_optional
+from polars._dependencies import import_optional
 from polars.io.database._utils import _run_async
 
 if TYPE_CHECKING:

--- a/py-polars/polars/io/database/_utils.py
+++ b/py-polars/polars/io/database/_utils.py
@@ -4,9 +4,9 @@ import re
 from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
+from polars._dependencies import import_optional
 from polars._utils.various import parse_version
 from polars.convert import from_arrow
-from polars.dependencies import import_optional
 from polars.exceptions import ModuleUpgradeRequiredError
 
 if TYPE_CHECKING:

--- a/py-polars/polars/io/database/functions.py
+++ b/py-polars/polars/io/database/functions.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Literal, overload
 
+from polars._dependencies import import_optional
 from polars._utils.unstable import issue_unstable_warning
 from polars._utils.various import qualified_type_name
 from polars.datatypes import N_INFER_DEFAULT
-from polars.dependencies import import_optional
 from polars.io.database._cursor_proxies import ODBCCursorProxy
 from polars.io.database._executor import ConnectionExecutor
 

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -5,9 +5,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from polars._dependencies import _DELTALAKE_AVAILABLE, deltalake
 from polars.datatypes import Null, Time
 from polars.datatypes.convert import unpack_dtypes
-from polars.dependencies import _DELTALAKE_AVAILABLE, deltalake
 from polars.io.cloud._utils import _get_path_scheme
 from polars.io.parquet import scan_parquet
 from polars.io.pyarrow_dataset.functions import scan_pyarrow_dataset

--- a/py-polars/polars/io/iceberg/_utils.py
+++ b/py-polars/polars/io/iceberg/_utils.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 
     from polars import DataFrame, Series
 else:
-    from polars.dependencies import pyiceberg
+    from polars._dependencies import pyiceberg
 
 _temporal_conversions: dict[str, Callable[..., datetime | date]] = {
     "to_py_date": to_py_date,

--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -7,6 +7,7 @@ from typing import IO, TYPE_CHECKING, Any, Literal
 
 import polars._reexport as pl
 import polars.functions as F
+from polars._dependencies import import_optional
 from polars._utils.deprecation import deprecate_renamed_parameter
 from polars._utils.various import (
     is_path_or_str_sequence,
@@ -14,7 +15,6 @@ from polars._utils.various import (
     normalize_filepath,
 )
 from polars._utils.wrap import wrap_df, wrap_ldf
-from polars.dependencies import import_optional
 from polars.io._utils import (
     is_glob_pattern,
     is_local_file,

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -8,6 +8,7 @@ from typing import IO, TYPE_CHECKING, Any
 
 import polars.functions as F
 from polars import concat as plconcat
+from polars._dependencies import import_optional
 from polars._utils.deprecation import (
     deprecate_renamed_parameter,
     issue_deprecation_warning,
@@ -20,7 +21,6 @@ from polars._utils.various import (
 )
 from polars._utils.wrap import wrap_ldf
 from polars.convert import from_arrow
-from polars.dependencies import import_optional
 from polars.io._utils import (
     prepare_file_arg,
 )

--- a/py-polars/polars/io/pyarrow_dataset/anonymous_scan.py
+++ b/py-polars/polars/io/pyarrow_dataset/anonymous_scan.py
@@ -4,7 +4,7 @@ from functools import partial
 from typing import TYPE_CHECKING
 
 import polars._reexport as pl
-from polars.dependencies import pyarrow as pa
+from polars._dependencies import pyarrow as pa
 
 if TYPE_CHECKING:
     from polars import DataFrame, LazyFrame

--- a/py-polars/polars/io/pyarrow_dataset/functions.py
+++ b/py-polars/polars/io/pyarrow_dataset/functions.py
@@ -7,7 +7,7 @@ from polars.io.pyarrow_dataset.anonymous_scan import _scan_pyarrow_dataset
 
 if TYPE_CHECKING:
     from polars import LazyFrame
-    from polars.dependencies import pyarrow as pa
+    from polars._dependencies import pyarrow as pa
 
 
 @unstable()

--- a/py-polars/polars/io/spreadsheet/_write_utils.py
+++ b/py-polars/polars/io/spreadsheet/_write_utils.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, overload
 
 from polars import functions as F
+from polars._dependencies import json
 from polars._utils.various import qualified_type_name
 from polars.datatypes import (
     Date,
@@ -16,7 +17,6 @@ from polars.datatypes import (
     Time,
 )
 from polars.datatypes.group import FLOAT_DTYPES, INTEGER_DTYPES
-from polars.dependencies import json
 from polars.exceptions import DuplicateError
 from polars.selectors import _expand_selector_dicts, _expand_selectors, numeric
 

--- a/py-polars/polars/io/spreadsheet/functions.py
+++ b/py-polars/polars/io/spreadsheet/functions.py
@@ -14,6 +14,7 @@ from typing import IO, TYPE_CHECKING, Any, Callable, NoReturn, overload
 import polars._reexport as pl
 from polars import from_arrow
 from polars import functions as F
+from polars._dependencies import import_optional
 from polars._utils.deprecation import (
     deprecate_renamed_parameter,
     issue_deprecation_warning,
@@ -32,7 +33,6 @@ from polars.datatypes import (
     UInt8,
 )
 from polars.datatypes.group import FLOAT_DTYPES, INTEGER_DTYPES, NUMERIC_DTYPES
-from polars.dependencies import import_optional
 from polars.exceptions import (
     ModuleUpgradeRequiredError,
     NoDataError,

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -24,6 +24,13 @@ from typing import (
 import polars._reexport as pl
 import polars.selectors as cs
 from polars import functions as F
+from polars._dependencies import (
+    _PYARROW_AVAILABLE,
+    import_optional,
+    subprocess,
+)
+from polars._dependencies import polars_cloud as pc
+from polars._dependencies import pyarrow as pa
 from polars._typing import (
     ParquetMetadata,
     PartitioningScheme,
@@ -89,13 +96,6 @@ from polars.datatypes import (
     parse_into_dtype,
 )
 from polars.datatypes.group import DataTypeGroup
-from polars.dependencies import (
-    _PYARROW_AVAILABLE,
-    import_optional,
-    subprocess,
-)
-from polars.dependencies import polars_cloud as pc
-from polars.dependencies import pyarrow as pa
 from polars.exceptions import PerformanceWarning
 from polars.interchange.protocol import CompatLevel
 from polars.lazyframe.engine_config import GPUEngine
@@ -124,6 +124,7 @@ if TYPE_CHECKING:
         import polars._plr as plr
 
     from polars import DataFrame, DataType, Expr
+    from polars._dependencies import numpy as np
     from polars._typing import (
         AsofJoinStrategy,
         ClosedInterval,
@@ -153,7 +154,6 @@ if TYPE_CHECKING:
         SyncOnCloseMethod,
         UniqueKeepStrategy,
     )
-    from polars.dependencies import numpy as np
     from polars.io.cloud import CredentialProviderFunction
     from polars.io.parquet import ParquetFieldOverwrites
 

--- a/py-polars/polars/ml/utilities.py
+++ b/py-polars/polars/ml/utilities.py
@@ -1,9 +1,9 @@
 from typing import Any
 
 from polars import DataFrame
+from polars._dependencies import numpy as np
 from polars._typing import IndexOrder
 from polars.datatypes import Array, List
-from polars.dependencies import numpy as np
 
 
 def frame_to_numpy(

--- a/py-polars/polars/series/plotting.py
+++ b/py-polars/polars/series/plotting.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 from typing import TYPE_CHECKING, Callable
 
-from polars.dependencies import altair as alt
+from polars._dependencies import altair as alt
 
 if TYPE_CHECKING:
     import sys

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -21,6 +21,20 @@ from typing import (
 
 import polars._reexport as pl
 from polars import functions as F
+from polars._dependencies import (
+    _ALTAIR_AVAILABLE,
+    _PYARROW_AVAILABLE,
+    _check_for_numpy,
+    _check_for_pandas,
+    _check_for_pyarrow,
+    _check_for_torch,
+    altair,
+    import_optional,
+    torch,
+)
+from polars._dependencies import numpy as np
+from polars._dependencies import pandas as pd
+from polars._dependencies import pyarrow as pa
 from polars._utils.construction import (
     arrow_to_pyseries,
     dataframe_to_pyseries,
@@ -84,20 +98,6 @@ from polars.datatypes import (
     supported_numpy_char_code,
 )
 from polars.datatypes._utils import dtype_to_init_repr
-from polars.dependencies import (
-    _ALTAIR_AVAILABLE,
-    _PYARROW_AVAILABLE,
-    _check_for_numpy,
-    _check_for_pandas,
-    _check_for_pyarrow,
-    _check_for_torch,
-    altair,
-    import_optional,
-    torch,
-)
-from polars.dependencies import numpy as np
-from polars.dependencies import pandas as pd
-from polars.dependencies import pyarrow as pa
 from polars.exceptions import ComputeError, ModuleUpgradeRequiredError, ShapeError
 from polars.interchange.protocol import CompatLevel
 from polars.series.array import ArrayNameSpace

--- a/py-polars/polars/sql/context.py
+++ b/py-polars/polars/sql/context.py
@@ -10,6 +10,9 @@ from typing import (
     overload,
 )
 
+from polars._dependencies import _check_for_pandas, _check_for_pyarrow
+from polars._dependencies import pandas as pd
+from polars._dependencies import pyarrow as pa
 from polars._typing import FrameType
 from polars._utils.deprecation import deprecate_renamed_parameter
 from polars._utils.pycapsule import is_pycapsule
@@ -18,9 +21,6 @@ from polars._utils.various import _get_stack_locals, qualified_type_name
 from polars._utils.wrap import wrap_ldf
 from polars.convert import from_arrow, from_pandas
 from polars.dataframe import DataFrame
-from polars.dependencies import _check_for_pandas, _check_for_pyarrow
-from polars.dependencies import pandas as pd
-from polars.dependencies import pyarrow as pa
 from polars.lazyframe import LazyFrame
 from polars.series import Series
 

--- a/py-polars/polars/testing/parametric/__init__.py
+++ b/py-polars/polars/testing/parametric/__init__.py
@@ -1,4 +1,4 @@
-from polars.dependencies import _HYPOTHESIS_AVAILABLE
+from polars._dependencies import _HYPOTHESIS_AVAILABLE
 
 if not _HYPOTHESIS_AVAILABLE:
     msg = (

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -210,7 +210,7 @@ ignore = [
 allowed-confusables = ["µ"]
 
 [tool.ruff.lint.per-file-ignores]
-"dependencies.py" = ["ICN001"]
+"_dependencies.py" = ["ICN001"]
 "tests/**/*.py" = ["D100", "D102", "D103", "B018", "FBT001"]
 
 [tool.ruff.lint.pycodestyle]

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -16,9 +16,9 @@ from pydantic import BaseModel, Field, TypeAdapter
 
 import polars as pl
 import polars.selectors as cs
+from polars._dependencies import dataclasses, pydantic
 from polars._utils.construction.utils import try_get_type_hints
 from polars.datatypes import numpy_char_code_to_dtype
-from polars.dependencies import dataclasses, pydantic
 from polars.exceptions import DuplicateError, ShapeError
 from polars.testing import assert_frame_equal, assert_series_equal
 from tests.unit.utils.pycapsule_utils import PyCapsuleArrayHolder, PyCapsuleStreamHolder

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -268,10 +268,10 @@ def test_from_arrow_with_bigquery_metadata() -> None:
 
 
 def test_from_optional_not_available() -> None:
-    from polars.dependencies import _LazyModule
+    from polars._dependencies import _LazyModule
 
     # proxy module is created dynamically if the required module is not available
-    # (see the polars.dependencies source code for additional detail/comments)
+    # (see the polars._dependencies source code for additional detail/comments)
 
     np = _LazyModule("numpy", module_available=False)
     with pytest.raises(ImportError, match=r"np\.array requires 'numpy'"):

--- a/py-polars/tests/unit/ml/test_to_jax.py
+++ b/py-polars/tests/unit/ml/test_to_jax.py
@@ -6,7 +6,7 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
-from polars.dependencies import _lazy_import
+from polars._dependencies import _lazy_import
 
 # don't import jax until an actual test is triggered (the decorator already
 # ensures the tests aren't run locally; this avoids premature local import)

--- a/py-polars/tests/unit/ml/test_torch.py
+++ b/py-polars/tests/unit/ml/test_torch.py
@@ -7,7 +7,7 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
-from polars.dependencies import _lazy_import
+from polars._dependencies import _lazy_import
 from polars.testing import assert_frame_equal, assert_series_equal
 
 # don't import torch until an actual test is triggered (the decorator already

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -202,7 +202,7 @@ def test_init_structured_objects() -> None:
     # validate init from dataclass, namedtuple, and pydantic model objects
     from typing import NamedTuple
 
-    from polars.dependencies import dataclasses, pydantic
+    from polars._dependencies import dataclasses, pydantic
 
     @dataclasses.dataclass
     class TeaShipmentDC:

--- a/py-polars/tests/unit/test_async.py
+++ b/py-polars/tests/unit/test_async.py
@@ -9,7 +9,7 @@ from typing import Any, Callable
 import pytest
 
 import polars as pl
-from polars.dependencies import gevent
+from polars._dependencies import gevent
 from polars.exceptions import ColumnNotFoundError
 
 pytestmark = pytest.mark.slow()

--- a/py-polars/tests/unit/test_ds_plugin.py
+++ b/py-polars/tests/unit/test_ds_plugin.py
@@ -1,7 +1,7 @@
 import pytest
 
 import polars as pl
-from polars.dependencies import _lazy_import
+from polars._dependencies import _lazy_import
 from polars.testing import assert_frame_equal
 
 # don't import polars_ds until an actual test is triggered (the decorator already

--- a/py-polars/tests/unit/test_polars_import.py
+++ b/py-polars/tests/unit/test_polars_import.py
@@ -86,7 +86,7 @@ def test_polars_import() -> None:
     ):
         # ensure that we have not broken lazy-loading (numpy, pandas, pyarrow, etc).
         lazy_modules = [
-            dep for dep in pl.dependencies.__all__ if not dep.startswith("_")
+            dep for dep in pl._dependencies.__all__ if not dep.startswith("_")
         ]
         for mod in lazy_modules:
             not_imported = not df_import["import"].str.starts_with(mod).any()


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/24524.

This is supposed to be internal but messes up autocomplete like PyCharm.