### PR TITLE
fix(rust): Set HEAD_RESPONSE_SIZE_ESTIMATE to 0

### DIFF
--- a/crates/polars-io/src/cloud/polars_object_store.rs
+++ b/crates/polars-io/src/cloud/polars_object_store.rs
@@ -12,7 +12,6 @@ use polars_error::{PolarsError, PolarsResult};
 use polars_utils::pl_path::PlRefPath;
 use tokio::io::AsyncWriteExt;
 
-use crate::metrics::HEAD_RESPONSE_SIZE_ESTIMATE;
 use crate::pl_async::{
     self, MAX_BUDGET_PER_REQUEST, get_concurrency_limit, get_download_chunk_size,
     tune_with_concurrency_budget, with_concurrency_budget,
@@ -436,10 +435,7 @@ impl PolarsObjectStore {
         with_concurrency_budget(1, || {
             self.exec_with_rebuild_retry_on_err(|s| {
                 async move {
-                    let head_result = self
-                        .io_metrics()
-                        .record_io_read(HEAD_RESPONSE_SIZE_ESTIMATE, s.head(path))
-                        .await;
+                    let head_result = self.io_metrics().record_io_read(0, s.head(path)).await;
 
                     if head_result.is_err() {
                         // Pre-signed URLs forbid the HEAD method, but we can still retrieve the header
@@ -447,7 +443,7 @@ impl PolarsObjectStore {
                         let get_range_0_1_result = self
                             .io_metrics()
                             .record_io_read(
-                                HEAD_RESPONSE_SIZE_ESTIMATE + 1,
+                                0,
                                 s.get_opts(
                                     path,
                                     object_store::GetOptions {

--- a/crates/polars-io/src/metrics.rs
+++ b/crates/polars-io/src/metrics.rs
@@ -3,8 +3,6 @@ use std::sync::Arc;
 use polars_utils::live_timer::{LiveTimer, LiveTimerSession};
 use polars_utils::relaxed_cell::RelaxedCell;
 
-pub const HEAD_RESPONSE_SIZE_ESTIMATE: u64 = 0;
-
 #[derive(Debug, Default, Clone)]
 pub struct IOMetrics {
     pub io_timer: LiveTimer,

--- a/crates/polars-io/src/metrics.rs
+++ b/crates/polars-io/src/metrics.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use polars_utils::live_timer::{LiveTimer, LiveTimerSession};
 use polars_utils::relaxed_cell::RelaxedCell;
 
-pub const HEAD_RESPONSE_SIZE_ESTIMATE: u64 = 1;
+pub const HEAD_RESPONSE_SIZE_ESTIMATE: u64 = 0;
 
 #[derive(Debug, Default, Clone)]
 pub struct IOMetrics {


### PR DESCRIPTION
The body of a head() call is always zero bytes. I've left in the `record_io_read(HEAD_RESPONSE_SIZE_ESTIMATE)` call [here](https://github.com/pola-rs/polars/blob/main/crates/polars-io/src/cloud/polars_object_store.rs#L441) in order to update the io timing for the head call (even though we will never count any bytes)