### PR TITLE
chore(python): Ignore a couple of unexplained typing errors

### DIFF
--- a/py-polars/src/polars/_utils/construction/dataframe.py
+++ b/py-polars/src/polars/_utils/construction/dataframe.py
@@ -1161,9 +1161,8 @@ def _pandas_has_default_index(df: pd.DataFrame) -> bool:
     else:
         # finally, is the index _equivalent_ to a default unnamed
         # integer index with frame data that was previously sorted
-        return (
-            str(df.index.dtype).startswith("int")
-            and (df.index.sort_values() == np.arange(len(df))).all()
+        return str(df.index.dtype).startswith("int") and bool(
+            (df.index.sort_values() == np.arange(len(df))).all()
         )
 
 

--- a/py-polars/tests/unit/interchange/test_roundtrip.py
+++ b/py-polars/tests/unit/interchange/test_roundtrip.py
@@ -163,7 +163,7 @@ def test_from_dataframe_pyarrow_zero_copy_parametric(df: pl.DataFrame) -> None:
 )
 def test_from_dataframe_pandas_parametric(df: pl.DataFrame) -> None:
     df_pd = df.to_pandas(use_pyarrow_extension_array=True)
-    result = from_dataframe_interchange_protocol(df_pd)  # type: ignore[arg-type]
+    result = from_dataframe_interchange_protocol(df_pd)  # type: ignore[arg-type,unused-ignore]
     assert_frame_equal(result, df, categorical_as_str=True)
 
 
@@ -185,7 +185,7 @@ def test_from_dataframe_pandas_parametric(df: pl.DataFrame) -> None:
 )
 def test_from_dataframe_pandas_zero_copy_parametric(df: pl.DataFrame) -> None:
     df_pd = df.to_pandas(use_pyarrow_extension_array=True)
-    result = from_dataframe_interchange_protocol(df_pd, allow_copy=False)  # type: ignore[arg-type]
+    result = from_dataframe_interchange_protocol(df_pd, allow_copy=False)  # type: ignore[arg-type,unused-ignore]
     assert_frame_equal(result, df)
 
 
@@ -204,7 +204,7 @@ def test_from_dataframe_pandas_zero_copy_parametric(df: pl.DataFrame) -> None:
 )
 def test_from_dataframe_pandas_native_parametric(df: pl.DataFrame) -> None:
     df_pd = df.to_pandas()
-    result = from_dataframe_interchange_protocol(df_pd)  # type: ignore[arg-type]
+    result = from_dataframe_interchange_protocol(df_pd)  # type: ignore[arg-type,unused-ignore]
     assert_frame_equal(result, df, categorical_as_str=True)
 
 
@@ -226,7 +226,7 @@ def test_from_dataframe_pandas_native_parametric(df: pl.DataFrame) -> None:
 )
 def test_from_dataframe_pandas_native_zero_copy_parametric(df: pl.DataFrame) -> None:
     df_pd = df.to_pandas()
-    result = from_dataframe_interchange_protocol(df_pd, allow_copy=False)  # type: ignore[arg-type]
+    result = from_dataframe_interchange_protocol(df_pd, allow_copy=False)  # type: ignore[arg-type,unused-ignore]
     assert_frame_equal(result, df)
 
 

--- a/py-polars/tests/unit/interchange/test_roundtrip.py
+++ b/py-polars/tests/unit/interchange/test_roundtrip.py
@@ -163,7 +163,7 @@ def test_from_dataframe_pyarrow_zero_copy_parametric(df: pl.DataFrame) -> None:
 )
 def test_from_dataframe_pandas_parametric(df: pl.DataFrame) -> None:
     df_pd = df.to_pandas(use_pyarrow_extension_array=True)
-    result = from_dataframe_interchange_protocol(df_pd)
+    result = from_dataframe_interchange_protocol(df_pd)  # type: ignore[arg-type]
     assert_frame_equal(result, df, categorical_as_str=True)
 
 
@@ -185,7 +185,7 @@ def test_from_dataframe_pandas_parametric(df: pl.DataFrame) -> None:
 )
 def test_from_dataframe_pandas_zero_copy_parametric(df: pl.DataFrame) -> None:
     df_pd = df.to_pandas(use_pyarrow_extension_array=True)
-    result = from_dataframe_interchange_protocol(df_pd, allow_copy=False)
+    result = from_dataframe_interchange_protocol(df_pd, allow_copy=False)  # type: ignore[arg-type]
     assert_frame_equal(result, df)
 
 
@@ -204,7 +204,7 @@ def test_from_dataframe_pandas_zero_copy_parametric(df: pl.DataFrame) -> None:
 )
 def test_from_dataframe_pandas_native_parametric(df: pl.DataFrame) -> None:
     df_pd = df.to_pandas()
-    result = from_dataframe_interchange_protocol(df_pd)
+    result = from_dataframe_interchange_protocol(df_pd)  # type: ignore[arg-type]
     assert_frame_equal(result, df, categorical_as_str=True)
 
 
@@ -226,7 +226,7 @@ def test_from_dataframe_pandas_native_parametric(df: pl.DataFrame) -> None:
 )
 def test_from_dataframe_pandas_native_zero_copy_parametric(df: pl.DataFrame) -> None:
     df_pd = df.to_pandas()
-    result = from_dataframe_interchange_protocol(df_pd, allow_copy=False)
+    result = from_dataframe_interchange_protocol(df_pd, allow_copy=False)  # type: ignore[arg-type]
     assert_frame_equal(result, df)
 
 

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -526,8 +526,7 @@ def test_to_pandas(test_data: list[Any]) -> None:
     if a.dtype == pl.List:
         vals_b = [(None if x is None else x.tolist()) for x in b]
     else:
-        v = b.replace({np.nan: None}).values.tolist()
-        vals_b = cast("list[Any]", v)
+        vals_b = b.replace({np.nan: None}).values.tolist()
 
     assert vals_b == test_data
 


### PR DESCRIPTION
This PR fixes (or rather, suppresses) the new mypy errors that have been breaking the CI.