### PR TITLE
docs(python): Normalise `Series` docstring whitespace indents

### DIFF
--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -227,9 +227,9 @@ class Series:
     shape: (3,)
     Series: 'a' [i64]
     [
-            1
-            2
-            3
+        1
+        2
+        3
     ]
 
     Notice that the dtype is automatically inferred as a polars Int64:
@@ -258,9 +258,9 @@ class Series:
     shape: (3,)
     Series: '' [i64]
     [
-            1
-            2
-            3
+        1
+        2
+        3
     ]
     """
 
@@ -2010,9 +2010,9 @@ class Series:
         shape: (3,)
         Series: '' [f64]
         [
-                1.0
-                3.0
-                NaN
+            1.0
+            3.0
+            NaN
         ]
         """
 
@@ -2038,9 +2038,9 @@ class Series:
         shape: (3,)
         Series: '' [f64]
         [
-                1.0
-                null
-                3.0
+            1.0
+            null
+            3.0
         ]
         """
 
@@ -2242,10 +2242,10 @@ class Series:
         shape: (4,)
         Series: 'foo' [f64]
         [
-                1.0
-                0.125
-                0.037037
-                0.015625
+            1.0
+            0.125
+            0.037037
+            0.015625
         ]
         """
         if _check_for_numpy(exponent) and isinstance(exponent, np.ndarray):
@@ -2569,11 +2569,11 @@ class Series:
         shape: (5,)
         Series: 'foo' [cat]
         [
-                "a"
-                "a"
-                "b"
-                "b"
-                "c"
+            "a"
+            "a"
+            "b"
+            "b"
+            "c"
         ]
 
         Create a DataFrame with the breakpoint and category for each value.
@@ -2650,11 +2650,11 @@ class Series:
         shape: (5,)
         Series: 'foo' [cat]
         [
-                "a"
-                "a"
-                "b"
-                "b"
-                "c"
+            "a"
+            "a"
+            "b"
+            "b"
+            "c"
         ]
 
         Divide a column into two categories using uniform quantile probabilities.
@@ -2663,11 +2663,11 @@ class Series:
         shape: (5,)
         Series: 'foo' [cat]
         [
-                "low"
-                "low"
-                "high"
-                "high"
-                "high"
+            "low"
+            "low"
+            "high"
+            "high"
+            "high"
         ]
 
         Create a DataFrame with the breakpoint and category for each value.
@@ -3016,9 +3016,9 @@ class Series:
         shape: (3,)
         Series: 'b' [i64]
         [
-                1
-                2
-                3
+            1
+            2
+            3
         ]
         """
         s = self.clone()
@@ -3043,9 +3043,9 @@ class Series:
         shape: (3,)
         Series: 'b' [i64]
         [
-                1
-                2
-                3
+            1
+            2
+            3
         ]
         """
         return self.alias(name)
@@ -3208,10 +3208,10 @@ class Series:
         shape: (4,)
         Series: '' [u32]
         [
-                1
-                2
-                2
-                3
+            1
+            2
+            2
+            3
         ]
         """
 
@@ -3234,8 +3234,8 @@ class Series:
         shape: (2,)
         Series: 'a' [i64]
         [
-                2
-                3
+            2
+            3
         ]
         """
         return self._from_pyseries(self._s.slice(offset=offset, length=length))
@@ -3364,8 +3364,8 @@ class Series:
         shape: (2,)
         Series: 'a' [i64]
         [
-                1
-                3
+            1
+            3
         ]
         """
         if not isinstance(predicate, Series):
@@ -3393,9 +3393,9 @@ class Series:
         shape: (3,)
         Series: 'a' [i64]
         [
-                1
-                2
-                3
+            1
+            2
+            3
         ]
 
         Pass a negative value to get all rows `except` the last `abs(n)`.
@@ -3404,8 +3404,8 @@ class Series:
         shape: (2,)
         Series: 'a' [i64]
         [
-                1
-                2
+            1
+            2
         ]
         """
         if n < 0:
@@ -3433,9 +3433,9 @@ class Series:
         shape: (3,)
         Series: 'a' [i64]
         [
-                3
-                4
-                5
+            3
+            4
+            5
         ]
 
         Pass a negative value to get all rows `except` the first `abs(n)`.
@@ -3444,8 +3444,8 @@ class Series:
         shape: (2,)
         Series: 'a' [i64]
         [
-                4
-                5
+            4
+            5
         ]
         """
         if n < 0:
@@ -3486,8 +3486,8 @@ class Series:
         shape: (2,)
         Series: 'a' [i64]
         [
-                1
-                2
+            1
+            2
         ]
         """
         return self.head(n)
