### PR TITLE
fix: Fix `format_str` in case of multiple chunks

### DIFF
--- a/crates/polars-ops/src/series/ops/strings.rs
+++ b/crates/polars-ops/src/series/ops/strings.rs
@@ -110,6 +110,7 @@ pub fn str_format(cs: &mut [Column], format: &str, insertions: &[usize]) -> Pola
             *elem_idx += 1;
             if i + 1 != output_length && *elem_idx == arr.len() {
                 *arr = iter.next().unwrap();
+                *elem_idx = 0;
             }
         }
 


### PR DESCRIPTION
fixes #25159

Note - suggestions on how to trigger `n_chunks() > 1` in CI would be appreciated.

ping @coastalwhite 