### PR TITLE
refactor: Re-use iterators in `set_` operations

### DIFF
--- a/crates/polars-ops/src/chunked_array/list/sets.rs
+++ b/crates/polars-ops/src/chunked_array/list/sets.rs
@@ -47,31 +47,23 @@ impl<'a> MaterializeValues<Option<&'a [u8]>> for MutablePlBinary {
     }
 }
 
-type TotalItem<T> = <Option<T> as ToTotalOrd>::TotalOrdItem;
-
 #[allow(clippy::too_many_arguments)]
-fn set_operation<'a, 'b, T, I, J, R>(
-    set: &mut PlIndexSet<TotalItem<T>>,
-    set2: &mut PlIndexSet<TotalItem<T>>,
+fn set_operation<I, J, K, R>(
+    set: &mut PlIndexSet<K>,
+    set2: &mut PlIndexSet<K>,
     a: &mut I,
     b: &mut J,
-    len_a: usize,
-    len_b: usize,
     out: &mut R,
     set_op: SetOperation,
     broadcast_rhs: bool,
 ) -> usize
 where
-    T: Copy + TotalEq + TotalHash + 'a + 'b,
-    I: Iterator<Item = Option<&'a T>>,
-    J: Iterator<Item = Option<&'b T>>,
-    R: MaterializeValues<TotalItem<T>>,
-    TotalItem<T>: Eq + Hash + Copy,
+    K: Eq + Hash + Copy,
+    I: Iterator<Item = K>,
+    J: Iterator<Item = K>,
+    R: MaterializeValues<K>,
 {
     set.clear();
-
-    let a = a.take(len_a).map(copied_wrapper_opt);
-    let b = b.take(len_b).map(copied_wrapper_opt);
 
     match set_op {
         SetOperation::Intersection => {
@@ -103,57 +95,6 @@ where
             }
             // We could speed this up, but implementing ourselves, but we need to have a cloneable
             // iterator as we need 2 passes
-            set.extend(a);
-            out.extend_buf(set.symmetric_difference(set2).copied())
-        },
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn set_operation_binary<'a, I, R>(
-    set: &mut PlIndexSet<Option<&'a [u8]>>,
-    set2: &mut PlIndexSet<Option<&'a [u8]>>,
-    a: &mut I,
-    b: &mut I,
-    len_a: usize,
-    len_b: usize,
-    out: &mut R,
-    set_op: SetOperation,
-    broadcast_rhs: bool,
-) -> usize
-where
-    I: Iterator<Item = Option<&'a [u8]>>,
-    R: MaterializeValues<Option<&'a [u8]>>,
-{
-    set.clear();
-    let a = a.take(len_a);
-    let b = b.take(len_b);
-
-    match set_op {
-        SetOperation::Intersection => {
-            set.extend(a);
-            if !broadcast_rhs {
-                set2.clear();
-                set2.extend(b);
-            }
-            out.extend_buf(set.intersection(set2).copied())
-        },
-        SetOperation::Union => {
-            set.extend(a.chain(b));
-            out.extend_buf(set.drain(..))
-        },
-        SetOperation::Difference => {
-            set.extend(a);
-            for v in b {
-                set.swap_remove(&v);
-            }
-            out.extend_buf(set.drain(..))
-        },
-        SetOperation::SymmetricDifference => {
-            if !broadcast_rhs {
-                set2.clear();
-                set2.extend(b);
-            }
             set.extend(a);
             out.extend_buf(set.symmetric_difference(set2).copied())
         },
@@ -238,54 +179,51 @@ where
         // If we go OOB we take the first element as we are then broadcasting.
         let start_a = *offsets_a.get(i - 1).unwrap_or(&first_a) as usize;
         let end_a = *offsets_a.get(i).unwrap_or(&second_a) as usize;
-        let len_a = end_a - start_a;
 
         let start_b = *offsets_b.get(i - 1).unwrap_or(&first_b) as usize;
         let end_b = *offsets_b.get(i).unwrap_or(&second_b) as usize;
-        let len_b = end_b - start_b;
+
+        let mut iter_a_broadcast = iter_a.clone();
+        let mut iter_b_broadcast = iter_b.clone();
 
         // The branches are the same every loop.
         // We rely on branch prediction here.
-        let offset = if broadcast_rhs {
-            let mut iter_b = iter_b.clone();
-            let len_b = second_b as usize - first_b as usize;
-            set_operation(
-                &mut set,
-                &mut set2,
-                &mut iter_a,
-                &mut iter_b,
-                len_a,
-                len_b,
-                &mut values_out,
-                set_op,
-                true,
-            )
-        } else if broadcast_lhs {
-            let mut iter_a = iter_a.clone();
-            let len_a = second_a as usize - first_a as usize;
-            set_operation(
-                &mut set,
-                &mut set2,
-                &mut iter_a,
-                &mut iter_b,
-                len_a,
-                len_b,
-                &mut values_out,
-                set_op,
-                false,
-            )
+        let mut iter_a = if broadcast_lhs {
+            iter_a_broadcast
+                .by_ref()
+                .take(second_a as usize - first_a as usize)
+                .map(copied_wrapper_opt)
         } else {
-            set_operation(
-                &mut set,
-                &mut set2,
-                &mut iter_a,
-                &mut iter_b,
-                len_a,
-                len_b,
-                &mut values_out,
-                set_op,
-                false,
-            )
+            iter_a
+                .by_ref()
+                .take(end_a - start_a)
+                .map(copied_wrapper_opt)
+        };
+        let mut iter_b = if broadcast_rhs {
+            iter_b_broadcast
+                .by_ref()
+                .take(second_b as usize - first_b as usize)
+                .map(copied_wrapper_opt)
+        } else {
+            iter_b
+                .by_ref()
+                .take(end_b - start_b)
+                .map(copied_wrapper_opt)
+        };
+
+        let offset = set_operation(
+            &mut set,
+            &mut set2,
+            &mut iter_a,
+            &mut iter_b,
+            &mut values_out,
+            set_op,
+            broadcast_rhs,
+        );
+
+        assert!(iter_a.next().is_none());
+        if !broadcast_rhs || matches!(set_op, SetOperation::Union | SetOperation::Difference) {
+            assert!(iter_b.next().is_none());
         };
 
         offsets.push(offset as i64);
@@ -344,55 +282,45 @@ fn binary(
         // If we go OOB we take the first element as we are then broadcasting.
         let start_a = *offsets_a.get(i - 1).unwrap_or(&first_a) as usize;
         let end_a = *offsets_a.get(i).unwrap_or(&second_a) as usize;
-        let len_a = end_a - start_a;
 
         let start_b = *offsets_b.get(i - 1).unwrap_or(&first_b) as usize;
         let end_b = *offsets_b.get(i).unwrap_or(&second_b) as usize;
-        let len_b = end_b - start_b;
+
+        let mut iter_a_broadcast = iter_a.clone();
+        let mut iter_b_broadcast = iter_b.clone();
 
         // The branches are the same every loop.
         // We rely on branch prediction here.
-        let offset = if broadcast_rhs {
-            let mut iter_b = iter_b.clone();
-            let len_b = second_b as usize - first_b as usize;
-            set_operation_binary(
-                &mut set,
-                &mut set2,
-                &mut iter_a,
-                &mut iter_b,
-                len_a,
-                len_b,
-                &mut values_out,
-                set_op,
-                true,
-            )
-        } else if broadcast_lhs {
-            let mut iter_a = iter_a.clone();
-            let len_a = second_a as usize - first_a as usize;
-            set_operation_binary(
-                &mut set,
-                &mut set2,
-                &mut iter_a,
-                &mut iter_b,
-                len_a,
-                len_b,
-                &mut values_out,
-                set_op,
-                false,
-            )
+        let mut iter_a = if broadcast_lhs {
+            iter_a_broadcast
+                .by_ref()
+                .take(second_a as usize - first_a as usize)
         } else {
-            set_operation_binary(
-                &mut set,
-                &mut set2,
-                &mut iter_a,
-                &mut iter_b,
-                len_a,
-                len_b,
-                &mut values_out,
-                set_op,
-                false,
-            )
+            iter_a.by_ref().take(end_a - start_a)
         };
+        let mut iter_b = if broadcast_rhs {
+            iter_b_broadcast
+                .by_ref()
+                .take(second_b as usize - first_b as usize)
+        } else {
+            iter_b.by_ref().take(end_b - start_b)
+        };
+
+        let offset = set_operation(
+            &mut set,
+            &mut set2,
+            &mut iter_a,
+            &mut iter_b,
+            &mut values_out,
+            set_op,
+            broadcast_rhs,
+        );
+
+        assert!(iter_a.next().is_none());
+        if !broadcast_rhs || matches!(set_op, SetOperation::Union | SetOperation::Difference) {
+            assert!(iter_b.next().is_none());
+        };
+
         offsets.push(offset as i64);
     }
     let offsets = unsafe { OffsetsBuffer::new_unchecked(offsets.into()) };


### PR DESCRIPTION
also fixes https://github.com/pola-rs/polars/issues/22751

The underlying problem in the reported issue is that the original code resets an iterator in the  loop and calls `skip` repeatedly on an unindexed iterator.

The first PR (https://github.com/pola-rs/polars/pull/24766) makes the call to `nth` indexed, effectively solving the reported issue. This PR drops the call to `skip` in the loop by holding on to the iterator state. This makes the implementation cleaner and more robust. Note, either PR solves the problem, so this PR is nice-to-have.