### PR TITLE
add support for templating an execution plan of a lazyframe.

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -84,6 +84,25 @@ impl From<DslPlan> for LazyFrame {
     }
 }
 
+impl From<IRPlan> for LazyFrame {
+    fn from(ir_plan: IRPlan) -> Self {
+        // Create a DslPlan::IR wrapper to hold the IR
+        let dsl_plan = DslPlan::IR {
+            node: Some(ir_plan.lp_top),
+            dsl: Arc::new(DslPlan::default()), // placeholder
+            version: ir_plan.lp_arena.version(),
+        };
+
+        let lf = Self {
+            logical_plan: dsl_plan,
+            opt_state: OptFlags::default(),
+            cached_arena: Arc::new(Mutex::new(None)),
+        };
+        lf.set_cached_arena(ir_plan.lp_arena, ir_plan.expr_arena);
+        lf
+    }
+}
+
 impl LazyFrame {
     pub(crate) fn from_inner(
         logical_plan: DslPlan,
@@ -518,6 +537,55 @@ impl LazyFrame {
         )?;
         let plan = IRPlan::new(node, lp_arena, expr_arena);
         Ok(plan)
+    }
+
+    /// Convert LazyFrame to a template by replacing data sources with placeholders.
+    ///
+    /// This allows serializing the transformation logic without the actual data,
+    /// which can then be applied to different datasets later using `from_template()`.
+    ///
+    /// # Important: Templates are Created from Unoptimized Plans
+    ///
+    /// Templates are intentionally created from **unoptimized** IR plans. This means:
+    /// - Filter nodes remain as separate `IR::Filter` nodes (not pushed into Scans)
+    /// - Projection nodes remain as separate `IR::Select` nodes (not pushed into Scans)
+    /// - All transformation logic is preserved as explicit IR nodes in the template
+    ///
+    /// **Why this matters:**
+    /// If predicates were pushed down into `IR::Scan` nodes (via optimization), they would
+    /// be lost during template conversion because `PlaceholderScan` only preserves schema
+    /// information, not scan-specific metadata like predicates or projection pushdowns.
+    ///
+    /// By keeping the plan unoptimized, all transformations remain separate and are
+    /// correctly preserved in the template.
+    ///
+    /// # Example
+    /// ```ignore
+    /// // Create template from filtered scan
+    /// let template = lf.filter(col("x").gt(lit(5))).to_template()?;
+    ///
+    /// // Filter remains as separate IR::Filter node, so it's preserved
+    /// // When applied to new data, the filter will work correctly
+    /// let result = LazyFrame::from_template(new_data, template)?.collect()?;
+    /// ```
+    ///
+    /// # Multi-DataFrame Templates
+    ///
+    /// Templates can contain multiple placeholders for joins, unions, etc.:
+    /// ```ignore
+    /// let template = left.join(right, ...).to_template()?;
+    /// let result = LazyFrame::from_template(vec![new_left, new_right], template)?;
+    /// ```
+    pub fn to_template(mut self) -> PolarsResult<IRPlan> {
+        // Disable type checking and other validations for template creation
+        // This allows templates to be created from empty LazyFrames with unresolved columns
+        self.opt_state.remove(OptFlags::TYPE_CHECK);
+
+        // Convert to IR without running optimization passes
+        // This is critical: optimization (especially predicate pushdown) would move
+        // filters/projections into Scan nodes, and those would be lost during templating
+        let ir_plan = self.to_alp()?;
+        Ok(ir_plan.to_template())
     }
 
     pub(crate) fn optimize_with_scratch(

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -891,6 +891,7 @@ fn create_physical_plan_impl(
             Ok(Box::new(exec))
         },
         Invalid => unreachable!(),
+        PlaceholderScan { .. } => unreachable!(),
     }
 }
 

--- a/crates/polars-plan/src/plans/ir/dot.rs
+++ b/crates/polars-plan/src/plans/ir/dot.rs
@@ -327,6 +327,7 @@ impl<'a> IRDotDisplay<'a> {
                 write_label(f, id, |f| write!(f, "MERGE_SORTED ON '{key}'",))?;
             },
             Invalid => write_label(f, id, |f| f.write_str("INVALID"))?,
+            PlaceholderScan { .. } => write_label(f, id, |f| f.write_str("PLACEHOLDER"))?,
         }
 
         Ok(())

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -975,6 +975,7 @@ pub fn write_ir_non_recursive(
             key,
         } => write!(f, "{:indent$}MERGE SORTED ON '{key}'", ""),
         IR::Invalid => write!(f, "{:indent$}INVALID", ""),
+        IR::PlaceholderScan { .. } => write!(f, "{:indent$}PLACEHOLDER", ""),
     }
 }
 

--- a/crates/polars-plan/src/plans/ir/inputs.rs
+++ b/crates/polars-plan/src/plans/ir/inputs.rs
@@ -119,6 +119,7 @@ impl IR {
             },
 
             Invalid => unreachable!(),
+            PlaceholderScan { .. } => unreachable!(),
         }
     }
 
@@ -192,6 +193,7 @@ impl IR {
             },
 
             Invalid => unreachable!(),
+            PlaceholderScan { .. } => unreachable!(),
         }
     }
 
@@ -230,6 +232,7 @@ impl IR {
             } => Inputs::Boxed(Box::new(iter::once(*input).chain(contexts.iter().copied()))),
             Scan { .. } => Inputs::Empty,
             DataFrameScan { .. } => Inputs::Empty,
