### PR TITLE
fix: Support "index" as column name in `group_by` iterator

### DIFF
--- a/py-polars/src/polars/dataframe/group_by.py
+++ b/py-polars/src/polars/dataframe/group_by.py
@@ -106,7 +106,7 @@ class GroupBy:
         temp_col = "__POLARS_GB_GROUP_INDICES"
         groups_df = (
             self.df.lazy()
-            .with_row_index()
+            .with_row_index("__POLARS_GB_ROW_INDEX")
             .group_by(*self.by, **self.named_by, maintain_order=self.maintain_order)
             .agg(F.first().alias(temp_col))
             .collect(optimizations=QueryOptFlags.none())
@@ -804,7 +804,7 @@ class RollingGroupBy:
         temp_col = "__POLARS_GB_GROUP_INDICES"
         groups_df = (
             self.df.lazy()
-            .with_row_index()
+            .with_row_index("__POLARS_GB_ROW_INDEX")
             .rolling(
                 index_column=self.time_column,
                 period=self.period,
@@ -953,7 +953,7 @@ class DynamicGroupBy:
         temp_col = "__POLARS_GB_GROUP_INDICES"
         groups_df = (
             self.df.lazy()
-            .with_row_index()
+            .with_row_index("__POLARS_GB_ROW_INDEX")
             .group_by_dynamic(
                 index_column=self.time_column,
                 every=self.every,

--- a/py-polars/tests/unit/operations/test_group_by_dynamic.py
+++ b/py-polars/tests/unit/operations/test_group_by_dynamic.py
@@ -1283,3 +1283,12 @@ def test_group_by_multiple_chunks_25063() -> None:
     )
 
     assert_frame_equal(df.select("id", "date", "value"), result, check_row_order=False)
+
+
+@pytest.mark.parametrize("col", ["g", "index"])
+def test_group_by_iterate_index_column_name_25137(col: pl.Expr) -> None:
+    df = pl.DataFrame({"g": [10, 20, 30], "index": [0, 1, 2]})
+
+    assert len(list(df.group_by(col))) == 3
+    assert len(list(df.group_by_dynamic(col, every="1i"))) == 3
+    assert len(list(df.rolling(col, period="1i"))) == 3


### PR DESCRIPTION
fixes #25137 