### PR TITLE
refactor(rust): Fix unsoundness in ChunkedArray::{first, last}

### DIFF
--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -591,10 +591,12 @@ where
     /// Panics if the [`ChunkedArray`] is empty.
     #[inline]
     pub fn last(&self) -> Option<T::Physical<'_>> {
-        let arr = self.downcast_iter().rev().find(|arr| !arr.is_empty()).unwrap();
-        unsafe {
-            arr.get_unchecked(arr.len() - 1)
-        }
+        let arr = self
+            .downcast_iter()
+            .rev()
+            .find(|arr| !arr.is_empty())
+            .unwrap();
+        unsafe { arr.get_unchecked(arr.len() - 1) }
     }
 
     pub fn set_validity(&mut self, validity: &Bitmap) {


### PR DESCRIPTION
@adamreeve These would blow up if the input `ChunkedArray` was empty or had empty chunks at the start/end.