### PR TITLE
refactor: Disable HTTP timeout for receiving response body

### DIFF
--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -212,7 +212,7 @@ pub(super) fn get_client_options() -> ClientOptions {
                         })
                         .get()
                 })
-                .unwrap_or(3 * 60),
+                .unwrap_or(5 * 60),
         ))
         .with_user_agent(HeaderValue::from_static(USER_AGENT))
         .with_allow_http(true)


### PR DESCRIPTION
ref https://github.com/pola-rs/polars/issues/25762#issuecomment-3671999631, the deadlock in the issue has to do only with the connect phase of the request.

#### Changes
* Revert to `with_timeout_disabled()`, as this timeout is measured against the total request time.
* Reduce the default connect phase timeout from 10 minutes to 5 minutes.
