### PR TITLE
fix(rust): Use (i64, u64) for VisualizationData (offset, length) slices

### DIFF
--- a/crates/polars-plan/src/plans/ir/visualization/mod.rs
+++ b/crates/polars-plan/src/plans/ir/visualization/mod.rs
@@ -490,6 +490,10 @@ impl IRVisualizationDataGenerator<'_> {
                         .collect()
                     });
 
+                let pre_slice = pre_slice
+                    .clone()
+                    .map(|x| <(i64, usize)>::try_from(x).unwrap());
+
                 let properties = IRNodeProperties::Scan {
                     scan_type: PlSmallStr::from_static(scan_type.as_ref().into()),
                     num_sources: sources.len().try_into().unwrap(),
@@ -501,10 +505,7 @@ impl IRVisualizationDataGenerator<'_> {
                         #[cfg_attr(feature = "bigidx", expect(clippy::useless_conversion))]
                         ri.offset.into()
                     }),
-                    pre_slice: pre_slice.clone().map(|x| {
-                        let (offset, len) = <(i128, i128)>::from(x);
-                        [offset, len]
-                    }),
+                    pre_slice: convert_opt_slice(&pre_slice),
                     predicate: predicate
                         .as_ref()
                         .map(|e| format_pl_smallstr!("{}", e.display(self.expr_arena))),
@@ -736,14 +737,14 @@ where
         .collect()
 }
 
-fn convert_opt_slice<T, U>(slice: &Option<(T, U)>) -> Option<[i128; 2]>
+fn convert_opt_slice<T, U>(slice: &Option<(T, U)>) -> Option<(i64, u64)>
 where
