### PR TITLE
fix: Properly resolve `HAVING` clause during SQL `GROUP BY` operations

### DIFF
--- a/py-polars/tests/unit/sql/test_group_by.py
+++ b/py-polars/tests/unit/sql/test_group_by.py
@@ -221,7 +221,6 @@ def test_group_by_errors() -> None:
             "c": [99, 99, 66],
         }
     )
-
     with pytest.raises(
         SQLSyntaxError,
         match=r"negative ordinal values are invalid for GROUP BY; found -99",
@@ -245,6 +244,223 @@ def test_group_by_errors() -> None:
         match=r"HAVING clause not valid outside of GROUP BY",
     ):
         df.sql("SELECT a, COUNT(a) AS n FROM self HAVING n > 1")
+
+
+def test_group_by_having_aggregate_not_in_select() -> None:
+    """Test HAVING with aggregate functions not present in SELECT."""
+    df = pl.DataFrame(
+        {"grp": ["a", "a", "a", "b", "b", "c"], "val": [1, 2, 3, 4, 5, 6]}
+    )
+    # COUNT(*) not in SELECT - only group 'a' has 3 rows
+    assert_sql_matches(
+        df,
+        query="SELECT grp FROM self GROUP BY grp HAVING COUNT(*) > 2",
+        compare_with="sqlite",
+        expected={"grp": ["a"]},
+    )
+
+    # SUM not in SELECT
+    assert_sql_matches(
+        df,
+        query="SELECT grp FROM self GROUP BY grp HAVING SUM(val) > 5 ORDER BY grp",
+        compare_with="sqlite",
+        expected={"grp": ["a", "b", "c"]},
+    )
+
+    # AVG not in SELECT
+    assert_sql_matches(
+        df,
+        query="SELECT grp FROM self GROUP BY grp HAVING AVG(val) > 4 ORDER BY grp",
+        compare_with="sqlite",
+        expected={"grp": ["b", "c"]},
+    )
+
+    # MIN/MAX not in SELECT
+    assert_sql_matches(
+        df,
+        query="SELECT grp FROM self GROUP BY grp HAVING MIN(val) >= 4 ORDER BY grp",
+        compare_with="sqlite",
+        expected={"grp": ["b", "c"]},
+    )
+
+
+def test_group_by_having_aggregate_in_select() -> None:
+    """Test HAVING properly references an aggregate already computed in SELECT."""
+    df = pl.DataFrame(
+        {"grp": ["a", "a", "a", "b", "b", "c"], "val": [1, 2, 3, 4, 5, 6]}
+    )
+    # COUNT(*) in SELECT and HAVING
+    for count_expr in ("COUNT(*)", "cnt"):
+        assert_sql_matches(
+            df,
+            query=f"SELECT grp, COUNT(*) AS cnt FROM self GROUP BY grp HAVING {count_expr} > 2",
+            compare_with="sqlite",
+            expected={"grp": ["a"], "cnt": [3]},
+        )
+
+    # SUM in SELECT and HAVING
+    for sum_expr in ("total", "SUM(val)"):
+        assert_sql_matches(
+            df,
+            query=f"SELECT grp, SUM(val) AS total FROM self GROUP BY grp HAVING {sum_expr} > 5 ORDER BY grp",
+            compare_with="sqlite",
+            expected={"grp": ["a", "b", "c"], "total": [6, 9, 6]},
+        )
+
+
+def test_group_by_having_multiple_aggregates() -> None:
+    """Test HAVING with multiple aggregate conditions."""
+    df = pl.DataFrame(
+        {"grp": ["a", "a", "a", "b", "b", "c"], "val": [1, 2, 3, 4, 5, 6]}
+    )
+    assert_sql_matches(
+        df,
+        query="SELECT grp FROM self GROUP BY grp HAVING COUNT(*) >= 2 AND SUM(val) > 5 ORDER BY grp",
+        compare_with="sqlite",
+        expected={"grp": ["a", "b"]},
+    )
+    assert_sql_matches(
+        df,
+        query="SELECT grp FROM self GROUP BY grp HAVING COUNT(*) = 1 OR SUM(val) >= 9 ORDER BY grp",
+        compare_with="sqlite",
+        expected={"grp": ["b", "c"]},
+    )
+
+
+def test_group_by_having_compound_expressions() -> None:
+    """Test HAVING with compound expressions involving aggregates."""
+    df = pl.DataFrame(
+        {"grp": ["a", "a", "c", "b", "b"], "val": [10, 20, 100, 5, 15]},
+    )
+    assert_sql_matches(
+        df,
+        query="SELECT grp FROM self GROUP BY grp HAVING SUM(val) / COUNT(*) > 10 ORDER BY grp",
+        compare_with="sqlite",
+        expected={"grp": ["a", "c"]},
+    )
+    assert_sql_matches(
+        df,
+        query="SELECT grp FROM self GROUP BY grp HAVING MAX(val) - MIN(val) > 5 ORDER BY grp DESC",
+        compare_with="sqlite",
+        expected={"grp": ["b", "a"]},
+    )
+    for sum_expr, count_expr in (
+        ("SUM(val)", "COUNT(*)"),
+        ("total", "COUNT(*)"),
+        ("SUM(val)", "n"),
+        ("total", "n"),
+    ):
+        assert_sql_matches(
+            df,
+            query=f"""
+                SELECT grp, SUM(val) AS total, COUNT(*) AS n
+                FROM self
+                GROUP BY grp
+                HAVING {sum_expr} / {count_expr} > 10 ORDER BY grp
+            """,
+            compare_with="sqlite",
+            expected={
+                "grp": ["a", "c"],
+                "total": [30, 100],
+                "n": [2, 1],
+            },
+        )
+
+
+def test_group_by_having_with_nulls() -> None:
+    """Test HAVING behaviour with NULL values."""
+    df = pl.DataFrame(
+        {"grp": ["a", "b", "a", "b", "c"], "val": [None, None, 1, None, 5]}
+    )
+    # COUNT(*) counts all rows, including NULLs...
+    assert_sql_matches(
+        df,
+        query="SELECT grp FROM self GROUP BY grp HAVING COUNT(*) > 1 ORDER BY grp",
+        compare_with="sqlite",
+        expected={"grp": ["a", "b"]},
+    )
+
+    # ...whereas COUNT(col) excludes NULLs
+    assert_sql_matches(
+        df,
+        query="SELECT grp FROM self GROUP BY grp HAVING COUNT(val) > 0 ORDER BY grp",
+        compare_with="sqlite",
+        expected={"grp": ["a", "c"]},
+    )
+
+
+@pytest.mark.parametrize(
+    ("having_clause", "expected"),
+    [
+        # basic count conditions
+        ("COUNT(*) > 2", [1]),
+        ("COUNT(*) >= 2 AND COUNT(*) <= 3", [1, 2]),
+        ("(COUNT(*) > 1)", [1, 2]),
+        ("NOT COUNT(*) < 2", [1, 2]),
+        # range / membership
+        ("COUNT(*) BETWEEN 2 AND 3", [1, 2]),
+        ("COUNT(*) NOT BETWEEN 1 AND 2", [1]),
+        ("COUNT(*) IN (1, 3)", [1, 3]),
+        ("COUNT(*) NOT IN (1, 2)", [1]),
+        # conditional
+        ("CASE WHEN COUNT(*) > 2 THEN 1 ELSE 0 END = 1", [1]),
+    ],
+)
+def test_group_by_having_misc_01(
+    having_clause: str,
+    expected: list[int],
+) -> None:
+    df = pl.DataFrame({"a": [1, 1, 1, 2, 2, 3]})
+    assert_sql_matches(
+        df,
+        query=f"SELECT a FROM self GROUP BY a HAVING {having_clause} ORDER BY a",
+        compare_with="sqlite",
+        expected={"a": expected},
+    )
+
+
+@pytest.mark.parametrize(
+    ("having_clause", "expected"),
+    [
+        ("SUM(b) > 50", [1, 3]),
+        ("AVG(b) > 15", [1, 3]),
+        ("ABS(SUM(b)) > 50", [1, 3]),
+        ("ROUND(ABS(AVG(b))) > 15", [1, 3]),
+        ("ABS(SUM(b)) + ABS(AVG(b)) > 100", [3]),
+        ("CASE WHEN SUM(b) < 10 THEN 0 ELSE SUM(b) END > 50", [1, 3]),
+    ],
+)
+def test_group_by_having_misc_02(
+    having_clause: str,
+    expected: list[int],
+) -> None:
+    df = pl.DataFrame({"a": [1, 1, 1, 2, 2, 3], "b": [10, 20, 30, 5, 15, 100]})
+    assert_sql_matches(
+        df,
+        query=f"SELECT a FROM self GROUP BY a HAVING {having_clause} ORDER BY a",
+        compare_with="sqlite",
+        expected={"a": expected},
+    )
+
+
+@pytest.mark.parametrize(
+    ("having_clause", "expected"),
+    [
+        ("MAX(b) IS NULL", [1]),
+        ("MAX(b) IS NOT NULL", [2]),
+    ],
+)
+def test_group_by_having_misc_03(
+    having_clause: str,
+    expected: list[int],
+) -> None:
+    df = pl.DataFrame({"a": [1, 1, 2], "b": [None, None, 5]})
+    assert_sql_matches(
+        df,
+        query=f"SELECT a FROM self GROUP BY a HAVING {having_clause}",
+        compare_with="sqlite",
+        expected={"a": expected},
+    )
 
 
 def test_group_by_output_struct() -> None:


