### PR TITLE
fix: Support `decimal_comma` on `Decimal` type in `write_csv`

### DIFF
--- a/crates/polars-compute/src/cast/decimal_to.rs
+++ b/crates/polars-compute/src/cast/decimal_to.rs
@@ -116,7 +116,7 @@ pub(super) fn decimal_to_utf8view(from: &PrimitiveArray<i128>) -> Utf8ViewArray 
     let mut mutable = MutableBinaryViewArray::with_capacity(from.len());
     let mut fmt_buf = DecimalFmtBuffer::new();
     for &x in from.values().iter() {
-        mutable.push_value_ignore_validity(fmt_buf.format_dec128(x, from_scale, false))
+        mutable.push_value_ignore_validity(fmt_buf.format_dec128(x, from_scale, false, false))
     }
 
     mutable.freeze().with_validity(from.validity().cloned())

--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -1311,7 +1311,7 @@ impl Series {
 fn fmt_decimal(f: &mut Formatter<'_>, v: i128, scale: usize) -> fmt::Result {
     let mut fmt_buf = polars_compute::decimal::DecimalFmtBuffer::new();
     let trim_zeros = get_trim_decimal_zeros();
-    f.write_str(fmt_float_string(fmt_buf.format_dec128(v, scale, trim_zeros)).as_str())
+    f.write_str(fmt_float_string(fmt_buf.format_dec128(v, scale, trim_zeros, false)).as_str())
 }
 
 #[cfg(all(

--- a/crates/polars-core/src/frame/row/av_buffer.rs
+++ b/crates/polars-core/src/frame/row/av_buffer.rs
@@ -143,7 +143,7 @@ impl<'a> AnyValueBuffer<'a> {
                 #[cfg(feature = "dtype-decimal")]
                 AnyValue::Decimal(v, _p, s) => {
                     let mut fmt = DecimalFmtBuffer::new();
-                    builder.append_value(fmt.format_dec128(v, s, false));
+                    builder.append_value(fmt.format_dec128(v, s, false, false));
                 },
                 _ => return None,
             },

--- a/crates/polars-json/src/json/write/serialize.rs
+++ b/crates/polars-json/src/json/write/serialize.rs
@@ -125,7 +125,7 @@ fn decimal_serializer<'a>(
     let mut fmt_buf = polars_compute::decimal::DecimalFmtBuffer::new();
     let f = move |x: Option<&i128>, buf: &mut Vec<u8>| {
         if let Some(x) = x {
-            utf8::write_str(buf, fmt_buf.format_dec128(*x, scale, trim_zeros)).unwrap()
+            utf8::write_str(buf, fmt_buf.format_dec128(*x, scale, trim_zeros, false)).unwrap()
         } else {
             buf.extend(b"null")
         }

--- a/crates/polars-python/src/conversion/any_value.rs
+++ b/crates/polars-python/src/conversion/any_value.rs
@@ -124,7 +124,7 @@ pub(crate) fn any_value_into_py_object<'py>(
         AnyValue::Decimal(v, prec, scale) => {
             let convert = utils.getattr(intern!(py, "to_py_decimal"))?;
             let mut buf = DecimalFmtBuffer::new();
-            let s = buf.format_dec128(v, scale, false);
+            let s = buf.format_dec128(v, scale, false, false);
             convert.call1((prec, s))
         },
     }

--- a/crates/polars-python/src/conversion/chunked_array.rs
+++ b/crates/polars-python/src/conversion/chunked_array.rs
@@ -143,7 +143,7 @@ pub(crate) fn decimal_to_pyobject_iter<'py, 'a>(
     let mut buf = DecimalFmtBuffer::new();
     Ok(ca.physical().iter().map(move |opt_v| {
         opt_v.map(|v| {
-            let s = buf.format_dec128(v, ca.scale(), false);
+            let s = buf.format_dec128(v, ca.scale(), false, false);
             convert.call1((&py_precision, s)).unwrap()
         })
     }))

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2250,14 +2250,14 @@ def test_skip_rows_after_header_pyarrow(use_pyarrow: bool) -> None:
     assert_frame_equal(df, expected)
 
 
-def test_csv_float_type_decimal_comma() -> None:
+def test_read_csv_float_type_decimal_comma() -> None:
     floats = b"a;b\n12,239;1,233\n13,908;87,32"
     read = pl.read_csv(floats, decimal_comma=True, separator=";")
     assert read.dtypes == [pl.Float64] * 2
     assert read.to_dict(as_series=False) == {"a": [12.239, 13.908], "b": [1.233, 87.32]}
 
 
-def test_csv_decimal_type_decimal_comma_24414() -> None:
+def test_read_csv_decimal_type_decimal_comma_24414() -> None:
     schema = pl.Schema({"a": pl.Decimal(scale=3), "b": pl.Decimal(scale=2)})
 
     csv_dot = b"a,b\n12.239,1.233\n13.908,87.32"
@@ -2707,7 +2707,7 @@ x"y,b,c
         (";", "never", None, None, True, b"123,75;60,0;9\n"),
     ],
 )
