### PR TITLE
test: Update tests to be index type agnostic

### DIFF
--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1934,7 +1934,7 @@ def test_group_by_agg_n_unique_empty_group_idx_path() -> None:
     expected = pl.DataFrame(
         {
             "key": [1, 2],
-            "n_unique": pl.Series([3, 0], dtype=pl.UInt32),
+            "n_unique": pl.Series([3, 0], dtype=pl.get_index_type()),
         }
     )
     assert_frame_equal(out, expected)
@@ -1954,7 +1954,7 @@ def test_group_by_agg_n_unique_empty_group_slice_path() -> None:
     expected = pl.DataFrame(
         {
             "key": [1, 2],
-            "n_unique": pl.Series([0, 0], dtype=pl.UInt32),
+            "n_unique": pl.Series([0, 0], dtype=pl.get_index_type()),
         }
     )
     assert_frame_equal(out, expected)
@@ -1992,7 +1992,7 @@ def test_with_row_index_bad_offset() -> None:
     with pytest.raises(
         ValueError, match="cannot be greater than the maximum index value"
     ):
-        df.with_row_index(offset=2**32)
+        df.with_row_index(offset=2**64)
 
 
 def test_with_row_index_bad_offset_lazy() -> None:
@@ -2003,7 +2003,7 @@ def test_with_row_index_bad_offset_lazy() -> None:
     with pytest.raises(
         ValueError, match="cannot be greater than the maximum index value"
     ):
-        lf.with_row_index(offset=2**32)
+        lf.with_row_index(offset=2**64)
 
 
 def test_with_row_count_deprecated() -> None:
@@ -2095,7 +2095,7 @@ def test_group_by_order_dispatch(name: str | None) -> None:
     name = "len" if name is None else name
     expected = pl.DataFrame(
         data={"x": ["b", "a"], name: [2, 1]},
-        schema_overrides={name: pl.UInt32},
+        schema_overrides={name: pl.get_index_type()},
     )
     assert_frame_equal(result, expected)
     assert_frame_equal(lazy_result.collect(), expected)
@@ -3177,7 +3177,8 @@ def test_window_deadlock() -> None:
 def test_sum_empty_column_names() -> None:
     df = pl.DataFrame({"x": [], "y": []}, schema={"x": pl.Boolean, "y": pl.Boolean})
     expected = pl.DataFrame(
-        {"x": [0], "y": [0]}, schema={"x": pl.UInt32, "y": pl.UInt32}
+        {"x": [0], "y": [0]},
+        schema={"x": pl.get_index_type(), "y": pl.get_index_type()},
     )
     assert_frame_equal(df.sum(), expected)
 

--- a/py-polars/tests/unit/dataframe/test_null_count.py
+++ b/py-polars/tests/unit/dataframe/test_null_count.py
@@ -34,7 +34,7 @@ def test_null_count_optimization_23031() -> None:
 
     expected = pl.DataFrame(
         [
-            pl.Series("count_all", [3], pl.UInt32()),
+            pl.Series("count_all", [3], pl.get_index_type()),
             pl.Series("sum_all", [12], pl.Int64()),
         ]
     )

--- a/py-polars/tests/unit/datatypes/test_float.py
+++ b/py-polars/tests/unit/datatypes/test_float.py
@@ -123,7 +123,7 @@ def test_unique_counts() -> None:
             None,
         ],
     )
-    expect = pl.Series("x", [2, 2, 1, 1], dtype=pl.UInt32)
+    expect = pl.Series("x", [2, 2, 1, 1], dtype=pl.get_index_type())
     out = s.unique_counts()
     assert_series_equal(expect, out)
 
@@ -167,7 +167,9 @@ def test_group_by_float() -> None:
         .with_columns(a=pl.lit("a"))
     )
 
-    expect = pl.Series("index", [[0, 1], [2, 3], [4], [5]], dtype=pl.List(pl.UInt32))
+    expect = pl.Series(
+        "index", [[0, 1], [2, 3], [4], [5]], dtype=pl.List(pl.get_index_type())
+    )
     expect_no_null = expect.head(3)
 
     for group_keys in (("x",), ("x", "a")):
@@ -230,7 +232,7 @@ def test_joins() -> None:
         assert_series_equal(expect, out)
 
         how = "inner"
-        expect = pl.Series("index", [0, 1, 2, 3], dtype=pl.UInt32)
+        expect = pl.Series("index", [0, 1, 2, 3], dtype=pl.get_index_type())
         out = (
             df.join(rhs, on=join_on, how=how).sort("index").select("index").to_series()  # type: ignore[arg-type]
         )

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -548,7 +548,7 @@ def test_logical_parallel_list_collect() -> None:
         .explode("Values")
         .unnest("Values")
     )
-    assert out.dtypes == [pl.String, pl.Categorical, pl.UInt32]
+    assert out.dtypes == [pl.String, pl.Categorical, pl.get_index_type()]
     assert out.to_dict(as_series=False) == {
         "Group": ["GroupA", "GroupA"],
         "Values": ["Value1", "Value2"],

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 def test_arg_true() -> None:
     df = pl.DataFrame({"a": [1, 1, 2, 1]})
     res = df.select((pl.col("a") == 1).arg_true())
-    expected = pl.DataFrame([pl.Series("a", [0, 1, 3], dtype=pl.UInt32)])
+    expected = pl.DataFrame([pl.Series("a", [0, 1, 3], dtype=pl.get_index_type())])
     assert_frame_equal(res, expected)
 
 

--- a/py-polars/tests/unit/functions/test_cum_count.py
+++ b/py-polars/tests/unit/functions/test_cum_count.py
@@ -10,7 +10,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
 def test_cum_count_single_arg(reverse: bool, output: list[int]) -> None:
     df = pl.DataFrame({"a": [5, 5, None]})
     result = df.select(pl.cum_count("a", reverse=reverse))
-    expected = pl.Series("a", output, dtype=pl.UInt32).to_frame()
+    expected = pl.Series("a", output, dtype=pl.get_index_type()).to_frame()
     assert_frame_equal(result, expected)
     assert result.to_series().flags[("SORTED_ASC", "SORTED_DESC")[reverse]]
 
@@ -28,11 +28,11 @@ def test_cum_count_multi_arg() -> None:
     result = df.select(pl.cum_count("a", "b", "c", "d", "e"))
     expected = pl.DataFrame(
         [
-            pl.Series("a", [1, 2, 3], dtype=pl.UInt32),
-            pl.Series("b", [0, 1, 2], dtype=pl.UInt32),
-            pl.Series("c", [1, 1, 2], dtype=pl.UInt32),
-            pl.Series("d", [1, 2, 2], dtype=pl.UInt32),
-            pl.Series("e", [0, 0, 0], dtype=pl.UInt32),
+            pl.Series("a", [1, 2, 3], dtype=pl.get_index_type()),
+            pl.Series("b", [0, 1, 2], dtype=pl.get_index_type()),
+            pl.Series("c", [1, 1, 2], dtype=pl.get_index_type()),
+            pl.Series("d", [1, 2, 2], dtype=pl.get_index_type()),
+            pl.Series("e", [0, 0, 0], dtype=pl.get_index_type()),
         ]
     )
     assert_frame_equal(result, expected)
@@ -51,11 +51,11 @@ def test_cum_count_multi_arg_reverse() -> None:
     result = df.select(pl.cum_count("a", "b", "c", "d", "e", reverse=True))
     expected = pl.DataFrame(
         [
-            pl.Series("a", [3, 2, 1], dtype=pl.UInt32),
-            pl.Series("b", [2, 2, 1], dtype=pl.UInt32),
-            pl.Series("c", [2, 1, 1], dtype=pl.UInt32),
-            pl.Series("d", [2, 1, 0], dtype=pl.UInt32),
-            pl.Series("e", [0, 0, 0], dtype=pl.UInt32),
+            pl.Series("a", [3, 2, 1], dtype=pl.get_index_type()),
+            pl.Series("b", [2, 2, 1], dtype=pl.get_index_type()),
+            pl.Series("c", [2, 1, 1], dtype=pl.get_index_type()),
+            pl.Series("d", [2, 1, 0], dtype=pl.get_index_type()),
+            pl.Series("e", [0, 0, 0], dtype=pl.get_index_type()),
         ]
     )
     assert_frame_equal(result, expected)
@@ -77,5 +77,5 @@ def test_cum_count() -> None:
 def test_series_cum_count() -> None:
     s = pl.Series(["x", "k", None, "d"])
     result = s.cum_count()
-    expected = pl.Series([1, 2, 2, 3], dtype=pl.UInt32)
+    expected = pl.Series([1, 2, 2, 3], dtype=pl.get_index_type())
     assert_series_equal(result, expected)

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -602,8 +602,8 @@ def test_lazy_functions() -> None:
         pl.DataFrame(
             data=expected,
             schema_overrides={
-                "a_n_unique": pl.UInt32,
-                "b_n_unique": pl.UInt32,
+                "a_n_unique": pl.get_index_type(),
+                "b_n_unique": pl.get_index_type(),
             },
         ),
     )

