### PR TITLE
refactor(rust): Add AExpr input node iterators

### DIFF
--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -371,7 +371,7 @@ fn create_physical_expr_inner(
             )))
         },
         Agg(agg) => {
-            let expr = agg.get_input().first();
+            let expr = agg.nodes_iter().next().unwrap();
             let input = create_physical_expr_inner(expr, expr_arena, schema, state)?;
             let allow_threading = state.allow_threading;
 

--- a/crates/polars-plan/src/plans/aexpr/equality.rs
+++ b/crates/polars-plan/src/plans/aexpr/equality.rs
@@ -24,8 +24,8 @@ impl AExpr {
         if !self.is_expr_equal_top_level(other) {
             return false;
         }
-        self.children_rev(l_stack);
-        other.children_rev(r_stack);
+        l_stack.extend(self.nodes_iter_name_last());
+        r_stack.extend(other.nodes_iter_name_last());
 
         // Traverse node in N R L order
         loop {
@@ -41,8 +41,8 @@ impl AExpr {
             if !l_expr.is_expr_equal_top_level(r_expr) {
                 return false;
             }
-            l_expr.children_rev(l_stack);
-            r_expr.children_rev(r_stack);
+            l_stack.extend(l_expr.nodes_iter_name_last());
+            r_stack.extend(r_expr.nodes_iter_name_last());
         }
 
         true

--- a/crates/polars-plan/src/plans/aexpr/hash.rs
+++ b/crates/polars-plan/src/plans/aexpr/hash.rs
@@ -124,6 +124,6 @@ pub(crate) fn traverse_and_hash_aexpr<H: Hasher>(
     while let Some(node) = scratch.pop() {
         let ae = expr_arena.get(node);
         ae.hash(state);
-        ae.children_rev(&mut scratch);
+        scratch.extend(ae.nodes_iter_name_last())
     }
 }

--- a/crates/polars-plan/src/plans/aexpr/mod.rs
+++ b/crates/polars-plan/src/plans/aexpr/mod.rs
@@ -363,14 +363,14 @@ impl AExpr {
 
 #[recursive::recursive]
 pub fn deep_clone_ae(ae: Node, arena: &mut Arena<AExpr>) -> Node {
-    let slf = arena.get(ae).clone();
+    let mut slf = arena.get(ae).clone();
 
     let mut children = vec![];
-    slf.children_rev(&mut children);
+    children.extend(slf.nodes_iter());
     for child in &mut children {
         *child = deep_clone_ae(*child, arena);
     }
-    children.reverse();
 
-    arena.add(slf.replace_children(&children))
+    slf.replace_nodes(children);
+    arena.add(slf)
 }

--- a/crates/polars-plan/src/plans/aexpr/properties/general.rs
+++ b/crates/polars-plan/src/plans/aexpr/properties/general.rs
@@ -78,7 +78,12 @@ where
     if !property(ae) {
         return false;
     }
-    ae.inputs_rev(stack);
+
+    stack.extend(if let AExpr::Eval { .. } = ae {
+        ae.inputs_iter()
+    } else {
+        ae.nodes_iter()
+    });
     true
 }
 
@@ -144,11 +149,11 @@ pub fn is_prop<P: Fn(&AExpr) -> bool>(
                     return;
                 }
             };
-            ae.inputs_rev(stack);
+            stack.extend(ae.nodes_iter());
         })(),
-        _ => {
-            ae.inputs_rev(stack);
-        },
+        // Ignore the eval expr of list.eval
+        Eval { .. } => stack.extend(ae.inputs_iter()),
+        _ => stack.extend(ae.nodes_iter()),
     }
 
     true
@@ -500,7 +505,11 @@ pub(crate) fn predicate_non_null_column_outputs(
         };
 
         if traverse_all_inputs {
-            ae.inputs_rev(stack);
+            stack.extend(if let AExpr::Eval { .. } = ae {
+                ae.inputs_iter()
+            } else {
+                ae.nodes_iter()
+            });
         }
     }
 }

--- a/crates/polars-plan/src/plans/aexpr/traverse.rs
+++ b/crates/polars-plan/src/plans/aexpr/traverse.rs
@@ -1,390 +1,56 @@
 use std::ops::ControlFlow;
+use std::{iter, slice};
 
