### PR TITLE
fix: Apply `strict` parameter in `from_{dicts,rows}`

### DIFF
--- a/crates/polars-python/src/dataframe/construction.rs
+++ b/crates/polars-python/src/dataframe/construction.rs
@@ -13,16 +13,17 @@ use crate::utils::EnterPolarsExt;
 #[pymethods]
 impl PyDataFrame {
     #[staticmethod]
-    #[pyo3(signature = (data, schema=None, infer_schema_length=None))]
+    #[pyo3(signature = (data, schema=None, strict=true, infer_schema_length=None ))]
     pub fn from_rows(
         py: Python<'_>,
         data: Vec<Wrap<Row>>,
         schema: Option<Wrap<Schema>>,
+        strict: bool,
         infer_schema_length: Option<usize>,
     ) -> PyResult<Self> {
         let data = vec_extract_wrapped(data);
         let schema = schema.map(|wrap| wrap.0);
-        py.enter_polars(move || finish_from_rows(data, schema, None, infer_schema_length))
+        py.enter_polars(move || finish_from_rows(data, schema, None, infer_schema_length, strict))
     }
 
     #[staticmethod]
@@ -66,7 +67,7 @@ impl PyDataFrame {
             ))
         });
         py.enter_polars(move || {
-            finish_from_rows(rows, schema, schema_overrides, infer_schema_length)
+            finish_from_rows(rows, schema, schema_overrides, infer_schema_length, strict)
         })
     }
 
@@ -86,6 +87,7 @@ fn finish_from_rows(
     schema: Option<Schema>,
     schema_overrides: Option<Schema>,
     infer_schema_length: Option<usize>,
+    strict: bool,
 ) -> PyResult<PyDataFrame> {
     let schema = if let Some(mut schema) = schema {
         resolve_schema_overrides(&mut schema, schema_overrides);
@@ -95,7 +97,31 @@ fn finish_from_rows(
         rows_to_schema_supertypes(&rows, infer_schema_length).map_err(PyPolarsErr::from)?
     };
 
-    let df = DataFrame::from_rows_and_schema(&rows, &schema).map_err(PyPolarsErr::from)?;
+    let num_rows = rows.len();
+
+    if strict && !rows.windows(2).all(|w| w[0].0.len() == w[1].0.len()) {
+        return Err(PyPolarsErr::from(polars_err!(
+            ComputeError: "rows must be of equal length"
+        ))
+        .into());
+    }
+
+    let columns: Vec<Column> = schema
+        .iter()
+        .enumerate()
+        .map(|(col_idx, (name, dtype))| {
+            let column_values: Vec<AnyValue> = rows
+                .iter()
+                .map(|row| row.0.get(col_idx).cloned().unwrap_or(AnyValue::Null))
+                .collect();
+
+            Series::from_any_values_and_dtype(name.clone(), &column_values, dtype, strict)
+                .map(|s| s.into_column())
+        })
+        .collect::<PolarsResult<Vec<_>>>()
+        .map_err(PyPolarsErr::from)?;
+
+    let df = DataFrame::new(num_rows, columns).map_err(PyPolarsErr::from)?;
     Ok(df.into())
 }
 

--- a/py-polars/src/polars/_plr.pyi
+++ b/py-polars/src/polars/_plr.pyi
@@ -707,6 +707,7 @@ class PyDataFrame:
     def from_rows(
         data: Sequence[PySeries],
         schema: Any | None,
+        strict: bool,
         infer_schema_length: int | None,
     ) -> PyDataFrame: ...
     @staticmethod

--- a/py-polars/src/polars/_utils/construction/dataframe.py
+++ b/py-polars/src/polars/_utils/construction/dataframe.py
@@ -604,6 +604,7 @@ def _sequence_of_sequence_to_pydf(
                 data,
                 schema=local_schema_override or None,
                 infer_schema_length=infer_schema_length,
+                strict=strict,
             )
         if column_names or schema_overrides:
             pydf = _post_apply_columns(
@@ -829,6 +830,7 @@ def _sequence_of_dataclasses_to_pydf(
             rows,  # type: ignore[arg-type]
             schema=overrides or None,
             infer_schema_length=infer_schema_length,
+            strict=strict,
         )
 
     if overrides:
@@ -888,7 +890,10 @@ def _sequence_of_pydantic_models_to_pydf(
         get_values = itemgetter(*model_fields)
         rows = [get_values(md.__dict__) for md in data]
         pydf = PyDataFrame.from_rows(
-            rows, schema=overrides, infer_schema_length=infer_schema_length
+            rows,
+            schema=overrides,
+            infer_schema_length=infer_schema_length,
+            strict=strict,
         )
     else:
         # ...and 'from_dicts' is faster otherwise


### PR DESCRIPTION
fixes #26282

*PR not ready*

The `from_dicts` dataframe constructor ignores the `strict` parameter. Same for `from_rows`. Note that strictness is not consistently implemented throughout the codeabase. To close this issue, strictness expectations need to be applied to the failing test cases, which may lead to (a) change the test, or (b) change the casting logic.

This PR is likely to cause perceived (false positive) regressions since strictness was not enforced.