### PR TITLE
fix: Fix panic on reading IPC with 0-row compressed bitmap

### DIFF
--- a/crates/polars-arrow/src/io/ipc/read/read_basic.rs
+++ b/crates/polars-arrow/src/io/ipc/read/read_basic.rs
@@ -297,6 +297,10 @@ fn read_compressed_bitmap<R: Read + Seek>(
     reader: &mut R,
     scratch: &mut Vec<u8>,
 ) -> PolarsResult<Vec<u8>> {
+    if row_limit == 0 {
+        return Ok(vec![]);
+    }
+
     scratch.clear();
     scratch.try_reserve(bytes)?;
     reader.by_ref().take(bytes as u64).read_to_end(scratch)?;

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -6,7 +6,9 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Any, no_type_check
 
 import pandas as pd
+import pyarrow as pa
 import pyarrow.feather as paf
+import pyarrow.ipc
 import pytest
 from hypothesis import given
 
@@ -569,3 +571,19 @@ def test_roundtrip_empty_str_list_21163() -> None:
     bytes = df.serialize()
     deserialized = pl.DataFrame.deserialize(io.BytesIO(bytes))
     assert_frame_equal(df, deserialized)
+
+
+def test_read_ipc_compressed_empty_bitmap_27532() -> None:
+    schema = pa.schema([("bool", pa.bool_())])
+    f = io.BytesIO()
+
+    with pyarrow.ipc.new_file(
+        f,
+        schema,
+        options=pyarrow.ipc.IpcWriteOptions(compression="lz4_frame"),
+    ) as w:
+        w.write_batch(pa.record_batch([pa.array([], type=pa.bool_())], schema=schema))
+
+    f.seek(0)
+
+    assert_frame_equal(pl.read_ipc(f), pl.DataFrame(schema={"bool": pl.Boolean}))


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/27532
