### PR TITLE
feat: Add environment variable to roundtrip empty struct in Parquet

### DIFF
--- a/crates/polars-arrow/src/datatypes/field.rs
+++ b/crates/polars-arrow/src/datatypes/field.rs
@@ -16,6 +16,8 @@ pub static DTYPE_ENUM_VALUES_NEW: &str = "_PL_ENUM_VALUES2";
 pub static DTYPE_CATEGORICAL_LEGACY: &str = "_PL_CATEGORICAL";
 pub static DTYPE_CATEGORICAL_NEW: &str = "_PL_CATEGORICAL2";
 
+pub static PARQUET_EMPTY_STRUCT: &str = "_PL_EMPTY_STRUCT";
+
 pub static MAINTAIN_PL_TYPE: &str = "maintain_type";
 pub static PL_KEY: &str = "pl";
 
@@ -93,6 +95,12 @@ impl Field {
         } else {
             false
         }
+    }
+
+    pub fn is_pl_pq_empty_struct(&self) -> bool {
+        self.metadata
+            .as_ref()
+            .is_some_and(|md| md.contains_key(PARQUET_EMPTY_STRUCT))
     }
 
     pub fn map_dtype(mut self, f: impl FnOnce(ArrowDataType) -> ArrowDataType) -> Self {

--- a/crates/polars-arrow/src/datatypes/mod.rs
+++ b/crates/polars-arrow/src/datatypes/mod.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 pub use field::{
     DTYPE_CATEGORICAL_LEGACY, DTYPE_CATEGORICAL_NEW, DTYPE_ENUM_VALUES_LEGACY,
-    DTYPE_ENUM_VALUES_NEW, Field, MAINTAIN_PL_TYPE, PL_KEY,
+    DTYPE_ENUM_VALUES_NEW, Field, MAINTAIN_PL_TYPE, PARQUET_EMPTY_STRUCT, PL_KEY,
 };
 pub use physical_type::*;
 use polars_utils::pl_str::PlSmallStr;

--- a/crates/polars-io/src/parquet/write/writer.rs
+++ b/crates/polars-io/src/parquet/write/writer.rs
@@ -226,28 +226,37 @@ fn to_column_write_options_rec(
         },
         Struct => {
             if let ArrowDataType::Struct(fields) = field.dtype().to_logical_type() {
-                let children_overwrites = overwrites.and_then(|o| match &o.children {
-                    ChildFieldOverwrites::None => None,
-                    ChildFieldOverwrites::Struct(child_overwrites) => Some(PlHashMap::from_iter(
-                        child_overwrites
-                            .iter()
-                            .map(|f| (f.name.as_ref().unwrap(), f)),
-                    )),
-                    _ => unreachable!(),
-                });
+                if fields.is_empty() {
+                    // Allow empty structs by mapping to boolean array.
+                    column_options.children = ChildWriteOptions::Leaf(FieldWriteOptions {
+                        encoding: Encoding::Rle,
+                    });
+                } else {
+                    let children_overwrites = overwrites.and_then(|o| match &o.children {
+                        ChildFieldOverwrites::None => None,
+                        ChildFieldOverwrites::Struct(child_overwrites) => {
+                            Some(PlHashMap::from_iter(
+                                child_overwrites
+                                    .iter()
+                                    .map(|f| (f.name.as_ref().unwrap(), f)),
+                            ))
+                        },
+                        _ => unreachable!(),
+                    });
 
-                let children = fields
-                    .iter()
-                    .map(|f| {
-                        let overwrites = children_overwrites
-                            .as_ref()
-                            .and_then(|o| o.get(&f.name).copied());
-                        to_column_write_options_rec(f, overwrites)
-                    })
-                    .collect();
+                    let children = fields
+                        .iter()
+                        .map(|f| {
+                            let overwrites = children_overwrites
+                                .as_ref()
+                                .and_then(|o| o.get(&f.name).copied());
+                            to_column_write_options_rec(f, overwrites)
+                        })
+                        .collect();
 
-                column_options.children =
-                    ChildWriteOptions::Struct(Box::new(StructFieldWriteOptions { children }));
+                    column_options.children =
+                        ChildWriteOptions::Struct(Box::new(StructFieldWriteOptions { children }));
+                }
             } else {
                 unreachable!()
             }

--- a/crates/polars-parquet/src/arrow/read/deserialize/nested.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/nested.rs
@@ -19,7 +19,7 @@ pub fn columns_to_iter_recursive(
     mut init: Vec<InitNested>,
     filter: Option<Filter>,
 ) -> ParquetResult<(NestedState, Vec<Box<dyn Array>>, Bitmap)> {
-    if !field.dtype().is_nested() {
+    if !field.dtype().is_nested() || field.is_pl_pq_empty_struct() {
         let pages = columns.pop().unwrap();
         init.push(InitNested::Primitive(field.is_nullable));
         let type_ = types.pop().unwrap();

--- a/crates/polars-parquet/src/arrow/write/schema.rs
+++ b/crates/polars-parquet/src/arrow/write/schema.rs
@@ -1,7 +1,9 @@
 use std::borrow::Cow;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
-use arrow::datatypes::{ArrowDataType, ArrowSchema, ExtensionType, Field, TimeUnit};
+use arrow::datatypes::{
+    ArrowDataType, ArrowSchema, ExtensionType, Field, PARQUET_EMPTY_STRUCT, TimeUnit,
+};
 use arrow::io::ipc::write::{default_ipc_fields, schema_to_bytes};
 use base64::Engine as _;
 use base64::engine::general_purpose;
@@ -56,7 +58,7 @@ fn convert_dtype(dtype: ArrowDataType) -> ArrowDataType {
 }
 
 fn insert_field_metadata(field: &mut Cow<Field>, options: &ColumnWriteOptions) {
-    if !options.metadata.is_empty() {
+    if !options.metadata.is_empty() || matches!(field.dtype(), D::Struct(fs) if fs.is_empty()) {
         let field = field.to_mut();
         let mut metadata = field.metadata.as_deref().cloned().unwrap_or_default();
 
@@ -65,6 +67,9 @@ fn insert_field_metadata(field: &mut Cow<Field>, options: &ColumnWriteOptions) {
                 kv.key.as_str().into(),
                 kv.value.as_deref().unwrap_or_default().into(),
             );
+        }
+        if matches!(field.dtype(), D::Struct(fs) if fs.is_empty()) {
+            metadata.insert(PARQUET_EMPTY_STRUCT.into(), "".into());
         }
         field.metadata = Some(Arc::new(metadata));
     }
@@ -79,6 +84,10 @@ fn insert_field_metadata(field: &mut Cow<Field>, options: &ColumnWriteOptions) {
     use ArrowDataType as D;
     match field.dtype() {
         D::Struct(f) => {
+            if let ChildWriteOptions::Leaf(_) = &options.children {
+                return;
+            }
+
             let ChildWriteOptions::Struct(o) = &options.children else {
                 unreachable!();
             };
@@ -302,9 +311,24 @@ pub fn to_parquet_type(field: &Field, options: &ColumnWriteOptions) -> PolarsRes
         ),
         ArrowDataType::Struct(fields) => {
             if fields.is_empty() {
-                polars_bail!(InvalidOperation:
-                    "Unable to write struct type with no child field to Parquet. Consider adding a dummy child field.".to_string(),
-                )
+                static ALLOW_EMPTY_STRUCTS: LazyLock<bool> = LazyLock::new(|| {
+                    std::env::var("POLARS_ALLOW_PQ_EMPTY_STRUCT").is_ok_and(|v| v.as_str() == "1")
+                });
+
+                if *ALLOW_EMPTY_STRUCTS {
+                    return Ok(ParquetType::try_from_primitive(
+                        name,
+                        PhysicalType::Boolean,
+                        repetition,
+                        None,
+                        None,
+                        field_id,
+                    )?);
+                } else {
+                    polars_bail!(InvalidOperation:
+                        "Unable to write struct type with no child field to Parquet. Consider adding a dummy child field.".to_string(),
+                    )
+                }
             }
 
             let ChildWriteOptions::Struct(struct_write_options) = &options.children else {

--- a/crates/polars-stream/src/nodes/io_sinks/parquet.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/parquet.rs
@@ -64,6 +64,7 @@ impl ParquetSinkNode {
         collect_metrics: bool,
     ) -> PolarsResult<Self> {
         let schema = schema_to_arrow_checked(&input_schema, CompatLevel::newest(), "parquet")?;
+        // insert here
         let column_options: Vec<ColumnWriteOptions> =
             get_column_write_options(&schema, &write_options.field_overwrites);
         let parquet_schema = to_parquet_schema(&schema, &column_options)?;
@@ -230,6 +231,7 @@ impl SinkNode for ParquetSinkNode {
                             let column_options = &column_options[col_idx];
 
                             let array = column.as_materialized_series().rechunk();
+                            // insert here
                             let array = array.to_arrow(0, CompatLevel::newest());
 
                             // @TODO: This causes all structs fields to be handled on a single thread. It


### PR DESCRIPTION
This PR adds the `POLARS_ALLOW_PQ_EMPTY_STRUCT` environment variable that when set to `1` allows writing Parquet with `pl.Struct([])`. It does this by mapping it to a `Boolean` column with the same validity.

This is not necessarily meant for general consumption.