### PR TITLE
refactor: Simplify sink parameter passing from Python

### DIFF
--- a/crates/polars-plan/src/dsl/options/mod.rs
+++ b/crates/polars-plan/src/dsl/options/mod.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 mod sink;
-
+pub mod sink2;
 use polars_core::error::PolarsResult;
 use polars_core::prelude::*;
 #[cfg(feature = "csv")]
@@ -29,6 +29,7 @@ use polars_utils::pl_str::PlSmallStr;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 pub use sink::*;
+pub use sink2::*;
 use strum_macros::IntoStaticStr;
 
 use super::{Expr, ExprIR};
@@ -331,6 +332,7 @@ pub struct AnonymousScanOptions {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, strum_macros::IntoStaticStr)]
+/// TODO: Rename to `FileWriteOptions`
 pub enum FileType {
     #[cfg(feature = "parquet")]
     Parquet(ParquetWriteOptions),

--- a/crates/polars-plan/src/dsl/options/sink2.rs
+++ b/crates/polars-plan/src/dsl/options/sink2.rs
@@ -1,0 +1,71 @@
+use polars_io::cloud::CloudOptions;
+use polars_io::utils::sync_on_close::SyncOnCloseType;
+use polars_utils::IdxSize;
+use polars_utils::plpath::{CloudScheme, PlPath};
+
+use super::Expr;
+use super::sink::*;
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, PartialEq)]
+pub enum SinkOutputType {
+    Single(SinkTarget),
+    Multiple(DirectorySinkOptions),
+}
+
+impl SinkOutputType {
+    pub fn cloud_scheme(&self) -> Option<CloudScheme> {
+        match self {
+            Self::Single(x) => match x {
+                SinkTarget::Path(p) => CloudScheme::from_uri(p.to_str()),
+                SinkTarget::Dyn(_) => None,
+            },
+            Self::Multiple(x) => x.cloud_scheme(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, PartialEq)]
+pub struct UnifiedSinkArgs {
+    pub mkdir: bool,
+    pub maintain_order: bool,
+    pub sync_on_close: SyncOnCloseType,
+    pub cloud_options: Option<CloudOptions>,
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, PartialEq)]
+pub struct DirectorySinkOptions {
+    pub base_path: PlPath,
+    pub file_path_provider: Option<PartitionTargetCallback>,
+    pub sink_type: PartitionVariant2,
+    /// TODO: Move this to UnifiedSinkArgs
+    pub finish_callback: Option<SinkFinishCallback>,
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, PartialEq)]
+pub enum PartitionVariant2 {
+    PartitionBy {
+        keys: Vec<Expr>,
+        include_keys: bool,
+        keys_sorted: bool,
+        per_partition_sort_by: Vec<SortColumn>,
+        // TODO: `max_rows_per_file` parameter.
+    },
+    MaxSize {
+        max_rows_per_file: IdxSize,
+        per_file_sort_by: Vec<SortColumn>,
+    },
+}
+
+impl DirectorySinkOptions {
+    pub fn cloud_scheme(&self) -> Option<CloudScheme> {
+        CloudScheme::from_uri(self.base_path.to_str())
+    }
+}

--- a/crates/polars-python/src/functions/io.rs
+++ b/crates/polars-python/src/functions/io.rs
@@ -131,6 +131,7 @@ pub fn write_clipboard_string(s: &str) -> PyResult<()> {
 }
 
 pub fn parse_cloud_options<'a>(
+    // TODO: Take CloudScheme (or CloudType) here instead of an entire path.
     first_path: Option<PlPathRef<'a>>,
     storage_options: Option<Vec<(String, String)>>,
     credential_provider: Option<Py<PyAny>>,

--- a/crates/polars-python/src/io/mod.rs
+++ b/crates/polars-python/src/io/mod.rs
@@ -1,3 +1,6 @@
+pub mod sink_options;
+pub mod sink_output;
+
 use std::sync::Arc;
 
 use polars::prelude::default_values::DefaultFieldValues;
@@ -17,6 +20,8 @@ use pyo3::{Bound, FromPyObject, Py, PyAny, PyResult, intern};
 use crate::PyDataFrame;
 use crate::functions::parse_cloud_options;
 use crate::prelude::Wrap;
+
+// TODO: Move all below code to `scan_options.rs`
 
 /// Interface to `class ScanOptions` on the Python side
 pub struct PyScanOptions<'py>(Bound<'py, pyo3::PyAny>);

