### PR TITLE
chore(rust): Add detailed Sink info to IRNodeProperties

### DIFF
--- a/crates/polars-plan/src/plans/ir/visualization/mod.rs
+++ b/crates/polars-plan/src/plans/ir/visualization/mod.rs
@@ -10,7 +10,7 @@ use polars_utils::unique_id::UniqueId;
 use crate::dsl::{
     GroupbyOptions, HConcatOptions, JoinOptionsIR, JoinTypeOptionsIR, UnifiedScanArgs, UnionOptions,
 };
-use crate::plans::visualization::models::{Edge, IRNodeProperties};
+use crate::plans::visualization::models::{Edge, IRNodeProperties, IntoWithArena, expr_list};
 use crate::plans::{AExpr, ExprIR, FileInfo, IR};
 use crate::prelude::{DistinctOptionsIR, ProjectionOptions};
 
@@ -571,7 +571,7 @@ impl IRVisualizationDataGenerator<'_> {
             },
             IR::Sink { input: _, payload } => {
                 let properties = IRNodeProperties::Sink {
-                    payload: format_pl_smallstr!("{:?}", payload),
+                    payload: payload.into_with_arena(self.expr_arena),
                 };
 
                 IRNodeInfo {
@@ -747,11 +747,4 @@ where
     <U as TryInto<u64>>::Error: std::fmt::Debug,
 {
     slice.map(|(offset, len)| (offset.try_into().unwrap(), len.try_into().unwrap()))
-}
-
-fn expr_list(exprs: &[ExprIR], expr_arena: &Arena<AExpr>) -> Vec<PlSmallStr> {
-    exprs
-        .iter()
-        .map(|e| format_pl_smallstr!("{}", e.display(expr_arena)))
-        .collect()
 }

--- a/crates/polars-plan/src/plans/ir/visualization/models.rs
+++ b/crates/polars-plan/src/plans/ir/visualization/models.rs
@@ -1,9 +1,16 @@
-use polars_core::frame::UniqueKeepStrategy;
-use polars_ops::frame::{JoinCoalesce, JoinValidation, MaintainOrderJoin};
-use polars_utils::pl_str::PlSmallStr;
-use polars_utils::unique_id::UniqueId;
+use std::sync::Arc;
 
-use crate::dsl::PredicateFileSkip;
+use polars_core::frame::UniqueKeepStrategy;
+use polars_io::utils::sync_on_close::SyncOnCloseType;
+use polars_ops::frame::{JoinCoalesce, JoinValidation, MaintainOrderJoin};
+use polars_utils::arena::Arena;
+use polars_utils::pl_str::PlSmallStr;
+use polars_utils::plpath::PlPath;
+use polars_utils::unique_id::UniqueId;
+use polars_utils::{IdxSize, format_pl_smallstr};
+
+use crate::dsl::{PartitionStrategyIR, PredicateFileSkip, SinkTypeIR, SortColumnIR};
+use crate::plans::{AExpr, ExprIR};
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ir_visualization_schema", derive(schemars::JsonSchema))]
@@ -150,7 +157,7 @@ pub enum IRNodeProperties {
         columns: Vec<PlSmallStr>,
     },
     Sink {
-        payload: PlSmallStr,
+        payload: SinkType,
     },
     SinkMultiple {
         num_inputs: u64,
@@ -240,4 +247,216 @@ pub enum IRNodeProperties {
         is_pure: bool,
         validate_schema: bool,
     },
+}
+
+pub trait FromWithArena<T>: Sized {
+    fn from_with_arena(value: T, expr_arena: &Arena<AExpr>) -> Self;
+}
+
+pub trait IntoWithArena<T> {
+    fn into_with_arena(self, expr_arena: &Arena<AExpr>) -> T;
+}
+
+impl<T, U> IntoWithArena<U> for T
+where
+    U: FromWithArena<T>,
+{
+    fn into_with_arena(self, expr_arena: &Arena<AExpr>) -> U {
+        U::from_with_arena(self, expr_arena)
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ir_visualization_schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, PartialEq)]
+pub enum SinkType {
+    Memory,
+    Callback(CallbackSinkType),
+    File(FileSinkOptions),
+    #[cfg_attr(all(feature = "serde", not(feature = "ir_serde")), serde(skip))]
+    Partitioned(PartitionedSinkOptions),
+}
+
+impl FromWithArena<&SinkTypeIR> for SinkType {
+    fn from_with_arena(value: &SinkTypeIR, expr_arena: &Arena<AExpr>) -> Self {
+        match value {
+            SinkTypeIR::Memory => Self::Memory,
+            SinkTypeIR::Callback(c) => Self::Callback(CallbackSinkType {
+                maintain_order: c.maintain_order,
+                chunk_size: c.chunk_size,
+            }),
+            SinkTypeIR::File(f) => Self::File(FileSinkOptions {
+                target: (&f.target).into(),
+                file_format: f.file_format.as_ref().into(),
+                mkdir: f.unified_sink_args.mkdir,
+                maintain_order: f.unified_sink_args.maintain_order,
+                sync_on_close: f.unified_sink_args.sync_on_close,
+            }),
+            SinkTypeIR::Partitioned(p) => Self::Partitioned(PartitionedSinkOptions {
+                base_path: p.base_path.clone(),
+                file_path_provider: (&p.file_path_provider).into(),
+                partition_strategy: (&p.partition_strategy).into_with_arena(expr_arena),
+                file_format: p.file_format.as_ref().into(),
+                mkdir: p.unified_sink_args.mkdir,
+                maintain_order: p.unified_sink_args.maintain_order,
+                sync_on_close: p.unified_sink_args.sync_on_close,
+                max_rows_per_file: p.max_rows_per_file,
+                approximate_bytes_per_file: p.approximate_bytes_per_file,
+            }),
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ir_visualization_schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, PartialEq, Hash)]
+pub struct CallbackSinkType {
+    pub maintain_order: bool,
+    pub chunk_size: Option<std::num::NonZeroUsize>,
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ir_visualization_schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Hash, PartialEq)]
+pub struct FileSinkOptions {
+    pub target: SinkTarget,
+    pub file_format: FileType,
+    pub mkdir: bool,
+    pub maintain_order: bool,
+    pub sync_on_close: SyncOnCloseType,
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ir_visualization_schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum SinkTarget {
+    Path(PlPath),
+    Dyn,
+}
+
+impl From<&crate::dsl::SinkTarget> for SinkTarget {
+    fn from(value: &crate::dsl::SinkTarget) -> Self {
+        match value {
+            crate::dsl::SinkTarget::Path(path) => Self::Path(path.to_owned()),
+            crate::dsl::SinkTarget::Dyn(_) => Self::Dyn,
+        }
+    }
+}
+
+#[cfg_attr(feature = "ir_serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ir_visualization_schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, PartialEq)]
+pub struct PartitionedSinkOptions {
+    pub base_path: PlPath,
+    pub file_path_provider: FileProviderType,
+    pub partition_strategy: PartitionStrategy,
+    pub file_format: FileType,
+    pub mkdir: bool,
+    pub maintain_order: bool,
+    pub sync_on_close: SyncOnCloseType,
+    pub max_rows_per_file: IdxSize,
+    pub approximate_bytes_per_file: u64,
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ir_visualization_schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Hash, PartialEq)]
+pub enum FileProviderType {
+    Hive { extension: PlSmallStr },
+    Function,
+    Legacy,
+}
+
+impl From<&crate::dsl::sink2::FileProviderType> for FileProviderType {
+    fn from(value: &crate::dsl::sink2::FileProviderType) -> Self {
+        match value {
+            crate::dsl::sink2::FileProviderType::Hive { extension } => Self::Hive {
+                extension: extension.to_owned(),
+            },
+            crate::dsl::sink2::FileProviderType::Function(_) => Self::Function,
+            crate::dsl::sink2::FileProviderType::Legacy(_) => Self::Legacy,
+        }
+    }
+}
+
+#[cfg_attr(feature = "ir_serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ir_visualization_schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, PartialEq)]
+pub enum PartitionStrategy {
+    Keyed {
+        keys: Vec<PlSmallStr>,
+        include_keys: bool,
+        keys_pregrouped: bool,
+        pre_partition_sort_by: Vec<SortColumn>,
+    },
+    FileSize,
+}
+
+impl FromWithArena<&PartitionStrategyIR> for PartitionStrategy {
+    fn from_with_arena(value: &PartitionStrategyIR, expr_arena: &Arena<AExpr>) -> Self {
+        match value {
+            PartitionStrategyIR::Keyed {
+                keys,
+                include_keys,
+                keys_pre_grouped,
+                per_partition_sort_by,
+            } => Self::Keyed {
+                keys: expr_list(keys, expr_arena),
+                include_keys: *include_keys,
+                keys_pregrouped: *keys_pre_grouped,
+                pre_partition_sort_by: per_partition_sort_by
+                    .iter()
+                    .map(
+                        |SortColumnIR {
+                             expr,
+                             descending,
+                             nulls_last,
+                         }| SortColumn {
+                            expr: format_pl_smallstr!("{}", expr.display(expr_arena)),
+                            descending: *descending,
+                            nulls_last: *nulls_last,
+                        },
+                    )
+                    .collect(),
+            },
+            PartitionStrategyIR::FileSize => Self::FileSize,
+        }
+    }
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ir_visualization_schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Hash, PartialEq)]
+pub enum FileType {
+    Parquet,
+    Ipc,
+    Csv,
+    Json,
+}
+
+impl From<&crate::dsl::FileType> for FileType {
+    fn from(value: &crate::dsl::FileType) -> Self {
+        match value {
+            crate::dsl::FileType::Parquet(_) => FileType::Parquet,
+            crate::dsl::FileType::Ipc(_) => FileType::Ipc,
+            crate::dsl::FileType::Csv(_) => FileType::Csv,
+            crate::dsl::FileType::Json(_) => FileType::Json,
+        }
+    }
+}
+
+#[cfg_attr(feature = "ir_serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ir_visualization_schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SortColumn {
+    pub expr: PlSmallStr,
+    pub descending: bool,
+    pub nulls_last: bool,
+}
+
+pub fn expr_list(exprs: &[ExprIR], expr_arena: &Arena<AExpr>) -> Vec<PlSmallStr> {
+    exprs
+        .iter()
+        .map(|e| format_pl_smallstr!("{}", e.display(expr_arena)))
+        .collect()
 }


### PR DESCRIPTION
Currently the IRNodeProperties::Sink variant just contains a debug string of the sink type as `payload`. This PR changes this to add more detailed info.