### PR TITLE
fix: Return `NaN` when using `corr()` with a literal and expr

### DIFF
--- a/crates/polars-compute/src/moment.rs
+++ b/crates/polars-compute/src/moment.rs
@@ -144,9 +144,7 @@ impl VarState {
 
 impl CovState {
     fn new(x: &[f64], y: &[f64]) -> Self {
-        if x.len() != y.len() {
-            return Self::default();
-        }
+        assert!(x.len() == y.len());
         if x.is_empty() {
             return Self::default();
         }
@@ -198,9 +196,7 @@ impl CovState {
 
 impl PearsonState {
     fn new(x: &[f64], y: &[f64]) -> Self {
-        if x.len() != y.len() {
-            return Self::default();
-        }
+        assert!(x.len() == y.len());
         if x.is_empty() {
             return Self::default();
         }
@@ -669,13 +665,7 @@ where
     T: NativeType + AsPrimitive<f64>,
     U: NativeType + AsPrimitive<f64>,
 {
-    if x.len() != y.len() {
-        return CovState {
-            weight: f64::INFINITY,
-            dp_xy: f64::NAN,
-            ..CovState::default()
-        };
-    }
+    assert!(x.len() == y.len());
     let mut out = CovState::default();
     if x.has_nulls() || y.has_nulls() {
         chunk_as_float_binary(
@@ -698,9 +688,7 @@ where
     T: NativeType + AsPrimitive<f64>,
     U: NativeType + AsPrimitive<f64>,
 {
-    if x.len() != y.len() {
-        return PearsonState::default();
-    }
+    assert!(x.len() == y.len());
     let mut out = PearsonState::default();
     if x.has_nulls() || y.has_nulls() {
         chunk_as_float_binary(

--- a/crates/polars-compute/src/moment.rs
+++ b/crates/polars-compute/src/moment.rs
@@ -144,7 +144,9 @@ impl VarState {
 
 impl CovState {
     fn new(x: &[f64], y: &[f64]) -> Self {
-        assert!(x.len() == y.len());
+        if x.len() != y.len() {
+            return Self::default();
+        }
         if x.is_empty() {
             return Self::default();
         }
@@ -196,7 +198,9 @@ impl CovState {
 
 impl PearsonState {
     fn new(x: &[f64], y: &[f64]) -> Self {
-        assert!(x.len() == y.len());
+        if x.len() != y.len() {
+            return Self::default();
+        }
         if x.is_empty() {
             return Self::default();
         }
@@ -665,7 +669,13 @@ where
     T: NativeType + AsPrimitive<f64>,
     U: NativeType + AsPrimitive<f64>,
 {
-    assert!(x.len() == y.len());
+    if x.len() != y.len() {
+        return CovState {
+            weight: f64::INFINITY,
+            dp_xy: f64::NAN,
+            ..CovState::default()
+        };
+    }
     let mut out = CovState::default();
     if x.has_nulls() || y.has_nulls() {
         chunk_as_float_binary(
@@ -688,7 +698,9 @@ where
     T: NativeType + AsPrimitive<f64>,
     U: NativeType + AsPrimitive<f64>,
 {
-    assert!(x.len() == y.len());
+    if x.len() != y.len() {
+        return PearsonState::default();
+    }
     let mut out = PearsonState::default();
     if x.has_nulls() || y.has_nulls() {
         chunk_as_float_binary(

--- a/crates/polars-ops/src/chunked_array/cov.rs
+++ b/crates/polars-ops/src/chunked_array/cov.rs
@@ -1,3 +1,5 @@
+use core::f64;
+
 use num_traits::AsPrimitive;
 use polars_compute::moment::{CovState, PearsonState};
 use polars_core::prelude::*;
@@ -10,6 +12,9 @@ where
     T::Native: AsPrimitive<f64>,
     ChunkedArray<T>: ChunkVar,
 {
+    if a.len() != b.len() {
+        return Some(f64::NAN);
+    }
     let (a, b) = align_chunks_binary(a, b);
     let mut out = CovState::default();
     for (a, b) in a.downcast_iter().zip(b.downcast_iter()) {
@@ -25,6 +30,9 @@ where
     T::Native: AsPrimitive<f64>,
     ChunkedArray<T>: ChunkVar,
 {
+    if a.len() != b.len() {
+        return Some(f64::NAN);
+    }
     let (a, b) = align_chunks_binary(a, b);
     let mut out = PearsonState::default();
     for (a, b) in a.downcast_iter().zip(b.downcast_iter()) {

--- a/crates/polars-ops/src/chunked_array/cov.rs
+++ b/crates/polars-ops/src/chunked_array/cov.rs
@@ -12,7 +12,7 @@ where
     T::Native: AsPrimitive<f64>,
     ChunkedArray<T>: ChunkVar,
 {
-    if a.len() != b.len() {
+    if a.len() == 1 || b.len() == 1 {
         return Some(f64::NAN);
     }
     let (a, b) = align_chunks_binary(a, b);
@@ -30,7 +30,7 @@ where
     T::Native: AsPrimitive<f64>,
     ChunkedArray<T>: ChunkVar,
 {
-    if a.len() != b.len() {
+    if a.len() == 1 || b.len() == 1 {
         return Some(f64::NAN);
     }
     let (a, b) = align_chunks_binary(a, b);

--- a/py-polars/tests/unit/operations/test_statistics.py
+++ b/py-polars/tests/unit/operations/test_statistics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from datetime import timedelta
 from typing import cast
 
@@ -149,3 +150,11 @@ def test_kurtosis_same_vals() -> None:
 def test_correction_shape_mismatch_22080() -> None:
     with pytest.raises(pl.exceptions.ShapeError):
         pl.select(pl.corr(pl.Series([1, 2]), pl.Series([2, 3, 5])))
+
+
+def test_corr_cov_lit_produces_nan_26633() -> None:
+    df = pl.DataFrame({"a": [1, 3, 2]})
+    result_corr = df.select(pl.corr(pl.lit(1), "a"))
+    assert math.isnan(result_corr.item())
+    result_cov = df.select(pl.cov(pl.lit(1), "a"))
+    assert math.isnan(result_cov.item())


### PR DESCRIPTION
Resolves: https://github.com/pola-rs/polars/issues/26633. 

Returns `NaN` rather than panicking or producing an error. In https://github.com/pola-rs/polars/pull/22305, the fix intentionally allowed length-1 (literals/scalars) through. This fixes the remaining case in the compute kernel by returning `NaN`. This is mathematically sound since correlation/covariance with a constant is undefined.

Could just as easily error, if the maintainers prefer. 