### PR TITLE
feat: Accept list of booleans for descending/nulls_last in `Expr.over()`

### DIFF
--- a/crates/polars-python/src/expr/general.rs
+++ b/crates/polars-python/src/expr/general.rs
@@ -20,6 +20,14 @@ use crate::error::PyPolarsErr;
 use crate::utils::EnterPolarsExt;
 use crate::{PyDataType, PyExpr};
 
+fn broadcast_bools(flags: &[bool], n: usize) -> Vec<bool> {
+    if flags.len() == 1 {
+        vec![flags[0]; n]
+    } else {
+        flags.to_vec()
+    }
+}
+
 #[pymethods]
 impl PyExpr {
     fn __richcmp__(&self, other: Self, op: CompareOp) -> Self {
@@ -622,8 +630,8 @@ impl PyExpr {
         &self,
         partition_by: Option<Vec<Self>>,
         order_by: Option<Vec<Self>>,
-        order_by_descending: bool,
-        order_by_nulls_last: bool,
+        order_by_descending: Vec<bool>,
+        order_by_nulls_last: Vec<bool>,
         mapping_strategy: Wrap<WindowMapping>,
     ) -> PyResult<Self> {
         let partition_by = partition_by.map(|partition_by| {
@@ -633,17 +641,44 @@ impl PyExpr {
                 .collect::<Vec<Expr>>()
         });
 
-        let order_by = order_by.map(|order_by| {
-            (
-                order_by.into_iter().map(|e| e.inner).collect::<Vec<Expr>>(),
-                SortOptions {
-                    descending: order_by_descending,
-                    nulls_last: order_by_nulls_last,
-                    maintain_order: false,
-                    ..Default::default()
-                },
-            )
-        });
+        let order_by = order_by
+            .map(|order_by| {
+                let n = order_by.len();
+                let descending = broadcast_bools(&order_by_descending, n);
+                let nulls_last = broadcast_bools(&order_by_nulls_last, n);
+
+                if n > 1 && !descending.windows(2).all(|w| w[0] == w[1]) {
+                    return Err(PyErr::from(PyPolarsErr::from(
+                        polars_err!(
+                            InvalidOperation:
+                            "`.over()` with multiple `order_by` columns requires all `descending` \
+                             values to be the same; mixed per-column sort directions are not yet \
+                             supported"
+                        ),
+                    )));
+                }
+                if n > 1 && !nulls_last.windows(2).all(|w| w[0] == w[1]) {
+                    return Err(PyErr::from(PyPolarsErr::from(
+                        polars_err!(
+                            InvalidOperation:
+                            "`.over()` with multiple `order_by` columns requires all `nulls_last` \
+                             values to be the same; mixed per-column null positions are not yet \
+                             supported"
+                        ),
+                    )));
+                }
+
+                Ok((
+                    order_by.into_iter().map(|e| e.inner).collect::<Vec<Expr>>(),
+                    SortOptions {
+                        descending: descending[0],
+                        nulls_last: nulls_last[0],
+                        maintain_order: false,
+                        ..Default::default()
+                    },
+                ))
+            })
+            .transpose()?;
 
         Ok(self
             .inner

--- a/crates/polars-python/src/expr/general.rs
+++ b/crates/polars-python/src/expr/general.rs
@@ -648,24 +648,20 @@ impl PyExpr {
                 let nulls_last = broadcast_bools(&order_by_nulls_last, n);
 
                 if n > 1 && !descending.windows(2).all(|w| w[0] == w[1]) {
-                    return Err(PyErr::from(PyPolarsErr::from(
-                        polars_err!(
-                            InvalidOperation:
-                            "`.over()` with multiple `order_by` columns requires all `descending` \
-                             values to be the same; mixed per-column sort directions are not yet \
-                             supported"
-                        ),
-                    )));
+                    return Err(PyErr::from(PyPolarsErr::from(polars_err!(
+                        InvalidOperation:
+                        "`.over()` with multiple `order_by` columns requires all `descending` \
+                         values to be the same; mixed per-column sort directions are not yet \
+                         supported"
+                    ))));
                 }
                 if n > 1 && !nulls_last.windows(2).all(|w| w[0] == w[1]) {
-                    return Err(PyErr::from(PyPolarsErr::from(
-                        polars_err!(
-                            InvalidOperation:
-                            "`.over()` with multiple `order_by` columns requires all `nulls_last` \
-                             values to be the same; mixed per-column null positions are not yet \
-                             supported"
-                        ),
-                    )));
+                    return Err(PyErr::from(PyPolarsErr::from(polars_err!(
+                        InvalidOperation:
+                        "`.over()` with multiple `order_by` columns requires all `nulls_last` \
+                         values to be the same; mixed per-column null positions are not yet \
+                         supported"
+                    ))));
                 }
 
                 Ok((

--- a/py-polars/src/polars/_plr.pyi
+++ b/py-polars/src/polars/_plr.pyi
@@ -1342,8 +1342,8 @@ class PyExpr:
         self,
         partition_by: Sequence[PyExpr] | None,
         order_by: Sequence[PyExpr] | None,
-        order_by_descending: bool,
-        order_by_nulls_last: bool,
+        order_by_descending: Sequence[bool],
+        order_by_nulls_last: Sequence[bool],
         mapping_strategy: Any,
     ) -> PyExpr: ...
     def rolling(

--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -3881,8 +3881,8 @@ class Expr:
         partition_by: IntoExpr | Iterable[IntoExpr] | None = None,
         *more_exprs: IntoExpr,
         order_by: IntoExpr | Iterable[IntoExpr] | None = None,
-        descending: bool = False,
-        nulls_last: bool = False,
+        descending: bool | Sequence[bool] = False,
+        nulls_last: bool | Sequence[bool] = False,
         mapping_strategy: WindowMappingStrategy = "group_to_rows",
     ) -> Expr:
         """
@@ -3907,10 +3907,12 @@ class Expr:
             result of the expression passed to `order_by`.
         descending
             In case 'order_by' is given, indicate whether to order in
-            ascending or descending order.
+            ascending or descending order. Accepts a single boolean or a
+            list of booleans matching the number of `order_by` columns.
         nulls_last
             In case 'order_by' is given, indicate whether to order
-            the nulls in last position.
+            the nulls in last position. Accepts a single boolean or a
+            list of booleans matching the number of `order_by` columns.
         mapping_strategy: {'group_to_rows', 'join', 'explode'}
             - group_to_rows
                 If the aggregation results in multiple values per group, map them back
@@ -4093,6 +4095,11 @@ class Expr:
             order_by_pyexprs = parse_into_list_of_expressions(order_by)
         else:
             order_by_pyexprs = None
+
+        if isinstance(descending, bool):
+            descending = [descending]
+        if isinstance(nulls_last, bool):
+            nulls_last = [nulls_last]
 
         return wrap_expr(
             self._pyexpr.over(

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -1052,23 +1052,22 @@ def test_shape_mismatch_group_by_unique_slice() -> None:
 def test_over_descending_list_27076() -> None:
     df = pl.DataFrame(
         {
-            "g": [1, 1, 1, 2, 2, 2],
-            "t": [3, 1, 2, 2, 3, 1],
-            "x": [10, 20, 30, 40, 50, 60],
+            "g": [1, 1, 1, 1, 2, 2, 2, 2],
+            "t": [1, 2, 3, 4, 4, 1, 2, 3],
+            "x": [10, 20, 30, 40, 10, 20, 30, 40],
         }
     )
 
-    # Single bool (existing behavior, should still work)
-    result = df.with_columns(
+    # Reference: single bool (existing behavior)
+    expected = df.with_columns(
         pl.col("x").shift(1).over("g", order_by="t", descending=True).alias("lag")
-    )
-    assert result["lag"].to_list() == [None, 30, 10, None, 60, 40]
+    )["lag"].to_list()
 
-    # List with single element broadcasts to all order_by columns
+    # List with single element should produce identical results
     result = df.with_columns(
         pl.col("x").shift(1).over("g", order_by=["t"], descending=[True]).alias("lag")
     )
-    assert result["lag"].to_list() == [None, 30, 10, None, 60, 40]
+    assert result["lag"].to_list() == expected
 
     # List matching multiple order_by columns (uniform values)
     result = df.with_columns(
@@ -1077,13 +1076,16 @@ def test_over_descending_list_27076() -> None:
         .over("g", order_by=["t", "x"], descending=[True, True])
         .alias("lag")
     )
-    assert result["lag"].to_list() == [None, 30, 10, None, 60, 40]
+    assert result["lag"].to_list() == expected
 
-    # nulls_last as list
+    # nulls_last as list should match single-bool nulls_last
+    expected_nl = df.with_columns(
+        pl.col("x").shift(1).over("g", order_by="t", nulls_last=True).alias("lag")
+    )["lag"].to_list()
     result = df.with_columns(
         pl.col("x").shift(1).over("g", order_by="t", nulls_last=[True]).alias("lag")
     )
-    assert result["lag"].to_list() == [None, 20, 30, None, 40, 50]
+    assert result["lag"].to_list() == expected_nl
 
 
 def test_over_descending_list_mixed_raises_27076() -> None:

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.exceptions import ShapeError
+from polars.exceptions import InvalidOperationError, ShapeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -1047,6 +1047,78 @@ def test_shape_mismatch_group_by_unique_slice() -> None:
         match="the length of the window expression did not match that of the group",
     ):
         q.collect()
+
+
+def test_over_descending_list_27076() -> None:
+    df = pl.DataFrame(
+        {
+            "g": [1, 1, 1, 2, 2, 2],
+            "t": [3, 1, 2, 2, 3, 1],
+            "x": [10, 20, 30, 40, 50, 60],
+        }
+    )
+
+    # Single bool (existing behavior, should still work)
+    result = df.with_columns(
+        pl.col("x").shift(1).over("g", order_by="t", descending=True).alias("lag")
+    )
+    assert result["lag"].to_list() == [None, 30, 10, None, 60, 40]
+
+    # List with single element broadcasts to all order_by columns
+    result = df.with_columns(
+        pl.col("x")
+        .shift(1)
+        .over("g", order_by=["t"], descending=[True])
+        .alias("lag")
+    )
+    assert result["lag"].to_list() == [None, 30, 10, None, 60, 40]
+
+    # List matching multiple order_by columns (uniform values)
+    result = df.with_columns(
+        pl.col("x")
+        .shift(1)
+        .over("g", order_by=["t", "x"], descending=[True, True])
+        .alias("lag")
+    )
+    assert result["lag"].to_list() == [None, 30, 10, None, 60, 40]
+
+    # nulls_last as list
+    result = df.with_columns(
+        pl.col("x")
+        .shift(1)
+        .over("g", order_by="t", nulls_last=[True])
+        .alias("lag")
+    )
+    assert result["lag"].to_list() == [None, 20, 30, None, 40, 50]
+
+
+def test_over_descending_list_mixed_raises_27076() -> None:
+    df = pl.DataFrame(
+        {
+            "g": [1, 1, 1],
+            "a": [1, 2, 3],
+            "b": [4, 5, 6],
+            "x": [10, 20, 30],
+        }
+    )
+
+    # Mixed descending values should raise
+    with pytest.raises(InvalidOperationError, match="mixed per-column sort directions"):
+        df.with_columns(
+            pl.col("x")
+            .shift(1)
+            .over("g", order_by=["a", "b"], descending=[True, False])
+            .alias("lag")
+        )
+
+    # Mixed nulls_last values should raise
+    with pytest.raises(InvalidOperationError, match="mixed per-column null positions"):
+        df.with_columns(
+            pl.col("x")
+            .shift(1)
+            .over("g", order_by=["a", "b"], nulls_last=[True, False])
+            .alias("lag")
+        )
 
 
 def test_over_literal_cum_sum_26800() -> None:

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -1066,10 +1066,7 @@ def test_over_descending_list_27076() -> None:
 
     # List with single element broadcasts to all order_by columns
     result = df.with_columns(
-        pl.col("x")
-        .shift(1)
-        .over("g", order_by=["t"], descending=[True])
-        .alias("lag")
+        pl.col("x").shift(1).over("g", order_by=["t"], descending=[True]).alias("lag")
     )
     assert result["lag"].to_list() == [None, 30, 10, None, 60, 40]
 
@@ -1084,10 +1081,7 @@ def test_over_descending_list_27076() -> None:
 
     # nulls_last as list
     result = df.with_columns(
-        pl.col("x")
-        .shift(1)
-        .over("g", order_by="t", nulls_last=[True])
-        .alias("lag")
+        pl.col("x").shift(1).over("g", order_by="t", nulls_last=[True]).alias("lag")
     )
     assert result["lag"].to_list() == [None, 20, 30, None, 40, 50]
 


### PR DESCRIPTION
Fixes #27076

`.over()` with multiple `order_by` columns and a list of `descending` values failed with `TypeError: argument 'order_by_descending': 'list' object cannot be cast as 'bool'` because both the Python signature and Rust binding only accepted a single `bool`.

Changes:
- **Python** (`expr.py`): Accept `bool | Sequence[bool]` for `descending` and `nulls_last`, normalize to list before passing to Rust
- **Rust** (`general.rs`): Accept `Vec<bool>`, broadcast single-element lists, validate that all values are uniform when multiple `order_by` columns are given (mixed per-column directions are not yet supported by the expression engine)
- Updated docstrings to document the new accepted types