### PR TITLE
chore(python): Add `Final` type-qualifier to module-level constants

### DIFF
--- a/py-polars/src/polars/_utils/constants.py
+++ b/py-polars/src/polars/_utils/constants.py
@@ -1,29 +1,30 @@
 from datetime import date, datetime, timezone
+from typing import Final
 
 # Integer ranges
-I8_MIN = -(2**7)
-I16_MIN = -(2**15)
-I32_MIN = -(2**31)
-I64_MIN = -(2**63)
-I128_MIN = -(2**127)
-I8_MAX = 2**7 - 1
-I16_MAX = 2**15 - 1
-I32_MAX = 2**31 - 1
-I64_MAX = 2**63 - 1
-I128_MAX = 2**127 - 1
-U8_MAX = 2**8 - 1
-U16_MAX = 2**16 - 1
-U32_MAX = 2**32 - 1
-U64_MAX = 2**64 - 1
-U128_MAX = 2**128 - 1
+I8_MIN: Final = -(2**7)
+I16_MIN: Final = -(2**15)
+I32_MIN: Final = -(2**31)
+I64_MIN: Final = -(2**63)
+I128_MIN: Final = -(2**127)
+I8_MAX: Final = 2**7 - 1
+I16_MAX: Final = 2**15 - 1
+I32_MAX: Final = 2**31 - 1
+I64_MAX: Final = 2**63 - 1
+I128_MAX: Final = 2**127 - 1
+U8_MAX: Final = 2**8 - 1
+U16_MAX: Final = 2**16 - 1
+U32_MAX: Final = 2**32 - 1
+U64_MAX: Final = 2**64 - 1
+U128_MAX: Final = 2**128 - 1
 
 # Temporal
-SECONDS_PER_DAY = 86_400
-SECONDS_PER_HOUR = 3_600
-NS_PER_SECOND = 1_000_000_000
-US_PER_SECOND = 1_000_000
-MS_PER_SECOND = 1_000
+SECONDS_PER_DAY: Final = 86_400
+SECONDS_PER_HOUR: Final = 3_600
+NS_PER_SECOND: Final = 1_000_000_000
+US_PER_SECOND: Final = 1_000_000
+MS_PER_SECOND: Final = 1_000
 
-EPOCH_DATE = date(1970, 1, 1)
-EPOCH = datetime(1970, 1, 1).replace(tzinfo=None)
-EPOCH_UTC = datetime(1970, 1, 1, tzinfo=timezone.utc)
+EPOCH_DATE: Final = date(1970, 1, 1)
+EPOCH: Final = datetime(1970, 1, 1).replace(tzinfo=None)
+EPOCH_UTC: Final = datetime(1970, 1, 1, tzinfo=timezone.utc)

--- a/py-polars/src/polars/_utils/construction/utils.py
+++ b/py-polars/src/polars/_utils/construction/utils.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Callable, get_type_hints
+from typing import TYPE_CHECKING, Any, Callable, Final, get_type_hints
 
 from polars._dependencies import _check_for_pydantic, pydantic
 
 if TYPE_CHECKING:
     import pandas as pd
 
