### PR TITLE
fix(rust): Fix building polars-expr without timezones feature

### DIFF
--- a/crates/polars-expr/src/dispatch/datetime.rs
+++ b/crates/polars-expr/src/dispatch/datetime.rs
@@ -1,9 +1,11 @@
 #[cfg(feature = "timezones")]
 use arrow::legacy::time_zone::Tz;
 use polars_core::error::{PolarsResult, polars_bail};
-use polars_core::prelude::{ArithmeticChunked, Column, IntoColumn, LogicalType, TimeUnit};
+use polars_core::prelude::{
+    ArithmeticChunked, Column, DataType, IntoColumn, LogicalType, TimeUnit,
+};
 #[cfg(feature = "timezones")]
-use polars_core::prelude::{DataType, NonExistent, StringChunked, TimeZone};
+use polars_core::prelude::{NonExistent, StringChunked, TimeZone};
 use polars_time::prelude::*;
 use polars_time::replace_datetime;
 use polars_time::series::TemporalMethods;


### PR DESCRIPTION
Correct feature gating the `DataType` to allow building without
 the "timezones" feature.

Fixes #25148.