### PR TITLE
perf: Remove unnecessary `groups` call in `aggregated`

### DIFF
--- a/crates/polars-expr/src/expressions/mod.rs
+++ b/crates/polars-expr/src/expressions/mod.rs
@@ -433,7 +433,6 @@ impl<'a> AggregationContext<'a> {
             },
             AggState::AggregatedList(s) | AggState::AggregatedScalar(s) => s.into_column(),
             AggState::LiteralScalar(s) => {
-                self.groups();
                 let rows = self.groups.len();
                 let s = s.implode().unwrap();
                 let s = s.new_from_index(0, rows);


### PR DESCRIPTION
Minor simplification / optimization when calling `aggregated()` on a `LiteralScalar`. The number of groups does not change, so the call to `groups` is not needed.

Ping @coastalwhite 