### PR TITLE
fix(python): Pinned pydantic to fix unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ requirements: .venv  ## Install/refresh Python project requirements
 	   -r py-polars/requirements-lint.txt \
 	   -r py-polars/docs/requirements-docs.txt \
 	   -r docs/source/requirements.txt \
-	&& $(VENV_BIN)/uv pip install --upgrade --compile-bytecode "pyiceberg>=0.7.1" pyiceberg-core \
+	&& $(VENV_BIN)/uv pip install --upgrade --compile-bytecode "pyiceberg>=0.7.1" pyiceberg-core "pydantic<=2.11.10" \
 	&& $(VENV_BIN)/uv pip install --no-deps -e py-polars
 
 .PHONY: requirements-all

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -51,7 +51,7 @@ polars_cloud = ["polars_cloud >= 0.0.1a1"]
 numpy = ["numpy >= 1.16.0"]
 pandas = ["pandas", "polars[pyarrow]"]
 pyarrow = ["pyarrow >= 7.0.0"]
-pydantic = ["pydantic"]
+pydantic = ["pydantic <= 2.11.10"]
 
 # Excel
 calamine = ["fastexcel >= 0.9"]

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -21,7 +21,7 @@ numpy
 numba >= 0.54; python_version < '3.14'  # Numba can lag Python releases
 pandas
 pyarrow
-pydantic>=2.0.0,<=2.11.10
+pydantic>=2.0.0,<=2.11.10 # TODO: when removing 2.11.10 upper bound, also remove it in root makefile's requirements and pyproject.toml
 # Datetime / time zones
 tzdata; platform_system == 'Windows'
 # Database


### PR DESCRIPTION
This fixes [CR-24929](https://github.com/pola-rs/polars/issues/24929). New pydantic version was breaking unit test.