### PR TITLE
fix(python): Fix `search_sorted` typing when used with `list[float]`

### DIFF
--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -3924,7 +3924,7 @@ class Series:
     @overload
     def search_sorted(
         self,
-        element: list_[NonNestedLiteral | None] | np.ndarray[Any, Any] | Expr | Series,
+        element: list_[Any] | np.ndarray[Any, Any] | Expr | Series,
         side: SearchSortedSide = ...,
         *,
         descending: bool = ...,

--- a/py-polars/tests/unit/operations/test_search_sorted.py
+++ b/py-polars/tests/unit/operations/test_search_sorted.py
@@ -94,3 +94,8 @@ def test_raise_literal_numeric_search_sorted_18096() -> None:
 
     with pytest.raises(pl.exceptions.InvalidOperationError):
         df.with_columns(idx=pl.col("foo").search_sorted("bar"))
+
+
+def test_search_sorted_typing_26937() -> None:
+    targets: list[float] = [0.1, 0.3, 0.8]
+    indices = pl.Series().search_sorted(targets)


### PR DESCRIPTION
Fixes: #26937

The proposed solution could be seen as a lost of information, but in reality I don't think that `list_[NonNestedLiteral | None]` is any useful as the user will need to provide exactly this type and for example list[int] will be rejected as in the issue. 
One other solution could be to use a `Sequence[NonNestedLiteral | None]` but then you get an issue with the overload decorator (signature overlap as `str` matches `NonNestedLiteral` and Sequence[NonNestedLiteral]).  