### PR TITLE
refactor(rust): Pass `sync_on_close` and `num_pipelines` via `start_file_writer` for IO sinks

### DIFF
--- a/crates/polars-stream/src/nodes/io_sinks2/components/partition_sink_starter.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/components/partition_sink_starter.rs
@@ -1,7 +1,9 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use polars_error::PolarsResult;
 use polars_io::pl_async;
+use polars_io::utils::sync_on_close::SyncOnCloseType;
 use polars_plan::dsl::sink2::FileProviderArgs;
 
 use crate::async_executor;
@@ -10,13 +12,15 @@ use crate::nodes::TaskPriority;
 use crate::nodes::io_sinks2::components::file_provider::FileProvider;
 use crate::nodes::io_sinks2::components::file_sink::{FileSinkPermit, FileSinkTaskData};
 use crate::nodes::io_sinks2::components::size::RowCountAndSize;
-use crate::nodes::io_sinks2::writers::interface::FileWriterStarter;
+use crate::nodes::io_sinks2::writers::interface::{FileOpenTaskHandle, FileWriterStarter};
 use crate::utils::tokio_handle_ext;
 
 #[derive(Clone)]
 pub struct PartitionSinkStarter {
     pub file_provider: Arc<FileProvider>,
     pub writer_starter: Arc<dyn FileWriterStarter>,
+    pub sync_on_close: SyncOnCloseType,
+    pub num_pipelines_per_sink: NonZeroUsize,
 }
 
 impl PartitionSinkStarter {
@@ -34,9 +38,11 @@ impl PartitionSinkStarter {
 
         let (morsel_tx, morsel_rx) = connector::connector();
 
-        let writer_handle = self
-            .writer_starter
-            .start_file_writer(morsel_rx, file_open_task)?;
+        let writer_handle = self.writer_starter.start_file_writer(
+            morsel_rx,
+            FileOpenTaskHandle::new(file_open_task, self.sync_on_close),
+            self.num_pipelines_per_sink,
+        )?;
 
         let task_handle = async_executor::spawn(TaskPriority::High, async move {
             writer_handle.await?;

--- a/crates/polars-stream/src/nodes/io_sinks2/config.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/config.rs
@@ -17,46 +17,42 @@ pub struct IOSinkNodeConfig {
     pub target: IOSinkTarget,
     pub unified_sink_args: UnifiedSinkArgs,
     pub input_schema: SchemaRef,
-    pub num_pipelines: usize,
 }
 
 impl IOSinkNodeConfig {
-    pub fn per_sink_pipeline_depth(&self) -> usize {
-        self.inflight_morsel_limit().min(self.num_pipelines)
+    pub fn num_pipelines_per_sink(&self, num_pipelines: NonZeroUsize) -> NonZeroUsize {
+        NonZeroUsize::min(num_pipelines, self.inflight_morsel_limit(num_pipelines))
     }
 
-    pub fn inflight_morsel_limit(&self) -> usize {
+    pub fn inflight_morsel_limit(&self, num_pipelines: NonZeroUsize) -> NonZeroUsize {
         if let Ok(v) = std::env::var("POLARS_INFLIGHT_SINK_MORSEL_LIMIT").map(|x| {
-            x.parse::<NonZeroUsize>()
-                .ok()
-                .unwrap_or_else(|| {
-                    panic!("invalid value for POLARS_INFLIGHT_SINK_MORSEL_LIMIT: {x}")
-                })
-                .get()
+            x.parse::<NonZeroUsize>().ok().unwrap_or_else(|| {
+                panic!("invalid value for POLARS_INFLIGHT_SINK_MORSEL_LIMIT: {x}")
+            })
         }) {
             return v;
         };
 
-        self.num_pipelines.saturating_add(
+        NonZeroUsize::saturating_add(
+            num_pipelines,
             // Additional buffer to accommodate head-of-line blocking
             4,
         )
     }
 
-    pub fn max_open_sinks(&self) -> usize {
+    pub fn max_open_sinks(&self) -> NonZeroUsize {
         if let Ok(v) = std::env::var("POLARS_MAX_OPEN_SINKS").map(|x| {
             x.parse::<NonZeroUsize>()
                 .ok()
                 .unwrap_or_else(|| panic!("invalid value for POLARS_MAX_OPEN_SINKS: {x}"))
-                .get()
         }) {
             return v;
         }
 
         if self.target.is_cloud_location() {
-            512
+            const { NonZeroUsize::new(512).unwrap() }
         } else {
-            128
+            const { NonZeroUsize::new(128).unwrap() }
         }
     }
 

--- a/crates/polars-stream/src/nodes/io_sinks2/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/mod.rs
@@ -178,11 +178,9 @@ impl IOSinkNodeState {
             return Ok(());
         }
 
-        let Uninitialized { mut config } = std::mem::replace(self, Finished) else {
+        let Uninitialized { config } = std::mem::replace(self, Finished) else {
             unreachable!()
         };
-
-        config.num_pipelines = execution_state.num_pipelines;
 
         let (phase_channel_tx, mut phase_channel_rx) = connector::connector::<PortReceiver>();
         let (mut multi_phase_tx, multi_phase_rx) = connector::connector();
@@ -209,9 +207,12 @@ impl IOSinkNodeState {
         });
 
         let task_handle = match &config.target {
-            IOSinkTarget::File(_) => {
-                start_single_file_sink_pipeline(node_name.clone(), multi_phase_rx, *config)?
-            },
+            IOSinkTarget::File(_) => start_single_file_sink_pipeline(
+                node_name.clone(),
+                multi_phase_rx,
+                *config,
+                execution_state,
+            )?,
 
             IOSinkTarget::Partitioned { .. } => {
                 start_partition_sink_pipeline(node_name, multi_phase_rx, *config, execution_state)?

--- a/crates/polars-stream/src/nodes/io_sinks2/pipeline_initialization/partition_by.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/pipeline_initialization/partition_by.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use polars_error::PolarsResult;
@@ -27,9 +28,11 @@ pub fn start_partition_sink_pipeline(
     config: IOSinkNodeConfig,
     execution_state: &StreamingExecutionState,
 ) -> PolarsResult<async_executor::AbortOnDropHandle<PolarsResult<()>>> {
-    let inflight_morsel_limit = config.inflight_morsel_limit();
-    let per_sink_pipeline_depth = config.per_sink_pipeline_depth();
-    let max_open_sinks = config.max_open_sinks();
+    let num_pipelines: NonZeroUsize = execution_state.num_pipelines.try_into().unwrap();
+
+    let inflight_morsel_limit = config.inflight_morsel_limit(num_pipelines);
+    let num_pipelines_per_sink = config.num_pipelines_per_sink(num_pipelines);
+    let max_open_sinks = config.max_open_sinks().get();
     let upload_chunk_size = config.partitioned_cloud_upload_chunk_size();
 
     let IOSinkNodeConfig {
@@ -43,7 +46,6 @@ pub fn start_partition_sink_pipeline(
                 cloud_options,
             },
         input_schema: _,
-        num_pipelines: _,
     } = config
     else {
         unreachable!()
@@ -71,12 +73,8 @@ pub fn start_partition_sink_pipeline(
         upload_chunk_size,
     });
 
-    let file_writer_starter: Arc<dyn FileWriterStarter> = create_file_writer_starter(
-        &file_format,
-        &file_schema,
-        per_sink_pipeline_depth,
-        sync_on_close,
-    )?;
+    let file_writer_starter: Arc<dyn FileWriterStarter> =
+        create_file_writer_starter(&file_format, &file_schema)?;
 
     let mut takeable_rows_provider = file_writer_starter.takeable_rows_provider();
 
@@ -109,10 +107,11 @@ pub fn start_partition_sink_pipeline(
     }
 
     let (partitioned_dfs_tx, partitioned_dfs_rx) = tokio::sync::mpsc::channel(match &partitioner {
-        Partitioner::Keyed(_) => inflight_morsel_limit,
+        Partitioner::Keyed(_) => inflight_morsel_limit.get(),
         Partitioner::FileSize => 1,
     });
-    let inflight_morsel_semaphore = Arc::new(tokio::sync::Semaphore::new(inflight_morsel_limit));
+    let inflight_morsel_semaphore =
+        Arc::new(tokio::sync::Semaphore::new(inflight_morsel_limit.get()));
     let no_partition_keys = matches!(partitioner, Partitioner::FileSize);
 
     let partitioner_handle = async_executor::AbortOnDropHandle::new(async_executor::spawn(
@@ -134,6 +133,8 @@ pub fn start_partition_sink_pipeline(
     let partition_sink_starter = PartitionSinkStarter {
         file_provider,
         writer_starter: Arc::clone(&file_writer_starter),
+        sync_on_close,
+        num_pipelines_per_sink,
     };
 
     let partition_morsel_sender = PartitionMorselSender {

--- a/crates/polars-stream/src/nodes/io_sinks2/pipeline_initialization/single_file.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/pipeline_initialization/single_file.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use polars_core::frame::DataFrame;
@@ -8,20 +9,24 @@ use polars_utils::pl_str::PlSmallStr;
 
 use crate::async_executor::{self, TaskPriority};
 use crate::async_primitives::connector;
+use crate::execute::StreamingExecutionState;
 use crate::morsel::Morsel;
 use crate::nodes::io_sinks2::components::morsel_resize_pipeline::MorselResizePipeline;
 use crate::nodes::io_sinks2::config::{IOSinkNodeConfig, IOSinkTarget};
 use crate::nodes::io_sinks2::writers::create_file_writer_starter;
-use crate::nodes::io_sinks2::writers::interface::FileWriterStarter;
+use crate::nodes::io_sinks2::writers::interface::{FileOpenTaskHandle, FileWriterStarter};
 use crate::utils::tokio_handle_ext;
 
 pub fn start_single_file_sink_pipeline(
     node_name: PlSmallStr,
     morsel_rx: connector::Receiver<Morsel>,
     config: IOSinkNodeConfig,
+    execution_state: &StreamingExecutionState,
 ) -> PolarsResult<async_executor::AbortOnDropHandle<PolarsResult<()>>> {
-    let inflight_morsel_limit = config.inflight_morsel_limit();
-    let per_sink_pipeline_depth = config.per_sink_pipeline_depth();
+    let num_pipelines: NonZeroUsize = execution_state.num_pipelines.try_into().unwrap();
+
+    let inflight_morsel_limit = config.inflight_morsel_limit(num_pipelines);
+    let num_pipelines_per_sink = config.num_pipelines_per_sink(num_pipelines);
     let upload_chunk_size = config.cloud_upload_chunk_size();
 
     let IOSinkNodeConfig {
@@ -35,7 +40,6 @@ pub fn start_single_file_sink_pipeline(
                 cloud_options,
             },
         input_schema,
-        num_pipelines: _,
     } = config
     else {
         unreachable!()
@@ -50,13 +54,10 @@ pub fn start_single_file_sink_pipeline(
                 .open_into_writeable_async(cloud_options.as_deref(), mkdir, upload_chunk_size)
                 .await
         }));
+    let file_open_task = FileOpenTaskHandle::new(file_open_task, sync_on_close);
 
-    let file_writer_starter: Arc<dyn FileWriterStarter> = create_file_writer_starter(
-        &file_format,
-        &file_schema,
-        per_sink_pipeline_depth,
-        sync_on_close,
-    )?;
+    let file_writer_starter: Arc<dyn FileWriterStarter> =
+        create_file_writer_starter(&file_format, &file_schema)?;
     let takeable_rows_provider = file_writer_starter.takeable_rows_provider();
 
     if verbose {
@@ -72,10 +73,12 @@ pub fn start_single_file_sink_pipeline(
     }
 
     let (writer_tx, writer_rx) = connector::connector();
-    let writer_handle = file_writer_starter.start_file_writer(writer_rx, file_open_task)?;
+    let writer_handle =
+        file_writer_starter.start_file_writer(writer_rx, file_open_task, num_pipelines_per_sink)?;
 
     let empty_with_schema_df = DataFrame::empty_with_arc_schema(file_schema.clone());
-    let inflight_morsel_semaphore = Arc::new(tokio::sync::Semaphore::new(inflight_morsel_limit));
+    let inflight_morsel_semaphore =
+        Arc::new(tokio::sync::Semaphore::new(inflight_morsel_limit.get()));
 
     let resize_pipeline = MorselResizePipeline {
         empty_with_schema_df,

--- a/crates/polars-stream/src/nodes/io_sinks2/writers/csv/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/writers/csv/mod.rs
@@ -5,7 +5,6 @@ use polars_core::schema::SchemaRef;
 use polars_error::PolarsResult;
 use polars_io::pl_async;
 use polars_io::prelude::{CsvSerializer, CsvWriterOptions};
-use polars_io::utils::sync_on_close::SyncOnCloseType;
 use polars_utils::index::NonZeroIdxSize;
 
 use crate::async_executor::{self, TaskPriority};
@@ -14,7 +13,9 @@ use crate::nodes::io_sinks2::components::sink_morsel::{SinkMorsel, SinkMorselPer
 use crate::nodes::io_sinks2::components::size::{
     NonZeroRowCountAndSize, RowCountAndSize, TakeableRowsProvider,
 };
-use crate::nodes::io_sinks2::writers::interface::{FileWriterStarter, ideal_sink_morsel_size_env};
+use crate::nodes::io_sinks2::writers::interface::{
+    FileOpenTaskHandle, FileWriterStarter, ideal_sink_morsel_size_env,
+};
 use crate::utils::tokio_handle_ext;
 
 mod io_writer;
@@ -25,8 +26,6 @@ pub struct CsvWriterStarter {
     /// `Mutex` is to handle `dyn ColumnSerializer` not being `Sync`.
     pub base_serializer: std::sync::Mutex<CsvSerializer>,
     pub schema: SchemaRef,
-    pub pipeline_depth: usize,
-    pub sync_on_close: SyncOnCloseType,
     pub initialized_state: std::sync::Mutex<Option<InitializedState>>,
 }
 
@@ -93,20 +92,17 @@ impl FileWriterStarter for CsvWriterStarter {
     fn start_file_writer(
         &self,
         morsel_rx: connector::Receiver<SinkMorsel>,
-        file: tokio_handle_ext::AbortOnDropHandle<
-            PolarsResult<polars_io::prelude::file::Writeable>,
-        >,
+        file: FileOpenTaskHandle,
+        num_pipelines: std::num::NonZeroUsize,
     ) -> PolarsResult<async_executor::JoinHandle<PolarsResult<()>>> {
         let (filled_serializer_tx, filled_serializer_rx) = tokio::sync::mpsc::channel::<(
             async_executor::AbortOnDropHandle<PolarsResult<morsel_serializer::MorselSerializer>>,
             SinkMorselPermit,
-        )>(self.pipeline_depth);
+        )>(num_pipelines.get());
 
-        let max_serializers = self.pipeline_depth;
+        let max_serializers = num_pipelines.get();
         let (reuse_serializer_tx, reuse_serializer_rx) =
             tokio::sync::mpsc::channel::<morsel_serializer::MorselSerializer>(max_serializers);
-
-        let sync_on_close = self.sync_on_close;
 
         let io_handle = tokio_handle_ext::AbortOnDropHandle(
             pl_async::get_runtime().spawn(
@@ -116,7 +112,6 @@ impl FileWriterStarter for CsvWriterStarter {
                     reuse_serializer_tx,
                     schema: Arc::clone(&self.schema),
                     options: Arc::clone(&self.options),
-                    sync_on_close,
                 }
                 .run(),
             ),

--- a/crates/polars-stream/src/nodes/io_sinks2/writers/interface.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/writers/interface.rs
@@ -1,7 +1,9 @@
-use std::num::NonZeroU64;
+use std::num::{NonZeroU64, NonZeroUsize};
 
+use futures::FutureExt;
 use polars_error::PolarsResult;
 use polars_io::utils::file::Writeable;
+use polars_io::utils::sync_on_close::SyncOnCloseType;
 use polars_utils::IdxSize;
 use polars_utils::index::NonZeroIdxSize;
 
@@ -20,8 +22,42 @@ pub trait FileWriterStarter: Send + Sync + 'static {
     fn start_file_writer(
         &self,
         morsel_rx: connector::Receiver<SinkMorsel>,
-        file: tokio_handle_ext::AbortOnDropHandle<PolarsResult<Writeable>>,
+        file: FileOpenTaskHandle,
+        num_pipelines: NonZeroUsize,
     ) -> PolarsResult<async_executor::JoinHandle<PolarsResult<()>>>;
+}
+
+pub struct FileOpenTaskHandle {
+    handle: tokio_handle_ext::AbortOnDropHandle<PolarsResult<Writeable>>,
+    sync_on_close: SyncOnCloseType,
+}
+
+impl FileOpenTaskHandle {
+    pub fn new(
+        handle: tokio_handle_ext::AbortOnDropHandle<PolarsResult<Writeable>>,
+        sync_on_close: SyncOnCloseType,
+    ) -> Self {
+        Self {
+            handle,
+            sync_on_close,
+        }
+    }
+}
+
+impl std::future::Future for FileOpenTaskHandle {
+    type Output = PolarsResult<(Writeable, SyncOnCloseType)>;
+
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        use std::task::Poll;
+
+        let file: Result<_, tokio::task::JoinError> = futures::ready!(self.handle.poll_unpin(cx));
+        let file: PolarsResult<Writeable> = file.unwrap();
+
+        Poll::Ready(file.map(|file| (file, self.sync_on_close)))
+    }
 }
 
 /// Load ideal morsel size configuration from environment variables.

--- a/crates/polars-stream/src/nodes/io_sinks2/writers/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/writers/mod.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use polars_core::schema::SchemaRef;
 use polars_error::PolarsResult;
-use polars_io::utils::sync_on_close::SyncOnCloseType;
 use polars_plan::dsl::FileWriteFormat;
 use polars_utils::IdxSize;
 
@@ -21,8 +20,6 @@ mod parquet;
 pub fn create_file_writer_starter(
     file_format: &FileWriteFormat,
     file_schema: &SchemaRef,
-    pipeline_depth: usize,
-    sync_on_close: SyncOnCloseType,
 ) -> PolarsResult<Arc<dyn FileWriterStarter>> {
     Ok(match file_format {
         #[cfg(feature = "parquet")]
@@ -42,8 +39,6 @@ pub fn create_file_writer_starter(
                 options: Arc::clone(options),
                 arrow_schema,
                 initialized_state: Default::default(),
-                pipeline_depth,
-                sync_on_close,
                 row_group_size: options
                     .row_group_size
                     .map(|x| IdxSize::try_from(x).unwrap()),
@@ -54,8 +49,6 @@ pub fn create_file_writer_starter(
             Arc::new(crate::nodes::io_sinks2::writers::ipc::IpcWriterStarter {
                 options: Arc::new(*options),
                 schema: file_schema.clone(),
-                pipeline_depth,
-                sync_on_close,
                 record_batch_size: options
                     .record_batch_size
                     .map(|x| IdxSize::try_from(x).unwrap()),
@@ -75,8 +68,6 @@ pub fn create_file_writer_starter(
                 )?
                 .into(),
                 schema: file_schema.clone(),
-                pipeline_depth,
-                sync_on_close,
                 initialized_state: Default::default(),
             }) as _
         },
@@ -84,8 +75,6 @@ pub fn create_file_writer_starter(
         FileWriteFormat::NDJson(polars_io::json::JsonWriterOptions {}) => Arc::new(
             crate::nodes::io_sinks2::writers::ndjson::NDJsonWriterStarter {
                 schema: file_schema.clone(),
-                pipeline_depth,
-                sync_on_close,
                 initialized_state: Default::default(),
             },
         ) as _,

--- a/crates/polars-stream/src/nodes/io_sinks2/writers/ndjson/io_writer.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/writers/ndjson/io_writer.rs
@@ -1,22 +1,19 @@
 use polars_error::PolarsResult;
 use polars_io::utils::file::AsyncWriteable;
-use polars_io::utils::sync_on_close::SyncOnCloseType;
 use tokio::io::AsyncWriteExt as _;
 
 use crate::async_executor;
 use crate::nodes::io_sinks2::components::sink_morsel::SinkMorselPermit;
+use crate::nodes::io_sinks2::writers::interface::FileOpenTaskHandle;
 use crate::nodes::io_sinks2::writers::ndjson::morsel_serializer::MorselSerializer;
-use crate::utils::tokio_handle_ext;
 
 pub struct IOWriter {
-    pub file:
-        tokio_handle_ext::AbortOnDropHandle<PolarsResult<polars_io::prelude::file::Writeable>>,
+    pub file: FileOpenTaskHandle,
     pub filled_serializer_rx: tokio::sync::mpsc::Receiver<(
         async_executor::AbortOnDropHandle<PolarsResult<MorselSerializer>>,
         SinkMorselPermit,
     )>,
     pub reuse_serializer_tx: tokio::sync::mpsc::Sender<MorselSerializer>,
-    pub sync_on_close: SyncOnCloseType,
 }
 
 impl IOWriter {
@@ -25,10 +22,9 @@ impl IOWriter {
             file,
             mut filled_serializer_rx,
             reuse_serializer_tx,
-            sync_on_close,
         } = self;
 
-        let file = file.await.unwrap()?;
+        let (file, sync_on_close) = file.await?;
         let mut file: AsyncWriteable = file.try_into_async_writeable()?;
 
         while let Some((handle, permit)) = filled_serializer_rx.recv().await {

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -336,7 +336,6 @@ fn to_graph_rec<'a>(
                 target,
                 unified_sink_args: unified_sink_args.clone(),
                 input_schema,
-                num_pipelines: 0,
             };
 
             ctx.graph
@@ -525,7 +524,6 @@ fn to_graph_rec<'a>(
                 target,
                 unified_sink_args: unified_sink_args.clone(),
                 input_schema,
-                num_pipelines: 0,
             };
 
             ctx.graph


### PR DESCRIPTION
Receive `sync_on_close` and `num_pipelines` from the `start_file_writer` interface of capturing it in the `self` of each file format writer.

Drive-by
* Rename `pipeline_depth` to `num_pipelines` to reduce confusion
