### PR TITLE
fix(python): Ensure `read_csv_batched()` prints deprecation warning

### DIFF
--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -739,6 +739,7 @@ def _read_csv_impl(
     )
     return wrap_df(pydf)
 
+
 @deprecated(
     "`read_csv_batched` is deprecated as of 1.37.0; use `scan_csv().collect_batches()` instead."
 )

--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -741,7 +741,7 @@ def _read_csv_impl(
 
 
 @deprecated(
-    "`read_csv_batched` is deprecated as of 1.37.0; use `scan_csv().collect_batches()` instead."
+    "`read_csv_batched` is deprecated; use `scan_csv().collect_batches()` instead."
 )
 @deprecate_renamed_parameter("dtypes", "schema_overrides", version="0.20.31")
 @deprecate_renamed_parameter("row_count_name", "row_index_name", version="0.20.4")

--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -740,8 +740,7 @@ def _read_csv_impl(
     return wrap_df(pydf)
 
 @deprecated(
-    "`read_csv_batched` is deprecated; use `scan_csv().collect_batches()` instead.",
-    version="1.37.0"
+    "`read_csv_batched` is deprecated as of 1.37.0; use `scan_csv().collect_batches()` instead."
 )
 @deprecate_renamed_parameter("dtypes", "schema_overrides", version="0.20.31")
 @deprecate_renamed_parameter("row_count_name", "row_index_name", version="0.20.4")

--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -739,13 +739,13 @@ def _read_csv_impl(
     )
     return wrap_df(pydf)
 
-
+@deprecated(
+    "`read_csv_batched` is deprecated; use `scan_csv().collect_batches()` instead.",
+    version="1.37.0"
+)
 @deprecate_renamed_parameter("dtypes", "schema_overrides", version="0.20.31")
 @deprecate_renamed_parameter("row_count_name", "row_index_name", version="0.20.4")
 @deprecate_renamed_parameter("row_count_offset", "row_index_offset", version="0.20.4")
-@deprecated(
-    "`read_csv_batched` is deprecated; use `scan_csv().collect_batches()` instead."
-)
 def read_csv_batched(
     source: str | Path,
     *,

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -3131,3 +3131,7 @@ def test_provided_schema_mismatch_truncate(chunk_override: None, read_fn: str) -
     )
     expected = [pl.Series("A", [1])]
     assert_frame_equal(df, pl.DataFrame(expected))
+
+def test_read_batch_csv_deprecations_26479() -> None:
+    with pytest.warns(DeprecationWarning, match="read_csv_batched is deprecated"):
+        pl.read_csv_batched(b"foo\nbar")

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -3132,6 +3132,7 @@ def test_provided_schema_mismatch_truncate(chunk_override: None, read_fn: str) -
     expected = [pl.Series("A", [1])]
     assert_frame_equal(df, pl.DataFrame(expected))
 
+
 def test_read_batch_csv_deprecations_26479(foods_file_path: Path) -> None:
     with pytest.warns(DeprecationWarning, match="read_csv_batched is deprecated"):
         pl.read_csv_batched(foods_file_path)

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -3134,5 +3134,5 @@ def test_provided_schema_mismatch_truncate(chunk_override: None, read_fn: str) -
 
 
 def test_read_batch_csv_deprecations_26479(foods_file_path: Path) -> None:
-    with pytest.warns(DeprecationWarning, match="read_csv_batched is deprecated"):
+    with pytest.warns(DeprecationWarning, match=r"`read_csv_batched` is deprecated"):
         pl.read_csv_batched(foods_file_path)

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -3132,6 +3132,6 @@ def test_provided_schema_mismatch_truncate(chunk_override: None, read_fn: str) -
     expected = [pl.Series("A", [1])]
     assert_frame_equal(df, pl.DataFrame(expected))
 
-def test_read_batch_csv_deprecations_26479() -> None:
+def test_read_batch_csv_deprecations_26479(foods_file_path: Path) -> None:
     with pytest.warns(DeprecationWarning, match="read_csv_batched is deprecated"):
-        pl.read_csv_batched(b"foo\nbar")
+        pl.read_csv_batched(foods_file_path)


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/26479.

Credit to @cmdlineluser for outlining the solution in the issue. I implemented it and added a test. 