### PR TITLE
fix: Allow empty list in `sort_by` in `list.eval` context

### DIFF
--- a/crates/polars-expr/src/expressions/sortby.rs
+++ b/crates/polars-expr/src/expressions/sortby.rs
@@ -96,10 +96,8 @@ fn sort_by_groups_single_by(
             map_sorted_indices_to_group_slice(&sorted_idx, first)
         },
     };
-    let first = new_idx
-        .first()
-        .ok_or_else(|| polars_err!(ComputeError: "{}", ERR_MSG))?;
 
+    let first = new_idx.first().unwrap_or(&0);
     Ok((*first, new_idx))
 }
 

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -1255,3 +1255,11 @@ def test_sort_by_dynamic_24057(expr: pl.Expr, result: list[list[int]]) -> None:
     out = q.collect()
     expected = pl.DataFrame({"time": [0, 5, 10], "sorted": result})
     assert_frame_equal(out, expected)
+
+
+def test_sort_by_empty_list_eval_25433() -> None:
+    some_list = [2, 1, 3]
+    df = pl.DataFrame({"a": [some_list, []]})
+    out = df.select(pl.col.a.list.eval(pl.element().sort_by(pl.element())))
+    expected = pl.DataFrame({"a": [sorted(some_list), []]})
+    assert_frame_equal(out, expected)


### PR DESCRIPTION
fixes #25433 

Unless there are reservations on the use of empty groups, this should be good to go.