### PR TITLE
docs(python): Fix small mistake in `scan_iceberg()` `catalog` argument docstring

### DIFF
--- a/py-polars/src/polars/io/iceberg/functions.py
+++ b/py-polars/src/polars/io/iceberg/functions.py
@@ -53,7 +53,7 @@ def scan_iceberg(
 
         More info is available `here <https://py.iceberg.apache.org/configuration/>`__.
     catalog
-        PyIceberg catalog to load the table from if the provided `target`
+        PyIceberg catalog to load the table from if the provided `source`
         was a table name.
     reader_override
         Overrides the reader used to read the data.


### PR DESCRIPTION

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->

Fix for small docs bug introduced in #26826 here: https://github.com/pola-rs/polars/pull/26826/changes#diff-93bb50a4269c50503bede20e44620eee6086b7afce47700be1f22b33d153fa70R56

I did not use AI at all making this PR
