### PR TITLE
chore: Disable `unused-ignore` mypy lint

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -101,6 +101,10 @@ enable_error_code = [
 ]
 disable_error_code = [
   "empty-body",
+  # Lint ignores can become unused depending on the python/mypy versions.
+  # Since we want to support multiple versions it can become an annoyance.
+  # Consider commenting out this line every once in a while to remove actually unused ignores.
+  "unused-ignore",
 ]
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
It can start triggering depending on the mypy/python version, which is annoying.

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
