### PR TITLE
fix(python): Check for list of types

### DIFF
--- a/py-polars/src/polars/_utils/construction/series.py
+++ b/py-polars/src/polars/_utils/construction/series.py
@@ -94,6 +94,11 @@ def sequence_to_pyseries(
     if isinstance(values, range):
         return range_to_series(name, values, dtype=dtype)._s
 
+    value = get_first_non_none(values)
+    if type(value) is type:
+        msg = "can't construct Series of types"
+        raise TypeError(msg)
+
     # empty sequence
     if len(values) == 0 and dtype is None:
         # if dtype for empty sequence could be guessed
@@ -108,7 +113,6 @@ def sequence_to_pyseries(
     py_temporal_types = {date, datetime, timedelta, time}
     pl_temporal_types = {Date, Datetime, Duration, Time}
 
-    value = get_first_non_none(values)
     if value is not None:
         if (
             dataclasses.is_dataclass(value)

--- a/py-polars/tests/unit/meta/test_errors.py
+++ b/py-polars/tests/unit/meta/test_errors.py
@@ -655,10 +655,16 @@ def test_err_invalid_comparison() -> None:
         _ = pl.Series("a", [date(2020, 1, 1)]) == pl.Series("b", [True])
 
     with pytest.raises(
+        TypeError,
+        match="can't construct Series of types",
+    ):
+        _ = pl.Series("a", [object()]) == pl.Series("b", [object])
+
+    with pytest.raises(
         InvalidOperationError,
         match="could not apply comparison on series of dtype 'object; operand names: 'a', 'b'",
     ):
-        _ = pl.Series("a", [object()]) == pl.Series("b", [object])
+        _ = pl.Series("a", [object()]) == pl.Series("b", [object()])
 
 
 def test_no_panic_pandas_nat() -> None:

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -580,11 +580,6 @@ def test_group_by_agg_input_types(input: Any) -> None:
     assert_frame_equal(result, expected)
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason="Test isolation issue: fails in full test suite but passes individually. "
-    "Known to fail after test_errors.py::test_err_invalid_comparison due to object() type pollution.",
-)
 @pytest.mark.parametrize("input", [str, "b".join])
 def test_group_by_agg_bad_input_types(input: Any) -> None:
     df = pl.LazyFrame({"a": [1, 1, 2, 2], "b": [1, 2, 3, 4]})

--- a/py-polars/tests/unit/operations/test_group_by_dynamic.py
+++ b/py-polars/tests/unit/operations/test_group_by_dynamic.py
@@ -914,11 +914,6 @@ def test_group_by_dynamic_agg_input_types(input: Any) -> None:
     assert_frame_equal(result, expected)
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason="Test isolation issue: fails in full test suite but passes individually. "
-    "Known to fail after test_errors.py::test_err_invalid_comparison due to object() type pollution.",
-)
 @pytest.mark.parametrize("input", [str, "b".join])
 def test_group_by_dynamic_agg_bad_input_types(input: Any) -> None:
     df = pl.LazyFrame({"index_column": [0, 1, 2, 3], "b": [1, 3, 1, 2]}).set_sorted(

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -132,11 +132,6 @@ def test_rolling_agg_input_types(input: Any, dtype: PolarsIntegerType) -> None:
     assert_frame_equal(result, expected)
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason="Test isolation issue: fails in full test suite but passes individually. "
-    "Known to fail after test_errors.py::test_err_invalid_comparison due to object() type pollution.",
-)
 @pytest.mark.parametrize("input", [str, "b".join])
 def test_rolling_agg_bad_input_types(input: Any) -> None:
     df = pl.LazyFrame({"index_column": [0, 1, 2, 3], "b": [1, 3, 1, 2]}).set_sorted(


### PR DESCRIPTION
This avoids modifying shared global state in a way that can be later observed.

Fixes: https://github.com/pola-rs/polars/issues/26182

Also removes xpass warnings in pytest.
