### PR TITLE
fix(python): Suggest str.contains for string containment in map_elements

### DIFF
--- a/.github/scripts/test_bytecode_parser.py
+++ b/.github/scripts/test_bytecode_parser.py
@@ -21,7 +21,10 @@ from typing import Any, Callable
 import pytest
 from polars._utils.udfs import BytecodeParser
 from tests.unit.operations.map.test_inefficient_map_warning import (
+    MY_COLLECTION,
     MY_DICT,
+    MY_STRING,
+    MY_SUBSTRING,
     NOOP_TEST_CASES,
     TEST_CASES,
 )
@@ -52,7 +55,10 @@ def test_bytecode_parser_expression_in_ipython(
         "from datetime import datetime; "
         "import numpy as np; "
         "import json; "
-        f"MY_DICT = {MY_DICT};"
+        f"MY_DICT = {MY_DICT}; "
+        f"MY_COLLECTION = {MY_COLLECTION}; "
+        f"MY_STRING = {repr(MY_STRING)}; "
+        f"MY_SUBSTRING = {repr(MY_SUBSTRING)}; "
         f'bytecode_parser = BytecodeParser({func}, map_target="expr");'
         f'print(bytecode_parser.to_expression("{col}"));'
     )

--- a/py-polars/src/polars/_utils/udfs.py
+++ b/py-polars/src/polars/_utils/udfs.py
@@ -712,11 +712,34 @@ class InstructionTranslator:
                     return f"{e1}.is_{not_}null()"
                 elif op in ("in", "not in"):
                     not_ = "" if op == "in" else "~"
-                    return (
-                        f"{not_}({e1}.is_in({e2}))"
-                        if " " in e1
-                        else f"{not_}{e1}.is_in({e2})"
-                    )
+                    is_collection = e2.startswith(("(", "[", "{", "frozenset("))
+                    if not is_collection and not e2.startswith(
+                        ("pl.col(", "'", '"')  # col ref, or string literal
+                    ):
+                        # bare variable: resolve its runtime type
+                        if not self._caller_variables:
+                            self._caller_variables = _get_all_caller_variables()
+                        var_value = self._caller_variables.get(e2)
+                        if isinstance(var_value, (list, tuple, set, frozenset, dict)):
+                            is_collection = True
+                        elif not isinstance(var_value, str):
+                            msg = "cannot determine operand type for 'in'"
+                            raise NotImplementedError(msg)
+
+                    if is_collection:
+                        return (
+                            f"{not_}({e1}.is_in({e2}))"
+                            if " " in e1
+                            else f"{not_}{e1}.is_in({e2})"
+                        )
+
+                    # string containment: x in s -> s contains x
+                    if e2.startswith("pl.col("):
+                        needle = e1 if e1.startswith("pl.col(") else f"pl.lit({e1})"
+                        haystack = e2
+                    else:
+                        needle, haystack = e1, f"pl.lit({e2})"
+                    return f"{not_}{haystack}.str.contains({needle}, literal=True)"
                 elif op == "replace_strict":
                     if not self._caller_variables:
                         self._caller_variables = _get_all_caller_variables()

--- a/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
+++ b/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
@@ -24,6 +24,9 @@ if TYPE_CHECKING:
 MY_CONSTANT = 3
 MY_DICT = {0: "a", 1: "b", 2: "c", 3: "d", 4: "e"}
 MY_LIST = [1, 2, 3]
