### PR TITLE
feat: Set sorted flag for categoricals

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/categorical.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical.rs
@@ -7,6 +7,7 @@ use crate::chunked_array::cast::CastOptions;
 use crate::chunked_array::flags::{StatisticsFlags, StatisticsFlagsIM};
 use crate::chunked_array::ops::ChunkFullNull;
 use crate::prelude::*;
+use crate::series::implementations::SeriesWrap;
 use crate::utils::handle_casting_failures;
 
 pub type CategoricalChunked<T> = Logical<T, <T as PolarsCategoricalType>::PolarsPhysical>;

--- a/crates/polars-core/src/chunked_array/logical/categorical.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical.rs
@@ -7,7 +7,6 @@ use crate::chunked_array::cast::CastOptions;
 use crate::chunked_array::flags::{StatisticsFlags, StatisticsFlagsIM};
 use crate::chunked_array::ops::ChunkFullNull;
 use crate::prelude::*;
-use crate::series::implementations::SeriesWrap;
 use crate::utils::handle_casting_failures;
 
 pub type CategoricalChunked<T> = Logical<T, <T as PolarsCategoricalType>::PolarsPhysical>;

--- a/crates/polars-core/src/chunked_array/logical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/mod.rs
@@ -27,6 +27,7 @@ pub use categorical::*;
 pub use time::*;
 
 use crate::chunked_array::cast::CastOptions;
+use crate::chunked_array::flags::StatisticsFlagsIM;
 use crate::prelude::*;
 
 /// Maps a logical type to a chunked array implementation of the physical type.
@@ -34,6 +35,9 @@ use crate::prelude::*;
 pub struct Logical<Logical: PolarsDataType, Physical: PolarsDataType> {
     pub phys: ChunkedArray<Physical>,
     pub dtype: DataType,
+    /// Used by logical types that store flags that only apply logically.
+    /// E.g. Categoricals will indicate sortedness here, but not in the physical.
+    pub logical_flags: StatisticsFlagsIM,
     _phantom: PhantomData<Logical>,
 }
 
@@ -42,6 +46,7 @@ impl<K: PolarsDataType, T: PolarsDataType> Clone for Logical<K, T> {
         Self {
             phys: self.phys.clone(),
             dtype: self.dtype.clone(),
+            logical_flags: self.logical_flags.clone(),
             _phantom: PhantomData,
         }
     }
@@ -54,6 +59,7 @@ impl<K: PolarsDataType, T: PolarsDataType> Logical<K, T> {
         Logical {
             phys,
             dtype,
+            logical_flags: StatisticsFlagsIM::empty(),
             _phantom: PhantomData,
         }
     }

--- a/crates/polars-core/src/chunked_array/ops/append.rs
+++ b/crates/polars-core/src/chunked_array/ops/append.rs
@@ -99,7 +99,7 @@ where
                     #[cfg(feature = "dtype-categorical")]
                     _ if matches!(ca.dtype(), DataType::Categorical(..)) => IsSorted::Not,
                     _ => {
-                        let mut out = IsSorted::Not;
+                        let out;
 
                         // This can be relatively expensive because of chunks, so delay as much as possible.
                         let l_val = unsafe { ca.value_unchecked(l_idx) };
@@ -129,11 +129,7 @@ where
                             l_val.tot_ge(&r_val)
                         };
 
-                        if !check {
-                            out = IsSorted::Not
-                        }
-
-                        out
+                        if check { out } else { IsSorted::Not }
                     },
                 }
             }

--- a/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -14,12 +14,13 @@ impl<T: PolarsCategoricalType> CategoricalChunked<T> {
         }
 
         let flags = self.get_flags();
+        let nulls_first = !options.nulls_last;
+        let options_ascending = !options.descending;
 
         if flags.is_sorted_any()
