### PR TITLE
fix: Fix panic on upsample() with group_by parameter on empty DataFrame

### DIFF
--- a/crates/polars-time/src/upsample.rs
+++ b/crates/polars-time/src/upsample.rs
@@ -164,6 +164,12 @@ fn upsample_core(
         return upsample_single_impl(source, index_column.as_materialized_series(), every);
     }
 
+    if source.height() == 0 {
+        polars_bail!(
+            ComputeError: "cannot determine upsample boundaries: all elements are null"
+        );
+    }
+
     let source_schema = source.schema();
 
     let group_keys_df = source.select(by)?;

--- a/py-polars/tests/unit/dataframe/test_upsample.py
+++ b/py-polars/tests/unit/dataframe/test_upsample.py
@@ -359,3 +359,19 @@ def test_upsample_with_group_by_15530() -> None:
             every="1d",
             group_by=["time", "time"],
         )
+
+
+def test_upsample_empty_dataframe_with_group_by_26342() -> None:
+    df = pl.DataFrame(
+        {
+            "time": pl.Series([], dtype=pl.Datetime("ns")),
+            "my_group": pl.Series([], dtype=pl.Int32),
+            "my_id": pl.Series([], dtype=pl.String),
+        }
+    )
+
+    with pytest.raises(
+        pl.exceptions.ComputeError,
+        match="cannot determine upsample boundaries: all elements are null",
+    ):
+        df.upsample(time_column="time", every="15m", group_by="my_group")


### PR DESCRIPTION
This wasn't marked as an accepted issue but it was an easy fix. Resolves https://github.com/pola-rs/polars/issues/26342.

When `upsample()` was being called on a `DataFrame` and the `group_by` parameter was passed, it resulted in a panic due to the empty result being passed to `accumulate_dataframes_vertical_unchecked()`. This function then uses an `.unwrap()` on an empty iterator, which panics since it encounters `None`. 

If the `group_by` parameter was not passed in the same situation, a `ComputeError` would be raised properly since `upsample_core()` delegates to `upsample_single_impl()` when `group_by` is empty and it properly handles a situation in which the `DataFrame` is empty.

The fix was to add an early return with a `ComputeError` if `source`, the `DataFrame`, is empty and the `group_by` parameter is not empty.

🤖 Claude Sonnet 4.6 for navigating the codebase.