### PR TITLE
fix: Correctly raise error on failing nested strict casts

### DIFF
--- a/crates/polars-arrow/src/array/primitive/mod.rs
+++ b/crates/polars-arrow/src/array/primitive/mod.rs
@@ -425,6 +425,13 @@ impl<T: NativeType> PrimitiveArray<T> {
         )
     }
 
+    /// Calls f with a [`PrimitiveArray`] backed by this slice.
+    ///
+    /// Aborts if any clones of the [`PrimitiveArray`] still live when `f` returns.
+    pub fn with_slice<R, F: FnOnce(PrimitiveArray<T>) -> R>(slice: &[T], f: F) -> R {
+        Buffer::with_slice(slice, |buf| f(Self::new(T::PRIMITIVE.into(), buf, None)))
+    }
+
     /// Creates a (non-null) [`PrimitiveArray`] from a [`TrustedLen`] of values.
     /// # Implementation
     /// This does not assume that the iterator has a known length.

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -463,8 +463,9 @@ impl Series {
         }
 
         let new_options = match options {
-            // Strictness is handled on this level to improve error messages.
-            CastOptions::Strict => CastOptions::NonStrict,
+            // Strictness is handled on this level to improve error messages, if not nested.
+            // Nested types could hide cast errors, so have to be done internally.
+            CastOptions::Strict if !dtype.is_nested() => CastOptions::NonStrict,
             opt => opt,
         };
 

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -1060,3 +1060,15 @@ def test_lit_cast_arithmetic_matrix_schema(
         else df.lazy().select(op(pl.col("a"), pl.lit(1, lit_dtype)))
     )
     assert q.collect_schema() == q.collect().schema
+
+
+def test_strict_cast_nested() -> None:
+    df = pl.DataFrame({"a": ["42", "10a"]})
+    struct = pl.Struct({"x": pl.Int32})
+    with pytest.raises(InvalidOperationError):
+        df.cast(struct, strict=True)
+
+    assert_frame_equal(
+        df.cast(struct, strict=False),
+        pl.DataFrame({"a": [{"x": 42}, {"x": None}]}, schema={"a": struct}),
+    )


### PR DESCRIPTION
Before if there was a casting failure inside a nested type (e.g. struct) the failure would be silently turned into a null.