### PR TITLE
fix(python): Convert scalar booleans to Iceberg expressions

### DIFF
--- a/py-polars/src/polars/io/iceberg/_utils.py
+++ b/py-polars/src/polars/io/iceberg/_utils.py
@@ -105,7 +105,11 @@ def _scan_pyarrow_dataset_impl(
 
 
 def _ensure_boolean_expression(result: Any) -> Any:
-    """Wrap bare field references as EqualTo(field, True)."""
+    """Convert scalar booleans and bare fields into PyIceberg boolean expressions."""
+    if result is True:
+        return pyiceberg.expressions.AlwaysTrue()  # type: ignore[misc]
+    if result is False:
+        return pyiceberg.expressions.AlwaysFalse()  # type: ignore[misc]
     if isinstance(result, list) and len(result) == 1:
         return pyiceberg.expressions.EqualTo(result[0], True)  # type: ignore[misc, call-arg, arg-type]
     return result

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -75,6 +75,8 @@ from polars.testing import assert_frame_equal
 from tests.unit.io.conftest import normalize_path_separator_pl
 
 if TYPE_CHECKING:
+    AlwaysFalse = Any
+    AlwaysTrue = Any
     from tests.conftest import PlMonkeyPatch
 
     # Mypy does not understand the constructors and we can't construct the inputs
@@ -92,6 +94,8 @@ if TYPE_CHECKING:
     Reference = Any
 else:
     from pyiceberg.expressions import (
+        AlwaysFalse,
+        AlwaysTrue,
         And,
         EqualTo,
         GreaterThan,
@@ -321,6 +325,14 @@ class TestIcebergExpressions:
     def test_bare_boolean_field_negated(self) -> None:
         expr = try_convert_pyarrow_predicate("~pa.compute.field('is_active')")
         assert expr == Not(EqualTo("is_active", True))
+
+    def test_scalar_false_expression(self) -> None:
+        expr = try_convert_pyarrow_predicate("pa.compute.scalar(False)")
+        assert expr == AlwaysFalse()
+
+    def test_scalar_true_expression(self) -> None:
+        expr = try_convert_pyarrow_predicate("pa.compute.scalar(True)")
+        assert expr == AlwaysTrue()
 
 
 @dataclass(kw_only=True)


### PR DESCRIPTION
### Description
fix(python): Corrects the try_convert_pyarrow_predicate handling of scalar boolean predicates.
Issue #27106: NotImplementedError when using scan_iceberg with is_in([]) filter.
I noticed that scalar predicates like pa.compute.scalar(False) could remain raw Python bool values after conversion, and PyIceberg filter scanning expects a PyIceberg boolean expression object. This PR addresses it by mapping scalar booleans to AlwaysTrue or AlwaysFalse in boolean expression normalization, and adding focused tests for scalar true, scalar false, and bare boolean field handling.

Closes #27106

### AI Assistance Disclosure
Tool(s) used: GitHub Copilot with GPT 5.3 Codex
Scope: Used AI to understand the codebase, and implement the minimal predicate conversion fix and add focused tests. I reviewed all changes and kept the patch targeted.
Verification: I have reviewed every line of the generated code, verified it against the Polars style guide, and confirmed local checks pass in WSL.

### Checklist
- [x] I have reviewed all changes in this PR myself.
- [x] I have added a relevant test case for this fix.
- [x] I have run the linting and formatting scripts (make lint).
- [x] I ran the full local make test suite in WSL and captured a screenshot for the PR.