### PR TITLE
refactor(rust): Add streaming IO sink components

### DIFF
--- a/crates/polars-stream/src/nodes/io_sinks2/components/arg_sort.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/components/arg_sort.rs
@@ -1,0 +1,52 @@
+use std::sync::Arc;
+
+use futures::{StreamExt as _, TryStreamExt as _};
+use polars_core::frame::DataFrame;
+use polars_core::prelude::sort::arg_sort;
+use polars_core::prelude::{Column, IdxArr, SortMultipleOptions};
+use polars_error::PolarsResult;
+use polars_expr::state::ExecutionState;
+
+use crate::async_executor::TaskPriority;
+use crate::async_primitives::opt_spawned_future::parallelize_first_to_local;
+use crate::expression::StreamExpr;
+
+#[derive(Clone)]
+pub struct ArgSortBy {
+    pub by: Arc<[StreamExpr]>,
+    pub sort_options: SortMultipleOptions,
+    pub in_memory_exec_state: Arc<ExecutionState>,
+}
+
+impl ArgSortBy {
+    pub async fn arg_sort_by_par(self, df: &Arc<DataFrame>) -> PolarsResult<IdxArr> {
+        let ArgSortBy {
+            by,
+            sort_options,
+            in_memory_exec_state,
+        } = self;
+
+        let sort_by_cols: Vec<Column> = futures::stream::iter(parallelize_first_to_local(
+            TaskPriority::Low,
+            (0..by.len()).map(|i| {
+                let df = Arc::clone(df);
+                let by = Arc::clone(&by);
+                let in_memory_exec_state = Arc::clone(&in_memory_exec_state);
+
+                async move {
+                    by[i]
+                        .evaluate(&df, in_memory_exec_state.as_ref())
+                        .await
+                        .map(|c| c.rechunk())
+                }
+            }),
+        ))
+        .then(|x| x)
+        .try_collect()
+        .await?;
+
+        Ok(arg_sort(&sort_by_cols, sort_options)?
+            .downcast_as_array()
+            .clone())
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sinks2/components/error_capture.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/components/error_capture.rs
@@ -1,0 +1,64 @@
+use std::any::Any;
+use std::panic::AssertUnwindSafe;
+
+use futures::FutureExt;
+use polars_error::{PolarsError, PolarsResult};
+
+/// Utility to capture errors and propagate them to an associated [`ErrorHandle`].
+#[derive(Clone)]
+pub struct ErrorCapture {
+    tx: tokio::sync::mpsc::Sender<ErrorMessage>,
+}
+
+impl ErrorCapture {
+    pub fn new() -> (Self, ErrorHandle) {
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        (Self { tx }, ErrorHandle { rx })
+    }
+
+    /// Wraps a future such that its error result is sent to the associated [`ErrorHandle`].
+    pub async fn wrap_future<F, O>(self, fut: F)
+    where
+        F: Future<Output = PolarsResult<O>>,
+    {
+        let err: Result<(), tokio::sync::mpsc::error::TrySendError<ErrorMessage>> =
+            match AssertUnwindSafe(fut).catch_unwind().await {
+                Ok(Ok(_)) => return,
+                Ok(Err(err)) => self.tx.try_send(ErrorMessage::Error(err)),
+                Err(panic) => self.tx.try_send(ErrorMessage::Panic(panic)),
+            };
+        drop(err);
+    }
+}
+
+enum ErrorMessage {
+    Error(PolarsError),
+    Panic(Box<dyn Any + Send + 'static>),
+}
+
+/// Handle to await the completion of multiple tasks. Propagates error results
+/// and resumes unwinds when joined.
+pub struct ErrorHandle {
+    rx: tokio::sync::mpsc::Receiver<ErrorMessage>,
+}
+
+impl ErrorHandle {
+    pub fn has_errored(&self) -> bool {
+        !self.rx.is_empty()
+    }
+
+    /// Block until either an error is received, or all [`ErrorCapture`]s associated with this
+    /// handle are dropped (i.e. successful completion of all wrapped futures).
+    ///
+    /// # Panics
+    /// If a panic is received, this will resume unwinding.
+    pub async fn join(self) -> PolarsResult<()> {
+        let ErrorHandle { mut rx } = self;
+
+        match rx.recv().await {
+            None => Ok(()),
+            Some(ErrorMessage::Error(e)) => Err(e),
+            Some(ErrorMessage::Panic(panic)) => std::panic::resume_unwind(panic),
+        }
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sinks2/components/exclude_keys_projection.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/components/exclude_keys_projection.rs
@@ -1,0 +1,27 @@
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub enum ExcludeKeysProjection {
+    /// Project these indices
+    Indices(Arc<[usize]>),
+    /// Project this many columns from the left.
+    Width(usize),
+}
+
+impl ExcludeKeysProjection {
+    pub fn iter_indices(&self) -> impl ExactSizeIterator<Item = usize> {
+        let (indices, end) = match self {
+            Self::Indices(indices) => (indices.as_ref(), indices.len()),
+            Self::Width(width) => (&[][..], *width),
+        };
+
+        (0..end).map(|i| if indices.is_empty() { i } else { indices[i] })
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Indices(indices) => indices.len(),
+            Self::Width(len) => *len,
+        }
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sinks2/components/file_provider.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/components/file_provider.rs
@@ -1,0 +1,114 @@
+use std::fmt::Write;
+use std::sync::Arc;
+
+use polars_core::prelude::{Column, DataType};
+use polars_error::PolarsResult;
+use polars_io::cloud::CloudOptions;
+use polars_io::pl_async;
+use polars_io::utils::HIVE_VALUE_ENCODE_CHARSET;
+use polars_io::utils::file::Writeable;
+use polars_plan::dsl::sink2::{FileProviderReturn, FileProviderType};
+use polars_plan::prelude::sink2::FileProviderArgs;
+use polars_utils::plpath::PlPath;
+
+pub struct FileProvider {
+    pub base_path: PlPath,
+    pub cloud_options: Option<Arc<CloudOptions>>,
+    pub provider_type: FileProviderType,
+}
+
+impl FileProvider {
+    pub async fn open_file(&self, args: FileProviderArgs) -> PolarsResult<Writeable> {
+        let provided_path: String = match &self.provider_type {
+            FileProviderType::Hive { extension } => {
+                let FileProviderArgs {
+                    index_in_partition,
+                    partition_keys,
+                } = args;
+
+                let mut partition_parts = String::new();
+
+                let partition_keys: &[Column] = partition_keys.get_columns();
+
+                write!(
+                    &mut partition_parts,
+                    "{}",
+                    HivePathFormatter::new(partition_keys)
+                )
+                .unwrap();
+
+                assert!(index_in_partition <= 0xffff_ffff);
+
+                write!(&mut partition_parts, "{index_in_partition:08x}.{extension}").unwrap();
+
+                partition_parts
+            },
+
+            FileProviderType::Function(f) => {
+                let f = f.clone();
+
+                let out = pl_async::get_runtime()
+                    .spawn_blocking(move || f.get_file(args))
+                    .await
+                    .unwrap()?;
+
+                match out {
+                    FileProviderReturn::Path(p) => p,
+                    FileProviderReturn::Writeable(v) => return Ok(v),
+                }
+            },
+
+            FileProviderType::Legacy(_) => unreachable!(),
+        };
+
+        let path = self.base_path.as_ref().join(&provided_path);
+        let path = path.as_ref();
+
+        if let Some(path) = path.as_local_path().and_then(|p| p.parent()) {
+            // Ignore errors from directory creation - the `Writeable::try_new()` below will raise
+            // appropriate errors.
+            let _ = tokio::fs::DirBuilder::new()
+                .recursive(true)
+                .create(path)
+                .await;
+        }
+
+        Writeable::try_new(path, self.cloud_options.as_deref())
+    }
+}
+
+/// # Panics
+/// The `Display` impl of this will panic if a column has non-unit length.
+pub struct HivePathFormatter<'a> {
+    keys: &'a [Column],
+}
+
+impl<'a> HivePathFormatter<'a> {
+    pub fn new(keys: &'a [Column]) -> Self {
+        Self { keys }
+    }
+}
+
+impl std::fmt::Display for HivePathFormatter<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for column in self.keys {
+            assert_eq!(column.len(), 1);
+            let column = column.cast(&DataType::String).unwrap();
+
+            let key = column.name();
+            let value = percent_encoding::percent_encode(
+                column
+                    .str()
+                    .unwrap()
+                    .get(0)
+                    .unwrap_or("__HIVE_DEFAULT_PARTITION__")
+                    .as_bytes(),
+                HIVE_VALUE_ENCODE_CHARSET,
+            );
+
+            write!(f, "{key}={value}/")?
+        }
+
+        Ok(())
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sinks2/components/file_sink.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/components/file_sink.rs
@@ -1,0 +1,21 @@
+use polars_error::PolarsResult;
+
+use crate::async_executor;
+use crate::async_primitives::connector;
+use crate::nodes::io_sinks2::components::sink_morsel::SinkMorsel;
+use crate::nodes::io_sinks2::components::size::RowCountAndSize;
+
+pub type FileSinkPermit = tokio::sync::OwnedSemaphorePermit;
+
+pub struct FileSinkTaskData {
+    pub morsel_tx: connector::Sender<SinkMorsel>,
+    pub start_position: RowCountAndSize,
+    pub task_handle: async_executor::JoinHandle<PolarsResult<FileSinkPermit>>,
+}
+
+impl FileSinkTaskData {
+    /// Signals to the writer to close, and returns its task handle.
+    pub fn close(self) -> async_executor::JoinHandle<PolarsResult<FileSinkPermit>> {
+        self.task_handle
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sinks2/components/hstack_columns.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/components/hstack_columns.rs
@@ -1,0 +1,67 @@
+use std::sync::Arc;
+
+use polars_core::prelude::Column;
+use polars_core::schema::Schema;
+use polars_utils::marked_usize::MarkedUsize;
+
+/// Applies a `with_columns()` operation with pre-computed indices.
+#[derive(Clone)]
+pub struct HStackColumns {
+    gather_indices: Arc<[MarkedUsize]>,
+}
+
+impl HStackColumns {
+    /// Note:
+    /// * Dtypes of the schemas are unused.
+    pub fn new(output_schema: &Schema, schema_left: &Schema, schema_right: &Schema) -> Self {
+        assert!(schema_left.len() <= MarkedUsize::UNMARKED_MAX);
+        assert!(schema_right.len() <= MarkedUsize::UNMARKED_MAX);
+
+        let gather_indices: Arc<[MarkedUsize]> = output_schema
+            .iter_names()
+            .map(|name| {
+                if let Some((idx, ..)) = schema_right.get_full(name) {
+                    MarkedUsize::new(idx, true)
+                } else {
+                    MarkedUsize::new(schema_left.get_full(name).unwrap().0, false)
+                }
+            })
+            .collect();
+
+        Self { gather_indices }
+    }
+
+    #[expect(unused)]
+    pub fn output_width(&self) -> usize {
+        self.gather_indices.len()
+    }
+
+    /// Broadcasts unit-length columns from the RHS.
+    pub fn hstack_columns_broadcast(
+        &self,
+        height: usize,
+        cols_left: &[Column],
+        cols_right: &[Column],
+    ) -> Vec<Column> {
+        self.gather_indices
+            .iter()
+            .copied()
+            .map(|mi| {
+                let i = mi.idx();
+
+                if mi.marked() {
+                    let c = &cols_right[i];
+
+                    if c.len() != height {
+                        assert_eq!(c.len(), 1);
+                        c.new_from_index(0, height)
+                    } else {
+                        c.clone()
+                    }
+                } else {
+                    cols_left[i].clone()
+                }
+            })
+            .collect()
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sinks2/components/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/components/mod.rs
@@ -1,0 +1,8 @@
+pub mod arg_sort;
+pub mod error_capture;
+pub mod exclude_keys_projection;
+pub mod file_provider;
+pub mod file_sink;
+pub mod hstack_columns;
+pub mod sink_morsel;
+pub mod size;

--- a/crates/polars-stream/src/nodes/io_sinks2/components/sink_morsel.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/components/sink_morsel.rs
@@ -1,0 +1,29 @@
+use polars_core::frame::DataFrame;
+
+pub type SinkMorselPermit = tokio::sync::OwnedSemaphorePermit;
+
+/// In-flight morsel in the IO sink. Holds a permit against a semaphore that restricts
+/// the total number of sink morsels in memory.
+pub struct SinkMorsel {
+    df: DataFrame,
+    /// Should only be dropped once the data associated with this morsel has been dropped from memory.
+    permit: SinkMorselPermit,
+}
+
+impl SinkMorsel {
+    pub fn new(df: DataFrame, permit: SinkMorselPermit) -> Self {
+        Self { df, permit }
+    }
+
+    pub fn into_inner(self) -> (DataFrame, SinkMorselPermit) {
+        (self.df, self.permit)
+    }
+
+    pub fn df(&self) -> &DataFrame {
+        &self.df
+    }
+
+    pub fn df_mut(&mut self) -> &mut DataFrame {
+        &mut self.df
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sinks2/components/size.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/components/size.rs
@@ -1,0 +1,76 @@
+use polars_core::frame::DataFrame;
+use polars_utils::IdxSize;
+
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct RowCountAndSize {
+    pub num_rows: IdxSize,
+    pub num_bytes: u64,
+}
+
+impl RowCountAndSize {
+    pub const MAX: RowCountAndSize = RowCountAndSize {
+        num_rows: IdxSize::MAX,
+        num_bytes: u64::MAX,
+    };
+
+    pub fn new_from_df(df: &DataFrame) -> Self {
+        Self {
+            num_rows: IdxSize::try_from(df.height()).unwrap(),
+            num_bytes: u64::try_from(df.estimated_size()).unwrap(),
+        }
+    }
+
+    pub fn min(self, other: Self) -> Self {
+        Self {
+            num_rows: self.num_rows.min(other.num_rows),
+            num_bytes: self.num_bytes.min(other.num_bytes),
+        }
+    }
+
+    /// How many rows from `other` can fit into `self`.
+    pub fn num_rows_takeable_from(self, other: Self) -> IdxSize {
+        let max_rows = self.num_rows.min(other.num_rows);
+
+        if self.num_bytes == u64::MAX {
+            max_rows
+        } else if self.num_bytes < other.row_byte_size() {
+            0
+        } else {
+            max_rows.min(
+                IdxSize::try_from(self.num_bytes.div_ceil(other.row_byte_size().max(1)))
+                    .unwrap_or(IdxSize::MAX),
+            )
+        }
+    }
+
+    /// Byte size of a single row. If `self.num_rows > 0`, the returned size will be at least 1.
+    pub fn row_byte_size(&self) -> u64 {
+        if self.num_rows == 0 {
+            0
+        } else {
+            #[allow(clippy::useless_conversion)]
+            (self.num_bytes / u64::from(self.num_rows)).max(1)
+        }
+    }
+
+    pub fn checked_add(self, rhs: Self) -> Option<Self> {
+        Some(Self {
+            num_rows: IdxSize::checked_add(self.num_rows, rhs.num_rows)?,
+            num_bytes: u64::checked_add(self.num_bytes, rhs.num_bytes)?,
+        })
+    }
+
+    pub fn checked_sub(self, rhs: Self) -> Option<Self> {
+        Some(Self {
+            num_rows: IdxSize::checked_sub(self.num_rows, rhs.num_rows)?,
+            num_bytes: u64::checked_sub(self.num_bytes, rhs.num_bytes)?,
+        })
+    }
+
+    pub fn saturating_add(self, rhs: Self) -> Self {
+        Self {
+            num_rows: IdxSize::saturating_add(self.num_rows, rhs.num_rows),
+            num_bytes: u64::saturating_add(self.num_bytes, rhs.num_bytes),
+        }
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sinks2/config.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/config.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+
+use polars_core::schema::SchemaRef;
+use polars_plan::dsl::{FileType, UnifiedSinkArgs};
+
+pub struct IOSinkNodeConfig {
+    pub file_format: Arc<FileType>,
+    pub target: IOSinkTarget,
+    pub unified_sink_args: UnifiedSinkArgs,
+    pub input_schema: SchemaRef,
+    pub num_pipelines: usize,
+}
+
+impl IOSinkNodeConfig {
+    pub fn per_sink_pipeline_depth(&self) -> usize {
+        self.inflight_morsel_limit().min(self.num_pipelines)
+    }
+
+    pub fn inflight_morsel_limit(&self) -> usize {
+        if let Ok(v) = std::env::var("POLARS_INFLIGHT_SINK_MORSEL_LIMIT").map(|x| {
+            x.parse::<usize>()
+                .ok()
+                .filter(|x| *x > 0)
+                .unwrap_or_else(|| {
+                    panic!("invalid value for POLARS_INFLIGHT_SINK_MORSEL_LIMIT: {x}")
+                })
+        }) {
+            return v;
+        };
+
+        self.num_pipelines.saturating_add(
+            // Additional buffer to accommodate head-of-line blocking
+            4,
+        )
+    }
+
+    pub fn max_open_sinks(&self) -> usize {
+        if let Ok(v) = std::env::var("POLARS_MAX_OPEN_SINKS").map(|x| {
+            x.parse::<usize>()
+                .ok()
+                .filter(|x| *x > 0)
+                .unwrap_or_else(|| panic!("invalid value for POLARS_MAX_OPEN_SINKS: {x}"))
+        }) {
+            return v;
+        }
+
+        128
+    }
+}
+
+pub enum IOSinkTarget {
+    Partitioned {
+        // TODO
+    },
+}

--- a/crates/polars-stream/src/nodes/io_sinks2/writers/interface.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/writers/interface.rs
@@ -1,0 +1,41 @@
+use polars_error::PolarsResult;
+use polars_io::utils::file::Writeable;
+
+use crate::async_executor;
+use crate::async_primitives::connector;
+use crate::nodes::io_sinks2::components::sink_morsel::SinkMorsel;
+use crate::nodes::io_sinks2::components::size::RowCountAndSize;
+use crate::utils::task_handles_ext;
+
+pub trait FileWriterStarter: Send + Sync + 'static {
+    fn writer_name(&self) -> &str;
+
+    /// Hints to the sender how morsels should be sized.
+    fn ideal_morsel_size(&self) -> RowCountAndSize {
+        default_ideal_sink_morsel_size()
+    }
+
+    fn start_file_writer(
+        &self,
+        morsel_rx: connector::Receiver<SinkMorsel>,
+        file: task_handles_ext::AbortOnDropHandle<PolarsResult<Writeable>>,
+    ) -> PolarsResult<async_executor::JoinHandle<PolarsResult<()>>>;
+}
+
+pub(super) fn default_ideal_sink_morsel_size() -> RowCountAndSize {
+    RowCountAndSize {
+        num_rows: 122_880,
+        num_bytes: {
+            std::env::var("POLARS_IDEAL_SINK_MORSEL_SIZE_BYTES")
+                .map(|x| {
+                    x.parse::<u64>().ok().filter(|x| *x > 0).unwrap_or_else(|| {
+                        panic!("invalid value for POLARS_IDEAL_SINK_MORSEL_SIZE_BYTES: {x}")
+                    })
+                })
+                .unwrap_or(
+                    // Should rarely be hit in practice
+                    64 * 1024 * 1024,
+                )
+        },
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sinks2/writers/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/writers/mod.rs
@@ -1,0 +1,20 @@
+use std::sync::Arc;
+
+use polars_core::schema::SchemaRef;
+use polars_error::PolarsResult;
+use polars_io::utils::sync_on_close::SyncOnCloseType;
+use polars_plan::dsl::FileType;
+
+use crate::nodes::io_sinks2::writers::interface::FileWriterStarter;
+
+pub mod interface;
+
+#[expect(unused)]
+pub fn create_file_writer_starter(
+    file_format: &Arc<FileType>,
+    file_schema: &SchemaRef,
+    pipeline_depth: usize,
+    sync_on_close: SyncOnCloseType,
+) -> PolarsResult<Arc<dyn FileWriterStarter>> {
+    unimplemented!()
+}

--- a/crates/polars-stream/src/nodes/mod.rs
+++ b/crates/polars-stream/src/nodes/mod.rs
@@ -14,6 +14,8 @@ pub mod in_memory_sink;
 pub mod in_memory_source;
 pub mod input_independent_select;
 pub mod io_sinks;
+#[allow(unused)]
+pub mod io_sinks2;
 pub mod io_sources;
 pub mod joins;
 pub mod map;

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -296,6 +296,7 @@ pub fn lower_ir(
                     cloud_options: cloud_options.map(Arc::unwrap_or_clone),
                 }
             },
+
             SinkTypeIR::Partitioned(PartitionedSinkOptionsIR {
                 base_path,
                 file_path_provider,

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -11,8 +11,8 @@ use polars_ops::frame::JoinArgs;
 use polars_plan::dsl::deletion::DeletionFilesList;
 use polars_plan::dsl::{
     CastColumnsPolicy, JoinTypeOptionsIR, MissingColumnsPolicy, PartitionTargetCallback,
-    PartitionVariantIR, ScanSources, SinkFinishCallback, SinkOptions, SinkTarget, SortColumnIR,
-    TableStatistics,
+    PartitionVariantIR, PartitionedSinkOptionsIR, ScanSources, SinkFinishCallback, SinkOptions,
+    SinkTarget, SortColumnIR, TableStatistics,
 };
 use polars_plan::plans::hive::HivePartitionsDf;
 use polars_plan::plans::{AExpr, DataFrameUdf, IR};
@@ -208,6 +208,11 @@ pub enum PhysNodeKind {
         cloud_options: Option<CloudOptions>,
         per_partition_sort_by: Option<Vec<SortColumnIR>>,
         finish_callback: Option<SinkFinishCallback>,
+    },
+
+    PartitionedSink2 {
+        input: PhysStream,
+        options: PartitionedSinkOptionsIR,
     },
 
     SinkMultiple {
@@ -447,6 +452,7 @@ fn visit_node_inputs_mut(
             | PhysNodeKind::CallbackSink { input, .. }
             | PhysNodeKind::FileSink { input, .. }
             | PhysNodeKind::PartitionedSink { input, .. }
+            | PhysNodeKind::PartitionedSink2 { input, .. }
             | PhysNodeKind::InMemoryMap { input, .. }
             | PhysNodeKind::SortedGroupBy { input, .. }
             | PhysNodeKind::Map { input, .. }

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -12,7 +12,7 @@ use polars_expr::reduce::into_reduction;
 use polars_expr::state::ExecutionState;
 use polars_mem_engine::create_physical_plan;
 use polars_mem_engine::scan_predicate::create_scan_predicate;
-use polars_plan::dsl::{JoinOptionsIR, PartitionVariantIR, ScanSources};
+use polars_plan::dsl::{JoinOptionsIR, PartitionVariantIR, PartitionedSinkOptionsIR, ScanSources};
 use polars_plan::plans::expr_ir::ExprIR;
 use polars_plan::plans::{AExpr, ArenaExprIter, IR, IRAggExpr};
 use polars_plan::prelude::{FileType, FunctionFlags};
@@ -371,6 +371,27 @@ fn to_graph_rec<'a>(
                     panic!("activate source feature")
                 },
             }
+        },
+
+        #[expect(unused)]
+        PartitionedSink2 {
+            input,
+            options:
+                PartitionedSinkOptionsIR {
+                    base_path,
+                    file_path_provider,
+                    partition_strategy,
+                    finish_callback: _,
+                    file_format,
+                    unified_sink_args,
+                    max_rows_per_file,
+                    approximate_bytes_per_file,
+                },
+        } => {
+            let input_schema = ctx.phys_sm[input.node].output_schema.clone();
+            let input_key = to_graph_rec(input.node, ctx)?;
+
+            todo!();
         },
 
         PartitionedSink {

--- a/crates/polars-stream/src/physical_plan/visualization/mod.rs
+++ b/crates/polars-stream/src/physical_plan/visualization/mod.rs
@@ -710,6 +710,10 @@ impl PhysicalPlanVisualizationDataGenerator<'_> {
                     ..Default::default()
                 }
             },
+            PhysNodeKind::PartitionedSink2 { input, options: _ } => {
+                phys_node_inputs.push(input.node);
+                unreachable!()
+            },
             PhysNodeKind::PeakMinMax { input, is_peak_max } => {
                 phys_node_inputs.push(input.node);
 

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -27,6 +27,7 @@ pub mod hashing;
 pub mod idx_map;
 pub mod idx_mapper;
 pub mod idx_vec;
+pub mod marked_usize;
 pub mod mem;
 pub mod min_max;
 pub mod order_statistic_tree;

--- a/crates/polars-utils/src/marked_usize.rs
+++ b/crates/polars-utils/src/marked_usize.rs
@@ -1,0 +1,23 @@
+/// A usize where the top bit is used as a marked indicator.
+#[derive(Copy, Clone)]
+pub struct MarkedUsize(usize);
+
+impl MarkedUsize {
+    pub const UNMARKED_MAX: usize = ((1 << (usize::BITS - 1)) - 1);
+
+    #[inline(always)]
+    pub fn new(idx: usize, marked: bool) -> Self {
+        debug_assert!(idx >> (usize::BITS - 1) == 0);
+        Self(idx | ((marked as usize) << (usize::BITS - 1)))
+    }
+
+    #[inline(always)]
+    pub fn idx(&self) -> usize {
+        self.0 & Self::UNMARKED_MAX
+    }
+
+    #[inline(always)]
+    pub fn marked(&self) -> bool {
+        (self.0 >> (usize::BITS - 1)) != 0
+    }
+}


### PR DESCRIPTION
Add components to be used by updated IO sinks. No code is reachable yet.
* `ArgSortBy` - used for per-partition sort
* `ErrorCapture` - used to defer catching of errors
* `ExcludeKeysProjection` - used to exclude key-columns from gathers / vstacks (since they're constant value)
* `FileProvider` - opens files from hive paths or user-provided functions
* `HStackColumns` - performs hstack (i.e. `with_columns()`) with pre-computed indices
  * Uses a newly added `MarkedUsize` (copied from `EvictIdx` with `IdxSize` replaced as `usize`)
* `SinkMorsel` - morsel type for sinks that holds a semaphore permit instead of a wait token
* `RowCountAndSize` - holds row count and byte size.
  * `RowCountAndSize::num_rows_takeable_from()` is used to determine how many rows can fit within e.g. `max_rows_per_file`.
* `trait FileWriterStarter` - Generic trait for starting file writers. Each file format will have an implementation of this.
