### PR TITLE
docs(python): Clarify join output columns

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -8249,10 +8249,10 @@ class DataFrame:
                  - Returns the Cartesian product of rows from both tables
                * - **semi**
                  - Returns rows from the left table that have a match in the right
-                   table.
+                   table. Does not return columns from the right table.
                * - **anti**
                  - Returns rows from the left table that have no match in the right
-                   table.
+                   table. Does not return columns from the right table.
 
         left_on
             Name(s) of the left join column(s).

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -6151,10 +6151,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                  - Returns the Cartesian product of rows from both tables
                * - **semi**
                  - Returns rows from the left table that have a match in the right
-                   table.
+                   table. Does not return columns from the right table.
                * - **anti**
                  - Returns rows from the left table that have no match in the right
-                   table.
+                   table. Does not return columns from the right table.
 
         left_on
             Join column of the left DataFrame.


### PR DESCRIPTION
Closes #23942.

Clarifies the `DataFrame.join` and `LazyFrame.join` docs for join output columns.

This PR documents that:

- `inner`, `left`, `right`, and `full` joins return columns from both tables.
- `semi` and `anti` joins filter rows from the left table without returning columns from the right table.

AI disclosure:

 - I used AI to help identify the corresponding `DataFrame.join` and `LazyFrame.join` documentation sections and review the wording.
 - I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.