### PR TITLE
docs: Update mixed-offset datetime parsing example in user guide

### DIFF
--- a/docs/source/user-guide/transformations/time-series/parsing.md
+++ b/docs/source/user-guide/transformations/time-series/parsing.md
@@ -59,8 +59,8 @@ You can extract data features such as the year or day from a date column using t
 ## Mixed offsets
 
 If your data contains datetimes with mixed UTC offsets (for example due to daylight-saving
-transitions), Polars parses them as UTC. You can either pass a target `time_zone` to
-`str to_datetime`, or call `convert_time_zone` after parsing:
+transitions), Polars parses them in UTC. You can either pass a target `time_zone` to
+`str.to_datetime`, or call `str.convert_time_zone` after parsing:
 
 {{code_block('user-guide/transformations/time-series/parsing','mixed',['str.to_datetime','dt.convert_time_zone'])}}
 


### PR DESCRIPTION
This updates the mixed-offset datetime parsing section of the docs.

The previous wording suggested using `utc=True` and converting the timezone
manually. However, current Polars behavior already normalizes mixed UTC
offsets when a `time_zone` is provided to `str.to_datetime`.

The updated text now reflects the simpler and equivalent usage:

    s.str.to_datetime(time_zone="Europe/Brussels")

This produces the same result as parsing with `%z` and then converting the
timezone manually, but is shorter and clearer.

Closes #25750
