### PR TITLE
fix(rust): Optimize projection pushdown through HConcat

### DIFF
--- a/crates/polars-lazy/src/tests/projection_queries.rs
+++ b/crates/polars-lazy/src/tests/projection_queries.rs
@@ -249,10 +249,7 @@ fn test_select_hconcat_pushdown_strict_25263() -> PolarsResult<()> {
     let lp_arena = plan.lp_arena;
 
     assert!(lp_arena.iter(node).all(|(_, plan)| match plan {
-        IR::DataFrameScan {
-            schema,
-            ..
-        } => {
+        IR::DataFrameScan { schema, .. } => {
             // make sure that we don't read any columns from `df_a`
             if schema.contains("a") {
                 panic!("should not have read any columns from `df_a`");

--- a/crates/polars-lazy/src/tests/projection_queries.rs
+++ b/crates/polars-lazy/src/tests/projection_queries.rs
@@ -173,3 +173,102 @@ fn test_coalesce_toggle_projection_pushdown() -> PolarsResult<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_select_hconcat_pushdown_non_strict_25263() -> PolarsResult<()> {
+    let df_a = df![
+        "a" => [1, 2, 2],
+        "b" => [4, 5, 6],
+    ]?
+    .lazy();
+
+    let df_b = df![
+        "d" => [1, 2],
+    ]?
+    .lazy();
+
+    // not strict: we read a single column from `df_a` to ensure that the concat output
+    // has the correct height
+    let lf = concat_lf_horizontal([df_a, df_b], UnionArgs::default())?.select([col("d")]);
+    let plan = lf.clone().to_alp_optimized()?;
+
+    let node = plan.lp_top;
+    let lp_arena = plan.lp_arena;
+
+    assert!(lp_arena.iter(node).all(|(_, plan)| match plan {
+        IR::DataFrameScan {
+            schema,
+            output_schema,
+            ..
+        } => {
+            // make sure that for `df_a` we apply a projection pushdown to only read a single column
+            if schema.contains("a") {
+                assert_eq!(output_schema.as_ref().unwrap().len(), 1);
+            }
+            true
+        },
+        _ => true,
+    }));
+
+    let out = lf.collect()?;
+    assert_eq!(
+        out,
+        df![
+            "d" => [Some(1), Some(2), None]
+        ]?
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_select_hconcat_pushdown_strict_25263() -> PolarsResult<()> {
+    let df_a = df![
+        "a" => [1, 2],
+        "b" => [4, 5],
+    ]?
+    .lazy();
+
+    let df_b = df![
+        "d" => [1, 2],
+    ]?
+    .lazy();
+
+    // strict: we don't read any columns from `df_a`
+    let lf = concat_lf_horizontal(
+        [df_a, df_b],
+        UnionArgs {
+            strict: true,
+            ..Default::default()
+        },
+    )?
+    .select([col("d")]);
+    let plan = lf.clone().to_alp_optimized()?;
+
+    let node = plan.lp_top;
+    let lp_arena = plan.lp_arena;
+
+    assert!(lp_arena.iter(node).all(|(_, plan)| match plan {
+        IR::DataFrameScan {
+            schema,
+            ..
+        } => {
+            // make sure that we don't read any columns from `df_a`
+            if schema.contains("a") {
+                panic!("should not have read any columns from `df_a`");
+            }
+            true
+        },
+        _ => true,
+    }));
+
+    let out = lf.collect()?;
+    assert_eq!(
+        out,
+        df![
+            "d" => [Some(1), Some(2)]
+        ]?
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/25263
by only projecting a single column through HConcat inputs that don't have any column projected.

After this https://github.com/pola-rs/polars/issues/19133 is done, it should actually completely skip those inputs in 'strict' mode.