### PR TITLE
chore: Use cargo-run to call dsl-schema script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,8 +151,7 @@ fix:
 
 .PHONY: update-dsl-schema-hashes
 update-dsl-schema-hashes:  ## Update the DSL schema hashes file
-	cargo build --all-features
-	./target/debug/dsl-schema update-hashes
+	cargo run --all-features --bin dsl-schema update-hashes
 
 .PHONY: pre-commit
 pre-commit: fmt clippy clippy-default  ## Run all code quality checks


### PR DESCRIPTION
When `$CARGO_TARGET_DIR` is different from the default, running `make update-dsl-schema-hashes` fails with the error:

```
./target/debug/dsl-schema update-hashes
bash: line 1: ./target/debug/dsl-schema: No such file or directory
make: *** [Makefile:155: update-dsl-schema-hashes] Error 127
```

This patch updates the Makefile such that we now use Cargo to find and run the script.