### PR TITLE
perf: improve to_numpy C-order by building Fortran-order then converting

### DIFF
--- a/crates/polars-core/src/chunked_array/ndarray.rs
+++ b/crates/polars-core/src/chunked_array/ndarray.rs
@@ -105,6 +105,8 @@ impl DataFrame {
         let mut membuf = Vec::with_capacity(shape.0 * shape.1);
         let ptr = membuf.as_ptr() as usize;
 
+        // Always build the buffer in Fortran (column-major) order for cache-friendly
+        // contiguous writes. For C-order output, we convert after filling the buffer.
         let columns = self.columns();
         POOL.install(|| {
             columns.par_iter().enumerate().try_for_each(|(col_idx, s)| {
@@ -130,31 +132,17 @@ impl DataFrame {
                 for arr in ca.downcast_iter() {
                     let vals = arr.values();
 
-                    // Depending on the desired order, we add items to the buffer.
                     // SAFETY:
                     // We get parallel access to the vector by offsetting index access accordingly.
-                    // For C-order, we only operate on every num-col-th element, starting from the
-                    // column index. For Fortran-order we only operate on n contiguous elements,
-                    // offset by n * the column index.
-                    match ordering {
-                        IndexOrder::C => unsafe {
-                            let num_cols = columns.len();
-                            let mut offset =
-                                (ptr as *mut N::Native).add(col_idx + chunk_offset * num_cols);
-                            for v in vals.iter() {
-                                *offset = *v;
-                                offset = offset.add(num_cols);
-                            }
-                        },
-                        IndexOrder::Fortran => unsafe {
-                            let offset_ptr =
-                                (ptr as *mut N::Native).add(col_idx * height + chunk_offset);
-                            // SAFETY:
-                            // this is uninitialized memory, so we must never read from this data
-                            // copy_from_slice does not read
-                            let buf = std::slice::from_raw_parts_mut(offset_ptr, vals.len());
-                            buf.copy_from_slice(vals)
-                        },
+                    // We only operate on n contiguous elements, offset by n * the column index.
+                    unsafe {
+                        let offset_ptr =
+                            (ptr as *mut N::Native).add(col_idx * height + chunk_offset);
+                        // SAFETY:
+                        // this is uninitialized memory, so we must never read from this data
+                        // copy_from_slice does not read
+                        let buf = std::slice::from_raw_parts_mut(offset_ptr, vals.len());
+                        buf.copy_from_slice(vals)
                     }
                     chunk_offset += vals.len();
                 }
@@ -168,14 +156,13 @@ impl DataFrame {
         unsafe {
             membuf.set_len(shape.0 * shape.1);
         }
-        // Depending on the desired order, we can either return the array buffer as-is or reverse
-        // the axes.
+        // The buffer is always in Fortran (column-major) order. Build the array accordingly,
+        // then convert to C-order if requested using `as_standard_layout()`.
+        let ndarr = Array2::from_shape_vec((shape.1, shape.0), membuf).unwrap();
+        let ndarr = ndarr.reversed_axes();
         match ordering {
-            IndexOrder::C => Ok(Array2::from_shape_vec((shape.0, shape.1), membuf).unwrap()),
-            IndexOrder::Fortran => {
-                let ndarr = Array2::from_shape_vec((shape.1, shape.0), membuf).unwrap();
-                Ok(ndarr.reversed_axes())
-            },
+            IndexOrder::C => Ok(ndarr.as_standard_layout().into_owned()),
+            IndexOrder::Fortran => Ok(ndarr),
         }
     }
 }

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
@@ -306,3 +306,14 @@ def test_to_numpy_array_shape_23426() -> None:
     )
 
     assert_frame_equal(df, pl.from_numpy(df.to_numpy(structured=True)))
+
+
+def test_to_numpy_c_order_matches_fortran_order() -> None:
+    df = pl.DataFrame({f"col_{i}": range(i, i + 100) for i in range(50)})
+
+    c_array = df.to_numpy(order="c")
+    f_array = df.to_numpy(order="fortran")
+
+    assert c_array.flags["C_CONTIGUOUS"]
+    assert f_array.flags["F_CONTIGUOUS"]
+    assert_array_equal(c_array, f_array)


### PR DESCRIPTION
Fixes #26855

## Problem
`df.to_numpy(order='c')` is ~6.5x slower than `np.ascontiguousarray(df.to_numpy(order='fortran'))` despite producing identical output. The C-order path in `ndarray.rs` writes elements with scattered stride-based writes (one element at a time, jumping across columns), creating poor cache locality for wide DataFrames.

## Fix
Build the array in Fortran order first (using contiguous `copy_from_slice` per column), then convert to C layout using `as_standard_layout()`. This matches what NumPy does internally and eliminates the cache-hostile scattered writes.

## Benchmark (from issue #26855)
- Before: `df.to_numpy(order='c')` — 541ms
- After (equivalent): `np.ascontiguousarray(df.to_numpy(order='fortran'))` — 83ms
- ~6.5x improvement

## Testing
- Existing C-order tests continue to pass
- Added correctness test verifying C-order and Fortran-order produce equivalent data