### PR TITLE
docs: Add Kubernetes documentation in user-guide

### DIFF
--- a/docs/source/polars-cloud/index.md
+++ b/docs/source/polars-cloud/index.md
@@ -44,5 +44,6 @@ Polars Cloud is available to try with a 30 day free trial. You can sign up on
 
 ![AWS logo](https://raw.githubusercontent.com/pola-rs/polars-static/refs/heads/master/polars_cloud/aws-logo.svg)
 
-Polars Cloud is available on AWS. Other cloud providers and on-premises solutions are on the roadmap
-and will become available in the upcoming months.
+Polars Cloud is available on AWS. Other cloud providers are on the roadmap and will become available
+in the upcoming months. Also see [Polars On-Prem](/polars-on-premises/) for running Polars Cloud on
+your own infrastructure.

--- a/docs/source/polars-on-premises/bare-metal/configuration/resource-limits.md
+++ b/docs/source/polars-on-premises/bare-metal/configuration/resource-limits.md
@@ -11,7 +11,7 @@ executor process. Polars On-Prem will already automatically configure `oom-score
 executor process.
 
 If there are other system critical processes, we recommend either delegating a cgroup to Polars
-On-Prem, or manually setting up cgroup limits for the entire Polars on-premises service.
+On-Prem, or manually setting up cgroup limits for the entire Polars On-Prem service.
 
 ### Delegating cgroup to Polars On-Prem
 

--- a/docs/source/polars-on-premises/bare-metal/getting-started.md
+++ b/docs/source/polars-on-premises/bare-metal/getting-started.md
@@ -30,7 +30,7 @@ $ curl -L 'https://get.onprem.pola.rs?version=0.1.0' --data $LICENSE_KEY --outpu
 ```
 
 See the [Python Environments page](/polars-on-premises/bare-metal/python-environment) for more
-information about setting up Polars On-Premises in your environment.
+information about setting up Polars On-Prem in your environment.
 
 ## Reading the license
 

--- a/docs/source/polars-on-premises/bare-metal/getting-started.md
+++ b/docs/source/polars-on-premises/bare-metal/getting-started.md
@@ -22,8 +22,7 @@ The `polars-on-premises` command will then be available within your virtual envi
 #### Downloading the server binary only
 
 You may also download the binary directly using the curl command below. Note that this still
-requires your system to have a Python interpreter available, and Polars to be installed. There are
-also some
+requires your system to have a Python interpreter available, and Polars to be installed.
 
 ```shell
 $ export LICENSE_KEY=$(cat license.json)

--- a/docs/source/polars-on-premises/integrations/openlineage.md
+++ b/docs/source/polars-on-premises/integrations/openlineage.md
@@ -9,7 +9,7 @@ orchestrator such as Airflow or Dagster.
 
 !!! note "OpenLineage is only supported for Polars On-Prem"
 
-    Note that OpenLineage is currently only supported for Polars On-Prem and not for Polars Cloud. Obtain a license for Polars on-premises by [signing up here](https://w0lzyfh2w8o.typeform.com/to/zuoDgoMv).
+    Note that OpenLineage is currently only supported for Polars On-Prem and not for Polars Cloud. Obtain a license for Polars On-Prem by [signing up here](https://w0lzyfh2w8o.typeform.com/to/zuoDgoMv).
 
 ## Setup
 

--- a/docs/source/polars-on-premises/kubernetes/configuration/anonymous-results.md
+++ b/docs/source/polars-on-premises/kubernetes/configuration/anonymous-results.md
@@ -1,0 +1,35 @@
+# Anonymous results
+
+For remote polars queries without a specific output sink, Polars Cloud can automatically add
+persistent sink. We call these sinks "anonymous results" sinks. Infrastructure-wise, these sinks are
+backed by S3-compatible storage, which should be accessible from all worker nodes and the python
+client. The data written to this location is not automatically deleted, so you need to configure a
+retention policy for this data yourself. You may configure the credentials as shown below. The key
+names correspond to the
+[`storage_options` parameter in `scan_parquet`](https://docs.pola.rs/api/python/stable/reference/api/polars.scan_parquet.html)
+(e.g. `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `aws_region`). We currently
+only support the AWS keys of the `storage_options` dictionary, but note that you can use any other
+cloud provider that supports the S3 API, such as MinIO or DigitalOcean Spaces.
+
+!!! note "Difference between Anonymous Users and Anonymous Results"
+
+    Note that Anonymous Users and Anonymous Results are different. Anonymous Users refer to queries that are submitted without a username, while Anonymous Results refer to queries without an explicit output sink.
+
+```yaml
+anonymousResults:
+  s3:
+    enabled: true
+    endpoint: "s3://my-bucket/path/to/dir"
+    options:
+      - name: aws_access_key_id
+        valueFrom:
+          secretKeyRef:
+            name: my-s3-secret
+            key: accessKeyId
+      - name: aws_endpoint_url
+        value: "http://localhost:9000"
+  # etc.
+```
+
+If you wish to disable anonymous results, keep `anonymousResults.s3.enabled: false`. This will
+ensure that all query result output locations need to be explicitly set by users.

