### PR TITLE
fix: Fix lifetime for `AmortSeries` lazy group iterator

### DIFF
--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -138,21 +138,16 @@ impl ApplyExpr {
 
         // In case of overlapping (rolling) groups, we build groups in a lazy manner to avoid
         // memory explosion.
-        // TODO: Add parallel iterator path; support Idx GroupsType.
-        if matches!(ac.agg_state(), AggState::NotAggregated(_))
-            && ac.groups.is_overlapping()
-        {
-            // SAFETY: switch to deep_clone()
-            unsafe {
-                let ca: ChunkedArray<_> = {
-                    ac.iter_groups_lazy(false)
-                        .map(|opt| opt.map(|s| s.deep_clone()))
-                        .map(f)
-                        .collect::<PolarsResult<_>>()?
-                };
-
-                return self.finish_apply_groups(ac, ca.with_name(name));
-            }
+        // TODO: support Idx GroupsType.
+        if matches!(ac.agg_state(), AggState::NotAggregated(_)) && ac.groups.is_overlapping() {
+            let ca: ChunkedArray<_> = if self.allow_threading {
+                ac.par_iter_groups_lazy()
+                    .map(f)
+                    .collect::<PolarsResult<_>>()?
+            } else {
+                ac.iter_groups_lazy().map(f).collect::<PolarsResult<_>>()?
+            };
+            return self.finish_apply_groups(ac, ca.with_name(name));
         }
 
         // At this point, calling aggregated() will not lead to memory explosion.

--- a/crates/polars-expr/src/expressions/group_iter.rs
+++ b/crates/polars-expr/src/expressions/group_iter.rs
@@ -2,6 +2,8 @@
 use std::rc::Rc;
 
 use polars_core::series::amortized_iter::AmortSeries;
+use rayon::iter::IntoParallelIterator;
+use rayon::prelude::*;
 
 use super::*;
 
@@ -75,36 +77,62 @@ impl AggregationContext<'_> {
 
 impl AggregationContext<'_> {
     /// Iterate over groups lazily, i.e., without greedy aggregation into an AggList.
-    ///
-    /// # Safety: AmortSeries does not live longer than the next call to `next`.
-    pub(super) unsafe fn iter_groups_lazy(
-        &mut self,
-        keep_names: bool,
-    ) -> Box<dyn Iterator<Item = Option<AmortSeries>> + '_> {
+    pub(super) fn iter_groups_lazy(&mut self) -> impl Iterator<Item = Option<Series>> + '_ {
         match self.agg_state() {
             AggState::NotAggregated(_) => {
                 let groups = self.groups();
                 let len = groups.len();
-                let c = self.get_values().rechunk();
-                let name = if keep_names {
-                    c.name().clone()
-                } else {
-                    PlSmallStr::EMPTY
-                };
-                let iter = self.groups().iter();
+                let groups = Arc::new(groups.clone());
 
-                // SAFETY: dtype is correct
-                unsafe {
-                    Box::new(NotAggLazyIter::new(
-                        c.as_materialized_series().array_ref(0).clone(),
-                        iter,
-                        len,
-                        c.dtype(),
-                        name,
-                    ))
-                }
+                let c = self.get_values().rechunk(); //TODO - investigate
+
+                let col = Arc::new(c);
+
+                (0..len).map(move |idx| {
+                    let g = groups.get(idx);
+                    // TODO
+                    match g {
+                        GroupsIndicator::Idx(_) => todo!(), //kdn TODO
+                        GroupsIndicator::Slice(s) => Some(
+                            col.slice(s[0] as i64, s[1] as usize)
+                                .into_materialized_series()
+                                .clone(),
+                        ),
+                    }
+                })
             },
-            _ => self.iter_groups(keep_names),
+            _ => todo!(),
+        }
+    }
+
+    /// Iterate parallel over groups lazily, i.e., without greedy aggregation into an AggList.
+    pub(super) fn par_iter_groups_lazy(
+        &mut self,
+    ) -> impl IndexedParallelIterator<Item = Option<Series>> + '_ {
+        match self.agg_state() {
+            AggState::NotAggregated(_) => {
+                let groups = self.groups();
+                let len = groups.len();
+                let groups = Arc::new(groups.clone());
+
+                let c = self.get_values().rechunk(); //TODO - do we require rechunk? rechunk_mut?
+
+                let col = Arc::new(c);
+
+                (0..len).into_par_iter().map(move |idx| {
+                    let g = groups.get(idx);
+                    // TODO
+                    match g {
+                        GroupsIndicator::Idx(_) => todo!(), //kdn TODO
+                        GroupsIndicator::Slice(s) => Some(
+                            col.slice(s[0] as i64, s[1] as usize)
+                                .into_materialized_series()
+                                .clone(),
+                        ),
+                    }
+                })
+            },
+            _ => todo!(),
         }
     }
 }
