### PR TITLE
fix(python): make GroupBy an Iterable instead of Iterator

### DIFF
--- a/py-polars/src/polars/dataframe/group_by.py
+++ b/py-polars/src/polars/dataframe/group_by.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from itertools import chain
 from typing import TYPE_CHECKING, Any
 
@@ -13,7 +14,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
     from datetime import timedelta
 
-    from polars import DataFrame
+    from polars import DataFrame, Series
     from polars._typing import (
         ClosedInterval,
         IntoExpr,
@@ -24,15 +25,37 @@ if TYPE_CHECKING:
     )
     from polars.lazyframe.group_by import LazyGroupBy
 
-    if sys.version_info >= (3, 11):
-        from typing import Self
-    else:
-        from typing_extensions import Self
-
     if sys.version_info >= (3, 13):
         from warnings import deprecated
     else:
         from typing_extensions import deprecated  # noqa: TC004
+
+
+class _GroupByIter(Iterator[tuple[tuple[Any, ...], "DataFrame"]]):
+    """Iterator over group by results."""
+
+    __slots__ = ("_df", "_group_names", "_group_indices", "_current_index")
+
+    def __init__(
+        self,
+        df: DataFrame,
+        group_names: Iterator[tuple[Any, ...]],
+        group_indices: Series,
+    ) -> None:
+        self._df = df
+        self._group_names = group_names
+        self._group_indices = group_indices
+        self._current_index = 0
+
+    def __next__(self) -> tuple[tuple[Any, ...], DataFrame]:
+        if self._current_index >= len(self._group_indices):
+            raise StopIteration
+
+        group_name = next(self._group_names)
+        group_data = self._df[self._group_indices[self._current_index], :]
+        self._current_index += 1
+
+        return group_name, group_data
 
 
 class GroupBy:
@@ -81,11 +104,11 @@ class GroupBy:
             return group_by.having(self.predicates)
         return group_by
 
-    def __iter__(self) -> Self:
+    def __iter__(self) -> _GroupByIter:
         """
         Allows iteration over the groups of the group by operation.
 
-        Each group is represented by a tuple of `(name, data)`. The group names are
+        Returns an iterator yielding `(name, data)` tuples. The group names are
         tuples of the distinct group values that identify each group.
 
         Examples
@@ -127,21 +150,10 @@ class GroupBy:
             .collect(optimizations=QueryOptFlags.none())
         )
 
-        self._group_names = groups_df.select(F.all().exclude(temp_col)).iter_rows()
-        self._group_indices = groups_df.select(temp_col).to_series()
-        self._current_index = 0
+        group_names = groups_df.select(F.all().exclude(temp_col)).iter_rows()
+        group_indices = groups_df.select(temp_col).to_series()
 
-        return self
-
-    def __next__(self) -> tuple[tuple[Any, ...], DataFrame]:
-        if self._current_index >= len(self._group_indices):
-            raise StopIteration
-
-        group_name = next(self._group_names)
-        group_data = self.df[self._group_indices[self._current_index], :]
-        self._current_index += 1
-
-        return group_name, group_data
+        return _GroupByIter(self.df, group_names, group_indices)
 
     def having(self, *predicates: IntoExpr | Iterable[IntoExpr]) -> GroupBy:
         """
@@ -884,7 +896,7 @@ class RollingGroupBy:
         self.group_by = group_by
         self.predicates = predicates
 
-    def __iter__(self) -> Self:
+    def __iter__(self) -> _GroupByIter:
         from polars.lazyframe.opt_flags import QueryOptFlags
 
         temp_col = "__POLARS_GB_GROUP_INDICES"
@@ -902,21 +914,10 @@ class RollingGroupBy:
             .collect(optimizations=QueryOptFlags.none())
         )
 
-        self._group_names = groups_df.select(F.all().exclude(temp_col)).iter_rows()
-        self._group_indices = groups_df.select(temp_col).to_series()
-        self._current_index = 0
+        group_names = groups_df.select(F.all().exclude(temp_col)).iter_rows()
+        group_indices = groups_df.select(temp_col).to_series()
 
