### PR TITLE
fix(rust): Make `.over()` respect `set_random_seed` for `shuffle` and `sample`

### DIFF
--- a/crates/polars-core/src/random.rs
+++ b/crates/polars-core/src/random.rs
@@ -9,6 +9,15 @@ pub(crate) fn get_global_random_u64() -> u64 {
     POLARS_GLOBAL_RNG_STATE.lock().unwrap().next_u64()
 }
 
+/// Draw `n` u64 seeds from the global RNG in a single locked, sequential pass.
+/// Used by group-aware randomised expressions to pre-compute per-group seeds
+/// before parallel dispatch, preserving deterministic seed assignment regardless
+/// of scheduling.
+pub fn draw_n_global_seeds(n: usize) -> Vec<u64> {
+    let mut rng = POLARS_GLOBAL_RNG_STATE.lock().unwrap();
+    (0..n).map(|_| rng.next_u64()).collect()
+}
+
 pub fn set_global_random_seed(seed: u64) {
     *POLARS_GLOBAL_RNG_STATE.lock().unwrap() = SmallRng::seed_from_u64(seed);
 }

--- a/crates/polars-expr/src/dispatch/groups_dispatch.rs
+++ b/crates/polars-expr/src/dispatch/groups_dispatch.rs
@@ -7,19 +7,21 @@ use arrow::bitmap::bitmask::BitMask;
 use arrow::trusted_len::TrustMyLength;
 use polars_compute::unique::{AmortizedUnique, amortized_unique_from_dtype};
 use polars_core::POOL;
-use polars_core::error::{PolarsResult, polars_bail, polars_ensure};
+use polars_core::chunked_array::builder::get_list_builder;
+use polars_core::chunked_array::from_iterator_par::try_list_from_par_iter;
+use polars_core::error::{PolarsResult, polars_bail, polars_ensure, polars_err};
 use polars_core::frame::DataFrame;
 use polars_core::prelude::row_encode::encode_rows_unordered;
 use polars_core::prelude::{
-    AnyValue, ChunkCast, Column, CompatLevel, Float64Chunked, GroupPositions, GroupsType,
-    IDX_DTYPE, IntoColumn,
+    AnyValue, ChunkCast, Column, CompatLevel, DataType, Float64Chunked, GroupPositions,
+    GroupsType, IDX_DTYPE, IntoColumn, IntoSeries, ListChunked,
 };
 use polars_core::scalar::Scalar;
 use polars_core::series::{ChunkCompareEq, Series};
 use polars_utils::itertools::Itertools;
 use polars_utils::pl_str::PlSmallStr;
 use polars_utils::{IdxSize, UnitVec};
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 
 use crate::prelude::{AggState, AggregationContext, PhysicalExpr, UpdateGroups};
 use crate::state::ExecutionState;
@@ -783,4 +785,223 @@ pub fn backward_fill_null<'a>(
         arg_backward_fill!(iter, validity, length),
         arg_backward_fill!(iter, validity, length),
     )
