### PR TITLE
perf: Implement `cumulative_eval` using the group-by engine

### DIFF
--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -590,6 +590,7 @@ where
     pub fn deposit(&self, validity: &Bitmap) -> Self {
         let set_bits = validity.set_bits();
 
+        assert_eq!(self.null_count(), 0);
         assert_eq!(self.len(), set_bits);
 
         if set_bits == validity.len() {

--- a/crates/polars-expr/src/expressions/eval.rs
+++ b/crates/polars-expr/src/expressions/eval.rs
@@ -2,14 +2,14 @@ use std::borrow::Cow;
 use std::cell::LazyCell;
 use std::sync::Arc;
 
-use polars_core::POOL;
+use arrow::bitmap::{Bitmap, BitmapBuilder};
 use polars_core::chunked_array::builder::AnonymousOwnedListBuilder;
-use polars_core::error::{PolarsResult, feature_gated, polars_ensure};
+use polars_core::error::{PolarsResult, feature_gated};
 use polars_core::frame::DataFrame;
 #[cfg(feature = "dtype-array")]
 use polars_core::prelude::ArrayChunked;
 use polars_core::prelude::{
-    AnyValue, ChunkCast, ChunkExplode, Column, Field, GroupPositions, GroupsType, IntoColumn,
+    ChunkCast, ChunkExplode, Column, Field, GroupPositions, GroupsType, IdxCa, IntoColumn,
     ListBuilderTrait, ListChunked,
 };
 use polars_core::schema::Schema;
@@ -17,7 +17,6 @@ use polars_core::series::Series;
 use polars_plan::dsl::{EvalVariant, Expr};
 use polars_utils::IdxSize;
 use polars_utils::pl_str::PlSmallStr;
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 use super::{AggregationContext, PhysicalExpr};
 use crate::state::ExecutionState;
@@ -28,7 +27,6 @@ pub struct EvalExpr {
     evaluation: Arc<dyn PhysicalExpr>,
     variant: EvalVariant,
     expr: Expr,
-    allow_threading: bool,
     output_field: Field,
     is_scalar: bool,
     evaluation_is_scalar: bool,
@@ -43,7 +41,6 @@ impl EvalExpr {
         evaluation: Arc<dyn PhysicalExpr>,
         variant: EvalVariant,
         expr: Expr,
-        allow_threading: bool,
         output_field: Field,
         is_scalar: bool,
         evaluation_is_scalar: bool,
@@ -55,7 +52,6 @@ impl EvalExpr {
             evaluation,
             variant,
             expr,
-            allow_threading,
             output_field,
             is_scalar,
             evaluation_is_scalar,
@@ -333,65 +329,65 @@ impl EvalExpr {
         input: &Series,
         min_samples: usize,
         state: &ExecutionState,
-    ) -> PolarsResult<Series> {
-        let finish = |out: Series| {
-            polars_ensure!(
-                out.len() <= 1,
-                ComputeError:
-                "expected single value, got a result with length {}, {:?}",
-                out.len(), out,
-            );
-            Ok(out.get(0).unwrap().into_static())
-        };
+    ) -> PolarsResult<Column> {
+        if input.is_empty() {
+            return Ok(Column::new_empty(
+                self.output_field.name().clone(),
+                self.output_field.dtype(),
+            ));
+        }
 
-        let input = input.clone().with_name(PlSmallStr::EMPTY);
-        let avs = if self.allow_threading {
-            POOL.install(|| {
-                (1..input.len() + 1)
-                    .into_par_iter()
-                    .map(|len| {
-                        let c = input.slice(0, len);
-                        if (len - c.null_count()) >= min_samples {
-                            let df = c.into_frame();
-                            let out = self
-                                .evaluation
-                                .evaluate(&df, state)?
-                                .take_materialized_series();
-                            finish(out)
-                        } else {
-                            Ok(AnyValue::Null)
-                        }
-                    })
-                    .collect::<PolarsResult<Vec<_>>>()
-            })?
+        let mut deposit: Option<Bitmap> = None;
+        let groups = if min_samples == 0 {
+            (1..input.len() as IdxSize).map(|i| [0, i]).collect()
         } else {
-            let mut df_container = DataFrame::empty();
-            (1..input.len() + 1)
-                .map(|len| {
-                    let c = input.slice(0, len);
-                    if (len - c.null_count()) >= min_samples {
-                        unsafe {
-                            df_container.with_column_unchecked(c.into_column());
-                            let out = self
-                                .evaluation
-                                .evaluate(&df_container, state)?
-                                .take_materialized_series();
-                            df_container.clear_columns();
-                            finish(out)
-                        }
-                    } else {
-                        Ok(AnyValue::Null)
-                    }
+            let validity = input
+                .rechunk_validity()
+                .unwrap_or_else(|| Bitmap::new_with_value(true, input.len()));
+            let mut count = 0;
+            let mut deposit_builder = BitmapBuilder::with_capacity(input.len());
+            let out = (0..input.len() as IdxSize)
+                .filter(|i| {
+                    count += usize::from(unsafe { validity.get_bit_unchecked(*i as usize) });
+                    let is_selected = count >= min_samples;
+                    unsafe { deposit_builder.push_unchecked(is_selected) };
+                    is_selected
                 })
-                .collect::<PolarsResult<Vec<_>>>()?
+                .map(|i| [0, i + 1])
+                .collect();
+            deposit = Some(deposit_builder.freeze());
+            out
         };
 
-        Series::from_any_values_and_dtype(
-            self.output_field.name().clone(),
-            &avs,
-            self.output_field.dtype(),
-            true,
-        )
+        let groups = GroupsType::Slice {
+            groups,
+            overlapping: true,
+        };
+
+        let groups = groups.into_sliceable();
+
+        let df = input.clone().with_name(PlSmallStr::EMPTY).into_frame();
+        let agg = self.evaluation.evaluate_on_groups(&df, &groups, state)?;
+        let (mut out, _) = agg.get_final_aggregation();
+
+        // Since we only evaluated the expressions on the items that satisfied the min samples, we
+        // need to fix it up here again.
+        if let Some(deposit) = deposit {
+            let mut i = 0;
+            let gather_idxs = deposit
+                .iter()
+                .map(|v| {
+                    let out = i;
+                    i += IdxSize::from(v);
+                    out
+                })
+                .collect::<Vec<IdxSize>>();
+            let gather_idxs =
+                IdxCa::from_vec_validity(PlSmallStr::EMPTY, gather_idxs, Some(deposit));
+            out = unsafe { out.take_unchecked(&gather_idxs) };
+        }
+
+        Ok(out)
     }
 }
 
@@ -417,9 +413,9 @@ impl PhysicalExpr for EvalExpr {
             EvalVariant::ArrayAgg => feature_gated!("dtype-array", {
                 self.evaluate_on_array_chunked(input.array()?, state, true, true)
             }),
-            EvalVariant::Cumulative { min_samples } => self
-                .evaluate_cumulative_eval(input.as_materialized_series(), min_samples, state)
-                .map(Column::from),
+            EvalVariant::Cumulative { min_samples } => {
+                self.evaluate_cumulative_eval(input.as_materialized_series(), min_samples, state)
+            },
         }
     }
 
@@ -466,7 +462,7 @@ impl PhysicalExpr for EvalExpr {
                         Some(group) => {
                             let out =
                                 self.evaluate_cumulative_eval(group.as_ref(), min_samples, state)?;
-                            builder.append_series(&out)?;
+                            builder.append_series(out.as_materialized_series())?;
                         },
                     }
                 }

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -550,7 +550,6 @@ fn create_physical_expr_inner(
                 evaluation,
                 *variant,
                 node_to_expr(expression, expr_arena),
-                state.allow_threading,
                 output_field,
                 is_scalar,
                 evaluation_is_scalar,

--- a/py-polars/tests/unit/functions/test_cumulative_eval.py
+++ b/py-polars/tests/unit/functions/test_cumulative_eval.py
@@ -1,7 +1,7 @@
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 
 def test_cumulative_eval_sum() -> None:
@@ -30,3 +30,24 @@ def test_cumulative_eval_deny_non_scalar() -> None:
                 b=pl.col.a.cumulative_eval(pl.element() + 1)
             ),
         )
+
+
+def test_cumulative_eval_empty() -> None:
+    s = pl.Series("a", [], pl.Int64)
+    assert_series_equal(s.cumulative_eval(pl.element().first()), s)
+
+
+def test_cumulative_eval_samples() -> None:
+    assert_series_equal(
+        pl.Series("a", [None, None, 1, 2, 3, None, None], pl.Int64).cumulative_eval(
+            pl.element().first(), min_samples=3
+        ),
+        pl.Series("a", [None, None, None, None, None, None, None], pl.Int64),
+    )
+
+    assert_series_equal(
+        pl.Series("a", [None, None, 1, 2, 3, None, None], pl.Int64).cumulative_eval(
+            pl.element().min(), min_samples=3
+        ),
+        pl.Series("a", [None, None, None, None, 1, 1, 1], pl.Int64),
+    )


### PR DESCRIPTION
This refactors `cumulative_eval` to rely on the group-by engine similar to how `{list,arr}.{eval,agg}` do.