### PR TITLE
fix(rust): Fix documentation for new()

### DIFF
--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -269,7 +269,7 @@ impl DataFrame {
         }
     }
 
-    /// Create a DataFrame from a Vector of Series.
+    /// Create a DataFrame from a Vector of Columns.
     ///
     /// Errors if a column names are not unique, or if heights are not all equal.
     ///
@@ -334,7 +334,7 @@ impl DataFrame {
 
     /// Converts a sequence of columns into a DataFrame, broadcasting length-1
     /// columns to match the other columns.
-    ///  
+    ///
     /// # Safety
     /// Does not check that the column names are unique (which they must be).
     pub unsafe fn new_with_broadcast_no_namecheck(


### PR DESCRIPTION
Fixes the documentation for the method `new()` in crates/polars-core/src/frame/mod.rs, since it does not compile when providing a series. 
It is stated [here](https://docs.pola.rs/api/rust/dev/polars/frame/column/enum.Column.html) that `columns` can be represented as series, however the method explicitly requires type column. Thus I think, the documentation should be changed for `new()`.

Before:
```
/// Create a DataFrame from a Vector of Series.
///
/// Errors if a column names are not unique, or if heights are not all equal.
///
/// # Example
///
/// ```
/// # use polars_core::prelude::*;
/// let s0 = Column::new("days".into(), [0, 1, 2].as_ref());
/// let s1 = Column::new("temp".into(), [22.1, 19.9, 7.].as_ref());
///
/// let df = DataFrame::new(vec![s0, s1])?;
/// # Ok::<(), PolarsError>(())
/// ```
pub fn new(columns: Vec<Column>) -> PolarsResult<Self> {
    DataFrame::validate_columns_slice(&columns)
        .map_err(|e| e.wrap_msg(|e| format!("could not create a new DataFrame: {e}")))?;
    Ok(unsafe { Self::new_no_checks_height_from_first(columns) })
}
```

After:
```
/// Create a DataFrame from a Vector of Columns.
///
/// Errors if a column names are not unique, or if heights are not all equal.
///
/// # Example
///
/// ```
/// # use polars_core::prelude::*;
/// let s0 = Column::new("days".into(), [0, 1, 2].as_ref());
/// let s1 = Column::new("temp".into(), [22.1, 19.9, 7.].as_ref());
///
/// let df = DataFrame::new(vec![s0, s1])?;
/// # Ok::<(), PolarsError>(())
/// ```
```