### PR TITLE
fix: Support duplicate names in `over`

### DIFF
--- a/crates/polars-expr/src/expressions/aggregation.rs
+++ b/crates/polars-expr/src/expressions/aggregation.rs
@@ -437,10 +437,9 @@ impl PhysicalExpr for AggregationExpr {
                         let groups = (0..col.len() as IdxSize).map(|i| [i, 1]).collect();
                         GroupsType::new_slice(groups, false, true).into_sliceable()
                     });
-                    return Ok(AggregationContext::from_agg_state(
-                        AggregatedScalar(col),
-                        groups,
-                    ));
+                    let mut out = AggregationContext::from_agg_state(AggregatedScalar(col), groups);
+                    out.set_original_len(false);
+                    return Ok(out);
                 },
                 GroupByMethod::Groups => {
                     let mut column: ListChunked = ac.groups().as_list_chunked();

--- a/crates/polars-expr/src/expressions/mod.rs
+++ b/crates/polars-expr/src/expressions/mod.rs
@@ -660,6 +660,7 @@ impl<'a> AggregationContext<'a> {
                     let groups = (0..c.len() as IdxSize).map(|i| [i, 1]).collect();
                     GroupsType::new_slice(groups, false, true).into_sliceable()
                 });
+                self.set_original_len(false);
             },
             AggState::LiteralScalar(c) => {
                 assert_eq!(c.len(), 1);
@@ -668,6 +669,7 @@ impl<'a> AggregationContext<'a> {
                     let groups = vec![[0, 1]; self.groups.len()];
                     GroupsType::new_slice(groups, true, true).into_sliceable()
                 });
+                self.set_original_len(false);
             },
         }
     }

--- a/crates/polars-expr/src/expressions/window.rs
+++ b/crates/polars-expr/src/expressions/window.rs
@@ -552,7 +552,13 @@ impl PhysicalExpr for WindowExpr {
                 let update_groups = !matches!(&ac.update_groups, UpdateGroups::No);
                 match (
                     &ac.update_groups,
-                    set_by_groups(&out_column, &ac, df.height(), update_groups),
+                    set_by_groups(
+                        &out_column,
+                        &ac,
+                        gb.get_groups(),
+                        df.height(),
+                        update_groups,
+                    ),
                 ) {
                     // for aggregations that reduce like sum, mean, first and are numeric
                     // we take the group locations to directly map them to the right place
@@ -598,13 +604,13 @@ impl PhysicalExpr for WindowExpr {
                                         .1,
                                 ))
                             } else {
-                                let df_right =
-                                    unsafe { DataFrame::new_unchecked_infer_height(keys) };
-                                let df_left = unsafe {
-                                    DataFrame::new_unchecked_infer_height(group_by_columns)
-                                };
                                 Ok(Arc::new(
-                                    private_left_join_multiple_keys(&df_left, &df_right, true)?.1,
+                                    private_left_join_multiple_keys(
+                                        &group_by_columns,
+                                        &keys,
+                                        true,
+                                    )?
+                                    .1,
                                 ))
                             }
                         };
@@ -1037,25 +1043,29 @@ fn materialize_column(join_opt_ids: &ChunkJoinOptIds, out_column: &Column) -> Co
 fn set_by_groups(
     s: &Column,
     ac: &AggregationContext,
+    gb_groups: &GroupPositions,
     len: usize,
     update_groups: bool,
 ) -> Option<Column> {
-    if update_groups
-        || !ac.original_len
-        || matches!(
-            ac.agg_state(),
-            AggState::AggregatedScalar(_) | AggState::LiteralScalar(_)
-        )
-    {
-        return None;
-    }
+    let groups = match ac.agg_state() {
+        AggState::AggregatedScalar(_) | AggState::LiteralScalar(_) => gb_groups,
+        AggState::NotAggregated(_) | AggState::AggregatedList(_) => {
+            if update_groups || !ac.original_len {
+                return None;
+            } else {
+                &ac.groups
+            }
+        },
+    };
+
     if s.dtype().to_physical().is_primitive_numeric() {
         let dtype = s.dtype();
         let s = s.to_physical_repr();
 
         macro_rules! dispatch {
-            ($ca:expr) => {{ Some(set_numeric($ca, &ac.groups, len)) }};
+            ($ca:expr) => {{ Some(set_numeric($ca, groups, len)) }};
         }
+
         downcast_as_macro_arg_physical!(&s, dispatch)
             .map(|s| unsafe { s.from_physical_unchecked(dtype) }.unwrap())
             .map(Column::from)

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -652,19 +652,19 @@ fn prepare_keys_multiple(s: &[Series], nulls_equal: bool) -> PolarsResult<Binary
         encode_rows_vertical_par_unordered_broadcast_nulls(&keys)
     }
 }
