### PR TITLE
fix: preserve row count for zero-column DataFrames in Arrow export

### DIFF
--- a/crates/polars-python/src/interop/arrow/to_py.rs
+++ b/crates/polars-python/src/interop/arrow/to_py.rs
@@ -120,6 +120,7 @@ pub struct DataFrameStreamIterator {
     dtype: ArrowDataType,
     idx: usize,
     n_chunks: usize,
+    height: usize,
 }
 
 impl DataFrameStreamIterator {
@@ -135,7 +136,8 @@ impl DataFrameStreamIterator {
                 .collect(),
             dtype,
             idx: 0,
-            n_chunks: df.first_col_n_chunks(),
+            n_chunks: usize::max(1, df.first_col_n_chunks()),
+            height: df.height(),
         }
     }
 
@@ -151,17 +153,17 @@ impl Iterator for DataFrameStreamIterator {
         if self.idx >= self.n_chunks {
             None
         } else {
-            // create a batch of the columns with the same chunk no.
-            let batch_cols = self
+            let batch_cols: Vec<ArrayRef> = self
                 .columns
                 .iter()
                 .map(|s| s.to_arrow(self.idx, CompatLevel::newest()))
-                .collect::<Vec<_>>();
+                .collect();
             self.idx += 1;
 
+            let len = batch_cols.first().map_or(self.height, |c| c.len());
             let array = arrow::array::StructArray::new(
                 self.dtype.clone(),
-                batch_cols[0].len(),
+                len,
                 batch_cols,
                 None,
             );

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -70,6 +70,17 @@ def test_arrow_empty_dataframe() -> None:
     assert df2.shape == (0, 1)
 
 
+
+def test_arrow_zero_column_dataframe_preserves_rows() -> None:
+    df = pl.DataFrame(height=5)
+    assert df.shape == (5, 0)
+
+    tbl = pa.table(df)
+    assert tbl.shape == (5, 0)
+
+    tbl2 = df.to_arrow()
+    assert tbl2.shape == (5, 0)
+
 def test_arrow_dict_to_polars() -> None:
     pa_dict = pa.DictionaryArray.from_arrays(
         indices=np.array([0, 1, 2, 3, 1, 0, 2, 3, 3, 2]),


### PR DESCRIPTION
Fixes #26834

`DataFrameStreamIterator` used `first_col_n_chunks()` to determine the number of batches. For zero-column DataFrames this returns 0, producing an empty stream and losing the row count.

The internal `RecordBatchIterExact` in `polars-core/src/frame/mod.rs` already handles this with `usize::max(1, self.first_col_n_chunks())` - this applies the same pattern to the Python C stream export path.

Also stores the frame height so the batch length can be determined even when there are no columns to index into.

```python
df = pl.DataFrame(height=5)
tbl = pa.table(df)
print(tbl.shape)  # was (0, 0), now (5, 0)
```