### PR TITLE
perf: Lower non-elementwise FunctionExprIR to ColumnarFunctionNode

### DIFF
--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -823,6 +823,7 @@ fn create_physical_plan_impl(
             };
             Ok(Box::new(exec))
         },
+        UnoptimizedDispatch { .. } => get_streaming_executor_builder()(root, lp_arena, expr_arena),
         Invalid => unreachable!(),
     }
 }

--- a/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
@@ -5,11 +5,7 @@ use polars_core::utils::materialize_dyn_int;
 use super::*;
 
 impl IRFunctionExpr {
-    pub(crate) fn get_field(
-        &self,
-        _input_schema: &Schema,
-        fields: &[Field],
-    ) -> PolarsResult<Field> {
+    pub(crate) fn get_field(&self, fields: &[Field]) -> PolarsResult<Field> {
         use IRFunctionExpr::*;
 
         let mapper = FieldsMapper { fields };

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -389,7 +389,7 @@ impl AExpr {
                     )
                 }
 
-                let out = function.get_field(ctx.schema, &fields)?;
+                let out = function.get_field(&fields)?;
 
                 Ok(out)
             },

--- a/crates/polars-plan/src/plans/ir/dot.rs
+++ b/crates/polars-plan/src/plans/ir/dot.rs
@@ -332,6 +332,12 @@ impl<'a> IRDotDisplay<'a> {
                     )
                 })?;
             },
+            UnoptimizedDispatch { inputs, operation } => {
+                for input in inputs {
+                    recurse!(*input);
+                }
+                write_label(f, id, |f| write!(f, "DISPATCH {operation}"))?;
+            },
             Invalid => write_label(f, id, |f| f.write_str("INVALID"))?,
         }
 

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -1009,6 +1009,10 @@ pub fn write_ir_non_recursive(
             "{:indent$}MERGE SORTED[maintain_order: {}] ON '{key}'",
             "", maintain_order
         ),
+        IR::UnoptimizedDispatch {
+            inputs: _,
+            operation,
+        } => write!(f, "{:indent$}DISPATCH {operation}", ""),
         IR::Invalid => write!(f, "{:indent$}INVALID", ""),
     }
 }

--- a/crates/polars-plan/src/plans/ir/inputs.rs
+++ b/crates/polars-plan/src/plans/ir/inputs.rs
@@ -101,6 +101,7 @@ impl IR {
                 },
             },
 
+            UnoptimizedDispatch { .. } => Exprs::Empty,
             Invalid => unreachable!(),
         }
     }
@@ -173,6 +174,7 @@ impl IR {
                 },
             },
 
+            UnoptimizedDispatch { .. } => ExprsMut::Empty,
             Invalid => unreachable!(),
         }
     }
@@ -185,7 +187,7 @@ impl IR {
         container.extend(self.exprs().cloned())
     }
 
