### PR TITLE
chore: Update license to be recognized as MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
-Copyright (c) 2025 Ritchie Vink
-Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved [Some portions]
+Copyright © 2025 Ritchie Vink
+Copyright © 2024 NVIDIA Corporation & Affiliates (for certain portions). All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Just a quick update to the license so GitHub recognizes it as MIT. This also allows other tools, such as Black Duck, to correctly identify the software license.

  1. I used AI for the copyright wording
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

