### PR TITLE
refactor(rust): Add Send bound for SharedStorage owner

### DIFF
--- a/crates/polars-arrow/src/ffi/mmap.rs
+++ b/crates/polars-arrow/src/ffi/mmap.rs
@@ -21,11 +21,11 @@ struct PrivateData<T> {
 }
 
 pub(crate) unsafe fn create_array<
-    T,
+    O: Send + 'static,
     I: Iterator<Item = Option<*const u8>>,
     II: Iterator<Item = ArrowArray>,
 >(
-    data: Arc<T>,
+    data: Arc<O>,
     num_rows: usize,
     null_count: usize,
     buffers: I,
@@ -48,7 +48,7 @@ pub(crate) unsafe fn create_array<
 
     let dictionary_ptr = dictionary.map(|array| Box::into_raw(Box::new(array)));
 
-    let mut private_data = Box::new(PrivateData::<Arc<T>> {
+    let mut private_data = Box::new(PrivateData::<Arc<O>> {
         data,
         buffers_ptr,
         children_ptr,
@@ -64,7 +64,7 @@ pub(crate) unsafe fn create_array<
         buffers: private_data.buffers_ptr.as_mut_ptr(),
         children: private_data.children_ptr.as_mut_ptr(),
         dictionary: private_data.dictionary_ptr.unwrap_or(std::ptr::null_mut()),
-        release: Some(release::<Arc<T>>),
+        release: Some(release::<Arc<O>>),
         private_data: Box::into_raw(private_data) as *mut ::std::os::raw::c_void,
     }
 }
@@ -115,7 +115,10 @@ pub unsafe fn slice<T: NativeType>(values: &[T]) -> PrimitiveArray<T> {
 /// # Safety
 ///
 /// The caller must ensure the passed `owner` ensures the data remains alive.
-pub unsafe fn slice_and_owner<T: NativeType, O>(slice: &[T], owner: O) -> PrimitiveArray<T> {
+pub unsafe fn slice_and_owner<T: NativeType, O: Send + 'static>(
+    slice: &[T],
+    owner: O,
+) -> PrimitiveArray<T> {
     let num_rows = slice.len();
     let null_count = 0;
     let validity = None;
@@ -178,7 +181,7 @@ pub unsafe fn bitmap(data: &[u8], offset: usize, length: usize) -> PolarsResult<
 /// # Safety
 ///
 /// The caller must ensure the passed `owner` ensures the data remains alive.
-pub unsafe fn bitmap_and_owner<O>(
+pub unsafe fn bitmap_and_owner<O: Send + 'static>(
     data: &[u8],
     offset: usize,
     length: usize,

--- a/crates/polars-arrow/src/mmap/array.rs
+++ b/crates/polars-arrow/src/mmap/array.rs
@@ -107,7 +107,7 @@ fn get_num_rows_and_null_count(node: &Node) -> PolarsResult<(usize, usize)> {
     Ok((num_rows, null_count))
 }
 
-fn mmap_binary<O: Offset, T: AsRef<[u8]>>(
+fn mmap_binary<O: Offset, T: AsRef<[u8]> + Send + Sync + 'static>(
     data: Arc<T>,
     node: &Node,
     block_offset: usize,
@@ -135,7 +135,7 @@ fn mmap_binary<O: Offset, T: AsRef<[u8]>>(
     })
 }
 
-fn mmap_binview<T: AsRef<[u8]>>(
+fn mmap_binview<T: AsRef<[u8]> + Send + Sync + 'static>(
     data: Arc<T>,
     node: &Node,
     block_offset: usize,
@@ -182,7 +182,7 @@ fn mmap_binview<T: AsRef<[u8]>>(
     })
 }
 
-fn mmap_fixed_size_binary<T: AsRef<[u8]>>(
+fn mmap_fixed_size_binary<T: AsRef<[u8]> + Send + Sync + 'static>(
     data: Arc<T>,
     node: &Node,
     block_offset: usize,
@@ -215,7 +215,7 @@ fn mmap_fixed_size_binary<T: AsRef<[u8]>>(
     })
 }
 
-fn mmap_null<T: AsRef<[u8]>>(
+fn mmap_null<T: AsRef<[u8]> + Send + Sync + 'static>(
     data: Arc<T>,
     node: &Node,
     _block_offset: usize,
@@ -236,7 +236,7 @@ fn mmap_null<T: AsRef<[u8]>>(
     })
 }
 
-fn mmap_boolean<T: AsRef<[u8]>>(
+fn mmap_boolean<T: AsRef<[u8]> + Send + Sync + 'static>(
     data: Arc<T>,
     node: &Node,
     block_offset: usize,
@@ -267,7 +267,7 @@ fn mmap_boolean<T: AsRef<[u8]>>(
     })
 }
 
-fn mmap_primitive<P: NativeType, T: AsRef<[u8]>>(
+fn mmap_primitive<P: NativeType, T: AsRef<[u8]> + Send + Sync + 'static>(
     data: Arc<T>,
     node: &Node,
     block_offset: usize,
@@ -339,7 +339,7 @@ fn mmap_primitive<P: NativeType, T: AsRef<[u8]>>(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn mmap_list<O: Offset, T: AsRef<[u8]>>(
+fn mmap_list<O: Offset, T: AsRef<[u8]> + Send + Sync + 'static>(
     data: Arc<T>,
     node: &Node,
     block_offset: usize,
@@ -385,7 +385,7 @@ fn mmap_list<O: Offset, T: AsRef<[u8]>>(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn mmap_fixed_size_list<T: AsRef<[u8]>>(
+fn mmap_fixed_size_list<T: AsRef<[u8]> + Send + Sync + 'static>(
     data: Arc<T>,
     node: &Node,
     block_offset: usize,
@@ -428,7 +428,7 @@ fn mmap_fixed_size_list<T: AsRef<[u8]>>(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn mmap_struct<T: AsRef<[u8]>>(
+fn mmap_struct<T: AsRef<[u8]> + Send + Sync + 'static>(
     data: Arc<T>,
     node: &Node,
     block_offset: usize,
@@ -478,7 +478,7 @@ fn mmap_struct<T: AsRef<[u8]>>(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn mmap_dict<K: DictionaryKey, T: AsRef<[u8]>>(
+fn mmap_dict<K: DictionaryKey, T: AsRef<[u8]> + Send + Sync + 'static>(
     data: Arc<T>,
     node: &Node,
     block_offset: usize,
@@ -515,7 +515,7 @@ fn mmap_dict<K: DictionaryKey, T: AsRef<[u8]>>(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn get_array<T: AsRef<[u8]>>(
+fn get_array<T: AsRef<[u8]> + Send + Sync + 'static>(
     data: Arc<T>,
     block_offset: usize,
     dtype: &ArrowDataType,
@@ -604,7 +604,7 @@ fn get_array<T: AsRef<[u8]>>(
 
 #[allow(clippy::too_many_arguments)]
 /// Maps a memory region to an [`Array`].
-pub(crate) unsafe fn mmap<T: AsRef<[u8]>>(
+pub(crate) unsafe fn mmap<T: AsRef<[u8]> + Send + Sync + 'static>(
     data: Arc<T>,
     block_offset: usize,
     dtype: ArrowDataType,

--- a/crates/polars-arrow/src/mmap/mod.rs
+++ b/crates/polars-arrow/src/mmap/mod.rs
@@ -72,7 +72,7 @@ fn get_buffers_nodes(batch: RecordBatchRef) -> PolarsResult<(VecDeque<IpcBuffer>
     Ok((buffers, field_nodes))
 }
 
-pub(crate) unsafe fn mmap_record<T: AsRef<[u8]>>(
+pub(crate) unsafe fn mmap_record<T: AsRef<[u8]> + Send + Sync + 'static>(
     fields: &ArrowSchema,
     ipc_fields: &[IpcField],
     data: Arc<T>,
@@ -132,7 +132,7 @@ pub(crate) unsafe fn mmap_record<T: AsRef<[u8]>>(
 /// The caller must ensure that `data` contains a valid buffers, for example:
 /// * Offsets in variable-sized containers must be in-bounds and increasing
 /// * Utf8 data is valid
-pub unsafe fn mmap_unchecked<T: AsRef<[u8]>>(
+pub unsafe fn mmap_unchecked<T: AsRef<[u8]> + Send + Sync + 'static>(
     metadata: &FileMetadata,
     dictionaries: &Dictionaries,
     data: Arc<T>,
@@ -152,7 +152,7 @@ pub unsafe fn mmap_unchecked<T: AsRef<[u8]>>(
     )
 }
 
-unsafe fn mmap_dictionary<T: AsRef<[u8]>>(
+unsafe fn mmap_dictionary<T: AsRef<[u8]> + Send + Sync + 'static>(
     schema: &ArrowSchema,
     ipc_fields: &[IpcField],
     data: Arc<T>,
@@ -164,7 +164,7 @@ unsafe fn mmap_dictionary<T: AsRef<[u8]>>(
     mmap_dictionary_from_batch(schema, ipc_fields, &data, batch, dictionaries, offset)
 }
 
-pub(crate) unsafe fn mmap_dictionary_from_batch<T: AsRef<[u8]>>(
+pub(crate) unsafe fn mmap_dictionary_from_batch<T: AsRef<[u8]> + Send + Sync + 'static>(
     schema: &ArrowSchema,
     ipc_fields: &[IpcField],
     data: &Arc<T>,
@@ -212,7 +212,7 @@ pub(crate) unsafe fn mmap_dictionary_from_batch<T: AsRef<[u8]>>(
 /// The caller must ensure that `data` contains a valid buffers, for example:
 /// * Offsets in variable-sized containers must be in-bounds and increasing
 /// * Utf8 data is valid
-pub unsafe fn mmap_dictionaries_unchecked<T: AsRef<[u8]>>(
+pub unsafe fn mmap_dictionaries_unchecked<T: AsRef<[u8]> + Send + Sync + 'static>(
     metadata: &FileMetadata,
     data: Arc<T>,
 ) -> PolarsResult<Dictionaries> {
@@ -224,7 +224,7 @@ pub unsafe fn mmap_dictionaries_unchecked<T: AsRef<[u8]>>(
     )
 }
 
-pub(crate) unsafe fn mmap_dictionaries_unchecked2<T: AsRef<[u8]>>(
+pub(crate) unsafe fn mmap_dictionaries_unchecked2<T: AsRef<[u8]> + Send + Sync + 'static>(
     schema: &ArrowSchema,
     ipc_fields: &[IpcField],
     dictionaries: Option<&Vec<arrow_format::ipc::Block>>,

--- a/crates/polars-python/src/series/construction.rs
+++ b/crates/polars-python/src/series/construction.rs
@@ -45,7 +45,7 @@ init_method!(new_u32, u32);
 init_method!(new_u64, u64);
 
 fn numpy_array_to_arrow<T: Element + NativeType>(array: &Bound<PyArray1<T>>) -> PrimitiveArray<T> {
-    let owner = Arc::new(array.clone().unbind());
+    let owner = array.clone().unbind();
     let ro = array.readonly();
     let vals = ro.as_slice().unwrap();
     unsafe {


### PR DESCRIPTION
We are potentially dropping the owner on a different thread than where it was created, thus requiring a `Send` bound. Similarly for `create_array` in arrow FFI.

We weren't violating this, but we should still add the bound to not have an unsound internal API.