### PR TITLE
fix(rust): Ensure index column is sorted in streaming rolling aggs

### DIFF
--- a/crates/polars-stream/src/nodes/rolling_group_by.rs
+++ b/crates/polars-stream/src/nodes/rolling_group_by.rs
@@ -6,6 +6,7 @@ use polars_core::prelude::{Column, DataType, GroupsType, TimeUnit};
 use polars_core::schema::Schema;
 use polars_error::{PolarsError, PolarsResult, polars_bail, polars_ensure};
 use polars_expr::state::ExecutionState;
+use polars_ops::series::SeriesMethods;
 use polars_time::prelude::{RollingWindower, ensure_duration_matches_dtype};
 use polars_time::{ClosedWindow, Duration};
 use polars_utils::IdxSize;
@@ -311,6 +312,7 @@ impl ComputeNode for RollingGroupBy {
         //
         // This finds boundaries to distribute to worker threads over.
         join_handles.push(scope.spawn_task(TaskPriority::High, async move {
+            let mut prev_max = None;
             while let Ok(morsel) = recv.recv().await
                 && self.slice_length > 0
             {
@@ -327,7 +329,18 @@ impl ComputeNode for RollingGroupBy {
                     morsel_index_column.null_count() == 0,
                     ComputeError: "null values in `rolling` not supported, fill nulls."
                 );
-
+                morsel_index_column
+                    .as_materialized_series()
+                    .ensure_sorted_arg("rolling")?;
+                if let Some(prev_max) = prev_max {
+                    polars_ensure!(prev_max <= morsel_index_column.get(0)?,
+                        InvalidOperation: "argument in operation 'rolling' is not sorted, please sort the 'expr/series/column' first");
+                }
+                prev_max = Some(
+                    morsel_index_column
+                        .get(morsel_index_column.len() - 1)?
+                        .into_static(),
+                );
                 self.buf_key_column.append(morsel_index_column)?;
 
                 use DataType as DT;

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
         RankMethod,
         TimeUnit,
     )
+    from tests.conftest import PlMonkeyPatch
 
 
 @pytest.fixture
@@ -2428,3 +2429,14 @@ def test_rolling_corr_ddof_invariant_27013() -> None:
 
     assert r0 == pytest.approx(1.0)
     assert r2 == pytest.approx(1.0)
+
+
+def test_rolling_streaming_ensures_sorted_27231(plmonkeypatch: PlMonkeyPatch) -> None:
+    plmonkeypatch.setenv("POLARS_IDEAL_MORSEL_SIZE", "2")
+    df = pl.LazyFrame({"index": [1, 4, 2, 3], "values": [1, 2, 3, 4]})
+    q = df.rolling("index", period="2i").agg(pl.col("values"))
+    with pytest.raises(
+        InvalidOperationError,
+        match="argument in operation 'rolling' is not sorted",
+    ):
+        q.collect(engine="streaming")


### PR DESCRIPTION
Previously, the streaming engine would not surface an error if the index
column for a rolling aggregation was not sorted. Do so by ensuring each
morsel is sorted, and that the maximum observed value of a previous morsel
is ordered before the minimum value of the next morsel.

- Closes https://github.com/pola-rs/polars/issues/27231
