### PR TITLE
docs: Fix credential parameter name in cloud-storage.py

### DIFF
--- a/docs/source/src/python/user-guide/io/cloud-storage.py
+++ b/docs/source/src/python/user-guide/io/cloud-storage.py
@@ -93,7 +93,7 @@ pl.scan_parquet(
 pl.scan_parquet(
     "abfss://...@.../...",
     credential_provider=pl.CredentialProviderAzure(
-        credentials=DefaultAzureCredential(exclude_managed_identity_credential=True)
+        credential=DefaultAzureCredential(exclude_managed_identity_credential=True)
     ),
 )
 


### PR DESCRIPTION
Fixing small typo 