### PR TITLE
docs: Clarify DataFrame.sort returns new frame

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -6039,7 +6039,7 @@ class DataFrame:
         maintain_order: bool = False,
     ) -> DataFrame:
         """
-        Sort the dataframe by the given columns.
+        Return a new DataFrame sorted by the given columns.
 
         Parameters
         ----------


### PR DESCRIPTION
Fixes #17636.

Clarifies the `DataFrame.sort` docstring to state that it returns a new sorted `DataFrame`, rather than implying in-place mutation.

- I used AI to help identify the affected docstring and draft the PR description. 
- I confirm that I have reviewed the change myself, and I believe it is relevant and correct.