--- a/py-polars/tests/unit/interop/test_from_pandas.py
+++ b/py-polars/tests/unit/interop/test_from_pandas.py
@@ -328,7 +328,8 @@ def test_untrusted_categorical_input() -> None:
     df = pl.from_pandas(df_pd)
     result = df.group_by("x").len()
     expected = pl.DataFrame(
-        {"x": ["x"], "len": [1]}, schema={"x": pl.Categorical, "len": pl.UInt32}
+        {"x": ["x"], "len": [1]},
+        schema={"x": pl.Categorical, "len": pl.get_index_type()},
     )
     assert_frame_equal(result, expected, categorical_as_str=True)
 

--- a/py-polars/tests/unit/io/test_lazy_count_star.py
+++ b/py-polars/tests/unit/io/test_lazy_count_star.py
@@ -246,5 +246,5 @@ def test_csv_scan_skip_lines_len_22889(
 
     # for comparison
     out = pl.scan_csv(bb, skip_lines=2).collect().select(pl.len())
-    expected = pl.DataFrame({"len": [1]}, schema={"len": pl.UInt32})
+    expected = pl.DataFrame({"len": [1]}, schema={"len": pl.get_index_type()})
     assert_frame_equal(expected, out)

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -219,7 +219,7 @@ def test_lazy_row_index_no_push_down(foods_file_path: Path) -> None:
         q,
         pl.LazyFrame(
             [
-                pl.Series("index", [14, 20, 25], dtype=pl.UInt32),
+                pl.Series("index", [14, 20, 25], dtype=pl.get_index_type()),
                 pl.Series(
                     "category",
                     ["vegetables", "vegetables", "vegetables"],
@@ -282,7 +282,7 @@ def test_scan_csv_schema_overwrite_not_projected_8483(foods_file_path: Path) -> 
         .select(pl.len())
         .collect()
     )
-    expected = pl.DataFrame({"len": 27}, schema={"len": pl.UInt32})
+    expected = pl.DataFrame({"len": 27}, schema={"len": pl.get_index_type()})
     assert_frame_equal(df, expected)
 
 

--- a/py-polars/tests/unit/io/test_lazy_ipc.py
+++ b/py-polars/tests/unit/io/test_lazy_ipc.py
@@ -62,7 +62,7 @@ def test_row_index_schema(foods_ipc_path: Path) -> None:
         pl.scan_ipc(foods_ipc_path, row_index_name="id")
         .select(["id", "category"])
         .collect()
-    ).dtypes == [pl.UInt32, pl.String]
+    ).dtypes == [pl.get_index_type(), pl.String]
 
 
 def test_glob_n_rows(io_files_path: Path) -> None:

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -209,7 +209,7 @@ def test_row_index_schema_parquet(parquet_file_path: Path) -> None:
         pl.scan_parquet(str(parquet_file_path), row_index_name="id")
         .select(["id", "b"])
         .collect()
-    ).dtypes == [pl.UInt32, pl.String]
+    ).dtypes == [pl.get_index_type(), pl.String]
 
 
 @pytest.mark.may_fail_cloud  # reason: inspects logs

--- a/py-polars/tests/unit/io/test_scan.py
+++ b/py-polars/tests/unit/io/test_scan.py
@@ -786,7 +786,7 @@ def test_scan_double_collect_row_index_invalidates_cached_ir_18892() -> None:
         out,
         pl.DataFrame(
             {"index": [0, 1, 2], "a": [1, 2, 3]},
-            schema={"index": pl.UInt32, "a": pl.Int64},
+            schema={"index": pl.get_index_type(), "a": pl.Int64},
         ),
     )
 
@@ -820,7 +820,7 @@ def test_streaming_scan_csv_with_row_index_19172(io_files_path: Path) -> None:
         lf.collect(engine="streaming"),
         pl.DataFrame(
             {"calories": "45", "index": 0},
-            schema={"calories": pl.String, "index": pl.UInt32},
+            schema={"calories": pl.String, "index": pl.get_index_type()},
         ),
     )
 

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -269,7 +269,7 @@ def test_apply_custom_function() -> None:
             "cars_count": [3, 2],
         }
     )
-    expected = expected.with_columns(pl.col("cars_count").cast(pl.UInt32))
+    expected = expected.with_columns(pl.col("cars_count").cast(pl.get_index_type()))
     assert_frame_equal(df, expected)
 
 
@@ -297,7 +297,7 @@ def test_group_by() -> None:
 def test_arg_unique() -> None:
     ldf = pl.LazyFrame({"a": [4, 1, 4]})
     col_a_unique = ldf.select(pl.col("a").arg_unique()).collect()["a"]
