### PR TITLE
fix(python): Flatten should not convert empty lists to null

### DIFF
--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -5031,7 +5031,7 @@ Consider using {self}.implode() instead"""
         """
         Flatten a list or string column.
 
-        Alias for :func:`Expr.list.explode`.
+        Similar to :func:`Expr.explode`, but does not convert empty lists to null.
 
         Examples
         --------
@@ -5052,7 +5052,7 @@ Consider using {self}.implode() instead"""
         │ b     ┆ [2, 3, 4] │
         └───────┴───────────┘
         """
-        return self.explode(empty_as_null=True, keep_nulls=True)
+        return self.explode(empty_as_null=False, keep_nulls=True)
 
     def explode(self, *, empty_as_null: bool = True, keep_nulls: bool = True) -> Expr:
         """

--- a/py-polars/tests/unit/operations/test_explode.py
+++ b/py-polars/tests/unit/operations/test_explode.py
@@ -28,6 +28,16 @@ def test_group_by_flatten_list() -> None:
     assert_frame_equal(result, expected)
 
 
+# https://github.com/pola-rs/polars/issues/26119
+def test_flatten_empty_list_not_null() -> None:
+    df = pl.DataFrame({"v": []}).cast({"v": pl.List(pl.String)})
+    result = df.select(pl.col("v").implode().flatten())
+
+    # flatten() should not convert empty lists to null
+    assert result.shape == (0, 1)
+    assert result.dtypes == [pl.List(pl.String)]
+
+
 def test_explode_empty_df_3402() -> None:
     df = pl.DataFrame({"a": pa.array([], type=pa.large_list(pa.int32()))})
     assert df.explode("a").dtypes == [pl.Int32]


### PR DESCRIPTION
## Summary
Fixes #26119

### Problem
When calling `flatten()` on an empty list, the result was `null` instead of an empty list:

```python
df = pl.DataFrame({"v": []}).cast({"v": pl.List(pl.Utf8)})
df.select(pl.col("v").implode().flatten())
# Returns: null (wrong)
# Expected: [] (empty list)
```

### Root cause
`flatten()` was calling `explode(empty_as_null=True)`, which converts empty lists to `null`. This parameter was never intended for `flatten()` but was accidentally inherited when `flatten()` was made an alias of `explode()`.

### Solution
- Changed `flatten()` to use `empty_as_null=False` so that empty lists remain empty
- Updated the docstring to clarify that `flatten()` differs from `explode()` in this behavior

## Test plan
- [x] Added test `test_flatten_empty_list_not_null` that verifies the fix
- [x] Existing `flatten()` tests still pass

---

Let me know if this approach works or if you'd prefer a different solution!