### PR TITLE
fix: Struct rechunk bug and add Series::with_validity

### DIFF
--- a/crates/polars-core/src/chunked_array/comparison/mod.rs
+++ b/crates/polars-core/src/chunked_array/comparison/mod.rs
@@ -13,7 +13,6 @@ use polars_compute::comparisons::{TotalEqKernel, TotalOrdKernel};
 use crate::prelude::*;
 use crate::series::IsSorted;
 use crate::series::implementations::null::NullChunked;
-use crate::utils::align_chunks_binary;
 
 impl<T> ChunkCompareEq<&ChunkedArray<T>> for ChunkedArray<T>
 where
@@ -795,70 +794,49 @@ where
     let len_a = a.len();
     let len_b = b.len();
     let broadcasts = len_a == 1 || len_b == 1;
-    if (a.len() != b.len() && !broadcasts) || a.struct_fields().len() != b.struct_fields().len() {
-        BooleanChunked::full(PlSmallStr::EMPTY, op_is_ne, a.len())
-    } else {
-        let (a, b) = align_chunks_binary(a, b);
+    assert!(a.struct_fields().len() == b.struct_fields().len());
+    assert!(a.len() == b.len() || broadcasts);
 
-        let mut out = a
-            .fields_as_series()
-            .iter()
-            .zip(b.fields_as_series().iter())
-            .map(|(l, r)| op(l, r))
-            .reduce(&reduce)
-            .unwrap_or_else(|| BooleanChunked::full(PlSmallStr::EMPTY, !op_is_ne, a.len()));
+    let mut out = a
+        .fields_as_series()
+        .iter()
+        .zip(b.fields_as_series().iter())
+        .map(|(l, r)| op(l, r))
+        .reduce(&reduce)
+        .unwrap_or_else(|| BooleanChunked::full(PlSmallStr::EMPTY, !op_is_ne, a.len()));
 
-        if is_missing && (a.has_nulls() || b.has_nulls()) {
-            // Do some allocations so that we can use the Series dispatch, it otherwise
-            // gets complicated dealing with combinations of ==, != and broadcasting.
-            let default =
-                || BooleanChunked::with_chunk(PlSmallStr::EMPTY, BooleanArray::from_slice([true]));
-            let validity_to_ca = |x| unsafe {
-                BooleanChunked::with_chunk(
-                    PlSmallStr::EMPTY,
-                    BooleanArray::from_inner_unchecked(ArrowDataType::Boolean, x, None),
-                )
-            };
+    if is_missing && (a.has_nulls() || b.has_nulls()) {
+        // Do some allocations so that we can use the Series dispatch, it otherwise
+        // gets complicated dealing with combinations of ==, != and broadcasting.
+        let default =
+            || BooleanChunked::with_chunk(PlSmallStr::EMPTY, BooleanArray::from_slice([true]));
+        let validity_to_ca = |x| unsafe {
+            BooleanChunked::with_chunk(
+                PlSmallStr::EMPTY,
+                BooleanArray::from_inner_unchecked(ArrowDataType::Boolean, x, None),
+            )
+        };
 
-            let a_s = a.rechunk_validity().map_or_else(default, validity_to_ca);
-            let b_s = b.rechunk_validity().map_or_else(default, validity_to_ca);
+        let a_s = a.rechunk_validity().map_or_else(default, validity_to_ca);
+        let b_s = b.rechunk_validity().map_or_else(default, validity_to_ca);
 
-            let shared_validity = (&a_s).bitand(&b_s);
-            let valid_nested = if op_is_ne {
-                (shared_validity).bitand(out)
-            } else {
-                (!shared_validity).bitor(out)
-            };
-            out = reduce(op(&a_s.into_series(), &b_s.into_series()), valid_nested);
-        }
-
-        if !is_missing && (a.has_nulls() || b.has_nulls()) {
-            let mut a = a;
-            let mut b = b;
-
-            if broadcasts {
-                if a.len() == 1 {
-                    a = std::borrow::Cow::Owned(a.new_from_index(0, b.len()));
-                }
-                if b.len() == 1 {
-                    b = std::borrow::Cow::Owned(b.new_from_index(0, a.len()));
-                }
-            }
-
-            let mut a = a.into_owned();
-            a.zip_outer_validity(&b);
-            unsafe {
-                let mut new_null_count = 0;
-                for (arr, a) in out.downcast_iter_mut().zip(a.downcast_iter()) {
-                    arr.set_validity(a.validity().cloned());
-                    new_null_count += arr.null_count();
-                }
-                out.set_null_count(new_null_count);
-            }
-        }
-
-        out
+        let shared_validity = (&a_s).bitand(&b_s);
+        let valid_nested = if op_is_ne {
+            (shared_validity).bitand(out)
+        } else {
+            (!shared_validity).bitor(out)
+        };
+        out = reduce(op(&a_s.into_series(), &b_s.into_series()), valid_nested);
     }
+
+    if !is_missing && (a.has_nulls() || b.has_nulls()) {
+        use arrow::compute::utils::combine_validities_and;
+        let av = a.rechunk_validity();
+        let bv = b.rechunk_validity();
+        out.set_validity(combine_validities_and(av.as_ref(), bv.as_ref()));
+    }
+
+    out
 }
 
 #[cfg(feature = "dtype-struct")]

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -598,15 +598,27 @@ where
         unsafe { arr.get_unchecked(arr.len() - 1) }
     }
 
