### PR TITLE
refactor(rust): Make polars-plan constants more consistent

### DIFF
--- a/crates/polars-expr/src/expressions/literal.rs
+++ b/crates/polars-expr/src/expressions/literal.rs
@@ -30,11 +30,11 @@ impl LiteralExpr {
                     }
                 }
 
-                sc.clone().into_column(get_literal_name().clone())
+                sc.clone().into_column(get_literal_name())
             },
             L::Series(s) => s.deref().clone().into_column(),
             lv @ L::Dyn(_) => polars_core::prelude::Series::from_any_values(
-                get_literal_name().clone(),
+                get_literal_name(),
                 &[lv.to_any_value().unwrap()],
                 false,
             )
@@ -138,7 +138,7 @@ impl PhysicalExpr for LiteralExpr {
 
     fn to_field(&self, _input_schema: &Schema) -> PolarsResult<Field> {
         let dtype = self.0.get_datatype();
-        Ok(Field::new(PlSmallStr::from_static("literal"), dtype))
+        Ok(Field::new(get_literal_name(), dtype))
     }
     fn is_literal(&self) -> bool {
         true

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -1,5 +1,5 @@
 use polars_core::prelude::*;
-use polars_plan::constants::PL_ELEMENT_NAME;
+use polars_plan::constants::{get_literal_name, get_pl_element_name};
 use polars_plan::prelude::expr_ir::ExprIR;
 use polars_plan::prelude::*;
 use recursive::recursive;
@@ -223,7 +223,7 @@ fn create_physical_expr_inner(
 
             if apply_columns.is_empty() {
                 if has_aexpr(function, expr_arena, |e| matches!(e, AExpr::Literal(_))) {
-                    apply_columns.push(PlSmallStr::from_static("literal"))
+                    apply_columns.push(get_literal_name())
                 } else if has_aexpr(function, expr_arena, |e| matches!(e, AExpr::Len)) {
                     apply_columns.push(PlSmallStr::from_static("len"))
                 } else if has_aexpr(function, expr_arena, |e| matches!(e, AExpr::Element)) {
@@ -482,7 +482,7 @@ fn create_physical_expr_inner(
 
             let element_dtype = variant.element_dtype(&input_field.dtype)?;
             let mut eval_schema = schema.as_ref().clone();
-            eval_schema.insert(PL_ELEMENT_NAME.clone(), element_dtype.clone());
+            eval_schema.insert(get_pl_element_name(), element_dtype.clone());
             let evaluation =
                 create_physical_expr_inner(*evaluation, expr_arena, &Arc::new(eval_schema), state)?;
 

--- a/crates/polars-plan/src/constants.rs
+++ b/crates/polars-plan/src/constants.rs
@@ -1,24 +1,23 @@
-use std::sync::OnceLock;
-
 use polars_utils::pl_str::PlSmallStr;
 
-pub static CSE_REPLACED: &str = "__POLARS_CSER_";
-pub static POLARS_TMP_PREFIX: &str = "_POLARS_";
-pub static POLARS_PLACEHOLDER: &str = "_POLARS_<>";
-pub static POLARS_ELEMENT: &str = "__PL_ELEMENT";
+pub const CSE_REPLACED: &str = "__POLARS_CSER_";
+pub const POLARS_TMP_PREFIX: &str = "_POLARS_";
+pub const POLARS_PLACEHOLDER: &str = "_POLARS_<>";
+pub const POLARS_ELEMENT: &str = "__PL_ELEMENT";
 pub const LEN: &str = "len";
-const LITERAL_NAME: &str = "literal";
 
-// Cache the often used LITERAL and LEN constants
-static LITERAL_NAME_INIT: OnceLock<PlSmallStr> = OnceLock::new();
-static LEN_INIT: OnceLock<PlSmallStr> = OnceLock::new();
-pub static PL_ELEMENT_NAME: PlSmallStr = PlSmallStr::from_static(POLARS_ELEMENT);
+const LITERAL_NAME: PlSmallStr = PlSmallStr::from_static("literal");
+const LEN_NAME: PlSmallStr = PlSmallStr::from_static(LEN);
+const PL_ELEMENT_NAME: PlSmallStr = PlSmallStr::from_static(POLARS_ELEMENT);
 
-pub fn get_literal_name() -> &'static PlSmallStr {
-    LITERAL_NAME_INIT.get_or_init(|| PlSmallStr::from_static(LITERAL_NAME))
+pub fn get_literal_name() -> PlSmallStr {
+    LITERAL_NAME.clone()
 }
+
 pub(crate) fn get_len_name() -> PlSmallStr {
-    LEN_INIT
-        .get_or_init(|| PlSmallStr::from_static(LEN))
-        .clone()
+    LEN_NAME.clone()
+}
+
+pub fn get_pl_element_name() -> PlSmallStr {
+    PL_ELEMENT_NAME.clone()
 }

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -4,7 +4,7 @@ use polars_utils::format_pl_smallstr;
 use recursive::recursive;
 
 use super::*;
-use crate::constants::{PL_ELEMENT_NAME, POLARS_ELEMENT};
+use crate::constants::{POLARS_ELEMENT, get_literal_name, get_pl_element_name};
 
 fn validate_expr(node: Node, ctx: &ToFieldContext) -> PolarsResult<()> {
     ctx.arena.get(node).to_field_impl(ctx).map(|_| ())
@@ -96,7 +96,7 @@ impl AExpr {
                 .ok_or_else(|| PolarsError::ColumnNotFound(name.to_string().into())),
             Literal(sv) => Ok(match sv {
                 LiteralValue::Series(s) => s.field().into_owned(),
-                _ => Field::new(sv.output_column_name().clone(), sv.get_datatype()),
+                _ => Field::new(sv.output_column_name(), sv.get_datatype()),
             }),
             BinaryExpr { left, right, op } => {
                 use DataType::*;
@@ -278,7 +278,7 @@ impl AExpr {
 
                 let element_dtype = variant.element_dtype(field.dtype())?;
                 let mut evaluation_schema = ctx.schema.clone();
-                evaluation_schema.insert(PL_ELEMENT_NAME.clone(), element_dtype.clone());
+                evaluation_schema.insert(get_pl_element_name(), element_dtype.clone());
                 let mut output_field = ctx
                     .arena
                     .get(*evaluation)
@@ -305,7 +305,7 @@ impl AExpr {
                             IRFunctionExpr::StringExpr(IRStringFunction::Format { .. })
                         )
                     {
-                        return Ok(Field::new("literal".into(), DataType::String));
+                        return Ok(Field::new(get_literal_name(), DataType::String));
                     }
                 }
 
@@ -391,7 +391,7 @@ impl AExpr {
                 None => input[0].output_name().clone(),
             },
             Column(name) => name.clone(),
-            Literal(lv) => lv.output_column_name().clone(),
+            Literal(lv) => lv.output_column_name(),
         }
     }
 }

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/datatype_fn_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/datatype_fn_to_ir.rs
@@ -20,19 +20,19 @@ pub fn datatype_fn_to_aexpr(
             AExpr::Literal(LiteralValue::Scalar(Scalar::from(PlSmallStr::from_string(
                 dt.into_datatype(ctx.schema)?.to_string(),
             )))),
-            get_literal_name().clone(),
+            get_literal_name(),
         ),
         DTF::Eq(l, r) => (
             AExpr::Literal(LiteralValue::Scalar(Scalar::from(
                 l.into_datatype(ctx.schema)? == r.into_datatype(ctx.schema)?,
             ))),
-            get_literal_name().clone(),
+            get_literal_name(),
         ),
         DTF::Matches(dt, selector) => {
             let dt = dt.into_datatype(ctx.schema)?;
             (
                 AExpr::Literal(LiteralValue::Scalar(Scalar::from(selector.matches(&dt)))),
-                get_literal_name().clone(),
+                get_literal_name(),
             )
         },
         DTF::DefaultValue {
@@ -65,7 +65,7 @@ pub fn datatype_fn_to_aexpr(
                 };
             }
 
-            (expr, get_literal_name().clone())
+            (expr, get_literal_name())
         },
         DTF::Array(dt_expr, f) => {
             let (inner, width): (DataType, usize) = match dt_expr.into_datatype(ctx.schema)? {
@@ -87,14 +87,11 @@ pub fn datatype_fn_to_aexpr(
                             dims.push(width as u32);
                             inner = *new_inner;
                         }
-                        LiteralValue::Series(SpecialEq::new(Series::new(
-                            get_literal_name().clone(),
-                            dims,
-                        )))
+                        LiteralValue::Series(SpecialEq::new(Series::new(get_literal_name(), dims)))
                     },
                 };
                 let value = AExpr::Literal(value);
-                (value, get_literal_name().clone())
+                (value, get_literal_name())
             })
         },
         DTF::Struct(dt_expr, f) => {
@@ -107,7 +104,7 @@ pub fn datatype_fn_to_aexpr(
             let value = match f {
                 StructDataTypeFunction::FieldNames => {
                     LiteralValue::Series(SpecialEq::new(Series::new(
-                        get_literal_name().clone(),
+                        get_literal_name(),
                         fields
                             .iter()
                             .map(|f| f.name.as_str())
@@ -116,7 +113,7 @@ pub fn datatype_fn_to_aexpr(
                 },
             };
             let value = AExpr::Literal(value);
-            (value, get_literal_name().clone())
+            (value, get_literal_name())
         },
     })
 }

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_expansion.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_expansion.rs
@@ -1,7 +1,7 @@
 //! this contains code used for rewriting projections, expanding wildcards, regex selection etc.
 
 use super::*;
-use crate::constants::{PL_ELEMENT_NAME, POLARS_ELEMENT};
+use crate::constants::{POLARS_ELEMENT, get_pl_element_name};
 
 pub fn prepare_projection(
     exprs: Vec<Expr>,
@@ -874,7 +874,7 @@ fn expand_expression_rec(
                 let expr_dtype = expr.to_field(schema)?.dtype;
                 let element_dtype = variant.element_dtype(&expr_dtype)?;
                 let mut evaluation_schema = schema.clone();
-                evaluation_schema.insert(PL_ELEMENT_NAME.clone(), element_dtype.clone());
+                evaluation_schema.insert(get_pl_element_name(), element_dtype.clone());
 
                 let start_length = out.len();
                 expand_expression_rec(

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_to_ir.rs
@@ -1,6 +1,6 @@
 use super::functions::convert_functions;
 use super::*;
-use crate::constants::PL_ELEMENT_NAME;
+use crate::constants::get_pl_element_name;
 use crate::plans::iterator::ArenaExprIter;
 
 pub fn to_expr_ir(expr: Expr, ctx: &mut ExprToIRContext) -> PolarsResult<ExprIR> {
@@ -128,7 +128,7 @@ pub(super) fn to_aexpr_impl(
         },
         Expr::Alias(e, name) => return Ok((recurse_arc!(e)?.0, name)),
         Expr::Literal(lv) => {
-            let output_name = lv.output_column_name().clone();
+            let output_name = lv.output_column_name();
             (AExpr::Literal(lv), output_name)
         },
         Expr::Column(name) => {
@@ -462,7 +462,7 @@ pub(super) fn to_aexpr_impl(
             }
 
             let mut evaluation_schema = ctx.schema.clone();
-            evaluation_schema.insert(PL_ELEMENT_NAME.clone(), element_dtype.clone());
+            evaluation_schema.insert(get_pl_element_name(), element_dtype.clone());
             let mut evaluation_ctx = ExprToIRContext {
                 with_fields: None,
                 schema: &evaluation_schema,

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
@@ -235,7 +235,7 @@ pub(super) fn convert_functions(
                             .arena
                             .add(AExpr::Literal(LiteralValue::Scalar(Scalar::from(format))));
 
-                        return Ok((out, get_literal_name().clone()));
+                        return Ok((out, get_literal_name()));
                     } else {
                         IS::Format { format, insertions }
                     }

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -12,7 +12,7 @@ use polars_utils::unique_id::UniqueId;
 use super::convert_utils::SplitPredicates;
 use super::stack_opt::ConversionOptimizer;
 use super::*;
-use crate::constants::PL_ELEMENT_NAME;
+use crate::constants::get_pl_element_name;
 use crate::dsl::PartitionedSinkOptions;
 use crate::dsl::sink2::FileProviderType;
 
@@ -779,7 +779,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             for value in values.iter() {
                 out.clear();
                 let value_dtype = input_schema.try_get(value)?;
-                expr_schema.insert(PL_ELEMENT_NAME.clone(), value_dtype.clone());
+                expr_schema.insert(get_pl_element_name(), value_dtype.clone());
                 expand_expression(
                     &agg,
                     &Default::default(),

--- a/crates/polars-plan/src/plans/conversion/stack_opt.rs
+++ b/crates/polars-plan/src/plans/conversion/stack_opt.rs
@@ -2,7 +2,7 @@ use std::borrow::Borrow;
 
 use self::type_check::TypeCheckRule;
 use super::*;
-use crate::constants::PL_ELEMENT_NAME;
+use crate::constants::get_pl_element_name;
 
 /// Applies expression simplification and type coercion during conversion to IR.
 pub struct ConversionOptimizer {
@@ -146,7 +146,7 @@ impl ConversionOptimizer {
 
                 let element_dtype = variant.element_dtype(&expr)?;
                 let mut schema = schema.clone();
-                schema.insert(PL_ELEMENT_NAME.clone(), element_dtype.clone());
+                schema.insert(get_pl_element_name(), element_dtype.clone());
                 self.schemas.push(schema);
                 self.scratch.push((*evaluation, self.schemas.len()));
             }

--- a/crates/polars-plan/src/plans/expr_ir.rs
+++ b/crates/polars-plan/src/plans/expr_ir.rs
@@ -9,7 +9,7 @@ use polars_utils::format_pl_smallstr;
 use serde::{Deserialize, Serialize};
 
 use super::*;
-use crate::constants::{PL_ELEMENT_NAME, get_len_name, get_literal_name};
+use crate::constants::{get_len_name, get_literal_name, get_pl_element_name};
 
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(feature = "ir_serde", derive(Serialize, Deserialize))]
@@ -128,7 +128,7 @@ impl ExprIR {
         for (_, ae) in arena.iter(node) {
             match ae {
                 AExpr::Element => {
-                    out.output_name = OutputName::ColumnLhs(PL_ELEMENT_NAME.clone());
+                    out.output_name = OutputName::ColumnLhs(get_pl_element_name());
                     break;
                 },
                 AExpr::Column(name) => {
@@ -139,7 +139,7 @@ impl ExprIR {
                     if let LiteralValue::Series(s) = lv {
                         out.output_name = OutputName::LiteralLhs(s.name().clone());
                     } else {
-                        out.output_name = OutputName::LiteralLhs(get_literal_name().clone());
+                        out.output_name = OutputName::LiteralLhs(get_literal_name());
                     }
                     break;
                 },

--- a/crates/polars-plan/src/plans/lit.rs
+++ b/crates/polars-plan/src/plans/lit.rs
@@ -94,33 +94,27 @@ impl DynListLiteralValue {
 
         let s = match self {
             DynListLiteralValue::Str(vs) => {
-                StringChunked::from_iter_options(PlSmallStr::from_static("literal"), vs.into_iter())
-                    .into_series()
+                StringChunked::from_iter_options(get_literal_name(), vs.into_iter()).into_series()
             },
             DynListLiteralValue::Int(vs) => {
                 #[cfg(feature = "dtype-i128")]
                 {
-                    Int128Chunked::from_iter_options(
-                        PlSmallStr::from_static("literal"),
-                        vs.into_iter(),
-                    )
-                    .into_series()
+                    Int128Chunked::from_iter_options(get_literal_name(), vs.into_iter())
+                        .into_series()
                 }
 
                 #[cfg(not(feature = "dtype-i128"))]
                 {
                     Int64Chunked::from_iter_options(
-                        PlSmallStr::from_static("literal"),
+                        get_literal_name(),
                         vs.into_iter().map(|v| v.map(|v| v as i64)),
                     )
                     .into_series()
                 }
             },
-            DynListLiteralValue::Float(vs) => Float64Chunked::from_iter_options(
-                PlSmallStr::from_static("literal"),
-                vs.into_iter(),
-            )
-            .into_series(),
+            DynListLiteralValue::Float(vs) => {
+                Float64Chunked::from_iter_options(get_literal_name(), vs.into_iter()).into_series()
+            },
             DynListLiteralValue::List(_) => todo!("nested lists"),
         };
 
@@ -216,9 +210,9 @@ impl RangeLiteralValue {
 
 impl LiteralValue {
     /// Get the output name as [`PlSmallStr`].
-    pub(crate) fn output_column_name(&self) -> &PlSmallStr {
+    pub(crate) fn output_column_name(&self) -> PlSmallStr {
         match self {
-            LiteralValue::Series(s) => s.name(),
+            LiteralValue::Series(s) => s.name().clone(),
             _ => get_literal_name(),
         }
     }

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -117,7 +117,7 @@ pub fn expr_output_name(expr: &Expr) -> PolarsResult<PlSmallStr> {
             Expr::KeepName(_) => polars_bail!(nyi = "`name.keep` is not allowed here"),
             Expr::RenameAlias { expr, function } => return function.call(&expr_output_name(expr)?),
             Expr::Len => return Ok(get_len_name()),
-            Expr::Literal(val) => return Ok(val.output_column_name().clone()),
+            Expr::Literal(val) => return Ok(val.output_column_name()),
 
             #[cfg(feature = "dtype-struct")]
             Expr::Function {

--- a/crates/polars-python/src/functions/range.rs
+++ b/crates/polars-python/src/functions/range.rs
@@ -1,6 +1,7 @@
 use polars::lazy::dsl;
 use polars_core::with_match_physical_integer_polars_type;
 use polars_ops::series::ClosedInterval;
+use polars_plan::constants::get_literal_name;
 use pyo3::prelude::*;
 
 use crate::error::PyPolarsErr;
@@ -45,7 +46,7 @@ pub fn eager_int_range(
         let start_v: <$T as PolarsNumericType>::Native = lower.extract()?;
         let end_v: <$T as PolarsNumericType>::Native = upper.extract()?;
         let step: i64 = step.extract()?;
-        py.enter_polars_series(|| new_int_range::<$T>(start_v, end_v, step, PlSmallStr::from_static("literal")))
+        py.enter_polars_series(|| new_int_range::<$T>(start_v, end_v, step, get_literal_name()))
     })
 }
 

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -583,8 +583,7 @@ pub fn lower_ir(
                 let k_node =
                     expr_arena.add(AExpr::Literal(LiteralValue::Scalar(Scalar::from(limit))));
                 let k_selector = ExprIR::from_node(k_node, expr_arena);
-                let k_output_schema =
-                    Schema::from_iter([(get_literal_name().clone(), DataType::UInt64)]);
+                let k_output_schema = Schema::from_iter([(get_literal_name(), DataType::UInt64)]);
                 let k_node = phys_sm.insert(PhysNode::new(
                     Arc::new(k_output_schema),
                     PhysNodeKind::InputIndependentSelect {


### PR DESCRIPTION
- Consistently use Use get_literal_name in implementation
- Consistently use const
- Use PlSmallString::from_static effectively