### PR TITLE
 feat(python): Add `LazyFrame.execute`

### DIFF
--- a/py-polars/docs/source/reference/lazyframe/index.rst
+++ b/py-polars/docs/source/reference/lazyframe/index.rst
@@ -16,6 +16,7 @@ This page gives an overview of all public LazyFrame methods.
    miscellaneous
    in_process
    gpu_engine
+   query_result
 
 .. _lazyframe:
 

--- a/py-polars/docs/source/reference/lazyframe/miscellaneous.rst
+++ b/py-polars/docs/source/reference/lazyframe/miscellaneous.rst
@@ -13,6 +13,7 @@ Miscellaneous
     LazyFrame.collect_async
     LazyFrame.collect_schema
     LazyFrame.collect_batches
+    LazyFrame.execute
     LazyFrame.sink_batches
     LazyFrame.lazy
     LazyFrame.map_batches

--- a/py-polars/docs/source/reference/lazyframe/query_result.rst
+++ b/py-polars/docs/source/reference/lazyframe/query_result.rst
@@ -1,0 +1,14 @@
+===========
+QueryResult
+===========
+
+The result of a Polars query, returned by `LazyFrame.execute()`.
+
+.. currentmodule:: polars.lazyframe.query_result
+
+.. autosummary::
+   :toctree: api/
+
+    QueryResult.head
+    QueryResult.n_rows_total
+    QueryResult.lazy

--- a/py-polars/src/polars/lazyframe/__init__.py
+++ b/py-polars/src/polars/lazyframe/__init__.py
@@ -1,9 +1,12 @@
 from polars.lazyframe.engine_config import GPUEngine
 from polars.lazyframe.frame import LazyFrame
 from polars.lazyframe.opt_flags import QueryOptFlags
+from polars.lazyframe.query_result import QueryResult, SingleNodeQueryResult
 
 __all__ = [
     "GPUEngine",
     "LazyFrame",
     "QueryOptFlags",
+    "QueryResult",
+    "SingleNodeQueryResult",
 ]

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -2233,6 +2233,111 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         return df, timings
 
