### PR TITLE
perf: Lower basic over() to streaming primitives

### DIFF
--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -24,7 +24,9 @@ use slotmap::SlotMap;
 use super::fmt::fmt_exprs;
 use super::{PhysNode, PhysNodeKey, PhysNodeKind, PhysStream, StreamingLowerIRContext};
 use crate::physical_plan::ZipBehavior;
-use crate::physical_plan::lower_group_by::build_group_by_stream;
+use crate::physical_plan::lower_group_by::{
+    GroupByLowerKind, build_group_by_stream, try_build_streaming_group_by,
+};
 use crate::physical_plan::lower_ir::{build_filter_stream, build_row_idx_stream};
 
 type ExprNodeKey = Node;
@@ -2555,6 +2557,40 @@ fn lower_exprs_with_ctx(
                 )?;
                 input_streams.insert(input);
                 transformed_exprs.push(ctx.expr_arena.add(AExpr::Column(out_name)));
+            },
+
+            AExpr::Over {
+                function,
+                partition_by,
+                order_by: None,
+                mapping: WindowMapping::GroupsToRows,
+            } => {
+                let out_name = unique_column_name();
+                let function_ir = AExprBuilder::new_from_node(function).expr_ir(out_name.clone());
+                let key_ir = partition_by
+                    .iter()
+                    .map(|n| AExprBuilder::new_from_node(*n).expr_ir(unique_column_name()))
+                    .collect_vec();
+
+                if let Some(gb) = try_build_streaming_group_by(
+                    input,
+                    &key_ir,
+                    &[function_ir],
+                    false,
+                    Arc::new(GroupbyOptions::default()),
+                    None,
+                    GroupByLowerKind::Over,
+                    ctx.expr_arena,
+                    ctx.phys_sm,
+                    ctx.cache,
+                    StreamingLowerIRContext::from(&*ctx),
+                )? {
+                    input_streams.insert(gb);
+                    transformed_exprs.push(ctx.expr_arena.add(AExpr::Column(out_name)));
+                } else {
+                    fallback_subset.push(ExprIR::new(expr, OutputName::Alias(out_name.clone())));
+                    transformed_exprs.push(ctx.expr_arena.add(AExpr::Column(out_name)));
+                }
             },
 
             AExpr::AnonymousFunction { .. }

--- a/crates/polars-stream/src/physical_plan/lower_group_by.rs
+++ b/crates/polars-stream/src/physical_plan/lower_group_by.rs
@@ -8,6 +8,7 @@ use polars_core::schema::Schema;
 use polars_error::{PolarsResult, polars_err};
 use polars_expr::state::ExecutionState;
 use polars_mem_engine::create_physical_plan;
+use polars_ops::frame::{JoinArgs, JoinType, MaintainOrderJoin};
 use polars_plan::plans::expr_ir::{ExprIR, OutputName};
 use polars_plan::plans::{AExpr, IR, IRAggExpr, IRFunctionExpr, NaiveExprMerger, write_group_by};
 use polars_plan::prelude::{GroupbyOptions, *};
@@ -26,6 +27,12 @@ use crate::physical_plan::lower_ir::{
     build_filter_stream, build_row_idx_stream, build_slice_stream,
 };
 use crate::utils::late_materialized_df::LateMaterializedDataFrame;
