### PR TITLE
fix(python): resolve DST ambiguity in from_repr for timezone-aware datetimes

### DIFF
--- a/py-polars/src/polars/_utils/various.py
+++ b/py-polars/src/polars/_utils/various.py
@@ -354,6 +354,25 @@ def _cast_repr_strings_with_schema(
         if tp is not None:
             if tp.base_type() == Datetime:
                 tp_base = Datetime(tp.time_unit)  # type: ignore[union-attr]
+                # Extract the trailing timezone abbreviation (e.g. "CEST", "CET")
+                # before stripping it.  Polars repr strings include the abbreviation
+                # that was in effect at serialisation time; we use it to resolve
+                # any DST ambiguity so that from_repr round-trips correctly.
+                #
+                # DST / summer-time abbreviations indicate the *earlier* (summer)
+                # instant when a wall-clock time occurs twice during a DST transition,
+                # so we map them to ambiguous='earliest'.  All other abbreviations
+                # (standard-time offsets) are mapped to ambiguous='latest'.
+                _dst_abbrevs = [
+                    "AEDT", "ADT", "AKDT", "BST", "CDT", "CEST", "EDT",
+                    "EEST", "MDT", "NDT", "NZDT", "PDT", "WADT", "WEDT",
+                ]
+                tz_abbr = F.col(c).str.extract(r"([A-Z]+)\s*$")
+                ambiguous_expr = (
+                    pl.when(tz_abbr.is_in(_dst_abbrevs))
+                    .then(pl.lit("earliest"))
+                    .otherwise(pl.lit("latest"))
+                )
                 d = F.col(c).str.replace(r"[A-Z ]+$", "")
                 cast_cols[c] = (
                     F.when(d.str.len_bytes() == 19)
@@ -363,7 +382,9 @@ def _cast_repr_strings_with_schema(
                     .str.strptime(tp_base, "%Y-%m-%d %H:%M:%S.%9f")
                 )
                 if getattr(tp, "time_zone", None) is not None:
-                    cast_cols[c] = cast_cols[c].dt.replace_time_zone(tp.time_zone)  # type: ignore[union-attr]
+                    cast_cols[c] = cast_cols[c].dt.replace_time_zone(  # type: ignore[union-attr]
+                        tp.time_zone, ambiguous=ambiguous_expr
+                    )
             elif tp == Date:
                 cast_cols[c] = F.col(c).str.strptime(tp, "%Y-%m-%d")  # type: ignore[arg-type]
             elif tp == Time:


### PR DESCRIPTION
## Problem

`pl.from_repr()` raises a `ComputeError` when the repr contains a timezone-aware datetime that falls inside a DST transition window, even though the timezone abbreviation embedded in the repr string uniquely identifies which instant was meant.

**Minimal reproducer** (from issue #26797):

```python
pl.from_repr("""
shape: (2, 3)
┌─────────────────────────────┬─────────────┬────────────┐
│ timestamp                   ┆ consumption ┆ production │
│ ---                         ┆ ---         ┆ ---        │
│ datetime[μs, Europe/Zurich] ┆ f64         ┆ f64        │
╞═════════════════════════════╪═════════════╪════════════╡
│ 2025-10-26 01:45:00 CEST    ┆ 0.010044    ┆ 0.0        │
│ 2025-10-26 02:00:00 CEST    ┆ 0.010044    ┆ 0.0        │
└─────────────────────────────┴─────────────┴────────────┘
""")
# polars.exceptions.ComputeError: datetime '2025-10-26 02:00:00' is ambiguous
# in time zone 'Europe/Zurich'. Please use  to tell how it should
# be localized.
```

## Root cause

`_cast_repr_strings_with_schema` (in `_utils/various.py`) strips the trailing timezone abbreviation with `str.replace(r"[A-Z ]+$", "")` before calling `strptime`, then calls `replace_time_zone` with the default `ambiguous='raise'`. The abbreviation that was stripped carries the disambiguation information but is discarded.

## Fix

Extract the timezone abbreviation *before* stripping it. Use a lookup against known DST / summer-time abbreviations to build a per-row polars expression that maps to `'earliest'` (for summer-time abbrevs like `CEST`, `BST`, `EDT`, …) or `'latest'` (for standard-time abbrevs like `CET`, `GMT`, `EST`, …). Pass this expression as the `ambiguous` argument to `replace_time_zone`.

This follows the existing pattern in the codebase where `replace_time_zone` accepts an `Expr` for `ambiguous`, and ensures that `from_repr` correctly round-trips any polars-generated repr, including those for DST-transition timestamps.

Closes #26797