### PR TITLE
docs(rust): Fix typo in max_by docstring

### DIFF
--- a/crates/polars-plan/src/dsl/statistics.rs
+++ b/crates/polars-plan/src/dsl/statistics.rs
@@ -34,7 +34,7 @@ impl Expr {
         Expr::n_ary(FunctionExpr::MinBy, vec![self, by])
     }
 
-    /// Get minimum value, ordered by another expression.
+    /// Get maximum value, ordered by another expression.
     pub fn max_by(self, by: Self) -> Self {
         Expr::n_ary(FunctionExpr::MaxBy, vec![self, by])
     }


### PR DESCRIPTION
Small typo fix in `max_by` docstring

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
