### PR TITLE
fix(rust): Off-by-one in `lp.with_inputs` length assertion

### DIFF
--- a/crates/polars-plan/src/plans/ir/inputs.rs
+++ b/crates/polars-plan/src/plans/ir/inputs.rs
@@ -1,5 +1,7 @@
 use std::iter;
 
+use polars_utils::itertools::Itertools;
+
 use super::*;
 
 impl IR {
@@ -11,18 +13,9 @@ impl IR {
     where
         E: IntoIterator<Item = ExprIR>,
     {
-        let mut exprs_mut = self.exprs_mut();
-        let mut new_exprs = exprs.into_iter();
-
-        for (expr, new_expr) in exprs_mut.by_ref().zip(new_exprs.by_ref()) {
+        for (expr, new_expr) in self.exprs_mut().zip_eq(exprs) {
             *expr = new_expr;
         }
-
-        assert!(exprs_mut.next().is_none(), "not enough exprs");
-        assert!(new_exprs.next().is_none(), "too many exprs");
-
-        drop(exprs_mut);
-
         self
     }
 
@@ -34,14 +27,9 @@ impl IR {
     where
         I: IntoIterator<Item = Node>,
     {
-        let mut new_inputs = inputs.into_iter();
-
-        for input in self.inputs_mut() {
-            *input = new_inputs.next().expect("not enough inputs");
+        for (input, new_input) in self.inputs_mut().zip_eq(inputs) {
+            *input = new_input;
         }
-
-        assert!(new_inputs.next().is_none(), "too many inputs");
-
         self
     }
 

--- a/crates/polars-utils/src/itertools/mod.rs
+++ b/crates/polars-utils/src/itertools/mod.rs
@@ -128,7 +128,7 @@ pub trait Itertools: Iterator {
     }
 
     /// Zips two iterators but **panics** if they are not of the same length.
-    fn zip_eq<I, J>(self, other: I) -> ZipEq<Self, I::IntoIter>
+    fn zip_eq<I>(self, other: I) -> ZipEq<Self, I::IntoIter>
     where
         Self: Sized,
         I: IntoIterator,


### PR DESCRIPTION
In `IR::with_inputs` assertion, `zip()` could stop after consuming +1 on the LHS in the unequal length case, (e.g. lengths (4, 3) would not trigger this assert)
