### PR TITLE
perf: Return references from `aexpr_to_leaf_names_iter`

### DIFF
--- a/crates/polars-mem-engine/src/scan_predicate/functions.rs
+++ b/crates/polars-mem-engine/src/scan_predicate/functions.rs
@@ -50,7 +50,7 @@ pub fn create_scan_predicate(
 
         for predicate_part in MintermIter::new(predicate.node(), expr_arena) {
             if aexpr_to_leaf_names_iter(predicate_part, expr_arena)
-                .all(|name| hive_schema.contains(&name))
+                .all(|name| hive_schema.contains(name))
             {
                 hive_predicate_parts.push(predicate_part)
             } else {
@@ -113,10 +113,9 @@ pub fn create_scan_predicate(
         hive_predicate = Some(phys_predicate.clone());
     }
 
-    let live_columns = Arc::new(PlIndexSet::from_iter(aexpr_to_leaf_names_iter(
-        predicate.node(),
-        expr_arena,
-    )));
+    let live_columns = Arc::new(PlIndexSet::from_iter(
+        aexpr_to_leaf_names_iter(predicate.node(), expr_arena).cloned(),
+    ));
 
     let mut skip_batch_predicate = None;
 

--- a/crates/polars-plan/src/plans/aexpr/predicates/column_expr.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/column_expr.rs
@@ -38,7 +38,7 @@ pub fn aexpr_to_column_predicates(
     let mut leaf_names = Vec::with_capacity(2);
     for minterm in minterms {
         leaf_names.clear();
-        leaf_names.extend(aexpr_to_leaf_names_iter(minterm, expr_arena));
+        leaf_names.extend(aexpr_to_leaf_names_iter(minterm, expr_arena).cloned());
 
         if leaf_names.len() != 1 {
             is_sumwise_complete = false;

--- a/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
@@ -468,7 +468,7 @@ fn aexpr_to_skip_batch_predicate_rec(
 
     let live_columns = PlIndexMap::from_iter(aexpr_to_leaf_names_iter(e, arena).map(|col| {
         let min_name = format_pl_smallstr!("{col}_min");
-        (col, min_name)
+        (col.clone(), min_name)
     }));
 
     // We cannot do proper equalities for these.

--- a/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
+++ b/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
@@ -102,7 +102,7 @@ pub(super) fn expand_datasets(
                     let mut out: Arc<[PlSmallStr]> =
                         PlHashSet::from_iter(aexpr_to_leaf_names_iter(x.node(), expr_arena))
                             .into_iter()
-                            .filter(|live_col| {
+                            .filter(|&live_col| {
                                 if unified_scan_args
                                     .row_index
                                     .as_ref()
@@ -114,6 +114,7 @@ pub(super) fn expand_datasets(
                                     true
                                 }
                             })
+                            .cloned()
                             .collect();
 
                     Arc::get_mut(&mut out).unwrap().sort_unstable();

--- a/crates/polars-plan/src/plans/optimizer/join_utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/join_utils.rs
@@ -47,7 +47,7 @@ impl ExprOrigin {
             |acc_origin, column_name| {
                 Ok(acc_origin
                     | Self::get_column_origin(
-                        &column_name,
+                        column_name,
                         left_schema,
                         right_schema,
                         suffix,

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
@@ -245,10 +245,10 @@ pub(super) fn process_join(
             .unwrap();
 
             push_left &= matches!(origin, ExprOrigin::Left | ExprOrigin::None)
-                || output_key_to_left_input_map.contains_key(&col_name);
+                || output_key_to_left_input_map.contains_key(col_name);
 
             push_right &= matches!(origin, ExprOrigin::Right | ExprOrigin::None)
-                || output_key_to_right_input_map.contains_key(&col_name);
+                || output_key_to_right_input_map.contains_key(col_name);
         }
 
         // Note: If `push_left` and `push_right` are both `true`, it means the predicate refers only

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/keys.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/keys.rs
@@ -10,17 +10,17 @@ pub(super) fn predicate_to_key(predicate: Node, expr_arena: &Arena<AExpr>) -> Pl
     if let Some(first) = iter.next() {
         if let Some(second) = iter.next() {
             let mut new = String::with_capacity(32 * iter.size_hint().0);
-            new.push_str(&first);
+            new.push_str(first);
             new.push_str(HIDDEN_DELIMITER);
-            new.push_str(&second);
+            new.push_str(second);
 
             for name in iter {
                 new.push_str(HIDDEN_DELIMITER);
-                new.push_str(&name);
+                new.push_str(name);
             }
             return PlSmallStr::from_string(new);
         }
-        first
+        first.clone()
     } else {
         PlSmallStr::from_str(HIDDEN_DELIMITER)
     }

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
@@ -135,7 +135,7 @@ where
     }
     let mut local_predicates = Vec::with_capacity(remove_keys.len());
     for key in remove_keys {
-        if let Some(pred) = acc_predicates.remove(&*key) {
+        if let Some(pred) = acc_predicates.remove(key) {
             local_predicates.push(pred)
         }
     }
@@ -158,7 +158,7 @@ where
     for (key, predicate) in &*acc_predicates {
         let root_names = aexpr_to_leaf_names_iter(predicate.node(), expr_arena);
         for name in root_names {
-            if condition(&name) {
+            if condition(name) {
                 remove_keys.push(key.clone());
                 break;
             }

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/joins.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/joins.rs
@@ -109,13 +109,13 @@ pub(super) fn process_join(
 
     // Add projections required by the join itself
     for expr_ir in left_on.as_slice() {
-        for name in aexpr_to_leaf_names_iter(expr_ir.node(), expr_arena) {
+        for name in aexpr_to_leaf_names_iter(expr_ir.node(), expr_arena).cloned() {
             project_left.insert(name);
         }
     }
 
     for expr_ir in right_on.as_slice() {
-        for name in aexpr_to_leaf_names_iter(expr_ir.node(), expr_arena) {
+        for name in aexpr_to_leaf_names_iter(expr_ir.node(), expr_arena).cloned() {
             project_right.insert(name);
         }
     }

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -245,20 +245,16 @@ where
 
 pub fn aexpr_to_leaf_names_iter(
     node: Node,
-    arena: &Arena<AExpr>,
-) -> impl Iterator<Item = PlSmallStr> + '_ {
+    arena: &'_ Arena<AExpr>,
+) -> impl Iterator<Item = &'_ PlSmallStr> + '_ {
     aexpr_to_column_nodes_iter(node, arena).map(|node| match arena.get(node.0) {
-        AExpr::Column(name) => name.clone(),
+        AExpr::Column(name) => name,
         _ => unreachable!(),
     })
 }
 
 pub fn aexpr_to_leaf_names(node: Node, arena: &Arena<AExpr>) -> Vec<PlSmallStr> {
-    aexpr_to_leaf_names_iter(node, arena).collect()
-}
-
-pub fn aexpr_to_leaf_name(node: Node, arena: &Arena<AExpr>) -> PlSmallStr {
-    aexpr_to_leaf_names_iter(node, arena).next().unwrap()
+    aexpr_to_leaf_names_iter(node, arena).cloned().collect()
 }
 
 /// check if a selection/projection can be done on the downwards schema

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -411,7 +411,9 @@ fn build_fallback_node_with_ctx(
     let input_schema = &ctx.phys_sm[input.node].output_schema;
     let mut select_names: PlHashSet<_> = exprs
         .iter()
-        .flat_map(|expr| polars_plan::utils::aexpr_to_leaf_names_iter(expr.node(), ctx.expr_arena))
+        .flat_map(|expr| {
+            polars_plan::utils::aexpr_to_leaf_names_iter(expr.node(), ctx.expr_arena).cloned()
+        })
         .collect();
     // To keep the length correct we have to ensure we select at least one
     // column.
@@ -422,7 +424,7 @@ fn build_fallback_node_with_ctx(
     }
     let input_stream = if input_schema
         .iter_names()
-        .any(|name| !select_names.contains(name.as_str()))
+        .any(|name| !select_names.contains(name))
     {
         let select_exprs = select_names
             .into_iter()


### PR DESCRIPTION
This should avoid cloning in a few places.