### PR TITLE
fix: Handle nulls/empty lists properly in Expr.flatten and add Series.flatten

### DIFF
--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -5029,9 +5029,10 @@ Consider using {self}.implode() instead"""
 
     def flatten(self) -> Expr:
         """
-        Flatten a list or string column.
+        Flattens one level of nesting from a list or array column.
 
-        Alias for :func:`Expr.list.explode`.
+        Alias for :func:`Expr.list.explode` with `empty_as_null = False` and
+        `keep_nulls = False`.
 
         Examples
         --------
@@ -5052,7 +5053,7 @@ Consider using {self}.implode() instead"""
         │ b     ┆ [2, 3, 4] │
         └───────┴───────────┘
         """
-        return self.explode(empty_as_null=True, keep_nulls=True)
+        return self.explode(empty_as_null=False, keep_nulls=False)
 
     def explode(self, *, empty_as_null: bool = True, keep_nulls: bool = True) -> Expr:
         """

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -4338,6 +4338,31 @@ class Series:
         ]
         """
 
+    def flatten(self) -> Series:
+        """
+        Flattens one level of nesting from a list or array series.
+
+        Alias for :func:`Series.list.explode` with `empty_as_null = False` and
+        `keep_nulls = False`.
+
+        Examples
+        --------
+        >>> s = pl.Series("a", [[0], [], [1, 2], None, [3, 4, None], [5, 6]])
+        >>> s.flatten()
+        shape: (8,)
+        Series: 'a' [i64]
+        [
+                0
+                1
+                2
+                3
+                4
+                null
+                5
+                6
+        ]
+        """
+
     def explode(self, *, empty_as_null: bool = True, keep_nulls: bool = True) -> Series:
         """
         Explode a list Series.


### PR DESCRIPTION
`flatten()` was added very early on in Polars to flatten a series of lists. We already had `explode` for this so it was aliased to it.

Explode was changed afterwards to match Pandas behavior for nulls/empty lists (something we intend to revert in 2.0), which unintentionally changed `flatten` as well. 

So we'll fix this right now as a bug as flattening clearly means you should only keep elements which are in the inner type.