### PR TITLE
docs: Fix LanceDB URL

### DIFF
--- a/docs/source/user-guide/ecosystem.md
+++ b/docs/source/user-guide/ecosystem.md
@@ -98,7 +98,7 @@ Tables with Polars.
 applications. They have added a direct integration with Polars. LanceDB can ingest Polars
 dataframes, return results as polars dataframes, and export the entire table as a polars lazyframe.
 You can find a quick tutorial in their blog
-[LanceDB + Polars](https://blog.lancedb.com/lancedb-polars-2d5eb32a8aa3)
+[LanceDB + Polars](https://lancedb.com/docs/integrations/platforms/polars_arrow/)
 
 #### Mage
 


### PR DESCRIPTION
<img width="530" height="96" alt="image" src="https://github.com/user-attachments/assets/cb296593-1df5-401b-b9a0-e1be36429138" />

The old link https://blog.lancedb.com/lancedb-polars-2d5eb32a8aa3 is dead, new link I think is https://lancedb.com/docs/integrations/platforms/polars_arrow/.

Someone should report an issue with LanceDB though because their code snippet syntax is incorrect so the tutorial is not very helpful (Edit: I did).