### PR TITLE
fix: Support varying quantile values per group in group_by aggregation

### DIFF
--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -884,6 +884,25 @@ impl Column {
     ///
     /// Does no bounds checks, groups must be correct.
     #[cfg(feature = "algorithm_group_by")]
+    pub unsafe fn agg_varying_quantile(
+        &self,
+        groups: &GroupsType,
+        quantiles: &[f64],
+        method: QuantileMethod,
+    ) -> Self {
+        // @scalar-opt
+
+        unsafe {
+            self.as_materialized_series()
+                .agg_varying_quantile(groups, quantiles, method)
+        }
+        .into()
+    }
+
+    /// # Safety
+    ///
+    /// Does no bounds checks, groups must be correct.
+    #[cfg(feature = "algorithm_group_by")]
     pub unsafe fn agg_median(&self, groups: &GroupsType) -> Self {
         self.agg_with_scalar_identity(groups, |s, g| unsafe { s.agg_median(g) })
     }

--- a/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
@@ -497,6 +497,73 @@ impl Series {
     }
 
     #[doc(hidden)]
+    pub unsafe fn agg_varying_quantile(
+        &self,
+        groups: &GroupsType,
+        quantiles: &[f64],
+        method: QuantileMethod,
+    ) -> Series {
+        // Prevent a rechunk for every individual group.
+        let s = if groups.len() > 1 {
+            self.rechunk()
+        } else {
+            self.clone()
+        };
+
+        use DataType::*;
+        match s.dtype() {
+            Float32 => s
+                .f32()
+                .unwrap()
+                .agg_varying_quantile(groups, quantiles, method),
+            Float64 => s
+                .f64()
+                .unwrap()
+                .agg_varying_quantile(groups, quantiles, method),
+            #[cfg(feature = "dtype-decimal")]
+            Decimal(_, _) => s
+                .cast(&DataType::Float64)
+                .unwrap()
+                .agg_varying_quantile(groups, quantiles, method),
+            #[cfg(feature = "dtype-datetime")]
+            Datetime(tu, tz) => self
+                .to_physical_repr()
+                .agg_varying_quantile(groups, quantiles, method)
+                .cast(&Int64)
+                .unwrap()
+                .into_datetime(*tu, tz.clone()),
+            #[cfg(feature = "dtype-duration")]
+            Duration(tu) => self
+                .to_physical_repr()
+                .agg_varying_quantile(groups, quantiles, method)
+                .cast(&Int64)
+                .unwrap()
+                .into_duration(*tu),
+            #[cfg(feature = "dtype-time")]
+            Time => self
+                .to_physical_repr()
+                .agg_varying_quantile(groups, quantiles, method)
+                .cast(&Int64)
+                .unwrap()
+                .into_time(),
+            #[cfg(feature = "dtype-date")]
+            Date => (self
+                .to_physical_repr()
+                .agg_varying_quantile(groups, quantiles, method)
+                .cast(&Float64)
+                .unwrap()
+                * (US_IN_DAY as f64))
+                .cast(&DataType::Int64)
+                .unwrap()
+                .into_datetime(TimeUnit::Microseconds, None),
+            dt if dt.is_primitive_numeric() => {
+                apply_method_physical_integer!(s, agg_varying_quantile, groups, quantiles, method)
+            },
+            _ => Series::full_null(PlSmallStr::EMPTY, groups.len(), s.dtype()),
+        }
+    }
+
+    #[doc(hidden)]
     pub unsafe fn agg_last(&self, groups: &GroupsType) -> Series {
         // Prevent a rechunk for every individual group.
         let s = if groups.len() > 1 {

--- a/crates/polars-core/src/frame/group_by/aggregations/mod.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/mod.rs
@@ -176,6 +176,17 @@ where
     ca.into_series()
 }
 
+/// Same as `agg_helper_idx_on_all` but also passes the group index to the closure.
+fn agg_helper_idx_on_all_with_idx<T, F>(groups: &GroupsIdx, f: F) -> Series
+where
+    F: Fn((usize, &IdxVec)) -> Option<T::Native> + Send + Sync,
+    T: PolarsNumericType,
+{
+    let ca: ChunkedArray<T> =
+        RAYON.install(|| groups.all().into_par_iter().enumerate().map(f).collect());
+    ca.into_series()
+}
+
 pub fn _agg_helper_slice<T, F>(groups: &[[IdxSize; 2]], f: F) -> Series
 where
     F: Fn([IdxSize; 2]) -> Option<T::Native> + Send + Sync,
@@ -198,6 +209,22 @@ where
     F: Fn([IdxSize; 2]) -> Option<IdxSize> + Send + Sync,
 {
     let ca: IdxCa = RAYON.install(|| groups.par_iter().copied().map(f).collect());
+    ca.into_series()
+}
+
+/// Same as `_agg_helper_slice` but also passes the group index to the closure.
+fn _agg_helper_slice_with_idx<T, F>(groups: &[[IdxSize; 2]], f: F) -> Series
+where
+    F: Fn(usize, [IdxSize; 2]) -> Option<T::Native> + Send + Sync,
+    T: PolarsNumericType,
+{
+    let ca: ChunkedArray<T> = RAYON.install(|| {
+        groups
+            .par_iter()
+            .enumerate()
+            .map(|(idx, &g)| f(idx, g))
+            .collect()
+    });
     ca.into_series()
 }
 
@@ -343,6 +370,71 @@ where
                     }
                 })
             }
