### PR TITLE
refactor(rust): Remove unused sink code

### DIFF
--- a/crates/polars-stream/src/nodes/io_sinks2/components/partition_distributor.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/components/partition_distributor.rs
@@ -31,7 +31,6 @@ pub struct PartitionDistributor {
     pub open_sinks_semaphore: Arc<tokio::sync::Semaphore>,
     pub partition_sink_starter: PartitionSinkStarter,
     pub per_partition_sort: Option<ArgSortBy>,
-    pub inflight_morsel_limit: usize,
     pub no_partition_keys: bool,
     pub verbose: bool,
 }
@@ -48,7 +47,6 @@ impl PartitionDistributor {
             open_sinks_semaphore,
             partition_sink_starter,
             per_partition_sort,
-            inflight_morsel_limit,
             no_partition_keys,
             verbose,
         } = self;
@@ -286,6 +284,7 @@ impl PartitionDistributor {
                     rechunk_par(unsafe { df.get_columns_mut() }).await;
                     let df = Arc::new(df);
 
+                    #[expect(unused)]
                     let gather_indices = per_partition_sort.arg_sort_by_par(&df).await?;
 
                     todo!()

--- a/crates/polars-stream/src/nodes/io_sinks2/components/partition_morsel_sender.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/components/partition_morsel_sender.rs
@@ -5,7 +5,6 @@ use polars_core::frame::DataFrame;
 use polars_error::PolarsResult;
 use polars_plan::dsl::sink2::FileProviderArgs;
 use polars_utils::IdxSize;
-use polars_utils::index::NonZeroIdxSize;
 
 use crate::async_executor::{self, TaskPriority};
 use crate::nodes::io_sinks2::components::error_capture::ErrorCapture;
@@ -48,17 +47,18 @@ impl PartitionMorselSender {
         // Sorted finalize
         morsel_stream: Option<(futures::stream::BoxStream<'static, (SinkMorsel, bool)>, u64)>,
     ) -> PolarsResult<()> {
+        #[expect(unused)]
         let row_byte_size: u64;
 
-        let mut sorted_finalize_stream = if let Some((stream, row_byte_size_)) = morsel_stream {
-            row_byte_size = row_byte_size_;
+        let mut sorted_finalize_stream = if let Some((stream, _)) = morsel_stream {
+            // row_byte_size = row_byte_size_;
 
             assert_eq!(partition.sinked_size, RowCountAndSize::default());
             assert_eq!(partition.buffered_rows.height(), 0);
 
             Some(stream)
         } else {
-            row_byte_size = partition.buffered_size().row_byte_size();
+            // row_byte_size = partition.buffered_size().row_byte_size();
             None
         };
 

--- a/crates/polars-stream/src/nodes/io_sinks2/components/partitioner.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/components/partitioner.rs
@@ -1,18 +1,11 @@
 use std::borrow::Cow;
 
-use arrow::array::{BinaryViewArray, FixedSizeBinaryArray, PrimitiveArray};
-use arrow::buffer::Buffer;
-use arrow::datatypes::ArrowDataType;
 use polars_core::frame::DataFrame;
 use polars_core::prelude::row_encode::_get_rows_encoded_ca_unordered;
-use polars_core::prelude::{
-    BinaryOffsetChunked, Column, DataType, GroupsIndicator, IntoGroupsType, LargeBinaryArray,
-};
-use polars_core::{with_match_physical_integer_type, with_match_physical_numeric_type};
+use polars_core::prelude::{BinaryOffsetChunked, Column, IntoGroupsType};
 use polars_error::PolarsResult;
 use polars_expr::hash_keys::{HashKeysVariant, hash_keys_variant_for_dtype};
 use polars_expr::state::ExecutionState;
-use polars_utils::IdxSize;
 use polars_utils::pl_str::PlSmallStr;
 
 use crate::async_primitives::wait_group::WaitToken;

--- a/crates/polars-stream/src/nodes/io_sinks2/components/size.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/components/size.rs
@@ -24,13 +24,6 @@ impl RowCountAndSize {
         }
     }
 
-    pub fn min(self, other: Self) -> Self {
-        Self {
-            num_rows: self.num_rows.min(other.num_rows),
-            num_bytes: self.num_bytes.min(other.num_bytes),
-        }
-    }
-
     /// How many rows from `other` can fit into `self`.
     ///
     /// # Parameters

--- a/crates/polars-stream/src/nodes/io_sinks2/pipeline_initialization/partition_by.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/pipeline_initialization/partition_by.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use polars_error::PolarsResult;
 use polars_plan::dsl::UnifiedSinkArgs;
-use polars_utils::IdxSize;
 use polars_utils::pl_str::PlSmallStr;
 
 use crate::async_executor::{self, TaskPriority};
@@ -17,7 +16,7 @@ use crate::nodes::io_sinks2::components::partition_morsel_sender::PartitionMorse
 use crate::nodes::io_sinks2::components::partition_sink_starter::PartitionSinkStarter;
 use crate::nodes::io_sinks2::components::partitioner::Partitioner;
 use crate::nodes::io_sinks2::components::partitioner_pipeline::PartitionerPipeline;
-use crate::nodes::io_sinks2::components::size::{NonZeroRowCountAndSize, RowCountAndSize};
+use crate::nodes::io_sinks2::components::size::NonZeroRowCountAndSize;
 use crate::nodes::io_sinks2::config::{IOSinkNodeConfig, IOSinkTarget, PartitionedTarget};
 use crate::nodes::io_sinks2::writers::create_file_writer_starter;
 use crate::nodes::io_sinks2::writers::interface::FileWriterStarter;
@@ -166,7 +165,6 @@ pub fn start_partition_sink_pipeline(
                 open_sinks_semaphore,
                 partition_sink_starter,
                 per_partition_sort,
-                inflight_morsel_limit,
                 no_partition_keys,
                 verbose,
             }

--- a/crates/polars-stream/src/nodes/io_sinks2/writers/csv/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/writers/csv/mod.rs
@@ -1,13 +1,11 @@
 use std::sync::Arc;
 
 use polars_core::config;
-use polars_core::prelude::DataType;
 use polars_core::schema::SchemaRef;
 use polars_error::PolarsResult;
 use polars_io::pl_async;
 use polars_io::prelude::{CsvSerializer, CsvWriterOptions};
 use polars_io::utils::sync_on_close::SyncOnCloseType;
-use polars_utils::IdxSize;
 use polars_utils::index::NonZeroIdxSize;
 
 use crate::async_executor::{self, TaskPriority};

--- a/crates/polars-stream/src/nodes/io_sinks2/writers/interface.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/writers/interface.rs
@@ -37,7 +37,7 @@ pub(super) fn ideal_sink_morsel_size_env() -> (Option<IdxSize>, Option<u64>) {
         })
         .ok();
 
-    let mut num_bytes = std::env::var("POLARS_IDEAL_SINK_MORSEL_SIZE_BYTES")
+    let num_bytes = std::env::var("POLARS_IDEAL_SINK_MORSEL_SIZE_BYTES")
         .map(|x| {
             x.parse::<NonZeroU64>()
                 .ok()

--- a/crates/polars-stream/src/nodes/io_sinks2/writers/ipc/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/writers/ipc/mod.rs
@@ -1,10 +1,6 @@
 use std::sync::Arc;
 
-use arrow::io::ipc::{self, IpcField};
-use polars_core::prelude::CompatLevel;
 use polars_core::schema::SchemaRef;
-use polars_core::series::ToArrowConverter;
-use polars_core::utils::arrow;
 use polars_core::utils::arrow::io::ipc::write::{EncodedData, WriteOptions};
 use polars_error::PolarsResult;
 use polars_io::ipc::IpcWriterOptions;

--- a/crates/polars-stream/src/nodes/io_sinks2/writers/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/writers/mod.rs
@@ -90,6 +90,12 @@ pub fn create_file_writer_starter(
                 initialized_state: Default::default(),
             }) as _
         },
-        _ => unimplemented!(),
+        #[cfg(not(any(
+            feature = "parquet",
+            feature = "ipc",
+            feature = "csv",
+            feature = "json"
+        )))]
+        _ => panic!("no enum variants on FileType (hint: missing feature flags?)"),
     })
 }

