### PR TITLE
docs(python): Clarify full join description

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -8242,7 +8242,8 @@ class DataFrame:
                  - Returns all rows from the right table, and the matched rows from
                    the left table.
                * - **full**
-                 - Returns all rows when there is a match in either left or right.
+                 - Returns all rows from both tables, joining matching rows and
+                   filling non-matches with null values.
                * - **cross**
                  - Returns the Cartesian product of rows from both tables
                * - **semi**

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -6138,7 +6138,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                  - Returns all rows from the right table, and the matched rows from
                    the left table.
                * - **full**
-                 - Returns all rows when there is a match in either left or right.
+                 - Returns all rows from both tables, joining matching rows and
+                   filling non-matches with null values.
                * - **cross**
                  - Returns the Cartesian product of rows from both tables
                * - **semi**


### PR DESCRIPTION
Closes #24367.

## Summary

Clarifies the `how="full"` description in `DataFrame.join` and `LazyFrame.join` so it states that full joins include rows from both tables, with non-matches filled with null values.

## Validation

- `git diff --check`
- `ruff check py-polars/src/polars/dataframe/frame.py py-polars/src/polars/lazyframe/frame.py`

## AI disclosure

- I used AI to help identify the narrow documentation scope and review the PR text.
- I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.