### PR TITLE
perf: Drop columns only needed for predicates after the predicate is applied

### DIFF
--- a/py-polars/tests/unit/lazyframe/test_predicates.py
+++ b/py-polars/tests/unit/lazyframe/test_predicates.py
@@ -1273,3 +1273,14 @@ def test_replace_strict_predicate_merging() -> None:
         df.filter(pl.col("x")).filter(pl.col("x").replace_strict(True, True)).collect()
     )
     assert out.height == 3
+
+
+def test_pred_pd_before_proj_pd_26611() -> None:
+    a = pl.LazyFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+    b = pl.LazyFrame({"x": [1, 2, 3]})
+
+    q = a.join(b, on="x").filter(pl.col("y") > 0).select("x")
+    assert q.explain().startswith("INNER JOIN")
+
+    q = a.filter(pl.col.y > 0).group_by("x").agg([])
+    assert q.explain().startswith("AGGREGATE")


### PR DESCRIPTION
closes #26611

This saves in JOIN payload size and in shuffle size for distributed.