### PR TITLE
perf: Lower `drop_{nulls,nans}` in streaming `group_by` aggregations

### DIFF
--- a/crates/polars-stream/src/physical_plan/lower_group_by.rs
+++ b/crates/polars-stream/src/physical_plan/lower_group_by.rs
@@ -599,6 +599,55 @@ fn try_lower_agg_input_expr(
             let trans_output = expr_arena.add(AExpr::Column(output_name));
             Ok(Some((stream, trans_output, false)))
         },
+        AExpr::Function {
+            input: inputs_ref,
+            function: function @ (IRFunctionExpr::DropNulls | IRFunctionExpr::DropNans),
+            options: _,
+        } => {
+            let input = &inputs_ref[0];
+            if !is_elementwise_rec_cached(input.node(), expr_arena, expr_cache) {
+                return Ok(None);
+            }
+
+            let output_name = unique_column_name();
+            let predicate_name = unique_column_name();
+            let mut select_exprs = keys.to_vec();
+            select_exprs.push(ExprIR::new(
+                input.node(),
+                OutputName::Alias(output_name.clone()),
+            ));
+            let predicate = AExprBuilder::function(
+                vec![inputs_ref[0].clone()],
+                if matches!(function, IRFunctionExpr::DropNulls) {
+                    IRFunctionExpr::Boolean(IRBooleanFunction::IsNotNull)
+                } else {
+                    IRFunctionExpr::Boolean(IRBooleanFunction::IsNotNan)
+                },
+                expr_arena,
+            )
+            .expr_ir(predicate_name.clone());
+            select_exprs.push(predicate);
+
+            let mut stream = build_select_stream(
+                input_stream,
+                &select_exprs,
+                expr_arena,
+                phys_sm,
+                expr_cache,
+                ctx,
+            )?;
+            stream = build_filter_stream(
+                stream,
+                ExprIR::from_column_name(predicate_name, expr_arena),
+                expr_arena,
+                phys_sm,
+                expr_cache,
+                ctx,
+            )?;
+
+            let trans_output = expr_arena.add(AExpr::Column(output_name));
+            Ok(Some((stream, trans_output, false)))
+        },
         _ => Ok(None),
     }
 }


### PR DESCRIPTION
This allows `drop_{nans,nulls}` for the streaming `group_by` aggregations similarly to how filter and unique are handled.

![plan](https://github.com/user-attachments/assets/894da787-bb2e-4c33-81fd-ebceb3561bb5)

<details>
<summary>Code</summary>

```python
import polars as pl

lf = pl.LazyFrame({"a": [1, 1, 2, 1, 2], "b": [5, None, 3, 7, None]}).group_by("a").agg(
    pl.col.b.drop_nulls().max()
)

lf.show_graph(engine="streaming", plan_stage="physical", output_path="plan.svg")
print(lf.collect(engine='streaming'))
```

</details>

No AI was used.
