### PR TITLE
fix: Fix dtype in `EvalExpr`

### DIFF
--- a/crates/polars-expr/src/expressions/aggregation.rs
+++ b/crates/polars-expr/src/expressions/aggregation.rs
@@ -162,6 +162,7 @@ impl PhysicalExpr for AggregationExpr {
         state: &ExecutionState,
     ) -> PolarsResult<AggregationContext<'a>> {
         let mut ac = self.input.evaluate_on_groups(df, groups, state)?;
+
         // don't change names by aggregations as is done in polars-core
         let keep_name = ac.get_values().name().clone();
 

--- a/crates/polars-expr/src/expressions/eval.rs
+++ b/crates/polars-expr/src/expressions/eval.rs
@@ -8,8 +8,8 @@ use polars_core::chunked_array::from_iterator_par::ChunkedCollectParIterExt;
 use polars_core::error::{PolarsResult, polars_ensure};
 use polars_core::frame::DataFrame;
 use polars_core::prelude::{
-    AnyValue, ChunkCast, ChunkNestingUtils, Column, CompatLevel, DataType, Field, GroupPositions,
-    GroupsType, IntoColumn, ListBuilderTrait, ListChunked,
+    AnyValue, ChunkCast, ChunkNestingUtils, Column, CompatLevel, Field, GroupPositions, GroupsType,
+    IntoColumn, ListBuilderTrait, ListChunked,
 };
 use polars_core::schema::Schema;
 use polars_core::series::Series;
@@ -30,11 +30,7 @@ pub struct EvalExpr {
     variant: EvalVariant,
     expr: Expr,
     allow_threading: bool,
-    //  `output_field_with_ctx`` accounts for the aggregation context, if any
-    // It will 'auto-implode/expplode' if needed.
-    output_field_with_ctx: Field,
-    // `non_aggregated_output_dtype`` ignores any aggregation context
-    non_aggregated_output_dtype: DataType,
+    output_field: Field,
     is_scalar: bool,
     pd_group: ExprPushdownGroup,
     evaluation_is_scalar: bool,
@@ -73,8 +69,7 @@ impl EvalExpr {
         variant: EvalVariant,
         expr: Expr,
         allow_threading: bool,
-        output_field_with_ctx: Field,
-        non_aggregated_output_dtype: DataType,
+        output_field: Field,
         is_scalar: bool,
         pd_group: ExprPushdownGroup,
         evaluation_is_scalar: bool,
@@ -85,8 +80,7 @@ impl EvalExpr {
             variant,
             expr,
             allow_threading,
-            output_field_with_ctx,
-            non_aggregated_output_dtype,
+            output_field,
             is_scalar,
             pd_group,
             evaluation_is_scalar,
@@ -100,8 +94,8 @@ impl EvalExpr {
     ) -> PolarsResult<Column> {
         if lst.chunks().is_empty() {
             return Ok(Column::new_empty(
-                self.output_field_with_ctx.name.clone(),
-                &self.non_aggregated_output_dtype,
+                self.output_field.name.clone(),
+                &self.output_field.dtype.clone(),
             ));
         }
 
@@ -110,7 +104,8 @@ impl EvalExpr {
             .map_or(Cow::Borrowed(lst), Cow::Owned);
 
         let output_arrow_dtype = self
-            .non_aggregated_output_dtype
+            .output_field
+            .dtype
             .clone()
             .to_arrow(CompatLevel::newest());
         let output_arrow_dtype_physical = output_arrow_dtype.underlying_physical_type();
@@ -155,9 +150,9 @@ impl EvalExpr {
                 .collect::<PolarsResult<Vec<Box<dyn Array>>>>()?
         };
 
-        let out_inner_dt = self.non_aggregated_output_dtype.inner_dtype().unwrap();
+        let out_inner_dt = self.output_field.dtype.inner_dtype().unwrap();
         Ok(unsafe {
-            ListChunked::from_chunks(self.output_field_with_ctx.name.clone(), chunks)
+            ListChunked::from_chunks(self.output_field.name.clone(), chunks)
                 .from_physical_unchecked(out_inner_dt.clone())
                 .unwrap()
         }
@@ -183,10 +178,7 @@ impl EvalExpr {
                             }
                         })
                     })
-                    .collect_ca_with_dtype(
-                        PlSmallStr::EMPTY,
-                        self.non_aggregated_output_dtype.clone(),
-                    )
+                    .collect_ca_with_dtype(PlSmallStr::EMPTY, self.output_field.dtype.clone())
             });
             err = m_err.into_inner().unwrap();
             ca
