### PR TITLE
fix(python): Run async DB queries with regular `asyncio` if not inside a running loop

### DIFF
--- a/py-polars/src/polars/_typing.py
+++ b/py-polars/src/polars/_typing.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from decimal import Decimal
 
     from sqlalchemy.engine import Connection, Engine
+    from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, AsyncSession
     from sqlalchemy.orm import Session
 
     from polars import DataFrame, Expr, LazyFrame, Series
@@ -299,8 +300,11 @@ class Cursor(BasicCursor):
 
 
 AlchemyConnection: TypeAlias = Union["Connection", "Engine", "Session"]
+AlchemyAsyncConnection: TypeAlias = Union[
+    "AsyncConnection", "AsyncEngine", "AsyncSession"
+]
 ConnectionOrCursor: TypeAlias = Union[
-    BasicConnection, BasicCursor, Cursor, AlchemyConnection
+    BasicConnection, BasicCursor, Cursor, AlchemyConnection, AlchemyAsyncConnection
 ]
 
 # Annotations for `__getitem__` methods

--- a/py-polars/src/polars/io/database/_utils.py
+++ b/py-polars/src/polars/io/database/_utils.py
@@ -29,7 +29,7 @@ def _run_async(co: Coroutine[Any, Any, Any]) -> Any:
         # inside running loop; use vendored `nest_asyncio` (for now)
         import polars._utils.nest_asyncio
 
-        polars._utils.nest_asyncio.apply()
+        polars._utils.nest_asyncio.apply()  # type: ignore[attr-defined]
         return running_loop.run_until_complete(co)
 
 

--- a/py-polars/tests/unit/io/database/test_async.py
+++ b/py-polars/tests/unit/io/database/test_async.py
@@ -212,16 +212,17 @@ def test_async_index_error_25209(tmp_sqlite_db: Path) -> None:
         if_table_exists="replace",
     )
 
-    async def run_async_query() -> pl.DataFrame:
+    async def run_async_query() -> Any:
         async_engine = create_async_engine(f"sqlite+aio{base_uri}")
         try:
             return pl.read_database(
-                query=f"SELECT * FROM {table_name}", connection=async_engine
+                query=f"SELECT * FROM {table_name}",
+                connection=async_engine,
             )
         finally:
             await async_engine.dispose()
 
-    async def testing() -> list[pl.DataFrame]:
+    async def testing() -> Any:
         # return/await multiple queries
         return await asyncio.gather(*(run_async_query(), run_async_query()))
 


### PR DESCRIPTION
Fixes #25209.

If we are not actually inside an existing running loop (eg: in a Jupyter Notebook), we don't need to monkey patch - can simply run "as-is" with regular `asyncio`. This prevents errors when running concurrent queries via `asyncio.gather`.

Also: minor typing improvement to explicitly recognise async SQLAlchemy connections.

(Thanks to @cmdlineluser for the nice/local MWE simplification! 👍)