### PR TITLE
fix: Ignore `ddof` parameter in `rolling_corr` and deprecate

### DIFF
--- a/crates/polars-expr/src/dispatch/rolling.rs
+++ b/crates/polars-expr/src/dispatch/rolling.rs
@@ -195,9 +195,19 @@ pub(super) fn rolling_corr_cov(
         &[AnyValue::from(cov_options.ddof).cast(&dtype)],
     );
 
-    let numerator = ((mean_x_y - (mean_x * mean_y).unwrap()).unwrap()
-        * (count_x_y.clone() / (count_x_y - ddof).unwrap()).unwrap())
-    .unwrap();
+    let numerator = if is_corr {
+        ((mean_x_y - (mean_x * mean_y).unwrap()).unwrap()
+            * (count_x_y.clone()
+                / (count_x_y
+                    - Series::new(PlSmallStr::EMPTY, &[AnyValue::from(1u8).cast(&dtype)]))
+                .unwrap())
+            .unwrap())
+        .unwrap()
+    } else {
+        ((mean_x_y - (mean_x * mean_y).unwrap()).unwrap()
+            * (count_x_y.clone() / (count_x_y - ddof).unwrap()).unwrap())
+        .unwrap()
+    };
 
     if is_corr {
         let var_x = x.rolling_var(rolling_options.clone())?;

--- a/crates/polars-expr/src/dispatch/rolling.rs
+++ b/crates/polars-expr/src/dispatch/rolling.rs
@@ -190,24 +190,16 @@ pub(super) fn rolling_corr_cov(
 
     let mean_x = x.rolling_mean(rolling_options.clone())?;
     let mean_y = y.rolling_mean(rolling_options.clone())?;
+
+    let ddof_value = if is_corr { 1u8 } else { cov_options.ddof };
     let ddof = Series::new(
         PlSmallStr::EMPTY,
-        &[AnyValue::from(cov_options.ddof).cast(&dtype)],
+        &[AnyValue::from(ddof_value).cast(&dtype)],
     );
 
-    let numerator = if is_corr {
-        ((mean_x_y - (mean_x * mean_y).unwrap()).unwrap()
-            * (count_x_y.clone()
-                / (count_x_y
-                    - Series::new(PlSmallStr::EMPTY, &[AnyValue::from(1u8).cast(&dtype)]))
-                .unwrap())
-            .unwrap())
-        .unwrap()
-    } else {
-        ((mean_x_y - (mean_x * mean_y).unwrap()).unwrap()
-            * (count_x_y.clone() / (count_x_y - ddof).unwrap()).unwrap())
-        .unwrap()
-    };
+    let numerator = ((mean_x_y - (mean_x * mean_y).unwrap()).unwrap()
+        * (count_x_y.clone() / (count_x_y - ddof).unwrap()).unwrap())
+    .unwrap();
 
     if is_corr {
         let var_x = x.rolling_var(rolling_options.clone())?;

--- a/py-polars/src/polars/functions/lazy.py
+++ b/py-polars/src/polars/functions/lazy.py
@@ -2692,7 +2692,7 @@ def rolling_corr(
     *,
     window_size: int,
     min_samples: int | None = None,
-    ddof: int = 1,
+    ddof: int | None = 1,
 ) -> Expr:
     """
     Compute the rolling correlation between two columns/ expressions.
@@ -2718,6 +2718,13 @@ def rolling_corr(
         Delta degrees of freedom. The divisor used in calculations
         is `N - ddof`, where `N` represents the number of elements.
     """
+    if ddof != 1:
+        issue_deprecation_warning(
+            "the `ddof` parameter for `rolling_corr` is deprecated."
+            " Correlation is invariant of `ddof`.",
+            version="1.39.4",
+        )
+
     if min_samples is None:
         min_samples = window_size
     if isinstance(a, str):

--- a/py-polars/src/polars/functions/lazy.py
+++ b/py-polars/src/polars/functions/lazy.py
@@ -2692,7 +2692,7 @@ def rolling_corr(
     *,
     window_size: int,
     min_samples: int | None = None,
-    ddof: int | None = 1,
+    ddof: int = 1,
 ) -> Expr:
     """
     Compute the rolling correlation between two columns/ expressions.

--- a/py-polars/src/polars/functions/lazy.py
+++ b/py-polars/src/polars/functions/lazy.py
@@ -2715,14 +2715,15 @@ def rolling_corr(
         The number of values in the window that should be non-null before computing
         a result. If None, it will be set equal to window size.
     ddof
-        Delta degrees of freedom. The divisor used in calculations
-        is `N - ddof`, where `N` represents the number of elements.
+        Has no effect, do not use.
+
+        .. deprecated:: 1.40.0
     """
     if ddof != 1:
         issue_deprecation_warning(
             "the `ddof` parameter for `rolling_corr` is deprecated."
             " Correlation is invariant of `ddof`.",
-            version="1.39.4",
+            version="1.40.0",
         )
 
     if min_samples is None:

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -2407,3 +2407,24 @@ def test_rolling_empty_windows_streaming_26732() -> None:
     )
 
     assert_frame_equal(result, expected)
+
+
+def test_rolling_corr_ddof_invariant_27013() -> None:
+    x = [1.0, 2.0, 3.0, 4.0, 5.0]
+    y = [10.0, 20.0, 30.0, 40.0, 50.0]
+    df = pl.DataFrame({"x": x, "y": y})
+
+    r1 = df.select(pl.rolling_corr("x", "y", window_size=5, min_samples=5))["x"][-1]
+    assert r1 == pytest.approx(1.0)
+
+    with pytest.warns(DeprecationWarning, match="ddof"):
+        r0 = df.select(pl.rolling_corr("x", "y", window_size=5, min_samples=5, ddof=0))[
+            "x"
+        ][-1]
+    with pytest.warns(DeprecationWarning, match="ddof"):
+        r2 = df.select(pl.rolling_corr("x", "y", window_size=5, min_samples=5, ddof=2))[
+            "x"
+        ][-1]
+
+    assert r0 == pytest.approx(1.0)
+    assert r2 == pytest.approx(1.0)


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/27013.

The issue was that the numerator was using the user-provided `ddof` while the denominator's `rolling_var` always used `ddof=1`. It was fixed by hardcoding `ddof=1` in the numerator when computing correlation, so both sides match and cancel correctly rather than producing incorrect values for the correlation. The user-provided `ddof` is now ignored for correlation and deprecated in Python.

🤖 Claude Sonnet 4.6 for navigating the codebase.