+    @unstable()
+    def execute(
+        self,
+        *,
+        optimizations: QueryOptFlags = ...,
+        engine: EngineType = "auto",
+        **_kwargs: Any,
+    ) -> Any:
+        """
+        Execute the query into a `QueryResult`.
+
+        This method of materializing a `LazyFrame` makes no guarantees as to where
+        the result is materialized. This can be on the GPU for the GPU-engine,
+        on the cluster or remote storage for the distributed engine and the streaming
+        engine could spill the result if it needed to.
+
+        The `QueryResult` can always be consumed as a new `LazyFrame` by calling `.lazy`
+
+
+        Parameters
+        ----------
+        engine
+            Select the engine used to process the query, optional.
+            At the moment, if set to `"auto"` (default), the query
+            is run using the polars in-memory engine. Polars will also
+            attempt to use the engine set by the `POLARS_ENGINE_AFFINITY`
+            environment variable. If it cannot run the query using the
+            selected engine, the query is run using the polars in-memory
+            engine. If set to `"gpu"`, the GPU engine is used. Fine-grained
+            control over the GPU engine, for example which device to use
+            on a system with multiple devices, is possible by providing a
+            :class:`~.GPUEngine` object with configuration options.
+
+            .. note::
+               GPU mode is considered **unstable**. Not all queries will run
+               successfully on the GPU, however, they should fall back transparently
+               to the default engine if execution is not supported.
+
+               Running with `POLARS_VERBOSE=1` will provide information if a query
+               falls back (and why).
+
+            .. note::
+               The GPU engine does not support streaming, if streaming is enabled, 
+               then GPU execution is switched off.
+        optimizations
+            The optimization passes done during query optimization.
+
+            .. warning::
+                This functionality is considered **unstable**. It may be changed
+                at any point without it being considered a breaking change.
+
+        Returns
+        -------
+        DataFrame
+
+        See Also
+        --------
+        explain : Print the query plan that is evaluated with collect.
+        profile : Collect the LazyFrame and time each node in the computation graph.
+        polars.collect_all : Collect multiple LazyFrames at the same time.
+        polars.Config.set_streaming_chunk_size : Set the size of streaming batches.
+
+        Examples
+        --------
+        >>> lf = pl.LazyFrame(
+        ...     {
+        ...         "a": ["a", "b", "a", "b", "b", "c"],
+        ...         "b": [1, 2, 3, 4, 5, 6],
+        ...         "c": [6, 5, 4, 3, 2, 1],
+        ...     }
+        ... )
+        >>> lf.group_by("a").agg(pl.all().sum()).collect()  # doctest: +SKIP
+        shape: (3, 3)
+        ┌─────┬─────┬─────┐
+        │ a   ┆ b   ┆ c   │
+        │ --- ┆ --- ┆ --- │
+        │ str ┆ i64 ┆ i64 │
+        ╞═════╪═════╪═════╡
+        │ a   ┆ 4   ┆ 10  │
+        │ b   ┆ 11  ┆ 10  │
+        │ c   ┆ 6   ┆ 1   │
+        └─────┴─────┴─────┘
+
+        Collect in streaming mode
+
+        >>> lf.group_by("a").agg(pl.all().sum()).collect(
+        ...     engine="streaming"
+        ... )  # doctest: +SKIP
+        shape: (3, 3)
+        ┌─────┬─────┬─────┐
+        │ a   ┆ b   ┆ c   │
+        │ --- ┆ --- ┆ --- │
+        │ str ┆ i64 ┆ i64 │
+        ╞═════╪═════╪═════╡
+        │ a   ┆ 4   ┆ 10  │
+        │ b   ┆ 11  ┆ 10  │
+        │ c   ┆ 6   ┆ 1   │
+        └─────┴─────┴─────┘
+
+        Collect in GPU mode
+
+        """
+        engine = _select_engine(engine)
+        pass
+
     @overload
     def collect(
         self,

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -102,6 +102,7 @@ from polars.lazyframe.engine_config import GPUEngine
 from polars.lazyframe.group_by import LazyGroupBy
 from polars.lazyframe.in_process import InProcessQuery
 from polars.lazyframe.opt_flags import DEFAULT_QUERY_OPT_FLAGS, forward_old_opt_flags
+from polars.lazyframe.query_result import SingleNodeQueryResult
 from polars.schema import Schema
 from polars.selectors import by_dtype, expand_selector
 
@@ -166,6 +167,7 @@ if TYPE_CHECKING:
     )
     from polars.config import TableFormatNames
     from polars.io.cloud import CredentialProviderFunction
+    from polars.lazyframe.query_result import QueryResult
 
     if sys.version_info >= (3, 11):
         from typing import Self
@@ -2237,10 +2239,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     def execute(
         self,
         *,
-        optimizations: QueryOptFlags = ...,
+        optimizations: QueryOptFlags = DEFAULT_QUERY_OPT_FLAGS,
         engine: EngineType = "auto",
         **_kwargs: Any,
-    ) -> Any:
+    ) -> QueryResult:
         """
         Execute the query into a `QueryResult`.
 
@@ -2275,7 +2277,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                falls back (and why).
 
             .. note::
-               The GPU engine does not support streaming, if streaming is enabled, 
+               The GPU engine does not support streaming, if streaming is enabled,
                then GPU execution is switched off.
         optimizations
             The optimization passes done during query optimization.
@@ -2335,8 +2337,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         Collect in GPU mode
 
         """
