### PR TITLE
refactor(rust): Utility for identifying expr projection heights

### DIFF
--- a/crates/polars-plan/src/dsl/expr/mod.rs
+++ b/crates/polars-plan/src/dsl/expr/mod.rs
@@ -692,16 +692,6 @@ impl EvalVariant {
             EvalVariant::Cumulative { min_samples: _ } => false,
         }
     }
-
-    pub fn is_length_preserving(&self) -> bool {
-        match self {
-            EvalVariant::List
-            | EvalVariant::ListAgg
-            | EvalVariant::Array { .. }
-            | EvalVariant::ArrayAgg
-            | EvalVariant::Cumulative { .. } => true,
-        }
-    }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]

--- a/crates/polars-plan/src/plans/aexpr/mod.rs
+++ b/crates/polars-plan/src/plans/aexpr/mod.rs
@@ -24,6 +24,7 @@ use polars_utils::arena::{Arena, Node};
 pub use scalar::{is_length_preserving_ae, is_scalar_ae};
 use strum_macros::IntoStaticStr;
 pub use traverse::*;
+pub mod projection_height;
 mod properties;
 pub use aexpr::function_expr::schema::FieldsMapper;
 pub use builder::AExprBuilder;
@@ -295,137 +296,6 @@ impl AExpr {
     #[cfg(feature = "cse")]
     pub(crate) fn col(name: PlSmallStr) -> Self {
         AExpr::Column(name)
-    }
-
-    #[recursive::recursive]
-    pub fn is_scalar(&self, arena: &Arena<AExpr>) -> bool {
-        match self {
-            AExpr::Element => false,
-            AExpr::Literal(lv) => lv.is_scalar(),
-            AExpr::Function { options, input, .. }
-            | AExpr::AnonymousFunction { options, input, .. } => {
-                if options.flags.contains(FunctionFlags::RETURNS_SCALAR) {
-                    true
-                } else if options.is_elementwise()
-                    || options.flags.contains(FunctionFlags::LENGTH_PRESERVING)
-                {
-                    input.iter().all(|e| e.is_scalar(arena))
-                } else {
-                    false
-                }
-            },
-            AExpr::BinaryExpr { left, right, .. } => {
-                is_scalar_ae(*left, arena) && is_scalar_ae(*right, arena)
-            },
-            AExpr::Ternary {
-                predicate,
-                truthy,
-                falsy,
-            } => {
-                is_scalar_ae(*predicate, arena)
-                    && is_scalar_ae(*truthy, arena)
-                    && is_scalar_ae(*falsy, arena)
-            },
-            AExpr::Agg(_) | AExpr::AnonymousAgg { .. } | AExpr::Len => true,
-            AExpr::Cast { expr, .. } => is_scalar_ae(*expr, arena),
-            AExpr::Eval { expr, variant, .. } => {
-                variant.is_length_preserving() && is_scalar_ae(*expr, arena)
-            },
-            #[cfg(feature = "dtype-struct")]
-            AExpr::StructEval { expr, .. } => is_scalar_ae(*expr, arena),
-            AExpr::Sort { expr, .. } => is_scalar_ae(*expr, arena),
-            AExpr::Gather { returns_scalar, .. } => *returns_scalar,
-            AExpr::SortBy { expr, .. } => is_scalar_ae(*expr, arena),
-
-            // Over and Rolling implicitly zip with the context and thus are never scalars
-            AExpr::Over { .. } => false,
-            #[cfg(feature = "dynamic_group_by")]
-            AExpr::Rolling { .. } => false,
-
-            AExpr::Explode { .. }
-            | AExpr::Column(_)
-            | AExpr::Filter { .. }
-            | AExpr::Slice { .. } => false,
-            #[cfg(feature = "dtype-struct")]
-            AExpr::StructField(_) => false,
-        }
-    }
-
-    #[recursive::recursive]
-    pub fn is_length_preserving(&self, arena: &Arena<AExpr>) -> bool {
-        fn broadcasting_input_length_preserving(
-            n: impl IntoIterator<Item = Node>,
-            arena: &Arena<AExpr>,
-        ) -> bool {
-            let mut num_items = 0;
-            let mut num_length_preserving = 0;
-            let mut num_scalar_or_length_preserving = 0;
-
-            for n in n {
-                num_items += 1;
-
-                if is_length_preserving_ae(n, arena) {
-                    num_length_preserving += 1;
-                    num_scalar_or_length_preserving += 1;
-                } else if is_scalar_ae(n, arena) {
-                    num_scalar_or_length_preserving += 1;
-                }
-            }
-
-            num_length_preserving > 0 && num_scalar_or_length_preserving == num_items
-        }
-
-        match self {
-            AExpr::Element => true,
-            AExpr::Column(_) => true,
-            #[cfg(feature = "dtype-struct")]
-            AExpr::StructField(_) => true,
-
-            // Over and Rolling implicitly zip with the context and thus should always be length
-            // preserving
-            AExpr::Over { mapping, .. } => !matches!(mapping, WindowMapping::Explode),
-            #[cfg(feature = "dynamic_group_by")]
-            AExpr::Rolling { .. } => true,
-
-            AExpr::AnonymousAgg { .. } | AExpr::Literal(_) | AExpr::Agg(_) | AExpr::Len => false,
-            AExpr::Function { options, input, .. }
-            | AExpr::AnonymousFunction { options, input, .. } => {
-                if options.flags.is_elementwise() {
-                    broadcasting_input_length_preserving(input.iter().map(|e| e.node()), arena)
-                } else if options.flags.is_length_preserving() {
-                    input.iter().all(|e| e.is_length_preserving(arena))
-                } else {
-                    false
-                }
-            },
-            AExpr::BinaryExpr { left, right, .. } => {
-                broadcasting_input_length_preserving([*left, *right], arena)
-            },
-            AExpr::Ternary {
-                predicate,
-                truthy,
-                falsy,
-            } => broadcasting_input_length_preserving([*predicate, *truthy, *falsy], arena),
-            AExpr::Cast { expr, .. } => is_length_preserving_ae(*expr, arena),
-            AExpr::Eval { expr, variant, .. } => {
-                variant.is_length_preserving() && is_length_preserving_ae(*expr, arena)
-            },
-            #[cfg(feature = "dtype-struct")]
-            AExpr::StructEval { expr, .. } => is_length_preserving_ae(*expr, arena),
-            AExpr::Sort { expr, .. } => is_length_preserving_ae(*expr, arena),
-            AExpr::Gather {
-                expr: _,
-                idx,
-                returns_scalar,
-                null_on_oob: _,
-            } => !returns_scalar && is_length_preserving_ae(*idx, arena),
-            AExpr::SortBy { expr, by, .. } => broadcasting_input_length_preserving(
-                std::iter::once(*expr).chain(by.iter().copied()),
-                arena,
-            ),
-
-            AExpr::Explode { .. } | AExpr::Filter { .. } | AExpr::Slice { .. } => false,
-        }
     }
 
     /// Is the top-level expression fallible based on the data values.

--- a/crates/polars-plan/src/plans/aexpr/projection_height.rs
+++ b/crates/polars-plan/src/plans/aexpr/projection_height.rs
@@ -1,0 +1,135 @@
+use polars_utils::arena::{Arena, Node};
+use polars_utils::scratch_vec::ScratchVec;
+
+use crate::dsl::WindowMapping;
+use crate::plans::{AExpr, aexpr_postvisit_traversal};
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum ExprProjectionHeight {
+    Column,
+    Scalar,
+    #[default]
+    Unknown,
+}
+
+impl ExprProjectionHeight {
+    pub fn zip_with(self, other: Self) -> Self {
+        use ExprProjectionHeight::*;
+
+        match (self, other) {
+            (Scalar, v) | (v, Scalar) => v,
+            (Unknown, _) | (_, Unknown) => Unknown,
+            (Column, Column) => Column,
+        }
+    }
+
+    pub fn zipped_projection_height(iter: impl IntoIterator<Item = Self>) -> Self {
+        let mut iter = iter.into_iter();
+
+        let Some(first) = iter.next() else {
+            return Self::Unknown;
+        };
+
+        iter.fold(first, |acc, h| acc.zip_with(h))
+    }
+}
+
+#[recursive::recursive]
+pub fn aexpr_projection_height_rec(
+    ae_node: Node,
+    mut expr_arena: &Arena<AExpr>,
+    stack: &mut ScratchVec<Node>,
+    inputs_stack: &mut ScratchVec<ExprProjectionHeight>,
+) -> ExprProjectionHeight {
+    aexpr_postvisit_traversal(
+        ae_node,
+        &mut expr_arena,
+        stack.get(),
+        inputs_stack.get(),
+        &mut |ae_node, input_heights, expr_arena| {
+            aexpr_projection_height(expr_arena.get(ae_node), input_heights)
+        },
+    )
+}
+
+pub fn aexpr_projection_height(
+    aexpr: &AExpr,
+    input_heights: &[ExprProjectionHeight],
+) -> ExprProjectionHeight {
+    use AExpr::*;
+    use ExprProjectionHeight as H;
+
+    match aexpr {
+        Column(_) => H::Column,
+
+        Element => H::Column,
+        #[cfg(feature = "dtype-struct")]
+        StructField(_) => H::Unknown,
+        Literal(lv) => {
+            if lv.is_scalar() {
+                H::Scalar
+            } else {
+                H::Unknown
+            }
+        },
+
+        Eval { .. } => input_heights[0],
+        #[cfg(feature = "dtype-struct")]
+        StructEval { .. } => input_heights[0],
+
+        Filter { .. } | Slice { .. } | Explode { .. } => H::Unknown,
+
+        Agg(_) | AnonymousAgg { .. } => H::Scalar,
+        Len => H::Scalar,
+
+        BinaryExpr { .. } => {
+            let [l, r] = input_heights.try_into().unwrap();
+            l.zip_with(r)
+        },
+        Ternary { .. } => {
+            let [pred, truthy, falsy] = input_heights.try_into().unwrap();
+            pred.zip_with(truthy).zip_with(falsy)
+        },
+
+        Cast { .. } | Sort { .. } => {
+            let [h] = input_heights.try_into().unwrap();
+            h
+        },
+
+        SortBy { .. } => input_heights[0],
+
+        Gather { returns_scalar, .. } => {
+            if *returns_scalar {
+                // This is `get()` from the API
+                H::Scalar
+            } else {
+                let indices_height = input_heights[1];
+
+                match indices_height {
+                    H::Column => H::Column,
+                    H::Scalar | H::Unknown => H::Unknown,
+                }
+            }
+        },
+
+        AExpr::Function { options, .. } | AExpr::AnonymousFunction { options, .. } => {
+            if options.flags.returns_scalar() {
+                H::Scalar
+            } else if options.flags.is_elementwise() || options.flags.is_length_preserving() {
+                H::zipped_projection_height(input_heights.iter().copied())
+            } else {
+                H::Unknown
+            }
+        },
+
+        #[cfg(feature = "dynamic_group_by")]
+        Rolling { .. } => H::Column,
+        Over { mapping, .. } => {
+            if matches!(mapping, WindowMapping::Explode) {
+                H::Unknown
+            } else {
+                H::Column
+            }
+        },
+    }
+}

--- a/crates/polars-plan/src/plans/aexpr/projection_height.rs
+++ b/crates/polars-plan/src/plans/aexpr/projection_height.rs
@@ -96,7 +96,7 @@ pub fn aexpr_projection_height(
             h
         },
 
-        SortBy { .. } => input_heights[0],
+        SortBy { .. } => H::zipped_projection_height(input_heights.iter().copied()),
 
         Gather { returns_scalar, .. } => {
             if *returns_scalar {

--- a/crates/polars-plan/src/plans/aexpr/scalar.rs
+++ b/crates/polars-plan/src/plans/aexpr/scalar.rs
@@ -1,9 +1,30 @@
 use super::*;
+use crate::plans::projection_height::{ExprProjectionHeight, aexpr_projection_height_rec};
 
 pub fn is_scalar_ae(node: Node, arena: &Arena<AExpr>) -> bool {
-    arena.get(node).is_scalar(arena)
+    use ExprProjectionHeight as H;
+
+    match aexpr_projection_height_rec(
+        node,
+        arena,
+        &mut Default::default(),
+        &mut Default::default(),
+    ) {
+        H::Scalar => true,
+        H::Column | H::Unknown => false,
+    }
 }
 
 pub fn is_length_preserving_ae(node: Node, arena: &Arena<AExpr>) -> bool {
-    arena.get(node).is_length_preserving(arena)
+    use ExprProjectionHeight as H;
+
+    match aexpr_projection_height_rec(
+        node,
+        arena,
+        &mut Default::default(),
+        &mut Default::default(),
+    ) {
+        H::Column => true,
+        H::Scalar | H::Unknown => false,
+    }
 }

--- a/crates/polars-plan/src/plans/aexpr/traverse.rs
+++ b/crates/polars-plan/src/plans/aexpr/traverse.rs
@@ -1,6 +1,92 @@
 use super::*;
 
 impl AExpr {
+    /// Push the inputs of this node to the given container, in field declaration order.
+    ///
+    /// This function and its users must be updated if the field declaration order changes.
+    pub fn inputs<E>(&self, container: &mut E)
+    where
+        E: Extend<Node>,
+    {
+        use AExpr::*;
+
+        match self {
+            Element | Column(_) | Literal(_) | Len => {},
+            #[cfg(feature = "dtype-struct")]
+            StructField(_) => {},
+            BinaryExpr { left, op: _, right } => {
+                container.extend([*left, *right]);
+            },
+            Cast { expr, .. } => container.extend([*expr]),
+            Sort { expr, .. } => container.extend([*expr]),
+            Gather { expr, idx, .. } => {
+                container.extend([*expr, *idx]);
+            },
+            SortBy { expr, by, .. } => {
+                container.extend([*expr]);
+                container.extend(by.iter().cloned());
+            },
+            Filter { input, by } => {
+                container.extend([*input, *by]);
+            },
+            Agg(agg_e) => match agg_e.get_input() {
+                NodeInputs::Single(node) => container.extend([node]),
+                NodeInputs::Many(nodes) => container.extend(nodes),
+                NodeInputs::Leaf => {},
+            },
+            Ternary {
+                truthy,
+                falsy,
+                predicate,
+            } => {
+                container.extend([*predicate, *truthy, *falsy]);
+            },
+            AnonymousFunction { input, .. }
+            | Function { input, .. }
+            | AnonymousAgg { input, .. } => container.extend(input.iter().map(|e| e.node())),
+            Explode { expr: e, .. } => container.extend([*e]),
+            #[cfg(feature = "dynamic_group_by")]
+            Rolling {
+                function,
+                index_column,
+                period: _,
+                offset: _,
+                closed_window: _,
+            } => {
+                container.extend([*function, *index_column]);
+            },
+            Over {
+                function,
+                partition_by,
+                order_by,
+                mapping: _,
+            } => {
+                container.extend([*function]);
+                container.extend(partition_by.iter().cloned());
+                container.extend(order_by.as_ref().map(|(n, _)| *n));
+            },
+            Eval {
+                expr,
+                evaluation,
+                variant: _,
+            } => {
+                container.extend([*expr, *evaluation]);
+            },
+            #[cfg(feature = "dtype-struct")]
+            StructEval { expr, evaluation } => {
+                container.extend([*expr]);
+                container.extend(evaluation.iter().map(|x| x.node()));
+            },
+            Slice {
+                input,
+                offset,
+                length,
+            } => {
+                container.extend([*input, *offset, *length]);
+            },
+        }
+    }
+
     /// Push the inputs of this node to the given container, in reverse order.
     /// This ensures the primary node responsible for the name is pushed last.
     ///
@@ -515,4 +601,43 @@ impl NodeInputs {
             NodeInputs::Leaf => panic!(),
         }
     }
+}
+
+#[recursive::recursive]
+pub fn aexpr_postvisit_traversal<F, State, ArenaT>(
+    ae_node: Node,
+    expr_arena: &mut ArenaT,
+    stack: &mut Vec<Node>,
+    inputs_stack: &mut Vec<State>,
+    visit: &mut F,
+) -> State
+where
+    F: FnMut(Node, &mut [State], &mut ArenaT) -> State,
+    State: Default,
+    ArenaT: AsRef<Arena<AExpr>>,
+{
+    let ae = expr_arena.as_ref().get(ae_node);
+
+    let base_stack_len = stack.len();
+    let base_inputs_stack_len = inputs_stack.len();
+    ae.inputs(stack);
+    let num_inputs = stack.len() - base_stack_len;
+
+    for i in base_stack_len..stack.len() {
+        let h = aexpr_postvisit_traversal(stack[i], expr_arena, stack, inputs_stack, visit);
+        inputs_stack.push(h);
+    }
+
+    assert_eq!(stack.len(), base_stack_len + num_inputs);
+    stack.truncate(base_stack_len);
+
+    assert_eq!(inputs_stack.len(), base_inputs_stack_len + num_inputs);
+    let state = visit(
+        ae_node,
+        &mut inputs_stack[base_inputs_stack_len..],
+        expr_arena,
+    );
+    inputs_stack.truncate(base_inputs_stack_len);
+
+    state
 }

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_to_ir.rs
@@ -2,6 +2,7 @@ use super::functions::convert_functions;
 use super::*;
 use crate::constants::{get_pl_element_name, get_pl_structfields_name};
 use crate::plans::iterator::ArenaExprIter;
+use crate::plans::projection_height::{ExprProjectionHeight, aexpr_projection_height_rec};
 
 pub fn to_expr_ir(expr: Expr, ctx: &mut ExprToIRContext) -> PolarsResult<ExprIR> {
     let (node, output_name) = to_aexpr_impl(expr, ctx)?;
@@ -518,7 +519,11 @@ pub(super) fn to_aexpr_impl(
                 EvalVariant::List | EvalVariant::ListAgg => {},
                 EvalVariant::Array { as_list } => {
                     polars_ensure!(
-                        as_list || is_length_preserving_ae(evaluation, ctx.arena),
+                        as_list ||
+                        matches!(
+                            aexpr_projection_height_rec(evaluation, ctx.arena, &mut Default::default(), &mut Default::default()),
+                            ExprProjectionHeight::Column
+                        ),
                         InvalidOperation: "`array.eval` is not allowed with non-length preserving expressions. Enable `as_list` if you want to output a variable amount of items per row."
                     )
                 },

--- a/crates/polars-stream/src/physical_plan/lower_group_by.rs
+++ b/crates/polars-stream/src/physical_plan/lower_group_by.rs
@@ -239,7 +239,7 @@ fn try_lower_elementwise_scalar_agg_expr(
     }
 
     if is_input_independent(expr, expr_arena, expr_cache) {
-        if expr_arena.get(expr).is_scalar(expr_arena) {
+        if is_scalar_ae(expr, expr_arena) {
             return Some(expr);
         } else {
             let agg = IRAggExpr::Implode {

--- a/crates/polars-utils/src/arena.rs
+++ b/crates/polars-utils/src/arena.rs
@@ -46,6 +46,18 @@ impl<T> Default for Arena<T> {
     }
 }
 
+impl<T> AsRef<Arena<T>> for &Arena<T> {
+    fn as_ref(&self) -> &Arena<T> {
+        self
+    }
+}
+
+impl<T> AsRef<Arena<T>> for &mut Arena<T> {
+    fn as_ref(&self) -> &Arena<T> {
+        self
+    }
+}
+
 /// Simple Arena implementation
 /// Allocates memory and stores item in a Vec. Only deallocates when being dropped itself.
 impl<T> Arena<T> {


### PR DESCRIPTION
Adds a function `aexpr_projection_height_rec` that resolves the output height of an expression to one of `Column`, `Scalar`, `Unknown`. This replaces the existing implementations of `is_scalar()` / `is_length_preserving()`.

* Will also be used in https://github.com/pola-rs/polars/pull/27200

--

* \> https://github.com/pola-rs/polars/pull/27198
  * https://github.com/pola-rs/polars/pull/27249
    * https://github.com/pola-rs/polars/pull/27200