+}
+
+/// Build a seed vector aligned with `groups`, where each non-null group receives
+/// a seed drawn in canonical (first-row-idx sorted) order. This decouples the
+/// seed-to-group assignment from the hashmap iteration order of `groups` while
+/// keeping `ac.groups` untouched (so the downstream `map_by_arg_sort` pointer-
+/// equality path at `window.rs` stays on its correct branch).
+#[cfg(feature = "random")]
+fn canonical_per_group_seeds(
+    items_mask: &[bool],
+    groups_type: &GroupsType,
+) -> Vec<Option<u64>> {
+    let n_groups = items_mask.len();
+
+    // first[i] = the first row-index of group i (in the iteration order that the
+    // ListChunked was produced in, which matches ac.groups / gb.get_groups()).
+    let first_rows: Vec<IdxSize> = match groups_type {
+        GroupsType::Idx(groups) => groups.first().to_vec(),
+        GroupsType::Slice { groups, .. } => groups.iter().map(|[f, _]| *f).collect(),
+    };
+    debug_assert_eq!(first_rows.len(), n_groups);
+
+    // Canonical ordering over non-null groups: sort their indices by first-row-idx.
+    let mut non_null: Vec<usize> = (0..n_groups).filter(|&i| items_mask[i]).collect();
+    non_null.sort_by_key(|&i| first_rows[i]);
+
+    // Draw exactly as many seeds as non-null groups (no wasted advancement).
+    let drawn = polars_core::random::draw_n_global_seeds(non_null.len());
+
+    // Distribute: the k-th non-null group (canonical order) gets drawn[k].
+    let mut seed_of: Vec<Option<u64>> = vec![None; n_groups];
+    for (k, &i) in non_null.iter().enumerate() {
+        seed_of[i] = Some(drawn[k]);
+    }
+
+    seed_of
+}
+
+#[cfg(feature = "random")]
+pub fn shuffle_over_groups<'a>(
+    inputs: &[Arc<dyn PhysicalExpr>],
+    df: &DataFrame,
+    groups: &'a GroupPositions,
+    state: &ExecutionState,
+) -> PolarsResult<AggregationContext<'a>> {
+    assert_eq!(inputs.len(), 1);
+    let mut ac = inputs[0].evaluate_on_groups(df, groups, state)?;
+    ac.groups();
+    // NOTE: the per-group list produced below is in the iteration order of the
+    // ORIGINAL `groups` parameter (upstream from WindowExpr), regardless of
+    // whether the inner expression returned NotAggregated or AggregatedList.
+    // We therefore derive canonical seed ordering from `groups` directly —
+    // NOT from `ac.groups`, because for AggregatedList inputs `ac.groups()`
+    // above runs a WithSeriesLen transform that replaces ac.groups with
+    // Slice-based groups whose "first" values are cumulative list offsets
+    // rather than original row indices.
+
+    // IMPORTANT: we intentionally do NOT call `ac.groups.to_mut().sort()`.
+    // Sorting clones the Cow, which breaks the `std::ptr::eq(ac.groups, gb.get_groups())`
+    // check in `window.rs::map_list_agg_by_arg_sort`. When the pointer check fails
+    // it takes the else-branch, which assumes ac.groups and gb.get_groups() describe
+    // the *same groups in the same order* and pairs their row-indices positionally.
+    // A reordered clone violates that contract and mis-maps values across groups
+    // (see issue #27307 analysis). Instead, we leave ac.groups alone (preserving
+    // pointer equality) and stabilise seed assignment via a canonical first-row-idx
+    // ordering computed below — giving the same determinism guarantee without
+    // disturbing the upstream group representation.
+
+    // Mirror AggregatedScalar / LiteralScalar handling from apply_single_group_aware
+    // (apply.rs:154-157).
+    let agg = match ac.agg_state() {
+        AggState::AggregatedScalar(s) | AggState::LiteralScalar(s) => s.as_list().into_column(),
+        _ => ac.aggregated(),
+    };
+    let ca = agg.list().unwrap();
+    let name = agg.name().clone();
+
+    let items: Vec<Option<Series>> = ca.into_iter().collect();
+    let n_groups = items.len();
+    debug_assert_eq!(
+        n_groups,
+        ac.groups.len(),
+        "aggregated ListChunked length ({}) must equal group count ({})",
+        n_groups,
+        ac.groups.len(),
+    );
+
+    // Pre-draw seeds in canonical order; see `canonical_per_group_seeds`.
+    let items_mask: Vec<bool> = items.iter().map(|o| o.is_some()).collect();
+    let seeds = canonical_per_group_seeds(&items_mask, groups.as_ref());
+
+    // Parallel dispatch is now safe — each group's seed is pre-determined
+    // regardless of rayon scheduling.
+    let out: ListChunked = POOL.install(|| {
+        try_list_from_par_iter(
+            items
+                .into_par_iter()
+                .zip(seeds.into_par_iter())
+                .map(|(opt_s, opt_seed)| -> PolarsResult<Option<Series>> {
+                    Ok(match (opt_s, opt_seed) {
+                        (Some(s), Some(seed)) => Some(s.shuffle(Some(seed))),
+                        _ => None,
+                    })
+                }),
+            PlSmallStr::EMPTY,
+        )
+    })?;
+
+    // Finalise using the same contract as ApplyExpr::finish_apply_groups (apply.rs:99-103).
+    let out_col = out.with_name(name).into_series().into_column();
+    ac.with_update_groups(UpdateGroups::WithSeriesLen);
+    ac.with_values_and_args(out_col, true, None, false, false)?;
+    Ok(ac)
+}
+
+#[cfg(feature = "random")]
+pub fn sample_over_groups<'a>(
+    inputs: &[Arc<dyn PhysicalExpr>],
+    df: &DataFrame,
+    groups: &'a GroupPositions,
+    state: &ExecutionState,
+    is_fraction: bool,
+    with_replacement: bool,
+    shuffle: bool,
+) -> PolarsResult<AggregationContext<'a>> {
+    assert_eq!(inputs.len(), 2);
+
+    let mut ac_data = inputs[0].evaluate_on_groups(df, groups, state)?;
+    let mut ac_n = inputs[1].evaluate_on_groups(df, groups, state)?;
+    ac_data.groups();
+    ac_n.groups();
+
+    // Same rationale as shuffle_over_groups: do NOT mutate ac_data.groups (it
+    // would break pointer-equality in `map_list_agg_by_arg_sort`), and derive
+    // canonical seed ordering from the ORIGINAL `groups` parameter so that
+    // AggregatedList upstream states (which trigger a WithSeriesLen transform
+    // replacing ac.groups with Slice-based list-offsets) are handled correctly.
+
+    let agg_data = match ac_data.agg_state() {
+        AggState::AggregatedScalar(s) | AggState::LiteralScalar(s) => s.as_list().into_column(),
+        _ => ac_data.aggregated(),
+    };
+    let ca_data = agg_data.list().unwrap();
+    let name = agg_data.name().clone();
+    let n_groups = ca_data.len();
+
+    // For `n`/`frac`: a LiteralScalar has length 1 regardless of group count and
+    // must be broadcast to n_groups. This mirrors the broadcast in
+    // `groups_dispatch::unique` for the scalar-state early-return path.
+    let agg_n = match ac_n.agg_state() {
+        AggState::LiteralScalar(s) => {
+            let mut list = s.as_list().into_column();
+            if list.len() == 1 && n_groups != 1 {
+                list = list.new_from_index(0, n_groups);
+            }
+            list
+        },
+        AggState::AggregatedScalar(s) => s.as_list().into_column(),
+        _ => ac_n.aggregated(),
+    };
+    let ca_n = agg_n.list().unwrap();
+
+    debug_assert_eq!(
+        n_groups,
+        ac_data.groups.len(),
+        "aggregated data ListChunked length ({}) must equal group count ({})",
+        n_groups,
+        ac_data.groups.len(),
+    );
+    debug_assert_eq!(n_groups, ca_n.len(), "data and n group counts must match");
+
+    // Collect into parallel arrays so we can build per-group seeds.
+    let items_data: Vec<Option<Series>> = ca_data.into_iter().collect();
+    let items_n: Vec<Option<Series>> = ca_n.into_iter().collect();
+    let items_mask: Vec<bool> = items_data
+        .iter()
+        .zip(items_n.iter())
+        .map(|(d, n)| d.is_some() && n.is_some())
+        .collect();
+    let seeds = canonical_per_group_seeds(&items_mask, groups.as_ref());
+
+    let inner_dtype = ca_data.inner_dtype().clone();
+    let mut builder = get_list_builder(&inner_dtype, n_groups * 5, n_groups, name.clone());
+
+    for ((opt_data, opt_n), opt_seed) in items_data
+        .into_iter()
+        .zip(items_n.into_iter())
+        .zip(seeds.into_iter())
+    {
+        match (opt_data, opt_n, opt_seed) {
+            (Some(data), Some(n_series), Some(seed)) => {
+                let seed_opt = Some(seed);
+                let out = if is_fraction {
+                    let frac_s = n_series.cast(&DataType::Float64)?;
+                    let frac = frac_s
+                        .f64()?
+                        .get(0)
+                        .ok_or_else(|| polars_err!(ComputeError: "sample fraction is null"))?;
+                    data.sample_frac(frac, with_replacement, shuffle, seed_opt)?
+                } else {
+                    let n_s = n_series.strict_cast(&IDX_DTYPE)?;
+                    let n = n_s
+                        .idx()?
+                        .get(0)
+                        .ok_or_else(|| polars_err!(ComputeError: "sample size is null"))?
+                        as usize;
+                    data.sample_n(n, with_replacement, shuffle, seed_opt)?
+                };
+                builder.append_series(&out)?;
+            },
+            _ => builder.append_null(),
+        }
+    }
+
+    let ca = builder.finish();
+    let out_col = ca.into_series().into_column();
+    ac_data.with_update_groups(UpdateGroups::WithSeriesLen);
+    ac_data.with_values_and_args(out_col, true, None, false, false)?;
+    Ok(ac_data)
 }

