### PR TITLE
fix: Function map_(rows|elements) with return_dtype = pl.Object

### DIFF
--- a/crates/polars-python/src/series/map.rs
+++ b/crates/polars-python/src/series/map.rs
@@ -1,10 +1,13 @@
 use pyo3::Python;
 use pyo3::prelude::*;
+use pyo3::types::{PyNone, PyTuple};
 
 use super::PySeries;
 use crate::error::PyPolarsErr;
 use crate::map::series::ApplyLambdaGeneric;
 use crate::prelude::*;
+#[cfg(feature = "object")]
+use crate::series::construction::series_from_objects;
 use crate::{apply_all_polars_dtypes, raise_err};
 
 #[pymethods]
@@ -34,19 +37,65 @@ impl PySeries {
         let return_dtype = return_dtype.map(|dt| dt.0);
 
         Python::attach(|py| {
-            let s = if let Some(return_dtype) = &return_dtype {
-                apply_all_polars_dtypes!(
-                    series,
-                    apply_generic_with_dtype,
-                    py,
-                    function,
-                    return_dtype,
-                    skip_nulls
-                )
-            } else {
-                apply_all_polars_dtypes!(series, apply_generic, py, function, skip_nulls)
+            let s = match &return_dtype {
+                #[cfg(feature = "object")]
+                Some(DataType::Object(_)) => {
+                    // If the return dtype is Object we should not go through AnyValue.
+                    call_and_collect_objects(
+                        py,
+                        series.name().clone(),
+                        function,
+                        series.len(),
+                        series.iter().map(|av| av.null_to_none().map(Wrap)),
+                        skip_nulls,
+                    )
+                },
+                Some(return_dtype) => {
+                    apply_all_polars_dtypes!(
+                        series,
+                        apply_generic_with_dtype,
+                        py,
+                        function,
+                        return_dtype,
+                        skip_nulls
+                    )
+                },
+                None => apply_all_polars_dtypes!(series, apply_generic, py, function, skip_nulls),
             };
             s.map(PySeries::from)
         })
     }
+}
+
+#[cfg(feature = "object")]
+fn call_and_collect_objects<'py, T, I>(
+    py: Python<'py>,
+    name: PlSmallStr,
+    lambda: &Bound<'py, PyAny>,
+    len: usize,
+    iter: I,
+    skip_nulls: bool,
+) -> PyResult<Series>
+where
+    T: IntoPyObject<'py>,
+    I: Iterator<Item = Option<T>>,
+{
+    let mut objects = Vec::with_capacity(len);
+    for opt_val in iter {
+        let arg = match opt_val {
+            None if skip_nulls => {
+                objects.push(ObjectValue {
+                    inner: PyNone::get(py).to_owned().unbind().into_any(),
+                });
+                continue;
+            },
+            None => PyTuple::new(py, [PyNone::get(py)])?,
+            Some(val) => PyTuple::new(py, [val])?,
+        };
+        let out = lambda.call1(arg)?;
+        objects.push(ObjectValue {
+            inner: out.unbind(),
+        });
+    }
+    Ok(series_from_objects(py, name, objects))
 }

--- a/crates/polars-python/src/series/mod.rs
+++ b/crates/polars-python/src/series/mod.rs
@@ -9,7 +9,7 @@ mod c_interface;
 #[cfg(feature = "pymethods")]
 mod comparison;
 #[cfg(feature = "pymethods")]
-mod construction;
+pub(crate) mod construction;
 #[cfg(feature = "pymethods")]
 mod export;
 #[cfg(feature = "pymethods")]

--- a/py-polars/tests/unit/operations/rolling/test_map.py
+++ b/py-polars/tests/unit/operations/rolling/test_map.py
@@ -192,3 +192,14 @@ def test_rolling_map_rolling_std() -> None:
 
     expected = s.rolling_std(window_size=4, min_samples=3, center=False)
     assert_series_equal(result, expected)
+
+
+def test_map_rows_object_dtype_25730() -> None:
+    df = pl.DataFrame({"id": [1, 2], "symbol": ["A", "B"]})
+    out = df.select(
+        pl.struct(["id", "symbol"]).map_elements(
+            lambda x: tuple(x.values()), return_dtype=pl.Object
+        )
+    )
+    assert out.schema == pl.Schema({"id": pl.Object})
+    assert out.to_dict(as_series=False) == {"id": [(1, "A"), (2, "B")]}


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/25730.

@alexander-beedie This definitely conflicts with https://github.com/pola-rs/polars/pull/25702, but this was actually needed for correctness. Perhaps it has also fixed (or at least reduced) the performance issues?