### PR TITLE
fix(python): Make polars compatible with ty

### DIFF
--- a/py-polars/src/polars/_utils/deprecation.py
+++ b/py-polars/src/polars/_utils/deprecation.py
@@ -14,6 +14,8 @@ from polars._typing import DeprecationType
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from polars._utils.various import IdentityFunction
+
 if sys.version_info >= (3, 13):
     from warnings import deprecated
 else:
@@ -21,9 +23,7 @@ else:
         from typing_extensions import deprecated
     except ImportError:
 
-        def deprecated(  # type: ignore[no-redef]
-            message: str,
-        ) -> Callable[[Callable[P, T]], Callable[P, T]]:
+        def deprecated(message: str) -> IdentityFunction:  # type: ignore[no-redef]
             return _deprecate_function(message)
 
 
@@ -61,7 +61,7 @@ def issue_deprecation_warning(message: str, *, version: str = "") -> None:
     issue_warning(message, DeprecationWarning)
 
 
-def _deprecate_function(message: str) -> Callable[[Callable[P, T]], Callable[P, T]]:
+def _deprecate_function(message: str) -> IdentityFunction:
     """Decorator to mark a function as deprecated."""
 
     def decorate(function: Callable[P, T]) -> Callable[P, T]:
@@ -77,7 +77,7 @@ def _deprecate_function(message: str) -> Callable[[Callable[P, T]], Callable[P, 
     return decorate
 
 
-def deprecate_streaming_parameter() -> Callable[[Callable[P, T]], Callable[P, T]]:
+def deprecate_streaming_parameter() -> IdentityFunction:
     """Decorator to mark `streaming` argument as deprecated due to being renamed."""
 
     def decorate(function: Callable[P, T]) -> Callable[P, T]:
@@ -104,7 +104,7 @@ def deprecate_streaming_parameter() -> Callable[[Callable[P, T]], Callable[P, T]
 
 def deprecate_renamed_parameter(
     old_name: str, new_name: str, *, version: str
-) -> Callable[[Callable[P, T]], Callable[P, T]]:
+) -> IdentityFunction:
     """
     Decorator to mark a function parameter as deprecated due to being renamed.
 
@@ -162,7 +162,7 @@ def _rename_keyword_argument(
 
 def deprecate_nonkeyword_arguments(
     allowed_args: list[str] | None = None, message: str | None = None, *, version: str
-) -> Callable[[Callable[P, T]], Callable[P, T]]:
+) -> IdentityFunction:
     """
     Decorator for deprecating the use of non-keyword arguments in a function.
 
@@ -251,9 +251,7 @@ def _format_argument_list(allowed_args: list[str]) -> str:
         return f" except for {args} and {last!r}"
 
 
-def deprecate_parameter_as_multi_positional(
-    old_name: str,
-) -> Callable[[Callable[P, T]], Callable[P, T]]:
+def deprecate_parameter_as_multi_positional(old_name: str) -> IdentityFunction:
     """
     Decorator to mark a function argument as deprecated due to being made multi-positional.
 

--- a/py-polars/src/polars/_utils/unstable.py
+++ b/py-polars/src/polars/_utils/unstable.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import ParamSpec
 
+    from polars._utils.various import IdentityFunction
+
     P = ParamSpec("P")
     T = TypeVar("T")
 
@@ -44,7 +46,7 @@ def issue_unstable_warning(message: str | None = None) -> None:
     issue_warning(message, UnstableWarning)
 
 
-def unstable() -> Callable[[Callable[P, T]], Callable[P, T]]:
+def unstable() -> IdentityFunction:
     """Decorator to mark a function as unstable."""
 
     def decorate(function: Callable[P, T]) -> Callable[P, T]:

--- a/py-polars/src/polars/_utils/various.py
+++ b/py-polars/src/polars/_utils/various.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
         MutableMapping,
         Reversible,
     )
-    from typing import ParamSpec, TypeGuard
+    from typing import ParamSpec, Protocol, TypeGuard
 
     from polars import DataFrame, Expr
     from polars._typing import PolarsDataType, SizeUnit
@@ -60,6 +60,11 @@ if TYPE_CHECKING:
 
     P = ParamSpec("P")
     T = TypeVar("T")
+
+    class IdentityFunction(Protocol):
+        # Use as a return type for signature preserving decorators
+        def __call__(self, fn: Callable[P, T], /) -> Callable[P, T]: ...
+
 
 # note: reversed views don't match as instances of MappingView
 if sys.version_info >= (3, 11):

--- a/py-polars/src/polars/lazyframe/opt_flags.py
+++ b/py-polars/src/polars/lazyframe/opt_flags.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import ParamSpec
 
+    from polars._utils.various import IdentityFunction
+
     P = ParamSpec("P")
     T = TypeVar("T")
 
@@ -265,7 +267,7 @@ except (ImportError, NameError) as _:
     DEFAULT_QUERY_OPT_FLAGS = ()  # type: ignore[assignment]
 
 
-def forward_old_opt_flags() -> Callable[[Callable[P, T]], Callable[P, T]]:
+def forward_old_opt_flags() -> IdentityFunction:
     """Decorator to mark to forward the old optimization flags."""
 
     def helper(f: QueryOptFlags, field_name: str, value: bool) -> QueryOptFlags:  # noqa: FBT001


### PR DESCRIPTION
Many polars decorators return `Callable[[Callable[P, T]], Callable[P, T]]` which has ambiguous scoping for `P` and `T`. This is special cased in mypy and pyright but it confuses ty. This PR changes this annotation to a protocol with identical meaning but with clear scoping for the type variables making it work with all type checkers and IDEs. This makes polars functions like `read_csv` compatible with ty which is especially useful for autocompletion.

Before:
<img width="326" height="78" alt="Screenshot 2026-01-24 194201" src="https://github.com/user-attachments/assets/bfeb909e-af43-4c23-b3d7-d855969f291c" />

After:
<img width="381" height="84" alt="image" src="https://github.com/user-attachments/assets/5659f84a-e763-4f00-90c0-5eeacce392b7" />
