### PR TITLE
refactor(rust): Add `is_all_null` convenience method

### DIFF
--- a/crates/polars-core/src/chunked_array/arg_min_max.rs
+++ b/crates/polars-core/src/chunked_array/arg_min_max.rs
@@ -43,7 +43,7 @@ where
     T: PolarsNumericType,
     for<'b> &'b [T::Native]: ArgMinMax,
 {
-    if ca.null_count() == ca.len() {
+    if ca.is_all_null() {
         None
     } else if let Ok(vals) = ca.cont_slice() {
         arg_min_numeric_slice(vals, ca.is_sorted_flag())
@@ -57,7 +57,7 @@ where
     T: PolarsNumericType,
     for<'b> &'b [T::Native]: ArgMinMax,
 {
-    if ca.null_count() == ca.len() {
+    if ca.is_all_null() {
         None
     } else if T::get_static_dtype().is_float() && !matches!(ca.is_sorted_flag(), IsSorted::Not) {
         arg_max_float_sorted(ca)
@@ -84,7 +84,7 @@ where
 
 #[cfg(feature = "dtype-categorical")]
 pub fn arg_min_cat<T: PolarsCategoricalType>(ca: &CategoricalChunked<T>) -> Option<usize> {
-    if ca.null_count() == ca.len() {
+    if ca.is_all_null() {
         return None;
     }
     arg_min_opt_iter(ca.iter_str())
@@ -92,7 +92,7 @@ pub fn arg_min_cat<T: PolarsCategoricalType>(ca: &CategoricalChunked<T>) -> Opti
 
 #[cfg(feature = "dtype-categorical")]
 pub fn arg_max_cat<T: PolarsCategoricalType>(ca: &CategoricalChunked<T>) -> Option<usize> {
-    if ca.null_count() == ca.len() {
+    if ca.is_all_null() {
         return None;
     }
     arg_max_opt_iter(ca.iter_str())
@@ -135,7 +135,7 @@ where
     T: PolarsDataType,
     for<'a> T::Physical<'a>: Ord,
 {
-    if ca.null_count() == ca.len() {
+    if ca.is_all_null() {
         return None;
     }
     match ca.is_sorted_flag() {
@@ -150,7 +150,7 @@ where
     T: PolarsDataType,
     for<'a> T::Physical<'a>: Ord,
 {
-    if ca.null_count() == ca.len() {
+    if ca.is_all_null() {
         return None;
     }
     match ca.is_sorted_flag() {

--- a/crates/polars-core/src/chunked_array/logical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/mod.rs
@@ -124,6 +124,11 @@ where
     }
 
     #[inline(always)]
+    pub fn is_all_null(&self) -> bool {
+        self.phys.is_all_null()
+    }
+
+    #[inline(always)]
     pub fn is_not_null(&self) -> BooleanChunked {
         self.phys.is_not_null()
     }

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -282,7 +282,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
             None
         }
         // We now know there is at least 1 non-null item in the array, and self.len() > 0
-        else if self.null_count() == self.len() {
+        else if self.is_all_null() {
             Some(0)
         } else if self.is_sorted_any() {
             let out = if unsafe { self.downcast_get_unchecked(0).is_null_unchecked(0) } {
@@ -307,7 +307,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
 
     /// Get the index of the first non null value in this [`ChunkedArray`].
     pub fn first_non_null(&self) -> Option<usize> {
-        if self.null_count() == self.len() {
+        if self.is_all_null() {
             None
         }
         // We now know there is at least 1 non-null item in the array, and self.len() > 0
@@ -336,7 +336,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
 
     /// Get the index of the last non null value in this [`ChunkedArray`].
     pub fn last_non_null(&self) -> Option<usize> {
-        if self.null_count() == self.len() {
+        if self.is_all_null() {
             None
         }
         // We now know there is at least 1 non-null item in the array, and self.len() > 0
@@ -404,6 +404,12 @@ impl<T: PolarsDataType> ChunkedArray<T> {
     /// Return if any the chunks in this [`ChunkedArray`] have nulls.
     pub fn has_nulls(&self) -> bool {
         self.null_count > 0
+    }
+
+    #[inline]
+    /// Return if all values in this [`ChunkedArray`] are null.
+    pub fn is_all_null(&self) -> bool {
+        self.null_count == self.len()
     }
 
     /// Shrink the capacity of this array to fit its length.

--- a/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -95,7 +95,7 @@ where
     }
 
     fn min(&self) -> Option<T::Native> {
-        if self.null_count() == self.len() {
+        if self.is_all_null() {
             return None;
         }
 
@@ -118,7 +118,7 @@ where
     }
 
     fn max(&self) -> Option<T::Native> {
-        if self.null_count() == self.len() {
+        if self.is_all_null() {
             return None;
         }
         // There is at least one non-null value.
@@ -150,7 +150,7 @@ where
     }
 
     fn min_max(&self) -> Option<(T::Native, T::Native)> {
-        if self.null_count() == self.len() {
+        if self.is_all_null() {
             return None;
         }
         // There is at least one non-null value.
@@ -240,13 +240,13 @@ impl BooleanChunked {
     }
 
     pub fn max(&self) -> Option<bool> {
-        if self.is_empty() || self.null_count() == self.len() {
+        if self.is_empty() || self.is_all_null() {
             return None;
         }
         if self.any() { Some(true) } else { Some(false) }
     }
     pub fn mean(&self) -> Option<f64> {
-        if self.is_empty() || self.null_count() == self.len() {
+        if self.is_empty() || self.is_all_null() {
             return None;
         }
         self.sum()
@@ -511,7 +511,7 @@ where
     ChunkedArray<T::PolarsPhysical>: ChunkAgg<T::Native>,
 {
     fn min_categorical(&self) -> Option<CatSize> {
-        if self.is_empty() || self.null_count() == self.len() {
+        if self.is_empty() || self.is_all_null() {
             return None;
         }
         if self.uses_lexical_ordering() {
@@ -530,7 +530,7 @@ where
     }
 
     fn max_categorical(&self) -> Option<CatSize> {
-        if self.is_empty() || self.null_count() == self.len() {
+        if self.is_empty() || self.is_all_null() {
             return None;
         }
         if self.uses_lexical_ordering() {
@@ -628,7 +628,7 @@ impl BinaryChunked {
         }
     }
     pub fn arg_min_binary(&self) -> Option<usize> {
-        if self.is_empty() || self.null_count() == self.len() {
+        if self.is_empty() || self.is_all_null() {
             return None;
         }
 
@@ -640,7 +640,7 @@ impl BinaryChunked {
     }
 
     pub fn arg_max_binary(&self) -> Option<usize> {
-        if self.is_empty() || self.null_count() == self.len() {
+        if self.is_empty() || self.is_all_null() {
             return None;
         }
 

--- a/crates/polars-core/src/chunked_array/ops/arity.rs
+++ b/crates/polars-core/src/chunked_array/ops/arity.rs
@@ -152,7 +152,7 @@ where
     F: UnaryFnMut<T::Physical<'a>>,
     V::Array: ArrayFromIter<<F as UnaryFnMut<T::Physical<'a>>>::Ret>,
 {
-    if ca.null_count() == ca.len() {
+    if ca.is_all_null() {
         let arr = V::Array::full_null(
             ca.len(),
             V::get_static_dtype().to_arrow(CompatLevel::newest()),
@@ -179,7 +179,7 @@ where
     F: FnMut(T::Physical<'a>) -> Result<K, E>,
     V::Array: ArrayFromIter<K>,
 {
-    if ca.null_count() == ca.len() {
+    if ca.is_all_null() {
         let arr = V::Array::full_null(
             ca.len(),
             V::get_static_dtype().to_arrow(CompatLevel::newest()),
@@ -359,7 +359,7 @@ where
     F: for<'a> FnMut(T::Physical<'a>, U::Physical<'a>) -> K,
     V::Array: ArrayFromIter<K>,
 {
-    if lhs.null_count() == lhs.len() || rhs.null_count() == rhs.len() {
+    if lhs.is_all_null() || rhs.is_all_null() {
         let len = lhs.len().min(rhs.len());
         let arr = V::Array::full_null(len, V::get_static_dtype().to_arrow(CompatLevel::newest()));
 
@@ -819,7 +819,7 @@ where
     F: for<'a> FnMut(T::Physical<'a>, U::Physical<'a>) -> K,
     V::Array: ArrayFromIter<K>,
 {
-    if lhs.null_count() == lhs.len() || rhs.null_count() == rhs.len() {
+    if lhs.is_all_null() || rhs.is_all_null() {
         let min = lhs.len().min(rhs.len());
         let max = lhs.len().max(rhs.len());
         let len = if min == 1 { max } else { min };

--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -400,9 +400,9 @@ impl<'a> AnyValue<'a> {
     pub fn is_nested_null(&self) -> bool {
         match self {
             AnyValue::Null => true,
-            AnyValue::List(s) => s.null_count() == s.len(),
+            AnyValue::List(s) => s.is_all_null(),
             #[cfg(feature = "dtype-array")]
-            AnyValue::Array(s, _) => s.null_count() == s.len(),
+            AnyValue::Array(s, _) => s.is_all_null(),
             #[cfg(feature = "dtype-struct")]
             AnyValue::Struct(_, _, _) => self._iter_struct_av().all(|av| av.is_nested_null()),
             _ => false,

--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -539,6 +539,7 @@ impl Column {
             },
         }
     }
+
     #[inline]
     pub fn is_not_null(&self) -> BooleanChunked {
         match self {
@@ -546,6 +547,14 @@ impl Column {
             Self::Scalar(s) => {
                 BooleanChunked::full(s.name().clone(), !s.scalar().is_null(), s.len())
             },
+        }
+    }
+
+    #[inline]
+    pub fn is_all_null(&self) -> bool {
+        match self {
+            Self::Series(s) => s.is_all_null(),
+            Self::Scalar(s) => s.has_nulls(),
         }
     }
 
@@ -1022,7 +1031,7 @@ impl Column {
             return IdxCa::from_vec(self.name().clone(), Vec::new());
         }
 
-        if self.null_count() == self.len() {
+        if self.is_all_null() {
             // We might need to maintain order so just respect the descending parameter.
             let values = if options.descending {
                 (0..self.len() as IdxSize).rev().collect()

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -449,6 +449,11 @@ pub trait SeriesTrait:
     /// Return if any the chunks in this [`ChunkedArray`] have nulls.
     fn has_nulls(&self) -> bool;
 
+    /// Check if all values in the Series are null.
+    fn is_all_null(&self) -> bool {
+        self.null_count() == self.len()
+    }
+
     /// Get unique values in the Series.
     fn unique(&self) -> PolarsResult<Series> {
         polars_bail!(opq = unique, self._dtype());

--- a/crates/polars-expr/src/expressions/eval.rs
+++ b/crates/polars-expr/src/expressions/eval.rs
@@ -72,7 +72,7 @@ impl EvalExpr {
             .map_or(Cow::Borrowed(ca), Cow::Owned);
 
         // Fast path: Empty or only nulls.
-        if ca.null_count() == ca.len() {
+        if ca.is_all_null() {
             let name = self.output_field.name.clone();
             return Ok(Column::full_null(name, ca.len(), self.output_field.dtype()));
         }
@@ -208,7 +208,7 @@ impl EvalExpr {
             .map_or(Cow::Borrowed(ca), Cow::Owned);
 
         // Fast path: Empty or only nulls.
-        if ca.null_count() == ca.len() {
+        if ca.is_all_null() {
             let name = self.output_field.name.clone();
             return Ok(Column::full_null(name, ca.len(), self.output_field.dtype()));
         }

--- a/crates/polars-ops/src/chunked_array/strings/concat.rs
+++ b/crates/polars-ops/src/chunked_array/strings/concat.rs
@@ -15,7 +15,7 @@ pub fn str_join(ca: &StringChunked, delimiter: &str, ignore_nulls: bool) -> Stri
     }
 
     // Fast path for all nulls.
-    if ignore_nulls && ca.null_count() == ca.len() {
+    if ignore_nulls && ca.is_all_null() {
         return StringChunked::new(ca.name().clone(), &[""]);
     }
 

--- a/crates/polars-ops/src/series/ops/cum_agg.rs
+++ b/crates/polars-ops/src/series/ops/cum_agg.rs
@@ -118,7 +118,7 @@ where
 }
 
 fn cum_max_bool(ca: &BooleanChunked, reverse: bool, init: Option<bool>) -> BooleanChunked {
-    if ca.len() == ca.null_count() {
+    if ca.is_all_null() {
         return ca.clone();
     }
 
@@ -160,7 +160,7 @@ fn cum_max_bool(ca: &BooleanChunked, reverse: bool, init: Option<bool>) -> Boole
 }
 
 fn cum_min_bool(ca: &BooleanChunked, reverse: bool, init: Option<bool>) -> BooleanChunked {
-    if ca.len() == ca.null_count() {
+    if ca.is_all_null() {
         return ca.clone();
     }
 

--- a/crates/polars-ops/src/series/ops/cut.rs
+++ b/crates/polars-ops/src/series/ops/cut.rs
@@ -121,7 +121,7 @@ pub fn qcut(
 ) -> PolarsResult<Series> {
     polars_ensure!(!probs.iter().any(|x| x.is_nan()), ComputeError: "quantiles cannot be NaN");
 
-    if s.null_count() == s.len() {
+    if s.is_all_null() {
         // If we only have nulls we don't have any breakpoints.
         return Ok(Series::full_null(
             s.name().clone(),

--- a/crates/polars-ops/src/series/ops/interpolation/interpolate.rs
+++ b/crates/polars-ops/src/series/ops/interpolation/interpolate.rs
@@ -48,7 +48,7 @@ where
 {
     // This implementation differs from pandas as that boundary None's are not removed.
     // This prevents a lot of errors due to expressions leading to different lengths.
-    if !chunked_arr.has_nulls() || chunked_arr.null_count() == chunked_arr.len() {
+    if !chunked_arr.has_nulls() || chunked_arr.is_all_null() {
         return chunked_arr.clone();
     }
 

--- a/crates/polars-ops/src/series/ops/interpolation/interpolate_by.rs
+++ b/crates/polars-ops/src/series/ops/interpolation/interpolate_by.rs
@@ -92,7 +92,7 @@ where
 {
     // This implementation differs from pandas as that boundary None's are not removed.
     // This prevents a lot of errors due to expressions leading to different lengths.
-    if !chunked_arr.has_nulls() || chunked_arr.null_count() == chunked_arr.len() {
+    if !chunked_arr.has_nulls() || chunked_arr.is_all_null() {
         return Ok(chunked_arr.clone());
     }
 
@@ -174,7 +174,7 @@ where
 {
     // This implementation differs from pandas as that boundary None's are not removed.
     // This prevents a lot of errors due to expressions leading to different lengths.
-    if !ca.has_nulls() || ca.null_count() == ca.len() {
+    if !ca.has_nulls() || ca.is_all_null() {
         return Ok(ca.clone());
     }
 

--- a/crates/polars-ops/src/series/ops/is_first_distinct.rs
+++ b/crates/polars-ops/src/series/ops/is_first_distinct.rs
@@ -38,7 +38,7 @@ fn is_first_distinct_boolean(ca: &BooleanChunked) -> BooleanChunked {
     let mut out = MutableBitmap::with_capacity(ca.len());
     out.extend_constant(ca.len(), false);
 
-    if ca.null_count() == ca.len() {
+    if ca.is_all_null() {
         out.set(0, true);
     } else {
         let ca = ca.rechunk();

--- a/crates/polars-ops/src/series/ops/is_last_distinct.rs
+++ b/crates/polars-ops/src/series/ops/is_last_distinct.rs
@@ -57,7 +57,7 @@ fn is_last_distinct_boolean(ca: &BooleanChunked) -> BooleanChunked {
     let mut out = MutableBitmap::with_capacity(ca.len());
     out.extend_constant(ca.len(), false);
 
-    if ca.null_count() == ca.len() {
+    if ca.is_all_null() {
         out.set(ca.len() - 1, true);
     }
     // TODO supports fast path.

--- a/crates/polars-ops/src/series/ops/replace.rs
+++ b/crates/polars-ops/src/series/ops/replace.rs
@@ -159,7 +159,7 @@ pub fn replace_strict(
 
     if old.is_empty() {
         polars_ensure!(
-            s.len() == s.null_count(),
+            s.is_all_null(),
             InvalidOperation: "must specify which values to replace"
         );
         return Ok(s.clone());

--- a/crates/polars-ops/src/series/ops/replace.rs
+++ b/crates/polars-ops/src/series/ops/replace.rs
@@ -230,7 +230,7 @@ fn replace_by_single_strict(s: &Series, old: &Series, new: &Series) -> PolarsRes
 ///
 /// Null values are propagated to the mask.
 fn get_replacement_mask(s: &Series, old: &Series) -> PolarsResult<BooleanChunked> {
-    if old.null_count() == old.len() {
+    if old.is_all_null() {
         // Fast path for when users are using `replace(None, ...)` instead of `fill_null`.
         Ok(s.is_null())
     } else if old.len() == 1 {

--- a/crates/polars-ops/src/series/ops/strings.rs
+++ b/crates/polars-ops/src/series/ops/strings.rs
@@ -36,7 +36,7 @@ pub fn str_format(cs: &mut [Column], format: &str, insertions: &[usize]) -> Pola
     for c in cs.iter_mut() {
         if let Some(c_validity) = c.rechunk_validity() {
             // Column with only nulls means output is only nulls.
-            if c.null_count() == c.len() {
+            if c.is_all_null() {
                 return Ok(Column::full_null(
                     output_name,
                     output_length,

--- a/crates/polars-ops/src/series/ops/unique.rs
+++ b/crates/polars-ops/src/series/ops/unique.rs
@@ -31,7 +31,7 @@ where
 pub fn unique_counts(s: &Series) -> PolarsResult<Series> {
     if s.is_empty() {
         return Ok(IdxCa::new(s.name().clone(), [] as [IdxSize; 0]).into_series());
-    } else if s.null_count() == s.len() {
+    } else if s.is_all_null() {
         return Ok(IdxCa::new(s.name().clone(), [s.len() as IdxSize]).into_series());
     }
 

--- a/crates/polars-python/src/series/map.rs
+++ b/crates/polars-python/src/series/map.rs
@@ -22,7 +22,7 @@ impl PySeries {
         let series = self.series.read().clone(); // Clone so we don't deadlock on re-entrance.
         let series = series.to_storage();
 
-        if skip_nulls && (series.null_count() == series.len()) {
+        if skip_nulls && (series.is_all_null()) {
             if let Some(return_dtype) = return_dtype {
                 return Ok(
                     Series::full_null(series.name().clone(), series.len(), &return_dtype.0).into(),

--- a/crates/polars-testing/src/asserts/utils.rs
+++ b/crates/polars-testing/src/asserts/utils.rs
@@ -306,7 +306,7 @@ fn assert_series_values_equal(
     // When `check_dtypes` is `false` and both series are entirely null,
     // consider them equal regardless of their underlying data types
     if !check_dtypes && left.dtype() != right.dtype() {
-        if left.null_count() == left.len() && right.null_count() == right.len() {
+        if left.is_all_null() && right.is_all_null() {
             return Ok(());
         }
     }


### PR DESCRIPTION
I noticed this when working on https://github.com/pola-rs/polars/pull/26948. There were many instances across the codebase where various types where using `null_count() == len()` or `len() == null_count()` to check if the entire instance of that type was null. This is a simple PR that adds an `is_all_null` convenience method to `ChunkedArray`, `Logical`, `SeriesTrait`, and `Column`.

The new `is_all_null` method is then used to replace 43 instances of `null_count() == len()` across the codebase. 

I thought this was a logical change since it shortens the code and improves readability. 