+
+#[derive(Copy, Clone, Debug)]
+pub enum GroupByLowerKind {
+    Groups,
+    Over,
+}
 
 #[allow(clippy::too_many_arguments)]
 fn build_group_by_fallback(
@@ -199,6 +206,7 @@ fn replace_elementwise_components(
 #[allow(clippy::too_many_arguments)]
 fn try_lower_elementwise_scalar_agg_expr(
     expr: Node,
+    gbl_kind: GroupByLowerKind,
     expr_merger: &mut NaiveExprMerger,
     expr_cache: &mut ExprCache,
     expr_arena: &mut Arena<AExpr>,
@@ -212,6 +220,7 @@ fn try_lower_elementwise_scalar_agg_expr(
         ($input:expr) => {
             try_lower_elementwise_scalar_agg_expr(
                 $input,
+                gbl_kind,
                 expr_merger,
                 expr_cache,
                 expr_arena,
@@ -260,8 +269,21 @@ fn try_lower_elementwise_scalar_agg_expr(
         },
 
         AExpr::Column(_) => {
-            // Implicit implode not yet supported.
-            None
+            match gbl_kind {
+                GroupByLowerKind::Over => {
+                    let id = expr_merger.add_and_get_uniq_id(expr, expr_arena);
+                    let name = uniq_input_names
+                        .entry(id)
+                        .or_insert_with(unique_column_name)
+                        .clone();
+                    let node = uniq_elementwise_exprs
+                        .entry(id)
+                        .or_insert_with(|| ExprIR::from_column_name(name, expr_arena))
+                        .node();
+                    Some(node)
+                },
+                GroupByLowerKind::Groups => None, // Implicit implode not yet supported.
+            }
         },
 
         AExpr::Literal(lit) => {
@@ -580,6 +602,7 @@ fn try_lower_agg_input_expr(
                 maintain_order,
                 options,
                 None,
+                GroupByLowerKind::Groups,
                 expr_arena,
                 phys_sm,
                 expr_cache,
@@ -689,13 +712,14 @@ fn try_lower_agg_input_expr(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn try_build_streaming_group_by(
+pub fn try_build_streaming_group_by(
     mut input: PhysStream,
     keys: &[ExprIR],
     aggs: &[ExprIR],
     maintain_order: bool,
     options: Arc<GroupbyOptions>,
     apply: Option<PlanCallback<DataFrame, DataFrame>>,
+    gbl_kind: GroupByLowerKind,
     expr_arena: &mut Arena<AExpr>,
     phys_sm: &mut SlotMap<PhysNodeKey, PhysNode>,
     expr_cache: &mut ExprCache,
@@ -782,6 +806,7 @@ fn try_build_streaming_group_by(
     for agg in aggs {
         let Some(trans_node) = try_lower_elementwise_scalar_agg_expr(
             agg.node(),
+            gbl_kind,
             &mut expr_merger,
             expr_cache,
             expr_arena,
@@ -924,7 +949,7 @@ fn try_build_streaming_group_by(
     ));
 
     // Sort the input based on the first row index if maintaining order.
-    let post_select_input = if maintain_order {
+    let mut post_select_input = if maintain_order {
         let sort_node = phys_sm.insert(PhysNode::new(
             group_by_output_schema,
             PhysNodeKind::Sort {
@@ -939,6 +964,41 @@ fn try_build_streaming_group_by(
     } else {
         PhysStream::first(agg_node)
     };
+
+    if let GroupByLowerKind::Over = gbl_kind {
+        // If there were any non-elementwise functions left over we can't simply
+        // apply them in the post-select while ignoring groups, so we have to abort.
+        if trans_output_exprs
+            .iter()
+            .any(|e| !is_elementwise_rec_cached(e.node(), expr_arena, expr_cache))
+        {
+            return Ok(None);
+        }
+
+        // TODO: projection pushdown on left side (original input).
+        // All the aggregates should have unique names so, schema should be simple.
+        let preselect_schema = &phys_sm[pre_select.node].output_schema;
+        let agg_schema = &phys_sm[post_select_input.node].output_schema;
+        let mut join_schema = (**preselect_schema).clone();
+        join_schema.merge((**agg_schema).clone());
+        let args = JoinArgs {
+            how: JoinType::Left,
+            maintain_order: MaintainOrderJoin::Left,
+            nulls_equal: true,
+            ..JoinArgs::default()
+        };
+        let join_key = phys_sm.insert(PhysNode::new(
+            Arc::new(join_schema),
+            PhysNodeKind::EquiJoin {
+                input_left: pre_select,
+                input_right: post_select_input,
+                left_on: trans_keys.clone(),
+                right_on: trans_keys,
+                args,
+            },
+        ));
+        post_select_input = PhysStream::first(join_key);
+    }
 
     let post_select = build_select_stream(
         post_select_input,
@@ -1225,6 +1285,7 @@ pub fn build_group_by_stream(
         maintain_order,
         options.clone(),
         apply.clone(),
+        GroupByLowerKind::Groups,
         expr_arena,
         phys_sm,
         expr_cache,

--- a/py-polars/tests/unit/operations/map/test_map_batches.py
+++ b/py-polars/tests/unit/operations/map/test_map_batches.py
@@ -38,6 +38,7 @@ def test_map_no_dtype_set_8531() -> None:
     assert_frame_equal(result, expected)
 
 
+@pytest.mark.may_fail_auto_streaming
 def test_error_on_reducing_map() -> None:
     df = pl.DataFrame(
         {"id": [0, 0, 0, 1, 1, 1], "t": [2, 4, 5, 10, 11, 14], "y": [0, 1, 1, 2, 3, 4]}


### PR DESCRIPTION
If you now use `over()` with the streaming engine and your expression consists of elementwise combinations of columns, literals or streaming-supported aggregations, it should now lower to a group-by + join.

```python
df = pl.DataFrame({
    "sport": [0, 0, 0, 1, 1, 1],
    "skill": [20, 40, 2, 30, 4, 3],
    "pro": [True, False, False, True, False, False]
})

q = (df.lazy()
    .with_columns(
        pro_skill = (pl.col.skill >= pl.col.skill.filter(pl.col.pro).mean())
            .over("sport")
    ))
q.show_graph(engine="streaming", plan_stage="physical")
```

<img width="1038" height="1718" alt="image" src="https://github.com/user-attachments/assets/718e900b-4aeb-47b1-807c-f6429d6c540b" />
