### PR TITLE
refactor(rust): Expose `CloudScheme` via `polars::prelude`

### DIFF
--- a/crates/polars-python/src/conversion/mod.rs
+++ b/crates/polars-python/src/conversion/mod.rs
@@ -33,7 +33,6 @@ use polars_parquet::write::StatisticsOptions;
 use polars_plan::dsl::ScanSources;
 use polars_utils::mmap::MemSlice;
 use polars_utils::pl_str::PlSmallStr;
-use polars_utils::plpath::CloudScheme;
 use polars_utils::total_ord::{TotalEq, TotalHash};
 use pyo3::basic::CompareOp;
 use pyo3::exceptions::{PyTypeError, PyValueError};

--- a/crates/polars/src/prelude.rs
+++ b/crates/polars/src/prelude.rs
@@ -8,4 +8,4 @@ pub use polars_lazy::prelude::*;
 pub use polars_ops::prelude::*;
 #[cfg(feature = "temporal")]
 pub use polars_time::prelude::*;
-pub use polars_utils::plpath::{PlPath, PlPathRef};
+pub use polars_utils::plpath::{CloudScheme, PlPath, PlPathRef};


### PR DESCRIPTION
A follow up for #24603.

Expose `CloudScheme`, just like `PlPath` and `PlPathRef`, so that downstream packages don't have to import `polars-utils`.

Ref: pola-rs/r-polars#1564