### PR TITLE
chore: Fix --uv argument for benchmark-remote

### DIFF
--- a/.github/workflows/benchmark-remote.yml
+++ b/.github/workflows/benchmark-remote.yml
@@ -63,7 +63,7 @@ jobs:
           RUSTFLAGS: -C embed-bitcode -D warnings
         working-directory: py-polars
         run: |
-          maturin develop --manifest-path runtime/polars-runtime-32/Cargo.toml --release -- -C codegen-units=8 -C lto=thin -C target-cpu=native --uv
+          maturin develop --manifest-path runtime/polars-runtime-32/Cargo.toml --release --uv -- -C codegen-units=8 -C lto=thin -C target-cpu=native
 
       - name: Run benchmark
         working-directory: polars-benchmark


### PR DESCRIPTION
I overlooked in my review that `--uv` was put after `--` by accident in this workflow.

@mcrumiller 