### PR TITLE
fix: Correct lexicographic ordering for Parquet BYTE_ARRAY statistics

### DIFF
--- a/crates/polars-parquet/src/parquet/write/statistics.rs
+++ b/crates/polars-parquet/src/parquet/write/statistics.rs
@@ -310,4 +310,53 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn binary_prefix_ordering() -> ParquetResult<()> {
+        // Here [1, 2] is a prefix of [1, 2, 0].
+        // Lexicographically: [1, 2] < [1, 2, 0],
+        // so min must be [1, 2] and max must be [1, 2, 0].
+        let iter = [
+            BinaryStatistics {
+                primitive_type: PrimitiveType::from_physical("bla".into(), PhysicalType::ByteArray),
+                null_count: Some(0),
+                distinct_count: None,
+                min_value: Some(vec![1, 2]),
+                max_value: Some(vec![1, 2]),
+            },
+            BinaryStatistics {
+                primitive_type: PrimitiveType::from_physical("bla".into(), PhysicalType::ByteArray),
+                null_count: Some(0),
+                distinct_count: None,
+                min_value: Some(vec![1, 2, 0]),
+                max_value: Some(vec![1, 2, 0]),
+            },
+        ];
+
+        let a = reduce_binary(iter.iter());
+
+        assert_eq!(a.min_value, Some(vec![1, 2]));
+        assert_eq!(a.max_value, Some(vec![1, 2, 0]));
+        assert_eq!(a.null_count, Some(0));
+        assert_eq!(a.distinct_count, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn ord_binary_equal_prefix_min_max() -> ParquetResult<()> {
+        // Directly exercise ord_binary on equal-prefix inputs.
+        let a = vec![1, 2];
+        let b = vec![1, 2, 0];
+
+        // For max=true, we expect the longer (lexicographically larger) value.
+        let max_val = ord_binary(a.clone(), b.clone(), true);
+        assert_eq!(max_val, b);
+
+        // For max=false, we expect the shorter (lexicographically smaller) value.
+        let min_val = ord_binary(a.clone(), b.clone(), false);
+        assert_eq!(min_val, a);
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
This PR fixes incorrect lexicographic ordering during Parquet statistics reduction for `BYTE_ARRAY` / binary string columns.

**Problem**

When reducing page-level statistics into column-level statistics, the helper `ord_binary` compared bytes pairwise. However, if all compared bytes matched (e.g., when one value was a prefix of another or one value was empty), it always returned the left operand instead of completing lexicographic comparison based on length.

This violated Parquet’s lexicographic ordering requirements for statistics, leading to incorrect `min_value` / `max_value` fields in metadata. This misordering could break predicate pushdown and cause incorrect filtering results. Issue #25817 is caused by this behavior (involving empty strings).

**Solution**

`ord_binary` has been corrected to follow proper Parquet lexicographic semantics:

* If bytes differ → compare by byte value (unchanged)
* If bytes are identical for the shorter length → compare by length

  * shorter sequence = lexicographically smaller
  * longer sequence = lexicographically larger

Fixes #25817.
