### PR TITLE
feat: Implement maintain_order for cross join

### DIFF
--- a/crates/polars-ops/src/frame/join/args.rs
+++ b/crates/polars-ops/src/frame/join/args.rs
@@ -169,6 +169,7 @@ where
 #[derive(Clone)]
 pub struct CrossJoinOptions {
     pub predicate: Arc<dyn CrossJoinFilter>,
+    pub maintain_order: MaintainOrderJoin,
 }
 
 impl CrossJoinOptions {
@@ -182,12 +183,14 @@ impl Eq for CrossJoinOptions {}
 impl PartialEq for CrossJoinOptions {
     fn eq(&self, other: &Self) -> bool {
         std::ptr::addr_eq(self.as_ptr_ref(), other.as_ptr_ref())
+            && self.maintain_order == other.maintain_order
     }
 }
 
 impl Hash for CrossJoinOptions {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.as_ptr_ref().hash(state);
+        self.maintain_order.hash(state);
     }
 }
 

--- a/crates/polars-ops/src/frame/join/cross_join.rs
+++ b/crates/polars-ops/src/frame/join/cross_join.rs
@@ -43,39 +43,15 @@ fn take_right(total_rows: IdxSize, n_rows_right: IdxSize, slice: Option<(i64, us
 }
 
 pub trait CrossJoin: IntoDf {
-    #[doc(hidden)]
-    /// used by streaming
-    fn _cross_join_with_names(
-        &self,
-        other: &DataFrame,
-        names: &[PlSmallStr],
-    ) -> PolarsResult<DataFrame> {
-        let (mut l_df, r_df) = cross_join_dfs(self.to_df(), other, None, false)?;
-        l_df.clear_schema();
-
-        unsafe {
-            l_df.get_columns_mut().extend_from_slice(r_df.get_columns());
-
-            l_df.get_columns_mut()
-                .iter_mut()
-                .zip(names)
-                .for_each(|(s, name)| {
-                    if s.name() != name {
-                        s.rename(name.clone());
-                    }
-                });
-        }
-        Ok(l_df)
-    }
-
     /// Creates the Cartesian product from both frames, preserves the order of the left keys.
     fn cross_join(
         &self,
         other: &DataFrame,
         suffix: Option<PlSmallStr>,
         slice: Option<(i64, usize)>,
+        maintain_order: MaintainOrderJoin,
     ) -> PolarsResult<DataFrame> {
-        let (l_df, r_df) = cross_join_dfs(self.to_df(), other, slice, true)?;
+        let (l_df, r_df) = cross_join_dfs(self.to_df(), other, slice, true, maintain_order)?;
 
         _finish_join(l_df, r_df, suffix)
     }
@@ -83,12 +59,27 @@ pub trait CrossJoin: IntoDf {
 
 impl CrossJoin for DataFrame {}
 
-fn cross_join_dfs(
-    df_self: &DataFrame,
-    other: &DataFrame,
+fn cross_join_dfs<'a>(
+    mut df_self: &'a DataFrame,
+    mut other: &'a DataFrame,
     slice: Option<(i64, usize)>,
     parallel: bool,
+    maintain_order: MaintainOrderJoin,
 ) -> PolarsResult<(DataFrame, DataFrame)> {
+    if df_self.height() == 0 || other.height() == 0 {
+        return Ok((df_self.clear(), other.clear()));
+    }
+
+    let left_is_primary = match maintain_order {
+        MaintainOrderJoin::None => true,
+        MaintainOrderJoin::Left | MaintainOrderJoin::LeftRight => true,
+        MaintainOrderJoin::Right | MaintainOrderJoin::RightLeft => false,
+    };
+
+    if !left_is_primary {
+        core::mem::swap(&mut df_self, &mut other);
+    }
+
     let n_rows_left = df_self.height() as IdxSize;
     let n_rows_right = other.height() as IdxSize;
     let Some(total_rows) = n_rows_left.checked_mul(n_rows_right) else {
@@ -97,9 +88,6 @@ fn cross_join_dfs(
             consider compiling with polars-big-idx feature, or set 'streaming'"
         );
     };
-    if n_rows_left == 0 || n_rows_right == 0 {
-        return Ok((df_self.clear(), other.clear()));
-    }
 
     // the left side has the Nth row combined with every row from right.
     // So let's say we have the following no. of rows
@@ -138,7 +126,11 @@ fn cross_join_dfs(
     } else {
         (create_left_df(), create_right_df())
     };
-    Ok((l_df, r_df))
+    if left_is_primary {
+        Ok((l_df, r_df))
+    } else {
+        Ok((r_df, l_df))
+    }
 }
 
 pub(super) fn fused_cross_filter(
@@ -147,17 +139,24 @@ pub(super) fn fused_cross_filter(
     suffix: Option<PlSmallStr>,
     cross_join_options: &CrossJoinOptions,
 ) -> PolarsResult<DataFrame> {
-    // Because we do a cartesian product, the number of partitions is squared.
-    // We take the sqrt, but we don't expect every partition to produce results and work can be
-    // imbalanced, so we multiply the number of partitions by 2;
-    let n_partitions = (_set_partition_size() as f32).sqrt() as usize * 2;
-    let splitted_a = split(left, n_partitions);
-    let splitted_b = split(right, n_partitions);
+    let unfiltered_size = (left.height() as u64).saturating_mul(right.height() as u64);
+    let chunk_size = (unfiltered_size / _set_partition_size() as u64).clamp(1, 100_000);
+    let num_chunks = (unfiltered_size / chunk_size).max(1) as usize;
 
-    let cartesian_prod = splitted_a
-        .iter()
-        .flat_map(|l| splitted_b.iter().map(move |r| (l, r)))
-        .collect::<Vec<_>>();
+    let left_is_primary = match cross_join_options.maintain_order {
+        MaintainOrderJoin::None => true,
+        MaintainOrderJoin::Left | MaintainOrderJoin::LeftRight => true,
+        MaintainOrderJoin::Right | MaintainOrderJoin::RightLeft => false,
+    };
+
+    let split_chunks;
+    let cartesian_prod = if left_is_primary {
+        split_chunks = split(left, num_chunks);
+        split_chunks.iter().map(|l| (l, right)).collect::<Vec<_>>()
+    } else {
+        split_chunks = split(right, num_chunks);
+        split_chunks.iter().map(|r| (left, r)).collect::<Vec<_>>()
+    };
 
     let names = _finish_join(left.clear(), right.clear(), suffix)?;
     let rename_names = names.get_column_names();
@@ -166,7 +165,8 @@ pub(super) fn fused_cross_filter(
     let dfs = POOL
         .install(|| {
             cartesian_prod.par_iter().map(|(left, right)| {
-                let (mut left, right) = cross_join_dfs(left, right, None, false)?;
+                let (mut left, right) =
+                    cross_join_dfs(left, right, None, false, cross_join_options.maintain_order)?;
                 let mut right_columns = right.take_columns();
 
                 for (c, name) in right_columns.iter_mut().zip(rename_names) {

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -136,7 +136,7 @@ pub trait DataFrameJoinOps: IntoDf {
                 assert!(args.slice.is_none());
                 return fused_cross_filter(left_df, other, args.suffix.clone(), cross_options);
             }
-            return left_df.cross_join(other, args.suffix.clone(), args.slice);
+            return left_df.cross_join(other, args.suffix.clone(), args.slice, args.maintain_order);
         }
 
         // Clear literals if a frame is empty. Otherwise we could get an oob

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -200,7 +200,11 @@ impl<'a> IRDisplay<'a> {
                 let right_on = self.display_expr_slice(right_on);
 
                 // Fused cross + filter (show as nested loop join)
-                if let Some(JoinTypeOptionsIR::CrossAndFilter { predicate }) = &options.options {
+                if let Some(JoinTypeOptionsIR::CrossAndFilter {
+                    predicate,
+                    maintain_order: _,
+                }) = &options.options
+                {
                     let predicate = self.display_expr(predicate);
                     let name = "NESTED LOOP";
                     write!(f, "{:indent$}{name} JOIN ON {predicate}:", "")?;
@@ -877,7 +881,11 @@ pub fn write_ir_non_recursive(
             };
 
             // Fused cross + filter (show as nested loop join)
-            if let Some(JoinTypeOptionsIR::CrossAndFilter { predicate }) = &options.options {
+            if let Some(JoinTypeOptionsIR::CrossAndFilter {
+                predicate,
+                maintain_order: _,
+            }) = &options.options
+            {
                 let predicate = predicate.display(expr_arena);
                 write!(f, "{:indent$}NESTED_LOOP JOIN ON {predicate}", "")?;
             } else {

--- a/crates/polars-plan/src/plans/ir/inputs.rs
+++ b/crates/polars-plan/src/plans/ir/inputs.rs
@@ -90,7 +90,10 @@ impl IR {
                 options,
                 ..
             } => match &options.options {
-                Some(JoinTypeOptionsIR::CrossAndFilter { predicate }) => Exprs::Boxed(Box::new(
+                Some(JoinTypeOptionsIR::CrossAndFilter {
+                    predicate,
+                    maintain_order: _,
+                }) => Exprs::Boxed(Box::new(
                     left_on
                         .iter()
                         .chain(right_on.iter())
@@ -163,7 +166,10 @@ impl IR {
                 options,
                 ..
             } => match Arc::make_mut(options).options.as_mut() {
-                Some(JoinTypeOptionsIR::CrossAndFilter { predicate }) => ExprsMut::Boxed(Box::new(
+                Some(JoinTypeOptionsIR::CrossAndFilter {
+                    predicate,
+                    maintain_order: _,
+                }) => ExprsMut::Boxed(Box::new(
                     left_on
                         .iter_mut()
                         .chain(right_on.iter_mut())

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
@@ -409,8 +409,10 @@ fn try_rewrite_join_type(
 
         match &options.options {
             Some(JoinTypeOptionsIR::CrossAndFilter { .. }) => {
-                let Some(JoinTypeOptionsIR::CrossAndFilter { predicate }) =
-                    Arc::make_mut(options).options.take()
+                let Some(JoinTypeOptionsIR::CrossAndFilter {
+                    predicate,
+                    maintain_order: _,
+                }) = Arc::make_mut(options).options.take()
                 else {
                     unreachable!()
                 };
@@ -535,10 +537,12 @@ fn try_rewrite_join_type(
             return Ok(());
         };
 
+        let maintain_order = options.args.maintain_order;
         let existing = Arc::make_mut(options)
             .options
             .replace(JoinTypeOptionsIR::CrossAndFilter {
                 predicate: ExprIR::from_node(nested_loop_predicates, expr_arena),
+                maintain_order,
             });
         assert!(existing.is_none()); // Important
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7956,7 +7956,6 @@ class DataFrame:
             Do not rely on any observed ordering without explicitly setting this
             parameter, as your code may break in a future release.
             Not specifying any ordering can improve performance.
-            Supported for inner, left, right and full joins
 
             .. list-table ::
                :header-rows: 0

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -5650,7 +5650,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Do not rely on any observed ordering without explicitly setting this
             parameter, as your code may break in a future release.
             Not specifying any ordering can improve performance.
-            Supported for inner, left, right and full joins
 
             .. list-table ::
                :header-rows: 0

--- a/py-polars/tests/unit/operations/test_cross_join.py
+++ b/py-polars/tests/unit/operations/test_cross_join.py
@@ -91,3 +91,29 @@ def test_cross_join_chunking_panic_22793() -> None:
         .collect(),
         df.schema.to_frame(),
     )
+
+
+@pytest.mark.parametrize(
+    "maintain_order", ["left", "right", "left_right", "right_left"]
+)
+def test_cross_join_maintain_order_24663(maintain_order: str) -> None:
+    df = pl.DataFrame({"x": [0, 1, 2, 3, 4]})
+    df2 = pl.DataFrame({"y": [0, 1, 2, 3, 4]})
+    primary = [x for x in range(5) for _ in range(5)]
+    secondary = [x for _ in range(5) for x in range(5)]
+    if maintain_order.startswith("left"):
+        expected = pl.DataFrame({"x": primary, "y": secondary})
+    else:
+        expected = pl.DataFrame({"x": secondary, "y": primary})
+
+    assert_frame_equal(
+        df.join(df2, how="cross", maintain_order=maintain_order), expected
+    )
+
+    # Test with fused filter as well.
+    assert_frame_equal(
+        df.lazy()
+        .join(df2.lazy(), how="cross", maintain_order=maintain_order)
+        .filter((pl.col.x + pl.col.y) % 2 == 0),
+        expected.lazy().filter((pl.col.x + pl.col.y) % 2 == 0),
+    )

--- a/py-polars/tests/unit/operations/test_cross_join.py
+++ b/py-polars/tests/unit/operations/test_cross_join.py
@@ -4,6 +4,7 @@ from zoneinfo import ZoneInfo
 import pytest
 
 import polars as pl
+from polars._typing import MaintainOrderJoin
 from polars.testing import assert_frame_equal
 
 
@@ -96,7 +97,7 @@ def test_cross_join_chunking_panic_22793() -> None:
 @pytest.mark.parametrize(
     "maintain_order", ["left", "right", "left_right", "right_left"]
 )
-def test_cross_join_maintain_order_24663(maintain_order: str) -> None:
+def test_cross_join_maintain_order_24663(maintain_order: MaintainOrderJoin) -> None:
     df = pl.DataFrame({"x": [0, 1, 2, 3, 4]})
     df2 = pl.DataFrame({"y": [0, 1, 2, 3, 4]})
     primary = [x for x in range(5) for _ in range(5)]


### PR DESCRIPTION
This was already implemented in the streaming engine, I now also quickly added it to the in-memory engine's implementation.

Fixes https://github.com/pola-rs/polars/issues/24663.
Fixes https://github.com/pola-rs/polars/issues/24664.