### PR TITLE
refactor(rust): Propagate object-store error information

### DIFF
--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -109,7 +109,30 @@ pub enum PolarsError {
     },
 }
 
-impl Error for PolarsError {}
+impl Error for PolarsError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            PolarsError::AssertionError(_)
+            | PolarsError::ColumnNotFound(_)
+            | PolarsError::ComputeError(_)
+            | PolarsError::Duplicate(_)
+            | PolarsError::InvalidOperation(_)
+            | PolarsError::NoData(_)
+            | PolarsError::OutOfBounds(_)
+            | PolarsError::SchemaFieldNotFound(_)
+            | PolarsError::SchemaMismatch(_)
+            | PolarsError::ShapeMismatch(_)
+            | PolarsError::SQLInterface(_)
+            | PolarsError::SQLSyntax(_)
+            | PolarsError::StringCacheMismatch(_)
+            | PolarsError::StructFieldNotFound(_) => None,
+            PolarsError::IO { error, .. } => Some(error.as_ref()),
+            PolarsError::Context { error, .. } => Some(error.as_ref()),
+            #[cfg(feature = "python")]
+            PolarsError::Python { error } => error.deref().source(),
+        }
+    }
+}
 
 impl Display for PolarsError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -157,6 +180,7 @@ impl From<regex::Error> for PolarsError {
     }
 }
 