-        engine = _select_engine(engine)
-        pass
+        df = self.collect(optimizations=optimizations, engine=engine)
+        return SingleNodeQueryResult(df)
 
     @overload
     def collect(

--- a/py-polars/src/polars/lazyframe/query_result.py
+++ b/py-polars/src/polars/lazyframe/query_result.py
@@ -1,0 +1,25 @@
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from polars._utils.wrap import wrap_df
+
+
+class QueryResult:
+    """The result of a Polars query.
+
+    .. note::
+     This object should not be instantiated directly by the user.
+
+    .. warning::
+        This functionality is considered **unstable**. It may be changed
+        at any point without it being considered a breaking change.
+    """
+
+    def __init__(
+        self,
+    ):
+        pass
+
+

--- a/py-polars/src/polars/lazyframe/query_result.py
+++ b/py-polars/src/polars/lazyframe/query_result.py
@@ -1,12 +1,14 @@
-
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-from polars._utils.wrap import wrap_df
+if TYPE_CHECKING:
+    from polars.dataframe import DataFrame
+    from polars.lazyframe import LazyFrame
 
 
-class QueryResult:
+@runtime_checkable
+class QueryResult(Protocol):
     """The result of a Polars query.
 
     .. note::
@@ -17,9 +19,74 @@ class QueryResult:
         at any point without it being considered a breaking change.
     """
 
-    def __init__(
-        self,
-    ):
-        pass
+    @property
+    def head(self) -> DataFrame | None:
+        """The first n rows of the result."""
+        ...
+
+    @property
+    def n_rows_total(self) -> int | None:
+        """Total rows that are outputted by the result."""
+        ...
+
+    def lazy(self) -> LazyFrame:
+        """Convert the `QueryResult` into a `LazyFrame`."""
+        ...
 
 
+class SingleNodeQueryResult:
+    """The result of a Polars query.
+
+    .. note::
+     This object should not be instantiated directly by the user.
+
+    .. warning::
+        This functionality is considered **unstable**. It may be changed
+        at any point without it being considered a breaking change.
+    """
+
+    def __init__(self, df: DataFrame) -> None:
+        self._df = df
+
+    @property
+    def head(self) -> DataFrame | None:
+        """The first n rows of the result."""
+        return self._df.head()
+
+    @property
+    def n_rows_total(self) -> int | None:
+        """Total rows that are outputted by the result."""
+        return self._df.height
+
+    def lazy(self) -> LazyFrame:
+        """Convert the `QueryResult` into a `LazyFrame`."""
+        return self._df.lazy()
+
+    def __repr__(self) -> str:
+        import polars as pl
+
+        with pl.Config(tbl_hide_dataframe_shape=True):
+            return f"""
+        QueryResult; head:
+            {self.head}
+        """
+
+    def _repr_html_(self) -> str:
+        """Format output data in HTML for display in Jupyter Notebooks."""
+        import polars as pl
+
+        with pl.Config(tbl_hide_dataframe_shape=True):
+            head_html = self._df.head()._repr_html_()
+
+        head_section = f"""
+        <div style="margin-bottom: 16px;">
+            <h3 style="margin: 0 0 8px 0; color: #333; font-family: sans-serif; font-size: 14px; font-weight: 600;">QueryResult; head:</h3>
+            <div>{head_html}</div>
+        </div>
+        """
+
+        return f"""
+        <div style="padding: 12px; border: 1px solid #ddd; border-radius: 4px; background: white;">
+            {head_section}
+        </div>
+        """

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -1838,3 +1838,9 @@ def test_sum_decimal_widens_precision_27269() -> None:
         schema={"x": pl.Decimal(15, 2)},
     )
     assert lf.select(pl.sum("x")).collect_schema()["x"] == pl.Decimal(38, 2)
+
+
+def test_execute() -> None:
+    assert pl.LazyFrame({"a": [1, 2, 3, 4]}).select(pl.col.a).execute().lazy().select(
+        sum=pl.col.a.sum(), count=pl.len()
+    ).collect().to_dict(as_series=False) == {"sum": [10], "count": [4]}


### PR DESCRIPTION
Adds an execution method that does not define where the result lives. This can be useful in distributed queries, on the gpu or streaming larger than memory results.

Data can be stored remotely, remain on the gpu or spilled to disk if needed.