### PR TITLE
fix: Widen decimal precision on sum aggregation

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -196,6 +196,8 @@ impl AExpr {
                             },
                             Boolean => Some(IDX_DTYPE),
                             UInt8 | Int8 | Int16 | UInt16 => Some(Int64),
+                            #[cfg(feature = "dtype-decimal")]
+                            Decimal(_, scale) => Some(Decimal(DEC128_MAX_PREC, *scale)),
                             _ => None,
                         };
                         if let Some(dt) = dt {

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -1828,3 +1828,13 @@ def test_cache_hit_child_removal() -> None:
     assert_frame_equal(df1.tail(3), df, check_row_order=False)
     assert_frame_equal(df2.head(3), df, check_row_order=False)
     assert_frame_equal(df2.tail(3), df, check_row_order=False)
+
+
+def test_sum_decimal_widens_precision_27269() -> None:
+    from decimal import Decimal
+
+    lf = pl.LazyFrame(
+        {"x": [Decimal("5000000000000.00"), Decimal("5000000000000.00")]},
+        schema={"x": pl.Decimal(15, 2)},
+    )
+    assert lf.select(pl.sum("x")).collect_schema()["x"] == pl.Decimal(38, 2)


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/27269.

The fix just widens the precision to the maximum size in the `Sum(expr)` arm of `Agg`. This is already the convention used across other operations in the file (`Operator::Minus`, `Operator::Plus`, etc.) so it was just a matter of applying it in `Sum(expr)`.