### PR TITLE
fix(python)!: Single indexing on List/Array columns returns Python list instead of Series

### DIFF
--- a/crates/polars-python/src/series/general.rs
+++ b/crates/polars-python/src/series/general.rs
@@ -11,7 +11,6 @@ use super::PySeries;
 use crate::dataframe::PyDataFrame;
 use crate::error::PyPolarsErr;
 use crate::prelude::*;
-use crate::py_modules::polars;
 use crate::utils::EnterPolarsExt;
 
 #[pymethods]
@@ -125,13 +124,7 @@ impl PySeries {
             Err(e) => return Err(PyPolarsErr::from(e).into()),
         };
 
-        match av {
-            AnyValue::List(s) | AnyValue::Array(s, _) => {
-                let pyseries = PySeries::new(s);
-                polars(py).getattr(py, "wrap_s")?.call1(py, (pyseries,))
-            },
-            _ => Wrap(av).into_py_any(py),
-        }
+        Wrap(av).into_py_any(py)
     }
 
     /// Get a value by index, allowing negative indices.

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -609,8 +609,8 @@ def test_take_misc(fruits_cars: pl.DataFrame) -> None:
             "fruits",
         )
 
-        assert out[0, "B"].to_list() == [2, 3]
-        assert out[4, "B"].to_list() == [1, 4]
+        assert out[0, "B"] == [2, 3]
+        assert out[4, "B"] == [1, 4]
 
     out = df.sort("fruits").select(
         pl.col("B").reverse().get(pl.lit(1)).over("fruits"),

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -468,16 +468,6 @@ def test_categorical_asof_join_by_arg() -> None:
     )
 
 
-def test_categorical_list_get_item() -> None:
-    s = pl.Series([["a"]]).cast(pl.List(pl.Categorical))
-    # Check the Series dtype has categorical inner type
-    assert s.dtype.inner == pl.Categorical  # type: ignore[attr-defined]
-    # item() now returns a Python list
-    out = s.item()
-    assert isinstance(out, list)
-    assert out == ["a"]
-
-
 def test_nested_categorical_aggregation_7848() -> None:
     # a double categorical aggregation
     assert pl.DataFrame(

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -469,9 +469,13 @@ def test_categorical_asof_join_by_arg() -> None:
 
 
 def test_categorical_list_get_item() -> None:
-    out = pl.Series([["a"]]).cast(pl.List(pl.Categorical)).item()
-    assert isinstance(out, pl.Series)
-    assert out.dtype == pl.Categorical
+    s = pl.Series([["a"]]).cast(pl.List(pl.Categorical))
+    # Check the Series dtype has categorical inner type
+    assert s.dtype.inner == pl.Categorical  # type: ignore[attr-defined]
+    # item() now returns a Python list
+    out = s.item()
+    assert isinstance(out, list)
+    assert out == ["a"]
 
 
 def test_nested_categorical_aggregation_7848() -> None:

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -222,15 +222,17 @@ def test_struct_cols() -> None:
 
     # struct in list
     df = build_struct_df([{"list_of_struct_col": [{"inner": 1}]}])
-    assert df["list_of_struct_col"][0].struct.field("inner").to_list() == [1]
+    # Accessing list element returns Python list of dicts
+    assert df["list_of_struct_col"][0] == [{"inner": 1}]
 
     # struct in list in struct
     df = build_struct_df(
         [{"struct_list_struct_col": {"list_struct_col": [{"inner": 1}]}}]
     )
-    assert df["struct_list_struct_col"].struct.field("list_struct_col")[0].struct.field(
-        "inner"
-    ).to_list() == [1]
+    # Accessing list element returns Python list of dicts
+    assert df["struct_list_struct_col"].struct.field("list_struct_col")[0] == [
+        {"inner": 1}
+    ]
 
 
 def test_struct_with_validity() -> None:

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -186,7 +186,7 @@ def test_diff_datetime() -> None:
     out = df.with_columns(
         pl.col("timestamp").diff().over("char", mapping_strategy="join")
     )["timestamp"]
-    assert_series_equal(out[0], out[1])
+    assert out[0] == out[1]
 
 
 def test_from_pydatetime() -> None:

--- a/py-polars/tests/unit/functions/range/test_linear_space.py
+++ b/py-polars/tests/unit/functions/range/test_linear_space.py
@@ -256,7 +256,7 @@ def test_linear_spaces_values(interval: ClosedInterval) -> None:
             expected = pl.linear_space(
                 start, end, ns, eager=True, closed=interval
             ).rename("")
-            assert_series_equal(row, expected)
+            assert row == expected.to_list()
 
 
 @pytest.mark.parametrize("interval", ["both", "left", "right", "none"])

--- a/py-polars/tests/unit/functions/test_cum_count.py
+++ b/py-polars/tests/unit/functions/test_cum_count.py
@@ -70,8 +70,8 @@ def test_cum_count() -> None:
         pl.col("A").cum_count().alias("foo")
     )
 
