### PR TITLE
fix: Fix perf regression in `scan_csv` `select(len())` when collected on streaming engine

### DIFF
--- a/crates/polars-io/src/csv/read/parser.rs
+++ b/crates/polars-io/src/csv/read/parser.rs
@@ -2,8 +2,8 @@ use std::cmp;
 
 use memchr::memchr2_iter;
 use polars_buffer::Buffer;
-use polars_core::POOL;
 use polars_core::prelude::*;
+use polars_core::{ALLOW_RAYON_THREADS, POOL};
 use polars_error::feature_gated;
 use polars_utils::mmap::MMapSemaphore;
 use polars_utils::pl_path::PlRefPath;

--- a/crates/polars-io/src/csv/read/parser.rs
+++ b/crates/polars-io/src/csv/read/parser.rs
@@ -2,8 +2,8 @@ use std::cmp;
 
 use memchr::memchr2_iter;
 use polars_buffer::Buffer;
+use polars_core::POOL;
 use polars_core::prelude::*;
-use polars_core::{ALLOW_RAYON_THREADS, POOL};
 use polars_error::feature_gated;
 use polars_utils::mmap::MMapSemaphore;
 use polars_utils::pl_path::PlRefPath;

--- a/crates/polars-plan/src/plans/functions/mod.rs
+++ b/crates/polars-plan/src/plans/functions/mod.rs
@@ -135,15 +135,18 @@ impl FunctionIR {
     pub fn is_streamable(&self) -> bool {
         use FunctionIR::*;
         match self {
-            Rechunk => false,
-            FastCount { .. } | Unnest { .. } | Explode { .. } => true,
+            Unnest { .. } | Explode { .. } => true,
             #[cfg(feature = "pivot")]
             Unpivot { .. } => true,
+            Hint(_) => true,
+
             Opaque { streamable, .. } => *streamable,
             #[cfg(feature = "python")]
             OpaquePython(OpaquePythonUdf { streamable, .. }) => *streamable,
+
+            Rechunk => false,
+            FastCount { .. } => false,
             RowIndex { .. } => false,
-            Hint(_) => true,
         }
     }
 
@@ -209,7 +212,10 @@ impl FunctionIR {
                 scan_type,
                 alias,
                 cloud_options,
-            } => count::count_rows(sources, scan_type, alias.clone(), cloud_options.as_ref()),
+            } => {
+                debug_assert_eq!(df.shape(), (0, 0));
+                count::count_rows(sources, scan_type, alias.clone(), cloud_options.as_ref())
+            },
             Rechunk => {
                 df.rechunk_mut_par();
                 Ok(df)

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -8,7 +8,7 @@ use polars_core::prelude::{DataType, IntoColumn, PlHashMap, PlHashSet};
 use polars_core::scalar::Scalar;
 use polars_core::schema::Schema;
 use polars_core::series::Series;
-use polars_core::{SchemaExtPl, config};
+use polars_core::{ALLOW_RAYON_THREADS, SchemaExtPl, config};
 use polars_error::{PolarsResult, polars_ensure};
 use polars_expr::dispatch::function_expr_to_udf;
 use polars_expr::state::ExecutionState;
@@ -435,7 +435,27 @@ pub fn lower_ir(
                         .unwrap();
                         buffer
                     });
-                    let map = Arc::new(move |df| function.evaluate(df));
+
+                    let non_reentrant = match &function {
+                        FunctionIR::Opaque { .. } => false,
+                        #[cfg(feature = "python")]
+                        FunctionIR::OpaquePython { .. } => false,
+                        _ => true,
+                    };
+
+                    let map = Arc::new(move |df| {
+                        let _guard = RestoreGuard(ALLOW_RAYON_THREADS.replace(non_reentrant));
+
+                        struct RestoreGuard(bool);
+
+                        impl Drop for RestoreGuard {
+                            fn drop(&mut self) {
+                                ALLOW_RAYON_THREADS.set(self.0)
+                            }
+                        }
+
+                        function.evaluate(df)
+                    });
                     PhysNodeKind::InMemoryMap {
                         input: phys_input,
                         map,


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/26675

---

* Change `FastCount` to indicate `false` in `is_streamable()`, so that it reaches the non-streamable branch in function IR->PhysNode lowering.
  * For non-streamable function IRs, enables rayon when they are identified as non-reentrant

```python
import polars as pl

q = pl.scan_csv('.env/_data_out/10x50.csv').select(pl.len())

print(q.collect(engine='streaming'))
```

1.40.1
```python
python .env/z.py  0.90s user 1.37s system 92% cpu 2.448 total
```

This PR
```python
python .env/z.py  1.53s user 1.34s system 587% cpu 0.489 total
```
