### PR TITLE
experiment: Try to get the disk space down for the coverage builds

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -88,6 +88,11 @@ jobs:
           name: coverage-rust
           path: coverage-rust.lcov
 
+      - name: Report free disk space
+        if: success() || failure()
+        continue-on-error: true
+        run: df -h
+
   coverage-python:
     # Running under ubuntu doesn't seem to work:
     # https://github.com/pola-rs/polars/issues/14255
@@ -202,6 +207,11 @@ jobs:
             py-polars/auto-streaming.xml
             py-polars/small-morsel.xml
             py-polars/async.xml
+
+      - name: Report free disk space
+        if: success() || failure()
+        continue-on-error: true
+        run: df -h
 
   upload-coverage:
     needs: [coverage-rust, coverage-python]

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -132,6 +132,11 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
+      - name: Report free disk space
+        if: success() || failure()
+        continue-on-error: true
+        run: df -h
+
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
@@ -146,6 +151,11 @@ jobs:
           uv pip uninstall polars-runtime-32 polars-runtime-64 polars-runtime-compat
           uv pip install --no-deps -e py-polars
           make build
+
+      - name: Report free disk space
+        if: success() || failure()
+        continue-on-error: true
+        run: df -h
 
       - name: Run Python tests
         working-directory: py-polars

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -25,14 +25,13 @@ defaults:
 env:
   RUSTFLAGS: '-C instrument-coverage --cfg=coverage --cfg=coverage_nightly --cfg=trybuild_no_target'
   RUST_BACKTRACE: 1
-  # Coverage data comes from instrumentation, not DWARF symbols.
-  # Keep macOS test binaries smaller to avoid linker/disk exhaustion.
-  CARGO_PROFILE_DEV_DEBUG: 0
-  CARGO_PROFILE_TEST_DEBUG: 0
-  LLVM_PROFILE_FILE: ${{ github.workspace }}/target/polars-%p-%3m.profraw
+  # Coverage artifacts go to target/coverage/ via the 'coverage' Cargo profile. This keeps them
+  # isolated from any non-coverage cache restored to target/debug/, which would otherwise create
+  # 3-4x duplicate rlib copies and exhaust disk space.
+  LLVM_PROFILE_FILE: ${{ github.workspace }}/target/coverage/polars-%p-%3m.profraw
   CARGO_LLVM_COV: 1
   CARGO_LLVM_COV_SHOW_ENV: 1
-  CARGO_LLVM_COV_TARGET_DIR: ${{ github.workspace }}/target
+  CARGO_LLVM_COV_TARGET_DIR: ${{ github.workspace }}/target/coverage
   # We use the stable ABI, silences error from PyO3 that the system Python is too new.
   PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
 
@@ -60,7 +59,7 @@ jobs:
 
       - name: Run tests
         run: >
-          cargo test --all-features
+          cargo test --all-features --profile coverage
           -p polars-arrow
           -p polars-compute
           -p polars-core
@@ -77,10 +76,10 @@ jobs:
       # Unfortunately we run out of disk space when running integration tests with coverage enabled.
       # Skipping for now.
       # - name: Run integration tests
-      #   run: cargo test --all-features -p polars --test it
+      #   run: cargo test --all-features --profile coverage -p polars --test it
 
       - name: Report coverage
-        run: cargo llvm-cov report --lcov --output-path coverage-rust.lcov
+        run: cargo llvm-cov report --profile coverage --lcov --output-path coverage-rust.lcov
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v6
@@ -145,7 +144,7 @@ jobs:
           # Make sure we use the Polars we're about to build.
           uv pip uninstall polars-runtime-32 polars-runtime-64 polars-runtime-compat
           uv pip install --no-deps -e py-polars
-          make build
+          make build ARGS="--profile coverage"
 
       - name: Run Python tests
         working-directory: py-polars
@@ -195,7 +194,7 @@ jobs:
           --cov --cov-report xml:async.xml --cov-fail-under=0
 
       - name: Report Rust coverage
