### PR TITLE
refactor(rust): Use PlSmallStr for CSV format strings

### DIFF
--- a/crates/polars-io/src/csv/write/options.rs
+++ b/crates/polars-io/src/csv/write/options.rs
@@ -1,5 +1,6 @@
 use std::num::NonZeroUsize;
 
+use polars_utils::pl_str::PlSmallStr;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -33,11 +34,11 @@ impl Default for CsvWriterOptions {
 #[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub struct SerializeOptions {
     /// Used for [`DataType::Date`](polars_core::datatypes::DataType::Date).
-    pub date_format: Option<String>,
+    pub date_format: Option<PlSmallStr>,
     /// Used for [`DataType::Time`](polars_core::datatypes::DataType::Time).
-    pub time_format: Option<String>,
+    pub time_format: Option<PlSmallStr>,
     /// Used for [`DataType::Datetime`](polars_core::datatypes::DataType::Datetime).
-    pub datetime_format: Option<String>,
+    pub datetime_format: Option<PlSmallStr>,
     /// Used for [`DataType::Float64`](polars_core::datatypes::DataType::Float64)
     /// and [`DataType::Float32`](polars_core::datatypes::DataType::Float32).
     pub float_scientific: Option<bool>,
@@ -49,9 +50,9 @@ pub struct SerializeOptions {
     /// Quoting character.
     pub quote_char: u8,
     /// Null value representation.
-    pub null: String,
+    pub null: PlSmallStr,
     /// String appended after every row.
-    pub line_terminator: String,
+    pub line_terminator: PlSmallStr,
     /// When to insert quotes.
     pub quote_style: QuoteStyle,
 }
@@ -67,7 +68,7 @@ impl Default for SerializeOptions {
             decimal_comma: false,
             separator: b',',
             quote_char: b'"',
-            null: String::new(),
+            null: PlSmallStr::EMPTY,
             line_terminator: "\n".into(),
             quote_style: Default::default(),
         }

--- a/crates/polars-io/src/csv/write/writer.rs
+++ b/crates/polars-io/src/csv/write/writer.rs
@@ -6,6 +6,7 @@ use polars_core::POOL;
 use polars_core::frame::DataFrame;
 use polars_core::schema::Schema;
 use polars_error::PolarsResult;
+use polars_utils::pl_str::PlSmallStr;
 
 use super::write_impl::{write, write_bom, write_csv_header};
 use super::{QuoteStyle, SerializeOptions};
@@ -97,7 +98,7 @@ where
     }
 
     /// Set the CSV file's date format.
-    pub fn with_date_format(mut self, format: Option<String>) -> Self {
+    pub fn with_date_format(mut self, format: Option<PlSmallStr>) -> Self {
         if format.is_some() {
             self.options_mut().date_format = format;
         }
@@ -105,7 +106,7 @@ where
     }
 
     /// Set the CSV file's time format.
-    pub fn with_time_format(mut self, format: Option<String>) -> Self {
+    pub fn with_time_format(mut self, format: Option<PlSmallStr>) -> Self {
         if format.is_some() {
             self.options_mut().time_format = format;
         }
@@ -113,7 +114,7 @@ where
     }
 
     /// Set the CSV file's datetime format.
-    pub fn with_datetime_format(mut self, format: Option<String>) -> Self {
+    pub fn with_datetime_format(mut self, format: Option<PlSmallStr>) -> Self {
         if format.is_some() {
             self.options_mut().datetime_format = format;
         }
@@ -149,13 +150,13 @@ where
     }
 
     /// Set the CSV file's null value representation.
-    pub fn with_null_value(mut self, null_value: String) -> Self {
+    pub fn with_null_value(mut self, null_value: PlSmallStr) -> Self {
         self.options_mut().null = null_value;
         self
     }
 
     /// Set the CSV file's line terminator.
-    pub fn with_line_terminator(mut self, line_terminator: String) -> Self {
+    pub fn with_line_terminator(mut self, line_terminator: PlSmallStr) -> Self {
         self.options_mut().line_terminator = line_terminator;
         self
     }

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -747,32 +747,34 @@ impl PyLazyFrame {
         include_bom: bool,
         include_header: bool,
         separator: u8,
-        line_terminator: String,
+        line_terminator: Wrap<PlSmallStr>,
         quote_char: u8,
         batch_size: NonZeroUsize,
-        datetime_format: Option<String>,
-        date_format: Option<String>,
-        time_format: Option<String>,
+        datetime_format: Option<Wrap<PlSmallStr>>,
+        date_format: Option<Wrap<PlSmallStr>>,
+        time_format: Option<Wrap<PlSmallStr>>,
         float_scientific: Option<bool>,
         float_precision: Option<usize>,
         decimal_comma: bool,
-        null_value: Option<String>,
+        null_value: Option<Wrap<PlSmallStr>>,
         quote_style: Option<Wrap<QuoteStyle>>,
     ) -> PyResult<PyLazyFrame> {
         let quote_style = quote_style.map_or(QuoteStyle::default(), |wrap| wrap.0);
-        let null_value = null_value.unwrap_or(SerializeOptions::default().null);
+        let null_value = null_value
+            .map(|x| x.0)
+            .unwrap_or(SerializeOptions::default().null);
 
         let serialize_options = SerializeOptions {
-            date_format,
-            time_format,
-            datetime_format,
+            date_format: date_format.map(|x| x.0),
+            time_format: time_format.map(|x| x.0),
+            datetime_format: datetime_format.map(|x| x.0),
             float_scientific,
             float_precision,
             decimal_comma,
             separator,
             quote_char,
             null: null_value,
-            line_terminator,
+            line_terminator: line_terminator.0,
             quote_style,
         };
 


### PR DESCRIPTION
These generally fit within the 24 character limit of `PlSmallStr`
