### PR TITLE
chore: Update nightly Rust compiler version

### DIFF
--- a/crates/polars-arrow/src/bitmap/mutable.rs
+++ b/crates/polars-arrow/src/bitmap/mutable.rs
@@ -623,10 +623,8 @@ impl MutableBitmap {
             }
             // the iterator will not fill the last byte
             let byte = self.buffer.last_mut().unwrap();
-            let mut i = bit_offset;
-            for value in iterator {
+            for (i, value) in (bit_offset..).zip(iterator) {
                 *byte = set_bit_in_byte(*byte, i, value);
-                i += 1;
             }
             self.length += length;
             return;

--- a/crates/polars-arrow/src/legacy/kernels/sorted_join/inner.rs
+++ b/crates/polars-arrow/src/legacy/kernels/sorted_join/inner.rs
@@ -21,6 +21,7 @@ pub fn join<T: PartialOrd + Copy + Debug>(
     let first_right = right[0];
     let mut left_idx = left.partition_point(|v| v < &first_right) as IdxSize;
 
+    #[allow(clippy::explicit_counter_loop)]
     for &val_l in &left[left_idx as usize..] {
         while let Some(&val_r) = right.get(right_idx as usize) {
             // matching join key
@@ -38,15 +39,13 @@ pub fn join<T: PartialOrd + Copy + Debug>(
                             right_idx = current_idx;
                             break;
                         },
-                        Some(&val_r) => {
-                            if val_l == val_r {
-                                out_lhs.push(left_idx + left_offset);
-                                out_rhs.push(right_idx);
-                            } else {
-                                // reset right index because the next lhs value can be the same
-                                right_idx = current_idx;
-                                break;
-                            }
+                        Some(&val_r) if val_l == val_r => {
+                            out_lhs.push(left_idx + left_offset);
+                            out_rhs.push(right_idx);
+                        },
+                        Some(_) => {
+                            right_idx = current_idx;
+                            break;
                         },
                     }
                 }

--- a/crates/polars-arrow/src/legacy/kernels/sorted_join/left.rs
+++ b/crates/polars-arrow/src/legacy/kernels/sorted_join/left.rs
@@ -33,6 +33,7 @@ pub fn join<T: PartialOrd + Copy + Debug>(
     ));
     out_lhs.extend(left_offset..(left_idx + left_offset));
 
+    #[allow(clippy::explicit_counter_loop)]
     for &val_l in &left[left_idx as usize..] {
         loop {
             match right.get(right_idx as usize) {
@@ -52,15 +53,14 @@ pub fn join<T: PartialOrd + Copy + Debug>(
                                     right_idx = current_idx;
                                     break;
                                 },
-                                Some(&val_r) => {
-                                    if val_l == val_r {
-                                        out_lhs.push(left_idx + left_offset);
-                                        out_rhs.push(right_idx.into());
-                                    } else {
-                                        // reset right index because the next lhs value can be the same
-                                        right_idx = current_idx;
-                                        break;
-                                    }
+                                Some(&val_r) if val_l == val_r => {
+                                    out_lhs.push(left_idx + left_offset);
+                                    out_rhs.push(right_idx.into());
+                                },
+                                Some(_) => {
+                                    // reset right index because the next lhs value can be the same
+                                    right_idx = current_idx;
+                                    break;
                                 },
                             }
                         }

--- a/crates/polars-compute/src/rolling/nulls/mod.rs
+++ b/crates/polars-compute/src/rolling/nulls/mod.rs
@@ -75,14 +75,11 @@ where
             // we are in bounds
             unsafe { agg_window.update(start, end) };
             match agg_window.get_agg(idx) {
-                Some(val) => {
-                    if agg_window.is_valid(min_periods) {
-                        val
-                    } else {
-                        // SAFETY: we are in bounds
-                        unsafe { validity.set_unchecked(idx, false) };
-                        Out::default()
-                    }
+                Some(val) if agg_window.is_valid(min_periods) => val,
+                Some(_) => {
+                    // SAFETY: we are in bounds
+                    unsafe { validity.set_unchecked(idx, false) };
+                    Out::default()
                 },
                 None => {
                     // SAFETY: we are in bounds

--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -147,7 +147,8 @@ impl AnyValue<'static> {
         numeric_to_one: bool,
         num_list_values: usize,
     ) -> AnyValue<'static> {
-        use {AnyValue as AV, DataType as DT};
+        use AnyValue as AV;
+        use DataType as DT;
         match dtype {
             DT::Boolean => AV::Boolean(false),
             DT::UInt8 => AV::UInt8(numeric_to_one.into()),

--- a/crates/polars-core/src/scalar/serde.rs
+++ b/crates/polars-core/src/scalar/serde.rs
@@ -249,7 +249,7 @@ impl TryFrom<Scalar> for SerializableScalar {
 
                 Self::Struct(
                     avs.into_iter()
-                        .zip(fields.into_iter())
+                        .zip(fields)
                         .map(|(av, field)| {
                             PolarsResult::Ok((
                                 field.name,

--- a/crates/polars-core/src/series/arrow_export/mod.rs
+++ b/crates/polars-core/src/series/arrow_export/mod.rs
@@ -441,12 +441,12 @@ impl ToArrowConverter {
             for (pl_dtype, arrow_field) in iter {
                 match pl_dtype {
                     #[cfg(feature = "dtype-categorical")]
-                    DataType::Categorical(..) | DataType::Enum(..) => {
-                        if !matches!(arrow_field.dtype(), ArrowDataType::Dictionary(..)) {
-                            // IPC sink can hit here when it exports only the keys of the categorical.
-                            // In this case we do not want to attach categorical metadata.
-                            continue;
-                        }
+                    DataType::Categorical(..) | DataType::Enum(..)
+                        if !matches!(arrow_field.dtype(), ArrowDataType::Dictionary(..)) =>
+                    {
+                        // IPC sink can hit here when it exports only the keys of the categorical.
+                        // In this case we do not want to attach categorical metadata.
+                        continue;
                     },
                     _ => {},
                 }

--- a/crates/polars-core/src/testing.rs
+++ b/crates/polars-core/src/testing.rs
@@ -18,10 +18,8 @@ impl Series {
             // Two [`Datetime`](DataType::Datetime) series are *not* equal if their timezones
             // are different, regardless if they represent the same UTC time or not.
             #[cfg(feature = "timezones")]
-            (DataType::Datetime(_, tz_lhs), DataType::Datetime(_, tz_rhs)) => {
-                if tz_lhs != tz_rhs {
-                    return false;
-                }
+            (DataType::Datetime(_, tz_lhs), DataType::Datetime(_, tz_rhs)) if tz_lhs != tz_rhs => {
+                return false;
             },
             _ => {},
         }

--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -9,16 +9,17 @@ use std::ops::{Deref, DerefMut};
 mod schema;
 
 pub use any_value::*;
+pub use arrow;
 use arrow::bitmap::Bitmap;
 pub use arrow::legacy::utils::*;
 pub use arrow::trusted_len::TrustMyLength;
 use flatten::*;
 use num_traits::{One, Zero};
+pub use rayon;
 use rayon::prelude::*;
 pub use schema::*;
 pub use series::*;
 pub use supertype::*;
-pub use {arrow, rayon};
 
 use crate::POOL;
 use crate::prelude::*;

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -250,10 +250,10 @@ fn create_physical_expr_inner(
                     AExpr::Agg(_) => {
                         agg_col = true;
                     },
-                    AExpr::Function { options, .. } | AExpr::AnonymousFunction { options, .. } => {
-                        if options.flags.returns_scalar() {
-                            agg_col = true;
-                        }
+                    AExpr::Function { options, .. } | AExpr::AnonymousFunction { options, .. }
+                        if options.flags.returns_scalar() =>
+                    {
+                        agg_col = true;
                     },
                     _ => {},
                 }

--- a/crates/polars-expr/src/reduce/approx_n_unique.rs
+++ b/crates/polars-expr/src/reduce/approx_n_unique.rs
@@ -8,8 +8,9 @@ use super::*;
 
 pub fn new_approx_n_unique_reduction(dtype: DataType) -> PolarsResult<Box<dyn GroupedReduction>> {
     // TODO: Move the error checks up and make this function infallible
+    use ApproxNUniqueReducer as R;
     use DataType::*;
-    use {ApproxNUniqueReducer as R, VecGroupedReduction as VGR};
+    use VecGroupedReduction as VGR;
     Ok(match dtype {
         Boolean => Box::new(VGR::new(dtype, R::<BooleanType>::default())),
         _ if dtype.is_primitive_numeric() || dtype.is_temporal() => {

--- a/crates/polars-io/src/file_cache/file_fetcher.rs
+++ b/crates/polars-io/src/file_cache/file_fetcher.rs
@@ -97,7 +97,7 @@ impl FileFetcher for CloudFileFetcher {
             pl_async::get_runtime().block_in_place_on(self.object_store.head(&self.cloud_path))?;
 
         Ok(RemoteMetadata {
-            size: metadata.size as u64,
+            size: metadata.size,
             version: metadata
                 .e_tag
                 .map(|x| FileVersion::ETag(blake3::hash(x.as_bytes()).to_hex()[..32].to_string()))

--- a/crates/polars-io/src/predicates.rs
+++ b/crates/polars-io/src/predicates.rs
@@ -118,7 +118,8 @@ impl ParquetColumnExpr for ColumnPredicateExpr {
 
 #[cfg(feature = "parquet")]
 fn cast_to_parquet_scalar(scalar: Scalar) -> Option<ParquetScalar> {
-    use {AnyValue as A, ParquetScalar as P};
+    use AnyValue as A;
+    use ParquetScalar as P;
 
     Some(match scalar.into_value() {
         A::Null => P::Null,

--- a/crates/polars-ops/src/chunked_array/strings/case.rs
+++ b/crates/polars-ops/src/chunked_array/strings/case.rs
@@ -75,10 +75,6 @@ fn to_lowercase_helper(s: &str, buf: &mut Vec<u8>) {
     }
 
     fn case_ignorable_then_cased<I: Iterator<Item = char>>(iter: I) -> bool {
-        #[cfg(feature = "nightly")]
-        use core::unicode::{Case_Ignorable, Cased};
-
-        #[cfg(not(feature = "nightly"))]
         use super::unicode_internals::{Case_Ignorable, Cased};
         #[allow(clippy::skip_while_next)]
         match iter.skip_while(|&c| Case_Ignorable(c)).next() {

--- a/crates/polars-ops/src/chunked_array/strings/find_many.rs
+++ b/crates/polars-ops/src/chunked_array/strings/find_many.rs
@@ -219,7 +219,7 @@ pub fn extract_many(
             let (ca, patterns) = align_chunks_binary(ca, patterns);
 
             for (arr, pat_arr) in ca.downcast_iter().zip(patterns.downcast_iter()) {
-                for z in arr.into_iter().zip(pat_arr.into_iter()) {
+                for z in arr.into_iter().zip(pat_arr) {
                     match z {
                         (None, _) | (_, None) => builder.append_null(),
                         (Some(val), Some(pat)) => {
@@ -311,7 +311,7 @@ pub fn find_many(
             let (ca, patterns) = align_chunks_binary(ca, patterns);
 
             for (arr, pat_arr) in ca.downcast_iter().zip(patterns.downcast_iter()) {
-                for z in arr.into_iter().zip(pat_arr.into_iter()) {
+                for z in arr.into_iter().zip(pat_arr) {
                     match z {
                         (None, _) | (_, None) => builder.append_null(),
                         (Some(val), Some(pat)) => {

--- a/crates/polars-ops/src/chunked_array/strings/mod.rs
+++ b/crates/polars-ops/src/chunked_array/strings/mod.rs
@@ -24,7 +24,7 @@ mod split;
 mod strip;
 #[cfg(feature = "strings")]
 mod substring;
-#[cfg(all(not(feature = "nightly"), feature = "strings"))]
+#[cfg(feature = "strings")]
 mod unicode_internals;
 
 #[cfg(feature = "strings")]

--- a/crates/polars-ops/src/chunked_array/strings/split.rs
+++ b/crates/polars-ops/src/chunked_array/strings/split.rs
@@ -315,7 +315,7 @@ pub fn split_regex_helper(
             let mut builder =
                 ListStringChunkedBuilder::new(ca.name().clone(), ca.len(), ca.get_values_size());
 
-            for (opt_s, opt_pat) in ca.into_iter().zip(by.into_iter()) {
+            for (opt_s, opt_pat) in ca.into_iter().zip(by) {
                 match (opt_s, opt_pat) {
                     (Some(s), Some(pat)) => append_split(&mut builder, s, pat, inclusive, strict)?,
                     _ => builder.append_null(),

--- a/crates/polars-ops/src/lib.rs
+++ b/crates/polars-ops/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(feature = "nightly", feature(unicode_internals))]
 #![cfg_attr(feature = "nightly", allow(internal_features))]
 #![cfg_attr(
     feature = "allow_unused",

--- a/crates/polars-parquet/src/arrow/read/deserialize/binview/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binview/mod.rs
@@ -536,7 +536,8 @@ impl utils::Decoder for BinViewDecoder {
             return Ok(false);
         };
 
-        use {SpecializedParquetColumnExpr as Spce, StateTranslation as St};
+        use SpecializedParquetColumnExpr as Spce;
+        use StateTranslation as St;
         match (&state.translation, predicate) {
             (St::Plain(iter), Spce::Equal(needle)) => {
                 assert!(!needle.is_null());

--- a/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
@@ -299,7 +299,8 @@ pub enum InitNested {
 
 /// Initialize [`NestedState`] from `&[InitNested]`.
 pub fn init_nested(init: &[InitNested], capacity: usize) -> NestedState {
-    use {InitNested as IN, Nested as N};
+    use InitNested as IN;
+    use Nested as N;
 
     let container = init
         .iter()

--- a/crates/polars-parquet/src/arrow/read/statistics.rs
+++ b/crates/polars-parquet/src/arrow/read/statistics.rs
@@ -170,7 +170,8 @@ impl ColumnStatistics {
             }};
         }
 
-        use {ArrowDataType as D, ParquetPhysicalType as PPT};
+        use ArrowDataType as D;
+        use ParquetPhysicalType as PPT;
         let (min_value, max_value) = match (self.field.dtype(), &self.physical_type) {
             (D::Null, _) => (None, None),
 
@@ -399,7 +400,8 @@ pub fn deserialize_all(
                 }};
             }
 
-            use {ArrowDataType as D, ParquetPhysicalType as PPT};
+            use ArrowDataType as D;
+            use ParquetPhysicalType as PPT;
             let (min_value, max_value) = match (field.dtype(), physical_type) {
                 (D::Null, _) => (
                     NullArray::new(ArrowDataType::Null, row_groups.len()).to_boxed(),

--- a/crates/polars-parquet/src/lib.rs
+++ b/crates/polars-parquet/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(feature = "simd", feature(portable_simd))]
 #![allow(clippy::len_without_is_empty)]
 pub mod arrow;
 pub use crate::arrow::{read, write};

--- a/crates/polars-parquet/src/parquet/statistics/mod.rs
+++ b/crates/polars-parquet/src/parquet/statistics/mod.rs
@@ -78,7 +78,8 @@ impl Statistics {
         statistics: &ParquetStatistics,
         primitive_type: PrimitiveType,
     ) -> ParquetResult<Self> {
-        use {PhysicalType as T, PrimitiveStatistics as PrimStat};
+        use PhysicalType as T;
+        use PrimitiveStatistics as PrimStat;
         let mut stats: Self = match primitive_type.physical_type {
             T::ByteArray => BinaryStatistics::deserialize(statistics, primitive_type)?.into(),
             T::Boolean => BooleanStatistics::deserialize(statistics)?.into(),

--- a/crates/polars-plan/src/dsl/expr/mod.rs
+++ b/crates/polars-plan/src/dsl/expr/mod.rs
@@ -512,13 +512,11 @@ impl Expr {
     pub fn extract_usize(&self) -> PolarsResult<usize> {
         match self {
             Expr::Literal(n) => n.extract_usize(),
-            Expr::Cast { expr, dtype, .. } => {
+            Expr::Cast { expr, dtype, .. }
+                if dtype.as_literal().is_some_and(|dt| dt.is_integer()) =>
+            {
                 // lit(x, dtype=...) are Cast expressions. We verify the inner expression is literal.
-                if dtype.as_literal().is_some_and(|dt| dt.is_integer()) {
-                    expr.extract_usize()
-                } else {
-                    polars_bail!(InvalidOperation: "expression must be constant literal to extract integer")
-                }
+                expr.extract_usize()
             },
             _ => {
                 polars_bail!(InvalidOperation: "expression must be constant literal to extract integer")
@@ -537,12 +535,11 @@ impl Expr {
                 },
                 _ => unreachable!(),
             },
-            Expr::Cast { expr, dtype, .. } => {
-                if dtype.as_literal().is_some_and(|dt| dt.is_integer()) {
-                    expr.extract_i64()
-                } else {
-                    polars_bail!(InvalidOperation: "expression must be constant literal to extract integer")
-                }
+            Expr::Cast { expr, dtype, .. }
+                if dtype.as_literal().is_some_and(|dt| dt.is_integer()) =>
+            {
+                // lit(x, dtype=...) are Cast expressions. We verify the inner expression is literal.
+                expr.extract_i64()
             },
             _ => {
                 polars_bail!(InvalidOperation: "expression must be constant literal to extract integer")

--- a/crates/polars-plan/src/dsl/serializable_plan.rs
+++ b/crates/polars-plan/src/dsl/serializable_plan.rs
@@ -180,7 +180,8 @@ fn convert_dsl_plan_to_serializable_plan(
     plan: &DslPlan,
     arenas: &mut SerializeArenas,
 ) -> SerializableDslPlanNode {
-    use {DslPlan as DP, SerializableDslPlanNode as SP};
+    use DslPlan as DP;
+    use SerializableDslPlanNode as SP;
 
     match plan {
         #[cfg(feature = "python")]
@@ -425,7 +426,8 @@ fn try_convert_serializable_plan_to_dsl_plan(
     ser_dsl_plan: &SerializableDslPlan,
     arenas: &mut DeserializeArenas,
 ) -> Result<DslPlan, PolarsError> {
-    use {DslPlan as DP, SerializableDslPlanNode as SP};
+    use DslPlan as DP;
+    use SerializableDslPlanNode as SP;
 
     match node {
         #[cfg(feature = "python")]

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
@@ -16,7 +16,8 @@ pub(super) fn convert_functions(
     function: FunctionExpr,
     ctx: &mut ExprToIRContext,
 ) -> PolarsResult<(Node, PlSmallStr)> {
-    use {FunctionExpr as F, IRFunctionExpr as I};
+    use FunctionExpr as F;
+    use IRFunctionExpr as I;
 
     // Converts inputs
     let input_is_empty = input.is_empty();
@@ -27,7 +28,8 @@ pub(super) fn convert_functions(
     let ir_function = match function {
         #[cfg(feature = "dtype-array")]
         F::ArrayExpr(array_function) => {
-            use {ArrayFunction as A, IRArrayFunction as IA};
+            use ArrayFunction as A;
+            use IRArrayFunction as IA;
             I::ArrayExpr(match array_function {
                 A::Length => IA::Length,
                 A::Min => IA::Min,
@@ -63,7 +65,8 @@ pub(super) fn convert_functions(
             })
         },
         F::BinaryExpr(binary_function) => {
-            use {BinaryFunction as B, IRBinaryFunction as IB};
+            use BinaryFunction as B;
+            use IRBinaryFunction as IB;
             I::BinaryExpr(match binary_function {
                 B::Contains => IB::Contains,
                 B::StartsWith => IB::StartsWith,
@@ -100,7 +103,8 @@ pub(super) fn convert_functions(
         },
         #[cfg(feature = "dtype-categorical")]
         F::Categorical(categorical_function) => {
-            use {CategoricalFunction as C, IRCategoricalFunction as IC};
+            use CategoricalFunction as C;
+            use IRCategoricalFunction as IC;
             I::Categorical(match categorical_function {
                 C::GetCategories => IC::GetCategories,
                 #[cfg(feature = "strings")]
@@ -117,7 +121,8 @@ pub(super) fn convert_functions(
         },
         #[cfg(feature = "dtype-extension")]
         F::Extension(extension_function) => {
-            use {ExtensionFunction as E, IRExtensionFunction as IE};
+            use ExtensionFunction as E;
+            use IRExtensionFunction as IE;
             I::Extension(match extension_function {
                 E::To(dtype) => {
                     let concrete_dtype = dtype.into_datatype(ctx.schema)?;
@@ -130,7 +135,8 @@ pub(super) fn convert_functions(
             })
         },
         F::ListExpr(list_function) => {
-            use {IRListFunction as IL, ListFunction as L};
+            use IRListFunction as IL;
+            use ListFunction as L;
             I::ListExpr(match list_function {
                 L::Concat => IL::Concat,
                 #[cfg(feature = "is_in")]
@@ -189,7 +195,8 @@ pub(super) fn convert_functions(
         },
         #[cfg(feature = "strings")]
         F::StringExpr(string_function) => {
-            use {IRStringFunction as IS, StringFunction as S};
+            use IRStringFunction as IS;
+            use StringFunction as S;
             I::StringExpr(match string_function {
                 S::Format { format, insertions } => {
                     if input_is_empty {
@@ -339,7 +346,8 @@ pub(super) fn convert_functions(
         },
         #[cfg(feature = "dtype-struct")]
         F::StructExpr(struct_function) => {
-            use {IRStructFunction as IS, StructFunction as S};
+            use IRStructFunction as IS;
+            use StructFunction as S;
             I::StructExpr(match struct_function {
                 S::FieldByName(pl_small_str) => IS::FieldByName(pl_small_str),
                 S::RenameFields(pl_small_strs) => IS::RenameFields(pl_small_strs),
@@ -353,7 +361,8 @@ pub(super) fn convert_functions(
         },
         #[cfg(feature = "temporal")]
         F::TemporalExpr(temporal_function) => {
-            use {IRTemporalFunction as IT, TemporalFunction as T};
+            use IRTemporalFunction as IT;
+            use TemporalFunction as T;
             I::TemporalExpr(match temporal_function {
                 T::Millennium => IT::Millennium,
                 T::Century => IT::Century,
@@ -438,7 +447,8 @@ pub(super) fn convert_functions(
             BitwiseFunction::Xor => IRBitwiseFunction::Xor,
         }),
         F::Boolean(boolean_function) => {
-            use {BooleanFunction as B, IRBooleanFunction as IB};
+            use BooleanFunction as B;
+            use IRBooleanFunction as IB;
             I::Boolean(match boolean_function {
                 B::Any { ignore_nulls } => IB::Any { ignore_nulls },
                 B::All { ignore_nulls } => IB::All { ignore_nulls },
@@ -686,7 +696,8 @@ pub(super) fn convert_functions(
         }),
         #[cfg(feature = "trigonometry")]
         F::Trigonometry(trigonometric_function) => {
-            use {IRTrigonometricFunction as IT, TrigonometricFunction as T};
+            use IRTrigonometricFunction as IT;
+            use TrigonometricFunction as T;
             I::Trigonometry(match trigonometric_function {
                 T::Cos => IT::Cos,
                 T::Cot => IT::Cot,
@@ -913,7 +924,8 @@ pub(super) fn convert_functions(
         F::ConcatExpr(rechunk) => I::ConcatExpr { rechunk },
         #[cfg(feature = "cov")]
         F::Correlation { method } => {
-            use {CorrelationMethod as C, IRCorrelationMethod as IC};
+            use CorrelationMethod as C;
+            use IRCorrelationMethod as IC;
             I::Correlation {
                 method: match method {
                     C::Pearson => IC::Pearson,
@@ -960,7 +972,8 @@ pub(super) fn convert_functions(
         F::ToPhysical => I::ToPhysical,
         #[cfg(feature = "random")]
         F::Random { method, seed } => {
-            use {IRRandomMethod as IR, RandomMethod as R};
+            use IRRandomMethod as IR;
+            use RandomMethod as R;
             I::Random {
                 method: match method {
                     R::Shuffle => IR::Shuffle,

--- a/crates/polars-plan/src/plans/conversion/ir_to_dsl.rs
+++ b/crates/polars-plan/src/plans/conversion/ir_to_dsl.rs
@@ -309,12 +309,14 @@ fn nodes_to_exprs(nodes: &[Node], expr_arena: &Arena<AExpr>) -> Vec<Expr> {
 }
 
 pub fn ir_function_to_dsl(input: Vec<Expr>, function: IRFunctionExpr) -> Expr {
-    use {FunctionExpr as F, IRFunctionExpr as IF};
+    use FunctionExpr as F;
+    use IRFunctionExpr as IF;
 
     let function = match function {
         #[cfg(feature = "dtype-array")]
         IF::ArrayExpr(f) => {
-            use {ArrayFunction as A, IRArrayFunction as IA};
+            use ArrayFunction as A;
+            use IRArrayFunction as IA;
             F::ArrayExpr(match f {
                 IA::Concat => A::Concat,
                 IA::Length => A::Length,
@@ -350,7 +352,8 @@ pub fn ir_function_to_dsl(input: Vec<Expr>, function: IRFunctionExpr) -> Expr {
             })
         },
         IF::BinaryExpr(f) => {
-            use {BinaryFunction as B, IRBinaryFunction as IB};
+            use BinaryFunction as B;
+            use IRBinaryFunction as IB;
             F::BinaryExpr(match f {
                 IB::Contains => B::Contains,
                 IB::StartsWith => B::StartsWith,
@@ -374,7 +377,8 @@ pub fn ir_function_to_dsl(input: Vec<Expr>, function: IRFunctionExpr) -> Expr {
         },
         #[cfg(feature = "dtype-categorical")]
         IF::Categorical(f) => {
-            use {CategoricalFunction as C, IRCategoricalFunction as IC};
+            use CategoricalFunction as C;
+            use IRCategoricalFunction as IC;
             F::Categorical(match f {
                 IC::GetCategories => C::GetCategories,
                 #[cfg(feature = "strings")]
@@ -391,14 +395,16 @@ pub fn ir_function_to_dsl(input: Vec<Expr>, function: IRFunctionExpr) -> Expr {
         },
         #[cfg(feature = "dtype-extension")]
         IF::Extension(f) => {
-            use {ExtensionFunction as E, IRExtensionFunction as IE};
+            use ExtensionFunction as E;
+            use IRExtensionFunction as IE;
             F::Extension(match f {
                 IE::To(dtype) => E::To(dtype.into()),
                 IE::Storage => E::Storage,
             })
         },
         IF::ListExpr(f) => {
-            use {IRListFunction as IL, ListFunction as L};
+            use IRListFunction as IL;
+            use ListFunction as L;
             F::ListExpr(match f {
                 IL::Concat => L::Concat,
                 #[cfg(feature = "is_in")]
@@ -457,7 +463,8 @@ pub fn ir_function_to_dsl(input: Vec<Expr>, function: IRFunctionExpr) -> Expr {
         },
         #[cfg(feature = "strings")]
         IF::StringExpr(f) => {
-            use {IRStringFunction as IB, StringFunction as B};
+            use IRStringFunction as IB;
+            use StringFunction as B;
             F::StringExpr(match f {
                 IB::Format { format, insertions } => B::Format { format, insertions },
                 #[cfg(feature = "concat_str")]
@@ -580,7 +587,8 @@ pub fn ir_function_to_dsl(input: Vec<Expr>, function: IRFunctionExpr) -> Expr {
         },
         #[cfg(feature = "dtype-struct")]
         IF::StructExpr(f) => {
-            use {IRStructFunction as IB, StructFunction as B};
+            use IRStructFunction as IB;
+            use StructFunction as B;
             F::StructExpr(match f {
                 IB::FieldByName(pl_small_str) => B::FieldByName(pl_small_str),
                 IB::RenameFields(pl_small_strs) => B::RenameFields(pl_small_strs),
@@ -593,7 +601,8 @@ pub fn ir_function_to_dsl(input: Vec<Expr>, function: IRFunctionExpr) -> Expr {
         },
         #[cfg(feature = "temporal")]
         IF::TemporalExpr(f) => {
-            use {IRTemporalFunction as IB, TemporalFunction as B};
+            use IRTemporalFunction as IB;
+            use TemporalFunction as B;
             F::TemporalExpr(match f {
                 IB::Millennium => B::Millennium,
                 IB::Century => B::Century,
@@ -667,7 +676,8 @@ pub fn ir_function_to_dsl(input: Vec<Expr>, function: IRFunctionExpr) -> Expr {
         },
         #[cfg(feature = "bitwise")]
         IF::Bitwise(f) => {
-            use {BitwiseFunction as B, IRBitwiseFunction as IB};
+            use BitwiseFunction as B;
+            use IRBitwiseFunction as IB;
             F::Bitwise(match f {
                 IB::CountOnes => B::CountOnes,
                 IB::CountZeros => B::CountZeros,
@@ -681,7 +691,8 @@ pub fn ir_function_to_dsl(input: Vec<Expr>, function: IRFunctionExpr) -> Expr {
             })
         },
         IF::Boolean(f) => {
-            use {BooleanFunction as B, IRBooleanFunction as IB};
+            use BooleanFunction as B;
+            use IRBooleanFunction as IB;
             F::Boolean(match f {
                 IB::Any { ignore_nulls } => B::Any { ignore_nulls },
                 IB::All { ignore_nulls } => B::All { ignore_nulls },
@@ -720,7 +731,8 @@ pub fn ir_function_to_dsl(input: Vec<Expr>, function: IRFunctionExpr) -> Expr {
         },
         #[cfg(feature = "business")]
         IF::Business(f) => {
-            use {BusinessFunction as B, IRBusinessFunction as IB};
+            use BusinessFunction as B;
+            use IRBusinessFunction as IB;
             F::Business(match f {
                 IB::BusinessDayCount { week_mask } => B::BusinessDayCount { week_mask },
                 IB::AddBusinessDay { week_mask, roll } => B::AddBusinessDay { week_mask, roll },
@@ -742,7 +754,8 @@ pub fn ir_function_to_dsl(input: Vec<Expr>, function: IRFunctionExpr) -> Expr {
         },
         IF::NullCount => F::NullCount,
         IF::Pow(f) => {
-            use {IRPowFunction as IP, PowFunction as P};
+            use IRPowFunction as IP;
+            use PowFunction as P;
             F::Pow(match f {
                 IP::Generic => P::Generic,
                 IP::Sqrt => P::Sqrt,
@@ -759,7 +772,8 @@ pub fn ir_function_to_dsl(input: Vec<Expr>, function: IRFunctionExpr) -> Expr {
         IF::SearchSorted { side, descending } => F::SearchSorted { side, descending },
         #[cfg(feature = "range")]
         IF::Range(f) => {
-            use {IRRangeFunction as IR, RangeFunction as R};
+            use IRRangeFunction as IR;
+            use RangeFunction as R;
             F::Range(match f {
                 IR::IntRange { step, dtype } => R::IntRange {
                     step,
@@ -832,7 +846,8 @@ pub fn ir_function_to_dsl(input: Vec<Expr>, function: IRFunctionExpr) -> Expr {
         },
         #[cfg(feature = "trigonometry")]
         IF::Trigonometry(f) => {
-            use {IRTrigonometricFunction as IT, TrigonometricFunction as T};
+            use IRTrigonometricFunction as IT;
+            use TrigonometricFunction as T;
             F::Trigonometry(match f {
                 IT::Cos => T::Cos,
                 IT::Cot => T::Cot,
@@ -859,7 +874,8 @@ pub fn ir_function_to_dsl(input: Vec<Expr>, function: IRFunctionExpr) -> Expr {
         IF::FillNullWithStrategy(strategy) => F::FillNullWithStrategy(strategy),
         #[cfg(feature = "rolling_window")]
         IF::RollingExpr { function, options } => {
-            use {IRRollingFunction as IR, RollingFunction as R};
+            use IRRollingFunction as IR;
+            use RollingFunction as R;
             FunctionExpr::RollingExpr {
                 function: match function {
                     IR::Min => R::Min,
@@ -892,7 +908,8 @@ pub fn ir_function_to_dsl(input: Vec<Expr>, function: IRFunctionExpr) -> Expr {
             function_by,
             options,
         } => {
-            use {IRRollingFunctionBy as IR, RollingFunctionBy as R};
+            use IRRollingFunctionBy as IR;
+            use RollingFunctionBy as R;
             FunctionExpr::RollingExprBy {
                 function_by: match function_by {
                     IR::MinBy => R::MinBy,
@@ -1017,7 +1034,8 @@ pub fn ir_function_to_dsl(input: Vec<Expr>, function: IRFunctionExpr) -> Expr {
         IF::ConcatExpr { rechunk } => F::ConcatExpr(rechunk),
         #[cfg(feature = "cov")]
         IF::Correlation { method } => {
-            use {CorrelationMethod as C, IRCorrelationMethod as IC};
+            use CorrelationMethod as C;
+            use IRCorrelationMethod as IC;
             F::Correlation {
                 method: match method {
                     IC::Pearson => C::Pearson,
@@ -1064,7 +1082,8 @@ pub fn ir_function_to_dsl(input: Vec<Expr>, function: IRFunctionExpr) -> Expr {
         IF::ToPhysical => F::ToPhysical,
         #[cfg(feature = "random")]
         IF::Random { method, seed } => {
-            use {IRRandomMethod as IR, RandomMethod as R};
+            use IRRandomMethod as IR;
+            use RandomMethod as R;
             F::Random {
                 method: match method {
                     IR::Shuffle => R::Shuffle,

--- a/crates/polars-plan/src/plans/conversion/type_coercion/datetime.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/datetime.rs
@@ -23,7 +23,8 @@ macro_rules! ensure_int {
         )
     }
 }
-pub use {ensure_datetime, ensure_int};
+pub use ensure_datetime;
+pub use ensure_int;
 
 /// Cast a date or datetime node to a supertype.
 ///

--- a/crates/polars-plan/src/plans/functions/mod.rs
+++ b/crates/polars-plan/src/plans/functions/mod.rs
@@ -231,9 +231,8 @@ impl FunctionIR {
             },
             RowIndex { name, offset, .. } => df.with_row_index(name.clone(), *offset),
             Hint(hint) => {
-                if let HintIR::Sorted(s) = &hint
-                    && let Some(s) = s.first()
-                {
+                let HintIR::Sorted(s) = &hint;
+                if let Some(s) = s.first() {
                     let idx = df.try_get_column_index(&s.column)?;
                     let col = &mut unsafe { df.columns_mut_retain_schema() }[idx];
                     if let Some(d) = s.descending {

--- a/crates/polars-plan/src/plans/functions/mod.rs
+++ b/crates/polars-plan/src/plans/functions/mod.rs
@@ -231,7 +231,6 @@ impl FunctionIR {
             },
             RowIndex { name, offset, .. } => df.with_row_index(name.clone(), *offset),
             Hint(hint) => {
-                #[expect(irrefutable_let_patterns)]
                 if let HintIR::Sorted(s) = &hint
                     && let Some(s) = s.first()
                 {

--- a/crates/polars-plan/src/plans/ir/tree_format.rs
+++ b/crates/polars-plan/src/plans/ir/tree_format.rs
@@ -171,7 +171,9 @@ impl<'a> TreeFmtNode<'a> {
     }
 
     fn node_data(&self) -> TreeFmtNodeData<'_> {
-        use {TreeFmtNodeContent as C, TreeFmtNodeData as ND, with_header as wh};
+        use TreeFmtNodeContent as C;
+        use TreeFmtNodeData as ND;
+        use with_header as wh;
 
         let lp = &self.lp;
         let h = &self.h;

--- a/crates/polars-plan/src/plans/optimizer/simplify_ordering/expr.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_ordering/expr.rs
@@ -150,7 +150,8 @@ impl ExprOrderSimplifier<'_> {
 
     #[recursive::recursive]
     fn rec(&mut self, current_ae_node: Node, recursion: RecursionState) -> ObservableOrders {
-        use {ObservableOrders as O, RecursionState as RS};
+        use ObservableOrders as O;
+        use RecursionState as RS;
 
         macro_rules! check_return_cached {
             () => {

--- a/crates/polars/tests/it/io/parquet/read/primitive_nested.rs
+++ b/crates/polars/tests/it/io/parquet/read/primitive_nested.rs
@@ -37,7 +37,7 @@ fn compose_array<I: Iterator<Item = u32>, F: Iterator<Item = u32>, G: Iterator<I
     let mut prev_def = 0;
     rep_levels
         .into_iter()
-        .zip(def_levels.into_iter())
+        .zip(def_levels)
         .try_for_each(|(rep, def)| {
             match rep {
                 1 => {},

--- a/pyo3-polars/example/extend_polars_python_dispatch/extend_polars/src/parallel_jaccard_mod.rs
+++ b/pyo3-polars/example/extend_polars_python_dispatch/extend_polars/src/parallel_jaccard_mod.rs
@@ -30,7 +30,7 @@ fn compute_jaccard_similarity(sa: &Series, sb: &Series) -> PolarsResult<Series> 
 
     let ca = sa
         .into_iter()
-        .zip(sb.into_iter())
+        .zip(sb)
         .map(|(a, b)| {
             match (a, b) {
                 (Some(a), Some(b)) => {

--- a/pyo3-polars/pyo3-polars/src/export.rs
+++ b/pyo3-polars/pyo3-polars/src/export.rs
@@ -1,1 +1,5 @@
-pub use {arrow as polars_arrow, polars_core, polars_error, polars_ffi, polars_plan};
+pub use arrow as polars_arrow;
+pub use polars_core;
+pub use polars_error;
+pub use polars_ffi;
+pub use polars_plan;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2026-02-19"
+channel = "nightly-2026-04-01"


### PR DESCRIPTION
Regarding what Orson said in https://github.com/pola-rs/polars/issues/27105.

> (A PR to update the toolchain and deal with whatever breakage that gives is welcome.)

In the newest nightly version, `core::unicode` was made private and is not longer accessible via the public API. So, it's usage had to be replaced to always use the Polars internal implementation in `case_ignorable_then_cased`. Any other usage in feature flags was deleted.

Note: Had a lot of `clippy` warning to address and some formatting seems to have changed regarding grouped imports, as they automatically de-grouped when I ran `make pre-commit`. 

🤖 Claude Sonnet 4.6 (and `clippy`) for applying linting recommendations.