### PR TITLE
refactor: Move Object `lit` fix earlier in the function

### DIFF
--- a/py-polars/src/polars/functions/lit.py
+++ b/py-polars/src/polars/functions/lit.py
@@ -16,7 +16,7 @@ from polars._dependencies import (
 )
 from polars._dependencies import numpy as np
 from polars._utils.wrap import wrap_expr
-from polars.datatypes import BaseExtension, Date, Datetime, Duration
+from polars.datatypes import BaseExtension, Date, Datetime, Duration, Object
 from polars.datatypes.convert import DataTypeMappings
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
@@ -83,7 +83,7 @@ def lit(
     elif isinstance(dtype, type) and issubclass(dtype, BaseExtension):
         msg = f"dtype '{dtype}' is a BaseExtension class, it should be an instance"
         raise TypeError(msg)
-    elif dtype and dtype.is_object():
+    elif dtype == Object:
         value_s = pl.Series("literal", [value], dtype=dtype)
         return wrap_expr(plr.lit(value_s._s, allow_object, is_scalar=True))
 

--- a/py-polars/tests/unit/functions/test_lit.py
+++ b/py-polars/tests/unit/functions/test_lit.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import enum
 import sys
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
@@ -272,3 +272,10 @@ def test_lit_structs(item: Any) -> None:
 def test_numpy_lit(value: Any, expected_dtype: PolarsDataType) -> None:
     result = pl.select(pl.lit(value)).get_column("literal")
     assert result.dtype == expected_dtype
+
+
+def test_lit_object_type_25713() -> None:
+    obj = time(hour=1)
+    out = pl.select(pl.lit(obj, dtype=pl.Object))
+    expected = pl.DataFrame({"literal": [obj]}, schema={"literal": pl.Object})
+    assert out.to_dict(as_series=False) == expected.to_dict(as_series=False)


### PR DESCRIPTION
Follow-up to #25690; small tweak to move the check earlier in the function.