### PR TITLE
feat(python): Raise suitable error on non-integer "n" value for `clear`

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -8863,10 +8863,10 @@ class DataFrame:
         │ null ┆ null ┆ null │
         └──────┴──────┴──────┘
         """
-        if n < 0:
-            msg = f"`n` should be greater than or equal to 0, got {n}"
-            raise ValueError(msg)
-        # faster path
+        if not (is_int := isinstance(n, int)) or n < 0:  # type: ignore[redundant-expr]
+            msg = f"`n` should be an integer >= 0, got {n}"
+            err = TypeError if not is_int else ValueError
+            raise err(msg)
         if n == 0:
             return self._from_pydf(self._df.clear())
         return self.__class__(

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -5149,10 +5149,10 @@ class Series:
             null
         ]
         """
-        if n < 0:
-            msg = f"`n` should be greater than or equal to 0, got {n}"
-            raise ValueError(msg)
-        # faster path
+        if not (is_int := isinstance(n, int)) or n < 0:  # type: ignore[redundant-expr]
+            msg = f"`n` should be an integer >= 0, got {n}"
+            err = TypeError if not is_int else ValueError
+            raise err(msg)
         if n == 0:
             return self._from_pyseries(self._s.clear())
         s = (

--- a/py-polars/tests/unit/operations/test_clear.py
+++ b/py-polars/tests/unit/operations/test_clear.py
@@ -85,11 +85,17 @@ def test_clear_series_object_starting_with_null() -> None:
     assert result.is_empty()
 
 
-def test_clear_raise_negative_n() -> None:
+def test_clear_raise_conditions() -> None:
     s = pl.Series([1, 2, 3])
 
-    msg = "`n` should be greater than or equal to 0, got -1"
+    # negative values
+    msg = "`n` should be an integer >= 0, got -1"
     with pytest.raises(ValueError, match=msg):
         s.clear(-1)
     with pytest.raises(ValueError, match=msg):
         s.to_frame().clear(-1)
+
+    # non-integer values
+    msg = "`n` should be an integer >= 0, got 2.5"
+    with pytest.raises(TypeError, match=msg):
+        s.clear(2.5)  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #25251.

Minor sanitisation; can't have a fractional number of rows.

## Example
```python
import polars as pl

df = pl.DataFrame({
    "a": [None, 2, 3, 4],
    "b": [0.5, None, 2.5, 13],
    "c": [True, True, False, None],
})

df.clear(n=0.75)
# TypeError: `n` should be an integer >= 0, got 0.75

df.clear(n=-100)
# ValueError: `n` should be an integer >= 0, got -100
```