### PR TITLE
perf: Make `is_in` row-group pruning precise on multi-value lists

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/predicates/column_expr.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/column_expr.rs
@@ -215,27 +215,14 @@ pub fn aexpr_to_column_predicates(
                             } => {
                                 into_column(input[0].node(), expr_arena)?;
 
-                                let values = constant_evaluate(
+                                let values = super::try_extract_is_in_haystack(
                                     input[1].node(),
                                     expr_arena,
                                     schema,
-                                    0,
-                                )??;
-                                let values = values.to_any_value()?;
-
-                                let values = match values {
-                                    AnyValue::List(v) => v,
-                                    #[cfg(feature = "dtype-array")]
-                                    AnyValue::Array(v, _) => v,
-                                    _ => return None,
-                                };
-
-                                if values.dtype() != &dtype {
-                                    return None;
-                                }
-                                if !nulls_equal && values.has_nulls() {
-                                    return None;
-                                }
+                                    &dtype,
+                                    *nulls_equal,
+                                    usize::MAX,
+                                )?;
 
                                 let values = values.iter()
                                     .map(|av| {

--- a/crates/polars-plan/src/plans/aexpr/predicates/mod.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/mod.rs
@@ -4,6 +4,8 @@ mod skip_batches;
 use std::borrow::Cow;
 
 pub use column_expr::*;
+#[cfg(feature = "is_in")]
+use polars_core::prelude::{AnyValue, DataType, Series};
 use polars_core::schema::Schema;
 use polars_utils::arena::{Arena, Node};
 use polars_utils::pl_str::PlSmallStr;
@@ -32,4 +34,44 @@ fn get_binary_expr_col_and_lv<'a>(
         (_, Some(col), Some(lv), _) => Some(((col, right), (lv, left))),
         _ => None,
     }
+}
+
+/// Extract the haystack of `col.is_in(haystack)` as a flat element [`Series`]
+/// at planner time. Returns `None` (signals the caller to use its fallback path)
+/// when any of:
+/// - `lv_node` is not an `AExpr::Literal` whose value is `AnyValue::List(_)`
+///   (or `AnyValue::Array(_, _)` under `dtype-array`).
+/// - The list's element dtype is not equal to `column_dtype`.
+/// - `nulls_equal` is `false` and the list contains a null.
+/// - The list has more than `max_len` elements.
+///
+/// Shared by [`skip_batches`] (skip-batch predicate) and [`column_expr`]
+/// (per-column predicate).
+#[cfg(feature = "is_in")]
+pub(super) fn try_extract_is_in_haystack(
+    lv_node: Node,
+    expr_arena: &Arena<AExpr>,
+    schema: &Schema,
+    column_dtype: &DataType,
+    nulls_equal: bool,
+    max_len: usize,
+) -> Option<Series> {
+    let lv = constant_evaluate(lv_node, expr_arena, schema, 0)??;
+    let av = lv.to_any_value()?;
+    let s = match av {
+        AnyValue::List(s) => s,
+        #[cfg(feature = "dtype-array")]
+        AnyValue::Array(s, _) => s,
+        _ => return None,
+    };
+    if s.dtype() != column_dtype {
+        return None;
+    }
+    if !nulls_equal && s.has_nulls() {
+        return None;
+    }
+    if s.len() > max_len {
+        return None;
+    }
+    Some(s)
 }

--- a/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
@@ -12,6 +12,8 @@ use super::super::evaluate::{constant_evaluate, into_column};
 use super::super::{AExpr, IRBooleanFunction, IRFunctionExpr, LiteralValue, Operator};
 use crate::plans::aexpr::builder::IntoAExprBuilder;
 use crate::plans::predicates::get_binary_expr_col_and_lv;
+#[cfg(feature = "is_in")]
+use crate::plans::predicates::try_extract_is_in_haystack;
 use crate::plans::{AExprBuilder, aexpr_to_leaf_names_iter, is_scalar_ae, rename_columns};
 
 /// Return a new boolean expression determines whether a batch can be skipped based on min, max and
@@ -349,15 +351,29 @@ fn aexpr_to_skip_batch_predicate_rec(
                                     return None;
                                 }
 
-                                // col(A).is_in([B1, ..., Bn]) ->
-                                //      ([B1, ..., Bn].has_no_nulls() || null_count(A) == 0) &&
-                                //      (
-                                //          min(A) > max[B1, ..., Bn] ||
-                                //          max(A) < min[B1, ..., Bn]
-                                //      )
-                                let col = col.clone();
-                                let lv_node = lv_node.into_aexpr_builder();
+                                // col(A).is_in([B1, ..., Bn]) -> {
+                                //     min(A) == max(A) && null_count(A) == 0 && !min(A).is_in(lv),
+                                //     (!lv.has_nulls() || null_count(A) == 0) &&
+                                //         (null_count(A) == LEN ||
+                                //             AND_i (min(A) > Bi || max(A) < Bi)) , if N <= LIMIT,
+                                //         (null_count(A) == LEN ||
+                                //             min(A) > max(lv) || max(A) < min(lv)) , otherwise,
+                                // }
+                                // Branch 1 mirrors the generic min==max fallback for const-col rgs.
+                                // `min(A) > X` / `max(A) < X` elide an `is_defined(stat) &&` guard.
+                                const LIST_ITEM_LIMIT: usize = 100;
 
+                                let col = col.clone();
+                                let values = try_extract_is_in_haystack(
+                                    lv_node,
+                                    arena,
+                                    schema,
+                                    dtype,
+                                    nulls_equal,
+                                    LIST_ITEM_LIMIT,
+                                );
+
+                                let lv_node = lv_node.into_aexpr_builder();
                                 let lv_node_exploded = lv_node.explode(
                                     arena,
                                     ExplodeOptions {
@@ -365,32 +381,55 @@ fn aexpr_to_skip_batch_predicate_rec(
                                         keep_nulls: true,
                                     },
                                 );
-                                let lv_min = lv_node_exploded.min(arena);
-                                let lv_max = lv_node_exploded.max(arena);
 
                                 let col_min = col!(min: col);
                                 let col_max = col!(max: col);
-
                                 let min_is_defined = is_stat_defined(col_min, dtype, arena);
                                 let max_is_defined = is_stat_defined(col_max, dtype, arena);
 
-                                let min_gt = col_min.gt(lv_max, arena);
-                                let min_gt = min_is_defined.and(min_gt, arena);
-
-                                let max_lt = col_max.lt(lv_min, arena);
-                                let max_lt = max_is_defined.and(max_lt, arena);
-
-                                let expr = min_gt.or(max_lt, arena);
-
+                                // all_nulls disjunct skips row groups whose column is entirely
+                                // null in this group. Sound for both paths — the outer null_case
+                                // wrapper below suppresses skip when haystack and column both have
+                                // nulls under nulls_equal=true.
                                 let col_nc = col!(null_count: col);
+                                let len = col!(len);
+                                let all_nulls = col_nc.eq(len, arena);
+
+                                let inner = if let Some(values) = values {
+                                    // Per-element AND. Empty list folds to `true` (AND identity) —
+                                    // `is_in([])` is unconditionally false. Null elements (only
+                                    // possible under nulls_equal=true) are skipped so they don't
+                                    // poison the AND with nulls; the outer null_case gate handles
+                                    // the column-has-nulls × haystack-has-null interaction.
+                                    values.iter().fold(lv!(true), |acc, av| {
+                                        if av.is_null() {
+                                            return acc;
+                                        }
+                                        let scalar = Scalar::new(dtype.clone(), av.into_static());
+                                        let bi = AExprBuilder::lit_scalar(scalar, arena);
+                                        let below =
+                                            min_is_defined.and(col_min.gt(bi, arena), arena);
+                                        let above =
+                                            max_is_defined.and(col_max.lt(bi, arena), arena);
+                                        acc.and(below.or(above, arena), arena)
+                                    })
+                                } else {
+                                    let lv_min = lv_node_exploded.min(arena);
+                                    let lv_max = lv_node_exploded.max(arena);
+                                    let below =
+                                        min_is_defined.and(col_min.gt(lv_max, arena), arena);
+                                    let above =
+                                        max_is_defined.and(col_max.lt(lv_min, arena), arena);
+                                    below.or(above, arena)
+                                };
+                                let expr = all_nulls.or(inner, arena);
+
                                 let col_has_no_nulls = col_nc.has_no_nulls(arena);
 
                                 let lv_has_not_nulls = lv_node_exploded.has_no_nulls(arena);
                                 let null_case = lv_has_not_nulls.or(col_has_no_nulls, arena);
 
                                 let min_max_is_in = null_case.and(expr, arena);
-
-                                let col_nc = col!(null_count: col);
 
                                 let min_is_max = col_min.eq(col_max, arena); // Eq so that (None == None) == None
                                 let idx_zero = lv!(idx: 0);

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -3504,6 +3504,33 @@ def test_scan_parquet_skip_row_groups_with_cast_inclusions(
     assert_frame_equal(out, pl.select(x=value).select(pl.first().cast(scan_dtype)))
 
 
+@pytest.mark.may_fail_cloud  # reason: looks at stdout
+def test_is_in_string_pushdown_27416(
+    plmonkeypatch: PlMonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    # Simplified repro of the user's setup.
+    # `is_in(["0","9"])` over 5 row groups whose value ranges tile [0..9].
+    # Only RG1 (contains "0") and RG5 (contains "9") match, 3 RGs must be pruned.
+    df = pl.DataFrame({"sym": [str(i) for i in range(10)], "val": list(range(10))})
+
+    def fixture() -> io.BytesIO:
+        f = io.BytesIO()
+        df.write_parquet(f, row_group_size=2, statistics="full")
+        f.seek(0)
+        return f
+
+    plmonkeypatch.setenv("POLARS_VERBOSE", "1")
+    capfd.readouterr()
+    out = pl.scan_parquet(fixture()).filter(pl.col("sym").is_in(["0", "9"])).collect()
+
+    assert_frame_equal(
+        out.sort("val"), pl.DataFrame({"sym": ["0", "9"], "val": [0, 9]})
+    )
+
+    assert "Predicate pushdown: reading 2 / 5 row groups" in capfd.readouterr().err
+
+
 def test_roundtrip_int128() -> None:
     f = io.BytesIO()
     s = pl.Series("a", [1, 2, 3], pl.Int128)


### PR DESCRIPTION
Fixes #27416

The skip-batch predicate for `col.is_in([B1, ..., Bn])` used a convex-hull range-overlap check (`min(A) > max(lv) || max(A) < min(lv)`), which is imprecise for set membership: any row group whose `[min, max]` interval overlaps `[min(lv), max(lv)]` is kept, even when no individual `Bi` falls inside the row-group interval. With strings spanning a wide lex range, the hull covers most of the symbol space and the pushdown becomes nearly useless.

Replaces it with a per-element AND `AND_i (min(A) > Bi || max(A) < Bi)` for haystacks of up to 100 elements, falling back to the old range-overlap form for larger lists. Per-element AND is precise for set membership (equivalent to OR-of-Eq pruning).

| Metric | Issue | Our main | Our fix (cold) |
|---|---|---|---|
| Machine | not stated in issue | Apple M4 Pro, 14 cores, 48 GB, macOS 26.3 | Apple M4 Pro, 14 cores, 48 GB, macOS 26.3 |
| Single Lookup | 0.0061 s | 0.0041 s | ~0.0042 s |
| Multi Lookup | 0.0426 s | 0.0257 s | **~0.0043 s — 6.0× faster** |
| Multi/Single ratio | 6.95× | 6.24× | **~1.0× (regression eliminated)** |
| Multi rgs read | 785 / 814 | 785 / 814 | 8 / 814 — **98× fewer** |