### PR TITLE
perf: Optimize single-value `replace` to `when/then/otherwise` in IR lowering

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
@@ -1024,6 +1024,7 @@ pub(super) fn convert_functions(
         F::Replace => {
             let is_single_value = |node| match ctx.arena.get(node) {
                 AExpr::Literal(LiteralValue::Scalar(sc)) => !sc.dtype().is_list(),
+                AExpr::Literal(LiteralValue::Dyn(_)) => true,
                 _ => false,
             };
             if is_single_value(e[1].node()) && is_single_value(e[2].node()) {

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
@@ -1021,7 +1021,28 @@ pub(super) fn convert_functions(
         #[cfg(feature = "ewma")]
         F::EwmVar { options } => I::EwmVar { options },
         #[cfg(feature = "replace")]
-        F::Replace => I::Replace,
+        F::Replace => {
+            let is_single_value = |node| match ctx.arena.get(node) {
+                AExpr::Literal(LiteralValue::Scalar(sc)) => !sc.dtype().is_list(),
+                _ => false,
+            };
+            if is_single_value(e[1].node()) && is_single_value(e[2].node()) {
+                let predicate =
+                    AExprBuilder::new_from_node(e[0].node()).eq_validity(e[1].node(), ctx.arena);
+                return Ok((
+                    AExprBuilder::when_then_otherwise(
+                        predicate,
+                        e[2].node(),
+                        e[0].node(),
+                        ctx.arena,
+                    )
+                    .node(),
+                    e[0].output_name().clone(),
+                ));
+            }
+
+            I::Replace
+        },
         #[cfg(feature = "replace")]
         F::ReplaceStrict { return_dtype } => I::ReplaceStrict {
             return_dtype: match return_dtype {

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
@@ -1021,29 +1021,7 @@ pub(super) fn convert_functions(
         #[cfg(feature = "ewma")]
         F::EwmVar { options } => I::EwmVar { options },
         #[cfg(feature = "replace")]
-        F::Replace => {
-            let is_single_value = |node| match ctx.arena.get(node) {
-                AExpr::Literal(LiteralValue::Scalar(sc)) => !sc.dtype().is_list(),
-                AExpr::Literal(LiteralValue::Dyn(_)) => true,
-                _ => false,
-            };
-            if is_single_value(e[1].node()) && is_single_value(e[2].node()) {
-                let predicate =
-                    AExprBuilder::new_from_node(e[0].node()).eq_validity(e[1].node(), ctx.arena);
-                return Ok((
-                    AExprBuilder::when_then_otherwise(
-                        predicate,
-                        e[2].node(),
-                        e[0].node(),
-                        ctx.arena,
-                    )
-                    .node(),
-                    e[0].output_name().clone(),
-                ));
-            }
-
-            I::Replace
-        },
+        F::Replace => I::Replace,
         #[cfg(feature = "replace")]
         F::ReplaceStrict { return_dtype } => I::ReplaceStrict {
             return_dtype: match return_dtype {

--- a/crates/polars-plan/src/plans/optimizer/simplify_expr/simplify_functions.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_expr/simplify_functions.rs
@@ -348,6 +348,33 @@ pub(super) fn optimize_functions(
                 length: length_node,
             })
         },
+        #[cfg(feature = "replace")]
+        IRFunctionExpr::Replace => {
+            let is_single_value = |node: Node| match expr_arena.get(node) {
+                AExpr::Literal(lit) => match lit {
+                    LiteralValue::Scalar(sc) => !sc.dtype().is_list(),
+                    LiteralValue::Dyn(_) => true,
+                    LiteralValue::Series(_) | LiteralValue::Range(_) => false,
+                },
+                _ => false,
+            };
+
+            if is_single_value(input[1].node()) && is_single_value(input[2].node()) {
+                let predicate = expr_arena.add(AExpr::BinaryExpr {
+                    left: input[0].node(),
+                    op: Operator::EqValidity,
+                    right: input[1].node(),
+                });
+
+                Some(AExpr::Ternary {
+                    predicate,
+                    truthy: input[2].node(),
+                    falsy: input[0].node(),
+                })
+            } else {
+                None
+            }
+        },
         _ => None,
     };
     Ok(out)

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -742,7 +742,7 @@ def test_repr_miscellaneous() -> None:
 def test_replace_no_cse() -> None:
     plan = (
         pl.LazyFrame({"a": [1], "b": [2]})
-        .select([(pl.col("a") * pl.col("a")).sum().replace(1, None)])
+        .select([(pl.col("a") * pl.col("a")).sum().alias("x")])
         .explain()
     )
     assert "POLARS_CSER" not in plan

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -742,7 +742,7 @@ def test_repr_miscellaneous() -> None:
 def test_replace_no_cse() -> None:
     plan = (
         pl.LazyFrame({"a": [1], "b": [2]})
-        .select([(pl.col("a") * pl.col("a")).sum().alias("x")])
+        .select([(pl.col("a") * pl.col("a")).sum()])
         .explain()
     )
     assert "POLARS_CSER" not in plan

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -742,7 +742,7 @@ def test_repr_miscellaneous() -> None:
 def test_replace_no_cse() -> None:
     plan = (
         pl.LazyFrame({"a": [1], "b": [2]})
-        .select([(pl.col("a") * pl.col("a")).sum()])
+        .select([(pl.col("a") * pl.col("a")).sum().replace([1, 2], [3, 4])])
         .explain()
     )
     assert "POLARS_CSER" not in plan

--- a/py-polars/tests/unit/operations/test_replace.py
+++ b/py-polars/tests/unit/operations/test_replace.py
@@ -289,3 +289,18 @@ def test_replace_single_argument_not_mapping() -> None:
         match="`new` argument is required if `old` argument is not a Mapping type",
     ):
         df.select(pl.col("a").replace("b"))
+
+
+def test_replace_single_value_rewrite_plan_21707() -> None:
+    plan = pl.LazyFrame({"a": [1, 2, 3]}).select(pl.col("a").replace(1, 99)).explain()
+    assert "when" in plan
+
+
+def test_replace_single_value_rewrite_result_21707() -> None:
+    lf = pl.LazyFrame({"a": [1, 2, 3, 1, None]})
+
+    result_replace = lf.select(pl.col("a").replace(1, 99)).collect()
+    result_when = lf.select(
+        pl.when(pl.col("a") == 1).then(99).otherwise(pl.col("a")).alias("a")
+    ).collect()
+    assert_frame_equal(result_replace, result_when)


### PR DESCRIPTION
Should resolve https://github.com/pola-rs/polars/issues/21707.

The solution was outlined in the discussion of this closed PR: https://github.com/pola-rs/polars/pull/21699.

@orlp said:

> I'd be interested in a PR that optimizes replace with a single value to when-then-otherwise.

To which @ritchie46  replied:

> Me too. That can completely be rewritten in the IR.

This is my first PR related to the query engine, so any feedback is appreciated and welcome. The fix was changing the DSL -> IR conversion for when `.replace()` was called with single values for `old` and `new`. When this situation was encountered, I used the `AExprBuilder` to build a `AExprBuilder::when_then_otherwise` node. Otherwise, it would just fall back to the existing `I::Replace`. This was modelled after looking at the `AnyHorizontal` and `AllHorizontal` arms in `convert_functions()`. 

As a note, I had to use a highly specific condition for checking if `e[1]` and `e[2]` instead of `.is_scalar()`, which is used in other parts of the code. `is_scalar()` was too broad and only excluded `Series` and `Range` variants, but `LiteralValue::Scalar` can wrap a list value inside of it. The current condition checks if it is a scalar and that the scalar's data type is not a list or if the value is a dynamic literal value. If I did not do this very specific check, many existing tests would break.

As a note, needed to update `test_replace_no_cse()` since the rewrite triggers CSE. Updated it to not use `.replace()` and it passes.

🤖 Claude 4.6 Sonnet for helping me understand the existing code, explaining concepts, and for debugging the condition after tests broke. 

## Benchmarks:

Code:

```
a = pl.DataFrame({'a': pl.Series(list(range(1_000_000)))})

t = timeit.timeit(lambda: a.with_columns(pl.col('a').replace(1, 99)), number=100)
print(f'replace: {t/100*1000:.1f} ms per loop')

t = timeit.timeit(lambda: a.with_columns(pl.when(pl.col('a') == 1).then(99).otherwise(pl.col('a'))), number=100)
print(f'when/then: {t/100*1000:.1f} ms per loop')
```

Before: 

* `replace` - 137.0 ms per loop
* `when/then` - 13.8 ms per loop

After:

* `replace` - 13.9 ms per loop
* `when/then` - 13.6 ms per loop