### PR TITLE
fix(rust): Handle empty lists in list.agg with scalar aggregations

### DIFF
--- a/crates/polars-expr/src/expressions/eval.rs
+++ b/crates/polars-expr/src/expressions/eval.rs
@@ -178,7 +178,7 @@ impl EvalExpr {
                     let null_count = expected_len - values.len();
                     let nulls =
                         Column::full_null(values.name().clone(), null_count, values.dtype());
-                    values = values.extend(&nulls)?;
+                    values.extend(&nulls)?;
                 }
                 values = values.deposit(&validity);
             }
@@ -341,7 +341,7 @@ impl EvalExpr {
                     let null_count = expected_len - values.len();
                     let nulls =
                         Column::full_null(values.name().clone(), null_count, values.dtype());
-                    values = values.extend(&nulls)?;
+                    values.extend(&nulls)?;
                 }
 
                 // Reinsert nulls according to the original validity bitmap.


### PR DESCRIPTION
Fixes #26237

When `list.agg()` is used with scalar aggregations (such as `first()`) on columns
containing a mix of nulls and empty lists, Polars may panic with an assertion
failure in `deposit()`.

This occurs because scalar aggregations on empty lists can produce no output,
while `deposit()` expects one value per valid group based on the validity bitmap,
leading to a length mismatch.

This PR pads the aggregation result with null values when necessary so the number
of values matches the number of valid groups before calling `deposit()`.

The fix is applied to functions:
- `evaluate_on_list_chunked`
- `evaluate_on_array_chunked`

AI disclosure
- I used AI assistance to help reason about the root cause .
- I have personally reviewed all code changes and confirm they are correct,
  relevant, and consistent with the existing codebase.
