### PR TITLE
perf: Pushdown `filter(False)` to pyiceberg

### DIFF
--- a/py-polars/src/polars/io/iceberg/_utils.py
+++ b/py-polars/src/polars/io/iceberg/_utils.py
@@ -99,7 +99,16 @@ def _scan_pyarrow_dataset_impl(
 def try_convert_pyarrow_predicate(pyarrow_predicate: str) -> Any | None:
     with contextlib.suppress(Exception):
         expr_ast = _to_ast(pyarrow_predicate)
-        return _convert_predicate(expr_ast)
+        result = _convert_predicate(expr_ast)
+
+        # Top-level boolean values should be converted to AlwaysTrue/AlwaysFalse
+        if isinstance(result, bool):
+            if result:
+                return pyiceberg.expressions.AlwaysTrue()  # type: ignore[no-untyped-call]
+            else:
+                return pyiceberg.expressions.AlwaysFalse()  # type: ignore[no-untyped-call]
+
+        return result
 
     return None
 

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -49,7 +49,7 @@ from pyiceberg.types import (
 
 import polars as pl
 from polars._utils.various import parse_version
-from polars.io.iceberg._utils import _convert_predicate, _to_ast
+from polars.io.iceberg._utils import _convert_predicate, _to_ast, try_convert_pyarrow_predicate
 from polars.io.iceberg.dataset import IcebergDataset, _NativeIcebergScanData
 from polars.testing import assert_frame_equal
 
@@ -148,6 +148,15 @@ class TestIcebergScanIO:
             (3, "3", datetime(2023, 3, 2, 22, 0)),
         ]
 
+    def test_scan_iceberg_filter_on_true_false(self, iceberg_path: str) -> None:
+        lf = pl.scan_iceberg(iceberg_path)
+
+        res = lf.filter(pl.lit(True))
+        assert len(res.collect()) == 3
+
+        res = lf.filter(pl.lit(False))
+        assert len(res.collect()) == 0
+
 
 @pytest.mark.ci_only
 class TestIcebergExpressions:
@@ -233,6 +242,15 @@ class TestIcebergExpressions:
 
         expr = _to_ast("(pa.compute.field('ts') == pa.compute.scalar(False))")
         assert _convert_predicate(expr) == EqualTo("ts", False)
+
+    def test_parse_always_true_false(self) -> None:
+        from pyiceberg.expressions import AlwaysFalse, AlwaysTrue
+
+        true_predicate = "pa.compute.scalar(True)"
+        assert try_convert_pyarrow_predicate(true_predicate) == AlwaysTrue()
+
+        false_predicate = "pa.compute.scalar(False)"
+        assert try_convert_pyarrow_predicate(false_predicate) == AlwaysFalse()
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Closes https://github.com/apache/iceberg-python/issues/2681

Converts top-level true/false to pyiceberg's AlwaysTrue / AlwaysFalse. PyIceberg's `scan` function expects AlwaysTrue/AlwaysFalse (as BooleanExpression) instead of true/false boolean. 

For cases such as 
```
    pl.scan_iceberg(table, storage_options=storage_options)
    .filter(pl.lit(True))
    .explain()

    pl.scan_iceberg(table, storage_options=storage_options)
    .filter(pl.lit(False))
    .explain()
```