-    assert out["foo"][0].to_list() == [1, 2, 3, 4]
-    assert out["foo"][1].to_list() == [1, 2]
+    assert out["foo"][0] == [1, 2, 3, 4]
+    assert out["foo"][1] == [1, 2]
 
 
 def test_series_cum_count() -> None:

--- a/py-polars/tests/unit/io/test_delta_deletion_vector.py
+++ b/py-polars/tests/unit/io/test_delta_deletion_vector.py
@@ -586,7 +586,7 @@ def test_scan_delta_dv_single(
             v.pop()
         return v
 
-    observed_vec = truncate_trailing_trues(dv_df["selection_vector"][0].to_list())
+    observed_vec = truncate_trailing_trues(dv_df["selection_vector"][0])
     expected_vec = truncate_trailing_trues([i not in dv for i in range(n_rows)])
 
     expected_dv_df = pl.DataFrame(

--- a/py-polars/tests/unit/operations/map/test_map_groups.py
+++ b/py-polars/tests/unit/operations/map/test_map_groups.py
@@ -103,8 +103,8 @@ def test_map_groups_none() -> None:
             ).alias("multiple")
         )
     )["multiple"]
-    assert out[0].to_list() == [4.75, 326.75, 82.75]
-    assert out[1].to_list() == [238.75, 3418849.75, 372.75]
+    assert out[0] == [4.75, 326.75, 82.75]
+    assert out[1] == [238.75, 3418849.75, 372.75]
 
     out_df = df.select(pl.map_batches(exprs=["a", "b"], function=lambda s: s[0] * s[1]))
     assert out_df["a"].to_list() == (df["a"] * df["b"]).to_list()

--- a/py-polars/tests/unit/operations/namespaces/array/test_eval.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_eval.py
@@ -162,16 +162,21 @@ def test_arr_agg_parametric(
 ) -> None:
     def test_case(s: pl.Series) -> None:
         out = s.arr.agg(expr(pl.element()))
+        inner_dtype = s.dtype.inner  # type: ignore[attr-defined]
 
         for i, v in enumerate(s):
             if v is None:
                 assert out[i] is None
                 continue
 
-            assert isinstance(v, pl.Series)
+            assert isinstance(v, list)
 
-            v = v.rename("")
-            v = v.to_frame().select(expr(pl.col(""))).to_series()
+            v = (
+                pl.Series("", v, dtype=inner_dtype)
+                .to_frame()
+                .select(expr(pl.col("")))
+                .to_series()
+            )
 
             if not is_scalar:
                 v = v.implode()

--- a/py-polars/tests/unit/operations/namespaces/list/test_eval.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_eval.py
@@ -362,15 +362,21 @@ def test_list_agg_parametric(
 ) -> None:
     def test_case(s: pl.Series) -> None:
         out = s.list.agg(expr(pl.element()))
+        inner_dtype = s.dtype.inner  # type: ignore[attr-defined]
 
         for i, v in enumerate(s):
             if v is None:
                 assert out[i] is None
                 continue
 
-            assert isinstance(v, pl.Series)
+            assert isinstance(v, list)
 
