### PR TITLE
fix: Covariance with constant is zero, not NaN

### DIFF
--- a/crates/polars-ops/src/chunked_array/cov.rs
+++ b/crates/polars-ops/src/chunked_array/cov.rs
@@ -13,7 +13,7 @@ where
     ChunkedArray<T>: ChunkVar,
 {
     if a.len() == 1 || b.len() == 1 {
-        return Some(f64::NAN);
+        return Some(0.0); // (Broadcasted) constant -> zero covariance.
     }
     let (a, b) = align_chunks_binary(a, b);
     let mut out = CovState::default();
@@ -31,7 +31,7 @@ where
     ChunkedArray<T>: ChunkVar,
 {
     if a.len() == 1 || b.len() == 1 {
-        return Some(f64::NAN);
+        return Some(f64::NAN); // (Broadcasted) constant -> NaN correlation.
     }
     let (a, b) = align_chunks_binary(a, b);
     let mut out = PearsonState::default();

--- a/py-polars/tests/unit/operations/test_statistics.py
+++ b/py-polars/tests/unit/operations/test_statistics.py
@@ -152,9 +152,9 @@ def test_correction_shape_mismatch_22080() -> None:
         pl.select(pl.corr(pl.Series([1, 2]), pl.Series([2, 3, 5])))
 
 
-def test_corr_cov_lit_produces_nan_26633() -> None:
+def test_corr_cov_lit_produces_zero_nan_26633() -> None:
     df = pl.DataFrame({"a": [1, 3, 2]})
     result_corr = df.select(pl.corr(pl.lit(1), "a"))
     assert math.isnan(result_corr.item())
     result_cov = df.select(pl.cov(pl.lit(1), "a"))
-    assert math.isnan(result_cov.item())
+    assert math.isclose(result_cov.item(), 0.0)


### PR DESCRIPTION
Was introduced in https://github.com/pola-rs/polars/pull/26697.

cc @Kevin-Patyk 