+            PlaceholderScan { .. } => Inputs::Empty,
             #[cfg(feature = "python")]
             PythonScan { .. } => Inputs::Empty,
             #[cfg(feature = "merge_sorted")]
@@ -269,6 +272,7 @@ impl IR {
             } => InputsMut::Boxed(Box::new(iter::once(input).chain(contexts.iter_mut()))),
             Scan { .. } => InputsMut::Empty,
             DataFrameScan { .. } => InputsMut::Empty,
+            PlaceholderScan { .. } => InputsMut::Empty,
             #[cfg(feature = "python")]
             PythonScan { .. } => InputsMut::Empty,
             #[cfg(feature = "merge_sorted")]

--- a/crates/polars-plan/src/plans/ir/mod.rs
+++ b/crates/polars-plan/src/plans/ir/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod tree_format;
 pub mod visualization;
 
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::fmt;
 
 pub use dot::{EscapeLabel, IRDotDisplay, PathsDisplay, ScanSourcesDisplay};
@@ -75,6 +76,13 @@ pub enum IR {
         schema: SchemaRef,
         // Schema of the projected file
         // If `None`, no projection is applied
+        output_schema: Option<SchemaRef>,
+    },
+    /// Placeholder for data source when serializing templates.
+    /// Used for serializing transformation logic without actual data.
+    PlaceholderScan {
+        id: usize,
+        schema: SchemaRef,
         output_schema: Option<SchemaRef>,
     },
     // Only selects columns (semantically only has row access).
