### PR TITLE
refactor(rust): Add support for multi-column reductions

### DIFF
--- a/crates/polars-expr/src/reduce/any_all.rs
+++ b/crates/polars-expr/src/reduce/any_all.rs
@@ -40,10 +40,11 @@ impl GroupedReduction for AnyIgnoreNullGroupedReduction {
 
     fn update_group(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         group_idx: IdxSize,
         _seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         assert!(values.dtype() == &DataType::Boolean);
         let values = values.as_materialized_series_maintain_scalar();
         let ca: &BooleanChunked = values.as_ref().as_ref();
@@ -55,11 +56,12 @@ impl GroupedReduction for AnyIgnoreNullGroupedReduction {
 
     unsafe fn update_groups_while_evicting(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         subset: &[IdxSize],
         group_idxs: &[EvictIdx],
         _seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         assert!(values.dtype() == &DataType::Boolean);
         assert!(subset.len() == group_idxs.len());
         let values = values.as_materialized_series(); // @scalar-opt
@@ -137,10 +139,11 @@ impl GroupedReduction for AllIgnoreNullGroupedReduction {
 
     fn update_group(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         group_idx: IdxSize,
         _seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         assert!(values.dtype() == &DataType::Boolean);
         let values = values.as_materialized_series_maintain_scalar();
         let ca: &BooleanChunked = values.as_ref().as_ref();
@@ -152,11 +155,12 @@ impl GroupedReduction for AllIgnoreNullGroupedReduction {
 
     unsafe fn update_groups_while_evicting(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         subset: &[IdxSize],
         group_idxs: &[EvictIdx],
         _seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         assert!(values.dtype() == &DataType::Boolean);
         assert!(subset.len() == group_idxs.len());
         let values = values.as_materialized_series(); // @scalar-opt
@@ -238,10 +242,11 @@ impl GroupedReduction for AnyKleeneNullGroupedReduction {
 
     fn update_group(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         group_idx: IdxSize,
         _seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         assert!(values.dtype() == &DataType::Boolean);
         let values = values.as_materialized_series_maintain_scalar();
         let ca: &BooleanChunked = values.as_ref().as_ref();
@@ -256,11 +261,12 @@ impl GroupedReduction for AnyKleeneNullGroupedReduction {
 
     unsafe fn update_groups_while_evicting(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         subset: &[IdxSize],
         group_idxs: &[EvictIdx],
         _seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         assert!(values.dtype() == &DataType::Boolean);
         assert!(subset.len() == group_idxs.len());
         let values = values.as_materialized_series(); // @scalar-opt
@@ -362,10 +368,11 @@ impl GroupedReduction for AllKleeneNullGroupedReduction {
 
     fn update_group(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         group_idx: IdxSize,
         _seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         assert!(values.dtype() == &DataType::Boolean);
         let values = values.as_materialized_series_maintain_scalar();
         let ca: &BooleanChunked = values.as_ref().as_ref();
@@ -380,11 +387,12 @@ impl GroupedReduction for AllKleeneNullGroupedReduction {
 
     unsafe fn update_groups_while_evicting(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         subset: &[IdxSize],
         group_idxs: &[EvictIdx],
         _seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         assert!(values.dtype() == &DataType::Boolean);
         assert!(subset.len() == group_idxs.len());
         let values = values.as_materialized_series(); // @scalar-opt

--- a/crates/polars-expr/src/reduce/bitwise.rs
+++ b/crates/polars-expr/src/reduce/bitwise.rs
@@ -155,10 +155,11 @@ impl GroupedReduction for BoolXorGroupedReduction {
 
     fn update_group(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         group_idx: IdxSize,
         _seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         assert!(values.dtype() == &DataType::Boolean);
         let values = values.as_materialized_series_maintain_scalar();
         let ca: &BooleanChunked = values.as_ref().as_ref();
@@ -176,11 +177,12 @@ impl GroupedReduction for BoolXorGroupedReduction {
 
     unsafe fn update_groups_while_evicting(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         subset: &[IdxSize],
         group_idxs: &[EvictIdx],
         _seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         assert!(values.dtype() == &DataType::Boolean);
         assert!(subset.len() == group_idxs.len());
         let values = values.as_materialized_series(); // @scalar-opt

--- a/crates/polars-expr/src/reduce/convert.rs
+++ b/crates/polars-expr/src/reduce/convert.rs
@@ -24,14 +24,14 @@ pub fn into_reduction(
     node: Node,
     expr_arena: &mut Arena<AExpr>,
     schema: &Schema,
-) -> PolarsResult<(Box<dyn GroupedReduction>, Node)> {
+) -> PolarsResult<(Box<dyn GroupedReduction>, Vec<Node>)> {
     let get_dt = |node| {
         expr_arena
             .get(node)
             .to_dtype(&ToFieldContext::new(expr_arena, schema))?
             .materialize_unknown(false)
     };
-    let out = match expr_arena.get(node) {
+    let (gr, in_node) = match expr_arena.get(node) {
         AExpr::Agg(agg) => match agg {
             IRAggExpr::Sum(input) => (new_sum_reduction(get_dt(*input)?)?, *input),
             IRAggExpr::Mean(input) => (new_mean_reduction(get_dt(*input)?)?, *input),
@@ -164,5 +164,5 @@ pub fn into_reduction(
         },
         _ => unreachable!(),
     };
-    Ok(out)
+    Ok((gr, vec![in_node]))
 }

--- a/crates/polars-expr/src/reduce/count.rs
+++ b/crates/polars-expr/src/reduce/count.rs
@@ -34,10 +34,11 @@ impl GroupedReduction for CountReduce {
 
     fn update_group(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         group_idx: IdxSize,
         _seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         let mut count = values.len();
         if !self.include_nulls {
             count -= values.null_count();
@@ -48,11 +49,12 @@ impl GroupedReduction for CountReduce {
 
     unsafe fn update_groups_while_evicting(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         subset: &[IdxSize],
         group_idxs: &[EvictIdx],
         _seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         assert!(subset.len() == group_idxs.len());
         let values = values.as_materialized_series(); // @scalar-opt
         let chunks = values.chunks();
@@ -150,21 +152,23 @@ impl GroupedReduction for NullCountReduce {
 
     fn update_group(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         group_idx: IdxSize,
         _seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         self.counts[group_idx as usize] += values.null_count() as u64;
         Ok(())
     }
 
     unsafe fn update_groups_while_evicting(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         subset: &[IdxSize],
         group_idxs: &[EvictIdx],
         _seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         assert!(subset.len() == group_idxs.len());
         let values = values.as_materialized_series(); // @scalar-opt
         let chunks = values.chunks();

--- a/crates/polars-expr/src/reduce/first_last.rs
+++ b/crates/polars-expr/src/reduce/first_last.rs
@@ -350,10 +350,11 @@ impl<P: Policy + 'static> GroupedReduction for GenericFirstLastGroupedReduction<
 
     fn update_group(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         group_idx: IdxSize,
         seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         assert!(values.dtype() == &self.in_dtype);
         if !values.is_empty() {
             let seq_id = seq_id + 1; // We use 0 for 'no value'.
@@ -372,11 +373,12 @@ impl<P: Policy + 'static> GroupedReduction for GenericFirstLastGroupedReduction<
 
     unsafe fn update_groups_while_evicting(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         subset: &[IdxSize],
         group_idxs: &[EvictIdx],
         seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         assert!(values.dtype() == &self.in_dtype);
         assert!(subset.len() == group_idxs.len());
         let seq_id = seq_id + 1; // We use 0 for 'no value'.

--- a/crates/polars-expr/src/reduce/first_last_nonnull.rs
+++ b/crates/polars-expr/src/reduce/first_last_nonnull.rs
@@ -360,10 +360,11 @@ impl<P: NonNullPolicy + 'static> GroupedReduction for GenericFirstLastNonNullGro
 
     fn update_group(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         group_idx: IdxSize,
         seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         assert!(values.dtype() == &self.in_dtype);
         if !values.is_empty() {
             let seq_id = seq_id + 1; // We use 0 for 'no value'.
@@ -401,11 +402,12 @@ impl<P: NonNullPolicy + 'static> GroupedReduction for GenericFirstLastNonNullGro
 
     unsafe fn update_groups_while_evicting(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         subset: &[IdxSize],
         group_idxs: &[EvictIdx],
         seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         assert!(values.dtype() == &self.in_dtype);
         assert!(subset.len() == group_idxs.len());
         let seq_id = seq_id + 1; // We use 0 for 'no value'.

--- a/crates/polars-expr/src/reduce/len.rs
+++ b/crates/polars-expr/src/reduce/len.rs
@@ -24,17 +24,18 @@ impl GroupedReduction for LenReduce {
 
     fn update_group(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         group_idx: IdxSize,
         _seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         self.groups[group_idx as usize] += values.len() as u64;
         Ok(())
     }
 
     unsafe fn update_groups_while_evicting(
         &mut self,
-        _values: &Column,
+        _values: &[&Column],
         subset: &[IdxSize],
         group_idxs: &[EvictIdx],
         _seq_id: u64,

--- a/crates/polars-expr/src/reduce/min_max.rs
+++ b/crates/polars-expr/src/reduce/min_max.rs
@@ -328,10 +328,11 @@ impl GroupedReduction for BoolMinGroupedReduction {
 
     fn update_group(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         group_idx: IdxSize,
         _seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         // TODO: we should really implement a sum-as-other-type operation instead
         // of doing this materialized cast.
         assert!(values.dtype() == &DataType::Boolean);
@@ -348,11 +349,12 @@ impl GroupedReduction for BoolMinGroupedReduction {
 
     unsafe fn update_groups_while_evicting(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         subset: &[IdxSize],
         group_idxs: &[EvictIdx],
         _seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         assert!(values.dtype() == &DataType::Boolean);
         assert!(subset.len() == group_idxs.len());
         let values = values.as_materialized_series(); // @scalar-opt
@@ -442,10 +444,11 @@ impl GroupedReduction for BoolMaxGroupedReduction {
 
     fn update_group(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         group_idx: IdxSize,
         _seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         // TODO: we should really implement a sum-as-other-type operation instead
         // of doing this materialized cast.
         assert!(values.dtype() == &DataType::Boolean);
@@ -462,11 +465,12 @@ impl GroupedReduction for BoolMaxGroupedReduction {
 
     unsafe fn update_groups_while_evicting(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         subset: &[IdxSize],
         group_idxs: &[EvictIdx],
         _seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         assert!(values.dtype() == &DataType::Boolean);
         assert!(subset.len() == group_idxs.len());
         let values = values.as_materialized_series(); // @scalar-opt
@@ -684,10 +688,11 @@ impl GroupedReduction for NullGroupedReduction {
 
     fn update_group(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         _group_idx: IdxSize,
         _seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         assert!(values.dtype() == &DataType::Null);
 
         // no-op
@@ -696,11 +701,12 @@ impl GroupedReduction for NullGroupedReduction {
 
     unsafe fn update_groups_while_evicting(
         &mut self,
-        values: &Column,
+        values: &[&Column],
         subset: &[IdxSize],
         group_idxs: &[EvictIdx],
         _seq_id: u64,
     ) -> PolarsResult<()> {
+        let &[values] = values else { unreachable!() };
         assert!(values.dtype() == &DataType::Null);
         assert!(subset.len() == group_idxs.len());
 

--- a/crates/polars-stream/src/nodes/io_sinks/metrics.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/metrics.rs
@@ -76,10 +76,10 @@ impl WriteMetrics {
 
             if has_non_null_non_nan_values {
                 if let Some(lb) = &mut w.lower_bound {
-                    lb.update_group(c, 0, 0)?;
+                    lb.update_group(&[c], 0, 0)?;
                 }
                 if let Some(ub) = &mut w.upper_bound {
-                    ub.update_group(c, 0, 0)?;
+                    ub.update_group(&[c], 0, 0)?;
                 }
             }
         }

--- a/crates/polars-stream/src/nodes/reduce.rs
+++ b/crates/polars-stream/src/nodes/reduce.rs
@@ -12,7 +12,7 @@ use crate::morsel::SourceToken;
 
 enum ReduceState {
     Sink {
-        selectors: Vec<StreamExpr>,
+        selectors: Vec<Vec<StreamExpr>>,
         reductions: Vec<Box<dyn GroupedReduction>>,
     },
     Source(Option<DataFrame>),
@@ -26,7 +26,7 @@ pub struct ReduceNode {
 
 impl ReduceNode {
     pub fn new(
-        selectors: Vec<StreamExpr>,
+        selectors: Vec<Vec<StreamExpr>>,
         reductions: Vec<Box<dyn GroupedReduction>>,
         output_schema: Arc<Schema>,
     ) -> Self {
@@ -40,7 +40,7 @@ impl ReduceNode {
     }
 
     fn spawn_sink<'env, 's>(
-        selectors: &'env [StreamExpr],
+        selectors: &'env [Vec<StreamExpr>],
         reductions: &'env mut [Box<dyn GroupedReduction>],
         scope: &'s TaskScope<'s, 'env>,
         recv: RecvPort<'_>,
@@ -61,12 +61,24 @@ impl ReduceNode {
                     .collect();
 
                 scope.spawn_task(TaskPriority::High, async move {
+                    let mut in_columns = Vec::new();
+                    let mut in_column_refs = Vec::new();
                     while let Ok(morsel) = recv.recv().await {
-                        for (reducer, selector) in local_reducers.iter_mut().zip(selectors) {
-                            let input = selector
-                                .evaluate(morsel.df(), &state.in_memory_exec_state)
-                                .await?;
-                            reducer.update_group(&input, 0, morsel.seq().to_u64())?;
+                        for (reducer, selector_set) in local_reducers.iter_mut().zip(selectors) {
+                            for selector in selector_set {
+                                let col = selector
+                                    .evaluate(morsel.df(), &state.in_memory_exec_state)
+                                    .await?;
+                                in_columns.push(col);
+                            }
+                            for c in in_columns.iter() {
+                                in_column_refs.push(c);
+                            }
+                            reducer.update_group(&in_column_refs, 0, morsel.seq().to_u64())?;
+                            in_column_refs.clear();
+                            in_column_refs =
+                                in_column_refs.into_iter().map(|_| unreachable!()).collect(); // Clear lifetimes.
+                            in_columns.clear();
                         }
                     }
 

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -254,16 +254,21 @@ fn to_graph_rec<'a>(
             let mut inputs = Vec::with_capacity(reductions.len());
 
             for e in exprs {
-                let (red, input_node) = into_reduction(e.node(), ctx.expr_arena, input_schema)?;
+                let (red, input_nodes) = into_reduction(e.node(), ctx.expr_arena, input_schema)?;
                 reductions.push(red);
 
-                let input_phys = create_stream_expr(
-                    &ExprIR::from_node(input_node, ctx.expr_arena),
-                    ctx,
-                    input_schema,
-                )?;
+                let input_phys_exprs = input_nodes
+                    .iter()
+                    .map(|node| {
+                        create_stream_expr(
+                            &ExprIR::from_node(*node, ctx.expr_arena),
+                            ctx,
+                            input_schema,
+                        )
+                    })
+                    .try_collect_vec()?;
 
-                inputs.push(input_phys)
+                inputs.push(input_phys_exprs)
             }
 
             ctx.graph.add_node(
@@ -817,13 +822,19 @@ fn to_graph_rec<'a>(
                             | IRAggExpr::LastNonNull(_)
                     )
                 );
-                let (reduction, input_node) =
+                let (reduction, input_nodes) =
                     into_reduction(agg.node(), ctx.expr_arena, input_schema)?;
-                let AExpr::Column(col) = ctx.expr_arena.get(input_node) else {
-                    unreachable!()
-                };
+                let cols = input_nodes
+                    .iter()
+                    .map(|node| {
+                        let AExpr::Column(col) = ctx.expr_arena.get(*node) else {
+                            unreachable!()
+                        };
+                        col.clone()
+                    })
+                    .collect();
                 grouped_reductions.push(reduction);
-                grouped_reduction_cols.push(col.clone());
+                grouped_reduction_cols.push(cols);
             }
 
             ctx.graph.add_node(


### PR DESCRIPTION
Preliminary work for adding `Expr.min_by` and `Expr.max_by` aggregations.