### PR TITLE
docs(python): Fix display of deprecation warning

### DIFF
--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -1317,7 +1317,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         streaming
             Unused parameter, kept for backward compatibility.
 
-           ... deprecated:: 1.30.0
+            .. deprecated:: 1.30.0
                 Use the `engine` parameter instead.
         engine
             Select the engine used to process the query, optional.


### PR DESCRIPTION
<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->

Tiny fix to make the warning display properly.

Currently looks like
<img width="876" height="335" alt="image" src="https://github.com/user-attachments/assets/58f9480a-cd14-4426-a589-590419e036da" />

