### PR TITLE
fix: Hang in multi-chunk DataFrame .rows()

### DIFF
--- a/crates/polars-python/src/dataframe/export.rs
+++ b/crates/polars-python/src/dataframe/export.rs
@@ -48,7 +48,7 @@ impl PyDataFrame {
         // TODO: iterate over the chunks directly instead of using random access.
         let df = if df.max_n_chunks() > 16 {
             rechunked = df.clone();
-            rechunked.as_single_chunk_par();
+            py.enter_polars_ok(|| rechunked.as_single_chunk_par())?;
             &rechunked
         } else {
             &df


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/25573.

We didn't release the GIL when rechunking and I guess that creates a deadlock. This seems to fix it.