-    T: Copy + TryInto<i128>,
-    U: Copy + TryInto<i128>,
-    <T as TryInto<i128>>::Error: std::fmt::Debug,
-    <U as TryInto<i128>>::Error: std::fmt::Debug,
+    T: Copy + TryInto<i64>,
+    U: Copy + TryInto<u64>,
+    <T as TryInto<i64>>::Error: std::fmt::Debug,
+    <U as TryInto<u64>>::Error: std::fmt::Debug,
 {
-    slice.map(|(offset, len)| [offset.try_into().unwrap(), len.try_into().unwrap()])
+    slice.map(|(offset, len)| (offset.try_into().unwrap(), len.try_into().unwrap()))
 }
 
 fn expr_list(exprs: &[ExprIR], expr_arena: &Arena<AExpr>) -> Vec<PlSmallStr> {

--- a/crates/polars-plan/src/plans/ir/visualization/models.rs
+++ b/crates/polars-plan/src/plans/ir/visualization/models.rs
@@ -67,7 +67,7 @@ pub enum IRNodeProperties {
         subset: Option<Vec<PlSmallStr>>,
         maintain_order: bool,
         keep_strategy: UniqueKeepStrategy,
-        slice: Option<[i128; 2]>,
+        slice: Option<(i64, u64)>,
     },
     ExtContext {
         num_contexts: u64,
@@ -80,7 +80,7 @@ pub enum IRNodeProperties {
         keys: Vec<PlSmallStr>,
         aggs: Vec<PlSmallStr>,
         maintain_order: bool,
-        slice: Option<[i128; 2]>,
+        slice: Option<(i64, u64)>,
         plan_callback: Option<PlSmallStr>,
     },
     HConcat {
@@ -105,13 +105,13 @@ pub enum IRNodeProperties {
         maintain_order: MaintainOrderJoin,
         validation: JoinValidation,
         suffix: Option<PlSmallStr>,
-        slice: Option<[i128; 2]>,
+        slice: Option<(i64, u64)>,
         allow_parallel: bool,
         force_parallel: bool,
     },
     CrossJoin {
         maintain_order: MaintainOrderJoin,
-        slice: Option<[i128; 2]>,
+        slice: Option<(i64, u64)>,
         predicate: Option<PlSmallStr>,
         suffix: Option<PlSmallStr>,
     },
@@ -126,7 +126,7 @@ pub enum IRNodeProperties {
         projection: Option<Vec<PlSmallStr>>,
         row_index_name: Option<PlSmallStr>,
         row_index_offset: Option<u64>,
-        pre_slice: Option<[i128; 2]>,
+        pre_slice: Option<(i64, u64)>,
         predicate: Option<PlSmallStr>,
         has_table_statistics: bool,
         include_file_paths: Option<PlSmallStr>,
@@ -152,12 +152,12 @@ pub enum IRNodeProperties {
         num_inputs: u64,
     },
     Slice {
-        offset: i128,
+        offset: i64,
         len: u64,
     },
     Sort {
         by_exprs: Vec<PlSmallStr>,
-        slice: Option<[i128; 2]>,
+        slice: Option<(i64, u64)>,
         descending: Vec<bool>,
         nulls_last: Vec<bool>,
         multithreaded: bool,
@@ -168,7 +168,7 @@ pub enum IRNodeProperties {
         maintain_order: bool,
         parallel: bool,
         rechunk: bool,
-        slice: Option<[i128; 2]>,
+        slice: Option<(i64, u64)>,
         from_partitioned_ds: bool,
         flattened_by_opt: bool,
     },
@@ -185,7 +185,7 @@ pub enum IRNodeProperties {
         /// [value, dtype_str]
         tolerance: Option<[PlSmallStr; 2]>,
         suffix: Option<PlSmallStr>,
-        slice: Option<[i128; 2]>,
+        slice: Option<(i64, u64)>,
         coalesce: JoinCoalesce,
         allow_eq: bool,
         check_sortedness: bool,
@@ -196,7 +196,7 @@ pub enum IRNodeProperties {
         right_on: Vec<PlSmallStr>,
         inequality_operators: Vec<polars_ops::frame::InequalityOperator>,
         suffix: Option<PlSmallStr>,
-        slice: Option<[i128; 2]>,
+        slice: Option<(i64, u64)>,
     },
     #[cfg(feature = "dynamic_group_by")]
     DynamicGroupBy {
@@ -219,7 +219,7 @@ pub enum IRNodeProperties {
         period: PlSmallStr,
         offset: PlSmallStr,
         closed_window: polars_time::ClosedWindow,
-        slice: Option<[i128; 2]>,
+        slice: Option<(i64, u64)>,
         plan_callback: Option<PlSmallStr>,
     },
     #[cfg(feature = "merge_sorted")]

--- a/crates/polars-stream/src/physical_plan/visualization/models.rs
+++ b/crates/polars-stream/src/physical_plan/visualization/models.rs
@@ -136,7 +136,7 @@ pub enum PhysNodeProperties {
         maintain_order: MaintainOrderJoin,
         validation: JoinValidation,
         suffix: Option<PlSmallStr>,
-        slice: Option<[i128; 2]>,
+        slice: Option<(i64, u64)>,
     },
     InMemoryAsOfJoin {
         left_on: PlSmallStr,
@@ -147,7 +147,7 @@ pub enum PhysNodeProperties {
         /// [value, dtype_str]
         tolerance: Option<[PlSmallStr; 2]>,
         suffix: Option<PlSmallStr>,
-        slice: Option<[i128; 2]>,
+        slice: Option<(i64, u64)>,
         coalesce: JoinCoalesce,
         allow_eq: bool,
         check_sortedness: bool,
@@ -157,7 +157,7 @@ pub enum PhysNodeProperties {
         right_on: Vec<PlSmallStr>,
         inequality_operators: Vec<polars_ops::frame::InequalityOperator>,
         suffix: Option<PlSmallStr>,
-        slice: Option<[i128; 2]>,
+        slice: Option<(i64, u64)>,
     },
     Map {
         display_str: PlSmallStr,
@@ -170,7 +170,7 @@ pub enum PhysNodeProperties {
         file_projection_builder_type: PlSmallStr,
         row_index_name: Option<PlSmallStr>,
         row_index_offset: Option<u64>,
-        pre_slice: Option<[i128; 2]>,
+        pre_slice: Option<(i64, u64)>,
         predicate: Option<PlSmallStr>,
         has_table_statistics: bool,
         include_file_paths: Option<PlSmallStr>,
@@ -179,8 +179,8 @@ pub enum PhysNodeProperties {
     },
     Multiplexer,
     NegativeSlice {
-        offset: i128,
-        length: i128,
+        offset: i64,
+        length: u64,
     },
     OrderedUnion {
         num_inputs: u64,
@@ -224,7 +224,7 @@ pub enum PhysNodeProperties {
     },
     Sort {
         by_exprs: Vec<PlSmallStr>,
-        slice: Option<[i128; 2]>,
+        slice: Option<(i64, u64)>,
         descending: Vec<bool>,
         nulls_last: Vec<bool>,
         multithreaded: bool,
@@ -232,8 +232,8 @@ pub enum PhysNodeProperties {
         limit: Option<u64>,
     },
     Slice {
-        offset: i128,
-        length: i128,
+        offset: i64,
+        length: u64,
     },
     TopK {
         by_exprs: Vec<PlSmallStr>,


### PR DESCRIPTION
Serde does not support i128s inside internally tagged enums. [This PR](https://github.com/serde-rs/serde/pull/2781) will add support but until it is merged we cannot deserialize IRVisualizationData or PhysVisualizationData. 

Discussed with @nameexhaustion and we should be able to use (i64, u64) to represent (offset, length) rather than [i128; 2].