### PR TITLE
fix(python): Improve Polars dtype inference from Python `Union` typing

### DIFF
--- a/py-polars/src/polars/datatypes/_parse.py
+++ b/py-polars/src/polars/datatypes/_parse.py
@@ -7,7 +7,16 @@ from datetime import date, datetime, time, timedelta
 from decimal import Decimal as PyDecimal
 from inspect import isclass
 from types import NoneType, UnionType
-from typing import TYPE_CHECKING, Any, Final, ForwardRef, NoReturn, get_args
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Final,
+    ForwardRef,
+    NoReturn,
+    Union,
+    get_args,
+    get_origin,
+)
 
 import polars._reexport as pl
 from polars.datatypes.classes import (
@@ -33,9 +42,6 @@ if TYPE_CHECKING:
     from polars._typing import PolarsDataType, PythonDataType, SchemaDict
 
 
-UnionTypeOld = type(int | str)
-
-
 def parse_into_datatype_expr(input: Any) -> pl.DataTypeExpr:
     """Parse an input into a DataTypeExpr."""
     if isinstance(input, pl.DataTypeExpr):
@@ -57,7 +63,7 @@ def parse_into_dtype(input: Any) -> PolarsDataType:
         return input
     elif isinstance(input, ForwardRef):
         return _parse_forward_ref_into_dtype(input)
-    elif isinstance(input, (UnionType, UnionTypeOld)):
+    elif isinstance(input, UnionType) or get_origin(input) is Union:
         return _parse_union_type_into_dtype(input)
     else:
         return parse_py_type_into_dtype(input)

--- a/py-polars/tests/unit/datatypes/test_datatypes.py
+++ b/py-polars/tests/unit/datatypes/test_datatypes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import pickle
 from datetime import datetime, time, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import pytest
 
@@ -113,7 +113,6 @@ def test_dtypes_picklable() -> None:
 def test_dtypes_hashable() -> None:
     # ensure that all the types can be hashed, and that their hashes
     # are sufficient to ensure distinct entries in a dictionary/set
-
     all_dtypes = [
         getattr(datatypes, d)
         for d in dir(datatypes)
@@ -122,6 +121,15 @@ def test_dtypes_hashable() -> None:
     assert len(set(all_dtypes + all_dtypes)) == len(all_dtypes)
     assert len({pl.Datetime("ms"), pl.Datetime("us"), pl.Datetime("ns")}) == 3
     assert len({pl.List, pl.List(pl.Int16), pl.List(pl.Int32), pl.List(pl.Int64)}) == 4
+
+
+@pytest.mark.parametrize(
+    "python_type",
+    [int, int | None, Optional[int], Union[int, None]],  # noqa: UP007,UP045
+)
+def test_inference_from_python_type(python_type: Any) -> None:
+    polars_type = pl.DataType.from_python(python_type)
+    assert polars_type == pl.Int64
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #26302.

Resolves an inference error that only occurred on specific versions of Python; we can use `typing.get_origin` to make the check more robust.

Validated the fix across all supported versions of Python (3.10-3.14 inclusive).