### PR TITLE
fix: apply thousands_separator to describe count for string columns

### DIFF
--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -1230,15 +1230,26 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         summary = dict(zip(schema, column_metrics, strict=True))
 
         # cast by column type (numeric/bool -> float), (other -> string)
+        # apply thousands separator to count values for non-numeric columns
+        thousands_sep = plr.get_thousands_separator()
+
+        def format_with_thousands_sep(v: Any, is_count: bool = False) -> str:
+            if is_count and thousands_sep and isinstance(v, (int, float)):
+                return f"{int(v):,}".replace(",", thousands_sep)
+            return str(v)
+
         for c in schema:
-            summary[c] = [  # type: ignore[assignment]
-                (
-                    None
-                    if (v is None or isinstance(v, dict))
-                    else (float(v) if (c in has_numeric_result) else str(v))
-                )
-                for v in summary[c]
-            ]
+            col_summary = []
+            for idx, v in enumerate(summary[c]):
+                if v is None or isinstance(v, dict):
+                    col_summary.append(None)
+                elif c in has_numeric_result:
+                    col_summary.append(float(v))
+                else:
+                    # apply thousands separator to count metrics for string columns
+                    is_count = metrics[idx] in ("count", "null_count")
+                    col_summary.append(format_with_thousands_sep(v, is_count))
+            summary[c] = col_summary  # type: ignore[assignment]
 
         # return results as a DataFrame
         df_summary = from_dict(summary)


### PR DESCRIPTION
Fixes #25946 - Applies thousands_separator to count values in describe() for string columns