### PR TITLE
docs: Improved `intersphinx` mappings

### DIFF
--- a/.github/scripts/test_bytecode_parser.py
+++ b/.github/scripts/test_bytecode_parser.py
@@ -1,7 +1,7 @@
 """
 Minimal testing script of the BytecodeParser class.
 
-This can be run without polars installed, and so can be easily run in CI
+This can be run without Polars installed, and so can be easily run in CI
 over all supported Python versions.
 
 All that needs to be installed is pytest, numpy, and ipython.

--- a/py-polars/docs/.gitignore
+++ b/py-polars/docs/.gitignore
@@ -1,2 +1,3 @@
 build/
 source/reference/**/api/
+_intersphinx/

--- a/py-polars/docs/Makefile
+++ b/py-polars/docs/Makefile
@@ -17,16 +17,18 @@ help:
 
 .PHONY: help Makefile fetch-intersphinx
 
-fetch-intersphinx:  ## Download intersphinx inventory files for offline/fallback use
+fetch-intersphinx:  ## Pre-fetch intersphinx inventories for slightly faster (or offline) builds
 	@mkdir -p $(INTERSPHINX)
-	@test -f $(INTERSPHINX)/deltalake.inv || curl -sL https://delta-io.github.io/delta-rs/python/objects.inv -o $(INTERSPHINX)/deltalake.inv
-	@test -f $(INTERSPHINX)/jax.inv || curl -sL https://jax.readthedocs.io/en/latest/objects.inv -o $(INTERSPHINX)/jax.inv
-	@test -f $(INTERSPHINX)/numpy.inv || curl -sL https://numpy.org/doc/stable/objects.inv -o $(INTERSPHINX)/numpy.inv
-	@test -f $(INTERSPHINX)/pandas.inv || curl -sL https://pandas.pydata.org/docs/objects.inv -o $(INTERSPHINX)/pandas.inv
-	@test -f $(INTERSPHINX)/pyarrow.inv || curl -sL https://arrow.apache.org/docs/objects.inv -o $(INTERSPHINX)/pyarrow.inv
-	@test -f $(INTERSPHINX)/python.inv || curl -sL https://docs.python.org/3/objects.inv -o $(INTERSPHINX)/python.inv
-	@test -f $(INTERSPHINX)/sqlalchemy.inv || curl -sL https://docs.sqlalchemy.org/en/20/objects.inv -o $(INTERSPHINX)/sqlalchemy.inv
-	@test -f $(INTERSPHINX)/torch.inv || curl -sL https://pytorch.org/docs/stable/objects.inv -o $(INTERSPHINX)/torch.inv
+	@# Remove cached files older than 1 day so they get re-fetched
+	@find $(INTERSPHINX) -name '*.inv' -mtime +1 -delete 2>/dev/null || true
+	@test -s $(INTERSPHINX)/deltalake.inv || curl -sfL https://delta-io.github.io/delta-rs/python/objects.inv -o $(INTERSPHINX)/deltalake.inv || true
+	@test -s $(INTERSPHINX)/jax.inv || curl -sfL https://jax.readthedocs.io/en/latest/objects.inv -o $(INTERSPHINX)/jax.inv || true
+	@test -s $(INTERSPHINX)/numpy.inv || curl -sfL https://numpy.org/doc/stable/objects.inv -o $(INTERSPHINX)/numpy.inv || true
+	@test -s $(INTERSPHINX)/pandas.inv || curl -sfL https://pandas.pydata.org/docs/objects.inv -o $(INTERSPHINX)/pandas.inv || true
+	@test -s $(INTERSPHINX)/pyarrow.inv || curl -sfL https://arrow.apache.org/docs/objects.inv -o $(INTERSPHINX)/pyarrow.inv || true
+	@test -s $(INTERSPHINX)/python.inv || curl -sfL https://docs.python.org/3/objects.inv -o $(INTERSPHINX)/python.inv || true
+	@test -s $(INTERSPHINX)/sqlalchemy.inv || curl -sfL https://docs.sqlalchemy.org/en/20/objects.inv -o $(INTERSPHINX)/sqlalchemy.inv || true
+	@test -s $(INTERSPHINX)/torch.inv || curl -sfL https://pytorch.org/docs/stable/objects.inv -o $(INTERSPHINX)/torch.inv || true
 
 clean:
 	@rm -rf source/reference/*/api/
@@ -35,5 +37,5 @@ clean:
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: fetch-intersphinx Makefile
+%: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/py-polars/docs/Makefile
+++ b/py-polars/docs/Makefile
@@ -9,12 +9,24 @@ export BUILDING_SPHINX_DOCS = 1
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
+INTERSPHINX   = _intersphinx
 
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: help Makefile fetch-intersphinx
+
+fetch-intersphinx:  ## Download intersphinx inventory files for offline/fallback use
+	@mkdir -p $(INTERSPHINX)
+	@test -f $(INTERSPHINX)/deltalake.inv || curl -sL https://delta-io.github.io/delta-rs/python/objects.inv -o $(INTERSPHINX)/deltalake.inv
+	@test -f $(INTERSPHINX)/jax.inv || curl -sL https://jax.readthedocs.io/en/latest/objects.inv -o $(INTERSPHINX)/jax.inv
+	@test -f $(INTERSPHINX)/numpy.inv || curl -sL https://numpy.org/doc/stable/objects.inv -o $(INTERSPHINX)/numpy.inv
+	@test -f $(INTERSPHINX)/pandas.inv || curl -sL https://pandas.pydata.org/docs/objects.inv -o $(INTERSPHINX)/pandas.inv
+	@test -f $(INTERSPHINX)/pyarrow.inv || curl -sL https://arrow.apache.org/docs/objects.inv -o $(INTERSPHINX)/pyarrow.inv
+	@test -f $(INTERSPHINX)/python.inv || curl -sL https://docs.python.org/3/objects.inv -o $(INTERSPHINX)/python.inv
+	@test -f $(INTERSPHINX)/sqlalchemy.inv || curl -sL https://docs.sqlalchemy.org/en/20/objects.inv -o $(INTERSPHINX)/sqlalchemy.inv
+	@test -f $(INTERSPHINX)/torch.inv || curl -sL https://pytorch.org/docs/stable/objects.inv -o $(INTERSPHINX)/torch.inv
 
 clean:
 	@rm -rf source/reference/*/api/
@@ -23,5 +35,5 @@ clean:
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
+%: fetch-intersphinx Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -76,40 +76,27 @@ overloads_location = ["bottom"]
 
 # sphinx.ext.intersphinx - link to other projects' documentation
 # https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
-inv = str(Path(__file__).resolve().parent.parent / "_intersphinx")
+#
+# Note: can use `make fetch-intersphinx` to pre-fetch files for faster/offline
+# builds; if cached files are not present, Sphinx fetches them at build time
+# (download failures don't block the build, but will generate warnings)
+_inv = Path(__file__).resolve().parent.parent / "_intersphinx"
+_intersphinx_targets = {
+    "deltalake": "https://delta-io.github.io/delta-rs/python/",
+    "jax": "https://jax.readthedocs.io/en/latest/",
+    "numpy": "https://numpy.org/doc/stable/",
+    "pandas": "https://pandas.pydata.org/docs/",
+    "pyarrow": "https://arrow.apache.org/docs/",
+    "python": "https://docs.python.org/3",
+    "sqlalchemy": "https://docs.sqlalchemy.org/en/stable/",
+    "torch": "https://pytorch.org/docs/stable/",
+}
 intersphinx_mapping = {
-    "deltalake": (
-        "https://delta-io.github.io/delta-rs/python/",
-        (f"{inv}/deltalake.inv", None),
-    ),
-    "jax": (
-        "https://jax.readthedocs.io/en/latest/",
-        (f"{inv}/jax.inv", None),
-    ),
-    "numpy": (
-        "https://numpy.org/doc/stable/",
-        (f"{inv}/numpy.inv", None),
-    ),
-    "pandas": (
-        "https://pandas.pydata.org/docs/",
-        (f"{inv}/pandas.inv", None),
-    ),
-    "pyarrow": (
-        "https://arrow.apache.org/docs/",
-        (f"{inv}/pyarrow.inv", None),
-    ),
-    "python": (
-        "https://docs.python.org/3",
-        (f"{inv}/python.inv", None),
-    ),
-    "sqlalchemy": (
-        "https://docs.sqlalchemy.org/en/stable/",
-        (f"{inv}/sqlalchemy.inv", None),
-    ),
-    "torch": (
-        "https://pytorch.org/docs/stable/",
-        (f"{inv}/torch.inv", None),
-    ),
+    name: (
+        url,
+        (str(_inv / f"{name}.inv"), None) if (_inv / f"{name}.inv").is_file() else None,
+    )
+    for name, url in _intersphinx_targets.items()
 }
 
 # numpydoc - parse numpy docstrings

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -76,11 +76,40 @@ overloads_location = ["bottom"]
 
 # sphinx.ext.intersphinx - link to other projects' documentation
 # https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
+inv = str(Path(__file__).resolve().parent.parent / "_intersphinx")
 intersphinx_mapping = {
-    "numpy": ("https://numpy.org/doc/stable/", None),
-    "pandas": ("https://pandas.pydata.org/docs/", None),
-    "pyarrow": ("https://arrow.apache.org/docs/", None),
-    "python": ("https://docs.python.org/3", None),
+    "deltalake": (
+        "https://delta-io.github.io/delta-rs/python/",
+        (f"{inv}/deltalake.inv", None),
+    ),
+    "jax": (
+        "https://jax.readthedocs.io/en/latest/",
+        (f"{inv}/jax.inv", None),
+    ),
+    "numpy": (
+        "https://numpy.org/doc/stable/",
+        (f"{inv}/numpy.inv", None),
+    ),
+    "pandas": (
+        "https://pandas.pydata.org/docs/",
+        (f"{inv}/pandas.inv", None),
+    ),
+    "pyarrow": (
+        "https://arrow.apache.org/docs/",
+        (f"{inv}/pyarrow.inv", None),
+    ),
+    "python": (
+        "https://docs.python.org/3",
+        (f"{inv}/python.inv", None),
+    ),
+    "sqlalchemy": (
+        "https://docs.sqlalchemy.org/en/stable/",
+        (f"{inv}/sqlalchemy.inv", None),
+    ),
+    "torch": (
+        "https://pytorch.org/docs/stable/",
+        (f"{inv}/torch.inv", None),
+    ),
 }
 
 # numpydoc - parse numpy docstrings

--- a/py-polars/src/polars/_utils/convert.py
+++ b/py-polars/src/polars/_utils/convert.py
@@ -46,7 +46,7 @@ def parse_as_duration_string(td: timedelta | str | None) -> str | None:
 
 
 def _timedelta_to_duration_string(td: timedelta) -> str:
-    """Convert a Python timedelta object to a Polars duration string."""
+    """Convert a :class:`~datetime.timedelta` object to a Polars duration string."""
     # Positive duration
     if td.days >= 0:
         d = f"{td.days}d" if td.days != 0 else ""
@@ -75,12 +75,12 @@ def negate_duration_string(duration: str) -> str:
 
 
 def date_to_int(d: date) -> int:
-    """Convert a Python time object to an integer."""
+    """Convert a :class:`~datetime.date` object to an integer."""
     return (d - EPOCH_DATE).days
 
 
 def time_to_int(t: time) -> int:
-    """Convert a Python time object to an integer."""
+    """Convert a :class:`~datetime.time` object to an integer."""
     t = t.replace(tzinfo=timezone.utc)
     seconds = t.hour * SECONDS_PER_HOUR + t.minute * 60 + t.second
     microseconds = t.microsecond
@@ -88,7 +88,7 @@ def time_to_int(t: time) -> int:
 
 
 def datetime_to_int(dt: datetime, time_unit: TimeUnit) -> int:
-    """Convert a Python datetime object to an integer."""
+    """Convert a :class:`~datetime.datetime` object to an integer."""
     # Make sure to use UTC rather than system time zone
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
@@ -108,7 +108,7 @@ def datetime_to_int(dt: datetime, time_unit: TimeUnit) -> int:
 
 
 def timedelta_to_int(td: timedelta, time_unit: TimeUnit) -> int:
-    """Convert a Python timedelta object to an integer."""
+    """Convert a :class:`~datetime.timedelta` object to an integer."""
     seconds = td.days * SECONDS_PER_DAY + td.seconds
     microseconds = td.microseconds
 
@@ -124,12 +124,12 @@ def timedelta_to_int(td: timedelta, time_unit: TimeUnit) -> int:
 
 @lru_cache(256)
 def to_py_date(value: int | float) -> date:
-    """Convert an integer or float to a Python date object."""
+    """Convert an integer or float to a :class:`~datetime.date` object."""
     return EPOCH_DATE + timedelta(days=value)
 
 
 def to_py_time(value: int) -> time:
-    """Convert an integer to a Python time object."""
+    """Convert an integer to a :class:`~datetime.time` object."""
     # Fast path for 00:00
     if value == 0:
         return time()
@@ -147,7 +147,7 @@ def to_py_datetime(
     time_unit: TimeUnit,
     time_zone: str | None = None,
 ) -> datetime:
-    """Convert an integer or float to a Python datetime object."""
+    """Convert an integer or float to a :class:`~datetime.datetime` object."""
     if time_unit == "us":
         td = timedelta(microseconds=value)
     elif time_unit == "ns":
@@ -195,7 +195,7 @@ def _parse_fixed_tz_offset(offset: str) -> tzinfo:
 
 
 def to_py_timedelta(value: int | float, time_unit: TimeUnit) -> timedelta:
-    """Convert an integer or float to a Python timedelta object."""
+    """Convert an integer or float to a :class:`~datetime.timedelta` object."""
     if time_unit == "us":
         return timedelta(microseconds=value)
     elif time_unit == "ns":
@@ -207,7 +207,7 @@ def to_py_timedelta(value: int | float, time_unit: TimeUnit) -> timedelta:
 
 
 def to_py_decimal(prec: int, value: str) -> Decimal:
-    """Convert decimal components to a Python Decimal object."""
+    """Convert decimal components to a :class:`decimal.Decimal` object."""
     return _create_decimal_with_prec(prec)(value)
 
 

--- a/py-polars/src/polars/api.py
+++ b/py-polars/src/polars/api.py
@@ -325,7 +325,7 @@ def register_lazyframe_namespace(name: str) -> Callable[[type[NS]], type[NS]]:
 
 def register_series_namespace(name: str) -> Callable[[type[NS]], type[NS]]:
     """
