### PR TITLE
refactor: Add asserts and tests for `list.eval` on multiple chunks with slicing

### DIFF
--- a/crates/polars-expr/src/expressions/eval.rs
+++ b/crates/polars-expr/src/expressions/eval.rs
@@ -105,6 +105,8 @@ impl EvalExpr {
         }
 
         let offsets = ca.offsets()?;
+        // Detect accidental inclusion of sliced-out elements from chunks after the 1st (if present).
+        assert_eq!(i64::try_from(flattened_len).unwrap(), *offsets.last());
 
         // Create groups for all valid array elements.
         let groups = if ca.has_nulls() {
@@ -247,6 +249,8 @@ impl EvalExpr {
                 out.clone().into_column()
             });
         }
+
+        assert_eq!(flattened_len, ca.width() * ca.len());
 
         // Create groups for all valid array elements.
         let groups = if ca.has_nulls() {

--- a/py-polars/tests/unit/operations/namespaces/list/test_eval.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_eval.py
@@ -610,6 +610,16 @@ def test_list_agg_after_filter_in_agg_25361(
     assert out.select(pl.col.a.count()).item() == df.select(pl.col.a.count()).item()
 
 
+def test_array_eval_after_slice() -> None:
+    df = pl.DataFrame({"array": [[0], [1]]}, schema={"array": pl.Array(pl.Int64, 1)})
+    df = pl.concat([df, df.slice(1)], rechunk=False)
+
+    assert_frame_equal(
+        df.select(pl.col("array").arr.eval(pl.element().first(), as_list=True)),
+        pl.DataFrame({"array": [[0], [1], [1]]}),
+    )
+
+
 def test_list_eval_after_slice() -> None:
     df = pl.DataFrame({"list": [[1], range(1, 10), range(1, 10)]})
     df_concat = pl.concat([df, df.slice(1)])
@@ -619,6 +629,14 @@ def test_list_eval_after_slice() -> None:
         )
     )
     assert all(grouped_result.to_series().to_list())
+
+    df = pl.DataFrame({"list": [[0], [1]]})
+    df = pl.concat([df, df.slice(1)], rechunk=False)
+
+    assert_frame_equal(
+        df.select(pl.col("list").list.eval(pl.element().first())),
+        pl.DataFrame({"list": [[0], [1], [1]]}),
+    )
 
 
 def test_list_agg_after_slice() -> None:


### PR DESCRIPTION
* ref https://github.com/pola-rs/polars/pull/25540
* ref https://github.com/pola-rs/polars/issues/25555

We were pairing the inner values retrieved from `ListChunked::get_inner()` with the offsets from `ListChunked::offsets()`. This does not match if there are multiple chunks where a chunk after the 1st has sliced-out elements.
