### PR TITLE
perf: Pushdown filter with `strptime` if input is literal

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/properties/general.rs
+++ b/crates/polars-plan/src/plans/aexpr/properties/general.rs
@@ -273,7 +273,8 @@ impl ExprPushdownGroup {
 
                         let ambiguous_is_fallible = !ambiguous_arg_is_infallible_scalar;
 
-                        strptime_options.strict || ambiguous_is_fallible
+                        !matches!(expr_arena.get(input[0].node()), AExpr::Literal(_))
+                            && (strptime_options.strict || ambiguous_is_fallible)
                     },
                     AExpr::Cast {
                         expr,


### PR DESCRIPTION
Avoid marking `strptime` as `Fallible` if the input is a literal.
