### PR TITLE
chore: Update markdown link checker

### DIFF
--- a/.github/workflows/docs-global.yml
+++ b/.github/workflows/docs-global.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.client_payload.sha }}
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: tcort/github-action-markdown-link-check@v1.1.1
         with:
           config-file: docs/mlc-config.json
           folder-path: docs

--- a/docs/mlc-config.json
+++ b/docs/mlc-config.json
@@ -9,5 +9,6 @@
     {
       "pattern": "^https://marketplace.visualstudio.com/"
     }
-  ]
+  ],
+  "retryOn429": true
 }


### PR DESCRIPTION
The current markdown link checker [is now deprecated as of April 2025](https://github.com/gaurav-nelson/github-action-markdown-link-check?tab=readme-ov-file). It instructs us to instead use the actively maintained fork at https://github.com/tcort/markdown-link-check.

In the process, I've added a retry option for the HTTP 429 errors ("Too Many Requests") that we get fairly often from codspeed:

<img width="388" height="44" alt="image" src="https://github.com/user-attachments/assets/e8da3e01-367f-492c-a8ba-a86a442798ab" />

The default number of retries is 2, we can always up this if need be. But this should help alleviate some of the markdown link checker pain.