### PR TITLE
fix(rust): Support broadcast inputs in `str.replace`/`str.replace_all`

### DIFF
--- a/crates/polars-expr/src/dispatch/strings.rs
+++ b/crates/polars-expr/src/dispatch/strings.rs
@@ -2,7 +2,9 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use polars_core::prelude::*;
-use polars_core::utils::{CustomIterTools, handle_casting_failures};
+#[cfg(feature = "regex")]
+use polars_core::ternary_output_height;
+use polars_core::utils::handle_casting_failures;
 #[cfg(feature = "regex")]
 use polars_ops::chunked_array::strings::split_regex_helper;
 use polars_ops::prelude::{BinaryNameSpaceImpl, StringNameSpaceImpl};
@@ -584,152 +586,150 @@ fn get_pat(pat: &StringChunked) -> PolarsResult<&str> {
     )
 }
 
-// used only if feature="regex"
-#[allow(dead_code)]
-fn iter_and_replace<'a, F>(ca: &'a StringChunked, val: &'a StringChunked, f: F) -> StringChunked
-where
-    F: Fn(&'a str, &'a str) -> Cow<'a, str>,
-{
-    let mut out: StringChunked = ca
-        .into_iter()
-        .zip(val)
-        .map(|(opt_src, opt_val)| match (opt_src, opt_val) {
-            (Some(src), Some(val)) => Some(f(src, val)),
-            (Some(src), None) => Some(Cow::from(src)),
-            _ => None,
-        })
-        .collect_trusted();
-
-    out.rename(ca.name().clone());
-    out
-}
-
 #[cfg(feature = "regex")]
 fn is_literal_pat(pat: &str) -> bool {
     pat.chars().all(|c| !c.is_ascii_punctuation())
 }
 
 #[cfg(feature = "regex")]