-    pub fn set_validity(&mut self, validity: &Bitmap) {
-        assert_eq!(self.len(), validity.len());
+    pub fn set_validity(&mut self, validity: Option<Bitmap>) {
+        assert!(
+            !self.dtype().is_struct(),
+            "set_outer_validity should be used for struct types"
+        );
+        if let Some(v) = &validity {
+            assert_eq!(self.len(), v.len());
+        }
         let mut i = 0;
         for chunk in unsafe { self.chunks_mut() } {
-            *chunk = chunk.with_validity(Some(validity.clone().sliced(i, chunk.len())));
+            *chunk =
+                chunk.with_validity(validity.as_ref().map(|v| v.clone().sliced(i, chunk.len())));
             i += chunk.len();
         }
-        self.null_count = validity.unset_bits();
+        self.null_count = validity.map(|v| v.unset_bits()).unwrap_or(0);
         self.set_fast_explode_list(false);
+    }
+
+    pub fn with_validity(mut self, validity: Option<Bitmap>) -> Self {
+        self.set_validity(validity);
+        self
     }
 }
 
@@ -642,13 +654,10 @@ where
         }));
 
         let mut ca = unsafe { ChunkTakeUnchecked::take_unchecked(self, &gather_idxs) };
-
-        if let Some(combined) =
-            combine_validities_and(Some(validity), ca.rechunk_validity().as_ref())
-        {
-            ca.set_validity(&combined);
-        }
-
+        ca.set_validity(combine_validities_and(
+            Some(validity),
+            ca.rechunk_validity().as_ref(),
+        ));
         ca
     }
 }

--- a/crates/polars-core/src/series/implementations/array.rs
+++ b/crates/polars-core/src/series/implementations/array.rs
@@ -199,6 +199,10 @@ impl SeriesTrait for SeriesWrap<ArrayChunked> {
         self.0.rechunk().into_owned().into_series()
     }
 
+    fn with_validity(&self, validity: Option<Bitmap>) -> Series {
+        self.0.clone().with_validity(validity).into_series()
+    }
+
     fn new_from_index(&self, index: usize, length: usize) -> Series {
         ChunkExpandAtIndex::new_from_index(&self.0, index, length).into_series()
     }

--- a/crates/polars-core/src/series/implementations/binary.rs
+++ b/crates/polars-core/src/series/implementations/binary.rs
@@ -188,6 +188,10 @@ impl SeriesTrait for SeriesWrap<BinaryChunked> {
         self.0.rechunk().into_owned().into_series()
     }
 
