### PR TITLE
fix(python): Detect non-CSV file extensions in `read_csv`

### DIFF
--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -53,6 +53,33 @@ if TYPE_CHECKING:
     from polars.io.cloud.credential_provider._builder import CredentialProviderBuilder
 
 
+_NON_CSV_EXTENSIONS: dict[str, str] = {
+    ".parquet": "read_parquet",
+    ".parq": "read_parquet",
+    ".ipc": "read_ipc",
+    ".arrow": "read_ipc",
+    ".feather": "read_ipc",
+    ".avro": "read_avro",
+    ".ndjson": "read_ndjson",
+    ".jsonl": "read_ndjson",
+    ".json": "read_json",
+    ".xlsx": "read_excel",
+    ".xls": "read_excel",
+    ".ods": "read_ods",
+}
+
+
+def _check_not_csv(path: Path) -> None:
+    ext = path.suffix.lower()
+    if ext in _NON_CSV_EXTENSIONS:
+        alt = _NON_CSV_EXTENSIONS[ext]
+        msg = (
+            f"the file extension {ext!r} suggests this is not a CSV file"
+            f"\n\nUse `pl.{alt}()` instead of `pl.read_csv()` for this file format."
+        )
+        raise ValueError(msg)
+
+
 @deprecate_renamed_parameter("dtypes", "schema_overrides", version="0.20.31")
 @deprecate_renamed_parameter("row_count_name", "row_index_name", version="0.20.4")
 @deprecate_renamed_parameter("row_count_offset", "row_index_offset", version="0.20.4")
@@ -638,6 +665,8 @@ def _read_csv_impl(
 
     path: str | None
     if isinstance(source, (str, Path)):
+        source_path = Path(source)
+        _check_not_csv(source_path)
         path = normalize_filepath(source, check_not_directory=False)
     else:
         path = None

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -3143,3 +3143,28 @@ def test_provided_schema_mismatch_truncate(chunk_override: None, read_fn: str) -
 def test_read_batch_csv_deprecations_26479(foods_file_path: Path) -> None:
     with pytest.warns(DeprecationWarning, match=r"`read_csv_batched` is deprecated"):
         pl.read_csv_batched(foods_file_path)
+
+
+@pytest.mark.parametrize(
+    ("ext", "reader"),
+    [
+        (".parquet", "read_parquet"),
+        (".parq", "read_parquet"),
+        (".ipc", "read_ipc"),
+        (".arrow", "read_ipc"),
+        (".feather", "read_ipc"),
+        (".avro", "read_avro"),
+        (".ndjson", "read_ndjson"),
+        (".jsonl", "read_ndjson"),
+        (".json", "read_json"),
+        (".xlsx", "read_excel"),
+        (".xls", "read_excel"),
+        (".ods", "read_ods"),
+    ],
+)
+@pytest.mark.write_disk
+def test_read_csv_wrong_file_extension(tmp_path: Path, ext: str, reader: str) -> None:
+    path = tmp_path / f"data{ext}"
+    path.write_bytes(b"not a csv")
+    with pytest.raises(ValueError, match=rf"pl\.{reader}\(\)"):
+        pl.read_csv(path)


### PR DESCRIPTION
Closes #16106

When a user accidentally calls `pl.read_csv("file.parquet")`, the binary
content causes garbled error messages and can clear the terminal via
control characters.

## Fix
Early file extension detection in `read_csv()` for 12 non-CSV formats.
Raises a clear `ValueError` suggesting the correct reader:

```python
>>> pl.read_csv("data.parquet")
ValueError: the file extension '.parquet' suggests this is not a CSV file

Use `pl.read_parquet()` instead of `pl.read_csv()` for this file format.
Supported extensions
.parquet, .parq, .ipc, .arrow, .feather, .avro,
.ndjson, .jsonl, .json, .xlsx, .xls, .ods

Tests
Parametrized test covering all 12 extensions.