### PR TITLE
fix: Improve SQL `GROUP BY` and `ORDER BY` expression resolution, handling aliasing edge-cases

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -473,7 +473,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             // this function.
             if !predicates.is_empty() {
                 let predicate_names = (0..predicates.len())
-                    .map(|i| PlSmallStr::from_string(format!("__POLARS_HAVING_{i}")))
+                    .map(|i| format_pl_smallstr!("__POLARS_HAVING_{i}"))
                     .collect::<Arc<[_]>>();
                 let predicates = predicates
                     .into_iter()

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -334,7 +334,27 @@ impl SQLContext {
                 SQLSyntax:
                 "{} requires a valid expression or positive ordinal; found {}", clause, v,
             )),
-            _ => parse_sql_expr(e, self, schema),
+            _ => {
+                // Handle qualified cross-aliasing in ORDER BY clauses
+                // (eg: `SELECT a AS b, -b AS a ... ORDER BY self.a`)
+                let mut expr = parse_sql_expr(e, self, schema)?;
+                if matches!(e, SQLExpr::CompoundIdentifier(_)) {
+                    if let Some(schema) = schema {
+                        expr = expr.map_expr(|ex| match &ex {
+                            Expr::Column(name) => {
+                                let prefixed = format!("__POLARS_ORIG_{}", name.as_str());
+                                if schema.contains(prefixed.as_str()) {
+                                    col(prefixed)
+                                } else {
+                                    ex
+                                }
+                            },
+                            _ => ex,
+                        });
+                    }
+                }
+                Ok(expr)
+            },
         }
     }
 
