### PR TITLE
feat: Add `is_unique` to list/array dtypes

### DIFF
--- a/crates/polars-ops/src/series/ops/is_unique.rs
+++ b/crates/polars-ops/src/series/ops/is_unique.rs
@@ -2,6 +2,7 @@ use std::hash::Hash;
 
 use arrow::array::BooleanArray;
 use arrow::bitmap::MutableBitmap;
+use polars_core::prelude::row_encode::encode_rows_unordered;
 use polars_core::prelude::*;
 use polars_core::with_match_physical_integer_polars_type;
 use polars_utils::total_ord::{ToTotalOrd, TotalEq, TotalHash};
@@ -39,6 +40,12 @@ where
     BooleanChunked::with_chunk(ca.name().clone(), arr)
 }
 
+fn is_unique_nested(s: &Series, invert: bool) -> PolarsResult<BooleanChunked> {
+    let encoded = encode_rows_unordered(&[s.clone().into_column()])?.into_series();
+    let ca = encoded.binary_offset().unwrap();
+    Ok(is_unique_ca(ca, invert).with_name(s.name().clone()))
+}
+
 fn dispatcher(s: &Series, invert: bool) -> PolarsResult<BooleanChunked> {
     let s = s.to_physical_repr();
     use DataType::*;
@@ -69,6 +76,9 @@ fn dispatcher(s: &Series, invert: bool) -> PolarsResult<BooleanChunked> {
             let ca = s.f64().unwrap();
             is_unique_ca(ca, invert)
         },
+        List(_) => return is_unique_nested(&s, invert),
+        #[cfg(feature = "dtype-array")]
+        Array(_, _) => return is_unique_nested(&s, invert),
         #[cfg(feature = "dtype-struct")]
         Struct(_) => {
             let ca = s.struct_().unwrap().clone();

--- a/py-polars/tests/unit/operations/unique/test_is_unique.py
+++ b/py-polars/tests/unit/operations/unique/test_is_unique.py
@@ -58,6 +58,53 @@ def test_is_unique_struct() -> None:
     ).is_duplicated().to_list() == [True, False, True]
 
 
+def test_is_unique_list() -> None:
+    # Expression API (original issue)
+    df = pl.DataFrame({"a": [[0, 1], [0, 1]]})
+    result = df.select(pl.col("a").is_unique())
+    assert result["a"].to_list() == [False, False]
+
+    # Basic list uniqueness
+    s = pl.Series("a", [[1, 2], [3, 4], [1, 2]])
+    assert s.is_unique().to_list() == [False, True, False]
+    assert s.is_duplicated().to_list() == [True, False, True]
+
+    # All unique
+    s = pl.Series("a", [[1, 2], [3, 4], [5, 6]])
+    assert s.is_unique().to_list() == [True, True, True]
+
+    # All duplicates
+    s = pl.Series("a", [[1, 2], [1, 2], [1, 2]])
+    assert s.is_unique().to_list() == [False, False, False]
+
+    # With nulls
+    s = pl.Series("a", [[1, 2], None, [1, 2], None])
+    assert s.is_unique().to_list() == [False, False, False, False]
+
+    # Empty lists
+    s = pl.Series("a", [[], [], [1]])
+    assert s.is_unique().to_list() == [False, False, True]
+
+    # Nested lists
+    s = pl.Series("a", [[[1, 2]], [[1, 2]], [[3, 4]]])
+    assert s.is_unique().to_list() == [False, False, True]
+
+
+def test_is_unique_array() -> None:
+    # Basic array uniqueness
+    s = pl.Series("a", [[1, 2, 3], [4, 5, 6], [1, 2, 3]], dtype=pl.Array(pl.Int64, 3))
+    assert s.is_unique().to_list() == [False, True, False]
+    assert s.is_duplicated().to_list() == [True, False, True]
+
+    # All unique
+    s = pl.Series("a", [[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=pl.Array(pl.Int64, 3))
+    assert s.is_unique().to_list() == [True, True, True]
+
+    # All duplicates
+    s = pl.Series("a", [[1, 2, 3], [1, 2, 3], [1, 2, 3]], dtype=pl.Array(pl.Int64, 3))
+    assert s.is_unique().to_list() == [False, False, False]
+
+
 def test_is_duplicated_series() -> None:
     s = pl.Series("a", [1, 2, 2, 3])
     assert_series_equal(s.is_duplicated(), pl.Series("a", [False, True, True, False]))


### PR DESCRIPTION
Closes: #27286 
Use the row encoding logic to implement `is_unique` to list and array datatypes. 

Notes: I kept the Struct logic as-is as I noticed a better performance as I guess that the `df.is_unique` will be multithreaded.

1. I used AI to write the tests and too help me implementing the logic.
2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.