### PR TITLE
fix: Rechunk on nested dtypes in `take_unchecked_impl` parallel path

### DIFF
--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -2050,8 +2050,34 @@ impl DataFrame {
     /// # Safety
     /// The indices must be in-bounds.
     pub unsafe fn take_unchecked_impl(&self, idx: &IdxCa, allow_threads: bool) -> Self {
-        let cols = if allow_threads {
-            POOL.install(|| self._apply_columns_par(&|c| c.take_unchecked(idx)))
+        let cols = if allow_threads && POOL.current_num_threads() > 1 {
+            POOL.install(|| {
+                if POOL.current_num_threads() > self.width() {
+                    let stride = usize::max(idx.len().div_ceil(POOL.current_num_threads()), 256);
+                    self._apply_columns_par(&|c| {
+                        // Nested types initiate a rechunk in their take_unchecked implementation.
+                        // If we do not rechunk, it will result in rechunk storms downstream.
+                        let c = if c.dtype().is_nested() {
+                            &c.rechunk()
+                        } else {
+                            c
+                        };
+
+                        (0..idx.len().div_ceil(stride))
+                            .into_par_iter()
+                            .map(|i| c.take_unchecked(&idx.slice((i * stride) as i64, stride)))
+                            .reduce(
+                                || Column::new_empty(c.name().clone(), c.dtype()),
+                                |mut a, b| {
+                                    a.append_owned(b).unwrap();
+                                    a
+                                },
+                            )
+                    })
+                } else {
+                    self._apply_columns_par(&|c| c.take_unchecked(idx))
+                }
+            })
         } else {
             self._apply_columns(&|s| s.take_unchecked(idx))
         };
@@ -2067,8 +2093,38 @@ impl DataFrame {
     /// # Safety
     /// The indices must be in-bounds.
     pub unsafe fn take_slice_unchecked_impl(&self, idx: &[IdxSize], allow_threads: bool) -> Self {
-        let cols = if allow_threads {
-            POOL.install(|| self._apply_columns_par(&|s| s.take_slice_unchecked(idx)))
+        let cols = if allow_threads && POOL.current_num_threads() > 1 {
+            POOL.install(|| {
+                if POOL.current_num_threads() > self.width() {
+                    let stride = usize::max(idx.len().div_ceil(POOL.current_num_threads()), 256);
+                    self._apply_columns_par(&|c| {
+                        // Nested types initiate a rechunk in their take_unchecked implementation.
+                        // If we do not rechunk, it will result in rechunk storms downstream.
+                        let c = if c.dtype().is_nested() {
+                            &c.rechunk()
+                        } else {
+                            c
+                        };
+
+                        (0..idx.len().div_ceil(stride))
+                            .into_par_iter()
+                            .map(|i| {
+                                let idx = &idx[i * stride..];
+                                let idx = &idx[..idx.len().min(stride)];
+                                c.take_slice_unchecked(idx)
+                            })
+                            .reduce(
+                                || Column::new_empty(c.name().clone(), c.dtype()),
+                                |mut a, b| {
+                                    a.append_owned(b).unwrap();
+                                    a
+                                },
+                            )
+                    })
+                } else {
+                    self._apply_columns_par(&|s| s.take_slice_unchecked(idx))
+                }
+            })
         } else {
             self._apply_columns(&|s| s.take_slice_unchecked(idx))
         };


### PR DESCRIPTION
fixes #25651

Mitigates the `rechunk storm` which happens on chained queries with nested dtypes that call `rechunk()` on every invocation of `take_unchecked` in `gather.rs`.

Note: performance is not (yet) at the level before PR https://github.com/pola-rs/polars/pull/24980. However, this is a tradeoff, since this PR made many expressions faster, including `sort()`.

Pending review of rechunk tradeoff design options and regression test (optional).

In build_release on the MRE:
```
df1 n_chunks: 24

(1) No sort
df2 n_chunks: 1
elapsed for join (no sort): 29.439 ms

(2) Sort
elapsed for sort: 85.679 ms
df2 n_chunks: 24
elapsed for join (no sort): 77.211 ms
```
(Latter was ~30ms originally)

Compare with release 1.36.0-beta.2:
```
df1 n_chunks: 24

(1) No sort
df2 n_chunks: 1
elapsed for join (no sort): 26.232 ms

(2) Sort
elapsed for sort: 76.233 ms
df2 n_chunks: 24
elapsed for join (no sort): 1993.969 ms
```

Compare with original 1.34.0 as released:
```
df1 n_chunks: 1

(1) No sort
df2 n_chunks: 1
elapsed for join (no sort): 32.138 ms

(2) Sort
elapsed for sort: 605.598 ms
df2 n_chunks: 1
elapsed for join (no sort): 30.416 ms
```
