### PR TITLE
perf: Optimize `.replace()` from a single value

### DIFF
--- a/crates/polars-ops/src/series/ops/replace.rs
+++ b/crates/polars-ops/src/series/ops/replace.rs
@@ -211,6 +211,7 @@ fn replace_by_single(
     }
     new.zip_with(&mask, default)
 }
+
 /// Fast path for replacing by a single value in strict mode
 fn replace_by_single_strict(s: &Series, old: &Series, new: &Series) -> PolarsResult<Series> {
     let mask = get_replacement_mask(s, old)?;
@@ -224,6 +225,7 @@ fn replace_by_single_strict(s: &Series, old: &Series, new: &Series) -> PolarsRes
     }
     Ok(out)
 }
+
 /// Get a boolean mask of which values in the original Series will be replaced.
 ///
 /// Null values are propagated to the mask.
@@ -231,6 +233,8 @@ fn get_replacement_mask(s: &Series, old: &Series) -> PolarsResult<BooleanChunked
     if old.null_count() == old.len() {
         // Fast path for when users are using `replace(None, ...)` instead of `fill_null`.
         Ok(s.is_null())
+    } else if old.len() == 1 {
+        Ok(s.equal(old)?)
     } else {
         let old = old.implode()?;
         is_in(s, &old.into_series(), false)


### PR DESCRIPTION
This supersedes https://github.com/pola-rs/polars/pull/26920 and still closes https://github.com/pola-rs/polars/issues/21707.

In the previous PR, I attempted to make the optimization for using `.replace()` when `old` and `new` were single values during DSL -> IR lowering, and then changed it to the optimization step. However, @nameexhaustion pointed out that there is an optimized path for this call in `polars-ops/src/series/ops/replace.rs`, so I investigated that code and why it was slower.

In this file, the final few lines of code in `replace` checks `if new.len() == 1`. If this condition is true, it delegates to `replace_by_single`, which calls the `get_replacement_mask` function. In `get_replacement_mask`, it didn't have special handling for when `old.len() == 1`. Rather, it was just pushing everything into `is_in`, no matter the length of `old`, as long as `old` was not all `null`.  

The fix added an extra condition to `get_replacement_mask` to do a direct equality comparison using `Series.equal` if `old.len() == 1`, which greatly improved performance. `is_in` uses complex mechanics that are important for checking multiple membership, but for a single value the overhead is wasteful. The new branch just does a direct equality check, which is much faster for single values.

## Benchmarks

Code:

```
import polars as pl
import timeit

a = pl.DataFrame({'a': pl.Series(list(range(1_000_000)))})

t = timeit.timeit(lambda: a.with_columns(pl.col('a').replace(1, 99)), number=100)
print(f'replace: {t/100*1000:.1f} ms per loop')

t = timeit.timeit(lambda: a.with_columns(pl.when(pl.col('a') == 1).then(99).otherwise(pl.col('a'))), number=100)
print(f'when/then: {t/100*1000:.1f} ms per loop')
```

Before (`main`):

* `replace`: 134.6 ms per loop
* `when/then`:  13.9 ms per loop

After (`perf/single_value_replace`):

* `replace`: 14.9 ms per loop
* `when/then`: 14.2 ms per loop