### PR TITLE
refactor: Disable recursive CSPE for now

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/cse/cse_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/cse_lp.rs
@@ -424,15 +424,16 @@ pub(crate) fn elim_cmn_subplans(
     // optimization
     // Below the inserted caches, might be more duplicates. So we recurse one time to find
     // inner duplicates as well.
-    for (_, (_count, caches_nodes)) in cid2c.iter() {
-        // The last node seems the one traversed by the planners. This is validated by tests.
-        // We could traverse all nodes, but it would be duplicate work.
-        if let Some(cache) = caches_nodes.last() {
-            if let IR::Cache { input, id: _ } = lp_arena.get(*cache) {
-                let _ = elim_cmn_subplans(*input, lp_arena, expr_arena);
-            }
-        }
-    }
+    // TODO! reactivate this and recursively deal with projection/predicate pushdown.
+    //for (_, (_count, caches_nodes)) in cid2c.iter() {
+    //    // The last node seems the one traversed by the planners. This is validated by tests.
+    //    // We could traverse all nodes, but it would be duplicate work.
+    //    if let Some(cache) = caches_nodes.last() {
+    //        if let IR::Cache { input, id: _ } = lp_arena.get(*cache) {
+    //            let _ = elim_cmn_subplans(*input, lp_arena, expr_arena);
+    //        }
+    //    }
+    //}
 
     (lp, changed)
 }

--- a/py-polars/tests/unit/test_cse.py
+++ b/py-polars/tests/unit/test_cse.py
@@ -1145,6 +1145,7 @@ def test_cse_custom_io_source_diff_filters() -> None:
     assert_frame_equal(expected[1], res[1])
 
 
+@pytest.mark.skip
 def test_cspe_recursive_24744() -> None:
     df_a = pl.DataFrame([pl.Series("x", [0, 1, 2, 3], dtype=pl.UInt32)])
 
@@ -1207,4 +1208,4 @@ def test_cpse_predicates_25030() -> None:
     )
 
     assert_frame_equal(got, expected)
-    assert q4.explain().count("CACHE") == 6
+    assert q4.explain().count("CACHE") == 2


### PR DESCRIPTION
Will hoist this to next release. Every cache inserts is also a predicate/ projection pushdown desision that needs to take other branches into account. It needs to reapply those pushdowns from subtrees. Will follow up later.