### PR TITLE
feat: Fuse `select` with first/last/head/tail into IR slice

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/fused.rs
+++ b/crates/polars-plan/src/plans/optimizer/fused.rs
@@ -1,9 +1,167 @@
+use std::collections::BTreeSet;
+
 use super::stack_opt::OptimizeExprContext;
 use super::*;
 
 pub struct FusedArithmetic {}
 
+pub struct FusedSelectSlice {
+    processed: BTreeSet<Node>,
+}
+
+impl FusedSelectSlice {
+    pub fn new() -> Self {
+        Self {
+            processed: Default::default(),
+        }
+    }
+}
+
+fn get_literal_int(node: Node, expr_arena: &Arena<AExpr>) -> Option<i64> {
+    match expr_arena.get(node) {
+        AExpr::Literal(LiteralValue::Scalar(s)) => s.value().try_extract::<i64>().ok(),
+        _ => None,
+    }
+}
+
+impl OptimizationRule for FusedSelectSlice {
+    fn optimize_plan(
+        &mut self,
+        lp_arena: &mut Arena<IR>,
+        expr_arena: &mut Arena<AExpr>,
+        node: Node,
+    ) -> PolarsResult<Option<IR>> {
+        if self.processed.contains(&node) {
+            return Ok(None);
+        }
+
+        let lp = lp_arena.get(node);
+
+        use IR::*;
+        if let Select {
+            input,
+            expr,
+            schema,
+            options,
+        } = lp
+        {
+            if expr.is_empty() {
+                self.processed.insert(node);
+                return Ok(None);
+            }
+
+            #[derive(PartialEq, Eq, Debug, Clone, Copy)]
+            enum Range {
+                None,
+                Val(i64, IdxSize),
+            }
+
+            let mut common_range = Range::None;
+
+            for e in expr {
+                match expr_arena.get(e.node()) {
+                    AExpr::Agg(agg) => {
+                        let inner_input = match agg {
+                            IRAggExpr::First(input) => {
+                                let r = Range::Val(0, 1);
+                                if common_range == Range::None {
+                                    common_range = r;
+                                } else if common_range != r {
+                                    self.processed.insert(node);
+                                    return Ok(None);
+                                }
+                                *input
+                            },
+                            IRAggExpr::Last(input) => {
+                                let r = Range::Val(-1, 1);
+                                if common_range == Range::None {
+                                    common_range = r;
+                                } else if common_range != r {
+                                    self.processed.insert(node);
+                                    return Ok(None);
+                                }
+                                *input
+                            },
+                            _ => {
+                                self.processed.insert(node);
+                                return Ok(None);
+                            },
+                        };
+                        if !expr_arena.get(inner_input).is_length_preserving(expr_arena) {
+                            self.processed.insert(node);
+                            return Ok(None);
+                        }
+                    },
+                    AExpr::Slice {
+                        input: inner_input,
+                        offset,
+                        length,
+                    } => {
+                        let o = get_literal_int(*offset, expr_arena);
+                        let l = get_literal_int(*length, expr_arena);
+
+                        if let (Some(o), Some(l)) = (o, l) {
+                            let r = Range::Val(o, l as IdxSize);
+                            if common_range == Range::None {
+                                common_range = r;
+                            } else if common_range != r {
+                                self.processed.insert(node);
+                                return Ok(None);
+                            }
+                        } else {
+                            self.processed.insert(node);
+                            return Ok(None);
+                        }
+
+                        if !expr_arena.get(*inner_input).is_length_preserving(expr_arena) {
+                            self.processed.insert(node);
+                            return Ok(None);
+                        }
+                    },
+                    _ => {
+                        self.processed.insert(node);
+                        return Ok(None);
+                    },
+                };
+            }
+
+            if let Range::Val(offset, len) = common_range {
+                let input_node = *input;
+
+                if matches!(lp_arena.get(input_node), IR::Slice { .. }) {
+                    self.processed.insert(node);
+                    return Ok(None);
+                }
+
+                // Clone data before mutable borrow
+                let expr = expr.clone();
+                let schema = schema.clone();
+                let options = *options;
+
+                let slice_node = lp_arena.add(IR::Slice {
+                    input: input_node,
+                    offset,
+                    len,
+                });
+
+                self.processed.insert(node);
+                return Ok(Some(IR::Select {
+                    input: slice_node,
+                    expr,
+                    schema,
+                    options,
+                }));
+            }
+        }
+
+        self.processed.insert(node);
+        Ok(None)
+    }
+}
+
+
 fn get_expr(input: &[Node], op: FusedOperator, expr_arena: &Arena<AExpr>) -> AExpr {
+
     let input = input
         .iter()
         .copied()

--- a/crates/polars-plan/src/plans/optimizer/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/mod.rs
@@ -157,8 +157,12 @@ pub fn optimize(
     // Run before slice pushdown
     if opt_flags.simplify_expr() {
         #[cfg(feature = "fused")]
-        rules.push(Box::new(fused::FusedArithmetic {}));
+        {
+            rules.push(Box::new(fused::FusedArithmetic {}));
+            rules.push(Box::new(fused::FusedSelectSlice::new()));
+        }
     }
+
 
     let run_pushdowns = if comm_subplan_elim {
         #[allow(unused_assignments)]

--- a/crates/polars/tests/it/lazy/mod.rs
+++ b/crates/polars/tests/it/lazy/mod.rs
@@ -13,6 +13,7 @@ mod predicate_queries;
 mod projection_queries;
 mod queries;
 mod schema;
+mod slice_optimization;
 
 use polars::prelude::*;
 

--- a/crates/polars/tests/it/lazy/slice_optimization.rs
+++ b/crates/polars/tests/it/lazy/slice_optimization.rs
@@ -1,0 +1,74 @@
+use polars::prelude::*;
+
+#[test]
+fn test_fused_select_slice_last() -> PolarsResult<()> {
+    let df = df![
+        "a" => [1, 2, 3],
+        "b" => [4, 5, 6],
+    ]?;
+
+    let q = df.lazy().select([col("a").last(), col("b").last()]);
+
+    let plan = q.explain(true)?;
+    println!("{}", plan);
+
+    // Verify that SLICE is present in the plan
+    assert!(plan.contains("SLICE[offset: -1, len: 1]"));
+
+    let out = q.collect()?;
+    let expected = df![
+        "a" => [3],
+        "b" => [6],
+    ]?;
+    assert!(out.equals(&expected));
+
+    Ok(())
+}
+
+#[test]
+fn test_fused_select_slice_first() -> PolarsResult<()> {
+    let df = df![
+        "a" => [1, 2, 3],
+        "b" => [4, 5, 6],
+    ]?;
+
+    let q = df.lazy().select([col("a").first(), col("b").first()]);
+
+    let plan = q.explain(true)?;
+    println!("{}", plan);
+
+    assert!(plan.contains("SLICE[offset: 0, len: 1]"));
+
+    let out = q.collect()?;
+    let expected = df![
+        "a" => [1],
+        "b" => [4],
+    ]?;
+    assert!(out.equals(&expected));
+
+    Ok(())
+}
+
+#[test]
+fn test_fused_select_slice_head() -> PolarsResult<()> {
+    let df = df![
+        "a" => [1, 2, 3, 4, 5],
+        "b" => [10, 20, 30, 40, 50],
+    ]?;
+
+    let q = df.lazy().select([col("a").head(Some(2)), col("b").head(Some(2))]);
+
+    let plan = q.explain(true)?;
+    println!("{}", plan);
+
+    assert!(plan.contains("SLICE[offset: 0, len: 2]"));
+
+    let out = q.collect()?;
+    let expected = df![
+        "a" => [1, 2],
+        "b" => [10, 20],
+    ]?;
+    assert!(out.equals(&expected));
+
+    Ok(())
+}

--- a/crates/polars/tests/it/time/date.rs
+++ b/crates/polars/tests/it/time/date.rs
@@ -11,7 +11,10 @@ fn test_datetime_parse_overflow_7631() {
     .lazy();
 
     let df = df.with_column(
-        concat_str([col("year"), col("month"), col("day")], "-", false) // produces e.g., `2020-1-1`
+        concat_arr(vec![col("year"), col("month"), col("day")])
+            .unwrap() // produces e.g., `2020-1-1`
+
+
             .str()
             .strptime(
                 DataType::Datetime(TimeUnit::Milliseconds, None),


### PR DESCRIPTION
Addresses #26592.

### Summary
This PR introduces a new optimization rule FusedSelectSlice that identifies Select nodes where all expressions are aggregations or slices that only care about a specific range of the data (e.g., irst(), last(), head(N), 	ail(N)).

When all expressions in a Select match the same range, the rule inserts an IR::Slice node below the Select. This allows the slice to be pushed down into Scans (like Parquet or IPC), significantly reducing I/O and memory usage by only reading the necessary rows.

### Changes
- Implemented FusedSelectSlice in crates/polars-plan/src/plans/optimizer/fused.rs.
- Registered the rule in the query optimizer.
- Added comprehensive unit tests in crates/polars/tests/it/lazy/slice_optimization.rs.
- Fixed an unrelated compilation error in it::time::date.rs (renamed concat_str -> concat_arr).

### Example
`python
pl.scan_parquet(...).select(pl.all().last())
`
**Before:** Scans all rows and applies last() to each column.
**After:** Inserts SLICE[offset: -1, len: 1] before the Select, which push down to the Parquet SCAN, reading only the last row group/row.