### PR TITLE
chore: Improve backtrace for `POLARS_PANIC_ON_ERR`

### DIFF
--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -45,6 +45,7 @@ impl<T> From<T> for ErrString
 where
     T: Into<Cow<'static, str>>,
 {
+    #[track_caller]
     fn from(msg: T) -> Self {
         match &*ERROR_STRATEGY {
             ErrorStrategy::Panic => panic!("{}", msg.into()),


### PR DESCRIPTION
eg:
```py
; POLARS_PANIC_ON_ERR=1 python
Python 3.13.5 (main, Jun 11 2025, 15:36:57) [GCC 14.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> __import__("polars").DataFrame({}).select("a")
```

before:
```
thread '<unnamed>' (...) panicked at crates/polars-error/src/lib.rs:50:37:
```
after:
```
thread '<unnamed>' (...) panicked at crates/polars-schema/src/schema.rs:316:13:
```
<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
