### PR TITLE
perf: Increase minimum default parquet row group prefetch to 8

### DIFF
--- a/crates/polars-stream/src/nodes/io_sources/parquet/builder.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/builder.rs
@@ -66,7 +66,12 @@ impl FileReaderBuilder for ParquetReaderBuilder {
                     })
                     .get()
             })
-            .unwrap_or(execution_state.num_pipelines.saturating_mul(2))
+            .unwrap_or(
+                execution_state
+                    .num_pipelines
+                    .saturating_mul(2)
+                    .clamp(8, 512),
+            )
             .max(1);
 
         self.prefetch_limit.store(prefetch_limit);


### PR DESCRIPTION
E.g. Single-core systems will now concurrently fetch 8 instead of 2 row groups by default.

We also clamp the maximum to 512.
