### PR TITLE
fix: Ensure `json_decode` doesn't fail for Date and Time string deserialization

### DIFF
--- a/crates/polars-compute/src/cast/binview_to.rs
+++ b/crates/polars-compute/src/cast/binview_to.rs
@@ -6,13 +6,12 @@ use arrow::datatypes::{ArrowDataType, Field, TimeUnit};
 use arrow::offset::Offset;
 use arrow::types::NativeType;
 use bytemuck::cast_slice_mut;
-use chrono::Datelike;
 use num_traits::FromBytes;
 use polars_error::{PolarsResult, polars_bail, polars_ensure, polars_err};
 
 use super::CastOptionsImpl;
 use super::binary_to::Parse;
-use super::temporal::EPOCH_DAYS_FROM_CE;
+use super::temporal::utf8_to_naive_date_scalar;
 #[cfg(feature = "dtype-decimal")]
 use crate::decimal::str_to_dec128;
 
@@ -134,13 +133,7 @@ pub fn utf8view_to_naive_timestamp(
 }
 
 pub(super) fn utf8view_to_date32(from: &Utf8ViewArray) -> PrimitiveArray<i32> {
-    let iter = from.iter().map(|x| {
-        x.and_then(|x| {
-            x.parse::<chrono::NaiveDate>()
-                .ok()
-                .map(|x| x.num_days_from_ce() - EPOCH_DAYS_FROM_CE)
-        })
-    });
+    let iter = from.iter().map(|x| x.and_then(utf8_to_naive_date_scalar));
     PrimitiveArray::<i32>::from_trusted_len_iter(iter).to(ArrowDataType::Date32)
 }
 

--- a/crates/polars-compute/src/cast/temporal.rs
+++ b/crates/polars-compute/src/cast/temporal.rs
@@ -6,6 +6,7 @@ pub use arrow::temporal_conversions::{
 };
 use arrow::temporal_conversions::{parse_offset, parse_offset_tz};
 use chrono::format::{Parsed, StrftimeItems};
+use chrono::{Datelike, NaiveDate, NaiveTime, Timelike};
 use polars_error::PolarsResult;
 use polars_utils::pl_str::PlSmallStr;
 
@@ -139,4 +140,30 @@ pub fn utf8_to_naive_timestamp_scalar(value: &str, fmt: &str, tu: &TimeUnit) -> 
             TimeUnit::Nanosecond => x.and_utc().timestamp_nanos_opt().unwrap(),
         })
         .ok()
+}
+
+/// Parses an ISO-8601 date (`YYYY-MM-DD`) into days since the Unix
+/// epoch; non-parsable values return `None`.
+#[inline]
+pub fn utf8_to_naive_date_scalar(value: &str) -> Option<i32> {
+    value
+        .parse::<NaiveDate>()
+        .ok()
+        .map(|d| d.num_days_from_ce() - EPOCH_DAYS_FROM_CE)
+}
+
+/// Parses an ISO-8601 time (`HH:MM:SS[.fff]`) into elapsed time since
+/// midnight in the given `TimeUnit`; non-parsable values return `None`.
+#[inline]
+pub fn utf8_to_naive_time_scalar(value: &str, tu: TimeUnit) -> Option<i64> {
+    value.parse::<NaiveTime>().ok().map(|t| {
+        let secs = t.num_seconds_from_midnight() as i64;
+        let nanos = t.nanosecond() as i64;
+        match tu {
+            TimeUnit::Second => secs,
+            TimeUnit::Millisecond => secs * MILLISECONDS + nanos / 1_000_000,
+            TimeUnit::Microsecond => secs * MICROSECONDS + nanos / 1_000,
+            TimeUnit::Nanosecond => secs * NANOSECONDS + nanos,
+        }
+    })
 }

--- a/crates/polars-json/src/json/deserialize.rs
+++ b/crates/polars-json/src/json/deserialize.rs
@@ -8,6 +8,7 @@ use arrow::offset::{Offset, Offsets};
 use arrow::temporal_conversions;
 use arrow::types::NativeType;
 use num_traits::NumCast;
+use polars_compute::cast::temporal::{utf8_to_naive_date_scalar, utf8_to_naive_time_scalar};
 #[cfg(feature = "dtype-decimal")]
 use polars_compute::decimal::{f64_to_dec128, i128_to_dec128, str_to_dec128};
 use polars_utils::float16::pf16;
@@ -376,6 +377,37 @@ where
     Ok(Box::new(A::from(array)))
 }
 
