### PR TITLE
fix: The `SQL` interface should use logical, not bitwise, behaviour for unary "NOT" operator

### DIFF
--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -656,7 +656,19 @@ impl SQLExprVisitor<'_> {
             // general case
             (UnaryOperator::Plus, _) => lit(0) + expr,
             (UnaryOperator::Minus, _) => lit(0) - expr,
-            (UnaryOperator::Not, _) => expr.not(),
+            (UnaryOperator::Not, _) => match &expr {
+                Expr::Column(name)
+                    if self
+                        .active_schema
+                        .and_then(|schema| schema.get(name))
+                        .is_some_and(|dtype| matches!(dtype, DataType::Boolean)) =>
+                {
+                    // if already boolean, can operate bitwise
+                    expr.not()
+                },
+                // otherwise SQL "NOT" expects logical, not bitwise, behaviour (eg: on integers)
+                _ => expr.strict_cast(DataType::Boolean).not(),
+            },
             other => polars_bail!(SQLInterface: "unary operator {:?} is not supported", other),
         })
     }


### PR DESCRIPTION
Closes #24964.

Need to ensure that SQL "NOT" always behaves as _logical_ "NOT" rather than bitwise "NOT" (which is a different SQL op/func, usually `~` or `BIT_NOT`). 

Addresses (unusual?) queries that apply logical "NOT" to ints other than 1/0.

## Example

```python
import polars as pl
lf = pl.LazyFrame({
    "valid": [True, False, None, False, True],
    "int_code": [1, 0, 2, None, -1],
})

res = lf.sql(
    """
    SELECT
      valid,
      NOT valid AS not_valid,
      int_code,
      NOT int_code AS int_code_zero
    FROM self
    ORDER BY int_code NULLS FIRST
    """
).collect()
```

#### Before 
_(bitwise `int_code_zero`)_
```python
# ┌───────┬───────────┬──────────┬───────────────┐
# │ valid ┆ not_valid ┆ int_code ┆ int_code_zero │
# │ ---   ┆ ---       ┆ ---      ┆ ---           │
# │ bool  ┆ bool      ┆ i64      ┆ i64           │
# ╞═══════╪═══════════╪══════════╪═══════════════╡
# │ false ┆ true      ┆ null     ┆ null          │
# │ true  ┆ false     ┆ -1       ┆ 0             │
# │ false ┆ true      ┆ 0        ┆ -1            │
# │ true  ┆ false     ┆ 1        ┆ -2            │
# │ null  ┆ null      ┆ 2        ┆ -3            │
# └───────┴───────────┴──────────┴───────────────┘
```
#### After 
_(fixed; logical `int_code_zero`)_
```python
# ┌───────┬───────────┬──────────┬───────────────┐
# │ valid ┆ not_valid ┆ int_code ┆ int_code_zero │
# │ ---   ┆ ---       ┆ ---      ┆ ---           │
# │ bool  ┆ bool      ┆ i64      ┆ bool          │
# ╞═══════╪═══════════╪══════════╪═══════════════╡
# │ false ┆ true      ┆ null     ┆ null          │
# │ true  ┆ false     ┆ -1       ┆ false         │
# │ false ┆ true      ┆ 0        ┆ true          │
# │ true  ┆ false     ┆ 1        ┆ false         │
# │ null  ┆ null      ┆ 2        ┆ false         │
# └───────┴───────────┴──────────┴───────────────┘
```