### PR TITLE
fix(python): Polars cloud typing issue in `conftest.py`

### DIFF
--- a/py-polars/tests/conftest.py
+++ b/py-polars/tests/conftest.py
@@ -61,7 +61,7 @@ def _patched_cloud(
             return prev_collect(
                 with_timeout(
                     lambda: lf.remote(plan_type="plain").distributed().execute()
-                ).lazy()
+                ).lazy()  # type: ignore[union-attr]
             )
 
         class LazyExe:


### PR DESCRIPTION
When running `make pre-commit` locally, even with an up-to-date version of `main`, I was getting:

<img width="1046" height="253" alt="image" src="https://github.com/user-attachments/assets/ed67ced2-8f72-4d23-9c06-0900cd306240" />

There seems to be an internal typing issue with `polars_cloud` that is leading to this. I just added a `type: ignore` for now so the check would pass.

If this isn't a big deal, this can also be ignored and the PR closed. 
