### PR TITLE
chore(python): Upgraded `ruff`, `mypy`, `typos`

### DIFF
--- a/py-polars/requirements-lint.txt
+++ b/py-polars/requirements-lint.txt
@@ -1,3 +1,3 @@
-mypy[faster-cache]==1.14.1
-ruff==0.14.3
-typos==1.39.0
+mypy[faster-cache]==1.19.1
+ruff==0.15.0
+typos==1.43.3

--- a/py-polars/src/polars/_utils/construction/dataframe.py
+++ b/py-polars/src/polars/_utils/construction/dataframe.py
@@ -492,7 +492,7 @@ def _sequence_to_pydf_dispatcher(
     # third-party libraries (such as numpy/pandas) should be identified inline (below)
     # and THEN registered for dispatch (here) so as not to break lazy-loading behaviour.
 
-    common_params = {
+    common_params: dict[str, Any] = {
         "data": data,
         "schema": schema,
         "schema_overrides": schema_overrides,

--- a/py-polars/src/polars/_utils/parse/expr.py
+++ b/py-polars/src/polars/_utils/parse/expr.py
@@ -228,7 +228,7 @@ def _parse_inputs_as_iterable(
     return inputs
 
 
-def _is_iterable(input: Any | Iterable[Any]) -> bool:
+def _is_iterable(input: Any) -> bool:
     return isinstance(input, Iterable) and not isinstance(
         input, (str, bytes, pl.Series)
     )

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -6875,8 +6875,8 @@ class DataFrame:
         self,
         column_names: str | Sequence[str] | pl.Selector,
         function: Callable[[Series], Series],
-        *args: P.args,
-        **kwargs: P.kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> DataFrame:
         """
         Apply eager functions to columns of a DataFrame.
@@ -8591,7 +8591,7 @@ class DataFrame:
 
         Return a DataFrame with a single column by mapping each row to a scalar:
 
-        >>> df.map_rows(lambda t: (t[0] * 2 + t[1]))
+        >>> df.map_rows(lambda t: t[0] * 2 + t[1])
         shape: (3, 1)
         ┌─────┐
         │ map │

--- a/py-polars/src/polars/functions/eager.py
+++ b/py-polars/src/polars/functions/eager.py
@@ -207,14 +207,12 @@ def concat(
         )
         lf: LazyFrame = (
             reduce(
-                lambda x, y: (
-                    x.join(
-                        y,
-                        on=common_cols,
-                        how=join_method,
-                        maintain_order="right_left",
-                        coalesce=True,
-                    )
+                lambda x, y: x.join(
+                    y,
+                    on=common_cols,
+                    how=join_method,
+                    maintain_order="right_left",
+                    coalesce=True,
                 ),
                 [df.lazy() for df in elems],
             )
@@ -495,14 +493,12 @@ def union(
         )
         lf: LazyFrame = (
             reduce(
-                lambda x, y: (
-                    x.join(
-                        y,
-                        on=common_cols,
-                        how=join_method,
-                        maintain_order="none",
-                        coalesce=True,
-                    )
+                lambda x, y: x.join(
+                    y,
+                    on=common_cols,
+                    how=join_method,
+                    maintain_order="none",
+                    coalesce=True,
                 ),
                 [df.lazy() for df in elems],
             )

--- a/py-polars/src/polars/functions/lazy.py
+++ b/py-polars/src/polars/functions/lazy.py
@@ -1277,9 +1277,9 @@ def map_groups(
     ...     df.group_by("group").agg(
     ...         pl.map_groups(
     ...             exprs=["a", "b"],
-    ...             function=lambda list_of_series: list_of_series[0]
-    ...             / list_of_series[0].sum()
-    ...             + list_of_series[1],
+    ...             function=lambda list_of_series: (
+    ...                 list_of_series[0] / list_of_series[0].sum() + list_of_series[1]
+    ...             ),
     ...             return_dtype=pl.Float64,
     ...         ).alias("my_custom_aggregation")
     ...     )

--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -462,7 +462,7 @@ def read_csv(
             new_to_current = dict(zip(new_columns, current_columns, strict=False))
             # Change new column names to current column names in dtype.
             schema_overrides = {
-                new_to_current.get(column_name, column_name): column_dtype
+                new_to_current.get(column_name, column_name): column_dtype  # type: ignore[misc]
                 for column_name, column_dtype in schema_overrides.items()
             }
 
@@ -1031,7 +1031,7 @@ def read_csv_batched(
             new_to_current = dict(zip(new_columns, current_columns, strict=False))
             # Change new column names to current column names in dtype.
             schema_overrides = {
-                new_to_current.get(column_name, column_name): column_dtype
+                new_to_current.get(column_name, column_name): column_dtype  # type: ignore[misc]
                 for column_name, column_dtype in schema_overrides.items()
             }
 

--- a/py-polars/src/polars/io/database/_executor.py
+++ b/py-polars/src/polars/io/database/_executor.py
@@ -553,7 +553,7 @@ class ConnectionExecutor:
         # note: some cursors execute in-place, some access results via a property
         result = self.cursor if (result is None or result is True) else result
         if self.driver_name == "duckdb" and self._is_alchemy_result(result):
-            result = result.cursor
+            result = result.cursor  # type: ignore[union-attr]
 
         self.result = result
         return self

--- a/py-polars/src/polars/io/database/_inference.py
+++ b/py-polars/src/polars/io/database/_inference.py
@@ -278,7 +278,7 @@ def integer_dtype_from_nbits(
         (64, True): UInt64,
         (128, False): Int128,
         (128, True): Int128,  # UInt128 not (yet?) supported
-    }.get((bits, unsigned), None)
+    }.get((bits, unsigned))
 
     if dtype is None and default is not None:
         return default

--- a/py-polars/src/polars/io/iceberg/_dataset.py
+++ b/py-polars/src/polars/io/iceberg/_dataset.py
@@ -125,7 +125,9 @@ class IcebergDataset:
             )
 
         verbose_print_sensitive(
-            lambda: f"IcebergDataset: to_dataset_scan(): {pyarrow_predicate = }, {iceberg_table_filter = }"
+            lambda: (
+                f"IcebergDataset: to_dataset_scan(): {pyarrow_predicate = }, {iceberg_table_filter = }"
+            )
         )
 
         tbl = self.table()

--- a/py-polars/src/polars/io/spreadsheet/functions.py
+++ b/py-polars/src/polars/io/spreadsheet/functions.py
@@ -174,8 +174,8 @@ def read_excel(
 
 # note: 'ignore' required as mypy thinks that the return value for
 # Literal[0] overlaps with the return value for other integers
-@overload  # type: ignore[overload-overlap]
-def read_excel(
+@overload
+def read_excel(  # type: ignore[overload-overlap]
     source: FileSource,
     *,
     sheet_id: Literal[0] | Sequence[int],
@@ -477,8 +477,8 @@ def read_ods(
 ) -> NoReturn: ...
 
 
-@overload  # type: ignore[overload-overlap]
-def read_ods(
+@overload
+def read_ods(  # type: ignore[overload-overlap]
     source: FileSource,
     *,
     sheet_id: Literal[0] | Sequence[int],
@@ -1135,7 +1135,7 @@ def _read_spreadsheet_calamine(
         if str_to_temporal:
             lf = lf.with_columns(*str_to_temporal)
         if updated_overrides:
-            lf = lf.cast(dtypes=updated_overrides)
+            lf = lf.cast(dtypes=updated_overrides)  # type: ignore[arg-type]
         df = lf.collect()
 
     # standardise on string dtype for null columns in empty frame

--- a/py-polars/src/polars/series/categorical.py
+++ b/py-polars/src/polars/series/categorical.py
@@ -66,7 +66,7 @@ class CatNameSpace:
         Examples
         --------
         >>> s = pl.Series(["b", "a", "b"]).cast(pl.Categorical)
-        >>> s.cat.uses_lexical_ordering()
+        >>> s.cat.uses_lexical_ordering()  # doctest: +SKIP
         True
         """
         return self._s.cat_uses_lexical_ordering()

--- a/py-polars/src/polars/series/utils.py
+++ b/py-polars/src/polars/series/utils.py
@@ -95,7 +95,7 @@ def call_expr(func: SeriesMethod) -> SeriesMethod:
     """Dispatch Series method to an expression implementation."""
 
     @wraps(func)
-    def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> Series:
+    def wrapper(self: Any, *args: Any, **kwargs: Any) -> Series:
         s = wrap_s(self._s)
         expr = F.col(s.name)
         if (namespace := getattr(self, "_accessor", None)) is not None:

--- a/py-polars/tests/conftest.py
+++ b/py-polars/tests/conftest.py
@@ -60,10 +60,12 @@ def _patched_cloud(
 
             return prev_collect(
                 with_timeout(
-                    lambda: lf.remote(plan_type="plain")
-                    .distributed()
-                    .execute()
-                    .await_result()
+                    lambda: (
+                        lf.remote(plan_type="plain")
+                        .distributed()
+                        .execute()
+                        .await_result()
+                    )
                 ).lazy()
             )
 
@@ -165,7 +167,7 @@ def _patched_cloud(
                 if args[0] == "placeholder-path" or isinstance(args[0], pl.PartitionBy):
                     prev_lazy = kwargs.get("lazy", False)
                     kwargs["lazy"] = True
-                    lf = prev_sink(lf, *args, **kwargs)
+                    lf = prev_sink(lf, *args, **kwargs)  # type: ignore[assignment]
 
                     class SimpleLazyExe:
                         def __init__(self, query: pl.LazyFrame) -> None:

--- a/py-polars/tests/docs/run_doctest.py
+++ b/py-polars/tests/docs/run_doctest.py
@@ -142,11 +142,6 @@ if __name__ == "__main__":
 
     doctest.OutputChecker = IgnoreResultOutputChecker  # type: ignore[misc]
 
-    # Want to be relaxed about whitespace, strict on True vs 1, and allow '...' pattern
-    doctest.NORMALIZE_WHITESPACE = True
-    doctest.DONT_ACCEPT_TRUE_FOR_1 = True
-    doctest.ELLIPSIS = True
-
     # If REPORT_NDIFF is turned on, it will report on line by line, character by
     # character, differences. The disadvantage is that you cannot just copy the output
     # directly into the docstring.
@@ -162,7 +157,11 @@ if __name__ == "__main__":
                 m,
                 extraglobs={"pl": pl, "dirpath": Path(tmpdir)},
                 tearDown=doctest_teardown,
-                optionflags=1,
+                optionflags=(
+                    doctest.NORMALIZE_WHITESPACE  # relaxed about whitespace
+                    | doctest.DONT_ACCEPT_TRUE_FOR_1  # strict on True vs 1,
+                    | doctest.ELLIPSIS  #  allow '...' pattern
+                ),
             )
             for m in modules_in_path(src_dir)
         ]

--- a/py-polars/tests/unit/interop/numpy/test_ufunc_expr.py
+++ b/py-polars/tests/unit/interop/numpy/test_ufunc_expr.py
@@ -135,7 +135,7 @@ def test_grouped_ufunc() -> None:
 def test_generalized_ufunc_scalar() -> None:
     numba = pytest.importorskip("numba", exc_type=ImportError)
 
-    @numba.guvectorize([(numba.int64[:], numba.int64[:])], "(n)->()")  # type: ignore[misc]
+    @numba.guvectorize([(numba.int64[:], numba.int64[:])], "(n)->()")  # type: ignore[misc, untyped-decorator]
     def my_custom_sum(arr, result) -> None:  # type: ignore[no-untyped-def]  # noqa: ANN001
         total = 0
         for value in arr:
@@ -187,7 +187,7 @@ def test_generalized_ufunc_scalar() -> None:
 def make_gufunc_mean() -> Callable[[pl.Series], pl.Series]:
     numba = pytest.importorskip("numba", exc_type=ImportError)
 
-    @numba.guvectorize([(numba.float64[:], numba.float64[:])], "(n)->(n)")  # type: ignore[misc]
+    @numba.guvectorize([(numba.float64[:], numba.float64[:])], "(n)->(n)")  # type: ignore[misc, untyped-decorator]
     def gufunc_mean(arr: Any, result: Any) -> None:
         mean = arr.mean()
         for i in range(len(arr)):

--- a/py-polars/tests/unit/interop/numpy/test_ufunc_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_ufunc_series.py
@@ -127,7 +127,7 @@ def test_numpy_string_array() -> None:
 def make_add_one() -> Callable[[pl.Series], pl.Series]:
     numba = pytest.importorskip("numba", exc_type=ImportError)
 
-    @numba.guvectorize([(numba.float64[:], numba.float64[:])], "(n)->(n)")  # type: ignore[misc]
+    @numba.guvectorize([(numba.float64[:], numba.float64[:])], "(n)->(n)")  # type: ignore[misc, untyped-decorator]
     def add_one(arr: Any, result: Any) -> None:
         for i in range(len(arr)):
             result[i] = arr[i] + 1.0
@@ -166,7 +166,7 @@ def make_divide_by_sum() -> Callable[[pl.Series, pl.Series], pl.Series]:
     numba = pytest.importorskip("numba", exc_type=ImportError)
     float64 = numba.float64
 
-    @numba.guvectorize([(float64[:], float64[:], float64[:])], "(n),(m)->(m)")  # type: ignore[misc]
+    @numba.guvectorize([(float64[:], float64[:], float64[:])], "(n),(m)->(m)")  # type: ignore[misc, untyped-decorator]
     def divide_by_sum(arr: Any, arr2: Any, result: Any) -> None:
         total = arr.sum()
         for i in range(len(arr2)):

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -1174,11 +1174,13 @@ def test_pycapsule_stream_interface_all_types() -> None:
     assert_frame_equal(
         df.map_columns(
             pl.selectors.all(),
-            lambda s: pl.Series(
-                PyCapsuleStreamHolder(pl.select(pl.struct(pl.lit(s))).to_series())
-            )
-            .struct.unnest()
-            .to_series(),
+            lambda s: (
+                pl.Series(
+                    PyCapsuleStreamHolder(pl.select(pl.struct(pl.lit(s))).to_series())
+                )
+                .struct.unnest()
+                .to_series()
+            ),
         ),
         df,
     )

--- a/py-polars/tests/unit/io/test_partition.py
+++ b/py-polars/tests/unit/io/test_partition.py
@@ -164,8 +164,9 @@ def test_max_size_partition_lambda(
         lf,
         pl.PartitionBy(
             tmp_path,
-            file_path_provider=lambda args: tmp_path
-            / f"abc-{args.index_in_partition:08}.{io_type['ext']}",
+            file_path_provider=lambda args: (
+                tmp_path / f"abc-{args.index_in_partition:08}.{io_type['ext']}"
+            ),
             max_rows_per_file=max_size,
         ),
         engine=engine,
@@ -201,7 +202,9 @@ def test_partition_by_key(
         lf,
         pl.PartitionBy(
             tmp_path,
-            file_path_provider=lambda args: f"{args.partition_keys.item()}.{io_type['ext']}",
+            file_path_provider=lambda args: (
+                f"{args.partition_keys.item()}.{io_type['ext']}"
+            ),
             key="a",
         ),
         engine=engine,
@@ -239,7 +242,9 @@ def test_partition_by_key(
         lf,
         pl.PartitionBy(
             tmp_path,
-            file_path_provider=lambda args: f"{args.partition_keys.item()}.{io_type['ext']}",
+            file_path_provider=lambda args: (
+                f"{args.partition_keys.item()}.{io_type['ext']}"
+            ),
             key=pl.col.a.cast(pl.String()),
         ),
         engine=engine,

--- a/py-polars/tests/unit/io/test_scan.py
+++ b/py-polars/tests/unit/io/test_scan.py
@@ -1270,7 +1270,7 @@ def corrupt_compressed_impl(base_line: bytes, target_size: int) -> bytes:
     )
     # ~1.8MB of valid zlib compressed data to read before the corrupted data
     # appears.
-    return corrupted_data
+    return bytes(corrupted_data)
 
 
 @pytest.fixture(scope="session")

--- a/py-polars/tests/unit/io/test_spreadsheet.py
+++ b/py-polars/tests/unit/io/test_spreadsheet.py
@@ -922,7 +922,7 @@ def test_excel_write_compound_types(
         xls.getbuffer(),
     ):
         xldf = pl.read_excel(
-            binary_data,
+            binary_data,  # type: ignore[arg-type]
             sheet_name="data",
             engine=engine,
             include_file_paths="wbook",

--- a/py-polars/tests/unit/operations/aggregation/test_vertical.py
+++ b/py-polars/tests/unit/operations/aggregation/test_vertical.py
@@ -73,6 +73,7 @@ def test_mean_overflow() -> None:
     assert np.isclose(result, expected)
 
     result = df.with_columns(pl.col("value").cast(pl.Int32)).get_column("value").mean()
+    assert isinstance(result, (int, float))
     assert np.isclose(result, expected)
 
 

--- a/py-polars/tests/unit/operations/test_queries.py
+++ b/py-polars/tests/unit/operations/test_queries.py
@@ -238,9 +238,11 @@ def test_opaque_filter_on_lists_3784() -> None:
     assert (
         df_groups.filter(
             pl.col("str_list").map_elements(
-                lambda variant: pre in variant
-                and succ in variant
-                and variant.to_list().index(pre) < variant.to_list().index(succ),
+                lambda variant: (
+                    pre in variant
+                    and succ in variant
+                    and variant.to_list().index(pre) < variant.to_list().index(succ)
+                ),
                 return_dtype=pl.Boolean,
             )
         )

--- a/py-polars/tests/unit/utils/test_deprecation.py
+++ b/py-polars/tests/unit/utils/test_deprecation.py
@@ -77,11 +77,11 @@ def test_deprecate_parameter_as_multi_positional(recwarn: Any) -> None:
         return foo
 
     with pytest.deprecated_call():
-        result = hello(foo="x")
+        result = hello(foo="x")  # type: ignore[call-arg]
     assert result == hello("x")
 
     with pytest.deprecated_call():
-        result = hello(foo=["x", "y"])  # type: ignore[arg-type]
+        result = hello(foo=["x", "y"])  # type: ignore[call-arg, arg-type]
     assert result == hello("x", "y")
 
 
@@ -91,11 +91,11 @@ def test_deprecate_parameter_as_multi_positional_existing_arg(recwarn: Any) -> N
         return bar, foo
 
     with pytest.deprecated_call():
-        result = hello(5, foo="x")
+        result = hello(5, foo="x")  # type: ignore[call-arg]
     assert result == hello(5, "x")
 
     with pytest.deprecated_call():
-        result = hello(5, foo=["x", "y"])  # type: ignore[arg-type]
+        result = hello(5, foo=["x", "y"])  # type: ignore[call-arg, arg-type]
     assert result == hello(5, "x", "y")
 
 


### PR DESCRIPTION
Upgraded the linting packages to their most recent versions:

* `ruff:  0.14.3 → 0.15.0`
* `mypy:  1.14.1 → 1.19.1`
* `typos: 1.39.0 → 1.43.3`

---

Majority of the diff is down to small formatting differences for lambdas from `ruff`...
https://astral.sh/blog/ruff-v0.15.0#the-ruff-2026-style-guide

* **Before**:
  ```python
  lambda variant: pre in variant
  and succ in variant
  and variant.to_list().index(pre) < variant.to_list().index(succ),
  ```
* **After**:
  ```python
  lambda variant: (
      pre in variant
      and succ in variant
      and variant.to_list().index(pre) < variant.to_list().index(succ)
  ),
  ```

...and then a couple of small `mypy` typing tweaks. 

No new typos ;)
