### PR TITLE
fix(rust): Fix small bug with `PyExpr` to `PyObject` conversion

### DIFF
--- a/pyo3-polars/pyo3-polars/src/types.rs
+++ b/pyo3-polars/pyo3-polars/src/types.rs
@@ -393,7 +393,7 @@ impl<'py> IntoPyObject<'py> for PyExpr {
             .map_err(|err| {
                 let msg = format!("deserialization failed: {err}");
                 PyValueError::new_err(msg)
-            });
+            })?;
         Ok(instance)
     }
 }


### PR DESCRIPTION
 Fix small bug where pyexpr is not being returned by the function resulting in None being returned