### PR TITLE
fix(rust): Prevent panic when casting `Array` to extension type with same inner type

### DIFF
--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -736,7 +736,7 @@ impl ArrayChunked {
         length: usize,
     ) -> Self {
         let dtype = DataType::Array(Box::new(inner_dtype.clone()), width);
-        let arrow_dtype = dtype.to_arrow(CompatLevel::newest());
+        let arrow_dtype = dtype.to_arrow(CompatLevel::newest()).to_storage_recursive();
         let field = Arc::new(Field::new(name, dtype));
         if width == 0 {
             use arrow::array::builder::{ArrayBuilder, make_builder};

--- a/py-polars/tests/unit/datatypes/test_extension.py
+++ b/py-polars/tests/unit/datatypes/test_extension.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
     from polars._typing import JoinStrategy, PolarsDataType
@@ -158,3 +158,12 @@ def test_extension_join_payload(how: JoinStrategy) -> None:
     )
     print(result, expected)
     assert_frame_equal(result, expected, check_row_order=False)
+
+
+def test_extension_native_to_extension_cast_27193() -> None:
+    native = pl.Series("inner", [[1, 2], [3, 4]], pl.Array(pl.Int8, 2))
+    casted = native.arr.eval(pl.element().ext.to(PythonTestExtension(storage=pl.Int8)))
+    expected = pl.Series(
+        "inner", [[1, 2], [3, 4]], pl.Array(PythonTestExtension(storage=pl.Int8), 2)
+    )
+    assert_series_equal(casted, expected)


### PR DESCRIPTION
Closes #27193 

Adding `.to_storage_recursive()` within `ArrayChunked` ensures the extension type storage type is unwrapped before being handed over, which prevents a panic in [`FixedSizeListArray`](https://github.com/pola-rs/polars/blob/b4954665fa9318be87988405e4915ceaef050cf8/crates/polars-arrow/src/array/fixed_size_list/mod.rs#L52)

FTC image
<img width="753" height="511" alt="pass" src="https://github.com/user-attachments/assets/d8a30d44-72e0-4026-aa30-c6a7a77bc629" />

