### PR TITLE
refactor: Mark `scan_ipc` cache arguments as deprecated

### DIFF
--- a/py-polars/src/polars/io/ipc/functions.py
+++ b/py-polars/src/polars/io/ipc/functions.py
@@ -380,7 +380,7 @@ def scan_ipc(
     ),
     *,
     n_rows: int | None = None,
-    cache: bool = True,
+    cache: bool | None = None,
     rechunk: bool = False,
     row_index_name: str | None = None,
     row_index_offset: int = 0,


### PR DESCRIPTION
Files are no longer cached with the streaming implementation.

Follow-up to https://github.com/pola-rs/polars/pull/25868.

Similar to https://github.com/pola-rs/polars/pull/26711.

fyi @nameexhaustion 