### PR TITLE
fix: Correct `drop_items` for scalar input

### DIFF
--- a/py-polars/tests/unit/operations/test_drop_nulls.py
+++ b/py-polars/tests/unit/operations/test_drop_nulls.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from hypothesis import given
 
 import polars as pl
@@ -7,14 +8,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
 from polars.testing.parametric import series
 
 
-@given(
-    s=series(
-        allow_null=True,
-        excluded_dtypes=[
-            pl.Struct,  # See: https://github.com/pola-rs/polars/issues/3462
-        ],
-    )
-)
+@given(s=series(allow_null=True))
 def test_drop_nulls_parametric(s: pl.Series) -> None:
     result = s.drop_nulls()
     assert result.len() == s.len() - s.null_count()
@@ -32,3 +26,16 @@ def test_df_drop_nulls_struct() -> None:
 
     expected = df.head(3)
     assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("maintain_order", [False, True])
+def test_drop_nulls_in_agg_25349(maintain_order: bool) -> None:
+    lf = pl.LazyFrame({"a": [1, 2], "b": [None, 1]})
+    q = lf.group_by("a", maintain_order=maintain_order).agg(
+        pl.col.b.first().drop_nulls()
+    )
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame({"a": [1, 2], "b": [[], [1]]}),
+        check_row_order=maintain_order,
+    )


### PR DESCRIPTION
Fixes #25349.