### PR TITLE
demo - force group positions to match `AggState`

### DIFF
--- a/crates/polars-expr/src/expressions/mod.rs
+++ b/crates/polars-expr/src/expressions/mod.rs
@@ -195,6 +195,26 @@ impl<'a> AggregationContext<'a> {
                 self.det_groups_from_list(s.as_materialized_series());
             },
         }
+
+        match &self.state {
+            AggState::AggregatedList(_) | AggState::NotAggregated(_) => {},
+            AggState::AggregatedScalar(c) => {
+                assert_eq!(self.update_groups, UpdateGroups::No);
+                self.groups = Cow::Owned({
+                    let groups = (0..c.len() as IdxSize).map(|i| [i, 1]).collect();
+                    GroupsType::new_slice(groups, false, true).into_sliceable()
+                });
+            },
+            AggState::LiteralScalar(c) => {
+                assert_eq!(c.len(), 1);
+                assert_eq!(self.update_groups, UpdateGroups::No);
+                self.groups = Cow::Owned({
+                    let groups = vec![[0, 1]; self.groups.len()];
+                    GroupsType::new_slice(groups, true, true).into_sliceable()
+                });
+            },
+        }
+
         &self.groups
     }
 
@@ -638,26 +658,7 @@ impl<'a> AggregationContext<'a> {
 
     /// Fixes groups for `AggregatedScalar` and `LiteralScalar` so that they point to valid
     /// data elements in the `AggState` values.
-    fn set_groups_for_undefined_agg_states(&mut self) {
-        match &self.state {
-            AggState::AggregatedList(_) | AggState::NotAggregated(_) => {},
-            AggState::AggregatedScalar(c) => {
-                assert_eq!(self.update_groups, UpdateGroups::No);
-                self.groups = Cow::Owned({
-                    let groups = (0..c.len() as IdxSize).map(|i| [i, 1]).collect();
-                    GroupsType::new_slice(groups, false, true).into_sliceable()
-                });
-            },
-            AggState::LiteralScalar(c) => {
-                assert_eq!(c.len(), 1);
-                assert_eq!(self.update_groups, UpdateGroups::No);
-                self.groups = Cow::Owned({
-                    let groups = vec![[0, 1]; self.groups.len()];
-                    GroupsType::new_slice(groups, true, true).into_sliceable()
-                });
-            },
-        }
-    }
+    fn set_groups_for_undefined_agg_states(&mut self) {}
 
     pub fn into_static(&self) -> AggregationContext<'static> {
         let groups: GroupPositions = GroupPositions::to_owned(&self.groups);


### PR DESCRIPTION
This PR forces `GroupPositions` to match `AggState` within `AggregationContext`.

In doing so, multiple queries will fail - e.g.

```python
>>> df = pl.DataFrame({"a": [1, 1, 2, 2, 3], "b": [1, 2, 1, 2, 1]})
>>> df.group_by(pl.lit(1)).agg(a=pl.col("a").first().filter(pl.col("b") >= 0))
```

* Expected results
```
shape: (1, 2)
┌─────────┬─────────────┐
│ literal ┆ a           │
│ ---     ┆ ---         │
│ i32     ┆ list[i64]   │
╞═════════╪═════════════╡
│ 1       ┆ [1, 1, … 1] │
└─────────┴─────────────┘
```

* Results from this PR
```
shape: (1, 2)
┌─────────┬───────────┐
│ literal ┆ a         │
│ ---     ┆ ---       │
│ i32     ┆ list[i64] │
╞═════════╪═══════════╡
│ 1       ┆ [1]       │
└─────────┴───────────┘
```
