### PR TITLE
docs(python): Add `{arr,list}.agg` API references

### DIFF
--- a/py-polars/docs/source/reference/expressions/array.rst
+++ b/py-polars/docs/source/reference/expressions/array.rst
@@ -9,6 +9,7 @@ The following methods are available under the `expr.arr` attribute.
    :toctree: api/
    :template: autosummary/accessor_method.rst
 
+    Expr.arr.agg
     Expr.arr.all
     Expr.arr.any
     Expr.arr.arg_max
@@ -16,6 +17,7 @@ The following methods are available under the `expr.arr` attribute.
     Expr.arr.contains
     Expr.arr.count_matches
     Expr.arr.explode
+    Expr.arr.eval
     Expr.arr.first
     Expr.arr.get
     Expr.arr.join

--- a/py-polars/docs/source/reference/expressions/list.rst
+++ b/py-polars/docs/source/reference/expressions/list.rst
@@ -9,6 +9,7 @@ The following methods are available under the `expr.list` attribute.
    :toctree: api/
    :template: autosummary/accessor_method.rst
 
+    Expr.list.agg
     Expr.list.all
     Expr.list.any
     Expr.list.arg_max

--- a/py-polars/docs/source/reference/series/array.rst
+++ b/py-polars/docs/source/reference/series/array.rst
@@ -9,6 +9,7 @@ The following methods are available under the `Series.arr` attribute.
    :toctree: api/
    :template: autosummary/accessor_method.rst
 
+    Series.arr.agg
     Series.arr.all
     Series.arr.any
     Series.arr.arg_max
@@ -16,6 +17,7 @@ The following methods are available under the `Series.arr` attribute.
     Series.arr.contains
     Series.arr.count_matches
     Series.arr.explode
+    Series.arr.eval
     Series.arr.first
     Series.arr.get
     Series.arr.join

--- a/py-polars/docs/source/reference/series/list.rst
+++ b/py-polars/docs/source/reference/series/list.rst
@@ -9,6 +9,7 @@ The following methods are available under the `Series.list` attribute.
    :toctree: api/
    :template: autosummary/accessor_method.rst
 
+    Series.list.agg
     Series.list.all
     Series.list.any
     Series.list.arg_max


### PR DESCRIPTION
Just adding so they show up in the online docs.