### PR TITLE
fix: Fix varying block metadata length in IPC reader

### DIFF
--- a/crates/polars-arrow/src/io/ipc/read/file.rs
+++ b/crates/polars-arrow/src/io/ipc/read/file.rs
@@ -346,13 +346,13 @@ pub fn read_batch<R: Read + Seek>(
     limit: Option<usize>,
     index: usize,
     // When true, the reader object is handled as an IPC Block.
-    block_mode: bool,
+    force_zero_offset: bool,
     message_scratch: &mut Vec<u8>,
     data_scratch: &mut Vec<u8>,
 ) -> PolarsResult<RecordBatchT<Box<dyn Array>>> {
     let block = metadata.blocks[index];
 
-    let offset: u64 = if block_mode {
+    let offset: u64 = if force_zero_offset {
         0
     } else {
         block

--- a/crates/polars-stream/src/nodes/io_sources/ipc/record_batch_decode.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ipc/record_batch_decode.rs
@@ -33,6 +33,7 @@ impl RecordBatchDecoder {
         let pl_schema = self.pl_schema.clone();
         let projection_info = self.projection_info.as_ref().clone();
         let bytes = record_batch_data.fetched_bytes;
+        let block_index = record_batch_data.block_index;
 
         let mut reader = BlockReader::new(Cursor::new(bytes.as_ref()));
         let dictionaries = self.dictionaries.as_ref().as_ref().unwrap();
@@ -53,7 +54,7 @@ impl RecordBatchDecoder {
                 &file_metadata.clone(),
                 projection_info.as_ref().map(|x| x.columns.as_ref()),
                 limit,
-                0,
+                block_index,
                 true,
                 &mut message_scratch,
                 &mut data_scratch,


### PR DESCRIPTION
fixes #25974 

The block index was not passed through correctly, which caused the block metadata length to be incorrect when it changes between record batches, resulting in incorrect data or read errors.

(Bug introduced here https://github.com/pola-rs/polars/pull/25868).