### PR TITLE
fix: Type error in `bitmask::nth_set_bit_u64`

### DIFF
--- a/crates/polars-arrow/src/bitmap/bitmask.rs
+++ b/crates/polars-arrow/src/bitmap/bitmask.rs
@@ -88,7 +88,7 @@ pub fn nth_set_bit_u64(w: u64, n: u64) -> Option<u64> {
             return None;
         }
 
-        Some(nth_set_bit.trailing_zeros())
+        Some(nth_set_bit.trailing_zeros().into())
     }
 
     #[cfg(any(miri, not(target_feature = "bmi2")))]


### PR DESCRIPTION
In my local worktree, https://github.com/pola-rs/polars/pull/24298 introduced a type error, where a `u32` was not converted into a `u64`. This patch fixes that error.