-use super::*;
+use polars_utils::arena::{Arena, Node};
+use polars_utils::itertools::Itertools as _;
+
+use crate::plans::{AExpr, ExprIR, IR, IRAggExpr};
 use crate::traversal::tree_traversal::{GetNodeInputs, tree_traversal};
 use crate::traversal::visitor::NodeVisitor;
 
 impl AExpr {
-    /// Push the inputs of this node to the given container, in field declaration order.
+    /// Iterator that returns the child nodes of this aexpr in field declaration order.
     ///
     /// This function and its users must be updated if the field declaration order changes.
-    pub fn inputs<E>(&self, container: &mut E)
-    where
-        E: Extend<Node>,
-    {
+    pub fn nodes_iter(&self) -> AENodesIter<'_> {
         use AExpr::*;
 
         match self {
-            Element | Column(_) | Literal(_) | Len => {},
+            Element | Column(_) | Literal(_) | Len => AENodesIter::new_empty(),
             #[cfg(feature = "dtype-struct")]
-            StructField(_) => {},
-            BinaryExpr { left, op: _, right } => {
-                container.extend([*left, *right]);
-            },
-            Cast { expr, .. } => container.extend([*expr]),
-            Sort { expr, .. } => container.extend([*expr]),
-            Gather { expr, idx, .. } => {
-                container.extend([*expr, *idx]);
-            },
-            SortBy { expr, by, .. } => {
-                container.extend([*expr]);
-                container.extend(by.iter().cloned());
-            },
-            Filter { input, by } => {
-                container.extend([*input, *by]);
-            },
-            Agg(agg_e) => match agg_e.get_input() {
-                NodeInputs::Single(node) => container.extend([node]),
-                NodeInputs::Many(nodes) => container.extend(nodes),
-                NodeInputs::Leaf => {},
-            },
-            Ternary {
-                truthy,
-                falsy,
-                predicate,
-            } => {
-                container.extend([*predicate, *truthy, *falsy]);
-            },
-            AnonymousFunction { input, .. }
-            | Function { input, .. }
-            | AnonymousAgg { input, .. } => container.extend(input.iter().map(|e| e.node())),
-            Explode { expr: e, .. } => container.extend([*e]),
-            #[cfg(feature = "dynamic_group_by")]
-            Rolling {
-                function,
-                index_column,
-                period: _,
-                offset: _,
-                closed_window: _,
-            } => {
-                container.extend([*function, *index_column]);
-            },
-            Over {
-                function,
-                partition_by,
-                order_by,
-                mapping: _,
-            } => {
-                container.extend([*function]);
-                container.extend(partition_by.iter().cloned());
-                container.extend(order_by.as_ref().map(|(n, _)| *n));
-            },
-            Eval {
+            StructField(_) => AENodesIter::new_empty(),
+
+            Cast {
                 expr,
-                evaluation,
-                variant: _,
-            } => {
-                container.extend([*expr, *evaluation]);
-            },
-            #[cfg(feature = "dtype-struct")]
-            StructEval { expr, evaluation } => {
-                container.extend([*expr]);
-                container.extend(evaluation.iter().map(|x| x.node()));
-            },
-            Slice {
-                input,
-                offset,
-                length,
-            } => {
-                container.extend([*input, *offset, *length]);
-            },
-        }
-    }
+                dtype: _,
+                options: _,
+            }
+            | Sort { expr, options: _ }
+            | Explode { expr, options: _ } => AENodesIter::new_single(expr),
 
-    /// Push the inputs of this node to the given container, in reverse order.
-    /// This ensures the primary node responsible for the name is pushed last.
-    ///
-    /// This is subtly different from `children_rev` as this only includes the input expressions,
-    /// not expressions used during evaluation.
-    pub fn inputs_rev<E>(&self, container: &mut E)
-    where
-        E: Extend<Node>,
-    {
-        use AExpr::*;
-
-        match self {
-            Element | Column(_) | Literal(_) | Len => {},
-            #[cfg(feature = "dtype-struct")]
-            StructField(_) => {},
-            BinaryExpr { left, op: _, right } => {
-                container.extend([*right, *left]);
-            },
-            Cast { expr, .. } => container.extend([*expr]),
-            Sort { expr, .. } => container.extend([*expr]),
-            Gather { expr, idx, .. } => {
-                container.extend([*idx, *expr]);
-            },
-            SortBy { expr, by, .. } => {
-                container.extend(by.iter().cloned().rev());
-                container.extend([*expr]);
-            },
-            Filter { input, by } => {
-                container.extend([*by, *input]);
-            },
-            Agg(agg_e) => match agg_e.get_input() {
-                NodeInputs::Single(node) => container.extend([node]),
-                NodeInputs::Many(nodes) => container.extend(nodes.into_iter().rev()),
-                NodeInputs::Leaf => {},
-            },
-            Ternary {
-                truthy,
-                falsy,
-                predicate,
-            } => {
-                container.extend([*predicate, *falsy, *truthy]);
-            },
-            AnonymousFunction { input, .. }
-            | Function { input, .. }
-            | AnonymousAgg { input, .. } => container.extend(input.iter().rev().map(|e| e.node())),
-            Explode { expr: e, .. } => container.extend([*e]),
-            #[cfg(feature = "dynamic_group_by")]
-            Rolling {
-                function,
-                index_column,
-                period: _,
-                offset: _,
-                closed_window: _,
-            } => {
-                container.extend([*index_column, *function]);
-            },
-            Over {
-                function,
-                partition_by,
-                order_by,
-                mapping: _,
-            } => {
-                if let Some((n, _)) = order_by {
-                    container.extend([*n]);
-                }
-                container.extend(partition_by.iter().rev().cloned());
-                container.extend([*function]);
-            },
-            Eval {
+            Gather {
                 expr,
-                evaluation,
-                variant: _,
-            } => {
-                // We don't use the evaluation here because it does not contain inputs.
-                _ = evaluation;
-                container.extend([*expr]);
-            },
-            #[cfg(feature = "dtype-struct")]
-            StructEval { expr, evaluation } => {
-                // Evaluation is included. In case this is not allowed, use `inputs_rev_strict()`.
-                container.extend(evaluation.iter().rev().map(ExprIR::node));
-                container.extend([*expr]);
-            },
-            Slice {
-                input,
-                offset,
-                length,
-            } => {
-                container.extend([*length, *offset, *input]);
-            },
-        }
-    }
-
-    /// Push the inputs of this node to the given container, in reverse order.
-    /// This ensures the primary node responsible for the name is pushed last.
-    ///
-    /// Unlike `inputs_rev`, this excludes Eval expressions. These use an extended schema,
-    /// determined by their input, which implies a different traversal order.
-    ///
-    /// This is subtly different from `children_rev` as this only includes the input expressions,
-    /// not expressions used during evaluation.
-    pub fn inputs_rev_strict<E>(&self, container: &mut E)
-    where
-        E: Extend<Node>,
-    {
-        use AExpr::*;
-
-        match self {
-            #[cfg(feature = "dtype-struct")]
-            StructEval { expr, evaluation } => {
-                // Evaluation is explicitly excluded. It is up to the caller to handle
-                // any tree traversal if required.
-                _ = evaluation;
-                container.extend([*expr]);
-            },
-            expr => expr.inputs_rev(container),
-        }
-    }
-
-    /// Push the children of this node to the given container, in reverse order.
-    /// This ensures the primary node responsible for the name is pushed last.
-    ///
-    /// This is subtly different from `input_rev` as this only all expressions included in the
-    /// expression not only the input expressions,
-    pub fn children_rev<E: Extend<Node>>(&self, container: &mut E) {
-        use AExpr::*;
-
-        match self {
-            Element | Column(_) | Literal(_) | Len => {},
-            #[cfg(feature = "dtype-struct")]
-            StructField(_) => {},
-            BinaryExpr { left, op: _, right } => {
-                container.extend([*right, *left]);
-            },
-            Cast { expr, .. } => container.extend([*expr]),
-            Sort { expr, .. } => container.extend([*expr]),
-            Gather { expr, idx, .. } => {
-                container.extend([*idx, *expr]);
-            },
+                idx,
+                returns_scalar: _,
+                null_on_oob: _,
+            } => AENodesIter::new_double(expr, idx),
             SortBy { expr, by, .. } => {
-                container.extend(by.iter().cloned().rev());
-                container.extend([*expr]);
+                AENodesIter::DoubleSlice(slice::from_ref(expr).iter().chain(by.iter()))
             },
-            Filter { input, by } => {
-                container.extend([*by, *input]);
-            },
-            Agg(agg_e) => match agg_e.get_input() {
-                NodeInputs::Single(node) => container.extend([node]),
-                NodeInputs::Many(nodes) => container.extend(nodes.into_iter().rev()),
-                NodeInputs::Leaf => {},
-            },
+            Filter { input, by } => AENodesIter::new_double(input, by),
+            Agg(agg) => agg.nodes_iter(),
+            BinaryExpr { left, op: _, right } => AENodesIter::new_double(left, right),
             Ternary {
+                predicate,
                 truthy,
                 falsy,
-                predicate,
-            } => {
-                container.extend([*predicate, *falsy, *truthy]);
-            },
-            AnonymousFunction { input, .. }
-            | Function { input, .. }
-            | AnonymousAgg { input, .. } => container.extend(input.iter().rev().map(|e| e.node())),
-            Explode { expr: e, .. } => container.extend([*e]),
-            #[cfg(feature = "dynamic_group_by")]
-            Rolling {
-                function,
-                index_column,
-                period: _,
-                offset: _,
-                closed_window: _,
-            } => {
-                container.extend([*index_column, *function]);
-            },
-            Over {
-                function,
-                partition_by,
-                order_by,
-                mapping: _,
-            } => {
-                if let Some((n, _)) = order_by {
-                    container.extend([*n]);
-                }
-                container.extend(partition_by.iter().rev().cloned());
-                container.extend([*function]);
-            },
-            Eval {
-                expr,
-                evaluation,
-                variant: _,
-            } => container.extend([*evaluation, *expr]),
-            #[cfg(feature = "dtype-struct")]
-            StructEval { expr, evaluation } => {
-                container.extend(evaluation.iter().rev().map(ExprIR::node));
-                container.extend([*expr]);
-            },
-            Slice {
-                input,
-                offset,
-                length,
-            } => {
-                container.extend([*length, *offset, *input]);
-            },
-        }
-    }
-
-    pub fn replace_inputs(mut self, inputs: &[Node]) -> Self {
-        use AExpr::*;
-        let input = match &mut self {
-            Element | Column(_) | Literal(_) | Len => return self,
-            #[cfg(feature = "dtype-struct")]
-            StructField(_) => return self,
-            Cast { expr, .. } => expr,
-            Explode { expr, .. } => expr,
-            BinaryExpr { left, right, .. } => {
-                *left = inputs[0];
-                *right = inputs[1];
-                return self;
-            },
-            Gather { expr, idx, .. } => {
-                *expr = inputs[0];
-                *idx = inputs[1];
-                return self;
-            },
-            Sort { expr, .. } => expr,
-            SortBy { expr, by, .. } => {
-                *expr = inputs[0];
-                by.clear();
-                by.extend_from_slice(&inputs[1..]);
-                return self;
-            },
-            Filter { input, by, .. } => {
-                *input = inputs[0];
-                *by = inputs[1];
-                return self;
-            },
-            Agg(a) => {
-                match a {
-                    IRAggExpr::Quantile {
-                        expr,
-                        quantile,
-                        method: _,
-                    } => {
-                        *expr = inputs[0];
-                        *quantile = inputs[1];
-                    },
-                    _ => {
-                        a.set_input(inputs[0]);
-                    },
-                }
-                return self;
-            },
-            Ternary {
-                truthy,
-                falsy,
-                predicate,
-            } => {
-                *truthy = inputs[0];
-                *falsy = inputs[1];
-                *predicate = inputs[2];
-                return self;
-            },
+            } => AENodesIter::new_triple(predicate, truthy, falsy),
             AnonymousFunction { input, .. }
             | Function { input, .. }
             | AnonymousAgg { input, .. } => {
-                assert_eq!(input.len(), inputs.len());
-                for (e, node) in input.iter_mut().zip(inputs.iter()) {
-                    e.set_node(*node);
-                }
-                return self;
+                AENodesIter::ExprIRSlice(input.iter().map(ExprIR::node_ref))
             },
-            Eval {
-                expr,
-                evaluation,
-                variant: _,
-            } => {
-                *expr = inputs[0];
-                _ = evaluation; // Intentional.
-                return self;
-            },
-            #[cfg(feature = "dtype-struct")]
-            StructEval { expr, evaluation } => {
-                *expr = inputs[0];
-                _ = evaluation; // Intentional.
-                return self;
-            },
-            Slice {
-                input,
-                offset,
-                length,
-            } => {
-                *input = inputs[0];
-                *offset = inputs[1];
-                *length = inputs[2];
-                return self;
-            },
+
             #[cfg(feature = "dynamic_group_by")]
             Rolling {
                 function,
@@ -392,122 +58,94 @@ impl AExpr {
                 period: _,
                 offset: _,
                 closed_window: _,
-            } => {
-                *function = inputs[0];
-                *index_column = inputs[1];
-                return self;
-            },
+            } => AENodesIter::new_double(function, index_column),
             Over {
                 function,
                 partition_by,
                 order_by,
-                ..
-            } => {
-                let offset = order_by.is_some() as usize;
-                *function = inputs[0];
-                partition_by.clear();
-                partition_by.extend_from_slice(&inputs[1..inputs.len() - offset]);
-                if let Some((_, options)) = order_by {
-                    *order_by = Some((*inputs.last().unwrap(), *options));
-                }
-                return self;
-            },
-        };
-        *input = inputs[0];
-        self
+                mapping: _,
+            } => AENodesIter::TripleSlice(
+                slice::from_ref(function)
+                    .iter()
+                    .chain(partition_by.iter())
+                    .chain(order_by.as_ref().map_or(&[][..], |x| slice::from_ref(&x.0))),
+            ),
+            Eval {
+                expr,
+                evaluation,
+                variant: _,
+            } => AENodesIter::new_double(expr, evaluation),
+            #[cfg(feature = "dtype-struct")]
+            StructEval { expr, evaluation } => AENodesIter::StructEval(
+                iter::once(expr).chain(evaluation.iter().map(ExprIR::node_ref as _)),
+            ),
+            Slice {
+                input,
+                offset,
+                length,
+            } => AENodesIter::new_triple(input, offset, length),
+        }
     }
 
