### PR TITLE
fix(python): Validate list.slice parameters are not lists

### DIFF
--- a/py-polars/src/polars/expr/list.py
+++ b/py-polars/src/polars/expr/list.py
@@ -1004,6 +1004,17 @@ class ExprListNameSpace:
         │ [10, 2, 1]  ┆ [2, 1]    │
         └─────────────┴───────────┘
         """
+        if isinstance(offset, Collection) and not isinstance(offset, str):
+            msg = f"'offset' must be an integer, string, or expression, not {type(offset).__name__}"
+            raise TypeError(msg)
+        if (
+            length is not None
+            and isinstance(length, Collection)
+            and not isinstance(length, str)
+        ):
+            msg = f"'length' must be an integer, string, or expression, not {type(length).__name__}"
+            raise TypeError(msg)
+
         offset_pyexpr = parse_into_expression(offset)
         length_pyexpr = parse_into_expression(length)
         return wrap_expr(self._pyexpr.list_slice(offset_pyexpr, length_pyexpr))

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -1266,3 +1266,27 @@ def test_list_df_invalid_type_in_planner() -> None:
 
     with pytest.raises(pl.exceptions.InvalidOperationError):
         q.collect_schema()
+
+
+def test_list_slice_invalid_length_type_22025() -> None:
+    df = pl.DataFrame([pl.Series("a", [["a"], ["eb", "d"]], pl.List(pl.String))])
+
+    with pytest.raises(
+        TypeError, match="'length' must be an integer, string, or expression"
+    ):
+        df.select(pl.col.a.list.slice(0, [0, 0]))  # type: ignore[arg-type]
+
+    with pytest.raises(
+        TypeError, match="'offset' must be an integer, string, or expression"
+    ):
+        df.select(pl.col.a.list.slice([0, 0], 1))  # type: ignore[arg-type]
+
+    with pytest.raises(
+        TypeError, match="'offset' must be an integer, string, or expression"
+    ):
+        df.select(pl.col.a.list.slice((0, 0), 1))  # type: ignore[arg-type]
+
+    with pytest.raises(
+        TypeError, match="'length' must be an integer, string, or expression"
+    ):
+        df.select(pl.col.a.list.slice(0, {0, 1}))  # type: ignore[arg-type]


### PR DESCRIPTION
Fixes #22025.

`list.slice()` silently became a no-op when passed a list as the `length` parameter instead of raising a type error.

### Reproduction
```python
df = pl.DataFrame([pl.Series("a", [["a"], ["eb", "d"]], pl.List(pl.String))])
df.select(pl.col.a.list.slice(0, [0, 0]))
# Returns unchanged data instead of erroring
```

### Cause

`list.slice()` calls `parse_into_expression()` which accepts any input, including lists. When a list like `[0, 0]` is passed as the `length` parameter, it's converted to a list literal expression instead of raising an error, causing the operation to silently fail.

### Fix

Add validation in `list.slice()` to reject list inputs for both `offset` and `length` parameters before parsing.