### PR TITLE
refactor: Add private `_expand_paths` scan function

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -1880,7 +1880,10 @@ impl LazyFrame {
                 unified_scan_args,
                 ..
             } if unified_scan_args.row_index.is_none()
-                && !matches!(&**scan_type, FileScanDsl::Anonymous { .. }) =>
+                && !matches!(
+                    &**scan_type,
+                    FileScanDsl::Anonymous { .. } | FileScanDsl::ExpandedPaths { .. }
+                ) =>
             {
                 let DslPlan::Scan {
                     sources,

--- a/crates/polars-mem-engine/src/scan_predicate/functions.rs
+++ b/crates/polars-mem-engine/src/scan_predicate/functions.rs
@@ -488,6 +488,7 @@ where
 
             #[cfg(feature = "scan_lines")]
             FileScanIR::Lines { name: _ } => {},
+            FileScanIR::ExpandedPaths { name: _ } => {},
 
             FileScanIR::Anonymous {
                 options: _,

--- a/crates/polars-plan/dsl-schema-hashes.json
+++ b/crates/polars-plan/dsl-schema-hashes.json
@@ -60,7 +60,7 @@
   "Field": "dd95c2b6d7aa44004b900ef31fcf18e70f862d97488ef46c67b7c64c226b50d8",
   "Field2": "5a81d8772b4c18be0a0de8fc79d433d4b1d54b4008e211f2ca9217c15cf5611c",
   "FileProviderType": "330497d01ca3e4ab79e838481eeab485603958a74534e214a9962e396c5b1770",
-  "FileScanDsl": "aec02dec7ace1d00b449f2f03fe5dc17b2d668cad483a74bc83ad5aee4b14981",
+  "FileScanDsl": "ed77d7dc8af8845915011232bab3c31a90a1755c8e3897cd1473c435eb75accd",
   "FileSinkOptions": "edebcf5e3965add5e4fd1be14ca6bdddc55fa22e6e829dca04beb321de0c992c",
   "FileWriteFormat": "1a685aba7dd5d6c0aefc99a9060d1b57f166ea44ef57ad0d0d0c565dbabda811",
   "FillNullStrategy": "459a9a9702415f9ca9e5218bb573609a60291e73162c38fbc046c97feb1b7500",

--- a/crates/polars-plan/src/dsl/builder_dsl.rs
+++ b/crates/polars-plan/src/dsl/builder_dsl.rs
@@ -96,6 +96,20 @@ impl DslBuilder {
         .into())
     }
 
+    pub fn expand_paths(
+        sources: ScanSources,
+        unified_scan_args: UnifiedScanArgs,
+        name: PlSmallStr,
+    ) -> PolarsResult<Self> {
+        Ok(DslPlan::Scan {
+            sources,
+            unified_scan_args: Box::new(unified_scan_args),
+            scan_type: Box::new(FileScanDsl::ExpandedPaths { name }),
+            cached_ir: Default::default(),
+        }
+        .into())
+    }
+
     #[allow(clippy::too_many_arguments)]
     #[cfg(feature = "csv")]
     pub fn scan_csv(

--- a/crates/polars-plan/src/dsl/file_scan/mod.rs
+++ b/crates/polars-plan/src/dsl/file_scan/mod.rs
@@ -46,16 +46,24 @@ const _: () = {
 /// Note: This is cheaply cloneable.
 pub enum FileScanDsl {
     #[cfg(feature = "csv")]
-    Csv { options: Arc<CsvReadOptions> },
+    Csv {
+        options: Arc<CsvReadOptions>,
+    },
 
     #[cfg(feature = "json")]
-    NDJson { options: NDJsonReadOptions },
+    NDJson {
+        options: NDJsonReadOptions,
+    },
 
     #[cfg(feature = "parquet")]
-    Parquet { options: ParquetOptions },
+    Parquet {
+        options: ParquetOptions,
+    },
 
     #[cfg(feature = "ipc")]
-    Ipc { options: IpcScanOptions },
+    Ipc {
+        options: IpcScanOptions,
+    },
 
     #[cfg(feature = "python")]
     PythonDataset {
@@ -63,7 +71,13 @@ pub enum FileScanDsl {
     },
 
     #[cfg(feature = "scan_lines")]
-    Lines { name: PlSmallStr },
+    Lines {
+        name: PlSmallStr,
+    },
+
+    ExpandedPaths {
+        name: PlSmallStr,
+    },
 
     #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(skip))]
     Anonymous {
@@ -83,10 +97,14 @@ const _: () = {
 /// Note: This is cheaply cloneable.
 pub enum FileScanIR {
     #[cfg(feature = "csv")]
-    Csv { options: Arc<CsvReadOptions> },
+    Csv {
+        options: Arc<CsvReadOptions>,
+    },
 
     #[cfg(feature = "json")]
-    NDJson { options: NDJsonReadOptions },
+    NDJson {
+        options: NDJsonReadOptions,
+    },
 
     #[cfg(feature = "parquet")]
     Parquet {
@@ -109,7 +127,13 @@ pub enum FileScanIR {
     },
 
     #[cfg(feature = "scan_lines")]
-    Lines { name: PlSmallStr },
+    Lines {
+        name: PlSmallStr,
+    },
+
+    ExpandedPaths {
+        name: PlSmallStr,
+    },
 
     #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(skip))]
     Anonymous {
@@ -364,7 +388,6 @@ mod _file_scan_eq_hash {
     use std::hash::{Hash, Hasher};
     use std::sync::Arc;
 
-    #[cfg(feature = "scan_lines")]
     use polars_utils::pl_str::PlSmallStr;
 
     use super::FileScanIR;
@@ -417,7 +440,13 @@ mod _file_scan_eq_hash {
         },
 
         #[cfg(feature = "scan_lines")]
-        Lines { name: &'a PlSmallStr },
+        Lines {
+            name: &'a PlSmallStr,
+        },
+
+        ExpandedPaths {
+            name: &'a PlSmallStr,
+        },
 
         Anonymous {
             options: &'a crate::dsl::AnonymousScanOptions,
@@ -461,6 +490,8 @@ mod _file_scan_eq_hash {
 
                 #[cfg(feature = "scan_lines")]
                 FileScanIR::Lines { name } => FileScanEqHashWrap::Lines { name },
+
+                FileScanIR::ExpandedPaths { name } => FileScanEqHashWrap::ExpandedPaths { name },
 
                 FileScanIR::Anonymous { options, function } => FileScanEqHashWrap::Anonymous {
                     options,

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
@@ -73,6 +73,7 @@ pub(super) async fn dsl_to_ir(
             },
             #[cfg(feature = "scan_lines")]
             FileScanDsl::Lines { .. } => sources.expand_paths(unified_scan_args).await?,
+            FileScanDsl::ExpandedPaths { .. } => sources.expand_paths(unified_scan_args).await?,
             FileScanDsl::Anonymous { .. } => sources.clone(),
         };
 
@@ -990,8 +991,6 @@ this scan to succeed with an empty DataFrame.",
             .map_err(|e| e.context(failed_here!(python dataset scan)))?,
             #[cfg(feature = "scan_lines")]
             FileScanDsl::Lines { name } => {
-                // We were passed a schema, we don't have to call `parquet_file_info`,
-                // but this does mean we don't have `row_estimation` and `first_metadata`.
                 let schema = Arc::new(Schema::from_iter([(name.clone(), DataType::String)]));
 
                 (
@@ -1001,6 +1000,18 @@ this scan to succeed with an empty DataFrame.",
                         row_estimation: (None, usize::MAX),
                     },
                     FileScanIR::Lines { name },
+                )
+            },
+            FileScanDsl::ExpandedPaths { name } => {
+                let schema = Arc::new(Schema::from_iter([(name.clone(), DataType::String)]));
+
+                (
+                    FileInfo {
+                        schema: schema.clone(),
+                        reader_schema: Some(either::Either::Right(schema.clone())),
+                        row_estimation: (Some(sources.len()), sources.len()),
+                    },
+                    FileScanIR::ExpandedPaths { name },
                 )
             },
             FileScanDsl::Anonymous {

--- a/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
+++ b/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
@@ -309,6 +309,10 @@ pub(super) fn expand_datasets(
                             #[cfg(feature = "scan_lines")]
                             FileScanDsl::Lines { name } => FileScanIR::Lines { name },
 
+                            FileScanDsl::ExpandedPaths { name } => {
+                                FileScanIR::ExpandedPaths { name }
+                            },
+
                             FileScanDsl::Anonymous {
                                 options,
                                 function,

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -363,16 +363,17 @@ impl PredicatePushDown {
                 };
                 let predicate = predicate_at_scan(acc_predicates, predicate.clone(), expr_arena);
 
-                let mut do_optimization = match &*scan_type {
-                    #[cfg(feature = "csv")]
-                    FileScanIR::Csv { .. } => unified_scan_args.pre_slice.is_none(),
-                    FileScanIR::Anonymous { function, .. } => function.allows_predicate_pushdown(),
-                    #[cfg(feature = "json")]
-                    FileScanIR::NDJson { .. } => true,
-                    #[allow(unreachable_patterns)]
-                    _ => true,
-                };
-                do_optimization &= predicate.is_some();
+                let do_optimization = predicate.is_some()
+                    && match &*scan_type {
+                        #[cfg(feature = "csv")]
+                        FileScanIR::Csv { .. } => unified_scan_args.pre_slice.is_none(),
+                        FileScanIR::ExpandedPaths { .. } => false,
+                        FileScanIR::Anonymous { function, .. } => {
+                            function.allows_predicate_pushdown()
+                        },
+                        #[allow(unreachable_patterns)]
+                        _ => true,
+                    };
 
                 let hive_parts = scan_hive_parts;
 

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -475,6 +475,7 @@ impl ProjectionPushDown {
                             FileScanIR::Anonymous { function, .. } => {
                                 function.allows_projection_pushdown()
                             },
+                            FileScanIR::ExpandedPaths { .. } => true,
                             #[cfg(feature = "json")]
                             FileScanIR::NDJson { .. } => true,
                             #[cfg(feature = "ipc")]

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -237,9 +237,11 @@ impl SlicePushDown {
                 #[cfg(feature = "scan_lines")]
                 FileScanIR::Lines { .. } => true,
 
+                FileScanIR::ExpandedPaths { .. } => false,
+
                 // TODO: This can be `true` after Anonymous scan dispatches to new-streaming.
                 FileScanIR::Anonymous { .. } => state.offset == 0,
-            }  =>  {
+            } => {
                 if let Some(sl) = &unified_scan_args.pre_slice {
                     // Already existing slice, dispatch to slice-slice pushdown.
                     let mut unified_scan_args = unified_scan_args.clone();

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -369,6 +369,28 @@ impl PyLazyFrame {
         Ok(lf.into())
     }
 
+    #[cfg(feature = "scan_lines")]
+    #[staticmethod]
+    #[pyo3(signature = (sources, scan_options, name))]
+    fn new_from_expand_paths(
+        sources: Wrap<ScanSources>,
+        scan_options: PyScanOptions,
+        name: PyBackedStr,
+    ) -> PyResult<Self> {
+        let sources = sources.0;
+        let first_path = sources.first_path();
+
+        let unified_scan_args =
+            scan_options.extract_unified_scan_args(first_path.and_then(|x| x.scheme()))?;
+
+        let dsl: DslPlan = DslBuilder::expand_paths(sources, unified_scan_args, (&*name).into())
+            .map_err(to_py_err)?
+            .build();
+        let lf: LazyFrame = dsl.into();
+
+        Ok(lf.into())
+    }
+
     #[staticmethod]
     #[pyo3(signature = (
         dataset_object

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -49,6 +49,9 @@ fn scan_type_to_pyobject(
         },
         #[cfg(feature = "scan_lines")]
         FileScanIR::Lines { name } => Ok(("lines", name.as_str()).into_py_any(py)?),
+        FileScanIR::ExpandedPaths { name } => {
+            Ok(("expanded-paths", name.as_str()).into_py_any(py)?)
+        },
         FileScanIR::PythonDataset { .. } => {
             Err(PyNotImplementedError::new_err("python dataset scan"))
         },

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -1,12 +1,15 @@
 use std::sync::Arc;
 
+use arrow::array::{MutableBinaryViewArray, Utf8ViewArray};
+use arrow::datatypes::ArrowDataType;
 use parking_lot::Mutex;
 use polars_core::frame::{DataFrame, UniqueKeepStrategy};
-use polars_core::prelude::{DataType, PlHashMap, PlHashSet};
+use polars_core::prelude::{DataType, IntoColumn, PlHashMap, PlHashSet};
 use polars_core::scalar::Scalar;
 use polars_core::schema::Schema;
+use polars_core::series::Series;
 use polars_core::{SchemaExtPl, config};
-use polars_error::PolarsResult;
+use polars_error::{PolarsResult, polars_ensure};
 use polars_expr::state::ExecutionState;
 use polars_mem_engine::create_physical_plan;
 use polars_ops::frame::JoinType;
@@ -641,6 +644,62 @@ pub fn lower_ir(
                     df: Arc::new(DataFrame::empty_with_height(num_rows)),
                     disable_morsel_split: disable_morsel_split.unwrap_or(true),
                 }
+            } else if let FileScanIR::ExpandedPaths { name: _ } = &*scan_type {
+                let unsupported_parameter = if unified_scan_args.pre_slice.is_some() {
+                    "pre_slice"
+                } else if unified_scan_args.include_file_paths.is_some() {
+                    "include_file_paths"
+                } else if unified_scan_args.row_index.is_some() {
+                    "row_index"
+                } else if predicate.is_some() {
+                    "predicate"
+                } else if hive_parts.is_some() {
+                    "hive_parts"
+                } else {
+                    ""
+                };
+
+                polars_ensure!(
+                    unsupported_parameter.is_empty(),
+                    ComputeError:
+                    "unsupported parameter for ExpandedPaths scan: '{unsupported_parameter}'"
+                );
+
+                assert!(output_schema.len() <= 1);
+
+                let df = if let Some((name, dtype)) = output_schema.get_at_index(0) {
+                    polars_ensure!(
+                        dtype.is_string(),
+                        ComputeError:
+                        "non-string dtype for ExpandedPaths scan"
+                    );
+
+                    let mut builder = MutableBinaryViewArray::with_capacity(
+                        scan_sources.len().wrapping_mul(
+                            scan_sources
+                                .first()
+                                .map_or(0, |x| x.to_include_path_name().len()),
+                        ),
+                    );
+
+                    for source in scan_sources.iter() {
+                        builder.push_value_ignore_validity(source.to_include_path_name());
+                    }
+
+                    let array: Utf8ViewArray = builder.freeze_with_dtype(ArrowDataType::Utf8View);
+                    let c = Series::from_arrow(name.clone(), Box::new(array))
+                        .unwrap()
+                        .into_column();
+
+                    DataFrame::new(scan_sources.len(), vec![c]).unwrap()
+                } else {
+                    DataFrame::empty_with_height(scan_sources.len())
+                };
+
+                PhysNodeKind::InMemorySource {
+                    df: Arc::new(df),
+                    disable_morsel_split: disable_morsel_split.unwrap_or(true),
+                }
             } else {
                 let file_reader_builder: Arc<dyn FileReaderBuilder> = match &*scan_type {
                     #[cfg(feature = "parquet")]
@@ -717,6 +776,8 @@ pub fn lower_ir(
                             io_metrics: std::sync::OnceLock::new(),
                         }) as _
                     },
+
+                    FileScanIR::ExpandedPaths { name: _ } => unreachable!(),
 
                     FileScanIR::Anonymous { .. } => todo!("unimplemented: AnonymousScan"),
                 };

--- a/py-polars/src/polars/_plr.pyi
+++ b/py-polars/src/polars/_plr.pyi
@@ -888,6 +888,13 @@ class PyLazyFrame:
         scan_options: ScanOptions,
     ) -> PyLazyFrame: ...
     @staticmethod
+    def new_from_expand_paths(
+        sources: Any,
+        *,
+        name: str,
+        scan_options: ScanOptions,
+    ) -> PyLazyFrame: ...
+    @staticmethod
     def new_from_dataset_object(dataset_object: Any) -> PyLazyFrame: ...
     @staticmethod
     def scan_from_python_function_arrow_schema(

--- a/py-polars/src/polars/io/_expand_paths.py
+++ b/py-polars/src/polars/io/_expand_paths.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import contextlib
+from typing import IO, TYPE_CHECKING, Literal
+
+from polars._utils.wrap import wrap_ldf
+from polars.io._utils import get_sources
+from polars.io.cloud.credential_provider._builder import (
+    _init_credential_provider_builder,
+)
+from polars.io.scan_options._options import ScanOptions
+
+with contextlib.suppress(ImportError):  # Module not available when building docs
+    from polars._plr import PyLazyFrame
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+    from polars._typing import StorageOptionsDict
+    from polars.io.cloud import CredentialProviderFunction
+    from polars.lazyframe.frame import LazyFrame
+
+
+def _expand_paths(
+    source: (
+        str
+        | Path
+        | IO[str]
+        | IO[bytes]
+        | bytes
+        | list[str]
+        | list[Path]
+        | list[IO[str]]
+        | list[IO[bytes]]
+    ),
+    *,
+    glob: bool = True,
+    hidden_file_prefix: str | Sequence[str] | None = None,
+    storage_options: StorageOptionsDict | None = None,
+    credential_provider: CredentialProviderFunction | Literal["auto"] | None = "auto",
+) -> LazyFrame:
+    sources = get_sources(source)
+
+    credential_provider_builder = _init_credential_provider_builder(
+        credential_provider, sources, storage_options, "expand_paths"
+    )
+    del credential_provider
+
+    pylf = PyLazyFrame.new_from_expand_paths(
+        sources=sources,
+        scan_options=ScanOptions(
+            row_index=None,
+            pre_slice=None,
+            include_file_paths=None,
+            glob=glob,
+            hidden_file_prefix=(
+                [hidden_file_prefix]
+                if isinstance(hidden_file_prefix, str)
+                else hidden_file_prefix
+            ),
+            storage_options=storage_options,
+            credential_provider=credential_provider_builder,
+        ),
+        name="path",
+    )
+
+    return wrap_ldf(pylf)

--- a/py-polars/tests/unit/io/test_scan.py
+++ b/py-polars/tests/unit/io/test_scan.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import os
 import sys
 import zlib
 from dataclasses import dataclass
@@ -14,6 +15,7 @@ import pytest
 
 import polars as pl
 from polars.exceptions import ComputeError
+from polars.io._expand_paths import _expand_paths
 from polars.testing.asserts.frame import assert_frame_equal
 from tests.unit.io.conftest import format_file_uri, normalize_path_separator_pl
 
@@ -1335,13 +1337,29 @@ def test_scan_file_uri_hostname_component() -> None:
 @pytest.mark.write_disk
 @pytest.mark.parametrize("polars_force_async", ["0", "1"])
 @pytest.mark.parametrize("n_repeats", [1, 2])
+@pytest.mark.parametrize("use_expand_paths_pyfn", [True, False])
 def test_scan_path_expansion_sorting_24528(
     tmp_path: Path,
     polars_force_async: str,
     n_repeats: int,
+    use_expand_paths_pyfn: bool,
     plmonkeypatch: PlMonkeyPatch,
 ) -> None:
     plmonkeypatch.setenv("POLARS_FORCE_ASYNC", polars_force_async)
+
+    def scan_fn(paths: list[Path] | list[str]) -> pl.LazyFrame:
+        return (
+            _expand_paths(paths).select(
+                pl.col("path")
+                .map_elements(
+                    lambda x: pl.scan_parquet(x).collect().item(),
+                    return_dtype=pl.String,
+                )
+                .alias("relpath")
+            )
+            if use_expand_paths_pyfn
+            else pl.scan_parquet(paths)
+        )
 
     relpaths = ["a.parquet", "a/a.parquet", "ab.parquet"]
 
@@ -1350,23 +1368,58 @@ def test_scan_path_expansion_sorting_24528(
         pl.DataFrame({"relpath": p}).write_parquet(tmp_path / p)
 
     assert_frame_equal(
-        pl.scan_parquet(n_repeats * [tmp_path]).collect(),
+        scan_fn(n_repeats * [tmp_path]).collect(),
         pl.DataFrame({"relpath": n_repeats * relpaths}),
     )
 
     assert_frame_equal(
-        pl.scan_parquet(n_repeats * [f"{tmp_path}/**/*"]).collect(),
+        scan_fn(n_repeats * [f"{tmp_path}/**/*"]).collect(),
         pl.DataFrame({"relpath": n_repeats * relpaths}),
     )
 
     assert_frame_equal(
-        pl.scan_parquet(n_repeats * [format_file_uri(tmp_path) + "/"]).collect(),
+        scan_fn(n_repeats * [format_file_uri(tmp_path) + "/"]).collect(),
         pl.DataFrame({"relpath": n_repeats * relpaths}),
     )
 
     assert_frame_equal(
-        pl.scan_parquet(n_repeats * [format_file_uri(f"{tmp_path}/**/*")]).collect(),
+        scan_fn(n_repeats * [format_file_uri(f"{tmp_path}/**/*")]).collect(),
         pl.DataFrame({"relpath": n_repeats * relpaths}),
+    )
+
+
+@pytest.mark.write_disk
+def test_scan_expand_paths_no_glob(tmp_path: Path) -> None:
+    pl.DataFrame(height=1).write_parquet(tmp_path / "data.parquet")
+    pl.DataFrame(height=1).write_parquet(tmp_path / "_HIDDEN_F.parquet")
+
+    assert not (
+        _expand_paths(tmp_path / "*")
+        .select(pl.col("path").str.ends_with("*").any())
+        .collect()
+        .item()
+    )
+
+    if "POLARS_FORCE_ASYNC" not in os.environ:
+        assert (
+            _expand_paths(tmp_path / "*", glob=False)
+            .select(pl.col("path").str.ends_with("*"))
+            .collect()
+            .item()
+        )
+
+    assert (
+        _expand_paths(tmp_path / "*")
+        .select(pl.col("path").str.contains("HIDDEN_F", literal=True).any())
+        .collect()
+        .item()
+    )
+
+    assert not (
+        _expand_paths(tmp_path / "*", hidden_file_prefix="_")
+        .select(pl.col("path").str.contains("HIDDEN_F", literal=True).any())
+        .collect()
+        .item()
     )
 
 


### PR DESCRIPTION
Adds `FileScan::ExpandedPaths` and `_expand_paths` (Python). This will simply return the expanded paths in a column.

* Will be used in https://github.com/pola-rs/polars/pull/26799

E.g.

```python
_expand_paths("hf://datasets/nameexhaustion/polars-docs/hive_dates").collect()

shape: (4, 1)
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ path                                                                                                                                                                                  │
│ ---                                                                                                                                                                                   │
│ str                                                                                                                                                                                   │
╞═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╡
│ https://huggingface.co/datasets/nameexhaustion/polars-docs/resolve/main/hive_dates/date1%3D2024-01-01/date2%3D2023-01-01%252000%253A00%253A00.000000/00000000.parquet                 │
│ https://huggingface.co/datasets/nameexhaustion/polars-docs/resolve/main/hive_dates/date1%3D2024-02-01/date2%3D2023-02-01%252000%253A00%253A00.000000/00000000.parquet                 │
│ https://huggingface.co/datasets/nameexhaustion/polars-docs/resolve/main/hive_dates/date1%3D2024-03-01/date2%3D__HIVE_DEFAULT_PARTITION__/00000000.parquet                             │
│ https://huggingface.co/datasets/nameexhaustion/polars-docs/resolve/main/hive_dates/date1%3D__HIVE_DEFAULT_PARTITION__/date2%3D2023-03-01%252001%253A01%253A01.000001/00000000.parquet │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

print(_expand_paths("hf://datasets/nameexhaustion/polars-docs/**/*.csv").collect())

shape: (10, 1)
┌───────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ path                                                                                                  │
│ ---                                                                                                   │
│ str                                                                                                   │
╞═══════════════════════════════════════════════════════════════════════════════════════════════════════╡
│ https://huggingface.co/datasets/nameexhaustion/polars-docs/resolve/main/iris.csv                      │
│ https://huggingface.co/datasets/nameexhaustion/polars-docs/resolve/main/legislators-historical.csv    │
│ https://huggingface.co/datasets/nameexhaustion/polars-docs/resolve/main/special-chars/%23.csv         │
│ https://huggingface.co/datasets/nameexhaustion/polars-docs/resolve/main/special-chars/%25%20%25.csv   │
│ https://huggingface.co/datasets/nameexhaustion/polars-docs/resolve/main/special-chars/%25.csv         │
│ https://huggingface.co/datasets/nameexhaustion/polars-docs/resolve/main/special-chars/%2520.csv       │
│ https://huggingface.co/datasets/nameexhaustion/polars-docs/resolve/main/special-chars/%5B%2A.csv      │
│ https://huggingface.co/datasets/nameexhaustion/polars-docs/resolve/main/special-chars/-.csv           │
│ https://huggingface.co/datasets/nameexhaustion/polars-docs/resolve/main/special-chars/sp%20ace%2C.csv │
│ https://huggingface.co/datasets/nameexhaustion/polars-docs/resolve/main/special-chars/sp%20ace.csv    │
└───────────────────────────────────────────────────────────────────────────────────────────────────────┘
```
