### PR TITLE
chore(python): Make `test_multiple_sorting_columns` test runnable

### DIFF
--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -3349,7 +3349,7 @@ def test_field_overwrites_metadata() -> None:
     assert schema[2].type.fields[1].metadata[b"md2"] == b"Yes!"
 
 
-def multiple_test_sorting_columns() -> None:
+def test_multiple_sorting_columns() -> None:
     df = pl.DataFrame(
         {
             "a": [1, 1, 1, 2, 2, 2],


### PR DESCRIPTION
@coastalwhite the test added in https://github.com/pola-rs/polars/pull/23184 doesn't currently run because it doesn't start with `test_` 😭 
```console
$ pytest tests/unit/io/test_parquet.py::multiple_test_sorting_columns
================================================================ test session starts =================================================================
platform linux -- Python 3.12.8, pytest-8.3.2, pluggy-1.6.0
codspeed: 3.2.0 (disabled, mode: walltime, timer_resolution: 1.0ns)
rootdir: /home/marcogorelli/polars-dev/py-polars
configfile: pyproject.toml
plugins: codspeed-3.2.0, cov-6.0.0, hypothesis-6.140.2, xdist-3.6.1
collected 0 items                                                                                                                                    

=============================================================== no tests ran in 2.21s ================================================================
ERROR: not found: /home/marcogorelli/polars-dev/py-polars/tests/unit/io/test_parquet.py::multiple_test_sorting_columns
(no match in any of [<Module test_parquet.py>])
```
this fixes it
```console
$ pytest tests/unit/io/test_parquet.py::test_multiple_sorting_columns
================================================================ test session starts =================================================================
platform linux -- Python 3.12.8, pytest-8.3.2, pluggy-1.6.0
codspeed: 3.2.0 (disabled, mode: walltime, timer_resolution: 1.0ns)
rootdir: /home/marcogorelli/polars-dev/py-polars
configfile: pyproject.toml
plugins: codspeed-3.2.0, cov-6.0.0, hypothesis-6.140.2, xdist-3.6.1
collected 1 item                                                                                                                                     

tests/unit/io/test_parquet.py .                                                                                                                [100%]

================================================================= 1 passed in -0.58s =================================================================

```