--- a/docs/source/polars-on-premises/kubernetes/configuration/anonymous-users.md
+++ b/docs/source/polars-on-premises/kubernetes/configuration/anonymous-users.md
@@ -1,0 +1,18 @@
+# Anonymous users
+
+By default, queries can be anonymously submitted to the scheduler. In the dashboard, queries
+submitted anonymously are shown as `Anonymous User` in the query list. To attach a username to a
+query, you can use the `POLARS_CLOUD_USER_NAME` environment variable or the
+`pc.Config.set_user_name()` method.
+
+```python
+import polars_cloud as pc
+pc.Config.set_user_name("user@example.com")
+```
+
+To deny all queries that don't have any username attached, you can set the `denyAnonymousUsers`
+value to `true`.
+
+!!! note "Difference between Anonymous Users and Anonymous Results"
+
+    Note that Anonymous Users and Anonymous Results are different. Anonymous Users refer to queries that are submitted without a username, while Anonymous Results refer to queries without an explicit output sink.

--- a/docs/source/polars-on-premises/kubernetes/configuration/exposing.md
+++ b/docs/source/polars-on-premises/kubernetes/configuration/exposing.md
@@ -1,0 +1,23 @@
+# Exposing Polars on-premise
+
+To use Polars on-premises from the Python client, the scheduler endpoint must be reachable from the
+client. By default, the chart creates a `ClusterIP` service for the scheduler, which is only
+reachable from within the cluster and through port-forwards:
+
+```shell
+kubectl port-forward svc/polars-scheduler 5051:5051
+kubectl port-forward svc/polars-observatory 3001:3001
+```
+
+To expose the scheduler outside the cluster, you can change the `scheduler.services.scheduler.type`
+value to `LoadBalancer` or `NodePort`. We recommend using the `LoadBalancer` type and configuring
+TLS such that the connection to the cluster is encrypted. If you decide to use an insecure
+connection, you must set `insecure=True` in the `ClusterContext`.
+
+When the python client can't reach the scheduler, it will fail with a connection timeout like this:
+
+```
+RuntimeError: Error setting up gRPC connection, transport error
+tcp connect error
+Hint: you may need to restart the query if this error persists
+```

--- a/docs/source/polars-on-premises/kubernetes/configuration/exposing.md
+++ b/docs/source/polars-on-premises/kubernetes/configuration/exposing.md
@@ -1,6 +1,6 @@
-# Exposing Polars on-premise
+# Exposing Polars On-Prem
 
-To use Polars on-premises from the Python client, the scheduler endpoint must be reachable from the
+To use Polars On-Prem from the Python client, the scheduler endpoint must be reachable from the
 client. By default, the chart creates a `ClusterIP` service for the scheduler, which is only
 reachable from within the cluster and through port-forwards:
 

