### PR TITLE
feat: Add SQL syntax support for `CROSS JOIN UNNEST(col)`

### DIFF
--- a/py-polars/tests/unit/sql/asserts.py
+++ b/py-polars/tests/unit/sql/asserts.py
@@ -4,6 +4,8 @@ import contextlib
 import sqlite3
 from typing import TYPE_CHECKING, Any, Literal
 
+import pytest
+
 import polars as pl
 from polars.datatypes.group import FLOAT_DTYPES, INTEGER_DTYPES
 from polars.testing import assert_frame_equal
@@ -60,12 +62,10 @@ def _execute_with_duckdb(
     try:
         import duckdb
     except ImportError:
-        msg = (
-            "DuckDB not found; required for `compare_with='duckdb'`.\n"
-            "Install with: `pip install duckdb`"
+        # if not available locally, skip (will always be run on CI)
+        pytest.skip(
+            """DuckDB not installed; required for `assert_sql_matches` with "compare_with='duckdb'"."""
         )
-        raise ImportError(msg) from None
-
     with duckdb.connect(":memory:") as conn:
         for name, df in frames.items():
             conn.register(name, df)

--- a/py-polars/tests/unit/sql/test_distinct_on.py
+++ b/py-polars/tests/unit/sql/test_distinct_on.py
@@ -1,16 +1,9 @@
 from __future__ import annotations
 
-import pytest
-
 import polars as pl
 from tests.unit.sql import assert_sql_matches
 
 # Note: SQLite does not support "DISTINCT ON", so only compare results against DuckDB
-try:
-    import duckdb  # noqa: F401
-
-except ImportError:
-    pytestmark = pytest.mark.ci_only
 
 
 def test_distinct_on_single_column(df_distinct: pl.DataFrame) -> None:

--- a/py-polars/tests/unit/sql/test_unnest.py
+++ b/py-polars/tests/unit/sql/test_unnest.py
@@ -5,6 +5,7 @@ import pytest
 import polars as pl
 from polars.exceptions import SQLInterfaceError, SQLSyntaxError
 from polars.testing import assert_frame_equal
+from tests.unit.sql.asserts import assert_sql_matches
 
 # ---------------------------------------------------------------------------------
 # NOTE: 'UNNEST' is available as both a table function and a select-level function
@@ -99,13 +100,12 @@ def test_unnest_select_expressions() -> None:
     res = df.sql(query)
     assert_frame_equal(res, expected)
 
-    # from tests.unit.sql.asserts import assert_sql_matches
-    # assert_sql_matches(
-    #     df,
-    #     query=query,
-    #     compare_with="duckdb",
-    #     expected=expected,
-    # )
+    assert_sql_matches(
+        df,
+        query=query,
+        compare_with="duckdb",
+        expected=expected,
+    )
 
 
 def test_unnest_aggregates() -> None:

--- a/py-polars/tests/unit/sql/test_window_functions.py
+++ b/py-polars/tests/unit/sql/test_window_functions.py
@@ -360,7 +360,7 @@ def test_window_function_first_last() -> None:
             }
         )
         assert_frame_equal(df.sql(query), expected)
-        # assert_sql_matches(df, query=query, compare_with="duckdb", expected=expected)
+        assert_sql_matches(df, query=query, compare_with="duckdb", expected=expected)
 
 
 def test_window_function_over_clause_misc() -> None:


### PR DESCRIPTION
Closes #21180.

This syntax represents a simple lateral unnest (explode) against the left join table and the referenced column, so this PR adds a small/dedicated path for handling it. Added suitable test coverage.



## Example

```python
import polars as pl

df = pl.DataFrame({
    "id": ["xyz", "abc"],
    "items": [[100, 200], [300, 400, 500]],
})

df.sql("""
  SELECT id, item
  FROM self CROSS JOIN UNNEST(items) AS item
  ORDER BY id DESC, item ASC
""")
# shape: (5, 2)
# ┌─────┬──────┐
# │ id  ┆ item │
# │ --- ┆ ---  │
# │ str ┆ i64  │
# ╞═════╪══════╡
# │ xyz ┆ 100  │
# │ xyz ┆ 200  │
# │ abc ┆ 300  │
# │ abc ┆ 400  │
# │ abc ┆ 500  │
# └─────┴──────┘
```
---
Also: automatic `pytest.skip` if running tests locally that use `assert_sql_matches` with duckdb, if duckdb is not installed (note: will always be available on CI).