### PR TITLE
feat: Add a convenience `make fresh` command to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,9 @@ FILTER_PIP_WARNINGS=| grep -v "don't match your environment"; test $${PIPESTATUS
 .PHONY: requirements
 requirements:  ## Install/refresh Python project requirements
 	@unset CONDA_PREFIX \
-	&& $(VENV_BIN)/python -m venv $(VENV) --clear \
+	&& python3 -m venv $(VENV) --clear \
 	&& $(VENV_BIN)/python -m pip install --upgrade uv \
+	$(if $(EXTRA_REQUIREMENTS),&& $(VENV_BIN)/uv pip install --upgrade --compile-bytecode -r $(EXTRA_REQUIREMENTS)) \
 	&& $(VENV_BIN)/uv pip install --upgrade --compile-bytecode --no-build \
 	   -r py-polars/requirements-dev.txt \
 	   -r py-polars/requirements-lint.txt \
@@ -96,8 +97,7 @@ requirements:  ## Install/refresh Python project requirements
 
 .PHONY: requirements-all
 requirements-all:  ## Install/refresh all Python requirements (including those needed for CI tests)
-	$(VENV_BIN)/uv pip install --upgrade --compile-bytecode -r py-polars/requirements-ci.txt
-	$(MAKE) requirements
+	$(MAKE) requirements EXTRA_REQUIREMENTS=py-polars/requirements-ci.txt
 
 .PHONY: build
 build: .venv  ## Compile and install Python Polars for development
@@ -181,6 +181,9 @@ update-dsl-schema-hashes:  ## Update the DSL schema hashes file
 
 .PHONY: pre-commit
 pre-commit: fmt py-lint clippy clippy-default  ## Run all code quality checks
+
+.PHONY: fresh
+fresh: clean requirements-all build  ## Clean everything, install all requirements, and rebuild Python Polars for development
 
 .PHONY: clean
 clean:  ## Clean up caches, build artifacts, and the venv


### PR DESCRIPTION
As mentioned/discussed in the Discord, there's now a convenience `make fresh` command 👍
Handy for Rust version updates, clean builds, etc., 

**Equivalent to...**
```
make clean              # cargo, ruff, mypy, pytest caches, build artifacts
make requirements-all   # get all python requirements
make build              # build/install debug-mode python polars 
```
**Also:** 
* Minor improvement for `requirements-all` (use `requirements` so it triggers the `venv` prerequisite)
* Edge-case fix for `requirements` (if `venv` isn't created yet, use the system python3 to clear/recreate it).

---

BTW, you might be surprised at the size of your `ruff` cache - I was! 😄 
```bash
❯ make fresh
Removing cache at: .ruff_cache
  Removed 26854 files, 33.7GiB total
```