### PR TITLE
fix: Allow for negative time in `group_by_dynamic` iterator

### DIFF
--- a/crates/polars-time/src/windows/window.rs
+++ b/crates/polars-time/src/windows/window.rs
@@ -378,7 +378,6 @@ impl<'a> BoundsIter<'a> {
     // Return the number of iterations to advance, such that the bounds are on target or, in
     // the case of non-constant duration, close to target.
     pub fn get_stride(&self, target: i64) -> usize {
-        assert!(target >= 0);
         let mut stride = 0;
         if self.bi.start < self.boundary.stop && target > self.bi.start {
             let gap = target - self.bi.start;

--- a/py-polars/tests/unit/operations/test_group_by_dynamic.py
+++ b/py-polars/tests/unit/operations/test_group_by_dynamic.py
@@ -1253,3 +1253,14 @@ def test_group_by_dynamic_sparse_count_small_24541(
     total = out.select("count").sum().item()
 
     assert total == expected
+
+
+def test_group_by_dynamic_negative_time_25039() -> None:
+    df = pl.DataFrame(
+        {"y": [1950, 1960, 1970], "m": [1, 1, 1], "d": [1, 1, 1], "n": [1, 2, 3]}
+    )
+    df = df.select(pl.date("y", "m", "d"), "n")
+
+    out = df.group_by_dynamic("date", every="1mo").agg(pl.col.n.mean()).select(pl.col.n)
+    expected = pl.DataFrame({"n": [1.0, 2.0, 3.0]})
+    assert_frame_equal(out, expected)


### PR DESCRIPTION
fixes #25039