### PR TITLE
fix: Make `pl.DataFrame.fill_null` work on columns with `Null` dtype

### DIFF
--- a/crates/polars-expr/src/dispatch/misc.rs
+++ b/crates/polars-expr/src/dispatch/misc.rs
@@ -562,6 +562,11 @@ pub(super) fn fill_null(s: &[Column]) -> PolarsResult<Column> {
 
             let fill_value = s[1].clone();
 
+            // Handle Null dtype columns: fill with the fill value (changes dtype)
+            if series.dtype() == &DataType::Null {
+                return Ok(fill_value.new_from_index(0, series.len()));
+            }
+
             // default branch
             fn default(series: Column, fill_value: Column) -> PolarsResult<Column> {
                 let mask = series.is_not_null();

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -7468,7 +7468,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
             if dtypes:
                 return self.with_columns(
-                    F.col(dtypes).fill_null(value, strategy, limit)
+                    F.col([*dtypes, Null]).fill_null(value, strategy, limit)
                 )
 
         return self.select(F.all().fill_null(value, strategy, limit))

--- a/py-polars/tests/unit/operations/test_fill_null.py
+++ b/py-polars/tests/unit/operations/test_fill_null.py
@@ -169,3 +169,14 @@ def test_fill_streaming_matches_in_memory(
     expected = q.collect(engine="in-memory")
     result = q.collect(engine="streaming")
     assert_series_equal(result["a"], expected["a"])
+
+
+def test_fill_null_null_dtype_24451() -> None:
+    # Test that fill_null changes Null dtype to fill value's dtype and fills values
+    df = pl.DataFrame({"col1": [None, None, None], "col2": [None, None, None]})
+
+    result = df.fill_null("rabbit")
+    assert result.dtypes == [pl.String, pl.String]
+    # Values are filled with the fill value
+    assert result["col1"].to_list() == ["rabbit", "rabbit", "rabbit"]
+    assert result["col2"].to_list() == ["rabbit", "rabbit", "rabbit"]


### PR DESCRIPTION

Fixes: #24451 
