### PR TITLE
fix(python): Make pl.lit(datetime) robust after datetime monkeypatching (fix #26698)

### DIFF
--- a/crates/polars-plan/src/dsl/meta.rs
+++ b/crates/polars-plan/src/dsl/meta.rs
@@ -92,11 +92,7 @@ impl MetaNameSpace {
                 expr,
                 dtype,
                 options: CastOptions::Strict,
-            } if matches!(dtype.as_literal(), Some(DataType::Datetime(_, _)))
-                && matches!(&**expr, Expr::Literal(_)) =>
-            {
-                true
-            },
+            } if matches!(dtype.as_literal(), Some(DataType::Datetime(_, _))) && matches!(&**expr, Expr::Literal(LiteralValue::Scalar(sc)) if matches!(sc.as_any_value(), AnyValue::Datetime(..))) => true,
             _ => false,
         })
     }

--- a/py-polars/src/polars/functions/lit.py
+++ b/py-polars/src/polars/functions/lit.py
@@ -156,14 +156,12 @@ def lit(
 
         dt_utc = value.replace(tzinfo=timezone.utc)
         dt_utc_int = _datetime_to_timestamp(dt_utc, time_unit)
-        expr = wrap_expr(plr.lit(dt_utc_int, allow_object=False, is_scalar=True)).cast(
-            Datetime(time_unit)
-        )
+        dt_utc_s = pl.Series("literal", [dt_utc_int]).cast(Datetime(time_unit))
         if tz is not None:
-            expr = expr.dt.replace_time_zone(
+            dt_utc_s = dt_utc_s.dt.replace_time_zone(
                 tz, ambiguous="earliest" if value.fold == 0 else "latest"
             )
-        return expr
+        return wrap_expr(plr.lit(dt_utc_s._s, allow_object=False, is_scalar=True))
 
     elif isinstance(value, timedelta):
         value_s = pl.Series("literal", [value])

--- a/py-polars/tests/unit/functions/test_lit.py
+++ b/py-polars/tests/unit/functions/test_lit.py
@@ -98,9 +98,13 @@ def test_lit_datetime_after_datetime_monkeypatch_26698() -> None:
             pass
 
         datetime_module.datetime = FakeDatetime
-        pl.lit(datetime_module.datetime(2026, 1, 1, 12))
+        fake_expr = pl.lit(datetime_module.datetime(2026, 1, 1, 12))
+        assert fake_expr.meta.is_literal()
+        assert pl.select(fake_expr).item() == datetime(2026, 1, 1, 12)
         datetime_module.datetime = datetime
-        pl.lit(datetime(2026, 1, 1, 12))
+        real_expr = pl.lit(datetime(2026, 1, 1, 12))
+        assert real_expr.meta.is_literal()
+        assert pl.select(real_expr).item() == datetime(2026, 1, 1, 12)
         """
     )
 


### PR DESCRIPTION
## Summary
Fixes a Python bug where `pl.lit(datetime)` can fail after temporary monkeypatching of
`datetime.datetime` (reported in #26698, commonly triggered by `freezegun.freeze_time`).

## Reproduction
```python
from datetime import datetime
import polars as pl
import freezegun

with freezegun.freeze_time("2026-02-24T12:00:00"):
    pl.lit(datetime(2026, 1, 1, 12))

pl.lit(datetime(2026, 1, 1, 12))  # used to fail
```

## Root Cause
`pl.lit(datetime)` constructed a temporary `Series([dt_utc])` and then casted it to
`Datetime`. That temporary Python-object conversion can be affected by datetime-class
monkeypatching, and the value may be inferred as `Date` instead of `Datetime`, which later
fails in datetime operations.

## Fix
In `py-polars/src/polars/functions/lit.py`:
- Replace temporary `Series([dt_utc]).cast(Datetime(...))` path with:
  - convert `dt_utc` to integer epoch timestamp (`ns/us/ms`)
  - `plr.lit(int_timestamp).cast(Datetime(time_unit))`
- Keep existing timezone/fold logic (`replace_time_zone(..., ambiguous=...)`).

## Tests
Added regression test in `py-polars/tests/unit/functions/test_lit.py`:
- `test_lit_datetime_after_datetime_monkeypatch_26698`

The test runs in a subprocess, monkeypatches `datetime.datetime` to a fake class, performs
`pl.lit(...)` during the patch, restores the real class, and verifies a second `pl.lit(...)`
still succeeds.

**Note** This specific section (the tests written) is AI generated. I have reviewed it to make sure it is correct, and then wrote the implementation to fix the issue accordingly. I am relying on the CI to ensure there are not any existing tests which fail

## Impact
This removes stateful failures after freeze/mocking contexts and stabilizes datetime literal
usage in dataframe/lazyframe expressions (filters, with_columns, joins using datetime literals).
