### PR TITLE
feat: Add optional "offset" parameter to `str.find` Expression

### DIFF
--- a/crates/polars-expr/src/dispatch/strings.rs
+++ b/crates/polars-expr/src/dispatch/strings.rs
@@ -255,7 +255,8 @@ pub(super) fn find(s: &[Column], literal: bool, strict: bool) -> PolarsResult<Co
     _check_same_length(s, "find")?;
     let ca = s[0].str()?;
     let pat = s[1].str()?;
-    ca.find_chunked(pat, literal, strict)
+    let offset = &s[2];
+    ca.find_chunked(pat, literal, strict, offset)
         .map(|ok| ok.into_column())
 }
 

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -222,25 +222,27 @@ impl StringNameSpace {
 
     /// Find the index of a literal substring within another string value.
     #[cfg(feature = "regex")]
-    pub fn find_literal(self, pat: Expr) -> Expr {
-        self.0.map_binary(
+    pub fn find_literal(self, pat: Expr, offset: Expr) -> Expr {
+        self.0.map_ternary(
             StringFunction::Find {
                 literal: true,
                 strict: false,
             },
             pat,
+            offset,
         )
     }
 
     /// Find the index of a substring defined by a regular expressions within another string value.
     #[cfg(feature = "regex")]
-    pub fn find(self, pat: Expr, strict: bool) -> Expr {
-        self.0.map_binary(
+    pub fn find(self, pat: Expr, strict: bool, offset: Expr) -> Expr {
+        self.0.map_ternary(
             StringFunction::Find {
                 literal: false,
                 strict,
             },
             pat,
+            offset,
         )
     }
 

--- a/crates/polars-plan/src/plans/aexpr/function_expr/strings.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/strings.rs
@@ -262,7 +262,7 @@ impl IRStringFunction {
             #[cfg(feature = "string_to_integer")]
             S::ToInteger { .. } => FunctionOptions::elementwise(),
             #[cfg(feature = "regex")]
-            S::Find { .. } => FunctionOptions::elementwise().with_supertyping(Default::default()),
+            S::Find { .. } => FunctionOptions::elementwise(),
             #[cfg(feature = "extract_jsonpath")]
             S::JsonDecode { .. } => FunctionOptions::elementwise(),
             #[cfg(feature = "extract_jsonpath")]

--- a/crates/polars-python/src/expr/string.rs
+++ b/crates/polars-python/src/expr/string.rs
@@ -194,12 +194,22 @@ impl PyExpr {
         }
     }
 
-    #[pyo3(signature = (pat, literal, strict))]
+    #[pyo3(signature = (pat, literal, strict, offset))]
     #[cfg(feature = "regex")]
-    fn str_find(&self, pat: Self, literal: Option<bool>, strict: bool) -> Self {
+    fn str_find(&self, pat: Self, literal: Option<bool>, strict: bool, offset: Self) -> Self {
         match literal {
-            Some(true) => self.inner.clone().str().find_literal(pat.inner).into(),
-            _ => self.inner.clone().str().find(pat.inner, strict).into(),
+            Some(true) => self
+                .inner
+                .clone()
+                .str()
+                .find_literal(pat.inner, offset.inner)
+                .into(),
+            _ => self
+                .inner
+                .clone()
+                .str()
+                .find(pat.inner, strict, offset.inner)
+                .into(),
         }
     }
 

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -200,7 +200,7 @@ impl SQLExprVisitor<'_> {
                 (self
                     .visit_expr(r#in)?
                     .str()
-                    .find(self.visit_expr(expr)?, true)
+                    .find(self.visit_expr(expr)?, true, lit(0u32))
                     + typed_lit(1u32))
                 .fill_null(typed_lit(0u32)),
             ),

--- a/py-polars/docs/source/reference/sql/functions/string.rst
+++ b/py-polars/docs/source/reference/sql/functions/string.rst
@@ -31,6 +31,9 @@ String
      - Convert string to the specified Unicode normalization form (one of NFC, NFD, NFKC, NFKD).
    * - :ref:`OCTET_LENGTH <octet_length>`
      - Returns the length of a given string in bytes.
+   * - :ref:`POSITION <position>`
+     - Returns the index of a given substring in the target string, or 0 if the substring is not contained;
+       result is 1-indexed.
    * - :ref:`REGEXP_LIKE <regexp_like>`
      - Returns True if `pattern` matches the value (optional: `flags`).
    * - :ref:`REPLACE <replace>`
@@ -440,6 +443,36 @@ Returns the length of a given string in bytes.
     # │ es       ┆ amarillo ┆ 8       ┆ 8       │
     # └──────────┴──────────┴─────────┴─────────┘
 
+.. _position:
+
+POSITION
+--------
+Returns the index of a given substring in the target string.
+
+.. seealso::
+
+   `STRPOS`
+
+**Example:**
+
+.. code-block:: python
+
+    df = pl.DataFrame({"foo": ["apple", "banana", "orange", "grape"]})
+    df.sql("""
+      SELECT foo, POSITION('a' IN foo) AS pos_a FROM self
+    """)
+    # shape: (4, 2)
+    # ┌────────┬───────┐
+    # │ foo    ┆ pos_a │
+    # │ ---    ┆ ---   │
+    # │ str    ┆ u32   │
+    # ╞════════╪═══════╡
+    # │ apple  ┆ 1     │
+    # │ banana ┆ 2     │
+    # │ orange ┆ 3     │
+    # │ grape  ┆ 3     │
+    # └────────┴───────┘
+
 .. _regexp_like:
 
 REGEXP_LIKE
@@ -656,25 +689,33 @@ STRPOS
 ------
 Returns the index of the given substring in the target string.
 
+.. admonition:: Aliases
+
+   `CHARINDEX`, `LOCATE`
+
 **Example:**
 
 .. code-block:: python
 
     df = pl.DataFrame({"foo": ["apple", "banana", "orange", "grape"]})
     df.sql("""
-      SELECT foo, STRPOS(foo, 'a') AS pos_a FROM self
+      SELECT
+        foo,
+        STRPOS(foo, 'a') AS pos_a,
+        STRPOS(foo, 'a', 2) AS pos_a_offset,
+      FROM self
     """)
-    # shape: (4, 2)
-    # ┌────────┬───────┐
-    # │ foo    ┆ pos_a │
-    # │ ---    ┆ ---   │
-    # │ str    ┆ u32   │
-    # ╞════════╪═══════╡
-    # │ apple  ┆ 1     │
-    # │ banana ┆ 2     │
-    # │ orange ┆ 3     │
-    # │ grape  ┆ 3     │
-    # └────────┴───────┘
+    # shape: (4, 3)
+    # ┌────────┬───────┬──────────────┐
+    # │ foo    ┆ pos_a ┆ pos_a_offset │
+    # │ ---    ┆ ---   ┆ ---          │
+    # │ str    ┆ u32   ┆ u32          │
+    # ╞════════╪═══════╪══════════════╡
+    # │ apple  ┆ 1     ┆ 0            │
+    # │ banana ┆ 2     ┆ 4            │
+    # │ orange ┆ 3     ┆ 3            │
+    # │ grape  ┆ 3     ┆ 3            │
+    # └────────┴───────┴──────────────┘
 
 
 .. _strptime:

--- a/py-polars/src/polars/_plr.pyi
+++ b/py-polars/src/polars/_plr.pyi
@@ -1856,7 +1856,12 @@ class PyExpr:
         self, pat: PyExpr, literal: bool | None = None, strict: bool = True
     ) -> PyExpr: ...
     def str_find(
-        self, pat: PyExpr, literal: bool | None = None, strict: bool = True
+        self,
+        pat: PyExpr,
+        *,
+        literal: bool | None = None,
+        strict: bool = True,
+        offset: PyExpr | None = None,
     ) -> PyExpr: ...
     def str_ends_with(self, sub: PyExpr) -> PyExpr: ...
     def str_starts_with(self, sub: PyExpr) -> PyExpr: ...

--- a/py-polars/src/polars/series/string.py
+++ b/py-polars/src/polars/series/string.py
@@ -540,7 +540,12 @@ class StringNameSpace:
         """
 
     def find(
-        self, pattern: str | Expr, *, literal: bool = False, strict: bool = True
+        self,
+        pattern: str | Expr,
+        *,
+        literal: bool = False,
+        strict: bool = True,
+        offset: int | IntoExprColumn | None = None,
     ) -> Series:
         """
         Return the bytes offset of the first substring matching a pattern.
@@ -557,6 +562,9 @@ class StringNameSpace:
         strict
             Raise an error if the underlying pattern is not a valid regex,
             otherwise mask out with a null value.
+        offset
+            Start searching at this byte offset into the string (the returned
+            position is still relative to the start of the string).
 
         Notes
         -----
@@ -611,7 +619,7 @@ class StringNameSpace:
             7
         ]
 
-        Match against a pattern found in another column or (expression):
+        Match against a pattern found in another column (or expression):
 
         >>> p = pl.Series("pat", ["a[bc]", "b.t", "[aeiuo]", "(?i)A[BC]"])
         >>> s.str.find(p).rename("idx")
@@ -622,6 +630,18 @@ class StringNameSpace:
             2
             null
             5
+        ]
+
+        Use the `offset` parameter to start searching later in the string:
+
+        >>> s = pl.Series(name="txt", values=["abcabc", "aaaaa", "axxx"])
+        >>> s.str.find("a", offset=2)
+        shape: (3,)
+        Series: 'txt' [u32]
+        [
+            3
+            2
+            null
         ]
         """
 

--- a/py-polars/tests/unit/sql/test_strings.py
+++ b/py-polars/tests/unit/sql/test_strings.py
@@ -302,19 +302,19 @@ def test_string_position() -> None:
             SELECT
               POSITION('a' IN city) AS a_lc1,
               POSITION('A' IN city) AS a_uc1,
-              STRPOS(city,'a') AS a_lc2,
+              -- note: locate/charindex/strpos are aliases
+              LOCATE(city,'a',3) AS a_lc2,
+              CHARINDEX(city,'a') AS a_lc3,
               STRPOS(city,'A') AS a_uc2,
             FROM cities
             """
         )
-        expected_lc = [4, 7, 3, 0, 4, 2]
-        expected_uc = [0, 1, 0, 1, 1, 5]
-
         assert res.to_dict(as_series=False) == {
-            "a_lc1": expected_lc,
-            "a_uc1": expected_uc,
-            "a_lc2": expected_lc,
-            "a_uc2": expected_uc,
+            "a_lc1": [4, 7, 3, 0, 4, 2],
+            "a_uc1": [0, 1, 0, 1, 1, 5],
+            "a_lc2": [4, 7, 6, 0, 4, 10],
+            "a_lc3": [4, 7, 3, 0, 4, 2],
+            "a_uc2": [0, 1, 0, 1, 1, 5],
         }
 
     df = pl.DataFrame({"txt": ["AbCdEXz", "XyzFDkE"]})


### PR DESCRIPTION
Was looking to add support for the optional "offset" parameter of SQL `STRPOS` (aka: `CHARINDEX` or `LOCATE`, depending on the underlying database) - needed to add "offset" to our own `find` expression to do it properly.

With the addition of the new param the `find` function was getting a bit unwieldy, so broke out `find_many_literal` and `find_many_regex` for clarity. Benchmarking actually shows a minor speedup following the refactor (~3%) though probably just noise - was only checking to make sure nothing regressed.

Unit tests, method docstrings, and SQL docs updated.

## Example
```python
import polars as pl
df = pl.DataFrame({
    "foo": ["apple", "banana", "orange", "grape"],
})
```
### Polars expression
```python
df.with_columns(
    pl.col("foo").str.find("a").alias("pos:a"),
    pl.col("foo").str.find("a",offset=2).alias("pos:a→2"),
)
# shape: (4, 3)
# ┌────────┬───────┬─────────┐
# │ foo    ┆ pos:a ┆ pos:a→2 │
# │ ---    ┆ ---   ┆ ---     │
# │ str    ┆ u32   ┆ u32     │
# ╞════════╪═══════╪═════════╡
# │ apple  ┆ 0     ┆ null    │
# │ banana ┆ 1     ┆ 3       │
# │ orange ┆ 2     ┆ 2       │
# │ grape  ┆ 2     ┆ 2       │
# └────────┴───────┴─────────┘
```
### SQL interface
_(note: SQL inputs/results are 1-indexed, not 0-indexed, and expected return value if the substring is not found is zero, not NULL)_
```python
df.sql("""
  SELECT
    foo,
    STRPOS(foo,'a') AS "pos:a",
    STRPOS(foo,'a',2) AS "pos:a→2",
  FROM self
""")
# shape: (4, 3)
# ┌────────┬───────┬─────────┐
# │ foo    ┆ pos:a ┆ pos:a→2 │
# │ ---    ┆ ---   ┆ ---     │
# │ str    ┆ u32   ┆ u32     │
# ╞════════╪═══════╪═════════╡
# │ apple  ┆ 1     ┆ 0       │
# │ banana ┆ 2     ┆ 4       │
# │ orange ┆ 3     ┆ 3       │
# │ grape  ┆ 3     ┆ 3       │
# └────────┴───────┴─────────┘
```