+    fn with_validity(&self, validity: Option<Bitmap>) -> Series {
+        self.0.clone().with_validity(validity).into_series()
+    }
+
     fn new_from_index(&self, index: usize, length: usize) -> Series {
         ChunkExpandAtIndex::new_from_index(&self.0, index, length).into_series()
     }

--- a/crates/polars-core/src/series/implementations/binary_offset.rs
+++ b/crates/polars-core/src/series/implementations/binary_offset.rs
@@ -154,6 +154,10 @@ impl SeriesTrait for SeriesWrap<BinaryOffsetChunked> {
         self.0.rechunk().into_owned().into_series()
     }
 
+    fn with_validity(&self, validity: Option<Bitmap>) -> Series {
+        self.0.clone().with_validity(validity).into_series()
+    }
+
     fn new_from_index(&self, index: usize, length: usize) -> Series {
         ChunkExpandAtIndex::new_from_index(&self.0, index, length).into_series()
     }

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -214,6 +214,10 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
         self.0.rechunk().into_owned().into_series()
     }
 
+    fn with_validity(&self, validity: Option<Bitmap>) -> Series {
+        self.0.clone().with_validity(validity).into_series()
+    }
+
     fn new_from_index(&self, index: usize, length: usize) -> Series {
         ChunkExpandAtIndex::new_from_index(&self.0, index, length).into_series()
     }

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -16,7 +16,7 @@ unsafe impl<T: PolarsCategoricalType> IntoSeries for CategoricalChunked<T> {
 impl<T: PolarsCategoricalType> SeriesWrap<CategoricalChunked<T>> {
     unsafe fn apply_on_phys<F>(&self, apply: F) -> CategoricalChunked<T>
     where
-        F: Fn(&ChunkedArray<T::PolarsPhysical>) -> ChunkedArray<T::PolarsPhysical>,
+        F: FnOnce(&ChunkedArray<T::PolarsPhysical>) -> ChunkedArray<T::PolarsPhysical>,
     {
         let cats = apply(self.0.physical());
         unsafe { CategoricalChunked::from_cats_and_dtype_unchecked(cats, self.0.dtype().clone()) }
@@ -24,7 +24,9 @@ impl<T: PolarsCategoricalType> SeriesWrap<CategoricalChunked<T>> {
 
     unsafe fn try_apply_on_phys<F>(&self, apply: F) -> PolarsResult<CategoricalChunked<T>>
     where
-        F: Fn(&ChunkedArray<T::PolarsPhysical>) -> PolarsResult<ChunkedArray<T::PolarsPhysical>>,
+        F: FnOnce(
+            &ChunkedArray<T::PolarsPhysical>,
+        ) -> PolarsResult<ChunkedArray<T::PolarsPhysical>>,
     {
         let cats = apply(self.0.physical())?;
         unsafe {
@@ -250,6 +252,10 @@ macro_rules! impl_cat_series {
 
             fn rechunk(&self) -> Series {
                 unsafe { self.apply_on_phys(|cats| cats.rechunk().into_owned()).into_series() }
+            }
+
+            fn with_validity(&self, validity: Option<Bitmap>) -> Series {
+                unsafe { self.apply_on_phys(move |cats| cats.clone().with_validity(validity)).into_series() }
             }
 
             fn new_from_index(&self, index: usize, length: usize) -> Series {

--- a/crates/polars-core/src/series/implementations/date.rs
+++ b/crates/polars-core/src/series/implementations/date.rs
@@ -294,6 +294,15 @@ impl SeriesTrait for SeriesWrap<DateChunked> {
             .into_series()
     }
 
+    fn with_validity(&self, validity: Option<Bitmap>) -> Series {
+        self.0
+            .physical()
+            .clone()
+            .with_validity(validity)
+            .into_date()
+            .into_series()
+    }
+
     fn new_from_index(&self, index: usize, length: usize) -> Series {
         self.0
             .physical()

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -292,6 +292,15 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
             .into_series()
     }
 
+    fn with_validity(&self, validity: Option<Bitmap>) -> Series {
+        self.0
+            .physical()
+            .clone()
+            .with_validity(validity)
+            .into_datetime(self.0.time_unit(), self.0.time_zone().clone())
+            .into_series()
+    }
+
     fn new_from_index(&self, index: usize, length: usize) -> Series {
         self.0
             .physical()

--- a/crates/polars-core/src/series/implementations/decimal.rs
+++ b/crates/polars-core/src/series/implementations/decimal.rs
@@ -346,6 +346,15 @@ impl SeriesTrait for SeriesWrap<DecimalChunked> {
             .into_series()
     }
 
+    fn with_validity(&self, validity: Option<Bitmap>) -> Series {
+        self.0
+            .physical()
+            .clone()
+            .with_validity(validity)
+            .into_decimal_unchecked(self.0.precision(), self.0.scale())
+            .into_series()
+    }
+
     fn new_from_index(&self, index: usize, length: usize) -> Series {
         self.0
             .physical()

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -426,6 +426,15 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
             .into_series()
     }
 
+    fn with_validity(&self, validity: Option<Bitmap>) -> Series {
+        self.0
+            .physical()
+            .clone()
+            .with_validity(validity)
+            .into_duration(self.0.time_unit())
+            .into_series()
+    }
+
     fn new_from_index(&self, index: usize, length: usize) -> Series {
         self.0
             .physical()

--- a/crates/polars-core/src/series/implementations/extension.rs
+++ b/crates/polars-core/src/series/implementations/extension.rs
@@ -10,7 +10,7 @@ unsafe impl IntoSeries for ExtensionChunked {
 impl SeriesWrap<ExtensionChunked> {
     fn apply_on_storage<F>(&self, apply: F) -> Series
     where
-        F: Fn(&Series) -> Series,
+        F: FnOnce(&Series) -> Series,
     {
         apply(self.0.storage()).into_extension(self.0.extension_type().clone())
     }
@@ -187,6 +187,10 @@ impl SeriesTrait for SeriesWrap<ExtensionChunked> {
 
     fn rechunk(&self) -> Series {
         self.apply_on_storage(|s| s.rechunk())
+    }
+
+    fn with_validity(&self, validity: Option<Bitmap>) -> Series {
+        self.apply_on_storage(move |s| s.with_validity(validity))
     }
 
     fn new_from_index(&self, index: usize, length: usize) -> Series {

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -259,6 +259,10 @@ macro_rules! impl_dyn_series {
                 self.0.rechunk().into_owned().into_series()
             }
 
+            fn with_validity(&self, validity: Option<Bitmap>) -> Series {
+                self.0.clone().with_validity(validity).into_series()
+            }
+
             fn new_from_index(&self, index: usize, length: usize) -> Series {
                 ChunkExpandAtIndex::new_from_index(&self.0, index, length).into_series()
             }

--- a/crates/polars-core/src/series/implementations/list.rs
+++ b/crates/polars-core/src/series/implementations/list.rs
@@ -178,6 +178,10 @@ impl SeriesTrait for SeriesWrap<ListChunked> {
         self.0.rechunk().into_owned().into_series()
     }
 
+    fn with_validity(&self, validity: Option<Bitmap>) -> Series {
+        self.0.clone().with_validity(validity).into_series()
+    }
+
     fn new_from_index(&self, index: usize, length: usize) -> Series {
         ChunkExpandAtIndex::new_from_index(&self.0, index, length).into_series()
     }

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -328,6 +328,10 @@ macro_rules! impl_dyn_series {
                 self.0.rechunk().into_owned().into_series()
             }
 
+            fn with_validity(&self, validity: Option<Bitmap>) -> Series {
+                self.0.clone().with_validity(validity).into_series()
+            }
+
             fn new_from_index(&self, index: usize, length: usize) -> Series {
                 ChunkExpandAtIndex::new_from_index(&self.0, index, length).into_series()
             }

--- a/crates/polars-core/src/series/implementations/null.rs
+++ b/crates/polars-core/src/series/implementations/null.rs
@@ -226,6 +226,10 @@ impl SeriesTrait for NullChunked {
         NullChunked::new(self.name.clone(), self.len()).into_series()
     }
 
+    fn with_validity(&self, _validity: Option<Bitmap>) -> Series {
+        self.clone().into_series()
+    }
+
     fn drop_nulls(&self) -> Series {
         NullChunked::new(self.name.clone(), 0).into_series()
     }

--- a/crates/polars-core/src/series/implementations/object.rs
+++ b/crates/polars-core/src/series/implementations/object.rs
@@ -182,6 +182,10 @@ where
         self.rechunk_object().into_series()
     }
 
+    fn with_validity(&self, validity: Option<Bitmap>) -> Series {
+        self.0.clone().with_validity(validity).into_series()
+    }
+
     fn new_from_index(&self, index: usize, length: usize) -> Series {
         ChunkExpandAtIndex::new_from_index(&self.0, index, length).into_series()
     }

--- a/crates/polars-core/src/series/implementations/string.rs
+++ b/crates/polars-core/src/series/implementations/string.rs
@@ -191,6 +191,10 @@ impl SeriesTrait for SeriesWrap<StringChunked> {
         self.0.rechunk().into_owned().into_series()
     }
 
+    fn with_validity(&self, validity: Option<Bitmap>) -> Series {
+        self.0.clone().with_validity(validity).into_series()
+    }
+
     fn new_from_index(&self, index: usize, length: usize) -> Series {
         ChunkExpandAtIndex::new_from_index(&self.0, index, length).into_series()
     }

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -195,6 +195,10 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
         self.0.rechunk().into_owned().into_series()
     }
 
+    fn with_validity(&self, validity: Option<Bitmap>) -> Series {
+        self.0.clone().with_outer_validity(validity).into_series()
+    }
+
     fn new_from_index(&self, _index: usize, _length: usize) -> Series {
         self.0.new_from_index(_index, _length).into_series()
     }

--- a/crates/polars-core/src/series/implementations/time.rs
+++ b/crates/polars-core/src/series/implementations/time.rs
@@ -273,6 +273,15 @@ impl SeriesTrait for SeriesWrap<TimeChunked> {
             .into_series()
     }
 
+    fn with_validity(&self, validity: Option<Bitmap>) -> Series {
+        self.0
+            .physical()
+            .clone()
+            .with_validity(validity)
+            .into_time()
+            .into_series()
+    }
+
     fn new_from_index(&self, index: usize, length: usize) -> Series {
         self.0
             .physical()

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -322,6 +322,7 @@ pub trait SeriesTrait:
     /// Aggregate all chunks to a contiguous array of memory.
     fn rechunk(&self) -> Series;
 
+    /// Returns the validity of this series as a single bitmap.
     fn rechunk_validity(&self) -> Option<Bitmap> {
         if self.chunks().len() == 1 {
             return self.chunks()[0].validity().cloned();
@@ -341,6 +342,9 @@ pub trait SeriesTrait:
         }
         bm.into_opt_validity()
     }
+
+    /// Sets the validity mask of this Series to the given bitmap.
+    fn with_validity(&self, validity: Option<Bitmap>) -> Series;
 
     /// Drop all null values and return a new Series.
     fn drop_nulls(&self) -> Series {

--- a/crates/polars-expr/src/expressions/eval.rs
+++ b/crates/polars-expr/src/expressions/eval.rs
@@ -241,10 +241,7 @@ impl EvalExpr {
                 ca.len(),
             );
 
-            if let Some(validity) = validity {
-                out.set_validity(&validity);
-            }
-
+            out.set_validity(validity);
             return Ok(if as_list {
                 out.to_list().into_column()
             } else {
@@ -312,10 +309,7 @@ impl EvalExpr {
                     ca.len(),
                 );
 
-                if let Some(validity) = validity {
-                    out.set_validity(&validity);
-                }
-
+                out.set_validity(validity);
                 return Ok(if as_list {
                     out.to_list().into_column()
                 } else {


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/27440.

I thought I needed `Series::with_validity` to solve this but I misread the original code. However, now that we have it might as well keep it, I've wanted it for a long time.