### PR TITLE
perf: Avoid unnecessary rechunk when sorting already sorted DataFrame

### DIFF
--- a/crates/polars-mem-engine/src/executors/sort.rs
+++ b/crates/polars-mem-engine/src/executors/sort.rs
@@ -13,10 +13,9 @@ impl SortExec {
     fn execute_impl(
         &mut self,
         state: &ExecutionState,
-        mut df: DataFrame,
+        df: DataFrame,
     ) -> PolarsResult<DataFrame> {
         state.should_stop()?;
-        df.rechunk_mut_par();
 
         let height = df.height();
 

--- a/crates/polars-mem-engine/src/executors/sort.rs
+++ b/crates/polars-mem-engine/src/executors/sort.rs
@@ -10,11 +10,7 @@ pub(crate) struct SortExec {
 }
 
 impl SortExec {
-    fn execute_impl(
-        &mut self,
-        state: &ExecutionState,
-        df: DataFrame,
-    ) -> PolarsResult<DataFrame> {
+    fn execute_impl(&mut self, state: &ExecutionState, df: DataFrame) -> PolarsResult<DataFrame> {
         state.should_stop()?;
 
         let height = df.height();

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -1290,7 +1290,7 @@ def test_sort_by_empty_list_eval_25433() -> None:
     expected = pl.DataFrame({"a": [sorted(some_list), []]})
     assert_frame_equal(out, expected)
 
-
+@pytest.mark.may_fail_auto_streaming
 def test_sort_already_sorted_no_rechunk_25733() -> None:
     df1 = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
     df2 = pl.DataFrame({"a": [3, 4], "b": [5, 6]})

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -1289,3 +1289,13 @@ def test_sort_by_empty_list_eval_25433() -> None:
     out = df.select(pl.col.a.list.eval(pl.element().sort_by(pl.element())))
     expected = pl.DataFrame({"a": [sorted(some_list), []]})
     assert_frame_equal(out, expected)
+
+
+def test_sort_already_sorted_no_rechunk_25733() -> None:
+    df1 = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
+    df2 = pl.DataFrame({"a": [3, 4], "b": [5, 6]})
+    df = pl.concat([df1, df2], rechunk=False).with_columns(pl.col("a").set_sorted())
+    assert df.n_chunks() == 2
+
+    result = df.sort("a")
+    assert result.n_chunks() == 2  # No rechunk happened

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -1290,6 +1290,7 @@ def test_sort_by_empty_list_eval_25433() -> None:
     expected = pl.DataFrame({"a": [sorted(some_list), []]})
     assert_frame_equal(out, expected)
 
+
 @pytest.mark.may_fail_auto_streaming
 def test_sort_already_sorted_no_rechunk_25733() -> None:
     df1 = pl.DataFrame({"a": [1, 2], "b": [3, 4]})


### PR DESCRIPTION
Fixes #25733
Removed unconditional `rechunk_mut_par()` call from the sort executor.
`sort_impl` already handles rechunking after checking if a fast path (already sorted) can be taken, so the executor's rechunk was redundant