@@ -220,67 +248,5 @@ impl Iterator for FlatIter {
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.len - self.offset, Some(self.len - self.offset))
-    }
-}
-
-struct NotAggLazyIter<'a, I: Iterator<Item = GroupsIndicator<'a>>> {
-    array: ArrayRef,
-    iter: I,
-    groups_idx: usize,
-    len: usize,
-    // AmortSeries referenced that series
-    #[allow(dead_code)]
-    series_container: Rc<Series>,
-    item: AmortSeries,
-}
-
-impl<'a, I: Iterator<Item = GroupsIndicator<'a>>> NotAggLazyIter<'a, I> {
-    /// # Safety
-    /// Caller must ensure the given `logical` dtype belongs to `array`.
-    unsafe fn new(
-        array: ArrayRef,
-        iter: I,
-        len: usize,
-        logical: &DataType,
-        name: PlSmallStr,
-    ) -> Self {
-        let series_container = Rc::new(Series::from_chunks_and_dtype_unchecked(
-            name,
-            vec![array.clone()],
-            logical,
-        ));
-        Self {
-            array,
-            iter,
-            groups_idx: 0,
-            len,
-            series_container: series_container.clone(),
-            item: AmortSeries::new(series_container),
-        }
-    }
-}
-
-impl<'a, I: Iterator<Item = GroupsIndicator<'a>>> Iterator for NotAggLazyIter<'a, I> {
-    type Item = Option<AmortSeries>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some(g) = self.iter.next() {
-            self.groups_idx += 1;
-            match g {
-                // TODO: Implement for Idx GroupsType
-                GroupsIndicator::Idx(_) => todo!(),
-                GroupsIndicator::Slice(s) => {
-                    let mut arr =
-                        unsafe { self.array.sliced_unchecked(s[0] as usize, s[1] as usize) };
-                    unsafe { self.item.swap(&mut arr) };
-                    Some(Some(self.item.clone()))
-                },
-            }
-        } else {
-            None
-        }
-    }
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len - self.groups_idx, Some(self.len - self.groups_idx))
     }
 }

--- a/py-polars/tests/unit/operations/test_group_by_dynamic.py
+++ b/py-polars/tests/unit/operations/test_group_by_dynamic.py
@@ -1416,3 +1416,12 @@ def test_group_by_dynamic_gather_every_lazy_iter_25567() -> None:
     )
     expected = pl.DataFrame({"index": [1, 2, 3], "value": [[[4]], [[5]], [[5]]]})
     assert_frame_equal(out, expected)
+
+    df = pl.DataFrame({"index": [1, 3, 4], "value": [[4], [5], [6]]})
+    out = df.group_by_dynamic("index", every="1i", period="2i").agg(
+        pl.all().gather_every(1)
+    )
+    expected = pl.DataFrame(
+        {"index": [1, 2, 3, 4], "value": [[[4]], [[5]], [[5], [6]], [[6]]]}
+    )
+    assert_frame_equal(out, expected)


### PR DESCRIPTION
fixes #25567 

Preliminary fix (or workaround) using `deep_clone()`.

Micro-benchmark:
```python
n_rows = 100_000
col = [1, 2, 3]
n_rows = n_rows // len(col) * len(col)
period = 1000

df = pl.DataFrame({"d": range(n_rows), "n": col * (n_rows // len(col))})
q = df.lazy().rolling("d", period=str(period) + "i").agg(pl.col.n.rank().last())
```
Gives:
- On 1.35.2 public release: 3742.435320 milliseconds
- On 1.36.0b2: 2761.884359 milliseconds
- Prior main (build-release): 2358.850281 milliseconds
- With this PR (build-release): 2514.513819 milliseconds