### PR TITLE
chore: Have parameterized series `rechunk()` if `not allow_chunks`

### DIFF
--- a/py-polars/src/polars/testing/parametric/strategies/core.py
+++ b/py-polars/src/polars/testing/parametric/strategies/core.py
@@ -247,6 +247,8 @@ def series(  # noqa: D417
         s = select(when(mask).then(s).alias(s.name)).to_series()
 
     # Apply chunking
+    if not allow_chunks:
+        s = s.rechunk()
     if allow_chunks and size > 1 and draw(st.booleans()):
         split_at = size // 2
         s = s[:split_at].append(s[split_at:])


### PR DESCRIPTION
At this point, generated dataframes can have multiple chunks is `allow_chunks == False`. This PR explicitly rechunks the dataframe (before splitting it again) to make sure that the dataframe always starts as a single chunks; and any chunking is deterministic.