### PR TITLE
feat(rust): Add a GPU slot to OptFlags so we can control CSE (similar to streaming)

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -197,6 +197,11 @@ impl LazyFrame {
         self
     }
 
+    pub fn with_gpu(mut self, toggle: bool) -> Self {
+        self.opt_state.set(OptFlags::GPU, toggle);
+        self
+    }
+
     /// Try to estimate the number of rows so that joins can determine which side to keep in memory.
     pub fn with_row_estimate(mut self, toggle: bool) -> Self {
         self.opt_state.set(OptFlags::ROW_ESTIMATE, toggle);
@@ -635,9 +640,12 @@ impl LazyFrame {
                 }
             })
         }
-
-        if let Engine::Streaming = engine {
-            feature_gated!("new_streaming", self = self.with_new_streaming(true))
+        match engine {
+            Engine::Streaming => {
+                feature_gated!("new_streaming", self = self.with_new_streaming(true))
+            },
+            Engine::Gpu => self = self.with_gpu(true),
+            _ => (),
         }
 
         let mut ir_plan = self.to_alp_optimized()?;

--- a/crates/polars-plan/src/frame/opt_state.rs
+++ b/crates/polars-plan/src/frame/opt_state.rs
@@ -39,6 +39,8 @@ bitflags! {
         const CHECK_ORDER_OBSERVE = 1 << 15;
         /// Collapse consecutive sort nodes and pull them up through selecting nodes.
         const SORT_COLLAPSE = 1 << 16;
+        /// Is the query going to run on the GPU engine.
+        const GPU = 1 << 17;
     }
 }
 
@@ -74,11 +76,14 @@ impl OptFlags {
     pub fn fast_projection(&self) -> bool {
         self.contains(OptFlags::FAST_PROJECTION)
     }
+    pub fn gpu(&self) -> bool {
+        self.contains(OptFlags::GPU)
+    }
 }
 
 impl Default for OptFlags {
     fn default() -> Self {
-        Self::from_bits_truncate(u32::MAX) & !Self::NEW_STREAMING & !Self::EAGER
+        Self::from_bits_truncate(u32::MAX) & !Self::NEW_STREAMING & !Self::EAGER & !Self::GPU
     }
 }
 

--- a/crates/polars-plan/src/plans/optimizer/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/mod.rs
@@ -264,8 +264,9 @@ pub fn optimize(
     // This one should run (nearly) last as this modifies the projections
     #[cfg(feature = "cse")]
     if comm_subexpr_elim && !get_or_init_members!().has_ext_context {
-        let mut optimizer =
-            CommonSubExprOptimizer::new(opt_flags.contains(OptFlags::NEW_STREAMING));
+        let mut optimizer = CommonSubExprOptimizer::new(
+            opt_flags.contains(OptFlags::NEW_STREAMING) | opt_flags.contains(OptFlags::GPU),
+        );
         let ir_node = IRNode::new_mutate(root);
 
         root = try_with_ir_arena(ir_arena, expr_arena, |arena| {

--- a/crates/polars-python/src/lazyframe/optflags.rs
+++ b/crates/polars-python/src/lazyframe/optflags.rs
@@ -62,4 +62,5 @@ flag_getter_setters! {
 
     (EAGER, get_eager, set_eager, clear=true)
     (NEW_STREAMING, get_streaming, set_streaming, clear=true)
+    (GPU, get_gpu, set_gpu, clear=true)
 }


### PR DESCRIPTION
Like the streaming engine, the GPU engine in streaming mode can only handle CSE-optimized expressions if the eliminated expressions are pointwise. To make this transparent add a optimization slot that we inspect/set in the appropriate places.
