### PR TITLE
fix(rust): Handle null results from scalar aggregation in list.agg deposit

### DIFF
--- a/crates/polars-expr/src/expressions/eval.rs
+++ b/crates/polars-expr/src/expressions/eval.rs
@@ -21,6 +21,34 @@ use polars_utils::pl_str::PlSmallStr;
 use super::{AggregationContext, PhysicalExpr};
 use crate::state::ExecutionState;
 
+/// Deposit values into null positions according to a validity bitmap.
+///
+/// When scalar aggregations produce null results (e.g., `first()` on an empty
+/// group), those nulls must be merged into the outer validity bitmap before
+/// calling `deposit`, which requires its input to have no nulls.
+fn deposit_with_result_nulls(values: Column, validity: &Bitmap) -> PolarsResult<Column> {
+    if values.null_count() == 0 {
+        return Ok(values.deposit(validity));
+    }
+
+    // Merge result nulls into the validity bitmap: outer-null positions stay
+    // null, and valid outer positions that produced null results also become null.
+    let is_valid_result = values.is_not_null();
+    let filtered = values.filter(&is_valid_result)?;
+
+    let mut combined = BitmapBuilder::with_capacity(validity.len());
+    let mut result_iter = is_valid_result.into_no_null_iter();
+    for outer_valid in validity.iter() {
+        if outer_valid {
+            combined.push(result_iter.next().unwrap_or(false));
+        } else {
+            combined.push(false);
+        }
+    }
+
+    Ok(filtered.deposit(&combined.freeze()))
+}
+
 #[derive(Clone)]
 pub struct EvalExpr {
     input: Arc<dyn PhysicalExpr>,
@@ -173,7 +201,7 @@ impl EvalExpr {
 
             // We didn't have any groups for the `null` values so we have to reinsert them.
             if let Some(validity) = validity {
-                values = values.deposit(&validity);
+                values = deposit_with_result_nulls(values, &validity)?;
             }
 
             Ok(values)
@@ -325,7 +353,7 @@ impl EvalExpr {
 
             // We didn't have any groups for the `null` values so we have to reinsert them.
             if let Some(validity) = validity {
-                values = values.deposit(&validity);
+                values = deposit_with_result_nulls(values, &validity)?;
             }
 
             Ok(values)

--- a/py-polars/tests/unit/operations/namespaces/list/test_eval.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_eval.py
@@ -666,3 +666,33 @@ def test_list_eval_groupby_sample_25796() -> None:
     out = df.group_by("g").agg(pl.col("x").sample(n=2).list.eval(pl.element()))
     expected = pl.DataFrame({"g": [10], "x": [[[1, 1], [1, 1]]]})
     assert_frame_equal(out, expected)
+
+
+def test_list_agg_mixed_nulls_and_empty_lists_26237() -> None:
+    # https://github.com/pola-rs/polars/issues/26237
+    # list.agg with scalar aggregation panics when input has both nulls and empty lists.
+    result = pl.DataFrame({"a": [[1], None, []]}).select(
+        pl.all().list.agg(pl.element().first())
+    )
+    expected = pl.DataFrame({"a": [1, None, None]})
+    assert_frame_equal(result, expected)
+
+    # Also test with other scalar aggregations on mixed null + empty lists.
+    result = pl.DataFrame({"a": [[1, 2], None, []]}).select(
+        pl.all().list.agg(pl.element().sum())
+    )
+    expected = pl.DataFrame({"a": [3, None, 0]})
+    assert_frame_equal(result, expected)
+
+    # Test with only nulls and only empty lists (should already work, regression guard).
+    result = pl.DataFrame({"a": [[1], None]}).select(
+        pl.all().list.agg(pl.element().first())
+    )
+    expected = pl.DataFrame({"a": [1, None]})
+    assert_frame_equal(result, expected)
+
+    result = pl.DataFrame({"a": [[1], []]}).select(
+        pl.all().list.agg(pl.element().first())
+    )
+    expected = pl.DataFrame({"a": [1, None]})
+    assert_frame_equal(result, expected)


### PR DESCRIPTION
## Summary

Fixes #26237

When `list.agg` with a scalar aggregation (e.g., `first()`) encounters empty groups alongside null outer values, the aggregation produces null results that violate `deposit()`'s invariant (`self.null_count() == 0`), causing a panic.

**Root cause:** For input like `[[1], None, []]`, the outer validity bitmap marks indices 0 and 2 as valid. Groups are created for valid elements only — `[0,1]` for `[1]` and `[1,0]` for `[]`. When `first()` runs on the empty group `[1,0]`, it correctly returns null. But `deposit()` asserts its input has no nulls, so it panics.

**Fix:** Added `deposit_with_result_nulls()` helper that merges result nulls from empty-group aggregations into the outer validity bitmap before calling `deposit()`, preserving its invariants. Applied to both list and array evaluation paths.

- Previous attempt (#26424) was rejected because it padded results with nulls, masking the real issue. This approach instead correctly propagates the null information through the validity bitmap.

## Changes

- `crates/polars-expr/src/expressions/eval.rs`: Added `deposit_with_result_nulls()` and applied it to both list and array scalar aggregation paths
- `py-polars/tests/unit/operations/namespaces/list/test_eval.py`: Added regression test covering mixed nulls + empty lists with `first()` and `sum()`

## Test plan

- [x] New test `test_list_agg_mixed_nulls_and_empty_lists_26237` passes
- [x] All 149 existing list eval tests pass (zero regressions)
- [ ] CI passes