### PR TITLE
perf: Add streaming GatherNode

### DIFF
--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -2,10 +2,6 @@ use std::borrow::Cow;
 use std::fmt::Write;
 
 use arrow::array::ValueSize;
-#[cfg(feature = "list_gather")]
-use num_traits::ToPrimitive;
-#[cfg(feature = "list_gather")]
-use num_traits::{NumCast, Signed, Zero};
 use polars_compute::gather::sublist::list::{index_is_oob, sublist_get};
 use polars_core::chunked_array::builder::get_list_builder;
 #[cfg(feature = "diff")]
@@ -18,7 +14,7 @@ use crate::chunked_array::list::sum_mean::sum_with_nulls;
 #[cfg(feature = "diff")]
 use crate::prelude::diff;
 use crate::prelude::list::sum_mean::{mean_list_numerical, sum_list_numerical};
-use crate::series::ArgAgg;
+use crate::series::{ArgAgg, convert_and_bound_index};
 
 pub(super) fn has_inner_nulls(ca: &ListChunked) -> bool {
     for arr in ca.downcast_iter() {
@@ -848,109 +844,6 @@ impl ListNameSpaceImpl for ListChunked {}
 #[cfg(feature = "list_gather")]
 fn take_series(s: &Series, idx: Series, null_on_oob: bool) -> PolarsResult<Series> {
     let len = s.len();
-    let idx = cast_index(idx, len, null_on_oob)?;
-    let idx = idx.idx().unwrap();
-    s.take(idx)
+    let idx = convert_and_bound_index(&idx, len, null_on_oob)?;
+    s.take(&idx)
 }
-
-#[cfg(feature = "list_gather")]
-fn cast_signed_index_ca<T: PolarsNumericType>(idx: &ChunkedArray<T>, len: usize) -> Series
-where
-    T::Native: Copy + PartialOrd + PartialEq + NumCast + Signed + Zero,
-{
-    idx.iter()
-        .map(|opt_idx| opt_idx.and_then(|idx| idx.negative_to_usize(len).map(|idx| idx as IdxSize)))
-        .collect::<IdxCa>()
-        .into_series()
-}
-
-#[cfg(feature = "list_gather")]
-fn cast_unsigned_index_ca<T: PolarsNumericType>(idx: &ChunkedArray<T>, len: usize) -> Series
-where
-    T::Native: Copy + PartialOrd + ToPrimitive,
-{
-    idx.iter()
-        .map(|opt_idx| {
-            opt_idx.and_then(|idx| {
-                let idx = idx.to_usize().unwrap();
-                if idx >= len {
-                    None
-                } else {
-                    Some(idx as IdxSize)
-                }
-            })
-        })
-        .collect::<IdxCa>()
-        .into_series()
-}
-
-#[cfg(feature = "list_gather")]
-fn cast_index(idx: Series, len: usize, null_on_oob: bool) -> PolarsResult<Series> {
-    let idx_null_count = idx.null_count();
-    use DataType::*;
-    let out = match idx.dtype() {
-        #[cfg(feature = "big_idx")]
-        UInt32 => {
-            if null_on_oob {
-                let a = idx.u32().unwrap();
-                cast_unsigned_index_ca(a, len)
-            } else {
-                idx.cast(&IDX_DTYPE).unwrap()
-            }
-        },
-        #[cfg(feature = "big_idx")]
-        UInt64 => {
-            if null_on_oob {
-                let a = idx.u64().unwrap();
-                cast_unsigned_index_ca(a, len)
-            } else {
-                idx
-            }
-        },
-        #[cfg(not(feature = "big_idx"))]
-        UInt64 => {
-            if null_on_oob {
-                let a = idx.u64().unwrap();
-                cast_unsigned_index_ca(a, len)
-            } else {
-                idx.cast(&IDX_DTYPE).unwrap()
-            }
-        },
-        #[cfg(not(feature = "big_idx"))]
-        UInt32 => {
-            if null_on_oob {
-                let a = idx.u32().unwrap();
-                cast_unsigned_index_ca(a, len)
-            } else {
-                idx
-            }
-        },
-        dt if dt.is_unsigned_integer() => idx.cast(&IDX_DTYPE).unwrap(),
-        Int8 => {
-            let a = idx.i8().unwrap();
-            cast_signed_index_ca(a, len)
-        },
-        Int16 => {
-            let a = idx.i16().unwrap();
-            cast_signed_index_ca(a, len)
-        },
-        Int32 => {
-            let a = idx.i32().unwrap();
-            cast_signed_index_ca(a, len)
-        },
-        Int64 => {
-            let a = idx.i64().unwrap();
-            cast_signed_index_ca(a, len)
-        },
-        _ => {
-            unreachable!()
-        },
-    };
-    polars_ensure!(
-        out.null_count() == idx_null_count || null_on_oob,
-        OutOfBounds: "gather indices are out of bounds"
-    );
-    Ok(out)
-}
-
-// TODO: implement the above for ArrayChunked as well?

--- a/crates/polars-stream/src/nodes/gather.rs
+++ b/crates/polars-stream/src/nodes/gather.rs
@@ -48,7 +48,8 @@ impl ComputeNode for GatherNode {
         // If the payload input is done, transition to gathering.
         if recv[0] == PortState::Done {
             if let GatherState::Sink(sink_node) = &mut self.state {
-                let df = sink_node.get_output()?.unwrap();
+                let mut df = sink_node.get_output()?.unwrap();
+                df.rechunk_mut_par();
                 self.state = GatherState::Gather(df);
             }
         }

--- a/crates/polars-stream/src/nodes/gather.rs
+++ b/crates/polars-stream/src/nodes/gather.rs
@@ -1,0 +1,150 @@
+use std::sync::Arc;
+
+use polars_core::prelude::*;
+use polars_ops::series::convert_and_bound_index;
+
+use super::compute_node_prelude::*;
+use super::in_memory_sink::InMemorySinkNode;
+
+pub struct GatherNode {
+    state: GatherState,
+    null_on_oob: bool,
+}
+
+enum GatherState {
+    Sink(InMemorySinkNode),
+    Gather(DataFrame),
+    Done,
+}
+
+impl GatherNode {
+    pub fn new(input_schema: Arc<Schema>, null_on_oob: bool) -> Self {
+        Self {
+            state: GatherState::Sink(InMemorySinkNode::new(input_schema)),
+            null_on_oob,
+        }
+    }
+}
+
+impl ComputeNode for GatherNode {
+    fn name(&self) -> &str {
+        "gather"
+    }
+
+    fn update_state(
+        &mut self,
+        recv: &mut [PortState],
+        send: &mut [PortState],
+        state: &StreamingExecutionState,
+    ) -> PolarsResult<()> {
+        assert!(recv.len() == 2 && send.len() == 1);
+
+        // If the output doesn't want any more data, or there are no more indices,
+        // transition to being done.
+        if send[0] == PortState::Done || recv[1] == PortState::Done {
+            self.state = GatherState::Done;
+        }
+
+        // If the payload input is done, transition to gathering.
+        if recv[0] == PortState::Done {
+            if let GatherState::Sink(sink_node) = &mut self.state {
+                let df = sink_node.get_output()?.unwrap();
+                self.state = GatherState::Gather(df);
+            }
+        }
+
+        match &mut self.state {
+            GatherState::Sink(sink_node) => {
+                sink_node.update_state(&mut recv[0..1], &mut [], state)?;
+                recv[1] = PortState::Blocked;
+                send[0] = PortState::Blocked;
+            },
+            GatherState::Gather(_) => {
+                recv[0] = PortState::Done;
+                recv[1..2].swap_with_slice(send);
+            },
+            GatherState::Done => {
+                recv[0] = PortState::Done;
+                send[0] = PortState::Done;
+            },
+        }
+        Ok(())
+    }
+
+    fn is_memory_intensive_pipeline_blocker(&self) -> bool {
+        matches!(self.state, GatherState::Sink(_))
+    }
+
+    fn spawn<'env, 's>(
+        &'env mut self,
+        scope: &'s TaskScope<'s, 'env>,
+        recv_ports: &mut [Option<RecvPort<'_>>],
+        send_ports: &mut [Option<SendPort<'_>>],
+        state: &'s StreamingExecutionState,
+        join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
+    ) {
+        assert!(recv_ports.len() == 2 && send_ports.len() == 1);
+
+        match &mut self.state {
+            GatherState::Sink(sink_node) => {
+                assert!(recv_ports[1].is_none());
+                sink_node.spawn(scope, &mut recv_ports[0..1], &mut [], state, join_handles)
+            },
+            GatherState::Gather(target) => {
+                assert!(recv_ports[0].is_none());
+                let receivers = recv_ports[1].take().unwrap().parallel();
+                let senders = send_ports[0].take().unwrap().parallel();
+
+                for (mut recv, mut send) in receivers.into_iter().zip(senders) {
+                    let null_on_oob = self.null_on_oob;
+                    let target = &*target;
+                    join_handles.push(scope.spawn_task(TaskPriority::High, async move {
+                        while let Ok(morsel) = recv.recv().await {
+                            let morsel = morsel.try_map(|idx_df| {
+                                assert!(idx_df.width() == 1);
+                                if idx_df.height() == 0 {
+                                    return Ok(target.clear());
+                                }
+
+                                match &idx_df.columns()[0] {
+                                    Column::Series(idx_s) => {
+                                        let idx_ca = convert_and_bound_index(
+                                            idx_s,
+                                            target.height(),
+                                            null_on_oob,
+                                        )?;
+                                        target.take(&idx_ca)
+                                    },
+                                    Column::Scalar(idx_c) => {
+                                        let idx_s = idx_c.as_single_value_series();
+                                        let idx_ca = convert_and_bound_index(
+                                            &idx_s,
+                                            target.height(),
+                                            null_on_oob,
+                                        )?;
+                                        match idx_ca.get(0) {
+                                            Some(idx) => {
+                                                Ok(target.new_from_index(idx as usize, idx_c.len()))
+                                            },
+                                            None => Ok(DataFrame::full_null(
+                                                target.schema(),
+                                                idx_c.len(),
+                                            )),
+                                        }
+                                    },
+                                }
+                            })?;
+
+                            if send.send(morsel).await.is_err() {
+                                break;
+                            }
+                        }
+
+                        Ok(())
+                    }));
+                }
+            },
+            GatherState::Done => unreachable!(),
+        }
+    }
+}

--- a/crates/polars-stream/src/nodes/mod.rs
+++ b/crates/polars-stream/src/nodes/mod.rs
@@ -10,6 +10,7 @@ pub mod dynamic_slice;
 pub mod ewm;
 pub mod filter;
 pub mod forward_fill;
+pub mod gather;
 pub mod gather_every;
 pub mod group_by;
 pub mod in_memory_map;

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -42,7 +42,9 @@ impl NodeStyle {
             | K::GroupBy { .. }
             | K::EquiJoin { .. }
             | K::SemiAntiJoin { .. }
-            | K::Multiplexer { .. } => Self::MemoryIntensive,
+            | K::CrossJoin { .. }
+            | K::Multiplexer { .. }
+            | K::Gather { .. } => Self::MemoryIntensive,
             #[cfg(feature = "iejoin")]
             K::RangeJoin { .. } => Self::MemoryIntensive,
             #[cfg(feature = "merge_sorted")]

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -828,6 +828,7 @@ fn visualize_plan_rec(
             input_right,
             ..
         } => ("merge-sorted".to_string(), &[*input_left, *input_right][..]),
+        PhysNodeKind::Gather { target, idxs, .. } => ("gather".to_string(), &[*target, *idxs][..]),
         #[cfg(feature = "ewma")]
         PhysNodeKind::EwmMean { input, options: _ } => ("ewm-mean".to_string(), &[*input][..]),
         #[cfg(feature = "ewma")]

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -1630,6 +1630,7 @@ fn lower_exprs_with_ctx(
                 input_streams.insert(trans_input);
                 transformed_exprs.push(ctx.expr_arena.add(bin_expr));
             },
+
             AExpr::Eval {
                 expr: inner,
                 evaluation,
@@ -1813,6 +1814,7 @@ fn lower_exprs_with_ctx(
                 input_streams.insert(stream);
                 transformed_exprs.push(exit_node);
             },
+
             AExpr::Ternary {
                 predicate,
                 truthy,
@@ -1828,6 +1830,7 @@ fn lower_exprs_with_ctx(
                 input_streams.insert(trans_input);
                 transformed_exprs.push(ctx.expr_arena.add(tern_expr));
             },
+
             AExpr::Cast {
                 expr: inner,
                 dtype,
@@ -1841,6 +1844,7 @@ fn lower_exprs_with_ctx(
                     options,
                 }));
             },
+
             AExpr::Sort {
                 expr: inner,
                 options,
@@ -1968,10 +1972,7 @@ fn lower_exprs_with_ctx(
                     build_select_stream_with_ctx(input, &[inner_expr_ir, by_expr_ir], ctx)?;
 
                 // Add a filter node.
-                let predicate = ExprIR::new(
-                    ctx.expr_arena.add(AExpr::Column(by_name.clone())),
-                    OutputName::Alias(by_name),
-                );
+                let predicate = ExprIR::from_column_name(by_name.clone(), ctx.expr_arena);
                 let kind = PhysNodeKind::Filter {
                     input: select_stream,
                     predicate,
@@ -1979,6 +1980,28 @@ fn lower_exprs_with_ctx(
                 let output_schema = select_stream.output_schema(ctx.phys_sm).clone();
                 let filter_node_key = ctx.phys_sm.insert(PhysNode::new(output_schema, kind));
                 input_streams.insert(PhysStream::first(filter_node_key));
+                transformed_exprs.push(ctx.expr_arena.add(AExpr::Column(out_name)));
+            },
+
+            AExpr::Gather {
+                expr: target_expr,
+                idx: idx_expr,
+                returns_scalar: _,
+                null_on_oob,
+            } => {
+                let out_name = unique_column_name();
+                let target_expr_ir = ExprIR::new(target_expr, OutputName::Alias(out_name.clone()));
+                let idx_expr_ir = ExprIR::from_node(idx_expr, ctx.expr_arena);
+                let target_stream = build_select_stream_with_ctx(input, &[target_expr_ir], ctx)?;
+                let idx_stream = build_select_stream_with_ctx(input, &[idx_expr_ir], ctx)?;
+                let kind = PhysNodeKind::Gather {
+                    target: target_stream,
+                    idxs: idx_stream,
+                    null_on_oob,
+                };
+                let output_schema = target_stream.output_schema(ctx.phys_sm).clone();
+                let gather_node_key = ctx.phys_sm.insert(PhysNode::new(output_schema, kind));
+                input_streams.insert(PhysStream::first(gather_node_key));
                 transformed_exprs.push(ctx.expr_arena.add(AExpr::Column(out_name)));
             },
 
@@ -2601,7 +2624,7 @@ fn lower_exprs_with_ctx(
                 transformed_exprs.push(ctx.expr_arena.add(AExpr::Column(out_name)));
             },
 
-            AExpr::Over { .. } | AExpr::Gather { .. } => {
+            AExpr::Over { .. } => {
                 let out_name = unique_column_name();
                 fallback_subset.push(ExprIR::new(expr, OutputName::Alias(out_name.clone())));
                 transformed_exprs.push(ctx.expr_arena.add(AExpr::Column(out_name)));

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -515,6 +515,12 @@ pub enum PhysNodeKind {
         maintain_order: bool,
     },
 
+    Gather {
+        target: PhysStream,
+        idxs: PhysStream,
+        null_on_oob: bool,
+    },
+
     #[cfg(feature = "ewma")]
     EwmMean {
         input: PhysStream,
@@ -681,6 +687,13 @@ fn visit_node_inputs_mut(
                 rec!(input_right.node);
                 visit(input_left);
                 visit(input_right);
+            },
+
+            PhysNodeKind::Gather { target, idxs, .. } => {
+                rec!(target.node);
+                rec!(idxs.node);
+                visit(target);
+                visit(idxs);
             },
 
             PhysNodeKind::TopK { input, k, .. } => {

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -1379,6 +1379,20 @@ fn to_graph_rec<'a>(
             )
         },
 
+        Gather {
+            target,
+            idxs,
+            null_on_oob,
+        } => {
+            let target_key = to_graph_rec(target.node, ctx)?;
+            let target_schema = target.output_schema(ctx.phys_sm).clone();
+            let idxs_key = to_graph_rec(idxs.node, ctx)?;
+            ctx.graph.add_node(
+                nodes::gather::GatherNode::new(target_schema, *null_on_oob),
+                [(target_key, target.port), (idxs_key, idxs.port)],
+            )
+        },
+
         #[cfg(feature = "python")]
         PythonScan { options } => {
             use polars_buffer::Buffer;


### PR DESCRIPTION
This adds a streaming gather node. The target `DataFrame` is still fully materialized into memory, but once that is done the indices -> gather operations are fully streamed (and done in parallel).

Example benchmark:

```python
import polars as pl
import numpy as np
from timeit import timeit

df = pl.DataFrame({"x": np.random.randint(0, 1000, 10**7)})
target = pl.Series(list(range(1000)))

q1 = df.lazy().select(pl.col.x.gather(pl.col.x).sum())
q2 = df.lazy().select(pl.lit(target).gather(pl.col.x).sum())

print("q1", timeit(lambda: q1.collect(engine="streaming"), number=100))
print("q2", timeit(lambda: q2.collect(engine="streaming"), number=100))
q1.show_graph(engine="streaming", plan_stage="physical")
```

Performance on 1.40.1:
```rust
q1 5.696350166108459
q2 2.1505114999599755
```

Performance with this PR:
```rust
q1 0.9761173748411238
q2 0.2642994159832597
```

So ~5-8x speedup for this microbenchmark on this machine (probably more on higher core machines), and more memory-friendly as well.

---

Sad plan of q1 before:

<img width="992" height="871" alt="image" src="https://github.com/user-attachments/assets/44c991e0-1bfa-49e8-b459-97b8498449ae" />

---

And after:

<img width="761" height="872" alt="image" src="https://github.com/user-attachments/assets/8e97d551-b929-4bb7-b6d4-da0798ee0dcf" />
