### PR TITLE
perf: Reduce HuggingFace API calls

### DIFF
--- a/crates/polars-io/src/path_utils/hugging_face.rs
+++ b/crates/polars-io/src/path_utils/hugging_face.rs
@@ -440,7 +440,7 @@ mod tests {
         let file_uri = loc.get_file_uri("special-chars/[*.parquet");
         assert_eq!(
             file_uri,
-            "https://huggingface.co/datasets/HuggingFaceFW/fineweb-2/resolve/main/special-chars/%5B*.parquet"
+            "https://huggingface.co/datasets/HuggingFaceFW/fineweb-2/resolve/main/special-chars/%5B%2A.parquet"
         );
 
         // Check that revision slashes ARE encoded (they're part of the revision name)


### PR DESCRIPTION
Fixes #25389 / cc @nameexhaustion

**Note** Some of the code in this PR was AI-generated. I have checked the changes closely, but I am not an expert in Rust, so I may have left some rough edges. 

There are quite a few comments in the code at the moment. It might make sense to remove some of the more repetitive comments pointing to the same issue. 

Two related issues caused rate limits when loading datasets from the Hub, which this PR aims to fix. 

1. Switch to using the recursive tree API. This Reduces API calls from ~379 to ~19 for repos like [fineweb-2](https://huggingface.co/datasets/HuggingFaceFW/fineweb-2)
2. Preserve slashes in URLs - Prevents requests from being misclassified as "pages" (100/5min limit) instead of "resolvers" (3000/5min limit). 


## Changes

### Recursive Tree API

Previously, glob expansion used stack-based directory traversal, making one API call per directory. Now uses `?recursive=true` parameter to fetch all files in a single paginated request.

| Dataset                  | Before        | After        |
|--------------------------|---------------|--------------|
| fineweb-2 (8,257 files)  | 379 API calls | 19 API calls |
| finepdfs-edu (429 files) | 139 API calls | 1 API call   |

The improvement is most significant for repos with deeply nested directory structures, where the old approach made one API call per directory. Now it's bound by pagination (1000 files per page) regardless of nesting depth.

### URL Encoding Fix

Polars was encoding slashes as `%2F` in URLs, which caused HF Hub to classify requests as "pages" instead of "resolvers":

- `https://huggingface.co/datasets/HuggingFaceFW%2Ffineweb-2/resolve/...` → "pages" (100/5min)
- `https://huggingface.co/datasets/HuggingFaceFW/fineweb-2/resolve/...` → "resolvers" (3000/5min)

This matches `huggingface_hub`'s behaviour, which uses quote(path, safe='/'). See https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/file_download.py#L262

## Testing

I am a Rust noob, but I believe I got the test running okay locally. 

- Existing tests pass (15134 passed)
- Manual testing with `hf://datasets/HuggingFaceFW/fineweb-2/data/*/train/*.parquet`
- Manual testing with `hf://datasets/HuggingFaceFW/finepdfs-edu/data/*_Latn/train/*.parquet`
- Added regression test `test_hf_url_no_slash_encoding` (this was perhaps overselous on the part of the AI agent. Not sure this adds much, but might be useful for anyone touching this code later) 