### PR TITLE
fix: Do not skip nulls when enumerating over rows in grouped AsOf join

### DIFF
--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -84,7 +84,9 @@ where
     T: PolarsDataType,
     S: PolarsNumericType,
     S::Native: TotalHash + TotalEq + DirtyHash + ToTotalOrd,
-    <S::Native as ToTotalOrd>::TotalOrdItem: Send + Sync + Copy + Hash + Eq + DirtyHash + IsNull,
+    Option<S::Native>: TotalHash + TotalEq + DirtyHash + ToTotalOrd,
+    <Option<S::Native> as ToTotalOrd>::TotalOrdItem:
+        Send + Sync + Copy + Hash + Eq + DirtyHash + IsNull,
     A: for<'a> AsofJoinState<T::Physical<'a>>,
     F: Sync + for<'a> Fn(T::Physical<'a>, T::Physical<'a>) -> bool,
 {
@@ -102,7 +104,11 @@ where
         .iter()
         .map(|ca| {
             assert_eq!(ca.chunks().len(), 1);
-            ca.downcast_iter().next().unwrap().non_null_values_iter()
+            ca.downcast_iter()
+                .next()
+                .unwrap()
+                .iter()
+                .map(|v| v.copied())
         })
         .collect();
     let hash_tbls = build_tables(right_slices, false);
@@ -124,7 +130,7 @@ where
                     results.push(NullableIdxSize::null());
                     continue;
                 };
-                let by_left_k = by_left_k.to_total_ord();
+                let by_left_k = Some(*by_left_k).to_total_ord();
                 let idx_left = (rel_idx_left + offset) as IdxSize;
                 let Some(left_val) = left_val_arr.get(idx_left as usize) else {
                     results.push(NullableIdxSize::null());

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -1737,3 +1737,43 @@ def test_join_asof_by_nulls_27165() -> None:
         {"index": 0, "key": [1.0], "group": [0], "index_right": [None]}
     )
     assert_frame_equal(actual, expected)
+
+
+def test_join_asof_by_nulls_27165_2() -> None:
+    dataframe = functools.partial(
+        pl.DataFrame,
+        schema_overrides={
+            "group": pl.Int32,
+            "index": pl.get_index_type(),
+            "index_right": pl.get_index_type(),
+        },
+    )
+    left = dataframe({"index": [0, 1], "key": [None, 0.0], "group": [None, 0]})
+    right = dataframe(
+        {
+            "index": [0, 1, 2, 3],
+            "key": [None, None, None, 1.0],
+            "group": [None, None, None, 0],
+        }
+    )
+
+    actual = (
+        left.lazy()
+        .join_asof(
+            right.lazy(),
+            on="key",
+            by="group",
+            strategy="nearest",
+            allow_exact_matches=False,
+        )
+        .collect(engine="in-memory")
+    )
+    expected = (
+        left.lazy()
+        .join_asof(
+            right.lazy(), on="key", strategy="nearest", allow_exact_matches=False
+        )
+        .collect(engine="in-memory")
+        .drop("group_right")
+    )
+    assert_frame_equal(actual, expected)

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -1688,7 +1688,7 @@ def test_join_asof_group_matches_nogroup(
     allow_exact_matches: bool,
     data: st.DataObject,
 ) -> None:
-    def groups(n: int) -> st.SearchStrategy[list[any]]:
+    def groups(n: int) -> st.SearchStrategy[list[int | None]]:
         return st.lists(st.sampled_from([None, 0]), min_size=n, max_size=n)
 
     df_left = df_left.rename({"col0": "key"}).sort("key")

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -1770,14 +1770,14 @@ def test_join_asof_by_nulls_27165_2() -> None:
             strategy="nearest",
             allow_exact_matches=False,
         )
-        .collect(engine="in-memory")
+        .collect()
     )
     expected = (
         left.lazy()
         .join_asof(
             right.lazy(), on="key", strategy="nearest", allow_exact_matches=False
         )
-        .collect(engine="in-memory")
+        .collect()
         .drop("group_right")
     )
     assert_frame_equal(actual, expected)

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -8,6 +8,7 @@ import warnings
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
+import hypothesis.strategies as st
 import numpy as np
 import pytest
 from hypothesis import given
@@ -1668,6 +1669,56 @@ def test_join_asof_nans(strategy: AsofJoinStrategy) -> None:
         }
     )
     assert_frame_equal(actual, expected)
+
+
+@pytest.mark.filterwarnings(
+    "ignore:Sortedness of columns cannot be checked when 'by' groups provided"
+)
+@pytest.mark.parametrize("strategy", ["backward", "forward", "nearest"])
+@pytest.mark.parametrize("allow_exact_matches", [False, True])
+@given(
+    df_left=dataframes(min_cols=1, max_cols=1, allowed_dtypes=[pl.Int32]),
+    df_right=dataframes(min_cols=1, max_cols=1, allowed_dtypes=[pl.Int32]),
+    data=st.data(),
+)
+def test_join_asof_group_matches_nogroup(
+    df_left: pl.DataFrame,
+    df_right: pl.DataFrame,
+    strategy: AsofJoinStrategy,
+    allow_exact_matches: bool,
+    data: st.DataObject,
+) -> None:
+    def groups(n: int) -> st.SearchStrategy[list[any]]:
+        return st.lists(st.sampled_from([None, 0]), min_size=n, max_size=n)
+
+    df_left = df_left.rename({"col0": "key"}).sort("key")
+    groups_left = pl.Series(data.draw(groups(len(df_left))), dtype=pl.Int32)
+    df_left = df_left.with_columns(group=groups_left).with_row_index()
+    df_right = df_right.rename({"col0": "key"}).sort("key")
+    groups_right = pl.Series(data.draw(groups(len(df_right))), dtype=pl.Int32)
+    df_right = df_right.with_columns(group=groups_right).with_row_index()
+
+    q_grouped = df_left.lazy().join_asof(
+        df_right.lazy(),
+        on="key",
+        by="group",
+        strategy=strategy,
+        allow_exact_matches=allow_exact_matches,
+    )
+    q_ungrouped = (
+        df_left.lazy()
+        .join_asof(
+            df_right.lazy(),
+            on="key",
+            strategy=strategy,
+            allow_exact_matches=allow_exact_matches,
+        )
+        .drop("group_right")
+    )
+
+    grouped = q_grouped.collect()
+    ungrouped = q_ungrouped.collect()
+    assert_frame_equal(grouped, ungrouped)
 
 
 def test_join_asof_by_nulls_27165() -> None:

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -1706,18 +1706,22 @@ def test_join_asof_group_matches_nogroup(
         allow_exact_matches=allow_exact_matches,
     )
     q_ungrouped = (
-        df_left.lazy()
-        .join_asof(
-            df_right.lazy(),
+        df_left.join_asof(
+            df_right.filter(pl.col("group").is_not_null()),
             on="key",
             strategy=strategy,
             allow_exact_matches=allow_exact_matches,
         )
         .drop("group_right")
+        .with_columns(
+            pl.when(pl.col("group").is_not_null())
+            .then(pl.col("index_right"))
+            .alias("index_right")
+        )
     )
 
     grouped = q_grouped.collect()
-    ungrouped = q_ungrouped.collect()
+    ungrouped = q_ungrouped
     assert_frame_equal(grouped, ungrouped)
 
 


### PR DESCRIPTION
Fixes #27165 

:robot:  The fix was proposed by claude-sonnet-4.6 and I reviewed that I think it is correct.

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
