### PR TITLE
fix: Respect SQL semantics for cumulative functions mapped via `OVER` clause

### DIFF
--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -1,6 +1,6 @@
 use std::ops::{Add, Sub};
 
-use polars_core::chunked_array::ops::{SortMultipleOptions, SortOptions};
+use polars_core::chunked_array::ops::{FillNullStrategy, SortMultipleOptions, SortOptions};
 use polars_core::prelude::{
     DataType, ExplodeOptions, PolarsResult, QuantileMethod, Schema, TimeUnit, polars_bail,
     polars_err,
@@ -1903,8 +1903,9 @@ impl SQLFunctionVisitor<'_> {
                 )
             };
 
-            // Apply cumulative function and wrap with window spec
-            let cumulative_expr = cumulative_fn(base_expr, false);
+            // Apply cumulative function; the forward-fill ensures we match SQL semantics
+            let cumulative_expr = cumulative_fn(base_expr, false)
+                .fill_null_with_strategy(FillNullStrategy::Forward(None));
             let sort_opts = SortOptions::default().with_order_descending(all_desc);
             cumulative_expr.over_with_options(
                 partition_by_exprs,


### PR DESCRIPTION
While implementing #26569 (and reading the related issue #26065) I noticed a corner case with cumulative functions mapped via the SQL interface. In SQL semantics NULL values are ignored in such a way that we expect a fill-forward of the previous value (with respect to the sort window order/partition), whereas our DataFrame semantics maintain the NULL value. Simple one-line fix.

New test coverage validates the updated behaviour against SQLite, using `assert_sql_matches`.
(And I additionally confirmed it manually against other backends).

## Example

```python
import polars as pl

df = pl.DataFrame({
  "idx": [1, 2, 3, 4, 5],
  "val": [10.0, 20.0, 30.0, None, 50.0],
})
```
**DataFrame behaviour**
```python
df.with_columns(
    cum_sum=pl.col("val").over(order_by="idx").cum_sum()
)
# shape: (5, 3)
# ┌─────┬──────┬─────────┐
# │ idx ┆ val  ┆ cum_sum │
# │ --- ┆ ---  ┆ ---     │
# │ i64 ┆ f64  ┆ f64     │
# ╞═════╪══════╪═════════╡
# │ 1   ┆ 10.0 ┆ 10.0    │
# │ 2   ┆ 20.0 ┆ 30.0    │
# │ 3   ┆ 30.0 ┆ 60.0    │
# │ 4   ┆ null ┆ null    │  <<  `null` in "cum_sum" col
# │ 5   ┆ 50.0 ┆ 110.0   │
# └─────┴──────┴─────────┘
```
**SQL behaviour** _(with the fix)_
```python
pl.sql("""
  SELECT
    *,
    SUM(val) OVER w AS cum_sum,
  FROM df
  WINDOW w AS (
    ORDER BY idx
    ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
  )
  ORDER BY idx
""").collect()
# shape: (5, 3)
# ┌─────┬──────┬─────────┐
# │ idx ┆ val  ┆ cum_sum │
# │ --- ┆ ---  ┆ ---     │
# │ i64 ┆ f64  ┆ f64     │
# ╞═════╪══════╪═════════╡
# │ 1   ┆ 10.0 ┆ 10.0    │
# │ 2   ┆ 20.0 ┆ 30.0    │
# │ 3   ┆ 30.0 ┆ 60.0    │
# │ 4   ┆ null ┆ 60.0    │  <<  previous value propagated
# │ 5   ┆ 50.0 ┆ 110.0   │
# └─────┴──────┴─────────┘

```