### PR TITLE
perf: Speed up `SQL` interface "UNION" clauses

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -513,6 +513,7 @@ impl SQLContext {
                 let opts = UnionArgs {
                     parallel: true,
                     to_supertypes: true,
+                    maintain_order: false,
                     ..Default::default()
                 };
                 let out = match quantifier {


### PR DESCRIPTION
Similar to #26037, there is no need to enforce "maintain_order: true" for `UNION` ops (the default provided by `UnionArgs` if not otherwise set). SQL expects an explicit `ORDER BY`.