### PR TITLE
refactor(rust): Mark `VarState` as `repr(C)`

### DIFF
--- a/crates/polars-compute/src/moment.rs
+++ b/crates/polars-compute/src/moment.rs
@@ -37,6 +37,7 @@ use polars_utils::algebraic_ops::*;
 const CHUNK_SIZE: usize = 128;
 
 #[derive(Default, Clone)]
+#[repr(C)] // For serialization, don't change struct member order.
 pub struct VarState {
     weight: f64,
     mean: f64,
@@ -44,6 +45,7 @@ pub struct VarState {
 }
 
 #[derive(Default, Clone)]
+#[repr(C)] // For serialization, don't change struct member order.
 pub struct CovState {
     weight: f64,
     mean_x: f64,
@@ -52,6 +54,7 @@ pub struct CovState {
 }
 
 #[derive(Default, Clone)]
+#[repr(C)] // For serialization, don't change struct member order.
 pub struct PearsonState {
     weight: f64,
     mean_x: f64,
@@ -253,6 +256,7 @@ impl PearsonState {
 }
 
 #[derive(Default, Clone)]
+#[repr(C)] // For serialization, don't change struct member order.
 pub struct SkewState {
     weight: f64,
     mean: f64,
@@ -407,6 +411,7 @@ impl SkewState {
 }
 
 #[derive(Default, Clone)]
+#[repr(C)] // For serialization, don't change struct member order.
 pub struct KurtosisState {
     weight: f64,
     mean: f64,


### PR DESCRIPTION
Needed for pre- post-aggregating the type
