### PR TITLE
fix(python): Make @deprecated work regardless of decorator stacking order

### DIFF
--- a/py-polars/src/polars/_utils/deprecation.py
+++ b/py-polars/src/polars/_utils/deprecation.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import ast
 import inspect
+import re
 import sys
+import warnings
 from collections import defaultdict
 from collections.abc import Sequence
 from functools import wraps
@@ -77,10 +79,38 @@ def _deprecate_function(message: str) -> IdentityFunction:
     return decorate
 
 
+def _forward_deprecated_warning(function: Callable[P, T]) -> Callable[P, T]:
+    """
+    Call a function that may carry a ``__deprecated__`` warning.
+
+    If `function` (or its inner wrapper) has a ``__deprecated__`` attribute
+    (set by ``typing_extensions.deprecated`` / ``warnings.deprecated``), this
+    helper emits the deprecation warning via `issue_deprecation_warning` (which
+    uses `find_stacklevel` for correct stack-level attribution) and then calls
+    the function with the original ``DeprecationWarning`` suppressed so the
+    same message is not emitted twice.
+    """
+    deprecated_msg: str | None = getattr(function, "__deprecated__", None)
+    if deprecated_msg is None:
+        return function
+
+    @wraps(function)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        issue_deprecation_warning(deprecated_msg)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=re.escape(deprecated_msg), category=DeprecationWarning)
+            return function(*args, **kwargs)
+
+    wrapper.__deprecated__ = deprecated_msg  # type: ignore[attr-defined]
+    return wrapper
+
+
 def deprecate_streaming_parameter() -> IdentityFunction:
     """Decorator to mark `streaming` argument as deprecated due to being renamed."""
 
     def decorate(function: Callable[P, T]) -> Callable[P, T]:
+        function = _forward_deprecated_warning(function)
+
         @wraps(function)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             if "streaming" in kwargs:
