### PR TITLE
docs(python): Fix typo in example of `set_tbl_rows`

### DIFF
--- a/py-polars/src/polars/config.py
+++ b/py-polars/src/polars/config.py
@@ -1302,7 +1302,7 @@ class Config(contextlib.ContextDecorator):
         >>> df = pl.DataFrame(
         ...     {"abc": [1.0, 2.5, 3.5, 5.0], "xyz": [True, False, True, False]}
         ... )
-        >>> with pl.Config(tbl_rows=2):
+        >>> with pl.Config(set_tbl_rows=2):
         ...     print(df)
         shape: (4, 2)
         ┌─────┬───────┐


### PR DESCRIPTION
as diff