### PR TITLE
fix: Double-counting of row metrics

### DIFF
--- a/crates/polars-stream/src/pipe.rs
+++ b/crates/polars-stream/src/pipe.rs
@@ -273,7 +273,7 @@ impl PhysicalPipe {
                 handles.push(scope.spawn_task(TaskPriority::High, async move {
                     while let Some(Priority(_, mut morsel)) = linearizer.get().await {
                         morsel.set_seq(morsel.seq().offset_by_u64(seq_offset));
-                        if send.send(morsel).await.is_err() {
+                        if send.0.send(morsel).await.is_err() {
                             break;
                         }
                     }
@@ -283,7 +283,7 @@ impl PhysicalPipe {
 
                 for (mut recv, mut inserter) in receivers.into_iter().zip(inserters) {
                     handles.push(scope.spawn_task(TaskPriority::High, async move {
-                        while let Ok(mut morsel) = recv.recv().await {
+                        while let Ok(mut morsel) = recv.0.recv().await {
                             // Drop the consume token, but only after the send has succeeded. This
                             // ensures we have backpressure, but only once the channel fills up.
                             let consume_token = morsel.take_consume_token();
@@ -312,7 +312,7 @@ impl PhysicalPipe {
                     let mut seq_offset = arc_seq_offset.load();
                     let mut prev_orig_seq = None;
 
-                    while let Ok(mut morsel) = recv.recv().await {
+                    while let Ok(mut morsel) = recv.0.recv().await {
                         // We have to relabel sequence ids to be unique before distributing.
                         // Normally within a single pipeline consecutive ids may repeat but
                         // when distributing this would destroy the order.
@@ -340,7 +340,7 @@ impl PhysicalPipe {
                         let wait_group = WaitGroup::default();
                         while let Ok(mut morsel) = recv.recv().await {
                             morsel.set_consume_token(wait_group.token());
-                            if send.send(morsel).await.is_err() {
+                            if send.0.send(morsel).await.is_err() {
                                 break;
                             }
                             wait_group.wait().await;
@@ -355,9 +355,9 @@ impl PhysicalPipe {
                 let seq_offset = self.seq_offset.load();
                 for (mut send, mut recv) in senders.into_iter().zip(receivers) {
                     handles.push(scope.spawn_task(TaskPriority::High, async move {
-                        while let Ok(mut morsel) = recv.recv().await {
+                        while let Ok(mut morsel) = recv.0.recv().await {
                             morsel.set_seq(morsel.seq().offset_by_u64(seq_offset));
-                            if send.send(morsel).await.is_err() {
+                            if send.0.send(morsel).await.is_err() {
                                 break;
                             }
                         }


### PR DESCRIPTION
If there was a distributor or a linearizer between nodes we double-counted those rows for our metrics.