### PR TITLE
fix(python): Ensure `schema_overrides` is respected when loading iterable row data

### DIFF
--- a/py-polars/src/polars/_utils/construction/dataframe.py
+++ b/py-polars/src/polars/_utils/construction/dataframe.py
@@ -1019,6 +1019,7 @@ def iterable_to_pydf(
             strict=strict,
             orient="row",
             infer_schema_length=infer_schema_length,
+            schema_overrides=schema_overrides,
         )
 
     n_chunks = 0

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1268,6 +1268,10 @@ def test_from_generator_or_iterable() -> None:
         for i in range(n):
             yield (str(i) if strkey else i), 1 * i, 2**i, 3**i
 
+    def gen_named(n: int, *, strkey: bool = True) -> Iterator[Any]:
+        for i in range(n):
+            yield {"a": (str(i) if strkey else i), "b": 1 * i, "c": 2**i, "d": 3**i}
+
     # iterable object
     class Rows:
         def __init__(self, n: int, *, strkey: bool = True) -> None:
@@ -1347,6 +1351,15 @@ def test_from_generator_or_iterable() -> None:
     assert_frame_equal(
         pl.DataFrame(data=gen(0), schema=["a", "b", "c", "d"]),
         pl.DataFrame(schema=["a", "b", "c", "d"]),
+    )
+
+    # schema overrides
+    assert_frame_equal(
+        pl.DataFrame(
+            data=gen_named(1),
+            schema_overrides={"a": pl.Float64(), "c": pl.Float64()},
+        ),
+        pl.DataFrame([{"a": 0.0, "b": 0, "c": 1.0, "d": 1}]),
     )
 
 


### PR DESCRIPTION
Fixes #24720 

got an error trying to test with `make test` though,
```
process didn't exit successfully: [...] /rustc [...]
error: could not compile `polars-ops` (lib)
[...]
(signal: 9, SIGKILL: kill)
```