### PR TITLE
fix: Remove outdated warning about List columns in unique() (#26295)

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -11128,11 +11128,6 @@ class DataFrame:
         DataFrame
             DataFrame with unique rows.
 
-        Warnings
-        --------
-        This method will fail if there is a column of type `List` in the DataFrame (or
-        in the "subset" parameter).
-
         Notes
         -----
         If you're coming from Pandas, this is similar to

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -7864,11 +7864,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         LazyFrame
             LazyFrame with unique rows.
 
-        Warnings
-        --------
-        This method will fail if there is a column of type `List` in the DataFrame (or
-        in the "subset" parameter).
-
         Notes
         -----
         If you're coming from Pandas, this is similar to


### PR DESCRIPTION
Fixes #26295

## Problem
The docstrings for DataFrame.unique() and LazyFrame.unique() contain an outdated warning stating that these methods will fail if there is a column of type List. However, as demonstrated in #26295, the method now works correctly with List columns.

## Solution
Remove the outdated warning section from both method docstrings to avoid misleading users.

## Changes
- Remove warning section from DataFrame.unique() docstring
- Remove warning section from LazyFrame.unique() docstring
- Total: 10 lines removed (outdated warning text)

## Testing
- Documentation-only change
- No runtime behavior changes
- Verified by issue reporter that unique() works with List columns