### PR TITLE
fix: Set `dictionary_page_offset` when dictionary encoding is used and point `data_page_offset` to the first data page

### DIFF
--- a/crates/polars-parquet/src/parquet/write/page.rs
+++ b/crates/polars-parquet/src/parquet/write/page.rs
@@ -18,6 +18,10 @@ pub(crate) fn is_data_page(page: &PageWriteSpec) -> bool {
     page.header.type_ == PageType::DATA_PAGE || page.header.type_ == PageType::DATA_PAGE_V2
 }
 
+pub(crate) fn is_dict_page(page: &PageWriteSpec) -> bool {
+    page.header.type_ == PageType::DICTIONARY_PAGE
+}
+
 fn maybe_bytes(uncompressed: usize, compressed: usize) -> ParquetResult<(i32, i32)> {
     let uncompressed_page_size: i32 = uncompressed.try_into().map_err(|_| {
         ParquetError::oos(format!(


### PR DESCRIPTION
Fixes #26531