-    assert_series_equal(col_a_unique, pl.Series("a", [0, 1]).cast(pl.UInt32))
+    assert_series_equal(col_a_unique, pl.Series("a", [0, 1]).cast(pl.get_index_type()))
 
 
 def test_arg_sort() -> None:
@@ -1080,7 +1080,7 @@ def test_group_lengths() -> None:
             "unique_counts_sum": [1.0, 1.0],
             "unique_len": [2, 3],
         },
-        schema_overrides={"unique_len": pl.UInt32},
+        schema_overrides={"unique_len": pl.get_index_type()},
     )
     assert_frame_equal(result.collect(), expected)
 

--- a/py-polars/tests/unit/lazyframe/test_optimizations.py
+++ b/py-polars/tests/unit/lazyframe/test_optimizations.py
@@ -105,7 +105,8 @@ def test_is_null_followed_by_sum() -> None:
     lf = pl.LazyFrame({"group": [0, 0, 0, 1, 2], "val": [6, 0, None, None, 5]})
 
     expected_df = pl.DataFrame(
-        {"group": [0, 1, 2], "val": [1, 1, 0]}, schema_overrides={"val": pl.UInt32}
+        {"group": [0, 1, 2], "val": [1, 1, 0]},
+        schema_overrides={"val": pl.get_index_type()},
     )
     result_lf = lf.group_by("group", maintain_order=True).agg(
         pl.col("val").is_null().sum()
@@ -118,7 +119,7 @@ def test_is_null_followed_by_sum() -> None:
     # edge case of empty series
     lf = pl.LazyFrame({"val": []}, schema={"val": pl.Int32})
 
-    expected_df = pl.DataFrame({"val": [0]}, schema={"val": pl.UInt32})
+    expected_df = pl.DataFrame({"val": [0]}, schema={"val": pl.get_index_type()})
     result_df = lf.select(pl.col("val").is_null().sum()).collect()
     assert_frame_equal(expected_df, result_df)
 
@@ -127,7 +128,8 @@ def test_is_not_null_followed_by_sum() -> None:
     lf = pl.LazyFrame({"group": [0, 0, 0, 1, 2], "val": [6, 0, None, None, 5]})
 
     expected_df = pl.DataFrame(
-        {"group": [0, 1, 2], "val": [2, 0, 1]}, schema_overrides={"val": pl.UInt32}
+        {"group": [0, 1, 2], "val": [2, 0, 1]},
+        schema_overrides={"val": pl.get_index_type()},
     )
     result_lf = lf.group_by("group", maintain_order=True).agg(
         pl.col("val").is_not_null().sum()
@@ -147,7 +149,7 @@ def test_is_not_null_followed_by_sum() -> None:
     # edge case of empty series
     lf = pl.LazyFrame({"val": []}, schema={"val": pl.Int32})
 
-    expected_df = pl.DataFrame({"val": [0]}, schema={"val": pl.UInt32})
+    expected_df = pl.DataFrame({"val": [0]}, schema={"val": pl.get_index_type()})
     result_df = lf.select(pl.col("val").is_not_null().sum()).collect()
     assert_frame_equal(expected_df, result_df)
 
@@ -156,7 +158,8 @@ def test_drop_nulls_followed_by_len() -> None:
     lf = pl.LazyFrame({"group": [0, 0, 0, 1, 2], "val": [6, 0, None, None, 5]})
 
     expected_df = pl.DataFrame(
-        {"group": [0, 1, 2], "val": [2, 0, 1]}, schema_overrides={"val": pl.UInt32}
+        {"group": [0, 1, 2], "val": [2, 0, 1]},
+        schema_overrides={"val": pl.get_index_type()},
     )
     result_lf = lf.group_by("group", maintain_order=True).agg(
         pl.col("val").drop_nulls().len()
@@ -180,7 +183,8 @@ def test_drop_nulls_followed_by_count() -> None:
     lf = pl.LazyFrame({"group": [0, 0, 0, 1, 2], "val": [6, 0, None, None, 5]})
 
     expected_df = pl.DataFrame(
-        {"group": [0, 1, 2], "val": [2, 0, 1]}, schema_overrides={"val": pl.UInt32}
+        {"group": [0, 1, 2], "val": [2, 0, 1]},
+        schema_overrides={"val": pl.get_index_type()},
     )
     result_lf = lf.group_by("group", maintain_order=True).agg(
         pl.col("val").drop_nulls().count()

--- a/py-polars/tests/unit/meta/test_index_type.py
+++ b/py-polars/tests/unit/meta/test_index_type.py
@@ -2,4 +2,7 @@ import polars as pl
 
 
 def test_get_index_type() -> None:
-    assert pl.get_index_type() == pl.UInt32()
+    len_type = pl.DataFrame({"a": []}).select(pl.len()).schema["len"]
+    index_type = pl.DataFrame({"a": []}).with_row_index().schema["index"]
+    assert pl.get_index_type() == len_type
+    assert pl.get_index_type() == index_type

--- a/py-polars/tests/unit/operations/aggregation/test_aggregations.py
+++ b/py-polars/tests/unit/operations/aggregation/test_aggregations.py
@@ -166,7 +166,7 @@ def test_literal_group_agg_chunked_7968() -> None:
         pl.DataFrame(
             [
                 pl.Series("A", [1], dtype=pl.Int64),
-                pl.Series("B", [[1, 2, 2]], dtype=pl.List(pl.UInt32)),
+                pl.Series("B", [[1, 2, 2]], dtype=pl.List(pl.get_index_type())),
             ]
         ),
     )
@@ -292,7 +292,9 @@ def test_horizontal_sum_null_to_identity() -> None:
 
 def test_horizontal_sum_bool_dtype() -> None:
     out = pl.DataFrame({"a": [True, False]}).select(pl.sum_horizontal("a"))
-    assert_frame_equal(out, pl.DataFrame({"a": pl.Series([1, 0], dtype=pl.UInt32)}))
+    assert_frame_equal(
+        out, pl.DataFrame({"a": pl.Series([1, 0], dtype=pl.get_index_type())})
+    )
 
 
 def test_horizontal_sum_in_group_by_15102() -> None:
@@ -315,8 +317,8 @@ def test_horizontal_sum_in_group_by_15102() -> None:
         out,
         pl.DataFrame(
             {
-                "num_null": pl.Series([0, 2, 3], dtype=pl.UInt32),
-                "len": pl.Series([nbr_records] * 3, dtype=pl.UInt32),
+                "num_null": pl.Series([0, 2, 3], dtype=pl.get_index_type()),
+                "len": pl.Series([nbr_records] * 3, dtype=pl.get_index_type()),
             }
         ),
     )
@@ -522,7 +524,7 @@ def test_horizontal_mean_in_group_by_15115() -> None:
         pl.DataFrame(
             {
                 "mean_null": pl.Series([0.25, 0.5, 0.75, 1.0], dtype=pl.Float64),
-                "len": pl.Series([nbr_records] * 4, dtype=pl.UInt32),
+                "len": pl.Series([nbr_records] * 4, dtype=pl.get_index_type()),
             }
         ),
     )

--- a/py-polars/tests/unit/operations/aggregation/test_horizontal.py
+++ b/py-polars/tests/unit/operations/aggregation/test_horizontal.py
@@ -507,7 +507,7 @@ def test_schema_mean_horizontal_single_column(
 
 def test_schema_boolean_sum_horizontal() -> None:
     lf = pl.LazyFrame({"a": [True, False]}).select(pl.sum_horizontal("a"))
-    assert lf.collect_schema() == OrderedDict([("a", pl.UInt32)])
+    assert lf.collect_schema() == OrderedDict([("a", pl.get_index_type())])
 
 
 def test_fold_all_schema() -> None:

--- a/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
@@ -662,7 +662,7 @@ def test_literal_subtract_schema_13284() -> None:
         .with_columns(pl.col("a") - pl.lit(1))
         .group_by("a")
         .len()
-    ).collect_schema() == OrderedDict([("a", pl.UInt8), ("len", pl.UInt32)])
+    ).collect_schema() == OrderedDict([("a", pl.UInt8), ("len", pl.get_index_type())])
 
 
 @pytest.mark.parametrize("dtype", INTEGER_DTYPES)

