### PR TITLE
chore: Implement `TotalOrd` for `Anyvalue<'_>`

### DIFF
--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -1460,6 +1460,126 @@ impl TotalEq for AnyValue<'_> {
     }
 }
 
+impl TotalOrd for AnyValue<'_> {
+    /// Only implemented for the same types and physical types!
+    ///
+    /// ## Panics
+    ///   * When both values are not of the same type
+    ///   * When total ordering is not supported for the AnyValue type
+    fn tot_cmp(&self, other: &Self) -> Ordering {
+        use AnyValue::*;
+        match (self, &other) {
+            // Map to borrowed.
+            (StringOwned(l), r) => AnyValue::String(l.as_str()).tot_cmp(r),
+            (BinaryOwned(l), r) => AnyValue::Binary(l.as_slice()).tot_cmp(r),
+            #[cfg(feature = "object")]
+            (ObjectOwned(l), r) => AnyValue::Object(&*l.0).tot_cmp(r),
+            (l, StringOwned(r)) => l.tot_cmp(&AnyValue::String(r.as_str())),
+            (l, BinaryOwned(r)) => l.tot_cmp(&AnyValue::Binary(r.as_slice())),
+            #[cfg(feature = "object")]
+            (l, ObjectOwned(r)) => l.tot_cmp(&AnyValue::Object(&*r.0)),
+            #[cfg(feature = "dtype-datetime")]
+            (DatetimeOwned(lv, ltu, ltz), r) => {
+                Datetime(*lv, *ltu, ltz.as_ref().map(|v| v.as_ref())).tot_cmp(r)
+            },
+            #[cfg(feature = "dtype-datetime")]
+            (l, DatetimeOwned(rv, rtu, rtz)) => {
+                l.tot_cmp(&Datetime(*rv, *rtu, rtz.as_ref().map(|v| v.as_ref())))
+            },
+            #[cfg(feature = "dtype-categorical")]
+            (CategoricalOwned(cat, map), r) => Categorical(*cat, map).tot_cmp(r),
+            #[cfg(feature = "dtype-categorical")]
+            (l, CategoricalOwned(cat, map)) => l.tot_cmp(&Categorical(*cat, map)),
+            #[cfg(feature = "dtype-categorical")]
+            (EnumOwned(cat, map), r) => Enum(*cat, map).tot_cmp(r),
+            #[cfg(feature = "dtype-categorical")]
+            (l, EnumOwned(cat, map)) => l.tot_cmp(&Enum(*cat, map)),
+
+            // Comparison with null.
+            (Null, Null) => Ordering::Equal,
+            (Null, _) => Ordering::Less,
+            (_, Null) => Ordering::Greater,
+
+            // Comparison between equal types.
+            (Boolean(l), Boolean(r)) => l.tot_cmp(r),
+            (UInt8(l), UInt8(r)) => l.tot_cmp(r),
+            (UInt16(l), UInt16(r)) => l.tot_cmp(r),
+            (UInt32(l), UInt32(r)) => l.tot_cmp(r),
+            (UInt64(l), UInt64(r)) => l.tot_cmp(r),
+            (UInt128(l), UInt128(r)) => l.tot_cmp(r),
+            (Int8(l), Int8(r)) => l.tot_cmp(r),
+            (Int16(l), Int16(r)) => l.tot_cmp(r),
+            (Int32(l), Int32(r)) => l.tot_cmp(r),
+            (Int64(l), Int64(r)) => l.tot_cmp(r),
+            (Int128(l), Int128(r)) => l.tot_cmp(r),
+            (Float16(l), Float16(r)) => l.tot_cmp(r),
+            (Float32(l), Float32(r)) => l.tot_cmp(r),
+            (Float64(l), Float64(r)) => l.tot_cmp(r),
+            (String(l), String(r)) => l.tot_cmp(r),
+            (Binary(l), Binary(r)) => l.tot_cmp(r),
+            #[cfg(feature = "dtype-date")]
+            (Date(l), Date(r)) => l.tot_cmp(r),
+            #[cfg(feature = "dtype-datetime")]
+            (Datetime(lt, lu, lz), Datetime(rt, ru, rz)) => {
+                if lu != ru || lz != rz {
+                    unimplemented!(
+                        "comparing datetimes with different units or timezones is not supported"
+                    );
+                }
+                lt.tot_cmp(rt)
+            },
+            #[cfg(feature = "dtype-duration")]
+            (Duration(lt, lu), Duration(rt, ru)) => {
+                if lu != ru {
+                    unimplemented!("comparing durations with different units is not supported");
+                }
+                lt.tot_cmp(rt)
+            },
+            #[cfg(feature = "dtype-time")]
+            (Time(l), Time(r)) => l.tot_cmp(r),
+            #[cfg(feature = "dtype-categorical")]
+            (Categorical(l_cat, l_map), Categorical(r_cat, r_map)) => unsafe {
+                let l_str = l_map.cat_to_str_unchecked(*l_cat);
+                let r_str = r_map.cat_to_str_unchecked(*r_cat);
+                TotalOrd::tot_cmp(&l_str, &r_str)
+            },
+            #[cfg(feature = "dtype-categorical")]
+            (Enum(l_cat, l_map), Enum(r_cat, r_map)) => {
+                if !Arc::ptr_eq(l_map, r_map) {
+                    unimplemented!("can't order enums from different FrozenCategories")
+                }
+                l_cat.tot_cmp(r_cat)
+            },
+            (List(_), List(_)) => {
+                unimplemented!("ordering for List dtype is not supported")
+            },
+            #[cfg(feature = "dtype-array")]
+            (Array(..), Array(..)) => {
+                unimplemented!("ordering for Array dtype is not supported")
+            },
+            #[cfg(feature = "object")]
+            (Object(_), Object(_)) => {
+                unimplemented!("ordering for Object dtype is not supported")
+            },
+            #[cfg(feature = "dtype-struct")]
+            (StructOwned(_), StructOwned(_))
+            | (StructOwned(_), Struct(..))
+            | (Struct(..), StructOwned(_))
+            | (Struct(..), Struct(..)) => {
+                unimplemented!("ordering for Struct dtype is not supported")
+            },
+            #[cfg(feature = "dtype-decimal")]
+            (Decimal(lv, _lp, ls), Decimal(rv, _rp, rs)) => dec128_cmp(*lv, *ls, *rv, *rs),
+
+            (_, _) => {
+                unimplemented!(
+                    "scalar ordering for mixed dtypes {self:?} and {other:?} is not supported"
+                )
+            },
+        }
+    }
+}
+
 #[cfg(feature = "dtype-struct")]
 fn struct_to_avs_static(idx: usize, arr: &StructArray, fields: &[Field]) -> Vec<AnyValue<'static>> {
     assert!(idx < arr.len());

