### PR TITLE
handle dynamic pattern columns in str.replace and str.replace_all

### DIFF
--- a/crates/polars-expr/src/dispatch/strings.rs
+++ b/crates/polars-expr/src/dispatch/strings.rs
@@ -695,30 +695,32 @@ fn replace_n<'a>(
 
             let mut out: StringChunked = ca
                 .into_iter()
-                .zip(pat.into_iter())
-                .zip(val.into_iter())
-                .map(|((opt_src, opt_pat), opt_val)| match (opt_src, opt_pat, opt_val) {
-                    (Some(src), Some(pat_str), Some(val_str)) => {
-                        let actual_pat = if literal || is_literal_pat(pat_str) {
-                            Cow::Owned(escape(pat_str))
-                        } else {
-                            Cow::Borrowed(pat_str)
-                        };
-                        match polars_utils::regex_cache::compile_regex(&actual_pat) {
-                            Ok(reg) => {
-                                let replaced = if literal {
-                                    reg.replace(src, NoExpand(val_str))
-                                } else {
-                                    reg.replace(src, val_str)
-                                };
-                                Some(replaced.into_owned())
-                            },
-                            Err(_) => Some(src.to_owned()),
-                        }
+                .zip(pat)
+                .zip(val)
+                .map(
+                    |((opt_src, opt_pat), opt_val)| match (opt_src, opt_pat, opt_val) {
+                        (Some(src), Some(pat_str), Some(val_str)) => {
+                            let actual_pat = if literal || is_literal_pat(pat_str) {
+                                Cow::Owned(escape(pat_str))
+                            } else {
+                                Cow::Borrowed(pat_str)
+                            };
+                            match polars_utils::regex_cache::compile_regex(&actual_pat) {
+                                Ok(reg) => {
+                                    let replaced = if literal {
+                                        reg.replace(src, NoExpand(val_str))
+                                    } else {
+                                        reg.replace(src, val_str)
+                                    };
+                                    Some(replaced.into_owned())
+                                },
+                                Err(_) => Some(src.to_owned()),
+                            }
+                        },
+                        (Some(src), _, _) => Some(src.to_owned()),
+                        _ => None,
                     },
-                    (Some(src), _, _) => Some(src.to_owned()),
-                    _ => None,
-                })
+                )
                 .collect_trusted();
 
             out.rename(ca.name().clone());
@@ -792,30 +794,32 @@ fn replace_all<'a>(
 
             let mut out: StringChunked = ca
                 .into_iter()
-                .zip(pat.into_iter())
-                .zip(val.into_iter())
-                .map(|((opt_src, opt_pat), opt_val)| match (opt_src, opt_pat, opt_val) {
-                    (Some(src), Some(pat_str), Some(val_str)) => {
-                        let actual_pat = if literal || is_literal_pat(pat_str) {
-                            Cow::Owned(escape(pat_str))
-                        } else {
-                            Cow::Borrowed(pat_str)
-                        };
-                        match polars_utils::regex_cache::compile_regex(&actual_pat) {
-                            Ok(reg) => {
-                                let replaced = if literal {
-                                    reg.replace_all(src, NoExpand(val_str))
-                                } else {
-                                    reg.replace_all(src, val_str)
-                                };
-                                Some(replaced.into_owned())
-                            },
-                            Err(_) => Some(src.to_owned()),
-                        }
+                .zip(pat)
+                .zip(val)
+                .map(
+                    |((opt_src, opt_pat), opt_val)| match (opt_src, opt_pat, opt_val) {
+                        (Some(src), Some(pat_str), Some(val_str)) => {
+                            let actual_pat = if literal || is_literal_pat(pat_str) {
+                                Cow::Owned(escape(pat_str))
+                            } else {
+                                Cow::Borrowed(pat_str)
+                            };
+                            match polars_utils::regex_cache::compile_regex(&actual_pat) {
+                                Ok(reg) => {
+                                    let replaced = if literal {
+                                        reg.replace_all(src, NoExpand(val_str))
+                                    } else {
+                                        reg.replace_all(src, val_str)
+                                    };
+                                    Some(replaced.into_owned())
+                                },
+                                Err(_) => Some(src.to_owned()),
+                            }
+                        },
+                        (Some(src), _, _) => Some(src.to_owned()),
+                        _ => None,
                     },
-                    (Some(src), _, _) => Some(src.to_owned()),
-                    _ => None,
-                })
+                )
                 .collect_trusted();
 
             out.rename(ca.name().clone());

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -1284,9 +1284,7 @@ def test_replace_dynamic_pattern_column() -> None:
     assert out.to_dict(as_series=False) == {"foo": ["NUM abc", "WORD def", "789_ghi"]}
 
     out = df3.select(pl.col("foo").str.replace_all(pl.col("pat"), pl.col("val")))
-    assert out.to_dict(as_series=False) == {
-        "foo": ["NUM NUM", "WORD WORD", "789_ghi"]
-    }
+    assert out.to_dict(as_series=False) == {"foo": ["NUM NUM", "WORD WORD", "789_ghi"]}
 
     # regression test: should work with single thread too
     df4 = pl.DataFrame({"s": ["abc"], "p": ["b"], "v": ["X"]})


### PR DESCRIPTION
Fixes #26789

When both pattern and value are column expressions (not scalar), `str.replace` and `str.replace_all` panic with `dynamic pattern length in 'str.replace' expressions is not supported yet`. Reproduces consistently with `POLARS_MAX_THREADS=1` because single-threaded execution preserves multi-chunk layouts that the multi-threaded path rechunks into a single chunk.

The `(1, len_val)` arm handles scalar pattern + dynamic values, but there was no arm for `(len_pat, len_val)` where both are dynamic. Added element-wise iteration over source, pattern, and value columns for both `replace_n` and `replace_all`, compiling regex per-row via the existing cache.

Added `test_replace_dynamic_pattern_column` covering literal replacement, replace vs replace_all with repeated matches, regex patterns from columns, and a single-row regression guard.