@@ -202,6 +210,539 @@ impl IRPlan {
 
     pub fn display_dot(&self) -> dot::IRDotDisplay<'_> {
         self.as_ref().display_dot()
+    }
+
+    /// Convert an IR plan to a template by replacing all data sources with PlaceholderScan nodes.
+    ///
+    /// This traverses the IR tree and replaces:
+    /// - `IR::DataFrameScan` → `IR::PlaceholderScan`
+    /// - `IR::Scan` (CSV, Parquet, etc.) → `IR::PlaceholderScan`
+    /// - `IR::PythonScan` → `IR::PlaceholderScan`
+    ///
+    /// All other IR nodes (Filter, Select, Join, etc.) are preserved as-is.
+    ///
+    /// # Important: Only Use with Unoptimized Plans
+    ///
+    /// This method should only be called on **unoptimized** IR plans where:
+    /// - Predicates remain as separate `IR::Filter` nodes
+    /// - Projections remain as separate `IR::Select` nodes
+    /// - No optimizations have pushed these into Scan nodes
+    ///
+    /// **Why:** `PlaceholderScan` only preserves `schema` and `output_schema`. If a Scan
+    /// node contains pushed-down predicates or projections, those will be silently lost.
+    ///
+    /// The safe usage pattern is:
+    /// ```ignore
+    /// // DSL → IR (no optimization) → template
+    /// let ir_plan = lf.to_alp()?;  // No optimization
+    /// let template = ir_plan.to_template();  // Safe
+    /// ```
+    ///
+    /// **Unsafe pattern** (would lose predicates):
+    /// ```ignore
+    /// // DSL → optimized IR → template
+    /// let ir_plan = lf.to_alp_optimized()?;  // Predicates pushed into Scans
+    /// let template = ir_plan.to_template();  // Predicates would be lost!
+    /// ```
+    pub fn to_template(&self) -> Self {
+        let mut new_arena = Arena::with_capacity(self.lp_arena.len());
+        let mut placeholder_id = 0;
+        let new_top = Self::convert_to_placeholder(self.lp_top, &self.lp_arena, &mut new_arena, &mut placeholder_id);
+        Self {
+            lp_top: new_top,
+            lp_arena: new_arena,
+            expr_arena: self.expr_arena.clone(),
+        }
+    }
+
+    #[recursive::recursive]
+    fn convert_to_placeholder(node: Node, old_arena: &Arena<IR>, new_arena: &mut Arena<IR>, placeholder_id: &mut usize) -> Node {
+        let ir = old_arena.get(node);
+        let new_ir = match ir {
+            IR::DataFrameScan { schema, output_schema, .. } => {
+                let id = *placeholder_id;
+                *placeholder_id += 1;
+                IR::PlaceholderScan {
+                    id,
+                    schema: schema.clone(),
+                    output_schema: output_schema.clone(),
+                }
+            }
+            IR::Scan { file_info, output_schema, .. } => {
+                let id = *placeholder_id;
+                *placeholder_id += 1;
+                IR::PlaceholderScan {
+                    id,
+                    schema: file_info.schema.clone(),
+                    output_schema: output_schema.clone(),
+                }
+            }
+            #[cfg(feature = "python")]
+            IR::PythonScan { options } => {
+                let id = *placeholder_id;
+                *placeholder_id += 1;
+                IR::PlaceholderScan {
+                    id,
+                    schema: options.schema.clone(),
+                    output_schema: options.output_schema.clone(),
+                }
+            }
+            IR::Select { input, expr, schema, options } => {
+                let new_input = Self::convert_to_placeholder(*input, old_arena, new_arena, placeholder_id);
+                IR::Select {
+                    input: new_input,
+                    expr: expr.clone(),
+                    schema: schema.clone(),
+                    options: *options,
+                }
+            }
+            IR::Filter { input, predicate } => {
+                let new_input = Self::convert_to_placeholder(*input, old_arena, new_arena, placeholder_id);
+                IR::Filter {
+                    input: new_input,
+                    predicate: predicate.clone(),
+                }
+            }
+            IR::Slice { input, offset, len } => {
+                let new_input = Self::convert_to_placeholder(*input, old_arena, new_arena, placeholder_id);
+                IR::Slice {
+                    input: new_input,
+                    offset: *offset,
+                    len: *len,
+                }
+            }
+            IR::GroupBy { input, keys, aggs, schema, maintain_order, options, apply } => {
+                let new_input = Self::convert_to_placeholder(*input, old_arena, new_arena, placeholder_id);
+                IR::GroupBy {
+                    input: new_input,
+                    keys: keys.clone(),
+                    aggs: aggs.clone(),
+                    schema: schema.clone(),
+                    maintain_order: *maintain_order,
+                    options: options.clone(),
+                    apply: apply.clone(),
+                }
+            }
+            IR::Join { input_left, input_right, schema, left_on, right_on, options } => {
+                let new_left = Self::convert_to_placeholder(*input_left, old_arena, new_arena, placeholder_id);
+                let new_right = Self::convert_to_placeholder(*input_right, old_arena, new_arena, placeholder_id);
+                IR::Join {
+                    input_left: new_left,
+                    input_right: new_right,
+                    schema: schema.clone(),
+                    left_on: left_on.clone(),
+                    right_on: right_on.clone(),
+                    options: options.clone(),
+                }
+            }
+            IR::HStack { input, exprs, schema, options } => {
+                let new_input = Self::convert_to_placeholder(*input, old_arena, new_arena, placeholder_id);
+                IR::HStack {
+                    input: new_input,
+                    exprs: exprs.clone(),
+                    schema: schema.clone(),
+                    options: *options,
+                }
+            }
+            IR::SimpleProjection { input, columns } => {
+                let new_input = Self::convert_to_placeholder(*input, old_arena, new_arena, placeholder_id);
+                IR::SimpleProjection {
+                    input: new_input,
+                    columns: columns.clone(),
+                }
+            }
+            IR::Sort { input, by_column, slice, sort_options } => {
+                let new_input = Self::convert_to_placeholder(*input, old_arena, new_arena, placeholder_id);
+                IR::Sort {
+                    input: new_input,
+                    by_column: by_column.clone(),
+                    slice: *slice,
+                    sort_options: sort_options.clone(),
+                }
+            }
+            IR::Distinct { input, options } => {
+                let new_input = Self::convert_to_placeholder(*input, old_arena, new_arena, placeholder_id);
+                IR::Distinct {
+                    input: new_input,
+                    options: options.clone(),
+                }
+            }
+            IR::MapFunction { input, function } => {
+                let new_input = Self::convert_to_placeholder(*input, old_arena, new_arena, placeholder_id);
+                IR::MapFunction {
+                    input: new_input,
+                    function: function.clone(),
+                }
+            }
+            IR::Cache { input, id } => {
+                let new_input = Self::convert_to_placeholder(*input, old_arena, new_arena, placeholder_id);
+                IR::Cache {
+                    input: new_input,
+                    id: *id,
+                }
+            }
+            IR::Union { inputs, options } => {
+                let new_inputs: Vec<_> = inputs
+                    .iter()
+                    .map(|&input| Self::convert_to_placeholder(input, old_arena, new_arena, placeholder_id))
+                    .collect();
+                IR::Union {
+                    inputs: new_inputs,
+                    options: options.clone(),
+                }
+            }
+            IR::HConcat { inputs, schema, options } => {
+                let new_inputs: Vec<_> = inputs
+                    .iter()
+                    .map(|&input| Self::convert_to_placeholder(input, old_arena, new_arena, placeholder_id))
+                    .collect();
+                IR::HConcat {
+                    inputs: new_inputs,
+                    schema: schema.clone(),
+                    options: options.clone(),
+                }
+            }
+            IR::ExtContext { input, contexts, schema } => {
+                let new_input = Self::convert_to_placeholder(*input, old_arena, new_arena, placeholder_id);
+                let new_contexts: Vec<_> = contexts
+                    .iter()
+                    .map(|&ctx| Self::convert_to_placeholder(ctx, old_arena, new_arena, placeholder_id))
+                    .collect();
+                IR::ExtContext {
+                    input: new_input,
+                    contexts: new_contexts,
+                    schema: schema.clone(),
+                }
+            }
+            IR::Sink { input, payload } => {
+                let new_input = Self::convert_to_placeholder(*input, old_arena, new_arena, placeholder_id);
+                IR::Sink {
+                    input: new_input,
+                    payload: payload.clone(),
+                }
+            }
+            IR::SinkMultiple { inputs } => {
+                let new_inputs: Vec<_> = inputs
+                    .iter()
+                    .map(|&input| Self::convert_to_placeholder(input, old_arena, new_arena, placeholder_id))
+                    .collect();
+                IR::SinkMultiple {
+                    inputs: new_inputs,
+                }
+            }
+            #[cfg(feature = "merge_sorted")]
+            IR::MergeSorted { input_left, input_right, key } => {
+                let new_left = Self::convert_to_placeholder(*input_left, old_arena, new_arena, placeholder_id);
+                let new_right = Self::convert_to_placeholder(*input_right, old_arena, new_arena, placeholder_id);
+                IR::MergeSorted {
+                    input_left: new_left,
+                    input_right: new_right,
+                    key: key.clone(),
+                }
+            }
+            // Nodes without inputs - just clone them
+            IR::PlaceholderScan { .. } => ir.clone(),
+            IR::Invalid => ir.clone(),
+        };
+        new_arena.add(new_ir)
+    }
+
+    pub fn bind_data(&self, data_map: HashMap<usize, Node>, data_arena: &Arena<IR>) -> PolarsResult<Self> {
+        let mut new_arena = Arena::with_capacity(self.lp_arena.len());
+        let new_top = Self::replace_placeholder(self.lp_top, &data_map, data_arena, &self.lp_arena, &mut new_arena)?;
+        Ok(Self {
+            lp_top: new_top,
+            lp_arena: new_arena,
+            expr_arena: self.expr_arena.clone(),
+        })
+    }
+
+    pub fn bind_to_df(&self, df: Arc<DataFrame>) -> PolarsResult<Self> {
+        // Validate that the template has exactly one placeholder
+        let placeholder_count = self.count_placeholders();
+        if placeholder_count != 1 {
+            polars_bail!(ComputeError:
+                "bind_to_df expects a template with exactly 1 placeholder, but found {}",
+                placeholder_count
+            );
+        }
+
+        let schema = df.schema().clone();
+        let mut data_arena = Arena::with_capacity(1);
+        let data_node = data_arena.add(IR::DataFrameScan {
+            df,
+            schema,
+            output_schema: None,
+        });
+        let mut data_map = HashMap::new();
+        data_map.insert(0, data_node);
+        self.bind_data(data_map, &data_arena)
+    }
+
+    pub fn bind_to_dfs(&self, dfs: Vec<Arc<DataFrame>>) -> PolarsResult<Self> {
+        if dfs.is_empty() {
+            polars_bail!(ComputeError: "bind_to_dfs requires at least one DataFrame");
+        }
+
+        // Validate that the number of DataFrames matches the number of placeholders
+        let placeholder_count = self.count_placeholders();
+        if dfs.len() != placeholder_count {
+            polars_bail!(ComputeError:
+                "DataFrame count mismatch: template has {} placeholder{}, but {} DataFrame{} provided",
+                placeholder_count,
+                if placeholder_count == 1 { "" } else { "s" },
+                dfs.len(),
+                if dfs.len() == 1 { "" } else { "s" }
+            );
+        }
+
+        let mut data_arena = Arena::with_capacity(dfs.len());
+        let mut data_map = HashMap::new();
+
+        for (id, df) in dfs.iter().enumerate() {
+            let schema = df.schema().clone();
+            let data_node = data_arena.add(IR::DataFrameScan {
+                df: df.clone(),
+                schema,
+                output_schema: None,
+            });
+            data_map.insert(id, data_node);
+        }
+
+        self.bind_data(data_map, &data_arena)
+    }
+
+    /// Count the number of PlaceholderScan nodes in the IR plan
+    fn count_placeholders(&self) -> usize {
+        self.count_placeholders_recursive(self.lp_top, &self.lp_arena)
+    }
+
+    /// Recursively count PlaceholderScan nodes in the IR tree
+    fn count_placeholders_recursive(&self, node: Node, arena: &Arena<IR>) -> usize {
+        let ir = arena.get(node);
+        match ir {
+            IR::PlaceholderScan { .. } => 1,
+            _ => {
+                // Sum placeholder counts from all input nodes
+                ir.inputs()
+                    .into_iter()
+                    .map(|input| self.count_placeholders_recursive(input, arena))
+                    .sum()
+            }
+        }
+    }
+
+    #[recursive::recursive]
+    fn replace_placeholder(
+        node: Node,
+        data_map: &HashMap<usize, Node>,
+        data_arena: &Arena<IR>,
+        template_arena: &Arena<IR>,
+        new_arena: &mut Arena<IR>,
+    ) -> PolarsResult<Node> {
+        let ir = template_arena.get(node);
+        let new_ir = match ir {
+            IR::PlaceholderScan { id, schema, .. } => {
+                let data_node = data_map.get(id).ok_or_else(|| {
+                    polars_err!(ComputeError: "Placeholder ID {} not found in data map", id)
+                })?;
+
+                let data_ir = data_arena.get(*data_node);
+                let data_schema = match data_ir {
+                    IR::DataFrameScan { schema: data_schema, .. } => data_schema,
+                    _ => polars_bail!(ComputeError: "bind_data requires data to be a DataFrameScan"),
+                };
+
+                // Allow empty schemas to bind to any data (generic templates)
+                if schema.len() > 0 {
+                    if schema.len() != data_schema.len() {
+                        polars_bail!(SchemaMismatch:
+                            "Schema mismatch: template expects {} columns, data has {}",
+                            schema.len(),
+                            data_schema.len()
+                        );
+                    }
+                    // Validate column names and types
+                    for (col_name, dtype) in schema.iter() {
+                        match data_schema.get(col_name) {
+                            Some(data_dtype) if data_dtype == dtype => {},
+                            Some(data_dtype) => polars_bail!(SchemaMismatch:
+                                "Column '{}' type mismatch: template expects {:?}, data has {:?}",
+                                col_name, dtype, data_dtype
+                            ),
+                            None => polars_bail!(SchemaMismatch:
+                                "Column '{}' not found in data schema",
+                                col_name
+                            ),
+                        }
+                    }
+                }
+
+                return Ok(new_arena.add(data_ir.clone()));
+            }
+            IR::Select { input, expr, schema, options } => {
+                let new_input = Self::replace_placeholder(*input, data_map, data_arena, template_arena, new_arena)?;
+                IR::Select {
+                    input: new_input,
+                    expr: expr.clone(),
+                    schema: schema.clone(),
+                    options: *options,
+                }
+            }
+            IR::Filter { input, predicate } => {
+                let new_input = Self::replace_placeholder(*input, data_map, data_arena, template_arena, new_arena)?;
+                IR::Filter {
+                    input: new_input,
+                    predicate: predicate.clone(),
+                }
+            }
+            IR::Slice { input, offset, len } => {
+                let new_input = Self::replace_placeholder(*input, data_map, data_arena, template_arena, new_arena)?;
+                IR::Slice {
+                    input: new_input,
+                    offset: *offset,
+                    len: *len,
+                }
+            }
+            IR::GroupBy { input, keys, aggs, schema, maintain_order, options, apply } => {
+                let new_input = Self::replace_placeholder(*input, data_map, data_arena, template_arena, new_arena)?;
+                IR::GroupBy {
+                    input: new_input,
+                    keys: keys.clone(),
+                    aggs: aggs.clone(),
+                    schema: schema.clone(),
+                    maintain_order: *maintain_order,
+                    options: options.clone(),
+                    apply: apply.clone(),
+                }
+            }
+            IR::Join { input_left, input_right, schema, left_on, right_on, options } => {
+                let new_left = Self::replace_placeholder(*input_left, data_map, data_arena, template_arena, new_arena)?;
+                let new_right = Self::replace_placeholder(*input_right, data_map, data_arena, template_arena, new_arena)?;
+                IR::Join {
+                    input_left: new_left,
+                    input_right: new_right,
+                    schema: schema.clone(),
+                    left_on: left_on.clone(),
+                    right_on: right_on.clone(),
+                    options: options.clone(),
+                }
+            }
+            IR::HStack { input, exprs, schema, options } => {
+                let new_input = Self::replace_placeholder(*input, data_map, data_arena, template_arena, new_arena)?;
+                IR::HStack {
+                    input: new_input,
+                    exprs: exprs.clone(),
+                    schema: schema.clone(),
+                    options: *options,
+                }
+            }
+            IR::SimpleProjection { input, columns } => {
+                let new_input = Self::replace_placeholder(*input, data_map, data_arena, template_arena, new_arena)?;
+                IR::SimpleProjection {
+                    input: new_input,
+                    columns: columns.clone(),
+                }
+            }
+            IR::Sort { input, by_column, slice, sort_options } => {
+                let new_input = Self::replace_placeholder(*input, data_map, data_arena, template_arena, new_arena)?;
+                IR::Sort {
+                    input: new_input,
+                    by_column: by_column.clone(),
+                    slice: *slice,
+                    sort_options: sort_options.clone(),
+                }
+            }
+            IR::Distinct { input, options } => {
+                let new_input = Self::replace_placeholder(*input, data_map, data_arena, template_arena, new_arena)?;
+                IR::Distinct {
+                    input: new_input,
+                    options: options.clone(),
+                }
+            }
+            IR::MapFunction { input, function } => {
+                let new_input = Self::replace_placeholder(*input, data_map, data_arena, template_arena, new_arena)?;
+                IR::MapFunction {
+                    input: new_input,
+                    function: function.clone(),
+                }
+            }
+            IR::Cache { input, id } => {
+                let new_input = Self::replace_placeholder(*input, data_map, data_arena, template_arena, new_arena)?;
+                IR::Cache {
+                    input: new_input,
+                    id: *id,
+                }
+            }
+            IR::Union { inputs, options } => {
+                let new_inputs: Vec<_> = inputs
+                    .iter()
+                    .map(|&input| Self::replace_placeholder(input, data_map, data_arena, template_arena, new_arena))
+                    .collect::<PolarsResult<_>>()?;
+                IR::Union {
+                    inputs: new_inputs,
+                    options: options.clone(),
+                }
+            }
+            IR::HConcat { inputs, schema, options } => {
+                let new_inputs: Vec<_> = inputs
+                    .iter()
+                    .map(|&input| Self::replace_placeholder(input, data_map, data_arena, template_arena, new_arena))
+                    .collect::<PolarsResult<_>>()?;
+                IR::HConcat {
+                    inputs: new_inputs,
+                    schema: schema.clone(),
+                    options: options.clone(),
+                }
+            }
+            IR::ExtContext { input, contexts, schema } => {
+                let new_input = Self::replace_placeholder(*input, data_map, data_arena, template_arena, new_arena)?;
+                let new_contexts: Vec<_> = contexts
+                    .iter()
+                    .map(|&ctx| Self::replace_placeholder(ctx, data_map, data_arena, template_arena, new_arena))
+                    .collect::<PolarsResult<_>>()?;
+                IR::ExtContext {
+                    input: new_input,
+                    contexts: new_contexts,
+                    schema: schema.clone(),
+                }
+            }
+            IR::Sink { input, payload } => {
+                let new_input = Self::replace_placeholder(*input, data_map, data_arena, template_arena, new_arena)?;
+                IR::Sink {
+                    input: new_input,
+                    payload: payload.clone(),
+                }
+            }
+            IR::SinkMultiple { inputs } => {
+                let new_inputs: Vec<_> = inputs
+                    .iter()
+                    .map(|&input| Self::replace_placeholder(input, data_map, data_arena, template_arena, new_arena))
+                    .collect::<PolarsResult<_>>()?;
+                IR::SinkMultiple {
+                    inputs: new_inputs,
+                }
+            }
+            #[cfg(feature = "merge_sorted")]
+            IR::MergeSorted { input_left, input_right, key } => {
+                let new_left = Self::replace_placeholder(*input_left, data_map, data_arena, template_arena, new_arena)?;
+                let new_right = Self::replace_placeholder(*input_right, data_map, data_arena, template_arena, new_arena)?;
+                IR::MergeSorted {
+                    input_left: new_left,
+                    input_right: new_right,
+                    key: key.clone(),
+                }
+            }
+            // Nodes without inputs - clone as-is
+            // Note: DataFrameScan/Scan/PythonScan shouldn't appear in templates (they're replaced by PlaceholderScan),
+            // but we handle them explicitly for exhaustiveness checking
+            IR::DataFrameScan { .. } => ir.clone(),
+            IR::Scan { .. } => ir.clone(),
+            #[cfg(feature = "python")]
+            IR::PythonScan { .. } => ir.clone(),
+            IR::Invalid => ir.clone(),
+        };
+        Ok(new_arena.add(new_ir))
     }
 }
 