-            v = v.to_frame().select(expr(pl.col(""))).to_series()
+            v = (
+                pl.Series("", v, dtype=inner_dtype)
+                .to_frame()
+                .select(expr(pl.col("")))
+                .to_series()
+            )
 
             if not is_scalar:
                 v = v.implode()
@@ -575,7 +581,7 @@ def test_list_eval_after_filter_in_agg_25361(
     )
     out = q.collect()
     assert_frame_equal(out, expected, check_row_order=maintain_order)
-    assert out.item().len() == df.height
+    assert len(out.item()) == df.height
 
     # over
     q = df.lazy().select(pl.col.a.filter(predicate).list.eval(pl.element()).over(keys))

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -282,13 +282,13 @@ def test_list_concat() -> None:
     df = pl.DataFrame({"a": [[1, 2], [1], [1, 2, 3]]})
 
     out = df.select([pl.col("a").list.concat(pl.Series([[1, 2]]))])
-    assert out["a"][0].to_list() == [1, 2, 1, 2]
+    assert out["a"][0] == [1, 2, 1, 2]
 
     out = df.select([pl.col("a").list.concat([1, 4])])
-    assert out["a"][0].to_list() == [1, 2, 1, 4]
+    assert out["a"][0] == [1, 2, 1, 4]
 
     out_s = df["a"].list.concat([4, 1])
-    assert out_s[0].to_list() == [1, 2, 4, 1]
+    assert out_s[0] == [1, 2, 4, 1]
 
 
 def test_list_join() -> None:

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -757,17 +757,17 @@ def test_str_strip_suffix_wrong_length() -> None:
 def test_str_split() -> None:
     a = pl.Series("a", ["a, b", "a", "ab,c,de"])
     for out in [a.str.split(","), pl.select(pl.lit(a).str.split(",")).to_series()]:
-        assert out[0].to_list() == ["a", " b"]
-        assert out[1].to_list() == ["a"]
-        assert out[2].to_list() == ["ab", "c", "de"]
+        assert out[0] == ["a", " b"]
+        assert out[1] == ["a"]
+        assert out[2] == ["ab", "c", "de"]
 
     for out in [
         a.str.split(",", inclusive=True),
         pl.select(pl.lit(a).str.split(",", inclusive=True)).to_series(),
     ]:
-        assert out[0].to_list() == ["a,", " b"]
-        assert out[1].to_list() == ["a"]
-        assert out[2].to_list() == ["ab,", "c,", "de"]
+        assert out[0] == ["a,", " b"]
+        assert out[1] == ["a"]
+        assert out[2] == ["ab,", "c,", "de"]
 
 
 def test_json_decode_series() -> None:

--- a/py-polars/tests/unit/operations/test_reshape.py
+++ b/py-polars/tests/unit/operations/test_reshape.py
@@ -131,10 +131,10 @@ def test_array_ndarray_reshape() -> None:
     s = pl.Series(range(64)).reshape(shape)
     n = s.to_numpy()
     assert n.shape == shape
-    assert (n[0] == s[0].to_numpy()).all()
+    assert n[0].tolist() == s[0]
     n = n[0]
-    s = s[0]
-    assert (n[0] == s[0].to_numpy()).all()
+    s0 = s[0]
+    assert n[0].tolist() == s0[0]
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -128,8 +128,8 @@ def test_init_inputs(plmonkeypatch: PlMonkeyPatch) -> None:
         ),
     ):
         assert res.dtype == pl.Array(pl.Float32, shape=2)
-        assert res[0].to_list() == [1.0, 2.0]
-        assert res[1].to_list() == [3.0, None]
+        assert res[0] == [1.0, 2.0]
+        assert res[1] == [3.0, None]
 
     # numpy from arange, with/without dtype
     two_ints = np.arange(2, dtype=np.int64)
@@ -1006,9 +1006,9 @@ def test_round_sig_figs_raises_exc() -> None:
 def test_apply_list_out() -> None:
     s = pl.Series("count", [3, 2, 2])
     out = s.map_elements(lambda val: pl.repeat(val, val, eager=True))