-    pub fn replace_children(mut self, inputs: &[Node]) -> Self {
+    /// Iterator that returns nodes in order such that the last item of the iterator is the node
+    /// from which the output name is sourced. The ordering of non-name nodes is unspecified but
+    /// guaranteed to match `AExpr::nodes_iter_mut_name_last`.
+    pub fn nodes_iter_name_last(&self) -> iter::Rev<AENodesIter<'_>> {
         use AExpr::*;
-        let input = match &mut self {
-            Element | Column(_) | Literal(_) | Len => return self,
-            #[cfg(feature = "dtype-struct")]
-            StructField(_) => return self,
-            Cast { expr, .. } => expr,
-            Explode { expr, .. } => expr,
-            BinaryExpr { left, right, .. } => {
-                *left = inputs[0];
-                *right = inputs[1];
-                return self;
-            },
-            Gather { expr, idx, .. } => {
-                *expr = inputs[0];
-                *idx = inputs[1];
-                return self;
-            },
-            Sort { expr, .. } => expr,
-            SortBy { expr, by, .. } => {
-                *expr = inputs[0];
-                by.clear();
-                by.extend_from_slice(&inputs[1..]);
-                return self;
-            },
-            Filter { input, by, .. } => {
-                *input = inputs[0];
-                *by = inputs[1];
-                return self;
-            },
-            Agg(a) => {
-                if let IRAggExpr::Quantile {
-                    expr,
-                    quantile,
-                    method: _,
-                } = a
-                {
-                    *expr = inputs[0];
-                    *quantile = inputs[1];
-                } else {
-                    a.set_input(inputs[0]);
-                }
-                return self;
-            },
+
+        Iterator::rev(match self {
             Ternary {
+                predicate,
                 truthy,
                 falsy,
-                predicate,
-            } => {
-                *truthy = inputs[0];
-                *falsy = inputs[1];
-                *predicate = inputs[2];
-                return self;
-            },
-            AnonymousAgg { input, .. }
-            | AnonymousFunction { input, .. }
-            | Function { input, .. } => {
-                assert_eq!(input.len(), inputs.len());
-                for (e, node) in input.iter_mut().zip(inputs.iter()) {
-                    e.set_node(*node);
-                }
-                return self;
-            },
-            Eval {
-                expr,
-                evaluation,
-                variant: _,
-            } => {
-                *expr = inputs[0];
-                *evaluation = inputs[1];
-                return self;
-            },
+            } => AENodesIter::new_triple(truthy, falsy, predicate),
+            _ => self.nodes_iter(),
+        })
+    }
+
+    /// Iterator that returns the child nodes of this aexpr in field declaration order.
+    ///
+    /// This function and its users must be updated if the field declaration order changes.
+    pub fn nodes_iter_mut(&mut self) -> AENodesIterMut<'_> {
+        use AExpr::*;
+        use slice;
+
+        match self {
+            Element | Column(_) | Literal(_) | Len => AENodesIterMut::new_empty(),
             #[cfg(feature = "dtype-struct")]
-            StructEval { expr, evaluation } => {
-                assert_eq!(inputs.len(), evaluation.len() + 1);
-                *expr = inputs[0];
-                for (e, node) in evaluation.iter_mut().zip(inputs[1..].iter()) {
-                    e.set_node(*node);
-                }
-                return self;
+            StructField(_) => AENodesIterMut::new_empty(),
+
+            Cast {
+                expr,
+                dtype: _,
+                options: _,
+            }
+            | Sort { expr, options: _ }
+            | Explode { expr, options: _ } => AENodesIterMut::new_single(expr),
+
+            Gather {
+                expr,
+                idx,
+                returns_scalar: _,
+                null_on_oob: _,
+            } => AENodesIterMut::new_double(expr, idx),
+            SortBy { expr, by, .. } => {
+                AENodesIterMut::DoubleSlice(slice::from_mut(expr).iter_mut().chain(by.iter_mut()))
             },
-            Slice {
-                input,
-                offset,
-                length,
-            } => {
-                *input = inputs[0];
-                *offset = inputs[1];
-                *length = inputs[2];
-                return self;
+            Filter { input, by } => AENodesIterMut::new_double(input, by),
+            Agg(agg) => agg.nodes_iter_mut(),
+            BinaryExpr { left, op: _, right } => AENodesIterMut::new_double(left, right),
+            Ternary {
+                predicate,
+                truthy,
+                falsy,
+            } => AENodesIterMut::new_triple(predicate, truthy, falsy),
+            AnonymousFunction { input, .. }
+            | Function { input, .. }
+            | AnonymousAgg { input, .. } => {
+                AENodesIterMut::ExprIRSlice(input.iter_mut().map(ExprIR::node_mut))
             },
+
             #[cfg(feature = "dynamic_group_by")]
             Rolling {
                 function,
@@ -515,57 +153,247 @@ impl AExpr {
                 period: _,
                 offset: _,
                 closed_window: _,
-            } => {
-                *function = inputs[0];
-                *index_column = inputs[1];
-                return self;
-            },
+            } => AENodesIterMut::new_double(function, index_column),
             Over {
                 function,
                 partition_by,
                 order_by,
-                ..
-            } => {
-                let offset = order_by.is_some() as usize;
-                *function = inputs[0];
-                partition_by.clear();
-                partition_by.extend_from_slice(&inputs[1..inputs.len() - offset]);
-                if let Some((_, options)) = order_by {
-                    *order_by = Some((*inputs.last().unwrap(), *options));
-                }
-                return self;
-            },
-        };
-        *input = inputs[0];
-        self
+                mapping: _,
+            } => AENodesIterMut::TripleSlice(
+                slice::from_mut(function)
+                    .iter_mut()
+                    .chain(partition_by.iter_mut())
+                    .chain(
+                        order_by
+                            .as_mut()
+                            .map_or(&mut [][..], |x| slice::from_mut(&mut x.0)),
+                    ),
+            ),
+            Eval {
+                expr,
+                evaluation,
+                variant: _,
+            } => AENodesIterMut::new_double(expr, evaluation),
+            #[cfg(feature = "dtype-struct")]
+            StructEval { expr, evaluation } => AENodesIterMut::StructEval(
+                iter::once(expr).chain(evaluation.iter_mut().map(ExprIR::node_mut as _)),
+            ),
+            Slice {
+                input,
+                offset,
+                length,
+            } => AENodesIterMut::new_triple(input, offset, length),
+        }
+    }
+
+    /// Iterator that returns nodes in order such that the last item of the iterator is the node
+    /// from which the output name is sourced. The ordering of non-name nodes is unspecified but
+    /// guaranteed to match `AExpr::nodes_iter_mut_name`.
+    pub fn nodes_iter_mut_name_last(&mut self) -> iter::Rev<AENodesIterMut<'_>> {
+        use AExpr::*;
+
+        Iterator::rev(match self {
+            Ternary {
+                predicate,
+                truthy,
+                falsy,
+            } => AENodesIterMut::new_triple(truthy, falsy, predicate),
+            _ => self.nodes_iter_mut(),
+        })
+    }
+
+    /// Iterator that returns the child nodes of this aexpr in field declaration order.
+    ///
+    /// This is derived from `nodes_iter`, but skips the eval exprs in list / struct eval.
+    ///
+    /// This function and its users must be updated if the field declaration order changes.
+    pub fn inputs_iter(&self) -> AENodesIter<'_> {
+        use AExpr::*;
+
+        match self {
+            #[cfg(feature = "dtype-struct")]
+            StructEval {
+                expr,
+                evaluation: _,
+            } => AENodesIter::new_single(expr),
+            Eval {
+                expr,
+                evaluation: _,
+                variant: _,
+            } => AENodesIter::new_single(expr),
+            ae => ae.nodes_iter(),
+        }
+    }
+
+    /// Iterator that returns the child nodes of this aexpr in field declaration order.
+    ///
+    /// This is derived from `nodes_iter`, but skips the eval exprs in list / struct eval.
+    ///
+    /// This function and its users must be updated if the field declaration order changes.
+    pub fn inputs_iter_mut(&mut self) -> AENodesIterMut<'_> {
+        use AExpr::*;
+
+        match self {
+            #[cfg(feature = "dtype-struct")]
+            StructEval {
+                expr,
+                evaluation: _,
+            } => AENodesIterMut::new_single(expr),
+            Eval {
+                expr,
+                evaluation: _,
+                variant: _,
+            } => AENodesIterMut::new_single(expr),
+            ae => ae.nodes_iter_mut(),
+        }
+    }
+
+    /// Iterator that returns nodes in order such that the last item of the iterator is the node
+    /// from which the output name is sourced. The ordering of non-name nodes is unspecified but
+    /// guaranteed to match `AExpr::inputs_iter_mut_name_last`.
+    ///
+    /// This is derived from `nodes_iter_name_last`, but skips the eval exprs in list / struct eval.
+    pub fn inputs_iter_name_last(&self) -> iter::Rev<AENodesIter<'_>> {
+        use AExpr::*;
+
+        Iterator::rev(match self {
+            Ternary {
+                predicate,
+                truthy,
+                falsy,
+            } => AENodesIter::new_triple(truthy, falsy, predicate),
+            _ => self.inputs_iter(),
+        })
+    }
+
+    /// Iterator that returns nodes in order such that the last item of the iterator is the node
+    /// from which the output name is sourced. The ordering of non-name nodes is unspecified but
+    /// guaranteed to match `AExpr::inputs_iter_name_last`.
+    ///
+    /// This is derived from `nodes_iter_name_last`, but skips the eval exprs in list / struct eval.
+    pub fn inputs_iter_mut_name_last(&mut self) -> iter::Rev<AENodesIterMut<'_>> {
+        use AExpr::*;
+
+        Iterator::rev(match self {
+            Ternary {
+                predicate,
+                truthy,
+                falsy,
+            } => AENodesIterMut::new_triple(truthy, falsy, predicate),
+            _ => self.inputs_iter_mut(),
+        })
+    }
+
+    /// Replace the inputs of this AExpr. This excludes the list / struct eval exprs.
+    ///
+    /// # Panics
+    /// Panics if the number of provided inputs does not match the number of inputs in this AExpr.
+    pub fn replace_inputs(&mut self, inputs: impl IntoIterator<Item = Node>) {
+        for (l, r) in self.inputs_iter_mut().zip_eq(inputs) {
+            *l = r;
+        }
+    }
+
+    /// Replace the nodes in this AExpr.
+    ///
+    /// # Panics
+    /// Panics if the number of provided nodes does not match the number of nodes in this AExpr.
+    pub fn replace_nodes(&mut self, nodes: impl IntoIterator<Item = Node>) {
+        for (l, r) in self.nodes_iter_mut().zip_eq(nodes) {
+            *l = r;
+        }
     }
 }
 
 impl IRAggExpr {
-    pub fn get_input(&self) -> NodeInputs {
+    pub fn nodes_iter(&self) -> AENodesIter<'_> {
         use IRAggExpr::*;
-        use NodeInputs::*;
 
         match self {
-            Min { input, .. } => Single(*input),
-            Max { input, .. } => Single(*input),
-            Median(input) => Single(*input),
-            NUnique(input) => Single(*input),
-            First(input) => Single(*input),
-            FirstNonNull(input) => Single(*input),
-            Last(input) => Single(*input),
-            LastNonNull(input) => Single(*input),
-            Item { input, .. } => Single(*input),
-            Mean(input) => Single(*input),
-            Implode { input, .. } => Single(*input),
-            Quantile { expr, quantile, .. } => Many(vec![*expr, *quantile]),
-            Sum(input) => Single(*input),
-            Count { input, .. } => Single(*input),
-            Std(input, _) => Single(*input),
-            Var(input, _) => Single(*input),
-            AggGroups(input) => Single(*input),
+            Min {
+                input,
+                propagate_nans: _,
+            }
+            | Max {
+                input,
+                propagate_nans: _,
+            }
+            | Median(input)
+            | NUnique(input)
+            | First(input)
+            | FirstNonNull(input)
+            | Last(input)
+            | LastNonNull(input)
+            | Item {
+                input,
+                allow_empty: _,
+            }
+            | Mean(input)
+            | Implode {
+                input,
+                maintain_order: _,
+            }
+            | Sum(input)
+            | Count {
+                input,
+                include_nulls: _,
+            }
+            | Std(input, _)
+            | Var(input, _)
+            | AggGroups(input) => AENodesIter::new_single(input),
+
+            Quantile {
+                expr,
+                quantile,
+                method: _,
+            } => AENodesIter::new_double(expr, quantile),
         }
     }
+
+    pub fn nodes_iter_mut(&mut self) -> AENodesIterMut<'_> {
+        use IRAggExpr::*;
+
+        match self {
+            Min {
+                input,
+                propagate_nans: _,
+            }
+            | Max {
+                input,
+                propagate_nans: _,
+            }
+            | Median(input)
+            | NUnique(input)
+            | First(input)
+            | FirstNonNull(input)
+            | Last(input)
+            | LastNonNull(input)
+            | Item {
+                input,
+                allow_empty: _,
+            }
+            | Mean(input)
+            | Implode {
+                input,
+                maintain_order: _,
+            }
+            | Sum(input)
+            | Count {
+                input,
+                include_nulls: _,
+            }
+            | Std(input, _)
+            | Var(input, _)
+            | AggGroups(input) => AENodesIterMut::new_single(input),
+
+            Quantile {
+                expr,
+                quantile,
+                method: _,
+            } => AENodesIterMut::new_double(expr, quantile),
+        }
+    }
+
     pub fn set_input(&mut self, input: Node) {
         use IRAggExpr::*;
         let node = match self {
@@ -591,18 +419,201 @@ impl IRAggExpr {
     }
 }
 
-pub enum NodeInputs {
-    Leaf,
-    Single(Node),
-    Many(Vec<Node>),
+#[expect(clippy::type_complexity)]
+pub enum AENodesIter<'a> {
+    Slice(slice::Iter<'a, Node>),
+    DoubleSlice(iter::Chain<slice::Iter<'a, Node>, slice::Iter<'a, Node>>),
+    TripleSlice(
+        iter::Chain<
+            iter::Chain<slice::Iter<'a, Node>, slice::Iter<'a, Node>>,
+            slice::Iter<'a, Node>,
+        >,
+    ),
+    ExprIRSlice(iter::Map<slice::Iter<'a, ExprIR>, fn(&'a ExprIR) -> &'a Node>),
+    StructEval(
+        iter::Chain<
+            iter::Once<&'a Node>,
+            iter::Map<slice::Iter<'a, ExprIR>, fn(&'a ExprIR) -> &'a Node>,
+        >,
+    ),
 }
 
-impl NodeInputs {
-    pub fn first(&self) -> Node {
+impl<'a> AENodesIter<'a> {
+    pub fn new_empty() -> Self {
+        Self::Slice([].iter())
+    }
+
+    pub fn new_single(node: &'a Node) -> Self {
+        Self::Slice(slice::from_ref(node).iter())
+    }
+
+    pub fn new_double(node1: &'a Node, node2: &'a Node) -> Self {
+        use slice::from_ref;
+
+        Self::DoubleSlice(from_ref(node1).iter().chain(from_ref(node2)))
+    }
+
+    pub fn new_triple(node1: &'a Node, node2: &'a Node, node3: &'a Node) -> Self {
+        use slice::from_ref;
+
+        Self::TripleSlice(
+            from_ref(node1)
+                .iter()
+                .chain(from_ref(node2))
+                .chain(from_ref(node3)),
+        )
+    }
+}
+
+impl<'a> Iterator for AENodesIter<'a> {
+    type Item = Node;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        use AENodesIter::*;
         match self {
-            NodeInputs::Single(node) => *node,
-            NodeInputs::Many(nodes) => nodes[0],
-            NodeInputs::Leaf => panic!(),
+            Slice(it) => it.next(),
+            DoubleSlice(it) => it.next(),
+            TripleSlice(it) => it.next(),
+            ExprIRSlice(it) => it.next(),
+            StructEval(it) => it.next(),
+        }
+        .copied()
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        use AENodesIter::*;
+        match self {
+            Slice(it) => it.nth(n),
+            DoubleSlice(it) => it.nth(n),
+            TripleSlice(it) => it.nth(n),
+            ExprIRSlice(it) => it.nth(n),
+            StructEval(it) => it.nth(n),
+        }
+        .copied()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        use AENodesIter::*;
+        match self {
+            Slice(it) => it.size_hint(),
+            DoubleSlice(it) => it.size_hint(),
+            TripleSlice(it) => it.size_hint(),
+            ExprIRSlice(it) => it.size_hint(),
+            StructEval(it) => it.size_hint(),
+        }
+    }
+}
+
+impl<'a> ExactSizeIterator for AENodesIter<'a> {}
+
+impl<'a> DoubleEndedIterator for AENodesIter<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        use AENodesIter::*;
+        match self {
+            Slice(it) => it.next_back(),
+            DoubleSlice(it) => it.next_back(),
+            TripleSlice(it) => it.next_back(),
+            ExprIRSlice(it) => it.next_back(),
+            StructEval(it) => it.next_back(),
+        }
+        .copied()
+    }
+}
+
+#[expect(clippy::type_complexity)]
+pub enum AENodesIterMut<'a> {
+    Slice(slice::IterMut<'a, Node>),
+    DoubleSlice(iter::Chain<slice::IterMut<'a, Node>, slice::IterMut<'a, Node>>),
+    TripleSlice(
+        iter::Chain<
+            iter::Chain<slice::IterMut<'a, Node>, slice::IterMut<'a, Node>>,
+            slice::IterMut<'a, Node>,
+        >,
+    ),
+    ExprIRSlice(iter::Map<slice::IterMut<'a, ExprIR>, fn(&'a mut ExprIR) -> &'a mut Node>),
+    StructEval(
+        iter::Chain<
+            iter::Once<&'a mut Node>,
+            iter::Map<slice::IterMut<'a, ExprIR>, fn(&'a mut ExprIR) -> &'a mut Node>,
+        >,
+    ),
+}
+
+impl<'a> AENodesIterMut<'a> {
+    pub fn new_empty() -> Self {
+        Self::Slice([].iter_mut())
+    }
+
+    pub fn new_single(node: &'a mut Node) -> Self {
+        Self::Slice(slice::from_mut(node).iter_mut())
+    }
+
+    pub fn new_double(node1: &'a mut Node, node2: &'a mut Node) -> Self {
+        use slice::from_mut;
+
+        Self::DoubleSlice(from_mut(node1).iter_mut().chain(from_mut(node2)))
+    }
+
+    pub fn new_triple(node1: &'a mut Node, node2: &'a mut Node, node3: &'a mut Node) -> Self {
+        use slice::from_mut;
+
+        Self::TripleSlice(
+            from_mut(node1)
+                .iter_mut()
+                .chain(from_mut(node2))
+                .chain(from_mut(node3)),
+        )
+    }
+}
+
+impl<'a> Iterator for AENodesIterMut<'a> {
+    type Item = &'a mut Node;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        use AENodesIterMut::*;
+        match self {
+            Slice(it) => it.next(),
+            DoubleSlice(it) => it.next(),
+            TripleSlice(it) => it.next(),
+            ExprIRSlice(it) => it.next(),
+            StructEval(it) => it.next(),
+        }
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        use AENodesIterMut::*;
+        match self {
+            Slice(it) => it.nth(n),
+            DoubleSlice(it) => it.nth(n),
+            TripleSlice(it) => it.nth(n),
+            ExprIRSlice(it) => it.nth(n),
+            StructEval(it) => it.nth(n),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        use AENodesIterMut::*;
+        match self {
+            Slice(it) => it.size_hint(),
+            DoubleSlice(it) => it.size_hint(),
+            TripleSlice(it) => it.size_hint(),
+            ExprIRSlice(it) => it.size_hint(),
+            StructEval(it) => it.size_hint(),
+        }
+    }
+}
+
+impl<'a> ExactSizeIterator for AENodesIterMut<'a> {}
+
+impl<'a> DoubleEndedIterator for AENodesIterMut<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        use AENodesIterMut::*;
+        match self {
+            Slice(it) => it.next_back(),
+            DoubleSlice(it) => it.next_back(),
+            TripleSlice(it) => it.next_back(),
+            ExprIRSlice(it) => it.next_back(),
+            StructEval(it) => it.next_back(),
         }
     }
 }
