### PR TITLE
fix: Fix panic on CSV count_rows with FORCE_ASYNC

### DIFF
--- a/crates/polars-plan/src/plans/functions/count.rs
+++ b/crates/polars-plan/src/plans/functions/count.rs
@@ -1,14 +1,17 @@
+use polars_io::cloud::CloudOptions;
+
 use super::*;
 
 pub fn count_rows(
     sources: &ScanSources,
     scan_type: &FileScanIR,
     alias: Option<PlSmallStr>,
+    cloud_options: Option<&CloudOptions>,
 ) -> PolarsResult<DataFrame> {
     feature_gated!("csv", {
         let count: PolarsResult<usize> = match scan_type {
             #[cfg(feature = "csv")]
-            FileScanIR::Csv { options } => count_all_rows_csv(sources, options),
+            FileScanIR::Csv { options } => count_all_rows_csv(sources, options, cloud_options),
             _ => unreachable!(),
         };
         let count = count?;
@@ -25,7 +28,27 @@ pub fn count_rows(
 fn count_all_rows_csv(
     sources: &ScanSources,
     options: &polars_io::prelude::CsvReadOptions,
+    cloud_options: Option<&CloudOptions>,
 ) -> PolarsResult<usize> {
+    let run_async =
+        sources.is_cloud_url() || (sources.is_paths() && polars_config::config().force_async());
+
+    if run_async {
+        if sources.as_paths().is_some() {
+            let sources_clone = sources.clone();
+            feature_gated!("cloud", {
+                polars_io::pl_async::get_runtime().block_in_place_on(
+                    polars_io::file_cache::init_entries_from_uri_list(
+                        (0..sources_clone.len()).map(move |i| {
+                            sources_clone.as_paths().unwrap().get(i).unwrap().clone()
+                        }),
+                        cloud_options,
+                    ),
+                )?;
+            })
+        }
+    }
+
     let parse_options = options.get_parse_options();
 
     sources

--- a/crates/polars-plan/src/plans/functions/mod.rs
+++ b/crates/polars-plan/src/plans/functions/mod.rs
@@ -43,6 +43,7 @@ pub enum FunctionIR {
         sources: ScanSources,
         scan_type: Box<FileScanIR>,
         alias: Option<PlSmallStr>,
+        cloud_options: Option<polars_io::cloud::CloudOptions>,
     },
 
     Unnest {
@@ -95,6 +96,7 @@ impl Hash for FunctionIR {
                 sources,
                 scan_type,
                 alias,
+                ..
             } => {
                 sources.hash(state);
                 scan_type.hash(state);
@@ -206,7 +208,8 @@ impl FunctionIR {
                 sources,
                 scan_type,
                 alias,
-            } => count::count_rows(sources, scan_type, alias.clone()),
+                cloud_options,
+            } => count::count_rows(sources, scan_type, alias.clone(), cloud_options.as_ref()),
             Rechunk => {
                 df.rechunk_mut_par();
                 Ok(df)
@@ -327,6 +330,7 @@ impl Display for FunctionIR {
                 sources,
                 scan_type,
                 alias,
+                ..
             } => {
                 let scan_type: &str = (&(**scan_type)).into();
                 let default_column_name = PlSmallStr::from_static(crate::constants::LEN);

--- a/crates/polars-plan/src/plans/optimizer/count_star.rs
+++ b/crates/polars-plan/src/plans/optimizer/count_star.rs
@@ -54,6 +54,7 @@ impl CountStar {
                             sources: count_star_expr.sources,
                             scan_type: count_star_expr.scan_type,
                             alias: count_star_expr.alias,
+                            cloud_options: count_star_expr.cloud_options,
                         },
                     };
 

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -658,6 +658,7 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<Py<PyAny>> {
                     sources,
                     scan_type,
                     alias,
+                    ..
                 } => {
                     let sources = sources
                         .into_paths()

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -598,3 +598,20 @@ def test_scan_csv_progressive_infer_schema_length(
     for infer_len in [1, 2, 100, n_rows - 1, n_rows, n_rows + 1, None]:
         out = pl.scan_csv(file_path, infer_schema_length=infer_len).collect()
         assert df.schema == out.schema
+
+
+@pytest.mark.write_disk
+def test_scan_csv_count_rows_async_with_schema(
+    plmonkeypatch: PlMonkeyPatch, tmp_path: Path
+) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    file_path = tmp_path / "test.csv"
+
+    plmonkeypatch.setenv("POLARS_FORCE_ASYNC", "1")
+
+    df = pl.DataFrame({"a": range(10)})
+    df.write_csv(file_path)
+
+    schema = pl.Schema({"a": pl.Int64})
+    out = pl.scan_csv(file_path, schema=schema).select(pl.len()).collect()
+    assert out.item() == 10


### PR DESCRIPTION
Fixes #26594

`count_rows` panics when `POLARS_FORCE_ASYNC=1` and an explicit schema is provided because schema inference (which normally populates the file cache) gets skipped. The `.unwrap()` on the missing cache entry then panics.

Falls back to direct file open for local paths when the cache entry is missing. Also fixed the same pattern in `scan_sources.rs`.