### PR TITLE
feat: Add primitive filter -> agg lowering in streaming GroupBy

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -946,10 +946,18 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 }
             }
 
-            let keys = index
+            let keys: Vec<_> = index
                 .into_iter()
                 .map(|i| AExprBuilder::col(i.clone(), ctxt.expr_arena).expr_ir(i))
                 .collect();
+
+            let mut uniq_names = PlHashSet::new();
+            for expr in keys.iter().chain(aggs.iter()) {
+                let name = expr.output_name();
+                let is_uniq = uniq_names.insert(name.clone());
+                polars_ensure!(is_uniq, duplicate = name);
+            }
+
             IRBuilder::new(input, ctxt.expr_arena, ctxt.lp_arena)
                 .group_by(keys, aggs, None, maintain_order, Default::default())
                 .build()

--- a/crates/polars-plan/src/plans/expr_ir.rs
+++ b/crates/polars-plan/src/plans/expr_ir.rs
@@ -109,6 +109,11 @@ impl ExprIR {
         }
     }
 
+    pub fn from_column_name(name: PlSmallStr, expr_arena: &mut Arena<AExpr>) -> Self {
+        let node = expr_arena.add(AExpr::Column(name.clone()));
+        ExprIR::new(node, OutputName::ColumnLhs(name))
+    }
+
     pub fn with_dtype(self, dtype: DataType) -> Self {
         let _ = self.output_dtype.set(dtype);
         self
@@ -325,8 +330,7 @@ impl From<&ExprIR> for Node {
 }
 
 pub(crate) fn name_to_expr_ir(name: PlSmallStr, expr_arena: &mut Arena<AExpr>) -> ExprIR {
-    let node = expr_arena.add(AExpr::Column(name.clone()));
-    ExprIR::new(node, OutputName::ColumnLhs(name))
+    ExprIR::from_column_name(name, expr_arena)
 }
 
 pub(crate) fn names_to_expr_irs<I, S>(names: I, expr_arena: &mut Arena<AExpr>) -> Vec<ExprIR>

--- a/crates/polars-stream/src/physical_plan/lower_group_by.rs
+++ b/crates/polars-stream/src/physical_plan/lower_group_by.rs
@@ -21,7 +21,9 @@ use crate::physical_plan::lower_expr::{
     build_hstack_stream, build_select_stream, compute_output_schema, is_elementwise_rec_cached,
     is_fake_elementwise_function, is_input_independent,
 };
-use crate::physical_plan::lower_ir::{build_row_idx_stream, build_slice_stream};
+use crate::physical_plan::lower_ir::{
+    build_filter_stream, build_row_idx_stream, build_slice_stream,
+};
 use crate::utils::late_materialized_df::LateMaterializedDataFrame;
 
 #[allow(clippy::too_many_arguments)]
@@ -588,6 +590,54 @@ fn try_build_streaming_group_by(
                     };
                     other_agg_input_streams.insert(input_id, (input_stream, Vec::new()));
                     all_keys_included_in_other_inputs = true;
+                },
+
+                AExpr::Filter {
+                    input: filter_input,
+                    by: predicate,
+                } => {
+                    if !is_elementwise_rec_cached(*filter_input, expr_arena, expr_cache)
+                        || !is_elementwise_rec_cached(*predicate, expr_arena, expr_cache)
+                    {
+                        return Ok(None);
+                    }
+
+                    // We have to uniquify the keys here to prevent name dupes since we uniquified them elsewhere.
+                    // TODO: use pre-select as input here.
+                    let mut select_exprs = Vec::new();
+                    let predicate_name = unique_column_name();
+                    for key_id in &key_ids {
+                        select_exprs.push(ExprIR::new(
+                            expr_merger.get_node(*key_id).unwrap(),
+                            OutputName::Alias(uniq_input_names[key_id].clone()),
+                        ));
+                    }
+                    select_exprs.push(ExprIR::new(
+                        *filter_input,
+                        OutputName::Alias(input_name.clone()),
+                    ));
+                    select_exprs.push(ExprIR::new(
+                        *predicate,
+                        OutputName::Alias(predicate_name.clone()),
+                    ));
+
+                    let mut stream = build_select_stream(
+                        input,
+                        &select_exprs,
+                        expr_arena,
+                        phys_sm,
+                        expr_cache,
+                        ctx,
+                    )?;
+                    stream = build_filter_stream(
+                        stream,
+                        ExprIR::from_column_name(predicate_name, expr_arena),
+                        expr_arena,
+                        phys_sm,
+                        expr_cache,
+                        ctx,
+                    )?;
+                    other_agg_input_streams.insert(input_id, (stream, Vec::new()));
                 },
                 _ => return Ok(None),
             }


### PR DESCRIPTION
This is primitive in that it doesn't yet optimally do common sub-expression elimination of the key expressions, and doesn't do recursive lowering, only `elementwise1.filter(elementwise2).agg()` is lowered. For example `(pl.col.x.filter(pl.col.x >= 0) + 1).sum()` does not yet get lowered by this.

But as an example, say we want to calculate not just a sum per group, but also the sum of positive and negative entries:

```python
df.lazy().group_by("g").agg(
    tot_sum = pl.col.x.sum(),
    pos_sum = pl.col.x.filter(pl.col.x >= 0).sum(),
    neg_sum = pl.col.x.filter(pl.col.x < 0).sum(),
)
```

This now gets lowered as such:

<img width="828" height="815" alt="image" src="https://github.com/user-attachments/assets/28738ed3-47b2-46da-901e-cc28ed27ed7c" />
