### PR TITLE
feat(python): Generalize type annotation for `Series` values input

### DIFF
--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -274,7 +274,7 @@ class Series:
     def __init__(
         self,
         name: str | ArrayLike | None = None,
-        values: ArrayLike | None = None,
+        values: ArrayLike | Iterable | None = None,
         dtype: PolarsDataType | None = None,
         *,
         strict: bool = True,


### PR DESCRIPTION
The Series constructor has a code path [that accepts generators](https://github.com/pola-rs/polars/blob/a3474bb4e2de5a6155bae8082e86b19cffa0f72b/py-polars/src/polars/series/series.py#L354), and [that check supports arbitrary iterables](https://github.com/pola-rs/polars/blob/main/py-polars/src/polars/_utils/various.py#L79).