### PR TITLE
refactor(rust): Move `?` to assignment site and use `extend()` in `StructEvalExpr`

### DIFF
--- a/crates/polars-expr/src/expressions/structeval.rs
+++ b/crates/polars-expr/src/expressions/structeval.rs
@@ -246,10 +246,8 @@ impl PhysicalExpr for StructEvalExpr {
                 .iter()
                 .map(f)
                 .collect::<PolarsResult<Vec<_>>>()
-        };
-        for col in cols? {
-            eval.push(col);
-        }
+        }?;
+        eval.extend(cols);
 
         // Apply with_fields.
         with_fields(&eval)
@@ -291,10 +289,8 @@ impl PhysicalExpr for StructEvalExpr {
                 .iter()
                 .map(f)
                 .collect::<PolarsResult<Vec<_>>>()
-        };
-        for ac in acs_eval? {
-            acs.push(ac)
-        }
+        }?;
+        acs.extend(acs_eval);
 
         // Revert ExecutionState.
         state.with_fields_ac = None;


### PR DESCRIPTION
Small drive-by to improve readability. I noticed this when I was looking into https://github.com/pola-rs/polars/issues/26022.

Rather than using the `?` operator inside of the `for` loop header to unwrap, it was moved to the end of the `if`/`else` assignment, which is clearer since it separates resolving the `Result` from iterating over contents.

The manual `for` loop pushing elements one-by-one has been removed in favour of `.extend()`, which is more idiomatic. 