--- a/crates/polars-plan/src/plans/ir/schema.rs
+++ b/crates/polars-plan/src/plans/ir/schema.rs
@@ -46,6 +46,7 @@ impl IR {
             #[cfg(feature = "merge_sorted")]
             MergeSorted { .. } => "merge_sorted",
             Invalid => "invalid",
+            PlaceholderScan { .. } => "placeholder",
         }
     }
 
@@ -81,6 +82,11 @@ impl IR {
                 ..
             } => output_schema.as_ref().unwrap_or(&file_info.schema),
             DataFrameScan {
+                schema,
+                output_schema,
+                ..
+            } => output_schema.as_ref().unwrap_or(schema),
+            PlaceholderScan {
                 schema,
                 output_schema,
                 ..
@@ -153,6 +159,11 @@ impl IR {
                 ..
             } => output_schema.as_ref().unwrap_or(&file_info.schema).clone(),
             DataFrameScan {
+                schema,
+                output_schema,
+                ..
+            } => output_schema.as_ref().unwrap_or(schema).clone(),
+            PlaceholderScan {
                 schema,
                 output_schema,
                 ..

--- a/crates/polars-plan/src/plans/ir/tree_format.rs
+++ b/crates/polars-plan/src/plans/ir/tree_format.rs
@@ -384,6 +384,7 @@ impl<'a> TreeFmtNode<'a> {
                             .collect(),
                     ),
                     Invalid => ND(wh(h, "INVALID"), vec![]),
+                    PlaceholderScan { .. } => ND(wh(h, "PLACEHOLDER"), vec![]),
                 }
             },
         }

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -654,6 +654,7 @@ impl PredicatePushDown {
                 self.pushdown_and_continue(lp, acc_predicates, lp_arena, expr_arena, false)
             },
             Invalid => unreachable!(),