-    Decorator for registering custom functionality with a polars Series.
+    Decorator for registering custom functionality with a Polars Series.
 
     Parameters
     ----------

--- a/py-polars/src/polars/catalog/unity/client.py
+++ b/py-polars/src/polars/catalog/unity/client.py
@@ -335,16 +335,16 @@ class Catalog:
             - If 'append', will add new data.
             - If 'overwrite', will replace table with new data.
             - If 'ignore', will not write anything if table already exists.
-            - If 'merge', return a `TableMerger` object to merge data from the DataFrame
-              with the existing data.
+            - If 'merge', return a :class:`~deltalake.table.TableMerger` object to merge
+              data from the DataFrame with the existing data.
         delta_write_options
             (For delta tables) Additional keyword arguments while writing a
-            Delta lake Table.
-            See a list of supported write options `here <https://delta-io.github.io/delta-rs/api/delta_writer/#deltalake.write_deltalake>`__.
+            Delta Lake Table.
+            See a list of supported write options in :func:`~deltalake.write_deltalake`.
         delta_merge_options
             (For delta tables) Keyword arguments which are required to `MERGE` a
-            Delta lake Table.
-            See a list of supported merge options `here <https://delta-io.github.io/delta-rs/api/delta_table/#deltalake.DeltaTable.merge>`__.
+            Delta Lake Table. See a list of supported merge options in
+            :meth:`~deltalake.table.DeltaTable.merge`.
         storage_options
             Options that indicate how to connect to a cloud provider.
 

