### PR TITLE
chore: Remove `xlsx2csv` dependency pin

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -58,7 +58,7 @@ pydantic = ["pydantic"]
 # Excel
 calamine = ["fastexcel >= 0.9"]
 openpyxl = ["openpyxl >= 3.0.0"]
-xlsx2csv = ["xlsx2csv >= 0.8.0, < 0.8.5"]
+xlsx2csv = ["xlsx2csv >= 0.8.0"]
 xlsxwriter = ["xlsxwriter"]
 excel = ["polars[calamine,openpyxl,xlsx2csv,xlsxwriter]"]
 

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -41,7 +41,7 @@ s3fs
 # Spreadsheet
 fastexcel>=0.11.5
 openpyxl
-xlsx2csv>=0.8.0,<0.8.5
+xlsx2csv
 xlsxwriter>=3.2.9
 # Other I/O
 deltalake>=1.1.4


### PR DESCRIPTION
The author of `xlsx2csv` uploaded a new version (`0.8.6`) with the regression fixed: https://github.com/dilshod/xlsx2csv/issues/307#issuecomment-3824458807

Everything works fine now, so can unpin the versions.
