### PR TITLE
chore: Add egg-info to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ polars/vendor
 .venv*/
 __pycache__/
 .coverage
+*.egg-info
 
 # Rust
 target/


### PR DESCRIPTION
We now produce such files but we weren't ignoring them yet, they should not be committed.