### PR TITLE
ci(rust): Cargo deny

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -103,3 +103,15 @@ jobs:
           --features object
           -p polars-core
 #          -p polars-arrow
+
+  deny:
+    if: github.ref_name != 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@cargo-deny
+
+      - name: Run cargo deny
+        run: cargo deny check

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,10 @@ fmt: update-cargo-env ## Run autoformatting and linting
 	dprint fmt
 	$(VENV_BIN)/typos
 
+.PHONY: deny
+deny:
+	cargo deny check
+
 .PHONY: fix
 fix: update-cargo-env
 	cargo clippy --workspace --all-targets --all-features --fix

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,90 @@
+# https://embarkstudios.github.io/cargo-deny/checks/cfg.html
+
+[advisories]
+unused-ignored-advisory = "allow"
+yanked = "deny"
+ignore = [
+  # THESE ISSUES ARE ALLOW-LISTED HERE TO SILENCE THE CI TEMPORARILY
+  # THESE ISSUES NEED TO BE FIXED
+
+  # error[vulnerability]: AWS-LC X.509 Name Constraints Bypass via Wildcard/Unicode CN
+  "RUSTSEC-2026-0044",
+  # error[vulnerability]: Timing Side-Channel in AES-CCM Tag Verification in AWS-LC
+  "RUSTSEC-2026-0045",
+  # error[vulnerability]: PKCS7_verify Certificate Chain Validation Bypass in AWS-LC
+  "RUSTSEC-2026-0046",
+  # error[vulnerability]: PKCS7_verify Signature Validation Bypass in AWS-LC
+  "RUSTSEC-2026-0047",
+  # error[vulnerability]: CRL Distribution Point Scope Check Logic Error in AWS-LC
+  "RUSTSEC-2026-0048",
+
+  # error[unmaintained]: Bincode is unmaintained
+  "RUSTSEC-2025-0141",
+
+  # error[unsound]: Rand is unsound with a custom logger using `rand::rng()`
+  "RUSTSEC-2026-0097",
+
+  # error[vulnerability]: Name constraints for URI names were incorrectly accepted
+  "RUSTSEC-2026-0098",
+  # error[vulnerability]: Name constraints were accepted for certificates asserting a wildcard name
+  "RUSTSEC-2026-0099",
+
+  # error[vulnerability]: CRLs not considered authoritative by Distribution Point due to faulty matching logic
+  "RUSTSEC-2026-0049",
+
+  # error[yanked]: detected yanked crate (try `cargo update -p core2`)
+  { name = "core2", version = "0.4.0" },
+]
+
+[licenses]
+unused-allowed-license = "allow"
+allow = [
+  # Permissive, most common
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "MIT",
+  # Unicode data / text processing
+  "Unicode-3.0",
+  "Unicode-DFS-2016",
+  # Public domain / no-rights-reserved
+  "CC0-1.0",
+  # Weak copyleft, file-level only; MPL-2.0 requires changes to MPL-licensed *files* to be
+  # released, but does not infect surrounding code
+  "MPL-2.0",
+  # Data license used by webpki-roots for Mozilla's CA root certificate bundle
+  "CDLA-Permissive-2.0",
+  # Other permissive / widely-used
+  "BlueOak-1.0.0",
+  "BSL-1.0",
+  "OpenSSL",
+  "Zlib",
+  # License to mark proprietary crates
+  "LicenseRef-Proprietary",
+]
+
+[bans]
+# Multiple versions of the same crate are allowed
+multiple-versions = "allow"
+# Wildcard dependency versions (`*`) are never acceptable, except for local path
+# dependencies (workspace-internal crates that have no registry version)
+wildcards = "deny"
+allow-wildcard-paths = true
+
+[sources]
+unused-allowed-source = "allow"
+# Reject crates from registries we have not explicitly approved
+unknown-registry = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# Reject git dependencies unless they come from an approved repository.
+# required = false suppresses the "unmatched-source" warning in workspaces that
+# don't use a given patch (these patches are only active in compute-plane).
+unknown-git = "deny"
+allow-git = [
+  "https://github.com/kdn36/arrow-rs-object-store",
+  "https://github.com/pola-rs/jemallocator",
+  "https://github.com/pola-rs/polars",
+  "https://github.com/pola-rs/pyo3",
+]

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,6 @@
 # https://embarkstudios.github.io/cargo-deny/checks/cfg.html
 
 [advisories]
