### PR TITLE
chore(python): Pin pandas to 2.x for now

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,5 +1,5 @@
 altair
-pandas
+pandas < 3
 pyarrow
 graphviz
 hvplot

--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -1,6 +1,6 @@
 hypothesis
 numpy
-pandas
+pandas < 3
 pyarrow
 
 sphinx==8.1.3

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -19,7 +19,7 @@ polars-cloud
 # Interop
 numba >= 0.54
 numpy
-pandas
+pandas < 3
 pyarrow
 pydantic>=2.0.0
 # Datetime / time zones


### PR DESCRIPTION
We'll figure out the Pandas 3.x compatibility in a dedicated PR, this unblocks the CI for now.