### PR TITLE
feat: Add configurable memory limit for streaming engine

### DIFF
--- a/crates/polars-config/src/lib.rs
+++ b/crates/polars-config/src/lib.rs
@@ -25,6 +25,9 @@ const DEFAULT_IDEAL_MORSEL_SIZE: u64 = 100_000;
 const ENGINE_AFFINITY: &str = "POLARS_ENGINE_AFFINITY";
 const DEFAULT_ENGINE_AFFINITY: Engine = Engine::Auto;
 
+const STREAMING_MEMORY_LIMIT: &str = "POLARS_STREAMING_MEMORY_LIMIT";
+const DEFAULT_STREAMING_MEMORY_LIMIT: u64 = 0;
+
 // Private.
 const VERBOSE_SENSITIVE: &str = "POLARS_VERBOSE_SENSITIVE";
 const DEFAULT_VERBOSE_SENSITIVE: bool = false;
@@ -43,6 +46,7 @@ static KNOWN_OPTIONS: &[&str] = &[
     IDEAL_MORSEL_SIZE,
     STREAMING_CHUNK_SIZE,
     ENGINE_AFFINITY,
+    STREAMING_MEMORY_LIMIT,
     /*
     Not yet supported public options:
 
@@ -78,6 +82,7 @@ pub struct Config {
     warn_unstable: AtomicBool,
     ideal_morsel_size: AtomicU64,
     engine_affinity: AtomicU8,
+    streaming_memory_limit: AtomicU64,
 
     // Private.
     verbose_sensitive: AtomicBool,
@@ -94,6 +99,7 @@ impl Config {
             warn_unstable: AtomicBool::new(DEFAULT_WARN_UNSTABLE),
             ideal_morsel_size: AtomicU64::new(DEFAULT_IDEAL_MORSEL_SIZE),
             engine_affinity: AtomicU8::new(DEFAULT_ENGINE_AFFINITY as u8),
+            streaming_memory_limit: AtomicU64::new(DEFAULT_STREAMING_MEMORY_LIMIT),
 
             // Private.
             verbose_sensitive: AtomicBool::new(DEFAULT_VERBOSE_SENSITIVE),
@@ -147,6 +153,11 @@ impl Config {
                     .unwrap_or(DEFAULT_ENGINE_AFFINITY) as u8,
                 Ordering::Relaxed,
             ),
+            STREAMING_MEMORY_LIMIT => self.streaming_memory_limit.store(
+                val.and_then(|x| parse::parse_u64(var, x))
+                    .unwrap_or(DEFAULT_STREAMING_MEMORY_LIMIT),
+                Ordering::Relaxed,
+            ),
 
             // Private flags.
             VERBOSE_SENSITIVE => self.verbose_sensitive.store(
@@ -195,6 +206,11 @@ impl Config {
     /// Which engine to use by default.
     pub fn engine_affinity(&self) -> Engine {
         Engine::from_discriminant(self.engine_affinity.load(Ordering::Relaxed))
+    }
+
+    /// The memory limit for the streaming engine, in bytes. 0 means unlimited.
+    pub fn streaming_memory_limit(&self) -> u64 {
+        self.streaming_memory_limit.load(Ordering::Relaxed)
     }
 
     /// Whether we should do verbose printing on sensitive information.

--- a/crates/polars-stream/src/execute.rs
+++ b/crates/polars-stream/src/execute.rs
@@ -14,6 +14,7 @@ use tokio::task::JoinHandle;
 
 use crate::async_executor;
 use crate::graph::{Graph, GraphNode, GraphNodeKey, LogicalPipeKey, PortState};
+use crate::memory::MemoryTracker;
 use crate::metrics::{GraphMetrics, MetricsBuilder};
 use crate::pipe::PhysicalPipe;
 
@@ -24,6 +25,9 @@ pub struct StreamingExecutionState {
 
     /// The ExecutionState passed to any non-streaming operations.
     pub in_memory_exec_state: ExecutionState,
+
+    /// Memory tracker for applying backpressure when a limit is configured.
+    pub memory_tracker: Arc<MemoryTracker>,
 
     query_tasks_send: Sender<JoinHandle<PolarsResult<()>>>,
     subphase_tasks_send: Sender<JoinHandle<PolarsResult<()>>>,
@@ -312,9 +316,19 @@ pub fn execute_graph(
     let (query_tasks_send, query_tasks_recv) = crossbeam_channel::unbounded();
     let (subphase_tasks_send, subphase_tasks_recv) = crossbeam_channel::unbounded();
 
+    let memory_limit = polars_config::config().streaming_memory_limit();
+    let memory_tracker = Arc::new(MemoryTracker::new(memory_limit));
+    if memory_tracker.has_limit() && polars_core::config::verbose() {
+        eprintln!(
+            "polars-stream: streaming memory limit set to {} bytes",
+            memory_limit
+        );
+    }
+
     let state = StreamingExecutionState {
         num_pipelines,
         in_memory_exec_state: ExecutionState::default(),
+        memory_tracker,
         query_tasks_send,
         subphase_tasks_send,
     };

--- a/crates/polars-stream/src/lib.rs
+++ b/crates/polars-stream/src/lib.rs
@@ -10,6 +10,7 @@ pub use skeleton::{run_query, visualize_physical_plan};
 mod execute;
 pub use dispatch::build_streaming_query_executor;
 pub(crate) mod expression;
+pub(crate) mod memory;
 mod graph;
 pub use graph::{GraphNodeKey, LogicalPipe, LogicalPipeKey};
 pub use skeleton::{QueryResult, StreamingQuery};

--- a/crates/polars-stream/src/memory.rs
+++ b/crates/polars-stream/src/memory.rs
@@ -1,0 +1,195 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::task::{Context, Poll, Waker};
+
+use parking_lot::Mutex;
+
+/// Tracks memory usage in the streaming engine and provides backpressure
+/// when a configured limit is exceeded.
+///
+/// When no limit is set (`limit == 0`), all operations are effectively no-ops
+/// with minimal overhead (a single branch on `has_limit()`).
+pub struct MemoryTracker {
+    used: AtomicU64,
+    limit: u64,
+    waiters: Mutex<Vec<Waker>>,
+}
+
+impl MemoryTracker {
+    pub fn new(limit: u64) -> Self {
+        Self {
+            used: AtomicU64::new(0),
+            limit,
+            waiters: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Returns true if a memory limit has been configured.
+    #[inline]
+    pub fn has_limit(&self) -> bool {
+        self.limit > 0
+    }
+
+    /// Record `bytes` as allocated. Short-circuits if no limit is set.
+    #[inline]
+    pub fn alloc(&self, bytes: u64) {
+        if !self.has_limit() {
+            return;
+        }
+        self.used.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    /// Record `bytes` as freed. Wakes any tasks waiting for memory
+    /// if usage drops below the limit. Short-circuits if no limit is set.
+    #[inline]
+    pub fn free(&self, bytes: u64) {
+        if !self.has_limit() {
+            return;
+        }
+        let prev = self.used.fetch_sub(bytes, Ordering::Relaxed);
+        // If we crossed from over-limit to under-limit, wake all waiters.
+        if prev > self.limit && prev - bytes <= self.limit {
+            let waiters: Vec<Waker> = {
+                let mut guard = self.waiters.lock();
+                std::mem::take(&mut *guard)
+            };
+            for waker in waiters {
+                waker.wake();
+            }
+        }
+    }
+
+    /// Async wait until memory usage is at or below the limit.
+    /// Resolves immediately if no limit is set or if usage is under the limit.
+    pub fn wait_for_available(&self) -> WaitForAvailable<'_> {
+        WaitForAvailable { tracker: self }
+    }
+
+    /// Returns the current tracked memory usage in bytes.
+    #[allow(unused)]
+    pub fn current_usage(&self) -> u64 {
+        self.used.load(Ordering::Relaxed)
+    }
+}
+
+pub struct WaitForAvailable<'a> {
+    tracker: &'a MemoryTracker,
+}
+
+impl Future for WaitForAvailable<'_> {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if !self.tracker.has_limit() {
+            return Poll::Ready(());
+        }
+        if self.tracker.used.load(Ordering::Relaxed) <= self.tracker.limit {
+            return Poll::Ready(());
+        }
+        // Over limit: register waker and park.
+        self.tracker.waiters.lock().push(cx.waker().clone());
+        // Re-check after registering to avoid lost wakeups.
+        if self.tracker.used.load(Ordering::Relaxed) <= self.tracker.limit {
+            Poll::Ready(())
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    #[test]
+    fn test_no_limit() {
+        let tracker = MemoryTracker::new(0);
+        assert!(!tracker.has_limit());
+        // alloc/free should be no-ops, no panics.
+        tracker.alloc(1_000_000);
+        assert_eq!(tracker.current_usage(), 0);
+        tracker.free(500_000);
+        assert_eq!(tracker.current_usage(), 0);
+    }
+
+    #[test]
+    fn test_alloc_and_free() {
+        let tracker = MemoryTracker::new(1000);
+        assert!(tracker.has_limit());
+
+        tracker.alloc(400);
+        assert_eq!(tracker.current_usage(), 400);
+
+        tracker.alloc(300);
+        assert_eq!(tracker.current_usage(), 700);
+
+        tracker.free(200);
+        assert_eq!(tracker.current_usage(), 500);
+
+        tracker.free(500);
+        assert_eq!(tracker.current_usage(), 0);
+    }
+
+    #[test]
+    fn test_wait_resolves_immediately_no_limit() {
+        let tracker = MemoryTracker::new(0);
+        tracker.alloc(999_999); // no-op since no limit
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            // Should resolve immediately.
+            tracker.wait_for_available().await;
+        });
+    }
+
+    #[test]
+    fn test_wait_resolves_immediately_under_limit() {
+        let tracker = MemoryTracker::new(1000);
+        tracker.alloc(500);
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            tracker.wait_for_available().await;
+        });
+    }
+
+    #[test]
+    fn test_wait_parks_then_wakes_on_free() {
+        let tracker = Arc::new(MemoryTracker::new(1000));
+        tracker.alloc(1500); // over limit
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let tracker2 = tracker.clone();
+        rt.block_on(async {
+            let handle = tokio::spawn({
+                let t = tracker2.clone();
+                async move {
+                    // This should park until memory is freed.
+                    t.wait_for_available().await;
+                }
+            });
+
+            // Give the spawned task time to park.
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+            // Free enough memory to go under limit.
+            tracker2.free(600); // 1500 - 600 = 900 <= 1000
+
+            // The handle should now resolve.
+            tokio::time::timeout(std::time::Duration::from_secs(2), handle)
+                .await
+                .expect("timed out waiting for task to wake")
+                .expect("task panicked");
+        });
+    }
+}

--- a/crates/polars-stream/src/nodes/in_memory_sink.rs
+++ b/crates/polars-stream/src/nodes/in_memory_sink.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use parking_lot::Mutex;
@@ -5,11 +6,14 @@ use polars_core::schema::Schema;
 use polars_core::utils::accumulate_dataframes_vertical_unchecked;
 
 use super::compute_node_prelude::*;
+use crate::memory::MemoryTracker;
 use crate::utils::in_memory_linearize::linearize;
 
 pub struct InMemorySinkNode {
     morsels_per_pipe: Mutex<Vec<Vec<(MorselSeq, DataFrame)>>>,
     schema: Arc<Schema>,
+    tracked_bytes: AtomicU64,
+    memory_tracker: Option<Arc<MemoryTracker>>,
 }
 
 impl InMemorySinkNode {
@@ -17,6 +21,19 @@ impl InMemorySinkNode {
         Self {
             morsels_per_pipe: Mutex::default(),
             schema,
+            tracked_bytes: AtomicU64::new(0),
+            memory_tracker: None,
+        }
+    }
+
+    /// Release all tracked memory back to the memory tracker.
+    fn free_tracked_memory(&mut self) {
+        if let Some(tracker) = &self.memory_tracker {
+            let bytes = self.tracked_bytes.load(Ordering::Relaxed);
+            if bytes > 0 {
+                tracker.free(bytes);
+                self.tracked_bytes.store(0, Ordering::Relaxed);
+            }
         }
     }
 }
@@ -52,11 +69,16 @@ impl ComputeNode for InMemorySinkNode {
         scope: &'s TaskScope<'s, 'env>,
         recv_ports: &mut [Option<RecvPort<'_>>],
         send_ports: &mut [Option<SendPort<'_>>],
-        _state: &'s StreamingExecutionState,
+        state: &'s StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
         assert!(recv_ports.len() == 1 && send_ports.is_empty());
         let receivers = recv_ports[0].take().unwrap().parallel();
+
+        // Store the memory tracker reference if a limit is configured.
+        if state.memory_tracker.has_limit() && self.memory_tracker.is_none() {
+            self.memory_tracker = Some(state.memory_tracker.clone());
+        }
 
         for mut recv in receivers {
             let slf = &*self;
@@ -64,7 +86,18 @@ impl ComputeNode for InMemorySinkNode {
                 let mut morsels = Vec::new();
                 while let Ok(mut morsel) = recv.recv().await {
                     morsel.take_consume_token();
-                    morsels.push((morsel.seq(), morsel.into_df()));
+                    let seq = morsel.seq();
+                    let df = morsel.into_df();
+
+                    // Track memory usage and apply backpressure if needed.
+                    if let Some(tracker) = &slf.memory_tracker {
+                        let size = df.estimated_size() as u64;
+                        tracker.alloc(size);
+                        slf.tracked_bytes.fetch_add(size, Ordering::Relaxed);
+                        tracker.wait_for_available().await;
+                    }
+
+                    morsels.push((seq, df));
                 }
 
                 slf.morsels_per_pipe.lock().push(morsels);
@@ -74,6 +107,7 @@ impl ComputeNode for InMemorySinkNode {
     }
 
     fn get_output(&mut self) -> PolarsResult<Option<DataFrame>> {
+        self.free_tracked_memory();
         let morsels_per_pipe = core::mem::take(&mut *self.morsels_per_pipe.get_mut());
         let dataframes = linearize(morsels_per_pipe);
         if dataframes.is_empty() {

--- a/py-polars/src/polars/config.py
+++ b/py-polars/src/polars/config.py
@@ -74,6 +74,7 @@ _POLARS_CFG_ENV_VARS: Final[set[str]] = {
     "POLARS_FMT_TABLE_INLINE_COLUMN_DATA_TYPE",
     "POLARS_FMT_TABLE_ROUNDED_CORNERS",
     "POLARS_STREAMING_CHUNK_SIZE",
+    "POLARS_STREAMING_MEMORY_LIMIT",
     "POLARS_TABLE_WIDTH",
     "POLARS_VERBOSE",
     "POLARS_MAX_EXPR_DEPTH",
@@ -107,6 +108,7 @@ class ConfigParameters(TypedDict, total=False):
     fmt_str_lengths: int | None
     fmt_table_cell_list_len: int | None
     streaming_chunk_size: int | None
+    streaming_memory_limit: int | None
     tbl_cell_alignment: Literal["LEFT", "CENTER", "RIGHT"] | None
     tbl_cell_numeric_alignment: Literal["LEFT", "CENTER", "RIGHT"] | None
     tbl_cols: int | None
@@ -132,6 +134,7 @@ class ConfigParameters(TypedDict, total=False):
     set_fmt_str_lengths: int | None
     set_fmt_table_cell_list_len: int | None
     set_streaming_chunk_size: int | None
+    set_streaming_memory_limit: int | None
     set_tbl_cell_alignment: Literal["LEFT", "CENTER", "RIGHT"] | None
     set_tbl_cell_numeric_alignment: Literal["LEFT", "CENTER", "RIGHT"] | None
     set_tbl_cols: int | None
@@ -905,6 +908,35 @@ class Config(contextlib.ContextDecorator):
 
             os.environ["POLARS_STREAMING_CHUNK_SIZE"] = str(size)
         plr.config_reload_env_var("POLARS_STREAMING_CHUNK_SIZE")
+        return cls
+
+    @classmethod
+    def set_streaming_memory_limit(cls, size: int | None) -> type[Config]:
+        """
+        Set the memory limit for the streaming engine.
+
+        When the streaming engine accumulates more data than the given limit
+        (in bytes), it applies backpressure to slow down data ingestion.
+        This is a soft limit.
+
+        Parameters
+        ----------
+        size
+            Memory limit in bytes. Set to ``None`` or ``0`` to remove the limit.
+
+        Raises
+        ------
+        ValueError
+            If `size` is negative.
+        """
+        if size is None or size == 0:
+            os.environ.pop("POLARS_STREAMING_MEMORY_LIMIT", None)
+        else:
+            if size < 0:
+                msg = "streaming memory limit must be >= 0"
+                raise ValueError(msg)
+            os.environ["POLARS_STREAMING_MEMORY_LIMIT"] = str(size)
+        plr.config_reload_env_var("POLARS_STREAMING_MEMORY_LIMIT")
         return cls
 
     @classmethod


### PR DESCRIPTION
Add POLARS_STREAMING_MEMORY_LIMIT config option that applies backpressure in the streaming engine when accumulated memory exceeds the configured limit. Implements a MemoryTracker that parks async tasks in sink nodes when over the limit and wakes them when memory is freed.

- Add POLARS_STREAMING_MEMORY_LIMIT to polars-config (default 0 = unlimited)
- Add MemoryTracker with alloc/free/wait_for_available async backpressure
- Instrument InMemorySinkNode to track morsel sizes and apply backpressure
- Add pl.Config.set_streaming_memory_limit() Python API
- Zero overhead when no limit is set (single branch check)

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
