### PR TITLE
fix(python): Respect `nulls_last` in `sort_by` within `group_by().agg()` slow path

### DIFF
--- a/crates/polars-expr/src/expressions/sortby.rs
+++ b/crates/polars-expr/src/expressions/sortby.rs
@@ -104,7 +104,7 @@ fn sort_by_groups_single_by(
 fn sort_by_groups_no_match_single<'a>(
     mut ac_in: AggregationContext<'a>,
     mut ac_by: AggregationContext<'a>,
-    descending: bool,
+    options: SortOptions,
     expr: &Expr,
 ) -> PolarsResult<AggregationContext<'a>> {
     let s_in = ac_in.aggregated();
@@ -120,10 +120,9 @@ fn sort_by_groups_no_match_single<'a>(
                 (Some(s), Some(s_sort_by)) => {
                     polars_ensure!(s.len() == s_sort_by.len(), ComputeError: "series lengths don't match in 'sort_by' expression");
                     let idx = s_sort_by.arg_sort(SortOptions {
-                        descending,
                         // We are already in par iter.
                         multithreaded: false,
-                        ..Default::default()
+                        ..options
                     });
                     Ok(Some(unsafe { s.take_unchecked(&idx) }))
                 },
@@ -366,7 +365,7 @@ impl PhysicalExpr for SortByExpr {
                 return sort_by_groups_no_match_single(
                     ac_in,
                     ac_sort_by,
-                    self.sort_options.descending[0],
+                    SortOptions::from(&self.sort_options),
                     &self.expr,
                 );
             };


### PR DESCRIPTION

Fixes : #26680 

`sort_by(nulls_last=True)` was silently ignored inside `group_by().agg()` when the expression passed through `map_batches`, so nulls always sorted first with no error. This happened because `map_batches` (without `is_elementwise=True`) set `UpdateGroups::WithSeriesLen`, forcing the slow path `sort_by_groups_no_match_single`, which only accepted `descending: bool` and never propagated `nulls_last` (it defaulted to `false`).

The fix updates `sort_by_groups_no_match_single` to take a full `SortOptions` and passes `SortOptions::from(&self.sort_options)` at the call site, only overriding `multithreaded: false` since it already runs in parallel. This aligns slow-path behavior with the fast path so all sort options, including `nulls_last`, are respected.
