### PR TITLE
fix(rust): Fix min/max for boolean arrays with nulls

### DIFF
--- a/crates/polars-compute/src/min_max/scalar.rs
+++ b/crates/polars-compute/src/min_max/scalar.rs
@@ -280,15 +280,15 @@ mod tests {
 
     #[test]
     fn test_boolean_min_max_no_nulls() {
-        let all_true = BooleanArray::from_slice(&[true, true]);
+        let all_true = BooleanArray::from_slice([true, true]);
         assert_eq!(all_true.min_ignore_nan_kernel(), Some(true));
         assert_eq!(all_true.max_ignore_nan_kernel(), Some(true));
 
-        let all_false = BooleanArray::from_slice(&[false, false]);
+        let all_false = BooleanArray::from_slice([false, false]);
         assert_eq!(all_false.min_ignore_nan_kernel(), Some(false));
         assert_eq!(all_false.max_ignore_nan_kernel(), Some(false));
 
-        let mixed = BooleanArray::from_slice(&[true, false]);
+        let mixed = BooleanArray::from_slice([true, false]);
         assert_eq!(mixed.min_ignore_nan_kernel(), Some(false));
         assert_eq!(mixed.max_ignore_nan_kernel(), Some(true));
     }


### PR DESCRIPTION
<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->

This should address https://github.com/pola-rs/polars/issues/26290

Basically if you had [True, True, null], min would be False, which would lead to incorrect parquet row group stats, breaking predicate pushdown. The previous implementation counted set/unset bits over the entire array of values, including null positions, where the underlying bit value is typically zero, leading `unset_bits()` to return `1` for that example.

I used AI (claude with Opus 4.6) to identify the bug, implement the fix, and write the tests, but I have reviewed this thoroughly and believe it to be correct.