### PR TITLE
chore(python): Avoid implicit import from `importlib`

### DIFF
--- a/py-polars/src/polars/catalog/unity/client.py
+++ b/py-polars/src/polars/catalog/unity/client.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import contextlib
 import importlib
+import importlib.util
 import os
 import sys
-from importlib.util import find_spec
 from typing import TYPE_CHECKING, Any, Literal
 
 from polars._utils.deprecation import issue_deprecation_warning
@@ -699,7 +699,7 @@ class Catalog:
 
     @classmethod
     def _get_databricks_token(cls) -> str:
-        if find_spec("databricks.sdk") is None:
+        if importlib.util.find_spec("databricks.sdk") is None:
             msg = "could not get Databricks token: databricks-sdk is not installed"
             raise ImportError(msg)
 

--- a/py-polars/src/polars/io/cloud/credential_provider/_providers.py
+++ b/py-polars/src/polars/io/cloud/credential_provider/_providers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+import importlib.util
 import json
 import os
 import subprocess
@@ -9,7 +10,6 @@ import zoneinfo
 from collections.abc import Callable
 from datetime import datetime
 from functools import partial
-from importlib.util import find_spec
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -294,7 +294,7 @@ class CredentialProviderAWS(CachingCredentialProvider):
 
     @classmethod
     def _ensure_module_availability(cls) -> None:
-        if find_spec("boto3") is None:
+        if importlib.util.find_spec("boto3") is None:
             msg = "boto3 must be installed to use `CredentialProviderAWS`"
             raise ImportError(msg)
 
@@ -436,7 +436,7 @@ class CredentialProviderAzure(CachingCredentialProvider):
 
     @classmethod
     def _ensure_module_availability(cls) -> None:
-        if find_spec("azure.identity") is None:
+        if importlib.util.find_spec("azure.identity") is None:
             msg = "azure-identity must be installed to use `CredentialProviderAzure`"
             raise ImportError(msg)
 
@@ -567,7 +567,7 @@ class CredentialProviderGCP(CachingCredentialProvider):
 
     @classmethod
     def _ensure_module_availability(cls) -> None:
-        if find_spec("google.auth") is None:
+        if importlib.util.find_spec("google.auth") is None:
             msg = "google-auth must be installed to use `CredentialProviderGCP`"
             raise ImportError(msg)
 

--- a/py-polars/src/polars/io/delta/functions.py
+++ b/py-polars/src/polars/io/delta/functions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from importlib.util import find_spec
+import importlib
+import importlib.util
 from typing import TYPE_CHECKING, Any
 
 from polars._utils.wrap import wrap_ldf
@@ -293,7 +294,7 @@ def scan_delta(
 
     table: DeltaTable | None = None
 
-    if find_spec("deltalake") is not None:
+    if importlib.util.find_spec("deltalake") is not None:
         from deltalake import DeltaTable
 
         if isinstance(source, DeltaTable):

--- a/py-polars/src/polars/io/iceberg/functions.py
+++ b/py-polars/src/polars/io/iceberg/functions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from importlib.util import find_spec
+import importlib
+import importlib.util
 from typing import TYPE_CHECKING, Literal
 
 from polars._utils.unstable import issue_unstable_warning
@@ -172,7 +173,7 @@ def scan_iceberg(
 
     table: Table | None = None
 
-    if find_spec("pyiceberg.table") is not None:
+    if importlib.util.find_spec("pyiceberg.table") is not None:
         from pyiceberg.table import Table
 
         if isinstance(source, Table):


### PR DESCRIPTION
Type checkers raise
```
ERROR Module `importlib.util` exists, but was not imported explicitly. You are relying on other modules to load it. [implicit-import]
```
on this. Not sure why it's currently silenced, but if the plan is to eventually move over to a modern / faster type checker, then this would need addressing anyway

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
