### PR TITLE
fix: Mark add_business_day as first-input-length-preserving

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/function_expr/business.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/business.rs
@@ -29,7 +29,8 @@ impl IRBusinessFunction {
             B::BusinessDayCount { .. } => {
                 FunctionOptions::elementwise().with_flags(|f| f | FunctionFlags::ALLOW_RENAME)
             },
-            B::AddBusinessDay { .. } | B::IsBusinessDay { .. } => FunctionOptions::elementwise(),
+            B::AddBusinessDay { .. } | B::IsBusinessDay { .. } => FunctionOptions::elementwise()
+                .with_flags(|f| f | FunctionFlags::LENGTH_PRESERVING_FIRST_INPUT),
         }
     }
 }

--- a/crates/polars-plan/src/plans/aexpr/mod.rs
+++ b/crates/polars-plan/src/plans/aexpr/mod.rs
@@ -306,9 +306,12 @@ impl AExpr {
             | AExpr::AnonymousFunction { options, input, .. } => {
                 if options.flags.contains(FunctionFlags::RETURNS_SCALAR) {
                     true
-                } else if options.is_elementwise()
-                    || options.flags.contains(FunctionFlags::LENGTH_PRESERVING)
+                } else if options
+                    .flags
+                    .contains(FunctionFlags::LENGTH_PRESERVING_FIRST_INPUT)
                 {
+                    input[..1].iter().all(|e| e.is_scalar(arena))
+                } else if options.flags.contains(FunctionFlags::LENGTH_PRESERVING) {
                     input.iter().all(|e| e.is_scalar(arena))
                 } else {
                     false

--- a/crates/polars-plan/src/plans/options.rs
+++ b/crates/polars-plan/src/plans/options.rs
@@ -117,6 +117,10 @@ bitflags!(
 
             /// Indicates that this expression does not produce any ordering into its output.
             const NON_ORDER_PRODUCING = 1 << 12;
+
+            /// In case there are multiple inputs some functions preserve the length
+            /// of the first input, irrespective of other inputs.
+            const LENGTH_PRESERVING_FIRST_INPUT = 1 << 13;
         }
 );
 
@@ -135,6 +139,10 @@ impl FunctionFlags {
 
     pub fn is_length_preserving(self) -> bool {
         self.contains(Self::LENGTH_PRESERVING)
+    }
+
+    pub fn preserves_length_of_first_input(self) -> bool {
+        self.contains(Self::LENGTH_PRESERVING_FIRST_INPUT)
     }
 
     pub fn observes_input_order(self) -> bool {


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/27089.

There are probably more expressions which are length preserving over one of their inputs, ignoring the length of other inputs. We can mark those later as `LENGTH_PRESERVING_FIRST_INPUT`.