+// TODO: Remove this conversion after reworking cloud writer
 #[cfg(feature = "object_store")]
 impl From<object_store::Error> for PolarsError {
     fn from(err: object_store::Error) -> Self {

--- a/crates/polars-io/src/cloud/glob.rs
+++ b/crates/polars-io/src/cloud/glob.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 
 use futures::TryStreamExt;
 use object_store::path::Path;
-use polars_core::error::to_compute_err;
 use polars_error::{PolarsResult, polars_bail, polars_err};
 use polars_utils::pl_path::{CloudScheme, PlRefPath};
 use polars_utils::pl_str::PlSmallStr;
@@ -236,22 +235,21 @@ pub async fn glob(
     let path = Some(&path);
 
     let mut locations = store
-        .try_exec_rebuild_on_err(|store| {
-            let st = store.clone();
-
-            async {
-                let store = st;
-                store
-                    .list(path)
-                    .try_filter_map(|x| async move {
-                        let out = (x.size > 0 && matcher.is_matching(x.location.as_ref()))
-                            .then_some(x.location);
-                        Ok(out)
-                    })
-                    .try_collect::<Vec<_>>()
-                    .await
-                    .map_err(to_compute_err)
-            }
+        .try_exec_rebuild_on_err(|store| async move {
+            Ok(store
+                .exec_with_store(|st| async move {
+                    let store = st;
+                    store
+                        .list(path)
+                        .try_filter_map(|x| async move {
+                            let out = (x.size > 0 && matcher.is_matching(x.location.as_ref()))
+                                .then_some(x.location);
+                            Ok(out)
+                        })
+                        .try_collect::<Vec<_>>()
+                        .await
+                })
+                .await?)
         })
         .await?;
 

--- a/crates/polars-io/src/cloud/object_store_setup.rs
+++ b/crates/polars-io/src/cloud/object_store_setup.rs
@@ -105,6 +105,10 @@ pub(crate) struct PolarsObjectStoreBuilder {
 }
 
 impl PolarsObjectStoreBuilder {
+    pub(super) fn path(&self) -> &PlRefPath {
+        &self.path
+    }
+
     pub(super) async fn build_impl(
         &self,
         // Whether to clear cached credentials for Python credential providers.
@@ -166,7 +170,7 @@ impl PolarsObjectStoreBuilder {
                 {
                     #[cfg(feature = "http")]
                     {
-                        let store = options.build_http(self.path.as_str())?;
+                        let store = options.build_http(self.path.clone())?;
                         PolarsResult::Ok(Arc::new(store) as Arc<dyn ObjectStore>)
                     }
                 }

--- a/crates/polars-io/src/cloud/polars_object_store.rs
+++ b/crates/polars-io/src/cloud/polars_object_store.rs
@@ -1,31 +1,85 @@
+use std::fmt::Display;
 use std::ops::Range;
+use std::sync::Arc;
 
-use futures::{StreamExt, TryStreamExt};
+use futures::TryStreamExt as _;
 use hashbrown::hash_map::RawEntryMut;
 use object_store::path::Path;
 use object_store::{ObjectMeta, ObjectStore, ObjectStoreExt};
 use polars_buffer::Buffer;
 use polars_core::prelude::{InitHashMaps, PlHashMap};
 use polars_error::{PolarsError, PolarsResult};
+use polars_utils::pl_path::PlRefPath;
 use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 
-use crate::metrics::{HEAD_RESPONSE_SIZE_ESTIMATE, OptIOMetrics};
+use crate::metrics::HEAD_RESPONSE_SIZE_ESTIMATE;
 use crate::pl_async::{
-    self, MAX_BUDGET_PER_REQUEST, get_concurrency_limit, get_download_chunk_size,
-    tune_with_concurrency_budget, with_concurrency_budget,
+    self, MAX_BUDGET_PER_REQUEST, get_download_chunk_size, tune_with_concurrency_budget,
+    with_concurrency_budget,
 };
 
+#[derive(Debug)]
+pub struct PolarsObjectStoreError {
+    pub base_url: PlRefPath,
+    pub source: object_store::Error,
+}
+
+impl PolarsObjectStoreError {
+    pub fn from_url(base_url: &PlRefPath) -> impl FnOnce(object_store::Error) -> Self {
+        |error| Self {
+            base_url: base_url.clone(),
+            source: error,
+        }
+    }
+}
+
+impl Display for PolarsObjectStoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "object-store error: {}", self.source)
+    }
+}
+
+impl std::error::Error for PolarsObjectStoreError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+impl From<PolarsObjectStoreError> for std::io::Error {
+    fn from(value: PolarsObjectStoreError) -> Self {
+        std::io::Error::other(value)
+    }
+}
+
+impl From<PolarsObjectStoreError> for PolarsError {
+    fn from(value: PolarsObjectStoreError) -> Self {
+        PolarsError::IO {
+            error: Arc::new(value.into()),
+            msg: None,
+        }
+    }
+}
+
 mod inner {
+
     use std::future::Future;
+    use std::ops::Range;
     use std::sync::Arc;
 
-    use object_store::ObjectStore;
+    use bytes::Bytes;
+    use futures::stream::BoxStream;
+    use futures::{Stream, StreamExt as _};
+    use object_store::path::Path;
+    use object_store::{ObjectStore, ObjectStoreExt as _};
+    use polars_buffer::Buffer;
     use polars_core::config;
     use polars_error::PolarsResult;
+    use polars_utils::pl_path::PlRefPath;
     use polars_utils::relaxed_cell::RelaxedCell;
 
     use crate::cloud::PolarsObjectStoreBuilder;
     use crate::metrics::{IOMetrics, OptIOMetrics};
+    use crate::pl_async::get_concurrency_limit;
 
     #[derive(Debug)]
     struct Inner {
@@ -106,12 +160,16 @@ mod inner {
 
         pub async fn try_exec_rebuild_on_err<Fn, Fut, O>(&self, mut func: Fn) -> PolarsResult<O>
         where
-            Fn: FnMut(&Arc<dyn ObjectStore>) -> Fut,
+            Fn: FnMut(ObjectStoreExecutionContext) -> Fut,
             Fut: Future<Output = PolarsResult<O>>,
         {
             let store = self.to_dyn_object_store().await;
 
-            let out = func(&store).await;
+            let out = func(ObjectStoreExecutionContext {
+                store: Arc::clone(&store),
+                url: self.path().clone(),
+            })
+            .await;
 
             let orig_err = match out {
                 Ok(v) => return Ok(v),
@@ -130,7 +188,12 @@ mod inner {
                 .await
                 .map_err(|e| e.wrap_msg(|e| format!("{e}; original error: {orig_err}")))?;
 
-            func(&store).await.map_err(|e| {
+            func(ObjectStoreExecutionContext {
+                store,
+                url: self.path().clone(),
+            })
+            .await
+            .map_err(|e| {
                 if self.inner.builder.is_azure()
                     && std::env::var("POLARS_AUTO_USE_AZURE_STORAGE_ACCOUNT_KEY").as_deref()
                         != Ok("1")
@@ -149,6 +212,80 @@ and use the storage account keys from Azure CLI to authenticate"
                 }
             })
         }
+
+        pub fn path(&self) -> &PlRefPath {
+            self.inner.builder.path()
+        }
+    }
+
+    /// Execution context that attaches path information to errors.
+    #[derive(Clone)]
+    pub struct ObjectStoreExecutionContext {
+        store: Arc<dyn ObjectStore>,
+        url: PlRefPath,
+    }
+
+    impl ObjectStoreExecutionContext {
+        fn attach_err_info(&self, err: object_store::Error) -> std::io::Error {
+            super::PolarsObjectStoreError {
+                base_url: self.url.clone(),
+                source: err,
+            }
+            .into()
+        }
+
+        pub async fn exec_with_store<'a, F, Fut, O>(&'a self, func: F) -> std::io::Result<O>
+        where
+            F: FnOnce(&'a Arc<dyn ObjectStore>) -> Fut,
+            Fut: Future<Output = object_store::Result<O>> + 'a,
+        {
+            func(&self.store).await.map_err(|e| self.attach_err_info(e))
+        }
+
+        pub fn build_buffered_ranges_stream<'a, T: Iterator<Item = Range<usize>>>(
+            &'a self,
+            path: &'a Path,
+            ranges: T,
+            io_metrics: OptIOMetrics,
+        ) -> impl Stream<Item = PolarsResult<Buffer<u8>>> + use<'a, T> {
+            futures::stream::iter(ranges.map(move |range| {
+                let io_metrics = io_metrics.clone();
+
+                async move {
+                    if range.is_empty() {
+                        return Ok(Buffer::new());
+                    }
+
+                    let out = io_metrics
+                        .record_io_read(
+                            range.len() as u64,
+                            self.exec_with_store(|s| {
+                                s.get_range(path, range.start as u64..range.end as u64)
+                            }),
+                        )
+                        .await?;
+
+                    Ok(Buffer::from_owner(out))
+                }
+            }))
+            // Add a limit locally as this gets run inside a single `tune_with_concurrency_budget`.
+            .buffered(get_concurrency_limit() as usize)
+        }
+
+        pub async fn get_into_stream(
+            &self,
+            path: &Path,
+        ) -> PolarsResult<BoxStream<'static, std::io::Result<Bytes>>> {
+            Ok(self
+                .exec_with_store(|s| s.get(path))
+                .await?
+                .into_stream()
+                .map({
+                    let slf = self.clone();
+                    move |v| v.map_err(|e| slf.attach_err_info(e))
+                })
+                .boxed())
+        }
     }
 }
 
@@ -157,37 +294,6 @@ pub use inner::PolarsObjectStore;
 pub type ObjectStorePath = object_store::path::Path;
 
 impl PolarsObjectStore {
-    /// Returns a buffered stream that downloads concurrently up to the concurrency limit.
-    fn get_buffered_ranges_stream<'a, T: Iterator<Item = Range<usize>>>(
-        store: &'a dyn ObjectStore,
-        path: &'a Path,
-        ranges: T,
-        io_metrics: OptIOMetrics,
-    ) -> impl StreamExt<Item = PolarsResult<Buffer<u8>>>
-    + TryStreamExt<Ok = Buffer<u8>, Error = PolarsError, Item = PolarsResult<Buffer<u8>>>
-    + use<'a, T> {
-        futures::stream::iter(ranges.map(move |range| {
-            let io_metrics = io_metrics.clone();
-
-            async move {
-                if range.is_empty() {
-                    return Ok(Buffer::new());
-                }
-
-                let out = io_metrics
-                    .record_io_read(
-                        range.len() as u64,
-                        store.get_range(path, range.start as u64..range.end as u64),
-                    )
-                    .await?;
-
-                Ok(Buffer::from_owner(out))
-            }
-        }))
-        // Add a limit locally as this gets run inside a single `tune_with_concurrency_budget`.
-        .buffered(get_concurrency_limit() as usize)
-    }
-
     pub async fn get_range(&self, path: &Path, range: Range<usize>) -> PolarsResult<Buffer<u8>> {
         if range.is_empty() {
             return Ok(Buffer::new());
@@ -195,13 +301,13 @@ impl PolarsObjectStore {
 
         let io_metrics = self.io_metrics();
 
-        self.try_exec_rebuild_on_err(move |store| {
+        self.try_exec_rebuild_on_err(move |store_cx| {
             let range = range.clone();
-            let st = store.clone();
+            let cx = store_cx.clone();
             let io_metrics = io_metrics.clone();
 
             async move {
-                let store = st;
+                let store_cx = cx;
                 let parts = split_range(range.clone());
 
                 if parts.len() == 1 {
@@ -209,7 +315,9 @@ impl PolarsObjectStore {
                         let bytes = io_metrics
                             .record_io_read(
                                 range.len() as u64,
-                                store.get_range(path, range.start as u64..range.end as u64),
+                                store_cx.exec_with_store(|s| {
+                                    s.get_range(path, range.start as u64..range.end as u64)
+                                }),
                             )
                             .await?;
 
@@ -222,7 +330,8 @@ impl PolarsObjectStore {
                     let parts = tune_with_concurrency_budget(
                         parts.len().clamp(0, MAX_BUDGET_PER_REQUEST) as u32,
                         || {
-                            Self::get_buffered_ranges_stream(&store, path, parts, io_metrics)
+                            store_cx
+                                .build_buffered_ranges_stream(path, parts, io_metrics)
                                 .try_collect::<Vec<Buffer<u8>>>()
                         },
                     )
@@ -263,16 +372,15 @@ impl PolarsObjectStore {
         let (merged_ranges, merged_ends): (Vec<_>, Vec<_>) = merge_ranges(ranges).unzip();
         let io_metrics = self.io_metrics();
 
-        self.try_exec_rebuild_on_err(|store| {
-            let st = store.clone();
+        self.try_exec_rebuild_on_err(|store_cx| {
+            let cx = store_cx.clone();
             let io_metrics = io_metrics.clone();
 
             async {
-                let store = st;
+                let store_cx = cx;
                 let mut out = PlHashMap::with_capacity(ranges_len);
 
-                let mut stream = Self::get_buffered_ranges_stream(
-                    &store,
+                let mut stream = store_cx.build_buffered_ranges_stream(
                     path,
                     merged_ranges.iter().cloned(),
                     io_metrics,
@@ -356,8 +464,8 @@ impl PolarsObjectStore {
         let initial_pos = file.stream_position().await?;
         let io_metrics = self.io_metrics();
 
-        self.try_exec_rebuild_on_err(|store| {
-            let st = store.clone();
+        self.try_exec_rebuild_on_err(|store_cx| {
+            let cx = store_cx.clone();
             let io_metrics = io_metrics.clone();
 
             // Workaround for "can't move captured variable".
@@ -366,7 +474,7 @@ impl PolarsObjectStore {
             async {
                 file.set_len(initial_pos).await?; // Reset if this function was called again.
 
-                let store = st;
+                let store_cx = cx;
                 let parts = opt_size
                     .map(|x| split_range(0..x as usize))
                     .filter(|x| x.len() > 1);
@@ -376,7 +484,7 @@ impl PolarsObjectStore {
                         parts.len().clamp(0, MAX_BUDGET_PER_REQUEST) as u32,
                         || async {
                             let mut stream =
-                                Self::get_buffered_ranges_stream(&store, path, parts, io_metrics);
+                                store_cx.build_buffered_ranges_stream(path, parts, io_metrics);
                             let mut len = 0;
                             while let Some(bytes) = stream.try_next().await? {
                                 len += bytes.len();
@@ -393,7 +501,7 @@ impl PolarsObjectStore {
                     tune_with_concurrency_budget(1, || async {
                         let io_session = io_metrics.start_io_session();
 
-                        let mut stream = store.get(path).await?.into_stream();
+                        let mut stream = store_cx.get_into_stream(path).await?;
                         let mut len = 0;
 
                         while let Some(bytes) = stream.try_next().await? {
@@ -424,15 +532,18 @@ impl PolarsObjectStore {
     pub async fn head(&self, path: &Path) -> PolarsResult<ObjectMeta> {
         let io_metrics = self.io_metrics();
 
-        self.try_exec_rebuild_on_err(|store| {
-            let st = store.clone();
+        self.try_exec_rebuild_on_err(|store_cx| {
+            let cx = store_cx.clone();
             let io_metrics = io_metrics.clone();
 
             async move {
                 with_concurrency_budget(1, || async {
-                    let store = st;
+                    let store_cx = cx;
                     let head_result = io_metrics
-                        .record_io_read(HEAD_RESPONSE_SIZE_ESTIMATE, store.head(path))
+                        .record_io_read(
+                            HEAD_RESPONSE_SIZE_ESTIMATE,
+                            store_cx.exec_with_store(|s| s.head(path)),
+                        )
                         .await;
 
                     if head_result.is_err() {
@@ -441,13 +552,15 @@ impl PolarsObjectStore {
                         let get_range_0_1_result = io_metrics
                             .record_io_read(
                                 HEAD_RESPONSE_SIZE_ESTIMATE + 1,
-                                store.get_opts(
-                                    path,
-                                    object_store::GetOptions {
-                                        range: Some((0..1).into()),
-                                        ..Default::default()
-                                    },
-                                ),
+                                store_cx.exec_with_store(|s| {
+                                    s.get_opts(
+                                        path,
+                                        object_store::GetOptions {
+                                            range: Some((0..1).into()),
+                                            ..Default::default()
+                                        },
+                                    )
+                                }),
                             )
                             .await;
 


### PR DESCRIPTION
The primary driver for this is distributed, so we know which connections fail and use this as part of machine/connection health monitoring.

@nameexhaustion 