### PR TITLE
perf: Optimise `map_rows` performance for Object dtype

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -8453,7 +8453,7 @@ class DataFrame:
         """
         # TODO: Enable warning for inefficient map
         # from polars._utils.udfs import warn_on_inefficient_map
-        # warn_on_inefficient_map(function, columns=self.columns, map_target="frame)
+        # warn_on_inefficient_map(function, columns=self.columns, map_target="frame")
 
         out, is_df = self._df.map_rows(function, return_dtype, inference_size)
         if is_df:

--- a/py-polars/tests/unit/operations/map/test_map_rows.py
+++ b/py-polars/tests/unit/operations/map/test_map_rows.py
@@ -54,11 +54,7 @@ def test_map_rows_shifted_chunks() -> None:
 
 
 def test_map_elements_infer() -> None:
-    lf = pl.LazyFrame(
-        {
-            "a": [1, 2, 3],
-        }
-    )
+    lf = pl.LazyFrame({"a": [1, 2, 3]})
     lf = lf.select(pl.col.a.map_elements(lambda v: f"pre-{v}"))
 
     # this should not go through execution, solely through the planner


### PR DESCRIPTION
Ref: #25688.

Added a dedicated `Object` path in `map_rows` that gets us a 50-60% speedup (on the given test-case). I think I can see a few opportunities to get a smaller speed-up for scalar/primitive types too, but will leave that for a separate PR.

### Benchmark

```python
import polars as pl
df = pl.DataFrame(
  data={
    "a": [1,2,3] * 1_000_000, 
    "b": [1,2,3] * 1_000_000,
  },
  schema={"a": pl.Int64, "b": pl.Int64},
)
%timeit df.map_rows(lambda d: (d[0] + d[1]), return_dtype=pl.Object)
```
#### Timings[^1] 🚀
```
Before: 306 ms ± 2.87 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
 After: 194 ms ± 1.44 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```
[^1]: _Tested using `make build-dist-release` on an Apple Silicon M4 Max_