### PR TITLE
docs: Fix docstring for bitwise_count_zeros method

### DIFF
--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -9420,7 +9420,7 @@ class Series:
         """Evaluate the number of set bits."""
 
     def bitwise_count_zeros(self) -> Self:
-        """Evaluate the number of unset Self."""
+        """Evaluate the number of unset bits."""
 
     def bitwise_leading_ones(self) -> Self:
         """Evaluate the number most-significant set bits before seeing an unset bit."""


### PR DESCRIPTION
Fixed a typo in the docstring for the Python method `Series.bitwise_count_zeros()`.