-unused-ignored-advisory = "allow"
 yanked = "deny"
 ignore = [
   # THESE ISSUES ARE ALLOW-LISTED HERE TO SILENCE THE CI TEMPORARILY
@@ -37,7 +36,6 @@ ignore = [
 ]
 
 [licenses]
-unused-allowed-license = "allow"
 allow = [
   # Permissive, most common
   "Apache-2.0",
@@ -48,21 +46,12 @@ allow = [
   "MIT",
   # Unicode data / text processing
   "Unicode-3.0",
-  "Unicode-DFS-2016",
   # Public domain / no-rights-reserved
   "CC0-1.0",
-  # Weak copyleft, file-level only; MPL-2.0 requires changes to MPL-licensed *files* to be
-  # released, but does not infect surrounding code
-  "MPL-2.0",
-  # Data license used by webpki-roots for Mozilla's CA root certificate bundle
-  "CDLA-Permissive-2.0",
   # Other permissive / widely-used
-  "BlueOak-1.0.0",
   "BSL-1.0",
   "OpenSSL",
   "Zlib",
-  # License to mark proprietary crates
-  "LicenseRef-Proprietary",
 ]
 
 [bans]
@@ -74,7 +63,6 @@ wildcards = "deny"
 allow-wildcard-paths = true
 
 [sources]
-unused-allowed-source = "allow"
 # Reject crates from registries we have not explicitly approved
 unknown-registry = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
@@ -85,6 +73,4 @@ unknown-git = "deny"
 allow-git = [
   "https://github.com/kdn36/arrow-rs-object-store",
   "https://github.com/pola-rs/jemallocator",
-  "https://github.com/pola-rs/polars",
-  "https://github.com/pola-rs/pyo3",
 ]

--- a/py-polars/runtime/polars-runtime-32/Cargo.toml
+++ b/py-polars/runtime/polars-runtime-32/Cargo.toml
@@ -3,6 +3,7 @@ name = "polars-runtime-32"
 # example: 1.35.0-beta.1
 version = "1.40.0"
 edition = "2021"
+license = "MIT"
 
 [lib]
 name = "_polars_runtime"

--- a/py-polars/runtime/polars-runtime-64/Cargo.toml
+++ b/py-polars/runtime/polars-runtime-64/Cargo.toml
@@ -3,6 +3,7 @@ name = "polars-runtime-64"
 # example: 1.35.0-beta.1
 version = "1.40.0"
 edition = "2021"
+license = "MIT"
 
 [lib]
 name = "_polars_runtime"

--- a/py-polars/runtime/polars-runtime-compat/Cargo.toml
+++ b/py-polars/runtime/polars-runtime-compat/Cargo.toml
@@ -3,6 +3,7 @@ name = "polars-runtime-compat"
 # example: 1.35.0-beta.1
 version = "1.40.0"
 edition = "2021"
+license = "MIT"
 
 [lib]
 name = "_polars_runtime"

--- a/py-polars/runtime/template/Cargo.template.toml
+++ b/py-polars/runtime/template/Cargo.template.toml
@@ -3,6 +3,7 @@ name = "polars-runtime-{{%RT_SUFFIX%}}"
 # example: 1.35.0-beta.1
 version = "1.40.0"
 edition = "2021"
+license = "MIT"
 
 [lib]
 name = "_polars_runtime"

--- a/pyo3-polars/example/derive_expression/expression_lib/Cargo.toml
+++ b/pyo3-polars/example/derive_expression/expression_lib/Cargo.toml
@@ -2,6 +2,7 @@
 name = "expression_lib"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
@@ -10,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 arrow = { workspace = true, default-features = false }
-num = "*"
+num = "0.4.3"
 polars = { workspace = true, features = ["timezones", "allow_unused"] }
 pyo3 = { workspace = true }
 pyo3-polars = { workspace = true, features = ["derive"] }

--- a/pyo3-polars/example/extend_polars_python_dispatch/extend_polars/Cargo.toml
+++ b/pyo3-polars/example/extend_polars_python_dispatch/extend_polars/Cargo.toml
@@ -2,6 +2,7 @@
 name = "extend_polars"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/pyo3-polars/example/io_plugin/io_plugin/Cargo.toml
+++ b/pyo3-polars/example/io_plugin/io_plugin/Cargo.toml
@@ -2,6 +2,7 @@
 name = "io_plugin"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]


### PR DESCRIPTION
Add `cargo-deny` and missing licenses. To silence the CI until the issues are fixed, all have been allow-listed in the `deny.toml`. To be picked up!