### PR TITLE
docs(python): Set default values for `write_csv` parameters

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -2918,7 +2918,7 @@ class DataFrame:
         quote_style: CsvQuoteStyle | None = None,
         storage_options: dict[str, Any] | None = None,
         credential_provider: CredentialProviderFunction
-        | Literal["auto"] 
+        | Literal["auto"]
         | None = "auto",
         retries: int = 2,
     ) -> str: ...
@@ -2943,8 +2943,8 @@ class DataFrame:
         null_value: str | None = None,
         quote_style: CsvQuoteStyle | None = None,
         storage_options: dict[str, Any] | None = None,
-        credential_provider: CredentialProviderFunction 
-        | Literal["auto"] 
+        credential_provider: CredentialProviderFunction
+        | Literal["auto"]
         | None = "auto",
         retries: int = 2,
     ) -> None: ...


### PR DESCRIPTION
- Add default values to `@overload` function signatures in `write_csv`.
- Add default values to docstring wherever not mentioned in `write_csv`.

Refers to issue #25439 