### PR TITLE
feat: More generic streaming GroupBy lowering

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/cse/csee.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/csee.rs
@@ -162,8 +162,13 @@ pub struct NaiveExprMerger {
 
 impl NaiveExprMerger {
     pub fn add_expr(&mut self, node: Node, arena: &Arena<AExpr>) {
-        let node = AexprNode::new(node);
-        node.visit(self, arena).unwrap();
+        AexprNode::new(node).visit(self, arena).unwrap();
+    }
+
+    pub fn add_and_get_uniq_id(&mut self, node: Node, arena: &Arena<AExpr>) -> u32 {
+        let aexpr_node = AexprNode::new(node);
+        aexpr_node.visit(self, arena).unwrap();
+        *self.node_to_uniq_id.get(&node).unwrap()
     }
 
     pub fn get_uniq_id(&self, node: Node) -> Option<u32> {


### PR DESCRIPTION
Allows more expressions inside a group-by to lower into the streaming engine (e.g. elementwise combinations of inputs to `filter`), or a `filter` into a `unique`, and also adds more common-subexpression elimination for this. For example:

```python
df = pl.DataFrame({"a": [1, 1, 2, 2, 3], "b": [1, 2, 1, 2, 1]})
(
    df.lazy()
    .group_by(["a", pl.col.a.alias("z")])
    .agg(
        q = pl.col.a.filter(pl.col.a >= 0).unique().sum(),
        r = pl.col.a.filter(pl.col.a >= 0).unique().len(),
        s = pl.col.a.abs().filter(pl.col.a > 100).sum() * pl.col.a.abs().filter(pl.col.a > 100).sum(),
        t = pl.col.a.abs().filter(pl.col.a > 100).len(),
        u = (pl.col.a > 100).sum() + pl.col.b.abs().mean()
    )
    .show_graph(plan_stage="physical", engine="streaming")
)
```

Output:

<img width="526" height="983" alt="image" src="https://github.com/user-attachments/assets/2fa36274-e108-4f7c-95b1-a23a420d0e38" />
