### PR TITLE
fix(python): Preserve raw line endings when transcoding CSV files for non-utf8 encoding

### DIFF
--- a/py-polars/src/polars/io/_utils.py
+++ b/py-polars/src/polars/io/_utils.py
@@ -240,7 +240,7 @@ def prepare_file_arg(
                     )
                 # decode first
                 with Path(file).open(
-                    encoding=encoding_str, errors=encoding_errors
+                    encoding=encoding_str, errors=encoding_errors, newline=""
                 ) as f:
                     return _check_empty(
                         BytesIO(f.read().encode("utf8")),
@@ -270,7 +270,9 @@ def prepare_file_arg(
     if isinstance(file, str):
         file = normalize_filepath(file, check_not_directory=check_not_dir)
         if not has_utf8_utf8_lossy_encoding:
-            with Path(file).open(encoding=encoding_str, errors=encoding_errors) as f:
+            with Path(file).open(
+                encoding=encoding_str, errors=encoding_errors, newline=""
+            ) as f:
                 return _check_empty(
                     BytesIO(f.read().encode("utf8")),
                     context=f"{file!r}",

--- a/py-polars/src/polars/io/_utils.py
+++ b/py-polars/src/polars/io/_utils.py
@@ -257,7 +257,7 @@ def prepare_file_arg(
                     )
                 # decode first
                 with Path(file).open(
-                    encoding=encoding_str, errors=encoding_errors
+                    encoding=encoding_str, errors=encoding_errors, newline=""
                 ) as f:
                     return _check_empty(
                         BytesIO(f.read().encode("utf8")),
@@ -287,7 +287,9 @@ def prepare_file_arg(
     if isinstance(file, str):
         file = normalize_filepath(file, check_not_directory=check_not_dir)
         if not has_utf8_utf8_lossy_encoding:
-            with Path(file).open(encoding=encoding_str, errors=encoding_errors) as f:
+            with Path(file).open(
+                encoding=encoding_str, errors=encoding_errors, newline=""
+            ) as f:
                 return _check_empty(
                     BytesIO(f.read().encode("utf8")),
                     context=f"{file!r}",

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -567,7 +567,7 @@ def test_read_csv_encoding_lossy(chunk_override: None, tmp_path: Path) -> None:
 def test_read_csv_eol_char_with_non_utf8_encoding(
     chunk_override: None, tmp_path: Path
 ) -> None:
-    """Regression test for #27408.
+    r"""Regression test for #27408.
 
     When `read_csv` is given a file path *and* a non-utf8 encoding, the file
     is opened in Python text mode for transcoding to utf-8 before being handed

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -563,6 +563,37 @@ def test_read_csv_encoding_lossy(chunk_override: None, tmp_path: Path) -> None:
 
 
 @pytest.mark.may_fail_auto_streaming  # read->scan_csv dispatch
+@pytest.mark.write_disk
+def test_read_csv_eol_char_with_non_utf8_encoding(
+    chunk_override: None, tmp_path: Path
+) -> None:
+    """Regression test for #27408.
+
+    When `read_csv` is given a file path *and* a non-utf8 encoding, the file
+    is opened in Python text mode for transcoding to utf-8 before being handed
+    to the rust reader. Without `newline=""`, Python's universal-newlines
+    mode rewrites every `\r` to `\n`, so passing `eol_char="\r"` produced
+    a single-line frame with bogus column names. Reading the same payload
+    from `BytesIO` worked because no text-mode translation happened.
+    """
+    tmp_path.mkdir(exist_ok=True)
+
+    bts = b"a,b,c\r1,2,3\r4,5,6"
+    file_path = tmp_path / "cr_eol.csv"
+    file_path.write_bytes(bts)
+
+    expected = pl.DataFrame({"a": [1, 4], "b": [2, 5], "c": [3, 6]})
+
+    # Path / str inputs go through the file-opening branch in
+    # `prepare_file_arg`; BytesIO does not.
+    for file in (file_path, str(file_path), io.BytesIO(bts)):
+        out = pl.read_csv(file, eol_char="\r", encoding="latin-1")  # type: ignore[arg-type]
+        assert out.shape == (2, 3)
+        assert out.columns == ["a", "b", "c"]
+        assert_frame_equal(out, expected)
+
+
+@pytest.mark.may_fail_auto_streaming  # read->scan_csv dispatch
 def test_column_rename_and_schema_overrides(chunk_override: None) -> None:
     csv = textwrap.dedent(
         """\

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -594,6 +594,35 @@ def test_read_csv_eol_char_with_non_utf8_encoding(
 
 
 @pytest.mark.may_fail_auto_streaming  # read->scan_csv dispatch
+@pytest.mark.write_disk
+def test_read_csv_eol_char_non_utf8_encoding_without_fsspec(
+    chunk_override: None, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    r"""Companion to #27408 covering the non-fsspec fallback open site.
+
+    A string path with a non-utf8 encoding takes the fsspec local-file branch
+    when fsspec is installed, but falls through to a second text-mode open in
+    `prepare_file_arg` when it is not. That site needs `newline=""` too, or the
+    universal-newlines mode rewrites the literal `\r` eol and collapses the
+    frame to one row. Force the fallback by disabling fsspec.
+    """
+    monkeypatch.setattr("polars.io._utils._FSSPEC_AVAILABLE", False)
+
+    tmp_path.mkdir(exist_ok=True)
+
+    bts = b"a,b,c\r1,2,3\r4,5,6"
+    file_path = tmp_path / "cr_eol_no_fsspec.csv"
+    file_path.write_bytes(bts)
+
+    expected = pl.DataFrame({"a": [1, 4], "b": [2, 5], "c": [3, 6]})
+
+    out = pl.read_csv(str(file_path), eol_char="\r", encoding="latin-1")
+    assert out.shape == (2, 3)
+    assert out.columns == ["a", "b", "c"]
+    assert_frame_equal(out, expected)
+
+
+@pytest.mark.may_fail_auto_streaming  # read->scan_csv dispatch
 def test_column_rename_and_schema_overrides(chunk_override: None) -> None:
     csv = textwrap.dedent(
         """\

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -598,6 +598,35 @@ def test_read_csv_eol_char_with_non_utf8_encoding(
 
 
 @pytest.mark.may_fail_auto_streaming  # read->scan_csv dispatch
+@pytest.mark.write_disk
+def test_read_csv_eol_char_non_utf8_encoding_without_fsspec(
+    chunk_override: None, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    r"""Companion to #27408 covering the non-fsspec fallback open site.
+
+    A string path with a non-utf8 encoding takes the fsspec local-file branch
+    when fsspec is installed, but falls through to a second text-mode open in
+    `prepare_file_arg` when it is not. That site needs `newline=""` too, or the
+    universal-newlines mode rewrites the literal `\r` eol and collapses the
+    frame to one row. Force the fallback by disabling fsspec.
+    """
+    monkeypatch.setattr("polars.io._utils._FSSPEC_AVAILABLE", False)
+
+    tmp_path.mkdir(exist_ok=True)
+
+    bts = b"a,b,c\r1,2,3\r4,5,6"
+    file_path = tmp_path / "cr_eol_no_fsspec.csv"
+    file_path.write_bytes(bts)
+
+    expected = pl.DataFrame({"a": [1, 4], "b": [2, 5], "c": [3, 6]})
+
+    out = pl.read_csv(str(file_path), eol_char="\r", encoding="latin-1")
+    assert out.shape == (2, 3)
+    assert out.columns == ["a", "b", "c"]
+    assert_frame_equal(out, expected)
+
+
+@pytest.mark.may_fail_auto_streaming  # read->scan_csv dispatch
 def test_column_rename_and_schema_overrides(chunk_override: None) -> None:
     csv = textwrap.dedent(
         """\

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -571,7 +571,7 @@ def test_read_csv_encoding_lossy(chunk_override: None, tmp_path: Path) -> None:
 def test_read_csv_eol_char_with_non_utf8_encoding(
     chunk_override: None, tmp_path: Path
 ) -> None:
-    """Regression test for #27408.
+    r"""Regression test for #27408.
 
     When `read_csv` is given a file path *and* a non-utf8 encoding, the file
     is opened in Python text mode for transcoding to utf-8 before being handed

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -567,6 +567,37 @@ def test_read_csv_encoding_lossy(chunk_override: None, tmp_path: Path) -> None:
 
 
 @pytest.mark.may_fail_auto_streaming  # read->scan_csv dispatch
+@pytest.mark.write_disk
+def test_read_csv_eol_char_with_non_utf8_encoding(
+    chunk_override: None, tmp_path: Path
+) -> None:
+    """Regression test for #27408.
+
+    When `read_csv` is given a file path *and* a non-utf8 encoding, the file
+    is opened in Python text mode for transcoding to utf-8 before being handed
+    to the rust reader. Without `newline=""`, Python's universal-newlines
+    mode rewrites every `\r` to `\n`, so passing `eol_char="\r"` produced
+    a single-line frame with bogus column names. Reading the same payload
+    from `BytesIO` worked because no text-mode translation happened.
+    """
+    tmp_path.mkdir(exist_ok=True)
+
+    bts = b"a,b,c\r1,2,3\r4,5,6"
+    file_path = tmp_path / "cr_eol.csv"
+    file_path.write_bytes(bts)
+
+    expected = pl.DataFrame({"a": [1, 4], "b": [2, 5], "c": [3, 6]})
+
+    # Path / str inputs go through the file-opening branch in
+    # `prepare_file_arg`; BytesIO does not.
+    for file in (file_path, str(file_path), io.BytesIO(bts)):
+        out = pl.read_csv(file, eol_char="\r", encoding="latin-1")  # type: ignore[arg-type]
+        assert out.shape == (2, 3)
+        assert out.columns == ["a", "b", "c"]
+        assert_frame_equal(out, expected)
+
+
+@pytest.mark.may_fail_auto_streaming  # read->scan_csv dispatch
 def test_column_rename_and_schema_overrides(chunk_override: None) -> None:
     csv = textwrap.dedent(
         """\


### PR DESCRIPTION
## Summary

`prepare_file_arg()` in `py-polars/src/polars/io/_utils.py` opens the file in Python text mode to transcode non-utf8 input to utf-8 before handing the buffer to the rust reader. Without `newline=""`, Python's universal-newlines mode rewrites every `\r` to `\n`, so a call like:

```python
pl.read_csv(path, eol_char="\r", encoding="latin-1")
```

arrived at the rust side with no `\r` left to split on — producing a single-row frame with mangled column names. Reading the same payload from `BytesIO` already worked because that path skips the text-mode `.open()` (it uses `read_bytes`).

The reporter (#27408) had already isolated this and pointed at the exact two call sites; this PR is that fix.

## Change

Add `newline=""` to both `Path.open(..., encoding=encoding_str, errors=encoding_errors)` call sites in `prepare_file_arg`:
- L242 — fsspec local-file branch
- L273 — fallback `str`-path branch

A standalone reproduction confirms the round-trip:

| | bytes seen by polars |
|---|---|
| original on disk | `a,b,c\r1,2,3\r4,5,6` |
| current behavior | `a,b,c\n1,2,3\n4,5,6` ← `\r` stripped |
| fixed behavior   | `a,b,c\r1,2,3\r4,5,6` ← preserved |

## Test

Adds `test_read_csv_eol_char_with_non_utf8_encoding` parameterized over `Path` / `str` / `BytesIO` inputs. Verified the fix logic via a standalone Python script (full pytest run not possible without rebuilding the Maturin wheel locally, so the regression test ships with the PR for CI to exercise).

Fixes #27408