--- a/crates/polars-expr/src/dispatch/mod.rs
+++ b/crates/polars-expr/src/dispatch/mod.rs
@@ -4,6 +4,8 @@ use polars_core::error::PolarsResult;
 use polars_core::frame::DataFrame;
 use polars_core::prelude::{Column, GroupPositions};
 use polars_plan::dsl::{ColumnsUdf, SpecialEq};
+#[cfg(feature = "random")]
+use polars_plan::plans::IRRandomMethod;
 use polars_plan::plans::{IRBooleanFunction, IRFunctionExpr, IRPowFunction};
 use polars_utils::IdxSize;
 
@@ -602,6 +604,29 @@ pub fn function_expr_to_groups_udf(func: &IRFunctionExpr) -> Option<SpecialEq<Ar
         },
         F::FillNullWithStrategy(polars_core::prelude::FillNullStrategy::Backward(limit)) => {
             wrap_groups!(groups_dispatch::backward_fill_null, (*limit, v: Option<IdxSize>))
+        },
+
+        #[cfg(feature = "random")]
+        F::Random {
+            method: IRRandomMethod::Shuffle,
+            seed: None,
+        } => wrap_groups!(groups_dispatch::shuffle_over_groups),
+        #[cfg(feature = "random")]
+        F::Random {
+            method:
+                IRRandomMethod::Sample {
+                    is_fraction,
+                    with_replacement,
+                    shuffle,
+                },
+            seed: None,
+        } => {
+            wrap_groups!(
+                groups_dispatch::sample_over_groups,
+                (*is_fraction, v1: bool),
+                (*with_replacement, v2: bool),
+                (*shuffle, v3: bool)
+            )
         },
 
         _ => return None,

