### PR TITLE
fix(rust): AnyValue::to_physical for categoricals

### DIFF
--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -703,10 +703,16 @@ impl<'a> AnyValue<'a> {
             Self::Time(v) => Self::Int64(v),
 
             #[cfg(feature = "dtype-categorical")]
-            Self::Categorical(v, _)
-            | Self::CategoricalOwned(v, _)
-            | Self::Enum(v, _)
-            | Self::EnumOwned(v, _) => Self::UInt32(v),
+            Self::Categorical(v, &ref m)
+            | Self::CategoricalOwned(v, ref m)
+            | Self::Enum(v, &ref m)
+            | Self::EnumOwned(v, ref m) => {
+                match CategoricalPhysical::smallest_physical(m.max_categories()).unwrap() {
+                    CategoricalPhysical::U8 => Self::UInt8(v as u8),
+                    CategoricalPhysical::U16 => Self::UInt16(v as u16),
+                    CategoricalPhysical::U32 => Self::UInt32(v),
+                }
+            },
             Self::List(series) => Self::List(series.to_physical_repr().into_owned()),
 
             #[cfg(feature = "dtype-array")]

--- a/crates/polars-dtype/src/categorical/mapping.rs
+++ b/crates/polars-dtype/src/categorical/mapping.rs
@@ -39,6 +39,10 @@ impl CategoricalMapping {
         &self.hasher
     }
 
+    pub fn max_categories(&self) -> usize {
+        self.max_categories
+    }
+
     pub fn set_max_categories(&mut self, max_categories: usize) {
         assert!(max_categories >= self.num_cats_upper_bound());
         self.max_categories = max_categories

--- a/crates/polars-dtype/src/categorical/mod.rs
+++ b/crates/polars-dtype/src/categorical/mod.rs
@@ -40,11 +40,11 @@ impl CategoricalPhysical {
     }
 
     pub fn smallest_physical(num_cats: usize) -> PolarsResult<Self> {
-        if num_cats < u8::MAX as usize {
+        if num_cats <= u8::MAX as usize {
             Ok(Self::U8)
-        } else if num_cats < u16::MAX as usize {
+        } else if num_cats <= u16::MAX as usize {
             Ok(Self::U16)
-        } else if num_cats < u32::MAX as usize {
+        } else if num_cats <= u32::MAX as usize {
             Ok(Self::U32)
         } else {
             polars_bail!(ComputeError: "attempted to insert more categories than the maximum allowed")


### PR DESCRIPTION
I think we want `Series.to_phys_repr()` to match behavior for `AnyValue::to_physical`. This should help with https://github.com/pola-rs/polars/pull/25298 @mcrumiller .