### PR TITLE
ci: Constrain new `issue-labeler` workflow to the Issue title

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,19 +1,19 @@
 # Automatically apply Issue labels based on string pattern matches in the issue title.
 # Note: the patterns/labels here are mirrored in `release-drafter.yml` (for PRs)
 documentation:
-  - '/docs|documentation/i'
+  - '/\bdocs\b|documentation/i'
 performance:
   - '/performance/i'
 regression:
   - '/regression/i'
 A-dtype-categorical:
-  - '/categorical|categories/i'
+  - '/categorical|categories|category/i'
 A-dtype-decimal:
   - '/decimal/i'
 A-dtype-object:
-  - '/Object/'
+  - '/\bObject\b/'
 A-dtype-struct:
-  - '/struct/i'
+  - '/\bstruct\b/i'
 A-gpu:
   - '/\bgpu\b/i'
 A-ide:
@@ -41,7 +41,7 @@ A-io-json:
 A-io-parquet:
   - '/parquet/i'
 A-io-spreadsheet:
-  - '/spreadsheet|excel/i'
+  - '/spreadsheet|excel|\bods\b/i'
 A-plugin:
   - '/plugin/i'
 A-sql:

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -18,3 +18,6 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/issue-labeler.yml
           enable-versioned-regex: 0
+          include-title: 1
+          include-body: 0
+          sync-labels: 1


### PR DESCRIPTION
Ahh... the default behaviour also looks at the Issue _body_ - we just want to look at the _title_ so it doesn't get over-excited with label matching (as the body could contain all kinds of things in sample code, traces/logs, etc).

Have set the appropriate flags in the workflow to omit the body from consideration (and to sync/remove tags if the title is updated and no longer matches the initially-applied tags):
```
include-title: 1
include-body: 0
sync-labels: 1
```
Also slightly tightened a few patterns (eg: `struct` → `\bstruct\b` so it doesn't match on words like "structure", for example).