### PR TITLE
feat: Drop now-unnecessary post-init "schema_overrides" cast on `DataFrame` load from list of dicts

### DIFF
--- a/py-polars/src/polars/_utils/construction/dataframe.py
+++ b/py-polars/src/polars/_utils/construction/dataframe.py
@@ -721,13 +721,6 @@ def _sequence_of_dict_to_pydf(
         strict=strict,
         infer_schema_length=infer_schema_length,
     )
-
-    # TODO: we can remove this `schema_overrides` block completely
-    #  once https://github.com/pola-rs/polars/issues/11044 is fixed
-    if schema_overrides:
-        pydf = _post_apply_columns(
-            pydf, columns=column_names, schema_overrides=schema_overrides, strict=strict
-        )
     return pydf
 
 


### PR DESCRIPTION
As per the inline "TODO", https://github.com/pola-rs/polars/issues/11044 was fixed a while back and I've confirmed that we can now avoid the additional post-init "schema_overrides" `cast` behaviour when loading a `DataFrame` from a list of records/dicts 👍 