### PR TITLE
docs(python): Document `write_ipc` buffer behavior with `file=None`

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -4009,6 +4009,16 @@ class DataFrame:
         ... )
         >>> path: pathlib.Path = dirpath / "new_file.arrow"
         >>> df.write_ipc(path)
+
+        Write to a ``BytesIO`` object by passing ``file=None``. The returned
+        buffer's position is at the end of the written data, so call ``seek(0)``
+        before reading it back.
+
+        >>> buf = df.write_ipc(file=None)
+        >>> buf.seek(0)
+        0
+        >>> pl.read_ipc(buf).equals(df)
+        True
         """
         return_bytes = file is None
         target: str | Path | IO[bytes]


### PR DESCRIPTION
Closes #18200.

Documents the behavior of `DataFrame.write_ipc(file=None)`.

When `file=None`, `write_ipc` returns a `BytesIO` object. The buffer position is left at the end of the written data, so users need to call `seek(0)` before reading it back with `pl.read_ipc`.

Added a short docstring example showing:

```python
buf = df.write_ipc(file=None)
buf.seek(0)
pl.read_ipc(buf).equals(df)
```

AI usage:

 - I used AI to help draft the documentation wording and PR description.
 - I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.


<img width="1061" height="231" alt="issue18200" src="https://github.com/user-attachments/assets/ecb68f1c-710a-4efc-8f1d-574412af5c90" />

