### PR TITLE
fix(plan): remove duplicate column in match_to_schema missing-columns error

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -754,7 +754,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             }
 
             // Report the error for missing columns
-            if let Some(lst) = found_missing_columns.first() {
+            if !found_missing_columns.is_empty() {
                 use std::fmt::Write;
                 let mut formatted = String::new();
                 write!(&mut formatted, "\"{}\"", found_missing_columns[0]).unwrap();
@@ -762,7 +762,6 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                     write!(&mut formatted, ", \"{c}\"").unwrap();
                 }
 
-                write!(&mut formatted, "\"{lst}\"").unwrap();
                 polars_bail!(SchemaMismatch: "missing columns in `match_to_schema`: {formatted}");
             }
 


### PR DESCRIPTION
Fixes #27256.

The `match_to_schema` missing-column error was printing the first missing column twice:

```
pl.DataFrame().match_to_schema({"b": pl.Int64, "c": pl.Int64})
# before: SchemaError: missing columns in `match_to_schema`: "b", "c""b"
# after:  SchemaError: missing columns in `match_to_schema`: "b", "c"
```

The loop at lines 760-763 already builds the full comma-separated list (`"b", "c"`). Line 765 then unconditionally appended `"{lst}"` where `lst = found_missing_columns.first()` — that's where the trailing `"b"` came from.

Dropped the stray `write!` and switched the `if let Some(lst) = …first()` to `if !is_empty()` since `lst` is no longer needed. Single-file, message-only fix.

```diff
- if let Some(lst) = found_missing_columns.first() {
+ if !found_missing_columns.is_empty() {
      use std::fmt::Write;
      let mut formatted = String::new();
      write!(&mut formatted, "\"{}\"", found_missing_columns[0]).unwrap();
      for c in &found_missing_columns[1..] {
          write!(&mut formatted, ", \"{c}\"").unwrap();
      }
-
-     write!(&mut formatted, "\"{lst}\"").unwrap();
      polars_bail!(SchemaMismatch: "missing columns in \`match_to_schema\`: {formatted}");
  }
```