### PR TITLE
feat: Allow pl.Object in pivot value

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/any_value.rs
+++ b/crates/polars-core/src/chunked_array/ops/any_value.rs
@@ -138,8 +138,6 @@ pub(crate) unsafe fn arr_to_any_value<'a>(
         DataType::Extension(typ, storage) => arr_to_any_value(arr, idx, storage),
         #[cfg(feature = "object")]
         DataType::Object(_) => {
-            // We should almost never hit this. The only known exception is when we put objects in
-            // structs. Any other hit should be considered a bug.
             let arr = arr.as_any().downcast_ref::<FixedSizeBinaryArray>().unwrap();
             PolarsExtension::arr_to_av(arr, idx)
         },

--- a/crates/polars-core/src/series/iterator.rs
+++ b/crates/polars-core/src/series/iterator.rs
@@ -80,11 +80,6 @@ impl Series {
     /// This will panic if the array is not rechunked first.
     pub fn iter(&self) -> SeriesIter<'_> {
         let dtype = self.dtype();
-        #[cfg(feature = "object")]
-        assert!(
-            !matches!(dtype, DataType::Object(_)),
-            "object dtype not supported in Series.iter"
-        );
         assert_eq!(self.chunks().len(), 1, "impl error");
         let arr = &*self.chunks()[0];
         let len = arr.len();
@@ -102,11 +97,6 @@ impl Series {
 
         assert_eq!(dtype, &phys_dtype, "impl error");
         assert_eq!(self.chunks().len(), 1, "impl error");
-        #[cfg(feature = "object")]
-        assert!(
-            !matches!(dtype, DataType::Object(_)),
-            "object dtype not supported in Series.iter"
-        );
         let arr = &*self.chunks()[0];
 
         if phys_dtype.is_primitive_numeric() {

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -668,3 +668,24 @@ def test_pivot_agg_null_methods_23408() -> None:
         {"idx": [0, 1], "a": ["aa", "aa"], "b": ["bb", "xx"], "c": ["xx", "cc"]}
     )
     assert_frame_equal(out, expected)
+
+
+def test_pivot_obj_25527() -> None:
+    df = pl.DataFrame(
+        {
+            "idx": [0, 0, 1, 1],
+            "key": ["foo", "bar", "foo", "bar"],
+            "value": ["obj 0 foo", "obj 0 bar", "obj 1 foo", "obj 1 bar"],
+        },
+        schema={
+            "idx": pl.Int64,
+            "key": pl.String,
+            "value": pl.Object,
+        },
+    )
+
+    out = df.pivot(on="key", index="idx")
+    assert out["foo"].to_list() == ["obj 0 foo", "obj 1 foo"]
+    assert out["foo"].dtype == pl.Object
+    assert out["bar"].to_list() == ["obj 0 bar", "obj 1 bar"]
+    assert out["bar"].dtype == pl.Object


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/25527.

I believe the restrictions on not letting `Object` into `SeriesIter` are outdated.