### PR TITLE
fix(rust): Fix `assert_frame_not_equal()` did not raise on dtype mismatch

### DIFF
--- a/crates/polars-testing/src/asserts/utils.rs
+++ b/crates/polars-testing/src/asserts/utils.rs
@@ -767,19 +767,17 @@ fn assert_dataframe_schema_equal(
                     format!("{:?}", right_dtypes_ordered)
                 ));
             }
-        } else {
-            if left_schema.len() != right_schema.len()
-                || left_schema
-                    .iter()
-                    .any(|(name, dtype)| right_schema.get(name) != Some(dtype))
-            {
-                return Err(polars_err!(
-                    assertion_error = "DataFrames",
-                    "dtypes do not match",
-                    format!("{:?}", left_schema),
-                    format!("{:?}", right_schema)
-                ));
-            }
+        } else if left_schema.len() != right_schema.len()
+            || left_schema
+                .iter()
+                .any(|(name, dtype)| right_schema.get(name) != Some(dtype))
+        {
+            return Err(polars_err!(
+                assertion_error = "DataFrames",
+                "dtypes do not match",
+                format!("{:?}", left_schema),
+                format!("{:?}", right_schema)
+            ));
         }
     }
 

--- a/crates/polars-testing/src/asserts/utils.rs
+++ b/crates/polars-testing/src/asserts/utils.rs
@@ -768,16 +768,16 @@ fn assert_dataframe_schema_equal(
                 ));
             }
         } else {
-            let left_dtypes_unordered: PlHashMap<&PlSmallStr, &DataType> =
-                left_schema.iter().collect();
-            let right_dtypes_unordered: PlHashMap<&PlSmallStr, &DataType> =
-                right_schema.iter().collect();
-            if left_dtypes_unordered != right_dtypes_unordered {
+            if left_schema.len() != right_schema.len()
+                || left_schema
+                    .iter()
+                    .any(|(name, dtype)| right_schema.get(name) != Some(dtype))
+            {
                 return Err(polars_err!(
                     assertion_error = "DataFrames",
                     "dtypes do not match",
-                    format!("{:?}", left_dtypes_unordered),
-                    format!("{:?}", right_dtypes_unordered)
+                    format!("{:?}", left_schema),
+                    format!("{:?}", right_schema)
                 ));
             }
         }

--- a/crates/polars-testing/src/asserts/utils.rs
+++ b/crates/polars-testing/src/asserts/utils.rs
@@ -768,14 +768,16 @@ fn assert_dataframe_schema_equal(
                 ));
             }
         } else {
-            let left_dtypes: PlHashSet<DataType> = left.dtypes().into_iter().collect();
-            let right_dtypes: PlHashSet<DataType> = right.dtypes().into_iter().collect();
-            if left_dtypes != right_dtypes {
+            let left_dtypes_unordered: PlHashMap<&PlSmallStr, &DataType> =
+                left_schema.iter().collect();
+            let right_dtypes_unordered: PlHashMap<&PlSmallStr, &DataType> =
+                right_schema.iter().collect();
+            if left_dtypes_unordered != right_dtypes_unordered {
                 return Err(polars_err!(
                     assertion_error = "DataFrames",
                     "dtypes do not match",
-                    format!("{:?}", left_dtypes),
-                    format!("{:?}", right_dtypes)
+                    format!("{:?}", left_dtypes_unordered),
+                    format!("{:?}", right_dtypes_unordered)
                 ));
             }
         }

--- a/py-polars/tests/unit/testing/test_assert_frame_equal.py
+++ b/py-polars/tests/unit/testing/test_assert_frame_equal.py
@@ -478,3 +478,37 @@ def test_frame_schema_fail():
     assert "AssertionError: DataFrames are equal" in stdout
     assert "AssertionError: inputs are different (unexpected input types)" in stdout
     assert "AssertionError: DataFrames are different (dtypes do not match)" in stdout
+
+
+def test_dtype_check_for_assert_frame_26507() -> None:
+    schema_a = {
+        "int_a": pl.Int16,
+        "int_b": pl.Int16,
+        "int_c": pl.Int64,
+    }
+
+    schema_b = {
+        "int_a": pl.Int64,
+        "int_b": pl.Int16,
+        "int_c": pl.Int64,
+    }
+
+    a = pl.DataFrame({}, schema=schema_a)
+    b = pl.DataFrame({}, schema=schema_b)
+
+    # SHOULD NOT raise an error since frames have different dtypes
+    assert_frame_not_equal(
+        left=a,
+        right=b,
+        check_column_order=False,
+        check_dtypes=True,
+    )
+
+    # SHOULD raise an error since frames have different dtypes
+    with pytest.raises(AssertionError):
+        assert_frame_equal(
+            left=a,
+            right=b,
+            check_column_order=False,
+            check_dtypes=True,
+        )


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/26507.

In `assert_dataframe_schema_equal()`, a helper function used in `assert_dataframe_equal()`, the code first checks if `check_dtypes` is `true`. If it is `true`, it then checks if `check_column_order` is `true`. If it is, data types are compared using a vector, comparing element by element in order. This was working properly. 

In the `else` condition, meaning `check_column_order` is `false`, the original code was using a `PlHashSet` of `DataType`. While `PlHashSet` does unordered comparison, it does not preserve column names or duplicate values. So, for example, if the data types of `left` were `{Int16, Int16, Int64}` and the data types of `right` were `{Int64, Int16, Int64}`, using a `PlHashSet` would result in deduplication and the comparison of `{Int16, Int64}` and `{Int64, Int16}`, which is considered equal. 

The solution was to instead use a `PlHashMap` which uses unordered comparison, but preserves the name -> data type association.

Edit: After reviewer comment, used Claude Sonnet 4.5 to help me better understand and work with `IndexMap`.