### PR TITLE
perf: Disable morsel splitting for fast-count on streaming engine

### DIFF
--- a/crates/polars-expr/src/reduce/convert.rs
+++ b/crates/polars-expr/src/reduce/convert.rs
@@ -25,6 +25,7 @@ pub fn into_reduction(
     node: Node,
     expr_arena: &mut Arena<AExpr>,
     schema: &Schema,
+    is_aggregation_context: bool,
 ) -> PolarsResult<(Box<dyn GroupedReduction>, Vec<Node>)> {
     let get_dt = |node| {
         expr_arena
@@ -94,6 +95,12 @@ pub fn into_reduction(
                 //   project to the height of the DataFrame (in the PhysicalExpr impl).
                 // * This approach is not sound for `update_groups()`, but currently that case is
                 //   not hit (it would need group-by -> len on empty morsels).
+                polars_ensure!(
+                    !is_aggregation_context,
+                    ComputeError:
+                    "not implemented: len() of groups with no columns"
+                );
+
                 let out: Box<dyn GroupedReduction> = new_sum_reduction(DataType::IDX_DTYPE)?;
                 let expr = expr_arena.add(AExpr::Len);
 

--- a/crates/polars-stream/src/nodes/in_memory_source.rs
+++ b/crates/polars-stream/src/nodes/in_memory_source.rs
@@ -22,6 +22,17 @@ impl InMemorySourceNode {
             seq_offset,
         }
     }
+
+    pub fn new_no_morsel_split(source: Arc<DataFrame>, seq_offset: MorselSeq) -> Self {
+        let morsel_size = source.height();
+
+        InMemorySourceNode {
+            source: Some(source),
+            morsel_size,
+            seq: AtomicU64::new(0),
+            seq_offset,
+        }
+    }
 }
 
 impl ComputeNode for InMemorySourceNode {

--- a/crates/polars-stream/src/nodes/io_sources/batch.rs
+++ b/crates/polars-stream/src/nodes/io_sources/batch.rs
@@ -180,6 +180,7 @@ impl FileReader for BatchFnReader {
             predicate: None,
             cast_columns_policy: _,
             num_pipelines: _,
+            disable_morsel_split: _,
             callbacks:
                 FileReaderCallbacks {
                     mut file_schema_tx,

--- a/crates/polars-stream/src/nodes/io_sources/csv.rs
+++ b/crates/polars-stream/src/nodes/io_sources/csv.rs
@@ -137,6 +137,7 @@ impl FileReader for CsvFileReader {
             predicate: None,
             cast_columns_policy: _,
             num_pipelines,
+            disable_morsel_split: _,
             callbacks:
                 FileReaderCallbacks {
                     file_schema_tx,

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/components/projection/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/components/projection/mod.rs
@@ -35,6 +35,10 @@ pub enum Projection {
 }
 
 impl Projection {
+    pub fn is_empty(&self) -> bool {
+        self.projected_schema().is_empty()
+    }
+
     /// Returns the full projected schema, keyed by the output name.
     pub fn projected_schema(&self) -> &SchemaRef {
         match self {

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/components/row_deletions.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/components/row_deletions.rs
@@ -157,6 +157,7 @@ impl DeletionFilesProvider {
                                     predicate: None,
                                     cast_columns_policy: CastColumnsPolicy::ERROR_ON_MISMATCH,
                                     num_pipelines,
+                                    disable_morsel_split: false,
                                     callbacks: FileReaderCallbacks {
                                         file_schema_tx: None,
                                         n_rows_in_file_tx: None,

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/config.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/config.rs
@@ -49,6 +49,7 @@ pub struct MultiScanConfig {
     /// step.
     pub n_readers_pre_init: RelaxedCell<usize>,
     pub max_concurrent_scans: RelaxedCell<usize>,
+    pub disable_morsel_split: bool,
 
     pub verbose: bool,
 }

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/initialization.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/initialization.rs
@@ -42,12 +42,14 @@ pub fn initialize_multi_scan_pipeline(
             reader name: {}, \
             {:?}, \
             n_readers_pre_init: {}, \
-            max_concurrent_scans: {}",
+            max_concurrent_scans: {}, \
+            disable_morsel_split: {}",
             config.sources.len(),
             config.file_reader_builder.reader_name(),
             config.reader_capabilities(),
             config.n_readers_pre_init(),
             config.max_concurrent_scans(),
+            config.disable_morsel_split,
         );
     }
 
@@ -363,6 +365,7 @@ async fn finish_initialize_multi_scan_pipeline(
     let final_output_schema = config.final_output_schema.clone();
     let file_projection_builder = config.file_projection_builder.clone();
     let max_concurrent_scans = config.max_concurrent_scans();
+    let disable_morsel_split = config.disable_morsel_split;
 
     let (started_reader_tx, started_reader_rx) =
         tokio::sync::mpsc::channel(max_concurrent_scans.max(2) - 1);
@@ -387,6 +390,7 @@ async fn finish_initialize_multi_scan_pipeline(
                 missing_columns_policy,
                 forbid_extra_columns: config.forbid_extra_columns.clone(),
                 num_pipelines,
+                disable_morsel_split,
                 verbose,
             },
             verbose,

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/models.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/models.rs
@@ -83,6 +83,7 @@ pub(super) struct StartReaderArgsConstant {
     pub(super) missing_columns_policy: MissingColumnsPolicy,
     pub(super) forbid_extra_columns: Option<ForbidExtraColumns>,
     pub(super) num_pipelines: usize,
+    pub(super) disable_morsel_split: bool,
     pub(super) verbose: bool,
 }
 

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/tasks/reader_starter.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/tasks/reader_starter.rs
@@ -409,6 +409,7 @@ async fn start_reader_impl(
         missing_columns_policy,
         forbid_extra_columns,
         num_pipelines,
+        disable_morsel_split,
         verbose,
     } = constant_args;
 
@@ -605,6 +606,7 @@ async fn start_reader_impl(
         predicate,
         cast_columns_policy: cast_columns_policy.clone(),
         num_pipelines,
+        disable_morsel_split,
         callbacks,
     };
 

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/reader_interface/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/reader_interface/mod.rs
@@ -149,6 +149,7 @@ pub struct BeginReadArgs {
     pub cast_columns_policy: CastColumnsPolicy,
 
     pub num_pipelines: usize,
+    pub disable_morsel_split: bool,
     pub callbacks: FileReaderCallbacks,
     // TODO
     // We could introduce dynamic `Option<Box<dyn Any>>` for the reader to use. That would help
@@ -166,6 +167,7 @@ impl Default for BeginReadArgs {
             // TODO: Use less restrictive default
             cast_columns_policy: CastColumnsPolicy::ERROR_ON_MISMATCH,
             num_pipelines: 1,
+            disable_morsel_split: false,
             callbacks: FileReaderCallbacks::default(),
         }
     }

--- a/crates/polars-stream/src/nodes/io_sources/ndjson/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ndjson/mod.rs
@@ -74,6 +74,7 @@ impl FileReader for NDJsonFileReader {
             pre_slice,
 
             num_pipelines,
+            disable_morsel_split: _,
             callbacks:
                 FileReaderCallbacks {
                     file_schema_tx,

--- a/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
@@ -22,6 +22,7 @@ use super::multi_scan::reader_interface::{
 };
 use crate::async_executor::{self};
 use crate::async_primitives::wait_group::{WaitGroup, WaitToken};
+use crate::morsel::SourceToken;
 use crate::nodes::compute_node_prelude::*;
 use crate::nodes::io_sources::parquet::projection::{
     ArrowFieldProjection, resolve_arrow_field_projections,
@@ -161,6 +162,36 @@ impl FileReader for ParquetFileReader {
             byte_source,
         } = self.init_data.clone().unwrap();
 
+        let n_rows_in_file = self._n_rows_in_file()?;
+
+        let single_morsel_height: Option<usize> = if let BeginReadArgs {
+            projection,
+            row_index: None,
+            pre_slice,
+            predicate: None,
+            cast_columns_policy: _,
+            num_pipelines: _,
+            disable_morsel_split: true,
+            callbacks:
+                FileReaderCallbacks {
+                    file_schema_tx: _,
+                    n_rows_in_file_tx: _,
+                    row_position_on_end_tx: _,
+                },
+        } = &args
+            && projection.is_empty()
+        {
+            let mut h: usize = n_rows_in_file as _;
+
+            if let Some(pre_slice) = pre_slice.clone() {
+                h = usize::min(h, pre_slice.restrict_to_bounds(h).len());
+            }
+
+            Some(h)
+        } else {
+            None
+        };
+
         let BeginReadArgs {
             projection,
             row_index,
@@ -168,6 +199,7 @@ impl FileReader for ParquetFileReader {
             predicate,
             cast_columns_policy,
             num_pipelines,
+            disable_morsel_split,
             callbacks:
                 FileReaderCallbacks {
                     file_schema_tx,
@@ -177,15 +209,6 @@ impl FileReader for ParquetFileReader {
         } = args;
 
         let file_schema = self._file_schema().clone();
-
-        let projected_arrow_fields = resolve_arrow_field_projections(
-            &file_arrow_schema,
-            &file_schema,
-            projection,
-            cast_columns_policy,
-        )?;
-
-        let n_rows_in_file = self._n_rows_in_file()?;
 
         let normalized_pre_slice = pre_slice_arg
             .clone()
@@ -217,8 +240,7 @@ impl FileReader for ParquetFileReader {
                     "[ParquetFileReader]: early return: \
                     n_rows_in_file: {n_rows_in_file}, \
                     pre_slice: {pre_slice_arg:?}, \
-                    resolved_pre_slice: {normalized_pre_slice:?} \
-                    "
+                    resolved_pre_slice: {normalized_pre_slice:?}"
                 )
             }
 
@@ -228,8 +250,55 @@ impl FileReader for ParquetFileReader {
             ));
         }
 
-        // Prepare parameters for dispatch
+        let mut _projected_arrow_fields: Option<Arc<[ArrowFieldProjection]>> = None;
+        let mut projected_arrow_fields = || {
+            if _projected_arrow_fields.is_none() {
+                _projected_arrow_fields = Some(resolve_arrow_field_projections(
+                    &file_arrow_schema,
+                    &file_schema,
+                    projection.clone(),
+                    cast_columns_policy.clone(),
+                )?);
+            }
+            PolarsResult::Ok(_projected_arrow_fields.as_ref().unwrap().clone())
+        };
 
+        if verbose {
+            eprintln!(
+                "[ParquetFileReader]: \
+                project: {} / {}, \
+                pre_slice: {:?}, \
+                resolved_pre_slice: {:?}, \
+                row_index: {:?}, \
+                predicate: {:?}",
+                projected_arrow_fields()?.len(),
+                file_schema.len(),
+                pre_slice_arg,
+                normalized_pre_slice,
+                &row_index,
+                predicate.as_ref().map(|_| "<predicate>"),
+            )
+        }
+
+        if let Some(single_morsel_height) = single_morsel_height {
+            let (mut tx, rx) = FileReaderOutputSend::new_serial();
+
+            let handle = async_executor::spawn(TaskPriority::Low, async move {
+                let _ = tx
+                    .send_morsel(Morsel::new(
+                        DataFrame::empty_with_height(single_morsel_height),
+                        MorselSeq::default(),
+                        SourceToken::default(),
+                    ))
+                    .await;
+                Ok(())
+            });
+
+            return Ok((rx, handle));
+        }
+
+        // Prepare parameters for dispatch
+        let projected_arrow_fields = projected_arrow_fields()?.clone();
         let memory_prefetch_func = get_memory_prefetch_func(verbose);
         let row_group_prefetch_size = self
             .row_group_prefetch_sync
@@ -244,24 +313,6 @@ impl FileReader for ParquetFileReader {
                 .unwrap_or(16_777_216);
 
         let is_full_projection = projected_arrow_fields.len() == file_schema.len();
-
-        if verbose {
-            eprintln!(
-                "[ParquetFileReader]: \
-                project: {} / {}, \
-                pre_slice: {:?}, \
-                resolved_pre_slice: {:?}, \
-                row_index: {:?}, \
-                predicate: {:?} \
-                ",
-                projected_arrow_fields.len(),
-                file_schema.len(),
-                pre_slice_arg,
-                normalized_pre_slice,
-                &row_index,
-                predicate.as_ref().map(|_| "<predicate>"),
-            )
-        }
 
         let (output_recv, handle) = ParquetReadImpl {
             projected_arrow_fields,
@@ -290,6 +341,7 @@ impl FileReader for ParquetFileReader {
             rg_prefetch_current_all_spawned: Option::take(
                 &mut self.row_group_prefetch_sync.current_all_spawned,
             ),
+            disable_morsel_split,
         }
         .run();
 
@@ -378,6 +430,7 @@ struct ParquetReadImpl {
     rg_prefetch_semaphore: Arc<tokio::sync::Semaphore>,
     rg_prefetch_prev_all_spawned: Option<WaitGroup>,
     rg_prefetch_current_all_spawned: Option<WaitToken>,
+    disable_morsel_split: bool,
 }
 
 #[derive(Debug)]

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -165,7 +165,10 @@ fn visualize_plan_rec(
 
     use std::slice::from_ref;
     let (label, inputs) = match kind {
-        PhysNodeKind::InMemorySource { df } => (
+        PhysNodeKind::InMemorySource {
+            df,
+            disable_morsel_split: _,
+        } => (
             format!(
                 "in-memory-source\\ncols: {}",
                 df.get_column_names_owned().join(", ")
@@ -439,6 +442,7 @@ fn visualize_plan_rec(
             deletion_files,
             table_statistics: _,
             file_schema: _,
+            disable_morsel_split: _,
         } => {
             let mut out = format!("multi-scan[{}]", file_reader_builder.reader_name());
             let mut f = EscapeLabel(&mut out);

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -157,10 +157,15 @@ pub fn lower_ir(
     expr_cache: &mut ExprCache,
     cache_nodes: &mut PlHashMap<UniqueId, PhysStream>,
     ctx: StreamingLowerIRContext,
+    mut disable_morsel_split: Option<bool>,
 ) -> PolarsResult<PhysStream> {
     // Helper macro to simplify recursive calls.
     macro_rules! lower_ir {
-        ($input:expr) => {
+        ($input:expr) => {{
+            // Disable for remaining execution graph if it wasn't explicitly set
+            // by the current IR.
+            disable_morsel_split.get_or_insert(false);
+
             lower_ir(
                 $input,
                 ir_arena,
@@ -170,14 +175,21 @@ pub fn lower_ir(
                 expr_cache,
                 cache_nodes,
                 ctx,
+                disable_morsel_split,
             )
-        };
+        }};
+    }
+
+    // Require the code below to explicitly set this to `true`
+    if disable_morsel_split == Some(true) {
+        disable_morsel_split.take();
     }
 
     let ir_node = ir_arena.get(node);
     let output_schema = IR::schema_with_cache(node, ir_arena, schema_cache);
     let node_kind = match ir_node {
         IR::SimpleProjection { input, columns } => {
+            disable_morsel_split.get_or_insert(true);
             let columns = columns.iter_names_cloned().collect::<Vec<_>>();
             let phys_input = lower_ir!(*input)?;
             PhysNodeKind::SimpleProjection {
@@ -188,6 +200,14 @@ pub fn lower_ir(
 
         IR::Select { input, expr, .. } => {
             let selectors = expr.clone();
+
+            if selectors
+                .iter()
+                .all(|e| matches!(expr_arena.get(e.node()), AExpr::Len | AExpr::Column(_)))
+            {
+                disable_morsel_split.get_or_insert(true);
+            }
+
             let phys_input = lower_ir!(*input)?;
             return build_select_stream(
                 phys_input, &selectors, expr_arena, phys_sm, expr_cache, ctx,
@@ -222,7 +242,10 @@ pub fn lower_ir(
             ..
         } => {
             let schema = schema.clone(); // This is initially the schema of df, but can change with the projection.
-            let mut node_kind = PhysNodeKind::InMemorySource { df: df.clone() };
+            let mut node_kind = PhysNodeKind::InMemorySource {
+                df: df.clone(),
+                disable_morsel_split: disable_morsel_split.unwrap_or(true),
+            };
 
             // Do we need to apply a projection?
             if let Some(projection_schema) = projection {
@@ -245,6 +268,7 @@ pub fn lower_ir(
 
         IR::Sink { input, payload } => match payload {
             SinkTypeIR::Memory => {
+                disable_morsel_split.get_or_insert(true);
                 let phys_input = lower_ir!(*input)?;
                 PhysNodeKind::InMemorySink { input: phys_input }
             },
@@ -279,6 +303,7 @@ pub fn lower_ir(
         },
 
         IR::SinkMultiple { inputs } => {
+            disable_morsel_split.get_or_insert(true);
             let mut sinks = Vec::with_capacity(inputs.len());
             for input in inputs.clone() {
                 let phys_node_stream = match ir_arena.get(input) {
@@ -575,6 +600,7 @@ pub fn lower_ir(
                 // schema.
                 PhysNodeKind::InMemorySource {
                     df: Arc::new(DataFrame::empty_with_schema(output_schema.as_ref())),
+                    disable_morsel_split: disable_morsel_split.unwrap_or(true),
                 }
             } else if output_schema.is_empty()
                 && let Some((physical_rows, deleted_rows)) = unified_scan_args.row_count
@@ -595,6 +621,7 @@ pub fn lower_ir(
 
                 PhysNodeKind::InMemorySource {
                     df: Arc::new(DataFrame::empty_with_height(num_rows)),
+                    disable_morsel_split: disable_morsel_split.unwrap_or(true),
                 }
             } else {
                 let file_reader_builder: Arc<dyn FileReaderBuilder> = match &*scan_type {
@@ -704,6 +731,7 @@ pub fn lower_ir(
                     );
 
                     let pre_slice = unified_scan_args.pre_slice.clone();
+                    let disable_morsel_split = disable_morsel_split.unwrap_or(true);
 
                     let mut multi_scan_node = PhysNodeKind::MultiScan {
                         scan_sources,
@@ -726,6 +754,7 @@ pub fn lower_ir(
                         ),
                         table_statistics: unified_scan_args.table_statistics,
                         file_schema,
+                        disable_morsel_split,
                     };
 
                     let PhysNodeKind::MultiScan {
@@ -876,6 +905,7 @@ pub fn lower_ir(
                     // Fallback to in-memory engine.
                     let input = PhysNodeKind::InMemorySource {
                         df: Arc::new(DataFrame::default()),
+                        disable_morsel_split: disable_morsel_split.unwrap_or(true),
                     };
                     let input_key =
                         phys_sm.insert(PhysNode::new(Arc::new(Schema::default()), input));

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -117,6 +117,7 @@ pub enum ZipBehavior {
 pub enum PhysNodeKind {
     InMemorySource {
         df: Arc<DataFrame>,
+        disable_morsel_split: bool,
     },
 
     Select {
@@ -305,6 +306,7 @@ pub enum PhysNodeKind {
 
         /// Schema of columns contained in the file. Does not contain external columns (e.g. hive / row_index).
         file_schema: SchemaRef,
+        disable_morsel_split: bool,
     },
 
     #[cfg(feature = "python")]
@@ -634,6 +636,7 @@ pub fn build_physical_plan(
         &mut expr_cache,
         &mut cache_nodes,
         ctx,
+        None,
     )?;
     insert_multiplexers(vec![phys_root.node], phys_sm);
     Ok(phys_root.node)

--- a/crates/polars-utils/src/slice_enum.rs
+++ b/crates/polars-utils/src/slice_enum.rs
@@ -205,15 +205,31 @@ mod tests {
         assert_eq!(
             Slice::Negative {
                 offset_from_end: 3,
-                len: 1
+                len: 2
             }
             .restrict_to_bounds(4),
-            Slice::Positive { offset: 1, len: 1 },
+            Slice::Positive { offset: 1, len: 2 },
         );
         assert_eq!(
             Slice::Negative {
                 offset_from_end: 3,
-                len: 1
+                len: 2
+            }
+            .restrict_to_bounds(3),
+            Slice::Positive { offset: 0, len: 2 },
+        );
+        assert_eq!(
+            Slice::Negative {
+                offset_from_end: 3,
+                len: 2
+            }
+            .restrict_to_bounds(2),
+            Slice::Positive { offset: 0, len: 1 },
+        );
+        assert_eq!(
+            Slice::Negative {
+                offset_from_end: 3,
+                len: 2
             }
             .restrict_to_bounds(1),
             Slice::Positive { offset: 0, len: 0 },

--- a/py-polars/src/polars/functions/lazy.py
+++ b/py-polars/src/polars/functions/lazy.py
@@ -2173,6 +2173,9 @@ def collect_all(
         lf = LazyFrame._from_pyldf(ldf)
         return lf
 
+    from polars.lazyframe.frame import _select_engine
+
+    engine = _select_engine(engine)
     out = plr.collect_all(lfs, engine, optimizations._pyoptflags)
 
     # wrap the pydataframes into dataframe


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/22702

Streaming queries that collect to an in-memory DataFrame and consist only of column projections (and `pl.len()`) will now disable morsel splitting at supported sources.

E.g -
* Scan->InMemorySink `scan_parquet().collect()`
* Fast-count `scan_parquet().select(pl.len()).collect()`
* Simple projections `scan_parquet().select("<column>", "column", ..).collect()`

Equivalently when starting from `InMemorySource` -
* InMemorySource->InMemorySink `LazyFrame().collect()`
* Fast-count `LazyFrame().select(pl.len()).collect()`
* Simple projections `LazyFrame().select("<column>", "column", ..).collect()`

#### Benchmark
Description: `scan_parquet().select(pl.len()).collect()`
File: 4B rows x 0 columns

| Runtime Before | Runtime After | Speedup |
| -------------- | ------------- | ------- |
| 0.0728s        | 0.000207s     | 351x    |

Before this PR the parquet source would split to morsels of 100k rows (sending ~42,949 morsels). It now sends only a single morsel.

<details>
<summary>Test script</summary>

```python
from time import perf_counter
import polars as pl

path = "/Users/nxs/git/polars/.env/_data_out/big.parquet"
pl.LazyFrame(height=(1 << 32) - 1).sink_parquet(path)

q = pl.scan_parquet(path).select(pl.len())
print(q.explain(engine="streaming"))

timings = []
for _ in range(5):
    t = perf_counter()
    q.collect()
    timings.append(perf_counter() - t)

print(f"{min(timings) = }")

```
</details>
