### PR TITLE
Fix list.sample fraction validation to enforce 0.0-1.0 range

### DIFF
--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -659,6 +659,14 @@ pub trait ListNameSpaceImpl: AsList {
         let fraction_s = fraction.cast(&DataType::Float64)?;
         let fraction = fraction_s.f64()?;
 
+        // Validate that all fraction values are between 0.0 and 1.0
+        for frac in fraction.into_no_null_iter() {
+            polars_ensure!(
+                frac >= 0.0 && frac <= 1.0,
+                ComputeError: "fraction must be between 0.0 and 1.0, got: {}", frac
+            );
+        }
+
         polars_ensure!(
             ca.len() == fraction.len() || ca.len() == 1 || fraction.len() == 1,
             length_mismatch = "list.sample(fraction)",

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -1109,6 +1109,38 @@ def test_list_sample_fraction_self_broadcast() -> None:
     )
 
 
+def test_list_sample_fraction_validation_22024() -> None:
+    """Test that list.sample fraction parameter validates bounds correctly."""
+    df = pl.DataFrame([
+        pl.Series('a', [
+            ["a"], ["eb", "d"],
+        ], pl.List(pl.String)),
+    ])
+    
+    # Test valid fractions work correctly
+    result = df.select(pl.col.a.list.sample(fraction=0.5))
+    assert result.shape[0] == 2
+    
+    result = df.select(pl.col.a.list.sample(fraction=1.0))
+    assert result.shape[0] == 2
+    
+    result = df.select(pl.col.a.list.sample(fraction=0.0))
+    assert result.shape[0] == 2
+    
+    # Test invalid fractions raise errors
+    with pytest.raises(pl.exceptions.ComputeError, match="fraction must be between 0.0 and 1.0, got: 1.5"):
+        df.select(pl.col.a.list.sample(fraction=1.5))
+    
+    with pytest.raises(pl.exceptions.ComputeError, match="fraction must be between 0.0 and 1.0, got: 2.0"):
+        df.select(pl.col.a.list.sample(fraction=2.0))
+    
+    with pytest.raises(pl.exceptions.ComputeError, match="fraction must be between 0.0 and 1.0, got: -0.1"):
+        df.select(pl.col.a.list.sample(fraction=-0.1))
+    
+    with pytest.raises(pl.exceptions.ComputeError, match="fraction must be between 0.0 and 1.0, got: 1.2"):
+        df.select(pl.col.a.list.sample(fraction=1.2))
+
+
 def test_list_shift_unequal_lengths_22018() -> None:
     with pytest.raises(pl.exceptions.ShapeError):
         pl.Series("a", [[1, 2], [1, 2]]).list.shift(pl.Series([1, 2, 3]))


### PR DESCRIPTION
## Summary

This PR fixes issue #22024 where the `list.sample` function with the `fraction` parameter was incorrectly accepting values outside the valid range of 0.0 to 1.0.

## Root Cause

The `lst_sample_fraction` function in the Rust core was not validating the fraction parameter bounds before using it in calculations. This allowed invalid fractions like 1.2 or -0.1 to be processed without error.

## Changes

**Core Fix:**
- Added validation in `lst_sample_fraction` to check that all fraction values are between 0.0 and 1.0
- Invalid fractions now raise a `ComputeError` with a descriptive message

**Test Coverage:**
- Added comprehensive test cases (`test_list_sample_fraction_validation_22024`) that verify:
  - Valid fractions (0.0, 0.5, 1.0) work correctly  
  - Invalid fractions (-0.1, 1.2, 1.5, 2.0) raise appropriate errors

## Example

Before this fix:
```python
df.select(pl.col.a.list.sample(fraction=1.2))  # Worked incorrectly
```

After this fix:
```python
df.select(pl.col.a.list.sample(fraction=1.2))  # Raises ComputeError
```

## Testing

The fix includes comprehensive test cases that verify both valid and invalid fraction values behave correctly.

Fixes #22024