### PR TITLE
chore(python): Update `s3fs` dev dependency

### DIFF
--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -37,7 +37,7 @@ boto3
 cloudpickle
 fsspec
 pyiceberg>=0.7.1; python_version < '3.13'
-s3fs
+s3fs>=2026.2.0
 # Spreadsheet
 fastexcel>=0.11.5
 openpyxl


### PR DESCRIPTION
Set a lower bound on `s3fs` because the CICD process was resolving to install a very old version (0.4.2) which came out Mar. 31, 2020.

If you look at the GitHub actions logs (of prior PRs) for the python package install step, you can see the resolver has to do a lot of work to figure out this package and it's dependencies. Setting a lower bound will help a lot with that.