### PR TITLE
chore: Mark top slow normal tests as slow

### DIFF
--- a/py-polars/tests/unit/io/cloud/test_credential_provider.py
+++ b/py-polars/tests/unit/io/cloud/test_credential_provider.py
@@ -116,6 +116,7 @@ def test_credential_provider_serialization_auto_init(
         q.collect()
 
 
+@pytest.mark.slow
 def test_credential_provider_serialization_custom_provider() -> None:
     err_magic = "err_magic_3"
 

--- a/py-polars/tests/unit/io/test_collect_batches.py
+++ b/py-polars/tests/unit/io/test_collect_batches.py
@@ -68,6 +68,7 @@ def test_chunk_size() -> None:
         assert_frame_equal(f, expected)
 
 
+@pytest.mark.slow
 def test_collect_batches_releases_gil_26031() -> None:
     out = subprocess.check_output(
         [

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -947,6 +947,7 @@ print("OK", end="")
     assert out == b"OK"
 
 
+@pytest.mark.slow
 def test_scan_parquet_in_mem_to_streaming_dispatch_deadlock_22641() -> None:
     out = subprocess.check_output(
         [

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -2629,11 +2629,29 @@ def test_group_bool_unique_25267(maintain_order: bool, stable: bool) -> None:
 
 
 @pytest.mark.parametrize("group_as_slice", [False, True])
-@pytest.mark.parametrize("n", [10, 100, 1_000, 10_000])
+@pytest.mark.parametrize("n", [10, 100, 519])
 @pytest.mark.parametrize(
     "dtype", [pl.Int32, pl.Boolean, pl.String, pl.Categorical, pl.List(pl.Int32)]
 )
 def test_group_by_first_last(
+    group_as_slice: bool, n: int, dtype: PolarsDataType
+) -> None:
+    group_by_first_last_test_impl(group_as_slice, n, dtype)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("group_as_slice", [False, True])
+@pytest.mark.parametrize("n", [1056, 10_432])
+@pytest.mark.parametrize(
+    "dtype", [pl.Int32, pl.Boolean, pl.String, pl.Categorical, pl.List(pl.Int32)]
+)
+def test_group_by_first_last_big(
+    group_as_slice: bool, n: int, dtype: PolarsDataType
+) -> None:
+    group_by_first_last_test_impl(group_as_slice, n, dtype)
+
+
+def group_by_first_last_test_impl(
     group_as_slice: bool, n: int, dtype: PolarsDataType
 ) -> None:
     idx = pl.Series([1, 2, 3, 4, 5], dtype=pl.Int32)

--- a/py-polars/tests/unit/utils/test_deprecation.py
+++ b/py-polars/tests/unit/utils/test_deprecation.py
@@ -99,6 +99,7 @@ def test_deprecate_parameter_as_multi_positional_existing_arg(recwarn: Any) -> N
     assert result == hello(5, "x", "y")
 
 
+@pytest.mark.slow
 def test_identify_deprecations() -> None:
     dep = identify_deprecations()
     assert isinstance(dep, dict)


### PR DESCRIPTION
For example the credential provider test takes upwards of 2s, and it looks like it does network IO. What remains are tests sub 300ms.
