### PR TITLE
ci: Don't run rust doctests

### DIFF
--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -43,9 +43,11 @@ jobs:
         with:
           save-if: ${{ github.ref_name == 'main' }}
 
+      # Note that we specify --lib, --bins etc
+      # to exclude the doc tests.
       - name: Compile tests
         run: >
-          cargo test --all-features --no-run
+          cargo test --lib --tests --bins --all-features --no-run
           -p polars-arrow
           -p polars-compute
           -p polars-core
@@ -62,7 +64,7 @@ jobs:
       - name: Run tests
         if: github.ref_name != 'main'
         run: >
-          cargo test --all-features
+          cargo test --lib --tests --bins --all-features
           -p polars-arrow
           -p polars-compute
           -p polars-core


### PR DESCRIPTION
These fail because of full disk