@@ -620,25 +631,27 @@ where
     tree_traversal(root_ae_node, expr_arena, visit_stack, edges, visitor)
 }
 
-struct ExtendWrap<'a, T>(&'a mut dyn FnMut(T));
-
-impl<'a, T> Extend<T> for ExtendWrap<'a, T> {
-    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
-        for v in iter.into_iter() {
-            (self.0)(v)
-        }
-    }
-}
-
 impl GetNodeInputs<Node> for Arena<AExpr> {
     fn get_node_inputs(&self, key: Node, push_fn: &mut dyn FnMut(Node)) {
-        self.get(key).inputs(&mut ExtendWrap(push_fn));
+        for node in self.get(key).nodes_iter() {
+            push_fn(node)
+        }
+    }
+
+    fn num_inputs(&self, key: Node) -> usize {
+        self.get(key).nodes_iter().len()
     }
 }
 
 impl GetNodeInputs<Node> for &Arena<AExpr> {
     fn get_node_inputs(&self, key: Node, push_fn: &mut dyn FnMut(Node)) {
-        self.get(key).inputs(&mut ExtendWrap(push_fn));
+        for node in self.get(key).nodes_iter() {
+            push_fn(node)
+        }
+    }
+
+    fn num_inputs(&self, key: Node) -> usize {
+        self.get(key).nodes_iter().len()
     }
 }
 
