### PR TITLE
fix: Fix `groups` update on slices with different offsets

### DIFF
--- a/crates/polars-expr/src/expressions/column.rs
+++ b/crates/polars-expr/src/expressions/column.rs
@@ -6,6 +6,7 @@ use polars_plan::constants::CSE_REPLACED;
 use super::*;
 use crate::expressions::{AggregationContext, PhysicalExpr};
 
+#[derive(Debug)]
 pub struct ColumnExpr {
     name: PlSmallStr,
     expr: Expr,

--- a/crates/polars-expr/src/expressions/mod.rs
+++ b/crates/polars-expr/src/expressions/mod.rs
@@ -168,10 +168,7 @@ impl<'a> AggregationContext<'a> {
                     // sliced groups are already in correct order,
                     // Update offsets in the case of overlapping groups
                     // e.g. [0,2], [1,3], [2,4] becomes [0,2], [2,3], [5,4]
-                    GroupsType::Slice {
-                        overlapping: true,
-                        groups,
-                    } => {
+                    GroupsType::Slice { groups, .. } => {
                         // unroll
                         let groups = groups
                             .iter()
@@ -190,7 +187,6 @@ impl<'a> AggregationContext<'a> {
                             .into_sliceable(),
                         )
                     },
-                    GroupsType::Slice { .. } => {},
                 }
                 self.update_groups = UpdateGroups::No;
             },

--- a/py-polars/tests/unit/operations/namespaces/list/test_eval.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_eval.py
@@ -374,3 +374,14 @@ def test_list_agg_parametric(expr: pl.Expr, is_scalar: bool) -> None:
     test_case(pl.Series("a", [[], [0], None]))
     test_case(pl.Series("a", [None, [0], None]))
     test_case(pl.Series("a", [[1, 2, 3], [4, 5]]))
+
+
+def test_list_eval_matching_slice_lengths() -> None:
+    df = pl.DataFrame({"a": [[1, 2], [3, 4]]})
+    out = df.select(
+        pl.col.a.list.eval(
+            (pl.element().slice(0, 1) * (pl.element().slice(1, 1))).sum()
+        )
+    )
+    expected = pl.DataFrame({"a": [[2], [12]]})
+    assert_frame_equal(out, expected)


### PR DESCRIPTION
fixes #17370 
