### PR TITLE
fix(python): Apply thousands separator to count/null_count in describe for non-numeric columns

### DIFF
--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -1135,6 +1135,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ max        ┆ 3.0      ┆ 50.0     ┆ 1.0      ┆ zz   ┆ 2022-12-31          ┆ 23:15:10 │
         └────────────┴──────────┴──────────┴──────────┴──────┴─────────────────────┴──────────┘
         """  # noqa: W505
+        from polars import _plr
         from polars.convert import from_dict
 
         schema = self.collect_schema()
@@ -1231,12 +1232,21 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         summary = dict(zip(schema, column_metrics, strict=True))
 
         # cast by column type (numeric/bool -> float), (other -> string)
+        thousands_sep = _plr.get_thousands_separator()
         for c in schema:
             summary[c] = [  # type: ignore[assignment]
                 (
                     None
                     if (v is None or isinstance(v, dict))
-                    else (float(v) if (c in has_numeric_result) else str(v))
+                    else (
+                        float(v)
+                        if (c in has_numeric_result)
+                        else (
+                            f"{v:,}".replace(",", thousands_sep)
+                            if (thousands_sep and isinstance(v, int))
+                            else str(v)
+                        )
+                    )
                 )
                 for v in summary[c]
             ]

--- a/py-polars/tests/unit/dataframe/test_describe.py
+++ b/py-polars/tests/unit/dataframe/test_describe.py
@@ -219,6 +219,17 @@ def test_df_describe_quantile_precision() -> None:
         assert m in result_metrics
 
 
+# https://github.com/pola-rs/polars/issues/25946
+def test_df_describe_thousands_separator() -> None:
+    df = pl.DataFrame({"s": ["a"] * 1001, "n": list(range(1001))})
+    with pl.Config(thousands_separator=","):
+        result = df.describe()
+
+    s_col = result["s"].to_list()
+    assert s_col[0] == "1,001"  # count row — separator applied
+    assert s_col[1] == "0"  # null_count row — no grouping needed
+
+
 # https://github.com/pola-rs/polars/issues/9830
 @pytest.mark.may_fail_cloud
 def test_df_describe_object() -> None:


### PR DESCRIPTION
## What

Closes #25946.

When `pl.Config(thousands_separator=...)` is set, `count` and `null_count` values in `describe()` were formatted correctly for **numeric** columns (stored as `float`, handled by the display engine) but not for **non-numeric** columns (string, date, time, etc.), where they were converted with plain `str(v)`.

## How

In `LazyFrame.describe`, after collecting metrics, read the current `thousands_separator` from Config via `_plr.get_thousands_separator()`. When converting integer values (count/null_count) for non-numeric columns to strings, apply grouping with the configured separator character.

## Test plan

- [ ] `test_df_describe_thousands_separator` — creates a 1001-row DataFrame with a string column, sets `thousands_separator=","`, and asserts the count row shows `"1,001"`