### PR TITLE
ci: Remove dist/ from release python workflow

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -435,12 +435,6 @@ jobs:
         with:
           ref: ${{ inputs.sha }}
 
-      - name: Download sdist
-        uses: actions/download-artifact@v4
-        with:
-          name: sdist-polars
-          path: dist
-
       - name: Get version from Cargo.toml
         id: version
         working-directory: py-polars
@@ -473,7 +467,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.github-release.outputs.tag_name }}
-          FILES: dist/polars-*.tar.gz wasm-dist/polars-*.whl
+          FILES: wasm-dist/polars-*.whl
 
       - name: Publish GitHub release
         if: inputs.dry-run == false


### PR DESCRIPTION
Remove the `sdist` as that would now become `sdist-polars-runtime-32`. Because of the indirection it doesn't make much sense anymore. The release will still include the source code with the instruction to compile from source.