### PR TITLE
ci(python): Add disk-cleaning step for Ubuntu runners

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Free some disk space (remove unused packages)
         uses: jlumbroso/free-disk-space@v1.3.1
+        if: ${{ matrix.os != 'windows-latest' }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
@orlp this should do it. It will add some ~2 mins per run though (**EDIT:** but since most of the runs take around 25 mins I reckon we should be fine?).