### PR TITLE
chore: Move `boto3` extra from s3fs in dev requirements

### DIFF
--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -33,6 +33,7 @@ connectorx
 kuzu
 # Cloud
 azure-identity
+boto3
 cloudpickle
 fsspec
 pyiceberg>=0.7.1; python_version < '3.13'


### PR DESCRIPTION
Saw this when setting up locally

```
warning: The package `s3fs==2025.12.0` does not have an extra named `boto3`
```

There doesn't seem to be any boto3 extras in the repo either (assuming I have the correct one) https://github.com/fsspec/s3fs