### PR TITLE
refactor(python): Simplify IcebergDataset

### DIFF
--- a/py-polars/src/polars/io/cloud/_utils.py
+++ b/py-polars/src/polars/io/cloud/_utils.py
@@ -13,7 +13,8 @@ class NoPickleOption(Generic[T]):
     """
     Wrapper that does not pickle the wrapped value.
 
-    This wrapper will unpickle to contain a None. Used for cached values.
+    This wrapper will unpickle to contain a None. Useful for cached or sensitive
+    values.
     """
 
     def __init__(self, opt_value: T | None = None) -> None:

--- a/py-polars/src/polars/io/iceberg/functions.py
+++ b/py-polars/src/polars/io/iceberg/functions.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import importlib
 from typing import TYPE_CHECKING, Any, Literal
 
 from polars._utils.unstable import issue_unstable_warning
 from polars._utils.wrap import wrap_ldf
-from polars.io.iceberg.dataset import IcebergDataset
+from polars.io.cloud._utils import NoPickleOption
+from polars.io.iceberg._dataset import IcebergDataset
 
 if TYPE_CHECKING:
     from pyiceberg.table import Table
@@ -167,8 +169,17 @@ def scan_iceberg(
     else:
         fast_deletion_count = False
 
+    table: NoPickleOption[Table] = NoPickleOption()
+
+    if importlib.util.find_spec("pyiceberg.table") is not None:
+        from pyiceberg.table import Table
+
+        if isinstance(source, Table):
+            table.set(source)
+
     dataset = IcebergDataset(
-        source,
+        table_=table,
+        metadata_path_=str(source) if table.get() is None else None,
         snapshot_id=snapshot_id,
         iceberg_storage_properties=storage_options,
         reader_override=reader_override,

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -13,6 +13,7 @@ from datetime import date, datetime
 from decimal import Decimal as D
 from functools import partial
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -49,14 +50,19 @@ from pyiceberg.types import (
 
 import polars as pl
 from polars._utils.various import parse_version
+from polars.io.cloud._utils import NoPickleOption
+from polars.io.iceberg._dataset import IcebergDataset, _NativeIcebergScanData
 from polars.io.iceberg._utils import (
     _convert_predicate,
     _normalize_windows_iceberg_file_uri,
     _to_ast,
 )
-from polars.io.iceberg.dataset import IcebergDataset, _NativeIcebergScanData
 from polars.testing import assert_frame_equal
 from tests.unit.io.conftest import normalize_path_separator_pl
+
+if TYPE_CHECKING:
+    from pyiceberg.table import Table
+
 
 with warnings.catch_warnings():
     # Upstream issue at https://github.com/apache/iceberg-python/issues/2648.
@@ -65,6 +71,21 @@ with warnings.catch_warnings():
     warnings.simplefilter("ignore", DeprecationWarning)
     from pyiceberg.catalog.sql import SqlCatalog
     from pyiceberg.io.pyarrow import schema_to_pyarrow
+
+
+def new_pl_iceberg_dataset(source: str | Table) -> IcebergDataset:
+    from pyiceberg.table import Table
+
+    return IcebergDataset(
+        table_=NoPickleOption(source if isinstance(source, Table) else None),
+        metadata_path_=source if not isinstance(source, Table) else None,
+        snapshot_id=None,
+        iceberg_storage_properties=None,
+        reader_override=None,
+        use_metadata_statistics=True,
+        fast_deletion_count=False,
+        use_pyiceberg_filter=True,
+    )
 
 
 # PyIceberg on Windows uses `file://C:/` rather than `file:///C:/`.
@@ -256,6 +277,40 @@ class TestIcebergExpressions:
         assert _convert_predicate(expr) == EqualTo("ts", False)
 
 
+@pytest.mark.write_disk
+def test_iceberg_dataset_does_not_pickle_table_object(tmp_path: Path) -> None:
+    catalog = SqlCatalog(
+        "default",
+        uri="sqlite:///:memory:",
+        warehouse=format_file_uri_iceberg(tmp_path),
+    )
+    catalog.create_namespace("namespace")
+
+    catalog.create_table(
+        "namespace.table",
+        IcebergSchema(
+            NestedField(1, "row_index", IntegerType()),
+        ),
+    )
+
+    tbl = catalog.load_table("namespace.table")
+
+    df = pl.DataFrame(
+        {"row_index": [0, 1, 2, 3, 4]},
+        schema={"row_index": pl.Int32},
+    )
+
+    df.write_iceberg(tbl, mode="append")
+
+    dataset = new_pl_iceberg_dataset(tbl)
+
+    assert dataset.table_.get() is not None
+    dataset = pickle.loads(pickle.dumps(dataset))
+    assert dataset.table_.get() is None
+
+    assert_frame_equal(dataset.to_dataset_scan()[0].collect(), df)  # type: ignore[index]
+
+
 @pytest.mark.slow
 @pytest.mark.write_disk
 @pytest.mark.filterwarnings("ignore:Delete operation did not match any records")
@@ -330,7 +385,10 @@ def test_scan_iceberg_row_index_renamed(tmp_path: Path) -> None:
             "row_index_in_file": pl.Int32,
             "file_path_in_file": pl.String,
         },
-        _column_mapping=("iceberg-column-mapping", IcebergDataset(tbl).arrow_schema()),
+        _column_mapping=(
+            "iceberg-column-mapping",
+            new_pl_iceberg_dataset(tbl).arrow_schema(),
+        ),
         include_file_paths="file_path",
         row_index_name="row_index",
         row_index_offset=3,
@@ -451,7 +509,10 @@ def test_scan_iceberg_extra_columns(tmp_path: Path) -> None:
     q = pl.scan_parquet(
         file_paths,
         schema={"a": pl.Int32},
-        _column_mapping=("iceberg-column-mapping", IcebergDataset(tbl).arrow_schema()),
+        _column_mapping=(
+            "iceberg-column-mapping",
+            new_pl_iceberg_dataset(tbl).arrow_schema(),
+        ),
     )
 
     # The original column is considered an extra column despite having the same
@@ -466,7 +527,10 @@ def test_scan_iceberg_extra_columns(tmp_path: Path) -> None:
     q = pl.scan_parquet(
         file_paths,
         schema={"a": pl.Int32},
-        _column_mapping=("iceberg-column-mapping", IcebergDataset(tbl).arrow_schema()),
+        _column_mapping=(
+            "iceberg-column-mapping",
+            new_pl_iceberg_dataset(tbl).arrow_schema(),
+        ),
         extra_columns="ignore",
         missing_columns="insert",
     )
@@ -519,7 +583,10 @@ def test_scan_iceberg_extra_struct_fields(tmp_path: Path) -> None:
     q = pl.scan_parquet(
         file_paths,
         schema={"a": pl.Struct({"a": pl.Int32})},
-        _column_mapping=("iceberg-column-mapping", IcebergDataset(tbl).arrow_schema()),
+        _column_mapping=(
+            "iceberg-column-mapping",
+            new_pl_iceberg_dataset(tbl).arrow_schema(),
+        ),
     )
 
     # The original column is considered an extra column despite having the same
@@ -534,7 +601,10 @@ def test_scan_iceberg_extra_struct_fields(tmp_path: Path) -> None:
     q = pl.scan_parquet(
         file_paths,
         schema={"a": pl.Struct({"a": pl.Int32})},
-        _column_mapping=("iceberg-column-mapping", IcebergDataset(tbl).arrow_schema()),
+        _column_mapping=(
+            "iceberg-column-mapping",
+            new_pl_iceberg_dataset(tbl).arrow_schema(),
+        ),
         cast_options=pl.ScanCastOptions(
             extra_struct_fields="ignore", missing_struct_fields="insert"
         ),
@@ -1657,13 +1727,13 @@ def test_scan_iceberg_min_max_statistics_filter(
 
     # Begin inspecting statistics
 
-    scan_data = IcebergDataset(tbl)._to_dataset_scan_impl()
+    scan_data = new_pl_iceberg_dataset(tbl)._to_dataset_scan_impl()
 
     assert isinstance(scan_data, _NativeIcebergScanData)
     assert scan_data.statistics_loader is None
     assert scan_data.min_max_statistics is None
 
-    scan_data = IcebergDataset(tbl)._to_dataset_scan_impl(
+    scan_data = new_pl_iceberg_dataset(tbl)._to_dataset_scan_impl(
         filter_columns=["height_provider"]
     )
 
@@ -1688,7 +1758,7 @@ def test_scan_iceberg_min_max_statistics_filter(
         ),
     )
 
-    scan_data = IcebergDataset(tbl)._to_dataset_scan_impl(
+    scan_data = new_pl_iceberg_dataset(tbl)._to_dataset_scan_impl(
         filter_columns=pl_schema.names()
     )
 


### PR DESCRIPTION
* Make it a dataclass to reduce manual `__init__` code bloat
* Use `NoPickleOption` for `self.table_`, allowing us to simplify the `__getstate__` / `__setstate__` logic
* This is tagged as breaking-dsl as it changes the serialization format of `IcebergDataset`
