### PR TITLE
fix(python): Propagate C Stream import errors instead of panicking

### DIFF
--- a/crates/polars-python/src/series/import.rs
+++ b/crates/polars-python/src/series/import.rs
@@ -121,7 +121,7 @@ pub(crate) fn import_stream_pycapsule(capsule: &Bound<PyCapsule>) -> PyResult<Py
 
     let mut produced_arrays: Vec<Box<dyn Array>> = vec![];
     while let Some(array) = unsafe { stream.next() } {
-        produced_arrays.push(array.unwrap());
+        produced_arrays.push(array.map_err(PyPolarsErr::from)?);
     }
 
     // Series::try_from fails for an empty vec of chunks
@@ -129,7 +129,7 @@ pub(crate) fn import_stream_pycapsule(capsule: &Bound<PyCapsule>) -> PyResult<Py
         let polars_dt = DataType::from_arrow_field(stream.field());
         Series::new_empty(stream.field().name.clone(), &polars_dt)
     } else {
-        Series::try_from((stream.field(), produced_arrays)).unwrap()
+        Series::try_from((stream.field(), produced_arrays)).map_err(PyPolarsErr::from)?
     };
     Ok(PySeries::new(s))
 }

--- a/py-polars/tests/unit/interop/test_arrow_stream_error.py
+++ b/py-polars/tests/unit/interop/test_arrow_stream_error.py
@@ -1,0 +1,32 @@
+"""Test for https://github.com/pola-rs/polars/issues/25966."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pyarrow as pa
+import pytest
+
+import polars as pl
+from polars.exceptions import ComputeError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+def test_arrow_stream_error_raises_compute_error() -> None:
+    error_msg = "simulated error"
+
+    def failing_generator() -> Iterator[pa.RecordBatch]:
+        raise pa.ArrowInvalid(error_msg)
+        yield
+
+    schema = pa.schema([("col", pa.int64())])
+    reader = pa.RecordBatchReader.from_batches(schema, failing_generator())
+
+    class FailingStream:
+        def __arrow_c_stream__(self, requested_schema: object = None) -> object:
+            return reader.__arrow_c_stream__(requested_schema)
+
+    with pytest.raises(ComputeError, match=error_msg):
+        pl.from_arrow(FailingStream())


### PR DESCRIPTION
Fixes #25966.

When an Arrow C Stream returns an error during iteration, polars panics instead of raising a catchable exception.

### Cause

`import_stream_pycapsule()` calls `.unwrap()` on stream iteration results and `Series::try_from()`, causing a panic when errors occur.

### Fix

Replace `.unwrap()` with `.map_err(PyPolarsErr::from)?` to propagate errors as `ComputeError`.