@@ -3633,19 +3633,19 @@ class Series:
         shape: (4,)
         Series: 'a' [i64]
         [
-                1
-                2
-                3
-                4
+            1
+            2
+            3
+            4
         ]
         >>> s.sort(descending=True)
         shape: (4,)
         Series: 'a' [i64]
         [
-                4
-                3
-                2
-                1
+            4
+            3
+            2
+            1
         ]
         """
         if in_place:
@@ -3874,9 +3874,9 @@ class Series:
         shape: (3,)
         Series: 'a' [u32]
         [
-                0
-                1
-                3
+            0
+            1
+            3
         ]
         """
 
@@ -3967,25 +3967,25 @@ class Series:
         shape: (3,)
         Series: 'set' [u32]
         [
-                0
-                3
-                5
+            0
+            3
+            5
         ]
         >>> s.search_sorted([1, 4, 5], "left")
         shape: (3,)
         Series: 'set' [u32]
         [
-                0
-                3
-                5
+            0
+            3
+            5
         ]
         >>> s.search_sorted([1, 4, 5], "right")
         shape: (3,)
         Series: 'set' [u32]
         [
-                1
-                5
-                6
+            1
+            5
+            6
         ]
         """
         df = F.select(F.lit(self).search_sorted(element, side, descending=descending))
@@ -4036,8 +4036,8 @@ class Series:
         shape: (2,)
         Series: 'a' [i64]
         [
-                2
-                4
+            2
+            4
         ]
         """
 
@@ -4201,9 +4201,9 @@ class Series:
         shape: (3,)
         Series: 'a' [bool]
         [
-                true
-                true
-                false
+            true
+            true
+            false
         ]
         """
 
@@ -4224,9 +4224,9 @@ class Series:
         shape: (3,)
         Series: 'a' [bool]
         [
-                false
-                false
-                true
+            false
+            false
+            true
         ]
         """
 
@@ -4247,10 +4247,10 @@ class Series:
         shape: (4,)
         Series: 'a' [bool]
         [
-                false
-                false
-                false
-                true
+            false
+            false
+            false
+            true
         ]
         """
 
@@ -4271,10 +4271,10 @@ class Series:
         shape: (4,)
         Series: 'a' [bool]
         [
-                true
-                true
-                true
-                false
+            true
+            true
+            true
+            false
         ]
         """
 
@@ -4307,18 +4307,18 @@ class Series:
         shape: (3,)
         Series: 'b' [bool]
         [
-                true
-                false
-                null
+            true
+            false
+            null
         ]
         >>> # when nulls_equal=True, None is treated as a distinct value
         >>> s2.is_in(s, nulls_equal=True)
         shape: (3,)
         Series: 'b' [bool]
         [
-                true
-                false
-                false
+            true
+            false
+            false
         ]
 
         >>> # check if some values are a member of sublists
@@ -4366,7 +4366,7 @@ class Series:
         shape: (1,)
         Series: 'a' [u32]
         [
-                1
+            1
         ]
         """
         return F.arg_where(self, eager=True)
@@ -4387,10 +4387,10 @@ class Series:
         shape: (4,)
         Series: 'a' [bool]
         [
-                true
-                false
-                false
-                true
+            true
+            false
+            false
+            true
         ]
         """
 
@@ -4410,11 +4410,11 @@ class Series:
         shape: (5,)
         Series: '' [bool]
         [
-                true
-                false
-                true
-                true
-                false
+            true
+            false
+            true
+            true
+            false
         ]
         """
 
@@ -4434,11 +4434,11 @@ class Series:
         shape: (5,)
         Series: '' [bool]
         [
-                false
-                true
-                false
-                true
-                true
+            false
+            true
+            false
+            true
+            true
         ]
         """
 
@@ -4458,10 +4458,10 @@ class Series:
         shape: (4,)
         Series: 'a' [bool]
         [
-                false
-                true
-                true
-                false
+            false
+            true
+            true
+            false
         ]
         """
 
@@ -4494,19 +4494,19 @@ class Series:
         shape: (2,)
         Series: 'a' [list[i64]]
         [
-                [1, 2, 3]
-                [4, 5, 6]
+            [1, 2, 3]
+            [4, 5, 6]
         ]
         >>> s.explode()
         shape: (6,)
         Series: 'a' [i64]
         [
-                1
-                2
-                3
-                4
-                5
-                6
+            1
+            2
+            3
+            4
+            5
+            6
         ]
         """
 
