### PR TITLE
fix: Correct `{first,last}_non_null` if there are empty chunks

### DIFF
--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -1235,18 +1235,18 @@ pub(crate) fn index_to_chunked_index_rev<
 
 pub fn first_non_null<'a, I>(iter: I) -> Option<usize>
 where
-    I: Iterator<Item = Option<&'a Bitmap>>,
+    I: Iterator<Item = &'a dyn Array>,
 {
     let mut offset = 0;
-    for validity in iter {
-        if let Some(mask) = validity {
+    for arr in iter {
+        if let Some(mask) = arr.validity() {
             let len_mask = mask.len();
             let n = mask.leading_zeros();
             if n < len_mask {
                 return Some(offset + n);
             }
             offset += len_mask
-        } else {
+        } else if !arr.is_empty() {
             return Some(offset);
         }
     }
@@ -1255,21 +1255,21 @@ where
 
 pub fn last_non_null<'a, I>(iter: I, len: usize) -> Option<usize>
 where
-    I: DoubleEndedIterator<Item = Option<&'a Bitmap>>,
+    I: DoubleEndedIterator<Item = &'a dyn Array>,
 {
     if len == 0 {
         return None;
     }
     let mut offset = 0;
-    for validity in iter.rev() {
-        if let Some(mask) = validity {
+    for arr in iter.rev() {
+        if let Some(mask) = arr.validity() {
             let len_mask = mask.len();
             let n = mask.trailing_zeros();
             if n < len_mask {
                 return Some(len - offset - n - 1);
             }
             offset += len_mask;
-        } else {
+        } else if !arr.is_empty() {
             return Some(len - offset - 1);
         }
     }

--- a/crates/polars-stream/src/nodes/cum_agg.rs
+++ b/crates/polars-stream/src/nodes/cum_agg.rs
@@ -92,7 +92,7 @@ impl ComputeNode for CumAggNode {
 
                 // Find the last non-null value and set that as the state.
                 let last_non_null_idx = if out.has_nulls() {
-                    last_non_null(out.chunks().iter().map(|c| c.validity()), out.len())
+                    last_non_null(out.chunks().iter().map(|arr| arr.as_ref()), out.len())
                 } else {
                     Some(out.len() - 1)
                 };

--- a/py-polars/tests/unit/operations/test_fill_null.py
+++ b/py-polars/tests/unit/operations/test_fill_null.py
@@ -121,3 +121,25 @@ def test_self_broadcast() -> None:
         pl.Series([None]).fill_null(pl.Series(range(3))),
         pl.Series(range(3)),
     )
+
+
+def test_forward_fill_chunking_25273() -> None:
+    df = pl.DataFrame(
+        {
+            "key": [0, 1, 1],
+            "a": [None, None, 0],
+        }
+    )
+
+    df = df.with_columns(a=pl.concat([pl.col.a.head(1), pl.col.a.tail(2)]))
+    df = df.select(pl.col.a.filter(pl.col.key == 1))
+    df = df.with_columns(ff=pl.col.a.forward_fill())
+    assert_frame_equal(
+        df,
+        pl.DataFrame(
+            {
+                "a": [None, 0],
+                "ff": [None, 0],
+            }
+        ),
+    )

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -2149,7 +2149,7 @@ def test_group_by_drop_nans(s: pl.Series) -> None:
         (pl.Expr.n_unique, True, True),
         (lambda e: e.filter(pl.int_range(0, e.len()) % 3 == 0), True, False),
         (pl.Expr.shift, True, False),
-        # (pl.Expr.forward_fill, True, False), # bug: issue #25273
+        (pl.Expr.forward_fill, True, False),
         (pl.Expr.backward_fill, True, False),
         # (pl.Expr.reverse, True, False), # bug: issue #25269
         (


### PR DESCRIPTION
Fixes #25273.