### PR TITLE
feat: Allow `implode` and aggregation in aggregation context

### DIFF
--- a/py-polars/tests/unit/operations/aggregation/test_aggregations.py
+++ b/py-polars/tests/unit/operations/aggregation/test_aggregations.py
@@ -242,12 +242,16 @@ def test_online_variance() -> None:
 def test_implode_and_agg() -> None:
     df = pl.DataFrame({"type": ["water", "fire", "water", "earth"]})
 
-    # this would OOB
-    with pytest.raises(
-        InvalidOperationError,
-        match=r"'implode' followed by an aggregation is not allowed",
-    ):
-        df.group_by("type").agg(pl.col("type").implode().first().alias("foo"))
+    assert_frame_equal(
+        df.group_by("type").agg(pl.col("type").implode().first().alias("foo")),
+        pl.DataFrame(
+            {
+                "type": ["water", "fire", "earth"],
+                "foo": [["water", "water"], ["fire"], ["earth"]],
+            }
+        ),
+        check_row_order=False,
+    )
 
     # implode + function should be allowed in group_by
     assert df.group_by("type", maintain_order=True).agg(

--- a/py-polars/tests/unit/operations/aggregation/test_implode.py
+++ b/py-polars/tests/unit/operations/aggregation/test_implode.py
@@ -1,5 +1,3 @@
-import pytest
-
 import polars as pl
 from polars.testing import assert_frame_equal
 
@@ -14,11 +12,19 @@ def test_implode_22192_22191() -> None:
     }
 
 
-@pytest.mark.parametrize("maintain_order", [False, True])
-def test_implode_agg_lit(maintain_order: bool) -> None:
+def test_implode_agg_lit() -> None:
     assert_frame_equal(
         pl.DataFrame()
         .group_by(pl.lit(1, pl.Int64))
         .agg(x=pl.lit([3]).list.set_union(pl.lit(1).implode())),
         pl.DataFrame({"literal": [1], "x": [[3, 1]]}),
+    )
+
+
+def test_implode_explode_agg() -> None:
+    assert_frame_equal(
+        pl.DataFrame({"a": [1, 2]})
+        .group_by(pl.lit(1, pl.Int64))
+        .agg(pl.col.a.implode().explode().sum()),
+        pl.DataFrame({"literal": [1], "a": [3]}),
     )


### PR DESCRIPTION
This removes the (already previously resolved) limitation that aggregations are not allowed after an `.implode()`.