### PR TITLE
ci: Update `ruff` action and simplify version handling

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -16,19 +16,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run ruff check
+      - name: Run ruff check and format
         uses: astral-sh/ruff-action@v3
         with:
-          src: py-polars/
           version-file: py-polars/requirements-lint.txt
-          args: check --no-fix
-
-      - name: Run ruff format
-        uses: astral-sh/ruff-action@v3
-        with:
-          src: py-polars/
-          version-file: py-polars/requirements-lint.txt
-          args: format --diff
+          args: --version
+      - run: ruff check --no-fix
+      - run: ruff format --diff
 
   mypy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Noticed the `ruff` GitHub action was using an archived repository and not the official Astral actions.
Old: https://github.com/ChartBoost/ruff-action
New: https://github.com/astral-sh/ruff-action