### PR TITLE
fix: Improve error message for temporal vs non-temporal comparison

### DIFF
--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -831,7 +831,10 @@ class Series:
             f = None
         if f is None:
             other_dtype = getattr(other, "dtype", type(other))
-            if (self.dtype.is_temporal() and not getattr(other_dtype, "is_temporal", lambda: False)()):
+            if (
+                self.dtype.is_temporal()
+                and not getattr(other_dtype, "is_temporal", lambda: False)()
+            ):
                 msg = (
                     "Invalid comparison between temporal dtype "
                     f"{self.dtype!r} and non-temporal value of dtype {other_dtype!r}. "

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -830,6 +830,14 @@ class Series:
         except NotImplementedError:
             f = None
         if f is None:
+            other_dtype = getattr(other, "dtype", type(other))
+            if (self.dtype.is_temporal() and not getattr(other_dtype, "is_temporal", lambda: False)()):
+                msg = (
+                    "Invalid comparison between temporal dtype "
+                    f"{self.dtype!r} and non-temporal value of dtype {other_dtype!r}. "
+                    "Temporal values may only be compared against compatible temporal dtypes."
+                )
+                raise TypeError(msg)
             msg = f"Series of type {self.dtype} does not have {op} operator"
             raise NotImplementedError(msg)
         if other is not None:


### PR DESCRIPTION
When comparing temporal dtypes (Date / Datetime / Duration / Time)
against non-temporal values, Polars previously raised:

    "Series of type <dtype> does not have eq operator"

This error was misleading, because the operator *does* exist — the
comparison is simply invalid due to incompatible types.

This change improves the error message to explicitly state that a
temporal value is being compared against a non-temporal dtype, e.g.:

    TypeError:
    Invalid comparison between temporal dtype 'Date'
    and non-temporal value of dtype <class 'int'>.
    Temporal values may only be compared against
    compatible temporal dtypes.

This makes the behavior clearer and more consistent with user
expectations when performing mixed-dtype comparisons.


Closes #25729