### PR TITLE
perf: Allow SimpleProjection in streaming engine to rename

### DIFF
--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -190,7 +190,10 @@ pub fn lower_ir(
     let node_kind = match ir_node {
         IR::SimpleProjection { input, columns } => {
             disable_morsel_split.get_or_insert(true);
-            let columns = columns.iter_names_cloned().collect::<Vec<_>>();
+            let columns = columns
+                .iter_names_cloned()
+                .map(|c| (c.clone(), c))
+                .collect();
             let phys_input = lower_ir!(*input)?;
             PhysNodeKind::SimpleProjection {
                 input: phys_input,
@@ -256,9 +259,13 @@ pub fn lower_ir(
                         .any(|(l, r)| l != r)
                 {
                     let phys_input = phys_sm.insert(PhysNode::new(schema, node_kind));
+                    let columns = projection_schema
+                        .iter_names_cloned()
+                        .map(|c| (c.clone(), c))
+                        .collect();
                     node_kind = PhysNodeKind::SimpleProjection {
                         input: PhysStream::first(phys_input),
-                        columns: projection_schema.iter_names_cloned().collect::<Vec<_>>(),
+                        columns,
                     };
                 }
             }
@@ -881,9 +888,13 @@ pub fn lower_ir(
                         stream = PhysStream::first(node_key);
 
                         if reorder_after_row_index_post {
+                            let columns = output_schema
+                                .iter_names_cloned()
+                                .map(|c| (c.clone(), c))
+                                .collect();
                             let node = PhysNodeKind::SimpleProjection {
                                 input: stream,
-                                columns: output_schema.iter_names_cloned().collect(),
+                                columns,
                             };
 
                             let node_key = phys_sm.insert(PhysNode {
@@ -910,9 +921,13 @@ pub fn lower_ir(
                         stream = PhysStream::first(node_key);
 
                         if reorder_after_row_index_post {
+                            let columns = output_schema
+                                .iter_names_cloned()
+                                .map(|c| (c.clone(), c))
+                                .collect();
                             let node = PhysNodeKind::SimpleProjection {
                                 input: stream,
-                                columns: output_schema.iter_names_cloned().collect(),
+                                columns,
                             };
 
                             let node_key = phys_sm.insert(PhysNode {

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use polars_core::frame::DataFrame;
-use polars_core::prelude::{IdxSize, InitHashMaps, PlHashMap, SortMultipleOptions};
+use polars_core::prelude::{IdxSize, InitHashMaps, PlHashMap, PlIndexMap, SortMultipleOptions};
 use polars_core::schema::{Schema, SchemaRef};
 use polars_error::PolarsResult;
 use polars_io::RowIndex;
@@ -172,7 +172,8 @@ pub enum PhysNodeKind {
 
     SimpleProjection {
         input: PhysStream,
-        columns: Vec<PlSmallStr>,
+        // Key: output column, value: input column.
+        columns: PlIndexMap<PlSmallStr, PlSmallStr>,
     },
 
     InMemorySink {

--- a/crates/polars-utils/src/itertools/mod.rs
+++ b/crates/polars-utils/src/itertools/mod.rs
@@ -1,4 +1,5 @@
 use std::cmp::Ordering;
+use std::fmt::Write;
 
 use crate::IdxSize;
 
@@ -99,6 +100,26 @@ pub trait Itertools: Iterator {
                     ord => return ord,
                 },
             }
+        }
+    }
+
+    fn join(&mut self, sep: &str) -> String
+    where
+        Self::Item: std::fmt::Display,
+    {
+        match self.next() {
+            None => String::new(),
+            Some(first_elt) => {
+                // Estimate lower bound of capacity needed.
+                let (lower, _) = self.size_hint();
+                let mut result = String::with_capacity(sep.len() * lower);
+                write!(&mut result, "{}", first_elt).unwrap();
+                self.for_each(|elt| {
+                    result.push_str(sep);
+                    write!(&mut result, "{}", elt).unwrap();
+                });
+                result
+            },
         }
     }
 }


### PR DESCRIPTION
The streaming engine `SimpleProjectionNode` is now more powerful in that it can do renames, and also faster because it no longer does lookups by name, only index, during runtime.

Considering so many `select` blocks in the streaming engine consist only of subselections and renames, this seemed worthwhile. As a follow-up PR I will merge sequences of `SimpleProjection -> Selection`, `Selection -> SimpleProjection` or `SimpleProjection -> SimpleProjection`.