### PR TITLE
chore(python): Upgrade `deltalake` with breaking change for `get_add_actions`

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -72,7 +72,7 @@ database = ["polars[adbc,connectorx,sqlalchemy]"]
 fsspec = ["fsspec"]
 
 # Other I/O
-deltalake = ["deltalake >= 1.0.0"]
+deltalake = ["deltalake >= 1.5.0"]
 iceberg = ["pyiceberg >= 0.7.1"]
 
 # Other

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -45,7 +45,7 @@ openpyxl
 xlsx2csv
 xlsxwriter>=3.2.9
 # Other I/O
-deltalake>=1.4.2
+deltalake>=1.5.0
 # Csv
 zstandard
 # Plotting

--- a/py-polars/src/polars/io/delta/_dataset.py
+++ b/py-polars/src/polars/io/delta/_dataset.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any
 
 import polars as pl
 from polars._utils.logging import eprint
-from polars._utils.various import parse_version
 from polars.io.cloud.credential_provider._providers import (
     _get_credentials_from_provider_expiry_aware,
 )
@@ -156,17 +155,6 @@ class DeltaDataset:
 
         deletion_files: DeletionFiles | None = None
         if has_deletion_vectors:
-            import deltalake
-
-            dv_min_version = (1, 4, 2)
-            installed = parse_version(deltalake.__version__)
-            if installed < dv_min_version:
-                msg = (
-                    f"reading delta deletion vectors requires "
-                    f"deltalake >= {'.'.join(str(v) for v in dv_min_version)}, "
-                    f"found {installed}."
-                )
-                raise ImportError(msg)
 
             def _deletion_vector_callback(
                 requested_paths: pl.DataFrame,

--- a/py-polars/src/polars/io/delta/_utils.py
+++ b/py-polars/src/polars/io/delta/_utils.py
@@ -39,7 +39,7 @@ def _get_delta_lake_table(
 
     Notes
     -----
-    Make sure to install deltalake>=0.8.0. Read the documentation
+    Make sure to install deltalake>=1.5.0. Read the documentation
     `here <https://delta-io.github.io/delta-rs/usage/installation/>`_.
     """
     _check_if_delta_available()

--- a/py-polars/tests/unit/io/test_delta_deletion_vector.py
+++ b/py-polars/tests/unit/io/test_delta_deletion_vector.py
@@ -955,20 +955,3 @@ def test_scan_delta_dv_delta_sink_mock(
         expected,
         check_row_order=False,
     )
-
-
-@pytest.mark.write_disk
-def test_scan_delta_dv_requires_deltalake_version(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    path = tmp_path / "delta_table"
-    df = pl.DataFrame({"a": [1, 2, 3]})
-    create_dv_table(path, df.to_arrow(), deleted_rows=[0])
-
-    import deltalake
-
-    monkeypatch.setattr(deltalake, "__version__", "1.4.1")
-
-    with pytest.raises(ImportError, match=r"deltalake >= 1.4.2"):
-        pl.scan_delta(path).collect()


### PR DESCRIPTION
Closes #26638 

`deltalake` 1.5.0 (https://github.com/delta-io/delta-rs/releases/tag/python-v1.5.0) includes a breaking change from delta-io/delta-rs#4204 — `DeltaTable.get_add_actions()` now returns `arro3.core.Table` instead of `arro3.core.RecordBatch`. `pl.DataFrame()` already handles the new type, so no code changes were needed for that.

Changes:
- Bump minimum `deltalake` version to `>= 1.5.0` in `pyproject.toml` and `requirements-dev.txt`
- Remove now-redundant `deltalake >= 1.4.2` version check for deletion vectors in `_dataset.py`
- Remove unused `parse_version` import in `_dataset.py`
- Remove `test_scan_delta_dv_requires_deltalake_version` test that validated the removed version check
- Update outdated version reference in `_utils.py` docstring

`make test` screenshot:
<img width="2032" height="1317" alt="image" src="https://github.com/user-attachments/assets/51ab175e-3197-4645-84bb-c087c501cd4c" />


1. I used Claude Code to check for any further updates, and it identified the outdated `deltalake>=0.8.0` reference in `_utils.py`, which I reviewed and updated.
2. I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.

