### PR TITLE
perf: Speed up `SQL` interface "ORDER BY" clauses

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -1840,8 +1840,7 @@ impl SQLContext {
             &by,
             SortMultipleOptions::default()
                 .with_order_descending_multi(descending)
-                .with_nulls_last_multi(nulls_last)
-                .with_maintain_order(true),
+                .with_nulls_last_multi(nulls_last),
         ))
     }
 

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -2207,8 +2207,7 @@ impl SQLFunctionVisitor<'_> {
             by,
             SortMultipleOptions::default()
                 .with_order_descending_multi(descending)
-                .with_nulls_last_multi(nulls_last)
-                .with_maintain_order(true),
+                .with_nulls_last_multi(nulls_last),
         ))
     }
 


### PR DESCRIPTION
Closes #26011.

Good observation from @henryharbeck; we have an unnecessary "maintain_order: true" param in the SQL interface (two, actually) -- there is no expectation or requirement that SQL sorts should do this. Removed both; no impact on tests.