### PR TITLE
docs(python): Document horizontal string concatenation

### DIFF
--- a/docs/source/src/python/user-guide/expressions/strings.py
+++ b/docs/source/src/python/user-guide/expressions/strings.py
@@ -61,6 +61,20 @@ result = df.with_columns(
 print(result)
 # --8<-- [end:replace]
 
+# --8<-- [start:concat]
+df = pl.DataFrame(
+    {
+        "first_name": ["Ada", "Grace", "Edsger"],
+        "last_name": ["Lovelace", "Hopper", "Dijkstra"],
+    }
+)
+
+result = df.with_columns(
+    full_name=pl.col("first_name") + pl.lit(" ") + pl.col("last_name"),
+)
+print(result)
+# --8<-- [end:concat]
+
 # --8<-- [start:casing]
 addresses = pl.DataFrame(
     {

--- a/docs/source/src/rust/user-guide/expressions/strings.rs
+++ b/docs/source/src/rust/user-guide/expressions/strings.rs
@@ -89,6 +89,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("{result}");
     // --8<-- [end:replace]
 
+    // --8<-- [start:concat]
+    let df = df! (
+        "first_name" => ["Ada", "Grace", "Edsger"],
+        "last_name" => ["Lovelace", "Hopper", "Dijkstra"],
+    )?;
+
+    let result = df
+        .lazy()
+        .with_columns([(col("first_name") + lit(" ") + col("last_name")).alias("full_name")])
+        .collect()?;
+
+    println!("{result}");
+    // --8<-- [end:concat]
+
     // --8<-- [start:casing]
     let addresses = df! (
         "addresses" => [

--- a/docs/source/user-guide/expressions/strings.md
+++ b/docs/source/user-guide/expressions/strings.md
@@ -93,6 +93,17 @@ finds.
 
 ## Modifying strings
 
+### Concatenating strings
+
+String expressions can be concatenated horizontally using the `+` operator, which is equivalent to
+:meth:`Expr.add <polars.Expr.add>`.
+
+{{code_block('user-guide/expressions/strings', 'concat', [])}}
+
+```python exec="on" result="text" session="expressions/strings"
+--8<-- "python/user-guide/expressions/strings.py:concat"
+```
+
 ### Case conversion
 
 Converting the casing of a string is a common operation and Polars supports it out of the box with


### PR DESCRIPTION
Closes #22673.

## Summary

- Document that string expressions can be concatenated horizontally with `+`.
- Add a small example showing that `+` concatenates string expressions through `Expr.add`.

## Validation

- `git diff --check`
- `ruff check docs/source/src/python/user-guide/expressions/strings.py`
- `python docs/source/src/python/user-guide/expressions/strings.py`

## AI disclosure

1. I used AI to help identify the narrow documentation scope and review the PR text.
2. I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.