-    assert out[0].to_list() == [3, 3, 3]
-    assert out[1].to_list() == [2, 2]
-    assert out[2].to_list() == [2, 2]
+    assert out[0] == [3, 3, 3]
+    assert out[1] == [2, 2]
+    assert out[2] == [2, 2]
 
 
 def test_reinterpret_signed() -> None:
@@ -1688,17 +1688,15 @@ def test_init_categorical() -> None:
 
 def test_iter_nested_list() -> None:
     elems = list(pl.Series("s", [[1, 2], [3, 4]]))
-    assert_series_equal(elems[0], pl.Series([1, 2]))
-    assert_series_equal(elems[1], pl.Series([3, 4]))
+    assert elems[0] == [1, 2]
+    assert elems[1] == [3, 4]
 
     rev_elems = list(reversed(pl.Series("s", [[1, 2], [3, 4]])))
-    assert_series_equal(rev_elems[0], pl.Series([3, 4]))
-    assert_series_equal(rev_elems[1], pl.Series([1, 2]))
+    assert rev_elems[0] == [3, 4]
+    assert rev_elems[1] == [1, 2]
 
 
 def test_iter_nested_struct() -> None:
-    # note: this feels inconsistent with the above test for nested list, but
-    # let's ensure the behaviour is codified before potentially modifying...
     elems = list(pl.Series("s", [{"a": 1, "b": 2}, {"a": 3, "b": 4}]))
     assert elems[0] == {"a": 1, "b": 2}
     assert elems[1] == {"a": 3, "b": 4}
@@ -1721,8 +1719,12 @@ def test_iter_nested_struct() -> None:
 )
 def test_nested_list_types_preserved(dtype: pl.DataType) -> None:
     srs = pl.Series([pl.Series([], dtype=dtype) for _ in range(5)])
-    for srs_nested in srs:
-        assert srs_nested.dtype == dtype
+    # Check that the inner dtype is preserved
+    assert srs.dtype.inner == dtype  # type: ignore[attr-defined]
+    # Elements are now Python lists
+    for elem in srs:
+        assert isinstance(elem, list)
+        assert elem == []
 
 
 def test_to_physical() -> None:

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1717,7 +1717,7 @@ def test_iter_nested_struct() -> None:
         pl.Struct([pl.Field("a", pl.Int64), pl.Field("b", pl.Boolean)]),
     ],
 )
-def test_nested_list_types_preserved(dtype: pl.DataType) -> None:
+def test_nested_list_types_not_preserved(dtype: pl.DataType) -> None:
     srs = pl.Series([pl.Series([], dtype=dtype) for _ in range(5)])
     # Check that the inner dtype is preserved
     assert srs.dtype.inner == dtype  # type: ignore[attr-defined]

--- a/py-polars/tests/unit/testing/parametric/strategies/test_core.py
+++ b/py-polars/tests/unit/testing/parametric/strategies/test_core.py
@@ -70,8 +70,7 @@ def test_series_allow_null_allowed_dtypes(s: pl.Series) -> None:
 
 @given(s=series(allowed_dtypes=[pl.List(pl.Int8)], allow_null=False))
 def test_series_allow_null_nested(s: pl.Series) -> None:
-    for v in s:
-        assert not v.has_nulls()
+    assert not s.explode(empty_as_null=False).has_nulls()
 
 
 @given(df=dataframes())


### PR DESCRIPTION
Fixes #23575 

This is a major breaking change, but it's much me corehent.

On main when you query a single index on a series you get python object in some case and polars series in other:
```python
# main
list_series = pl.Series([[1, 2, 3, 4]])
struct_series = pl.Series([{"a": [1]}])

list_series[0]
# shape: (4,)
# Series: '' [i64]
# [
# 	1
# 	2
# 	3
# 	4
# ]

struct_series[0]
# {'a': 1}
```
In this PR, querying a single index gives you always a python object.

```python
# PR
list_series[0]
# [1, 2, 3, 4]

struct_series[0]
# {'a': 1}
```


 I used AI to help me updating all the tests
