### PR TITLE
fix: Reject invalid input to `sql_expr`

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -47,7 +47,7 @@ A-panic:
 A-plugin:
   - '/plugin/i'
 A-sql:
-  - '/\bsql\b|sqlcontext/i'
+  - '/\bsql\b|sql_expr|sqlcontext/i'
 A-selectors:
   - '/selector/i'
 A-streaming:

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -25,7 +25,9 @@ use sqlparser::ast::{
     UnaryOperator as SQLUnaryOperator, Value as SQLValue, ValueWithSpan,
 };
 use sqlparser::dialect::GenericDialect;
+use sqlparser::keywords;
 use sqlparser::parser::{Parser, ParserOptions};
+use sqlparser::tokenizer::Token;
 
 use crate::SQLContext;
 use crate::functions::SQLFunctionVisitor;
@@ -1294,6 +1296,7 @@ impl SQLExprVisitor<'_> {
 /// ```
 pub fn sql_expr<S: AsRef<str>>(s: S) -> PolarsResult<Expr> {
     let mut ctx = SQLContext::new();
+    let s = s.as_ref();
 
     let mut parser = Parser::new(&GenericDialect);
     parser = parser.with_options(ParserOptions {
@@ -1301,18 +1304,34 @@ pub fn sql_expr<S: AsRef<str>>(s: S) -> PolarsResult<Expr> {
         ..Default::default()
     });
 
-    let mut ast = parser
-        .try_with_sql(s.as_ref())
-        .map_err(to_sql_interface_err)?;
-    let expr = ast.parse_select_item().map_err(to_sql_interface_err)?;
+    // `sql_expr` should only translate expressions, not statements or clauses
+    let mut ast = parser.try_with_sql(s).map_err(to_sql_interface_err)?;
+    if let Token::Word(word) = &ast.peek_token().token {
+        if keywords::RESERVED_FOR_COLUMN_ALIAS.contains(&word.keyword) {
+            polars_bail!(SQLInterface: "expected an expression (found '{}' clause)", word.value)
+        }
+    }
+    let expr = ast
+        .parse_select_item()
+        .map_err(|_| polars_err!(SQLInterface: "unable to parse '{}' as Expr", s))?;
 
+    // ensure all input was consumed; remaining tokens indicate invalid trailing SQL
+    match &ast.peek_token().token {
+        Token::EOF => {},
+        Token::Word(word) if keywords::RESERVED_FOR_COLUMN_ALIAS.contains(&word.keyword) => {
+            polars_bail!(SQLInterface: "expected an expression (found '{}' clause)", word.value)
+        },
+        token => {
+            polars_bail!(SQLInterface: "invalid expression (found unexpected token '{}')", token)
+        },
+    }
     Ok(match &expr {
         SelectItem::ExprWithAlias { expr, alias } => {
             let expr = parse_sql_expr(expr, &mut ctx, None)?;
             expr.alias(alias.value.as_str())
         },
         SelectItem::UnnamedExpr(expr) => parse_sql_expr(expr, &mut ctx, None)?,
-        _ => polars_bail!(SQLInterface: "unable to parse '{}' as Expr", s.as_ref()),
+        _ => polars_bail!(SQLInterface: "unable to parse '{}' as Expr", s),
     })
 }
 

--- a/py-polars/tests/unit/sql/test_functions.py
+++ b/py-polars/tests/unit/sql/test_functions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -25,14 +26,65 @@ def test_sql_expr() -> None:
     )
     result = df.select(*sql_exprs)
     expected = pl.DataFrame(
-        {"a": [1, 1, 1], "aa": [1, 4, 27], "b2": ["yz", "bc", None]}
+        {
+            "a": [1, 1, 1],
+            "aa": [1, 4, 27],
+            "b2": ["yz", "bc", None],
+        }
     )
     assert_frame_equal(result, expected)
 
-    # expect expressions that can't reasonably be parsed as expressions to raise
-    # (for example: those that explicitly reference tables and/or use wildcards)
+
+@pytest.mark.parametrize(
+    ("expr", "clause"),
+    [
+        ("1 + 2 ORDER BY a", "ORDER"),
+        ("EXCEPT x", "EXCEPT"),
+        ("EXPLAIN SELECT 1", "EXPLAIN"),
+        ("FROM tbl", "FROM"),
+        ("GROUP BY a", "GROUP"),
+        ("HAVING count(*) > 1", "HAVING"),
+        ("INTERSECT y", "INTERSECT"),
+        ("INTO outfile", "INTO"),
+        ("LIMIT 10", "LIMIT"),
+        ("MAX(a) UNION SELECT b", "UNION"),
+        ("ORDER BY a", "ORDER"),
+        ("SELECT xyz", "SELECT"),
+        ("UNION ALL", "UNION"),
+        ("WHERE abcd = 1", "WHERE"),
+        ("WITH cte AS (SELECT 1)", "WITH"),
+        ("a = 3 WHERE x = 0", "WHERE"),
+        ("a SELECT b", "SELECT"),
+        ("x + 1 LIMIT 10", "LIMIT"),
+    ],
+)
+def test_sql_expr_rejects_clauses(expr: str, clause: str) -> None:
     with pytest.raises(
         SQLInterfaceError,
-        match=r"unable to parse 'xyz\.\*' as Expr",
+        match=rf"expected an expression \(found '{clause}' clause\)",
     ):
-        pl.sql_expr("xyz.*")
+        pl.sql_expr(expr)
+
+
+@pytest.mark.parametrize(
+    ("expr", "token"),
+    [("a, b", ","), ("x AS y %", "%"), ("a; DROP TABLE t", ";")],
+)
+def test_sql_expr_rejects_invalid_expressions(expr: str, token: str) -> None:
+    with pytest.raises(
+        SQLInterfaceError,
+        match=rf"invalid expression \(found unexpected token '{re.escape(token)}'\)",
+    ):
+        pl.sql_expr(expr)
+
+
+@pytest.mark.parametrize(
+    "expr",
+    ["@#$$% = 100", "||| AS abcd", "xyz.*"],
+)
+def test_sql_expr_invalid_colnames(expr: str) -> None:
+    with pytest.raises(
+        SQLInterfaceError,
+        match=rf"unable to parse '{re.escape(expr)}' as Expr",
+    ):
+        pl.sql_expr(expr)


### PR DESCRIPTION
Closes #26926.

Improved validation of `sql_expr` input.
Now properly rejects non-expression SQL, raising an informative error.

## Example

```python
pl.sql_expr('&^%$@')
# SQLInterfaceError: unable to parse '&^%$@' as Expr

pl.sql_expr('a AS b %')
# SQLInterfaceError: invalid expression (found unexpected token '%')

pl.sql_expr('SELECT xyz')
# SQLInterfaceError: expected an expression (found 'SELECT' clause)

pl.sql_expr('colx WHERE abc = 0')
# SQLInterfaceError: expected an expression (found 'WHERE' clause)
```