### PR TITLE
ci: Add "panic" and "streaming" tagging to `issue-labeler` workflow

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -42,7 +42,11 @@ A-io-parquet:
   - '/parquet/i'
 A-io-spreadsheet:
   - '/spreadsheet|excel|\bods\b/i'
+A-panic:
+  - '/panic/i'
 A-plugin:
   - '/plugin/i'
 A-sql:
   - '/\bsql\b/i'
+A-streaming:
+  - '/streaming/i'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -48,9 +48,15 @@ autolabeler:
   - label: fix
     title:
       - '/^fix/'
+  - label: performance
+    title:
+      - '/^perf/'
   - label: regression
     title:
       - '/regression/'
+  - label: release
+    title:
+      - '/^release/'
   - label: A-sql
     title:
       - '/\bsql\b/i'
@@ -111,12 +117,10 @@ autolabeler:
   - label: A-plugin
     title:
       - '/plugin/i'
-  - label: performance
+  - label: A-streaming
     title:
-      - '/^perf/'
-  - label: release
-    title:
-      - '/^release/'
+      - '/streaming/i'
+
 
 template: |
   $CHANGES


### PR DESCRIPTION
The Issue labeler seems to be working nicely now; this adds a couple of extra tags (and "streaming" to the PR labeler).