### PR DESCRIPTION
Closes #15950.
Closes #21229.
Closes #22926.

(Supersedes https://github.com/pola-rs/polars/pull/25609)

We now handle the `HAVING` clause much more robustly, addressing all outstanding issues. 

Can refer to aggregate expressions in the `SELECT` by name _or_ the full expression (without recomputing), or use aggregate expressions that are _not_ found in the `SELECT` and, crucially, these expressions are now always evaluated at the right time (during projection, not afterwards).

Lots of new test coverage, using the new `assert_sql_matches` to compare/validate `GROUP BY` with `HAVING` against SQLite.

## Example

```python
import polars as pl

df = pl.DataFrame({
  "id": [1, 2, 1, 3],
  "quantity": [50, 75, 60, 40],
})
```
If we refer to a full expression in the aggregate constraint (typical for `HAVING` usage, which is not restricted to only referring to columns computed/available in the `SELECT`) we see the following...
```python
df.sql("""
  SELECT id, SUM(quantity) as total_quantity
  FROM self
  GROUP BY id
  HAVING SUM(quantity) > 100
""")
```
_(note: `HAVING total_quantity > 100` would work here)_

* #### Before
  _fails to resolve "SUM(quantity)" in the `HAVING` 
  (evaluation was done after projection removed the original column)_
  ```python
  # ColumnNotFoundError: 
  #  unable to find column "quantity"; 
  #   valid columns: ["id", "total_quantity"]
  ```

* #### After
  ```python
  # shape: (1, 2)
  # ┌─────┬────────────────┐
  # │ id  ┆ total_quantity │
  # │ --- ┆ ---            │
  # │ i64 ┆ i64            │
  # ╞═════╪════════════════╡
  # │ 1   ┆ 110            │
  # └─────┴────────────────┘
  ```