### PR TITLE
refactor(rust): Add `TakeableRowsProvider` for IO sinks

### DIFF
--- a/crates/polars-stream/src/nodes/io_sinks2/components/morsel_resize_pipeline.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/components/morsel_resize_pipeline.rs
@@ -7,12 +7,12 @@ use polars_utils::IdxSize;
 use crate::async_primitives::connector;
 use crate::morsel::Morsel;
 use crate::nodes::io_sinks2::components::sink_morsel::SinkMorsel;
-use crate::nodes::io_sinks2::components::size::{DEFAULT_BYTE_SIZE_MIN_ROWS, RowCountAndSize};
+use crate::nodes::io_sinks2::components::size::{RowCountAndSize, TakeableRowsProvider};
 
 /// Splits large morsels / combines small morsels.
 pub struct MorselResizePipeline {
     pub empty_with_schema_df: DataFrame,
-    pub ideal_morsel_size: RowCountAndSize,
+    pub takeable_rows_provider: TakeableRowsProvider,
     pub inflight_morsel_semaphore: Arc<tokio::sync::Semaphore>,
     pub morsel_rx: connector::Receiver<Morsel>,
     pub morsel_tx: connector::Sender<SinkMorsel>,
@@ -24,7 +24,7 @@ impl MorselResizePipeline {
     pub async fn run(self) -> PolarsResult<RowCountAndSize> {
         let MorselResizePipeline {
             empty_with_schema_df,
-            ideal_morsel_size,
+            takeable_rows_provider,
             inflight_morsel_semaphore,
             mut morsel_rx,
             mut morsel_tx,
@@ -43,12 +43,9 @@ impl MorselResizePipeline {
                 buffered_size.num_rows,
                 IdxSize::try_from(buffered_rows.height()).unwrap()
             );
-            let num_rows_to_take = ideal_morsel_size
-                .num_rows_takeable_from(buffered_size, DEFAULT_BYTE_SIZE_MIN_ROWS.get());
 
-            if num_rows_to_take < buffered_size.num_rows
-                || num_rows_to_take == ideal_morsel_size.num_rows
-                || (num_rows_to_take > 0 && flush)
+            if let Some(num_rows_to_take) =
+                takeable_rows_provider.num_rows_takeable_from(buffered_size, flush)
             {
                 let morsel_permit = inflight_morsel_semaphore
                     .clone()

--- a/crates/polars-stream/src/nodes/io_sinks2/components/partition_morsel_sender.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/components/partition_morsel_sender.rs
@@ -5,6 +5,7 @@ use polars_core::frame::DataFrame;
 use polars_error::PolarsResult;
 use polars_plan::dsl::sink2::FileProviderArgs;
 use polars_utils::IdxSize;
+use polars_utils::index::NonZeroIdxSize;
 
 use crate::async_executor::{self, TaskPriority};
 use crate::nodes::io_sinks2::components::error_capture::ErrorCapture;
@@ -13,12 +14,14 @@ use crate::nodes::io_sinks2::components::hstack_columns::HStackColumns;
 use crate::nodes::io_sinks2::components::partition_sink_starter::PartitionSinkStarter;
 use crate::nodes::io_sinks2::components::partition_state::PartitionState;
 use crate::nodes::io_sinks2::components::sink_morsel::SinkMorsel;
-use crate::nodes::io_sinks2::components::size::{DEFAULT_BYTE_SIZE_MIN_ROWS, RowCountAndSize};
+use crate::nodes::io_sinks2::components::size::{
+    NonZeroRowCountAndSize, RowCountAndSize, TakeableRowsProvider,
+};
 
 pub struct PartitionMorselSender {
     /// Note: Must be <= `file_size_limit` if there is one.
-    pub ideal_morsel_size: RowCountAndSize,
-    pub file_size_limit: RowCountAndSize,
+    pub takeable_rows_provider: TakeableRowsProvider,
+    pub file_size_limit: NonZeroRowCountAndSize,
     pub inflight_morsel_semaphore: Arc<tokio::sync::Semaphore>,
     pub open_sinks_semaphore: Arc<tokio::sync::Semaphore>,
     pub partition_sink_starter: PartitionSinkStarter,
@@ -71,10 +74,13 @@ impl PartitionMorselSender {
                         .sinked_size
                         .checked_sub($file_sink_task_data.start_position)
                         .unwrap();
-                    available_row_capacity = if self.file_size_limit == RowCountAndSize::MAX {
+                    available_row_capacity = if self.file_size_limit.get() == RowCountAndSize::MAX {
                         RowCountAndSize::MAX
                     } else {
-                        self.file_size_limit.checked_sub(used_row_capacity).unwrap()
+                        self.file_size_limit
+                            .get()
+                            .checked_sub(used_row_capacity)
+                            .unwrap()
                     };
                 }};
             }
@@ -88,54 +94,50 @@ impl PartitionMorselSender {
                 };
             }
 
-            let (next_morsel, start_new_sink) =
-                if let Some(sorted_finalize_stream) = sorted_finalize_stream.as_mut() {
-                    let Some((morsel, start_new_sink)) = sorted_finalize_stream.next().await else {
-                        return Ok(());
-                    };
-
-                    (NextMorsel::Morsel(morsel), start_new_sink)
-                } else {
-                    let buffered_size = partition.buffered_size();
-
-                    if buffered_size.num_rows == 0 {
-                        return Ok(());
-                    }
-
-                    let num_rows_to_take = self
-                        .ideal_morsel_size
-                        .num_rows_takeable_from(buffered_size, DEFAULT_BYTE_SIZE_MIN_ROWS.get());
-
-                    let could_buffer_more = num_rows_to_take == buffered_size.num_rows
-                        && num_rows_to_take < self.ideal_morsel_size.num_rows;
-
-                    if could_buffer_more && !flush {
-                        return Ok(());
-                    }
-
-                    let max_takeable_rows: IdxSize = available_row_capacity.num_rows_takeable_from(
-                        buffered_size,
-                        if used_row_capacity.num_rows == 0 {
-                            1
-                        } else {
-                            0
-                        },
-                    );
-
-                    let start_new_sink = max_takeable_rows == 0;
-                    let num_rows_to_take = if start_new_sink {
-                        num_rows_to_take
-                    } else {
-                        num_rows_to_take.min(max_takeable_rows)
-                    };
-
-                    (
-                        NextMorsel::TakeFromBuffered {
-                            num_rows: num_rows_to_take,
-                        },
-                        start_new_sink,
-                    )
+            let (next_morsel, start_new_sink) = if let Some(sorted_finalize_stream) =
+                sorted_finalize_stream.as_mut()
+            {
+                let Some((morsel, start_new_sink)) = sorted_finalize_stream.next().await else {
+                    return Ok(());
                 };
+
+                (NextMorsel::Morsel(morsel), start_new_sink)
+            } else {
+                let buffered_size = partition.buffered_size();
+
+                if buffered_size.num_rows == 0 {
+                    return Ok(());
+                }
+
+                let Some(num_rows_to_take) = self
+                    .takeable_rows_provider
+                    .num_rows_takeable_from(buffered_size, flush)
+                else {
+                    return Ok(());
+                };
+
+                let file_min_available_rows_for_byte_size =
+                    NonZeroRowCountAndSize::get(self.takeable_rows_provider.max_size)
+                        .num_rows
+                        .saturating_sub(used_row_capacity.num_rows);
+
+                let max_takeable_rows: IdxSize = available_row_capacity
+                    .num_rows_takeable_from(buffered_size, file_min_available_rows_for_byte_size);
+
+                let start_new_sink = max_takeable_rows == 0;
+                let num_rows_to_take = if start_new_sink {
+                    num_rows_to_take
+                } else {
+                    num_rows_to_take.min(max_takeable_rows)
+                };
+
+                (
+                    NextMorsel::TakeFromBuffered {
+                        num_rows: num_rows_to_take,
+                    },
+                    start_new_sink,
+                )
+            };
 
             if start_new_sink {
                 assert!(used_row_capacity.num_rows > 0);
@@ -193,8 +195,11 @@ impl PartitionMorselSender {
 
             let morsel_height: IdxSize = IdxSize::try_from(morsel.df().height()).unwrap();
 
-            debug_assert!(self.ideal_morsel_size.num_rows <= self.file_size_limit.num_rows);
-            debug_assert!(morsel_height <= self.ideal_morsel_size.num_rows);
+            debug_assert!(
+                self.takeable_rows_provider.max_size.get().num_rows
+                    <= self.file_size_limit.get().num_rows
+            );
+            debug_assert!(morsel_height <= self.takeable_rows_provider.max_size.get().num_rows);
 
             assert!((1..=available_row_capacity.num_rows).contains(&morsel_height));
 

--- a/crates/polars-stream/src/nodes/io_sinks2/config.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/config.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use polars_core::prelude::SortMultipleOptions;
@@ -9,7 +10,7 @@ use polars_utils::plpath::{CloudScheme, PlPath};
 use crate::expression::StreamExpr;
 use crate::nodes::io_sinks2::components::hstack_columns::HStackColumns;
 use crate::nodes::io_sinks2::components::partitioner::Partitioner;
-use crate::nodes::io_sinks2::components::size::RowCountAndSize;
+use crate::nodes::io_sinks2::components::size::NonZeroRowCountAndSize;
 
 pub struct IOSinkNodeConfig {
     pub file_format: Arc<FileType>,
@@ -26,12 +27,12 @@ impl IOSinkNodeConfig {
 
     pub fn inflight_morsel_limit(&self) -> usize {
         if let Ok(v) = std::env::var("POLARS_INFLIGHT_SINK_MORSEL_LIMIT").map(|x| {
-            x.parse::<usize>()
+            x.parse::<NonZeroUsize>()
                 .ok()
-                .filter(|x| *x > 0)
                 .unwrap_or_else(|| {
                     panic!("invalid value for POLARS_INFLIGHT_SINK_MORSEL_LIMIT: {x}")
                 })
+                .get()
         }) {
             return v;
         };
@@ -44,10 +45,10 @@ impl IOSinkNodeConfig {
 
     pub fn max_open_sinks(&self) -> usize {
         if let Ok(v) = std::env::var("POLARS_MAX_OPEN_SINKS").map(|x| {
-            x.parse::<usize>()
+            x.parse::<NonZeroUsize>()
                 .ok()
-                .filter(|x| *x > 0)
                 .unwrap_or_else(|| panic!("invalid value for POLARS_MAX_OPEN_SINKS: {x}"))
+                .get()
         }) {
             return v;
         }
@@ -65,12 +66,12 @@ impl IOSinkNodeConfig {
 
     pub fn partitioned_cloud_upload_chunk_size(&self) -> usize {
         if let Ok(v) = std::env::var("POLARS_PARTITIONED_UPLOAD_CHUNK_SIZE").map(|x| {
-            x.parse::<usize>()
+            x.parse::<NonZeroUsize>()
                 .ok()
-                .filter(|x| *x > 0)
                 .unwrap_or_else(|| {
                     panic!("invalid value for POLARS_PARTITIONED_UPLOAD_CHUNK_SIZE: {x}")
                 })
+                .get()
         }) {
             return v;
         }
@@ -102,6 +103,6 @@ pub struct PartitionedTarget {
     pub hstack_keys: Option<HStackColumns>,
     pub include_keys_in_file: bool,
     pub file_schema: SchemaRef,
-    pub file_size_limit: Option<RowCountAndSize>,
+    pub file_size_limit: Option<NonZeroRowCountAndSize>,
     pub per_partition_sort: Option<(Arc<[StreamExpr]>, SortMultipleOptions)>,
 }

--- a/crates/polars-stream/src/nodes/io_sinks2/pipeline_initialization/partition_by.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/pipeline_initialization/partition_by.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use polars_error::PolarsResult;
 use polars_plan::dsl::UnifiedSinkArgs;
+use polars_utils::IdxSize;
 use polars_utils::pl_str::PlSmallStr;
 
 use crate::async_executor::{self, TaskPriority};
@@ -16,7 +17,7 @@ use crate::nodes::io_sinks2::components::partition_morsel_sender::PartitionMorse
 use crate::nodes::io_sinks2::components::partition_sink_starter::PartitionSinkStarter;
 use crate::nodes::io_sinks2::components::partitioner::Partitioner;
 use crate::nodes::io_sinks2::components::partitioner_pipeline::PartitionerPipeline;
-use crate::nodes::io_sinks2::components::size::RowCountAndSize;
+use crate::nodes::io_sinks2::components::size::{NonZeroRowCountAndSize, RowCountAndSize};
 use crate::nodes::io_sinks2::config::{IOSinkNodeConfig, IOSinkTarget, PartitionedTarget};
 use crate::nodes::io_sinks2::writers::create_file_writer_starter;
 use crate::nodes::io_sinks2::writers::interface::FileWriterStarter;
@@ -78,10 +79,10 @@ pub fn start_partition_sink_pipeline(
         sync_on_close,
     )?;
 
-    let mut ideal_morsel_size = file_writer_starter.ideal_morsel_size();
+    let mut takeable_rows_provider = file_writer_starter.takeable_rows_provider();
 
     if let Some(file_size_limit) = file_size_limit {
-        ideal_morsel_size = ideal_morsel_size.min(file_size_limit)
+        takeable_rows_provider.max_size = takeable_rows_provider.max_size.min(file_size_limit)
     }
 
     if verbose {
@@ -92,7 +93,7 @@ pub fn start_partition_sink_pipeline(
             file_provider: {:?}, \
             max_open_sinks: {}, \
             inflight_morsel_limit: {}, \
-            ideal_morsel_size: {:?}, \
+            takeable_rows_provider: {:?}, \
             file_size_limit: {:?}, \
             per_partition_sort: {}, \
             upload_chunk_size: {}",
@@ -101,7 +102,7 @@ pub fn start_partition_sink_pipeline(
             &file_provider.provider_type,
             max_open_sinks,
             inflight_morsel_limit,
-            ideal_morsel_size,
+            takeable_rows_provider,
             file_size_limit,
             per_partition_sort.is_some(),
             upload_chunk_size
@@ -137,8 +138,8 @@ pub fn start_partition_sink_pipeline(
     };
 
     let partition_morsel_sender = PartitionMorselSender {
-        ideal_morsel_size,
-        file_size_limit: file_size_limit.unwrap_or(RowCountAndSize::MAX),
+        takeable_rows_provider,
+        file_size_limit: file_size_limit.unwrap_or(NonZeroRowCountAndSize::MAX),
         inflight_morsel_semaphore,
         open_sinks_semaphore: open_sinks_semaphore.clone(),
         partition_sink_starter: partition_sink_starter.clone(),

--- a/crates/polars-stream/src/nodes/io_sinks2/pipeline_initialization/single_file.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/pipeline_initialization/single_file.rs
@@ -57,16 +57,16 @@ pub fn start_single_file_sink_pipeline(
         per_sink_pipeline_depth,
         sync_on_close,
     )?;
-    let ideal_morsel_size = file_writer_starter.ideal_morsel_size();
+    let takeable_rows_provider = file_writer_starter.takeable_rows_provider();
 
     if verbose {
         eprintln!(
             "{node_name}: start_single_file_sink_pipeline: \
             file_writer_starter: {}, \
-            ideal_morsel_size: {:?}, \
+            takeable_rows_provider: {:?}, \
             upload_chunk_size: {}",
             file_writer_starter.writer_name(),
-            ideal_morsel_size,
+            takeable_rows_provider,
             upload_chunk_size
         )
     }
@@ -79,7 +79,7 @@ pub fn start_single_file_sink_pipeline(
 
     let resize_pipeline = MorselResizePipeline {
         empty_with_schema_df,
-        ideal_morsel_size,
+        takeable_rows_provider,
         inflight_morsel_semaphore,
         morsel_rx,
         morsel_tx: writer_tx,

--- a/crates/polars-stream/src/nodes/io_sinks2/writers/interface.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/writers/interface.rs
@@ -1,18 +1,21 @@
+use std::num::NonZeroU64;
+
 use polars_error::PolarsResult;
 use polars_io::utils::file::Writeable;
 use polars_utils::IdxSize;
+use polars_utils::index::NonZeroIdxSize;
 
 use crate::async_executor;
 use crate::async_primitives::connector;
 use crate::nodes::io_sinks2::components::sink_morsel::SinkMorsel;
-use crate::nodes::io_sinks2::components::size::RowCountAndSize;
+use crate::nodes::io_sinks2::components::size::TakeableRowsProvider;
 use crate::utils::tokio_handle_ext;
 
 pub trait FileWriterStarter: Send + Sync + 'static {
     fn writer_name(&self) -> &str;
 
     /// Hints to the sender how morsels should be sized.
-    fn ideal_morsel_size(&self) -> RowCountAndSize;
+    fn takeable_rows_provider(&self) -> TakeableRowsProvider;
 
     fn start_file_writer(
         &self,
@@ -25,20 +28,23 @@ pub trait FileWriterStarter: Send + Sync + 'static {
 pub(super) fn ideal_sink_morsel_size_env() -> (Option<IdxSize>, Option<u64>) {
     let num_rows = std::env::var("POLARS_IDEAL_SINK_MORSEL_SIZE_ROWS")
         .map(|x| {
-            x.parse::<IdxSize>()
+            x.parse::<NonZeroIdxSize>()
                 .ok()
-                .filter(|x| *x > 0)
                 .unwrap_or_else(|| {
                     panic!("invalid value for POLARS_IDEAL_SINK_MORSEL_SIZE_ROWS: {x}")
                 })
+                .get()
         })
         .ok();
 
     let mut num_bytes = std::env::var("POLARS_IDEAL_SINK_MORSEL_SIZE_BYTES")
         .map(|x| {
-            x.parse::<u64>().ok().filter(|x| *x > 0).unwrap_or_else(|| {
-                panic!("invalid value for POLARS_IDEAL_SINK_MORSEL_SIZE_BYTES: {x}")
-            })
+            x.parse::<NonZeroU64>()
+                .ok()
+                .unwrap_or_else(|| {
+                    panic!("invalid value for POLARS_IDEAL_SINK_MORSEL_SIZE_BYTES: {x}")
+                })
+                .get()
         })
         .ok();
 

--- a/crates/polars-stream/src/nodes/io_sinks2/writers/parquet/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/writers/parquet/mod.rs
@@ -9,11 +9,14 @@ use polars_parquet::write::{
     ColumnWriteOptions, CompressedPage, SchemaDescriptor, Version, WriteOptions, to_parquet_schema,
 };
 use polars_utils::IdxSize;
+use polars_utils::index::NonZeroIdxSize;
 
 use crate::async_executor::{self, TaskPriority};
 use crate::async_primitives::connector;
 use crate::nodes::io_sinks2::components::sink_morsel::{SinkMorsel, SinkMorselPermit};
-use crate::nodes::io_sinks2::components::size::RowCountAndSize;
+use crate::nodes::io_sinks2::components::size::{
+    NonZeroRowCountAndSize, RowCountAndSize, TakeableRowsProvider,
+};
 use crate::nodes::io_sinks2::writers::interface::{FileWriterStarter, ideal_sink_morsel_size_env};
 use crate::utils::tokio_handle_ext;
 
@@ -45,19 +48,29 @@ impl FileWriterStarter for ParquetWriterStarter {
         "parquet"
     }
 
-    fn ideal_morsel_size(&self) -> RowCountAndSize {
-        if let Some(row_group_size) = self.row_group_size {
-            RowCountAndSize {
+    fn takeable_rows_provider(&self) -> TakeableRowsProvider {
+        let max_size = if let Some(row_group_size) = self.row_group_size
+            && row_group_size > 0
+        {
+            NonZeroRowCountAndSize::new(RowCountAndSize {
                 num_rows: row_group_size,
                 num_bytes: u64::MAX,
-            }
+            })
+            .unwrap()
         } else {
             let (num_rows, num_bytes) = ideal_sink_morsel_size_env();
 
-            RowCountAndSize {
+            NonZeroRowCountAndSize::new(RowCountAndSize {
                 num_rows: num_rows.unwrap_or(122_880),
                 num_bytes: num_bytes.unwrap_or(u64::MAX),
-            }
+            })
+            .unwrap()
+        };
+
+        TakeableRowsProvider {
+            max_size,
+            byte_size_min_rows: NonZeroIdxSize::new(16384).unwrap(),
+            allow_non_max_size: false,
         }
     }
 

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/functions/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/functions/mod.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use polars_utils::slice_enum::Slice;
 
 pub mod resolve_projections;
@@ -9,10 +11,10 @@ pub fn calc_n_readers_pre_init(
     pre_slice: Option<&Slice>,
 ) -> usize {
     if let Ok(v) = std::env::var("POLARS_NUM_READERS_PRE_INIT").map(|x| {
-        x.parse::<usize>()
+        x.parse::<NonZeroUsize>()
             .ok()
-            .filter(|x| *x > 0)
             .unwrap_or_else(|| panic!("invalid value for POLARS_NUM_READERS_PRE_INIT: {x}"))
+            .get()
     }) {
         return v;
     }
@@ -33,10 +35,10 @@ pub fn calc_n_readers_pre_init(
 
 pub fn calc_max_concurrent_scans(num_pipelines: usize, num_sources: usize) -> usize {
     if let Ok(v) = std::env::var("POLARS_MAX_CONCURRENT_SCANS").map(|x| {
-        x.parse::<usize>()
+        x.parse::<NonZeroUsize>()
             .ok()
-            .filter(|x| *x > 0)
             .unwrap_or_else(|| panic!("invalid value for POLARS_MAX_CONCURRENT_SCANS: {x}"))
+            .get()
     }) {
         return v;
     }

--- a/crates/polars-stream/src/nodes/io_sources/ndjson/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ndjson/mod.rs
@@ -1,6 +1,7 @@
 pub mod builder;
 
 use std::cmp::Reverse;
+use std::num::NonZeroUsize;
 use std::ops::Range;
 use std::sync::Arc;
 
@@ -169,8 +170,12 @@ impl FileReader for NDJsonFileReader {
             let chunk_size = chunk_size.clamp(min_chunk_size, max_chunk_size);
 
             std::env::var("POLARS_FORCE_NDJSON_CHUNK_SIZE").map_or(chunk_size, |x| {
-                x.parse::<usize>()
-                    .expect("expected `POLARS_FORCE_NDJSON_CHUNK_SIZE` to be an integer")
+                x.parse::<NonZeroUsize>()
+                    .ok()
+                    .unwrap_or_else(|| {
+                        panic!("invalid value for POLARS_FORCE_NDJSON_CHUNK_SIZE: {x}")
+                    })
+                    .get()
             })
         };
 

--- a/crates/polars-stream/src/nodes/io_sources/parquet/builder.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/builder.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use polars_core::config;
@@ -31,7 +32,6 @@ impl std::fmt::Debug for ParquetReaderBuilder {
     }
 }
 
-#[cfg(feature = "parquet")]
 impl FileReaderBuilder for ParquetReaderBuilder {
     fn reader_name(&self) -> &str {
         "parquet"
@@ -58,12 +58,12 @@ impl FileReaderBuilder for ParquetReaderBuilder {
     fn set_execution_state(&self, execution_state: &crate::execute::StreamingExecutionState) {
         let prefetch_limit = std::env::var("POLARS_ROW_GROUP_PREFETCH_SIZE")
             .map(|x| {
-                x.parse::<usize>()
+                x.parse::<NonZeroUsize>()
                     .ok()
-                    .filter(|x| *x > 0)
                     .unwrap_or_else(|| {
                         panic!("invalid value for POLARS_ROW_GROUP_PREFETCH_SIZE: {x}")
                     })
+                    .get()
             })
             .unwrap_or(execution_state.num_pipelines.saturating_mul(2))
             .max(1);

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -431,7 +431,9 @@ fn to_graph_rec<'a>(
             use crate::nodes::io_sinks2::components::exclude_keys_projection::ExcludeKeysProjection;
             use crate::nodes::io_sinks2::components::hstack_columns::HStackColumns;
             use crate::nodes::io_sinks2::components::partitioner::{KeyedPartitioner, Partitioner};
-            use crate::nodes::io_sinks2::components::size::RowCountAndSize;
+            use crate::nodes::io_sinks2::components::size::{
+                NonZeroRowCountAndSize, RowCountAndSize,
+            };
             use crate::nodes::io_sinks2::config::{
                 IOSinkNodeConfig, IOSinkTarget, PartitionedTarget,
             };
@@ -571,8 +573,8 @@ fn to_graph_rec<'a>(
                 file_size_limit.num_bytes = *approximate_bytes_per_file
             }
 
-            let file_size_limit =
-                (file_size_limit != RowCountAndSize::MAX).then_some(file_size_limit);
+            let file_size_limit = (file_size_limit != RowCountAndSize::MAX)
+                .then_some(NonZeroRowCountAndSize::new(file_size_limit).unwrap());
 
             let target = IOSinkTarget::Partitioned(Box::new(PartitionedTarget {
                 base_path: base_path.clone(),


### PR DESCRIPTION
Adds a `TakeableRowsProvider` wrapper around the existing `RowCountAndSize` that additionally allows morsels to be sent if they have a minimum number of rows, instead of always buffering to exactly `max_size`. This is opt-in and will be used by the CSV sink to avoid regressing performance when sinking small amounts of rows.

Parquet and IPC will do not enable this as it may cause large amounts of small row groups.
