### PR TITLE
refactor(rust): Store record batch row counts custom polars IPC metadata field

### DIFF
--- a/crates/polars-arrow/src/io/ipc/append/mod.rs
+++ b/crates/polars-arrow/src/io/ipc/append/mod.rs
@@ -71,6 +71,7 @@ impl<R: Read + Seek + Write> FileWriter<R> {
             },
             encoded_message: Default::default(),
             custom_schema_metadata: None,
+            custom_metadata: None,
         })
     }
 }

--- a/crates/polars-arrow/src/io/ipc/read/file.rs
+++ b/crates/polars-arrow/src/io/ipc/read/file.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::io::{Read, Seek, SeekFrom};
 use std::sync::Arc;
 
@@ -24,6 +25,9 @@ pub struct FileMetadata {
 
     /// The custom metadata that is read from the schema
     pub custom_schema_metadata: Option<Arc<Metadata>>,
+
+    /// Custom metadata from footer.
+    pub custom_metadata: Option<Arc<Metadata>>,
 
     /// The files' [`IpcSchema`]
     pub ipc_schema: IpcSchema,
@@ -264,6 +268,22 @@ pub fn deserialize_footer(footer_data: &[u8], size: u64) -> PolarsResult<FileMet
     let ipc_schema = deserialize_schema_ref_from_footer(footer)?;
     let (schema, ipc_schema, custom_schema_metadata) = fb_to_schema(ipc_schema)?;
 
+    let custom_metadata = footer
+        .custom_metadata()?
+        .map(|md| {
+            md.iter()
+                .map(|kv_pair| {
+                    let kv_pair = kv_pair?;
+                    Ok((
+                        kv_pair.key()?.unwrap_or("").into(),
+                        kv_pair.value()?.unwrap_or("").into(),
+                    ))
+                })
+                .collect::<PolarsResult<BTreeMap<_, _>>>()
+        })
+        .transpose()?
+        .map(Arc::new);
+
     Ok(FileMetadata {
         schema: Arc::new(schema),
         ipc_schema,
@@ -271,6 +291,7 @@ pub fn deserialize_footer(footer_data: &[u8], size: u64) -> PolarsResult<FileMet
         dictionaries,
         size,
         custom_schema_metadata: custom_schema_metadata.map(Arc::new),
+        custom_metadata,
     })
 }
 

--- a/crates/polars-arrow/src/io/ipc/write/common_sync.rs
+++ b/crates/polars-arrow/src/io/ipc/write/common_sync.rs
@@ -1,6 +1,7 @@
 use std::io::Write;
 use std::sync::Arc;
 
+use arrow_format::ipc::KeyValue;
 use arrow_format::ipc::planus::Builder;
 use bytes::Bytes;
 use polars_error::PolarsResult;
@@ -143,6 +144,7 @@ pub fn push_footer(
     ipc_fields: &[IpcField],
     dictionary_blocks: Vec<arrow_format::ipc::Block>,
     record_blocks: Vec<arrow_format::ipc::Block>,
+    custom_metadata: Option<Vec<(String, String)>>,
     // Placeholder, inherited from FileWriter for future use.
     custom_schema_metadata: Option<Arc<Metadata>>,
 ) -> usize {
@@ -157,7 +159,15 @@ pub fn push_footer(
         schema: Some(Box::new(schema)),
         dictionaries: Some(dictionary_blocks),
         record_batches: Some(record_blocks),
-        custom_metadata: None,
+        custom_metadata: custom_metadata.map(|kv_vec| {
+            kv_vec
+                .into_iter()
+                .map(|(k, v)| KeyValue {
+                    key: Some(k),
+                    value: Some(v),
+                })
+                .collect()
+        }),
     };
     let mut builder = Builder::new();
     let footer_data = builder.finish(&root, None);

--- a/crates/polars-arrow/src/io/ipc/write/writer.rs
+++ b/crates/polars-arrow/src/io/ipc/write/writer.rs
@@ -1,6 +1,7 @@
 use std::io::Write;
 use std::sync::Arc;
 
+use arrow_format::ipc::KeyValue;
 use arrow_format::ipc::planus::Builder;
 use polars_error::{PolarsResult, polars_bail};
 
@@ -43,6 +44,8 @@ pub struct FileWriter<W: Write> {
     pub(crate) encoded_message: EncodedData,
     /// Custom schema-level metadata
     pub(crate) custom_schema_metadata: Option<Arc<Metadata>>,
+    /// Custom metadata
+    pub(crate) custom_metadata: Option<Vec<(String, String)>>,
 }
 
 impl<W: Write> FileWriter<W> {
@@ -87,6 +90,7 @@ impl<W: Write> FileWriter<W> {
             },
             encoded_message: Default::default(),
             custom_schema_metadata: None,
+            custom_metadata: None,
         }
     }
 
