### PR TITLE
fix(rust): Fix skip_batches not handling negation of bool dtype with None values

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
@@ -458,6 +458,34 @@ fn aexpr_to_skip_batch_predicate_rec(
                             _ => None,
                         }
                     },
+                    IRBooleanFunction::Not => {
+                        let col = into_column(input[0].node(), arena)?;
+                        let dtype = schema.get(col)?;
+                        if !can_use_min_max_stats(dtype, None, None) {
+                            return None;
+                        }
+
+                        let col = col.clone();
+                        let col_nc = col!(null_count: col);
+                        let len = col!(len);
+                        let col_min = col!(min: col);
+                        let col_max = col!(max: col);
+                        let col_min_is_true = col_min.eq(lv!(true), arena);
+                        let col_max_is_true = col_max.eq(lv!(true), arena);
+                        let min_is_defined = is_stat_defined(col_min, dtype, arena);
+                        let max_is_defined = is_stat_defined(col_max, dtype, arena);
+
+                        // col(A).Not() ->
+                        //     null_count(A) == LEN ||
+                        //         min(A) == max(A) == True
+                        let all_null = col_nc.eq(len, arena);
+                        let all_true = min_is_defined
+                            .and(max_is_defined, arena)
+                            .and(col_min_is_true, arena)
+                            .and(col_max_is_true, arena);
+
+                        Some(all_null.or(all_true, arena).node())
+                    },
                     IRBooleanFunction::IsNull => {
                         let col = into_column(input[0].node(), arena)?;
 

--- a/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
@@ -469,22 +469,15 @@ fn aexpr_to_skip_batch_predicate_rec(
                         let col_nc = col!(null_count: col);
                         let len = col!(len);
                         let col_min = col!(min: col);
-                        let col_max = col!(max: col);
                         let col_min_is_true = col_min.eq(lv!(true), arena);
-                        let col_max_is_true = col_max.eq(lv!(true), arena);
                         let min_is_defined = is_stat_defined(col_min, dtype, arena);
-                        let max_is_defined = is_stat_defined(col_max, dtype, arena);
 
                         // col(A).Not() ->
-                        //     null_count(A) == LEN ||
-                        //         min(A) == max(A) == True
+                        //     null_count(A) == LEN || min(A) == True
                         let all_null = col_nc.eq(len, arena);
-                        let all_true = min_is_defined
-                            .and(max_is_defined, arena)
-                            .and(col_min_is_true, arena)
-                            .and(col_max_is_true, arena);
+                        let min = min_is_defined.and(col_min_is_true, arena);
 
-                        Some(all_null.or(all_true, arena).node())
+                        Some(all_null.or(min, arena).node())
                     },
                     IRBooleanFunction::IsNull => {
                         let col = into_column(input[0].node(), arena)?;

--- a/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
@@ -461,7 +461,7 @@ fn aexpr_to_skip_batch_predicate_rec(
                     IRBooleanFunction::Not => {
                         let col = into_column(input[0].node(), arena)?;
                         let dtype = schema.get(col)?;
-                        if !can_use_min_max_stats(dtype, None, None) {
+                        if !matches!(dtype, DataType::Boolean) {
                             return None;
                         }
 

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -955,7 +955,7 @@ def _df_many_types() -> pl.DataFrame:
     "expr",
     [
         # Bool (requires deltalake >= 1.5.1)
-        # ~pl.col.bool, ## see github issue #26290
+        ~pl.col.bool,
         pl.col.bool <= False,
         pl.col.bool < True,
         pl.col.bool.is_null(),

--- a/py-polars/tests/unit/io/test_skip_batch_predicate.py
+++ b/py-polars/tests/unit/io/test_skip_batch_predicate.py
@@ -103,6 +103,24 @@ def test_equality() -> None:
     )
 
 
+def test_not_bool() -> None:
+    assert_skp_series(
+        "b",
+        pl.Boolean(),
+        ~pl.col("b"),
+        [
+            {"min": True, "max": True, "null_count": 0, "len": 42, "can_skip": True},
+            {"min": True, "max": True, "null_count": 5, "len": 42, "can_skip": True},
+            {"min": None, "max": None, "null_count": 42, "len": 42, "can_skip": True},
+            {"min": False, "max": False, "null_count": 0, "len": 42, "can_skip": False},
+            {"min": False, "max": True, "null_count": 0, "len": 42, "can_skip": False},
+            {"min": False, "max": False, "null_count": 5, "len": 42, "can_skip": False},
+            {"min": False, "max": True, "null_count": 5, "len": 42, "can_skip": False},
+            {"min": None, "max": None, "null_count": 5, "len": 42, "can_skip": False},
+        ],
+    )
+
+
 def test_datetimes() -> None:
     d = datetime.datetime(2023, 4, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
     td = datetime.timedelta
@@ -168,6 +186,7 @@ def test_skip_batch_predicate_parametric(s: pl.Series) -> None:
     exprs = [
         pl.col.x == lit_a,
         pl.col.x != lit_a,
+        ~pl.col.x,
         pl.col.x.eq_missing(lit_a),
         pl.col.x.ne_missing(lit_a),
         pl.col.x.is_null(),

--- a/py-polars/tests/unit/io/test_skip_batch_predicate.py
+++ b/py-polars/tests/unit/io/test_skip_batch_predicate.py
@@ -186,7 +186,6 @@ def test_skip_batch_predicate_parametric(s: pl.Series) -> None:
     exprs = [
         pl.col.x == lit_a,
         pl.col.x != lit_a,
-        ~pl.col.x,
         pl.col.x.eq_missing(lit_a),
         pl.col.x.ne_missing(lit_a),
         pl.col.x.is_null(),


### PR DESCRIPTION
Hi, this is my first PR, so I've picked a 'good first issue', #26290, and added a case for IRBooleanFunction::Not to the recursive skip predicate evaluation, which didn't exist before.

I implemented the rule col(A).Not() -> null_count(A) == LEN || min(A) == max(A) == True. This makes sense because null and true both fail the ~b filter, and if min and max are both true, then all non-null values are true and the current batch has no rows passing the filter and is hence safe to skip.

As by the contribution guidellines, here is a screen shot of me running the tests (`make test`): 
<img width="1501" height="870" alt="image" src="https://github.com/user-attachments/assets/ea9f0e6b-c8be-4fca-a855-6833e991cf7f" />

  1. I used AI to understand the problem, but implemented the code by hand, based on the patterns I found in the file. I also used AI to generate the 8 test cases in `test_not_bool`.
  2. I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.