### PR TITLE
fix: Fix iterable on `dynamic_group_by` and `rolling` object

### DIFF
--- a/py-polars/src/polars/dataframe/group_by.py
+++ b/py-polars/src/polars/dataframe/group_by.py
@@ -803,6 +803,7 @@ class RollingGroupBy:
         temp_col = "__POLARS_GB_GROUP_INDICES"
         groups_df = (
             self.df.lazy()
+            .with_row_index()
             .rolling(
                 index_column=self.time_column,
                 period=self.period,
@@ -810,7 +811,7 @@ class RollingGroupBy:
                 closed=self.closed,
                 group_by=self.group_by,
             )
-            .agg(F.first().agg_groups().alias(temp_col))
+            .agg(F.first().alias(temp_col))
             .collect(optimizations=QueryOptFlags.none())
         )
 
@@ -951,6 +952,7 @@ class DynamicGroupBy:
         temp_col = "__POLARS_GB_GROUP_INDICES"
         groups_df = (
             self.df.lazy()
+            .with_row_index()
             .group_by_dynamic(
                 index_column=self.time_column,
                 every=self.every,
@@ -962,7 +964,7 @@ class DynamicGroupBy:
                 group_by=self.group_by,
                 start_by=self.start_by,
             )
-            .agg(F.first().agg_groups().alias(temp_col))
+            .agg(F.first().alias(temp_col))
             .collect(optimizations=QueryOptFlags.none())
         )
 

--- a/py-polars/src/polars/dataframe/group_by.py
+++ b/py-polars/src/polars/dataframe/group_by.py
@@ -106,8 +106,9 @@ class GroupBy:
         temp_col = "__POLARS_GB_GROUP_INDICES"
         groups_df = (
             self.df.lazy()
+            .with_row_index()
             .group_by(*self.by, **self.named_by, maintain_order=self.maintain_order)
-            .agg(F.first().agg_groups().alias(temp_col))
+            .agg(F.first().alias(temp_col))
             .collect(optimizations=QueryOptFlags.none())
         )
 

--- a/py-polars/tests/unit/operations/test_group_by_dynamic.py
+++ b/py-polars/tests/unit/operations/test_group_by_dynamic.py
@@ -1168,3 +1168,22 @@ def test_group_by_dynamic_closed_ternary_cum_sum_with_agg_24566(
 
     expected = pl.DataFrame({"d": [10, 11, 12, 13, 14], "index": result})
     assert_frame_equal(out, expected)
+
+
+def test_group_by_dynamic_with_group_by_iter_24394() -> None:
+    df = pl.DataFrame(
+        {
+            "t": [0, 1, 2, 3],
+            "g": [10, 20, 10, 20],
+        }
+    )
+
+    groups_dynamic = df.group_by_dynamic(
+        "t", every="3i", group_by="g", start_by="datapoint"
+    )
+    for (_, _), sub_df in groups_dynamic:
+        assert len(sub_df["g"].unique()) == 1
+
+    groups_rolling = df.rolling("t", period="2i", group_by="g")
+    for (_, _), sub_df in groups_rolling:
+        assert len(sub_df["g"].unique()) == 1


### PR DESCRIPTION
fixes #24394

Note - there is still an underlying bug in `agg_groups()`, as documented in the issue. Since this expression is to be deprecated, see https://github.com/pola-rs/polars/issues/22468, the iterable issue has been fixed in the Python code.