### PR TITLE
fix(python): Fix typing for `DataFrame.__init__` and `Series.__init__` so they don't require all optional dependencies to be installed

### DIFF
--- a/py-polars/src/polars/_typing.py
+++ b/py-polars/src/polars/_typing.py
@@ -24,9 +24,6 @@ if TYPE_CHECKING:
 
     from polars import DataFrame, Expr, LazyFrame, Series
     from polars._dependencies import numpy as np
-    from polars._dependencies import pandas as pd
-    from polars._dependencies import pyarrow as pa
-    from polars._dependencies import torch
     from polars.datatypes import DataType, DataTypeClass, IntegerType, TemporalType
     from polars.lazyframe.engine_config import GPUEngine
     from polars.selectors import Selector
@@ -50,6 +47,98 @@ class ArrowSchemaExportable(Protocol):
     """Type protocol for Arrow C Schema Interface via Arrow PyCapsule Interface."""
 
     def __arrow_c_schema__(self) -> object: ...
+
+
+class NumpyArray(Protocol):
+    """Protocol to match NumPy Arrays without needing NumPy installed."""
+
+    def byteswap(self, *args: Any, **kwargs: Any) -> Any: ...
+    def conjugate(self, *args: Any, **kwargs: Any) -> Any: ...
+    def ravel(self, *args: Any, **kwargs: Any) -> Any: ...
+    def searchsorted(self, *args: Any, **kwargs: Any) -> Any: ...
+    def swapaxes(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
+class PyArrowArray(Protocol):
+    """
+    Protocol to match PyArrow arrays without needing PyArrow installed.
+
+    Only use for function arguments, not return types.
+    """
+
+    def buffers(self, *args: Any, **kwargs: Any) -> Any: ...
+    def tolist(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
+class PyArrowChunkedArray(Protocol):
+    """
+    Protocol to match PyArrow chunked arrays without needing PyArrow installed.
+
+    Only use for function arguments, not return types.
+    """
+
+    def iterchunks(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
+class PyArrowTable(Protocol):
+    """
+    Protocol to match PyArrow tables without needing PyArrow installed.
+
+    Only use for function arguments, not return types.
+    """
+
+    def filter(self, *args: Any, **kwargs: Any) -> Any: ...
+    def group_by(self, *args: Any, **kwargs: Any) -> Any: ...
+    def add_column(self, *args: Any, **kwargs: Any) -> Any: ...
+    def remove_column(self, *args: Any, **kwargs: Any) -> Any: ...
+    def take(self, *args: Any, **kwargs: Any) -> Any: ...
+    def to_pandas(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
+class PandasDataFrame(Protocol):
+    """
+    Protocol to match pandas dataframes without needing pandas-stubs installed.
+
+    Only use for function arguments, not return types.
+    """
+
+    def where(self, *args: Any, **kwargs: Any) -> Any: ...
+    def groupby(self, *args: Any, **kwargs: Any) -> Any: ...
+    def unstack(self, *args: Any, **kwargs: Any) -> Any: ...
+    def pivot_table(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
+class PandasSeries(Protocol):
+    """
+    Protocol to match pandas series without needing pandas-stubs installed.
+
+    Only use for function arguments, not return types.
+    """
+
+    def to_frame(self, *args: Any, **kwargs: Any) -> Any: ...
+    def isna(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
+class PandasIndex(Protocol):
+    """
+    Protocol to match pandas indexes without needing pandas-stubs installed.
+
+    Only use for function arguments, not return types.
+    """
+
+    def to_series(self, *args: Any, **kwargs: Any) -> Any: ...
+    def isna(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
+class TorchTensor(Protocol):
+    """
+    Protocol to match PyTorch tensors without needing PyTorch installed.
+
+    Only use for function arguments, not return types.
+    """
+
+    def cuda(self, *args: Any, **kwargs: Any) -> Any: ...
+    def backward(self, *args: Any, **kwargs: Any) -> Any: ...
 
 
 # Data types
@@ -214,18 +303,30 @@ TransferEncoding: TypeAlias = Literal["hex", "base64"]
 WindowMappingStrategy: TypeAlias = Literal["group_to_rows", "join", "explode"]
 ExplainFormat: TypeAlias = Literal["plain", "tree"]
 
-# type signature for allowed frame init
-FrameInitTypes: TypeAlias = Union[
-    Mapping[
-        str, Union[Sequence[object], Mapping[str, Sequence[object]], "Series", None]
-    ],
-    Sequence[Any],
-    "np.ndarray[Any, Any]",
-    "pa.Table",
-    "pd.DataFrame",
+# type signature for allowed series init
+ArrayLike: TypeAlias = Union[
+    Iterable[Any],
+    "Series",
+    "PyArrowArray",
+    "PyArrowChunkedArray",
+    "NumpyArray",
+    "PandasSeries",
+    "PandasIndex",
     "ArrowArrayExportable",
     "ArrowStreamExportable",
-    "torch.Tensor",
+]
+
+
+# type signature for allowed frame init
+FrameInitTypes: TypeAlias = Union[
+    Mapping[str, ArrayLike | NonNestedLiteral | None],
+    Iterable[Any],
+    NumpyArray,
+    PyArrowTable,
+    PandasDataFrame,
+    "ArrowArrayExportable",
+    "ArrowStreamExportable",
+    TorchTensor,
     "DataFrame",
 ]
 

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -14,7 +14,6 @@ from typing import (
     ClassVar,
     Literal,
     NoReturn,
-    Union,
     overload,
 )
 
@@ -130,8 +129,7 @@ if TYPE_CHECKING:
 
     from polars import DataFrame, DataType, Expr
     from polars._typing import (
-        ArrowArrayExportable,
-        ArrowStreamExportable,
+        ArrayLike,
         BufferInfo,
         ClosedInterval,
         ComparisonOperator,
@@ -171,18 +169,6 @@ elif BUILDING_SPHINX_DOCS:
     # (ref: https://github.com/davidhalter/jedi/issues/2057)
     current_module = sys.modules[__name__]
     current_module.property = sphinx_accessor
-
-ArrayLike = Union[
-    Sequence[Any],
-    "Series",
-    "pa.Array",
-    "pa.ChunkedArray",
-    "np.ndarray[Any, Any]",
-    "pd.Series[Any]",
-    "pd.DatetimeIndex",
-    "ArrowArrayExportable",
-    "ArrowStreamExportable",
-]
 
 
 @expr_dispatch

--- a/py-polars/tests/unit/constructors/test_argument_types.py
+++ b/py-polars/tests/unit/constructors/test_argument_types.py
@@ -1,0 +1,37 @@
+"""
+Test the protocols used for Series and DataFrame argument types.
+
+We can only test what's included in `requirements-dev.txt`, which currently does
+not include pyarrow stubs.
+"""
+
+import numpy as np
+import pandas as pd
+
+from polars._typing import NumpyArray, PandasDataFrame, PandasIndex, PandasSeries
+
+
+def test_protocols() -> None:
+    def _func(
+        df: PandasDataFrame,
+        idx: PandasIndex,
+        ser: PandasSeries,
+        arr: NumpyArray,
+    ) -> None:
+        return None
+
+    ser = pd.Series([1])
+    idx = pd.Index([1])
+    df = pd.DataFrame({"a": [1]})
+    arr = np.array([1, 2, 3])
+
+    # Check for no errors
+    _func(df, idx, ser, arr)
+
+    # Check for type errors
+    _func(
+        arr,  # type: ignore[arg-type]
+        ser,  # type: ignore[arg-type]
+        idx,  # type: ignore[arg-type]
+        df,  # type: ignore[arg-type]
+    )

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -1020,7 +1020,11 @@ def test_init_errors() -> None:
 
     # Unmatched input
     with pytest.raises(TypeError):
-        pl.DataFrame(0)
+        # Note: the `type: ignore` is correct here, as `0` is
+        # an invalid type. If you make a PR which removes this
+        # `type: ignore`, you may have inadvertently introduced
+        # an `Any` type in the `DataFrame.__init__` signature.
+        pl.DataFrame(0)  # type: ignore[arg-type]
 
 
 def test_init_records() -> None:

--- a/py-polars/tests/unit/constructors/test_series.py
+++ b/py-polars/tests/unit/constructors/test_series.py
@@ -198,3 +198,12 @@ def test_temporal_dtype_string_values(
         s = pl.Series(name="srs", values=data, dtype=tp)
         assert s.to_list() == expected_values
         assert s.dtype == dtype
+
+
+def test_invalid() -> None:
+    with pytest.raises(TypeError, match="constructor"):
+        # Note: the `type: ignore` is correct here, as `0` is
+        # an invalid type. If you make a PR which removes this
+        # `type: ignore`, you may have inadvertently introduced
+        # an `Any` type in the `Series.__init__` signature.
+        pl.Series(1)  # type: ignore[arg-type]

--- a/py-polars/tests/unit/datatypes/test_array.py
+++ b/py-polars/tests/unit/datatypes/test_array.py
@@ -1,6 +1,6 @@
 import datetime
 from datetime import timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pytest
@@ -8,6 +8,9 @@ import pytest
 import polars as pl
 from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def test_cast_list_array() -> None:
@@ -409,7 +412,7 @@ def test_zero_width_array(fn: str) -> None:
     series_f = getattr(pl.Series, fn)
     expr_f = getattr(pl.Expr, fn)
 
-    values = [
+    values: Sequence[Sequence[list[list[Any] | None]]] = [
         [
             [[]],
             [None],

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -861,7 +861,7 @@ def test_timelike_init() -> None:
     dates = [date(2022, 1, 1), date(2022, 1, 2)]
     datetimes = [datetime(2022, 1, 1), datetime(2022, 1, 2)]
 
-    for ts in [durations, dates, datetimes]:
+    for ts in (durations, dates, datetimes):
         s = pl.Series(ts)
         assert s.to_list() == ts
 

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -23,7 +23,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
 from polars.testing.parametric import column, dataframes, series
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
     from polars._typing import PolarsDataType, TimeUnit
     from tests.conftest import PlMonkeyPatch
@@ -2048,7 +2048,7 @@ def test_group_by_unique_parametric(
     ],
 )
 def test_group_by_any_all(expr: Callable[[pl.Expr], pl.Expr]) -> None:
-    combinations = [
+    combinations: Sequence[list[bool | None]] = [
         [True, None],
         [None, None],
         [False, None],
@@ -2222,7 +2222,7 @@ def test_group_by_explode_none_dtype_25045() -> None:
 def test_group_by_forward_backward_fill(
     expr: Callable[[pl.Expr], pl.Expr], is_scalar: bool
 ) -> None:
-    combinations = [
+    combinations: Sequence[list[int | None]] = [
         [1, None, 2, None, None],
         [None, 1, 2, 3, 4],
         [None, None, None, None, None],

--- a/py-polars/tests/unit/operations/test_inequality_join.py
+++ b/py-polars/tests/unit/operations/test_inequality_join.py
@@ -772,7 +772,7 @@ def test_range_join_single_parametric(
     ],
 )
 def test_range_join_dtypes(
-    s: pl.DataType,
+    s: pl.Series,
     lower_op: str | None,
     upper_op: str | None,
 ) -> None:

--- a/py-polars/tests/unit/operations/test_row_encoding.py
+++ b/py-polars/tests/unit/operations/test_row_encoding.py
@@ -16,7 +16,7 @@ from tests.unit.conftest import FLOAT_DTYPES, INTEGER_DTYPES
 if TYPE_CHECKING:
     from typing import Any
 
-    from polars._typing import PolarsDataType
+    from polars._typing import ArrayLike, PolarsDataType
 
 FIELD_COMBS = [
     (descending, nulls_last, False)
@@ -60,7 +60,7 @@ def roundtrip_re(
 
 
 def roundtrip_series_re(
-    values: pl.series.series.ArrayLike,
+    values: ArrayLike,
     dtype: PolarsDataType,
     *,
     unordered: bool = False,

--- a/py-polars/tests/unit/operations/test_row_encoding_sort.py
+++ b/py-polars/tests/unit/operations/test_row_encoding_sort.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime
 import decimal
 import functools
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import pytest
 from hypothesis import example, given
@@ -13,6 +13,9 @@ from hypothesis import example, given
 import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
 from polars.testing.parametric import column, dataframes, series
+
+if TYPE_CHECKING:
+    from polars._typing import ArrayLike, PolarsDataType
 
 Element = (
     None
@@ -223,9 +226,9 @@ def test_df_sort_parametric(df: pl.DataFrame) -> None:
 
 
 def assert_order_series(
-    lhs: pl.series.series.ArrayLike,
-    rhs: pl.series.series.ArrayLike,
-    dtype: pl._typing.PolarsDataType,
+    lhs: ArrayLike,
+    rhs: ArrayLike,
+    dtype: PolarsDataType,
 ) -> None:
     lhs_s = pl.Series("lhs", lhs, dtype)
     rhs_s = pl.Series("rhs", rhs, dtype)

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1680,7 +1680,7 @@ def test_cast_datetime_to_time(unit: TimeUnit) -> None:
 
 
 def test_init_categorical() -> None:
-    for values in [[None], ["foo", "bar"], [None, "foo", "bar"]]:
+    for values in ([None], ["foo", "bar"], [None, "foo", "bar"]):
         expected = pl.Series("a", values, dtype=pl.String).cast(pl.Categorical)
         a = pl.Series("a", values, dtype=pl.Categorical)
         assert_series_equal(a, expected)

--- a/py-polars/tests/unit/utils/pycapsule_utils.py
+++ b/py-polars/tests/unit/utils/pycapsule_utils.py
@@ -39,5 +39,7 @@ class PyCapsuleArrayHolder:
     def __init__(self, arrow_obj: object) -> None:
         self.arrow_obj = arrow_obj
 
-    def __arrow_c_array__(self, requested_schema: object = None) -> object:
-        return self.arrow_obj.__arrow_c_array__(requested_schema)
+    def __arrow_c_array__(
+        self, requested_schema: object | None = None
+    ) -> tuple[object, object]:
+        return self.arrow_obj.__arrow_c_array__(requested_schema)  # type: ignore[no-any-return]


### PR DESCRIPTION
closes https://github.com/pola-rs/polars/issues/27049

towards #27049 

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
