### PR TITLE
fix(python): Support expressions in `DataFrame.unpivot`

### DIFF
--- a/py-polars/src/polars/_utils/parse/expr.py
+++ b/py-polars/src/polars/_utils/parse/expr.py
@@ -121,7 +121,7 @@ def parse_into_list_of_expressions(
 
 @overload
 def parse_into_selector(
-    i: ColumnNameOrSelector,
+    i: Expr | ColumnNameOrSelector,
     *,
     strict: bool = ...,
     raise_if_not_selector: Literal[False] = False,
@@ -130,7 +130,7 @@ def parse_into_selector(
 
 @overload
 def parse_into_selector(
-    i: ColumnNameOrSelector,
+    i: Expr | ColumnNameOrSelector,
     *,
     strict: bool = ...,
     raise_if_not_selector: Literal[True],
@@ -138,7 +138,7 @@ def parse_into_selector(
 
 
 def parse_into_selector(
-    i: ColumnNameOrSelector,
+    i: Expr | ColumnNameOrSelector,
     *,
     strict: bool = True,
     raise_if_not_selector: bool = True,
@@ -160,7 +160,7 @@ def parse_into_selector(
 
 
 def parse_list_into_selector(
-    inputs: ColumnNameOrSelector | Collection[ColumnNameOrSelector],
+    inputs: Expr | ColumnNameOrSelector | Collection[Expr | ColumnNameOrSelector],
     *,
     strict: bool = True,
 ) -> pl.Selector:

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -9676,9 +9676,15 @@ class DataFrame:
 
     def unpivot(
         self,
-        on: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None = None,
+        on: Expr
+        | ColumnNameOrSelector
+        | Sequence[Expr | ColumnNameOrSelector]
+        | None = None,
         *,
-        index: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None = None,
+        index: Expr
+        | ColumnNameOrSelector
+        | Sequence[Expr | ColumnNameOrSelector]
+        | None = None,
         variable_name: str | None = None,
         value_name: str | None = None,
     ) -> DataFrame:
@@ -9738,10 +9744,15 @@ class DataFrame:
         │ z   ┆ c        ┆ 6     │
         └─────┴──────────┴───────┘
         """
-        on = None if on is None else _expand_selectors(self, on)
-        index = [] if index is None else _expand_selectors(self, index)
+        from polars.lazyframe.opt_flags import QueryOptFlags
 
-        return self._from_pydf(self._df.unpivot(on, index, value_name, variable_name))
+        return (
+            self.lazy()
+            .unpivot(
+                on, index=index, variable_name=variable_name, value_name=value_name
+            )
+            .collect(optimizations=QueryOptFlags._eager())
+        )
 
     def unstack(
         self,

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -8409,9 +8409,15 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def unpivot(
         self,
-        on: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None = None,
+        on: Expr
+        | ColumnNameOrSelector
+        | Sequence[Expr | ColumnNameOrSelector]
+        | None = None,
         *,
-        index: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None = None,
+        index: Expr
+        | ColumnNameOrSelector
+        | Sequence[Expr | ColumnNameOrSelector]
+        | None = None,
         variable_name: str | None = None,
         value_name: str | None = None,
         streamable: bool = True,

--- a/py-polars/tests/unit/operations/test_unpivot.py
+++ b/py-polars/tests/unit/operations/test_unpivot.py
@@ -109,9 +109,9 @@ def test_unpivot_categorical() -> None:
     )
     out = df.unpivot(["1", "2"], index="index")
     assert out.dtypes == [pl.Int64, pl.String, pl.Categorical()]
-    assert out.to_dict(as_series=False) == {
-        "index": [0, 1, 0, 1],
-        "variable": ["1", "1", "2", "2"],
+    assert out.sort("index", "variable").to_dict(as_series=False) == {
+        "index": [0, 0, 1, 1],
+        "variable": ["1", "2", "1", "2"],
         "value": ["a", "b", "b", "c"],
     }
 
@@ -318,3 +318,17 @@ def test_unpivot_projection_pushdown_schema_25720() -> None:
             ]
         ),
     )
+
+
+def test_unpivot_expr_27037() -> None:
+    df = pl.DataFrame({"x": [1], "y": [2]})
+    result = df.unpivot(pl.col.x)
+    expected = pl.DataFrame({"variable": ["x"], "value": [1]})
+    assert_frame_equal(result, expected)
+
+
+def test_unpivot_expr_index_27037() -> None:
+    df = pl.DataFrame({"x": [1], "y": [2]})
+    result = df.unpivot(pl.col.y, index=pl.col.x)
+    expected = pl.DataFrame({"x": [1], "variable": ["y"], "value": [2]})
+    assert_frame_equal(result, expected)


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/27037.

`DataFrame.unpivot` raised `TypeError: 'Expr' object cannot be cast as 'str'` when given expressions like `pl.col.x`, even though `LazyFrame.unpivot` handled them fine. The fix dispatches to the lazy implementation, matching the pattern used by `unnest`.