### PR TITLE
feat(rust): Expose `AExpr::Rolling` in the python visitor

### DIFF
--- a/crates/polars-python/src/c_api/mod.rs
+++ b/crates/polars-python/src/c_api/mod.rs
@@ -92,6 +92,7 @@ fn _expr_nodes(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<Slice>().unwrap();
     m.add_class::<Len>().unwrap();
     m.add_class::<Window>().unwrap();
+    m.add_class::<Rolling>().unwrap();
     m.add_class::<PyOperator>().unwrap();
     m.add_class::<PyStringFunction>().unwrap();
     m.add_class::<PyBooleanFunction>().unwrap();

--- a/crates/polars-python/src/lazyframe/visit.rs
+++ b/crates/polars-python/src/lazyframe/visit.rs
@@ -58,7 +58,7 @@ impl NodeTraverser {
     // Increment major on breaking changes to the IR (e.g. renaming
     // fields, reordering tuples), minor on backwards compatible
     // changes (e.g. exposing a new expression node).
-    const VERSION: Version = (12, 0);
+    const VERSION: Version = (12, 1);
 
     pub fn new(root: Node, lp_arena: Arena<IR>, expr_arena: Arena<AExpr>) -> Self {
         Self {


### PR DESCRIPTION
<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->

Needed for the GPU engine.

question: Do you think we could get this into the 1.39 release?