@@ -243,7 +247,15 @@ impl<W: Write> FileWriter<W> {
             schema: Some(Box::new(schema)),
             dictionaries: Some(std::mem::take(&mut self.dictionary_blocks)),
             record_batches: Some(std::mem::take(&mut self.record_blocks)),
-            custom_metadata: None,
+            custom_metadata: self.custom_metadata.take().map(|kv_vec| {
+                kv_vec
+                    .into_iter()
+                    .map(|(k, v)| KeyValue {
+                        key: Some(k),
+                        value: Some(v),
+                    })
+                    .collect()
+            }),
         };
         let mut builder = Builder::new();
         let footer_data = builder.finish(&root, None);
@@ -257,8 +269,12 @@ impl<W: Write> FileWriter<W> {
         Ok(())
     }
 
-    /// Sets custom schema metadata. Must be called before `start` is called
+    /// Sets custom schema metadata.
     pub fn set_custom_schema_metadata(&mut self, custom_metadata: Arc<Metadata>) {
         self.custom_schema_metadata = Some(custom_metadata);
+    }
+
+    pub fn set_custom_metadata(&mut self, custom_metadata: Vec<(String, String)>) {
+        self.custom_metadata = Some(custom_metadata);
     }
 }

--- a/crates/polars-io/src/ipc/mod.rs
+++ b/crates/polars-io/src/ipc/mod.rs
@@ -11,6 +11,8 @@ mod write;
 pub use ipc_file::{IpcReader, IpcScanOptions};
 #[cfg(feature = "cloud")]
 pub use ipc_reader_async::*;
+#[cfg(feature = "ipc")]
+pub mod pl_ipc_metadata;
 #[cfg(feature = "ipc_streaming")]
 pub use ipc_stream::*;
 pub use write::{BatchedWriter, IpcCompression, IpcWriter, IpcWriterOptions};

--- a/crates/polars-io/src/ipc/pl_ipc_metadata.rs
+++ b/crates/polars-io/src/ipc/pl_ipc_metadata.rs
@@ -1,0 +1,10 @@
+use polars_utils::IdxSize;
+
+pub static POLARS_IPC_METADATA_KEY: &str = "__POLARS_IPC_METADATA";
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct PlIpcMetadata {
+    /// Cumulative length including the current record batch.
+    pub record_batch_cum_len: Vec<IdxSize>,
+}

--- a/crates/polars-io/src/ipc/write.rs
+++ b/crates/polars-io/src/ipc/write.rs
@@ -220,6 +220,10 @@ impl<W: Write> BatchedWriter<W> {
         self.writer.write_encoded_dictionaries(encoded_dictionaries)
     }
 
