### PR TITLE
perf: Speed up `reverse` in group-by context

### DIFF
--- a/crates/polars-expr/src/dispatch/groups_dispatch.rs
+++ b/crates/polars-expr/src/dispatch/groups_dispatch.rs
@@ -1,0 +1,56 @@
+use std::sync::Arc;
+
+use polars_core::POOL;
+use polars_core::error::PolarsResult;
+use polars_core::frame::DataFrame;
+use polars_core::prelude::{GroupPositions, GroupsType};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+
+use crate::prelude::{AggState, AggregationContext, PhysicalExpr};
+use crate::state::ExecutionState;
+
+pub fn reverse<'a>(
+    inputs: &[Arc<dyn PhysicalExpr>],
+    df: &DataFrame,
+    groups: &'a GroupPositions,
+    state: &ExecutionState,
+) -> PolarsResult<AggregationContext<'a>> {
+    assert_eq!(inputs.len(), 1);
+
+    let mut ac = inputs[0].evaluate_on_groups(df, groups, state)?;
+
+    // Length preserving operation on scalars keeps scalar.
+    if let AggState::AggregatedScalar(_) | AggState::LiteralScalar(_) = &ac.agg_state() {
+        return Ok(ac);
+    }
+
+    POOL.install(|| {
+        let positions = GroupsType::Idx(match &**ac.groups().as_ref() {
+            GroupsType::Idx(idx) => idx
+                .into_par_iter()
+                .map(|(first, idx)| {
+                    (
+                        idx.last().copied().unwrap_or(first),
+                        idx.iter().copied().rev().collect(),
+                    )
+                })
+                .collect(),
+            GroupsType::Slice {
+                groups,
+                overlapping: _,
+            } => groups
+                .into_par_iter()
+                .map(|[start, len]| {
+                    (
+                        start + len.saturating_sub(1),
+                        (*start..*start + *len).rev().collect(),
+                    )
+                })
+                .collect(),
+        })
+        .into_sliceable();
+        ac.with_groups(positions);
+    });
+
+    Ok(ac)
+}

--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -9,6 +9,7 @@ use polars_core::prelude::*;
 use rayon::prelude::*;
 
 use super::*;
+use crate::dispatch::GroupsUdf;
 use crate::expressions::{
     AggState, AggregationContext, PartitionedAggregation, PhysicalExpr, UpdateGroups,
 };
@@ -17,6 +18,7 @@ use crate::expressions::{
 pub struct ApplyExpr {
     inputs: Vec<Arc<dyn PhysicalExpr>>,
     function: SpecialEq<Arc<dyn ColumnsUdf>>,
+    groups_function: Option<SpecialEq<Arc<dyn GroupsUdf>>>,
     expr: Expr,
     flags: FunctionFlags,
     function_operates_on_scalar: bool,
@@ -34,6 +36,7 @@ impl ApplyExpr {
     pub(crate) fn new(
         inputs: Vec<Arc<dyn PhysicalExpr>>,
         function: SpecialEq<Arc<dyn ColumnsUdf>>,
+        groups_function: Option<SpecialEq<Arc<dyn GroupsUdf>>>,
         expr: Expr,
         options: FunctionOptions,
         allow_threading: bool,
@@ -51,6 +54,7 @@ impl ApplyExpr {
         Self {
             inputs,
             function,
+            groups_function,
             expr,
             flags: options.flags,
             function_operates_on_scalar,
@@ -434,6 +438,11 @@ impl PhysicalExpr for ApplyExpr {
         groups: &'a GroupPositions,
         state: &ExecutionState,
     ) -> PolarsResult<AggregationContext<'a>> {
+        // Some function have specialized implementation.
+        if let Some(groups_function) = self.groups_function.as_ref() {
+            return groups_function.evaluate_on_groups(&self.inputs, df, groups, state);
+        }
+
         if self.inputs.len() == 1 {
             let mut ac = self.inputs[0].evaluate_on_groups(df, groups, state)?;
 

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -3,7 +3,7 @@ use polars_plan::prelude::expr_ir::ExprIR;
 use polars_plan::prelude::*;
 use recursive::recursive;
 
-use crate::dispatch::function_expr_to_udf;
+use crate::dispatch::{function_expr_to_groups_udf, function_expr_to_udf};
 use crate::expressions as phys_expr;
 use crate::expressions::*;
 
@@ -498,6 +498,7 @@ fn create_physical_expr_inner(
             Ok(Arc::new(ApplyExpr::new(
                 input,
                 SpecialEq::new(function),
+                None,
                 node_to_expr(expression, expr_arena),
                 *options,
                 state.allow_threading,
@@ -576,6 +577,7 @@ fn create_physical_expr_inner(
             Ok(Arc::new(ApplyExpr::new(
                 input,
                 function_expr_to_udf(function.clone()),
+                function_expr_to_groups_udf(function),
                 node_to_expr(expression, expr_arena),
                 *options,
                 state.allow_threading,
@@ -616,6 +618,7 @@ fn create_physical_expr_inner(
             Ok(Arc::new(ApplyExpr::new(
                 vec![input],
                 function,
+                None,
                 node_to_expr(expression, expr_arena),
                 FunctionOptions::groupwise(),
                 state.allow_threading,


### PR DESCRIPTION
This speeds up `list.eval(pl.element().reverse())` and `.group_by(...).agg(pl.element().reverse())` by 20% in microbenchmarks.

This is mostly in preparation for other expressions like `null_count`, `all`, `any` and `unique`.