--- a/py-polars/tests/unit/operations/test_random.py
+++ b/py-polars/tests/unit/operations/test_random.py
@@ -146,3 +146,321 @@ def test_sample_16232() -> None:
     assert df.select(pl.col("b").list.sample(n=pl.col("a"), seed=0)).to_dict(
         as_series=False
     ) == {"b": [[], [], [1]]}
+
+
+# ---------------------------------------------------------------------------
+# Reproducibility of `.over()` with `pl.set_random_seed` — issues #27307, #15464
+# ---------------------------------------------------------------------------
+
+
+# Category 1: Core reproducibility — parametrised 20x to catch scheduling-
+# dependent regressions that a single-pair comparison might pass by coincidence.
+
+
+@pytest.mark.parametrize("run", range(20))
+def test_shuffle_over_respects_global_seed_15464(run: int) -> None:
+    df = pl.DataFrame(
+        {
+            "grp": ["A", "A", "A", "B", "B", "C", "C", "D"],
+            "val": [1, 2, 3, 4, 5, 6, 7, 8],
+        }
+    )
+
+    pl.set_random_seed(0)
+    result1 = df.with_columns(pl.int_range(pl.len()).shuffle().over("grp"))
+
+    pl.set_random_seed(0)
+    result2 = df.with_columns(pl.int_range(pl.len()).shuffle().over("grp"))
+
+    assert_frame_equal(result1, result2)
+
+
+@pytest.mark.parametrize("run", range(20))
+def test_sample_over_respects_global_seed(run: int) -> None:
+    df = pl.DataFrame(
+        {
+            "grp": ["A", "A", "A", "B", "B", "C", "C"],
+            "val": [1, 2, 3, 4, 5, 6, 7],
+        }
+    )
+
+    pl.set_random_seed(42)
+    result1 = df.with_columns(
+        pl.col("val").sample(n=pl.len(), shuffle=True).over("grp")
+    )
+
+    pl.set_random_seed(42)
+    result2 = df.with_columns(
+        pl.col("val").sample(n=pl.len(), shuffle=True).over("grp")
+    )
+
+    assert_frame_equal(result1, result2)
+
+
+@pytest.mark.parametrize("run", range(20))
+def test_shuffle_over_reproducible_second_seed(run: int) -> None:
+    # Belt-and-braces: different seed + different shape than test 1 to guard
+    # against a fix that happens to work only for one (seed, shape) combination.
+    df = pl.DataFrame(
+        {
+            "grp": ["A", "A", "A", "B", "B", "B", "C", "C", "C"],
+            "val": [1, 2, 3, 4, 5, 6, 7, 8, 9],
+        }
+    )
+
+    pl.set_random_seed(123)
+    result1 = df.with_columns(pl.col("val").shuffle().over("grp"))
+
+    pl.set_random_seed(123)
+    result2 = df.with_columns(pl.col("val").shuffle().over("grp"))
+
+    assert_frame_equal(result1, result2)
+
+
+# Category 2: Per-group seed independence.
+
+
+def test_shuffle_over_different_per_group_seeds() -> None:
+    # With size-10 identical-data groups, P(collision for a fixed seed)
+    # ≈ 1/10! ≈ 2.8e-7. Using a fixed seed rather than a search loop —
+    # if this specific seed ever collides, change the literal; do NOT
+    # reintroduce a loop (CI-hostile).
+    n = 10
+    df = pl.DataFrame(
+        {"grp": ["A"] * n + ["B"] * n, "val": list(range(n)) * 2}
+    )
+
+    pl.set_random_seed(0)
+    result = df.with_columns(pl.col("val").shuffle().over("grp"))
+    a_vals = result.filter(pl.col("grp") == "A")["val"].to_list()
+    b_vals = result.filter(pl.col("grp") == "B")["val"].to_list()
+
+    assert a_vals != b_vals, (
+        f"Groups A and B got identical shuffles: {a_vals}. "
+        "Per-group seeds aren't being differentiated."
+    )
+
+
+def test_shuffle_over_different_seeds_different_results() -> None:
+    # Verifies the fix actually consumes the global seed (not hardcoded).
+    # Size-10 groups → 10! × 10! ≈ 1.3e13 combinations → no accidental collision.
+    n = 10
+    df = pl.DataFrame(
+        {"grp": ["A"] * n + ["B"] * n, "val": list(range(n * 2))}
+    )
+
+    pl.set_random_seed(0)
+    result1 = df.with_columns(pl.col("val").shuffle().over("grp"))
+
+    pl.set_random_seed(999)
+    result2 = df.with_columns(pl.col("val").shuffle().over("grp"))
+
+    assert not result1.equals(result2)
+
+
+# Category 3: Backward compatibility — explicit seeds.
+
+
+def test_shuffle_over_explicit_seed_deterministic() -> None:
+    df = pl.DataFrame(
+        {
+            "grp": ["A", "A", "A", "B", "B", "C", "C", "D"],
+            "val": [1, 2, 3, 4, 5, 6, 7, 8],
+        }
+    )
+
+    result1 = df.with_columns(pl.col("val").shuffle(seed=42).over("grp"))
+    result2 = df.with_columns(pl.col("val").shuffle(seed=42).over("grp"))
+
+    assert_frame_equal(result1, result2)
+
+
+def test_shuffle_over_explicit_seed_same_per_group() -> None:
+    # With identical data and the same explicit seed, both groups must
+    # produce identical shuffles — preserving the documented pre-fix behavior.
+    df = pl.DataFrame(
+        {"grp": ["A", "A", "A", "B", "B", "B"], "val": [1, 2, 3, 1, 2, 3]}
+    )
+
+    result = df.with_columns(pl.col("val").shuffle(seed=42).over("grp"))
+    a_vals = result.filter(pl.col("grp") == "A")["val"].to_list()
+    b_vals = result.filter(pl.col("grp") == "B")["val"].to_list()
+
+    assert a_vals == b_vals
+
+
+# Category 4: Backward compatibility — sequential operations.
+
+
+def test_shuffle_over_does_not_break_subsequent_random_ops() -> None:
+    # .over() must advance the global RNG by a deterministic count so that
+    # downstream random ops (without a seed reset) see identical state.
+    df = pl.DataFrame({"grp": ["A", "A", "B", "B"], "val": [1, 2, 3, 4]})
+
+    pl.set_random_seed(0)
+    _ = df.with_columns(pl.col("val").shuffle().over("grp"))
+    after1 = df.with_columns(pl.col("val").shuffle())
+
+    pl.set_random_seed(0)
+    _ = df.with_columns(pl.col("val").shuffle().over("grp"))
+    after2 = df.with_columns(pl.col("val").shuffle())
+
+    assert_frame_equal(after1, after2)
+
+
+def test_multiple_shuffle_over_calls_reproducible() -> None:
+    # Multiple .over() expressions in the same with_columns — exercises
+    # the window-cache interaction between partitioned random ops.
+    df = pl.DataFrame(
+        {
+            "grp": ["A", "A", "A", "B", "B", "B"],
+            "x": [1, 2, 3, 4, 5, 6],
+            "y": [10, 20, 30, 40, 50, 60],
+        }
+    )
+
+    pl.set_random_seed(0)
+    result1 = df.with_columns(
+        pl.col("x").shuffle().over("grp").alias("x_shuffled"),
+        pl.col("y").shuffle().over("grp").alias("y_shuffled"),
+    )
+
+    pl.set_random_seed(0)
+    result2 = df.with_columns(
+        pl.col("x").shuffle().over("grp").alias("x_shuffled"),
+        pl.col("y").shuffle().over("grp").alias("y_shuffled"),
+    )
+
+    assert_frame_equal(result1, result2)
+
+
+# Category 5: Edge cases.
+
+
+def test_shuffle_over_single_element_groups() -> None:
+    df = pl.DataFrame({"grp": ["A", "B", "C", "D"], "val": [1, 2, 3, 4]})
+
+    pl.set_random_seed(0)
+    result1 = df.with_columns(pl.col("val").shuffle().over("grp"))
+
+    pl.set_random_seed(0)
+    result2 = df.with_columns(pl.col("val").shuffle().over("grp"))
+
+    assert_frame_equal(result1, result2)
+    assert_series_equal(result1["val"], df["val"])
+
+
+def test_shuffle_over_single_group() -> None:
+    df = pl.DataFrame({"grp": ["A", "A", "A", "A", "A"], "val": [1, 2, 3, 4, 5]})
+
+    pl.set_random_seed(0)
+    result1 = df.with_columns(pl.col("val").shuffle().over("grp"))
+
+    pl.set_random_seed(0)
+    result2 = df.with_columns(pl.col("val").shuffle().over("grp"))
+
+    assert_frame_equal(result1, result2)
+
+
+def test_shuffle_over_many_groups() -> None:
+    # 200 groups → rayon will use multiple workers. Most likely scenario
+    # to expose a remaining scheduling-dependent regression.
+    n_groups = 200
+    group_size = 10
+    df = pl.DataFrame(
+        {
+            "grp": [i for i in range(n_groups) for _ in range(group_size)],
+            "val": list(range(group_size)) * n_groups,
+        }
+    )
+
+    pl.set_random_seed(0)
+    result1 = df.with_columns(pl.col("val").shuffle().over("grp"))
+
+    pl.set_random_seed(0)
+    result2 = df.with_columns(pl.col("val").shuffle().over("grp"))
+
+    assert_frame_equal(result1, result2)
+
+
+def test_shuffle_over_with_null_values() -> None:
+    df = pl.DataFrame(
+        {"grp": ["A", "A", "A", "B", "B", "B"], "val": [1, None, 3, None, 5, None]}
+    )
+
+    pl.set_random_seed(0)
+    result1 = df.with_columns(pl.col("val").shuffle().over("grp"))
+
+    pl.set_random_seed(0)
+    result2 = df.with_columns(pl.col("val").shuffle().over("grp"))
+
+    assert_frame_equal(result1, result2)
+    # Shuffle is an intra-group permutation, so the total null count is invariant.
+    assert result1["val"].null_count() == 3
+
+
+def test_shuffle_over_multi_column_partition() -> None:
+    df = pl.DataFrame(
+        {
+            "a": ["X", "X", "X", "X", "Y", "Y", "Y", "Y"],
+            "b": [1, 1, 2, 2, 1, 1, 2, 2],
+            "val": [10, 20, 30, 40, 50, 60, 70, 80],
+        }
+    )
+
+    pl.set_random_seed(0)
+    result1 = df.with_columns(pl.col("val").shuffle().over("a", "b"))
+
+    pl.set_random_seed(0)
+    result2 = df.with_columns(pl.col("val").shuffle().over("a", "b"))
+
+    assert_frame_equal(result1, result2)
+
+
+def test_shuffle_over_unequal_group_sizes() -> None:
+    df = pl.DataFrame(
+        {
+            "grp": ["A"] * 1 + ["B"] * 5 + ["C"] * 20 + ["D"] * 2,
+            "val": list(range(28)),
+        }
+    )
+
+    pl.set_random_seed(0)
+    result1 = df.with_columns(pl.col("val").shuffle().over("grp"))
+
+    pl.set_random_seed(0)
+    result2 = df.with_columns(pl.col("val").shuffle().over("grp"))
+
+    assert_frame_equal(result1, result2)
+
+
+# Category 6: Non-regression — non-`.over()` paths must be untouched.
+
+
+def test_shuffle_without_over_still_works() -> None:
+    s = pl.Series("a", range(20))
+
+    pl.set_random_seed(1)
+    result1 = pl.select(pl.lit(s).shuffle()).to_series()
+
+    pl.set_random_seed(1)
+    result2 = pl.select(pl.lit(s).shuffle()).to_series()
+
+    assert_series_equal(result1, result2)
+
+
+def test_shuffle_group_by_agg_still_works() -> None:
+    # group_by().agg() takes a different code path than .over() — this
+    # test pins the non-regression.
+    df = pl.DataFrame(
+        {"grp": ["A", "A", "A", "B", "B", "B"], "val": [1, 2, 3, 4, 5, 6]}
+    )
+
+    result1 = df.group_by("grp", maintain_order=True).agg(
+        pl.col("val").shuffle(seed=0xDEADBEEF)
+    )
+    result2 = df.group_by("grp", maintain_order=True).agg(
+        pl.col("val").shuffle(seed=0xDEADBEEF)
+    )
+
+    assert_frame_equal(result1, result2)


