### PR TITLE
chore: Remove PyOdide from release for now

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -402,76 +402,8 @@ jobs:
           name: wheel-${{ matrix.package }}-${{ matrix.os }}-${{ matrix.architecture }}
           path: dist/*.whl
 
-  build-wheel-pyodide:
-    name: build-wheels (polars, pyodide, wasm32)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.sha }}
-
-      # Avoid potential out-of-memory errors
-      - name: Set swap space for Linux
-        uses: pierotofy/set-swap-space@master
-        with:
-          swap-size-gb: 10
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install yq
-        run: pip install yq
-
-      - name: Update runtime package and module names
-        run: |
-          mv py-polars/_polars_runtime_64 py-polars/_polars_runtime_32
-          tomlq -i -t ".project.name = \"polars-runtime-32\"" py-polars/pyproject.toml
-          tomlq -i -t ".lib.name = \"_polars_runtime_32\"" py-polars/Cargo.toml
-          sed -i "s/pub fn _polars_runtime_64/pub fn _polars_runtime_32/" crates/polars-python/src/c_api/mod.rs
-
-      - name: Disable incompatible features
-        env:
-            FEATURES: csv|ipc|ipc_streaming|parquet|async|json|extract_jsonpath|catalog|cloud|polars_cloud|tokio|clipboard|decompress|new_streaming
-        run: |
-          sed -i 's/serde_json = { workspace = true, optional = true }/serde_json = { workspace = true }/' crates/polars-python/Cargo.toml
-          sed -i 's/"serde_json", //' crates/polars-python/Cargo.toml
-          sed -E -i "/^  \"(${FEATURES})\",$/d" crates/polars-python/Cargo.toml py-polars/Cargo.toml
-
-      - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v14
-        with:
-          # This should match the exact version of Emscripten used by Pyodide
-          # UPDATE; set to latest due to breaking build
-          version: latest
-
-      - name: Set CFLAGS and RUSTFLAGS for wasm32
-        run: |
-            echo "CFLAGS=-fPIC" >> $GITHUB_ENV
-            echo "RUSTFLAGS=-C link-self-contained=no" >> $GITHUB_ENV
-
-      - name: Build wheel
-        uses: PyO3/maturin-action@v1
-        with:
-          command: build
-          target: wasm32-unknown-emscripten
-          args: >
-            --profile dist-release
-            --manifest-path py-polars/Cargo.toml
-            --interpreter python3.10
-            --out wasm-dist
-          maturin-version: 1.8.3
-
-      - name: Upload wheel
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheel-polars-emscripten-wasm32
-          path: wasm-dist/*.whl
-
   publish-to-pypi:
-    needs: [base-package, create-sdist, build-wheels, build-wheel-pyodide]
+    needs: [base-package, create-sdist, build-wheels]
     environment:
       name: release-python
       url: https://pypi.org/project/polars
@@ -496,7 +428,7 @@ jobs:
           verbose: true
 
   publish-to-github:
-    needs: [publish-to-pypi, build-wheel-pyodide]
+    needs: [publish-to-pypi]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -508,12 +440,6 @@ jobs:
         with:
           name: sdist-polars
           path: dist
-
-      - name: Download Pyodide wheel
-        uses: actions/download-artifact@v4
-        with:
-          name: wheel-polars-emscripten-wasm32
-          path: wasm-dist
 
       - name: Get version from Cargo.toml
         id: version


### PR DESCRIPTION
PyOdide for the so-manyth time has ran into build problems with `mio`. Since many things don't work on PyOdide anyway and the PyOdide package repository doesn't have a recent version of Polars, this disables the PyOdide build for now.