### PR TITLE
refactor(rust): Export PhysNode related struct

### DIFF
--- a/crates/polars-stream/src/lib.rs
+++ b/crates/polars-stream/src/lib.rs
@@ -18,9 +18,9 @@ pub use metrics::{GraphMetrics, NodeMetrics};
 mod morsel;
 mod nodes;
 mod physical_plan;
-pub use physical_plan::PhysNodeKey;
 #[cfg(feature = "physical_plan_visualization")]
 pub use physical_plan::visualization as physical_plan_visualization;
+pub use physical_plan::{PhysNode, PhysNodeKey, PhysNodeKind, ZipBehavior};
 mod pipe;
 mod utils;
 

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -50,6 +50,12 @@ slotmap::new_key_type! {
     pub struct PhysNodeKey;
 }
 
+impl PhysNodeKey {
+    pub fn as_ffi(&self) -> u64 {
+        self.0.as_ffi()
+    }
+}
+
 /// A node in the physical plan.
 ///
 /// A physical plan is created when the `IR` is translated to a directed


### PR DESCRIPTION
Makes some structs relating to PhysNodes publicly available.