### PR TITLE
fix: Default engine as streaming for `collect_batches`

### DIFF
--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -4271,7 +4271,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         >>> for df in lf.collect_batches():
         ...     print(df)  # doctest: +SKIP
         """
-        engine = "streaming" if engine == "auto" else _select_engine(engine)
+        engine = _select_engine(engine)
+
+        if engine == "auto":
+            engine = "streaming"
 
         class CollectBatches:
             def __init__(self, inner: Any) -> None:


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/26930

Default to the streaming engine for `collect_batches`.

Presumably we didn't respect the `engine` parameter for `collect_batches` in the past and defaulted to the streaming engine, in this PR we set it explicitly to the streaming engine if it's `"auto"`