@@ -4678,12 +4678,12 @@ class Series:
         shape: (6,)
         Series: 'a' [i64]
         [
-                1
-                2
-                3
-                4
-                5
-                6
+            1
+            2
+            3
+            4
+            5
+            6
         ]
         >>> s.n_chunks()
         1
@@ -5297,9 +5297,9 @@ class Series:
         shape: (3,)
         Series: 'a' [i64]
         [
-                1
-                10
-                3
+            1
+            10
+            3
         ]
 
         It is better to implement this as follows:
@@ -5349,9 +5349,9 @@ class Series:
         shape: (3,)
         Series: 'a' [i64]
         [
-                1
-                10
-                3
+            1
+            10
+            3
         ]
 
         It is better to implement this as follows:
@@ -5469,9 +5469,9 @@ class Series:
         shape: (3,)
         Series: 'a' [i64]
         [
-                1
-                2
-                3
+            1
+            2
+            3
         ]
         """
         return self._from_pyseries(self._s.clone())
@@ -5501,10 +5501,10 @@ class Series:
         shape: (4,)
         Series: 'a' [f64]
         [
-                1.0
-                2.0
-                3.0
-                0.0
+            1.0
+            2.0
+            3.0
+            0.0
         ]
         """
 
@@ -5621,9 +5621,9 @@ class Series:
         shape: (3,)
         Series: 'a' [f64]
         [
-                1.0
-                2.0
-                3.0
+            1.0
+            2.0
+            3.0
         ]
         """
 
@@ -5640,9 +5640,9 @@ class Series:
         shape: (3,)
         Series: 'a' [f64]
         [
-                2.0
-                3.0
-                4.0
+            2.0
+            3.0
+            4.0
         ]
         """
 
@@ -5736,9 +5736,9 @@ class Series:
         shape: (3,)
         Series: 'a' [f64]
         [
-                1.12
-                2.57
-                3.9
+            1.12
+            2.57
+            3.9
         ]
 
         >>> s = pl.Series([-3.5, -2.5, -1.5, -0.5, 0.5, 1.5, 2.5, 3.5])
@@ -5773,9 +5773,9 @@ class Series:
         shape: (3,)
         Series: '' [f64]
         [
-                0.012
-                3.3
-                3500.0
+            0.012
+            3.3
+            3500.0
         ]
         """
 
@@ -5821,7 +5821,7 @@ class Series:
         shape: (1,)
         Series: 'a' [i64]
         [
-                2
+            2
         ]
         """
 
@@ -5844,12 +5844,12 @@ class Series:
         shape: (6,)
         Series: 'a' [f64]
         [
-                -1.0
-                -0.0
-                0.0
-                1.0
-                NaN
-                null
+            -1.0
+            -0.0
+            0.0
+            1.0
+            NaN
+            null
         ]
         """
 
@@ -6155,9 +6155,9 @@ class Series:
         shape: (3,)
         Series: 'a' [i64]
         [
-                11
-                12
-                13
+            11
+            12
+            13
         ]
 
         Returns
@@ -6205,10 +6205,10 @@ class Series:
         shape: (4,)
         Series: '' [i64]
         [
-                null
-                1
-                2
-                3
+            null
+            1
+            2
+            3
         ]
 
         Pass a negative value to shift in the opposite direction instead.
@@ -6217,10 +6217,10 @@ class Series:
         shape: (4,)
         Series: '' [i64]
         [
-                3
-                4
-                null
-                null
+            3
+            4
+            null
+            null
         ]
 
         Specify `fill_value` to fill the resulting null values.
@@ -6229,10 +6229,10 @@ class Series:
         shape: (4,)
         Series: '' [i64]
         [
-                3
-                4
-                100
-                100
+            3
+            4
+            100
+            100
         ]
         """
 
@@ -6262,22 +6262,22 @@ class Series:
         shape: (5,)
         Series: '' [i64]
         [
-                1
-                2
-                3
-                2
-                1
+            1
+            2
+            3
+            2
+            1
         ]
         >>> mask = pl.Series([True, False, True, False, True])
         >>> s1.zip_with(mask, s2)
         shape: (5,)
         Series: '' [i64]
         [
-                1
-                4
-                3
-                2
-                5
+            1
+            4
+            3
+            2
+            5
         ]
         """
         require_same_type(self, other)
@@ -7107,17 +7107,17 @@ class Series:
         shape: (25,)
         Series: 'date' [datetime[μs]]
         [
-                2001-01-01 00:00:00
-                2001-01-01 01:00:00
-                2001-01-01 02:00:00
-                2001-01-01 03:00:00
-                2001-01-01 04:00:00
-                …
-                2001-01-01 20:00:00
-                2001-01-01 21:00:00
-                2001-01-01 22:00:00
-                2001-01-01 23:00:00
-                2001-01-02 00:00:00
+            2001-01-01 00:00:00
+            2001-01-01 01:00:00
+            2001-01-01 02:00:00
+            2001-01-01 03:00:00
+            2001-01-01 04:00:00
+            …
+            2001-01-01 20:00:00
+            2001-01-01 21:00:00
+            2001-01-01 22:00:00
+            2001-01-01 23:00:00
+            2001-01-02 00:00:00
         ]
 
         Compute the rolling std with the temporal windows
@@ -7186,12 +7186,12 @@ class Series:
         shape: (6,)
         Series: 'a' [f64]
         [
-                null
-                null
-                1.0
-                1.0
-                1.527525
-                2.0
+            null
+            null
+            1.0
+            1.0
+            1.527525
+            2.0
         ]
         """
 