--- a/py-polars/tests/unit/operations/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_array.py
@@ -84,13 +84,14 @@ def test_array_lengths() -> None:
     )
     out = df.select(pl.col("a").arr.len(), pl.col("b").arr.len())
     expected_df = pl.DataFrame(
-        {"a": [3], "b": [2]}, schema={"a": pl.UInt32, "b": pl.UInt32}
+        {"a": [3], "b": [2]},
+        schema={"a": pl.get_index_type(), "b": pl.get_index_type()},
     )
     assert_frame_equal(out, expected_df)
 
     assert pl.Series("a", [], pl.Array(pl.Null, 1)).arr.len().to_list() == []
     assert pl.Series(
-        "a", [[1, 2, 3], None, [7, 8, 9]], pl.Array(pl.Int32, 3)
+        "a", [[1, 2, 3], None, [7, 8, 9]], pl.Array(pl.get_index_type(), 3)
     ).arr.len().to_list() == [3, None, 3]
 
 
@@ -209,9 +210,9 @@ def test_array_reverse() -> None:
 
 def test_array_arg_min_max() -> None:
     s = pl.Series("a", [[1, 2, 4], [3, 2, 1]], dtype=pl.Array(pl.UInt32, 3))
-    expected = pl.Series("a", [0, 2], dtype=pl.UInt32)
+    expected = pl.Series("a", [0, 2], dtype=pl.get_index_type())
     assert_series_equal(s.arr.arg_min(), expected)
-    expected = pl.Series("a", [2, 0], dtype=pl.UInt32)
+    expected = pl.Series("a", [2, 0], dtype=pl.get_index_type())
     assert_series_equal(s.arr.arg_max(), expected)
 
 
@@ -541,7 +542,7 @@ def test_array_n_unique() -> None:
 
     out = df.select(n_unique=pl.col("a").arr.n_unique())
     expected = pl.DataFrame(
-        {"n_unique": [2, 1, 1, None]}, schema={"n_unique": pl.UInt32}
+        {"n_unique": [2, 1, 1, None]}, schema={"n_unique": pl.get_index_type()}
     )
     assert_frame_equal(out, expected)
 

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -336,9 +336,9 @@ def test_list_arr_empty() -> None:
 
 def test_list_argminmax() -> None:
     s = pl.Series("a", [[1, 2], [3, 2, 1]])
-    expected = pl.Series("a", [0, 2], dtype=pl.UInt32)
+    expected = pl.Series("a", [0, 2], dtype=pl.get_index_type())
     assert_series_equal(s.list.arg_min(), expected)
-    expected = pl.Series("a", [1, 0], dtype=pl.UInt32)
+    expected = pl.Series("a", [1, 0], dtype=pl.get_index_type())
     assert_series_equal(s.list.arg_max(), expected)
 
 
@@ -824,14 +824,15 @@ def test_list_to_array_wrong_dtype() -> None:
 def test_list_lengths() -> None:
     s = pl.Series([[1, 2, None], [5]])
     result = s.list.len()
-    expected = pl.Series([3, 1], dtype=pl.UInt32)
+    expected = pl.Series([3, 1], dtype=pl.get_index_type())
     assert_series_equal(result, expected)
 
     s = pl.Series("a", [[1, 2], [1, 2, 3]])
-    assert_series_equal(s.list.len(), pl.Series("a", [2, 3], dtype=pl.UInt32))
+    assert_series_equal(s.list.len(), pl.Series("a", [2, 3], dtype=pl.get_index_type()))
     df = pl.DataFrame([s])
     assert_series_equal(
-        df.select(pl.col("a").list.len())["a"], pl.Series("a", [2, 3], dtype=pl.UInt32)
+        df.select(pl.col("a").list.len())["a"],
+        pl.Series("a", [2, 3], dtype=pl.get_index_type()),
     )
 
     assert_series_equal(
@@ -840,7 +841,7 @@ def test_list_lengths() -> None:
             .then(pl.Series([[1, 1], [1, 1]]))
             .list.len()
         ).to_series(),
-        pl.Series([2, None], dtype=pl.UInt32),
+        pl.Series([2, None], dtype=pl.get_index_type()),
     )
 
     assert_series_equal(
@@ -849,7 +850,7 @@ def test_list_lengths() -> None:
             .then(pl.Series([[1, 1], [1, 1]]))
             .list.len()
         ).to_series(),
-        pl.Series([None, None], dtype=pl.UInt32),
+        pl.Series([None, None], dtype=pl.get_index_type()),
     )
 
 
@@ -940,7 +941,7 @@ def test_list_n_unique() -> None:
 
     out = df.select(n_unique=pl.col("a").list.n_unique())
     expected = pl.DataFrame(
-        {"n_unique": [2, 1, 1, None, 0]}, schema={"n_unique": pl.UInt32}
+        {"n_unique": [2, 1, 1, None, 0]}, schema={"n_unique": pl.get_index_type()}
     )
     assert_frame_equal(out, expected)
 
@@ -969,7 +970,7 @@ def test_list_get_with_null() -> None:
 
 def test_list_sum_bool_schema() -> None:
     q = pl.LazyFrame({"x": [[True, True, False]]})
-    assert q.select(pl.col("x").list.sum()).collect_schema()["x"] == pl.UInt32
+    assert q.select(pl.col("x").list.sum()).collect_schema()["x"] == pl.get_index_type()
 
 
 def test_list_concat_struct_19279() -> None:

