### PR TITLE
docs: Expand streaming user guide with 6 real-world patterns

### DIFF
--- a/docs/source/src/python/user-guide/concepts/streaming.py
+++ b/docs/source/src/python/user-guide/concepts/streaming.py
@@ -53,3 +53,137 @@ with open("docs/assets/images/query_plan.png", "rb") as f:
     png = base64.b64encode(f.read()).decode()
     print(f'<img src="data:image/png;base64, {png}"/>')
 # --8<-- [end:createplan]
+
+
+# --8<-- [start:larger_than_ram]
+import polars as pl
+
+# collect(engine="streaming") keeps memory bounded -- data flows through in chunks
+q = (
+    pl.scan_csv("docs/assets/data/iris.csv")
+    .filter(pl.col("sepal_length") > 5)
+    .group_by("species")
+    .agg(
+        pl.col("sepal_width").mean().round(3).alias("avg_sepal_width"),
+        pl.len().alias("n_rows"),
+    )
+    .sort("avg_sepal_width", descending=True)
+)
+df = q.collect(engine="streaming")
+print(df)
+# --8<-- [end:larger_than_ram]
+
+
+# --8<-- [start:sink_parquet]
+import pathlib
+import tempfile
+
+import polars as pl
+
+with tempfile.TemporaryDirectory() as tmp:
+    out = pathlib.Path(tmp) / "enriched.parquet"
+    # Writes to disk in streaming batches -- full enriched result never loads into RAM
+    (
+        pl.scan_csv("docs/assets/data/iris.csv")
+        .with_columns(
+            (pl.col("sepal_length") * pl.col("sepal_width")).alias("sepal_area")
+        )
+        .filter(pl.col("sepal_area") > 15.0)
+        .sink_parquet(out)
+    )
+    print(pl.read_parquet(out).head(5))
+# --8<-- [end:sink_parquet]
+
+
+# --8<-- [start:sink_csv]
+import pathlib
+import tempfile
+
+import polars as pl
+
+with tempfile.TemporaryDirectory() as tmp:
+    out = pathlib.Path(tmp) / "summary.csv"
+    (
+        pl.scan_csv("docs/assets/data/iris.csv")
+        .group_by("species")
+        .agg(
+            pl.col("sepal_length").mean().round(2).alias("avg_sepal_length"),
+            pl.col("petal_length").mean().round(2).alias("avg_petal_length"),
+            pl.len().alias("n"),
+        )
+        .sort("species")
+        .sink_csv(out)
+    )
+    print(pl.read_csv(out))
+# --8<-- [end:sink_csv]
+
+
+# --8<-- [start:sink_batches]
+import polars as pl
+
+batches_seen: list[int] = []
+
+
+def on_batch(batch: pl.DataFrame) -> None:
+    batches_seen.append(len(batch))
+
+
+pl.scan_csv("docs/assets/data/iris.csv").sink_batches(on_batch, chunk_size=50)
+print(f"Processed {sum(batches_seen)} rows in {len(batches_seen)} batch(es)")
+print(f"Rows per batch: {batches_seen}")
+# --8<-- [end:sink_batches]
+
+
+# --8<-- [start:collect_async]
+import asyncio
+
+import polars as pl
+
+
+async def run_concurrent() -> None:
+    lf = pl.scan_csv("docs/assets/data/iris.csv")
+    # Both queries execute concurrently in Polars' thread-pool via asyncio.gather
+    short, long_ = await asyncio.gather(
+        lf.filter(pl.col("sepal_length") < 5.5)
+        .group_by("species")
+        .agg(pl.col("sepal_length").mean().round(3).alias("mean_short"))
+        .collect_async(),
+        lf.filter(pl.col("sepal_length") >= 5.5)
+        .group_by("species")
+        .agg(pl.col("sepal_length").mean().round(3).alias("mean_long"))
+        .collect_async(),
+    )
+    print("Short sepals (< 5.5 cm):")
+    print(short.sort("species"))
+    print("Long sepals (>= 5.5 cm):")
+    print(long_.sort("species"))
+
+
+asyncio.run(run_concurrent())
+# --8<-- [end:collect_async]
+
+
+# --8<-- [start:partition_pruning]
+import pathlib
+import tempfile
+
+import polars as pl
+
+with tempfile.TemporaryDirectory() as tmp:
+    tmp_path = pathlib.Path(tmp)
+    # Write two synthetic "partitions"
+    pl.DataFrame({"year": [2023] * 4, "value": [1.0, 2.0, 3.0, 4.0]}).write_parquet(
+        tmp_path / "part_2023.parquet"
+    )
+    pl.DataFrame({"year": [2024] * 4, "value": [5.0, 6.0, 7.0, 8.0]}).write_parquet(
+        tmp_path / "part_2024.parquet"
+    )
+    # Polars evaluates the predicate on file statistics before reading --
+    # only the 2024 file is opened for this query.
+    result = (
+        pl.scan_parquet(tmp_path / "*.parquet")
+        .filter(pl.col("year") == 2024)
+        .collect(engine="streaming")
+    )
+    print(result)
+# --8<-- [end:partition_pruning]

--- a/docs/source/user-guide/concepts/streaming.md
+++ b/docs/source/user-guide/concepts/streaming.md
@@ -1,16 +1,44 @@
 # Streaming
 
-<!-- Not included in the docs “until we have something we are proud of”. https://github.com/pola-rs/polars/pull/19087/files/92bffabe48c6c33a9ec5bc003d8683e59c97158c#r1788988580 -->
-
 One additional benefit of the lazy API is that it allows queries to be executed in a streaming
 manner. Instead of processing all the data at once, Polars can execute the query in batches allowing
 you to process datasets that do not fit in memory. Besides memory pressure, the streaming engine
 also is more performant than Polars' in-memory engine.
 
