### PR TITLE
perf: Optimize `drop_nulls().{first,last}()` to `{first,last}(ignore_nulls=True)`

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/simplify_expr/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_expr/mod.rs
@@ -440,6 +440,30 @@ impl OptimizationRule for SimplifyExprRule {
                     _ => None,
                 }
             },
+            // drop_nulls().first() -> first(ignore_nulls=True)
+            AExpr::Agg(IRAggExpr::First(input)) => {
+                let input_node = expr_arena.get(*input);
+                match input_node {
+                    AExpr::Function {
+                        input,
+                        function: IRFunctionExpr::DropNulls,
+                        options: _,
+                    } => Some(AExpr::Agg(IRAggExpr::FirstNonNull(input[0].node()))),
+                    _ => None,
+                }
+            },
+            // drop_nulls().last()  -> last(ignore_nulls=True)
+            AExpr::Agg(IRAggExpr::Last(input)) => {
+                let input_node = expr_arena.get(*input);
+                match input_node {
+                    AExpr::Function {
+                        input,
+                        function: IRFunctionExpr::DropNulls,
+                        options: _,
+                    } => Some(AExpr::Agg(IRAggExpr::LastNonNull(input[0].node()))),
+                    _ => None,
+                }
+            },
             // lit(left) + lit(right) => lit(left + right)
             // and null propagation
             AExpr::BinaryExpr { left, op, right } => {

--- a/py-polars/tests/unit/lazyframe/test_optimizations.py
+++ b/py-polars/tests/unit/lazyframe/test_optimizations.py
@@ -628,3 +628,16 @@ def test_slice_pushdown_with_cache_arena_take_panic_26905() -> None:
         q.collect(),
         pl.DataFrame({"x": [4, 5]}),
     )
+
+
+def test_drop_nulls_first_last_optimization_25478() -> None:
+    lf = pl.LazyFrame({"a": [None, 1, None, 3, None]})
+    lf = lf.select(a=pl.col.a.drop_nulls().first(), b=pl.col.a.drop_nulls().last())
+
+    explain = lf.explain(engine="streaming")
+    assert "first(" not in explain
+    assert "first_non_null(" in explain
+    assert "last(" not in explain
+    assert "last_non_null(" in explain
+
+    assert_frame_equal(lf.collect(), pl.DataFrame({"a": [1], "b": [3]}))


### PR DESCRIPTION
Fixes #25478.

No AI was used.
