### PR TITLE
fix(rust): Fix initial MutableBooleanArray::extend_constant(count, None) calls

### DIFF
--- a/crates/polars-arrow/src/array/boolean/mutable.rs
+++ b/crates/polars-arrow/src/array/boolean/mutable.rs
@@ -216,16 +216,15 @@ impl MutableBooleanArray {
     }
 
     pub fn extend_null(&mut self, additional: usize) {
-        self.values.extend_constant(additional, false);
         if let Some(validity) = self.validity.as_mut() {
             validity.extend_constant(additional, false)
         } else {
-            self.init_validity();
-            self.validity
-                .as_mut()
-                .unwrap()
-                .extend_constant(additional, false)
+            let mut validity = MutableBitmap::with_capacity(self.values.capacity());
+            validity.extend_constant(self.len(), true);
+            validity.extend_constant(additional, false);
+            self.validity = Some(validity);
         };
+        self.values.extend_constant(additional, false);
     }
 
     fn init_validity(&mut self) {

--- a/crates/polars/tests/it/arrow/array/boolean/mutable.rs
+++ b/crates/polars/tests/it/arrow/array/boolean/mutable.rs
@@ -175,3 +175,25 @@ fn extend_from_self() {
         MutableBooleanArray::from([Some(true), None, Some(true), None])
     );
 }
+
+#[test]
+fn extend_constant_with_none_validity_empty() {
+    let mut a = MutableBooleanArray::new();
+
+    a.extend_constant(2, None);
+
+    assert_eq!(a.validity(), Some(&MutableBitmap::from([false, false])));
+}
+
+#[test]
+fn extend_constant_with_none_validity_nonempty() {
+    let mut a = MutableBooleanArray::new();
+    a.push_value(true);
+
+    a.extend_constant(2, None);
+
+    assert_eq!(
+        a.validity(),
+        Some(&MutableBitmap::from([true, false, false]))
+    );
+}


### PR DESCRIPTION
Preconditions:

* `MutableBooleanArray` is empty and does not have a validity bitmap.
* `MutableBooleanArray` is being extended with `null`s.

What happens in the `None` branch of `extend_constant()`:

* `MutableBooleanArray::init_validity()` creates validity bitmap with N bits, sets the last one to `false`, all others - to `true`.
* `self.validity.extend_constant()` is called, extending the map with another N bits.
* After this, validity bitmap ends up being longer than the value array, leading to errors when attmpting to finalize the array.

Fix

`init_validity()` is being used in other contexts, so I swapped it with the direct initialization of the validity map that allocates capacity, but does not write any bits.

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
