### PR TITLE
fix: Fix slicing on compressed IPC

### DIFF
--- a/crates/polars-stream/src/nodes/io_sources/ipc/record_batch_decode.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ipc/record_batch_decode.rs
@@ -41,7 +41,7 @@ impl RecordBatchDecoder {
         let mut data_scratch = Vec::new();
         let mut message_scratch = Vec::new();
 
-        let limit = Some(slice_offset + slice_len);
+        let limit = None;
 
         // Create the DataFrame with the appropriate schema based on the data.
         // @NOTE: This empty schema code path is relied upon for `select(pl.len())`

--- a/py-polars/tests/unit/io/test_lazy_ipc.py
+++ b/py-polars/tests/unit/io/test_lazy_ipc.py
@@ -327,3 +327,14 @@ def test_sink_ipc_record_batch_size(record_batch_size: int, n_chunks: int) -> No
         assert n_rows == record_batch_size or (
             i + 1 == n_batches and n_rows <= record_batch_size
         )
+
+
+@pytest.mark.parametrize("compression", COMPRESSIONS)
+def test_scan_ipc_compression_with_slice_26063(compression: IpcCompression) -> None:
+    df = pl.DataFrame({"a": [1, 2, 3]})
+    buf = io.BytesIO()
+
+    df.lazy().sink_ipc(buf, compression=compression)
+    out = pl.scan_ipc(buf).slice(0, 1).collect()
+    expected = df.slice(0, 1)
+    assert_frame_equal(out, expected)


### PR DESCRIPTION
fixes #26063 

This reverts to prior behavior.

Note - the underlying bug may be with the length check introduced here:
https://github.com/pola-rs/polars/pull/24674
https://github.com/pola-rs/polars/blob/b0fdbd34d430d934bda9a4ca3f75e136223bd95b/crates/polars-arrow/src/io/ipc/read/read_basic.rs#L140C1-L142C6

ping @nameexhaustion 

