### PR TITLE
perf: Skip validity mask processing in __array_ufunc__ when no inputs have nulls

### DIFF
--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -1719,9 +1719,9 @@ class Series:
 
             # We're using a regular ufunc, that operates value by value. That
             # means we allowed missing data in the input, so filter it out:
-            validity_mask = self.is_not_null()
+            validity_mask = F.lit(True) if self.null_count() == 0 else self.is_not_null()
             for arg in inputs:
-                if isinstance(arg, Series):
+                if isinstance(arg, Series) and self.null_count() >0:
                     validity_mask &= arg.is_not_null()
             return (
                 result.to_frame()

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -1719,9 +1719,11 @@ class Series:
 
             # We're using a regular ufunc, that operates value by value. That
             # means we allowed missing data in the input, so filter it out:
-            validity_mask = F.lit(True) if self.null_count() == 0 else self.is_not_null()
+            validity_mask = (
+                F.lit(True) if self.null_count() == 0 else self.is_not_null()
+            )
             for arg in inputs:
-                if isinstance(arg, Series) and self.null_count() >0:
+                if isinstance(arg, Series) and arg.null_count() > 0:
                     validity_mask &= arg.is_not_null()
             return (
                 result.to_frame()

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -1719,11 +1719,9 @@ class Series:
 
             # We're using a regular ufunc, that operates value by value. That
             # means we allowed missing data in the input, so filter it out:
-            validity_mask = (
-                F.lit(True) if self.null_count() == 0 else self.is_not_null()
-            )
+            validity_mask = self.is_not_null() if self.has_nulls() else F.lit(True)
             for arg in inputs:
-                if isinstance(arg, Series) and arg.null_count() > 0:
+                if isinstance(arg, Series) and arg.has_nulls():
                     validity_mask &= arg.is_not_null()
             return (
                 result.to_frame()


### PR DESCRIPTION
Closes #27357 