### PR TITLE
fix: Raise for duplicate columns in `over()`

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_to_ir.rs
@@ -447,13 +447,20 @@ pub(super) fn to_aexpr_impl(
                 None
             };
 
+            // Convert partition_by expressions and check for duplicate names
+            let mut partition_nodes = Vec::with_capacity(partition_by.len());
+            let mut seen_names = PlHashSet::with_capacity(partition_by.len());
+
+            for expr in partition_by {
+                let (node, name) = to_aexpr_impl_materialized_lit(expr, ctx)?;
+                polars_ensure!(seen_names.insert(name.clone()), duplicate = name);
+                partition_nodes.push(node);
+            }
+
             (
                 AExpr::Over {
                     function,
-                    partition_by: partition_by
-                        .into_iter()
-                        .map(|e| Ok(to_aexpr_impl_materialized_lit(e, ctx)?.0))
-                        .collect::<PolarsResult<_>>()?,
+                    partition_by: partition_nodes,
                     order_by,
                     mapping,
                 },

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -2401,7 +2401,7 @@ def test_group_by_drop_nans(s: pl.Series) -> None:
             True,
         ),
         (
-            lambda e: e.fill_null(strategy="forward").over([e, e]),
+            lambda e: e.fill_null(strategy="forward").over([e]),
             True,
             False,
             True,

--- a/py-polars/tests/unit/operations/test_over.py
+++ b/py-polars/tests/unit/operations/test_over.py
@@ -181,3 +181,9 @@ def test_nulls_last_over_24989() -> None:
     )
 
     assert_frame_equal(out, expected)
+
+
+def test_over_duplicate_partition_by_26921() -> None:
+    df = pl.DataFrame({"x": [1, 2, 3]})
+    with pytest.raises(pl.exceptions.DuplicateError):
+        df.with_columns(pl.len().over("x", "x"))


### PR DESCRIPTION
Resolves #26921.

In `polars-plan/src/plans/conversion/dsl_to_ir/mod.rs`, the `Expr::Over` 
handling during DSL→IR conversion could panic in debug mode or silently 
produce incorrect results in release mode when duplicate column names were 
passed to `partition_by`. Added duplicate detection by tracking output names 
and raising a `DuplicateError` if the same column name appears more than once.

Also updated the parametric test that was using `.over([e, e])` which now 
correctly triggers the new duplicate detection.

🤖 Used Claude Sonnet 4.6 to help implement the duplicate detection logic and update the parametric test.
I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.
<img width="1608" height="235" alt="Capture d&#39;écran 2026-03-18 210622" src="https://github.com/user-attachments/assets/7df861f2-8c79-4a3f-aed6-7a28dbc52db5" />

