### PR TITLE
perf: Lower null count to streaming engine

### DIFF
--- a/crates/polars-expr/src/reduce/convert.rs
+++ b/crates/polars-expr/src/reduce/convert.rs
@@ -8,7 +8,7 @@ use crate::reduce::any_all::{new_all_reduction, new_any_reduction};
 use crate::reduce::bitwise::{
     new_bitwise_and_reduction, new_bitwise_or_reduction, new_bitwise_xor_reduction,
 };
-use crate::reduce::count::CountReduce;
+use crate::reduce::count::{CountReduce, NullCountReduce};
 use crate::reduce::first_last::{new_first_reduction, new_last_reduction};
 use crate::reduce::len::LenReduce;
 use crate::reduce::mean::new_mean_reduction;
@@ -81,6 +81,18 @@ pub fn into_reduction(
                 (out, expr)
             }
         },
+
+        AExpr::Function {
+            input: inner_exprs,
+            function: IRFunctionExpr::NullCount,
+            options: _,
+        } => {
+            assert!(inner_exprs.len() == 1);
+            let input = inner_exprs[0].node();
+            let count = Box::new(NullCountReduce::new()) as Box<_>;
+            (count, input)
+        },
+
         #[cfg(feature = "bitwise")]
         AExpr::Function {
             input: inner_exprs,

--- a/crates/polars-expr/src/reduce/count.rs
+++ b/crates/polars-expr/src/reduce/count.rs
@@ -120,3 +120,113 @@ impl GroupedReduction for CountReduce {
         self
     }
 }
+
+pub struct NullCountReduce {
+    counts: Vec<u64>,
+    evicted_counts: Vec<u64>,
+}
+
+impl NullCountReduce {
+    pub fn new() -> Self {
+        Self {
+            counts: Vec::new(),
+            evicted_counts: Vec::new(),
+        }
+    }
+}
+
+impl GroupedReduction for NullCountReduce {
+    fn new_empty(&self) -> Box<dyn GroupedReduction> {
+        Box::new(Self::new())
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        self.counts.reserve(additional);
+    }
+
+    fn resize(&mut self, num_groups: IdxSize) {
+        self.counts.resize(num_groups as usize, 0);
+    }
+
+    fn update_group(
+        &mut self,
+        values: &Column,
+        group_idx: IdxSize,
+        _seq_id: u64,
+    ) -> PolarsResult<()> {
+        self.counts[group_idx as usize] += values.null_count() as u64;
+        Ok(())
+    }
+
+    unsafe fn update_groups_while_evicting(
+        &mut self,
+        values: &Column,
+        subset: &[IdxSize],
+        group_idxs: &[EvictIdx],
+        _seq_id: u64,
+    ) -> PolarsResult<()> {
+        assert!(subset.len() == group_idxs.len());
+        let values = values.as_materialized_series(); // @scalar-opt
+        let chunks = values.chunks();
+        assert!(chunks.len() == 1);
+        let arr = &*chunks[0];
+        if arr.has_nulls() {
+            let valid = arr.validity().unwrap();
+            for (i, g) in subset.iter().zip(group_idxs) {
+                let grp = self.counts.get_unchecked_mut(g.idx());
+                if g.should_evict() {
+                    self.evicted_counts.push(*grp);
+                    *grp = 0;
+                }
+                *grp += (!valid.get_bit_unchecked(*i as usize)) as u64;
+            }
+        } else {
+            for (_, g) in subset.iter().zip(group_idxs) {
+                let grp = self.counts.get_unchecked_mut(g.idx());
+                if g.should_evict() {
+                    self.evicted_counts.push(*grp);
+                    *grp = 0;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    unsafe fn combine_subset(
+        &mut self,
+        other: &dyn GroupedReduction,
+        subset: &[IdxSize],
+        group_idxs: &[IdxSize],
+    ) -> PolarsResult<()> {
+        let other = other.as_any().downcast_ref::<Self>().unwrap();
+        assert!(subset.len() == group_idxs.len());
+        unsafe {
+            // SAFETY: indices are in-bounds guaranteed by trait.
+            for (i, g) in subset.iter().zip(group_idxs) {
+                *self.counts.get_unchecked_mut(*g as usize) +=
+                    *other.counts.get_unchecked(*i as usize);
+            }
+        }
+        Ok(())
+    }
+
+    fn take_evictions(&mut self) -> Box<dyn GroupedReduction> {
+        Box::new(Self {
+            counts: core::mem::take(&mut self.evicted_counts),
+            evicted_counts: Vec::new(),
+        })
+    }
+
+    fn finalize(&mut self) -> PolarsResult<Series> {
+        let ca: IdxCa = self
+            .counts
+            .drain(..)
+            .map(|l| IdxSize::try_from(l).expect(LENGTH_LIMIT_MSG))
+            .collect_ca(PlSmallStr::EMPTY);
+        Ok(ca.into_series())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -1705,7 +1705,8 @@ fn lower_exprs_with_ctx(
                 function:
                     IRFunctionExpr::Boolean(
                         IRBooleanFunction::Any { .. } | IRBooleanFunction::All { .. },
-                    ),
+                    )
+                    | IRFunctionExpr::NullCount,
                 ..
             } => {
                 let (trans_stream, trans_expr) = lower_unary_reduce_node(input, expr, ctx)?;

--- a/crates/polars-stream/src/physical_plan/lower_group_by.rs
+++ b/crates/polars-stream/src/physical_plan/lower_group_by.rs
@@ -228,9 +228,10 @@ fn try_lower_elementwise_scalar_agg_expr(
         AExpr::Function {
             input: inner_exprs,
             function:
-                IRFunctionExpr::Boolean(
-                    inner_fn @ (IRBooleanFunction::Any { .. } | IRBooleanFunction::All { .. }),
-                ),
+                inner_fn @ (IRFunctionExpr::Boolean(
+                    IRBooleanFunction::Any { .. } | IRBooleanFunction::All { .. },
+                )
+                | IRFunctionExpr::NullCount),
             options,
         } => {
             assert!(inner_exprs.len() == 1);
@@ -261,7 +262,7 @@ fn try_lower_elementwise_scalar_agg_expr(
                     let input_col_node = expr_arena.add(AExpr::Column(input_col));
                     let trans_agg_node = expr_arena.add(AExpr::Function {
                         input: vec![ExprIR::from_node(input_col_node, expr_arena)],
-                        function: IRFunctionExpr::Boolean(inner_fn),
+                        function: inner_fn,
                         options,
                     });
 


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/24698.

I had overlooked this one, we had a streaming non-null count but not a streaming null count.