+fn deserialize_temporal_primitive<'a, T, A>(
+    rows: &[A],
+    dtype: ArrowDataType,
+    type_name: &'static str,
+    parse_str: impl Fn(&str) -> Option<T>,
+) -> PolarsResult<Box<dyn Array>>
+where
+    T: NativeType + NumCast,
+    A: Borrow<BorrowedValue<'a>>,
+{
+    let mut err_idx = rows.len();
+    let iter = rows.iter().enumerate().map(|(i, row)| match row.borrow() {
+        BorrowedValue::Static(StaticNode::I64(v)) => T::from(*v),
+        BorrowedValue::Static(StaticNode::U64(v)) => T::from(*v),
+        BorrowedValue::Static(StaticNode::I128(v)) => T::from(*v),
+        BorrowedValue::Static(StaticNode::U128(v)) => T::from(*v),
+        BorrowedValue::Static(StaticNode::F64(v)) => T::from(*v),
+        BorrowedValue::String(s) => parse_str(s),
+        BorrowedValue::Static(StaticNode::Null) => None,
+        _ => {
+            if err_idx == rows.len() {
+                err_idx = i;
+            }
+            None
+        },
+    });
+    let out = Box::new(PrimitiveArray::<T>::from_iter(iter).to(dtype));
+    check_err_idx(rows, err_idx, type_name)?;
+    Ok(out)
+}
+
 pub(crate) fn _deserialize<'a, A: Borrow<BorrowedValue<'a>>>(
     rows: &[A],
     dtype: ArrowDataType,
@@ -400,20 +432,35 @@ pub(crate) fn _deserialize<'a, A: Borrow<BorrowedValue<'a>>>(
         ArrowDataType::Int16 => {
             fill_array_from::<_, _, PrimitiveArray<i16>>(deserialize_primitive_into, dtype, rows)
         },
-        ArrowDataType::Int32
-        | ArrowDataType::Date32
-        | ArrowDataType::Time32(_)
-        | ArrowDataType::Interval(IntervalUnit::YearMonth) => {
+        ArrowDataType::Int32 | ArrowDataType::Interval(IntervalUnit::YearMonth) => {
             fill_array_from::<_, _, PrimitiveArray<i32>>(deserialize_primitive_into, dtype, rows)
         },
         ArrowDataType::Interval(IntervalUnit::DayTime) => {
             unimplemented!("There is no natural representation of DayTime in JSON.")
         },
-        ArrowDataType::Int64
-        | ArrowDataType::Date64
-        | ArrowDataType::Time64(_)
-        | ArrowDataType::Duration(_) => {
+        ArrowDataType::Int64 | ArrowDataType::Duration(_) => {
             fill_array_from::<_, _, PrimitiveArray<i64>>(deserialize_primitive_into, dtype, rows)
+        },
+        ArrowDataType::Date32 => {
+            deserialize_temporal_primitive::<i32, _>(rows, dtype, "date", utf8_to_naive_date_scalar)
+        },
+        ArrowDataType::Date64 => {
+            deserialize_temporal_primitive::<i64, _>(rows, dtype, "date", |s| {
+                utf8_to_naive_date_scalar(s)
+                    .map(|d| d as i64 * temporal_conversions::MILLISECONDS_IN_DAY)
+            })
+        },
+        ArrowDataType::Time32(tu) => {
+            let tu = *tu;
+            deserialize_temporal_primitive::<i32, _>(rows, dtype, "time", |s| {
+                utf8_to_naive_time_scalar(s, tu).and_then(|v| i32::try_from(v).ok())
+            })
+        },
+        ArrowDataType::Time64(tu) => {
+            let tu = *tu;
+            deserialize_temporal_primitive::<i64, _>(rows, dtype, "time", |s| {
+                utf8_to_naive_time_scalar(s, tu)
+            })
         },
         ArrowDataType::Int128 => {
             fill_array_from::<_, _, PrimitiveArray<i128>>(deserialize_primitive_into, dtype, rows)

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -2253,7 +2253,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         The `QueryResult` can always be consumed as a new `LazyFrame` by calling `.lazy`
 
-
         Parameters
         ----------
         engine

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import date, datetime, time
 from typing import Any
 
 import pytest
@@ -858,6 +859,85 @@ def test_json_decode_primitive_to_list_11053() -> None:
     ).unnest("decoded_json")
     expected = pl.DataFrame({"col1": [["123"], ["xyz"]], "col2": [["123"], None]})
     assert_frame_equal(output, expected)
+
+
+def test_json_decode_temporal_strings() -> None:
+    df = pl.DataFrame(
+        {
+            "js": [
+                '{"mkt": "AUD/USD", "value": 0.6402, "dtm": "2024-01-04 07:10:13",'
+                ' "dt": "2024-01-04", "tm": "07:10:13"}',
+                '{"mkt": "AUD/USD", "value": 0.6473, "dtm": "2025-02-05 08:11:14",'
+                ' "dt": "2025-02-05", "tm": "08:11:14"}',
+                '{"mkt": "AUD/USD", "value": 0.6078, "dtm": "2026-03-06 09:12:15",'
+                ' "dt": "2026-03-06", "tm": "09:12:15"}',
+                '{"mkt": "AUD/USD", "value": null, "dtm": null, "dt": null, "tm": null}',
+            ]
+        }
+    )
+    expected = pl.DataFrame(
+        {
+            "mkt": ["AUD/USD", "AUD/USD", "AUD/USD", "AUD/USD"],
+            "value": [0.6402, 0.6473, 0.6078, None],
+            "dtm": [
+                datetime(2024, 1, 4, 7, 10, 13),
+                datetime(2025, 2, 5, 8, 11, 14),
+                datetime(2026, 3, 6, 9, 12, 15),
+                None,
+            ],
+            "dt": [
+                date(2024, 1, 4),
+                date(2025, 2, 5),
+                date(2026, 3, 6),
+                None,
+            ],
+            "tm": [
+                time(7, 10, 13),
+                time(8, 11, 14),
+                time(9, 12, 15),
+                None,
+            ],
+        },
+        schema={
+            "mkt": pl.String,
+            "value": pl.Float64,
+            "dtm": pl.Datetime("us"),
+            "dt": pl.Date,
+            "tm": pl.Time,
+        },
+    )
+    js_schema = pl.Struct(
+        {
+            "mkt": pl.String,
+            "value": pl.Float64,
+            "dtm": pl.Datetime("us"),
+            "dt": pl.Date,
+            "tm": pl.Time,
+        }
+    )
+    res = df.select(pl.col("js").str.json_decode(dtype=js_schema))
+    assert_frame_equal(res.unnest("js"), expected)
+
+
+def test_json_decode_temporal_numeric() -> None:
+    schema = pl.Struct({"dt": pl.Date, "tm": pl.Time})
+    df = pl.DataFrame(
+        {
+            "js": [
+                '{"dt": 19726, "tm": 25813000000000}',
+                '{"dt": null, "tm": null}',
+            ]
+        }
+    )
+    out = df.select(pl.col("js").str.json_decode(dtype=schema)).unnest("js")
+    expected = pl.DataFrame(
+        {
+            "dt": [date(2024, 1, 4), None],
+            "tm": [time(7, 10, 13), None],
+        },
+        schema={"dt": pl.Date, "tm": pl.Time},
+    )
+    assert_frame_equal(out, expected)
 
 
 def test_jsonpath_single() -> None:


### PR DESCRIPTION
For some reason we were missing the _string_ path for `Date` and `Time` JSON deserialisation (despite having it for `Datetime`); only the numeric path was present. 

Fixed, and added the missing temporal-value test coverage.

## Example

```python
import polars as pl

df = pl.DataFrame({
    'js': [
        '{"mkt": "AUD/USD", "value": 0.6402, "dt": "2024-01-04"}',
        '{"mkt": "AUD/USD", "value": 0.6473, "dt": "2025-02-05"}',
        '{"mkt": "AUD/USD", "value": 0.6078, "dt": "2026-03-06"}',
    ],
})
decoded = df.select(
    pl.col("js").str.json_decode(
        dtype=pl.Struct({
            'mkt': pl.String,
            'value': pl.Float64,
            'dt': pl.Date,
        }),
    )
)
```
#### Before
```python
# ComputeError: 
#  error deserializing JSON:
#   error deserializing value "String("2024-01-04")" as numeric.
```
#### After
```python
decoded
# shape: (3, 1)
# ┌───────────────────────────────┐
# │ js                            │
# │ ---                           │
# │ struct[3]                     │
# ╞═══════════════════════════════╡
# │ {"AUD/USD",0.6402,2024-01-04} │
# │ {"AUD/USD",0.6473,2025-02-05} │
# │ {"AUD/USD",0.6078,2026-03-06} │
# └───────────────────────────────┘

decoded.unnest("js")
# shape: (3, 3)
# ┌─────────┬────────┬────────────┐
# │ mkt     ┆ value  ┆ dt         │
# │ ---     ┆ ---    ┆ ---        │
# │ str     ┆ f64    ┆ date       │
# ╞═════════╪════════╪════════════╡
# │ AUD/USD ┆ 0.6402 ┆ 2024-01-04 │
# │ AUD/USD ┆ 0.6473 ┆ 2025-02-05 │
# │ AUD/USD ┆ 0.6078 ┆ 2026-03-06 │
# └─────────┴────────┴────────────┘
```