### PR TITLE
fix: Only consider perfectly equal Extension types as matching schema

### DIFF
--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -1120,6 +1120,15 @@ impl DataType {
                 Ok(false)
             },
 
+            #[cfg(feature = "dtype-extension")]
+            (l @ DataType::Extension(l_ext_instance, _), r @ DataType::Extension(r_ext_instance, _)) => {
+                if l_ext_instance != r_ext_instance {
+                    polars_bail!(SchemaMismatch: "type {:?} is incompatible with expected type {:?}", l, r)
+                } else {
+                    Ok(true)
+                }
+            },
+
             (l, r) if l == r => Ok(false),
             (l, r) => {
                 polars_bail!(SchemaMismatch: "type {:?} is incompatible with expected type {:?}", l, r)

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -1121,11 +1121,14 @@ impl DataType {
             },
 
             #[cfg(feature = "dtype-extension")]
-            (l @ DataType::Extension(l_ext_instance, _), r @ DataType::Extension(r_ext_instance, _)) => {
-                if l_ext_instance != r_ext_instance {
-                    polars_bail!(SchemaMismatch: "type {:?} is incompatible with expected type {:?}", l, r)
+            (
+                l @ DataType::Extension(l_ext_type_instance, l_inner_dtype),
+                r @ DataType::Extension(r_ext_type_instance, r_inner_dtype),
+            ) => {
+                if l_ext_type_instance == r_ext_type_instance && l_inner_dtype == r_inner_dtype {
+                    Ok(false)
                 } else {
-                    Ok(true)
+                    polars_bail!(SchemaMismatch: "type {:?} is incompatible with expected type {:?}", l, r)
                 }
             },
 


### PR DESCRIPTION
This resolves #27512, but I am not sure whether this is the correct level at which non-matching Extension types should be addressed. We could achieve the same functionality by just changing the PartialEq implementation for DataType::Extension as well, but I don't know what other sites would be affected.

The failing test was failed before these changes were made as well


<img width="1574" height="812" alt="{2CFCA11F-924D-4CD0-AEF6-3706C22EBD8D}" src="https://github.com/user-attachments/assets/f0718f12-6701-4f2a-bff7-0927e2ed2c03" />

