### PR TITLE
feat: Allow `Expr.unique` on `List`/`Array` with non-numeric types

### DIFF
--- a/crates/polars-core/src/series/implementations/array.rs
+++ b/crates/polars-core/src/series/implementations/array.rs
@@ -232,9 +232,6 @@ impl SeriesTrait for SeriesWrap<ArrayChunked> {
 
     #[cfg(feature = "algorithm_group_by")]
     fn unique(&self) -> PolarsResult<Series> {
-        if !self.inner_dtype().is_primitive_numeric() {
-            polars_bail!(opq = unique, self.dtype());
-        }
         // this can be called in aggregation, so this fast path can be worth a lot
         if self.len() < 2 {
             return Ok(self.0.clone().into_series());
@@ -262,9 +259,6 @@ impl SeriesTrait for SeriesWrap<ArrayChunked> {
 
     #[cfg(feature = "algorithm_group_by")]
     fn arg_unique(&self) -> PolarsResult<IdxCa> {
-        if !self.inner_dtype().is_primitive_numeric() {
-            polars_bail!(opq = arg_unique, self.dtype());
-        }
         // this can be called in aggregation, so this fast path can be worth a lot
         if self.len() == 1 {
             return Ok(IdxCa::new_vec(self.name().clone(), vec![0 as IdxSize]));

--- a/crates/polars-core/src/series/implementations/list.rs
+++ b/crates/polars-core/src/series/implementations/list.rs
@@ -211,9 +211,6 @@ impl SeriesTrait for SeriesWrap<ListChunked> {
 
     #[cfg(feature = "algorithm_group_by")]
     fn unique(&self) -> PolarsResult<Series> {
-        if !self.inner_dtype().is_primitive_numeric() {
-            polars_bail!(opq = unique, self.dtype());
-        }
         // this can be called in aggregation, so this fast path can be worth a lot
         if self.len() < 2 {
             return Ok(self.0.clone().into_series());
@@ -241,9 +238,6 @@ impl SeriesTrait for SeriesWrap<ListChunked> {
 
     #[cfg(feature = "algorithm_group_by")]
     fn arg_unique(&self) -> PolarsResult<IdxCa> {
-        if !self.inner_dtype().is_primitive_numeric() {
-            polars_bail!(opq = arg_unique, self.dtype());
-        }
         // this can be called in aggregation, so this fast path can be worth a lot
         if self.len() == 1 {
             return Ok(IdxCa::new_vec(self.name().clone(), vec![0 as IdxSize]));

--- a/py-polars/tests/unit/operations/unique/test_unique.py
+++ b/py-polars/tests/unit/operations/unique/test_unique.py
@@ -364,3 +364,20 @@ def test_unique_column_subset_25233() -> None:
     result = df.unique(subset="op_type")
     assert result.height == 2
     assert result.select(pl.col.op_type.n_unique()).item() == 2
+
+
+@pytest.mark.parametrize("stable", [False, True])
+def test_unique_list_arr_non_numeric(stable: bool) -> None:
+    assert_series_equal(
+        pl.Series([["A"], ["B"], ["A"]]).unique(maintain_order=stable),
+        pl.Series([["A"], ["B"]]),
+        check_order=stable,
+    )
+
+    assert_series_equal(
+        pl.Series([["A"], ["B"], ["A"]], dtype=pl.Array(pl.String, 1)).unique(
+            maintain_order=stable
+        ),
+        pl.Series([["A"], ["B"]], dtype=pl.Array(pl.String, 1)),
+        check_order=stable,
+    )


### PR DESCRIPTION
This was already supported because of the row-encoding, but just never updated.