### PR TITLE
fix: Incorrect boolean min/max with nulls

### DIFF
--- a/crates/polars-compute/src/min_max/scalar.rs
+++ b/crates/polars-compute/src/min_max/scalar.rs
@@ -110,21 +110,11 @@ impl MinMaxKernel for BooleanArray {
     type Scalar<'a> = bool;
 
     fn min_ignore_nan_kernel(&self) -> Option<Self::Scalar<'_>> {
-        if self.len() - self.null_count() == 0 {
-            return None;
-        }
-
-        let unset_bits = self.values().unset_bits();
-        Some(unset_bits == 0)
+        crate::boolean::all(self)
     }
 
     fn max_ignore_nan_kernel(&self) -> Option<Self::Scalar<'_>> {
-        if self.len() - self.null_count() == 0 {
-            return None;
-        }
-
-        let set_bits = self.values().set_bits();
-        Some(set_bits > 0)
+        crate::boolean::any(self)
     }
 
     #[inline(always)]


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/26667.

Should've been part of https://github.com/pola-rs/polars/pull/26636.