### PR TITLE
fix: Add {Float16, Float32} -> Float32 lossless upcast

### DIFF
--- a/crates/polars-core/src/utils/supertype.rs
+++ b/crates/polars-core/src/utils/supertype.rs
@@ -33,6 +33,7 @@ pub fn get_numeric_upcast_supertype_lossless(l: &DataType, r: &DataType) -> Opti
     } else if l.is_float() && r.is_float() {
         match (l, r) {
             (Float64, _) | (_, Float64) => Some(Float64),
+            (Float32, _) | (_, Float32) => Some(Float32),
             v => {
                 // Did we add a new float type?
                 if cfg!(debug_assertions) {

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -1480,6 +1480,7 @@ def test_join_preserve_order_full() -> None:
         ["UInt16", "UInt16", "UInt8"],
 
         ["Float64", "Float64", "Float32"],
+        ["Float32", "Float32", "Float16"],
     ],
 )  # fmt: skip
 @pytest.mark.parametrize("swap", [True, False])


### PR DESCRIPTION
This PR fixes a panic that triggers when one key of a join operation is `float16`.

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
