### PR TITLE
chore: Remove unused problematic ArrayFromIter

### DIFF
--- a/crates/polars-arrow/src/array/static_array_collect.rs
+++ b/crates/polars-arrow/src/array/static_array_collect.rs
@@ -794,29 +794,6 @@ impl<T: AsArray> ArrayFromIterDtype<Option<T>> for ListArray<i64> {
     }
 }
 
-impl<T: AsArray> ArrayFromIter<Option<T>> for ListArray<i64> {
-    fn arr_from_iter<I: IntoIterator<Item = Option<T>>>(iter: I) -> Self {
-        let iter = iter.into_iter();
-        let iter_values: Vec<Option<T>> = iter.into_iter().collect();
-        let mut builder = AnonymousListArrayBuilder::new(iter_values.len());
-        for arr in &iter_values {
-            builder.push_opt(arr.as_ref().map(|a| a.as_array()));
-        }
-        builder.finish(None).unwrap()
-    }
-
-    fn try_arr_from_iter<E, I: IntoIterator<Item = Result<Option<T>, E>>>(
-        iter: I,
-    ) -> Result<Self, E> {
-        let iter_values = iter.into_iter().collect::<Result<Vec<_>, E>>()?;
-        let mut builder = AnonymousListArrayBuilder::new(iter_values.len());
-        for arr in &iter_values {
-            builder.push_opt(arr.as_ref().map(|a| a.as_array()));
-        }
-        Ok(builder.finish(None).unwrap())
-    }
-}
-
 impl ArrayFromIterDtype<Box<dyn Array>> for FixedSizeListArray {
     #[allow(unused_variables)]
     fn arr_from_iter_with_dtype<I: IntoIterator<Item = Box<dyn Array>>>(

--- a/crates/polars-core/src/chunked_array/from_iterator.rs
+++ b/crates/polars-core/src/chunked_array/from_iterator.rs
@@ -230,13 +230,6 @@ impl FromIterator<Option<Series>> for ListChunked {
     }
 }
 
-impl FromIterator<Option<Box<dyn Array>>> for ListChunked {
-    #[inline]
-    fn from_iter<I: IntoIterator<Item = Option<Box<dyn Array>>>>(iter: I) -> Self {
-        iter.into_iter().collect_ca(PlSmallStr::EMPTY)
-    }
-}
-
 #[cfg(feature = "object")]
 impl<T: PolarsObject> FromIterator<Option<T>> for ObjectChunked<T> {
     fn from_iter<I: IntoIterator<Item = Option<T>>>(iter: I) -> Self {


### PR DESCRIPTION
We really should not be collecting into arrays with nested types without knowing the dtype. This is one example, luckily it was unused so easy to remove.