### PR TITLE
chore: Add wrapper for clippy so it continues on warnings

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -48,7 +48,7 @@ jobs:
           save-if: ${{ github.ref_name == 'main' }}
 
       - name: Run cargo clippy with all features enabled
-        run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings -D clippy::dbg_macro
+        run: python3 tools/cargo-fail-warning.py clippy --workspace --all-targets --all-features --locked -- -W clippy::dbg_macro
 
   # Default feature set should compile on the stable toolchain
   clippy-stable:
@@ -68,7 +68,7 @@ jobs:
           save-if: ${{ github.ref_name == 'main' }}
 
       - name: Run cargo clippy
-        run: cargo clippy --all-targets --locked -- -D warnings -D clippy::dbg_macro
+        run: python3 tools/cargo-fail-warning.py clippy --all-targets --locked -- -W clippy::dbg_macro
 
   rustfmt:
     if: github.ref_name != 'main'

--- a/Makefile
+++ b/Makefile
@@ -141,11 +141,11 @@ check:  ## Run cargo check with all features
 
 .PHONY: clippy
 clippy:  ## Run clippy with all features
-	cargo clippy --workspace --all-targets --all-features --locked -- -D warnings -D clippy::dbg_macro
+	python3 tools/cargo-fail-warning.py clippy --workspace --all-targets --all-features --locked -- -W clippy::dbg_macro
 
 .PHONY: clippy-default
 clippy-default:  ## Run clippy with default features
-	cargo clippy --all-targets --locked -- -D warnings -D clippy::dbg_macro
+	python3 tools/cargo-fail-warning.py clippy --all-targets --locked -- -W clippy::dbg_macro
 
 .PHONY: fmt
 fmt:  ## Run autoformatting and linting

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -62,7 +62,7 @@ fmt: .venv  ## Run autoformatting (python and rust)
 
 .PHONY: clippy
 clippy:  ## Run clippy
-	cargo clippy --locked -- -D warnings -D clippy::dbg_macro
+	python3 ../tools/cargo-fail-warning.py clippy --locked -- -W clippy::dbg_macro
 
 .PHONY: pre-commit
 pre-commit: fmt lint clippy  ## Run all code formatting, lint, and clippy quality checks

--- a/tools/cargo-fail-warning.py
+++ b/tools/cargo-fail-warning.py
@@ -1,0 +1,36 @@
+# A wrapper for cargo which fails on warnings.
+# This is better than -D warnings as it will continue the build rather than fail early.
+
+import subprocess
+import json
+import sys
+
+subcommand = sys.argv[1]
+
+proc = subprocess.Popen(
+    ["cargo", subcommand, "--message-format=json-diagnostic-rendered-ansi"]
+    + sys.argv[2:],
+    stdout=subprocess.PIPE,
+)
+
+found_warning = False
+for line in iter(proc.stdout.readline, b""):
+    msg = json.loads(line)
+    if msg["reason"] in (
+        "compiler-artifact",
+        "build-script-executed",
+        "build-finished",
+    ):
+        continue
+
+    if msg["reason"] == "compiler-message":
+        print(msg["message"]["rendered"], file=sys.stderr)
+        if msg["message"]["level"] == "warning":
+            found_warning = True
+        continue
+
+    raise RuntimeError("unknown message reason:\n", json.dumps(msg, indent=4))
+
+# Respect original exit code if non-zero, otherwise emit if warning was found.
+exit = proc.wait()
+sys.exit(exit if exit != 0 else int(found_warning))


### PR DESCRIPTION
Clippy with `-D warnings` has the annoying behavior that it (sometimes?) stops on the first warning (since it's an error now), rather than keep going. This gives an annoying workflow where the CI/`make clippy` fails, you fix something, only to be presented with a new error on the next CI run that could've immediately been reported.

There is `cargo clippy --keep-going`, but it appears that option doesn't really do what you want, and only keeps going within one `rustc` invocation but still stopping between multiple invocations.

So I wrote a little wrapper for `cargo` which should output normal diagnostics to stderr but also scan if any of them are warnings. If so, the exit code at the end is modified to a failure condition if it wasn't already.

---

I've learned that the unstable Cargo option described here should be able to do the same, so once that stabilizes we can just use that: https://github.com/rust-lang/cargo/issues/14802.