### PR TITLE
refactor(rust): Use `from_any_values_and_dtype` in `Series.extend_constant()`

### DIFF
--- a/crates/polars-core/src/series/ops/extend.rs
+++ b/crates/polars-core/src/series/ops/extend.rs
@@ -3,9 +3,7 @@ use crate::prelude::*;
 impl Series {
     /// Extend with a constant value.
     pub fn extend_constant(&self, value: AnyValue, n: usize) -> PolarsResult<Self> {
-        // TODO: Use `from_any_values_and_dtype` here instead of casting afterwards
-        let s = Series::from_any_values(PlSmallStr::EMPTY, &[value], true).unwrap();
-        let s = s.cast(self.dtype())?;
+        let s = Series::from_any_values_and_dtype(PlSmallStr::EMPTY, &[value], self.dtype(), true)?;
         let to_append = s.new_from_index(0, n);
 
         let mut out = self.clone();

--- a/crates/polars-plan/src/dsl/options/mod.rs
+++ b/crates/polars-plan/src/dsl/options/mod.rs
@@ -149,7 +149,7 @@ pub struct JoinOptions {
 
 impl Default for JoinOptions {
     fn default() -> Self {
-        JoinOptions {
+        Self {
             allow_parallel: true,
             force_parallel: false,
             // Todo!: make default


### PR DESCRIPTION
Does not resolve any particular issue but addresses a small `TODO` I found in `series/ops/extend.rs` and moves to more idiomatic `Self` rather than `JoinOptions` in `dsl/options/mod.rs`.