+MY_STRING = "ABcd"
+MY_SUBSTRING = "cd"
+MY_COLLECTION = [2, 3, 4]
 
 # column_name, function, expected_suggestion
 TEST_CASES = [
@@ -70,12 +73,68 @@ TEST_CASES = [
     ),
     ("a", "lambda x: x in (2, 3, 4)", 'pl.col("a").is_in((2, 3, 4))', None),
     ("a", "lambda x: x not in (2, 3, 4)", '~pl.col("a").is_in((2, 3, 4))', None),
+    ("a", "lambda x: x in MY_COLLECTION", 'pl.col("a").is_in(MY_COLLECTION)', None),
+    ("a", "lambda x: x in MY_DICT", 'pl.col("a").is_in(MY_DICT)', None),
+    (
+        "a",
+        "lambda x: (x + 1) in (1, 2, 3)",
+        '((pl.col("a") + 1).is_in((1, 2, 3)))',
+        None,
+    ),
     (
         "a",
         "lambda x: x in (1, 2, 3, 4, 3) and x % 2 == 0 and x > 0",
         'pl.col("a").is_in((1, 2, 3, 4, 3)) & ((pl.col("a") % 2) == 0) & (pl.col("a") > 0)',
         None,
     ),
+    # ---------------------------------------------
+    # string containment with 'in' operator
+    # ---------------------------------------------
+    (
+        "b",
+        "lambda x: x in MY_STRING",
+        'pl.lit(MY_STRING).str.contains(pl.col("b"), literal=True)',
+        None,
+    ),
+    (
+        "b",
+        "lambda x: MY_SUBSTRING in x",
+        'pl.col("b").str.contains(pl.lit(MY_SUBSTRING), literal=True)',
+        None,
+    ),
+    (
+        "b",
+        'lambda x: "A" in x',
+        "pl.col(\"b\").str.contains(pl.lit('A'), literal=True)",
+        None,
+    ),
+    (
+        "b",
+        "lambda x: x not in MY_STRING",
+        '~pl.lit(MY_STRING).str.contains(pl.col("b"), literal=True)',
+        None,
+    ),
+    (
+        "b",
+        'lambda x: "test" in x',
+        "pl.col(\"b\").str.contains(pl.lit('test'), literal=True)",
+        None,
+    ),
+    (
+        "b",
+        'lambda x: x not in "hello"',
+        "~pl.lit('hello').str.contains(pl.col(\"b\"), literal=True)",
+        None,
+    ),
+    (
+        "b",
+        'lambda x: x in "it\'s"',
+        'pl.lit("it\'s").str.contains(pl.col("b"), literal=True)',
+        None,
+    ),
+    # ---------------------------------------------
+    # constants
+    # ---------------------------------------------
     ("a", "lambda x: MY_CONSTANT + x", 'MY_CONSTANT + pl.col("a")', None),
     (
         "a",
@@ -313,6 +372,9 @@ EVAL_ENVIRONMENT = {
     "MY_CONSTANT": MY_CONSTANT,
     "MY_DICT": MY_DICT,
     "MY_LIST": MY_LIST,
+    "MY_STRING": MY_STRING,
+    "MY_SUBSTRING": MY_SUBSTRING,
+    "MY_COLLECTION": MY_COLLECTION,
     "cosh": cosh,
     "datetime": datetime,
     "dt": dt,
@@ -606,3 +668,29 @@ def test_partial_functions_13523() -> None:
     df = pl.DataFrame(data)
     # should not warn
     _ = df["a"].map_elements(partial(plus, amount=1))
+
+
+@pytest.mark.filterwarnings(
+    "ignore:.*:polars.exceptions.PolarsInefficientMapWarning",
+    "ignore:.*:polars.exceptions.MapWithoutReturnDtypeWarning",
+)
+@pytest.mark.parametrize(
+    "pattern", [".", "^", "$", "[0]", "a|b", "a+", "a?", "*", "(", ")", "["]
+)
+def test_string_containment_regex_metacharacters_17182(pattern: str) -> None:
+    df = pl.DataFrame({"b": [f"x{pattern}y", "xyz", pattern, "hello"]})
+
+    result_lambda = df.select(
+        pl.col("b").map_elements(
+            lambda x: pattern in x,
+            return_dtype=pl.Boolean,
+        )
+    )
+
+    func = lambda x: pattern in x  # noqa: E731
+    parser = BytecodeParser(func, map_target="expr")
+    suggested = parser.to_expression("b")
+    assert suggested is not None
+
+    result_suggested = df.select(eval(suggested, {"pl": pl, "pattern": pattern}))
+    assert_frame_equal(result_lambda, result_suggested)


### PR DESCRIPTION
Fixes #17182.

`PolarsInefficientMapWarning` incorrectly suggested `.is_in()` for string containment operations like `substring in string` inside `map_elements`.

### Cause

Bytecode parser treated all `in` operations identically without checking operand types.

### Fix

Use runtime type checking via `_get_all_caller_variables()` to distinguish:
- Collection literals/variables → `.is_in()`
- String literals/variables → `.str.contains()` with proper `pl.lit()` wrapping