### PR TITLE
fix: Null count for aggregated list inside count aggregation

### DIFF
--- a/crates/polars-expr/src/expressions/aggregation.rs
+++ b/crates/polars-expr/src/expressions/aggregation.rs
@@ -252,7 +252,18 @@ impl PhysicalExpr for AggregationExpr {
                     AggregatedScalar(agg_c.with_name(keep_name))
                 },
                 GroupByMethod::Count { include_nulls } => {
-                    if include_nulls || ac.get_values().null_count() == 0 {
+                    let values_have_no_nulls = match ac.agg_state() {
+                        AggState::AggregatedList(s) => {
+                            let list = s.list()?;
+                            list.null_count() == 0
+                                && list
+                                    .downcast_iter()
+                                    .all(|arr| arr.values().null_count() == 0)
+                        },
+                        _ => ac.get_values().null_count() == 0,
+                    };
+
+                    if include_nulls || values_have_no_nulls {
                         // a few fast paths that prevent materializing new groups
                         match ac.update_groups {
                             UpdateGroups::WithSeriesLen => {

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -68,6 +68,16 @@ def test_group_by() -> None:
     assert result.columns == ["b", "a"]
 
 
+def test_group_by_count_respects_inner_nulls_in_aggregated_list_27031() -> None:
+    df = pl.DataFrame({"g": [1, 1, 1], "x": [1, 2, None]})
+
+    result = df.group_by("g", maintain_order=True).agg(
+        pl.col("x").cum_sum().count().alias("x_count")
+    )
+
+    assert result.rows() == [(1, 2)]
+
+
 @pytest.mark.parametrize(
     ("input", "expected", "input_dtype", "output_dtype"),
     [

--- a/py-polars/tests/unit/operations/test_over.py
+++ b/py-polars/tests/unit/operations/test_over.py
@@ -187,3 +187,13 @@ def test_over_duplicate_partition_by_26921() -> None:
     df = pl.DataFrame({"x": [1, 2, 3]})
     with pytest.raises(pl.exceptions.DuplicateError):
         df.with_columns(pl.len().over("x", "x"))
+
+
+def test_count_over_aggregated_list_respects_inner_nulls_27031() -> None:
+    df = pl.DataFrame({"g": [1, 1, 1], "x": [1, 2, None]})
+
+    result = df.with_columns(
+        pl.col("x").cum_sum().count().over("g").alias("x_count"),
+    )
+
+    assert result.get_column("x_count").to_list() == [2, 2, 2]


### PR DESCRIPTION
<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
Fixes #27031

I used AI (codex) to find and explain the fix to me as I reviewed the code. I generated the `over` test case myself, and AI to generate the test case using `group_by`