+
+// Duplicate column names are allowed
 pub fn private_left_join_multiple_keys(
-    a: &DataFrame,
-    b: &DataFrame,
+    a: &[Column],
+    b: &[Column],
     nulls_equal: bool,
 ) -> PolarsResult<LeftJoinIds> {
     // @scalar-opt
     let a_cols = a
-        .columns()
         .iter()
         .map(|c| c.as_materialized_series().clone())
         .collect::<Vec<_>>();
     let b_cols = b
-        .columns()
         .iter()
         .map(|c| c.as_materialized_series().clone())
         .collect::<Vec<_>>();

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_to_ir.rs
@@ -449,15 +449,10 @@ pub(super) fn to_aexpr_impl(
                 None
             };
 
-            // Convert partition_by expressions and check for duplicate names
-            let mut partition_nodes = Vec::with_capacity(partition_by.len());
-            let mut seen_names = PlHashSet::with_capacity(partition_by.len());
-
-            for expr in partition_by {
-                let (node, name) = to_aexpr_impl_materialized_lit(expr, ctx)?;
-                polars_ensure!(seen_names.insert(name.clone()), duplicate = name);
-                partition_nodes.push(node);
-            }
+            let partition_nodes = partition_by
+                .into_iter()
+                .map(|e| Ok(to_aexpr_impl_materialized_lit(e, ctx)?.0))
+                .collect::<PolarsResult<_>>()?;
 
             (
                 AExpr::Over {

--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -3941,9 +3941,9 @@ class Expr:
             - group_to_rows
                 If the aggregation results in multiple values per group, map them back
                 to their row position in the DataFrame. This can only be done if each
-                group yields the same elements before aggregation as after. If the
-                aggregation results in one scalar value per group, this value will be
-                mapped to every row.
+                group yields the same number of elements before aggregation as after. If
+                the aggregation results in one scalar value per group, this value will
+                be mapped to every row.
             - join
                 If the aggregation may result in multiple values per group, join the
                 values as 'List<group_dtype>' to each row position. Warning: this can be

--- a/py-polars/tests/unit/operations/test_over.py
+++ b/py-polars/tests/unit/operations/test_over.py
@@ -218,3 +218,29 @@ def test_over_empty_order_by_27067() -> None:
     result = df.select(pl.col("a").sum().over("g", order_by=[]))
     expected = df.select(pl.col("a").sum().over("g"))
     assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        pl.col.a,
+        pl.col.a.reverse(),
+        pl.lit(1),
+        pl.lit("f"),
+        pl.lit([1]),
+        pl.col.a.mean(),
+        pl.col.s.first(),
+        pl.col.a.implode(),
+    ],
+)
+def test_over_duplicate_name_27443(expr: pl.Expr) -> None:
+    df = pl.DataFrame(
+        {
+            "g": [10, 10, 20],
+            "a": [1, 2, 3],
+            "s": ["a", "b", "c"],
+        }
+    )
+    out = df.select(expr.over(pl.col.g, pl.col.g))
+    expected = df.select(expr.over(pl.col.g))
+    assert_frame_equal(out, expected)

--- a/py-polars/tests/unit/operations/test_over.py
+++ b/py-polars/tests/unit/operations/test_over.py
@@ -192,12 +192,6 @@ def test_over_order_by_descending_nulls_agg_context() -> None:
     assert result["v"][0].to_list() == [6, 2, 5]
 
 
-def test_over_duplicate_partition_by_26921() -> None:
-    df = pl.DataFrame({"x": [1, 2, 3]})
-    with pytest.raises(pl.exceptions.DuplicateError):
-        df.with_columns(pl.len().over("x", "x"))
-
-
 def test_count_over_aggregated_list_respects_inner_nulls_27031() -> None:
     df = pl.DataFrame({"g": [1, 1, 1], "x": [1, 2, None]})
 


### PR DESCRIPTION
Fixes #27443

- Support duplicate names in `over`, undo #26968
- Revert to the numeric fast path from #26827
- Fix the newly found issue on non-numeric aggregations, for MRE see #27443
- Fixup `original_len` internal code incorrectness issues (no github issue)
