### PR TITLE
fix: Preserve height when unnesting empty struct columns

### DIFF
--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -2670,7 +2670,7 @@ impl DataFrame {
             }
         }
 
-        DataFrame::new_infer_height(new_cols)
+        DataFrame::new(self.height(), new_cols)
     }
 
     pub fn append_record_batch(&mut self, rb: RecordBatchT<ArrayRef>) -> PolarsResult<()> {


### PR DESCRIPTION
When all struct columns being unnested have zero fields (empty structs), `DataFrame.unnest()` incorrectly returns a DataFrame with 0 rows instead of preserving the original row count.

**Root cause:** `unnest_impl()` calls `DataFrame::new_infer_height(new_cols)` which defaults to 0 rows when `new_cols` is empty. The `StructChunked::unnest()` method correctly handles this by using `DataFrame::new_unchecked(self.len(), columns)`.

**Fix:** Changed `new_infer_height(new_cols)` to `new(self.height(), new_cols)` to preserve the original DataFrame height.

Fixes #22529

1. I used AI to help identify the root cause and draft the fix.
2. I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.