### PR TITLE
feat: Environment variables to configure cloud retry config

### DIFF
--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -206,33 +206,38 @@ fn get_retry_config(max_retries: usize) -> RetryConfig {
     *retry_timeout = std::time::Duration::from_secs(10);
 
     if let Ok(v) = std::env::var("POLARS_STORAGE_BACKOFF_INIT_MS").as_deref() {
-        let v: u64 = v.parse().unwrap_or_else(|_| {
-            panic!("failed to parse u64 from POLARS_STORAGE_BACKOFF_INIT_MS={v}")
-        });
+        let v: u64 = v
+            .parse()
+            .ok()
+            .filter(|x| *x > 0)
+            .unwrap_or_else(|| panic!("invalid value for POLARS_STORAGE_BACKOFF_INIT_MS: {v}"));
 
         *init_backoff = Duration::from_millis(v);
     };
 
     if let Ok(v) = std::env::var("POLARS_STORAGE_BACKOFF_MAX_MS").as_deref() {
-        let v: u64 = v.parse().unwrap_or_else(|_| {
-            panic!("failed to parse u64 from POLARS_STORAGE_BACKOFF_MAX_MS={v}")
-        });
+        let v: u64 = v
+            .parse()
+            .ok()
+            .filter(|x| *x > 0)
+            .unwrap_or_else(|| panic!("invalid value for POLARS_STORAGE_BACKOFF_MAX_MS: {v}"));
 
         *max_backoff = Duration::from_millis(v);
     };
 
     if let Ok(v) = std::env::var("POLARS_STORAGE_BACKOFF_BASE_MULTIPLIER").as_deref() {
-        let v: f64 = v.parse().unwrap_or_else(|_| {
-            panic!("failed to parse f64 from POLARS_STORAGE_BACKOFF_BASE_MULTIPLIER={v}")
+        let v: f64 = v.parse().ok().filter(|x| *x > 0.0).unwrap_or_else(|| {
+            panic!("invalid value for POLARS_STORAGE_BACKOFF_BASE_MULTIPLIER: {v}")
         });
 
         *base = v;
     };
 
     if let Ok(v) = std::env::var("POLARS_STORAGE_RETRY_TIMEOUT_MS").as_deref() {
-        let v: u64 = v.parse().unwrap_or_else(|_| {
-            panic!("failed to parse u64 from POLARS_STORAGE_RETRY_TIMEOUT_MS={v}")
-        });
+        let v: u64 =
+            v.parse().ok().filter(|x| *x > 0).unwrap_or_else(|| {
+                panic!("invalid value for POLARS_STORAGE_RETRY_TIMEOUT_MS: {v}")
+            });
 
         *retry_timeout = Duration::from_millis(v);
     };


### PR DESCRIPTION
Following can be set:
```python
os.environ["POLARS_STORAGE_BACKOFF_INIT_MS"]
os.environ["POLARS_STORAGE_BACKOFF_MAX_MS"]
os.environ["POLARS_STORAGE_BACKOFF_BASE_MULTIPLIER"]
os.environ["POLARS_STORAGE_RETRY_TIMEOUT_MS"]
```

Set `POLARS_VERBOSE=1` to confirm:
```
...
get_retry_config: RetryConfig { backoff: BackoffConfig { init_backoff: 100s, max_backoff: 100s, base: 999.91 }, max_retries: 2, retry_timeout: 999.999s }
...
```
