### PR TITLE
fix(rust): Prevent `struct.with_fields` from broadcasting unit lengths that are non-scalar

### DIFF
--- a/crates/polars-expr/src/expressions/structeval.rs
+++ b/crates/polars-expr/src/expressions/structeval.rs
@@ -250,18 +250,23 @@ impl PhysicalExpr for StructEvalExpr {
 
         for (i, col) in cols.iter().enumerate() {
             let col_len = col.len();
-            if col_len != input_len && col_len == 1 && !self.evaluation[i].is_scalar() {
-                let identifier = match self.evaluation[i].as_expression() {
-                    Some(expr) => format!("expression: {expr}"),
-                    None => "this Series".to_string(),
-                };
+            if col_len != input_len && col_len == 1 {
+                #[allow(clippy::collapsible_if)]
+                if !self.evaluation[i].is_scalar()
+                    && std::env::var("POLARS_ALLOW_NON_SCALAR_EXP").as_deref() != Ok("1")
+                {
+                    let identifier = match self.evaluation[i].as_expression() {
+                        Some(expr) => format!("expression: {expr}"),
+                        None => "this Series".to_string(),
+                    };
 
-                polars_bail!(InvalidOperation:
-                    "Series {}, length {} doesn't match the DataFrame height of {}\n\n\
-                    If you want {} to be broadcasted, ensure it is a scalar \
-                    (for instance by adding '.first()').",
-                    col.name(), col_len, input_len, identifier
-                );
+                    polars_bail!(InvalidOperation:
+                        "Series {}, length {} doesn't match the DataFrame height of {}\n\n\
+                        If you want {} to be broadcasted, ensure it is a scalar \
+                        (for instance by adding '.first()').",
+                        col.name(), col_len, input_len, identifier
+                    );
+                }
             }
         }
 

--- a/crates/polars-expr/src/expressions/structeval.rs
+++ b/crates/polars-expr/src/expressions/structeval.rs
@@ -214,7 +214,6 @@ impl PhysicalExpr for StructEvalExpr {
     }
 
     fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Column> {
-        eprintln!("DEBUG: evaluate() called");
         let input = self.input.evaluate(df, state)?;
 
         // Set ExecutionState.
@@ -251,7 +250,11 @@ impl PhysicalExpr for StructEvalExpr {
 
         for (i, col) in cols.iter().enumerate() {
             let col_len = col.len();
-            if col_len != input_len && col_len == 1 && !self.evaluation[i].is_scalar() {
+            if col_len != input_len
+                && col_len == 1
+                && !self.evaluation[i].is_scalar()
+                && std::env::var("POLARS_ALLOW_NON_SCALAR_EXP").as_deref() != Ok("1")
+            {
                 let identifier = match self.evaluation[i].as_expression() {
                     Some(expr) => format!("expression: {expr}"),
                     None => "this Series".to_string(),
@@ -282,7 +285,6 @@ impl PhysicalExpr for StructEvalExpr {
     ) -> PolarsResult<AggregationContext<'a>> {
         // The evaluation is similar to a regular Function, with the modification that the input
         // is evaluated first, and retained for future use in the ExecutionState.
-        eprintln!("DEBUG: evaluate_on_groups() called");
         // Evaluate input.
         let mut ac = self.input.evaluate_on_groups(df, groups, state)?;
 
@@ -319,7 +321,12 @@ impl PhysicalExpr for StructEvalExpr {
         for (i, ac) in acs.iter().enumerate().skip(1) {
             let col = ac.flat_naive();
             let col_len = col.len();
-            if col_len != input_len && col_len == 1 && !ac.is_literal() && !self.is_scalar() {
+            if col_len != input_len
+                && col_len == 1
+                && !ac.is_literal()
+                && !self.is_scalar()
+                && std::env::var("POLARS_ALLOW_NON_SCALAR_EXP").as_deref() != Ok("1")
+            {
                 let identifier = match self.evaluation.get(i - 1).and_then(|e| e.as_expression()) {
                     Some(expr) => format!("expression: {expr}"),
                     None => "this Series".to_string(),

--- a/crates/polars-expr/src/expressions/structeval.rs
+++ b/crates/polars-expr/src/expressions/structeval.rs
@@ -228,22 +228,6 @@ impl PhysicalExpr for StructEvalExpr {
 
         let f = |e: &Arc<dyn PhysicalExpr>| {
             let result = e.evaluate(df, &state)?;
-            let result_len = result.len();
-
-            if result_len != input_len && result_len == 1 && !e.is_scalar() {
-                let identifier = match e.as_expression() {
-                    Some(expr) => format!("expression: {expr}"),
-                    None => "this Series".to_string(),
-                };
-
-                polars_bail!(InvalidOperation:
-                    "Series {}, length {} doesn't match the DataFrame height of {}\n\n\
-                    If you want {} to be broadcasted, ensure it is a scalar \
-                    (for instance by adding '.first()').",
-                    result.name(), result_len, input_len, identifier
-                );
-            }
-
             polars_ensure!(
                 result.len() == input_len || result.len() == 1,
                 ShapeMismatch: "struct.with_fields expressions must have matching or unit length"
@@ -262,8 +246,26 @@ impl PhysicalExpr for StructEvalExpr {
                 .iter()
                 .map(f)
                 .collect::<PolarsResult<Vec<_>>>()
-        };
-        for col in cols? {
+        }?;
+
+        for (i, col) in cols.iter().enumerate() {
+            let col_len = col.len();
+            if col_len != input_len && col_len == 1 && !self.evaluation[i].is_scalar() {
+                let identifier = match self.evaluation[i].as_expression() {
+                    Some(expr) => format!("expression: {expr}"),
+                    None => "this Series".to_string(),
+                };
+
+                polars_bail!(InvalidOperation:
+                    "Series {}, length {} doesn't match the DataFrame height of {}\n\n\
+                    If you want {} to be broadcasted, ensure it is a scalar \
+                    (for instance by adding '.first()').",
+                    col.name(), col_len, input_len, identifier
+                );
+            }
+        }
+
+        for col in cols {
             eval.push(col);
         }
 

--- a/crates/polars-expr/src/expressions/structeval.rs
+++ b/crates/polars-expr/src/expressions/structeval.rs
@@ -136,31 +136,6 @@ impl StructEvalExpr {
                     .collect::<Vec<_>>();
 
                 let input_len = cols[base_ac_idx].len();
-
-                for (i, col) in cols.iter().enumerate().skip(1) {
-                    let col_len = col.len();
-                    if col_len != input_len
-                        && col_len == 1
-                        && !acs[i].is_literal()
-                        && !self.is_scalar()
-                    {
-                        let identifier = match self
-                            .evaluation
-                            .get(i.saturating_sub(1))
-                            .and_then(|e| e.as_expression())
-                        {
-                            Some(expr) => format!("expression: {expr}"),
-                            None => "this Series".to_string(),
-                        };
-                        polars_bail!(InvalidOperation:
-                            "Series {}, length {} doesn't match the DataFrame height of {}\n\n\
-                            If you want {} to be broadcasted, ensure it is a scalar \
-                            (for instance by adding '.first()').",
-                            col.name(), col_len, input_len, identifier
-                        );
-                    }
-                }
-
                 let out = with_fields(&cols)?;
                 assert!(input_len == out.len());
 
@@ -182,23 +157,6 @@ impl StructEvalExpr {
         mut acs: Vec<AggregationContext<'a>>,
     ) -> PolarsResult<AggregationContext<'a>> {
         let len = acs[0].groups.len();
-        let input_len = acs[0].flat_naive().len();
-        for (i, ac) in acs.iter().enumerate().skip(1) {
-            let col = ac.flat_naive();
-            let col_len = col.len();
-            if col_len != input_len && col_len == 1 && !ac.is_literal() && !self.is_scalar() {
-                let identifier = match self.evaluation.get(i - 1).and_then(|e| e.as_expression()) {
-                    Some(expr) => format!("expression: {expr}"),
-                    None => "this Series".to_string(),
-                };
-                polars_bail!(InvalidOperation:
-                    "Series {}, length {} doesn't match the DataFrame height of {}\n\n\
-                    If you want {} to be broadcasted, ensure it is a scalar \
-                    (for instance by adding '.first()').",
-                    col.name(), col_len, input_len, identifier
-                );
-            }
-        }
         let mut iters = acs
             .iter_mut()
             .map(|ac| ac.iter_groups(true))
@@ -354,6 +312,24 @@ impl PhysicalExpr for StructEvalExpr {
         };
         for ac in acs_eval? {
             acs.push(ac)
+        }
+
+        let input_len = acs[0].flat_naive().len();
+        for (i, ac) in acs.iter().enumerate().skip(1) {
+            let col = ac.flat_naive();
+            let col_len = col.len();
+            if col_len != input_len && col_len == 1 && !ac.is_literal() && !self.is_scalar() {
+                let identifier = match self.evaluation.get(i - 1).and_then(|e| e.as_expression()) {
+                    Some(expr) => format!("expression: {expr}"),
+                    None => "this Series".to_string(),
+                };
+                polars_bail!(InvalidOperation:
+                    "Series {}, length {} doesn't match the DataFrame height of {}\n\n\
+                    If you want {} to be broadcasted, ensure it is a scalar \
+                    (for instance by adding '.first()').",
+                    col.name(), col_len, input_len, identifier
+                );
+            }
         }
 
         // Revert ExecutionState.

--- a/crates/polars-expr/src/expressions/structeval.rs
+++ b/crates/polars-expr/src/expressions/structeval.rs
@@ -136,6 +136,31 @@ impl StructEvalExpr {
                     .collect::<Vec<_>>();
 
                 let input_len = cols[base_ac_idx].len();
+
+                for (i, col) in cols.iter().enumerate().skip(1) {
+                    let col_len = col.len();
+                    if col_len != input_len
+                        && col_len == 1
+                        && !acs[i].is_literal()
+                        && !self.is_scalar()
+                    {
+                        let identifier = match self
+                            .evaluation
+                            .get(i.saturating_sub(1))
+                            .and_then(|e| e.as_expression())
+                        {
+                            Some(expr) => format!("expression: {expr}"),
+                            None => "this Series".to_string(),
+                        };
+                        polars_bail!(InvalidOperation:
+                            "Series {}, length {} doesn't match the DataFrame height of {}\n\n\
+                            If you want {} to be broadcasted, ensure it is a scalar \
+                            (for instance by adding '.first()').",
+                            col.name(), col_len, input_len, identifier
+                        );
+                    }
+                }
+
                 let out = with_fields(&cols)?;
                 assert!(input_len == out.len());
 

--- a/crates/polars-expr/src/expressions/structeval.rs
+++ b/crates/polars-expr/src/expressions/structeval.rs
@@ -182,6 +182,23 @@ impl StructEvalExpr {
         mut acs: Vec<AggregationContext<'a>>,
     ) -> PolarsResult<AggregationContext<'a>> {
         let len = acs[0].groups.len();
+        let input_len = acs[0].flat_naive().len();
+        for (i, ac) in acs.iter().enumerate().skip(1) {
+            let col = ac.flat_naive();
+            let col_len = col.len();
+            if col_len != input_len && col_len == 1 && !ac.is_literal() && !self.is_scalar() {
+                let identifier = match self.evaluation.get(i - 1).and_then(|e| e.as_expression()) {
+                    Some(expr) => format!("expression: {expr}"),
+                    None => "this Series".to_string(),
+                };
+                polars_bail!(InvalidOperation:
+                    "Series {}, length {} doesn't match the DataFrame height of {}\n\n\
+                    If you want {} to be broadcasted, ensure it is a scalar \
+                    (for instance by adding '.first()').",
+                    col.name(), col_len, input_len, identifier
+                );
+            }
+        }
         let mut iters = acs
             .iter_mut()
             .map(|ac| ac.iter_groups(true))

--- a/crates/polars-expr/src/expressions/structeval.rs
+++ b/crates/polars-expr/src/expressions/structeval.rs
@@ -214,6 +214,7 @@ impl PhysicalExpr for StructEvalExpr {
     }
 
     fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Column> {
+        eprintln!("DEBUG: evaluate() called");
         let input = self.input.evaluate(df, state)?;
 
         // Set ExecutionState.

--- a/crates/polars-expr/src/expressions/structeval.rs
+++ b/crates/polars-expr/src/expressions/structeval.rs
@@ -250,23 +250,18 @@ impl PhysicalExpr for StructEvalExpr {
 
         for (i, col) in cols.iter().enumerate() {
             let col_len = col.len();
-            if col_len != input_len && col_len == 1 {
-                #[allow(clippy::collapsible_if)]
-                if !self.evaluation[i].is_scalar()
-                    && std::env::var("POLARS_ALLOW_NON_SCALAR_EXP").as_deref() != Ok("1")
-                {
-                    let identifier = match self.evaluation[i].as_expression() {
-                        Some(expr) => format!("expression: {expr}"),
-                        None => "this Series".to_string(),
-                    };
+            if col_len != input_len && col_len == 1 && !self.evaluation[i].is_scalar() {
+                let identifier = match self.evaluation[i].as_expression() {
+                    Some(expr) => format!("expression: {expr}"),
+                    None => "this Series".to_string(),
+                };
 
-                    polars_bail!(InvalidOperation:
-                        "Series {}, length {} doesn't match the DataFrame height of {}\n\n\
-                        If you want {} to be broadcasted, ensure it is a scalar \
-                        (for instance by adding '.first()').",
-                        col.name(), col_len, input_len, identifier
-                    );
-                }
+                polars_bail!(InvalidOperation:
+                    "Series {}, length {} doesn't match the DataFrame height of {}\n\n\
+                    If you want {} to be broadcasted, ensure it is a scalar \
+                    (for instance by adding '.first()').",
+                    col.name(), col_len, input_len, identifier
+                );
             }
         }
 

--- a/crates/polars-expr/src/expressions/structeval.rs
+++ b/crates/polars-expr/src/expressions/structeval.rs
@@ -228,6 +228,22 @@ impl PhysicalExpr for StructEvalExpr {
 
         let f = |e: &Arc<dyn PhysicalExpr>| {
             let result = e.evaluate(df, &state)?;
+            let result_len = result.len();
+
+            if result_len != input_len && result_len == 1 && !e.is_scalar() {
+                let identifier = match e.as_expression() {
+                    Some(expr) => format!("expression: {expr}"),
+                    None => "this Series".to_string(),
+                };
+
+                polars_bail!(InvalidOperation:
+                    "Series {}, length {} doesn't match the DataFrame height of {}\n\n\
+                    If you want {} to be broadcasted, ensure it is a scalar \
+                    (for instance by adding '.first()').",
+                    result.name(), result_len, input_len, identifier
+                );
+            }
+
             polars_ensure!(
                 result.len() == input_len || result.len() == 1,
                 ShapeMismatch: "struct.with_fields expressions must have matching or unit length"

--- a/crates/polars-expr/src/expressions/structeval.rs
+++ b/crates/polars-expr/src/expressions/structeval.rs
@@ -282,7 +282,7 @@ impl PhysicalExpr for StructEvalExpr {
     ) -> PolarsResult<AggregationContext<'a>> {
         // The evaluation is similar to a regular Function, with the modification that the input
         // is evaluated first, and retained for future use in the ExecutionState.
-
+        eprintln!("DEBUG: evaluate_on_groups() called");
         // Evaluate input.
         let mut ac = self.input.evaluate_on_groups(df, groups, state)?;
 

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -7,7 +7,7 @@ use polars_core::prelude::{
 };
 use polars_core::scalar::Scalar;
 use polars_core::schema::{Schema, SchemaExt};
-use polars_error::PolarsResult;
+use polars_error::{PolarsResult, polars_bail};
 use polars_expr::state::ExecutionState;
 use polars_expr::{ExpressionConversionState, create_physical_expr};
 use polars_ops::frame::{JoinArgs, JoinType};
@@ -1618,6 +1618,23 @@ fn lower_exprs_with_ctx(
                 // Rewrite any `StructField(x)`` expression into a `Col(prefix_x)`` expression.
                 let separator = PlSmallStr::from_static("_FLD_");
                 let field_prefix = polars_utils::format_pl_smallstr!("{}{}", out_name, separator);
+
+                if std::env::var("POLARS_ALLOW_NON_SCALAR_EXP").as_deref() != Ok("1") {
+                    for e in &evaluation {
+                        if !e.is_scalar(ctx.expr_arena)
+                            && !is_elementwise_rec_cached(e.node(), ctx.expr_arena, ctx.cache)
+                        {
+                            let name = e.output_name();
+                            polars_bail!(InvalidOperation:
+                                "Series {}, length 1 doesn't match the DataFrame height\n\n\
+                                If you want expression: {} to be broadcasted, ensure it is a scalar \
+                                (for instance by adding '.first()').",
+                                name, name
+                            );
+                        }
+                    }
+                }
+
                 evaluation.iter_mut().for_each(|e| {
                     e.set_node(structfield_to_column(
                         e.node(),

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -1870,10 +1870,12 @@ def test_join_struct_error_lazy_26276() -> None:
 def test_expr_broadcasting_errors_26022() -> None:
     with pytest.raises(
         pl.exceptions.InvalidOperationError,
-        match=r"Series .*, length 1 doesn't match the DataFrame height of 2",
+        match=r"doesn't match the DataFrame height",
     ):
         pl.DataFrame(
             {"a": [{"field": 1}, {"field": 2}]},
         ).lazy().with_columns(
-            pl.col("a").struct.with_fields(pl.field("field").head(1).alias("head_1"))
+            pl.col("a").struct.with_fields(
+                pl.field("field").filter(pl.field("field") == 1).alias("filtered")
+            )
         ).collect()

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -1870,7 +1870,7 @@ def test_join_struct_error_lazy_26276() -> None:
 def test_expr_broadcasting_errors_26022() -> None:
     with pytest.raises(
         pl.exceptions.InvalidOperationError,
-        match=r"Series .*, length 1 doesn't match the DataFrame height of 2",
+        match=r"Series .*, length 1 doesn't match the DataFrame height",
     ):
         pl.DataFrame(
             {"a": [{"field": 1}, {"field": 2}]},

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -1870,12 +1870,10 @@ def test_join_struct_error_lazy_26276() -> None:
 def test_expr_broadcasting_errors_26022() -> None:
     with pytest.raises(
         pl.exceptions.InvalidOperationError,
-        match=r"doesn't match the DataFrame height",
+        match=r"Series .*, length 1 doesn't match the DataFrame height of 2",
     ):
         pl.DataFrame(
             {"a": [{"field": 1}, {"field": 2}]},
         ).lazy().with_columns(
-            pl.col("a").struct.with_fields(
-                pl.field("field").filter(pl.field("field") == 1).alias("filtered")
-            )
+            pl.col("a").struct.with_fields(pl.field("field").head(1).alias("head_1"))
         ).collect()

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -1870,7 +1870,7 @@ def test_join_struct_error_lazy_26276() -> None:
 def test_expr_broadcasting_errors_26022() -> None:
     with pytest.raises(
         pl.exceptions.InvalidOperationError,
-        match=r"doesn't match the DataFrame height",
+        match=r"Series .*, length 1 doesn't match the DataFrame height of 2",
     ):
         pl.DataFrame(
             {"a": [{"field": 1}, {"field": 2}]},

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -1865,3 +1865,15 @@ def test_join_struct_error_lazy_26276() -> None:
 
     with pytest.raises(pl.exceptions.SchemaError, match=r"struct \{.*\}"):
         lhs.join(rhs, on="x").collect()
+
+
+def test_expr_broadcasting_errors_26022() -> None:
+    with pytest.raises(
+        pl.exceptions.InvalidOperationError,
+        match=r"Series .*, length 1 doesn't match the DataFrame height of 2",
+    ):
+        pl.DataFrame(
+            {"a": [{"field": 1}, {"field": 2}]},
+        ).lazy().with_columns(
+            pl.col("a").struct.with_fields(pl.field("field").head(1).alias("head_1"))
+        ).collect()

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -1870,7 +1870,7 @@ def test_join_struct_error_lazy_26276() -> None:
 def test_expr_broadcasting_errors_26022() -> None:
     with pytest.raises(
         pl.exceptions.InvalidOperationError,
-        match=r"Series .*, length 1 doesn't match the DataFrame height of 2",
+        match=r"doesn't match the DataFrame height",
     ):
         pl.DataFrame(
             {"a": [{"field": 1}, {"field": 2}]},


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/26022/.

The logic already existed for throwing an error in this exact situation, but for `.with_columns()` in [crates/polars-mem-engine/src/executors/stack.rs](https://github.com/pola-rs/polars/blob/py-1.38.1/crates/polars-mem-engine/src/executors/stack.rs), so the provided solution is nothing novel. I just had to find the right placement. 

Claude Sonnet 4.5 was to help me navigate the codebase and to translate the error over to a new context.