### PR TITLE
Expression order simplification

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/mod.rs
@@ -23,6 +23,7 @@ mod predicate_pushdown;
 mod projection_pushdown;
 pub mod set_order;
 mod simplify_expr;
+pub mod simplify_ordering;
 mod slice_pushdown_expr;
 mod slice_pushdown_lp;
 mod sortedness;
@@ -285,6 +286,7 @@ pub fn optimize(
                             });
                         }
                     }
+                    simplify_ordering::simplify_ir_ordering(&roots, ir_arena, expr_arena);
                     set_order::simplify_and_fetch_orderings(&roots, ir_arena, expr_arena);
                 },
                 ir => {
@@ -295,7 +297,10 @@ pub fn optimize(
                             payload: SinkTypeIR::Memory,
                         });
                     }
-                    _ = set_order::simplify_and_fetch_orderings(&[tmp_top], ir_arena, expr_arena)
+                    _ = {
+                        simplify_ordering::simplify_ir_ordering(&[tmp_top], ir_arena, expr_arena);
+                        set_order::simplify_and_fetch_orderings(&[tmp_top], ir_arena, expr_arena)
+                    }
                 },
             }
         }

--- a/crates/polars-plan/src/plans/optimizer/set_order/ir_pullup.rs
+++ b/crates/polars-plan/src/plans/optimizer/set_order/ir_pullup.rs
@@ -9,8 +9,8 @@ use polars_utils::arena::{Arena, Node};
 use polars_utils::idx_vec::UnitVec;
 use polars_utils::unique_id::UniqueId;
 
-use super::expr_pullup::is_output_ordered;
 use crate::dsl::{FileSinkOptions, PartitionedSinkOptionsIR, SinkTypeIR};
