### PR TITLE
fix: Handle sliced list arrays correctly in Avro writer

### DIFF
--- a/crates/polars-arrow/src/io/avro/write/serialize.rs
+++ b/crates/polars-arrow/src/io/avro/write/serialize.rs
@@ -16,6 +16,12 @@ const IS_VALID: u8 = 2;
 /// (i.e. a column -> row transposition of types known at run-time)
 pub type BoxSerializer<'a> = Box<dyn StreamingIterator<Item = [u8]> + 'a + Send + Sync>;
 
+fn skip_serializer_items(serializer: &mut BoxSerializer<'_>, n: usize) {
+    for _ in 0..n {
+        let _ = serializer.next();
+    }
+}
+
 fn utf8_required<O: Offset>(array: &Utf8Array<O>) -> BoxSerializer<'_> {
     Box::new(BufStreamingIterator::new(
         array.values_iter(),
@@ -102,6 +108,11 @@ fn list_required<'a, O: Offset>(array: &'a ListArray<O>, schema: &AvroSchema) ->
         .buffer()
         .windows(2)
         .map(|w| (w[1] - w[0]).to_usize() as i64);
+    let first_offset = array.offsets().first().to_usize();
+
+    // Sliced list arrays keep their original child values buffer; skip the elements
+    // before the first logical offset so we serialize the visible rows only.
+    skip_serializer_items(&mut inner, first_offset);
 
     Box::new(BufStreamingIterator::new(
         lengths,
@@ -129,6 +140,11 @@ fn list_optional<'a, O: Offset>(array: &'a ListArray<O>, schema: &AvroSchema) ->
         .windows(2)
         .map(|w| (w[1] - w[0]).to_usize() as i64);
     let lengths = ZipValidity::new_with_validity(lengths, array.validity());
+    let first_offset = array.offsets().first().to_usize();
+
+    // Sliced list arrays keep their original child values buffer; skip the elements
+    // before the first logical offset so we serialize the visible rows only.
+    skip_serializer_items(&mut inner, first_offset);
 
     Box::new(BufStreamingIterator::new(
         lengths,

--- a/crates/polars/tests/it/io/avro/write.rs
+++ b/crates/polars/tests/it/io/avro/write.rs
@@ -485,3 +485,57 @@ fn test_with_columns() -> PolarsResult<()> {
 
     Ok(())
 }
+
+#[test]
+fn sliced_list_columns_roundtrip() -> PolarsResult<()> {
+    let labels_dtype = ArrowDataType::List(Box::new(Field::new(
+        "item".into(),
+        ArrowDataType::Utf8,
+        false,
+    )));
+    let nullable_labels_dtype = ArrowDataType::List(Box::new(Field::new(
+        "item".into(),
+        ArrowDataType::Utf8,
+        false,
+    )));
+
+    let labels = ListArray::<i32>::new(
+        labels_dtype.clone(),
+        vec![0, 2, 4, 6].try_into().unwrap(),
+        Utf8Array::<i32>::from_slice([
+            "label_0", "label_1", "label_2", "label_3", "label_4", "label_5",
+        ])
+        .boxed(),
+        None,
+    )
+    .sliced(1, 2);
+
+    let nullable_labels = ListArray::<i32>::new(
+        nullable_labels_dtype.clone(),
+        vec![0, 2, 4, 4].try_into().unwrap(),
+        Utf8Array::<i32>::from_slice(["value_0", "value_1", "value_2", "value_3"]).boxed(),
+        Some([true, true, false].into()),
+    )
+    .sliced(1, 2);
+
+    let schema = ArrowSchema::from_iter([
+        Field::new("labels".into(), labels_dtype, false),
+        Field::new("nullable_labels".into(), nullable_labels_dtype, true),
+    ]);
+
+    let expected = RecordBatchT::new(
+        2,
+        Arc::new(schema.clone()),
+        vec![labels.boxed(), nullable_labels.boxed()],
+    );
+
+    let data = write_avro(&expected, &schema, None)?;
+    let (result, read_schema) = read_avro(&data, None)?;
+
+    assert_eq!(read_schema, schema);
+    for (lhs, rhs) in result.columns().iter().zip(expected.columns().iter()) {
+        assert_eq!(lhs.as_ref(), rhs.as_ref());
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- skip child values before the first logical offset when serializing sliced list arrays to Avro
- add a regression test covering sliced required and nullable `list[str]` columns in Avro roundtrip

Alternative to #27137.
Fixes #27090.

## Test plan
- cargo test -p polars-arrow --features io_avro --lib
