### PR TITLE
perf: Reduce memory usage for .item() count in grouped first/last

### DIFF
--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -515,7 +515,7 @@ on startup."#.trim_start())
             } else {
                 polars_err!(ComputeError: "aggregation 'item' expected a single value, got 100+ values")
             }
-        } else {
+        } else if $n > 1 {
             if $allow_empty {
                 polars_err!(ComputeError:
                     "aggregation 'item' expected no or a single value, got {} values", $n
@@ -525,6 +525,8 @@ on startup."#.trim_start())
                     "aggregation 'item' expected a single value, got {} values", $n
                 )
             }
+        } else {
+            unreachable!()
         }
     };
 }

--- a/crates/polars-expr/src/reduce/first_last.rs
+++ b/crates/polars-expr/src/reduce/first_last.rs
@@ -102,6 +102,10 @@ struct Item {
 impl Policy for Item {
     type Count = u8;
 
+    fn add_count(a: &mut Self::Count, b: usize) {
+        *a = a.saturating_add(b.min(255) as u8);
+    }
+
     fn combine_count(a: &mut Self::Count, b: &Self::Count) {
         *a = a.saturating_add(*b);
     }


### PR DESCRIPTION
We recently added `Expr.item()` to ensure an expression returns exactly one item. This was done by adding a 64-bit counter to each first/last group which was then optionally checked at the end.

Now we only use that counter if we're actually doing `.item()`, and it's also now only a `u8` which saturates rather than an extra 64-bit value per group.