### PR TITLE
refactor: Unset `Context` in `Window` expression

### DIFF
--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -176,13 +176,8 @@ fn create_physical_expr_inner(
             let output_field = aexpr.to_field(&ToFieldContext::new(expr_arena, schema))?;
             let function = *function;
             state.set_window();
-            let phys_function = create_physical_expr_inner(
-                function,
-                Context::Default,
-                expr_arena,
-                schema,
-                state,
-            )?;
+            let phys_function =
+                create_physical_expr_inner(function, Context::Default, expr_arena, schema, state)?;
 
             let order_by = order_by
                 .map(|(node, options)| {


### PR DESCRIPTION
This PR is one of multiple where we reset all `Context::Aggregation` to `Context::Default`, and eventually remove `Context` altogether from the in-memory engine.

ping @coastalwhite 