-PANDAS_SIMPLE_NUMPY_DTYPES = {
+PANDAS_SIMPLE_NUMPY_DTYPES: Final[set[str]] = {
     "int64",
     "int32",
     "int16",

--- a/py-polars/src/polars/_utils/udfs.py
+++ b/py-polars/src/polars/_utils/udfs.py
@@ -19,6 +19,7 @@ from typing import (
     Any,
     Callable,
     ClassVar,
+    Final,
     Literal,
     NamedTuple,
     Union,
@@ -51,9 +52,9 @@ class StackValue(NamedTuple):
 MapTarget: TypeAlias = Literal["expr", "frame", "series"]
 StackEntry: TypeAlias = Union[str, StackValue]
 
-_MIN_PY311 = sys.version_info >= (3, 11)
-_MIN_PY312 = _MIN_PY311 and sys.version_info >= (3, 12)
-_MIN_PY314 = _MIN_PY312 and sys.version_info >= (3, 14)
+_MIN_PY311: Final = sys.version_info >= (3, 11)
+_MIN_PY312: Final = _MIN_PY311 and sys.version_info >= (3, 12)
+_MIN_PY314: Final = _MIN_PY312 and sys.version_info >= (3, 14)
 
 _BYTECODE_PARSER_CACHE_: MutableMapping[
     tuple[Callable[[Any], Any], str], BytecodeParser
@@ -121,7 +122,7 @@ class OpNames:
 
 
 # math module funcs that we can map to native expressions
-_MATH_FUNCTIONS = frozenset(
+_MATH_FUNCTIONS: Final[frozenset[str]] = frozenset(
     (
         "acos",
         "acosh",
@@ -150,8 +151,8 @@ _MATH_FUNCTIONS = frozenset(
 )
 
 # numpy functions that we can map to native expressions
-_NUMPY_MODULE_ALIASES = frozenset(("np", "numpy"))
-_NUMPY_FUNCTIONS = frozenset(
+_NUMPY_MODULE_ALIASES: Final[frozenset[str]] = frozenset(("np", "numpy"))
+_NUMPY_FUNCTIONS: Final[frozenset[str]] = frozenset(
     (
         # "abs",  # TODO: this one clashes with Python builtin abs
         "arccos",
@@ -181,7 +182,7 @@ _NUMPY_FUNCTIONS = frozenset(
 )
 
 # python attrs/funcs that map to native expressions
-_PYTHON_ATTRS_MAP = {
+_PYTHON_ATTRS_MAP: Final[dict[str, str]] = {
     "date": "dt.date()",
     "day": "dt.day()",
     "hour": "dt.hour()",
@@ -191,9 +192,13 @@ _PYTHON_ATTRS_MAP = {
     "second": "dt.second()",
     "year": "dt.year()",
 }
-_PYTHON_CASTS_MAP = {"float": "Float64", "int": "Int64", "str": "String"}
-_PYTHON_BUILTINS = frozenset(_PYTHON_CASTS_MAP) | {"abs"}
-_PYTHON_METHODS_MAP = {
+_PYTHON_CASTS_MAP: Final[dict[str, str]] = {
+    "float": "Float64",
+    "int": "Int64",
+    "str": "String",
+}
+_PYTHON_BUILTINS: Final[frozenset[str]] = frozenset(_PYTHON_CASTS_MAP) | {"abs"}
+_PYTHON_METHODS_MAP: Final[dict[str, str]] = {
     # string
     "endswith": "str.ends_with",
     "lower": "str.to_lowercase",
@@ -284,7 +289,7 @@ _MODULE_FUNCTIONS = [
     for unary in [[set(OpNames.UNARY)], []]
 ]
 # Lookup for module functions that have different names as polars expressions
-_MODULE_FUNC_TO_EXPR_NAME = {
+_MODULE_FUNC_TO_EXPR_NAME: Final[dict[str, str]] = {
     "math.acos": "arccos",
     "math.acosh": "arccosh",
     "math.asin": "arcsin",
@@ -293,9 +298,9 @@ _MODULE_FUNC_TO_EXPR_NAME = {
     "math.atanh": "arctanh",
     "json.loads": "str.json_decode",
 }
-_RE_IMPLICIT_BOOL = re.compile(r'pl\.col\("([^"]*)"\) & pl\.col\("\1"\)\.(.+)')
-_RE_SERIES_NAMES = re.compile(r"^(s|srs\d?|series)\.")
-_RE_STRIP_BOOL = re.compile(r"^bool\((.+)\)$")
+_RE_IMPLICIT_BOOL: Final = re.compile(r'pl\.col\("([^"]*)"\) & pl\.col\("\1"\)\.(.+)')
+_RE_SERIES_NAMES: Final = re.compile(r"^(s|srs\d?|series)\.")
+_RE_STRIP_BOOL: Final = re.compile(r"^bool\((.+)\)$")
 
 
 def _get_all_caller_variables() -> dict[str, Any]:

--- a/py-polars/src/polars/config.py
+++ b/py-polars/src/polars/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, TypedDict, get_args
+from typing import TYPE_CHECKING, Final, Literal, TypedDict, get_args
 
 from polars._dependencies import json
 from polars._typing import EngineType
@@ -58,7 +58,7 @@ TableFormatNames: TypeAlias = Literal[
 # note: register all Config-specific environment variable names here; need to constrain
 # which 'POLARS_' environment variables are recognized, as there are other lower-level
 # and/or unstable settings that should not be saved or reset with the Config vars.
-_POLARS_CFG_ENV_VARS = {
+_POLARS_CFG_ENV_VARS: Final[set[str]] = {
     "POLARS_WARN_UNSTABLE",
     "POLARS_FMT_MAX_COLS",
     "POLARS_FMT_MAX_ROWS",

--- a/py-polars/src/polars/datatypes/_parse.py
+++ b/py-polars/src/polars/datatypes/_parse.py
@@ -7,7 +7,7 @@ import sys
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal as PyDecimal
 from inspect import isclass
-from typing import TYPE_CHECKING, Any, ForwardRef, NoReturn, Union, get_args
+from typing import TYPE_CHECKING, Any, Final, ForwardRef, NoReturn, Union, get_args
 
 import polars._reexport as pl
 from polars.datatypes.classes import (
@@ -135,7 +135,7 @@ def _parse_generic_into_dtype(input: Any) -> PolarsDataType:
     return List(inner_dtype)
 
 
-PY_TYPE_STR_TO_DTYPE: SchemaDict = {
+PY_TYPE_STR_TO_DTYPE: Final[SchemaDict] = {
     "Decimal": Decimal,
     "NoneType": Null(),
     "bool": Boolean(),

--- a/py-polars/src/polars/datatypes/constants.py
+++ b/py-polars/src/polars/datatypes/constants.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 if TYPE_CHECKING:
     from polars._typing import TimeUnit
 
 # Number of rows to scan by default when inferring datatypes
-N_INFER_DEFAULT = 100
+N_INFER_DEFAULT: Final = 100
 
-DTYPE_TEMPORAL_UNITS: frozenset[TimeUnit] = frozenset(["ns", "us", "ms"])
+DTYPE_TEMPORAL_UNITS: Final[frozenset[TimeUnit]] = frozenset(["ns", "us", "ms"])

--- a/py-polars/src/polars/datatypes/group.py
+++ b/py-polars/src/polars/datatypes/group.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 from polars.datatypes.classes import (
     Array,
@@ -79,7 +79,7 @@ class DataTypeGroup(frozenset):  # type: ignore[type-arg]
         return super().__contains__(item)
 
 
-SIGNED_INTEGER_DTYPES: frozenset[PolarsIntegerType] = DataTypeGroup(
+SIGNED_INTEGER_DTYPES: Final[frozenset[PolarsIntegerType]] = DataTypeGroup(
     [
         Int8,
         Int16,
@@ -88,7 +88,7 @@ SIGNED_INTEGER_DTYPES: frozenset[PolarsIntegerType] = DataTypeGroup(
         Int128,
     ]
 )
-UNSIGNED_INTEGER_DTYPES: frozenset[PolarsIntegerType] = DataTypeGroup(
+UNSIGNED_INTEGER_DTYPES: Final[frozenset[PolarsIntegerType]] = DataTypeGroup(
     [
         UInt8,
         UInt16,
@@ -97,15 +97,17 @@ UNSIGNED_INTEGER_DTYPES: frozenset[PolarsIntegerType] = DataTypeGroup(
         UInt128,
     ]
 )
-INTEGER_DTYPES: frozenset[PolarsIntegerType] = (
+INTEGER_DTYPES: Final[frozenset[PolarsIntegerType]] = (
     SIGNED_INTEGER_DTYPES | UNSIGNED_INTEGER_DTYPES
 )
-FLOAT_DTYPES: frozenset[PolarsDataType] = DataTypeGroup([Float16, Float32, Float64])
-NUMERIC_DTYPES: frozenset[PolarsDataType] = DataTypeGroup(
+FLOAT_DTYPES: Final[frozenset[PolarsDataType]] = DataTypeGroup(
+    [Float16, Float32, Float64]
+)
+NUMERIC_DTYPES: Final[frozenset[PolarsDataType]] = DataTypeGroup(
     FLOAT_DTYPES | INTEGER_DTYPES | frozenset([Decimal])
 )
 
-DATETIME_DTYPES: frozenset[PolarsDataType] = DataTypeGroup(
+DATETIME_DTYPES: Final[frozenset[PolarsDataType]] = DataTypeGroup(
     [
         Datetime,
         Datetime("ms"),
@@ -116,7 +118,7 @@ DATETIME_DTYPES: frozenset[PolarsDataType] = DataTypeGroup(
         Datetime("ns", "*"),
     ]
 )
-DURATION_DTYPES: frozenset[PolarsDataType] = DataTypeGroup(
+DURATION_DTYPES: Final[frozenset[PolarsDataType]] = DataTypeGroup(
     [
         Duration,
         Duration("ms"),
@@ -124,8 +126,8 @@ DURATION_DTYPES: frozenset[PolarsDataType] = DataTypeGroup(
         Duration("ns"),
     ]
 )
-TEMPORAL_DTYPES: frozenset[PolarsTemporalType] = DataTypeGroup(
+TEMPORAL_DTYPES: Final[frozenset[PolarsTemporalType]] = DataTypeGroup(
     frozenset([Date, Time]) | DATETIME_DTYPES | DURATION_DTYPES
 )
 
-NESTED_DTYPES: frozenset[PolarsDataType] = DataTypeGroup([List, Struct, Array])
+NESTED_DTYPES: Final[frozenset[PolarsDataType]] = DataTypeGroup([List, Struct, Array])

--- a/py-polars/src/polars/io/cloud/credential_provider/_builder.py
+++ b/py-polars/src/polars/io/cloud/credential_provider/_builder.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 import os
 import threading
-from typing import TYPE_CHECKING, Any, Callable, Literal, Union
+from typing import TYPE_CHECKING, Any, Callable, Final, Literal, Union
 
 import polars._utils.logging
 from polars._utils.cache import LRUCache
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
         from typing_extensions import TypeAlias
 
 # https://docs.rs/object_store/latest/object_store/enum.ClientConfigKey.html
-OBJECT_STORE_CLIENT_OPTIONS: frozenset[str] = frozenset(
+OBJECT_STORE_CLIENT_OPTIONS: Final[frozenset[str]] = frozenset(
     [
         "allow_http",
         "allow_invalid_certificates",

--- a/py-polars/src/polars/io/database/_arrow_registry.py
+++ b/py-polars/src/polars/io/database/_arrow_registry.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Final, TypedDict
 
 
 class ArrowDriverProperties(TypedDict):
@@ -18,7 +18,7 @@ class ArrowDriverProperties(TypedDict):
 
 
 # arrow driver properties should be specified from highest `minimum_version` to lowest
-ARROW_DRIVER_REGISTRY: dict[str, list[ArrowDriverProperties]] = {
+ARROW_DRIVER_REGISTRY: Final[dict[str, list[ArrowDriverProperties]]] = {
     # In version 1.6.0, ADBC released `Cursor.fetch_arrow`, returning an object
     # implementing the Arrow PyCapsule interface (not requiring PyArrow). This should be
     # used if the version permits.

--- a/py-polars/src/polars/io/database/_executor.py
+++ b/py-polars/src/polars/io/database/_executor.py
@@ -4,7 +4,7 @@ import re
 from collections.abc import Coroutine, Sequence
 from contextlib import suppress
 from inspect import Parameter, signature
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 from polars import functions as F
 from polars._utils.various import parse_version, qualified_type_name
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     from polars import DataFrame
     from polars._typing import ConnectionOrCursor, Cursor, SchemaDict
 
-_INVALID_QUERY_TYPES = {
+_INVALID_QUERY_TYPES: Final[set[str]] = {
     "ALTER",
     "ANALYZE",
     "CREATE",

--- a/py-polars/src/polars/io/iceberg/dataset.py
+++ b/py-polars/src/polars/io/iceberg/dataset.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import partial
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Final, Literal
 
 import polars._reexport as pl
 from polars._utils.logging import eprint, verbose, verbose_print_sensitive
@@ -597,7 +597,7 @@ def _convert_iceberg_to_object_store_storage_options(
 
 # https://py.iceberg.apache.org/configuration/#fileio
 # This does not contain all keys - some have no object-store equivalent.
-ICEBERG_TO_OBJECT_STORE_CONFIG_KEY_MAP: dict[str, str] = {
+ICEBERG_TO_OBJECT_STORE_CONFIG_KEY_MAP: Final[dict[str, str]] = {
     # S3
     "s3.endpoint": "aws_endpoint_url",
     "s3.access-key-id": "aws_access_key_id",


### PR DESCRIPTION
**Ref:** _PEP591 https://peps.python.org/pep-0591/_

Minor typing improvement for the Python side; mark module-level constants as `Final`[^1] so the type-checker can warn us if they are accidentally modified/reassigned. 

Might be a few other places where this is useful, or that I missed (and there is also a `final` decorator we could look at), but this covers the obvious/basic cases.

[^1]: https://docs.python.org/3/library/typing.html#typing.Final