### PR TITLE
fix: Always rechunk sorts, prune sorts even in eager execution

### DIFF
--- a/crates/polars-mem-engine/src/executors/sort.rs
+++ b/crates/polars-mem-engine/src/executors/sort.rs
@@ -10,8 +10,13 @@ pub(crate) struct SortExec {
 }
 
 impl SortExec {
-    fn execute_impl(&mut self, state: &ExecutionState, df: DataFrame) -> PolarsResult<DataFrame> {
+    fn execute_impl(
+        &mut self,
+        state: &ExecutionState,
+        mut df: DataFrame,
+    ) -> PolarsResult<DataFrame> {
         state.should_stop()?;
+        df.rechunk_mut_par();
 
         let height = df.height();
 

--- a/crates/polars-plan/src/plans/optimizer/sortedness.rs
+++ b/crates/polars-plan/src/plans/optimizer/sortedness.rs
@@ -248,12 +248,12 @@ fn is_sorted_rec(
                     IsSorted::Ascending => Some(Sorted {
                         column: c.name().clone(),
                         descending: Some(false),
-                        nulls_last: Some(c.get(0).is_ok_and(|v| !v.is_null())),
+                        nulls_last: Some(c.get(c.len() - 1).is_ok_and(|v| v.is_null())),
                     }),
                     IsSorted::Descending => Some(Sorted {
                         column: c.name().clone(),
                         descending: Some(true),
-                        nulls_last: Some(c.get(0).is_ok_and(|v| !v.is_null())),
+                        nulls_last: Some(c.get(c.len() - 1).is_ok_and(|v| v.is_null())),
                     }),
                 })
                 .collect_vec();

--- a/crates/polars-plan/src/plans/optimizer/sortedness.rs
+++ b/crates/polars-plan/src/plans/optimizer/sortedness.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use polars_core::chunked_array::cast::CastOptions;
-use polars_core::prelude::{FillNullStrategy, PlHashMap, PlHashSet};
+use polars_core::prelude::*;
 use polars_core::schema::Schema;
 use polars_core::series::IsSorted;
 use polars_utils::arena::{Arena, Node};
@@ -240,6 +240,7 @@ fn is_sorted_rec(
         } => rec!(*input),
         IR::Scan { .. } => None,
         IR::DataFrameScan { df, .. } => {
+            let last_is_null = |c: &Column| Some(c.get(c.len().checked_sub(1)?).ok()?.is_null());
             let sorted_cols = df
                 .columns()
                 .iter()
@@ -248,12 +249,12 @@ fn is_sorted_rec(
                     IsSorted::Ascending => Some(Sorted {
                         column: c.name().clone(),
                         descending: Some(false),
-                        nulls_last: Some(c.get(c.len() - 1).is_ok_and(|v| v.is_null())),
+                        nulls_last: Some(last_is_null(c).unwrap_or(false)),
                     }),
                     IsSorted::Descending => Some(Sorted {
                         column: c.name().clone(),
                         descending: Some(true),
-                        nulls_last: Some(c.get(c.len() - 1).is_ok_and(|v| v.is_null())),
+                        nulls_last: Some(last_is_null(c).unwrap_or(false)),
                     }),
                 })
                 .collect_vec();

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -6116,6 +6116,8 @@ class DataFrame:
         """
         from polars.lazyframe import QueryOptFlags
 
+        optimizations = QueryOptFlags._eager()
+        optimizations.sort_collapse = True
         return (
             self.lazy()
             .sort(
@@ -6126,7 +6128,7 @@ class DataFrame:
                 multithreaded=multithreaded,
                 maintain_order=maintain_order,
             )
-            .collect(optimizations=QueryOptFlags._eager())
+            .collect(optimizations=optimizations)
         )
 
     def sql(self, query: str, *, table_name: str = "self") -> DataFrame:

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -1289,3 +1289,14 @@ def test_sort_by_empty_list_eval_25433() -> None:
     out = df.select(pl.col.a.list.eval(pl.element().sort_by(pl.element())))
     expected = pl.DataFrame({"a": [sorted(some_list), []]})
     assert_frame_equal(out, expected)
+
+
+@pytest.mark.may_fail_auto_streaming
+def test_sort_already_sorted_no_rechunk_25733() -> None:
+    df1 = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
+    df2 = pl.DataFrame({"a": [3, 4], "b": [5, 6]})
+    df = pl.concat([df1, df2], rechunk=False).with_columns(pl.col("a").set_sorted())
+    assert df.n_chunks() == 2
+
+    result = df.sort("a")
+    assert result.n_chunks() == 2  # No rechunk happened

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -1289,14 +1289,3 @@ def test_sort_by_empty_list_eval_25433() -> None:
     out = df.select(pl.col.a.list.eval(pl.element().sort_by(pl.element())))
     expected = pl.DataFrame({"a": [sorted(some_list), []]})
     assert_frame_equal(out, expected)
-
-
-@pytest.mark.may_fail_auto_streaming
-def test_sort_already_sorted_no_rechunk_25733() -> None:
-    df1 = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
-    df2 = pl.DataFrame({"a": [3, 4], "b": [5, 6]})
-    df = pl.concat([df1, df2], rechunk=False).with_columns(pl.col("a").set_sorted())
-    assert df.n_chunks() == 2
-
-    result = df.sort("a")
-    assert result.n_chunks() == 2  # No rechunk happened


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/27353

:robot: No AI was used in this PR.