### PR TITLE
fix: Fall back to global streaming chunk size in `collect_batches`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3286,6 +3286,7 @@ dependencies = [
  "polars-arrow",
  "polars-buffer",
  "polars-compute",
+ "polars-config",
  "polars-core",
  "polars-expr",
  "polars-io",

--- a/crates/polars-lazy/Cargo.toml
+++ b/crates/polars-lazy/Cargo.toml
@@ -14,6 +14,7 @@ chrono = { workspace = true }
 futures = { workspace = true, optional = true }
 polars-buffer = { workspace = true }
 polars-compute = { workspace = true }
+polars-config = { workspace = true }
 polars-core = { workspace = true, features = ["lazy", "zip_with", "random"] }
 polars-expr = { workspace = true }
 polars-io = { workspace = true, features = ["lazy"] }

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -747,6 +747,8 @@ impl LazyFrame {
         chunk_size: Option<NonZeroUsize>,
         lazy: bool,
     ) -> PolarsResult<CollectBatches> {
+        let chunk_size = chunk_size
+            .or_else(|| NonZeroUsize::new(polars_config::config().ideal_morsel_size() as usize));
         let (send, recv) = sync_channel(1);
         let runner_send = send.clone();
         let ldf = self.sink_batches(

--- a/py-polars/tests/unit/io/test_collect_batches.py
+++ b/py-polars/tests/unit/io/test_collect_batches.py
@@ -109,3 +109,15 @@ print("OK", end="")
     )
 
     assert out == b"OK"
+
+
+def test_collect_batches_respects_config_chunk_size() -> None:
+    df = pl.DataFrame({"a": range(113)})
+
+    pl.Config.set_streaming_chunk_size(17)
+    try:
+        batches = list(df.lazy().collect_batches())
+        assert all(len(b) == 17 for b in batches[:-1])
+        assert_frame_equal(pl.concat(batches), df)
+    finally:
+        pl.Config.restore_defaults()


### PR DESCRIPTION
Closes #26963

When `collect_batches()` is called without an explicit `chunk_size`, it now 
falls back to the value set by `Config.set_streaming_chunk_size()` via 
`ideal_morsel_size`, instead of passing `None` to `CallbackSinkNode` (which 
means "no buffering").

Thanks to @0xRozier for identifying the root cause and suggesting the fix.

## Changes
- `crates/polars-lazy/src/frame/mod.rs`: Added config fallback for `chunk_size` 
  in `collect_batches()`
- `py-polars/tests/unit/io/test_collect_batches.py`: Added test verifying the 
  global config is respected

## AI disclosure
I used an AI assistant to help me navigate the codebase, set up the dev 
environment, and draft the test case. I have reviewed all changes in this PR and 
believe they are relevant and correct. The core fix was suggested by @0xRozier 
in the linked issue.

<img width="514" height="991" alt="Screenshot 2026-03-19 at 8 47 49 AM" src="https://github.com/user-attachments/assets/f1ae2a2f-461c-43e6-b73f-eebaa8b05f96" />