### PR TITLE
build(python): Add build for riscv64 wheels

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -154,7 +154,7 @@ jobs:
       fail-fast: false
       matrix:
         package: [polars-runtime-32, polars-runtime-64, polars-runtime-compat]
-        job_config: [linux-x64, linux-arm64, linux-riscv64, linux-musl-x64, linux-musl-arm64, macos-x64, macos-arm64, win-x64, win-arm64]
+        job_config: [linux-x64, linux-arm64, linux-riscv64, linux-musl-x64, linux-musl-arm64, linux-musl-riscv64, macos-x64, macos-arm64, win-x64, win-arm64]
         include:
           - job_config: linux-x64
             os: ubuntu-latest
@@ -176,6 +176,10 @@ jobs:
             os: linux-arm-large
             architecture: aarch64
             target: aarch64-unknown-linux-musl
+          - job_config: linux-musl-riscv64
+            os: ubuntu-24.04-riscv
+            architecture: riscv64
+            target: riscv64-unknown-linux-musl
           - job_config: macos-x64
             os: macos-15-intel
             architecture: x86-64

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -19,6 +19,7 @@ concurrency:
 
 env:
   PYTHON_VERSION: '3.10'
+  PYTHON_VERSION_LINUX_RISCV64: '3.11'
   PYTHON_VERSION_WIN_ARM64: '3.11' # ARM64 Windows doesn't have older versions
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
@@ -263,7 +264,7 @@ jobs:
           swap-size-gb: 10
 
       - name: Set up Python
-        if: matrix.os != 'windows-11-arm'
+        if: matrix.os != 'windows-11-arm' && matrix.os != 'ubuntu-24.04-riscv'
         uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -273,6 +274,12 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION_WIN_ARM64 }}
+
+      - name: Set up Python (RISCV64 Linux)
+        if: matrix.os == 'ubuntu-24.04-riscv'
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION_LINUX_RISCV64 }}
 
       # Otherwise can't find `tomlq` after `pip install yq`
       - name: Add Python scripts folder to GITHUB_PATH (ARM64 Windows)

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -154,7 +154,7 @@ jobs:
       fail-fast: false
       matrix:
         package: [polars-runtime-32, polars-runtime-64, polars-runtime-compat]
-        job_config: [linux-x64, linux-arm64, linux-musl-x64, linux-musl-arm64, macos-x64, macos-arm64, win-x64, win-arm64]
+        job_config: [linux-x64, linux-arm64, linux-riscv64, linux-musl-x64, linux-musl-arm64, macos-x64, macos-arm64, win-x64, win-arm64]
         include:
           - job_config: linux-x64
             os: ubuntu-latest
@@ -164,6 +164,10 @@ jobs:
             os: linux-arm-large
             architecture: aarch64
             target: aarch64-unknown-linux-gnu
+          - job_config: linux-riscv64
+            os: ubuntu-24.04-riscv
+            architecture: riscv64
+            target: riscv64gc-unknown-linux-gnu
           - job_config: linux-musl-x64
             os: ubuntu-latest
             architecture: x86-64

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -285,9 +285,10 @@ jobs:
 
       - name: Set up Python (RISCV64 Linux)
         if: matrix.os == 'ubuntu-24.04-riscv'
-        uses: actions/setup-python@v6
+        uses: riseproject-dev/setup-python@8b57351c0f828145e2ac14bd328c731503361b7a
         with:
           python-version: ${{ env.PYTHON_VERSION_LINUX_RISCV64 }}
+          mirror: https://raw.githubusercontent.com/riseproject-dev/python-versions/main
 
       # Otherwise can't find `tomlq` after `pip install yq`
       - name: Add Python scripts folder to GITHUB_PATH (ARM64 Windows)


### PR DESCRIPTION
As part of the [RISE Project](https://riseproject.dev/), we are helping to build riscv64 binary wheels for a variety Python modules. Add support for both standard and musl-based builds by using official [RISE RISC-V GitHub Actions Runners](https://riseproject-dev.github.io/riscv-runner/). Note that they have to be enabled for the project to use them - instructions for doing so are [here](https://github.com/apps/rise-risc-v-runners).

I've tried testing the CI ahead of time on my fork, but only the linter and PR checks ran. I also didn't see `make test` available locally, so I ran `make check` after `make build`. Here's the end of that output:

<img width="1252" height="888" alt="polars" src="https://github.com/user-attachments/assets/e13f51c4-a628-4352-8b2d-228380f14a75" />
