### PR TITLE
docs(python): Fix outdated `LazyGroupBy.map_groups` docstring

### DIFF
--- a/py-polars/src/polars/lazyframe/group_by.py
+++ b/py-polars/src/polars/lazyframe/group_by.py
@@ -214,7 +214,7 @@ class LazyGroupBy:
 
         The idiomatic way to apply custom functions over multiple columns is using:
 
-        `pl.struct([my_columns]).apply(lambda struct_series: ..)`
+        `pl.struct([my_columns]).map_elements(lambda struct_series: ..)`
 
         Parameters
         ----------


### PR DESCRIPTION
Closes: #24818

Advice to use `map_elements` as it is done in `Rolling/DynamicGroupby`