### PR TITLE
feat: Use same sort order for expanded paths across local / cloud / directory / glob

### DIFF
--- a/crates/polars-io/src/path_utils/hugging_face.rs
+++ b/crates/polars-io/src/path_utils/hugging_face.rs
@@ -321,7 +321,7 @@ pub(super) async fn expand_paths_hf(
         }
 
         if let Some(mut_slice) = out_paths.get_mut(sort_start_idx..) {
-            mut_slice.sort_unstable();
+            <[PlRefPath]>::sort_unstable(mut_slice);
         }
     }
 

--- a/crates/polars-io/src/path_utils/mod.rs
+++ b/crates/polars-io/src/path_utils/mod.rs
@@ -424,12 +424,7 @@ pub fn expand_paths_hive(
 
                 let sort_start_idx = out_paths.paths.len();
 
-                if !glob || !has_glob(path.as_bytes()) {
-                    let (expand_start_idx, paths) =
-                        expand_path_cloud(path.into_owned(), cloud_options.as_ref())?;
-                    out_paths.extend_from_slice(&paths);
-                    hive_idx_tracker.update(expand_start_idx, path_idx)?;
-                } else {
+                if glob && has_glob(path.as_bytes()) {
                     hive_idx_tracker.update(0, path_idx)?;
 
                     let iter = crate::pl_async::get_runtime().block_in_place_on(
@@ -443,10 +438,15 @@ pub fn expand_paths_hive(
                         // URI result.
                         out_paths.extend(iter.iter().map(|x| &x[7..]).map(PlRefPath::new))
                     };
+                } else {
+                    let (expand_start_idx, paths) =
+                        expand_path_cloud(path.into_owned(), cloud_options.as_ref())?;
+                    out_paths.extend_from_slice(&paths);
+                    hive_idx_tracker.update(expand_start_idx, path_idx)?;
                 };
 
                 if let Some(mut_slice) = out_paths.paths.get_mut(sort_start_idx..) {
-                    mut_slice.sort_unstable();
+                    <[PlRefPath]>::sort_unstable(mut_slice);
                 }
             }
         }
@@ -513,7 +513,7 @@ pub fn expand_paths_hive(
             };
 
             if let Some(mut_slice) = out_paths.paths.get_mut(sort_start_idx..) {
-                mut_slice.sort_unstable();
+                <[PlRefPath]>::sort_unstable(mut_slice);
             }
         }
     }

--- a/py-polars/tests/unit/io/test_scan.py
+++ b/py-polars/tests/unit/io/test_scan.py
@@ -1281,9 +1281,11 @@ def test_scan_file_uri_hostname_component() -> None:
 
 @pytest.mark.write_disk
 @pytest.mark.parametrize("polars_force_async", ["0", "1"])
+@pytest.mark.parametrize("n_repeats", [1, 2])
 def test_scan_path_expansion_sorting_24528(
     tmp_path: Path,
     polars_force_async: str,
+    n_repeats: int,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("POLARS_FORCE_ASYNC", polars_force_async)
@@ -1295,21 +1297,21 @@ def test_scan_path_expansion_sorting_24528(
         pl.DataFrame({"relpath": p}).write_parquet(tmp_path / p)
 
     assert_frame_equal(
-        pl.scan_parquet(tmp_path).collect(),
-        pl.DataFrame({"relpath": relpaths}),
+        pl.scan_parquet(n_repeats * [tmp_path]).collect(),
+        pl.DataFrame({"relpath": n_repeats * relpaths}),
     )
 
     assert_frame_equal(
-        pl.scan_parquet(f"{tmp_path}/**/*").collect(),
-        pl.DataFrame({"relpath": relpaths}),
+        pl.scan_parquet(n_repeats * [f"{tmp_path}/**/*"]).collect(),
+        pl.DataFrame({"relpath": n_repeats * relpaths}),
     )
 
     assert_frame_equal(
-        pl.scan_parquet(format_file_uri(tmp_path) + "/").collect(),
-        pl.DataFrame({"relpath": relpaths}),
+        pl.scan_parquet(n_repeats * [format_file_uri(tmp_path) + "/"]).collect(),
+        pl.DataFrame({"relpath": n_repeats * relpaths}),
     )
 
     assert_frame_equal(
-        pl.scan_parquet(format_file_uri(f"{tmp_path}/**/*")).collect(),
-        pl.DataFrame({"relpath": relpaths}),
+        pl.scan_parquet(n_repeats * [format_file_uri(f"{tmp_path}/**/*")]).collect(),
+        pl.DataFrame({"relpath": n_repeats * relpaths}),
     )


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/24528

Paths are now all sorted lexically.

This could be considered a breaking change as it may change the file scan ordering when scanning multiple files, but I think this is worth the benefit in making the paths sort consistently.