--- a/py-polars/src/polars/catalog/unity/models.py
+++ b/py-polars/src/polars/catalog/unity/models.py
@@ -65,7 +65,7 @@ class TableInfo:
 
     def get_polars_schema(self) -> Schema | None:
         """
-        Get the native polars schema of this table.
+        Get the native Polars schema of this table.
 
         .. warning::
             This functionality is considered **unstable**. It may be changed
@@ -102,7 +102,7 @@ class ColumnInfo:
 
     def get_polars_dtype(self) -> DataType:
         """
-        Get the native polars datatype of this column.
+        Get the native Polars datatype of this column.
 
         .. warning::
             This functionality is considered **unstable**. It may be changed

--- a/py-polars/src/polars/convert/general.py
+++ b/py-polars/src/polars/convert/general.py
@@ -317,7 +317,7 @@ def from_numpy(
     orient: Orientation | None = None,
 ) -> DataFrame:
     """
-    Construct a DataFrame from a NumPy ndarray. This operation clones data.
+    Construct a DataFrame from a :class:`numpy.ndarray`. This operation clones data.
 
     Note that this is slower than creating from columnar memory.
 
@@ -383,7 +383,7 @@ def from_torch(
     force: bool = False,
 ) -> DataFrame:
     """
-    Construct a DataFrame from a PyTorch Tensor.
+    Construct a DataFrame from a :class:`torch.Tensor`.
 
     Parameters
     ----------
