### PR TITLE
fix: Fix repeated word typos in comments

### DIFF
--- a/py-polars/tests/unit/io/cloud/test_credential_provider.py
+++ b/py-polars/tests/unit/io/cloud/test_credential_provider.py
@@ -673,7 +673,7 @@ def test_credential_provider_rebuild_clears_cache(
     # Set the cache
     provider_local()
 
-    # Now update the the retrieval function to return updated credentials.
+    # Now update the retrieval function to return updated credentials.
     plmonkeypatch.setattr(
         credential_provider_class,
         "retrieve_credentials_impl",

--- a/py-polars/tests/unit/sql/test_group_by.py
+++ b/py-polars/tests/unit/sql/test_group_by.py
@@ -525,7 +525,7 @@ def test_group_by_aggregate_name_is_group_key() -> None:
     """Unaliased aggregation with a column that's also used in the GROUP BY key."""
     df = pl.DataFrame({"c0": [1, 2]})
 
-    # 'COUNT(col)' where 'col' is also part of the the group key
+    # 'COUNT(col)' where 'col' is also part of the group key
     for query in (
         "SELECT COUNT(c0) FROM self GROUP BY c0",
         "SELECT COUNT(c0) AS c0 FROM self GROUP BY c0",

--- a/pyo3-polars/pyo3-polars/src/derive.rs
+++ b/pyo3-polars/pyo3-polars/src/derive.rs
@@ -58,7 +58,7 @@ fn start_up_init() {
 /// FFI function, so unsafe
 pub unsafe extern "C" fn _polars_plugin_get_version() -> u32 {
     if !INIT.swap(true, Ordering::Relaxed) {
-        // Plugin version is is always called at least once.
+        // Plugin version is always called at least once.
         start_up_init();
     }
     let (major, minor) = polars_ffi::get_version();


### PR DESCRIPTION
## Summary
- Fix "the the" → "the" in `py-polars/tests/unit/sql/test_group_by.py`
- Fix "the the" → "the" in `py-polars/tests/unit/io/cloud/test_credential_provider.py`
- Fix "is is" → "is" in `pyo3-polars/pyo3-polars/src/derive.rs`

## Note
There are also two misspelled test function names that I didn't change since renaming them could break external references:
- `test_sort_multicolum_null` → should be `test_sort_multicolumn_null` (`py-polars/tests/unit/operations/test_sort.py:1166`)
- `test_order_sensitive_paramateric` → should be `test_order_sensitive_parametric` (`py-polars/tests/unit/lazyframe/test_order_observability.py:297`)