### PR TITLE
fix(python): Address bug in `reduce_balanced` for certain input length lists affecting `pl.concat`

### DIFF
--- a/py-polars/src/polars/_utils/reduce_balanced.py
+++ b/py-polars/src/polars/_utils/reduce_balanced.py
@@ -12,26 +12,23 @@ def reduce_balanced(function: Callable[[T, T], T], iterable: Iterable[T]) -> T:
         msg = "reduce_balanced() of empty iterable"
         raise TypeError(msg)
 
-    while len(values) > 2:
-        half_floor = len(values) // 2
+    while len(values) > 1:
+        split_at = len(values) if len(values) <= 3 else len(values) // 2
 
-        for i in range(0, half_floor, 2):
-            values[i // 2] = (
-                values[i] if i + 1 == half_floor else function(values[i], values[i + 1])
-            )
+        for i in range(0, split_at, 2):
+            if i + 1 == split_at:
+                prev = i // 2 - 1
+                values[prev] = function(values[prev], values[i])
+            else:
+                values[i // 2] = function(values[i], values[i + 1])
 
-        rtree_offset = half_floor % 2
+        for i in range(split_at, len(values), 2):
+            if i + 1 == len(values):
+                prev = i // 2 - 1
+                values[prev] = function(values[prev], values[i])
+            else:
+                values[i // 2] = function(values[i], values[i + 1])
 
-        for i in range(half_floor, len(values), 2):
-            values[i // 2 + rtree_offset] = (
-                values[i]
-                if i + 1 == len(values)
-                else function(values[i], values[i + 1])
-            )
+        del values[split_at // 2 + (len(values) - split_at) // 2 :]
 
-        n_ltree = -(half_floor // -2)
-        n_rtree = -((len(values) - half_floor) // -2)
-
-        del values[n_ltree + n_rtree :]
-
-    return values.pop() if len(values) == 1 else function(values[0], values[1])
+    return values.pop()

--- a/py-polars/src/polars/_utils/reduce_balanced.py
+++ b/py-polars/src/polars/_utils/reduce_balanced.py
@@ -12,17 +12,26 @@ def reduce_balanced(function: Callable[[T, T], T], iterable: Iterable[T]) -> T:
         msg = "reduce_balanced() of empty iterable"
         raise TypeError(msg)
 
-    while len(values) > 1:
-        rem = len(values) % 2
+    while len(values) > 2:
+        half_floor = len(values) // 2
 
-        for i in range(0, len(values) - rem, 2):
-            values[i // 2] = function(values[i], values[i + 1])
+        for i in range(0, half_floor, 2):
+            values[i // 2] = (
+                values[i] if i + 1 == half_floor else function(values[i], values[i + 1])
+            )
 
-        new_len = (len(values) // 2) + rem
+        rtree_offset = half_floor % 2
 
-        if rem:
-            values[new_len - 1] = values[-1]
+        for i in range(half_floor, len(values), 2):
+            values[i // 2 + rtree_offset] = (
+                values[i]
+                if i + 1 == len(values)
+                else function(values[i], values[i + 1])
+            )
 
-        del values[new_len:]
+        n_ltree = -(half_floor // -2)
+        n_rtree = -((len(values) - half_floor) // -2)
 
-    return values.pop()
+        del values[n_ltree + n_rtree :]
+
+    return values.pop() if len(values) == 1 else function(values[0], values[1])

--- a/py-polars/src/polars/_utils/reduce_balanced.py
+++ b/py-polars/src/polars/_utils/reduce_balanced.py
@@ -12,13 +12,16 @@ def reduce_balanced(function: Callable[[T, T], T], iterable: Iterable[T]) -> T:
         msg = "reduce_balanced() of empty iterable"
         raise TypeError(msg)
 
-    last = [values.pop()] if len(values) > 1 and len(values) % 2 != 0 else []
-
     while len(values) > 1:
+        last = [values.pop()] if len(values) % 2 != 0 else []
+
         for i in range(0, len(values), 2):
             v = function(values[i], values[i + 1])
             values[i // 2] = v
 
         del values[len(values) // 2 :]
 
-    return function(values[0], last[0]) if last else values[0]
+        if last:
+            values.append(last[0])
+
+    return values[0]

--- a/py-polars/src/polars/_utils/reduce_balanced.py
+++ b/py-polars/src/polars/_utils/reduce_balanced.py
@@ -36,4 +36,4 @@ def reduce_balanced(function: Callable[[T, T], T], iterable: Iterable[T]) -> T:
     for idx_l, idx_r in reversed(stack):
         values[idx_l] = function(values[idx_l], values[idx_r])
 
-    return values[stack[0][0]]
+    return values[0]

--- a/py-polars/src/polars/_utils/reduce_balanced.py
+++ b/py-polars/src/polars/_utils/reduce_balanced.py
@@ -13,15 +13,16 @@ def reduce_balanced(function: Callable[[T, T], T], iterable: Iterable[T]) -> T:
         raise TypeError(msg)
 
     while len(values) > 1:
-        last = [values.pop()] if len(values) % 2 != 0 else []
+        rem = len(values) % 2
 
-        for i in range(0, len(values), 2):
-            v = function(values[i], values[i + 1])
-            values[i // 2] = v
+        for i in range(0, len(values) - rem, 2):
+            values[i // 2] = function(values[i], values[i + 1])
 
-        del values[len(values) // 2 :]
+        new_len = (len(values) // 2) + rem
 
-        if last:
-            values.append(last[0])
+        if rem:
+            values[new_len - 1] = values[-1]
 
-    return values[0]
+        del values[new_len:]
+
+    return values.pop()

--- a/py-polars/src/polars/_utils/reduce_balanced.py
+++ b/py-polars/src/polars/_utils/reduce_balanced.py
@@ -12,23 +12,28 @@ def reduce_balanced(function: Callable[[T, T], T], iterable: Iterable[T]) -> T:
         msg = "reduce_balanced() of empty iterable"
         raise TypeError(msg)
 
-    while len(values) > 1:
-        split_at = len(values) if len(values) <= 3 else len(values) // 2
+    if len(values) == 1:
+        return values.pop()
 
-        for i in range(0, split_at, 2):
-            if i + 1 == split_at:
-                prev = i // 2 - 1
-                values[prev] = function(values[prev], values[i])
-            else:
-                values[i // 2] = function(values[i], values[i + 1])
+    stack = [(0, len(values))]
 
-        for i in range(split_at, len(values), 2):
-            if i + 1 == len(values):
-                prev = i // 2 - 1
-                values[prev] = function(values[prev], values[i])
-            else:
-                values[i // 2] = function(values[i], values[i + 1])
+    i = 0
 
-        del values[split_at // 2 + (len(values) - split_at) // 2 :]
+    while i < len(stack):
+        offset, length = stack[i]
+        half = -(length // -2)
 
-    return values.pop()
+        if length > 3:
+            stack.append((offset + half, length - half))
+
+        if length > 2:
+            stack.append((offset, half))
+
+        stack[i] = (offset, offset + half)
+
+        i += 1
+
+    for idx_l, idx_r in reversed(stack):
+        values[idx_l] = function(values[idx_l], values[idx_r])
+
+    return values[stack[0][0]]

--- a/py-polars/tests/unit/functions/test_concat.py
+++ b/py-polars/tests/unit/functions/test_concat.py
@@ -436,7 +436,7 @@ def test_concat_with_empty_dataframes_nonstrict_25727() -> None:
 )
 @pytest.mark.parametrize(
     "n_dfs",
-    [3, 4, 5],  # balanced tree +/- 1
+    [3, 4, 5, 6],  # balanced tree +/- 1
 )
 def test_concat_align_associativity_26788(how: ConcatMethod, n_dfs: int) -> None:
     # create every possible key combination over `n_dfs` dataframes

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -318,8 +318,8 @@ def test_is_str_sequence_check(
             [0, 1, 2, 3, 4, 5],
             [
                 ([0], [1]),
-                ([3], [4]),
                 ([0, 1], [2]),
+                ([3], [4]),
                 ([3, 4], [5]),
                 ([0, 1, 2], [3, 4, 5]),
             ],
@@ -331,12 +331,12 @@ def test_is_str_sequence_check(
             [
                 ([0], [1]),
                 ([2], [3]),
+                ([2, 3], [4]),
                 ([5], [6]),
                 ([7], [8]),
-                ([0, 1], [2, 3]),
-                ([5, 6], [7, 8]),
-                ([0, 1, 2, 3], [4]),
-                ([5, 6, 7, 8], [9]),
+                ([7, 8], [9]),
+                ([0, 1], [2, 3, 4]),
+                ([5, 6], [7, 8, 9]),
                 ([0, 1, 2, 3, 4], [5, 6, 7, 8, 9]),
             ],
             id="length_9",
@@ -355,6 +355,7 @@ def test_reduce_balanced(
         return left + right
 
     assert reduce_balanced(reducer, values) == expected_acc
+    print(seen)
     assert seen == expected_seen
 
     with pytest.raises(TypeError):

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -339,7 +339,7 @@ def test_is_str_sequence_check(
                 ([5, 6, 7], [8, 9]),
                 ([0, 1, 2, 3, 4], [5, 6, 7, 8, 9]),
             ],
-            id="length_9",
+            id="length_10",
         ),
     ],
 )

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -299,24 +299,47 @@ def test_is_str_sequence_check(
         assert is_sequence(sequence, include_series=include_series)
 
 
-def test_reduce_balanced() -> None:
-    values = [[0], [1], [2], [3], [4]]
-
+@pytest.mark.parametrize(
+    ("values", "expected_acc", "expected_seen"),
+    [
+        pytest.param(
+            [[0], [1], [2], [3], [4]],
+            [0, 1, 2, 3, 4],
+            [
+                ([0], [1]),
+                ([2], [3]),
+                ([0, 1], [2, 3]),
+                ([0, 1, 2, 3], [4]),
+            ],
+            id="length_5",
+        ),
+        pytest.param(
+            [[0], [1], [2], [3], [4], [5]],
+            [0, 1, 2, 3, 4, 5],
+            [
+                ([0], [1]),
+                ([2], [3]),
+                ([4], [5]),
+                ([0, 1], [2, 3]),
+                ([0, 1, 2, 3], [4, 5]),
+            ],
+            id="length_6",
+        ),
+    ],
+)
+def test_reduce_balanced(
+    values: list[list[int]],
+    expected_acc: list[int],
+    expected_seen: list[tuple[list[int], list[int]]],
+) -> None:
     seen = []
 
     def reducer(left: list[int], right: list[int]) -> list[int]:
         seen.append((left, right))
         return left + right
 
-    acc = reduce_balanced(reducer, values)
-
-    assert acc == [0, 1, 2, 3, 4]
-    assert seen == [
-        ([0], [1]),
-        ([2], [3]),
-        ([0, 1], [2, 3]),
-        ([0, 1, 2, 3], [4]),
-    ]
+    assert reduce_balanced(reducer, values) == expected_acc
+    assert seen == expected_seen
 
     with pytest.raises(TypeError):
         reduce_balanced(reducer, [])

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -308,8 +308,8 @@ def test_is_str_sequence_check(
             [
                 ([0], [1]),
                 ([2], [3]),
-                ([0, 1], [2, 3]),
-                ([0, 1, 2, 3], [4]),
+                ([2, 3], [4]),
+                ([0, 1], [2, 3, 4]),
             ],
             id="length_5",
         ),
@@ -318,12 +318,28 @@ def test_is_str_sequence_check(
             [0, 1, 2, 3, 4, 5],
             [
                 ([0], [1]),
-                ([2], [3]),
-                ([4], [5]),
-                ([0, 1], [2, 3]),
-                ([0, 1, 2, 3], [4, 5]),
+                ([3], [4]),
+                ([0, 1], [2]),
+                ([3, 4], [5]),
+                ([0, 1, 2], [3, 4, 5]),
             ],
             id="length_6",
+        ),
+        pytest.param(
+            [[0], [1], [2], [3], [4], [5], [6], [7], [8], [9]],
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            [
+                ([0], [1]),
+                ([2], [3]),
+                ([5], [6]),
+                ([7], [8]),
+                ([0, 1], [2, 3]),
+                ([5, 6], [7, 8]),
+                ([0, 1, 2, 3], [4]),
+                ([5, 6, 7, 8], [9]),
+                ([0, 1, 2, 3, 4], [5, 6, 7, 8, 9]),
+            ],
+            id="length_9",
         ),
     ],
 )
@@ -339,7 +355,13 @@ def test_reduce_balanced(
         return left + right
 
     assert reduce_balanced(reducer, values) == expected_acc
+    print()
     assert seen == expected_seen
 
     with pytest.raises(TypeError):
         reduce_balanced(reducer, [])
+
+
+@pytest.mark.parametrize("n", range(1, 99))
+def test_reduce_balanced_parametric(n: int) -> None:
+    assert reduce_balanced(list.__add__, [[i] for i in range(n)]) == [*range(n)]

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -355,7 +355,6 @@ def test_reduce_balanced(
         return left + right
 
     assert reduce_balanced(reducer, values) == expected_acc
-    print(seen)
     assert seen == expected_seen
 
     with pytest.raises(TypeError):

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -307,9 +307,9 @@ def test_is_str_sequence_check(
             [0, 1, 2, 3, 4],
             [
                 ([0], [1]),
-                ([2], [3]),
-                ([2, 3], [4]),
-                ([0, 1], [2, 3, 4]),
+                ([0, 1], [2]),
+                ([3], [4]),
+                ([0, 1, 2], [3, 4]),
             ],
             id="length_5",
         ),
@@ -318,8 +318,8 @@ def test_is_str_sequence_check(
             [0, 1, 2, 3, 4, 5],
             [
                 ([0], [1]),
-                ([0, 1], [2]),
                 ([3], [4]),
+                ([0, 1], [2]),
                 ([3, 4], [5]),
                 ([0, 1, 2], [3, 4, 5]),
             ],
@@ -330,13 +330,13 @@ def test_is_str_sequence_check(
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
             [
                 ([0], [1]),
-                ([2], [3]),
-                ([2, 3], [4]),
                 ([5], [6]),
-                ([7], [8]),
-                ([7, 8], [9]),
-                ([0, 1], [2, 3, 4]),
-                ([5, 6], [7, 8, 9]),
+                ([0, 1], [2]),
+                ([3], [4]),
+                ([5, 6], [7]),
+                ([8], [9]),
+                ([0, 1, 2], [3, 4]),
+                ([5, 6, 7], [8, 9]),
                 ([0, 1, 2, 3, 4], [5, 6, 7, 8, 9]),
             ],
             id="length_9",
@@ -363,4 +363,16 @@ def test_reduce_balanced(
 
 @pytest.mark.parametrize("n", range(1, 99))
 def test_reduce_balanced_parametric(n: int) -> None:
-    assert reduce_balanced(list.__add__, [[i] for i in range(n)]) == [*range(n)]
+    values = [[i] for i in range(n)]
+    expected_acc = [*range(n)]
+
+    seen = []
+
+    def reducer(left: list[int], right: list[int]) -> list[int]:
+        seen.append((left, right))
+        return left + right
+
+    assert reduce_balanced(reducer, values) == expected_acc
+
+    for seq_lsubtree, seq_rsubtree in seen:
+        assert abs(len(seq_lsubtree) - len(seq_rsubtree)) <= 1

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -355,7 +355,6 @@ def test_reduce_balanced(
         return left + right
 
     assert reduce_balanced(reducer, values) == expected_acc
-    print()
     assert seen == expected_seen
 
     with pytest.raises(TypeError):


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/27351

Instead of only addressing the case where the input list is odd before the loop, continue addressing it within the loop. This ensures that when the list is of length `2x` where `x` is odd the logic works and does not break.

Went ahead and added a test case for this, that would have caught the original issue and now passes on both. Refactored the test function to allow multiple inputs (via `pytest.mark.parametrize`) vs the hardcoded single case it had before.

As far as I see, the one rust CI failure is unrelated to my PR.

I would also encourage the maintainers that this PR (or any other one that fixes the underlying bug) is merged and released quickly to patch 1.40.0. I would imagine that `pl.concat` is a fairly widely used operation and will induce many failures as people upgrade.