### PR TITLE
feat: Allow creation of `Object` literal

### DIFF
--- a/py-polars/src/polars/functions/lit.py
+++ b/py-polars/src/polars/functions/lit.py
@@ -185,7 +185,11 @@ def lit(
         return lit(value.value, dtype=dtype)
 
     if dtype:
-        value_s = pl.Series("literal", [value]).cast(dtype)
+        value_s = (
+            pl.Series("literal", [value], dtype=dtype)
+            if dtype.is_object()
+            else pl.Series("literal", [value]).cast(dtype)
+        )
         return wrap_expr(plr.lit(value_s._s, allow_object, is_scalar=True))
 
     if _check_for_numpy(value) and isinstance(value, np.generic):

--- a/py-polars/tests/unit/expr/test_literal.py
+++ b/py-polars/tests/unit/expr/test_literal.py
@@ -122,3 +122,15 @@ def test_literal_datetime_timezone_utc_error() -> None:
     ):
         # the offset does not correspond to the offset of the declared timezone
         pl.select(dt=pl.lit(value, dtype=pl.Datetime(time_zone="Pacific/Galapagos")))
+
+
+def test_literal_object_25679() -> None:
+    df = pl.DataFrame(
+        data={"colx": [0, 0, 1, 2, None, 3, 3, None]},
+        schema={"colx": pl.Object},
+    )
+    obj_zero = pl.lit(0, dtype=pl.Object())
+    res = df.select(pl.col("colx").fill_null(obj_zero))
+
+    assert res.schema == {"colx": pl.Object()}
+    assert res["colx"].to_list() == [0, 0, 1, 2, 0, 3, 3, 0]


### PR DESCRIPTION
Closes #25679.

Simple fix; create `lit` Object-dtype Series directly instead of relying on a post-creation (and unsupported) cast. 

## Example

```python
import polars as pl

df = pl.DataFrame(
    data={"colx": [0, 0, 1, 2, None, 3, 3, None]},
    schema={"colx": pl.Object},
)
df.select(
    pl.col("colx").fill_null(pl.lit(0, dtype=pl.Object()))
)
# shape: (8, 1)
# ┌────────┐
# │ colx   │
# │ ---    │
# │ object │ << 👀
# ╞════════╡
# │ 0      │
# │ 0      │
# │ 1      │
# │ 2      │
# │ 0      │
# │ 3      │
# │ 3      │
# │ 0      │
# └────────┘
```
Previously failed with...
```python
# InvalidOperationError:
#  casting from Int128 to FixedSizeBinary(8) not supported`
```