### PR TITLE
perf: Make `is_in` row-group pruning precise on null-containing haystacks

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/predicates/column_expr.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/column_expr.rs
@@ -210,17 +210,18 @@ pub fn aexpr_to_column_predicates(
                             #[cfg(feature = "is_in")]
                             AExpr::Function {
                                 input,
-                                function: IRFunctionExpr::Boolean(IRBooleanFunction::IsIn { nulls_equal }),
+                                function: IRFunctionExpr::Boolean(IRBooleanFunction::IsIn { nulls_equal: _ }),
                                 options: _,
                             } => {
                                 into_column(input[0].node(), expr_arena)?;
 
-                                let values = super::try_extract_is_in_haystack(
+                                // `SpecializedColumnPredicate` is only invoked on non-null rows
+                                // (asserted in `polars-io`), so `had_nulls` needs no compensation.
+                                let (values, _had_nulls) = super::try_extract_is_in_haystack(
                                     input[1].node(),
                                     expr_arena,
                                     schema,
                                     &dtype,
-                                    *nulls_equal,
                                     usize::MAX,
                                 )?;
 

--- a/crates/polars-plan/src/plans/aexpr/predicates/column_expr.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/column_expr.rs
@@ -210,14 +210,12 @@ pub fn aexpr_to_column_predicates(
                             #[cfg(feature = "is_in")]
                             AExpr::Function {
                                 input,
-                                function: IRFunctionExpr::Boolean(IRBooleanFunction::IsIn { nulls_equal: _ }),
+                                function: IRFunctionExpr::Boolean(IRBooleanFunction::IsIn { nulls_equal }),
                                 options: _,
                             } => {
                                 into_column(input[0].node(), expr_arena)?;
 
-                                // `SpecializedColumnPredicate` is only invoked on non-null rows
-                                // (asserted in `polars-io`), so `had_nulls` needs no compensation.
-                                let (values, _had_nulls) = super::try_extract_is_in_haystack(
+                                let (values, had_nulls) = super::try_extract_is_in_haystack(
                                     input[1].node(),
                                     expr_arena,
                                     schema,
@@ -225,10 +223,16 @@ pub fn aexpr_to_column_predicates(
                                     usize::MAX,
                                 )?;
 
-                                let values = values.iter()
-                                    .map(|av| {
-                                        Scalar::new(dtype.clone(), av.into_static())
-                                    })
+                                // EqualOneOf describes the full set membership: include
+                                // Scalar::Null under nulls_equal=true so the specialization is
+                                // sound regardless of how the runtime chooses to invoke it.
+                                let values = values
+                                    .iter()
+                                    .map(|av| Scalar::new(dtype.clone(), av.into_static()))
+                                    .chain(
+                                        (*nulls_equal && had_nulls)
+                                            .then(|| Scalar::new(dtype.clone(), AnyValue::Null)),
+                                    )
                                     .collect();
 
                                 Some(SpecializedColumnPredicate::EqualOneOf(values))

--- a/crates/polars-plan/src/plans/aexpr/predicates/mod.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/mod.rs
@@ -37,13 +37,15 @@ fn get_binary_expr_col_and_lv<'a>(
 }
 
 /// Extract the haystack of `col.is_in(haystack)` as a flat element [`Series`]
-/// at planner time. Returns `None` (signals the caller to use its fallback path)
-/// when any of:
+/// at planner time, dropping any nulls (pyarrow-style). The returned `bool`
+/// is `true` iff a null was dropped; under `nulls_equal=true` the caller must
+/// compensate (typically AND'ing with `null_count(col) == 0`).
+///
+/// Returns `None` (signals the caller to use its fallback path) when any of:
 /// - `lv_node` is not an `AExpr::Literal` whose value is `AnyValue::List(_)`
 ///   (or `AnyValue::Array(_, _)` under `dtype-array`).
 /// - The list's element dtype is not equal to `column_dtype`.
-/// - `nulls_equal` is `false` and the list contains a null.
-/// - The list has more than `max_len` elements.
+/// - The list has more than `max_len` elements after null filtering.
 ///
 /// Shared by [`skip_batches`] (skip-batch predicate) and [`column_expr`]
 /// (per-column predicate).
@@ -53,9 +55,8 @@ pub(super) fn try_extract_is_in_haystack(
     expr_arena: &Arena<AExpr>,
     schema: &Schema,
     column_dtype: &DataType,
-    nulls_equal: bool,
     max_len: usize,
-) -> Option<Series> {
+) -> Option<(Series, bool)> {
     let lv = constant_evaluate(lv_node, expr_arena, schema, 0)??;
     let av = lv.to_any_value()?;
     let s = match av {
@@ -67,11 +68,10 @@ pub(super) fn try_extract_is_in_haystack(
     if s.dtype() != column_dtype {
         return None;
     }
-    if !nulls_equal && s.has_nulls() {
-        return None;
-    }
+    let had_nulls = s.has_nulls();
+    let s = if had_nulls { s.drop_nulls() } else { s };
     if s.len() > max_len {
         return None;
     }
-    Some(s)
+    Some((s, had_nulls))
 }

--- a/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
@@ -361,6 +361,10 @@ fn aexpr_to_skip_batch_predicate_rec(
                                 // }
                                 // Branch 1 mirrors the generic min==max fallback for const-col rgs.
                                 // `min(A) > X` / `max(A) < X` elide an `is_defined(stat) &&` guard.
+                                // Helper drops haystack nulls; the `(!lv.has_nulls() || null_count(A)
+                                // == 0)` gate is applied only when needed: per-case under
+                                // nulls_equal=true in the unrolled path (when a null was dropped),
+                                // and conditionally in the fallback path.
                                 const LIST_ITEM_LIMIT: usize = 100;
 
                                 let col = col.clone();
@@ -369,7 +373,6 @@ fn aexpr_to_skip_batch_predicate_rec(
                                     arena,
                                     schema,
                                     dtype,
-                                    nulls_equal,
                                     LIST_ITEM_LIMIT,
                                 );
 
@@ -388,23 +391,22 @@ fn aexpr_to_skip_batch_predicate_rec(
                                 let max_is_defined = is_stat_defined(col_max, dtype, arena);
 
                                 // all_nulls disjunct skips row groups whose column is entirely
-                                // null in this group. Sound for both paths — the outer null_case
-                                // wrapper below suppresses skip when haystack and column both have
-                                // nulls under nulls_equal=true.
+                                // null in this group. Sound for both paths; the per-case
+                                // null_count(A) == 0 guards suppress skip when haystack and column
+                                // both have nulls under nulls_equal=true.
                                 let col_nc = col!(null_count: col);
                                 let len = col!(len);
+                                let idx_zero = lv!(idx: 0);
                                 let all_nulls = col_nc.eq(len, arena);
+                                let col_has_no_nulls = col_nc.eq(idx_zero, arena);
 
-                                let inner = if let Some(values) = values {
-                                    // Per-element AND. Empty list folds to `true` (AND identity) —
-                                    // `is_in([])` is unconditionally false. Null elements (only
-                                    // possible under nulls_equal=true) are skipped so they don't
-                                    // poison the AND with nulls; the outer null_case gate handles
-                                    // the column-has-nulls × haystack-has-null interaction.
-                                    values.iter().fold(lv!(true), |acc, av| {
-                                        if av.is_null() {
-                                            return acc;
-                                        }
+                                let min_max_not_in = if let Some((values, had_nulls)) = values {
+                                    // Per-element AND. Empty list folds to `true` (AND identity);
+                                    // `is_in([])` is unconditionally false. The helper has dropped
+                                    // any haystack nulls; the per-case `null_count(A) == 0` guard
+                                    // below handles the column-has-nulls × haystack-has-null
+                                    // interaction under nulls_equal=true.
+                                    let inner = values.iter().fold(lv!(true), |acc, av| {
                                         let scalar = Scalar::new(dtype.clone(), av.into_static());
                                         let bi = AExprBuilder::lit_scalar(scalar, arena);
                                         let below =
@@ -412,7 +414,13 @@ fn aexpr_to_skip_batch_predicate_rec(
                                         let above =
                                             max_is_defined.and(col_max.lt(bi, arena), arena);
                                         acc.and(below.or(above, arena), arena)
-                                    })
+                                    });
+                                    let expr = all_nulls.or(inner, arena);
+                                    if had_nulls && nulls_equal {
+                                        expr.and(col_has_no_nulls, arena)
+                                    } else {
+                                        expr
+                                    }
                                 } else {
                                     let lv_min = lv_node_exploded.min(arena);
                                     let lv_max = lv_node_exploded.max(arena);
@@ -420,30 +428,31 @@ fn aexpr_to_skip_batch_predicate_rec(
                                         min_is_defined.and(col_min.gt(lv_max, arena), arena);
                                     let above =
                                         max_is_defined.and(col_max.lt(lv_min, arena), arena);
-                                    below.or(above, arena)
+                                    let inner = below.or(above, arena);
+                                    let expr = all_nulls.or(inner, arena);
+
+                                    if nulls_equal {
+                                        let lv_has_not_nulls = lv_node_exploded.has_no_nulls(arena);
+                                        let null_case =
+                                            lv_has_not_nulls.or(col_has_no_nulls, arena);
+                                        null_case.and(expr, arena)
+                                    } else {
+                                        expr
+                                    }
                                 };
-                                let expr = all_nulls.or(inner, arena);
-
-                                let col_has_no_nulls = col_nc.has_no_nulls(arena);
-
-                                let lv_has_not_nulls = lv_node_exploded.has_no_nulls(arena);
-                                let null_case = lv_has_not_nulls.or(col_has_no_nulls, arena);
-
-                                let min_max_is_in = null_case.and(expr, arena);
 
                                 let min_is_max = col_min.eq(col_max, arena); // Eq so that (None == None) == None
-                                let idx_zero = lv!(idx: 0);
-                                let has_no_nulls = col_nc.eq(idx_zero, arena);
 
                                 // The above case does always cover the fallback path. Since there
                                 // is code that relies on the `min==max` always filtering normally,
                                 // we add it here.
                                 let exact_not_in =
                                     col_min.is_in(lv_node, nulls_equal, arena).not(arena);
-                                let exact_not_in =
-                                    min_is_max.and(has_no_nulls, arena).and(exact_not_in, arena);
+                                let exact_not_in = min_is_max
+                                    .and(col_has_no_nulls, arena)
+                                    .and(exact_not_in, arena);
 
-                                Some(exact_not_in.or(min_max_is_in, arena).node())
+                                Some(exact_not_in.or(min_max_not_in, arena).node())
                             },
                             _ => None,
                         }

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -3531,6 +3531,39 @@ def test_is_in_string_pushdown_27416(
     assert "Predicate pushdown: reading 2 / 5 row groups" in capfd.readouterr().err
 
 
+@pytest.mark.may_fail_cloud  # reason: looks at stdout
+def test_is_in_string_pushdown_null_haystack(
+    plmonkeypatch: PlMonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    # Under `nulls_equal=True`, a null in the haystack matches column-null
+    # rows so the all-null row group must not be skipped; row groups that
+    # contain neither "1" nor "9" nor nulls are still pruned.
+    df = pl.DataFrame(
+        {
+            "sym": ["0", "1", "2", "3", None, None, "6", "7", "8", "9"],
+            "val": list(range(10)),
+        }
+    )
+    f = io.BytesIO()
+    df.write_parquet(f, row_group_size=2, statistics="full")
+    f.seek(0)
+
+    plmonkeypatch.setenv("POLARS_VERBOSE", "1")
+    capfd.readouterr()
+    out = (
+        pl.scan_parquet(f)
+        .filter(pl.col("sym").is_in([None, "1", "9"], nulls_equal=True))
+        .collect()
+    )
+
+    assert_frame_equal(
+        out.sort("val"),
+        pl.DataFrame({"sym": ["1", None, None, "9"], "val": [1, 4, 5, 9]}),
+    )
+    assert "Predicate pushdown: reading 3 / 5 row groups" in capfd.readouterr().err
+
+
 def test_roundtrip_int128() -> None:
     f = io.BytesIO()
     s = pl.Series("a", [1, 2, 3], pl.Int128)


### PR DESCRIPTION
Follow-up to #27475. The helper `try_extract_is_in_haystack` used to give up on haystacks with nulls under default `nulls_equal=false`. Now it drops them (like pyarrow does); under `nulls_equal=true`, if a null was dropped, we add `null_count(col) == 0` to the skip predicate so row groups with nulls aren't skipped.

Also fixes a hidden bug: `col_has_no_nulls = col_nc.has_no_nulls(arena)` computes a column-wide value that's always `true` against the stats table, so the check did nothing. Replaced with `col_nc.eq(idx_zero, arena)` so it checks per row group.