### PR TITLE
fix: Handle sliced list arrays correctly in Avro writer

### DIFF
--- a/crates/polars-arrow/src/io/avro/write/serialize.rs
+++ b/crates/polars-arrow/src/io/avro/write/serialize.rs
@@ -103,6 +103,13 @@ fn list_required<'a, O: Offset>(array: &'a ListArray<O>, schema: &AvroSchema) ->
         .windows(2)
         .map(|w| (w[1] - w[0]).to_usize() as i64);
 
+    // For sliced arrays, the values array is not sliced but offsets are adjusted.
+    // Skip past the values before the first offset.
+    let first_offset = array.offsets().first().to_usize();
+    for _ in 0..first_offset {
+        inner.next();
+    }
+
     Box::new(BufStreamingIterator::new(
         lengths,
         move |length, buf| {
@@ -129,6 +136,13 @@ fn list_optional<'a, O: Offset>(array: &'a ListArray<O>, schema: &AvroSchema) ->
         .windows(2)
         .map(|w| (w[1] - w[0]).to_usize() as i64);
     let lengths = ZipValidity::new_with_validity(lengths, array.validity());
+
+    // For sliced arrays, the values array is not sliced but offsets are adjusted.
+    // Skip past the values before the first offset.
+    let first_offset = array.offsets().first().to_usize();
+    for _ in 0..first_offset {
+        inner.next();
+    }
 
     Box::new(BufStreamingIterator::new(
         lengths,


### PR DESCRIPTION
## Summary
- When a sliced DataFrame with list columns is written to Avro, the inner values serializer started from position 0 of the unsliced values array while offsets were correctly adjusted, causing list values to be replaced with data from early rows
- Skip past the values before the first offset in both `list_required` and `list_optional` Avro serializers

Fixes #27090

## Test plan
- [x] Reproduction script confirms sliced `list[str]`, `list[i64]`, and nullable list columns roundtrip correctly through Avro
- [x] Full DataFrame (non-sliced) write continues to work
- [ ] CI