### PR TITLE
refactor(rust): Improve accuracy of active IO time metric

### DIFF
--- a/crates/polars-stream/src/metrics_io.rs
+++ b/crates/polars-stream/src/metrics_io.rs
@@ -6,63 +6,24 @@ use std::time::Instant;
 use futures::FutureExt;
 use polars_utils::relaxed_cell::RelaxedCell;
 
+#[derive(Default)]
+struct ActiveIOMetricsInner {
+    active_io_count: AtomicU64,
+    /// Offset against `base_instant`.
+    active_io_offset_ns: RelaxedCell<u64>,
+    active_io_total_ns: RelaxedCell<u64>,
+}
+
 pub struct ActiveIOMetrics {
     base_instant: Instant,
-    active_io_count: RelaxedCell<u64>,
-    /// Offset against `base_instant`.
-    active_io_offset_ns: AtomicU64,
-    active_io_total_ns: RelaxedCell<u64>,
+    inner: parking_lot::RwLock<ActiveIOMetricsInner>,
 }
 
 impl Default for ActiveIOMetrics {
     fn default() -> Self {
         Self {
             base_instant: Instant::now(),
-            active_io_count: RelaxedCell::default(),
-            active_io_offset_ns: AtomicU64::new(0),
-            active_io_total_ns: RelaxedCell::new_u64(0),
-        }
-    }
-}
-
-/// Has Drop impl that ensures atomic counter is decremented.
-struct IOSession<'a> {
-    active_io_metrics: &'a ActiveIOMetrics,
-    decremented: bool,
-}
-
-impl IOSession<'_> {
-    fn finish(&mut self, ns_since_base_instant: u64) -> bool {
-        assert!(!self.decremented);
-        self.decremented = true;
-
-        let active_io_metrics = self.active_io_metrics;
-
-        let elapsed = u64::saturating_sub(
-            ns_since_base_instant,
-            active_io_metrics
-                .active_io_offset_ns
-                .load(atomic::Ordering::Acquire),
-        );
-
-        let ended_by_this_call = active_io_metrics.active_io_count.fetch_sub(1) == 1;
-
-        if ended_by_this_call {
-            active_io_metrics.active_io_total_ns.fetch_add(elapsed);
-        }
-
-        ended_by_this_call
-    }
-}
-
-impl Drop for IOSession<'_> {
-    fn drop(&mut self) {
-        if !self.decremented {
-            self.finish(
-                Instant::now()
-                    .saturating_duration_since(self.active_io_metrics.base_instant)
-                    .as_nanos() as _,
-            );
+            inner: Default::default(),
         }
     }
 }
@@ -74,48 +35,43 @@ impl ActiveIOMetrics {
             .as_nanos() as _
     }
 
-    fn start_io_session(&self) -> (IOSession<'_>, bool) {
-        let started_by_this_call = self.active_io_count.fetch_add(1) == 0;
+    fn get_or_start_session(&self) -> IOSession<'_> {
+        let inner = self.inner.read();
 
-        if started_by_this_call {
-            self.active_io_offset_ns
-                .store(self.ns_since_base_instant(), atomic::Ordering::Release);
+        if inner
+            .active_io_count
+            .fetch_add(1, atomic::Ordering::Relaxed)
+            == 0
+        {
+            inner
+                .active_io_offset_ns
+                .store(self.ns_since_base_instant());
         }
 
-        (
-            IOSession {
-                active_io_metrics: self,
-                decremented: false,
-            },
-            started_by_this_call,
-        )
+        drop(inner);
+
+        IOSession {
+            active_io_metrics: self,
+            finished: false,
+        }
     }
 
     pub fn active_io_total_ns(&self) -> u64 {
-        // If there are active I/O tasks, we would like to add the current elapsed
-        // time to the `active_io_total_ns` counter.
-        // For us to do so we need to ensure no other threads will concurrently
-        // update the counter - we do this by starting a session here.
-        let (mut session_ref, started_by_this_call) = self.start_io_session();
-
         let ns_since_base_instant = self.ns_since_base_instant();
-        let elapsed = u64::saturating_sub(
-            ns_since_base_instant,
-            self.active_io_offset_ns.load(atomic::Ordering::Acquire),
-        );
 
-        let active_io_total_ns = self.active_io_total_ns.load();
+        // Take an exclusive lock to wait for in-flight commits to finish and block new commits.
+        let inner = self.inner.write();
+        let active_io_count = inner.active_io_count.load(atomic::Ordering::Acquire);
+        let active_io_offset_ns = inner.active_io_offset_ns.load();
+        let active_io_total_ns = inner.active_io_total_ns.load();
+        drop(inner);
 
-        session_ref.finish(if started_by_this_call {
-            0
-        } else {
-            ns_since_base_instant
-        });
+        let elapsed = u64::saturating_sub(ns_since_base_instant, active_io_offset_ns);
 
-        if started_by_this_call {
-            active_io_total_ns
-        } else {
+        if active_io_count > 0 {
             active_io_total_ns + elapsed
+        } else {
+            active_io_total_ns
         }
     }
 
@@ -123,15 +79,53 @@ impl ActiveIOMetrics {
     where
         F: Future<Output = O>,
     {
-        let (mut session_ref, _) = self.start_io_session();
+        let session = self.get_or_start_session();
 
         let out = AssertUnwindSafe(fut).catch_unwind().await;
 
-        session_ref.finish(self.ns_since_base_instant());
+        drop(session);
 
         match out {
             Ok(v) => v,
             Err(e) => std::panic::resume_unwind(e),
+        }
+    }
+}
+
+/// Has Drop impl that ensures atomic counter is decremented.
+struct IOSession<'a> {
+    active_io_metrics: &'a ActiveIOMetrics,
+    finished: bool,
+}
+
+impl IOSession<'_> {
+    fn finish_by_ref(&mut self) {
+        assert!(!self.finished);
+        self.finished = true;
+
+        let ns_since_base_instant = self.active_io_metrics.ns_since_base_instant();
+        let active_io_metrics = self.active_io_metrics.inner.read();
+
+        let elapsed = u64::saturating_sub(
+            ns_since_base_instant,
+            active_io_metrics.active_io_offset_ns.load(),
+        );
+
+        if active_io_metrics
+            .active_io_count
+            .fetch_sub(1, atomic::Ordering::Release)
+            == 1
+        {
+            atomic::fence(atomic::Ordering::Acquire);
+            active_io_metrics.active_io_total_ns.fetch_add(elapsed);
+        }
+    }
+}
+
+impl Drop for IOSession<'_> {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.finish_by_ref();
         }
     }
 }


### PR DESCRIPTION
The current `active_io_total_ns()` implementation could read an old value (though unlikely). This PR add a `RwLock` to ensure `active_io_total_ns()` waits for active commits against `active_io_total_ns`.

#### Other
* Changes Acq/Rel atomic ordering to be on the counter rather than `io_offset_ns` 
