### PR TITLE
fix: Respect `nulls_last` for descending over(order_by) in `group_by().agg()`

### DIFF
--- a/crates/polars-expr/src/expressions/window.rs
+++ b/crates/polars-expr/src/expressions/window.rs
@@ -1,4 +1,3 @@
-use std::cmp::Ordering;
 use std::fmt::Write;
 
 use arrow::array::PrimitiveArray;
@@ -845,14 +844,12 @@ impl PhysicalExpr for WindowExpr {
                                     let is_valid_b =
                                         unsafe { validity.get_bit_unchecked(in_group_idx_b) };
 
-                                    if !is_valid_a | !is_valid_b {
-                                        if !is_valid_a & !is_valid_b {
-                                            return Ordering::Equal;
+                                    if !(is_valid_a & is_valid_b) {
+                                        let mut cmp = is_valid_a.cmp(&is_valid_b);
+                                        if options.nulls_last {
+                                            cmp = cmp.reverse();
                                         }
-                                        return match (options.nulls_last, !is_valid_a) {
-                                            (false, true) | (true, false) => Ordering::Less,
-                                            _ => Ordering::Greater,
-                                        };
+                                        return cmp;
                                     }
 
                                     let order_a = unsafe { arr.get_unchecked(in_group_idx_a) };

--- a/crates/polars-expr/src/expressions/window.rs
+++ b/crates/polars-expr/src/expressions/window.rs
@@ -844,23 +844,22 @@ impl PhysicalExpr for WindowExpr {
                                         unsafe { validity.get_bit_unchecked(in_group_idx_a) };
                                     let is_valid_b =
                                         unsafe { validity.get_bit_unchecked(in_group_idx_b) };
+
+                                    if !is_valid_a | !is_valid_b {
+                                        if !is_valid_a & !is_valid_b {
+                                            return Ordering::Equal;
+                                        }
+                                        return match (options.nulls_last, !is_valid_a) {
+                                            (false, true) | (true, false) => Ordering::Less,
+                                            _ => Ordering::Greater,
+                                        };
+                                    }
+
                                     let order_a = unsafe { arr.get_unchecked(in_group_idx_a) };
                                     let order_b = unsafe { arr.get_unchecked(in_group_idx_b) };
 
-                                    if !is_valid_a & !is_valid_b {
-                                        return Ordering::Equal;
-                                    }
-
                                     let mut cmp = order_a.cmp(&order_b);
-                                    if !is_valid_a {
-                                        cmp = Ordering::Less;
-                                    }
-                                    if !is_valid_b {
-                                        cmp = Ordering::Greater;
-                                    }
-                                    if options.descending
-                                        | ((!is_valid_a | !is_valid_b) & options.nulls_last)
-                                    {
+                                    if options.descending {
                                         cmp = cmp.reverse();
                                     }
                                     cmp

--- a/py-polars/tests/unit/operations/test_over.py
+++ b/py-polars/tests/unit/operations/test_over.py
@@ -183,6 +183,15 @@ def test_nulls_last_over_24989() -> None:
     assert_frame_equal(out, expected)
 
 
+def test_over_order_by_descending_nulls_agg_context() -> None:
+    df = pl.DataFrame({"g": ["a", "a", "a"], "v": [1, 2, 3], "d": [1, None, 2]})
+    expr = pl.col("v").cum_sum().over("g", order_by="d", descending=True)
+
+    result = df.group_by("g", maintain_order=True).agg(expr.alias("v"))
+
+    assert result["v"][0].to_list() == [6, 2, 5]
+
+
 def test_over_duplicate_partition_by_26921() -> None:
     df = pl.DataFrame({"x": [1, 2, 3]})
     with pytest.raises(pl.exceptions.DuplicateError):


### PR DESCRIPTION
Fixed the window order_by comparator to handle null placement and value ordering independently. `nulls_last` now solely controls where nulls sort, and `descending` only reverses comparisons between valid values.

Fixes #27485