### PR TITLE
fix: Fix `panic` edge-case when scanning hive partitioned data

### DIFF
--- a/crates/polars-mem-engine/src/scan_predicate/functions.rs
+++ b/crates/polars-mem-engine/src/scan_predicate/functions.rs
@@ -222,7 +222,6 @@ pub fn initialize_scan_predicate<'a>(
 
         let (skip_files_mask, send_predicate_to_readers) = if let Some(hive_parts) = hive_parts
             && let Some(hive_predicate) = &predicate.hive_predicate
-            && hive_parts.df().height() > 0
         {
             if verbose {
                 eprintln!(

--- a/crates/polars-plan/src/plans/hive.rs
+++ b/crates/polars-plan/src/plans/hive.rs
@@ -39,13 +39,16 @@ impl HivePartitionsDf {
 
     /// Filter the columns to those contained in `projected_columns`.
     pub fn filter_columns(&self, projected_columns: &Schema) -> Self {
-        self.df()
+        let columns: Vec<_> = self
+            .df()
             .get_columns()
             .iter()
             .filter(|c| projected_columns.contains(c.name()))
             .cloned()
-            .collect::<DataFrame>()
-            .into()
+            .collect();
+
+        let height = self.df().height();
+        DataFrame::new_with_height(height, columns).unwrap().into()
     }
 
     pub fn take_indices(&self, row_indexes: &[IdxSize]) -> Self {

--- a/py-polars/tests/unit/io/test_multiscan.py
+++ b/py-polars/tests/unit/io/test_multiscan.py
@@ -934,5 +934,8 @@ def test_hive_predicate_filtering_edge_case_25630(
     write(df.filter(pl.col.y == 1).drop("y"), tmp_path / "y=1" / f"data.{ext}")
 
     res = scan(tmp_path).filter(predicate).select("index").collect(engine="streaming")
-    expected = pl.DataFrame({"index": expected_indices}, schema={"index": pl.UInt32})
+    expected = pl.DataFrame(
+        data={"index": expected_indices},
+        schema={"index": pl.get_index_type()},
+    )
     assert_frame_equal(res, expected)

--- a/py-polars/tests/unit/operations/namespaces/array/test_eval.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_eval.py
@@ -264,7 +264,7 @@ def test_arr_eval_with_filter_in_agg_25384(
     ("expr", "result"),
     [
         (pl.element().sum(), pl.Series("a", [1, 8, 22])),
-        (pl.element().null_count(), pl.Series("a", [1, 1, 0], pl.UInt32)),
+        (pl.element().null_count(), pl.Series("a", [1, 1, 0], pl.get_index_type())),
     ],
 )
 def test_arr_agg_with_filter_in_agg_25384(


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/25630

@nameexhaustion: I think the fix may be as simple as checking that `hive_parts.df` actually has some rows? In the given Issue all the hive columns get filtered out, so `hive_parts.df` ends up with no columns/no rows, but goes on to try hive predicate evaluation (and we end up with mismatched bitmap lengths, leading to the panic) 🤔

**Updated** (ref: https://github.com/pola-rs/polars/pull/25656#issuecomment-3621972660)