### PR TITLE
build: Address a macOS-specific compile issue

### DIFF
--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_dispatch.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_dispatch.rs
@@ -328,19 +328,21 @@ pub trait SeriesJoin: SeriesSealed + Sized {
 
                 use BitRepr as B;
                 match (lhs, rhs) {
-                    (B::U8(lhs), B::U8(rhs)) => group_join_inner(&lhs, &rhs, validate, nulls_equal),
+                    (B::U8(lhs), B::U8(rhs)) => {
+                        group_join_inner::<UInt8Type>(&lhs, &rhs, validate, nulls_equal)
+                    },
                     (B::U16(lhs), B::U16(rhs)) => {
-                        group_join_inner(&lhs, &rhs, validate, nulls_equal)
+                        group_join_inner::<UInt16Type>(&lhs, &rhs, validate, nulls_equal)
                     },
                     (B::U32(lhs), B::U32(rhs)) => {
-                        group_join_inner(&lhs, &rhs, validate, nulls_equal)
+                        group_join_inner::<UInt32Type>(&lhs, &rhs, validate, nulls_equal)
                     },
                     (B::U64(lhs), BitRepr::U64(rhs)) => {
-                        group_join_inner(&lhs, &rhs, validate, nulls_equal)
+                        group_join_inner::<UInt64Type>(&lhs, &rhs, validate, nulls_equal)
                     },
                     #[cfg(feature = "dtype-u128")]
                     (B::U128(lhs), BitRepr::U128(rhs)) => {
-                        group_join_inner(&lhs, &rhs, validate, nulls_equal)
+                        group_join_inner::<UInt128Type>(&lhs, &rhs, validate, nulls_equal)
                     },
                     _ => {
                         polars_bail!(


### PR DESCRIPTION
Not sure why this only just appeared, but I've been having issues incrementally compiling (on macOS) this week and finally sat down to fix it. The issue is shown in the following trace when running `make pre-commit`:
```
cargo clippy --workspace --all-targets --all-features --locked -- -D warnings -D clippy::dbg_macro

  Checking polars-ops v0.52.0 (/Users/.../polars/crates/polars-ops)
  error[E0275]: overflow evaluating the requirement `&itertools::groupbylazy::ChunkBy<_, _, _>: std::iter::IntoIterator`
  --> crates/polars-ops/src/frame/join/hash_join/single_keys_dispatch.rs:331:49
  |
  331 |                     (B::U8(lhs), B::U8(rhs)) => group_join_inner(&lhs, &rhs, validate, nulls_equal),
  |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: consider increasing the recursion limit by adding a `#![recursion_limit = "2048"]` attribute to your crate (`polars_ops`)
  = note: required for `&objc2::rc::retained::Retained<itertools::groupbylazy::ChunkBy<_, _, _>>` to implement `std::iter::IntoIterator`
  = note: 1021 redundant requirements hidden
  = note: required for `&Retained<Retained<Retained<Retained<Retained<Retained<Retained<Retained<Retained<Retained<Retained<Retained<...>>>>>>>>>>>>` to implement `for<'a> std::iter::IntoIterator`
  note: required by a bound in `frame::join::hash_join::single_keys_dispatch::group_join_inner`
  --> crates/polars-ops/src/frame/join/hash_join/single_keys_dispatch.rs:470:27
  |
  462 | fn group_join_inner<T>(
  |    ---------------- required by a bound in this function
  ...
  470 |     for<'a> &'a T::Array: IntoIterator<Item = Option<&'a T::Physical<'a>>>,
  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `group_join_inner`
  = note: the full name for the type has been written to '/Users/.../polars/target/debug/deps/polars_ops-e872de6c9e3c07b0.long-type-6766950214240393978.txt'
  = note: consider using `--verbose` to print the full type name to the console
```
---

The suggestion to increase the recursion limit is wrong - the real clue is in the reference to `objc2::rc::retained::Retained`, which is an Objective-C binding crate that has nothing to do with our code, indicating `clippy` type inference went a bit rogue (`grep` seems to indicate that it gets pulled in incidentally via the `arboard` crate).

The fix is thankfully simple; making a small handful of types explicit is sufficient to put `clippy` back on track 👍 