### PR TITLE
refactor(rust): Add oneshot channel to polars-stream

### DIFF
--- a/crates/polars-stream/src/async_primitives/mod.rs
+++ b/crates/polars-stream/src/async_primitives/mod.rs
@@ -2,6 +2,7 @@ pub mod connector;
 pub mod distributor_channel;
 pub mod linearizer;
 pub mod morsel_linearizer;
+pub mod oneshot_channel;
 pub mod opt_spawned_future;
 pub mod task_parker;
 pub mod wait_group;

--- a/crates/polars-stream/src/async_primitives/oneshot_channel.rs
+++ b/crates/polars-stream/src/async_primitives/oneshot_channel.rs
@@ -1,0 +1,26 @@
+use crate::async_primitives::connector;
+
+pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
+    let (tx, rx) = connector::connector();
+    (Sender { inner: tx }, Receiver { inner: rx })
+}
+
+pub struct Sender<T> {
+    inner: connector::Sender<T>,
+}
+
+impl<T: Send> Sender<T> {
+    pub fn send(mut self, value: T) -> Result<(), connector::SendError<T>> {
+        self.inner.try_send(value)
+    }
+}
+
+pub struct Receiver<T> {
+    inner: connector::Receiver<T>,
+}
+
+impl<T: Send> Receiver<T> {
+    pub async fn recv(mut self) -> Result<T, ()> {
+        self.inner.recv().await
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sources/batch.rs
+++ b/crates/polars-stream/src/nodes/io_sources/batch.rs
@@ -197,7 +197,7 @@ impl FileReader for BatchFnReader {
             _ = file_schema_tx
                 .take()
                 .unwrap()
-                .try_send(self.output_schema.clone().unwrap());
+                .send(self.output_schema.clone().unwrap());
         }
 
         let mut get_batch_state = self
@@ -215,14 +215,13 @@ impl FileReader for BatchFnReader {
         let (mut morsel_sender, morsel_rx) = FileReaderOutputSend::new_serial();
 
         let handle = spawn(TaskPriority::Low, async move {
-            if let Some(mut file_schema_tx) = file_schema_tx {
+            if let Some(file_schema_tx) = file_schema_tx {
                 let opt_df;
 
                 (get_batch_state, opt_df) =
                     GetBatchState::peek(get_batch_state, execution_state.clone()).await?;
 
-                _ = file_schema_tx
-                    .try_send(opt_df.map(|df| df.schema().clone()).unwrap_or_default())
+                _ = file_schema_tx.send(opt_df.map(|df| df.schema().clone()).unwrap_or_default())
             }
 
             let mut seq: u64 = 0;
@@ -253,14 +252,14 @@ impl FileReader for BatchFnReader {
                 seq = seq.saturating_add(1);
             }
 
-            if let Some(mut row_position_on_end_tx) = row_position_on_end_tx {
+            if let Some(row_position_on_end_tx) = row_position_on_end_tx {
                 let n_rows_seen = IdxSize::try_from(n_rows_seen)
                     .map_err(|_| polars_err!(bigidx, ctx = "batch reader", size = n_rows_seen))?;
 
-                _ = row_position_on_end_tx.try_send(n_rows_seen)
+                _ = row_position_on_end_tx.send(n_rows_seen)
             }
 
-            if let Some(mut n_rows_in_file_tx) = n_rows_in_file_tx {
+            if let Some(n_rows_in_file_tx) = n_rows_in_file_tx {
                 if verbose {
                     eprintln!("[BatchFnReader]: read to end for full row count");
                 }
@@ -281,7 +280,7 @@ impl FileReader for BatchFnReader {
                 let n_rows_seen = IdxSize::try_from(n_rows_seen)
                     .map_err(|_| polars_err!(bigidx, ctx = "batch reader", size = n_rows_seen))?;
 
-                _ = n_rows_in_file_tx.try_send(n_rows_seen)
+                _ = n_rows_in_file_tx.send(n_rows_seen)
             }
 
             Ok(())

--- a/crates/polars-stream/src/nodes/io_sources/csv.rs
+++ b/crates/polars-stream/src/nodes/io_sources/csv.rs
@@ -230,8 +230,8 @@ impl FileReader for CsvFileReader {
 
         let inferred_schema = Arc::new(inferred_schema);
 
-        if let Some(mut tx) = file_schema_tx {
-            _ = tx.try_send(inferred_schema.clone())
+        if let Some(tx) = file_schema_tx {
+            _ = tx.send(inferred_schema.clone())
         }
 
         let projection: Vec<usize> = projected_schema
@@ -381,13 +381,13 @@ impl FileReader for CsvFileReader {
                 let row_position = IdxSize::try_from(row_position)
                     .map_err(|_| polars_err!(bigidx, ctx = "csv file", size = row_position))?;
 
-                if let Some(mut n_rows_in_file_tx) = n_rows_in_file_tx {
+                if let Some(n_rows_in_file_tx) = n_rows_in_file_tx {
                     assert!(needs_full_row_count);
-                    _ = n_rows_in_file_tx.try_send(row_position);
+                    _ = n_rows_in_file_tx.send(row_position);
                 }
 
-                if let Some(mut row_position_on_end_tx) = row_position_on_end_tx {
-                    _ = row_position_on_end_tx.try_send(row_position);
+                if let Some(row_position_on_end_tx) = row_position_on_end_tx {
+                    _ = row_position_on_end_tx.send(row_position);
                 }
 
                 Ok(())

--- a/crates/polars-stream/src/nodes/io_sources/ipc.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ipc.rs
@@ -223,17 +223,17 @@ impl FileReader for IpcFileReader {
             None
         };
 
-        if let Some(mut n_rows_in_file_tx) = n_rows_in_file_tx {
-            _ = n_rows_in_file_tx.try_send(self._n_rows_in_file()?);
+        if let Some(n_rows_in_file_tx) = n_rows_in_file_tx {
+            _ = n_rows_in_file_tx.send(self._n_rows_in_file()?);
         }
 
-        if let Some(mut row_position_on_end_tx) = row_position_on_end_tx {
+        if let Some(row_position_on_end_tx) = row_position_on_end_tx {
             _ = row_position_on_end_tx
-                .try_send(self._row_position_after_slice(normalized_pre_slice.clone())?);
+                .send(self._row_position_after_slice(normalized_pre_slice.clone())?);
         }
 
-        if let Some(mut file_schema_tx) = file_schema_tx {
-            _ = file_schema_tx.try_send(file_schema_pl.clone());
+        if let Some(file_schema_tx) = file_schema_tx {
+            _ = file_schema_tx.send(file_schema_pl.clone());
         }
 
         if normalized_pre_slice.as_ref().is_some_and(|x| x.len() == 0) {

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/tasks/reader_starter.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/tasks/reader_starter.rs
@@ -16,7 +16,7 @@ use polars_utils::row_counter::RowCounter;
 use polars_utils::slice_enum::Slice;
 
 use crate::async_executor::{self, AbortOnDropHandle, TaskPriority};
-use crate::async_primitives::connector;
+use crate::async_primitives::oneshot_channel;
 use crate::async_primitives::wait_group::{WaitGroup, WaitToken};
 use crate::nodes::io_sources::multi_scan::components;
 use crate::nodes::io_sources::multi_scan::components::apply_extra_ops::ApplyExtraOps;
@@ -303,7 +303,7 @@ impl ReaderStarter {
 
             let (row_position_on_end_tx, row_position_on_end_rx) =
                 if should_update_row_position && n_rows_in_file.is_none() {
-                    let (tx, rx) = connector::connector();
+                    let (tx, rx) = oneshot_channel::channel();
                     (Some(tx), Some(rx))
                 } else {
                     (None, None)
@@ -359,7 +359,7 @@ impl ReaderStarter {
                     };
 
                     // Note, can be None on the last scan source.
-                    let Some(mut rx) = row_position_on_end_rx else {
+                    let Some(rx) = row_position_on_end_rx else {
                         break;
                     };
 
@@ -495,7 +495,7 @@ async fn start_reader_impl(
     let file_schema_rx = if forbid_extra_columns.is_some() {
         // Upstream should not have any reason to attach this.
         assert!(callbacks.file_schema_tx.is_none());
-        let (tx, rx) = connector::connector();
+        let (tx, rx) = oneshot_channel::channel();
         callbacks.file_schema_tx = Some(tx);
         Some(rx)
     } else {

--- a/crates/polars-stream/src/nodes/io_sources/ndjson/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ndjson/mod.rs
@@ -26,6 +26,7 @@ use super::multi_scan::reader_interface::{BeginReadArgs, FileReader, FileReaderC
 use crate::async_executor::{AbortOnDropHandle, spawn};
 use crate::async_primitives::distributor_channel::distributor_channel;
 use crate::async_primitives::linearizer::Linearizer;
+use crate::async_primitives::oneshot_channel;
 use crate::morsel::SourceToken;
 use crate::nodes::compute_node_prelude::*;
 use crate::nodes::io_sources::multi_scan::reader_interface::Projection;
@@ -93,8 +94,8 @@ impl FileReader for NDJsonFileReader {
         // between the 2 dtypes.
         let schema = projected_schema;
 
-        if let Some(mut tx) = file_schema_tx {
-            _ = tx.try_send(schema.clone())
+        if let Some(tx) = file_schema_tx {
+            _ = tx.send(schema.clone())
         }
 
         let is_negative_slice = matches!(pre_slice, Some(Slice::Negative { .. }));
@@ -121,7 +122,7 @@ impl FileReader for NDJsonFileReader {
         };
 
         let (total_row_count_tx, total_row_count_rx) = if is_negative_slice && row_index.is_some() {
-            let (tx, rx) = tokio::sync::oneshot::channel();
+            let (tx, rx) = oneshot_channel::channel();
             (Some(tx), Some(rx))
         } else {
             (None, None)
@@ -375,7 +376,7 @@ impl FileReader for NDJsonFileReader {
                 eprintln!("[NDJsonFileReader]: line batch processor handles returned");
             }
 
-            if let Some(mut row_position_on_end_tx) = row_position_on_end_tx {
+            if let Some(row_position_on_end_tx) = row_position_on_end_tx {
                 let n = match pre_slice {
                     None => n_rows_skipped.saturating_add(n_rows_processed),
 
@@ -391,7 +392,7 @@ impl FileReader for NDJsonFileReader {
                 let n = IdxSize::try_from(n)
                     .map_err(|_| polars_err!(bigidx, ctx = "ndjson file", size = n))?;
 
-                _ = row_position_on_end_tx.try_send(n);
+                _ = row_position_on_end_tx.send(n);
             }
 
             if let Some(tx) = total_row_count_tx {
@@ -406,7 +407,7 @@ impl FileReader for NDJsonFileReader {
                 _ = tx.send(total_row_count);
             }
 
-            if let Some(mut n_rows_in_file_tx) = n_rows_in_file_tx {
+            if let Some(n_rows_in_file_tx) = n_rows_in_file_tx {
                 let total_row_count = total_row_count.unwrap();
 
                 if verbose {
@@ -416,7 +417,7 @@ impl FileReader for NDJsonFileReader {
                 let num_rows = total_row_count;
                 let num_rows = IdxSize::try_from(num_rows)
                     .map_err(|_| polars_err!(bigidx, ctx = "ndjson file", size = num_rows))?;
-                _ = n_rows_in_file_tx.try_send(num_rows);
+                _ = n_rows_in_file_tx.send(num_rows);
             }
 
             if let Some(handle) = opt_post_process_handle {

--- a/crates/polars-stream/src/nodes/io_sources/ndjson/negative_slice_pass.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ndjson/negative_slice_pass.rs
@@ -12,6 +12,7 @@ use polars_utils::priority::Priority;
 use crate::async_executor;
 use crate::async_executor::AbortOnDropHandle;
 use crate::async_primitives::linearizer::Linearizer;
+use crate::async_primitives::oneshot_channel;
 use crate::morsel::{Morsel, MorselSeq, SourceToken, get_ideal_morsel_size};
 use crate::nodes::io_sources::multi_scan::reader_interface::output::FileReaderOutputSend;
 
@@ -26,7 +27,7 @@ pub struct MorselStreamReverser {
     pub morsel_senders: Vec<FileReaderOutputSend>,
     /// Slice from right to left.
     pub offset_len_rtl: (usize, usize),
-    pub row_index: Option<(RowIndex, tokio::sync::oneshot::Receiver<usize>)>,
+    pub row_index: Option<(RowIndex, oneshot_channel::Receiver<usize>)>,
     pub verbose: bool,
 }
 
@@ -101,7 +102,7 @@ impl MorselStreamReverser {
                 eprintln!("MorselStreamReverser: wait for total row count");
             }
 
-            let Ok(total_count) = total_row_count_rx.await else {
+            let Ok(total_count) = total_row_count_rx.recv().await else {
                 // Errored, or empty file.
                 if verbose {
                     eprintln!("MorselStreamReverser: did not receive total row count, returning");

--- a/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
@@ -164,19 +164,19 @@ impl FileReader for ParquetFileReader {
         // Send all callbacks to unblock the next reader. We can do this immediately as we know
         // the total row count upfront.
 
-        if let Some(mut n_rows_in_file_tx) = n_rows_in_file_tx {
-            _ = n_rows_in_file_tx.try_send(n_rows_in_file);
+        if let Some(n_rows_in_file_tx) = n_rows_in_file_tx {
+            _ = n_rows_in_file_tx.send(n_rows_in_file);
         }
 
         // We are allowed to send this value immediately, even though we haven't "ended" yet
         // (see its definition under FileReaderCallbacks).
-        if let Some(mut row_position_on_end_tx) = row_position_on_end_tx {
+        if let Some(row_position_on_end_tx) = row_position_on_end_tx {
             _ = row_position_on_end_tx
-                .try_send(self._row_position_after_slice(normalized_pre_slice.clone())?);
+                .send(self._row_position_after_slice(normalized_pre_slice.clone())?);
         }
 
-        if let Some(mut file_schema_tx) = file_schema_tx {
-            _ = file_schema_tx.try_send(file_schema.clone());
+        if let Some(file_schema_tx) = file_schema_tx {
+            _ = file_schema_tx.send(file_schema.clone());
         }
 
         if normalized_pre_slice.as_ref().is_some_and(|x| x.len() == 0) {


### PR DESCRIPTION
For places where a `connector()` is being used as a oneshot channel, we now use a dedicated oneshot wrapper.

* Note, tokio's oneshot channel is not used due to an unresolved deadlock issue - https://github.com/pola-rs/polars/pull/21916
