### PR TITLE
fix(python): Make `@deprecated` work regardless of decorator ordering

### DIFF
--- a/py-polars/src/polars/_utils/deprecation.py
+++ b/py-polars/src/polars/_utils/deprecation.py
@@ -16,17 +16,6 @@ if TYPE_CHECKING:
 
     from polars._utils.various import IdentityFunction
 
-if sys.version_info >= (3, 13):
-    from warnings import deprecated
-else:
-    try:
-        from typing_extensions import deprecated
-    except ImportError:
-
-        def deprecated(message: str) -> IdentityFunction:  # type: ignore[no-redef]
-            return _deprecate_function(message)
-
-
 from polars._utils.various import issue_warning
 
 if TYPE_CHECKING:
@@ -75,6 +64,16 @@ def _deprecate_function(message: str) -> IdentityFunction:
         return wrapper
 
     return decorate
+
+
+def deprecated(message: str) -> IdentityFunction:
+    """
+    Mark a function as deprecated.
+
+    Uses ``find_stacklevel()`` internally so that the warning is correctly
+    attributed to the caller regardless of decorator ordering.
+    """
+    return _deprecate_function(message)
 
 
 def deprecate_streaming_parameter() -> IdentityFunction:

--- a/py-polars/tests/unit/utils/test_deprecation.py
+++ b/py-polars/tests/unit/utils/test_deprecation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import TYPE_CHECKING, Any, get_args
+from typing import Any, get_args
 
 import pytest
 
@@ -14,14 +14,6 @@ from polars._utils.deprecation import (
     identify_deprecations,
     issue_deprecation_warning,
 )
-
-if TYPE_CHECKING:
-    import sys
-
-    if sys.version_info >= (3, 13):
-        from warnings import deprecated
-    else:
-        from typing_extensions import deprecated  # noqa: TC004
 
 
 def test_issue_deprecation_warning() -> None:
@@ -97,6 +89,37 @@ def test_deprecate_parameter_as_multi_positional_existing_arg(recwarn: Any) -> N
     with pytest.deprecated_call():
         result = hello(5, foo=["x", "y"])  # type: ignore[call-arg, arg-type]
     assert result == hello(5, "x", "y")
+
+
+def test_deprecated_decorator_ordering_26536() -> None:
+    """Test that @deprecated works regardless of decorator ordering."""
+    # @deprecated on top (outermost) — always worked
+    @deprecated("`func_a` is deprecated.")
+    @deprecate_renamed_parameter("old", "new", version="1.0.0")
+    def func_a(new: str) -> str:
+        return new
+
+    with pytest.deprecated_call(match="`func_a` is deprecated."):
+        assert func_a(old="x") == "x"  # type: ignore[call-arg]
+
+    # @deprecated on bottom (innermost) — previously broken
+    @deprecate_renamed_parameter("old", "new", version="1.0.0")
+    @deprecated("`func_b` is deprecated.")
+    def func_b(new: str) -> str:
+        return new
+
+    with pytest.deprecated_call(match="`func_b` is deprecated."):
+        assert func_b(old="x") == "x"  # type: ignore[call-arg]
+
+    # @deprecated sandwiched between multiple decorators
+    @deprecate_renamed_parameter("foo", "bar", version="1.0.0")
+    @deprecate_renamed_parameter("baz", "qux", version="1.0.0")
+    @deprecated("`func_c` is deprecated.")
+    def func_c(bar: str, qux: str) -> str:
+        return bar + qux
+
+    with pytest.deprecated_call(match="`func_c` is deprecated."):
+        assert func_c(foo="a", baz="b") == "ab"  # type: ignore[call-arg]
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary
- Replace conditional import of `deprecated` from `warnings`/`typing_extensions` with Polars' own `_deprecate_function` implementation
- `typing_extensions.deprecated` / `warnings.deprecated` use a fixed `stacklevel=2`, which only works when `@deprecated` is the outermost decorator
- When stacked below `@deprecate_renamed_parameter` or similar decorators, the extra wrapper frames cause the warning to be attributed to internal library code, and Python's default filter suppresses `DeprecationWarning` from library code
- Polars' `_deprecate_function` uses `find_stacklevel()` to dynamically walk the call stack to the first non-Polars frame, making it immune to decorator ordering
- `__deprecated__` attribute is still set on wrapped functions for introspection

Closes #26536

## Test plan
- [x] New test `test_deprecated_decorator_ordering_26536` verifies all orderings:
  - `@deprecated` on top (outermost) — always worked
  - `@deprecated` on bottom (innermost) — previously broken
  - `@deprecated` sandwiched between multiple `@deprecate_renamed_parameter` decorators
- [x] Existing `test_deprecate_function` continues to pass
- [x] `test_read_batch_csv_deprecations_26479` from PR #26530 continues to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)