### PR TITLE
fix: Rounding behaviour for `f32` values with "HalfAwayFromZero" mode

### DIFF
--- a/crates/polars-ops/src/series/ops/round.rs
+++ b/crates/polars-ops/src/series/ops/round.rs
@@ -124,8 +124,7 @@ pub trait RoundSeries: SeriesSealed {
                         let multiplier = 10.0_f64.powi(decimals as i32);
                         let s = ca
                             .apply_values(|val| {
-                                let ret = ((val as f64 * multiplier).round_ties_even() / multiplier)
-                                    as f32;
+                                let ret = ((val as f64 * multiplier).round() / multiplier) as f32;
                                 if ret.is_finite() {
                                     ret
                                 } else {


### PR DESCRIPTION
The `f32` path with "RoundMode::HalfAwayFromZero" was using `round_ties_even` instead of `round`. Fixed, and added test coverage with specific f16/f32/f64 values that ensure we validate tiebreak behaviour 👍