### PR TITLE
chore(rust): In merge-sorted node, when buffering, request a stop on *every* unbuffered morsel

### DIFF
--- a/crates/polars-stream/src/nodes/merge_sorted.rs
+++ b/crates/polars-stream/src/nodes/merge_sorted.rs
@@ -289,16 +289,11 @@ impl ComputeNode for MergeSortedNode {
                 ) {
                     // If a stop was requested, we need to buffer the remaining
                     // morsels and trigger a phase transition.
-                    let Ok(morsel) = port.recv().await else {
-                        return;
-                    };
 
-                    // Request the port stop producing morsels.
-                    morsel.source_token().stop();
-
-                    // Buffer all the morsels that were already produced.
-                    unmerged.push_back(morsel.into_df());
                     while let Ok(morsel) = port.recv().await {
+                        // Request the port stop producing morsels.
+                        morsel.source_token().stop();
+                        // Buffer all the morsels that were already produced.
                         unmerged.push_back(morsel.into_df());
                     }
                 }


### PR DESCRIPTION
In case the incoming morsels come from different sources, we may need to request a `stop()` for multiple different sources. Otherwise, only one sender may receive the stop request, but another will keep sending.

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
