### PR TITLE
test(python): Add explicit `ResourceWarning` coverage

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -275,9 +275,6 @@ filterwarnings = [
   # Introspection under PyCharm IDE can generate this in Python 3.12
   "ignore:.*co_lnotab is deprecated, use co_lines.*:DeprecationWarning",
   "ignore:the argument `return_as_string` for `DataFrame.glimpse` is deprecated",
-  # TODO: Excel tests lead to unclosed file warnings
-  # https://github.com/pola-rs/polars/issues/14466
-  "ignore:unclosed file.*:ResourceWarning",
   # TODO: Database tests lead to unclosed database warnings
   # https://github.com/pola-rs/polars/issues/20296
   "ignore:unclosed database.*:ResourceWarning",

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -5,6 +5,7 @@ import io
 import os
 import sys
 import textwrap
+import warnings
 import zlib
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal as D
@@ -2348,7 +2349,9 @@ def test_write_csv_to_dangling_file_17328(
     chunk_override: None, df_no_lists: pl.DataFrame, tmp_path: Path
 ) -> None:
     tmp_path.mkdir(exist_ok=True)
-    df_no_lists.write_csv((tmp_path / "dangling.csv").open("w"))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        df_no_lists.write_csv((tmp_path / "dangling.csv").open("w"))
 
 
 @pytest.mark.may_fail_cloud  # really hard to mimic this error
@@ -2356,9 +2359,12 @@ def test_write_csv_to_dangling_file_17328(
 def test_write_csv_raise_on_non_utf8_17328(
     chunk_override: None, df_no_lists: pl.DataFrame, tmp_path: Path
 ) -> None:
-    tmp_path.mkdir(exist_ok=True)
-    with pytest.raises(InvalidOperationError, match="file encoding is not UTF-8"):
-        df_no_lists.write_csv((tmp_path / "dangling.csv").open("w", encoding="gbk"))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+
+        tmp_path.mkdir(exist_ok=True)
+        with pytest.raises(InvalidOperationError, match="file encoding is not UTF-8"):
+            df_no_lists.write_csv((tmp_path / "dangling.csv").open("w", encoding="gbk"))
 
 
 @pytest.mark.may_fail_auto_streaming  # read->scan_csv dispatch

--- a/py-polars/tests/unit/io/test_spreadsheet.py
+++ b/py-polars/tests/unit/io/test_spreadsheet.py
@@ -1471,3 +1471,26 @@ def test_excel_read_columns_nonlist_sequence(engine: ExcelSpreadsheetEngine) -> 
     xldf = pl.read_excel(xls, engine=engine, columns="colx")
     expected = df.select("colx")
     assert_frame_equal(xldf, expected)
+
+
+@pytest.mark.parametrize(
+    ("read_spreadsheet", "source", "params"),
+    [
+        (pl.read_excel, "path_xlsx", {"engine": "calamine"}),
+        (pl.read_excel, "path_xlsx", {"engine": "openpyxl"}),
+        (pl.read_excel, "path_xlsx", {"engine": "xlsx2csv"}),
+        (pl.read_ods, "path_ods", {}),
+    ],
+)
+def test_spreadsheet_no_resource_warning(
+    read_spreadsheet: Callable[..., pl.DataFrame],
+    source: str,
+    params: dict[str, str],
+    request: pytest.FixtureRequest,
+) -> None:
+    # ref: https://github.com/pola-rs/polars/issues/14466
+    spreadsheet_path = request.getfixturevalue(source)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", ResourceWarning)
+        read_spreadsheet(spreadsheet_path, **params)
+        read_spreadsheet(spreadsheet_path, sheet_id=0, **params)


### PR DESCRIPTION
We already closed #14466 (I'm pretty sure we solved it properly), but this ensures more visibility/traceability by not hiding `ResourceWarning` in the general case, and adds explicit coverage for spreadsheet I/O.

(There is a test that explicitly writes to a "dangling.csv" that looks intentional; handled that case specifically).