### PR TITLE
fix: Boolean `bitwise_xor` aggregation inverted when column contains nulls

### DIFF
--- a/crates/polars-core/src/frame/group_by/aggregations/boolean.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/boolean.rs
@@ -54,7 +54,7 @@ impl BooleanChunked {
                     })
                     .sum::<IdxSize>()
                     % 2
-                    == 0
+                    == 1
             },
             |_, _, _| unreachable!(),
             |values, start, length| {

--- a/py-polars/tests/unit/operations/test_bitwise.py
+++ b/py-polars/tests/unit/operations/test_bitwise.py
@@ -366,6 +366,20 @@ def test_bitwise_boolean_evict_path(plmonkeypatch: PlMonkeyPatch) -> None:
     assert_frame_equal(out, expected)
 
 
+def test_bool_xor_group_by_with_nulls() -> None:
+    df = pl.DataFrame(
+        {
+            "g": ["a", "a", "b", "b", "b"],
+            "v": [True, None, True, True, None],
+        }
+    )
+    assert_frame_equal(
+        df.group_by("g").agg(XOR=pl.col.v.bitwise_xor()),
+        pl.DataFrame({"g": ["a", "b"], "XOR": [True, False]}),
+        check_row_order=False,
+    )
+
+
 def test_bitwise_in_group_by() -> None:
     df = pl.DataFrame(
         {


### PR DESCRIPTION
The idx_validity closure in `BooleanChunked::agg_xor` checked % 2 == 0 instead of % 2 == 1. Fixed by changing == 0
to == 1.

Fixes : #26748