### PR TITLE
fix(python): Enable mimalloc v3 on Windows

### DIFF
--- a/crates/polars-python/Cargo.toml
+++ b/crates/polars-python/Cargo.toml
@@ -51,7 +51,10 @@ recursive = { workspace = true }
 serde_json = { workspace = true, optional = true }
 uuid = { workspace = true }
 
-[target.'cfg(any(not(target_family = "unix"), target_os = "emscripten"))'.dependencies]
+[target.'cfg(target_os = "windows")'.dependencies]
+mimalloc = { version = "0.1", default-features = false, features = ["v3"] }
+
+[target.'cfg(any(all(not(target_family = "unix"), not(target_os = "windows")), target_os = "emscripten"))'.dependencies]
 mimalloc = { version = "0.1", default-features = false }
 
 # Feature background_threads is unsupported on MacOS (https://github.com/jemalloc/jemalloc/issues/843).


### PR DESCRIPTION
### Description:
fix(python): Corrects the Windows mimalloc configuration handling for Python builds.

I noticed that the non-Unix mimalloc dependency also covered Windows, but it did not enable the v3 feature there. This PR addresses it by splitting the target configuration so Windows uses mimalloc with `features = ["v3"]` while the existing non-Windows non-Unix and emscripten paths keep the previous settings.

Closes #27061

### AI Assistance Disclosure:
- Tool(s) used: GitHub Copilot in VS Code, WSL, PowerShell, and the GitHub API.
- Scope: Minimal change in `crates/polars-python/Cargo.toml` to enable Windows-only mimalloc v3.
- Verification: Ran `cargo tree -p polars-python --target x86_64-pc-windows-msvc -e features` in WSL and confirmed `mimalloc feature "v3"` and `libmimalloc-sys feature "v3"`. Ran `make lint` in `py-polars` on WSL and it passed.

### Checklist:
- [x] I have reviewed all changes in this PR myself.
- [x] I have verified the Windows target dependency resolution with `cargo tree`.
- [x] I have run the linting and formatting scripts (`make lint`).