### PR TITLE
fix: Export enum as ordered dictionary to arrow

### DIFF
--- a/crates/polars-arrow/src/array/dictionary/mod.rs
+++ b/crates/polars-arrow/src/array/dictionary/mod.rs
@@ -195,8 +195,12 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     /// # Errors
     /// This function errors iff
     /// * any of the keys's values is not represented in `usize` or is `>= values.len()`
-    pub fn try_from_keys(keys: PrimitiveArray<K>, values: Box<dyn Array>) -> PolarsResult<Self> {
-        let dtype = Self::default_dtype(values.dtype().clone());
+    pub fn try_from_keys(
+        keys: PrimitiveArray<K>,
+        values: Box<dyn Array>,
+        ordered: bool,
+    ) -> PolarsResult<Self> {
+        let dtype = Self::default_dtype(values.dtype().clone(), ordered);
         Self::try_new(dtype, keys, values)
     }
 
@@ -305,8 +309,8 @@ impl<K: DictionaryKey> DictionaryArray<K> {
         }
     }
 
-    pub(crate) fn default_dtype(values_datatype: ArrowDataType) -> ArrowDataType {
-        ArrowDataType::Dictionary(K::KEY_TYPE, Box::new(values_datatype), false)
+    pub(crate) fn default_dtype(values_datatype: ArrowDataType, ordered: bool) -> ArrowDataType {
+        ArrowDataType::Dictionary(K::KEY_TYPE, Box::new(values_datatype), ordered)
     }
 
     /// Slices this [`DictionaryArray`].

--- a/crates/polars-arrow/src/array/dictionary/mutable.rs
+++ b/crates/polars-arrow/src/array/dictionary/mutable.rs
@@ -35,14 +35,14 @@ impl<K: DictionaryKey, M: MutableArray> From<MutableDictionaryArray<K, M>> for D
 
 impl<K: DictionaryKey, M: MutableArray + Default> MutableDictionaryArray<K, M> {
     /// Creates an empty [`MutableDictionaryArray`].
-    pub fn new() -> Self {
-        Self::try_empty(M::default()).unwrap()
+    pub fn new(ordered: bool) -> Self {
+        Self::try_empty(M::default(), ordered).unwrap()
     }
 
     /// Creates an empty [`MutableDictionaryArray`] with the given value dtype.
-    pub fn empty_with_value_dtype(value_dtype: ArrowDataType) -> Self {
+    pub fn empty_with_value_dtype(value_dtype: ArrowDataType, ordered: bool) -> Self {
         let keys = MutablePrimitiveArray::<K>::new();
-        let dtype = ArrowDataType::Dictionary(K::KEY_TYPE, Box::new(value_dtype), false);
+        let dtype = ArrowDataType::Dictionary(K::KEY_TYPE, Box::new(value_dtype), ordered);
         Self {
             dtype,
             map: ValueMap::<K, M>::try_empty(M::default()).unwrap(),
@@ -53,7 +53,7 @@ impl<K: DictionaryKey, M: MutableArray + Default> MutableDictionaryArray<K, M> {
 
 impl<K: DictionaryKey, M: MutableArray + Default> Default for MutableDictionaryArray<K, M> {
     fn default() -> Self {
-        Self::new()
+        Self::new(false)
     }
 }
 
@@ -61,8 +61,11 @@ impl<K: DictionaryKey, M: MutableArray> MutableDictionaryArray<K, M> {
     /// Creates an empty [`MutableDictionaryArray`] from a given empty values array.
     /// # Errors
     /// Errors if the array is non-empty.
-    pub fn try_empty(values: M) -> PolarsResult<Self> {
-        Ok(Self::from_value_map(ValueMap::<K, M>::try_empty(values)?))
+    pub fn try_empty(values: M, ordered: bool) -> PolarsResult<Self> {
+        Ok(Self::from_value_map(
+            ValueMap::<K, M>::try_empty(values)?,
+            ordered,
+        ))
     }
 
     /// Creates an empty [`MutableDictionaryArray`] preloaded with a given dictionary of values.
@@ -70,18 +73,21 @@ impl<K: DictionaryKey, M: MutableArray> MutableDictionaryArray<K, M> {
     /// the values.
     /// # Errors
     /// Errors if there's more values than the maximum value of `K` or if values are not unique.
-    pub fn from_values(values: M) -> PolarsResult<Self>
+    pub fn from_values(values: M, ordered: bool) -> PolarsResult<Self>
     where
         M: Indexable,
         M::Type: Eq + Hash,
     {
-        Ok(Self::from_value_map(ValueMap::<K, M>::from_values(values)?))
+        Ok(Self::from_value_map(
+            ValueMap::<K, M>::from_values(values)?,
+            ordered,
+        ))
     }
 
-    fn from_value_map(value_map: ValueMap<K, M>) -> Self {
+    fn from_value_map(value_map: ValueMap<K, M>, ordered: bool) -> Self {
         let keys = MutablePrimitiveArray::<K>::new();
         let dtype =
-            ArrowDataType::Dictionary(K::KEY_TYPE, Box::new(value_map.dtype().clone()), false);
+            ArrowDataType::Dictionary(K::KEY_TYPE, Box::new(value_map.dtype().clone()), ordered);
         Self {
             dtype,
             map: value_map,
@@ -93,16 +99,16 @@ impl<K: DictionaryKey, M: MutableArray> MutableDictionaryArray<K, M> {
     /// mutable dictionary array, but with no data. This may come useful when serializing the
     /// array into multiple chunks, where there's a requirement that the dictionary is the same.
     /// No copying is performed, the value map is moved over to the new array.
-    pub fn into_empty(self) -> Self {
-        Self::from_value_map(self.map)
+    pub fn into_empty(self, ordered: bool) -> Self {
+        Self::from_value_map(self.map, ordered)
     }
 
     /// Same as `into_empty` but clones the inner value map instead of taking full ownership.
-    pub fn to_empty(&self) -> Self
+    pub fn to_empty(&self, ordered: bool) -> Self
     where
         M: Clone,
     {
-        Self::from_value_map(self.map.clone())
+        Self::from_value_map(self.map.clone(), ordered)
     }
 
     /// pushes a null value

--- a/crates/polars-arrow/src/datatypes/mod.rs
+++ b/crates/polars-arrow/src/datatypes/mod.rs
@@ -159,7 +159,7 @@ pub enum ArrowDataType {
     /// This type mostly used to represent low cardinality string
     /// arrays or a limited set of primitive types as integers.
     ///
-    /// The `bool` value indicates the `Dictionary` is sorted if set to `true`.
+    /// The `bool` value indicates the `Dictionary` keys are considered ordered.
     Dictionary(IntegerType, Box<ArrowDataType>, bool),
     /// Decimal value with precision and scale
     /// precision is the number of digits in the number and
@@ -413,8 +413,8 @@ impl ArrowDataType {
                     })
                     .collect(),
             ),
-            Dictionary(keys, values, is_sorted) => {
-                Dictionary(*keys, Box::new(values.to_storage_recursive()), *is_sorted)
+            Dictionary(keys, values, is_ordered) => {
+                Dictionary(*keys, Box::new(values.to_storage_recursive()), *is_ordered)
             },
             Union(_) => unimplemented!(),
             Map(_, _) => unimplemented!(),

--- a/crates/polars-compute/src/cast/binary_to.rs
+++ b/crates/polars-compute/src/cast/binary_to.rs
@@ -143,9 +143,11 @@ where
 /// in the array.
 pub fn binary_to_dictionary<O: Offset, K: DictionaryKey>(
     from: &BinaryArray<O>,
+    ordered: bool,
 ) -> PolarsResult<DictionaryArray<K>> {
     let mut array = MutableDictionaryArray::<K, MutableBinaryArray<O>>::empty_with_value_dtype(
         from.dtype().clone(),
+        ordered,
     );
     array.reserve(from.len());
     array.try_extend(from.iter())?;
@@ -155,9 +157,10 @@ pub fn binary_to_dictionary<O: Offset, K: DictionaryKey>(
 
 pub(super) fn binary_to_dictionary_dyn<O: Offset, K: DictionaryKey>(
     from: &dyn Array,
+    ordered: bool,
 ) -> PolarsResult<Box<dyn Array>> {
     let values = from.as_any().downcast_ref().unwrap();
-    binary_to_dictionary::<O, K>(values).map(|x| Box::new(x) as Box<dyn Array>)
+    binary_to_dictionary::<O, K>(values, ordered).map(|x| Box::new(x) as Box<dyn Array>)
 }
 
 fn fixed_size_to_offsets<O: Offset>(values_len: usize, fixed_size: usize) -> Offsets<O> {

--- a/crates/polars-compute/src/cast/binview_to.rs
+++ b/crates/polars-compute/src/cast/binview_to.rs
@@ -24,8 +24,9 @@ pub(super) const RFC3339: &str = "%Y-%m-%dT%H:%M:%S%.f%:z";
 /// in the array.
 pub(super) fn binview_to_dictionary<K: DictionaryKey>(
     from: &BinaryViewArray,
+    ordered: bool,
 ) -> PolarsResult<DictionaryArray<K>> {
-    let mut array = MutableDictionaryArray::<K, MutableBinaryViewArray<[u8]>>::new();
+    let mut array = MutableDictionaryArray::<K, MutableBinaryViewArray<[u8]>>::new(ordered);
     array.reserve(from.len());
     array.try_extend(from.iter())?;
 
@@ -34,8 +35,9 @@ pub(super) fn binview_to_dictionary<K: DictionaryKey>(
 
 pub(super) fn utf8view_to_dictionary<K: DictionaryKey>(
     from: &Utf8ViewArray,
+    ordered: bool,
 ) -> PolarsResult<DictionaryArray<K>> {
-    let mut array = MutableDictionaryArray::<K, MutableBinaryViewArray<str>>::new();
+    let mut array = MutableDictionaryArray::<K, MutableBinaryViewArray<str>>::new(ordered);
     array.reserve(from.len());
     array.try_extend(from.iter())?;
 

--- a/crates/polars-compute/src/cast/mod.rs
+++ b/crates/polars-compute/src/cast/mod.rs
@@ -423,8 +423,8 @@ pub fn cast(
         (Dictionary(index_type, ..), _) => match_integer_type!(index_type, |$T| {
             dictionary_cast_dyn::<$T>(array, to_type, options)
         }),
-        (_, Dictionary(index_type, value_type, _)) => match_integer_type!(index_type, |$T| {
-            cast_to_dictionary::<$T>(array, value_type, options)
+        (_, Dictionary(index_type, value_type, ordered)) => match_integer_type!(index_type, |$T| {
+            cast_to_dictionary::<$T>(array, value_type, *ordered, options)
         }),
         // not supported by polars
         // (List(_), FixedSizeList(inner, size)) => cast_list_to_fixed_size_list::<i32>(
@@ -1072,32 +1072,33 @@ pub fn cast(
 fn cast_to_dictionary<K: DictionaryKey>(
     array: &dyn Array,
     dict_value_type: &ArrowDataType,
+    ordered: bool,
     options: CastOptionsImpl,
 ) -> PolarsResult<Box<dyn Array>> {
     let array = cast(array, dict_value_type, options)?;
     let array = array.as_ref();
     match dict_value_type.to_storage() {
-        ArrowDataType::Int8 => primitive_to_dictionary_dyn::<i8, K>(array),
-        ArrowDataType::Int16 => primitive_to_dictionary_dyn::<i16, K>(array),
-        ArrowDataType::Int32 => primitive_to_dictionary_dyn::<i32, K>(array),
-        ArrowDataType::Int64 => primitive_to_dictionary_dyn::<i64, K>(array),
-        ArrowDataType::UInt8 => primitive_to_dictionary_dyn::<u8, K>(array),
-        ArrowDataType::UInt16 => primitive_to_dictionary_dyn::<u16, K>(array),
-        ArrowDataType::UInt32 => primitive_to_dictionary_dyn::<u32, K>(array),
-        ArrowDataType::UInt64 => primitive_to_dictionary_dyn::<u64, K>(array),
+        ArrowDataType::Int8 => primitive_to_dictionary_dyn::<i8, K>(array, ordered),
+        ArrowDataType::Int16 => primitive_to_dictionary_dyn::<i16, K>(array, ordered),
+        ArrowDataType::Int32 => primitive_to_dictionary_dyn::<i32, K>(array, ordered),
+        ArrowDataType::Int64 => primitive_to_dictionary_dyn::<i64, K>(array, ordered),
+        ArrowDataType::UInt8 => primitive_to_dictionary_dyn::<u8, K>(array, ordered),
+        ArrowDataType::UInt16 => primitive_to_dictionary_dyn::<u16, K>(array, ordered),
+        ArrowDataType::UInt32 => primitive_to_dictionary_dyn::<u32, K>(array, ordered),
+        ArrowDataType::UInt64 => primitive_to_dictionary_dyn::<u64, K>(array, ordered),
         ArrowDataType::BinaryView => {
-            binview_to_dictionary::<K>(array.as_any().downcast_ref().unwrap())
+            binview_to_dictionary::<K>(array.as_any().downcast_ref().unwrap(), ordered)
                 .map(|arr| arr.boxed())
         },
         ArrowDataType::Utf8View => {
-            utf8view_to_dictionary::<K>(array.as_any().downcast_ref().unwrap())
+            utf8view_to_dictionary::<K>(array.as_any().downcast_ref().unwrap(), ordered)
                 .map(|arr| arr.boxed())
         },
-        ArrowDataType::LargeUtf8 => utf8_to_dictionary_dyn::<i64, K>(array),
-        ArrowDataType::LargeBinary => binary_to_dictionary_dyn::<i64, K>(array),
-        ArrowDataType::Time64(_) => primitive_to_dictionary_dyn::<i64, K>(array),
-        ArrowDataType::Timestamp(_, _) => primitive_to_dictionary_dyn::<i64, K>(array),
-        ArrowDataType::Date32 => primitive_to_dictionary_dyn::<i32, K>(array),
+        ArrowDataType::LargeUtf8 => utf8_to_dictionary_dyn::<i64, K>(array, ordered),
+        ArrowDataType::LargeBinary => binary_to_dictionary_dyn::<i64, K>(array, ordered),
+        ArrowDataType::Time64(_) => primitive_to_dictionary_dyn::<i64, K>(array, ordered),
+        ArrowDataType::Timestamp(_, _) => primitive_to_dictionary_dyn::<i64, K>(array, ordered),
+        ArrowDataType::Date32 => primitive_to_dictionary_dyn::<i32, K>(array, ordered),
         _ => polars_bail!(ComputeError:
             "unsupported output type for dictionary packing: {dict_value_type:?}"
         ),

--- a/crates/polars-compute/src/cast/primitive_to.rs
+++ b/crates/polars-compute/src/cast/primitive_to.rs
@@ -338,9 +338,10 @@ where
 
 pub(super) fn primitive_to_dictionary_dyn<T: NativeType + Eq + Hash, K: DictionaryKey>(
     from: &dyn Array,
+    ordered: bool,
 ) -> PolarsResult<Box<dyn Array>> {
     let from = from.as_any().downcast_ref().unwrap();
-    primitive_to_dictionary::<T, K>(from).map(|x| Box::new(x) as Box<dyn Array>)
+    primitive_to_dictionary::<T, K>(from, ordered).map(|x| Box::new(x) as Box<dyn Array>)
 }
 
 /// Cast [`PrimitiveArray`] to [`DictionaryArray`]. Also known as packing.
@@ -349,11 +350,13 @@ pub(super) fn primitive_to_dictionary_dyn<T: NativeType + Eq + Hash, K: Dictiona
 /// in the array.
 pub fn primitive_to_dictionary<T: NativeType + Eq + Hash, K: DictionaryKey>(
     from: &PrimitiveArray<T>,
+    ordered: bool,
 ) -> PolarsResult<DictionaryArray<K>> {
     let iter = from.iter().map(|x| x.copied());
-    let mut array = MutableDictionaryArray::<K, _>::try_empty(MutablePrimitiveArray::<T>::from(
-        from.dtype().clone(),
-    ))?;
+    let mut array = MutableDictionaryArray::<K, _>::try_empty(
+        MutablePrimitiveArray::<T>::from(from.dtype().clone()),
+        ordered,
+    )?;
     array.reserve(from.len());
     array.try_extend(iter)?;
 

--- a/crates/polars-compute/src/cast/utf8_to.rs
+++ b/crates/polars-compute/src/cast/utf8_to.rs
@@ -10,9 +10,10 @@ pub(super) const RFC3339: &str = "%Y-%m-%dT%H:%M:%S%.f%:z";
 
 pub(super) fn utf8_to_dictionary_dyn<O: Offset, K: DictionaryKey>(
     from: &dyn Array,
+    ordered: bool,
 ) -> PolarsResult<Box<dyn Array>> {
     let values = from.as_any().downcast_ref().unwrap();
-    utf8_to_dictionary::<O, K>(values).map(|x| Box::new(x) as Box<dyn Array>)
+    utf8_to_dictionary::<O, K>(values, ordered).map(|x| Box::new(x) as Box<dyn Array>)
 }
 
 /// Cast [`Utf8Array`] to [`DictionaryArray`], also known as packing.
@@ -21,9 +22,11 @@ pub(super) fn utf8_to_dictionary_dyn<O: Offset, K: DictionaryKey>(
 /// in the array.
 pub fn utf8_to_dictionary<O: Offset, K: DictionaryKey>(
     from: &Utf8Array<O>,
+    ordered: bool,
 ) -> PolarsResult<DictionaryArray<K>> {
     let mut array = MutableDictionaryArray::<K, MutableUtf8Array<O>>::empty_with_value_dtype(
         from.dtype().clone(),
+        ordered,
     );
     array.reserve(from.len());
     array.try_extend(from.iter())?;

--- a/crates/polars-core/src/chunked_array/logical/categorical.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical.rs
@@ -207,8 +207,11 @@ impl<T: PolarsCategoricalType> CategoricalChunked<T> {
             .get_mapping()
             .to_arrow(compat_level.uses_binview_types());
         let values_dtype = Box::new(values.dtype().clone());
-        let dtype =
-            ArrowDataType::Dictionary(<T::Native as DictionaryKey>::KEY_TYPE, values_dtype, false);
+        let dtype = ArrowDataType::Dictionary(
+            <T::Native as DictionaryKey>::KEY_TYPE,
+            values_dtype,
+            self.is_enum(),
+        );
         unsafe { DictionaryArray::try_new_unchecked(dtype, keys.clone(), values).unwrap() }
     }
 }

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -1032,7 +1032,7 @@ impl DataType {
                 Ok(ArrowDataType::Dictionary(
                     arrow_phys,
                     Box::new(values),
-                    false,
+                    matches!(self, Enum(_, _)),
                 ))
             },
             #[cfg(feature = "dtype-struct")]

--- a/crates/polars-core/src/schema/iceberg.rs
+++ b/crates/polars-core/src/schema/iceberg.rs
@@ -178,7 +178,7 @@ fn arrow_field_to_iceberg_column_rec(
         },
 
         dtype => {
-            if let ADT::Dictionary(_key_type, value_type, _is_sorted) = dtype
+            if let ADT::Dictionary(_key_type, value_type, _is_ordered) = dtype
                 && !value_type.is_nested()
             {
                 let dtype =

--- a/crates/polars-core/src/series/arrow_export/categorical.rs
+++ b/crates/polars-core/src/series/arrow_export/categorical.rs
@@ -216,7 +216,7 @@ impl CategoricalArrayToArrowConverter {
         let dictionary_dtype = ArrowDataType::Dictionary(
             <T as DictionaryKey>::KEY_TYPE,
             Box::new(values.dtype().clone()),
-            false, // is_sorted
+            dtype.is_enum()
         );
 
         unsafe {

--- a/crates/polars-core/src/series/arrow_export/categorical.rs
+++ b/crates/polars-core/src/series/arrow_export/categorical.rs
@@ -216,7 +216,7 @@ impl CategoricalArrayToArrowConverter {
         let dictionary_dtype = ArrowDataType::Dictionary(
             <T as DictionaryKey>::KEY_TYPE,
             Box::new(values.dtype().clone()),
-            dtype.is_enum()
+            dtype.is_enum(),
         );
 
         unsafe {

--- a/crates/polars-parquet/src/arrow/read/schema/metadata.rs
+++ b/crates/polars-parquet/src/arrow/read/schema/metadata.rs
@@ -31,7 +31,7 @@ fn convert_field(field: &mut Field) {
     // @NOTE: We cast non-Polars dictionaries to normal values because Polars does not have a
     // generic dictionary type.
     field.dtype = match std::mem::take(&mut field.dtype) {
-        ArrowDataType::Dictionary(key_type, value_type, sorted) => {
+        ArrowDataType::Dictionary(key_type, value_type, ordered) => {
             let is_pl_enum_or_categorical =
                 field.metadata.as_ref().is_some_and(|md| {
                     md.contains_key(DTYPE_ENUM_VALUES_LEGACY)
@@ -47,8 +47,15 @@ fn convert_field(field: &mut Field) {
                 ArrowDataType::Utf8View | ArrowDataType::Utf8 | ArrowDataType::LargeUtf8
             );
 
-            if is_pl_enum_or_categorical || is_int_to_str {
-                convert_dtype(ArrowDataType::Dictionary(key_type, value_type, sorted))
+            if is_pl_enum_or_categorical {
+                let is_pl_enum = 
+                    field.metadata.as_ref().is_some_and(|md| {
+                        md.contains_key(DTYPE_ENUM_VALUES_LEGACY)
+                            || md.contains_key(DTYPE_ENUM_VALUES_NEW)
+                    });
+                convert_dtype(ArrowDataType::Dictionary(key_type, value_type, is_pl_enum))
+            } else if is_int_to_str  {
+                convert_dtype(ArrowDataType::Dictionary(key_type, value_type, ordered))
             } else {
                 convert_dtype(*value_type)
             }

--- a/crates/polars-parquet/src/arrow/read/schema/metadata.rs
+++ b/crates/polars-parquet/src/arrow/read/schema/metadata.rs
@@ -48,13 +48,12 @@ fn convert_field(field: &mut Field) {
             );
 
             if is_pl_enum_or_categorical {
-                let is_pl_enum = 
-                    field.metadata.as_ref().is_some_and(|md| {
-                        md.contains_key(DTYPE_ENUM_VALUES_LEGACY)
-                            || md.contains_key(DTYPE_ENUM_VALUES_NEW)
-                    });
+                let is_pl_enum = field.metadata.as_ref().is_some_and(|md| {
+                    md.contains_key(DTYPE_ENUM_VALUES_LEGACY)
+                        || md.contains_key(DTYPE_ENUM_VALUES_NEW)
+                });
                 convert_dtype(ArrowDataType::Dictionary(key_type, value_type, is_pl_enum))
-            } else if is_int_to_str  {
+            } else if is_int_to_str {
                 convert_dtype(ArrowDataType::Dictionary(key_type, value_type, ordered))
             } else {
                 convert_dtype(*value_type)

--- a/crates/polars-parquet/src/arrow/read/statistics.rs
+++ b/crates/polars-parquet/src/arrow/read/statistics.rs
@@ -46,14 +46,6 @@ pub struct ColumnStatistics {
     statistics: ParquetStatistics,
 }
 
-#[derive(Debug, PartialEq)]
-pub enum ColumnPathSegment {
-    List { is_large: bool },
-    FixedSizeList { width: usize },
-    Dictionary { key: IntegerType, is_sorted: bool },
-    Struct { column_idx: usize },
-}
-
 /// Arrow-deserialized parquet statistics of a leaf-column
 #[derive(Debug, PartialEq)]
 pub struct ArrowColumnStatistics {
@@ -565,14 +557,14 @@ pub fn deserialize<'a>(
         D::List(field) | D::LargeList(field) => Ok(Some(Statistics::List(
             deserialize(field.as_ref(), columns)?.map(Box::new),
         ))),
-        D::Dictionary(key, dtype, is_sorted) => Ok(Some(Statistics::Dictionary(
+        D::Dictionary(key, dtype, ordered) => Ok(Some(Statistics::Dictionary(
             *key,
             deserialize(
                 &Field::new(PlSmallStr::EMPTY, dtype.as_ref().clone(), true),
                 columns,
             )?
             .map(Box::new),
-            *is_sorted,
+            *ordered,
         ))),
         D::FixedSizeList(field, width) => Ok(Some(Statistics::FixedSizeList(
             deserialize(field.as_ref(), columns)?.map(Box::new),

--- a/crates/polars-parquet/src/arrow/write/schema.rs
+++ b/crates/polars-parquet/src/arrow/write/schema.rs
@@ -48,9 +48,9 @@ fn convert_dtype(dtype: ArrowDataType) -> ArrowDataType {
             }
             D::Struct(fields)
         },
-        D::Dictionary(it, dtype, sorted) => {
+        D::Dictionary(it, dtype, ordered) => {
             let dtype = convert_dtype(*dtype);
-            D::Dictionary(it, Box::new(dtype), sorted)
+            D::Dictionary(it, Box::new(dtype), ordered)
         },
         D::Extension(ext) => {
             let dtype = convert_dtype(ext.inner);

--- a/crates/polars-python/src/dataframe/export.rs
+++ b/crates/polars-python/src/dataframe/export.rs
@@ -3,6 +3,7 @@ use arrow::record_batch::RecordBatch;
 use parking_lot::RwLockWriteGuard;
 use polars::prelude::*;
 use polars_compute::cast::CastOptionsImpl;
+use polars_utils::itertools::Itertools;
 use pyo3::IntoPyObjectExt;
 use pyo3::prelude::*;
 use pyo3::types::{PyCapsule, PyList, PyTuple};
@@ -113,7 +114,7 @@ impl PyDataFrame {
         let df = RwLockWriteGuard::downgrade(df);
         Python::attach(|py| {
             let pyarrow = py.import("pyarrow")?;
-            let cat_columns = df
+            let dict_columns = df
                 .columns()
                 .iter()
                 .enumerate()
@@ -124,9 +125,15 @@ impl PyDataFrame {
                     )
                 })
                 .map(|(i, _)| i)
-                .collect::<Vec<_>>();
+                .collect_vec();
+            let is_enum_col = df.columns().iter().map(|c| matches!(c.dtype(), DataType::Enum(_, _))).collect_vec();
 
-            let enum_and_categorical_dtype = ArrowDataType::Dictionary(
+            let enum_dtype = ArrowDataType::Dictionary(
+                IntegerType::Int64,
+                Box::new(ArrowDataType::LargeUtf8),
+                true,
+            );
+            let categorical_dtype = ArrowDataType::Dictionary(
                 IntegerType::Int64,
                 Box::new(ArrowDataType::LargeUtf8),
                 false,
@@ -141,20 +148,21 @@ impl PyDataFrame {
 
                     // Pandas does not allow unsigned dictionary indices so we replace them.
                     replaced_schema =
-                        (replaced_schema.is_none() && !cat_columns.is_empty()).then(|| {
+                        (replaced_schema.is_none() && !dict_columns.is_empty()).then(|| {
                             let mut schema = schema.as_ref().clone();
-                            for i in &cat_columns {
+                            for i in &dict_columns {
                                 let (_, field) = schema.get_at_index_mut(*i).unwrap();
-                                field.dtype = enum_and_categorical_dtype.clone();
+                                field.dtype = if is_enum_col[*i] { enum_dtype.clone() } else { categorical_dtype.clone() };
                             }
                             Arc::new(schema)
                         });
 
-                    for i in &cat_columns {
+                    for i in &dict_columns {
                         let arr = arrays.get_mut(*i).unwrap();
+                        let cast_dtype = if is_enum_col[*i] { &enum_dtype } else { &categorical_dtype };
                         let out = polars_compute::cast::cast(
                             &**arr,
-                            &enum_and_categorical_dtype,
+                            cast_dtype,
                             CastOptionsImpl::default(),
                         )
                         .unwrap();

--- a/crates/polars-python/src/dataframe/export.rs
+++ b/crates/polars-python/src/dataframe/export.rs
@@ -126,7 +126,11 @@ impl PyDataFrame {
                 })
                 .map(|(i, _)| i)
                 .collect_vec();
-            let is_enum_col = df.columns().iter().map(|c| matches!(c.dtype(), DataType::Enum(_, _))).collect_vec();
+            let is_enum_col = df
+                .columns()
+                .iter()
+                .map(|c| matches!(c.dtype(), DataType::Enum(_, _)))
+                .collect_vec();
 
             let enum_dtype = ArrowDataType::Dictionary(
                 IntegerType::Int64,
@@ -152,14 +156,22 @@ impl PyDataFrame {
                             let mut schema = schema.as_ref().clone();
                             for i in &dict_columns {
                                 let (_, field) = schema.get_at_index_mut(*i).unwrap();
-                                field.dtype = if is_enum_col[*i] { enum_dtype.clone() } else { categorical_dtype.clone() };
+                                field.dtype = if is_enum_col[*i] {
+                                    enum_dtype.clone()
+                                } else {
+                                    categorical_dtype.clone()
+                                };
                             }
                             Arc::new(schema)
                         });
 
                     for i in &dict_columns {
                         let arr = arrays.get_mut(*i).unwrap();
-                        let cast_dtype = if is_enum_col[*i] { &enum_dtype } else { &categorical_dtype };
+                        let cast_dtype = if is_enum_col[*i] {
+                            &enum_dtype
+                        } else {
+                            &categorical_dtype
+                        };
                         let out = polars_compute::cast::cast(
                             &**arr,
                             cast_dtype,

--- a/crates/polars/tests/it/arrow/array/dictionary/mod.rs
+++ b/crates/polars/tests/it/arrow/array/dictionary/mod.rs
@@ -85,8 +85,9 @@ fn try_new_incorrect_values_dt() {
 fn try_new_out_of_bounds() {
     let values = Utf8Array::<i32>::from_slice(["a", "aa"]);
 
-    let r = DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![2, 0]), values.boxed())
-        .is_err();
+    let r =
+        DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![2, 0]), values.boxed(), false)
+            .is_err();
 
     assert!(r);
 }
@@ -95,8 +96,12 @@ fn try_new_out_of_bounds() {
 fn try_new_out_of_bounds_neg() {
     let values = Utf8Array::<i32>::from_slice(["a", "aa"]);
 
-    let r = DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![-1, 0]), values.boxed())
-        .is_err();
+    let r = DictionaryArray::try_from_keys(
+        PrimitiveArray::from_vec(vec![-1, 0]),
+        values.boxed(),
+        false,
+    )
+    .is_err();
 
     assert!(r);
 }
@@ -121,7 +126,7 @@ fn new_empty() {
 fn with_validity() {
     let values = Utf8Array::<i32>::from_slice(["a", "aa"]);
     let array =
-        DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![1, 0]), values.boxed())
+        DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![1, 0]), values.boxed(), false)
             .unwrap();
 
     let array = array.with_validity(Some([true, false].into()));
@@ -133,7 +138,7 @@ fn with_validity() {
 fn rev_iter() {
     let values = Utf8Array::<i32>::from_slice(["a", "aa"]);
     let array =
-        DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![1, 0]), values.boxed())
+        DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![1, 0]), values.boxed(), false)
             .unwrap();
 
     let mut iter = array.into_iter();
@@ -145,7 +150,7 @@ fn rev_iter() {
 fn iter_values() {
     let values = Utf8Array::<i32>::from_slice(["a", "aa"]);
     let array =
-        DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![1, 0]), values.boxed())
+        DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![1, 0]), values.boxed(), false)
             .unwrap();
 
     let mut iter = array.values_iter();
@@ -157,7 +162,7 @@ fn iter_values() {
 fn keys_values_iter() {
     let values = Utf8Array::<i32>::from_slice(["a", "aa"]);
     let array =
-        DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![1, 0]), values.boxed())
+        DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![1, 0]), values.boxed(), false)
             .unwrap();
 
     assert_eq!(array.keys_values_iter().collect::<Vec<_>>(), vec![1, 0]);
@@ -166,9 +171,12 @@ fn keys_values_iter() {
 #[test]
 fn iter_values_typed() {
     let values = Utf8Array::<i32>::from_slice(["a", "aa"]);
-    let array =
-        DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![1, 0, 0]), values.boxed())
-            .unwrap();
+    let array = DictionaryArray::try_from_keys(
+        PrimitiveArray::from_vec(vec![1, 0, 0]),
+        values.boxed(),
+        false,
+    )
+    .unwrap();
 
     let iter = array.values_iter_typed::<Utf8Array<i32>>().unwrap();
     assert_eq!(iter.size_hint(), (3, Some(3)));
@@ -186,9 +194,12 @@ fn iter_values_typed() {
 #[should_panic]
 fn iter_values_typed_panic() {
     let values = Utf8Array::<i32>::from_iter([Some("a"), Some("aa"), None]);
-    let array =
-        DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![1, 0, 0]), values.boxed())
-            .unwrap();
+    let array = DictionaryArray::try_from_keys(
+        PrimitiveArray::from_vec(vec![1, 0, 0]),
+        values.boxed(),
+        false,
+    )
+    .unwrap();
 
     // should not be iterating values
     let iter = array.values_iter_typed::<Utf8Array<i32>>().unwrap();
@@ -199,9 +210,12 @@ fn iter_values_typed_panic() {
 #[should_panic]
 fn iter_values_typed_panic_2() {
     let values = Utf8Array::<i32>::from_iter([Some("a"), Some("aa"), None]);
-    let array =
-        DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![1, 0, 0]), values.boxed())
-            .unwrap();
+    let array = DictionaryArray::try_from_keys(
+        PrimitiveArray::from_vec(vec![1, 0, 0]),
+        values.boxed(),
+        false,
+    )
+    .unwrap();
 
     // should not be iterating values
     let iter = array.iter_typed::<Utf8Array<i32>>().unwrap();

--- a/crates/polars/tests/it/arrow/array/dictionary/mutable.rs
+++ b/crates/polars/tests/it/arrow/array/dictionary/mutable.rs
@@ -11,7 +11,7 @@ use polars_utils::aliases::{InitHashMaps, PlHashSet};
 fn primitive() -> PolarsResult<()> {
     let data = vec![Some(1), Some(2), Some(1)];
 
-    let mut a = MutableDictionaryArray::<i32, MutablePrimitiveArray<i32>>::new();
+    let mut a = MutableDictionaryArray::<i32, MutablePrimitiveArray<i32>>::new(false);
     a.try_extend(data)?;
     assert_eq!(a.len(), 3);
     assert_eq!(a.values().len(), 2);
@@ -22,7 +22,7 @@ fn primitive() -> PolarsResult<()> {
 fn utf8_natural() -> PolarsResult<()> {
     let data = vec![Some("a"), Some("b"), Some("a")];
 
-    let mut a = MutableDictionaryArray::<i32, MutableUtf8Array<i32>>::new();
+    let mut a = MutableDictionaryArray::<i32, MutableUtf8Array<i32>>::new(false);
     a.try_extend(data)?;
 
     assert_eq!(a.len(), 3);
@@ -38,7 +38,7 @@ fn binary_natural() -> PolarsResult<()> {
         Some("a".as_bytes()),
     ];
 
-    let mut a = MutableDictionaryArray::<i32, MutableBinaryArray<i32>>::new();
+    let mut a = MutableDictionaryArray::<i32, MutableBinaryArray<i32>>::new(false);
     a.try_extend(data)?;
     assert_eq!(a.len(), 3);
     assert_eq!(a.values().len(), 2);
@@ -47,7 +47,8 @@ fn binary_natural() -> PolarsResult<()> {
 
 #[test]
 fn push_utf8() {
-    let mut new: MutableDictionaryArray<i32, MutableUtf8Array<i32>> = MutableDictionaryArray::new();
+    let mut new: MutableDictionaryArray<i32, MutableUtf8Array<i32>> =
+        MutableDictionaryArray::new(false);
 
     for value in [Some("A"), Some("B"), None, Some("C"), Some("A"), Some("B")] {
         new.try_push(value).unwrap();
@@ -68,36 +69,38 @@ fn push_utf8() {
 
 #[test]
 fn into_empty() {
-    let mut new: MutableDictionaryArray<i32, MutableUtf8Array<i32>> = MutableDictionaryArray::new();
+    let mut new: MutableDictionaryArray<i32, MutableUtf8Array<i32>> =
+        MutableDictionaryArray::new(false);
     for value in [Some("A"), Some("B"), None, Some("C"), Some("A"), Some("B")] {
         new.try_push(value).unwrap();
     }
     let values = new.values().clone();
-    let empty = new.into_empty();
+    let empty = new.into_empty(false);
     assert_eq!(empty.values(), &values);
     assert!(empty.is_empty());
 }
 
 #[test]
 fn from_values() {
-    let mut new: MutableDictionaryArray<i32, MutableUtf8Array<i32>> = MutableDictionaryArray::new();
+    let mut new: MutableDictionaryArray<i32, MutableUtf8Array<i32>> =
+        MutableDictionaryArray::new(false);
     for value in [Some("A"), Some("B"), None, Some("C"), Some("A"), Some("B")] {
         new.try_push(value).unwrap();
     }
     let mut values = new.values().clone();
-    let empty = MutableDictionaryArray::<i32, _>::from_values(values.clone()).unwrap();
+    let empty = MutableDictionaryArray::<i32, _>::from_values(values.clone(), false).unwrap();
     assert_eq!(empty.values(), &values);
     assert!(empty.is_empty());
     values.push(Some("A"));
-    assert!(MutableDictionaryArray::<i32, _>::from_values(values).is_err());
+    assert!(MutableDictionaryArray::<i32, _>::from_values(values, false).is_err());
 }
 
 #[test]
 fn try_empty() {
     let mut values = MutableUtf8Array::<i32>::new();
-    MutableDictionaryArray::<i32, _>::try_empty(values.clone()).unwrap();
+    MutableDictionaryArray::<i32, _>::try_empty(values.clone(), false).unwrap();
     values.push(Some("A"));
-    assert!(MutableDictionaryArray::<i32, _>::try_empty(values.clone()).is_err());
+    assert!(MutableDictionaryArray::<i32, _>::try_empty(values.clone(), false).is_err());
 }
 
 fn test_push_ex<M, T>(values: Vec<T>, gen_: impl Fn(usize) -> T)
@@ -108,7 +111,7 @@ where
 {
     for is_extend in [false, true] {
         let mut set = PlHashSet::new();
-        let mut arr = MutableDictionaryArray::<u8, M>::new();
+        let mut arr = MutableDictionaryArray::<u8, M>::new(false);
         macro_rules! push {
             ($v:expr) => {
                 if is_extend {
@@ -155,7 +158,7 @@ fn test_push_i64_ex() {
 fn test_big_dict() {
     let n = 10;
     let strings = (0..10).map(|i| i.to_string()).collect::<Vec<_>>();
-    let mut arr = MutableDictionaryArray::<u8, MutableUtf8Array<i32>>::new();
+    let mut arr = MutableDictionaryArray::<u8, MutableUtf8Array<i32>>::new(false);
     for s in &strings {
         arr.try_push(Some(s)).unwrap();
     }

--- a/crates/polars/tests/it/arrow/array/equal/dictionary.rs
+++ b/crates/polars/tests/it/arrow/array/equal/dictionary.rs
@@ -6,7 +6,7 @@ fn create_dictionary_array(values: &[Option<&str>], keys: &[Option<i16>]) -> Dic
     let keys = Int16Array::from(keys);
     let values = Utf8Array::<i64>::from(values);
 
-    DictionaryArray::try_from_keys(keys, values.boxed()).unwrap()
+    DictionaryArray::try_from_keys(keys, values.boxed(), false).unwrap()
 }
 
 #[test]

--- a/crates/polars/tests/it/io/parquet/arrow/mod.rs
+++ b/crates/polars/tests/it/io/parquet/arrow/mod.rs
@@ -529,7 +529,7 @@ pub fn pyarrow_nullable(column: &str) -> Box<dyn Array> {
         "int32_dict" => {
             let keys = PrimitiveArray::<i32>::from([Some(0), Some(1), None, Some(1)]);
             let values = Box::new(PrimitiveArray::<i32>::from_slice([10, 200]));
-            Box::new(DictionaryArray::try_from_keys(keys, values).unwrap())
+            Box::new(DictionaryArray::try_from_keys(keys, values, false).unwrap())
         },
         "timestamp_us" => Box::new(
             PrimitiveArray::<i64>::from(i64_values)

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -97,7 +97,7 @@ def test_arrow_array_logical() -> None:
     pa_data1 = (
         pa.array(["a", "b", "c", "d"])
         .dictionary_encode()
-        .cast(pa.dictionary(pa.uint8(), pa.large_string()))
+        .cast(pa.dictionary(pa.uint8(), pa.large_string(), ordered=True))
     )
     pa_array_logical1 = pa.FixedSizeListArray.from_arrays(pa_data1, 2)
 

--- a/py-polars/tests/unit/interop/test_to_pandas.py
+++ b/py-polars/tests/unit/interop/test_to_pandas.py
@@ -91,8 +91,9 @@ def test_cat_to_pandas(dtype: pl.DataType) -> None:
     assert isinstance(pd_out["a"].dtype, pd.CategoricalDtype)
 
     pd_pa_out = df.to_pandas(use_pyarrow_extension_array=True)
+    ordered = isinstance(dtype, pl.Enum)
     assert pd_pa_out["a"].dtype == pd.ArrowDtype(
-        pa.dictionary(pa.int64(), pa.large_string())
+        pa.dictionary(pa.int64(), pa.large_string(), ordered=ordered)
     )
 
     assert pl.Series(dtype=pl.Enum(["A"])).to_pandas().dtype.categories.tolist() == [  # type: ignore[union-attr]

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -3738,7 +3738,7 @@ def test_between_prefiltering_parametric(s: pl.Series, start: int, end: int) -> 
         (pl.Float64, pa.float64()),
         (pl.Decimal(38, 10), pa.decimal128(38, 10)),
         (pl.Categorical, pa.dictionary(pa.uint32(), pa.string())),
-        (pl.Enum(["x", "y", "z"]), pa.dictionary(pa.uint8(), pa.string())),
+        (pl.Enum(["x", "y", "z"]), pa.dictionary(pa.uint8(), pa.string(), ordered=True)),
         (pl.List(pl.Int32), pa.large_list(pa.int32())),
         (pl.Array(pl.Int32, 3), pa.list_(pa.int32(), 3)),
         (

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -3738,7 +3738,10 @@ def test_between_prefiltering_parametric(s: pl.Series, start: int, end: int) -> 
         (pl.Float64, pa.float64()),
         (pl.Decimal(38, 10), pa.decimal128(38, 10)),
         (pl.Categorical, pa.dictionary(pa.uint32(), pa.string())),
-        (pl.Enum(["x", "y", "z"]), pa.dictionary(pa.uint8(), pa.string(), ordered=True)),
+        (
+            pl.Enum(["x", "y", "z"]),
+            pa.dictionary(pa.uint8(), pa.string(), ordered=True),
+        ),
         (pl.List(pl.Int32), pa.large_list(pa.int32())),
         (pl.Array(pl.Int32, 3), pa.list_(pa.int32(), 3)),
         (


### PR DESCRIPTION
We weren't correctly setting the ordered parameter on Arrow dictionaries created from `pl.Enum`s. This is likely caused because the comment in the codebase mentioned that this attribute was *sorted*, rather than *ordered*. I did a pass through the code-base to fix this to be consistent.

Fixes https://github.com/pola-rs/polars/issues/27417.