### PR TITLE
fix: Raise `DuplicateError` on parquet files with duplicate column names

### DIFF
--- a/crates/polars-parquet/src/arrow/read/schema/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/schema/mod.rs
@@ -7,7 +7,8 @@ mod metadata;
 pub(crate) use convert::*;
 pub use convert::{parquet_to_arrow_schema, parquet_to_arrow_schema_with_options};
 pub use metadata::{read_custom_key_value_metadata, read_schema_from_metadata};
-use polars_error::PolarsResult;
+use polars_error::{PolarsResult, polars_ensure};
+use polars_utils::aliases::{InitHashMaps, PlHashSet};
 
 use self::metadata::parse_key_value_metadata;
 pub use crate::parquet::metadata::{FileMetadata, KeyValue, SchemaDescriptor};
@@ -39,8 +40,9 @@ impl Default for SchemaInferenceOptions {
 /// Parquet types declared in the file's Parquet schema to Arrow's equivalent.
 ///
 /// # Error
-/// This function errors iff the key `"ARROW:schema"` exists but is not correctly encoded,
-/// indicating that the file's arrow metadata was incorrectly written.
+/// - Errors if the key `"ARROW:schema"` exists but is not correctly encoded.
+/// - Errors if the parquet schema contains duplicate top-level column names, since
+///   the resulting [`ArrowSchema`] cannot represent them.
 pub fn infer_schema(file_metadata: &FileMetadata) -> PolarsResult<ArrowSchema> {
     infer_schema_with_options(file_metadata, &None)
 }
@@ -50,10 +52,14 @@ pub fn infer_schema_with_options(
     file_metadata: &FileMetadata,
     options: &Option<SchemaInferenceOptions>,
 ) -> PolarsResult<ArrowSchema> {
+    let fields = file_metadata.schema().fields();
+    let mut seen = PlHashSet::with_capacity(fields.len());
+    for f in fields {
+        polars_ensure!(seen.insert(f.name()), duplicate = f.name());
+    }
+
     let mut metadata = parse_key_value_metadata(file_metadata.key_value_metadata());
 
     let schema = read_schema_from_metadata(&mut metadata)?;
-    Ok(schema.unwrap_or_else(|| {
-        parquet_to_arrow_schema_with_options(file_metadata.schema().fields(), options)
-    }))
+    Ok(schema.unwrap_or_else(|| parquet_to_arrow_schema_with_options(fields, options)))
 }

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -4118,3 +4118,20 @@ def test_predicate_pushdown_null_column_schema_override_26974() -> None:
         lf.collect(),
         lf.collect(optimizations=pl.QueryOptFlags(predicate_pushdown=False)),
     )
+
+
+@pytest.mark.write_disk
+def test_parquet_duplicate_column_names_27393(tmp_path: Path) -> None:
+    schema = pa.schema([("ra", pa.int64()), ("ra", pa.int64())])
+    table = pa.Table.from_arrays(
+        [pa.array([1, 2, 3]), pa.array([4, 5, 6])],
+        schema=schema,
+    )
+    path = tmp_path / "duplicated.parquet"
+    pq.write_table(table, path)
+
+    with pytest.raises(pl.exceptions.DuplicateError):
+        pl.read_parquet(path)
+
+    with pytest.raises(pl.exceptions.DuplicateError):
+        pl.scan_parquet(path).collect_schema()


### PR DESCRIPTION
Fixes #27393