### PR TITLE
refactor: Move `stop_and_buffer_pipe_contents` into `joins/utils.rs`

### DIFF
--- a/crates/polars-stream/src/nodes/joins/asof_join.rs
+++ b/crates/polars-stream/src/nodes/joins/asof_join.rs
@@ -12,7 +12,7 @@ use crate::execute::StreamingExecutionState;
 use crate::graph::PortState;
 use crate::morsel::{Morsel, MorselSeq, SourceToken};
 use crate::nodes::ComputeNode;
-use crate::nodes::joins::utils::DataFrameSearchBuffer;
+use crate::nodes::joins::utils::{DataFrameSearchBuffer, stop_and_buffer_pipe_contents};
 use crate::pipe::{PortReceiver, PortSender, RecvPort, SendPort};
 
 #[derive(Debug)]
@@ -208,22 +208,6 @@ impl ComputeNode for AsOfJoinNode {
                 unreachable!();
             },
         }
-    }
-}
-
-/// Tell the sender to this port to stop, and buffer everything that is still in the pipe.
-async fn stop_and_buffer_pipe_contents<F>(port: Option<&mut PortReceiver>, buffer_morsel: &mut F)
-where
-    F: FnMut(DataFrame, MorselSeq),
-{
-    let Some(port) = port else {
-        return;
-    };
-
-    while let Ok(morsel) = port.recv().await {
-        morsel.source_token().stop();
-        let (df, seq, _, _) = morsel.into_inner();
-        buffer_morsel(df, seq);
     }
 }
 

--- a/crates/polars-stream/src/nodes/joins/merge_join.rs
+++ b/crates/polars-stream/src/nodes/joins/merge_join.rs
@@ -354,8 +354,12 @@ async fn find_mergeable_task(
 
     loop {
         if source_token.stop_requested() {
-            stop_and_buffer_pipe_contents(recv_build.as_mut(), build_unmerged).await;
-            stop_and_buffer_pipe_contents(recv_probe.as_mut(), probe_unmerged).await;
+            build_unmerged
+                .stop_and_buffer_from_pipe(recv_build.as_mut())
+                .await;
+            probe_unmerged
+                .stop_and_buffer_from_pipe(recv_probe.as_mut())
+                .await;
             return Ok(());
         }
 
@@ -391,14 +395,18 @@ async fn find_mergeable_task(
             },
             Err(NeedMore::Build | NeedMore::Both) if recv_build.is_some() => {
                 let Ok(m) = recv_build.as_mut().unwrap().recv().await else {
-                    stop_and_buffer_pipe_contents(recv_probe.as_mut(), probe_unmerged).await;
+                    probe_unmerged
+                        .stop_and_buffer_from_pipe(recv_probe.as_mut())
+                        .await;
                     return Ok(());
                 };
                 build_unmerged.push_df(m.into_df());
             },
             Err(NeedMore::Probe | NeedMore::Both) if recv_probe.is_some() => {
                 let Ok(m) = recv_probe.as_mut().unwrap().recv().await else {
-                    stop_and_buffer_pipe_contents(recv_build.as_mut(), build_unmerged).await;
+                    build_unmerged
+                        .stop_and_buffer_from_pipe(recv_build.as_mut())
+                        .await;
                     return Ok(());
                 };
                 probe_unmerged.push_df(m.into_df());
@@ -407,21 +415,6 @@ async fn find_mergeable_task(
                 unreachable!("unexpected NeedMore value: {other:?}");
             },
         }
-    }
-}
-
-/// Tell the sender to this port to stop, and buffer everything that is still in the pipe.
-async fn stop_and_buffer_pipe_contents(
-    port: Option<&mut PortReceiver>,
-    unmerged: &mut DataFrameSearchBuffer,
-) {
-    let Some(port) = port else {
-        return;
-    };
-
-    while let Ok(morsel) = port.recv().await {
-        morsel.source_token().stop();
-        unmerged.push_df(morsel.into_df());
     }
 }
 

--- a/crates/polars-stream/src/nodes/joins/utils.rs
+++ b/crates/polars-stream/src/nodes/joins/utils.rs
@@ -5,6 +5,9 @@ use polars_core::prelude::*;
 use polars_core::schema::SchemaRef;
 use polars_core::series::Series;
 
+use crate::morsel::MorselSeq;
+use crate::pipe::PortReceiver;
+
 #[derive(Clone, Debug)]
 pub(super) struct DataFrameSearchBuffer {
     schema: SchemaRef,
@@ -128,6 +131,28 @@ impl DataFrameSearchBuffer {
             }
         }
         lower
+    }
+
+    pub(super) async fn stop_and_buffer_from_pipe(&mut self, port: Option<&mut PortReceiver>) {
+        stop_and_buffer_pipe_contents(port, &mut |df, _| self.push_df(df)).await
+    }
+}
+
+/// Tell the sender to this port to stop, and buffer everything that is still in the pipe.
+pub(super) async fn stop_and_buffer_pipe_contents<F>(
+    port: Option<&mut PortReceiver>,
+    buffer_morsel: &mut F,
+) where
+    F: FnMut(DataFrame, MorselSeq),
+{
+    let Some(port) = port else {
+        return;
+    };
+
+    while let Ok(morsel) = port.recv().await {
+        morsel.source_token().stop();
+        let (df, seq, _, _) = morsel.into_inner();
+        buffer_morsel(df, seq);
     }
 }
 


### PR DESCRIPTION
Move the duplicated stop_and_buffer_pipe_contents helper from asof_join.rs and merge_join.rs into the shared utils module. Add a DataFrameSearchBuffer::stop_and_buffer_from_pipe convenience method and update all call sites.

:robot: Sonnet 4.6 was used to do git magic. It did not write any code.

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
