### PR TITLE
docs: Improve  SQL docs for `EXTRACT` and `DATE_PART` functions

### DIFF
--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -1265,7 +1265,7 @@ pub(crate) fn parse_extract_date_part(expr: Expr, field: &DateTimeField) -> Pola
             let value = value.to_ascii_lowercase();
             match value.as_str() {
                 "millennium" | "millennia" => &DateTimeField::Millennium,
-                "century" | "centuries" => &DateTimeField::Century,
+                "century" | "centuries" | "c" => &DateTimeField::Century,
                 "decade" | "decades" => &DateTimeField::Decade,
                 "isoyear" => &DateTimeField::Isoyear,
                 "year" | "years" | "y" => &DateTimeField::Year,
@@ -1275,7 +1275,7 @@ pub(crate) fn parse_extract_date_part(expr: Expr, field: &DateTimeField) -> Pola
                 "dayofweek" | "dow" => &DateTimeField::DayOfWeek,
                 "isoweek" | "week" | "weeks" => &DateTimeField::IsoWeek,
                 "isodow" => &DateTimeField::Isodow,
-                "day" | "days" | "d" => &DateTimeField::Day,
+                "day" | "days" | "dayofmonth" | "d" => &DateTimeField::Day,
                 "hour" | "hours" | "h" => &DateTimeField::Hour,
                 "minute" | "minutes" | "mins" | "min" | "m" => &DateTimeField::Minute,
                 "second" | "seconds" | "sec" | "secs" | "s" => &DateTimeField::Second,

--- a/py-polars/docs/Makefile
+++ b/py-polars/docs/Makefile
@@ -1,13 +1,11 @@
 # Minimal makefile for Sphinx documentation
 
 ifeq ($(shell uname),Darwin)
-export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+SPHINXOPTS    ?= -j 1 -W
+else
+SPHINXOPTS    ?= -j auto -W
 endif
 export BUILDING_SPHINX_DOCS = 1
-
-# You can set these variables from the command line, and also
-# from the environment for the first two.
-SPHINXOPTS    ?= -j auto -W
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/py-polars/docs/source/reference/sql/functions/temporal.rst
+++ b/py-polars/docs/source/reference/sql/functions/temporal.rst
@@ -23,27 +23,77 @@ DATE_PART
 Extracts a part of a date (or datetime) such as 'year', 'month', etc.
 
 **Supported parts/fields:**
-    - "millennium" | "millennia"
-    - "century" | "centuries"
-    - "decade" | "decades"
-    - "isoyear"
-    - "year" | "years" | "y"
-    - "quarter" | "quarters"
-    - "month" | "months" | "mon" | "mons"
-    - "dayofyear" | "doy"
-    - "dayofweek" | "dow"
-    - "isoweek" | "week"
-    - "isodow"
-    - "day" | "days" | "d"
-    - "hour" | "hours" | "h"
-    - "minute" | "minutes" | "mins" | "min" | "m"
-    - "second" | "seconds" | "sec" | "secs" | "s"
-    - "millisecond" | "milliseconds" | "ms"
-    - "microsecond" | "microseconds" | "us"
-    - "nanosecond" | "nanoseconds" | "ns"
-    - "timezone"
-    - "time"
-    - "epoch"
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Part
+     - Description
+     - DataType
+   * - 'millennium', 'millennia'
+     - Millennium number
+     - Int32
+   * - 'century', 'centuries', 'c'
+     - Century number
+     - Int32
+   * - 'decade', 'decades'
+     - Decade number (year / 10)
+     - Int32
+   * - 'isoyear'
+     - ISO year number
+     - Int32
+   * - 'year', 'years', 'y'
+     - Calendar year
+     - Int32
+   * - 'quarter', 'quarters'
+     - Quarter of the year (1–4)
+     - Int8
+   * - 'month', 'months', 'mon', 'mons'
+     - Month of the year (1–12)
+     - Int8
+   * - 'dayofyear', 'doy'
+     - Day of the year (1–366)
+     - Int16
+   * - 'dayofweek', 'dow', 'weekday'
+     - Day of the week (0:Sunday – 6:Saturday)
+     - Int8
+   * - 'isoweek', 'week'
+     - ISO week number (1–53)
+     - Int8
+   * - 'isodow'
+     - ISO day of the week (1:Monday – 7:Sunday)
+     - Int8
+   * - 'day', 'days', 'dayofmonth', d'
+     - Day of the month (1–31)
+     - Int8
+   * - 'hour', 'hours', 'h'
+     - Hour of the day (0–23)
+     - Int8
+   * - 'minute', 'minutes', 'mins', 'min', 'm'
+     - Minute of the hour (0–59)
+     - Int8
+   * - 'second', 'seconds', 'sec', 'secs', 's'
+     - Second of the minute (0–59)
+     - Int8
+   * - 'millisecond', 'milliseconds', 'ms'
+     - Sub-minute seconds and milliseconds (0–59999.)
+     - Float64
+   * - 'microsecond', 'microseconds', 'us'
+     - Sub-minute seconds and microseconds (0–59999999.)
+     - Float64
+   * - 'nanosecond', 'nanoseconds', 'ns'
+     - Sub-minute seconds and nanoseconds (0–59999999999.)
+     - Float64
+   * - 'timezone'
+     - UTC offset of the timezone, in seconds ()
+     - Int64
+   * - 'time'
+     - Time component
+     - Time
+   * - 'epoch'
+     - Seconds since Unix epoch (1970-01-01)
+     - Float64
 
 **Example:**
 
@@ -52,9 +102,9 @@ Extracts a part of a date (or datetime) such as 'year', 'month', etc.
     df = pl.DataFrame(
       {
           "dt": [
-              date(1969, 12, 31),
-              date(2026, 8, 22),
-              date(2077, 2, 10),
+              datetime(1969, 12, 31, 4, 30, 45, 123456),
+              datetime(2026, 7, 12, 10, 23, 59, 999999),
+              datetime(2077, 2, 10, 18, 10, 15, 654321),
           ]
       }
     )
@@ -63,19 +113,20 @@ Extracts a part of a date (or datetime) such as 'year', 'month', etc.
         dt,
         DATE_PART('year', dt) AS year,
         DATE_PART('month', dt) AS month,
-        DATE_PART('day', dt) AS day
+        DATE_PART('day', dt) AS day,
+        DATE_PART('ms', dt) AS secs_ms,
       FROM self
     """)
-    # shape: (3, 4)
-    # ┌────────────┬──────┬───────┬─────┐
-    # │ dt         ┆ year ┆ month ┆ day │
-    # │ ---        ┆ ---  ┆ ---   ┆ --- │
-    # │ date       ┆ i32  ┆ i8    ┆ i8  │
-    # ╞════════════╪══════╪═══════╪═════╡
-    # │ 1969-12-31 ┆ 1969 ┆ 12    ┆ 31  │
-    # │ 2026-08-22 ┆ 2026 ┆ 8     ┆ 22  │
-    # │ 2077-02-10 ┆ 2077 ┆ 2     ┆ 10  │
-    # └────────────┴──────┴───────┴─────┘
+    # shape: (3, 5)
+    # ┌────────────────────────────┬──────┬───────┬─────┬───────────┐
+    # │ dt                         ┆ year ┆ month ┆ day ┆ secs_ms   │
+    # │ ---                        ┆ ---  ┆ ---   ┆ --- ┆ ---       │
+    # │ datetime[μs]               ┆ i32  ┆ i8    ┆ i8  ┆ f64       │
+    # ╞════════════════════════════╪══════╪═══════╪═════╪═══════════╡
+    # │ 1969-12-31 04:30:45.123456 ┆ 1969 ┆ 12    ┆ 31  ┆ 45123.456 │
+    # │ 2026-07-12 10:23:59.999999 ┆ 2026 ┆ 7     ┆ 12  ┆ 59999.999 │
+    # │ 2077-02-10 18:10:15.654321 ┆ 2077 ┆ 2     ┆ 10  ┆ 15654.321 │
+    # └────────────────────────────┴──────┴───────┴─────┴───────────┘
 
 .. _extract:
 
@@ -83,29 +134,81 @@ EXTRACT
 -------
 Extracts a part of a date (or datetime) such as 'year', 'month', etc.
 
-**Supported parts/fields:**
-    - "millennium" | "millennia"
-    - "century" | "centuries"
-    - "decade" | "decades"
-    - "isoyear"
-    - "year" | "years" | "y"
-    - "quarter" | "quarters"
-    - "month" | "months" | "mon" | "mons"
-    - "dayofyear" | "doy"
-    - "dayofweek" | "dow"
-    - "isoweek" | "week"
-    - "isodow"
-    - "day" | "days" | "d"
-    - "hour" | "hours" | "h"
-    - "minute" | "minutes" | "mins" | "min" | "m"
-    - "second" | "seconds" | "sec" | "secs" | "s"
-    - "millisecond" | "milliseconds" | "ms"
-    - "microsecond" | "microseconds" | "us"
-    - "nanosecond" | "nanoseconds" | "ns"
-    - "timezone"
-    - "time"
-    - "epoch"
 
+**Supported parts/fields:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 40 20
+
+   * - Part
+     - Description
+     - DataType
+   * - 'millennium', 'millennia'
+     - Millennium number
+     - Int32
+   * - 'century', 'centuries', 'c'
+     - Century number
+     - Int32
+   * - 'decade', 'decades'
+     - Decade number (year / 10)
+     - Int32
+   * - 'isoyear'
+     - ISO year number
+     - Int32
+   * - 'year', 'years', 'y'
+     - Calendar year
+     - Int32
+   * - 'quarter', 'quarters'
+     - Quarter of the year (1–4)
+     - Int8
+   * - 'month', 'months', 'mon', 'mons'
+     - Month of the year (1–12)
+     - Int8
+   * - 'dayofyear', 'doy'
+     - Day of the year (1–366)
+     - Int16
+   * - 'dayofweek', 'dow', 'weekday'
+     - Day of the week (0:Sunday – 6:Saturday)
+     - Int8
+   * - 'isoweek', 'week'
+     - ISO week number (1–53)
+     - Int8
+   * - 'isodow'
+     - ISO day of the week (1:Monday – 7:Sunday)
+     - Int8
+   * - 'day', 'days', 'dayofmonth', d'
+     - Day of the month (1–31)
+     - Int8
+   * - 'hour', 'hours', 'h'
+     - Hour of the day (0–23)
+     - Int8
+   * - 'minute', 'minutes', 'mins', 'min', 'm'
+     - Minute of the hour (0–59)
+     - Int8
+   * - 'second', 'seconds', 'sec', 'secs', 's'
+     - Second of the minute (0–59)
+     - Int8
+   * - 'millisecond', 'milliseconds', 'ms'
+     - Sub-minute seconds and milliseconds (0–59999.)
+     - Float64
+   * - 'microsecond', 'microseconds', 'us'
+     - Sub-minute seconds and microseconds (0–59999999.)
+     - Float64
+   * - 'nanosecond', 'nanoseconds', 'ns'
+     - Sub-minute seconds and nanoseconds (0–59999999999.)
+     - Float64
+   * - 'timezone'
+     - UTC offset of the timezone, in seconds ()
+     - Int64
+   * - 'time'
+     - Time component
+     - Time
+   * - 'epoch'
+     - Seconds since Unix epoch (1970-01-01)
+     - Float64
+
+**Example:**
 
 .. code-block:: python
 


### PR DESCRIPTION
Clarifies these two functions by adding explicit ranges and dtypes for the expected output for each "part". Now given as a table with "Part", "Description", and "DataType" headers instead of being just a basic bulleted list of parts. This is particularly helpful for fields such as `'dow'` vs `'isodow'`.

<img width="1397" height="1191" alt="SQL Temporal Docs" src="https://github.com/user-attachments/assets/8ace1dad-6eab-4688-9bab-37de63bb0207" />

**Also:**

* Added "c" shortcut for "century", and "dayofmonth" alias for "day" parts (as found in other SQL dialects).
* Tweaked `macOS` docs build to skip parallelism, as it almost always crashes (I built the docs to validate this PR).