### PR TITLE
fix: Set http client timeouts to 10 minutes

### DIFF
--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -212,7 +212,7 @@ pub(super) fn get_client_options() -> ClientOptions {
                         })
                         .get()
                 })
-                .unwrap_or(30 * 60),
+                .unwrap_or(10 * 60),
         ))
         // Concurrency can increase connection latency, so also set high.
         .with_connect_timeout(std::time::Duration::from_secs(
@@ -225,7 +225,7 @@ pub(super) fn get_client_options() -> ClientOptions {
                         })
                         .get()
                 })
-                .unwrap_or(30 * 60),
+                .unwrap_or(10 * 60),
         ))
         .with_user_agent(HeaderValue::from_static(USER_AGENT))
         .with_allow_http(true)


### PR DESCRIPTION
It's currently unbounded, causing some users to observe forever hanging processes.

Also adds environment variables to control these

* ref https://github.com/pola-rs/polars/issues/25762#issuecomment-3671999631
* Supercedes https://github.com/pola-rs/polars/pull/25763
