### PR TITLE
fix(python): Apply thousands_separator to count/null_count in describe() for non-numeric columns

### DIFF
--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -104,6 +104,7 @@ from polars.schema import Schema
 from polars.selectors import by_dtype, expand_selector
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
+    import polars._plr as plr
     from polars._plr import PyLazyFrame, get_engine_affinity
 
 if TYPE_CHECKING:
@@ -119,9 +120,6 @@ if TYPE_CHECKING:
 
     with contextlib.suppress(ImportError):  # Module not available when building docs
         from polars._plr import PyExpr, PySelector
-
-    with contextlib.suppress(ImportError):  # Module not available when building docs
-        import polars._plr as plr
 
     from polars import DataFrame, DataType, Expr
     from polars._dependencies import numpy as np
@@ -1229,14 +1227,32 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         summary = dict(zip(schema, column_metrics, strict=True))
 
         # cast by column type (numeric/bool -> float), (other -> string)
+        # note: for non-numeric columns, count/null_count are formatted with
+        # the thousands_separator config setting to match numeric columns.
+        thousands_sep = plr.get_thousands_separator()
+
+        def _fmt_count(v: int) -> str:
+            """Format count value with thousands separator."""
+            if not thousands_sep:
+                return str(v)
+            return f"{v:,}".replace(",", thousands_sep)
+
         for c in schema:
             summary[c] = [  # type: ignore[assignment]
                 (
                     None
                     if (v is None or isinstance(v, dict))
-                    else (float(v) if (c in has_numeric_result) else str(v))
+                    else (
+                        float(v)
+                        if (c in has_numeric_result)
+                        else (
+                            _fmt_count(int(v))
+                            if metric in ("count", "null_count")
+                            else str(v)
+                        )
+                    )
                 )
-                for v in summary[c]
+                for metric, v in zip(metrics, summary[c], strict=True)
             ]
 
         # return results as a DataFrame


### PR DESCRIPTION
## Summary
- Fixes #25946
- When using `pl.Config(thousands_separator=...)`, the `describe()` method now correctly applies the thousands separator to `count` and `null_count` statistics for non-numeric columns (string, categorical, temporal, etc.)
- Previously, these values were converted to strings without formatting, while numeric columns received proper thousands formatting

## Test plan
- [x] Added test `test_df_describe_thousands_separator_string_columns` that verifies the fix
- [x] All existing `describe()` tests pass

---

This is my first contribution to Polars, so please let me know if anything needs to be adjusted. Happy to make changes!