### PR TITLE
fix(python): Handle bare Decimal dtype in row-oriented DataFrame construction

### DIFF
--- a/py-polars/src/polars/_utils/construction/dataframe.py
+++ b/py-polars/src/polars/_utils/construction/dataframe.py
@@ -576,7 +576,7 @@ def _sequence_of_sequence_to_pydf(
         for col, tp in local_schema_override.items():
             if tp in (Categorical, Enum):
                 local_schema_override[col] = String
-            elif tp == Decimal:
+            elif tp is Decimal:
                 # Bare Decimal (no precision/scale) cannot be serialized into the
                 # Rust schema dict. Replace with Unknown so from_rows infers the
                 # native type; we rebuild these columns afterwards using pl.Series
@@ -608,8 +608,16 @@ def _sequence_of_sequence_to_pydf(
         if bare_decimal_cols:
             for col, col_idx in bare_decimal_cols:
                 col_values = [row[col_idx] for row in data]
+                # Infer the concrete Decimal(precision, scale) from non-null values
+                # so that null-containing columns are handled correctly.
+                non_null = [v for v in col_values if v is not None]
+                decimal_dtype = (
+                    pl.Series("_", non_null, dtype=Decimal).dtype
+                    if non_null
+                    else Decimal(scale=0)
+                )
                 pyseries = pl.Series(
-                    col, col_values, dtype=Decimal, strict=strict, nan_to_null=nan_to_null
+                    col, col_values, dtype=decimal_dtype, strict=strict, nan_to_null=nan_to_null
                 )._s
                 pydf.replace_column(col_idx, pyseries)
             if schema_overrides:

--- a/py-polars/src/polars/_utils/construction/dataframe.py
+++ b/py-polars/src/polars/_utils/construction/dataframe.py
@@ -43,6 +43,7 @@ from polars._utils.various import (
 from polars.datatypes import (
     N_INFER_DEFAULT,
     Categorical,
+    Decimal,
     Duration,
     Enum,
     String,
@@ -571,9 +572,18 @@ def _sequence_of_sequence_to_pydf(
         )
 
         unpack_nested = False
+        bare_decimal_cols: list[tuple[str, int]] = []
         for col, tp in local_schema_override.items():
             if tp in (Categorical, Enum):
                 local_schema_override[col] = String
+            elif tp == Decimal:
+                # Bare Decimal (no precision/scale) cannot be serialized into the
+                # Rust schema dict. Replace with Unknown so from_rows infers the
+                # native type; we rebuild these columns afterwards using pl.Series
+                # which applies Python-level Decimal inference (mirrors the
+                # column-oriented construction path).
+                local_schema_override[col] = Unknown
+                bare_decimal_cols.append((col, column_names.index(col)))
             elif not unpack_nested and (tp.base_type() in (Unknown, Struct)):
                 unpack_nested = contains_nested(
                     getattr(first_element, col, None).__class__, is_namedtuple
@@ -594,6 +604,21 @@ def _sequence_of_sequence_to_pydf(
                 schema=local_schema_override or None,
                 infer_schema_length=infer_schema_length,
             )
+
+        if bare_decimal_cols:
+            for col, col_idx in bare_decimal_cols:
+                col_values = [row[col_idx] for row in data]
+                pyseries = pl.Series(
+                    col, col_values, dtype=Decimal, strict=strict, nan_to_null=nan_to_null
+                )._s
+                pydf.replace_column(col_idx, pyseries)
+            if schema_overrides:
+                bare_decimal_names = {col for col, _ in bare_decimal_cols}
+                schema_overrides = (
+                    {k: v for k, v in schema_overrides.items() if k not in bare_decimal_names}
+                    or None
+                )
+
         if column_names or schema_overrides:
             pydf = _post_apply_columns(
                 pydf, column_names, schema_overrides=schema_overrides, strict=strict

--- a/py-polars/src/polars/_utils/construction/dataframe.py
+++ b/py-polars/src/polars/_utils/construction/dataframe.py
@@ -617,15 +617,20 @@ def _sequence_of_sequence_to_pydf(
                     else Decimal(scale=0)
                 )
                 pyseries = pl.Series(
-                    col, col_values, dtype=decimal_dtype, strict=strict, nan_to_null=nan_to_null
+                    col,
+                    col_values,
+                    dtype=decimal_dtype,
+                    strict=strict,
+                    nan_to_null=nan_to_null,
                 )._s
                 pydf.replace_column(col_idx, pyseries)
             if schema_overrides:
                 bare_decimal_names = {col for col, _ in bare_decimal_cols}
-                schema_overrides = (
-                    {k: v for k, v in schema_overrides.items() if k not in bare_decimal_names}
-                    or None
-                )
+                schema_overrides = {
+                    k: v
+                    for k, v in schema_overrides.items()
+                    if k not in bare_decimal_names
+                } or None
 
         if column_names or schema_overrides:
             pydf = _post_apply_columns(

--- a/py-polars/tests/unit/constructors/test_dataframe.py
+++ b/py-polars/tests/unit/constructors/test_dataframe.py
@@ -264,7 +264,7 @@ def test_dataframe_row_orient_bare_decimal_float() -> None:
     )
     assert result["asset"].to_list() == ["USD"]
     assert result["amount"].dtype.is_decimal()
-    assert result["amount"].to_python() == [PyDecimal("1000.0")]
+    assert result["amount"].to_list() == [PyDecimal("1000.0")]
 
 
 def test_dataframe_row_orient_bare_decimal_integer() -> None:
@@ -274,7 +274,7 @@ def test_dataframe_row_orient_bare_decimal_integer() -> None:
         orient="row",
     )
     assert result["amount"].dtype == pl.Decimal(scale=0)
-    assert result["amount"].to_python() == [PyDecimal("500")]
+    assert result["amount"].to_list() == [PyDecimal("500")]
 
 
 def test_dataframe_row_orient_bare_decimal_with_nulls() -> None:
@@ -295,7 +295,7 @@ def test_dataframe_row_orient_explicit_decimal_scale_unaffected() -> None:
         orient="row",
     )
     assert result["amount"].dtype == pl.Decimal(scale=2)
-    assert result["amount"].to_python() == [PyDecimal("10.50")]
+    assert result["amount"].to_list() == [PyDecimal("10.50")]
 
 
 def test_dataframe_row_and_col_orient_bare_decimal_consistent() -> None:
@@ -311,4 +311,4 @@ def test_dataframe_row_and_col_orient_bare_decimal_consistent() -> None:
     )
     assert row_df["amount"].dtype.is_decimal()
     assert col_df["amount"].dtype.is_decimal()
-    assert row_df["amount"].to_python() == col_df["amount"].to_python()
+    assert row_df["amount"].to_list() == col_df["amount"].to_list()

--- a/py-polars/tests/unit/constructors/test_dataframe.py
+++ b/py-polars/tests/unit/constructors/test_dataframe.py
@@ -5,6 +5,7 @@ import sys
 from collections import OrderedDict
 from collections.abc import Mapping
 from datetime import date, datetime, time
+from decimal import Decimal as PyDecimal
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -252,3 +253,62 @@ def test_temporal_string_schema_overrides(schema_param: dict[str, SchemaDict]) -
             "datetime": datetime(2024, 1, 2, 13, 30, 0, 123456),
         },
     ]
+
+
+def test_dataframe_row_orient_bare_decimal_float() -> None:
+    # Regression test for https://github.com/pola-rs/polars/issues/27177
+    result = pl.DataFrame(
+        [("USD", 1000.0)],
+        schema={"asset": pl.String, "amount": pl.Decimal},
+        orient="row",
+    )
+    assert result["asset"].to_list() == ["USD"]
+    assert result["amount"].dtype.is_decimal()
+    assert result["amount"].to_python() == [PyDecimal("1000.0")]
+
+
+def test_dataframe_row_orient_bare_decimal_integer() -> None:
+    result = pl.DataFrame(
+        [(1, 500)],
+        schema={"id": pl.Int32, "amount": pl.Decimal},
+        orient="row",
+    )
+    assert result["amount"].dtype == pl.Decimal(scale=0)
+    assert result["amount"].to_python() == [PyDecimal("500")]
+
+
+def test_dataframe_row_orient_bare_decimal_with_nulls() -> None:
+    result = pl.DataFrame(
+        [("USD", None), ("EUR", 100.5)],
+        schema={"asset": pl.String, "amount": pl.Decimal},
+        orient="row",
+    )
+    assert result["amount"][0] is None
+    assert result["amount"].dtype.is_decimal()
+
+
+def test_dataframe_row_orient_explicit_decimal_scale_unaffected() -> None:
+    # Decimal(scale=2) instance should continue to work (no regression)
+    result = pl.DataFrame(
+        [("USD", PyDecimal("10.50"))],
+        schema={"asset": pl.String, "amount": pl.Decimal(scale=2)},
+        orient="row",
+    )
+    assert result["amount"].dtype == pl.Decimal(scale=2)
+    assert result["amount"].to_python() == [PyDecimal("10.50")]
+
+
+def test_dataframe_row_and_col_orient_bare_decimal_consistent() -> None:
+    # Both orientations should produce a Decimal column with the same value
+    row_df = pl.DataFrame(
+        [("USD", 1000.0)],
+        schema={"asset": pl.String, "amount": pl.Decimal},
+        orient="row",
+    )
+    col_df = pl.DataFrame(
+        [["USD"], [1000.0]],
+        schema={"asset": pl.String, "amount": pl.Decimal},
+    )
+    assert row_df["amount"].dtype.is_decimal()
+    assert col_df["amount"].dtype.is_decimal()
+    assert row_df["amount"].to_python() == col_df["amount"].to_python()

--- a/py-polars/tests/unit/constructors/test_dataframe.py
+++ b/py-polars/tests/unit/constructors/test_dataframe.py
@@ -312,3 +312,15 @@ def test_dataframe_row_and_col_orient_bare_decimal_consistent() -> None:
     assert row_df["amount"].dtype.is_decimal()
     assert col_df["amount"].dtype.is_decimal()
     assert row_df["amount"].to_list() == col_df["amount"].to_list()
+
+
+def test_dataframe_row_orient_bare_decimal_only_column() -> None:
+    # schema_overrides is empty after bare Decimal cols are removed — exercises
+    # the `if schema_overrides` False branch in _sequence_of_sequence_to_pydf.
+    result = pl.DataFrame(
+        [(1000.0,)],
+        schema={"amount": pl.Decimal},
+        orient="row",
+    )
+    assert result["amount"].dtype.is_decimal()
+    assert result["amount"].to_list() == [PyDecimal("1000.0")]


### PR DESCRIPTION
## Summary

- Bare `pl.Decimal` (no precision/scale) in `schema_overrides` crashed row-oriented `DataFrame` construction because it cannot be serialized into the Rust schema dict
- Fix: replace bare `Decimal` with `Unknown` so `from_rows` infers the native type, then rebuild those columns via `pl.Series` — matching the existing column-oriented path
- Use `tp is Decimal` (identity check) instead of `tp == Decimal` so that explicit `Decimal(scale=N)` instances are not incorrectly treated as bare Decimal
- Infer concrete `Decimal(precision, scale)` from non-null values first, then create the full Series with that specific dtype to handle null-containing columns correctly

Closes #27177

## AI Disclosure

1. I used AI to implement the fix for bare `Decimal` in row-oriented DataFrame construction and write the accompanying tests.
2. I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.

## Test Plan
- [x] `test_dataframe_row_orient_bare_decimal_float` — float values with bare `pl.Decimal`
- [x] `test_dataframe_row_orient_bare_decimal_integer` — integer values with bare `pl.Decimal`
- [x] `test_dataframe_row_orient_bare_decimal_with_nulls` — null handling
- [x] `test_dataframe_row_orient_explicit_decimal_scale_unaffected` — no regression for `Decimal(scale=N)`
- [x] `test_dataframe_row_and_col_orient_bare_decimal_consistent` — row and column orientations produce identical results

<img width="1919" height="847" alt="image" src="https://github.com/user-attachments/assets/07f3d057-600d-456e-bdd8-4fede468c86b" />