-    pub fn inputs(&'_ self) -> Inputs<'_> {
+    pub fn inputs(&self) -> Inputs<'_> {
         use IR::*;
         match self {
             Union { inputs, .. } | HConcat { inputs, .. } | SinkMultiple { inputs } => {
@@ -220,11 +222,12 @@ impl IR {
                 input_right,
                 ..
             } => Inputs::double(*input_left, *input_right),
+            UnoptimizedDispatch { inputs, .. } => Inputs::slice(inputs),
             Invalid => unreachable!(),
         }
     }
 
-    pub fn inputs_mut(&'_ mut self) -> InputsMut<'_> {
+    pub fn inputs_mut(&mut self) -> InputsMut<'_> {
         use IR::*;
         match self {
             Union { inputs, .. } | HConcat { inputs, .. } | SinkMultiple { inputs } => {
@@ -259,6 +262,7 @@ impl IR {
                 input_right,
                 ..
             } => InputsMut::double(input_left, input_right),
+            UnoptimizedDispatch { inputs, .. } => InputsMut::slice(inputs),
             Invalid => unreachable!(),
         }
     }

--- a/crates/polars-plan/src/plans/ir/mod.rs
+++ b/crates/polars-plan/src/plans/ir/mod.rs
@@ -3,6 +3,7 @@ mod format;
 pub mod inputs;
 mod schema;
 pub(crate) mod tree_format;
+mod unoptimized;
 
 use std::borrow::Cow;
 use std::fmt;
@@ -15,6 +16,7 @@ use polars_utils::unique_id::UniqueId;
 #[cfg(feature = "ir_serde")]
 use serde::{Deserialize, Serialize};
 use strum_macros::IntoStaticStr;
+pub use unoptimized::UnoptimizedOperation;
 
 use self::hive::HivePartitionsDf;
 use crate::prelude::*;
@@ -159,6 +161,10 @@ pub enum IR {
         input_right: Node,
         key: PlSmallStr,
         maintain_order: bool,
+    },
+    UnoptimizedDispatch {
+        inputs: Vec<Node>,
+        operation: UnoptimizedOperation,
     },
     #[default]
     Invalid,

--- a/crates/polars-plan/src/plans/ir/schema.rs
+++ b/crates/polars-plan/src/plans/ir/schema.rs
@@ -1,3 +1,4 @@
+use polars_utils::itertools::Itertools;
 use recursive::recursive;
 
 use super::*;
@@ -45,6 +46,7 @@ impl IR {
             SimpleProjection { .. } => "simple_projection",
             #[cfg(feature = "merge_sorted")]
             MergeSorted { .. } => "merge_sorted",
+            UnoptimizedDispatch { .. } => "unoptimized_dispatch",
             Invalid => "invalid",
         }
     }
@@ -111,6 +113,13 @@ impl IR {
             ExtContext { schema, .. } => schema,
             #[cfg(feature = "merge_sorted")]
             MergeSorted { input_left, .. } => return arena.get(*input_left).schema(arena),
+            UnoptimizedDispatch { inputs, operation } => {
+                let input_schemas = inputs
+                    .iter()
+                    .map(|input| arena.get(*input).schema(arena).into_owned())
+                    .collect_vec();
+                return Cow::Owned(operation.schema(&input_schemas));
+            },
             Invalid => unreachable!(),
         };
         Cow::Borrowed(schema)
@@ -171,6 +180,13 @@ impl IR {
             },
             #[cfg(feature = "merge_sorted")]
             MergeSorted { input_left, .. } => IR::schema_with_cache(*input_left, arena, cache),
+            UnoptimizedDispatch { inputs, operation } => {
+                let input_schemas = inputs
+                    .iter()
+                    .map(|input| IR::schema_with_cache(*input, arena, cache))
+                    .collect_vec();
+                operation.schema(&input_schemas)
+            },
             Invalid => unreachable!(),
         };
         cache.insert(node, schema.clone());

--- a/crates/polars-plan/src/plans/ir/tree_format.rs
+++ b/crates/polars-plan/src/plans/ir/tree_format.rs
@@ -400,6 +400,13 @@ impl<'a> TreeFmtNode<'a> {
                             .chain([self.lp_node(Some("RIGHT PLAN:".to_string()), *input_right)])
                             .collect(),
                     ),
+                    UnoptimizedDispatch { inputs, operation } => ND(
+                        wh(h, &format!("DISPATCH {operation}")),
+                        inputs
+                            .iter()
+                            .map(|input| self.lp_node(None, *input))
+                            .collect(),
+                    ),
                     Invalid => ND(wh(h, "INVALID"), vec![]),
                 }
             },

