### PR TITLE
refactor(rust): Add `arg_sort()` and `Writeable::as_buffered()`

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/downcast.rs
+++ b/crates/polars-core/src/chunked_array/ops/downcast.rs
@@ -109,6 +109,8 @@ impl<T: PolarsDataType> ChunkedArray<T> {
         unsafe { Some(&*(arr as *const dyn Array as *const T::Array)) }
     }
 
+    /// # Panics
+    /// Panics if `self.chunks().len() != 1`.
     #[inline]
     pub fn downcast_as_array(&self) -> &T::Array {
         assert_eq!(self.chunks.len(), 1);


### PR DESCRIPTION
* Move arg-sort logic out of `DataFrame::sort_impl()` into a re-usable function
* `Writeable::as_buffered()` to ensure we don't apply buffering on a `CloudWriter`, as that already has internal buffering

Will be used by streaming IO sinks