+            PlaceholderScan { .. } => unreachable!(),
         }
     }
 

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -742,6 +742,7 @@ impl ProjectionPushDown {
                 })
             },
             Invalid => unreachable!(),
+            PlaceholderScan { .. } => unreachable!(),
         }
     }
 

--- a/crates/polars-plan/src/plans/optimizer/set_order/ir_pullup.rs
+++ b/crates/polars-plan/src/plans/optimizer/set_order/ir_pullup.rs
@@ -210,6 +210,7 @@ pub(super) fn pullup_orders(
             },
 
             IR::SinkMultiple { .. } | IR::Invalid => unreachable!(),
+            IR::PlaceholderScan { .. } => unreachable!(),
         }
 
         stack.extend(node_outputs.iter().map(|v| v.0));

--- a/crates/polars-plan/src/plans/optimizer/set_order/ir_pushdown.rs
+++ b/crates/polars-plan/src/plans/optimizer/set_order/ir_pushdown.rs
@@ -313,6 +313,7 @@ pub(super) fn pushdown_orders(
             },
 
             IR::SinkMultiple { .. } | IR::Invalid => unreachable!(),
+            IR::PlaceholderScan { .. } => unreachable!(),
         };
 
         let prev_value = orders.insert(node, node_ordering);

--- a/crates/polars-plan/src/plans/optimizer/sortedness.rs
+++ b/crates/polars-plan/src/plans/optimizer/sortedness.rs
@@ -118,6 +118,7 @@ fn is_sorted_rec(
         IR::MergeSorted { .. } => None,
         IR::Distinct { .. } => None,
         IR::Invalid => unreachable!(),
+        IR::PlaceholderScan { .. } => unreachable!(),
     };
 
     sortedness.insert(root, sorted.clone());

