### PR TITLE
fix: Handle column indexing in `read_parquet`/`read_csv` with pyarrow reader

### DIFF
--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -332,9 +332,16 @@ def read_csv(
                 include_columns = columns
 
         if not columns and projection:
-            # Convert column indices from projection to 'f0', 'f1', ... column names
-            # for pyarrow.
-            include_columns = [f"f{column_idx}" for column_idx in projection]
+            # User selected columns by positional index (e.g. `columns=[0]`).
+            if not has_header:
+                # pyarrow auto-generates names 'f0', 'f1', ... when there is no
+                # header, so index N maps to name 'fN'.
+                include_columns = [f"f{column_idx}" for column_idx in projection]
+            else:
+                # With a header, real names come from row 1 and aren't known
+                # until after the read. Leave the filter off and slice the
+                # Table by position later.
+                include_columns = None
 
         with prepare_file_arg(
             source,
@@ -377,6 +384,11 @@ def read_csv(
             tbl = tbl.rename_columns(
                 [f"column_{int(column[1:]) + 1}" for column in tbl.column_names]
             )
+        elif not columns and projection:
+            # User selected columns by positional index (e.g. `columns=[0, 2]`).
+            # pyarrow's include_columns only accepts names, so the read above
+            # fetched every column; pick out the requested positions now.
+            tbl = tbl.select(list(projection))
 
         df = pl.DataFrame._from_arrow(tbl, rechunk=rechunk)
         if new_columns:

--- a/py-polars/src/polars/io/parquet/functions.py
+++ b/py-polars/src/polars/io/parquet/functions.py
@@ -332,10 +332,19 @@ def _read_parquet_with_pyarrow(
             use_pyarrow=True,
             storage_options=storage_options,
         ) as source_prep:
+            resolved_columns: Sequence[str] | None
+            if columns is not None and is_int_sequence(columns):
+                # pyarrow's read_table needs column names; resolve int indices
+                # via the file's schema. For list sources, peek the first file.
+                peek = source_prep[0] if isinstance(source_prep, list) else source_prep
+                schema = pyarrow_parquet.read_schema(peek)
+                resolved_columns = [schema.names[i] for i in columns]
+            else:
+                resolved_columns = columns  # type: ignore[assignment]
             pa_table = pyarrow_parquet.read_table(
                 source_prep,
                 memory_map=memory_map,
-                columns=columns,
+                columns=resolved_columns,
                 **pyarrow_options,
             )
         result = from_arrow(pa_table, rechunk=rechunk)

--- a/py-polars/src/polars/io/parquet/functions.py
+++ b/py-polars/src/polars/io/parquet/functions.py
@@ -336,7 +336,11 @@ def _read_parquet_with_pyarrow(
             if columns is not None and is_int_sequence(columns):
                 # pyarrow's read_table needs column names; resolve int indices
                 # via the file's schema. For list sources, peek the first file.
-                peek = source_prep[0] if isinstance(source_prep, list) else source_prep
+                peek = (
+                    source_prep[0]
+                    if isinstance(source_prep, list)  # type: ignore[redundant-expr]
+                    else source_prep
+                )
                 schema = pyarrow_parquet.read_schema(peek)
                 resolved_columns = [schema.names[i] for i in columns]
             else:

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -3173,3 +3173,15 @@ def test_scan_csv_missing_columns_27268() -> None:
             }
         ),
     )
+
+
+@pytest.mark.write_disk
+def test_read_csv_use_pyarrow_int_columns_27389(tmp_path: Path) -> None:
+    path = tmp_path / "test.csv"
+    path.write_text("h1,h2\n1,2\n2,3\n")
+
+    expected = pl.DataFrame({"h1": [1, 2]})
+    assert_frame_equal(
+        pl.read_csv(path, columns=[0], use_pyarrow=True),
+        expected,
+    )

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -4137,6 +4137,18 @@ def test_parquet_duplicate_column_names_27393(tmp_path: Path) -> None:
         pl.scan_parquet(path).collect_schema()
 
 
+@pytest.mark.write_disk
+def test_read_parquet_use_pyarrow_int_columns_27389(tmp_path: Path) -> None:
+    path = tmp_path / "test.parquet"
+    pl.DataFrame({"h1": [1, 2], "h2": [2, 3]}).write_parquet(path)
+
+    expected = pl.DataFrame({"h1": [1, 2]})
+    assert_frame_equal(
+        pl.read_parquet(path, columns=[0], use_pyarrow=True),
+        expected,
+    )
+
+
 def test_read_parquet_legacy_nested_maps_27159(io_files_path: Path) -> None:
     path = io_files_path / "nested_maps.snappy.parquet"
 


### PR DESCRIPTION
Fixes #27389