### PR TITLE
fix: Preserve casts for horizontal ops with untyped literals

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/function_expr/mod.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/mod.rs
@@ -1200,11 +1200,18 @@ impl IRFunctionExpr {
             F::SetSortedFlag(_) => FunctionOptions::elementwise(),
             #[cfg(feature = "ffi_plugin")]
             F::FfiPlugin { flags, .. } => *flags,
-            F::MaxHorizontal | F::MinHorizontal => FunctionOptions::elementwise().with_flags(|f| {
-                f | FunctionFlags::INPUT_WILDCARD_EXPANSION | FunctionFlags::ALLOW_RENAME
-            }),
-            F::MeanHorizontal { .. } | F::SumHorizontal { .. } => FunctionOptions::elementwise()
+            F::MaxHorizontal | F::MinHorizontal => FunctionOptions::elementwise()
+                .with_flags(|f| {
+                    f | FunctionFlags::INPUT_WILDCARD_EXPANSION | FunctionFlags::ALLOW_RENAME
+                })
+                .with_supertyping(
+                    (SuperTypeFlags::default() & !SuperTypeFlags::ALLOW_PRIMITIVE_TO_STRING).into(),
+                ),
+            F::MeanHorizontal { .. } => FunctionOptions::elementwise()
                 .with_flags(|f| f | FunctionFlags::INPUT_WILDCARD_EXPANSION),
+            F::SumHorizontal { .. } => FunctionOptions::elementwise()
+                .with_flags(|f| f | FunctionFlags::INPUT_WILDCARD_EXPANSION)
+                .with_supertyping(Default::default()),
 
             F::FoldHorizontal { returns_scalar, .. }
             | F::ReduceHorizontal { returns_scalar, .. } => FunctionOptions::groupwise()

--- a/py-polars/tests/unit/operations/aggregation/test_horizontal.py
+++ b/py-polars/tests/unit/operations/aggregation/test_horizontal.py
@@ -8,7 +8,7 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
-from polars.exceptions import ComputeError, PolarsError
+from polars.exceptions import ComputeError, InvalidOperationError, PolarsError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -284,6 +284,14 @@ def test_str_sum_horizontal() -> None:
     assert_series_equal(out["A"], pl.Series("A", ["af", "bg", "h", "c", ""]))
 
 
+def test_str_primitive_sum_horizontal() -> None:
+    result = (
+        pl.LazyFrame({"a": ["A"]}).select(pl.sum_horizontal("a", pl.lit(1))).collect()
+    )
+    expected = pl.DataFrame({"a": ["A1"]})
+    assert_frame_equal(result, expected)
+
+
 def test_sum_null_dtype() -> None:
     df = pl.DataFrame(
         {
@@ -438,6 +446,89 @@ def test_mean_horizontal() -> None:
 
     expected = pl.LazyFrame({"mean": [2.0, 3.0, 6.0]}, schema={"mean": pl.Float64})
     assert_frame_equal(result, expected)
+
+
+def test_horizontal_untyped_literal_cast_regression_26723() -> None:
+    df = pl.DataFrame({"a": [1, 2], "b": [1, 2]}, schema={"a": pl.Int8, "b": pl.Int16})
+
+    expected_no_cast = pl.DataFrame(
+        {
+            "a": [1, 2],
+            "b": [1, 2],
+            "sum_a": [1, 2],
+            "max_a": [1, 2],
+            "min_a": [0, 0],
+            "sum_b": [1, 2],
+        },
+        schema={
+            "a": pl.Int8,
+            "b": pl.Int16,
+            "sum_a": pl.Int8,
+            "max_a": pl.Int8,
+            "min_a": pl.Int8,
+            "sum_b": pl.Int16,
+        },
+    )
+
+    expected_cast = pl.DataFrame(
+        {
+            "a": [1, 2],
+            "b": [1, 2],
+            "sum_a": [1, 2],
+            "max_a": [1, 2],
+            "min_a": [0, 0],
+            "sum_b": [1, 2],
+        },
+        schema={
+            "a": pl.Int8,
+            "b": pl.Int16,
+            "sum_a": pl.Int8,
+            "max_a": pl.Int8,
+            "min_a": pl.Int8,
+            "sum_b": pl.Int8,
+        },
+    )
+
+    out_no_cast = df.with_columns(
+        sum_a=pl.sum_horizontal("a", 0),
+        max_a=pl.max_horizontal("a", 0),
+        min_a=pl.min_horizontal("a", 0),
+        sum_b=pl.sum_horizontal("b", 0),
+    )
+    assert_frame_equal(out_no_cast, expected_no_cast)
+
+    out_lf_no_cast = (
+        df.lazy()
+        .with_columns(
+            sum_a=pl.sum_horizontal("a", 0),
+            max_a=pl.max_horizontal("a", 0),
+            min_a=pl.min_horizontal("a", 0),
+            sum_b=pl.sum_horizontal("b", 0),
+        )
+        .collect()
+    )
+    assert_frame_equal(out_lf_no_cast, expected_no_cast)
+
+    out_expr_cast = df.with_columns(
+        sum_a=pl.sum_horizontal("a", 0).cast(pl.Int8),
+        max_a=pl.max_horizontal("a", 0).cast(pl.Int8),
+        min_a=pl.min_horizontal("a", 0).cast(pl.Int8),
+        sum_b=pl.sum_horizontal("b", 0).cast(pl.Int8),
+    )
+    assert_frame_equal(out_expr_cast, expected_cast)
+
+    out_lf_cast = (
+        df.lazy()
+        .with_columns(
+            sum_a=pl.sum_horizontal("a", 0),
+            max_a=pl.max_horizontal("a", 0),
+            min_a=pl.min_horizontal("a", 0),
+            sum_b=pl.sum_horizontal("b", 0),
+        )
+        .cast({"sum_a": pl.Int8, "max_a": pl.Int8, "min_a": pl.Int8, "sum_b": pl.Int8})
+        .collect()
+    )
+    assert_frame_equal(out_lf_cast, expected_cast)
 
 
 def test_mean_horizontal_bool() -> None:
@@ -664,7 +755,7 @@ def test_raise_invalid_types_21835() -> None:
     df = pl.DataFrame({"x": [1, 2], "y": ["three", "four"]})
 
     with pytest.raises(
-        ComputeError,
-        match=r"cannot compare string with numeric type \(i64\)",
+        InvalidOperationError,
+        match=r"got invalid or ambiguous dtypes: '\[i64, str\]' in expression 'min_horizontal'",
     ):
         df.select(pl.min_horizontal("x", "y"))


### PR DESCRIPTION
This PR aims to solve for https://github.com/pola-rs/polars/issues/26723, and is a follow up based on the review from: https://github.com/pola-rs/polars/pull/26767

As per the https://docs.pola.rs/development/contributing/#pull-requests, here are the screenshots of `make test` locally passing:
<img width="1430" height="1510" alt="Screenshot 2026-03-23 at 8 13 55 PM" src="https://github.com/user-attachments/assets/98801aba-5514-4bf0-9d76-ec3dfec2c94e" />
<img width="1433" height="1806" alt="Screenshot 2026-03-23 at 8 12 28 PM" src="https://github.com/user-attachments/assets/e9fd7742-24ed-487c-a28f-1620106bd658" />

In this PR, AI was used to assist with additional root cause investigation, identifying the fix approach given reviewer feedback on https://github.com/pola-rs/polars/pull/26767, and initial test generation. However, I confirm the final implementation and test updates were written by me.

@nameexhaustion following up on the last comments regarding `args_to_supertype`, my understanding of the suggestion was, "can we fix this bug by only changing `args_to_supertype`?" If that is the case, I could not find a correct fix by only changing `args_to_supertype`, because the bug is not in the supertype computation. It is that horizontal ops were not opting into the shared coercion pass.

To support the above with some more details:
- Based on my current knowledge/understanding of the polars codebase, `args_to_supertype` appears to compute a type from a list of dtypes based on this: https://github.com/abhidotsh/polars/blob/e58a0c3bed13720c2e99725865339dab13eede0b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs#L809-L832 It does not control whether the function's inputs actually get cast to that type prior to execution. The casting appears to happen in the shared coercion pass right here: https://github.com/abhidotsh/polars/blob/e58a0c3bed13720c2e99725865339dab13eede0b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs#L639-L704
- The lower-level supertype computation is already doing the right thing if we look at https://github.com/abhidotsh/polars/blob/e58a0c3bed13720c2e99725865339dab13eede0b/crates/polars-core/src/utils/supertype.rs#L465-L477 where Polars uses `materialize_smallest_dyn_int` when combining a concrete numeric type with an unknown integer literal to pick the smallest fitting integer type. For `0`, that leads to `Int8` via `materialize_smallest_dyn_int` (https://github.com/abhidotsh/polars/blob/e58a0c3bed13720c2e99725865339dab13eede0b/crates/polars-core/src/utils/supertype.rs#L652-L663)
- If we contrast the above points with the generic runtime materialization path, it uses `materialize_dyn_int` which turns small ints into Int32, this can be seen here: https://github.com/abhidotsh/polars/blob/e58a0c3bed13720c2e99725865339dab13eede0b/crates/polars-core/src/utils/supertype.rs#L611-L618 and which appears to be the mismatch.

To add on to the above points, `args_to_supertype` is also shared by other functions via `map_to_supertype`, including `FillNull` and `Coalesce`:
- https://github.com/abhidotsh/polars/blob/e58a0c3bed13720c2e99725865339dab13eede0b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs#L625-L629
- https://github.com/abhidotsh/polars/blob/e58a0c3bed13720c2e99725865339dab13eede0b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs#L66-L66
- https://github.com/abhidotsh/polars/blob/e58a0c3bed13720c2e99725865339dab13eede0b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs#L47-L47
This means that if we tried to fix this via `args_to_supertype`, we would be changing a shared schema helper instead of horizontal-specific behavior.

If the above makes sense, the proper fix should be to not change the supertype computation, but to instead make horizontal ops opt into the shared coercion pass so the literal gets cast to the agreed supertype before the function runs. As part of the fix, the supertyping uses `!ALLOW_PRIMITIVE_TO_STRING` to prevent `min_horizontal(int_col, str_col)` from silently coercing to string comparison instead of erroring. This changes the existing error from a runtime `ComputeError` to a planning-time `InvalidOperationError` which we can see is reflected in `test_raise_invalid_types_21835`.

Please let me know if there are any questions/comments/suggestions/concerns, and correct me if my understanding is incorrect on any of the above, given my new (and limited) understanding of the Polars codebase. If there is a specific fix already in mind or any general suggestions on the current PR, please let me know and I am happy to adjust.
