### PR TITLE
refactor(rust): Unify expression order resolution

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/set_order/expr_pullup.rs
+++ b/crates/polars-plan/src/plans/optimizer/set_order/expr_pullup.rs
@@ -2,13 +2,13 @@ use polars_utils::arena::Arena;
 
 use crate::plans::AExpr;
 use crate::plans::set_order::expr_pushdown::{
-    ExprOutputOrder, FrameOrderObserved, ObservableOrderingsResolver,
+    ExprOutputOrder, ExprOutputOrderResolver, FrameOrderObserved,
 };
 
 pub fn is_output_ordered(aexpr: &AExpr, arena: &Arena<AExpr>, frame_ordered: bool) -> bool {
     use ExprOutputOrder as O;
 
-    match ObservableOrderingsResolver::new(if frame_ordered {
+    match ExprOutputOrderResolver::new(if frame_ordered {
         O::Independent
     } else {
         O::None
@@ -18,40 +18,13 @@ pub fn is_output_ordered(aexpr: &AExpr, arena: &Arena<AExpr>, frame_ordered: boo
         Ok(O::None) => false,
         Ok(O::Independent) => true,
 
-        // Sorts always output in a defined ordering.
-        AExpr::Sort { .. } | AExpr::SortBy { .. } => true,
-        AExpr::Gather {
-            expr: _,
-            idx,
-            returns_scalar,
-        } => !returns_scalar && rec!(*idx),
-
-        // Filter propagates the input order.
-        AExpr::Filter { input, by: _ } => rec!(*input),
-
-        // This aggregation is jiberish. Just be conservative.
-        AExpr::Agg(IRAggExpr::AggGroups(_)) => true,
-
-        // Aggregations always output 1 row.
-        AExpr::Agg(..) | AExpr::Len => false,
-
-        AExpr::Eval {
-            expr,
-            evaluation: _,
-            variant,
-        } => match variant {
-            EvalVariant::List => rec!(*expr),
-            EvalVariant::Cumulative { min_samples: _ } => true,
-        },
-        AExpr::AnonymousFunction { input, options, .. }
-        | AExpr::Function { input, options, .. } => {
-            if options.flags.returns_scalar() || options.flags.is_output_unordered() {
-                false
-            } else if options.is_elementwise() {
-                input.iter().any(|e| rec!(e.node()))
-            } else if options.flags.propagates_order() {
-                assert_eq!(input.len(), 1);
-                rec!(input[0].node())
+        Ok(O::Frame | O::Both) | Err(FrameOrderObserved) => {
+            // It is a logic error to hit this branch, as that would mean that frame ordering was
+            // introduced into the expression tree from a non-column node.
+            //
+            // In release mode just conservatively indicate ordered output.
+            if cfg!(debug_assertions) {
+                unreachable!()
             } else {
                 true
             }

--- a/crates/polars-plan/src/plans/optimizer/set_order/expr_pullup.rs
+++ b/crates/polars-plan/src/plans/optimizer/set_order/expr_pullup.rs
@@ -1,37 +1,22 @@
 use polars_utils::arena::Arena;
 
-use crate::dsl::EvalVariant;
-use crate::plans::{AExpr, IRAggExpr};
+use crate::plans::AExpr;
+use crate::plans::set_order::expr_pushdown::{
+    ExprOutputOrder, FrameOrderObserved, ObservableOrderingsResolver,
+};
 
-/// Determine whether the output of an expression has a defined order.
-///
-/// This will recursively walk through the expression and answers the question:
-///
-/// > Given that the input dataframe (does not have/has) a defined ordered, does the expression
-/// > have a defined output order?
-#[recursive::recursive]
 pub fn is_output_ordered(aexpr: &AExpr, arena: &Arena<AExpr>, frame_ordered: bool) -> bool {
-    macro_rules! rec {
-        ($node:expr) => {{ is_output_ordered(arena.get($node), arena, frame_ordered) }};
-    }
-    match aexpr {
-        // Explode creates local orders.
-        AExpr::Explode { .. } => true,
-        AExpr::Column(..) => frame_ordered,
-        AExpr::Literal(lv) => !lv.is_scalar(),
+    use ExprOutputOrder as O;
 
-        // All elementwise expressions are ordered if any of its inputs are ordered.
-        AExpr::BinaryExpr { left, right, op: _ } => rec!(*left) || rec!(*right),
-        AExpr::Ternary {
-            predicate,
-            truthy,
-            falsy,
-        } => rec!(*predicate) || rec!(*truthy) || rec!(*falsy),
-        AExpr::Cast {
-            expr,
-            dtype: _,
-            options: _,
-        } => rec!(*expr),
+    match ObservableOrderingsResolver::new(if frame_ordered {
+        O::Independent
+    } else {
+        O::None
+    })
+    .resolve_observable_orderings(aexpr, arena)
+    {
+        Ok(O::None) => false,
+        Ok(O::Independent) => true,
 
         // Sorts always output in a defined ordering.
         AExpr::Sort { .. } | AExpr::SortBy { .. } => true,
@@ -71,13 +56,5 @@ pub fn is_output_ordered(aexpr: &AExpr, arena: &Arena<AExpr>, frame_ordered: boo
                 true
             }
         },
-        // @Performance. This is probably quite pessimistic and can be optimizes to be `false` in
-        // some cases.
-        AExpr::Window { .. } => true,
-        AExpr::Slice {
-            input,
-            offset: _,
-            length: _,
-        } => rec!(*input),
     }
 }

--- a/crates/polars-plan/src/plans/optimizer/set_order/expr_pushdown.rs
+++ b/crates/polars-plan/src/plans/optimizer/set_order/expr_pushdown.rs
@@ -98,209 +98,272 @@ pub fn adjust_for_with_columns_context(
 ///
 /// This answers the question:
 /// > Given that my output is (un)ordered, can my input be unordered?
-#[recursive::recursive]
-pub fn get_frame_observing(
+pub fn get_observable_orders(
     aexpr: &AExpr,
     expr_arena: &Arena<AExpr>,
 ) -> Result<ExprOutputOrder, FrameOrderObserved> {
-    macro_rules! rec {
-        ($expr:expr) => {{ get_frame_observing(expr_arena.get($expr), expr_arena)? }};
+    ObservableOrderingsResolver::new(ExprOutputOrder::Frame)
+        .resolve_observable_orderings(aexpr, expr_arena)
+}
+
+pub(super) struct ObservableOrderingsResolver {
+    column_ordering: ExprOutputOrder,
+}
+
+impl ObservableOrderingsResolver {
+    pub(super) fn new(column_ordering: ExprOutputOrder) -> Self {
+        use ExprOutputOrder as O;
+
+        match &column_ordering {
+            O::Frame | O::Independent | O::None => {},
+            O::Both => panic!(),
+        }
+
+        Self { column_ordering }
     }
 
-    macro_rules! zip {
-        ($($expr:expr),*) => {{ zip([$(Ok(rec!($expr))),*])? }};
-    }
+    #[recursive::recursive]
+    pub(super) fn resolve_observable_orderings(
+        &self,
+        aexpr: &AExpr,
+        expr_arena: &Arena<AExpr>,
+    ) -> Result<ExprOutputOrder, FrameOrderObserved> {
+        macro_rules! rec {
+            ($expr:expr) => {{ self.resolve_observable_orderings(expr_arena.get($expr), expr_arena)? }};
+        }
 
-    use ExprOutputOrder as O;
-    Ok(match aexpr {
-        // Explode creates local orders.
-        //
-        // The following observes order:
-        //
-        // a: [[1, 2], [3]]
-        // b: [[3], [4, 5]]
-        //
-        // col(a).explode() * col(b).explode()
-        AExpr::Explode { expr, .. } => rec!(*expr) | O::Independent,
+        macro_rules! zip {
+            ($($expr:expr),*) => {{ zip([$(Ok(rec!($expr))),*])? }};
+        }
 
-        AExpr::Column(_) => O::Frame,
-        AExpr::Literal(lv) if lv.is_scalar() => O::None,
-        AExpr::Literal(_) => O::Independent,
+        use ExprOutputOrder as O;
+        Ok(match aexpr {
+            // Explode creates local orders.
+            //
+            // The following observes order:
+            //
+            // a: [[1, 2], [3]]
+            // b: [[3], [4, 5]]
+            //
+            // col(a).explode() * col(b).explode()
+            AExpr::Explode { expr, .. } => rec!(*expr) | O::Independent,
 
-        AExpr::Cast { expr, .. } => rec!(*expr),
+            AExpr::Column(_) => self.column_ordering,
+            AExpr::Literal(lv) if lv.is_scalar() => O::None,
+            AExpr::Literal(_) => O::Independent,
 
-        // Elementwise can be seen as a `zip + op`.
-        AExpr::BinaryExpr { left, op: _, right } => zip!(*left, *right),
-        AExpr::Ternary {
-            predicate,
-            truthy,
-            falsy,
-        } => zip!(*predicate, *truthy, *falsy),
+            AExpr::Cast { expr, .. } => rec!(*expr),
 
-        // Filter has to check whether zipping observes order, otherwise it propagates expr order.
-        AExpr::Filter { input, by } => {
-            let input = rec!(*input);
-            input.zip_with(rec!(*by))?;
-            input
-        },
+            // Elementwise can be seen as a `zip + op`.
+            AExpr::BinaryExpr { left, op: _, right } => zip!(*left, *right),
+            AExpr::Ternary {
+                predicate,
+                truthy,
+                falsy,
+            } => zip!(*predicate, *truthy, *falsy),
 
-        AExpr::Sort { expr, options } => {
-            if options.maintain_order {
-                rec!(*expr) | O::Independent
-            } else {
-                _ = rec!(*expr);
-                O::Independent
-            }
-        },
-        AExpr::SortBy {
-            expr,
-            by,
-            sort_options,
-        } => {
-            let mut zipped = rec!(*expr);
-            for e in by {
-                zipped = zipped.zip_with(rec!(*e))?;
-            }
-
-            if sort_options.maintain_order {
-                zipped | O::Independent
-            } else {
-                O::Independent
-            }
-        },
-
-        AExpr::Agg(agg) => match agg {
-            // Input order agnostic aggregations.
-            IRAggExpr::Min { input: node, .. }
-            | IRAggExpr::Max { input: node, .. }
-            | IRAggExpr::Median(node)
-            | IRAggExpr::NUnique(node)
-            | IRAggExpr::Mean(node)
-            | IRAggExpr::Sum(node)
-            | IRAggExpr::Count { input: node, .. }
-            | IRAggExpr::Std(node, _)
-            | IRAggExpr::Var(node, _) => {
-                // Input order is deregarded, but must not observe order.
-                _ = rec!(*node);
-                O::None
-            },
-            IRAggExpr::Quantile { expr, quantile, .. } => {
-                // Input and quantile order is deregarded, but must not observe order.
-                _ = rec!(*expr);
-                _ = rec!(*quantile);
-                O::None
+            // Filter has to check whether zipping observes order, otherwise it propagates expr order.
+            AExpr::Filter { input, by } => {
+                let input = rec!(*input);
+                input.zip_with(rec!(*by))?;
+                input
             },
 
-            // Input order observing aggregations.
-            IRAggExpr::Implode(node) | IRAggExpr::First(node) | IRAggExpr::Last(node) => {
-                if rec!(*node).has_frame_ordering() {
-                    return Err(FrameOrderObserved);
+            AExpr::Sort { expr, options } => {
+                if options.maintain_order {
+                    rec!(*expr) | O::Independent
+                } else {
+                    _ = rec!(*expr);
+                    O::Independent
                 }
-                O::None
+            },
+            AExpr::SortBy {
+                expr,
+                by,
+                sort_options,
+            } => {
+                let mut zipped = rec!(*expr);
+                for e in by {
+                    zipped = zipped.zip_with(rec!(*e))?;
+                }
+
+                if sort_options.maintain_order {
+                    zipped | O::Independent
+                } else {
+                    O::Independent
+                }
             },
 
-            // @NOTE: This aggregation makes very little sense. We do the most pessimistic thing
-            // possible here.
-            IRAggExpr::AggGroups(_) => return Err(FrameOrderObserved),
-        },
+            AExpr::Agg(agg) => match agg {
+                // Input order agnostic aggregations.
+                IRAggExpr::Min { input: node, .. }
+                | IRAggExpr::Max { input: node, .. }
+                | IRAggExpr::Median(node)
+                | IRAggExpr::NUnique(node)
+                | IRAggExpr::Mean(node)
+                | IRAggExpr::Sum(node)
+                | IRAggExpr::Count { input: node, .. }
+                | IRAggExpr::Std(node, _)
+                | IRAggExpr::Var(node, _) => {
+                    // Input order is deregarded, but must not observe order.
+                    _ = rec!(*node);
+                    O::None
+                },
+                IRAggExpr::Quantile { expr, quantile, .. } => {
+                    // Input and quantile order is deregarded, but must not observe order.
+                    _ = rec!(*expr);
+                    _ = rec!(*quantile);
+                    O::None
+                },
 
-        AExpr::Gather {
-            expr,
-            idx,
-            returns_scalar,
-        } => {
-            let expr = rec!(*expr);
-            let idx = rec!(*idx);
+                // Input order observing aggregations.
+                IRAggExpr::Implode(node) | IRAggExpr::First(node) | IRAggExpr::Last(node) => {
+                    if rec!(*node).has_frame_ordering() {
+                        return Err(FrameOrderObserved);
+                    }
+                    O::None
+                },
 
-            // We need to ensure that the values come in frame order. The order of the idxes is
-            // propagated.
-            if expr.has_frame_ordering() {
-                return Err(FrameOrderObserved);
-            }
+                // @NOTE: This aggregation makes very little sense. We do the most pessimistic thing
+                // possible here.
+                IRAggExpr::AggGroups(_) => return Err(FrameOrderObserved),
+            },
 
-            if *returns_scalar { O::None } else { idx }
-        },
-        AExpr::AnonymousFunction { input, options, .. }
-        | AExpr::Function { input, options, .. } => {
-            let input_ordering = if input.is_empty() {
-                O::None
-            } else {
-                zip(input.iter().map(|e| Ok(rec!(e.node()))))?
-            };
-
-            if input_ordering.has_frame_ordering() && options.flags.observes_input_order() {
-                return Err(FrameOrderObserved);
-            }
-
-            match (
-                options.flags.terminates_input_order(),
-                options.flags.non_order_producing(),
-            ) {
-                (false, false) => input_ordering | O::Independent,
-                (false, true) => input_ordering,
-                (true, false) => O::Independent,
-                (true, true) => O::None,
-            }
-        },
-
-        AExpr::Eval {
-            expr,
-            evaluation: _,
-            variant,
-        } => match variant {
-            EvalVariant::List => rec!(*expr),
-            EvalVariant::Cumulative { min_samples: _ } => {
+            AExpr::Gather {
+                expr,
+                idx,
+                returns_scalar,
+            } => {
                 let expr = rec!(*expr);
+                let idx = rec!(*idx);
+
+                // We need to ensure that the values come in frame order. The order of the idxes is
+                // propagated.
                 if expr.has_frame_ordering() {
                     return Err(FrameOrderObserved);
                 }
-                expr
+
+                if *returns_scalar { O::None } else { idx }
             },
-        },
+            AExpr::AnonymousFunction { input, options, .. }
+            | AExpr::Function { input, options, .. } => {
+                // By definition, does not observe any input so cannot observe any ordering.
+                if input.is_empty() {
+                    return Ok(
+                        if options.flags.returns_scalar() || options.flags.is_output_unordered() {
+                            O::None
+                        } else {
+                            O::Independent
+                        },
+                    );
+                }
 
-        AExpr::Window {
-            function,
-            partition_by,
-            order_by,
-            options: _,
-        } => {
-            let input = rec!(*function);
+                // Elementwise are regarded as a `zip + function`.
+                if options.flags.is_elementwise() {
+                    return zip(input.iter().map(|e| Ok(rec!(e.node()))));
+                }
 
-            // @Performance.
-            // All of the code below might be a bit pessimistic, several window function variants
-            // are length preserving and/or propagate order in specific ways.
-            if input.has_frame_ordering() {
-                return Err(FrameOrderObserved);
-            }
-            for e in partition_by {
-                if rec!(*e).has_frame_ordering() {
+                if options.flags.propagates_order() {
+                    // Propagate the order of the singular input, this is for expressions like
+                    // `drop_nulls` and `rechunk`.
+                    assert_eq!(input.len(), 1);
+                    match rec!(input[0].node()) {
+                        v if !(options.flags.is_row_separable()
+                            || options.flags.is_input_order_agnostic())
+                            && v.has_frame_ordering() =>
+                        {
+                            return Err(FrameOrderObserved);
+                        },
+                        v => v,
+                    }
+                } else if options.flags.is_input_order_agnostic() {
+                    // There are also expressions that are entirely input order agnostic like
+                    // `null_count` and `unique(maintain_order=False)`
+                    for e in input {
+                        _ = rec!(e.node());
+                    }
+
+                    if options.returns_scalar() || options.flags.is_output_unordered() {
+                        O::None
+                    } else {
+                        O::Independent
+                    }
+                } else {
+                    // For other expressions, we are observing frame order i.f.f. any of the inputs are
+                    // observing frame order.
+                    for e in input {
+                        if rec!(e.node()).has_frame_ordering() {
+                            return Err(FrameOrderObserved);
+                        }
+                    }
+
+                    if options.returns_scalar() || options.flags.is_output_unordered() {
+                        O::None
+                    } else {
+                        O::Independent
+                    }
+                }
+            },
+
+            AExpr::Eval {
+                expr,
+                evaluation: _,
+                variant,
+            } => match variant {
+                EvalVariant::List => rec!(*expr),
+                EvalVariant::Cumulative { min_samples: _ } => {
+                    let expr = rec!(*expr);
+                    if expr.has_frame_ordering() {
+                        return Err(FrameOrderObserved);
+                    }
+                    expr
+                },
+            },
+
+            AExpr::Window {
+                function,
+                partition_by,
+                order_by,
+                options: _,
+            } => {
+                let input = rec!(*function);
+
+                // @Performance.
+                // All of the code below might be a bit pessimistic, several window function variants
+                // are length preserving and/or propagate order in specific ways.
+                if input.has_frame_ordering() {
                     return Err(FrameOrderObserved);
                 }
-            }
-            if let Some((e, _)) = &order_by
-                && rec!(*e).has_frame_ordering()
-            {
-                return Err(FrameOrderObserved);
-            }
-            O::Independent
-        },
-        AExpr::Slice {
-            input,
-            offset,
-            length,
-        } => {
-            // @NOTE
-            // `offset` and `length` are supposed to be scalars, they have to resolved as they
-            // might be order observing, but are not important for the output order.
-            _ = rec!(*offset);
-            _ = rec!(*length);
+                for e in partition_by {
+                    if rec!(*e).has_frame_ordering() {
+                        return Err(FrameOrderObserved);
+                    }
+                }
+                if let Some((e, _)) = &order_by
+                    && rec!(*e).has_frame_ordering()
+                {
+                    return Err(FrameOrderObserved);
+                }
+                O::Independent
+            },
+            AExpr::Slice {
+                input,
+                offset,
+                length,
+            } => {
+                // @NOTE
+                // `offset` and `length` are supposed to be scalars, they have to resolved as they
+                // might be order observing, but are not important for the output order.
+                _ = rec!(*offset);
+                _ = rec!(*length);
 
-            let input = rec!(*input);
-            if input.has_frame_ordering() {
-                return Err(FrameOrderObserved);
-            }
-            input
-        },
-        AExpr::Len => O::None,
-    })
+                let input = rec!(*input);
+                if input.has_frame_ordering() {
+                    return Err(FrameOrderObserved);
+                }
+                input
+            },
+            AExpr::Len => O::None,
+        })
+    }
 }

--- a/crates/polars-plan/src/plans/optimizer/set_order/expr_pushdown.rs
+++ b/crates/polars-plan/src/plans/optimizer/set_order/expr_pushdown.rs
@@ -76,12 +76,7 @@ impl ExprOutputOrder {
 pub fn zip(
     orders: impl IntoIterator<Item = Result<ExprOutputOrder, FrameOrderObserved>>,
 ) -> Result<ExprOutputOrder, FrameOrderObserved> {
-    use ExprOutputOrder as O;
-    let mut orders = orders.into_iter();
-    let Some(output_order) = orders.next() else {
-        return Ok(O::Independent);
-    };
-    let mut output_order = output_order?;
+    let mut output_order = ExprOutputOrder::None;
     for order in orders {
         output_order = output_order.zip_with(order?)?;
     }
@@ -102,15 +97,15 @@ pub fn get_observable_orders(
     aexpr: &AExpr,
     expr_arena: &Arena<AExpr>,
 ) -> Result<ExprOutputOrder, FrameOrderObserved> {
-    ObservableOrderingsResolver::new(ExprOutputOrder::Frame)
+    ExprOutputOrderResolver::new(ExprOutputOrder::Frame)
         .resolve_observable_orderings(aexpr, expr_arena)
 }
 
-pub(super) struct ObservableOrderingsResolver {
+pub(super) struct ExprOutputOrderResolver {
     column_ordering: ExprOutputOrder,
 }
 
-impl ObservableOrderingsResolver {
+impl ExprOutputOrderResolver {
     pub(super) fn new(column_ordering: ExprOutputOrder) -> Self {
         use ExprOutputOrder as O;
 
@@ -148,7 +143,7 @@ impl ObservableOrderingsResolver {
             // col(a).explode() * col(b).explode()
             AExpr::Explode { expr, .. } => rec!(*expr) | O::Independent,
 
-            AExpr::Column(_) => self.column_ordering,
+            AExpr::Column(_) => O::Frame,
             AExpr::Literal(lv) if lv.is_scalar() => O::None,
             AExpr::Literal(_) => O::Independent,
 
@@ -247,61 +242,24 @@ impl ObservableOrderingsResolver {
             },
             AExpr::AnonymousFunction { input, options, .. }
             | AExpr::Function { input, options, .. } => {
-                // By definition, does not observe any input so cannot observe any ordering.
-                if input.is_empty() {
-                    return Ok(
-                        if options.flags.returns_scalar() || options.flags.is_output_unordered() {
-                            O::None
-                        } else {
-                            O::Independent
-                        },
-                    );
-                }
-
-                // Elementwise are regarded as a `zip + function`.
-                if options.flags.is_elementwise() {
-                    return zip(input.iter().map(|e| Ok(rec!(e.node()))));
-                }
-
-                if options.flags.propagates_order() {
-                    // Propagate the order of the singular input, this is for expressions like
-                    // `drop_nulls` and `rechunk`.
-                    assert_eq!(input.len(), 1);
-                    match rec!(input[0].node()) {
-                        v if !(options.flags.is_row_separable()
-                            || options.flags.is_input_order_agnostic())
-                            && v.has_frame_ordering() =>
-                        {
-                            return Err(FrameOrderObserved);
-                        },
-                        v => v,
-                    }
-                } else if options.flags.is_input_order_agnostic() {
-                    // There are also expressions that are entirely input order agnostic like
-                    // `null_count` and `unique(maintain_order=False)`
-                    for e in input {
-                        _ = rec!(e.node());
-                    }
-
-                    if options.returns_scalar() || options.flags.is_output_unordered() {
-                        O::None
-                    } else {
-                        O::Independent
-                    }
+                let input_ordering = if input.is_empty() {
+                    O::None
                 } else {
-                    // For other expressions, we are observing frame order i.f.f. any of the inputs are
-                    // observing frame order.
-                    for e in input {
-                        if rec!(e.node()).has_frame_ordering() {
-                            return Err(FrameOrderObserved);
-                        }
-                    }
+                    zip(input.iter().map(|e| Ok(rec!(e.node()))))?
+                };
 
-                    if options.returns_scalar() || options.flags.is_output_unordered() {
-                        O::None
-                    } else {
-                        O::Independent
-                    }
+                if input_ordering.has_frame_ordering() && options.flags.observes_input_order() {
+                    return Err(FrameOrderObserved);
+                }
+
+                match (
+                    options.flags.terminates_input_order(),
+                    options.flags.non_order_producing(),
+                ) {
+                    (false, false) => input_ordering | O::Independent,
+                    (false, true) => input_ordering,
+                    (true, false) => O::Independent,
+                    (true, true) => O::None,
                 }
             },
 

--- a/crates/polars-plan/src/plans/optimizer/set_order/ir_pushdown.rs
+++ b/crates/polars-plan/src/plans/optimizer/set_order/ir_pushdown.rs
@@ -9,7 +9,7 @@ use polars_utils::arena::{Arena, Node};
 use polars_utils::idx_vec::UnitVec;
 use polars_utils::unique_id::UniqueId;
 
-use super::expr_pushdown::{adjust_for_with_columns_context, get_frame_observing, zip};
+use super::expr_pushdown::{adjust_for_with_columns_context, get_observable_orders, zip};
 use crate::dsl::{PartitionVariantIR, SinkTypeIR, UnionOptions};
 use crate::plans::set_order::expr_pushdown::FrameOrderObserved;
 use crate::plans::{AExpr, IR, is_scalar_ae};
@@ -91,7 +91,7 @@ pub(super) fn pushdown_orders(
                 let is_order_observing = sort_options.maintain_order || {
                     adjust_for_with_columns_context(zip(by_column
                         .iter()
-                        .map(|e| get_frame_observing(expr_arena.get(e.node()), expr_arena))))
+                        .map(|e| get_observable_orders(expr_arena.get(e.node()), expr_arena))))
                     .is_err()
                 };
                 [is_order_observing].into()
@@ -120,7 +120,7 @@ pub(super) fn pushdown_orders(
                         let expr_observing = adjust_for_with_columns_context(zip(keys
                             .iter()
                             .chain(aggs.iter())
-                            .map(|e| get_frame_observing(expr_arena.get(e.node()), expr_arena))))
+                            .map(|e| get_observable_orders(expr_arena.get(e.node()), expr_arena))))
                         .is_err();
 
                         expr_observing
@@ -218,7 +218,7 @@ pub(super) fn pushdown_orders(
                 let input = *input;
                 let mut observing = zip(exprs
                     .iter()
-                    .map(|e| get_frame_observing(expr_arena.get(e.node()), expr_arena)));
+                    .map(|e| get_observable_orders(expr_arena.get(e.node()), expr_arena)));
 
                 let input_schema = ir_arena.get(input).schema(ir_arena).as_ref().clone();
                 ir = ir_arena.get_mut(node);
@@ -244,7 +244,7 @@ pub(super) fn pushdown_orders(
             IR::Select { expr: exprs, .. } => {
                 let observing = zip(exprs
                     .iter()
-                    .map(|e| get_frame_observing(expr_arena.get(e.node()), expr_arena)));
+                    .map(|e| get_observable_orders(expr_arena.get(e.node()), expr_arena)));
                 let is_order_observing = match observing {
                     Ok(o) => o.has_frame_ordering() && !all_outputs_unordered,
                     Err(FrameOrderObserved) => true,
@@ -256,7 +256,7 @@ pub(super) fn pushdown_orders(
                 input: _,
                 predicate,
             } => {
-                let observing = adjust_for_with_columns_context(get_frame_observing(
+                let observing = adjust_for_with_columns_context(get_observable_orders(
                     expr_arena.get(predicate.node()),
                     expr_arena,
                 ));
@@ -294,7 +294,7 @@ pub(super) fn pushdown_orders(
                             PartitionVariantIR::Parted { .. } => true,
                             PartitionVariantIR::ByKey { key_exprs, .. } => {
                                 adjust_for_with_columns_context(zip(key_exprs.iter().map(|e| {
-                                    get_frame_observing(expr_arena.get(e.node()), expr_arena)
+                                    get_observable_orders(expr_arena.get(e.node()), expr_arena)
                                 })))
                                 .is_err()
                             },


### PR DESCRIPTION
The order definitions for expressions are currently duplicated across 2 functions.

This PR makes it so that we only use a single function, making it less error-prone, as well as now having a single source of truth.
