### PR TITLE
fix: Preserve nulls when casting from all-null `Series` to `Struct`

### DIFF
--- a/crates/polars-core/src/series/ops/null.rs
+++ b/crates/polars-core/src/series/ops/null.rs
@@ -56,12 +56,8 @@ impl Series {
                     .collect::<Vec<_>>();
                 let ca = StructChunked::from_series(name, size, fields.iter()).unwrap();
 
-                if !fields.is_empty() {
-                    ca.with_outer_validity(Some(Bitmap::new_zeroed(size)))
-                        .into_series()
-                } else {
-                    ca.into_series()
-                }
+                ca.with_outer_validity(Some(Bitmap::new_zeroed(size)))
+                    .into_series()
             },
             DataType::BinaryOffset => {
                 let length = size;

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -2482,3 +2482,11 @@ def test_setitem_invalid_series_dtype_27110() -> None:
     idx = pl.Series([0.0, 2.0])
     with pytest.raises(TypeError, match="cannot use Series of dtype"):
         s[idx] = 99
+
+
+def test_full_null_cast_to_empty_struct_23276() -> None:
+    s = pl.Series([None])
+    assert s.cast(pl.Struct({}))[0] is None
+
+    s = pl.Series([None, None, None])
+    assert s.cast(pl.Struct({})).to_list() == [None, None, None]


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/23276.

The bug in the code was that the chunked array was only being created with an outer validity bitmap if the target `Struct` fields were not empty. If the fields were empty, it would delegate to making a `Series` straight from a `StructChunked` which would just be an empty container with a length of `size` and no validity bitmap, so Arrow would treat it as valid and not `null`, resulting in an empty `Struct`.

The fix was to always create the chunked array with an outer validity bitmap, allowing Arrow to recognize that a particular row is `null` rather than just an empty `Struct`.

🤖 Claude Sonnet 4.6 for helping me understand chunked array dynamics and the issue.