### PR TITLE
fix(rust): Return error when `by=` is nested type in `min_by` / `max_by`

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
@@ -142,7 +142,15 @@ impl IRFunctionExpr {
             #[cfg(feature = "moment")]
             Kurtosis(..) => mapper.with_dtype(DataType::Float64),
             ArgUnique | ArgMin | ArgMax | ArgSort { .. } => mapper.with_dtype(IDX_DTYPE),
-            MinBy | MaxBy => mapper.with_same_dtype(),
+            MinBy | MaxBy => {
+                if fields[1].dtype.is_nested() {
+                    polars_bail!(
+                        InvalidOperation: "cannot use a nested type as `by` argument in `min_by`/`max_by`, got dtype `{}`", fields[1].dtype
+                    )
+                }
+
+                mapper.with_same_dtype()
+            },
             Product => mapper.map_dtype(|dtype| {
                 use DataType as T;
                 match dtype {

--- a/py-polars/tests/unit/operations/aggregation/test_aggregations.py
+++ b/py-polars/tests/unit/operations/aggregation/test_aggregations.py
@@ -1456,3 +1456,20 @@ def test_min_max_by_series_length_mismatch_26049(
         match=r"^expressions must have matching group lengths$",
     ):
         q.collect(engine="in-memory")
+
+
+@pytest.mark.parametrize(
+    "by_expr",
+    [
+        pl.struct("b", "c"),
+        pl.concat_list("b", "c"),
+    ],
+)
+def test_min_by_max_by_nested_type_key_26268(by_expr: pl.Expr) -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 6, 5], "c": [7, 5, 2]})
+
+    with pytest.raises(
+        pl.exceptions.InvalidOperationError,
+        match="cannot use a nested type as `by` argument in `min_by`/`max_by`",
+    ):
+        df.select(pl.col("a").min_by(by_expr))


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/26268.

The decision to return an error for this was outlined in: https://github.com/pola-rs/polars/issues/26262#issuecomment-3794851034.

In this case, I assumed that all nested types should raise an error when `by=` is a nested type using `DataType::is_nested()`.  The specific examples in the issue refer to `pl.struct` and `pl.concat_list`, which are covered in tests. 

Claude Sonnet 4.5 was used to guide me through the codebase. 