### PR TITLE
fix: Block predicate pushdown at IR with embedded slices

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
@@ -19,6 +19,19 @@ pub(super) fn process_join(
     mut acc_predicates: PlHashMap<PlSmallStr, ExprIR>,
     streaming: bool,
 ) -> PolarsResult<IR> {
+    if options.args.slice.is_some() {
+        let lp = IR::Join {
+            input_left,
+            input_right,
+            left_on,
+            right_on,
+            schema,
+            options,
+        };
+
+        return opt.no_pushdown_restart_opt(lp, acc_predicates, lp_arena, expr_arena);
+    }
+
     let schema_left = lp_arena.get(input_left).schema(lp_arena).into_owned();
     let schema_right = lp_arena.get(input_right).schema(lp_arena).into_owned();
 

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -187,24 +187,32 @@ impl PredicatePushDown {
     fn no_pushdown_restart_opt(
         &mut self,
         lp: IR,
-        acc_predicates: PlHashMap<PlSmallStr, ExprIR>,
+        mut acc_predicates: PlHashMap<PlSmallStr, ExprIR>,
         lp_arena: &mut Arena<IR>,
         expr_arena: &mut Arena<AExpr>,
     ) -> PolarsResult<IR> {
         let inputs = lp.inputs();
 
+        let local_predicates: Vec<ExprIR> = acc_predicates.drain().map(|x| x.1).collect();
+
+        assert!(acc_predicates.is_empty());
+        let mut reuse_hashmap: Option<PlHashMap<_, _>> = Some(acc_predicates);
+
         let new_inputs = inputs
             .map(|node| {
                 let alp = lp_arena.take(node);
-                let alp = self.push_down(alp, init_hashmap(None), lp_arena, expr_arena)?;
+                let alp = self.push_down(
+                    alp,
+                    reuse_hashmap.take().unwrap_or_else(|| init_hashmap(None)),
+                    lp_arena,
+                    expr_arena,
+                )?;
                 lp_arena.replace(node, alp);
                 Ok(node)
             })
             .collect::<PolarsResult<Vec<_>>>()?;
         let lp = lp.with_inputs(new_inputs);
 
-        // all predicates are done locally
-        let local_predicates = acc_predicates.into_values().collect::<Vec<_>>();
         Ok(self.optional_apply_predicate(lp, local_predicates, lp_arena, expr_arena))
     }
 
@@ -405,6 +413,11 @@ impl PredicatePushDown {
                 Ok(self.optional_apply_predicate(lp, local_predicates, lp_arena, expr_arena))
             },
             Distinct { input, options } => {
+                if options.slice.is_some() {
+                    let lp = Distinct { input, options };
+                    return self.no_pushdown_restart_opt(lp, acc_predicates, lp_arena, expr_arena);
+                }
+
                 let subset = if let Some(ref subset) = options.subset {
                     subset.as_ref()
                 } else {
@@ -416,20 +429,19 @@ impl PredicatePushDown {
                 }
 
                 let local_predicates = match options.keep_strategy {
-                    UniqueKeepStrategy::Any => {
-                        let condition = |e: &ExprIR| {
-                            // if not elementwise -> to local
-                            !is_elementwise_rec(e.node(), expr_arena)
-                        };
-                        transfer_to_local_by_expr_ir(expr_arena, &mut acc_predicates, condition)
-                    },
+                    UniqueKeepStrategy::Any => vec![],
                     UniqueKeepStrategy::First
                     | UniqueKeepStrategy::Last
                     | UniqueKeepStrategy::None => {
-                        let condition = |name: &PlSmallStr| {
-                            !subset.is_empty() && !names_set.contains(name.as_str())
-                        };
-                        transfer_to_local_by_name(expr_arena, &mut acc_predicates, condition)
+                        if !subset.is_empty() {
+                            transfer_to_local_by_name(
+                                expr_arena,
+                                &mut acc_predicates,
+                                |name: &PlSmallStr| !names_set.contains(name.as_str()),
+                            )
+                        } else {
+                            vec![]
+                        }
                     },
                 };
 
@@ -568,8 +580,14 @@ impl PredicatePushDown {
                 options,
                 acc_predicates,
             ),
-            lp @ Union { .. } => {
-                self.pushdown_and_continue(lp, acc_predicates, lp_arena, expr_arena, false)
+            Union { inputs, options } => {
+                if options.slice.is_some() {
+                    let lp = Union { inputs, options };
+                    self.no_pushdown_restart_opt(lp, acc_predicates, lp_arena, expr_arena)
+                } else {
+                    let lp = Union { inputs, options };
+                    self.pushdown_and_continue(lp, acc_predicates, lp_arena, expr_arena, false)
+                }
             },
             Sort {
                 input,
@@ -578,9 +596,9 @@ impl PredicatePushDown {
                 sort_options,
             } => {
                 let mut local_predicates = Vec::new();
+
                 if slice.is_some() && !acc_predicates.is_empty() {
-                    local_predicates = acc_predicates.into_values().collect();
-                    acc_predicates = init_hashmap(None);
+                    local_predicates.extend(acc_predicates.drain().map(|x| x.1));
                 }
 
                 if let Some((offset, len, None)) = slice

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
@@ -116,35 +116,6 @@ pub(super) fn predicate_at_scan(
 /// Evaluates a condition on the column name inputs of every predicate, where if
 /// the condition evaluates to true on any column name the predicate is
 /// transferred to local.
-pub(super) fn transfer_to_local_by_expr_ir<F>(
-    expr_arena: &Arena<AExpr>,
-    acc_predicates: &mut PlHashMap<PlSmallStr, ExprIR>,
-    mut condition: F,
-) -> Vec<ExprIR>
-where
-    F: FnMut(&ExprIR) -> bool,
-{
-    let mut remove_keys = Vec::with_capacity(acc_predicates.len());
-
-    for predicate in acc_predicates.values() {
-        if condition(predicate) {
-            if let Some(name) = aexpr_to_leaf_names_iter(predicate.node(), expr_arena).next() {
-                remove_keys.push(name);
-            }
-        }
-    }
-    let mut local_predicates = Vec::with_capacity(remove_keys.len());
-    for key in remove_keys {
-        if let Some(pred) = acc_predicates.remove(key) {
-            local_predicates.push(pred)
-        }
-    }
-    local_predicates
-}
-
-/// Evaluates a condition on the column name inputs of every predicate, where if
-/// the condition evaluates to true on any column name the predicate is
-/// transferred to local.
 pub(super) fn transfer_to_local_by_name<F>(
     expr_arena: &Arena<AExpr>,
     acc_predicates: &mut PlHashMap<PlSmallStr, ExprIR>,

--- a/py-polars/tests/unit/lazyframe/test_predicates.py
+++ b/py-polars/tests/unit/lazyframe/test_predicates.py
@@ -1351,8 +1351,7 @@ def test_predicate_slice_pushdown_26816() -> None:
 
     plan = q.explain()
 
-    assert plan.index("SLICE") > plan.index("WITH_COLUMNS")
-    assert plan.index("FILTER") > plan.index("SLICE")
+    assert plan.index("WITH_COLUMNS") < plan.index("SLICE") < plan.index("FILTER")
 
     assert_frame_equal(
         q.collect(),
@@ -1375,3 +1374,83 @@ def test_repeated_slice_pushdown_26815() -> None:
     plan = q.explain()
     assert plan.index("SLICED UNION: (3, 5)") > plan.index("SLICE[offset: -3, len: 3]")
     assert_frame_equal(q.collect(), pl.DataFrame({"a": [5, 6, 7]}))
+
+
+def test_predicate_pushdown_block_at_embedded_slice_union_26824() -> None:
+    q = (
+        pl.concat(
+            [
+                pl.LazyFrame({"a": [0, 1, 2, 3, 4]}),
+                pl.LazyFrame({"a": [5, 6, 7, 8, 9]}),
+            ]
+        )
+        .head(3)
+        .filter(pl.col("a") > 1)
+    )
+
+    plan = q.explain()
+    assert plan.index("FILTER") < plan.index("SLICED UNION")
+    assert_frame_equal(q.collect(), pl.DataFrame({"a": 2}))
+
+
+def test_predicate_pushdown_block_at_embedded_slice_distinct_26824() -> None:
+    q = (
+        pl.LazyFrame({"a": [0, 1, 1]})
+        .unique(maintain_order=True)
+        .head(1)
+        .filter(pl.col("a") >= 1)
+    )
+
+    plan = q.explain()
+    assert plan.index("FILTER") < plan.index("UNIQUE")
+    assert q.collect().height == 0
+
+
+def test_predicate_pushdown_block_at_embedded_slice_join_26824() -> None:
+    q = (
+        pl.LazyFrame({"a": [0, 1, 2], "b": [0, 1, 2]})
+        .join(
+            pl.LazyFrame({"a": [0, 1, 2, 3, 4], "b": [9, 8, 7, 6, 5]}),
+            on="a",
+            how="full",
+            maintain_order="left_right",
+        )
+        .slice(1, 2)
+        .filter(pl.col("b") >= 1)
+    )
+
+    plan = q.explain()
+    assert plan.index("FILTER") < plan.index("JOIN")
+
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            {
+                "a": [1, 2],
+                "b": [1, 2],
+                "a_right": [1, 2],
+                "b_right": [8, 7],
+            }
+        ),
+    )
+
+
+def test_predicate_pushdown_block_at_embedded_slice_groupby_26824() -> None:
+    q = (
+        pl.LazyFrame({"a": [0, 1, 2], "b": [0, 1, 2]})
+        .group_by("a", maintain_order=True)
+        .agg(pl.len())
+        .head(2)
+        .filter(pl.col("a") >= 1)
+    )
+
+    plan = q.explain()
+    assert plan.index("FILTER") < plan.index("AGGREGATE")
+
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            {"a": 1, "len": 1},
+            schema_overrides={"len": pl.get_index_type()},
+        ),
+    )


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/26824

E.g. During predicate pushdown, running into `IR::Union { options, .. }`, where `options.slice` is `Some(_)`, is now checked and properly blocks predicates to happen above the Union. (Previously was not possible to encounter this case as predicate pushdown took place before slice pushdown).
