### PR TITLE
fix: Support grouped `{arg_,}_{min,max}` for Categoricals

### DIFF
--- a/crates/polars-core/src/frame/group_by/aggregations/categorical.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/categorical.rs
@@ -1,0 +1,221 @@
+use super::*;
+use crate::chunked_array::arg_min_max::{arg_max_opt_iter, arg_min_opt_iter};
+
+#[cfg(feature = "dtype-categorical")]
+impl<T: PolarsCategoricalType> CategoricalChunked<T> {
+    /// # Safety
+    /// Groups must be in bounds of the array.
+    pub(crate) unsafe fn agg_min(&self, groups: &GroupsType) -> Series {
+        let mapping = self.get_mapping();
+        // Rechunk to a single array so that random index lookups are O(1) rather than O(chunks).
+        let phys = self.physical().rechunk();
+        let arr = phys.downcast_as_array();
+        let cats: ChunkedArray<T::PolarsPhysical> = match groups {
+            GroupsType::Idx(groups) => {
+                POOL.install(|| {
+                    groups
+                        .into_par_iter()
+                        .map(|(first, idx)| {
+                            if idx.is_empty() {
+                                None
+                            } else if idx.len() == 1 {
+                                // SAFETY: group indices are valid by GroupsType invariant
+                                unsafe { arr.get_unchecked(first as usize) }
+                            } else {
+                                let min_pos = arg_min_opt_iter(idx.iter().map(|&i| {
+                                    // SAFETY: group indices are valid by GroupsType invariant
+                                    unsafe { arr.get_unchecked(i as usize) }.map(|cat| unsafe {
+                                        mapping.cat_to_str_unchecked(cat.as_cat())
+                                    })
+                                }));
+                                // SAFETY: min_pos points to a non-null element by arg_min_opt_iter contract
+                                min_pos.map(|pos| {
+                                    unsafe { arr.get_unchecked(idx[pos] as usize) }.unwrap()
+                                })
+                            }
+                        })
+                        .collect()
+                })
+            },
+            GroupsType::Slice {
+                groups: groups_slice,
+                ..
+            } => {
+                POOL.install(|| {
+                    groups_slice
+                        .par_iter()
+                        .copied()
+                        .map(|[first, len]| {
+                            let min_pos = arg_min_opt_iter(
+                                (first as usize..first as usize + len as usize).map(|i| {
+                                    // SAFETY: slice bounds are valid by GroupsType invariant
+                                    unsafe { arr.get_unchecked(i) }.map(|cat| unsafe {
+                                        mapping.cat_to_str_unchecked(cat.as_cat())
+                                    })
+                                }),
+                            );
+                            // SAFETY: min_pos is within [0, len), so first+min_pos is a valid non-null index
+                            min_pos.map(|pos| {
+                                unsafe { arr.get_unchecked(first as usize + pos) }.unwrap()
+                            })
+                        })
+                        .collect()
+                })
+            },
+        };
+        let result: CategoricalChunked<T> = unsafe {
+            CategoricalChunked::from_cats_and_dtype_unchecked(cats, self.dtype().clone())
+        };
+        result.into_series()
+    }
+
+    /// # Safety
+    /// Groups must be in bounds of the array.
+    pub(crate) unsafe fn agg_max(&self, groups: &GroupsType) -> Series {
+        let mapping = self.get_mapping();
+        // Rechunk to a single array so that random index lookups are O(1) rather than O(chunks).
+        let phys = self.physical().rechunk();
+        let arr = phys.downcast_as_array();
+        let cats: ChunkedArray<T::PolarsPhysical> = match groups {
+            GroupsType::Idx(groups) => {
+                POOL.install(|| {
+                    groups
+                        .into_par_iter()
+                        .map(|(first, idx)| {
+                            if idx.is_empty() {
+                                None
+                            } else if idx.len() == 1 {
+                                // SAFETY: group indices are valid by GroupsType invariant
+                                unsafe { arr.get_unchecked(first as usize) }
+                            } else {
+                                let max_pos = arg_max_opt_iter(idx.iter().map(|&i| {
+                                    // SAFETY: group indices are valid by GroupsType invariant
+                                    unsafe { arr.get_unchecked(i as usize) }.map(|cat| unsafe {
+                                        mapping.cat_to_str_unchecked(cat.as_cat())
+                                    })
+                                }));
+                                // SAFETY: max_pos points to a non-null element by arg_max_opt_iter contract
+                                max_pos.map(|pos| {
+                                    unsafe { arr.get_unchecked(idx[pos] as usize) }.unwrap()
+                                })
+                            }
+                        })
+                        .collect()
+                })
+            },
+            GroupsType::Slice {
+                groups: groups_slice,
+                ..
+            } => {
+                POOL.install(|| {
+                    groups_slice
+                        .par_iter()
+                        .copied()
+                        .map(|[first, len]| {
+                            let max_pos = arg_max_opt_iter(
+                                (first as usize..first as usize + len as usize).map(|i| {
+                                    // SAFETY: slice bounds are valid by GroupsType invariant
+                                    unsafe { arr.get_unchecked(i) }.map(|cat| unsafe {
+                                        mapping.cat_to_str_unchecked(cat.as_cat())
+                                    })
+                                }),
+                            );
+                            // SAFETY: max_pos is within [0, len), so first+max_pos is a valid non-null index
+                            max_pos.map(|pos| {
+                                unsafe { arr.get_unchecked(first as usize + pos) }.unwrap()
+                            })
+                        })
+                        .collect()
+                })
+            },
+        };
+        let result: CategoricalChunked<T> = unsafe {
+            CategoricalChunked::from_cats_and_dtype_unchecked(cats, self.dtype().clone())
+        };
+        result.into_series()
+    }
+
+    /// # Safety
+    /// Groups must be in bounds of the array.
+    pub(crate) unsafe fn agg_arg_min(&self, groups: &GroupsType) -> Series {
+        let mapping = self.get_mapping();
+        // Rechunk to a single array so that random index lookups are O(1) rather than O(chunks).
+        let phys = self.physical().rechunk();
+        let arr = phys.downcast_as_array();
+        match groups {
+            GroupsType::Idx(groups) => {
+                _agg_helper_idx_idx(groups, |(_, idx)| {
+                    if idx.is_empty() {
+                        None
+                    } else {
+                        arg_min_opt_iter(idx.iter().map(|&i| {
+                            // SAFETY: group indices are valid by GroupsType invariant
+                            unsafe { arr.get_unchecked(i as usize) }
+                                .map(|cat| unsafe { mapping.cat_to_str_unchecked(cat.as_cat()) })
+                        }))
+                        .map(|pos| pos as IdxSize)
+                    }
+                })
+            },
+            GroupsType::Slice {
+                groups: groups_slice,
+                ..
+            } => {
+                _agg_helper_slice_idx(groups_slice, |[first, len]| {
+                    if len == 0 {
+                        None
+                    } else {
+                        arg_min_opt_iter((first as usize..first as usize + len as usize).map(|i| {
+                            // SAFETY: slice bounds are valid by GroupsType invariant
+                            unsafe { arr.get_unchecked(i) }
+                                .map(|cat| unsafe { mapping.cat_to_str_unchecked(cat.as_cat()) })
+                        }))
+                        .map(|pos| pos as IdxSize)
+                    }
+                })
+            },
+        }
+    }
+
+    /// # Safety
+    /// Groups must be in bounds of the array.
+    pub(crate) unsafe fn agg_arg_max(&self, groups: &GroupsType) -> Series {
+        let mapping = self.get_mapping();
+        // Rechunk to a single array so that random index lookups are O(1) rather than O(chunks).
+        let phys = self.physical().rechunk();
+        let arr = phys.downcast_as_array();
+        match groups {
+            GroupsType::Idx(groups) => {
+                _agg_helper_idx_idx(groups, |(_, idx)| {
+                    if idx.is_empty() {
+                        None
+                    } else {
+                        arg_max_opt_iter(idx.iter().map(|&i| {
+                            // SAFETY: group indices are valid by GroupsType invariant
+                            unsafe { arr.get_unchecked(i as usize) }
+                                .map(|cat| unsafe { mapping.cat_to_str_unchecked(cat.as_cat()) })
+                        }))
+                        .map(|pos| pos as IdxSize)
+                    }
+                })
+            },
+            GroupsType::Slice {
+                groups: groups_slice,
+                ..
+            } => {
+                _agg_helper_slice_idx(groups_slice, |[first, len]| {
+                    if len == 0 {
+                        None
+                    } else {
+                        arg_max_opt_iter((first as usize..first as usize + len as usize).map(|i| {
+                            // SAFETY: slice bounds are valid by GroupsType invariant
+                            unsafe { arr.get_unchecked(i) }
+                                .map(|cat| unsafe { mapping.cat_to_str_unchecked(cat.as_cat()) })
+                        }))
+                        .map(|pos| pos as IdxSize)
+                    }
+                })
+            },
+        }
+    }
+}