--- a/crates/polars-plan/src/plans/ir/unoptimized.rs
+++ b/crates/polars-plan/src/plans/ir/unoptimized.rs
@@ -1,0 +1,55 @@
+use std::fmt;
+use std::sync::Arc;
+
+use polars_core::schema::{Schema, SchemaExt};
+use polars_utils::itertools::Itertools;
+use polars_utils::pl_str::PlSmallStr;
+#[cfg(feature = "ir_serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::prelude::*;
+
+/// These IR nodes are generated to dispatch to specific functionality in the
+/// streaming engine, and aren't optimized across. They should not be generated
+/// directly by operations, only lowered to post-optimization.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "ir_serde", derive(Serialize, Deserialize))]
+pub enum UnoptimizedOperation {
+    /// Calls the given IRFunctionExpr with the columns of the inputs in order.
+    /// The inputs do not have to be the same height.
+    ColumnarFunction {
+        function: IRFunctionExpr,
+        options: FunctionOptions,
+        output_name: PlSmallStr,
+    },
+}
+
+impl UnoptimizedOperation {
+    pub fn schema(&self, inputs: &[Arc<Schema>]) -> Arc<Schema> {
+        match self {
+            UnoptimizedOperation::ColumnarFunction {
+                function,
+                options: _,
+                output_name,
+            } => {
+                let input_fields = inputs.iter().flat_map(|i| i.iter_fields()).collect_vec();
+                let output_field = function.get_field(&input_fields).unwrap();
+                Arc::new(Schema::from_iter([
+                    output_field.with_name(output_name.clone())
+                ]))
+            },
+        }
+    }
+}
+
+impl fmt::Display for UnoptimizedOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ColumnarFunction {
+                function,
+                output_name,
+                ..
+            } => write!(f, "{output_name} = {}(...)", function),
+        }
+    }
+}

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -686,6 +686,9 @@ impl PredicatePushDown {
             lp @ MergeSorted { .. } => {
                 self.pushdown_and_continue(lp, acc_predicates, lp_arena, expr_arena, false)
             },
+            UnoptimizedDispatch { .. } => {
+                self.no_pushdown_restart_opt(lp, acc_predicates, lp_arena, expr_arena)
+            },
             Invalid => unreachable!(),
         }
     }

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -808,6 +808,9 @@ impl ProjectionPushDown {
                     maintain_order,
                 })
             },
+            UnoptimizedDispatch { .. } => {
+                self.no_pushdown_restart_opt(logical_plan, ctx, lp_arena, expr_arena)
+            },
             Invalid => unreachable!(),
         }
     }

--- a/crates/polars-plan/src/plans/optimizer/simplify_ordering/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_ordering/mod.rs
@@ -511,8 +511,7 @@ impl SimplifyIRNodeOrder<'_> {
             #[cfg(feature = "python")]
             IR::PythonScan { .. } => {},
 
-            IR::Scan { .. } | IR::DataFrameScan { .. } => {},
-
+            IR::Scan { .. } | IR::DataFrameScan { .. } | IR::UnoptimizedDispatch { .. } => {},
             IR::SinkMultiple { .. } | IR::Invalid => unreachable!(),
         };
 

--- a/crates/polars-plan/src/plans/optimizer/sortedness.rs
+++ b/crates/polars-plan/src/plans/optimizer/sortedness.rs
@@ -489,6 +489,7 @@ fn is_sorted_rec(
             let input = *input;
             rec!(input)
         },
+        IR::UnoptimizedDispatch { .. } => None,
         IR::Invalid => unreachable!(),
     };
 

--- a/crates/polars-plan/src/plans/visitor/hash.rs
+++ b/crates/polars-plan/src/plans/visitor/hash.rs
@@ -6,7 +6,7 @@ use polars_utils::arena::Arena;
 use super::*;
 #[cfg(feature = "python")]
 use crate::plans::PythonOptions;
-use crate::plans::{AExpr, IR};
+use crate::plans::{AExpr, IR, UnoptimizedOperation};
 use crate::prelude::aexpr::traverse_and_hash_aexpr;
 use crate::prelude::{ExprIR, PlanCallback};
 
@@ -265,6 +265,20 @@ impl Hash for IRHashWrap<'_> {
             } => {
                 key.hash(state);
                 maintain_order.hash(state);
+            },
+            IR::UnoptimizedDispatch {
+                inputs: _,
+                operation,
+            } => match operation {
+                UnoptimizedOperation::ColumnarFunction {
+                    function,
+                    options,
+                    output_name,
+                } => {
+                    function.hash(state);
+                    options.hash(state);
+                    output_name.hash(state);
+                },
             },
             IR::Invalid => unreachable!(),
         }

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -754,6 +754,9 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<Py<PyAny>> {
             maintain_order: *maintain_order,
         }
         .into_py_any(py),
+        IR::UnoptimizedDispatch { .. } => Err(PyNotImplementedError::new_err(
+            "Not expecting to see a UnoptimizedDispatch node",
+        )),
         IR::Invalid => Err(PyNotImplementedError::new_err("Invalid")),
     }
 }

