### PR TITLE
feat: Log which file the schema was sourced from, and which file caused an extra column error

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
@@ -572,6 +572,13 @@ passing a schema can allow \
 this scan to succeed with an empty DataFrame.",
                         )?;
 
+                        if verbose() {
+                            eprintln!(
+                                "sourcing parquet scan file schema from: '{}'",
+                                first_scan_source.to_include_path_name()
+                            )
+                        }
+
                         let (file_info, mut metadata) = scans::parquet_file_info(
                             first_scan_source,
                             unified_scan_args.row_index.as_ref(),
@@ -589,8 +596,18 @@ this scan to succeed with an empty DataFrame.",
             },
             #[cfg(feature = "ipc")]
             FileScanDsl::Ipc { options } => (|| {
+                let first_scan_source =
+                    require_first_source("failed to retrieve first file schema (ipc)", "")?;
+
+                if verbose() {
+                    eprintln!(
+                        "sourcing ipc scan file schema from: '{}'",
+                        first_scan_source.to_include_path_name()
+                    )
+                }
+
                 let (file_info, md) = scans::ipc_file_info(
-                    require_first_source("failed to retrieve first file schema (ipc)", "")?,
+                    first_scan_source,
                     unified_scan_args.row_index.as_ref(),
                     cloud_options,
                 )?;
@@ -614,10 +631,20 @@ this scan to succeed with an empty DataFrame.",
                         unified_scan_args.missing_columns_policy = MissingColumnsPolicy::Insert;
                     }
 
+                    let first_scan_source =
+                        require_first_source("failed to retrieve file schemas (csv)", "")?;
+
+                    if verbose() {
+                        eprintln!(
+                            "sourcing csv scan file schema from: '{}'",
+                            first_scan_source.to_include_path_name()
+                        )
+                    }
+
                     PolarsResult::Ok((
                         scans::csv_file_info(
                             sources,
-                            require_first_source("failed to retrieve file schemas (csv)", "")?,
+                            first_scan_source,
                             unified_scan_args.row_index.as_ref(),
                             &mut options,
                             cloud_options,
@@ -629,10 +656,20 @@ this scan to succeed with an empty DataFrame.",
             },
             #[cfg(feature = "json")]
             FileScanDsl::NDJson { options } => (|| {
+                let first_scan_source =
+                    require_first_source("failed to retrieve first file schema (ndjson)", "")?;
+
+                if verbose() {
+                    eprintln!(
+                        "sourcing ndjson scan file schema from: '{}'",
+                        first_scan_source.to_include_path_name()
+                    )
+                }
+
                 PolarsResult::Ok((
                     scans::ndjson_file_info(
                         sources,
-                        require_first_source("failed to retrieve first file schema (ndjson)", "")?,
+                        first_scan_source,
                         unified_scan_args.row_index.as_ref(),
                         &options,
                         cloud_options,

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/components/errors.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/components/errors.rs
@@ -8,12 +8,13 @@ pub fn missing_column_err(missing_column_name: &str) -> PolarsError {
     )
 }
 
-pub fn extra_column_err(extra_column_name: &str) -> PolarsError {
+pub fn extra_column_err(extra_column_name: &str, file_path: &str) -> PolarsError {
     polars_err!(
         SchemaMismatch:
         "extra column in file outside of expected schema: {}, \
         hint: specify this column in the schema, or pass \
-        extra_columns='ignore' in scan options",
-        extra_column_name,
+        extra_columns='ignore' in scan options. File containing extra column: \
+        '{}'.",
+        extra_column_name, file_path,
     )
 }

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/components/forbid_extra_columns.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/components/forbid_extra_columns.rs
@@ -35,6 +35,7 @@ impl ForbidExtraColumns {
         &self,
         file_schema: &Schema,
         file_iceberg_schema: Option<&IcebergSchema>,
+        file_path: &str,
     ) -> PolarsResult<()> {
         let Some(extra_column_name) = (match self {
             Self::Plain(schema) => file_schema.iter_names().find(|x| !schema.contains(x)),
@@ -46,6 +47,6 @@ impl ForbidExtraColumns {
             return Ok(());
         };
 
-        Err(extra_column_err(extra_column_name))
+        Err(extra_column_err(extra_column_name, file_path))
     }
 }

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/tasks/reader_starter.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/tasks/reader_starter.rs
@@ -610,8 +610,11 @@ async fn start_reader_impl(
 
     if let Some(forbid_extra_columns) = forbid_extra_columns {
         if let Ok(this_file_schema) = file_schema_rx.unwrap().recv().await {
-            forbid_extra_columns
-                .check_file_schema(&this_file_schema, file_iceberg_schema.as_ref())?;
+            forbid_extra_columns.check_file_schema(
+                &this_file_schema,
+                file_iceberg_schema.as_ref(),
+                scan_source.as_scan_source_ref().to_include_path_name(),
+            )?;
         } else {
             drop(reader_output_port);
             return Err(reader_handle.await.unwrap_err());

--- a/py-polars/tests/unit/io/test_multiscan.py
+++ b/py-polars/tests/unit/io/test_multiscan.py
@@ -640,7 +640,7 @@ def test_extra_columns_not_ignored_22218() -> None:
         pl.exceptions.SchemaError,
         match="extra column in file outside of expected schema: c, hint: specify .*or pass",
     ):
-        (pl.scan_parquet(files, missing_columns="insert").select(pl.all()).collect())
+        pl.scan_parquet(files, missing_columns="insert").select(pl.all()).collect()
 
     assert_frame_equal(
         pl.scan_parquet(


### PR DESCRIPTION
* To see which file the schema of the scan was inferred from, set `POLARS_VERBOSE=1` and search for the following:
`sourcing parquet scan file schema from: `

When encountering an error due to an extra column, the file path will now be included in the error message:

```
polars.exceptions.SchemaError: extra column in file outside of expected schema: c, hint: specify this column in the schema, or pass extra_columns='ignore' in scan options. File containing extra column: '/private/var/folders/40/dbrh5w851n163_9yfmf8v2t40000gn/T/pytest-of-nxs/pytest-203/test_extra_columns_not_ignored0/2'
```
