### PR TITLE
ci: Avoid relabelling changes-dsl on every commit

### DIFF
--- a/.github/changes-dsl-labeler-config.yml
+++ b/.github/changes-dsl-labeler-config.yml
@@ -1,3 +1,0 @@
-changes-dsl:
-  - changed-files:
-      - all-globs-to-any-file: 'crates/polars-plan/dsl-schema-hashes.json'

--- a/.github/workflows/changes-dsl-labeler.yml
+++ b/.github/workflows/changes-dsl-labeler.yml
@@ -11,15 +11,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Clear existing label
+      - name: Fetch PR merge commit
         run: |
-          curl -s \
-          -X DELETE \
-          -H 'Accept: application/vnd.github.v3+json' \
-          -H 'Authorization: token ${{ github.token }}' \
-          'https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/labels/changes-dsl' \
-          || true
+          git fetch origin refs/pull/${{ github.event.number }}/merge:pr-merge-commit
 
-      - uses: actions/labeler@v5
-        with:
-          configuration-path: .github/changes-dsl-labeler-config.yml
+      - name: Update label
+        run: |
+          if [ "$(git diff origin/main..pr-merge-commit crates/polars-plan/dsl-schema-hashes.json)" ]; then
+            curl -s \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H 'Authorization: token ${{ github.token }}' \
+            'https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/labels' \
+            -d '{"labels":["changes-dsl"]}' \
+            || true
+          else
+            curl -s \
+            -X DELETE \
+            -H 'Accept: application/vnd.github.v3+json' \
+            -H 'Authorization: token ${{ github.token }}' \
+            'https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/labels/changes-dsl' \
+            || true
+          fi


### PR DESCRIPTION
* Updates the changes-dsl workflow added in https://github.com/pola-rs/polars/pull/25177

This PR updates the workflow to avoid constantly re-adding the label on every commit -

#### Before
<img width="647" height="191" alt="image" src="https://github.com/user-attachments/assets/5fa0d967-2d02-4714-8a5a-a2786ef9733f" />

#### After
<img width="865" height="621" alt="image" src="https://github.com/user-attachments/assets/96fd0b6e-ee9e-4487-98bf-442b1dda3c5d" />
