### PR TITLE
fix(python): Require PyArrow for SQLite and Snowflake ADBC drivers in `write_database`. Convert data to PyArrow for Snowflake driver

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4235,7 +4235,8 @@ class DataFrame:
               method (though this will eventually be phased out in favor of a native
               solution).
             * Setting `engine` to "adbc" inserts using the ADBC cursor's `adbc_ingest`
-              method.
+              method. Note that when passing an instantiated connection object, PyArrow
+              is required for SQLite and Snowflake drivers.
 
         Examples
         --------
@@ -4295,6 +4296,7 @@ class DataFrame:
             from polars.io.database._utils import (
                 _get_adbc_module_name_from_uri,
                 _import_optional_adbc_driver,
+                _is_adbc_snowflake_conn,
                 _open_adbc_connection,
             )
 
@@ -4342,15 +4344,31 @@ class DataFrame:
                 catalog, db_schema, unpacked_table_name = unpack_table_name(table_name)
                 n_rows: int
 
-                adbc_module_name = (
-                    _get_adbc_module_name_from_uri(connection)
-                    if isinstance(connection, str)
-                    else connection_module_root
-                )
-                adbc_driver = _import_optional_adbc_driver(
-                    adbc_module_name, dbapi_submodule=False
-                )
-                adbc_driver_str_version = getattr(adbc_driver, "__version__", "0.0")
+                # We can reliably introspect the underlying driver from a URI
+                # We can also introspect instiated connections when PyArrow is installed
+                # Otherwise, the underlying driver is unknown
+                # Ref: https://github.com/apache/arrow-adbc/issues/2828
+                if isinstance(connection, str):
+                    adbc_module_name = _get_adbc_module_name_from_uri(connection)
+                elif _PYARROW_AVAILABLE:
+                    adbc_module_name = (
+                        f"adbc_driver_{conn.adbc_get_info()['vendor_name'].lower()}"
+                    )
+                else:
+                    adbc_module_name = "Unknown"
+
+                if adbc_module_name != "Unknown":
+                    adbc_driver = _import_optional_adbc_driver(
+                        adbc_module_name, dbapi_submodule=False
+                    )
+                    adbc_driver_str_version = getattr(adbc_driver, "__version__", "0.0")
+                else:
+                    adbc_driver = "Unknown"
+                    # If we can't introspect the driver, guess that it has the same
+                    # version as the driver manager. This is what happens by default
+                    # when installed
+                    adbc_driver_str_version = driver_manager_str_version
+
                 adbc_driver_version = parse_version(adbc_driver_str_version)
 
                 if adbc_module_name.split("_")[-1] == "sqlite":
@@ -4366,9 +4384,27 @@ class DataFrame:
                         cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
                         mode = "create"
 
+                # For Snowflake, we convert to PyArrow until string_view columns can be
+                # written. Ref: https://github.com/apache/arrow-adbc/issues/3420
+                is_snowflake_driver = (
+                    "snowflake" in adbc_module_name
+                    if _PYARROW_AVAILABLE
+                    else _is_adbc_snowflake_conn(conn)
+                )
+                if is_snowflake_driver and not _PYARROW_AVAILABLE:
+                    msg = (
+                        "write_database with Snowflake driver requires 'pyarrow'.\n"
+                        "Please install using the command `pip install pyarrow`."
+                    )
+                    raise ModuleNotFoundError(msg)
+
                 # As of adbc_driver_manager 1.6.0, adbc_ingest can take a Polars
                 # DataFrame via the PyCapsule interface
-                data = self if driver_manager_version >= (1, 6) else self.to_arrow()
+                data = (
+                    self
+                    if (driver_manager_version >= (1, 6)) and not is_snowflake_driver
+                    else self.to_arrow()
+                )
 
                 # use of schema-qualified table names was released in
                 # adbc-driver-manager 0.7.0 and is working without bugs from driver
@@ -4383,7 +4419,11 @@ class DataFrame:
                         **(engine_options or {}),
                     )
                 elif db_schema is not None:
-                    adbc_driver_pypi_name = adbc_module_name.replace("_", "-")
+                    adbc_driver_pypi_name = (
+                        adbc_module_name.replace("_", "-")
+                        if adbc_module_name != "Unknown"
+                        else "adbc-driver-<driver>"
+                    )
                     msg = (
                         "use of schema-qualified table names requires "
                         "adbc-driver-manager version >= 0.7.0, found "


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/24433

The ADBC Snowflake driver cannot handle Polars' string view column type and writes fail with this error. This was regressed in https://github.com/pola-rs/polars/pull/24136 when `adbc_ingest` started accepting a PyCapsule interface object (i.e. Polars DataFrame) and the PyArrow conversion was removed. So, for the Snowflake driver, the data must still be converted to PyArrow and into the large string type (so the PyArrow requirement is re-introduced).

Furthermore, instantiated ADBC connection objects passed into `write_database` cannot be reliably introspected without PyArrow as they are all of type `adbc_driver_manager.dbapi.Connection` and the underlying driver is not known. Because SQLite databases don't have a schema (and we do `catalog, db_schema = db_schema, None`), they also require PyArrow to be introspected.

I was able to introspect the Snowflake driver in a little bit of a hacky way without PyArrow and a suitable message is raised.

For the remainder of the drivers (and since ADBC driver manager version 1.6.0), they still do **not** require PyArrow.

----
### Additional detail

As per https://github.com/pola-rs/polars/issues/24433#issuecomment-3322293776, a better long-term fix could be to allow setting the Compat Level when using the Arrow C stream interface - this PR fixes the immediate regression.

Related ADBC feature requests:
https://github.com/apache/arrow-adbc/issues/2828 - driver introspection without PyArrow - likely depends on addition of a union type to Polars
https://github.com/apache/arrow-adbc/issues/3420 - write Polars DataFrame with string view columns or covert them to large_string on ADBC side