--- a/crates/polars-stream/src/nodes/columnar_function.rs
+++ b/crates/polars-stream/src/nodes/columnar_function.rs
@@ -1,0 +1,129 @@
+use std::sync::Arc;
+
+use polars_core::schema::Schema;
+use polars_plan::dsl::ColumnsUdf;
+use polars_utils::itertools::Itertools;
+use polars_utils::pl_str::PlSmallStr;
+
+use super::compute_node_prelude::*;
+use super::in_memory_sink::InMemorySinkNode;
+use super::in_memory_source::InMemorySourceNode;
+
+pub enum ColumnarFunctionNode {
+    Sink {
+        sink_nodes: Vec<InMemorySinkNode>,
+        func: Arc<dyn ColumnsUdf>,
+        output_name: PlSmallStr,
+    },
+    Source(InMemorySourceNode),
+    Done,
+}
+
+impl ColumnarFunctionNode {
+    pub fn new(
+        input_schemas: Vec<Arc<Schema>>,
+        func: Arc<dyn ColumnsUdf>,
+        output_name: PlSmallStr,
+    ) -> Self {
+        Self::Sink {
+            sink_nodes: input_schemas
+                .into_iter()
+                .map(InMemorySinkNode::new)
+                .collect(),
+            func,
+            output_name,
+        }
+    }
+}
+
+impl ComputeNode for ColumnarFunctionNode {
+    fn name(&self) -> &str {
+        "columnar-function"
+    }
+
+    fn update_state(
+        &mut self,
+        recv: &mut [PortState],
+        send: &mut [PortState],
+        state: &StreamingExecutionState,
+    ) -> PolarsResult<()> {
+        assert!(send.len() == 1);
+
+        // If the output doesn't want any more data, transition to being done.
+        if send[0] == PortState::Done && !matches!(self, Self::Done) {
+            *self = Self::Done;
+        }
+
+        // If all inputs are done, transition to being a source.
+        if let Self::Sink {
+            sink_nodes,
+            func,
+            output_name,
+        } = self
+        {
+            assert!(recv.len() == sink_nodes.len());
+            if recv.iter().all(|p| *p == PortState::Done) {
+                let mut cols = Vec::new();
+                for sink_node in sink_nodes {
+                    let df = sink_node.get_output()?.unwrap();
+                    cols.extend(df.into_columns());
+                }
+                let out_col = func.call_udf(&mut cols)?.with_name(output_name.clone());
+                let source_node = InMemorySourceNode::new(
+                    Arc::new(DataFrame::new(out_col.len(), vec![out_col])?),
+                    MorselSeq::default(),
+                );
+                *self = Self::Source(source_node);
+            }
+        }
+
+        match self {
+            Self::Sink { sink_nodes, .. } => {
+                for (sink_node, r) in sink_nodes.iter_mut().zip_eq(recv) {
+                    sink_node.update_state(core::slice::from_mut(r), &mut [], state)?;
+                }
+                send[0] = PortState::Blocked;
+            },
+            Self::Source(source_node) => {
+                recv[0] = PortState::Done;
+                source_node.update_state(&mut [], send, state)?;
+            },
+            Self::Done => {
+                recv[0] = PortState::Done;
+                send[0] = PortState::Done;
+            },
+        }
+        Ok(())
+    }
+
+    fn is_memory_intensive_pipeline_blocker(&self) -> bool {
+        matches!(self, Self::Sink { .. })
+    }
+
+    fn spawn<'env, 's>(
+        &'env mut self,
+        scope: &'s TaskScope<'s, 'env>,
+        recv_ports: &mut [Option<RecvPort<'_>>],
+        send_ports: &mut [Option<SendPort<'_>>],
+        state: &'s StreamingExecutionState,
+        join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
+    ) {
+        match self {
+            Self::Sink { sink_nodes, .. } => {
+                for (sink_node, recv) in sink_nodes.iter_mut().zip_eq(recv_ports) {
+                    if recv.is_some() {
+                        sink_node.spawn(
+                            scope,
+                            core::slice::from_mut(recv),
+                            &mut [],
+                            state,
+                            join_handles,
+                        )
+                    }
+                }
+            },
+            Self::Source(source) => source.spawn(scope, &mut [], send_ports, state, join_handles),
+            Self::Done => unreachable!(),
+        }
+    }
+}

--- a/crates/polars-stream/src/nodes/mod.rs
+++ b/crates/polars-stream/src/nodes/mod.rs
@@ -1,5 +1,6 @@
 pub mod backward_fill;
 pub mod callback_sink;
+pub mod columnar_function;
 #[cfg(feature = "cum_agg")]
 pub mod cum_agg;
 #[cfg(feature = "dynamic_group_by")]

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -40,7 +40,8 @@ impl NodeStyle {
             | K::GroupBy { .. }
             | K::EquiJoin { .. }
             | K::SemiAntiJoin { .. }
-            | K::Multiplexer { .. } => Self::MemoryIntensive,
+            | K::Multiplexer { .. }
+            | K::ColumnarFunction { .. } => Self::MemoryIntensive,
             #[cfg(feature = "iejoin")]
             K::RangeJoin { .. } => Self::MemoryIntensive,
             #[cfg(feature = "merge_sorted")]
@@ -357,6 +358,22 @@ fn visualize_plan_rec(
                 f.write_str(format_str).unwrap();
             }
             (label, from_ref(input))
+        },
+        PhysNodeKind::ColumnarFunction {
+            inputs,
+            func: _,
+            output_name,
+            format_str,
+        } => {
+            let mut label = String::new();
+            label.push_str("columnar-function");
+            if let Some(format_str) = format_str {
+                label.push_str("\\n");
+
+                let mut f = EscapeLabel(&mut label);
+                write!(f, "{output_name} = {format_str}(...)").unwrap();
+            }
+            (label, &inputs[..])
         },
         PhysNodeKind::SortedGroupBy {
             input,

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -31,7 +31,9 @@ impl NodeStyle {
     pub fn for_node_kind(kind: &PhysNodeKind) -> Self {
         use PhysNodeKind as K;
         match kind {
-            K::InMemoryMap { .. } | K::InMemoryJoin { .. } => Self::InMemoryFallback,
+            K::InMemoryMap { .. } | K::InMemoryJoin { .. } | K::ColumnarFunction { .. } => {
+                Self::InMemoryFallback
+            },
             K::InMemorySource { .. }
             | K::InputIndependentSelect { .. }
             | K::NegativeSlice { .. }
@@ -40,8 +42,7 @@ impl NodeStyle {
             | K::GroupBy { .. }
             | K::EquiJoin { .. }
             | K::SemiAntiJoin { .. }
-            | K::Multiplexer { .. }
-            | K::ColumnarFunction { .. } => Self::MemoryIntensive,
+            | K::Multiplexer { .. } => Self::MemoryIntensive,
             #[cfg(feature = "iejoin")]
             K::RangeJoin { .. } => Self::MemoryIntensive,
             #[cfg(feature = "merge_sorted")]

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -9,6 +9,7 @@ use polars_core::prelude::{
 use polars_core::scalar::Scalar;
 use polars_core::schema::{Schema, SchemaExt};
 use polars_error::{PolarsResult, feature_gated};
+use polars_expr::dispatch::function_expr_to_udf;
 use polars_expr::state::ExecutionState;
 use polars_expr::{ExpressionConversionState, create_physical_expr};
 use polars_ops::frame::{JoinArgs, JoinType};
@@ -2550,10 +2551,59 @@ fn lower_exprs_with_ctx(
                 }
             },
 
-            AExpr::AnonymousFunction { .. }
-            | AExpr::Function { .. }
-            | AExpr::Over { .. }
-            | AExpr::Gather { .. } => {
+            // Generic fallback for column-based functions/UDFs.
+            ref node @ AExpr::AnonymousFunction {
+                input: ref inner_exprs,
+                ..
+            }
+            | ref node @ AExpr::Function {
+                input: ref inner_exprs,
+                ..
+            } => {
+                // Lower inputs separately to different streams (they might have different lengths).
+                // We maintain the original names because the function might be sensitive to input names.
+                let inputs = inner_exprs
+                    .iter()
+                    .map(|expr| {
+                        build_select_stream_with_ctx(input, core::slice::from_ref(expr), ctx)
+                    })
+                    .try_collect_vec()?;
+
+                let input_schema = &ctx.phys_sm[input.node].output_schema;
+                let out_name = unique_column_name();
+                let out_schema = compute_output_schema(
+                    input_schema,
+                    &[ExprIR::new(expr, OutputName::Alias(out_name.clone()))],
+                    ctx.expr_arena,
+                )?;
+
+                let (func, format_str);
+                match node {
+                    AExpr::AnonymousFunction {
+                        function, fmt_str, ..
+                    } => {
+                        func = function.clone().materialize()?.into_inner().as_column_udf();
+                        format_str = Some(fmt_str.to_string());
+                    },
+                    AExpr::Function { function, .. } => {
+                        func = function_expr_to_udf(function.clone()).into_inner();
+                        format_str = Some(function.to_string());
+                    },
+                    _ => unreachable!(),
+                };
+
+                let kind = PhysNodeKind::ColumnarFunction {
+                    inputs,
+                    func,
+                    output_name: out_name.clone(),
+                    format_str,
+                };
+                let node_key = ctx.phys_sm.insert(PhysNode::new(out_schema, kind));
+                input_streams.insert(PhysStream::first(node_key));
+                transformed_exprs.push(ctx.expr_arena.add(AExpr::Column(out_name)));
+            },
+
+            AExpr::Over { .. } | AExpr::Gather { .. } => {
                 let out_name = unique_column_name();
                 fallback_subset.push(ExprIR::new(expr, OutputName::Alias(out_name.clone())));
                 transformed_exprs.push(ctx.expr_arena.add(AExpr::Column(out_name)));

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -10,6 +10,7 @@ use polars_core::schema::Schema;
 use polars_core::series::Series;
 use polars_core::{SchemaExtPl, config};
 use polars_error::{PolarsResult, polars_ensure};
+use polars_expr::dispatch::function_expr_to_udf;
 use polars_expr::state::ExecutionState;
 use polars_mem_engine::create_physical_plan;
 use polars_ops::frame::JoinType;
@@ -1582,6 +1583,68 @@ pub fn lower_ir(
             return Ok(stream);
         },
         IR::ExtContext { .. } => todo!(),
+        IR::UnoptimizedDispatch { inputs, operation } => {
+            let operation = operation.clone();
+            let inputs = inputs.clone();
+            let trans_inputs = inputs.iter().map(|input| lower_ir!(*input)).try_collect()?;
+
+            match operation {
+                UnoptimizedOperation::ColumnarFunction {
+                    function,
+                    options,
+                    output_name,
+                } => {
+                    if options.is_elementwise() {
+                        // If it is elementwise we can just zip the inputs together.
+                        let mut zip_schema = Schema::default();
+                        for input in inputs {
+                            zip_schema.hstack_mut(
+                                (*IR::schema_with_cache(input, ir_arena, schema_cache)).clone(),
+                            )?;
+                        }
+                        let zip_schema = Arc::new(zip_schema);
+                        let zip_node = phys_sm.insert(PhysNode {
+                            output_schema: zip_schema.clone(),
+                            kind: PhysNodeKind::Zip {
+                                inputs: trans_inputs,
+                                zip_behavior: ZipBehavior::Broadcast,
+                            },
+                        });
+
+                        let expr_input = zip_schema
+                            .iter_names()
+                            .map(|n| ExprIR::from_column_name(n.clone(), expr_arena))
+                            .collect_vec();
+                        let expr = ExprIR::from_node(
+                            expr_arena.add(AExpr::Function {
+                                input: expr_input,
+                                function,
+                                options,
+                            }),
+                            expr_arena,
+                        )
+                        .with_alias(output_name);
+                        return build_select_stream(
+                            PhysStream::first(zip_node),
+                            &[expr],
+                            expr_arena,
+                            phys_sm,
+                            expr_cache,
+                            ctx,
+                        );
+                    } else {
+                        let func = function_expr_to_udf(function.clone()).into_inner();
+                        let format_str = Some(format!("COLUMNAR {function}"));
+                        PhysNodeKind::ColumnarFunction {
+                            inputs: trans_inputs,
+                            func,
+                            output_name,
+                            format_str,
+                        }
+                    }
+                },
+            }
+        },
         IR::Invalid => unreachable!(),
     };
 

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -22,7 +22,7 @@ use polars_ops::frame::JoinArgs;
 use polars_plan::dsl::StrptimeOptions;
 use polars_plan::dsl::deletion::DeletionFilesList;
 use polars_plan::dsl::{
-    CastColumnsPolicy, FileSinkOptions, JoinTypeOptionsIR, MissingColumnsPolicy,
+    CastColumnsPolicy, ColumnsUdf, FileSinkOptions, JoinTypeOptionsIR, MissingColumnsPolicy,
     PartitionedSinkOptionsIR, PredicateFileSkip, ScanSources, TableStatistics,
 };
 use polars_plan::plans::expr_ir::ExprIR;
@@ -219,16 +219,21 @@ pub enum PhysNodeKind {
     InMemoryMap {
         input: PhysStream,
         map: Arc<dyn DataFrameUdf>,
-
-        /// A formatted explain of what the in-memory map. This usually calls format on the IR.
+        /// A formatted string of what the in-memory map is. This usually calls format on the IR.
         format_str: Option<String>,
     },
 
     Map {
         input: PhysStream,
         map: Arc<dyn DataFrameUdf>,
+        /// A formatted string of what the map is. This usually calls format on the IR.
+        format_str: Option<String>,
+    },
 
-        /// A formatted explain of what the in-memory map. This usually calls format on the IR.
+    ColumnarFunction {
+        inputs: Vec<PhysStream>,
+        func: Arc<dyn ColumnsUdf>,
+        output_name: PlSmallStr,
         format_str: Option<String>,
     },
 
@@ -698,7 +703,8 @@ fn visit_node_inputs_mut(
             PhysNodeKind::GroupBy { inputs, .. }
             | PhysNodeKind::OrderedUnion { inputs }
             | PhysNodeKind::UnorderedUnion { inputs }
-            | PhysNodeKind::Zip { inputs, .. } => {
+            | PhysNodeKind::Zip { inputs, .. }
+            | PhysNodeKind::ColumnarFunction { inputs, .. } => {
                 for input in inputs {
                     rec!(input.node);
                     visit(input);

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -503,6 +503,42 @@ fn to_graph_rec<'a>(
             )
         },
 
+        Map {
+            input,
+            map,
+            format_str: _,
+        } => {
+            let input_key = to_graph_rec(input.node, ctx)?;
+            ctx.graph.add_node(
+                nodes::map::MapNode::new(map.clone()),
+                [(input_key, input.port)],
+            )
+        },
+
+        ColumnarFunction {
+            inputs,
+            func,
+            output_name,
+            format_str: _,
+        } => {
+            let input_schemas = inputs
+                .iter()
+                .map(|i| ctx.phys_sm[i.node].output_schema.clone())
+                .collect_vec();
+            let input_keys = inputs
+                .iter()
+                .map(|i| PolarsResult::Ok((to_graph_rec(i.node, ctx)?, i.port)))
+                .try_collect_vec()?;
+            ctx.graph.add_node(
+                nodes::columnar_function::ColumnarFunctionNode::new(
+                    input_schemas,
+                    func.clone(),
+                    output_name.clone(),
+                ),
+                input_keys,
+            )
+        },
+
         #[cfg(any(
             feature = "dtype-date",
             feature = "dtype-datetime",
@@ -521,18 +557,6 @@ fn to_graph_rec<'a>(
                     options.clone(),
                     *ambiguous_is_raise,
                 ),
-                [(input_key, input.port)],
-            )
-        },
-
-        Map {
-            input,
-            map,
-            format_str: _,
-        } => {
-            let input_key = to_graph_rec(input.node, ctx)?;
-            ctx.graph.add_node(
-                nodes::map::MapNode::new(map.clone()),
                 [(input_key, input.port)],
             )
         },


### PR DESCRIPTION
Adds a `ColumnarFunctionNode` which is similar to an `InMemoryMapNode`, but crucially is not defined on `DataFrame -> DataFrame` but rather on `Vec<Column> -> Column`. This lets it map functions which have different input lengths (e.g. `search_sorted`). This is needed for polars-cloud dispatch, and also helps lowering of such functions in OSS Polars directly.

Before when encountering such a non-elementwise function which goes to a fallback, all inputs to that function would necessarily also get merged into the fallback. Now that's not the case anymore, only the non-elementwise function itself isn't lowered. For example:

```python
df = pl.DataFrame({"x": [1, 2, 3, -5]})
df.select(pl.col.x.search_sorted(pl.col.x.sum() / 2))
```

Before:
<img width="1313" height="581" alt="image" src="https://github.com/user-attachments/assets/78b59f78-38cf-4c49-b531-2b81603f13d2" />

After:
<img width="1267" height="987" alt="image" src="https://github.com/user-attachments/assets/b3eb1d45-4c65-4d33-ac73-8bcdcd2c223f" />
