### PR TITLE
docs: Use Polars random seed in sample example

### DIFF
--- a/docs/source/src/python/user-guide/concepts/data-types-and-structures.py
+++ b/docs/source/src/python/user-guide/concepts/data-types-and-structures.py
@@ -48,9 +48,7 @@ print(df.tail(3))
 # --8<-- [end:tail]
 
 # --8<-- [start:sample]
-import random
-
-random.seed(42)  # For reproducibility.
+pl.set_random_seed(42)  # For reproducibility.
 
 print(df.sample(2))
 # --8<-- [end:sample]


### PR DESCRIPTION
Closes #18072

This updates the `sample` example in the data types and structures user guide to use `pl.set_random_seed(42)` instead of Python's `random.seed(42)`.

`DataFrame.sample` uses Polars' internal RNG, so seeding Python's standard-library RNG does not make the example reproducible.