### PR TITLE
docs(python): Deprecate `Categorical` functions for lexical ordering and local checks

### DIFF
--- a/py-polars/src/polars/series/categorical.py
+++ b/py-polars/src/polars/series/categorical.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from polars._utils.unstable import unstable
+from polars._utils.deprecation import deprecated
 from polars._utils.wrap import wrap_s
 from polars.series.utils import expr_dispatch
 
@@ -37,6 +37,10 @@ class CatNameSpace:
         ]
         """
 
+    @deprecated(
+        "`cat.is_local()` is deprecated; Categoricals no longer have a local scope. "
+        "This method will be removed in Polars 2.0."
+    )
     def is_local(self) -> bool:
         """
         Return whether or not the column is a local categorical.
@@ -49,14 +53,15 @@ class CatNameSpace:
         """Simply returns the column as-is, local representations are deprecated."""
         return wrap_s(self._s.cat_to_local())
 
-    @unstable()
+    @deprecated(
+        "`cat.uses_lexical_ordering()` is deprecated; Categoricals are now always ordered lexically. "
+        "This method will be removed in Polars 2.0."
+    )
     def uses_lexical_ordering(self) -> bool:
         """
         Indicate whether the Series uses lexical ordering.
 
-        .. warning::
-            This functionality is considered **unstable**. It may be changed
-            at any point without it being considered a breaking change.
+        Always returns true.
 
         Examples
         --------

--- a/py-polars/tests/unit/operations/namespaces/test_categorical.py
+++ b/py-polars/tests/unit/operations/namespaces/test_categorical.py
@@ -88,18 +88,17 @@ def test_cat_to_local() -> None:
 
 
 def test_cat_uses_lexical_ordering() -> None:
-    s = pl.Series(["a", "b", None, "b"]).cast(pl.Categorical)
-    assert s.cat.uses_lexical_ordering()
+    with pytest.warns(DeprecationWarning, match="ordering parameter"):
+        physical_cat = pl.Categorical(ordering="physical")
 
-    s = s.cast(pl.Categorical())
-    assert s.cat.uses_lexical_ordering()
+    for dtype in [pl.Categorical, pl.Categorical(), physical_cat]:
+        s = pl.Series(["a", "b", None, "b"]).cast(dtype)  # type: ignore[arg-type]
 
-    with pytest.warns(
-        DeprecationWarning,
-        match="ordering is now always lexical",
-    ):
-        s = s.cast(pl.Categorical(ordering="physical"))
-    assert s.cat.uses_lexical_ordering()
+        with pytest.warns(
+            DeprecationWarning,
+            match="Categoricals are now always ordered lexically",
+        ):
+            assert s.cat.uses_lexical_ordering()
 
 
 @pytest.mark.parametrize("dtype", [pl.Categorical, pl.Enum])


### PR DESCRIPTION
Since the rewrite of `Categorical` some functions always return true or false, because they became irrelevant. This PR marks them deprecated and warns they'll be removed in Polars 2.0