### PR TITLE
feat: Speed up casting primitive to bool by at least 2x

### DIFF
--- a/crates/polars-compute/src/cast/primitive_to.rs
+++ b/crates/polars-compute/src/cast/primitive_to.rs
@@ -7,7 +7,6 @@ use arrow::datatypes::{ArrowDataType, TimeUnit};
 use arrow::offset::{Offset, Offsets};
 use arrow::types::NativeType;
 use num_traits::AsPrimitive;
-use crate::comparisons::TotalEqKernel;
 #[cfg(feature = "dtype-decimal")]
 use num_traits::{Float, ToPrimitive};
 use polars_error::PolarsResult;
@@ -17,6 +16,7 @@ use polars_utils::vec::PushUnchecked;
 
 use super::CastOptionsImpl;
 use super::temporal::*;
+use crate::comparisons::TotalEqKernel;
 #[cfg(feature = "dtype-decimal")]
 use crate::decimal::{dec128_verify_prec_scale, f64_to_dec128, i128_to_dec128};
 


### PR DESCRIPTION
<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->

Noticed that if you have a dataframe like

```python
n = 10_000_000
df = pl.DataFrame({"login_count": [i % 5 for i in range(n)]})
```

It's much faster to do
```
df.select((pl.col("login_count") != 0).alias("has_logins"))
```

than it is to do
```
df.select(pl.col("login_count").cast(pl.Boolean).alias("has_logins"))
```

```
Benchmarking cast(Boolean) vs != 0 on 10,000,000 i64 elements
Randomized order, 1000 iterations each, with warmup

                      p5   median      p95     mean
--------------------------------------------------
  cast(Boolean)    5.20ms    5.27ms    5.52ms    5.32ms
           != 0    1.60ms    1.97ms    3.84ms    2.43ms
          ratio    3.24x     2.68x     1.44x     2.18x
```

But it doesn't have to be this way! `cast` could be just as fast. I've proposed a change in this PR which basically enables simd acceleration by using `tot_ne_kernel_broadcast`. So we go from:

```asm
    cmpq    $0, (%rdi,%r9,8)     ; compare value to zero
    je      skip                  ; BRANCH per element
    shrq    $3, %r8              ; i / 8
    shlb    %cl, %r10b           ; 1 << (i % 8)
    orb     %r10b, (%rdx,%r8)   ; out[byte] |= bit (read-modify-write)
```

to

```asm
    vmovdqu64  (%rdi,%rcx,8), %zmm0   ; load 8 x i64 (512 bits)
    vptestmq   %zmm0, %zmm0, %k0     ; test all 8 != 0 → 8-bit mask
    kmovb      %k0, (%rdx,%r9)        ; store mask byte directly
```

You'll notice that this also means the magnitude of the speedup scales with the element width. Float64s will see the least improvement (around 2x), but casting Int8 to bool should be around 16x faster .

AI use disclaimer: I used Claude (Opus 4.6) to spot the root cause and propose the fix, and to write the benchmarking.
