### PR TITLE
fix: Support varying quantiles per group in group_by aggregation

### DIFF
--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -868,6 +868,24 @@ impl Column {
     ///
     /// Does no bounds checks, groups must be correct.
     #[cfg(feature = "algorithm_group_by")]
+    pub unsafe fn agg_varying_quantile(
+        &self,
+        groups: &GroupsType,
+        quantiles: &[f64],
+        method: QuantileMethod,
+    ) -> Self {
+        // @scalar-opt
+        unsafe {
+            self.as_materialized_series()
+                .agg_varying_quantile(groups, quantiles, method)
+        }
+        .into()
+    }
+
+    /// # Safety
+    ///
+    /// Does no bounds checks, groups must be correct.
+    #[cfg(feature = "algorithm_group_by")]
     pub unsafe fn agg_median(&self, groups: &GroupsType) -> Self {
         self.agg_with_scalar_identity(groups, |s, g| unsafe { s.agg_median(g) })
     }

--- a/crates/polars-expr/src/expressions/aggregation.rs
+++ b/crates/polars-expr/src/expressions/aggregation.rs
@@ -576,31 +576,67 @@ impl PhysicalExpr for AggQuantileExpr {
         // don't change names by aggregations as is done in polars-core
         let keep_name = ac.get_values().name().clone();
 
-        let quantile_column = self.quantile.evaluate(df, state)?;
-        polars_ensure!(quantile_column.len() <= 1, ComputeError:
-            "polars only supports computing a single quantile in a groupby aggregation context"
-        );
-        let quantile: f64 = quantile_column.get(0).unwrap().try_extract()?;
+        // Evaluate quantile per group to support varying quantiles across groups.
+        let quantile_ac = self.quantile.evaluate_on_groups(df, groups, state)?;
 
-        if let AggState::LiteralScalar(c) = &mut ac.state {
-            *c = c
-                .quantile_reduce(quantile, self.method)?
-                .into_column(keep_name);
-            return Ok(ac);
+        match quantile_ac.agg_state() {
+            AggState::LiteralScalar(c) => {
+                // Single quantile for all groups.
+                let quantile: f64 = c.get(0).unwrap().try_extract()?;
+
+                if let AggState::LiteralScalar(c) = &mut ac.state {
+                    *c = c
+                        .quantile_reduce(quantile, self.method)?
+                        .into_column(keep_name);
+                    return Ok(ac);
+                }
+
+                // SAFETY: groups are in bounds
+                let mut agg = unsafe {
+                    ac.flat_naive()
+                        .into_owned()
+                        .agg_quantile(ac.groups(), quantile, self.method)
+                };
+                agg.rename(keep_name);
+                Ok(AggregationContext::from_agg_state(
+                    AggregatedScalar(agg),
+                    Cow::Borrowed(groups),
+                ))
+            },
+            AggState::AggregatedScalar(c) => {
+                // Per-group quantile values.
+                let c = c.cast(&DataType::Float64)?;
+                let ca = c.f64()?;
+                let quantiles: Vec<f64> = ca.iter().map(|v| v.unwrap_or(f64::NAN)).collect();
+
+                if let AggState::LiteralScalar(c) = &mut ac.state {
+                    // Input is a literal scalar; quantile of a single value is always
+                    // that value, regardless of the quantile parameter.
+                    let q = quantiles.first().copied().unwrap_or(f64::NAN);
+                    *c = c.quantile_reduce(q, self.method)?.into_column(keep_name);
+                    return Ok(ac);
+                }
+
+                // SAFETY: groups are in bounds
+                let mut agg = unsafe {
+                    ac.flat_naive().into_owned().agg_varying_quantile(
+                        ac.groups(),
+                        &quantiles,
+                        self.method,
+                    )
+                };
+                agg.rename(keep_name);
+                Ok(AggregationContext::from_agg_state(
+                    AggregatedScalar(agg),
+                    Cow::Borrowed(groups),
+                ))
+            },
+            _ => {
+                polars_bail!(ComputeError:
+                    "quantile expression in group_by must produce a scalar per group"
+                );
+            },
         }
-
-        // SAFETY:
-        // groups are in bounds
-        let mut agg = unsafe {
-            ac.flat_naive()
-                .into_owned()
-                .agg_quantile(ac.groups(), quantile, self.method)
-        };
-        agg.rename(keep_name);
-        Ok(AggregationContext::from_agg_state(
-            AggregatedScalar(agg),
-            Cow::Borrowed(groups),
-        ))
     }
 
     fn to_field(&self, input_schema: &Schema) -> PolarsResult<Field> {

--- a/crates/polars-ops/src/chunked_array/nan_propagating_aggregate.rs
+++ b/crates/polars-ops/src/chunked_array/nan_propagating_aggregate.rs
@@ -120,7 +120,7 @@ unsafe fn group_nan_max<T: PolarsFloatType>(ca: &ChunkedArray<T>, groups: &Group
                 };
                 ChunkedArray::<T>::from(arr).into_series()
             } else {
-                _agg_helper_slice::<T, _>(groups_slice, |[first, len]| {
+                _agg_helper_slice::<T, _>(groups_slice, |_, [first, len]| {
                     debug_assert!(len <= ca.len() as IdxSize);
                     match len {
                         0 => None,
@@ -187,7 +187,7 @@ unsafe fn group_nan_min<T: PolarsFloatType>(ca: &ChunkedArray<T>, groups: &Group
                 };
                 ChunkedArray::<T>::from(arr).into_series()
             } else {
-                _agg_helper_slice::<T, _>(groups_slice, |[first, len]| {
+                _agg_helper_slice::<T, _>(groups_slice, |_, [first, len]| {
                     debug_assert!(len <= ca.len() as IdxSize);
                     match len {
                         0 => None,


### PR DESCRIPTION
# Overview

Fixes #25888 and Fixes #20951

When using pl.col.value.quantile(pl.col.quantile.first()) in a group_by, the quantile parameter was evaluated once globally rather than per group, causing all groups to use the same quantile value.

The fix follows the approach proposed by @orlp in the issue:

- AggQuantileExpr::evaluate_on_groups now calls evaluate_on_groups (instead of evaluate) on the quantile expression, yielding per-group values
- Added agg_varying_quantile through the Column → Series → ChunkedArray → generic dispatch chain, mirroring the existing agg_quantile path but accepting &[f64] (one quantile per group)
- Modified agg_helper_idx_on_all and _agg_helper_slice to pass the group index to closures via .enumerate(), so the new generic function can select the correct quantile per group

## AI Usage

I used Claude Opus 4.6 to review the code styling and ensure I followed practices throughout the repo. It recommended a change that I adopted:

`Missing bounds assertion on quantiles[group_idx]`: Adding a code block similar to below since the codebase uses debug_assert! defensively throughout certain sections

  ```rust
  debug_assert_eq!(quantiles.len(), groups.len(),
        "quantiles length ({}) must match groups length ({})",
        quantiles.len(), groups.len()); 
  ```

Otherwise I used the documentation and asked Opus 4.6 questions to better understand the codebase.

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  4. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->

