### PR TITLE
chore(python): Resolve bad instantiations in test_iceberg

### DIFF
--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -75,23 +75,23 @@ from polars.testing import assert_frame_equal
 from tests.unit.io.conftest import normalize_path_separator_pl
 
 if TYPE_CHECKING:
-    AlwaysFalse = Any
-    AlwaysTrue = Any
     from tests.conftest import PlMonkeyPatch
 
     # Mypy does not understand the constructors and we can't construct the inputs
     # explicitly since they are abstract base classes.
-    And = Any
-    EqualTo = Any
-    GreaterThan = Any
-    GreaterThanOrEqual = Any
-    In = Any
-    IsNull = Any
-    LessThan = Any
-    LessThanOrEqual = Any
-    Not = Any
-    Or = Any
-    Reference = Any
+    AlwaysFalse: Any
+    AlwaysTrue: Any
+    And: Any
+    EqualTo: Any
+    GreaterThan: Any
+    GreaterThanOrEqual: Any
+    In: Any
+    IsNull: Any
+    LessThan: Any
+    LessThanOrEqual: Any
+    Not: Any
+    Or: Any
+    Reference: Any
 else:
     from pyiceberg.expressions import (
         AlwaysFalse,


### PR DESCRIPTION
other type checkers would flag
```
object of type "type[Any]" is not callable
```
on 

https://github.com/pola-rs/polars/blob/44e162f5ac1e6193943a2ce9d4110ecdcfb24895/py-polars/tests/unit/io/test_iceberg.py#L351

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
