### PR TITLE
docs: Clarify trigonometric functions use radians

### DIFF
--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -9869,7 +9869,7 @@ Consider using {self}.implode() instead"""
 
     def sin(self) -> Expr:
         """
-        Compute the element-wise value for the sine.
+        Compute the element-wise value for the sine (in radians).
 
         Returns
         -------
@@ -9893,7 +9893,7 @@ Consider using {self}.implode() instead"""
 
     def cos(self) -> Expr:
         """
-        Compute the element-wise value for the cosine.
+        Compute the element-wise value for the cosine (in radians).
 
         Returns
         -------
@@ -9917,7 +9917,7 @@ Consider using {self}.implode() instead"""
 
     def tan(self) -> Expr:
         """
-        Compute the element-wise value for the tangent.
+        Compute the element-wise value for the tangent (in radians).
 
         Returns
         -------
@@ -9941,7 +9941,7 @@ Consider using {self}.implode() instead"""
 
     def cot(self) -> Expr:
         """
-        Compute the element-wise value for the cotangent.
+        Compute the element-wise value for the cotangent (in radians).
 
         Returns
         -------
@@ -9965,7 +9965,7 @@ Consider using {self}.implode() instead"""
 
     def arcsin(self) -> Expr:
         """
-        Compute the element-wise value for the inverse sine.
+        Compute the element-wise value for the inverse sine (in radians).
 
         Returns
         -------
@@ -9989,7 +9989,7 @@ Consider using {self}.implode() instead"""
 
     def arccos(self) -> Expr:
         """
-        Compute the element-wise value for the inverse cosine.
+        Compute the element-wise value for the inverse cosine (in radians).
 
         Returns
         -------
@@ -10013,7 +10013,7 @@ Consider using {self}.implode() instead"""
 
     def arctan(self) -> Expr:
         """
-        Compute the element-wise value for the inverse tangent.
+        Compute the element-wise value for the inverse tangent (in radians).
 
         Returns
         -------

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -5887,7 +5887,7 @@ class Series:
 
     def sin(self) -> Series:
         """
-        Compute the element-wise value for the sine.
+        Compute the element-wise value for the sine (in radians).
 
         Examples
         --------
@@ -5905,7 +5905,7 @@ class Series:
 
     def cos(self) -> Series:
         """
-        Compute the element-wise value for the cosine.
+        Compute the element-wise value for the cosine (in radians).
 
         Examples
         --------
@@ -5923,7 +5923,7 @@ class Series:
 
     def tan(self) -> Series:
         """
-        Compute the element-wise value for the tangent.
+        Compute the element-wise value for the tangent (in radians).
 
         Examples
         --------
@@ -5941,7 +5941,7 @@ class Series:
 
     def cot(self) -> Series:
         """
-        Compute the element-wise value for the cotangent.
+        Compute the element-wise value for the cotangent (in radians).
 
         Examples
         --------
@@ -5959,7 +5959,7 @@ class Series:
 
     def arcsin(self) -> Series:
         """
-        Compute the element-wise value for the inverse sine.
+        Compute the element-wise value for the inverse sine (in radians).
 
         Examples
         --------
@@ -5976,7 +5976,7 @@ class Series:
 
     def arccos(self) -> Series:
         """
-        Compute the element-wise value for the inverse cosine.
+        Compute the element-wise value for the inverse cosine (in radians).
 
         Examples
         --------
@@ -5993,7 +5993,7 @@ class Series:
 
     def arctan(self) -> Series:
         """
-        Compute the element-wise value for the inverse tangent.
+        Compute the element-wise value for the inverse tangent (in radians).
 
         Examples
         --------


### PR DESCRIPTION
Closes #18783.

Clarifies the documentation for trigonometric `Expr` and `Series` methods.

This PR documents that:

- `sin`, `cos`, `tan`, and `cot` interpret input values as radians.
- `arcsin`, `arccos`, and `arctan` return output values in radians.

No behavior is changed.

- I used AI to help identify the relevant docstrings and draft the wording.
- I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.