### PR TITLE
feat: Process batched `list.eval` on overflow boundaries

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/chunkops.rs
+++ b/crates/polars-core/src/chunked_array/ops/chunkops.rs
@@ -97,7 +97,7 @@ pub(crate) fn slice(
 // we take the underlying values array as a Series. This call stack
 // is hard to follow, so for this one case we make an exception
 // and use a thread local.
-thread_local!(static CHECK_LENGTH: Cell<bool> = const { Cell::new(true) });
+thread_local!(pub static CHECK_LENGTH: Cell<bool> = const { Cell::new(true) });
 
 /// Meant for internal use. In very rare conditions this can be turned off.
 /// # Safety

--- a/crates/polars-core/src/series/implementations/null.rs
+++ b/crates/polars-core/src/series/implementations/null.rs
@@ -19,7 +19,7 @@ impl Series {
 #[derive(Clone)]
 pub struct NullChunked {
     pub(crate) name: PlSmallStr,
-    length: IdxSize,
+    length: usize,
     // we still need chunks as many series consumers expect
     // chunks to be there
     chunks: Vec<ArrayRef>,
@@ -27,9 +27,13 @@ pub struct NullChunked {
 
 impl NullChunked {
     pub(crate) fn new(name: PlSmallStr, len: usize) -> Self {
+        if len >= (IdxSize::MAX as usize) && chunkops::CHECK_LENGTH.get() {
+            panic!("{}", LENGTH_LIMIT_MSG);
+        }
+
         Self {
             name,
-            length: len as IdxSize,
+            length: len,
             chunks: vec![Box::new(arrow::array::NullArray::new(
                 ArrowDataType::Null,
                 len,
@@ -38,7 +42,7 @@ impl NullChunked {
     }
 
     pub fn len(&self) -> usize {
-        self.length as usize
+        self.length
     }
 
     pub fn is_empty(&self) -> bool {
@@ -63,7 +67,11 @@ impl PrivateSeries for NullChunked {
                 _ => chunks.iter().fold(0, |acc, arr| acc + arr.len()),
             }
         }
-        self.length = IdxSize::try_from(inner(&self.chunks)).expect(LENGTH_LIMIT_MSG);
+        let len = inner(&self.chunks);
+        if len >= (IdxSize::MAX as usize) && chunkops::CHECK_LENGTH.get() {
+            panic!("{}", LENGTH_LIMIT_MSG);
+        }
+        self.length = len;
     }
     fn _field(&self) -> Cow<'_, Field> {
         Cow::Owned(Field::new(self.name().clone(), DataType::Null))
@@ -120,7 +128,7 @@ impl PrivateSeries for NullChunked {
         Ok(if self.is_empty() {
             GroupsType::default()
         } else {
-            GroupsType::new_slice(vec![[0, self.length]], false, true)
+            GroupsType::new_slice(vec![[0, self.length as IdxSize]], false, true)
         })
     }
 
@@ -215,7 +223,7 @@ impl SeriesTrait for NullChunked {
     }
 
     fn len(&self) -> usize {
-        self.length as usize
+        self.length
     }
 
     fn has_nulls(&self) -> bool {
@@ -280,7 +288,7 @@ impl SeriesTrait for NullChunked {
         let (chunks, len) = chunkops::slice(&self.chunks, offset, length, self.len());
         NullChunked {
             name: self.name.clone(),
-            length: len as IdxSize,
+            length: len,
             chunks,
         }
         .into_series()
@@ -291,13 +299,13 @@ impl SeriesTrait for NullChunked {
         (
             NullChunked {
                 name: self.name.clone(),
-                length: l.iter().map(|arr| arr.len() as IdxSize).sum(),
+                length: l.iter().map(|arr| arr.len()).sum(),
                 chunks: l,
             }
             .into_series(),
             NullChunked {
                 name: self.name.clone(),
-                length: r.iter().map(|arr| arr.len() as IdxSize).sum(),
+                length: r.iter().map(|arr| arr.len()).sum(),
                 chunks: r,
             }
             .into_series(),
@@ -376,7 +384,7 @@ impl SeriesTrait for NullChunked {
     fn append(&mut self, other: &Series) -> PolarsResult<()> {
         polars_ensure!(other.dtype() == &DataType::Null, ComputeError: "expected null dtype");
         // we don't create a new null array to keep probability of aligned chunks higher
-        self.length += other.len() as IdxSize;
+        self.length += other.len();
         self.chunks.extend(other.chunks().iter().cloned());
         Ok(())
     }
@@ -384,7 +392,7 @@ impl SeriesTrait for NullChunked {
         polars_ensure!(other.dtype() == &DataType::Null, ComputeError: "expected null dtype");
         // we don't create a new null array to keep probability of aligned chunks higher
         let other: &mut NullChunked = other._get_inner_mut().as_any_mut().downcast_mut().unwrap();
-        self.length += other.len() as IdxSize;
+        self.length += other.len();
         self.chunks.extend(std::mem::take(&mut other.chunks));
         Ok(())
     }

--- a/crates/polars-expr/src/expressions/eval.rs
+++ b/crates/polars-expr/src/expressions/eval.rs
@@ -89,19 +89,32 @@ impl EvalExpr {
         // whose accumulated inner element count stays within IdxSize::MAX.
         if flattened_len > IdxSize::MAX as usize {
             let offsets = ca.offsets()?;
+            // offsets_slice[i] / offsets_slice[i+1] are the start/end of row i.
+            let offsets_slice = offsets.as_slice();
             let mut batch_results: Vec<Column> = Vec::new();
             let mut batch_row_start = 0usize;
             let mut batch_inner_start: i64 = 0;
 
-            for i in 0..ca.len() {
-                let inner_end = unsafe { offsets.start_end_unchecked(i).1 } as i64;
-                // Flush the current batch before including row `i` if it would overflow.
-                if inner_end - batch_inner_start > IdxSize::MAX as i64 && i > batch_row_start {
-                    let batch = ca.slice(batch_row_start as i64, i - batch_row_start);
-                    batch_results.push(self.evaluate_on_list_chunked(&batch, state, is_agg)?);
-                    batch_row_start = i;
-                    batch_inner_start = unsafe { offsets.start_end_unchecked(i).0 } as i64;
+            loop {
+                if batch_row_start >= ca.len() {
+                    break;
                 }
+                let threshold = batch_inner_start + IdxSize::MAX as i64;
+                // Binary search for the first row whose end offset exceeds the threshold.
+                // offsets_slice[batch_row_start+1..] holds end offsets for rows
+                // batch_row_start, batch_row_start+1, …; partition_point returns how many fit.
+                let rel = offsets_slice[batch_row_start + 1..].partition_point(|&v| v <= threshold);
+                if batch_row_start + rel >= ca.len() {
+                    // All remaining rows fit in one batch.
+                    break;
+                }
+                // Flush [batch_row_start, batch_row_start + flush_len). Use at least 1 so we
+                // never produce an empty batch when a single row exceeds IdxSize::MAX on its own.
+                let flush_len = rel.max(1);
+                let batch = ca.slice(batch_row_start as i64, flush_len);
+                batch_results.push(self.evaluate_on_list_chunked(&batch, state, is_agg)?);
+                batch_row_start += flush_len;
+                batch_inner_start = offsets_slice[batch_row_start] as i64;
             }
             // Flush the final batch.
             let batch = ca.slice(batch_row_start as i64, ca.len() - batch_row_start);

--- a/crates/polars-expr/src/expressions/eval.rs
+++ b/crates/polars-expr/src/expressions/eval.rs
@@ -84,6 +84,36 @@ impl EvalExpr {
         let flattened_len = flattened.len();
         let validity = ca.rechunk_validity();
 
+        // Batch when the total number of inner elements exceeds IdxSize::MAX to avoid
+        // truncating offset/length casts below. Each batch covers a contiguous row-range
+        // whose accumulated inner element count stays within IdxSize::MAX.
+        if flattened_len > IdxSize::MAX as usize {
+            let offsets = ca.offsets()?;
+            let mut batch_results: Vec<Column> = Vec::new();
+            let mut batch_row_start = 0usize;
+            let mut batch_inner_start: i64 = 0;
+
+            for i in 0..ca.len() {
+                let inner_end = unsafe { offsets.start_end_unchecked(i).1 } as i64;
+                // Flush the current batch before including row `i` if it would overflow.
+                if inner_end - batch_inner_start > IdxSize::MAX as i64 && i > batch_row_start {
+                    let batch = ca.slice(batch_row_start as i64, i - batch_row_start);
+                    batch_results.push(self.evaluate_on_list_chunked(&batch, state, is_agg)?);
+                    batch_row_start = i;
+                    batch_inner_start = unsafe { offsets.start_end_unchecked(i).0 } as i64;
+                }
+            }
+            // Flush the final batch.
+            let batch = ca.slice(batch_row_start as i64, ca.len() - batch_row_start);
+            batch_results.push(self.evaluate_on_list_chunked(&batch, state, is_agg)?);
+
+            let mut out = batch_results.remove(0);
+            for other in batch_results {
+                out.append_owned(other)?;
+            }
+            return Ok(out);
+        }
+
         // Fast path: fully elementwise expression without masked out values.
         if self.evaluation_is_elementwise && !may_fail_on_masked_out_elements {
             let mut state = state.clone();

--- a/crates/polars-expr/src/expressions/eval.rs
+++ b/crates/polars-expr/src/expressions/eval.rs
@@ -9,8 +9,8 @@ use polars_core::frame::DataFrame;
 #[cfg(feature = "dtype-array")]
 use polars_core::prelude::ArrayChunked;
 use polars_core::prelude::{
-    ChunkCast, ChunkExplode, ChunkNestingUtils, Column, Field, GroupPositions, GroupsType, IdxCa,
-    IntoColumn, ListBuilderTrait, ListChunked,
+    _set_check_length, ChunkCast, ChunkExplode, ChunkNestingUtils, Column, Field, GroupPositions,
+    GroupsType, IdxCa, IntoColumn, ListBuilderTrait, ListChunked,
 };
 use polars_core::schema::Schema;
 use polars_core::series::Series;
@@ -66,21 +66,21 @@ impl EvalExpr {
         state: &ExecutionState,
         is_agg: bool,
     ) -> PolarsResult<Column> {
-        let df = DataFrame::empty_with_height(ca.len());
-        let ca = ca
-            .trim_lists_to_normalized_offsets()
-            .map_or(Cow::Borrowed(ca), Cow::Owned);
-
         // Fast path: Empty or only nulls.
         if ca.null_count() == ca.len() {
             let name = self.output_field.name.clone();
             return Ok(Column::full_null(name, ca.len(), self.output_field.dtype()));
         }
+        let ca = ca
+            .trim_lists_to_normalized_offsets()
+            .map_or(Cow::Borrowed(ca), Cow::Owned);
 
-        let has_masked_out_values = LazyCell::new(|| ca.has_masked_out_values());
-        let may_fail_on_masked_out_elements = self.evaluation_is_fallible && *has_masked_out_values;
-
+        // SAFETY:
+        // We may temporarily create lengths that exceed IDXSIZE.
+        // If that happens we slice and process in batches.
+        unsafe { _set_check_length(false) };
         let flattened = ca.get_inner().into_column();
+        unsafe { _set_check_length(true) };
         let flattened_len = flattened.len();
         let validity = ca.rechunk_validity();
 
@@ -114,7 +114,7 @@ impl EvalExpr {
                 let batch = ca.slice(batch_row_start as i64, flush_len);
                 batch_results.push(self.evaluate_on_list_chunked(&batch, state, is_agg)?);
                 batch_row_start += flush_len;
-                batch_inner_start = offsets_slice[batch_row_start] as i64;
+                batch_inner_start = offsets_slice[batch_row_start];
             }
             // Flush the final batch.
             let batch = ca.slice(batch_row_start as i64, ca.len() - batch_row_start);
@@ -126,6 +126,11 @@ impl EvalExpr {
             }
             return Ok(out);
         }
+
+        let df = DataFrame::empty_with_height(ca.len());
+
+        let has_masked_out_values = LazyCell::new(|| ca.has_masked_out_values());
+        let may_fail_on_masked_out_elements = self.evaluation_is_fallible && *has_masked_out_values;
 
         // Fast path: fully elementwise expression without masked out values.
         if self.evaluation_is_elementwise && !may_fail_on_masked_out_elements {

--- a/crates/polars-expr/src/expressions/eval.rs
+++ b/crates/polars-expr/src/expressions/eval.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use arrow::bitmap::{Bitmap, BitmapBuilder};
 use polars_core::chunked_array::builder::AnonymousOwnedListBuilder;
-use polars_core::error::{PolarsResult, feature_gated};
+use polars_core::error::{PolarsResult, feature_gated, polars_ensure};
 use polars_core::frame::DataFrame;
 #[cfg(feature = "dtype-array")]
 use polars_core::prelude::ArrayChunked;
@@ -109,9 +109,8 @@ impl EvalExpr {
                     // All remaining rows fit in one batch.
                     break;
                 }
-                // Flush [batch_row_start, batch_row_start + flush_len). Use at least 1 so we
-                // never produce an empty batch when a single row exceeds IdxSize::MAX on its own.
-                let flush_len = rel.max(1);
+                let flush_len = rel;
+                polars_ensure!(flush_len > 0, ComputeError: "list elements larger than IdxSize::MAX are not supported");
                 let batch = ca.slice(batch_row_start as i64, flush_len);
                 batch_results.push_back(self.evaluate_on_list_chunked(&batch, state, is_agg)?);
                 batch_row_start += flush_len;
@@ -121,8 +120,8 @@ impl EvalExpr {
             let batch = ca.slice(batch_row_start as i64, ca.len() - batch_row_start);
             batch_results.push_back(self.evaluate_on_list_chunked(&batch, state, is_agg)?);
 
-            let mut out = batch_results.pop_front();
-            for other in batch_results {
+            let mut out = batch_results.pop_front().unwrap();
+            for other in batch_results.into_iter() {
                 out.append_owned(other)?;
             }
             return Ok(out);

--- a/crates/polars-expr/src/expressions/eval.rs
+++ b/crates/polars-expr/src/expressions/eval.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::cell::LazyCell;
+use std::collections::VecDeque;
 use std::sync::Arc;
 
 use arrow::bitmap::{Bitmap, BitmapBuilder};
@@ -76,7 +77,7 @@ impl EvalExpr {
             .map_or(Cow::Borrowed(ca), Cow::Owned);
 
         // SAFETY:
-        // We may temporarily create lengths that exceed IDXSIZE.
+        // We may temporarily create lengths that exceed IDXSIZE
         // If that happens we slice and process in batches.
         unsafe { _set_check_length(false) };
         let flattened = ca.get_inner().into_column();
@@ -91,7 +92,7 @@ impl EvalExpr {
             let offsets = ca.offsets()?;
             // offsets_slice[i] / offsets_slice[i+1] are the start/end of row i.
             let offsets_slice = offsets.as_slice();
-            let mut batch_results: Vec<Column> = Vec::new();
+            let mut batch_results: VecDeque<Column> = VecDeque::new();
             let mut batch_row_start = 0usize;
             let mut batch_inner_start: i64 = 0;
 
@@ -112,15 +113,15 @@ impl EvalExpr {
                 // never produce an empty batch when a single row exceeds IdxSize::MAX on its own.
                 let flush_len = rel.max(1);
                 let batch = ca.slice(batch_row_start as i64, flush_len);
-                batch_results.push(self.evaluate_on_list_chunked(&batch, state, is_agg)?);
+                batch_results.push_back(self.evaluate_on_list_chunked(&batch, state, is_agg)?);
                 batch_row_start += flush_len;
                 batch_inner_start = offsets_slice[batch_row_start];
             }
             // Flush the final batch.
             let batch = ca.slice(batch_row_start as i64, ca.len() - batch_row_start);
-            batch_results.push(self.evaluate_on_list_chunked(&batch, state, is_agg)?);
+            batch_results.push_back(self.evaluate_on_list_chunked(&batch, state, is_agg)?);
 
-            let mut out = batch_results.remove(0);
+            let mut out = batch_results.pop_front();
             for other in batch_results {
                 out.append_owned(other)?;
             }

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -1366,3 +1366,21 @@ def test_list_sample_fraction_with_replacement_27344() -> None:
 
     result = df.select(pl.col("x").list.sample(fraction=2, with_replacement=True))
     assert result["x"][0].to_list() == [1, 1]
+
+
+def test_list_eval_exceed_idx_size() -> None:
+    s = pl.Series([None])
+    s = s.new_from_index(0, 2**31)
+    assert (
+        pl.Series("a", [s, s.head(-1), s.head(-2)])
+        .to_frame()
+        .select(
+            count=pl.col("a").list.eval(pl.element().count()),
+            len=pl.col("a").list.eval(pl.element().len()),
+            unique=pl.col("a").list.eval(pl.element().unique()),
+        )
+    ).to_dict(as_series=False) == {
+        "count": [[0], [0], [0]],
+        "len": [[2147483648], [2147483647], [2147483646]],
+        "unique": [[None], [None], [None]],
+    }


### PR DESCRIPTION
This ensures we can safely dispatch to `list.eval` without risking overflowing `IdxSize`.  The invariant is that the list elements should be lower than `IdxSize::MAX`. 

Partial :robot: 