### PR TITLE
chore: Ensure `.gitignore` and `.typos.toml` exclude `"_polars_runtime*"` directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ coverage.lcov
 coverage.xml
 profile.json
 polars/vendor
+_polars_runtime*/
 
 # OS
 .DS_Store

--- a/.typos.toml
+++ b/.typos.toml
@@ -8,6 +8,7 @@ extend-exclude = [
   "**/py-polars/src/polars/_utils/nest_asyncio.py",
   "*.nix",
   "**/crates/polars-plan/dsl-schema-hashes.json",
+  "**/_polars_runtime*/",
 ]
 ignore-hidden = false
 


### PR DESCRIPTION
After a bit of a clean/rebuild cycle I found I was getting a gajillion "typos" errors coming from some intermediate artifacts when running a `make pre-commit`. Added the offending directory pattern to `.gitignore` and `.typos.toml`.