--- a/crates/polars-python/src/io/sink_options.rs
+++ b/crates/polars-python/src/io/sink_options.rs
@@ -1,0 +1,63 @@
+use polars::prelude::sync_on_close::SyncOnCloseType;
+use polars::prelude::{CloudScheme, PlPath, UnifiedSinkArgs};
+use pyo3::types::PyAnyMethods;
+use pyo3::{Bound, FromPyObject, Py, PyAny, PyResult};
+
+use crate::functions::parse_cloud_options;
+use crate::prelude::Wrap;
+
+/// Interface to `class SinkOptions` on the Python side
+pub struct PySinkOptions<'py>(Bound<'py, pyo3::PyAny>);
+
+impl<'py> FromPyObject<'py> for PySinkOptions<'py> {
+    fn extract_bound(ob: &Bound<'py, pyo3::PyAny>) -> pyo3::PyResult<Self> {
+        Ok(Self(ob.clone()))
+    }
+}
+
+impl PySinkOptions<'_> {
+    pub fn extract_unified_sink_args(
+        &self,
+        cloud_scheme: Option<CloudScheme>,
+    ) -> PyResult<UnifiedSinkArgs> {
+        #[derive(FromPyObject)]
+        struct Extract {
+            mkdir: bool,
+            maintain_order: bool,
+            sync_on_close: Option<Wrap<SyncOnCloseType>>,
+            storage_options: Option<Vec<(String, String)>>,
+            credential_provider: Option<Py<PyAny>>,
+            retries: usize,
+        }
+
+        let Extract {
+            mkdir,
+            maintain_order,
+            sync_on_close,
+            storage_options,
+            credential_provider,
+            retries,
+        } = self.0.extract()?;
+
+        let cloud_options = parse_cloud_options(
+            cloud_scheme
+                .map(|x| PlPath::new(&x.dummy_uri()))
+                .as_ref()
+                .map(|x| x.as_ref()),
+            storage_options,
+            credential_provider,
+            retries,
+        )?;
+
+        let sync_on_close = sync_on_close.map_or(SyncOnCloseType::default(), |x| x.0);
+
+        let unified_sink_args = UnifiedSinkArgs {
+            mkdir,
+            maintain_order,
+            sync_on_close,
+            cloud_options,
+        };
+
+        Ok(unified_sink_args)
+    }
+}

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -16,13 +16,15 @@ use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
 use pyo3::types::{PyDict, PyDictMethods, PyList};
 
-use super::{PyLazyFrame, PyOptFlags, SinkTarget};
+use super::{PyLazyFrame, PyOptFlags};
 use crate::error::PyPolarsErr;
 use crate::expr::ToExprs;
 use crate::expr::datatype::PyDataTypeExpr;
 use crate::expr::selector::PySelector;
 use crate::interop::arrow::to_rust::pyarrow_schema_to_rust;
 use crate::io::PyScanOptions;
+use crate::io::sink_options::PySinkOptions;
+use crate::io::sink_output::PySinkOutputType;
 use crate::lazyframe::visit::NodeTraverser;
 use crate::prelude::*;
 use crate::utils::{EnterPolarsExt, to_py_err};