-        return self
-
-    def __next__(self) -> tuple[tuple[object, ...], DataFrame]:
-        if self._current_index >= len(self._group_indices):
-            raise StopIteration
-
-        group_name = next(self._group_names)
-        group_data = self.df[self._group_indices[self._current_index], :]
-        self._current_index += 1
-
-        return group_name, group_data
+        return _GroupByIter(self.df, group_names, group_indices)
 
     def having(self, *predicates: IntoExpr | Iterable[IntoExpr]) -> RollingGroupBy:
         """
@@ -1066,7 +1067,7 @@ class DynamicGroupBy:
         self.start_by = start_by
         self.predicates = predicates
 
-    def __iter__(self) -> Self:
+    def __iter__(self) -> _GroupByIter:
         from polars.lazyframe.opt_flags import QueryOptFlags
 
         temp_col = "__POLARS_GB_GROUP_INDICES"
@@ -1088,21 +1089,10 @@ class DynamicGroupBy:
             .collect(optimizations=QueryOptFlags.none())
         )
 
-        self._group_names = groups_df.select(F.all().exclude(temp_col)).iter_rows()
-        self._group_indices = groups_df.select(temp_col).to_series()
-        self._current_index = 0
+        group_names = groups_df.select(F.all().exclude(temp_col)).iter_rows()
+        group_indices = groups_df.select(temp_col).to_series()
 
-        return self
-
-    def __next__(self) -> tuple[tuple[object, ...], DataFrame]:
-        if self._current_index >= len(self._group_indices):
-            raise StopIteration
-
-        group_name = next(self._group_names)
-        group_data = self.df[self._group_indices[self._current_index], :]
-        self._current_index += 1
-
-        return group_name, group_data
+        return _GroupByIter(self.df, group_names, group_indices)
 
     def having(self, *predicates: IntoExpr | Iterable[IntoExpr]) -> DynamicGroupBy:
         """

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -577,6 +577,31 @@ def test_group_by_iteration() -> None:
     assert result3 == expected3
 
 
+def test_group_by_next_raises_type_error() -> None:
+    # Calling next() directly on a GroupBy should raise TypeError,
+    # because GroupBy is an Iterable, not an Iterator. See #12868.
+    df = pl.DataFrame({"a": [1, 1, 2], "b": [3, 4, 5]})
+    gb = df.group_by("a")
+    with pytest.raises(TypeError):
+        next(gb)
+
+    # But iter() should work and return an iterator
+    it = iter(gb)
+    name, data = next(it)
+    assert isinstance(name, tuple)
+    assert isinstance(data, pl.DataFrame)
+
+
+def test_group_by_multiple_iterations() -> None:
+    # A GroupBy should support being iterated multiple times. See #12868.
+    df = pl.DataFrame({"a": ["x", "y", "x"], "b": [1, 2, 3]})
+    gb = df.group_by("a", maintain_order=True)
+
+    result1 = [(name, data.rows()) for name, data in gb]
+    result2 = [(name, data.rows()) for name, data in gb]
+    assert result1 == result2
+
+
 def test_group_by_iteration_selector() -> None:
     df = pl.DataFrame({"a": ["one", "two", "one", "two"], "b": [1, 2, 3, 4]})
     result = dict(df.group_by(cs.string()))


### PR DESCRIPTION
## Summary

- Fixes `next()` on `GroupBy` raising `AttributeError` instead of `TypeError` by separating the iterator into a dedicated `_GroupByIter` class
- Applies the same fix to `RollingGroupBy` and `DynamicGroupBy`
- Enables iterating over the same `GroupBy` object multiple times (each `iter()` call returns a fresh iterator)

Closes #12868

## Design

As suggested by @ritchie46 in https://github.com/pola-rs/polars/issues/12868#issuecomment-2454018519, this introduces a `_GroupByIter` class returned from `__iter__`. The `GroupBy` classes become **Iterables** (have `__iter__` but no `__next__`), so:

- `next(df.group_by("a"))` raises `TypeError` (same as `next([])`)
- `for name, data in df.group_by("a"): ...` works as before
- `next(iter(df.group_by("a")))` works as before
- Iterating multiple times over the same `GroupBy` now works correctly

## Test plan

- [x] Added `test_group_by_next_raises_type_error` — verifies `TypeError` on direct `next()` and that `iter()` returns a working iterator
- [x] Added `test_group_by_multiple_iterations` — verifies a `GroupBy` can be iterated multiple times with consistent results
- [x] Existing iteration tests (`test_group_by_iteration`, `test_group_by_iteration_selector`) should continue to pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)