### PR TITLE
fix: Make `Operator::swap_operands` return correct operators for `Plus`, `Minus`, `Multiply` and `Divide`

### DIFF
--- a/crates/polars-plan/src/dsl/expr/mod.rs
+++ b/crates/polars-plan/src/dsl/expr/mod.rs
@@ -734,11 +734,13 @@ impl Operator {
             Operator::NotEq => Operator::NotEq,
             Operator::EqValidity => Operator::EqValidity,
             Operator::NotEqValidity => Operator::NotEqValidity,
-            Operator::Divide => Operator::Multiply,
-            Operator::Multiply => Operator::Divide,
+            // Operator::Divide requires modifying the right operand: left / right == 1/right * left
+            Operator::Divide => unimplemented!(),
+            Operator::Multiply => Operator::Multiply,
             Operator::And => Operator::And,
-            Operator::Plus => Operator::Minus,
-            Operator::Minus => Operator::Plus,
+            Operator::Plus => Operator::Plus,
+            // Operator::Minus requires modifying the right operand: left - right == -right + left
+            Operator::Minus => unimplemented!(),
             Operator::Lt => Operator::Gt,
             _ => unimplemented!(),
         }


### PR DESCRIPTION
Given `left op right`, method `Operator::swap_operands` is expected to provide the operator `op2` that yields the same result for swapped operands: `left op right == right op2 left`.

Operators `Plus` and `Multiply` are commutative, so they should be their own counterpart (like `Eq`).
Operators `Minus` and `Divide` cannot be swapped without touching the operands:

    left - right ==  -right + left
    left / right == 1/right * left

Currently, this method is only used to swap operands of join conditions, which evaluate to boolean. I that use-case, `Multiply`, `Divide`, `Plus` and `Minus` cannot occur.