### PR TITLE
chore: Fix CI by excluding missing wheel version of pyiceberg

### DIFF
--- a/py-polars/requirements-ci.txt
+++ b/py-polars/requirements-ci.txt
@@ -6,5 +6,5 @@ duckdb
 torch
 jax[cpu]
 pyiceberg>=0.7.1
-pyiceberg-core
+pyiceberg-core!=0.9.0  # 0.9.0 is missing a wheel
 polars-ds==0.10.0


### PR DESCRIPTION
Upstream issue: https://github.com/apache/iceberg-python/issues/3190.