### PR TITLE
fix: Allow `Null` dtype values in `scatter`

### DIFF
--- a/crates/polars-python/src/series/scatter.rs
+++ b/crates/polars-python/src/series/scatter.rs
@@ -35,7 +35,7 @@ fn scatter(mut s: Series, idx: &Series, values: &Series) -> Result<Series, (Seri
     let values = if logical_dtype.is_categorical() || logical_dtype.is_enum() {
         if matches!(
             values.dtype(),
-            DataType::Categorical(_, _) | DataType::Enum(_, _) | DataType::String
+            DataType::Categorical(_, _) | DataType::Enum(_, _) | DataType::String | DataType::Null
         ) {
             match values.strict_cast(&logical_dtype) {
                 Ok(values) => values,

--- a/py-polars/tests/unit/series/test_scatter.py
+++ b/py-polars/tests/unit/series/test_scatter.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars._typing import PolarsDataType
 from polars.exceptions import ComputeError, InvalidOperationError, OutOfBoundsError
 from polars.testing import assert_series_equal
 
@@ -122,3 +123,11 @@ def test_scatter_enum() -> None:
 
     with pytest.raises(InvalidOperationError):
         s.scatter(1, 2)
+
+
+@pytest.mark.parametrize("dtype", [pl.Categorical, pl.Enum(["a", "b"])])
+def test_scatter_null(dtype: PolarsDataType) -> None:
+    s = pl.Series("a", ["a", "b"], dtype=dtype)
+    result = s.scatter(0, None)
+    expected = pl.Series("a", [None, "b"], dtype=dtype)
+    assert_series_equal(result, expected)


### PR DESCRIPTION
Fixes #25244.

`Null` dtypes can be safely cast to any other dtype, this was left out from the scatter casting logic.