### PR TITLE
perf: Nested common subplan elimination

### DIFF
--- a/crates/polars-lazy/src/tests/cse.rs
+++ b/crates/polars-lazy/src/tests/cse.rs
@@ -75,7 +75,7 @@ fn test_cse_unions() -> PolarsResult<()> {
             _ => true,
         }
     }));
-    assert_eq!(cache_count, 2);
+    assert_eq!(cache_count, 5);
     let out = lf.collect()?;
     assert_eq!(out.get_column_names(), &["category", "fats_g"]);
 
@@ -265,20 +265,36 @@ fn test_cache_with_partial_projection() -> PolarsResult<()> {
     // EDIT: #15264 this originally
     // tested 2 caches, but we cannot do that after #15264 due to projection pushdown
     // running first and the cache semantics changing, so now we test 1. Maybe we can improve later.
-
-    // ensure we get two different caches
-    // and ensure that every cache only has 1 hit.
+    let mut df_hits = 0;
     let cache_ids = lp_arena
         .iter(lp)
         .flat_map(|(_, lp)| {
             use IR::*;
             match lp {
                 Cache { id, .. } => Some(*id),
+                DataFrameScan {
+                    df, output_schema, ..
+                } => {
+                    if df
+                        .schema()
+                        .iter_names()
+                        .map(|x| x.as_str())
+                        .collect::<Vec<_>>()
+                        .as_slice()
+                        == ["id", "x", "freq"]
+                    {
+                        assert!(output_schema.as_ref().is_some_and(|x| x.len() == 2));
+                        df_hits += 1;
+                    }
+
+                    None
+                },
                 _ => None,
             }
         })
         .collect::<BTreeSet<_>>();
-    assert_eq!(cache_ids.len(), 1);
+    assert_eq!(cache_ids.len(), 2);
+    assert!(df_hits == 3);
 
     Ok(())
 }

--- a/crates/polars-plan/src/plans/optimizer/cse/cspe.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/cspe.rs
@@ -270,9 +270,6 @@ impl<'a, 'arena> NodeVisitor for InsertCachesVisitor<'a, 'arena> {
             };
 
             curr_state.replacement_ir = Some(replacement_ir);
-
-            // TODO: Remove this to enabled nested CSPE
-            return ControlFlow::Continue(SubtreeVisit::Skip);
         }
 
         ControlFlow::Continue(SubtreeVisit::Visit)

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -1215,10 +1215,17 @@ def test_cpse_predicates_25030() -> None:
     q4 = q3.group_by("key").len().join(q3, on="key")
 
     got = q4.collect()
-    expected = q4.collect(optimizations=pl.QueryOptFlags(comm_subplan_elim=False))
+    expected = pl.DataFrame(
+        [
+            pl.Series("key", [2], dtype=pl.Int64),
+            pl.Series("len", [1], dtype=pl.UInt32),
+            pl.Series("len_right", [2], dtype=pl.UInt32),
+            pl.Series("x", [2], dtype=pl.Int64),
+            pl.Series("y", [1], dtype=pl.Int64),
+        ]
+    )
 
     assert_frame_equal(got, expected)
-    assert q4.explain().count("CACHE") == 2
 
 
 def test_asof_join_25699() -> None:
@@ -1403,9 +1410,6 @@ def test_cspe_projection_between_filter_and_cache_drop_filter_column() -> None:
     )
 
 
-@pytest.mark.xfail(
-    reason="nested CSPE not yet enabled; needs refactor of predicate/projection/slice pushdowns"
-)
 def test_cspe_create_nested_caches() -> None:
     lf = pl.LazyFrame({"a": [0, 1, 2]})
 


### PR DESCRIPTION
* Nested common plan elimination is achieved by just traversing once into the subtree of an inserted cache node during the cache insertion phase, instead of stopping traversal.
* Refactored implementation for CSPE using a different tree-visitor setup. High-level approach otherwise remains the same (blake3 hashing of subtrees).

E.g. -

```python
lf = pl.LazyFrame({"a": [0, 1, 2]})
lf1 = lf.select(pl.col("a") + 1)
lf2 = pl.concat([lf1, lf1])
lf3 = pl.concat([lf2, lf2])

print(lf3.explain())
```

Before / after -

<img width="966" height="487" alt="image" src="https://github.com/user-attachments/assets/e23c5830-e0bc-4964-aea3-364c0049d581" />

---

* https://github.com/pola-rs/polars/pull/27425
  * https://github.com/pola-rs/polars/pull/27422
    * https://github.com/pola-rs/polars/pull/27437
      * https://github.com/pola-rs/polars/pull/27438
        * https://github.com/pola-rs/polars/pull/27340
        
        
        
Edit by @ritchie46:
Readers of this PR, please try `POLARS_ALLOW_NESTED_CSPE=1` and report back if you find any issues. That would help us a lot. 