### PR TITLE
refactor: Replace iejoin `is_supported_type` macro with a closure in `predicate_pushdown/join.rs`

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
@@ -1070,20 +1070,17 @@ fn take_iejoin_compatible_filters(
                     None,
                 )?;
 
-                macro_rules! is_supported_type {
-                    ($node:expr) => {{
-                        let node = $node;
-                        let field = expr_arena
-                            .get(node)
-                            .to_field(&ToFieldContext::new(expr_arena, output_schema))?;
-                        let dtype = field.dtype();
-
-                        !dtype.is_nested() && dtype.to_physical().is_primitive_numeric()
-                    }};
-                }
+                let is_supported_type = |node: Node| -> PolarsResult<bool> {
+                    let field = expr_arena
+                        .get(node)
+                        .to_field(&ToFieldContext::new(expr_arena, output_schema))?;
+                    let dtype = field.dtype();
+                    let phys = dtype.to_physical();
+                    Ok(!dtype.is_nested() && phys.is_primitive_numeric())
+                };
 
                 // IEJoin only supports numeric.
-                if !is_supported_type!(*left) || !is_supported_type!(*right) {
+                if !is_supported_type(*left)? || !is_supported_type(*right)? {
                     return Ok(None);
                 }
 


### PR DESCRIPTION
<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
