### PR TITLE
chore: Automatically add first-contribution label

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,14 +12,32 @@ jobs:
   labeler:
     runs-on: ubuntu-latest
     steps:
-      - name: Check pull request title
-        uses: thehanimo/pr-title-checker@v1.4.2
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Label pull request
         uses: release-drafter/release-drafter@v6
         with:
           disable-releaser: true
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Label first-time contributors
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const author = context.payload.pull_request.user.login;
+            const { data } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:pr is:merged author:${author}`,
+            });
+            if (data.total_count === 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: ['first-contribution']
+              });
+            }
+
+      - name: Check pull request title
+        uses: thehanimo/pr-title-checker@v1.4.2
+        with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should help us enforce our contribution policy. I also made sure the `title-needs-formatting` check runs last, since that can actually fail.