### PR TITLE
test: Ensure literal-only `SELECT` broadcast conforms to SQL semantics

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -20,4 +20,3 @@ jobs:
           enable-versioned-regex: 0
           include-title: 1
           include-body: 0
-          sync-labels: 1

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -984,6 +984,7 @@ impl SQLContext {
             let mut retained_cols = Vec::with_capacity(projections.len());
             let mut retained_names = Vec::with_capacity(projections.len());
             let have_order_by = query.order_by.is_some();
+
             // Initialize containing InheritsContext to handle empty projection case.
             let mut projection_heights = ExprSqlProjectionHeightBehavior::InheritsContext;
 


### PR DESCRIPTION
Additional test coverage for literal-only SQL broadcasting behaviour (no functional changes), in much the same vein as https://github.com/pola-rs/polars/pull/25440.

(Also, am opportunistically dropping `sync-labels: 1` from the Issue labeller - realised that we don't actually want this as it can remove _manually_ added labels on Issue update if the title wouldn't otherwise apply that label).