### PR TITLE
perf: Create IR slice from expr slice pushdown

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/mod.rs
@@ -211,9 +211,6 @@ pub fn optimize(
         ir_arena.replace(root, ir);
 
         repeat_slice_pd_after_filter_pd = slice_pushdown_opt.slice_node_in_optimized_plan;
-
-        // Expressions use the stack optimizer.
-        rules.push(Box::new(slice_pushdown_opt));
     }
 
     if run_pushdowns {

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_expr.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_expr.rs
@@ -1,163 +1,485 @@
-use std::borrow::BorrowMut;
+use std::ops::ControlFlow;
+
+use polars_core::chunked_array::cast::CastOptions;
+use polars_utils::UnitVec;
+use polars_utils::collection::{Collection, CollectionWrap, MappedCollection};
 
 use super::*;
+use crate::plans::optimizer::slice_pushdown_lp::{
+    State as ExtractedSlice, combine_outer_inner_slice,
+};
+use crate::plans::projection_height::{ExprProjectionHeight, aexpr_projection_height};
+use crate::traversal::visitor::{FnVisitors, SubtreeVisit};
 
-/// Returns whether slice was pushed
-fn pushdown<T>(inputs: &mut [T], offset: Node, length: Node, arena: &mut Arena<AExpr>) -> bool
-where
-    T: BorrowMut<Node>,
-{
-    if inputs.is_empty() {
-        return false;
-    }
-
-    let mut has_column_height_projection = false;
-
-    macro_rules! is_column_height {
-        ($node:expr) => {{
-            let node = $node;
-            is_length_preserving_ae(node, arena)
-                && aexpr_to_leaf_names_iter(node, arena).next().is_some()
-        }};
-    }
-
-    for node in inputs.iter().map(|x| x.borrow()).copied() {
-        if is_scalar_ae(node, arena) {
-            continue;
-        }
-
-        let column_height = is_column_height!(node);
-
-        if column_height {
-            has_column_height_projection = true;
-        } else {
-            // Unknown non-scalar height
-            // TODO: Can technically still push slices with offset >=0.
-            return false;
-        }
-    }
-
-    if !has_column_height_projection {
-        return false;
-    }
-
-    for node in inputs {
-        let n = *node.borrow();
-
-        if is_scalar_ae(n, arena) {
-            continue;
-        }
-
-        if is_column_height!(n) {
-            *node.borrow_mut() = arena.add(AExpr::Slice {
-                input: n,
-                offset,
-                length,
-            })
-        }
-    }
-
-    true
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum CommonSlice {
+    Positive {
+        /// Invariant: >=0
+        min_offset: i64,
+        /// `max(s.offset + s.len) for s in slices`
+        /// Invariant: >=0
+        max_end: IdxSize,
+    },
+    Negative {
+        /// Invariant: <0
+        min_offset: i64,
+        /// Invariant: <=0
+        max_end: i64,
+    },
 }
 
-impl OptimizationRule for SlicePushDown {
-    fn optimize_expr(
-        &mut self,
-        expr_arena: &mut Arena<AExpr>,
-        expr_node: Node,
-        _schema: &Schema,
-        _ctx: OptimizeExprContext,
-    ) -> PolarsResult<Option<AExpr>> {
-        if let AExpr::Slice {
-            input,
-            offset,
-            length,
-        } = expr_arena.get(expr_node)
-        {
-            let offset = *offset;
-            let length = *length;
-
-            use AExpr::*;
-            let out = match expr_arena.get(*input) {
-                ae @ Cast { .. } => {
-                    let ae = ae.clone();
-                    let scratch = self.empty_nodes_scratch_mut();
-
-                    ae.inputs_rev(scratch);
-                    assert_eq!(scratch.len(), 1);
-
-                    pushdown(scratch, offset, length, expr_arena)
-                        .then(|| ae.replace_inputs(scratch))
+impl CommonSlice {
+    pub(crate) fn common_limit_with(self, other: Self) -> Option<Self> {
+        Some(match (self, other) {
+            (
+                CommonSlice::Positive {
+                    min_offset,
+                    max_end,
                 },
-                BinaryExpr { left, right, op } => {
-                    let left = *left;
-                    let right = *right;
-                    let op = *op;
+                CommonSlice::Positive {
+                    min_offset: r_min_offset,
+                    max_end: r_max_end,
+                },
+            ) => CommonSlice::Positive {
+                min_offset: i64::min(min_offset, r_min_offset),
+                max_end: IdxSize::max(max_end, r_max_end),
+            },
+            (
+                CommonSlice::Negative {
+                    min_offset,
+                    max_end,
+                },
+                CommonSlice::Negative {
+                    min_offset: r_min_offset,
+                    max_end: r_max_end,
+                },
+            ) => CommonSlice::Negative {
+                min_offset: i64::min(min_offset, r_min_offset),
+                max_end: i64::max(max_end, r_max_end),
+            },
+            _ => return None,
+        })
+    }
 
-                    let mut inputs = [left, right];
-
-                    pushdown(&mut inputs[..], offset, length, expr_arena).then(|| BinaryExpr {
-                        left: inputs[0],
-                        op,
-                        right: inputs[1],
-                    })
-                },
-                Ternary {
-                    truthy,
-                    falsy,
-                    predicate,
-                } => {
-                    let mut inputs = [*truthy, *falsy, *predicate];
-
-                    pushdown(&mut inputs[..], offset, length, expr_arena).then(|| Ternary {
-                        truthy: inputs[0],
-                        falsy: inputs[1],
-                        predicate: inputs[2],
-                    })
-                },
-                m @ AnonymousFunction { options, .. } if options.is_elementwise() => {
-                    if let AnonymousFunction {
-                        mut input,
-                        function,
-                        options,
-                        fmt_str,
-                    } = m.clone()
-                    {
-                        pushdown(input.as_mut_slice(), offset, length, expr_arena).then(|| {
-                            AnonymousFunction {
-                                input,
-                                function,
-                                options,
-                                fmt_str,
-                            }
-                        })
-                    } else {
-                        unreachable!()
-                    }
-                },
-                m @ Function { options, .. } if options.is_elementwise() => {
-                    if let Function {
-                        mut input,
-                        function,
-                        options,
-                    } = m.clone()
-                    {
-                        pushdown(input.as_mut_slice(), offset, length, expr_arena).then(|| {
-                            Function {
-                                input,
-                                function,
-                                options,
-                            }
-                        })
-                    } else {
-                        unreachable!()
-                    }
-                },
-                _ => None,
-            };
-            Ok(out)
+    pub(crate) fn from_slice(slice: ExtractedSlice) -> Self {
+        if slice.offset >= 0 {
+            CommonSlice::Positive {
+                min_offset: slice.offset,
+                max_end: slice
+                    .offset
+                    .try_into()
+                    .unwrap_or(IdxSize::MAX)
+                    .saturating_add(slice.len),
+            }
         } else {
-            Ok(None)
+            CommonSlice::Negative {
+                min_offset: slice.offset,
+                #[cfg_attr(
+                    not(feature = "bigidx"),
+                    expect(clippy::unnecessary_fallible_conversions)
+                )]
+                max_end: i64::min(
+                    0,
+                    slice
+                        .offset
+                        .saturating_add(slice.len.try_into().unwrap_or(i64::MAX)),
+                ),
+            }
         }
     }
+
+    /// Compute the IR slice that can be inserted to apply before the projections. Also returns
+    /// an offset correction to be subtracted from the direct column slices in the expression tree
+    /// due to the added IR slice.
+    pub(crate) fn to_slice_with_correction(self) -> (ExtractedSlice, i64) {
+        match self {
+            Self::Positive {
+                min_offset,
+                max_end,
+            } => {
+                assert!(min_offset >= 0);
+                let len = max_end - min_offset.try_into().unwrap_or(IdxSize::MAX);
+
+                (
+                    ExtractedSlice {
+                        offset: min_offset,
+                        len,
+                    },
+                    min_offset,
+                )
+            },
+            Self::Negative {
+                min_offset,
+                max_end,
+            } => {
+                assert!(min_offset < 0);
+                assert!(max_end <= 0);
+
+                let len = min_offset.abs_diff(max_end);
+                #[cfg_attr(feature = "bigidx", expect(clippy::useless_conversion))]
+                let len: IdxSize = len.try_into().unwrap_or(IdxSize::MAX);
+
+                (
+                    ExtractedSlice {
+                        offset: min_offset,
+                        len,
+                    },
+                    max_end,
+                )
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum Slice {
+    Extracted(ExtractedSlice),
+    Opaque { offset: Node, len: Node },
+}
+
+impl Slice {
+    pub(crate) fn from_nodes(offset: Node, len: Node, arena: &Arena<AExpr>) -> Self {
+        if let (AExpr::Literal(offset), AExpr::Literal(len)) = (arena.get(offset), arena.get(len))
+            && offset.is_scalar()
+            && len.is_scalar()
+            && let (LiteralValue::Scalar(offset), LiteralValue::Scalar(len)) =
+                (offset.clone().materialize(), len.clone().materialize())
+            && let (Ok(offset), Ok(len)) = (
+                offset.cast_with_options(&DataType::Int64, CastOptions::NonStrict),
+                len.cast_with_options(&DataType::IDX_DTYPE, CastOptions::NonStrict),
+            )
+            && let AnyValue::Int64(offset) = offset.as_any_value()
+            && let Some(len) = match len.as_any_value() {
+                AnyValue::Null => {
+                    if offset < 0 {
+                        (-offset).try_into().ok()
+                    } else {
+                        Some(IdxSize::MAX)
+                    }
+                },
+                #[cfg(feature = "bigidx")]
+                AnyValue::UInt64(len) => Some(len),
+                #[cfg(not(feature = "bigidx"))]
+                AnyValue::UInt32(len) => Some(len),
+                _ => None,
+            }
+        {
+            return Self::Extracted(ExtractedSlice { offset, len });
+        };
+
+        Slice::Opaque { offset, len }
+    }
+
+    fn combine_with_inner_slice(&self, inner_slice: &Self) -> Option<Self> {
+        use slice_pushdown_lp::State;
+
+        let Self::Extracted(ExtractedSlice { offset, len }) = self else {
+            return None;
+        };
+        let outer = State {
+            offset: *offset,
+            len: *len,
+        };
+
+        let Self::Extracted(ExtractedSlice { offset, len }) = inner_slice else {
+            return None;
+        };
+        let inner = State {
+            offset: *offset,
+            len: *len,
+        };
+
+        let State { offset, len } = combine_outer_inner_slice(outer, inner)?;
+
+        Some(Self::Extracted(ExtractedSlice { offset, len }))
+    }
+
+    pub(crate) fn slice_arena_node(&self, ae_node: Node, expr_arena: &mut Arena<AExpr>) {
+        let (offset, length) = match self {
+            Self::Extracted(ExtractedSlice { offset, len }) => (
+                expr_arena.add(AExpr::Literal(LiteralValue::Scalar(Scalar::new(
+                    DataType::Int64,
+                    AnyValue::Int64(*offset),
+                )))),
+                expr_arena.add(AExpr::Literal(LiteralValue::Scalar(Scalar::new(
+                    DataType::IDX_DTYPE,
+                    {
+                        #[cfg(not(feature = "bigidx"))]
+                        {
+                            AnyValue::UInt32(*len)
+                        }
+                        #[cfg(feature = "bigidx")]
+                        {
+                            AnyValue::UInt64(*len)
+                        }
+                    },
+                )))),
+            ),
+            Self::Opaque { offset, len } => (*offset, *len),
+        };
+
+        let ae_node_copy = expr_arena.add(expr_arena.get(ae_node).clone());
+
+        expr_arena.replace(
+            ae_node,
+            AExpr::Slice {
+                input: ae_node_copy,
+                offset,
+                length,
+            },
+        );
+    }
+
+    fn to_extracted_slice(&self) -> Option<ExtractedSlice> {
+        match self {
+            Self::Extracted(v) => Some(*v),
+            Self::Opaque { .. } => None,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct State {
+    candidate_push_locations: UnitVec<Node>,
+    height: ExprProjectionHeight,
+}
+
+impl SlicePushDown {
+    pub(crate) fn aexpr_slice_pushdown_rec(
+        &mut self,
+        current_ae_node: Node,
+        expr_arena: &mut Arena<AExpr>,
+        common_col_limit: &mut Option<CommonSlice>,
+        col_hit_count: &mut Option<usize>,
+        all_slice_ae_nodes_with_direct_col_input: &mut PlHashSet<Node>,
+        maintain_errors: bool,
+    ) {
+        let mut visitor = FnVisitors::new(
+            State::default,
+            |_, _, _| ControlFlow::Continue(SubtreeVisit::Visit),
+            |ae_node, arena, edges| {
+                edges.outputs()[0] = aexpr_slice_pushdown_top(
+                    ae_node,
+                    &mut *edges.inputs(),
+                    arena,
+                    common_col_limit,
+                    col_hit_count,
+                    all_slice_ae_nodes_with_direct_col_input,
+                    maintain_errors,
+                );
+
+                ControlFlow::<()>::Continue(())
+            },
+        );
+
+        aexpr_tree_traversal(
+            current_ae_node,
+            expr_arena,
+            self.ae_nodes_scratch.get(),
+            self.ae_slice_pd_state_scratch.get(),
+            &mut visitor,
+        )
+        .continue_value()
+        .unwrap();
+    }
+}
+
+fn aexpr_slice_pushdown_top(
+    current_ae_node: Node,
+    input_states: &mut dyn Collection<State>,
+    expr_arena: &mut Arena<AExpr>,
+    common_col_limit: &mut Option<CommonSlice>,
+    col_hit_count: &mut Option<usize>,
+    all_slice_ae_nodes_with_direct_col_input: &mut PlHashSet<Node>,
+    maintain_errors: bool,
+) -> State {
+    use ExprProjectionHeight as H;
+
+    let mut input_states = CollectionWrap::new(input_states);
+    let ae = expr_arena.get(current_ae_node);
+
+    // We propagate upwards the position of the last non-elementwise node(s), these represent
+    // the deepest position that a slice can be pushed to from the current node.
+    //
+    // E.g.
+    //
+    //                ▲
+    //                │
+    //            H::Column
+    //                │
+    //        ┌──────►==◄─────┐  (current expr)
+    //        │                │
+    //        │           H::Co│umn
+    //        │                │
+    //        │                │
+    //    H::Column     ┌────►+◄──┐
+    //        │         │          │
+    //        │         H::Column  H::Scalar
+    //    ┌──────┐   ┌──────┐      │
+    //    │col(A)│   │col(B)│      1
+    //    └──────┘   └──────┘
+    //
+    // Push candidates are `col(A)` and `col(B)`.
+    let idx = input_states
+        .iter()
+        .position(|s| s.height != H::Scalar)
+        .unwrap_or(input_states.len());
+    let mut state = input_states
+        .get_mut(idx)
+        .map_or(State::default(), |s| State {
+            candidate_push_locations: std::mem::take(&mut s.candidate_push_locations),
+            height: s.height,
+        });
+
+    for remainder in (idx + 1..input_states.len()).map(|i| &input_states[i]) {
+        match (state.height, remainder.height) {
+            (_, H::Scalar) => {},
+            (H::Column, H::Column) => state
+                .candidate_push_locations
+                .extend(remainder.candidate_push_locations.iter().copied()),
+            _ => {
+                state.candidate_push_locations.clear();
+                break;
+            },
+        }
+    }
+
+    state.height = aexpr_projection_height(
+        ae,
+        Some(&mut MappedCollection::new(
+            &mut *input_states,
+            |s| &s.height,
+            |s| &mut s.height,
+        )),
+    )
+    .unwrap();
+
+    if let AExpr::Column(_) = ae {
+        *col_hit_count = col_hit_count.map(|x| x + 1);
+    }
+
+    'pushdown_current_slice: {
+        if state.candidate_push_locations.is_empty() {
+            break 'pushdown_current_slice;
+        }
+
+        let (current_input_node, current_slice) = match ae {
+            AExpr::Slice {
+                input,
+                offset,
+                length,
+            } => (*input, Slice::from_nodes(*offset, *length, expr_arena)),
+            AExpr::Agg(IRAggExpr::First(input)) => (
+                *input,
+                Slice::Extracted(ExtractedSlice { offset: 0, len: 1 }),
+            ),
+            AExpr::Agg(IRAggExpr::Last(input)) => (
+                *input,
+                Slice::Extracted(ExtractedSlice { offset: -1, len: 1 }),
+            ),
+            _ => break 'pushdown_current_slice,
+        };
+
+        for candidate_node in state.candidate_push_locations.iter().copied() {
+            let mut extracted_slice: Option<ExtractedSlice> = current_slice.to_extracted_slice();
+            // Set to 0 if updating an existing slice.
+            let mut hit_count_contribution: usize = 1;
+            let mut sliced_at_candidate = false;
+
+            match expr_arena.get(candidate_node) {
+                AExpr::Slice {
+                    input: inner_input,
+                    offset: inner_offset,
+                    length: inner_length,
+                } => {
+                    hit_count_contribution = 0;
+                    let inner_slice = Slice::from_nodes(*inner_offset, *inner_length, expr_arena);
+
+                    if let Some(combined) = current_slice.combine_with_inner_slice(&inner_slice) {
+                        // Update existing slice
+                        let inner_input = *inner_input;
+
+                        extracted_slice = combined.to_extracted_slice();
+
+                        if combined != inner_slice {
+                            expr_arena.replace(candidate_node, expr_arena.get(inner_input).clone());
+                            combined.slice_arena_node(candidate_node, expr_arena);
+                        }
+
+                        sliced_at_candidate = true;
+                    } else {
+                        if candidate_node != current_input_node {
+                            current_slice.slice_arena_node(candidate_node, expr_arena);
+                            sliced_at_candidate = true;
+                        }
+                    }
+                },
+                _ => {
+                    if candidate_node != current_input_node {
+                        current_slice.slice_arena_node(candidate_node, expr_arena);
+                        sliced_at_candidate = true;
+                    }
+                },
+            };
+
+            if sliced_at_candidate && matches!(expr_arena.get(current_ae_node), AExpr::Slice { .. })
+            {
+                expr_arena.replace(current_ae_node, expr_arena.get(current_input_node).clone());
+            }
+
+            let slice_input = if sliced_at_candidate {
+                let AExpr::Slice { input, .. } = expr_arena.get(candidate_node) else {
+                    unreachable!()
+                };
+                *input
+            } else {
+                current_input_node
+            };
+
+            'update_common_slice: {
+                let AExpr::Column(_) = expr_arena.get(slice_input) else {
+                    break 'update_common_slice;
+                };
+
+                if sliced_at_candidate {
+                    all_slice_ae_nodes_with_direct_col_input.insert(candidate_node);
+                } else if matches!(expr_arena.get(current_ae_node), AExpr::Slice { .. }) {
+                    all_slice_ae_nodes_with_direct_col_input.insert(current_ae_node);
+                }
+
+                *col_hit_count = col_hit_count.and_then(|x| x.checked_sub(hit_count_contribution));
+
+                let Some(extracted_slice) = extracted_slice else {
+                    *col_hit_count = None;
+                    break 'update_common_slice;
+                };
+
+                let extracted_limit = CommonSlice::from_slice(extracted_slice);
+
+                if let Some(existing) = common_col_limit {
+                    let Some(new) = extracted_limit.common_limit_with(*existing) else {
+                        *col_hit_count = None;
+                        break 'update_common_slice;
+                    };
+                    *existing = new;
+                } else {
+                    *common_col_limit = Some(extracted_limit)
+                }
+            }
+        }
+    }
+
+    let current_ae = expr_arena.get(current_ae_node);
+
+    if !current_ae.is_elementwise_top_level()
+        || (maintain_errors && current_ae.is_fallible_top_level(expr_arena))
+    {
+        state.candidate_push_locations.clear();
+    }
+
+    if state.candidate_push_locations.is_empty() {
+        state.candidate_push_locations.push(current_ae_node);
+    }
+
+    state
 }

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -3,17 +3,25 @@ use polars_utils::idx_vec::UnitVec;
 use polars_utils::slice_enum::Slice;
 use recursive::recursive;
 
+use crate::plans::optimizer::slice_pushdown_expr;
 use crate::prelude::*;
 
 mod inner {
+    use polars_core::prelude::ScratchHashSet;
     use polars_utils::arena::Node;
     use polars_utils::idx_vec::UnitVec;
+    use polars_utils::scratch_vec::ScratchVec;
     use polars_utils::unitvec;
+
+    use crate::plans::optimizer::slice_pushdown_expr;
 
     pub struct SlicePushDown {
         scratch: UnitVec<Node>,
         pub(super) maintain_errors: bool,
         pub(crate) slice_node_in_optimized_plan: bool,
+        pub(crate) ae_nodes_scratch: ScratchVec<Node>,
+        pub(crate) ae_slice_pd_state_scratch: ScratchVec<slice_pushdown_expr::State>,
+        pub(crate) ae_slice_pd_direct_col_slice_nodes: ScratchHashSet<Node>,
     }
 
     impl SlicePushDown {
@@ -26,6 +34,9 @@ mod inner {
                 // the new-streaming engine still may not error due to early-stopping.
                 maintain_errors: false,
                 slice_node_in_optimized_plan: false,
+                ae_nodes_scratch: ScratchVec::default(),
+                ae_slice_pd_state_scratch: ScratchVec::default(),
+                ae_slice_pd_direct_col_slice_nodes: ScratchHashSet::default(),
             }
         }
 
@@ -39,10 +50,10 @@ mod inner {
 
 pub(super) use inner::SlicePushDown;
 
-#[derive(Copy, Clone, Debug)]
-struct State {
-    offset: i64,
-    len: IdxSize,
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub(crate) struct State {
+    pub(crate) offset: i64,
+    pub(crate) len: IdxSize,
 }
 
 impl State {
@@ -55,7 +66,7 @@ impl State {
 }
 
 /// Returns a combined slice if the 2 slices can be combined.
-fn combine_outer_inner_slice(outer_slice: State, inner_slice: State) -> Option<State> {
+pub(crate) fn combine_outer_inner_slice(outer_slice: State, inner_slice: State) -> Option<State> {
     // Both are positive, can combine into a single slice.
     if outer_slice.offset >= 0 && inner_slice.offset >= 0 {
         return Some(State {
@@ -244,6 +255,92 @@ impl SlicePushDown {
                 expr_arena,
             );
         }
+
+        let maintain_errors = self.maintain_errors;
+
+        let ir = lp_arena.get_mut(ir_node);
+
+        let mut common_expr_col_slice = None;
+        let mut col_hit_count: Option<usize> = Some(0);
+        let mut ae_slice_pd_direct_col_slice_nodes =
+            std::mem::take(self.ae_slice_pd_direct_col_slice_nodes.get());
+
+        for eir in ir.exprs() {
+            self.aexpr_slice_pushdown_rec(
+                eir.node(),
+                expr_arena,
+                &mut common_expr_col_slice,
+                &mut col_hit_count,
+                &mut ae_slice_pd_direct_col_slice_nodes,
+                maintain_errors,
+            );
+        }
+
+        if col_hit_count != Some(0) {
+            common_expr_col_slice = None;
+        }
+
+        'add_common_ir_slice: {
+            let IR::Select { input, .. } = ir else {
+                break 'add_common_ir_slice;
+            };
+
+            let Some((limit, 0)) = common_expr_col_slice.zip(col_hit_count) else {
+                break 'add_common_ir_slice;
+            };
+
+            let (ir_slice, offset_correction) = limit.to_slice_with_correction();
+
+            let input = *input;
+            let new_input_node = lp_arena.add(IR::Slice {
+                input,
+                offset: ir_slice.offset,
+                len: ir_slice.len,
+            });
+
+            let IR::Select { input, .. } = lp_arena.get_mut(ir_node) else {
+                unreachable!()
+            };
+
+            *input = new_input_node;
+
+            for node in ae_slice_pd_direct_col_slice_nodes.drain() {
+                use slice_pushdown_expr::Slice;
+                let AExpr::Slice {
+                    input: input_node,
+                    offset: offset_node,
+                    length,
+                } = expr_arena.get(node)
+                else {
+                    unreachable!()
+                };
+
+                let input_node = *input_node;
+                let offset_node = *offset_node;
+
+                let Slice::Extracted(ae_slice) =
+                    Slice::from_nodes(offset_node, *length, expr_arena)
+                else {
+                    unreachable!()
+                };
+
+                if ae_slice.len == ir_slice.len {
+                    assert_eq!(ae_slice.offset, ir_slice.offset);
+                    expr_arena.replace(node, expr_arena.get(input_node).clone());
+                } else if offset_correction != 0 {
+                    let new_offset = ae_slice.offset.checked_sub(offset_correction).unwrap();
+                    expr_arena.replace(
+                        offset_node,
+                        AExpr::Literal(LiteralValue::Scalar(Scalar::new(
+                            DataType::Int64,
+                            AnyValue::Int64(new_offset),
+                        ))),
+                    );
+                }
+            }
+        }
+
+        *self.ae_slice_pd_direct_col_slice_nodes.get() = ae_slice_pd_direct_col_slice_nodes;
 
         match (lp_arena.take(ir_node), state) {
             #[cfg(feature = "python")]

--- a/crates/polars-plan/src/traversal/visitor.rs
+++ b/crates/polars-plan/src/traversal/visitor.rs
@@ -1,3 +1,4 @@
+use std::marker::PhantomData;
 use std::ops::ControlFlow;
 
 use crate::traversal::edge_provider::NodeEdgesProvider;
@@ -28,4 +29,86 @@ pub trait NodeVisitor {
         storage: &mut Self::Storage,
         edges: &mut dyn NodeEdgesProvider<Self::Edge>,
     ) -> ControlFlow<Self::BreakValue>;
+}
+
+pub struct FnVisitors<Key, Storage, Edge, BreakValue, DefaultEdgeFn, PreVisitFn, PostVisitFn>
+where
+    PreVisitFn: FnMut(
+        Key,
+        &mut Storage,
+        &mut dyn NodeEdgesProvider<Edge>,
+    ) -> ControlFlow<BreakValue, SubtreeVisit>,
+    PostVisitFn:
+        FnMut(Key, &mut Storage, &mut dyn NodeEdgesProvider<Edge>) -> ControlFlow<BreakValue>,
+{
+    default_edge_fn: DefaultEdgeFn,
+    pre_visit_fn: PreVisitFn,
+    post_visit_fn: PostVisitFn,
+    phantom: PhantomData<(Key, Storage, Edge, BreakValue)>,
+}
+
+impl<Key, Storage, Edge, BreakValue, DefaultEdgeFn, PreVisitFn, PostVisitFn>
+    FnVisitors<Key, Storage, Edge, BreakValue, DefaultEdgeFn, PreVisitFn, PostVisitFn>
+where
+    DefaultEdgeFn: FnMut() -> Edge,
+    PreVisitFn: FnMut(
+        Key,
+        &mut Storage,
+        &mut dyn NodeEdgesProvider<Edge>,
+    ) -> ControlFlow<BreakValue, SubtreeVisit>,
+    PostVisitFn:
+        FnMut(Key, &mut Storage, &mut dyn NodeEdgesProvider<Edge>) -> ControlFlow<BreakValue>,
+{
+    pub fn new(
+        default_edge_fn: DefaultEdgeFn,
+        pre_visit_fn: PreVisitFn,
+        post_visit_fn: PostVisitFn,
+    ) -> Self {
+        Self {
+            default_edge_fn,
+            pre_visit_fn,
+            post_visit_fn,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<Key, Storage, Edge, BreakValue, DefaultEdgeFn, PreVisitFn, PostVisitFn> NodeVisitor
+    for FnVisitors<Key, Storage, Edge, BreakValue, DefaultEdgeFn, PreVisitFn, PostVisitFn>
+where
+    DefaultEdgeFn: FnMut() -> Edge,
+    PreVisitFn: FnMut(
+        Key,
+        &mut Storage,
+        &mut dyn NodeEdgesProvider<Edge>,
+    ) -> ControlFlow<BreakValue, SubtreeVisit>,
+    PostVisitFn:
+        FnMut(Key, &mut Storage, &mut dyn NodeEdgesProvider<Edge>) -> ControlFlow<BreakValue>,
+{
+    type Key = Key;
+    type Storage = Storage;
+    type Edge = Edge;
+    type BreakValue = BreakValue;
+
+    fn default_edge(&mut self) -> Self::Edge {
+        (self.default_edge_fn)()
+    }
+
+    fn pre_visit(
+        &mut self,
+        key: Self::Key,
+        storage: &mut Self::Storage,
+        edges: &mut dyn NodeEdgesProvider<Self::Edge>,
+    ) -> ControlFlow<Self::BreakValue, SubtreeVisit> {
+        (self.pre_visit_fn)(key, storage, edges)
+    }
+
+    fn post_visit(
+        &mut self,
+        key: Self::Key,
+        storage: &mut Self::Storage,
+        edges: &mut dyn NodeEdgesProvider<Self::Edge>,
+    ) -> ControlFlow<Self::BreakValue> {
+        (self.post_visit_fn)(key, storage, edges)
+    }
 }

--- a/crates/polars-utils/src/collection.rs
+++ b/crates/polars-utils/src/collection.rs
@@ -162,3 +162,35 @@ impl<T> Collection<T> for &mut [T] {
         <[T]>::get_mut(self, idx)
     }
 }
+
+pub struct MappedCollection<'src, Src: ?Sized, T: ?Sized, U: ?Sized> {
+    src: &'src mut Src,
+    map: fn(&T) -> &U,
+    map_mut: fn(&mut T) -> &mut U,
+}
+
+impl<'src, Src: ?Sized, T: ?Sized, U: ?Sized> Collection<U> for MappedCollection<'src, Src, T, U>
+where
+    Src: Collection<T>,
+{
+    fn len(&self) -> usize {
+        self.src.len()
+    }
+
+    fn get(&self, idx: usize) -> Option<&U> {
+        self.src.get(idx).map(|t| (self.map)(t))
+    }
+
+    fn get_mut(&mut self, idx: usize) -> Option<&mut U> {
+        self.src.get_mut(idx).map(|t| (self.map_mut)(t))
+    }
+}
+
+impl<'src, Src: ?Sized, T: ?Sized, U: ?Sized> MappedCollection<'src, Src, T, U>
+where
+    Src: Collection<T>,
+{
+    pub fn new(src: &'src mut Src, map: fn(&T) -> &U, map_mut: fn(&mut T) -> &mut U) -> Self {
+        Self { src, map, map_mut }
+    }
+}

--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -5484,9 +5484,13 @@ Consider using {self}.implode() instead"""
         """
         # This cast enables tail with expressions that return unsigned integers,
         # for which negate otherwise raises InvalidOperationError.
-        offset = -(
-            wrap_expr(parse_into_expression(n)).cast(
-                Int64, strict=False, wrap_numerical=True
+        offset = (
+            -n
+            if isinstance(n, int)
+            else -(
+                wrap_expr(parse_into_expression(n)).cast(
+                    Int64, strict=False, wrap_numerical=True
+                )
             )
         )
         return self.slice(offset, n)

--- a/py-polars/tests/unit/lazyframe/test_optimizations.py
+++ b/py-polars/tests/unit/lazyframe/test_optimizations.py
@@ -443,6 +443,10 @@ def test_slice_pushdown_expr_25473() -> None:
     )
 
     assert_frame_equal(
+        lf.select((pl.col("a") + 1).slice(1, 2)).collect(), pl.DataFrame({"a": [2, 3]})
+    )
+
+    assert_frame_equal(
         lf.select(
             a=(
                 pl.when(pl.col("a") == 1).then(pl.lit("one")).otherwise(pl.lit("other"))
@@ -648,3 +652,260 @@ true,1
 false,2
 """
     assert pl.scan_csv(csv).filter(pl.col.a).select(pl.len()).collect().item() == 1
+
+
+def test_slice_pushdown_expr_create_ir_slice_26592() -> None:
+    lf = pl.scan_csv(
+        pl.DataFrame({"a": [0, 1, 2, 3, 4], "b": [9, 8, 7, 6, 5]}).write_csv().encode()
+    )
+
+    q = lf.select(
+        a_first=pl.min_horizontal(
+            pl.min_horizontal(pl.all()), 99, pl.col("a") + pl.col("b") + 999
+        ).first()
+    )
+    plan = q.explain(optimizations=pl.QueryOptFlags(comm_subexpr_elim=False))
+
+    assert "SLICE: Positive { offset: 0, len: 1 }" in plan
+    # Temporarily inserted expr slice should be pruned
+    assert ".slice(" not in plan
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            [
+                pl.Series("a_first", [0], dtype=pl.Int64),
+            ]
+        ),
+    )
+
+    q = lf.select(a_first=pl.first("a"), b_first=pl.first("b"))
+    plan = q.explain()
+
+    assert "SLICE: Positive { offset: 0, len: 1 }" in plan
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame({"a_first": 0, "b_first": 9}),
+    )
+
+    q = lf.select(
+        a_first=pl.first("a"),
+        a_head1=pl.col("a").head(1),
+        a_head3_sum=pl.col("a").head(3).sum(),
+    )
+    plan = q.explain()
+    assert "SLICE: Positive { offset: 0, len: 3 }" in plan
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            [
+                pl.Series("a_first", [0], dtype=pl.Int64),
+                pl.Series("a_head1", [0], dtype=pl.Int64),
+                pl.Series("a_head3_sum", [3], dtype=pl.Int64),
+            ]
+        ),
+    )
+
+    q = lf.select(
+        a_first=pl.first("a"),
+        a_slice3=pl.col("a").slice(3, 1).sum(),
+    )
+    plan = q.explain()
+    assert "SLICE: Positive { offset: 0, len: 4 }" in plan
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            [
+                pl.Series("a_first", [0], dtype=pl.Int64),
+                pl.Series("a_slice3", [3], dtype=pl.Int64),
+            ]
+        ),
+    )
+
+    q = lf.select(a_last=pl.last("a"))
+    plan = q.explain()
+    assert "SLICE: Negative { offset_from_end: 1, len: 1 }" in plan
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            [
+                pl.Series("a_last", [4], dtype=pl.Int64),
+            ]
+        ),
+    )
+
+    q = lf.select(a_last=pl.last("a"), tail_3=pl.col("a").tail(3))
+    plan = q.explain()
+    assert "SLICE: Negative { offset_from_end: 3, len: 3 }" in plan
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            [
+                pl.Series("a_last", [4, 4, 4], dtype=pl.Int64),
+                pl.Series("tail_3", [2, 3, 4], dtype=pl.Int64),
+            ]
+        ),
+    )
+
+    # NULL length with negative offset -> set len to (-offset) as IdxSize
+    q = lf.select(a_off_neg3=pl.col("a").slice(-3))
+    plan = q.explain()
+    assert "SLICE: Negative { offset_from_end: 3, len: 3 }" in plan
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            [
+                pl.Series("a_off_neg3", [2, 3, 4], dtype=pl.Int64),
+            ]
+        ),
+    )
+
+
+def test_slice_pushdown_expr_no_common_26592() -> None:
+    lf = pl.scan_csv(
+        pl.DataFrame({"a": [0, 1, 2, 3, 4], "b": [9, 8, 7, 6, 5]}).write_csv().encode()
+    )
+
+    q = lf.select(
+        a_first=pl.first("a"),
+        b_sort_first=pl.col("b").sort().first(),
+    )
+    plan = q.explain()
+    assert "SLICE: " not in plan
+
+    assert_frame_equal(q.collect(), pl.DataFrame({"a_first": 0, "b_sort_first": 5}))
+
+
+def test_slice_pushdown_expr_prune_slice_26592() -> None:
+    lf = pl.scan_csv(
+        pl.DataFrame({"a": [0, 1, 2, 3, 4], "b": [9, 8, 7, 6, 5]}).write_csv().encode()
+    )
+
+    q = lf.select(
+        a_1_1=pl.col("a").slice(1, 1).max(),
+        b_1_2=pl.col("b").slice(1, 2),
+    )
+    plan = q.explain()
+
+    # slice(1, 2) should be pruned from the expression tree
+    assert 'col("b").alias("b_1_2")' in plan
+    assert '.slice(offset=0, length=1).max().alias("a_1_1")' in plan
+
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            {
+                "a_1_1": [1, 1],
+                "b_1_2": [8, 7],
+            }
+        ),
+    )
+
+    q = lf.select(
+        a_n2_1=pl.col("a").slice(-2, 1).max(),
+        b_n2_2=pl.col("b").slice(-2, 2),
+    )
+    plan = q.explain()
+
+    # slice(-2, 2) should be pruned from the expression tree
+    assert 'col("b").alias("b_n2_2")' in plan
+    assert '.slice(offset=-2, length=1).max().alias("a_n2_1")' in plan
+
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            {
+                "a_n2_1": [3, 3],
+                "b_n2_2": [6, 5],
+            }
+        ),
+    )
+
+
+def test_slice_pushdown_expr_create_ir_slice_offset_correction_26592() -> None:
+    lf = pl.scan_csv(
+        pl.DataFrame({"a": [0, 1, 2, 3, 4], "b": [9, 8, 7, 6, 5]}).write_csv().encode()
+    )
+
+    q = lf.select(a_off2=pl.col("a").slice(2, 1), a_off3=pl.col("a").slice(3, 1))
+    plan = q.explain()
+    assert "SLICE: Positive { offset: 2, len: 2 }" in plan
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            [
+                pl.Series("a_off2", [2], dtype=pl.Int64),
+                pl.Series("a_off3", [3], dtype=pl.Int64),
+            ]
+        ),
+    )
+
+    q = lf.select(a_off2=pl.col("a").slice(-2, 1), a_off3=pl.col("a").slice(-3, 1))
+    plan = q.explain()
+    assert "SLICE: Negative { offset_from_end: 3, len: 2 }" in plan
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            [
+                pl.Series("a_off2", [3], dtype=pl.Int64),
+                pl.Series("a_off3", [2], dtype=pl.Int64),
+            ]
+        ),
+    )
+
+    # NULL length -> IdxSize::MAX
+    q = lf.select(a_off2=pl.col("a").slice(2))
+    plan = q.explain()
+    assert "SLICE: Positive { offset: 2, len: " in plan
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            [
+                pl.Series("a_off2", [2, 3, 4], dtype=pl.Int64),
+            ]
+        ),
+    )
+
+
+def test_slice_pushdown_expr_height_rules() -> None:
+    lf = pl.LazyFrame({"a": [0, 1, 2, 3, 4]})
+
+    # Single unknown height - push
+    q = lf.select((((pl.lit(pl.Series("x", [0, 1, 2, 3, 4])) + 1) + 2) + 3).head(1))
+    plan = q.explain()
+    assert "Series[x].slice(offset=0, length=1)" in plan
+
+    assert_frame_equal(q.collect(), pl.DataFrame({"x": 6}))
+
+    # Multiple unknown heights - block at binary expr
+    q = lf.select(
+        (
+            (
+                (
+                    (pl.lit(pl.Series("x", [0, 1, 2, 3, 4])) + 1)
+                    + pl.lit(pl.Series([9, 9, 9, 9, 9]))
+                )
+                + 311
+            )
+            + 312
+        ).head(1)
+    )
+    plan = q.explain()
+    assert (
+        plan.index(".slice(offset=0, length=1)") < plan.index("311") < plan.index("312")
+    )
+
+    assert_frame_equal(q.collect(), pl.DataFrame({"x": 633}))
+
+    # Mixed column<>unknown, do not push
+    q = lf.select((pl.col("a") + pl.lit(pl.Series("x", [0, 1, 2, 3, 4]))).slice(1, 1))
+    plan = q.explain()
+    assert plan.index(".slice(offset=1, length=1)]") > plan.index("Series")
+
+    assert_frame_equal(q.collect(), pl.DataFrame({"a": 2}))
+
+    # All column, push
+    q = lf.select((pl.col("a") + (pl.col("a") + 1)).slice(1, 1))
+    plan = q.explain()
+    assert ".slice(" not in plan
+
+    assert_frame_equal(q.collect(), pl.DataFrame({"a": 3}))


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/26592
* Depends on https://github.com/pola-rs/polars/pull/27198

Create IR-level slices as the common slice of all expr slices that apply to columns. This can then be pushed down by the optimizer to perform the slice at lower levels.

In implementation, we add a new expr slice pushdown implementation via recursive tree traversal instead of going through `OptimizationRule::optimize_expr`, and this is called when doing IR slice pushdown on the exprs of each IR.

E.g. `lf.select(pl.all().first())` can currently be much slower than `lf.head(1)`, but after this PR it will optimize to the same as `lf.head(1)`.

Detected exprs: `head()` / `tail()` / `first()` / `last()` / `slice()`.

E.g. - The following now creates a slice at the scan:

```python
print(pl.scan_csv(data).select(pl.first("a")).explain())
# SELECT [col("a").first()]
#   Csv SCAN [12 in-mem bytes]
#   PROJECT */1 COLUMNS
#   SLICE: Positive { offset: 0, len: 1 }
#   ESTIMATED ROWS: 6
```

E.g. - We are able to size the IR::Slice to the exact common boundary, then apply an offset correction to the expr slices -
```python
print(
    pl.scan_csv(data)
    .select(a2=pl.col("a").slice(2, 1), a3=pl.col("a").slice(3, 1))
    .explain()
)
# SELECT [col("a").slice(offset=0, length=1).alias("a2"), col("a").slice(offset=1, length=1).alias("a3")]
#   Csv SCAN [12 in-mem bytes]
#   PROJECT */1 COLUMNS
#   SLICE: Positive { offset: 2, len: 2 }
#   ESTIMATED ROWS: 6

```

As well as for negative slices-
```python
print(
    pl.scan_csv(data)
    .select(a2=pl.col("a").slice(-2, 1), a3=pl.col("a").slice(-3, 1))
    .explain()
)
# SELECT [col("a").slice(offset=-1, length=1).alias("a2"), col("a").slice(offset=-2, length=1).alias("a3")]
#   Csv SCAN [12 in-mem bytes]
#   PROJECT */1 COLUMNS
#   SLICE: Negative { offset_from_end: 3, len: 2 }
#   ESTIMATED ROWS: 6
```

--

* https://github.com/pola-rs/polars/pull/27198
  * https://github.com/pola-rs/polars/pull/27249
    * \> https://github.com/pola-rs/polars/pull/27200
