### PR TITLE
chore: Ramp up CSV read size

### DIFF
--- a/crates/polars-stream/src/nodes/io_sources/csv.rs
+++ b/crates/polars-stream/src/nodes/io_sources/csv.rs
@@ -378,7 +378,7 @@ impl LineBatchSource {
         let mut row_offset = 0usize;
         let mut morsel_seq = MorselSeq::default();
         let mut n_rows_skipped: usize = 0;
-        let mut read_size = 512 * 1024; // L2 sized chunks performed the best in testing.
+        let mut read_size = CompressedReader::ideal_read_size();
 
         loop {
             let (mem_slice, bytes_read) = reader.read_next_slice(&prev_leftover, read_size)?;
@@ -396,7 +396,7 @@ impl LineBatchSource {
 
             if batch_slice.is_empty() && !is_eof {
                 // This allows the slice to grow until at least a single row is included. To avoid a quadratic run-time for large row sizes, we double the read size.
-                read_size *= 2;
+                read_size = read_size.saturating_sub(2);
                 continue;
             }
 
@@ -448,6 +448,10 @@ impl LineBatchSource {
 
             if is_eof {
                 break;
+            }
+
+            if read_size < CompressedReader::ideal_read_size() {
+                read_size *= 4;
             }
         }
 

--- a/py-polars/tests/unit/io/test_scan.py
+++ b/py-polars/tests/unit/io/test_scan.py
@@ -1224,11 +1224,11 @@ def test_scan_with_schema_skips_schema_inference(
 
 @pytest.fixture(scope="session")
 def corrupt_compressed_csv() -> bytes:
-    large_and_simple_csv = b"line_val\n" * 500_000
+    large_and_simple_csv = b"line_val\n" * 200_000
     compressed_data = zlib.compress(large_and_simple_csv, level=0)
 
     corruption_start_pos = round(len(compressed_data) * 0.9)
-    assert corruption_start_pos > 4_000_000
+    assert corruption_start_pos > 1_600_000
     corruption_len = 500
 
     # The idea is to corrupt the input to make sure the scan never fully
@@ -1237,7 +1237,7 @@ def corrupt_compressed_csv() -> bytes:
     corrupted_data[corruption_start_pos : corruption_start_pos + corruption_len] = (
         b"\00"
     )
-    # ~4MB of valid zlib compressed CSV to read before the corrupted data
+    # ~1.6MB of valid zlib compressed CSV to read before the corrupted data
     # appears.
     return corrupted_data
 


### PR DESCRIPTION
Optimize ramp up read size for CSV. Previously it would always decompress at least 768KB if available, not matter how little of it needed. With this change only 96KB are *requested* decompressed and it grows to the ideal read size dynamically. Internally the decoders may and do decode more. But at least we request and copy out less.

Benchmark `N == 100M gz` 492MB -> 1.9GB uncompressed `scan_csv(path.csv).slice(0, 10)` ~1.5x decompression share speedup, 3ms -> 2ms.
