### PR TITLE
chore: Upgrade to latest version of `sqlparser-rs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4907,19 +4907,20 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.53.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a528114c392209b3264855ad491fcce534b94a38771b0a0b97a79379275ce8"
+checksum = "505aa16b045c4c1375bf5f125cce3813d0176325bfe9ffc4a903f423de7774ff"
 dependencies = [
  "log",
+ "recursive",
  "sqlparser_derive",
 ]
 
 [[package]]
 name = "sqlparser_derive"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
+checksum = "028e551d5e270b31b9f3ea271778d9d827148d4287a5d96167b6bb9787f5cc38"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ sha2 = "0.10"
 simd-json = { version = "0.17", features = ["known-key"] }
 simdutf8 = "0.1.4"
 slotmap = "1"
-sqlparser = { version = "0.53", features = ["visitor"] }
+sqlparser = { version = "0.60", features = ["visitor"] }
 stacker = "0.1"
 streaming-iterator = "0.1.9"
 strength_reduce = "0.2"

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -20,8 +20,8 @@ use sqlparser::ast::helpers::attached_token::AttachedToken;
 use sqlparser::ast::{
     DateTimeField, DuplicateTreatment, Expr as SQLExpr, Function as SQLFunction, FunctionArg,
     FunctionArgExpr, FunctionArgumentClause, FunctionArgumentList, FunctionArguments, Ident,
-    OrderByExpr, Value as SQLValue, WindowFrame, WindowFrameBound, WindowFrameUnits, WindowSpec,
-    WindowType,
+    OrderByExpr, Value as SQLValue, ValueWithSpan, WindowFrame, WindowFrameBound, WindowFrameUnits,
+    WindowSpec, WindowType,
 };
 use sqlparser::tokenizer::Span;
 
@@ -887,7 +887,7 @@ impl PolarsSQLFunctions {
 
 impl PolarsSQLFunctions {
     fn try_from_sql(function: &'_ SQLFunction, ctx: &'_ SQLContext) -> PolarsResult<Self> {
-        let function_name = function.name.0[0].value.to_lowercase();
+        let function_name = function.name.0[0].as_ident().unwrap().value.to_lowercase();
         Ok(match function_name.as_str() {
             // ----
             // Bitwise functions
@@ -2198,9 +2198,9 @@ impl SQLFunctionVisitor<'_> {
         for ob in order_by {
             // Note: if not specified 'NULLS FIRST' is default for DESC, 'NULLS LAST' otherwise
             // https://www.postgresql.org/docs/current/queries-order.html
-            let desc_order = !ob.asc.unwrap_or(true);
+            let desc_order = !ob.options.asc.unwrap_or(true);
             by.push(parse_sql_expr(&ob.expr, self.ctx, self.active_schema)?);
-            nulls_last.push(!ob.nulls_first.unwrap_or(desc_order));
+            nulls_last.push(!ob.options.nulls_first.unwrap_or(desc_order));
             descending.push(desc_order);
         }
         Ok(expr.sort_by(
@@ -2220,8 +2220,8 @@ impl SQLFunctionVisitor<'_> {
     ) -> PolarsResult<Expr> {
         // If ORDER BY references the base expression, use .sort() directly
         if order_by.len() == 1 && order_by[0].expr == *base_sql_expr {
-            let desc_order = !order_by[0].asc.unwrap_or(true);
-            let nulls_last = !order_by[0].nulls_first.unwrap_or(desc_order);
+            let desc_order = !order_by[0].options.asc.unwrap_or(true);
+            let nulls_last = !order_by[0].options.nulls_first.unwrap_or(desc_order);
             return Ok(expr.sort(
                 SortOptions::default()
                     .with_order_descending(desc_order)
@@ -2242,10 +2242,10 @@ impl SQLFunctionVisitor<'_> {
             return Ok((Vec::new(), false));
         }
         // Parse expressions and validate uniform direction
-        let all_ascending = order_by[0].asc.unwrap_or(true);
+        let all_ascending = order_by[0].options.asc.unwrap_or(true);
         let mut exprs = Vec::with_capacity(order_by.len());
         for o in order_by {
-            if all_ascending != o.asc.unwrap_or(true) {
+            if all_ascending != o.options.asc.unwrap_or(true) {
                 // TODO: mixed sort directions are not currently supported; we
                 //  need to enhance `over_with_options` to take SortMultipleOptions
                 polars_bail!(
@@ -2369,7 +2369,7 @@ impl FromSQLExpr for f64 {
         Self: Sized,
     {
         match expr {
-            SQLExpr::Value(v) => match v {
+            SQLExpr::Value(ValueWithSpan { value: v, .. }) => match v {
                 SQLValue::Number(s, _) => s
                     .parse()
                     .map_err(|_| polars_err!(SQLInterface: "cannot parse literal {:?}", s)),
@@ -2386,7 +2386,7 @@ impl FromSQLExpr for bool {
         Self: Sized,
     {
         match expr {
-            SQLExpr::Value(v) => match v {
+            SQLExpr::Value(ValueWithSpan { value: v, .. }) => match v {
                 SQLValue::Boolean(v) => Ok(*v),
                 _ => polars_bail!(SQLInterface: "cannot parse boolean {:?}", v),
             },
@@ -2401,7 +2401,7 @@ impl FromSQLExpr for String {
         Self: Sized,
     {
         match expr {
-            SQLExpr::Value(v) => match v {
+            SQLExpr::Value(ValueWithSpan { value: v, .. }) => match v {
                 SQLValue::SingleQuotedString(s) => Ok(s.clone()),
                 _ => polars_bail!(SQLInterface: "cannot parse literal {:?}", v),
             },
@@ -2416,7 +2416,7 @@ impl FromSQLExpr for StrptimeOptions {
         Self: Sized,
     {
         match expr {
-            SQLExpr::Value(v) => match v {
+            SQLExpr::Value(ValueWithSpan { value: v, .. }) => match v {
                 SQLValue::SingleQuotedString(s) => Ok(StrptimeOptions {
                     format: Some(PlSmallStr::from_str(s)),
                     ..StrptimeOptions::default()

--- a/crates/polars-sql/src/table_functions.rs
+++ b/crates/polars-sql/src/table_functions.rs
@@ -12,7 +12,10 @@ use polars_core::prelude::{PolarsError, PolarsResult, polars_bail};
 use polars_lazy::prelude::LazyCsvReader;
 use polars_lazy::prelude::LazyFrame;
 use polars_utils::plpath::PlPath;
-use sqlparser::ast::{FunctionArg, FunctionArgExpr};
+use sqlparser::ast::{
+    Expr as SQLExpr, FunctionArg as SQLFunctionArg, FunctionArgExpr as SQLFunctionArgExpr,
+    Value as SQLValue, ValueWithSpan as SQLValueWithSpan,
+};
 
 /// Table functions that are supported by Polars
 #[allow(clippy::enum_variant_names)]
@@ -64,7 +67,7 @@ impl FromStr for PolarsTableFunctions {
 
 impl PolarsTableFunctions {
     #[allow(unused_variables, unreachable_patterns)]
-    pub(crate) fn execute(&self, args: &[FunctionArg]) -> PolarsResult<(PlPath, LazyFrame)> {
+    pub(crate) fn execute(&self, args: &[SQLFunctionArg]) -> PolarsResult<(PlPath, LazyFrame)> {
         match self {
             #[cfg(feature = "csv")]
             PolarsTableFunctions::ReadCsv => self.read_csv(args),
@@ -79,7 +82,7 @@ impl PolarsTableFunctions {
     }
 
     #[cfg(feature = "csv")]
-    fn read_csv(&self, args: &[FunctionArg]) -> PolarsResult<(PlPath, LazyFrame)> {
+    fn read_csv(&self, args: &[SQLFunctionArg]) -> PolarsResult<(PlPath, LazyFrame)> {
         polars_ensure!(args.len() == 1, SQLSyntax: "`read_csv` expects a single file path; found {:?} arguments", args.len());
 
         use polars_lazy::frame::LazyFileListReader;
@@ -92,7 +95,7 @@ impl PolarsTableFunctions {
     }
 
     #[cfg(feature = "parquet")]
-    fn read_parquet(&self, args: &[FunctionArg]) -> PolarsResult<(PlPath, LazyFrame)> {
+    fn read_parquet(&self, args: &[SQLFunctionArg]) -> PolarsResult<(PlPath, LazyFrame)> {
         polars_ensure!(args.len() == 1, SQLSyntax: "`read_parquet` expects a single file path; found {:?} arguments", args.len());
 
         let path = self.get_file_path_from_arg(&args[0])?;
@@ -101,7 +104,7 @@ impl PolarsTableFunctions {
     }
 
     #[cfg(feature = "ipc")]
-    fn read_ipc(&self, args: &[FunctionArg]) -> PolarsResult<(PlPath, LazyFrame)> {
+    fn read_ipc(&self, args: &[SQLFunctionArg]) -> PolarsResult<(PlPath, LazyFrame)> {
         polars_ensure!(args.len() == 1, SQLSyntax: "`read_ipc` expects a single file path; found {:?} arguments", args.len());
 
         let path = self.get_file_path_from_arg(&args[0])?;
@@ -109,7 +112,7 @@ impl PolarsTableFunctions {
         Ok((path, lf))
     }
     #[cfg(feature = "json")]
-    fn read_ndjson(&self, args: &[FunctionArg]) -> PolarsResult<(PlPath, LazyFrame)> {
+    fn read_ndjson(&self, args: &[SQLFunctionArg]) -> PolarsResult<(PlPath, LazyFrame)> {
         polars_ensure!(args.len() == 1, SQLSyntax: "`read_ndjson` expects a single file path; found {:?} arguments", args.len());
 
         use polars_lazy::frame::LazyFileListReader;
@@ -121,11 +124,13 @@ impl PolarsTableFunctions {
     }
 
     #[allow(dead_code)]
-    fn get_file_path_from_arg(&self, arg: &FunctionArg) -> PolarsResult<PlPath> {
-        use sqlparser::ast::{Expr as SQLExpr, Value as SQLValue};
+    fn get_file_path_from_arg(&self, arg: &SQLFunctionArg) -> PolarsResult<PlPath> {
         match arg {
-            FunctionArg::Unnamed(FunctionArgExpr::Expr(SQLExpr::Value(
-                SQLValue::SingleQuotedString(s),
+            SQLFunctionArg::Unnamed(SQLFunctionArgExpr::Expr(SQLExpr::Value(
+                SQLValueWithSpan {
+                    value: SQLValue::SingleQuotedString(s),
+                    ..
+                },
             ))) => Ok(PlPath::from_str(s)),
             _ => polars_bail!(
                 SQLSyntax:

--- a/crates/polars-sql/src/types.rs
+++ b/crates/polars-sql/src/types.rs
@@ -5,7 +5,8 @@ use polars_core::datatypes::{DataType, TimeUnit};
 use polars_error::{PolarsResult, polars_bail};
 use polars_plan::dsl::{Expr, lit};
 use sqlparser::ast::{
-    ArrayElemTypeDef, DataType as SQLDataType, ExactNumberInfo, Ident, ObjectName, TimezoneInfo,
+    ArrayElemTypeDef, DataType as SQLDataType, ExactNumberInfo, Ident, ObjectName, ObjectNamePart,
+    TimezoneInfo,
 };
 
 polars_utils::regex_cache::cached_regex! {
@@ -83,44 +84,52 @@ pub(crate) fn map_sql_dtype_to_polars(dtype: &SQLDataType) -> PolarsResult<DataT
         // ---------------------------------
         // signed integer
         // ---------------------------------
-        SQLDataType::Int16 | SQLDataType::Int2(_) => DataType::Int16,
-        SQLDataType::Int32 | SQLDataType::Int4(_) => DataType::Int32,
-        SQLDataType::Int64 | SQLDataType::Int8(_) => DataType::Int64,
-        SQLDataType::Int128 => DataType::Int128,
-        SQLDataType::Integer(_) | SQLDataType::Int(_) => DataType::Int32,
-        SQLDataType::SmallInt(_) => DataType::Int16,
-        SQLDataType::MediumInt(_) => DataType::Int32,
-        SQLDataType::BigInt(_) => DataType::Int64,
         SQLDataType::TinyInt(_) => DataType::Int8,
+        SQLDataType::Int16 | SQLDataType::Int2(_) | SQLDataType::SmallInt(_) => DataType::Int16,
+        SQLDataType::Int32
+        | SQLDataType::Int4(_)
+        | SQLDataType::MediumInt(_)
+        | SQLDataType::Integer(_)
+        | SQLDataType::Int(_) => DataType::Int32,
+        SQLDataType::Int64 | SQLDataType::Int8(_) | SQLDataType::BigInt(_) => DataType::Int64,
+        SQLDataType::Int128 | SQLDataType::HugeInt => DataType::Int128,
 
         // ---------------------------------
         // unsigned integer
         // ---------------------------------
-        SQLDataType::UInt16 => DataType::UInt16,
-        SQLDataType::UInt32 => DataType::UInt32,
-        SQLDataType::UInt64 => DataType::UInt64,
-        SQLDataType::UnsignedTinyInt(_) => DataType::UInt8,
-        SQLDataType::UnsignedInt(_) | SQLDataType::UnsignedInteger(_) => DataType::UInt32,
-        SQLDataType::UnsignedInt2(_) | SQLDataType::UnsignedSmallInt(_) => DataType::UInt16,
-        SQLDataType::UnsignedInt4(_) | SQLDataType::UnsignedMediumInt(_) => DataType::UInt32,
-        SQLDataType::UnsignedInt8(_) | SQLDataType::UnsignedBigInt(_) | SQLDataType::UInt8 => {
-            DataType::UInt64
+        SQLDataType::UTinyInt | SQLDataType::TinyIntUnsigned(_) => DataType::UInt8,
+        SQLDataType::Int2Unsigned(_)
+        | SQLDataType::SmallIntUnsigned(_)
+        | SQLDataType::USmallInt
+        | SQLDataType::UInt16 => DataType::UInt16,
+        SQLDataType::Int4Unsigned(_) | SQLDataType::MediumIntUnsigned(_) | SQLDataType::UInt32 => {
+            DataType::UInt32
         },
+        SQLDataType::Int8Unsigned(_)
+        | SQLDataType::BigIntUnsigned(_)
+        | SQLDataType::UBigInt
+        | SQLDataType::UInt64
+        | SQLDataType::UInt8 => DataType::UInt64,
+        SQLDataType::IntUnsigned(_) | SQLDataType::UnsignedInteger => DataType::UInt32,
+        SQLDataType::UHugeInt => DataType::UInt128,
 
         // ---------------------------------
         // float
         // ---------------------------------
         SQLDataType::Float4 | SQLDataType::Real => DataType::Float32,
-        SQLDataType::Double | SQLDataType::DoublePrecision | SQLDataType::Float8 => {
+        SQLDataType::Double(_) | SQLDataType::DoublePrecision | SQLDataType::Float8 => {
             DataType::Float64
         },
         SQLDataType::Float(n_bytes) => match n_bytes {
-            Some(n) if (1u64..=24u64).contains(n) => DataType::Float32,
-            Some(n) if (25u64..=53u64).contains(n) => DataType::Float64,
-            Some(n) => {
+            ExactNumberInfo::Precision(n) if (1u64..=24u64).contains(n) => DataType::Float32,
+            ExactNumberInfo::Precision(n) if (25u64..=53u64).contains(n) => DataType::Float64,
+            ExactNumberInfo::Precision(n) => {
                 polars_bail!(SQLSyntax: "unsupported `float` size (expected a value between 1 and 53, found {})", n)
             },
-            None => DataType::Float64,
+            ExactNumberInfo::None => DataType::Float64,
+            ExactNumberInfo::PrecisionAndScale(_, _) => {
+                polars_bail!(SQLSyntax: "FLOAT does not support scale parameter")
+            },
         },
 
         // ---------------------------------
@@ -140,7 +149,22 @@ pub(crate) fn map_sql_dtype_to_polars(dtype: &SQLDataType) -> PolarsResult<DataT
         // temporal
         // ---------------------------------
         SQLDataType::Date => DataType::Date,
-        SQLDataType::Interval => DataType::Duration(TimeUnit::Microseconds),
+        SQLDataType::Interval { fields, precision } => {
+            if !fields.is_none() {
+                // eg: "YEARS TO MONTH"
+                polars_bail!(SQLInterface: "`interval` definition with fields={:?} is not supported", fields)
+            }
+            let time_unit = match precision {
+                Some(p) if (1u64..=3u64).contains(p) => TimeUnit::Milliseconds,
+                Some(p) if (4u64..=6u64).contains(p) => TimeUnit::Microseconds,
+                Some(p) if (7u64..=9u64).contains(p) => TimeUnit::Nanoseconds,
+                Some(p) => {
+                    polars_bail!(SQLSyntax: "invalid `interval` precision (expected 1-9, found {})", p)
+                },
+                None => TimeUnit::Microseconds,
+            };
+            DataType::Duration(time_unit)
+        },
         SQLDataType::Time(_, tz) => match tz {
             TimezoneInfo::None => DataType::Time,
             _ => {
@@ -172,20 +196,20 @@ pub(crate) fn map_sql_dtype_to_polars(dtype: &SQLDataType) -> PolarsResult<DataT
         // custom
         // ---------------------------------
         SQLDataType::Custom(ObjectName(idents), _) => match idents.as_slice() {
-            [Ident { value, .. }] => match value.to_lowercase().as_str() {
-                // these integer types are not supported by the PostgreSQL core distribution,
-                // but they ARE available via `pguint` (https://github.com/petere/pguint), an
-                // extension maintained by one of the PostgreSQL core developers, and/or DuckDB.
-                "int1" => DataType::Int8,
-                "uint1" | "utinyint" => DataType::UInt8,
-                "uint2" | "usmallint" => DataType::UInt16,
-                "uint4" | "uinteger" | "uint" => DataType::UInt32,
-                "uint8" | "ubigint" => DataType::UInt64,
-                "hugeint" => DataType::Int128,
-                "uhugeint" => DataType::UInt128,
-                _ => {
-                    polars_bail!(SQLInterface: "datatype {:?} is not currently supported", value)
-                },
+            [ObjectNamePart::Identifier(Ident { value, .. })] => {
+                match value.to_lowercase().as_str() {
+                    // these integer types are not supported by the PostgreSQL core distribution,
+                    // but they ARE available via `pguint` (https://github.com/petere/pguint), an
+                    // extension maintained by one of the PostgreSQL core developers, and/or DuckDB.
+                    "int1" => DataType::Int8,
+                    "uint1" | "utinyint" => DataType::UInt8,
+                    "uint2" | "usmallint" => DataType::UInt16,
+                    "uint4" | "uinteger" | "uint" => DataType::UInt32,
+                    "uint8" | "ubigint" => DataType::UInt64,
+                    _ => {
+                        polars_bail!(SQLInterface: "datatype {:?} is not currently supported", value)
+                    },
+                }
             },
             _ => {
                 polars_bail!(SQLInterface: "datatype {:?} is not currently supported", idents)


### PR DESCRIPTION
`sqlparser 0.53 → 0.60`

Will try not to let so many releases go by next time, as this was a non-trivial upgrade 😝

FYI: while almost all of this is a mechanical update to handle breaking changes in the returned parse-tree, I also added support for `SUBSTRING(expr FROM start FOR length)`[^1] syntax while exploring some of the changes.

~Let's wait until `1.36.0` is out/released before merging this one.~
**Update**: rebased and ready to roll 👍  

[^1]: PostgreSQL [SUBSTRING](https://www.postgresql.org/docs/current/functions-string.html#:~:text=substring%20(%20string%20text%20[%20FROM%20start%20integer%20]%20[%20FOR%20count%20integer%20]%20)) expression