### PR TITLE
perf: Prefetch compressed reader

### DIFF
--- a/crates/polars-io/src/csv/read/parser.rs
+++ b/crates/polars-io/src/csv/read/parser.rs
@@ -15,7 +15,7 @@ use super::options::{CommentPrefix, NullValuesCompiled};
 use super::splitfields::SplitFields;
 use crate::csv::read::read_until_start_and_infer_schema;
 use crate::prelude::CsvReadOptions;
-use crate::utils::compression::CompressedReader;
+use crate::utils::compression::{CompressedReader, ReaderPrefetch};
 
 /// Read the number of rows without parsing columns
 /// useful for count(*) queries
@@ -69,7 +69,7 @@ pub fn count_rows_from_slice_par(
     skip_rows_before_header: usize,
     skip_rows_after_header: usize,
 ) -> PolarsResult<usize> {
-    let mut reader = CompressedReader::try_new(mem_slice)?;
+    let mut reader = CompressedReader::try_new(mem_slice, ReaderPrefetch::Auto)?;
 
     let reader_options = CsvReadOptions {
         parse_options: Arc::new(CsvParseOptions {

--- a/crates/polars-io/src/csv/read/read_impl.rs
+++ b/crates/polars-io/src/csv/read/read_impl.rs
@@ -21,7 +21,7 @@ use crate::RowIndex;
 use crate::csv::read::{CsvReadOptions, read_until_start_and_infer_schema};
 use crate::mmap::ReaderBytes;
 use crate::predicates::PhysicalIoExpr;
-use crate::utils::compression::{CompressedReader, SupportedCompression};
+use crate::utils::compression::{CompressedReader, ReaderPrefetch, SupportedCompression};
 use crate::utils::update_row_counts2;
 
 pub fn cast_columns(
@@ -192,7 +192,7 @@ impl<'a> CoreReader<'a> {
             },
             ReaderBytes::Owned(slice) => slice.clone(),
         };
-        let mut compressed_reader = CompressedReader::try_new(reader_slice)?;
+        let mut compressed_reader = CompressedReader::try_new(reader_slice, ReaderPrefetch::Auto)?;
 
         let read_options = CsvReadOptions {
             parse_options: parse_options.clone(),

--- a/crates/polars-lazy/src/scan/csv.rs
+++ b/crates/polars-lazy/src/scan/csv.rs
@@ -7,7 +7,7 @@ use polars_io::csv::read::{
     read_until_start_and_infer_schema,
 };
 use polars_io::path_utils::expand_paths;
-use polars_io::utils::compression::CompressedReader;
+use polars_io::utils::compression::{CompressedReader, ReaderPrefetch};
 use polars_io::{HiveOptions, RowIndex};
 use polars_utils::mmap::MemSlice;
 use polars_utils::pl_path::PlRefPath;
@@ -256,7 +256,7 @@ impl LazyCsvReader {
         let n_threads = self.read_options.n_threads;
 
         let infer_schema = |bytes: MemSlice| {
-            let mut reader = CompressedReader::try_new(bytes)?;
+            let mut reader = CompressedReader::try_new(bytes, ReaderPrefetch::None)?;
 
             let (inferred_schema, _) =
                 read_until_start_and_infer_schema(&self.read_options, None, None, &mut reader)?;

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
@@ -8,7 +8,7 @@ use polars_io::csv::read::streaming::read_until_start_and_infer_schema;
 #[cfg(feature = "cloud")]
 use polars_io::pl_async::get_runtime;
 use polars_io::prelude::*;
-use polars_io::utils::compression::CompressedReader;
+use polars_io::utils::compression::{CompressedReader, ReaderPrefetch};
 
 use super::*;
 
@@ -366,7 +366,7 @@ pub fn csv_file_info(
     let infer_schema_func = |i| {
         let source = sources.at(i);
         let mem_slice = source.to_memslice_possibly_async(run_async, cache_entries.as_ref(), i)?;
-        let mut reader = CompressedReader::try_new(mem_slice)?;
+        let mut reader = CompressedReader::try_new(mem_slice, ReaderPrefetch::None)?;
 
         let mut first_row_len = 0;
         let (schema, _) = read_until_start_and_infer_schema(
@@ -465,7 +465,8 @@ pub fn ndjson_file_info(
     } else {
         let mem_slice =
             first_scan_source.to_memslice_possibly_async(run_async, cache_entries.as_ref(), 0)?;
-        let mut reader = BufReader::new(CompressedReader::try_new(mem_slice)?);
+        let mut reader =
+            BufReader::new(CompressedReader::try_new(mem_slice, ReaderPrefetch::None)?);
 
         Arc::new(polars_io::ndjson::infer_schema(
             &mut reader,

--- a/crates/polars-stream/src/nodes/io_sources/csv.rs
+++ b/crates/polars-stream/src/nodes/io_sources/csv.rs
@@ -13,7 +13,7 @@ use polars_io::prelude::_csv_read_internal::{
 };
 use polars_io::prelude::buffer::validate_utf8;
 use polars_io::prelude::{CsvEncoding, CsvParseOptions, CsvReadOptions};
-use polars_io::utils::compression::CompressedReader;
+use polars_io::utils::compression::{CompressedReader, ReaderPrefetch};
 use polars_io::utils::slice::SplitSlicePosition;
 use polars_plan::dsl::ScanSource;
 use polars_utils::IdxSize;
@@ -165,7 +165,8 @@ impl FileReader for CsvFileReader {
             _ => {},
         }
 
-        let mut reader = CompressedReader::try_new(self.cached_bytes.clone().unwrap())?;
+        let mut reader =
+            CompressedReader::try_new(self.cached_bytes.clone().unwrap(), ReaderPrefetch::Auto)?;
 
         let (inferred_schema, base_leftover) = read_until_start_and_infer_schema(
             &self.options,


### PR DESCRIPTION
In addition to chunk L2 prefetching, madvise full slice if possible. This should improve cold reading and future reading.

`scan_csv + sum` for 1.9GB CSV native Rust application includes Polars startup time:

- hot OS cache: ~443 ms -> ~441ms
- cold OS cache ~1860ms -> ~1874ms

OS cache cleaned via `hyperfine -n 5 "sync; sudo sh -c "echo 3 > /proc/sys/vm/drop_caches" && <bin> <path.csv>`

So not really an improvement.
