### PR TITLE
chore: Fix Python docs build

### DIFF
--- a/py-polars/docs/source/reference/io.rst
+++ b/py-polars/docs/source/reference/io.rst
@@ -108,9 +108,6 @@ Sink to disk with differing partitioning strategies.
    :toctree: api/
 
    PartitionBy
-   PartitionByKey
-   PartitionMaxSize
-   PartitionParted
 
 .. currentmodule:: polars.io.partition
 
@@ -118,9 +115,6 @@ Sink to disk with differing partitioning strategies.
    :toctree: api/
 
    FileProviderArgs
-   KeyedPartition
-   BasePartitionContext
-   KeyedPartitionContext
 
 .. currentmodule:: polars
 


### PR DESCRIPTION
Missed removing these from the reference guide.
