### PR TITLE
fix(rust,python): Distinguish NaN and infinity in Expr.meta.serialize JSON

### DIFF
--- a/crates/polars-plan/src/plans/lit.rs
+++ b/crates/polars-plan/src/plans/lit.rs
@@ -14,7 +14,7 @@ use crate::constants::get_literal_name;
 use crate::prelude::*;
 
 #[derive(Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize))]
 #[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
 pub enum DynLiteralValue {
     Str(PlSmallStr),
@@ -40,6 +40,45 @@ impl Hash for DynLiteralValue {
             Self::Int(i) => i.hash(state),
             Self::Float(i) => i.to_ne_bytes().hash(state),
             Self::List(i) => i.hash(state),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for DynLiteralValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // Keep variant ordering in sync with the enum definition above.
+        match self {
+            DynLiteralValue::Str(v) => {
+                serializer.serialize_newtype_variant("DynLiteralValue", 0, "Str", v)
+            },
+            DynLiteralValue::Int(v) => {
+                serializer.serialize_newtype_variant("DynLiteralValue", 1, "Int", v)
+            },
+            DynLiteralValue::Float(f) => {
+                if f.is_nan() {
+                    // Preserve existing JSON shape while distinguishing NaN from Infinity:
+                    // NaN -> {"Float": null}
+                    let none: Option<f64> = None;
+                    serializer.serialize_newtype_variant("DynLiteralValue", 2, "Float", &none)
+                } else if f.is_infinite() {
+                    // Infinity -> {"Float": "infinity"} or {"Float": "-infinity"}
+                    let marker = if f.is_sign_positive() {
+                        "infinity"
+                    } else {
+                        "-infinity"
+                    };
+                    serializer.serialize_newtype_variant("DynLiteralValue", 2, "Float", marker)
+                } else {
+                    serializer.serialize_newtype_variant("DynLiteralValue", 2, "Float", f)
+                }
+            },
+            DynLiteralValue::List(v) => {
+                serializer.serialize_newtype_variant("DynLiteralValue", 3, "List", v)
+            },
         }
     }
 }

--- a/py-polars/tests/unit/expr/test_serde.py
+++ b/py-polars/tests/unit/expr/test_serde.py
@@ -59,6 +59,16 @@ def test_expression_json_13991() -> None:
     assert round_tripped.meta == expr
 
 
+def test_expr_serde_nan_vs_inf_26929() -> None:
+    nan_json = pl.lit(float("nan")).meta.serialize(format="json")
+    inf_json = pl.lit(float("inf")).meta.serialize(format="json")
+    ninf_json = pl.lit(float("-inf")).meta.serialize(format="json")
+
+    assert nan_json != inf_json
+    assert nan_json != ninf_json
+    assert inf_json != ninf_json
+
+
 def test_expr_write_json_from_json_deprecated() -> None:
     expr = pl.col("foo").sum().over("bar")
 


### PR DESCRIPTION
## Summary

- Fix JSON serialization of floating `DynLiteralValue` so that `NaN`, `+inf`, and `-inf` are encoded distinctly in `Expr.meta.serialize(format="json")`.
- Add regression test `test_expr_serde_nan_vs_inf_26929` to ensure literals created from `float("nan")`, `float("inf")`, and `float("-inf")` no longer share the same serialized JSON.

## Related issue

- Fixes #26929.