### PR TITLE
fix: Enhanced column resolution/tracking through multi-way SQL joins

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -1644,6 +1644,22 @@ impl<'a> Visitor for FindTableIdentifier<'a> {
     }
 }
 
+/// Check if all columns referred to in a Polars expression exist in the given Schema.
+fn expr_cols_all_in_schema(expr: &Expr, schema: &Schema) -> bool {
+    let mut found_cols = false;
+    let mut all_in_schema = true;
+    for e in expr.into_iter() {
+        if let Expr::Column(name) = e {
+            found_cols = true;
+            if !schema.contains(name.as_str()) {
+                all_in_schema = false;
+                break;
+            }
+        }
+    }
+    found_cols && all_in_schema
+}
+
 /// Check if a SQL expression contains a reference to a specific table.
 fn expr_refers_to_table(expr: &SQLExpr, table_name: &str) -> bool {
     let mut table_finder = FindTableIdentifier {
@@ -1654,79 +1670,132 @@ fn expr_refers_to_table(expr: &SQLExpr, table_name: &str) -> bool {
     table_finder.found
 }
 
-fn process_join_on(
-    expression: &sqlparser::ast::Expr,
+/// Determine which parsed join expressions actually belong in `left_om` and which in `right_on`.
+///
+/// This needs to be handled carefully because in SQL joins you can write "join on" constraints
+/// either way round, and in joins with more than two tables you can also join against an earlier
+/// table (e.g.: you could be joining `df1` to `df2` to `df3`, but the final join condition where
+/// we join  `df2` to `df3` could refer to `df1.a = df3.b`; this takes a little more work to
+/// resolve as our native `join` function operates on only two tables at a time.
+fn determine_left_right_join_on(
+    ctx: &mut SQLContext,
+    expr_left: &SQLExpr,
+    expr_right: &SQLExpr,
     tbl_left: &TableInfo,
     tbl_right: &TableInfo,
-    ctx: &mut SQLContext,
+    join_schema: &Schema,
 ) -> PolarsResult<(Vec<Expr>, Vec<Expr>)> {
-    match expression {
+    // parse, removing any aliases that may have been added by `resolve_column`
+    // (called inside `parse_sql_expr`) as we need the actual/underlying col
+    let left_on = match parse_sql_expr(expr_left, ctx, Some(join_schema))? {
+        Expr::Alias(inner, _) => Arc::unwrap_or_clone(inner),
+        e => e,
+    };
+    let right_on = match parse_sql_expr(expr_right, ctx, Some(join_schema))? {
+        Expr::Alias(inner, _) => Arc::unwrap_or_clone(inner),
+        e => e,
+    };
+
+    // ------------------------------------------------------------------
+    // simple/typical case: can fully resolve SQL-level table references
+    // ------------------------------------------------------------------
+    let left_refs = (
+        expr_refers_to_table(expr_left, &tbl_left.name),
+        expr_refers_to_table(expr_left, &tbl_right.name),
+    );
+    let right_refs = (
+        expr_refers_to_table(expr_right, &tbl_left.name),
+        expr_refers_to_table(expr_right, &tbl_right.name),
+    );
+    // if the SQL-level references unambiguously indicate table ownership, we're done
+    match (left_refs, right_refs) {
+        // standard: left expr → left table, right expr → right table
+        ((true, false), (false, true)) => return Ok((vec![left_on], vec![right_on])),
+        // reversed: left expr → right table, right expr → left table
+        ((false, true), (true, false)) => return Ok((vec![right_on], vec![left_on])),
+        // unsupported: one side references *both* tables
+        ((true, true), _) | (_, (true, true)) if tbl_left.name != tbl_right.name => {
+            polars_bail!(
+               SQLInterface: "unsupported join condition: {} side references both '{}' and '{}'",
+               if left_refs.0 && left_refs.1 {
+                    "left"
+                } else {
+                    "right"
+                }, tbl_left.name, tbl_right.name
+            )
+        },
+        // fall through to the more involved col/ref resolution
+        _ => {},
+    }
+
+    // ------------------------------------------------------------------
+    // more involved: additionally employ schema-based column resolution
+    // (applies to unqualified columns and/or chained joins)
+    // ------------------------------------------------------------------
+    let left_on_cols_in = (
+        expr_cols_all_in_schema(&left_on, &tbl_left.schema),
+        expr_cols_all_in_schema(&left_on, &tbl_right.schema),
+    );
+    let right_on_cols_in = (
+        expr_cols_all_in_schema(&right_on, &tbl_left.schema),
+        expr_cols_all_in_schema(&right_on, &tbl_right.schema),
+    );
+    match (left_on_cols_in, right_on_cols_in) {
+        // each expression's columns exist in exactly one schema
+        ((true, false), (false, true)) => Ok((vec![left_on], vec![right_on])),
+        ((false, true), (true, false)) => Ok((vec![right_on], vec![left_on])),
+        // one expression in both, other only in one; prefer the unique one
+        ((true, true), (true, false)) => Ok((vec![right_on], vec![left_on])),
+        ((true, true), (false, true)) => Ok((vec![left_on], vec![right_on])),
+        ((true, false), (true, true)) => Ok((vec![left_on], vec![right_on])),
+        ((false, true), (true, true)) => Ok((vec![right_on], vec![left_on])),
+        // pass through as-is
+        _ => Ok((vec![left_on], vec![right_on])),
+    }
+}
+
+fn process_join_on(
+    ctx: &mut SQLContext,
+    sql_expr: &SQLExpr,
+    tbl_left: &TableInfo,
+    tbl_right: &TableInfo,
+) -> PolarsResult<(Vec<Expr>, Vec<Expr>)> {
+    match sql_expr {
         SQLExpr::BinaryOp { left, op, right } => match op {
             BinaryOperator::And => {
-                let (mut left_i, mut right_i) = process_join_on(left, tbl_left, tbl_right, ctx)?;
-                let (mut left_j, mut right_j) = process_join_on(right, tbl_left, tbl_right, ctx)?;
+                let (mut left_i, mut right_i) = process_join_on(ctx, left, tbl_left, tbl_right)?;
+                let (mut left_j, mut right_j) = process_join_on(ctx, right, tbl_left, tbl_right)?;
                 left_i.append(&mut left_j);
                 right_i.append(&mut right_j);
                 Ok((left_i, right_i))
             },
             BinaryOperator::Eq => {
-                // establish a unified schema with cols from both tables; needed
-                // for chained joins where the joined cols aren't in the original
-                let mut unified_schema =
+                // establish unified schema with cols from both tables; needed for multi/chained
+                // joins where suffixed intermediary/joined cols aren't in an existing schema.
+                let mut join_schema =
                     Schema::with_capacity(tbl_left.schema.len() + tbl_right.schema.len());
                 for (name, dtype) in tbl_left.schema.iter() {
-                    unified_schema.insert_at_index(
-                        unified_schema.len(),
-                        name.clone(),
-                        dtype.clone(),
-                    )?;
+                    join_schema.insert_at_index(join_schema.len(), name.clone(), dtype.clone())?;
                 }
                 for (name, dtype) in tbl_right.schema.iter() {
-                    if !unified_schema.contains(name) {
-                        unified_schema.insert_at_index(
-                            unified_schema.len(),
+                    if !join_schema.contains(name) {
+                        join_schema.insert_at_index(
+                            join_schema.len(),
                             name.clone(),
                             dtype.clone(),
                         )?;
                     }
                 }
-                let left_on = parse_sql_expr(left, ctx, Some(&unified_schema))?;
-                let right_on = parse_sql_expr(right, ctx, Some(&unified_schema))?;
-
-                // identify which side of the condition references which table/frame
-                let left_refs = (
-                    expr_refers_to_table(left, &tbl_left.name),
-                    expr_refers_to_table(left, &tbl_right.name),
-                );
-                let right_refs = (
-                    expr_refers_to_table(right, &tbl_left.name),
-                    expr_refers_to_table(right, &tbl_right.name),
-                );
-                match (left_refs, right_refs) {
-                    // swap left_on/right_on (if necessary)
-                    ((true, false), (false, true)) => Ok((vec![left_on], vec![right_on])),
-                    ((false, true), (true, false)) => Ok((vec![right_on], vec![left_on])),
-                    // unsupported: one side of the condition refers to *both* tables
-                    ((true, true), _) if tbl_left.name != tbl_right.name => polars_bail!(
-                        SQLInterface: "unsupported join condition: left side references both '{}' and '{}'",
-                        tbl_left.name, tbl_right.name
-                    ),
-                    (_, (true, true)) if tbl_left.name != tbl_right.name => polars_bail!(
-                        SQLInterface: "unsupported join condition: right side references both '{}' and '{}'",
-                        tbl_left.name, tbl_right.name
-                    ),
-                    // unqualified columns
-                    _ => Ok((vec![left_on], vec![right_on])),
-                }
+                determine_left_right_join_on(ctx, left, right, tbl_left, tbl_right, &join_schema)
             },
             _ => polars_bail!(
-                // TODO: should be able to support more operators later via `join_where`
+                // TODO: should be able to support more operators later (via `join_where`?)
                 SQLInterface: "only equi-join constraints (combined with 'AND') are currently supported; found op = '{:?}'", op
             ),
         },
-        SQLExpr::Nested(expr) => process_join_on(expr, tbl_left, tbl_right, ctx),
+        SQLExpr::Nested(expr) => process_join_on(ctx, expr, tbl_left, tbl_right),
         _ => polars_bail!(
-            SQLInterface: "only equi-join constraints are currently supported; found expression = {:?}", expression
+            SQLInterface: "only equi-join constraints are currently supported; found expression = {:?}", sql_expr
         ),
     }
 }
@@ -1739,7 +1808,7 @@ fn process_join_constraint(
 ) -> PolarsResult<(Vec<Expr>, Vec<Expr>)> {
     match constraint {
         JoinConstraint::On(expr @ SQLExpr::BinaryOp { .. }) => {
-            process_join_on(expr, tbl_left, tbl_right, ctx)
+            process_join_on(ctx, expr, tbl_left, tbl_right)
         },
         JoinConstraint::Using(idents) if !idents.is_empty() => {
             let using: Vec<Expr> = idents.iter().map(|id| col(id.value.as_str())).collect();

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -215,7 +215,7 @@ allowed-confusables = ["µ"]
 [tool.ruff.lint.per-file-ignores]
 "_dependencies.py" = ["ICN001"]
 "config.py" = ["FBT001"]
-"tests/**/*.py" = ["D100", "D102", "D103", "B018", "FBT001"]
+"tests/**/*.py" = ["D100", "D102", "D103", "B018", "F841", "FBT001"]
 
 [tool.ruff.lint.pycodestyle]
 max-doc-length = 88

--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -99,9 +99,9 @@ def test_join_cross() -> None:
 
 
 def test_join_cross_11927() -> None:
-    df1 = pl.DataFrame({"id": [1, 2, 3]})  # noqa: F841
-    df2 = pl.DataFrame({"id": [3, 4, 5]})  # noqa: F841
-    df3 = pl.DataFrame({"id": [4, 5, 6]})  # noqa: F841
+    df1 = pl.DataFrame({"id": [1, 2, 3]})
+    df2 = pl.DataFrame({"id": [3, 4, 5]})
+    df3 = pl.DataFrame({"id": [4, 5, 6]})
 
     res = pl.sql("SELECT df1.id FROM df1 CROSS JOIN df2 WHERE df1.id = df2.id")
     assert_frame_equal(res.collect(), pl.DataFrame({"id": [3]}))
@@ -120,7 +120,7 @@ def test_join_cross_11927() -> None:
 )
 def test_join_inner(foods_ipc_path: Path, join_clause: str) -> None:
     foods1 = pl.scan_ipc(foods_ipc_path)
-    foods2 = foods1  # noqa: F841
+    foods2 = foods1
     schema = foods1.collect_schema()
 
     sort_clause = ", ".join(f'{c} ASC, "{c}:foods2" DESC' for c in schema)
@@ -182,8 +182,8 @@ def test_join_inner_multi(join_clause: str) -> None:
 
 
 def test_join_inner_15663() -> None:
-    df_a = pl.DataFrame({"LOCID": [1, 2, 3], "VALUE": [0.1, 0.2, 0.3]})  # noqa: F841
-    df_b = pl.DataFrame({"LOCID": [1, 2, 3], "VALUE": [25.6, 53.4, 12.7]})  # noqa: F841
+    df_a = pl.DataFrame({"LOCID": [1, 2, 3], "VALUE": [0.1, 0.2, 0.3]})
+    df_b = pl.DataFrame({"LOCID": [1, 2, 3], "VALUE": [25.6, 53.4, 12.7]})
     df_expected = pl.DataFrame(
         {
             "LOCID": [1, 2, 3],
@@ -295,8 +295,8 @@ def test_join_misc_13618() -> None:
 
 
 def test_join_misc_16255() -> None:
-    df1 = pl.read_csv(BytesIO(b"id,data\n1,open"))  # noqa: F841
-    df2 = pl.read_csv(BytesIO(b"id,data\n1,closed"))  # noqa: F841
+    df1 = pl.read_csv(BytesIO(b"id,data\n1,open"))
+    df2 = pl.read_csv(BytesIO(b"id,data\n1,closed"))
     res = pl.sql(
         """
         SELECT a.id, a.data AS d1, b.data AS d2
@@ -446,8 +446,8 @@ def test_implicit_joins() -> None:
 def test_wildcard_resolution_and_join_order(
     query: str, expected: dict[str, Any]
 ) -> None:
-    df1 = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"], "c": [100, 200, 300]})  # noqa: F841
-    df2 = pl.DataFrame({"a": [1, 3, 4], "b": ["qq", "pp", "oo"], "c": [400, 500, 600]})  # noqa: F841
+    df1 = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"], "c": [100, 200, 300]})
+    df2 = pl.DataFrame({"a": [1, 3, 4], "b": ["qq", "pp", "oo"], "c": [400, 500, 600]})
 
     res = pl.sql(query).collect()
     assert_frame_equal(
@@ -576,13 +576,13 @@ def test_natural_joins_01() -> None:
     ],
 )
 def test_natural_joins_02(cols_constraint: str, expect_data: list[tuple[int]]) -> None:
-    df1 = pl.DataFrame(  # noqa: F841
+    df1 = pl.DataFrame(
         {
             "x": [1, 5, 3, 8, 6, 7, 4, 0, 2],
             "y": [3, 4, 6, 8, 3, 4, 1, 7, 8],
         }
     )
-    df2 = pl.DataFrame(  # noqa: F841
+    df2 = pl.DataFrame(
         {
             "y": [0, 4, 0, 8, 0, 4, 0, 7, None],
             "z": [9, 8, 7, 6, 5, 4, 3, 2, 1],
@@ -762,13 +762,13 @@ def test_nulls_equal_19624() -> None:
 
 
 def test_join_on_literal_string_comparison() -> None:
-    df1 = pl.DataFrame(  # noqa: F841
+    df1 = pl.DataFrame(
         {
             "name": ["alice", "bob", "adam", "charlie"],
             "role": ["admin", "user", "admin", "user"],
         }
     )
-    df2 = pl.DataFrame(  # noqa: F841
+    df2 = pl.DataFrame(
         {
             "name": ["alice", "bob", "charlie", "adam"],
             "dept": ["IT", "HR", "IT", "SEC"],
@@ -798,13 +798,13 @@ def test_join_on_literal_string_comparison() -> None:
     ],
 )
 def test_join_on_expression_conditions(expression: str, expected_length: int) -> None:
-    df1 = pl.DataFrame(  # noqa: F841
+    df1 = pl.DataFrame(
         {
             "text": ["HELLO", "WORLD", "FOO"],
             "code": ["ABC", "DEF", "GHI"],
         }
     )
-    df2 = pl.DataFrame(  # noqa: F841
+    df2 = pl.DataFrame(
         {
             "text": ["hello", "world", "bar"],
             "code": ["ABX", "DEY", "GHZ"],
@@ -1096,6 +1096,43 @@ def test_join_on_unqualified_expressions(
     assert_frame_equal(res, df_expected)
 
 
+def test_multiway_join_chain_with_aliased_cols() -> None:
+    # tracking/resolving constraints for 3-way (or more) joins can be... "fun" :)
+    # ref: https://github.com/pola-rs/polars/issues/25126
+
+    df1 = pl.DataFrame({"a": [111, 222], "x1": ["df1", "df1"]})
+    df2 = pl.DataFrame({"a": [333, 111], "b": [444, 222], "x2": ["df2", "df2"]})
+    df3 = pl.DataFrame({"a": [222, 111], "x3": ["df3", "df3"]})
+
+    for query, expected_cols, expected_row in (
+        (
+            # three-way join where "a" exists in all three frames (df1, df2, df3)
+            """
+            SELECT * FROM df3
+            INNER JOIN df2 ON df2.b = df3.a
+            INNER JOIN df1 ON df1.a = df2.a
+            """,
+            ["a", "x3", "a:df2", "b", "x2", "a:df1", "x1"],
+            (222, "df3", 111, 222, "df2", 111, "df1"),
+        ),
+        (
+            # almost the same, but the final constraint on "a" refers back to df1
+            """
+            SELECT * FROM df3
+            INNER JOIN df2 ON df2.b = df3.a
+            INNER JOIN df1 ON df1.a = df3.a
+            """,
+            ["a", "x3", "a:df2", "b", "x2", "a:df1", "x1"],
+            (222, "df3", 111, 222, "df2", 222, "df1"),
+        ),
+    ):
+        res = pl.sql(query, eager=True)
+
+        assert res.height == 1
+        assert res.columns == expected_cols
+        assert res.row(0) == expected_row
+
+
 @pytest.mark.parametrize(
     ("join_condition", "expected_error"),
     [
@@ -1111,8 +1148,8 @@ def test_join_on_unqualified_expressions(
 )
 def test_unsupported_join_conditions(join_condition: str, expected_error: str) -> None:
     # note: this is technically valid (if unusual) SQL, but we don't support it
-    df1 = pl.DataFrame({"id": [1, 2, 3], "val": [10, 20, 30]})  # noqa: F841
-    df2 = pl.DataFrame({"id": [2, 3, 4], "val": [20, 30, 40]})  # noqa: F841
+    df1 = pl.DataFrame({"id": [1, 2, 3], "val": [10, 20, 30]})
+    df2 = pl.DataFrame({"id": [2, 3, 4], "val": [20, 30, 40]})
 
     with pytest.raises(SQLInterfaceError, match=expected_error):
         pl.sql(f"SELECT * FROM df1 INNER JOIN df2 ON {join_condition}")

--- a/py-polars/tests/unit/sql/test_literals.py
+++ b/py-polars/tests/unit/sql/test_literals.py
@@ -229,7 +229,7 @@ def test_select_literals_no_table() -> None:
 
 
 def test_select_from_table_with_reserved_names() -> None:
-    select = pl.DataFrame({"select": [1, 2, 3], "from": [4, 5, 6]})  # noqa: F841
+    select = pl.DataFrame({"select": [1, 2, 3], "from": [4, 5, 6]})
     out = pl.sql(
         """
         SELECT "from", "select"

--- a/py-polars/tests/unit/sql/test_miscellaneous.py
+++ b/py-polars/tests/unit/sql/test_miscellaneous.py
@@ -21,7 +21,7 @@ def foods_ipc_path() -> Path:
 
 
 def test_any_all() -> None:
-    df = pl.DataFrame(  # noqa: F841
+    df = pl.DataFrame(
         {
             "x": [-1, 0, 1, 2, 3, 4],
             "y": [1, 0, 0, 1, 2, 3],
@@ -135,8 +135,8 @@ def test_count() -> None:
 
 
 def test_cte_aliasing() -> None:
-    df1 = pl.DataFrame({"colx": ["aa", "bb"], "coly": [40, 30]})  # noqa: F841
-    df2 = pl.DataFrame({"colx": "aa", "colz": 20})  # noqa: F841
+    df1 = pl.DataFrame({"colx": ["aa", "bb"], "coly": [40, 30]})
+    df2 = pl.DataFrame({"colx": "aa", "colz": 20})
     df3 = pl.sql(
         query="""
             WITH
@@ -190,7 +190,7 @@ def test_distinct() -> None:
 
 def test_frame_sql_globals_error() -> None:
     df1 = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-    df2 = pl.DataFrame({"a": [2, 3, 4], "b": [7, 6, 5]})  # noqa: F841
+    df2 = pl.DataFrame({"a": [2, 3, 4], "b": [7, 6, 5]})
 
     query = """
         SELECT df1.a, df2.b
@@ -209,7 +209,7 @@ def test_global_misc_lookup() -> None:
     # as supporting pycapsule (as it can look like it has *any* attr)
     from polars import col  # noqa: F401
 
-    df = pl.DataFrame({"col": [90, 80, 70]})  # noqa: F841
+    df = pl.DataFrame({"col": [90, 80, 70]})
     df_res = pl.sql("SELECT col FROM df WHERE col > 75", eager=True)
     assert df_res.rows() == [(90,), (80,)]
 
@@ -296,8 +296,8 @@ def test_sql_on_compatible_frame_types() -> None:
     # create various different frame types
     dfp = df.to_pandas()
     dfa = df.to_arrow()
-    dfb = dfa.to_batches()[0]  # noqa: F841
-    dfo = PyCapsuleStreamHolder(df)  # noqa: F841
+    dfb = dfa.to_batches()[0]
+    dfo = PyCapsuleStreamHolder(df)
 
     # run polars sql query against all frame types
     for dfs in (  # noqa: B007

--- a/py-polars/tests/unit/sql/test_set_ops.py
+++ b/py-polars/tests/unit/sql/test_set_ops.py
@@ -8,8 +8,8 @@ from polars.testing import assert_frame_equal
 
 
 def test_except_intersect() -> None:
-    df1 = pl.DataFrame({"x": [1, 9, 1, 1], "y": [2, 3, 4, 4], "z": [5, 5, 5, 5]})  # noqa: F841
-    df2 = pl.DataFrame({"x": [1, 9, 1], "y": [2, None, 4], "z": [7, 6, 5]})  # noqa: F841
+    df1 = pl.DataFrame({"x": [1, 9, 1, 1], "y": [2, 3, 4, 4], "z": [5, 5, 5, 5]})
+    df2 = pl.DataFrame({"x": [1, 9, 1], "y": [2, None, 4], "z": [7, 6, 5]})
 
     res_e = pl.sql("SELECT x, y, z FROM df1 EXCEPT SELECT * FROM df2", eager=True)
     res_i = pl.sql("SELECT * FROM df1 INTERSECT SELECT x, y, z FROM df2", eager=True)
@@ -40,14 +40,14 @@ def test_except_intersect() -> None:
 
 
 def test_except_intersect_by_name() -> None:
-    df1 = pl.DataFrame(  # noqa: F841
+    df1 = pl.DataFrame(
         {
             "x": [1, 9, 1, 1],
             "y": [2, 3, 4, 4],
             "z": [5, 5, 5, 5],
         }
     )
-    df2 = pl.DataFrame(  # noqa: F841
+    df2 = pl.DataFrame(
         {
             "y": [2, None, 4],
             "w": ["?", "!", "%"],
@@ -79,8 +79,8 @@ def test_except_intersect_by_name() -> None:
     ],
 )
 def test_except_intersect_all_unsupported(op: str, op_subtype: str) -> None:
-    df1 = pl.DataFrame({"n": [1, 1, 1, 2, 2, 2, 3]})  # noqa: F841
-    df2 = pl.DataFrame({"n": [1, 1, 2, 2]})  # noqa: F841
+    df1 = pl.DataFrame({"n": [1, 1, 1, 2, 2, 2, 3]})
+    df2 = pl.DataFrame({"n": [1, 1, 2, 2]})
 
     with pytest.raises(
         SQLInterfaceError,
@@ -139,8 +139,8 @@ def test_update_statement_error() -> None:
 
 @pytest.mark.parametrize("op", ["EXCEPT", "INTERSECT", "UNION"])
 def test_except_intersect_errors(op: str) -> None:
-    df1 = pl.DataFrame({"x": [1, 9, 1, 1], "y": [2, 3, 4, 4], "z": [5, 5, 5, 5]})  # noqa: F841
-    df2 = pl.DataFrame({"x": [1, 9, 1], "y": [2, None, 4], "z": [7, 6, 5]})  # noqa: F841
+    df1 = pl.DataFrame({"x": [1, 9, 1, 1], "y": [2, 3, 4, 4], "z": [5, 5, 5, 5]})
+    df2 = pl.DataFrame({"x": [1, 9, 1], "y": [2, None, 4], "z": [7, 6, 5]})
 
     if op != "UNION":
         with pytest.raises(

--- a/py-polars/tests/unit/sql/test_subqueries.py
+++ b/py-polars/tests/unit/sql/test_subqueries.py
@@ -150,7 +150,7 @@ def test_in_subquery() -> None:
 
 
 def test_subquery_20732() -> None:
-    lf = pl.concat(  # noqa: F841
+    lf = pl.concat(
         [
             pl.LazyFrame([{"id": 1, "s": "a"}]),
             pl.LazyFrame([{"id": 2, "s": "b"}]),
@@ -162,7 +162,7 @@ def test_subquery_20732() -> None:
 
 def test_unsupported_subquery_comparisons() -> None:
     """Test that using = with a subquery gives a helpful error message."""
-    df = pl.DataFrame({"value": [2000, 2000]})  # noqa: F841
+    df = pl.DataFrame({"value": [2000, 2000]})
 
     for op, suggestion in (("=", "IN"), ("!=", "NOT IN")):
         with pytest.raises(

--- a/py-polars/tests/unit/sql/test_temporal.py
+++ b/py-polars/tests/unit/sql/test_temporal.py
@@ -43,7 +43,7 @@ def test_date_func() -> None:
 
 @pytest.mark.parametrize("time_unit", ["ms", "us", "ns"])
 def test_datetime_to_time(time_unit: Literal["ns", "us", "ms"]) -> None:
-    df = pl.DataFrame(  # noqa: F841
+    df = pl.DataFrame(
         {
             "dtm": [
                 datetime(2099, 12, 31, 23, 59, 59),

--- a/py-polars/tests/unit/sql/test_trigonometric.py
+++ b/py-polars/tests/unit/sql/test_trigonometric.py
@@ -8,7 +8,7 @@ from polars.testing import assert_frame_equal
 
 def test_arctan2() -> None:
     twoRootTwo = math.sqrt(2) / 2.0
-    df = pl.DataFrame(  # noqa: F841
+    df = pl.DataFrame(
         {
             "y": [twoRootTwo, -twoRootTwo, twoRootTwo, -twoRootTwo],
             "x": [twoRootTwo, twoRootTwo, -twoRootTwo, -twoRootTwo],


### PR DESCRIPTION
Closes #25126.

Builds on the improvements made to join-column resolution in #25132.

Factored out the core column-resolution code for join constraints into its own `determine_left_right_join_on ` function, and then extended it with an extra stage that covers more (all?) of the remaining cases.

Commented it fairly extensively; the code itself isn't (at all) complicated, but the logic behind it needed a bit of thought, so I tried to make clear what is happening at each stage for anyone who looks at it later.

As well as fixing the linked issue, we can also now support joins like this, eg: a three-way join where we join `df1` to `df2` to `df3`, and the final constraint condition joins `df1` back to `df3`, without referring to the adjacent `df2`.
```sql
SELECT * FROM df3
INNER JOIN df2 ON df2.b = df3.a
INNER JOIN df1 ON df1.a = df3.a  -- << no ref to df2
```

## Example

Three-way joins with potentially tricky column-resolution properties.
Previously both failed.
```python
import polars as pl

df1 = pl.DataFrame({"a": [111,222], "x1": ["df1","df1"]})
df2 = pl.DataFrame({"a": [333,111], "x2": ["df2","df2"], "b": [444,222]})
df3 = pl.DataFrame({"a": [222,111], "x3": ["df3","df3"]})
```
We now resolve the common "a" column correctly across chained joins:
```python
pl.sql("""
    SELECT * FROM df3
    INNER JOIN df2 ON df2.b = df3.a
    INNER JOIN df1 ON df1.a = df2.a
""").collect()

# shape: (1, 7)
# ┌─────┬─────┬───────┬─────┬─────┬───────┬─────┐
# │ a   ┆ x3  ┆ a:df2 ┆ b   ┆ x2  ┆ a:df1 ┆ x1  │
# │ --- ┆ --- ┆ ---   ┆ --- ┆ --- ┆ ---   ┆ --- │
# │ i64 ┆ str ┆ i64   ┆ i64 ┆ str ┆ i64   ┆ str │
# ╞═════╪═════╪═══════╪═════╪═════╪═══════╪═════╡
# │ 222 ┆ df3 ┆ 111   ┆ 222 ┆ df2 ┆ 111   ┆ df1 │
# └─────┴─────┴───────┴─────┴─────┴───────┴─────┘
```
Can additionally resolve joins with constraints that are not consecutive with respect to the tables being joined (the final constraint doesn't join `df1` back to `df2`, but rather to `df3`; note the -correct- change in value for the "a:df1" column with this constraint):
```python
pl.sql("""
    SELECT * FROM df3
    INNER JOIN df2 ON df2.b = df3.a
    INNER JOIN df1 ON df1.a = df3.a
""").collect()

# shape: (1, 7)
# ┌─────┬─────┬───────┬─────┬─────┬───────┬─────┐
# │ a   ┆ x3  ┆ a:df2 ┆ b   ┆ x2  ┆ a:df1 ┆ x1  │
# │ --- ┆ --- ┆ ---   ┆ --- ┆ --- ┆ ---   ┆ --- │
# │ i64 ┆ str ┆ i64   ┆ i64 ┆ str ┆ i64   ┆ str │
# ╞═════╪═════╪═══════╪═════╪═════╪═══════╪═════╡
# │ 222 ┆ df3 ┆ 111   ┆ 222 ┆ df2 ┆ 222   ┆ df1 │
# └─────┴─────┴───────┴─────┴─────┴───────┴─────┘
```