-def test_write_csv_decimal_comma(
+def test_write_csv_float_type_decimal_comma(
     separator: str,
     quote_style: CsvQuoteStyle | None,
     scientific: bool | None,
@@ -2779,6 +2779,93 @@ def test_write_csv_decimal_comma(
             quote_style=quote_style,
             float_precision=precision,
             float_scientific=scientific,
+            decimal_comma=decimal_comma,
+            include_header=True,
+        )
+        buf.seek(0)
+        out = pl.scan_csv(
+            buf, decimal_comma=decimal_comma, separator=separator, schema=df.schema
+        ).collect()
+        assert_frame_equal(df, out)
+
+
+@pytest.mark.parametrize(
+    (
+        "separator",
+        "quote_style",
+        "decimal_comma",
+        "expected",
+    ),
+    [
+        (",", None, False, b"123.75,60.0,9\n"),
+        (",", None, True, b'"123,75","60,0",9\n'),
+        (";", None, False, b"123.75;60.0;9\n"),
+        (";", None, True, b"123,75;60,0;9\n"),
+        (",", "always", True, b'"123,75","60,0","9"\n'),
+        (",", "necessary", True, b'"123,75","60,0",9\n'),
+        (",", "non_numeric", True, b'"123,75","60,0",9\n'),
+        (",", "never", True, b"123,75,60,0,9\n"),  # mal-formed
+        (";", "always", True, b'"123,75";"60,0";"9"\n'),
+        (";", "necessary", True, b"123,75;60,0;9\n"),
+    ],
+)
+def test_write_csv_decimal_type_decimal_comma(
+    separator: str,
+    quote_style: CsvQuoteStyle | None,
+    decimal_comma: bool,
+    expected: bytes,
+) -> None:
+    schema = {
+        "a": pl.Decimal(scale=2),
+        "b": pl.Decimal(scale=1),
+        "c": pl.Decimal(scale=0),
+    }
+
+    df = pl.DataFrame(
+        data={
+            "a": [123.75],
+            "b": [60.0],
+            "c": [9],
+        },
+        schema=schema,
+    )
+
+    buf = io.BytesIO()
+    df.write_csv(
+        buf,
+        separator=separator,
+        quote_style=quote_style,
+        decimal_comma=decimal_comma,
+        include_header=False,
+    )
+    buf.seek(0)
+    assert buf.read() == expected
+
+    # Round-trip testing: assert df == read_csv(write_csv(df))
+    # eager
+    round_trip = not (quote_style == "never" and decimal_comma and separator == ",")
+    if round_trip:
+        print("BOO")
+        buf.seek(0)
+        df.write_csv(
+            buf,
+            separator=separator,
+            quote_style=quote_style,
+            decimal_comma=decimal_comma,
+            include_header=True,
+        )
+        buf.seek(0)
+        out = pl.read_csv(
+            buf, decimal_comma=decimal_comma, separator=separator, schema=df.schema
+        )
+        assert_frame_equal(df, out)
+
+        # lazy
+        buf.seek(0)
+        df.lazy().sink_csv(
+            buf,
+            separator=separator,
+            quote_style=quote_style,
             decimal_comma=decimal_comma,
             include_header=True,
         )


### PR DESCRIPTION
fixes #23932

When writing decimal  `Decimal` types to CSV, they can now be formatted with a comma character (`','`) as the decimal separator.

Recreated from the original PR https://github.com/pola-rs/polars/pull/24139 (by [Luke Marques](https://github.com/Luke-Marques) - thanks :)), which can now be closed, based on the new `Decimal` implementation.

