### PR TITLE
build(python): Update pyo3 and numpy crates to version 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2703,9 +2703,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f1dee9aa8d3f6f8e8b9af3803006101bb3653866ef056d530d53ae68587191"
+checksum = "9b2dba356160b54f5371b550575b78130a54718b4c6e46b3f33a6da74a27e78b"
 dependencies = [
  "libc",
  "ndarray",
@@ -3814,9 +3814,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -3834,19 +3834,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3854,9 +3853,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3866,9 +3865,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,13 +62,13 @@ memmap = { package = "memmap2", version = "0.9" }
 ndarray = { version = "0.16", default-features = false }
 num-bigint = "0.4.6"
 num-traits = "0.2"
-numpy = "0.25"
+numpy = "0.26"
 object_store = { version = "0.12", default-features = false, features = ["fs"] }
 parking_lot = "0.12"
 percent-encoding = "2.3"
 pin-project-lite = "0.2"
 proptest = { version = "1.6", default-features = false, features = ["std"] }
-pyo3 = "0.25"
+pyo3 = "0.26"
 rand = "0.9"
 rand_distr = "0.5"
 raw-cpuid = "11"

--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -265,7 +265,7 @@ impl PolarsError {
             SQLSyntax(msg) => SQLSyntax(func(msg).into()),
             Context { error, .. } => error.wrap_msg(func),
             #[cfg(feature = "python")]
-            Python { error } => pyo3::Python::with_gil(|py| {
+            Python { error } => pyo3::Python::attach(|py| {
                 use pyo3::types::{PyAnyMethods, PyStringMethods};
                 use pyo3::{IntoPyObject, PyErr};
 

--- a/crates/polars-error/src/python.rs
+++ b/crates/polars-error/src/python.rs
@@ -14,7 +14,7 @@ impl From<pyo3::PyErr> for PolarsError {
 
 impl Clone for PyErrWrap {
     fn clone(&self) -> Self {
-        Python::with_gil(|py| Self(self.0.clone_ref(py)))
+        Python::attach(|py| Self(self.0.clone_ref(py)))
     }
 }
 

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -386,7 +386,7 @@ impl CloudOptions {
         let opt_credential_provider = match opt_credential_provider {
             #[cfg(feature = "python")]
             Some(PlCredentialProvider::Python(object)) => {
-                if pyo3::Python::with_gil(|py| {
+                if pyo3::Python::attach(|py| {
                     let Ok(func_object) = object
                         .unwrap_as_provider_ref()
                         .getattr(py, "_can_use_as_provider")

--- a/crates/polars-lazy/src/frame/python.rs
+++ b/crates/polars-lazy/src/frame/python.rs
@@ -2,15 +2,15 @@ use std::sync::Arc;
 
 use either::Either;
 use polars_core::schema::SchemaRef;
-use pyo3::PyObject;
+use pyo3::{Py, PyAny};
 
 use self::python_dsl::{PythonOptionsDsl, PythonScanSource};
 use crate::prelude::*;
 
 impl LazyFrame {
     pub fn scan_from_python_function(
-        schema: Either<PyObject, SchemaRef>,
-        scan_fn: PyObject,
+        schema: Either<Py<PyAny>, SchemaRef>,
+        scan_fn: Py<PyAny>,
         pyarrow: bool,
         // Validate that the source gives the proper schema
         validate_schema: bool,

--- a/crates/polars-mem-engine/src/executors/scan/python_scan.rs
+++ b/crates/polars-mem-engine/src/executors/scan/python_scan.rs
@@ -60,7 +60,7 @@ impl Executor for PythonScanExec {
         }
         let with_columns = self.options.with_columns.take();
         let n_rows = self.options.n_rows.take();
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let pl = PyModule::import(py, intern!(py, "polars")).unwrap();
             let utils = pl.getattr(intern!(py, "_utils")).unwrap();
             let callable = utils.getattr(intern!(py, "_execute_from_rust")).unwrap();

--- a/crates/polars-plan/src/callback.rs
+++ b/crates/polars-plan/src/callback.rs
@@ -239,7 +239,7 @@ impl<Args: PlanCallbackArgs, Out: PlanCallbackOut> PlanCallback<Args, Out> {
     pub fn call(&self, args: Args) -> PolarsResult<Out> {
         match self {
             #[cfg(feature = "python")]
-            Self::Python(pyfn) => pyo3::Python::with_gil(|py| {
+            Self::Python(pyfn) => pyo3::Python::attach(|py| {
                 let out = Out::from_pyany(pyfn.call1(py, (args.into_pyany(py)?,))?, py)?;
                 Ok(out)
             }),

--- a/crates/polars-plan/src/dsl/options/sink.rs
+++ b/crates/polars-plan/src/dsl/options/sink.rs
@@ -265,10 +265,10 @@ impl PartitionTargetContextKey {
         Ok(value.to_string())
     }
     #[getter]
-    pub fn raw_value(&self) -> pyo3::PyObject {
+    pub fn raw_value(&self) -> pyo3::Py<pyo3::PyAny> {
         let converter = polars_core::chunked_array::object::registry::get_pyobject_converter();
         *(converter.as_ref())(self.raw_value.as_any_value())
-            .downcast::<pyo3::PyObject>()
+            .downcast::<pyo3::Py<pyo3::PyAny>>()
             .unwrap()
     }
 }
@@ -318,7 +318,7 @@ impl SinkFinishCallback {
         match self {
             Self::Rust(f) => f(df),
             #[cfg(feature = "python")]
-            Self::Python(f) => pyo3::Python::with_gil(|py| {
+            Self::Python(f) => pyo3::Python::attach(|py| {
                 let converter =
                     polars_utils::python_convert_registry::get_python_convert_registry();
                 let df = (converter.to_py.df)(Box::new(df) as Box<dyn std::any::Any>)?;
@@ -340,7 +340,7 @@ impl PartitionTargetCallback {
         match self {
             Self::Rust(f) => f(ctx),
             #[cfg(feature = "python")]
-            Self::Python(f) => pyo3::Python::with_gil(|py| {
+            Self::Python(f) => pyo3::Python::attach(|py| {
                 let partition_target = f.call1(py, (ctx,))?;
                 let converter =
                     polars_utils::python_convert_registry::get_python_convert_registry();

--- a/crates/polars-plan/src/dsl/python_dsl/python_udf.rs
+++ b/crates/polars-plan/src/dsl/python_dsl/python_udf.rs
@@ -15,10 +15,10 @@ use crate::prelude::*;
 // Will be overwritten on Python Polars start up.
 #[allow(clippy::type_complexity)]
 pub static mut CALL_COLUMNS_UDF_PYTHON: Option<
-    fn(s: &[Column], output_dtype: Option<DataType>, lambda: &PyObject) -> PolarsResult<Column>,
+    fn(s: &[Column], output_dtype: Option<DataType>, lambda: &Py<PyAny>) -> PolarsResult<Column>,
 > = None;
 pub static mut CALL_DF_UDF_PYTHON: Option<
-    fn(s: DataFrame, lambda: &PyObject) -> PolarsResult<DataFrame>,
+    fn(s: DataFrame, lambda: &Py<PyAny>) -> PolarsResult<DataFrame>,
 > = None;
 
 pub use polars_utils::python_function::PythonFunction;
@@ -26,7 +26,7 @@ pub use polars_utils::python_function::PythonFunction;
 pub use polars_utils::python_function::{PYTHON_SERDE_MAGIC_BYTE_MARK, PYTHON3_VERSION};
 
 pub struct PythonUdfExpression {
-    python_function: PyObject,
+    python_function: Py<PyAny>,
     output_type: Option<DataTypeExpr>,
     materialized_field: OnceLock<Field>,
     is_elementwise: bool,
@@ -35,7 +35,7 @@ pub struct PythonUdfExpression {
 
 impl PythonUdfExpression {
     pub fn new(
-        lambda: PyObject,
+        lambda: Py<PyAny>,
         output_type: Option<impl Into<DataTypeExpr>>,
         is_elementwise: bool,
         returns_scalar: bool,
@@ -120,7 +120,7 @@ impl AnonymousColumnsUdf for PythonUdfExpression {
     }
     fn deep_clone(self: Arc<Self>) -> Arc<dyn AnonymousColumnsUdf> {
         Arc::new(Self {
-            python_function: Python::with_gil(|py| self.python_function.clone_ref(py)),
+            python_function: Python::attach(|py| self.python_function.clone_ref(py)),
             output_type: self.output_type.clone(),
             materialized_field: OnceLock::new(),
             is_elementwise: self.is_elementwise,

--- a/crates/polars-plan/src/dsl/python_dsl/source.rs
+++ b/crates/polars-plan/src/dsl/python_dsl/source.rs
@@ -27,7 +27,7 @@ pub struct PythonOptionsDsl {
 impl PythonOptionsDsl {
     pub fn get_schema(&self) -> PolarsResult<SchemaRef> {
         match self.schema_fn.as_ref().expect("should be set").as_ref() {
-            Either::Left(func) => Python::with_gil(|py| {
+            Either::Left(func) => Python::attach(|py| {
                 let schema = func
                     .0
                     .call0(py)

--- a/crates/polars-plan/src/plans/aexpr/function_expr/plugin.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/plugin.rs
@@ -24,7 +24,7 @@ fn get_lib(lib: &str) -> PolarsResult<&'static PluginAndVersion> {
         #[cfg(feature = "python")]
         let load_path = if !std::path::Path::new(lib).is_absolute() {
             // Get python virtual environment path
-            let prefix = Python::with_gil(|py| {
+            let prefix = Python::attach(|py| {
                 let sys = py.import("sys").unwrap();
                 let prefix = sys.getattr("prefix").unwrap();
                 prefix.to_string()

--- a/crates/polars-python/src/conversion/any_value.rs
+++ b/crates/polars-python/src/conversion/any_value.rs
@@ -18,7 +18,7 @@ use polars_core::utils::arrow::temporal_conversions::date32_to_date;
 use polars_utils::aliases::PlFixedStateQuality;
 use pyo3::exceptions::{PyOverflowError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
-use pyo3::sync::GILOnceCell;
+use pyo3::sync::PyOnceLock;
 use pyo3::types::{
     PyBool, PyBytes, PyDate, PyDateTime, PyDelta, PyDict, PyFloat, PyInt, PyList, PyMapping,
     PyRange, PySequence, PyString, PyTime, PyTuple, PyType, PyTzInfo,
@@ -520,14 +520,14 @@ pub(crate) fn py_object_to_any_value(
         } else if ob.is_instance_of::<PyRange>() {
             Ok(get_list as InitFn)
         } else {
-            static NDARRAY_TYPE: GILOnceCell<Py<PyType>> = GILOnceCell::new();
+            static NDARRAY_TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
             if let Ok(ndarray_type) = NDARRAY_TYPE.import(py, "numpy", "ndarray") {
                 if ob.is_instance(ndarray_type)? {
                     // will convert via Series -> mmap_numpy_array
                     return Ok(get_list as InitFn);
                 }
             }
-            static DECIMAL_TYPE: GILOnceCell<Py<PyType>> = GILOnceCell::new();
+            static DECIMAL_TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
             if ob.is_instance(DECIMAL_TYPE.import(py, "decimal", "Decimal")?)? {
                 return Ok(get_decimal as InitFn);
             }

--- a/crates/polars-python/src/dataframe/general.rs
+++ b/crates/polars-python/src/dataframe/general.rs
@@ -365,7 +365,7 @@ impl PyDataFrame {
         &self,
         py: Python<'_>,
         by: Vec<PyBackedStr>,
-        lambda: PyObject,
+        lambda: Py<PyAny>,
         maintain_order: bool,
     ) -> PyResult<Self> {
         py.enter_polars_df(|| {
@@ -377,7 +377,7 @@ impl PyDataFrame {
             }?;
 
             let function = move |df: DataFrame| {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let pypolars = polars(py).bind(py);
                     let pydf = PyDataFrame::new(df);
                     let python_df_wrapper =
@@ -498,8 +498,8 @@ impl PyDataFrame {
         lambda: Bound<PyAny>,
         output_type: Option<Wrap<DataType>>,
         inference_size: usize,
-    ) -> PyResult<(PyObject, bool)> {
-        Python::with_gil(|py| {
+    ) -> PyResult<(Py<PyAny>, bool)> {
+        Python::attach(|py| {
             let mut df = self.df.write();
             df.as_single_chunk_par(); // needed for series iter
             let df = &*RwLockWriteGuard::downgrade(df);

--- a/crates/polars-python/src/dataframe/io.rs
+++ b/crates/polars-python/src/dataframe/io.rs
@@ -217,7 +217,7 @@ impl PyDataFrame {
     #[pyo3(signature = (py_f, columns, projection, n_rows))]
     pub fn read_avro(
         py: Python<'_>,
-        py_f: PyObject,
+        py_f: Py<PyAny>,
         columns: Option<Vec<String>>,
         projection: Option<Vec<usize>>,
         n_rows: Option<usize>,
@@ -235,7 +235,7 @@ impl PyDataFrame {
     }
 
     #[cfg(feature = "json")]
-    pub fn write_json(&self, py: Python<'_>, py_f: PyObject) -> PyResult<()> {
+    pub fn write_json(&self, py: Python<'_>, py_f: Py<PyAny>) -> PyResult<()> {
         let file = BufWriter::new(get_file_like(py_f, true)?);
         py.enter_polars(|| {
             // TODO: Cloud support
@@ -250,7 +250,7 @@ impl PyDataFrame {
     pub fn write_ipc_stream(
         &self,
         py: Python<'_>,
-        py_f: PyObject,
+        py_f: Py<PyAny>,
         compression: Wrap<Option<IpcCompression>>,
         compat_level: PyCompatLevel,
     ) -> PyResult<()> {
@@ -268,7 +268,7 @@ impl PyDataFrame {
     pub fn write_avro(
         &self,
         py: Python<'_>,
-        py_f: PyObject,
+        py_f: Py<PyAny>,
         compression: Wrap<Option<AvroCompression>>,
         name: String,
     ) -> PyResult<()> {

--- a/crates/polars-python/src/dataframe/serde.rs
+++ b/crates/polars-python/src/dataframe/serde.rs
@@ -14,7 +14,7 @@ use crate::utils::EnterPolarsExt;
 #[pymethods]
 impl PyDataFrame {
     /// Serialize into binary data.
-    fn serialize_binary(slf: Bound<'_, Self>, py_f: PyObject) -> PyResult<()> {
+    fn serialize_binary(slf: Bound<'_, Self>, py_f: Py<PyAny>) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
         let mut writer = BufWriter::new(file);
 
@@ -28,7 +28,7 @@ impl PyDataFrame {
 
     /// Deserialize a file-like object containing binary data into a DataFrame.
     #[staticmethod]
-    fn deserialize_binary(py: Python<'_>, py_f: PyObject) -> PyResult<Self> {
+    fn deserialize_binary(py: Python<'_>, py_f: Py<PyAny>) -> PyResult<Self> {
         let file = get_file_like(py_f, false)?;
         let mut file = BufReader::new(file);
 
@@ -37,7 +37,7 @@ impl PyDataFrame {
 
     /// Serialize into a JSON string.
     #[cfg(feature = "json")]
-    pub fn serialize_json(&self, py: Python<'_>, py_f: PyObject) -> PyResult<()> {
+    pub fn serialize_json(&self, py: Python<'_>, py_f: Py<PyAny>) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
         let writer = BufWriter::new(file);
         py.enter_polars(|| {

--- a/crates/polars-python/src/expr/array.rs
+++ b/crates/polars-python/src/expr/array.rs
@@ -119,7 +119,7 @@ impl PyExpr {
     }
 
     #[pyo3(signature = (name_gen))]
-    fn arr_to_struct(&self, name_gen: Option<PyObject>) -> Self {
+    fn arr_to_struct(&self, name_gen: Option<Py<PyAny>>) -> Self {
         let name_gen = name_gen.map(|o| PlanCallback::new_python(PythonObject(o)));
         self.inner.clone().arr().to_struct(name_gen).into()
     }

--- a/crates/polars-python/src/expr/name.rs
+++ b/crates/polars-python/src/expr/name.rs
@@ -10,7 +10,7 @@ impl PyExpr {
         self.inner.clone().name().keep().into()
     }
 
-    fn name_map(&self, lambda: PyObject) -> Self {
+    fn name_map(&self, lambda: Py<PyAny>) -> Self {
         self.inner
             .clone()
             .name()
@@ -34,7 +34,7 @@ impl PyExpr {
         self.inner.clone().name().to_uppercase().into()
     }
 
-    fn name_map_fields(&self, name_mapper: PyObject) -> Self {
+    fn name_map_fields(&self, name_mapper: Py<PyAny>) -> Self {
         self.inner
             .clone()
             .name()

--- a/crates/polars-python/src/expr/rolling.rs
+++ b/crates/polars-python/src/expr/rolling.rs
@@ -366,7 +366,7 @@ impl PyExpr {
     #[pyo3(signature = (lambda, window_size, weights, min_periods, center))]
     fn rolling_map(
         &self,
-        lambda: PyObject,
+        lambda: Py<PyAny>,
         window_size: usize,
         weights: Option<Vec<f64>>,
         min_periods: Option<usize>,

--- a/crates/polars-python/src/expr/serde.rs
+++ b/crates/polars-python/src/expr/serde.rs
@@ -35,7 +35,7 @@ impl PyExpr {
     }
 
     /// Serialize into binary data.
-    fn serialize_binary(&self, py_f: PyObject) -> PyResult<()> {
+    fn serialize_binary(&self, py_f: Py<PyAny>) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
         let writer = BufWriter::new(file);
         pl_serialize::SerializeOptions::default()
@@ -45,7 +45,7 @@ impl PyExpr {
 
     /// Serialize into a JSON string.
     #[cfg(feature = "json")]
-    fn serialize_json(&self, py_f: PyObject) -> PyResult<()> {
+    fn serialize_json(&self, py_f: Py<PyAny>) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
         let writer = BufWriter::new(file);
         serde_json::to_writer(writer, &self.inner)
@@ -54,7 +54,7 @@ impl PyExpr {
 
     /// Deserialize a file-like object containing binary data into an Expr.
     #[staticmethod]
-    fn deserialize_binary(py_f: PyObject) -> PyResult<PyExpr> {
+    fn deserialize_binary(py_f: Py<PyAny>) -> PyResult<PyExpr> {
         let file = get_file_like(py_f, false)?;
         let reader = BufReader::new(file);
         let expr: Expr = pl_serialize::SerializeOptions::default()
@@ -66,7 +66,7 @@ impl PyExpr {
     /// Deserialize a file-like object containing JSON string data into an Expr.
     #[staticmethod]
     #[cfg(feature = "json")]
-    fn deserialize_json(py_f: PyObject) -> PyResult<PyExpr> {
+    fn deserialize_json(py_f: Py<PyAny>) -> PyResult<PyExpr> {
         // it is faster to first read to memory and then parse: https://github.com/serde-rs/json/issues/160
         // so don't bother with files.
         let mut json = String::new();

--- a/crates/polars-python/src/functions/io.rs
+++ b/crates/polars-python/src/functions/io.rs
@@ -13,7 +13,7 @@ use crate::file::{EitherRustPythonFile, get_either_file};
 
 #[cfg(feature = "ipc")]
 #[pyfunction]
-pub fn read_ipc_schema(py: Python<'_>, py_f: PyObject) -> PyResult<Bound<'_, PyDict>> {
+pub fn read_ipc_schema(py: Python<'_>, py_f: Py<PyAny>) -> PyResult<Bound<'_, PyDict>> {
     use arrow::io::ipc::read::read_file_metadata;
     let metadata = match get_either_file(py_f, false)? {
         EitherRustPythonFile::Rust(r) => {
@@ -31,9 +31,9 @@ pub fn read_ipc_schema(py: Python<'_>, py_f: PyObject) -> PyResult<Bound<'_, PyD
 #[pyfunction]
 pub fn read_parquet_metadata(
     py: Python,
-    py_f: PyObject,
+    py_f: Py<PyAny>,
     storage_options: Option<Vec<(String, String)>>,
-    credential_provider: Option<PyObject>,
+    credential_provider: Option<Py<PyAny>>,
     retries: usize,
 ) -> PyResult<Bound<PyDict>> {
     use std::io::Cursor;
@@ -131,7 +131,7 @@ pub fn write_clipboard_string(s: &str) -> PyResult<()> {
 pub fn parse_cloud_options<'a>(
     first_path: Option<PlPathRef<'a>>,
     storage_options: Option<Vec<(String, String)>>,
-    credential_provider: Option<PyObject>,
+    credential_provider: Option<Py<PyAny>>,
     retries: usize,
 ) -> PyResult<Option<CloudOptions>> {
     let result = if let Some(first_path) = first_path {

--- a/crates/polars-python/src/functions/lazy.rs
+++ b/crates/polars-python/src/functions/lazy.rs
@@ -148,7 +148,7 @@ pub fn collect_all_with_callback(
     lfs: Vec<PyLazyFrame>,
     engine: Wrap<Engine>,
     optflags: PyOptFlags,
-    lambda: PyObject,
+    lambda: Py<PyAny>,
     py: Python<'_>,
 ) {
     let plans = lfs
@@ -165,7 +165,7 @@ pub fn collect_all_with_callback(
                 .collect::<Vec<PyDataFrame>>()
         });
 
-    Python::with_gil(|py| match result {
+    Python::attach(|py| match result {
         Ok(dfs) => {
             lambda.call1(py, (dfs,)).map_err(|err| err.restore(py)).ok();
         },
@@ -246,7 +246,7 @@ pub fn arctan2(y: PyExpr, x: PyExpr) -> PyExpr {
 #[pyfunction]
 pub fn cum_fold(
     acc: PyExpr,
-    lambda: PyObject,
+    lambda: Py<PyAny>,
     exprs: Vec<PyExpr>,
     returns_scalar: bool,
     return_dtype: Option<PyDataTypeExpr>,
@@ -267,7 +267,7 @@ pub fn cum_fold(
 
 #[pyfunction]
 pub fn cum_reduce(
-    lambda: PyObject,
+    lambda: Py<PyAny>,
     exprs: Vec<PyExpr>,
     returns_scalar: bool,
     return_dtype: Option<PyDataTypeExpr>,
@@ -411,7 +411,7 @@ pub fn duration(
 #[pyfunction]
 pub fn fold(
     acc: PyExpr,
-    lambda: PyObject,
+    lambda: Py<PyAny>,
     exprs: Vec<PyExpr>,
     returns_scalar: bool,
     return_dtype: Option<PyDataTypeExpr>,
@@ -487,7 +487,7 @@ pub fn lit(value: &Bound<'_, PyAny>, allow_object: bool, is_scalar: bool) -> PyR
 #[pyo3(signature = (pyexpr, lambda, output_type, is_elementwise, returns_scalar))]
 pub fn map_expr(
     pyexpr: Vec<PyExpr>,
-    lambda: PyObject,
+    lambda: Py<PyAny>,
     output_type: Option<PyDataTypeExpr>,
     is_elementwise: bool,
     returns_scalar: bool,
@@ -502,7 +502,7 @@ pub fn pearson_corr(a: PyExpr, b: PyExpr) -> PyExpr {
 
 #[pyfunction]
 pub fn reduce(
-    lambda: PyObject,
+    lambda: Py<PyAny>,
     exprs: Vec<PyExpr>,
     returns_scalar: bool,
     return_dtype: Option<PyDataTypeExpr>,

--- a/crates/polars-python/src/interop/arrow/to_py.rs
+++ b/crates/polars-python/src/interop/arrow/to_py.rs
@@ -18,7 +18,7 @@ pub(crate) fn to_py_array(
     array: ArrayRef,
     field: &ArrowField,
     pyarrow: &Bound<PyModule>,
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     let schema = Box::new(ffi::export_field_to_c(field));
     let array = Box::new(ffi::export_array_to_c(array));
 
@@ -38,7 +38,7 @@ pub(crate) fn to_py_rb(
     rb: &RecordBatch,
     py: Python<'_>,
     pyarrow: &Bound<PyModule>,
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     let mut arrays = Vec::with_capacity(rb.width());
 
     for (array, field) in rb.columns().iter().zip(rb.schema().iter_values()) {

--- a/crates/polars-python/src/interop/numpy/utils.rs
+++ b/crates/polars-python/src/interop/numpy/utils.rs
@@ -16,8 +16,8 @@ pub(super) unsafe fn create_borrowed_np_array<I>(
     mut shape: Dim<I>,
     flags: c_int,
     data: *mut c_void,
-    owner: PyObject,
-) -> PyObject
+    owner: Py<PyAny>,
+) -> Py<PyAny>
 where
     Dim<I>: Dimension + ToNpyDims,
 {
@@ -72,10 +72,10 @@ pub(super) fn series_contains_null(s: &Series) -> bool {
 /// Reshape the first dimension of a NumPy array to the given height and width.
 pub(super) fn reshape_numpy_array(
     py: Python<'_>,
-    arr: PyObject,
+    arr: Py<PyAny>,
     height: usize,
     width: usize,
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     let shape = arr
         .getattr(py, intern!(py, "shape"))?
         .extract::<Vec<usize>>(py)?;

--- a/crates/polars-python/src/io/mod.rs
+++ b/crates/polars-python/src/io/mod.rs
@@ -12,7 +12,7 @@ use polars_utils::plpath::PlPathRef;
 use polars_utils::slice_enum::Slice;
 use pyo3::pybacked::PyBackedStr;
 use pyo3::types::PyAnyMethods;
-use pyo3::{Bound, FromPyObject, PyObject, PyResult, intern};
+use pyo3::{Bound, FromPyObject, Py, PyAny, PyResult, intern};
 
 use crate::PyDataFrame;
 use crate::functions::parse_cloud_options;
@@ -62,7 +62,7 @@ impl PyScanOptions<'_> {
             rechunk: bool,
             cache: bool,
             storage_options: Option<Vec<(String, String)>>,
-            credential_provider: Option<PyObject>,
+            credential_provider: Option<Py<PyAny>>,
             retries: usize,
             deletion_files: Option<Wrap<DeletionFilesList>>,
             table_statistics: Option<Wrap<TableStatistics>>,

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -29,7 +29,7 @@ use crate::utils::{EnterPolarsExt, to_py_err};
 use crate::{PyDataFrame, PyExpr, PyLazyGroupBy};
 
 fn pyobject_to_first_path_and_scan_sources(
-    obj: PyObject,
+    obj: Py<PyAny>,
 ) -> PyResult<(Option<PlPath>, ScanSources)> {
     use crate::file::{PythonScanSourceInput, get_python_scan_source_input};
     Ok(match get_python_scan_source_input(obj, false)? {
@@ -43,13 +43,13 @@ fn pyobject_to_first_path_and_scan_sources(
 }
 
 fn post_opt_callback(
-    lambda: &PyObject,
+    lambda: &Py<PyAny>,
     root: Node,
     lp_arena: &mut Arena<IR>,
     expr_arena: &mut Arena<AExpr>,
     duration_since_start: Option<std::time::Duration>,
 ) -> PolarsResult<()> {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let nt = NodeTraverser::new(root, std::mem::take(lp_arena), std::mem::take(expr_arena));
 
         // Get a copy of the arenas.
@@ -82,7 +82,7 @@ impl PyLazyFrame {
         row_index, ignore_errors, include_file_paths, cloud_options, credential_provider, retries, file_cache_ttl
     ))]
     fn new_from_ndjson(
-        source: Option<PyObject>,
+        source: Option<Py<PyAny>>,
         sources: Wrap<ScanSources>,
         infer_schema_length: Option<usize>,
         schema: Option<Wrap<Schema>>,
@@ -95,7 +95,7 @@ impl PyLazyFrame {
         ignore_errors: bool,
         include_file_paths: Option<String>,
         cloud_options: Option<Vec<(String, String)>>,
-        credential_provider: Option<PyObject>,
+        credential_provider: Option<Py<PyAny>>,
         retries: usize,
         file_cache_ttl: Option<u64>,
     ) -> PyResult<Self> {
@@ -159,7 +159,7 @@ impl PyLazyFrame {
     )
     )]
     fn new_from_csv(
-        source: Option<PyObject>,
+        source: Option<Py<PyAny>>,
         sources: Wrap<ScanSources>,
         separator: &str,
         has_header: bool,
@@ -175,7 +175,7 @@ impl PyLazyFrame {
         null_values: Option<Wrap<NullValues>>,
         missing_utf8_is_empty_string: bool,
         infer_schema_length: Option<usize>,
-        with_schema_modify: Option<PyObject>,
+        with_schema_modify: Option<Py<PyAny>>,
         rechunk: bool,
         skip_rows_after_header: usize,
         encoding: Wrap<CsvEncoding>,
@@ -188,7 +188,7 @@ impl PyLazyFrame {
         glob: bool,
         schema: Option<Wrap<Schema>>,
         cloud_options: Option<Vec<(String, String)>>,
-        credential_provider: Option<PyObject>,
+        credential_provider: Option<Py<PyAny>>,
         retries: usize,
         file_cache_ttl: Option<u64>,
         include_file_paths: Option<String>,
@@ -278,7 +278,7 @@ impl PyLazyFrame {
         if let Some(lambda) = with_schema_modify {
             let f = |schema: Schema| {
                 let iter = schema.iter_names().map(|s| s.as_str());
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let names = PyList::new(py, iter).unwrap();
 
                     let out = lambda.call1(py, (names,)).expect("python function failed");
@@ -347,14 +347,14 @@ impl PyLazyFrame {
         include_file_paths
     ))]
     fn new_from_ipc(
-        source: Option<PyObject>,
+        source: Option<Py<PyAny>>,
         sources: Wrap<ScanSources>,
         n_rows: Option<usize>,
         cache: bool,
         rechunk: bool,
         row_index: Option<(String, IdxSize)>,
         cloud_options: Option<Vec<(String, String)>>,
-        credential_provider: Option<PyObject>,
+        credential_provider: Option<Py<PyAny>>,
         hive_partitioning: Option<bool>,
         hive_schema: Option<Wrap<Schema>>,
         try_parse_hive_dates: bool,
@@ -418,7 +418,7 @@ impl PyLazyFrame {
     #[pyo3(signature = (
         dataset_object
     ))]
-    fn new_from_dataset_object(dataset_object: PyObject) -> PyResult<Self> {
+    fn new_from_dataset_object(dataset_object: Py<PyAny>) -> PyResult<Self> {
         let lf =
             LazyFrame::from(DslBuilder::scan_python_dataset(PythonObject(dataset_object)).build())
                 .into();
@@ -429,7 +429,7 @@ impl PyLazyFrame {
     #[staticmethod]
     fn scan_from_python_function_arrow_schema(
         schema: &Bound<'_, PyList>,
-        scan_fn: PyObject,
+        scan_fn: Py<PyAny>,
         pyarrow: bool,
         validate_schema: bool,
         is_pure: bool,
@@ -449,7 +449,7 @@ impl PyLazyFrame {
     #[staticmethod]
     fn scan_from_python_function_pl_schema(
         schema: Vec<(PyBackedStr, Wrap<DataType>)>,
-        scan_fn: PyObject,
+        scan_fn: Py<PyAny>,
         pyarrow: bool,
         validate_schema: bool,
         is_pure: bool,
@@ -471,8 +471,8 @@ impl PyLazyFrame {
 
     #[staticmethod]
     fn scan_from_python_function_schema_function(
-        schema_fn: PyObject,
-        scan_fn: PyObject,
+        schema_fn: Py<PyAny>,
+        scan_fn: Py<PyAny>,
         validate_schema: bool,
         is_pure: bool,
     ) -> PyResult<Self> {
@@ -634,7 +634,7 @@ impl PyLazyFrame {
     fn profile(
         &self,
         py: Python<'_>,
-        lambda_post_opt: Option<PyObject>,
+        lambda_post_opt: Option<Py<PyAny>>,
     ) -> PyResult<(PyDataFrame, PyDataFrame)> {
         let (df, time_df) = py.enter_polars(|| {
             let ldf = self.ldf.read().clone();
@@ -654,7 +654,7 @@ impl PyLazyFrame {
         &self,
         py: Python<'_>,
         engine: Wrap<Engine>,
-        lambda_post_opt: Option<PyObject>,
+        lambda_post_opt: Option<Py<PyAny>>,
     ) -> PyResult<PyDataFrame> {
         py.enter_polars_df(|| {
             let ldf = self.ldf.read().clone();
@@ -673,7 +673,7 @@ impl PyLazyFrame {
         &self,
         py: Python<'_>,
         engine: Wrap<Engine>,
-        lambda: PyObject,
+        lambda: Py<PyAny>,
     ) -> PyResult<()> {
         py.enter_polars_ok(|| {
             let ldf = self.ldf.read().clone();
@@ -684,7 +684,7 @@ impl PyLazyFrame {
                     .map(PyDataFrame::new)
                     .map_err(PyPolarsErr::from);
 
-                Python::with_gil(|py| match result {
+                Python::attach(|py| match result {
                     Ok(df) => {
                         lambda.call1(py, (df,)).map_err(|err| err.restore(py)).ok();
                     },
@@ -714,7 +714,7 @@ impl PyLazyFrame {
         row_group_size: Option<usize>,
         data_page_size: Option<usize>,
         cloud_options: Option<Vec<(String, String)>>,
-        credential_provider: Option<PyObject>,
+        credential_provider: Option<Py<PyAny>>,
         retries: usize,
         sink_options: Wrap<SinkOptions>,
         metadata: Wrap<Option<KeyValueMetadata>>,
@@ -781,7 +781,7 @@ impl PyLazyFrame {
         compression: Wrap<Option<IpcCompression>>,
         compat_level: PyCompatLevel,
         cloud_options: Option<Vec<(String, String)>>,
-        credential_provider: Option<PyObject>,
+        credential_provider: Option<Py<PyAny>>,
         retries: usize,
         sink_options: Wrap<SinkOptions>,
     ) -> PyResult<PyLazyFrame> {
@@ -857,7 +857,7 @@ impl PyLazyFrame {
         null_value: Option<String>,
         quote_style: Option<Wrap<QuoteStyle>>,
         cloud_options: Option<Vec<(String, String)>>,
-        credential_provider: Option<PyObject>,
+        credential_provider: Option<Py<PyAny>>,
         retries: usize,
         sink_options: Wrap<SinkOptions>,
     ) -> PyResult<PyLazyFrame> {
@@ -934,7 +934,7 @@ impl PyLazyFrame {
         py: Python<'_>,
         target: SinkTarget,
         cloud_options: Option<Vec<(String, String)>>,
-        credential_provider: Option<PyObject>,
+        credential_provider: Option<Py<PyAny>>,
         retries: usize,
         sink_options: Wrap<SinkOptions>,
     ) -> PyResult<PyLazyFrame> {
@@ -981,7 +981,7 @@ impl PyLazyFrame {
     pub fn sink_batches(
         &self,
         py: Python<'_>,
-        function: PyObject,
+        function: Py<PyAny>,
         maintain_order: bool,
         chunk_size: Option<NonZeroUsize>,
     ) -> PyResult<PyLazyFrame> {
@@ -1349,7 +1349,7 @@ impl PyLazyFrame {
             .into())
     }
 
-    fn pipe_with_schema(&self, callback: PyObject) -> Self {
+    fn pipe_with_schema(&self, callback: Py<PyAny>) -> Self {
         let ldf = self.ldf.read().clone();
         let function = PythonObject(callback);
         ldf.pipe_with_schema(PlanCallback::new_python(function))
@@ -1510,7 +1510,7 @@ impl PyLazyFrame {
     #[pyo3(signature = (function, predicate_pushdown, projection_pushdown, slice_pushdown, streamable, schema, validate_output))]
     fn map_batches(
         &self,
-        function: PyObject,
+        function: Py<PyAny>,
         predicate_pushdown: bool,
         projection_pushdown: bool,
         slice_pushdown: bool,

--- a/crates/polars-python/src/lazyframe/serde.rs
+++ b/crates/polars-python/src/lazyframe/serde.rs
@@ -12,7 +12,7 @@ use crate::utils::EnterPolarsExt;
 #[allow(clippy::should_implement_trait)]
 impl PyLazyFrame {
     /// Serialize into binary data.
-    fn serialize_binary(&self, py: Python<'_>, py_f: PyObject) -> PyResult<()> {
+    fn serialize_binary(&self, py: Python<'_>, py_f: Py<PyAny>) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
         let writer = BufWriter::new(file);
         py.enter_polars(|| {
@@ -25,7 +25,7 @@ impl PyLazyFrame {
 
     /// Serialize into a JSON string.
     #[cfg(feature = "json")]
-    fn serialize_json(&self, py: Python<'_>, py_f: PyObject) -> PyResult<()> {
+    fn serialize_json(&self, py: Python<'_>, py_f: Py<PyAny>) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
         let writer = BufWriter::new(file);
         py.enter_polars(|| {
@@ -36,7 +36,7 @@ impl PyLazyFrame {
 
     /// Deserialize a file-like object containing binary data into a LazyFrame.
     #[staticmethod]
-    fn deserialize_binary(py: Python<'_>, py_f: PyObject) -> PyResult<Self> {
+    fn deserialize_binary(py: Python<'_>, py_f: Py<PyAny>) -> PyResult<Self> {
         let file = get_file_like(py_f, false)?;
         let reader = BufReader::new(file);
 
@@ -47,7 +47,7 @@ impl PyLazyFrame {
     /// Deserialize a file-like object containing JSON string data into a LazyFrame.
     #[staticmethod]
     #[cfg(feature = "json")]
-    fn deserialize_json(py: Python<'_>, py_f: PyObject) -> PyResult<Self> {
+    fn deserialize_json(py: Python<'_>, py_f: Py<PyAny>) -> PyResult<Self> {
         // it is faster to first read to memory and then parse: https://github.com/serde-rs/json/issues/160
         // so don't bother with files.
         let mut json = String::new();

--- a/crates/polars-python/src/lazyframe/visit.rs
+++ b/crates/polars-python/src/lazyframe/visit.rs
@@ -155,7 +155,7 @@ impl NodeTraverser {
 
     /// Set a python UDF that will replace the subtree location with this function src.
     #[pyo3(signature = (function, is_pure = false))]
-    fn set_udf(&mut self, function: PyObject, is_pure: bool) {
+    fn set_udf(&mut self, function: Py<PyAny>, is_pure: bool) {
         let mut lp_arena = self.lp_arena.lock().unwrap();
         let schema = lp_arena.get(self.root).schema(&lp_arena).into_owned();
         let ir = IR::PythonScan {
@@ -174,13 +174,13 @@ impl NodeTraverser {
         lp_arena.replace(self.root, ir);
     }
 
-    fn view_current_node(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn view_current_node(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let lp_arena = self.lp_arena.lock().unwrap();
         let lp_node = lp_arena.get(self.root);
         nodes::into_py(py, lp_node)
     }
 
-    fn view_expression(&self, py: Python<'_>, node: usize) -> PyResult<PyObject> {
+    fn view_expression(&self, py: Python<'_>, node: usize) -> PyResult<Py<PyAny>> {
         let expr_arena = self.expr_arena.lock().unwrap();
         let n = match &self.expr_mapping {
             Some(mapping) => *mapping.get(node).unwrap(),

--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -31,21 +31,21 @@ pub struct Alias {
     #[pyo3(get)]
     expr: usize,
     #[pyo3(get)]
-    name: PyObject,
+    name: Py<PyAny>,
 }
 
 #[pyclass(frozen)]
 pub struct Column {
     #[pyo3(get)]
-    name: PyObject,
+    name: Py<PyAny>,
 }
 
 #[pyclass(frozen)]
 pub struct Literal {
     #[pyo3(get)]
-    value: PyObject,
+    value: Py<PyAny>,
     #[pyo3(get)]
-    dtype: PyObject,
+    dtype: Py<PyAny>,
 }
 
 #[pyclass(name = "Operator", eq, frozen)]
@@ -296,7 +296,7 @@ pub struct BinaryExpr {
     #[pyo3(get)]
     left: usize,
     #[pyo3(get)]
-    op: PyObject,
+    op: Py<PyAny>,
     #[pyo3(get)]
     right: usize,
 }
@@ -306,7 +306,7 @@ pub struct Cast {
     #[pyo3(get)]
     expr: usize,
     #[pyo3(get)]
-    dtype: PyObject,
+    dtype: Py<PyAny>,
     // 0: strict
     // 1: non-strict
     // 2: overflow
@@ -355,12 +355,12 @@ pub struct SortBy {
 #[pyclass(frozen)]
 pub struct Agg {
     #[pyo3(get)]
-    name: PyObject,
+    name: Py<PyAny>,
     #[pyo3(get)]
     arguments: Vec<usize>,
     #[pyo3(get)]
     // Arbitrary control options
-    options: PyObject,
+    options: Py<PyAny>,
 }
 
 #[pyclass(frozen)]
@@ -378,9 +378,9 @@ pub struct Function {
     #[pyo3(get)]
     input: Vec<usize>,
     #[pyo3(get)]
-    function_data: PyObject,
+    function_data: Py<PyAny>,
     #[pyo3(get)]
-    options: PyObject,
+    options: Py<PyAny>,
 }
 
 #[pyclass(frozen)]
@@ -409,7 +409,7 @@ pub struct Window {
     #[pyo3(get)]
     order_by_nulls_last: bool,
     #[pyo3(get)]
-    options: PyObject,
+    options: Py<PyAny>,
 }
 
 #[pyclass(name = "WindowMapping", frozen)]
@@ -553,7 +553,7 @@ impl PyGroupbyOptions {
     }
 }
 
-pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
+pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<Py<PyAny>> {
     match expr {
         AExpr::Explode { .. } => Err(PyNotImplementedError::new_err("explode")),
         AExpr::Column(name) => Column {
@@ -562,7 +562,7 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
         .into_py_any(py),
         AExpr::Literal(lit) => {
             use polars_core::prelude::AnyValue;
-            let dtype: PyObject = Wrap(lit.get_datatype()).into_py_any(py)?;
+            let dtype: Py<PyAny> = Wrap(lit.get_datatype()).into_py_any(py)?;
             let py_value = match lit {
                 LiteralValue::Dyn(d) => match d {
                     DynLiteralValue::Int(v) => v.into_py_any(py)?,
@@ -1344,7 +1344,7 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                 },
                 IRFunctionExpr::Negate => ("negate",).into_py_any(py),
                 IRFunctionExpr::FillNullWithStrategy(strategy) => {
-                    let (strategy_str, py_limit): (&str, PyObject) = match strategy {
+                    let (strategy_str, py_limit): (&str, Py<PyAny>) = match strategy {
                         FillNullStrategy::Forward(limit) => {
                             let py_limit = limit
                                 .map(|v| PyInt::new(py, v).into())

--- a/crates/polars-python/src/lazygroupby.rs
+++ b/crates/polars-python/src/lazygroupby.rs
@@ -36,7 +36,7 @@ impl PyLazyGroupBy {
     }
 
     #[pyo3(signature = (lambda, schema))]
-    fn map_groups(&self, lambda: PyObject, schema: Option<Wrap<Schema>>) -> PyResult<PyLazyFrame> {
+    fn map_groups(&self, lambda: Py<PyAny>, schema: Option<Wrap<Schema>>) -> PyResult<PyLazyFrame> {
         let lgb = self.lgb.clone().unwrap();
         let schema = match schema {
             Some(schema) => Arc::new(schema.0),

--- a/crates/polars-python/src/map/dataframe.rs
+++ b/crates/polars-python/src/map/dataframe.rs
@@ -32,7 +32,7 @@ pub fn apply_lambda_unknown<'py>(
     py: Python<'py>,
     lambda: Bound<'py, PyAny>,
     inference_size: usize,
-) -> PyResult<(PyObject, bool)> {
+) -> PyResult<(Py<PyAny>, bool)> {
     let mut null_count = 0;
     let mut iters = get_iters(df);
 

--- a/crates/polars-python/src/map/lazy.rs
+++ b/crates/polars-python/src/map/lazy.rs
@@ -11,7 +11,7 @@ pub(crate) fn call_lambda_with_series(
     py: Python<'_>,
     s: &[Column],
     output_dtype: Option<DataType>,
-    lambda: &PyObject,
+    lambda: &Py<PyAny>,
 ) -> PolarsResult<Column> {
     // Set return_dtype in kwargs
     let dict = PyDict::new(py);
@@ -24,7 +24,7 @@ pub(crate) fn call_lambda_with_series(
     let series_objects = s
         .iter()
         .map(|c| PySeries::new(c.as_materialized_series().clone()).into_py_any(py))
-        .collect::<PyResult<Vec<PyObject>>>()?;
+        .collect::<PyResult<Vec<Py<PyAny>>>>()?;
 
     let result = lambda.call(py, (series_objects,), Some(&dict))?;
     Ok(result
@@ -34,7 +34,7 @@ pub(crate) fn call_lambda_with_series(
 
 pub fn map_expr(
     pyexpr: &[PyExpr],
-    lambda: PyObject,
+    lambda: Py<PyAny>,
     output_type: Option<PyDataTypeExpr>,
     is_elementwise: bool,
     returns_scalar: bool,

--- a/crates/polars-python/src/map/series.rs
+++ b/crates/polars-python/src/map/series.rs
@@ -75,7 +75,7 @@ fn infer_and_finish<'py, A: ApplyLambda<'py>>(
         //     pl.Series(lambda(value))
         let lambda_owned = lambda.to_owned().unbind();
         let new_lambda = PyCFunction::new_closure(py, None, None, move |args, _kwargs| {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let out = lambda_owned.call1(py, args)?;
                 // check if Series, if not, call series constructor on it
                 pl_series(py).call1(py, (out,))
@@ -195,7 +195,7 @@ pub trait ApplyLambda<'py> {
     fn apply_lambda_with_list_out_type(
         &self,
         py: Python<'py>,
-        lambda: PyObject,
+        lambda: Py<PyAny>,
         init_null_count: usize,
         first_value: Option<&Series>,
         dt: &DataType,
@@ -442,7 +442,7 @@ impl<'py> ApplyLambda<'py> for BooleanChunked {
     fn apply_lambda_with_list_out_type(
         &self,
         py: Python<'py>,
-        lambda: PyObject,
+        lambda: Py<PyAny>,
         init_null_count: usize,
         first_value: Option<&Series>,
         dt: &DataType,
@@ -660,7 +660,7 @@ where
     fn apply_lambda_with_list_out_type(
         &self,
         py: Python<'py>,
-        lambda: PyObject,
+        lambda: Py<PyAny>,
         init_null_count: usize,
         first_value: Option<&Series>,
         dt: &DataType,
@@ -873,7 +873,7 @@ impl<'py> ApplyLambda<'py> for StringChunked {
     fn apply_lambda_with_list_out_type(
         &self,
         py: Python<'py>,
-        lambda: PyObject,
+        lambda: Py<PyAny>,
         init_null_count: usize,
         first_value: Option<&Series>,
         dt: &DataType,
@@ -1171,7 +1171,7 @@ impl<'py> ApplyLambda<'py> for ListChunked {
     fn apply_lambda_with_list_out_type(
         &self,
         py: Python<'py>,
-        lambda: PyObject,
+        lambda: Py<PyAny>,
         init_null_count: usize,
         first_value: Option<&Series>,
         dt: &DataType,
@@ -1486,7 +1486,7 @@ impl<'py> ApplyLambda<'py> for ArrayChunked {
     fn apply_lambda_with_list_out_type(
         &self,
         py: Python<'py>,
-        lambda: PyObject,
+        lambda: Py<PyAny>,
         init_null_count: usize,
         first_value: Option<&Series>,
         dt: &DataType,
@@ -1742,7 +1742,7 @@ impl<'py> ApplyLambda<'py> for ObjectChunked<ObjectValue> {
     fn apply_lambda_with_list_out_type(
         &self,
         py: Python<'py>,
-        lambda: PyObject,
+        lambda: Py<PyAny>,
         init_null_count: usize,
         first_value: Option<&Series>,
         dt: &DataType,
@@ -1946,7 +1946,7 @@ impl<'py> ApplyLambda<'py> for StructChunked {
     fn apply_lambda_with_list_out_type(
         &self,
         py: Python<'py>,
-        lambda: PyObject,
+        lambda: Py<PyAny>,
         init_null_count: usize,
         first_value: Option<&Series>,
         dt: &DataType,

--- a/crates/polars-python/src/py_modules.rs
+++ b/crates/polars-python/src/py_modules.rs
@@ -1,28 +1,28 @@
 use pyo3::prelude::*;
-use pyo3::sync::GILOnceCell;
+use pyo3::sync::PyOnceLock;
 
-static POLARS: GILOnceCell<Py<PyModule>> = GILOnceCell::new();
-static POLARS_PLR: GILOnceCell<PyObject> = GILOnceCell::new();
-static UTILS: GILOnceCell<PyObject> = GILOnceCell::new();
-static SERIES: GILOnceCell<PyObject> = GILOnceCell::new();
-static DATAFRAME: GILOnceCell<PyObject> = GILOnceCell::new();
+static POLARS: PyOnceLock<Py<PyModule>> = PyOnceLock::new();
+static POLARS_PLR: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
+static UTILS: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
+static SERIES: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
+static DATAFRAME: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
 
 pub fn polars(py: Python<'_>) -> &Py<PyModule> {
     POLARS.get_or_init(py, || py.import("polars").unwrap().unbind())
 }
 
-pub fn polars_rs(py: Python<'_>) -> &PyObject {
+pub fn polars_rs(py: Python<'_>) -> &Py<PyAny> {
     POLARS_PLR.get_or_init(py, || polars(py).getattr(py, "_plr").unwrap())
 }
 
-pub fn pl_utils(py: Python<'_>) -> &PyObject {
+pub fn pl_utils(py: Python<'_>) -> &Py<PyAny> {
     UTILS.get_or_init(py, || polars(py).getattr(py, "_utils").unwrap())
 }
 
-pub fn pl_series(py: Python<'_>) -> &PyObject {
+pub fn pl_series(py: Python<'_>) -> &Py<PyAny> {
     SERIES.get_or_init(py, || polars(py).getattr(py, "Series").unwrap())
 }
 
-pub fn pl_df(py: Python<'_>) -> &PyObject {
+pub fn pl_df(py: Python<'_>) -> &Py<PyAny> {
     DATAFRAME.get_or_init(py, || polars(py).getattr(py, "DataFrame").unwrap())
 }

--- a/crates/polars-python/src/series/construction.rs
+++ b/crates/polars-python/src/series/construction.rs
@@ -219,7 +219,7 @@ impl PySeries {
 
         // Fall back to Object type for non-strict construction.
         if !strict && result.is_err() {
-            return Python::with_gil(|py| {
+            return Python::attach(|py| {
                 let objects = values
                     .try_iter()?
                     .map(|v| v?.extract())

--- a/crates/polars-python/src/series/export.rs
+++ b/crates/polars-python/src/series/export.rs
@@ -148,7 +148,7 @@ impl PySeries {
 
     /// Return the underlying Arrow array.
     #[allow(clippy::wrong_self_convention)]
-    fn to_arrow(&self, py: Python<'_>, compat_level: PyCompatLevel) -> PyResult<PyObject> {
+    fn to_arrow(&self, py: Python<'_>, compat_level: PyCompatLevel) -> PyResult<Py<PyAny>> {
         self.rechunk(py, true)?;
         let pyarrow = py.import("pyarrow")?;
 
@@ -165,7 +165,7 @@ impl PySeries {
     fn __arrow_c_stream__<'py>(
         &self,
         py: Python<'py>,
-        requested_schema: Option<PyObject>,
+        requested_schema: Option<Py<PyAny>>,
     ) -> PyResult<Bound<'py, PyCapsule>> {
         series_to_stream(&self.series.read(), py)
     }

--- a/crates/polars-python/src/series/map.rs
+++ b/crates/polars-python/src/series/map.rs
@@ -56,7 +56,7 @@ impl PySeries {
 
         }
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             if matches!(
                 series.dtype(),
                 DataType::Datetime(_, _)
@@ -259,7 +259,7 @@ impl PySeries {
                     let dtype_py = Wrap((*inner).clone());
                     let function_wrapped =
                         PyCFunction::new_closure(py, None, None, move |args, _kwargs| {
-                            Python::with_gil(|py| {
+                            Python::attach(|py| {
                                 let out = function_owned.call1(py, args)?;
                                 if out.is_none(py) {
                                     Ok(py.None())

--- a/crates/polars-python/src/series/numpy_ufunc.rs
+++ b/crates/polars-python/src/series/numpy_ufunc.rs
@@ -80,7 +80,7 @@ macro_rules! impl_ufuncs {
             // have to convert that NumPy array into a pl.Series.
             fn $name(&self, lambda: &Bound<PyAny>, allocate_out: bool) -> PyResult<PySeries> {
                 // numpy array object, and a *mut ptr
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     if !allocate_out {
                         // We're not going to allocate the output array.
                         // Instead, we'll let the ufunc do it.

--- a/crates/polars-python/src/utils.rs
+++ b/crates/polars-python/src/utils.rs
@@ -104,7 +104,7 @@ impl EnterPolarsExt for Python<'_> {
         E: Ungil + Send + Into<PyPolarsErr>,
     {
         let timeout = schedule_polars_timeout();
-        let ret = self.allow_threads(|| catch_keyboard_interrupt(AssertUnwindSafe(f)));
+        let ret = self.detach(|| catch_keyboard_interrupt(AssertUnwindSafe(f)));
         cancel_polars_timeout(timeout);
         match ret {
             Ok(Ok(ret)) => Ok(ret),

--- a/crates/polars-stream/src/physical_plan/io/python_dataset.rs
+++ b/crates/polars-stream/src/physical_plan/io/python_dataset.rs
@@ -24,7 +24,7 @@ pub fn python_dataset_scan_to_reader_builder(
             (
                 format_pl_smallstr!("python[{} @ pyarrow]", &expanded_scan.name),
                 Box::new(move |_state: &StreamingExecutionState| {
-                    Python::with_gil(|py| {
+                    Python::attach(|py| {
                         let Some(python_scan_function) =
                             python_scan_function.lock().unwrap().take()
                         else {

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -1036,7 +1036,7 @@ fn to_graph_rec<'a>(
 
                     // Setup the IO plugin generator.
                     let (generator, can_parse_predicate) = {
-                        Python::with_gil(|py| {
+                        Python::attach(|py| {
                             let pl = PyModule::import(py, intern!(py, "polars")).unwrap();
                             let utils = pl.getattr(intern!(py, "_utils")).unwrap();
                             let callable =
@@ -1086,7 +1086,7 @@ fn to_graph_rec<'a>(
                     }?;
 
                     let get_batch_fn = Box::new(move |state: &StreamingExecutionState| {
-                        let df = Python::with_gil(|py| {
+                        let df = Python::attach(|py| {
                             match generator.bind(py).call_method0(intern!(py, "__next__")) {
                                 Ok(out) => polars_plan::plans::python_df_to_rust(py, out).map(Some),
                                 Err(err)

--- a/crates/polars-utils/src/pl_serialize.rs
+++ b/crates/polars-utils/src/pl_serialize.rs
@@ -220,7 +220,7 @@ pub fn python_object_serialize(
     use crate::python_function::PYTHON3_VERSION;
 
     let mut use_cloudpickle = USE_CLOUDPICKLE.get();
-    let dumped = Python::with_gil(|py| {
+    let dumped = Python::attach(|py| {
         // Pickle with whatever pickling method was selected.
         if use_cloudpickle {
             let cloudpickle = PyModule::import(py, "cloudpickle")?.getattr("dumps")?;
@@ -271,7 +271,7 @@ pub fn python_object_deserialize(buf: &[u8]) -> PolarsResult<pyo3::Py<pyo3::PyAn
     }
     let buf = &buf[3..];
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let loads = PyModule::import(py, "pickle")?.getattr("loads")?;
         let arg = (PyBytes::new(py, buf),);
         let python_function = loads.call1(arg)?;

--- a/pyo3-polars/pyo3-polars/src/alloc.rs
+++ b/pyo3-polars/pyo3-polars/src/alloc.rs
@@ -69,7 +69,7 @@ impl PolarsAllocator {
         self.0.get_or_init(|| {
             let r = (unsafe { Py_IsInitialized() } != 0)
                 .then(|| {
-                    Python::with_gil(|_| unsafe {
+                    Python::attach(|_| unsafe {
                         let capsule =
                             (PyCapsule_Import(ALLOCATOR_CAPSULE_NAME.as_ptr() as *const c_char, 0)
                                 as *const AllocatorCapsule)

--- a/pyo3-polars/pyo3-polars/src/lib.rs
+++ b/pyo3-polars/pyo3-polars/src/lib.rs
@@ -58,11 +58,10 @@ use pyo3::prelude::*;
 pub use types::*;
 
 pub(crate) static POLARS: Lazy<Py<PyModule>> =
-    Lazy::new(|| Python::with_gil(|py| PyModule::import(py, "polars").unwrap().unbind()));
+    Lazy::new(|| Python::attach(|py| PyModule::import(py, "polars").unwrap().unbind()));
 
-pub(crate) static POLARS_INTERCHANGE: Lazy<Py<PyModule>> = Lazy::new(|| {
-    Python::with_gil(|py| PyModule::import(py, "polars.interchange").unwrap().unbind())
-});
+pub(crate) static POLARS_INTERCHANGE: Lazy<Py<PyModule>> =
+    Lazy::new(|| Python::attach(|py| PyModule::import(py, "polars.interchange").unwrap().unbind()));
 
 pub(crate) static SERIES: Lazy<Py<PyAny>> =
-    Lazy::new(|| Python::with_gil(|py| POLARS.getattr(py, "Series").unwrap()));
+    Lazy::new(|| Python::attach(|py| POLARS.getattr(py, "Series").unwrap()));

--- a/pyo3-polars/pyo3-polars/src/types.rs
+++ b/pyo3-polars/pyo3-polars/src/types.rs
@@ -398,7 +398,7 @@ impl<'py> IntoPyObject<'py> for PyExpr {
 }
 
 #[cfg(feature = "dtype-categorical")]
-pub(crate) fn to_series(py: Python, s: PySeries) -> PyObject {
+pub(crate) fn to_series(py: Python, s: PySeries) -> Py<PyAny> {
     let series = SERIES.bind(py);
     let constructor = series
         .getattr(intern!(series.py(), "_from_pyseries"))


### PR DESCRIPTION
https://pyo3.rs/main/changelog.html

PR also deals with various deprecations:

1. `with_gil` deprecated and renamed to `attach`
2. `allow_threads` deprecated and renamed to `detach`
3. type alias `PyObject = Py<PyAny>` deprecation
4. `GILOnceCell` deprecated in favour of `PyOnceLock`