### PR TITLE
docs: Put first-time contribution requirements in its own linkable section

### DIFF
--- a/docs/source/development/contributing/index.md
+++ b/docs/source/development/contributing/index.md
@@ -313,6 +313,15 @@ in the Polars repository. Please adhere to the following guidelines:
   If you fail either requirement the maintainer may simply close your pull request.
 <!-- dprint-ignore-end -->
 
+After you have opened your pull request, a maintainer will review it and possibly leave some
+comments. Once all issues are resolved, the maintainer will merge your pull request, and your work
+will be part of the next Polars release!
+
+Keep in mind that your work does not have to be perfect right away! If you are stuck or unsure about
+your solution, feel free to open a draft pull request and ask for help.
+
+### First-time contributions
+
 We unfortunately are overwhelmed by the amount of low-quality contributions created primarily using
 AI. These cost us a lot of time (and regularly simply don't work), while the author has barely spent
 any effort, so for first-time contributors there are some more rules:
@@ -320,13 +329,6 @@ any effort, so for first-time contributors there are some more rules:
 - You must post a screenshot of you successfully running the test suite (`make test`), locally on
   your machine (not the CI).
 - You may not have more than one open PR at a time.
-
-After you have opened your pull request, a maintainer will review it and possibly leave some
-comments. Once all issues are resolved, the maintainer will merge your pull request, and your work
-will be part of the next Polars release!
-
-Keep in mind that your work does not have to be perfect right away! If you are stuck or unsure about
-your solution, feel free to open a draft pull request and ask for help.
 
 ## Contributing to documentation
 


### PR DESCRIPTION
This should make it easier to link directly.