### PR TITLE
fix: Prevent infinite recursion in streaming `group_by` fallback

### DIFF
--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -615,7 +615,7 @@ fn create_physical_plan_impl(
 
             // We first check if we can partition the group_by on the latest moment.
             let partitionable = partitionable_gb(&keys, &aggs, &input_schema, expr_arena, &apply);
-            if partitionable {
+            if partitionable && build_streaming_executor.is_some() {
                 let from_partitioned_ds = lp_arena.iter(input).any(|(_, lp)| {
                     if let Union { options, .. } = lp {
                         options.from_partitioned_ds

--- a/crates/polars-stream/src/physical_plan/lower_group_by.rs
+++ b/crates/polars-stream/src/physical_plan/lower_group_by.rs
@@ -56,7 +56,7 @@ fn build_group_by_fallback(
         group_by_lp_node,
         &mut lp_arena,
         expr_arena,
-        Some(crate::dispatch::build_streaming_query_executor),
+        None,
     )?);
 
     let group_by_node = PhysNode {

--- a/py-polars/tests/unit/streaming/test_streaming_group_by.py
+++ b/py-polars/tests/unit/streaming/test_streaming_group_by.py
@@ -507,3 +507,26 @@ def test_streaming_group_by_all_null_21593() -> None:
 
     out = df.lazy().group_by(pl.all()).min().collect(engine="streaming")
     assert_frame_equal(df, out, check_row_order=False)
+
+
+def test_streaming_group_by_nested_agg_fallback() -> None:
+    n = 1001
+    df = pl.DataFrame(
+        {
+            "id": range(n),
+            "key": ["aaa" if i < n // 3 else "bbb" for i in range(n)],
+        }
+    )
+
+    # nested agg `col.len().sum()` maps to `Sum(Count(col))` in IR, which the streaming
+    # engine cannot (currently) lower; fallback should have used in-memory engine but
+    # was re-entering the streaming engine, causing infinite recursion and SIGSEGV.
+    res = (
+        df.lazy()
+        .group_by("key")
+        .agg(pl.col("id").len().sum())
+        .sort("key")
+        .collect(engine="streaming")
+    )
+    expected = {("aaa", n // 3), ("bbb", n - n // 3)}
+    assert expected == set(res.rows())


### PR DESCRIPTION
When executing a `group_by` with a nested aggregate that can't be lowered, it was possible to crash with a `SIGSEGV` following a stack overflow caused by an infinite recursion (triggering it also requires the number of rows to be greater than or equal to the value of the `PARTITION_LIMIT` found in `executors/group_by_streaming.rs`).

## Fix

Just a two-liner. In `build_group_by_fallback`, pass `None` instead of `Some(build_streaming_query_executor)` to `create_physical_plan`. The fallback is for expressions the streaming engine can't handle, so re-entering streaming with the same expression fails again, etc. When the streaming builder is `None`, it now skips `GroupByStreamingExec` and uses `GroupByExec`, allowing the operation to succeed.

## Example

Took a while to isolate the problem as it was found in "real" code at work, but the following MWE reproduces it:

```python
import polars as pl

n = 1001

df = pl.DataFrame({
    "id": range(n),
    "key": ["aaa" if i < (n // 3) else "bbb" for i in range(n)],
})

# nested agg `col.len().sum()` maps to `Sum(Count(col))` in IR, which the
# streaming engine cannot (currently) lower; fallback should have used
# in-memory engine but was re-entering streaming, leading to SIGSEGV.
res = (
    df.lazy()
    .group_by("key")
    .agg(pl.col("id").len().sum())
    .sort("key")
    .collect(engine="streaming")
)
```
**Before:**
```python
# Process finished with exit code 139 (interrupted by signal 11:SIGSEGV)
```
**After:**
```python
# shape: (2, 2)
# ┌─────┬─────┐
# │ key ┆ id  │
# │ --- ┆ --- │
# │ str ┆ u32 │
# ╞═════╪═════╡
# │ aaa ┆ 333 │
# │ bbb ┆ 668 │
# └─────┴─────┘
```
