### PR TITLE
refactor(rust): Remove tokio-util dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3056,7 +3056,6 @@ dependencies = [
  "proptest",
  "rand 0.9.1",
  "tokio",
- "tokio-util",
  "version_check",
 ]
 
@@ -3309,7 +3308,6 @@ dependencies = [
  "strum_macros 0.27.1",
  "tempfile",
  "tokio",
- "tokio-util",
  "url",
  "zstd",
 ]
@@ -3630,7 +3628,6 @@ dependencies = [
  "recursive",
  "slotmap",
  "tokio",
- "tokio-util",
  "version_check",
 ]
 
@@ -5193,10 +5190,7 @@ checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
- "futures-io",
  "futures-sink",
- "futures-util",
- "hashbrown 0.15.4",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,6 @@ strength_reduce = "0.2"
 strum = "0.27"
 strum_macros = "0.27"
 tokio = { version = "1.44", default-features = false }
-tokio-util = "0.7.8"
 unicode-normalization = "0.1.24"
 unicode-reverse = "1.0.8"
 url = "2.4"

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -49,7 +49,6 @@ simdutf8 = { workspace = true, optional = true }
 strum = { workspace = true, optional = true }
 strum_macros = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["fs", "net", "rt-multi-thread", "time", "sync"], optional = true }
-tokio-util = { workspace = true, features = ["io", "io-util"], optional = true }
 url = { workspace = true, optional = true }
 zstd = { workspace = true, optional = true }
 
@@ -114,7 +113,6 @@ async = [
   "async-trait",
   "futures",
   "tokio",
-  "tokio-util",
   "polars-error/regex",
   "polars-parquet?/async",
 ]

--- a/crates/polars-stream/Cargo.toml
+++ b/crates/polars-stream/Cargo.toml
@@ -31,7 +31,6 @@ rayon = { workspace = true }
 recursive = { workspace = true }
 slotmap = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
-tokio-util = { workspace = true, features = ["rt"] }
 
 polars-core = { workspace = true, features = ["partition_by"] }
 polars-error = { workspace = true }

--- a/crates/polars-stream/src/nodes/io_sinks/csv.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/csv.rs
@@ -19,6 +19,7 @@ use crate::morsel::MorselSeq;
 use crate::nodes::io_sinks::parallelize_receive_task;
 use crate::nodes::io_sinks::phase::PhaseOutcome;
 use crate::nodes::{JoinHandle, TaskPriority};
+use crate::utils::task_handles_ext::AbortOnDropHandle;
 
 type IOSend = Linearizer<Priority<Reverse<MorselSeq>, Vec<u8>>>;
 
@@ -30,7 +31,7 @@ pub struct CsvSinkNode {
     cloud_options: Option<CloudOptions>,
 
     io_tx: Option<Sender<IOSend>>,
-    io_task: Option<tokio_util::task::AbortOnDropHandle<PolarsResult<()>>>,
+    io_task: Option<AbortOnDropHandle<PolarsResult<()>>>,
 }
 impl CsvSinkNode {
     pub fn new(
@@ -116,7 +117,7 @@ impl SinkNode for CsvSinkNode {
         });
 
         self.io_tx = Some(io_tx);
-        self.io_task = Some(tokio_util::task::AbortOnDropHandle::new(io_task));
+        self.io_task = Some(AbortOnDropHandle(io_task));
 
         Ok(())
     }

--- a/crates/polars-stream/src/nodes/io_sinks/ipc.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/ipc.rs
@@ -28,6 +28,7 @@ use crate::async_primitives::linearizer::Linearizer;
 use crate::execute::StreamingExecutionState;
 use crate::nodes::io_sinks::phase::PhaseOutcome;
 use crate::nodes::{JoinHandle, TaskPriority};