@@ -643,22 +645,19 @@ impl PyLazyFrame {
 
     #[cfg(feature = "parquet")]
     #[pyo3(signature = (
-        target, compression, compression_level, statistics, row_group_size, data_page_size,
-        cloud_options, credential_provider, retries, sink_options, metadata, field_overwrites,
+        target, sink_options, compression, compression_level, statistics, row_group_size, data_page_size,
+        metadata, field_overwrites,
     ))]
     fn sink_parquet(
         &self,
         py: Python<'_>,
-        target: SinkTarget,
+        target: PySinkOutputType,
+        sink_options: PySinkOptions,
         compression: &str,
         compression_level: Option<i32>,
         statistics: Wrap<StatisticsOptions>,
         row_group_size: Option<usize>,
         data_page_size: Option<usize>,
-        cloud_options: Option<Vec<(String, String)>>,
-        credential_provider: Option<Py<PyAny>>,
-        retries: usize,
-        sink_options: Wrap<SinkOptions>,
         metadata: Wrap<Option<KeyValueMetadata>>,
         field_overwrites: Vec<Wrap<ParquetFieldOverwrites>>,
     ) -> PyResult<PyLazyFrame> {
@@ -673,39 +672,15 @@ impl PyLazyFrame {
             field_overwrites: field_overwrites.into_iter().map(|f| f.0).collect(),
         };
 
-        let cloud_options = match target.base_path() {
-            None => None,
-            Some(base_path) => {
-                let cloud_options =
-                    parse_cloud_options(base_path.to_str(), cloud_options.unwrap_or_default())?;
-                Some(
-                    cloud_options
-                        .with_max_retries(retries)
-                        .with_credential_provider(
-                            credential_provider.map(polars::prelude::cloud::credential_provider::PlCredentialProvider::from_python_builder),
-                        ),
-                )
-            },
-        };
+        let target = target.extract_sink_output_type()?;
+        let unified_sink_args = sink_options.extract_unified_sink_args(target.cloud_scheme())?;
 
         py.enter_polars(|| {
-            let ldf = self.ldf.read().clone();
-            match target {
-                SinkTarget::File(target) => {
-                    ldf.sink_parquet(target, options, cloud_options, sink_options.0)
-                },
-                SinkTarget::Partition(partition) => ldf.sink_parquet_partitioned(
-                    Arc::new(partition.base_path.0),
-                    partition.file_path_cb.map(PartitionTargetCallback::Python),
-                    partition.variant,
-                    options,
-                    cloud_options,
-                    sink_options.0,
-                    partition.per_partition_sort_by,
-                    partition.finish_callback,
-                ),
-            }
-            .into()
+            self.ldf
+                .read()
+                .clone()
+                .sink2(target, FileType::Parquet(options), unified_sink_args)
+                .into()
         })
         .map(Into::into)
         .map_err(Into::into)
@@ -713,19 +688,15 @@ impl PyLazyFrame {
 
     #[cfg(feature = "ipc")]
     #[pyo3(signature = (
-        target, compression, compat_level, cloud_options, credential_provider, retries,
-        sink_options
+        target, sink_options, compression, compat_level
     ))]
     fn sink_ipc(
         &self,
         py: Python<'_>,
-        target: SinkTarget,
+        target: PySinkOutputType,
+        sink_options: PySinkOptions,
         compression: Wrap<Option<IpcCompression>>,
         compat_level: PyCompatLevel,
-        cloud_options: Option<Vec<(String, String)>>,
-        credential_provider: Option<Py<PyAny>>,
-        retries: usize,
-        sink_options: Wrap<SinkOptions>,
     ) -> PyResult<PyLazyFrame> {
         let options = IpcWriterOptions {
             compression: compression.0,
@@ -733,42 +704,15 @@ impl PyLazyFrame {
             ..Default::default()
         };
 
-        #[cfg(feature = "cloud")]
-        let cloud_options = match target.base_path() {
-            None => None,
-            Some(base_path) => {
-                let cloud_options =
-                    parse_cloud_options(base_path.to_str(), cloud_options.unwrap_or_default())?;
-                Some(
-                    cloud_options
-                        .with_max_retries(retries)
-                        .with_credential_provider(
-                            credential_provider.map(polars::prelude::cloud::credential_provider::PlCredentialProvider::from_python_builder),
-                        ),
-                )
-            },
-        };
-
-        #[cfg(not(feature = "cloud"))]
-        let cloud_options = None;
+        let target = target.extract_sink_output_type()?;
+        let unified_sink_args = sink_options.extract_unified_sink_args(target.cloud_scheme())?;
 
         py.enter_polars(|| {
-            let ldf = self.ldf.read().clone();
-            match target {
-                SinkTarget::File(target) => {
-                    ldf.sink_ipc(target, options, cloud_options, sink_options.0)
-                },
-                SinkTarget::Partition(partition) => ldf.sink_ipc_partitioned(
-                    Arc::new(partition.base_path.0),
-                    partition.file_path_cb.map(PartitionTargetCallback::Python),
-                    partition.variant,
-                    options,
-                    cloud_options,
-                    sink_options.0,
-                    partition.per_partition_sort_by,
-                    partition.finish_callback,
-                ),
-            }
+            self.ldf
+                .read()
+                .clone()
+                .sink2(target, FileType::Ipc(options), unified_sink_args)
+                .into()
         })
         .map(Into::into)
         .map_err(Into::into)
@@ -776,14 +720,15 @@ impl PyLazyFrame {
 
     #[cfg(feature = "csv")]
     #[pyo3(signature = (
-        target, include_bom, include_header, separator, line_terminator, quote_char, batch_size,
+        target, sink_options, include_bom, include_header, separator, line_terminator, quote_char, batch_size,
         datetime_format, date_format, time_format, float_scientific, float_precision, decimal_comma, null_value,
-        quote_style, cloud_options, credential_provider, retries, sink_options
+        quote_style
     ))]
     fn sink_csv(
         &self,
         py: Python<'_>,
-        target: SinkTarget,
+        target: PySinkOutputType,
+        sink_options: PySinkOptions,
         include_bom: bool,
         include_header: bool,
         separator: u8,
@@ -798,10 +743,6 @@ impl PyLazyFrame {
         decimal_comma: bool,
         null_value: Option<String>,
         quote_style: Option<Wrap<QuoteStyle>>,
-        cloud_options: Option<Vec<(String, String)>>,
-        credential_provider: Option<Py<PyAny>>,
-        retries: usize,
-        sink_options: Wrap<SinkOptions>,
     ) -> PyResult<PyLazyFrame> {
         let quote_style = quote_style.map_or(QuoteStyle::default(), |wrap| wrap.0);
         let null_value = null_value.unwrap_or(SerializeOptions::default().null);
@@ -827,42 +768,15 @@ impl PyLazyFrame {
             serialize_options,
         };
 
-        #[cfg(feature = "cloud")]
-        let cloud_options = match target.base_path() {
-            None => None,
-            Some(base_path) => {
-                let cloud_options =
-                    parse_cloud_options(base_path.to_str(), cloud_options.unwrap_or_default())?;
-                Some(
-                    cloud_options
-                        .with_max_retries(retries)
-                        .with_credential_provider(
-                            credential_provider.map(polars::prelude::cloud::credential_provider::PlCredentialProvider::from_python_builder),
-                        ),
-                )
-            },
-        };
-
-        #[cfg(not(feature = "cloud"))]
-        let cloud_options = None;
+        let target = target.extract_sink_output_type()?;
+        let unified_sink_args = sink_options.extract_unified_sink_args(target.cloud_scheme())?;
 
         py.enter_polars(|| {
-            let ldf = self.ldf.read().clone();
-            match target {
-                SinkTarget::File(target) => {
-                    ldf.sink_csv(target, options, cloud_options, sink_options.0)
-                },
-                SinkTarget::Partition(partition) => ldf.sink_csv_partitioned(
-                    Arc::new(partition.base_path.0),
-                    partition.file_path_cb.map(PartitionTargetCallback::Python),
-                    partition.variant,
-                    options,
-                    cloud_options,
-                    sink_options.0,
-                    partition.per_partition_sort_by,
-                    partition.finish_callback,
-                ),
-            }
+            self.ldf
+                .read()
+                .clone()
+                .sink2(target, FileType::Csv(options), unified_sink_args)
+                .into()
         })
         .map(Into::into)
         .map_err(Into::into)
@@ -870,50 +784,24 @@ impl PyLazyFrame {
 
     #[allow(clippy::too_many_arguments)]
     #[cfg(feature = "json")]
-    #[pyo3(signature = (target, cloud_options, credential_provider, retries, sink_options))]
+    #[pyo3(signature = (target, sink_options))]
     fn sink_json(
         &self,
         py: Python<'_>,
-        target: SinkTarget,
-        cloud_options: Option<Vec<(String, String)>>,
-        credential_provider: Option<Py<PyAny>>,
-        retries: usize,
-        sink_options: Wrap<SinkOptions>,
+        target: PySinkOutputType,
+        sink_options: PySinkOptions,
     ) -> PyResult<PyLazyFrame> {
         let options = JsonWriterOptions {};
 
-        let cloud_options = match target.base_path() {
-            None => None,
-            Some(base_path) => {
-                let cloud_options =
-                    parse_cloud_options(base_path.to_str(), cloud_options.unwrap_or_default())?;
-                Some(
-                cloud_options
-                    .with_max_retries(retries)
-                    .with_credential_provider(
-                        credential_provider.map(polars::prelude::cloud::credential_provider::PlCredentialProvider::from_python_builder),
-                    ),
-            )
-            },
-        };
+        let target = target.extract_sink_output_type()?;
+        let unified_sink_args = sink_options.extract_unified_sink_args(target.cloud_scheme())?;
 
         py.enter_polars(|| {
-            let ldf = self.ldf.read().clone();
-            match target {
-                SinkTarget::File(path) => {
-                    ldf.sink_json(path, options, cloud_options, sink_options.0)
-                },
-                SinkTarget::Partition(partition) => ldf.sink_json_partitioned(
-                    Arc::new(partition.base_path.0),
-                    partition.file_path_cb.map(PartitionTargetCallback::Python),
-                    partition.variant,
-                    options,
-                    cloud_options,
-                    sink_options.0,
-                    partition.per_partition_sort_by,
-                    partition.finish_callback,
-                ),
-            }
+            self.ldf
+                .read()
+                .clone()
+                .sink2(target, FileType::Json(options), unified_sink_args)
+                .into()
         })
         .map(Into::into)
         .map_err(Into::into)

--- a/crates/polars-python/src/lazyframe/mod.rs
+++ b/crates/polars-python/src/lazyframe/mod.rs
@@ -16,7 +16,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::pybacked::PyBackedStr;
 use pyo3::types::PyAnyMethods;
 use pyo3::{Bound, FromPyObject, PyAny, PyResult, pyclass};
-pub use sink::{PyPartitioning, SinkTarget};
+pub use sink::PyPartitioning; // TODO: Remove
 
 use crate::prelude::Wrap;
 

--- a/crates/polars-python/src/lazyframe/sink.rs
+++ b/crates/polars-python/src/lazyframe/sink.rs
@@ -17,6 +17,7 @@ use crate::expr::PyExpr;
 use crate::prelude::Wrap;
 
 #[derive(Clone)]
+// TODO: Remove
 pub enum SinkTarget {
     File(polars_plan::dsl::SinkTarget),
     Partition(PyPartitioning),
@@ -187,6 +188,7 @@ impl<'py> FromPyObject<'py> for SinkTarget {
 }
 
 impl SinkTarget {
+    #[expect(unused)]
     pub fn base_path(&self) -> Option<PlPathRef<'_>> {
         match self {
             Self::File(t) => match t {

--- a/crates/polars-utils/src/plpath.rs
+++ b/crates/polars-utils/src/plpath.rs
@@ -3,6 +3,9 @@ use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use crate::format_pl_smallstr;
+use crate::pl_str::PlSmallStr;
+
 /// A Path or URI
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -123,6 +126,13 @@ macro_rules! impl_cloud_scheme {
             pub const fn as_str(&self) -> &'static str {
                 match self {
                     $(Self::$t => $n,)+
+                }
+            }
+
+            /// TODO: This is a temporary hack to satisfy `parse_cloud_options` needing a path. Remove in the future.
+            pub fn dummy_uri(&self) -> PlSmallStr {
+                match self {
+                    $(Self::$t => format_pl_smallstr!("{}://", $n),)+
                 }
             }
         }

--- a/py-polars/src/polars/_plr.pyi
+++ b/py-polars/src/polars/_plr.pyi
@@ -33,7 +33,7 @@ NullValues: TypeAlias = Any
 DataType: TypeAlias = Any
 SyncOnCloseType: TypeAlias = Literal["none", "data", "all"]
 SinkOptions: TypeAlias = dict[str, Any]
-SinkTarget: TypeAlias = str | Any | PyPartitioning
+SinkTarget: TypeAlias = Any
 AsofStrategy: TypeAlias = Literal["backward", "forward", "nearest"]
 InterpolationMethod: TypeAlias = Literal["linear", "nearest"]
 AvroCompression: TypeAlias = Literal["uncompressed", "snappy", "deflate"]
@@ -915,31 +915,26 @@ class PyLazyFrame:
     def sink_parquet(
         self,
         target: SinkTarget,
+        sink_options: Any,
         compression: str,
         compression_level: int | None,
         statistics: StatisticsOptions,
         row_group_size: int | None,
         data_page_size: int | None,
-        cloud_options: dict[str, Any] | None,
-        credential_provider: Any | None,
-        retries: int,
-        sink_options: Any,
         metadata: KeyValueMetadata | None,
         field_overwrites: Sequence[ParquetFieldOverwrites],
     ) -> PyLazyFrame: ...
     def sink_ipc(
         self,
         target: SinkTarget,
+        sink_options: Any,
         compression: IpcCompression | None,
         compat_level: CompatLevel,
-        cloud_options: dict[str, Any] | None,
-        credential_provider: Any | None,
-        retries: int,
-        sink_options: Any,
     ) -> PyLazyFrame: ...
     def sink_csv(
         self,
         target: SinkTarget,
+        sink_options: Any,
         include_bom: bool,
         include_header: bool,
         separator: int,
@@ -954,17 +949,10 @@ class PyLazyFrame:
         decimal_comma: bool,
         null_value: str | None,
         quote_style: QuoteStyle | None,
-        cloud_options: dict[str, Any] | None,
-        credential_provider: Any | None,
-        retries: int,
-        sink_options: Any,
     ) -> PyLazyFrame: ...
     def sink_json(
         self,
         target: SinkTarget,
-        cloud_options: dict[str, Any] | None,
-        credential_provider: Any | None,
-        retries: int,
         sink_options: Any,
     ) -> PyLazyFrame: ...
     def sink_batches(
@@ -2029,37 +2017,6 @@ class PyOptFlags:
     def streaming(self) -> bool: ...
     @streaming.setter
     def streaming(self, value: bool) -> None: ...
-
-class PyPartitioning:
-    def __init__(self) -> None: ...
-    base_path: Any
-
-    @staticmethod
-    def new_max_size(
-        base_path: Any,
-        file_path_cb: Any | None,
-        max_size: int,
-        per_partition_sort_by: Sequence[PyExpr] | None,
-        finish_callback: Any | None,
-    ) -> PyPartitioning: ...
-    @staticmethod
-    def new_by_key(
-        base_path: Any,
-        file_path_cb: Any | None,
-        by: Sequence[PyExpr],
-        include_key: bool,
-        per_partition_sort_by: Sequence[PyExpr] | None,
-        finish_callback: Any | None,
-    ) -> PyPartitioning: ...
-    @staticmethod
-    def new_parted(
-        base_path: Any,
-        file_path_cb: Any | None,
-        by: Sequence[PyExpr],
-        include_key: bool,
-        per_partition_sort_by: Sequence[PyExpr] | None,
-        finish_callback: Any | None,
-    ) -> PyPartitioning: ...
 
 # functions.lazy
 def rolling_corr(

--- a/py-polars/src/polars/_typing.py
+++ b/py-polars/src/polars/_typing.py
@@ -15,7 +15,6 @@ from typing import (
 )
 
 if TYPE_CHECKING:
-    import contextlib
     import sys
     from datetime import date, datetime, time, timedelta
     from decimal import Decimal
@@ -32,9 +31,6 @@ if TYPE_CHECKING:
     from polars.datatypes import DataType, DataTypeClass, IntegerType, TemporalType
     from polars.lazyframe.engine_config import GPUEngine
     from polars.selectors import Selector
-
-    with contextlib.suppress(ImportError):  # Module not available when building docs
-        from polars._plr import PyPartitioning
 
     if sys.version_info >= (3, 10):
         from typing import TypeAlias
@@ -360,18 +356,6 @@ DeprecationType: TypeAlias = Literal[
 ]
 
 
-class PartitioningScheme:
-    def __init__(
-        self,
-        py_partitioning: PyPartitioning,
-    ) -> None:
-        self._py_partitioning = py_partitioning
-
-    @property
-    def _base_path(self) -> str | None:
-        return self._py_partitioning.base_path
-
-
 __all__ = [
     "Ambiguous",
     "ArrowArrayExportable",
@@ -433,7 +417,6 @@ __all__ = [
     "ParallelStrategy",
     "ParametricProfileNames",
     "ParquetCompression",
-    "PartitioningScheme",
     "PivotAgg",
     "PolarsDataType",
     "PolarsIntegerType",

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -163,7 +163,6 @@ if TYPE_CHECKING:
         Orientation,
         ParquetCompression,
         ParquetMetadata,
-        PartitioningScheme,
         PivotAgg,
         PolarsDataType,
         PythonDataType,
@@ -183,6 +182,7 @@ if TYPE_CHECKING:
     from polars._utils.various import NoDefault
     from polars.interchange.dataframe import PolarsDataFrame
     from polars.io.cloud import CredentialProviderFunction
+    from polars.io.partition import _SinkDirectory
     from polars.ml.torch import PolarsDataset
 
     if sys.version_info >= (3, 10):
@@ -4161,7 +4161,7 @@ class DataFrame:
 
             return
 
-        target: str | Path | IO[bytes] | PartitioningScheme = file
+        target: str | Path | IO[bytes] | _SinkDirectory = file
         engine: EngineType = "in-memory"
         if partition_by is not None:
             if not isinstance(file, str):

--- a/py-polars/src/polars/io/cloud/_utils.py
+++ b/py-polars/src/polars/io/cloud/_utils.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Generic, TypeVar
 
-from polars._typing import PartitioningScheme
 from polars._utils.various import is_path_or_str_sequence
+from polars.io.partition import _SinkDirectory
 
 T = TypeVar("T")
 
@@ -40,7 +40,7 @@ def _first_scan_path(
         return source
     elif is_path_or_str_sequence(source) and source:
         return source[0]
-    elif isinstance(source, PartitioningScheme):
+    elif isinstance(source, _SinkDirectory):
         return source._base_path
 
     return None

--- a/py-polars/src/polars/io/partition.py
+++ b/py-polars/src/polars/io/partition.py
@@ -1,23 +1,26 @@
 from __future__ import annotations
 
-import contextlib
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from polars import DataFrame, col
-from polars._typing import PartitioningScheme
+from polars import DataFrame
+from polars._utils.parse.expr import parse_into_list_of_expressions
 from polars._utils.unstable import issue_unstable_warning
-from polars.expr import Expr
 
 if TYPE_CHECKING:
+    import contextlib
+
     with contextlib.suppress(ImportError):  # Module not available when building docs
         from polars._plr import PyDataFrame, PyExpr
 
+    from collections.abc import Sequence
     from typing import IO, Any, Callable
 
-with contextlib.suppress(ImportError):  # Module not available when building docs
-    from polars._plr import PyPartitioning
+    from polars._typing import SyncOnCloseMethod
+    from polars.expr import Expr
+    from polars.io.cloud.credential_provider._builder import CredentialProviderBuilder
 
 
 class KeyedPartition:
@@ -122,10 +125,76 @@ class BasePartitionContext:
     )
 
 
+# TODO: Expose this as Python API (as unstable).
+class _SinkDirectory:
+    def __init__(
+        self,
+        base_path: str | Path,
+        *,
+        file_path_provider: Callable[
+            [KeyedPartitionContext], Path | str | IO[bytes] | IO[str]
+        ]
+        | None = None,
+        partition_by: str
+        | Expr
+        | Sequence[str | Expr]
+        | Mapping[str, Expr]
+        | None = None,
+        partition_keys_sorted: bool | None = None,
+        include_keys: bool | None = None,
+        per_partition_sort_by: str | Expr | Sequence[str | Expr] | None = None,
+        per_file_sort_by: str | Expr | Sequence[str | Expr] | None = None,
+        max_rows_per_file: int | None = None,
+        finish_callback: Callable[[DataFrame], None] | None = None,
+    ) -> None:
+        base_path = str(base_path)
+
+        self._pl_sink_directory = _SinkDirectoryInner(
+            base_path=base_path,
+            file_path_provider=file_path_provider,
+            partition_by=(
+                _parse_to_pyexpr_list(partition_by)
+                if partition_by is not None
+                else None
+            ),
+            partition_keys_sorted=partition_keys_sorted,
+            include_keys=include_keys,
+            per_partition_sort_by=(
+                _parse_to_pyexpr_list(per_partition_sort_by)
+                if per_partition_sort_by is not None
+                else None
+            ),
+            per_file_sort_by=(
+                _parse_to_pyexpr_list(per_file_sort_by)
+                if per_file_sort_by is not None
+                else None
+            ),
+            max_rows_per_file=max_rows_per_file,
+            finish_callback=(
+                _prepare_finish_callback(finish_callback)
+                if finish_callback is not None
+                else None
+            ),
+        )
+
+    @property
+    def _base_path(self) -> str | None:
+        return self._pl_sink_directory.base_path
+
+
+def _parse_to_pyexpr_list(
+    exprs_or_columns: str | Expr | Sequence[str | Expr] | Mapping[str, Expr],
+) -> list[PyExpr]:
+    if isinstance(exprs_or_columns, Mapping):
+        return [e.alias(k)._pyexpr for k, e in exprs_or_columns.items()]
+
+    return parse_into_list_of_expressions(exprs_or_columns)
+
+
 def _cast_base_file_path_cb(
     file_path_cb: Callable[[BasePartitionContext], Path | str | IO[bytes] | IO[str]]
     | None,
-) -> Callable[[BasePartitionContext], Path | str | IO[bytes] | IO[str]] | None:
+) -> Callable[[KeyedPartitionContext], Path | str | IO[bytes] | IO[str]] | None:
     if file_path_cb is None:
         return None
     return lambda ctx: file_path_cb(
@@ -160,31 +229,6 @@ def _cast_keyed_file_path_cb(
     )
 
 
-def _prepare_per_partition_sort_by(
-    e: str | Expr | Iterable[str | Expr] | None,
-) -> list[PyExpr] | None:
-    def prepare_one(v: str | Expr) -> PyExpr:
-        if isinstance(v, str):
-            return col(v)._pyexpr
-        elif isinstance(v, Expr):
-            return v._pyexpr
-        else:
-            msg = f"cannot do a per partition sort by for {v!r}"
-            raise TypeError(msg)
-
-    if e is None:
-        return None
-    elif isinstance(e, str):
-        return [col(e)._pyexpr]
-    elif isinstance(e, Expr):
-        return [e._pyexpr]
-    elif isinstance(e, Iterable):
-        return [prepare_one(v) for v in e]
-    else:
-        msg = f"cannot do a per partition sort by for {e!r}"
-        raise TypeError(msg)
-
-
 def _prepare_finish_callback(
     f: Callable[[DataFrame], None] | None,
 ) -> Callable[[PyDataFrame], None] | None:
@@ -198,7 +242,7 @@ def _prepare_finish_callback(
     return cb
 
 
-class PartitionMaxSize(PartitioningScheme):
+class PartitionMaxSize(_SinkDirectory):
     """
     Partitioning scheme to write files with a maximum size.
 
@@ -254,49 +298,23 @@ class PartitionMaxSize(PartitioningScheme):
         file_path: Callable[[BasePartitionContext], Path | str | IO[bytes] | IO[str]]
         | None = None,
         max_size: int,
-        per_partition_sort_by: str | Expr | Iterable[str | Expr] | None = None,
+        per_partition_sort_by: str | Expr | Sequence[str | Expr] | None = None,
         finish_callback: Callable[[DataFrame], None] | None = None,
     ) -> None:
         issue_unstable_warning("partitioning strategies are considered unstable.")
+
+        file_path_provider = _cast_base_file_path_cb(file_path)
+
         super().__init__(
-            PyPartitioning.new_max_size(
-                base_path=base_path,
-                file_path_cb=_cast_base_file_path_cb(file_path),
-                max_size=max_size,
-                per_partition_sort_by=_prepare_per_partition_sort_by(
-                    per_partition_sort_by
-                ),
-                finish_callback=_prepare_finish_callback(finish_callback),
-            )
+            base_path=base_path,
+            file_path_provider=file_path_provider,
+            max_rows_per_file=max_size,
+            finish_callback=finish_callback,
+            per_file_sort_by=per_partition_sort_by,
         )
 
 
-def _lower_by(
-    by: str | Expr | Sequence[str | Expr] | Mapping[str, Expr],
-) -> list[PyExpr]:
-    def to_expr(i: str | Expr) -> Expr:
-        if isinstance(i, str):
-            return col(i)
-        else:
-            return i
-
-    lowered_by: list[PyExpr]
-    if isinstance(by, str):
-        lowered_by = [col(by)._pyexpr]
-    elif isinstance(by, Expr):
-        lowered_by = [by._pyexpr]
-    elif isinstance(by, Sequence):
-        lowered_by = [to_expr(e)._pyexpr for e in by]
-    elif isinstance(by, Mapping):
-        lowered_by = [e.alias(n)._pyexpr for n, e in by.items()]
-    else:
-        msg = "invalid `by` type"
-        raise TypeError(msg)
-
-    return lowered_by
-
-
-class PartitionByKey(PartitioningScheme):
+class PartitionByKey(_SinkDirectory):
     """
     Partitioning scheme to write files split by the values of keys.
 
@@ -382,27 +400,22 @@ class PartitionByKey(PartitioningScheme):
         | None = None,
         by: str | Expr | Sequence[str | Expr] | Mapping[str, Expr],
         include_key: bool = True,
-        per_partition_sort_by: str | Expr | Iterable[str | Expr] | None = None,
+        per_partition_sort_by: str | Expr | Sequence[str | Expr] | None = None,
         finish_callback: Callable[[DataFrame], None] | None = None,
     ) -> None:
         issue_unstable_warning("partitioning strategies are considered unstable.")
 
-        lowered_by = _lower_by(by)
         super().__init__(
-            PyPartitioning.new_by_key(
-                base_path=base_path,
-                file_path_cb=_cast_keyed_file_path_cb(file_path),
-                by=lowered_by,
-                include_key=include_key,
-                per_partition_sort_by=_prepare_per_partition_sort_by(
-                    per_partition_sort_by
-                ),
-                finish_callback=_prepare_finish_callback(finish_callback),
-            )
+            base_path=base_path,
+            file_path_provider=_cast_keyed_file_path_cb(file_path),
+            partition_by=by,
+            include_keys=include_key,
+            per_partition_sort_by=per_partition_sort_by,
+            finish_callback=finish_callback,
         )
 
 
-class PartitionParted(PartitioningScheme):
+class PartitionParted(_SinkDirectory):
     """
     Partitioning scheme to split parted dataframes.
 
@@ -471,21 +484,57 @@ class PartitionParted(PartitioningScheme):
         | None = None,
         by: str | Expr | Sequence[str | Expr] | Mapping[str, Expr],
         include_key: bool = True,
-        per_partition_sort_by: str | Expr | Iterable[str | Expr] | None = None,
+        per_partition_sort_by: str | Expr | Sequence[str | Expr] | None = None,
         finish_callback: Callable[[DataFrame], None] | None = None,
     ) -> None:
         issue_unstable_warning("partitioning strategies are considered unstable.")
 
-        lowered_by = _lower_by(by)
         super().__init__(
-            PyPartitioning.new_by_key(
-                base_path=base_path,
-                file_path_cb=_cast_keyed_file_path_cb(file_path),
-                by=lowered_by,
-                include_key=include_key,
-                per_partition_sort_by=_prepare_per_partition_sort_by(
-                    per_partition_sort_by
-                ),
-                finish_callback=_prepare_finish_callback(finish_callback),
-            )
+            base_path=base_path,
+            file_path_provider=_cast_keyed_file_path_cb(file_path),
+            partition_by=by,
+            partition_keys_sorted=True,
+            include_keys=include_key,
+            per_partition_sort_by=per_partition_sort_by,
+            finish_callback=finish_callback,
         )
+
+
+# TODO: Add `kw_only=True` after 3.9 support dropped
+@dataclass
+class _SinkDirectoryInner:
+    """
+    Holds parsed directory sink options.
+
+    For internal use.
+    """
+
+    base_path: str
+    file_path_provider: (
+        Callable[[KeyedPartitionContext], Path | str | IO[bytes] | IO[str]] | None
+    )
+    partition_by: list[PyExpr] | None
+    partition_keys_sorted: bool | None
+    include_keys: bool | None
+    per_partition_sort_by: list[PyExpr] | None
+    per_file_sort_by: list[PyExpr] | None
+    max_rows_per_file: int | None
+    finish_callback: Callable[[PyDataFrame], None] | None
+
+
+@dataclass
+class _SinkOptions:
+    """
+    Holds sink options that are generic over file / target type.
+
+    For internal use. Most of the options will parse into `UnifiedSinkArgs`.
+    """
+
+    mkdir: bool
+    maintain_order: bool
+    sync_on_close: SyncOnCloseMethod | None = None
+
+    # Cloud
+    storage_options: list[tuple[str, str]] | None = None
+    credential_provider: CredentialProviderBuilder | None = None
+    retries: int = 2

--- a/py-polars/tests/conftest.py
+++ b/py-polars/tests/conftest.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, TypeVar, cast
 import pytest
 
 import polars as pl
-from polars._typing import PartitioningScheme
+from polars.io.partition import _SinkDirectory
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -160,9 +160,7 @@ def _patched_cloud(
 
             def _(lf: pl.LazyFrame, *args: Any, **kwargs: Any) -> pl.LazyFrame | None:
                 # The cloud client sinks to a "placeholder-path".
-                if args[0] == "placeholder-path" or isinstance(
-                    args[0], PartitioningScheme
-                ):
+                if args[0] == "placeholder-path" or isinstance(args[0], _SinkDirectory):
                     prev_lazy = kwargs.get("lazy", False)
                     kwargs["lazy"] = True
                     lf = prev_sink(lf, *args, **kwargs)

--- a/py-polars/tests/unit/io/cloud/test_credential_provider.py
+++ b/py-polars/tests/unit/io/cloud/test_credential_provider.py
@@ -10,7 +10,6 @@ import pytest
 
 import polars as pl
 import polars.io.cloud.credential_provider
-from polars._typing import PartitioningScheme
 from polars.io.cloud._utils import NoPickleOption
 from polars.io.cloud.credential_provider._builder import (
     AutoInit,
@@ -22,6 +21,7 @@ from polars.io.cloud.credential_provider._providers import (
     CachingCredentialProvider,
     UserProvidedGCPToken,
 )
+from polars.io.partition import _SinkDirectory
 
 
 @pytest.mark.parametrize(
@@ -762,7 +762,7 @@ def test_cached_credential_provider_returns_copied_creds() -> None:
     ],
 )
 def test_credential_provider_init_from_partition_target(
-    partition_target: PartitioningScheme,
+    partition_target: _SinkDirectory,
 ) -> None:
     assert isinstance(
         _init_credential_provider_builder(

--- a/py-polars/tests/unit/io/test_partition.py
+++ b/py-polars/tests/unit/io/test_partition.py
@@ -338,10 +338,7 @@ def test_max_size_partition_collect_files(tmp_path: Path) -> None:
     output_files = []
 
     def file_path_cb(ctx: BasePartitionContext) -> Path:
-        print(ctx)
-        print(ctx.full_path)
         output_files.append(ctx.full_path)
-        print(ctx.file_path)
         return ctx.file_path
 
     (io_type["sink"])(


### PR DESCRIPTION
#### Changes in this PR
Python
* Introduce a `SinkDirectory` class and refactors the separate `Partition(Parted|ByKey|MaxSize)` classes to dispatch to this.
  * Eventual goal is to remove `Partition(Parted|ByKey|MaxSize)` entirely in favor of `SinkDirectory`
* Introduce a `SinkOptions` class to hold common parameters for sinking across different target/file types. This holds e.g. cloud options, `mkdir`, `maintain_order`
* Removed `class PartitioningScheme`

Rust
* Removed `LazyFrame::sink_(<file_type>)_partitioned()` functions. In the future we will just have a single function `sink(target_type, file_write_options, unified_sink_args)` (see `fn sink2()` added in this PR).
* Added structs/enum to support future simplification of sink DSL/IR representation

#### Follow-up
* Rename `LazyFrame::sink2` to `LazyFrame::sink`
  * Remove existing `LazyFrame::sink` after IR is updated
  * https://github.com/pola-rs/polars/pull/25308
* [ ] Rename `enum FileType` to `enum FileWriteOptions`
* https://github.com/pola-rs/polars/pull/25304
* https://github.com/pola-rs/polars/pull/25303
