### PR TITLE
perf: Lazy gather for `{forward,backward}_fill` in group-by contexts

### DIFF
--- a/crates/polars-expr/src/dispatch/groups_dispatch.rs
+++ b/crates/polars-expr/src/dispatch/groups_dispatch.rs
@@ -616,3 +616,166 @@ pub fn unique<'a>(
 
     Ok(ac)
 }
+
+fn fw_bw_fill_null<'a>(
+    inputs: &[Arc<dyn PhysicalExpr>],
+    df: &DataFrame,
+    groups: &'a GroupPositions,
+    state: &ExecutionState,
+    f_idx: impl Fn(
+        std::iter::Copied<std::slice::Iter<'_, IdxSize>>,
+        BitMask<'_>,
+        usize,
+    ) -> UnitVec<IdxSize>
+    + Send
+    + Sync,
+    f_range: impl Fn(std::ops::Range<IdxSize>, BitMask<'_>, usize) -> UnitVec<IdxSize> + Send + Sync,
+) -> PolarsResult<AggregationContext<'a>> {
+    assert_eq!(inputs.len(), 1);
+    let mut ac = inputs[0].evaluate_on_groups(df, groups, state)?;
+    ac.groups();
+
+    if let AggState::AggregatedScalar(_) | AggState::LiteralScalar(_) = &mut ac.state {
+        return Ok(ac);
+    }
+
+    let values = ac.flat_naive();
+    let Some(validity) = values.rechunk_validity() else {
+        return Ok(ac);
+    };
+
+    let validity = BitMask::from_bitmap(&validity);
+    POOL.install(|| {
+        let positions = GroupsType::Idx(match &**ac.groups().as_ref() {
+            GroupsType::Idx(idx) => idx
+                .into_par_iter()
+                .map(|(first, idx)| {
+                    let idx = f_idx(idx.iter().copied(), validity, idx.len());
+                    (idx.first().copied().unwrap_or(first), idx)
+                })
+                .collect(),
+            GroupsType::Slice {
+                groups,
+                overlapping: _,
+            } => groups
+                .into_par_iter()
+                .map(|[start, len]| {
+                    let idx = f_range(*start..*start + *len, validity, *len as usize);
+                    (idx.first().copied().unwrap_or(*start), idx)
+                })
+                .collect(),
+        })
+        .into_sliceable();
+        ac.with_groups(positions);
+    });
+
+    Ok(ac)
+}
+
+pub fn forward_fill_null<'a>(
+    inputs: &[Arc<dyn PhysicalExpr>],
+    df: &DataFrame,
+    groups: &'a GroupPositions,
+    state: &ExecutionState,
+    limit: Option<IdxSize>,
+) -> PolarsResult<AggregationContext<'a>> {
+    let limit = limit.unwrap_or(IdxSize::MAX);
+    macro_rules! arg_forward_fill {
+        (
+            $iter:ident,
+            $validity:ident,
+            $length:ident
+        ) => {{
+            |$iter, $validity, $length| {
+                let Some(start) = $iter
+                    .clone()
+                    .position(|i| unsafe { $validity.get_bit_unchecked(i as usize) })
+                else {
+                    return $iter.collect();
+                };
+
+                let mut idx = UnitVec::with_capacity($length);
+                let mut iter = $iter;
+                idx.extend((&mut iter).take(start));
+
+                let mut current_limit = limit;
+                let mut value = iter.next().unwrap();
+                idx.push(value);
+
+                idx.extend(iter.map(|i| {
+                    if unsafe { $validity.get_bit_unchecked(i as usize) } {
+                        current_limit = limit;
+                        value = i;
+                        i
+                    } else if current_limit == 0 {
+                        i
+                    } else {
+                        current_limit -= 1;
+                        value
+                    }
+                }));
+                idx
+            }
+        }};
+    }
+
+    fw_bw_fill_null(
+        inputs,
+        df,
+        groups,
+        state,
+        arg_forward_fill!(iter, validity, length),
+        arg_forward_fill!(iter, validity, length),
+    )
+}
+
+pub fn backward_fill_null<'a>(
+    inputs: &[Arc<dyn PhysicalExpr>],
+    df: &DataFrame,
+    groups: &'a GroupPositions,
+    state: &ExecutionState,
+    limit: Option<IdxSize>,
+) -> PolarsResult<AggregationContext<'a>> {
+    let limit = limit.unwrap_or(IdxSize::MAX);
+    macro_rules! arg_backward_fill {
+        (
+            $iter:ident,
+            $validity:ident,
+            $length:ident
+        ) => {{
+            |$iter, $validity, $length| {
+                let Some(start) = $iter
+                    .clone()
+                    .rev()
+                    .position(|i| unsafe { $validity.get_bit_unchecked(i as usize) })
+                else {
+                    return $iter.collect();
+                };
+
+                let mut idx = UnitVec::from_iter($iter);
+                let mut current_limit = limit;
+                let mut value = idx[$length - start - 1];
+                for i in idx[..$length - start].iter_mut().rev() {
+                    if unsafe { $validity.get_bit_unchecked(*i as usize) } {
+                        current_limit = limit;
+                        value = *i;
+                    } else if current_limit != 0 {
+                        current_limit -= 1;
+                        *i = value;
+                    }
+                }
+
+                idx
+            }
+        }};
+    }
+
+    fw_bw_fill_null(
+        inputs,
+        df,
+        groups,
+        state,
+        arg_backward_fill!(iter, validity, length),
+        arg_backward_fill!(iter, validity, length),
+    )
+}

