### PR TITLE
depr: Rename aggregate_function to agg_function

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -803,7 +803,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
 
                 polars_ensure!(
                     aexpr_to_leaf_names_iter(agg_ae, ctxt.expr_arena).count() == 0,
-                    InvalidOperation: "explicit column references are not allowed in the `aggregate_function` of `pivot`"
+                    InvalidOperation: "explicit column references are not allowed in the `agg_function` of `pivot`"
                 );
 
                 for i in 0..on_columns.height() {

--- a/docs/source/src/python/user-guide/lazy/schema.py
+++ b/docs/source/src/python/user-guide/lazy/schema.py
@@ -31,7 +31,7 @@ lazy_eager_query = (
     )
     .with_columns((2 * pl.col("values")).alias("double_values"))
     .collect()
-    .pivot(index="id", on="month", values="double_values", aggregate_function="first")
+    .pivot(index="id", on="month", values="double_values", agg_function="first")
     .lazy()
     .filter(pl.col("mar").is_null())
     .collect()

--- a/docs/source/src/python/user-guide/transformations/pivot.py
+++ b/docs/source/src/python/user-guide/transformations/pivot.py
@@ -15,7 +15,7 @@ print(df)
 # --8<-- [end:df]
 
 # --8<-- [start:eager]
-out = df.pivot("bar", index="foo", values="N", aggregate_function="first")
+out = df.pivot("bar", index="foo", values="N", agg_function="first")
 print(out)
 # --8<-- [end:eager]
 
@@ -23,7 +23,7 @@ print(out)
 q = (
     df.lazy()
     .collect()
-    .pivot(index="foo", on="bar", values="N", aggregate_function="first")
+    .pivot(index="foo", on="bar", values="N", agg_function="first")
     .lazy()
 )
 out = q.collect()

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -9260,6 +9260,7 @@ class DataFrame:
         )
 
     @deprecate_renamed_parameter("columns", "on", version="1.0.0")
+    @deprecate_renamed_parameter("aggregate_function", "agg_function", version="1.36.0")
     def pivot(
         self,
         on: ColumnNameOrSelector | Sequence[ColumnNameOrSelector],
@@ -9267,7 +9268,7 @@ class DataFrame:
         *,
         index: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None = None,
         values: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None = None,
-        aggregate_function: PivotAgg | Expr | None = None,
+        agg_function: PivotAgg | Expr | None = None,
         maintain_order: bool = True,
         sort_columns: bool = False,
         separator: str = "_",
@@ -9280,6 +9281,9 @@ class DataFrame:
 
         .. versionchanged:: 1.0.0
             The `columns` parameter was renamed `on`.
+
+        .. versionchanged:: 1.36.0
+            The `aggregate_function` parameter was renamed `agg_function`.
 
         Parameters
         ----------
@@ -9298,7 +9302,7 @@ class DataFrame:
             aggregation is specified, these are the values on which the aggregation will be computed.
             If None, all remaining columns not specified on `on` and `index` will be used.
             At least one of `index` and `values` must be specified.
-        aggregate_function
+        agg_function
             Choose from:
 
             - None: no aggregation takes place, will raise error if multiple values are in group.
@@ -9399,7 +9403,7 @@ class DataFrame:
         └───────┴──────────────┴────────────────┴──────────────┴────────────────┘
 
         If you end up with multiple values per cell, you can specify how to aggregate
-        them with `aggregate_function`:
+        them with `agg_function`:
 
         >>> df = pl.DataFrame(
         ...     {
@@ -9409,7 +9413,7 @@ class DataFrame:
         ...         "bar": [0, 2, 0, 0, 9, 4],
         ...     }
         ... )
-        >>> df.pivot("col", index="ix", aggregate_function="sum")
+        >>> df.pivot("col", index="ix", agg_function="sum")
         shape: (2, 5)
         ┌─────┬───────┬───────┬───────┬───────┐
         │ ix  ┆ foo_a ┆ foo_b ┆ bar_a ┆ bar_b │
@@ -9434,7 +9438,7 @@ class DataFrame:
         ...     "col2",
         ...     index="col1",
         ...     values="col3",
-        ...     aggregate_function=pl.element().tanh().mean(),
+        ...     agg_function=pl.element().tanh().mean(),
         ... )
         shape: (2, 3)
         ┌──────┬──────────┬──────────┐
