### PR TITLE
fix: Update `groups` to correct length for `Implode`

### DIFF
--- a/crates/polars-expr/src/expressions/aggregation.rs
+++ b/crates/polars-expr/src/expressions/aggregation.rs
@@ -493,10 +493,9 @@ impl PhysicalExpr for AggregationExpr {
             }
         };
 
-        Ok(AggregationContext::from_agg_state(
-            out,
-            Cow::Borrowed(groups),
-        ))
+        let mut ac_out = AggregationContext::from_agg_state(out, Cow::Borrowed(groups));
+        ac_out.set_groups_for_undefined_agg_states();
+        Ok(ac_out)
     }
 
     fn to_field(&self, _input_schema: &Schema) -> PolarsResult<Field> {

--- a/crates/polars-expr/src/expressions/aggregation.rs
+++ b/crates/polars-expr/src/expressions/aggregation.rs
@@ -425,11 +425,23 @@ impl PhysicalExpr for AggregationExpr {
                     AggregatedScalar(agg_s.with_name(keep_name))
                 },
                 GroupByMethod::Implode { maintain_order: _ } => {
-                    AggregatedScalar(match ac.agg_state() {
+                    let col = match ac.agg_state() {
                         AggState::LiteralScalar(_) => unreachable!(), // handled above
                         AggState::AggregatedScalar(c) => c.as_list().into_column(),
-                        AggState::NotAggregated(_) | AggState::AggregatedList(_) => ac.aggregated(),
-                    })
+                        AggState::AggregatedList(c) => c.clone(),
+                        AggState::NotAggregated(_) => ac.aggregated(),
+                    };
+                    // TODO: Introduce `UpdateGroups::WithUnitLen` as a new lazy `groups()` method
+                    // and move the groups constructor there. Then, set `UpdateGroups::WithUnitLen` to
+                    // all AggregationExprs.
+                    let groups = Cow::Owned({
+                        let groups = (0..col.len() as IdxSize).map(|i| [i, 1]).collect();
+                        GroupsType::new_slice(groups, false, true).into_sliceable()
+                    });
+                    return Ok(AggregationContext::from_agg_state(
+                        AggregatedScalar(col),
+                        groups,
+                    ));
                 },
                 GroupByMethod::Groups => {
                     let mut column: ListChunked = ac.groups().as_list_chunked();
@@ -493,9 +505,10 @@ impl PhysicalExpr for AggregationExpr {
             }
         };
 
-        let mut ac_out = AggregationContext::from_agg_state(out, Cow::Borrowed(groups));
-        ac_out.set_groups_for_undefined_agg_states();
-        Ok(ac_out)
+        Ok(AggregationContext::from_agg_state(
+            out,
+            Cow::Borrowed(groups),
+        ))
     }
 
     fn to_field(&self, _input_schema: &Schema) -> PolarsResult<Field> {

--- a/py-polars/tests/unit/operations/aggregation/test_implode.py
+++ b/py-polars/tests/unit/operations/aggregation/test_implode.py
@@ -55,12 +55,16 @@ def test_implode_unordered() -> None:
     }
 
 
-def test_implode_and_list_sort_aggregated_25252() -> None:
+def test_implode_and_list_sort_aggregated_27252() -> None:
     df = pl.DataFrame(
         {"a": [1, 1, 1, 2, 2, 2, 3, 3, 3], "b": [1, 2, 1, 3, 1, 2, 3, 3, 1]}
     )
 
-    q = df.lazy().group_by("a").agg(pl.col.b.implode().list.unique().sort())
+    q = (
+        df.lazy()
+        .group_by("a")
+        .agg(pl.col.b.implode().list.unique(maintain_order=True).sort())
+    )
 
-    expected = pl.DataFrame({"a": [1, 2, 3], "b": [[1, 2], [1, 2, 3], [1, 3]]})
+    expected = pl.DataFrame({"a": [1, 2, 3], "b": [[1, 2], [3, 1, 2], [3, 1]]})
     assert_frame_equal(q.collect(), expected, check_row_order=False)

--- a/py-polars/tests/unit/operations/aggregation/test_implode.py
+++ b/py-polars/tests/unit/operations/aggregation/test_implode.py
@@ -53,3 +53,14 @@ def test_implode_unordered() -> None:
         "y": [3, 4],
         "x": [[[("x", 1), ("y", 3)], [("x", 5), ("y", 3)]], [[("x", 2), ("y", 4)]]],
     }
+
+
+def test_implode_and_list_sort_aggregated_25252() -> None:
+    df = pl.DataFrame(
+        {"a": [1, 1, 1, 2, 2, 2, 3, 3, 3], "b": [1, 2, 1, 3, 1, 2, 3, 3, 1]}
+    )
+
+    q = df.lazy().group_by("a").agg(pl.col.b.implode().list.unique().sort())
+
+    expected = pl.DataFrame({"a": [1, 2, 3], "b": [[1, 2], [1, 2, 3], [1, 3]]})
+    assert_frame_equal(q.collect(), expected, check_row_order=False)


### PR DESCRIPTION
fixes #27252

The problem: the `AggregationExpr` implementation leaves the groups as-is, which is inconsistent with the latest semantics on `AggregationContext`. For most (numeric) aggregations, that is usually not a problem, as they do not get chained with group-aware expressions For implode however, the situation is different: since they produce `List`s, they may get chained with expressions that act on the groups info, as shared in the issue.

A couple of ways to rsolve this:
(a) fix `groups` for all `AggregationExpr`s: logically correct, but comes at a cost of updating groups
(b) fix `groups` for `Implode` only: minimal change only, lowest overhead, but may leave us exposed
(c) introduce a new `UpdateGroups` variant (e.g. `AsScalar`) such that (only!) when groups() is called, it sets the group to their correct value, i.e. `[(offset,len=1)]` slices in pseudocode: this is logically correct and has minimum overhead because it is lazy, but would come at some extra dev work
(d) enforce `set_groups_for_undefined_agg_states` on entry: while this would probably work technically (and is already happening in some places), it is an anti-pattern imo (although it does have the benefit of minimum overhead)

**EDIT: The latest commit has (b) implemented to avoid any performance regression, with (c) as the next step, see https://github.com/pola-rs/polars/issues/27299.