### PR TITLE
fix: Binary slice methods missing from Series and docs

### DIFF
--- a/py-polars/docs/source/reference/expressions/binary.rst
+++ b/py-polars/docs/source/reference/expressions/binary.rst
@@ -13,6 +13,9 @@ The following methods are available under the `expr.bin` attribute.
     Expr.bin.decode
     Expr.bin.encode
     Expr.bin.ends_with
+    Expr.bin.head
     Expr.bin.reinterpret
     Expr.bin.size
+    Expr.bin.slice
     Expr.bin.starts_with
+    Expr.bin.tail

--- a/py-polars/docs/source/reference/series/binary.rst
+++ b/py-polars/docs/source/reference/series/binary.rst
@@ -13,6 +13,9 @@ The following methods are available under the `Series.bin` attribute.
     Series.bin.decode
     Series.bin.encode
     Series.bin.ends_with
+    Series.bin.head
     Series.bin.reinterpret
     Series.bin.size
+    Series.bin.slice
     Series.bin.starts_with
+    Series.bin.tail

--- a/py-polars/src/polars/series/binary.py
+++ b/py-polars/src/polars/series/binary.py
@@ -252,3 +252,99 @@ class BinaryNameSpace:
         ]
 
         """
+
+    def slice(self, offset: int, length: int | None = None) -> Series:
+        r"""
+        Slice the binary values.
+
+        Parameters
+        ----------
+        offset
+            Start index. Negative indexing is supported.
+        length
+            Length of the slice. If set to ``None`` (default), the slice is taken to the
+            end of the value.
+
+        Returns
+        -------
+        Series
+            Series of data type :class:`Binary`.
+
+        Examples
+        --------
+        >>> colors = pl.Series([b"\x00\x00\x00", b"\xff\xff\x00", b"\x00\x00\xff"])
+        >>> colors.bin.slice(1, 2)
+        shape: (3,)
+        Series: '' [binary]
+        [
+                b"\x00\x00"
+                b"\xff\x00"
+                b"\x00\xff"
+        ]
+        """
+
+    def head(self, n: int = 5) -> Series:
+        r"""
+        Take the first `n` bytes of the binary values.
+
+        Parameters
+        ----------
+        n
+            Length of the slice. Negative indexing is supported; see note (2) below.
+
+        Returns
+        -------
+        Series
+            Series of data type :class:`Binary`.
+
+        Notes
+        -----
+        (1) A similar method exists for taking the last `n` bytes: :func:`tail`.
+        (2) If `n` is negative, it is interpreted as "until the nth byte from the end",
+            e.g., ``head(-3)`` returns all but the last three bytes.
+
+        Examples
+        --------
+        >>> colors = pl.Series([b"\x00\x00\x00", b"\xff\xff\x00", b"\x00\x00\xff"])
+        >>> colors.bin.head(2)
+        shape: (3,)
+        Series: '' [binary]
+        [
+                b"\x00\x00"
+                b"\xff\xff"
+                b"\x00\x00"
+        ]
+        """
+
+    def tail(self, n: int = 5) -> Series:
+        r"""
+        Take the last `n` bytes of the binary values.
+
+        Parameters
+        ----------
+        n
+            Length of the slice. Negative indexing is supported; see note (2) below.
+
+        Returns
+        -------
+        Series
+            Series of data type :class:`Binary`.
+
+        Notes
+        -----
+        (1) A similar method exists for taking the first `n` bytes: :func:`head`.
+        (2) If `n` is negative, it is interpreted as "starting at the nth byte",
+            e.g., ``tail(-3)`` returns all but the first three bytes.
+
+        Examples
+        --------
+        >>> colors = pl.Series([b"\x00\x00\x00", b"\xff\xff\x00", b"\x00\x00\xff"])
+        >>> colors.bin.tail(2)
+        shape: (3,)
+        Series: '' [binary]
+        [
+                b"\x00\x00"
+                b"\xff\x00"
+                b"\x00\xff"
+        ]
+        """


### PR DESCRIPTION
@Kevin-Patyk I overlooked this in my review of https://github.com/pola-rs/polars/pull/25647, but when adding new expressions you need to add the appropriately named functions with docs to `Series` as well (can use empty implementation to automatically defer to `Expr` behavior), and also list the functions in the docs `.rst`s.