@@ -867,10 +887,8 @@ impl SQLContext {
                         other_expr => {
                             // Note: skip aggregate expressions; those are handled in the GROUP BY phase
                             if !has_expr(other_expr, |e| matches!(e, Expr::Agg(_) | Expr::Len)) {
-                                let temp_name = PlSmallStr::from(format!(
-                                    "__POLARS_UNNEST_{}",
-                                    explode_exprs.len()
-                                ));
+                                let temp_name =
+                                    format_pl_smallstr!("__POLARS_UNNEST_{}", explode_exprs.len());
                                 explode_exprs.push(other_expr.clone().alias(temp_name.as_str()));
                                 explode_lookup.insert(other_expr.clone(), temp_name.clone());
                                 explode_names.push(temp_name);
@@ -919,17 +937,25 @@ impl SQLContext {
                 if !modifiers.is_empty() {
                     polars_bail!(SQLInterface: "GROUP BY does not support CUBE, ROLLUP, or TOTALS modifiers")
                 }
-                // translate the group expressions, allowing ordinal values
+                // Translate the group expressions, resolving ordinal values and SELECT aliases
                 group_by_keys = group_by_exprs
                     .iter()
-                    .map(|e| {
-                        self.expr_or_ordinal(
-                            e,
-                            &projections,
-                            None,
-                            Some(schema.deref()),
-                            "GROUP BY",
-                        )
+                    .map(|e| match e {
+                        SQLExpr::Identifier(ident) => {
+                            resolve_select_alias(&ident.value, &projections, &schema).map_or_else(
+                                || {
+                                    self.expr_or_ordinal(
+                                        e,
+                                        &projections,
+                                        None,
+                                        Some(&schema),
+                                        "GROUP BY",
+                                    )
+                                },
+                                Ok,
+                            )
+                        },
+                        _ => self.expr_or_ordinal(e, &projections, None, Some(&schema), "GROUP BY"),
                     })
                     .collect::<PolarsResult<_>>()?
             },
@@ -1048,14 +1074,12 @@ impl SQLContext {
                         );
                 }
             }
-
             if !select_modifiers.replace.is_empty() {
                 lf = lf.with_columns(&select_modifiers.replace);
             }
             if !select_modifiers.rename.is_empty() {
                 lf = lf.with_columns(select_modifiers.renamed_cols());
             }
-
             lf = self.process_order_by(lf, &query.order_by, Some(&retained_cols))?;
 
             // Note: If `have_order_by`, with_columns is already done above.
@@ -1067,7 +1091,6 @@ impl SQLContext {
             } else {
                 lf = lf.select(retained_cols);
             }
-
             if !select_modifiers.rename.is_empty() {
                 lf = lf.rename(
                     select_modifiers.rename.keys(),
@@ -1084,7 +1107,17 @@ impl SQLContext {
                 .transpose()?;
             lf = self.process_group_by(lf, &group_by_keys, &projections, having)?;
             lf = self.process_order_by(lf, &query.order_by, None)?;
-            lf
+
+            // Drop any extra columns (eg: added to maintain ORDER BY access to original cols)
+            let output_cols: Vec<_> = projections
+                .iter()
+                .map(|p| p.to_field(&schema))
+                .collect::<PolarsResult<Vec<_>>>()?
+                .into_iter()
+                .map(|f| col(f.name))
+                .collect();
+
+            lf.select(&output_cols)
         };
 
         // Apply optional DISTINCT clause.
@@ -1543,32 +1576,58 @@ impl SQLContext {
         let mut projection_aliases = PlHashSet::new();
         let mut group_key_aliases = PlHashSet::new();
 
-        for mut e in projections {
+        // Pre-compute group key data (stripped expression + output name) to avoid repeated work.
+        // We check both expression AND output name match to avoid cross-aliasing issues.
+        let group_key_data: Vec<_> = group_by_keys
+            .iter()
+            .map(|gk| {
+                (
+                    strip_outer_alias(gk),
+                    gk.to_field(&schema_before).ok().map(|f| f.name),
+                )
+            })
+            .collect();
+
+        let projection_matches_group_key: Vec<bool> = projections
+            .iter()
+            .map(|p| {
+                let p_stripped = strip_outer_alias(p);
+                let p_name = p.to_field(&schema_before).ok().map(|f| f.name);
+                group_key_data
+                    .iter()
+                    .any(|(gk_stripped, gk_name)| *gk_stripped == p_stripped && *gk_name == p_name)
+            })
+            .collect();
+
+        for (e, &matches_group_key) in projections.iter().zip(&projection_matches_group_key) {
             // `Len` represents COUNT(*) so we treat as an aggregation here.
-            let is_non_group_key_expr = has_expr(e, |e| {
-                match e {
-                    Expr::Agg(_) | Expr::Len | Expr::Over { .. } => true,
-                    #[cfg(feature = "dynamic_group_by")]
-                    Expr::Rolling { .. } => true,
-                    Expr::Function { function: func, .. }
-                        if !matches!(func, FunctionExpr::StructExpr(_)) =>
-                    {
-                        // If it's a function call containing a column NOT in the group by keys,
-                        // we treat it as an aggregation.
-                        has_expr(e, |e| match e {
-                            Expr::Column(name) => !group_by_keys_schema.contains(name),
-                            _ => false,
-                        })
-                    },
-                    _ => false,
-                }
-            });
+            let is_non_group_key_expr = !matches_group_key
+                && has_expr(e, |e| {
+                    match e {
+                        Expr::Agg(_) | Expr::Len | Expr::Over { .. } => true,
+                        #[cfg(feature = "dynamic_group_by")]
+                        Expr::Rolling { .. } => true,
+                        Expr::Function { function: func, .. }
+                            if !matches!(func, FunctionExpr::StructExpr(_)) =>
+                        {
+                            // If it's a function call containing a column NOT in the group by keys,
+                            // we treat it as an aggregation.
+                            has_expr(e, |e| match e {
+                                Expr::Column(name) => !group_by_keys_schema.contains(name),
+                                _ => false,
+                            })
+                        },
+                        _ => false,
+                    }
+                });
 
             // Note: if simple aliased expression we defer aliasing until after the group_by.
+            // Use `e_inner` to track the potentially unwrapped expression for field lookup.
+            let mut e_inner = e;
             if let Expr::Alias(expr, alias) = e {
                 if e.clone().meta().is_simple_projection(Some(&schema_before)) {
                     group_key_aliases.insert(alias.as_ref());
-                    e = expr
+                    e_inner = expr
                 } else if let Expr::Function {
                     function: FunctionExpr::StructExpr(StructFunction::FieldByName(name)),
                     ..
@@ -1580,7 +1639,7 @@ impl SQLContext {
                     projection_aliases.insert(alias.as_ref());
                 }
             }
-            let field = e.to_field(&schema_before)?;
+            let field = e_inner.to_field(&schema_before)?;
             if is_non_group_key_expr {
                 let mut e = e.clone();
                 if let Expr::Agg(AggExpr::Implode(expr)) = &e {
@@ -1598,15 +1657,17 @@ impl SQLContext {
                     aliased_aggregations.insert(field.name.clone(), alias_name.as_str().into());
                 }
                 aggregation_projection.push(e);
-            } else if let Expr::Column(_)
-            | Expr::Function {
-                function: FunctionExpr::StructExpr(StructFunction::FieldByName(_)),
-                ..
-            } = e
-            {
+            } else if !matches_group_key {
                 // Non-aggregated columns must be part of the GROUP BY clause
-                if !group_by_keys_schema.contains(&field.name) {
-                    polars_bail!(SQLSyntax: "'{}' should participate in the GROUP BY clause or an aggregate function", &field.name);
+                if let Expr::Column(_)
+                | Expr::Function {
+                    function: FunctionExpr::StructExpr(StructFunction::FieldByName(_)),
+                    ..
+                } = e_inner
+                {
+                    if !group_by_keys_schema.contains(&field.name) {
+                        polars_bail!(SQLSyntax: "'{}' should participate in the GROUP BY clause or an aggregate function", &field.name);
+                    }
                 }
             }
         }
@@ -1639,7 +1700,7 @@ impl SQLContext {
                     .iter()
                     .find_map(|(expr, n)| (*expr == e).then(|| n.clone()))
                     .unwrap_or_else(|| {
-                        let n = PlSmallStr::from(format!("__POLARS_HAVING_{n_having_aggs}"));
+                        let n = format_pl_smallstr!("__POLARS_HAVING_{n_having_aggs}");
                         aggregation_projection.push(e.clone().alias(n.clone()));
                         agg_to_name.push((e.clone(), n.clone()));
                         n_having_aggs += 1;
@@ -1667,12 +1728,14 @@ impl SQLContext {
         // (will also drop any temporary columns created for the HAVING post-filter).
         let final_projection = projection_schema
             .iter_names()
-            .zip(projections)
-            .map(|(name, projection_expr)| {
+            .zip(projections.iter().zip(&projection_matches_group_key))
+            .map(|(name, (projection_expr, &matches_group_key))| {
                 if let Some(expr) = projection_overrides.get(name.as_str()) {
                     expr.clone()
                 } else if let Some(aliased_name) = aliased_aggregations.get(name) {
                     col(aliased_name.clone()).alias(name.clone())
+                } else if group_by_keys_schema.get(name).is_some() && matches_group_key {
+                    col(name.clone())
                 } else if group_by_keys_schema.get(name).is_some()
                     || projection_aliases.contains(name.as_str())
                     || group_key_aliases.contains(name.as_str())
@@ -1690,7 +1753,26 @@ impl SQLContext {
             })
             .collect::<Vec<_>>();
 
-        Ok(aggregated.select(&final_projection))
+        // Include original GROUP BY columns for ORDER BY access (if aliased).
+        let mut output_projection = final_projection;
+        for key_name in group_by_keys_schema.iter_names() {
+            if !projection_schema.contains(key_name) {
+                // Original col name not in output - add for ORDER BY access
+                output_projection.push(col(key_name.clone()));
+            } else if group_by_keys.iter().any(|k| is_simple_col_ref(k, key_name)) {
+                // Original col name in output - check if cross-aliased
+                let is_cross_aliased = projections.iter().any(|p| {
+                    p.to_field(&schema_before).is_ok_and(|f| f.name == key_name)
+                        && !is_simple_col_ref(p, key_name)
+                });
+                if is_cross_aliased {
+                    // Add original name under a prefixed alias for subsequent ORDER BY resolution
+                    let internal_name = format_pl_smallstr!("__POLARS_ORIG_{}", key_name);
+                    output_projection.push(col(key_name.clone()).alias(internal_name));
+                }
+            }
+        }
+        Ok(aggregated.select(&output_projection))
     }
 
     fn process_limit_offset(
@@ -1906,6 +1988,42 @@ impl<'a> Visitor for FindTableIdentifier<'a> {
         }
         ControlFlow::Continue(())
     }
+}
+
+/// Check if an expression is a simple column reference (with optional alias) to the given name.
+fn is_simple_col_ref(expr: &Expr, col_name: &PlSmallStr) -> bool {
+    match expr {
+        Expr::Column(n) => n == col_name,
+        Expr::Alias(inner, _) => matches!(inner.as_ref(), Expr::Column(n) if n == col_name),
+        _ => false,
+    }
+}
+
+/// Strip the outer alias from an expression (if present) for expression equality comparison.
+fn strip_outer_alias(expr: &Expr) -> Expr {
+    if let Expr::Alias(inner, _) = expr {
+        inner.as_ref().clone()
+    } else {
+        expr.clone()
+    }
+}
+
+/// Resolve a SELECT alias to its underlying expression (for use in GROUP BY).
+///
+/// Returns the expression WITH alias if the name matches a projection alias and is NOT a column
+/// that exists in the schema; otherwise returns `None` to use the default/standard resolution.
+fn resolve_select_alias(name: &str, projections: &[Expr], schema: &Schema) -> Option<Expr> {
+    // Original columns take precedence over SELECT aliases
+    if schema.contains(name) {
+        return None;
+    }
+    // Find a projection with this alias and return its expression (preserving the alias)
+    projections.iter().find_map(|p| match p {
+        Expr::Alias(inner, alias) if alias.as_str() == name => {
+            Some(inner.as_ref().clone().alias(alias.clone()))
+        },
+        _ => None,
+    })
 }
 
 /// Check if all columns referred to in a Polars expression exist in the given Schema.


### PR DESCRIPTION
Closes #16258.
Closes #19290.
Closes #20428.

We now correctly resolve cross-aliased columns, `SELECT` aliases referenced in the `GROUP BY` clause, and properly maintain qualified `ORDER BY` references to the original columns. New test coverage validates behaviour against SQLite (via `assert_sql_matches`).

# Examples

* ### `ORDER BY` fix

  ```python
  import polars as pl
  
  df = pl.DataFrame({
      "a": [3, 1, 2],
      "b": [30, 10, 20],
  })
  
  df.sql("""
    SELECT a AS b, -b AS a
    FROM self GROUP BY a, b
    ORDER BY self.a
  """)
  ```
  #### Before:
  _(wrong order; `self.a` should resolve to the **original** value of "a", not the new alias)_
  ```python
  # shape: (3, 2)
  # ┌─────┬─────┐
  # │ b   ┆ a   │
  # │ --- ┆ --- │
  # │ i64 ┆ i64 │
  # ╞═════╪═════╡
  # │ 3   ┆ -30 │
  # │ 2   ┆ -20 │
  # │ 1   ┆ -10 │
  # └─────┴─────┘
  ```
  
  #### After:
  _(resolves properly, sorting in the opposite direction to the above)_
  ```python
  # shape: (3, 2)
  # ┌─────┬─────┐
  # │ b   ┆ a   │
  # │ --- ┆ --- │
  # │ i64 ┆ i64 │
  # ╞═════╪═════╡
  # │ 1   ┆ -10 │
  # │ 2   ┆ -20 │
  # │ 3   ┆ -30 │
  # └─────┴─────┘
  ```

* ### `GROUP BY` fix

  ```python
  from datetime import datetime
  import polars as pl
  
  df = pl.DataFrame({
    "id": [1, 2, 3, 4, 5],
    "dt": [
        datetime(2024, 5, 13, 8, 30),
        datetime(2024, 5, 13, 10, 45),
        datetime(2024, 5, 13, 13, 15),
        datetime(2024, 5, 13, 16, 20),
        datetime(2025, 5, 13, 16, 20),
    ]
  })
  ```
  ```python
  df.sql("""
    SELECT
      COUNT(*) AS n,
      EXTRACT(YEAR FROM dt) AS yr
    FROM self
    GROUP BY yr
    ORDER BY yr
  """)
  ```
  
  #### Before:
  ```python
  # ColumnNotFoundError: 
  #  unable to find column "yr"; valid columns: ["id", "dt"]
  ```
  
  #### After:
  ```python
  # shape: (2, 2)
  # ┌─────┬──────┐
  # │ n   ┆ yr   │
  # │ --- ┆ ---  │
  # │ u32 ┆ i32  │
  # ╞═════╪══════╡
  # │ 4   ┆ 2024 │
  # │ 1   ┆ 2025 │
  # └─────┴──────┘
  ```