+use crate::utils::task_handles_ext::AbortOnDropHandle;
 
 pub struct IpcSinkNode {
     target: SinkTarget,
@@ -38,7 +39,7 @@ pub struct IpcSinkNode {
     cloud_options: Option<CloudOptions>,
 
     io_tx: Option<Sender<(Vec<EncodedData>, EncodedData)>>,
-    io_task: Option<tokio_util::task::AbortOnDropHandle<PolarsResult<()>>>,
+    io_task: Option<AbortOnDropHandle<PolarsResult<()>>>,
 }
 
 impl IpcSinkNode {
@@ -114,7 +115,7 @@ impl SinkNode for IpcSinkNode {
         });
 
         self.io_tx = Some(io_tx);
-        self.io_task = Some(tokio_util::task::AbortOnDropHandle::new(io_task));
+        self.io_task = Some(AbortOnDropHandle(io_task));
 
         Ok(())
     }

--- a/crates/polars-stream/src/nodes/io_sinks/json.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/json.rs
@@ -16,6 +16,7 @@ use crate::morsel::MorselSeq;
 use crate::nodes::io_sinks::parallelize_receive_task;
 use crate::nodes::io_sinks::phase::PhaseOutcome;
 use crate::nodes::{JoinHandle, TaskPriority};
+use crate::utils::task_handles_ext::AbortOnDropHandle;
 
 type IOSend = Linearizer<Priority<Reverse<MorselSeq>, Vec<u8>>>;
 
@@ -25,7 +26,7 @@ pub struct NDJsonSinkNode {
     cloud_options: Option<CloudOptions>,
 
     io_tx: Option<Sender<IOSend>>,
-    io_task: Option<tokio_util::task::AbortOnDropHandle<PolarsResult<()>>>,
+    io_task: Option<AbortOnDropHandle<PolarsResult<()>>>,
 }
 impl NDJsonSinkNode {
     pub fn new(
@@ -86,7 +87,7 @@ impl SinkNode for NDJsonSinkNode {
         });
 
         self.io_tx = Some(io_tx);
-        self.io_task = Some(tokio_util::task::AbortOnDropHandle::new(io_task));
+        self.io_task = Some(AbortOnDropHandle(io_task));
 
         Ok(())
     }

--- a/crates/polars-stream/src/nodes/io_sinks/parquet.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/parquet.rs
@@ -32,6 +32,7 @@ use crate::async_primitives::linearizer::Linearizer;
 use crate::execute::StreamingExecutionState;
 use crate::nodes::io_sinks::phase::PhaseOutcome;
 use crate::nodes::{JoinHandle, TaskPriority};
+use crate::utils::task_handles_ext::AbortOnDropHandle;
 
 pub struct ParquetSinkNode {
     target: SinkTarget,
@@ -49,7 +50,7 @@ pub struct ParquetSinkNode {
     metrics: Arc<Mutex<Option<WriteMetrics>>>,
 
     io_tx: Option<crate::async_primitives::connector::Sender<Vec<Vec<CompressedPage>>>>,
-    io_task: Option<tokio_util::task::AbortOnDropHandle<PolarsResult<()>>>,
+    io_task: Option<AbortOnDropHandle<PolarsResult<()>>>,
 }
 
 impl ParquetSinkNode {
@@ -168,7 +169,7 @@ impl SinkNode for ParquetSinkNode {
         });
 
         self.io_tx = Some(io_tx);
-        self.io_task = Some(tokio_util::task::AbortOnDropHandle::new(io_task));
+        self.io_task = Some(AbortOnDropHandle(io_task));
 
         Ok(())
     }

--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -36,7 +36,6 @@ proptest = { workspace = true }
 rand = { workspace = true }
 # used to test async readers
 tokio = { workspace = true, features = ["macros", "rt", "fs", "io-util"] }
-tokio-util = { workspace = true, features = ["compat"] }
 
 [build-dependencies]
 version_check = { workspace = true }


### PR DESCRIPTION
We had this dependency for one struct, which we already had in-tree as well.

Supersedes https://github.com/pola-rs/polars/pull/24611.