### PR TITLE
fix: Do not use merge-join if `nulls_last` is unknown

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/sortedness.rs
+++ b/crates/polars-plan/src/plans/optimizer/sortedness.rs
@@ -356,7 +356,13 @@ fn is_sorted_rec(
 
 #[derive(Debug, PartialEq)]
 pub struct AExprSorted {
+    /// None: either way / unsure
+    /// Some(false): ascending
+    /// Some(true): descending
     pub descending: Option<bool>,
+    /// None: either way / unsure
+    /// Some(false): nulls (if any) at start
+    /// Some(true): nulls (if any) at end
     pub nulls_last: Option<bool>,
 }
 

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -1088,7 +1088,18 @@ pub fn lower_ir(
             let join_keys_sorted_together =
                 Option::zip(left_on_sorted.as_ref(), right_on_sorted.as_ref())
                     .is_some_and(|(ls, rs)| ls == rs);
-            let use_streaming_merge_join = args.how.is_equi() && join_keys_sorted_together;
+            let mut key_descending = left_on_sorted
+                .as_ref()
+                .and_then(|v| v.first())
+                .and_then(|s| s.descending);
+            let key_nulls_last = left_on_sorted
+                .as_ref()
+                .and_then(|v| v.first())
+                .and_then(|s| s.nulls_last);
+            let use_streaming_merge_join = args.how.is_equi()
+                && join_keys_sorted_together
+                && key_descending.is_some()
+                && key_nulls_last.is_some();
             #[cfg(feature = "asof_join")]
             let use_streaming_asof_join = if let JoinType::AsOf(ref asof_options) = args.how {
                 // Grouped asof-join is not yet supported in the streaming engine.
@@ -1141,8 +1152,6 @@ pub fn lower_ir(
                 trans_left_on.drain(left_on.len()..);
                 trans_right_on.drain(right_on.len()..);
 
-                let mut key_descending = left_on_sorted.as_ref().and_then(|v| v[0].descending);
-                let key_nulls_last = left_on_sorted.as_ref().and_then(|v| v[0].nulls_last);
                 let mut tmp_left_key_col = None;
                 let mut tmp_right_key_col = None;
                 if use_streaming_merge_join || use_streaming_asof_join {

--- a/py-polars/tests/unit/streaming/test_streaming_join.py
+++ b/py-polars/tests/unit/streaming/test_streaming_join.py
@@ -580,23 +580,29 @@ def test_merge_join_exprs() -> None:
 
 @pytest.mark.parametrize("left_descending", [False, True])
 @pytest.mark.parametrize("right_descending", [False, True])
-@pytest.mark.parametrize("left_nulls_last", [False, True])
-@pytest.mark.parametrize("right_nulls_last", [False, True])
+@pytest.mark.parametrize("left_nulls_last", [False, True, None])
+@pytest.mark.parametrize("right_nulls_last", [False, True, None])
 def test_merge_join_applicable(
     left_descending: bool,
     right_descending: bool,
-    left_nulls_last: bool,
-    right_nulls_last: bool,
+    left_nulls_last: bool | None,
+    right_nulls_last: bool | None,
 ) -> None:
-    left = pl.LazyFrame({"key": [1]}).set_sorted(
-        "key", descending=left_descending, nulls_last=left_nulls_last
-    )
-    right = pl.LazyFrame({"key": [2]}).set_sorted(
-        "key", descending=right_descending, nulls_last=right_nulls_last
-    )
+    def make_set_sorted_lf(descending: bool, nulls_last: bool | None) -> pl.LazyFrame:
+        lf = pl.LazyFrame({"key": [1]})
+        if nulls_last is None:
+            return lf.with_columns(pl.col("key").set_sorted(descending=descending))
+        else:
+            return lf.set_sorted("key", descending=descending, nulls_last=nulls_last)
+
+    left = make_set_sorted_lf(left_descending, left_nulls_last)
+    right = make_set_sorted_lf(right_descending, right_nulls_last)
     q = left.join(right, on="key", how="full", maintain_order="left_right")
     dot = q.show_graph(engine="streaming", plan_stage="physical", raw_output=True)
-    if (left_descending, left_nulls_last) == (right_descending, right_nulls_last):
+    if (
+        left_descending == right_descending
+        and left_nulls_last == right_nulls_last is not None
+    ):
         assert "merge-join" in typing.cast("str", dot)
     else:
         assert "merge-join" not in typing.cast("str", dot)


### PR DESCRIPTION
The IR lowering would lower to a merge-join node even though it was unknown if the key column was `descending` or if the key column had its `nulls_last`. This could result in a panic when both columns were set as `pl.col("key").set_sorted(descending=descending)` (which does not set `nulls_last` info), and the `nulls_last` `None` got `unwrap()`'d.

:robot: Used Claude Sonnet 4.6 for debugging the issue and updating the test. I have reviewed everything properly.