### PR TITLE
perf: Improve string slicing performance

### DIFF
--- a/crates/polars-ops/src/chunked_array/strings/substring.rs
+++ b/crates/polars-ops/src/chunked_array/strings/substring.rs
@@ -1,9 +1,122 @@
-use std::cmp::Ordering;
-
 use arrow::array::View;
 use polars_core::prelude::arity::{binary_elementwise, ternary_elementwise, unary_elementwise};
 use polars_core::prelude::{ChunkFullNull, Int64Chunked, StringChunked, UInt64Chunked};
 use polars_error::{PolarsResult, polars_ensure};
+
+fn is_utf8_codepoint_start(b: u8) -> bool {
+    // The top two bits of a continuation byte are 10. Any other value is a
+    // starting byte. We can use signed comparison to test for this in one
+    // instruction, as the top bits 11, 00 and 01 are all more positive and thus
+    // larger in signed comparison.
+    (b as i8) >= (0b1100_0000_u8 as i8)
+}
+
+/// Similar to char_to_byte_idx but if `char_idx` would be out-of-bounds the
+/// number of codepoints in s is returned as an error.
+pub fn char_to_byte_idx_or_cp_count(s: &str, char_idx: usize) -> Result<usize, usize> {
+    let bytes = s.as_bytes();
+    if char_idx == 0 {
+        return Ok(0);
+    }
+
+    let mut offset = 0;
+    let mut num_chars_seen = 0;
+
+    // Auto-vectorized bulk processing, but skip if index is small.
+    if char_idx >= 16 {
+        while let Some(chunk) = bytes.get(offset..offset + 16) {
+            let chunk_seen: usize = chunk
+                .iter()
+                .map(|b| is_utf8_codepoint_start(*b) as usize)
+                .sum();
+            if num_chars_seen + chunk_seen > char_idx {
+                break;
+            }
+            offset += 16;
+            num_chars_seen += chunk_seen;
+        }
+    }
+
+    while let Some(b) = bytes.get(offset) {
+        num_chars_seen += is_utf8_codepoint_start(*b) as usize;
+        if num_chars_seen > char_idx {
+            return Ok(offset);
+        }
+        offset += 1;
+    }
+
+    debug_assert!(offset == bytes.len());
+    Err(num_chars_seen)
+}
+
+/// Given an offset to the start of the `char_idx`th codepoint, returns the
+/// equivalent offset in bytes.
+///
+/// If `char_idx` would be out-of-bounds s.len() is returned.
+pub fn char_to_byte_idx(s: &str, char_idx: usize) -> usize {
+    if char_idx >= s.len() {
+        // No need to even count.
+        s.len()
+    } else {
+        char_to_byte_idx_or_cp_count(s, char_idx).unwrap_or(s.len())
+    }
+}
+
+/// Similar to rev_char_to_byte_idx but if `char_idx` would be out-of-bounds the
+/// number of codepoints in s is returned as an error.
+pub fn rev_char_to_byte_idx_or_cp_count(s: &str, rev_char_idx: usize) -> Result<usize, usize> {
+    let bytes = s.as_bytes();
+    if rev_char_idx == 0 {
+        return Ok(bytes.len());
+    }
+
+    let mut offset = s.len();
+    let mut num_chars_seen = 0;
+
+    // Auto-vectorized bulk processing, but skip if index is small.
+    if rev_char_idx >= 16 {
+        while offset >= 16 {
+            let chunk = unsafe { bytes.get_unchecked(offset - 16..offset) };
+            let chunk_seen: usize = chunk
+                .iter()
+                .map(|b| is_utf8_codepoint_start(*b) as usize)
+                .sum();
+            if num_chars_seen + chunk_seen >= rev_char_idx {
+                break;
+            }
+            offset -= 16;
+            num_chars_seen += chunk_seen;
+        }
+    }
+
+    while offset > 0 {
+        offset -= 1;
+        let byte = unsafe { bytes.get_unchecked(offset) };
+        num_chars_seen += is_utf8_codepoint_start(*byte) as usize;
+        if num_chars_seen >= rev_char_idx {
+            return Ok(offset);
+        }
+    }
+
+    debug_assert!(offset == 0);
+    Err(num_chars_seen)
+}
+
+/// Counts rev_char_idx code points from *the end* of the string, returning an
+/// offset in bytes where this codepoint ends.
+///
+/// For example, rev_char_to_byte_idx(0, s) returns s.len(), and
+/// rev_char_to_byte_idx(1, s) returns s.len() - width(last_codepoint_in_s).
+///
+/// If rev_char_idx is large enough that we would go out of bounds, 0 is returned.
+pub fn rev_char_to_byte_idx(s: &str, rev_char_idx: usize) -> usize {
+    if rev_char_idx >= s.len() {
+        // No need to even count.
+        0
+    } else {
+        rev_char_to_byte_idx_or_cp_count(s, rev_char_idx).unwrap_or(0)
+    }
+}
 
 fn head_binary(opt_str_val: Option<&str>, opt_n: Option<i64>) -> Option<&str> {
     if let (Some(str_val), Some(n)) = (opt_str_val, opt_n) {
@@ -15,28 +128,10 @@ fn head_binary(opt_str_val: Option<&str>, opt_n: Option<i64>) -> Option<&str> {
 }
 
 fn head_binary_values(str_val: &str, n: i64) -> usize {
-    match n.cmp(&0) {
-        Ordering::Equal => 0,
-        Ordering::Greater => {
-            if n as usize >= str_val.len() {
-                return str_val.len();
-            }
-            // End after the nth codepoint.
-            str_val
-                .char_indices()
-                .nth(n as usize)
-                .map(|(idx, _)| idx)
-                .unwrap_or(str_val.len())
-        },
-        _ => {
-            // End after the nth codepoint from the end.
-            str_val
-                .char_indices()
-                .rev()
-                .nth((-n - 1) as usize)
-                .map(|(idx, _)| idx)
-                .unwrap_or(0)
-        },
+    if n >= 0 {
+        char_to_byte_idx(str_val, n as usize)
+    } else {
+        rev_char_to_byte_idx(str_val, (-n) as usize)
     }
 }
 
@@ -50,31 +145,10 @@ fn tail_binary(opt_str_val: Option<&str>, opt_n: Option<i64>) -> Option<&str> {
 }
 
 fn tail_binary_values(str_val: &str, n: i64) -> usize {
-    // `max_len` is guaranteed to be at least the total number of characters.
-    let max_len = str_val.len();
-
-    match n.cmp(&0) {
-        Ordering::Equal => max_len,
-        Ordering::Greater => {
-            if n as usize >= max_len {
-                return 0;
-            }
-            // Start from nth codepoint from the end
-            str_val
-                .char_indices()
-                .rev()
-                .nth((n - 1) as usize)
-                .map(|(idx, _)| idx)
-                .unwrap_or(0)
-        },
-        _ => {
-            // Start after the nth codepoint
-            str_val
-                .char_indices()
-                .nth((-n) as usize)
-                .map(|(idx, _)| idx)
-                .unwrap_or(max_len)
-        },
+    if n >= 0 {
+        rev_char_to_byte_idx(str_val, n as usize)
+    } else {
+        char_to_byte_idx(str_val, (-n) as usize)
     }
 }
 
@@ -92,40 +166,40 @@ fn substring_ternary_offsets(
     ))
 }
 
-pub fn substring_ternary_offsets_value(str_val: &str, offset: i64, length: u64) -> (usize, usize) {
+pub fn substring_ternary_offsets_value(
+    str_val: &str,
+    offset: i64,
+    mut length: u64,
+) -> (usize, usize) {
     // Fast-path: always empty string.
     if length == 0 || offset >= str_val.len() as i64 {
         return (0, 0);
     }
 
-    let mut indices = str_val.char_indices().map(|(o, _)| o);
-    let mut length_reduction = 0;
     let start_byte_offset = if offset >= 0 {
-        indices.nth(offset as usize).unwrap_or(str_val.len())
+        char_to_byte_idx(str_val, offset as usize)
     } else {
-        // If `offset` is negative, it counts from the end of the string.
-        let mut chars_skipped = 0;
-        let found = indices
-            .inspect(|_| chars_skipped += 1)
-            .nth_back((-offset - 1) as usize);
+        // Fast-path: always empty string.
+        let end_offset_upper_bound = offset
+            .saturating_add(str_val.len() as i64)
+            .saturating_add(length.try_into().unwrap_or(i64::MAX));
+        if end_offset_upper_bound < 0 {
+            return (0, 0);
+        }
 
-        // If we didn't find our char that means our offset was so negative it
-        // is before the start of our string. This means our length must be
-        // reduced, assuming it is finite.
-        if let Some(off) = found {
-            off
-        } else {
-            length_reduction = (-offset) as usize - chars_skipped;
-            0
+        match rev_char_to_byte_idx_or_cp_count(str_val, (-offset) as usize) {
+            Ok(so) => so,
+            Err(n_cp) => {
+                // Our offset was so negative it is before the start of our string.
+                // This means our length must be reduced, assuming it is finite.
+                length = length.saturating_sub((-offset) as u64 - n_cp as u64);
+                0
+            },
         }
     };
 
-    let str_val = &str_val[start_byte_offset..];
-    let mut indices = str_val.char_indices().map(|(o, _)| o);
-    let stop_byte_offset = indices
-        .nth((length as usize).saturating_sub(length_reduction))
-        .unwrap_or(str_val.len());
-    (start_byte_offset, stop_byte_offset + start_byte_offset)
+    let stop_byte_offset = char_to_byte_idx(&str_val[start_byte_offset..], length as usize);
+    (start_byte_offset, start_byte_offset + stop_byte_offset)
 }
 
 fn substring_ternary(


### PR DESCRIPTION
A simple example adapted from @alexander-beedie:

```python
N = 1
df = pl.DataFrame({
    "foo": [
        "apple and pears" * N,
        "banana, pineapple" * N,
        "orange and grapefruit" * N,
        "miscellaneous" * N,
        "xyz" * N,
    ] * 1_000_000,
})
print(timeit(lambda: df.select(pl.col("foo").str.slice(5)), number=10))
```

Results:

```
        N = 1   N = 100
main    1.58    198.5
pr      0.53    2.26
```

So between 3x and 100x+ faster depending on the length of strings being sliced (and the offset(s)). The 3x is mostly just real raw performance of the kernel, the 100x+ part is algorithmic - before we would always scan the full string to evaluate the `length` portion, regardless of whether that was necessary or not.