### PR TITLE
fix(python): Add PerformanceWarning to LazyFrame.__contains__

### DIFF
--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -741,6 +741,12 @@ class LazyFrame:
         self._comparison_error("<=")
 
     def __contains__(self, key: str) -> bool:
+        issue_warning(
+            "Checking column membership of a LazyFrame requires resolving its schema,"
+            " which is a potentially expensive operation. Use"
+            " `key in LazyFrame.collect_schema()` to perform this check without this warning.",
+            category=PerformanceWarning,
+        )
         return key in self.collect_schema()
 
     def __copy__(self) -> LazyFrame:

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -1505,6 +1505,10 @@ def test_lf_properties() -> None:
         assert lf.dtypes == [pl.Int64, pl.Float64, pl.String]
     with pytest.warns(PerformanceWarning):
         assert lf.width == 3
+    with pytest.warns(PerformanceWarning):
+        assert ("foo" in lf) is True
+    with pytest.warns(PerformanceWarning):
+        assert ("missing" in lf) is False
 
 
 def test_lf_unnest() -> None:


### PR DESCRIPTION
Closes #21917

## What changed

`'col' in lf` silently called `collect_schema()` without warning the user. All other schema-resolving properties (`.columns`, `.dtypes`, `.schema`, `.width`) already emit a `PerformanceWarning` via `issue_warning()`; `__contains__` was overlooked.

## Fix

Added `issue_warning(..., category=PerformanceWarning)` to `__contains__` before the `collect_schema()` call, matching the existing pattern.

## Tests

Extended `test_lf_properties` with two assertions — one for a present column, one for an absent column — both asserting the warning is emitted.