### PR TITLE
refactor(rust): Remove duplicate maintain_order from CrossJoinOptions

### DIFF
--- a/crates/polars-ops/src/frame/join/args.rs
+++ b/crates/polars-ops/src/frame/join/args.rs
@@ -169,7 +169,6 @@ where
 #[derive(Clone)]
 pub struct CrossJoinOptions {
     pub predicate: Arc<dyn CrossJoinFilter>,
-    pub maintain_order: MaintainOrderJoin,
 }
 
 impl CrossJoinOptions {
@@ -183,14 +182,12 @@ impl Eq for CrossJoinOptions {}
 impl PartialEq for CrossJoinOptions {
     fn eq(&self, other: &Self) -> bool {
         std::ptr::addr_eq(self.as_ptr_ref(), other.as_ptr_ref())
-            && self.maintain_order == other.maintain_order
     }
 }
 
 impl Hash for CrossJoinOptions {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.as_ptr_ref().hash(state);
-        self.maintain_order.hash(state);
     }
 }
 

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -134,7 +134,13 @@ pub trait DataFrameJoinOps: IntoDf {
         if let JoinType::Cross = args.how {
             if let Some(JoinTypeOptions::Cross(cross_options)) = &options {
                 assert!(args.slice.is_none());
-                return fused_cross_filter(left_df, other, args.suffix.clone(), cross_options);
+                return fused_cross_filter(
+                    left_df,
+                    other,
+                    args.suffix.clone(),
+                    cross_options,
+                    args.maintain_order,
+                );
             }
             return left_df.cross_join(other, args.suffix.clone(), args.slice, args.maintain_order);
         }

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -200,11 +200,7 @@ impl<'a> IRDisplay<'a> {
                 let right_on = self.display_expr_slice(right_on);
 
                 // Fused cross + filter (show as nested loop join)
-                if let Some(JoinTypeOptionsIR::CrossAndFilter {
-                    predicate,
-                    maintain_order: _,
-                }) = &options.options
-                {
+                if let Some(JoinTypeOptionsIR::CrossAndFilter { predicate }) = &options.options {
                     let predicate = self.display_expr(predicate);
                     let name = "NESTED LOOP";
                     write!(f, "{:indent$}{name} JOIN ON {predicate}:", "")?;
@@ -881,11 +877,7 @@ pub fn write_ir_non_recursive(
             };
 
             // Fused cross + filter (show as nested loop join)
-            if let Some(JoinTypeOptionsIR::CrossAndFilter {
-                predicate,
-                maintain_order: _,
-            }) = &options.options
-            {
+            if let Some(JoinTypeOptionsIR::CrossAndFilter { predicate }) = &options.options {
                 let predicate = predicate.display(expr_arena);
                 write!(f, "{:indent$}NESTED_LOOP JOIN ON {predicate}", "")?;
             } else {

--- a/crates/polars-plan/src/plans/ir/inputs.rs
+++ b/crates/polars-plan/src/plans/ir/inputs.rs
@@ -90,10 +90,7 @@ impl IR {
                 options,
                 ..
             } => match &options.options {
-                Some(JoinTypeOptionsIR::CrossAndFilter {
-                    predicate,
-                    maintain_order: _,
-                }) => Exprs::Boxed(Box::new(
+                Some(JoinTypeOptionsIR::CrossAndFilter { predicate }) => Exprs::Boxed(Box::new(
                     left_on
                         .iter()
                         .chain(right_on.iter())
@@ -166,10 +163,7 @@ impl IR {
                 options,
                 ..
             } => match Arc::make_mut(options).options.as_mut() {
-                Some(JoinTypeOptionsIR::CrossAndFilter {
-                    predicate,
-                    maintain_order: _,
-                }) => ExprsMut::Boxed(Box::new(
+                Some(JoinTypeOptionsIR::CrossAndFilter { predicate }) => ExprsMut::Boxed(Box::new(
                     left_on
                         .iter_mut()
                         .chain(right_on.iter_mut())

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
@@ -409,10 +409,8 @@ fn try_rewrite_join_type(
 
         match &options.options {
             Some(JoinTypeOptionsIR::CrossAndFilter { .. }) => {
-                let Some(JoinTypeOptionsIR::CrossAndFilter {
-                    predicate,
-                    maintain_order: _,
-                }) = Arc::make_mut(options).options.take()
+                let Some(JoinTypeOptionsIR::CrossAndFilter { predicate }) =
+                    Arc::make_mut(options).options.take()
                 else {
                     unreachable!()
                 };
@@ -537,12 +535,10 @@ fn try_rewrite_join_type(
             return Ok(());
         };
 
-        let maintain_order = options.args.maintain_order;
         let existing = Arc::make_mut(options)
             .options
             .replace(JoinTypeOptionsIR::CrossAndFilter {
                 predicate: ExprIR::from_node(nested_loop_predicates, expr_arena),
-                maintain_order,
             });
         assert!(existing.is_none()); // Important
 


### PR DESCRIPTION
I added this in https://github.com/pola-rs/polars/pull/24665 but it was not necessary.