@@ -7374,12 +7374,12 @@ class Series:
         shape: (6,)
         Series: 'a' [f64]
         [
-                null
-                null
-                1.0
-                1.0
-                2.333333
-                4.0
+            null
+            null
+            1.0
+            1.0
+            2.333333
+            4.0
         ]
         """
 
@@ -7432,11 +7432,11 @@ class Series:
         shape: (5,)
         Series: '' [f64]
         [
-                null
-                null
-                22.0
-                11.0
-                17.0
+            null
+            null
+            22.0
+            11.0
+            17.0
         ]
         """
 
@@ -7614,12 +7614,12 @@ class Series:
         shape: (6,)
         Series: 'a' [f64]
         [
-                null
-                null
-                2.0
-                3.0
-                4.0
-                6.0
+            null
+            null
+            2.0
+            3.0
+            4.0
+            6.0
         ]
         """
 
@@ -7808,23 +7808,23 @@ class Series:
         shape: (6,)
         Series: 'a' [f64]
         [
-                null
-                null
-                2.0
-                3.0
-                4.0
-                6.0
+            null
+            null
+            2.0
+            3.0
+            4.0
+            6.0
         ]
         >>> s.rolling_quantile(quantile=0.33, interpolation="linear", window_size=3)
         shape: (6,)
         Series: 'a' [f64]
         [
-                null
-                null
-                1.66
-                2.66
-                3.66
-                5.32
+            null
+            null
+            1.66
+            2.66
+            3.66
+            5.32
         ]
         """  # noqa: W505
 
@@ -8139,11 +8139,11 @@ class Series:
         shape: (5,)
         Series: 'a' [bool]
         [
-                false
-                false
-                false
-                false
-                true
+            false
+            false
+            false
+            false
+            true
         ]
         """
 
@@ -8265,17 +8265,17 @@ class Series:
         shape: (3,)
         Series: 'a' [i64]
         [
-                -1152921504606846976
-                -2
-                3
+            -1152921504606846976
+            -2
+            3
         ]
         >>> s.reinterpret(signed=False)
         shape: (3,)
         Series: 'a' [u64]
         [
-                17293822569102704640
-                18446744073709551614
-                3
+            17293822569102704640
+            18446744073709551614
+            3
         ]
         >>> s.reinterpret(dtype=pl.Int64)
         shape: (3,)
@@ -8646,10 +8646,10 @@ class Series:
         shape: (4,)
         Series: '' [i64]
         [
-                1
-                5
-                10
-                null
+            1
+            5
+            10
+            null
         ]
 
         Specifying only a single bound:
@@ -8658,10 +8658,10 @@ class Series:
         shape: (4,)
         Series: '' [i64]
         [
-                -50
-                5
-                10
-                null
+            -50
+            5
+            10
+            null
         ]
         """
 
@@ -8777,10 +8777,10 @@ class Series:
         shape: (4,)
         Series: '' [i64]
         [
-                1
-                100
-                100
-                3
+            1
+            100
+            100
+            3
         ]
 
         Replace multiple values by passing sequences to the `old` and `new` parameters.
@@ -8789,10 +8789,10 @@ class Series:
         shape: (4,)
         Series: '' [i64]
         [
-                1
-                100
-                100
-                200
+            1
+            100
+            100
+            200
         ]
 
         Passing a mapping with replacements is also supported as syntactic sugar.
@@ -8802,10 +8802,10 @@ class Series:
         shape: (4,)
         Series: '' [i64]
         [
-                1
-                100
-                100
-                200
+            1
+            100
+            100
+            200
         ]
 
         The original data type is preserved when replacing by values of a different