-        run: cargo llvm-cov report --lcov --output-path coverage-python.lcov
+        run: cargo llvm-cov report --profile coverage --lcov --output-path coverage-python.lcov
 
       - name: Upload coverage reports
         uses: actions/upload-artifact@v6

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -25,13 +25,14 @@ defaults:
 env:
   RUSTFLAGS: '-C instrument-coverage --cfg=coverage --cfg=coverage_nightly --cfg=trybuild_no_target'
   RUST_BACKTRACE: 1
-  # Coverage artifacts go to target/coverage/ via the 'coverage' Cargo profile. This keeps them
-  # isolated from any non-coverage cache restored to target/debug/, which would otherwise create
-  # 3-4x duplicate rlib copies and exhaust disk space.
-  LLVM_PROFILE_FILE: ${{ github.workspace }}/target/coverage/polars-%p-%3m.profraw
+  # Coverage data comes from instrumentation, not DWARF symbols.
+  # Keep macOS test binaries smaller to avoid linker/disk exhaustion.
+  CARGO_PROFILE_DEV_DEBUG: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
+  LLVM_PROFILE_FILE: ${{ github.workspace }}/target/polars-%p-%3m.profraw
   CARGO_LLVM_COV: 1
   CARGO_LLVM_COV_SHOW_ENV: 1
-  CARGO_LLVM_COV_TARGET_DIR: ${{ github.workspace }}/target/coverage
+  CARGO_LLVM_COV_TARGET_DIR: ${{ github.workspace }}/target
   # We use the stable ABI, silences error from PyO3 that the system Python is too new.
   PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
 
@@ -59,7 +60,7 @@ jobs:
 
       - name: Run tests
         run: >
-          cargo test --all-features --profile coverage
+          cargo test --all-features
           -p polars-arrow
           -p polars-compute
           -p polars-core
@@ -76,10 +77,10 @@ jobs:
       # Unfortunately we run out of disk space when running integration tests with coverage enabled.
       # Skipping for now.
       # - name: Run integration tests
-      #   run: cargo test --all-features --profile coverage -p polars --test it
+      #   run: cargo test --all-features -p polars --test it
 
       - name: Report coverage
-        run: cargo llvm-cov report --profile coverage --lcov --output-path coverage-rust.lcov
+        run: cargo llvm-cov report --lcov --output-path coverage-rust.lcov
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v6
@@ -144,7 +145,7 @@ jobs:
           # Make sure we use the Polars we're about to build.
           uv pip uninstall polars-runtime-32 polars-runtime-64 polars-runtime-compat
           uv pip install --no-deps -e py-polars
-          make build ARGS="--profile coverage"
+          make build
 
       - name: Run Python tests
         working-directory: py-polars
@@ -194,7 +195,7 @@ jobs:
           --cov --cov-report xml:async.xml --cov-fail-under=0
 
       - name: Report Rust coverage
-        run: cargo llvm-cov report --profile coverage --lcov --output-path coverage-python.lcov
+        run: cargo llvm-cov report --lcov --output-path coverage-python.lcov
 
       - name: Upload coverage reports
         uses: actions/upload-artifact@v6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,10 +170,6 @@ color-backtrace = { git = "https://github.com/orlp/color-backtrace", rev = "bb62
 inherits = "dev"
 debug = "line-tables-only"
 
-[profile.coverage]
-inherits = "test"
-debug = "line-tables-only"
-
 [profile.release]
 lto = "thin"
 debug = "line-tables-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,10 @@ color-backtrace = { git = "https://github.com/orlp/color-backtrace", rev = "bb62
 inherits = "dev"
 debug = "line-tables-only"
 
+[profile.coverage]
+inherits = "test"
+debug = "line-tables-only"
+
 [profile.release]
 lto = "thin"
 debug = "line-tables-only"


### PR DESCRIPTION
It would be useful to know how much disk space is left after the coverage jobs have run. This PR adds a step that prints the free disk space at that point.

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