+use crate::plans::simplify_ordering::expr::{ExprOrderSimplifier, ObservableOrders, ZipState};
 use crate::plans::{AExpr, IR};
 
 pub(super) fn pullup_orders(
@@ -74,10 +74,15 @@ pub(super) fn pullup_orders(
                     // and
                     // Unordered -> Unordered
 
-                    let keys_produce_order = keys
-                        .iter()
-                        .any(|k| is_output_ordered(expr_arena.get(k.node()), expr_arena, false));
-                    if !keys_produce_order {
+                    let mut eos = ExprOrderSimplifier::new(Some(inputs_ordered[0]), expr_arena);
+
+                    let observable_orders =
+                        keys.iter().fold(ObservableOrders::empty(), |acc, eir| {
+                            acc | eos
+                                .simplify_and_resolve_observable_orderings(eir.node(), Some(true))
+                        });
+
+                    if observable_orders.is_empty() {
                         *maintain_order = false;
                     }
                 }
@@ -171,33 +176,35 @@ pub(super) fn pullup_orders(
             },
 
             IR::Select { expr, .. } => {
-                if !expr.iter().any(|e| {
-                    is_output_ordered(expr_arena.get(e.node()), expr_arena, inputs_ordered[0])
-                }) {
+                let mut eos = ExprOrderSimplifier::new(Some(inputs_ordered[0]), expr_arena);
+
+                let observable_orders = expr.iter().fold(ObservableOrders::empty(), |acc, eir| {
+                    acc | eos.simplify_and_resolve_observable_orderings(eir.node(), Some(true))
+                });
+
+                if observable_orders.is_empty() {
                     set_unordered_output!();
                 }
             },
 
-            IR::HStack { input, .. } => {
-                let input = *input;
-                let input_schema = ir_arena.get(input).schema(ir_arena).as_ref().clone();
-                ir = ir_arena.get_mut(node);
-                let IR::HStack { exprs, .. } = ir else {
-                    unreachable!()
-                };
+            IR::HStack {
+                input,
+                exprs,
+                schema,
+                ..
+            } => {
+                let mut eos = ExprOrderSimplifier::new(Some(inputs_ordered[0]), expr_arena);
 
-                let has_any_ordered_expression = exprs.iter().any(|e| {
-                    is_output_ordered(expr_arena.get(e.node()), expr_arena, inputs_ordered[0])
-                });
-                let only_overwrites_existing_columns = exprs
-                    .iter()
-                    .filter(|e| input_schema.contains(e.output_name()))
-                    .count()
-                    == input_schema.len();
-                let is_output_unordered =
-                    !has_any_ordered_expression && only_overwrites_existing_columns;
+                let mut observable_orders =
+                    exprs.iter().fold(ObservableOrders::empty(), |acc, eir| {
+                        acc | eos.simplify_and_resolve_observable_orderings(eir.node(), Some(true))
+                    });
 
-                if is_output_unordered {
+                if exprs.len() != schema.len() && inputs_ordered[0] {
+                    observable_orders |= ObservableOrders::COLUMN;
+                }
+
+                if observable_orders.is_empty() {
                     set_unordered_output!();
                 }
             },

--- a/crates/polars-plan/src/plans/optimizer/set_order/ir_pushdown.rs
+++ b/crates/polars-plan/src/plans/optimizer/set_order/ir_pushdown.rs
@@ -9,16 +9,15 @@ use polars_utils::arena::{Arena, Node};
 use polars_utils::idx_vec::UnitVec;
 use polars_utils::unique_id::UniqueId;
 
-use super::expr_pushdown::{adjust_for_with_columns_context, resolve_observable_orders, zip};
 use crate::dsl::sink::PartitionStrategyIR;
 use crate::dsl::{SinkTypeIR, UnionOptions};
-use crate::plans::set_order::expr_pushdown::ColumnOrderObserved;
+use crate::plans::simplify_ordering::expr::{ExprOrderSimplifier, ObservableOrders, ZipState};
 use crate::plans::{AExpr, IR, is_scalar_ae};
 
 pub(super) fn pushdown_orders(
     roots: &[Node],
     ir_arena: &mut Arena<IR>,
-    expr_arena: &Arena<AExpr>,
+    expr_arena: &mut Arena<AExpr>,
     outputs: &mut PlHashMap<Node, Vec<(Node, usize)>>,
     cache_proxy: &PlHashMap<UniqueId, Vec<Node>>,
 ) -> PlHashMap<Node, UnitVec<bool>> {
@@ -93,12 +92,32 @@ pub(super) fn pushdown_orders(
                 sort_options,
                 ..
             } => {
-                let is_order_observing = sort_options.maintain_order || {
-                    adjust_for_with_columns_context(zip(by_column
+                let mut zs = ZipState::default();
+                let mut eos = ExprOrderSimplifier::new(None, expr_arena);
+
+                let mut expr_observable_orders =
+                    by_column
                         .iter()
-                        .map(|e| resolve_observable_orders(expr_arena.get(e.node()), expr_arena))))
-                    .is_err()
-                };
+                        .fold(ObservableOrders::empty(), |acc, eir| {
+                            zs.reduce(
+                                acc,
+                                eos.simplify_and_resolve_observable_orderings(
+                                    eir.node(),
+                                    Some(!all_outputs_unordered),
+                                ),
+                            )
+                        });
+                expr_observable_orders =
+                    zs.reduce(expr_observable_orders, ObservableOrders::COLUMN);
+
+                let is_order_observing = sort_options.maintain_order
+                    | zs.saw_mixed_inputs
+                    | eos
+                        .internally_observed_orders()
+                        .contains(ObservableOrders::COLUMN)
+                    | (sort_options.maintain_order
+                        && expr_observable_orders.contains(ObservableOrders::COLUMN));
+
                 [is_order_observing].into()
             },
             IR::GroupBy {
@@ -111,29 +130,41 @@ pub(super) fn pushdown_orders(
             } => {
                 *maintain_order &= !all_outputs_unordered;
 
+                let exprs_observe_column_order = {
+                    {
+                        let mut zs = ZipState::default();
+                        let mut eos = ExprOrderSimplifier::new(None, expr_arena);
+
+                        let mut expr_observable_orders = keys.iter().chain(aggs.iter()).fold(
+                            ObservableOrders::empty(),
+                            |acc, eir| {
+                                zs.reduce(
+                                    acc,
+                                    eos.simplify_and_resolve_observable_orderings(
+                                        eir.node(),
+                                        Some(!all_outputs_unordered),
+                                    ),
+                                )
+                            },
+                        );
+                        expr_observable_orders =
+                            zs.reduce(expr_observable_orders, ObservableOrders::COLUMN);
+
+                        zs.saw_mixed_inputs
+                            | eos
+                                .internally_observed_orders()
+                                .contains(ObservableOrders::COLUMN)
+                            | aggs.iter().any(|agg| !is_scalar_ae(agg.node(), expr_arena))
+                            | ((!all_outputs_unordered && *maintain_order)
+                                && expr_observable_orders.contains(ObservableOrders::COLUMN))
+                    }
+                };
+
                 let is_order_observing = apply.is_some()
                     || options.is_dynamic()
                     || options.is_rolling()
                     || *maintain_order
-                    || {
-                        // _ -> Unordered
-                        //   to
-                        // maintain_order = false
-                        // and
-                        // Unordered -> Unordered (if no order sensitive expressions)
-
-                        let expr_observing = adjust_for_with_columns_context(zip(keys
-                            .iter()
-                            .chain(aggs.iter())
-                            .map(|e| {
-                                resolve_observable_orders(expr_arena.get(e.node()), expr_arena)
-                            })))
-                        .is_err();
-
-                        expr_observing
-                            // The auto-implode is also other sensitive.
-                            || aggs.iter().any(|agg| !is_scalar_ae(agg.node(), expr_arena))
-                    };
+                    || exprs_observe_column_order;
                 [is_order_observing].into()
             },
             #[cfg(feature = "merge_sorted")]
@@ -221,41 +252,60 @@ pub(super) fn pushdown_orders(
             },
             IR::SimpleProjection { .. } => [!all_outputs_unordered].into(),
             IR::Slice { .. } => [true].into(),
-            IR::HStack { input, exprs, .. } => {
-                let input = *input;
-                let mut observing = zip(exprs
-                    .iter()
-                    .map(|e| resolve_observable_orders(expr_arena.get(e.node()), expr_arena)));
+            IR::HStack {
+                input,
+                exprs,
+                schema,
+                ..
+            } => {
+                let mut zs = ZipState::default();
+                let mut eos = ExprOrderSimplifier::new(None, expr_arena);
 
-                let input_schema = ir_arena.get(input).schema(ir_arena).as_ref().clone();
-                ir = ir_arena.get_mut(node);
-                let IR::HStack { exprs, .. } = ir else {
-                    unreachable!()
-                };
+                let mut expr_observable_orders =
+                    exprs.iter().fold(ObservableOrders::empty(), |acc, eir| {
+                        zs.reduce(
+                            acc,
+                            eos.simplify_and_resolve_observable_orderings(
+                                eir.node(),
+                                Some(!all_outputs_unordered),
+                            ),
+                        )
+                    });
 
-                let mut hits = 0;
-                for expr in exprs {
-                    hits += usize::from(input_schema.contains(expr.output_name()));
+                if exprs.len() != schema.len() {
+                    expr_observable_orders =
+                        zs.reduce(expr_observable_orders, ObservableOrders::COLUMN);
                 }
 
-                if hits < input_schema.len() {
-                    observing = adjust_for_with_columns_context(observing);
-                }
+                let is_order_observing = ((zs.saw_mixed_inputs | !all_outputs_unordered)
+                    && expr_observable_orders.contains(ObservableOrders::COLUMN))
+                    | eos
+                        .internally_observed_orders()
+                        .contains(ObservableOrders::COLUMN);
 
-                let is_order_observing = match observing {
-                    Ok(o) => o.column_ordering_observable() && !all_outputs_unordered,
-                    Err(ColumnOrderObserved) => true,
-                };
                 [is_order_observing].into()
             },
             IR::Select { expr: exprs, .. } => {
-                let observing = zip(exprs
-                    .iter()
-                    .map(|e| resolve_observable_orders(expr_arena.get(e.node()), expr_arena)));
-                let is_order_observing = match observing {
-                    Ok(o) => o.column_ordering_observable() && !all_outputs_unordered,
-                    Err(ColumnOrderObserved) => true,
-                };
+                let mut zs = ZipState::default();
+                let mut eos = ExprOrderSimplifier::new(None, expr_arena);
+
+                let mut expr_observable_orders =
+                    exprs.iter().fold(ObservableOrders::empty(), |acc, eir| {
+                        zs.reduce(
+                            acc,
+                            eos.simplify_and_resolve_observable_orderings(
+                                eir.node(),
+                                Some(!all_outputs_unordered),
+                            ),
+                        )
+                    });
+
+                let is_order_observing = ((zs.saw_mixed_inputs || !all_outputs_unordered)
+                    && expr_observable_orders.contains(ObservableOrders::COLUMN))
+                    | eos
+                        .internally_observed_orders()
+                        .contains(ObservableOrders::COLUMN);
+
                 [is_order_observing].into()
             },
 
@@ -263,14 +313,27 @@ pub(super) fn pushdown_orders(
                 input: _,
                 predicate,
             } => {
-                let observing = adjust_for_with_columns_context(resolve_observable_orders(
-                    expr_arena.get(predicate.node()),
-                    expr_arena,
-                ));
-                let is_order_observing = match observing {
-                    Ok(o) => o.column_ordering_observable() && !all_outputs_unordered,
-                    Err(ColumnOrderObserved) => true,
-                };
+                let mut zs = ZipState::default();
+                let mut eos = ExprOrderSimplifier::new(None, expr_arena);
+
+                let mut expr_observable_orders = zs.reduce(
+                    ObservableOrders::empty(),
+                    eos.simplify_and_resolve_observable_orderings(
+                        predicate.node(),
+                        Some(!all_outputs_unordered),
+                    ),
+                );
+
+                expr_observable_orders =
+                    zs.reduce(expr_observable_orders, ObservableOrders::COLUMN);
+
+                let is_order_observing = zs.saw_mixed_inputs
+                    | eos
+                        .internally_observed_orders()
+                        .contains(ObservableOrders::COLUMN)
+                    | (!all_outputs_unordered
+                        && expr_observable_orders.contains(ObservableOrders::COLUMN));
+
                 [is_order_observing].into()
             },
 
@@ -304,10 +367,34 @@ pub(super) fn pushdown_orders(
                                     include_keys: _,
                                     keys_pre_grouped: true,
                                 }
-                            ) || adjust_for_with_columns_context(zip(options.expr_irs_iter().map(
-                                |e| resolve_observable_orders(expr_arena.get(e.node()), expr_arena),
-                            )))
-                            .is_err()
+                            ) || {
+                                let mut zs = ZipState::default();
+                                let mut eos = ExprOrderSimplifier::new(None, expr_arena);
+
+                                let mut expr_observable_orders = options.expr_irs_iter().fold(
+                                    ObservableOrders::empty(),
+                                    |acc, eir| {
+                                        zs.reduce(
+                                            acc,
+                                            eos.simplify_and_resolve_observable_orderings(
+                                                eir.node(),
+                                                Some(!all_outputs_unordered),
+                                            ),
+                                        )
+                                    },
+                                );
+
+                                expr_observable_orders =
+                                    zs.reduce(expr_observable_orders, ObservableOrders::COLUMN);
+
+                                zs.saw_mixed_inputs
+                                    | eos
+                                        .internally_observed_orders()
+                                        .contains(ObservableOrders::COLUMN)
+                                    | (!all_outputs_unordered
+                                        && expr_observable_orders
+                                            .contains(ObservableOrders::COLUMN))
+                            }
                         },
                     };
 

--- a/crates/polars-plan/src/plans/optimizer/set_order/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/set_order/mod.rs
@@ -10,8 +10,8 @@
 //! When the two passes are done, we are left with a map from all nodes to the ordering status of
 //! their inputs.
 
-mod expr_pullup;
-mod expr_pushdown;
+// mod expr_pullup;
+// mod expr_pushdown;
 mod ir_pullup;
 mod ir_pushdown;
 

--- a/crates/polars-plan/src/plans/optimizer/simplify_ordering/expr.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_ordering/expr.rs
@@ -1,0 +1,768 @@
+use std::ops::{BitOr, BitOrAssign};
+use std::sync::atomic::{AtomicU8, Ordering};
+
+use bitflags::bitflags;
+use polars_core::prelude::{InitHashMaps, PlHashMap, PlHashSet};
+use polars_error::PolarsResult;
+use polars_utils::UnitVec;
+use polars_utils::arena::{Arena, Node};
+use polars_utils::relaxed_cell::RelaxedCell;
+use slotmap::{SlotMap, new_key_type};
+
+use crate::dsl::EvalVariant;
+use crate::plans::{AExpr, IRAggExpr, IRFunctionExpr, is_scalar_ae};
+
+/// Tracks orders that can be observed in the output of an expression.
+///
+/// This also allows distinguishing if an output is strictly column ordered (i.e. contains no other
+/// observable ordering).
+///
+/// This currently does not support distinguishing the origin(s) of independent orders.
+bitflags! {
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    pub(crate) struct ObservableOrders: u8 {
+        /// Ordering of a column can be observed. Note that this does not capture information on whether
+        /// the column itself is ordered (e.g. this is not the case after an unstable unique).
+        const COLUMN = 1 << 0;
+        /// Order originating from a non-column node can be observed.
+        /// E.g.: sort()
+        const INDEPENDENT = 1 << 1;
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct ZipState {
+    pub(crate) saw_mixed_inputs: bool,
+    num_ordered_inputs: usize,
+
+    #[cfg(debug_assertions)]
+    called: bool,
+}
+
+impl ZipState {
+    /// Note: Must not be called with a non-empty initial accumulator, as that will cause `num_ordered_inputs` tracking
+    /// to be incorrect.
+    pub(crate) fn reduce(
+        &mut self,
+        left: ObservableOrders,
+        right: ObservableOrders,
+    ) -> ObservableOrders {
+        use ObservableOrders as O;
+
+        #[cfg(debug_assertions)]
+        if !self.called {
+            assert!(left.is_empty());
+            self.called = true;
+        }
+
+        // Mainly want to catch Column<>Independent.
+        // In the general case we also catch Independent<>Independent since we don't have ordering
+        // provenance information to check ordering equality.
+        self.saw_mixed_inputs |= (left.contains(O::INDEPENDENT) && right != O::empty())
+            || (right.contains(O::INDEPENDENT) && left != O::empty());
+
+        self.num_ordered_inputs += (right != O::empty()) as usize;
+
+        left | right
+    }
+}
+
+pub(crate) struct ExprOrderSimplifier<'a> {
+    column_ordering: ObservableOrders,
+    struct_field_ordering: Option<ObservableOrders>,
+    list_element_ordering: ObservableOrders,
+
+    /// Entries for nodes whose subtrees will not change on revisits with different recursion states.
+    /// Guide: Any aexpr node that recurses with `RecursionState::new(false)`.
+    revisit_cache: PlHashMap<Node, ObservableOrders>,
+    internal_observer: OrderObserver,
+
+    expr_arena: &'a mut Arena<AExpr>,
+}
+
+struct OrderObserver(
+    // Atomic for interior mutability
+    AtomicU8,
+);
+
+impl OrderObserver {
+    fn new() -> Self {
+        Self(AtomicU8::new(0))
+    }
+
+    fn observed_orders(&self) -> ObservableOrders {
+        ObservableOrders::from_bits(self.0.load(Ordering::Relaxed)).unwrap()
+    }
+
+    fn observe_orders(&self, observable_orders: ObservableOrders) {
+        self.0
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |x| {
+                Some((ObservableOrders::from_bits(x).unwrap() | observable_orders).bits())
+            })
+            .unwrap();
+    }
+}
+
+impl<'a> ExprOrderSimplifier<'a> {
+    pub(crate) fn new(column_ordered: Option<bool>, expr_arena: &'a mut Arena<AExpr>) -> Self {
+        Self {
+            column_ordering: match column_ordered {
+                Some(true) | None => ObservableOrders::COLUMN,
+                Some(false) => ObservableOrders::empty(),
+            },
+            struct_field_ordering: None,
+            list_element_ordering: ObservableOrders::INDEPENDENT,
+
+            revisit_cache: PlHashMap::new(),
+            internal_observer: OrderObserver::new(),
+
+            expr_arena,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum RecursionState {
+    /// Inverted from "observe", since it could be unknown whether a consumer observes order.
+    /// But it is always known whether deordering rewrites should be allowed.
+    Recurse {
+        allow_deordering_rewrites: bool,
+    },
+    DeorderAndReturn,
+}
+
+impl RecursionState {
+    const fn new(allow_deordering_rewrites: bool) -> Self {
+        Self::Recurse {
+            allow_deordering_rewrites,
+        }
+    }
+
+    fn to_zip_previsit_state(&self) -> Self {
+        use RecursionState::*;
+
+        match self {
+            Recurse {
+                allow_deordering_rewrites: _,
+            } => Recurse {
+                allow_deordering_rewrites: false,
+            },
+            DeorderAndReturn => DeorderAndReturn,
+        }
+    }
+
+    fn to_zip_revisit_deorder_state(&self) -> Option<Self> {
+        use RecursionState::*;
+
+        match self {
+            Recurse {
+                allow_deordering_rewrites,
+            } => allow_deordering_rewrites.then_some(Self::DeorderAndReturn),
+            DeorderAndReturn => None,
+        }
+    }
+
+    fn allows_deordering_rewrites(&self) -> bool {
+        match self {
+            Self::Recurse {
+                allow_deordering_rewrites,
+            } => *allow_deordering_rewrites,
+            Self::DeorderAndReturn => true,
+        }
+    }
+}
+
+impl ExprOrderSimplifier<'_> {
+    /// Returns all orderings that were observed by this expression tree.
+    pub(crate) fn simplify_and_resolve_observable_orderings(
+        &mut self,
+        current_ae_node: Node,
+        observe_top_order: Option<bool>,
+    ) -> ObservableOrders {
+        self.list_element_ordering = ObservableOrders::INDEPENDENT;
+
+        self.rec(
+            current_ae_node,
+            RecursionState::Recurse {
+                allow_deordering_rewrites: observe_top_order == Some(false),
+            },
+        )
+    }
+
+    pub(crate) fn internally_observed_orders(&self) -> ObservableOrders {
+        self.internal_observer.observed_orders()
+    }
+
+    fn internal_observe(&self, observable_orders: ObservableOrders) {
+        self.internal_observer.observe_orders(observable_orders);
+    }
+
+    #[recursive::recursive]
+    fn rec<'os>(&mut self, current_ae_node: Node, recursion: RecursionState) -> ObservableOrders {
+        const NO_DEORDER: RecursionState = RecursionState::new(false);
+        const ALLOW_DEORDER: RecursionState = RecursionState::new(true);
+
+        use ObservableOrders as O;
+
+        match self.expr_arena.get(current_ae_node) {
+            AExpr::Column(_) => self.column_ordering,
+
+            AExpr::Literal(lv) => {
+                if lv.is_scalar() {
+                    O::empty()
+                } else {
+                    O::INDEPENDENT
+                }
+            },
+
+            AExpr::Eval {
+                expr,
+                evaluation,
+                variant,
+            } => {
+                if let Some(o) = self.revisit_cache.get(&current_ae_node) {
+                    return *o;
+                }
+
+                let expr = *expr;
+                let evaluation = *evaluation;
+
+                let out = match variant {
+                    EvalVariant::Array { as_list: _ }
+                    | EvalVariant::ArrayAgg
+                    | EvalVariant::List
+                    | EvalVariant::ListAgg => self.rec(expr, NO_DEORDER),
+                    EvalVariant::Cumulative { min_samples: _ } => {
+                        let expr_ordering = self.rec(expr, NO_DEORDER);
+
+                        expr_ordering | O::INDEPENDENT
+                    },
+                };
+
+                let sublist_observable_orderings = self.rec(evaluation, NO_DEORDER);
+                // Register this ordering to the global list item ordering.
+                // TODO: This would cause effects between exprs from unrelated subtrees; should
+                // be stored in `ObservableOrders` instead.
+                self.list_element_ordering |= sublist_observable_orderings;
+
+                self.revisit_cache.insert(current_ae_node, out);
+
+                out
+            },
+            AExpr::Element => self.list_element_ordering,
+
+            #[cfg(feature = "dtype-struct")]
+            AExpr::StructEval { expr, evaluation } => {
+                if let Some(o) = self.revisit_cache.get(&current_ae_node) {
+                    return *o;
+                }
+
+                let evaluation_len = evaluation.len();
+
+                let struct_expr = *expr;
+                let subtree_recursion = recursion.to_zip_previsit_state();
+                let struct_field_ordering = self.rec(struct_expr, subtree_recursion);
+
+                let prev_struct_field_ordering =
+                    self.struct_field_ordering.replace(struct_field_ordering);
+
+                let mut zs = ZipState::default();
+
+                let evaluation_observable = (0..evaluation_len).fold(O::empty(), |acc, i| {
+                    let AExpr::StructEval { evaluation, .. } = self.expr_arena.get(current_ae_node)
+                    else {
+                        unreachable!()
+                    };
+
+                    zs.reduce(acc, self.rec(evaluation[i].node(), subtree_recursion))
+                });
+
+                let output_observable = zs.reduce(struct_field_ordering, evaluation_observable);
+
+                if zs.saw_mixed_inputs {
+                    self.internal_observe(output_observable);
+                    self.revisit_cache
+                        .insert(current_ae_node, output_observable);
+                } else if zs.num_ordered_inputs <= 1 {
+                    self.struct_field_ordering = prev_struct_field_ordering;
+
+                    let output_observable =
+                        if let Some(recursion) = recursion.to_zip_revisit_deorder_state() {
+                            self.rec(current_ae_node, recursion)
+                        } else {
+                            output_observable
+                        };
+
+                    self.revisit_cache
+                        .insert(current_ae_node, output_observable);
+
+                    return output_observable;
+                }
+
+                self.struct_field_ordering = prev_struct_field_ordering;
+
+                output_observable
+            },
+
+            AExpr::BinaryExpr { .. } | AExpr::Ternary { .. } => {
+                if let Some(o) = self.revisit_cache.get(&current_ae_node) {
+                    return *o;
+                }
+
+                let (nodes, ternary_predicate_node) = match self.expr_arena.get(current_ae_node) {
+                    AExpr::BinaryExpr { left, op: _, right } => ([*left, *right], None),
+                    AExpr::Ternary {
+                        predicate,
+                        truthy,
+                        falsy,
+                    } => ([*truthy, *falsy], Some(*predicate)),
+                    _ => unreachable!(),
+                };
+
+                let mut zs = ZipState::default();
+                let subtree_recursion = recursion.to_zip_previsit_state();
+
+                let output_observable = nodes.iter().fold(O::empty(), |acc, node| {
+                    zs.reduce(acc, self.rec(*node, subtree_recursion))
+                });
+
+                if let Some(ternary_predicate_node) = ternary_predicate_node {
+                    zs.reduce(
+                        output_observable,
+                        self.rec(ternary_predicate_node, subtree_recursion),
+                    );
+                }
+
+                if zs.saw_mixed_inputs {
+                    self.internal_observe(output_observable);
+                    self.revisit_cache
+                        .insert(current_ae_node, output_observable);
+                } else if zs.num_ordered_inputs <= 1 {
+                    let output_observable =
+                        if let Some(recursion) = recursion.to_zip_revisit_deorder_state() {
+                            self.rec(current_ae_node, recursion)
+                        } else {
+                            output_observable
+                        };
+
+                    self.revisit_cache
+                        .insert(current_ae_node, output_observable);
+
+                    return output_observable;
+                }
+
+                output_observable
+            },
+
+            #[cfg(feature = "dtype-struct")]
+            AExpr::StructField(_) => self.struct_field_ordering.unwrap(),
+
+            AExpr::Cast { expr, .. } => self.rec(*expr, recursion),
+            AExpr::Explode { expr, .. } => {
+                let observable_in_input = self.rec(*expr, recursion);
+
+                observable_in_input | O::INDEPENDENT
+            },
+            AExpr::Len => O::empty(),
+            AExpr::Sort { expr, options } => {
+                let expr = *expr;
+                let maintain_order = options.maintain_order;
+
+                if recursion.allows_deordering_rewrites() {
+                    self.expr_arena
+                        .replace(current_ae_node, self.expr_arena.get(expr).clone());
+                    return self.rec(current_ae_node, ALLOW_DEORDER);
+                } else {
+                    if maintain_order {
+                        self.rec(expr, NO_DEORDER) | O::INDEPENDENT
+                    } else {
+                        self.rec(expr, ALLOW_DEORDER);
+                        O::INDEPENDENT
+                    }
+                }
+            },
+
+            AExpr::Filter { input, by } => {
+                if let Some(o) = self.revisit_cache.get(&current_ae_node) {
+                    return *o;
+                }
+
+                let input = *input;
+                let by = *by;
+
+                let observable_in_input = self.rec(input, NO_DEORDER);
+                let observable_in_by = self.rec(by, NO_DEORDER);
+
+                let mut zs = ZipState::default();
+                let observable_in_input = zs.reduce(O::empty(), observable_in_input);
+                let zipped_observable = zs.reduce(observable_in_input, observable_in_by);
+
+                if zs.saw_mixed_inputs {
+                    self.internal_observe(zipped_observable);
+                }
+
+                self.revisit_cache
+                    .insert(current_ae_node, observable_in_input);
+
+                observable_in_input
+            },
+
+            AExpr::Gather {
+                expr,
+                idx,
+                returns_scalar,
+                null_on_oob: _,
+            } => {
+                let expr = *expr;
+                let idx = *idx;
+                let returns_scalar = *returns_scalar;
+
+                if let Some(o) = self.revisit_cache.get(&current_ae_node) {
+                    return *o;
+                }
+
+                let observable_in_expr = self.rec(expr, NO_DEORDER);
+                let observable_in_idx = self.rec(idx, NO_DEORDER);
+
+                self.internal_observe(observable_in_expr);
+
+                let out = if returns_scalar {
+                    O::empty()
+                } else {
+                    observable_in_idx
+                };
+
+                self.revisit_cache.insert(current_ae_node, out);
+
+                out
+            },
+
+            AExpr::Over {
+                function,
+                partition_by,
+                order_by,
+                mapping: _,
+            } => {
+                if let Some(o) = self.revisit_cache.get(&current_ae_node) {
+                    return *o;
+                }
+
+                let function = *function;
+                let partition_by_len = partition_by.len();
+                let order_by = order_by.as_ref().map(|(node, _)| *node);
+
+                let observable_in_function = self.rec(function, NO_DEORDER);
+                let observable_in_partition_by =
+                    (0..partition_by_len).fold(O::empty(), |acc, i| {
+                        let AExpr::Over { partition_by, .. } = self.expr_arena.get(current_ae_node)
+                        else {
+                            unreachable!()
+                        };
+                        acc | self.rec(partition_by[i], NO_DEORDER)
+                    });
+                let observable_in_order_by =
+                    order_by.map_or(O::empty(), |node| self.rec(node, NO_DEORDER));
+
+                let zipped_observable =
+                    observable_in_function | observable_in_partition_by | observable_in_order_by;
+                self.internal_observe(zipped_observable);
+
+                let output_observable = zipped_observable | O::INDEPENDENT;
+
+                self.revisit_cache
+                    .insert(current_ae_node, output_observable);
+
+                output_observable
+            },
+
+            #[cfg(feature = "dynamic_group_by")]
+            AExpr::Rolling {
+                function,
+                index_column,
+                period: _,
+                offset: _,
+                closed_window: _,
+            } => {
+                if let Some(o) = self.revisit_cache.get(&current_ae_node) {
+                    return *o;
+                }
+
+                let function = *function;
+                let index_column = *index_column;
+
+                let observable_in_function = self.rec(function, NO_DEORDER);
+                let observable_in_index_column = self.rec(index_column, NO_DEORDER);
+
+                self.internal_observe(observable_in_function);
+                self.internal_observe(observable_in_index_column);
+
+                let output_observable =
+                    observable_in_function | observable_in_index_column | O::INDEPENDENT;
+                self.revisit_cache
+                    .insert(current_ae_node, output_observable);
+
+                output_observable
+            },
+
+            AExpr::SortBy {
+                expr,
+                by,
+                sort_options,
+            } => {
+                let expr = *expr;
+                let maintain_order = sort_options.maintain_order;
+                let by_len = by.len();
+
+                if recursion.allows_deordering_rewrites() {
+                    self.expr_arena
+                        .replace(current_ae_node, self.expr_arena.get(expr).clone());
+                    return self.rec(current_ae_node, ALLOW_DEORDER);
+                }
+
+                let mut zs = ZipState::default();
+                let observable_in_input = self.rec(expr, NO_DEORDER);
+
+                let observable_in_by = (0..by_len).fold(O::empty(), |acc, i| {
+                    let AExpr::SortBy { by, .. } = self.expr_arena.get(current_ae_node) else {
+                        unreachable!()
+                    };
+                    zs.reduce(acc, self.rec(by[i], NO_DEORDER))
+                });
+
+                let zipped_observable = zs.reduce(observable_in_input, observable_in_by);
+
+                if zs.saw_mixed_inputs {
+                    self.internal_observe(zipped_observable);
+                } else if zs.num_ordered_inputs == 0 {
+                    return self.rec(current_ae_node, RecursionState::DeorderAndReturn);
+                }
+
+                if maintain_order {
+                    zipped_observable | O::INDEPENDENT
+                } else {
+                    O::INDEPENDENT
+                }
+            },
+
+            AExpr::Slice {
+                input,
+                offset,
+                length,
+            } => {
+                let input = *input;
+                let offset = *offset;
+                let length = *length;
+
+                debug_assert!(is_scalar_ae(offset, self.expr_arena));
+                debug_assert!(is_scalar_ae(length, self.expr_arena));
+
+                let observable_in_offset = self.rec(offset, NO_DEORDER);
+                let observable_in_length = self.rec(length, NO_DEORDER);
+
+                debug_assert_eq!(observable_in_offset, O::empty());
+                debug_assert_eq!(observable_in_length, O::empty());
+
+                let output_observable = self.rec(input, recursion);
+
+                self.internal_observe(output_observable);
+
+                output_observable
+            },
+
+            AExpr::Function {
+                input,
+                function: IRFunctionExpr::MinBy | IRFunctionExpr::MaxBy,
+                ..
+            } => {
+                if let Some(o) = self.revisit_cache.get(&current_ae_node) {
+                    return *o;
+                }
+
+                assert_eq!(input.len(), 2);
+                let of = input[0].node();
+                let by = input[1].node();
+
+                let observable_in_of = self.rec(of, NO_DEORDER);
+                let observable_in_by = self.rec(by, NO_DEORDER);
+
+                self.internal_observe(observable_in_of);
+                self.internal_observe(observable_in_by);
+
+                let output_observable = O::empty();
+                self.revisit_cache
+                    .insert(current_ae_node, output_observable);
+
+                output_observable
+            },
+
+            AExpr::AnonymousFunction { input, options, .. }
+            | AExpr::Function { input, options, .. } => {
+                if let Some(o) = self.revisit_cache.get(&current_ae_node) {
+                    return *o;
+                }
+
+                let input_len = input.len();
+                let observes_input_order = options.flags.observes_input_order();
+                let terminates_input_order = options.flags.terminates_input_order();
+                let non_order_producing = options.flags.non_order_producing();
+
+                let subtree_recursion = if observes_input_order {
+                    NO_DEORDER
+                } else {
+                    recursion.to_zip_previsit_state()
+                };
+
+                let mut zs = ZipState::default();
+
+                let zipped_observable = (0..input_len).fold(O::empty(), |acc, i| {
+                    let (AExpr::AnonymousFunction { input, .. } | AExpr::Function { input, .. }) =
+                        self.expr_arena.get(current_ae_node)
+                    else {
+                        unreachable!()
+                    };
+
+                    zs.reduce(acc, self.rec(input[i].node(), subtree_recursion))
+                });
+
+                let output_observable = match (terminates_input_order, non_order_producing) {
+                    (false, false) => zipped_observable | O::INDEPENDENT,
+                    (false, true) => zipped_observable,
+                    (true, false) => O::INDEPENDENT,
+                    (true, true) => O::empty(),
+                };
+
+                if zs.saw_mixed_inputs {
+                    self.internal_observe(zipped_observable);
+                    self.revisit_cache
+                        .insert(current_ae_node, output_observable);
+                } else if !observes_input_order {
+                    let output_observable =
+                        if let Some(recursion) = recursion.to_zip_revisit_deorder_state() {
+                            self.rec(current_ae_node, recursion)
+                        } else if recursion != RecursionState::DeorderAndReturn
+                            && terminates_input_order
+                        {
+                            self.rec(current_ae_node, RecursionState::DeorderAndReturn)
+                        } else {
+                            output_observable
+                        };
+
+                    self.revisit_cache
+                        .insert(current_ae_node, output_observable);
+
+                    return output_observable;
+                };
+
+                output_observable
+            },
+
+            AExpr::AnonymousAgg {
+                input,
+                fmt_str: _,
+                function: _,
+            } => {
+                if let Some(o) = self.revisit_cache.get(&current_ae_node) {
+                    return *o;
+                }
+
+                let input_len = input.len();
+
+                let zipped_observable = (0..input_len).fold(O::empty(), |acc, i| {
+                    let AExpr::AnonymousAgg { input, .. } = self.expr_arena.get(current_ae_node)
+                    else {
+                        unreachable!()
+                    };
+
+                    acc | self.rec(input[i].node(), NO_DEORDER)
+                });
+
+                self.internal_observe(zipped_observable);
+
+                let output_observable = zipped_observable | O::INDEPENDENT;
+
+                self.revisit_cache
+                    .insert(current_ae_node, output_observable);
+
+                output_observable
+            },
+
+            AExpr::Agg(agg) => {
+                if let Some(o) = self.revisit_cache.get(&current_ae_node) {
+                    return *o;
+                }
+
+                let output_observable = match agg {
+                    // Input order agnostic aggregations.
+                    IRAggExpr::Min { input: node, .. }
+                    | IRAggExpr::Max { input: node, .. }
+                    | IRAggExpr::Median(node)
+                    | IRAggExpr::NUnique(node)
+                    | IRAggExpr::Mean(node)
+                    | IRAggExpr::Sum(node)
+                    | IRAggExpr::Count { input: node, .. }
+                    | IRAggExpr::Std(node, _)
+                    | IRAggExpr::Var(node, _)
+                    | IRAggExpr::Item { input: node, .. } => {
+                        self.rec(*node, ALLOW_DEORDER);
+                        O::empty()
+                    },
+                    IRAggExpr::Quantile { expr, quantile, .. } => {
+                        let expr = *expr;
+                        let quantile = *quantile;
+                        self.rec(expr, ALLOW_DEORDER);
+                        self.rec(quantile, ALLOW_DEORDER);
+
+                        O::empty()
+                    },
+
+                    // Input order observing aggregations.
+                    IRAggExpr::First(node)
+                    | IRAggExpr::FirstNonNull(node)
+                    | IRAggExpr::Last(node)
+                    | IRAggExpr::LastNonNull(node) => {
+                        let observable = self.rec(*node, NO_DEORDER);
+
+                        self.internal_observe(observable);
+
+                        O::empty()
+                    },
+
+                    IRAggExpr::Implode {
+                        input,
+                        maintain_order,
+                    } => {
+                        let input = *input;
+                        let maintain_order = *maintain_order;
+
+                        let input_observable =
+                            self.rec(input, RecursionState::new(!maintain_order));
+
+                        if input_observable.is_empty() && maintain_order {
+                            self.expr_arena.replace(
+                                current_ae_node,
+                                AExpr::Agg(IRAggExpr::Implode {
+                                    input,
+                                    maintain_order: false,
+                                }),
+                            );
+                        }
+
+                        O::empty()
+                    },
+
+                    IRAggExpr::AggGroups(node) => {
+                        let observable = self.rec(*node, NO_DEORDER);
+
+                        self.internal_observe(observable);
+
+                        observable | O::INDEPENDENT
+                    },
+                };
+
+                self.revisit_cache
+                    .insert(current_ae_node, output_observable);
+                output_observable
+            },
+        }
+    }
+}

--- a/crates/polars-plan/src/plans/optimizer/simplify_ordering/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_ordering/mod.rs
@@ -1,0 +1,152 @@
+pub(crate) mod expr;
+
+use std::sync::Arc;
+
+use polars_core::prelude::{InitHashMaps, PlHashMap};
+use polars_utils::arena::{Arena, Node};
+use polars_utils::unique_id::UniqueId;
+use polars_utils::{UnitVec, unitvec};
+use slotmap::{SlotMap, new_key_type};
+
+use crate::plans::Sorted as SortingColumn;
+use crate::prelude::{AExpr, IR};
+
+enum Edge {
+    Unordered,
+    Ordered {
+        sorting: Option<Arc<UnitVec<SortingColumn>>>,
+    },
+}
+
+new_key_type! {
+    struct EdgeKey;
+}
+
+type EdgesMap = SlotMap<EdgeKey, Option<Edge>>;
+
+#[derive(Default, Debug)]
+struct IRNodeEdges {
+    in_edges: UnitVec<EdgeKey>,
+    out_edges: UnitVec<EdgeKey>,
+}
+
+pub(crate) fn simplify_ir_ordering(
+    roots: &[Node],
+    ir_arena: &mut Arena<IR>,
+    expr_arena: &mut Arena<AExpr>,
+) {
+    let mut cache_hits: PlHashMap<UniqueId, usize> = PlHashMap::new();
+    let mut num_nodes: usize = 0;
+
+    let mut ir_nodes_stack = Vec::with_capacity(roots.len() + 8);
+    ir_nodes_stack.extend_from_slice(roots);
+
+    while let Some(ir_node) = ir_nodes_stack.pop() {
+        let ir = ir_arena.get(ir_node);
+
+        if let IR::Cache { id, .. } = ir {
+            let _ = cache_hits.try_insert(*id, 0);
+            *cache_hits.get_mut(id).unwrap() += 1;
+        } else {
+            num_nodes += 1;
+        }
+
+        ir.copy_inputs(&mut ir_nodes_stack);
+    }
+
+    num_nodes += cache_hits.len();
+
+    let mut all_edges_map: SlotMap<EdgeKey, Option<Edge>> =
+        SlotMap::with_capacity_and_key(num_nodes);
+    let mut ir_node_to_edges_map: PlHashMap<Node, IRNodeEdges> =
+        PlHashMap::with_capacity(num_nodes);
+
+    ir_nodes_stack.reserve_exact(num_nodes);
+    ir_nodes_stack.extend_from_slice(roots);
+
+    for i in 0..(num_nodes + 1) {
+        let Some(current_node) = ir_nodes_stack.get(i).copied() else {
+            break;
+        };
+
+        assert!(i + 1 <= num_nodes);
+
+        let ir = ir_arena.get(current_node);
+
+        if let IR::Cache { id, .. } = ir {
+            let hits = cache_hits.get_mut(id).unwrap();
+            *hits -= 1;
+
+            if *hits != 0 {
+                debug_assert!(i < ir_nodes_stack.len());
+                continue;
+            }
+        }
+
+        let inputs_start_idx = ir_nodes_stack.len();
+        ir_arena.get(current_node).copy_inputs(&mut ir_nodes_stack);
+        let num_inputs = ir_nodes_stack.len() - inputs_start_idx;
+
+        let mut current_node_in_edges =
+            UnitVec::from_iter((0..num_inputs).map(|_| all_edges_map.insert(None)));
+
+        for i in 0..num_inputs {
+            let input_node = ir_nodes_stack[i + inputs_start_idx];
+            let _ = ir_node_to_edges_map.try_insert(input_node, IRNodeEdges::default());
+            let IRNodeEdges {
+                out_edges: input_node_out_edges,
+                ..
+            } = ir_node_to_edges_map.get_mut(&input_node).unwrap();
+
+            input_node_out_edges.push(current_node_in_edges[i])
+        }
+
+        let _ = ir_node_to_edges_map.try_insert(current_node, IRNodeEdges::default());
+        let current_edges = ir_node_to_edges_map.get_mut(&current_node).unwrap();
+
+        assert!(current_edges.in_edges.is_empty());
+        current_edges.in_edges = current_node_in_edges;
+    }
+
+    // for node in ir_nodes_stack.iter().copied() {
+    //     simplify_ir_node_ordering(
+    //         node,
+    //         &mut ir_node_to_edges_map,
+    //         &mut all_edges_map,
+    //         ir_arena,
+    //         expr_arena,
+    //     );
+    // }
+
+    // for node in ir_nodes_stack.drain(..).rev() {
+    //     simplify_ir_node_ordering(
+    //         node,
+    //         &mut ir_node_to_edges_map,
+    //         &mut all_edges_map,
+    //         ir_arena,
+    //         expr_arena,
+    //     );
+    // }
+
+    // dbg!("OK");
+}
+
+// fn simplify_ir_node_ordering(
+//     current_ir_node: Node,
+//     ir_node_to_edges_map: &mut PlHashMap<Node, IRNodeEdges>,
+//     all_edges_map: &mut EdgesMap,
+//     ir_arena: &mut Arena<IR>,
+//     expr_arena: &mut Arena<AExpr>,
+// ) {
+//     match ir_arena.get(current_ir_node) {
+//         IR::Sink { input, payload } => {
+//             let IRNodeEdges { in_edges, .. } =
+//                 ir_node_to_edges_map.get_mut(&current_ir_node).unwrap();
+//         },
+//         IR::SinkMultiple { .. } | IR::Invalid => unreachable!(),
+//         _ => {
+//             dbg!();
+//             unimplemented!()
+//         },
+//     }
+// }


### PR DESCRIPTION
```python
q = (
    pl.LazyFrame({"a": [0, 1, 2]})
    .unique("*", maintain_order=False)
    .select(pl.implode("a"), sum=pl.col("a").sort().sum())
)
print(q.explain())

# Before
# SELECT [col("a").implode(), col("a").sort(asc).sum().alias("sum")]
#   UNIQUE[maintain_order: false, keep_strategy: Any] BY Some(["a"])
#     DF ["a"]; PROJECT */1 COLUMNS

# After
# SELECT [col("a").implode(maintain_order=false), col("a").sum().alias("sum")]
#   UNIQUE[maintain_order: false, keep_strategy: Any] BY Some(["a"])
#     DF ["a"]; PROJECT */1 COLUMNS

```
