### PR TITLE
fix: Do not reverse dataframes when sorting with all-null key columns

### DIFF
--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -1039,6 +1039,8 @@ impl Column {
         }
 
         if self.null_count() == self.len() {
+            // If all key values are null, then they are all equal,
+            // so we can just return the original dataframe.
             return IdxCa::from_iter_values(self.name().clone(), 0..self.len() as IdxSize);
         }
 

--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -1039,14 +1039,7 @@ impl Column {
         }
 
         if self.null_count() == self.len() {
-            // We might need to maintain order so just respect the descending parameter.
-            let values = if options.descending {
-                (0..self.len() as IdxSize).rev().collect()
-            } else {
-                (0..self.len() as IdxSize).collect()
-            };
-
-            return IdxCa::from_vec(self.name().clone(), values);
+            return IdxCa::from_iter_values(self.name().clone(), 0..self.len() as IdxSize);
         }
 
         let is_sorted = Some(self.is_sorted_flag());

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -1300,3 +1300,19 @@ def test_sort_already_sorted_no_rechunk_25733() -> None:
 
     result = df.sort("a")
     assert result.n_chunks() == 2  # No rechunk happened
+
+
+@pytest.mark.parametrize("descending", [False, True])
+@pytest.mark.parametrize("nulls_last", [False, True])
+def test_sort_maintain_order_all_nulls_27514(
+    descending: bool, nulls_last: bool
+) -> None:
+    df = pl.DataFrame(
+        {"a": [None, None, None, None]}, schema={"a": pl.Int32}
+    ).with_row_index()
+    result = (
+        df.lazy()
+        .sort("a", descending=descending, nulls_last=nulls_last, maintain_order=True)
+        .collect()
+    )
+    assert_frame_equal(result, df)


### PR DESCRIPTION
Fixes #27514

:robot: The cause of the bug was found using AI, but the code was updated by myself.

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
