### PR TITLE
fix(python): Address a potential overflow in `from_epoch` scaling

### DIFF
--- a/py-polars/src/polars/functions/lazy.py
+++ b/py-polars/src/polars/functions/lazy.py
@@ -2632,11 +2632,11 @@ def from_epoch(
     if time_unit == "d":
         return column.cast(Date)
     if time_unit in (scale := {"s": 1_000_000, "ms": 1_000}):
-        if isinstance(column, pl.Series) and column.dtype.is_integer():
-            column = column.cast(Int64)
-        elif isinstance(column, pl.Expr):
+        if isinstance(column, pl.Expr):
             column = column * F.lit(scale[time_unit], dtype=Int64)
             return column.cast(Datetime("us"))
+        if isinstance(column, pl.Series) and column.dtype.is_integer():
+            column = column.cast(Int64)
         return (column * scale[time_unit]).cast(Datetime("us"))
     if time_unit in DTYPE_TEMPORAL_UNITS:
         return column.cast(Datetime(time_unit))  # type: ignore[arg-type]

--- a/py-polars/src/polars/functions/lazy.py
+++ b/py-polars/src/polars/functions/lazy.py
@@ -2635,7 +2635,7 @@ def from_epoch(
         if isinstance(column, pl.Expr):
             column = column * F.lit(scale[time_unit], dtype=Int64)
             return column.cast(Datetime("us"))
-        if isinstance(column, pl.Series) and column.dtype.is_integer():
+        if column.dtype.is_integer():
             column = column.cast(Int64)
         return (column * scale[time_unit]).cast(Datetime("us"))
     if time_unit in DTYPE_TEMPORAL_UNITS:

--- a/py-polars/src/polars/functions/lazy.py
+++ b/py-polars/src/polars/functions/lazy.py
@@ -23,7 +23,7 @@ from polars._utils.parse import (
 from polars._utils.unstable import issue_unstable_warning, unstable
 from polars._utils.various import extend_bool, qualified_type_name
 from polars._utils.wrap import wrap_df, wrap_expr, wrap_s
-from polars.datatypes import DTYPE_TEMPORAL_UNITS, Date, Datetime
+from polars.datatypes import DTYPE_TEMPORAL_UNITS, Date, Datetime, Int64
 from polars.datatypes._parse import parse_into_datatype_expr
 from polars.lazyframe.opt_flags import (
     DEFAULT_QUERY_OPT_FLAGS,
@@ -2632,6 +2632,11 @@ def from_epoch(
     if time_unit == "d":
         return column.cast(Date)
     if time_unit in (scale := {"s": 1_000_000, "ms": 1_000}):
+        if isinstance(column, pl.Series) and column.dtype.is_integer():
+            column = column.cast(Int64)
+        elif isinstance(column, pl.Expr):
+            column = column * F.lit(scale[time_unit], dtype=Int64)
+            return column.cast(Datetime("us"))
         return (column * scale[time_unit]).cast(Datetime("us"))
     if time_unit in DTYPE_TEMPORAL_UNITS:
         return column.cast(Datetime(time_unit))  # type: ignore[arg-type]

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -27,7 +27,11 @@ if TYPE_CHECKING:
 
     from _pytest.capture import CaptureFixture
 
-    from polars._typing import MapElementsStrategy, PolarsDataType
+    from polars._typing import (
+        EpochTimeUnit,
+        MapElementsStrategy,
+        PolarsDataType,
+    )
     from tests.conftest import PlMonkeyPatch
 
 
@@ -1346,14 +1350,65 @@ def test_from_epoch(input_dtype: PolarsDataType) -> None:
         _ = ldf.select(pl.from_epoch(ts_col, time_unit="s2"))  # type: ignore[call-overload]
 
 
-@pytest.mark.parametrize("input_dtype", [pl.UInt32, pl.Int32])
-def test_from_epoch_27107(input_dtype: PolarsDataType) -> None:
-    epoch_s = 1721068200  # 2024-07-15 18:30:00 UTC
-    ldf = pl.LazyFrame([pl.Series("timestamp_s", [epoch_s], dtype=input_dtype)])
-    res = ldf.select(pl.from_epoch("timestamp_s", time_unit="s"))
+@pytest.mark.parametrize(
+    ("input_dtype", "epoch_value", "time_unit", "expected_datetime"),
+    [
+        # 32-bit types with large positive values (original overflow case)
+        (pl.Int32, 1_721_068_200, "s", datetime(2024, 7, 15, 18, 30)),
+        (pl.UInt32, 1_721_068_200, "s", datetime(2024, 7, 15, 18, 30)),
+        # larger integer types
+        (pl.Int64, 1_721_068_200, "s", datetime(2024, 7, 15, 18, 30)),
+        (pl.UInt64, 1_721_068_200, "s", datetime(2024, 7, 15, 18, 30)),
+        (pl.Int128, 1_721_068_200, "s", datetime(2024, 7, 15, 18, 30)),
+        (pl.UInt128, 1_721_068_200, "s", datetime(2024, 7, 15, 18, 30)),
+        # small unsigned types
+        (pl.UInt8, 100, "s", datetime(1970, 1, 1, 0, 1, 40)),
+        (pl.UInt16, 32_000, "s", datetime(1970, 1, 1, 8, 53, 20)),
+        # small signed types (positive values)
+        (pl.Int8, 100, "s", datetime(1970, 1, 1, 0, 1, 40)),
+        (pl.Int16, 32_000, "ms", datetime(1970, 1, 1, 0, 0, 32)),
+        # signed types with negative values (pre-epoch)
+        (pl.Int8, -100, "s", datetime(1969, 12, 31, 23, 58, 20)),
+        (pl.Int16, -32_000, "s", datetime(1969, 12, 31, 15, 6, 40)),
+        (pl.Int32, -1_721_068_200, "s", datetime(1915, 6, 19, 5, 30)),
+        (pl.Int64, -1_721_068_200, "s", datetime(1915, 6, 19, 5, 30)),
+        # milliseconds (with subsecond component)
+        (pl.Int64, 1_721_068_200_456, "ms", datetime(2024, 7, 15, 18, 30, 0, 456000)),
+        (pl.Int32, 2_000_456, "ms", datetime(1970, 1, 1, 0, 33, 20, 456000)),
+        (pl.Int64, -1_721_068_200_456, "ms", datetime(1915, 6, 19, 5, 29, 59, 544000)),
+        # nanoseconds (with subsecond component)
+        (
+            pl.UInt128,
+            1_721_068_200_456_789_000,
+            "ns",
+            datetime(2024, 7, 15, 18, 30, 0, 456789),
+        ),
+        (
+            pl.UInt128,
+            2_721_068_200_999_999_000,
+            "ns",
+            datetime(2056, 3, 23, 20, 16, 40, 999999),
+        ),
+        (
+            pl.Int128,
+            -1_721_068_200_456_789_000,
+            "ns",
+            datetime(1915, 6, 19, 5, 29, 59, 543211),
+        ),
+    ],
+)
+def test_from_epoch_27107(
+    input_dtype: PolarsDataType,
+    epoch_value: int,
+    time_unit: EpochTimeUnit,
+    expected_datetime: datetime,
+) -> None:
+    ldf = pl.LazyFrame({"ts": [epoch_value]}, schema={"ts": input_dtype})
+    res = ldf.select(pl.from_epoch("ts", time_unit=time_unit))
 
-    expected = pl.DataFrame([pl.Series("timestamp_s", [datetime(2024, 7, 15, 18, 30)])])
-    assert_frame_equal(res.collect(), expected)
+    dtype = pl.Datetime(time_unit if time_unit == "ns" else "us")
+    expected = pl.LazyFrame({"ts": [expected_datetime]}, schema={"ts": dtype})
+    assert_frame_equal(res, expected)
 
 
 def test_from_epoch_str() -> None:

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -1346,6 +1346,16 @@ def test_from_epoch(input_dtype: PolarsDataType) -> None:
         _ = ldf.select(pl.from_epoch(ts_col, time_unit="s2"))  # type: ignore[call-overload]
 
 
+@pytest.mark.parametrize("input_dtype", [pl.UInt32, pl.Int32])
+def test_from_epoch_27107(input_dtype: PolarsDataType) -> None:
+    epoch_s = 1721068200  # 2024-07-15 18:30:00 UTC
+    ldf = pl.LazyFrame([pl.Series("timestamp_s", [epoch_s], dtype=input_dtype)])
+    res = ldf.select(pl.from_epoch("timestamp_s", time_unit="s"))
+
+    expected = pl.DataFrame([pl.Series("timestamp_s", [datetime(2024, 7, 15, 18, 30)])])
+    assert_frame_equal(res.collect(), expected)
+
+
 def test_from_epoch_str() -> None:
     ldf = pl.LazyFrame(
         [


### PR DESCRIPTION
Closes #27107.

* Ensure we widen during scaling (where necessary) so 32bit (or smaller) epoch values don't overflow.
* Parametrize epoch conversion test coverage to _all_ signed/unsigned integer types (8bit → 128bit).
