### PR TITLE
fix: Prevent slice pushdown from misaligning rows in non-strict horizontal `pl.concat`

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -895,15 +895,32 @@ impl SlicePushDown {
                     schema,
                     options,
                 },
-                _,
+                opt_state,
             ) => {
-                // Slice can always be pushed down for horizontal concatenation
+                // In non-strict mode, HConcat pads shorter inputs with nulls.
+                // Keep the original slice above HConcat so padding happens before slicing.
+                let (subplan_slice, above_slice) = if options.strict {
+                    (opt_state, None)
+                } else {
+                    (
+                        opt_state
+                            .filter(|s| s.offset >= 0)
+                            .and_then(|s| s.len.checked_add(s.offset.try_into().unwrap()))
+                            .map(|len| State { offset: 0, len }),
+                        opt_state,
+                    )
+                };
+
+                for input in &inputs {
+                    let input_lp = self.pushdown(*input, subplan_slice, lp_arena, expr_arena)?;
+                    lp_arena.replace(*input, input_lp);
+                }
                 let lp = HConcat {
                     inputs,
                     schema,
                     options,
                 };
-                self.pushdown_and_continue(lp, state, lp_arena, expr_arena)
+                self.no_pushdown_finish_opt(lp, above_slice, lp_arena)
             },
             (lp @ Sink { .. }, _) | (lp @ SinkMultiple { .. }, _) => {
                 // Slice can always be pushed down for sinks

--- a/py-polars/tests/unit/functions/test_concat.py
+++ b/py-polars/tests/unit/functions/test_concat.py
@@ -511,3 +511,35 @@ def test_concat_horizontal_lazy_strict_raises_shape_error_27415(
             }
         ),
     )
+
+
+@pytest.mark.parametrize(
+    ("heights", "offset", "length"),
+    [
+        ([5, 3], -2, 2),
+        ([5, 3], -2, 5),
+        ([5, 3, 2], -2, 5),
+        ([5, 3], 2, 5),
+        ([5, 5], -2, 5),
+    ],
+)
+def test_concat_horizontal_lazy_slice_matches_eager(
+    heights: list[int], offset: int, length: int
+) -> None:
+    lfs = [pl.LazyFrame({f"c{i}": list(range(h))}) for i, h in enumerate(heights)]
+    eager = pl.concat([lf.collect() for lf in lfs], how="horizontal").slice(
+        offset, length
+    )
+    lazy = pl.concat(lfs, how="horizontal").slice(offset, length).collect()
+
+    assert_frame_equal(eager, lazy)
+
+
+def test_concat_horizontal_lazy_negative_slice_not_pushed_down() -> None:
+    a = pl.LazyFrame({"x": [1, 2, 3, 4, 5]})
+    b = pl.LazyFrame({"y": [10, 20, 30]})
+
+    plan = pl.concat([a, b], how="horizontal").tail(2).explain()
+
+    assert "SLICE" in plan
+    assert plan.index("SLICE") < plan.index("HCONCAT")

--- a/py-polars/tests/unit/operations/test_slice.py
+++ b/py-polars/tests/unit/operations/test_slice.py
@@ -148,7 +148,7 @@ def test_hconcat_slice_pushdown() -> None:
         pl.LazyFrame({f"column_{i}": list(range(i, i + 10))}) for i in range(num_dfs)
     ]
 
-    out = pl.concat(lfs, how="horizontal").slice(2, 3)
+    out = pl.concat(lfs, how="horizontal", strict=True).slice(2, 3)
     plan = out.explain()
 
     assert not plan.startswith("SLICE")


### PR DESCRIPTION
In non-strict mode, we now push only an upper-bound slice `(0, offset + len)` into each `HConcat` input when the outer offset is non-negative, and keep the original slice as a `Slice` node above `HConcat`. This preserves null-padding alignment while still allowing scans to receive a row-count cap for `head`/positive-offset slices.

In strict mode, equal input heights are enforced at execution time, so we still push the exact slice into each input and preserve the existing optimization.

Fixes #27552