### PR TITLE
fix: DSL_SCHEMA_HASH should not changed by line endings

### DIFF
--- a/crates/polars-plan/build.rs
+++ b/crates/polars-plan/build.rs
@@ -20,8 +20,12 @@ fn main() {
 fn generate_schema_hash() {
     let hash_hexstr = {
         let mut digest = sha2::Sha256::new();
+        // Read as UTF-8 text and normalize CRLF to LF to make hashing
+        // invariant to Git EOL conversion on Windows.
+        let content = include_str!("dsl-schema-hashes.json");
+        let normalized = content.replace("\r\n", "\n");
         digest
-            .write_all(include_bytes!("dsl-schema-hashes.json"))
+            .write_all(normalized.as_bytes())
             .expect("failed to hash the schema hashes file");
         let hash = digest.finalize();
 


### PR DESCRIPTION
Ref: pola-rs/r-polars#1625

If we reference Polars on GitHub and build it from Windows, Git for Windows may rewrite the line ending characters from LF to CRLF, resulting in a different value for `DSL_SCHEMA_HASH`.
By replacing CRLF to LF before hashing, we can prevent such accidents.

Currently, Python Polars on Windows has a different `DSL_SCHEMA_HASH` compared to other platforms:

```
polars.exceptions.ComputeError: deserialization failed

given DSL_SCHEMA_HASH: 6286bad7b59c6dffbabcb7eda0d3a1c386cc651ad8b2479b2e4e4686199e04e1 is not compatible with this Polars version which uses DSL_SCHEMA_HASH: 45389c69048be32a61fcfa8990e6bd529f3d369c229e6004318f7e15baa0b597
error: can't deserialize DSL with incompatible schema
```

- Other Platforms: `6286bad7b59c6dffbabcb7eda0d3a1c386cc651ad8b2479b2e4e4686199e04e1`
- Windows: `45389c69048be32a61fcfa8990e6bd529f3d369c229e6004318f7e15baa0b597`

As shown below, it can be confirmed that this is the result of replacing the line ending characters from LF to CRLF.

```sh
$ wget \
    https://raw.githubusercontent.com/pola-rs/polars/df69276daf5d195c8feb71eef82cbe9804e0f47f/crates/polars-plan/dsl-schema-hashes.json \
    --quiet
$ sha256sum dsl-schema-hashes.json
6286bad7b59c6dffbabcb7eda0d3a1c386cc651ad8b2479b2e4e4686199e04e1  dsl-schema-hashes.json
$ sed -e 's/$/\r/g' dsl-schema-hashes.json | head -c -1 >crlf.json
$ sha256sum crlf.json
45389c69048be32a61fcfa8990e6bd529f3d369c229e6004318f7e15baa0b597  crlf.json
```