### PR TITLE
refactor(rust): Cleanup Rust DataFrame interface

### DIFF
--- a/crates/polars-core/src/chunked_array/ndarray.rs
+++ b/crates/polars-core/src/chunked_array/ndarray.rs
@@ -86,7 +86,7 @@ impl DataFrame {
     /// let a = UInt32Chunked::new("a".into(), &[1, 2, 3]).into_column();
     /// let b = Float64Chunked::new("b".into(), &[10., 8., 6.]).into_column();
     ///
-    /// let df = DataFrame::new(vec![a, b]).unwrap();
+    /// let df = DataFrame::new_infer_height(vec![a, b]).unwrap();
     /// let ndarray = df.to_ndarray::<Float64Type>(IndexOrder::Fortran).unwrap();
     /// println!("{:?}", ndarray);
     /// ```
@@ -105,7 +105,7 @@ impl DataFrame {
         let mut membuf = Vec::with_capacity(shape.0 * shape.1);
         let ptr = membuf.as_ptr() as usize;
 
-        let columns = self.get_columns();
+        let columns = self.columns();
         POOL.install(|| {
             columns.par_iter().enumerate().try_for_each(|(col_idx, s)| {
                 let s = s.as_materialized_series().cast(&N::get_static_dtype())?;

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -1002,7 +1002,7 @@ mod test {
             PlSmallStr::from_static("c"),
             &["a", "b", "c", "d", "e", "f", "g", "h"],
         );
-        let df = DataFrame::new(vec![
+        let df = DataFrame::new_infer_height(vec![
             a.into_series().into(),
             b.into_series().into(),
             c.into_series().into(),
@@ -1030,7 +1030,7 @@ mod test {
         )
         .into_series();
         let b = Int32Chunked::new(PlSmallStr::from_static("b"), &[5, 4, 2, 3, 4, 5]).into_series();
-        let df = DataFrame::new(vec![a.into(), b.into()])?;
+        let df = DataFrame::new_infer_height(vec![a.into(), b.into()])?;
 
         let out = df.sort(["a", "b"], SortMultipleOptions::default())?;
         let expected = df!(

--- a/crates/polars-core/src/chunked_array/struct_/frame.rs
+++ b/crates/polars-core/src/chunked_array/struct_/frame.rs
@@ -5,6 +5,6 @@ use crate::prelude::StructChunked;
 
 impl DataFrame {
     pub fn into_struct(self, name: PlSmallStr) -> StructChunked {
-        StructChunked::from_columns(name, self.height(), &self.columns).expect("same invariants")
+        StructChunked::from_columns(name, self.height(), self.columns()).unwrap()
     }
 }

--- a/crates/polars-core/src/chunked_array/struct_/mod.rs
+++ b/crates/polars-core/src/chunked_array/struct_/mod.rs
@@ -450,7 +450,7 @@ impl StructChunked {
             .collect::<Vec<_>>();
 
         // SAFETY: invariants for struct are the same
-        unsafe { DataFrame::new_no_checks(self.len(), columns) }
+        unsafe { DataFrame::new_unchecked(self.len(), columns) }
     }
 
     /// Get access to one of this [`StructChunked`]'s fields

--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -590,7 +590,7 @@ impl Display for DataFrame {
         {
             let height = self.height();
             assert!(
-                self.columns.iter().all(|s| s.len() == height),
+                self.columns().iter().all(|s| s.len() == height),
                 "The column lengths in the DataFrame are not equal."
             );
 
@@ -666,7 +666,7 @@ impl Display for DataFrame {
 
                     for i in 0..(half + rest) {
                         let row = self
-                            .get_columns()
+                            .columns()
                             .iter()
                             .map(|c| c.str_value(i).unwrap())
                             .collect();
@@ -687,7 +687,7 @@ impl Display for DataFrame {
 
                     for i in (height - half)..height {
                         let row = self
-                            .get_columns()
+                            .columns()
                             .iter()
                             .map(|c| c.str_value(i).unwrap())
                             .collect();
@@ -728,7 +728,7 @@ impl Display for DataFrame {
                     }
                 }
             } else if height > 0 {
-                let dots: Vec<String> = vec![ellipsis; self.columns.len()];
+                let dots: Vec<String> = vec![ellipsis; self.width()];
                 table.add_row(dots);
             }
             let tbl_fallback_width = 100;

--- a/crates/polars-core/src/frame/broadcast.rs
+++ b/crates/polars-core/src/frame/broadcast.rs
@@ -1,0 +1,45 @@
+use polars_error::{PolarsResult, polars_bail};
+
+use crate::frame::column::Column;
+
+pub(super) fn infer_broadcast_height(columns: &[Column]) -> usize {
+    if columns.is_empty() {
+        return 0;
+    }
+
+    columns
+        .iter()
+        .map(|c| c.len())
+        .find(|len| *len != 1)
+        .unwrap_or(1)
+}
+
+/// Broadcasts to `height`. Errors if a column has non-unit length that does not match `height`.
+/// Does not check name duplicates.
+pub(super) fn broadcast_columns(height: usize, columns: &mut [Column]) -> PolarsResult<()> {
+    for col in columns.iter_mut() {
+        // Length not equal to the broadcast len, needs broadcast or is an error.
+        let len = col.len();
+        if len != height {
+            if len != 1 {
+                let name = col.name().clone();
+
+                let extra_info = if let Some(c) = columns.iter().find(|c| c.len() == height) {
+                    format!(" (matching column '{}')", c.name())
+                } else {
+                    String::new()
+                };
+
+                polars_bail!(
+                    ShapeMismatch:
+                    "could not create a new DataFrame: \
+                    series {name:?} has length {len} \
+                    while trying to broadcast to length {height}{extra_info}",
+                );
+            }
+            *col = col.new_from_index(0, height);
+        }
+    }
+
+    Ok(())
+}

--- a/crates/polars-core/src/frame/builder.rs
+++ b/crates/polars-core/src/frame/builder.rs
@@ -47,7 +47,7 @@ impl DataFrameBuilder {
 
         // SAFETY: we checked the lengths and the names are unique because they
         // come from Schema.
-        unsafe { DataFrame::new_no_checks(self.height, columns) }
+        unsafe { DataFrame::new_unchecked(self.height, columns) }
     }
 
     pub fn freeze_reset(&mut self) -> DataFrame {
@@ -64,7 +64,7 @@ impl DataFrameBuilder {
 
         // SAFETY: we checked the lengths and the names are unique because they
         // come from Schema.
-        let out = unsafe { DataFrame::new_no_checks(self.height, columns) };
+        let out = unsafe { DataFrame::new_unchecked(self.height, columns) };
         self.height = 0;
         out
     }
@@ -93,7 +93,7 @@ impl DataFrameBuilder {
         length: usize,
         share: ShareStrategy,
     ) {
-        let columns = other.get_columns();
+        let columns = other.columns();
         assert!(self.builders.len() == columns.len());
         for (builder, column) in self.builders.iter_mut().zip(columns) {
             match column {
@@ -121,7 +121,7 @@ impl DataFrameBuilder {
         repeats: usize,
         share: ShareStrategy,
     ) {
-        let columns = other.get_columns();
+        let columns = other.columns();
         assert!(self.builders.len() == columns.len());
         for (builder, column) in self.builders.iter_mut().zip(columns) {
             match column {
@@ -150,7 +150,7 @@ impl DataFrameBuilder {
         repeats: usize,
         share: ShareStrategy,
     ) {
-        let columns = other.get_columns();
+        let columns = other.columns();
         assert!(self.builders.len() == columns.len());
         for (builder, column) in self.builders.iter_mut().zip(columns) {
             match column {
@@ -181,7 +181,7 @@ impl DataFrameBuilder {
         idxs: &[IdxSize],
         share: ShareStrategy,
     ) {
-        let columns = other.get_columns();
+        let columns = other.columns();
         assert!(self.builders.len() == columns.len());
         for (builder, column) in self.builders.iter_mut().zip(columns) {
             match column {
@@ -205,7 +205,7 @@ impl DataFrameBuilder {
     /// other dataframe is not rechunked.
     pub fn opt_gather_extend(&mut self, other: &DataFrame, idxs: &[IdxSize], share: ShareStrategy) {
         let mut trans_idxs = Vec::new();
-        let columns = other.get_columns();
+        let columns = other.columns();
         assert!(self.builders.len() == columns.len());
         for (builder, column) in self.builders.iter_mut().zip(columns) {
             match column {

--- a/crates/polars-core/src/frame/chunks.rs
+++ b/crates/polars-core/src/frame/chunks.rs
@@ -30,7 +30,7 @@ impl From<RecordBatch> for DataFrame {
             .collect();
 
         // SAFETY: RecordBatch has the same invariants for names and heights as DataFrame.
-        unsafe { DataFrame::new_no_checks(height, columns) }
+        unsafe { DataFrame::new_unchecked(height, columns) }
     }
 }
 
@@ -39,7 +39,7 @@ impl DataFrame {
         self.align_chunks_par();
 
         let first_series_col_idx = self
-            .columns
+            .columns()
             .iter()
             .position(|col| col.as_series().is_some());
         let df_height = self.height();
@@ -48,10 +48,10 @@ impl DataFrame {
             // There might still be scalar/partitioned columns after aligning,
             // so we follow the size of the chunked column, if any.
             let chunk_size = first_series_col_idx
-                .map(|c| self.get_columns()[c].as_series().unwrap().chunks()[i].len())
+                .map(|c| self.columns()[c].as_series().unwrap().chunks()[i].len())
                 .unwrap_or(df_height);
             let columns = self
-                .get_columns()
+                .columns()
                 .iter()
                 .map(|col| match col {
                     Column::Series(s) => Column::from(s.select_chunk(i)),
@@ -61,7 +61,7 @@ impl DataFrame {
 
             prev_height += chunk_size;
 
-            DataFrame::new_no_checks(chunk_size, columns)
+            DataFrame::new_unchecked(chunk_size, columns)
         })
     }
 
@@ -92,8 +92,8 @@ pub fn chunk_df_for_writing(
 
     // Accumulate many small chunks to the row group size.
     // See: #16403
-    if !df.get_columns().is_empty()
-        && df.get_columns()[0]
+    if !df.columns().is_empty()
+        && df.columns()[0]
             .as_materialized_series()
             .chunk_lengths()
             .take(5)
@@ -101,7 +101,7 @@ pub fn chunk_df_for_writing(
     {
         fn finish(scratch: &mut Vec<DataFrame>, new_chunks: &mut Vec<DataFrame>) {
             let mut new = accumulate_dataframes_vertical_unchecked(scratch.drain(..));
-            new.as_single_chunk_par();
+            new.rechunk_mut_par();
             new_chunks.push(new);
         }
 
@@ -136,7 +136,7 @@ pub fn chunk_df_for_writing(
             // merge them.
             let n_chunks = df.first_col_n_chunks();
             if n_chunks > 1 && (df.estimated_size() / n_chunks < 128 * 1024) {
-                df.as_single_chunk_par();
+                df.rechunk_mut_par();
             }
         }
 

--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -1147,7 +1147,7 @@ impl Column {
 
     pub fn into_frame(self) -> DataFrame {
         // SAFETY: A single-column dataframe cannot have length mismatches or duplicate names
-        unsafe { DataFrame::new_no_checks(self.len(), vec![self]) }
+        unsafe { DataFrame::new_unchecked(self.len(), vec![self]) }
     }
 
     pub fn extend(&mut self, other: &Column) -> PolarsResult<&mut Self> {

--- a/crates/polars-core/src/frame/dataframe.rs
+++ b/crates/polars-core/src/frame/dataframe.rs
@@ -1,0 +1,377 @@
+use std::sync::{Arc, OnceLock};
+
+use polars_error::PolarsResult;
+
+use super::broadcast::{broadcast_columns, infer_broadcast_height};
+use super::validation::validate_columns_slice;
+use crate::frame::column::Column;
+use crate::schema::{Schema, SchemaRef};
+
+/// A contiguous growable collection of [`Column`]s that have the same length.
+///
+/// ## Use declarations
+///
+/// All the common tools can be found in [`crate::prelude`] (or in `polars::prelude`).
+///
+/// ```rust
+/// use polars_core::prelude::*; // if the crate polars-core is used directly
+/// // use polars::prelude::*;      if the crate polars is used
+/// ```
+///
+/// # Initialization
+/// ## Default
+///
+/// A `DataFrame` can be initialized empty:
+///
+/// ```rust
+/// # use polars_core::prelude::*;
+/// let df = DataFrame::empty();
+/// assert_eq!(df.shape(), (0, 0));
+/// ```
+///
+/// ## Wrapping a `Vec<Series>`
+///
+/// A `DataFrame` is built upon a `Vec<Series>` where the `Series` have the same length.
+///
+/// ```rust
+/// # use polars_core::prelude::*;
+/// let s1 = Column::new("Fruit".into(), ["Apple", "Apple", "Pear"]);
+/// let s2 = Column::new("Color".into(), ["Red", "Yellow", "Green"]);
+///
+/// let df: PolarsResult<DataFrame> = DataFrame::new_infer_height(vec![s1, s2]);
+/// ```
+///
+/// ## Using a macro
+///
+/// The [`df!`] macro is a convenient method:
+///
+/// ```rust
+/// # use polars_core::prelude::*;
+/// let df: PolarsResult<DataFrame> = df!("Fruit" => ["Apple", "Apple", "Pear"],
+///                                       "Color" => ["Red", "Yellow", "Green"]);
+/// ```
+///
+/// ## Using a CSV file
+///
+/// See the `polars_io::csv::CsvReader`.
+///
+/// # Indexing
+/// ## By a number
+///
+/// The `Index<usize>` is implemented for the `DataFrame`.
+///
+/// ```rust
+/// # use polars_core::prelude::*;
+/// let df = df!("Fruit" => ["Apple", "Apple", "Pear"],
+///              "Color" => ["Red", "Yellow", "Green"])?;
+///
+/// assert_eq!(df[0], Column::new("Fruit".into(), &["Apple", "Apple", "Pear"]));
+/// assert_eq!(df[1], Column::new("Color".into(), &["Red", "Yellow", "Green"]));
+/// # Ok::<(), PolarsError>(())
+/// ```
+///
+/// ## By a `Series` name
+///
+/// ```rust
+/// # use polars_core::prelude::*;
+/// let df = df!("Fruit" => ["Apple", "Apple", "Pear"],
+///              "Color" => ["Red", "Yellow", "Green"])?;
+///
+/// assert_eq!(df["Fruit"], Column::new("Fruit".into(), &["Apple", "Apple", "Pear"]));
+/// assert_eq!(df["Color"], Column::new("Color".into(), &["Red", "Yellow", "Green"]));
+/// # Ok::<(), PolarsError>(())
+/// ```
+#[derive(Clone)]
+pub struct DataFrame {
+    height: usize,
+    /// All columns must have length equal to `self.height`.
+    columns: Vec<Column>,
+    /// Cached schema. Must be cleared if column names / dtypes in `self.columns` change.
+    cached_schema: OnceLock<SchemaRef>,
+}
+
+impl Default for DataFrame {
+    fn default() -> Self {
+        DataFrame::empty()
+    }
+}
+
+impl DataFrame {
+    /// Creates an empty `DataFrame` usable in a compile time context (such as static initializers).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use polars_core::prelude::DataFrame;
+    /// static EMPTY: DataFrame = DataFrame::empty();
+    /// ```
+    pub const fn empty() -> Self {
+        DataFrame::empty_with_height(0)
+    }
+
+    pub const fn empty_with_height(height: usize) -> Self {
+        DataFrame {
+            height,
+            columns: vec![],
+            cached_schema: OnceLock::new(),
+        }
+    }
+
+    pub fn new(height: usize, columns: Vec<Column>) -> PolarsResult<Self> {
+        let columns: Vec<Column> = columns.into_iter().collect();
+
+        validate_columns_slice(height, &columns)
+            .map_err(|e| e.wrap_msg(|e| format!("could not create a new DataFrame: {e}")))?;
+
+        Ok(unsafe { DataFrame::_new_unchecked_impl(height, columns) })
+    }
+
+    /// Height is sourced from first column.
+    pub fn new_infer_height(columns: Vec<Column>) -> PolarsResult<Self> {
+        DataFrame::new(columns.first().map_or(0, |c| c.len()), columns)
+    }
+
+    /// Create a new `DataFrame` but does not check the length or duplicate occurrence of the
+    /// [`Column`]s.
+    ///
+    /// # Safety
+    /// [`Column`]s must have unique names and matching lengths.
+    pub unsafe fn new_unchecked(height: usize, columns: Vec<Column>) -> DataFrame {
+        if cfg!(debug_assertions) {
+            validate_columns_slice(height, &columns).unwrap();
+        }
+
+        unsafe { DataFrame::_new_unchecked_impl(height, columns) }
+    }
+
+    /// Height is sourced from first column. Does not check for matching height / duplicate names.
+    ///
+    /// # Safety
+    /// [`Column`]s must have unique names and matching lengths.
+    pub unsafe fn new_unchecked_infer_height(columns: Vec<Column>) -> DataFrame {
+        DataFrame::new_unchecked(columns.first().map_or(0, |c| c.len()), columns)
+    }
+
+    /// This will not panic even in debug mode - there are some (rare) use cases where a DataFrame
+    /// is temporarily constructed containing duplicates for dispatching to functions. A DataFrame
+    /// constructed with this method is generally highly unsafe and should not be long-lived.
+    #[expect(clippy::missing_safety_doc)]
+    pub const unsafe fn _new_unchecked_impl(height: usize, columns: Vec<Column>) -> DataFrame {
+        DataFrame {
+            height,
+            columns,
+            cached_schema: OnceLock::new(),
+        }
+    }
+
+    /// Broadcasts unit-length columns to `height`. Errors if a column has height that is non-unit
+    /// length and not equal to `self.height()`.
+    pub fn new_with_broadcast(height: usize, mut columns: Vec<Column>) -> PolarsResult<Self> {
+        broadcast_columns(height, &mut columns)?;
+        DataFrame::new(height, columns)
+    }
+
+    /// Infers height as the first non-unit length column or 1 if not found.
+    pub fn new_infer_broadcast(columns: Vec<Column>) -> PolarsResult<Self> {
+        DataFrame::new_with_broadcast(infer_broadcast_height(&columns), columns)
+    }
+
+    /// Broadcasts unit-length columns to `height`. Errors if a column has height that is non-unit
+    /// length and not equal to `self.height()`.
+    ///
+    /// # Safety
+    /// [`Column`]s must have unique names.
+    pub unsafe fn new_unchecked_with_broadcast(
+        height: usize,
+        mut columns: Vec<Column>,
+    ) -> PolarsResult<Self> {
+        broadcast_columns(height, &mut columns)?;
+        Ok(unsafe { DataFrame::new_unchecked(height, columns) })
+    }
+
+    /// # Safety
+    /// [`Column`]s must have unique names.
+    pub unsafe fn new_unchecked_infer_broadcast(columns: Vec<Column>) -> PolarsResult<Self> {
+        DataFrame::new_unchecked_with_broadcast(infer_broadcast_height(&columns), columns)
+    }
+
+    /// Create a `DataFrame` 0 height and columns as per the `schema`.
+    pub fn empty_with_schema(schema: &Schema) -> Self {
+        let cols = schema
+            .iter()
+            .map(|(name, dtype)| Column::new_empty(name.clone(), dtype))
+            .collect();
+
+        unsafe { DataFrame::_new_unchecked_impl(0, cols) }
+    }
+
+    /// Create an empty `DataFrame` with empty columns as per the `schema`.
+    pub fn empty_with_arc_schema(schema: SchemaRef) -> Self {
+        let mut df = DataFrame::empty_with_schema(&schema);
+        unsafe { df.set_schema(schema) };
+        df
+    }
+
+    /// Set the height (i.e. number of rows) of this [`DataFrame`].
+    ///
+    /// # Safety
+    ///
+    /// This needs to be equal to the length of all the columns, or `self.width()` must be 0.
+    #[inline]
+    pub unsafe fn set_height(&mut self, height: usize) -> &mut Self {
+        self.height = height;
+        self
+    }
+
+    /// Get the height of the [`DataFrame`] which is the number of rows.
+    #[inline]
+    pub fn height(&self) -> usize {
+        self.height
+    }
+
+    /// Get the number of columns in this [`DataFrame`].
+    #[inline]
+    pub fn width(&self) -> usize {
+        self.columns.len()
+    }
+
+    /// Get (height, width) of the [`DataFrame`].
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use polars_core::prelude::*;
+    /// let df0: DataFrame = DataFrame::empty();
+    /// let df1: DataFrame = df!("1" => [1, 2, 3, 4, 5])?;
+    /// let df2: DataFrame = df!("1" => [1, 2, 3, 4, 5],
+    ///                          "2" => [1, 2, 3, 4, 5])?;
+    ///
+    /// assert_eq!(df0.shape(), (0 ,0));
+    /// assert_eq!(df1.shape(), (5, 1));
+    /// assert_eq!(df2.shape(), (5, 2));
+    /// # Ok::<(), PolarsError>(())
+    /// ```
+    #[inline]
+    pub fn shape(&self) -> (usize, usize) {
+        (self.height(), self.width())
+    }
+
+    /// 0 width or height.
+    #[inline]
+    pub fn shape_has_zero(&self) -> bool {
+        matches!(self.shape(), (0, _) | (_, 0))
+    }
+
+    #[inline]
+    pub fn columns(&self) -> &[Column] {
+        self.columns.as_slice()
+    }
+
+    #[inline]
+    pub fn into_columns(self) -> Vec<Column> {
+        self.columns
+    }
+
+    /// # Safety
+    ///
+    /// The caller must ensure the length of all [`Column`]s remains equal to `self.height`, or
+    /// that [`DataFrame::set_height`] is called afterwards with the new `height`.
+    #[inline]
+    pub unsafe fn columns_mut(&mut self) -> &mut Vec<Column> {
+        self.clear_schema();
+        &mut self.columns
+    }
+
+    /// # Safety
+    /// Adheres to all safety requirements of [`DataFrame::columns_mut`], and that the list of column
+    /// names remains unchanged.
+    #[inline]
+    pub unsafe fn columns_mut_retain_schema(&mut self) -> &mut Vec<Column> {
+        &mut self.columns
+    }
+
+    /// Get the schema of this [`DataFrame`].
+    ///
+    /// # Panics
+    /// Panics if there are duplicate column names.
+    pub fn schema(&self) -> &SchemaRef {
+        let out = self.cached_schema.get_or_init(|| {
+            Arc::new(
+                Schema::from_iter_check_duplicates(
+                    self.columns
+                        .iter()
+                        .map(|x| (x.name().clone(), x.dtype().clone())),
+                )
+                .unwrap(),
+            )
+        });
+
+        assert_eq!(out.len(), self.width());
+
+        out
+    }
+
+    #[inline]
+    pub fn cached_schema(&self) -> Option<&SchemaRef> {
+        self.cached_schema.get()
+    }
+
+    /// Set the cached schema
+    ///
+    /// # Safety
+    /// Schema must match the columns in `self`.
+    #[inline]
+    pub unsafe fn set_schema(&mut self, schema: SchemaRef) -> &mut Self {
+        self.cached_schema = schema.into();
+        self
+    }
+
+    /// Set the cached schema
+    ///
+    /// # Safety
+    /// Schema must match the columns in `self`.
+    #[inline]
+    pub unsafe fn with_schema(mut self, schema: SchemaRef) -> Self {
+        self.cached_schema = schema.into();
+        self
+    }
+
+    /// Set the cached schema if `schema` is `Some()`.
+    ///
+    /// # Safety
+    /// Schema must match the columns in `self`.
+    #[inline]
+    pub unsafe fn set_opt_schema(&mut self, schema: Option<SchemaRef>) -> &mut Self {
+        if let Some(schema) = schema {
+            unsafe { self.set_schema(schema) };
+        }
+
+        self
+    }
+
+    /// Clones the cached schema from `from` to `self.cached_schema` if there is one.
+    ///
+    /// # Safety
+    /// Schema must match the columns in `self`.
+    #[inline]
+    pub unsafe fn set_schema_from(&mut self, from: &DataFrame) -> &mut Self {
+        self.set_opt_schema(from.cached_schema().cloned());
+        self
+    }
+
+    /// Clones the cached schema from `from` to `self.cached_schema` if there is one.
+    ///
+    /// # Safety
+    /// Schema must match the columns in `self`.
+    #[inline]
+    pub unsafe fn with_schema_from(mut self, from: &DataFrame) -> Self {
+        self.set_opt_schema(from.cached_schema().cloned());
+        self
+    }
+
+    #[inline]
+    fn clear_schema(&mut self) -> &mut Self {
+        self.cached_schema = OnceLock::new();
+        self
+    }
+}

--- a/crates/polars-core/src/frame/filter.rs
+++ b/crates/polars-core/src/frame/filter.rs
@@ -1,0 +1,24 @@
+use polars_error::{PolarsResult, polars_ensure};
+
+use crate::frame::DataFrame;
+use crate::prelude::BooleanChunked;
+
+pub(super) fn filter_zero_width(height: usize, mask: &BooleanChunked) -> PolarsResult<DataFrame> {
+    let new_height = if mask.len() == 1 {
+        match mask.get(0) {
+            Some(true) => height,
+            _ => 0,
+        }
+    } else {
+        polars_ensure!(
+            height == mask.len(),
+            ShapeMismatch:
+            "cannot filter DataFrame of height {} with mask of length {}",
+            height, mask.len(),
+        );
+
+        mask.num_trues()
+    };
+
+    Ok(DataFrame::empty_with_height(new_height))
+}

--- a/crates/polars-core/src/frame/from.rs
+++ b/crates/polars-core/src/frame/from.rs
@@ -4,7 +4,7 @@ impl TryFrom<StructArray> for DataFrame {
     type Error = PolarsError;
 
     fn try_from(arr: StructArray) -> PolarsResult<Self> {
-        let (fld, _length, arrs, nulls) = arr.into_data();
+        let (fld, height, arrs, nulls) = arr.into_data();
         polars_ensure!(
             nulls.is_none(),
             ComputeError: "cannot deserialize struct with nulls into a DataFrame"
@@ -26,6 +26,7 @@ impl TryFrom<StructArray> for DataFrame {
                 .map(Column::from)
             })
             .collect::<PolarsResult<Vec<_>>>()?;
-        DataFrame::new(columns)
+
+        DataFrame::new(height, columns)
     }
 }

--- a/crates/polars-core/src/frame/group_by/mod.rs
+++ b/crates/polars-core/src/frame/group_by/mod.rs
@@ -63,7 +63,7 @@ impl DataFrame {
         } else if by.iter().any(|s| s.dtype().is_object()) {
             #[cfg(feature = "object")]
             {
-                let mut df = DataFrame::new(by.clone()).unwrap();
+                let mut df = DataFrame::new(self.height(), by.clone()).unwrap();
                 let n = df.height();
                 let rows = df.to_av_rows();
                 let iter = (0..n).map(|i| rows.get(i));
@@ -81,11 +81,12 @@ impl DataFrame {
                 .cloned()
                 .collect::<Vec<_>>();
             if by.is_empty() {
-                let groups = if self.is_empty() {
+                let groups = if self.height() == 0 {
                     vec![]
                 } else {
                     vec![[0, self.height() as IdxSize]]
                 };
+
                 Ok(GroupsType::new_slice(groups, false, true))
             } else {
                 let rows = if multithreaded {
@@ -115,9 +116,9 @@ impl DataFrame {
     pub fn group_by<I, S>(&self, by: I) -> PolarsResult<GroupBy<'_>>
     where
         I: IntoIterator<Item = S>,
-        S: Into<PlSmallStr>,
+        S: AsRef<str>,
     {
-        let selected_keys = self.select_columns(by)?;
+        let selected_keys = self.select_to_vec(by)?;
         self.group_by_with_series(selected_keys, true, false)
     }
 
@@ -126,9 +127,9 @@ impl DataFrame {
     pub fn group_by_stable<I, S>(&self, by: I) -> PolarsResult<GroupBy<'_>>
     where
         I: IntoIterator<Item = S>,
-        S: Into<PlSmallStr>,
+        S: AsRef<str>,
     {
-        let selected_keys = self.select_columns(by)?;
+        let selected_keys = self.select_to_vec(by)?;
         self.group_by_with_series(selected_keys, true, true)
     }
 }
@@ -158,7 +159,7 @@ impl DataFrame {
 /// // create rain series
 /// let s2 = Series::new("rain".into(), [0.2, 0.1, 0.3, 0.1, 0.01]);
 /// // create a new DataFrame
-/// let df = DataFrame::new(vec![s0, s1, s2]).unwrap();
+/// let df = DataFrame::new_infer_height(vec![s0, s1, s2]).unwrap();
 /// println!("{:?}", df);
 /// ```
 ///
@@ -307,18 +308,19 @@ impl<'a> GroupBy<'a> {
         let keys = self.keys();
 
         let agg_col = match &self.selected_agg {
-            Some(selection) => self.df.select_columns_impl(selection.as_slice()),
+            Some(selection) => self.df.select_to_vec(selection),
             None => {
                 let by: Vec<_> = self.selected_keys.iter().map(|s| s.name()).collect();
                 let selection = self
                     .df
+                    .columns()
                     .iter()
                     .map(|s| s.name())
                     .filter(|a| !by.contains(a))
                     .cloned()
                     .collect::<Vec<_>>();
 
-                self.df.select_columns_impl(selection.as_slice())
+                self.df.select_to_vec(selection.as_slice())
             },
         }?;
 
@@ -360,7 +362,8 @@ impl<'a> GroupBy<'a> {
             agg.rename(new_name);
             cols.push(agg);
         }
-        DataFrame::new(cols)
+
+        DataFrame::new_infer_height(cols)
     }
 
     /// Aggregate grouped series and compute the sum per group.
@@ -398,7 +401,7 @@ impl<'a> GroupBy<'a> {
             agg.rename(new_name);
             cols.push(agg);
         }
-        DataFrame::new(cols)
+        DataFrame::new_infer_height(cols)
     }
 
     /// Aggregate grouped series and compute the minimal value per group.
@@ -435,7 +438,7 @@ impl<'a> GroupBy<'a> {
             agg.rename(new_name);
             cols.push(agg);
         }
-        DataFrame::new(cols)
+        DataFrame::new_infer_height(cols)
     }
 
     /// Aggregate grouped series and compute the maximum value per group.
@@ -472,7 +475,7 @@ impl<'a> GroupBy<'a> {
             agg.rename(new_name);
             cols.push(agg);
         }
-        DataFrame::new(cols)
+        DataFrame::new_infer_height(cols)
     }
 
     /// Aggregate grouped `Series` and find the first value per group.
@@ -509,7 +512,7 @@ impl<'a> GroupBy<'a> {
             agg.rename(new_name);
             cols.push(agg);
         }
-        DataFrame::new(cols)
+        DataFrame::new_infer_height(cols)
     }
 
     /// Aggregate grouped `Series` and return the last value per group.
@@ -546,7 +549,7 @@ impl<'a> GroupBy<'a> {
             agg.rename(new_name);
             cols.push(agg);
         }
-        DataFrame::new(cols)
+        DataFrame::new_infer_height(cols)
     }
 
     /// Aggregate grouped `Series` by counting the number of unique values.
@@ -583,7 +586,7 @@ impl<'a> GroupBy<'a> {
             agg.rename(new_name);
             cols.push(agg);
         }
-        DataFrame::new(cols)
+        DataFrame::new_infer_height(cols)
     }
 
     /// Aggregate grouped [`Series`] and determine the quantile per group.
@@ -613,7 +616,7 @@ impl<'a> GroupBy<'a> {
             agg.rename(new_name);
             cols.push(agg);
         }
-        DataFrame::new(cols)
+        DataFrame::new_infer_height(cols)
     }
 
     /// Aggregate grouped [`Series`] and determine the median per group.
@@ -635,7 +638,7 @@ impl<'a> GroupBy<'a> {
             agg.rename(new_name);
             cols.push(agg);
         }
-        DataFrame::new(cols)
+        DataFrame::new_infer_height(cols)
     }
 
     /// Aggregate grouped [`Series`] and determine the variance per group.
@@ -648,7 +651,7 @@ impl<'a> GroupBy<'a> {
             agg.rename(new_name);
             cols.push(agg);
         }
-        DataFrame::new(cols)
+        DataFrame::new_infer_height(cols)
     }
 
     /// Aggregate grouped [`Series`] and determine the standard deviation per group.
@@ -661,7 +664,7 @@ impl<'a> GroupBy<'a> {
             agg.rename(new_name);
             cols.push(agg);
         }
-        DataFrame::new(cols)
+        DataFrame::new_infer_height(cols)
     }
 
     /// Aggregate grouped series and compute the number of values per group.
@@ -703,7 +706,7 @@ impl<'a> GroupBy<'a> {
             ca.rename(new_name);
             cols.push(ca.into_column());
         }
-        DataFrame::new(cols)
+        DataFrame::new_infer_height(cols)
     }
 
     /// Get the group_by group indexes.
@@ -737,7 +740,7 @@ impl<'a> GroupBy<'a> {
         let new_name = fmt_group_by_column("", GroupByMethod::Groups);
         column.rename(new_name);
         cols.push(column.into_column());
-        DataFrame::new(cols)
+        DataFrame::new_infer_height(cols)
     }
 
     /// Aggregate the groups of the group_by operation into lists.
@@ -775,7 +778,7 @@ impl<'a> GroupBy<'a> {
             agg.rename(new_name);
             cols.push(agg);
         }
-        DataFrame::new(cols)
+        DataFrame::new_infer_height(cols)
     }
 
     fn prepare_apply(&self) -> PolarsResult<DataFrame> {
@@ -786,9 +789,9 @@ impl<'a> GroupBy<'a> {
             } else {
                 let mut new_cols = Vec::with_capacity(self.selected_keys.len() + agg.len());
                 new_cols.extend_from_slice(&self.selected_keys);
-                let cols = self.df.select_columns_impl(agg.as_slice())?;
+                let cols = self.df.select_to_vec(agg.as_slice())?;
                 new_cols.extend(cols);
-                Ok(unsafe { DataFrame::new_no_checks(self.df.height(), new_cols) })
+                Ok(unsafe { DataFrame::new_unchecked(self.df.height(), new_cols) })
             }
         } else {
             Ok(self.df.clone())
@@ -814,7 +817,7 @@ impl<'a> GroupBy<'a> {
             .collect::<PolarsResult<Vec<_>>>()?;
 
         let mut df = accumulate_dataframes_vertical(dfs)?;
-        df.as_single_chunk_par();
+        df.rechunk_mut_par();
         Ok(df)
     }
 
@@ -977,7 +980,7 @@ mod test {
         );
         let s1 = Column::new(PlSmallStr::from_static("temp"), [20, 10, 7, 9, 1]);
         let s2 = Column::new(PlSmallStr::from_static("rain"), [0.2, 0.1, 0.3, 0.1, 0.01]);
-        let df = DataFrame::new(vec![s0, s1, s2]).unwrap();
+        let df = DataFrame::new_infer_height(vec![s0, s1, s2]).unwrap();
 
         let out = df.group_by_stable(["date"])?.select(["temp"]).count()?;
         assert_eq!(
@@ -1041,8 +1044,10 @@ mod test {
         let s11 = Column::new("G11".into(), ["(", ")", "@", "@", "$"].as_ref());
         let s12 = Column::new("G12".into(), ["-", "_", ";", ";", ","].as_ref());
 
-        let df =
-            DataFrame::new(vec![s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12]).unwrap();
+        let df = DataFrame::new_infer_height(vec![
+            s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12,
+        ])
+        .unwrap();
 
         // Use of deprecated `sum()` for testing purposes
         #[allow(deprecated)]
@@ -1086,7 +1091,7 @@ mod test {
         columns.push(agg_series);
 
         // Create the dataframe with the computed series.
-        let df = DataFrame::new(columns).unwrap();
+        let df = DataFrame::new_infer_height(columns).unwrap();
 
         // Use of deprecated `sum()` for testing purposes
         #[allow(deprecated)]

--- a/crates/polars-core/src/frame/horizontal.rs
+++ b/crates/polars-core/src/frame/horizontal.rs
@@ -3,6 +3,7 @@ use polars_error::{PolarsResult, polars_err};
 use super::Column;
 use crate::datatypes::AnyValue;
 use crate::frame::DataFrame;
+use crate::frame::validation::validate_columns_slice;
 
 impl DataFrame {
     /// Add columns horizontally.
@@ -17,19 +18,20 @@ impl DataFrame {
     ///
     /// Note that on a debug build this will panic on duplicates / height mismatch.
     pub unsafe fn hstack_mut_unchecked(&mut self, columns: &[Column]) -> &mut Self {
-        self.clear_schema();
-        self.columns.extend_from_slice(columns);
-
-        if cfg!(debug_assertions) {
-            if let err @ Err(_) = DataFrame::validate_columns_slice(&self.columns) {
-                // Reset DataFrame state to before extend.
-                self.columns.truncate(self.columns.len() - columns.len());
-                err.unwrap();
-            }
+        if self.shape() == (0, 0)
+            && let Some(c) = columns.first()
+        {
+            unsafe { self.set_height(c.len()) };
         }
 
-        if let Some(c) = self.columns.first() {
-            unsafe { self.set_height(c.len()) };
+        unsafe { self.columns_mut() }.extend_from_slice(columns);
+
+        if cfg!(debug_assertions) {
+            if let err @ Err(_) = validate_columns_slice(self.height(), self.columns()) {
+                let initial_width = self.width() - columns.len();
+                unsafe { self.columns_mut() }.truncate(initial_width);
+                err.unwrap();
+            }
         }
 
         self
@@ -50,17 +52,18 @@ impl DataFrame {
     /// }
     /// ```
     pub fn hstack_mut(&mut self, columns: &[Column]) -> PolarsResult<&mut Self> {
-        self.clear_schema();
-        self.columns.extend_from_slice(columns);
-
-        if let err @ Err(_) = DataFrame::validate_columns_slice(&self.columns) {
-            // Reset DataFrame state to before extend.
-            self.columns.truncate(self.columns.len() - columns.len());
-            err?;
+        if self.shape() == (0, 0)
+            && let Some(c) = columns.first()
+        {
+            unsafe { self.set_height(c.len()) };
         }
 
-        if let Some(c) = self.columns.first() {
-            unsafe { self.set_height(c.len()) };
+        unsafe { self.columns_mut() }.extend_from_slice(columns);
+
+        if let err @ Err(_) = validate_columns_slice(self.height(), self.columns()) {
+            let initial_width = self.width() - columns.len();
+            unsafe { self.columns_mut() }.truncate(initial_width);
+            err?;
         }
 
         Ok(self)
@@ -110,14 +113,15 @@ pub fn concat_df_horizontal(
 
                     // SAFETY: We extend each column with nulls to the point of being of length
                     // `output_height`. Then, we set the height of the resulting dataframe.
-                    unsafe { df.get_columns_mut() }.iter_mut().for_each(|c| {
+                    unsafe { df.columns_mut() }.iter_mut().for_each(|c| {
                         *c = c.extend_constant(AnyValue::Null, diff).unwrap();
                     });
-                    df.clear_schema();
+
                     unsafe {
                         df.set_height(output_height);
                     }
                 }
+
                 df
             })
             .collect::<Vec<_>>();
@@ -129,14 +133,14 @@ pub fn concat_df_horizontal(
     let mut acc_cols = Vec::with_capacity(out_width);
 
     for df in dfs {
-        acc_cols.extend(df.get_columns().iter().cloned());
+        acc_cols.extend(df.columns().iter().cloned());
     }
 
-    if check_duplicates {
-        DataFrame::validate_columns_slice(&acc_cols)?;
-    }
-
-    let df = unsafe { DataFrame::new_no_checks_height_from_first(acc_cols) };
+    let df = if check_duplicates {
+        DataFrame::new(output_height, acc_cols)?
+    } else {
+        unsafe { DataFrame::new_unchecked(output_height, acc_cols) }
+    };
 
     Ok(df)
 }

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -1,11 +1,7 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 //! DataFrame module.
-use std::sync::OnceLock;
-use std::{mem, ops};
-
 use arrow::datatypes::ArrowSchemaRef;
 use polars_row::ArrayRef;
-use polars_schema::schema::ensure_matching_schema_names;
 use polars_utils::UnitVec;
 use polars_utils::itertools::Itertools;
 use rayon::prelude::*;
@@ -13,6 +9,7 @@ use rayon::prelude::*;
 use crate::chunked_array::flags::StatisticsFlags;
 #[cfg(feature = "algorithm_group_by")]
 use crate::chunked_array::ops::unique::is_unique_helper;
+use crate::prelude::gather::check_bounds_ca;
 use crate::prelude::*;
 #[cfg(feature = "row_hash")]
 use crate::utils::split_df;
@@ -24,7 +21,15 @@ mod arithmetic;
 pub mod builder;
 mod chunks;
 pub use chunks::chunk_df_for_writing;
+mod broadcast;
 pub mod column;
+mod dataframe;
+mod filter;
+mod projection;
+pub use dataframe::DataFrame;
+use filter::filter_zero_width;
+use projection::{AmortizedColumnSelector, LINEAR_SEARCH_LIMIT};
+
 pub mod explode;
 mod from;
 #[cfg(feature = "algorithm_group_by")]
@@ -67,140 +72,9 @@ pub enum UniqueKeepStrategy {
     Any,
 }
 
-fn ensure_names_unique<T, F>(items: &[T], mut get_name: F) -> PolarsResult<()>
-where
-    F: for<'a> FnMut(&'a T) -> &'a str,
-{
-    // Always unique.
-    if items.len() <= 1 {
-        return Ok(());
-    }
-
-    if items.len() <= 4 {
-        // Too small to be worth spawning a hashmap for, this is at most 6 comparisons.
-        for i in 0..items.len() - 1 {
-            let name = get_name(&items[i]);
-            for other in items.iter().skip(i + 1) {
-                if name == get_name(other) {
-                    polars_bail!(duplicate = name);
-                }
-            }
-        }
-    } else {
-        let mut names = PlHashSet::with_capacity(items.len());
-        for item in items {
-            let name = get_name(item);
-            if !names.insert(name) {
-                polars_bail!(duplicate = name);
-            }
-        }
-    }
-    Ok(())
-}
-
-/// A contiguous growable collection of `Series` that have the same length.
-///
-/// ## Use declarations
-///
-/// All the common tools can be found in [`crate::prelude`] (or in `polars::prelude`).
-///
-/// ```rust
-/// use polars_core::prelude::*; // if the crate polars-core is used directly
-/// // use polars::prelude::*;      if the crate polars is used
-/// ```
-///
-/// # Initialization
-/// ## Default
-///
-/// A `DataFrame` can be initialized empty:
-///
-/// ```rust
-/// # use polars_core::prelude::*;
-/// let df = DataFrame::default();
-/// assert!(df.is_empty());
-/// ```
-///
-/// ## Wrapping a `Vec<Series>`
-///
-/// A `DataFrame` is built upon a `Vec<Series>` where the `Series` have the same length.
-///
-/// ```rust
-/// # use polars_core::prelude::*;
-/// let s1 = Column::new("Fruit".into(), ["Apple", "Apple", "Pear"]);
-/// let s2 = Column::new("Color".into(), ["Red", "Yellow", "Green"]);
-///
-/// let df: PolarsResult<DataFrame> = DataFrame::new(vec![s1, s2]);
-/// ```
-///
-/// ## Using a macro
-///
-/// The [`df!`] macro is a convenient method:
-///
-/// ```rust
-/// # use polars_core::prelude::*;
-/// let df: PolarsResult<DataFrame> = df!("Fruit" => ["Apple", "Apple", "Pear"],
-///                                       "Color" => ["Red", "Yellow", "Green"]);
-/// ```
-///
-/// ## Using a CSV file
-///
-/// See the `polars_io::csv::CsvReader`.
-///
-/// # Indexing
-/// ## By a number
-///
-/// The `Index<usize>` is implemented for the `DataFrame`.
-///
-/// ```rust
-/// # use polars_core::prelude::*;
-/// let df = df!("Fruit" => ["Apple", "Apple", "Pear"],
-///              "Color" => ["Red", "Yellow", "Green"])?;
-///
-/// assert_eq!(df[0], Column::new("Fruit".into(), &["Apple", "Apple", "Pear"]));
-/// assert_eq!(df[1], Column::new("Color".into(), &["Red", "Yellow", "Green"]));
-/// # Ok::<(), PolarsError>(())
-/// ```
-///
-/// ## By a `Series` name
-///
-/// ```rust
-/// # use polars_core::prelude::*;
-/// let df = df!("Fruit" => ["Apple", "Apple", "Pear"],
-///              "Color" => ["Red", "Yellow", "Green"])?;
-///
-/// assert_eq!(df["Fruit"], Column::new("Fruit".into(), &["Apple", "Apple", "Pear"]));
-/// assert_eq!(df["Color"], Column::new("Color".into(), &["Red", "Yellow", "Green"]));
-/// # Ok::<(), PolarsError>(())
-/// ```
-#[derive(Clone)]
-pub struct DataFrame {
-    height: usize,
-    // invariant: columns[i].len() == height for each 0 >= i > columns.len()
-    pub(crate) columns: Vec<Column>,
-
-    /// A cached schema. This might not give correct results if the DataFrame was modified in place
-    /// between schema and reading.
-    cached_schema: OnceLock<SchemaRef>,
-}
-
 impl DataFrame {
-    pub fn clear_schema(&mut self) {
-        self.cached_schema = OnceLock::new();
-    }
-
-    #[inline]
-    pub fn column_iter(&self) -> impl ExactSizeIterator<Item = &Column> {
-        self.columns.iter()
-    }
-
-    #[inline]
     pub fn materialized_column_iter(&self) -> impl ExactSizeIterator<Item = &Series> {
-        self.columns.iter().map(Column::as_materialized_series)
-    }
-
-    #[inline]
-    pub fn par_materialized_column_iter(&self) -> impl ParallelIterator<Item = &Series> {
-        self.columns.par_iter().map(Column::as_materialized_series)
+        self.columns().iter().map(Column::as_materialized_series)
     }
 
     /// Returns an estimation of the total (heap) allocated size of the `DataFrame` in bytes.
@@ -216,52 +90,56 @@ impl DataFrame {
     ///
     /// FFI buffers are included in this estimation.
     pub fn estimated_size(&self) -> usize {
-        self.columns.iter().map(Column::estimated_size).sum()
+        self.columns().iter().map(Column::estimated_size).sum()
     }
 
-    // Reduce monomorphization.
-    fn try_apply_columns(
+    pub fn try_apply_columns(
         &self,
-        func: &(dyn Fn(&Column) -> PolarsResult<Column> + Send + Sync),
+        func: impl Fn(&Column) -> PolarsResult<Column> + Send + Sync,
     ) -> PolarsResult<Vec<Column>> {
-        self.columns.iter().map(func).collect()
+        return inner(self, &func);
+
+        fn inner(
+            slf: &DataFrame,
+            func: &(dyn Fn(&Column) -> PolarsResult<Column> + Send + Sync),
+        ) -> PolarsResult<Vec<Column>> {
+            slf.columns().iter().map(func).collect()
+        }
     }
-    // Reduce monomorphization.
-    pub fn _apply_columns(&self, func: &dyn Fn(&Column) -> Column) -> Vec<Column> {
-        self.columns.iter().map(func).collect()
+
+    pub fn apply_columns(&self, func: impl Fn(&Column) -> Column + Send + Sync) -> Vec<Column> {
+        return inner(self, &func);
+
+        fn inner(slf: &DataFrame, func: &(dyn Fn(&Column) -> Column + Send + Sync)) -> Vec<Column> {
+            slf.columns().iter().map(func).collect()
+        }
     }
-    // Reduce monomorphization.
-    fn try_apply_columns_par(
+
+    pub fn try_apply_columns_par(
         &self,
-        func: &(dyn Fn(&Column) -> PolarsResult<Column> + Send + Sync),
+        func: impl Fn(&Column) -> PolarsResult<Column> + Send + Sync,
     ) -> PolarsResult<Vec<Column>> {
-        POOL.install(|| self.columns.par_iter().map(func).collect())
-    }
-    // Reduce monomorphization.
-    pub fn _apply_columns_par(
-        &self,
-        func: &(dyn Fn(&Column) -> Column + Send + Sync),
-    ) -> Vec<Column> {
-        POOL.install(|| self.columns.par_iter().map(func).collect())
+        return inner(self, &func);
+
+        fn inner(
+            slf: &DataFrame,
+            func: &(dyn Fn(&Column) -> PolarsResult<Column> + Send + Sync),
+        ) -> PolarsResult<Vec<Column>> {
+            POOL.install(|| slf.columns().par_iter().map(func).collect())
+        }
     }
 
-    /// Get the index of the column.
-    fn check_name_to_idx(&self, name: &str) -> PolarsResult<usize> {
-        self.get_column_index(name)
-            .ok_or_else(|| polars_err!(col_not_found = name))
-    }
+    pub fn apply_columns_par(&self, func: impl Fn(&Column) -> Column + Send + Sync) -> Vec<Column> {
+        return inner(self, &func);
 
-    fn check_already_present(&self, name: &str) -> PolarsResult<()> {
-        polars_ensure!(
-            self.columns.iter().all(|s| s.name().as_str() != name),
-            Duplicate: "column with name {:?} is already present in the DataFrame", name
-        );
-        Ok(())
+        fn inner(slf: &DataFrame, func: &(dyn Fn(&Column) -> Column + Send + Sync)) -> Vec<Column> {
+            POOL.install(|| slf.columns().par_iter().map(func).collect())
+        }
     }
 
     /// Reserve additional slots into the chunks of the series.
     pub(crate) fn reserve_chunks(&mut self, additional: usize) {
-        for s in &mut self.columns {
+        for s in unsafe { self.columns_mut_retain_schema() } {
             if let Column::Series(s) = s {
                 // SAFETY:
                 // do not modify the data, simply resize.
@@ -269,174 +147,29 @@ impl DataFrame {
             }
         }
     }
-
-    /// Create a DataFrame from a Vector of Columns.
-    ///
-    /// Errors if a column names are not unique, or if heights are not all equal.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use polars_core::prelude::*;
-    /// let s0 = Column::new("days".into(), [0, 1, 2].as_ref());
-    /// let s1 = Column::new("temp".into(), [22.1, 19.9, 7.].as_ref());
-    ///
-    /// let df = DataFrame::new(vec![s0, s1])?;
-    /// # Ok::<(), PolarsError>(())
-    /// ```
-    pub fn new(columns: Vec<Column>) -> PolarsResult<Self> {
-        DataFrame::validate_columns_slice(&columns)
-            .map_err(|e| e.wrap_msg(|e| format!("could not create a new DataFrame: {e}")))?;
-        Ok(unsafe { Self::new_no_checks_height_from_first(columns) })
-    }
-
-    pub fn new_with_height(height: usize, columns: Vec<Column>) -> PolarsResult<Self> {
-        for col in &columns {
-            polars_ensure!(
-                col.len() == height,
-                ShapeMismatch: "could not create a new DataFrame: series {:?} has length {} while series {:?} has length {}",
-                columns[0].name(), height, col.name(), col.len()
-            );
-        }
-
-        ensure_names_unique(&columns, |s| s.name().as_str())?;
-
-        Ok(DataFrame {
-            height,
-            columns,
-            cached_schema: OnceLock::new(),
-        })
-    }
-
-    /// Converts a sequence of columns into a DataFrame, broadcasting length-1
-    /// columns to match the other columns.
-    pub fn new_with_broadcast(columns: Vec<Column>) -> PolarsResult<Self> {
-        // The length of the longest non-unit length column determines the
-        // broadcast length. If all columns are unit-length the broadcast length
-        // is one.
-        let broadcast_len = columns
-            .iter()
-            .map(|s| s.len())
-            .filter(|l| *l != 1)
-            .max()
-            .unwrap_or(1);
-        Self::new_with_broadcast_len(columns, broadcast_len)
-    }
-
-    /// Converts a sequence of columns into a DataFrame, broadcasting length-1
-    /// columns to broadcast_len.
-    pub fn new_with_broadcast_len(
-        columns: Vec<Column>,
-        broadcast_len: usize,
-    ) -> PolarsResult<Self> {
-        ensure_names_unique(&columns, |s| s.name().as_str())?;
-        unsafe { Self::new_with_broadcast_no_namecheck(columns, broadcast_len) }
-    }
-
-    /// Converts a sequence of columns into a DataFrame, broadcasting length-1
-    /// columns to match the other columns.
-    ///
-    /// # Safety
-    /// Does not check that the column names are unique (which they must be).
-    pub unsafe fn new_with_broadcast_no_namecheck(
-        mut columns: Vec<Column>,
-        broadcast_len: usize,
-    ) -> PolarsResult<Self> {
-        for col in &mut columns {
-            // Length not equal to the broadcast len, needs broadcast or is an error.
-            let len = col.len();
-            if len != broadcast_len {
-                if len != 1 {
-                    let name = col.name().to_owned();
-                    let extra_info =
-                        if let Some(c) = columns.iter().find(|c| c.len() == broadcast_len) {
-                            format!(" (matching column '{}')", c.name())
-                        } else {
-                            String::new()
-                        };
-                    polars_bail!(
-                        ShapeMismatch: "could not create a new DataFrame: series {name:?} has length {len} while trying to broadcast to length {broadcast_len}{extra_info}",
-                    );
-                }
-                *col = col.new_from_index(0, broadcast_len);
-            }
-        }
-
-        let length = if columns.is_empty() { 0 } else { broadcast_len };
-
-        Ok(unsafe { DataFrame::new_no_checks(length, columns) })
-    }
-
     pub fn new_from_index(&self, index: usize, height: usize) -> Self {
-        let cols = self.columns.iter().map(|c| c.new_from_index(index, height));
-        unsafe { Self::new_no_checks(height, cols.collect()) }
-    }
+        let new_cols = self.apply_columns(|c| c.new_from_index(index, height));
 
-    /// Creates an empty `DataFrame` usable in a compile time context (such as static initializers).
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use polars_core::prelude::DataFrame;
-    /// static EMPTY: DataFrame = DataFrame::empty();
-    /// ```
-    pub const fn empty() -> Self {
-        Self::empty_with_height(0)
-    }
-
-    /// Creates an empty `DataFrame` with a specific `height`.
-    pub const fn empty_with_height(height: usize) -> Self {
-        DataFrame {
-            height,
-            columns: vec![],
-            cached_schema: OnceLock::new(),
-        }
-    }
-
-    /// Create an empty `DataFrame` with empty columns as per the `schema`.
-    pub fn empty_with_arc_schema(schema: Arc<Schema>) -> Self {
-        let mut df = Self::empty_with_schema(&schema);
-        df.cached_schema = OnceLock::from(schema);
-        df
-    }
-
-    /// Create an empty `DataFrame` with empty columns as per the `schema`.
-    pub fn empty_with_schema(schema: &Schema) -> Self {
-        let cols = schema
-            .iter()
-            .map(|(name, dtype)| Column::from(Series::new_empty(name.clone(), dtype)))
-            .collect();
-        unsafe { DataFrame::new_no_checks(0, cols) }
-    }
-
-    /// Create an empty `DataFrame` with empty columns as per the `schema`.
-    pub fn empty_with_arrow_schema(schema: &ArrowSchema) -> Self {
-        let cols = schema
-            .iter_values()
-            .map(|fld| {
-                Column::from(Series::new_empty(
-                    fld.name.clone(),
-                    &(DataType::from_arrow_field(fld)),
-                ))
-            })
-            .collect();
-        unsafe { DataFrame::new_no_checks(0, cols) }
+        unsafe { Self::_new_unchecked_impl(height, new_cols).with_schema_from(self) }
     }
 
     /// Create a new `DataFrame` with the given schema, only containing nulls.
     pub fn full_null(schema: &Schema, height: usize) -> Self {
         let columns = schema
             .iter_fields()
-            .map(|f| Column::full_null(f.name.clone(), height, f.dtype()))
+            .map(|f| Column::full_null(f.name().clone(), height, f.dtype()))
             .collect();
-        unsafe { DataFrame::new_no_checks(height, columns) }
+
+        unsafe { DataFrame::_new_unchecked_impl(height, columns) }
     }
 
     /// Ensure this DataFrame matches the given schema. Casts null columns to
     /// the expected schema if necessary (but nothing else).
     pub fn ensure_matches_schema(&mut self, schema: &Schema) -> PolarsResult<()> {
-        let mut any_needed_cast = false;
-        for (col, (name, dt)) in self.columns.iter_mut().zip(schema.iter()) {
+        let mut did_cast = false;
+        let cached_schema = self.cached_schema().cloned();
+
+        for (col, (name, dt)) in unsafe { self.columns_mut() }.iter_mut().zip(schema.iter()) {
             polars_ensure!(
                 col.name() == name,
                 SchemaMismatch: "column name mismatch: expected {:?}, found {:?}",
@@ -445,37 +178,18 @@ impl DataFrame {
             );
 
             let needs_cast = col.dtype().matches_schema_type(dt)?;
-            any_needed_cast |= needs_cast;
+
             if needs_cast {
                 *col = col.cast(dt)?;
+                did_cast = true;
             }
         }
-        if any_needed_cast {
-            self.clear_schema();
+
+        if !did_cast {
+            unsafe { self.set_opt_schema(cached_schema) };
         }
+
         Ok(())
-    }
-
-    /// Removes the last `Series` from the `DataFrame` and returns it, or [`None`] if it is empty.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use polars_core::prelude::*;
-    /// let s1 = Column::new("Ocean".into(), ["Atlantic", "Indian"]);
-    /// let s2 = Column::new("Area (km²)".into(), [106_460_000, 70_560_000]);
-    /// let mut df = DataFrame::new(vec![s1.clone(), s2.clone()])?;
-    ///
-    /// assert_eq!(df.pop(), Some(s2));
-    /// assert_eq!(df.pop(), Some(s1));
-    /// assert_eq!(df.pop(), None);
-    /// assert!(df.is_empty());
-    /// # Ok::<(), PolarsError>(())
-    /// ```
-    pub fn pop(&mut self) -> Option<Column> {
-        self.clear_schema();
-
-        self.columns.pop()
     }
 
     /// Add a new column at index 0 that counts the rows.
@@ -513,13 +227,18 @@ impl DataFrame {
     ///  +-----+----------+
     /// ```
     pub fn with_row_index(&self, name: PlSmallStr, offset: Option<IdxSize>) -> PolarsResult<Self> {
-        let mut columns = Vec::with_capacity(self.columns.len() + 1);
+        let mut new_columns = Vec::with_capacity(self.width() + 1);
         let offset = offset.unwrap_or(0);
 
+        if self.get_column_index(&name).is_some() {
+            polars_bail!(duplicate = name)
+        }
+
         let col = Column::new_row_index(name, offset, self.height())?;
-        columns.push(col);
-        columns.extend_from_slice(&self.columns);
-        DataFrame::new(columns)
+        new_columns.push(col);
+        new_columns.extend_from_slice(self.columns());
+
+        Ok(unsafe { DataFrame::new_unchecked(self.height(), new_columns) })
     }
 
     /// Add a row index column in place.
@@ -534,9 +253,8 @@ impl DataFrame {
         name: PlSmallStr,
         offset: Option<IdxSize>,
     ) -> &mut Self {
-        // TODO: Make this function unsafe
         debug_assert!(
-            self.columns.iter().all(|c| c.name() != &name),
+            self.get_column_index(&name).is_none(),
             "with_row_index_mut(): column with name {} already exists",
             &name
         );
@@ -544,132 +262,42 @@ impl DataFrame {
         let offset = offset.unwrap_or(0);
         let col = Column::new_row_index(name, offset, self.height()).unwrap();
 
-        self.clear_schema();
-        self.columns.insert(0, col);
+        unsafe { self.columns_mut() }.insert(0, col);
         self
-    }
-
-    /// Create a new `DataFrame` but does not check the length or duplicate occurrence of the
-    /// `Series`.
-    ///
-    /// Calculates the height from the first column or `0` if no columns are given.
-    ///
-    /// # Safety
-    ///
-    /// It is the callers responsibility to uphold the contract of all `Series`
-    /// having an equal length and a unique name, if not this may panic down the line.
-    pub unsafe fn new_no_checks_height_from_first(columns: Vec<Column>) -> DataFrame {
-        let height = columns.first().map_or(0, Column::len);
-        unsafe { Self::new_no_checks(height, columns) }
-    }
-
-    /// Create a new `DataFrame` but does not check the length or duplicate occurrence of the
-    /// `Series`.
-    ///
-    /// It is advised to use [DataFrame::new] in favor of this method.
-    ///
-    /// # Safety
-    ///
-    /// It is the callers responsibility to uphold the contract of all `Series`
-    /// having an equal length and a unique name, if not this may panic down the line.
-    pub unsafe fn new_no_checks(height: usize, columns: Vec<Column>) -> DataFrame {
-        if cfg!(debug_assertions) {
-            DataFrame::validate_columns_slice(&columns).unwrap();
-        }
-
-        unsafe { Self::_new_no_checks_impl(height, columns) }
-    }
-
-    /// This will not panic even in debug mode - there are some (rare) use cases where a DataFrame
-    /// is temporarily constructed containing duplicates for dispatching to functions. A DataFrame
-    /// constructed with this method is generally highly unsafe and should not be long-lived.
-    #[allow(clippy::missing_safety_doc)]
-    pub const unsafe fn _new_no_checks_impl(height: usize, columns: Vec<Column>) -> DataFrame {
-        DataFrame {
-            height,
-            columns,
-            cached_schema: OnceLock::new(),
-        }
     }
 
     /// Shrink the capacity of this DataFrame to fit its length.
     pub fn shrink_to_fit(&mut self) {
         // Don't parallelize this. Memory overhead
-        for s in &mut self.columns {
+        for s in unsafe { self.columns_mut_retain_schema() } {
             s.shrink_to_fit();
         }
     }
 
-    /// Aggregate all the chunks in the DataFrame to a single chunk.
-    pub fn as_single_chunk(&mut self) -> &mut Self {
-        // Don't parallelize this. Memory overhead
-        for s in &mut self.columns {
-            *s = s.rechunk();
-        }
-        self
-    }
-
     /// Aggregate all the chunks in the DataFrame to a single chunk in parallel.
     /// This may lead to more peak memory consumption.
-    pub fn as_single_chunk_par(&mut self) -> &mut Self {
-        if self.columns.iter().any(|c| c.n_chunks() > 1) {
-            self.columns = self._apply_columns_par(&|s| s.rechunk());
+    pub fn rechunk_mut_par(&mut self) -> &mut Self {
+        if self.columns().iter().any(|c| c.n_chunks() > 1) {
+            POOL.install(|| {
+                unsafe { self.columns_mut_retain_schema() }
+                    .par_iter_mut()
+                    .for_each(|c| *c = c.rechunk());
+            })
         }
+
         self
     }
 
     /// Rechunks all columns to only have a single chunk.
-    pub fn rechunk_mut(&mut self) {
+    pub fn rechunk_mut(&mut self) -> &mut Self {
         // SAFETY: We never adjust the length or names of the columns.
-        let columns = unsafe { self.get_columns_mut() };
+        let columns = unsafe { self.columns_mut() };
 
         for col in columns.iter_mut().filter(|c| c.n_chunks() > 1) {
             *col = col.rechunk();
         }
-    }
 
-    pub fn _deshare_views_mut(&mut self) {
-        // SAFETY: We never adjust the length or names of the columns.
-        unsafe {
-            let columns = self.get_columns_mut();
-            for col in columns {
-                let Column::Series(s) = col else { continue };
-
-                if let Ok(ca) = s.binary() {
-                    let gc_ca = ca.apply_kernel(&|a| a.deshare().into_boxed());
-                    *col = Column::from(gc_ca.into_series());
-                } else if let Ok(ca) = s.str() {
-                    let gc_ca = ca.apply_kernel(&|a| a.deshare().into_boxed());
-                    *col = Column::from(gc_ca.into_series());
-                }
-            }
-        }
-    }
-
-    /// Rechunks all columns to only have a single chunk and turns it into a [`RecordBatchT`].
-    pub fn rechunk_to_record_batch(
-        self,
-        compat_level: CompatLevel,
-    ) -> RecordBatchT<Box<dyn Array>> {
-        let height = self.height();
-
-        let (schema, arrays) = self
-            .columns
-            .into_iter()
-            .map(|col| {
-                let mut series = col.take_materialized_series();
-                // Rechunk to one chunk if necessary
-                if series.n_chunks() > 1 {
-                    series = series.rechunk();
-                }
-                (
-                    series.field().to_arrow(compat_level),
-                    series.to_arrow(0, compat_level),
-                )
-            })
-            .collect();
-
-        RecordBatchT::new(height, Arc::new(schema), arrays)
+        self
     }
 
     /// Returns true if the chunks of the columns do not align and re-chunking should be done
@@ -677,7 +305,7 @@ impl DataFrame {
         // Fast check. It is also needed for correctness, as code below doesn't check if the number
         // of chunks is equal.
         if !self
-            .get_columns()
+            .columns()
             .iter()
             .filter_map(|c| c.as_series().map(|s| s.n_chunks()))
             .all_equal()
@@ -716,129 +344,19 @@ impl DataFrame {
     /// Ensure all the chunks in the [`DataFrame`] are aligned.
     pub fn align_chunks_par(&mut self) -> &mut Self {
         if self.should_rechunk() {
-            self.as_single_chunk_par()
+            self.rechunk_mut_par()
         } else {
             self
         }
     }
 
+    /// Ensure all the chunks in the [`DataFrame`] are aligned.
     pub fn align_chunks(&mut self) -> &mut Self {
         if self.should_rechunk() {
-            self.as_single_chunk()
+            self.rechunk_mut()
         } else {
             self
         }
-    }
-
-    /// Get the [`DataFrame`] schema.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use polars_core::prelude::*;
-    /// let df: DataFrame = df!("Thing" => ["Observable universe", "Human stupidity"],
-    ///                         "Diameter (m)" => [8.8e26, f64::INFINITY])?;
-    ///
-    /// let f1: Field = Field::new("Thing".into(), DataType::String);
-    /// let f2: Field = Field::new("Diameter (m)".into(), DataType::Float64);
-    /// let sc: Schema = Schema::from_iter(vec![f1, f2]);
-    ///
-    /// assert_eq!(&**df.schema(), &sc);
-    /// # Ok::<(), PolarsError>(())
-    /// ```
-    pub fn schema(&self) -> &SchemaRef {
-        let out = self.cached_schema.get_or_init(|| {
-            Arc::new(
-                self.columns
-                    .iter()
-                    .map(|x| (x.name().clone(), x.dtype().clone()))
-                    .collect(),
-            )
-        });
-
-        debug_assert_eq!(out.len(), self.width());
-
-        out
-    }
-
-    /// Get a reference to the [`DataFrame`] columns.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use polars_core::prelude::*;
-    /// let df: DataFrame = df!("Name" => ["Adenine", "Cytosine", "Guanine", "Thymine"],
-    ///                         "Symbol" => ["A", "C", "G", "T"])?;
-    /// let columns: &[Column] = df.get_columns();
-    ///
-    /// assert_eq!(columns[0].name(), "Name");
-    /// assert_eq!(columns[1].name(), "Symbol");
-    /// # Ok::<(), PolarsError>(())
-    /// ```
-    #[inline]
-    pub fn get_columns(&self) -> &[Column] {
-        &self.columns
-    }
-
-    #[inline]
-    /// Get mutable access to the underlying columns.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure the length of all [`Series`] remains equal to `height` or
-    /// [`DataFrame::set_height`] is called afterwards with the appropriate `height`.
-    /// The caller must ensure that the cached schema is cleared if it modifies the schema by
-    /// calling [`DataFrame::clear_schema`].
-    pub unsafe fn get_columns_mut(&mut self) -> &mut Vec<Column> {
-        &mut self.columns
-    }
-
-    #[inline]
-    /// Remove all the columns in the [`DataFrame`] but keep the `height`.
-    pub fn clear_columns(&mut self) {
-        unsafe { self.get_columns_mut() }.clear();
-        self.clear_schema();
-    }
-
-    #[inline]
-    /// Extend the columns without checking for name collisions or height.
-    ///
-    /// # Safety
-    ///
-    /// The caller needs to ensure that:
-    /// - Column names are unique within the resulting [`DataFrame`].
-    /// - The length of each appended column matches the height of the [`DataFrame`]. For
-    ///   `DataFrame`]s with no columns (ZCDFs), it is important that the height is set afterwards
-    ///   with [`DataFrame::set_height`].
-    pub unsafe fn column_extend_unchecked(&mut self, iter: impl IntoIterator<Item = Column>) {
-        unsafe { self.get_columns_mut() }.extend(iter);
-        self.clear_schema();
-    }
-
-    /// Take ownership of the underlying columns vec.
-    pub fn take_columns(self) -> Vec<Column> {
-        self.columns
-    }
-
-    /// Iterator over the columns as [`Series`].
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use polars_core::prelude::*;
-    /// let s1 = Column::new("Name".into(), ["Pythagoras' theorem", "Shannon entropy"]);
-    /// let s2 = Column::new("Formula".into(), ["a²+b²=c²", "H=-Σ[P(x)log|P(x)|]"]);
-    /// let df: DataFrame = DataFrame::new(vec![s1.clone(), s2.clone()])?;
-    ///
-    /// let mut iterator = df.iter();
-    ///
-    /// assert_eq!(iterator.next(), Some(s1.as_materialized_series()));
-    /// assert_eq!(iterator.next(), Some(s2.as_materialized_series()));
-    /// assert_eq!(iterator.next(), None);
-    /// # Ok::<(), PolarsError>(())
-    /// ```
-    pub fn iter(&self) -> impl ExactSizeIterator<Item = &Series> {
-        self.materialized_column_iter()
     }
 
     /// # Example
@@ -852,16 +370,12 @@ impl DataFrame {
     /// # Ok::<(), PolarsError>(())
     /// ```
     pub fn get_column_names(&self) -> Vec<&PlSmallStr> {
-        self.columns.iter().map(|s| s.name()).collect()
+        self.columns().iter().map(|s| s.name()).collect()
     }
 
     /// Get the [`Vec<PlSmallStr>`] representing the column names.
     pub fn get_column_names_owned(&self) -> Vec<PlSmallStr> {
-        self.columns.iter().map(|s| s.name().clone()).collect()
-    }
-
-    pub fn get_column_names_str(&self) -> Vec<&str> {
-        self.columns.iter().map(|s| s.name().as_str()).collect()
+        self.columns().iter().map(|s| s.name().clone()).collect()
     }
 
     /// Set the column names.
@@ -870,39 +384,29 @@ impl DataFrame {
     /// ```rust
     /// # use polars_core::prelude::*;
     /// let mut df: DataFrame = df!("Mathematical set" => ["ℕ", "ℤ", "𝔻", "ℚ", "ℝ", "ℂ"])?;
-    /// df.set_column_names(["Set"])?;
+    /// df.set_column_names(&["Set"])?;
     ///
     /// assert_eq!(df.get_column_names(), &["Set"]);
     /// # Ok::<(), PolarsError>(())
     /// ```
-    pub fn set_column_names<I, S>(&mut self, names: I) -> PolarsResult<()>
+    pub fn set_column_names<T>(&mut self, new_names: &[T]) -> PolarsResult<()>
     where
-        I: IntoIterator<Item = S>,
-        S: Into<PlSmallStr>,
+        T: AsRef<str>,
     {
-        let names = names.into_iter().map(Into::into).collect::<Vec<_>>();
-        self._set_column_names_impl(names.as_slice())
-    }
-
-    fn _set_column_names_impl(&mut self, names: &[PlSmallStr]) -> PolarsResult<()> {
         polars_ensure!(
-            names.len() == self.width(),
+            new_names.len() == self.width(),
             ShapeMismatch: "{} column names provided for a DataFrame of width {}",
-            names.len(), self.width()
+            new_names.len(), self.width()
         );
-        ensure_names_unique(names, |s| s.as_str())?;
 
-        let columns = mem::take(&mut self.columns);
-        self.columns = columns
+        validation::ensure_names_unique(new_names)?;
+
+        *unsafe { self.columns_mut() } = std::mem::take(unsafe { self.columns_mut() })
             .into_iter()
-            .zip(names)
-            .map(|(s, name)| {
-                let mut s = s;
-                s.rename(name.clone());
-                s
-            })
+            .zip(new_names)
+            .map(|(c, name)| c.with_name(PlSmallStr::from_str(name.as_ref())))
             .collect();
-        self.clear_schema();
+
         Ok(())
     }
 
@@ -919,17 +423,13 @@ impl DataFrame {
     /// # Ok::<(), PolarsError>(())
     /// ```
     pub fn dtypes(&self) -> Vec<DataType> {
-        self.columns.iter().map(|s| s.dtype().clone()).collect()
-    }
-
-    pub(crate) fn first_series_column(&self) -> Option<&Series> {
-        self.columns.iter().find_map(|col| col.as_series())
+        self.columns().iter().map(|s| s.dtype().clone()).collect()
     }
 
     /// The number of chunks for the first column.
     pub fn first_col_n_chunks(&self) -> usize {
-        match self.first_series_column() {
-            None if self.columns.is_empty() => 0,
+        match self.columns().iter().find_map(|col| col.as_series()) {
+            None if self.width() == 0 => 0,
             None => 1,
             Some(s) => s.n_chunks(),
         }
@@ -937,14 +437,14 @@ impl DataFrame {
 
     /// The highest number of chunks for any column.
     pub fn max_n_chunks(&self) -> usize {
-        self.columns
+        self.columns()
             .iter()
             .map(|s| s.as_series().map(|s| s.n_chunks()).unwrap_or(1))
             .max()
             .unwrap_or(0)
     }
 
-    /// Get a reference to the schema fields of the [`DataFrame`].
+    /// Generate the schema fields of the [`DataFrame`].
     ///
     /// # Example
     ///
@@ -960,102 +460,10 @@ impl DataFrame {
     /// # Ok::<(), PolarsError>(())
     /// ```
     pub fn fields(&self) -> Vec<Field> {
-        self.columns
+        self.columns()
             .iter()
             .map(|s| s.field().into_owned())
             .collect()
-    }
-
-    /// Get (height, width) of the [`DataFrame`].
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use polars_core::prelude::*;
-    /// let df0: DataFrame = DataFrame::default();
-    /// let df1: DataFrame = df!("1" => [1, 2, 3, 4, 5])?;
-    /// let df2: DataFrame = df!("1" => [1, 2, 3, 4, 5],
-    ///                          "2" => [1, 2, 3, 4, 5])?;
-    ///
-    /// assert_eq!(df0.shape(), (0 ,0));
-    /// assert_eq!(df1.shape(), (5, 1));
-    /// assert_eq!(df2.shape(), (5, 2));
-    /// # Ok::<(), PolarsError>(())
-    /// ```
-    pub fn shape(&self) -> (usize, usize) {
-        (self.height, self.columns.len())
-    }
-
-    /// Get the width of the [`DataFrame`] which is the number of columns.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use polars_core::prelude::*;
-    /// let df0: DataFrame = DataFrame::default();
-    /// let df1: DataFrame = df!("Series 1" => [0; 0])?;
-    /// let df2: DataFrame = df!("Series 1" => [0; 0],
-    ///                          "Series 2" => [0; 0])?;
-    ///
-    /// assert_eq!(df0.width(), 0);
-    /// assert_eq!(df1.width(), 1);
-    /// assert_eq!(df2.width(), 2);
-    /// # Ok::<(), PolarsError>(())
-    /// ```
-    pub fn width(&self) -> usize {
-        self.columns.len()
-    }
-
-    /// Get the height of the [`DataFrame`] which is the number of rows.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use polars_core::prelude::*;
-    /// let df0: DataFrame = DataFrame::default();
-    /// let df1: DataFrame = df!("Currency" => ["€", "$"])?;
-    /// let df2: DataFrame = df!("Currency" => ["€", "$", "¥", "£", "₿"])?;
-    ///
-    /// assert_eq!(df0.height(), 0);
-    /// assert_eq!(df1.height(), 2);
-    /// assert_eq!(df2.height(), 5);
-    /// # Ok::<(), PolarsError>(())
-    /// ```
-    pub fn height(&self) -> usize {
-        self.height
-    }
-
-    /// Returns the size as number of rows * number of columns
-    pub fn size(&self) -> usize {
-        let s = self.shape();
-        s.0 * s.1
-    }
-
-    /// Returns `true` if the [`DataFrame`] contains no rows.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use polars_core::prelude::*;
-    /// let df1: DataFrame = DataFrame::default();
-    /// assert!(df1.is_empty());
-    ///
-    /// let df2: DataFrame = df!("First name" => ["Forever"],
-    ///                          "Last name" => ["Alone"])?;
-    /// assert!(!df2.is_empty());
-    /// # Ok::<(), PolarsError>(())
-    /// ```
-    pub fn is_empty(&self) -> bool {
-        matches!(self.shape(), (0, _) | (_, 0))
-    }
-
-    /// Set the height (i.e. number of rows) of this [`DataFrame`].
-    ///
-    /// # Safety
-    ///
-    /// This needs to be equal to the length of all the columns.
-    pub unsafe fn set_height(&mut self, height: usize) {
-        self.height = height;
     }
 
     /// Add multiple [`Series`] to a [`DataFrame`].
@@ -1092,11 +500,13 @@ impl DataFrame {
     /// +---------+--------+----------+
     /// ```
     pub fn hstack(&self, columns: &[Column]) -> PolarsResult<Self> {
-        let mut new_cols = self.columns.clone();
-        new_cols.extend_from_slice(columns);
-        DataFrame::new(new_cols)
-    }
+        let mut new_cols = Vec::with_capacity(self.width() + columns.len());
 
+        new_cols.extend(self.columns().iter().cloned());
+        new_cols.extend_from_slice(columns);
+
+        DataFrame::new(self.height(), new_cols)
+    }
     /// Concatenate a [`DataFrame`] to this [`DataFrame`] and return as newly allocated [`DataFrame`].
     ///
     /// If many `vstack` operations are done, it is recommended to call [`DataFrame::align_chunks_par`].
@@ -1186,19 +596,22 @@ impl DataFrame {
     pub fn vstack_mut(&mut self, other: &DataFrame) -> PolarsResult<&mut Self> {
         if self.width() != other.width() {
             polars_ensure!(
-                self.width() == 0,
+                self.shape() == (0, 0),
                 ShapeMismatch:
-                "unable to append to a DataFrame of width {} with a DataFrame of width {}",
-                self.width(), other.width(),
+                "unable to append to a DataFrame of shape {:?} with a DataFrame of width {}",
+                self.shape(), other.width(),
             );
-            self.columns.clone_from(&other.columns);
-            self.height = other.height;
+
+            self.clone_from(other);
+
             return Ok(self);
         }
 
-        self.columns
+        let new_height = usize::checked_add(self.height(), other.height()).unwrap();
+
+        unsafe { self.columns_mut_retain_schema() }
             .iter_mut()
-            .zip(other.columns.iter())
+            .zip(other.columns())
             .try_for_each::<_, PolarsResult<_>>(|(left, right)| {
                 ensure_can_extend(&*left, right)?;
                 left.append(right).map_err(|e| {
@@ -1206,26 +619,31 @@ impl DataFrame {
                 })?;
                 Ok(())
             })?;
-        self.height += other.height;
+
+        unsafe { self.set_height(new_height) };
+
         Ok(self)
     }
 
     pub fn vstack_mut_owned(&mut self, other: DataFrame) -> PolarsResult<&mut Self> {
         if self.width() != other.width() {
             polars_ensure!(
-                self.width() == 0,
+                self.shape() == (0, 0),
                 ShapeMismatch:
                 "unable to append to a DataFrame of width {} with a DataFrame of width {}",
                 self.width(), other.width(),
             );
-            self.columns = other.columns;
-            self.height = other.height;
+
+            *self = other;
+
             return Ok(self);
         }
 
-        self.columns
+        let new_height = usize::checked_add(self.height(), other.height()).unwrap();
+
+        unsafe { self.columns_mut_retain_schema() }
             .iter_mut()
-            .zip(other.columns.into_iter())
+            .zip(other.into_columns())
             .try_for_each::<_, PolarsResult<_>>(|(left, right)| {
                 ensure_can_extend(&*left, &right)?;
                 let right_name = right.name().clone();
@@ -1234,7 +652,9 @@ impl DataFrame {
                 })?;
                 Ok(())
             })?;
-        self.height += other.height;
+
+        unsafe { self.set_height(new_height) };
+
         Ok(self)
     }
 
@@ -1244,10 +664,12 @@ impl DataFrame {
     ///
     /// # Panics
     /// Panics if the schema's don't match.
-    pub fn vstack_mut_unchecked(&mut self, other: &DataFrame) {
-        self.columns
+    pub fn vstack_mut_unchecked(&mut self, other: &DataFrame) -> &mut Self {
+        let new_height = usize::checked_add(self.height(), other.height()).unwrap();
+
+        unsafe { self.columns_mut_retain_schema() }
             .iter_mut()
-            .zip(other.columns.iter())
+            .zip(other.columns())
             .for_each(|(left, right)| {
                 left.append(right)
                     .map_err(|e| {
@@ -1255,7 +677,10 @@ impl DataFrame {
                     })
                     .expect("should not fail");
             });
-        self.height += other.height;
+
+        unsafe { self.set_height(new_height) };
+
+        self
     }
 
     /// Concatenate a [`DataFrame`] to this [`DataFrame`]
@@ -1264,14 +689,19 @@ impl DataFrame {
     ///
     /// # Panics
     /// Panics if the schema's don't match.
-    pub fn vstack_mut_owned_unchecked(&mut self, other: DataFrame) {
-        self.columns
+    pub fn vstack_mut_owned_unchecked(&mut self, other: DataFrame) -> &mut Self {
+        let new_height = usize::checked_add(self.height(), other.height()).unwrap();
+
+        unsafe { self.columns_mut_retain_schema() }
             .iter_mut()
-            .zip(other.columns)
+            .zip(other.into_columns())
             .for_each(|(left, right)| {
                 left.append_owned(right).expect("should not fail");
             });
-        self.height += other.height;
+
+        unsafe { self.set_height(new_height) };
+
+        self
     }
 
     /// Extend the memory backed by this [`DataFrame`] with the values from `other`.
@@ -1296,9 +726,11 @@ impl DataFrame {
             self.width(), other.width(),
         );
 
-        self.columns
+        let new_height = usize::checked_add(self.height(), other.height()).unwrap();
+
+        unsafe { self.columns_mut_retain_schema() }
             .iter_mut()
-            .zip(other.columns.iter())
+            .zip(other.columns())
             .try_for_each::<_, PolarsResult<_>>(|(left, right)| {
                 ensure_can_extend(&*left, right)?;
                 left.extend(right).map_err(|e| {
@@ -1306,8 +738,9 @@ impl DataFrame {
                 })?;
                 Ok(())
             })?;
-        self.height += other.height;
-        self.clear_schema();
+
+        unsafe { self.set_height(new_height) };
+
         Ok(())
     }
 
@@ -1328,9 +761,8 @@ impl DataFrame {
     /// # Ok::<(), PolarsError>(())
     /// ```
     pub fn drop_in_place(&mut self, name: &str) -> PolarsResult<Column> {
-        let idx = self.check_name_to_idx(name)?;
-        self.clear_schema();
-        Ok(self.columns.remove(idx))
+        let idx = self.try_get_column_index(name)?;
+        Ok(unsafe { self.columns_mut() }.remove(idx))
     }
 
     /// Return a new [`DataFrame`] where all null values are dropped.
@@ -1363,13 +795,13 @@ impl DataFrame {
     /// ```
     pub fn drop_nulls<S>(&self, subset: Option<&[S]>) -> PolarsResult<Self>
     where
-        for<'a> &'a S: Into<PlSmallStr>,
+        for<'a> &'a S: AsRef<str>,
     {
         if let Some(v) = subset {
-            let v = self.select_columns(v)?;
+            let v = self.select_to_vec(v)?;
             self._drop_nulls_impl(v.as_slice())
         } else {
-            self._drop_nulls_impl(self.columns.as_slice())
+            self._drop_nulls_impl(self.columns())
         }
     }
 
@@ -1403,20 +835,20 @@ impl DataFrame {
     /// let df1: DataFrame = df!("Ray type" => ["α", "β", "X", "γ"])?;
     /// let df2: DataFrame = df1.drop("Ray type")?;
     ///
-    /// assert!(df2.is_empty());
+    /// assert_eq!(df2.width(), 0);
     /// # Ok::<(), PolarsError>(())
     /// ```
     pub fn drop(&self, name: &str) -> PolarsResult<Self> {
-        let idx = self.check_name_to_idx(name)?;
-        let mut new_cols = Vec::with_capacity(self.columns.len() - 1);
+        let idx = self.try_get_column_index(name)?;
+        let mut new_cols = Vec::with_capacity(self.width() - 1);
 
-        self.columns.iter().enumerate().for_each(|(i, s)| {
+        self.columns().iter().enumerate().for_each(|(i, s)| {
             if i != idx {
                 new_cols.push(s.clone())
             }
         });
 
-        Ok(unsafe { DataFrame::new_no_checks(self.height(), new_cols) })
+        Ok(unsafe { DataFrame::_new_unchecked_impl(self.height(), new_cols) })
     }
 
     /// Drop columns that are in `names`.
@@ -1434,205 +866,143 @@ impl DataFrame {
         if names.is_empty() {
             return self.clone();
         }
-        let mut new_cols = Vec::with_capacity(self.columns.len().saturating_sub(names.len()));
-        self.columns.iter().for_each(|s| {
+        let mut new_cols = Vec::with_capacity(self.width().saturating_sub(names.len()));
+        self.columns().iter().for_each(|s| {
             if !names.contains(s.name()) {
                 new_cols.push(s.clone())
             }
         });
 
-        unsafe { DataFrame::new_no_checks(self.height(), new_cols) }
+        unsafe { DataFrame::new_unchecked(self.height(), new_cols) }
     }
 
     /// Insert a new column at a given index without checking for duplicates.
     /// This can leave the [`DataFrame`] at an invalid state
-    fn insert_column_no_name_check(
+    fn insert_column_no_namecheck(
         &mut self,
         index: usize,
         column: Column,
     ) -> PolarsResult<&mut Self> {
+        if self.shape() == (0, 0) {
+            unsafe { self.set_height(column.len()) };
+        }
+
         polars_ensure!(
-            self.width() == 0 || column.len() == self.height(),
-            ShapeMismatch: "unable to add a column of length {} to a DataFrame of height {}",
+            column.len() == self.height(),
+            ShapeMismatch:
+            "unable to add a column of length {} to a DataFrame of height {}",
             column.len(), self.height(),
         );
 
-        if self.width() == 0 {
-            self.height = column.len();
-        }
-
-        self.columns.insert(index, column);
-        self.clear_schema();
+        unsafe { self.columns_mut() }.insert(index, column);
         Ok(self)
     }
 
     /// Insert a new column at a given index.
-    pub fn insert_column<S: IntoColumn>(
-        &mut self,
-        index: usize,
-        column: S,
-    ) -> PolarsResult<&mut Self> {
-        let column = column.into_column();
-        self.check_already_present(column.name().as_str())?;
-        self.insert_column_no_name_check(index, column)
+    pub fn insert_column(&mut self, index: usize, column: Column) -> PolarsResult<&mut Self> {
+        let name = column.name();
+
+        polars_ensure!(
+            self.get_column_index(name).is_none(),
+            Duplicate:
+            "column with name {:?} is already present in the DataFrame", name
+        );
+
+        self.insert_column_no_namecheck(index, column)
     }
 
-    fn add_column_by_search(&mut self, column: Column) -> PolarsResult<()> {
-        if let Some(idx) = self.get_column_index(column.name().as_str()) {
-            self.replace_column(idx, column)?;
+    /// Add a new column to this [`DataFrame`] or replace an existing one. Broadcasts unit-length
+    /// columns.
+    pub fn with_column(&mut self, mut column: Column) -> PolarsResult<&mut Self> {
+        if self.shape() == (0, 0) {
+            unsafe { self.set_height(column.len()) };
+        }
+
+        if column.len() != self.height() && column.len() == 1 {
+            column = column.new_from_index(0, self.height());
+        }
+
+        polars_ensure!(
+            column.len() == self.height(),
+            ShapeMismatch: "unable to add a column of length {} to a DataFrame of height {}",
+            column.len(), self.height(),
+        );
+
+        if let Some(i) = self.get_column_index(column.name()) {
+            *unsafe { self.columns_mut() }.get_mut(i).unwrap() = column
         } else {
-            if self.width() == 0 {
-                self.height = column.len();
-            }
+            unsafe { self.columns_mut() }.push(column)
+        };
 
-            self.columns.push(column);
-            self.clear_schema();
-        }
-        Ok(())
-    }
-
-    /// Add a new column to this [`DataFrame`] or replace an existing one.
-    pub fn with_column<C: IntoColumn>(&mut self, column: C) -> PolarsResult<&mut Self> {
-        fn inner(df: &mut DataFrame, mut column: Column) -> PolarsResult<&mut DataFrame> {
-            let height = df.height();
-            if column.len() == 1 && height > 1 {
-                column = column.new_from_index(0, height);
-            }
-
-            if column.len() == height || df.get_columns().is_empty() {
-                df.add_column_by_search(column)?;
-                Ok(df)
-            }
-            // special case for literals
-            else if height == 0 && column.len() == 1 {
-                let s = column.clear();
-                df.add_column_by_search(s)?;
-                Ok(df)
-            } else {
-                polars_bail!(
-                    ShapeMismatch: "unable to add a column of length {} to a DataFrame of height {}",
-                    column.len(), height,
-                );
-            }
-        }
-        let column = column.into_column();
-        inner(self, column)
+        Ok(self)
     }
 
     /// Adds a column to the [`DataFrame`] without doing any checks
     /// on length or duplicates.
     ///
     /// # Safety
-    /// The caller must ensure `self.width() == 0 || column.len() == self.height()` .
-    pub unsafe fn with_column_unchecked(&mut self, column: Column) -> &mut Self {
-        debug_assert!(self.width() == 0 || self.height() == column.len());
-        debug_assert!(self.get_column_index(column.name().as_str()).is_none());
-
-        // SAFETY: Invariant of function guarantees for case `width` > 0. We set the height
-        // properly for `width` == 0.
-        if self.width() == 0 {
-            unsafe { self.set_height(column.len()) };
-        }
-        unsafe { self.get_columns_mut() }.push(column);
-        self.clear_schema();
-
+    /// The caller must ensure `column.len() == self.height()` .
+    pub unsafe fn push_column_unchecked(&mut self, column: Column) -> &mut Self {
+        unsafe { self.columns_mut() }.push(column);
         self
     }
 
-    // Note: Schema can be both input or output_schema
-    fn add_column_by_schema(&mut self, c: Column, schema: &Schema) -> PolarsResult<()> {
-        let name = c.name();
-        if let Some((idx, _, _)) = schema.get_full(name.as_str()) {
-            if self.columns.get(idx).map(|s| s.name()) != Some(name) {
-                // Given schema is output_schema and we can push.
-                if idx == self.columns.len() {
-                    if self.width() == 0 {
-                        self.height = c.len();
-                    }
-
-                    self.columns.push(c);
-                    self.clear_schema();
-                }
-                // Schema is incorrect fallback to search
-                else {
-                    debug_assert!(false);
-                    self.add_column_by_search(c)?;
-                }
-            } else {
-                self.replace_column(idx, c)?;
-            }
-        } else {
-            if self.width() == 0 {
-                self.height = c.len();
-            }
-
-            self.columns.push(c);
-            self.clear_schema();
-        }
-
-        Ok(())
-    }
-
-    // Note: Schema can be both input or output_schema
-    pub fn _add_series(&mut self, series: Vec<Series>, schema: &Schema) -> PolarsResult<()> {
-        for (i, s) in series.into_iter().enumerate() {
-            // we need to branch here
-            // because users can add multiple columns with the same name
-            if i == 0 || schema.get(s.name().as_str()).is_some() {
-                self.with_column_and_schema(s.into_column(), schema)?;
-            } else {
-                self.with_column(s.clone().into_column())?;
-            }
-        }
-        Ok(())
-    }
-
-    pub fn _add_columns(&mut self, columns: Vec<Column>, schema: &Schema) -> PolarsResult<()> {
-        for (i, s) in columns.into_iter().enumerate() {
-            // we need to branch here
-            // because users can add multiple columns with the same name
-            if i == 0 || schema.get(s.name().as_str()).is_some() {
-                self.with_column_and_schema(s, schema)?;
-            } else {
-                self.with_column(s.clone())?;
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Add a new column to this [`DataFrame`] or replace an existing one.
-    /// Uses an existing schema to amortize lookups.
-    /// If the schema is incorrect, we will fallback to linear search.
-    ///
-    /// Note: Schema can be both input or output_schema
-    pub fn with_column_and_schema<C: IntoColumn>(
+    /// Add or replace columns to this [`DataFrame`] or replace an existing one.
+    /// Broadcasts unit-length columns, and uses an existing schema to amortize lookups.
+    pub fn with_columns_mut(
         &mut self,
-        column: C,
-        schema: &Schema,
+        columns: impl IntoIterator<Item = Column>,
+        output_schema: &Schema,
+    ) -> PolarsResult<()> {
+        let columns = columns.into_iter();
+
+        unsafe {
+            self.columns_mut_retain_schema()
+                .reserve(columns.size_hint().0)
+        }
+
+        for c in columns {
+            self.with_column_and_schema_mut(c, output_schema)?;
+        }
+
+        Ok(())
+    }
+
+    fn with_column_and_schema_mut(
+        &mut self,
+        mut column: Column,
+        output_schema: &Schema,
     ) -> PolarsResult<&mut Self> {
-        let mut column = column.into_column();
-
-        let height = self.height();
-        if column.len() == 1 && height > 1 {
-            column = column.new_from_index(0, height);
+        if self.shape() == (0, 0) {
+            unsafe { self.set_height(column.len()) };
         }
 
-        if column.len() == height || self.columns.is_empty() {
-            self.add_column_by_schema(column, schema)?;
-            Ok(self)
+        if column.len() != self.height() && column.len() == 1 {
+            column = column.new_from_index(0, self.height());
         }
-        // special case for literals
-        else if height == 0 && column.len() == 1 {
-            let s = column.clear();
-            self.add_column_by_schema(s, schema)?;
-            Ok(self)
+
+        polars_ensure!(
+            column.len() == self.height(),
+            ShapeMismatch:
+            "unable to add a column of length {} to a DataFrame of height {}",
+            column.len(), self.height(),
+        );
+
+        let i = output_schema
+            .index_of(column.name())
+            .or_else(|| self.get_column_index(column.name()))
+            .unwrap_or(self.width());
+
+        if i < self.width() {
+            *unsafe { self.columns_mut() }.get_mut(i).unwrap() = column
+        } else if i == self.width() {
+            unsafe { self.columns_mut() }.push(column)
         } else {
-            polars_bail!(
-                ShapeMismatch: "unable to add a column of length {} to a DataFrame of height {}",
-                column.len(), height,
-            );
+            // Unordered column insertion is not handled.
+            panic!()
         }
+
+        Ok(self)
     }
 
     /// Get a row in the [`DataFrame`]. Beware this is slow.
@@ -1646,16 +1016,7 @@ impl DataFrame {
     /// }
     /// ```
     pub fn get(&self, idx: usize) -> Option<Vec<AnyValue<'_>>> {
-        match self.columns.first() {
-            Some(s) => {
-                if s.len() <= idx {
-                    return None;
-                }
-            },
-            None => return None,
-        }
-        // SAFETY: we just checked bounds
-        unsafe { Some(self.columns.iter().map(|c| c.get_unchecked(idx)).collect()) }
+        (idx < self.height()).then(|| self.columns().iter().map(|c| c.get(idx).unwrap()).collect())
     }
 
     /// Select a [`Series`] by index.
@@ -1674,69 +1035,7 @@ impl DataFrame {
     /// # Ok::<(), PolarsError>(())
     /// ```
     pub fn select_at_idx(&self, idx: usize) -> Option<&Column> {
-        self.columns.get(idx)
-    }
-
-    /// Select column(s) from this [`DataFrame`] by range and return a new [`DataFrame`]
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use polars_core::prelude::*;
-    /// let df = df! {
-    ///     "0" => [0, 0, 0],
-    ///     "1" => [1, 1, 1],
-    ///     "2" => [2, 2, 2]
-    /// }?;
-    ///
-    /// assert!(df.select(["0", "1"])?.equals(&df.select_by_range(0..=1)?));
-    /// assert!(df.equals(&df.select_by_range(..)?));
-    /// # Ok::<(), PolarsError>(())
-    /// ```
-    pub fn select_by_range<R>(&self, range: R) -> PolarsResult<Self>
-    where
-        R: ops::RangeBounds<usize>,
-    {
-        // This function is copied from std::slice::range (https://doc.rust-lang.org/std/slice/fn.range.html)
-        // because it is the nightly feature. We should change here if this function were stable.
-        fn get_range<R>(range: R, bounds: ops::RangeTo<usize>) -> ops::Range<usize>
-        where
-            R: ops::RangeBounds<usize>,
-        {
-            let len = bounds.end;
-
-            let start: ops::Bound<&usize> = range.start_bound();
-            let start = match start {
-                ops::Bound::Included(&start) => start,
-                ops::Bound::Excluded(start) => start.checked_add(1).unwrap_or_else(|| {
-                    panic!("attempted to index slice from after maximum usize");
-                }),
-                ops::Bound::Unbounded => 0,
-            };
-
-            let end: ops::Bound<&usize> = range.end_bound();
-            let end = match end {
-                ops::Bound::Included(end) => end.checked_add(1).unwrap_or_else(|| {
-                    panic!("attempted to index slice up to maximum usize");
-                }),
-                ops::Bound::Excluded(&end) => end,
-                ops::Bound::Unbounded => len,
-            };
-
-            if start > end {
-                panic!("slice index starts at {start} but ends at {end}");
-            }
-            if end > len {
-                panic!("range end index {end} out of range for slice of length {len}",);
-            }
-
-            ops::Range { start, end }
-        }
-
-        let colnames = self.get_column_names_owned();
-        let range = get_range(range, ..colnames.len());
-
-        self._select_impl(&colnames[range])
+        self.columns().get(idx)
     }
 
     /// Get column index of a [`Series`] by name.
@@ -1757,18 +1056,13 @@ impl DataFrame {
     /// # Ok::<(), PolarsError>(())
     /// ```
     pub fn get_column_index(&self, name: &str) -> Option<usize> {
-        let schema = self.schema();
-        if let Some(idx) = schema.index_of(name) {
-            if self
-                .get_columns()
-                .get(idx)
-                .is_some_and(|c| c.name() == name)
-            {
-                return Some(idx);
-            }
+        if let Some(schema) = self.cached_schema() {
+            schema.index_of(name)
+        } else if self.width() <= LINEAR_SEARCH_LIMIT {
+            self.columns().iter().position(|s| s.name() == name)
+        } else {
+            self.schema().index_of(name)
         }
-
-        self.columns.iter().position(|s| s.name().as_str() == name)
     }
 
     /// Get column index of a [`Series`] by name.
@@ -1785,7 +1079,7 @@ impl DataFrame {
     /// # use polars_core::prelude::*;
     /// let s1 = Column::new("Password".into(), ["123456", "[]B$u$g$s$B#u#n#n#y[]{}"]);
     /// let s2 = Column::new("Robustness".into(), ["Weak", "Strong"]);
-    /// let df: DataFrame = DataFrame::new(vec![s1.clone(), s2])?;
+    /// let df: DataFrame = DataFrame::new_infer_height(vec![s1.clone(), s2])?;
     ///
     /// assert_eq!(df.column("Password")?, &s1);
     /// # Ok::<(), PolarsError>(())
@@ -1793,31 +1087,6 @@ impl DataFrame {
     pub fn column(&self, name: &str) -> PolarsResult<&Column> {
         let idx = self.try_get_column_index(name)?;
         Ok(self.select_at_idx(idx).unwrap())
-    }
-
-    /// Selected multiple columns by name.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use polars_core::prelude::*;
-    /// let df: DataFrame = df!("Latin name" => ["Oncorhynchus kisutch", "Salmo salar"],
-    ///                         "Max weight (kg)" => [16.0, 35.89])?;
-    /// let sv: Vec<&Column> = df.columns(["Latin name", "Max weight (kg)"])?;
-    ///
-    /// assert_eq!(&df[0], sv[0]);
-    /// assert_eq!(&df[1], sv[1]);
-    /// # Ok::<(), PolarsError>(())
-    /// ```
-    pub fn columns<I, S>(&self, names: I) -> PolarsResult<Vec<&Column>>
-    where
-        I: IntoIterator<Item = S>,
-        S: AsRef<str>,
-    {
-        names
-            .into_iter()
-            .map(|name| self.column(name.as_ref()))
-            .collect()
     }
 
     /// Select column(s) from this [`DataFrame`] and return a new [`DataFrame`].
@@ -1830,122 +1099,29 @@ impl DataFrame {
     ///     df.select(["foo", "bar"])
     /// }
     /// ```
-    pub fn select<I, S>(&self, selection: I) -> PolarsResult<Self>
+    pub fn select<I, S>(&self, names: I) -> PolarsResult<Self>
     where
         I: IntoIterator<Item = S>,
-        S: Into<PlSmallStr>,
+        S: AsRef<str>,
     {
-        let cols: UnitVec<PlSmallStr> = selection.into_iter().map(|s| s.into()).collect();
-        self._select_impl(cols.as_slice())
+        DataFrame::new(self.height(), self.select_to_vec(names)?)
     }
 
-    pub fn _select_impl(&self, cols: &[PlSmallStr]) -> PolarsResult<Self> {
-        ensure_names_unique(cols, |s| s.as_str())?;
-        self._select_impl_unchecked(cols)
-    }
-
-    pub fn _select_impl_unchecked(&self, cols: &[PlSmallStr]) -> PolarsResult<Self> {
-        let selected = self.select_columns_impl(cols)?;
-        Ok(unsafe { DataFrame::new_no_checks(self.height(), selected) })
-    }
-
-    /// Select with a known schema. The schema names must match the column names of this DataFrame.
-    pub fn select_with_schema<I, S>(&self, selection: I, schema: &SchemaRef) -> PolarsResult<Self>
-    where
-        I: IntoIterator<Item = S>,
-        S: Into<PlSmallStr>,
-    {
-        let cols: UnitVec<PlSmallStr> = selection.into_iter().map(|s| s.into()).collect();
-        self._select_with_schema_impl(&cols, schema, true)
-    }
-
-    /// Select with a known schema without checking for duplicates in `selection`.
-    /// The schema names must match the column names of this DataFrame.
-    pub fn select_with_schema_unchecked<I, S>(
-        &self,
-        selection: I,
-        schema: &Schema,
-    ) -> PolarsResult<Self>
-    where
-        I: IntoIterator<Item = S>,
-        S: Into<PlSmallStr>,
-    {
-        let cols: UnitVec<PlSmallStr> = selection.into_iter().map(|s| s.into()).collect();
-        self._select_with_schema_impl(&cols, schema, false)
-    }
-
-    /// * The schema names must match the column names of this DataFrame.
-    pub fn _select_with_schema_impl(
-        &self,
-        cols: &[PlSmallStr],
-        schema: &Schema,
-        check_duplicates: bool,
-    ) -> PolarsResult<Self> {
-        if check_duplicates {
-            ensure_names_unique(cols, |s| s.as_str())?;
-        }
-
-        let selected = self.select_columns_impl_with_schema(cols, schema)?;
-        Ok(unsafe { DataFrame::new_no_checks(self.height(), selected) })
-    }
-
-    /// A non generic implementation to reduce compiler bloat.
-    fn select_columns_impl_with_schema(
-        &self,
-        cols: &[PlSmallStr],
-        schema: &Schema,
-    ) -> PolarsResult<Vec<Column>> {
-        if cfg!(debug_assertions) {
-            ensure_matching_schema_names(schema, self.schema())?;
-        }
-
-        cols.iter()
-            .map(|name| {
-                let index = schema.try_get_full(name.as_str())?.0;
-                Ok(self.columns[index].clone())
-            })
-            .collect()
-    }
-
-    pub fn select_physical<I, S>(&self, selection: I) -> PolarsResult<Self>
-    where
-        I: IntoIterator<Item = S>,
-        S: Into<PlSmallStr>,
-    {
-        let cols: UnitVec<PlSmallStr> = selection.into_iter().map(|s| s.into()).collect();
-        self.select_physical_impl(&cols)
-    }
-
-    fn select_physical_impl(&self, cols: &[PlSmallStr]) -> PolarsResult<Self> {
-        ensure_names_unique(cols, |s| s.as_str())?;
-        let selected = self.select_columns_physical_impl(cols)?;
-        Ok(unsafe { DataFrame::new_no_checks(self.height(), selected) })
-    }
-
+    /// Does not check for duplicates.
+    ///
     /// # Safety
-    /// Dtypes must match, as the provided schema becomes the cached schema of the result.
-    pub unsafe fn project(&self, to: SchemaRef) -> PolarsResult<Self> {
-        let mut df = unsafe { self.project_names(to.iter_names())? };
-        df.cached_schema = to.into();
-        Ok(df)
-    }
-
-    /// # Safety
-    /// This does not check for duplicates on names.
-    pub unsafe fn project_names(
-        &self,
-        names: impl IntoIterator<Item = impl AsRef<str>>,
-    ) -> PolarsResult<Self> {
-        let from = self.schema();
-        let columns = names
-            .into_iter()
-            .map(|name| Ok(self.columns[from.try_index_of(name.as_ref())?].clone()))
-            .collect::<PolarsResult<_>>()?;
-        let df = unsafe { Self::new_no_checks(self.height(), columns) };
-        Ok(df)
+    /// `names` must not contain duplicates.
+    pub unsafe fn select_unchecked<I, S>(&self, names: I) -> PolarsResult<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        Ok(unsafe { DataFrame::new_unchecked(self.height(), self.select_to_vec(names)?) })
     }
 
     /// Select column(s) from this [`DataFrame`] and return them into a [`Vec`].
+    ///
+    /// This does not error on duplicate selections.
     ///
     /// # Example
     ///
@@ -1954,85 +1130,17 @@ impl DataFrame {
     /// let df: DataFrame = df!("Name" => ["Methane", "Ethane", "Propane"],
     ///                         "Carbon" => [1, 2, 3],
     ///                         "Hydrogen" => [4, 6, 8])?;
-    /// let sv: Vec<Column> = df.select_columns(["Carbon", "Hydrogen"])?;
+    /// let sv: Vec<Column> = df.select_to_vec(["Carbon", "Hydrogen"])?;
     ///
     /// assert_eq!(df["Carbon"], sv[0]);
     /// assert_eq!(df["Hydrogen"], sv[1]);
     /// # Ok::<(), PolarsError>(())
     /// ```
-    pub fn select_columns(&self, selection: impl IntoVec<PlSmallStr>) -> PolarsResult<Vec<Column>> {
-        let cols = selection.into_vec();
-        self.select_columns_impl(&cols)
-    }
-
-    fn _names_to_idx_map(&self) -> PlHashMap<&str, usize> {
-        self.columns
-            .iter()
-            .enumerate()
-            .map(|(i, s)| (s.name().as_str(), i))
-            .collect()
-    }
-
-    /// A non generic implementation to reduce compiler bloat.
-    fn select_columns_physical_impl(&self, cols: &[PlSmallStr]) -> PolarsResult<Vec<Column>> {
-        let selected = if cols.len() > 1 && self.columns.len() > 10 {
-            let name_to_idx = self._names_to_idx_map();
-            cols.iter()
-                .map(|name| {
-                    let idx = *name_to_idx
-                        .get(name.as_str())
-                        .ok_or_else(|| polars_err!(col_not_found = name))?;
-                    Ok(self.select_at_idx(idx).unwrap().to_physical_repr())
-                })
-                .collect::<PolarsResult<Vec<_>>>()?
-        } else {
-            cols.iter()
-                .map(|c| self.column(c.as_str()).map(|s| s.to_physical_repr()))
-                .collect::<PolarsResult<Vec<_>>>()?
-        };
-
-        Ok(selected)
-    }
-
-    /// A non generic implementation to reduce compiler bloat.
-    fn select_columns_impl(&self, cols: &[PlSmallStr]) -> PolarsResult<Vec<Column>> {
-        let selected = if cols.len() > 1 && self.columns.len() > 10 {
-            // we hash, because there are user that having millions of columns.
-            // # https://github.com/pola-rs/polars/issues/1023
-            let name_to_idx = self._names_to_idx_map();
-
-            cols.iter()
-                .map(|name| {
-                    let idx = *name_to_idx
-                        .get(name.as_str())
-                        .ok_or_else(|| polars_err!(col_not_found = name))?;
-                    Ok(self.select_at_idx(idx).unwrap().clone())
-                })
-                .collect::<PolarsResult<Vec<_>>>()?
-        } else {
-            cols.iter()
-                .map(|c| self.column(c.as_str()).cloned())
-                .collect::<PolarsResult<Vec<_>>>()?
-        };
-
-        Ok(selected)
-    }
-
-    fn filter_height(&self, filtered: &[Column], mask: &BooleanChunked) -> usize {
-        // If there is a filtered column just see how many columns there are left.
-        if let Some(fst) = filtered.first() {
-            return fst.len();
-        }
-
-        // Otherwise, count the number of values that would be filtered and return that height.
-        let num_trues = mask.num_trues();
-        if mask.len() == self.height() {
-            num_trues
-        } else {
-            // This is for broadcasting masks
-            debug_assert!(num_trues == 0 || num_trues == 1);
-            self.height() * num_trues
-        }
+    pub fn select_to_vec(
+        &self,
+        selection: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> PolarsResult<Vec<Column>> {
+        AmortizedColumnSelector::new(self).select_multiple(selection)
     }
 
     /// Take the [`DataFrame`] rows by a boolean mask.
@@ -2047,21 +1155,33 @@ impl DataFrame {
     /// }
     /// ```
     pub fn filter(&self, mask: &BooleanChunked) -> PolarsResult<Self> {
-        let new_col = self.try_apply_columns_par(&|s| s.filter(mask))?;
-        let height = self.filter_height(&new_col, mask);
+        if self.width() == 0 {
+            filter_zero_width(self.height(), mask)
+        } else {
+            let new_columns: Vec<Column> = self.try_apply_columns_par(|s| s.filter(mask))?;
+            let out = unsafe {
+                DataFrame::new_unchecked(new_columns[0].len(), new_columns).with_schema_from(self)
+            };
 
-        Ok(unsafe { DataFrame::new_no_checks(height, new_col) })
+            Ok(out)
+        }
     }
 
     /// Same as `filter` but does not parallelize.
-    pub fn _filter_seq(&self, mask: &BooleanChunked) -> PolarsResult<Self> {
-        let new_col = self.try_apply_columns(&|s| s.filter(mask))?;
-        let height = self.filter_height(&new_col, mask);
+    pub fn filter_seq(&self, mask: &BooleanChunked) -> PolarsResult<Self> {
+        if self.width() == 0 {
+            filter_zero_width(self.height(), mask)
+        } else {
+            let new_columns: Vec<Column> = self.try_apply_columns(|s| s.filter(mask))?;
+            let out = unsafe {
+                DataFrame::new_unchecked(new_columns[0].len(), new_columns).with_schema_from(self)
+            };
 
-        Ok(unsafe { DataFrame::new_no_checks(height, new_col) })
+            Ok(out)
+        }
     }
 
-    /// Take [`DataFrame`] rows by index values.
+    /// Gather [`DataFrame`] rows by index values.
     ///
     /// # Example
     ///
@@ -2073,9 +1193,14 @@ impl DataFrame {
     /// }
     /// ```
     pub fn take(&self, indices: &IdxCa) -> PolarsResult<Self> {
-        let new_col = POOL.install(|| self.try_apply_columns_par(&|s| s.take(indices)))?;
+        check_bounds_ca(indices, self.height().try_into().unwrap_or(IdxSize::MAX))?;
 
-        Ok(unsafe { DataFrame::new_no_checks(indices.len(), new_col) })
+        let new_cols = self.apply_columns_par(|c| {
+            assert_eq!(c.len(), self.height());
+            unsafe { c.take_unchecked(indices) }
+        });
+
+        Ok(unsafe { DataFrame::new_unchecked(indices.len(), new_cols).with_schema_from(self) })
     }
 
     /// # Safety
@@ -2102,8 +1227,8 @@ impl DataFrame {
             POOL.install(|| {
                 if POOL.current_num_threads() > self.width() {
                     let stride = usize::max(idx.len().div_ceil(POOL.current_num_threads()), 256);
-                    if self.len() / stride >= 2 {
-                        self._apply_columns_par(&|c| {
+                    if self.height() / stride >= 2 {
+                        self.apply_columns_par(|c| {
                             // Nested types initiate a rechunk in their take_unchecked implementation.
                             // If we do not rechunk, it will result in rechunk storms downstream.
                             let c = if c.dtype().is_nested() {
@@ -2124,16 +1249,17 @@ impl DataFrame {
                                 )
                         })
                     } else {
-                        self._apply_columns_par(&|c| c.take_unchecked(idx))
+                        self.apply_columns_par(|c| c.take_unchecked(idx))
                     }
                 } else {
-                    self._apply_columns_par(&|c| c.take_unchecked(idx))
+                    self.apply_columns_par(|c| c.take_unchecked(idx))
                 }
             })
         } else {
-            self._apply_columns(&|s| s.take_unchecked(idx))
+            self.apply_columns(|s| s.take_unchecked(idx))
         };
-        unsafe { DataFrame::new_no_checks(idx.len(), cols) }
+
+        unsafe { DataFrame::new_unchecked(idx.len(), cols).with_schema_from(self) }
     }
 
     /// # Safety
@@ -2149,8 +1275,8 @@ impl DataFrame {
             POOL.install(|| {
                 if POOL.current_num_threads() > self.width() {
                     let stride = usize::max(idx.len().div_ceil(POOL.current_num_threads()), 256);
-                    if self.len() / stride >= 2 {
-                        self._apply_columns_par(&|c| {
+                    if self.height() / stride >= 2 {
+                        self.apply_columns_par(|c| {
                             // Nested types initiate a rechunk in their take_unchecked implementation.
                             // If we do not rechunk, it will result in rechunk storms downstream.
                             let c = if c.dtype().is_nested() {
@@ -2175,16 +1301,16 @@ impl DataFrame {
                                 )
                         })
                     } else {
-                        self._apply_columns_par(&|s| s.take_slice_unchecked(idx))
+                        self.apply_columns_par(|s| s.take_slice_unchecked(idx))
                     }
                 } else {
-                    self._apply_columns_par(&|s| s.take_slice_unchecked(idx))
+                    self.apply_columns_par(|s| s.take_slice_unchecked(idx))
                 }
             })
         } else {
-            self._apply_columns(&|s| s.take_slice_unchecked(idx))
+            self.apply_columns(|s| s.take_slice_unchecked(idx))
         };
-        unsafe { DataFrame::new_no_checks(idx.len(), cols) }
+        unsafe { DataFrame::new_unchecked(idx.len(), cols).with_schema_from(self) }
     }
 
     /// Rename a column in the [`DataFrame`].
@@ -2211,10 +1337,9 @@ impl DataFrame {
         );
 
         self.get_column_index(column)
-            .and_then(|idx| self.columns.get_mut(idx))
+            .and_then(|idx| unsafe { self.columns_mut() }.get_mut(idx))
             .ok_or_else(|| polars_err!(col_not_found = column))
             .map(|c| c.rename(name))?;
-        self.clear_schema();
 
         Ok(self)
     }
@@ -2223,8 +1348,8 @@ impl DataFrame {
         &mut self,
         renames: impl Iterator<Item = (&'a str, PlSmallStr)>,
     ) -> PolarsResult<&mut Self> {
-        let mut schema = self.schema().as_ref().clone();
-        self.clear_schema();
+        let mut schema_arc = self.schema().clone();
+        let schema = Arc::make_mut(&mut schema_arc);
 
         for (from, to) in renames {
             if from == to.as_str() {
@@ -2241,12 +1366,16 @@ impl DataFrame {
                 Some((idx, _, _)) => {
                     let (n, _) = schema.get_at_index_mut(idx).unwrap();
                     *n = to.clone();
-                    self.columns.get_mut(idx).unwrap().rename(to);
+                    unsafe { self.columns_mut() }
+                        .get_mut(idx)
+                        .unwrap()
+                        .rename(to);
                 },
             }
         }
 
-        self.cached_schema = OnceLock::from(Arc::new(schema));
+        unsafe { self.set_schema(schema_arc) };
+
         Ok(self)
     }
 
@@ -2255,11 +1384,16 @@ impl DataFrame {
     /// See [`DataFrame::sort`] for more instruction.
     pub fn sort_in_place(
         &mut self,
-        by: impl IntoVec<PlSmallStr>,
+        by: impl IntoIterator<Item = impl AsRef<str>>,
         sort_options: SortMultipleOptions,
     ) -> PolarsResult<&mut Self> {
-        let by_column = self.select_columns(by)?;
-        self.columns = self.sort_impl(by_column, sort_options, None)?.columns;
+        let by_column = self.select_to_vec(by)?;
+
+        let mut out = self.sort_impl(by_column, sort_options, None)?;
+        unsafe { out.set_schema_from(self) };
+
+        *self = out;
+
         Ok(self)
     }
 
@@ -2300,14 +1434,15 @@ impl DataFrame {
                 s
             });
         };
-        if self.is_empty() {
+
+        if self.shape_has_zero() {
             let mut out = self.clone();
             set_sorted(&mut out);
             return Ok(out);
         }
 
         if let Some((0, k)) = slice {
-            if k < self.len() {
+            if k < self.height() {
                 return self.bottom_k_impl(k, by_column, sort_options);
             }
         }
@@ -2350,7 +1485,7 @@ impl DataFrame {
 
         // a lot of indirection in both sorting and take
         let mut df = self.clone();
-        let df = df.as_single_chunk_par();
+        let df = df.rechunk_mut_par();
         let mut take = match (by_column.len(), has_nested) {
             (1, false) => {
                 let s = &by_column[0];
@@ -2364,7 +1499,7 @@ impl DataFrame {
                 // fast path for a frame with a single series
                 // no need to compute the sort indices and then take by these indices
                 // simply sort and return as frame
-                if df.width() == 1 && df.check_name_to_idx(s.name().as_str()).is_ok() {
+                if df.width() == 1 && df.try_get_column_index(s.name().as_str()).is_ok() {
                     let mut out = s.sort_with(options)?;
                     if let Some((offset, len)) = slice {
                         out = out.slice(offset, len);
@@ -2392,7 +1527,7 @@ impl DataFrame {
     /// This dataframe does not necessarily have a specified schema and may be changed at any
     /// point. It is primarily used for debugging.
     pub fn _to_metadata(&self) -> DataFrame {
-        let num_columns = self.columns.len();
+        let num_columns = self.width();
 
         let mut column_names =
             StringChunkedBuilder::new(PlSmallStr::from_static("column_name"), num_columns);
@@ -2406,7 +1541,7 @@ impl DataFrame {
         let mut materialized_at_ca =
             StringChunkedBuilder::new(PlSmallStr::from_static("materialized_at"), num_columns);
 
-        for col in &self.columns {
+        for col in self.columns() {
             let flags = col.get_flags();
 
             let (repr, materialized_at) = match col {
@@ -2426,7 +1561,7 @@ impl DataFrame {
         }
 
         unsafe {
-            DataFrame::new_no_checks(
+            DataFrame::new_unchecked(
                 self.width(),
                 vec![
                     column_names.finish().into_column(),
@@ -2439,7 +1574,6 @@ impl DataFrame {
             )
         }
     }
-
     /// Return a sorted clone of this [`DataFrame`].
     ///
     /// In many cases the output chunks will be continuous in memory but this is not guaranteed
@@ -2479,7 +1613,7 @@ impl DataFrame {
     /// Also see [`DataFrame::sort_in_place`].
     pub fn sort(
         &self,
-        by: impl IntoVec<PlSmallStr>,
+        by: impl IntoIterator<Item = impl AsRef<str>>,
         sort_options: SortMultipleOptions,
     ) -> PolarsResult<Self> {
         let mut df = self.clone();
@@ -2487,7 +1621,7 @@ impl DataFrame {
         Ok(df)
     }
 
-    /// Replace a column with a [`Series`].
+    /// Replace a column with a [`Column`].
     ///
     /// # Example
     ///
@@ -2495,27 +1629,14 @@ impl DataFrame {
     /// # use polars_core::prelude::*;
     /// let mut df: DataFrame = df!("Country" => ["United States", "China"],
     ///                         "Area (km²)" => [9_833_520, 9_596_961])?;
-    /// let s: Series = Series::new("Country".into(), ["USA", "PRC"]);
+    /// let s: Column = Column::new("Country".into(), ["USA", "PRC"]);
     ///
     /// assert!(df.replace("Nation", s.clone()).is_err());
     /// assert!(df.replace("Country", s).is_ok());
     /// # Ok::<(), PolarsError>(())
     /// ```
-    pub fn replace<S: IntoSeries>(&mut self, column: &str, new_col: S) -> PolarsResult<&mut Self> {
-        self.apply(column, |_| new_col.into_series())
-    }
-
-    /// Replace or update a column. The difference between this method and [DataFrame::with_column]
-    /// is that now the value of `column: &str` determines the name of the column and not the name
-    /// of the `Series` passed to this method.
-    pub fn replace_or_add<S: IntoSeries>(
-        &mut self,
-        column: PlSmallStr,
-        new_col: S,
-    ) -> PolarsResult<&mut Self> {
-        let mut new_col = new_col.into_series();
-        new_col.rename(column);
-        self.with_column(new_col)
+    pub fn replace(&mut self, column: &str, new_col: Column) -> PolarsResult<&mut Self> {
+        self.apply(column, |_| new_col)
     }
 
     /// Replace column at index `idx` with a [`Series`].
@@ -2526,33 +1647,29 @@ impl DataFrame {
     /// # use polars_core::prelude::*;
     /// let s0 = Series::new("foo".into(), ["ham", "spam", "egg"]);
     /// let s1 = Series::new("ascii".into(), [70, 79, 79]);
-    /// let mut df = DataFrame::new(vec![s0, s1])?;
+    /// let mut df = DataFrame::new_infer_height(vec![s0, s1])?;
     ///
     /// // Add 32 to get lowercase ascii values
     /// df.replace_column(1, df.select_at_idx(1).unwrap() + 32);
     /// # Ok::<(), PolarsError>(())
     /// ```
-    pub fn replace_column<C: IntoColumn>(
-        &mut self,
-        index: usize,
-        new_column: C,
-    ) -> PolarsResult<&mut Self> {
+    pub fn replace_column(&mut self, index: usize, new_column: Column) -> PolarsResult<&mut Self> {
         polars_ensure!(
             index < self.width(),
             ShapeMismatch:
             "unable to replace at index {}, the DataFrame has only {} columns",
             index, self.width(),
         );
-        let mut new_column = new_column.into_column();
+
         polars_ensure!(
             new_column.len() == self.height(),
             ShapeMismatch:
             "unable to replace a column, series length {} doesn't match the DataFrame height {}",
             new_column.len(), self.height(),
         );
-        let old_col = &mut self.columns[index];
-        mem::swap(old_col, &mut new_column);
-        self.clear_schema();
+
+        unsafe { *self.columns_mut().get_mut(index).unwrap() = new_column };
+
         Ok(self)
     }
 
@@ -2564,7 +1681,7 @@ impl DataFrame {
     /// # use polars_core::prelude::*;
     /// let s0 = Column::new("foo".into(), ["ham", "spam", "egg"]);
     /// let s1 = Column::new("names".into(), ["Jean", "Claude", "van"]);
-    /// let mut df = DataFrame::new(vec![s0, s1])?;
+    /// let mut df = DataFrame::new_infer_height(vec![s0, s1])?;
     ///
     /// fn str_to_len(str_val: &Column) -> Column {
     ///     str_val.str()
@@ -2601,7 +1718,7 @@ impl DataFrame {
         F: FnOnce(&Column) -> C,
         C: IntoColumn,
     {
-        let idx = self.check_name_to_idx(name)?;
+        let idx = self.try_get_column_index(name)?;
         self.apply_at_idx(idx, f)?;
         Ok(self)
     }
@@ -2615,7 +1732,7 @@ impl DataFrame {
     /// # use polars_core::prelude::*;
     /// let s0 = Column::new("foo".into(), ["ham", "spam", "egg"]);
     /// let s1 = Column::new("ascii".into(), [70, 79, 79]);
-    /// let mut df = DataFrame::new(vec![s0, s1])?;
+    /// let mut df = DataFrame::new_infer_height(vec![s0, s1])?;
     ///
     /// // Add 32 to get lowercase ascii values
     /// df.apply_at_idx(1, |s| s + 32);
@@ -2643,39 +1760,36 @@ impl DataFrame {
     {
         let df_height = self.height();
         let width = self.width();
-        let col = self.columns.get_mut(idx).ok_or_else(|| {
+
+        let cached_schema = self.cached_schema().cloned();
+
+        let col = unsafe { self.columns_mut() }.get_mut(idx).ok_or_else(|| {
             polars_err!(
                 ComputeError: "invalid column index: {} for a DataFrame with {} columns",
                 idx, width
             )
         })?;
-        let name = col.name().clone();
-        let dtype_before = col.dtype().clone();
-        let new_col = f(col).into_column();
-        match new_col.len() {
-            1 => {
-                let new_col = new_col.new_from_index(0, df_height);
-                let _ = mem::replace(col, new_col);
-            },
-            len if (len == df_height) => {
-                let _ = mem::replace(col, new_col);
-            },
-            len => polars_bail!(
-                ShapeMismatch:
-                "resulting Series has length {} while the DataFrame has height {}",
-                len, df_height
-            ),
+
+        let mut new_col = f(col).into_column();
+
+        if new_col.len() != df_height && new_col.len() == 1 {
+            new_col = new_col.new_from_index(0, df_height);
         }
 
-        // make sure the name remains the same after applying the closure
-        unsafe {
-            let col = self.columns.get_unchecked_mut(idx);
-            col.rename(name);
+        polars_ensure!(
+            new_col.len() == df_height,
+            ShapeMismatch:
+            "apply_at_idx: resulting Series has length {} while the DataFrame has height {}",
+            new_col.len(), df_height
+        );
 
-            if col.dtype() != &dtype_before {
-                self.clear_schema();
-            }
+        new_col = new_col.with_name(col.name().clone());
+        let col_before = std::mem::replace(col, new_col);
+
+        if col.dtype() == col_before.dtype() {
+            unsafe { self.set_opt_schema(cached_schema) };
         }
+
         Ok(self)
     }
 
@@ -2690,7 +1804,7 @@ impl DataFrame {
     /// # use polars_core::prelude::*;
     /// let s0 = Column::new("foo".into(), ["ham", "spam", "egg", "bacon", "quack"]);
     /// let s1 = Column::new("values".into(), [1, 2, 3, 4, 5]);
-    /// let mut df = DataFrame::new(vec![s0, s1])?;
+    /// let mut df = DataFrame::new_infer_height(vec![s0, s1])?;
     ///
     /// let idx = vec![0, 1, 4];
     ///
@@ -2724,22 +1838,35 @@ impl DataFrame {
         F: FnOnce(&Column) -> PolarsResult<C>,
         C: IntoColumn,
     {
+        let df_height = self.height();
         let width = self.width();
-        let col = self.columns.get_mut(idx).ok_or_else(|| {
+
+        let cached_schema = self.cached_schema().cloned();
+
+        let col = unsafe { self.columns_mut() }.get_mut(idx).ok_or_else(|| {
             polars_err!(
                 ComputeError: "invalid column index: {} for a DataFrame with {} columns",
                 idx, width
             )
         })?;
-        let name = col.name().clone();
 
-        let _ = mem::replace(col, f(col).map(|c| c.into_column())?);
+        let mut new_col = f(col).map(|c| c.into_column())?;
+
+        polars_ensure!(
+            new_col.len() == df_height,
+            ShapeMismatch:
+            "try_apply_at_idx: resulting Series has length {} while the DataFrame has height {}",
+            new_col.len(), df_height
+        );
 
         // make sure the name remains the same after applying the closure
-        unsafe {
-            let col = self.columns.get_unchecked_mut(idx);
-            col.rename(name);
+        new_col = new_col.with_name(col.name().clone());
+        let col_before = std::mem::replace(col, new_col);
+
+        if col.dtype() == col_before.dtype() {
+            unsafe { self.set_opt_schema(cached_schema) };
         }
+
         Ok(self)
     }
 
@@ -2754,7 +1881,7 @@ impl DataFrame {
     /// # use polars_core::prelude::*;
     /// let s0 = Column::new("foo".into(), ["ham", "spam", "egg", "bacon", "quack"]);
     /// let s1 = Column::new("values".into(), [1, 2, 3, 4, 5]);
-    /// let mut df = DataFrame::new(vec![s0, s1])?;
+    /// let mut df = DataFrame::new_infer_height(vec![s0, s1])?;
     ///
     /// // create a mask
     /// let values = df.column("values")?.as_materialized_series();
@@ -2828,14 +1955,12 @@ impl DataFrame {
         if offset == 0 && length == self.height() {
             return self.clone();
         }
+
         if length == 0 {
             return self.clear();
         }
-        let cols = self
-            .columns
-            .iter()
-            .map(|s| s.slice(offset, length))
-            .collect::<Vec<_>>();
+
+        let cols = self.apply_columns(|s| s.slice(offset, length));
 
         let height = if let Some(fst) = cols.first() {
             fst.len()
@@ -2844,24 +1969,24 @@ impl DataFrame {
             length
         };
 
-        unsafe { DataFrame::new_no_checks(height, cols) }
+        unsafe { DataFrame::_new_unchecked_impl(height, cols).with_schema_from(self) }
     }
 
     /// Split [`DataFrame`] at the given `offset`.
     pub fn split_at(&self, offset: i64) -> (Self, Self) {
-        let (a, b) = self.columns.iter().map(|s| s.split_at(offset)).unzip();
+        let (a, b) = self.columns().iter().map(|s| s.split_at(offset)).unzip();
 
         let (idx, _) = slice_offsets(offset, 0, self.height());
 
-        let a = unsafe { DataFrame::new_no_checks(idx, a) };
-        let b = unsafe { DataFrame::new_no_checks(self.height() - idx, b) };
+        let a = unsafe { DataFrame::new_unchecked(idx, a).with_schema_from(self) };
+        let b = unsafe { DataFrame::new_unchecked(self.height() - idx, b).with_schema_from(self) };
         (a, b)
     }
 
     #[must_use]
     pub fn clear(&self) -> Self {
-        let cols = self.columns.iter().map(|s| s.clear()).collect::<Vec<_>>();
-        unsafe { DataFrame::new_no_checks(0, cols) }
+        let cols = self.columns().iter().map(|s| s.clear()).collect::<Vec<_>>();
+        unsafe { DataFrame::_new_unchecked_impl(0, cols).with_schema_from(self) }
     }
 
     #[must_use]
@@ -2869,8 +1994,8 @@ impl DataFrame {
         if offset == 0 && length == self.height() {
             return self.clone();
         }
-        let columns = self._apply_columns_par(&|s| s.slice(offset, length));
-        unsafe { DataFrame::new_no_checks(length, columns) }
+        let columns = self.apply_columns_par(|s| s.slice(offset, length));
+        unsafe { DataFrame::new_unchecked(length, columns).with_schema_from(self) }
     }
 
     #[must_use]
@@ -2879,12 +2004,12 @@ impl DataFrame {
             return self.clone();
         }
         // @scalar-opt
-        let columns = self._apply_columns(&|s| {
+        let columns = self.apply_columns(|s| {
             let mut out = s.slice(offset, length);
             out.shrink_to_fit();
             out
         });
-        unsafe { DataFrame::new_no_checks(length, columns) }
+        unsafe { DataFrame::new_unchecked(length, columns).with_schema_from(self) }
     }
 
     /// Get the head of the [`DataFrame`].
@@ -2922,15 +2047,10 @@ impl DataFrame {
     /// ```
     #[must_use]
     pub fn head(&self, length: Option<usize>) -> Self {
-        let cols = self
-            .columns
-            .iter()
-            .map(|c| c.head(length))
-            .collect::<Vec<_>>();
+        let new_height = usize::min(self.height(), length.unwrap_or(HEAD_DEFAULT_LENGTH));
+        let new_cols = self.apply_columns(|c| c.head(Some(new_height)));
 
-        let height = length.unwrap_or(HEAD_DEFAULT_LENGTH);
-        let height = usize::min(height, self.height());
-        unsafe { DataFrame::new_no_checks(height, cols) }
+        unsafe { DataFrame::new_unchecked(new_height, new_cols).with_schema_from(self) }
     }
 
     /// Get the tail of the [`DataFrame`].
@@ -2965,15 +2085,10 @@ impl DataFrame {
     /// ```
     #[must_use]
     pub fn tail(&self, length: Option<usize>) -> Self {
-        let cols = self
-            .columns
-            .iter()
-            .map(|c| c.tail(length))
-            .collect::<Vec<_>>();
+        let new_height = usize::min(self.height(), length.unwrap_or(TAIL_DEFAULT_LENGTH));
+        let new_cols = self.apply_columns(|c| c.tail(Some(new_height)));
 
-        let height = length.unwrap_or(TAIL_DEFAULT_LENGTH);
-        let height = usize::min(height, self.height());
-        unsafe { DataFrame::new_no_checks(height, cols) }
+        unsafe { DataFrame::new_unchecked(new_height, new_cols).with_schema_from(self) }
     }
 
     /// Iterator over the rows in this [`DataFrame`] as Arrow RecordBatches.
@@ -2992,16 +2107,16 @@ impl DataFrame {
         let must_convert = compat_level.0 == 0;
         let parallel = parallel
             && must_convert
-            && self.columns.len() > 1
+            && self.width() > 1
             && self
-                .columns
+                .columns()
                 .iter()
                 .any(|s| matches!(s.dtype(), DataType::String | DataType::Binary));
 
         RecordBatchIter {
-            columns: &self.columns,
+            columns: self.columns(),
             schema: Arc::new(
-                self.columns
+                self.columns()
                     .iter()
                     .map(|c| c.field().to_arrow(compat_level))
                     .collect(),
@@ -3026,7 +2141,7 @@ impl DataFrame {
         debug_assert!(!self.should_rechunk());
         PhysRecordBatchIter {
             schema: Arc::new(
-                self.get_columns()
+                self.columns()
                     .iter()
                     .map(|c| c.field().to_arrow(CompatLevel::newest()))
                     .collect(),
@@ -3041,8 +2156,8 @@ impl DataFrame {
     /// Get a [`DataFrame`] with all the columns in reversed order.
     #[must_use]
     pub fn reverse(&self) -> Self {
-        let cols = self.columns.iter().map(|s| s.reverse()).collect::<Vec<_>>();
-        unsafe { DataFrame::new_no_checks(self.height(), cols) }
+        let new_cols = self.apply_columns(Column::reverse);
+        unsafe { DataFrame::new_unchecked(self.height(), new_cols).with_schema_from(self) }
     }
 
     /// Shift the values by a given period and fill the parts that will be empty due to this operation
@@ -3051,8 +2166,8 @@ impl DataFrame {
     /// See the method on [Series](crate::series::SeriesTrait::shift) for more info on the `shift` operation.
     #[must_use]
     pub fn shift(&self, periods: i64) -> Self {
-        let col = self._apply_columns_par(&|s| s.shift(periods));
-        unsafe { DataFrame::new_no_checks(self.height(), col) }
+        let col = self.apply_columns_par(|s| s.shift(periods));
+        unsafe { DataFrame::new_unchecked(self.height(), col).with_schema_from(self) }
     }
 
     /// Replace None values with one of the following strategies:
@@ -3064,9 +2179,9 @@ impl DataFrame {
     ///
     /// See the method on [Series](crate::series::Series::fill_null) for more info on the `fill_null` operation.
     pub fn fill_null(&self, strategy: FillNullStrategy) -> PolarsResult<Self> {
-        let col = self.try_apply_columns_par(&|s| s.fill_null(strategy))?;
+        let col = self.try_apply_columns_par(|s| s.fill_null(strategy))?;
 
-        Ok(unsafe { DataFrame::new_no_checks(self.height(), col) })
+        Ok(unsafe { DataFrame::new_unchecked(self.height(), col) })
     }
 
     /// Pipe different functions/ closure operations that work on a DataFrame together.
@@ -3092,7 +2207,6 @@ impl DataFrame {
     {
         f(self, args)
     }
-
     /// Drop duplicate rows from a [`DataFrame`].
     /// *This fails when there is a column of type List in DataFrame*
     ///
@@ -3165,10 +2279,15 @@ impl DataFrame {
         keep: UniqueKeepStrategy,
         slice: Option<(i64, usize)>,
     ) -> PolarsResult<Self> {
+        if self.width() == 0 {
+            let height = usize::min(self.height(), 1);
+            return Ok(DataFrame::empty_with_height(height));
+        }
+
         let names = subset.unwrap_or_else(|| self.get_column_names_owned());
         let mut df = self.clone();
         // take on multiple chunks is terrible
-        df.as_single_chunk_par();
+        df.rechunk_mut_par();
 
         let columns = match (keep, maintain_order) {
             (UniqueKeepStrategy::First | UniqueKeepStrategy::Any, true) => {
@@ -3176,7 +2295,7 @@ impl DataFrame {
                 let groups = gb.get_groups();
                 let (offset, len) = slice.unwrap_or((0, groups.len()));
                 let groups = groups.slice(offset, len);
-                df._apply_columns_par(&|s| unsafe { s.agg_first(&groups) })
+                df.apply_columns_par(|s| unsafe { s.agg_first(&groups) })
             },
             (UniqueKeepStrategy::Last, true) => {
                 // maintain order by last values, so the sorted groups are not correct as they
@@ -3207,14 +2326,14 @@ impl DataFrame {
                 let groups = gb.get_groups();
                 let (offset, len) = slice.unwrap_or((0, groups.len()));
                 let groups = groups.slice(offset, len);
-                df._apply_columns_par(&|s| unsafe { s.agg_first(&groups) })
+                df.apply_columns_par(|s| unsafe { s.agg_first(&groups) })
             },
             (UniqueKeepStrategy::Last, false) => {
                 let gb = df.group_by(names)?;
                 let groups = gb.get_groups();
                 let (offset, len) = slice.unwrap_or((0, groups.len()));
                 let groups = groups.slice(offset, len);
-                df._apply_columns_par(&|s| unsafe { s.agg_last(&groups) })
+                df.apply_columns_par(|s| unsafe { s.agg_last(&groups) })
             },
             (UniqueKeepStrategy::None, _) => {
                 let df_part = df.select(names)?;
@@ -3227,8 +2346,7 @@ impl DataFrame {
                 return Ok(filtered);
             },
         };
-        let height = Self::infer_height(&columns);
-        Ok(unsafe { DataFrame::new_no_checks(height, columns) })
+        Ok(unsafe { DataFrame::new_unchecked_infer_height(columns).with_schema_from(self) })
     }
 
     /// Get a mask of all the unique rows in the [`DataFrame`].
@@ -3284,12 +2402,9 @@ impl DataFrame {
     /// Create a new [`DataFrame`] that shows the null counts per column.
     #[must_use]
     pub fn null_count(&self) -> Self {
-        let cols = self
-            .columns
-            .iter()
-            .map(|c| Column::new(c.name().clone(), [c.null_count() as IdxSize]))
-            .collect();
-        unsafe { Self::new_no_checks(1, cols) }
+        let cols =
+            self.apply_columns(|c| Column::new(c.name().clone(), [c.null_count() as IdxSize]));
+        unsafe { Self::new_unchecked(1, cols) }
     }
 
     /// Hash and combine the row values
@@ -3311,7 +2426,7 @@ impl DataFrame {
 
     /// Get the supertype of the columns in this DataFrame
     pub fn get_supertype(&self) -> Option<PolarsResult<DataType>> {
-        self.columns
+        self.columns()
             .iter()
             .map(|s| Ok(s.dtype().clone()))
             .reduce(|acc, b| try_get_supertype(&acc?, &b.unwrap()))
@@ -3342,6 +2457,8 @@ impl DataFrame {
         #[cfg(debug_assertions)]
         {
             if idx.len() > 2 {
+                use crate::series::IsSorted;
+
                 match sorted {
                     IsSorted::Ascending => {
                         assert!(idx[0] <= idx[idx.len() - 1]);
@@ -3357,7 +2474,6 @@ impl DataFrame {
         ca.set_sorted_flag(sorted);
         self.take_unchecked_impl(&ca, allow_threads)
     }
-
     #[cfg(all(feature = "partition_by", feature = "algorithm_group_by"))]
     #[doc(hidden)]
     pub fn _partition_by_impl(
@@ -3367,7 +2483,7 @@ impl DataFrame {
         include_key: bool,
         parallel: bool,
     ) -> PolarsResult<Vec<DataFrame>> {
-        let selected_keys = self.select_columns(cols.iter().cloned())?;
+        let selected_keys = self.select_to_vec(cols.iter().cloned())?;
         let groups = self.group_by_with_series(selected_keys, parallel, stable)?;
         let groups = groups.into_groups();
 
@@ -3386,7 +2502,7 @@ impl DataFrame {
                     GroupsType::Idx(idx) => {
                         // Rechunk as the gather may rechunk for every group #17562.
                         let mut df = df.clone();
-                        df.as_single_chunk_par();
+                        df.rechunk_mut_par();
                         Ok(idx
                             .into_par_iter()
                             .map(|(_, group)| {
@@ -3412,7 +2528,7 @@ impl DataFrame {
                 GroupsType::Idx(idx) => {
                     // Rechunk as the gather may rechunk for every group #17562.
                     let mut df = df;
-                    df.as_single_chunk();
+                    df.rechunk_mut();
                     Ok(idx
                         .into_iter()
                         .map(|(_, group)| {
@@ -3461,13 +2577,12 @@ impl DataFrame {
     /// Unnest the given `Struct` columns. This means that the fields of the `Struct` type will be
     /// inserted as columns.
     #[cfg(feature = "dtype-struct")]
-    pub fn unnest<I: IntoVec<PlSmallStr>>(
+    pub fn unnest(
         &self,
-        cols: I,
+        cols: impl IntoIterator<Item = impl Into<PlSmallStr>>,
         separator: Option<&str>,
     ) -> PolarsResult<DataFrame> {
-        let cols = cols.into_vec();
-        self.unnest_impl(cols.into_iter().collect(), separator)
+        self.unnest_impl(cols.into_iter().map(Into::into).collect(), separator)
     }
 
     #[cfg(feature = "dtype-struct")]
@@ -3478,7 +2593,7 @@ impl DataFrame {
     ) -> PolarsResult<DataFrame> {
         let mut new_cols = Vec::with_capacity(std::cmp::min(self.width() * 2, self.width() + 128));
         let mut count = 0;
-        for s in &self.columns {
+        for s in self.columns() {
             if cols.contains(s.name()) {
                 let ca = s.struct_()?.clone();
                 new_cols.extend(ca.fields_as_series().into_iter().map(|mut f| {
@@ -3507,11 +2622,8 @@ impl DataFrame {
                     .ok_or_else(|| polars_err!(col_not_found = col))?;
             }
         }
-        DataFrame::new(new_cols)
-    }
 
-    pub(crate) fn infer_height(cols: &[Column]) -> usize {
-        cols.first().map_or(0, Column::len)
+        DataFrame::new_infer_height(new_cols)
     }
 
     pub fn append_record_batch(&mut self, rb: RecordBatchT<ArrayRef>) -> PolarsResult<()> {
@@ -3526,14 +2638,10 @@ impl DataFrame {
         self.vstack_mut_owned_unchecked(df);
         Ok(())
     }
-
-    pub fn into_columns(self) -> Vec<Column> {
-        self.columns
-    }
 }
 
 pub struct RecordBatchIter<'a> {
-    columns: &'a Vec<Column>,
+    columns: &'a [Column],
     schema: ArrowSchemaRef,
     idx: usize,
     n_chunks: usize,
@@ -3604,18 +2712,6 @@ impl Iterator for PhysRecordBatchIter<'_> {
     }
 }
 
-impl Default for DataFrame {
-    fn default() -> Self {
-        DataFrame::empty()
-    }
-}
-
-impl From<DataFrame> for Vec<Column> {
-    fn from(df: DataFrame) -> Self {
-        df.columns
-    }
-}
-
 // utility to test if we can vstack/extend the columns
 fn ensure_can_extend(left: &Column, right: &Column) -> PolarsResult<()> {
     polars_ensure!(
@@ -3633,7 +2729,7 @@ mod test {
     fn create_frame() -> DataFrame {
         let s0 = Column::new("days".into(), [0, 1, 2].as_ref());
         let s1 = Column::new("temp".into(), [22.1, 19.9, 7.].as_ref());
-        DataFrame::new(vec![s0, s1]).unwrap()
+        DataFrame::new_infer_height(vec![s0, s1]).unwrap()
     }
 
     #[test]
@@ -3670,7 +2766,7 @@ mod test {
         let col_name = "some_col";
         let v = vec!["test".to_string()];
         let s0 = Column::new(PlSmallStr::from_str(col_name), v);
-        let mut df = DataFrame::new(vec![s0]).unwrap();
+        let mut df = DataFrame::new_infer_height(vec![s0]).unwrap();
 
         df = df
             .filter(
@@ -3729,7 +2825,7 @@ mod test {
         s.append(&s2)?;
 
         // Append series to frame
-        let out = base.with_column(s)?;
+        let out = base.with_column(s.into_column())?;
 
         // Now we should rechunk
         assert!(out.should_rechunk());
@@ -3744,11 +2840,11 @@ mod test {
         .unwrap();
         // check if column is replaced
         assert!(
-            df.with_column(Series::new("foo".into(), &[1, 2, 3]))
+            df.with_column(Column::new("foo".into(), &[1, 2, 3]))
                 .is_ok()
         );
         assert!(
-            df.with_column(Series::new("bar".into(), &[1, 2, 3]))
+            df.with_column(Column::new("bar".into(), &[1, 2, 3]))
                 .is_ok()
         );
         assert!(df.column("bar").is_ok())
@@ -3803,21 +2899,7 @@ mod test {
         .unwrap();
 
         df.vstack_mut(&df_data).unwrap();
-        assert_eq!(df.height, 6)
-    }
-
-    #[test]
-    fn test_replace_or_add() -> PolarsResult<()> {
-        let mut df = df!(
-            "a" => [1, 2, 3],
-            "b" => [1, 2, 3]
-        )?;
-
-        // check that the new column is "c" and not "bar".
-        df.replace_or_add("c".into(), Series::new("bar".into(), [1, 2, 3]))?;
-
-        assert_eq!(df.get_column_names(), &["a", "b", "c"]);
-        Ok(())
+        assert_eq!(df.height(), 6)
     }
 
     #[test]

--- a/crates/polars-core/src/frame/projection.rs
+++ b/crates/polars-core/src/frame/projection.rs
@@ -1,0 +1,60 @@
+use polars_error::{PolarsResult, polars_err};
+use polars_utils::aliases::PlHashMap;
+
+use crate::frame::DataFrame;
+use crate::prelude::Column;
+
+pub(super) const LINEAR_SEARCH_LIMIT: usize = 4;
+
+/// Selects columns by name.
+pub(super) enum AmortizedColumnSelector<'a> {
+    Direct {
+        df: &'a DataFrame,
+    },
+    NameToIdxMapping {
+        df: &'a DataFrame,
+        name_to_idx: PlHashMap<&'a str, usize>,
+    },
+}
+
+impl<'a> AmortizedColumnSelector<'a> {
+    pub(super) fn new(df: &'a DataFrame) -> Self {
+        if df.width() <= LINEAR_SEARCH_LIMIT || df.cached_schema().is_some() {
+            Self::Direct { df }
+        } else {
+            Self::NameToIdxMapping {
+                df,
+                name_to_idx: df
+                    .columns()
+                    .iter()
+                    .enumerate()
+                    .map(|(i, s)| (s.name().as_str(), i))
+                    .collect(),
+            }
+        }
+    }
+
+    fn select(&self, name: &str) -> PolarsResult<&'a Column> {
+        match self {
+            Self::Direct { df } => df.column(name),
+            Self::NameToIdxMapping { df, name_to_idx } => {
+                let i = *name_to_idx
+                    .get(name)
+                    .ok_or_else(|| polars_err!(col_not_found = name))?;
+
+                Ok(df.select_at_idx(i).unwrap())
+            },
+        }
+    }
+
+    /// Does not error on duplicate selections.
+    pub(super) fn select_multiple(
+        &self,
+        names: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> PolarsResult<Vec<Column>> {
+        names
+            .into_iter()
+            .map(|name| self.select(name.as_ref()).cloned())
+            .collect()
+    }
+}

--- a/crates/polars-core/src/frame/proptest.rs
+++ b/crates/polars-core/src/frame/proptest.rs
@@ -1,10 +1,6 @@
 use std::ops::RangeInclusive;
-use std::rc::Rc;
 
-use proptest::prelude::*;
-
-use crate::prelude::{Column, DataFrame};
-use crate::series::proptest::{SeriesArbitraryOptions, series_strategy};
+use crate::series::proptest::SeriesArbitraryOptions;
 
 pub struct DataFrameArbitraryOptions {
     pub series_options: SeriesArbitraryOptions,
@@ -18,24 +14,4 @@ impl Default for DataFrameArbitraryOptions {
             num_columns: 0..=5,
         }
     }
-}
-
-pub fn dataframe_strategy(
-    options: Rc<DataFrameArbitraryOptions>,
-    nesting_level: usize,
-) -> impl Strategy<Value = DataFrame> {
-    options
-        .series_options
-        .series_length_range
-        .clone()
-        .prop_flat_map(move |series_length| {
-            let mut opts = options.series_options.clone();
-            opts.series_length_range = series_length..=series_length;
-
-            prop::collection::vec(
-                series_strategy(Rc::new(opts), nesting_level),
-                options.num_columns.clone(),
-            )
-        })
-        .prop_map(|series| DataFrame::new(series.into_iter().map(Column::from).collect()).unwrap())
 }

--- a/crates/polars-core/src/frame/row/dataframe.rs
+++ b/crates/polars-core/src/frame/row/dataframe.rs
@@ -54,7 +54,7 @@ impl DataFrame {
         if schema.is_empty() {
             let height = rows.count();
             let columns = Vec::new();
-            return Ok(unsafe { DataFrame::new_no_checks(height, columns) });
+            return Ok(unsafe { DataFrame::new_unchecked(height, columns) });
         }
 
         let capacity = rows.size_hint().0;
@@ -75,6 +75,7 @@ impl DataFrame {
             }
             Ok(())
         })?;
+
         let v = buffers
             .into_iter()
             .zip(schema.iter_names())
@@ -90,7 +91,8 @@ impl DataFrame {
                 }
             })
             .collect();
-        DataFrame::new(v)
+
+        DataFrame::new(expected_len, v)
     }
 
     /// Create a new [`DataFrame`] from an iterator over rows. This should only be used when you have row wise data,
@@ -132,7 +134,8 @@ impl DataFrame {
                 }
             })
             .collect();
-        DataFrame::new(v)
+
+        DataFrame::new(expected_len, v)
     }
 
     /// Create a new [`DataFrame`] from rows. This should only be used when you have row wise data,

--- a/crates/polars-core/src/frame/row/transpose.rs
+++ b/crates/polars-core/src/frame/row/transpose.rs
@@ -29,7 +29,7 @@ impl DataFrame {
             },
         };
 
-        let cols = &self.columns;
+        let cols = self.columns();
         match dtype {
             #[cfg(feature = "dtype-i8")]
             DataType::Int8 => numeric_transpose::<Int8Type>(cols, names_out, &mut cols_t),
@@ -84,7 +84,8 @@ impl DataFrame {
                 }));
             },
         };
-        DataFrame::new_with_height(new_height, cols_t)
+
+        DataFrame::new(new_height, cols_t)
     }
 
     pub fn transpose(
@@ -109,7 +110,7 @@ impl DataFrame {
         new_col_names: Option<Either<PlSmallStr, Vec<PlSmallStr>>>,
     ) -> PolarsResult<DataFrame> {
         // We must iterate columns as [`AnyValue`], so we must be contiguous.
-        self.as_single_chunk_par();
+        self.rechunk_mut_par();
 
         let mut df = Cow::Borrowed(self); // Can't use self because we might drop a name column
         let names_out = match new_col_names {

--- a/crates/polars-core/src/frame/upstream_traits.rs
+++ b/crates/polars-core/src/frame/upstream_traits.rs
@@ -4,26 +4,6 @@ use arrow::record_batch::RecordBatchT;
 
 use crate::prelude::*;
 
-impl FromIterator<Series> for DataFrame {
-    /// # Panics
-    ///
-    /// Panics if Series have different lengths.
-    fn from_iter<T: IntoIterator<Item = Series>>(iter: T) -> Self {
-        let v = iter.into_iter().map(Column::from).collect();
-        DataFrame::new(v).expect("could not create DataFrame from iterator")
-    }
-}
-
-impl FromIterator<Column> for DataFrame {
-    /// # Panics
-    ///
-    /// Panics if Column have different lengths.
-    fn from_iter<T: IntoIterator<Item = Column>>(iter: T) -> Self {
-        let v = iter.into_iter().collect();
-        DataFrame::new(v).expect("could not create DataFrame from iterator")
-    }
-}
-
 impl TryExtend<RecordBatchT<Box<dyn Array>>> for DataFrame {
     fn try_extend<I: IntoIterator<Item = RecordBatchT<Box<dyn Array>>>>(
         &mut self,
@@ -54,7 +34,7 @@ impl Index<usize> for DataFrame {
     type Output = Column;
 
     fn index(&self, index: usize) -> &Self::Output {
-        &self.columns[index]
+        &self.columns()[index]
     }
 }
 
@@ -64,7 +44,7 @@ macro_rules! impl_ranges {
             type Output = [Column];
 
             fn index(&self, index: $range_type) -> &Self::Output {
-                &self.columns[index]
+                &self.columns()[index]
             }
         }
     };
@@ -82,7 +62,6 @@ impl Index<&str> for DataFrame {
     type Output = Column;
 
     fn index(&self, index: &str) -> &Self::Output {
-        let idx = self.check_name_to_idx(index).unwrap();
-        &self.columns[idx]
+        self.column(index).unwrap()
     }
 }

--- a/crates/polars-core/src/frame/validation.rs
+++ b/crates/polars-core/src/frame/validation.rs
@@ -1,67 +1,100 @@
 use polars_error::{PolarsResult, polars_bail};
 use polars_utils::aliases::{InitHashMaps, PlHashSet};
 
-use super::DataFrame;
-use super::column::Column;
+use crate::frame::column::Column;
 
-impl DataFrame {
-    /// Ensure all equal height and names are unique.
-    ///
-    /// An Ok() result indicates `columns` is a valid state for a DataFrame.
-    pub fn validate_columns_slice(columns: &[Column]) -> PolarsResult<()> {
-        if columns.len() <= 1 {
-            return Ok(());
-        }
-
-        if columns.len() <= 4 {
-            // Too small to be worth spawning a hashmap for, this is at most 6 comparisons.
-            for i in 0..columns.len() - 1 {
-                let name = columns[i].name();
-                let height = columns[i].len();
-
-                for other in columns.iter().skip(i + 1) {
-                    if other.name() == name {
-                        polars_bail!(duplicate = name);
-                    }
-
-                    if other.len() != height {
-                        polars_bail!(
-                            ShapeMismatch:
-                            "height of column '{}' ({}) does not match height of column '{}' ({})",
-                            other.name(), other.len(), name, height
-                        )
-                    }
-                }
-            }
-        } else {
-            let first = &columns[0];
-
-            let first_len = first.len();
-            let first_name = first.name();
-
-            let mut names = PlHashSet::with_capacity(columns.len());
-            names.insert(first_name);
-
-            for col in &columns[1..] {
-                let col_name = col.name();
-                let col_len = col.len();
-
-                if col_len != first_len {
-                    polars_bail!(
-                        ShapeMismatch:
-                        "height of column '{}' ({}) does not match height of column '{}' ({})",
-                        col_name, col_len, first_name, first_len
-                    )
-                }
-
-                if names.contains(col_name) {
-                    polars_bail!(duplicate = col_name)
-                }
-
-                names.insert(col_name);
-            }
-        }
-
-        Ok(())
+/// Checks for duplicates and mismatching heights.
+pub(super) fn validate_columns_slice(
+    expected_height: usize,
+    columns: &[Column],
+) -> PolarsResult<()> {
+    if columns.is_empty() {
+        return Ok(());
     }
+
+    let expected_height_msg = || {
+        if let Some(c) = columns.iter().find(|c| c.len() == expected_height) {
+            format!("height of column '{}' ({})", c.name(), c.len())
+        } else {
+            format!("DataFrame height ({expected_height})")
+        }
+    };
+
+    if columns.len() <= 4 {
+        // Too small to be worth spawning a hashmap for, this is at most 6 comparisons.
+        for (i, col) in columns.iter().enumerate() {
+            if col.len() != expected_height {
+                polars_bail!(
+                    ShapeMismatch:
+                    "height of column '{}' ({}) does not match {}",
+                    col.name(), col.len(), expected_height_msg()
+                )
+            }
+
+            let name = col.name();
+
+            for other in columns.iter().skip(i + 1) {
+                if other.name() == name {
+                    polars_bail!(duplicate = name);
+                }
+            }
+        }
+    } else {
+        let mut names = PlHashSet::with_capacity(columns.len());
+
+        for col in columns {
+            let col_name = col.name();
+            let col_len = col.len();
+
+            if col_len != expected_height {
+                polars_bail!(
+                    ShapeMismatch:
+                    "height of column '{}' ({}) does not match {}",
+                    col_name, col_len, expected_height_msg()
+                )
+            }
+
+            if names.contains(col_name) {
+                polars_bail!(duplicate = col_name)
+            }
+
+            names.insert(col_name);
+        }
+    }
+
+    Ok(())
+}
+
+pub(super) fn ensure_names_unique<T>(names: &[T]) -> PolarsResult<()>
+where
+    T: AsRef<str>,
+{
+    // Always unique.
+    if names.len() <= 1 {
+        return Ok(());
+    }
+
+    if names.len() <= 4 {
+        // Too small to be worth spawning a hashmap for, this is at most 6 comparisons.
+        for i in 0..names.len() - 1 {
+            let name = names[i].as_ref();
+
+            for other in names.iter().skip(i + 1) {
+                if name == other.as_ref() {
+                    polars_bail!(duplicate = name);
+                }
+            }
+        }
+    } else {
+        let mut names_set: PlHashSet<&str> = PlHashSet::with_capacity(names.len());
+
+        for name in names {
+            let name = name.as_ref();
+
+            if !names_set.insert(name) {
+                polars_bail!(duplicate = name);
+            }
+        }
+    }
+    Ok(())
 }

--- a/crates/polars-core/src/functions.rs
+++ b/crates/polars-core/src/functions.rs
@@ -18,7 +18,7 @@ pub fn concat_df_diagonal(dfs: &[DataFrame]) -> PolarsResult<DataFrame> {
     let mut schema = Vec::with_capacity(upper_bound_width);
 
     for df in dfs {
-        df.get_columns().iter().for_each(|s| {
+        df.columns().iter().for_each(|s| {
             let name = s.name().clone();
             if column_names.insert(name.clone()) {
                 schema.push((name, s.dtype()))
@@ -38,7 +38,7 @@ pub fn concat_df_diagonal(dfs: &[DataFrame]) -> PolarsResult<DataFrame> {
                     None => columns.push(Column::full_null(name.clone(), height, dtype)),
                 }
             }
-            unsafe { DataFrame::new_no_checks(height, columns) }
+            unsafe { DataFrame::new_unchecked(height, columns) }
         })
         .collect::<Vec<_>>();
 

--- a/crates/polars-core/src/hashing/vector_hasher.rs
+++ b/crates/polars-core/src/hashing/vector_hasher.rs
@@ -488,7 +488,7 @@ pub fn _df_rows_to_hashes_threaded_vertical(
             .map(|df| {
                 let hb = build_hasher.clone();
                 let mut hashes = vec![];
-                columns_to_hashes(df.get_columns(), Some(hb), &mut hashes)?;
+                columns_to_hashes(df.columns(), Some(hb), &mut hashes)?;
                 Ok(UInt64Chunked::from_vec(PlSmallStr::EMPTY, hashes))
             })
             .collect::<PolarsResult<Vec<_>>>()

--- a/crates/polars-core/src/serde/mod.rs
+++ b/crates/polars-core/src/serde/mod.rs
@@ -44,14 +44,14 @@ mod test {
         let s3 = Series::new("string".into(), &["mouse", "elephant", "dog"]);
         let s_list = Column::new("list".into(), &[s1.clone(), s1.clone(), s1.clone()]);
 
-        DataFrame::new(vec![s1.into(), s2.into(), s3.into(), s_list]).unwrap()
+        DataFrame::new_infer_height(vec![s1.into(), s2.into(), s3.into(), s_list]).unwrap()
     }
 
     #[test]
     fn test_serde_flags() {
         let df = sample_dataframe();
 
-        for mut column in df.columns {
+        for mut column in df.into_columns() {
             column.set_sorted_flag(IsSorted::Descending);
             let json = serde_json::to_string(&column).unwrap();
             let out = serde_json::from_reader::<_, Column>(json.as_bytes()).unwrap();
@@ -118,7 +118,7 @@ mod test {
         let s =
             Series::from_any_values_and_dtype("item".into(), &[row_1, row_2, row_3], &dtype, false)
                 .unwrap();
-        let df = DataFrame::new(vec![s.into()]).unwrap();
+        let df = DataFrame::new_infer_height(vec![s.into()]).unwrap();
 
         let df_str = serde_json::to_string(&df).unwrap();
         let out = serde_json::from_str::<DataFrame>(&df_str).unwrap();

--- a/crates/polars-core/src/serde/series.rs
+++ b/crates/polars-core/src/serde/series.rs
@@ -9,7 +9,7 @@ use crate::prelude::*;
 impl Series {
     pub fn serialize_into_writer(&self, writer: &mut dyn std::io::Write) -> PolarsResult<()> {
         let mut df =
-            unsafe { DataFrame::new_no_checks_height_from_first(vec![self.clone().into_column()]) };
+            unsafe { DataFrame::new_unchecked_infer_height(vec![self.clone().into_column()]) };
 
         df.serialize_into_writer(writer)
     }
@@ -32,7 +32,7 @@ impl Series {
             )
         }
 
-        Ok(df.take_columns().swap_remove(0).take_materialized_series())
+        Ok(df.into_columns().swap_remove(0).take_materialized_series())
     }
 }
 

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -277,7 +277,7 @@ impl Series {
 
     pub fn into_frame(self) -> DataFrame {
         // SAFETY: A single-column dataframe cannot have length mismatches or duplicate names
-        unsafe { DataFrame::new_no_checks(self.len(), vec![self.into()]) }
+        unsafe { DataFrame::new_unchecked(self.len(), vec![self.into()]) }
     }
 
     /// Rename series.

--- a/crates/polars-core/src/testing.rs
+++ b/crates/polars-core/src/testing.rs
@@ -46,7 +46,7 @@ impl PartialEq for Series {
 impl DataFrame {
     /// Check if [`DataFrame`]' schemas are equal.
     pub fn schema_equal(&self, other: &DataFrame) -> PolarsResult<()> {
-        for (lhs, rhs) in self.iter().zip(other.iter()) {
+        for (lhs, rhs) in self.columns().iter().zip(other.columns().iter()) {
             polars_ensure!(
                 lhs.name() == rhs.name(),
                 SchemaMismatch: "column name mismatch: left-hand = '{}', right-hand = '{}'",
@@ -79,7 +79,7 @@ impl DataFrame {
         if self.shape() != other.shape() {
             return false;
         }
-        for (left, right) in self.get_columns().iter().zip(other.get_columns()) {
+        for (left, right) in self.columns().iter().zip(other.columns()) {
             if left.name() != right.name() || !left.equals(right) {
                 return false;
             }
@@ -105,7 +105,7 @@ impl DataFrame {
         if self.shape() != other.shape() {
             return false;
         }
-        for (left, right) in self.get_columns().iter().zip(other.get_columns()) {
+        for (left, right) in self.columns().iter().zip(other.columns()) {
             if left.name() != right.name() || !left.equals_missing(right) {
                 return false;
             }
@@ -118,9 +118,9 @@ impl PartialEq for DataFrame {
     fn eq(&self, other: &Self) -> bool {
         self.shape() == other.shape()
             && self
-                .columns
+                .columns()
                 .iter()
-                .zip(other.columns.iter())
+                .zip(other.columns().iter())
                 .all(|(s1, s2)| s1.equals_missing(s2))
     }
 }
@@ -166,7 +166,7 @@ mod test {
         let a = Column::new("a".into(), [1, 2, 3].as_ref());
         let b = Column::new("b".into(), [1, 2, 3].as_ref());
 
-        let df1 = DataFrame::new(vec![a, b]).unwrap();
+        let df1 = DataFrame::new_infer_height(vec![a, b]).unwrap();
         assert!(df1.equals(&df1))
     }
 

--- a/crates/polars-core/src/tests.rs
+++ b/crates/polars-core/src/tests.rs
@@ -7,9 +7,9 @@ fn test_initial_empty_sort() -> PolarsResult<()> {
     let mut series = Column::new("data".into(), Vec::<f64>::new());
     let series2 = Column::new("data2".into(), data.clone());
     let series3 = Column::new("data3".into(), data);
-    let df = DataFrame::new(vec![series2, series3])?;
+    let df = DataFrame::new_infer_height(vec![series2, series3])?;
 
-    for column in df.get_columns().iter() {
+    for column in df.columns().iter() {
         series.append(column)?;
     }
     series.f64()?.sort(false);

--- a/crates/polars-expr/src/expressions/column.rs
+++ b/crates/polars-expr/src/expressions/column.rs
@@ -80,7 +80,7 @@ impl ColumnExpr {
     ) -> PolarsResult<Column> {
         match schema.get_full(&self.name) {
             None => self.process_by_linear_search(df, state, true),
-            Some((idx, _, _)) => match df.get_columns().get(idx) {
+            Some((idx, _, _)) => match df.columns().get(idx) {
                 Some(out) => self.process_by_idx(out, state, schema, df, false),
                 None => self.process_by_linear_search(df, state, true),
             },
@@ -90,7 +90,7 @@ impl ColumnExpr {
     fn process_cse(&self, df: &DataFrame, schema: &Schema) -> PolarsResult<Column> {
         // The CSE columns are added on the rhs.
         let offset = schema.len();
-        let columns = &df.get_columns()[offset..];
+        let columns = &df.columns()[offset..];
         // Linear search will be relatively cheap as we only search the CSE columns.
         Ok(columns
             .iter()
@@ -110,7 +110,7 @@ impl PhysicalExpr for ColumnExpr {
             Some((idx, _, _)) => {
                 // check if the schema was correct
                 // if not do O(n) search
-                match df.get_columns().get(idx) {
+                match df.columns().get(idx) {
                     Some(out) => self.process_by_idx(out, state, &self.schema, df, true),
                     None => {
                         // partitioned group_by special case

--- a/crates/polars-expr/src/expressions/eval.rs
+++ b/crates/polars-expr/src/expressions/eval.rs
@@ -66,7 +66,7 @@ impl EvalExpr {
         state: &ExecutionState,
         is_agg: bool,
     ) -> PolarsResult<Column> {
-        let df = DataFrame::empty();
+        let df = DataFrame::empty_with_height(ca.len());
         let ca = ca
             .trim_lists_to_normalized_offsets()
             .map_or(Cow::Borrowed(ca), Cow::Owned);
@@ -197,7 +197,7 @@ impl EvalExpr {
         as_list: bool,
         is_agg: bool,
     ) -> PolarsResult<Column> {
-        let df = DataFrame::empty();
+        let df = DataFrame::empty_with_height(ca.len());
         let ca = ca
             .trim_lists_to_normalized_offsets()
             .map_or(Cow::Borrowed(ca), Cow::Owned);
@@ -388,7 +388,7 @@ impl EvalExpr {
 
         let groups = groups.into_sliceable();
 
-        let df = DataFrame::empty();
+        let df = DataFrame::empty_with_height(input.len());
 
         let mut state = state.clone();
         state.element = Arc::new(Some((flattened, validity)));

--- a/crates/polars-expr/src/expressions/window.rs
+++ b/crates/polars-expr/src/expressions/window.rs
@@ -380,7 +380,7 @@ impl PhysicalExpr for WindowExpr {
 
         // 4. select the final column and return
 
-        if df.is_empty() {
+        if df.height() == 0 {
             let field = self.phys_function.to_field(df.schema())?;
             match self.mapping {
                 WindowMapping::Join => {
@@ -600,9 +600,9 @@ impl PhysicalExpr for WindowExpr {
                                 ))
                             } else {
                                 let df_right =
-                                    unsafe { DataFrame::new_no_checks_height_from_first(keys) };
+                                    unsafe { DataFrame::new_unchecked_infer_height(keys) };
                                 let df_left = unsafe {
-                                    DataFrame::new_no_checks_height_from_first(group_by_columns)
+                                    DataFrame::new_unchecked_infer_height(group_by_columns)
                                 };
                                 Ok(Arc::new(
                                     private_left_join_multiple_keys(&df_left, &df_right, true)?.1,

--- a/crates/polars-expr/src/groups/binview.rs
+++ b/crates/polars-expr/src/groups/binview.rs
@@ -82,7 +82,7 @@ impl BinviewHashGrouper {
             );
             let s =
                 Series::from_chunks_and_dtype_unchecked(name.clone(), vec![Box::new(keys)], dtype);
-            DataFrame::new(vec![Column::from(s)]).unwrap()
+            DataFrame::new_unchecked(s.len(), vec![Column::from(s)])
         }
     }
 }

--- a/crates/polars-expr/src/groups/row_encoded.rs
+++ b/crates/polars-expr/src/groups/row_encoded.rs
@@ -58,7 +58,7 @@ impl RowEncodedHashGrouper {
                     .into_column()
             })
             .collect();
-        unsafe { DataFrame::new_no_checks_height_from_first(cols) }
+        unsafe { DataFrame::new_unchecked_infer_height(cols) }
     }
 }
 

--- a/crates/polars-expr/src/groups/single_key.rs
+++ b/crates/polars-expr/src/groups/single_key.rs
@@ -68,7 +68,7 @@ where
         unsafe {
             let s =
                 Series::from_chunks_and_dtype_unchecked(name.clone(), vec![Box::new(keys)], dtype);
-            DataFrame::new(vec![Column::from(s)]).unwrap()
+            DataFrame::new_unchecked(s.len(), vec![Column::from(s)])
         }
     }
 }

--- a/crates/polars-expr/src/hash_keys.rs
+++ b/crates/polars-expr/src/hash_keys.rs
@@ -115,7 +115,7 @@ impl HashKeys {
             || df.width() > 1
             || first_col_variant == HashKeysVariant::RowEncoded;
         if use_row_encoding {
-            let keys = df.get_columns();
+            let keys = df.columns();
             let mut keys_encoded = _get_rows_encoded_unordered(keys).unwrap().into_array();
 
             if !null_is_valid {
@@ -129,7 +129,7 @@ impl HashKeys {
 
             // TODO: use vechash? Not supported yet for lists.
             // let mut hashes = Vec::with_capacity(df.height());
-            // columns_to_hashes(df.get_columns(), Some(random_state), &mut hashes).unwrap();
+            // columns_to_hashes(df.columns(), Some(random_state), &mut hashes).unwrap();
 
             let hashes = keys_encoded
                 .values_iter()

--- a/crates/polars-expr/src/state/node_timer.rs
+++ b/crates/polars-expr/src/state/node_timer.rs
@@ -67,7 +67,7 @@ impl NodeTimer {
 
         let height = nodes_s.len();
         let columns = vec![nodes_s, start.into_column(), end.into_column()];
-        let df = unsafe { DataFrame::new_no_checks(height, columns) };
+        let df = unsafe { DataFrame::new_unchecked(height, columns) };
         df.sort(vec!["start"], SortMultipleOptions::default())
     }
 }

--- a/crates/polars-ffi/src/version_0.rs
+++ b/crates/polars-ffi/src/version_0.rs
@@ -126,7 +126,7 @@ pub unsafe fn import_df(e: *mut SeriesExport, len: usize) -> PolarsResult<DataFr
         let s = import_series(e)?;
         out.push(s.into())
     }
-    Ok(DataFrame::new_no_checks_height_from_first(out))
+    Ok(DataFrame::new_unchecked_infer_height(out))
 }
 
 /// Passed to an expression.

--- a/crates/polars-io/src/csv/read/reader.rs
+++ b/crates/polars-io/src/csv/read/reader.rs
@@ -153,9 +153,9 @@ where
         // As that leads to great memory overhead.
         if rechunk && df.first_col_n_chunks() > 1 {
             if low_memory {
-                df.as_single_chunk();
+                df.rechunk_mut();
             } else {
-                df.as_single_chunk_par();
+                df.rechunk_mut_par();
             }
         }
 

--- a/crates/polars-io/src/csv/write/write_impl.rs
+++ b/crates/polars-io/src/csv/write/write_impl.rs
@@ -154,7 +154,7 @@ impl CsvSerializer {
         let options = options.as_ref();
 
         let mut serializers_vec = reuse_vec(std::mem::take(&mut self.serializers));
-        let serializers = self.build_serializers(df.get_columns(), &mut serializers_vec)?;
+        let serializers = self.build_serializers(df.columns(), &mut serializers_vec)?;
 
         for _ in 0..df.height() {
             serializers[0].serialize(buffer, options);
@@ -225,7 +225,7 @@ pub(crate) fn write(
                 // so will be faster.
                 // and allows writing `pl.concat([df] * 100, rechunk=False).write_csv()` as the rechunk
                 // would go OOM
-                df.as_single_chunk();
+                df.rechunk_mut();
 
                 csv_serializer.serialize_to_csv(&df, write_buffer)?;
 

--- a/crates/polars-io/src/hive.rs
+++ b/crates/polars-io/src/hive.rs
@@ -45,13 +45,13 @@ pub(crate) fn materialize_hive_partitions<D>(
 
         // `hive_partitions_from_paths()` guarantees `hive_columns` is sorted by their appearance in `reader_schema`.
         merge_sorted_to_schema_order(
-            &mut unsafe { df.get_columns_mut().drain(..) },
+            &mut unsafe { df.columns_mut() }.drain(..),
             &mut hive_columns.into_iter(),
             reader_schema,
             &mut merged,
         );
 
-        *df = unsafe { DataFrame::new_no_checks(num_rows, merged) };
+        *df = unsafe { DataFrame::new_unchecked(num_rows, merged) };
     }
 }
 

--- a/crates/polars-io/src/ipc/ipc_file.rs
+++ b/crates/polars-io/src/ipc/ipc_file.rs
@@ -14,7 +14,7 @@
 //!
 //! let s0 = Column::new("days".into(), &[0, 1, 2, 3, 4]);
 //! let s1 = Column::new("temp".into(), &[22.1, 19.9, 7., 2., 3.]);
-//! let mut df = DataFrame::new(vec![s0, s1]).unwrap();
+//! let mut df = DataFrame::new_infer_height(vec![s0, s1]).unwrap();
 //!
 //! // Create an in memory file handler.
 //! // Vec<u8>: Read + Write
@@ -311,7 +311,7 @@ impl<R: MmapBytesReader> SerReader<R> for IpcReader<R> {
 
         if let Some((col, value)) = include_file_path {
             unsafe {
-                df.with_column_unchecked(Column::new_scalar(
+                df.push_column_unchecked(Column::new_scalar(
                     col,
                     Scalar::new(
                         DataType::String,

--- a/crates/polars-io/src/ipc/ipc_stream.rs
+++ b/crates/polars-io/src/ipc/ipc_stream.rs
@@ -15,7 +15,7 @@
 //!
 //! let c0 = Column::new("days".into(), &[0, 1, 2, 3, 4]);
 //! let c1 = Column::new("temp".into(), &[22.1, 19.9, 7., 2., 3.]);
-//! let mut df = DataFrame::new(vec![c0, c1]).unwrap();
+//! let mut df = DataFrame::new_infer_height(vec![c0, c1]).unwrap();
 //!
 //! // Create an in memory file handler.
 //! // Vec<u8>: Read + Write

--- a/crates/polars-io/src/ndjson/core.rs
+++ b/crates/polars-io/src/ndjson/core.rs
@@ -185,7 +185,7 @@ where
 
         let mut df: DataFrame = json_reader.as_df()?;
         if rechunk && df.first_col_n_chunks() > 1 {
-            df.as_single_chunk_par();
+            df.rechunk_mut_par();
         }
         Ok(df)
     }
@@ -426,7 +426,7 @@ pub fn parse_ndjson(
     let mut buffers = init_buffers(schema, capacity, ignore_errors)?;
     parse_lines(bytes, &mut buffers, ignore_errors)?;
 
-    DataFrame::new(
+    DataFrame::new_infer_height(
         buffers
             .into_values()
             .map(|buf| Ok(buf.into_series()?.into_column()))

--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -142,7 +142,7 @@ fn rg_to_dfs(
             let placeholder =
                 NullChunkedBuilder::new(PlSmallStr::from_static("__PL_TMP"), pre_slice.1).finish();
             return Ok(vec![
-                DataFrame::new(vec![placeholder.into_series().into_column()])?
+                DataFrame::new_infer_height(vec![placeholder.into_series().into_column()])?
                     .with_row_index(
                         row_index.name.clone(),
                         Some(row_index.offset + IdxSize::try_from(pre_slice.0).unwrap()),
@@ -250,7 +250,7 @@ fn rg_to_dfs_optionally_par_over_columns(
             projection.iter().map(f).collect::<PolarsResult<Vec<_>>>()?
         };
 
-        let mut df = unsafe { DataFrame::new_no_checks(rg_slice.1, columns) };
+        let mut df = unsafe { DataFrame::new_unchecked(rg_slice.1, columns) };
         if let Some(rc) = &row_index {
             unsafe {
                 df.with_row_index_mut(
@@ -383,7 +383,7 @@ fn rg_to_dfs_par_over_rg(
                     })
                     .collect::<PolarsResult<Vec<_>>>()?;
 
-                let mut df = unsafe { DataFrame::new_no_checks(slice.1, columns) };
+                let mut df = unsafe { DataFrame::new_unchecked(slice.1, columns) };
 
                 if let Some(rc) = &row_index {
                     unsafe {

--- a/crates/polars-io/src/parquet/read/reader.rs
+++ b/crates/polars-io/src/parquet/read/reader.rs
@@ -220,12 +220,12 @@ impl<R: MmapBytesReader> SerReader<R> for ParquetReader<R> {
         )?;
 
         if self.rechunk {
-            df.as_single_chunk_par();
+            df.rechunk_mut_par();
         };
 
         if let Some((col, value)) = &self.include_file_path {
             unsafe {
-                df.with_column_unchecked(Column::new_scalar(
+                df.push_column_unchecked(Column::new_scalar(
                     col.clone(),
                     Scalar::new(
                         DataType::String,

--- a/crates/polars-io/src/parquet/read/utils.rs
+++ b/crates/polars-io/src/parquet/read/utils.rs
@@ -1,8 +1,9 @@
 use std::borrow::Cow;
 
-use polars_core::prelude::{ArrowSchema, DataFrame, DataType, IDX_DTYPE, Series};
-use polars_core::schema::SchemaNamesAndDtypes;
+use polars_core::prelude::{ArrowSchema, Column, DataFrame, DataType, IDX_DTYPE, Series};
+use polars_core::schema::{SchemaExt, SchemaNamesAndDtypes};
 use polars_error::{PolarsResult, polars_bail};
+use polars_schema::Schema;
 
 use crate::RowIndex;
 use crate::hive::materialize_hive_partitions;
@@ -19,10 +20,10 @@ pub fn materialize_empty_df(
     } else {
         Cow::Borrowed(reader_schema)
     };
-    let mut df = DataFrame::empty_with_arrow_schema(&schema);
+    let mut df = DataFrame::empty_with_schema(&Schema::from_arrow_schema(&schema));
 
     if let Some(row_index) = row_index {
-        df.insert_column(0, Series::new_empty(row_index.name.clone(), &IDX_DTYPE))
+        df.insert_column(0, Column::new_empty(row_index.name.clone(), &IDX_DTYPE))
             .unwrap();
     }
 

--- a/crates/polars-io/src/partition.rs
+++ b/crates/polars-io/src/partition.rs
@@ -51,7 +51,7 @@ pub fn write_partitioned_dataset(
     chunk_size: usize,
 ) -> PolarsResult<()> {
     // Ensure we have a single chunk as the gather will otherwise rechunk per group.
-    df.as_single_chunk_par();
+    df.rechunk_mut_par();
 
     // Note: When adding support for formats other than Parquet, avoid writing the partitioned
     // columns into the file. We write them for parquet because they are encoded efficiently with
@@ -70,7 +70,7 @@ pub fn write_partitioned_dataset(
             .collect::<PolarsResult<Vec<_>>>()?;
 
         move |df: &DataFrame| {
-            let cols = df.get_columns();
+            let cols = df.columns();
 
             partition_by_col_idx
                 .iter()

--- a/crates/polars-io/src/utils/other.rs
+++ b/crates/polars-io/src/utils/other.rs
@@ -81,8 +81,8 @@ pub fn columns_to_projection<T: AsRef<str>>(
 #[cfg(debug_assertions)]
 fn check_offsets(dfs: &[DataFrame]) {
     dfs.windows(2).for_each(|s| {
-        let a = &s[0].get_columns()[0];
-        let b = &s[1].get_columns()[0];
+        let a = &s[0].columns()[0];
+        let b = &s[1].columns()[0];
 
         let prev = a.get(a.len() - 1).unwrap().extract::<usize>().unwrap();
         let next = b.get(0).unwrap().extract::<usize>().unwrap();
@@ -97,11 +97,11 @@ pub(crate) fn update_row_counts2(dfs: &mut [DataFrame], offset: IdxSize) {
     if !dfs.is_empty() {
         let mut previous = offset;
         for df in &mut *dfs {
-            if df.is_empty() {
+            if df.shape_has_zero() {
                 continue;
             }
             let n_read = df.height() as IdxSize;
-            if let Some(s) = unsafe { df.get_columns_mut() }.get_mut(0) {
+            if let Some(s) = unsafe { df.columns_mut_retain_schema() }.get_mut(0) {
                 if let Ok(v) = s.get(0) {
                     if v.extract::<usize>().unwrap() != previous as usize {
                         *s = &*s + previous;
@@ -126,11 +126,11 @@ pub(crate) fn update_row_counts3(dfs: &mut [DataFrame], heights: &[IdxSize], off
         let mut previous = offset;
         for i in 0..dfs.len() {
             let df = &mut dfs[i];
-            if df.is_empty() {
+            if df.shape_has_zero() {
                 continue;
             }
 
-            if let Some(s) = unsafe { df.get_columns_mut() }.get_mut(0) {
+            if let Some(s) = unsafe { df.columns_mut_retain_schema() }.get_mut(0) {
                 if let Ok(v) = s.get(0) {
                     if v.extract::<usize>().unwrap() != previous as usize {
                         *s = &*s + previous;

--- a/crates/polars-lazy/src/tests/aggregations.rs
+++ b/crates/polars-lazy/src/tests/aggregations.rs
@@ -574,7 +574,7 @@ fn test_anonymous_function_returns_scalar_all_null_20679() {
     let a = Column::new("a".into(), &[0, 0, 1]);
     let dtype = DataType::Null;
     let b = Column::new_scalar("b".into(), Scalar::new(dtype, AnyValue::Null), 3);
-    let df = DataFrame::new(vec![a, b]).unwrap();
+    let df = DataFrame::new_infer_height(vec![a, b]).unwrap();
 
     let f = move |c: &mut [Column]| reduction_function(std::mem::take(&mut c[0]));
     let dt = |_: &Schema, fs: &[Field]| Ok(fs[0].clone());
@@ -595,5 +595,5 @@ fn test_anonymous_function_returns_scalar_all_null_20679() {
         .collect()
         .unwrap();
 
-    assert_eq!(grouped_df.get_columns()[1].dtype(), &DataType::Null);
+    assert_eq!(grouped_df.columns()[1].dtype(), &DataType::Null);
 }

--- a/crates/polars-lazy/src/tests/io.rs
+++ b/crates/polars-lazy/src/tests/io.rs
@@ -768,10 +768,10 @@ fn scan_anonymous_fn_count() -> PolarsResult<()> {
         .collect()
         .unwrap();
 
-    assert_eq!(df.get_columns().len(), 1);
-    assert_eq!(df.get_columns()[0].len(), 1);
+    assert_eq!(df.columns().len(), 1);
+    assert_eq!(df.columns()[0].len(), 1);
     assert_eq!(
-        df.get_columns()[0]
+        df.columns()[0]
             .cast(&DataType::UInt32)
             .unwrap()
             .as_materialized_series()

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -445,7 +445,7 @@ fn test_lazy_query_10() {
         TimeUnit::Nanoseconds,
     )
     .into_column();
-    let df = DataFrame::new(vec![x, y]).unwrap();
+    let df = DataFrame::new_infer_height(vec![x, y]).unwrap();
     let out = df
         .lazy()
         .select(&[(col("x") - col("y")).alias("z")])
@@ -482,7 +482,7 @@ fn test_lazy_query_10() {
         TimeUnit::Nanoseconds,
     )
     .into_column();
-    let df = DataFrame::new(vec![x, y]).unwrap();
+    let df = DataFrame::new_infer_height(vec![x, y]).unwrap();
     let out = df
         .lazy()
         .select(&[(col("x") - col("y")).alias("z")])
@@ -512,7 +512,7 @@ fn test_lazy_query_7() {
         NaiveDateTime::new(date, NaiveTime::from_hms_opt(12, 5, 0).unwrap()),
     ];
     let data = vec![Some(1.), Some(2.), Some(3.), Some(4.), None, None];
-    let df = DataFrame::new(vec![
+    let df = DataFrame::new_infer_height(vec![
         DatetimeChunked::from_naive_datetime("date".into(), dates, TimeUnit::Nanoseconds)
             .into_column(),
         Column::new("data".into(), data),
@@ -542,7 +542,7 @@ fn test_lazy_query_7() {
 #[test]
 fn test_lazy_shift_and_fill_all() {
     let data = &[1, 2, 3];
-    let df = DataFrame::new(vec![Column::new("data".into(), data)]).unwrap();
+    let df = DataFrame::new_infer_height(vec![Column::new("data".into(), data)]).unwrap();
     let out = df
         .lazy()
         .with_column(col("data").shift(lit(1)).fill_null(lit(0)).alias("output"))
@@ -1152,7 +1152,7 @@ fn test_filter_lit() {
     // failed due to broadcasting filters and splitting threads.
     let iter = (0..100).map(|i| ('A'..='Z').nth(i % 26).unwrap().to_string());
     let a = Series::from_iter(iter).into_column();
-    let df = DataFrame::new([a].into()).unwrap();
+    let df = DataFrame::new_infer_height([a].into()).unwrap();
 
     let out = df.lazy().filter(lit(true)).collect().unwrap();
     assert_eq!(out.shape(), (100, 1));
@@ -1411,7 +1411,7 @@ fn test_lazy_ternary_predicate_pushdown() -> PolarsResult<()> {
         .collect()?;
 
     assert_eq!(
-        Vec::from(out.get_columns()[0].i32()?),
+        Vec::from(out.columns()[0].i32()?),
         &[Some(1), Some(2), Some(3)]
     );
 
@@ -1514,7 +1514,7 @@ fn test_list_in_select_context() -> PolarsResult<()> {
     builder.append_series(s.as_materialized_series()).unwrap();
     let expected = builder.finish().into_column();
 
-    let df = DataFrame::new(vec![s])?;
+    let df = DataFrame::new_infer_height(vec![s])?;
 
     let out = df.lazy().select([col("a").implode()]).collect()?;
 
@@ -1590,7 +1590,7 @@ fn test_fill_nan() -> PolarsResult<()> {
     let s0 = Column::new("date".into(), &[1, 2, 3]).cast(&DataType::Date)?;
     let s1 = Column::new("float".into(), &[Some(1.0), Some(f32::NAN), Some(3.0)]);
 
-    let df = DataFrame::new(vec![s0, s1])?;
+    let df = DataFrame::new_infer_height(vec![s0, s1])?;
     let out = df.lazy().fill_nan(Null {}.lit()).collect()?;
     let out = out.column("float")?;
     assert_eq!(Vec::from(out.f32()?), &[Some(1.0), None, Some(3.0)]);
@@ -1983,7 +1983,7 @@ fn test_sort_maintain_order_true() -> PolarsResult<()> {
 
 #[test]
 fn test_over_with_options_empty_join() -> PolarsResult<()> {
-    let empty_df = DataFrame::new(vec![
+    let empty_df = DataFrame::new_infer_height(vec![
         Series::new_empty("a".into(), &DataType::Int32).into(),
         Series::new_empty("b".into(), &DataType::Int32).into(),
     ])?;
@@ -2010,7 +2010,7 @@ fn test_over_with_options_empty_join() -> PolarsResult<()> {
 fn test_named_udfs() -> PolarsResult<()> {
     use polars_plan::dsl::named_serde::{ExprRegistry, set_named_serde_registry};
 
-    let lf = DataFrame::new(vec![Column::new("a".into(), vec![1, 2, 3, 4])])?.lazy();
+    let lf = DataFrame::new_infer_height(vec![Column::new("a".into(), vec![1, 2, 3, 4])])?.lazy();
 
     struct X;
     impl ExprRegistry for X {
@@ -2039,7 +2039,7 @@ fn test_named_udfs() -> PolarsResult<()> {
 
     assert_eq!(
         lf.select(&[expr]).collect()?,
-        DataFrame::new(vec![Column::new("a".into(), vec![2, 4, 6, 8])])?,
+        DataFrame::new_infer_height(vec![Column::new("a".into(), vec![2, 4, 6, 8])])?,
     );
 
     Ok(())

--- a/crates/polars-mem-engine/src/executors/group_by.rs
+++ b/crates/polars-mem-engine/src/executors/group_by.rs
@@ -63,7 +63,7 @@ pub(super) fn group_by_helper(
     maintain_order: bool,
     slice: Option<(i64, usize)>,
 ) -> PolarsResult<DataFrame> {
-    df.as_single_chunk_par();
+    df.rechunk_mut_par();
     let gb = df.group_by_with_series(keys, true, maintain_order)?;
 
     if let Some(f) = apply {
@@ -90,7 +90,7 @@ pub(super) fn group_by_helper(
     });
 
     columns.extend(agg_columns?);
-    DataFrame::new(columns)
+    DataFrame::new_infer_height(columns)
 }
 
 impl GroupByExec {

--- a/crates/polars-mem-engine/src/executors/group_by_dynamic.rs
+++ b/crates/polars-mem-engine/src/executors/group_by_dynamic.rs
@@ -23,7 +23,7 @@ impl GroupByDynamicExec {
     ) -> PolarsResult<DataFrame> {
         use crate::executors::group_by_rolling::sort_and_groups;
 
-        df.as_single_chunk_par();
+        df.rechunk_mut_par();
 
         let mut keys = self
             .keys
@@ -75,7 +75,7 @@ impl GroupByDynamicExec {
         columns.push(time_key);
         columns.extend(agg_columns);
 
-        DataFrame::new(columns)
+        DataFrame::new_infer_height(columns)
     }
 }
 

--- a/crates/polars-mem-engine/src/executors/group_by_rolling.rs
+++ b/crates/polars-mem-engine/src/executors/group_by_rolling.rs
@@ -27,7 +27,7 @@ pub(super) fn sort_and_groups(
     });
 
     let encoded = unsafe {
-        df.with_column_unchecked(encoded.into_series().into());
+        df.push_column_unchecked(encoded.into_series().into());
 
         // If not sorted on keys, sort.
         let idx_s = idx.clone().into_series();
@@ -44,7 +44,7 @@ pub(super) fn sort_and_groups(
             *keys = keys_ordered;
         }
 
-        df.get_columns_mut().pop().unwrap()
+        df.columns_mut().pop().unwrap()
     };
     let encoded = encoded.as_materialized_series();
     let encoded = encoded.binary_offset().unwrap();
@@ -65,7 +65,7 @@ impl GroupByRollingExec {
         state: &ExecutionState,
         mut df: DataFrame,
     ) -> PolarsResult<DataFrame> {
-        df.as_single_chunk_par();
+        df.rechunk_mut_par();
 
         let mut keys = self
             .keys
@@ -108,7 +108,7 @@ impl GroupByRollingExec {
         columns.push(time_key);
         columns.extend(agg_columns);
 
-        DataFrame::new(columns)
+        DataFrame::new_infer_height(columns)
     }
 }
 

--- a/crates/polars-mem-engine/src/executors/group_by_streaming.rs
+++ b/crates/polars-mem-engine/src/executors/group_by_streaming.rs
@@ -108,7 +108,7 @@ fn compute_keys(
         .map(|s| s.evaluate(df, state))
         .collect::<PolarsResult<_>>()?;
     let df = check_expand_literals(df, keys, evaluated, false, Default::default())?;
-    Ok(df.take_columns())
+    Ok(df.into_columns())
 }
 
 fn estimate_unique_count(keys: &[Column], mut sample_size: usize) -> PolarsResult<usize> {
@@ -144,7 +144,7 @@ fn estimate_unique_count(keys: &[Column], mut sample_size: usize) -> PolarsResul
         Ok(finish(&groups))
     } else {
         let offset = (keys[0].len() / 2) as i64;
-        let df = unsafe { DataFrame::new_no_checks_height_from_first(keys.to_vec()) };
+        let df = unsafe { DataFrame::new_unchecked_infer_height(keys.to_vec()) };
         let df = df.slice(offset, sample_size);
         let names = df.get_column_names().into_iter().cloned();
         let gb = df.group_by(names).unwrap();

--- a/crates/polars-mem-engine/src/executors/projection.rs
+++ b/crates/polars-mem-engine/src/executors/projection.rs
@@ -37,7 +37,13 @@ impl ProjectionExec {
                     self.has_windows,
                     self.options.run_parallel,
                 )?;
-                check_expand_literals(&df, &self.expr, selected_cols, df.is_empty(), self.options)
+                check_expand_literals(
+                    &df,
+                    &self.expr,
+                    selected_cols,
+                    df.shape_has_zero(),
+                    self.options,
+                )
             });
 
             let df = POOL.install(|| iter.collect::<PolarsResult<Vec<_>>>())?;
@@ -53,7 +59,13 @@ impl ProjectionExec {
                 self.has_windows,
                 self.options.run_parallel,
             )?;
-            check_expand_literals(&df, &self.expr, selected_cols, df.is_empty(), self.options)?
+            check_expand_literals(
+                &df,
+                &self.expr,
+                selected_cols,
+                df.shape_has_zero(),
+                self.options,
+            )?
         };
 
         // this only runs during testing and check if the runtime type matches the predicted schema
@@ -61,7 +73,7 @@ impl ProjectionExec {
         #[allow(unused_must_use)]
         {
             // TODO: also check the types.
-            for (l, r) in df.iter().zip(self.schema.iter_names()) {
+            for (l, r) in df.columns().iter().zip(self.schema.iter_names()) {
                 assert_eq!(l.name(), r);
             }
         }

--- a/crates/polars-mem-engine/src/executors/projection_simple.rs
+++ b/crates/polars-mem-engine/src/executors/projection_simple.rs
@@ -8,7 +8,7 @@ pub struct ProjectionSimple {
 impl ProjectionSimple {
     fn execute_impl(&mut self, df: DataFrame, columns: &[PlSmallStr]) -> PolarsResult<DataFrame> {
         // No duplicate check as that an invariant of this node.
-        df._select_impl_unchecked(columns.as_ref())
+        unsafe { df.select_unchecked(columns) }
     }
 }
 

--- a/crates/polars-mem-engine/src/executors/sort.rs
+++ b/crates/polars-mem-engine/src/executors/sort.rs
@@ -16,7 +16,7 @@ impl SortExec {
         mut df: DataFrame,
     ) -> PolarsResult<DataFrame> {
         state.should_stop()?;
-        df.as_single_chunk_par();
+        df.rechunk_mut_par();
 
         let height = df.height();
 

--- a/crates/polars-mem-engine/src/executors/stack.rs
+++ b/crates/polars-mem-engine/src/executors/stack.rs
@@ -38,7 +38,7 @@ impl StackExec {
                     self.options.run_parallel,
                 )?;
                 // We don't have to do a broadcast check as cse is not allowed to hit this.
-                df._add_columns(res.into_iter().collect(), schema)?;
+                df.with_columns_mut(res, schema)?;
                 Ok(df)
             });
 
@@ -65,13 +65,13 @@ impl StackExec {
                 // new, unique column names. It is immediately
                 // followed by a projection which pulls out the
                 // possibly mismatching column lengths.
-                unsafe { df.column_extend_unchecked(res) };
+                unsafe { df.columns_mut() }.extend(res);
             } else {
                 let (df_height, df_width) = df.shape();
 
                 // When we have CSE we cannot verify scalars yet.
-                let verify_scalar = if !df.get_columns().is_empty() {
-                    !df.get_columns()[df.width() - 1]
+                let verify_scalar = if !df.columns().is_empty() {
+                    !df.columns()[df.width() - 1]
                         .name()
                         .starts_with(CSE_REPLACED)
                 } else {
@@ -95,7 +95,7 @@ impl StackExec {
                         }
                     }
                 }
-                df._add_columns(res.into_iter().collect(), schema)?;
+                df.with_columns_mut(res, schema)?;
             }
             df
         };

--- a/crates/polars-mem-engine/src/executors/union.rs
+++ b/crates/polars-mem-engine/src/executors/union.rs
@@ -109,7 +109,7 @@ impl Executor for UnionExec {
         }
         .map(|mut df| {
             if self.options.rechunk {
-                df.as_single_chunk_par();
+                df.rechunk_mut_par();
             }
             df
         })

--- a/crates/polars-mem-engine/src/executors/unique.rs
+++ b/crates/polars-mem-engine/src/executors/unique.rs
@@ -24,10 +24,6 @@ impl Executor for UniqueExec {
 
         state.record(
             || {
-                if df.is_empty() {
-                    return Ok(df);
-                }
-
                 df.unique_impl(
                     self.options.maintain_order,
                     subset,

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -276,7 +276,7 @@ fn create_physical_plan_impl(
                     input: recurse!(input, state)?,
                     name: PlSmallStr::from_static("batches"),
                     f: Box::new(move |mut buffer, _state| {
-                        while !buffer.is_empty() {
+                        while buffer.height() > 0 {
                             let df;
                             (df, buffer) = buffer.split_at(buffer.height().min(chunk_size) as i64);
                             let should_stop = function.call(df)?;
@@ -630,7 +630,7 @@ fn create_physical_plan_impl(
                             let mask = phys_expr.evaluate(&df, &execution_state)?;
                             let mask = mask.as_materialized_series();
                             let mask = mask.bool()?;
-                            df._filter_seq(mask)
+                            df.filter_seq(mask)
                         }))
                     })
                 })

--- a/crates/polars-ops/src/chunked_array/gather/chunked.rs
+++ b/crates/polars-ops/src/chunked_array/gather/chunked.rs
@@ -53,9 +53,9 @@ impl TakeChunked for DataFrame {
     ) -> DataFrame {
         let cols = self
             .to_df()
-            ._apply_columns(&|s| s.take_chunked_unchecked(idx, sorted, avoid_sharing));
+            .apply_columns(|s| s.take_chunked_unchecked(idx, sorted, avoid_sharing));
 
-        unsafe { DataFrame::new_no_checks_height_from_first(cols) }
+        unsafe { DataFrame::new_unchecked_infer_height(cols) }
     }
 
     /// Take elements by a slice of optional [`ChunkId`]s.
@@ -69,9 +69,9 @@ impl TakeChunked for DataFrame {
     ) -> DataFrame {
         let cols = self
             .to_df()
-            ._apply_columns(&|s| s.take_opt_chunked_unchecked(idx, avoid_sharing));
+            .apply_columns(|s| s.take_opt_chunked_unchecked(idx, avoid_sharing));
 
-        unsafe { DataFrame::new_no_checks_height_from_first(cols) }
+        unsafe { DataFrame::new_unchecked_infer_height(cols) }
     }
 }
 
@@ -85,9 +85,9 @@ pub trait TakeChunkedHorPar: IntoDf {
     ) -> DataFrame {
         let cols = self
             .to_df()
-            ._apply_columns_par(&|s| s.take_chunked_unchecked(idx, sorted, false));
+            .apply_columns_par(|s| s.take_chunked_unchecked(idx, sorted, false));
 
-        unsafe { DataFrame::new_no_checks_height_from_first(cols) }
+        unsafe { DataFrame::new_unchecked_infer_height(cols) }
     }
 
     /// # Safety
@@ -100,9 +100,9 @@ pub trait TakeChunkedHorPar: IntoDf {
     ) -> DataFrame {
         let cols = self
             .to_df()
-            ._apply_columns_par(&|s| s.take_opt_chunked_unchecked(idx, false));
+            .apply_columns_par(|s| s.take_opt_chunked_unchecked(idx, false));
 
-        unsafe { DataFrame::new_no_checks_height_from_first(cols) }
+        unsafe { DataFrame::new_unchecked_infer_height(cols) }
     }
 }
 

--- a/crates/polars-ops/src/frame/join/cross_join.rs
+++ b/crates/polars-ops/src/frame/join/cross_join.rs
@@ -167,7 +167,7 @@ pub(super) fn fused_cross_filter(
         .install(|| {
             cartesian_prod.par_iter().map(|(left, right)| {
                 let (mut left, right) = cross_join_dfs(left, right, None, false, maintain_order)?;
-                let mut right_columns = right.take_columns();
+                let mut right_columns = right.into_columns();
 
                 for (c, name) in right_columns.iter_mut().zip(rename_names) {
                     c.rename((*name).clone());

--- a/crates/polars-ops/src/frame/join/general.rs
+++ b/crates/polars-ops/src/frame/join/general.rs
@@ -21,7 +21,7 @@ pub fn _finish_join(
 ) -> PolarsResult<DataFrame> {
     let mut left_names = PlHashSet::with_capacity(df_left.width());
 
-    df_left.get_columns().iter().for_each(|series| {
+    df_left.columns().iter().for_each(|series| {
         left_names.insert(series.name());
     });
 
@@ -45,7 +45,7 @@ pub fn _finish_join(
 
     drop(left_names);
     // Safety: IR resolving should guarantee this passes
-    unsafe { df_left.hstack_mut_unchecked(df_right.get_columns()) };
+    unsafe { df_left.hstack_mut_unchecked(df_right.columns()) };
     Ok(df_left)
 }
 
@@ -68,8 +68,7 @@ pub fn _coalesce_full_join(
     let schema = df.schema().clone();
     let mut to_remove = Vec::with_capacity(keys_right.len());
 
-    // SAFETY: we maintain invariants.
-    let columns = unsafe { df.get_columns_mut() };
+    let columns = unsafe { df.columns_mut() };
     let suffix = get_suffix(suffix);
     for (l, r) in keys_left.iter().zip(keys_right.iter()) {
         let pos_l = schema.get_full(l.as_str()).unwrap().0;
@@ -92,7 +91,7 @@ pub fn _coalesce_full_join(
     for pos in to_remove {
         let _ = columns.remove(pos);
     }
-    df.clear_schema();
+
     df
 }
 

--- a/crates/polars-ops/src/frame/join/hash_join/mod.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/mod.rs
@@ -162,10 +162,12 @@ pub trait JoinDispatch: IntoDf {
         let idx_ca_r = IdxCa::with_chunk("b".into(), join_idx_r);
 
         let (df_left, df_right) = if args.maintain_order != MaintainOrderJoin::None {
-            let mut df = DataFrame::new(vec![
-                idx_ca_l.into_series().into(),
-                idx_ca_r.into_series().into(),
-            ])?;
+            let mut df = unsafe {
+                DataFrame::new_unchecked_infer_height(vec![
+                    idx_ca_l.into_series().into(),
+                    idx_ca_r.into_series().into(),
+                ])
+            };
 
             let options = SortMultipleOptions::new()
                 .with_order_descending(false)

--- a/crates/polars-ops/src/frame/join/merge_sorted.rs
+++ b/crates/polars-ops/src/frame/join/merge_sorted.rs
@@ -29,9 +29,9 @@ pub fn _merge_sorted_dfs(
 
     let merge_indicator = series_to_merge_indicator(left_s, right_s)?;
     let new_columns = left
-        .get_columns()
+        .columns()
         .iter()
-        .zip(right.get_columns())
+        .zip(right.columns())
         .map(|(lhs, rhs)| {
             let lhs_phys = lhs.to_physical_repr();
             let rhs_phys = rhs.to_physical_repr();
@@ -48,7 +48,7 @@ pub fn _merge_sorted_dfs(
         })
         .collect::<PolarsResult<_>>()?;
 
-    Ok(unsafe { DataFrame::new_no_checks(left.height() + right.height(), new_columns) })
+    Ok(unsafe { DataFrame::new_unchecked(left.height() + right.height(), new_columns) })
 }
 
 fn merge_series(lhs: &Series, rhs: &Series, merge_indicator: &[bool]) -> PolarsResult<Series> {

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -86,14 +86,14 @@ pub trait DataFrameJoinOps: IntoDf {
     fn join(
         &self,
         other: &DataFrame,
-        left_on: impl IntoIterator<Item = impl Into<PlSmallStr>>,
-        right_on: impl IntoIterator<Item = impl Into<PlSmallStr>>,
+        left_on: impl IntoIterator<Item = impl AsRef<str>>,
+        right_on: impl IntoIterator<Item = impl AsRef<str>>,
         args: JoinArgs,
         options: Option<JoinTypeOptions>,
     ) -> PolarsResult<DataFrame> {
         let df_left = self.to_df();
-        let selected_left = df_left.select_columns(left_on)?;
-        let selected_right = other.select_columns(right_on)?;
+        let selected_left = df_left.select_to_vec(left_on)?;
+        let selected_right = other.select_to_vec(right_on)?;
 
         let selected_left = selected_left
             .into_iter()
@@ -153,10 +153,10 @@ pub trait DataFrameJoinOps: IntoDf {
                 }
             }
         }
-        if left_df.is_empty() {
+        if left_df.height() == 0 {
             clear(&mut selected_left);
         }
-        if other.is_empty() {
+        if other.height() == 0 {
             clear(&mut selected_right);
         }
 
@@ -184,7 +184,7 @@ pub trait DataFrameJoinOps: IntoDf {
                     }
 
                     let mut tmp_left = left_df.clone();
-                    tmp_left.as_single_chunk_par();
+                    tmp_left.rechunk_mut_par();
                     left = Cow::Owned(tmp_left);
                 }
                 if other.should_rechunk() {
@@ -196,7 +196,7 @@ pub trait DataFrameJoinOps: IntoDf {
                         );
                     }
                     let mut tmp_right = other.clone();
-                    tmp_right.as_single_chunk_par();
+                    tmp_right.rechunk_mut_par();
                     right = Cow::Owned(tmp_right);
                 }
                 return left._join_impl(
@@ -230,7 +230,9 @@ pub trait DataFrameJoinOps: IntoDf {
             let Some(JoinTypeOptions::IEJoin(options)) = options else {
                 unreachable!()
             };
-            let func = if POOL.current_num_threads() > 1 && !left_df.is_empty() && !other.is_empty()
+            let func = if POOL.current_num_threads() > 1
+                && !left_df.shape_has_zero()
+                && !other.shape_has_zero()
             {
                 iejoin::iejoin_par
             } else {
@@ -332,19 +334,20 @@ pub trait DataFrameJoinOps: IntoDf {
                 },
             };
         }
-        let (lhs_keys, rhs_keys) =
-            if (left_df.is_empty() || other.is_empty()) && matches!(&args.how, JoinType::Inner) {
-                // Fast path for empty inner joins.
-                // Return 2 dummies so that we don't row-encode.
-                let a = Series::full_null("".into(), 0, &DataType::Null);
-                (a.clone(), a)
-            } else {
-                // Row encode the keys.
-                (
-                    prepare_keys_multiple(&selected_left, args.nulls_equal)?.into_series(),
-                    prepare_keys_multiple(&selected_right, args.nulls_equal)?.into_series(),
-                )
-            };
+        let (lhs_keys, rhs_keys) = if (left_df.height() == 0 || other.height() == 0)
+            && matches!(&args.how, JoinType::Inner)
+        {
+            // Fast path for empty inner joins.
+            // Return 2 dummies so that we don't row-encode.
+            let a = Series::full_null("".into(), 0, &DataType::Null);
+            (a.clone(), a)
+        } else {
+            // Row encode the keys.
+            (
+                prepare_keys_multiple(&selected_left, args.nulls_equal)?.into_series(),
+                prepare_keys_multiple(&selected_right, args.nulls_equal)?.into_series(),
+            )
+        };
 
         let drop_names = if should_coalesce {
             if args.how == JoinType::Right {
@@ -449,8 +452,8 @@ pub trait DataFrameJoinOps: IntoDf {
     fn inner_join(
         &self,
         other: &DataFrame,
-        left_on: impl IntoIterator<Item = impl Into<PlSmallStr>>,
-        right_on: impl IntoIterator<Item = impl Into<PlSmallStr>>,
+        left_on: impl IntoIterator<Item = impl AsRef<str>>,
+        right_on: impl IntoIterator<Item = impl AsRef<str>>,
     ) -> PolarsResult<DataFrame> {
         self.join(
             other,
@@ -499,8 +502,8 @@ pub trait DataFrameJoinOps: IntoDf {
     fn left_join(
         &self,
         other: &DataFrame,
-        left_on: impl IntoIterator<Item = impl Into<PlSmallStr>>,
-        right_on: impl IntoIterator<Item = impl Into<PlSmallStr>>,
+        left_on: impl IntoIterator<Item = impl AsRef<str>>,
+        right_on: impl IntoIterator<Item = impl AsRef<str>>,
     ) -> PolarsResult<DataFrame> {
         self.join(
             other,
@@ -524,8 +527,8 @@ pub trait DataFrameJoinOps: IntoDf {
     fn full_join(
         &self,
         other: &DataFrame,
-        left_on: impl IntoIterator<Item = impl Into<PlSmallStr>>,
-        right_on: impl IntoIterator<Item = impl Into<PlSmallStr>>,
+        left_on: impl IntoIterator<Item = impl AsRef<str>>,
+        right_on: impl IntoIterator<Item = impl AsRef<str>>,
     ) -> PolarsResult<DataFrame> {
         self.join(
             other,
@@ -579,8 +582,12 @@ trait DataFrameJoinOpsPrivate: IntoDf {
         try_raise_keyboard_interrupt();
         let (df_left, df_right) =
             if args.maintain_order != MaintainOrderJoin::None && !already_left_sorted {
-                let mut df =
-                    DataFrame::new(vec![left.into_series().into(), right.into_series().into()])?;
+                let mut df = unsafe {
+                    DataFrame::new_unchecked_infer_height(vec![
+                        left.into_series().into(),
+                        right.into_series().into(),
+                    ])
+                };
 
                 let columns = match args.maintain_order {
                     MaintainOrderJoin::Left | MaintainOrderJoin::LeftRight => vec!["a"],
@@ -594,7 +601,7 @@ trait DataFrameJoinOpsPrivate: IntoDf {
 
                 df.sort_in_place(columns, options)?;
 
-                let [mut a, b]: [Column; 2] = df.take_columns().try_into().unwrap();
+                let [mut a, b]: [Column; 2] = df.into_columns().try_into().unwrap();
                 if matches!(
                     args.maintain_order,
                     MaintainOrderJoin::Left | MaintainOrderJoin::LeftRight
@@ -650,12 +657,12 @@ pub fn private_left_join_multiple_keys(
 ) -> PolarsResult<LeftJoinIds> {
     // @scalar-opt
     let a_cols = a
-        .get_columns()
+        .columns()
         .iter()
         .map(|c| c.as_materialized_series().clone())
         .collect::<Vec<_>>();
     let b_cols = b
-        .get_columns()
+        .columns()
         .iter()
         .map(|c| c.as_materialized_series().clone())
         .collect::<Vec<_>>();

--- a/crates/polars-ops/src/frame/mod.rs
+++ b/crates/polars-ops/src/frame/mod.rs
@@ -105,11 +105,11 @@ pub trait DataFrameOps: IntoDf {
         let set: PlHashSet<&str> = if let Some(columns) = columns {
             PlHashSet::from_iter(columns)
         } else {
-            PlHashSet::from_iter(df.iter().map(|s| s.name().as_str()))
+            PlHashSet::from_iter(df.columns().iter().map(|s| s.name().as_str()))
         };
 
         let cols = POOL.install(|| {
-            df.get_columns()
+            df.columns()
                 .par_iter()
                 .map(|s| match set.contains(s.name().as_str()) {
                     true => s

--- a/crates/polars-ops/src/series/ops/horizontal.rs
+++ b/crates/polars-ops/src/series/ops/horizontal.rs
@@ -31,10 +31,10 @@ pub trait MinMaxHorizontal {
 
 impl MinMaxHorizontal for DataFrame {
     fn min_horizontal(&self) -> PolarsResult<Option<Column>> {
-        min_horizontal(self.get_columns())
+        min_horizontal(self.columns())
     }
     fn max_horizontal(&self) -> PolarsResult<Option<Column>> {
-        max_horizontal(self.get_columns())
+        max_horizontal(self.columns())
     }
 }
 
@@ -54,10 +54,10 @@ pub trait SumMeanHorizontal {
 
 impl SumMeanHorizontal for DataFrame {
     fn sum_horizontal(&self, null_strategy: NullStrategy) -> PolarsResult<Option<Column>> {
-        sum_horizontal(self.get_columns(), null_strategy)
+        sum_horizontal(self.columns(), null_strategy)
     }
     fn mean_horizontal(&self, null_strategy: NullStrategy) -> PolarsResult<Option<Column>> {
-        mean_horizontal(self.get_columns(), null_strategy)
+        mean_horizontal(self.columns(), null_strategy)
     }
 }
 
@@ -374,7 +374,7 @@ mod tests {
         let b = Column::new("b".into(), [Some(1), None, None]);
         let c = Column::new("c".into(), [Some(4), None, Some(3)]);
 
-        let df = DataFrame::new(vec![a, b, c]).unwrap();
+        let df = DataFrame::new_infer_height(vec![a, b, c]).unwrap();
         assert_eq!(
             Vec::from(
                 df.mean_horizontal(NullStrategy::Ignore)

--- a/crates/polars-ops/src/series/ops/replace.rs
+++ b/crates/polars-ops/src/series/ops/replace.rs
@@ -323,7 +323,7 @@ fn create_replacer(mut old: Series, mut new: Series, add_mask: bool) -> PolarsRe
     } else {
         vec![old.into(), new.into()]
     };
-    let out = unsafe { DataFrame::new_no_checks(len, cols) };
+    let out = unsafe { DataFrame::new_unchecked(len, cols) };
     Ok(out)
 }
 

--- a/crates/polars-ops/src/series/ops/to_dummies.rs
+++ b/crates/polars-ops/src/series/ops/to_dummies.rs
@@ -67,7 +67,7 @@ impl ToDummies for Series {
             })
             .collect::<Vec<_>>();
 
-        DataFrame::new(sort_columns(columns))
+        DataFrame::new_infer_height(sort_columns(columns))
     }
 }
 

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -45,7 +45,7 @@ pub trait SeriesMethods: SeriesSealed {
 
         let height = counts.len();
         let cols = vec![values, counts];
-        let df = unsafe { DataFrame::new_no_checks(height, cols) };
+        let df = unsafe { DataFrame::new_unchecked(height, cols) };
         if sort {
             df.sort(
                 [name],

--- a/crates/polars-plan/src/dsl/serializable_plan.rs
+++ b/crates/polars-plan/src/dsl/serializable_plan.rs
@@ -716,7 +716,8 @@ mod tests {
     fn test_dsl_plan_serialization() {
         let name = || "a".into();
         let df = Arc::new(
-            DataFrame::new(vec![Column::new(name(), Series::new(name(), &[1, 2, 3]))]).unwrap(),
+            DataFrame::new_infer_height(vec![Column::new(name(), Series::new(name(), &[1, 2, 3]))])
+                .unwrap(),
         );
         let dfscan = Arc::new(DslPlan::DataFrameScan {
             df: df.clone(),

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -755,14 +755,14 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             polars_ensure!(on.len() == on_columns.width(), InvalidOperation: "`pivot` expected `on` and `on_columns` to have the same amount of columns.");
             if on.len() > 1 {
                 polars_ensure!(
-                    on_columns.get_columns().iter().zip(on.iter()).all(|(c, o)| o == c.name()),
+                    on_columns.columns().iter().zip(on.iter()).all(|(c, o)| o == c.name()),
                     InvalidOperation: "`pivot` has mismatching column names between `on` and `on_columns`."
                 );
             }
             polars_ensure!(!values.is_empty(), InvalidOperation: "`pivot` called without `values` columns.");
 
             let on_titles = if on_columns.width() == 1 {
-                on_columns.get_columns()[0].cast(&DataType::String)?
+                on_columns.columns()[0].cast(&DataType::String)?
             } else {
                 on_columns
                     .as_ref()
@@ -836,7 +836,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                     }
 
                     let predicate = if on.len() == 1 {
-                        on_predicate(&on[0], &on_columns.get_columns()[0], i, ctxt.expr_arena)
+                        on_predicate(&on[0], &on_columns.columns()[0], i, ctxt.expr_arena)
                     } else {
                         AExprBuilder::function(
                             on.iter()
@@ -844,7 +844,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                                 .map(|(j, on_col)| {
                                     on_predicate(
                                         on_col,
-                                        &on_columns.get_columns()[j],
+                                        &on_columns.columns()[j],
                                         i,
                                         ctxt.expr_arena,
                                     )

--- a/crates/polars-plan/src/plans/functions/count.rs
+++ b/crates/polars-plan/src/plans/functions/count.rs
@@ -70,7 +70,8 @@ pub fn count_rows(
             |_| polars_err!(ComputeError: "count of {} exceeded maximum row size", count),
         )?;
         let column_name = alias.unwrap_or(PlSmallStr::from_static(crate::constants::LEN));
-        DataFrame::new(vec![Column::new(column_name, [count])])
+
+        Ok(unsafe { DataFrame::new_unchecked(1, vec![Column::new(column_name, [count])]) })
     }
 }
 

--- a/crates/polars-plan/src/plans/functions/mod.rs
+++ b/crates/polars-plan/src/plans/functions/mod.rs
@@ -241,7 +241,7 @@ impl FunctionIR {
                 alias,
             } => count::count_rows(sources, scan_type, cloud_options.as_ref(), alias.clone()),
             Rechunk => {
-                df.as_single_chunk_par();
+                df.rechunk_mut_par();
                 Ok(df)
             },
             Unnest { columns, separator } => {
@@ -266,7 +266,7 @@ impl FunctionIR {
                     && let Some(s) = s.first()
                 {
                     let idx = df.try_get_column_index(&s.column)?;
-                    let col = &mut unsafe { df.get_columns_mut() }[idx];
+                    let col = &mut unsafe { df.columns_mut_retain_schema() }[idx];
                     if let Some(d) = s.descending {
                         let flag = if d {
                             IsSorted::Descending

--- a/crates/polars-plan/src/plans/hive.rs
+++ b/crates/polars-plan/src/plans/hive.rs
@@ -15,14 +15,14 @@ impl HivePartitionsDf {
     pub fn filter_columns(&self, projected_columns: &Schema) -> Self {
         let columns: Vec<_> = self
             .df()
-            .get_columns()
+            .columns()
             .iter()
             .filter(|c| projected_columns.contains(c.name()))
             .cloned()
             .collect();
 
         let height = self.df().height();
-        DataFrame::new_with_height(height, columns).unwrap().into()
+        unsafe { DataFrame::new_unchecked(height, columns) }.into()
     }
 
     pub fn df(&self) -> &DataFrame {
@@ -201,7 +201,7 @@ pub fn hive_partitions_from_paths(
         .collect::<PolarsResult<Vec<_>>>()?;
     buffers.sort_by_key(|s| reader_schema.index_of(s.name()).unwrap_or(usize::MAX));
 
-    Ok(Some(HivePartitionsDf(DataFrame::new_with_height(
+    Ok(Some(HivePartitionsDf(DataFrame::new(
         paths.len(),
         buffers,
     )?)))

--- a/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
+++ b/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
@@ -246,9 +246,7 @@ pub(super) fn expand_datasets(
                                     .contains(&format_pl_smallstr!("{}_nc", row_index_name))
                             );
 
-                            statistics_df.clear_schema();
-
-                            unsafe { statistics_df.get_columns_mut() }.extend([
+                            unsafe { statistics_df.columns_mut() }.extend([
                                 IdxCa::from_vec(
                                     format_pl_smallstr!("{}_nc", row_index_name),
                                     vec![0],

--- a/crates/polars-plan/src/plans/optimizer/sortedness.rs
+++ b/crates/polars-plan/src/plans/optimizer/sortedness.rs
@@ -106,21 +106,19 @@ fn is_sorted_rec(
         } => rec!(*input),
         IR::Scan { .. } => None,
         IR::DataFrameScan { df, .. } => Some(IRSorted(
-            [df.get_columns()
-                .iter()
-                .find_map(|c| match c.is_sorted_flag() {
-                    IsSorted::Not => None,
-                    IsSorted::Ascending => Some(Sorted {
-                        column: c.name().clone(),
-                        descending: Some(false),
-                        nulls_last: Some(c.get(0).is_ok_and(|v| !v.is_null())),
-                    }),
-                    IsSorted::Descending => Some(Sorted {
-                        column: c.name().clone(),
-                        descending: Some(true),
-                        nulls_last: Some(c.get(0).is_ok_and(|v| !v.is_null())),
-                    }),
-                })?]
+            [df.columns().iter().find_map(|c| match c.is_sorted_flag() {
+                IsSorted::Not => None,
+                IsSorted::Ascending => Some(Sorted {
+                    column: c.name().clone(),
+                    descending: Some(false),
+                    nulls_last: Some(c.get(0).is_ok_and(|v| !v.is_null())),
+                }),
+                IsSorted::Descending => Some(Sorted {
+                    column: c.name().clone(),
+                    descending: Some(true),
+                    nulls_last: Some(c.get(0).is_ok_and(|v| !v.is_null())),
+                }),
+            })?]
             .into(),
         )),
         IR::SimpleProjection { input, columns } => {

--- a/crates/polars-python/src/dataframe/general.rs
+++ b/crates/polars-python/src/dataframe/general.rs
@@ -27,7 +27,7 @@ impl PyDataFrame {
         let columns = columns.to_series();
         // @scalar-opt
         let columns = columns.into_iter().map(|s| s.into()).collect();
-        let df = DataFrame::new(columns).map_err(PyPolarsErr::from)?;
+        let df = DataFrame::new_infer_height(columns).map_err(PyPolarsErr::from)?;
         Ok(PyDataFrame::new(df))
     }
 
@@ -38,7 +38,7 @@ impl PyDataFrame {
     pub fn dtype_strings(&self) -> Vec<String> {
         self.df
             .read()
-            .get_columns()
+            .columns()
             .iter()
             .map(|s| format!("{}", s.dtype()))
             .collect()
@@ -119,7 +119,7 @@ impl PyDataFrame {
     pub fn rechunk(&self, py: Python) -> PyResult<Self> {
         py.enter_polars_df(|| {
             let mut df = self.df.read().clone();
-            df.as_single_chunk_par();
+            df.rechunk_mut_par();
             Ok(df)
         })
     }
@@ -130,7 +130,7 @@ impl PyDataFrame {
     }
 
     pub fn get_columns(&self) -> Vec<PySeries> {
-        let cols = self.df.read().get_columns().to_vec();
+        let cols = self.df.read().columns().to_vec();
         cols.to_pyseries()
     }
 
@@ -138,7 +138,7 @@ impl PyDataFrame {
     pub fn columns(&self) -> Vec<String> {
         self.df
             .read()
-            .get_columns()
+            .columns()
             .iter()
             .map(|s| s.name().to_string())
             .collect()
@@ -148,7 +148,7 @@ impl PyDataFrame {
     pub fn set_column_names(&self, names: Vec<PyBackedStr>) -> PyResult<()> {
         self.df
             .write()
-            .set_column_names(names.iter().map(|x| &**x))
+            .set_column_names(&names)
             .map_err(PyPolarsErr::from)?;
         Ok(())
     }
@@ -157,6 +157,7 @@ impl PyDataFrame {
     pub fn dtypes<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
         let df = self.df.read();
         let iter = df
+            .columns()
             .iter()
             .map(|s| Wrap(s.dtype().clone()).into_pyobject(py).unwrap());
         PyList::new(py, iter)
@@ -179,7 +180,7 @@ impl PyDataFrame {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.df.read().is_empty()
+        self.df.read().shape_has_zero()
     }
 
     pub fn hstack(&self, py: Python<'_>, columns: Vec<PySeries>) -> PyResult<Self> {
@@ -205,7 +206,7 @@ impl PyDataFrame {
         py.enter_polars(|| {
             // Prevent self-vstack deadlocks.
             let other = other.df.read().clone();
-            self.df.write().vstack_mut(&other)?;
+            self.df.write().vstack_mut_owned(other)?;
             PolarsResult::Ok(())
         })?;
         Ok(())
@@ -285,7 +286,7 @@ impl PyDataFrame {
     pub fn replace(&self, column: &str, new_col: PySeries) -> PyResult<()> {
         self.df
             .write()
-            .replace(column, new_col.series.into_inner())
+            .replace(column, new_col.series.into_inner().into_column())
             .map_err(PyPolarsErr::from)?;
         Ok(())
     }
@@ -293,7 +294,7 @@ impl PyDataFrame {
     pub fn replace_column(&self, index: usize, new_column: PySeries) -> PyResult<()> {
         self.df
             .write()
-            .replace_column(index, new_column.series.into_inner())
+            .replace_column(index, new_column.series.into_inner().into_column())
             .map_err(PyPolarsErr::from)?;
         Ok(())
     }
@@ -301,7 +302,7 @@ impl PyDataFrame {
     pub fn insert_column(&self, index: usize, column: PySeries) -> PyResult<()> {
         self.df
             .write()
-            .insert_column(index, column.series.into_inner())
+            .insert_column(index, column.series.into_inner().into_column())
             .map_err(PyPolarsErr::from)?;
         Ok(())
     }
@@ -554,7 +555,7 @@ impl PyDataFrame {
         use polars_ffi::version_0::export_column;
 
         let df = self.df.read();
-        let cols = df.get_columns();
+        let cols = df.columns();
 
         let location = location as *mut SeriesExport;
 
@@ -593,14 +594,14 @@ impl PyDataFrame {
             let is_unordered = opts.first().is_some_and(|(_, _, v)| *v);
 
             let ca = if is_unordered {
-                _get_rows_encoded_ca_unordered(name, self.df.read().get_columns())
+                _get_rows_encoded_ca_unordered(name, self.df.read().columns())
             } else {
                 let descending = opts.iter().map(|(v, _, _)| *v).collect::<Vec<_>>();
                 let nulls_last = opts.iter().map(|(_, v, _)| *v).collect::<Vec<_>>();
 
                 _get_rows_encoded_ca(
                     name,
-                    self.df.read().get_columns(),
+                    self.df.read().columns(),
                     descending.as_slice(),
                     nulls_last.as_slice(),
                 )

--- a/crates/polars-python/src/dataframe/io.rs
+++ b/crates/polars-python/src/dataframe/io.rs
@@ -138,19 +138,19 @@ impl PyDataFrame {
         let mmap_bytes_r = get_mmap_bytes_reader(&py_f)?;
 
         py.enter_polars_df(move || {
-            let mut builder = JsonReader::new(mmap_bytes_r)
+            let mut reader = JsonReader::new(mmap_bytes_r)
                 .with_json_format(JsonFormat::Json)
                 .infer_schema_len(infer_schema_length.and_then(NonZeroUsize::new));
 
             if let Some(schema) = schema {
-                builder = builder.with_schema(Arc::new(schema.0));
+                reader = reader.with_schema(Arc::new(schema.0));
             }
 
             if let Some(schema) = schema_overrides.as_ref() {
-                builder = builder.with_schema_overwrite(&schema.0);
+                reader = reader.with_schema_overwrite(&schema.0);
             }
 
-            builder.finish()
+            reader.finish()
         })
     }
 

--- a/crates/polars-python/src/dataframe/map.rs
+++ b/crates/polars-python/src/dataframe/map.rs
@@ -24,7 +24,7 @@ impl PyDataFrame {
         let df = self.df.read();
         let height = df.height();
         let col_series: Vec<_> = df
-            .get_columns()
+            .columns()
             .iter()
             .map(|s| s.as_materialized_series().clone())
             .collect();

--- a/crates/polars-python/src/functions/eager.rs
+++ b/crates/polars-python/src/functions/eager.rs
@@ -31,13 +31,13 @@ pub fn concat_df(dfs: &Bound<'_, PyAny>, py: Python) -> PyResult<PyDataFrame> {
         polars_core::POOL.install(|| {
             rdfs.into_par_iter()
                 .fold(identity, |acc: PolarsResult<DataFrame>, df| {
-                    let mut acc = acc?;
-                    acc.vstack_mut(&df?)?;
+                    let mut acc: DataFrame = acc?;
+                    acc.vstack_mut_owned(df?)?;
                     Ok(acc)
                 })
                 .reduce(identity, |acc, df| {
                     let mut acc = acc?;
-                    acc.vstack_mut(&df?)?;
+                    acc.vstack_mut_owned(df?)?;
                     Ok(acc)
                 })
         })

--- a/crates/polars-python/src/interop/arrow/to_py.rs
+++ b/crates/polars-python/src/interop/arrow/to_py.rs
@@ -129,7 +129,7 @@ impl DataFrameStreamIterator {
 
         Self {
             columns: df
-                .get_columns()
+                .columns()
                 .iter()
                 .map(|v| v.as_materialized_series().clone())
                 .collect(),

--- a/crates/polars-python/src/interop/arrow/to_rust.rs
+++ b/crates/polars-python/src/interop/arrow/to_rust.rs
@@ -96,7 +96,7 @@ pub fn to_rust_df(
             .collect::<Vec<_>>();
 
         // no need to check as a record batch has the same guarantees
-        return Ok(unsafe { DataFrame::new_no_checks_height_from_first(columns) });
+        return Ok(unsafe { DataFrame::new_unchecked_infer_height(columns) });
     }
 
     let dfs = rb
@@ -174,7 +174,7 @@ pub fn to_rust_df(
             }?;
 
             // no need to check as a record batch has the same guarantees
-            Ok(unsafe { DataFrame::new_no_checks_height_from_first(columns) })
+            Ok(unsafe { DataFrame::new_unchecked_infer_height(columns) })
         })
         .collect::<PyResult<Vec<_>>>()?;
 

--- a/crates/polars-python/src/interop/numpy/to_numpy_df.rs
+++ b/crates/polars-python/src/interop/numpy/to_numpy_df.rs
@@ -37,7 +37,7 @@ pub(super) fn df_to_numpy(
     writable: bool,
     allow_copy: bool,
 ) -> PyResult<Py<PyAny>> {
-    if df.is_empty() {
+    if df.shape_has_zero() {
         // Take this path to ensure a writable array.
         // This does not actually copy data for an empty DataFrame.
         return df_to_numpy_with_copy(py, df, order, true);
@@ -71,7 +71,7 @@ fn try_df_to_numpy_view(py: Python<'_>, df: &DataFrame, allow_nulls: bool) -> Op
     let first_dtype = check_df_dtypes_support_view(df)?;
 
     // TODO: Check for nested nulls using `series_contains_null` util when we support Array types.
-    if !allow_nulls && df.get_columns().iter().any(|s| s.null_count() > 0) {
+    if !allow_nulls && df.columns().iter().any(|s| s.null_count() > 0) {
         return None;
     }
     if !check_df_columns_contiguous(df) {
@@ -97,7 +97,7 @@ fn try_df_to_numpy_view(py: Python<'_>, df: &DataFrame, allow_nulls: bool) -> Op
 ///
 /// Returns the common data type if it is supported, otherwise returns `None`.
 fn check_df_dtypes_support_view(df: &DataFrame) -> Option<&DataType> {
-    let columns = df.get_columns();
+    let columns = df.columns();
     let first_dtype = columns.first()?.dtype();
 
     // TODO: Support viewing Array types
@@ -111,7 +111,7 @@ fn check_df_dtypes_support_view(df: &DataFrame) -> Option<&DataType> {
 }
 /// Returns whether all columns of the dataframe are contiguous in memory.
 fn check_df_columns_contiguous(df: &DataFrame) -> bool {
-    let columns = df.get_columns();
+    let columns = df.columns();
 
     if columns
         .iter()
@@ -178,7 +178,7 @@ where
     T::Native: Element,
 {
     let ca: &ChunkedArray<T> = df
-        .get_columns()
+        .columns()
         .first()
         .unwrap()
         .as_materialized_series()
@@ -203,7 +203,7 @@ where
 }
 /// Create a NumPy view of a Datetime or Duration DataFrame.
 fn temporal_df_to_numpy_view(py: Python<'_>, df: &DataFrame, owner: Py<PyAny>) -> Py<PyAny> {
-    let s = df.get_columns().first().unwrap();
+    let s = df.columns().first().unwrap();
     let phys = s.to_physical_repr();
     let ca = phys.i64().unwrap();
     let first_slice = ca.data_views().next().unwrap();
@@ -241,7 +241,7 @@ fn try_df_to_numpy_numeric_supertype(
     df: &DataFrame,
     order: IndexOrder,
 ) -> Option<Py<PyAny>> {
-    let st = dtypes_to_supertype(df.iter().map(|s| s.dtype())).ok()?;
+    let st = dtypes_to_supertype(df.columns().iter().map(|s| s.dtype())).ok()?;
 
     let np_array = match st {
         dt if dt.is_primitive_numeric() => with_match_physical_numpy_polars_type!(dt, |$T| {
@@ -258,8 +258,8 @@ fn df_columns_to_numpy(
     order: IndexOrder,
     writable: bool,
 ) -> PyResult<Py<PyAny>> {
-    let np_arrays = df.iter().map(|s| {
-        let mut arr = series_to_numpy(py, s, writable, true).unwrap();
+    let np_arrays = df.columns().iter().map(|c| {
+        let mut arr = series_to_numpy(py, c.as_materialized_series(), writable, true).unwrap();
 
         // Convert multidimensional arrays to 1D object arrays.
         let shape: Vec<usize> = arr

--- a/crates/polars-schema/src/schema.rs
+++ b/crates/polars-schema/src/schema.rs
@@ -491,21 +491,6 @@ where
     }
 }
 
-pub fn ensure_matching_schema_names<D>(lhs: &Schema<D>, rhs: &Schema<D>) -> PolarsResult<()> {
-    let lhs_names = lhs.iter_names();
-    let rhs_names = rhs.iter_names();
-
-    if !(lhs_names.len() == rhs_names.len() && lhs_names.zip(rhs_names).all(|(l, r)| l == r)) {
-        polars_bail!(
-            SchemaMismatch:
-            "lhs: {:?} rhs: {:?}",
-            lhs.iter_names().collect::<Vec<_>>(), rhs.iter_names().collect::<Vec<_>>()
-        )
-    }
-
-    Ok(())
-}
-
 impl<D: Debug> Debug for Schema<D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Schema:")?;

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -643,7 +643,7 @@ impl SQLContext {
                     .collect::<Series>()
                     .with_name(PlSmallStr::from_static("Logical Plan"))
                     .into_column();
-                let df = DataFrame::new(vec![plan])?;
+                let df = DataFrame::new_infer_height(vec![plan])?;
                 Ok(df.lazy())
             },
             _ => polars_bail!(SQLInterface: "unexpected statement type; expected EXPLAIN"),
@@ -653,7 +653,7 @@ impl SQLContext {
     // SHOW TABLES
     fn execute_show_tables(&mut self, _: &Statement) -> PolarsResult<LazyFrame> {
         let tables = Column::new("name".into(), self.get_tables());
-        let df = DataFrame::new(vec![tables])?;
+        let df = DataFrame::new_infer_height(vec![tables])?;
         Ok(df.lazy())
     }
 
@@ -1671,7 +1671,7 @@ impl SQLContext {
                         .map(Column::from)
                         .collect();
 
-                    let lf = DataFrame::new(column_series)?.lazy();
+                    let lf = DataFrame::new_infer_height(column_series)?.lazy();
 
                     if *with_offset {
                         // TODO: support 'WITH ORDINALITY|OFFSET' modifier.

--- a/crates/polars-sql/tests/simple_exprs.rs
+++ b/crates/polars-sql/tests/simple_exprs.rs
@@ -9,7 +9,7 @@ fn create_sample_df() -> DataFrame {
         (1..10000i64).map(|i| i / 100).collect::<Vec<_>>(),
     );
     let b = Column::new("b".into(), 1..10000i64);
-    DataFrame::new(vec![a, b]).unwrap()
+    DataFrame::new_infer_height(vec![a, b]).unwrap()
 }
 
 fn create_struct_df() -> (DataFrame, DataFrame) {
@@ -646,7 +646,7 @@ fn test_multiple_explodes_with_same_column() {
         })
         .collect();
 
-    let expected_df = DataFrame::new(vec![
+    let expected_df = DataFrame::new_infer_height(vec![
         Column::new(PlSmallStr::from_static("list_a"), expected_list_a),
         Column::new(PlSmallStr::from_static("list_b"), expected_list_b),
         Column::new(
@@ -712,7 +712,7 @@ fn test_multiple_explodes_different_columns() {
     let expected_list_b: Vec<i64> = (1..10000).collect();
     let expected_value: Vec<i32> = vec![100i32; expected_list_b.len()];
 
-    let expected_df = DataFrame::new(vec![
+    let expected_df = DataFrame::new_infer_height(vec![
         Column::new(PlSmallStr::from_static("list_a"), expected_list_a),
         Column::new(PlSmallStr::from_static("list_b"), expected_list_b),
         Column::new(PlSmallStr::from_static("value"), expected_value),
@@ -745,7 +745,7 @@ fn explode_same_name_with_cte() {
 
     let list_series = Column::new(PlSmallStr::from_static("list_a"), values);
 
-    let df = DataFrame::new(vec![list_series]).unwrap();
+    let df = DataFrame::new_infer_height(vec![list_series]).unwrap();
 
     let df_imploded = df
         .lazy()
@@ -809,7 +809,7 @@ fn explode_same_name_with_cte() {
         .unwrap();
 
     let expected_results = vec![1i64, 2, 3, 4, 5, 6, 7, 8];
-    let expected_df = DataFrame::new(vec![Column::new(
+    let expected_df = DataFrame::new_infer_height(vec![Column::new(
         PlSmallStr::from_static("list_a"),
         expected_results,
     )])

--- a/crates/polars-sql/tests/statements.rs
+++ b/crates/polars-sql/tests/statements.rs
@@ -5,7 +5,7 @@ use polars_sql::*;
 fn create_ctx() -> SQLContext {
     let a = Column::new("a".into(), (1..10i64).map(|i| i / 100).collect::<Vec<_>>());
     let b = Column::new("b".into(), 1..10i64);
-    let df = DataFrame::new(vec![a, b]).unwrap().lazy();
+    let df = DataFrame::new_infer_height(vec![a, b]).unwrap().lazy();
     let mut ctx = SQLContext::new();
     ctx.register("df", df);
     ctx

--- a/crates/polars-stream/src/dispatch.rs
+++ b/crates/polars-stream/src/dispatch.rs
@@ -54,7 +54,7 @@ impl Executor for StreamingQueryExecutor {
             .map(|x| x.unwrap_single())?;
 
         if self.rechunk {
-            df.as_single_chunk_par();
+            df.rechunk_mut_par();
         }
 
         Ok(df)

--- a/crates/polars-stream/src/nodes/callback_sink.rs
+++ b/crates/polars-stream/src/nodes/callback_sink.rs
@@ -53,7 +53,7 @@ impl ComputeNode for CallbackSinkNode {
             recv[0] = PortState::Done;
 
             // Flush the last buffer
-            if !self.buffer.is_empty() && !self.is_done {
+            if self.buffer.height() > 0 && !self.is_done {
                 let function = self.function.clone();
                 let df = std::mem::take(&mut self.buffer);
 
@@ -98,9 +98,9 @@ impl ComputeNode for CallbackSinkNode {
                 let (df, _, _, consume_token) = m.into_inner();
 
                 // @NOTE: This also performs schema validation.
-                self.buffer.vstack_mut(&df)?;
+                self.buffer.vstack_mut_owned(df)?;
 
-                while !self.buffer.is_empty()
+                while self.buffer.height() > 0
                     && self
                         .chunk_size
                         .is_none_or(|chunk_size| self.buffer.height() >= chunk_size.into())

--- a/crates/polars-stream/src/nodes/dynamic_slice.rs
+++ b/crates/polars-stream/src/nodes/dynamic_slice.rs
@@ -46,8 +46,8 @@ impl ComputeNode for DynamicSliceNode {
             if let Self::GatheringParams { offset, length } = self {
                 let offset = offset.get_output()?.unwrap();
                 let length = length.get_output()?.unwrap();
-                let offset_item = offset.get_columns()[0].get(0)?;
-                let length_item = length.get_columns()[0].get(0)?;
+                let offset_item = offset.columns()[0].get(0)?;
+                let length_item = length.columns()[0].get(0)?;
                 let offset = offset_item.extract::<i64>().unwrap_or(0);
                 let length = length_item.extract::<usize>().unwrap_or(usize::MAX);
                 if let Ok(non_neg_offset) = offset.try_into() {

--- a/crates/polars-stream/src/nodes/ewm.rs
+++ b/crates/polars-stream/src/nodes/ewm.rs
@@ -57,7 +57,7 @@ impl ComputeNode for EwmNode {
                 debug_assert_eq!(df.width(), 1);
 
                 unsafe {
-                    let c = df.get_columns_mut().get_mut(0).unwrap();
+                    let c = df.columns_mut_retain_schema().get_mut(0).unwrap();
 
                     *c = Series::from_chunks_and_dtype_unchecked(
                         c.name().clone(),

--- a/crates/polars-stream/src/nodes/filter.rs
+++ b/crates/polars-stream/src/nodes/filter.rs
@@ -55,7 +55,7 @@ impl ComputeNode for FilterNode {
                         })?;
 
                         // We already parallelize, call the sequential filter.
-                        df._filter_seq(mask)
+                        df.filter_seq(mask)
                     }).await?;
 
                     if morsel.df().height() == 0 {

--- a/crates/polars-stream/src/nodes/io_sinks/metrics.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/metrics.rs
@@ -60,7 +60,7 @@ impl WriteMetrics {
     pub fn append(&mut self, df: &DataFrame) -> PolarsResult<()> {
         assert_eq!(self.columns.len(), df.width());
         self.num_rows += df.height() as u64;
-        for (w, c) in self.columns.iter_mut().zip(df.get_columns()) {
+        for (w, c) in self.columns.iter_mut().zip(df.columns()) {
             let null_count = c.null_count();
             w.null_count += c.null_count() as u64;
 
@@ -206,7 +206,7 @@ impl WriteMetrics {
             df_columns.push(struct_ca.into_column());
         }
 
-        DataFrame::new_with_height(num_metrics, df_columns).unwrap()
+        DataFrame::new(num_metrics, df_columns).unwrap()
     }
 }
 

--- a/crates/polars-stream/src/nodes/io_sinks/partition/by_key.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/by_key.rs
@@ -163,7 +163,7 @@ impl SinkNode for PartitionByKeySinkNode {
                         let partitions = partitions
                             .into_iter()
                             .map(|mut df| {
-                                let keys = df.select_columns(key_cols.iter().cloned())?;
+                                let keys = df.select_to_vec(key_cols.iter().cloned())?;
                                 let keys = keys
                                     .into_iter()
                                     .map(|c| c.head(Some(1)))

--- a/crates/polars-stream/src/nodes/io_sinks/partition/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/mod.rs
@@ -291,7 +291,9 @@ async fn open_new_sink(
                     limit: None,
                 },
             )?;
-            df = df.select_by_range(0..df.width() - num_selectors)?;
+
+            let truncate_len = df.width() - num_selectors;
+            unsafe { df.columns_mut() }.truncate(truncate_len);
 
             _ = old_sender
                 .send(Morsel::new(df, MorselSeq::default(), SourceToken::new()))

--- a/crates/polars-stream/src/nodes/io_sinks/partition/parted.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/parted.rs
@@ -175,9 +175,9 @@ impl SinkNode for PartedPartitionSinkNode {
 
                     let mut c = if key_cols.len() == 1 {
                         let idx = df.try_get_column_index(&key_cols[0])?;
-                        df.get_columns()[idx].clone()
+                        df.columns()[idx].clone()
                     } else {
-                        let columns = df.select_columns(key_cols.iter().cloned())?;
+                        let columns = df.select_to_vec(key_cols.iter().cloned())?;
                         _get_rows_encoded_ca_unordered(PlSmallStr::EMPTY, &columns)?.into_column()
                     };
 
@@ -219,7 +219,7 @@ impl SinkNode for PartedPartitionSinkNode {
                         let current_sink = match current_sink_opt.as_mut() {
                             Some(c) => c,
                             None => {
-                                let keys = parted_df.select_columns(key_cols.iter().cloned())?;
+                                let keys = parted_df.select_to_vec(key_cols.iter().cloned())?;
                                 let result = open_new_sink(
                                     base_path.as_ref().as_ref(),
                                     file_path_cb.as_ref(),

--- a/crates/polars-stream/src/nodes/io_sinks2/components/file_provider.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/components/file_provider.rs
@@ -29,7 +29,7 @@ impl FileProvider {
 
                 let mut partition_parts = String::new();
 
-                let partition_keys: &[Column] = partition_keys.get_columns();
+                let partition_keys: &[Column] = partition_keys.columns();
 
                 write!(
                     &mut partition_parts,

--- a/crates/polars-stream/src/nodes/io_sinks2/components/partition_distributor.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/components/partition_distributor.rs
@@ -281,7 +281,7 @@ impl PartitionDistributor {
                     assert_eq!(partition.buffered_size(), partition.total_size);
 
                     let mut df = std::mem::take(&mut partition.buffered_rows);
-                    rechunk_par(unsafe { df.get_columns_mut() }).await;
+                    rechunk_par(unsafe { df.columns_mut_retain_schema() }).await;
                     let df = Arc::new(df);
 
                     #[expect(unused)]

--- a/crates/polars-stream/src/nodes/io_sinks2/components/partition_morsel_sender.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/components/partition_morsel_sender.rs
@@ -204,15 +204,15 @@ impl PartitionMorselSender {
             assert!((1..=available_row_capacity.num_rows).contains(&morsel_height));
 
             if let Some(hstack_keys) = self.hstack_keys.as_ref() {
-                let columns = morsel.df().get_columns();
+                let columns = morsel.df().columns();
                 let height = morsel.df().height();
                 let new_columns = hstack_keys.hstack_columns_broadcast(
                     height,
                     columns,
-                    partition.keys_df.get_columns(),
+                    partition.keys_df.columns(),
                 );
 
-                *morsel.df_mut() = unsafe { DataFrame::new_no_checks(height, new_columns) };
+                *morsel.df_mut() = unsafe { DataFrame::new_unchecked(height, new_columns) };
             };
 
             if file_sink_task_data.morsel_tx.send(morsel).await.is_err() {

--- a/crates/polars-stream/src/nodes/io_sinks2/writers/csv/morsel_serializer.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/writers/csv/morsel_serializer.rs
@@ -78,7 +78,7 @@ impl MorselSerializer {
             serialized_data,
         } = &mut self;
 
-        rechunk_par(unsafe { df.get_columns_mut() }).await;
+        rechunk_par(unsafe { df.columns_mut_retain_schema() }).await;
 
         serialized_data.clear();
         csv_serializer.serialize_to_csv(&df, serialized_data)?;

--- a/crates/polars-stream/src/nodes/io_sinks2/writers/ndjson/morsel_serializer.rs
+++ b/crates/polars-stream/src/nodes/io_sinks2/writers/ndjson/morsel_serializer.rs
@@ -73,7 +73,7 @@ impl MorselSerializer {
     pub async fn serialize_morsel(mut self, mut df: DataFrame) -> PolarsResult<Self> {
         let MorselSerializer { serialized_data } = &mut self;
 
-        rechunk_par(unsafe { df.get_columns_mut() }).await;
+        rechunk_par(unsafe { df.columns_mut_retain_schema() }).await;
 
         serialized_data.clear();
 

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/components/row_deletions.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/components/row_deletions.rs
@@ -310,11 +310,11 @@ impl ExternalFilterMask {
                 if !mask.is_empty() {
                     *df = if mask.len() < df.height() {
                         accumulate_dataframes_vertical_unchecked([
-                            df.slice(0, mask.len())._filter_seq(mask)?,
+                            df.slice(0, mask.len()).filter_seq(mask)?,
                             df.slice(i64::try_from(mask.len()).unwrap(), df.height() - mask.len()),
                         ])
                     } else {
-                        df._filter_seq(mask)?
+                        df.filter_seq(mask)?
                     }
                 }
             },

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/tasks/reader_starter.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/tasks/reader_starter.rs
@@ -545,7 +545,7 @@ async fn start_reader_impl(
         if let Some(hp) = &hive_parts {
             external_predicate_cols.extend(
                 hp.df()
-                    .get_columns()
+                    .columns()
                     .iter()
                     .filter(|c| predicate.live_columns.contains(c.name()))
                     .map(|c| {

--- a/crates/polars-stream/src/nodes/io_sources/parquet/statistics.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/statistics.rs
@@ -151,7 +151,7 @@ pub(super) async fn calculate_row_group_pred_pushdown_skip_mask(
             columns.extend([statistics.min, statistics.max, statistics.null_count]);
         }
 
-        let statistics_df = DataFrame::new_with_height(num_row_groups, columns)?;
+        let statistics_df = DataFrame::new(num_row_groups, columns)?;
 
         sbp.evaluate_with_stat_df(&statistics_df)
     })

--- a/crates/polars-stream/src/nodes/joins/cross_join.rs
+++ b/crates/polars-stream/src/nodes/joins/cross_join.rs
@@ -173,18 +173,15 @@ impl ComputeNode for CrossJoinNode {
                                             core::mem::swap(&mut left_join_df, &mut right_join_df);
                                         }
 
-                                        for (col, opt_rename) in right_join_df
-                                            .get_columns_mut()
-                                            .iter_mut()
-                                            .zip(right_rename)
+                                        for (col, opt_rename) in
+                                            right_join_df.columns_mut().iter_mut().zip(right_rename)
                                         {
                                             if let Some(rename) = opt_rename {
                                                 col.rename(rename.clone());
                                             }
                                         }
 
-                                        left_join_df
-                                            .hstack_mut_unchecked(right_join_df.get_columns());
+                                        left_join_df.hstack_mut_unchecked(right_join_df.columns());
                                         Morsel::new(
                                             left_join_df,
                                             morsel.seq(),

--- a/crates/polars-stream/src/nodes/joins/semi_anti_join.rs
+++ b/crates/polars-stream/src/nodes/joins/semi_anti_join.rs
@@ -27,7 +27,7 @@ async fn select_keys(
     for selector in key_selectors {
         key_columns.push(selector.evaluate(df, state).await?.into_column());
     }
-    let keys = DataFrame::new_with_broadcast_len(key_columns, df.height())?;
+    let keys = unsafe { DataFrame::new_unchecked_with_broadcast(df.height(), key_columns) }?;
     Ok(HashKeys::from_df(
         &keys,
         params.random_state.clone(),
@@ -305,7 +305,7 @@ impl ProbeState {
                         arr.set_validity(hash_keys.validity().cloned());
                     }
                     let s = BooleanChunked::with_chunk(df[0].name().clone(), arr).into_series();
-                    DataFrame::new(vec![Column::from(s)])?
+                    DataFrame::new_unchecked(s.len(), vec![Column::from(s)])
                 } else {
                     probe_match.clear();
                     partitions[0].probe_partitioned_groupers(

--- a/crates/polars-stream/src/nodes/merge_sorted.rs
+++ b/crates/polars-stream/src/nodes/merge_sorted.rs
@@ -68,8 +68,8 @@ fn find_mergeable(
             (None, None) => return Ok(None),
         };
 
-        let left_key = left.get_columns().last().unwrap();
-        let right_key = right.get_columns().last().unwrap();
+        let left_key = left.columns().last().unwrap();
+        let right_key = right.columns().last().unwrap();
 
         let left_null_count = left_key.null_count();
         let right_null_count = right_key.null_count();
@@ -147,10 +147,10 @@ fn find_mergeable(
         (left_mergeable, left) = left.split_at(left_cutoff as i64);
         (right_mergeable, right) = right.split_at(right_cutoff as i64);
 
-        if !left.is_empty() {
+        if left.height() > 0 {
             left_unmerged.push_front(left);
         }
-        if !right.is_empty() {
+        if right.height() > 0 {
             right_unmerged.push_front(right);
         }
 
@@ -163,8 +163,7 @@ fn remove_key_column(df: &mut DataFrame) {
     // - We only pop so height stays same.
     // - We only pop so no new name collisions.
     // - We clear schema afterwards.
-    unsafe { df.get_columns_mut().pop().unwrap() };
-    df.clear_schema();
+    unsafe { df.columns_mut().pop().unwrap() };
 }
 
 impl ComputeNode for MergeSortedNode {
@@ -454,7 +453,7 @@ impl ComputeNode for MergeSortedNode {
                             // When we are flushing the buffer, we will just send one morsel from
                             // the input. We don't want to mess with the source token or wait group
                             // and just pass it on.
-                            if right.is_empty() {
+                            if right.shape_has_zero() {
                                 remove_key_column(left.df_mut());
 
                                 if send.send(left).await.is_err() {
@@ -467,13 +466,13 @@ impl ComputeNode for MergeSortedNode {
                             assert!(wg.is_none());
 
                             let left_s = left
-                                .get_columns()
+                                .columns()
                                 .last()
                                 .unwrap()
                                 .as_materialized_series()
                                 .clone();
                             let right_s = right
-                                .get_columns()
+                                .columns()
                                 .last()
                                 .unwrap()
                                 .as_materialized_series()

--- a/crates/polars-stream/src/nodes/peak_minmax.rs
+++ b/crates/polars-stream/src/nodes/peak_minmax.rs
@@ -111,7 +111,7 @@ impl ComputeNode for PeakMinMaxNode {
                         self.is_peak_max,
                     )?
                     .into_column();
-                    let df = DataFrame::new(vec![column]).unwrap();
+                    let df = unsafe { DataFrame::new_unchecked(column.len(), vec![column]) };
                     _ = send.send(Morsel::new(df, seq, SourceToken::new())).await;
 
                     self.state = State::Done;
@@ -153,7 +153,7 @@ impl ComputeNode for PeakMinMaxNode {
 
                         let wg = WaitGroup::default();
                         let mut m = Morsel::new(
-                            DataFrame::new(vec![out]).unwrap(),
+                            unsafe { DataFrame::new_unchecked(out.len(), vec![out]) },
                             prev_seq,
                             source_token.clone(),
                         );

--- a/crates/polars-stream/src/nodes/reduce.rs
+++ b/crates/polars-stream/src/nodes/reduce.rs
@@ -149,7 +149,7 @@ impl ComputeNode for ReduceNode {
                         })
                     })
                     .try_collect_vec()?;
-                let out = DataFrame::new(columns).unwrap();
+                let out = unsafe { DataFrame::new_unchecked(1, columns) };
 
                 self.state = ReduceState::Source(Some(out));
             },

--- a/crates/polars-stream/src/nodes/repeat.rs
+++ b/crates/polars-stream/src/nodes/repeat.rs
@@ -45,7 +45,7 @@ impl ComputeNode for RepeatNode {
         if recv[0] == PortState::Done && recv[1] == PortState::Done {
             if let Self::GatheringParams { value, repeats } = self {
                 let repeats = repeats.get_output()?.unwrap();
-                let repeats_item = repeats.get_columns()[0].get(0)?;
+                let repeats_item = repeats.columns()[0].get(0)?;
                 let repeats_left = repeats_item.extract::<usize>().unwrap();
 
                 let value = value.get_output()?.unwrap();

--- a/crates/polars-stream/src/nodes/rle.rs
+++ b/crates/polars-stream/src/nodes/rle.rs
@@ -110,7 +110,7 @@ impl ComputeNode for RleNode {
                         )
                         .into_column(self.name.clone());
 
-                        let df = DataFrame::new(vec![column]).unwrap();
+                        let df = unsafe { DataFrame::new_unchecked(column.len(), vec![column]) };
                         _ = send
                             .send(Morsel::new(df, self.seq.successor(), SourceToken::new()))
                             .await;
@@ -215,7 +215,12 @@ impl ComputeNode for RleNode {
                             [&lengths, &series].into_iter(),
                         )
                         .unwrap();
-                        *m.df_mut() = DataFrame::new(vec![rle_struct.into_column()]).unwrap();
+                        *m.df_mut() = unsafe {
+                            DataFrame::new_unchecked(
+                                rle_struct.len(),
+                                vec![rle_struct.into_column()],
+                            )
+                        };
 
                         if send.send(m).await.is_err() {
                             break;

--- a/crates/polars-stream/src/nodes/rle_id.rs
+++ b/crates/polars-stream/src/nodes/rle_id.rs
@@ -97,7 +97,7 @@ impl ComputeNode for RleIdNode {
                     column
                 };
 
-                *df = unsafe { DataFrame::new_no_checks(column.len(), vec![column]) };
+                *df = unsafe { DataFrame::new_unchecked(column.len(), vec![column]) };
 
                 if send.send(m).await.is_err() {
                     break;

--- a/crates/polars-stream/src/nodes/select.rs
+++ b/crates/polars-stream/src/nodes/select.rs
@@ -67,10 +67,10 @@ impl ComputeNode for SelectNode {
 
                     let ret = if slf.extend_original {
                         let mut out = df;
-                        out._add_columns(selected, &slf.schema)?;
+                        out.with_columns_mut(selected, &slf.schema)?;
                         out
                     } else {
-                        DataFrame::new_with_broadcast(selected)?
+                        unsafe { DataFrame::new_unchecked_infer_broadcast(selected)? }
                     };
 
                     let mut morsel = Morsel::new(ret, seq, source_token);

--- a/crates/polars-stream/src/nodes/shift.rs
+++ b/crates/polars-stream/src/nodes/shift.rs
@@ -45,7 +45,7 @@ impl ShiftState {
                 if let Some(r) = &mut recv {
                     let Ok(morsel) = r.recv().await else { break };
                     source_token = morsel.source_token().clone();
-                    if morsel.df().is_empty() {
+                    if morsel.df().height() == 0 {
                         continue;
                     }
                     self.rows_received += morsel.df().height();
@@ -62,7 +62,7 @@ impl ShiftState {
                 let src = self.buffer.front_mut().unwrap();
                 let len = self.rows_received - self.rows_sent;
                 (df, *src) = src.split_at(len as i64);
-                if src.is_empty() {
+                if src.height() == 0 {
                     self.buffer.pop_front();
                 }
             };
@@ -94,7 +94,7 @@ impl ShiftState {
                 morsel =
                     morsel.map(|df| df.slice(shift_needed.min(df.height()) as i64, df.height()));
             }
-            if morsel.df().is_empty() {
+            if morsel.df().height() == 0 {
                 continue;
             }
 
@@ -183,7 +183,7 @@ impl ComputeNode for ShiftNode {
             {
                 let offset_frame = offset.get_output()?.unwrap();
                 polars_ensure!(offset_frame.height() == 1, ComputeError: "got more than one value for 'n' in shift");
-                let offset_item = offset_frame.get_columns()[0].get(0)?;
+                let offset_item = offset_frame.columns()[0].get(0)?;
                 let offset = if offset_item.is_null() {
                     polars_warn!(
                         Deprecation, // @2.0

--- a/crates/polars-stream/src/nodes/simple_projection.rs
+++ b/crates/polars-stream/src/nodes/simple_projection.rs
@@ -51,12 +51,9 @@ impl ComputeNode for SimpleProjectionNode {
             let slf = &*self;
             join_handles.push(scope.spawn_task(TaskPriority::High, async move {
                 while let Ok(morsel) = recv.recv().await {
-                    let morsel = morsel.try_map(|df| {
-                        df._select_with_schema_impl(
-                            slf.columns.as_slice(),
-                            &slf.input_schema,
-                            cfg!(debug_assertions), // check_duplicates
-                        )
+                    let morsel = morsel.try_map(|df| unsafe {
+                        df.with_schema(slf.input_schema.clone())
+                            .select_unchecked(slf.columns.as_slice())
                     })?;
 
                     if send.send(morsel).await.is_err() {

--- a/crates/polars-stream/src/nodes/top_k.rs
+++ b/crates/polars-stream/src/nodes/top_k.rs
@@ -225,7 +225,7 @@ impl<T: PolarsNumericType, const REVERSE: bool, const NULLS_LAST: bool> DfByKeyR
 
     fn add(&mut self, df: DataFrame, keys: DataFrame) {
         assert!(keys.width() == 1);
-        let keys = keys.get_columns()[0].as_materialized_series();
+        let keys = keys.columns()[0].as_materialized_series();
         let key_ca: &ChunkedArray<T> = keys.as_phys_any().downcast_ref().unwrap();
         self.inner.add_df(
             df,
@@ -321,7 +321,7 @@ impl DfByKeyReducer for RowEncodedBottomK {
     }
 
     fn add(&mut self, df: DataFrame, keys: DataFrame) {
-        let keys_encoded = _get_rows_encoded(keys.get_columns(), &self.reverse, &self.nulls_last)
+        let keys_encoded = _get_rows_encoded(keys.columns(), &self.reverse, &self.nulls_last)
             .unwrap()
             .into_array();
         self.inner.add_df(
@@ -446,7 +446,7 @@ impl ComputeNode for TopKNode {
             TopKState::WaitingForK(inner) if recv[1] == PortState::Done => {
                 let k_frame = inner.get_output()?.unwrap();
                 polars_ensure!(k_frame.height() == 1, ComputeError: "got more than one value for 'k' in top_k");
-                let k_item = k_frame.get_columns()[0].get(0)?;
+                let k_item = k_frame.columns()[0].get(0)?;
                 let k = k_item.extract::<usize>().ok_or_else(
                     || polars_err!(ComputeError: "invalid value of 'k' in top_k: {:?}", k_item),
                 )?;
@@ -543,7 +543,9 @@ impl ComputeNode for TopKNode {
                                 let s = selector.evaluate(&df, &state.in_memory_exec_state).await?;
                                 key_columns.push(s.into_column());
                             }
-                            let keys = DataFrame::new_with_broadcast_len(key_columns, df.height())?;
+                            let keys = unsafe {
+                                DataFrame::new_unchecked_with_broadcast(df.height(), key_columns)?
+                            };
 
                             reducer.add(df, keys);
                         }

--- a/crates/polars-stream/src/nodes/zip.rs
+++ b/crates/polars-stream/src/nodes/zip.rs
@@ -2,6 +2,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use polars_core::functions::concat_df_horizontal;
+use polars_core::prelude::{Column, IntoColumn};
 use polars_core::schema::Schema;
 use polars_core::series::Series;
 use polars_error::polars_ensure;
@@ -80,29 +81,31 @@ impl InputHead {
     }
 
     fn take(&mut self, len: usize) -> DataFrame {
-        if self.is_broadcast.unwrap() {
+        let columns: Vec<Column> = if self.is_broadcast.unwrap() {
             self.morsels[0]
                 .df()
+                .columns()
                 .iter()
                 .map(|s| s.new_from_index(0, len))
                 .collect()
         } else if self.total_len > 0 {
             self.total_len -= len;
-            if self.morsels[0].df().height() == len {
+
+            return if self.morsels[0].df().height() == len {
                 self.morsels.pop_front().unwrap().into_df()
             } else {
                 let (head, tail) = self.morsels[0].df().split_at(len as i64);
                 *self.morsels[0].df_mut() = tail;
                 head
-            }
-        } else if self.schema.is_empty() {
-            DataFrame::empty_with_height(len)
+            };
         } else {
             self.schema
                 .iter()
-                .map(|(name, dtype)| Series::full_null(name.clone(), len, dtype))
+                .map(|(name, dtype)| Series::full_null(name.clone(), len, dtype).into_column())
                 .collect()
-        }
+        };
+
+        unsafe { DataFrame::new_unchecked(len, columns) }
     }
 
     fn consume_broadcast(&mut self) -> DataFrame {

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -461,7 +461,8 @@ fn build_fallback_node_with_ctx(
             .iter()
             .map(|phys_expr| phys_expr.evaluate(&df, &exec_state))
             .try_collect()?;
-        DataFrame::new_with_broadcast(columns)
+
+        DataFrame::new_infer_broadcast(columns)
     };
 
     let format_str = ctx.prepare_visualization.then(|| {

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -787,15 +787,7 @@ pub fn lower_ir(
                 };
 
                 {
-                    let cloud_options = &unified_scan_args.cloud_options;
-                    let output_schema =
-                        if std::env::var("POLARS_FORCE_EMPTY_PROJECT").as_deref() == Ok("1") {
-                            Default::default()
-                        } else {
-                            output_schema
-                        };
-
-                    let cloud_options = cloud_options.clone().map(Arc::new);
+                    let cloud_options = unified_scan_args.cloud_options.clone().map(Arc::new);
                     let file_schema = file_info.schema;
 
                     let (projected_schema, file_schema) =

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -1388,7 +1388,10 @@ fn to_graph_rec<'a>(
                         let Some(mut df) = df else { return Ok(None) };
 
                         if let Some(simple_projection) = &simple_projection {
-                            df = unsafe { df.project(simple_projection.clone())? };
+                            df = unsafe {
+                                df.select_unchecked(simple_projection.iter_names())?
+                                    .with_schema(simple_projection.clone())
+                            };
                         }
 
                         if validate_schema {

--- a/crates/polars-testing/src/asserts/frame.rs
+++ b/crates/polars-testing/src/asserts/frame.rs
@@ -74,13 +74,13 @@ mod tests {
     #[test]
     #[should_panic(expected = "height (row count) mismatch")]
     fn test_dataframe_height_mismatch() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1, 2]).into(),
             Series::new("col2".into(), &["a", "b"]).into(),
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1, 2, 3]).into(),
             Series::new("col2".into(), &["a", "b", "c"]).into(),
         ])
@@ -92,13 +92,13 @@ mod tests {
     #[test]
     #[should_panic(expected = "columns mismatch")]
     fn test_dataframe_column_mismatch() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1, 2, 3]).into(),
             Series::new("col2".into(), &["a", "b", "c"]).into(),
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1, 2, 3]).into(),
             Series::new("different_col".into(), &["a", "b", "c"]).into(),
         ])
@@ -110,13 +110,13 @@ mod tests {
     #[test]
     #[should_panic(expected = "dtypes do not match")]
     fn test_dataframe_dtype_mismatch() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1, 2, 3]).into(),
             Series::new("col2".into(), &["a", "b", "c"]).into(),
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1.0, 2.0, 3.0]).into(),
             Series::new("col2".into(), &["a", "b", "c"]).into(),
         ])
@@ -127,13 +127,13 @@ mod tests {
 
     #[test]
     fn test_dataframe_dtype_mismatch_ignored() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1, 2, 3]).into(),
             Series::new("col2".into(), &["a", "b", "c"]).into(),
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1.0, 2.0, 3.0]).into(),
             Series::new("col2".into(), &["a", "b", "c"]).into(),
         ])
@@ -146,13 +146,13 @@ mod tests {
     #[test]
     #[should_panic(expected = "columns are not in the same order")]
     fn test_dataframe_column_order_mismatch() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1, 2, 3]).into(),
             Series::new("col2".into(), &["a", "b", "c"]).into(),
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("col2".into(), &["a", "b", "c"]).into(),
             Series::new("col1".into(), &[1, 2, 3]).into(),
         ])
@@ -163,13 +163,13 @@ mod tests {
 
     #[test]
     fn test_dataframe_column_order_mismatch_ignored() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1, 2, 3]).into(),
             Series::new("col2".into(), &["a", "b", "c"]).into(),
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("col2".into(), &["a", "b", "c"]).into(),
             Series::new("col1".into(), &[1, 2, 3]).into(),
         ])
@@ -183,14 +183,14 @@ mod tests {
     #[test]
     #[should_panic(expected = "columns mismatch: [\"col3\"] in left, but not in right")]
     fn test_dataframe_left_has_extra_column() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1, 2, 3]).into(),
             Series::new("col2".into(), &["a", "b", "c"]).into(),
             Series::new("col3".into(), &[true, false, true]).into(),
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1, 2, 3]).into(),
             Series::new("col2".into(), &["a", "b", "c"]).into(),
         ])
@@ -202,13 +202,13 @@ mod tests {
     #[test]
     #[should_panic(expected = "columns mismatch: [\"col3\"] in right, but not in left")]
     fn test_dataframe_right_has_extra_column() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1, 2, 3]).into(),
             Series::new("col2".into(), &["a", "b", "c"]).into(),
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1, 2, 3]).into(),
             Series::new("col2".into(), &["a", "b", "c"]).into(),
             Series::new("col3".into(), &[true, false, true]).into(),
@@ -222,14 +222,14 @@ mod tests {
     #[test]
     #[should_panic(expected = "value mismatch for column")]
     fn test_dataframe_value_mismatch() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1, 2, 3]).into(),
             Series::new("col2".into(), &["a", "b", "c"]).into(),
             Series::new("col3".into(), &[true, false, true]).into(),
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1, 2, 3]).into(),
             Series::new("col2".into(), &["a", "b", "changed"]).into(),
             Series::new("col3".into(), &[true, false, true]).into(),
@@ -241,14 +241,14 @@ mod tests {
 
     #[test]
     fn test_dataframe_equal() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1, 2, 3]).into(),
             Series::new("col2".into(), &["a", "b", "c"]).into(),
             Series::new("col3".into(), &[true, false, true]).into(),
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1, 2, 3]).into(),
             Series::new("col2".into(), &["a", "b", "c"]).into(),
             Series::new("col3".into(), &[true, false, true]).into(),
@@ -261,13 +261,13 @@ mod tests {
     #[test]
     #[should_panic(expected = "value mismatch")]
     fn test_dataframe_row_order_mismatch() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1, 2, 3]).into(),
             Series::new("col2".into(), &["a", "b", "c"]).into(),
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[3, 1, 2]).into(),
             Series::new("col2".into(), &["c", "a", "b"]).into(),
         ])
@@ -278,13 +278,13 @@ mod tests {
 
     #[test]
     fn test_dataframe_row_order_ignored() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1, 2, 3]).into(),
             Series::new("col2".into(), &["a", "b", "c"]).into(),
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[3, 1, 2]).into(),
             Series::new("col2".into(), &["c", "a", "b"]).into(),
         ])
@@ -298,7 +298,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "value mismatch")]
     fn test_dataframe_complex_mismatch() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("integers".into(), &[1, 2, 3, 4, 5]).into(),
             Series::new("floats".into(), &[1.1, 2.2, 3.3, 4.4, 5.5]).into(),
             Series::new("strings".into(), &["a", "b", "c", "d", "e"]).into(),
@@ -307,7 +307,7 @@ mod tests {
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("integers".into(), &[1, 2, 99, 4, 5]).into(),
             Series::new("floats".into(), &[1.1, 2.2, 3.3, 9.9, 5.5]).into(),
             Series::new("strings".into(), &["a", "b", "c", "CHANGED", "e"]).into(),
@@ -321,7 +321,7 @@ mod tests {
 
     #[test]
     fn test_dataframe_complex_match() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("integers".into(), &[1, 2, 3, 4, 5]).into(),
             Series::new("floats".into(), &[1.1, 2.2, 3.3, 4.4, 5.5]).into(),
             Series::new("strings".into(), &["a", "b", "c", "d", "e"]).into(),
@@ -330,7 +330,7 @@ mod tests {
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("integers".into(), &[1, 2, 3, 4, 5]).into(),
             Series::new("floats".into(), &[1.1, 2.2, 3.3, 4.4, 5.5]).into(),
             Series::new("strings".into(), &["a", "b", "c", "d", "e"]).into(),
@@ -346,13 +346,14 @@ mod tests {
     #[test]
     #[should_panic(expected = "value mismatch")]
     fn test_dataframe_numeric_exact_fail() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1.0000001, 2.0000002, 3.0000003]).into(),
         ])
         .unwrap();
 
         let df2 =
-            DataFrame::new(vec![Series::new("col1".into(), &[1.0, 2.0, 3.0]).into()]).unwrap();
+            DataFrame::new_infer_height(vec![Series::new("col1".into(), &[1.0, 2.0, 3.0]).into()])
+                .unwrap();
 
         let options = crate::asserts::DataFrameEqualOptions::default().with_check_exact(true);
         assert_dataframe_equal!(&df1, &df2, options);
@@ -360,13 +361,14 @@ mod tests {
 
     #[test]
     fn test_dataframe_numeric_tolerance_pass() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1.0000001, 2.0000002, 3.0000003]).into(),
         ])
         .unwrap();
 
         let df2 =
-            DataFrame::new(vec![Series::new("col1".into(), &[1.0, 2.0, 3.0]).into()]).unwrap();
+            DataFrame::new_infer_height(vec![Series::new("col1".into(), &[1.0, 2.0, 3.0]).into()])
+                .unwrap();
 
         assert_dataframe_equal!(&df1, &df2);
     }
@@ -374,21 +376,21 @@ mod tests {
     // Testing equality with special values
     #[test]
     fn test_empty_dataframe_equal() {
-        let df1 = DataFrame::default();
-        let df2 = DataFrame::default();
+        let df1 = DataFrame::empty();
+        let df2 = DataFrame::empty();
 
         assert_dataframe_equal!(&df1, &df2);
     }
 
     #[test]
     fn test_empty_dataframe_schema_equal() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &Vec::<i32>::new()).into(),
             Series::new("col2".into(), &Vec::<String>::new()).into(),
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &Vec::<i32>::new()).into(),
             Series::new("col2".into(), &Vec::<String>::new()).into(),
         ])
@@ -400,14 +402,14 @@ mod tests {
     #[test]
     #[should_panic(expected = "value mismatch")]
     fn test_dataframe_single_row_mismatch() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[42]).into(),
             Series::new("col2".into(), &["value"]).into(),
             Series::new("col3".into(), &[true]).into(),
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[42]).into(),
             Series::new("col2".into(), &["different"]).into(),
             Series::new("col3".into(), &[true]).into(),
@@ -419,14 +421,14 @@ mod tests {
 
     #[test]
     fn test_dataframe_single_row_match() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[42]).into(),
             Series::new("col2".into(), &["value"]).into(),
             Series::new("col3".into(), &[true]).into(),
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[42]).into(),
             Series::new("col2".into(), &["value"]).into(),
             Series::new("col3".into(), &[true]).into(),
@@ -439,12 +441,12 @@ mod tests {
     #[test]
     #[should_panic(expected = "value mismatch")]
     fn test_dataframe_null_values_mismatch() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[Some(1), None, Some(3)]).into(),
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[Some(1), Some(2), None]).into(),
         ])
         .unwrap();
@@ -454,12 +456,12 @@ mod tests {
 
     #[test]
     fn test_dataframe_null_values_match() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[Some(1), None, Some(3)]).into(),
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[Some(1), None, Some(3)]).into(),
         ])
         .unwrap();
@@ -470,12 +472,12 @@ mod tests {
     #[test]
     #[should_panic(expected = "value mismatch")]
     fn test_dataframe_nan_values_mismatch() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1.0, f64::NAN, 3.0]).into(),
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1.0, 2.0, f64::NAN]).into(),
         ])
         .unwrap();
@@ -485,12 +487,12 @@ mod tests {
 
     #[test]
     fn test_dataframe_nan_values_match() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1.0, f64::NAN, 3.0]).into(),
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1.0, f64::NAN, 3.0]).into(),
         ])
         .unwrap();
@@ -501,12 +503,12 @@ mod tests {
     #[test]
     #[should_panic(expected = "value mismatch")]
     fn test_dataframe_infinity_values_mismatch() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1.0, f64::INFINITY, 3.0]).into(),
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1.0, f64::NEG_INFINITY, 3.0]).into(),
         ])
         .unwrap();
@@ -516,12 +518,12 @@ mod tests {
 
     #[test]
     fn test_dataframe_infinity_values_match() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1.0, f64::INFINITY, 3.0]).into(),
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new("col1".into(), &[1.0, f64::INFINITY, 3.0]).into(),
         ])
         .unwrap();
@@ -537,13 +539,13 @@ mod tests {
         categorical1 = categorical1
             .cast(&DataType::from_categories(Categories::global()))
             .unwrap();
-        let df1 = DataFrame::new(vec![categorical1.into()]).unwrap();
+        let df1 = DataFrame::new_infer_height(vec![categorical1.into()]).unwrap();
 
         let mut categorical2 = Series::new("categories".into(), &["a", "b", "c", "e"]);
         categorical2 = categorical2
             .cast(&DataType::from_categories(Categories::global()))
             .unwrap();
-        let df2 = DataFrame::new(vec![categorical2.into()]).unwrap();
+        let df2 = DataFrame::new_infer_height(vec![categorical2.into()]).unwrap();
 
         let options =
             crate::asserts::DataFrameEqualOptions::default().with_categorical_as_str(true);
@@ -556,13 +558,13 @@ mod tests {
         categorical1 = categorical1
             .cast(&DataType::from_categories(Categories::global()))
             .unwrap();
-        let df1 = DataFrame::new(vec![categorical1.into()]).unwrap();
+        let df1 = DataFrame::new_infer_height(vec![categorical1.into()]).unwrap();
 
         let mut categorical2 = Series::new("categories".into(), &["a", "b", "c", "d"]);
         categorical2 = categorical2
             .cast(&DataType::from_categories(Categories::global()))
             .unwrap();
-        let df2 = DataFrame::new(vec![categorical2.into()]).unwrap();
+        let df2 = DataFrame::new_infer_height(vec![categorical2.into()]).unwrap();
 
         let options =
             crate::asserts::DataFrameEqualOptions::default().with_categorical_as_str(true);
@@ -573,7 +575,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "value mismatch")]
     fn test_dataframe_nested_values_mismatch() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new(
                 "list_col".into(),
                 &[
@@ -587,7 +589,7 @@ mod tests {
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new(
                 "list_col".into(),
                 &[
@@ -606,7 +608,7 @@ mod tests {
 
     #[test]
     fn test_dataframe_nested_values_match() {
-        let df1 = DataFrame::new(vec![
+        let df1 = DataFrame::new_infer_height(vec![
             Series::new(
                 "list_col".into(),
                 &[Some(vec![1, 2, 3]), Some(vec![]), None, Some(vec![7, 8, 9])],
@@ -615,7 +617,7 @@ mod tests {
         ])
         .unwrap();
 
-        let df2 = DataFrame::new(vec![
+        let df2 = DataFrame::new_infer_height(vec![
             Series::new(
                 "list_col".into(),
                 &[Some(vec![1, 2, 3]), Some(vec![]), None, Some(vec![7, 8, 9])],

--- a/crates/polars-time/src/group_by/dynamic.rs
+++ b/crates/polars-time/src/group_by/dynamic.rs
@@ -523,7 +523,7 @@ mod test {
             .into_column();
             date.set_sorted_flag(IsSorted::Ascending);
             let a = Column::new("a".into(), [3, 7, 5, 9, 2, 1]);
-            let df = DataFrame::new(vec![date, a.clone()])?;
+            let df = DataFrame::new_infer_height(vec![date, a.clone()])?;
 
             let (_, groups) = df
                 .rolling(
@@ -570,7 +570,7 @@ mod test {
         date.set_sorted_flag(IsSorted::Ascending);
 
         let a = Column::new("a".into(), [3, 7, 5, 9, 2, 1]);
-        let df = DataFrame::new(vec![date, a.clone()])?;
+        let df = DataFrame::new_infer_height(vec![date, a.clone()])?;
 
         let (_, groups) = df
             .rolling(

--- a/crates/polars/src/docs/eager.rs
+++ b/crates/polars/src/docs/eager.rs
@@ -94,7 +94,7 @@
 //! // from a Vec<Column>
 //! let c1 = Column::new("names".into(), &["a", "b", "c"]);
 //! let c2 = Column::new("values".into(), &[Some(1), None, Some(3)]);
-//! let df = DataFrame::new(vec![c1, c2])?;
+//! let df = DataFrame::new_infer_height(vec![c1, c2])?;
 //! # Ok(())
 //! # }
 //! ```
@@ -533,7 +533,7 @@
 //! // construct a few more Series.
 //! let s0 = Column::new("B".into(), [1, 2, 3]);
 //! let s1 = Column::new("C".into(), [1, 1, 1]);
-//! let df = DataFrame::new(vec![list, s0, s1])?;
+//! let df = DataFrame::new_infer_height(vec![list, s0, s1])?;
 //!
 //! let exploded = df.explode([PlSmallStr::from("foo")])?;
 //! // exploded:

--- a/crates/polars/src/lib.rs
+++ b/crates/polars/src/lib.rs
@@ -131,7 +131,7 @@
 //! ```no_run
 //! # use polars::prelude::*;
 //! # fn example() -> PolarsResult<()> {
-//! # let df = DataFrame::default();
+//! # let df = DataFrame::empty();
 //!   df.lazy()
 //!    .select([
 //!        col("foo").sort(Default::default()).head(None),

--- a/crates/polars/tests/it/core/date_like.rs
+++ b/crates/polars/tests/it/core/date_like.rs
@@ -8,7 +8,7 @@ fn test_datelike_join() -> PolarsResult<()> {
     let mut s1 = s.cast(&DataType::Datetime(TimeUnit::Nanoseconds, None))?;
     s1.rename("bar".into());
 
-    let df = DataFrame::new(vec![s, s1])?;
+    let df = DataFrame::new_infer_height(vec![s, s1])?;
 
     let out = df.left_join(&df.clone(), ["bar"], ["bar"])?;
     assert!(matches!(

--- a/crates/polars/tests/it/core/joins.rs
+++ b/crates/polars/tests/it/core/joins.rs
@@ -41,11 +41,11 @@ fn create_frames() -> (DataFrame, DataFrame) {
     let s0 = Column::new("days".into(), &[0, 1, 2]);
     let s1 = Column::new("temp".into(), &[22.1, 19.9, 7.]);
     let s2 = Column::new("rain".into(), &[0.2, 0.1, 0.3]);
-    let temp = DataFrame::new(vec![s0, s1, s2]).unwrap();
+    let temp = DataFrame::new_infer_height(vec![s0, s1, s2]).unwrap();
 
     let s0 = Column::new("days".into(), &[1, 2, 3, 1]);
     let s1 = Column::new("rain".into(), &[0.1, 0.2, 0.3, 0.4]);
-    let rain = DataFrame::new(vec![s0, s1]).unwrap();
+    let rain = DataFrame::new_infer_height(vec![s0, s1]).unwrap();
     (temp, rain)
 }
 
@@ -62,7 +62,7 @@ fn test_inner_join() {
         let join_col_temp = Column::new("temp".into(), &[19.9, 7., 19.9]);
         let join_col_rain = Column::new("rain".into(), &[0.1, 0.3, 0.1]);
         let join_col_rain_right = Column::new("rain_right".into(), [0.1, 0.2, 0.4].as_ref());
-        let true_df = DataFrame::new(vec![
+        let true_df = DataFrame::new_infer_height(vec![
             join_col_days,
             join_col_temp,
             join_col_rain,
@@ -82,11 +82,11 @@ fn test_left_join() {
         unsafe { std::env::set_var("POLARS_MAX_THREADS", format!("{i}")) };
         let s0 = Column::new("days".into(), &[0, 1, 2, 3, 4]);
         let s1 = Column::new("temp".into(), &[22.1, 19.9, 7., 2., 3.]);
-        let temp = DataFrame::new(vec![s0, s1]).unwrap();
+        let temp = DataFrame::new_infer_height(vec![s0, s1]).unwrap();
 
         let s0 = Column::new("days".into(), &[1, 2]);
         let s1 = Column::new("rain".into(), &[0.1, 0.2]);
-        let rain = DataFrame::new(vec![s0, s1]).unwrap();
+        let rain = DataFrame::new_infer_height(vec![s0, s1]).unwrap();
         let joined = temp.left_join(&rain, ["days"], ["days"]).unwrap();
         assert_eq!(
             (joined
@@ -104,11 +104,11 @@ fn test_left_join() {
         // test join on string
         let s0 = Column::new("days".into(), &["mo", "tue", "wed", "thu", "fri"]);
         let s1 = Column::new("temp".into(), &[22.1, 19.9, 7., 2., 3.]);
-        let temp = DataFrame::new(vec![s0, s1]).unwrap();
+        let temp = DataFrame::new_infer_height(vec![s0, s1]).unwrap();
 
         let s0 = Column::new("days".into(), &["tue", "wed"]);
         let s1 = Column::new("rain".into(), &[0.1, 0.2]);
-        let rain = DataFrame::new(vec![s0, s1]).unwrap();
+        let rain = DataFrame::new_infer_height(vec![s0, s1]).unwrap();
         let joined = temp.left_join(&rain, ["days"], ["days"]).unwrap();
         assert_eq!(
             (joined
@@ -174,14 +174,14 @@ fn test_full_outer_join() -> PolarsResult<()> {
 fn test_join_with_nulls() {
     let dts = &[20, 21, 22, 23, 24, 25, 27, 28];
     let vals = &[1.2, 2.4, 4.67, 5.8, 4.4, 3.6, 7.6, 6.5];
-    let df = DataFrame::new(vec![
+    let df = DataFrame::new_infer_height(vec![
         Column::new("date".into(), dts),
         Column::new("val".into(), vals),
     ])
     .unwrap();
 
     let vals2 = &[Some(1.1), None, Some(3.3), None, None];
-    let df2 = DataFrame::new(vec![
+    let df2 = DataFrame::new_infer_height(vec![
         Column::new("date".into(), &dts[3..]),
         Column::new("val2".into(), vals2),
     ])
@@ -232,7 +232,7 @@ fn test_join_multiple_columns() {
         + df_a.column("b").unwrap().str().unwrap();
     s.rename("dummy".into());
 
-    df_a.with_column(s).unwrap();
+    df_a.with_column(s.into_column()).unwrap();
     let mut s = df_b
         .column("foo")
         .unwrap()
@@ -242,7 +242,7 @@ fn test_join_multiple_columns() {
         .unwrap()
         + df_b.column("bar").unwrap().str().unwrap();
     s.rename("dummy".into());
-    df_b.with_column(s).unwrap();
+    df_b.with_column(s.into_column()).unwrap();
 
     let joined = df_a.left_join(&df_b, ["dummy"], ["dummy"]).unwrap();
     let ham_col = joined.column("ham").unwrap();
@@ -372,13 +372,13 @@ fn test_join_categorical() {
 #[cfg_attr(miri, ignore)]
 fn test_empty_df_join() -> PolarsResult<()> {
     let empty: Vec<String> = vec![];
-    let empty_df = DataFrame::new(vec![
+    let empty_df = DataFrame::new_infer_height(vec![
         Column::new("key".into(), &empty),
         Column::new("eval".into(), &empty),
     ])
     .unwrap();
 
-    let df = DataFrame::new(vec![
+    let df = DataFrame::new_infer_height(vec![
         Column::new("key".into(), &["foo"]),
         Column::new("aval".into(), &[4]),
     ])
@@ -395,7 +395,7 @@ fn test_empty_df_join() -> PolarsResult<()> {
     df.full_join(&empty_df, ["key"], ["key"])?;
 
     let empty: Vec<String> = vec![];
-    let _empty_df = DataFrame::new(vec![
+    let _empty_df = DataFrame::new_infer_height(vec![
         Column::new("key".into(), &empty),
         Column::new("eval".into(), &empty),
     ])
@@ -408,7 +408,7 @@ fn test_empty_df_join() -> PolarsResult<()> {
 
     // https://github.com/pola-rs/polars/issues/1824
     let empty: Vec<i32> = vec![];
-    let empty_df = DataFrame::new(vec![
+    let empty_df = DataFrame::new_infer_height(vec![
         Column::new("key".into(), &empty),
         Column::new("1val".into(), &empty),
         Column::new("2val".into(), &empty),
@@ -658,7 +658,7 @@ fn test_4_threads_bit_offset() -> PolarsResult<()> {
         .collect::<Int64Chunked>();
     left_a.rename("a".into());
     left_b.rename("b".into());
-    let left_df = DataFrame::new(vec![left_a.into_column(), left_b.into_column()])?;
+    let left_df = DataFrame::new_infer_height(vec![left_a.into_column(), left_b.into_column()])?;
 
     let i = 1;
     let len = 8;
@@ -670,7 +670,7 @@ fn test_4_threads_bit_offset() -> PolarsResult<()> {
     right_a.rename("a".into());
     right_b.rename("b".into());
 
-    let right_df = DataFrame::new(vec![right_a.into_column(), right_b.into_column()])?;
+    let right_df = DataFrame::new_infer_height(vec![right_a.into_column(), right_b.into_column()])?;
     let out = JoinBuilder::new(left_df.lazy())
         .with(right_df.lazy())
         .on([col("a"), col("b")])

--- a/crates/polars/tests/it/io/csv.rs
+++ b/crates/polars/tests/it/io/csv.rs
@@ -61,7 +61,7 @@ fn write_dates() {
             None,
         ],
     );
-    let mut df = DataFrame::new(vec![s0, s1, s2.clone()]).unwrap();
+    let mut df = DataFrame::new_infer_height(vec![s0, s1, s2.clone()]).unwrap();
 
     let mut buf: Vec<u8> = Vec::new();
     CsvWriter::new(&mut buf)
@@ -124,7 +124,7 @@ fn write_dates() {
     )
     .unwrap()
     .into_column();
-    let mut with_timezone_df = DataFrame::new(vec![with_timezone]).unwrap();
+    let mut with_timezone_df = DataFrame::new_infer_height(vec![with_timezone]).unwrap();
     buf.clear();
     CsvWriter::new(&mut buf)
         .include_header(false)
@@ -221,7 +221,7 @@ fn test_parser() -> PolarsResult<()> {
     assert_eq!(col.get(0)?, AnyValue::String("Setosa"));
     assert_eq!(col.get(2)?, AnyValue::String("Setosa"));
 
-    assert_eq!("sepal_length", df.get_columns()[0].name().as_str());
+    assert_eq!("sepal_length", df.columns()[0].name().as_str());
     assert_eq!(df.height(), 7);
 
     // test windows line endings
@@ -235,7 +235,7 @@ fn test_parser() -> PolarsResult<()> {
         .finish()
         .unwrap();
 
-    assert_eq!("head_1", df.get_columns()[0].name().as_str());
+    assert_eq!("head_1", df.columns()[0].name().as_str());
     assert_eq!(df.shape(), (3, 2));
 
     // test windows line ending with 1 byte char column and no line endings for last line.
@@ -249,7 +249,7 @@ fn test_parser() -> PolarsResult<()> {
         .finish()
         .unwrap();
 
-    assert_eq!("head_1", df.get_columns()[0].name().as_str());
+    assert_eq!("head_1", df.columns()[0].name().as_str());
     assert_eq!(df.shape(), (3, 1));
     Ok(())
 }
@@ -746,7 +746,7 @@ null-value,b,bar
         })
         .into_reader_with_file_handle(file)
         .finish()?;
-    assert!(df.get_columns()[0].null_count() > 0);
+    assert!(df.columns()[0].null_count() > 0);
     Ok(())
 }
 

--- a/crates/polars/tests/it/io/ipc.rs
+++ b/crates/polars/tests/it/io/ipc.rs
@@ -26,7 +26,7 @@ fn test_ipc_compression_variadic_buffers() {
 pub(crate) fn create_df() -> DataFrame {
     let s0 = Column::new("days".into(), [0, 1, 2, 3, 4].as_ref());
     let s1 = Column::new("temp".into(), [22.1, 19.9, 7., 2., 3.].as_ref());
-    DataFrame::new(vec![s0, s1]).unwrap()
+    DataFrame::new_infer_height(vec![s0, s1]).unwrap()
 }
 
 #[test]
@@ -145,7 +145,7 @@ fn test_write_with_compression() {
 fn write_and_read_ipc_empty_series() {
     let mut buf: Cursor<Vec<u8>> = Cursor::new(Vec::new());
     let chunked_array = Float64Chunked::new("empty".into(), &[0_f64; 0]);
-    let mut df = DataFrame::new(vec![chunked_array.into_column()]).unwrap();
+    let mut df = DataFrame::new_infer_height(vec![chunked_array.into_column()]).unwrap();
     IpcWriter::new(&mut buf)
         .finish(&mut df)
         .expect("ipc writer");

--- a/crates/polars/tests/it/io/ipc_stream.rs
+++ b/crates/polars/tests/it/io/ipc_stream.rs
@@ -145,7 +145,7 @@ mod test {
     #[test]
     fn write_and_read_ipc_stream_empty_series() {
         fn df() -> DataFrame {
-            DataFrame::new(vec![
+            DataFrame::new_infer_height(vec![
                 Float64Chunked::new("empty".into(), &[0_f64; 0]).into_column(),
             ])
             .unwrap()

--- a/crates/polars/tests/it/io/json.rs
+++ b/crates/polars/tests/it/io/json.rs
@@ -25,8 +25,8 @@ fn read_json() {
         .with_batch_size(NonZeroUsize::new(3).unwrap())
         .finish()
         .unwrap();
-    assert_eq!("a", df.get_columns()[0].name().as_str());
-    assert_eq!("d", df.get_columns()[3].name().as_str());
+    assert_eq!("a", df.columns()[0].name().as_str());
+    assert_eq!("d", df.columns()[3].name().as_str());
     assert_eq!((12, 4), df.shape());
 }
 #[test]
@@ -53,8 +53,8 @@ fn read_json_with_whitespace() {
         .with_batch_size(NonZeroUsize::new(3).unwrap())
         .finish()
         .unwrap();
-    assert_eq!("a", df.get_columns()[0].name().as_str());
-    assert_eq!("d", df.get_columns()[3].name().as_str());
+    assert_eq!("a", df.columns()[0].name().as_str());
+    assert_eq!("d", df.columns()[3].name().as_str());
     assert_eq!((12, 4), df.shape());
 }
 #[test]
@@ -76,12 +76,12 @@ fn read_json_with_escapes() {
         .infer_schema_len(NonZeroUsize::new(6))
         .finish()
         .unwrap();
-    assert_eq!("id", df.get_columns()[0].name().as_str());
+    assert_eq!("id", df.columns()[0].name().as_str());
     assert_eq!(
         AnyValue::String("\""),
         df.column("text").unwrap().get(0).unwrap()
     );
-    assert_eq!("text", df.get_columns()[1].name().as_str());
+    assert_eq!("text", df.columns()[1].name().as_str());
     assert_eq!((10, 3), df.shape());
 }
 
@@ -107,8 +107,8 @@ fn read_unordered_json() {
         .with_batch_size(NonZeroUsize::new(3).unwrap())
         .finish()
         .unwrap();
-    assert_eq!("a", df.get_columns()[0].name().as_str());
-    assert_eq!("d", df.get_columns()[3].name().as_str());
+    assert_eq!("a", df.columns()[0].name().as_str());
+    assert_eq!("d", df.columns()[3].name().as_str());
     assert_eq!((12, 4), df.shape());
 }
 

--- a/crates/polars/tests/it/io/mod.rs
+++ b/crates/polars/tests/it/io/mod.rs
@@ -19,5 +19,5 @@ use polars::prelude::*;
 pub(crate) fn create_df() -> DataFrame {
     let s0 = Column::new("days".into(), [0, 1, 2, 3, 4].as_ref());
     let s1 = Column::new("temp".into(), [22.1, 19.9, 7., 2., 3.].as_ref());
-    DataFrame::new(vec![s0, s1]).unwrap()
+    DataFrame::new_infer_height(vec![s0, s1]).unwrap()
 }

--- a/crates/polars/tests/it/joins.rs
+++ b/crates/polars/tests/it/joins.rs
@@ -36,12 +36,12 @@ fn join_nans_outer() -> PolarsResult<()> {
 #[test]
 #[cfg(feature = "lazy")]
 fn join_empty_datasets() -> PolarsResult<()> {
-    let a = DataFrame::new(Vec::from([Column::new_empty(
+    let a = DataFrame::new_infer_height(Vec::from([Column::new_empty(
         "foo".into(),
         &DataType::Int64,
     )]))
     .unwrap();
-    let b = DataFrame::new(Vec::from([
+    let b = DataFrame::new_infer_height(Vec::from([
         Column::new_empty("foo".into(), &DataType::Int64),
         Column::new_empty("bar".into(), &DataType::Int64),
     ]))

--- a/crates/polars/tests/it/lazy/aggregation.rs
+++ b/crates/polars/tests/it/lazy/aggregation.rs
@@ -17,7 +17,7 @@ fn test_lazy_agg() {
     .into_column();
     let s1 = Column::new("temp".into(), [20, 10, 7, 9, 1].as_ref());
     let s2 = Column::new("rain".into(), [0.2, 0.1, 0.3, 0.1, 0.01].as_ref());
-    let df = DataFrame::new(vec![s0, s1, s2]).unwrap();
+    let df = DataFrame::new_infer_height(vec![s0, s1, s2]).unwrap();
 
     let lf = df
         .lazy()

--- a/crates/polars/tests/it/lazy/cwc.rs
+++ b/crates/polars/tests/it/lazy/cwc.rs
@@ -80,7 +80,9 @@ fn fuzz_cluster_with_columns() {
             used_cols.push(column);
         }
 
-        let mut lf = DataFrame::new(std::mem::take(&mut columns)).unwrap().lazy();
+        let mut lf = DataFrame::new_infer_height(std::mem::take(&mut columns))
+            .unwrap()
+            .lazy();
 
         for _ in 0..num_with_columns {
             let num_exprs = rng.random_range(0..8);

--- a/crates/polars/tests/it/lazy/exprs.rs
+++ b/crates/polars/tests/it/lazy/exprs.rs
@@ -6,7 +6,7 @@ fn fuzz_exprs() {
     const PRIMES: &[i32] = &[2, 3, 5, 7, 11, 13, 17, 19, 23, 29];
     use rand::Rng;
 
-    let lf = DataFrame::new(vec![
+    let lf = DataFrame::new_infer_height(vec![
         Column::new("A".into(), vec![1, 2, 3, 4, 5]),
         Column::new("B".into(), vec![Some(5), Some(4), None, Some(2), Some(1)]),
         Column::new(
@@ -16,7 +16,7 @@ fn fuzz_exprs() {
     ])
     .unwrap()
     .lazy();
-    let empty = DataFrame::new(vec![
+    let empty = DataFrame::new_infer_height(vec![
         Column::new("A".into(), Vec::<bool>::new()),
         Column::new("B".into(), Vec::<u32>::new()),
         Column::new("C".into(), Vec::<&str>::new()),

--- a/crates/polars/tests/it/lazy/predicate_queries.rs
+++ b/crates/polars/tests/it/lazy/predicate_queries.rs
@@ -181,7 +181,7 @@ fn test_binaryexpr_pushdown_left_join_9506() -> PolarsResult<()> {
     }?;
     let df = df1.lazy().left_join(df2.lazy(), col("b"), col("b"));
     let out = df.filter(col("c").eq(lit("c2"))).collect()?;
-    assert!(out.is_empty());
+    assert_eq!(out.height(), 0);
     Ok(())
 }
 

--- a/crates/polars/tests/it/lazy/queries.rs
+++ b/crates/polars/tests/it/lazy/queries.rs
@@ -7,7 +7,7 @@ fn test_with_duplicate_column_empty_df() {
     let a = Int32Chunked::from_slice("a".into(), &[]);
 
     assert_eq!(
-        DataFrame::new(vec![a.into_column()])
+        DataFrame::new_infer_height(vec![a.into_column()])
             .unwrap()
             .lazy()
             .with_columns([lit(true).alias("a")])
@@ -247,7 +247,7 @@ fn test_group_by_on_lists() -> PolarsResult<()> {
     builder.append_series(s1.as_materialized_series()).unwrap();
     let s2 = builder.finish().into_column();
 
-    let df = DataFrame::new(vec![s1, s2])?;
+    let df = DataFrame::new_infer_height(vec![s1, s2])?;
     let out = df
         .clone()
         .lazy()

--- a/crates/polars/tests/it/time/date.rs
+++ b/crates/polars/tests/it/time/date.rs
@@ -25,7 +25,7 @@ fn test_datetime_parse_overflow_7631() {
     );
     let actual = df.collect().unwrap();
 
-    let expected = DataFrame::new(vec![
+    let expected = DataFrame::new_infer_height(vec![
         Column::new("year".into(), &[2020, 2021, 2022]),
         Column::new("month".into(), &[1, 2, 3]),
         Column::new("day".into(), &[1, 2, 3]),

--- a/docs/source/src/rust/user-guide/transformations/time-series/timezones.rs
+++ b/docs/source/src/rust/user-guide/transformations/time-series/timezones.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --8<-- [start:example]
     let ts = ["2021-03-27 03:00", "2021-03-28 03:00"];
     let tz_naive = Column::new("tz_naive".into(), &ts);
-    let time_zones_df = DataFrame::new(vec![tz_naive])?
+    let time_zones_df = DataFrame::new_infer_height(vec![tz_naive])?
         .lazy()
         .select([col("tz_naive").str().to_datetime(
             Some(TimeUnit::Milliseconds),

--- a/py-polars/tests/unit/operations/test_unpivot.py
+++ b/py-polars/tests/unit/operations/test_unpivot.py
@@ -117,7 +117,7 @@ def test_unpivot_categorical() -> None:
 
 
 def test_unpivot_index_not_found_23165() -> None:
-    with pytest.raises(pl.exceptions.SchemaFieldNotFoundError):
+    with pytest.raises(pl.exceptions.ColumnNotFoundError):
         pl.DataFrame({"a": [1]}).unpivot(index="b")
 
 

--- a/pyo3-polars/example/extend_polars_python_dispatch/extend_polars/src/lib.rs
+++ b/pyo3-polars/example/extend_polars_python_dispatch/extend_polars/src/lib.rs
@@ -26,7 +26,7 @@ fn debug(pydf: PyDataFrame) -> PyResult<PyDataFrame> {
 
 #[pyfunction]
 fn empty_df() -> PyResult<PyDataFrame> {
-    Ok(PyDataFrame(DataFrame::new(vec![]).unwrap()))
+    Ok(PyDataFrame(DataFrame::empty()))
 }
 
 #[pyfunction]

--- a/pyo3-polars/example/io_plugin/io_plugin/src/lib.rs
+++ b/pyo3-polars/example/io_plugin/io_plugin/src/lib.rs
@@ -90,7 +90,7 @@ impl RandomSource {
                 })
                 .collect::<Vec<_>>();
 
-            let mut df = DataFrame::new(columns).map_err(PyPolarsErr::from)?;
+            let mut df = DataFrame::new_infer_height(columns).map_err(PyPolarsErr::from)?;
             self.n_rows = self.n_rows.saturating_sub(self.size_hint);
 
             // Apply predicate pushdown.

--- a/pyo3-polars/pyo3-polars/src/types.rs
+++ b/pyo3-polars/pyo3-polars/src/types.rs
@@ -219,11 +219,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for PyDataFrame {
             let s = pyseries.extract::<PySeries>()?.0;
             columns.push(s.into_column());
         }
-        unsafe {
-            Ok(PyDataFrame(DataFrame::new_no_checks_height_from_first(
-                columns,
-            )))
-        }
+        unsafe { Ok(PyDataFrame(DataFrame::new_unchecked_infer_height(columns))) }
     }
 }
 
@@ -352,7 +348,7 @@ impl<'py> IntoPyObject<'py> for PyDataFrame {
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         let pyseries = self
             .0
-            .get_columns()
+            .columns()
             .iter()
             .map(|s| PySeries(s.as_materialized_series().clone()).into_pyobject(py))
             .collect::<PyResult<Vec<_>>>()?;


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/25959

#### Key API Changes
* DataFrame constructors now take `height` by default. Height-inferring constructors are named with `_infer_height`.
  * E.g. `DataFrame::new` now takes `height`, and the existing constructor that doesn't take height is now `DataFrame::new_infer_height`
  * It is highly recommended to explicitly pass a height where possible
* `unsafe { df.columns_mut() }` now clears the schema by default, avoiding the need to manually call `clear_schema()` afterwards
  * `unsafe { df.columns_mut_retain_schema() }` can be used if the operation preserves column names and dtypes
  * Note that the height must still be updated with `set_height()` if it is changed
  * `fn clear_schema()` is no longer exposed
* Selecting columns via `df.select()` / `df.select_unchecked()` will preserve the height of `df` on empty selections
* (See linked issue for full list of name changes)

#### Drive-bys
* Replace some usage of `df.is_empty()` (renamed to `df.shape_has_zero()` with either:
  * `df.height() == 0`, e.g. when buffering rows to handle 0-width dfs
  * `df.shape() == (0, 0)`, explicitly matching to the (0, 0) shaped df
* Add `AmortizedColumnSelector<'a>`, which allows `DataFrame::select` to take `Iterator<Item = AsRef<str>>` instead of `Iterator<Item = Into<PlSmallStr>>`
