### PR TITLE
fix: Resolve stack overflow on `merge_sorted` and `union`

### DIFF
--- a/crates/polars-mem-engine/src/executors/merge_sorted.rs
+++ b/crates/polars-mem-engine/src/executors/merge_sorted.rs
@@ -1,4 +1,5 @@
 use polars_ops::prelude::*;
+use recursive::recursive;
 
 use super::*;
 
@@ -9,6 +10,7 @@ pub(crate) struct MergeSorted {
 }
 
 impl Executor for MergeSorted {
+    #[recursive]
     fn execute(&mut self, state: &mut ExecutionState) -> PolarsResult<DataFrame> {
         state.should_stop()?;
         #[cfg(debug_assertions)]

--- a/crates/polars-mem-engine/src/executors/union.rs
+++ b/crates/polars-mem-engine/src/executors/union.rs
@@ -1,4 +1,5 @@
 use polars_core::utils::concat_df;
+use recursive::recursive;
 
 use super::*;
 
@@ -8,6 +9,7 @@ pub(crate) struct UnionExec {
 }
 
 impl Executor for UnionExec {
+    #[recursive]
     fn execute(&mut self, state: &mut ExecutionState) -> PolarsResult<DataFrame> {
         state.should_stop()?;
         #[cfg(debug_assertions)]


### PR DESCRIPTION
fixes #26960 

Includes both merge_sorted and union since the optimizer may map the first to the latter.