### PR TITLE
fix(rust): Fix building polars-plan with features lazy,concat_str (but no strings)

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_expansion.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_expansion.rs
@@ -110,8 +110,9 @@ fn function_input_wildcard_expansion(function: &FunctionExpr) -> FunctionExpansi
         expand_into_inputs |= matches!(function, F::FfiPlugin { flags, .. } if flags.flags.contains(FunctionFlags::INPUT_WILDCARD_EXPANSION));
         allow_empty_inputs |= matches!(function, F::FfiPlugin { flags, .. } if flags.flags.contains(FunctionFlags::ALLOW_EMPTY_INPUTS));
     }
-    #[cfg(feature = "concat_str")]
+    #[cfg(all(feature = "strings", feature = "concat_str"))]
     {
+        use crate::dsl::StringFunction;
         expand_into_inputs |= matches!(
             function,
             F::StringExpr(StringFunction::ConcatHorizontal { .. })


### PR DESCRIPTION
# Fix compilation error with `concat_str` feature without `strings`

Fixes #25305.

## Changes

Updated the feature gate in `crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_expansion.rs:113` from:

```rust
#[cfg(feature = "concat_str")]
```

to:

```rust
#[cfg(all(feature = "strings", feature = "concat_str"))]
```

## Rationale

- `StringFunction` and `FunctionExpr::StringExpr` require the `strings` feature to exist
- `StringFunction::ConcatHorizontal` requires the `concat_str` feature
- This pattern matches the existing codebase convention (see `crates/polars-plan/src/dsl/functions/concat.rs:3`)
- Without both features, `ConcatHorizontal` expressions cannot be created, so excluding the code block is correct

## Testing

Verified the fix compiles successfully:

```bash
cargo check -p polars -F bench,concat_str
```