### PR TITLE
fix: Allow missing time in inexact strptime

### DIFF
--- a/crates/polars-time/src/chunkedarray/string/infer.rs
+++ b/crates/polars-time/src/chunkedarray/string/infer.rs
@@ -338,24 +338,24 @@ fn transform_date(val: &str, fmt: &str) -> Option<i32> {
 
 pub(crate) fn parse_datetime(val: &str, fmt: &str) -> Option<NaiveDateTime> {
     NaiveDateTime::parse_from_str(val, fmt)
-        .or_else(|parse_error| {
-            match parse_error.kind() {
-                ParseErrorKind::NotEnough => NaiveDate::parse_from_str(val, fmt)
-                    .map(|nd| nd.and_hms_opt(0, 0, 0).unwrap()),
-                _ => Err(parse_error),
-            }
+        .or_else(|parse_error| match parse_error.kind() {
+            ParseErrorKind::NotEnough => {
+                NaiveDate::parse_from_str(val, fmt).map(|nd| nd.and_hms_opt(0, 0, 0).unwrap())
+            },
+            _ => Err(parse_error),
         })
         .ok()
 }
 
-pub(crate) fn parse_datetime_and_remainder<'a>(val: &'a str, fmt: &str) -> Option<(NaiveDateTime, &'a str)> {
+pub(crate) fn parse_datetime_and_remainder<'a>(
+    val: &'a str,
+    fmt: &str,
+) -> Option<(NaiveDateTime, &'a str)> {
     NaiveDateTime::parse_and_remainder(val, fmt)
-        .or_else(|parse_error| {
-            match parse_error.kind() {
-                ParseErrorKind::NotEnough => NaiveDate::parse_and_remainder(val, fmt)
-                    .map(|(nd, r)| (nd.and_hms_opt(0, 0, 0).unwrap(), r)),
-                _ => Err(parse_error),
-            }
+        .or_else(|parse_error| match parse_error.kind() {
+            ParseErrorKind::NotEnough => NaiveDate::parse_and_remainder(val, fmt)
+                .map(|(nd, r)| (nd.and_hms_opt(0, 0, 0).unwrap(), r)),
+            _ => Err(parse_error),
         })
         .ok()
 }
@@ -379,7 +379,6 @@ fn transform_tzaware_datetime_ns(val: &str, fmt: &str) -> Option<i64> {
     let dt = DateTime::parse_from_str(val, fmt);
     dt.ok().map(|dt| datetime_to_timestamp_ns(dt.naive_utc()))
 }
-
 
 fn transform_tzaware_datetime_us(val: &str, fmt: &str) -> Option<i64> {
     let dt = DateTime::parse_from_str(val, fmt);

--- a/crates/polars-time/src/chunkedarray/string/mod.rs
+++ b/crates/polars-time/src/chunkedarray/string/mod.rs
@@ -155,12 +155,14 @@ pub trait StringMethods: AsString {
             TimeUnit::Microseconds => datetime_to_timestamp_us,
             TimeUnit::Milliseconds => datetime_to_timestamp_ms,
         };
-        
+
         let ca = unary_elementwise(string_ca, |opt_s| {
             let mut s = opt_s?;
             while !s.is_empty() {
                 let timestamp = if tz_aware {
-                    DateTime::parse_and_remainder(s, fmt).ok().map(|(dt, _r)| func(dt.naive_utc()))
+                    DateTime::parse_and_remainder(s, fmt)
+                        .ok()
+                        .map(|(dt, _r)| func(dt.naive_utc()))
                 } else {
                     infer::parse_datetime_and_remainder(s, fmt).map(|(nd, _r)| func(nd))
                 };

--- a/py-polars/tests/unit/operations/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/operations/namespaces/test_strptime.py
@@ -943,3 +943,16 @@ def test_strptime_in_group_by(maintain_order: bool) -> None:
         ),
         check_row_order=maintain_order,
     )
+
+
+def test_strptime_inexact_datetime_date_only_26713() -> None:
+    df = pl.DataFrame({"date_str": ["2024-01-01", "2025-06-03"]})
+    result = df.with_columns(
+        pl.col("date_str").str.strptime(
+            pl.Datetime(time_unit="ns"), "%Y-%m-%d", exact=False, strict=False
+        )
+    )
+    expected = df.with_columns(
+        pl.col("date_str").str.strptime(pl.Datetime(time_unit="ns"), "%Y-%m-%d")
+    )
+    assert_frame_equal(result, expected)


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/26713.

We have special logic to replace the error with 'not enough components' with an attempt to parse it as a date + zero time component, but were missing this for the inexact path.