### PR TITLE
fix(rust): Flatten late `merge_sorted` unions

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/mod.rs
@@ -301,6 +301,15 @@ pub fn optimize(
         }
     }
 
+    if !opt_flags.eager() {
+        // The late order pass can rewrite merge_sorted into unions after the
+        // main union-flattening pass has already run. Flatten again here so any
+        // newly created nested unions are collapsed before execution planning.
+        let mut post_order_rules: Vec<Box<dyn OptimizationRule>> =
+            vec![Box::new(FlattenUnionRule {})];
+        root = opt.optimize_loop(&mut post_order_rules, expr_arena, ir_arena, root)?;
+    }
+
     expand_datasets::expand_datasets(root, ir_arena, expr_arena, apply_scan_predicate_to_scan_ir)?;
 
     // During debug we check if the optimizations have not modified the final schema.

--- a/py-polars/tests/unit/lazyframe/test_order_observability.py
+++ b/py-polars/tests/unit/lazyframe/test_order_observability.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 from typing import Any
 
 import pytest
@@ -162,6 +163,16 @@ def test_merge_sorted_to_union() -> None:
     explain = lf.explain()
     assert "MERGE_SORTED" not in explain
     assert "UNION" in explain
+
+
+def test_merge_sorted_chain_to_flat_union() -> None:
+    lfs = [pl.LazyFrame({"a": [i]}) for i in range(8)]
+
+    lf = functools.reduce(lambda a, b: a.merge_sorted(b, key="a"), lfs).sort("a")
+
+    explain = lf.explain()
+    assert explain.count("END UNION") == 1
+    assert "MERGE_SORTED" not in explain
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes: #26960 

The merge_sorted crash in 1.37 comes from a bad plan shape produced by the optimizer, not from merge_sorted itself returning the wrong data.

A repeated reduction like:

    functools.reduce(lambda a, b: a.merge_sorted(b, key="ts"), inputs)

builds a left-deep MergeSorted tree. When the query later ends in an order-destroying or order-reestablishing operator such as a final sort, the order-observability pass is allowed to rewrite each MergeSorted node into an unordered Union because the exact intermediate merge order is no longer semantically observable.

That rewrite is fine in isolation, but in 1.37 the order pass runs after the main FlattenUnionRule. The result is that the optimizer can manufacture a left-deep Union(Union(Union(...))) tree after the only flattening pass has already finished. The memory engine then executes that nested union tree recursively. With enough inputs, the recursive execution depth is large enough to overflow a rayon worker stack and segfault.

This patch keeps the existing MergeSorted -> Union optimization but immediately runs FlattenUnionRule again afterwards. That is enough to collapse the late-created nested unions back into one flat Union node before execution planning continues.

In other words, this does not disable the optimization. It preserves the cheaper unordered execution strategy while preventing the pathological recursive executor shape that was causing the crash.

The regression test added here intentionally uses a much smaller merge_sorted chain than the real crash repro. The production repro uses thousands of inputs; the test only needs enough inputs to prove the optimizer emits a single flat UNION block instead of a chain of nested UNION nodes.

-----

As requested by the first contribution guidelines:

<img width="1402" height="1285" alt="Screenshot 2026-03-18 at 12 55 52" src="https://github.com/user-attachments/assets/5a79d826-a6dd-463b-af93-7b725a689cba" />
