### PR TITLE
docs(python): Document that `pl.Unknown` in `dtype` results in dtype being autoinferred

### DIFF
--- a/py-polars/src/polars/convert/general.py
+++ b/py-polars/src/polars/convert/general.py
@@ -70,7 +70,8 @@ def from_dict(
     schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
         The DataFrame schema may be declared in several ways:
 
-        * As a dict of {name:type} pairs; if type is None, it will be auto-inferred.
+        * As a dict of {name:type} pairs; if type is None or `pl.Unknown`, it will
+          be auto-inferred.
         * As a list of column names; in this case types are automatically inferred.
         * As a list of (name,type) pairs; this is equivalent to the dictionary form.
 
@@ -132,7 +133,8 @@ def from_dicts(
     schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
         The DataFrame schema may be declared in several ways:
 
-        * As a dict of {name:type} pairs; if type is None, it will be auto-inferred.
+        * As a dict of {name:type} pairs; if type is None or `pl.Unknown`, it will
+          be auto-inferred.
         * As a list of column names; in this case types are automatically inferred.
         * As a list of (name,type) pairs; this is equivalent to the dictionary form.
 
@@ -244,7 +246,8 @@ def from_records(
     schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
         The DataFrame schema may be declared in several ways:
 
-        * As a dict of {name:type} pairs; if type is None, it will be auto-inferred.
+        * As a dict of {name:type} pairs; if type is None or `pl.Unknown`, it will
+          be auto-inferred.
         * As a list of column names; in this case types are automatically inferred.
         * As a list of (name,type) pairs; this is equivalent to the dictionary form.
 
@@ -326,7 +329,8 @@ def from_numpy(
     schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
         The DataFrame schema may be declared in several ways:
 
-        * As a dict of {name:type} pairs; if type is None, it will be auto-inferred.
+        * As a dict of {name:type} pairs; if type is None or `pl.Unknown`, it will
+          be auto-inferred.
         * As a list of column names; in this case types are automatically inferred.
         * As a list of (name,type) pairs; this is equivalent to the dictionary form.
 
@@ -390,7 +394,8 @@ def from_torch(
     schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
         The DataFrame schema may be declared in several ways:
 
-        * As a dict of {name:type} pairs; if type is None, it will be auto-inferred.
+        * As a dict of {name:type} pairs; if type is None or `pl.Unknown`, it will
+          be auto-inferred.
         * As a list of column names; in this case types are automatically inferred.
         * As a list of (name,type) pairs; this is equivalent to the dictionary form.
 
@@ -487,7 +492,8 @@ def from_arrow(
     schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
         The DataFrame schema may be declared in several ways:
 
-        * As a dict of {name:type} pairs; if type is None, it will be auto-inferred.
+        * As a dict of {name:type} pairs; if type is None or `pl.Unknown`, it will
+          be auto-inferred.
         * As a list of column names; in this case types are automatically inferred.
         * As a list of (name,type) pairs; this is equivalent to the dictionary form.
 

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -212,7 +212,8 @@ class DataFrame:
         The schema of the resulting DataFrame. The schema may be declared in several
         ways:
 
-        * As a dict of {name:type} pairs; if type is None, it will be auto-inferred.
+        * As a dict of {name:type} pairs; if type is None or `pl.Unknown`, it will
+          be auto-inferred.
         * As a list of column names; in this case types are automatically inferred.
         * As a list of (name,type) pairs; this is equivalent to the dictionary form.
 
@@ -549,7 +550,8 @@ class DataFrame:
         schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
             The DataFrame schema may be declared in several ways:
 
-            * As a dict of {name:type} pairs; if type is None, it will be auto-inferred.
+            * As a dict of {name:type} pairs; if type is None or `pl.Unknown`, it will
+              be auto-inferred.
             * As a list of column names; in this case types are automatically inferred.
             * As a list of (name,type) pairs; this is equivalent to the dictionary form.
 
@@ -592,7 +594,8 @@ class DataFrame:
         schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
             The DataFrame schema may be declared in several ways:
 
-            * As a dict of {name:type} pairs; if type is None, it will be auto-inferred.
+            * As a dict of {name:type} pairs; if type is None or `pl.Unknown`, it will
+              be auto-inferred.
             * As a list of column names; in this case types are automatically inferred.
             * As a list of (name,type) pairs; this is equivalent to the dictionary form.
 

--- a/py-polars/src/polars/io/json/read.py
+++ b/py-polars/src/polars/io/json/read.py
@@ -39,7 +39,8 @@ def read_json(
     schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
         The DataFrame schema may be declared in several ways:
 
-        * As a dict of {name:type} pairs; if type is None, it will be auto-inferred.
+        * As a dict of {name:type} pairs; if type is None or `pl.Unknown`, it will
+          be auto-inferred.
         * As a list of column names; in this case types are automatically inferred.
         * As a list of (name,type) pairs; this is equivalent to the dictionary form.
 

--- a/py-polars/src/polars/io/ndjson.py
+++ b/py-polars/src/polars/io/ndjson.py
@@ -62,7 +62,8 @@ def read_ndjson(
     schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
         The DataFrame schema may be declared in several ways:
 
-        * As a dict of {name:type} pairs; if type is None, it will be auto-inferred.
+        * As a dict of {name:type} pairs; if type is None or `pl.Unknown`, it will
+          be auto-inferred.
         * As a list of column names; in this case types are automatically inferred.
         * As a list of (name,type) pairs; this is equivalent to the dictionary form.
 
@@ -222,7 +223,8 @@ def scan_ndjson(
     schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
         The DataFrame schema may be declared in several ways:
 
-        * As a dict of {name:type} pairs; if type is None, it will be auto-inferred.
+        * As a dict of {name:type} pairs; if type is None or `pl.Unknown`, it will
+          be auto-inferred.
         * As a list of column names; in this case types are automatically inferred.
         * As a list of (name,type) pairs; this is equivalent to the dictionary form.
 

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -258,7 +258,8 @@ class LazyFrame:
     schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
         The LazyFrame schema may be declared in several ways:
 
-        * As a dict of {name:type} pairs; if type is None, it will be auto-inferred.
+        * As a dict of {name:type} pairs; if type is None or `pl.Unknown`, it will
+          be auto-inferred.
         * As a list of column names; in this case types are automatically inferred.
         * As a list of (name,type) pairs; this is equivalent to the dictionary form.
 

--- a/py-polars/tests/unit/dataframe/test_from_dict.py
+++ b/py-polars/tests/unit/dataframe/test_from_dict.py
@@ -255,3 +255,15 @@ def test_from_dict_cast_logical_type(dtype: pl.DataType, data: Any) -> None:
     )
 
     assert_frame_equal(df_from_dicts, df)
+
+
+def test_auto_infer_schema() -> None:
+    result = pl.from_dict(
+        {"a": [1], "b": [2], "c": [3]},
+        schema={"a": pl.Int32, "b": None, "c": pl.Unknown},
+    )
+    expected = pl.from_dict(
+        {"a": [1], "b": [2], "c": [3]},
+        schema={"a": pl.Int32, "b": pl.Int64, "c": pl.Int64},
+    )
+    assert_frame_equal(result, expected)


### PR DESCRIPTION
This looks like it's supported on-purpose, but it's not documented

https://github.com/pola-rs/polars/blob/9136029ee07724a67ba7b9eb545c8567b7072052/py-polars/src/polars/_utils/construction/dataframe.py#L327

```py
In [2]: pl.from_dict({"a": [1, 2], "b": [3, 4]}, schema={'a': pl.Int32, 'b': pl.Unknown})
Out[2]: 
shape: (2, 2)
┌─────┬─────┐
│ a   ┆ b   │
│ --- ┆ --- │
│ i32 ┆ i64 │
╞═════╪═════╡
│ 1   ┆ 3   │
│ 2   ┆ 4   │
└─────┴─────┘
```