### PR TITLE
docs(python): Clarify regex replacement backreferences

### DIFF
--- a/py-polars/src/polars/expr/name.py
+++ b/py-polars/src/polars/expr/name.py
@@ -367,6 +367,8 @@ class ExprNameNameSpace:
         Capture groups are supported. Use `$1` or `${1}` in the `value` string to refer
         to the first capture group in the pattern, `$2` or `${2}` to refer to the
         second capture group, and so on. You can also use named capture groups.
+        Python-style backreferences such as `\1` and `\g<name>` are not supported
+        in replacement strings; use `$1` or `${name}` instead.
 
         >>> df = pl.DataFrame({"x_1": [1], "x_2": [2], "group_id": ["xyz"]})
         >>> df.select(pl.all().name.replace(r"_(\d+)$", ":$1"))

--- a/py-polars/src/polars/expr/string.py
+++ b/py-polars/src/polars/expr/string.py
@@ -2077,6 +2077,8 @@ class ExprStringNameSpace:
         Capture groups are supported. Use `$1` or `${1}` in the `value` string to refer
         to the first capture group in the `pattern`, `$2` or `${2}` to refer to the
         second capture group, and so on. You can also use *named* capture groups.
+        Python-style backreferences such as `\1` and `\g<name>` are not supported
+        in replacement strings; use `$1` or `${name}` instead.
 
         >>> df = pl.DataFrame({"word": ["hat", "hut"]})
         >>> df.with_columns(
@@ -2196,6 +2198,8 @@ class ExprStringNameSpace:
         Capture groups are supported. Use `$1` or `${1}` in the `value` string to refer
         to the first capture group in the `pattern`, `$2` or `${2}` to refer to the
         second capture group, and so on. You can also use *named* capture groups.
+        Python-style backreferences such as `\1` and `\g<name>` are not supported
+        in replacement strings; use `$1` or `${name}` instead.
 
         >>> df = pl.DataFrame({"word": ["hat", "hut"]})
         >>> df.with_columns(

--- a/py-polars/src/polars/series/string.py
+++ b/py-polars/src/polars/series/string.py
@@ -1270,6 +1270,8 @@ class StringNameSpace:
         Capture groups are supported. Use `$1` or `${1}` in the `value` string to refer
         to the first capture group in the `pattern`, `$2` or `${2}` to refer to the
         second capture group, and so on. You can also use *named* capture groups.
+        Python-style backreferences such as `\1` and `\g<name>` are not supported
+        in replacement strings; use `$1` or `${name}` instead.
 
         >>> s = pl.Series(["hat", "hut"])
         >>> s.str.replace("h(.)t", "b${1}d")
@@ -1360,6 +1362,8 @@ class StringNameSpace:
         Capture groups are supported. Use `$1` or `${1}` in the `value` string to refer
         to the first capture group in the `pattern`, `$2` or `${2}` to refer to the
         second capture group, and so on. You can also use *named* capture groups.
+        Python-style backreferences such as `\1` and `\g<name>` are not supported
+        in replacement strings; use `$1` or `${name}` instead.
 
         >>> s = pl.Series(["hat", "hut"])
         >>> s.str.replace_all("h(.)t", "b${1}d")


### PR DESCRIPTION
## Summary

Clarifies that Python-style replacement backreferences such as `\1` and `\g<name>` are not supported in regex replacement strings.

Polars uses Rust regex replacement syntax, so users should use `$1`, `${1}`, or `${name}` instead.

Closes #6683.

## Tests

- `python -m pytest py-polars/tests/unit/operations/namespaces/string/test_string.py -k "replace"`: 42 passed, 138 deselected

`make doctest` was attempted, but the local build failed before running doctests during the `maturin` build step with `No such file or directory (os error 2)`.

## AI Assistance Disclosure

1. I used AI to help triage the issue, identify the relevant documentation locations, and draft wording alternatives.
2. I confirm that I reviewed all changes myself, and I believe they are relevant and correct.

<img width="983" height="381" alt="make-tests" src="https://github.com/user-attachments/assets/18d57a7c-13df-4991-8a9c-b80cc0271753" />