@@ -648,6 +661,10 @@ impl GetNodeInputs<Node> for Arena<IR> {
             push_fn(v)
         }
     }
+
+    fn num_inputs(&self, key: Node) -> usize {
+        self.get(key).inputs().len()
+    }
 }
 
 impl GetNodeInputs<Node> for &Arena<IR> {
@@ -655,5 +672,9 @@ impl GetNodeInputs<Node> for &Arena<IR> {
         for v in self.get(key).inputs() {
             push_fn(v)
         }
+    }
+
+    fn num_inputs(&self, key: Node) -> usize {
+        self.get(key).inputs().len()
     }
 }

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -972,7 +972,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                         arena: &mut Arena<AExpr>,
                         replacement: Node,
                     ) -> Node {
-                        let slf = arena.get(ae).clone();
+                        let mut slf = arena.get(ae).clone();
                         if matches!(slf, AExpr::Element) {
                             return deep_clone_ae(replacement, arena);
                         } else if matches!(slf, AExpr::Len) {
@@ -983,13 +983,13 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                         }
 
                         let mut children = vec![];
-                        slf.children_rev(&mut children);
+                        children.extend(slf.nodes_iter());
                         for child in &mut children {
                             *child = deep_clone_element_replace(*child, arena, replacement);
                         }
-                        children.reverse();
 
-                        arena.add(slf.replace_children(&children))
+                        slf.replace_nodes(children);
+                        arena.add(slf)
                     }
                     aggs.push(ExprIR::new(
                         deep_clone_element_replace(agg_ae, ctxt.expr_arena, replacement_element),

--- a/crates/polars-plan/src/plans/conversion/stack_opt.rs
+++ b/crates/polars-plan/src/plans/conversion/stack_opt.rs
@@ -20,17 +20,6 @@ pub struct ConversionOptimizer {
     pub(super) used_arenas: PlHashSet<u32>,
 }
 
-struct ExtendVec<'a> {
-    out: &'a mut Vec<(Node, usize)>,
-    schema_idx: usize,
-}
-impl Extend<Node> for ExtendVec<'_> {
-    fn extend<T: IntoIterator<Item = Node>>(&mut self, iter: T) {
-        self.out
-            .extend(iter.into_iter().map(|n| (n, self.schema_idx)))
-    }
-}
-
 impl ConversionOptimizer {
     pub fn new(simplify: bool, type_coercion: bool, type_check: bool) -> Self {
         let simplify = if simplify {
@@ -64,12 +53,10 @@ impl ConversionOptimizer {
     pub fn push_scratch(&mut self, expr: Node, expr_arena: &Arena<AExpr>) {
         self.scratch.push((expr, 0));
         // traverse all subexpressions and add to the stack
-        let expr = unsafe { expr_arena.get_unchecked(expr) };
+        let expr = expr_arena.get(expr);
 
-        expr.inputs_rev_strict(&mut ExtendVec {
-            out: &mut self.scratch,
-            schema_idx: 0,
-        });
+        self.scratch
+            .extend(expr.inputs_iter_name_last().map(|node| (node, 0)))
     }
 
     pub fn fill_scratch<I, N>(&mut self, exprs: I, expr_arena: &Arena<AExpr>)
@@ -194,12 +181,11 @@ impl ConversionOptimizer {
                 }
             }
 
-            let expr = unsafe { expr_arena.get_unchecked(current_expr_node) };
+            let expr = expr_arena.get(current_expr_node);
+
             // traverse subexpressions and add to the stack
-            expr.inputs_rev_strict(&mut ExtendVec {
-                out: &mut self.scratch,
-                schema_idx,
-            });
+            self.scratch
+                .extend(expr.inputs_iter_name_last().map(|node| (node, schema_idx)))
         }
 
         Ok(())

--- a/crates/polars-plan/src/plans/expr_ir.rs
+++ b/crates/polars-plan/src/plans/expr_ir.rs
@@ -196,6 +196,14 @@ impl ExprIR {
         self.node
     }
 
+    pub fn node_ref(&self) -> &Node {
+        &self.node
+    }
+
+    pub fn node_mut(&mut self) -> &mut Node {
+        &mut self.node
+    }
+
     /// Create a `ExprIR` structure that implements display
     pub fn display<'a>(&'a self, expr_arena: &'a Arena<AExpr>) -> ExprIRDisplay<'a> {
         ExprIRDisplay {

--- a/crates/polars-plan/src/plans/ir/inputs.rs
+++ b/crates/polars-plan/src/plans/ir/inputs.rs
@@ -338,7 +338,19 @@ impl<'a> Iterator for Inputs<'a> {
             Self::DoubleSlice(it) => it.nth(n),
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            Self::Empty => (0, Some(0)),
+            Self::Single(it) => it.size_hint(),
+            Self::Double(it) => it.size_hint(),
+            Self::Slice(it) => it.size_hint(),
+            Self::DoubleSlice(it) => it.size_hint(),
+        }
+    }
 }
+
+impl<'a> ExactSizeIterator for Inputs<'a> {}
 
 pub enum InputsMut<'a> {
     Empty,
@@ -384,7 +396,19 @@ impl<'a> Iterator for InputsMut<'a> {
             Self::DoubleSlice(it) => it.nth(n),
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            Self::Empty => (0, Some(0)),
+            Self::Single(it) => it.size_hint(),
+            Self::Double(it) => it.size_hint(),
+            Self::Slice(it) => it.size_hint(),
+            Self::DoubleSlice(it) => it.size_hint(),
+        }
+    }
 }