@@ -217,8 +209,8 @@ impl EvalExpr {
         ca.rename(lst.name().clone());
 
         // Cast may still be required in some cases, e.g. for an empty frame when running single-threaded
-        if ca.dtype() != &self.non_aggregated_output_dtype {
-            ca.cast(&self.non_aggregated_output_dtype).map(Column::from)
+        if ca.dtype() != &self.output_field.dtype {
+            ca.cast(&self.output_field.dtype).map(Column::from)
         } else {
             Ok(ca.into_column())
         }
@@ -252,9 +244,7 @@ impl EvalExpr {
             },
             _ => ac.aggregated(),
         };
-        Ok(out
-            .with_name(self.output_field_with_ctx.name.clone())
-            .into_column())
+        Ok(out.with_name(self.output_field.name.clone()).into_column())
     }
 
     fn evaluate_on_list_chunked(
@@ -336,9 +326,9 @@ impl EvalExpr {
         };
 
         Series::from_any_values_and_dtype(
-            self.output_field_with_ctx.name().clone(),
+            self.output_field.name().clone(),
             &avs,
-            &self.non_aggregated_output_dtype,
+            self.output_field.dtype(),
             true,
         )
     }
@@ -376,9 +366,9 @@ impl PhysicalExpr for EvalExpr {
             },
             EvalVariant::Cumulative { min_samples } => {
                 let mut builder = AnonymousOwnedListBuilder::new(
-                    self.output_field_with_ctx.name().clone(),
+                    self.output_field.name().clone(),
                     input.groups().len(),
-                    Some(self.non_aggregated_output_dtype.clone()),
+                    Some(self.output_field.dtype.clone()),
                 );
                 for group in input.iter_groups(false) {
                     match group {
@@ -398,7 +388,7 @@ impl PhysicalExpr for EvalExpr {
     }
 
     fn to_field(&self, _input_schema: &Schema) -> PolarsResult<Field> {
-        Ok(self.output_field_with_ctx.clone())
+        Ok(self.output_field.clone())
     }
 
     fn is_scalar(&self) -> bool {

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -500,10 +500,7 @@ fn create_physical_expr_inner(
             let mut pd_group = ExprPushdownGroup::Pushable;
             pd_group.update_with_expr_rec(expr_arena.get(*evaluation), expr_arena, None);
 
-            let output_field_with_ctx = expr_arena
-                .get(expression)
-                .to_field_with_ctx(ctxt, &ToFieldContext::new(expr_arena, schema))?;
-            let non_aggregated_output_field = expr_arena
+            let output_field = expr_arena
                 .get(expression)
                 .to_field(&ToFieldContext::new(expr_arena, schema))?;
             let input_field = expr_arena
@@ -528,8 +525,7 @@ fn create_physical_expr_inner(
                 *variant,
                 node_to_expr(expression, expr_arena),
                 state.allow_threading,
-                output_field_with_ctx,
-                non_aggregated_output_field.dtype,
+                output_field,
                 is_scalar,
                 pd_group,
                 evaluation_is_scalar,


### PR DESCRIPTION
fixes #24635

This PR is a follow-up to https://github.com/pola-rs/polars/pull/23911, which removed the aggregation context in all but the `to_field` functions. This PR contains the last remaining change in `to_field`, the rest is cleanup and regression tests.

ping @coastalwhite 