### PR TITLE
feat: Raise error in `.collect_schema()` when `arr.get()` is out-of-bounds

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -378,12 +378,12 @@ impl AExpr {
 
                 #[cfg(feature = "dtype-array")]
                 if let IRFunctionExpr::ArrayExpr(IRArrayFunction::Get(false)) = function
-                    && let DataType::Array(_, shape) = fields[0].dtype()
+                    && let DataType::Array(_, width) = fields[0].dtype()
                     && let AExpr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(index))) =
                         ctx.arena.get(input[1].node())
                 {
-                    polars_ensure!(*index < *shape as i128 && *index >= -(*shape as i128),
-                        ComputeError: "get index is out of bounds"
+                    polars_ensure!(*index < *width as i128 && *index >= -(*width as i128),
+                        ComputeError: "get index {index:?} is out of bounds for array of width {width:?}"
                     )
                 }
 

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -375,6 +375,19 @@ impl AExpr {
 
                 let fields = func_args_to_fields(input, ctx)?;
                 polars_ensure!(!fields.is_empty(), ComputeError: "expression: '{}' didn't get any inputs", function);
+
+                if let IRFunctionExpr::ArrayExpr(IRArrayFunction::Get(false)) = function {
+                    if let DataType::Array(_, shape) = fields[0].dtype() {
+                        if let AExpr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(index))) =
+                            ctx.arena.get(input[1].node())
+                        {
+                            polars_ensure!(*index < *shape as i128 && *index >= -(*shape as i128),
+                                ComputeError: "get index is out of bounds"
+                            )
+                        }
+                    };
+                }
+
                 let out = function.get_field(ctx.schema, &fields)?;
 
                 Ok(out)

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -377,16 +377,14 @@ impl AExpr {
                 polars_ensure!(!fields.is_empty(), ComputeError: "expression: '{}' didn't get any inputs", function);
 
                 #[cfg(feature = "dtype-array")]
-                if let IRFunctionExpr::ArrayExpr(IRArrayFunction::Get(false)) = function {
-                    if let DataType::Array(_, shape) = fields[0].dtype() {
-                        if let AExpr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(index))) =
-                            ctx.arena.get(input[1].node())
-                        {
-                            polars_ensure!(*index < *shape as i128 && *index >= -(*shape as i128),
-                                ComputeError: "get index is out of bounds"
-                            )
-                        }
-                    };
+                if let IRFunctionExpr::ArrayExpr(IRArrayFunction::Get(false)) = function
+                    && let DataType::Array(_, shape) = fields[0].dtype()
+                    && let AExpr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(index))) =
+                        ctx.arena.get(input[1].node())
+                {
+                    polars_ensure!(*index < *shape as i128 && *index >= -(*shape as i128),
+                        ComputeError: "get index is out of bounds"
+                    )
                 }
 
                 let out = function.get_field(ctx.schema, &fields)?;

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -376,6 +376,7 @@ impl AExpr {
                 let fields = func_args_to_fields(input, ctx)?;
                 polars_ensure!(!fields.is_empty(), ComputeError: "expression: '{}' didn't get any inputs", function);
 
+                #[cfg(feature = "dtype-array")]
                 if let IRFunctionExpr::ArrayExpr(IRArrayFunction::Get(false)) = function {
                     if let DataType::Array(_, shape) = fields[0].dtype() {
                         if let AExpr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(index))) =

--- a/py-polars/tests/unit/lazyframe/test_collect_schema.py
+++ b/py-polars/tests/unit/lazyframe/test_collect_schema.py
@@ -49,3 +49,19 @@ def test_collect_schema_unpivot_duplicate() -> None:
         pl.exceptions.DuplicateError, match="duplicate column name 'value'"
     ):
         _ = lf.collect_schema()
+
+
+def test_arr_get_oob_errors_at_schema_26088() -> None:
+    lf = pl.LazyFrame({"arr": [[1, 2, 3]]}).cast({"arr": pl.Array(pl.Int64, shape=3)})
+
+    with pytest.raises(pl.exceptions.ComputeError):
+        lf.select(pl.col("arr").arr.get(5)).collect_schema()
+
+    with pytest.raises(pl.exceptions.ComputeError):
+        lf.select(pl.col("arr").arr.get(-4)).collect_schema()
+
+    lf.select(pl.col("arr").arr.get(2)).collect_schema()
+
+    lf.select(pl.col("arr").arr.get(-1)).collect_schema()
+
+    lf.select(pl.col("arr").arr.get(5, null_on_oob=True)).collect_schema()

--- a/py-polars/tests/unit/operations/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_array.py
@@ -248,8 +248,13 @@ def test_array_get() -> None:
     assert_frame_equal(out_df, expected_df)
 
     # Out-of-bounds index literal.
-    with pytest.raises(ComputeError, match="get index is out of bounds"):
-        out = s.arr.get(100, null_on_oob=False)
+    with pytest.raises(
+        ComputeError,
+        match="get index 100 is out of bounds for array of width 4",
+    ):
+        s.to_frame().lazy().select(
+            pl.first().arr.get(100, null_on_oob=False)
+        ).collect_schema()
 
     # Negative index literal.
     out = s.arr.get(-2, null_on_oob=False)


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/26088.

I believe this is the right place for the fix, but open to other suggestions/solutions. I placed it in `polars-plan/src/plans/aexpr/schema.rs` since it has access to both the shape of the array `.get()` is being called on and the literal value being placed into `.get()`. I checked possibly putting it in `polars-plan/src/plans/aexpr/function_expr/array.rs` , but the literal index is not available at this point for comparison with the array shape. 

The check for comparison of the selected index and shape of the array only happens when the `function` is using `.get()` with `null_on_oob = false`, the data type is an array, and we are dealing with a literal input value for `.get()`. If the check if reached, it checks both positive and negative indices against the shape to ensure the index is not out-of-bounds. 

🤖 Claude Sonnet 4.6 for navigating the codebase, explaining the relationships between files in `polars-plan`, and helping with syntax. 