+
+impl<'a> ExactSizeIterator for InputsMut<'a> {}
 
 pub enum Exprs<'a> {
     Empty,

--- a/crates/polars-plan/src/plans/iterator.rs
+++ b/crates/polars-plan/src/plans/iterator.rs
@@ -197,7 +197,7 @@ impl<'a> Iterator for AExprIter<'a> {
             let arena = self.arena.unwrap();
             let current_expr = arena.get(node);
             // Expressions such as StructEval may reference columns that are not input.
-            current_expr.children_rev(&mut self.stack);
+            self.stack.extend(current_expr.nodes_iter_name_last());
 
             self.arena = Some(arena);
             (node, current_expr)

--- a/crates/polars-plan/src/plans/optimizer/cse/csee.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/csee.rs
@@ -866,9 +866,9 @@ impl CommonSubExprOptimizer {
                             continue;
                         }
 
-                        aes[0].inputs_rev(&mut scratch);
+                        scratch.extend(aes[0].nodes_iter_name_last());
                         let offset = scratch.len();
-                        aes[1].inputs_rev(&mut scratch);
+                        scratch.extend(aes[1].nodes_iter_name_last());
 
                         // If they have a different number of inputs, we don't follow the nodes.
                         if scratch.len() != offset * 2 {

--- a/crates/polars-plan/src/plans/optimizer/stack_opt.rs
+++ b/crates/polars-plan/src/plans/optimizer/stack_opt.rs
@@ -26,7 +26,6 @@ impl StackOptimizer {
         let mut plans = vec![];
         let mut exprs = vec![];
         let mut scratch = vec![];
-        let mut children = vec![];
         let mut schema_stack: Vec<Arc<Schema>> = vec![];
 
         // Run loop until reaching fixed point.
@@ -114,12 +113,8 @@ impl StackOptimizer {
                                 exprs.push((node, eval_schema_idx));
                             }
                         },
-                        expr => {
-                            children.clear();
-                            expr.inputs_rev(&mut children);
-                            for node in children.drain(..) {
-                                exprs.push((node, schema_idx));
-                            }
+                        ae => {
+                            exprs.extend(ae.inputs_iter_name_last().map(|node| (node, schema_idx)))
                         },
                     }
                 }

--- a/crates/polars-plan/src/plans/prune.rs
+++ b/crates/polars-plan/src/plans/prune.rs
@@ -5,7 +5,7 @@ use polars_utils::arena::{Arena, Node};
 use polars_utils::unique_id::UniqueId;
 use recursive::recursive;
 
-use crate::plans::{AExpr, ExprIR, IR, IRPlan, IRPlanRef};
+use crate::plans::{AExpr, IR, IRPlan, IRPlanRef};
 
 /// Returns a pruned copy of this plan with new arenas (without unreachable nodes).
 ///
@@ -130,30 +130,8 @@ impl<'a> CopyContext<'a> {
     fn copy_expr(&mut self, node: Node) -> Node {
         let expr = self.src_expr.get(node);
 
-        let mut inputs = vec![];
-        expr.inputs_rev(&mut inputs);
-
-        for input in &mut inputs {
-            *input = self.copy_expr(*input);
-        }
-        inputs.reverse();
-
-        let mut dst_expr = expr.clone().replace_inputs(&inputs);
-
-        // Fix up eval, the evaluation subtree is not treated as an input,
-        // so it needs to be copied manually.
-        if let AExpr::Eval { evaluation, .. } = &mut dst_expr {
-            *evaluation = self.copy_expr(*evaluation);
-        }
-        #[cfg(feature = "dtype-struct")]
-        if let AExpr::StructEval { evaluation, .. } = &mut dst_expr {
-            for e in evaluation.iter_mut() {
-                *e = ExprIR::new(
-                    self.copy_expr(e.node()),
-                    crate::plans::OutputName::Alias(e.output_name().clone()),
-                );
-            }
-        }
+        let mut dst_expr = expr.clone();
+        dst_expr.replace_nodes(expr.nodes_iter().map(|node| self.copy_expr(node)));
 
         self.dst_expr.add(dst_expr)
     }

--- a/crates/polars-plan/src/plans/visitor/expr.rs
+++ b/crates/polars-plan/src/plans/visitor/expr.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Debug, Formatter};
 
 use polars_core::prelude::{Field, Schema};
+use polars_utils::itertools::Itertools;
 use polars_utils::unitvec;
 
 use super::*;
@@ -328,8 +329,8 @@ impl PartialEq for AExprArena<'_> {
                         return false;
                     }
 
