### PR TITLE
build: Make building the docs on macOS more reliable

### DIFF
--- a/py-polars/docs/Makefile
+++ b/py-polars/docs/Makefile
@@ -1,6 +1,8 @@
 # Minimal makefile for Sphinx documentation
-#
 
+ifeq ($(shell uname),Darwin)
+export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+endif
 export BUILDING_SPHINX_DOCS = 1
 
 # You can set these variables from the command line, and also


### PR DESCRIPTION
Recently got a new machine at work and realised I had been exporting this in my personal `.zshrc` the whole time to make Sphinx docs building more reliable (will still occasionally die when building multithreaded, but without this export it will basically _always_ die).

This is macOS-specific, and is conditionally applied as such; should improve the default experience for anyone building the docs on macOS who isn't setting this themselves.

Specifically, setting `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` in the environment mitigates against the following fork/multithreading error (the sooner "spawn" becomes Python's default more broadly, the better 😅):
```
objc[40712]: +[__NSPlaceholderDate initialize] 
  may have been in progress in another thread when fork() was called.
```