### PR TITLE
feat: Support SQL "FROM-first" `SELECT` query syntax

### DIFF
--- a/py-polars/docs/source/reference/sql/clauses.rst
+++ b/py-polars/docs/source/reference/sql/clauses.rst
@@ -12,7 +12,7 @@ SQL Clauses
    * - :ref:`DISTINCT <distinct>`
      - Returns unique values from a query.
    * - :ref:`FROM <from>`
-     - Specify the table(s) from which to retrieve or delete data.
+     - Specify the table(s) from which to retrieve or delete data. Can also be used as the leading clause.
    * - :ref:`JOIN <join>`
      - Combine rows from two or more tables based on a related column.
    * - :ref:`WHERE <where>`
@@ -65,6 +65,11 @@ Select the columns to be returned by the query.
     # │ 3   ┆ xx  │
     # └─────┴─────┘
 
+.. note::
+
+   Use of bare ``FROM tbl`` is also supported, as shorthand for ``SELECT * FROM tbl``;
+   see the :ref:`FROM <from>` clause for more detail.
+
 .. _distinct:
 
 DISTINCT
@@ -100,6 +105,12 @@ FROM
 ----
 Specifies the table(s) from which to retrieve or delete data.
 
+In addition to the usual ``SELECT ... FROM tbl`` syntax, the ``FROM`` clause can
+also be used as the leading clause in a query, supporting the following variations:
+
+* ``FROM tbl`` - equivalent to ``SELECT * FROM tbl``.
+* ``FROM tbl SELECT ...`` - a reordered ``SELECT`` with explicit projections.
+
 **Example:**
 
 .. code-block:: python
@@ -110,18 +121,39 @@ Specifies the table(s) from which to retrieve or delete data.
         "b": ["zz", "yy", "xx"],
       }
     )
+    for query in (
+      "SELECT * FROM self",
+      "FROM self SELECT *",
+      "FROM self",
+    ):
+      df.sql(query)
+      # shape: (3, 2)
+      # ┌─────┬─────┐
+      # │ a   ┆ b   │
+      # │ --- ┆ --- │
+      # │ i64 ┆ str │
+      # ╞═════╪═════╡
+      # │ 1   ┆ zz  │
+      # │ 2   ┆ yy  │
+      # │ 3   ┆ xx  │
+      # └─────┴─────┘
+
+Using ``FROM`` as the leading clause, with ``SELECT``:
+
+.. code-block:: python
+
     df.sql("""
-      SELECT * FROM self
+      FROM self SELECT b, a
     """)
     # shape: (3, 2)
     # ┌─────┬─────┐
-    # │ a   ┆ b   │
+    # │ b   ┆ a   │
     # │ --- ┆ --- │
-    # │ i64 ┆ str │
+    # │ str ┆ i64 │
     # ╞═════╪═════╡
-    # │ 1   ┆ zz  │
-    # │ 2   ┆ yy  │
-    # │ 3   ┆ xx  │
+    # │ zz  ┆ 1   │
+    # │ yy  ┆ 2   │
+    # │ xx  ┆ 3   │
     # └─────┴─────┘
 
 .. _join:

--- a/py-polars/tests/unit/sql/test_subqueries.py
+++ b/py-polars/tests/unit/sql/test_subqueries.py
@@ -193,7 +193,7 @@ def test_derived_table_without_alias() -> None:
         # set operation without subquery aliases
         res = ctx.execute(
             """
-            SELECT * FROM (
+            FROM (
                 SELECT a, b FROM df WHERE a <= 2
                 UNION ALL
                 SELECT a, b FROM df WHERE a > 2


### PR DESCRIPTION
Several modern SQL dialects support the convenience "FROM-first" syntax. We were silently parsing it but not acting on the implied column information, resulting in an empty (column-less) frame.

Only took a couple of lines to support properly, which is a nice quality of life improvement for anyone familiar with it. Updated the SQL "clauses" docs with details.

## Example

Trivial example -
```python
df = pl.DataFrame({
  "a": [1, 2, 3],
  "b": ["zz", "yy", "xx"],
})
```
**Before:** 
_(incorrect: no parsing error, produces a column-less frame)_
```python
df.sql("FROM self ORDER BY a DESC")
# shape: (0, 0)
# ┌┐
# ╞╡
# └┘
```
**After:** 
_(correctly recognised as shorthand for "SELECT * FROM self ...")_
```python
df.sql("FROM self ORDER BY a DESC")
# shape: (3, 2)
# ┌─────┬─────┐
# │ a   ┆ b   │
# │ --- ┆ --- │
# │ i64 ┆ str │
# ╞═════╪═════╡
# │ 3   ┆ xx  │
# │ 2   ┆ yy  │
# │ 1   ┆ zz  │
# └─────┴─────┘
```