### PR TITLE
fix(python): Recognize pd.Timestamp values in Series constructor

### DIFF
--- a/crates/polars-python/src/conversion/any_value.rs
+++ b/crates/polars-python/src/conversion/any_value.rs
@@ -553,6 +553,13 @@ pub(crate) fn py_object_to_any_value(
             if ob.is_instance(DECIMAL_TYPE.import(py, "decimal", "Decimal")?)? {
                 return Ok(get_decimal as InitFn);
             }
+            // Check for pandas Timestamp (subclass of datetime not recognized by PyDateTime::type_check)
+            static PANDAS_TIMESTAMP_TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+            if let Ok(ts_type) = PANDAS_TIMESTAMP_TYPE.import(py, "pandas", "Timestamp") {
+                if ob.is_instance(ts_type)? {
+                    return Ok(get_datetime as InitFn);
+                }
+            }
 
             // support NumPy scalars
             if ob.extract::<i64>().is_ok() || ob.extract::<u64>().is_ok() {

--- a/py-polars/tests/unit/constructors/test_series.py
+++ b/py-polars/tests/unit/constructors/test_series.py
@@ -149,6 +149,29 @@ def test_series_init_pandas_timestamp_18127() -> None:
     assert result.dtype == pl.Datetime("us", "UTC")
 
 
+def test_series_init_pandas_timestamp_14432() -> None:
+    # Test pd.Timestamp without timezone (issue #14432)
+    result = pl.Series([pd.Timestamp("2000-01-01T12:30:00")])
+    assert result.dtype == pl.Datetime("us")
+    assert result[0] == datetime(2000, 1, 1, 12, 30, 0)
+
+    # Test multiple pd.Timestamp values
+    result = pl.Series(
+        [
+            pd.Timestamp("2020-01-01"),
+            pd.Timestamp("2020-06-15"),
+            pd.Timestamp("2020-12-31"),
+        ]
+    )
+    assert result.dtype == pl.Datetime("us")
+    assert result.len() == 3
+
+    # Test pd.Timestamp with None values
+    result = pl.Series([pd.Timestamp("2020-01-01"), None, pd.Timestamp("2020-01-03")])
+    assert result.dtype == pl.Datetime("us")
+    assert result[1] is None
+
+
 def test_series_init_np_2d_zero_zero_shape() -> None:
     arr = np.array([]).reshape(0, 0)
     assert_series_equal(


### PR DESCRIPTION
## Summary
Fixes #14432

When constructing a Series from a list of `pd.Timestamp` values, Polars was creating an `Object` dtype instead of `Datetime`:

```python
import pandas as pd
import polars as pl

# Before: dtype=Object
# After: dtype=Datetime(time_unit='us', time_zone=None)
pl.Series([pd.Timestamp("2020-01-01")])
```

### Root cause
`PyDateTime::type_check()` in Rust doesn't recognize `pd.Timestamp` even though it's a subclass of `datetime.datetime`.

### Solution
Added an explicit check for `pandas.Timestamp` before the `PyDateTime` check, following the same pattern used for `numpy.ndarray` and `decimal.Decimal`.

## Test plan
- [x] Added `test_series_init_pandas_timestamp_14432` covering:
  - pd.Timestamp without timezone
  - Multiple pd.Timestamp values  
  - pd.Timestamp with None values
- [x] Existing test `test_series_init_pandas_timestamp_18127` (with timezone) still passes
- [x] All 28 tests in `test_series.py` pass
- [x] All 118 tests in `test_any_value_fallbacks.py` pass