### PR TITLE
ci: Properly disable the Pyodide tests

### DIFF
--- a/.github/workflows/test-pyodide.yml
+++ b/.github/workflows/test-pyodide.yml
@@ -1,7 +1,9 @@
 name: Test Pyodide
 
 on:
-  # disabled for now
+  push:
+    branches:
+      - disabled-pyodide-tests  # disabled for now
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Since #26325, GitHub is still trying the Pyodide tests on forks but now the workflow file is failing to parse.

Fixes #26357 