### PR TITLE
refactor(rust): Allow multiple inputs to streaming GroupBy node

### DIFF
--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -523,14 +523,27 @@ fn visualize_plan_rec(
 
             (out, &[][..])
         },
-        PhysNodeKind::GroupBy { input, key, aggs } => (
-            format!(
-                "group-by\\nkey:\\n{}\\naggs:\\n{}",
-                fmt_exprs_to_label(key, expr_arena, FormatExprStyle::Select),
-                fmt_exprs_to_label(aggs, expr_arena, FormatExprStyle::Select)
-            ),
-            from_ref(input),
-        ),
+        PhysNodeKind::GroupBy {
+            inputs,
+            key_per_input,
+            aggs_per_input,
+        } => {
+            let mut out = String::new();
+            for (key, aggs) in key_per_input.iter().zip(aggs_per_input) {
+                if !out.is_empty() {
+                    out.push('\n');
+                }
+
+                write!(
+                    &mut out,
+                    "group-by\\nkey:\\n{}\\naggs:\\n{}",
+                    fmt_exprs_to_label(key, expr_arena, FormatExprStyle::Select),
+                    fmt_exprs_to_label(aggs, expr_arena, FormatExprStyle::Select)
+                )
+                .ok();
+            }
+            (out, inputs.as_slice())
+        },
         #[cfg(feature = "dynamic_group_by")]
         PhysNodeKind::DynamicGroupBy {
             input,

--- a/crates/polars-stream/src/physical_plan/lower_group_by.rs
+++ b/crates/polars-stream/src/physical_plan/lower_group_by.rs
@@ -491,9 +491,9 @@ fn try_build_streaming_group_by(
     let agg_node = phys_sm.insert(PhysNode::new(
         group_by_output_schema.clone(),
         PhysNodeKind::GroupBy {
-            input: pre_select,
-            key: trans_keys,
-            aggs: trans_agg_exprs,
+            inputs: vec![pre_select],
+            key_per_input: vec![trans_keys],
+            aggs_per_input: vec![trans_agg_exprs],
         },
     ));
 

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -932,50 +932,71 @@ fn to_graph_rec<'a>(
             )
         },
 
