### PR TITLE
feat(rust,python): add arr.sample for array namespace

### DIFF
--- a/crates/polars-ops/src/chunked_array/array/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/array/namespace.rs
@@ -250,6 +250,22 @@ pub trait ArrayNameSpace: AsArray {
         );
         Ok(slice_arr.into_series())
     }
+
+    #[cfg(feature = "list_sample")]
+    fn array_sample_n_literal(
+        &self,
+        n: usize,
+        with_replacement: bool,
+        shuffle: bool,
+        seed: Option<u64>,
+    ) -> PolarsResult<ArrayChunked> {
+        let ca = self.as_array();
+        let sampled = ca.try_apply_amortized_to_list(|s| {
+            s.as_ref().sample_n(n, with_replacement, shuffle, seed)
+        })?;
+        let sampled = sampled.cast(&DataType::Array(Box::new(ca.inner_dtype().clone()), n))?;
+        Ok(sampled.array()?.clone())
+    }
 }
 
 impl ArrayNameSpace for ArrayChunked {}

--- a/crates/polars-plan/src/dsl/array.rs
+++ b/crates/polars-plan/src/dsl/array.rs
@@ -190,6 +190,32 @@ impl ArrayNameSpace {
         self.0
             .map_binary(FunctionExpr::ArrayExpr(ArrayFunction::Shift), n)
     }
+
+    #[cfg(feature = "list_sample")]
+    /// Sample `n` values from every sub-array.
+    pub fn sample(
+        self,
+        n: Expr,
+        with_replacement: bool,
+        shuffle: bool,
+        seed: Option<u64>,
+    ) -> PolarsResult<Expr> {
+        let Ok(n) = n.extract_i64() else {
+            polars_bail!(InvalidOperation: "Sample size must be a constant `i64` value, got: {}", n)
+        };
+        let n: usize = n.try_into().map_err(
+            |_| polars_err!(OutOfBounds: "Sample size must be a non-negative integer, got: {}", n),
+        )?;
+        Ok(self
+            .0
+            .map_unary(FunctionExpr::ArrayExpr(ArrayFunction::Sample {
+                n,
+                with_replacement,
+                shuffle,
+                seed,
+            })))
+    }
+
     /// Returns a column with a separate row for every array element.
     pub fn explode(self, options: ExplodeOptions) -> Expr {
         self.0

--- a/crates/polars-plan/src/dsl/function_expr/array.rs
+++ b/crates/polars-plan/src/dsl/function_expr/array.rs
@@ -41,6 +41,13 @@ pub enum ArrayFunction {
     Concat,
     #[cfg(feature = "array_to_struct")]
     ToStruct(Option<super::DslNameGenerator>),
+    #[cfg(feature = "list_sample")]
+    Sample {
+        n: usize,
+        with_replacement: bool,
+        shuffle: bool,
+        seed: Option<u64>,
+    },
 }
 
 impl fmt::Display for ArrayFunction {
@@ -78,6 +85,8 @@ impl fmt::Display for ArrayFunction {
             Explode { .. } => "explode",
             #[cfg(feature = "array_to_struct")]
             ToStruct(_) => "to_struct",
+            #[cfg(feature = "list_sample")]
+            Sample { .. } => "sample",
         };
         write!(f, "arr.{name}")
     }

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
@@ -57,6 +57,18 @@ pub(super) fn convert_functions(
                 A::Explode(options) => IA::Explode(options),
                 A::Concat => IA::Concat,
                 A::Slice(offset, length) => IA::Slice(offset, length),
+                #[cfg(feature = "list_sample")]
+                A::Sample {
+                    n,
+                    with_replacement,
+                    shuffle,
+                    seed,
+                } => IA::Sample {
+                    n,
+                    with_replacement,
+                    shuffle,
+                    seed,
+                },
                 #[cfg(feature = "array_to_struct")]
                 A::ToStruct(ng) => IA::ToStruct(ng),
             })

--- a/crates/polars-plan/src/plans/conversion/ir_to_dsl.rs
+++ b/crates/polars-plan/src/plans/conversion/ir_to_dsl.rs
@@ -336,6 +336,18 @@ pub fn ir_function_to_dsl(input: Vec<Expr>, function: IRFunctionExpr) -> Expr {
                 IA::Shift => A::Shift,
                 IA::Slice(offset, length) => A::Slice(offset, length),
                 IA::Explode(options) => A::Explode(options),
+                #[cfg(feature = "list_sample")]
+                IA::Sample {
+                    n,
+                    with_replacement,
+                    shuffle,
+                    seed,
+                } => A::Sample {
+                    n,
+                    with_replacement,
+                    shuffle,
+                    seed,
+                },
                 #[cfg(feature = "array_to_struct")]
                 IA::ToStruct(ng) => A::ToStruct(ng),
             })

--- a/crates/polars-python/src/expr/array.rs
+++ b/crates/polars-python/src/expr/array.rs
@@ -148,6 +148,24 @@ impl PyExpr {
             .into())
     }
 
