### PR TITLE
fix(python): Ensure `sample()`  respects the global set seed

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import contextlib
 import io
 import os
-import random
 from collections import defaultdict
 from collections.abc import (
     Generator,
@@ -11439,9 +11438,6 @@ class DataFrame:
         if n is not None and fraction is not None:
             msg = "cannot specify both `n` and `fraction`"
             raise ValueError(msg)
-
-        if seed is None:
-            seed = random.randint(0, 10000)
 
         if n is None and fraction is not None:
             if not isinstance(fraction, pl.Series):

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -11413,7 +11413,7 @@ class DataFrame:
             neither stable nor fully random.
         seed
             Seed for the random number generator. If set to None (default), a
-            random seed is generated for each sample operation.
+            random seed is generated for each time the sample is called.
 
         Examples
         --------

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -3354,3 +3354,14 @@ def test_sort_errors_with_object_dtype_24677() -> None:
         match=r"column '.*' has a dtype of '.*', which does not support sorting",
     ):
         df.sort("a")
+
+
+def test_sample_respects_global_seed_26973() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8]})
+
+    pl.set_random_seed(0)
+    result1 = df.sample(1)
+    pl.set_random_seed(0)
+    result2 = df.sample(1)
+
+    assert_frame_equal(result1, result2)


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/26973.

In the Python code, if the seed was not set, it was defaulting to:

```
seed = random.randint(0, 10000)
```

This was bypassing the Rust backend that properly handles dealing with set/unset seeds. Deleting this line also increases the randomness range since it falls back to `get_global_random_u64` in Rust. I followed the `shuffle()` implementation as a guide since it was properly respecting the global seed and correctly delegating to the Rust backend.