### PR TITLE
docs(python): Fix formatting in categorical documentation

### DIFF
--- a/docs/source/user-guide/expressions/categorical-data-and-enums.md
+++ b/docs/source/user-guide/expressions/categorical-data-and-enums.md
@@ -173,7 +173,7 @@ to specify so when creating the column:
 {{code_block('user-guide/expressions/categoricals', 'stringcache-categorical-comparison-lexical',
 ['StringCache', 'Categorical'])}}
 
-```python result="text" session="expressions/categoricals"
+```python exec="on" result="text" session="expressions/categoricals"
 --8<-- "python/user-guide/expressions/categoricals.py:stringcache-categorical-comparison-lexical"
 ```
 
@@ -181,10 +181,6 @@ Otherwise, the order is inferred together with the values:
 
 {{code_block('user-guide/expressions/categoricals', 'stringcache-categorical-comparison-physical',
 ['StringCache', 'Categorical'])}}
-
-```python
---8<-- "python/user-guide/expressions/categoricals.py:stringcache-categorical-comparison-physical"
-```
 
 ```
 shape: (5,)


### PR DESCRIPTION
As @juhaszp95 pointed out, there was a formatting error after https://github.com/pola-rs/polars/pull/24249 was merged. It looked like:

<img width="764" height="349" alt="image" src="https://github.com/user-attachments/assets/8ee69a1f-672e-4165-a84f-c08224312c39" />

This fixes the code formatting and output so it is now correct. 
