### PR TITLE
fix(python): Ensure proper handling of `timedelta` when multiplying with a `Series`

### DIFF
--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -1176,8 +1176,14 @@ class Series:
             return self._from_pyseries(getattr(self._s, op_s)(other._s))
         elif _check_for_numpy(other) and isinstance(other, np.ndarray):
             return self._from_pyseries(getattr(self._s, op_s)(Series(other)._s))
+        elif isinstance(other, timedelta):
+            _s = sequence_to_pyseries(self.name, [other])
+            if "rhs" in op_ffi:
+                return self._from_pyseries(getattr(_s, op_s)(self._s))
+            else:
+                return self._from_pyseries(getattr(self._s, op_s)(_s))
         elif (
-            isinstance(other, (float, date, datetime, timedelta, str))
+            isinstance(other, (float, date, datetime, str))
             and not self.dtype.is_float()
         ):
             _s = sequence_to_pyseries(self.name, [other])

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -2419,3 +2419,28 @@ def test_comparisons_structs_raise() -> None:
             match=r"Series of type Struct\(\{'x': Int64\}\) does not have eq operator",
         ):
             s == rhs  # noqa: B015
+
+
+def test_multiply_series_by_timedelta_26205() -> None:
+    result = pl.Series([1.0, 2.0, 3.0]) * timedelta(seconds=5)
+    expected = pl.Series(
+        [timedelta(seconds=5), timedelta(seconds=10), timedelta(seconds=15)]
+    )
+
+    assert_series_equal(expected, result)
+
+
+def test_multiply_timedelta_by_series_26205() -> None:
+    result = timedelta(seconds=5) * pl.Series([1.0, 2.0, 3.0])
+    expected = pl.Series(
+        [timedelta(seconds=5), timedelta(seconds=10), timedelta(seconds=15)]
+    )
+    assert_series_equal(expected, result)
+
+
+def test_multiply_int_series_by_timedelta_26205() -> None:
+    result = pl.Series([1, 2, 3]) * timedelta(seconds=5)
+    expected = pl.Series(
+        [timedelta(seconds=5), timedelta(seconds=10), timedelta(seconds=15)]
+    )
+    assert_series_equal(expected, result)

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -2426,7 +2426,6 @@ def test_multiply_series_by_timedelta_26205() -> None:
     expected = pl.Series(
         [timedelta(seconds=5), timedelta(seconds=10), timedelta(seconds=15)]
     )
-
     assert_series_equal(expected, result)
 
 


### PR DESCRIPTION
So this PR (https://github.com/pola-rs/polars/pull/26438) seems to have gone stale, so I decided to look into this. Should resolve https://github.com/pola-rs/polars/issues/26205.

@orlp I think this is the right solution based on your comment (https://github.com/pola-rs/polars/pull/26438#pullrequestreview-3757391097).

Rather than including another branch in `__mul__` to handle `timedelta`, I looked at the `_arithmetic` logic. In one of the branches, `timedelta` was only being handled when `self` (the `Series`) was not a float, which is what was causing the bug since, in the MRE, the left `Series` was a float. Thus, the operation fell through to `maybe_cast`. If the element in `maybe_cast` is a `timedelta`, it runs `timedelta_to_int`, which converts it to an integer, causing incorrect results.

The fix was to add an individual branch in `_arithmetic` which handles the case if `other` is a `timedelta`, regardless of the type of `self`.

🤖 Claude Sonnet 4.6 for navigating the codebase. 