### PR TITLE
fix(object): avoid panic when printing DataFrame with ObjectChunked scalar

### DIFF
--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -939,7 +939,6 @@ fn any_values_to_struct(
 #[cfg(feature = "object")]
 fn any_values_to_object(values: &[AnyValue]) -> PolarsResult<Series> {
     use crate::chunked_array::object::registry;
-    let converter = registry::get_object_converter();
     let mut builder = registry::get_object_builder(PlSmallStr::EMPTY, values.len());
     for av in values {
         match av {
@@ -948,6 +947,7 @@ fn any_values_to_object(values: &[AnyValue]) -> PolarsResult<Series> {
             _ => {
                 // This is needed because in Python users can send mixed types.
                 // This only works if you set a global converter.
+                let converter = registry::get_object_converter();
                 let any = converter(av.as_borrowed());
                 builder.append_value(&*any)
             },


### PR DESCRIPTION
## Problem

Fixes #27078

When an `ObjectChunked` of length 1 is used in a `DataFrame` alongside columns with longer length (e.g., length 3), printing the DataFrame causes a panic:

```
called `Option::unwrap()` on a `None` value
at polars-core/src/chunked_array/object/registry.rs:157
```

## Root Cause

When the DataFrame aligns columns, the length-1 `ObjectChunked` gets stored as a `ScalarColumn`. During formatting (`Display::fmt` for `DataFrame`), the `ScalarColumn` is materialized back into a `Series` via:

`ScalarColumn::to_series` → `Scalar::into_series` → `Series::from_any_values_and_dtype` → `any_values_to_object`

In `any_values_to_object`, `get_object_converter()` is called **unconditionally** at the top of the function. This function does `reg.object_converter.as_ref().unwrap()`, which panics when no object converter has been registered — which is the case when users create custom `PolarsObject` types directly via `ObjectChunked::new_from_vec` without going through the Python registry.

However, the converter is only actually **needed** in the `_` fallback branch for mixed-type (non-`Object`) `AnyValues` — a Python-specific use case. For the common case where all values are `AnyValue::Object` or `AnyValue::Null`, the converter is never used.

## Solution

Move the `get_object_converter()` call from the top of `any_values_to_object` into the `_` branch, so it is only evaluated when actually needed. This prevents the panic when all `AnyValue`s are already `Object` or `Null` variants.

## Testing

- `cargo check -p polars-core --features object` compiles successfully
- The fix directly addresses the panic path shown in the stack trace in #27078
- No behavior change for Python users (the converter is still called when mixed types are encountered)