+        },
+    }
+}
+
+/// Compute quantile aggregation where each group can have a different quantile value.
+unsafe fn agg_varying_quantile_generic<T, K>(
+    ca: &ChunkedArray<T>,
+    groups: &GroupsType,
+    quantiles: &[f64],
+    method: QuantileMethod,
+) -> Series
+where
+    T: PolarsNumericType,
+    ChunkedArray<T>: QuantileDispatcher<K::Native>,
+    K: PolarsNumericType,
+    <K as datatypes::PolarsNumericType>::Native: num_traits::Float + quantile_filter::SealedRolling,
+{
+    debug_assert_eq!(
+        quantiles.len(),
+        groups.len(),
+        "quantiles length ({}) must match groups length ({})",
+        quantiles.len(),
+        groups.len()
+    );
+    match groups {
+        GroupsType::Idx(groups) => {
+            let ca = ca.rechunk();
+            agg_helper_idx_on_all_with_idx::<K, _>(groups, |(group_idx, idx)| {
+                debug_assert!(idx.len() <= ca.len());
+                let quantile = quantiles[group_idx];
+                if !(0.0..=1.0).contains(&quantile) {
+                    return None;
+                }
+                match idx.len() {
+                    0 => None,
+                    1 => {
+                        let idx = idx[0] as usize;
+                        ca.get(idx).map(|v| NumCast::from(v).unwrap())
+                    },
+                    _ => {
+                        let take = { ca.take_unchecked(idx) };
+                        take._quantile(quantile, method).unwrap_unchecked()
+                    },
+                }
+            })
+        },
+        GroupsType::Slice { groups, .. } => {
+            _agg_helper_slice_with_idx::<K, _>(groups, |group_idx, [first, len]| {
+                debug_assert!(first + len <= ca.len() as IdxSize);
+                let quantile = quantiles[group_idx];
+                if !(0.0..=1.0).contains(&quantile) {
+                    return None;
+                }
+                match len {
+                    0 => None,
+                    1 => ca.get(first as usize).map(|v| NumCast::from(v).unwrap()),
+                    _ => {
+                        let arr_group = _slice_from_offsets(ca, first, len);
+                        arr_group
+                            ._quantile(quantile, method)
+                            .unwrap_unchecked()
+                            .map(|flt| NumCast::from(flt).unwrap_unchecked())
+                    },
+                }
+            })
         },
     }
 }
@@ -1147,6 +1239,14 @@ impl Float32Chunked {
     ) -> Series {
         agg_quantile_generic::<_, Float32Type>(self, groups, quantile, method)
     }
