### PR TITLE
feat(rust)!: removed lossy type coercion for primitive numeric types …

### DIFF
--- a/crates/polars-plan/src/plans/conversion/type_coercion/is_in.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/is_in.rs
@@ -147,46 +147,34 @@ See https://github.com/pola-rs/polars/issues/22149 for more information."
             return Ok(None);
         },
 
-        // don't attempt to cast between obviously mismatched types, but
-        // allow integer/float comparison (will use their supertypes).
         (a, b) => {
-            if (a.is_primitive_numeric() && b.is_primitive_numeric()) || (a == &DataType::Null) {
-                if a != b {
-                    // @TAG: 2.0
-                    // @HACK: `is_in` does supertype casting between primitive numerics, which
-                    // honestly makes very little sense. To stay backwards compatible we keep this,
-                    // but please in 2.0 remove this. FirstArgLossless might be a good alternative,
-                    // as used by index_of(), or build on index_of().
-                    //
-                    // Try lossless supertype first to avoid precision loss (e.g.,
-                    // UInt64 + Int64 would otherwise become Float64), then fall back
-                    // to the existing supertype behavior.
-                    let super_type = polars_core::utils::get_numeric_upcast_supertype_lossless(
-                        &type_left,
-                        type_other_inner,
-                    )
-                    .map_or_else(
-                        || polars_core::utils::try_get_supertype(&type_left, type_other_inner),
-                        Ok,
-                    )?;
+            // Only do lossless coercion for primitive numerics; keep existing Null
+            // behavior by resolving its supertype against the inner right dtype.
+            let super_type = if a.is_primitive_numeric() && b.is_primitive_numeric() {
+                polars_core::utils::get_numeric_upcast_supertype_lossless(
+                    &type_left,
+                    type_other_inner,
+                )
+                .ok_or_else(
+                    || polars_err!(InvalidOperation: "'{op}' cannot check for {:?} values in {:?} data",&type_left, &type_other)
+                )?
+            } else if a == &DataType::Null {
+                polars_core::utils::try_get_supertype(&type_left, type_other_inner)?
+            } else {
+                polars_bail!(
+                InvalidOperation: "'{op}' cannot check for {:?} values in {:?} data", &type_other, &type_left
+                                    )
+            };
+            let other_type = match &type_other {
+                DataType::List(_) => DataType::List(Box::new(super_type.clone())),
+                #[cfg(feature = "dtype-array")]
+                DataType::Array(_, width) => DataType::Array(Box::new(super_type.clone()), *width),
+                _ => unreachable!(),
+            };
 
-                    let other_type = match &type_other {
-                        DataType::List(_) => DataType::List(Box::new(super_type.clone())),
-                        #[cfg(feature = "dtype-array")]
-                        DataType::Array(_, width) => {
-                            DataType::Array(Box::new(super_type.clone()), *width)
-                        },
-                        _ => unreachable!(),
-                    };
-
-                    return Ok(Some(IsInTypeCoercionResult::SuperType(
-                        super_type, other_type,
-                    )));
-                }
-
-                return Ok(None);
-            }
-            polars_bail!(InvalidOperation: "'{op}' cannot check for {:?} values in {:?} data", &type_other, &type_left)
+            return Ok(Some(IsInTypeCoercionResult::SuperType(
+                super_type, other_type,
+            )));
         },
     };
     Ok(Some(casted_expr))


### PR DESCRIPTION
…(#25624)

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
From what I understand, `is_in` currently falls back to lossy supertype conversion with `try_get_supertype` if the lossless upcast ( `get_numeric_upcast_supertype_lossless` ) doesn't work. 

I made these assumptions in my changes to `resolve_is_in` 
 - return an error if no lossless supertype exists for the two primitive numerics. 
 - kept the existing Null behavior with `try_get_supertype`. 
 - removed the `a != b` branch since the `a == b` match arm ensures that `a != b` will always be true (right?). 

Let me know if this aligns with the intended direction. I'll fix stale/add tests for this once I get the confirmation.

Currently these tests fail. Most of these make sense as they involve lossy numeric casting. 

<img width="1902" height="817" alt="image" src="https://github.com/user-attachments/assets/e36a9f38-4154-45da-936b-aece1473104d" />
