### PR TITLE
fix: Improve scalar resolution in row constructor for nested dtypes

### DIFF
--- a/crates/polars-core/src/frame/row/av_buffer.rs
+++ b/crates/polars-core/src/frame/row/av_buffer.rs
@@ -137,7 +137,7 @@ impl<'a> AnyValueBuffer<'a> {
                     let s = Series::from_any_values_and_dtype(
                         PlSmallStr::EMPTY,
                         &[v],
-                        &dt.inner_dtype().unwrap(),
+                        dt.inner_dtype().unwrap(),
                         true,
                     )
                     .ok()?;

--- a/crates/polars-core/src/frame/row/av_buffer.rs
+++ b/crates/polars-core/src/frame/row/av_buffer.rs
@@ -131,8 +131,22 @@ impl<'a> AnyValueBuffer<'a> {
                 builder.append_value(val.extract()?)
             },
             (Null(builder), AnyValue::Null) => builder.append_null(),
-            // Struct and List can be recursive so use AnyValues for that
-            (All(_, vals), v) => vals.push(v.into_static()),
+            (All(dt, vals), v) => {
+                let av = if dt.is_nested() && v.dtype().is_primitive() {
+                    // The builder is nested but the value is scalar. We wrap in a List.
+                    let s = Series::from_any_values_and_dtype(
+                        PlSmallStr::EMPTY,
+                        &[v],
+                        &dt.inner_dtype().unwrap(),
+                        true,
+                    )
+                    .ok()?;
+                    AnyValue::List(s)
+                } else {
+                    v
+                };
+                vals.push(av.into_static());
+            },
 
             // dynamic types
             (String(builder), av) => match av {

--- a/crates/polars-core/src/frame/row/mod.rs
+++ b/crates/polars-core/src/frame/row/mod.rs
@@ -159,7 +159,7 @@ pub fn rows_to_schema_supertypes(
     rows: &[Row],
     infer_schema_length: Option<usize>,
 ) -> PolarsResult<Schema> {
-    let dtypes = rows_to_supertypes(rows, infer_schema_length)?;
+    let dtypes = rows_to_supertypes(rows, infer_schema_length, None)?;
     let schema = dtypes_to_schema(dtypes);
     Ok(schema)
 }
@@ -168,17 +168,48 @@ pub fn rows_to_schema_supertypes(
 pub fn rows_to_supertypes(
     rows: &[Row],
     infer_schema_length: Option<usize>,
+    row_mask: Option<&[bool]>,
 ) -> PolarsResult<Vec<DataType>> {
     polars_ensure!(!rows.is_empty(), NoData: "no rows, cannot infer schema");
 
     let max_infer = infer_schema_length.unwrap_or(rows.len());
 
-    let mut dtypes: Vec<PlIndexSet<DataType>> = vec![PlIndexSet::new(); rows[0].0.len()];
-    for row in rows.iter().take(max_infer) {
-        for (val, dtypes_set) in row.0.iter().zip(dtypes.iter_mut()) {
-            dtypes_set.insert(val.into());
-        }
-    }
+    let row_len = rows[0].0.len();
+    let (count, row_mask) = match row_mask {
+        Some(mask) => {
+            let count = mask.into_iter().filter(|&&b| b).count();
+            // If all items are included in the mask, we can discard it.
+            if count == row_len {
+                (count, None)
+            } else {
+                (count, row_mask)
+            }
+        },
+        None => (row_len, None),
+    };
+    let mut dtypes: Vec<PlIndexSet<DataType>> = vec![PlIndexSet::new(); count];
+
+    match row_mask {
+        Some(mask) => {
+            for row in rows.iter().take(max_infer) {
+                let row_iter = row
+                    .0
+                    .iter()
+                    .zip(mask.into_iter())
+                    .filter_map(|(v, &use_value)| if use_value { Some(v) } else { None });
+                for (val, dtypes_set) in row_iter.zip(dtypes.iter_mut()) {
+                    dtypes_set.insert(val.into());
+                }
+            }
+        },
+        None => {
+            for row in rows.iter().take(max_infer) {
+                for (val, dtypes_set) in row.0.iter().zip(dtypes.iter_mut()) {
+                    dtypes_set.insert(val.into());
+                }
+            }
+        },
+    };
 
     dtypes
         .into_iter()

--- a/crates/polars-core/src/frame/row/mod.rs
+++ b/crates/polars-core/src/frame/row/mod.rs
@@ -177,7 +177,7 @@ pub fn rows_to_supertypes(
     let row_len = rows[0].0.len();
     let (count, row_mask) = match row_mask {
         Some(mask) => {
-            let count = mask.into_iter().filter(|&&b| b).count();
+            let count = mask.iter().filter(|&&b| b).count();
             // If all items are included in the mask, we can discard it.
             if count == row_len {
                 (count, None)
@@ -195,7 +195,7 @@ pub fn rows_to_supertypes(
                 let row_iter = row
                     .0
                     .iter()
-                    .zip(mask.into_iter())
+                    .zip(mask.iter())
                     .filter_map(|(v, &use_value)| if use_value { Some(v) } else { None });
                 for (val, dtypes_set) in row_iter.zip(dtypes.iter_mut()) {
                     dtypes_set.insert(val.into());

--- a/py-polars/tests/unit/dataframe/test_from_dict.py
+++ b/py-polars/tests/unit/dataframe/test_from_dict.py
@@ -257,8 +257,8 @@ def test_from_dict_cast_logical_type(dtype: pl.DataType, data: Any) -> None:
     assert_frame_equal(df_from_dicts, df)
 
 
-def test_from_dict_upcast_scalars() -> None:
-    dicts = [
+def test_from_dict_upcast_scalars_25232() -> None:
+    dicts: list[dict[str, int | float | list[float]]] = [
         {
             "a": 0,
             "b": 0.64134,

--- a/py-polars/tests/unit/dataframe/test_from_dict.py
+++ b/py-polars/tests/unit/dataframe/test_from_dict.py
@@ -255,3 +255,24 @@ def test_from_dict_cast_logical_type(dtype: pl.DataType, data: Any) -> None:
     )
 
     assert_frame_equal(df_from_dicts, df)
+
+
+def test_from_dict_upcast_scalars() -> None:
+    dicts = [
+        {
+            "a": 0,
+            "b": 0.64134,
+        },
+        {
+            "b": [0.522672, 0.706087],
+        },
+    ]
+    override_schema = {
+        "b": pl.List(pl.Float64),
+    }
+
+    result = pl.from_dicts(dicts, schema_overrides=override_schema)
+    expected = pl.DataFrame(
+        {"a": [0, None], "b": pl.Series([[0.64134], [0.522672, 0.706087]])}
+    )
+    assert_frame_equal(result, expected)


### PR DESCRIPTION
Fixes #25232. Two fixes were required to resolve this:

1. Only infer unknown dtypes in the row constructor. There was a `TODO!` note for this already. I'm not sure if this is the best way to do it, but I added an optional row mask to `rows_to_supertypes` which, if present, only determines the dtypes for the masked columns.
2. In the `AnyValueBuffer`, if the builder had an `All` builder with a nested dtype, and encountered a primitive value, the value would nullified. This fix wraps it in a `List` in that case. I am not sure if I should check for other nested types here or not--I did some tests and it looks like this occurs prior to solidfying the final data type if we're dealing with e.g. arrays or structs.

Updated OP example:

```python
import polars as pl

dicts = [
    {
        "a": 0,
        "b": 0.64134,
    },
    {
        "b": [0.522672, 0.706087],
    },
]
override_schema = {
    "b": pl.List(pl.Float64),
}

df = pl.from_dicts(dicts, schema_overrides=override_schema)
print(df.schema)
```
```
Schema({'a': Int64, 'b': List(Float64)})
```