### PR TITLE
fix: Remove non-existent parameter from `SQLContext` typing overloads

### DIFF
--- a/py-polars/src/polars/sql/context.py
+++ b/py-polars/src/polars/sql/context.py
@@ -114,7 +114,6 @@ class SQLContext(Generic[FrameType]):
         frames: Mapping[str, CompatibleFrameType | None] | None = ...,
         *,
         register_globals: bool | int = ...,
-        all_compatible: bool = ...,
         eager: Literal[False] = False,
         **named_frames: CompatibleFrameType | None,
     ) -> None: ...
@@ -125,7 +124,6 @@ class SQLContext(Generic[FrameType]):
         frames: Mapping[str, CompatibleFrameType | None] | None = ...,
         *,
         register_globals: bool | int = ...,
-        all_compatible: bool = ...,
         eager: Literal[True],
         **named_frames: CompatibleFrameType | None,
     ) -> None: ...
@@ -136,7 +134,6 @@ class SQLContext(Generic[FrameType]):
         frames: Mapping[str, CompatibleFrameType | None] | None = ...,
         *,
         register_globals: bool | int = ...,
-        all_compatible: bool = ...,
         eager: bool,
         **named_frames: CompatibleFrameType | None,
     ) -> None: ...


### PR DESCRIPTION
Minor tidy-up; not sure how this got in there, but it's not present in `SQLContext.__init__`, and I don't think it ever has been (nor in any deprecated decorator handling) 🤷‍♂️