### PR TITLE
chore: Fix cloud test

### DIFF
--- a/py-polars/tests/conftest.py
+++ b/py-polars/tests/conftest.py
@@ -60,12 +60,7 @@ def _patched_cloud(
 
             return prev_collect(
                 with_timeout(
-                    lambda: (
-                        lf.remote(plan_type="plain")
-                        .distributed()
-                        .execute()
-                        .await_result()
-                    )
+                    lambda: lf.remote(plan_type="plain").distributed().execute()
                 ).lazy()
             )
 


### PR DESCRIPTION
`execute()` is now blocking so mypy was complaining about `.await_result()`.