### PR TITLE
fix(rust): Avoid panic for open-ended slice in CSV scan

### DIFF
--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "diff")]
 use polars_core::series::ops::NullBehavior;
+#[cfg(all(feature = "csv", feature = "new_streaming"))]
+use polars_core::SINGLE_LOCK;
 
 use super::*;
 
@@ -265,6 +267,19 @@ fn test_lazy_query_3() {
         .agg([col("fats_g").max()])
         .collect()
         .unwrap();
+}
+
+#[test]
+#[cfg(all(feature = "csv", feature = "new_streaming"))]
+fn test_scan_csv_open_ended_slice_offset() -> PolarsResult<()> {
+    let _guard = SINGLE_LOCK.lock().unwrap();
+
+    let expected = scan_foods_csv().collect()?.slice(1, IdxSize::MAX as usize);
+    let result = scan_foods_csv().slice(1, IdxSize::MAX).collect()?;
+
+    assert!(result.equals_missing(&expected));
+
+    Ok(())
 }
 
 #[test]

--- a/crates/polars-stream/src/nodes/io_sources/csv/line_batch_source.rs
+++ b/crates/polars-stream/src/nodes/io_sources/csv/line_batch_source.rs
@@ -1,11 +1,10 @@
-use std::ops::Range;
-
 use polars_buffer::Buffer;
 use polars_error::PolarsResult;
 use polars_io::prelude::_csv_read_internal::CountLines;
 use polars_io::utils::compression::ByteSourceReader;
 use polars_io::utils::slice::SplitSlicePosition;
 use polars_io::utils::stream_buf_reader::ReaderSource;
+use polars_utils::IdxSize;
 use polars_utils::mem::prefetch::prefetch_l2;
 use polars_utils::slice_enum::Slice;
 
@@ -33,6 +32,56 @@ pub(super) struct LineBatchSource {
     pub(super) verbose: bool,
 }
 
+#[derive(Clone, Copy)]
+struct GlobalPositiveSlice {
+    start: usize,
+    end: Option<usize>,
+}
+
+impl GlobalPositiveSlice {
+    fn from_slice(slice: Slice) -> Self {
+        let Slice::Positive { offset, len } = slice else {
+            panic!("cannot convert negative slice into csv pre-slice");
+        };
+
+        // `IdxSize::MAX` is also used to represent an unspecified/open-ended slice length.
+        let end = if len == IdxSize::MAX as usize {
+            None
+        } else {
+            Some(offset.saturating_add(len))
+        };
+
+        Self { start: offset, end }
+    }
+
+    fn split_at_file(
+        self,
+        current_row_offset: usize,
+        n_rows_this_file: usize,
+    ) -> SplitSlicePosition {
+        match self.end {
+            Some(end) => SplitSlicePosition::split_slice_at_file(
+                current_row_offset,
+                n_rows_this_file,
+                self.start..end,
+            ),
+            None => {
+                let next_row_offset = current_row_offset + n_rows_this_file;
+
+                if next_row_offset <= self.start {
+                    SplitSlicePosition::Before
+                } else {
+                    let n_rows_to_skip = self.start.saturating_sub(current_row_offset);
+                    SplitSlicePosition::Overlapping(
+                        n_rows_to_skip,
+                        n_rows_this_file - n_rows_to_skip,
+                    )
+                }
+            },
+        }
+    }
+}
+
 impl LineBatchSource {
     /// Returns the number of rows skipped from the start of the file according to CountLines.
     pub(crate) async fn run(self) -> PolarsResult<usize> {
@@ -48,7 +97,7 @@ impl LineBatchSource {
 
         let global_slice = if let Some(pre_slice) = pre_slice {
             match pre_slice {
-                Slice::Positive { .. } => Some(Range::<usize>::from(pre_slice)),
+                Slice::Positive { .. } => Some(GlobalPositiveSlice::from_slice(pre_slice)),
                 // IR lowering puts negative slice in separate node.
                 // TODO: Native line buffering for negative slice
                 Slice::Negative { .. } => unreachable!(),
@@ -94,11 +143,7 @@ impl LineBatchSource {
             row_offset += n_lines;
 
             let slice = if let Some(global_slice) = &global_slice {
-                match SplitSlicePosition::split_slice_at_file(
-                    prev_row_offset,
-                    n_lines,
-                    global_slice.clone(),
-                ) {
+                match global_slice.split_at_file(prev_row_offset, n_lines) {
                     // Note that we don't check that the skipped line batches actually contain this many
                     // lines.
                     SplitSlicePosition::Before => {


### PR DESCRIPTION
Fixes #27030

## Summary
This fixes a panic in the CSV streaming path for open-ended lazy slices such as:

```python
pl.scan_csv("examples/datasets/foods1.csv").slice(1).collect()
```
## Root cause
Open-ended slices were represented with a sentinel max length and converted too early into a concrete `Range<usize>` in the CSV streaming path. This could overflow when computing the end bound and panic.

## Fix
This keeps the open-ended slice semantics local to the CSV line batch source until per-file bounds are known, rather than changing `Slice -> Range<usize>` globally.

This preserves the “unspecified length” behavior discussed in the issue thread.

## Tests
Added regression test:
- `test_scan_csv_open_ended_slice_offset`

Verified existing bounded behavior:
- `test_slice_at_scan_group_by`

## Validation

- Ran full test suite locally using `make test` (see screenshot below)
- Verified new regression test passes
- Verified no regressions in existing CSV streaming behavior
```bash
cargo test -p polars-lazy --features csv,new_streaming test_scan_csv_open_ended_slice_offset -- --nocapture
cargo test -p polars-lazy --features csv,new_streaming test_slice_at_scan_group_by -- --nocapture
```
<img width="712" height="144" alt="Screenshot 2026-03-31 at 7 19 26 PM" src="https://github.com/user-attachments/assets/dcd73773-ea74-46e1-8215-84e8819ccdd5" />

## AI disclosure
1. I used AI to help investigate the code path, reason about possible fixes, and draft an initial version of the patch and test.
2. I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.