### PR TITLE
chore: Fix Decimal precision annotation

### DIFF
--- a/py-polars/src/polars/datatypes/classes.py
+++ b/py-polars/src/polars/datatypes/classes.py
@@ -428,7 +428,7 @@ class Decimal(NumericType):
         Number of digits to the right of the decimal point in each number.
     """
 
-    precision: int | None
+    precision: int
     scale: int
 
     def __init__(


### PR DESCRIPTION
On construction the precision if set to None is shifted to 38, so the precision is always non-None.