### PR TITLE
feat: Simplify traceback

### DIFF
--- a/py-polars/src/polars/_utils/deprecation.py
+++ b/py-polars/src/polars/_utils/deprecation.py
@@ -83,6 +83,7 @@ def deprecate_streaming_parameter() -> IdentityFunction:
     def decorate(function: Callable[P, T]) -> Callable[P, T]:
         @wraps(function)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            __tracebackhide__ = True
             if "streaming" in kwargs:
                 issue_deprecation_warning(
                     "the `streaming` parameter was deprecated in 1.25.0; use `engine` instead."

--- a/py-polars/src/polars/lazyframe/opt_flags.py
+++ b/py-polars/src/polars/lazyframe/opt_flags.py
@@ -326,6 +326,7 @@ def forward_old_opt_flags() -> IdentityFunction:
     def decorate(function: Callable[P, T]) -> Callable[P, T]:
         @wraps(function)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            __tracebackhide__ = True
             optflags: QueryOptFlags = kwargs.get(
                 "optimizations", DEFAULT_QUERY_OPT_FLAGS
             )  # type: ignore[assignment]


### PR DESCRIPTION
Closes #22596 

I am not sure this completly close the issue, but I am not sure we can do better.

In this PR, I only remove the traceback from wrappers which were not really useful for the end users.

Main:
<img width="2272" height="1098" alt="image" src="https://github.com/user-attachments/assets/6193b3a4-2a84-4cb8-a733-897a85bc746d" />


PR:
<img width="1534" height="886" alt="image" src="https://github.com/user-attachments/assets/08821398-b2c3-41ae-aa1f-5c812d67f1a5" />
