### PR TITLE
fix: Resolve edge-case with SQL aggregates that have the same name as one of the `GROUP BY` keys

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -1500,7 +1500,7 @@ impl SQLContext {
                         e = (**expr).clone().alias(name.clone());
                     }
                 }
-                // If aggregation name conflicts with a group key,
+                // If aggregation colname conflicts with a group key,
                 // alias it to avoid duplicate/mis-tracked columns
                 if group_by_keys_schema.get(&field.name).is_some() {
                     let alias_name = format!("__POLARS_AGG_{}", field.name);


### PR DESCRIPTION
Fixes #25354.

Edge-case resolving aggregate cols that have the same name as one of the group keys; we just needed to track these internally with a temporary/unique alias so they can be properly resolved, post-aggregation.

**Also:** added a little extra functionality to the new `assert_sql_matches` helper.