### PR TITLE
fix(python): Assert missing_columns dtypes in `match_to_schema`

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -719,7 +719,48 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                             column.clone(),
                         )),
                         MissingColumnsPolicyOrExpr::InsertWith(expr) => {
-                            exprs.push(Expr::Alias(Arc::new(expr.clone()), column.clone()))
+                            // Validate expression dtype against the schema, same as for existing columns.
+                            let eir = to_expr_ir(
+                                expr.clone(),
+                                &mut ExprToIRContext::new_with_opt_eager(
+                                    ctxt.expr_arena,
+                                    &input_schema,
+                                    ctxt.opt_flags,
+                                ),
+                            )?;
+                            // Materialize Unknown dtypes (e.g., dyn int) to concrete types.
+                            let from_dtype = eir
+                                .field(&input_schema, ctxt.expr_arena)?
+                                .dtype
+                                .materialize_unknown(true)?;
+
+                            let final_expr = if &from_dtype == dtype {
+                                expr.clone()
+                            } else {
+                                // Apply the same casting policy as for existing columns with dtype mismatch.
+                                let policy = CastColumnsPolicy {
+                                    integer_upcast: per_column.integer_cast
+                                        == UpcastOrForbid::Upcast,
+                                    float_upcast: per_column.float_cast == UpcastOrForbid::Upcast,
+                                    missing_struct_fields: per_column.missing_struct_fields,
+                                    extra_struct_fields: per_column.extra_struct_fields,
+                                    ..Default::default()
+                                };
+
+                                // This will raise an error if the cast is not allowed by policy.
+                                let should_cast =
+                                    policy.should_cast_column(column, dtype, &from_dtype)?;
+
+                                let mut final_expr = expr.clone();
+                                if should_cast {
+                                    final_expr = final_expr.cast_with_options(
+                                        dtype.clone(),
+                                        CastOptions::NonStrict,
+                                    );
+                                }
+                                final_expr
+                            };
+                            exprs.push(Expr::Alias(Arc::new(final_expr), column.clone()))
                         },
                     },
                     Some(input_dtype) if dtype == input_dtype => {

--- a/py-polars/tests/unit/lazyframe/test_match_to_schema.py
+++ b/py-polars/tests/unit/lazyframe/test_match_to_schema.py
@@ -227,3 +227,19 @@ def test_match_to_schema_float_upcast(float_dtype: pl.DataType) -> None:
 
     result = df.lazy().match_to_schema(expected.schema, float_cast="upcast").collect()
     assert_frame_equal(expected, result)
+
+
+def test_match_to_schema_missing_columns_expression_dtype_27255() -> None:
+
+    with pytest.raises(pl.exceptions.SchemaError, match=r"Int32.*Int64"):
+        pl.DataFrame().match_to_schema(
+            {"b": pl.Int64}, missing_columns={"b": pl.lit(0, dtype=pl.Int32)}
+        )
+
+    result = pl.DataFrame().match_to_schema(
+        {"b": pl.Int64},
+        missing_columns={"b": pl.lit(0, dtype=pl.Int32)},
+        integer_cast="upcast",
+    )
+    assert result.schema == {"b": pl.Int64}
+    assert result["b"].to_list() == [0]


### PR DESCRIPTION
fixes: #27255 

  1. I used AI to implement the logic.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.
