### PR TITLE
docs(python): Clarify null handling in unique operations

### DIFF
--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -3736,6 +3736,8 @@ class Expr:
         """
         Get unique values of this expression.
 
+        `null` is considered to be a unique value for the purposes of this operation.
+
         Parameters
         ----------
         maintain_order

--- a/py-polars/src/polars/functions/lazy.py
+++ b/py-polars/src/polars/functions/lazy.py
@@ -489,6 +489,8 @@ def n_unique(*columns: str) -> Expr:
 
     This function is syntactic sugar for `pl.col(columns).n_unique()`.
 
+    `null` is considered to be a unique value for the purposes of this operation.
+
     Parameters
     ----------
     columns
@@ -498,7 +500,7 @@ def n_unique(*columns: str) -> Expr:
     --------
     >>> df = pl.DataFrame(
     ...     {
-    ...         "a": [1, 8, 1],
+    ...         "a": [1, 1, None],
     ...         "b": [4, 5, 2],
     ...         "c": ["foo", "bar", "foo"],
     ...     }

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -4030,6 +4030,8 @@ class Series:
         """
         Get unique elements in series.
 
+        `null` is considered to be a unique value for the purposes of this operation.
+
         Parameters
         ----------
         maintain_order
@@ -8200,9 +8202,11 @@ class Series:
         """
         Count the number of unique values in this Series.
 
+        `null` is considered to be a unique value for the purposes of this operation.
+
         Examples
         --------
-        >>> s = pl.Series("a", [1, 2, 2, 3])
+        >>> s = pl.Series("a", [1, 2, 2, None])
         >>> s.n_unique()
         3
         """


### PR DESCRIPTION
Closes #7770.

## Summary

Clarifies that `null` is considered a unique value in Python API documentation for unique operations.

Updated docs for:

- `Series.unique`
- `Series.n_unique`
- `Expr.unique`
- `pl.n_unique`

Also updates the `pl.n_unique` and `Series.n_unique` examples to include `None`.

## Validation

```bash
git diff --check
ruff check py-polars/src/polars/series/series.py py-polars/src/polars/expr/expr.py py-polars/src/polars/functions/lazy.py
python -m pytest \
  py-polars/tests/unit/operations/unique/test_n_unique.py \
  py-polars/tests/unit/operations/unique/test_unique.py \
  -k "n_unique or unique"
 ```

- I used AI to help identify the narrow documentation scope and review the PR text.
- I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.
  
<img width="879" height="336" alt="image" src="https://github.com/user-attachments/assets/4b28177b-10a6-4dc2-883c-6d82a94fad9f" />