--- a/crates/polars-expr/src/dispatch/misc.rs
+++ b/crates/polars-expr/src/dispatch/misc.rs
@@ -429,6 +429,8 @@ pub(super) fn arg_where(s: &mut [Column]) -> PolarsResult<Column> {
 pub(super) fn index_of(s: &mut [Column]) -> PolarsResult<Column> {
     use polars_core::series::IsSorted;
     use polars_ops::series::index_of as index_of_op;
+    use polars_utils::total_ord::TotalEq;
+
     let series = if let Column::Scalar(ref sc) = s[0] {
         // We only care about the first value:
         &sc.as_single_value_series()
@@ -464,7 +466,11 @@ pub(super) fn index_of(s: &mut [Column]) -> PolarsResult<Column> {
             .and_then(|idx| {
                 // search_sorted() gives an index even if it's not an exact
                 // match! So we want to make sure it actually found the value.
-                if series.get(idx as usize).ok()? == needle.as_any_value() {
+                if series
+                    .get(idx as usize)
+                    .ok()?
+                    .tot_eq(&needle.as_any_value())
+                {
                     Some(idx as usize)
                 } else {
                     None

--- a/crates/polars-stream/src/nodes/joins/merge_join.rs
+++ b/crates/polars-stream/src/nodes/joins/merge_join.rs
@@ -8,6 +8,7 @@ use polars_core::utils::Container;
 use polars_ops::frame::merge_join::*;
 use polars_ops::frame::{JoinArgs, JoinType, MaintainOrderJoin};
 use polars_utils::UnitVec;
+use polars_utils::total_ord::TotalOrd;
 use rayon::slice::ParallelSliceMut;
 
 use crate::DEFAULT_DISTRIBUTOR_BUFFER_SIZE;
@@ -804,7 +805,7 @@ fn binary_search_upper(
 }
 
 fn keys_cmp(lhs: &AnyValue, rhs: &AnyValue, params: &MergeJoinParams) -> Ordering {
-    match AnyValue::partial_cmp(lhs, rhs).unwrap() {
+    match AnyValue::tot_cmp(lhs, rhs) {
         Ordering::Equal => Ordering::Equal,
         _ if lhs.is_null() && params.key_nulls_last => Ordering::Greater,
         _ if rhs.is_null() && params.key_nulls_last => Ordering::Less,


### PR DESCRIPTION
<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
