### PR TITLE
docs: Fix typos in Excel and Pandas migration guides

### DIFF
--- a/docs/source/user-guide/io/excel.md
+++ b/docs/source/user-guide/io/excel.md
@@ -28,8 +28,8 @@ dependency.
     $ pip install fastexcel xlsx2csv openpyxl 
     ```
 
-The default engine for reading .xslx files is fastexcel. This engine uses the Rust calamine crate to
-read .xslx files into an Apache Arrow in-memory representation that Polars can read without needing
+The default engine for reading .xlsx files is fastexcel. This engine uses the Rust calamine crate to
+read .xlsx files into an Apache Arrow in-memory representation that Polars can read without needing
 to copy the data.
 
 {{code_block('user-guide/io/excel','read',['read_excel'])}}

--- a/docs/source/user-guide/migration/pandas.md
+++ b/docs/source/user-guide/migration/pandas.md
@@ -17,8 +17,8 @@ an index or a `reset_index` call.
 
 In Polars a DataFrame will always be a 2D table with heterogeneous data-types. The data-types may
 have nesting, but the table itself will not. Operations like resampling will be done by specialized
-functions or methods that act like 'verbs' on a table explicitly stating the columns that that
-'verb' operates on. As such, it is our conviction that not having indices make things simpler, more
+functions or methods that act like 'verbs' on a table explicitly stating the columns that 'verb'
+operates on. As such, it is our conviction that not having indices make things simpler, more
 explicit, more readable and less error-prone.
 
 Note that an 'index' data structure as known in databases will be used by Polars as an optimization


### PR DESCRIPTION
## Summary

Fix minor typos in documentation:

- `.xslx` → `.xlsx` in `docs/source/user-guide/io/excel.md`
- Remove duplicated word "that that" → "that" in `docs/source/user-guide/migration/pandas.md`