### PR TITLE
chore(python): Fix `test_dtype_concat_3735` not actually iterating through numeric dtypes

### DIFF
--- a/py-polars/tests/unit/operations/test_queries.py
+++ b/py-polars/tests/unit/operations/test_queries.py
@@ -216,12 +216,12 @@ def test_dtype_concat_3735() -> None:
     for dt in NUMERIC_DTYPES:
         d1 = pl.DataFrame([pl.Series("val", [1, 2], dtype=dt)])
 
-    d2 = pl.DataFrame([pl.Series("val", [3, 4], dtype=dt)])
-    df = pl.concat([d1, d2])
+        d2 = pl.DataFrame([pl.Series("val", [3, 4], dtype=dt)])
+        df = pl.concat([d1, d2])
 
-    assert df.shape == (4, 1)
-    assert df.columns == ["val"]
-    assert df.to_series().to_list() == [1, 2, 3, 4]
+        assert df.shape == (4, 1)
+        assert df.columns == ["val"]
+        assert df.to_series().to_list() == [1, 2, 3, 4]
 
 
 def test_opaque_filter_on_lists_3784() -> None:


### PR DESCRIPTION
I think there's missing indentation in this test, else I can't make sense of what it's trying to do by iterating over `NUMERIC_DTYPES`

test introduced in https://github.com/pola-rs/polars/issues/3735

---

noticed looking into #27049 where `df1` was flagged as unbound variable

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