-                    l.to_aexpr().inputs_rev(&mut scratch1);
-                    r.to_aexpr().inputs_rev(&mut scratch2);
+                    scratch1.extend(l.to_aexpr().inputs_iter_name_last());
+                    scratch2.extend(r.to_aexpr().inputs_iter_name_last());
                 },
                 (None, None) => return true,
                 _ => return false,
@@ -347,7 +348,7 @@ impl TreeWalker for AexprNode {
     ) -> PolarsResult<VisitRecursion> {
         let mut scratch = unitvec![];
 
-        self.to_aexpr(arena).inputs_rev(&mut scratch);
+        scratch.extend(self.to_aexpr(arena).inputs_iter_name_last());
         for node in scratch.as_slice() {
             let aenode = AexprNode::new(*node);
             match op(&aenode, arena)? {
@@ -367,8 +368,8 @@ impl TreeWalker for AexprNode {
     ) -> PolarsResult<Self> {
         let mut scratch = unitvec![];
 
-        let ae = arena.get(self.node).clone();
-        ae.inputs_rev(&mut scratch);
+        let mut ae = arena.get(self.node).clone();
+        scratch.extend(ae.inputs_iter_name_last());
 
         // rewrite the nodes
         for node in scratch.as_mut_slice() {
@@ -376,8 +377,10 @@ impl TreeWalker for AexprNode {
             *node = op(aenode, arena)?.node;
         }
 
-        scratch.as_mut_slice().reverse();
-        let ae = ae.replace_inputs(&scratch);
+        for (l, r) in ae.inputs_iter_mut_name_last().zip_eq(scratch) {
+            *l = r;
+        }
+
         self.node = arena.add(ae);
         Ok(self)
     }

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -193,15 +193,9 @@ pub fn is_input_independent_rec(
             is_input_independent_rec(*input, arena, cache)
                 && is_input_independent_rec(*by, arena, cache)
         },
-        AExpr::Agg(agg_expr) => match agg_expr.get_input() {
-            polars_plan::plans::NodeInputs::Leaf => true,
-            polars_plan::plans::NodeInputs::Single(expr) => {
-                is_input_independent_rec(expr, arena, cache)
-            },
-            polars_plan::plans::NodeInputs::Many(exprs) => exprs
-                .iter()
-                .all(|expr| is_input_independent_rec(*expr, arena, cache)),
-        },
+        AExpr::Agg(agg_expr) => agg_expr
+            .nodes_iter()
+            .all(|node| is_input_independent_rec(node, arena, cache)),
         AExpr::Ternary {
             predicate,
             truthy,
@@ -528,13 +522,13 @@ fn lower_reduce_node(
     agg_node: Node,
     ctx: &mut LowerExprContext,
 ) -> PolarsResult<(PhysStream, Node)> {
-    let agg_aexpr = ctx.expr_arena.get(agg_node).clone();
-    let mut agg_input = Vec::with_capacity(1);
-    agg_aexpr.inputs_rev(&mut agg_input);
-    agg_input.reverse();
+    let mut agg_aexpr = ctx.expr_arena.get(agg_node).clone();
 
+    let agg_input = Vec::from_iter(agg_aexpr.inputs_iter());
     let (trans_input, trans_exprs) = lower_exprs_with_ctx(input, &agg_input, ctx)?;
-    let trans_agg_node = ctx.expr_arena.add(agg_aexpr.replace_inputs(&trans_exprs));
+    agg_aexpr.replace_inputs(trans_exprs);
+
+    let trans_agg_node = ctx.expr_arena.add(agg_aexpr);
 
     let out_name = unique_column_name();
     let expr_ir = ExprIR::new(trans_agg_node, OutputName::Alias(out_name.clone()));

--- a/crates/polars-stream/src/physical_plan/lower_group_by.rs
+++ b/crates/polars-stream/src/physical_plan/lower_group_by.rs
@@ -103,21 +103,18 @@ fn replace_agg_uniq(
     uniq_agg_exprs: &mut PlIndexMap<u32, (ExprIR, Vec<u32>)>,
     uniq_elementwise_exprs: &mut PlIndexMap<u32, ExprIR>,
 ) -> Node {
-    let aexpr = expr_arena.get(expr).clone();
-    let mut inputs = Vec::new();
-    aexpr.inputs_rev(&mut inputs);
-    inputs.reverse();
+    let mut aexpr = expr_arena.get(expr).clone();
 
     let agg_id = expr_merger.get_uniq_id(expr).unwrap();
     let name = uniq_agg_exprs
         .entry(agg_id)
         .or_insert_with(|| {
             let mut input_ids = Vec::new();
-            let input_cols = inputs
-                .iter()
+            let input_cols = aexpr
+                .inputs_iter()
                 .map(|input| {
                     let (input_id, node) = replace_elementwise_components(
-                        *input,
+                        input,
                         expr_merger,
                         expr_cache,
                         expr_arena,
@@ -139,7 +136,8 @@ fn replace_agg_uniq(
                     }
                 })
                 .collect::<Vec<_>>();
-            let trans_agg_node = expr_arena.add(aexpr.replace_inputs(&input_cols));
+            aexpr.replace_inputs(input_cols);
+            let trans_agg_node = expr_arena.add(aexpr);
 
             // Add to aggregation expressions and replace with a reference to its output.
             let agg_expr = ExprIR::new(trans_agg_node, OutputName::Alias(unique_column_name()));
@@ -177,23 +175,22 @@ fn replace_elementwise_components(
             .node();
         (Some(id), node)
     } else {
-        let aexpr = expr_arena.get(expr).clone();
-        let mut inputs = Vec::new();
-        aexpr.inputs_rev(&mut inputs);
-        inputs.reverse();
-
-        for input in &mut inputs {
-            *input = replace_elementwise_components(
-                *input,
+        let mut aexpr = expr_arena.get(expr).clone();
+        let new_inputs = Vec::from_iter(aexpr.inputs_iter().map(|node| {
+            replace_elementwise_components(
+                node,
                 expr_merger,
                 expr_cache,
                 expr_arena,
                 uniq_input_names,
                 uniq_elementwise_exprs,
             )
-            .1;
-        }
-        let rec_node = expr_arena.add(aexpr.replace_inputs(&inputs));
+            .1
+        }));
+
+        aexpr.replace_inputs(new_inputs);
+
+        let rec_node = expr_arena.add(aexpr);
         (None, rec_node)
     }
 }


### PR DESCRIPTION
Adds
* `AExpr::nodes_iter(_mut)`
* `AExpr::inputs_iter(_mut)` - like `nodes_iter` but excludes the evaluation exprs of list/eval exprs

Before / after
* `ae.children_rev(stack)` -> `stack.extend(ae.nodes_iter_name_last())`
* `ae.inputs_rev(stack)` -> `stack.extend(ae.inputs_iter_name_last())`

Other notes
* At the moment `inputs_rev()` is inconsistent in that it excludes the eval exprs of `ListEval` but includes the eval exprs of `StructEval`. In this PR `inputs_iter` will exclude eval exprs of both variants.
