### PR TITLE
fix(python): Raise clear ValueError when read_csv is given a Parquet file

### DIFF
--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -62,7 +62,7 @@ def _check_not_parquet(source: str | Path | IO[str] | IO[bytes] | bytes) -> None
         src = str(source)
         if "://" not in src and not is_glob_pattern(src):
             try:
-                with open(src, "rb") as f:
+                with Path(src).open("rb") as f:
                     magic = f.read(4)
             except OSError:
                 pass

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -3144,11 +3144,11 @@ def test_read_csv_parquet_file_hint(tmp_path: Path) -> None:
     parquet_file = tmp_path / "data.parquet"
     pl.DataFrame({"a": [1, 2, 3]}).write_parquet(parquet_file)
 
-    with pytest.raises(ValueError, match="Parquet file.*read_parquet"):
+    with pytest.raises(ValueError, match=r"Parquet file.*read_parquet"):
         pl.read_csv(parquet_file)
 
-    with pytest.raises(ValueError, match="Parquet file.*read_parquet"):
+    with pytest.raises(ValueError, match=r"Parquet file.*read_parquet"):
         pl.read_csv(str(parquet_file))
 
-    with pytest.raises(ValueError, match="Parquet file.*read_parquet"):
+    with pytest.raises(ValueError, match=r"Parquet file.*read_parquet"):
         pl.read_csv(parquet_file.read_bytes())


### PR DESCRIPTION
Closes #16106

## What changed

When a Parquet file is accidentally passed to `read_csv`, the Parquet binary data can contain ANSI escape sequences that clear the terminal, making it look like the shell history was erased and leaving behind a confusing, unreadable error.

## Fix

Before any parsing, peek at the first four bytes of the source. If they match the Parquet magic number (`PAR1`), raise a `ValueError` with a clear message pointing the user to `read_parquet`.

The check covers `Path`, `str` (local files only; remote URLs and glob patterns are skipped), and raw `bytes` inputs.

## Tests

Added `test_read_csv_parquet_file_hint` which asserts the `ValueError` is raised for a `Path`, a `str`, and a `bytes` source that starts with the Parquet magic bytes.