### PR TITLE
fix: Don't trigger csv fast count if predicate is pushed down

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/count_star.rs
+++ b/crates/polars-plan/src/plans/optimizer/count_star.rs
@@ -153,6 +153,7 @@ fn visit_logical_plan_for_scan_paths(
             scan_type,
             sources,
             unified_scan_args,
+            predicate,
             ..
         } => {
             // New-streaming is generally on par for all except CSV (see https://github.com/pola-rs/polars/pull/22363).
@@ -160,7 +161,7 @@ fn visit_logical_plan_for_scan_paths(
 
             let use_fast_file_count = match scan_type.as_ref() {
                 #[cfg(feature = "csv")]
-                FileScanIR::Csv { .. } => true,
+                FileScanIR::Csv { .. } => predicate.is_none(),
                 _ => false,
             };
 

--- a/py-polars/tests/unit/lazyframe/test_optimizations.py
+++ b/py-polars/tests/unit/lazyframe/test_optimizations.py
@@ -641,3 +641,11 @@ def test_drop_nulls_first_last_optimization_25478() -> None:
     assert "last_non_null(" in explain
 
     assert_frame_equal(lf.collect(), pl.DataFrame({"a": [1], "b": [3]}))
+
+
+def test_fast_count_predicate_27168() -> None:
+    csv = b"""a,b
+true,1
+false,2
+"""
+    assert pl.scan_csv(csv).filter(pl.col.a).select(pl.len()).collect().item() == 1


### PR DESCRIPTION
fixes #27168