### PR TITLE
fix: Throw an error if a string is passed to LazyFrame.pivot `on_columns`

### DIFF
--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -8357,8 +8357,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             on_cols = on_columns
         elif isinstance(on_columns, pl.Series):
             on_cols = on_columns.to_frame()
+        elif isinstance(on_columns, str):
+            msg = f"invalid type for `on_columns` argument: {qualified_type_name(on_columns)!r}"
+            raise TypeError(msg)
         else:
-            on_cols = pl.Series(on_columns).to_frame()
+            on_cols = pl.Series(values=on_columns).to_frame()
 
         return self._from_pyldf(
             self._ldf.pivot(

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -695,3 +695,15 @@ def test_pivot_dup_name_rename_26605() -> None:
     lf = pl.LazyFrame({"variable": [], "a": []}).unpivot(["a"], variable_name="other")
     expected = pl.DataFrame(schema={"other": pl.String, "value": pl.Null})
     assert_frame_equal(lf.collect(), expected)
+
+
+def test_pivot_on_columns_str_25862() -> None:
+    df = pl.DataFrame(
+        {
+            "index": ["A", "A", "B", "B"],
+            "data": ["bar", "baz", "bar", "baz"],
+            "value": [1, 2, 3, 4],
+        }
+    )
+    with pytest.raises(TypeError, match="on_columns"):
+        result = df.pivot("data", index="index", values="value", on_columns="bar")


### PR DESCRIPTION
Fixes #25862.

If a string is passed to the `on_columns` argument, it will now throw an error. Originally, I had it dispatch to a single value, but it produced weird behavior.

AI was used, but it was not very useful.