--- a/crates/polars-plan/src/plans/visitor/hash.rs
+++ b/crates/polars-plan/src/plans/visitor/hash.rs
@@ -260,6 +260,7 @@ impl Hash for HashableEqLP<'_> {
                 key.hash(state);
             },
             IR::Invalid => unreachable!(),
+            IR::PlaceholderScan { .. } => unreachable!(),
         }
     }
 }
@@ -579,6 +580,7 @@ impl HashableEqLP<'_> {
             (IR::Invalid, IR::Invalid) => unreachable!(),
             #[cfg(feature = "merge_sorted")]
             (IR::MergeSorted { key: l, .. }, IR::MergeSorted { key: r, .. }) => l == r,
+            (IR::PlaceholderScan { .. }, IR::PlaceholderScan { .. }) => unreachable!(),
             _ => false,
         }
     }

--- a/crates/polars-python/Cargo.toml
+++ b/crates/polars-python/Cargo.toml
@@ -115,6 +115,7 @@ features = [
   "rows",
   "semi_anti_join",
   "serde-lazy",
+  "ir_serde",
   "string_encoding",
   "string_normalize",
   "string_reverse",
@@ -289,6 +290,7 @@ full = [
   "ffi_plugin",
   "polars_cloud_client",
   "new_streaming",
+  "serde_json",
 ]
 
 # we cannot conditionally activate simd

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -719,5 +719,6 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<Py<PyAny>> {
         }
         .into_py_any(py),
         IR::Invalid => Err(PyNotImplementedError::new_err("Invalid")),
+        IR::PlaceholderScan { .. } => Err(PyNotImplementedError::new_err("PlaceholderScan")),
     }
 }

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -1237,6 +1237,7 @@ pub fn lower_ir(
         },
         IR::ExtContext { .. } => todo!(),
         IR::Invalid => unreachable!(),
