### PR TITLE
fix(python): Support all integer dtypes for Series index assignment

### DIFF
--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -1563,9 +1563,7 @@ class Series:
         if isinstance(key, Series):
             if key.dtype == Boolean:
                 self._s = self.set(key, value)._s
-            elif key.dtype == UInt64:
-                self._s = self.scatter(key.cast(UInt32), value)._s
-            elif key.dtype == UInt32:
+            elif key.dtype.is_integer():
                 self._s = self.scatter(key, value)._s
 
         # TODO: implement for these types without casting to series

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -1514,7 +1514,7 @@ class Series:
 
             - ``int``: a single row index.
             - ``Series`` (Boolean): a boolean mask.
-            - ``Series`` (UInt32/UInt64): an index array.
+            - ``Series`` (Integer): an index array.
             - ``ndarray``: a NumPy boolean mask or integer index array.
             - ``list`` / ``tuple``: an index sequence (cast to UInt32).
         value

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -1565,6 +1565,9 @@ class Series:
                 self._s = self.set(key, value)._s
             elif key.dtype.is_integer():
                 self._s = self.scatter(key, value)._s
+            else:
+                msg = f"cannot use Series of dtype {key.dtype!r} for indexing; expected boolean or integer dtype"
+                raise TypeError(msg)
 
         # TODO: implement for these types without casting to series
         elif _check_for_numpy(key) and isinstance(key, np.ndarray):

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -2475,3 +2475,10 @@ def test_setitem_negative_index_27110() -> None:
     idx = pl.Series([-1])
     s[idx] = 99
     assert s.to_list() == [1, 2, 99]
+
+
+def test_setitem_invalid_series_dtype_27110() -> None:
+    s = pl.Series("a", [1, 2, 3])
+    idx = pl.Series([0.0, 2.0])
+    with pytest.raises(TypeError, match="cannot use Series of dtype"):
+        s[idx] = 99

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -2458,3 +2458,20 @@ def test_multiply_int_series_by_timedelta_26205() -> None:
         [timedelta(seconds=5), timedelta(seconds=10), timedelta(seconds=15)]
     )
     assert_series_equal(expected, result)
+
+
+@pytest.mark.parametrize(
+    "dtype", [pl.Int8, pl.Int16, pl.Int32, pl.Int64, pl.UInt8, pl.UInt16]
+)
+def test_setitem_integer_dtypes_27110(dtype: pl.PolarsDataType) -> None:
+    s = pl.Series("a", [1, 2, 3])
+    idx = pl.Series([0, 2], dtype=dtype)
+    s[idx] = 99
+    assert s.to_list() == [99, 2, 99]
+
+
+def test_setitem_negative_index_27110() -> None:
+    s = pl.Series("a", [1, 2, 3])
+    idx = pl.Series([-1])
+    s[idx] = 99
+    assert s.to_list() == [1, 2, 99]

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -2463,7 +2463,7 @@ def test_multiply_int_series_by_timedelta_26205() -> None:
 @pytest.mark.parametrize(
     "dtype", [pl.Int8, pl.Int16, pl.Int32, pl.Int64, pl.UInt8, pl.UInt16]
 )
-def test_setitem_integer_dtypes_27110(dtype: pl.PolarsDataType) -> None:
+def test_setitem_integer_dtypes_27110(dtype: pl.DataType) -> None:
     s = pl.Series("a", [1, 2, 3])
     idx = pl.Series([0, 2], dtype=dtype)
     s[idx] = 99


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/27093.
Resolves https://github.com/pola-rs/polars/issues/26358.

🤖 Claude Sonnet 4.6 for rubber ducking 🦆 