### PR TITLE
test(python): Use monkeypatch.chdir in test_sink_path_slicing_utf8_boundaries_26324

### DIFF
--- a/py-polars/tests/unit/io/test_sink.py
+++ b/py-polars/tests/unit/io/test_sink.py
@@ -331,9 +331,9 @@ def test_write_unsupported_compression(write_fn_name: str, fmt: str) -> None:
 @pytest.mark.write_disk
 @pytest.mark.parametrize("file_name", ["凸变英雄X", "影分身の術"])
 def test_sink_path_slicing_utf8_boundaries_26324(
-    tmp_path: Path, file_name: str
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, file_name: str
 ) -> None:
-    os.chdir(tmp_path)
+    monkeypatch.chdir(tmp_path)
 
     df = pl.DataFrame({"a": 1})
     df.write_parquet(file_name)


### PR DESCRIPTION
<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->

It appears https://github.com/pola-rs/polars/pull/26389 added a unit tests that uses `os.chdir` and does not revert the directory back to the original directory. This can cause issues for other unit tests, namely `test_scan_parquet_local_with_async`, which relies on `Path.cwd()`

```bash
/polars/py-polars$ pytest @tmp.txt --collect-only
================================================================= test session starts ==================================================================
platform linux -- Python 3.13.12, pytest-8.3.2, pluggy-1.6.0
codspeed: 3.2.0 (disabled, mode: walltime, timer_resolution: 1.0ns)
rootdir: polars/py-polars
configfile: pyproject.toml
plugins: hypothesis-6.151.9, codspeed-3.2.0, xdist-3.6.1, cov-6.0.0
collected 3 items                                                                                                                                      

<Dir py-polars>
  <Package tests>
    <Package unit>
      <Dir io>
        <Module test_sink.py>
          <Function test_sink_path_slicing_utf8_boundaries_26324[\u51f8\u53d8\u82f1\u96c4X]>
          <Function test_sink_path_slicing_utf8_boundaries_26324[\u5f71\u5206\u8eab\u306e\u8853]>
        <Module test_lazy_parquet.py>
          <Function test_scan_parquet_local_with_async>

polars/py-polars$ pytest @tmp.txt
================================================================= test session starts ==================================================================
platform linux -- Python 3.13.12, pytest-8.3.2, pluggy-1.6.0
codspeed: 3.2.0 (disabled, mode: walltime, timer_resolution: 1.0ns)
rootdir: polars/py-polars
configfile: pyproject.toml
plugins: hypothesis-6.151.9, codspeed-3.2.0, xdist-3.6.1, cov-6.0.0
collected 3 items                                                                                                                                      

tests/unit/io/test_sink.py ..                                                                                                                    [ 66%]
tests/unit/io/test_lazy_parquet.py F                                                                                                             [100%]

======================================================================= FAILURES =======================================================================
__________________________________________________________ test_scan_parquet_local_with_async __________________________________________________________
/polars/py-polars/tests/unit/io/test_lazy_parquet.py:46: in test_scan_parquet_local_with_async
    pl.scan_parquet(foods_parquet_path.relative_to(Path.cwd())).head(1).collect()
/conda/envs/polars-dev/lib/python3.13/pathlib/_local.py:385: in relative_to
    raise ValueError(f"{str(self)!r} is not in the subpath of {str(other)!r}")
E   ValueError: '/polars/py-polars/tests/unit/io/files/foods1.parquet' is not in the subpath of '/tmp/pytest-of-me/pytest-295/test_sink_path_slicing_utf8_bo1'
```

We encountered this error when running the Polars unit tests for validating cudf_polars https://github.com/rapidsai/cudf/actions/runs/22149447764/job/64047139637?pr=21451#step:13:66836