+        IR::PlaceholderScan { .. } => unreachable!(),
     };
 
     let node_key = phys_sm.insert(PhysNode::new(output_schema, node_kind));

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -535,6 +535,110 @@ class LazyFrame:
 
         return cls._from_pyldf(deserializer(source))
 
+    def to_template(self) -> bytes:
+        """
+        Convert this LazyFrame to a reusable template.
+
+        Replaces all data sources with placeholders, allowing you to serialize
+        just the transformation logic and apply it to different datasets later.
+
+        Returns
+        -------
+        bytes
+            Serialized template that can be applied to different data sources.
+
+        See Also
+        --------
+        from_template : Apply a template to data
+
+        Examples
+        --------
+        >>> template = (
+        ...     pl.LazyFrame()
+        ...     .filter(pl.col("a") > 1)
+        ...     .select(pl.col("b") * 2)
+        ...     .to_template()
+        ... )
+        >>> lf = pl.LazyFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+        >>> result = pl.LazyFrame.from_template(lf, template)
+        """
+        return self._ldf.serialize_template()
+
+    @classmethod
+    def from_template(
+        cls,
+        data: LazyFrame | DataFrame | list[LazyFrame | DataFrame] | tuple[LazyFrame | DataFrame, ...],
+        template: bytes,
+    ) -> LazyFrame:
+        """
+        Create a LazyFrame by applying a template to data.
+
+        Parameters
+        ----------
+        data
+            The LazyFrame or DataFrame to apply the template transformations to.
+            For templates with multiple data sources (e.g., joins), provide a list or tuple
+            of DataFrames/LazyFrames corresponding to each placeholder in the template.
+        template
+            Serialized template bytes from `to_template()`.
+
+        Returns
+        -------
+        LazyFrame
+            A new LazyFrame with the template transformations applied to the data.
+
+        See Also
+        --------
+        to_template : Create a reusable template
+
+        Examples
+        --------
+        Single data source:
+
+        >>> template = (
+        ...     pl.LazyFrame()
+        ...     .filter(pl.col("a") > 1)
+        ...     .select(pl.col("b") * 2)
+        ...     .to_template()
+        ... )
+        >>> lf = pl.LazyFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+        >>> result = pl.LazyFrame.from_template(lf, template).collect()
+
+        Multiple data sources (for joins, unions, etc.):
+
+        >>> left = pl.LazyFrame({"a": [1, 2, 3]})
+        >>> right = pl.LazyFrame({"b": [4, 5, 6]})
+        >>> template = left.join(right, left_on="a", right_on="b").to_template()
+        >>> new_left = pl.DataFrame({"a": [7, 8, 9]})
+        >>> new_right = pl.DataFrame({"b": [10, 11, 12]})
+        >>> result = pl.LazyFrame.from_template([new_left, new_right], template).collect()
+        """
+        from polars.dataframe import DataFrame
+
+        # Handle list/tuple of data sources
+        if isinstance(data, (list, tuple)):
+            dfs = []
+            for item in data:
+                if isinstance(item, LazyFrame):
+                    dfs.append(item.collect())
+                else:
+                    dfs.append(item)
+            # Convert to PyDataFrame objects
+            py_dfs = [df._df for df in dfs]
+            return cls._from_pyldf(
+                PyLazyFrame.deserialize_template_and_bind_multi(template, py_dfs)
+            )
+
+        # Handle single data source
+        if isinstance(data, LazyFrame):
+            df = data.collect()
+        else:
+            df = data
+
+        return cls._from_pyldf(
+            PyLazyFrame.deserialize_template_and_bind(template, df._df)
+        )
+
     @property
     def columns(self) -> list[str]:
         """


### PR DESCRIPTION
# Add LazyFrame Template Serialization

## What This Does

Adds two new methods to `LazyFrame`:
- `to_template()` - saves transformation logic without the data source(s)
- `from_template(data, template)` - applies that logic to new data

This lets you define a transformation pipeline once and reuse it across multiple datasets. **Supports both single and multi-DataFrame operations** (joins, unions, etc.).

## The Problem

Right now if you want to apply the same transformations to different datasets, you either copy-paste the logic everywhere or try to use `serialize()` (which doesn't work because it includes the data source).

```python
# Copy-paste hell
jan_result = pl.scan_csv("jan.csv").filter(pl.col("x") > 5).collect()
feb_result = pl.scan_csv("feb.csv").filter(pl.col("x") > 5).collect()
mar_result = pl.scan_csv("mar.csv").filter(pl.col("x") > 5).collect()
```

## The Solution

### Single DataFrame Operations
```python
# Define once
template = (
    pl.LazyFrame(schema={"x": pl.Int64})
    .filter(pl.col("x") > 5)
    .to_template()
)

# Apply anywhere
jan_result = pl.LazyFrame.from_template(pl.scan_csv("jan.csv"), template).collect()
feb_result = pl.LazyFrame.from_template(pl.scan_csv("feb.csv"), template).collect()
mar_result = pl.LazyFrame.from_template(pl.scan_csv("mar.csv"), template).collect()
```

### Multi-DataFrame Operations (Joins, Unions)
```python
# Define join template once
template = (
    pl.LazyFrame(schema={"id": pl.Int64, "value": pl.Int64})
    .join(
        pl.LazyFrame(schema={"id": pl.Int64, "extra": pl.Int64}),
        on="id",
        how="inner"
    )
    .to_template()
)

# Apply to different dataset pairs
jan_result = pl.LazyFrame.from_template(
    [pl.scan_csv("jan_sales.csv"), pl.scan_csv("jan_customers.csv")],
    template
).collect()

feb_result = pl.LazyFrame.from_template(
    [pl.scan_csv("feb_sales.csv"), pl.scan_csv("feb_customers.csv")],
    template
).collect()
```

## Use Cases

### ML Feature Engineering
Apply the same features to train/test/val sets:

```python
features = (
    pl.LazyFrame(schema={"x": pl.Float64, "y": pl.Float64})
    .with_columns(
        (pl.col("x") ** 2).alias("x_squared"),
        (pl.col("x") * pl.col("y")).alias("interaction"),
        (pl.col("y").log1p()).alias("y_log")
    )
    .to_template()
)

train = pl.LazyFrame.from_template(train_df, features).collect()
test = pl.LazyFrame.from_template(test_df, features).collect()
val = pl.LazyFrame.from_template(val_df, features).collect()
```

### Multi-Tenant Systems with Joins
Same business logic for different clients:

```python
# Define the analytics template once
analytics = (
    pl.LazyFrame(schema={"user_id": pl.Int64, "usage": pl.Float64})
    .join(
        pl.LazyFrame(schema={"user_id": pl.Int64, "tier": pl.Utf8, "rate": pl.Float64}),
        on="user_id"
    )
    .filter(pl.col("tier").is_in(["premium", "enterprise"]))
    .with_columns((pl.col("usage") * pl.col("rate")).alias("cost"))
    .group_by("tier")
    .agg(pl.col("cost").sum())
    .to_template()
)

# Apply to each client's data
client_a_report = pl.LazyFrame.from_template(
    [client_a_usage, client_a_pricing],
    analytics
).collect()

client_b_report = pl.LazyFrame.from_template(
    [client_b_usage, client_b_pricing],
    analytics
).collect()
```

### ETL Pipelines with Union
Combine multiple sources with consistent logic:

```python
# Define transformation for combining regional data
combine_regions = (
    pl.concat([
        pl.LazyFrame(schema={"region": pl.Utf8, "sales": pl.Float64}),
        pl.LazyFrame(schema={"region": pl.Utf8, "sales": pl.Float64}),
        pl.LazyFrame(schema={"region": pl.Utf8, "sales": pl.Float64})
    ])
    .group_by("region")
    .agg(pl.col("sales").sum())
    .sort("sales", descending=True)
    .to_template()
)

# Apply to different time periods
q1 = pl.LazyFrame.from_template(
    [q1_north, q1_south, q1_west],
    combine_regions
).collect()

q2 = pl.LazyFrame.from_template(
    [q2_north, q2_south, q2_west],
    combine_regions
).collect()
```

## Why Not Just Use serialize()?

They solve different problems:

- `serialize()` saves the **entire query** including data sources (file paths, table names, DataFrame refs)
- `to_template()` saves **only the transformations**

When you deserialize a regular serialized LazyFrame, you're still tied to the original data source. Templates can be applied to any compatible data.

## Implementation

### New IR Node: PlaceholderScan

Added a new IR variant that represents a data source placeholder:

```rust
pub enum IR {
    // ... existing variants ...

    /// Placeholder for data source when serializing templates
    PlaceholderScan {
        schema: SchemaRef,
        output_schema: Option<SchemaRef>,
    },
}
```

Each `PlaceholderScan` gets a unique ID, enabling multi-input templates.

### How It Works

**Creating a template:**
1. Walk the IR tree recursively
2. Replace all `DataFrameScan` nodes with `PlaceholderScan` nodes (assigned sequential IDs)
3. Serialize to JSON

**Applying a template:**
1. Deserialize JSON → IRPlan with placeholders
2. Create `DataFrameScan` nodes from the new data (single or multiple)
3. Map each input DataFrame to its corresponding placeholder ID
4. Recursively replace all `PlaceholderScan` nodes with their `DataFrameScan`
5. Validate schemas match