### PR TITLE
refactor(rust): Use NullChunked as default for Series

### DIFF
--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -1090,6 +1090,12 @@ impl Series {
     }
 }
 
+impl Default for Series {
+    fn default() -> Self {
+        NullChunked::new(PlSmallStr::EMPTY, 0).into_series()
+    }
+}
+
 impl Deref for Series {
     type Target = dyn SeriesTrait;
 
@@ -1101,12 +1107,6 @@ impl Deref for Series {
 impl<'a> AsRef<dyn SeriesTrait + 'a> for Series {
     fn as_ref(&self) -> &(dyn SeriesTrait + 'a) {
         self.0.as_ref()
-    }
-}
-
-impl Default for Series {
-    fn default() -> Self {
-        Int64Chunked::default().into_series()
     }
 }
 


### PR DESCRIPTION
I found it very strange we used `Int64Chunked` as the default for `Series`, I think `NullChunked` makes a lot more sense.