### PR TITLE
fix: Use local unicode tables instead of private core::unicode internals

### DIFF
--- a/crates/polars-ops/src/chunked_array/strings/case.rs
+++ b/crates/polars-ops/src/chunked_array/strings/case.rs
@@ -75,10 +75,6 @@ fn to_lowercase_helper(s: &str, buf: &mut Vec<u8>) {
     }
 
     fn case_ignorable_then_cased<I: Iterator<Item = char>>(iter: I) -> bool {
-        #[cfg(feature = "nightly")]
-        use core::unicode::{Case_Ignorable, Cased};
-
-        #[cfg(not(feature = "nightly"))]
         use super::unicode_internals::{Case_Ignorable, Cased};
         #[allow(clippy::skip_while_next)]
         match iter.skip_while(|&c| Case_Ignorable(c)).next() {


### PR DESCRIPTION
## Summary
- Remove the `#[cfg(feature = "nightly")]` import of `core::unicode::{Case_Ignorable, Cased}` which are `pub(crate)` in the standard library and became inaccessible in recent Rust nightly builds
- Always use the existing local `unicode_internals` fallback that was already in place for non-nightly builds

Fixes #27130

## Test plan
- [x] `cargo check -p polars-ops --features nightly` compiles successfully
- [x] `cargo check -p polars-ops` (without nightly) compiles successfully
- The `unicode_internals` module contains the same Unicode lookup tables, so behavior is unchanged