### PR TITLE
fix(plan): remove duplicated column in `match_to_schema` missing-column error

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -754,7 +754,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             }
 
             // Report the error for missing columns
-            if let Some(lst) = found_missing_columns.first() {
+            if !found_missing_columns.is_empty() {
                 use std::fmt::Write;
                 let mut formatted = String::new();
                 write!(&mut formatted, "\"{}\"", found_missing_columns[0]).unwrap();
@@ -762,7 +762,6 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                     write!(&mut formatted, ", \"{c}\"").unwrap();
                 }
 
-                write!(&mut formatted, "\"{lst}\"").unwrap();
                 polars_bail!(SchemaMismatch: "missing columns in `match_to_schema`: {formatted}");
             }
 


### PR DESCRIPTION
## Summary

The error message for missing columns in `match_to_schema` was appending the first missing column a second time at the end of the list, producing broken output like:

```
SchemaError: missing columns in `match_to_schema`: "b", "c""b"
```

instead of:

```
SchemaError: missing columns in `match_to_schema`: "b", "c"
```

The first column was written once with `write!(&mut formatted, "\"{}\"", found_missing_columns[0])` and then a stray second `write!(&mut formatted, "\"{lst}\"")` after the loop wrote it again, where `lst = found_missing_columns.first()`. Removed the stray write and replaced the `if let Some(lst) = ...` with `if !found_missing_columns.is_empty()` since `lst` is no longer used.

Fixes #27256

## Test plan

Repro from the issue:

```python
import polars as pl
pl.DataFrame().match_to_schema({"b": pl.Int64, "c": pl.Int64})
```

- Before: `SchemaError: missing columns in \`match_to_schema\`: "b", "c""b"`
- After:  `SchemaError: missing columns in \`match_to_schema\`: "b", "c"`