### PR TITLE
fix(python): Make Series equality with ndarray work

### DIFF
--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -59,6 +59,7 @@ from polars._utils.various import (
     BUILDING_SPHINX_DOCS,
     NO_DEFAULT,
     _is_generator,
+    is_sequence,
     parse_version,
     qualified_type_name,
     require_same_type,
@@ -904,7 +905,7 @@ class Series:
             assert f is not None
             return self._from_pyseries(f(d))
 
-        if isinstance(other, Sequence) and not isinstance(other, str):
+        if is_sequence(other):
             if self.dtype in (List, Array):
                 other = [other]
             other = Series("", other)

--- a/py-polars/tests/unit/series/test_equals.py
+++ b/py-polars/tests/unit/series/test_equals.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from datetime import datetime
 
+import numpy as np
 import pytest
 
 import polars as pl
@@ -98,6 +99,42 @@ def test_eq_list() -> None:
 
     result = s == 1
     expected = pl.Series([True, True])
+    assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        np.int16,
+        np.int32,
+        np.int64,
+        np.float32,
+        np.float64,
+        str,
+        bytes,
+        "<U4",
+        "S4",
+        "datetime64[ns]",
+        "timedelta64[ns]",
+    ],
+)
+def test_eq_np(dtype: str | type) -> None:
+    s = pl.Series(np.array([1, 1234, 1], dtype=dtype))
+
+    result = s == np.array([1, 2, 1], dtype=dtype)
+    expected = pl.Series([True, False, True])
+    assert_series_equal(result, expected)
+
+    result = s == np.array([1, 1234, 1], dtype=dtype)
+    expected = pl.Series([True, True, True])
+    assert_series_equal(result, expected)
+
+    result = s == np.array([1234, 1, 5], dtype=dtype)
+    expected = pl.Series([False, False, False])
+    assert_series_equal(result, expected)
+
+    result = s == np.array(1, dtype=dtype)
+    expected = pl.Series([True, False, True])
     assert_series_equal(result, expected)
 
 


### PR DESCRIPTION
Implements proposed fix to https://github.com/pola-rs/polars/issues/26164, i.e. makes `Series` equality with `np.ndarray` work.

EDIT: Sorry, I forgot to post screenshot of tests am rerunning them now.