### PR TITLE
fix: Prevent `DataFrame` creation panic on `list[struct]` with heterogenous types

### DIFF
--- a/crates/polars-core/src/frame/row/av_buffer.rs
+++ b/crates/polars-core/src/frame/row/av_buffer.rs
@@ -277,8 +277,8 @@ impl<'a> AnyValueBuffer<'a> {
         Ok(out)
     }
 
-    pub fn into_series(mut self) -> Series {
-        self.reset(0, false).unwrap()
+    pub fn into_series(mut self) -> PolarsResult<Series> {
+        self.reset(0, false)
     }
 
     pub fn new(dtype: &DataType, capacity: usize) -> AnyValueBuffer<'a> {
@@ -670,8 +670,7 @@ impl<'a> AnyValueBufferTrusted<'a> {
                 let old_outer_validity = core::mem::take(outer_validity);
                 outer_validity.reserve(capacity);
 
-                StructChunked::from_series(PlSmallStr::EMPTY, length, v.iter())
-                    .unwrap()
+                StructChunked::from_series(PlSmallStr::EMPTY, length, v.iter())?
                     .with_outer_validity(Some(old_outer_validity.freeze()))
                     .into_series()
             },
@@ -683,8 +682,7 @@ impl<'a> AnyValueBufferTrusted<'a> {
             All(dtype, vals) => {
                 let mut swap_vals = Vec::with_capacity(capacity);
                 std::mem::swap(vals, &mut swap_vals);
-                Series::from_any_values_and_dtype(PlSmallStr::EMPTY, &swap_vals, dtype, false)
-                    .unwrap()
+                Series::from_any_values_and_dtype(PlSmallStr::EMPTY, &swap_vals, dtype, false)?
             },
         };
 

--- a/crates/polars-core/src/frame/row/dataframe.rs
+++ b/crates/polars-core/src/frame/row/dataframe.rs
@@ -80,17 +80,17 @@ impl DataFrame {
             .into_iter()
             .zip(schema.iter_names())
             .map(|(b, name)| {
-                let mut c = b.into_series().into_column();
+                let mut c = b.into_series()?.into_column();
                 // if the schema adds a column not in the rows, we
                 // fill it with nulls
                 if c.is_empty() {
-                    Column::full_null(name.clone(), expected_len, c.dtype())
+                    Ok(Column::full_null(name.clone(), expected_len, c.dtype()))
                 } else {
                     c.rename(name.clone());
-                    c
+                    Ok(c)
                 }
             })
-            .collect();
+            .collect::<PolarsResult<Vec<_>>>()?;
 
         DataFrame::new(expected_len, v)
     }
@@ -123,17 +123,17 @@ impl DataFrame {
             .into_iter()
             .zip(schema.iter_names())
             .map(|(b, name)| {
-                let mut c = b.into_series().into_column();
+                let mut c = b.into_series()?.into_column();
                 // if the schema adds a column not in the rows, we
                 // fill it with nulls
                 if c.is_empty() {
-                    Column::full_null(name.clone(), expected_len, c.dtype())
+                    Ok(Column::full_null(name.clone(), expected_len, c.dtype()))
                 } else {
                     c.rename(name.clone());
-                    c
+                    Ok(c)
                 }
             })
-            .collect();
+            .collect::<PolarsResult<Vec<_>>>()?;
 
         DataFrame::new(expected_len, v)
     }

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -12,7 +12,7 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
-from polars.exceptions import DuplicateError, InvalidOperationError
+from polars.exceptions import ComputeError, DuplicateError, InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -1897,3 +1897,11 @@ def test_join_struct_error_lazy_26276() -> None:
 
     with pytest.raises(pl.exceptions.SchemaError, match=r"struct \{.*\}"):
         lhs.join(rhs, on="x").collect()
+
+
+def test_from_dicts_mixed_struct_schema_raises_not_panics_27170() -> None:
+    records = [{"id": f"id_{i}", "vals": [{"value": i}]} for i in range(200)]
+    records += [{"id": f"bad_{i}", "vals": [{"value": {"key": i}}]} for i in range(5)]
+
+    with pytest.raises(ComputeError):
+        pl.DataFrame(records)


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/27170.

🤖 Claude Sonnet 4.6 for navigating the codebase.
