### PR TITLE
fix: fix horizontal concat with dataframe using streaming engine

### DIFF
--- a/crates/polars-stream/src/nodes/zip.rs
+++ b/crates/polars-stream/src/nodes/zip.rs
@@ -301,7 +301,11 @@ impl ComputeNode for ZipNode {
                 for input_head in &mut self.input_heads {
                     out.push(input_head.take(common_size));
                 }
-                let out_df = concat_df_horizontal(&out, false, true)?;
+                let out_df = concat_df_horizontal(
+                    &out,
+                    false,
+                    matches!(self.zip_behavior, ZipBehavior::Strict),
+                )?;
                 out.clear();
 
                 let morsel = Morsel::new(out_df, self.out_seq, source_token.clone());


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/25727

[This comment](https://github.com/pola-rs/polars/pull/25452#discussion_r2556368798) mentions that the match is unnecessary, but apparently it is in cases of empty dataframes.

Or maybe we want to simply always ignore empty dataframes in horizontal concats? (see https://github.com/pola-rs/polars/issues/25725)