### PR TITLE
chore(python): Use more precise internal typing (pt. iii)

### DIFF
--- a/py-polars/src/polars/_utils/__init__.py
+++ b/py-polars/src/polars/_utils/__init__.py
@@ -15,12 +15,12 @@ from polars._utils.convert import (
     to_py_time,
     to_py_timedelta,
 )
-from polars._utils.various import NoDefault, _polars_warn, is_column, no_default
+from polars._utils.various import NO_DEFAULT, NoDefault, _polars_warn, is_column
 
 __all__ = [
     "NoDefault",
     "is_column",
-    "no_default",
+    "NO_DEFAULT",
     # Required for Rust bindings
     "date_to_int",
     "datetime_to_int",

--- a/py-polars/src/polars/_utils/cache.py
+++ b/py-polars/src/polars/_utils/cache.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any, TypeVar, overload
 
-from polars._utils.various import no_default
+from polars._utils.various import NO_DEFAULT
 
 if TYPE_CHECKING:
     import sys
@@ -155,14 +155,14 @@ class LRUCache(MutableMapping[K, V]):
             self.popitem()
         self._max_size = n
 
-    def pop(self, key: K, default: D | NoDefault = no_default) -> V | D:
+    def pop(self, key: K, default: D | NoDefault = NO_DEFAULT) -> V | D:
         """
         Remove specified key from the cache and return the associated value.
 
         If the key is not found, `default` is returned (if given).
         Otherwise, a KeyError is raised.
         """
-        if (item := self._items.pop(key, default)) is no_default:
+        if (item := self._items.pop(key, default)) is NO_DEFAULT:
             msg = f"{key!r} not found in cache"
             raise KeyError(msg)
         return item

--- a/py-polars/src/polars/_utils/construction/dataframe.py
+++ b/py-polars/src/polars/_utils/construction/dataframe.py
@@ -305,13 +305,15 @@ def _post_apply_columns(
     for i, col in enumerate(columns):
         dtype = dtypes.get(col)
         pydf_dtype = pydf_dtypes[i]
+        if dtype is None:
+            continue
         if dtype == Categorical != pydf_dtype:
             column_casts.append(F.col(col).cast(Categorical, strict=strict)._pyexpr)
         elif dtype == Enum != pydf_dtype:
             column_casts.append(F.col(col).cast(dtype, strict=strict)._pyexpr)
         elif structs and (struct := structs.get(col)) and struct != pydf_dtype:
             column_casts.append(F.col(col).cast(struct, strict=strict)._pyexpr)
-        elif dtype is not None and dtype != Unknown and dtype != pydf_dtype:
+        elif dtype != Unknown and dtype != pydf_dtype:
             if dtype.is_temporal() and dtype != Duration and pydf_dtype == String:
                 temporal_cast = F.col(col).str.strptime(dtype, strict=strict)._pyexpr  # type: ignore[arg-type]
                 column_casts.append(temporal_cast)

--- a/py-polars/src/polars/_utils/udfs.py
+++ b/py-polars/src/polars/_utils/udfs.py
@@ -24,7 +24,7 @@ from typing import (
 )
 
 from polars._utils.cache import LRUCache
-from polars._utils.various import no_default, re_escape
+from polars._utils.various import NO_DEFAULT, re_escape
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, MutableMapping
@@ -357,7 +357,7 @@ class BytecodeParser:
     _map_target_name: str | None = None
     _can_attempt_rewrite: bool | None = None
     _caller_variables: dict[str, Any] | None = None
-    _col_expression: tuple[str, str] | NoDefault | None = no_default
+    _col_expression: tuple[str, str] | NoDefault | None = NO_DEFAULT
 
     def __init__(self, function: Callable[[Any], Any], map_target: MapTarget) -> None:
         """
@@ -490,7 +490,7 @@ class BytecodeParser:
 
     def to_expression(self, col: str) -> str | None:
         """Translate postfix bytecode instructions to polars expression/string."""
-        if self._col_expression is not no_default and self._col_expression is not None:
+        if self._col_expression is not NO_DEFAULT and self._col_expression is not None:
             col_name, expr = self._col_expression
             if col != col_name:
                 expr = re.sub(

--- a/py-polars/src/polars/_utils/various.py
+++ b/py-polars/src/polars/_utils/various.py
@@ -451,9 +451,9 @@ class _NoDefault(Enum):
         return "<no_default>"
 
 
-# the "no_default" sentinel should typically be used when one of the valid parameter
+# the "NO_DEFAULT" sentinel should typically be used when one of the valid parameter
 # values is None, as otherwise we cannot determine if the caller has set that value.
-no_default = _NoDefault.no_default
+NO_DEFAULT = _NoDefault.no_default
 NoDefault = Literal[_NoDefault.no_default]
 
 

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -69,9 +69,9 @@ from polars._utils.pycapsule import is_pycapsule, pycapsule_to_frame
 from polars._utils.serde import serialize_polars_object
 from polars._utils.unstable import issue_unstable_warning, unstable
 from polars._utils.various import (
+    NO_DEFAULT,
     _in_notebook,
     is_bool_sequence,
-    no_default,
     normalize_filepath,
     parse_version,
     qualified_type_name,
@@ -9168,7 +9168,7 @@ class DataFrame:
     def get_column(self, name: str, *, default: Any) -> Any: ...
 
     def get_column(
-        self, name: str, *, default: Any | NoDefault = no_default
+        self, name: str, *, default: Any | NoDefault = NO_DEFAULT
     ) -> Series | Any:
         """
         Get a single column by name.
@@ -9219,7 +9219,7 @@ class DataFrame:
         try:
             return wrap_s(self._df.get_column(name))
         except ColumnNotFoundError:
-            if default is no_default:
+            if default is NO_DEFAULT:
                 raise
             return default
 

--- a/py-polars/src/polars/datatypes/convert.py
+++ b/py-polars/src/polars/datatypes/convert.py
@@ -216,7 +216,7 @@ class _DataTypeMappings:
 
     @property
     @functools.lru_cache  # noqa: B019
-    def PY_TYPE_TO_ARROW_TYPE(self) -> dict[PythonDataType, pa.lib.DataType]:
+    def PY_TYPE_TO_ARROW_TYPE(self) -> dict[PythonDataType, pa.DataType]:
         return {
             bool: pa.bool_(),
             date: pa.date32(),
@@ -269,7 +269,7 @@ def dtype_to_py_type(dtype: PolarsDataType) -> PythonDataType:
         raise NotImplementedError(msg) from None
 
 
-def py_type_to_arrow_type(dtype: PythonDataType) -> pa.lib.DataType:
+def py_type_to_arrow_type(dtype: PythonDataType) -> pa.DataType:
     """Convert a Python dtype to an Arrow dtype."""
     try:
         return DataTypeMappings.PY_TYPE_TO_ARROW_TYPE[dtype]

--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -37,9 +37,9 @@ from polars._utils.parse import (
 from polars._utils.unstable import issue_unstable_warning, unstable
 from polars._utils.various import (
     BUILDING_SPHINX_DOCS,
+    NO_DEFAULT,
     extend_bool,
     find_stacklevel,
-    no_default,
     normalize_filepath,
     sphinx_accessor,
     warn_null_comparison,
@@ -11294,9 +11294,9 @@ Consider using {self}.implode() instead"""
     def replace(
         self,
         old: IntoExpr | Sequence[Any] | Mapping[Any, Any],
-        new: IntoExpr | Sequence[Any] | NoDefault = no_default,
+        new: IntoExpr | Sequence[Any] | NoDefault = NO_DEFAULT,
         *,
-        default: IntoExpr | NoDefault = no_default,
+        default: IntoExpr | NoDefault = NO_DEFAULT,
         return_dtype: PolarsDataType | None = None,
     ) -> Expr:
         """
@@ -11437,7 +11437,7 @@ Consider using {self}.implode() instead"""
                 " Use `replace_strict` instead to set a return data type while replacing values.",
                 version="1.0.0",
             )
-        if default is not no_default:
+        if default is not NO_DEFAULT:
             issue_deprecation_warning(
                 "the `default` parameter for `replace` is deprecated."
                 " Use `replace_strict` instead to set a default while replacing values.",
@@ -11447,7 +11447,7 @@ Consider using {self}.implode() instead"""
                 old, new, default=default, return_dtype=return_dtype
             )
 
-        if new is no_default:
+        if new is NO_DEFAULT:
             if not isinstance(old, Mapping):
                 msg = (
                     "`new` argument is required if `old` argument is not a Mapping type"
@@ -11474,9 +11474,9 @@ Consider using {self}.implode() instead"""
     def replace_strict(
         self,
         old: IntoExpr | Sequence[Any] | Mapping[Any, Any],
-        new: IntoExpr | Sequence[Any] | NoDefault = no_default,
+        new: IntoExpr | Sequence[Any] | NoDefault = NO_DEFAULT,
         *,
-        default: IntoExpr | NoDefault = no_default,
+        default: IntoExpr | NoDefault = NO_DEFAULT,
         return_dtype: PolarsDataType | pl.DataTypeExpr | None = None,
     ) -> Expr:
         """
@@ -11643,7 +11643,7 @@ Consider using {self}.implode() instead"""
         │ 3   ┆ 1.0 ┆ 10.0     │
         └─────┴─────┴──────────┘
         """  # noqa: W505
-        if new is no_default:
+        if new is NO_DEFAULT:
             if not isinstance(old, Mapping):
                 msg = (
                     "`new` argument is required if `old` argument is not a Mapping type"
@@ -11663,7 +11663,7 @@ Consider using {self}.implode() instead"""
 
         default_pyexpr = (
             None
-            if default is no_default
+            if default is NO_DEFAULT
             else parse_into_expression(default, str_as_lit=True)
         )
 

--- a/py-polars/src/polars/expr/string.py
+++ b/py-polars/src/polars/expr/string.py
@@ -10,9 +10,9 @@ from polars._utils.deprecation import deprecate_nonkeyword_arguments, deprecated
 from polars._utils.parse import parse_into_expression
 from polars._utils.unstable import unstable
 from polars._utils.various import (
+    NO_DEFAULT,
     find_stacklevel,
     issue_warning,
-    no_default,
     qualified_type_name,
 )
 from polars._utils.wrap import wrap_expr
@@ -2646,7 +2646,7 @@ class ExprStringNameSpace:
     def replace_many(
         self,
         patterns: IntoExpr | Mapping[str, str],
-        replace_with: IntoExpr | NoDefault = no_default,
+        replace_with: IntoExpr | NoDefault = NO_DEFAULT,
         *,
         ascii_case_insensitive: bool = False,
         leftmost: bool = False,
@@ -2826,7 +2826,7 @@ class ExprStringNameSpace:
         │ abcd     ┆ z        │
         └──────────┴──────────┘
         """  # noqa: W505
-        if replace_with is no_default:
+        if replace_with is NO_DEFAULT:
             if not isinstance(patterns, Mapping):
                 msg = "`replace_with` argument is required if `patterns` argument is not a Mapping type"
                 raise TypeError(msg)

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -58,8 +58,8 @@ from polars._utils.getitem import get_series_item_by_key
 from polars._utils.unstable import unstable
 from polars._utils.various import (
     BUILDING_SPHINX_DOCS,
+    NO_DEFAULT,
     _is_generator,
-    no_default,
     parse_version,
     qualified_type_name,
     require_same_type,
@@ -8766,9 +8766,9 @@ class Series:
     def replace(
         self,
         old: IntoExpr | Sequence[Any] | Mapping[Any, Any],
-        new: IntoExpr | Sequence[Any] | NoDefault = no_default,
+        new: IntoExpr | Sequence[Any] | NoDefault = NO_DEFAULT,
         *,
-        default: IntoExpr | NoDefault = no_default,
+        default: IntoExpr | NoDefault = NO_DEFAULT,
         return_dtype: PolarsDataType | None = None,
     ) -> Self:
         """
@@ -8871,9 +8871,9 @@ class Series:
     def replace_strict(
         self,
         old: IntoExpr | Sequence[Any] | Mapping[Any, Any],
-        new: IntoExpr | Sequence[Any] | NoDefault = no_default,
+        new: IntoExpr | Sequence[Any] | NoDefault = NO_DEFAULT,
         *,
-        default: IntoExpr | NoDefault = no_default,
+        default: IntoExpr | NoDefault = NO_DEFAULT,
         return_dtype: PolarsDataType | None = None,
     ) -> Self:
         """

--- a/py-polars/src/polars/series/string.py
+++ b/py-polars/src/polars/series/string.py
@@ -6,7 +6,7 @@ import polars._reexport as pl
 import polars.functions as F
 from polars._utils.deprecation import deprecate_nonkeyword_arguments, deprecated
 from polars._utils.unstable import unstable
-from polars._utils.various import no_default
+from polars._utils.various import NO_DEFAULT
 from polars._utils.wrap import wrap_s
 from polars.datatypes import Int64
 from polars.datatypes.classes import Datetime
@@ -2029,7 +2029,7 @@ class StringNameSpace:
     def replace_many(
         self,
         patterns: Series | list[str] | Mapping[str, str],
-        replace_with: Series | list[str] | str | NoDefault = no_default,
+        replace_with: Series | list[str] | str | NoDefault = NO_DEFAULT,
         *,
         ascii_case_insensitive: bool = False,
         leftmost: bool = False,

--- a/py-polars/tests/unit/constructors/test_convert.py
+++ b/py-polars/tests/unit/constructors/test_convert.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 import polars as pl
@@ -39,7 +41,7 @@ def test_from_dicts_empty() -> None:
 
 
 def test_from_dicts_all_cols_6716() -> None:
-    dicts = [{"a": None} for _ in range(20)] + [{"a": "crash"}]
+    dicts: list[dict[str, Any]] = [{"a": None} for _ in range(20)] + [{"a": "crash"}]
 
     with pytest.raises(
         ComputeError, match="make sure that all rows have the same schema"

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Sequence
 
     from polars import Expr
-    from polars._typing import JoinStrategy, UniqueKeepStrategy
+    from polars._typing import JoinStrategy, PolarsDataType, UniqueKeepStrategy
     from tests.conftest import PlMonkeyPatch
 
 
@@ -190,7 +190,7 @@ def test_from_arrow(plmonkeypatch: PlMonkeyPatch) -> None:
         }
     )
     record_batches = tbl.to_batches(max_chunksize=1)
-    expected_schema = {
+    expected_schema: dict[str, PolarsDataType] = {
         "a": pl.Datetime("ms"),
         "b": pl.Datetime("ms"),
         "c": pl.Datetime("us"),
@@ -241,7 +241,7 @@ def test_from_arrow(plmonkeypatch: PlMonkeyPatch) -> None:
     # try a single column dtype override
     for t in (tbl, empty_tbl):
         df = pl.DataFrame(t, schema_overrides={"e": pl.Int8})
-        override_schema = expected_schema.copy()
+        override_schema: dict[str, PolarsDataType] = expected_schema.copy()
         override_schema["e"] = pl.Int8
         assert df.schema == override_schema
         assert df.rows() == expected_data[: (df.height)]
@@ -2860,6 +2860,7 @@ def test_init_datetimes_with_timezone() -> None:
     tz_europe = "Europe/Amsterdam"
 
     dtm = datetime(2022, 10, 12, 12, 30)
+    type_overrides: dict[str, Any]
     for time_unit in DTYPE_TEMPORAL_UNITS:
         for type_overrides in (
             {

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -826,34 +826,29 @@ def test_concat_deprecation() -> None:
     ],
 )
 def test_reinterpret_numeric_dtype_13659(compatible_set: list[pl.DataType]) -> None:
-    try:
-        for source_dtype, target_dtype in permutations(compatible_set, 2):
-            q = (
-                pl.DataFrame({"a": pl.Series([0, 1, 2]).cast(source_dtype)})
-                .lazy()
-                .select(pl.col("a").reinterpret(dtype=target_dtype))
+    for source_dtype, target_dtype in permutations(compatible_set, 2):
+        q = (
+            pl.DataFrame({"a": pl.Series([0, 1, 2]).cast(source_dtype)})
+            .lazy()
+            .select(pl.col("a").reinterpret(dtype=target_dtype))
+        )
+
+        assert q.collect_schema().dtypes() == [target_dtype]
+
+        expect = (
+            pl.DataFrame({"a": pl.Series([0, 1, 2]).cast(target_dtype)})
+            if source_dtype.is_integer() and target_dtype.is_integer()
+            else pl.DataFrame(
+                {
+                    "a": pl.Series([0, 1, 2])
+                    .cast(source_dtype)
+                    .to_numpy()
+                    .view(pl.Series([1]).cast(target_dtype).to_numpy().dtype)
+                }
             )
+        )
 
-            assert q.collect_schema().dtypes() == [target_dtype]
-
-            expect = (
-                pl.DataFrame({"a": pl.Series([0, 1, 2]).cast(target_dtype)})
-                if source_dtype.is_integer() and target_dtype.is_integer()
-                else pl.DataFrame(
-                    {
-                        "a": pl.Series([0, 1, 2])
-                        .cast(source_dtype)
-                        .to_numpy()
-                        .view(pl.Series([1]).cast(target_dtype).to_numpy().dtype)
-                    }
-                )
-            )
-
-            assert_frame_equal(q.collect(), expect)
-
-    except Exception as e:
-        msg = f"{e}; {(source_dtype, target_dtype) = }"
-        raise type(e)(msg) from e
+        assert_frame_equal(q.collect(), expect)
 
 
 def test_reinterpret_errors_13659() -> None:

--- a/py-polars/tests/unit/interop/test_to_pandas.py
+++ b/py-polars/tests/unit/interop/test_to_pandas.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import hypothesis.strategies as st
 import numpy as np
@@ -48,7 +48,7 @@ def test_to_pandas() -> None:
     string_dtype = (
         pd.StringDtype(na_value=float("nan")) if pd_version >= (3,) else np.object_
     )
-    pd_out_dtypes_expected = [
+    pd_out_dtypes_expected: list[Any] = [
         np.dtype(np.uint8),
         np.dtype(np.float64),
         np.dtype(np.float64),

--- a/py-polars/tests/unit/io/database/test_async.py
+++ b/py-polars/tests/unit/io/database/test_async.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from math import ceil
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, overload
+from typing import TYPE_CHECKING, Any, cast, overload
 
 import pytest
 import sqlalchemy
@@ -195,11 +195,13 @@ def test_surrealdb_fetchall(batch_size: int | None) -> None:
             )
         )
         if batch_size:
-            frames = list(res)  # type: ignore[call-overload]
+            res = cast("Iterable[pl.DataFrame]", res)
+            frames = list(res)
             n_mock_rows = len(SURREAL_MOCK_DATA)
             assert len(frames) == ceil(n_mock_rows / batch_size)
             assert_frame_equal(df_expected[:batch_size], frames[0])
         else:
+            res = cast("pl.DataFrame", res)
             assert_frame_equal(df_expected, res)  # type: ignore[arg-type]
 
 

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -558,7 +558,7 @@ def test_hive_partition_force_async_17155(
 @pytest.mark.parametrize("projection_pushdown", [True, False])
 def test_hive_partition_columns_contained_in_file(
     tmp_path: Path,
-    scan_func: Callable[[Any], pl.LazyFrame],
+    scan_func: Callable[..., pl.LazyFrame],
     write_func: Callable[[pl.DataFrame, Path], None],
     projection_pushdown: bool,
 ) -> None:
@@ -591,7 +591,7 @@ def test_hive_partition_columns_contained_in_file(
                 df.select(projection),
             )
 
-    lf = scan_func(path, hive_partitioning=True)  # type: ignore[call-arg]
+    lf = scan_func(path, hive_partitioning=True)
     rhs = df
     assert_frame_equal(
         lf.collect(
@@ -601,7 +601,7 @@ def test_hive_partition_columns_contained_in_file(
     )
     assert_with_projections(lf, rhs)
 
-    lf = scan_func(  # type: ignore[call-arg]
+    lf = scan_func(
         path,
         hive_schema={"a": pl.String, "b": pl.String},
         hive_partitioning=True,
@@ -630,7 +630,7 @@ def test_hive_partition_columns_contained_in_file(
         pl.col("a").cast(pl.Int64),
     )
 
-    lf = scan_func(partial_path, hive_partitioning=True)  # type: ignore[call-arg]
+    lf = scan_func(partial_path, hive_partitioning=True)
     assert_frame_equal(
         lf.collect(
             optimizations=pl.QueryOptFlags(projection_pushdown=projection_pushdown)
@@ -663,7 +663,7 @@ def test_hive_partition_columns_contained_in_file(
         row_index="index",
     )
 
-    lf = scan_func(  # type: ignore[call-arg]
+    lf = scan_func(
         partial_path,
         hive_schema={"a": pl.String, "b": pl.String},
         hive_partitioning=True,

--- a/py-polars/tests/unit/io/test_lazy_json.py
+++ b/py-polars/tests/unit/io/test_lazy_json.py
@@ -11,7 +11,7 @@ from polars.testing import assert_frame_equal
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from polars._typing import NdjsonCompression
+    from polars._typing import NdjsonCompression, PolarsDataType
     from tests.conftest import PlMonkeyPatch
 
 
@@ -43,7 +43,7 @@ def test_scan_ndjson(foods_ndjson_path: Path) -> None:
 
 
 def test_scan_ndjson_with_schema(foods_ndjson_path: Path) -> None:
-    schema = {
+    schema: dict[str, PolarsDataType] = {
         "category": pl.Categorical,
         "calories": pl.Int64,
         "fats_g": pl.Float64,

--- a/py-polars/tests/unit/io/test_write.py
+++ b/py-polars/tests/unit/io/test_write.py
@@ -41,19 +41,19 @@ READ_WRITE_FUNC_PARAM = [
 )
 @pytest.mark.write_disk
 def test_write_async(
-    read_func: Callable[[Path], pl.DataFrame],
-    write_func: Callable[[pl.DataFrame, Path], None],
+    read_func: Callable[[str], pl.DataFrame],
+    write_func: Callable[[pl.DataFrame, str], None],
     tmp_path: Path,
 ) -> None:
     tmp_path.mkdir(exist_ok=True)
     path = (tmp_path / "1").absolute()
-    path = format_file_uri(path)  # type: ignore[assignment]
+    path_str = format_file_uri(path)
 
     df = pl.DataFrame({"x": 1})
 
-    write_func(df, path)
+    write_func(df, path_str)
 
-    assert_frame_equal(read_func(path), df)
+    assert_frame_equal(read_func(path_str), df)
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/meta/test_config.py
+++ b/py-polars/tests/unit/meta/test_config.py
@@ -632,6 +632,7 @@ def test_config_load_save(tmp_path: Path) -> None:
         assert os.environ.get("POLARS_VERBOSE") == "0"
 
         # ...load back from config file/string...
+        assert isinstance(cfg, str)
         if file is None:
             pl.Config.load(cfg)
         else:

--- a/py-polars/tests/unit/operations/aggregation/test_horizontal.py
+++ b/py-polars/tests/unit/operations/aggregation/test_horizontal.py
@@ -12,6 +12,8 @@ from polars.exceptions import ComputeError, InvalidOperationError, PolarsError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from polars._typing import PolarsDataType
 
 
@@ -627,7 +629,9 @@ def test_fold_all_schema() -> None:
         pl.sum_horizontal,
     ],
 )
-def test_expected_horizontal_dtype_errors(horizontal_func: type[pl.Expr]) -> None:
+def test_expected_horizontal_dtype_errors(
+    horizontal_func: Callable[..., pl.Expr],
+) -> None:
     from decimal import Decimal as D
 
     import polars as pl
@@ -643,7 +647,7 @@ def test_expected_horizontal_dtype_errors(horizontal_func: type[pl.Expr]) -> Non
     )
     with pytest.raises(PolarsError):
         df.select(
-            horizontal_func(  # type: ignore[call-arg]
+            horizontal_func(
                 pl.col("cola"),
                 pl.col("colb"),
                 pl.col("colc"),

--- a/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
+++ b/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
@@ -356,6 +356,7 @@ def test_parse_apply_functions(
 
     parser = BytecodeParser(eval(func), map_target="expr")
     suggested_expression = parser.to_expression(col)
+    assert suggested_expression is not None
     assert suggested_expression == expr_repr
 
     df = pl.DataFrame(
@@ -538,6 +539,7 @@ def test_parse_apply_series(
 
     parser = BytecodeParser(func, map_target="series")
     suggested_expression = parser.to_expression(s.name)
+    assert suggested_expression is not None
     assert suggested_expression == expr_repr
 
     with pytest.warns(

--- a/py-polars/tests/unit/operations/test_index_of.py
+++ b/py-polars/tests/unit/operations/test_index_of.py
@@ -60,7 +60,7 @@ def assert_index_of(
 
 @pytest.mark.parametrize("dtype", [pl.Float32, pl.Float64])
 def test_float(dtype: pl.DataType) -> None:
-    values = [1.5, np.nan, np.inf, 3.0, None, -np.inf, 0.0, -0.0, -np.nan]
+    values: list[Any] = [1.5, np.nan, np.inf, 3.0, None, -np.inf, 0.0, -0.0, -np.nan]
     if dtype == pl.Float32:
         # Can't pass Python literals to index_of() for Float32
         values = [(None if v is None else np.float32(v)) for v in values]  # type: ignore[misc]
@@ -70,7 +70,7 @@ def test_float(dtype: pl.DataType) -> None:
     sorted_series_desc = series.sort(descending=True)
     chunked_series = pl.concat([pl.Series([1, 7], dtype=dtype), series], rechunk=False)
 
-    extra_values = [
+    extra_values: list[Any] = [
         np.int8(3),
         np.float32(1.5),
         np.float32(2**10),

--- a/py-polars/tests/unit/operations/test_top_k.py
+++ b/py-polars/tests/unit/operations/test_top_k.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import re
-from collections.abc import Callable
+from typing import TYPE_CHECKING, Protocol
 
 import pytest
 from hypothesis import given
@@ -10,6 +12,24 @@ import polars.selectors as cs
 from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 from polars.testing.parametric import series
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Sequence
+
+    from polars._typing import IntoExpr
+
+    class TopKFunction(Protocol):
+        """Function signature of `DataFrame.top_k` / `DataFrame.bottom_k`."""
+
+        def __call__(
+            self,
+            df: pl.DataFrame,
+            /,
+            k: int,
+            *,
+            by: IntoExpr | Iterable[IntoExpr],
+            reverse: bool | Sequence[bool] = False,
+        ) -> pl.DataFrame: ...
 
 
 def test_top_k() -> None:
@@ -487,12 +507,13 @@ def test_sorted_top_k_20719(descending: bool) -> None:
     # Note: Output stability is guaranteed by the input sortedness as an
     # implementation detail.
 
+    func: TopKFunction
     for func, reverse in [
-        [pl.DataFrame.top_k, False],
-        [pl.DataFrame.bottom_k, True],
+        (pl.DataFrame.top_k, False),
+        (pl.DataFrame.bottom_k, True),
     ]:
         assert_frame_equal(
-            df.pipe(func, 2, by="a", reverse=reverse),  # type: ignore[arg-type]
+            df.pipe(func, 2, by="a", reverse=reverse),
             pl.DataFrame(
                 [
                     {"a": 10, "b": 20},
@@ -502,11 +523,11 @@ def test_sorted_top_k_20719(descending: bool) -> None:
         )
 
     for func, reverse in [
-        [pl.DataFrame.top_k, True],
-        [pl.DataFrame.bottom_k, False],
+        (pl.DataFrame.top_k, True),
+        (pl.DataFrame.bottom_k, False),
     ]:
         assert_frame_equal(
-            df.pipe(func, 2, by="a", reverse=reverse),  # type: ignore[arg-type]
+            df.pipe(func, 2, by="a", reverse=reverse),
             pl.DataFrame(
                 [
                     {"a": 1, "b": 1},
@@ -527,13 +548,13 @@ def test_sorted_top_k_20719(descending: bool) -> None:
 )
 @pytest.mark.parametrize("descending", [True, False])
 def test_sorted_top_k_duplicates(
-    func: Callable[[pl.DataFrame], pl.DataFrame],
+    func: TopKFunction,
     reverse: bool,
     expect: pl.DataFrame,
     descending: bool,
 ) -> None:
     assert_frame_equal(
-        pl.DataFrame({"a": [1, 2, 2]})  # type: ignore[call-arg]
+        pl.DataFrame({"a": [1, 2, 2]})
         .sort("a", descending=descending)
         .pipe(func, 2, by="a", reverse=reverse),
         expect,


### PR DESCRIPTION
Another step towards #27049 

After this one, I think we'll need to wait for the upstream issues to be resolved (they're listed in the issue). But I don't think we're too far off from being able to run a modern type checker in CI

This shows 24 files changed but most changes are _tiny_

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  3. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
