### PR TITLE
fix: Raise error when `.get()` is out-of-bounds in group by context

### DIFF
--- a/crates/polars-expr/src/expressions/gather.rs
+++ b/crates/polars-expr/src/expressions/gather.rs
@@ -51,7 +51,7 @@ impl PhysicalExpr for GatherExpr {
             let idx = idx.flat_naive();
             let idx = idx.cast(&DataType::Int64)?;
             let idx = idx.i64().unwrap();
-            let taken = lst_get(ac_list.as_ref(), idx, true)?;
+            let taken = lst_get(ac_list.as_ref(), idx, self.null_on_oob)?;
 
             ac.with_values_and_args(taken, true, Some(&self.expr), false, true)?;
             ac.with_update_groups(UpdateGroups::No);

--- a/crates/polars-python/src/expr/general.rs
+++ b/crates/polars-python/src/expr/general.rs
@@ -362,6 +362,7 @@ impl PyExpr {
     fn get(&self, idx: Self, null_on_oob: bool) -> Self {
         self.inner.clone().get(idx.inner, null_on_oob).into()
     }
+
     fn sort_by(
         &self,
         by: Vec<Self>,

--- a/py-polars/tests/unit/operations/namespaces/list/test_eval.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_eval.py
@@ -473,7 +473,12 @@ def test_list_eval_parametric_rank(df: pl.DataFrame, expr: pl.Expr) -> None:
     ],
 )
 @pytest.mark.parametrize(
-    "expr", [pl.element().first(), pl.element().get(0), pl.element().reverse().last()]
+    "expr",
+    [
+        pl.element().first(),
+        pl.element().get(0, null_on_oob=True),
+        pl.element().reverse().last(),
+    ],
 )
 def test_list_eval_parametric_first_scalar(
     df: pl.DataFrame, expected: pl.DataFrame, expr: pl.Expr

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -15,6 +15,7 @@ import polars.selectors as cs
 from polars import Expr
 from polars.exceptions import (
     ColumnNotFoundError,
+    ComputeError,
     InvalidOperationError,
 )
 from polars.meta import get_index_type
@@ -2965,3 +2966,10 @@ def test_group_by_cse_alias_26423() -> None:
         },
     )
     assert_frame_equal(result, expected, check_row_order=False)
+
+
+def test_group_by_agg_get_oob_error_26747() -> None:
+    df = pl.DataFrame({"x": [1, 1, 2, 3]})
+
+    with pytest.raises(ComputeError, match="get index is out of bounds"):
+        df.group_by("x").agg(y=pl.col.x.get(100))


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/26747.

The issue stemmed from the fact that, in `evaluate_on_groups`, when hitting the if `self.returns_scalar` path, `lst.get(...)` had hardcoded `true` for `null_on_oob`. The fix was `using self.null_on_oob` to match the parameter selection, rather than using a hard-coded default. 

As a note, the test `test_list_eval_parametric_first_scalar` was updated to have `.get(0, null_on_oob=True)` since it was using the old implicit behaviour where `.get()` silently returned `null` on OOB indices. Now that the default is `False`, the test needs to explicitly specify null on OOB behaviour.  

🤖 Claude Sonnet 4.6 for navigating the codebase. 