### PR TITLE
docs: Mention ComputeContexts create ephemeral environments by default and hint at re-use

### DIFF
--- a/docs/source/polars-cloud/context/compute-context.md
+++ b/docs/source/polars-cloud/context/compute-context.md
@@ -56,24 +56,32 @@ cloud portal interface.
 
 Once defined, you can apply your compute context to queries in three ways:
 
+<!-- dprint-ignore -->
 1. By directly passing the context to the remote query:
 
-   ```python
-   query.remote(context=ctx).sink_parquet(...)
-   ```
+    ```python
+    query.remote(context=ctx).sink_parquet(...)
+    ```
 
 2. By globally setting the compute context. This way you set it once and don't need to provide it to
    every `remote` call:
 
-   ```python
-   pc.set_compute_context(ctx)
+    ```python
+    pc.set_compute_context(ctx)
 
-   query.remote().sink_parquet(...)
-   ```
+    query.remote().sink_parquet(...)
+    ```
 
 3. When a default compute context is set via the Polars Cloud dashboard. It is no longer required to
    define a compute context.
 
-   ```python
-   query.remote().sink_parquet(...)
-   ```
+    ```python
+    query.remote().sink_parquet(...)
+    ```
+
+<!-- dprint-ignore -->
+!!! note "Ephemeral compute"
+    Each `ComputeContext` creates a new, ephemeral compute cluster. If you re-run your script,
+    a new cluster will be started instead of reusing an existing one. To reuse a running cluster,
+    either [reference it by name](reconnect.md#reconnect-with-a-manifest-recommended) using a
+    manifest, or [reconnect to an existing cluster](reconnect.md).


### PR DESCRIPTION
<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
Mention that compute contexts create ephemeral environments instead of reconnecting to existing ones by default, and hint at cluster re-use.
Fix dprint breaking the bullet list numbering along the way.

Fix polars-inc/polars-cloud#1471