@@ -120,6 +150,8 @@ def deprecate_renamed_parameter(
     """
 
     def decorate(function: Callable[P, T]) -> Callable[P, T]:
+        function = _forward_deprecated_warning(function)
+
         @wraps(function)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             _rename_keyword_argument(
@@ -190,6 +222,7 @@ def deprecate_nonkeyword_arguments(
     """
 
     def decorate(function: Callable[P, T]) -> Callable[P, T]:
+        function = _forward_deprecated_warning(function)
         old_sig = inspect.signature(function)
 
         if allowed_args is not None:
@@ -267,6 +300,8 @@ def deprecate_parameter_as_multi_positional(old_name: str) -> IdentityFunction:
     """  # noqa: W505
 
     def decorate(function: Callable[P, T]) -> Callable[P, T]:
+        function = _forward_deprecated_warning(function)
+
         @wraps(function)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             try:

--- a/py-polars/src/polars/_utils/deprecation.py
+++ b/py-polars/src/polars/_utils/deprecation.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import ast
 import inspect
-import re
 import sys
-import warnings
 from collections import defaultdict
 from collections.abc import Sequence
 from functools import wraps
@@ -81,29 +79,41 @@ def _deprecate_function(message: str) -> IdentityFunction:
 
 def _forward_deprecated_warning(function: Callable[P, T]) -> Callable[P, T]:
     """
-    Call a function that may carry a ``__deprecated__`` warning.
+    Re-emit a ``@deprecated`` warning with correct stack-level attribution.
 
-    If `function` (or its inner wrapper) has a ``__deprecated__`` attribute
-    (set by ``typing_extensions.deprecated`` / ``warnings.deprecated``), this
-    helper emits the deprecation warning via `issue_deprecation_warning` (which
-    uses `find_stacklevel` for correct stack-level attribution) and then calls
-    the function with the original ``DeprecationWarning`` suppressed so the
-    same message is not emitted twice.
+    When ``typing_extensions.deprecated`` / ``warnings.deprecated`` is stacked
+    below a Polars deprecation decorator, its hard-coded ``stacklevel=2``
+    causes the warning to be attributed to internal library code and silently
+    suppressed by Python's default warning filter.
+
+    This helper detects the ``__deprecated__`` attribute, bypasses the original
+    ``@deprecated`` wrapper (via ``__wrapped__``), and re-emits the warning
+    through ``issue_deprecation_warning`` which uses ``find_stacklevel`` to
+    attribute it to user code.
     """
     deprecated_msg: str | None = getattr(function, "__deprecated__", None)
     if deprecated_msg is None:
         return function
 
+    # Already forwarded by an inner Polars decorator — skip to avoid duplicates.
+    if getattr(function, "_polars_deprecated_forwarded", False):
+        return function
+
+    # Both typing_extensions.deprecated and warnings.deprecated use
+    # functools.wraps, which sets __wrapped__ to the original function.
+    # Calling __wrapped__ directly bypasses the @deprecated wrapper
+    # (and its broken stacklevel) entirely.
+    unwrapped: Callable[P, T] | None = getattr(function, "__wrapped__", None)
+    if unwrapped is None:
+        return function
+
     @wraps(function)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
         issue_deprecation_warning(deprecated_msg)
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore", message=re.escape(deprecated_msg), category=DeprecationWarning
-            )
-            return function(*args, **kwargs)
+        return unwrapped(*args, **kwargs)
 
     wrapper.__deprecated__ = deprecated_msg  # type: ignore[attr-defined]
+    wrapper._polars_deprecated_forwarded = True  # type: ignore[attr-defined]
     return wrapper
 
 

--- a/py-polars/src/polars/_utils/deprecation.py
+++ b/py-polars/src/polars/_utils/deprecation.py
@@ -98,7 +98,9 @@ def _forward_deprecated_warning(function: Callable[P, T]) -> Callable[P, T]:
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
         issue_deprecation_warning(deprecated_msg)
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message=re.escape(deprecated_msg), category=DeprecationWarning)
+            warnings.filterwarnings(
+                "ignore", message=re.escape(deprecated_msg), category=DeprecationWarning
+            )
             return function(*args, **kwargs)
 
     wrapper.__deprecated__ = deprecated_msg  # type: ignore[attr-defined]

--- a/py-polars/tests/unit/utils/test_deprecation.py
+++ b/py-polars/tests/unit/utils/test_deprecation.py
@@ -112,3 +112,31 @@ def test_identify_deprecations() -> None:
         match="unrecognised deprecation type 'bitterballen'",
     ):
         identify_deprecations("bitterballen")  # type: ignore[arg-type]
+
+
+def test_deprecated_under_deprecate_renamed_parameter() -> None:
+    """Test that @deprecated fires even when below @deprecate_renamed_parameter."""
+    # @deprecated on top (outermost) -- always worked
+    @deprecated("`top_hello` is deprecated.")
+    @deprecate_renamed_parameter("foo", "oof", version="1.0.0")
+    def top_hello(oof: str) -> None: ...
+
+    with pytest.deprecated_call(match=r"`top_hello` is deprecated\."):
+        top_hello(oof="x")
+
+    # @deprecated on bottom (innermost) -- previously broken on Python 3.13+
+    @deprecate_renamed_parameter("foo", "oof", version="1.0.0")
+    @deprecated("`bottom_hello` is deprecated.")
+    def bottom_hello(oof: str) -> None: ...
+
+    with pytest.deprecated_call(match=r"`bottom_hello` is deprecated\."):
+        bottom_hello(oof="x")
+
+    # @deprecated sandwiched between two @deprecate_renamed_parameter
+    @deprecate_renamed_parameter("foo", "oof", version="1.0.0")
+    @deprecated("`mid_hello` is deprecated.")
+    @deprecate_renamed_parameter("bar", "rab", version="2.0.0")
+    def mid_hello(oof: str, rab: str) -> None: ...
+
+    with pytest.deprecated_call(match=r"`mid_hello` is deprecated\."):
+        mid_hello(oof="x", rab="y")

--- a/py-polars/tests/unit/utils/test_deprecation.py
+++ b/py-polars/tests/unit/utils/test_deprecation.py
@@ -116,6 +116,7 @@ def test_identify_deprecations() -> None:
 
 def test_deprecated_under_deprecate_renamed_parameter() -> None:
     """Test that @deprecated fires even when below @deprecate_renamed_parameter."""
+
     # @deprecated on top (outermost) -- always worked
     @deprecated("`top_hello` is deprecated.")
     @deprecate_renamed_parameter("foo", "oof", version="1.0.0")


### PR DESCRIPTION
Closes #26536

## Summary

- Adds a `_forward_deprecated_warning` helper that re-emits `__deprecated__` warnings via `issue_deprecation_warning` (which uses `find_stacklevel` for correct stack-level attribution) when `@deprecated` is stacked below other Polars deprecation decorators
- Each Polars deprecation decorator (`deprecate_renamed_parameter`, `deprecate_nonkeyword_arguments`, `deprecate_streaming_parameter`, `deprecate_parameter_as_multi_positional`) now calls this helper on its inner function, so `@deprecated` fires correctly regardless of decorator ordering
- Keeps the real `deprecated` import from `typing_extensions`/`warnings` so IDEs (VSCode, PyCharm) continue showing strikethrough on deprecated functions (ref: #22594)
- Suppresses duplicate warnings from the inner `deprecated` wrapper using `warnings.catch_warnings`

## Test plan

- [x] New test `test_deprecated_under_deprecate_renamed_parameter` verifies all orderings: `@deprecated` on top, on bottom, and sandwiched between multiple `@deprecate_renamed_parameter` decorators
- [x] Existing `test_deprecate_function`, `test_deprecate_renamed_parameter`, and all other deprecation tests continue to pass
- [x] `test_read_batch_csv_deprecations_26479` from PR #26530 continues to pass
- [x] Verified no duplicate warnings are emitted
- [x] Verified `__deprecated__` attribute is preserved through wrapper layers for IDE support

AI-assisted: Claude Code was used to help implement this fix.