### PR TITLE
perf: Pushdown slices to inputs on left/right/full join

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -21,11 +21,11 @@ use crate::utils::{check_input_node, has_aexpr};
 pub struct PredicatePushDown {
     // How many cache nodes a predicate may be pushed down to.
     // Normally this is 0. Only needed for CSPE.
-    pub(super) caches_pass_allowance: u32,
+    caches_pass_allowance: u32,
     nodes_scratch: ScratchUnitVec<Node>,
-    pub(super) new_streaming: bool,
+    new_streaming: bool,
     // Controls pushing filters past fallible projections
-    pub(super) maintain_errors: bool,
+    maintain_errors: bool,
 }
 
 impl PredicatePushDown {

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -8,6 +8,7 @@ pub use dynamic::{DynamicPred, DynamicPredWeakRef, PredicateExpr, TrivialPredica
 use polars_core::datatypes::PlHashMap;
 use polars_core::prelude::*;
 use polars_utils::idx_vec::UnitVec;
+use polars_utils::scratch_vec::ScratchUnitVec;
 use recursive::recursive;
 use utils::*;
 
@@ -17,41 +18,26 @@ use crate::prelude::optimizer::predicate_pushdown::group_by::process_group_by;
 use crate::prelude::optimizer::predicate_pushdown::join::process_join;
 use crate::utils::{check_input_node, has_aexpr};
 
-/// The struct is wrapped in a mod to prevent direct member access of `nodes_scratch`
-mod inner {
-    use polars_utils::arena::Node;
-    use polars_utils::idx_vec::UnitVec;
-    use polars_utils::unitvec;
+pub struct PredicatePushDown {
+    // How many cache nodes a predicate may be pushed down to.
+    // Normally this is 0. Only needed for CSPE.
+    pub(super) caches_pass_allowance: u32,
+    nodes_scratch: ScratchUnitVec<Node>,
+    pub(super) new_streaming: bool,
+    // Controls pushing filters past fallible projections
+    pub(super) maintain_errors: bool,
+}
 
-    pub struct PredicatePushDown {
-        // How many cache nodes a predicate may be pushed down to.
-        // Normally this is 0. Only needed for CSPE.
-        pub(super) caches_pass_allowance: u32,
-        nodes_scratch: UnitVec<Node>,
-        pub(super) new_streaming: bool,
-        // Controls pushing filters past fallible projections
-        pub(super) maintain_errors: bool,
-    }
-
-    impl PredicatePushDown {
-        pub fn new(maintain_errors: bool, new_streaming: bool) -> Self {
-            Self {
-                caches_pass_allowance: 0,
-                nodes_scratch: unitvec![],
-                new_streaming,
-                maintain_errors,
-            }
-        }
-
-        /// Returns shared scratch space after clearing.
-        pub(super) fn empty_nodes_scratch_mut(&mut self) -> &mut UnitVec<Node> {
-            self.nodes_scratch.clear();
-            &mut self.nodes_scratch
+impl PredicatePushDown {
+    pub fn new(maintain_errors: bool, new_streaming: bool) -> Self {
+        Self {
+            caches_pass_allowance: 0,
+            nodes_scratch: ScratchUnitVec::default(),
+            new_streaming,
+            maintain_errors,
         }
     }
 }
-
-pub use inner::PredicatePushDown;
 
 impl PredicatePushDown {
     pub(crate) fn block_at_cache(mut self, count: u32) -> Self {
@@ -116,7 +102,7 @@ impl PredicatePushDown {
                 &[],
                 &acc_predicates,
                 expr_arena,
-                self.empty_nodes_scratch_mut(),
+                self.nodes_scratch.get(),
                 maintain_errors,
                 lp_arena.get(input),
             )?;
@@ -278,7 +264,7 @@ impl PredicatePushDown {
                     &[(&tmp_key, predicate.clone())],
                     &acc_predicates,
                     expr_arena,
-                    self.empty_nodes_scratch_mut(),
+                    self.nodes_scratch.get(),
                     maintain_errors,
                     lp_arena.get(input),
                 )?

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -9,11 +9,11 @@ use crate::prelude::*;
 
 pub(super) struct SlicePushDown {
     nodes_scratch: ScratchUnitVec<Node>,
-    pub(super) maintain_errors: bool,
+    maintain_errors: bool,
     pub(crate) slice_node_in_optimized_plan: bool,
-    pub(super) ae_nodes_scratch: ScratchVec<Node>,
-    pub(crate) ae_slice_pd_state_scratch: ScratchVec<slice_pushdown_expr::State>,
-    pub(crate) ae_slice_pd_direct_col_slice_nodes: ScratchHashSet<Node>,
+    ae_nodes_scratch: ScratchVec<Node>,
+    ae_slice_pd_state_scratch: ScratchVec<slice_pushdown_expr::State>,
+    ae_slice_pd_direct_col_slice_nodes: ScratchHashSet<Node>,
 }
 
 impl SlicePushDown {

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -529,13 +529,27 @@ impl SlicePushDown {
                     };
                 }
 
+                let input_slice = if state.offset < 0 {
+                    IdxSize::try_from(-state.offset).ok().map(|len| State {
+                        offset: state.offset,
+                        len,
+                    })
+                } else {
+                    IdxSize::try_from(state.offset)
+                        .ok()
+                        .and_then(|offset| offset.checked_add(state.len))
+                        .map(|limit| State {
+                            offset: 0,
+                            len: limit,
+                        })
+                };
+
                 // Also pushdown slice for some joins. Only accept offset 0 or -1 as the slice gets
                 // double applied after pushdown.
                 let lp_left = self.pushdown(
                     input_left,
-                    (matches!(&options.args.how, JoinType::Left | JoinType::Full)
-                        && (-1i64..=0).contains(&state.offset))
-                    .then_some(state),
+                    input_slice
+                        .filter(|_| matches!(&options.args.how, JoinType::Left | JoinType::Full)),
                     lp_arena,
                     expr_arena,
                 )?;
@@ -543,9 +557,8 @@ impl SlicePushDown {
 
                 let lp_right = self.pushdown(
                     input_right,
-                    (matches!(&options.args.how, JoinType::Right | JoinType::Full)
-                        && (-1i64..=0).contains(&state.offset))
-                    .then_some(state),
+                    input_slice
+                        .filter(|_| matches!(&options.args.how, JoinType::Right | JoinType::Full)),
                     lp_arena,
                     expr_arena,
                 )?;

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -10,10 +10,10 @@ use crate::prelude::*;
 pub(super) struct SlicePushDown {
     nodes_scratch: ScratchUnitVec<Node>,
     maintain_errors: bool,
-    pub(crate) slice_node_in_optimized_plan: bool,
-    ae_nodes_scratch: ScratchVec<Node>,
-    ae_slice_pd_state_scratch: ScratchVec<slice_pushdown_expr::State>,
-    ae_slice_pd_direct_col_slice_nodes: ScratchHashSet<Node>,
+    pub(super) slice_node_in_optimized_plan: bool,
+    pub(super) ae_nodes_scratch: ScratchVec<Node>,
+    pub(super) ae_slice_pd_state_scratch: ScratchVec<slice_pushdown_expr::State>,
+    pub(super) ae_slice_pd_direct_col_slice_nodes: ScratchHashSet<Node>,
 }
 
 impl SlicePushDown {

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -529,10 +529,13 @@ impl SlicePushDown {
                     };
                 }
 
-                // first restart optimization in both inputs and get the updated LP
+                // Also pushdown slice for some joins. Only accept offset 0 or -1 as the slice gets
+                // double applied after pushdown.
                 let lp_left = self.pushdown(
                     input_left,
-                    matches!(&options.args.how, JoinType::Left | JoinType::Full).then_some(state),
+                    (matches!(&options.args.how, JoinType::Left | JoinType::Full)
+                        && (-1i64..=0).contains(&state.offset))
+                    .then_some(state),
                     lp_arena,
                     expr_arena,
                 )?;
@@ -540,7 +543,9 @@ impl SlicePushDown {
 
                 let lp_right = self.pushdown(
                     input_right,
-                    matches!(&options.args.how, JoinType::Right | JoinType::Full).then_some(state),
+                    (matches!(&options.args.how, JoinType::Right | JoinType::Full)
+                        && (-1i64..=0).contains(&state.offset))
+                    .then_some(state),
                     lp_arena,
                     expr_arena,
                 )?;

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -529,7 +529,8 @@ impl SlicePushDown {
                     };
                 }
 
-                let input_slice = if state.offset < 0 {
+                // For left/right/full joins we can push a limit.
+                let input_limit_slice = if state.offset < 0 {
                     IdxSize::try_from(-state.offset).ok().map(|len| State {
                         offset: state.offset,
                         len,
@@ -544,11 +545,9 @@ impl SlicePushDown {
                         })
                 };
 
-                // Also pushdown slice for some joins. Only accept offset 0 or -1 as the slice gets
-                // double applied after pushdown.
                 let lp_left = self.pushdown(
                     input_left,
-                    input_slice
+                    input_limit_slice
                         .filter(|_| matches!(&options.args.how, JoinType::Left | JoinType::Full)),
                     lp_arena,
                     expr_arena,
@@ -557,7 +556,7 @@ impl SlicePushDown {
 
                 let lp_right = self.pushdown(
                     input_right,
-                    input_slice
+                    input_limit_slice
                         .filter(|_| matches!(&options.args.how, JoinType::Right | JoinType::Full)),
                     lp_arena,
                     expr_arena,

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -547,10 +547,20 @@ impl SlicePushDown {
                 }
 
                 // first restart optimization in both inputs and get the updated LP
-                let lp_left = self.pushdown(input_left, None, lp_arena, expr_arena)?;
+                let lp_left = self.pushdown(
+                    input_left,
+                    matches!(&options.args.how, JoinType::Left | JoinType::Full).then_some(state),
+                    lp_arena,
+                    expr_arena,
+                )?;
                 let input_left = lp_arena.add(lp_left);
 
-                let lp_right = self.pushdown(input_right, None, lp_arena, expr_arena)?;
+                let lp_right = self.pushdown(
+                    input_right,
+                    matches!(&options.args.how, JoinType::Right | JoinType::Full).then_some(state),
+                    lp_arena,
+                    expr_arena,
+                )?;
                 let input_right = lp_arena.add(lp_right);
 
                 // then assign the slice state to the join operation

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -1,54 +1,37 @@
 use polars_core::prelude::*;
 use polars_utils::idx_vec::UnitVec;
+use polars_utils::scratch_vec::{ScratchUnitVec, ScratchVec};
 use polars_utils::slice_enum::Slice;
 use recursive::recursive;
 
 use crate::plans::optimizer::slice_pushdown_expr;
 use crate::prelude::*;
 
-mod inner {
-    use polars_core::prelude::ScratchHashSet;
-    use polars_utils::arena::Node;
-    use polars_utils::idx_vec::UnitVec;
-    use polars_utils::scratch_vec::ScratchVec;
-    use polars_utils::unitvec;
+pub(super) struct SlicePushDown {
+    nodes_scratch: ScratchUnitVec<Node>,
+    pub(super) maintain_errors: bool,
+    pub(crate) slice_node_in_optimized_plan: bool,
+    pub(super) ae_nodes_scratch: ScratchVec<Node>,
+    pub(crate) ae_slice_pd_state_scratch: ScratchVec<slice_pushdown_expr::State>,
+    pub(crate) ae_slice_pd_direct_col_slice_nodes: ScratchHashSet<Node>,
+}
 
-    use crate::plans::optimizer::slice_pushdown_expr;
-
-    pub struct SlicePushDown {
-        scratch: UnitVec<Node>,
-        pub(super) maintain_errors: bool,
-        pub(crate) slice_node_in_optimized_plan: bool,
-        pub(crate) ae_nodes_scratch: ScratchVec<Node>,
-        pub(crate) ae_slice_pd_state_scratch: ScratchVec<slice_pushdown_expr::State>,
-        pub(crate) ae_slice_pd_direct_col_slice_nodes: ScratchHashSet<Node>,
-    }
-
-    impl SlicePushDown {
-        pub fn new() -> Self {
-            Self {
-                scratch: unitvec![],
-                // We don't maintain errors on slice to make the behavior predictable across engines.
-                //
-                // Even if we enable maintain_errors (thereby preventing the slice from being pushed),
-                // the new-streaming engine still may not error due to early-stopping.
-                maintain_errors: false,
-                slice_node_in_optimized_plan: false,
-                ae_nodes_scratch: ScratchVec::default(),
-                ae_slice_pd_state_scratch: ScratchVec::default(),
-                ae_slice_pd_direct_col_slice_nodes: ScratchHashSet::default(),
-            }
-        }
-
-        /// Returns shared scratch space after clearing.
-        pub fn empty_nodes_scratch_mut(&mut self) -> &mut UnitVec<Node> {
-            self.scratch.clear();
-            &mut self.scratch
+impl SlicePushDown {
+    pub(super) fn new() -> Self {
+        Self {
+            nodes_scratch: ScratchUnitVec::default(),
+            // We don't maintain errors on slice to make the behavior predictable across engines.
+            //
+            // Even if we enable maintain_errors (thereby preventing the slice from being pushed),
+            // the new-streaming engine still may not error due to early-stopping.
+            maintain_errors: false,
+            slice_node_in_optimized_plan: false,
+            ae_nodes_scratch: ScratchVec::default(),
+            ae_slice_pd_state_scratch: ScratchVec::default(),
+            ae_slice_pd_direct_col_slice_nodes: ScratchHashSet::default(),
         }
     }
 }
-
-pub(super) use inner::SlicePushDown;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) struct State {
@@ -565,9 +548,7 @@ impl SlicePushDown {
 
                 // then assign the slice state to the join operation
 
-                let mut_options = Arc::make_mut(&mut options);
-
-                mut_options.args.slice = Some((state.offset, state.len as usize));
+                Arc::make_mut(&mut options).args.slice = Some((state.offset, state.len as usize));
 
                 Ok(Join {
                     input_left,
@@ -823,7 +804,7 @@ impl SlicePushDown {
                 if can_pushdown_slice_past_projections(
                     &expr,
                     expr_arena,
-                    self.empty_nodes_scratch_mut(),
+                    self.nodes_scratch.get(),
                     maintain_errors,
                 )
                 .1
@@ -861,7 +842,7 @@ impl SlicePushDown {
                     can_pushdown_slice_past_projections(
                         &exprs,
                         expr_arena,
-                        self.empty_nodes_scratch_mut(),
+                        self.nodes_scratch.get(),
                         maintain_errors,
                     );
 

--- a/crates/polars-utils/src/scratch_vec.rs
+++ b/crates/polars-utils/src/scratch_vec.rs
@@ -1,3 +1,5 @@
+use crate::UnitVec;
+
 /// Vec container with a getter that clears the vec.
 #[derive(Default)]
 pub struct ScratchVec<T>(Vec<T>);
@@ -9,6 +11,22 @@ impl<T> ScratchVec<T> {
 
     /// Clear the vec and return a mutable reference to it.
     pub fn get(&mut self) -> &mut Vec<T> {
+        self.0.clear();
+        &mut self.0
+    }
+}
+
+/// UnitVec container with a getter that clears the vec.
+#[derive(Default)]
+pub struct ScratchUnitVec<T>(UnitVec<T>);
+
+impl<T> ScratchUnitVec<T> {
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(UnitVec::with_capacity(capacity))
+    }
+
+    /// Clear the UnitVec and return a mutable reference to it.
+    pub fn get(&mut self) -> &mut UnitVec<T> {
         self.0.clear();
         &mut self.0
     }

--- a/crates/polars-utils/src/scratch_vec.rs
+++ b/crates/polars-utils/src/scratch_vec.rs
@@ -16,7 +16,7 @@ impl<T> ScratchVec<T> {
     }
 }
 
-/// UnitVec container with a getter that clears the vec.
+/// UnitVec container with a getter that clears the unitvec.
 #[derive(Default)]
 pub struct ScratchUnitVec<T>(UnitVec<T>);
 
@@ -25,7 +25,7 @@ impl<T> ScratchUnitVec<T> {
         Self(UnitVec::with_capacity(capacity))
     }
 
-    /// Clear the UnitVec and return a mutable reference to it.
+    /// Clear the unitvec and return a mutable reference to it.
     pub fn get(&mut self) -> &mut UnitVec<T> {
         self.0.clear();
         &mut self.0

--- a/py-polars/tests/unit/lazyframe/test_optimizations.py
+++ b/py-polars/tests/unit/lazyframe/test_optimizations.py
@@ -912,32 +912,30 @@ def test_slice_pushdown_expr_height_rules() -> None:
 
 
 def test_slice_pushdown_joins_27199() -> None:
-    lhs = pl.LazyFrame({"index": [0, 0]})
-    rhs = pl.LazyFrame({"index": [0, 0]})
+    lhs = pl.LazyFrame({"a": [0, 0]})
+    rhs = pl.LazyFrame({"a": [0, 0]})
 
     lhs = pl.scan_csv(lhs.collect().write_csv().encode())
     rhs = pl.scan_csv(rhs.collect().write_csv().encode())
 
     # Left join, push to left
-    q = lhs.join(rhs, on="index", how="left").head(1)
-
+    q = lhs.join(rhs, on="a", how="left").head(1)
     plan = q.explain()
 
     assert plan.index("SLICE") > plan.index("LEFT PLAN")
     assert q.collect().height == 1
 
     # Right join, push to right
-    q = rhs.join(lhs, on="index", how="right").head(1)
-
+    q = rhs.join(lhs, on="a", how="right").head(1)
     plan = q.explain()
 
     assert plan.index("SLICE") > plan.index("RIGHT PLAN")
     assert q.collect().height == 1
 
     # Full join, push to both
-    q = lhs.join(rhs, on="index", how="full").head(1)
-
+    q = lhs.join(rhs, on="a", how="full").head(1)
     plan = q.explain()
+
     i = plan.index("RIGHT PLAN ON")
     assert plan[:i].index("SLICE") > plan[:i].index("LEFT PLAN")
     assert plan[i:].index("SLICE") > plan[i:].index("RIGHT PLAN")
@@ -945,15 +943,55 @@ def test_slice_pushdown_joins_27199() -> None:
     assert q.collect().height == 1
 
 
+def test_slice_pushdown_joins_nonzero_offset_27199() -> None:
+    lhs = pl.LazyFrame({"a": [0, 1]}).with_row_index()
+    rhs = pl.LazyFrame({"a": [0, 0, 1, 1]}).with_row_index()
+
+    lhs = pl.scan_csv(lhs.collect().write_csv().encode())
+    rhs = pl.scan_csv(rhs.collect().write_csv().encode())
+
+    q = lhs.join(rhs, on="a", how="left", maintain_order="left").slice(1, 2)
+    plan = q.explain()
+
+    assert "SLICE: Positive { offset: 0, len: 3 }" in plan
+
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            [
+                pl.Series("index", [0, 1], dtype=pl.Int64),
+                pl.Series("a", [0, 1], dtype=pl.Int64),
+                pl.Series("index_right", [1, 2], dtype=pl.Int64),
+            ]
+        ),
+    )
+
+    q = lhs.join(rhs, on="a", how="left", maintain_order="left").slice(-3, 2)
+    plan = q.explain()
+
+    assert "SLICE: Negative { offset_from_end: 3, len: 3 }" in plan
+
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            [
+                pl.Series("index", [0, 1], dtype=pl.Int64),
+                pl.Series("a", [0, 1], dtype=pl.Int64),
+                pl.Series("index_right", [1, 2], dtype=pl.Int64),
+            ]
+        ),
+    )
+
+
 def test_slice_pushdown_from_expr_to_join_26553() -> None:
-    lhs = pl.LazyFrame({"index": [0, 0]})
-    rhs = pl.LazyFrame({"index": [0, 0]})
+    lhs = pl.LazyFrame({"a": [0, 0]})
+    rhs = pl.LazyFrame({"a": [0, 0]})
 
     lhs = pl.scan_csv(lhs.collect().write_csv().encode())
     rhs = pl.scan_csv(rhs.collect().write_csv().encode())
 
     # Left join, push to left
-    q = lhs.join(rhs, on="index", how="left").select(pl.last("*"))
+    q = lhs.join(rhs, on="a", how="left").select(pl.last("*"))
 
     plan = q.explain()
     assert plan.index("SLICE") > plan.index("LEFT PLAN")

--- a/py-polars/tests/unit/lazyframe/test_optimizations.py
+++ b/py-polars/tests/unit/lazyframe/test_optimizations.py
@@ -911,6 +911,56 @@ def test_slice_pushdown_expr_height_rules() -> None:
     assert_frame_equal(q.collect(), pl.DataFrame({"a": 3}))
 
 
+def test_slice_pushdown_joins_27199() -> None:
+    lhs = pl.LazyFrame({"index": [0, 0]})
+    rhs = pl.LazyFrame({"index": [0, 0]})
+
+    lhs = pl.scan_csv(lhs.collect().write_csv().encode())
+    rhs = pl.scan_csv(rhs.collect().write_csv().encode())
+
+    # Left join, push to left
+    q = lhs.join(rhs, on="index", how="left").head(1)
+
+    plan = q.explain()
+
+    assert plan.index("SLICE") > plan.index("LEFT PLAN")
+    assert q.collect().height == 1
+
+    # Right join, push to right
+    q = rhs.join(lhs, on="index", how="right").head(1)
+
+    plan = q.explain()
+
+    assert plan.index("SLICE") > plan.index("RIGHT PLAN")
+    assert q.collect().height == 1
+
+    # Full join, push to both
+    q = lhs.join(rhs, on="index", how="full").head(1)
+
+    plan = q.explain()
+    i = plan.index("RIGHT PLAN ON")
+    assert plan[:i].index("SLICE") > plan[:i].index("LEFT PLAN")
+    assert plan[i:].index("SLICE") > plan[i:].index("RIGHT PLAN")
+
+    assert q.collect().height == 1
+
+
+def test_slice_pushdown_from_expr_to_join_26553() -> None:
+    lhs = pl.LazyFrame({"index": [0, 0]})
+    rhs = pl.LazyFrame({"index": [0, 0]})
+
+    lhs = pl.scan_csv(lhs.collect().write_csv().encode())
+    rhs = pl.scan_csv(rhs.collect().write_csv().encode())
+
+    # Left join, push to left
+    q = lhs.join(rhs, on="index", how="left").select(pl.last("*"))
+
+    plan = q.explain()
+    assert plan.index("SLICE") > plan.index("LEFT PLAN")
+
+    assert q.collect().height == 1
+
+
 def test_forbid_flatten_sliced_union_27455() -> None:
     df = pl.DataFrame({"a": [0, 0, 0, 0, 0]})
     q1 = pl.concat([(df + 1).lazy(), (df + 10).lazy()])


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/27199
* Fixes https://github.com/pola-rs/polars/issues/26553

We can pushdown the `offset + len` range (or `abs(offset)` for negative slices) to individual sides on left/right/full joins.

E.g. -

<img width="721" height="218" alt="image" src="https://github.com/user-attachments/assets/22c0a9da-bc55-4f98-9127-ab37e227627d" />

