### PR TITLE
docs: Remove confusing join validation note

### DIFF
--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -6036,9 +6036,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                  - One-to-many. Checks if join keys are unique in left dataset.
                * - **m:1**
                  - Many-to-one. Check if join keys are unique in right dataset.
-
-            .. note::
-                This is currently not supported by the streaming engine.
         nulls_equal
             Join on null values. By default null values will never produce matches.
         coalesce


### PR DESCRIPTION
This note was just confusing people, it just means the join automatically falls back to the in-memory engine. We'll add native validation join support to the streaming engine sometime in the future anyway.