### PR TITLE
docs(python): Align `str.json_path_match` docstring with actual behavior

### DIFF
--- a/py-polars/src/polars/expr/string.py
+++ b/py-polars/src/polars/expr/string.py
@@ -1317,8 +1317,10 @@ class ExprStringNameSpace:
         """
         Extract the first match from a JSON string using the provided JSONPath.
 
-        Throws errors if invalid JSON strings are encountered. All return values
-        are cast to :class:`String`, regardless of the original value.
+        All return values are cast to :class:`String`, regardless of the
+        original value. Strings that do not parse as JSON yield a null
+        result; an invalid JSONPath query expression raises a
+        :class:`ComputeError`.
 
         Documentation on the JSONPath standard can be found
         `here <https://goessner.net/articles/JsonPath/>`_.
@@ -1331,8 +1333,9 @@ class ExprStringNameSpace:
         Returns
         -------
         Expr
-            Expression of data type :class:`String`. Contains null values if original
-            value is null or the json_path returns nothing.
+            Expression of data type :class:`String`. Contains null values if
+            the original value is null, the input does not parse as JSON, or
+            the JSONPath query returns no match.
 
         Examples
         --------

--- a/py-polars/src/polars/series/string.py
+++ b/py-polars/src/polars/series/string.py
@@ -785,24 +785,26 @@ class StringNameSpace:
 
     def json_path_match(self, json_path: IntoExprColumn) -> Series:
         """
-        Extract the first match of JSON string with provided JSONPath expression.
+        Extract the first match of a JSON string with the provided JSONPath expression.
 
-        Throw errors if encounter invalid JSON strings.
-        All return values will be cast to String regardless of the original value.
+        All return values are cast to String, regardless of the original
+        value. Strings that do not parse as JSON yield a null result; an
+        invalid JSONPath query expression raises a ComputeError.
 
-        Documentation on JSONPath standard can be found
+        Documentation on the JSONPath standard can be found
         `here <https://goessner.net/articles/JsonPath/>`_.
 
         Parameters
         ----------
         json_path
-            A valid JSON path query string.
+            A valid JSONPath query string.
 
         Returns
         -------
         Series
-            Series of data type :class:`String`. Contains null values if the original
-            value is null or the json_path returns nothing.
+            Series of data type :class:`String`. Contains null values if the
+            original value is null, the input does not parse as JSON, or the
+            JSONPath query returns no match.
 
         Examples
         --------

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -900,6 +900,22 @@ def test_str_json_path_match_wrong_length() -> None:
         df.select(pl.col("num").str.json_path_match(pl.Series(["a", "b"])))
 
 
+def test_str_json_path_match_invalid_json() -> None:
+    # Strings that do not parse as JSON should yield a null result
+    # (not raise). See gh-27333.
+    df = pl.DataFrame({"json_val": ["{{{", '{"a":"1"}', "not json", None]})
+    out = df.select(matched=pl.col("json_val").str.json_path_match("$.a"))
+    expected = pl.DataFrame({"matched": [None, "1", None, None]})
+    assert_frame_equal(out, expected)
+
+
+def test_str_json_path_match_invalid_query() -> None:
+    # An invalid JSONPath query expression *does* raise.
+    df = pl.DataFrame({"json_val": ['{"a":"1"}']})
+    with pytest.raises(ComputeError):
+        df.select(pl.col("json_val").str.json_path_match("not a valid jsonpath"))
+
+
 def test_extract_regex() -> None:
     s = pl.Series(
         [


### PR DESCRIPTION
Closes #27333.

## Summary

Both `Expr.str.json_path_match` and `Series.str.json_path_match` claimed:

> Throws errors if invalid JSON strings are encountered.

The implementation tells a different story. In `crates/polars-ops/src/chunked_array/strings/json_path.rs`:

```rust
unary_elementwise(ca, |opt_s| opt_s.and_then(|s| extract_json(&pat, s)))
```

`extract_json` returns `Option<String>` and `None` is propagated as a null cell — invalid JSON is silently skipped. The only `ComputeError` actually raised here is for invalid *JSONPath query expressions* (the `PathCompiled::compile(...)` call).

This PR updates both docstrings to describe what actually happens and tightens the `Returns` section to enumerate every case that yields null:

- The original value is null.
- The input does not parse as JSON.
- The JSONPath query returns no match.

## Tests

Added two regression tests in `py-polars/tests/unit/operations/namespaces/string/test_string.py` to lock the documented contract in:

- `test_str_json_path_match_invalid_json` — invalid JSON → null (matches the reproducer in the issue).
- `test_str_json_path_match_invalid_query` — invalid JSONPath query expression → `ComputeError`.

Both pass against current `main`. The existing `test_json_path_match` still passes (no regression).

## Behavior change?

None. This PR only changes documentation + adds tests that pin the existing behavior. If maintainers would prefer the docstring's *original* contract (i.e. raise on invalid JSON), that's a separate, larger change and I'd be happy to follow up.

## Checks

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `typos` — clean
- [x] `pytest` — 3/3 passed (2 new + 1 existing)