### PR TITLE
feat: Accept table identifier string in `scan_iceberg()`

### DIFF
--- a/py-polars/docs/source/reference/io.rst
+++ b/py-polars/docs/source/reference/io.rst
@@ -87,6 +87,7 @@ Iceberg
 
    scan_iceberg
    DataFrame.write_iceberg
+   LazyFrame.sink_iceberg
 
 JSON
 ~~~~

--- a/py-polars/src/polars/io/iceberg/_dataset.py
+++ b/py-polars/src/polars/io/iceberg/_dataset.py
@@ -64,7 +64,7 @@ class IcebergTableWrap:
             if verbose():
                 from_ = (
                     "catalog table descriptor: "
-                    f"{self.table_descriptor_.table_identifier = },"
+                    f"{self.table_descriptor_.table_identifier = }, "
                     f"{self.table_descriptor_.catalog_config.class_ = }"
                     if isinstance(self.table_descriptor_, IcebergCatalogTableDescriptor)
                     else f"metadata path: {self.table_descriptor_}"
@@ -142,6 +142,60 @@ class IcebergCatalogConfig:
             name=catalog.name,
             properties=catalog.properties,
         )
+
+    @staticmethod
+    def _from_api_parameter_or_environment_default(
+        catalog: pyiceberg.catalog.Catalog | IcebergCatalogConfig | None,
+        *,
+        fn_name: Literal["scan_iceberg", "sink_iceberg"],
+    ) -> IcebergCatalogConfig:
+        import pyiceberg.catalog
+        from pyiceberg.catalog.noop import NoopCatalog
+
+        import polars._utils.logging
+        from polars._utils.logging import eprint
+
+        if isinstance(catalog, IcebergCatalogConfig):
+            catalog_config = catalog
+        elif isinstance(catalog, pyiceberg.catalog.Catalog):
+            catalog_config = IcebergCatalogConfig.from_catalog(catalog)
+        elif catalog is not None:
+            msg = f"unknown type for `catalog` parameter: {type(catalog)}"
+            raise TypeError(msg)
+        else:
+            if polars._utils.logging.verbose():
+                eprint(f"{fn_name}(): calling pyiceberg.catalog.load_catalog()")
+
+            try:
+                default_catalog = pyiceberg.catalog.load_catalog()
+
+            except Exception as error:
+                static_metadata_hint = (
+                    (
+                        " "
+                        "If you intended to pass a static metadata path, "
+                        "ensure it is an absolute path."
+                    )
+                    if fn_name == "scan_iceberg"
+                    else ""
+                )
+
+                msg = (
+                    f"failed to load catalog for {fn_name}() ({error = }). "
+                    "Configure the default PyIceberg catalog, or pass "
+                    "a catalog via the 'catalog' parameter, or pass a PyIceberg "
+                    "table object instead of the name."
+                    f"{static_metadata_hint}"
+                )
+                raise ComputeError(msg) from error
+
+            catalog_config = IcebergCatalogConfig.from_catalog(default_catalog)
+
+        if catalog_config.class_ == NoopCatalog:
+            msg = f"cannot use NoopCatalog with {fn_name}()"
+            raise TypeError(msg)
+
+        return catalog_config
 
 
 @dataclass(kw_only=True)

--- a/py-polars/src/polars/io/iceberg/_sink.py
+++ b/py-polars/src/polars/io/iceberg/_sink.py
@@ -72,8 +72,6 @@ class IcebergSinkState:
         mode: Literal["append", "overwrite"] = "append",
         storage_options: StorageOptionsDict | None = None,
     ) -> None:
-        import pyiceberg.catalog
-
         table: pyiceberg.table.Table | None = None
 
         if importlib.util.find_spec("pyiceberg.table") is not None:
@@ -85,26 +83,12 @@ class IcebergSinkState:
         table_descriptor: IcebergCatalogTableDescriptor | None = None
 
         if isinstance(target, str):