--- a/crates/polars-expr/src/dispatch/mod.rs
+++ b/crates/polars-expr/src/dispatch/mod.rs
@@ -587,6 +587,12 @@ pub fn function_expr_to_groups_udf(func: &IRFunctionExpr) -> Option<SpecialEq<Ar
         },
 
         F::Unique(stable) => wrap_groups!(groups_dispatch::unique, (*stable, v: bool)),
+        F::FillNullWithStrategy(polars_core::prelude::FillNullStrategy::Forward(limit)) => {
+            wrap_groups!(groups_dispatch::forward_fill_null, (*limit, v: Option<IdxSize>))
+        },
+        F::FillNullWithStrategy(polars_core::prelude::FillNullStrategy::Backward(limit)) => {
+            wrap_groups!(groups_dispatch::backward_fill_null, (*limit, v: Option<IdxSize>))
+        },
 
         _ => return None,
     })

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -1983,3 +1983,75 @@ def test_group_by_explode_none_dtype_25045() -> None:
     )
     expected_c = pl.DataFrame({"a": [[1.0], [2.0], [None]]})
     assert_frame_equal(out_c, expected_c)
+
+
+@pytest.mark.parametrize(
+    ("expr", "is_scalar"),
+    [
+        (pl.Expr.forward_fill, False),
+        (pl.Expr.backward_fill, False),
+        (lambda e: e.forward_fill(1), False),
+        (lambda e: e.backward_fill(1), False),
+        (lambda e: e.forward_fill(2), False),
+        (lambda e: e.backward_fill(2), False),
+        (lambda e: e.forward_fill().min(), True),
+        (lambda e: e.backward_fill().min(), True),
+        (lambda e: e.forward_fill().first(), True),
+        (lambda e: e.backward_fill().first(), True),
+    ],
+)
+def test_group_by_forward_backward_fill(
+    expr: Callable[[pl.Expr], pl.Expr], is_scalar: bool
+) -> None:
+    combinations = [
+        [1, None, 2, None, None],
+        [None, 1, 2, 3, 4],
+        [None, None, None, None, None],
+        [1, 2, 3, 4, 5],
+        [1, None, 2, 3, 4],
+        [None, None, None, None, 1],
+        [1, None, None, None, None],
+        [None, None, None, 1, None],
+        [None, 1, None, None, None],
+    ]
+
+    cl = cs.starts_with("x")
+    df = pl.DataFrame(
+        [pl.Series("g", [1] * 5)]
+        + [pl.Series(f"x{i}", c, pl.Int64()) for i, c in enumerate(combinations)]
+    )
+
+    # verify that we are actually calculating something
+    assert len(df.lazy().select(expr(cl)).collect_schema()) == len(combinations)
+
+    data = df.group_by(lit=pl.lit(1)).agg(expr(cl)).drop("lit")
+    if not is_scalar:
+        data = data.explode(cs.all())
+    assert_frame_equal(df.select(expr(cl)), data)
+
+    data = df.group_by("g").agg(expr(cl)).drop("g")
+    if not is_scalar:
+        data = data.explode(cs.all())
+    assert_frame_equal(df.select(expr(cl)), data)
+
+    assert_frame_equal(
+        df.select(expr(cl)),
+        df.select(cl.implode().list.eval(expr(pl.element())).explode()),
+    )
+
+    df = pl.Schema({"x": pl.Int64()}).to_frame()
+
+    data = (
+        pl.DataFrame({"x": [None]})
+        .group_by(lit=pl.lit(1))
+        .agg(expr(pl.lit(pl.Series("x", [], pl.Int64()))))
+        .drop("lit")
+    )
+    if not is_scalar:
+        data = data.select(cs.all().reshape((-1,)))
+    assert_frame_equal(df.select(expr(cl)), data)
+
+    assert_frame_equal(
+        df.select(expr(cl)),
+        df.select(cl.implode().list.eval(expr(pl.element())).reshape((-1,))),
+    )


### PR DESCRIPTION
This should significantly speed up `{forward,backward}_fill` and their aliases `fill_null(strategy='forward'/'backward')` in group-by contexts like `group-by`, `cumulative_eval`, `pivot`, `{list,arr}.{eval,agg}`, `over` and `rolling`.