### PR TITLE
feat(python): Support expressions in DataFrame.partition_by

### DIFF
--- a/py-polars/tests/unit/dataframe/test_partition_by.py
+++ b/py-polars/tests/unit/dataframe/test_partition_by.py
@@ -216,7 +216,9 @@ def test_partition_by_series() -> None:
 def test_partition_by_invalid_type() -> None:
     """Test that partitioning by an invalid type raises TypeError."""
     df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-    with pytest.raises(TypeError, match="expected column name, selector, or expression"):
+    with pytest.raises(
+        TypeError, match="expected column name, selector, or expression"
+    ):
         df.partition_by(123)  # type: ignore[arg-type]
 
 


### PR DESCRIPTION
## Summary
Fixes #26108

This change allows `partition_by` to accept expressions in addition to column names and selectors, making it consistent with `group_by`.

Previously, partitioning by a computed value required creating a temporary column first:

```python
df.with_columns(is_big=pl.col("b") > 100).partition_by("is_big")
```

Now expressions can be used directly:

```python
df.partition_by(pl.col("b") > 100)

# Can also combine columns and expressions
df.partition_by("a", pl.col("b") > 100)
```

## Implementation
- Expressions are evaluated to temporary columns using `with_columns()`
- Partitioning is performed on both original columns and temporary columns
- Temporary columns are removed from the output partitions
- Full backward compatibility with existing column name and selector usage

## Test plan
- [x] Added `test_partition_by_expression` - basic expression partitioning
- [x] Added `test_partition_by_expression_as_dict` - expression with `as_dict=True`
- [x] Added `test_partition_by_column_and_expression` - mixing columns and expressions
- [x] Added `test_partition_by_expression_include_key_false` - expression with `include_key=False`
- [x] Added `test_partition_by_column_and_expression_include_key_false` - combined with `include_key=False`
- [x] All existing `partition_by` tests pass