--- a/crates/polars-core/src/frame/group_by/aggregations/mod.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/mod.rs
@@ -1,5 +1,7 @@
 mod agg_list;
 mod boolean;
+#[cfg(feature = "dtype-categorical")]
+mod categorical;
 mod dispatch;
 mod string;
 
@@ -189,6 +191,22 @@ where
     T: PolarsNumericType,
 {
     let ca: ChunkedArray<T> = POOL.install(|| groups.par_iter().copied().map(f).collect());
+    ca.into_series()
+}
+
+pub fn _agg_helper_idx_idx<'a, F>(groups: &'a GroupsIdx, f: F) -> Series
+where
+    F: Fn((IdxSize, &'a IdxVec)) -> Option<IdxSize> + Send + Sync,
+{
+    let ca: IdxCa = POOL.install(|| groups.into_par_iter().map(f).collect());
+    ca.into_series()
+}
+
+pub fn _agg_helper_slice_idx<F>(groups: &[[IdxSize; 2]], f: F) -> Series
+where
+    F: Fn([IdxSize; 2]) -> Option<IdxSize> + Send + Sync,
+{
+    let ca: IdxCa = POOL.install(|| groups.par_iter().copied().map(f).collect());
     ca.into_series()
 }
 

--- a/crates/polars-core/src/frame/group_by/aggregations/string.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/string.rs
@@ -16,22 +16,6 @@ where
     ca.into_series()
 }
 
-pub fn _agg_helper_idx_idx<'a, F>(groups: &'a GroupsIdx, f: F) -> Series
-where
-    F: Fn((IdxSize, &'a IdxVec)) -> Option<IdxSize> + Send + Sync,
-{
-    let ca: IdxCa = POOL.install(|| groups.into_par_iter().map(f).collect());
-    ca.into_series()
-}
-
-pub fn _agg_helper_slice_idx<F>(groups: &[[IdxSize; 2]], f: F) -> Series
-where
-    F: Fn([IdxSize; 2]) -> Option<IdxSize> + Send + Sync,
-{
-    let ca: IdxCa = POOL.install(|| groups.par_iter().copied().map(f).collect());
-    ca.into_series()
-}
-
 impl BinaryChunked {
     #[allow(clippy::needless_lifetimes)]
     pub(crate) unsafe fn agg_min<'a>(&'a self, groups: &GroupsType) -> Series {

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -100,7 +100,7 @@ macro_rules! impl_cat_series {
             #[cfg(feature = "algorithm_group_by")]
             unsafe fn agg_min(&self, groups: &GroupsType) -> Series {
                 if self.0.uses_lexical_ordering() {
-                    unimplemented!()
+                    unsafe { self.0.agg_min(groups) }
                 } else {
                     self.apply_on_phys(|phys| phys.agg_min(groups).$ca_fn().unwrap().clone())
                         .into_series()
@@ -110,7 +110,7 @@ macro_rules! impl_cat_series {
             #[cfg(feature = "algorithm_group_by")]
             unsafe fn agg_max(&self, groups: &GroupsType) -> Series {
                 if self.0.uses_lexical_ordering() {
-                    unimplemented!()
+                    unsafe { self.0.agg_max(groups) }
                 } else {
                     self.apply_on_phys(|phys| phys.agg_max(groups).$ca_fn().unwrap().clone())
                         .into_series()
@@ -120,7 +120,7 @@ macro_rules! impl_cat_series {
             #[cfg(feature = "algorithm_group_by")]
             unsafe fn agg_arg_min(&self, groups: &GroupsType) -> Series {
                 if self.0.uses_lexical_ordering() {
-                    unimplemented!()
+                    unsafe { self.0.agg_arg_min(groups) }
                 } else {
                     self.0.physical().agg_arg_min(groups)
                 }
@@ -129,7 +129,7 @@ macro_rules! impl_cat_series {
             #[cfg(feature = "algorithm_group_by")]
             unsafe fn agg_arg_max(&self, groups: &GroupsType) -> Series {
                 if self.0.uses_lexical_ordering() {
-                    unimplemented!()
+                    unsafe { self.0.agg_arg_max(groups) }
                 } else {
                     self.0.physical().agg_arg_max(groups)
                 }

--- a/py-polars/tests/unit/operations/aggregation/test_aggregations.py
+++ b/py-polars/tests/unit/operations/aggregation/test_aggregations.py
@@ -1369,14 +1369,18 @@ def test_min_max_by(agg_funcs: Any, by_col: str) -> None:
     expected = df.select([agg(pl.col(c)) for c in COLS])
     assert_frame_equal(result, expected)
 
-    # TODO: remove after https://github.com/pola-rs/polars/issues/25906.
-    if by_col != "cat":
-        df = df.drop("cat")
-        cols = [c for c in COLS if c != "cat"]
+    result = df.group_by("g").agg([agg_by(pl.col(c), pl.col(by_col)) for c in COLS])
+    expected = df.group_by("g").agg([agg(pl.col(c)) for c in COLS])
+    assert_frame_equal(result, expected, check_row_order=False)
 
-        result = df.group_by("g").agg([agg_by(pl.col(c), pl.col(by_col)) for c in cols])
-        expected = df.group_by("g").agg([agg(pl.col(c)) for c in cols])
-        assert_frame_equal(result, expected, check_row_order=False)
+
+def test_group_by_categorical_min_max_25906() -> None:
+    df = pl.Series(["a", "b"], dtype=pl.Categorical).to_frame("cat")
+    df = df.with_columns(g=1)
+    result = df.group_by("g").agg(pl.col.cat.min())
+    assert result["cat"].item() == "a"
+    result = df.group_by("g").agg(pl.col.cat.max())
+    assert result["cat"].item() == "b"
 
 
 @pytest.mark.parametrize(("agg", "expected"), [("max", 2), ("min", 0)])

--- a/py-polars/tests/unit/operations/namespaces/array/test_eval.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_eval.py
@@ -311,3 +311,27 @@ def test_arr_agg_with_filter_in_agg_25384(
     q = df.lazy().group_by(keys, maintain_order=True).agg(q_inner)
     out = q.collect().select(pl.col.a).explode("a")
     assert_series_equal(out.to_series(), result)
+
+
+def test_arr_eval_categorical_min_max_25906() -> None:
+    s = pl.Series(
+        "a",
+        [["c", "a", "b"], ["z", "m", "k"]],
+        dtype=pl.Array(pl.Categorical, 3),
+    )
+    assert_series_equal(
+        s.arr.agg(pl.element().min()),
+        pl.Series("a", ["a", "k"], dtype=pl.Categorical),
+    )
+    assert_series_equal(
+        s.arr.agg(pl.element().max()),
+        pl.Series("a", ["c", "z"], dtype=pl.Categorical),
+    )
+    assert_series_equal(
+        s.arr.agg(pl.element().arg_min()),
+        pl.Series("a", [1, 2], dtype=pl.get_index_type()),
+    )
+    assert_series_equal(
+        s.arr.agg(pl.element().arg_max()),
+        pl.Series("a", [0, 0], dtype=pl.get_index_type()),
+    )

--- a/py-polars/tests/unit/operations/namespaces/list/test_eval.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_eval.py
@@ -661,6 +661,30 @@ def test_list_agg_after_slice() -> None:
     assert all(grouped_result.to_series().to_list())
 
 
+def test_list_eval_categorical_min_max_25906() -> None:
+    s = pl.Series(
+        "a",
+        [["c", "a", "b"], ["z", None, "m"], [None, None]],
+        dtype=pl.List(pl.Categorical),
+    )
+    assert_series_equal(
+        s.list.agg(pl.element().min()),
+        pl.Series("a", ["a", "m", None], dtype=pl.Categorical),
+    )
+    assert_series_equal(
+        s.list.agg(pl.element().max()),
+        pl.Series("a", ["c", "z", None], dtype=pl.Categorical),
+    )
+    assert_series_equal(
+        s.list.agg(pl.element().arg_min()),
+        pl.Series("a", [1, 2, None], dtype=pl.get_index_type()),
+    )
+    assert_series_equal(
+        s.list.agg(pl.element().arg_max()),
+        pl.Series("a", [0, 0, None], dtype=pl.get_index_type()),
+    )
+
+
 def test_list_eval_groupby_sample_25796() -> None:
     df = pl.DataFrame({"g": [10, 10], "x": [[1, 1], [1, 1]]})
     out = df.group_by("g").agg(pl.col("x").sample(n=2).list.eval(pl.element()))


### PR DESCRIPTION
Fixes #25906.

This implements `arg_min`, `arg_max`, `min` and `max` for categoricals in aggregation contexts. Each function gets its own specialized kernel, which is almost the same as existing kernels for numerics, but just with category lookups.

The test mentioned in the issue was fixed up, and I added some tests for `list.agg` and `arr.agg` because they also go through this code path.

I used Claude to write the code and tests. I looked at the code and think it is correct and relevant.