### PR TITLE
ci: Temporarily pin pydantic to fix CI

### DIFF
--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -21,7 +21,7 @@ numpy
 numba >= 0.54; python_version < '3.14'  # Numba can lag Python releases
 pandas
 pyarrow
-pydantic>=2.0.0
+pydantic>=2.0.0,<=2.11.10
 # Datetime / time zones
 tzdata; platform_system == 'Windows'
 # Database


### PR DESCRIPTION
* Latest release causes CI failure in our Iceberg interop. Upstream issues:
  * https://github.com/apache/iceberg-python/issues/2590
  * https://github.com/pydantic/pydantic/issues/12347