+The table below summarises the streaming APIs available in Polars:
+
+| API | Description |
+| ---- | ----------- |
+| `collect(engine="streaming")` | Execute a lazy query in streaming mode and return a `DataFrame` |
+| `sink_parquet(path)` | Stream query output directly to a Parquet file |
+| `sink_csv(path)` | Stream query output directly to a CSV file |
+| `sink_ndjson(path)` | Stream query output to a newline-delimited JSON file |
+| `sink_batches(fn, chunk_size)` | Call a Python function for each output batch |
+| `collect_async()` | Execute a lazy query asynchronously and return an `Awaitable[DataFrame]` |
+
+## Basic streaming: `collect(engine="streaming")`
+
 To tell Polars we want to execute a query in streaming mode we pass the `engine="streaming"`
 argument to `collect`:
 
 {{code_block('user-guide/concepts/streaming','streaming',['collect'])}}
+
+The streaming engine processes data in **chunks**, keeping peak memory bounded regardless of
+dataset size:
+
+```
+scan_parquet  -->  filter (pushdown)  -->  select  -->  group_by
+   [chunk 1]            |                    |              |
+   [chunk 2]        predicate             project         agg
+   [chunk N]                                            merge results
+                                                              |
+                                                         DataFrame
+```
+
+Here is a more complete example -- grouping and aggregating across a full file scan where only
+the matching rows need to reside in memory at any time:
+
+{{code_block('user-guide/concepts/streaming','larger_than_ram',['collect'])}}
 
 ## Inspecting a streaming query
 
@@ -29,3 +57,50 @@ how memory intensive the operation can be.
 ```python exec="on" session="user-guide/concepts/streaming"
 --8<-- "python/user-guide/concepts/streaming.py:createplan"
 ```
+
+## Writing in streaming mode: `sink_*`
+
+Polars can also **write** results in streaming mode. The `sink_*` family of methods flush each
+batch to disk as it is produced -- the full query result never needs to fit in memory. This is
+essential for large ETL pipelines that transform and re-partition data.
+
+### `sink_parquet`
+
+{{code_block('user-guide/concepts/streaming','sink_parquet',['sink_parquet'])}}
+
+### `sink_csv`
+
+{{code_block('user-guide/concepts/streaming','sink_csv',['sink_csv'])}}
+
+## Per-batch callbacks: `sink_batches`
+
+`sink_batches(callback, chunk_size=N)` calls your Python function once per output batch.
+This enables patterns such as:
+
+- **Real-time alerting** -- trigger on threshold violations as each chunk arrives
+- **Incremental forwarding** -- push each batch onward to a WebSocket, database, or queue
+- **Stateful accumulation** -- maintain running summaries without holding the full dataset in memory
+
+{{code_block('user-guide/concepts/streaming','sink_batches',['sink_batches'])}}
+
+## Concurrent async execution: `collect_async`
+
+`collect_async()` submits a lazy query to Polars' thread pool and returns an
+`Awaitable[DataFrame]`. Combine it with `asyncio.gather` to run multiple independent queries
+concurrently and overlap their execution:
+
+{{code_block('user-guide/concepts/streaming','collect_async',['collect_async'])}}
+
+## Multi-file scans and partition pruning
+
+When data is stored across many Parquet files (for example in hourly or daily partitions),
+Polars' lazy scanner evaluates predicates on file statistics **before opening files**. Only files
+that could satisfy the filter are opened, dramatically reducing I/O for selective queries.
+
+{{code_block('user-guide/concepts/streaming','partition_pruning',['scan_parquet'])}}
+
+!!! note
+    Predicate pushdown works best when partition columns are encoded in Hive-style directory
+    paths (`year=2024/month=01/...`) and when Parquet row-group statistics are present.
+    Write partitions with `write_parquet(statistics=True)` (the default) for maximum pruning
+    efficiency.


### PR DESCRIPTION
## Summary

The streaming page currently only covers `collect(engine="streaming")` and `show_graph()`. This PR expands it with actionable examples for the full streaming API surface.

## What's added

**`streaming.py`** — 6 new tagged code sections:

| Tag | Pattern |
|-----|---------|
| `larger_than_ram` | Realistic group_by/agg showing the chunk-based memory model |
| `sink_parquet` | ETL write: scan CSV → enrich → `sink_parquet` (full output never in RAM) |
| `sink_csv` | Aggregation → `sink_csv` |
| `sink_batches` | Per-batch callback: count rows in each chunk |
| `collect_async` | Two concurrent queries via `asyncio.gather` + `collect_async()` |
| `partition_pruning` | Multi-file `scan_parquet` with predicate pushdown skipping non-matching files |

**`streaming.md`** — expanded from ~1,500 to ~4,000 bytes:
- API summary table at the top (all 6 streaming APIs in one view)
- ASCII diagram of the chunk-based memory pipeline
- "Writing in streaming mode: `sink_*`" section (`sink_parquet` + `sink_csv`)
- "Per-batch callbacks: `sink_batches`" section
- "Concurrent async execution: `collect_async`" section
- "Multi-file scans and partition pruning" section with Hive-partition best-practices note

The hidden comment `<!-- Not included in the docs "until we have something we are proud of" -->` has been removed now that the page has substantive content.

## Testing

All examples are self-contained (iris fixture + `tempfile.TemporaryDirectory`), requiring no external network access. Compatible with the existing docs CI.

## Related

pola-rs/polars#20947 (streaming engine tracking issue)
