### PR TITLE
fix: Use the physical dtype for `NumUnorderedImplodeReducer` arrow `ListArray`

### DIFF
--- a/crates/polars-expr/src/reduce/implode.rs
+++ b/crates/polars-expr/src/reduce/implode.rs
@@ -100,8 +100,9 @@ impl<T: PolarsNumericType> Reducer for NumUnorderedImplodeReducer<T> {
 
         let values = out.freeze();
         let list_dtype = DataType::List(Box::new(dtype.clone()));
+        let phys_list_dtype = DataType::List(Box::new(dtype.to_physical()));
         let arr = ListArray::new(
-            list_dtype.to_arrow(CompatLevel::newest()),
+            phys_list_dtype.to_arrow(CompatLevel::newest()),
             offsets.freeze(),
             values.boxed(),
             None,

--- a/py-polars/tests/unit/operations/aggregation/test_aggregations.py
+++ b/py-polars/tests/unit/operations/aggregation/test_aggregations.py
@@ -1573,7 +1573,7 @@ def test_min_max_by_all_null_by_group_slice(agg: Callable[..., pl.Expr]) -> None
 
 
 @pytest.mark.parametrize(
-    ("dtype", "input", "expected"),
+    ("dtype", "input", "expect"),
     [
         (pl.Int32, [1, 2, 2], [[1, 2], [2]]),
         (pl.Boolean, [True, False, False], [[False, True], [False]]),
@@ -1601,9 +1601,7 @@ def test_unordered_implode_reduction_27373(
         schema={"group": pl.String, "val": pl.List(dtype)},
     )
     q = df.lazy().group_by("group").agg(pl.col("val").unique())
-    actual = (
-        q.collect(engine="streaming")
-        .with_columns(pl.col("val").map_elements(sorted, return_dtype=pl.List(dtype)))
-        .sort("group")
+    actual = q.collect(engine="streaming").with_columns(
+        pl.col("val").map_elements(sorted, return_dtype=pl.List(dtype))
     )
-    assert_frame_equal(actual, expected)
+    assert_frame_equal(actual, expected, check_row_order=False)

--- a/py-polars/tests/unit/operations/aggregation/test_aggregations.py
+++ b/py-polars/tests/unit/operations/aggregation/test_aggregations.py
@@ -10,17 +10,7 @@ from hypothesis import given
 
 import polars as pl
 from polars.testing import assert_frame_equal
-from polars.testing.asserts.series import assert_series_equal
 from polars.testing.parametric import dataframes
-from polars.testing.parametric.strategies.core import column
-from tests.unit.conftest import (
-    DATETIME_DTYPES,
-    DURATION_DTYPES,
-    FLOAT_DTYPES,
-    INTEGER_DTYPES,
-    NUMERIC_DTYPES,
-    TEMPORAL_DTYPES,
-)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -1585,6 +1575,8 @@ def test_min_max_by_all_null_by_group_slice(agg: Callable[..., pl.Expr]) -> None
 @pytest.mark.parametrize(
     ("dtype", "input", "expected"),
     [
+        (pl.Int32, [1, 2, 2], [[1, 2], [2]]),
+        (pl.Boolean, [True, False, False], [[False, True], [False]]),
         (
             pl.Date,
             [date(2020, 1, 1), date(2020, 1, 2), date(2020, 1, 2)],
@@ -1593,17 +1585,19 @@ def test_min_max_by_all_null_by_group_slice(agg: Callable[..., pl.Expr]) -> None
         (pl.Decimal(), [1, 2, 2], [[1, 2], [2]]),
         (pl.Categorical, ["A", "B", "B"], [["A", "B"], ["B"]]),
         (pl.Enum(["A", "B"]), ["A", "B", "B"], [["A", "B"], ["B"]]),
+        (pl.String, ["A", "B", "B"], [["A", "B"], ["B"]]),
+        (pl.Binary, [b"A", b"B", b"B"], [[b"A", b"B"], [b"B"]]),
     ],
 )
 def test_unordered_implode_reduction_27373(
-    dtype: pl.DataType, input: list[Any], expected: list[Any]
+    dtype: pl.DataType, input: list[Any], expect: list[Any]
 ) -> None:
     df = pl.DataFrame(
         {"group": ["a", "a", "b"], "val": input},
         schema={"group": pl.String, "val": dtype},
     )
     expected = pl.DataFrame(
-        {"group": ["a", "b"], "val": expected},
+        {"group": ["a", "b"], "val": expect},
         schema={"group": pl.String, "val": pl.List(dtype)},
     )
     q = df.lazy().group_by("group").agg(pl.col("val").unique())

--- a/py-polars/tests/unit/operations/aggregation/test_aggregations.py
+++ b/py-polars/tests/unit/operations/aggregation/test_aggregations.py
@@ -10,7 +10,17 @@ from hypothesis import given
 
 import polars as pl
 from polars.testing import assert_frame_equal
+from polars.testing.asserts.series import assert_series_equal
 from polars.testing.parametric import dataframes
+from polars.testing.parametric.strategies.core import column
+from tests.unit.conftest import (
+    DATETIME_DTYPES,
+    DURATION_DTYPES,
+    FLOAT_DTYPES,
+    INTEGER_DTYPES,
+    NUMERIC_DTYPES,
+    TEMPORAL_DTYPES,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -1570,3 +1580,36 @@ def test_min_max_by_all_null_by_group_slice(agg: Callable[..., pl.Expr]) -> None
         .collect()
     )
     assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("dtype", "input", "expected"),
+    [
+        (
+            pl.Date,
+            [date(2020, 1, 1), date(2020, 1, 2), date(2020, 1, 2)],
+            [[date(2020, 1, 1), date(2020, 1, 2)], [date(2020, 1, 2)]],
+        ),
+        (pl.Decimal(), [1, 2, 2], [[1, 2], [2]]),
+        (pl.Categorical, ["A", "B", "B"], [["A", "B"], ["B"]]),
+        (pl.Enum(["A", "B"]), ["A", "B", "B"], [["A", "B"], ["B"]]),
+    ],
+)
+def test_unordered_implode_reduction_27373(
+    dtype: pl.DataType, input: list[Any], expected: list[Any]
+) -> None:
+    df = pl.DataFrame(
+        {"group": ["a", "a", "b"], "val": input},
+        schema={"group": pl.String, "val": dtype},
+    )
+    expected = pl.DataFrame(
+        {"group": ["a", "b"], "val": expected},
+        schema={"group": pl.String, "val": pl.List(dtype)},
+    )
+    q = df.lazy().group_by("group").agg(pl.col("val").unique())
+    actual = (
+        q.collect(engine="streaming")
+        .with_columns(pl.col("val").map_elements(sorted, return_dtype=pl.List(dtype)))
+        .sort("group")
+    )
+    assert_frame_equal(actual, expected)


### PR DESCRIPTION
Fixes #27373

:robot: Used Claude Sonnet 4.6 to track down the issue