### PR TITLE
fix: Ensure `list.sample()` allows `fraction` > 1 when `with_replacement=True`

### DIFF
--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -645,11 +645,13 @@ pub trait ListNameSpaceImpl: AsList {
         let fraction_s = fraction.cast(&DataType::Float64)?;
         let fraction = fraction_s.f64()?;
 
-        for frac in fraction.iter().flatten() {
-            polars_ensure!(
-                (0.0..=1.0).contains(&frac),
-                ComputeError: "fraction must be between 0.0 and 1.0, got: {}", frac
-            )
+        if !with_replacement {
+            for frac in fraction.iter().flatten() {
+                polars_ensure!(
+                    (0.0..=1.0).contains(&frac),
+                    ComputeError: "fraction must be between 0.0 and 1.0, got: {}", frac
+                )
+            }
         }
 
         polars_ensure!(

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -1362,3 +1362,10 @@ def test_list_sample_fraction_boundary_values_22024() -> None:
     s.list.sample(fraction=0.0)
     s.list.sample(fraction=1.0)
     s.list.sample(fraction=pl.Series([0.0, 1.0]))
+
+
+def test_list_sample_fraction_with_replacement_27344() -> None:
+    df = pl.DataFrame({"x": [[1]]})
+
+    result = df.select(pl.col("x").list.sample(fraction=2, with_replacement=True))
+    assert result["x"][0].to_list() == [1, 1]


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/27344.

Since fractions > `1` make sense when `with_replacement=True`, the fix just adds a condition to the fraction validation so it only occurs when sampling without replacement.

🥦 Only organic intelligence was used for this PR. 
