### PR TITLE
fix: Panic in streaming MergeSortedNode

### DIFF
--- a/crates/polars-stream/src/nodes/merge_sorted.rs
+++ b/crates/polars-stream/src/nodes/merge_sorted.rs
@@ -134,12 +134,12 @@ fn find_mergeable(
             // @TODO: This is essentially search sorted, but that does not
             // support categoricals at moment.
             let gt_mask = right_key.gt(&left_key_last)?;
-            right_cutoff = gt_mask.downcast_as_array().values().leading_zeros();
+            right_cutoff = gt_mask.first_true_idx().unwrap_or(gt_mask.len());
         } else if left_key_last.gt(&right_key_last)?.all() {
             // @TODO: This is essentially search sorted, but that does not
             // support categoricals at moment.
             let gt_mask = left_key.gt(&right_key_last)?;
-            left_cutoff = gt_mask.downcast_as_array().values().leading_zeros();
+            left_cutoff = gt_mask.first_true_idx().unwrap_or(gt_mask.len());
         }
 
         let left_mergeable: DataFrame;


### PR DESCRIPTION
Depending on the exact chunking we might have multiple chunks here, meaning `downcast_as_array` would fail.