### PR TITLE
docs(python): Add partitioning examples for `sink_*` methods

### DIFF
--- a/py-polars/src/polars/io/partition.py
+++ b/py-polars/src/polars/io/partition.py
@@ -237,7 +237,7 @@ class PartitionMaxSize(PartitioningScheme):
     Split a parquet file by over smaller CSV files with 100 000 rows each:
 
     >>> pl.scan_parquet("/path/to/file.parquet").sink_csv(
-    ...     PartitionMax("./out", max_size=100_000),
+    ...     pl.PartitionMax("./out/", max_size=100_000),
     ... )  # doctest: +SKIP
 
     See Also
@@ -345,12 +345,12 @@ class PartitionByKey(PartitioningScheme):
     Split into a hive-partitioning style partition:
 
     >>> (
-    ...     pl.DataFrame({"a": [1, 2, 3], "b": [5, 7, 9], "c": ["A", "B", "C"]})
-    ...     .lazy()
-    ...     .sink_parquet(
-    ...         PartitionByKey(
-    ...             "./out",
-    ...             by=[pl.col.a, pl.col.b],
+    ...     pl.LazyFrame(
+    ...         {"a": [1, 2, 3], "b": [5, 7, 9], "c": ["A", "B", "C"]}
+    ...     ).sink_parquet(
+    ...         pl.PartitionByKey(
+    ...             "./out/",
+    ...             by=["a", "b"],
     ...             include_key=False,
     ...         ),
     ...         mkdir=True,
@@ -452,7 +452,7 @@ class PartitionParted(PartitioningScheme):
     Split a parquet file by a column `year` into CSV files:
 
     >>> pl.scan_parquet("/path/to/file.parquet").sink_csv(
-    ...     PartitionParted("./out", by="year"),
+    ...     pl.PartitionParted("./out/", by="year"),
     ...     mkdir=True,
     ... )  # doctest: +SKIP
 

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -2685,10 +2685,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             - `True`: enable default set of statistics (default). Some
               statistics may be disabled.
             - `False`: disable all statistics
-            - "full": calculate and write all available statistics. Cannot be
-              combined with `use_pyarrow`.
-            - `{ "statistic-key": True / False, ... }`. Cannot be combined with
-              `use_pyarrow`. Available keys:
+            - "full": calculate and write all available statistics.
+            - `{ "statistic-key": True / False, ... }`. Available keys:
 
               - "min": column minimum value (default: `True`)
               - "max": column maximum value (default: `True`)
@@ -2796,6 +2794,23 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         --------
         >>> lf = pl.scan_csv("/path/to/my_larger_than_ram_file.csv")  # doctest: +SKIP
         >>> lf.sink_parquet("out.parquet")  # doctest: +SKIP
+
+        Sink to a `BytesIO` object.
+
+        >>> import io
+        >>> buf = io.BytesIO()  # doctest: +SKIP
+        >>> pl.LazyFrame({"x": [1, 2, 1]}).sink_parquet(buf)  # doctest: +SKIP
+
+        Split into a hive-partitioning style partition:
+
+        >>> pl.LazyFrame({"x": [1, 2, 1], "y": [3, 4, 5]}).sink_parquet(
+        ...     pl.PartitionByKey("./out/", by="x"),
+        ...     mkdir=True
+        ... )  # doctest: +SKIP
+
+        See Also
+        --------
+        PartitionByKey
         """
         engine = _select_engine(engine)
         if metadata is not None:
@@ -3053,6 +3068,23 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         --------
         >>> lf = pl.scan_csv("/path/to/my_larger_than_ram_file.csv")  # doctest: +SKIP
         >>> lf.sink_ipc("out.arrow")  # doctest: +SKIP
+
+        Sink to a `BytesIO` object.
+
+        >>> import io
+        >>> buf = io.BytesIO()  # doctest: +SKIP
+        >>> pl.LazyFrame({"x": [1, 2, 1]}).sink_ipc(buf)  # doctest: +SKIP
+
+        Split into a hive-partitioning style partition:
+
+        >>> pl.LazyFrame({"x": [1, 2, 1], "y": [3, 4, 5]}).sink_ipc(
+        ...     pl.PartitionByKey("./out/", by="x"),
+        ...     mkdir=True
+        ... )  # doctest: +SKIP
+
+        See Also
+        --------
+        PartitionByKey
         """
         engine = _select_engine(engine)
 
@@ -3342,6 +3374,23 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         --------
         >>> lf = pl.scan_csv("/path/to/my_larger_than_ram_file.csv")  # doctest: +SKIP
         >>> lf.sink_csv("out.csv")  # doctest: +SKIP
+
+        Sink to a `BytesIO` object.
+
+        >>> import io
+        >>> buf = io.BytesIO()  # doctest: +SKIP
+        >>> pl.LazyFrame({"x": [1, 2, 1]}).sink_csv(buf)  # doctest: +SKIP
+
+        Split into a hive-partitioning style partition:
+
+        >>> pl.LazyFrame({"x": [1, 2, 1], "y": [3, 4, 5]}).sink_csv(
+        ...     pl.PartitionByKey("./out/", by="x"),
+        ...     mkdir=True
+        ... )  # doctest: +SKIP
+
+        See Also
+        --------
+        PartitionByKey
         """
         from polars.io.csv._utils import _check_arg_is_1byte
 
@@ -3541,6 +3590,23 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         --------
         >>> lf = pl.scan_csv("/path/to/my_larger_than_ram_file.csv")  # doctest: +SKIP
         >>> lf.sink_ndjson("out.ndjson")  # doctest: +SKIP
+
+        Sink to a `BytesIO` object.
+
+        >>> import io
+        >>> buf = io.BytesIO()  # doctest: +SKIP
+        >>> pl.LazyFrame({"x": [1, 2, 1]}).sink_ndjson(buf)  # doctest: +SKIP
+
+        Split into a hive-partitioning style partition:
+
+        >>> pl.LazyFrame({"x": [1, 2, 1], "y": [3, 4, 5]}).sink_ndjson(
+        ...     pl.PartitionByKey("./out/", by="x"),
+        ...     mkdir=True
+        ... )  # doctest: +SKIP
+
+        See Also
+        --------
+        PartitionByKey
         """
         engine = _select_engine(engine)
 


### PR DESCRIPTION
Addresses: https://github.com/pola-rs/polars/issues/19845#issuecomment-3365268685
Fixes: https://github.com/pola-rs/polars/issues/24900

I meant to add some examples previously so thought I may as well add them now and remove the pyarrow references at the same time.

While here, I noticed all the sink methods say they return a DataFrame:

- **Returns: DataFrame**

Should these Returns sections be removed?

The  _path_ parameter now has PartitioningScheme in the type hint

> path: str | Path | IO[bytes] | PartitioningScheme,

And the description is

> **path** File path to which the file should be written.

Should the description be updated to mention partitioning scheme?



