### PR TITLE
perf: Speed up parquet metadata decode with hand-written Thrift

### DIFF
--- a/crates/polars-io/src/parquet/read/async_impl.rs
+++ b/crates/polars-io/src/parquet/read/async_impl.rs
@@ -144,10 +144,6 @@ pub async fn fetch_metadata(
         .await?;
 
     Ok(polars_parquet::parquet::read::deserialize_metadata(
-        std::io::Cursor::new(footer_bytes.as_ref()),
-        // TODO: Describe why this makes sense. Taken from the previous
-        // implementation which said "a highly nested but sparse struct could
-        // result in many allocations".
-        footer_bytes.as_ref().len() * 2 + 1024,
+        footer_bytes,
     )?)
 }

--- a/crates/polars-parquet/LICENSE
+++ b/crates/polars-parquet/LICENSE
@@ -1,6 +1,52 @@
-Some of the code in this crate is subject to the Apache 2 license below, as it
-was taken from the arrow2 and parquet2 Rust crate in October 2023. Later changes are subject
-to the MIT license in ../../LICENSE.
+Some of the code in this crate is subject to the Apache 2 license below.
+
+The original code was taken from the arrow2 and parquet2 Rust crates in
+October 2023.
+
+Additional code in `src/parquet/handwritten_thrift/` was ported from
+apache/arrow-rs 57.0 (https://github.com/apache/arrow-rs) in April 2026.
+Both files below carry the upstream Apache-2.0 license header at file
+top. The unmodified arrow-rs 57.0 sources are preserved alongside this
+repository so the divergence below is auditable line by line.
+
+  - `parquet_macros.rs` is verbatim arrow-rs 57.0 except for two
+    `OrderedF64` `$crate::` path edits, each preceded by a one-line
+    polars-integration comment. No other lines differ from upstream.
+
+  - `parquet_thrift.rs` is the arrow-rs 57.0 source with the changes
+    listed below; every other line is byte-identical to upstream:
+      * Integration shims:
+          - use-path remap of `ParquetError` / `Result` to polars's
+            `parquet::error` module;
+          - file-local `general_err!` / `eof_err!` macros producing
+            the same `ParquetError::OutOfSpec(format!(...))` value
+            arrow-rs's crate-global versions construct;
+          - explicit `std::result::Result` aliasing for the
+            `ThriftProtocolResult` alias.
+      * Polars-side removal:
+          - `impl ReadThrift for String` is dropped. arrow-rs's version
+            does `String::from_utf8(...)?` and would force
+            `From<std::string::FromUtf8Error> for ParquetError` into
+            polars's error module. Polars doesn't invoke that impl
+            (the file-metadata decoder uses `prot.read_string()`
+            directly), so dropping the impl plus the `From` shim is
+            cleaner than carrying both. A short comment marks the
+            location in this file.
+      * Polars-side additions:
+          - 1-byte varint fast-path peel in `read_vlq` with a
+            `#[cold] #[inline(never)]` `read_vlq_slow` continuation;
+          - `skip_list_of_varint` and `skip_list_of_binary` helpers
+            used by the inline-skip optimisation in the file-metadata
+            decoder;
+          - `offset_from(origin_ptr) -> u32` on
+            `ThriftSliceInputProtocol`, used to record stats
+            `ByteRange` offsets relative to the footer buffer;
+          - module-level `#![allow(dead_code, private_interfaces)]`
+            so the file body stays an unmodified copy of arrow-rs
+            despite shipping write-side primitives polars doesn't
+            currently use.
+
+Later changes are subject to the MIT license in ../../LICENSE.
 
 
 

--- a/crates/polars-parquet/LICENSE
+++ b/crates/polars-parquet/LICENSE
@@ -5,46 +5,6 @@ October 2023.
 
 Additional code in `src/parquet/handwritten_thrift/` was ported from
 apache/arrow-rs 57.0 (https://github.com/apache/arrow-rs) in April 2026.
-Both files below carry the upstream Apache-2.0 license header at file
-top. The unmodified arrow-rs 57.0 sources are preserved alongside this
-repository so the divergence below is auditable line by line.
-
-  - `parquet_macros.rs` is verbatim arrow-rs 57.0 except for two
-    `OrderedF64` `$crate::` path edits, each preceded by a one-line
-    polars-integration comment. No other lines differ from upstream.
-
-  - `parquet_thrift.rs` is the arrow-rs 57.0 source with the changes
-    listed below; every other line is byte-identical to upstream:
-      * Integration shims:
-          - use-path remap of `ParquetError` / `Result` to polars's
-            `parquet::error` module;
-          - file-local `general_err!` / `eof_err!` macros producing
-            the same `ParquetError::OutOfSpec(format!(...))` value
-            arrow-rs's crate-global versions construct;
-          - explicit `std::result::Result` aliasing for the
-            `ThriftProtocolResult` alias.
-      * Polars-side removal:
-          - `impl ReadThrift for String` is dropped. arrow-rs's version
-            does `String::from_utf8(...)?` and would force
-            `From<std::string::FromUtf8Error> for ParquetError` into
-            polars's error module. Polars doesn't invoke that impl
-            (the file-metadata decoder uses `prot.read_string()`
-            directly), so dropping the impl plus the `From` shim is
-            cleaner than carrying both. A short comment marks the
-            location in this file.
-      * Polars-side additions:
-          - 1-byte varint fast-path peel in `read_vlq` with a
-            `#[cold] #[inline(never)]` `read_vlq_slow` continuation;
-          - `skip_list_of_varint` and `skip_list_of_binary` helpers
-            used by the inline-skip optimisation in the file-metadata
-            decoder;
-          - `offset_from(origin_ptr) -> u32` on
-            `ThriftSliceInputProtocol`, used to record stats
-            `ByteRange` offsets relative to the footer buffer;
-          - module-level `#![allow(dead_code, private_interfaces)]`
-            so the file body stays an unmodified copy of arrow-rs
-            despite shipping write-side primitives polars doesn't
-            currently use.
 
 Later changes are subject to the MIT license in ../../LICENSE.
 

--- a/crates/polars-parquet/src/arrow/read/statistics.rs
+++ b/crates/polars-parquet/src/arrow/read/statistics.rs
@@ -9,6 +9,7 @@ use arrow::datatypes::{ArrowDataType, Field, IntegerType, IntervalUnit, TimeUnit
 use arrow::types::{days_ms, i256};
 use ethnum::I256;
 use num_traits::{AsPrimitive, FromBytes};
+use polars_buffer::Buffer;
 use polars_utils::IdxSize;
 use polars_utils::float16::pf16;
 use polars_utils::pl_str::PlSmallStr;
@@ -300,6 +301,7 @@ pub fn deserialize_all(
     field: &Field,
     row_groups: &[RowGroupMetadata],
     field_idx: usize,
+    footer_buf: &Buffer<u8>,
 ) -> ParquetResult<Option<ArrowColumnStatisticsArrays>> {
     assert!(!row_groups.is_empty());
     use ArrowDataType as D;
@@ -330,7 +332,7 @@ pub fn deserialize_all(
 
                     for rg in row_groups {
                         let column = &rg.parquet_columns()[field_idx];
-                        let s = column.statistics().transpose()?;
+                        let s = column.statistics(footer_buf).transpose()?;
 
                         let (v_min, v_max, v_null_count, v_distinct_count) = match s {
                             None => (None, None, None, None),
@@ -559,47 +561,52 @@ pub fn deserialize_all(
 pub fn deserialize<'a>(
     field: &Field,
     columns: &mut impl ExactSizeIterator<Item = &'a ColumnChunkMetadata>,
+    footer_buf: &Buffer<u8>,
 ) -> ParquetResult<Option<Statistics>> {
     use ArrowDataType as D;
     match field.dtype() {
         D::List(field) | D::LargeList(field) => Ok(Some(Statistics::List(
-            deserialize(field.as_ref(), columns)?.map(Box::new),
+            deserialize(field.as_ref(), columns, footer_buf)?.map(Box::new),
         ))),
         D::Dictionary(key, dtype, is_sorted) => Ok(Some(Statistics::Dictionary(
             *key,
             deserialize(
                 &Field::new(PlSmallStr::EMPTY, dtype.as_ref().clone(), true),
                 columns,
+                footer_buf,
             )?
             .map(Box::new),
             *is_sorted,
         ))),
         D::FixedSizeList(field, width) => Ok(Some(Statistics::FixedSizeList(
-            deserialize(field.as_ref(), columns)?.map(Box::new),
+            deserialize(field.as_ref(), columns, footer_buf)?.map(Box::new),
             *width,
         ))),
         D::Struct(fields) => {
             let field_columns = fields
                 .iter()
-                .map(|f| deserialize(f, columns))
+                .map(|f| deserialize(f, columns, footer_buf))
                 .collect::<ParquetResult<_>>()?;
             Ok(Some(Statistics::Struct(field_columns)))
         },
         _ => {
             let column = columns.next().unwrap();
 
-            Ok(column.statistics().transpose()?.map(|statistics| {
-                let primitive_type = &column.descriptor().descriptor.primitive_type;
+            Ok(column
+                .statistics(footer_buf)
+                .transpose()?
+                .map(|statistics| {
+                    let primitive_type = &column.descriptor().descriptor.primitive_type;
 
-                Statistics::Column(Box::new(ColumnStatistics {
-                    field: field.clone(),
+                    Statistics::Column(Box::new(ColumnStatistics {
+                        field: field.clone(),
 
-                    logical_type: primitive_type.logical_type,
-                    physical_type: primitive_type.physical_type,
+                        logical_type: primitive_type.logical_type,
+                        physical_type: primitive_type.physical_type,
 
-                    statistics,
+                        statistics,
+                    }))
                 }))
-            }))
         },
     }
 }

--- a/crates/polars-parquet/src/parquet/bloom_filter/read.rs
+++ b/crates/polars-parquet/src/parquet/bloom_filter/read.rs
@@ -18,9 +18,7 @@ pub fn read<R: Read + Seek>(
     mut reader: &mut R,
     bitset: &mut Vec<u8>,
 ) -> ParquetResult<()> {
-    let offset = column_metadata.metadata().bloom_filter_offset;
-
-    let offset = if let Some(offset) = offset {
+    let offset = if let Some(offset) = column_metadata.bloom_filter_offset() {
         offset as u64
     } else {
         bitset.clear();

--- a/crates/polars-parquet/src/parquet/handwritten_thrift/file_metadata_thrift.rs
+++ b/crates/polars-parquet/src/parquet/handwritten_thrift/file_metadata_thrift.rs
@@ -1,0 +1,684 @@
+//! Hand-written file-metadata decoder. Produces a [`CompactFileMetaData`]
+//! using the [`super::parquet_thrift`] primitives (ported from arrow-rs 57.0).
+//!
+//! Two design wins over a format-struct decoder:
+//! - Output type is a polars-controlled compact struct hierarchy that drops
+//!   fields with no in-tree consumer (~110 bytes saved per `ColumnChunk`).
+//! - `Statistics.min_value` / `max_value` payloads are recorded as `ByteRange`
+//!   offsets into the input buffer rather than per-stat `Vec<u8>` allocations.
+//!   The caller passes the footer as [`Buffer<u8>`] so those offsets stay
+//!   resolvable for the lifetime of the resulting metadata.
+
+use polars_buffer::Buffer;
+use polars_parquet_format::{ColumnOrder, KeyValue, SchemaElement, SortingColumn};
+
+use super::parquet_thrift::{FieldType, ThriftCompactInputProtocol, ThriftSliceInputProtocol};
+use crate::parquet::compression::Compression;
+use crate::parquet::error::{ParquetError, ParquetResult};
+use crate::parquet::metadata::{
+    ByteRange, CompactColumnChunk, CompactColumnMetaData, CompactFileMetaData, CompactRowGroup,
+    CompactStatistics,
+};
+
+trait RequireField<T> {
+    /// Convert `None` into a uniform `ParquetError::oos("<name> missing")`.
+    fn require(self, name: &str) -> ParquetResult<T>;
+}
+
+impl<T> RequireField<T> for Option<T> {
+    #[inline]
+    fn require(self, name: &str) -> ParquetResult<T> {
+        self.ok_or_else(|| ParquetError::oos(format!("{name} missing")))
+    }
+}
+
+/// Decode a Thrift list by reading the prefix and invoking `read_one` for
+/// each element. Pre-sizes the `Vec` from the list header.
+#[inline]
+fn read_list<T>(
+    prot: &mut ThriftSliceInputProtocol<'_>,
+    mut read_one: impl FnMut(&mut ThriftSliceInputProtocol<'_>) -> ParquetResult<T>,
+) -> ParquetResult<Vec<T>> {
+    let list = prot.read_list_begin()?;
+    let mut v = Vec::with_capacity(list.size.max(0) as usize);
+    for _ in 0..list.size {
+        v.push(read_one(prot)?);
+    }
+    Ok(v)
+}
+
+/// Decode a Parquet `FileMetaData` footer into [`CompactFileMetaData`].
+///
+/// `footer` holds the bytes `&buf` views. `ByteRange` offsets into stats
+/// min/max are recorded relative to `footer.as_ptr()`, and the [`Buffer`]
+/// is cloned (refcount-bump) into the output so they stay resolvable.
+///
+/// Crate-internal: external callers go through
+/// [`crate::parquet::read::deserialize_metadata`] which combines this with
+/// [`crate::parquet::metadata::FileMetadata::from_compact`] to produce the
+/// public [`crate::parquet::metadata::FileMetadata`].
+pub(crate) fn decode_file_metadata(footer: Buffer<u8>) -> ParquetResult<CompactFileMetaData> {
+    let buf: &[u8] = footer.as_ref();
+    let origin_ptr = buf.as_ptr();
+    let mut prot = ThriftSliceInputProtocol::new(buf);
+    read_file_metadata(&mut prot, origin_ptr, &footer)
+}
+
+fn read_file_metadata(
+    prot: &mut ThriftSliceInputProtocol<'_>,
+    origin_ptr: *const u8,
+    footer: &Buffer<u8>,
+) -> ParquetResult<CompactFileMetaData> {
+    let mut version: Option<i32> = None;
+    let mut schema: Option<Vec<SchemaElement>> = None;
+    let mut num_rows: Option<i64> = None;
+    let mut row_groups: Option<Vec<CompactRowGroup>> = None;
+    let mut key_value_metadata: Option<Vec<KeyValue>> = None;
+    let mut created_by: Option<String> = None;
+    let mut column_orders: Option<Vec<ColumnOrder>> = None;
+
+    let mut last_field_id = 0i16;
+    loop {
+        let f = prot.read_field_begin(last_field_id)?;
+        if f.field_type == FieldType::Stop {
+            break;
+        }
+        match f.id {
+            1 => version = Some(prot.read_i32()?),
+            2 => schema = Some(read_list(prot, read_schema_element)?),
+            3 => num_rows = Some(prot.read_i64()?),
+            4 => row_groups = Some(read_list(prot, |p| read_row_group(p, origin_ptr))?),
+            5 => key_value_metadata = Some(read_list(prot, read_key_value)?),
+            6 => created_by = Some(prot.read_string()?.to_owned()),
+            7 => column_orders = Some(read_list(prot, read_column_order)?),
+            // 8/9 (encryption): polars has no encryption support; skip.
+            _ => prot.skip(f.field_type)?,
+        }
+        last_field_id = f.id;
+    }
+
+    Ok(CompactFileMetaData {
+        version: version.require("FileMetaData.version")?,
+        schema: schema.require("FileMetaData.schema")?,
+        num_rows: num_rows.require("FileMetaData.num_rows")?,
+        row_groups: row_groups.require("FileMetaData.row_groups")?,
+        key_value_metadata,
+        created_by,
+        column_orders,
+        footer_buf: footer.clone(),
+    })
+}
+
+/// Decode a `SchemaElement`.
+///
+/// Same shape as `polars_parquet_format::SchemaElement`. We keep the format
+/// type because polars's `SchemaDescriptor::try_from_thrift` consumes it
+/// directly and refactoring that crosses the format-crate boundary.
+fn read_schema_element(prot: &mut ThriftSliceInputProtocol<'_>) -> ParquetResult<SchemaElement> {
+    use polars_parquet_format::{ConvertedType, FieldRepetitionType, LogicalType, Type};
+
+    let mut type_: Option<Type> = None;
+    let mut type_length: Option<i32> = None;
+    let mut repetition_type: Option<FieldRepetitionType> = None;
+    let mut name: Option<String> = None;
+    let mut num_children: Option<i32> = None;
+    let mut converted_type: Option<ConvertedType> = None;
+    let mut scale: Option<i32> = None;
+    let mut precision: Option<i32> = None;
+    let mut field_id: Option<i32> = None;
+    let mut logical_type: Option<LogicalType> = None;
+
+    let mut last_field_id = 0i16;
+    loop {
+        let f = prot.read_field_begin(last_field_id)?;
+        if f.field_type == FieldType::Stop {
+            break;
+        }
+        match f.id {
+            1 => type_ = Some(Type(prot.read_i32()?)),
+            2 => type_length = Some(prot.read_i32()?),
+            3 => repetition_type = Some(FieldRepetitionType(prot.read_i32()?)),
+            4 => name = Some(prot.read_string()?.to_owned()),
+            5 => num_children = Some(prot.read_i32()?),
+            6 => converted_type = Some(ConvertedType(prot.read_i32()?)),
+            7 => scale = Some(prot.read_i32()?),
+            8 => precision = Some(prot.read_i32()?),
+            9 => field_id = Some(prot.read_i32()?),
+            10 => logical_type = Some(read_logical_type(prot)?),
+            _ => prot.skip(f.field_type)?,
+        }
+        last_field_id = f.id;
+    }
+
+    Ok(SchemaElement {
+        type_,
+        type_length,
+        repetition_type,
+        name: name.require("SchemaElement.name")?,
+        num_children,
+        converted_type,
+        scale,
+        precision,
+        field_id,
+        logical_type,
+    })
+}
+
+/// Decode a `RowGroup` into a [`CompactRowGroup`].
+///
+/// Skip-decode: `file_offset`, `total_compressed_size`, `ordinal`. None have
+/// in-workspace consumers.
+fn read_row_group(
+    prot: &mut ThriftSliceInputProtocol<'_>,
+    origin_ptr: *const u8,
+) -> ParquetResult<CompactRowGroup> {
+    let mut columns: Option<Vec<CompactColumnChunk>> = None;
+    let mut total_byte_size: Option<i64> = None;
+    let mut num_rows: Option<i64> = None;
+    let mut sorting_columns: Option<Vec<SortingColumn>> = None;
+
+    let mut last_field_id = 0i16;
+    loop {
+        let f = prot.read_field_begin(last_field_id)?;
+        if f.field_type == FieldType::Stop {
+            break;
+        }
+        match f.id {
+            1 => columns = Some(read_list(prot, |p| read_column_chunk(p, origin_ptr))?),
+            2 => total_byte_size = Some(prot.read_i64()?),
+            3 => num_rows = Some(prot.read_i64()?),
+            4 => sorting_columns = Some(read_list(prot, read_sorting_column)?),
+            // Inlined skips: these fields have no in-tree consumer.
+            5 => prot.skip_vlq()?, // file_offset (i64)
+            6 => prot.skip_vlq()?, // total_compressed_size (i64)
+            7 => prot.skip_vlq()?, // ordinal (i16)
+            _ => prot.skip(f.field_type)?,
+        }
+        last_field_id = f.id;
+    }
+
+    Ok(CompactRowGroup {
+        columns: columns.require("RowGroup.columns")?,
+        total_byte_size: total_byte_size.require("RowGroup.total_byte_size")?,
+        num_rows: num_rows.require("RowGroup.num_rows")?,
+        sorting_columns,
+    })
+}
+
+/// Decode a `ColumnChunk` into a [`CompactColumnChunk`].
+///
+/// Skip-decode: `file_path`, `file_offset`, encryption fields.
+fn read_column_chunk(
+    prot: &mut ThriftSliceInputProtocol<'_>,
+    origin_ptr: *const u8,
+) -> ParquetResult<CompactColumnChunk> {
+    let mut meta_data: Option<CompactColumnMetaData> = None;
+    let mut offset_index_offset: Option<i64> = None;
+    let mut offset_index_length: Option<i32> = None;
+    let mut column_index_offset: Option<i64> = None;
+    let mut column_index_length: Option<i32> = None;
+
+    let mut last_field_id = 0i16;
+    loop {
+        let f = prot.read_field_begin(last_field_id)?;
+        if f.field_type == FieldType::Stop {
+            break;
+        }
+        match f.id {
+            // Inlined skips for fields polars doesn't consume (hot path: runs
+            // once per column chunk × 200k chunks on wide fixtures).
+            1 => prot.skip_binary()?, // file_path (optional binary)
+            2 => prot.skip_vlq()?,    // file_offset (i64)
+            3 => meta_data = Some(read_column_meta_data(prot, origin_ptr)?),
+            4 => offset_index_offset = Some(prot.read_i64()?),
+            5 => offset_index_length = Some(prot.read_i32()?),
+            6 => column_index_offset = Some(prot.read_i64()?),
+            7 => column_index_length = Some(prot.read_i32()?),
+            // 8/9 (encryption_algorithm, encrypted_column_metadata): rare.
+            _ => prot.skip(f.field_type)?,
+        }
+        last_field_id = f.id;
+    }
+
+    Ok(CompactColumnChunk {
+        meta_data: meta_data.require("ColumnChunk.meta_data")?,
+        offset_index_offset,
+        offset_index_length,
+        column_index_offset,
+        column_index_length,
+    })
+}
+
+/// Decode a `ColumnMetaData` into a [`CompactColumnMetaData`].
+///
+/// Skip-decode: `type_`, `encodings`, `path_in_schema`, `key_value_metadata`,
+/// `encoding_stats`, `size_statistics`, `geospatial_statistics`. These have no
+/// in-tree readers. See `metadata/compact.rs` for the audit.
+fn read_column_meta_data(
+    prot: &mut ThriftSliceInputProtocol<'_>,
+    origin_ptr: *const u8,
+) -> ParquetResult<CompactColumnMetaData> {
+    let mut codec: Option<i32> = None;
+    let mut num_values: Option<i64> = None;
+    let mut total_uncompressed_size: Option<i64> = None;
+    let mut total_compressed_size: Option<i64> = None;
+    let mut data_page_offset: Option<i64> = None;
+    let mut index_page_offset: Option<i64> = None;
+    let mut dictionary_page_offset: Option<i64> = None;
+    let mut statistics: Option<CompactStatistics> = None;
+    let mut bloom_filter_offset: Option<i64> = None;
+    let mut bloom_filter_length: Option<i32> = None;
+
+    let mut last_field_id = 0i16;
+    loop {
+        let f = prot.read_field_begin(last_field_id)?;
+        if f.field_type == FieldType::Stop {
+            break;
+        }
+        match f.id {
+            // Inlined skips for universally-present unused fields, bypasses
+            // the generic recursive `skip_till_depth` on the hot path.
+            1 => prot.skip_vlq()?,            // type_ (i32 enum)
+            2 => prot.skip_list_of_varint()?, // encodings (list<i32>)
+            3 => prot.skip_list_of_binary()?, // path_in_schema (list<binary>)
+            4 => codec = Some(prot.read_i32()?),
+            5 => num_values = Some(prot.read_i64()?),
+            6 => total_uncompressed_size = Some(prot.read_i64()?),
+            7 => total_compressed_size = Some(prot.read_i64()?),
+            // 8 (key_value_metadata): column-level KV, falls through to the
+            // generic `_ => skip(...)` arm below.
+            9 => data_page_offset = Some(prot.read_i64()?),
+            10 => index_page_offset = Some(prot.read_i64()?),
+            11 => dictionary_page_offset = Some(prot.read_i64()?),
+            12 => statistics = Some(read_statistics(prot, origin_ptr)?),
+            14 => bloom_filter_offset = Some(prot.read_i64()?),
+            15 => bloom_filter_length = Some(prot.read_i32()?),
+            // 13 (encoding_stats), 16 (size_statistics), 17 (geospatial):
+            // tried dedicated skip_simple_struct helpers, no measurable win
+            // vs the generic recursive skip (same per-field dispatch cost).
+            _ => prot.skip(f.field_type)?,
+        }
+        last_field_id = f.id;
+    }
+
+    let codec_i32 = codec.require("ColumnMetaData.codec")?;
+    let codec = Compression::try_from(polars_parquet_format::CompressionCodec(codec_i32))?;
+
+    Ok(CompactColumnMetaData {
+        codec,
+        num_values: num_values.require("ColumnMetaData.num_values")?,
+        total_uncompressed_size: total_uncompressed_size
+            .require("ColumnMetaData.total_uncompressed_size")?,
+        total_compressed_size: total_compressed_size
+            .require("ColumnMetaData.total_compressed_size")?,
+        data_page_offset: data_page_offset.require("ColumnMetaData.data_page_offset")?,
+        index_page_offset,
+        dictionary_page_offset,
+        statistics,
+        bloom_filter_offset,
+        bloom_filter_length,
+    })
+}
+
+/// Decode a `Statistics` into a [`CompactStatistics`].
+///
+/// Skip-decode: deprecated `max` / `min` byte vecs (polars reads `max_value` /
+/// `min_value`). Modern values land as [`ByteRange`]s into the shared footer
+/// buffer instead of per-stat `Vec<u8>` allocations.
+fn read_statistics(
+    prot: &mut ThriftSliceInputProtocol<'_>,
+    origin_ptr: *const u8,
+) -> ParquetResult<CompactStatistics> {
+    let mut null_count: Option<i64> = None;
+    let mut distinct_count: Option<i64> = None;
+    let mut max_value: Option<ByteRange> = None;
+    let mut min_value: Option<ByteRange> = None;
+    let mut is_max_value_exact: Option<bool> = None;
+    let mut is_min_value_exact: Option<bool> = None;
+
+    let mut last_field_id = 0i16;
+    loop {
+        let f = prot.read_field_begin(last_field_id)?;
+        if f.field_type == FieldType::Stop {
+            break;
+        }
+        match f.id {
+            // Deprecated max/min (pre-2019 writers). Skip without allocation.
+            1 => prot.skip_binary()?, // max (deprecated)
+            2 => prot.skip_binary()?, // min (deprecated)
+            3 => null_count = Some(prot.read_i64()?),
+            4 => distinct_count = Some(prot.read_i64()?),
+            5 => {
+                // Record (offset, len) into the shared footer; skip the bytes.
+                let len = prot.read_vlq()? as u32;
+                let offset = prot.offset_from(origin_ptr);
+                prot.skip_bytes(len as usize)?;
+                max_value = Some(ByteRange { offset, len });
+            },
+            6 => {
+                let len = prot.read_vlq()? as u32;
+                let offset = prot.offset_from(origin_ptr);
+                prot.skip_bytes(len as usize)?;
+                min_value = Some(ByteRange { offset, len });
+            },
+            7 => is_max_value_exact = Some(f.bool_val.unwrap_or_default()),
+            8 => is_min_value_exact = Some(f.bool_val.unwrap_or_default()),
+            _ => prot.skip(f.field_type)?,
+        }
+        last_field_id = f.id;
+    }
+
+    Ok(CompactStatistics {
+        null_count,
+        distinct_count,
+        max_value,
+        min_value,
+        is_max_value_exact,
+        is_min_value_exact,
+    })
+}
+
+/// Decode a `KeyValue` (kept as format-crate type, polars exposes it directly).
+fn read_key_value(prot: &mut ThriftSliceInputProtocol<'_>) -> ParquetResult<KeyValue> {
+    let mut key: Option<String> = None;
+    let mut value: Option<String> = None;
+
+    let mut last_field_id = 0i16;
+    loop {
+        let f = prot.read_field_begin(last_field_id)?;
+        if f.field_type == FieldType::Stop {
+            break;
+        }
+        match f.id {
+            1 => key = Some(prot.read_string()?.to_owned()),
+            2 => value = Some(prot.read_string()?.to_owned()),
+            _ => prot.skip(f.field_type)?,
+        }
+        last_field_id = f.id;
+    }
+
+    Ok(KeyValue {
+        key: key.require("KeyValue.key")?,
+        value,
+    })
+}
+
+/// Decode a `SortingColumn` (kept as format-crate type, polars exposes it directly).
+fn read_sorting_column(prot: &mut ThriftSliceInputProtocol<'_>) -> ParquetResult<SortingColumn> {
+    let mut column_idx: Option<i32> = None;
+    let mut descending: Option<bool> = None;
+    let mut nulls_first: Option<bool> = None;
+
+    let mut last_field_id = 0i16;
+    loop {
+        let f = prot.read_field_begin(last_field_id)?;
+        if f.field_type == FieldType::Stop {
+            break;
+        }
+        match f.id {
+            1 => column_idx = Some(prot.read_i32()?),
+            2 => descending = Some(f.bool_val.unwrap_or_default()),
+            3 => nulls_first = Some(f.bool_val.unwrap_or_default()),
+            _ => prot.skip(f.field_type)?,
+        }
+        last_field_id = f.id;
+    }
+
+    Ok(SortingColumn {
+        column_idx: column_idx.require("SortingColumn.column_idx")?,
+        descending: descending.require("SortingColumn.descending")?,
+        nulls_first: nulls_first.require("SortingColumn.nulls_first")?,
+    })
+}
+
+/// Decode a `ColumnOrder` union (kept as format-crate type).
+///
+/// Thrift definition: `union ColumnOrder { 1: TypeDefinedOrder TYPE_ORDER }`.
+fn read_column_order(prot: &mut ThriftSliceInputProtocol<'_>) -> ParquetResult<ColumnOrder> {
+    use polars_parquet_format::TypeDefinedOrder;
+
+    let mut ret: Option<ColumnOrder> = None;
+    let mut last_field_id = 0i16;
+    loop {
+        let f = prot.read_field_begin(last_field_id)?;
+        if f.field_type == FieldType::Stop {
+            break;
+        }
+        match f.id {
+            1 => {
+                read_empty_struct(prot)?;
+                ret.get_or_insert(ColumnOrder::TYPEORDER(TypeDefinedOrder {}));
+            },
+            _ => prot.skip(f.field_type)?,
+        }
+        last_field_id = f.id;
+    }
+    ret.ok_or_else(|| ParquetError::oos("ColumnOrder union has no variant set"))
+}
+
+/// Decode a `LogicalType` union.
+///
+/// Kept as `polars_parquet_format::LogicalType` so polars's `SchemaElement`
+/// consumer (`SchemaDescriptor::try_from_thrift`) sees the same shape it
+/// always has.
+fn read_logical_type(
+    prot: &mut ThriftSliceInputProtocol<'_>,
+) -> ParquetResult<polars_parquet_format::LogicalType> {
+    use polars_parquet_format::{
+        BsonType, DateType, EnumType, Float16Type, JsonType, ListType, LogicalType, MapType,
+        NullType, StringType, UUIDType,
+    };
+
+    let mut ret: Option<LogicalType> = None;
+    let mut last_field_id = 0i16;
+    loop {
+        let f = prot.read_field_begin(last_field_id)?;
+        if f.field_type == FieldType::Stop {
+            break;
+        }
+        match f.id {
+            1 => {
+                read_empty_struct(prot)?;
+                ret.get_or_insert(LogicalType::STRING(StringType {}));
+            },
+            2 => {
+                read_empty_struct(prot)?;
+                ret.get_or_insert(LogicalType::MAP(MapType {}));
+            },
+            3 => {
+                read_empty_struct(prot)?;
+                ret.get_or_insert(LogicalType::LIST(ListType {}));
+            },
+            4 => {
+                read_empty_struct(prot)?;
+                ret.get_or_insert(LogicalType::ENUM(EnumType {}));
+            },
+            5 => {
+                let v = read_decimal_type(prot)?;
+                ret.get_or_insert(LogicalType::DECIMAL(v));
+            },
+            6 => {
+                read_empty_struct(prot)?;
+                ret.get_or_insert(LogicalType::DATE(DateType {}));
+            },
+            7 => {
+                let v = read_time_type(prot)?;
+                ret.get_or_insert(LogicalType::TIME(v));
+            },
+            8 => {
+                let v = read_timestamp_type(prot)?;
+                ret.get_or_insert(LogicalType::TIMESTAMP(v));
+            },
+            10 => {
+                let v = read_int_type(prot)?;
+                ret.get_or_insert(LogicalType::INTEGER(v));
+            },
+            11 => {
+                read_empty_struct(prot)?;
+                ret.get_or_insert(LogicalType::UNKNOWN(NullType {}));
+            },
+            12 => {
+                read_empty_struct(prot)?;
+                ret.get_or_insert(LogicalType::JSON(JsonType {}));
+            },
+            13 => {
+                read_empty_struct(prot)?;
+                ret.get_or_insert(LogicalType::BSON(BsonType {}));
+            },
+            14 => {
+                read_empty_struct(prot)?;
+                ret.get_or_insert(LogicalType::UUID(UUIDType {}));
+            },
+            15 => {
+                read_empty_struct(prot)?;
+                ret.get_or_insert(LogicalType::FLOAT16(Float16Type {}));
+            },
+            _ => prot.skip(f.field_type)?,
+        }
+        last_field_id = f.id;
+    }
+    ret.ok_or_else(|| ParquetError::oos("LogicalType union has no variant set"))
+}
+
+fn read_empty_struct(prot: &mut ThriftSliceInputProtocol<'_>) -> ParquetResult<()> {
+    let mut last_field_id = 0i16;
+    loop {
+        let f = prot.read_field_begin(last_field_id)?;
+        if f.field_type == FieldType::Stop {
+            return Ok(());
+        }
+        prot.skip(f.field_type)?;
+        last_field_id = f.id;
+    }
+}
+
+fn read_decimal_type(
+    prot: &mut ThriftSliceInputProtocol<'_>,
+) -> ParquetResult<polars_parquet_format::DecimalType> {
+    use polars_parquet_format::DecimalType;
+    let mut scale: Option<i32> = None;
+    let mut precision: Option<i32> = None;
+    let mut last_field_id = 0i16;
+    loop {
+        let f = prot.read_field_begin(last_field_id)?;
+        if f.field_type == FieldType::Stop {
+            break;
+        }
+        match f.id {
+            1 => scale = Some(prot.read_i32()?),
+            2 => precision = Some(prot.read_i32()?),
+            _ => prot.skip(f.field_type)?,
+        }
+        last_field_id = f.id;
+    }
+    Ok(DecimalType {
+        scale: scale.require("DecimalType.scale")?,
+        precision: precision.require("DecimalType.precision")?,
+    })
+}
+
+fn read_time_unit(
+    prot: &mut ThriftSliceInputProtocol<'_>,
+) -> ParquetResult<polars_parquet_format::TimeUnit> {
+    use polars_parquet_format::{MicroSeconds, MilliSeconds, NanoSeconds, TimeUnit};
+    let mut ret: Option<TimeUnit> = None;
+    let mut last_field_id = 0i16;
+    loop {
+        let f = prot.read_field_begin(last_field_id)?;
+        if f.field_type == FieldType::Stop {
+            break;
+        }
+        match f.id {
+            1 => {
+                read_empty_struct(prot)?;
+                ret.get_or_insert(TimeUnit::MILLIS(MilliSeconds {}));
+            },
+            2 => {
+                read_empty_struct(prot)?;
+                ret.get_or_insert(TimeUnit::MICROS(MicroSeconds {}));
+            },
+            3 => {
+                read_empty_struct(prot)?;
+                ret.get_or_insert(TimeUnit::NANOS(NanoSeconds {}));
+            },
+            _ => prot.skip(f.field_type)?,
+        }
+        last_field_id = f.id;
+    }
+    ret.ok_or_else(|| ParquetError::oos("TimeUnit union has no variant set"))
+}
+
+fn read_time_type(
+    prot: &mut ThriftSliceInputProtocol<'_>,
+) -> ParquetResult<polars_parquet_format::TimeType> {
+    use polars_parquet_format::TimeType;
+    let mut is_adjusted: Option<bool> = None;
+    let mut unit: Option<polars_parquet_format::TimeUnit> = None;
+    let mut last_field_id = 0i16;
+    loop {
+        let f = prot.read_field_begin(last_field_id)?;
+        if f.field_type == FieldType::Stop {
+            break;
+        }
+        match f.id {
+            1 => is_adjusted = Some(f.bool_val.unwrap_or_default()),
+            2 => unit = Some(read_time_unit(prot)?),
+            _ => prot.skip(f.field_type)?,
+        }
+        last_field_id = f.id;
+    }
+    Ok(TimeType {
+        is_adjusted_to_u_t_c: is_adjusted.require("TimeType.is_adjusted_to_u_t_c")?,
+        unit: unit.require("TimeType.unit")?,
+    })
+}
+
+fn read_timestamp_type(
+    prot: &mut ThriftSliceInputProtocol<'_>,
+) -> ParquetResult<polars_parquet_format::TimestampType> {
+    use polars_parquet_format::TimestampType;
+    let mut is_adjusted: Option<bool> = None;
+    let mut unit: Option<polars_parquet_format::TimeUnit> = None;
+    let mut last_field_id = 0i16;
+    loop {
+        let f = prot.read_field_begin(last_field_id)?;
+        if f.field_type == FieldType::Stop {
+            break;
+        }
+        match f.id {
+            1 => is_adjusted = Some(f.bool_val.unwrap_or_default()),
+            2 => unit = Some(read_time_unit(prot)?),
+            _ => prot.skip(f.field_type)?,
+        }
+        last_field_id = f.id;
+    }
+    Ok(TimestampType {
+        is_adjusted_to_u_t_c: is_adjusted.require("TimestampType.is_adjusted_to_u_t_c")?,
+        unit: unit.require("TimestampType.unit")?,
+    })
+}
+
+fn read_int_type(
+    prot: &mut ThriftSliceInputProtocol<'_>,
+) -> ParquetResult<polars_parquet_format::IntType> {
+    use polars_parquet_format::IntType;
+    let mut bit_width: Option<i8> = None;
+    let mut is_signed: Option<bool> = None;
+    let mut last_field_id = 0i16;
+    loop {
+        let f = prot.read_field_begin(last_field_id)?;
+        if f.field_type == FieldType::Stop {
+            break;
+        }
+        match f.id {
+            1 => bit_width = Some(prot.read_i8()?),
+            2 => is_signed = Some(f.bool_val.unwrap_or_default()),
+            _ => prot.skip(f.field_type)?,
+        }
+        last_field_id = f.id;
+    }
+    Ok(IntType {
+        bit_width: bit_width.require("IntType.bit_width")?,
+        is_signed: is_signed.require("IntType.is_signed")?,
+    })
+}

--- a/crates/polars-parquet/src/parquet/handwritten_thrift/file_metadata_thrift.rs
+++ b/crates/polars-parquet/src/parquet/handwritten_thrift/file_metadata_thrift.rs
@@ -8,6 +8,8 @@
 //!   offsets into the input buffer rather than per-stat `Vec<u8>` allocations.
 //!   The caller passes the footer as [`Buffer<u8>`] so those offsets stay
 //!   resolvable for the lifetime of the resulting metadata.
+//!
+//!   See <https://github.com/apache/parquet-format/blob/96edf77704b60b6f3ca2232c218c64eff6c874d3/src/main/thrift/parquet.thrift> for spec
 
 use polars_buffer::Buffer;
 use polars_parquet_format::{ColumnOrder, KeyValue, SchemaElement, SortingColumn};

--- a/crates/polars-parquet/src/parquet/handwritten_thrift/mod.rs
+++ b/crates/polars-parquet/src/parquet/handwritten_thrift/mod.rs
@@ -1,0 +1,17 @@
+//! Hand-written Thrift compact decoders, ported from apache/arrow-rs 57.0.
+//!
+//! Replaces the generic `polars_parquet_format::thrift::TCompactInputProtocol`
+//! on the file-metadata footer decode path. Page-header and PageIndex decode
+//! still go through the generic codec. Porting those is a follow-up task.
+
+// `#[macro_use]` brings the `thrift_struct!` / `thrift_union!` / `thrift_enum!`
+// / `write_thrift_field!` / `__thrift_*` macros into scope for sibling modules
+// *before* they compile. Needed because `parquet_thrift.rs` uses
+// `write_thrift_field!`; without this ordering macro resolution fails at
+// `write_thrift_field!(i8, FieldType::Byte);` etc.
+#[macro_use]
+mod parquet_macros;
+mod file_metadata_thrift;
+mod parquet_thrift;
+
+pub(crate) use file_metadata_thrift::decode_file_metadata;

--- a/crates/polars-parquet/src/parquet/handwritten_thrift/parquet_macros.rs
+++ b/crates/polars-parquet/src/parquet/handwritten_thrift/parquet_macros.rs
@@ -1,0 +1,500 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// These macros are adapted from Jörn Horstmann's thrift macros at
+// https://github.com/jhorstmann/compact-thrift
+// They allow for pasting sections of the Parquet thrift IDL file
+// into a macro to generate rust structures and implementations.
+
+//! This is a collection of macros used to parse Thrift IDL descriptions of structs,
+//! unions, and enums into their corresponding Rust types. These macros will also
+//! generate the code necessary to serialize and deserialize to/from the [Thrift compact]
+//! protocol.
+//!
+//! Further details of how to use them (and other aspects of the Thrift serialization process)
+//! can be found in [THRIFT.md].
+//!
+//! [Thrift compact]: https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md#list-and-set
+//! [THRIFT.md]: https://github.com/apache/arrow-rs/blob/main/parquet/THRIFT.md
+
+#[doc(hidden)]
+#[macro_export]
+#[allow(clippy::crate_in_macro_def)]
+/// Macro used to generate rust enums from a Thrift `enum` definition.
+///
+/// When utilizing this macro the Thrift serialization traits and structs need to be in scope.
+macro_rules! thrift_enum {
+    ($(#[$($def_attrs:tt)*])* enum $identifier:ident { $($(#[$($field_attrs:tt)*])* $field_name:ident = $field_value:literal;)* }) => {
+        $(#[$($def_attrs)*])*
+        #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+        #[allow(non_camel_case_types)]
+        #[allow(missing_docs)]
+        pub enum $identifier {
+            $($(#[cfg_attr(not(doctest), $($field_attrs)*)])* $field_name = $field_value,)*
+        }
+
+        impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for $identifier {
+            #[allow(deprecated)]
+            fn read_thrift(prot: &mut R) -> Result<Self> {
+                let val = prot.read_i32()?;
+                match val {
+                    $($field_value => Ok(Self::$field_name),)*
+                    _ => Err(general_err!("Unexpected {} {}", stringify!($identifier), val)),
+                }
+            }
+        }
+
+        impl fmt::Display for $identifier {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "{self:?}")
+            }
+        }
+
+        impl WriteThrift for $identifier {
+            const ELEMENT_TYPE: ElementType = ElementType::I32;
+
+            fn write_thrift<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>) -> Result<()> {
+                writer.write_i32(*self as i32)
+            }
+        }
+
+        impl WriteThriftField for $identifier {
+            fn write_thrift_field<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>, field_id: i16, last_field_id: i16) -> Result<i16> {
+                writer.write_field_begin(FieldType::I32, field_id, last_field_id)?;
+                self.write_thrift(writer)?;
+                Ok(field_id)
+            }
+        }
+    }
+}
+
+/// Macro used to generate Rust enums for Thrift unions in which all variants are typed with empty
+/// structs.
+///
+/// Because the compact protocol does not write any struct type information, these empty structs
+/// become a single `0` (end-of-fields marker) upon serialization. Rather than trying to deserialize
+/// an empty struct, we can instead simply read the `0` and discard it.
+///
+/// The resulting Rust enum will have all unit variants.
+///
+/// When utilizing this macro the Thrift serialization traits and structs need to be in scope.
+#[doc(hidden)]
+#[macro_export]
+#[allow(clippy::crate_in_macro_def)]
+macro_rules! thrift_union_all_empty {
+    ($(#[$($def_attrs:tt)*])* union $identifier:ident { $($(#[$($field_attrs:tt)*])* $field_id:literal : $field_type:ident $(< $element_type:ident >)? $field_name:ident $(;)?)* }) => {
+        $(#[cfg_attr(not(doctest), $($def_attrs)*)])*
+        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        #[allow(non_camel_case_types)]
+        #[allow(non_snake_case)]
+        #[allow(missing_docs)]
+        pub enum $identifier {
+            $($(#[cfg_attr(not(doctest), $($field_attrs)*)])* $field_name),*
+        }
+
+        impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for $identifier {
+            fn read_thrift(prot: &mut R) -> Result<Self> {
+                let field_ident = prot.read_field_begin(0)?;
+                if field_ident.field_type == FieldType::Stop {
+                    return Err(general_err!("Received empty union from remote {}", stringify!($identifier)));
+                }
+                let ret = match field_ident.id {
+                    $($field_id => {
+                        prot.skip_empty_struct()?;
+                        Self::$field_name
+                    }
+                    )*
+                    _ => {
+                        return Err(general_err!("Unexpected {} {}", stringify!($identifier), field_ident.id));
+                    }
+                };
+                let field_ident = prot.read_field_begin(field_ident.id)?;
+                if field_ident.field_type != FieldType::Stop {
+                    return Err(general_err!(
+                        "Received multiple fields for union from remote {}", stringify!($identifier)
+                    ));
+                }
+                Ok(ret)
+            }
+        }
+
+        impl WriteThrift for $identifier {
+            const ELEMENT_TYPE: ElementType = ElementType::Struct;
+
+            fn write_thrift<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>) -> Result<()> {
+                match *self {
+                    $(Self::$field_name => writer.write_empty_struct($field_id, 0)?,)*
+                };
+                // write end of struct for this union
+                writer.write_struct_end()
+            }
+        }
+
+        impl WriteThriftField for $identifier {
+            fn write_thrift_field<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>, field_id: i16, last_field_id: i16) -> Result<i16> {
+                writer.write_field_begin(FieldType::Struct, field_id, last_field_id)?;
+                self.write_thrift(writer)?;
+                Ok(field_id)
+            }
+        }
+    }
+}
+
+/// Macro used to generate Rust enums for Thrift unions where variants are a mix of unit and
+/// tuple types.
+///
+/// Use of this macro requires modifying the thrift IDL. For variants with empty structs as their
+/// type, delete the typename (i.e. `1: EmptyStruct Var1;` becomes `1: Var1`). For variants with a
+/// non-empty type, the typename must be contained within parens (e.g. `1: MyType Var1;` becomes
+/// `1: (MyType) Var1;`).
+///
+/// This macro allows for specifying lifetime annotations for the resulting `enum` and its fields.
+///
+/// When utilizing this macro the Thrift serialization traits and structs need to be in scope.
+#[doc(hidden)]
+#[macro_export]
+#[allow(clippy::crate_in_macro_def)]
+macro_rules! thrift_union {
+    ($(#[$($def_attrs:tt)*])* union $identifier:ident $(< $lt:lifetime >)? { $($(#[$($field_attrs:tt)*])* $field_id:literal : $( ( $field_type:ident $(< $element_type:ident >)? $(< $field_lt:lifetime >)?) )? $field_name:ident $(;)?)* }) => {
+        $(#[cfg_attr(not(doctest), $($def_attrs)*)])*
+        #[derive(Clone, Debug, Eq, PartialEq)]
+        #[allow(non_camel_case_types)]
+        #[allow(non_snake_case)]
+        #[allow(missing_docs)]
+        pub enum $identifier $(<$lt>)? {
+            $($(#[cfg_attr(not(doctest), $($field_attrs)*)])* $field_name $( ( $crate::__thrift_union_type!{$field_type $($field_lt)? $($element_type)?} ) )?),*
+        }
+
+        impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for $identifier $(<$lt>)? {
+            fn read_thrift(prot: &mut R) -> Result<Self> {
+                let field_ident = prot.read_field_begin(0)?;
+                if field_ident.field_type == FieldType::Stop {
+                    return Err(general_err!("Received empty union from remote {}", stringify!($identifier)));
+                }
+                let ret = match field_ident.id {
+                    $($field_id => {
+                        let val = $crate::__thrift_read_variant!(prot, $field_name $($field_type $($element_type)?)?);
+                        val
+                    })*
+                    _ => {
+                        return Err(general_err!("Unexpected {} {}", stringify!($identifier), field_ident.id));
+                    }
+                };
+                let field_ident = prot.read_field_begin(field_ident.id)?;
+                if field_ident.field_type != FieldType::Stop {
+                    return Err(general_err!(
+                        concat!("Received multiple fields for union from remote {}", stringify!($identifier))
+                    ));
+                }
+                Ok(ret)
+            }
+        }
+
+        impl $(<$lt>)? WriteThrift for $identifier $(<$lt>)? {
+            const ELEMENT_TYPE: ElementType = ElementType::Struct;
+
+            fn write_thrift<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>) -> Result<()> {
+                match self {
+                    $($crate::__thrift_write_variant_lhs!($field_name $($field_type)?, variant_val) =>
+                      $crate::__thrift_write_variant_rhs!($field_id $($field_type)?, writer, variant_val),)*
+                };
+                writer.write_struct_end()
+            }
+        }
+
+        impl $(<$lt>)? WriteThriftField for $identifier $(<$lt>)? {
+            fn write_thrift_field<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>, field_id: i16, last_field_id: i16) -> Result<i16> {
+                writer.write_field_begin(FieldType::Struct, field_id, last_field_id)?;
+                self.write_thrift(writer)?;
+                Ok(field_id)
+            }
+        }
+    }
+}
+
+/// Macro used to generate Rust structs from a Thrift `struct` definition.
+///
+/// This macro allows for specifying lifetime annotations for the resulting `struct` and its fields.
+///
+/// When utilizing this macro the Thrift serialization traits and structs need to be in scope.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! thrift_struct {
+    ($(#[$($def_attrs:tt)*])* $vis:vis struct $identifier:ident $(< $lt:lifetime >)? { $($(#[$($field_attrs:tt)*])* $field_id:literal : $required_or_optional:ident $field_type:ident $(< $field_lt:lifetime >)? $(< $element_type:ident >)? $field_name:ident $(= $default_value:literal)? $(;)?)* }) => {
+        $(#[cfg_attr(not(doctest), $($def_attrs)*)])*
+        #[derive(Clone, Debug, Eq, PartialEq)]
+        #[allow(non_camel_case_types)]
+        #[allow(non_snake_case)]
+        #[allow(missing_docs)]
+        $vis struct $identifier $(<$lt>)? {
+            $($(#[cfg_attr(not(doctest), $($field_attrs)*)])* $vis $field_name: $crate::__thrift_required_or_optional!($required_or_optional $crate::__thrift_field_type!($field_type $($field_lt)? $($element_type)?))),*
+        }
+
+        impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for $identifier $(<$lt>)? {
+            fn read_thrift(prot: &mut R) -> Result<Self> {
+                $(let mut $field_name: Option<$crate::__thrift_field_type!($field_type $($field_lt)? $($element_type)?)> = None;)*
+                let mut last_field_id = 0i16;
+                loop {
+                    let field_ident = prot.read_field_begin(last_field_id)?;
+                    if field_ident.field_type == FieldType::Stop {
+                        break;
+                    }
+                    match field_ident.id {
+                        $($field_id => {
+                            let val = $crate::__thrift_read_field!(prot, field_ident, $field_type $($field_lt)? $($element_type)?);
+                            $field_name = Some(val);
+                        })*
+                        _ => {
+                            prot.skip(field_ident.field_type)?;
+                        }
+                    };
+                    last_field_id = field_ident.id;
+                }
+                $($crate::__thrift_result_required_or_optional!($required_or_optional $field_name);)*
+                Ok(Self {
+                    $($field_name),*
+                })
+            }
+        }
+
+        impl $(<$lt>)? WriteThrift for $identifier $(<$lt>)? {
+            const ELEMENT_TYPE: ElementType = ElementType::Struct;
+
+            #[allow(unused_assignments)]
+            fn write_thrift<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>) -> Result<()> {
+                #[allow(unused_mut, unused_variables)]
+                let mut last_field_id = 0i16;
+                $($crate::__thrift_write_required_or_optional_field!($required_or_optional $field_name, $field_id, $field_type, self, writer, last_field_id);)*
+                writer.write_struct_end()
+            }
+        }
+
+        impl $(<$lt>)? WriteThriftField for $identifier $(<$lt>)? {
+            fn write_thrift_field<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>, field_id: i16, last_field_id: i16) -> Result<i16> {
+                writer.write_field_begin(FieldType::Struct, field_id, last_field_id)?;
+                self.write_thrift(writer)?;
+                Ok(field_id)
+            }
+        }
+    }
+}
+
+#[doc(hidden)]
+#[macro_export]
+/// Generate `WriteThriftField` implementation for a struct.
+macro_rules! write_thrift_field {
+    ($identifier:ident $(< $lt:lifetime >)?, $fld_type:expr) => {
+        impl $(<$lt>)? WriteThriftField for $identifier $(<$lt>)? {
+            fn write_thrift_field<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>, field_id: i16, last_field_id: i16) -> Result<i16> {
+                writer.write_field_begin($fld_type, field_id, last_field_id)?;
+                self.write_thrift(writer)?;
+                Ok(field_id)
+            }
+        }
+    }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __thrift_write_required_or_optional_field {
+    (required $field_name:ident, $field_id:literal, $field_type:ident, $self:tt, $writer:tt, $last_id:tt) => {
+        $crate::__thrift_write_required_field!(
+            $field_type,
+            $field_name,
+            $field_id,
+            $self,
+            $writer,
+            $last_id
+        )
+    };
+    (optional $field_name:ident, $field_id:literal, $field_type:ident, $self:tt, $writer:tt, $last_id:tt) => {
+        $crate::__thrift_write_optional_field!(
+            $field_type,
+            $field_name,
+            $field_id,
+            $self,
+            $writer,
+            $last_id
+        )
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __thrift_write_required_field {
+    (binary, $field_name:ident, $field_id:literal, $self:ident, $writer:ident, $last_id:ident) => {
+        $writer.write_field_begin(FieldType::Binary, $field_id, $last_id)?;
+        $writer.write_bytes($self.$field_name)?;
+        $last_id = $field_id;
+    };
+    ($field_type:ident, $field_name:ident, $field_id:literal, $self:ident, $writer:ident, $last_id:ident) => {
+        $last_id = $self
+            .$field_name
+            .write_thrift_field($writer, $field_id, $last_id)?;
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __thrift_write_optional_field {
+    (binary, $field_name:ident, $field_id:literal, $self:ident, $writer:tt, $last_id:tt) => {
+        if $self.$field_name.is_some() {
+            $writer.write_field_begin(FieldType::Binary, $field_id, $last_id)?;
+            $writer.write_bytes($self.$field_name.as_ref().unwrap())?;
+            $last_id = $field_id;
+        }
+    };
+    ($field_type:ident, $field_name:ident, $field_id:literal, $self:ident, $writer:tt, $last_id:tt) => {
+        if $self.$field_name.is_some() {
+            $last_id = $self
+                .$field_name
+                .as_ref()
+                .unwrap()
+                .write_thrift_field($writer, $field_id, $last_id)?;
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __thrift_required_or_optional {
+    (required $field_type:ty) => { $field_type };
+    (optional $field_type:ty) => { Option<$field_type> };
+}
+
+// Performance note: using `expect` here is about 4% faster on the page index bench,
+// but we want to propagate errors. Using `ok_or` is *much* slower.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __thrift_result_required_or_optional {
+    (required $field_name:ident) => {
+        let Some($field_name) = $field_name else {
+            return Err(general_err!(concat!(
+                "Required field ",
+                stringify!($field_name),
+                " is missing",
+            )));
+        };
+    };
+    (optional $field_name:ident) => {};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __thrift_read_field {
+    ($prot:tt, $field_ident:tt, list $lt:lifetime binary) => {
+        read_thrift_vec::<&'a [u8], R>(&mut *$prot)?
+    };
+    ($prot:tt, $field_ident:tt, list $lt:lifetime $element_type:ident) => {
+        read_thrift_vec::<$element_type, R>(&mut *$prot)?
+    };
+    ($prot:tt, $field_ident:tt, list string) => {
+        read_thrift_vec::<String, R>(&mut *$prot)?
+    };
+    ($prot:tt, $field_ident:tt, list $element_type:ident) => {
+        read_thrift_vec::<$element_type, R>(&mut *$prot)?
+    };
+    ($prot:tt, $field_ident:tt, string $lt:lifetime) => {
+        <&$lt str>::read_thrift(&mut *$prot)?
+    };
+    ($prot:tt, $field_ident:tt, binary $lt:lifetime) => {
+        <&$lt [u8]>::read_thrift(&mut *$prot)?
+    };
+    ($prot:tt, $field_ident:tt, $field_type:ident $lt:lifetime) => {
+        $field_type::read_thrift(&mut *$prot)?
+    };
+    ($prot:tt, $field_ident:tt, string) => {
+        String::read_thrift(&mut *$prot)?
+    };
+    ($prot:tt, $field_ident:tt, binary) => {
+        // this one needs to not conflict with `list<i8>`
+        $prot.read_bytes_owned()?
+    };
+    ($prot:tt, $field_ident:tt, double) => {
+        // Polars integration: arrow puts `parquet_thrift` at crate root; polars nests it.
+        $crate::parquet::handwritten_thrift::parquet_thrift::OrderedF64::read_thrift(&mut *$prot)?
+    };
+    ($prot:tt, $field_ident:tt, bool) => {
+        $field_ident.bool_val.unwrap()
+    };
+    ($prot:tt, $field_ident:tt, $field_type:ident) => {
+        $field_type::read_thrift(&mut *$prot)?
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __thrift_field_type {
+    (binary $lt:lifetime) => { &$lt [u8] };
+    (string $lt:lifetime) => { &$lt str };
+    ($field_type:ident $lt:lifetime) => { $field_type<$lt> };
+    (list $lt:lifetime $element_type:ident) => { Vec< $crate::__thrift_field_type!($element_type $lt) > };
+    (list string) => { Vec<String> };
+    (list $element_type:ident) => { Vec< $crate::__thrift_field_type!($element_type) > };
+    (binary) => { Vec<u8> };
+    (string) => { String };
+    // Polars integration: arrow puts `parquet_thrift` at crate root; polars nests it.
+    (double) => { $crate::parquet::handwritten_thrift::parquet_thrift::OrderedF64 };
+    ($field_type:ty) => { $field_type };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __thrift_union_type {
+    (binary $lt:lifetime) => { &$lt [u8] };
+    (string $lt:lifetime) => { &$lt str };
+    ($field_type:ident $lt:lifetime) => { $field_type<$lt> };
+    ($field_type:ident) => { $field_type };
+    (list $field_type:ident) => { Vec<$field_type> };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __thrift_read_variant {
+    ($prot:tt, $field_name:ident $field_type:ident) => {
+        Self::$field_name($field_type::read_thrift(&mut *$prot)?)
+    };
+    ($prot:tt, $field_name:ident list $field_type:ident) => {
+        Self::$field_name(Vec::<$field_type>::read_thrift(&mut *$prot)?)
+    };
+    ($prot:tt, $field_name:ident) => {{
+        $prot.skip_empty_struct()?;
+        Self::$field_name
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __thrift_write_variant_lhs {
+    ($field_name:ident $field_type:ident, $val:tt) => {
+        Self::$field_name($val)
+    };
+    ($field_name:ident, $val:tt) => {
+        Self::$field_name
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __thrift_write_variant_rhs {
+    ($field_id:literal $field_type:ident, $writer:tt, $val:ident) => {
+        $val.write_thrift_field($writer, $field_id, 0)?
+    };
+    ($field_id:literal, $writer:tt, $val:tt) => {
+        $writer.write_empty_struct($field_id, 0)?
+    };
+}

--- a/crates/polars-parquet/src/parquet/handwritten_thrift/parquet_thrift.rs
+++ b/crates/polars-parquet/src/parquet/handwritten_thrift/parquet_thrift.rs
@@ -1,0 +1,1144 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Verbatim arrow-rs 57.0 port (see module docs in `mod.rs`). Polars wires only
+// the read-side primitives into the file-metadata decoder; the write-side
+// primitives + `ThriftReadInputProtocol` + `ReadThrift` macros stay byte-identical
+// to arrow-rs for future re-ports but are unused in this build. Allow the
+// resulting dead-code / private-interfaces lints at the module boundary so the
+// source body itself remains an unmodified copy of arrow-rs.
+#![allow(dead_code, private_interfaces)]
+
+//! Structs used for encoding and decoding Parquet Thrift objects.
+//!
+//! These include:
+//! * [`ThriftCompactInputProtocol`]: Trait implemented by Thrift decoders.
+//!     * [`ThriftSliceInputProtocol`]: Thrift decoder that takes a slice of bytes as input.
+//!     * [`ThriftReadInputProtocol`]: Thrift decoder that takes a [`Read`] as input.
+//! * [`ReadThrift`]: Trait implemented by serializable objects.
+//! * [`ThriftCompactOutputProtocol`]: Thrift encoder.
+//! * [`WriteThrift`]: Trait implemented by serializable objects.
+//! * [`WriteThriftField`]: Trait implemented by serializable objects that are fields in Thrift structs.
+
+use std::cmp::Ordering;
+// `write_thrift_field!` is defined in the sibling `parquet_macros` module and
+// registered at crate root via `#[macro_export]`, so it resolves unqualified
+// in this file. No explicit `use` needed.
+use std::io::Error;
+use std::io::{Read, Write};
+use std::str::Utf8Error;
+
+// Polars integration shim. Arrow exposes `crate::errors::{ParquetError, Result}`
+// at crate root; polars keeps them under `parquet::error`. Bound under the same
+// names so the rest of this file stays byte-identical to arrow-rs 57.0.
+use crate::parquet::error::{ParquetError, ParquetResult as Result};
+
+// Polars doesn't carry arrow's `general_err!` / `eof_err!`. File-local shims
+// produce the same `ParquetError::OutOfSpec(format!(...))` value arrow's
+// versions construct.
+macro_rules! general_err {
+    ($($arg:tt)*) => { $crate::parquet::error::ParquetError::oos(format!($($arg)*)) };
+}
+macro_rules! eof_err {
+    ($($arg:tt)*) => { $crate::parquet::error::ParquetError::oos(format!($($arg)*)) };
+}
+
+#[derive(Debug)]
+pub(crate) enum ThriftProtocolError {
+    Eof,
+    IO(Error),
+    InvalidFieldType(u8),
+    InvalidElementType(u8),
+    FieldDeltaOverflow { field_delta: u8, last_field_id: i16 },
+    InvalidBoolean(u8),
+    Utf8Error,
+    SkipDepth(FieldType),
+    SkipUnsupportedType(FieldType),
+}
+
+impl From<ThriftProtocolError> for ParquetError {
+    #[inline(never)]
+    fn from(e: ThriftProtocolError) -> Self {
+        match e {
+            ThriftProtocolError::Eof => eof_err!("Unexpected EOF"),
+            ThriftProtocolError::IO(e) => e.into(),
+            ThriftProtocolError::InvalidFieldType(value) => {
+                general_err!("Unexpected struct field type {}", value)
+            },
+            ThriftProtocolError::InvalidElementType(value) => {
+                general_err!("Unexpected list/set element type{}", value)
+            },
+            ThriftProtocolError::FieldDeltaOverflow {
+                field_delta,
+                last_field_id,
+            } => general_err!("cannot add {} to {}", field_delta, last_field_id),
+            ThriftProtocolError::InvalidBoolean(value) => {
+                general_err!("cannot convert {} into bool", value)
+            },
+            ThriftProtocolError::Utf8Error => general_err!("invalid utf8"),
+            ThriftProtocolError::SkipDepth(field_type) => {
+                general_err!("cannot parse past {:?}", field_type)
+            },
+            ThriftProtocolError::SkipUnsupportedType(field_type) => {
+                general_err!("cannot skip field type {:?}", field_type)
+            },
+        }
+    }
+}
+
+impl From<Utf8Error> for ThriftProtocolError {
+    fn from(_: Utf8Error) -> Self {
+        // ignore error payload to reduce the size of ThriftProtocolError
+        Self::Utf8Error
+    }
+}
+
+impl From<Error> for ThriftProtocolError {
+    fn from(e: Error) -> Self {
+        Self::IO(e)
+    }
+}
+
+// Arrow writes `Result<T, ThriftProtocolError>` here, relying on its two-arg
+// `std::result::Result` alias. Our local `Result = ParquetResult<T>` takes
+// one arg, so spell `std::result::Result` explicitly for this one alias.
+pub type ThriftProtocolResult<T> = std::result::Result<T, ThriftProtocolError>;
+
+/// Wrapper for thrift `double` fields. This is used to provide
+/// an implementation of `Eq` for floats. This implementation
+/// uses IEEE 754 total order.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct OrderedF64(f64);
+
+impl From<f64> for OrderedF64 {
+    fn from(value: f64) -> Self {
+        Self(value)
+    }
+}
+
+impl From<OrderedF64> for f64 {
+    fn from(value: OrderedF64) -> Self {
+        value.0
+    }
+}
+
+impl Eq for OrderedF64 {} // Marker trait, requires PartialEq
+
+impl Ord for OrderedF64 {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.total_cmp(&other.0)
+    }
+}
+
+impl PartialOrd for OrderedF64 {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+// Thrift compact protocol types for struct fields.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum FieldType {
+    Stop = 0,
+    BooleanTrue = 1,
+    BooleanFalse = 2,
+    Byte = 3,
+    I16 = 4,
+    I32 = 5,
+    I64 = 6,
+    Double = 7,
+    Binary = 8,
+    List = 9,
+    Set = 10,
+    Map = 11,
+    Struct = 12,
+}
+
+impl TryFrom<u8> for FieldType {
+    type Error = ThriftProtocolError;
+    fn try_from(value: u8) -> ThriftProtocolResult<Self> {
+        match value {
+            0 => Ok(Self::Stop),
+            1 => Ok(Self::BooleanTrue),
+            2 => Ok(Self::BooleanFalse),
+            3 => Ok(Self::Byte),
+            4 => Ok(Self::I16),
+            5 => Ok(Self::I32),
+            6 => Ok(Self::I64),
+            7 => Ok(Self::Double),
+            8 => Ok(Self::Binary),
+            9 => Ok(Self::List),
+            10 => Ok(Self::Set),
+            11 => Ok(Self::Map),
+            12 => Ok(Self::Struct),
+            _ => Err(ThriftProtocolError::InvalidFieldType(value)),
+        }
+    }
+}
+
+impl TryFrom<ElementType> for FieldType {
+    type Error = ThriftProtocolError;
+    fn try_from(value: ElementType) -> std::result::Result<Self, Self::Error> {
+        match value {
+            ElementType::Bool => Ok(Self::BooleanTrue),
+            ElementType::Byte => Ok(Self::Byte),
+            ElementType::I16 => Ok(Self::I16),
+            ElementType::I32 => Ok(Self::I32),
+            ElementType::I64 => Ok(Self::I64),
+            ElementType::Double => Ok(Self::Double),
+            ElementType::Binary => Ok(Self::Binary),
+            ElementType::List => Ok(Self::List),
+            ElementType::Struct => Ok(Self::Struct),
+            _ => Err(ThriftProtocolError::InvalidFieldType(value as u8)),
+        }
+    }
+}
+
+// Thrift compact protocol types for list elements
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ElementType {
+    Bool = 2,
+    Byte = 3,
+    I16 = 4,
+    I32 = 5,
+    I64 = 6,
+    Double = 7,
+    Binary = 8,
+    List = 9,
+    Set = 10,
+    Map = 11,
+    Struct = 12,
+}
+
+impl TryFrom<u8> for ElementType {
+    type Error = ThriftProtocolError;
+    fn try_from(value: u8) -> ThriftProtocolResult<Self> {
+        match value {
+            // For historical and compatibility reasons, a reader should be capable to deal with both cases.
+            // The only valid value in the original spec was 2, but due to an widespread implementation bug
+            // the defacto standard across large parts of the library became 1 instead.
+            // As a result, both values are now allowed.
+            // https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md#list-and-set
+            1 | 2 => Ok(Self::Bool),
+            3 => Ok(Self::Byte),
+            4 => Ok(Self::I16),
+            5 => Ok(Self::I32),
+            6 => Ok(Self::I64),
+            7 => Ok(Self::Double),
+            8 => Ok(Self::Binary),
+            9 => Ok(Self::List),
+            10 => Ok(Self::Set),
+            11 => Ok(Self::Map),
+            12 => Ok(Self::Struct),
+            _ => Err(ThriftProtocolError::InvalidElementType(value)),
+        }
+    }
+}
+
+/// Struct used to describe a [thrift struct] field during decoding.
+///
+/// [thrift struct]: https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md#struct-encoding
+pub(crate) struct FieldIdentifier {
+    /// The type for the field.
+    pub(crate) field_type: FieldType,
+    /// The field's `id`. May be computed from delta or directly decoded.
+    pub(crate) id: i16,
+    /// Stores the value for booleans.
+    ///
+    /// Boolean fields store no data, instead the field type is either boolean true, or
+    /// boolean false.
+    pub(crate) bool_val: Option<bool>,
+}
+
+/// Struct used to describe a [thrift list].
+///
+/// [thrift list]: https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md#list-and-set
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ListIdentifier {
+    /// The type for each element in the list.
+    pub(crate) element_type: ElementType,
+    /// Number of elements contained in the list.
+    pub(crate) size: i32,
+}
+
+/// Low-level object used to deserialize structs encoded with the Thrift [compact] protocol.
+///
+/// Implementation of this trait must provide the low-level functions `read_byte`, `read_bytes`,
+/// `skip_bytes`, and `read_double`. These primitives are used by the default functions provided
+/// here to perform deserialization.
+///
+/// [compact]: https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md
+pub(crate) trait ThriftCompactInputProtocol<'a> {
+    /// Read a single byte from the input.
+    fn read_byte(&mut self) -> ThriftProtocolResult<u8>;
+
+    /// Read a Thrift encoded [binary] from the input.
+    ///
+    /// [binary]: https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md#binary-encoding
+    fn read_bytes(&mut self) -> ThriftProtocolResult<&'a [u8]>;
+
+    fn read_bytes_owned(&mut self) -> ThriftProtocolResult<Vec<u8>>;
+
+    /// Skip the next `n` bytes of input.
+    fn skip_bytes(&mut self, n: usize) -> ThriftProtocolResult<()>;
+
+    /// Read a ULEB128 encoded unsigned varint from the input.
+    ///
+    /// Fast path for the 1-byte case (~80-90% of Parquet metadata varints).
+    /// Multi-byte fallback is in `read_vlq_slow`, marked `#[cold]` so the
+    /// common path stays tight.
+    #[inline]
+    fn read_vlq(&mut self) -> ThriftProtocolResult<u64> {
+        let byte = self.read_byte()?;
+        if byte & 0x80 == 0 {
+            return Ok(byte as u64);
+        }
+        self.read_vlq_slow(byte)
+    }
+
+    /// Cold-path continuation for [`Self::read_vlq`] when the first byte has
+    /// its high bit set. `first` is the already-consumed first byte.
+    #[cold]
+    #[inline(never)]
+    fn read_vlq_slow(&mut self, first: u8) -> ThriftProtocolResult<u64> {
+        let mut in_progress = (first & 0x7F) as u64;
+        let mut shift = 7;
+        loop {
+            let byte = self.read_byte()?;
+            in_progress |= ((byte & 0x7F) as u64).wrapping_shl(shift);
+            if byte & 0x80 == 0 {
+                return Ok(in_progress);
+            }
+            shift += 7;
+        }
+    }
+
+    /// Read a zig-zag encoded signed varint from the input.
+    fn read_zig_zag(&mut self) -> ThriftProtocolResult<i64> {
+        let val = self.read_vlq()?;
+        Ok((val >> 1) as i64 ^ -((val & 1) as i64))
+    }
+
+    /// Read the [`ListIdentifier`] for a Thrift encoded list.
+    fn read_list_begin(&mut self) -> ThriftProtocolResult<ListIdentifier> {
+        let header = self.read_byte()?;
+        let element_type = ElementType::try_from(header & 0x0f)?;
+
+        let possible_element_count = (header & 0xF0) >> 4;
+        let element_count = if possible_element_count != 15 {
+            // high bits set high if count and type encoded separately
+            possible_element_count as i32
+        } else {
+            self.read_vlq()? as _
+        };
+
+        Ok(ListIdentifier {
+            element_type,
+            size: element_count,
+        })
+    }
+
+    // Full field ids are uncommon.
+    // Not inlining this method reduces the code size of `read_field_begin`, which then ideally gets
+    // inlined everywhere.
+    #[cold]
+    fn read_full_field_id(&mut self) -> ThriftProtocolResult<i16> {
+        self.read_i16()
+    }
+
+    /// Read the [`FieldIdentifier`] for a field in a Thrift encoded struct.
+    fn read_field_begin(&mut self, last_field_id: i16) -> ThriftProtocolResult<FieldIdentifier> {
+        // we can read at least one byte, which is:
+        // - the type
+        // - the field delta and the type
+        let field_type = self.read_byte()?;
+        let field_delta = (field_type & 0xf0) >> 4;
+        let field_type = FieldType::try_from(field_type & 0xf)?;
+        let mut bool_val: Option<bool> = None;
+
+        match field_type {
+            FieldType::Stop => Ok(FieldIdentifier {
+                field_type: FieldType::Stop,
+                id: 0,
+                bool_val,
+            }),
+            _ => {
+                // special handling for bools
+                if field_type == FieldType::BooleanFalse {
+                    bool_val = Some(false);
+                } else if field_type == FieldType::BooleanTrue {
+                    bool_val = Some(true);
+                }
+                let field_id = if field_delta != 0 {
+                    last_field_id.checked_add(field_delta as i16).ok_or(
+                        ThriftProtocolError::FieldDeltaOverflow {
+                            field_delta,
+                            last_field_id,
+                        },
+                    )?
+                } else {
+                    self.read_full_field_id()?
+                };
+
+                Ok(FieldIdentifier {
+                    field_type,
+                    id: field_id,
+                    bool_val,
+                })
+            },
+        }
+    }
+
+    /// This is a specialized version of [`Self::read_field_begin`], solely for use in parsing
+    /// simple structs. This function assumes that the delta field will always be less than 0xf,
+    /// fields will be in order, and no boolean fields will be read.
+    /// This also skips validation of the field type.
+    ///
+    /// Returns a tuple of `(field_type, field_delta)`.
+    fn read_field_header(&mut self) -> ThriftProtocolResult<(u8, u8)> {
+        let field_type = self.read_byte()?;
+        let field_delta = (field_type & 0xf0) >> 4;
+        let field_type = field_type & 0xf;
+        Ok((field_type, field_delta))
+    }
+
+    /// Read a boolean list element. This should not be used for struct fields. For the latter,
+    /// use the [`FieldIdentifier::bool_val`] field.
+    fn read_bool(&mut self) -> ThriftProtocolResult<bool> {
+        let b = self.read_byte()?;
+        // Previous versions of the thrift specification said to use 0 and 1 inside collections,
+        // but that differed from existing implementations.
+        // The specification was updated in https://github.com/apache/thrift/commit/2c29c5665bc442e703480bb0ee60fe925ffe02e8.
+        // At least the go implementation seems to have followed the previously documented values.
+        match b {
+            0x01 => Ok(true),
+            0x00 | 0x02 => Ok(false),
+            _ => Err(ThriftProtocolError::InvalidBoolean(b)),
+        }
+    }
+
+    /// Read a Thrift [binary] as a UTF-8 encoded string.
+    ///
+    /// [binary]: https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md#binary-encoding
+    fn read_string(&mut self) -> ThriftProtocolResult<&'a str> {
+        let slice = self.read_bytes()?;
+        Ok(std::str::from_utf8(slice)?)
+    }
+
+    /// Read an `i8`.
+    fn read_i8(&mut self) -> ThriftProtocolResult<i8> {
+        Ok(self.read_byte()? as _)
+    }
+
+    /// Read an `i16`.
+    fn read_i16(&mut self) -> ThriftProtocolResult<i16> {
+        Ok(self.read_zig_zag()? as _)
+    }
+
+    /// Read an `i32`.
+    fn read_i32(&mut self) -> ThriftProtocolResult<i32> {
+        Ok(self.read_zig_zag()? as _)
+    }
+
+    /// Read an `i64`.
+    fn read_i64(&mut self) -> ThriftProtocolResult<i64> {
+        self.read_zig_zag()
+    }
+
+    /// Read a Thrift `double` as `f64`.
+    fn read_double(&mut self) -> ThriftProtocolResult<f64>;
+
+    /// Skip a ULEB128 encoded varint.
+    fn skip_vlq(&mut self) -> ThriftProtocolResult<()> {
+        loop {
+            let byte = self.read_byte()?;
+            if byte & 0x80 == 0 {
+                return Ok(());
+            }
+        }
+    }
+
+    /// Skip a thrift [binary].
+    ///
+    /// [binary]: https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md#binary-encoding
+    fn skip_binary(&mut self) -> ThriftProtocolResult<()> {
+        let len = self.read_vlq()? as usize;
+        self.skip_bytes(len)
+    }
+
+    /// Skip a thrift list whose element type is a varint (i16/i32/i64). Reads
+    /// the list header, then consumes each element as a varint without
+    /// dispatching through the generic per-element recursive `skip`. Used in
+    /// hot paths where we know the element type up-front (e.g. skipping
+    /// `ColumnMetaData.encodings` which is a `list<i32>`).
+    fn skip_list_of_varint(&mut self) -> ThriftProtocolResult<()> {
+        let list = self.read_list_begin()?;
+        for _ in 0..list.size.max(0) {
+            self.skip_vlq()?;
+        }
+        Ok(())
+    }
+
+    /// Skip a thrift list whose element type is `binary` (bytes / string).
+    /// Used in hot paths where we know the element type up-front (e.g.
+    /// skipping `ColumnMetaData.path_in_schema` which is a `list<binary>`).
+    fn skip_list_of_binary(&mut self) -> ThriftProtocolResult<()> {
+        let list = self.read_list_begin()?;
+        for _ in 0..list.size.max(0) {
+            self.skip_binary()?;
+        }
+        Ok(())
+    }
+
+    /// Skip a field with type `field_type` recursively until the default
+    /// maximum skip depth (currently 64) is reached.
+    fn skip(&mut self, field_type: FieldType) -> ThriftProtocolResult<()> {
+        const DEFAULT_SKIP_DEPTH: i8 = 64;
+        self.skip_till_depth(field_type, DEFAULT_SKIP_DEPTH)
+    }
+
+    /// Empty structs in unions consist of a single byte of 0 for the field stop record.
+    /// This skips that byte without encuring the cost of processing the [`FieldIdentifier`].
+    /// Will return an error if the struct is not actually empty.
+    fn skip_empty_struct(&mut self) -> Result<()> {
+        let b = self.read_byte()?;
+        if b != 0 {
+            Err(general_err!("Empty struct has fields"))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Skip a field with type `field_type` recursively up to `depth` levels.
+    fn skip_till_depth(&mut self, field_type: FieldType, depth: i8) -> ThriftProtocolResult<()> {
+        if depth == 0 {
+            return Err(ThriftProtocolError::SkipDepth(field_type));
+        }
+
+        match field_type {
+            // boolean field has no data
+            FieldType::BooleanFalse | FieldType::BooleanTrue => Ok(()),
+            FieldType::Byte => self.read_i8().map(|_| ()),
+            FieldType::I16 => self.skip_vlq().map(|_| ()),
+            FieldType::I32 => self.skip_vlq().map(|_| ()),
+            FieldType::I64 => self.skip_vlq().map(|_| ()),
+            FieldType::Double => self.skip_bytes(8).map(|_| ()),
+            FieldType::Binary => self.skip_binary().map(|_| ()),
+            FieldType::Struct => {
+                let mut last_field_id = 0i16;
+                loop {
+                    let field_ident = self.read_field_begin(last_field_id)?;
+                    if field_ident.field_type == FieldType::Stop {
+                        break;
+                    }
+                    self.skip_till_depth(field_ident.field_type, depth - 1)?;
+                    last_field_id = field_ident.id;
+                }
+                Ok(())
+            },
+            FieldType::List => {
+                let list_ident = self.read_list_begin()?;
+                for _ in 0..list_ident.size {
+                    let element_type = FieldType::try_from(list_ident.element_type)?;
+                    self.skip_till_depth(element_type, depth - 1)?;
+                }
+                Ok(())
+            },
+            // no list or map types in parquet format
+            _ => Err(ThriftProtocolError::SkipUnsupportedType(field_type)),
+        }
+    }
+}
+
+/// A high performance Thrift reader that reads from a slice of bytes.
+pub(crate) struct ThriftSliceInputProtocol<'a> {
+    buf: &'a [u8],
+}
+
+impl<'a> ThriftSliceInputProtocol<'a> {
+    /// Create a new `ThriftSliceInputProtocol` using the bytes in `buf`.
+    pub fn new(buf: &'a [u8]) -> Self {
+        Self { buf }
+    }
+
+    /// Return the current buffer as a slice.
+    pub fn as_slice(&self) -> &'a [u8] {
+        self.buf
+    }
+
+    /// Byte offset of the cursor from `origin_ptr`. The pointer must point
+    /// into the same allocation we were constructed from (typically the
+    /// footer start). Used as a value only, never dereferenced, so
+    /// caller-side `unsafe` is not needed.
+    #[inline]
+    pub fn offset_from(&self, origin_ptr: *const u8) -> u32 {
+        (self.buf.as_ptr() as usize - origin_ptr as usize) as u32
+    }
+}
+
+impl<'b, 'a: 'b> ThriftCompactInputProtocol<'b> for ThriftSliceInputProtocol<'a> {
+    #[inline]
+    fn read_byte(&mut self) -> ThriftProtocolResult<u8> {
+        let ret = *self.buf.first().ok_or(ThriftProtocolError::Eof)?;
+        self.buf = &self.buf[1..];
+        Ok(ret)
+    }
+
+    fn read_bytes(&mut self) -> ThriftProtocolResult<&'b [u8]> {
+        let len = self.read_vlq()? as usize;
+        let ret = self.buf.get(..len).ok_or(ThriftProtocolError::Eof)?;
+        self.buf = &self.buf[len..];
+        Ok(ret)
+    }
+
+    fn read_bytes_owned(&mut self) -> ThriftProtocolResult<Vec<u8>> {
+        Ok(self.read_bytes()?.to_vec())
+    }
+
+    #[inline]
+    fn skip_bytes(&mut self, n: usize) -> ThriftProtocolResult<()> {
+        self.buf.get(..n).ok_or(ThriftProtocolError::Eof)?;
+        self.buf = &self.buf[n..];
+        Ok(())
+    }
+
+    fn read_double(&mut self) -> ThriftProtocolResult<f64> {
+        let slice = self.buf.get(..8).ok_or(ThriftProtocolError::Eof)?;
+        self.buf = &self.buf[8..];
+        match slice.try_into() {
+            Ok(slice) => Ok(f64::from_le_bytes(slice)),
+            Err(_) => unreachable!(),
+        }
+    }
+}
+
+/// A Thrift input protocol that wraps a [`Read`] object.
+///
+/// Note that this is only intended for use in reading Parquet page headers. This will panic
+/// if Thrift `binary` data is encountered because a slice of that data cannot be returned.
+pub(crate) struct ThriftReadInputProtocol<R: Read> {
+    reader: R,
+}
+
+impl<R: Read> ThriftReadInputProtocol<R> {
+    pub(crate) fn new(reader: R) -> Self {
+        Self { reader }
+    }
+}
+
+impl<'a, R: Read> ThriftCompactInputProtocol<'a> for ThriftReadInputProtocol<R> {
+    #[inline]
+    fn read_byte(&mut self) -> ThriftProtocolResult<u8> {
+        let mut buf = [0_u8; 1];
+        self.reader.read_exact(&mut buf)?;
+        Ok(buf[0])
+    }
+
+    fn read_bytes(&mut self) -> ThriftProtocolResult<&'a [u8]> {
+        unimplemented!()
+    }
+
+    fn read_bytes_owned(&mut self) -> ThriftProtocolResult<Vec<u8>> {
+        let len = self.read_vlq()? as usize;
+        let mut v = Vec::with_capacity(len);
+        std::io::copy(&mut self.reader.by_ref().take(len as u64), &mut v)?;
+        Ok(v)
+    }
+
+    fn skip_bytes(&mut self, n: usize) -> ThriftProtocolResult<()> {
+        std::io::copy(
+            &mut self.reader.by_ref().take(n as u64),
+            &mut std::io::sink(),
+        )?;
+        Ok(())
+    }
+
+    fn read_double(&mut self) -> ThriftProtocolResult<f64> {
+        let mut buf = [0_u8; 8];
+        self.reader.read_exact(&mut buf)?;
+        Ok(f64::from_le_bytes(buf))
+    }
+}
+
+/// Trait implemented for objects that can be deserialized from a Thrift input stream.
+/// Implementations are provided for Thrift primitive types.
+pub(crate) trait ReadThrift<'a, R: ThriftCompactInputProtocol<'a>> {
+    /// Read an object of type `Self` from the input protocol object.
+    fn read_thrift(prot: &mut R) -> Result<Self>
+    where
+        Self: Sized;
+}
+
+impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for bool {
+    fn read_thrift(prot: &mut R) -> Result<Self> {
+        Ok(prot.read_bool()?)
+    }
+}
+
+impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for i8 {
+    fn read_thrift(prot: &mut R) -> Result<Self> {
+        Ok(prot.read_i8()?)
+    }
+}
+
+impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for i16 {
+    fn read_thrift(prot: &mut R) -> Result<Self> {
+        Ok(prot.read_i16()?)
+    }
+}
+
+impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for i32 {
+    fn read_thrift(prot: &mut R) -> Result<Self> {
+        Ok(prot.read_i32()?)
+    }
+}
+
+impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for i64 {
+    fn read_thrift(prot: &mut R) -> Result<Self> {
+        Ok(prot.read_i64()?)
+    }
+}
+
+impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for OrderedF64 {
+    fn read_thrift(prot: &mut R) -> Result<Self> {
+        Ok(OrderedF64(prot.read_double()?))
+    }
+}
+
+impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for &'a str {
+    fn read_thrift(prot: &mut R) -> Result<Self> {
+        Ok(prot.read_string()?)
+    }
+}
+
+// Polars-side removal: arrow-rs's `impl ReadThrift for String` would force
+// `From<std::string::FromUtf8Error> for ParquetError` into polars's error
+// module to support the inner `String::from_utf8(...)?`. Polars doesn't
+// invoke that impl (the file-metadata decoder uses `prot.read_string()`
+// directly), so the impl and its `From` shim are dropped.
+
+impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for &'a [u8] {
+    fn read_thrift(prot: &mut R) -> Result<Self> {
+        Ok(prot.read_bytes()?)
+    }
+}
+
+/// Read a Thrift encoded [list] from the input protocol object.
+///
+/// [list]: https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md#list-and-set
+pub(crate) fn read_thrift_vec<'a, T, R>(prot: &mut R) -> Result<Vec<T>>
+where
+    R: ThriftCompactInputProtocol<'a>,
+    T: ReadThrift<'a, R>,
+{
+    let list_ident = prot.read_list_begin()?;
+    let mut res = Vec::with_capacity(list_ident.size as usize);
+    for _ in 0..list_ident.size {
+        let val = T::read_thrift(prot)?;
+        res.push(val);
+    }
+    Ok(res)
+}
+
+/////////////////////////
+// thrift compact output
+
+/// Low-level object used to serialize structs to the Thrift [compact output] protocol.
+///
+/// This struct serves as a wrapper around a [`Write`] object, to which thrift encoded data
+/// will written. The implementation provides functions to write Thrift primitive types, as well
+/// as functions used in the encoding of lists and structs. This should rarely be used directly,
+/// but is instead intended for use by implementers of [`WriteThrift`] and [`WriteThriftField`].
+///
+/// [compact output]: https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md
+pub(crate) struct ThriftCompactOutputProtocol<W: Write> {
+    writer: W,
+}
+
+impl<W: Write> ThriftCompactOutputProtocol<W> {
+    /// Create a new `ThriftCompactOutputProtocol` wrapping the byte sink `writer`.
+    pub(crate) fn new(writer: W) -> Self {
+        Self { writer }
+    }
+
+    /// Write a single byte to the output stream.
+    fn write_byte(&mut self, b: u8) -> Result<()> {
+        self.writer.write_all(&[b])?;
+        Ok(())
+    }
+
+    /// Write the given `u64` as a ULEB128 encoded varint.
+    fn write_vlq(&mut self, val: u64) -> Result<()> {
+        let mut v = val;
+        while v > 0x7f {
+            self.write_byte(v as u8 | 0x80)?;
+            v >>= 7;
+        }
+        self.write_byte(v as u8)
+    }
+
+    /// Write the given `i64` as a zig-zag encoded varint.
+    fn write_zig_zag(&mut self, val: i64) -> Result<()> {
+        let s = (val < 0) as i64;
+        self.write_vlq((((val ^ -s) << 1) + s) as u64)
+    }
+
+    /// Used to mark the start of a Thrift struct field of type `field_type`. `last_field_id`
+    /// is used to compute a delta to the given `field_id` per the compact protocol [spec].
+    ///
+    /// [spec]: https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md#struct-encoding
+    pub(crate) fn write_field_begin(
+        &mut self,
+        field_type: FieldType,
+        field_id: i16,
+        last_field_id: i16,
+    ) -> Result<()> {
+        let delta = field_id.wrapping_sub(last_field_id);
+        if delta > 0 && delta <= 0xf {
+            self.write_byte((delta as u8) << 4 | field_type as u8)
+        } else {
+            self.write_byte(field_type as u8)?;
+            self.write_i16(field_id)
+        }
+    }
+
+    /// Used to indicate the start of a list of `element_type` elements.
+    pub(crate) fn write_list_begin(&mut self, element_type: ElementType, len: usize) -> Result<()> {
+        if len < 15 {
+            self.write_byte((len as u8) << 4 | element_type as u8)
+        } else {
+            self.write_byte(0xf0u8 | element_type as u8)?;
+            self.write_vlq(len as _)
+        }
+    }
+
+    /// Used to mark the end of a struct. This must be called after all fields of the struct have
+    /// been written.
+    pub(crate) fn write_struct_end(&mut self) -> Result<()> {
+        self.write_byte(0)
+    }
+
+    /// Serialize a slice of `u8`s. This will encode a length, and then write the bytes without
+    /// further encoding.
+    pub(crate) fn write_bytes(&mut self, val: &[u8]) -> Result<()> {
+        self.write_vlq(val.len() as u64)?;
+        self.writer.write_all(val)?;
+        Ok(())
+    }
+
+    /// Short-cut method used to encode structs that have no fields (often used in Thrift unions).
+    /// This simply encodes the field id and then immediately writes the end-of-struct marker.
+    pub(crate) fn write_empty_struct(&mut self, field_id: i16, last_field_id: i16) -> Result<i16> {
+        self.write_field_begin(FieldType::Struct, field_id, last_field_id)?;
+        self.write_struct_end()?;
+        Ok(last_field_id)
+    }
+
+    /// Write a boolean value.
+    pub(crate) fn write_bool(&mut self, val: bool) -> Result<()> {
+        match val {
+            true => self.write_byte(1),
+            false => self.write_byte(2),
+        }
+    }
+
+    /// Write a zig-zag encoded `i8` value.
+    pub(crate) fn write_i8(&mut self, val: i8) -> Result<()> {
+        self.write_byte(val as u8)
+    }
+
+    /// Write a zig-zag encoded `i16` value.
+    pub(crate) fn write_i16(&mut self, val: i16) -> Result<()> {
+        self.write_zig_zag(val as _)
+    }
+
+    /// Write a zig-zag encoded `i32` value.
+    pub(crate) fn write_i32(&mut self, val: i32) -> Result<()> {
+        self.write_zig_zag(val as _)
+    }
+
+    /// Write a zig-zag encoded `i64` value.
+    pub(crate) fn write_i64(&mut self, val: i64) -> Result<()> {
+        self.write_zig_zag(val as _)
+    }
+
+    /// Write a double value.
+    pub(crate) fn write_double(&mut self, val: f64) -> Result<()> {
+        self.writer.write_all(&val.to_le_bytes())?;
+        Ok(())
+    }
+}
+
+/// Trait implemented by objects that are to be serialized to a Thrift [compact output] protocol
+/// stream. Implementations are also provided for primitive Thrift types.
+///
+/// [compact output]: https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md
+pub(crate) trait WriteThrift {
+    /// The [`ElementType`] to use when a list of this object is written.
+    const ELEMENT_TYPE: ElementType;
+
+    /// Serialize this object to the given `writer`.
+    fn write_thrift<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>) -> Result<()>;
+}
+
+/// Implementation for a vector of thrift serializable objects that implement [`WriteThrift`].
+/// This will write the necessary list header and then serialize the elements one-at-a-time.
+impl<T> WriteThrift for Vec<T>
+where
+    T: WriteThrift,
+{
+    const ELEMENT_TYPE: ElementType = ElementType::List;
+
+    fn write_thrift<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>) -> Result<()> {
+        writer.write_list_begin(T::ELEMENT_TYPE, self.len())?;
+        for item in self {
+            item.write_thrift(writer)?;
+        }
+        Ok(())
+    }
+}
+
+impl WriteThrift for bool {
+    const ELEMENT_TYPE: ElementType = ElementType::Bool;
+
+    fn write_thrift<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>) -> Result<()> {
+        writer.write_bool(*self)
+    }
+}
+
+impl WriteThrift for i8 {
+    const ELEMENT_TYPE: ElementType = ElementType::Byte;
+
+    fn write_thrift<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>) -> Result<()> {
+        writer.write_i8(*self)
+    }
+}
+
+impl WriteThrift for i16 {
+    const ELEMENT_TYPE: ElementType = ElementType::I16;
+
+    fn write_thrift<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>) -> Result<()> {
+        writer.write_i16(*self)
+    }
+}
+
+impl WriteThrift for i32 {
+    const ELEMENT_TYPE: ElementType = ElementType::I32;
+
+    fn write_thrift<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>) -> Result<()> {
+        writer.write_i32(*self)
+    }
+}
+
+impl WriteThrift for i64 {
+    const ELEMENT_TYPE: ElementType = ElementType::I64;
+
+    fn write_thrift<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>) -> Result<()> {
+        writer.write_i64(*self)
+    }
+}
+
+impl WriteThrift for OrderedF64 {
+    const ELEMENT_TYPE: ElementType = ElementType::Double;
+
+    fn write_thrift<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>) -> Result<()> {
+        writer.write_double(self.0)
+    }
+}
+
+impl WriteThrift for f64 {
+    const ELEMENT_TYPE: ElementType = ElementType::Double;
+
+    fn write_thrift<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>) -> Result<()> {
+        writer.write_double(*self)
+    }
+}
+
+impl WriteThrift for &[u8] {
+    const ELEMENT_TYPE: ElementType = ElementType::Binary;
+
+    fn write_thrift<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>) -> Result<()> {
+        writer.write_bytes(self)
+    }
+}
+
+impl WriteThrift for &str {
+    const ELEMENT_TYPE: ElementType = ElementType::Binary;
+
+    fn write_thrift<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>) -> Result<()> {
+        writer.write_bytes(self.as_bytes())
+    }
+}
+
+impl WriteThrift for String {
+    const ELEMENT_TYPE: ElementType = ElementType::Binary;
+
+    fn write_thrift<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>) -> Result<()> {
+        writer.write_bytes(self.as_bytes())
+    }
+}
+
+/// Trait implemented by objects that are fields of Thrift structs.
+///
+/// For example, given the Thrift struct definition
+/// ```ignore
+/// struct MyStruct {
+///   1: required i32 field1
+///   2: optional bool field2
+///   3: optional OtherStruct field3
+/// }
+/// ```
+///
+/// which becomes in Rust
+/// ```no_run
+/// # struct OtherStruct {}
+/// struct MyStruct {
+///   field1: i32,
+///   field2: Option<bool>,
+///   field3: Option<OtherStruct>,
+/// }
+/// ```
+/// the impl of `WriteThrift` for `MyStruct` will use the `WriteThriftField` impls for `i32`,
+/// `bool`, and `OtherStruct`.
+///
+/// ```ignore
+/// impl WriteThrift for MyStruct {
+///   fn write_thrift<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>) -> Result<()> {
+///     let mut last_field_id = 0i16;
+///     last_field_id = self.field1.write_thrift_field(writer, 1, last_field_id)?;
+///     if self.field2.is_some() {
+///       // if field2 is `None` then this assignment won't happen and last_field_id will remain
+///       // `1` when writing `field3`
+///       last_field_id = self.field2.write_thrift_field(writer, 2, last_field_id)?;
+///     }
+///     if self.field3.is_some() {
+///       // no need to assign last_field_id since this is the final field.
+///       self.field3.write_thrift_field(writer, 3, last_field_id)?;
+///     }
+///     writer.write_struct_end()
+///   }
+/// }
+/// ```
+///
+pub(crate) trait WriteThriftField {
+    /// Used to write struct fields (which may be primitive or IDL defined types). This will
+    /// write the field marker for the given `field_id`, using `last_field_id` to compute the
+    /// field delta used by the Thrift [compact protocol]. On success this will return `field_id`
+    /// to be used in chaining.
+    ///
+    /// [compact protocol]: https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md#struct-encoding
+    fn write_thrift_field<W: Write>(
+        &self,
+        writer: &mut ThriftCompactOutputProtocol<W>,
+        field_id: i16,
+        last_field_id: i16,
+    ) -> Result<i16>;
+}
+
+// bool struct fields are written differently to bool values
+impl WriteThriftField for bool {
+    fn write_thrift_field<W: Write>(
+        &self,
+        writer: &mut ThriftCompactOutputProtocol<W>,
+        field_id: i16,
+        last_field_id: i16,
+    ) -> Result<i16> {
+        // boolean only writes the field header
+        match *self {
+            true => writer.write_field_begin(FieldType::BooleanTrue, field_id, last_field_id)?,
+            false => writer.write_field_begin(FieldType::BooleanFalse, field_id, last_field_id)?,
+        }
+        Ok(field_id)
+    }
+}
+
+write_thrift_field!(i8, FieldType::Byte);
+write_thrift_field!(i16, FieldType::I16);
+write_thrift_field!(i32, FieldType::I32);
+write_thrift_field!(i64, FieldType::I64);
+write_thrift_field!(OrderedF64, FieldType::Double);
+write_thrift_field!(f64, FieldType::Double);
+write_thrift_field!(String, FieldType::Binary);
+
+impl WriteThriftField for &[u8] {
+    fn write_thrift_field<W: Write>(
+        &self,
+        writer: &mut ThriftCompactOutputProtocol<W>,
+        field_id: i16,
+        last_field_id: i16,
+    ) -> Result<i16> {
+        writer.write_field_begin(FieldType::Binary, field_id, last_field_id)?;
+        writer.write_bytes(self)?;
+        Ok(field_id)
+    }
+}
+
+impl WriteThriftField for &str {
+    fn write_thrift_field<W: Write>(
+        &self,
+        writer: &mut ThriftCompactOutputProtocol<W>,
+        field_id: i16,
+        last_field_id: i16,
+    ) -> Result<i16> {
+        writer.write_field_begin(FieldType::Binary, field_id, last_field_id)?;
+        writer.write_bytes(self.as_bytes())?;
+        Ok(field_id)
+    }
+}
+
+impl<T> WriteThriftField for Vec<T>
+where
+    T: WriteThrift,
+{
+    fn write_thrift_field<W: Write>(
+        &self,
+        writer: &mut ThriftCompactOutputProtocol<W>,
+        field_id: i16,
+        last_field_id: i16,
+    ) -> Result<i16> {
+        writer.write_field_begin(FieldType::List, field_id, last_field_id)?;
+        self.write_thrift(writer)?;
+        Ok(field_id)
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    // Arrow's `test_enum_roundtrip` / `test_union_all_empty_roundtrip` depend on
+    // `crate::basic::{TimeUnit, Type}` enums (their `ReadThrift`/`WriteThrift`
+    // impls are generated by `thrift_enum!` in arrow). Polars doesn't yet have
+    // the equivalent polars-side enum impls. The two tests are dropped.
+    // The generic roundtrip helper stays so future polars-native enums can reuse it.
+    use std::fmt::Debug;
+
+    use super::*;
+
+    pub(crate) fn test_roundtrip<T>(val: T)
+    where
+        T: for<'a> ReadThrift<'a, ThriftSliceInputProtocol<'a>> + WriteThrift + PartialEq + Debug,
+    {
+        let mut buf = Vec::<u8>::new();
+        {
+            let mut writer = ThriftCompactOutputProtocol::new(&mut buf);
+            val.write_thrift(&mut writer).unwrap();
+        }
+
+        let mut prot = ThriftSliceInputProtocol::new(&buf);
+        let read_val = T::read_thrift(&mut prot).unwrap();
+        assert_eq!(val, read_val);
+    }
+}

--- a/crates/polars-parquet/src/parquet/metadata/column_chunk_metadata.rs
+++ b/crates/polars-parquet/src/parquet/metadata/column_chunk_metadata.rs
@@ -1,210 +1,183 @@
-use polars_parquet_format::{ColumnChunk, ColumnMetaData, Encoding};
+use polars_buffer::Buffer;
+use polars_parquet_format::Statistics as ParquetStatistics;
 
-use super::column_descriptor::ColumnDescriptor;
+use super::column_descriptor::{ColumnDescriptor, ColumnDescriptorRef};
+use super::compact::{CompactColumnChunk, CompactColumnMetaData, CompactStatistics};
 use crate::parquet::compression::Compression;
-use crate::parquet::error::{ParquetError, ParquetResult};
+use crate::parquet::error::ParquetResult;
 use crate::parquet::schema::types::PhysicalType;
 use crate::parquet::statistics::Statistics;
 
-#[cfg(feature = "serde")]
-mod serde_types {
-    pub use std::io::Cursor;
-
-    pub use polars_parquet_format::thrift::protocol::{
-        TCompactInputProtocol, TCompactOutputProtocol,
-    };
-    pub use serde::de::Error as DeserializeError;
-    pub use serde::ser::Error as SerializeError;
-    pub use serde::{Deserialize, Deserializer, Serialize, Serializer};
-}
-#[cfg(feature = "serde")]
-use serde_types::*;
-
 /// Metadata for a column chunk.
 ///
-/// This contains the `ColumnDescriptor` associated with the chunk so that deserializers have
-/// access to the descriptor (e.g. physical, converted, logical).
+/// Wraps a [`CompactColumnChunk`] (drops fields with no in-tree consumer).
+/// Stats `min_value` / `max_value` are stored as `(offset, len)` ranges
+/// into the file's footer buffer; resolve them by passing
+/// `&FileMetadata::footer_buf` to [`Self::statistics`].
+///
+/// `column_descr` is a [`ColumnDescriptorRef`]: refcount-bump on clone, no
+/// deep `ColumnDescriptor` copy. All chunks of one file share a single
+/// underlying `Vec<ColumnDescriptor>` allocation.
 ///
 /// This struct is intentionally not `Clone`, as it is a huge struct.
 #[derive(Debug)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct ColumnChunkMetadata {
-    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_column_chunk"))]
-    #[cfg_attr(
-        feature = "serde",
-        serde(deserialize_with = "deserialize_column_chunk")
-    )]
-    column_chunk: ColumnChunk,
-    column_descr: ColumnDescriptor,
-}
-
-#[cfg(feature = "serde")]
-fn serialize_column_chunk<S>(
-    column_chunk: &ColumnChunk,
-    serializer: S,
-) -> std::result::Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    let mut buf = vec![];
-    let cursor = Cursor::new(&mut buf[..]);
-    let mut protocol = TCompactOutputProtocol::new(cursor);
-    column_chunk
-        .write_to_out_protocol(&mut protocol)
-        .map_err(S::Error::custom)?;
-    serializer.serialize_bytes(&buf)
-}
-
-#[cfg(feature = "serde")]
-fn deserialize_column_chunk<'de, D>(deserializer: D) -> std::result::Result<ColumnChunk, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    use polars_utils::pl_serialize::deserialize_map_bytes;
-
-    deserialize_map_bytes(deserializer, |b| {
-        let mut b = b.as_ref();
-        let mut protocol = TCompactInputProtocol::new(&mut b, usize::MAX);
-        ColumnChunk::read_from_in_protocol(&mut protocol).map_err(D::Error::custom)
-    })?
+    column_chunk: CompactColumnChunk,
+    column_descr: ColumnDescriptorRef,
 }
 
 // Represents common operations for a column chunk.
 impl ColumnChunkMetadata {
-    /// Returns a new [`ColumnChunkMetadata`]
-    pub fn new(column_chunk: ColumnChunk, column_descr: ColumnDescriptor) -> Self {
-        Self {
-            column_chunk,
-            column_descr,
-        }
-    }
-
-    /// File where the column chunk is stored.
+    /// The compact column metadata for this chunk. Always present;
+    /// encrypted columns are rejected at footer-decode time.
     ///
-    /// If not set, assumed to belong to the same file as the metadata.
-    /// This path is relative to the current file.
-    pub fn file_path(&self) -> &Option<String> {
-        &self.column_chunk.file_path
+    /// Crate-internal: callers outside `polars-parquet` should use the
+    /// typed accessors below (`compression()`, `num_values()`, etc.)
+    /// rather than reaching into the compact representation directly.
+    #[inline]
+    pub(crate) fn compact_metadata(&self) -> &CompactColumnMetaData {
+        &self.column_chunk.meta_data
     }
 
-    /// Byte offset in `file_path()`.
-    pub fn file_offset(&self) -> i64 {
-        self.column_chunk.file_offset
-    }
-
-    /// Returns this column's [`ColumnChunk`]
-    pub fn column_chunk(&self) -> &ColumnChunk {
-        &self.column_chunk
-    }
-
-    /// The column's [`ColumnMetaData`]
-    pub fn metadata(&self) -> &ColumnMetaData {
-        self.column_chunk.meta_data.as_ref().unwrap()
-    }
-
-    /// The [`ColumnDescriptor`] for this column. This descriptor contains the physical and logical type
-    /// of the pages.
+    /// The [`ColumnDescriptor`] for this column. This descriptor contains
+    /// the physical and logical type of the pages.
     pub fn descriptor(&self) -> &ColumnDescriptor {
         &self.column_descr
     }
 
     /// The [`PhysicalType`] of this column.
     pub fn physical_type(&self) -> PhysicalType {
-        self.column_descr.descriptor.primitive_type.physical_type
+        self.descriptor().descriptor.primitive_type.physical_type
     }
 
     /// Decodes the raw statistics into [`Statistics`].
-    pub fn statistics(&self) -> Option<ParquetResult<Statistics>> {
-        self.metadata().statistics.as_ref().map(|x| {
-            Statistics::deserialize(x, self.column_descr.descriptor.primitive_type.clone())
-        })
+    ///
+    /// `CompactStatistics` stores min/max as `ByteRange`s into the footer
+    /// buffer to avoid per-stat allocations during decode. This accessor
+    /// materialises the bytes back into a `ParquetStatistics` (one alloc
+    /// per side present) and runs the existing per-type deserializer.
+    ///
+    /// `footer_buf` must be the same buffer this chunk was decoded from,
+    /// typically [`super::FileMetadata::footer_buf`].
+    pub fn statistics(&self, footer_buf: &Buffer<u8>) -> Option<ParquetResult<Statistics>> {
+        let stats = self.compact_metadata().statistics.as_ref()?;
+        let parquet_stats = compact_stats_to_parquet(stats, footer_buf);
+        Some(Statistics::deserialize(
+            &parquet_stats,
+            self.descriptor().descriptor.primitive_type.clone(),
+        ))
     }
 
-    /// Total number of values in this column chunk. Note that this is not necessarily the number
-    /// of rows. E.g. the (nested) array `[[1, 2], [3]]` has 2 rows and 3 values.
+    /// Total number of values in this column chunk. Note that this is not
+    /// necessarily the number of rows. E.g. the (nested) array `[[1, 2], [3]]`
+    /// has 2 rows and 3 values.
     pub fn num_values(&self) -> i64 {
-        self.metadata().num_values
+        self.compact_metadata().num_values
     }
 
     /// [`Compression`] for this column.
     pub fn compression(&self) -> Compression {
-        self.metadata().codec.try_into().unwrap()
+        self.compact_metadata().codec
     }
 
     /// Returns the total compressed data size of this column chunk.
     pub fn compressed_size(&self) -> i64 {
-        self.metadata().total_compressed_size
+        self.compact_metadata().total_compressed_size
     }
 
     /// Returns the total uncompressed data size of this column chunk.
     pub fn uncompressed_size(&self) -> i64 {
-        self.metadata().total_uncompressed_size
+        self.compact_metadata().total_uncompressed_size
     }
 
     /// Returns the offset for the column data.
     pub fn data_page_offset(&self) -> i64 {
-        self.metadata().data_page_offset
+        self.compact_metadata().data_page_offset
     }
 
-    /// Returns `true` if this column chunk contains a index page, `false` otherwise.
+    /// Returns `true` if this column chunk contains an index page, `false` otherwise.
     pub fn has_index_page(&self) -> bool {
-        self.metadata().index_page_offset.is_some()
+        self.compact_metadata().index_page_offset.is_some()
     }
 
     /// Returns the offset for the index page.
     pub fn index_page_offset(&self) -> Option<i64> {
-        self.metadata().index_page_offset
+        self.compact_metadata().index_page_offset
     }
 
     /// Returns the offset for the dictionary page, if any.
     pub fn dictionary_page_offset(&self) -> Option<i64> {
-        self.metadata().dictionary_page_offset
+        self.compact_metadata().dictionary_page_offset
     }
 
-    /// Returns the encoding for this column
-    pub fn column_encoding(&self) -> &Vec<Encoding> {
-        &self.metadata().encodings
+    /// Bloom filter byte offset, if present.
+    pub fn bloom_filter_offset(&self) -> Option<i64> {
+        self.compact_metadata().bloom_filter_offset
     }
 
-    /// Returns the offset and length in bytes of the column chunk within the file
+    /// Bloom filter byte length, if present.
+    pub fn bloom_filter_length(&self) -> Option<i32> {
+        self.compact_metadata().bloom_filter_length
+    }
+
+    /// PageIndex `OffsetIndex` byte offset, if present.
+    pub fn offset_index_offset(&self) -> Option<i64> {
+        self.column_chunk.offset_index_offset
+    }
+
+    /// PageIndex `OffsetIndex` byte length, if present.
+    pub fn offset_index_length(&self) -> Option<i32> {
+        self.column_chunk.offset_index_length
+    }
+
+    /// PageIndex `ColumnIndex` byte offset, if present.
+    pub fn column_index_offset(&self) -> Option<i64> {
+        self.column_chunk.column_index_offset
+    }
+
+    /// PageIndex `ColumnIndex` byte length, if present.
+    pub fn column_index_length(&self) -> Option<i32> {
+        self.column_chunk.column_index_length
+    }
+
+    /// Returns the offset and length in bytes of the column chunk within the file.
     pub fn byte_range(&self) -> core::ops::Range<u64> {
-        // this has been validated in [`try_from_thrift`]
-        column_metadata_byte_range(self.metadata())
+        column_metadata_byte_range_compact(self.compact_metadata())
     }
 
-    /// Method to convert from Thrift.
-    pub(crate) fn try_from_thrift(
-        column_descr: ColumnDescriptor,
-        column_chunk: ColumnChunk,
-    ) -> ParquetResult<Self> {
-        // validate metadata
-        if let Some(meta) = &column_chunk.meta_data {
-            let _: u64 = meta.total_compressed_size.try_into()?;
-
-            if let Some(offset) = meta.dictionary_page_offset {
-                let _: u64 = offset.try_into()?;
-            }
-            let _: u64 = meta.data_page_offset.try_into()?;
-
-            let _: Compression = meta.codec.try_into()?;
-        } else {
-            return Err(ParquetError::oos("Column chunk requires metadata"));
-        }
-
-        Ok(Self {
+    /// Build from a [`CompactColumnChunk`] + descriptor handle.
+    /// Infallible: the decoder rejects malformed chunks (missing
+    /// `meta_data`) up front, so by here the invariant is type-enforced.
+    pub(crate) fn from_compact(
+        column_descr: ColumnDescriptorRef,
+        column_chunk: CompactColumnChunk,
+    ) -> Self {
+        Self {
             column_chunk,
             column_descr,
-        })
-    }
-
-    /// Method to convert to Thrift.
-    pub fn into_thrift(self) -> ColumnChunk {
-        self.column_chunk
+        }
     }
 }
 
-pub(super) fn column_metadata_byte_range(
-    column_metadata: &ColumnMetaData,
+/// Materialise a `polars_parquet_format::Statistics` from a `CompactStatistics`
+/// by resolving the `ByteRange`s against `footer_buf`. Allocates 0-2 `Vec<u8>`s
+/// (one per side present). Used by [`ColumnChunkMetadata::statistics`].
+#[inline]
+fn compact_stats_to_parquet(s: &CompactStatistics, footer_buf: &[u8]) -> ParquetStatistics {
+    ParquetStatistics {
+        max: None,
+        min: None,
+        null_count: s.null_count,
+        distinct_count: s.distinct_count,
+        max_value: s.max_value.map(|r| r.resolve(footer_buf).to_vec()),
+        min_value: s.min_value.map(|r| r.resolve(footer_buf).to_vec()),
+        is_max_value_exact: s.is_max_value_exact,
+        is_min_value_exact: s.is_min_value_exact,
+    }
+}
+
+pub(super) fn column_metadata_byte_range_compact(
+    column_metadata: &CompactColumnMetaData,
 ) -> core::ops::Range<u64> {
     let offset = if let Some(dict_page_offset) = column_metadata.dictionary_page_offset {
         dict_page_offset as u64

--- a/crates/polars-parquet/src/parquet/metadata/column_descriptor.rs
+++ b/crates/polars-parquet/src/parquet/metadata/column_descriptor.rs
@@ -61,7 +61,7 @@ impl Deref for BaseType {
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct ColumnDescriptor {
-    /// The descriptor this columns' leaf.
+    /// The descriptor at this column's leaf.
     pub descriptor: Descriptor,
 
     /// The path of this column. For instance, "a.b.c.d".
@@ -83,5 +83,33 @@ impl ColumnDescriptor {
             path_in_schema,
             base_type,
         }
+    }
+}
+
+/// Reference to one [`ColumnDescriptor`] inside a shared schema.
+///
+/// Held by [`super::ColumnChunkMetadata`] so all column chunks of a file
+/// can share a single `Vec<ColumnDescriptor>` allocation. `Clone` is a
+/// refcount-bump; `Deref` resolves to `&ColumnDescriptor` transparently.
+///
+/// Crate-internal: external code never sees this type. The chunk's public
+/// `descriptor()` accessor returns `&ColumnDescriptor` via `Deref`.
+#[derive(Debug, Clone)]
+pub(crate) struct ColumnDescriptorRef {
+    descrs: Arc<Vec<ColumnDescriptor>>,
+    idx: usize,
+}
+
+impl ColumnDescriptorRef {
+    pub(crate) fn new(descrs: Arc<Vec<ColumnDescriptor>>, idx: usize) -> Self {
+        Self { descrs, idx }
+    }
+}
+
+impl Deref for ColumnDescriptorRef {
+    type Target = ColumnDescriptor;
+    #[inline]
+    fn deref(&self) -> &ColumnDescriptor {
+        &self.descrs[self.idx]
     }
 }

--- a/crates/polars-parquet/src/parquet/metadata/compact.rs
+++ b/crates/polars-parquet/src/parquet/metadata/compact.rs
@@ -1,0 +1,137 @@
+//! Compact replacements for the format-crate read-path types: `FileMetaData`,
+//! `RowGroup`, `ColumnChunk`, `ColumnMetaData`, `Statistics`. Produced by the
+//! hand-written Thrift decoder in [`crate::parquet::handwritten_thrift`] and
+//! consumed by [`super::FileMetadata::from_compact`].
+//!
+//! Two wins over the format-crate types:
+//!
+//! 1. **Smaller resident footprint.** Fields with no in-tree consumer
+//!    (`encodings`, `path_in_schema`, `key_value_metadata`,
+//!    `encoding_stats`, `size_statistics`, `type_`) are omitted entirely.
+//!    Saves ~110 bytes per `ColumnChunk` × 200k chunks on a wide file.
+//!
+//! 2. **Shared-buffer statistics.** `min_value` / `max_value` are stored as
+//!    `(offset, len)` ranges into the footer [`Buffer<u8>`] rather than
+//!    per-stat `Vec<u8>` allocations. On a 10k-col × 20-rg file with stats
+//!    this drops ~400k heap allocs to zero. The buffer itself is held once
+//!    on [`super::FileMetadata::footer_buf`].
+
+use polars_buffer::Buffer;
+use polars_parquet_format::{ColumnOrder, KeyValue, SchemaElement, SortingColumn};
+
+use crate::parquet::compression::Compression;
+
+/// `(offset, len)` into a shared [`Buffer<u8>`] holding the footer bytes.
+/// Used by [`CompactStatistics`] to reference `min_value` / `max_value`
+/// payloads in the footer without per-value heap allocation.
+///
+/// Both fields are `u32`; footers larger than 4 GiB cannot be represented.
+/// Parquet footer size is dominated by per-column metadata and in practice
+/// sits well under this limit even for 100k-column tables. Construction
+/// sites cast from `usize` with `as u32` (silent truncation). Audit these
+/// if the 4 GiB invariant is ever in doubt.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ByteRange {
+    pub offset: u32,
+    pub len: u32,
+}
+
+impl ByteRange {
+    /// Resolve this range against the shared `buf`. Caller must pass the
+    /// same buffer the range was produced from (typically the parquet footer).
+    #[inline]
+    pub(crate) fn resolve<'a>(&self, buf: &'a [u8]) -> &'a [u8] {
+        &buf[self.offset as usize..(self.offset as usize + self.len as usize)]
+    }
+}
+
+/// Compact replacement for `polars_parquet_format::Statistics`.
+///
+/// Deprecated `max` / `min` fields skipped (polars reads `max_value` /
+/// `min_value`). Modern values are stored as offsets into the file's
+/// footer buffer, available via [`super::FileMetadata::footer_buf`].
+#[derive(Debug, Clone)]
+pub(crate) struct CompactStatistics {
+    pub null_count: Option<i64>,
+    pub distinct_count: Option<i64>,
+    pub max_value: Option<ByteRange>,
+    pub min_value: Option<ByteRange>,
+    pub is_max_value_exact: Option<bool>,
+    pub is_min_value_exact: Option<bool>,
+}
+
+/// Compact replacement for `polars_parquet_format::ColumnMetaData`.
+///
+/// Drops fields with no read-path consumer:
+/// - `type_`: `ColumnDescriptor::primitive_type.physical_type` covers it
+/// - `encodings`: no in-workspace caller
+/// - `path_in_schema`: `ColumnDescriptor::path_in_schema` covers it
+/// - `key_value_metadata`: only file-level KV is exposed
+/// - `encoding_stats`, `size_statistics`: no public accessors
+#[derive(Debug, Clone)]
+pub(crate) struct CompactColumnMetaData {
+    pub codec: Compression,
+    pub num_values: i64,
+    pub total_uncompressed_size: i64,
+    pub total_compressed_size: i64,
+    pub data_page_offset: i64,
+    pub index_page_offset: Option<i64>,
+    pub dictionary_page_offset: Option<i64>,
+    pub statistics: Option<CompactStatistics>,
+    pub bloom_filter_offset: Option<i64>,
+    pub bloom_filter_length: Option<i32>,
+}
+
+/// Compact replacement for `polars_parquet_format::ColumnChunk`.
+///
+/// Drops `file_path`, `file_offset`, encryption fields. None have read-path
+/// consumers in this build (the write path constructs format-crate types).
+///
+/// `meta_data` is non-`Option` because polars has no encryption support: a
+/// chunk without unencrypted metadata is unrepresentable here. The decoder
+/// rejects such chunks at footer-decode time with `"ColumnChunk.meta_data
+/// missing"`, so by the time a `CompactColumnChunk` exists the field is
+/// guaranteed present.
+#[derive(Debug, Clone)]
+pub(crate) struct CompactColumnChunk {
+    pub meta_data: CompactColumnMetaData,
+    pub offset_index_offset: Option<i64>,
+    pub offset_index_length: Option<i32>,
+    pub column_index_offset: Option<i64>,
+    pub column_index_length: Option<i32>,
+}
+
+/// Compact replacement for `polars_parquet_format::RowGroup`.
+///
+/// `file_offset`, `total_compressed_size`, `ordinal` are dropped (no
+/// in-workspace consumers).
+#[derive(Debug, Clone)]
+pub(crate) struct CompactRowGroup {
+    pub columns: Vec<CompactColumnChunk>,
+    pub total_byte_size: i64,
+    pub num_rows: i64,
+    pub sorting_columns: Option<Vec<SortingColumn>>,
+}
+
+/// Compact replacement for `polars_parquet_format::FileMetaData`.
+///
+/// `schema`, `key_value_metadata`, `column_orders` stay as lists of
+/// format-crate structs because downstream consumers
+/// (`SchemaDescriptor::try_from_thrift`, `FileMetadata::key_value_metadata`,
+/// `parse_column_orders`) expect that shape. Refactoring those would cross
+/// the `polars-parquet-format` boundary. (Note: `sorting_columns` lives on
+/// `CompactRowGroup`, not here, and is also kept as the format-crate type.)
+#[derive(Debug, Clone)]
+pub(crate) struct CompactFileMetaData {
+    pub version: i32,
+    pub schema: Vec<SchemaElement>,
+    pub num_rows: i64,
+    pub row_groups: Vec<CompactRowGroup>,
+    pub key_value_metadata: Option<Vec<KeyValue>>,
+    pub created_by: Option<String>,
+    pub column_orders: Option<Vec<ColumnOrder>>,
+    /// The footer buffer the [`CompactStatistics`] `ByteRange`s point into.
+    /// `from_compact` stores it on [`super::FileMetadata::footer_buf`] so
+    /// stats payloads remain resolvable for the lifetime of the metadata.
+    pub footer_buf: Buffer<u8>,
+}

--- a/crates/polars-parquet/src/parquet/metadata/file_metadata.rs
+++ b/crates/polars-parquet/src/parquet/metadata/file_metadata.rs
@@ -1,15 +1,21 @@
+use polars_buffer::Buffer;
 use polars_parquet_format::ColumnOrder as TColumnOrder;
 
 use super::RowGroupMetadata;
 use super::column_order::ColumnOrder;
+use super::compact::CompactFileMetaData;
 use super::schema_descriptor::SchemaDescriptor;
-use crate::parquet::error::ParquetError;
+use crate::parquet::error::ParquetResult;
 use crate::parquet::metadata::get_sort_order;
 pub use crate::parquet::thrift_format::KeyValue;
 
 /// Metadata for a Parquet file.
-// This is almost equal to [`polars_parquet_format::FileMetaData`] but contains the descriptors,
-// which are crucial to deserialize pages.
+//
+// Polars-side representation of a parsed Parquet file footer. Wraps the
+// schema descriptor (with column descriptors needed for page deserialisation),
+// per-row-group structures, and the footer buffer that backs lazily-resolved
+// column-chunk statistics. Built from `CompactFileMetaData` (the hand-written
+// decoder's output) via `Self::from_compact`.
 #[derive(Debug, Clone)]
 pub struct FileMetadata {
     /// version of this file.
@@ -41,15 +47,20 @@ pub struct FileMetadata {
     /// When `None` is returned, there are no column orders available, and each column
     /// should be assumed to have undefined (legacy) column order.
     pub column_orders: Option<Vec<ColumnOrder>>,
+    /// Footer bytes that back this file's column-chunk statistics. Stats
+    /// `min_value` / `max_value` are stored as `(offset, len)` ranges into
+    /// this buffer; pass `&self.footer_buf` to
+    /// [`super::ColumnChunkMetadata::statistics`] to materialise them.
+    pub footer_buf: Buffer<u8>,
 }
 
 impl FileMetadata {
-    /// Returns the [`SchemaDescriptor`] that describes schema of this file.
+    /// Returns the [`SchemaDescriptor`] that describes the schema of this file.
     pub fn schema(&self) -> &SchemaDescriptor {
         &self.schema_descr
     }
 
-    /// returns the metadata
+    /// Returns the file-level key-value metadata, if present.
     pub fn key_value_metadata(&self) -> &Option<Vec<KeyValue>> {
         &self.key_value_metadata
     }
@@ -63,37 +74,50 @@ impl FileMetadata {
             .unwrap_or(ColumnOrder::Undefined)
     }
 
-    /// Deserializes [`crate::parquet::thrift_format::FileMetadata`] into this struct
-    pub fn try_from_thrift(
-        metadata: polars_parquet_format::FileMetaData,
-    ) -> Result<Self, ParquetError> {
-        let schema_descr = SchemaDescriptor::try_from_thrift(&metadata.schema)?;
+    /// Build a `FileMetadata` from a [`CompactFileMetaData`], the output of
+    /// the hand-written Thrift decoder. Parses the schema, attaches each
+    /// row group's chunks to the schema's descriptors, and stores the
+    /// footer buffer at the file level for stats resolution.
+    ///
+    /// Crate-internal: external callers go through
+    /// [`crate::parquet::read::deserialize_metadata`] which combines the
+    /// hand-written decoder with this constructor.
+    pub(crate) fn from_compact(compact: CompactFileMetaData) -> ParquetResult<Self> {
+        let CompactFileMetaData {
+            version,
+            schema,
+            num_rows,
+            row_groups,
+            key_value_metadata,
+            created_by,
+            column_orders,
+            footer_buf,
+        } = compact;
+
+        let schema_descr = SchemaDescriptor::try_from_thrift(&schema)?;
 
         let mut max_row_group_height = 0;
-
-        let row_groups = metadata
-            .row_groups
+        let row_groups = row_groups
             .into_iter()
             .map(|rg| {
-                let md = RowGroupMetadata::try_from_thrift(&schema_descr, rg)?;
+                let md = RowGroupMetadata::from_compact(&schema_descr, rg)?;
                 max_row_group_height = max_row_group_height.max(md.num_rows());
                 Ok(md)
             })
-            .collect::<Result<_, ParquetError>>()?;
+            .collect::<ParquetResult<_>>()?;
 
-        let column_orders = metadata
-            .column_orders
-            .map(|orders| parse_column_orders(&orders, &schema_descr));
+        let column_orders = column_orders.map(|orders| parse_column_orders(&orders, &schema_descr));
 
         Ok(FileMetadata {
-            version: metadata.version,
-            num_rows: metadata.num_rows.try_into()?,
+            version,
+            num_rows: num_rows.try_into()?,
             max_row_group_height,
-            created_by: metadata.created_by,
+            created_by,
             row_groups,
-            key_value_metadata: metadata.key_value_metadata,
+            key_value_metadata,
             schema_descr,
             column_orders,
+            footer_buf,
         })
     }
 }

--- a/crates/polars-parquet/src/parquet/metadata/mod.rs
+++ b/crates/polars-parquet/src/parquet/metadata/mod.rs
@@ -1,6 +1,7 @@
 mod column_chunk_metadata;
 mod column_descriptor;
 mod column_order;
+mod compact;
 mod file_metadata;
 mod row_metadata;
 mod schema_descriptor;
@@ -9,6 +10,10 @@ mod sort;
 pub use column_chunk_metadata::ColumnChunkMetadata;
 pub use column_descriptor::{ColumnDescriptor, Descriptor};
 pub use column_order::ColumnOrder;
+pub(crate) use compact::{
+    ByteRange, CompactColumnChunk, CompactColumnMetaData, CompactFileMetaData, CompactRowGroup,
+    CompactStatistics,
+};
 pub use file_metadata::{FileMetadata, KeyValue};
 pub use row_metadata::RowGroupMetadata;
 pub use schema_descriptor::SchemaDescriptor;

--- a/crates/polars-parquet/src/parquet/metadata/row_metadata.rs
+++ b/crates/polars-parquet/src/parquet/metadata/row_metadata.rs
@@ -1,46 +1,42 @@
 use std::sync::Arc;
 
 use hashbrown::hash_map::RawEntryMut;
-use polars_parquet_format::{RowGroup, SortingColumn};
+use polars_parquet_format::SortingColumn;
 use polars_utils::aliases::{InitHashMaps, PlHashMap};
 use polars_utils::idx_vec::UnitVec;
 use polars_utils::pl_str::PlSmallStr;
 use polars_utils::unitvec;
 
-use super::column_chunk_metadata::{ColumnChunkMetadata, column_metadata_byte_range};
+use super::column_chunk_metadata::{ColumnChunkMetadata, column_metadata_byte_range_compact};
+use super::column_descriptor::ColumnDescriptorRef;
+use super::compact::CompactRowGroup;
 use super::schema_descriptor::SchemaDescriptor;
 use crate::parquet::error::{ParquetError, ParquetResult};
 
 type ColumnLookup = PlHashMap<PlSmallStr, UnitVec<usize>>;
 
-trait InitColumnLookup {
-    fn add_column(&mut self, index: usize, column: &ColumnChunkMetadata);
-}
+#[inline(always)]
+fn add_column(lookup: &mut ColumnLookup, index: usize, column: &ColumnChunkMetadata) {
+    let root_name = &column.descriptor().path_in_schema[0];
 
-impl InitColumnLookup for ColumnLookup {
-    #[inline(always)]
-    fn add_column(&mut self, index: usize, column: &ColumnChunkMetadata) {
-        let root_name = &column.descriptor().path_in_schema[0];
-
-        match self.raw_entry_mut().from_key(root_name) {
-            RawEntryMut::Vacant(slot) => {
-                slot.insert(root_name.clone(), unitvec![index]);
-            },
-            RawEntryMut::Occupied(mut slot) => {
-                slot.get_mut().push(index);
-            },
-        };
+    match lookup.raw_entry_mut().from_key(root_name) {
+        RawEntryMut::Vacant(slot) => {
+            slot.insert(root_name.clone(), unitvec![index]);
+        },
+        RawEntryMut::Occupied(mut slot) => {
+            slot.get_mut().push(index);
+        },
     }
 }
 
 /// Metadata for a row group.
 #[derive(Debug, Clone, Default)]
 pub struct RowGroupMetadata {
-    // Moving of `ColumnChunkMetadata` is very expensive they are rather big. So, we arc the vec
-    // instead of having an arc slice. This way we don't to move the vec values into an arc when
-    // collecting.
+    // `ColumnChunkMetadata` is large, so we use `Arc<Vec<_>>` instead of `Arc<[_]>` to avoid
+    // moving every value into a fresh Arc allocation when collecting. The `Arc<Vec<...>>`
+    // form just wraps the existing Vec buffer: one Arc bump, zero element moves.
     columns: Arc<Vec<ColumnChunkMetadata>>,
-    column_lookup: PlHashMap<PlSmallStr, UnitVec<usize>>,
+    column_lookup: ColumnLookup,
     num_rows: usize,
     total_byte_size: usize,
     full_byte_range: core::ops::Range<u64>,
@@ -69,7 +65,7 @@ impl RowGroupMetadata {
     }
 
     pub fn parquet_columns(&self) -> &[ColumnChunkMetadata] {
-        self.columns.as_ref().as_slice()
+        &self.columns
     }
 
     /// Number of rows in this row group.
@@ -83,10 +79,14 @@ impl RowGroupMetadata {
     }
 
     /// Total size of all compressed column data in this row group.
+    ///
+    /// Per-chunk sizes are clamped at zero before summing so a malformed
+    /// file with a negative `compressed_size` cannot underflow into a huge
+    /// `usize`.
     pub fn compressed_size(&self) -> usize {
         self.columns
             .iter()
-            .map(|c| c.compressed_size() as usize)
+            .map(|c| c.compressed_size().max(0) as usize)
             .sum::<usize>()
     }
 
@@ -94,7 +94,7 @@ impl RowGroupMetadata {
         self.full_byte_range.clone()
     }
 
-    pub fn byte_ranges_iter(&self) -> impl '_ + ExactSizeIterator<Item = core::ops::Range<u64>> {
+    pub fn byte_ranges_iter(&self) -> impl ExactSizeIterator<Item = core::ops::Range<u64>> + '_ {
         self.columns.iter().map(|x| x.byte_range())
     }
 
@@ -102,10 +102,11 @@ impl RowGroupMetadata {
         self.sorting_columns.as_deref()
     }
 
-    /// Method to convert from Thrift.
-    pub(crate) fn try_from_thrift(
+    /// Build a `RowGroupMetadata` from a [`CompactRowGroup`], joining each
+    /// chunk to its descriptor in the schema.
+    pub(crate) fn from_compact(
         schema_descr: &SchemaDescriptor,
-        rg: RowGroup,
+        rg: CompactRowGroup,
     ) -> ParquetResult<RowGroupMetadata> {
         if schema_descr.columns().len() != rg.columns.len() {
             return Err(ParquetError::oos(format!(
@@ -118,35 +119,34 @@ impl RowGroupMetadata {
         let num_rows = rg.num_rows.try_into()?;
 
         let mut column_lookup = ColumnLookup::with_capacity(rg.columns.len());
-        let mut full_byte_range = if let Some(first_column_chunk) = rg.columns.first() {
-            let Some(metadata) = &first_column_chunk.meta_data else {
-                return Err(ParquetError::oos("Column chunk requires metadata"));
-            };
-            column_metadata_byte_range(metadata)
-        } else {
-            0..0
+        let mut full_byte_range = match rg.columns.first() {
+            Some(first) => column_metadata_byte_range_compact(&first.meta_data),
+            None => 0..0,
         };
 
-        let sorting_columns = rg.sorting_columns.clone();
+        let sorting_columns = rg.sorting_columns;
+
+        // Refcount-bump the schema's `Arc<Vec<ColumnDescriptor>>` once; each
+        // chunk holds a [`ColumnDescriptorRef`] that bumps the refcount again
+        // (cheap), instead of deep-cloning the descriptor.
+        let column_descrs = Arc::clone(schema_descr.columns_arc());
 
         let columns = rg
             .columns
             .into_iter()
-            .zip(schema_descr.columns())
             .enumerate()
-            .map(|(i, (column_chunk, descriptor))| {
-                let column =
-                    ColumnChunkMetadata::try_from_thrift(descriptor.clone(), column_chunk)?;
-
-                column_lookup.add_column(i, &column);
-
+            .map(|(i, column_chunk)| {
+                let column = ColumnChunkMetadata::from_compact(
+                    ColumnDescriptorRef::new(Arc::clone(&column_descrs), i),
+                    column_chunk,
+                );
+                add_column(&mut column_lookup, i, &column);
                 let byte_range = column.byte_range();
                 full_byte_range = full_byte_range.start.min(byte_range.start)
                     ..full_byte_range.end.max(byte_range.end);
-
-                Ok(column)
+                column
             })
-            .collect::<ParquetResult<Vec<_>>>()?;
+            .collect::<Vec<_>>();
         let columns = Arc::new(columns);
 
         Ok(RowGroupMetadata {

--- a/crates/polars-parquet/src/parquet/metadata/schema_descriptor.rs
+++ b/crates/polars-parquet/src/parquet/metadata/schema_descriptor.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use polars_parquet_format::SchemaElement;
 use polars_utils::pl_str::PlSmallStr;
 #[cfg(feature = "serde")]
@@ -9,8 +11,8 @@ use crate::parquet::schema::Repetition;
 use crate::parquet::schema::io_message::from_message;
 use crate::parquet::schema::types::{FieldInfo, ParquetType};
 
-/// A schema descriptor. This encapsulates the top-level schemas for all the columns,
-/// as well as all descriptors for all the primitive columns.
+/// A schema descriptor. This encapsulates the top-level schema for all the
+/// columns, as well as the descriptors for the primitive columns.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct SchemaDescriptor {
@@ -19,8 +21,11 @@ pub struct SchemaDescriptor {
     fields: Vec<ParquetType>,
 
     // All the descriptors for primitive columns in this schema, constructed from
-    // `schema` in DFS order.
-    leaves: Vec<ColumnDescriptor>,
+    // `schema` in DFS order. Wrapped in `Arc` so all `ColumnChunkMetadata`
+    // built from this schema can share one heap allocation; per-chunk
+    // ownership is `(Arc::clone, index)` instead of a deep `ColumnDescriptor`
+    // clone. See [`super::ColumnChunkMetadata`].
+    leaves: Arc<Vec<ColumnDescriptor>>,
 }
 
 impl SchemaDescriptor {
@@ -35,7 +40,7 @@ impl SchemaDescriptor {
         Self {
             name,
             fields,
-            leaves,
+            leaves: Arc::new(leaves),
         }
     }
 
@@ -47,19 +52,21 @@ impl SchemaDescriptor {
         &self.leaves
     }
 
-    /// The schemas' name.
+    /// Internal handle on the shared `Arc<Vec<ColumnDescriptor>>` so the
+    /// metadata-build path (`RowGroupMetadata::from_compact`) can refcount-bump
+    /// instead of deep-cloning the descriptors per chunk.
+    pub(crate) fn columns_arc(&self) -> &Arc<Vec<ColumnDescriptor>> {
+        &self.leaves
+    }
+
+    /// The schema's name.
     pub fn name(&self) -> &str {
         &self.name
     }
 
-    /// The schemas' fields.
+    /// The schema's fields.
     pub fn fields(&self) -> &[ParquetType] {
         &self.fields
-    }
-
-    /// The schemas' leaves.
-    pub fn leaves(&self) -> &[ColumnDescriptor] {
-        &self.leaves
     }
 
     pub(crate) fn into_thrift(self) -> Vec<SchemaElement> {
@@ -90,7 +97,7 @@ impl SchemaDescriptor {
         Self::try_from_type(schema)
     }
 
-    /// Creates a schema from
+    /// Creates a schema from a Parquet message-format string.
     pub fn try_from_message(message: &str) -> ParquetResult<Self> {
         let schema = from_message(message)?;
         Self::try_from_type(schema)
@@ -141,8 +148,8 @@ fn build_tree<'a>(
                     leaves,
                     path_so_far,
                 );
-                path_so_far.pop();
             }
         },
     }
+    path_so_far.pop();
 }

--- a/crates/polars-parquet/src/parquet/mod.rs
+++ b/crates/polars-parquet/src/parquet/mod.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod bloom_filter;
 pub mod compression;
 pub mod encoding;
+pub(crate) mod handwritten_thrift;
 pub mod metadata;
 pub mod page;
 mod parquet_bridge;

--- a/crates/polars-parquet/src/parquet/read/metadata.rs
+++ b/crates/polars-parquet/src/parquet/read/metadata.rs
@@ -1,14 +1,15 @@
 use std::cmp::min;
 use std::io::{Read, Seek, SeekFrom};
 
-use polars_parquet_format::FileMetaData as TFileMetadata;
-use polars_parquet_format::thrift::protocol::TCompactInputProtocol;
+use polars_buffer::Buffer;
 
 use super::super::metadata::FileMetadata;
 use super::super::{DEFAULT_FOOTER_READ_SIZE, FOOTER_SIZE, HEADER_SIZE, PARQUET_MAGIC};
 use crate::parquet::error::{ParquetError, ParquetResult};
+use crate::parquet::handwritten_thrift::decode_file_metadata;
 
-pub(super) fn metadata_len(buffer: &[u8], len: usize) -> u32 {
+pub(super) fn metadata_len(buffer: &[u8]) -> u32 {
+    let len = buffer.len();
     u32::from_le_bytes(buffer[len - 8..len - 4].try_into().unwrap())
 }
 
@@ -40,7 +41,7 @@ pub fn read_metadata_with_size<R: Read + Seek>(
 ) -> ParquetResult<FileMetadata> {
     if file_size < HEADER_SIZE + FOOTER_SIZE {
         return Err(ParquetError::oos(
-            "A parquet file must contain a header and footer with at least 12 bytes",
+            "A Parquet file must contain a header and footer with at least 12 bytes",
         ));
     }
 
@@ -48,9 +49,9 @@ pub fn read_metadata_with_size<R: Read + Seek>(
     let default_end_len = min(DEFAULT_FOOTER_READ_SIZE, file_size) as usize;
     reader.seek(SeekFrom::End(-(default_end_len as i64)))?;
 
-    let mut buffer = Vec::with_capacity(default_end_len);
+    let mut buffer = vec![];
+    buffer.try_reserve(default_end_len)?;
     reader
-        .by_ref()
         .take(default_end_len as u64)
         .read_to_end(&mut buffer)?;
 
@@ -59,7 +60,7 @@ pub fn read_metadata_with_size<R: Read + Seek>(
         return Err(ParquetError::oos("The file must end with PAR1"));
     }
 
-    let metadata_len: u32 = metadata_len(&buffer, default_end_len);
+    let metadata_len: u32 = metadata_len(&buffer);
     let metadata_len: u64 = metadata_len as u64;
 
     let footer_len = FOOTER_SIZE + metadata_len;
@@ -69,31 +70,34 @@ pub fn read_metadata_with_size<R: Read + Seek>(
         ));
     }
 
-    let reader: &[u8] = if (footer_len as usize) < buffer.len() {
-        // the whole metadata is in the bytes we already read
+    // Footer bytes need to outlive the FileMetadata so stats `ByteRange`s
+    // stay resolvable, wrap in a `Buffer`. Both branches end with a
+    // zero-copy move from the source `Vec<u8>` into the buffer.
+    let footer_buf: Buffer<u8> = if (footer_len as usize) <= buffer.len() {
+        // The full footer is already in the bytes we prefetched, slice into
+        // the existing buffer.
         let remaining = buffer.len() - footer_len as usize;
-        &buffer[remaining..]
+        Buffer::from_vec(buffer).sliced(remaining..)
     } else {
-        // the end of file read by default is not long enough, read again including the metadata.
+        // the end of file read by default is not long enough, read again
+        // including the metadata.
         reader.seek(SeekFrom::End(-(footer_len as i64)))?;
 
         buffer.clear();
         buffer.try_reserve(footer_len as usize)?;
         reader.take(footer_len).read_to_end(&mut buffer)?;
 
-        &buffer
+        Buffer::from_vec(buffer)
     };
-
-    // a highly nested but sparse struct could result in many allocations
-    let max_size = reader.len() * 2 + 1024;
-
-    deserialize_metadata(reader, max_size)
+    deserialize_metadata(footer_buf)
 }
 
-/// Parse loaded metadata bytes
-pub fn deserialize_metadata<R: Read>(reader: R, max_size: usize) -> ParquetResult<FileMetadata> {
-    let mut prot = TCompactInputProtocol::new(reader, max_size);
-    let metadata = TFileMetadata::read_from_in_protocol(&mut prot)?;
-
-    FileMetadata::try_from_thrift(metadata)
+/// Parse loaded metadata bytes via the hand-written Thrift compact decoder.
+///
+/// `footer` must be a [`Buffer<u8>`] because [`FileMetadata`] holds the buffer
+/// for the lifetime of the metadata; column-chunk statistics store
+/// `ByteRange`s into it instead of allocating per-stat byte vecs.
+pub fn deserialize_metadata(footer: Buffer<u8>) -> ParquetResult<FileMetadata> {
+    let compact = decode_file_metadata(footer)?;
+    FileMetadata::from_compact(compact)
 }

--- a/crates/polars-parquet/src/parquet/read/stream.rs
+++ b/crates/polars-parquet/src/parquet/read/stream.rs
@@ -1,6 +1,7 @@
 use std::io::SeekFrom;
 
 use futures::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt};
+use polars_buffer::Buffer;
 
 use super::super::metadata::FileMetadata;
 use super::super::{DEFAULT_FOOTER_READ_SIZE, FOOTER_SIZE, PARQUET_MAGIC};
@@ -31,7 +32,7 @@ pub async fn read_metadata<R: AsyncRead + AsyncSeek + Send + std::marker::Unpin>
 
     if file_size < HEADER_SIZE + FOOTER_SIZE {
         return Err(ParquetError::oos(
-            "A parquet file must contain a header and footer with at least 12 bytes",
+            "A Parquet file must contain a header and footer with at least 12 bytes",
         ));
     }
 
@@ -50,10 +51,10 @@ pub async fn read_metadata<R: AsyncRead + AsyncSeek + Send + std::marker::Unpin>
 
     // check this is indeed a parquet file
     if buffer[default_end_len - 4..] != PARQUET_MAGIC {
-        return Err(ParquetError::oos("Invalid Parquet file. Corrupt footer"));
+        return Err(ParquetError::oos("The file must end with PAR1"));
     }
 
-    let metadata_len: u32 = metadata_len(&buffer, default_end_len);
+    let metadata_len: u32 = metadata_len(&buffer);
     let metadata_len: u64 = metadata_len as u64;
 
     let footer_len = FOOTER_SIZE + metadata_len;
@@ -63,26 +64,24 @@ pub async fn read_metadata<R: AsyncRead + AsyncSeek + Send + std::marker::Unpin>
         ));
     }
 
-    let reader = if (footer_len as usize) < buffer.len() {
-        // the whole metadata is in the bytes we already read
+    // Footer bytes need to outlive the FileMetadata so stats `ByteRange`s
+    // stay resolvable, wrap in a `Buffer`. Both branches end with a
+    // zero-copy move from the source `Vec<u8>` into the buffer.
+    let footer_buf: Buffer<u8> = if (footer_len as usize) <= buffer.len() {
+        // The full footer is already in the bytes we prefetched, slice into
+        // the existing buffer.
         let remaining = buffer.len() - footer_len as usize;
-        &buffer[remaining..]
+        Buffer::from_vec(buffer).sliced(remaining..)
     } else {
-        // the end of file read by default is not long enough, read again including the metadata.
+        // the end of file read by default is not long enough, read again
+        // including the metadata.
         reader.seek(SeekFrom::End(-(footer_len as i64))).await?;
 
         buffer.clear();
         buffer.try_reserve(footer_len as usize)?;
-        reader
-            .take(footer_len as u64)
-            .read_to_end(&mut buffer)
-            .await?;
+        reader.take(footer_len).read_to_end(&mut buffer).await?;
 
-        &buffer
+        Buffer::from_vec(buffer)
     };
-
-    // a highly nested but sparse struct could result in many allocations
-    let max_size = reader.len() * 2 + 1024;
-
-    deserialize_metadata(reader, max_size)
+    deserialize_metadata(footer_buf)
 }

--- a/crates/polars-stream/src/nodes/io_sinks/writers/parquet/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/writers/parquet/mod.rs
@@ -113,7 +113,7 @@ impl FileWriterStarter for ParquetWriterStarter {
         };
 
         let arrow_schema = Arc::clone(&self.arrow_schema);
-        let num_leaf_columns = schema_descriptor.leaves().len();
+        let num_leaf_columns = schema_descriptor.columns().len();
 
         let io_handle = tokio_handle_ext::AbortOnDropHandle(
             pl_async::get_runtime().spawn(

--- a/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
@@ -122,8 +122,7 @@ impl FileReader for ParquetFileReader {
             }
 
             Arc::new(polars_parquet::parquet::read::deserialize_metadata(
-                metadata_bytes.as_ref(),
-                metadata_bytes.len() * 2 + 1024,
+                metadata_bytes,
             )?)
         };
 

--- a/crates/polars-stream/src/nodes/io_sources/parquet/statistics.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/statistics.rs
@@ -132,7 +132,8 @@ pub(super) async fn calculate_row_group_pred_pushdown_skip_mask(
                 continue;
             }
 
-            let mut statistics = load_parquet_column_statistics(row_groups_slice, projection)?;
+            let mut statistics =
+                load_parquet_column_statistics(row_groups_slice, projection, &metadata.footer_buf)?;
 
             // Note: Order is important here. We re-use the transform for the output column, meaning
             // that it may set the column name.
@@ -172,6 +173,7 @@ pub(super) async fn calculate_row_group_pred_pushdown_skip_mask(
 fn load_parquet_column_statistics(
     row_groups: &[RowGroupMetadata],
     projection: &ArrowFieldProjection,
+    footer_buf: &polars_buffer::Buffer<u8>,
 ) -> PolarsResult<StatisticsColumns> {
     let arrow_field = projection.arrow_field();
 
@@ -197,7 +199,7 @@ fn load_parquet_column_statistics(
 
     let idx = idxs[0];
 
-    let Some(statistics) = deserialize_all(arrow_field, row_groups, idx)? else {
+    let Some(statistics) = deserialize_all(arrow_field, row_groups, idx, footer_buf)? else {
         return null_statistics();
     };
 

--- a/crates/polars/tests/it/io/parquet/read/mod.rs
+++ b/crates/polars/tests/it/io/parquet/read/mod.rs
@@ -237,7 +237,7 @@ pub fn read_column(
     let mut statistics = metadata.row_groups[row_group]
         .columns_under_root_iter(field.name())
         .unwrap()
-        .map(|column_meta| column_meta.statistics().transpose())
+        .map(|column_meta| column_meta.statistics(&metadata.footer_buf).transpose())
         .collect::<ParquetResult<Vec<_>>>()?;
 
     let array = columns_to_array(columns, field)?;


### PR DESCRIPTION
| Fixture                          |   Footer | `main` median | this PR  | Speedup   |
| -------------------------------- | -------: | ------------: | -------: | --------: |
| `float32_100cols_20rg.parquet`   | 129.0 KB |       2.12 ms |  1.32 ms | **1.61×** |
| `float32_1000cols_20rg.parquet`  |  1.33 MB |      11.66 ms |  4.43 ms | **2.63×** |
| `float32_10000cols_20rg.parquet` | 13.75 MB |       117.4 ms | 35.74 ms | **3.29×** |
| `string_100cols_20rg.parquet`    | 127.1 KB |       2.10 ms |  1.35 ms | **1.56×** |
| `string_1000cols_20rg.parquet`   |  1.32 MB |      11.63 ms |  4.52 ms | **2.57×** |
| `string_10000cols_20rg.parquet`  | 13.75 MB |       113.5 ms | 37.34 ms | **3.04×** |

- **Fixtures:** {Float32, String} × N columns × 20 row groups × 1 row/rg, uncompressed (full Thrift decode, alamb-harness shape).
- **Hardware:** Apple M4 Pro.