-fn replace_n<'a>(
-    ca: &'a StringChunked,
-    pat: &'a StringChunked,
-    val: &'a StringChunked,
+fn replace_broadcast<F>(
+    ca: &StringChunked,
+    pat: &StringChunked,
+    val: &StringChunked,
     literal: bool,
-    n: usize,
-) -> PolarsResult<StringChunked> {
-    match (pat.len(), val.len()) {
-        (1, 1) => {
-            let pat = get_pat(pat)?;
-            let Some(val) = val.get(0) else {
-                return Ok(ca.clone());
-            };
-            let literal = literal || is_literal_pat(pat);
+    apply_regex: F,
+) -> PolarsResult<StringChunked>
+where
+    F: Fn(&regex::Regex, &str, &str, bool) -> String,
+{
+    let output_height = ternary_output_height!(ca, pat, val, op = "str.replace")?;
 
-            match literal {
-                true => ca.replace_literal(pat, val, n),
-                false => {
-                    if n > 1 {
-                        polars_bail!(ComputeError: "regex replacement with 'n > 1' not yet supported")
-                    }
-                    ca.replace(pat, val)
-                },
+    if pat.len() == 1 {
+        let mut pat_str = get_pat(pat)?.to_string();
+        let literal_pat = literal || is_literal_pat(&pat_str);
+        if literal_pat {
+            pat_str = escape(&pat_str);
+        }
+        let reg = polars_utils::regex_cache::compile_regex(&pat_str)?;
+
+        let ca = ca.rechunk();
+        let val = val.rechunk();
+        let mut builder = StringChunkedBuilder::new(ca.name().clone(), output_height);
+        for i in 0..output_height {
+            let src = ca.get(if ca.len() == 1 { 0 } else { i });
+            let v = val.get(if val.len() == 1 { 0 } else { i });
+            match (src, v) {
+                (Some(s), Some(v)) => builder.append_value(apply_regex(&reg, s, v, literal_pat)),
+                (Some(s), None) => builder.append_value(s),
+                _ => builder.append_null(),
             }
-        },
-        (1, len_val) => {
-            if n > 1 {
-                polars_bail!(ComputeError: "multivalue replacement with 'n > 1' not yet supported")
-            }
-
-            if n == 0 {
-                return Ok(ca.clone());
-            };
-
-            // from here on, we know that n == 1
-            let mut pat = get_pat(pat)?.to_string();
-            polars_ensure!(
-                len_val == ca.len(),
-                ComputeError:
-                "replacement value length ({}) does not match string column length ({})",
-                len_val, ca.len(),
-            );
-            let lit = is_literal_pat(&pat);
-            let literal_pat = literal || lit;
-
-            if literal_pat {
-                pat = escape(&pat)
-            }
-
-            let reg = polars_utils::regex_cache::compile_regex(&pat)?;
-
-            let f = |s: &'a str, val: &'a str| {
-                if literal {
-                    reg.replace(s, NoExpand(val))
-                } else {
-                    reg.replace(s, val)
-                }
-            };
-
-            Ok(iter_and_replace(ca, val, f))
-        },
-        _ => polars_bail!(
-            ComputeError: "dynamic pattern length in 'str.replace' expressions is not supported yet"
-        ),
+        }
+        return Ok(builder.finish());
     }
+
+    let ca = ca.rechunk();
+    let pat = pat.rechunk();
+    let val = val.rechunk();
+    let mut builder = StringChunkedBuilder::new(ca.name().clone(), output_height);
+    for i in 0..output_height {
+        let src = ca.get(if ca.len() == 1 { 0 } else { i });
+        let p = pat.get(if pat.len() == 1 { 0 } else { i });
+        let v = val.get(if val.len() == 1 { 0 } else { i });
+        match (src, p, v) {
+            (Some(s), Some(p), Some(v)) => {
+                let literal_pat = literal || is_literal_pat(p);
+                let pat_str = if literal_pat {
+                    Cow::Owned(escape(p))
+                } else {
+                    Cow::Borrowed(p)
+                };
+                let reg = polars_utils::regex_cache::compile_regex(&pat_str)?;
+                builder.append_value(apply_regex(&reg, s, v, literal_pat));
+            },
+            (Some(s), None, _) | (Some(s), _, None) => builder.append_value(s),
+            _ => builder.append_null(),
+        }
+    }
+    Ok(builder.finish())
 }
 
 #[cfg(feature = "regex")]
-fn replace_all<'a>(
-    ca: &'a StringChunked,
-    pat: &'a StringChunked,
-    val: &'a StringChunked,
+fn replace_n(
+    ca: &StringChunked,
+    pat: &StringChunked,
+    val: &StringChunked,
+    literal: bool,
+    n: usize,
+) -> PolarsResult<StringChunked> {
+    if pat.len() == 1 && val.len() == 1 {
+        let pat_str = get_pat(pat)?;
+        let Some(val_str) = val.get(0) else {
+            return Ok(ca.clone());
+        };
+        let literal = literal || is_literal_pat(pat_str);
+
+        return match literal {
+            true => ca.replace_literal(pat_str, val_str, n),
+            false => {
+                if n > 1 {
+                    polars_bail!(ComputeError: "regex replacement with 'n > 1' not yet supported")
+                }
+                ca.replace(pat_str, val_str)
+            },
+        };
+    }
+
+    if n > 1 {
+        polars_bail!(ComputeError: "multivalue replacement with 'n > 1' not yet supported")
+    }
+    if n == 0 {
+        let output_height = ternary_output_height!(ca, pat, val, op = "str.replace")?;
+        if ca.len() == output_height {
+            return Ok(ca.clone());
+        }
+        let mut out = ca.new_from_index(0, output_height);
+        out.rename(ca.name().clone());
+        return Ok(out);
+    }
+
+    replace_broadcast(ca, pat, val, literal, |reg, src, v, literal_pat| {
+        let result = if literal_pat {
+            reg.replace(src, NoExpand(v))
+        } else {
+            reg.replace(src, v)
+        };
+        result.into_owned()
+    })
+}
+
+#[cfg(feature = "regex")]
+fn replace_all(
+    ca: &StringChunked,
+    pat: &StringChunked,
+    val: &StringChunked,
     literal: bool,
 ) -> PolarsResult<StringChunked> {
-    match (pat.len(), val.len()) {
-        (1, 1) => {
-            let pat = get_pat(pat)?;
-            let val = val.get(0).ok_or_else(
-                || polars_err!(ComputeError: "value cannot be 'null' in 'replace' expression"),
-            )?;
-            let literal = literal || is_literal_pat(pat);
+    if pat.len() == 1 && val.len() == 1 {
+        let pat_str = get_pat(pat)?;
+        let val_str = val.get(0).ok_or_else(
+            || polars_err!(ComputeError: "value cannot be 'null' in 'replace' expression"),
+        )?;
+        let literal = literal || is_literal_pat(pat_str);
 
-            match literal {
-                true => ca.replace_literal_all(pat, val),
-                false => ca.replace_all(pat, val),
-            }
-        },
-        (1, len_val) => {
-            let mut pat = get_pat(pat)?.to_string();
-            polars_ensure!(
-                len_val == ca.len(),
-                ComputeError:
-                "replacement value length ({}) does not match string column length ({})",
-                len_val, ca.len(),
-            );
-
-            let literal_pat = literal || is_literal_pat(&pat);
-
-            if literal_pat {
-                pat = escape(&pat)
-            }
-
-            let reg = polars_utils::regex_cache::compile_regex(&pat)?;
-
-            let f = |s: &'a str, val: &'a str| {
-                // According to the docs for replace_all
-                // when literal = True then capture groups are ignored.
-                if literal {
-                    reg.replace_all(s, NoExpand(val))
-                } else {
-                    reg.replace_all(s, val)
-                }
-            };
-
-            Ok(iter_and_replace(ca, val, f))
-        },
-        _ => polars_bail!(
-            ComputeError: "dynamic pattern length in 'str.replace' expressions is not supported yet"
-        ),
+        return match literal {
+            true => ca.replace_literal_all(pat_str, val_str),
+            false => ca.replace_all(pat_str, val_str),
+        };
     }
+
+    replace_broadcast(ca, pat, val, literal, |reg, src, v, literal_pat| {
+        let result = if literal_pat {
+            reg.replace_all(src, NoExpand(v))
+        } else {
+            reg.replace_all(src, v)
+        };
+        result.into_owned()
+    })
 }
 
 pub(super) fn format(s: &mut [Column], format: &str, insertions: &[usize]) -> PolarsResult<Column> {

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -2315,3 +2315,130 @@ def test_str_split_regex_scalar_string_expr() -> None:
     )
 
     assert_frame_equal(out, expected)
+
+
+def test_str_replace_broadcast_26789() -> None:
+    lf = pl.LazyFrame({"foo": ["123 bla 45 asd", "xyz 678 910t"], "value": ["A", "B"]})
+    q = lf.select(pl.col("foo").str.replace(pl.col("foo").first(), pl.col("value")))
+    expected = pl.DataFrame({"foo": ["A", "xyz 678 910t"]})
+    assert_frame_equal(q.collect(), expected)
+    assert_frame_equal(q.collect(engine="streaming"), expected)
+
+
+def test_str_replace_scalar_source_broadcast_26789() -> None:
+    df = pl.DataFrame({"a": ["A", "B"]})
+    q = df.lazy().select(pl.lit("A").str.replace(pl.col("a"), "X"))
+    expected = pl.DataFrame({"literal": ["X", "A"]})
+    assert_frame_equal(q.collect(), expected)
+    assert_frame_equal(q.collect(engine="streaming"), expected)
+
+
+def test_str_replace_scalar_pat_column_val_26789() -> None:
+    df = pl.DataFrame({"foo": ["hello world", "foo bar"], "val": ["X", "Y"]})
+    q = df.lazy().select(pl.col("foo").str.replace(pl.lit("o"), pl.col("val")))
+    expected = pl.DataFrame({"foo": ["hellX world", "fYo bar"]})
+    assert_frame_equal(q.collect(), expected)
+    assert_frame_equal(q.collect(engine="streaming"), expected)
+
+
+def test_str_replace_scalar_val_column_pat_26789() -> None:
+    df = pl.DataFrame({"foo": ["abc def", "ghi jkl"], "pat": ["abc", "jkl"]})
+    q = df.lazy().select(pl.col("foo").str.replace(pl.col("pat"), pl.lit("Z")))
+    expected = pl.DataFrame({"foo": ["Z def", "ghi Z"]})
+    assert_frame_equal(q.collect(), expected)
+    assert_frame_equal(q.collect(engine="streaming"), expected)
+
+
+def test_str_replace_all_broadcast_26789() -> None:
+    df = pl.DataFrame(
+        {
+            "foo": ["aaa bbb aaa", "ccc ddd ccc"],
+            "pat": ["aaa", "ccc"],
+            "val": ["X", "Y"],
+        }
+    )
+    q = df.lazy().select(pl.col("foo").str.replace_all(pl.col("pat"), pl.col("val")))
+    expected = pl.DataFrame({"foo": ["X bbb X", "Y ddd Y"]})
+    assert_frame_equal(q.collect(), expected)
+    assert_frame_equal(q.collect(engine="streaming"), expected)
+
+
+def test_str_replace_all_scalar_source_26789() -> None:
+    df = pl.DataFrame({"pat": ["A", "B"], "val": ["X", "Y"]})
+    q = df.lazy().select(pl.lit("A B A").str.replace_all(pl.col("pat"), pl.col("val")))
+    expected = pl.DataFrame({"literal": ["X B X", "A Y A"]})
+    assert_frame_equal(q.collect(), expected)
+    assert_frame_equal(q.collect(engine="streaming"), expected)
+
+
+def test_str_replace_broadcast_regex_pattern_26789() -> None:
+    df = pl.DataFrame(
+        {
+            "foo": ["abc123", "def456"],
+            "pat": [r"\d+", r"[a-z]+"],
+            "val": ["NUM", "ALPHA"],
+        }
+    )
+    q = df.lazy().select(pl.col("foo").str.replace(pl.col("pat"), pl.col("val")))
+    expected = pl.DataFrame({"foo": ["abcNUM", "ALPHA456"]})
+    assert_frame_equal(q.collect(), expected)
+    assert_frame_equal(q.collect(engine="streaming"), expected)
+
+
+def test_str_replace_broadcast_with_nulls_26789() -> None:
+    df = pl.DataFrame(
+        {"foo": ["abc", "def", None], "pat": ["a", None, "d"], "val": ["X", "Y", "Z"]}
+    )
+    result = df.select(pl.col("foo").str.replace(pl.col("pat"), pl.col("val")))
+    expected = pl.DataFrame({"foo": ["Xbc", "def", None]})
+    assert_frame_equal(result, expected)
+
+
+def test_str_replace_broadcast_null_val_preserves_26789() -> None:
+    df = pl.DataFrame({"foo": ["abc", "def"], "val": [None, "X"]})
+    q = df.lazy().select(pl.col("foo").str.replace(pl.lit("d"), pl.col("val")))
+    expected = pl.DataFrame({"foo": ["abc", "Xef"]})
+    assert_frame_equal(q.collect(), expected)
+    assert_frame_equal(q.collect(engine="streaming"), expected)
+
+
+def test_str_replace_broadcast_no_match_26789() -> None:
+    df = pl.DataFrame(
+        {"foo": ["hello", "world"], "pat": ["zzz", "qqq"], "val": ["X", "Y"]}
+    )
+    q = df.lazy().select(pl.col("foo").str.replace(pl.col("pat"), pl.col("val")))
+    expected = pl.DataFrame({"foo": ["hello", "world"]})
+    assert_frame_equal(q.collect(), expected)
+    assert_frame_equal(q.collect(engine="streaming"), expected)
+
+
+def test_str_replace_broadcast_empty_strings_26789() -> None:
+    df = pl.DataFrame(
+        {"foo": ["", "abc", ""], "pat": ["", "a", "x"], "val": ["Y", "Z", "W"]}
+    )
+    q = df.lazy().select(pl.col("foo").str.replace(pl.col("pat"), pl.col("val")))
+    expected = pl.DataFrame({"foo": ["Y", "Zbc", ""]})
+    assert_frame_equal(q.collect(), expected)
+    assert_frame_equal(q.collect(engine="streaming"), expected)
+
+
+def test_str_replace_all_broadcast_regex_26789() -> None:
+    df = pl.DataFrame(
+        {
+            "foo": ["abc123abc", "def456def"],
+            "pat": [r"\d+", r"[a-z]+"],
+            "val": ["N", "A"],
+        }
+    )
+    q = df.lazy().select(pl.col("foo").str.replace_all(pl.col("pat"), pl.col("val")))
+    expected = pl.DataFrame({"foo": ["abcNabc", "A456A"]})
+    assert_frame_equal(q.collect(), expected)
+    assert_frame_equal(q.collect(engine="streaming"), expected)
+
+
+def test_str_replace_all_scalar_pat_column_val_26789() -> None:
+    df = pl.DataFrame({"foo": ["aXa", "bXb"], "val": ["1", "2"]})
+    q = df.lazy().select(pl.col("foo").str.replace_all(pl.lit("X"), pl.col("val")))
+    expected = pl.DataFrame({"foo": ["a1a", "b2b"]})
+    assert_frame_equal(q.collect(), expected)
+    assert_frame_equal(q.collect(engine="streaming"), expected)


### PR DESCRIPTION
Fixes #26789

`str.replace` and `str.replace_all` panic with `POLARS_MAX_THREADS=1` when the streaming engine produces non-scalar pattern columns (e.g., from `.first()`).

The root cause: with a single thread, the streaming engine packs all data into one morsel, so `.first()` materializes as a full-length column instead of a length-1 scalar. The existing `replace_n` and `replace_all` only handled `(pat.len() == 1, val.len() == 1)` and `(pat.len() == 1, val.len() == N)` — all other combinations hit a catch-all panic.

**Changes:**

- Extract shared `replace_broadcast` function that handles all 3-way broadcast combinations for `ca`, `pat`, and `val` using the `ternary_output_height!` macro
- Scalar pattern path compiles regex once outside the loop
- Multi-pattern path compiles regex per row via the LRU cache
- Null pattern or null value preserves the original source string (consistent with `iter_and_replace` semantics)
- `n == 0` validates broadcast shape before returning, and correctly broadcasts scalar `ca` to the output height
- Conditional rechunk (only when `chunks().len() > 1`)
- Remove dead `iter_and_replace` helper
- Regex compilation errors propagate as `PolarsResult` instead of being silently swallowed as nulls
- 13 regression tests covering: streaming + in-memory engines, scalar source/pat/val combinations, regex patterns in broadcast, null handling, no-match, empty strings, `replace_all` variants