### PR TITLE
fix: Correct off-by-one in RLE row counting for nullable dictionary-encoded columns

### DIFF
--- a/crates/polars-parquet/src/arrow/read/deserialize/dictionary_encoded/optional.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/dictionary_encoded/optional.rs
@@ -76,15 +76,15 @@ pub fn decode<B: AlignedBytes, D: IndexMapping<Output = B>>(
             debug_assert!(num_values_to_skip < chunk.len() || chunk.len() == 0);
 
             match chunk {
-                HybridRleChunk::Rle(value, size) => {
-                    if size == 0 {
+                HybridRleChunk::Rle(value, length) => {
+                    if length == 0 {
                         continue;
                     }
 
-                    // If we know that we have `size` times `value` that we can append, but there
+                    // If we know that we have `length` times `value` that we can append, but there
                     // might be nulls in between those values.
                     //
-                    // 1. See how many `num_rows = valid + invalid` values `size` would entail.
+                    // 1. See how many `num_rows = valid + invalid` values `length` would entail.
                     //    This is done with `nth_set_bit_idx` on the validity mask.
                     // 2. Fill `num_rows` values into the target buffer.
                     // 3. Advance the validity mask by `num_rows` values.
@@ -93,8 +93,23 @@ pub fn decode<B: AlignedBytes, D: IndexMapping<Output = B>>(
                         return Err(oob_dict_idx());
                     };
 
-                    let num_chunk_rows =
-                        validity.nth_set_bit_idx(size, 0).unwrap_or(validity.len());
+                    // We have `length` values but they may span more rows due to interspersed nulls.
+                    //
+                    // Example: validity = [1,0,0,0,1,0,0,0,1,0,0, 1, 1, 1] and length = 3
+                    //          positions:  0 1 2 3 4 5 6 7 8 9 10 11 12 13
+                    //          indices:    0       1       2      3  4  5  (of set bits)
+                    //
+                    // First RLE chunk owns 3 values at positions 0, 4, 8 (sparse, many nulls).
+                    // Second RLE chunk owns values at positions 11, 12, 13.
+                    //
+                    // Correct: nth_set_bit_idx(length-1 = 2, 0) = 8  → rows = 8+1 = 9 (rows 0-8) ✓
+                    // Bug:     nth_set_bit_idx(length = 3, 0)   = 11 → rows = 11   (rows 0-10!)
+                    //
+                    // The bug claims rows 9, 10 which are nulls belonging to the second chunk.
+                    let num_chunk_rows = validity
+                        .nth_set_bit_idx(length - 1, 0)
+                        .map_or(validity.len(), |v| v + 1);
+
                     validity.advance_by(num_chunk_rows);
 
                     target.resize(target.len() + num_chunk_rows - num_rows_to_skip, value);
@@ -198,4 +213,62 @@ pub fn decode<B: AlignedBytes, D: IndexMapping<Output = B>>(
     target.resize(end_length, B::zeroed());
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow::bitmap::Bitmap;
+    use arrow::types::Bytes4Alignment4;
+
+    use super::decode;
+    use crate::parquet::encoding::hybrid_rle::{Encoder, HybridRleDecoder};
+
+    /// Position:  0  1  2  3  4  5  6  7  8  9 10 11 12 13
+    /// Validity:  1  0  0  0  1  0  0  0  1  0  0  1  1  1
+    /// Value:    66          66          66       99 99 99
+    ///           |----chunk0 (3 values)----|      |-chunk1-|
+    ///
+    /// Chunk0 owns rows 0-8 (9 rows), chunk1 owns rows 9-13 (5 rows).
+    /// Positions 9,10 are nulls that belong to chunk1, so they get filled with 99.
+    ///
+    /// BUG: `nth_set_bit_idx(length=3, 0)` returns 11, so chunk0 claims rows 0-10.
+    ///      Positions 9,10 get filled with 66 (wrong - they belong to chunk1).
+    ///
+    /// FIX: `nth_set_bit_idx(length-1=2, 0) + 1` returns 9, so chunk0 claims rows 0-8.
+    ///      Positions 9,10 get filled with 99 (correct - they belong to chunk1).
+    #[test]
+    fn test_rle_decode_with_sparse_nulls() {
+        // Bitmap bits (LSB first within each byte):
+        // Byte 0: positions 0-7  = 1,0,0,0,1,0,0,0 = 0b00010001
+        // Byte 1: positions 8-13 = 1,0,0,1,1,1     = 0b00111001
+        let validity_bytes: Vec<u8> = vec![0b00010001, 0b00111001];
+        let validity = Bitmap::try_new(validity_bytes, 14).unwrap();
+
+        let mut encoded = Vec::new();
+        u32::run_length_encode(&mut encoded, 3, 0, 1).unwrap(); // 3x dict index 0
+        u32::run_length_encode(&mut encoded, 3, 1, 1).unwrap(); // 3x dict index 1
+
+        let dict: &[Bytes4Alignment4] = bytemuck::cast_slice(&[66u32, 99u32]);
+        let decoder = HybridRleDecoder::new(&encoded, 1, 6); // 6 total values
+
+        let mut target = Vec::new();
+        decode(decoder, dict, validity, &mut target, 0).unwrap();
+
+        assert_eq!(target.len(), 14, "should have 14 rows");
+
+        // Valid positions in chunk0 (dict[0]=66): positions 0, 4, 8
+        assert_eq!(target[0], dict[0], "position 0 should be dict[0]");
+        assert_eq!(target[4], dict[0], "position 4 should be dict[0]");
+        assert_eq!(target[8], dict[0], "position 8 should be dict[0]");
+
+        // Valid positions in chunk1 (dict[1]=99): positions 11, 12, 13
+        assert_eq!(target[11], dict[1], "position 11 should be dict[1]");
+        assert_eq!(target[12], dict[1], "position 12 should be dict[1]");
+        assert_eq!(target[13], dict[1], "position 13 should be dict[1]");
+
+        // Null positions 9,10 belong to chunk1, so they should be filled with dict[1].
+        // BUG: These would be dict[0] if chunk0 incorrectly claims rows 0-10.
+        assert_eq!(target[9], dict[1], "position 9 (null) should be dict[1]");
+        assert_eq!(target[10], dict[1], "position 10 (null) should be dict[1]");
+    }
 }


### PR DESCRIPTION
Fixes #19867