### PR TITLE
fix: Ensure SQL `COUNT(<lit>)` expressions return the correct value

### DIFF
--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -2179,9 +2179,14 @@ impl SQLFunctionVisitor<'_> {
             if let Some(WindowType::WindowSpec(spec)) = &self.func.over {
                 self.validate_window_frame(&spec.window_frame)?;
 
+                let is_count_star = match args.as_slice() {
+                    [FunctionArgExpr::Wildcard] | [] => true,
+                    [FunctionArgExpr::Expr(e)] => is_non_null_literal(e),
+                    _ => false,
+                };
                 match args.as_slice() {
-                    [FunctionArgExpr::Wildcard] | [] => {
-                        // COUNT(*) with ORDER BY -> map to `int_range`
+                    _ if is_count_star => {
+                        // COUNT(*) / COUNT(1) with ORDER BY -> map to `int_range`
                         let (order_by_exprs, all_desc) =
                             self.parse_order_by_in_window(&spec.order_by)?;
                         let partition_by_exprs = if spec.partition_by.is_empty() {
@@ -2217,6 +2222,8 @@ impl SQLFunctionVisitor<'_> {
         let count_expr = match (is_distinct, args.as_slice()) {
             // COUNT(*), COUNT()
             (false, [FunctionArgExpr::Wildcard] | []) => len(),
+            // COUNT(<non-null literal>) is equivalent to COUNT(*)
+            (false, [FunctionArgExpr::Expr(sql_expr)]) if is_non_null_literal(sql_expr) => len(),
             // COUNT(col)
             (false, [FunctionArgExpr::Expr(sql_expr)]) => {
                 let expr = parse_sql_expr(sql_expr, self.ctx, self.active_schema)?;
@@ -2345,6 +2352,17 @@ impl SQLFunctionVisitor<'_> {
             self.func.to_string()
         );
     }
+}
+
+/// Returns true if the SQL expression is a non-null literal value (e.g. `1`, `'hello'`, `TRUE`).
+fn is_non_null_literal(expr: &SQLExpr) -> bool {
+    matches!(
+        expr,
+        SQLExpr::Value(ValueWithSpan {
+            value: v,
+            ..
+        }) if !matches!(v, SQLValue::Null)
+    )
 }
 
 fn extract_args(func: &SQLFunction) -> PolarsResult<Vec<&FunctionArgExpr>> {

--- a/py-polars/tests/unit/sql/test_miscellaneous.py
+++ b/py-polars/tests/unit/sql/test_miscellaneous.py
@@ -96,6 +96,7 @@ def test_count() -> None:
           COUNT(b) AS count_b,
           COUNT(c) AS count_c,
           COUNT(*) AS count_star,
+          COUNT(1) AS count_one,
           COUNT(NULL) AS count_null,
           -- count distinct
           COUNT(DISTINCT a) AS count_unique_a,
@@ -110,6 +111,7 @@ def test_count() -> None:
         "count_b": [5],
         "count_c": [3],
         "count_star": [5],
+        "count_one": [5],
         "count_null": [0],
         "count_unique_a": [5],
         "count_unique_b": [3],
@@ -123,6 +125,8 @@ def test_count() -> None:
         SELECT
           COUNT(x) AS count_x,
           COUNT(*) AS count_star,
+          COUNT(1) AS count_one,
+          COUNT('hello') AS count_hello,
           COUNT(DISTINCT x) AS count_unique_x
         FROM self
         """
@@ -130,6 +134,8 @@ def test_count() -> None:
     assert res.to_dict(as_series=False) == {
         "count_x": [0],
         "count_star": [3],
+        "count_one": [3],
+        "count_hello": [3],
         "count_unique_x": [0],
     }
 
@@ -574,6 +580,10 @@ def test_select_explode_height_filter_order_by() -> None:
         ),
         (
             """SELECT a, COUNT() OVER (PARTITION BY a) AS b FROM self""",
+            [3, 3, 3, 1, 3, 3, 3],
+        ),
+        (
+            """SELECT a, COUNT(1) OVER (PARTITION BY a) AS b FROM self""",
             [3, 3, 3, 1, 3, 3, 3],
         ),
         (


### PR DESCRIPTION
Closes #27054.

`"COUNT(<non-null-literal>)"` should be treated the same as `"COUNT(*)"`.

