### PR TITLE
build: Address remaining Python 3.14 issues with `make requirements-all`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,8 @@ requirements:  ## Install/refresh Python project requirements
 
 .PHONY: requirements-all
 requirements-all:  ## Install/refresh all Python requirements (including those needed for CI tests)
-	$(MAKE) requirements
 	$(VENV_BIN)/uv pip install --upgrade --compile-bytecode -r py-polars/requirements-ci.txt
+	$(MAKE) requirements
 
 .PHONY: build
 build: .venv  ## Compile and install Python Polars for development

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -7,12 +7,14 @@ matplotlib
 plotnine
 seaborn
 plotly
-numba >= 0.54; python_version < '3.13'  # numba does not support Python 3.13
+numba >= 0.54
 numpy
 
-mkdocs-material==9.6.1
-mkdocs-macros-plugin==1.3.7
-mkdocs-redirects==1.2.1
-material-plausible-plugin==0.3.0
-markdown-exec[ansi]==1.10.0
+# one of the associated packages (watchdog) only has macOS wheels up to py3.13 at the moment
+# ref: https://github.com/gorakhargosh/watchdog/issues/1143
+mkdocs-material==9.6.20; python_version < "3.14" or sys_platform != "darwin"
+mkdocs-macros-plugin==1.3.7; python_version < "3.14" or sys_platform != "darwin"
+mkdocs-redirects==1.2.1; python_version < "3.14" or sys_platform != "darwin"
+material-plausible-plugin==0.3.0; python_version < "3.14" or sys_platform != "darwin"
+markdown-exec[ansi]==1.10.0; python_version < "3.14" or sys_platform != "darwin"
 pygithub==2.6.1

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -109,6 +109,7 @@ clean:  ## Clean up caches and build artifacts
 	@rm -f .coverage
 	@rm -f coverage.xml
 	@rm -f polars/polars.abi3.so
+	@find runtime -type f -name '*.so' -delete
 	@find . -type f -name '*.py[co]' -delete -or -type d -name __pycache__ -exec rm -r {} +
 
 .PHONY: help

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -17,8 +17,8 @@ pip
 
 polars-cloud
 # Interop
+numba >= 0.54
 numpy
-numba >= 0.54; python_version < '3.14'  # Numba can lag Python releases
 pandas
 pyarrow
 pydantic>=2.0.0
@@ -29,7 +29,7 @@ sqlalchemy
 adbc-driver-manager; platform_system != 'Windows'
 adbc-driver-sqlite; platform_system != 'Windows'
 aiosqlite
-connectorx>=0.4.5a2
+connectorx>=0.4.5
 # Cloud
 azure-identity
 boto3
@@ -41,7 +41,7 @@ s3fs
 fastexcel>=0.11.5
 openpyxl
 xlsx2csv
-xlsxwriter<=3.2.5
+xlsxwriter>=3.2.9
 # Other I/O
 deltalake>=1.1.4
 # Csv


### PR DESCRIPTION
We still had a few minor gremlins if you wanted to install all the dev dependencies on Python 3.14 using `make requirements-all`; everything is now resolved.

### Python 3.14

* Can remove the Python pin on `numba` (supports 3.14 since 0.60).
* There is now a non-alpha release[^1] of `connectorx`.
* Have `requirements-ci.txt` install before `requirements-dev.txt` 
  (solves a `numpy` version issue with `numba`).

### Miscellaneous

* Ensure potentially stale runtime `*.so` files are removed when calling `make clean`.
* Replace the upper bound on `xlsxwriter` with a lower-bound (typing issue was fixed).
* Added Python upper bound on `mkdocs` packages for macOS (still no wheel[^2] for one of its key dependencies on Python 3.14, so it fails to install).

Confirmed it all now installs/builds cleanly, every test passes, etc 👍

[^1]: https://github.com/sfu-db/connector-x/releases/tag/v0.4.5
[^2]: https://github.com/gorakhargosh/watchdog/issues/1143