@@ -9468,7 +9472,7 @@ class DataFrame:
                 on_columns=on_cols,
                 index=index,
                 values=values,
-                aggregate_function=aggregate_function,
+                agg_function=agg_function,
                 maintain_order=maintain_order,
                 separator=separator,
             )

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -7740,6 +7740,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             selector_subset = parse_list_into_selector(subset)._pyselector
         return self._from_pyldf(self._ldf.drop_nulls(subset=selector_subset))
 
+    @deprecate_renamed_parameter("aggregate_function", "agg_function", version="1.36.0")
     def pivot(
         self,
         on: ColumnNameOrSelector | Sequence[ColumnNameOrSelector],
@@ -7747,12 +7748,15 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         *,
         index: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None = None,
         values: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None = None,
-        aggregate_function: PivotAgg | Expr | None = None,
+        agg_function: PivotAgg | Expr | None = None,
         maintain_order: bool = False,
         separator: str = "_",
     ) -> LazyFrame:
         """
         Create a spreadsheet-style pivot table as a DataFrame.
+
+        .. versionchanged:: 1.36.0
+            The `aggregate_function` parameter was renamed `agg_function`.
 
         Parameters
         ----------
@@ -7771,7 +7775,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             aggregation is specified, these are the values on which the aggregation will be computed.
             If None, all remaining columns not specified on `on` and `index` will be used.
             At least one of `index` and `values` must be specified.
-        aggregate_function
+        agg_function
             Choose from:
 
             - None: no aggregation takes place, will raise error if multiple values are in group.
@@ -7859,7 +7863,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └───────┴──────────────┴────────────────┴──────────────┴────────────────┘
 
         If you end up with multiple values per cell, you can specify how to aggregate
-        them with `aggregate_function`:
+        them with `agg_function`:
 
         >>> lf = pl.LazyFrame(
         ...     {
@@ -7870,7 +7874,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...     }
         ... )
         >>> lf.pivot(
-        ...     "col", on_columns=["a", "b"], index="ix", aggregate_function="sum"
+        ...     "col", on_columns=["a", "b"], index="ix", agg_function="sum"
         ... ).collect()  # doctest: +IGNORE_RESULT
         shape: (2, 5)
         ┌─────┬───────┬───────┬───────┬───────┐
@@ -7897,7 +7901,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...     on_columns=["x", "y"],
         ...     index="col1",
         ...     values="col3",
-        ...     aggregate_function=pl.element().tanh().mean(),
+        ...     agg_function=pl.element().tanh().mean(),
         ... ).collect()  # doctest: +IGNORE_RESULT
         shape: (2, 3)
         ┌──────┬──────────┬──────────┐
@@ -7925,39 +7929,39 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             index_selector = cs.all() - on_selector - values_selector
 
         agg = F.element()
-        if isinstance(aggregate_function, str):
-            if aggregate_function == "first":
+        if isinstance(agg_function, str):
+            if agg_function == "first":
                 agg = agg.first()
-            elif aggregate_function == "item":
+            elif agg_function == "item":
                 agg = agg.item()
-            elif aggregate_function == "sum":
+            elif agg_function == "sum":
                 agg = agg.sum()
-            elif aggregate_function == "max":
+            elif agg_function == "max":
                 agg = agg.max()
-            elif aggregate_function == "min":
+            elif agg_function == "min":
                 agg = agg.min()
-            elif aggregate_function == "mean":
+            elif agg_function == "mean":
                 agg = agg.mean()
-            elif aggregate_function == "median":
+            elif agg_function == "median":
                 agg = agg.median()
-            elif aggregate_function == "last":
+            elif agg_function == "last":
                 agg = agg.last()
-            elif aggregate_function == "len":
+            elif agg_function == "len":
                 agg = agg.len()
-            elif aggregate_function == "count":
+            elif agg_function == "count":
                 issue_deprecation_warning(
-                    "`aggregate_function='count'` input for `pivot` is deprecated."
-                    " Please use `aggregate_function='len'`.",
+                    "`agg_function='count'` input for `pivot` is deprecated."
+                    " Please use `agg_function='len'`.",
                     version="0.20.5",
                 )
                 agg = agg.len()
             else:
-                msg = f"invalid input for `aggregate_function` argument: {aggregate_function!r}"
+                msg = f"invalid input for `agg_function` argument: {agg_function!r}"
                 raise ValueError(msg)
-        elif aggregate_function is None:
+        elif agg_function is None:
             agg = agg.item(allow_empty=True)
         else:
-            agg = aggregate_function
+            agg = agg_function
 
         on_cols: pl.DataFrame
         if isinstance(on_columns, pl.DataFrame):

--- a/py-polars/src/polars/selectors.py
+++ b/py-polars/src/polars/selectors.py
@@ -2039,7 +2039,7 @@ def digit(ascii_only: bool = False) -> Selector:  # noqa: FBT001
     ...     values="value",
     ...     index="key",
     ...     on="year",
-    ...     aggregate_function="sum",
+    ...     agg_function="sum",
     ... )
     >>> print(df)
     shape: (2, 3)

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -22,7 +22,7 @@ def test_pivot() -> None:
             "N": [1, 2, 2, 4, 2],
         }
     )
-    result = df.pivot("bar", values="N", aggregate_function=None)
+    result = df.pivot("bar", values="N", agg_function=None)
 
     expected = pl.DataFrame(
         [
@@ -45,7 +45,7 @@ def test_pivot_no_values() -> None:
             "N2": [1, 2, 2, 4, 2],
         }
     )
-    result = df.pivot(on="bar", index="foo", aggregate_function=None)
+    result = df.pivot(on="bar", index="foo", agg_function=None)
     expected = pl.DataFrame(
         {
             "foo": ["A", "B", "C"],
@@ -80,7 +80,7 @@ def test_pivot_list() -> None:
         index="a",
         on="a",
         values="b",
-        aggregate_function="first",
+        agg_function="first",
         sort_columns=True,
     )
     assert_frame_equal(out, expected)
@@ -107,7 +107,7 @@ def test_pivot_aggregate(agg_fn: PivotAgg, expected_rows: list[tuple[Any]]) -> N
         }
     )
     result = df.pivot(
-        index="b", on="a", values="c", aggregate_function=agg_fn, sort_columns=True
+        index="b", on="a", values="c", agg_function=agg_fn, sort_columns=True
     )
     assert result.rows() == expected_rows
 
@@ -145,7 +145,7 @@ def test_pivot_categorical_index(maintain_order: bool) -> None:
         index=["A"],
         on="B",
         values="B",
-        aggregate_function="len",
+        agg_function="len",
         maintain_order=maintain_order,
     )
     expected = pl.DataFrame(
@@ -163,7 +163,7 @@ def test_pivot_categorical_index(maintain_order: bool) -> None:
         index=["A"],
         on="B",
         values="B",
-        aggregate_function=pl.len(),
+        agg_function=pl.len(),
         maintain_order=maintain_order,
     )
     assert_frame_equal(result, expected, check_row_order=maintain_order)
@@ -180,7 +180,7 @@ def test_pivot_categorical_index(maintain_order: bool) -> None:
         index=["A", "C"],
         on="B",
         values="B",
-        aggregate_function="len",
+        agg_function="len",
         maintain_order=maintain_order,
     )
     expected = pl.DataFrame(
@@ -219,7 +219,7 @@ def test_pivot_multiple_values_column_names_5116() -> None:
             on="c2",
             values=["x1", "x2"],
             separator="|",
-            aggregate_function=None,
+            agg_function=None,
         )
 
     result = df.pivot(
@@ -227,7 +227,7 @@ def test_pivot_multiple_values_column_names_5116() -> None:
         on="c2",
         values=["x1", "x2"],
         separator="|",
-        aggregate_function="first",
+        agg_function="first",
     )
     expected = {
         "c1": ["A", "B"],
@@ -254,7 +254,7 @@ def test_pivot_duplicate_names_7731(maintain_order: bool) -> None:
         index=cs.float(),
         on=cs.string(),
         values=cs.integer(),
-        aggregate_function="first",
+        agg_function="first",
         maintain_order=maintain_order,
     )
     expected = pl.DataFrame(
@@ -287,7 +287,7 @@ def test_pivot_multiple_columns_12407() -> None:
         }
     )
     result = df.pivot(
-        index="b", on=["c", "e"], values=["a"], aggregate_function="len"
+        index="b", on=["c", "e"], values=["a"], agg_function="len"
     ).to_dict(as_series=False)
     expected = {"b": ["a", "b"], '{"s","x"}': [1, 0], '{"f","y"}': [0, 1]}
     assert result == expected
@@ -370,7 +370,7 @@ def test_pivot_name_already_exists() -> None:
             ["a", "b"],
             index='{"a","b"}',
             values="a",
-            aggregate_function="first",
+            agg_function="first",
         )
 
 
@@ -389,11 +389,11 @@ def test_pivot_floats() -> None:
         match="aggregation 'item' expected no or a single value, got 2 values",
     ):
         result = df.pivot(
-            index="weight", on="quantity", values="price", aggregate_function=None
+            index="weight", on="quantity", values="price", agg_function=None
         )
 
     result = df.pivot(
-        index="weight", on="quantity", values="price", aggregate_function="first"
+        index="weight", on="quantity", values="price", agg_function="first"
     )
     expected = {
         "weight": [1.0, 4.4, 8.8],
@@ -407,7 +407,7 @@ def test_pivot_floats() -> None:
         index=["article", "weight"],
         on="quantity",
         values="price",
-        aggregate_function=None,
+        agg_function=None,
     )
     expected = {
         "article": ["a", "a", "b", "b"],
@@ -429,7 +429,7 @@ def test_pivot_reinterpret_5907() -> None:
     )
 
     result = df.pivot(
-        index=["A"], on=["B"], values=["C"], aggregate_function=pl.element().sum()
+        index=["A"], on=["B"], values=["C"], agg_function=pl.element().sum()
     )
     expected = {"A": [3, -2], "x": [100, 50], "y": [500, -80]}
     assert result.to_dict(as_series=False) == expected
@@ -458,9 +458,9 @@ def test_pivot_temporal_logical_types(dtype: PolarsTemporalType) -> None:
             "value": [0] * 8,
         }
     )
-    assert df.pivot(
-        index="idx", on="foo", values="value", aggregate_function=None
-    ).to_dict(as_series=False) == {
+    assert df.pivot(index="idx", on="foo", values="value", agg_function=None).to_dict(
+        as_series=False
+    ) == {
         "idx": idx.to_list(),
         "a": [0, 0, 0, None, None, None, None, None],
         "b": [None, None, None, 0, 0, 0, 0, 0],
@@ -475,7 +475,7 @@ def test_pivot_negative_duration() -> None:
         pl.Series(name="value", values=range(len(df1) * len(df2)))
     )
     assert df.pivot(
-        index="delta", on="root", values="value", aggregate_function=None
+        index="delta", on="root", values="value", agg_function=None
     ).to_dict(as_series=False) == {
         "delta": [
             timedelta(days=-2),
@@ -488,7 +488,7 @@ def test_pivot_negative_duration() -> None:
     }
 
 
-def test_aggregate_function_default() -> None:
+def test_agg_function_default() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": ["foo", "foo"], "c": ["x", "x"]})
     with pytest.raises(
         ComputeError,
@@ -497,7 +497,7 @@ def test_aggregate_function_default() -> None:
         df.pivot(index="b", on="c", values="a")
 
 
-def test_pivot_aggregate_function_count_deprecated() -> None:
+def test_pivot_agg_function_count_deprecated() -> None:
     df = pl.DataFrame(
         {
             "foo": ["A", "A", "B", "B", "C"],
@@ -506,7 +506,7 @@ def test_pivot_aggregate_function_count_deprecated() -> None:
         }
     )
     with pytest.deprecated_call():
-        df.pivot(index="foo", on="bar", values="N", aggregate_function="count")  # type: ignore[arg-type]
+        df.pivot(index="foo", on="bar", values="N", agg_function="count")  # type: ignore[arg-type]
 
 
 def test_pivot_struct() -> None:
@@ -518,9 +518,9 @@ def test_pivot_struct() -> None:
     }
     df = pl.DataFrame(data).with_columns(nums=pl.struct(["num1", "num2"]))
 
-    assert df.pivot(
-        values="nums", index="id", on="week", aggregate_function="first"
-    ).to_dict(as_series=False) == {
+    assert df.pivot(values="nums", index="id", on="week", agg_function="first").to_dict(
+        as_series=False
+    ) == {
         "id": ["a", "b", "c"],
         "1": [
             {"num1": 1, "num2": 4},
@@ -596,7 +596,7 @@ def test_pivot_string_17081() -> None:
             "c": ["7", "8", "9"],
         }
     )
-    assert df.pivot(index="a", on="b", values="c", aggregate_function="min").to_dict(
+    assert df.pivot(index="a", on="b", values="c", agg_function="min").to_dict(
         as_series=False
     ) == {
         "a": ["1", "2", "3"],
@@ -632,11 +632,9 @@ def test_pivot_agg_column_ref_invalid_22479() -> None:
     )
     with pytest.raises(
         pl.exceptions.InvalidOperationError,
-        match="explicit column references are not allowed in the `aggregate_function` of `pivot`",
+        match="explicit column references are not allowed in the `agg_function` of `pivot`",
     ):
-        df.pivot(
-            on="a", index="b", values="c", aggregate_function=pl.element().sort_by("d")
-        )
+        df.pivot(on="a", index="b", values="c", agg_function=pl.element().sort_by("d"))
 
 
 def test_pivot_agg_null_methods_23408() -> None:
@@ -651,7 +649,7 @@ def test_pivot_agg_null_methods_23408() -> None:
         on="on",
         index="idx",
         values="val",
-        aggregate_function=pl.element().first().is_null(),
+        agg_function=pl.element().first().is_null(),
     )
     expected = pl.DataFrame(
         {"idx": [0, 1], "a": [False, False], "b": [False, True], "c": [True, False]}
@@ -662,9 +660,33 @@ def test_pivot_agg_null_methods_23408() -> None:
         on="on",
         index="idx",
         values="val",
-        aggregate_function=pl.element().first().fill_null("xx"),
+        agg_function=pl.element().first().fill_null("xx"),
     )
     expected = pl.DataFrame(
         {"idx": [0, 1], "a": ["aa", "aa"], "b": ["bb", "xx"], "c": ["xx", "cc"]}
     )
     assert_frame_equal(out, expected)
+
+
+def test_pivot_aggregate_function_deprecated() -> None:
+    df = pl.DataFrame(
+        {
+            "foo": ["A", "A", "B", "B", "C"],
+            "N": [1, 2, 2, 4, 2],
+            "bar": ["k", "l", "m", "n", "o"],
+        }
+    )
+
+    args = ("foo",)
+
+    kwargs = {
+        "index": "foo",
+        "values": "N",
+        "aggregate_function": "count",
+    }
+    with pytest.deprecated_call():
+        df.pivot(*args, **kwargs)  # type: ignore[arg-type]
+
+    # TODO: move this test to lazyframe pivot tests, when those are available
+    with pytest.deprecated_call():
+        df.lazy().pivot(*args, "bar", **kwargs)  # type: ignore[arg-type]


### PR DESCRIPTION
#25467

This seems to fit the naming convention better. We have `.agg()` or even `agg_list` parameters in some methods.

