### PR TITLE
fix: Incorrect result in aggregated `first`/`last` with `ignore_nulls`

### DIFF
--- a/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
@@ -135,7 +135,7 @@ impl Series {
                             // All values are null, we have no first non-null.
                             None
                         } else {
-                            Some(leading_zeros)
+                            Some(first + leading_zeros)
                         }
                     })
                     .collect_ca(PlSmallStr::EMPTY)
@@ -432,7 +432,7 @@ impl Series {
                             // All values are null, we have no last non-null.
                             None
                         } else {
-                            Some(len - trailing_zeros - 1)
+                            Some(first + len - trailing_zeros - 1)
                         }
                     })
                     .collect_ca(PlSmallStr::EMPTY)


### PR DESCRIPTION
Fixes #25405.

The index from each group was the within-group index, but we need to offset the index by the group's position. This only occurs in the `GroupsType::Slice` path.