### PR TITLE
perf: Optimize `select(len())` for non-strict horizontal concat

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -1218,7 +1218,8 @@ impl ProjectionPushdownVisitor<'_, '_> {
 
                 let strict = options.strict;
 
-                // concat_horizontal([lf.select(len().alias(i)) for i, lf in enumerate(_)]).select(max_horizontal('*'))
+                // concat_horizontal([lf, ..]).select(len())
+                // -> concat_horizontal([lf.select(len().alias(i)) for i, lf in enumerate(_)]).select(max_horizontal('*'))
                 if out_edge.projection() == Projection::Len
                     && !strict
                     && let Some(select_len_ae_node) =

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -1221,13 +1221,14 @@ impl ProjectionPushdownVisitor<'_, '_> {
                 // concat_horizontal([lf.select(len().alias(i)) for i, lf in enumerate(_)]).select(max_horizontal('*'))
                 if out_edge.projection() == Projection::Len
                     && !strict
-                    && extract_select_len_expr(parent_ir, self.expr_arena).is_some()
+                    && let Some(select_len_ae_node) =
+                        extract_select_len_expr(parent_ir, self.expr_arena).map(|eir| eir.node())
                 {
                     let mut max_horizontal_inputs = Vec::with_capacity(inputs.len());
                     let mut new_output_schema = Schema::with_capacity(inputs.len());
                     let mut new_inputs = mem::take(inputs);
 
-                    for (i, node) in new_inputs.iter_mut().enumerate() {
+                    for (i, input_ir_node) in new_inputs.iter_mut().enumerate() {
                         let name = format_pl_smallstr!("{:016x}", i);
 
                         let exprs = vec![ExprIR::new(
@@ -1238,23 +1239,8 @@ impl ProjectionPushdownVisitor<'_, '_> {
                             .push(ExprIR::from_column_name(name.clone(), self.expr_arena));
                         new_output_schema.insert(name.clone(), DataType::IDX_DTYPE);
 
-                        let in_edge = &mut edges.inputs()[i];
-                        *in_edge.projection_mut() = Projection::Len;
-                        // The parent key is unchanged since we mutate the node in-place, but port
-                        // idx is changed to 0.
-                        in_edge.parent_key_and_port_mut().idx = 0;
-
-                        // Ensure newly added `select(len())` can be seen by input node.
-                        debug_assert!(
-                            extract_select_len_expr(
-                                storage.get_mut(in_edge.parent_key_and_port().node),
-                                self.expr_arena
-                            )
-                            .is_some()
-                        );
-
-                        *node = storage.add(IR::Select {
-                            input: *node,
+                        let select_ir_node = storage.add(IR::Select {
+                            input: *input_ir_node,
                             expr: exprs,
                             schema: Arc::new(Schema::from_iter([(name, DataType::IDX_DTYPE)])),
                             options: ProjectionOptions {
@@ -1263,31 +1249,37 @@ impl ProjectionPushdownVisitor<'_, '_> {
                                 should_broadcast: false,
                             },
                         });
+
+                        *input_ir_node = select_ir_node;
+
+                        let in_edge = &mut edges.inputs()[i];
+                        *in_edge.projection_mut() = Projection::Len;
+                        *in_edge.parent_key_and_port_mut() = ParentKeyAndPort {
+                            node: select_ir_node,
+                            idx: 0,
+                        };
+
+                        debug_assert!(
+                            extract_select_len_expr(
+                                storage.get_mut(in_edge.parent_key_and_port().node),
+                                self.expr_arena
+                            )
+                            .is_some()
+                        );
                     }
 
-                    let [
-                        IR::HConcat {
-                            inputs,
-                            options,
-                            schema,
-                        },
-                        parent_ir,
-                    ] = storage
-                        .get_disjoint_mut([key, edges.outputs()[0].parent_key_and_port().node])
-                    else {
+                    let IR::HConcat { inputs, schema, .. } = storage.get_mut(key) else {
                         unreachable!()
                     };
 
-                    mem::replace(inputs, new_inputs);
+                    *inputs = new_inputs;
                     *schema = Arc::new(new_output_schema);
 
                     let function = IRFunctionExpr::MaxHorizontal;
                     let options = function.function_options();
 
                     self.expr_arena.replace(
-                        extract_select_len_expr(parent_ir, self.expr_arena)
-                            .unwrap()
-                            .node(),
+                        select_len_ae_node,
                         AExpr::Function {
                             input: max_horizontal_inputs,
                             function,

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -23,8 +23,8 @@ use crate::plans::optimizer::projection_pushdown::edge::{
 };
 use crate::plans::projection_height::{ExprProjectionHeight, aexpr_projection_height_rec};
 use crate::plans::{
-    AExpr, ArenaExprIter, ExprIR, ExprOrigin, FunctionIR, IR, IRAggExpr, IRBuilder, OutputName,
-    det_join_schema,
+    AExpr, ArenaExprIter, ExprIR, ExprOrigin, FunctionIR, IR, IRAggExpr, IRBuilder, IRFunctionExpr,
+    OutputName, det_join_schema,
 };
 use crate::prelude::{DistinctOptionsIR, ProjectionOptions};
 use crate::traversal::edge_provider::NodeEdgesProvider;
@@ -524,6 +524,8 @@ impl ProjectionPushdownVisitor<'_, '_> {
                     }
                 {
                     let name = exprs[0].output_name().clone();
+                    // Force alias, this way downstream doesn't need to handle name when mutating
+                    // the AExpr node.
                     exprs[0].set_alias(name);
                     *edges.inputs()[0].projection_mut() = Projection::Len;
                     reuse_names_alloc(edges);
@@ -1203,9 +1205,100 @@ impl ProjectionPushdownVisitor<'_, '_> {
                 pushdown_with_added_names!(len_before_added_names)
             },
 
-            IR::HConcat {
-                inputs, options, ..
-            } => {
+            IR::HConcat { .. } => {
+                let [
+                    IR::HConcat {
+                        inputs, options, ..
+                    },
+                    parent_ir,
+                ] = storage.get_disjoint_mut([key, out_edge.parent_key_and_port().node])
+                else {
+                    unreachable!()
+                };
+
+                let strict = options.strict;
+
+                // concat_horizontal([lf.select(len().alias(i)) for i, lf in enumerate(_)]).select(max_horizontal('*'))
+                if out_edge.projection() == Projection::Len
+                    && !strict
+                    && extract_select_len_expr(parent_ir, self.expr_arena).is_some()
+                {
+                    let mut max_horizontal_inputs = Vec::with_capacity(inputs.len());
+                    let mut new_output_schema = Schema::with_capacity(inputs.len());
+                    let mut new_inputs = mem::take(inputs);
+
+                    for (i, node) in new_inputs.iter_mut().enumerate() {
+                        let name = format_pl_smallstr!("{:016x}", i);
+
+                        let exprs = vec![ExprIR::new(
+                            self.expr_arena.add(AExpr::Len),
+                            OutputName::Alias(name.clone()),
+                        )];
+                        max_horizontal_inputs
+                            .push(ExprIR::from_column_name(name.clone(), self.expr_arena));
+                        new_output_schema.insert(name.clone(), DataType::IDX_DTYPE);
+
+                        let in_edge = &mut edges.inputs()[i];
+                        *in_edge.projection_mut() = Projection::Len;
+                        // The parent key is unchanged since we mutate the node in-place, but port
+                        // idx is changed to 0.
+                        in_edge.parent_key_and_port_mut().idx = 0;
+
+                        // Ensure newly added `select(len())` can be seen by input node.
+                        debug_assert!(
+                            extract_select_len_expr(
+                                storage.get_mut(in_edge.parent_key_and_port().node),
+                                self.expr_arena
+                            )
+                            .is_some()
+                        );
+
+                        *node = storage.add(IR::Select {
+                            input: *node,
+                            expr: exprs,
+                            schema: Arc::new(Schema::from_iter([(name, DataType::IDX_DTYPE)])),
+                            options: ProjectionOptions {
+                                run_parallel: false,
+                                duplicate_check: false,
+                                should_broadcast: false,
+                            },
+                        });
+                    }
+
+                    let [
+                        IR::HConcat {
+                            inputs,
+                            options,
+                            schema,
+                        },
+                        parent_ir,
+                    ] = storage
+                        .get_disjoint_mut([key, edges.outputs()[0].parent_key_and_port().node])
+                    else {
+                        unreachable!()
+                    };
+
+                    mem::replace(inputs, new_inputs);
+                    *schema = Arc::new(new_output_schema);
+
+                    let function = IRFunctionExpr::MaxHorizontal;
+                    let options = function.function_options();
+
+                    self.expr_arena.replace(
+                        extract_select_len_expr(parent_ir, self.expr_arena)
+                            .unwrap()
+                            .node(),
+                        AExpr::Function {
+                            input: max_horizontal_inputs,
+                            function,
+                            options,
+                        },
+                    );
+
+                    reuse_names_alloc(edges);
+                    return;
+                }
+
                 let (..) = projected_names_subset_or_return!();
 
                 let mut inputs = mem::take(inputs);

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -754,23 +754,24 @@ impl ProjectionPushdownVisitor<'_, '_> {
                         break 'len_to_predicate_sum;
                     }
 
-                    let Some(expr) = extract_select_len_expr(
+                    let Some(select_len_ae_node) = extract_select_len_expr(
                         storage.get_mut(out_edge.parent_key_and_port().node),
                         self.expr_arena,
-                    ) else {
+                    )
+                    .map(|eir| eir.node()) else {
                         break 'len_to_predicate_sum;
                     };
 
-                    let sum_expr = self
-                        .expr_arena
-                        .add(AExpr::Agg(IRAggExpr::Sum(predicate_node)));
-
-                    expr.set_node(sum_expr);
+                    self.expr_arena.replace(
+                        select_len_ae_node,
+                        AExpr::Agg(IRAggExpr::Sum(predicate_node)),
+                    );
 
                     *out_edge.projection_mut() = Projection::Names;
                     let names = out_edge.names_mut();
                     names.clear();
-                    names.extend(aexpr_to_leaf_names_iter(sum_expr, self.expr_arena).cloned());
+                    names
+                        .extend(aexpr_to_leaf_names_iter(predicate_node, self.expr_arena).cloned());
 
                     unlink_current_node_and_return!(input)
                 }

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -1219,7 +1219,7 @@ impl ProjectionPushdownVisitor<'_, '_> {
                 let strict = options.strict;
 
                 // concat_horizontal([lf, ..]).select(len())
-                // -> concat_horizontal([lf.select(len().alias(i)) for i, lf in enumerate(_)]).select(max_horizontal('*'))
+                // -> concat_horizontal([lf.select(len().alias(i)) for i, lf in enumerate(..)]).select(max_horizontal('*'))
                 if out_edge.projection() == Projection::Len
                     && !strict
                     && let Some(select_len_ae_node) =

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -1230,7 +1230,7 @@ impl ProjectionPushdownVisitor<'_, '_> {
                     let mut new_inputs = mem::take(inputs);
 
                     for (i, input_ir_node) in new_inputs.iter_mut().enumerate() {
-                        let name = format_pl_smallstr!("{:016x}", i);
+                        let name = format_pl_smallstr!("__POLARS_{:010x}", i);
 
                         let exprs = vec![ExprIR::new(
                             self.expr_arena.add(AExpr::Len),

--- a/py-polars/tests/unit/lazyframe/test_projections.py
+++ b/py-polars/tests/unit/lazyframe/test_projections.py
@@ -834,6 +834,23 @@ def test_projection_pushdown_select_len() -> None:
     assert q.collect().item() == 1
 
 
+def test_projection_pushdown_nonstrict_hconcat_select_len() -> None:
+    q = pl.concat(
+        [
+            pl.LazyFrame({"a": [0, 1, 2]}),
+            pl.LazyFrame({"b": [0, 1, 2, 3, 4]}),
+        ],
+        how="horizontal",
+    ).select(pl.len())
+    plan = q.explain()
+
+    assert plan.index("len()") > plan.index("HCONCAT")
+    assert_frame_equal(
+        q.collect(),
+        pl.Series("len", [5], dtype=pl.get_index_type()).to_frame(),
+    )
+
+
 def test_projection_pushdown_non_projected_sort_column() -> None:
     lf = pl.LazyFrame({"a": [0, 1, 2], "b": [1, 2, 3]})
     q = lf.sort("a", descending=True).unique("b", maintain_order=True).drop("a")


### PR DESCRIPTION
For non-strict hconcat the output length is defined as the max height across all inputs, so we can rewrite to pushdown `Projection::Len` to all inputs.

Before / After

<img width="1048" height="244" alt="image" src="https://github.com/user-attachments/assets/12a909f0-d21a-4753-b1df-62b9bfd17def" />

