### PR TITLE
fix: Always respect DataFrame height in `with_columns`

### DIFF
--- a/crates/polars-mem-engine/src/executors/stack.rs
+++ b/crates/polars-mem-engine/src/executors/stack.rs
@@ -95,6 +95,30 @@ impl StackExec {
                         }
                     }
                 }
+
+                // When DataFrame is empty (0 rows, 0 columns), broadcast scalars to length 0.
+                // This ensures with_columns on an empty DataFrame doesn't create rows from scalars.
+                // Non-scalars with length > 0 should error (length mismatch).
+                let res = if df_height == 0 && df_width == 0 {
+                    let mut result = Vec::with_capacity(res.len());
+                    for (i, c) in res.into_iter().enumerate() {
+                        if c.len() == 1 {
+                            // Broadcast scalar to length 0
+                            result.push(c.new_from_index(0, 0));
+                        } else if c.is_empty() {
+                            // Already empty, keep as is
+                            result.push(c);
+                        } else {
+                            // Non-scalar with length > 1: this is a shape mismatch
+                            polars_bail!(ShapeMismatch: "unable to add column {:?} of length {} to a DataFrame of height 0",
+                                c.name(), c.len());
+                        }
+                    }
+                    result
+                } else {
+                    res
+                };
+
                 df.with_columns_mut(res, schema)?;
             }
             df

--- a/py-polars/tests/unit/operations/test_with_columns.py
+++ b/py-polars/tests/unit/operations/test_with_columns.py
@@ -177,3 +177,20 @@ def test_with_columns_scalar_20981() -> None:
     lf = pl.LazyFrame({"a": [1.0, 2.0, 3.0]})
     assert_frame_equal(lf.with_columns(a=2.0).collect(), expected)
     assert_frame_equal(lf.with_columns(pl.col.a.mean()).collect(), expected)
+
+
+def test_with_columns_empty_dataframe_scalar_broadcast_17107() -> None:
+    # with_columns on empty DataFrame should broadcast scalars to 0 rows
+    result = pl.DataFrame().with_columns(c=pl.lit(1))
+    assert result.shape == (0, 1)
+    assert result.columns == ["c"]
+
+    # Empty Series should also work
+    result = pl.DataFrame().with_columns(c=pl.Series([], dtype=pl.Int64))
+    assert result.shape == (0, 1)
+
+    # Non-scalar Series should raise ShapeError
+    with pytest.raises(
+        pl.exceptions.ShapeError, match='unable to add column "c" of length 2'
+    ):
+        pl.DataFrame().with_columns(c=pl.Series([1, 2]))


### PR DESCRIPTION
Fixes: #17107

As per [ritchtie comment's](https://github.com/pola-rs/polars/issues/17107#issuecomment-2337928231)
`with_columns` on a zero-height DataFrame will always result in a zero-height dataframe:

Meaning this will now raise:

```python
import polars as pl
pl.DataFrame().with_columns(c=pl.Series([1, 2]))
# ShapeError: unable to add a column of length 2 to a DataFrame of height 0

```