@@ -8818,9 +8818,9 @@ class Series:
         shape: (3,)
         Series: '' [str]
         [
-                "1"
-                "2"
-                "3"
+            "1"
+            "2"
+            "3"
         ]
         """
 
@@ -8876,10 +8876,10 @@ class Series:
         shape: (4,)
         Series: '' [i64]
         [
-                100
-                200
-                200
-                300
+            100
+            200
+            200
+            300
         ]
 
         Passing a mapping with replacements is also supported as syntactic sugar.
@@ -8889,10 +8889,10 @@ class Series:
         shape: (4,)
         Series: '' [i64]
         [
-                100
-                200
-                200
-                300
+            100
+            200
+            200
+            300
         ]
 
         By default, an error is raised if any non-null values were not replaced.
@@ -8907,10 +8907,10 @@ class Series:
         shape: (4,)
         Series: '' [i64]
         [
-                -1
-                200
-                200
-                300
+            -1
+            200
+            200
+            300
         ]
 
         The default can be another Series.
@@ -8920,10 +8920,10 @@ class Series:
         shape: (4,)
         Series: '' [f64]
         [
-                2.5
-                200.0
-                200.0
-                10.0
+            2.5
+            200.0
+            200.0
+            10.0
         ]
 
         Replacing by values of a different data type sets the return type based on
@@ -8935,17 +8935,17 @@ class Series:
         shape: (3,)
         Series: '' [i64]
         [
-                1
-                2
-                3
+            1
+            2
+            3
         ]
         >>> s.replace_strict(mapping, default="x")
         shape: (3,)
         Series: '' [str]
         [
-                "1"
-                "2"
-                "3"
+            "1"
+            "2"
+            "3"
         ]
 
         Set the `return_dtype` parameter to control the resulting data type directly.
@@ -8954,9 +8954,9 @@ class Series:
         shape: (3,)
         Series: '' [u8]
         [
-                1
-                2
-                3
+            1
+            2
+            3
         ]
         """  # noqa: W505
 
@@ -8990,23 +8990,23 @@ class Series:
         shape: (3,)
         Series: 'foo' [array[i64, 3]]
         [
-                [1, 2, 3]
-                [4, 5, 6]
-                [7, 8, 9]
+            [1, 2, 3]
+            [4, 5, 6]
+            [7, 8, 9]
         ]
         >>> square.reshape((9,))
         shape: (9,)
         Series: 'foo' [i64]
         [
-                1
-                2
-                3
-                4
-                5
-                6
-                7
-                8
-                9
+            1
+            2
+            3
+            4
+            5
+            6
+            7
+            8
+            9
         ]
         """
         return self._from_pyseries(self._s.reshape(dimensions))
@@ -9028,9 +9028,9 @@ class Series:
         shape: (3,)
         Series: 'a' [i64]
         [
-                2
-                3
-                1
+            2
+            3
+            1
         ]
         """
 
@@ -9112,9 +9112,9 @@ class Series:
         shape: (3,)
         Series: '' [f64]
         [
-                1.0
-                1.666667
-                2.428571
+            1.0
+            1.666667
+            2.428571
         ]
         """
 
@@ -9195,11 +9195,11 @@ class Series:
         shape: (5,)
         Series: 'values' [f64]
         [
-                0.0
-                0.292893
-                1.492474
-                null
-                3.254508
+            0.0
+            0.292893
+            1.492474
+            null
+            3.254508
         ]
         """
 
@@ -9398,11 +9398,11 @@ class Series:
         shape: (5,)
         Series: '' [i64]
         [
-                1
-                2
-                3
-                99
-                99
+            1
+            2
+            3
+            99
+            99
         ]
         """
 
@@ -9462,23 +9462,23 @@ class Series:
         shape: (6,)
         Series: 'a' [i64]
         [
-                1
-                2
-                3
-                4
-                5
-                6
+            1
+            2
+            3
+            4
+            5
+            6
         ]
         >>> s.shrink_dtype()
         shape: (6,)
         Series: 'a' [i8]
         [
-                1
-                2
-                3
-                4
-                5
-                6
+            1
+            2
+            3
+            4
+            5
+            6
         ]
         """
         return wrap_s(self._s.shrink_dtype())
@@ -9496,15 +9496,15 @@ class Series:
         [shape: (3,)
         Series: 'a' [i64]
         [
-                1
-                2
-                3
+            1
+            2
+            3
         ], shape: (3,)
         Series: 'a' [i64]
         [
-                4
-                5
-                6
+            4
+            5
+            6
         ]]
         """
         return self._s.get_chunks()


### PR DESCRIPTION
We have a lot of rogue whitespace in the `Series` docstrings.
Normalised to the standard (repr) level of indentation.