### PR TITLE
fix: Prevent deadlock when using `to_arrow()` in a multithreaded context

### DIFF
--- a/crates/polars-python/src/dataframe/export.rs
+++ b/crates/polars-python/src/dataframe/export.rs
@@ -1,6 +1,5 @@
 use arrow::datatypes::IntegerType;
 use arrow::record_batch::RecordBatch;
-use parking_lot::RwLockWriteGuard;
 use polars::prelude::*;
 use polars_compute::cast::CastOptionsImpl;
 use polars_utils::itertools::Itertools;
@@ -83,10 +82,9 @@ impl PyDataFrame {
         py: Python<'_>,
         compat_level: PyCompatLevel,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let mut df = self.df.write();
-        let dfr = &mut *df; // Lock guard isn't Send, but mut ref is.
-        py.enter_polars_ok(|| dfr.align_chunks_par())?;
-        let df = RwLockWriteGuard::downgrade(df);
+        let mut df = self.df.read().clone();
+        py.enter_polars_ok(|| df.align_chunks_par())?;
+        *self.df.write() = df.clone();
 
         let pyarrow = py.import("pyarrow")?;
 

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -1527,6 +1527,19 @@ def test_0_width_df_roundtrip() -> None:
         pl.LazyFrame(height=1).sink_csv(io.BytesIO())
 
 
+def test_to_arrow_no_deadlock_multithreaded() -> None:
+    from concurrent.futures import ThreadPoolExecutor
+
+    df = pl.DataFrame({"a": [1] * 100000})
+
+    def to_arrow() -> None:
+        df.to_arrow()
+
+    with ThreadPoolExecutor(10) as e:
+        fs = [e.submit(to_arrow) for _ in range(100)]
+        [f.result(timeout=10) for f in fs]
+
+
 def test_from_pandas_timestamp_17382() -> None:
     my_date_pd = pd.to_datetime("2021-01-01 11:00:00.0000000 +11:00")
     result = pl.DataFrame([my_date_pd]).item()

--- a/py-polars/tests/unit/interop/test_to_pandas.py
+++ b/py-polars/tests/unit/interop/test_to_pandas.py
@@ -219,7 +219,7 @@ def test_filter_with_pandas_timedelta_26620() -> None:
     assert_frame_equal(actual, expected)
 
 
-def test_no_deadlock_multithreaded_27396() -> None:
+def test_to_pandas_no_deadlock_multithreaded_27396() -> None:
     from concurrent.futures import ThreadPoolExecutor
 
     df = pl.DataFrame({"a": [1] * 100000})


### PR DESCRIPTION
A follow-up to https://github.com/pola-rs/polars/pull/27451. Just tagging @orlp since he helped me with the last one and reviewed it.

After finishing the above PR, when I looked at the `to_arrow()` implementation on the Rust side, it had the exact same issue as `to_pandas()` where a write lock was held across a GIL release, which would cause a deadlock under concurrent calls. I ran a simple test to verify:

```python
import polars as pl
from concurrent.futures import ThreadPoolExecutor

df = pl.DataFrame({'a': [1] * 100000})

def to_arrow():
    df.to_arrow()

with ThreadPoolExecutor(10) as e:
    fs = [e.submit(to_arrow) for _ in range(100)]
    [f.result(timeout=10) for f in fs]

print('No deadlock')
```

And this code indeed resulted in a deadlock. The solution was the same as it was in the above `to_pandas()` PR.

🥦 Only organic intelligence was used in this PR.