--- a/docs/source/polars-on-premises/kubernetes/configuration/license.md
+++ b/docs/source/polars-on-premises/kubernetes/configuration/license.md
@@ -1,0 +1,32 @@
+# License
+
+Polars on-premises requires a license key to run. If you haven't contacted Polars yet,
+[sign up here to apply](https://w0lzyfh2w8o.typeform.com/to/zuoDgoMv). A license key looks like
+this:
+
+```json
+{ "params": { "expiry": "2026-01-31T23:59:59Z", "name": "Company" }, "signature": "..." }
+```
+
+Create a secret for the received offline license key.
+
+```shell
+kubectl create secret generic polars-offline-license --from-file=license.json=license.json
+```
+
+In the Helm values, you need to specify the secret name and key. For example:
+
+```yaml
+license:
+    secretName: polars-offline-license
+    secretProperty: license.json
+```
+
+The cluster verifies the license key periodically, and will shutdown once the license expires.
+
+## EULA license
+
+Polars on-premises is licensed under the End User License Agreement (EULA) which can be found in the
+Polars on-premises binary. The EULA must be accepted by setting the `POLARS_EULA_ACCEPTED`
+environment variable to `1`. If the environment variable is not set, the executable will print the
+EULA and exit.

--- a/docs/source/polars-on-premises/kubernetes/configuration/license.md
+++ b/docs/source/polars-on-premises/kubernetes/configuration/license.md
@@ -26,7 +26,7 @@ The cluster verifies the license key periodically, and will shutdown once the li
 
 ## EULA license
 
-Polars on-premises is licensed under the End User License Agreement (EULA) which can be found in the
-Polars on-premises binary. The EULA must be accepted by setting the `POLARS_EULA_ACCEPTED`
-environment variable to `1`. If the environment variable is not set, the executable will print the
-EULA and exit.
+Polars On-Prem is licensed under the End User License Agreement (EULA) which can be found in the
+Polars On-Prem binary. The EULA must be accepted by setting the `POLARS_EULA_ACCEPTED` environment
+variable to `1`. If the environment variable is not set, the executable will print the EULA and
+exit.

--- a/docs/source/polars-on-premises/kubernetes/configuration/license.md
+++ b/docs/source/polars-on-premises/kubernetes/configuration/license.md
@@ -1,6 +1,6 @@
 # License
 
-Polars on-premises requires a license key to run. If you haven't contacted Polars yet,
+Polars On-Prem requires a license key to run. If you haven't contacted Polars yet,
 [sign up here to apply](https://w0lzyfh2w8o.typeform.com/to/zuoDgoMv). A license key looks like
 this:
 

--- a/docs/source/polars-on-premises/kubernetes/configuration/monitoring.md
+++ b/docs/source/polars-on-premises/kubernetes/configuration/monitoring.md
@@ -50,7 +50,7 @@ The host metrics exporter supports collecting CPU and memory usage metrics from 
 
 ## Telemetry
 
-Polars on-premises uses OpenTelemetry as its telemetry framework. To receive OTLP metrics and
+Polars On-Prem uses OpenTelemetry as its telemetry framework. To receive OTLP metrics and
 traces, configure `telemetry.otlpEndpoint` to point to your OTLP collector. Logs are written to
 stdout in JSON format. For the compute plane, the log level can be configured using the `logLevel`
 value.

--- a/docs/source/polars-on-premises/kubernetes/configuration/monitoring.md
+++ b/docs/source/polars-on-premises/kubernetes/configuration/monitoring.md
@@ -50,7 +50,6 @@ The host metrics exporter supports collecting CPU and memory usage metrics from 
 
 ## Telemetry
 
-Polars On-Prem uses OpenTelemetry as its telemetry framework. To receive OTLP metrics and
-traces, configure `telemetry.otlpEndpoint` to point to your OTLP collector. Logs are written to
-stdout in JSON format. For the compute plane, the log level can be configured using the `logLevel`
-value.
+Polars On-Prem uses OpenTelemetry as its telemetry framework. To receive OTLP metrics and traces,
+configure `telemetry.otlpEndpoint` to point to your OTLP collector. Logs are written to stdout in
+JSON format. For the compute plane, the log level can be configured using the `logLevel` value.

--- a/docs/source/polars-on-premises/kubernetes/configuration/monitoring.md
+++ b/docs/source/polars-on-premises/kubernetes/configuration/monitoring.md
@@ -1,0 +1,56 @@
+# Profiling and host metrics
+
+The profiling and host metrics system consists of a sender and receiving side. The observatory
+component's main task is to receive telemetry data from the cluster's nodes. It exposes the
+profiling data in a dashboard that can be accessed through the `polars-observatory` service.
+
+## Observatory data stores
+
+The observatory stores profiling data in an SQLite database file. By default, this file is stored in
+an `emptyDir`, so data is lost when the scheduler pod is recreated. This volume can also be
+configured as a persistent volume claim, allowing the observatory to persist profiling data across
+scheduler pod restarts or even cluster recreation. The storage needed for this file is in the order
+of several tens of MB, depending on the number of queries and their complexity.
+
+You can configure the chart to create a persistent volume claim by configuring these volumes:
+
+```yaml
+observatory:
+  data:
+    persistentVolumeClaim:
+      enabled: true
+      storageClassName: "hostpath" # As configured in your k8s cluster
+      size: 1Gi
+```
+
+Or reuse an existing volume claim as shown below. Make sure the volume has the `ReadWriteOnce`
+access mode as the observatory requires exclusive access to the database file.
+
+```yaml
+observatory:
+  data:
+    persistentVolumeClaim:
+      enabled: true
+      create: false
+      existingClaimName: "your-persistent-volume-claim"
+```
+
+The observatory stores host metrics in a pre-allocated buffer in memory. The size of this buffer can
+be configured using the `observatory.maxMetricsBytesTotal` key. The default is around 100 MB. You
+can estimate the required memory at around 50 bytes per second per worker node. So for a cluster
+with 32 worker nodes, with a history of 1 hour, you would need around `50 * 32 * 3600 = 5760000`
+bytes, or 5.7 MB.
+
+## Host metrics exporter
+
+The dashboard shows host metrics for each worker node. These metrics are exported by default and can
+be disabled by setting `disableHostMetrics: true`.
+
+The host metrics exporter supports collecting CPU and memory usage metrics from cgroups v1 and v2.
+
+## Telemetry
+
+Polars on-premises uses OpenTelemetry as its telemetry framework. To receive OTLP metrics and
+traces, configure `telemetry.otlpEndpoint` to point to your OTLP collector. Logs are written to
+stdout in JSON format. For the compute plane, the log level can be configured using the `logLevel`
+value.

--- a/docs/source/polars-on-premises/kubernetes/configuration/openlineage.md
+++ b/docs/source/polars-on-premises/kubernetes/configuration/openlineage.md
@@ -1,0 +1,21 @@
+# OpenLineage
+
+OpenLineage is an open platform for collection and analysis of data lineage. See
+[openlineage.io](https://openlineage.io) for more information. See
+[OpenLineage Integration](https://docs.pola.rs/polars-on-premises/integrations/openlineage/) for
+more information on how to annotate Polars queries and inspecting them in an OpenLineage collector.
+
+The cluster must be configured with a lineage transport endpoint, pointing at the collector. HTTP(S)
+is the only supported transport protocol. The following example points at an instance of Marquez
+deployed in the default namespace:
+
+```yaml
+lineage:
+  enabled: true
+  transport:
+    http:
+      endpoint: "http://marquez.default.svc.cluster.local:5000"
+```
+
+See [OpenLineage Integration](/polars-on-premises/integrations/openlineage) for more information on
+how to annotate Polars queries and inspect them in an OpenLineage collector.

--- a/docs/source/polars-on-premises/kubernetes/configuration/resource-allocation.md
+++ b/docs/source/polars-on-premises/kubernetes/configuration/resource-allocation.md
@@ -2,8 +2,8 @@
 
 # Resource allocation and node selectors
 
-Most of the time, it is a good idea to run Polars On-Prem on dedicated nodes, with only one
-worker pod per node.
+Most of the time, it is a good idea to run Polars On-Prem on dedicated nodes, with only one worker
+pod per node.
 
 First, figure out the available resources on your nodes. This is usually lower than the actual node
 resources, as Kubernetes reserves some resources for system daemons. For example, if you have a
@@ -27,9 +27,9 @@ worker:
 ```
 
 If your cluster has other workloads running on it, we still recommend running Polars On-Prem on
-dedicated nodes, and using node selectors and taints/tolerations to ensure that only Polars
-On-Prem pods are scheduled on those nodes. For example, you can add a node selector, toleration,
-and affinity rules like this:
+dedicated nodes, and using node selectors and taints/tolerations to ensure that only Polars On-Prem
+pods are scheduled on those nodes. For example, you can add a node selector, toleration, and
+affinity rules like this:
 
 ```yaml
 worker:

--- a/docs/source/polars-on-premises/kubernetes/configuration/resource-allocation.md
+++ b/docs/source/polars-on-premises/kubernetes/configuration/resource-allocation.md
@@ -2,7 +2,7 @@
 
 # Resource allocation and node selectors
 
-Most of the time, it is a good idea to run Polars on-premises on dedicated nodes, with only one
+Most of the time, it is a good idea to run Polars On-Prem on dedicated nodes, with only one
 worker pod per node.
 
 First, figure out the available resources on your nodes. This is usually lower than the actual node
@@ -26,9 +26,9 @@ worker:
           memory: 14.31GiB
 ```
 
-If your cluster has other workloads running on it, we still recommend running Polars on-premises on
+If your cluster has other workloads running on it, we still recommend running Polars On-Prem on
 dedicated nodes, and using node selectors and taints/tolerations to ensure that only Polars
-on-premises pods are scheduled on those nodes. For example, you can add a node selector, toleration,
+On-Prem pods are scheduled on those nodes. For example, you can add a node selector, toleration,
 and affinity rules like this:
 
 ```yaml

--- a/docs/source/polars-on-premises/kubernetes/configuration/resource-allocation.md
+++ b/docs/source/polars-on-premises/kubernetes/configuration/resource-allocation.md
@@ -1,0 +1,58 @@
+# Resource allocation
+
+# Resource allocation and node selectors
+
+Most of the time, it is a good idea to run Polars on-premises on dedicated nodes, with only one
+worker pod per node.
+
+First, figure out the available resources on your nodes. This is usually lower than the actual node
+resources, as Kubernetes reserves some resources for system daemons. For example, if you have a
+cluster of 3 `m4.xlarge` nodes (4 vCPUs, 16GiB memory), you may have 3770m CPU and 14.31GiB memory
+available.
+
+```yaml
+worker:
+  deployment:
+    replicaCount: 3
+
+    runtimeContainer:
+      resources:
+        requests:
+          cpu: 3770m
+          memory: 14.31GiB
+   
+        limits:
+          cpu: 3770m
+          memory: 14.31GiB
+```
+
+If your cluster has other workloads running on it, we still recommend running Polars on-premises on
+dedicated nodes, and using node selectors and taints/tolerations to ensure that only Polars
+on-premises pods are scheduled on those nodes. For example, you can add a node selector, toleration,
+and affinity rules like this:
+
+```yaml
+worker:
+  deployment:
+    nodeSelector:
+      kubernetes.io/e2e-az-name: e2e-az1
+    tolerations:
+    - key: "key"
+      operator: "Equal"
+      value: "value"
+      effect: "NoSchedule"
+
+    affinity:
+     nodeAffinity:
+       requiredDuringSchedulingIgnoredDuringExecution:
+         nodeSelectorTerms:
+         - matchExpressions:
+           - key: kubernetes.io/e2e-az-name
+             operator: In
+             values:
+             - e2e-az1
+```
+
+A compute cluster can be fully occupied running a query, preventing new queries from being
+scheduled. To avoid this, you can deploy this chart multiple times in the same cluster, reserving
+the resources between the different deployments.

--- a/docs/source/polars-on-premises/kubernetes/configuration/runtime.md
+++ b/docs/source/polars-on-premises/kubernetes/configuration/runtime.md
@@ -1,0 +1,104 @@
+# Runtime
+
+Polars on-premises consists of a single scheduler and multiple workers. Both components are
+contained in a single binary. While the scheduler can run without any system-level dependencies, the
+worker node needs the following:
+
+- Python runtime (e.g. any version)
+- Polars (i.e. pip wheel)
+- Additional python requirements (e.g. numpy, pyarrow)
+
+If your Kubernetes cluster has internet access, we support installing these all at worker boot. For
+example, you can use the following configuration:
+
+```yaml
+runtime:
+  prebuilt:
+    enabled: false
+
+  composed:
+    enabled: true
+
+    dist:
+      repository: "polarscloud/polars-on-premises"
+      tag: ""
+      pullPolicy: "IfNotPresent"
+
+    runtime:
+      repository: "python"
+      tag: "3.13.9-slim-bookworm"
+      pullPolicy: ""
+
+    requirements: |
+      boto3==1.40.70
+      urllib==2.5.0
+
+    polarsExtras: "async,cloudpickle,database,deltalake,fsspec,iceberg,numpy,pandas,pyarrow,pydantic,timezone"
+```
+
+Behind the scenes, this mechanism copies the Polars on-premises binary, wheel, uv, and a setup
+script from an init-container to the pod's main container. On startup of the main container, the
+setup script uses uv to install the polars wheel with the additional specified packages before
+starting the worker.
+
+If you prefer self-building a Docker image, you can instead configure the chart to use your image:
+
+```yaml
+runtime:
+  prebuilt:
+    enabled: false
+
+    runtime:
+      repository: "your-prebuilt-image"
+      tag: ""
+      pullPolicy: ""
+
+  composed:
+    enabled: false
+```
+
+The Dockerfile for a prebuilt image can look something like this:
+
+```Dockerfile
+# your specific python version (you could also use any other base image and install python in a run statement)
+FROM python:3.13.9-slim-bookworm
+
+WORKDIR /opt
+
+# your os-level dependencies
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    libpq-dev \
+    gcc \
+ && rm -rf /var/lib/apt/lists/*
+
+# install polars with specific features enabled for these packages
+ENV POLARS_EXTRAS="async,cloudpickle,database,deltalake,fsspec,iceberg,numpy,pandas,pyarrow,pydantic,timezone"
+
+# enale bash so we can write multiline strings
+SHELL ["/bin/bash", "-c"]
+RUN --mount=from=ghcr.io/astral-sh/uv:0.9.8,source=/uv,target=/bin/uv \
+    --mount=type=cache,target=/root/.cache/uv \
+    --mount=from=polarscloud/polars-on-premises:20251203,source=/opt/whl/polars-1.35.2-py3-none-any.whl,target=/opt/polars-1.35.2-py3-none-any.whl \
+    --mount=type=bind,source=./requirements.txt,target=/opt/requirements.txt \
+    # install polars with extras from wheel overriding to prevent installation of runtimes as those are already included in pc-cublet \
+    echo -e "\
+polars[$POLARS_EXTRAS] @ file:///opt/polars-1.35.2-py3-none-any.whl\n\
+polars-runtime-32; sys_platform == 'never'\n\
+polars-runtime-64; sys_platform == 'never'\n\
+polars-runtime-compat; sys_platform == 'never'\n" | \
+  uv pip install \
+  -r requirements.txt \
+  "polars[$POLARS_EXTRAS] @ file:///opt/polars-1.35.2-py3-none-any.whl" \
+  --system \
+  --overrides=-
+
+COPY --from=polarscloud/polars-on-premises:20251203 /opt/bin/pc-cublet /opt/bin/pc-cublet
+
+CMD ["/opt/bin/pc-cublet", "service"]
+```
+
+Note that the helm tests will still use the runtime defined in `.Values.runtime.composed.runtime`,
+so ensure that this image contains the same Python version as your prebuilt image. All the Python
+dependencies required for the tests are already included in the image used in the helm test, and the
+test does not require internet access, so a prebuilt image for the tests has no direct advantage.

--- a/docs/source/polars-on-premises/kubernetes/configuration/runtime.md
+++ b/docs/source/polars-on-premises/kubernetes/configuration/runtime.md
@@ -1,10 +1,10 @@
 # Runtime
 
-Polars On-Prem consists of a single scheduler and multiple workers. Both components are
-contained in a single binary. While the scheduler can run without any system-level dependencies, the
-worker node needs the following:
+Polars On-Prem consists of a single scheduler and multiple workers. Both components are contained in
+a single binary. While the scheduler can run without any system-level dependencies, the worker node
+needs the following:
 
-- Python runtime (e.g. any version)
+- Python runtime (any version or a matching client version for running UDFs)
 - Polars (i.e. pip wheel)
 - Additional python requirements (e.g. numpy, pyarrow)
 
@@ -36,10 +36,10 @@ runtime:
     polarsExtras: "async,cloudpickle,database,deltalake,fsspec,iceberg,numpy,pandas,pyarrow,pydantic,timezone"
 ```
 
-Behind the scenes, this mechanism copies the Polars On-Prem binary, wheel, uv, and a setup
-script from an init-container to the pod's main container. On startup of the main container, the
-setup script uses uv to install the polars wheel with the additional specified packages before
-starting the worker.
+Behind the scenes, this mechanism copies the Polars On-Prem binary, wheel, uv, and a setup script
+from an init-container to the pod's main container. On startup of the main container, the setup
+script uses uv to install the polars wheel with the additional specified packages before starting
+the worker.
 
 If you prefer self-building a Docker image, you can instead configure the chart to use your image:
 

--- a/docs/source/polars-on-premises/kubernetes/configuration/runtime.md
+++ b/docs/source/polars-on-premises/kubernetes/configuration/runtime.md
@@ -1,6 +1,6 @@
 # Runtime
 
-Polars on-premises consists of a single scheduler and multiple workers. Both components are
+Polars On-Prem consists of a single scheduler and multiple workers. Both components are
 contained in a single binary. While the scheduler can run without any system-level dependencies, the
 worker node needs the following:
 
@@ -36,7 +36,7 @@ runtime:
     polarsExtras: "async,cloudpickle,database,deltalake,fsspec,iceberg,numpy,pandas,pyarrow,pydantic,timezone"
 ```
 
-Behind the scenes, this mechanism copies the Polars on-premises binary, wheel, uv, and a setup
+Behind the scenes, this mechanism copies the Polars On-Prem binary, wheel, uv, and a setup
 script from an init-container to the pod's main container. On startup of the main container, the
 setup script uses uv to install the polars wheel with the additional specified packages before
 starting the worker.

--- a/docs/source/polars-on-premises/kubernetes/configuration/shuffle-data.md
+++ b/docs/source/polars-on-premises/kubernetes/configuration/shuffle-data.md
@@ -1,0 +1,93 @@
+# Shuffle data
+
+When running distributed queries, data needs to be transferred in between the nodes. Polars
+on-premises requires a configuration for this storage location. You should decide and benchmark
+which location is the best for your infrastructure, as it has a large impact on query execution
+times.
+
+## Worker local storage
+
+When using local storage, Polars queries write shuffle data directly to a file. This is preferably
+configured with a node local SSD. For other nodes to access the data, the following sequence
+happens:
+
+```
+worker_1 -[fs write]-> disk
+worker_2 <-[net]- worker_1 <-[fs read]- disk
+```
+
+By default, the ephemeral volume for this is disabled, and an `emptyDir` volume is used instead.
+However, to prevent the host from running out of disk space during large queries, it is recommended
+to enable an ephemeral volume for this purpose. The feature below will add a
+[Generic Ephemeral Volume](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/) to each
+of the pods.
+
+```yaml
+shuffleData:
+  ephemeralVolumeClaim:
+    enabled: true
+    storageClassName: "hostpath" # As configured in your k8s cluster
+    size: 125Gi
+```
+
+## Worker shared storage
+
+If your infrastructure has some shared storage file system, such as NFS (or CephFs, etc.), Polars
+on-premises can use that for its shuffle data too. In Kubernetes terms, this boils down to having a
+fast `ReadWriteMany` capable storage class. This shuffle type reduces complexity, as Polars can
+directly write to the shared disk, and any worker can directly read from it. This setup can lead to
+improved performance when the network storage provider is fast enough. In addition, it provides
+automatic shuffle data persistence in case of worker node failure.
+
+```
+worker_1 -[net]-> shared storage -[fs]-> disk
+worker_2 <-[net]- shared storage <-[fs]- disk
+```
+
+Configure it as show below:
+
+```yaml
+shuffleData:
+  sharedPersistentVolumeClaim:
+    enabled: true
+    storageClassName: "cephfs" # As configured in your k8s cluster
+    size: 125Gi
+```
+
+## S3 compatible storage
+
+S3 compatible storage is similar to the shared filesystem storage described above, but uses the S3
+API. It has the same advantages and disadvantages as the shared filesystem storage. You may
+configure the credentials as shown below. The key names correspond to the
+[`storage_options` parameter in `scan_parquet`](https://docs.pola.rs/api/python/stable/reference/api/polars.scan_parquet.html)
+(e.g. `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `aws_region`). We currently
+only support the AWS keys of the `storage_options` dictionary, but note that you can use any other
+cloud provider that supports the S3 API, such as MinIO or DigitalOcean Spaces.
+
+```yaml
+shuffleData:
+  s3:
+    enabled: true
+    endpoint: "s3://my-bucket/path/to/dir"
+    options:
+      - name: aws_access_key_id
+        valueFrom:
+          secretKeyRef:
+            name: my-s3-secret
+            key: accessKeyId
+  # etc.
+```
+
+If you self-host an S3 compatible storage solution, you can override the `aws_endpoint_url`
+configuration option.
+
+```yaml
+shuffleData:
+  s3:
+    enabled: true
+    endpoint: "s3://my-bucket/path/to/dir"
+    options:
+      - name: aws_endpoint_url
+        value: "http://your-s3-compatible-storage-host:8080"
+  # etc.
+```

--- a/docs/source/polars-on-premises/kubernetes/configuration/shuffle-data.md
+++ b/docs/source/polars-on-premises/kubernetes/configuration/shuffle-data.md
@@ -1,9 +1,8 @@
 # Shuffle data
 
-When running distributed queries, data needs to be transferred in between the nodes. Polars
-On-Prem requires a configuration for this storage location. You should decide and benchmark
-which location is the best for your infrastructure, as it has a large impact on query execution
-times.
+When running distributed queries, data needs to be transferred in between the nodes. Polars On-Prem
+requires a configuration for this storage location. You should decide and benchmark which location
+is the best for your infrastructure, as it has a large impact on query execution times.
 
 ## Worker local storage
 
@@ -33,11 +32,11 @@ shuffleData:
 ## Worker shared storage
 
 If your infrastructure has some shared storage file system, such as NFS (or CephFs, etc.), Polars
-On-Prem can use that for its shuffle data too. In Kubernetes terms, this boils down to having a
-fast `ReadWriteMany` capable storage class. This shuffle type reduces complexity, as Polars can
-directly write to the shared disk, and any worker can directly read from it. This setup can lead to
-improved performance when the network storage provider is fast enough. In addition, it provides
-automatic shuffle data persistence in case of worker node failure.
+On-Prem can use that for its shuffle data too. In Kubernetes terms, this boils down to having a fast
+`ReadWriteMany` capable storage class. This shuffle type reduces complexity, as Polars can directly
+write to the shared disk, and any worker can directly read from it. This setup can lead to improved
+performance when the network storage provider is fast enough. In addition, it provides automatic
+shuffle data persistence in case of worker node failure.
 
 ```
 worker_1 -[net]-> shared storage -[fs]-> disk

--- a/docs/source/polars-on-premises/kubernetes/configuration/shuffle-data.md
+++ b/docs/source/polars-on-premises/kubernetes/configuration/shuffle-data.md
@@ -1,7 +1,7 @@
 # Shuffle data
 
 When running distributed queries, data needs to be transferred in between the nodes. Polars
-on-premises requires a configuration for this storage location. You should decide and benchmark
+On-Prem requires a configuration for this storage location. You should decide and benchmark
 which location is the best for your infrastructure, as it has a large impact on query execution
 times.
 
@@ -33,7 +33,7 @@ shuffleData:
 ## Worker shared storage
 
 If your infrastructure has some shared storage file system, such as NFS (or CephFs, etc.), Polars
-on-premises can use that for its shuffle data too. In Kubernetes terms, this boils down to having a
+On-Prem can use that for its shuffle data too. In Kubernetes terms, this boils down to having a
 fast `ReadWriteMany` capable storage class. This shuffle type reduces complexity, as Polars can
 directly write to the shared disk, and any worker can directly read from it. This setup can lead to
 improved performance when the network storage provider is fast enough. In addition, it provides

--- a/docs/source/polars-on-premises/kubernetes/configuration/temporary-data.md
+++ b/docs/source/polars-on-premises/kubernetes/configuration/temporary-data.md
@@ -1,0 +1,17 @@
+#### Temporary data
+
+Polars itself uses some temporary storage location in the streaming engine and in some cases when
+downloading remote files. For most queries this is a relatively small volume and is not
+performance-sensitive. By default, the persistent volume for this is disabled, and an `emptyDir`
+volume is used instead. However, to prevent the host from running out of disk space during large
+queries, it is recommended to enable a persistent volume for this purpose. The feature below will
+add a [Generic Ephemeral Volume](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/) to
+each of the pods.
+
+```yaml
+temporaryData:
+  ephemeralVolumeClaim:
+    enabled: true
+    storageClassName: "hostpath" # As configured in your k8s cluster
+    size: 125Gi
+```

--- a/docs/source/polars-on-premises/kubernetes/getting-started.md
+++ b/docs/source/polars-on-premises/kubernetes/getting-started.md
@@ -13,9 +13,58 @@ repository as follows:
 
 ```shell
 helm repo add polars-inc https://polars-inc.github.io/helm-charts
+helm repo update
 ```
 
 You can then run `helm search repo polars-inc` to see the available charts.
 
-Further explanation on the different configuration can be found in the
-[chart `README.md`](https://github.com/polars-inc/helm-charts/blob/main/charts/polars/README.md).
+Create a secret for the received offline license key.
+
+```shell
+kubectl create secret generic polars-offline-license --from-file=license.json=license.json
+```
+
+For this quickstart, we install a SeaweedFS instance for the output results. The following commands
+install the Polars chart and expose the services locally.
+
+```shell
+helm upgrade --install polars polars-inc/polars \
+    --set license.secretName=polars-offline-license \
+    --set license.secretProperty=license.json \
+    --set anonymousResults.seaweedfs.enabled=true
+kubectl port-forward svc/polars-scheduler 5051:5051
+kubectl port-forward svc/polars-observatory 3001:3001
+kubectl port-forward svc/polars-seaweedfs 8333:8333
+```
+
+You can then run a simple query like so:
+
+```python
+import polars as pl
+import polars_cloud as pc
+
+ctx = pc.ClusterContext(compute_address="localhost")
+
+result = (
+    pl.LazyFrame(
+        {
+            "a": [1, 2, 3],
+            "b": [4, 4, 5],
+        }
+    )
+    .with_columns(
+        pl.col("a").max().over("b").alias("c"),
+    )
+    .remote(ctx)
+    .execute()
+)
+
+print(result.head)
+```
+
+To get your polars cluster ready for production, see the different configuration values. Most
+importantly:
+
+- [Anonymous Results](/polars-on-premises/kubernetes/configuration/anonymous-results)
+- [Shuffle Data](/polars-on-premises/kubernetes/configuration/shuffle-data)
+- [Resource Allocation](/polars-on-premises/kubernetes/configuration/resource-allocation)

--- a/docs/source/polars-on-premises/releases.md
+++ b/docs/source/polars-on-premises/releases.md
@@ -15,8 +15,7 @@ $ curl -L 'https://get.onprem.pola.rs?version=<TAG>' --data @license.json --outp
 To pull the docker image:
 
 ```sh
-$ docker login -u polarscustomer -p <DockerHub_PAT_token>
-$ docker pull --platform linux/amd64 polarscloud/polars-on-premise:<TAG>
+$ docker pull polarscloud/polars-on-premise:<TAG>
 ```
 
 ### 0.3.1 (latest)
@@ -85,6 +84,5 @@ the following command:
 helm search repo polars-inc --versions
 ```
 
-The container can be pulled from the DockerHub after logging in using `polarscustomer` as username
-and the provided Personal Access Token (PAT) as password. The container images are tagged after the
-versions listed above.
+The container can be pulled from the DockerHub without any authentication. The container images are
+tagged after the versions listed above.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,6 +159,17 @@ nav:
     - polars-on-premises/index.md
     - Kubernetes:
       - polars-on-premises/kubernetes/getting-started.md
+      - Configuration:
+        - polars-on-premises/kubernetes/configuration/anonymous-results.md
+        - polars-on-premises/kubernetes/configuration/shuffle-data.md
+        - polars-on-premises/kubernetes/configuration/exposing.md
+        - polars-on-premises/kubernetes/configuration/monitoring.md
+        - polars-on-premises/kubernetes/configuration/temporary-data.md
+        - polars-on-premises/kubernetes/configuration/runtime.md
+        - polars-on-premises/kubernetes/configuration/license.md
+        - polars-on-premises/kubernetes/configuration/resource-allocation.md
+        - polars-on-premises/kubernetes/configuration/anonymous-users.md
+        - polars-on-premises/kubernetes/configuration/openlineage.md
     - Bare-metal:
       - polars-on-premises/bare-metal/getting-started.md
       - Configuration:


### PR DESCRIPTION
Pulling in the docs from the helm chart in preparation for on-prem workspaces. Could use another read-through..