### PR TITLE
fix: Ensure `append()` errors when `upcast=False`

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/functions.rs
@@ -776,7 +776,6 @@ pub(super) fn convert_functions(
                     e[1].dtype(ctx.schema, ctx.arena)?.clone(),
                 ];
                 let supertype = try_get_supertype(&dtypes[0], &dtypes[1])?;
-
                 for i in 0..2 {
                     if dtypes[i] != supertype {
                         let node = ctx.arena.add(AExpr::Cast {
@@ -786,6 +785,12 @@ pub(super) fn convert_functions(
                         });
                         e[i] = ExprIR::new(node, e[i].output_name_inner().clone());
                     }
+                }
+            } else {
+                let lhs = e[0].dtype(ctx.schema, ctx.arena)?;
+                let rhs = e[1].dtype(ctx.schema, ctx.arena)?;
+                if lhs != rhs {
+                    polars_bail!(SchemaMismatch: "type {} is incompatible with expected type {}", rhs, lhs);
                 }
             }
             I::ConcatExpr { rechunk: false }

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -877,3 +877,8 @@ def test_reinterpret_errors_13659() -> None:
         match="cannot reinterpret from Int8 to Int16",
     ):
         q.collect_schema()
+
+
+def test_append_no_upcast_27345() -> None:
+    with pytest.raises(pl.exceptions.SchemaError):
+        pl.select(pl.lit("Bob").append(1, upcast=False))


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/27345.

In https://github.com/pola-rs/polars/pull/27022, when `F::Append` was changed to delegate to `I::ConcatExpr`, it was always casting due to only having an `if` branch that dealt with `upcast=True`. If `upcast=False`, it would just fall through to `I::ConcatExpr`, which is using `map_to_supertype()` in `IRFunctionExpr` and does not respect the `upcast` parameter (it only takes a `rechunk` parameter), like `I::Append` use to. 

The fix was to add an `else` branch with `polars_bail` in the new `F::Append` arm that raises a `SchemaMismatch` if the data types do not match.

🤖 Claude Sonnet 4.6 for navigating and explaining existing code. 