### PR TITLE
fix: Fix single-column CSV header duplication with leading empty lines

### DIFF
--- a/crates/polars-io/src/csv/read/read_impl.rs
+++ b/crates/polars-io/src/csv/read/read_impl.rs
@@ -611,9 +611,9 @@ pub fn find_starting_point(
         // Skip utf8 byte-order-mark (BOM)
         bytes = skip_bom(bytes);
 
-        // \n\n can be a empty string row of a single column
-        // in other cases we skip it.
-        if schema_len > 1 {
+        // \n\n can be an empty row in a single column without header,
+        // in other cases we skip leading empty lines.
+        if schema_len > 1 || has_header {
             bytes = skip_line_ending(bytes, eol_char)
         }
         bytes

--- a/crates/polars/tests/it/io/csv.rs
+++ b/crates/polars/tests/it/io/csv.rs
@@ -1405,3 +1405,20 @@ fn test_read_io_reader() {
         .head(Some(df.height()));
     assert_eq!(&df, &expected);
 }
+
+#[test]
+fn test_single_column_leading_empty_line_25166() -> PolarsResult<()> {
+    // Single-column CSV with leading empty line should not duplicate header as data.
+    let csv = "\ncol1\nval1\nval2\n";
+    let file = Cursor::new(csv);
+    let df = CsvReadOptions::default()
+        .with_has_header(true)
+        .into_reader_with_file_handle(file)
+        .finish()?;
+
+    assert_eq!(df.shape(), (2, 1));
+    assert_eq!(df.column("col1")?.str()?.get(0), Some("val1"));
+    assert_eq!(df.column("col1")?.str()?.get(1), Some("val2"));
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #25166.

Single-column CSVs with leading empty lines incorrectly duplicated the header as the first data row.

This patch ensures leading empty lines are skipped when `has_header=True`, regardless of column count.