### PR TITLE
fix(python): Handle comment lines after CSV header correctly

### DIFF
--- a/crates/polars-io/src/csv/read/read_impl.rs
+++ b/crates/polars-io/src/csv/read/read_impl.rs
@@ -659,6 +659,12 @@ pub fn find_starting_point(
     if has_header {
         bytes = skip_this_line(bytes, quote_char, eol_char);
     }
+
+    // skip comment lines after header
+    while is_comment_line(bytes, comment_prefix) {
+        bytes = skip_this_line_naive(bytes, eol_char);
+    }
+
     // skip 'n' rows following the header
     if skip_rows_after_header > 0 {
         let mut split_lines = SplitLines::new(bytes, quote_char, eol_char, comment_prefix);


### PR DESCRIPTION
## Summary
- Comment lines immediately following the header row were not being skipped
- This caused parsing errors when comments appeared right after the header

## Changes
- Added logic in `find_starting_point` to skip comment lines after processing the header row
- Added test case to verify fix

Closes #25841

Signed-off-by: majiayu000 <lifcc@users.noreply.github.com>