### PR TITLE
fix: Set feature flags during python release

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -39,8 +39,6 @@ defaults:
 jobs:
   base-package:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
 
     steps:
       - name: Checkout


### PR DESCRIPTION
@coastalwhite the 1.34.0 build doesn't include the appropriate feature flags in `_plr.py`, neither in the wheel nor in the sdist.

This was because there were still leftovers from the previous build process. In this pipeline, there is no `matrix` anymore.

<img width="749" height="246" alt="image" src="https://github.com/user-attachments/assets/5ad16c53-7c0d-4f80-bc56-0c99f85456bc" />
