### PR TITLE
fix: Fix shape error not raised for 0 width inputs with non-0 height for streaming horizontal concat

### DIFF
--- a/crates/polars-stream/src/nodes/zip.rs
+++ b/crates/polars-stream/src/nodes/zip.rs
@@ -36,11 +36,13 @@ struct InputHead {
 }
 
 impl InputHead {
-    fn new(schema: Arc<Schema>, may_broadcast: bool) -> Self {
+    fn new(schema: Arc<Schema>, zip_behavior: ZipBehavior) -> Self {
+        let infer_broadcast = matches!(zip_behavior, ZipBehavior::Broadcast) || schema.is_empty();
+
         Self {
             schema,
             morsels: VecDeque::new(),
-            is_broadcast: if may_broadcast { None } else { Some(false) },
+            is_broadcast: if infer_broadcast { None } else { Some(false) },
             total_len: 0,
             stream_exhausted: false,
         }
@@ -70,7 +72,7 @@ impl InputHead {
 
     fn notify_no_more_morsels(&mut self) {
         if self.is_broadcast.is_none() {
-            self.is_broadcast = Some(self.total_len == 1);
+            self.is_broadcast = Some(self.total_len == 1 || self.shape() == (0, 0));
         }
         self.stream_exhausted = true;
     }
@@ -80,7 +82,7 @@ impl InputHead {
     }
 
     async fn take(&mut self, len: usize) -> DataFrame {
-        let columns: Vec<Column> = if self.is_broadcast.unwrap() {
+        let columns: Vec<Column> = if self.is_broadcast.unwrap() && self.shape() != (0, 0) {
             mm().df(&self.morsels[0].0)
                 .await
                 .columns()
@@ -117,8 +119,8 @@ impl InputHead {
         out
     }
 
-    fn null_shape(&self) -> bool {
-        self.schema.is_empty() && self.total_len == 0
+    fn shape(&self) -> (usize, usize) {
+        (self.total_len, self.schema.len())
     }
 
     fn clear(&mut self) {
@@ -138,7 +140,7 @@ impl ZipNode {
     pub fn new(zip_behavior: ZipBehavior, schemas: Vec<Arc<Schema>>) -> Self {
         let input_heads = schemas
             .into_iter()
-            .map(|s| InputHead::new(s, matches!(zip_behavior, ZipBehavior::Broadcast)))
+            .map(|s| InputHead::new(s, zip_behavior))
             .collect();
         Self {
             zip_behavior,
@@ -200,7 +202,7 @@ impl ComputeNode for ZipNode {
                     let all_len_equal = self
                         .input_heads
                         .iter()
-                        .filter(|h| !h.null_shape())
+                        .filter(|h| h.is_broadcast == Some(false))
                         .all(|h| h.total_len == first_len);
                     polars_ensure!(
                         all_len_equal,
@@ -317,9 +319,8 @@ impl ComputeNode for ZipNode {
                                 Some(token.height())
                             } else {
                                 should_break |= match self.zip_behavior {
-                                    ZipBehavior::Strict => !h.null_shape(),
                                     ZipBehavior::NullExtend => false,
-                                    ZipBehavior::Broadcast => true,
+                                    ZipBehavior::Broadcast | ZipBehavior::Strict => true,
                                 };
                                 None
                             }

--- a/py-polars/tests/unit/functions/test_concat.py
+++ b/py-polars/tests/unit/functions/test_concat.py
@@ -5,6 +5,7 @@ import pytest
 
 import polars as pl
 from polars._typing import ConcatMethod
+from polars.exceptions import ShapeError
 from polars.testing import assert_frame_equal
 
 
@@ -457,3 +458,17 @@ def test_concat_align_associativity_26788(how: ConcatMethod, n_dfs: int) -> None
 
     full = pl.concat(dfs, how=how)
     assert_frame_equal(chained_from_left, full)
+
+
+def test_concat_horizontal_zero_width_height_mismatch_26876() -> None:
+    q = pl.concat(
+        [
+            pl.LazyFrame(height=5),
+            pl.LazyFrame(height=3),
+        ],
+        how="horizontal",
+        strict=True,
+    )
+
+    with pytest.raises(ShapeError):
+        q.collect()


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/26876
* Follow-up to https://github.com/pola-rs/polars/pull/26871
