### PR TITLE
fix: Prevent FixedSizeList cross-type hash collisions via dtype fingerprint tag

### DIFF
--- a/crates/polars-row/src/decode.rs
+++ b/crates/polars-row/src/decode.rs
@@ -6,7 +6,7 @@ use arrow::types::NativeType;
 use polars_buffer::Buffer;
 use polars_dtype::categorical::CatNative;
 
-use self::encode::{fixed_size, FSL_TAG_SIZE};
+use self::encode::{FSL_TAG_SIZE, fixed_size};
 use self::row::{RowEncodingCategoricalContext, RowEncodingOptions};
 use self::variable::utf8::decode_str;
 use super::*;

--- a/crates/polars-row/src/encode.rs
+++ b/crates/polars-row/src/encode.rs
@@ -1091,10 +1091,8 @@ mod tests {
         let dicts_1 = vec![None];
         let dicts_2 = vec![None];
 
-        let encoded_u16 =
-            convert_columns_no_order(1, &[u16_fsl.to_boxed()], &dicts_1);
-        let encoded_u8 =
-            convert_columns_no_order(1, &[u8_fsl.to_boxed()], &dicts_2);
+        let encoded_u16 = convert_columns_no_order(1, &[u16_fsl.to_boxed()], &dicts_1);
+        let encoded_u8 = convert_columns_no_order(1, &[u8_fsl.to_boxed()], &dicts_2);
 
         // The row encodings must differ due to the dtype fingerprint tag
         assert_ne!(


### PR DESCRIPTION
## Summary

- **Fix structural cross-type hash collision vulnerability in `FixedSizeList` row encoding** — different Array dtypes (e.g. `Array(UInt16, 2)` vs `Array(UInt8, 3)`) could produce byte-identical row encodings for certain values, causing deterministic hash collisions in `hash_rows()`, `join`, and `group_by`
- **Add 4-byte dtype fingerprint tag** after the validity byte in FixedSizeList encoding, packing width + inner element size to guarantee type-distinct byte sequences
- **Add regression test** verifying the specific collision pair no longer collides

## Vulnerability Details

The FixedSizeList row encoding format encodes only validity bytes and data bytes without any dtype information. When two Array types have identical total encoded sizes (e.g. `1 + 2*(1+2) = 7` for `Array(UInt16, 2)` and `1 + 3*(1+1) = 7` for `Array(UInt8, 3)`), validity bytes of one type can be "impersonated" by data bytes of the other, creating a **256-member deterministic collision family**:

```
Array(UInt16, 2)[257, 256+z] ≡ Array(UInt8, 3)[1, 1, z]   ∀ z ∈ [0, 255]
```

This collision occurs at the byte encoding level (before hashing), so it holds for **any hash seed** and cannot be mitigated by seed changes.

### Impact
- `hash_rows()` returns identical hashes for semantically different rows across schemas
- Internal `join`/`group_by` paths using row hashing can produce incorrect matches
- Potential for silent data corruption in deduplication or cross-schema operations

## Changes

| File | Change |
|------|--------|
| `crates/polars-row/src/encode.rs` | Add `FSL_TAG_SIZE` const + `compute_fsl_dtype_tag()` helper; update `fixed_size()`, `get_encoder()` (both fixed-size and variable-size paths), `encode_array()`, and `EncoderState` enum |
| `crates/polars-row/src/decode.rs` | Skip dtype tag bytes in `decode()` and `dtype_and_data_to_encoded_item_len()` |

New encoding format for FixedSizeList rows:
```
Before: [validity: 1B] [elements...]
After:  [validity: 1B] [dtype_tag: 4B] [elements...]
```

The tag encodes `width` (upper 16 bits) and `inner_element_encoded_size` (lower 16 bits), ensuring different FixedSizeList types always produce distinct byte sequences.

## Test plan

- [x] New regression test `test_fsl_cross_type_no_collision` verifies `Array(UInt16, 2)[257, 256]` and `Array(UInt8, 3)[1, 1, 0]` produce different row encodings
- [x] Existing proptest `test_encode_arrays` (encode-decode roundtrip) passes
- [x] `cargo check -p polars-row` compiles cleanly
- [x] `cargo test -p polars-row` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)