### PR TITLE
fix: Return error for unsupported `maintain_order` on joins

### DIFF
--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -3905,3 +3905,28 @@ def test_join_asof_by_i128() -> None:
             schema={"a": pl.Int128, "i": pl.Int32, "b": pl.Int128},
         ),
     )
+
+
+@pytest.mark.parametrize(
+    ("how", "supported"),
+    [
+        ("inner", True),
+        ("left", True),
+        ("right", True),
+        ("full", True),
+        ("anti", False),
+        ("cross", False),
+        ("semi", False),
+    ],
+)
+def test_error_for_unsupported_maintain_order(
+    how: JoinStrategy, supported: bool
+) -> None:
+    df = pl.DataFrame({"a": [1, 2]})
+
+    if supported:
+        df.join(df, on="a", how=how, maintain_order="left_right")
+    else:
+        on = "a" if how != "cross" else None
+        with pytest.raises(InvalidOperationError):
+            df.join(df, on=on, how=how, maintain_order="left_right")


### PR DESCRIPTION
The docs for `LazyFrame.join` state that
> `maintain_order`: Supported for inner, left, right and full joins

I noticed we have code that expects `cross` to have `maintain_order == None`, but we never check if the user leaves it as `None`. Currently we will propagate whatever the user sets all the way to the engine.

This is also a footgun for the user, since we don't give any error or warning if they set `maintain_order` for a join type that doesn't support it.