### PR TITLE
feat: Support nested datatypes for `{min,max}_by`

### DIFF
--- a/crates/polars-core/src/chunked_array/arg_min_max.rs
+++ b/crates/polars-core/src/chunked_array/arg_min_max.rs
@@ -7,7 +7,8 @@ use crate::chunked_array::ops::float_sorted_arg_max::{
     float_arg_max_sorted_ascending, float_arg_max_sorted_descending,
 };
 use crate::datatypes::{
-    BinaryChunked, BooleanChunked, PolarsDataType, PolarsNumericType, StringChunked,
+    BinaryChunked, BinaryOffsetChunked, BooleanChunked, PolarsDataType, PolarsNumericType,
+    StringChunked,
 };
 #[cfg(feature = "dtype-categorical")]
 use crate::datatypes::{CategoricalChunked, PolarsCategoricalType};
@@ -118,6 +119,14 @@ pub fn arg_min_binary(ca: &BinaryChunked) -> Option<usize> {
 }
 
 pub fn arg_max_binary(ca: &BinaryChunked) -> Option<usize> {
+    arg_max_physical_generic(ca)
+}
+
+pub fn arg_min_binary_offset(ca: &BinaryOffsetChunked) -> Option<usize> {
+    arg_min_physical_generic(ca)
+}
+
+pub fn arg_max_binary_offset(ca: &BinaryOffsetChunked) -> Option<usize> {
     arg_max_physical_generic(ca)
 }
 

--- a/crates/polars-expr/src/reduce/convert.rs
+++ b/crates/polars-expr/src/reduce/convert.rs
@@ -169,8 +169,24 @@ pub fn into_reduction(
         } => {
             assert!(inner_exprs.len() == 2);
             let input = inner_exprs[0].node();
-            let by = inner_exprs[1].node();
-            let gr = new_min_by_reduction(get_dt(input)?, get_dt(by)?)?;
+            let mut by = inner_exprs[1].node();
+            let input_dtype = get_dt(input)?;
+            let mut by_dtype = get_dt(by)?;
+            if by_dtype.is_nested() {
+                by = AExprBuilder::row_encode(
+                    vec![inner_exprs[1].clone()],
+                    vec![by_dtype.clone()],
+                    RowEncodingVariant::Ordered {
+                        descending: None,
+                        nulls_last: None,
+                        broadcast_nulls: None,
+                    },
+                    expr_arena,
+                )
+                .node();
+                by_dtype = DataType::BinaryOffset;
+            }
+            let gr = new_min_by_reduction(input_dtype, by_dtype)?;
             return Ok((gr, vec![input, by]));
         },
 
@@ -181,8 +197,24 @@ pub fn into_reduction(
         } => {
             assert!(inner_exprs.len() == 2);
             let input = inner_exprs[0].node();
-            let by = inner_exprs[1].node();
-            let gr = new_max_by_reduction(get_dt(input)?, get_dt(by)?)?;
+            let mut by = inner_exprs[1].node();
+            let input_dtype = get_dt(input)?;
+            let mut by_dtype = get_dt(by)?;
+            if by_dtype.is_nested() {
+                by = AExprBuilder::row_encode(
+                    vec![inner_exprs[1].clone()],
+                    vec![by_dtype.clone()],
+                    RowEncodingVariant::Ordered {
+                        descending: None,
+                        nulls_last: None,
+                        broadcast_nulls: None,
+                    },
+                    expr_arena,
+                )
+                .node();
+                by_dtype = DataType::BinaryOffset;
+            }
+            let gr = new_max_by_reduction(input_dtype, by_dtype)?;
             return Ok((gr, vec![input, by]));
         },
 

--- a/crates/polars-expr/src/reduce/min_max_by.rs
+++ b/crates/polars-expr/src/reduce/min_max_by.rs
@@ -4,7 +4,8 @@ use std::marker::PhantomData;
 
 use num_traits::Bounded;
 use polars_core::chunked_array::arg_min_max::{
-    arg_max_binary, arg_max_bool, arg_max_numeric, arg_min_binary, arg_min_bool, arg_min_numeric,
+    arg_max_binary, arg_max_binary_offset, arg_max_bool, arg_max_numeric, arg_min_binary,
+    arg_min_binary_offset, arg_min_bool, arg_min_numeric,
 };
 use polars_core::with_match_physical_integer_polars_type;
 use polars_utils::arg_min_max::ArgMinMax;
@@ -43,6 +44,7 @@ pub fn new_min_by_reduction(
         )),
         Null => Box::new(NullGroupedReduction::new(Scalar::null(dtype))),
         String | Binary => Box::new(SPGR::new(by_dtype, BinaryMinSelector, payload)),
