### PR TITLE
fix: Segfault in `JoinExec` on deep plan

### DIFF
--- a/py-polars/src/polars/functions/eager.py
+++ b/py-polars/src/polars/functions/eager.py
@@ -205,20 +205,25 @@ def concat(
         join_method: JoinStrategy = (
             "full" if how == "align" else how.removeprefix("align_")  # type: ignore[assignment]
         )
-        lf: LazyFrame = (
-            _balanced_reduce(
-                [df.lazy() for df in elems],
-                lambda x, y: x.join(
-                    y,
-                    on=common_cols,
-                    how=join_method,
-                    maintain_order="right_left",
-                    coalesce=True,
-                ),
+        join_frames = [df.lazy() for df in elems]
+
+        def join_fn(x: pl.LazyFrame, y: pl.LazyFrame) -> pl.LazyFrame:
+            return x.join(
+                y,
+                on=common_cols,
+                how=join_method,
+                maintain_order="right_left",
+                coalesce=True,
             )
-            .sort(by=common_cols, maintain_order=True)
-            .select(*output_column_order)
-        )
+
+        if join_method in ("full", "inner"):
+            # associative => balanced tree, recursion depth is O(log(n))
+            lf = _balanced_reduce(join_frames, join_fn)
+        else:
+            # not associative => linear chain, recursion depth is O(n)
+            lf = reduce(join_fn, join_frames)
+        lf = lf.sort(by=common_cols, maintain_order=True).select(*output_column_order)
+
         eager = isinstance(elems[0], pl.DataFrame)
         return lf.collect() if eager else lf  # type: ignore[return-value]
 
@@ -491,20 +496,25 @@ def union(
         join_method: JoinStrategy = (
             "full" if how == "align" else how.removeprefix("align_")  # type: ignore[assignment]
         )
-        lf: LazyFrame = (
-            _balanced_reduce(
-                [df.lazy() for df in elems],
-                lambda x, y: x.join(
-                    y,
-                    on=common_cols,
-                    how=join_method,
-                    maintain_order="none",
-                    coalesce=True,
-                ),
+        join_frames = [df.lazy() for df in elems]
+
+        def join_fn(x: pl.LazyFrame, y: pl.LazyFrame) -> pl.LazyFrame:
+            return x.join(
+                y,
+                on=common_cols,
+                how=join_method,
+                maintain_order="none",
+                coalesce=True,
             )
-            .sort(by=common_cols, maintain_order=False)
-            .select(*output_column_order)
-        )
+
+        if join_method in ("full", "inner"):
+            # associative => balanced tree, recursion depth is O(log(n))
+            lf = _balanced_reduce(join_frames, join_fn)
+        else:
+            # not associative => linear chain, recursion depth is O(n)
+            lf = reduce(join_fn, join_frames)
+        lf = lf.sort(by=common_cols, maintain_order=False).select(*output_column_order)
+
         eager = isinstance(elems[0], pl.DataFrame)
         return lf.collect() if eager else lf  # type: ignore[return-value]
 

--- a/py-polars/tests/unit/functions/test_concat.py
+++ b/py-polars/tests/unit/functions/test_concat.py
@@ -4,6 +4,7 @@ from typing import IO
 import pytest
 
 import polars as pl
+from polars._typing import ConcatMethod
 from polars.testing import assert_frame_equal
 
 
@@ -423,23 +424,36 @@ def test_concat_with_empty_dataframes_nonstrict_25727() -> None:
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    "depth",
+    "how",
     [
-        1,
-        31,
-        32,
-        33,
-        875,  # per the original issue, we observe segfault at 875
-        2000,
+        "align",
+        "align_full",
+        "align_inner",
+        "align_left",
+        "align_right",
     ],
 )
-def test_concat_stack_overflow_26788(depth: int) -> None:
-    dfs = [pl.DataFrame({"foo": [0], f"c{i}": [1.0]}) for i in range(depth)]
-    out = pl.concat(dfs, how="align")
-
-    dfs_alt = [pl.DataFrame({"foo": [0]})] + [
-        pl.DataFrame({f"c{i}": [1.0]}) for i in range(depth)
+@pytest.mark.parametrize(
+    "n_dfs",
+    [3, 4, 5],  # balanced tree +/- 1
+)
+def test_concat_align_associativity_26788(how: ConcatMethod, n_dfs: int) -> None:
+    # create every possible key combination over `n_dfs` dataframes
+    n_dfs = n_dfs
+    keys = [
+        [x for x in range(1 << n_dfs) if not (x >> (n_dfs - 1 - i) & 1)]
+        for i in range(n_dfs)
     ]
-    expected = pl.concat(dfs_alt, how="horizontal")
+    dfs = [
+        pl.DataFrame({"k": key})
+        .with_columns((i * 100 + pl.col.k).alias(f"v_{i}"))
+        .lazy()
+        for i, key in enumerate(keys)
+    ]
 
-    assert_frame_equal(out, expected)
+    chained_from_left = dfs[0]
+    for df in dfs[1:]:
+        chained_from_left = pl.concat([chained_from_left, df], how=how)
+
+    full = pl.concat(dfs, how=how)
+    assert_frame_equal(chained_from_left, full)

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -855,24 +855,3 @@ def test_corr_spearman_float_dtype_26335(
     q = df.lazy().group_by("c").agg(pl.corr("a", "b", method=method))
     out = q.collect()
     assert out.schema["a"] == dt
-
-
-@pytest.mark.slow
-@pytest.mark.parametrize(
-    "depth",
-    [
-        1,
-        31,
-        32,
-        33,
-        875,  # per the original issue, we observe segfault at 875
-        2000,
-    ],
-)
-def test_align_frames_stack_overflow_26788(depth: int) -> None:
-    dfs = [pl.DataFrame({"foo": [0], f"c{i}": [1.0]}) for i in range(depth)]
-    out = pl.align_frames(dfs, on="foo")
-
-    assert len(dfs) == len(out)
-    for a, b in zip(dfs, out, strict=True):
-        assert_frame_equal(a, b)

--- a/py-polars/tests/unit/functions/test_union.py
+++ b/py-polars/tests/unit/functions/test_union.py
@@ -1,6 +1,7 @@
 import pytest
 
 import polars as pl
+from polars._typing import ConcatMethod
 from polars.testing import assert_frame_equal
 
 
@@ -217,23 +218,36 @@ def test_union_with_empty_dataframes() -> None:
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    "depth",
+    "how",
     [
-        1,
-        31,
-        32,
-        33,
-        875,  # per the original issue, we observe segfault at 875
-        2000,
+        "align",
+        "align_full",
+        "align_inner",
+        "align_left",
+        "align_right",
     ],
 )
-def test_union_stack_overflow_26788(depth: int) -> None:
-    dfs = [pl.DataFrame({"foo": [0], f"c{i}": [1.0]}) for i in range(depth)]
-    out = pl.union(dfs, how="align")
-
-    dfs_alt = [pl.DataFrame({"foo": [0]})] + [
-        pl.DataFrame({f"c{i}": [1.0]}) for i in range(depth)
+@pytest.mark.parametrize(
+    "n_dfs",
+    [3, 4, 5],  # balanced tree +/- 1
+)
+def test_union_align_associativity_26788(how: ConcatMethod, n_dfs: int) -> None:
+    # create every possible key combination over `n_dfs` dataframes
+    n_dfs = n_dfs
+    keys = [
+        [x for x in range(1 << n_dfs) if not (x >> (n_dfs - 1 - i) & 1)]
+        for i in range(n_dfs)
     ]
-    expected = pl.concat(dfs_alt, how="horizontal")
+    dfs = [
+        pl.DataFrame({"k": key})
+        .with_columns((i * 100 + pl.col.k).alias(f"v_{i}"))
+        .lazy()
+        for i, key in enumerate(keys)
+    ]
 
-    assert_frame_equal(out, expected, check_row_order=False)
+    chained_from_left = dfs[0]
+    for df in dfs[1:]:
+        chained_from_left = pl.union([chained_from_left, df], how=how)
+
+    full = pl.union(dfs, how=how)
+    assert_frame_equal(chained_from_left, full, check_row_order=False)


### PR DESCRIPTION
fixes #26788

The reference issue shows how a `concat(.., how="align")` on many dfs generates a deep (O(n)) Join plan that leads to stack overflow on Rayon and a segfault. This happens when `parallel==true` in eager.

The change is two-fold:
(a) add `#[recursive]` to `JoinExec::execute()` to allow the stack to grow, if it has to
(b) switch to a balanced join tree that is not one-sided: the plan depth drops from O(n) to O(log(n)), while the expression arena size drops from O(n^2) to O(n.log(n)).

UPDATE:
(1) Associativity (and therefore tree rebalancing only holds for `align_full`, and `align_inner` - adjusted
(2) The other align options, ie `align_left` and `align_right` can be refactor to be at most `O(log(n)` deep if we use a two-stage, whereby we first join `df[0]` with `df[n]` and then reduce with no worse than a balanced tree. This requires further investigation and is out of scope for this PR.
(3) The test harness now focuses on exhaustive correctness.

One of these is sufficient in some cases, but having both gives us a safety net. We could also switch to a non-recursive stack-based implementation in the execution to completely eliminate the stack overflow risk.

For `concat` and `union` and `align_full` or `align_inner` we have (a) and (b). Because of the prior work on `align_frames` (ref the use of `post_align_collect`, however that is insufficient), we only have (a) for now, and subsequent rebalancing of the tree will be moved to a separate PR.

Performance illustration: for (b) on 5000 dfs with the provided MRE, in debug build, the execution goes from 3 min to 3 seconds.

Kindly review for correctness, especially: (a) whether join associativity holds for all parameter combinations, and (b) the use of `#[recursive]`).


