### PR TITLE
chore: Clear venv with appropriate version of Python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,14 +74,16 @@ export CFLAGS
 FILTER_PIP_WARNINGS=| grep -v "don't match your environment"; test $${PIPESTATUS[0]} -eq 0
 
 .venv:  ## Set up Python virtual environment and install requirements
-	$(MAKE) requirements
+	@unset CONDA_PREFIX \
+	&& python3 -m venv $(VENV) \
+	&& $(MAKE) requirements
 
 # Note: Installed separately as pyiceberg does not have wheels for 3.13, causing
 # --no-build to fail.
 .PHONY: requirements
 requirements:  ## Install/refresh Python project requirements
 	@unset CONDA_PREFIX \
-	&& python3 -m venv $(VENV) --clear \
+	&& $(VENV_BIN)/python -m venv $(VENV) --clear \
 	&& $(VENV_BIN)/python -m pip install --upgrade uv \
 	&& $(VENV_BIN)/uv pip install --upgrade --compile-bytecode --no-build \
 	   -r py-polars/requirements-dev.txt \


### PR DESCRIPTION
If you initialized your dev `.venv` with a specific version of Python `make requirements` shouldn't quietly override it with your global `python3` version.