### PR TITLE
fix(rust): Use try_new in StructArray construction in polars-json

### DIFF
--- a/crates/polars-json/src/json/deserialize.rs
+++ b/crates/polars-json/src/json/deserialize.rs
@@ -287,12 +287,12 @@ fn deserialize_struct<'a, A: Borrow<BorrowedValue<'a>>>(
         })
         .collect::<PolarsResult<Vec<_>>>()?;
 
-    Ok(StructArray::new(
+    StructArray::try_new(
         dtype.clone(),
         rows.len(),
         values,
         validity.into_opt_validity(),
-    ))
+    )
 }
 
 fn fill_array_from<B, T, A>(


### PR DESCRIPTION
## What

`deserialize_struct` constructs a `StructArray` after recursively deserializing each field. If a downstream `_deserialize` call widens a field's dtype (e.g. an integer-inferred field whose later rows contain `1.1`, where the per-field path produces a `Float64` array instead of the `Int64` the inferred struct dtype claims), the `StructArray::new` call validates dtype-against-children and panics inside `try_new(...).unwrap()`:

```
thread '<unnamed>' panicked at polars-arrow/src/array/struct_/mod.rs:122:56:
called `Result::unwrap()` on an `Err` value: ComputeError(ErrString(
  "The children DataTypes of a StructArray must equal the children data types.
   However, the field 29 has data type Int64 but the value has data type Float64"))
   ...
   5: deserialize_struct
              at polars-json/src/json/deserialize.rs:290:8
   6: _deserialize<simd_json::value::borrowed::Value>
              at polars-json/src/json/deserialize.rs:482:49
   7: deserialize
              at polars-json/src/json/deserialize.rs:499:17
```

This switches the call to `StructArray::try_new(...)` and propagates the error with `?` so attacker-controlled JSON bubbles up as a `PolarsError` instead of crashing the process. It's a routing fix, not the underlying correctness fix — schema inference vs. per-field deserialization disagreeing on dtype is a separate issue that deserves its own work.

```rust
// before
Ok(StructArray::new(
    dtype.clone(),
    rows.len(),
    values,
    validity.into_opt_validity(),
))

// after
StructArray::try_new(
    dtype.clone(),
    rows.len(),
    values,
    validity.into_opt_validity(),
)
```

## Repro

A cargo-fuzz harness driving `simd_json::to_borrowed_value` → `polars_json::infer` → `polars_json::deserialize` over random `&[u8]` reaches this in roughly 5 minutes from an empty corpus. The minimized repro is 3.5 KiB; the relevant pattern is "JSON array of objects where one field appears as integer in some rows and float in others, with enough total fields that the struct inference path is exercised". Happy to attach the bytes directly if useful.

After this PR the same input returns a `PolarsError::ComputeError(...)` (the same `try_new` rejection, just propagated cleanly) instead of panicking.

## Context

Surfaced from work towards [pola-rs/polars#27488](https://github.com/pola-rs/polars/issues/27488) (proposing OSS-Fuzz / cargo-fuzz coverage for the polars-arrow / polars-parquet / polars-json reader stack). The harness producing this repro is currently on my fork at [`fuzz/initial-harnesses`](https://github.com/masumi-ryugo/polars/tree/fuzz/initial-harnesses) — the same branch referenced from #27488.

## Tests

The polars-json crate currently has no in-tree unit tests for the deserialize path; rather than add one whose only purpose is `is_err()` against a 3.5 KiB byte string, the regression coverage will live in the fuzz harness once #27488 lands. Happy to add a smaller hand-crafted test inline if reviewers prefer.