-        GroupBy { input, key, aggs } => {
-            let input_key = to_graph_rec(input.node, ctx)?;
-
-            let input_schema = &ctx.phys_sm[input.node].output_schema;
-            let key_schema = compute_output_schema(input_schema, key, ctx.expr_arena)?;
-            let grouper = new_hash_grouper(key_schema.clone());
-
-            let key_selectors = key
-                .iter()
-                .map(|e| create_stream_expr(e, ctx, input_schema))
-                .try_collect_vec()?;
-
+        GroupBy {
+            inputs,
+            key_per_input,
+            aggs_per_input,
+        } => {
+            let mut key_ports = Vec::new();
+            let mut key_schema_per_input = Vec::new();
+            let mut key_selectors_per_input = Vec::new();
+            let mut reductions_per_input = Vec::new();
             let mut grouped_reductions = Vec::new();
             let mut grouped_reduction_cols = Vec::new();
             let mut has_order_sensitive_agg = false;
-            for agg in aggs {
-                has_order_sensitive_agg |= matches!(
-                    ctx.expr_arena.get(agg.node()),
-                    AExpr::Agg(
-                        IRAggExpr::First(_)
-                            | IRAggExpr::FirstNonNull(_)
-                            | IRAggExpr::Last(_)
-                            | IRAggExpr::LastNonNull(_)
-                    )
-                );
-                let (reduction, input_nodes) =
-                    into_reduction(agg.node(), ctx.expr_arena, input_schema)?;
-                let cols = input_nodes
+            for ((input, key), aggs) in inputs.iter().zip(key_per_input).zip(aggs_per_input) {
+                let input_key = to_graph_rec(input.node, ctx)?;
+                key_ports.push((input_key, input.port));
+
+                let input_schema = &ctx.phys_sm[input.node].output_schema;
+                let key_schema = compute_output_schema(input_schema, key, ctx.expr_arena)?;
+                key_schema_per_input.push(key_schema);
+
+                let key_selectors = key
                     .iter()
-                    .map(|node| {
-                        let AExpr::Column(col) = ctx.expr_arena.get(*node) else {
-                            unreachable!()
-                        };
-                        col.clone()
-                    })
-                    .collect();
-                grouped_reductions.push(reduction);
-                grouped_reduction_cols.push(cols);
+                    .map(|e| create_stream_expr(e, ctx, input_schema))
+                    .try_collect_vec()?;
+                key_selectors_per_input.push(key_selectors);
+
+                let mut reductions_for_this_input = Vec::new();
+                for agg in aggs {
+                    has_order_sensitive_agg |= matches!(
+                        ctx.expr_arena.get(agg.node()),
+                        AExpr::Agg(
+                            IRAggExpr::First(_)
+                                | IRAggExpr::FirstNonNull(_)
+                                | IRAggExpr::Last(_)
+                                | IRAggExpr::LastNonNull(_)
+                        )
+                    );
+                    let (reduction, input_nodes) =
+                        into_reduction(agg.node(), ctx.expr_arena, input_schema)?;
+                    let cols = input_nodes
+                        .iter()
+                        .map(|node| {
+                            let AExpr::Column(col) = ctx.expr_arena.get(*node) else {
+                                unreachable!()
+                            };
+                            col.clone()
+                        })
+                        .collect();
+                    reductions_for_this_input.push(grouped_reductions.len());
+                    grouped_reductions.push(reduction);
+                    grouped_reduction_cols.push(cols);
+                }
+
+                reductions_per_input.push(reductions_for_this_input);
             }
 
+            let key_schema = key_schema_per_input.swap_remove(0);
+            assert!(key_schema_per_input.iter().all(|s| **s == *key_schema));
+
+            let grouper = new_hash_grouper(key_schema.clone());
             ctx.graph.add_node(
                 nodes::group_by::GroupByNode::new(
                     key_schema,
-                    key_selectors,
+                    key_selectors_per_input,
+                    reductions_per_input,
                     grouper,
                     grouped_reduction_cols,
                     grouped_reductions,
@@ -984,7 +1005,7 @@ fn to_graph_rec<'a>(
                     ctx.num_pipelines,
                     has_order_sensitive_agg,
                 ),
-                [(input_key, input.port)],
+                key_ports,
             )
         },
 

--- a/crates/polars-stream/src/physical_plan/visualization/mod.rs
+++ b/crates/polars-stream/src/physical_plan/visualization/mod.rs
@@ -149,12 +149,26 @@ impl PhysicalPlanVisualizationDataGenerator<'_> {
                     ..Default::default()
                 }
             },
-            PhysNodeKind::GroupBy { input, key, aggs } => {
-                phys_node_inputs.push(input.node);
+            PhysNodeKind::GroupBy {
+                inputs,
+                key_per_input,
+                aggs_per_input,
+            } => {
+                for input in inputs {
+                    phys_node_inputs.push(input.node);
+                }
 
+                let key_per_input: Vec<_> = key_per_input
+                    .iter()
+                    .map(|key| expr_list(key, self.expr_arena))
+                    .collect();
+                let aggs_per_input: Vec<_> = aggs_per_input
+                    .iter()
+                    .map(|aggs| expr_list(aggs, self.expr_arena))
+                    .collect();
                 let properties = PhysNodeProperties::GroupBy {
-                    keys: expr_list(key, self.expr_arena),
-                    aggs: expr_list(aggs, self.expr_arena),
+                    key_per_input,
+                    aggs_per_input,
                 };
 
                 PhysNodeInfo {

--- a/crates/polars-stream/src/physical_plan/visualization/models.rs
+++ b/crates/polars-stream/src/physical_plan/visualization/models.rs
@@ -96,8 +96,8 @@ pub enum PhysNodeProperties {
         offset: u64,
     },
     GroupBy {
-        keys: Vec<PlSmallStr>,
-        aggs: Vec<PlSmallStr>,
+        key_per_input: Vec<Vec<PlSmallStr>>,
+        aggs_per_input: Vec<Vec<PlSmallStr>>,
     },
     #[cfg(feature = "dynamic_group_by")]
     DynamicGroupBy {


### PR DESCRIPTION
Being able to pipe input into a `GroupBy` node from multiple input streams is a prerequisite for lowering grouped `n_unique` and `filter` when next to other expressions. No functional change yet, just plumbing.