--- a/crates/polars-stream/src/nodes/io_sinks2/writers/ndjson/morsel_serializer.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/writers/ndjson/morsel_serializer.rs
@@ -93,7 +93,7 @@ impl MorselSerializer {
             .unzip();
 
         let array = StructArray::new(ArrowDataType::Struct(fields), height, arrays, None);
-        let mut serializer = polars_json::json::write::new_serializer(&array, 0, usize::MAX);
+        let serializer = polars_json::json::write::new_serializer(&array, 0, usize::MAX);
 
         serializer.serialize_json_lines_to_vec(serialized_data, height);
 

--- a/crates/polars-stream/src/nodes/io_sinks2/writers/parquet/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/writers/parquet/mod.rs
@@ -76,7 +76,7 @@ impl FileWriterStarter for ParquetWriterStarter {
 
     fn start_file_writer(
         &self,
-        mut morsel_rx: connector::Receiver<SinkMorsel>,
+        morsel_rx: connector::Receiver<SinkMorsel>,
         file: tokio_handle_ext::AbortOnDropHandle<
             PolarsResult<polars_io::prelude::file::Writeable>,
         >,

--- a/crates/polars-stream/src/nodes/mod.rs
+++ b/crates/polars-stream/src/nodes/mod.rs
@@ -14,7 +14,6 @@ pub mod in_memory_sink;
 pub mod in_memory_source;
 pub mod input_independent_select;
 pub mod io_sinks;
-#[allow(unused)]
 pub mod io_sinks2;
 pub mod io_sources;
 pub mod joins;

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -264,20 +264,6 @@ fn visualize_plan_rec(
         ),
         PhysNodeKind::InMemorySink { input } => ("in-memory-sink".to_string(), from_ref(input)),
         PhysNodeKind::CallbackSink { input, .. } => ("callback-sink".to_string(), from_ref(input)),
-        PhysNodeKind::FileSink {
-            input, file_type, ..
-        } => match file_type {
-            #[cfg(feature = "parquet")]
-            FileType::Parquet(_) => ("parquet-sink".to_string(), from_ref(input)),
-            #[cfg(feature = "ipc")]
-            FileType::Ipc(_) => ("ipc-sink".to_string(), from_ref(input)),
-            #[cfg(feature = "csv")]
-            FileType::Csv(_) => ("csv-sink".to_string(), from_ref(input)),
-            #[cfg(feature = "json")]
-            FileType::Json(_) => ("ndjson-sink".to_string(), from_ref(input)),
-            #[allow(unreachable_patterns)]
-            _ => todo!(),
-        },
         PhysNodeKind::PartitionedSink {
             input,
             file_type,
@@ -303,7 +289,7 @@ fn visualize_plan_rec(
                 _ => todo!(),
             }
         },
-        PhysNodeKind::FileSink2 { input, options } => match options.file_format.as_ref() {
+        PhysNodeKind::FileSink { input, options } => match options.file_format.as_ref() {
             #[cfg(feature = "parquet")]
             FileType::Parquet(_) => ("parquet-sink".to_string(), from_ref(input)),
             #[cfg(feature = "ipc")]

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -14,8 +14,8 @@ use polars_plan::dsl::default_values::DefaultFieldValues;
 use polars_plan::dsl::deletion::DeletionFilesList;
 use polars_plan::dsl::sink2::FileProviderType;
 use polars_plan::dsl::{
-    CallbackSinkType, ExtraColumnsPolicy, FileScanIR, FileSinkOptions, PartitionStrategyIR,
-    PartitionVariantIR, PartitionedSinkOptionsIR, SinkOptions, SinkTypeIR, UnifiedSinkArgs,
+    CallbackSinkType, ExtraColumnsPolicy, FileScanIR, PartitionStrategyIR, PartitionVariantIR,
+    PartitionedSinkOptionsIR, SinkOptions, SinkTypeIR, UnifiedSinkArgs,
 };
 use polars_plan::plans::expr_ir::{ExprIR, OutputName};
 use polars_plan::plans::{
@@ -268,23 +268,10 @@ pub fn lower_ir(
                 }
             },
 
-            SinkTypeIR::File(options)
-                if match options.file_format.as_ref() {
-                    #[cfg(feature = "parquet")]
-                    polars_plan::dsl::FileType::Parquet(_) => true,
-                    #[cfg(feature = "ipc")]
-                    polars_plan::dsl::FileType::Ipc(_) => true,
-                    #[cfg(feature = "csv")]
-                    polars_plan::dsl::FileType::Csv(_) => true,
-                    #[cfg(feature = "json")]
-                    polars_plan::dsl::FileType::Json(_) => true,
-                    #[expect(unreachable_patterns)]
-                    _ => false,
-                } =>
-            {
+            SinkTypeIR::File(options) => {
                 let options = options.clone();
                 let input = lower_ir!(*input)?;
-                PhysNodeKind::FileSink2 { input, options }
+                PhysNodeKind::FileSink { input, options }
             },
 
             SinkTypeIR::Partitioned(options)
@@ -299,45 +286,18 @@ pub fn lower_ir(
                         polars_plan::dsl::FileType::Csv(_) => true,
                         #[cfg(feature = "json")]
                         polars_plan::dsl::FileType::Json(_) => true,
-                        #[expect(unreachable_patterns)]
-                        _ => false,
+                        #[cfg(not(any(
+                            feature = "parquet",
+                            feature = "ipc",
+                            feature = "csv",
+                            feature = "json"
+                        )))]
+                        _ => panic!("no enum variants on FileType (hint: missing feature flags?)"),
                     } =>
             {
                 let options = options.clone();
                 let input = lower_ir!(*input)?;
                 PhysNodeKind::PartitionedSink2 { input, options }
-            },
-            SinkTypeIR::File(FileSinkOptions {
-                target,
-                file_format,
-                unified_sink_args,
-            }) => {
-                // Convert to old parameters for now
-
-                let target = target.clone();
-
-                let UnifiedSinkArgs {
-                    mkdir,
-                    maintain_order,
-                    sync_on_close,
-                    cloud_options,
-                } = unified_sink_args.clone();
-
-                let sink_options = SinkOptions {
-                    sync_on_close,
-                    maintain_order,
-                    mkdir,
-                };
-                let file_type = file_format.as_ref().clone();
-
-                let phys_input = lower_ir!(*input)?;
-                PhysNodeKind::FileSink {
-                    target,
-                    sink_options,
-                    file_type,
-                    input: phys_input,
-                    cloud_options: cloud_options.map(Arc::unwrap_or_clone),
-                }
             },
 
             SinkTypeIR::Partitioned(PartitionedSinkOptionsIR {

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -12,7 +12,7 @@ use polars_plan::dsl::deletion::DeletionFilesList;
 use polars_plan::dsl::{
     CastColumnsPolicy, FileSinkOptions, JoinTypeOptionsIR, MissingColumnsPolicy,
     PartitionTargetCallback, PartitionVariantIR, PartitionedSinkOptionsIR, PredicateFileSkip,
-    ScanSources, SinkFinishCallback, SinkOptions, SinkTarget, SortColumnIR, TableStatistics,
+    ScanSources, SinkFinishCallback, SinkOptions, SortColumnIR, TableStatistics,
 };
 use polars_plan::plans::hive::HivePartitionsDf;
 use polars_plan::plans::{AExpr, DataFrameUdf, IR};
@@ -191,11 +191,8 @@ pub enum PhysNodeKind {
     },
 
     FileSink {
-        target: SinkTarget,
-        sink_options: SinkOptions,
-        file_type: FileType,
         input: PhysStream,
-        cloud_options: Option<CloudOptions>,
+        options: FileSinkOptions,
     },
 
     PartitionedSink {
@@ -208,11 +205,6 @@ pub enum PhysNodeKind {
         cloud_options: Option<CloudOptions>,
         per_partition_sort_by: Option<Vec<SortColumnIR>>,
         finish_callback: Option<SinkFinishCallback>,
-    },
-
-    FileSink2 {
-        input: PhysStream,
-        options: FileSinkOptions,
     },
 
     PartitionedSink2 {
@@ -456,7 +448,6 @@ fn visit_node_inputs_mut(
             | PhysNodeKind::InMemorySink { input }
             | PhysNodeKind::CallbackSink { input, .. }
             | PhysNodeKind::FileSink { input, .. }
-            | PhysNodeKind::FileSink2 { input, .. }
             | PhysNodeKind::PartitionedSink { input, .. }
             | PhysNodeKind::PartitionedSink2 { input, .. }
             | PhysNodeKind::InMemoryMap { input, .. }

--- a/crates/polars-stream/src/physical_plan/visualization/mod.rs
+++ b/crates/polars-stream/src/physical_plan/visualization/mod.rs
@@ -122,38 +122,6 @@ impl PhysicalPlanVisualizationDataGenerator<'_> {
                     ..Default::default()
                 }
             },
-            PhysNodeKind::FileSink {
-                target,
-                sink_options:
-                    SinkOptions {
-                        sync_on_close,
-                        maintain_order,
-                        mkdir,
-                    },
-                file_type,
-                input,
-                cloud_options,
-            } => {
-                phys_node_inputs.push(input.node);
-
-                let properties = PhysNodeProperties::FileSink {
-                    target: match target {
-                        SinkTarget::Path(p) => format_pl_smallstr!("Path({})", p.to_str()),
-                        SinkTarget::Dyn(_) => PlSmallStr::from_static("DynWriteable"),
-                    },
-                    file_format: PlSmallStr::from_static(file_type.into()),
-                    sync_on_close: *sync_on_close,
-                    maintain_order: *maintain_order,
-                    mkdir: *mkdir,
-                    cloud_options: cloud_options.is_some(),
-                };
-
-                PhysNodeInfo {
-                    title: properties.variant_name(),
-                    properties,
-                    ..Default::default()
-                }
-            },
             PhysNodeKind::Filter { input, predicate } => {
                 phys_node_inputs.push(input.node);
 
@@ -720,7 +688,7 @@ impl PhysicalPlanVisualizationDataGenerator<'_> {
                     ..Default::default()
                 }
             },
-            PhysNodeKind::FileSink2 {
+            PhysNodeKind::FileSink {
                 input,
                 options:
                     FileSinkOptions {


### PR DESCRIPTION
* Removes a blanket `allow(unused)` on the `io_sinks2` module and fixes lints
* Replaces the contents of `PhysNodeKind::FileSink` with the contents of `PhysNodeKind::FileSink2`, and removes `FileSink2`
