### PR TITLE
fix(python): Minor improvement to internal `is_pycapsule` utility function

### DIFF
--- a/py-polars/src/polars/_utils/pycapsule.py
+++ b/py-polars/src/polars/_utils/pycapsule.py
@@ -15,8 +15,11 @@ if TYPE_CHECKING:
 
 
 def is_pycapsule(obj: Any) -> bool:
-    """Check if object supports the PyCapsule interface."""
-    return hasattr(obj, "__arrow_c_stream__") or hasattr(obj, "__arrow_c_array__")
+    """Check if object looks like it supports the PyCapsule interface."""
+    return any(
+        callable(getattr(obj, attr, None))
+        for attr in ("__arrow_c_stream__", "__arrow_c_array__")
+    )
 
 
 def pycapsule_to_frame(

--- a/py-polars/tests/unit/sql/test_miscellaneous.py
+++ b/py-polars/tests/unit/sql/test_miscellaneous.py
@@ -184,6 +184,16 @@ def test_frame_sql_globals_error() -> None:
     assert res.to_dict(as_series=False) == {"a": [2, 3], "b": [7, 6]}
 
 
+def test_global_misc_lookup() -> None:
+    # check that `col` in global namespace is not incorrectly identified
+    # as supporting pycapsule (as it can look like it has *any* attr)
+    from polars import col  # noqa: F401
+
+    df = pl.DataFrame({"col": [90, 80, 70]})  # noqa: F841
+    df_res = pl.sql("SELECT col FROM df WHERE col > 75", eager=True)
+    assert df_res.rows() == [(90,), (80,)]
+
+
 def test_in_no_ops_11946() -> None:
     lf = pl.LazyFrame(
         [


### PR DESCRIPTION
Just because an object has an `"__arrow_c_stream__"` or `"__arrow_c_array__"` _attribute_ doesn't necessarily mean it supports PyCapsule; now, it's very unlikely_that it doesn't (in the general case), but there is an edge-case we could plausibly hit, which is dealt with by this update -

## Example

Polars `col` acts as a factory, creating column expressions from _any_ attribute:
```python
from polars import col
col.__arrow_c_stream__
# <Expr ['col("__arrow_c_stream__")'] at 0x11957CD50>
```
You can see where this is going; currently `is_pycapsule` only checks "hasattr":
```python
from polars._utils.pycapsule import is_pycapsule
is_pycapsule(col)
# True
```
While "col" may not be the best name for a table data column it's not implausible, so you can hit an error caused by this factory behaviour like so (assuming you have loaded Polars' `col` in the same namespace):
```python
from polars import col
df = pl.DataFrame({"col": [90, 80, 70]})
res = pl.sql("SELECT col FROM df WHERE col > 75")
# TypeError: 'Expr' object is not callable
```
This occurs when we quickly check SQL string/query tokens to see if they can be referenced as frames/tables that are present in the current/global Python namespace.

Additionally confirming `callable` (not just `hasattr`) in `is_pycapsule` makes the check a little more robust/correct, solving the above issue.