### PR TITLE
fix: Restore pyarrow predicate conversion for is_in

### DIFF
--- a/crates/polars-plan/src/plans/python/pyarrow.rs
+++ b/crates/polars-plan/src/plans/python/pyarrow.rs
@@ -217,6 +217,10 @@ pub fn predicate_to_pa(
                     return None;
                 }
 
+                if converted_len == 0 {
+                    return Some("pa.compute.scalar(False)".to_string());
+                }
+
                 if !*nulls_equal {
                     haystack_series = haystack_series.drop_nulls();
                 }

--- a/py-polars/tests/unit/io/test_pyarrow_dataset.py
+++ b/py-polars/tests/unit/io/test_pyarrow_dataset.py
@@ -334,7 +334,7 @@ def test_pyarrow_dataset_is_in_predicate_pushdown_nulls_equality(
     result = q.collect()
     capture = capfd.readouterr().err
 
-    assert "converted pyarrow predicate: (pa.compute.field('id')).isin([])" in capture
+    assert "converted pyarrow predicate: pa.compute.scalar(False)" in capture
     assert "residual predicate: None" in capture
 
     assert_frame_equal(q.collect(), expected)
@@ -350,7 +350,7 @@ def test_pyarrow_dataset_is_in_predicate_pushdown_nulls_equality(
 
     plmonkeypatch.setenv("POLARS_VERBOSE_SENSITIVE", "0")
 
-    assert "converted pyarrow predicate: (pa.compute.field('id')).isin([])" in capture
+    assert "converted pyarrow predicate: pa.compute.scalar(False)" in capture
     assert "residual predicate: None" in capture
 
     assert_frame_equal(q.collect(), expected)


### PR DESCRIPTION
Closes #26802

AI DIsclosure:
1. I used Claude Code while working on this pull request.
2. I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.