+    pub(crate) unsafe fn agg_varying_quantile(
+        &self,
+        groups: &GroupsType,
+        quantiles: &[f64],
+        method: QuantileMethod,
+    ) -> Series {
+        agg_varying_quantile_generic::<_, Float32Type>(self, groups, quantiles, method)
+    }
     pub(crate) unsafe fn agg_median(&self, groups: &GroupsType) -> Series {
         agg_median_generic::<_, Float32Type>(self, groups)
     }
@@ -1159,6 +1259,14 @@ impl Float64Chunked {
         method: QuantileMethod,
     ) -> Series {
         agg_quantile_generic::<_, Float64Type>(self, groups, quantile, method)
+    }
+    pub(crate) unsafe fn agg_varying_quantile(
+        &self,
+        groups: &GroupsType,
+        quantiles: &[f64],
+        method: QuantileMethod,
+    ) -> Series {
+        agg_varying_quantile_generic::<_, Float64Type>(self, groups, quantiles, method)
     }
     pub(crate) unsafe fn agg_median(&self, groups: &GroupsType) -> Series {
         agg_median_generic::<_, Float64Type>(self, groups)
@@ -1351,6 +1459,14 @@ where
         method: QuantileMethod,
     ) -> Series {
         agg_quantile_generic::<_, Float64Type>(self, groups, quantile, method)
+    }
+    pub(crate) unsafe fn agg_varying_quantile(
+        &self,
+        groups: &GroupsType,
+        quantiles: &[f64],
+        method: QuantileMethod,
+    ) -> Series {
+        agg_varying_quantile_generic::<_, Float64Type>(self, groups, quantiles, method)
     }
     pub(crate) unsafe fn agg_median(&self, groups: &GroupsType) -> Series {
         agg_median_generic::<_, Float64Type>(self, groups)

--- a/crates/polars-expr/src/dispatch/groups_dispatch.rs
+++ b/crates/polars-expr/src/dispatch/groups_dispatch.rs
@@ -11,8 +11,8 @@ use polars_core::error::{PolarsResult, polars_bail, polars_ensure};
 use polars_core::frame::DataFrame;
 use polars_core::prelude::row_encode::encode_rows_unordered;
 use polars_core::prelude::{
-    AnyValue, BooleanChunked, ChunkCast, Column, CompatLevel, Float64Chunked, GroupPositions,
-    GroupsType, IDX_DTYPE, IntoColumn,
+    AnyValue, BooleanChunked, ChunkCast, Column, CompatLevel, DataType, Float64Chunked,
+    GroupPositions, GroupsType, IDX_DTYPE, IntoColumn,
 };
 use polars_core::runtime::RAYON;
 use polars_core::scalar::Scalar;
@@ -515,41 +515,75 @@ pub fn quantile<'a>(
     // AggregatedScalar has no defined group structure. We fix it up here, so that we can
     // reliably call `agg_quantile` functions with the groups.
     let mut ac = inputs[0].evaluate_on_groups(df, groups, state)?;
+    let quantile_ac = inputs[1].evaluate_on_groups(df, groups, state)?;
     ac.set_groups_for_undefined_agg_states();
 
     // Don't change names by aggregations as is done in polars-core.
     let keep_name = ac.get_values().name().clone();
 
-    let quantile_column = inputs[1].evaluate(df, state)?;
-    polars_ensure!(
-        quantile_column.len() <= 1,
-        ComputeError:
-            "polars only supports computing a single quantile in a groupby aggregation context"
-    );
-    polars_ensure!(
-        quantile_column.dtype().is_numeric(),
-        SchemaMismatch:
-            "expected expression of dtype 'numeric' for quantile, got '{}'",
-        quantile_column.dtype()
-    );
-    let quantile: f64 = quantile_column.get(0).unwrap().try_extract()?;
+    match quantile_ac.agg_state() {
+        AggState::LiteralScalar(_) => {
+            // Fast path: single quantile value for all groups.
+            let quantile_column = quantile_ac.get_values();
+            polars_ensure!(
+                quantile_column.len() <= 1,
+                ComputeError:
+                    "polars only supports computing a single quantile; \
+                    make sure the 'quantile' expression input produces a single quantile"
+            );
+            polars_ensure!(
+                quantile_column.dtype().is_numeric(),
+                SchemaMismatch:
+                    "expected expression of dtype 'numeric' for quantile, got '{}'",
+                quantile_column.dtype()
+            );
+            let quantile: f64 = quantile_column.get(0).unwrap().try_extract()?;
 
-    if let AggState::LiteralScalar(c) = &mut ac.state {
-        *c = c.quantile_reduce(quantile, method)?.into_column(keep_name);
-        return Ok(ac);
+            if let AggState::LiteralScalar(c) = &mut ac.state {
+                *c = c.quantile_reduce(quantile, method)?.into_column(keep_name);
+                return Ok(ac);
+            }
+
+            // SAFETY: groups are in bounds.
+            let mut agg = unsafe {
+                ac.flat_naive()
+                    .into_owned()
+                    .agg_quantile(ac.groups(), quantile, method)
+            };
+            agg.rename(keep_name);
+            Ok(AggregationContext::from_agg_state(
+                AggState::AggregatedScalar(agg),
+                Cow::Borrowed(groups),
+            ))
+        },
+        AggState::AggregatedScalar(_) => {
+            // Different quantile value per group.
+            let quantile_column = quantile_ac.get_values().cast(&DataType::Float64)?;
+            let quantiles: Vec<f64> = quantile_column
+                .f64()?
+                .iter()
+                .map(|v| v.unwrap_or(f64::NAN))
+                .collect();
+
+            // SAFETY: groups are in bounds.
+            let mut agg = unsafe {
+                ac.flat_naive()
+                    .into_owned()
+                    .agg_varying_quantile(ac.groups(), &quantiles, method)
+            };
+            agg.rename(keep_name);
+            Ok(AggregationContext::from_agg_state(
+                AggState::AggregatedScalar(agg),
+                Cow::Borrowed(groups),
+            ))
+        },
+        _ => {
+            polars_bail!(ComputeError:
+                "quantile expression in group_by must produce a scalar per group; \
+                use .first() or another aggregation to reduce to a scalar"
+            );
+        },
     }
-
-    // SAFETY: groups are in bounds.
-    let mut agg = unsafe {
-        ac.flat_naive()
-            .into_owned()
-            .agg_quantile(ac.groups(), quantile, method)
-    };
-    agg.rename(keep_name);
-    Ok(AggregationContext::from_agg_state(
-        AggState::AggregatedScalar(agg),
-        Cow::Borrowed(groups),
-    ))
 }
 
 #[cfg(feature = "moment")]

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -25,7 +25,7 @@ from polars.testing.parametric import column, dataframes, series
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
-    from polars._typing import PolarsDataType, TimeUnit
+    from polars._typing import PolarsDataType, QuantileMethod, TimeUnit
     from tests.conftest import PlMonkeyPatch
 
 
@@ -502,6 +502,215 @@ def test_group_by_quantile_time() -> None:
         }
     )
     assert_frame_equal(result.collect(), expected)