--- a/py-polars/tests/unit/operations/namespaces/test_categorical.py
+++ b/py-polars/tests/unit/operations/namespaces/test_categorical.py
@@ -132,7 +132,7 @@ def test_cat_len_bytes(dtype: PolarsDataType) -> None:
         {
             "key": [1, 1, 1, 1, 1, 2, 2, 2, 2, 2],
             "len_bytes": pl.Series(
-                [5, None, 5, 3, 6, 5, None, 5, 3, 6], dtype=pl.get_index_type()
+                [5, None, 5, 3, 6, 5, None, 5, 3, 6], dtype=pl.UInt32
             ),
         }
     )
@@ -172,7 +172,7 @@ def test_cat_len_chars(dtype: PolarsDataType) -> None:
         {
             "key": [1, 1, 1, 1, 1, 2, 2, 2, 2, 2],
             "len_bytes": pl.Series(
-                [4, None, 4, 3, 2, 4, None, 4, 3, 2], dtype=pl.get_index_type()
+                [4, None, 4, 3, 2, 4, None, 4, 3, 2], dtype=pl.UInt32
             ),
         }
     )

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -861,7 +861,7 @@ def test_rolling_aggregations_with_over_11225() -> None:
             "group": ["A", "A", "B", "B", "B"],
             "rolling_row_mean": [None, 0.0, None, 2.0, 2.5],
         },
-        schema_overrides={"index": pl.UInt32},
+        schema_overrides={"index": pl.get_index_type()},
     )
     assert_frame_equal(result, expected)
 

--- a/py-polars/tests/unit/operations/test_explode.py
+++ b/py-polars/tests/unit/operations/test_explode.py
@@ -98,7 +98,7 @@ def test_explode_correct_for_slice() -> None:
             "group": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
             "b": [1, 2, 3, 2, 3, 4, 1, 2, 3, 0, 1, 2, 3, 2, 3, 4, 1, 2, 3, 0],
         },
-        schema_overrides={"index": pl.UInt32},
+        schema_overrides={"index": pl.get_index_type()},
     )
     assert_frame_equal(df.slice(0, 10).explode(["b"]), expected)
 

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -690,7 +690,7 @@ def test_group_by_multiple_column_reference() -> None:
         ("mean", [], [1.0, None], pl.Float64),
         ("median", [], [1.0, None], pl.Float64),
         ("min", [], [1, None], pl.Int64),
-        ("n_unique", [], [1, 0], pl.UInt32),
+        ("n_unique", [], [1, 0], pl.get_index_type()),
         ("quantile", [0.5], [1.0, None], pl.Float64),
     ],
 )
@@ -1064,8 +1064,8 @@ def test_group_by_schema_err() -> None:
         (
             {"x": [True]},
             pl.col("x").sum(),
-            {"x": pl.UInt32},
-            {"x": pl.UInt32},
+            {"x": pl.get_index_type()},
+            {"x": pl.get_index_type()},
         ),
         (
             {"a": [[1, 2]]},

--- a/py-polars/tests/unit/operations/test_group_by_dynamic.py
+++ b/py-polars/tests/unit/operations/test_group_by_dynamic.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
                     ],
                     "num_points": [1, 2, 1],
                 },
-                schema={"dt": pl.Datetime, "num_points": pl.UInt32},
+                schema={"dt": pl.Datetime, "num_points": pl.get_index_type()},
             ).sort("dt"),
         )
     ],
@@ -597,7 +597,7 @@ def test_group_by_dynamic_when_conversion_crosses_dates_7274() -> None:
     expected = pl.DataFrame({"timestamp": [datetime(1970, 1, 1)], "value": [2]})
     expected = expected.with_columns(
         pl.col("timestamp").dt.replace_time_zone("Africa/Lagos"),
-        pl.col("value").cast(pl.UInt32),
+        pl.col("value").cast(pl.get_index_type()),
     )
     assert_frame_equal(result, expected)
     result = df.group_by_dynamic(
@@ -611,7 +611,7 @@ def test_group_by_dynamic_when_conversion_crosses_dates_7274() -> None:
     )
     expected = expected.with_columns(
         pl.col("timestamp_utc").dt.replace_time_zone("UTC"),
-        pl.col("value").cast(pl.UInt32),
+        pl.col("value").cast(pl.get_index_type()),
     )
     assert_frame_equal(result, expected)
 
@@ -1080,7 +1080,7 @@ def test_group_by_dynamic_single_row_22585() -> None:
     out = df.group_by_dynamic("date", every="1y", group_by=["group"]).agg(pl.len())
     expected = pl.DataFrame(
         {"group": ["x"], "date": [date(2025, 1, 1)], "len": [1]}
-    ).with_columns(pl.col("len").cast(pl.UInt32))
+    ).with_columns(pl.col("len").cast(pl.get_index_type()))
     assert_frame_equal(expected, out)
 
 

--- a/py-polars/tests/unit/operations/test_hist.py
+++ b/py-polars/tests/unit/operations/test_hist.py
@@ -34,7 +34,9 @@ def test_hist_empty_data_no_inputs() -> None:
                 ],
                 dtype=pl.Categorical,
             ),
-            "count": pl.Series([0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=pl.UInt32),
+            "count": pl.Series(
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=pl.get_index_type()
+            ),
         }
     )
     result = s.hist()
@@ -49,7 +51,7 @@ def test_hist_empty_data_empty_bins() -> None:
         {
             "breakpoint": pl.Series([], dtype=pl.Float64),
             "category": pl.Series([], dtype=pl.Categorical),
-            "count": pl.Series([], dtype=pl.UInt32),
+            "count": pl.Series([], dtype=pl.get_index_type()),
         }
     )
     result = s.hist(bins=[])
@@ -64,7 +66,7 @@ def test_hist_empty_data_single_bin_edge() -> None:
         {
             "breakpoint": pl.Series([], dtype=pl.Float64),
             "category": pl.Series([], dtype=pl.Categorical),
-            "count": pl.Series([], dtype=pl.UInt32),
+            "count": pl.Series([], dtype=pl.get_index_type()),
         }
     )
     result = s.hist(bins=[2])
@@ -79,7 +81,7 @@ def test_hist_empty_data_valid_edges() -> None:
         {
             "breakpoint": pl.Series([2.0, 3.0], dtype=pl.Float64),
             "category": pl.Series(["[1.0, 2.0]", "(2.0, 3.0]"], dtype=pl.Categorical),
-            "count": pl.Series([0, 0], dtype=pl.UInt32),
+            "count": pl.Series([0, 0], dtype=pl.get_index_type()),
         }
     )
     result = s.hist(bins=[1, 2, 3])
@@ -104,7 +106,7 @@ def test_hist_empty_data_zero_bin_count() -> None:
         {
             "breakpoint": pl.Series([], dtype=pl.Float64),
             "category": pl.Series([], dtype=pl.Categorical),
-            "count": pl.Series([], dtype=pl.UInt32),
+            "count": pl.Series([], dtype=pl.get_index_type()),
         }
     )
     result = s.hist(bin_count=0)