@@ -483,9 +483,10 @@ def from_arrow(
 
     Parameters
     ----------
-    data : :class:`pyarrow.Table`, :class:`pyarrow.Array`, one or more :class:`pyarrow.RecordBatch`
-        Data representing an Arrow Table, Array, sequence of RecordBatches or Tables, or other
-        object that supports the Arrow PyCapsule interface.
+    data : pyarrow Table, Array, one or more RecordBatches or Tables, PyCapsule object
+        Data representing a :class:`pyarrow.Table`, :class:`pyarrow.Array`, sequence of
+        :class:`pyarrow.RecordBatch` or :class:`pyarrow.Table`, or another object that
+        supports the Arrow PyCapsule interface.
     schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
         The DataFrame schema may be declared in several ways:
 
@@ -540,7 +541,7 @@ def from_arrow(
         2
         3
     ]
-    """  # noqa: W505
+    """
     if is_pycapsule(data) and not _check_for_pyarrow(data):
         return pycapsule_to_frame(
             data,
@@ -635,21 +636,21 @@ def from_pandas(
     include_index: bool = False,
 ) -> DataFrame | Series:
     """
-    Construct a Polars DataFrame or Series from a pandas DataFrame, Series, or Index.
+    Construct a Polars DataFrame or Series from a :class:`pandas.DataFrame`, :class:`pandas.Series`, or :class:`pandas.Index`.
 
     This operation may clone data. If you want to ensure that in-place modifications
     of the output don't affect the input, you may want to consider one of the following:
 
     - Enable `Copy-On-Write <https://pandas.pydata.org/docs/dev/user_guide/copy_on_write.html>`_
-      in pandas.
+      in Pandas.
     - Call :meth:`DataFrame.clone` on the output of `from_pandas`.
 
     This requires that :mod:`pandas` and :mod:`pyarrow` are installed.
 
     Parameters
     ----------
-    data : :class:`pandas.DataFrame` or :class:`pandas.Series` or :class:`pandas.Index`
-        Data represented as a pandas DataFrame, Series, or Index.
+    data : pandas.DataFrame, pandas.Series, or pandas.Index
+        Data represented as a :class:`pandas.DataFrame`, :class:`pandas.Series`, or :class:`pandas.Index`.
     schema_overrides : dict, default None
         Support override of inferred types for one or more columns.
     rechunk : bool, default True
@@ -700,7 +701,7 @@ def from_pandas(
         2
         3
     ]
-    """
+    """  # noqa: W505
     if include_index and isinstance(data, pd.Series):
         data = data.reset_index()
 

--- a/py-polars/src/polars/convert/normalize.py
+++ b/py-polars/src/polars/convert/normalize.py
@@ -75,7 +75,7 @@ def _normalize_json(
     max_level
         recursion depth
     encoder
-        Custom JSON encoder; if not given, `json.dumps` is used.
+        Custom JSON encoder; if not given, :func:`json.dumps` is used.
     """
     if isinstance(data, dict):
         if max_level > 0:
@@ -119,7 +119,7 @@ def _normalize_json_ordered(
     max_level
         Max number of levels(depth of dict) to normalize.
     encoder
-        Custom JSON encoder; if not given, `json.dumps` is used.
+        Custom JSON encoder; if not given, :func:`json.dumps` is used.
 
     Returns
     -------
@@ -183,7 +183,7 @@ def json_normalize(
     infer_schema_length
         Number of rows to take into consideration to determine the schema.
     encoder
-        Custom JSON encoder function; if not given, `json.dumps` is used.
+        Custom JSON encoder function; if not given, :func:`json.dumps` is used.
 
     Examples
     --------

--- a/py-polars/src/polars/dataframe/group_by.py
+++ b/py-polars/src/polars/dataframe/group_by.py
@@ -941,7 +941,7 @@ class RollingGroupBy:
     """
     A rolling grouper.
 
-    This has an `.agg` method which will allow you to run all polars expressions in a
+    This has an `.agg` method which will allow you to run all Polars expressions in a
     group by context.
     """
 
@@ -1090,7 +1090,7 @@ class RollingGroupBy:
         schema
             Schema of the output function. This has to be known statically. If the
             given schema is incorrect, this is a bug in the caller's query and may
-            lead to errors. If set to None, polars assumes the schema is unchanged.
+            lead to errors. If set to None, Polars assumes the schema is unchanged.
         """
         from polars.lazyframe.opt_flags import QueryOptFlags
 

--- a/py-polars/src/polars/expr/datetime.py
+++ b/py-polars/src/polars/expr/datetime.py
@@ -508,7 +508,8 @@ class ExprDateTimeNameSpace(_NamespaceSuggestMixin):
         Parameters
         ----------
         time
-            A python time literal or polars expression/column that resolves to a time.
+            A Python :class:`~datetime.time` literal or Polars expression/column that
+            resolves to a time.
         time_unit : {'ns', 'us', 'ms'}
             Unit of time.
 
@@ -2501,7 +2502,7 @@ class ExprDateTimeNameSpace(_NamespaceSuggestMixin):
 
         Notes
         -----
-        If you're coming from pandas, you can think of this as a vectorised version
+        If you're coming from Pandas, you can think of this as a vectorised version
         of `pandas.tseries.offsets.MonthBegin().rollback(datetime)`.
 
         Examples
@@ -2552,7 +2553,7 @@ class ExprDateTimeNameSpace(_NamespaceSuggestMixin):
 
         Notes
         -----
-        If you're coming from pandas, you can think of this as a vectorised version
+        If you're coming from Pandas, you can think of this as a vectorised version
         of `pandas.tseries.offsets.MonthEnd().rollforward(datetime)`.
 
         Examples

--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -9737,7 +9737,7 @@ Consider using {self}.implode() instead"""
 
         Notes
         -----
-        Null values are preserved. If you're coming from pandas, this matches
+        Null values are preserved. If you're coming from Pandas, this matches
         their ``fill_method=None`` behaviour.
 
         Examples
@@ -12332,7 +12332,7 @@ Consider using {self}.implode() instead"""
         .. deprecated:: 0.20.11
             This method has been renamed to :meth:`deserialize`.
             Note that the new method operates on file-like inputs rather than strings.
-            Enclose your input in `io.StringIO` to keep the same behavior.
+            Enclose your input in :class:`~io.StringIO` to keep the same behavior.
 
         Parameters
         ----------

--- a/py-polars/src/polars/functions/as_datatype.py
+++ b/py-polars/src/polars/functions/as_datatype.py
@@ -329,7 +329,7 @@ def duration(
     `Expr.dt.offset_by('1d')` means "1 calendar day", which could sometimes be
     23 hours or 25 hours depending on Daylight Savings Time.
     For non-fixed durations such as "calendar month" or "calendar day",
-    please use :meth:`polars.Expr.dt.offset_by` instead.
+    please use :meth:`~polars.Expr.dt.offset_by` instead.
 
     Examples
     --------
@@ -368,7 +368,7 @@ def duration(
     │ 2022-01-16 00:00:00 ┆ 2022-01-04 00:00:00 ┆ 2022-01-02 00:00:02 ┆ 2022-01-02 00:00:00.002 ┆ 2022-01-02 02:00:00 │
     └─────────────────────┴─────────────────────┴─────────────────────┴─────────────────────────┴─────────────────────┘
 
-    If you need to add non-fixed durations, you should use :meth:`polars.Expr.dt.offset_by` instead:
+    If you need to add non-fixed durations, you should use :meth:`~polars.Expr.dt.offset_by` instead:
 
     >>> with pl.Config(tbl_width_chars=120):
     ...     df.select(

--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -212,11 +212,11 @@ def read_csv(
         Make sure that all columns are contiguous in memory by
         aggregating the chunks into a single array.
     use_pyarrow
-        Try to use pyarrow's native CSV parser. This will always
+        Try to use PyArrow's native CSV parser. This will always
         parse dates, even if `try_parse_dates=False`.
         This is not always possible. The set of arguments given to
-        this function determines if it is possible to use pyarrow's
-        native parser. Note that pyarrow and polars may have a
+        this function determines if it is possible to use PyArrow's
+        native parser. Note that PyArrow and Polars may have a
         different strategy regarding type inference.
     storage_options
         Extra options that make sense for `fsspec.open()` or a

--- a/py-polars/src/polars/io/database/_cursor_proxies.py
+++ b/py-polars/src/polars/io/database/_cursor_proxies.py
@@ -40,7 +40,7 @@ class ODBCCursorProxy:
         *,
         fetch_all: bool = False,  # noqa: ARG002
     ) -> pa.Table:
-        """Fetch all results as a pyarrow Table."""
+        """Fetch all results as a PyArrow Table."""
         from pyarrow import Table
 
         return Table.from_batches(

--- a/py-polars/src/polars/io/database/_executor.py
+++ b/py-polars/src/polars/io/database/_executor.py
@@ -360,7 +360,7 @@ class ConnectionExecutor:
 
     @staticmethod
     def _is_alchemy_async(conn: Any) -> bool:
-        """Check if the given connection is SQLALchemy async."""
+        """Check if the given connection is SQLAlchemy async."""
         try:
             from sqlalchemy.ext.asyncio import (
                 AsyncConnection,

--- a/py-polars/src/polars/io/database/functions.py
+++ b/py-polars/src/polars/io/database/functions.py
@@ -77,7 +77,8 @@ def read_database(
     ----------
     query
         SQL query to execute (if using a SQLAlchemy connection object this can
-        be a suitable "Selectable", otherwise it is expected to be a string).
+        be a suitable :class:`~sqlalchemy.sql.expression.Selectable`, otherwise it is
+        expected to be a string).
     connection
         An instantiated connection (or cursor/client object) that the query can be
         executed against. Can also pass a valid ODBC connection string (identified as
@@ -101,7 +102,7 @@ def read_database(
         a single DataFrame is yielded from the iterator.
 
         .. note::
-            If using SQLALchemy, you may also want to pass `stream_results=True` to the
+            If using SQLAlchemy, you may also want to pass `stream_results=True` to the
             connection's `execution_options` method when setting this parameter, which
             will establish a server-side cursor; without this option some drivers (such
             as "psycopg2") will still materialise the entire result set client-side

--- a/py-polars/src/polars/io/delta/_dataset.py
+++ b/py-polars/src/polars/io/delta/_dataset.py
@@ -241,7 +241,7 @@ class DeltaDataset:
         return self.table_uri_
 
     def table(self) -> DeltaTable:
-        """Fetch the DeltaTable object."""
+        """Fetch the :class:`~deltalake.table.DeltaTable` object."""
         if self.table_.get() is None:
             from deltalake.exceptions import DeltaProtocolError
             from deltalake.table import (

--- a/py-polars/src/polars/io/delta/_utils.py
+++ b/py-polars/src/polars/io/delta/_utils.py
@@ -36,7 +36,7 @@ def _get_delta_lake_table(
     delta_table_options: dict[str, Any] | None = None,
 ) -> deltalake.DeltaTable:
     """
-    Initialize a Delta lake table for use in read and scan operations.
+    Initialize a Delta Lake table for use in read and scan operations.
 
     Notes
     -----

--- a/py-polars/src/polars/io/delta/functions.py
+++ b/py-polars/src/polars/io/delta/functions.py
@@ -33,17 +33,18 @@ def read_delta(
     pyarrow_options: dict[str, Any] | None = None,
 ) -> DataFrame:
     """
-    Reads into a DataFrame from a Delta lake table.
+    Reads into a DataFrame from a Delta Lake table.
 
     Parameters
     ----------
     source
-        DeltaTable or a Path or URI to the root of the Delta lake table.
+        :class:`~deltalake.table.DeltaTable` or a Path or URI to the root of the
+        Delta Lake table.
 
         Note: For Local filesystem, absolute and relative paths are supported but
         for the supported object storages - GCS, Azure and S3 full URI must be provided.
     version
-        Numerical version or timestamp version of the Delta lake table.
+        Numerical version or timestamp version of the Delta Lake table.
 
         Note: If `version` is not provided, the latest version of delta lake
         table is read.
@@ -67,11 +68,11 @@ def read_delta(
             This functionality is considered **unstable**. It may be changed
             at any point without it being considered a breaking change.
     delta_table_options
-        Additional keyword arguments while reading a Delta lake Table.
+        Additional keyword arguments while reading a Delta Lake Table.
     use_pyarrow
-        Flag to enable pyarrow dataset reads.
+        Flag to enable PyArrow dataset reads.
     pyarrow_options
-        Keyword arguments while converting a Delta lake Table to pyarrow table.
+        Keyword arguments while converting a Delta Lake Table to PyArrow table.
 
     Returns
     -------
@@ -171,17 +172,18 @@ def scan_delta(
     rechunk: bool | None = None,
 ) -> LazyFrame:
     """
-    Lazily read from a Delta lake table.
+    Lazily read from a Delta Lake table.
 
     Parameters
     ----------
     source
-        DeltaTable or a Path or URI to the root of the Delta lake table.
+        :class:`~deltalake.table.DeltaTable` or a Path or URI to the root of the
+        Delta Lake table.
 
         Note: For Local filesystem, absolute and relative paths are supported but
         for the supported object storages - GCS, Azure and S3 full URI must be provided.
     version
-        Numerical version or timestamp version of the Delta lake table.
+        Numerical version or timestamp version of the Delta Lake table.
 
         Note: If `version` is not provided, the latest version of delta lake
         table is read.
@@ -200,11 +202,11 @@ def scan_delta(
             This functionality is considered **unstable**. It may be changed
             at any point without it being considered a breaking change.
     delta_table_options
-        Additional keyword arguments while reading a Delta lake Table.
+        Additional keyword arguments while reading a Delta Lake Table.
     use_pyarrow
-        Flag to enable pyarrow dataset reads.
+        Flag to enable PyArrow dataset reads.
     pyarrow_options
-        Keyword arguments while converting a Delta lake Table to pyarrow table.
+        Keyword arguments while converting a Delta Lake Table to PyArrow table.
         Use this parameter when filtering on partitioned columns or to read
         from a 'fsspec' supported filesystem.
     rechunk

--- a/py-polars/src/polars/io/iceberg/_utils.py
+++ b/py-polars/src/polars/io/iceberg/_utils.py
@@ -75,7 +75,7 @@ def _scan_pyarrow_dataset_impl(
     Parameters
     ----------
     tbl
-        pyarrow dataset
+        PyArrow dataset
     with_columns
         Columns that are projected
     iceberg_table_filter
@@ -85,7 +85,7 @@ def _scan_pyarrow_dataset_impl(
     snapshot_id:
         The snapshot ID to scan from.
     batch_size
-        The maximum row count for scanned pyarrow record batches.
+        The maximum row count for scanned PyArrow record batches.
     kwargs:
         For backward compatibility
 

--- a/py-polars/src/polars/io/ipc/functions.py
+++ b/py-polars/src/polars/io/ipc/functions.py
@@ -82,7 +82,7 @@ def read_ipc(
         Stop reading from IPC file after reading `n_rows`.
         Only valid when `use_pyarrow=False`.
     use_pyarrow
-        Use pyarrow or the native Rust reader.
+        Use PyArrow or the native Rust reader.
     memory_map
         Try to memory map the file. This can greatly improve performance on repeated
         queries as the OS may cache pages.
@@ -298,7 +298,7 @@ def read_ipc_stream(
         Stop reading from IPC stream after reading `n_rows`.
         Only valid when `use_pyarrow=False`.
     use_pyarrow
-        Use pyarrow or the native Rust reader.
+        Use PyArrow or the native Rust reader.
     storage_options
         Extra options that make sense for `fsspec.open()` or a particular storage
         connection, e.g. host, port, username, password, etc.

--- a/py-polars/src/polars/io/parquet/functions.py
+++ b/py-polars/src/polars/io/parquet/functions.py
@@ -174,8 +174,7 @@ def read_parquet(
         Use PyArrow instead of the Rust-native Parquet reader. The PyArrow reader is
         more stable.
     pyarrow_options
-        Keyword arguments for `pyarrow.parquet.read_table
-        <https://arrow.apache.org/docs/python/generated/pyarrow.parquet.read_table.html>`_.
+        Keyword arguments for :func:`pyarrow.parquet.read_table`.
     memory_map
         Memory map underlying file. This will likely increase performance.
         Only used when `use_pyarrow=True`.

--- a/py-polars/src/polars/io/pyarrow_dataset/functions.py
+++ b/py-polars/src/polars/io/pyarrow_dataset/functions.py
@@ -18,7 +18,7 @@ def scan_pyarrow_dataset(
     batch_size: int | None = None,
 ) -> LazyFrame:
     """
-    Scan a pyarrow dataset.
+    Scan a PyArrow :class:`~pyarrow.dataset.Dataset`.
 
     .. warning::
         This functionality is considered **unstable**. It may be changed
@@ -29,29 +29,29 @@ def scan_pyarrow_dataset(
     Parameters
     ----------
     source
-        Pyarrow dataset to scan.
+        PyArrow :class:`~pyarrow.dataset.Dataset` to scan.
     allow_pyarrow_filter
-        Allow predicates to be pushed down to pyarrow. This can lead to different
-        results if comparisons are done with null values as pyarrow handles this
+        Allow predicates to be pushed down to PyArrow. This can lead to different
+        results if comparisons are done with null values as PyArrow handles this
         different than polars does.
     batch_size
-        The maximum row count for scanned pyarrow record batches.
+        The maximum row count for scanned PyArrow record batches.
 
     Warnings
     --------
-    Don't use this if you accept untrusted user inputs. Predicates will be evaluated
-    with python 'eval'. There is sanitation in place, but it is a possible attack
-    vector.
-    This method can only can push down predicates that are allowed by PyArrow
-    (e.g. not the full Polars API).
+    * Don't use this if you accept untrusted user inputs. Predicates will be
+      evaluated with Python 'eval'. There is sanitation in place, but it is
+      a possible attack vector.
+    * This method can only push down predicates that are allowed by PyArrow
+      (e.g. not the full Polars API).
 
     If :func:`scan_parquet` works for your source, you should use that instead.
 
     Notes
     -----
     When using partitioning, the appropriate `partitioning` option must be set on
-    `pyarrow.dataset.dataset` before passing to Polars or the partitioned-on column(s)
-    may not get passed to Polars.
+    the :func:`~pyarrow.dataset.dataset` function or the partitioned-on column(s)
+    may not be passed to Polars.
 
     Examples
     --------

--- a/py-polars/src/polars/ml/torch.py
+++ b/py-polars/src/polars/ml/torch.py
@@ -34,7 +34,7 @@ __all__ = ["PolarsDataset"]
 
 class PolarsDataset(TensorDataset):  # type: ignore[misc]
     """
-    TensorDataset class specialized for use with Polars DataFrames.
+    Specialized :class:`~torch.utils.data.TensorDataset` class for use with Polars DataFrames.
 
     .. warning::
         This functionality is considered **unstable**. It may be changed
@@ -87,7 +87,8 @@ class PolarsDataset(TensorDataset):  # type: ignore[misc]
     >>> ds[0]
     (tensor([1.0000, 1.5000]), tensor(0.))
 
-    The Dataset can be used standalone, or in conjunction with a DataLoader.
+    The Dataset can be used standalone, or in conjunction with a
+    :class:`~torch.utils.data.DataLoader`.
 
     >>> dl = DataLoader(ds, batch_size=2)
     >>> list(dl)
@@ -110,7 +111,7 @@ class PolarsDataset(TensorDataset):  # type: ignore[misc]
     >>> ds[:2]
     (tensor([[ 1.0000,  1.5000],
     [ 0.0000, -0.5000]]), tensor([0, 8], dtype=torch.int16))
-    """
+    """  # noqa: W505
 
     tensors: tuple[Tensor, ...]
     labels: Tensor | None

--- a/py-polars/src/polars/schema.py
+++ b/py-polars/src/polars/schema.py
@@ -102,7 +102,7 @@ class Schema(BaseSchema):
     >>> schema.len()
     3
 
-    Import a pyarrow schema.
+    Import a PyArrow schema.
 
     >>> import pyarrow as pa
     >>> pl.Schema(pa.schema([pa.field("x", pa.int32())]))
@@ -206,7 +206,7 @@ class Schema(BaseSchema):
     @unstable()
     def to_arrow(self, *, compat_level: CompatLevel | None = None) -> pa.Schema:
         """
-        Convert the schema to a pyarrow schema.
+        Convert the schema to a PyArrow schema.
 
         Parameters
         ----------

--- a/py-polars/src/polars/selectors.py
+++ b/py-polars/src/polars/selectors.py
@@ -125,7 +125,7 @@ def expand_selector(
     target
         A Polars DataFrame, LazyFrame or Schema.
     selector
-        An arbitrary polars selector (or compound selector).
+        An arbitrary Polars selector (or compound selector).
     strict
         Setting False additionally allows for a broader range of column selection
         expressions (such as bare columns or use of `.exclude()`) to be expanded,

--- a/py-polars/src/polars/series/datetime.py
+++ b/py-polars/src/polars/series/datetime.py
@@ -147,7 +147,7 @@ class DateTimeNameSpace(_NamespaceSuggestMixin):
 
     def min(self) -> dt.date | dt.datetime | dt.timedelta | None:
         """
-        Return minimum as Python datetime.
+        Return minimum as Python :class:`~datetime.datetime`.
 
         Examples
         --------
@@ -160,7 +160,7 @@ class DateTimeNameSpace(_NamespaceSuggestMixin):
 
     def max(self) -> dt.date | dt.datetime | dt.timedelta | None:
         """
-        Return maximum as Python datetime.
+        Return maximum as Python :class:`~datetime.datetime`.
 
         Examples
         --------
@@ -2107,7 +2107,8 @@ class DateTimeNameSpace(_NamespaceSuggestMixin):
         Parameters
         ----------
         time
-            A python time literal or Series of the same length as this Series.
+            A Python :class:`~datetime.time` literal or Series of the same length
+            as this Series.
         time_unit : {'ns', 'us', 'ms'}
             Unit of time.
 
@@ -2138,7 +2139,7 @@ class DateTimeNameSpace(_NamespaceSuggestMixin):
 
         Notes
         -----
-        If you're coming from pandas, you can think of this as a vectorised version
+        If you're coming from Pandas, you can think of this as a vectorised version
         of `pandas.tseries.offsets.MonthBegin().rollback(datetime)`.
 
         Examples
@@ -2169,7 +2170,7 @@ class DateTimeNameSpace(_NamespaceSuggestMixin):
 
         Notes
         -----
-        If you're coming from pandas, you can think of this as a vectorised version
+        If you're coming from Pandas, you can think of this as a vectorised version
         of `pandas.tseries.offsets.MonthEnd().rollforward(datetime)`.
 
         Examples

--- a/py-polars/src/polars/series/list.py
+++ b/py-polars/src/polars/series/list.py
@@ -601,7 +601,7 @@ class ListNameSpace(_NamespaceSuggestMixin):
 
         See Also
         --------
-        :meth:`Series.list.get` : Get the value by index in the sublists.
+        :meth:`~Series.list.get` : Get the value by index in the sublists.
 
         Examples
         --------

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -182,7 +182,7 @@ class Series:
         When not specified, name is set to an empty string.
     values : ArrayLike, default None
         One-dimensional data in various forms. Supported are: Sequence, Series,
-        pyarrow Array, and numpy ndarray.
+        :class:`pyarrow.Array`, and :class:`numpy.ndarray`.
     dtype : DataType, default None
         Data type of the resulting Series. If set to `None` (default), the data type is
         inferred from the `values` input. The strategy for data type inference depends
@@ -1577,13 +1577,15 @@ class Series:
         copy: bool | None = None,  # noqa: FBT001
     ) -> np.ndarray[Any, Any]:
         """
-        Return a NumPy ndarray with the given data type.
+        Return a :class:`numpy.ndarray` with the given data type.
 
-        This method ensures a Polars Series can be treated as a NumPy ndarray.
-        It enables `np.asarray` and NumPy universal functions.
+        This method ensures a Polars Series can be treated as a
+        :class:`numpy.ndarray`. It enables :func:`numpy.asarray` and NumPy universal
+        functions.
 
-        See the NumPy documentation for more information:
-        https://numpy.org/doc/stable/user/basics.interoperability.html#the-array-method
+        See the `NumPy interoperability documentation
+        <https://numpy.org/doc/stable/user/basics.interoperability.html#the-array-method>`_
+        for more information.
 
         See Also
         --------
@@ -4692,10 +4694,7 @@ class Series:
 
         Examples
         --------
-        Replicating the pandas
-        `pd.Series.factorize
-        <https://pandas.pydata.org/docs/reference/api/pandas.Series.factorize.html>`_
-        method.
+        Replicating the :meth:`pandas.Series.factorize` method.
 
         >>> s = pl.Series("values", ["a", None, "x", "a"])
         >>> s.cast(pl.Categorical).to_physical()
@@ -4930,7 +4929,7 @@ class Series:
         zero_copy_only: bool | None = None,
     ) -> np.ndarray[Any, Any]:
         """
-        Convert this Series to a NumPy ndarray.
+        Convert this Series to a :class:`numpy.ndarray`.
 
         This operation copies data only when necessary. The conversion is zero copy when
         all of the following hold:
@@ -4951,10 +4950,8 @@ class Series:
             causes conversions that are not zero-copy to fail.
 
         use_pyarrow
-            First convert to PyArrow, then call `pyarrow.Array.to_numpy
-            <https://arrow.apache.org/docs/python/generated/pyarrow.Array.html#pyarrow.Array.to_numpy>`_
-            to convert to NumPy. If set to `False`, Polars' own conversion logic is
-            used.
+            First convert to PyArrow, then call :meth:`pyarrow.Array.to_numpy` to
+            convert to NumPy. If set to `False`, Polars' own conversion logic is used.
 
             .. deprecated:: 0.20.28
                 Polars now uses its native engine by default for conversion to NumPy.
@@ -5044,7 +5041,7 @@ class Series:
     @unstable()
     def to_jax(self, device: jax.Device | str_ | None = None) -> jax.Array:
         """
-        Convert this Series to a Jax Array.
+        Convert this Series to a :class:`jax.Array`.
 
         .. versionadded:: 0.20.27
 
@@ -5055,11 +5052,11 @@ class Series:
         Parameters
         ----------
         device
-            Specify the jax `Device` on which the array will be created; can provide
-            a string (such as "cpu", "gpu", or "tpu") in which case the device is
-            retrieved as `jax.devices(string)[0]`. For more specific control you
-            can supply the instantiated `Device` directly. If None, arrays are
-            created on the default device.
+            Specify the :class:`jax.Device` on which the array will be created; can
+            provide a string (such as "cpu", "gpu", or "tpu") in which case the device
+            is retrieved as `jax.devices(string)[0]`. For more specific control you
+            can supply the instantiated :class:`jax.Device` directly. If None, arrays
+            are created on the default device.
 
         Examples
         --------
@@ -5094,7 +5091,7 @@ class Series:
     @unstable()
     def to_torch(self) -> torch.Tensor:
         """
-        Convert this Series to a PyTorch Tensor.
+        Convert this Series to a :class:`torch.Tensor`.
 
         .. versionadded:: 0.20.23
 
@@ -8614,7 +8611,7 @@ class Series:
 
         Notes
         -----
-        Null values are preserved. If you're coming from pandas, this matches
+        Null values are preserved. If you're coming from Pandas, this matches
         their ``fill_method=None`` behaviour.
 
         Examples

--- a/py-polars/src/polars/sql/context.py
+++ b/py-polars/src/polars/sql/context.py
@@ -157,12 +157,13 @@ class SQLContext(Generic[FrameType]):
         ----------
         frames
             A `{name:frame, ...}` mapping which can include Polars frames *and*
-            pandas DataFrames, Series and pyarrow Table and RecordBatch objects.
+            :class:`pandas.DataFrame`, :class:`pandas.Series`, :class:`pyarrow.Table`,
+            and :class:`pyarrow.RecordBatch` objects.
         register_globals
-            Register compatible objects (polars DataFrame, LazyFrame, and Series) found
-            in the globals, automatically mapping their variable name to a table name.
-            To register other objects (pandas/pyarrow data) pass them explicitly, or
-            call the `execute_global` classmethod. If given an integer then only the
+            Register compatible objects (Polars `DataFrame`, `LazyFrame`, and `Series`)
+            found in the globals, automatically mapping their variable name to a table
+            name. To register other objects (Pandas/PyArrow data) pass them explicitly,
+            or call the `execute_global` classmethod. If given an integer then only the
             most recent "n" objects found will be registered.
         eager
             If True, returns execution results as `DataFrame` instead of `LazyFrame`.
@@ -229,13 +230,13 @@ class SQLContext(Generic[FrameType]):
 
         Notes
         -----
-        * This convenience method automatically registers all compatible objects in
-          the local stack that are referenced in the query, mapping their variable name
-          to a table name. Note that in addition to polars DataFrame, LazyFrame, and
-          Series this method *also* registers pandas DataFrame, Series, and pyarrow
-          Table and RecordBatch objects.
+        * This convenience method automatically registers all compatible objects in the
+          local stack that are referenced in the query, mapping their variable name to a
+          table name. Note that in addition to polars DataFrame, LazyFrame, and Series
+          this method also registers :class:`pandas.DataFrame`, :class:`pandas.Series`,
+          :class:`pyarrow.Table`, and :class:`pyarrow.RecordBatch` objects.
         * Instead of calling this classmethod you should consider using `pl.sql`,
-          which will use this code internally.
+          which uses this code internally.
 
         Parameters
         ----------
@@ -482,8 +483,9 @@ class SQLContext(Generic[FrameType]):
         n
             Register only the most recent "n" frames.
         all_compatible
-            Control whether we *also* register pandas DataFrame, Series, and
-            pyarrow Table and RecordBatch objects. If False, only Polars
+            Control whether we *also* register :class:`pandas.DataFrame`,
+            :class:`pandas.Series`, and :class:`pyarrow.Table` and
+            :class:`pyarrow.RecordBatch` objects. If False, only Polars
             classes are registered with the SQL engine.
 
         Examples

--- a/py-polars/src/polars/sql/functions.py
+++ b/py-polars/src/polars/sql/functions.py
@@ -33,8 +33,9 @@ def sql(query: str, *, eager: bool = False) -> DataFrame | LazyFrame:
 
     Notes
     -----
-    * The Polars SQL engine can operate against Polars DataFrame, LazyFrame, and Series
-      objects, as well as Pandas DataFrame and Series, PyArrow Table and RecordBatch.
+    * The Polars SQL engine can operate against Polars `DataFrame`, `LazyFrame`, and
+      `Series` objects, as well as :class:`pandas.DataFrame` and :class:`pandas.Series`,
+      :class:`pyarrow.Table` and :class:`pyarrow.RecordBatch`.
     * Additional control over registration and execution behaviour is available
       with the :class:`SQLContext` object.
 

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -542,7 +542,7 @@ def test_to_pandas(test_data: list[Any]) -> None:
         vals_c = [None if x is pd.NA else x for x in c.tolist()]
         assert vals_c == test_data
     except ModuleNotFoundError:
-        # Skip test if pandas>=1.5.0 or Pyarrow>=8.0.0 is not installed.
+        # Skip test if pandas>=1.5.0 or pyarrow>=8.0.0 is not installed.
         pass
 
 


### PR DESCRIPTION
Recently added some of the below `intersphinx`[^1] mappings for some docs at work, so extending them here too ;)

* Extended/improved the links/build for the Sphinx docs.
* Adds `deltalake`, `jax`, `sqlalchemy`, and `torch` mappings.
* Llinks a few more objects from the docstrings.
* Adds an (optional) local cache/fallback for the "inv" files.

[^1]: `sphinx.ext.intersphinx`
https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html