### PR TITLE
fix: Raise error instead of panic for unsupported pivot aggregate

### DIFF
--- a/crates/polars-plan/src/plans/builder_ir.rs
+++ b/crates/polars-plan/src/plans/builder_ir.rs
@@ -277,10 +277,9 @@ impl<'a> IRBuilder<'a> {
         apply: Option<PlanCallback<DataFrame, DataFrame>>,
         maintain_order: bool,
         options: Arc<GroupbyOptions>,
-    ) -> Self {
+    ) -> PolarsResult<Self> {
         let current_schema = self.schema();
-        let mut schema = expr_irs_to_schema(&keys, &current_schema, self.expr_arena)
-            .expect("no valid schema can be derived for the key expression");
+        let mut schema = expr_irs_to_schema(&keys, &current_schema, self.expr_arena)?;
 
         #[cfg(feature = "dynamic_group_by")]
         {
@@ -299,8 +298,7 @@ impl<'a> IRBuilder<'a> {
             }
         }
 
-        let mut aggs_schema = expr_irs_to_schema(&aggs, &current_schema, self.expr_arena)
-            .expect("no valid schema can be derived for the agg expression");
+        let mut aggs_schema = expr_irs_to_schema(&aggs, &current_schema, self.expr_arena)?;
 
         // Coerce aggregation column(s) into List unless not needed (auto-implode)
         debug_assert!(aggs_schema.len() == aggs.len());
@@ -321,7 +319,7 @@ impl<'a> IRBuilder<'a> {
             maintain_order,
             options,
         };
-        self.add_alp(lp)
+        Ok(self.add_alp(lp))
     }
 
     pub fn join(

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -978,7 +978,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             }
 
             IRBuilder::new(input, ctxt.expr_arena, ctxt.lp_arena)
-                .group_by(keys, aggs, None, maintain_order, Default::default())
+                .group_by(keys, aggs, None, maintain_order, Default::default())?
                 .build()
         },
         DslPlan::Distinct { input, options } => {

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/group_by.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/group_by.rs
@@ -85,7 +85,7 @@ pub(super) fn process_group_by(
             apply,
             maintain_order,
             options,
-        );
+        )?;
         Ok(builder.build())
     }
 }

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -707,3 +707,9 @@ def test_pivot_on_columns_str_25862() -> None:
     )
     with pytest.raises(TypeError, match="on_columns"):
         result = df.pivot("data", index="index", values="value", on_columns="bar")
+
+
+def test_pivot_unsupported_agg_raises_25860() -> None:
+    df = pl.DataFrame({"index": [0, 0], "data": ["foo", "bar"]})
+    with pytest.raises(pl.exceptions.InvalidOperationError, match="sum"):
+        df.pivot("index", index="index", aggregate_function=pl.element().sum())


### PR DESCRIPTION
## Summary
- Fix panic in `pivot()` when an unsupported aggregate function is applied to an incompatible dtype (e.g. `sum()` on string columns)
- The panic was caused by `.expect()` in `IRBuilder::group_by()` (`builder_ir.rs:303`) when schema derivation failed for an unsupported aggregate expression
- Changed `group_by()` to return `PolarsResult<Self>` so the error propagates as an `InvalidOperationError` instead of panicking

Note: This PR only addresses the panic. The behavioral regression (returning an error instead of `null` like v1.35.2) is tracked separately.

Closes #25860

## Test plan
- [x] Added `test_pivot_unsupported_agg_raises_25860` verifying `InvalidOperationError` is raised instead of panic
