### PR TITLE
chore(python): Use zstandard implementation from stdlib (PEP-784)

### DIFF
--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -45,7 +45,7 @@ xlsxwriter<=3.2.5
 # Other I/O
 deltalake>=1.1.4
 # Csv
-zstandard
+backports.zstd ; python_version < '3.14'
 # Plotting
 altair>=5.4.0
 # Styling

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -5,6 +5,7 @@ import io
 import json
 import math
 import re
+import sys
 import zlib
 from collections import OrderedDict
 from datetime import datetime
@@ -12,7 +13,11 @@ from decimal import Decimal as D
 from io import BytesIO
 from typing import TYPE_CHECKING
 
-import zstandard
+if sys.version_info >= (3, 14):
+    from compression import zstd
+else:
+    from backports import zstd
+
 from hypothesis import given
 
 from polars.datatypes.group import FLOAT_DTYPES
@@ -541,7 +546,7 @@ def test_compressed_json() -> None:
     assert_frame_equal(out, expected)
 
     # zstd
-    compressed_bytes = zstandard.compress(json_bytes)
+    compressed_bytes = zstd.compress(json_bytes)
     out = pl.read_json(compressed_bytes)
     assert_frame_equal(out, expected)
 


### PR DESCRIPTION
Thanks to [PEP-784](https://peps.python.org/pep-0784/), Zstandard is included in Python starting from version 3.14 with the [`compression.zstd`](https://docs.python.org/3.14/library/compression.zstd.html) module.

So for Python 3.14+, we don't need an external lib. For older version of Python, I'm using [`backports.zstd`](https://github.com/Rogdham/backports.zstd) which exposes the same API as stdlib.

_Full disclosure: I'm the author and maintainer of `backports.zstd`, and the maintainer of `pyzstd` (which code was used as a base for the integration into Python). I also helped with PEP-784 and its integration into CPython._