@@ -117,7 +119,7 @@ def test_hist_empty_data_single_bin_count() -> None:
         {
             "breakpoint": pl.Series([1.0], dtype=pl.Float64),
             "category": pl.Series(["[0.0, 1.0]"], dtype=pl.Categorical),
-            "count": pl.Series([0], dtype=pl.UInt32),
+            "count": pl.Series([0], dtype=pl.get_index_type()),
         }
     )
     result = s.hist(bin_count=1)
@@ -139,7 +141,7 @@ def test_hist_empty_data_valid_bin_count() -> None:
                 ],
                 dtype=pl.Categorical,
             ),
-            "count": pl.Series([0, 0, 0, 0, 0], dtype=pl.UInt32),
+            "count": pl.Series([0, 0, 0, 0, 0], dtype=pl.get_index_type()),
         }
     )
     result = s.hist(bin_count=5)
@@ -165,7 +167,7 @@ def test_hist_bin_outside_data() -> None:
         {
             "breakpoint": pl.Series([-9.0], dtype=pl.Float64),
             "category": pl.Series(["[-10.0, -9.0]"], dtype=pl.Categorical),
-            "count": pl.Series([0], dtype=pl.UInt32),
+            "count": pl.Series([0], dtype=pl.get_index_type()),
         }
     )
     assert_frame_equal(result, expected)
@@ -178,7 +180,7 @@ def test_hist_bins_between_data() -> None:
         {
             "breakpoint": pl.Series([10.5], dtype=pl.Float64),
             "category": pl.Series(["[4.5, 10.5]"], dtype=pl.Categorical),
-            "count": pl.Series([0], dtype=pl.UInt32),
+            "count": pl.Series([0], dtype=pl.get_index_type()),
         }
     )
     assert_frame_equal(result, expected)
@@ -191,7 +193,7 @@ def test_hist_bins_first_edge() -> None:
         {
             "breakpoint": pl.Series([3.0, 4.0], dtype=pl.Float64),
             "category": pl.Series(["[2.0, 3.0]", "(3.0, 4.0]"], dtype=pl.Categorical),
-            "count": pl.Series([1, 0], dtype=pl.UInt32),
+            "count": pl.Series([1, 0], dtype=pl.get_index_type()),
         }
     )
     assert_frame_equal(result, expected)
@@ -211,7 +213,7 @@ def test_hist_bins_last_edge() -> None:
                 ],
                 dtype=pl.Categorical,
             ),
-            "count": pl.Series([1, 3, 0], dtype=pl.UInt32),
+            "count": pl.Series([1, 3, 0], dtype=pl.get_index_type()),
         }
     )
     assert_frame_equal(result, expected)
@@ -224,7 +226,7 @@ def test_hist_single_value_single_bin_count() -> None:
         {
             "breakpoint": pl.Series([1.5], dtype=pl.Float64),
             "category": pl.Series(["[0.5, 1.5]"], dtype=pl.Categorical),
-            "count": pl.Series([1], dtype=pl.UInt32),
+            "count": pl.Series([1], dtype=pl.get_index_type()),
         }
     )
     assert_frame_equal(result, expected)
@@ -237,7 +239,7 @@ def test_hist_single_bin_count() -> None:
         {
             "breakpoint": pl.Series([99.0], dtype=pl.Float64),
             "category": pl.Series(["[-5.0, 99.0]"], dtype=pl.Categorical),
-            "count": pl.Series([5], dtype=pl.UInt32),
+            "count": pl.Series([5], dtype=pl.get_index_type()),
         }
     )
     assert_frame_equal(result, expected)
@@ -252,7 +254,7 @@ def test_hist_partial_covering() -> None:
             "category": pl.Series(
                 ["[-1.5, 2.5]", "(2.5, 50.0]", "(50.0, 105.0]"], dtype=pl.Categorical
             ),
-            "count": pl.Series([3, 0, 1], dtype=pl.UInt32),
+            "count": pl.Series([3, 0, 1], dtype=pl.get_index_type()),
         }
     )
     assert_frame_equal(result, expected)
@@ -267,7 +269,7 @@ def test_hist_full_covering() -> None:
             "category": pl.Series(
                 ["[-5.5, 2.5]", "(2.5, 50.0]", "(50.0, 105.0]"], dtype=pl.Categorical
             ),
-            "count": pl.Series([4, 0, 1], dtype=pl.UInt32),
+            "count": pl.Series([4, 0, 1], dtype=pl.get_index_type()),
         }
     )
     assert_frame_equal(result, expected)
@@ -288,7 +290,7 @@ def test_hist_more_bins_than_data() -> None:
         {
             "breakpoint": pl.Series(breaks[1:], dtype=pl.Float64),
             "category": pl.Series(categories, dtype=pl.Categorical),
-            "count": pl.Series([4, 0, 0, 0, 0, 0, 0, 1], dtype=pl.UInt32),
+            "count": pl.Series([4, 0, 0, 0, 0, 0, 0, 1], dtype=pl.get_index_type()),
         }
     )
     assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_index_of.py
+++ b/py-polars/tests/unit/operations/test_index_of.py
@@ -158,7 +158,7 @@ def test_groupby() -> None:
     )
     expected = pl.DataFrame(
         {"label": ["a", "b"], "value": [1, 2]},
-        schema={"label": pl.String, "value": pl.UInt32},
+        schema={"label": pl.String, "value": pl.get_index_type()},
     )
     assert_frame_equal(
         df.group_by("label", maintain_order=True).agg(pl.col("value").index_of(20)),

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -2992,7 +2992,7 @@ def test_join_filter_pushdown_iejoin() -> None:
 
     expect = pl.DataFrame(
         [
-            pl.Series("index", [0, 1, 1, 2, 2, 3, 3, 4, 4], dtype=pl.UInt32),
+            pl.Series("index", [0, 1, 1, 2, 2, 3, 3, 4, 4], dtype=pl.get_index_type()),
             pl.Series("a", [1, 2, 2, 3, 3, 4, 4, 5, 5], dtype=pl.Int64),
             pl.Series("b", [1, 2, 2, 3, 3, 4, 4, None, None], dtype=pl.Int64),
             pl.Series(

--- a/py-polars/tests/unit/operations/test_rank.py
+++ b/py-polars/tests/unit/operations/test_rank.py
@@ -27,7 +27,8 @@ def test_rank_random_expr() -> None:
 def test_rank_random_series() -> None:
     s = pl.Series("a", [1, 2, 3, 2, 2, 3, 0])
     assert_series_equal(
-        s.rank("random", seed=1), pl.Series("a", [2, 5, 7, 3, 4, 6, 1], dtype=pl.UInt32)
+        s.rank("random", seed=1),
+        pl.Series("a", [2, 5, 7, 3, 4, 6, 1], dtype=pl.get_index_type()),
     )
 
 
@@ -101,7 +102,8 @@ def test_rank_series() -> None:
     s = pl.Series("a", [1, 2, 3, 2, 2, 3, 0])
 
     assert_series_equal(
-        s.rank("dense"), pl.Series("a", [2, 3, 4, 3, 3, 4, 1], dtype=pl.UInt32)
+        s.rank("dense"),
+        pl.Series("a", [2, 3, 4, 3, 3, 4, 1], dtype=pl.get_index_type()),
     )
 
     df = pl.DataFrame([s])
@@ -109,7 +111,7 @@ def test_rank_series() -> None:
 
     assert_series_equal(
         s.rank("dense", descending=True),
-        pl.Series("a", [3, 2, 1, 2, 2, 1, 4], dtype=pl.UInt32),
+        pl.Series("a", [3, 2, 1, 2, 2, 1, 4], dtype=pl.get_index_type()),
     )
 
     assert s.rank(method="average").dtype == pl.Float64

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -411,7 +411,7 @@ def test_negative_zero_offset_16168() -> None:
     result = df.rolling(index_column="foo", period="1i", offset="0i").agg("index")
     expected = pl.DataFrame(
         {"foo": [1, 1, 1], "index": [[], [], []]},
-        schema_overrides={"index": pl.List(pl.UInt32)},
+        schema_overrides={"index": pl.List(pl.get_index_type())},
     )
     assert_frame_equal(result, expected)
     result = df.rolling(index_column="foo", period="1i", offset="-0i").agg("index")

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -393,7 +393,7 @@ def test_sorted_join_and_dtypes(dtype: PolarsDataType) -> None:
                 "index": [1, 2, 3, 5],
                 "a": [-2, 3, 3, 10],
             },
-            schema={"index": pl.UInt32, "a": dtype},
+            schema={"index": pl.get_index_type(), "a": dtype},
         ),
         check_row_order=False,
     )
@@ -406,7 +406,7 @@ def test_sorted_join_and_dtypes(dtype: PolarsDataType) -> None:
                 "index": [0, 1, 2, 3, 4, 5],
                 "a": [-5, -2, 3, 3, 9, 10],
             },
