### PR TITLE
docs: clarify streaming fallback for LazyFrame.join() validate parameter

### DIFF
--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -6038,7 +6038,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                  - Many-to-one. Check if join keys are unique in right dataset.
 
             .. note::
-                This is currently not supported by the streaming engine.
+                When validation is enabled (any value other than ``m:m``), the
+                streaming engine falls back to the in-memory engine to perform
+                the validation check. This means memory usage may be
+                significantly higher than a pure streaming execution.
         nulls_equal
             Join on null values. By default null values will never produce matches.
         coalesce


### PR DESCRIPTION
## What does this PR fix?

Closes #26678

The `validate` parameter docstring on `LazyFrame.join()` previously contained:

> **Note:** This is currently not supported by the streaming engine.

This phrasing is inaccurate and caused confusion for users (see #26678). In practice, when a validation constraint is enabled (`1:1`, `1:m`, `m:1`), the streaming engine **falls back to the in-memory engine** to perform the validation check — so validation *does* work, but the query will not run in streaming mode for that join.

## Changes

Updated the note to accurately describe the behavior:

```
When validation is enabled (any value other than ``m:m``), the
streaming engine falls back to the in-memory engine to perform
the validation check. This means memory usage may be
significantly higher than a pure streaming execution.
```

This clarifies:
1. Validation **does work** — it is not silently skipped
2. Users should expect higher memory usage when validation is enabled on large datasets

Made with [Cursor](https://cursor.com)