### PR TITLE
feat: Improve error message on unsupported SQL subquery comparisons

### DIFF
--- a/py-polars/tests/unit/sql/test_subqueries.py
+++ b/py-polars/tests/unit/sql/test_subqueries.py
@@ -158,3 +158,28 @@ def test_subquery_20732() -> None:
     )
     res = pl.sql("SELECT * FROM lf WHERE id IN (SELECT MAX(id) FROM lf)", eager=True)
     assert res.to_dict(as_series=False) == {"id": [2], "s": ["b"]}
+
+
+def test_unsupported_subquery_comparisons() -> None:
+    """Test that using = with a subquery gives a helpful error message."""
+    df = pl.DataFrame({"value": [2000, 2000]})  # noqa: F841
+
+    for op, suggestion in (("=", "IN"), ("!=", "NOT IN")):
+        with pytest.raises(
+            SQLSyntaxError,
+            match=rf"subquery comparisons with '{op}' are not supported; use '{suggestion}' instead",
+        ):
+            pl.sql(f"SELECT * FROM df WHERE value {op} (SELECT MAX(e) FROM df)")
+
+    for op in ("<", "<=", ">", ">="):
+        with pytest.raises(
+            SQLSyntaxError,
+            match=rf"subquery comparisons with '{op}' are not supported",
+        ):
+            pl.sql(f"SELECT * FROM df WHERE (SELECT MAX(e) FROM df) {op} value")
+
+        with pytest.raises(
+            SQLSyntaxError,
+            match=rf"subquery comparisons with '{op}' are not supported",
+        ):
+            pl.sql(f"SELECT * FROM df WHERE value {op} (SELECT MAX(value) FROM df)")


### PR DESCRIPTION
Closes #13142.

Provide more helpful error messages on unsupported SQL scalar subquery comparisons.

For "=" and "!=" we will also now suggest the supported "IN" or "NOT IN" syntax instead; for any other binary/comparison ops we just provide the more specific error.

## Example
```python
import polars as pl

df = pl.DataFrame({'n': [2000, 2000]})
pl.sql("SELECT * FROM df WHERE n = (SELECT MAX(e) AS a FROM df)")
```
**Before**
```
SQLInterfaceError:
  unexpected subquery
```
**After**
```
SQLSyntaxError:
  subquery comparisons with '=' are not supported; use 'IN' instead
```