### PR TITLE
fix: replace unwrap() with ? in hist cont_slice() to prevent panic

### DIFF
--- a/crates/polars-ops/src/chunked_array/hist.rs
+++ b/crates/polars-ops/src/chunked_array/hist.rs
@@ -248,7 +248,7 @@ pub fn hist_series(
         let bins_s = bins.rechunk();
         owned_bins = bins_s;
         let bins = owned_bins.f64().unwrap();
-        let bins = bins.cont_slice().unwrap();
+        let bins = bins.cont_slice()?;
         bins_arg = Some(bins);
     };
     polars_ensure!(s.dtype().is_primitive_numeric(), InvalidOperation: "'hist' is only supported for numeric data");


### PR DESCRIPTION
## Problem

`pl.col.a.hist(bins=bins)` panics with `PanicException: called Result::unwrap() on an Err value: ComputeError(ErrString("chunked array is not contiguous"))` when bins data is not contiguous after rechunk.

## Root Cause

`cont_slice().unwrap()` on line 251 of `hist.rs` panics instead of returning a proper error.

## Solution

Replace `.unwrap()` with `?` to propagate the error gracefully.

```rust
// Before:
let bins = bins.cont_slice().unwrap();

// After:
let bins = bins.cont_slice()?;
```

Fixes #27155