### PR TITLE
docs: Make expressions operations RNG deterministic

### DIFF
--- a/docs/source/src/rust/user-guide/expressions/operations.rs
+++ b/docs/source/src/rust/user-guide/expressions/operations.rs
@@ -74,10 +74,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --8<-- [end:bitwise]
 
     // --8<-- [start:count]
+    use rand::SeedableRng;
     use rand::distr::{Distribution, Uniform};
-    use rand::rng;
+    use rand::rngs::StdRng;
 
-    let mut rng = rng();
+    let mut rng = StdRng::seed_from_u64(42);
     let between = Uniform::new_inclusive(0, 100_000).unwrap();
     let arr: Vec<u32> = between.sample_iter(&mut rng).take(100_100).collect();
 


### PR DESCRIPTION
Related issue: #18072

This makes the Rust user-guide expression operations example deterministic by replacing the thread-local RNG with a seeded RNG.

The corresponding Python example already uses `np.random.seed(42)`, so this keeps the documentation example reproducible across languages.