+
+
+def _naive_varying_quantile_groupby(
+    df: pl.DataFrame,
+    group_col: str,
+    value_col: str,
+    q_col: str,
+    method: QuantileMethod = "linear",
+) -> pl.DataFrame:
+    """Reference implementation using numpy for quantile computation."""
+    # Polars converts Date to Datetime(us) for quantile aggregation,
+    # so do the same before converting to physical floats.
+    if df[value_col].dtype == pl.Date:
+        df = df.with_columns(pl.col(value_col).cast(pl.Datetime("us")))
+
+    grouped = df.group_by(group_col).agg(
+        pl.col(value_col).to_physical().cast(pl.Float64).alias("values"),
+        pl.col(q_col).first().alias("q"),
+    )
+
+    results = []
+    for row in grouped.iter_rows(named=True):
+        group_val = row[group_col]
+        values = row["values"]
+        quantile_val = row["q"]
+
+        if method == "equiprobable":
+            sorted_vals = sorted(values)
+            n = len(sorted_vals)
+            idx = max(int(np.ceil(quantile_val * n)) - 1, 0)
+            quantile_result = sorted_vals[idx]
+        else:
+            quantile_result = float(np.quantile(values, quantile_val, method=method))
+
+        results.append({group_col: group_val, value_col: quantile_result})
+
+    return pl.DataFrame(results).sort(group_col)
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["nearest", "higher", "lower", "midpoint", "linear", "equiprobable"],
+)
+@pytest.mark.parametrize(
+    ("dtype", "test_values"),
+    [
+        (pl.Int32, [1, 2, 3, 4, 10, 20, 30, 40]),
+        (pl.Int64, [1, 2, 3, 4, 10, 20, 30, 40]),
+        (pl.Float32, [1.0, 2.0, 3.0, 4.0, 10.0, 20.0, 30.0, 40.0]),
+        (pl.Float64, [1.0, 2.0, 3.0, 4.0, 10.0, 20.0, 30.0, 40.0]),
+        (
+            pl.Date,
+            [
+                date(2020, 1, 1),
+                date(2020, 1, 2),
+                date(2020, 6, 1),
+                date(2020, 6, 2),
+                date(2021, 3, 1),
+                date(2021, 3, 2),
+                date(2021, 9, 1),
+                date(2021, 9, 2),
+            ],
+        ),
+        (
+            pl.Datetime,
+            [
+                datetime(2020, 1, 1),
+                datetime(2020, 1, 2),
+                datetime(2020, 6, 1),
+                datetime(2020, 6, 2),
+                datetime(2021, 3, 1),
+                datetime(2021, 3, 2),
+                datetime(2021, 9, 1),
+                datetime(2021, 9, 2),
+            ],
+        ),
+        (
+            pl.Duration,
+            [
+                timedelta(hours=1),
+                timedelta(hours=2),
+                timedelta(hours=10),
+                timedelta(hours=20),
+                timedelta(hours=100),
+                timedelta(hours=200),
+                timedelta(hours=1000),
+                timedelta(hours=2000),
+            ],
+        ),
+        (
+            pl.Time,
+            [
+                time(1, 0),
+                time(2, 0),
+                time(10, 0),
+                time(20, 0),
+                time(3, 0),
+                time(6, 0),
+                time(12, 0),
+                time(18, 0),
+            ],
+        ),
+    ],
+)
+def test_group_by_varying_quantile(
+    method: QuantileMethod, dtype: pl.DataType, test_values: list[Any]
+) -> None:
+    df = pl.DataFrame(
+        {
+            "group": ["a", "a", "a", "a", "b", "b", "b", "b"],
+            "value": pl.Series(test_values, dtype=dtype),
+            "q": [0.25] * 4 + [0.75] * 4,
+        }
+    )
+
+    result = (
+        df.group_by("group")
+        .agg(pl.col.value.quantile(pl.col.q.first(), interpolation=method))
+        .sort("group")
+    )
+
+    # Verify against numpy reference implementation (compared in physical float space)
+    naive_result = _naive_varying_quantile_groupby(df, "group", "value", "q", method)
+    result_phys = result.with_columns(pl.col("value").to_physical().cast(pl.Float64))
+    assert_frame_equal(result_phys, naive_result, check_dtypes=False)
+
+
+def test_group_by_varying_quantile_edge_cases() -> None:
+    # Out of range quantile (q > 1)
+    df = pl.DataFrame(
+        {
+            "group": ["a", "a", "b", "b"],
+            "value": [1, 2, 10, 20],
+            "q": [0.5, 0.5, 1.5, 1.5],
+        }
+    )
+    result = (
+        df.group_by("group").agg(pl.col.value.quantile(pl.col.q.first())).sort("group")
+    )
+    assert result["value"][0] == 2.0
+    assert result["value"][1] is None
+
+    # Out of range quantile (q < 0)
+    df = pl.DataFrame(
+        {
+            "group": ["a", "a", "b", "b"],
+            "value": [1, 2, 10, 20],
+            "q": [-0.5, -0.5, 0.5, 0.5],
+        }
+    )
+    result = (
+        df.group_by("group").agg(pl.col.value.quantile(pl.col.q.first())).sort("group")
+    )
+    assert result["value"][0] is None
+    assert result["value"][1] == 20.0  # default interpolation is "nearest"
+
+    # Null quantile value
+    df = pl.DataFrame(
+        {
+            "group": ["a", "a", "b", "b"],
+            "value": [1, 2, 10, 20],
+            "q": [None, None, 0.5, 0.5],
+        }
+    )
+    result = (
+        df.group_by("group").agg(pl.col.value.quantile(pl.col.q.first())).sort("group")
+    )
+    assert result["value"][0] is None
+    assert result["value"][1] == 20.0  # default interpolation is "nearest"
+
+    # Single element groups
+    df = pl.DataFrame({"group": ["a", "b"], "value": [5.0, 10.0], "q": [0.0, 1.0]})
+    result = (
+        df.group_by("group").agg(pl.col.value.quantile(pl.col.q.first())).sort("group")
+    )
+    expected = pl.DataFrame({"group": ["a", "b"], "value": [5.0, 10.0]})
+    assert_frame_equal(result, expected)
+
+    # Lazy API (https://github.com/pola-rs/polars/issues/20951)
+    df = pl.DataFrame(
+        {
+            "group": ["a", "a", "b", "b"],
+            "value": [1.0, 2.0, 10.0, 20.0],
+            "q": [0.0, 0.0, 1.0, 1.0],
+        }
+    )
+    result = (
+        df.lazy()
+        .group_by("group")
+        .agg(pl.col.value.quantile(pl.col.q.first()))
+        .sort("group")
+        .collect()
+    )
+    expected = pl.DataFrame({"group": ["a", "b"], "value": [1.0, 20.0]})
+    assert_frame_equal(result, expected)
+
+    # Maintain order
+    df = pl.DataFrame(
+        {
+            "group": ["a", "a", "a", "b", "b", "b"],
+            "value": [1.0, 2.0, 3.0, 10.0, 20.0, 30.0],
+            "q": [0.0, 0.0, 0.0, 0.5, 0.5, 0.5],
+        }
+    ).sort("group")
+    result = df.group_by("group", maintain_order=True).agg(
+        pl.col.value.quantile(pl.col.q.first())
+    )
+    expected = pl.DataFrame({"group": ["a", "b"], "value": [1.0, 20.0]})
+    assert_frame_equal(result, expected)
 
 
 def test_group_by_args() -> None:


