### PR TITLE
fix(rust): Materialize unknown scalar int/float literals in `collect_dtype()`

### DIFF
--- a/crates/polars-plan/src/dsl/datatype_expr.rs
+++ b/crates/polars-plan/src/dsl/datatype_expr.rs
@@ -92,6 +92,7 @@ fn into_datatype_impl(
             let dtype = arena
                 .get(e.node())
                 .to_dtype(&ToFieldContext::new(&arena, schema))?;
+            let dtype = dtype.materialize_unknown(true)?;
             polars_ensure!(!dtype.contains_unknown(),InvalidOperation:"DataType expression is not allowed to instantiate to `unknown`");
             dtype
         },

--- a/py-polars/tests/unit/expr/test_dtype_of.py
+++ b/py-polars/tests/unit/expr/test_dtype_of.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import polars as pl
+
+
+def test_dtype_of_scalar_literal_collect_dtype_26271() -> None:
+    assert pl.dtype_of(pl.lit(1)).collect_dtype({}) == pl.Int32
+    assert pl.dtype_of(pl.lit(1.0)).collect_dtype({}) == pl.Float64
+
+    # These already worked but included for completeness
+    assert pl.dtype_of(pl.lit("foo")).collect_dtype({}) == pl.String
+    assert pl.dtype_of(pl.lit([1])).collect_dtype({}) == pl.List(pl.Int64)


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/26271.

The bug originated in how Polars handles bare scalar integer and float literals. When `pl.lit(1)` is written, Polars engages in deferred type inference until it sees what it is being used alongside. This is especially relevant for integers and floats since they have many different subtypes. 

For this particular issue, `.collect_dtype({})` has an empty schema, meaning no columns available to infer the type. This works fine for most literals since they don't depend on any columns, but for bare integer or float literals, it isn't enough. This is because there are many subtypes and there was nothing in the empty schema to help determine the type, so it would stay as an unknown value. 

In the code, if `dtype` was an unknown value, it would produce an error:

```
polars_ensure!(!dtype.contains_unknown(),InvalidOperation:"DataType expression is not allowed to instantiate to `unknown`");
```

The introduced fix adds one step before the above check: it calls `materialize_unknown()` on `dtype` to pick a sensible default, if it is available. To keep other tests passing and the logic the same, the `allow_unkown` flag was set as `true`, so if we hit an unresolvable unknown, it passes through unchanged. This allows the `polars_ensure!` check to handle unresolvable cases. 

Claude Sonnet 4.5 was used to help me navigate the codebase and explain concepts.