### PR TITLE
fix: Fix handling `Null` dtype in `ApplyExpr` on `group_by`

### DIFF
--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -170,7 +170,7 @@ impl ApplyExpr {
             let lst = agg.list().unwrap();
             let iter = lst.par_iter().map(f);
 
-            if self.output_field.dtype.is_known() && !self.output_field.dtype.is_null() {
+            if self.output_field.dtype.is_known() {
                 let dtype = self.output_field.dtype.clone();
                 let dtype = dtype.implode();
                 POOL.install(|| {


### PR DESCRIPTION
fixes #25045

This PR fixes how the `Null` dtype is handled in `group_by` aggregation context.

Kindly doublecheck the expected outcome (see issue & test).