### PR DESCRIPTION
Fixes #20951 and its duplicate #25888.

When using `group_by()` with a quantile parameter that varies per group (e.g., `pl.col.quantile.first()`), all groups incorrectly received the same quantile value instead of each group using its own.

### Reproduction
```python
df = pl.DataFrame({
    "value": [1, 2, 1, 2],
    "quantile": [0, 0, 1, 1],
})
df.group_by("quantile").agg(pl.col("value").quantile(pl.col("quantile").first()))
# Expected: quantile=0 -> 1.0, quantile=1 -> 2.0
# Actual: both groups returned 1.0
```

### Cause

`AggQuantileExpr::evaluate_on_groups()` always called `get_quantile()` which evaluates the quantile expression against the full dataframe, returning a single scalar. This worked for literal quantile values but failed when the quantile expression varied per group (e.g., `first()` aggregation).

### Fix

Added `agg_varying_quantile` which accepts a slice of quantile values (one per group) and computes quantile per group using the existing aggregation helpers.

**polars-core changes:**
- Added `agg_helper_idx_on_all_with_idx` and `_agg_helper_slice_with_idx` helpers that pass the group index to closures
- Added `agg_varying_quantile_generic` that iterates over groups with their corresponding quantile values
- Added `agg_varying_quantile` methods to `Float32Chunked`, `Float64Chunked`, integer `ChunkedArray`, `Series`, and `Column`

**polars-expr changes:**
- `AggQuantileExpr::evaluate_on_groups()` now detects whether the quantile is uniform (literal/scalar) or varies per group, and dispatches to the appropriate path