### PR TITLE
fix: Set sorted flag for Boolean and Time

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/time.rs
+++ b/crates/polars-core/src/chunked_array/logical/time.rs
@@ -36,14 +36,16 @@ impl Int64Chunked {
 
         debug_assert!(null_count >= self.null_count);
 
-        // @TODO: We throw away metadata here. That is mostly not needed.
         // SAFETY: We calculated the null_count again. And we are taking the rest from the previous
         // Int64Chunked.
-        let int64chunked =
+        let mut ca =
             unsafe { Self::new_with_dims(self.field.clone(), chunks, self.length, null_count) };
+        if null_count == self.null_count {
+            ca.set_sorted_flag(self.is_sorted_flag());
+        }
 
         // SAFETY: no invalid states.
-        unsafe { TimeChunked::new_logical(int64chunked, DataType::Time) }
+        unsafe { TimeChunked::new_logical(ca, DataType::Time) }
     }
 }
 

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -751,13 +751,19 @@ impl ChunkSort<BooleanType> for BooleanChunked {
             }
         }
 
-        Self::from_chunk_iter(
+        let mut ca = Self::from_chunk_iter(
             self.name().clone(),
             Some(BooleanArray::from_data_default(
                 bitmap.freeze(),
                 validity.map(|v| v.freeze()),
             )),
-        )
+        );
+        ca.set_sorted_flag(if options.descending {
+            IsSorted::Descending
+        } else {
+            IsSorted::Ascending
+        });
+        ca
     }
 
     fn sort(&self, descending: bool) -> BooleanChunked {

--- a/py-polars/tests/unit/operations/test_is_sorted.py
+++ b/py-polars/tests/unit/operations/test_is_sorted.py
@@ -427,3 +427,23 @@ def test_is_sorted_struct() -> None:
     s = s.sort(descending=True)
     assert s.flags["SORTED_DESC"]
     assert not s.flags["SORTED_ASC"]
+
+
+def test_is_sorted_boolean_27034() -> None:
+    s = pl.Series("a", [False, True]).sort()
+    assert s.flags["SORTED_ASC"]
+    assert not s.flags["SORTED_DESC"]
+
+    s = pl.Series("a", [False, True]).sort(descending=True)
+    assert s.flags["SORTED_DESC"]
+    assert not s.flags["SORTED_ASC"]
+
+
+def test_is_sorted_time() -> None:
+    s = pl.Series("a", [0, 1]).sort().cast(pl.Time)
+    assert s.flags["SORTED_ASC"]
+    assert not s.flags["SORTED_DESC"]
+
+    s = pl.Series("a", [1, 1]).sort(descending=True).cast(pl.Time)
+    assert s.flags["SORTED_DESC"]
+    assert not s.flags["SORTED_ASC"]


### PR DESCRIPTION
Fixes #27034.

I noticed that `pl.Time` also had a TODO to keep the sortedness information.
