### PR TITLE
refactor(rust): Parametrize the chunk reader used by the NDJSON source node

### DIFF
--- a/crates/polars-stream/src/nodes/io_sources/ndjson/builder.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ndjson/builder.rs
@@ -7,9 +7,10 @@ use polars_plan::dsl::ScanSource;
 use super::{FileReader, NDJsonFileReader};
 use crate::nodes::io_sources::multi_scan::reader_interface::builder::FileReaderBuilder;
 use crate::nodes::io_sources::multi_scan::reader_interface::capabilities::ReaderCapabilities;
+use crate::nodes::io_sources::ndjson::chunk_reader::ChunkReaderBuilder;
 
 #[cfg(feature = "json")]
-impl FileReaderBuilder for Arc<polars_plan::dsl::NDJsonReadOptions> {
+impl FileReaderBuilder for polars_plan::dsl::NDJsonReadOptions {
     fn reader_name(&self) -> &str {
         "ndjson"
     }
@@ -27,13 +28,16 @@ impl FileReaderBuilder for Arc<polars_plan::dsl::NDJsonReadOptions> {
         _scan_source_idx: usize,
     ) -> Box<dyn FileReader> {
         let scan_source = source;
-        let options = self.clone();
+        let chunk_reader_builder = ChunkReaderBuilder::NDJson {
+            ignore_errors: self.ignore_errors,
+        };
         let verbose = config::verbose();
 
         let reader = NDJsonFileReader {
             scan_source,
             cloud_options,
-            options,
+            chunk_reader_builder,
+            count_rows_fn: polars_io::ndjson::count_rows,
             cached_bytes: None,
             verbose,
         };

--- a/crates/polars-stream/src/nodes/io_sources/ndjson/chunk_reader.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ndjson/chunk_reader.rs
@@ -2,35 +2,91 @@ use polars_core::schema::SchemaRef;
 use polars_error::PolarsResult;
 use polars_io::ndjson;
 use polars_io::prelude::parse_ndjson;
-use polars_plan::dsl::NDJsonReadOptions;
+#[cfg(feature = "scan_lines")]
+use polars_utils::pl_str::PlSmallStr;
 
 use crate::nodes::compute_node_prelude::*;
 
-/// NDJSON chunk reader.
-#[derive(Default)]
-pub(super) struct ChunkReader {
-    projected_schema: SchemaRef,
-    ignore_errors: bool,
+#[derive(Clone)]
+pub enum ChunkReaderBuilder {
+    NDJson {
+        ignore_errors: bool,
+    },
+    #[cfg(feature = "scan_lines")]
+    #[expect(unused)]
+    Lines {
+        name: PlSmallStr,
+    },
+}
+
+#[derive(Clone)]
+pub enum ChunkReader {
+    /// NDJSON chunk reader.
+    NDJson {
+        projected_schema: SchemaRef,
+        ignore_errors: bool,
+    },
+    #[cfg(feature = "scan_lines")]
+    #[expect(unused)]
+    Lines {
+        /// If this is `None` we are projecting 0-width morsels.
+        projection: Option<PlSmallStr>,
+    },
+}
+
+impl ChunkReaderBuilder {
+    pub(super) fn max_chunk_size(&self) -> usize {
+        match self {
+            Self::NDJson { .. } => usize::MAX,
+            #[cfg(feature = "scan_lines")]
+            Self::Lines { .. } => u32::MAX.try_into().unwrap(),
+        }
+    }
+
+    pub(super) fn build(&self, projected_schema: SchemaRef) -> ChunkReader {
+        match self {
+            Self::NDJson { ignore_errors } => ChunkReader::NDJson {
+                projected_schema,
+                ignore_errors: *ignore_errors,
+            },
+            #[cfg(feature = "scan_lines")]
+            Self::Lines { name } => {
+                use polars_core::prelude::DataType;
+
+                assert!(projected_schema.len() <= 1);
+
+                let projection = projected_schema
+                    .get_at_index(0)
+                    .map(|(projected_name, dtype)| {
+                        assert_eq!(projected_name, name);
+                        assert!(matches!(dtype, DataType::String));
+
+                        name.clone()
+                    });
+
+                ChunkReader::Lines { projection }
+            },
+        }
+    }
 }
 
 impl ChunkReader {
-    pub(super) fn try_new(
-        options: &NDJsonReadOptions,
-        projected_schema: &SchemaRef,
-    ) -> PolarsResult<Self> {
-        let projected_schema = projected_schema.clone();
-
-        Ok(Self {
-            projected_schema,
-            ignore_errors: options.ignore_errors,
-        })
-    }
-
     pub(super) fn read_chunk(&self, chunk: &[u8]) -> PolarsResult<DataFrame> {
-        if self.projected_schema.is_empty() {
-            Ok(DataFrame::empty_with_height(ndjson::count_rows(chunk)))
-        } else {
-            parse_ndjson(chunk, None, &self.projected_schema, self.ignore_errors)
+        match self {
+            Self::NDJson {
+                projected_schema,
+                ignore_errors,
+            } => {
+                if projected_schema.is_empty() {
+                    Ok(DataFrame::empty_with_height(ndjson::count_rows(chunk)))
+                } else {
+                    parse_ndjson(chunk, None, projected_schema, *ignore_errors)
+                }
+            },
+            #[cfg(feature = "scan_lines")]
+            Self::Lines { projection: _ } => {
+                todo!()
+            },
         }
     }
 }

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -669,7 +669,7 @@ pub fn lower_ir(
                     FileScanIR::Csv { options } => Arc::new(Arc::new(options.clone())) as _,
 
                     #[cfg(feature = "json")]
-                    FileScanIR::NDJson { options } => Arc::new(Arc::new(options.clone())) as _,
+                    FileScanIR::NDJson { options } => Arc::new(options.clone()) as _,
 
                     #[cfg(feature = "python")]
                     FileScanIR::PythonDataset {


### PR DESCRIPTION
Work towards `scan_lines` support

* Moves the initialization logic for the chunk reader out of the NDJSON source node
* Refactors `ChunkReader` to be an `enum` that contains a `::Lines` variant, which will be used by `scan_lines`.
* Adds a `max_chunk_size` to the `LineBatchDistributor`. A `ChunkReader::Lines` will set this to `u32::MAX` to avoid overflowing the `BinaryView` buffer size limit
