### PR TITLE
feat: Implement or fix json encode/decode for (U)Int128, Categorical, Enum, Decimal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ serde = { version = "1.0.188", features = ["derive", "rc"] }
 serde_json = "1"
 serde_stacker = "0.1.12"
 sha2 = "0.10"
-simd-json = { version = "0.17", features = ["known-key"] }
+simd-json = { version = "0.17", features = ["known-key", "128bit"] }
 simdutf8 = "0.1.4"
 slotmap = "1"
 sqlparser = { version = "0.60", features = ["visitor"] }

--- a/crates/polars-arrow/src/datatypes/field.rs
+++ b/crates/polars-arrow/src/datatypes/field.rs
@@ -113,8 +113,11 @@ impl Field {
     }
 
     pub fn with_dtype(&self, dtype: ArrowDataType) -> Self {
-        let mut field = self.clone();
-        field.dtype = dtype;
-        field
+        Self {
+            name: self.name.clone(),
+            dtype,
+            is_nullable: self.is_nullable,
+            metadata: self.metadata.clone(),
+        }
     }
 }

--- a/crates/polars-core/src/datatypes/field.rs
+++ b/crates/polars-core/src/datatypes/field.rs
@@ -109,6 +109,12 @@ impl Field {
         self
     }
 
+    // Returns this `Field`, with a different datatype.
+    pub fn with_dtype(mut self, dtype: DataType) -> Self {
+        self.dtype = dtype;
+        self
+    }
+
     /// Converts the `Field` to an `arrow::datatypes::Field`.
     ///
     /// # Example

--- a/crates/polars-json/src/json/infer_schema.rs
+++ b/crates/polars-json/src/json/infer_schema.rs
@@ -17,6 +17,7 @@ pub fn infer(json: &BorrowedValue) -> PolarsResult<ArrowDataType> {
     Ok(match json {
         BorrowedValue::Static(StaticNode::Bool(_)) => ArrowDataType::Boolean,
         BorrowedValue::Static(StaticNode::U64(_) | StaticNode::I64(_)) => ArrowDataType::Int64,
+        BorrowedValue::Static(StaticNode::U128(_) | StaticNode::I128(_)) => ArrowDataType::Int128,
         BorrowedValue::Static(StaticNode::F64(_)) => ArrowDataType::Float64,
         BorrowedValue::Static(StaticNode::Null) => ArrowDataType::Null,
         BorrowedValue::Array(array) => infer_array(array)?,

--- a/crates/polars-json/src/json/write/serialize.rs
+++ b/crates/polars-json/src/json/write/serialize.rs
@@ -479,6 +479,9 @@ pub(crate) fn new_serializer<'a>(
         ArrowDataType::Int64 => {
             primitive_serializer::<i64>(array.as_any().downcast_ref().unwrap(), offset, take)
         },
+        ArrowDataType::Int128 => {
+            primitive_serializer::<i128>(array.as_any().downcast_ref().unwrap(), offset, take)
+        },
         ArrowDataType::UInt8 => {
             primitive_serializer::<u8>(array.as_any().downcast_ref().unwrap(), offset, take)
         },
@@ -490,6 +493,9 @@ pub(crate) fn new_serializer<'a>(
         },
         ArrowDataType::UInt64 => {
             primitive_serializer::<u64>(array.as_any().downcast_ref().unwrap(), offset, take)
+        },
+        ArrowDataType::UInt128 => {
+            primitive_serializer::<u128>(array.as_any().downcast_ref().unwrap(), offset, take)
         },
         ArrowDataType::Float16 => {
             float16_serializer(array.as_any().downcast_ref().unwrap(), offset, take)

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -711,10 +711,18 @@ def test_ndjson_22229() -> None:
 
 
 def test_json_encode_enum_23826() -> None:
-    s = pl.Series("a", ["b"], dtype=pl.Enum(["b"]))
+    s = pl.Series("a", ["foo", "bar"], dtype=pl.Enum(["bar", "foo"]))
     assert_series_equal(
         s.to_frame().select(c=pl.struct("a").struct.json_encode()).to_series(),
-        pl.Series("c", ['{"a":"0"}'], pl.String),
+        pl.Series("c", ['{"a":"foo"}', '{"a":"bar"}'], pl.String),
+    )
+
+
+def test_json_encode_categorical() -> None:
+    s = pl.Series("a", ["foo", "bar"], dtype=pl.Categorical)
+    assert_series_equal(
+        s.to_frame().select(c=pl.struct("a").struct.json_encode()).to_series(),
+        pl.Series("c", ['{"a":"foo"}', '{"a":"bar"}'], pl.String),
     )
 
 

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -2175,3 +2175,40 @@ def test_json_decode_decimal_25789() -> None:
         ComputeError, match=r"error deserializing value.*30.127.* as Decimal\(3, 2\)"
     ):
         s.str.json_decode(dtype=pl.Struct({"a": pl.Decimal(3, 2)}))
+
+
+def test_json_decode_i128() -> None:
+    s = pl.Series(
+        [
+            '{"a":170141183460469231731687303715884105723}',
+            '{"a":null}',
+            '{"a":-170141183460469231731687303715759193239}',
+        ]
+    )
+    result = s.str.json_decode(dtype=pl.Struct({"a": pl.Int128}))
+    expected = pl.Series(
+        [{"a": 2**127 - 5}, {"a": None}, {"a": -(2**127) + 124912489}],
+        dtype=pl.Struct({"a": pl.Int128}),
+    )
+    assert_series_equal(result, expected)
+
+
+def test_json_decode_u128() -> None:
+    s = pl.Series(['{"a":340282366920938463463374607431768211451}', '{"a":null}'])
+    result = s.str.json_decode(dtype=pl.Struct({"a": pl.UInt128}))
+    expected = pl.Series(
+        [{"a": 2**128 - 5}, {"a": None}],
+        dtype=pl.Struct({"a": pl.UInt128}),
+    )
+    assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize("dtype", [pl.Enum(["bar", "foo"]), pl.Categorical])
+def test_json_decode_categorical_enum(dtype: pl.DataType) -> None:
+    s = pl.Series(['{"a":"foo"}', '{"a":"bar"}', '{"a":null}', '{"a":"foo"}'])
+    result = s.str.json_decode(dtype=pl.Struct({"a": dtype}))
+    expected = pl.Series(
+        [{"a": "foo"}, {"a": "bar"}, {"a": None}, {"a": "foo"}],
+        dtype=pl.Struct({"a": dtype}),
+    )
+    assert_series_equal(result, expected)


### PR DESCRIPTION
Some of these types only supported encoding or decoding, or had buggy behavior. Now all should be fully supported. The only exception is that UInt128 in inference still always infers as Int128, so values larger than `i128::MAX` might be problematic. Fixing this was more effort than it was worth right now.

Fixes https://github.com/pola-rs/polars/issues/25881.