### PR TITLE
fix: Return the correct string-case `Expr` reprs

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -159,7 +159,7 @@ impl Display for StringFunction {
             #[cfg(feature = "extract_jsonpath")]
             JsonPathMatch => "json_path_match",
             LenBytes => "len_bytes",
-            Lowercase => "lowercase",
+            Lowercase => "to_lowercase",
             LenChars => "len_chars",
             #[cfg(feature = "string_pad")]
             PadEnd { .. } => "pad_end",
@@ -206,10 +206,10 @@ impl Display for StringFunction {
                 }
             },
             #[cfg(feature = "nightly")]
-            Titlecase => "titlecase",
+            Titlecase => "to_titlecase",
             #[cfg(feature = "dtype-decimal")]
             ToDecimal { .. } => "to_decimal",
-            Uppercase => "uppercase",
+            Uppercase => "to_uppercase",
             #[cfg(feature = "string_pad")]
             ZFill => "zfill",
             #[cfg(feature = "find_many")]

--- a/crates/polars-plan/src/plans/aexpr/function_expr/strings.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/strings.rs
@@ -336,7 +336,7 @@ impl Display for IRStringFunction {
             #[cfg(feature = "extract_jsonpath")]
             JsonPathMatch => "json_path_match",
             LenBytes => "len_bytes",
-            Lowercase => "lowercase",
+            Lowercase => "to_lowercase",
             LenChars => "len_chars",
             #[cfg(feature = "string_pad")]
             PadEnd { .. } => "pad_end",
@@ -383,10 +383,10 @@ impl Display for IRStringFunction {
                 }
             },
             #[cfg(feature = "nightly")]
-            Titlecase => "titlecase",
+            Titlecase => "to_titlecase",
             #[cfg(feature = "dtype-decimal")]
             ToDecimal { .. } => "to_decimal",
-            Uppercase => "uppercase",
+            Uppercase => "to_uppercase",
             #[cfg(feature = "string_pad")]
             ZFill => "zfill",
             #[cfg(feature = "find_many")]


### PR DESCRIPTION
The string-case Exprs (upper, lower, title) were dropping the leading "to_" in their `repr` output.

## Example

#### Before
```python
pl.col("strcol").str.to_lowercase()
# <Expr ['col("strcol").str.lowercase()'] at 0x119598750>
```
#### After
```python
pl.col("strcol").str.to_lowercase()
# <Expr ['col("strcol").str.to_lowercase…'] at 0x10E198850>
```