### PR TITLE
fix: Fix `{min,max}_by` in streaming engine for Boolean full `{min,max}` value column

### DIFF
--- a/crates/polars-expr/src/reduce/min_max_by.rs
+++ b/crates/polars-expr/src/reduce/min_max_by.rs
@@ -341,11 +341,11 @@ struct BooleanMinSelector;
 struct BooleanMaxSelector;
 
 impl SelectReducer for BooleanMinSelector {
-    type Value = bool;
+    type Value = Option<bool>;
     type Dtype = BooleanType;
 
     fn init(&self) -> Self::Value {
-        true
+        None
     }
 
     fn select_ca(&self, v: &mut Self::Value, ca: &ChunkedArray<Self::Dtype>) -> Option<usize> {
@@ -361,24 +361,24 @@ impl SelectReducer for BooleanMinSelector {
         b: <Self::Dtype as PolarsDataType>::Physical<'_>,
     ) -> bool {
         #[allow(clippy::bool_comparison)]
-        let better = b < *a;
+        let better = a.is_none_or(|a| b <= a);
         if better {
-            *a = b;
+            *a = Some(b);
         }
         better
     }
 
     fn select_combine(&self, a: &mut Self::Value, b: &Self::Value) -> bool {
-        self.select_one(a, *b)
+        self.select_one(a, b.unwrap_or(true))
     }
 }
 
 impl SelectReducer for BooleanMaxSelector {
-    type Value = bool;
+    type Value = Option<bool>;
     type Dtype = BooleanType;
 
     fn init(&self) -> Self::Value {
-        false
+        None
     }
 
     fn select_ca(&self, v: &mut Self::Value, ca: &ChunkedArray<Self::Dtype>) -> Option<usize> {
@@ -394,15 +394,15 @@ impl SelectReducer for BooleanMaxSelector {
         b: <Self::Dtype as PolarsDataType>::Physical<'_>,
     ) -> bool {
         #[allow(clippy::bool_comparison)]
-        let better = b > *a;
+        let better = a.is_none_or(|a| b > a);
         if better {
-            *a = b;
+            *a = Some(b);
         }
         better
     }
 
     fn select_combine(&self, a: &mut Self::Value, b: &Self::Value) -> bool {
-        self.select_one(a, *b)
+        self.select_one(a, b.unwrap_or(false))
     }
 }
 

--- a/py-polars/tests/unit/operations/aggregation/test_aggregations.py
+++ b/py-polars/tests/unit/operations/aggregation/test_aggregations.py
@@ -1480,3 +1480,23 @@ def test_max_by_scalar_26548() -> None:
     out = df.select(pl.col.x.max_by("y").over("g"))
     expected = pl.DataFrame({"x": 1})
     assert_frame_equal(out, expected)
+
+
+@pytest.mark.parametrize(
+    ("agg", "expected"),
+    [
+        (pl.Expr.min_by, 1),
+        (pl.Expr.max_by, 1),
+    ],
+)
+def test_min_max_by_on_boolean_26847(
+    agg: Callable[..., pl.Expr],
+    expected: int,
+) -> None:
+    df = pl.DataFrame({"a": [1], "b": [True]})
+    result = df.select(agg(pl.col("a"), pl.col("b")))
+    assert result.item() == expected
+
+    df = pl.DataFrame({"a": [1] * 10, "b": [True] * 10})
+    result = df.select(agg(pl.col("a"), pl.col("b")))
+    assert result.item() == expected


### PR DESCRIPTION
Fixes #26847.

I, initially, used Claude Code to address the problem. But after some back-and-forth, its solutions were bad, so I resolved the problem myself.

The problem is that if the whole column is the same value. The `.select_ca` function never returns a value. This is problematic in `min_by` or `max_by`.