### PR TITLE
chore: Pin maturin due to compile time regression

### DIFF
--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -6,7 +6,7 @@
 # BUILD
 # -----
 
-maturin
+maturin<=1.12.4  # https://github.com/PyO3/maturin/issues/3106
 # extra dependency for maturin (linux-only)
 patchelf; platform_system == 'Linux'
 pip

--- a/pyo3-polars/example/derive_expression/requirements.txt
+++ b/pyo3-polars/example/derive_expression/requirements.txt
@@ -1,2 +1,2 @@
-maturin
+maturin<=1.12.4  # https://github.com/PyO3/maturin/issues/3106
 polars

--- a/pyo3-polars/example/extend_polars_python_dispatch/requirements.txt
+++ b/pyo3-polars/example/extend_polars_python_dispatch/requirements.txt
@@ -1,1 +1,1 @@
-maturin
+maturin<=1.12.4  # https://github.com/PyO3/maturin/issues/3106

--- a/pyo3-polars/example/io_plugin/requirements.txt
+++ b/pyo3-polars/example/io_plugin/requirements.txt
@@ -1,2 +1,2 @@
-maturin
+maturin<=1.12.4  # https://github.com/PyO3/maturin/issues/3106
 polars


### PR DESCRIPTION
Until https://github.com/PyO3/maturin/issues/3106 is fixed I've pinned maturin to 1.12.4, as it caused dramatic compile time regressions on MacOS.