### PR TITLE
fix(python): Allow `DataTypeExpr` in `pl.lit()`

### DIFF
--- a/py-polars/src/polars/functions/lit.py
+++ b/py-polars/src/polars/functions/lit.py
@@ -88,7 +88,7 @@ def lit(
         msg = f"dtype '{dtype}' is a BaseExtension class, it should be an instance"
         raise TypeError(msg)
     elif isinstance(dtype, DataTypeExpr):
-        dtype = dtype.collect_dtype({})
+        return lit(value).cast(dtype)
     elif dtype == Object:
         value_s = pl.Series("literal", [value], dtype=dtype)
         return wrap_expr(plr.lit(value_s._s, allow_object, is_scalar=True))

--- a/py-polars/src/polars/functions/lit.py
+++ b/py-polars/src/polars/functions/lit.py
@@ -16,6 +16,7 @@ from polars._dependencies import (
 )
 from polars._dependencies import numpy as np
 from polars._utils.wrap import wrap_expr
+from polars.datatype_expr import DataTypeExpr
 from polars.datatypes import BaseExtension, Date, Datetime, Duration, Object
 from polars.datatypes.convert import DataTypeMappings
 
@@ -83,6 +84,8 @@ def lit(
     elif isinstance(dtype, type) and issubclass(dtype, BaseExtension):
         msg = f"dtype '{dtype}' is a BaseExtension class, it should be an instance"
         raise TypeError(msg)
+    elif isinstance(dtype, DataTypeExpr):
+        dtype = dtype.collect_dtype({})
     elif dtype == Object:
         value_s = pl.Series("literal", [value], dtype=dtype)
         return wrap_expr(plr.lit(value_s._s, allow_object, is_scalar=True))

--- a/py-polars/src/polars/functions/lit.py
+++ b/py-polars/src/polars/functions/lit.py
@@ -29,7 +29,10 @@ if TYPE_CHECKING:
 
 
 def lit(
-    value: Any, dtype: PolarsDataType | None = None, *, allow_object: bool = False
+    value: Any,
+    dtype: PolarsDataType | DataTypeExpr | None = None,
+    *,
+    allow_object: bool = False,
 ) -> Expr:
     """
     Return an expression representing a literal value.

--- a/py-polars/tests/unit/functions/test_lit.py
+++ b/py-polars/tests/unit/functions/test_lit.py
@@ -279,3 +279,11 @@ def test_lit_object_type_25713() -> None:
     out = pl.select(pl.lit(obj, dtype=pl.Object))
     expected = pl.DataFrame({"literal": [obj]}, schema={"literal": pl.Object})
     assert out.to_dict(as_series=False) == expected.to_dict(as_series=False)
+
+
+def test_allow_dtype_expr_lit_26644() -> None:
+    result = pl.DataFrame().select(
+        pl.lit(None, pl.dtype_of(pl.lit(["abc"])).list.inner_dtype())
+    )
+    expected = pl.DataFrame({"literal": pl.Series([None], dtype=pl.String)})
+    assert_frame_equal(result, expected)


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/26644.

Implemented the fix on the Python side since the Rust function `pub fn lit(...)` in `crates/polars-python/src/functions/lazy.rs` does not contain an equivalent `dtype` argument.

Used `DataTypeExpr.collect_dtype()` to resolve the `DataTypeExpr` into a concrete `DataType` prior to running the rest of the function. Passed an empty schema (`{}`) to `.collect_dtype()` since it seems like it can resolve itself (there were many examples of just passing `{}` to `.collect_dtype()` in the method docstrings located in  `Class DataTypeExpr`).