### PR TITLE
fix: Prevent deadlock when using `to_pandas()` in multithreaded context

### DIFF
--- a/crates/polars-python/src/dataframe/export.rs
+++ b/crates/polars-python/src/dataframe/export.rs
@@ -107,95 +107,86 @@ impl PyDataFrame {
     /// since those can't be converted correctly via PyArrow. The calling Python
     /// code should make sure these are not included.
     #[allow(clippy::wrong_self_convention)]
-    pub fn to_pandas(&self) -> PyResult<Vec<Py<PyAny>>> {
-        let df = self.df.read();
-        let df = if df.columns().iter().any(|c| c.n_chunks() > 1) {
-            drop(df);
-            let mut df = self.df.write();
-            let dfr = &mut *df; // Lock guard isn't Send, but mut ref is.
-            dfr.rechunk_mut_par();
-            RwLockWriteGuard::downgrade(df)
-        } else {
-            df
-        };
-        Python::attach(|py| {
-            let pyarrow = py.import("pyarrow")?;
-            let dict_columns = df
-                .columns()
-                .iter()
-                .enumerate()
-                .filter(|(_i, s)| {
-                    matches!(
-                        s.dtype(),
-                        DataType::Categorical(_, _) | DataType::Enum(_, _)
+    pub fn to_pandas(&self, py: Python) -> PyResult<Vec<Py<PyAny>>> {
+        let mut df = self.df.read().clone();
+        py.enter_polars_ok(|| df.rechunk_mut_par())?; 
+        *self.df.write() = df.clone();
+
+        let pyarrow = py.import("pyarrow")?;
+
+        let dict_columns = df
+            .columns()
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| {
+                matches!(
+                    s.dtype(),
+                    DataType::Categorical(_, _) | DataType::Enum(_, _)
+                )
+            })
+            .map(|(i, _)| i)
+            .collect_vec();
+        let is_enum_col = df
+            .columns()
+            .iter()
+            .map(|c| matches!(c.dtype(), DataType::Enum(_, _)))
+            .collect_vec();
+
+        let enum_dtype = ArrowDataType::Dictionary(
+            IntegerType::Int64,
+            Box::new(ArrowDataType::LargeUtf8),
+            true,
+        );
+        let categorical_dtype = ArrowDataType::Dictionary(
+            IntegerType::Int64,
+            Box::new(ArrowDataType::LargeUtf8),
+            false,
+        );
+
+        let mut replaced_schema = None;
+        df.iter_chunks(CompatLevel::oldest(), true)
+            .map(|rb| {
+                let length = rb.len();
+                let (schema, mut arrays) = rb.into_schema_and_arrays();
+
+                // Pandas does not allow unsigned dictionary indices, so replace them.
+                replaced_schema = (replaced_schema.is_none() && !dict_columns.is_empty())
+                    .then(|| {
+                        let mut schema = schema.as_ref().clone();
+                        for i in &dict_columns {
+                            let (_, field) = schema.get_at_index_mut(*i).unwrap();
+                            field.dtype = if is_enum_col[*i] {
+                                enum_dtype.clone()
+                            } else {
+                                categorical_dtype.clone()
+                            };
+                        }
+                        Arc::new(schema)
+                    });
+
+                for i in &dict_columns {
+                    let arr = arrays.get_mut(*i).unwrap();
+                    let cast_dtype = if is_enum_col[*i] {
+                        &enum_dtype
+                    } else {
+                        &categorical_dtype
+                    };
+                    let out = polars_compute::cast::cast(
+                        &**arr,
+                        cast_dtype,
+                        CastOptionsImpl::default(),
                     )
-                })
-                .map(|(i, _)| i)
-                .collect_vec();
-            let is_enum_col = df
-                .columns()
-                .iter()
-                .map(|c| matches!(c.dtype(), DataType::Enum(_, _)))
-                .collect_vec();
+                    .unwrap();
+                    *arr = out;
+                }
+                let schema = replaced_schema
+                    .as_ref()
+                    .map_or(schema, |replaced| replaced.clone());
+                let rb = RecordBatch::new(length, schema, arrays);
 
-            let enum_dtype = ArrowDataType::Dictionary(
-                IntegerType::Int64,
-                Box::new(ArrowDataType::LargeUtf8),
-                true,
-            );
-            let categorical_dtype = ArrowDataType::Dictionary(
-                IntegerType::Int64,
-                Box::new(ArrowDataType::LargeUtf8),
-                false,
-            );
-
-            let mut replaced_schema = None;
-            let rbs = df
-                .iter_chunks(CompatLevel::oldest(), true)
-                .map(|rb| {
-                    let length = rb.len();
-                    let (schema, mut arrays) = rb.into_schema_and_arrays();
-
-                    // Pandas does not allow unsigned dictionary indices so we replace them.
-                    replaced_schema =
-                        (replaced_schema.is_none() && !dict_columns.is_empty()).then(|| {
-                            let mut schema = schema.as_ref().clone();
-                            for i in &dict_columns {
-                                let (_, field) = schema.get_at_index_mut(*i).unwrap();
-                                field.dtype = if is_enum_col[*i] {
-                                    enum_dtype.clone()
-                                } else {
-                                    categorical_dtype.clone()
-                                };
-                            }
-                            Arc::new(schema)
-                        });
-
-                    for i in &dict_columns {
-                        let arr = arrays.get_mut(*i).unwrap();
-                        let cast_dtype = if is_enum_col[*i] {
-                            &enum_dtype
-                        } else {
-                            &categorical_dtype
-                        };
-                        let out = polars_compute::cast::cast(
-                            &**arr,
-                            cast_dtype,
-                            CastOptionsImpl::default(),
-                        )
-                        .unwrap();
-                        *arr = out;
-                    }
-                    let schema = replaced_schema
-                        .as_ref()
-                        .map_or(schema, |replaced| replaced.clone());
-                    let rb = RecordBatch::new(length, schema, arrays);
-
-                    interop::arrow::to_py::to_py_rb(&rb, py, &pyarrow)
-                })
-                .collect::<PyResult<_>>()?;
-            Ok(rbs)
-        })
+                interop::arrow::to_py::to_py_rb(&rb, py, &pyarrow)
+            })
+            .collect::<PyResult<_>>()
     }
 
     #[allow(unused_variables)]

--- a/crates/polars-python/src/dataframe/export.rs
+++ b/crates/polars-python/src/dataframe/export.rs
@@ -107,11 +107,17 @@ impl PyDataFrame {
     /// since those can't be converted correctly via PyArrow. The calling Python
     /// code should make sure these are not included.
     #[allow(clippy::wrong_self_convention)]
-    pub fn to_pandas(&self, py: Python) -> PyResult<Vec<Py<PyAny>>> {
-        let mut df = self.df.write();
-        let dfr = &mut *df; // Lock guard isn't Send, but mut ref is.
-        py.enter_polars_ok(|| dfr.rechunk_mut_par())?;
-        let df = RwLockWriteGuard::downgrade(df);
+    pub fn to_pandas(&self) -> PyResult<Vec<Py<PyAny>>> {
+        let df = self.df.read();
+        let df = if df.columns().iter().any(|c| c.n_chunks() > 1) {
+            drop(df);
+            let mut df = self.df.write();
+            let dfr = &mut *df; // Lock guard isn't Send, but mut ref is.
+            dfr.rechunk_mut_par();
+            RwLockWriteGuard::downgrade(df)
+        } else {
+            df
+        };
         Python::attach(|py| {
             let pyarrow = py.import("pyarrow")?;
             let dict_columns = df

--- a/crates/polars-python/src/dataframe/export.rs
+++ b/crates/polars-python/src/dataframe/export.rs
@@ -109,7 +109,7 @@ impl PyDataFrame {
     #[allow(clippy::wrong_self_convention)]
     pub fn to_pandas(&self, py: Python) -> PyResult<Vec<Py<PyAny>>> {
         let mut df = self.df.read().clone();
-        py.enter_polars_ok(|| df.rechunk_mut_par())?; 
+        py.enter_polars_ok(|| df.rechunk_mut_par())?;
         *self.df.write() = df.clone();
 
         let pyarrow = py.import("pyarrow")?;
@@ -132,11 +132,8 @@ impl PyDataFrame {
             .map(|c| matches!(c.dtype(), DataType::Enum(_, _)))
             .collect_vec();
 
-        let enum_dtype = ArrowDataType::Dictionary(
-            IntegerType::Int64,
-            Box::new(ArrowDataType::LargeUtf8),
-            true,
-        );
+        let enum_dtype =
+            ArrowDataType::Dictionary(IntegerType::Int64, Box::new(ArrowDataType::LargeUtf8), true);
         let categorical_dtype = ArrowDataType::Dictionary(
             IntegerType::Int64,
             Box::new(ArrowDataType::LargeUtf8),
@@ -150,8 +147,8 @@ impl PyDataFrame {
                 let (schema, mut arrays) = rb.into_schema_and_arrays();
 
                 // Pandas does not allow unsigned dictionary indices, so replace them.
-                replaced_schema = (replaced_schema.is_none() && !dict_columns.is_empty())
-                    .then(|| {
+                replaced_schema =
+                    (replaced_schema.is_none() && !dict_columns.is_empty()).then(|| {
                         let mut schema = schema.as_ref().clone();
                         for i in &dict_columns {
                             let (_, field) = schema.get_at_index_mut(*i).unwrap();
@@ -171,12 +168,9 @@ impl PyDataFrame {
                     } else {
                         &categorical_dtype
                     };
-                    let out = polars_compute::cast::cast(
-                        &**arr,
-                        cast_dtype,
-                        CastOptionsImpl::default(),
-                    )
-                    .unwrap();
+                    let out =
+                        polars_compute::cast::cast(&**arr, cast_dtype, CastOptionsImpl::default())
+                            .unwrap();
                     *arr = out;
                 }
                 let schema = replaced_schema

--- a/py-polars/tests/unit/interop/test_to_pandas.py
+++ b/py-polars/tests/unit/interop/test_to_pandas.py
@@ -217,3 +217,16 @@ def test_filter_with_pandas_timedelta_26620() -> None:
     )
 
     assert_frame_equal(actual, expected)
+
+
+def test_no_deadlock_multithreaded_27396() -> None:
+    from concurrent.futures import ThreadPoolExecutor
+
+    df = pl.DataFrame({"a": [1] * 100000})
+
+    def to_pandas() -> None:
+        df.to_pandas()
+
+    with ThreadPoolExecutor(10) as e:
+        fs = [e.submit(to_pandas) for _ in range(100)]
+        [f.result(timeout=10) for f in fs]


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/27396.

I did quite some tests with various fixes and this solution is the only one that worked. It also does not drastically reduce performance, as you can see with the benchmark results below.

In the original code, the problem was that one thread would acquire the write lock and then drop the Python GIL using `enter_polars_ok`. After doing the rechunk, the lock would get downgraded to read, but another thread could pick up the GIL and would then be trying to acquire the write lock, which is not possible due to the other thread having the read lock. This resulted in a deadlock since the thread with the read lock cannot proceed into `Python::attach` without the GIL and the other thread cannot release the GIL since it cannot acquire the write lock and execute the code that follows.

The fix was to always acquire a read lock initially. Then, if the `DataFrame` needed rechunking, the read lock would be dropped and a write lock would be acquired. The rechunking would then happen, followed by the write lock being downgraded to read. Thus, the first thread that encountered a `DataFrame` that needs to be rechunked would be the only one that would require a write lock, while the others would only ever need read locks and many could be held simultaneously. After the first thread is downgraded to read, all other threads can also read and then start competing for the GIL when encountering `Python::attach`.

🤖 Claude Sonnet 4.6 for a detailed refresher on multithreading/`RwLock` and rubber ducking. 

## Benchmark

Benchmark Code:

```python
import timeit
import polars as pl

df_single = pl.DataFrame({'a': [5234.523] * 100000})
n = 100

single_time = timeit.timeit(lambda: df_single.to_pandas(), number=n)
multi_time = timeit.timeit(lambda: pl.concat([pl.DataFrame({'a': [5234.523] * 50000}), pl.DataFrame({'a': [5234.523] * 50000})], rechunk=False).to_pandas(), number=n)

print(f'Single chunk: {single_time / n * 1000:.2f}ms per call')
print(f'Multi chunk:  {multi_time / n * 1000:.2f}ms per call')
```

Fix Branch:

Single chunk: `1.96ms` per call
Multi chunk: `5.79ms` per call

Main Branch:

Single chunk: `4.91ms` per call
Multi chunk: `5.87ms` per call