### PR TITLE
perf: Streaming first/last on Enum through physical

### DIFF
--- a/crates/polars-expr/src/reduce/first_last.rs
+++ b/crates/polars-expr/src/reduce/first_last.rs
@@ -33,7 +33,8 @@ fn new_reduction_with_policy<P: Policy + 'static>(
         _ if dtype.is_primitive_numeric()
             || dtype.is_temporal()
             || dtype.is_decimal()
-            || dtype.is_categorical() =>
+            || dtype.is_categorical()
+            || dtype.is_enum() =>
         {
             with_match_physical_numeric_polars_type!(dtype.to_physical(), |$T| {
                 Box::new(VGR::new(dtype, NumFirstLastReducer::<_, $T>(policy, PhantomData)))

--- a/crates/polars-expr/src/reduce/first_last_nonnull.rs
+++ b/crates/polars-expr/src/reduce/first_last_nonnull.rs
@@ -26,7 +26,8 @@ fn new_nonnull_reduction_with_policy<P: NonNullPolicy + 'static>(
         _ if dtype.is_primitive_numeric()
             || dtype.is_temporal()
             || dtype.is_decimal()
-            || dtype.is_categorical() =>
+            || dtype.is_categorical()
+            || dtype.is_enum() =>
         {
             with_match_physical_numeric_polars_type!(dtype.to_physical(), |$T| {
                 Box::new(VGR::new(dtype, NumFirstLastNonNullReducer::<_, $T>(policy, PhantomData)))


### PR DESCRIPTION
This was overlooked before, enum can just use the numeric path.