### PR TITLE
fix(python): Replace multiprocessing.dummy.Pool with ThreadPoolExecutor

### DIFF
--- a/py-polars/src/polars/_utils/construction/dataframe.py
+++ b/py-polars/src/polars/_utils/construction/dataframe.py
@@ -112,36 +112,23 @@ def dict_to_pydf(
         if count_numpy >= 3:
             # yes, multi-threading was easier in python here; we cannot have multiple
             # threads running python and release the gil in pyo3 (it will deadlock).
+            from concurrent.futures import ThreadPoolExecutor
 
-            # (note: 'dummy' is threaded)
-            # We catch FileNotFoundError: see 16675
-            try:
-                import multiprocessing.dummy
-
-                pool_size = thread_pool_size()
-                with multiprocessing.dummy.Pool(pool_size) as pool:
-                    data = dict(
-                        zip(
-                            column_names,
-                            pool.map(
-                                lambda t: (
-                                    pl.Series(t[0], t[1], nan_to_null=nan_to_null)
-                                    if isinstance(t[1], np.ndarray)
-                                    else t[1]
-                                ),
-                                list(data.items()),
+            pool_size = thread_pool_size()
+            with ThreadPoolExecutor(max_workers=pool_size) as pool:
+                data = dict(
+                    zip(
+                        column_names,
+                        pool.map(
+                            lambda t: (
+                                pl.Series(t[0], t[1], nan_to_null=nan_to_null)
+                                if isinstance(t[1], np.ndarray)
+                                else t[1]
                             ),
-                            strict=True,
-                        )
+                            list(data.items()),
+                        ),
+                        strict=True,
                     )
-            except FileNotFoundError:
-                return dict_to_pydf(
-                    data=data,
-                    schema=schema,
-                    schema_overrides=schema_overrides,
-                    strict=strict,
-                    nan_to_null=nan_to_null,
-                    allow_multithreaded=False,
                 )
 
     if not data and schema_overrides:


### PR DESCRIPTION
`multiprocessing.dummy.Pool` is a thread pool, but it inherits from `multiprocessing.pool.Pool`, which creates POSIX semaphores via `sem_open()` during initialization. `sem_open` requires `/dev/shm` to be mounted as tmpfs, and on environments like AWS Lambda where it isn't, the pool creation fails with `OSError: [Errno 38]` or `FileNotFoundError` depending on the runtime.

`concurrent.futures.ThreadPoolExecutor` provides the same thread-based parallelism using `threading.Lock` internally, which doesn't depend on POSIX semaphores or `/dev/shm`.

This also removes the `FileNotFoundError` fallback added in #16686 since the underlying cause is gone.

Fixes #16675, #20252, #24727.