### PR TITLE
chore(rust): Remove unused AnonymousScan functions

### DIFF
--- a/crates/polars-plan/src/plans/anonymous_scan.rs
+++ b/crates/polars-plan/src/plans/anonymous_scan.rs
@@ -18,11 +18,6 @@ pub trait AnonymousScan: Send + Sync {
     /// Creates a DataFrame from the supplied function & scan options.
     fn scan(&self, scan_opts: AnonymousScanArgs) -> PolarsResult<DataFrame>;
 
-    #[deprecated(note = "has no effect")]
-    fn next_batch(&self, scan_opts: AnonymousScanArgs) -> PolarsResult<Option<DataFrame>> {
-        self.scan(scan_opts).map(Some)
-    }
-
     /// function to supply the schema.
     /// Allows for an optional infer schema argument for data sources with dynamic schemas
     fn schema(&self, _infer_schema_length: Option<usize>) -> PolarsResult<SchemaRef> {
@@ -38,10 +33,6 @@ pub trait AnonymousScan: Send + Sync {
     ///
     /// Defaults to `false`
     fn allows_projection_pushdown(&self) -> bool {
-        false
-    }
-    #[deprecated(note = "has no effect")]
-    fn allows_slice_pushdown(&self) -> bool {
         false
     }
 }


### PR DESCRIPTION
After a rather frustrating few hours debugging, I realised that a few functions from `AnonymousScan` are not used at all and never have been. I have marked them as such to help others down the line and will look for a different way to do lazy scanning of a custom file format. 

Relevant commits:
- 6db9de621e420d7b95572edaf9a705dfe2840e2b introduces allows_slice_pushdown but never does anything with it
- dea0679d2b7d7a1223efd5c2d4d342f003b36948 introduces next_batch but never does anything with it

Happy holidays