### PR TITLE
fix: Invalid usage of `drop_first` in `to_dummies` when nulls present

### DIFF
--- a/crates/polars-ops/src/series/ops/to_dummies.rs
+++ b/crates/polars-ops/src/series/ops/to_dummies.rs
@@ -30,13 +30,24 @@ impl ToDummies for Series {
     ) -> PolarsResult<DataFrame> {
         let sep = separator.unwrap_or("_");
         let col_name = self.name();
-        let groups = self.group_tuples(true, drop_first)?;
 
-        // SAFETY: groups are in bounds
+        // We only need to maintain order if we need to drop the first non-null item.
+        let maintain_order = drop_first;
+        let groups = self.group_tuples(true, maintain_order)?;
+
+        // SAFETY: groups are in bounds.
         let columns = unsafe { self.agg_first(&groups) };
-        let columns = columns.iter().zip(groups.iter()).skip(drop_first as usize);
+        let columns = columns.iter().zip(groups.iter());
+        let mut seen_first = false;
         let columns = columns
             .filter_map(|(av, group)| {
+                if av.is_null() && drop_nulls {
+                    return None;
+                } else if !seen_first && !av.is_null() && drop_first {
+                    // The position of the first non-null item could be either 0 or 1.
+                    seen_first = true;
+                    return None;
+                }
                 // strings are formatted with extra \" \" in polars, so we
                 // extract the string
                 let name = if let Some(s) = av.get_str() {
@@ -45,10 +56,6 @@ impl ToDummies for Series {
                     // other types don't have this formatting issue
                     format_pl_smallstr!("{col_name}{sep}{av}")
                 };
-
-                if av.is_null() && drop_nulls {
-                    return None;
-                }
 
                 let ca = match group {
                     GroupsIndicator::Idx((_, group)) => dummies_helper_idx(group, self.len(), name),

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -2294,7 +2294,8 @@ class Series:
         drop_first
             Remove the first category from the variable being encoded.
         drop_nulls
-            If there are `None` values in the series, a `null` column is not generated
+            If there are `None` values in the series, a `null` column is not generated.
+            Null values in the nput are represented by zero vectors.
 
         Examples
         --------
@@ -2320,6 +2321,20 @@ class Series:
         ╞═════╪═════╡
         │ 0   ┆ 0   │
         │ 1   ┆ 0   │
+        │ 0   ┆ 1   │
+        └─────┴─────┘
+
+        >>> s = pl.Series("a", [1, 2, None, 3])
+        >>> s.to_dummies(drop_nulls=True, drop_first=True)
+        shape: (4, 2)
+        ┌─────┬─────┐
+        │ a_2 ┆ a_3 │
+        │ --- ┆ --- │
+        │ u8  ┆ u8  │
+        ╞═════╪═════╡
+        │ 0   ┆ 0   │
+        │ 1   ┆ 0   │
+        │ 0   ┆ 0   │
         │ 0   ┆ 1   │
         └─────┴─────┘
         """


### PR DESCRIPTION
Closes #25334.

If the series has nulls, then it's possible that the first tuple group will be the null group. We must ensure if `drop_first=True` that we drop the first _non_null_ group, which may be the second group. So the `.skip(...)` sometimes gets it wrong. This fixes the issue.

I also combined some of the unit tests with parametrization for slightly better coverage.