-            schema={"index": pl.UInt32, "a": dtype},
+            schema={"index": pl.get_index_type(), "a": dtype},
         ),
         check_row_order=False,
     )
@@ -831,7 +831,9 @@ def test_sort_by_descending() -> None:
 def test_arg_sort_by_descending() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     result = df.select(pl.arg_sort_by(["a", "b"], descending=True))
-    expected = pl.DataFrame({"a": [2, 1, 0]}).select(pl.col("a").cast(pl.UInt32))
+    expected = pl.DataFrame({"a": [2, 1, 0]}).select(
+        pl.col("a").cast(pl.get_index_type())
+    )
     assert_frame_equal(result, expected)
     result = df.select(pl.arg_sort_by(["a", "b"], descending=[True, True]))
     assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_statistics.py
+++ b/py-polars/tests/unit/operations/test_statistics.py
@@ -133,7 +133,7 @@ def test_count() -> None:
             "one_null_float": [2],
             "no_nulls_int": [3],
         },
-    ).cast(pl.UInt32)
+    ).cast(pl.get_index_type())
     assert_frame_equal(lf_result, expected)
     assert_frame_equal(df_result, expected.collect())
 

--- a/py-polars/tests/unit/operations/test_value_counts.py
+++ b/py-polars/tests/unit/operations/test_value_counts.py
@@ -11,7 +11,8 @@ def test_value_counts() -> None:
     s = pl.Series("a", [1, 2, 2, 3])
     result = s.value_counts()
     expected = pl.DataFrame(
-        {"a": [1, 2, 3], "count": [1, 2, 1]}, schema_overrides={"count": pl.UInt32}
+        {"a": [1, 2, 3], "count": [1, 2, 1]},
+        schema_overrides={"count": pl.get_index_type()},
     )
     result_sorted = result.sort("a")
     assert_frame_equal(result_sorted, expected)
@@ -73,7 +74,7 @@ def test_value_counts_duplicate_name() -> None:
     # ... but can customize that
     result = s.value_counts(name="n", sort=True)
     expected = pl.DataFrame(
-        {"count": [1, 0], "n": [2, 1]}, schema_overrides={"n": pl.UInt32}
+        {"count": [1, 0], "n": [2, 1]}, schema_overrides={"n": pl.get_index_type()}
     )
     assert_frame_equal(result, expected)
 

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -220,7 +220,7 @@ def test_window_cached_keys_sorted_update_4183() -> None:
     )
     expected = pl.DataFrame(
         {"count": [2, 2, 1], "rank": [1, 2, 1]},
-        schema={"count": pl.UInt32, "rank": pl.UInt32},
+        schema={"count": pl.get_index_type(), "rank": pl.get_index_type()},
     )
     assert_frame_equal(result, expected)
 
@@ -404,7 +404,7 @@ def test_window_filtered_false_15483() -> None:
             "group": ["A", "A"],
             "value": [None, None],
         },
-        schema_overrides={"value": pl.UInt32},
+        schema_overrides={"value": pl.get_index_type()},
     )
     assert_frame_equal(out, expected)
 

--- a/py-polars/tests/unit/operations/unique/test_approx_n_unique.py
+++ b/py-polars/tests/unit/operations/unique/test_approx_n_unique.py
@@ -8,7 +8,7 @@ def test_df_approx_n_unique_deprecated() -> None:
     df = pl.DataFrame({"a": [1, 2, 2], "b": [2, 2, 2]})
     with pytest.deprecated_call():
         result = df.approx_n_unique()
-    expected = pl.DataFrame({"a": [2], "b": [1]}).cast(pl.UInt32)
+    expected = pl.DataFrame({"a": [2], "b": [1]}).cast(pl.get_index_type())
     assert_frame_equal(result, expected)
 
 
@@ -16,5 +16,5 @@ def test_lf_approx_n_unique_deprecated() -> None:
     df = pl.LazyFrame({"a": [1, 2, 2], "b": [2, 2, 2]})
     with pytest.deprecated_call():
         result = df.approx_n_unique()
-    expected = pl.LazyFrame({"a": [2], "b": [1]}).cast(pl.UInt32)
+    expected = pl.LazyFrame({"a": [2], "b": [1]}).cast(pl.get_index_type())
     assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/unique/test_unique_counts.py
+++ b/py-polars/tests/unit/operations/unique/test_unique_counts.py
@@ -6,7 +6,7 @@ from polars.testing import assert_series_equal
 
 def test_unique_counts() -> None:
     s = pl.Series("id", ["a", "b", "b", "c", "c", "c"])
-    expected = pl.Series("id", [1, 2, 3], dtype=pl.UInt32)
+    expected = pl.Series("id", [1, 2, 3], dtype=pl.get_index_type())
     assert_series_equal(s.unique_counts(), expected)
 
 
@@ -31,13 +31,13 @@ def test_unique_counts_on_dates() -> None:
 
 def test_unique_counts_null() -> None:
     s = pl.Series([])
