### PR TITLE
refactor(rust): Rename `URL_ENCODE_CHARSET` to `HIVE_ENCODE_CHARSET`

### DIFF
--- a/crates/polars-io/src/partition.rs
+++ b/crates/polars-io/src/partition.rs
@@ -8,9 +8,9 @@ use rayon::prelude::*;
 
 use crate::cloud::CloudOptions;
 use crate::parquet::write::ParquetWriteOptions;
+use crate::prelude::HIVE_VALUE_ENCODE_CHARSET;
 #[cfg(feature = "ipc")]
 use crate::prelude::IpcWriterOptions;
-use crate::prelude::URL_ENCODE_CHAR_SET;
 use crate::utils::file::Writeable;
 use crate::{SerWriter, WriteDataFrameToFile};
 
@@ -86,7 +86,7 @@ pub fn write_partitioned_dataset(
                                 .get(0)
                                 .unwrap_or("__HIVE_DEFAULT_PARTITION__")
                                 .as_bytes(),
-                            URL_ENCODE_CHAR_SET
+                            HIVE_VALUE_ENCODE_CHARSET
                         )
                     )
                 })

--- a/crates/polars-io/src/path_utils/hugging_face.rs
+++ b/crates/polars-io/src/path_utils/hugging_face.rs
@@ -12,7 +12,7 @@ use crate::cloud::{
 };
 use crate::path_utils::HiveIdxTracker;
 use crate::pl_async::with_concurrency_budget;
-use crate::prelude::URL_ENCODE_CHAR_SET;
+use crate::prelude::HIVE_VALUE_ENCODE_CHARSET;
 use crate::utils::decode_json_response;
 
 #[derive(Debug, PartialEq)]
@@ -333,7 +333,7 @@ pub(super) async fn expand_paths_hf(
 }
 
 fn percent_encode(bytes: &[u8]) -> percent_encoding::PercentEncode<'_> {
-    percent_encoding::percent_encode(bytes, URL_ENCODE_CHAR_SET)
+    percent_encoding::percent_encode(bytes, HIVE_VALUE_ENCODE_CHARSET)
 }
 
 mod tests {

--- a/crates/polars-io/src/utils/mod.rs
+++ b/crates/polars-io/src/utils/mod.rs
@@ -9,9 +9,31 @@ pub mod mkdir;
 pub mod slice;
 pub mod sync_on_close;
 
-pub const URL_ENCODE_CHAR_SET: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
-    .add(b'/')
-    .add(b'=')
+/// Excludes only the unreserved URI characters in RFC-3986:
+///
+/// <https://datatracker.ietf.org/doc/html/rfc3986#section-2.3>
+///
+/// Characters that are allowed in a URI but do not have a reserved
+/// purpose are called unreserved.  These include uppercase and lowercase
+/// letters, decimal digits, hyphen, period, underscore, and tilde.
+///
+/// unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
+pub const URL_ENCODE_CHARSET: &percent_encoding::AsciiSet = &percent_encoding::NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~');
+
+/// Characters to percent-encode for hive values such that they round-trip from bucket storage.
+///
+/// This is much more relaxed than the RFC-3986 URI spec as bucket storage is more permissive of allowed
+/// characters.
+pub const HIVE_VALUE_ENCODE_CHARSET: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
+    .add(b'/') // Exclude path separator
+    .add(b'=') // Exclude hive `key=value` separator
+    .add(b'%') // Percent itself.
+    // Colon and space are supported by object storage, but are encoded to mimic
+    // the datetime output format from pyarrow:
+    // * i.e. 'date2=2023-01-01 00:00:00.000000' becomes 'date2=2023-01-01%2000%3A00%3A00.000000'
     .add(b':')
-    .add(b' ')
-    .add(b'%');
+    .add(b' ');

--- a/crates/polars-plan/src/dsl/options/sink.rs
+++ b/crates/polars-plan/src/dsl/options/sink.rs
@@ -258,7 +258,8 @@ impl PartitionTargetContextKey {
             .map_err(|err| pyo3::exceptions::PyRuntimeError::new_err(err.to_string()))?;
         let value = value.str().unwrap();
         let value = value.get(0).unwrap_or("null").as_bytes();
-        let value = percent_encoding::percent_encode(value, polars_io::utils::URL_ENCODE_CHAR_SET);
+        let value =
+            percent_encoding::percent_encode(value, polars_io::utils::HIVE_VALUE_ENCODE_CHARSET);
         Ok(value.to_string())
     }
     #[getter]

--- a/crates/polars-stream/src/nodes/io_sinks/partition/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/mod.rs
@@ -141,7 +141,8 @@ fn default_by_key_file_path_cb(
             .get(0)
             .unwrap_or("__HIVE_DEFAULT_PARTITION__")
             .as_bytes();
-        let value = percent_encoding::percent_encode(value, polars_io::utils::URL_ENCODE_CHAR_SET);
+        let value =
+            percent_encoding::percent_encode(value, polars_io::utils::HIVE_VALUE_ENCODE_CHARSET);
         write!(&mut file_path, "{name}={value}").unwrap();
         file_path.push(separator);
     }


### PR DESCRIPTION
* ref https://github.com/pola-rs/polars/issues/25550
* ref https://github.com/pola-rs/polars/pull/25521
  * Will be used in the HuggingFace path expansion in this PR

#### Changes
* Old `URL_ENCODE_CHAR_SET` is renamed to `HIVE_ENCODE_CHARSET`
* Changed `URL_ENCODE_CHARSET` to be strictly RFC-3986 compliant
