### PR TITLE
perf: Streaming native `backward_fill`

### DIFF
--- a/crates/polars-stream/src/nodes/backward_fill.rs
+++ b/crates/polars-stream/src/nodes/backward_fill.rs
@@ -1,0 +1,224 @@
+use polars_core::prelude::{Column, DataType, FillNullStrategy};
+use polars_error::PolarsResult;
+use polars_utils::IdxSize;
+use polars_utils::pl_str::PlSmallStr;
+
+use super::compute_node_prelude::*;
+use crate::DEFAULT_DISTRIBUTOR_BUFFER_SIZE;
+use crate::async_primitives::distributor_channel::distributor_channel;
+use crate::async_primitives::wait_group::WaitGroup;
+use crate::morsel::{MorselSeq, SourceToken, get_ideal_morsel_size};
+
+pub struct BackwardFillNode {
+    dtype: DataType,
+
+    /// Maximum number of consecutive nulls to fill.
+    limit: IdxSize,
+
+    /// Sequence counter for output morsels emitted by the serial thread.
+    seq: MorselSeq,
+
+    /// Count of trailing nulls from previous morsels not yet emitted. These are waiting for a
+    /// future non-null value to potentially fill them or to exceed the limit.
+    pending_nulls: IdxSize,
+
+    /// Column name.
+    col_name: PlSmallStr,
+}
+
+impl BackwardFillNode {
+    pub fn new(limit: Option<IdxSize>, dtype: DataType, col_name: PlSmallStr) -> Self {
+        Self {
+            limit: limit.unwrap_or(IdxSize::MAX),
+            dtype,
+            seq: MorselSeq::default(),
+            pending_nulls: 0,
+            col_name,
+        }
+    }
+}
+
+impl ComputeNode for BackwardFillNode {
+    fn name(&self) -> &str {
+        "backward_fill"
+    }
+
+    fn update_state(
+        &mut self,
+        recv: &mut [PortState],
+        send: &mut [PortState],
+        _state: &StreamingExecutionState,
+    ) -> PolarsResult<()> {
+        assert!(recv.len() == 1 && send.len() == 1);
+
+        if send[0] == PortState::Done {
+            recv[0] = PortState::Done;
+            self.pending_nulls = 0;
+        } else if recv[0] == PortState::Done {
+            // We may still have pending nulls to flush as actual nulls.
+            if self.pending_nulls > 0 {
+                send[0] = PortState::Ready;
+            } else {
+                send[0] = PortState::Done;
+            }
+        } else {
+            recv.swap_with_slice(send);
+        }
+
+        Ok(())
+    }
+
+    fn spawn<'env, 's>(
+        &'env mut self,
+        scope: &'s TaskScope<'s, 'env>,
+        recv_ports: &mut [Option<RecvPort<'_>>],
+        send_ports: &mut [Option<SendPort<'_>>],
+        _state: &'s StreamingExecutionState,
+        join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
+    ) {
+        assert_eq!(recv_ports.len(), 1);
+        assert_eq!(send_ports.len(), 1);
+
+        let recv = recv_ports[0].take();
+        let send = send_ports[0].take().unwrap();
+
+        let limit = self.limit;
+        let dtype = self.dtype.clone();
+        let pending_nulls = &mut self.pending_nulls;
+        let seq = &mut self.seq;
+        let col_name = self.col_name.clone();
+
+        let Some(recv) = recv else {
+            // Input exhausted. Flush remaining pending_nulls as actual nulls.
+            if *pending_nulls == 0 {
+                return;
+            }
+
+            let pending = *pending_nulls;
+            let mut send = send.serial();
+            join_handles.push(scope.spawn_task(TaskPriority::High, async move {
+                let source_token = SourceToken::new();
+                let morsel_size = get_ideal_morsel_size();
+                let mut remaining = pending as usize;
+                while remaining > 0 {
+                    let chunk_size = morsel_size.min(remaining);
+                    let df = Column::full_null(col_name.clone(), chunk_size, &dtype).into_frame();
+                    if send
+                        .send(Morsel::new(df, *seq, source_token.clone()))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                    *seq = seq.successor();
+                    remaining -= chunk_size;
+                }
+                Ok(())
+            }));
+
+            *pending_nulls = 0;
+            return;
+        };
+
+        let mut receiver = recv.serial();
+        let senders = send.parallel();
+
+        let (mut distributor, distr_receivers) =
+            distributor_channel(senders.len(), *DEFAULT_DISTRIBUTOR_BUFFER_SIZE);
+
+        // Serial thread: handles serial state and sends morsel without backward_fill to parallel
+        // workers.
+        let serial_dtype = dtype.clone();
+        join_handles.push(scope.spawn_task(TaskPriority::High, async move {
+            let dtype = serial_dtype;
+            let source_token = SourceToken::new();
+            let ideal_morsel_size = get_ideal_morsel_size() as IdxSize;
+
+            while let Ok(morsel) = receiver.recv().await {
+                let column = &morsel.df()[0];
+                let height = column.len();
+                if height == 0 {
+                    continue;
+                }
+
+                let null_count = column.null_count();
+                if null_count == height {
+                    *pending_nulls += height as IdxSize;
+                }
+
+                // Flush pending nulls that exceed the limit as already-final null morsels.
+                // This also covers the all-null case above.
+                while *pending_nulls > limit {
+                    let chunk_size = ideal_morsel_size.min(*pending_nulls - limit);
+                    let col = Column::full_null(col_name.clone(), chunk_size as usize, &dtype);
+                    let null_morsel = Morsel::new(col.into_frame(), *seq, source_token.clone());
+
+                    *seq = seq.successor();
+                    *pending_nulls -= chunk_size;
+                    if distributor.send(null_morsel).await.is_err() {
+                        return Ok(());
+                    }
+                }
+
+                if null_count == height {
+                    // Fast path: all nulls.
+                    continue;
+                }
+
+                let new_pending_nulls = if null_count == 0 {
+                    0
+                } else {
+                    // Note: unwrap is fine as `null_count != height`.
+                    let trailing_nulls = height - column.last_non_null().unwrap() - 1;
+                    (trailing_nulls as IdxSize).min(limit)
+                };
+
+                let mut column = if new_pending_nulls > 0 {
+                    // Remove new pending nulls.
+                    column.slice(0, column.len() - new_pending_nulls as usize)
+                } else {
+                    column.clone()
+                };
+                if *pending_nulls > 0 {
+                    // Prepend the old pending nulls.
+                    let mut c =
+                        Column::full_null(col_name.clone(), *pending_nulls as usize, &dtype);
+                    c.append_owned(column)?;
+                    column = c;
+                }
+
+                let morsel = Morsel::new(column.into_frame(), *seq, source_token.clone());
+
+                *seq = seq.successor();
+                *pending_nulls = new_pending_nulls;
+                if distributor.send(morsel).await.is_err() {
+                    return Ok(());
+                }
+            }
+
+            Ok(())
+        }));
+
+        // Parallel worker threads: Apply fill null and emit.
+        for (mut send, mut recv) in senders.into_iter().zip(distr_receivers) {
+            join_handles.push(scope.spawn_task(TaskPriority::High, async move {
+                let wait_group = WaitGroup::default();
+                while let Ok(mut morsel) = recv.recv().await {
+                    let col = &morsel.df()[0];
+                    if col.has_nulls() {
+                        *morsel.df_mut() = col
+                            .fill_null(FillNullStrategy::Backward(Some(limit)))?
+                            .into_frame();
+                    }
+                    morsel.set_consume_token(wait_group.token());
+                    if send.send(morsel).await.is_err() {
+                        break;
+                    }
+                    wait_group.wait().await;
+                }
+
+                Ok(())
+            }));
+        }
+    }
+}

--- a/crates/polars-stream/src/nodes/mod.rs
+++ b/crates/polars-stream/src/nodes/mod.rs
@@ -1,3 +1,4 @@
+pub mod backward_fill;
 pub mod callback_sink;
 #[cfg(feature = "cum_agg")]
 pub mod cum_agg;

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -436,9 +436,14 @@ fn visualize_plan_rec(
             format!("gather_every\\nn: {n}, offset: {offset}"),
             &[*input][..],
         ),
-        PhysNodeKind::ForwardFill { input, limit } => (
+        PhysNodeKind::ForwardFill { input, limit }
+        | PhysNodeKind::BackwardFill { input, limit } => (
             {
-                let mut out = String::from("forward_fill");
+                let mut out = if matches!(kind, PhysNodeKind::ForwardFill { .. }) {
+                    String::from("forward_fill")
+                } else {
+                    String::from("backward_fill")
+                };
                 if let Some(limit) = limit {
                     use std::fmt::Write;
                     writeln!(&mut out).unwrap();

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -1191,7 +1191,8 @@ fn lower_exprs_with_ctx(
                 input: ref inner_exprs,
                 function:
                     IRFunctionExpr::FillNullWithStrategy(
-                        polars_core::prelude::FillNullStrategy::Forward(limit),
+                        strategy @ (polars_core::prelude::FillNullStrategy::Forward(limit)
+                        | polars_core::prelude::FillNullStrategy::Backward(limit)),
                     ),
                 options: _,
             } => {
@@ -1206,7 +1207,12 @@ fn lower_exprs_with_ctx(
                     &[inner_exprs[0].with_alias(value_key.clone())],
                     ctx,
                 )?;
-                let node_kind = PhysNodeKind::ForwardFill { input, limit };
+                let node_kind =
+                    if matches!(strategy, polars_core::prelude::FillNullStrategy::Forward(_)) {
+                        PhysNodeKind::ForwardFill { input, limit }
+                    } else {
+                        PhysNodeKind::BackwardFill { input, limit }
+                    };
 
                 let output_schema = Schema::from_iter([(value_key.clone(), value_dtype.clone())]);
                 let node_key = ctx

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -264,6 +264,10 @@ pub enum PhysNodeKind {
         input: PhysStream,
         limit: Option<IdxSize>,
     },
+    BackwardFill {
+        input: PhysStream,
+        limit: Option<IdxSize>,
+    },
     Rle(PhysStream),
     RleId(PhysStream),
     PeakMinMax {
@@ -488,6 +492,7 @@ fn visit_node_inputs_mut(
             | PhysNodeKind::Multiplexer { input }
             | PhysNodeKind::GatherEvery { input, .. }
             | PhysNodeKind::ForwardFill { input, .. }
+            | PhysNodeKind::BackwardFill { input, .. }
             | PhysNodeKind::Rle(input)
             | PhysNodeKind::RleId(input)
             | PhysNodeKind::PeakMinMax { input, .. } => {

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -671,6 +671,17 @@ fn to_graph_rec<'a>(
             )
         },
 
+        BackwardFill { input, limit } => {
+            let input_key = to_graph_rec(input.node, ctx)?;
+            let input_schema = &ctx.phys_sm[input.node].output_schema;
+            assert_eq!(input_schema.len(), 1);
+            let (name, dtype) = input_schema.get_at_index(0).unwrap();
+            ctx.graph.add_node(
+                nodes::backward_fill::BackwardFillNode::new(*limit, dtype.clone(), name.clone()),
+                [(input_key, input.port)],
+            )
+        },
+
         PeakMinMax { input, is_peak_max } => {
             let input_key = to_graph_rec(input.node, ctx)?;
             ctx.graph.add_node(

--- a/py-polars/tests/unit/operations/test_fill_null.py
+++ b/py-polars/tests/unit/operations/test_fill_null.py
@@ -158,13 +158,14 @@ def test_forward_fill_is_length_preserving() -> None:
 
 
 @given(
-    s=series(allow_null=True, min_size=1),
+    s=series(allow_null=True),
     limit=st.one_of(st.none(), st.integers(min_value=0, max_value=10)),
 )
-def test_forward_fill_streaming_matches_in_memory(
-    s: pl.Series, limit: int | None
+@pytest.mark.parametrize("fill", ["forward_fill", "backward_fill"])
+def test_fill_streaming_matches_in_memory(
+    fill: str, s: pl.Series, limit: int | None
 ) -> None:
-    q = pl.LazyFrame({"a": s}).select(pl.col("a").forward_fill(limit=limit))
+    q = pl.LazyFrame({"a": s}).select(getattr(pl.col("a"), fill)(limit=limit))
     expected = q.collect(engine="in-memory")
     result = q.collect(engine="streaming")
     assert_series_equal(result["a"], expected["a"])


### PR DESCRIPTION
This implements `backward_fill` similarly to how `forward_fill` was implemented in #26922. This needs to buffer a `pending_nulls` count as it does not know what to fill nulls with yet.

Again, the streaming node is divided into two parts. A serial part that handles all the starts and prepares Morsel for parallel worker threads. These parallel worker threads call into the existing `BackwardFill` logic. This node can be seen as a merger of the `RleNode` and the `ForwardFillNode`.

The scaffolding was done by Claude, but again a lot of cleanup and manual editing had to happen. Although it did oneshot a functional version, it was much too long (600 lines, pfff) and the logic all over the place.

I appended `backward_fill` to the test from last time and tested with several configurations of sizes, `POLARS_IDEAL_MORSEL_SIZE` and `POLARS_MAX_THREADS`.

xref: #20947.