+    pub fn set_custom_metadata(&mut self, custom_metadata: Vec<(String, String)>) {
+        self.writer.set_custom_metadata(custom_metadata)
+    }
+
     /// Writes the footer of the IPC file.
     pub fn finish(&mut self) -> PolarsResult<()> {
         self.writer.finish()?;

--- a/crates/polars-stream/src/nodes/io_sinks/writers/ipc/io_writer.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/writers/ipc/io_writer.rs
@@ -7,7 +7,8 @@ use arrow::io::ipc::write::{EncodedDataBytes, arrow_ipc_block};
 use bytes::Bytes;
 use polars_core::schema::SchemaRef;
 use polars_core::utils::arrow;
-use polars_error::PolarsResult;
+use polars_error::{PolarsResult, to_compute_err};
+use polars_io::ipc::pl_ipc_metadata::{POLARS_IPC_METADATA_KEY, PlIpcMetadata};
 use polars_io::ipc::{IpcWriter, IpcWriterOptions};
 use polars_io::utils::file::Writeable;
 use polars_io::{SerWriter, schema_to_arrow_checked};
@@ -21,6 +22,7 @@ pub struct IOWriter {
     pub options: Arc<IpcWriterOptions>,
     pub schema: SchemaRef,
     pub ipc_fields: Vec<IpcField>,
+    pub write_custom_pl_metadata: bool,
 }
 
 impl IOWriter {
@@ -31,9 +33,12 @@ impl IOWriter {
             options,
             schema,
             ipc_fields,
+            write_custom_pl_metadata,
         } = self;
 
         let (file, sync_on_close) = file.await?;
+
+        let mut custom_pl_metadata = write_custom_pl_metadata.then_some(PlIpcMetadata::default());
 
         match file {
             Writeable::Cloud(cloudwriter) => {
@@ -67,8 +72,12 @@ impl IOWriter {
                 // Process each incoming batch as a message.
                 while let Some(batch) = ipc_batch_rx.recv().await {
                     match batch {
-                        IpcBatch::Record(handle, sink_morsel_permit) => {
-                            let encoded_data = handle.await;
+                        IpcBatch::Record {
+                            encoded_data,
+                            morsel_permit,
+                            num_rows,
+                        } => {
+                            let encoded_data = encoded_data.await;
                             let encoded_data = EncodedDataBytes {
                                 ipc_message: Bytes::from(encoded_data.ipc_message),
                                 arrow_data: Bytes::from(encoded_data.arrow_data),
@@ -83,7 +92,17 @@ impl IOWriter {
                             record_blocks.push(block);
                             block_offsets += meta + data;
 
-                            drop(sink_morsel_permit);
+                            if let Some(md) = custom_pl_metadata.as_mut() {
+                                if let Some(end_offset) = num_rows.checked_add(
+                                    md.record_batch_cum_len.last().copied().unwrap_or(0),
+                                ) {
+                                    md.record_batch_cum_len.push(end_offset);
+                                } else {
+                                    custom_pl_metadata = None;
+                                };
+                            }
+
+                            drop(morsel_permit);
                         },
                         IpcBatch::Dictionary(dictionary_data) => {
                             let encoded_dictionary = EncodedDataBytes {
@@ -110,6 +129,14 @@ impl IOWriter {
                     &ipc_fields,
                     dictionary_blocks,
                     record_blocks,
+                    if let Some(custom_pl_metadata) = custom_pl_metadata {
+                        Some(vec![(
+                            POLARS_IPC_METADATA_KEY.into(),
+                            serde_json::to_string(&custom_pl_metadata).map_err(to_compute_err)?,
+                        )])
+                    } else {
+                        None
+                    },
                     None,
                 );
                 push_magic(&mut sink_queue, false);
@@ -131,16 +158,38 @@ impl IOWriter {
 
                 while let Some(batch) = ipc_batch_rx.recv().await {
                     match batch {
-                        IpcBatch::Record(handle, sink_morsel_permit) => {
-                            let encoded_data = handle.await;
+                        IpcBatch::Record {
+                            encoded_data,
+                            morsel_permit,
+                            num_rows,
+                        } => {
+                            let encoded_data = encoded_data.await;
                             ipc_writer.write_encoded(&[], &encoded_data)?;
+
+                            if let Some(md) = custom_pl_metadata.as_mut() {
+                                if let Some(end_offset) = num_rows.checked_add(
+                                    md.record_batch_cum_len.last().copied().unwrap_or(0),
+                                ) {
+                                    md.record_batch_cum_len.push(end_offset);
+                                } else {
+                                    custom_pl_metadata = None;
+                                };
+                            }
+
                             drop(encoded_data);
-                            drop(sink_morsel_permit);
+                            drop(morsel_permit);
                         },
                         IpcBatch::Dictionary(dictionary_data) => {
                             ipc_writer.write_encoded_dictionaries(&[dictionary_data])?
                         },
                     }
+                }
+
+                if let Some(custom_pl_metadata) = custom_pl_metadata {
+                    ipc_writer.set_custom_metadata(vec![(
+                        POLARS_IPC_METADATA_KEY.into(),
+                        serde_json::to_string(&custom_pl_metadata).map_err(to_compute_err)?,
+                    )]);
                 }
 
                 ipc_writer.finish()?;

--- a/crates/polars-stream/src/nodes/io_sinks/writers/ipc/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/writers/ipc/mod.rs
@@ -32,7 +32,11 @@ pub struct IpcWriterStarter {
 }
 
 enum IpcBatch {
-    Record(executor::AbortOnDropHandle<EncodedData>, SinkMorselPermit),
+    Record {
+        encoded_data: executor::AbortOnDropHandle<EncodedData>,
+        morsel_permit: SinkMorselPermit,
+        num_rows: IdxSize,
+    },
     Dictionary(EncodedData),
 }
 
@@ -103,6 +107,7 @@ impl FileWriterStarter for IpcWriterStarter {
                         options,
                         schema: file_schema,
                         ipc_fields,
+                        write_custom_pl_metadata: write_statistics_flags,
                     }
                     .run(),
                 ),

--- a/crates/polars-stream/src/nodes/io_sinks/writers/ipc/record_batch_encoder.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/writers/ipc/record_batch_encoder.rs
@@ -14,6 +14,7 @@ use polars_core::utils::arrow::io::ipc::write::{
     EncodedData, WriteOptions, commit_encoded_arrays, encode_array, schema,
 };
 use polars_error::PolarsResult;
+use polars_utils::IdxSize;
 use polars_utils::concat_vec::ConcatVec as _;
 
 use crate::nodes::io_sinks::components::sink_morsel::SinkMorsel;
@@ -168,7 +169,11 @@ impl RecordBatchEncoder {
                 }));
 
             if ipc_batch_tx
-                .send(IpcBatch::Record(array_combine_handle, permit))
+                .send(IpcBatch::Record {
+                    encoded_data: array_combine_handle,
+                    morsel_permit: permit,
+                    num_rows: height as IdxSize,
+                })
                 .await
                 .is_err()
             {

--- a/py-polars/tests/unit/io/test_lazy_ipc.py
+++ b/py-polars/tests/unit/io/test_lazy_ipc.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import json
 import typing
 from typing import IO, TYPE_CHECKING, Any
 
@@ -380,6 +381,34 @@ def test_sink_scan_ipc_round_trip_statistics() -> None:
     # remain pyarrow compatible
     out = pl.read_ipc(buf, use_pyarrow=True)
     assert_frame_equal(df, out)
+
+
+def test_sink_ipc_custom_metadata() -> None:
+    f = io.BytesIO()
+    pl.LazyFrame({"a": range(37)}).sink_ipc(
+        f,
+        record_batch_size=10,
+        _record_batch_statistics=True,
+    )
+
+    with pyarrow.ipc.open_file(f) as reader:
+        assert [
+            reader.get_record_batch(i).num_rows
+            for i in range(reader.num_record_batches)
+        ] == [10, 10, 10, 7]
+        assert json.loads(reader.metadata.get(b"__POLARS_IPC_METADATA")) == {
+            "record_batch_cum_len": [10, 20, 30, 37]
+        }
+
+    f = io.BytesIO()
+    pl.LazyFrame({"a": [0, 1, 2, 3, 4]}).sink_ipc(
+        f,
+        record_batch_size=3,
+        _record_batch_statistics=False,
+    )
+
+    with pyarrow.ipc.open_file(f) as reader:
+        assert reader.metadata is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/27246
* ref https://github.com/pola-rs/polars/issues/27285

Streaming IPC sink will now write custom footer metadata (key: `__POLARS_IPC_METADATA`, JSON-encoded value) if `record_batch_statistics` is set to `true`.

For this PR we will store the cumulative row counts at each record batch inside this metadata field. In the future this can be used when reading an IPC file with a slice to determine the range of record batches to read without needing to fetch the metadata region of each individual record batch.

Note, that IPC has 2 location in the footer where metadata can be stored:
* `footer.schema.metadata`
  * Added in https://github.com/pola-rs/polars/pull/20066
* `footer.metadata` <- Used in this PR, as this metadata isn't necessarily tied to the schema

#### Future considerations
* Storing column byte ranges for all record batches, allowing for subset projections to be resolved without walking individual record batch metadata.
* Note a 4GB upper limit (2GB on some consumers that parse as `i32`) on footer metadata size, which may require a more compact serialization strategy should we add more data.
