### PR TITLE
refactor(rust): Remove incorrect cast in reduce code

### DIFF
--- a/crates/polars-expr/src/reduce/var_std.rs
+++ b/crates/polars-expr/src/reduce/var_std.rs
@@ -102,17 +102,29 @@ impl<T: PolarsNumericType> Reducer for VarStdReducer<T> {
         &self,
         v: Vec<Self::Value>,
         m: Option<Bitmap>,
-        _dtype: &DataType,
+        dtype: &DataType,
     ) -> PolarsResult<Series> {
         assert!(m.is_none());
-        let ca: Float64Chunked = v
-            .into_iter()
-            .map(|s| {
-                let var = s.finalize(self.ddof);
-                if self.is_std { var.map(f64::sqrt) } else { var }
-            })
-            .collect_ca(PlSmallStr::EMPTY);
-        Ok(ca.into_series())
+        if matches!(dtype, DataType::Float32) {
+            let ca: Float32Chunked = v
+                .into_iter()
+                .map(|s| {
+                    let var = s.finalize(self.ddof);
+                    let out = if self.is_std { var.map(f64::sqrt) } else { var };
+                    out.map(|v| v as f32)
+                })
+                .collect_ca(PlSmallStr::EMPTY);
+            Ok(ca.into_series())
+        } else {
+            let ca: Float64Chunked = v
+                .into_iter()
+                .map(|s| {
+                    let var = s.finalize(self.ddof);
+                    if self.is_std { var.map(f64::sqrt) } else { var }
+                })
+                .collect_ca(PlSmallStr::EMPTY);
+            Ok(ca.into_series())
+        }
     }
 }
 

--- a/crates/polars-stream/src/nodes/reduce.rs
+++ b/crates/polars-stream/src/nodes/reduce.rs
@@ -132,7 +132,7 @@ impl ComputeNode for ReduceNode {
                     .map(|(r, field)| {
                         r.resize(1);
                         r.finalize().map(|s| {
-                            let s = s.with_name(field.name.clone()).cast(&field.dtype).unwrap();
+                            let s = s.with_name(field.name.clone());
                             Column::Scalar(ScalarColumn::unit_scalar_from_series(s))
                         })
                     })


### PR DESCRIPTION
There was an extra cast in the reduce node which shouldn't be there. Only the var/std return type was incorrect so I fixed it in that operator.

This was messing up extension types.