### PR TITLE
refactor(rust): Take `sync` parameter in `Writeable::close()`

### DIFF
--- a/crates/polars-io/src/utils/sync_on_close.rs
+++ b/crates/polars-io/src/utils/sync_on_close.rs
@@ -1,7 +1,3 @@
-use std::{fs, io};
-
-use crate::utils::file::WriteableTrait;
-
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
@@ -14,35 +10,4 @@ pub enum SyncOnCloseType {
     Data,
     /// Synce the file contents and the metadata.
     All,
-}
-
-pub fn sync_on_close(sync_on_close: SyncOnCloseType, file: &mut fs::File) -> io::Result<()> {
-    match sync_on_close {
-        SyncOnCloseType::None => Ok(()),
-        SyncOnCloseType::Data => file.sync_data(),
-        SyncOnCloseType::All => file.sync_all(),
-    }
-}
-
-pub fn sync_on_close_dyn(
-    sync_on_close: SyncOnCloseType,
-    file: &mut dyn WriteableTrait,
-) -> io::Result<()> {
-    match sync_on_close {
-        SyncOnCloseType::None => Ok(()),
-        SyncOnCloseType::Data => file.sync_data(),
-        SyncOnCloseType::All => file.sync_all(),
-    }
-}
-
-#[cfg(feature = "tokio")]
-pub async fn tokio_sync_on_close(
-    sync_on_close: SyncOnCloseType,
-    file: &mut tokio::fs::File,
-) -> io::Result<()> {
-    match sync_on_close {
-        SyncOnCloseType::None => Ok(()),
-        SyncOnCloseType::Data => file.sync_data().await,
-        SyncOnCloseType::All => file.sync_all().await,
-    }
 }

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -372,8 +372,7 @@ fn create_physical_plan_impl(
                                 _ => panic!("enable filetype feature"),
                             }
 
-                            file.sync_on_close(unified_sink_args.sync_on_close)?;
-                            file.close()?;
+                            file.close(unified_sink_args.sync_on_close)?;
 
                             Ok(None)
                         }),

--- a/crates/polars-stream/src/nodes/io_sinks/csv.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/csv.rs
@@ -110,8 +110,7 @@ impl SinkNode for CsvSinkNode {
                 }
             }
 
-            file.sync_on_close(sink_options.sync_on_close).await?;
-            file.close().await?;
+            file.close(sink_options.sync_on_close).await?;
 
             PolarsResult::Ok(())
         });

--- a/crates/polars-stream/src/nodes/io_sinks/ipc.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/ipc.rs
@@ -169,8 +169,7 @@ impl SinkNode for IpcSinkNode {
             writer.finish()?;
             drop(writer);
 
-            file.sync_on_close(sink_options.sync_on_close)?;
-            file.close()?;
+            file.close(sink_options.sync_on_close)?;
 
             PolarsResult::Ok(())
         });

--- a/crates/polars-stream/src/nodes/io_sinks/json.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/json.rs
@@ -80,8 +80,7 @@ impl SinkNode for NDJsonSinkNode {
                 }
             }
 
-            file.sync_on_close(sink_options.sync_on_close).await?;
-            file.close().await?;
+            file.close(sink_options.sync_on_close).await?;
 
             PolarsResult::Ok(())
         });

--- a/crates/polars-stream/src/nodes/io_sinks/parquet.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/parquet.rs
@@ -163,8 +163,7 @@ impl SinkNode for ParquetSinkNode {
             let file_size = writer.finish()?;
             drop(writer);
 
-            file.sync_on_close(sink_options.sync_on_close)?;
-            file.close()?;
+            file.close(sink_options.sync_on_close)?;
 
             output_file_size.store(file_size);
             PolarsResult::Ok(())


### PR DESCRIPTION
Also adds `fn sync_all()`, `fn sync_data()` to `(Async)Writeable`, matching with the API exposed by `File` in the stdlib.
