### PR TITLE
fix(rust): Preserve scalar inputs for streaming string replace

### DIFF
--- a/crates/polars-expr/src/dispatch/strings.rs
+++ b/crates/polars-expr/src/dispatch/strings.rs
@@ -744,6 +744,8 @@ pub(super) fn replace(s: &[Column], literal: bool, n: i64) -> PolarsResult<Colum
     let all = n < 0;
 
     let column = column.str()?;
+    let pat = pat.as_materialized_series_maintain_scalar();
+    let val = val.as_materialized_series_maintain_scalar();
     let pat = pat.str()?;
     let val = val.str()?;
 

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -1696,6 +1696,34 @@ fn test_single_group_result() -> PolarsResult<()> {
 }
 
 #[test]
+#[cfg(all(feature = "new_streaming", feature = "regex", feature = "strings"))]
+fn test_streaming_string_replace_with_scalar_agg_pattern() -> PolarsResult<()> {
+    let df = df![
+        "foo" => ["123 bla 45 asd", "xyz 678 910t"],
+        "value" => ["A", "B"],
+    ]?;
+
+    let query = df.lazy().select([col("foo")
+        .str()
+        .replace(col("foo").first(), col("value"), false)
+        .alias("foo")]);
+
+    let expected = df!["foo" => ["A", "xyz 678 910t"]]?;
+    let in_memory = query
+        .clone()
+        .collect_with_engine(Engine::InMemory)?
+        .unwrap_single();
+    let streaming = query
+        .collect_with_engine(Engine::Streaming)?
+        .unwrap_single();
+
+    assert!(in_memory.equals_missing(&expected));
+    assert!(streaming.equals_missing(&expected));
+    assert!(streaming.equals_missing(&in_memory));
+    Ok(())
+}
+
+#[test]
 #[cfg(feature = "rank")]
 fn test_single_ranked_group() -> PolarsResult<()> {
     // tests type consistency of rank algorithm


### PR DESCRIPTION
Closes #26789.

## Summary

Single-thread streaming materialized scalar aggregation inputs for str.replace into full-length string columns before dispatch. That converted the broadcasted scalar pattern into a length-N pattern column and hit the existing unsupported dynamic-pattern path.

This change preserves scalar columns for pat and al via s_materialized_series_maintain_scalar(), so the intended scalar replace path is used.

## Test

- added 	est_streaming_string_replace_with_scalar_agg_pattern
- re-ran the targeted regression test with POLARS_MAX_THREADS=1

## AI disclosure

AI-assisted code generation was used for this change. All code and test changes were reviewed manually before submission.