### PR TITLE
fix: Move query parameters to request body when retrieving Unity Catalog temporary credentials

### DIFF
--- a/crates/polars-io/src/catalog/unity/client.rs
+++ b/crates/polars-io/src/catalog/unity/client.rs
@@ -95,16 +95,22 @@ impl CatalogClient {
                     "{}{}",
                     &self.workspace_url, "/api/2.1/unity-catalog/temporary-table-credentials"
                 ))
-                .query(&[
-                    ("table_id", table_id),
-                    ("operation", if write { "READ_WRITE" } else { "READ" }),
-                ]),
+                .json(&Body {
+                    table_id,
+                    operation: if write { "READ_WRITE" } else { "READ" },
+                }),
         )
         .await?;
 
         let out: TableCredentials = decode_json_response(&bytes)?;
 
-        Ok(out)
+        return Ok(out);
+
+        #[derive(serde::Serialize)]
+        struct Body<'a> {
+            table_id: &'a str,
+            operation: &'a str,
+        }
     }
 
     pub async fn create_catalog(


### PR DESCRIPTION
This PR fixes #26535 by sending the required parameters in the body instead of the query params. 

Currently polars is sending `table_id` and `operation` as query parameter, while the unity catalog expects it as JSON body here.
Databricks: https://docs.databricks.com/api/workspace/temporarytablecredentials/generatetemporarytablecredentials#operation
Unity Catalog OSS: https://github.com/unitycatalog/unitycatalog/blob/77e450d6462a4d39a2725ea2d97da68da0de8057/api/all.yaml#L683

Fixes #26535.

