### PR TITLE
fix(python): Correct type hint for `map_columns` function parameter

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -6874,9 +6874,9 @@ class DataFrame:
     def map_columns(
         self,
         column_names: str | Sequence[str] | pl.Selector,
-        function: Callable[[Series], Series],
-        *args: Any,
-        **kwargs: Any,
+        function: Callable[Concatenate[Series, P], Series],
+        *args: P.args,
+        **kwargs: P.kwargs,
     ) -> DataFrame:
         """
         Apply eager functions to columns of a DataFrame.


### PR DESCRIPTION
## Summary

Fixes #26371

The type hint for the `function` parameter in `DataFrame.map_columns` was `Callable[[Series], Series]`, which incorrectly implied the function only accepts a single `Series` argument. However, the implementation passes `*args` and `**kwargs` to the function (line 6964).

This PR updates the type hint to `Callable[Concatenate[Series, P], Series]` using `ParamSpec` to accurately reflect that the function can accept additional positional and keyword arguments after the `Series` parameter.

## Changes

- Updated `function` parameter type hint from `Callable[[Series], Series]` to `Callable[Concatenate[Series, P], Series]`
- Updated `*args` type hint from `Any` to `P.args`
- Updated `**kwargs` type hint from `Any` to `P.kwargs`
- The `ParamSpec` `P` was already defined in the TYPE_CHECKING block (line 206)

## Test Plan

Created and ran a test script demonstrating the fix:

```python
import polars as pl

def function(s: pl.Series, a: int, b: int = 0) -> pl.Series:
    return a * s + b

df = pl.DataFrame({"a": [1, 2]})
df.map_columns("a", function, 1, b=2)  # Now correctly type-checked
```

The code executes correctly and type checkers can now properly validate that functions passed to `map_columns` can accept additional arguments beyond the Series parameter.