### PR TITLE
fix: preserve row count for zero-column DataFrames in Arrow stream export

### DIFF
--- a/crates/polars-python/src/interop/arrow/to_py.rs
+++ b/crates/polars-python/src/interop/arrow/to_py.rs
@@ -120,6 +120,7 @@ pub struct DataFrameStreamIterator {
     dtype: ArrowDataType,
     idx: usize,
     n_chunks: usize,
+    height: usize,
 }
 
 impl DataFrameStreamIterator {
@@ -135,7 +136,8 @@ impl DataFrameStreamIterator {
                 .collect(),
             dtype,
             idx: 0,
-            n_chunks: df.first_col_n_chunks(),
+            n_chunks: usize::max(1, df.first_col_n_chunks()),
+            height: df.height(),
         }
     }
 
@@ -151,17 +153,17 @@ impl Iterator for DataFrameStreamIterator {
         if self.idx >= self.n_chunks {
             None
         } else {
-            // create a batch of the columns with the same chunk no.
-            let batch_cols = self
+            let batch_cols: Vec<ArrayRef> = self
                 .columns
                 .iter()
                 .map(|s| s.to_arrow(self.idx, CompatLevel::newest()))
-                .collect::<Vec<_>>();
+                .collect();
             self.idx += 1;
 
+            let len = batch_cols.first().map_or(self.height, |c| c.len());
             let array = arrow::array::StructArray::new(
                 self.dtype.clone(),
-                batch_cols[0].len(),
+                len,
                 batch_cols,
                 None,
             );

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -70,6 +70,17 @@ def test_arrow_empty_dataframe() -> None:
     assert df2.shape == (0, 1)
 
 
+
+def test_arrow_zero_column_dataframe_preserves_rows() -> None:
+    df = pl.DataFrame(height=5)
+    assert df.shape == (5, 0)
+
+    tbl = pa.table(df)
+    assert tbl.shape == (5, 0)
+
+    tbl2 = df.to_arrow()
+    assert tbl2.shape == (5, 0)
+
 def test_arrow_dict_to_polars() -> None:
     pa_dict = pa.DictionaryArray.from_arrays(
         indices=np.array([0, 1, 2, 3, 1, 0, 2, 3, 3, 2]),


### PR DESCRIPTION
## Summary

- Fix `pa.table(df)` losing row count when `df` has zero columns but non-zero rows (e.g. `pl.DataFrame(height=5)`)
- The issue was in `DataFrameStreamIterator` which used `first_col_n_chunks()` to determine how many Arrow batches to emit. For zero-column DataFrames this returns 0, so the iterator produced no batches and PyArrow saw 0 rows.
- Fix: use `max(1, first_col_n_chunks())` so zero-column frames emit one batch, and store the DataFrame height to use as the batch length when there are no columns.
- Added test `test_arrow_zero_column_dataframe_preserves_rows` covering both `pa.table(df)` and `df.to_arrow()`.

Fixes #26834

## Test plan

- [x] Added `test_arrow_zero_column_dataframe_preserves_rows` in `py-polars/tests/unit/interop/test_interop.py`
- [ ] Verify `pa.table(pl.DataFrame(height=5)).shape == (5, 0)`
- [ ] Verify `pl.DataFrame(height=5).to_arrow().shape == (5, 0)`