+    #[cfg(feature = "list_sample")]
+    #[pyo3(signature = (n, with_replacement, shuffle, seed=None))]
+    fn arr_sample(
+        &self,
+        n: PyExpr,
+        with_replacement: bool,
+        shuffle: bool,
+        seed: Option<u64>,
+    ) -> PyResult<Self> {
+        Ok(self
+            .inner
+            .clone()
+            .arr()
+            .sample(n.inner, with_replacement, shuffle, seed)
+            .map_err(PyPolarsErr::from)?
+            .into())
+    }
+
     fn arr_shift(&self, n: PyExpr) -> Self {
         self.inner.clone().arr().shift(n.inner).into()
     }

--- a/py-polars/src/polars/expr/array.py
+++ b/py-polars/src/polars/expr/array.py
@@ -191,6 +191,59 @@ class ExprArrayNameSpace:
         n_pyexpr = parse_into_expression(n)
         return wrap_expr(self._pyexpr.arr_tail(n_pyexpr, as_array))
 
+    def sample(
+        self,
+        n: int | str | Expr | None = None,
+        *,
+        with_replacement: bool = False,
+        shuffle: bool = False,
+        seed: int | None = None,
+    ) -> Expr:
+        """
+        Sample from this Array.
+
+        Parameters
+        ----------
+        n
+            Number of items to return. Defaults to 1.
+            This must be a scalar literal value.
+        with_replacement
+            Allow values to be sampled more than once.
+        shuffle
+            Shuffle the order of sampled items.
+        seed
+            Seed for the random number generator. If set to None (default), a random
+            seed is generated for each sample operation.
+
+        Returns
+        -------
+        Expr
+            Expression of data type :class:`Array`.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {"a": [[1, 2, 3], [4, 5, 6]]}, schema={"a": pl.Array(pl.Int64, 3)}
+        ... )
+        >>> df.select(pl.col("a").arr.sample(2, seed=42))
+        shape: (2, 1)
+        ┌───────────────┐
+        │ a             │
+        │ ---           │
+        │ array[i64, 2] │
+        ╞═══════════════╡
+        │ [1, 3]        │
+        │ [6, 5]        │
+        └───────────────┘
+        """
+        if n is None:
+            n = 1
+
+        n = parse_into_expression(n)
+        return wrap_expr(
+            self._pyexpr.arr_sample(n, with_replacement, shuffle, seed)
+        )
+
     def min(self) -> Expr:
         """
         Compute the min values of the sub-arrays.

--- a/py-polars/src/polars/series/array.py
+++ b/py-polars/src/polars/series/array.py
@@ -255,6 +255,49 @@ class ArrayNameSpace:
         ]
         """
 
+    def sample(
+        self,
+        n: int | IntoExprColumn | None = None,
+        *,
+        with_replacement: bool = False,
+        shuffle: bool = False,
+        seed: int | None = None,
+    ) -> Series:
+        """
+        Sample from this array.
+
+        Parameters
+        ----------
+        n
+            Number of items to return. Defaults to 1.
+            This must be a scalar literal value.
+        with_replacement
+            Allow values to be sampled more than once.
+        shuffle
+            Shuffle the order of sampled data points.
+        seed
+            Seed for the random number generator. If set to None (default), a
+            random seed is generated for each sample operation.
+
+        Returns
+        -------
+        Series
+            Series of data type :class:`Array`.
+
+        Examples
+        --------
+        >>> s = pl.Series(
+        ...     "a", [[1, 2, 3], [4, 5, 6]], dtype=pl.Array(pl.Int64, 3)
+        ... )
+        >>> s.arr.sample(2, seed=42)
+        shape: (2,)
+        Series: 'a' [array[i64, 2]]
+        [
+            [1, 3]
+            [6, 5]
+        ]
+        """
+
     def slice(
         self,
         offset: int | Expr,


### PR DESCRIPTION
Adds `arr.sample` for fixed-size arrays (part of #21302).

I followed the existing list sampling path and adapted it for arrays, wiring it through Rust DSL/IR, dispatch, and Python bindings.

Because array output width must be known ahead of time, `n` is restricted to a scalar literal so the result can keep `Array(inner, n)` dtype.

### Included
- `Expr.arr.sample(...)` support
- `Series.arr.sample(...)` support
- Array `Sample` wiring in DSL/IR conversion
- Execution/kernel path for array sampling
- Error handling for non-literal `n` and negative `n`
- Unit tests for normal sampling, sampling with replacement, and error cases

### Validation
- `cargo fmt --all --check`
- `cargo check -p polars-plan --features "dtype-array,list_sample"`
- `cargo check -p polars-expr --features "dtype-array,list_sample"`
- `cargo check -p polars-python --features "dtype-array,list_sample"`
- `cargo check -p polars-plan --features "dtype-array"`
- `POLARS_FORCE_PKG=32 .venv/bin/python -m pytest py-polars/tests/unit/operations/namespaces/array/test_array.py` (`74 passed`)
