### PR TITLE
fix: Update groups in `list.eval`

### DIFF
--- a/crates/polars-expr/src/expressions/eval.rs
+++ b/crates/polars-expr/src/expressions/eval.rs
@@ -454,6 +454,8 @@ impl PhysicalExpr for EvalExpr {
         state: &ExecutionState,
     ) -> PolarsResult<AggregationContext<'a>> {
         let mut input = self.input.evaluate_on_groups(df, groups, state)?;
+        input.groups();
+
         match self.variant {
             EvalVariant::List => {
                 let input_col = input.flat_naive();

--- a/py-polars/tests/unit/operations/namespaces/list/test_eval.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_eval.py
@@ -651,3 +651,10 @@ def test_list_agg_after_slice() -> None:
         has_no_duplicates=~pl.col("list").list.agg(pl.element().is_duplicated().any())
     )
     assert all(grouped_result.to_series().to_list())
+
+
+def test_list_eval_groupby_sample_25796() -> None:
+    df = pl.DataFrame({"g": [10, 10], "x": [[1, 1], [1, 1]]})
+    out = df.group_by("g").agg(pl.col("x").sample(n=2).list.eval(pl.element()))
+    expected = pl.DataFrame({"g": [10], "x": [[[1, 1], [1, 1]]]})
+    assert_frame_equal(out, expected)


### PR DESCRIPTION
fixes #25796 