-            import pyiceberg.catalog
-            from pyiceberg.catalog.noop import NoopCatalog
-
             catalog_config = (
-                catalog
-                if isinstance(catalog, IcebergCatalogConfig)
-                else IcebergCatalogConfig.from_catalog(catalog)
-                if isinstance(catalog, pyiceberg.catalog.Catalog)
-                else IcebergCatalogConfig.from_catalog(pyiceberg.catalog.load_catalog())
-                if catalog is None  # type: ignore[redundant-expr]
-                else None
+                IcebergCatalogConfig._from_api_parameter_or_environment_default(
+                    catalog,
+                    fn_name="sink_iceberg",
+                )
             )
-
-            if catalog_config is None:
-                msg = f"unknown type for `catalog` parameter: {type(catalog)}"
-                raise TypeError(msg)
-
-            if catalog_config.class_ == NoopCatalog:
-                msg = "cannot use NoopCatalog with sink_iceberg"
-                raise TypeError(msg)
 
             table_descriptor = IcebergCatalogTableDescriptor(
                 table_identifier=target,

--- a/py-polars/src/polars/io/iceberg/functions.py
+++ b/py-polars/src/polars/io/iceberg/functions.py
@@ -8,23 +8,30 @@ from polars._utils.unstable import issue_unstable_warning
 from polars._utils.wrap import wrap_ldf
 from polars.io.cloud._utils import NoPickleOption
 from polars.io.iceberg._dataset import (
+    IcebergCatalogConfig,
+    IcebergCatalogTableDescriptor,
     IcebergScanResolver,
     IcebergScanTableSerializer,
     IcebergTableWrap,
 )
 
 if TYPE_CHECKING:
-    from pyiceberg.table import Table
+    import pyiceberg.catalog
+    import pyiceberg.table
 
+    import polars.io.iceberg
     from polars._typing import StorageOptionsDict
     from polars.lazyframe.frame import LazyFrame
 
 
 def scan_iceberg(
-    source: str | Table,
+    source: str | pyiceberg.table.Table,
     *,
     snapshot_id: int | None = None,
     storage_options: StorageOptionsDict | None = None,
+    catalog: pyiceberg.catalog.Catalog
+    | polars.io.iceberg.IcebergCatalogConfig
+    | None = None,
     reader_override: Literal["native", "pyiceberg"] | None = None,
     use_metadata_statistics: bool = True,
     fast_deletion_count: bool | None = None,
@@ -36,10 +43,8 @@ def scan_iceberg(
     Parameters
     ----------
     source
-        A PyIceberg table, or a direct path to the metadata.
-
-        Note: For Local filesystem, absolute and relative paths are supported but
-        for the supported object storages - GCS, Azure and S3 full URI must be provided.
+        A PyIceberg table, or a 'namespace.table_name' identifier string,
+        or an absolute path to the metadata.
     snapshot_id
         The snapshot ID to scan from.
     storage_options
@@ -47,6 +52,9 @@ def scan_iceberg(
         For cloud storages, this may include configurations for authentication etc.
 
         More info is available `here <https://py.iceberg.apache.org/configuration/>`__.
+    catalog
+        PyIceberg catalog to load the table from if the provided `target`
+        was a table name.
     reader_override
         Overrides the reader used to read the data.
 
@@ -175,18 +183,34 @@ def scan_iceberg(
     else:
         fast_deletion_count = False
 
-    table: Table | None = None
+    table: pyiceberg.table.Table | None = None
 
     if importlib.util.find_spec("pyiceberg.table") is not None:
-        from pyiceberg.table import Table
+        import pyiceberg.table
 
-        if isinstance(source, Table):
+        if isinstance(source, pyiceberg.table.Table):
             table = source
+
+    table_descriptor_ = None
+
+    if table is None:
+        source = str(source)
+        table_descriptor_ = (
+            source  # Inferred as static metadata path
+            if "/" in source or "\\" in source
+            else IcebergCatalogTableDescriptor(
+                table_identifier=source,
+                catalog_config=IcebergCatalogConfig._from_api_parameter_or_environment_default(
+                    catalog,
+                    fn_name="scan_iceberg",
+                ),
+            )
+        )
 
     dataset = IcebergScanResolver(
         table=IcebergTableWrap(
             table_=NoPickleOption(table),
-            table_descriptor_=str(source) if table is None else None,
+            table_descriptor_=table_descriptor_,
             serializer=IcebergScanTableSerializer(),
             iceberg_storage_properties=storage_options,
         ),

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -3237,13 +3237,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         Parameters
         ----------
         target
-            Name of the table or the Table object representing an Iceberg table.
-
-            If a table name is provided, `catalog` must also be specified.
-
-            Note: For Local filesystem, absolute and relative paths are supported but
-            for the supported object storages - GCS, Azure and S3 full URI must be
-            provided.
+            A PyIceberg Table object, or a 'namespace.table_name' identifier string.
         mode : {'append', 'overwrite'}
             How to handle existing data.
 
@@ -3251,7 +3245,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             - If 'overwrite', will replace table with new data.
         catalog
             PyIceberg catalog to load the table from if the provided `target`
-            was a table name.
+            was a table identifier.
         storage_options
             Extra options for the storage backends supported by `pyiceberg`.
             For cloud storages, this may include configurations for authentication etc.

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -433,18 +433,10 @@ class _TableDataAllTypes:
 def test_iceberg_sink_parquet_arrow_schema_roundtrip_all_iceberg_types(
     tmp_path: Path,
 ) -> None:
-    catalog = SqlCatalog(
-        "default",
-        uri="sqlite:///:memory:",
-        warehouse=format_file_uri_iceberg(tmp_path / "catalog"),
-    )
-
-    catalog.create_namespace("namespace")
-
     table_data = _TableDataAllTypes.new()
     iceberg_schema = table_data.iceberg_schema
 
-    tbl = catalog.create_table("namespace.table", iceberg_schema)
+    tbl, _ = new_iceberg_table(tmp_path, schema=iceberg_schema)
 
     data_file_path = str(tmp_path / "data.parquet")
 
@@ -789,6 +781,40 @@ def test_scan_iceberg_row_index_renamed(tmp_path: Path) -> None:
                 "file_path": pl.String,
             },
         ),
+    )
+
+
+@pytest.mark.write_disk
+def test_scan_iceberg_table_name(tmp_path: Path) -> None:
+    tbl, catalog = new_iceberg_table(
+        tmp_path,
+        schema=IcebergSchema(
+            NestedField(1, "a", LongType()),
+        ),
+    )
+
+    pl.DataFrame({"a": 1}).lazy().sink_iceberg(tbl, mode="append")
+    pl.DataFrame({"a": 2}).lazy().sink_iceberg(
+        ".".join(tbl.name()),
+        mode="append",
+        catalog=catalog,
+    )
+
+    tbl = catalog.load_table(tbl.name())
+
+    assert_frame_equal(
+        pl.scan_iceberg(tbl).collect(),
+        pl.DataFrame({"a": [2, 1]}),
+    )
+
+    assert_frame_equal(
+        pl.scan_iceberg(tbl.metadata_location).collect(),
+        pl.DataFrame({"a": [2, 1]}),
+    )
+
+    assert_frame_equal(
+        pl.scan_iceberg(".".join(tbl.name()), catalog=catalog).collect(),
+        pl.DataFrame({"a": [2, 1]}),
     )
 
 


### PR DESCRIPTION
E.g. We can now do the following shorthand -
```python
pl.scan_iceberg("namespace.table").collect()
```

Which is equivalent to -
```python
catalog = load_catalog()
table = catalog.load_table("namespace.table")
pl.scan_iceberg(table).collect()
```

#### Metadata path string support
`scan_iceberg()` currently treats string source as a metadata path. This will generally continue to work (i.e. `scan_iceberg('s3://bucket/table/metadata.json')` will still interpret the string as a static metadata path rather than a table identifier. We distinguish between the 2 via the presence of slashes `/` `\`.

The only breakage for the case of scanning the metadata file name of the form `scan_iceberg('metadata.json')` - this can be written instead as `scan_iceberg('./metadata.json')` for it to be treated as a metadata path.

#### Other
Drive-by add sink_iceberg to reference guide.
