### PR TITLE
fix: Support formatting List(Object) dtype

### DIFF
--- a/crates/polars-core/src/series/iterator.rs
+++ b/crates/polars-core/src/series/iterator.rs
@@ -80,11 +80,6 @@ impl Series {
     /// This will panic if the array is not rechunked first.
     pub fn iter(&self) -> SeriesIter<'_> {
         let dtype = self.dtype();
-        #[cfg(feature = "object")]
-        assert!(
-            !matches!(dtype, DataType::Object(_)),
-            "object dtype not supported in Series.iter"
-        );
         assert_eq!(self.chunks().len(), 1, "impl error");
         let arr = &*self.chunks()[0];
         let len = arr.len();


### PR DESCRIPTION
Fixes #22814.

Using `map_groups` with `return_dtype=pl.Object` would panic when attempting to display the result.

### Reproduction
```python
class CustomObject:
    pass

df = pl.DataFrame({
    "id": [1, 2, 3, 4],
    "objects": [CustomObject(), CustomObject(), CustomObject(), CustomObject()],
})

df.group_by("id").agg(
    pl.map_groups([pl.col("objects")], lambda x: x[0], return_dtype=pl.Object).alias("first_object")
)
# PanicException: object dtype not supported in Series.iter
```

### Cause

`map_groups` without `returns_scalar=True` wraps the result in a `List`, creating a `List(Object)` column. When formatting this column for display, the code attempted to iterate over the inner `Object` dtype `Series`, which was blocked by assertions in both `Series::iter()` and `Series::fmt_list()`.

### Fix

- Remove assertions preventing `Object` dtype iteration and formatting
- Handle `List(Object)` specially during `AnyValue` conversion to avoid empty chunks
- Use `.get()` instead of `.iter()` when formatting `Object` dtype `Series`

**Note:** Test skips on new streaming engine due to a separate issue with `List(Object)` creation in that engine.