### PR TITLE
fix: Prevent panic in `transpose()` with mixed List and non-List columns

### DIFF
--- a/crates/polars-core/src/frame/row/transpose.rs
+++ b/crates/polars-core/src/frame/row/transpose.rs
@@ -62,8 +62,8 @@ impl DataFrame {
                 let columns = self
                     .materialized_column_iter()
                     // first cast to supertype before casting to physical to ensure units are correct
-                    .map(|s| s.cast(dtype).unwrap().cast(&phys_dtype).unwrap())
-                    .collect::<Vec<_>>();
+                    .map(|s| s.cast(dtype)?.cast(&phys_dtype))
+                    .collect::<PolarsResult<Vec<_>>>()?;
 
                 // this is very expensive. A lot of cache misses here.
                 // This is the part that is performance critical.

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -3365,3 +3365,17 @@ def test_sample_respects_global_seed_26973() -> None:
     result2 = df.sample(1)
 
     assert_frame_equal(result1, result2)
+
+
+def test_transpose_mixed_list_and_non_list_columns_no_panic_26538() -> None:
+    df = pl.DataFrame(
+        {
+            "a": [[1, 2], [3, 4]],
+            "b": [[5, 6], [7, 8]],
+            "c": ["foo", "bar"],
+            "d": [["baz"], ["qux"]],
+        }
+    )
+
+    with pytest.raises(pl.exceptions.InvalidOperationError):
+        df.transpose()


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/26538.

The problem came from using `.unwrap()` on `.cast()`. If the casting failed, it would panic. The fix was to use the `?` operator to propagate the error instead. It now raises and `InvalidOperationError` instead of panicking. 

🤖 Claude Sonnet 4.6 for navigating the codebase. 