### PR TITLE
Avoid warning when map an Object

### DIFF
--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -5092,7 +5092,11 @@ Consider using {self}.implode() instead"""
         from polars._utils.udfs import warn_on_inefficient_map
 
         root_names = self.meta.root_names()
-        if len(root_names) > 0:
+        if (
+            return_dtype is None
+            or isinstance(return_dtype, pl.DataTypeExpr)
+            or (not return_dtype.is_object() and len(root_names) > 0)
+        ):
             warn_on_inefficient_map(function, columns=root_names, map_target="expr")
 
         if pass_name:

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -6089,7 +6089,8 @@ class Series:
         else:
             pl_return_dtype = parse_into_dtype(return_dtype)
 
-        warn_on_inefficient_map(function, columns=[self.name], map_target="series")
+        if pl_return_dtype is None or not pl_return_dtype.is_object():
+            warn_on_inefficient_map(function, columns=[self.name], map_target="series")
         return self._from_pyseries(
             self._s.map_elements(
                 function, return_dtype=pl_return_dtype, skip_nulls=skip_nulls


### PR DESCRIPTION
fixes #26481

No raise a warning when the user uses
`map_elements(json.loads, pl.Object)` in a Object type. Because Polars doesn't have native support to Object by design

pl.Object is fundamentally incompatible with Polars' design

pl.Object stores opaque Python objects (bypasses Rust entirely) str.json_decode() is a native Rust implementation for performance Adding pl.Object support would require:

Calling back into Python from Rust (slow, defeats the purpose) Or duplicating json.loads logic in Rust just to wrap it in Object (pointless)

We should allow to user to use Object when it is required

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