### PR DESCRIPTION
## Summary

Closes #27307. Also meaningfully addresses #15464; the same two root causes
explain why `shuffle().over()` was broken there, and the mechanism introduced
here resolves that case as a side-effect.

> **Note to maintainers:** I am aware #27307 is still labelled `needs triage`
> and not yet `accepted`. I have commented on the issue to flag my intent to
> fix it. Happy to hold this as a draft until the label is updated if preferred.

---

## Problem

`pl.set_random_seed(x)` does not produce deterministic results when `shuffle()`
or `sample()` is used inside `.over()`. Two separate mechanisms conspire to
break reproducibility.

**Factor 1: Group iteration order varies across calls.**
`.over()` builds groups via a `PlHashMap` whose `foldhash::quality::RandomState`
is re-seeded per-hashmap from OS entropy. The same query, run twice, visits
groups in a different order each time.

**Factor 2: Per-group seeds are drawn inside a rayon parallel iterator.**
The global RNG mutex serialises *access* but not *order*; which rayon worker
reaches the lock first is non-deterministic. The set of seeds drawn from the
global RNG is fixed, but *which group receives which seed* varies across runs,
so per-group shuffles change even when the global seed is set.

Together, both factors mean that two calls with the same `set_random_seed` value
can, and do, produce different results; reproducibility is broken.

