### PR TITLE
fix: Output SVG if output_path ends with '.svg' in show_graph

### DIFF
--- a/py-polars/src/polars/_utils/various.py
+++ b/py-polars/src/polars/_utils/various.py
@@ -680,7 +680,7 @@ def display_dot_graph(
 
     output_type = (
         "svg"
-        if output_path.endswith(".svg")
+        if (output_path is not None and str(output_path).endswith(".svg"))
         or _in_notebook()
         or _in_marimo_notebook()
         or "POLARS_DOT_SVG_VIEWER" in os.environ


### PR DESCRIPTION
Currently we'd still write PNG data to the file.