### PR TITLE
fix: Change `IdxSize` of `rtcompat` back to `u32`

### DIFF
--- a/crates/polars-python/Cargo.toml
+++ b/crates/polars-python/Cargo.toml
@@ -296,7 +296,7 @@ full = [
 
 rt32 = []
 rt64 = ["polars/bigidx"]
-rtcompat = ["polars/bigidx"]
+rtcompat = []
 
 # we cannot conditionally activate simd
 # https://github.com/rust-lang/cargo/issues/1197


### PR DESCRIPTION
While updating the build logic, the PR #25284 ~~accidentally~~ intentionally enabled the `bigidx` feature for `polars[rtcompat]`, which is a breaking change for consumers of `polars[rtcompat]`. This change occured between the last stable release `1.35.2` and the current pre-release `1.36.0-b2`, and should probably be either reverted or clearly documented before the public release.

This PR reverts to the previous state of `rtcompat` behaving like `rt32` instead of like `rt64`. If a version that combines `rtcompat` and  `bigidx` is desired, it should be provided as a separate `rtcompat64` feature (and `rtcompat` should be made into an alias for a new `rtcompat32` feature).