### PR TITLE
fix: Panic exception when calling `Expr.rolling` in `.over`

### DIFF
--- a/crates/polars-expr/src/expressions/rolling.rs
+++ b/crates/polars-expr/src/expressions/rolling.rs
@@ -131,8 +131,8 @@ impl PhysicalExpr for RollingExpr {
                 let mut data = Vec::with_capacity(num_elements);
                 let mut slices = Vec::with_capacity(groups.len());
                 for i in idx.all() {
-                    data.extend(i.iter().map(|i| index_column_data[*i as usize]));
                     slices.push([data.len() as IdxSize, i.len() as IdxSize]);
+                    data.extend(i.iter().map(|i| index_column_data[*i as usize]));
                 }
                 index_column_data = Cow::Owned(data);
                 (Cow::Owned(slices), false)

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -838,3 +838,22 @@ def test_rolling_in_group_by() -> None:
         .collect(),
         pl.Series("a", [[[[1]], [[1], [1, 2]], [[2], [2, 3]]]]).to_frame(),
     )
+
+
+def test_rolling_in_over_25280() -> None:
+    dates = [
+        "2020-01-01",
+        "2020-01-02",
+    ]
+
+    df = pl.DataFrame(
+        {"dt": dates, "train_line": ["a", "b"], "num_passengers": [3, 7]}
+    ).with_columns(pl.col("dt").str.to_date())
+
+    result = df.with_columns(
+        pl.col("num_passengers")
+        .sum()
+        .rolling(index_column="dt", period="1d")
+        .over("train_line")
+    )
+    assert_frame_equal(df, result)


### PR DESCRIPTION
Fixes #25280.