+        BinaryOffset => Box::new(SPGR::new(by_dtype, BinaryOffsetMinSelector, payload)),
         _ if by_dtype.is_integer() || by_dtype.is_temporal() || by_dtype.is_enum() => {
             with_match_physical_integer_polars_type!(by_dtype.to_physical(), |$T| {
                 Box::new(SPGR::new(by_dtype, MinSelector::<$T>(PhantomData), payload))
@@ -94,6 +96,7 @@ pub fn new_max_by_reduction(
         )),
         Null => Box::new(NullGroupedReduction::new(Scalar::null(dtype))),
         String | Binary => Box::new(SPGR::new(by_dtype, BinaryMaxSelector, payload)),
+        BinaryOffset => Box::new(SPGR::new(by_dtype, BinaryOffsetMaxSelector, payload)),
         _ if by_dtype.is_integer() || by_dtype.is_temporal() || by_dtype.is_enum() => {
             with_match_physical_integer_polars_type!(by_dtype.to_physical(), |$T| {
                 Box::new(SPGR::new(by_dtype, MaxSelector::<$T>(PhantomData), payload))
@@ -312,6 +315,89 @@ impl SelectReducer for BinaryMaxSelector {
 
     fn select_ca(&self, v: &mut Self::Value, ca: &ChunkedArray<Self::Dtype>) -> Option<usize> {
         arg_max_binary(ca).filter(|idx| {
+            let val = unsafe { ca.value_unchecked(*idx) };
+            self.select_one(v, val)
+        })
+    }
+
+    fn select_one(
+        &self,
+        a: &mut Self::Value,
+        b: <Self::Dtype as PolarsDataType>::Physical<'_>,
+    ) -> bool {
+        let better = b > a.as_slice();
+        if better {
+            a.clear();
+            a.extend_from_slice(b);
+        }
+        better
+    }
+
+    fn select_combine(&self, a: &mut Self::Value, b: &Self::Value) -> bool {
+        self.select_one(a, b)
+    }
+}
+
+#[derive(Clone)]
+struct BinaryOffsetMinSelector;
+#[derive(Clone)]
+struct BinaryOffsetMaxSelector;
+
+impl SelectReducer for BinaryOffsetMinSelector {
+    type Dtype = BinaryOffsetType;
+    type Value = Option<Vec<u8>>;
+
+    fn init(&self) -> Self::Value {
+        // There's no "maximum string" initializer.
+        None
+    }
+
+    fn select_ca(&self, v: &mut Self::Value, ca: &ChunkedArray<Self::Dtype>) -> Option<usize> {
+        arg_min_binary_offset(ca).filter(|idx| {
+            let val = unsafe { ca.value_unchecked(*idx) };
+            self.select_one(v, val)
+        })
+    }
+
+    fn select_one(
+        &self,
+        a: &mut Self::Value,
+        b: <Self::Dtype as PolarsDataType>::Physical<'_>,
+    ) -> bool {
+        if let Some(av) = a {
+            if b < av.as_slice() {
+                av.clear();
+                av.extend_from_slice(b);
+                true
+            } else {
+                false
+            }
+        } else {
+            *a = Some(b.to_vec());
+            true
+        }
+    }
+
+    fn select_combine(&self, a: &mut Self::Value, b: &Self::Value) -> bool {
+        if let Some(bv) = b {
+            self.select_one(a, bv)
+        } else {
+            false
+        }
+    }
+}
+
+impl SelectReducer for BinaryOffsetMaxSelector {
+    type Dtype = BinaryOffsetType;
+    type Value = Vec<u8>;
+
+    fn init(&self) -> Self::Value {
+        // Empty string is <= any other string, so can initialize max with it.
+        Vec::new()
+    }
+
+    fn select_ca(&self, v: &mut Self::Value, ca: &ChunkedArray<Self::Dtype>) -> Option<usize> {
+        arg_max_binary_offset(ca).filter(|idx| {
             let val = unsafe { ca.value_unchecked(*idx) };
             self.select_one(v, val)
         })

--- a/crates/polars-ops/src/series/ops/arg_min_max.rs
+++ b/crates/polars-ops/src/series/ops/arg_min_max.rs
@@ -1,6 +1,6 @@
 use polars_core::chunked_array::arg_min_max::{
-    arg_max_binary, arg_max_bool, arg_max_numeric, arg_max_str, arg_min_binary, arg_min_bool,
-    arg_min_numeric, arg_min_str,
+    arg_max_binary, arg_max_binary_offset, arg_max_bool, arg_max_numeric, arg_max_str,
+    arg_min_binary, arg_min_binary_offset, arg_min_bool, arg_min_numeric, arg_min_str,
 };
 #[cfg(feature = "dtype-categorical")]
 use polars_core::chunked_array::arg_min_max::{arg_max_cat, arg_min_cat};
@@ -65,6 +65,7 @@ impl ArgAgg for Series {
             Date | Datetime(_, _) | Duration(_) | Time => phys_s.arg_min(),
             String => arg_min_str(self.str().unwrap()),
             Binary => arg_min_binary(self.binary().unwrap()),
+            BinaryOffset => arg_min_binary_offset(self.binary_offset().unwrap()),
             Boolean => arg_min_bool(self.bool().unwrap()),
             dt if dt.is_primitive_numeric() => {
                 with_match_physical_numeric_polars_type!(phys_s.dtype(), |$T| {
@@ -72,6 +73,11 @@ impl ArgAgg for Series {
                     arg_min_numeric(ca)
                 })
             },
+            dt if dt.is_nested() => self
+                .row_encode_ordered(false, false)
+                .ok()?
+                .into_series()
+                .arg_min(),
             _ => None,
         }
     }
@@ -93,6 +99,7 @@ impl ArgAgg for Series {
             Date | Datetime(_, _) | Duration(_) | Time => phys_s.arg_max(),
             String => arg_max_str(self.str().unwrap()),
             Binary => arg_max_binary(self.binary().unwrap()),
+            BinaryOffset => arg_max_binary_offset(self.binary_offset().unwrap()),
             Boolean => arg_max_bool(self.bool().unwrap()),
             dt if dt.is_primitive_numeric() => {
                 with_match_physical_numeric_polars_type!(phys_s.dtype(), |$T| {
@@ -100,6 +107,11 @@ impl ArgAgg for Series {
                     arg_max_numeric(ca)
                 })
             },
+            dt if dt.is_nested() => self
+                .row_encode_ordered(false, false)
+                .ok()?
+                .into_series()
+                .arg_max(),
             _ => None,
         }
     }

--- a/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
@@ -144,15 +144,7 @@ impl IRFunctionExpr {
             #[cfg(feature = "moment")]
             Kurtosis(..) => mapper.with_dtype(DataType::Float64),
             ArgUnique | ArgMin | ArgMax | ArgSort { .. } => mapper.with_dtype(IDX_DTYPE),
-            MinBy | MaxBy => {
-                if fields[1].dtype.is_nested() {
-                    polars_bail!(
-                        InvalidOperation: "cannot use a nested type as `by` argument in `min_by`/`max_by`, got dtype `{}`", fields[1].dtype
-                    )
-                }
-
-                mapper.with_same_dtype()
-            },
+            MinBy | MaxBy => mapper.with_same_dtype(),
             Product => mapper.map_dtype(|dtype| {
                 use DataType as T;
                 match dtype {

--- a/py-polars/tests/unit/operations/aggregation/test_aggregations.py
+++ b/py-polars/tests/unit/operations/aggregation/test_aggregations.py
@@ -1356,12 +1356,37 @@ def test_min_max_by(agg_funcs: Any, by_col: str) -> None:
                 None,
                 datetime(2023, 4, 4),
             ],
+            "array": [
+                [1, 2],
+                [None, 1],
+                [7, 1],
+                [1, 4],
+                None,
+                [7, None],
+            ],
+            "list": [
+                [1],
+                [None, 1],
+                [1, 2],
+                [7],
+                None,
+                [7, None],
+            ],
+            "struct": [
+                {"x": 1, "y": "abc"},
+                {"x": 7, "y": "xyz"},
+                {"x": 7, "y": ""},
+                {"x": 1, "y": None},
+                {"x": None, "y": ""},
+                {"x": 8, "y": "z"},
+            ],
             "g": [1, 1, 1, 2, 2, 2],
         },
         schema_overrides={
             "dec": pl.Decimal(scale=5),
             "cat": pl.Categorical,
             "enum": pl.Enum(["a", "b", "c", "d", "e", "f"]),
+            "array": pl.Array(pl.Int8, 2),
         },
     )
 
@@ -1456,23 +1481,6 @@ def test_min_max_by_series_length_mismatch_26049(
         match=r"expressions must have matching group lengths",
     ):
         q.collect(engine="in-memory")
-
-
-@pytest.mark.parametrize(
-    "by_expr",
-    [
-        pl.struct("b", "c"),
-        pl.concat_list("b", "c"),
-    ],
-)
-def test_min_by_max_by_nested_type_key_26268(by_expr: pl.Expr) -> None:
-    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 6, 5], "c": [7, 5, 2]})
-
-    with pytest.raises(
-        pl.exceptions.InvalidOperationError,
-        match="cannot use a nested type as `by` argument in `min_by`/`max_by`",
-    ):
-        df.select(pl.col("a").min_by(by_expr))
 
 
 def test_max_by_scalar_26548() -> None:


### PR DESCRIPTION
This implements nested datatypes for the `by` argument of `min_by` and `max_by` by dispatching to the row encoding.

Only natural intelligence was used in the making of this PR.