-            && (!self.physical().has_nulls()
-                || self.physical().first().is_none() == !options.nulls_last)
+            && (!self.physical().has_nulls() || self.physical().first().is_none() == nulls_first)
         {
-            return if flags.is_sorted_ascending() == !options.descending {
+            return if flags.is_sorted_ascending() == options_ascending {
                 self.clone()
             } else {
                 unsafe {

--- a/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -1,8 +1,6 @@
 use num_traits::Zero;
 
 use super::*;
-use crate::series::implementations::SeriesWrap;
-use crate::sort_with_fast_path;
 
 impl<T: PolarsCategoricalType> CategoricalChunked<T> {
     #[must_use]

--- a/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -53,9 +53,20 @@ impl<T: PolarsCategoricalType> CategoricalChunked<T> {
         let cats = ChunkedArray::with_chunk(self.name().clone(), arr);
 
         // SAFETY: we only reordered the indexes so we are still in bounds.
-        unsafe {
+        let mut out = unsafe {
             CategoricalChunked::<T>::from_cats_and_dtype_unchecked(cats, self.dtype().clone())
-        }
+        };
+        let s = if options.descending {
+            IsSorted::Descending
+        } else {
+            IsSorted::Ascending
+        };
+
+        let mut flags = out.get_flags();
+        flags.set_sorted(s);
+        out.set_flags(flags);
+
+        out
     }
 
     /// Returned a sorted `ChunkedArray`.

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -124,7 +124,6 @@ fn create_validity(len: usize, null_count: usize, nulls_last: bool) -> Bitmap {
     validity.freeze()
 }
 
-#[macro_export]
 macro_rules! sort_with_fast_path {
     ($ca:ident, $options:expr) => {{
         if $ca.is_empty() {

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -124,6 +124,7 @@ fn create_validity(len: usize, null_count: usize, nulls_last: bool) -> Bitmap {
     validity.freeze()
 }
 
+#[macro_export]
 macro_rules! sort_with_fast_path {
     ($ca:ident, $options:expr) => {{
         if $ca.is_empty() {

--- a/crates/polars-expr/src/dispatch/misc.rs
+++ b/crates/polars-expr/src/dispatch/misc.rs
@@ -422,13 +422,13 @@ pub(super) fn index_of(s: &mut [Column]) -> PolarsResult<Column> {
     );
 
     let is_sorted_flag = series.is_sorted_flag();
+    let dtype = series.dtype();
     let result = match is_sorted_flag {
         // If the Series is sorted, we can use an optimized binary search to
         // find the value.
         IsSorted::Ascending | IsSorted::Descending
-            if !needle.is_null() &&
-            // search_sorted() doesn't support decimals at the moment.
-            !series.dtype().is_decimal() =>
+            if !needle.is_null()
+                && !(dtype.is_decimal() || dtype.is_categorical() || dtype.is_enum()) =>
         {
             use polars_ops::series::SearchSortedSide;
 

--- a/crates/polars-expr/src/dispatch/misc.rs
+++ b/crates/polars-expr/src/dispatch/misc.rs
@@ -427,8 +427,10 @@ pub(super) fn index_of(s: &mut [Column]) -> PolarsResult<Column> {
         // If the Series is sorted, we can use an optimized binary search to
         // find the value.
         IsSorted::Ascending | IsSorted::Descending
-            if !needle.is_null()
-                && !(dtype.is_decimal() || dtype.is_categorical() || dtype.is_enum()) =>
+            if !(needle.is_null()
+                || dtype.is_decimal()
+                || dtype.is_categorical()
+                || dtype.is_enum()) =>
         {
             use polars_ops::series::SearchSortedSide;
 

--- a/py-polars/tests/unit/operations/namespaces/test_categorical.py
+++ b/py-polars/tests/unit/operations/namespaces/test_categorical.py
@@ -248,3 +248,17 @@ def test_cat_order_flag_csv_read_23823() -> None:
         schema_overrides={"colx": pl.Categorical},
     )
     assert_frame_equal(expected, lf.sort("colx", descending=False).collect())
+
+
+def test_cat_sort_flag() -> None:
+    s = pl.Series(["B", "A"], dtype=pl.Categorical(pl.Categories.random()))
+    s = s.sort()
+    assert s.flags["SORTED_ASC"]
+    assert not s.to_physical().flags["SORTED_ASC"]
+
+
+def test_enum_sort_flag() -> None:
+    s = pl.Series(["B", "A"], dtype=pl.Enum(["A", "B"]))
+    s = s.sort()
+    assert s.flags["SORTED_ASC"]
+    assert s.to_physical().flags["SORTED_ASC"]


### PR DESCRIPTION
#### Note for future reference

This PR sets the sorted flag on categoricals in an additional slot on the `Logical<>` wrapper struct. The flag can be set in this way, however this causes breakage across the codebase, e.g. in:
* `update_sorted_flag_before_append()`
* merge_sorted

The codepaths assume the ordering of `T::Physical<'_>` follow the sorted flag of the ChunkedArray, but this is not the case for lexically ordered categoricals.
