### PR TITLE
fix(python): Raise `TypeError` instead of `AttributeError` when calling `next()` on uninitialized `GroupBy`

### DIFF
--- a/py-polars/src/polars/dataframe/group_by.py
+++ b/py-polars/src/polars/dataframe/group_by.py
@@ -134,6 +134,9 @@ class GroupBy:
         return self
 
     def __next__(self) -> tuple[tuple[Any, ...], DataFrame]:
+        if not hasattr(self, "_current_index"):
+            msg = f"'{type(self).__name__}' object is not an iterator"
+            raise TypeError(msg)
         if self._current_index >= len(self._group_indices):
             raise StopIteration
 
@@ -909,6 +912,9 @@ class RollingGroupBy:
         return self
 
     def __next__(self) -> tuple[tuple[object, ...], DataFrame]:
+        if not hasattr(self, "_current_index"):
+            msg = f"'{type(self).__name__}' object is not an iterator"
+            raise TypeError(msg)
         if self._current_index >= len(self._group_indices):
             raise StopIteration
 
@@ -1095,6 +1101,9 @@ class DynamicGroupBy:
         return self
 
     def __next__(self) -> tuple[tuple[object, ...], DataFrame]:
+        if not hasattr(self, "_current_index"):
+            msg = f"'{type(self).__name__}' object is not an iterator"
+            raise TypeError(msg)
         if self._current_index >= len(self._group_indices):
             raise StopIteration
 


### PR DESCRIPTION
## Summary

Calling `next()` on a `GroupBy`, `RollingGroupBy`, or `DynamicGroupBy` object without first iterating over it raises an unhelpful `AttributeError: 'GroupBy' object has no attribute '_current_index'`. This PR changes the error to a clear `TypeError`, consistent with standard Python behavior for non-iterators.

```python
import polars as pl
next(pl.DataFrame().group_by(1))
# Before: AttributeError: 'GroupBy' object has no attribute '_current_index'
# After:  TypeError: 'GroupBy' object is not an iterator
```

## Changes

Added a `hasattr` check at the start of `__next__` in `GroupBy`, `RollingGroupBy`, and `DynamicGroupBy` to raise a descriptive `TypeError` when iteration state hasn't been initialized.

Closes #12868