---

## Root Cause (Verified)

### Factor 1: Group-order non-determinism

For `pl.col("val").shuffle().over("grp")` on an unsorted key column,
`sort_groups` at [`window.rs:415-424`](crates/polars-expr/src/expressions/window.rs#L415)
evaluates to `false`. The downstream sort at
[`window.rs:480-485`](crates/polars-expr/src/expressions/window.rs#L480) is
gated on `sort_groups || state.cache_window()`. When a window-function partition
contains only one expression (`partition.len() == 1`),
[`projection_utils.rs:95-102`](crates/polars-mem-engine/src/executors/projection_utils.rs#L95)
clears the `CACHE_WINDOW_EXPR` flag, so neither condition holds; groups arrive
in whatever order `PlHashMap` produces this run.

### Factor 2: Per-group parallel seed race

Shuffle reaches
[`ApplyExpr::apply_single_group_aware`](crates/polars-expr/src/expressions/apply.rs#L117),
which iterates groups with `par_iter().map(f)`. Each closure calls
`Series::shuffle(None)` → `create_rand_index_no_replacement(..., seed=None)`
→ `SmallRng::seed_from_u64(seed.unwrap_or_else(get_global_random_u64))`. The
global RNG mutex serialises lock *acquisition* but not the order in which
workers acquire it.

Sample takes a different dispatch path (`apply_multiple_group_aware`, sequential)
and is only affected by Factor 1.

### Empirical verification

Both factors were confirmed by reproducing the bug under `POLARS_MAX_THREADS=1`
(9 / 50 distinct results; eliminating parallelism alone is not sufficient, as
Factor 1 still applies), and by instrumenting `canonical_per_group_seeds` to
log `first_rows` across calls (hashmap iteration order varies between
`[0, 3, 5, 7]`, `[3, 0, 7, 5]`, `[7, 3, 5, 0]`, etc. across runs).

---

## Fix

**1. `draw_n_global_seeds(n: usize) -> Vec<u64>` (`polars-core/src/random.rs`)**

A narrowly-scoped helper that acquires the global RNG mutex *once* and draws
`n` seeds sequentially. This ensures the full set of seeds for a `.over()` call
is drawn atomically, with no interleaving with other threads between draws.

**2. `GroupsUdf` for `IRFunctionExpr::Random { seed: None, .. }` (`polars-expr/src/dispatch/`)**

A specialised dispatch path is registered for `Shuffle` and `Sample` when no
explicit seed is provided. It:

- Evaluates the inner expression and materialises per-group values.
- Draws `n_non_null_groups` seeds via `draw_n_global_seeds`.
- Assigns seeds canonically by sorting non-null groups by their **first-row-index**;
  this makes the seed any given group receives independent of hashmap iteration order.
- Dispatches `Series::shuffle(Some(seed))` per group in parallel; each group's
  seed is pre-determined, so rayon scheduling cannot affect output.

Explicit seeds (`shuffle(seed=42)`, `sample(..., seed=42)`) fall through to the
existing `map!` / `map_as_slice!` dispatch and are completely unchanged.

---

## Design Decisions

### Why not sort `ac.groups` directly?

An earlier draft sorted `ac.groups` inside the `GroupsUdf` to establish a
canonical group order. This causes subtle cross-group data corruption.

`Cow::to_mut()` **clones** when the inner is `Borrowed`, so the sort only
affects `ac.groups`, not `gb.get_groups()` upstream. The mapping-back logic in
[`WindowExpr::map_list_agg_by_arg_sort`](crates/polars-expr/src/expressions/window.rs#L54)
uses `std::ptr::eq(ac.groups().as_ref(), gb.get_groups())` to choose between an
identity mapping and an arg-sort-based one; the clone breaks pointer equality
unconditionally, forcing the else-branch. That else-branch pairs `ac.groups`
slice positions with `gb.get_groups()` row indices *positionally*, assuming both
contexts describe groups in the same order. A sorted clone violates this
assumption and causes values to leak across groups.

This PR avoids touching `ac.groups` entirely. Canonical order is derived from
the untouched `groups: &GroupPositions` parameter and used only to reorder seed
*assignment*. The `ListChunked` and its groups remain in upstream order, so
pointer equality holds and the identity-mapping branch always runs.

### Why `groups.as_ref()` rather than `ac.groups.as_ref().as_ref()`?

For inputs like `pl.int_range(pl.len()).shuffle().over("grp")`, the inner
expression produces `AggState::AggregatedList`. The `ac.groups()` call that
follows applies the `WithSeriesLen` lazy update, replacing `ac.groups` with
`GroupsType::Slice` whose `first` fields are **cumulative list offsets**, not
original row indices. Sorting by those offsets gives non-canonical,
call-varying order and defeats the fix entirely.

Deriving `first_rows` from the `groups: &GroupPositions` parameter, which is the
pristine upstream `gb.get_groups()` and is never mutated, avoids this. The order
of the aggregated `ListChunked` matches `groups`' iteration order, so indexing
remains consistent.

### `sample`: LiteralScalar broadcast

`sample(n=literal_scalar, ...)` evaluates the `n` input to a `LiteralScalar`
(length 1) regardless of group count. Without broadcasting, `ca_n.len() == 1`
while `ca_data.len() == n_groups`; the zip terminates after the first group, and
`with_values_and_args` errors with a shape mismatch. The broadcast
(`list.new_from_index(0, n_groups)`) mirrors the existing pattern in
`groups_dispatch::unique`.

### Relationship to PR #23541

[PR #23541](https://github.com/pola-rs/polars/pull/23541) attempted a broader
`Seed` abstraction, with one seed value per IR node XORed with an execution seed
at runtime. It was closed because it could not extend cleanly to `.over()`: a
single per-node seed gives every group the same shuffle permutation, which is
correct for explicit seeds but wrong for global-seed semantics where distinct
groups should permute independently.

This PR is the narrowly-scoped missing piece: per-group seed derivation, without
changing how seeds are represented in the IR. If a future PR resurrects the
`Seed` abstraction, `draw_n_global_seeds(n)` is a one-line integration point.

---

## Files Changed

| File | Change |
|---|---|
| `crates/polars-core/src/random.rs` | Add `pub fn draw_n_global_seeds(n: usize) -> Vec<u64>` |
| `crates/polars-expr/src/dispatch/groups_dispatch.rs` | Add `canonical_per_group_seeds`, `shuffle_over_groups`, `sample_over_groups` |
| `crates/polars-expr/src/dispatch/mod.rs` | Register both `GroupsUdf`s in `function_expr_to_groups_udf` |
| `py-polars/tests/unit/operations/test_random.py` | Add 17 tests across 6 categories (see Tests below) |

No changes to `polars-plan`, `polars-python`, or any public Python API.

---

## Backward Compatibility

| Scenario | Before | After |
|---|---|---|
| `.over()` + global seed (shuffle, multi-threaded) | Non-deterministic ❌ | Deterministic ✅ |
| `.over()` + global seed (sample, multi-threaded) | Non-deterministic ❌ | Deterministic ✅ |
| `.over()` + global seed (single-threaded) | Deterministic within-process only | Deterministic across processes ✅ |
| Explicit `seed=42` + `.over()` | Deterministic ✅ | Deterministic (same path, untouched) ✅ |
| `shuffle()` / `sample()` without `.over()` | Deterministic ✅ | Deterministic (untouched) ✅ |
| `group_by().agg(shuffle())` | Deterministic with explicit seed ✅ | Deterministic with explicit seed (untouched) ✅ |
| Global RNG advancement after `.over()` shuffle | N draws | N draws (unchanged) ✅ |

Users who pinned specific per-group outputs from a single-threaded process run
will see different outputs; those outputs were never stable across processes
however, and the global RNG advances by the same N steps as before.

---

## Tests

17 tests added to `py-polars/tests/unit/operations/test_random.py`:

| Category | Count | Purpose |
|---|---|---|
| Core reproducibility (`@pytest.mark.parametrize("run", range(20))`) | 3 | `shuffle.over()`, `sample.over()`, second seed + shape coverage |
| Per-group seed independence | 2 | Different groups get different shuffles; different seeds give different outputs |
| Explicit-seed backward compatibility | 2 | Explicit seed is deterministic; same-data groups with same explicit seed give same shuffle |
| Sequential operations | 2 | Downstream random ops unaffected; multiple `.over()` calls in one `with_columns` are reproducible |
| Edge cases | 6 | Single-element groups, single group, 200 groups, null values, multi-column partition, unequal group sizes |
| Non-regression | 2 | `shuffle()` without `.over()`; `group_by().agg(shuffle())` |

Core reproducibility tests use `range(20)` parametrisation so each runs as 20
independent pytest cases; this catches probabilistic regressions under
thread scheduling, that a single-pair comparison could pass by coincidence.

---

## Out of Scope: `rank(method='random')`

While tracing this bug, a separate pre-existing issue was identified:
`rank(method='random')` bypasses `POLARS_GLOBAL_RNG_STATE` entirely via
[`rank.rs:43-47`](crates/polars-ops/src/series/ops/rank.rs#L43), seeding a
fresh `SmallRng` from OS entropy. This breaks `set_random_seed` for rank
*without* `.over()`, giving it a wider surface than this PR. A separate issue
should be filed.

---

## AI Disclosure

Per the repository's AI policy: multiple AI assistants were used during this
contribution.

**Tests:** All 17 tests in `py-polars/tests/unit/operations/test_random.py`
were written by **Claude Sonnet 4.6 Extended**. I reviewed every test, confirmed each
one exercises the intended behaviour, and believe they are correct and
appropriate.

**Solution design and PR write-up:** I used **Gemini 3.1 Pro** as a sounding board to
talk through my understanding of the two root causes and my proposed approach
before and during implementation. I also used it to help draft and refine this
PR description. I get Gemini on the web for free since I used my younger brother's
uni email to get a year of free Gemini.

The diagnosis (identifying the two factors, the line-level citations, empirical
verification under `POLARS_MAX_THREADS=1`) and all Rust code changes were done
by me. I have reviewed every line of every changed file and believe all changes
are relevant and correct.