### PR TITLE
fix: Fix handling of `AggregatedScalar` in `ApplyExpr` single input

### DIFF
--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -117,7 +117,11 @@ impl ApplyExpr {
         }
 
         let name = s.name().clone();
-        let agg = ac.aggregated();
+        let agg = match ac.agg_state() {
+            AggState::AggregatedScalar(_) => s.as_list().into_column(),
+            _ => ac.aggregated(),
+        };
+
         // Collection of empty list leads to a null dtype. See: #3687.
         if agg.is_empty() {
             // Create input for the function to determine the output dtype, see #3946.


### PR DESCRIPTION
fixes #24616

This PR fixes how `AggregatedScalar` is handled in `ApplyExpr` with single input on group_aware. 

Kindly review, especially around low-level performance implications. 