-    expected = pl.Series([], dtype=pl.UInt32)
+    expected = pl.Series([], dtype=pl.get_index_type())
     assert_series_equal(s.unique_counts(), expected)
 
     s = pl.Series([None])
-    expected = pl.Series([1], dtype=pl.UInt32)
+    expected = pl.Series([1], dtype=pl.get_index_type())
     assert_series_equal(s.unique_counts(), expected)
 
     s = pl.Series([None, None, None])
-    expected = pl.Series([3], dtype=pl.UInt32)
+    expected = pl.Series([3], dtype=pl.get_index_type())
     assert_series_equal(s.unique_counts(), expected)

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -419,7 +419,9 @@ def test_various() -> None:
     a.sort(in_place=True)
     assert_series_equal(a, pl.Series("a", [1, 2, 4]))
     a = pl.Series("a", [2, 1, 1, 4, 4, 4])
-    assert_series_equal(a.arg_unique(), pl.Series("a", [0, 1, 3], dtype=UInt32))
+    assert_series_equal(
+        a.arg_unique(), pl.Series("a", [0, 1, 3], dtype=pl.get_index_type())
+    )
 
     assert_series_equal(a.gather([2, 3]), pl.Series("a", [1, 4]))
 
@@ -1442,11 +1444,11 @@ def test_gather_every() -> None:
 
 def test_arg_sort() -> None:
     s = pl.Series("a", [5, 3, 4, 1, 2])
-    expected = pl.Series("a", [3, 4, 1, 2, 0], dtype=UInt32)
+    expected = pl.Series("a", [3, 4, 1, 2, 0], dtype=pl.get_index_type())
 
     assert_series_equal(s.arg_sort(), expected)
 
-    expected_descending = pl.Series("a", [0, 2, 1, 4, 3], dtype=UInt32)
+    expected_descending = pl.Series("a", [0, 2, 1, 4, 3], dtype=pl.get_index_type())
     assert_series_equal(s.arg_sort(descending=True), expected_descending)
 
 
@@ -2197,7 +2199,9 @@ def test_search_sorted(
     assert single_s == single_expected
 
     multiple_s = s.search_sorted(multiple)
-    assert_series_equal(multiple_s, pl.Series(multiple_expected, dtype=pl.UInt32))
+    assert_series_equal(
+        multiple_s, pl.Series(multiple_expected, dtype=pl.get_index_type())
+    )
 
 
 def test_series_from_pandas_with_dtype() -> None:

--- a/py-polars/tests/unit/sql/test_miscellaneous.py
+++ b/py-polars/tests/unit/sql/test_miscellaneous.py
@@ -543,5 +543,5 @@ def test_count_partition_22665(query: str, result: list[Any]) -> None:
         }
     )
     out = df.sql(query).select("b")
-    expected = pl.DataFrame({"b": result}).cast({"b": pl.UInt32})
+    expected = pl.DataFrame({"b": result}).cast({"b": pl.get_index_type()})
     assert_frame_equal(out, expected)

--- a/py-polars/tests/unit/sql/test_structs.py
+++ b/py-polars/tests/unit/sql/test_structs.py
@@ -109,7 +109,7 @@ def test_struct_field_group_by(df_struct: pl.DataFrame) -> None:
 
     expected = pl.DataFrame(
         data={"n": [2, 1], "names": [["Bob", "Zoe"], ["David"]]},
-        schema_overrides={"n": pl.UInt32},
+        schema_overrides={"n": pl.get_index_type()},
     )
     assert_frame_equal(expected, res)
 

--- a/py-polars/tests/unit/streaming/test_streaming_group_by.py
+++ b/py-polars/tests/unit/streaming/test_streaming_group_by.py
@@ -83,7 +83,7 @@ def test_streaming_group_by_types() -> None:
             "bool_first": pl.Boolean,
             "bool_last": pl.Boolean,
             "bool_mean": pl.Float64,
-            "bool_sum": pl.UInt32,
+            "bool_sum": pl.get_index_type(),
             # "date_sum": pl.Date,
             # "date_mean": pl.Date,
             "date_first": pl.Date,

--- a/py-polars/tests/unit/test_empty.py
+++ b/py-polars/tests/unit/test_empty.py
@@ -46,7 +46,7 @@ def test_empty_count_window() -> None:
     )
 
     out = df.select(pl.col("ID").count().over(["ID", "DESC"]))
-    assert out.schema == {"ID": pl.UInt32}
+    assert out.schema == {"ID": pl.get_index_type()}
     assert out.height == 0
 
 

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -626,7 +626,9 @@ def test_predicate_pushdown_struct_unnest_19632() -> None:
 
     assert_frame_equal(
         q.collect(),
-        pl.DataFrame({"a": 1, "count": 1}, schema={"a": pl.Int64, "count": pl.UInt32}),
+        pl.DataFrame(
+            {"a": 1, "count": 1}, schema={"a": pl.Int64, "count": pl.get_index_type()}
+        ),
     )
 
 

--- a/py-polars/tests/unit/test_projections.py
+++ b/py-polars/tests/unit/test_projections.py
@@ -305,7 +305,7 @@ def test_distinct_projection_pd_7578() -> None:
             "bar": ["a", "b"],
             "len": [3, 2],
         },
-        schema_overrides={"len": pl.UInt32},
+        schema_overrides={"len": pl.get_index_type()},
     )
     assert_frame_equal(result, expected, check_row_order=False)
 
@@ -554,7 +554,7 @@ def test_projection_empty_frame_len_16904() -> None:
 
     assert "0/0 COLUMNS" in q.explain()
 
-    expect = pl.DataFrame({"len": [0]}, schema_overrides={"len": pl.UInt32()})
+    expect = pl.DataFrame({"len": [0]}, schema_overrides={"len": pl.get_index_type()})
     assert_frame_equal(q.collect(), expect)
 
 

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -292,7 +292,7 @@ def test_lazy_nested_function_expr_agg_schema() -> None:
 def test_lazy_agg_scalar_return_schema() -> None:
     q = pl.LazyFrame({"k": [1]}).group_by("k").agg(pl.col("k").null_count().alias("o"))
 
-    schema = {"k": pl.Int64, "o": pl.UInt32}
+    schema = {"k": pl.Int64, "o": pl.get_index_type()}
     assert q.collect_schema() == schema
     assert_frame_equal(q.collect(), pl.DataFrame({"k": 1, "o": 0}, schema=schema))
 

--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -842,7 +842,7 @@ def test_selector_or() -> None:
 
     expected = pl.DataFrame(
         {"idx": [0, 1, 2], "str": ["x", "y", "z"]},
-        schema_overrides={"idx": pl.UInt32},
+        schema_overrides={"idx": pl.get_index_type()},
     )
     assert_frame_equal(result, expected)
 


### PR DESCRIPTION
This PR:
- Update the tests to work for both regular and bigidx polars
- Bigidx is not currently tested in OSS, but this will be useful if we decide to do so or when running OSS tests in cloud
- xref #24882