### PR TITLE
feat: Better error messages for hex literal conversion issues in the SQL interface

### DIFF
--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -857,7 +857,8 @@ impl SQLExprVisitor<'_> {
                 if x.len() % 2 != 0 {
                     polars_bail!(SQLSyntax: "hex string literal must have an even number of digits; found '{}'", x)
                 };
-                lit(hex::decode(x.clone()).unwrap())
+                lit(hex::decode(x.clone())
+                    .map_err(|_| polars_err!(SQLSyntax: "invalid hex string literal: '{}'", x))?)
             },
             SQLValue::Null => Expr::Literal(LiteralValue::untyped_null()),
             SQLValue::Number(s, _) => {
@@ -896,7 +897,11 @@ impl SQLExprVisitor<'_> {
                 if x.len() % 2 != 0 {
                     polars_bail!(SQLSyntax: "hex string literal must have an even number of digits; found '{}'", x)
                 };
-                AnyValue::BinaryOwned(hex::decode(x.clone()).unwrap())
+                AnyValue::BinaryOwned(
+                    hex::decode(x.clone()).map_err(
+                        |_| polars_err!(SQLSyntax: "invalid hex string literal: '{}'", x),
+                    )?,
+                )
             },
             SQLValue::Null => AnyValue::Null,
             SQLValue::Number(s, _) => {

--- a/py-polars/tests/unit/sql/test_literals.py
+++ b/py-polars/tests/unit/sql/test_literals.py
@@ -72,6 +72,18 @@ def test_bit_hex_errors() -> None:
             pl.sql_expr("colx IN (x'FF',x'123')")
 
         with pytest.raises(
+            SQLSyntaxError,
+            match="invalid hex string literal",
+        ):
+            ctx.execute("SELECT x'ZZZZ' FROM test", eager=True)
+
+        with pytest.raises(
+            SQLSyntaxError,
+            match="invalid hex string literal",
+        ):
+            pl.sql_expr("colx IN (x'FF',x'GHIJ')")
+
+        with pytest.raises(
             SQLInterfaceError,
             match=r'NationalStringLiteral\("hmmm"\) is not a supported literal',
         ):


### PR DESCRIPTION
Raise a proper error (instead of panicking) on invalid hex-literal conversions in the SQL layer.

## Example

```python
import polars as pl
pl.sql("SELECT x'ZZZZ'", eager=True)
```
#### Before
```python
# PanicException: 
#   called `Result::unwrap()` on an `Err` value: InvalidHexCharacter { c: 'Z', index: 0 }
```
#### After
```python
# SQLSyntaxError:
#   invalid hex string literal: 'ZZZZ'
```
