### PR TITLE
fix: Newline escaping in streaming show_graph

### DIFF
--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -128,7 +128,7 @@ pub fn fmt_exprs(
         }
 
         for (name, expr) in formatted {
-            write!(f, "{name:>max_name_width$} = {expr:<max_expr_width$}\n").unwrap();
+            writeln!(f, "{name:>max_name_width$} = {expr:<max_expr_width$}").unwrap();
         }
     } else {
         let Some(e) = exprs.first() else {

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -128,7 +128,7 @@ pub fn fmt_exprs(
         }
 
         for (name, expr) in formatted {
-            write!(f, "{name:>max_name_width$} = {expr:<max_expr_width$}\\n").unwrap();
+            write!(f, "{name:>max_name_width$} = {expr:<max_expr_width$}\n").unwrap();
         }
     } else {
         let Some(e) = exprs.first() else {
@@ -138,7 +138,7 @@ pub fn fmt_exprs(
         fmt_expr(f, e, expr_arena).unwrap();
 
         for e in &exprs[1..] {
-            f.write_str("\\n").unwrap();
+            f.write_str("\n").unwrap();
             fmt_expr(f, e, expr_arena).unwrap();
         }
     }


### PR DESCRIPTION
After https://github.com/pola-rs/polars/pull/24532 we were doing some double-escaping.