### PR TITLE
docs: Modernize Dagster integration example for Polars Cloud

### DIFF
--- a/docs/source/polars-cloud/integrations/dagster.md
+++ b/docs/source/polars-cloud/integrations/dagster.md
@@ -1,34 +1,31 @@
 # Dagster
 
-Integrate Polars Cloud authentication and compute sizing into a Dagster
-pipeline. Two patterns are documented below; both code blocks are complete and
-runnable on their own.
+Integrate Polars Cloud authentication and compute sizing into a Dagster pipeline. Two patterns are
+documented below; both code blocks are complete and runnable on their own.
 
-- **Single compute size** — every asset uses the same VM shape. The compute
-  resource auto-manages one `ComputeContext` per Dagster run via
-  `yield_for_execution`; asset bodies need no per-asset setup.
-- **Per-asset compute sizing** — different assets need different VM shapes.
-  Each asset opens a `session()` context manager on the compute resource it
-  needs.
+- **Single compute size** — every asset uses the same VM shape. The compute resource auto-manages
+  one `ComputeContext` per Dagster run via `yield_for_execution`; asset bodies need no per-asset
+  setup.
+- **Per-asset compute sizing** — different assets need different VM shapes. Each asset opens a
+  `session()` context manager on the compute resource it needs.
 
 Credentials are referenced through
 [`EnvVar`](https://docs.dagster.io/guides/operate/configuration/using-environment-variables-and-secrets#dagster-envvar-class)
-so the raw values are resolved at run launch and never displayed in the
-Dagster UI. Populate `POLARS_CLOUD_CLIENT_ID` and `POLARS_CLOUD_CLIENT_SECRET`
-in the Dagster deployment environment — either directly or by exporting from a
-secret manager (e.g.
+so the raw values are resolved at run launch and never displayed in the Dagster UI. Populate
+`POLARS_CLOUD_CLIENT_ID` and `POLARS_CLOUD_CLIENT_SECRET` in the Dagster deployment environment —
+either directly or by exporting from a secret manager (e.g.
 [AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/retrieving-secrets-python.html)).
 
 In both patterns `PolarsCloudCompute` declares `PolarsCloudAuth` as a
-[nested resource](https://docs.dagster.io/guides/build/external-resources/defining-resources)
-so Dagster runs `PolarsCloudAuth.setup_for_execution` — which calls
-`authenticate(...)` — before any compute resource is used.
+[nested resource](https://docs.dagster.io/guides/build/external-resources/defining-resources) so
+Dagster runs `PolarsCloudAuth.setup_for_execution` — which calls `authenticate(...)` — before any
+compute resource is used.
 
 ## Pattern 1: single compute size
 
-The compute resource owns the `ComputeContext` lifecycle through
-`yield_for_execution`: one VM is started at run init and stopped on exit,
-including on failure. Asset bodies contain only Polars code.
+The compute resource owns the `ComputeContext` lifecycle through `yield_for_execution`: one VM is
+started at run init and stopped on exit, including on failure. Asset bodies contain only Polars
+code.
 
 ```python
 from contextlib import contextmanager
@@ -105,15 +102,13 @@ defs = Definitions(
 
 ## Pattern 2: per-asset compute sizing
 
-`set_compute_context` is process-global state, so a single auto-managed
-context cannot serve multiple VM shapes within one run. When assets need
-different shapes, each compute resource exposes a `session()` context manager
-instead of starting its `ComputeContext` at run init. The asset opens the
-session of the resource sized for it; the VM is stopped on exit, including on
-failure.
+`set_compute_context` is process-global state, so a single auto-managed context cannot serve
+multiple VM shapes within one run. When assets need different shapes, each compute resource exposes
+a `session()` context manager instead of starting its `ComputeContext` at run init. The asset opens
+the session of the resource sized for it; the VM is stopped on exit, including on failure.
 
-A single `PolarsCloudAuth` instance is reused for both compute resources, so
-the credentials are loaded once at run start.
+A single `PolarsCloudAuth` instance is reused for both compute resources, so the credentials are
+loaded once at run start.
 
 ```python
 from contextlib import contextmanager
@@ -188,6 +183,6 @@ defs = Definitions(
 )
 ```
 
-The Dagster resource key (the dictionary key in `Definitions.resources`) must
-match the parameter name in each asset signature. The type annotation is for
-editor and type-checker support; Dagster injects by key, not by type.
+The Dagster resource key (the dictionary key in `Definitions.resources`) must match the parameter
+name in each asset signature. The type annotation is for editor and type-checker support; Dagster
+injects by key, not by type.

--- a/docs/source/polars-cloud/integrations/dagster.md
+++ b/docs/source/polars-cloud/integrations/dagster.md
@@ -1,46 +1,46 @@
 # Dagster
 
-Configure Polars Cloud authentication securely within Dagster pipelines using resource based secret
-management. This section details how to integrate Polars Cloud service account credentials with
-Dagster's resource pattern.
+Integrate Polars Cloud authentication and compute sizing into a Dagster
+pipeline. Two patterns are documented below; both code blocks are complete and
+runnable on their own.
 
-Dagster implements secret management through
-[Resources](https://docs.dagster.io/getting-started/concepts#resource), which provide dependency
-injection for external services. The modern, type-checked way to declare a resource is
-[`ConfigurableResource`](https://docs.dagster.io/guides/build/external-resources/defining-resources),
-combined with
+- **Single compute size** — every asset uses the same VM shape. The compute
+  resource auto-manages one `ComputeContext` per Dagster run via
+  `yield_for_execution`; asset bodies need no per-asset setup.
+- **Per-asset compute sizing** — different assets need different VM shapes.
+  Each asset opens a `session()` context manager on the compute resource it
+  needs.
+
+Credentials are referenced through
 [`EnvVar`](https://docs.dagster.io/guides/operate/configuration/using-environment-variables-and-secrets#dagster-envvar-class)
-for any secret you do not want to surface in the Dagster UI. Pull the secret values from one of:
+so the raw values are resolved at run launch and never displayed in the
+Dagster UI. Populate `POLARS_CLOUD_CLIENT_ID` and `POLARS_CLOUD_CLIENT_SECRET`
+in the Dagster deployment environment — either directly or by exporting from a
+secret manager (e.g.
+[AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/retrieving-secrets-python.html)).
 
-1. **Secret manager** (<ins>recommended</ins>): pull the secret from a metastore (see official docs
-   of your secret manager; here is
-   [AWS](https://docs.aws.amazon.com/secretsmanager/latest/userguide/retrieving-secrets-python.html)'
-   as an example) and expose it to the process as an environment variable, then reference it via
-   `EnvVar`.
-2. **Environment variables**: define the values as environment variables in your Dagster environment
-   (containers or else), and reference them via `EnvVar` so they are resolved at launch time and
-   never displayed in the UI.
+In both patterns `PolarsCloudCompute` declares `PolarsCloudAuth` as a
+[nested resource](https://docs.dagster.io/guides/build/external-resources/defining-resources)
+so Dagster runs `PolarsCloudAuth.setup_for_execution` — which calls
+`authenticate(...)` — before any compute resource is used.
 
-Below a complete pipeline definition demonstrating both authentication and per-asset compute sizing.
-The two `PolarsCloud*` resources own all lifecycle: `PolarsCloudAuth` calls `authenticate(...)` once
-at run start (via `setup_for_execution`), and `PolarsCloudCompute` exposes a `session()` context
-manager that activates a fresh `ComputeContext` for the asset body and stops the underlying VM on
-exit — including on failure.
+## Pattern 1: single compute size
+
+The compute resource owns the `ComputeContext` lifecycle through
+`yield_for_execution`: one VM is started at run init and stopped on exit,
+including on failure. Asset bodies contain only Polars code.
 
 ```python
-import polars as pl
 from contextlib import contextmanager
 
+import polars as pl
 from dagster import asset, ConfigurableResource, Definitions, EnvVar
+
 from polars_cloud import ComputeContext, authenticate, set_compute_context
 
 
 class PolarsCloudAuth(ConfigurableResource):
-    """Authenticate to Polars Cloud using a service-account secret pair.
-
-    Source ``client_id`` and ``client_secret`` via :class:`dagster.EnvVar` so the
-    raw values are resolved at run launch time and never appear in the Dagster UI.
-    """
+    """Service-account authentication. Runs once per Dagster run."""
 
     client_id: str
     client_secret: str
@@ -50,13 +50,99 @@ class PolarsCloudAuth(ConfigurableResource):
 
 
 class PolarsCloudCompute(ConfigurableResource):
-    """A managed Polars Cloud compute context.
+    """Polars Cloud compute context with auto-managed VM lifecycle.
 
-    Use the ``session()`` context manager from inside an asset (or op) body to
-    activate a ``ComputeContext`` of the configured shape and stop the underlying
-    VM on exit — including on failure.
+    Declares ``PolarsCloudAuth`` as a nested resource so Dagster runs
+    ``authenticate(...)`` before this resource is used. The active
+    ``ComputeContext`` is started in ``yield_for_execution`` and stopped on
+    exit — the ``finally`` clause guarantees the VM is released even when an
+    asset raises.
     """
 
+    auth: PolarsCloudAuth
+    cpus: int
+    memory: int
+
+    @contextmanager
+    def yield_for_execution(self, context):
+        ctx = ComputeContext(cpus=self.cpus, memory=self.memory)
+        try:
+            set_compute_context(ctx)
+            yield self
+        finally:
+            ctx.stop()
+
+
+@asset
+def dataset_1(compute: PolarsCloudCompute):
+    pl.scan_csv(...).remote().sink_parquet(...)
+
+
+@asset
+def dataset_2(compute: PolarsCloudCompute):
+    pl.scan_ndjson(...).remote().sink_parquet(...)
+
+
+@asset(deps=[dataset_1, dataset_2])
+def joined(compute: PolarsCloudCompute):
+    pl.scan_parquet(...).remote().sink_parquet(...)
+
+
+defs = Definitions(
+    assets=[dataset_1, dataset_2, joined],
+    resources={
+        "compute": PolarsCloudCompute(
+            auth=PolarsCloudAuth(
+                client_id=EnvVar("POLARS_CLOUD_CLIENT_ID"),
+                client_secret=EnvVar("POLARS_CLOUD_CLIENT_SECRET"),
+            ),
+            cpus=4,
+            memory=16,
+        ),
+    },
+)
+```
+
+## Pattern 2: per-asset compute sizing
+
+`set_compute_context` is process-global state, so a single auto-managed
+context cannot serve multiple VM shapes within one run. When assets need
+different shapes, each compute resource exposes a `session()` context manager
+instead of starting its `ComputeContext` at run init. The asset opens the
+session of the resource sized for it; the VM is stopped on exit, including on
+failure.
+
+A single `PolarsCloudAuth` instance is reused for both compute resources, so
+the credentials are loaded once at run start.
+
+```python
+from contextlib import contextmanager
+
+import polars as pl
+from dagster import asset, ConfigurableResource, Definitions, EnvVar
+
+from polars_cloud import ComputeContext, authenticate, set_compute_context
+
+
+class PolarsCloudAuth(ConfigurableResource):
+    """Service-account authentication. Runs once per Dagster run."""
+
+    client_id: str
+    client_secret: str
+
+    def setup_for_execution(self, context) -> None:
+        authenticate(client_id=self.client_id, client_secret=self.client_secret)
+
+
+class PolarsCloudCompute(ConfigurableResource):
+    """Polars Cloud compute context with per-asset session management.
+
+    Each ``session()`` call starts a fresh ``ComputeContext`` of the configured
+    shape and stops the VM on exit. ``PolarsCloudAuth`` is a nested resource
+    so Dagster initialises it before any compute resource is used.
+    """
+
+    auth: PolarsCloudAuth
     cpus: int
     memory: int
 
@@ -70,40 +156,38 @@ class PolarsCloudCompute(ConfigurableResource):
             ctx.stop()
 
 
-# Each asset declares both ``auth`` (so ``PolarsCloudAuth.setup_for_execution`` is
-# invoked at run start) and the compute resource that should size its VM.
-
 @asset
-def dataset_1(auth: PolarsCloudAuth, small_vm: PolarsCloudCompute):
+def dataset_1(small_vm: PolarsCloudCompute):
     with small_vm.session():
         pl.scan_csv(...).remote().sink_parquet(...)
 
 
 @asset
-def dataset_2(auth: PolarsCloudAuth, small_vm: PolarsCloudCompute):
+def dataset_2(small_vm: PolarsCloudCompute):
     with small_vm.session():
         pl.scan_ndjson(...).remote().sink_parquet(...)
 
 
-# Use a bigger machine for the join.
 @asset(deps=[dataset_1, dataset_2])
-def joined(auth: PolarsCloudAuth, large_vm: PolarsCloudCompute):
+def joined(large_vm: PolarsCloudCompute):
     with large_vm.session():
         pl.scan_parquet(...).remote().sink_parquet(...)
 
 
+auth = PolarsCloudAuth(
+    client_id=EnvVar("POLARS_CLOUD_CLIENT_ID"),
+    client_secret=EnvVar("POLARS_CLOUD_CLIENT_SECRET"),
+)
+
 defs = Definitions(
     assets=[dataset_1, dataset_2, joined],
     resources={
-        "auth": PolarsCloudAuth(
-            client_id=EnvVar("POLARS_CLOUD_CLIENT_ID"),
-            client_secret=EnvVar("POLARS_CLOUD_CLIENT_SECRET"),
-        ),
-        "small_vm": PolarsCloudCompute(cpus=2, memory=4),
-        "large_vm": PolarsCloudCompute(cpus=4, memory=16),
+        "small_vm": PolarsCloudCompute(auth=auth, cpus=2, memory=4),
+        "large_vm": PolarsCloudCompute(auth=auth, cpus=4, memory=16),
     },
 )
 ```
 
-The Dagster resource key (the dictionary key in `Definitions.resources`) must match the parameter
-name in the asset signature — the type annotation is for editor and type-checker support only.
+The Dagster resource key (the dictionary key in `Definitions.resources`) must
+match the parameter name in each asset signature. The type annotation is for
+editor and type-checker support; Dagster injects by key, not by type.

--- a/docs/source/polars-cloud/integrations/dagster.md
+++ b/docs/source/polars-cloud/integrations/dagster.md
@@ -5,81 +5,105 @@ management. This section details how to integrate Polars Cloud service account c
 Dagster's resource pattern.
 
 Dagster implements secret management through
-[Resources](https://docs.dagster.io/getting-started/concepts#resource)), which provide dependency
-injection for external services. To configure Polars Cloud authentication, define credentials
-through one of these standard approaches:
+[Resources](https://docs.dagster.io/getting-started/concepts#resource), which provide dependency
+injection for external services. The modern, type-checked way to declare a resource is
+[`ConfigurableResource`](https://docs.dagster.io/guides/build/external-resources/defining-resources),
+combined with
+[`EnvVar`](https://docs.dagster.io/guides/operate/configuration/using-environment-variables-and-secrets#dagster-envvar-class)
+for any secret you do not want to surface in the Dagster UI. Pull the secret values from one of:
 
 1. **Secret manager** (<ins>recommended</ins>): pull the secret from a metastore (see official docs
    of your secret manager; here is
    [AWS](https://docs.aws.amazon.com/secretsmanager/latest/userguide/retrieving-secrets-python.html)'
-   as an example).
+   as an example) and expose it to the process as an environment variable, then reference it via
+   `EnvVar`.
 2. **Environment variables**: define the values as environment variables in your Dagster environment
-   (containers or else), and pick them up from your code or Dagster configuration (via the
-   `dagster.yaml` or `workspace.yaml`).
+   (containers or else), and reference them via `EnvVar` so they are resolved at launch time and
+   never displayed in the UI.
 
-Some code snippets for the solutions described above:
-
-```python
-# pull secrets from the aws secret manager
-@resource
-def service_account_from_aws(_):
-    client = boto3.client("secretsmanager")
-    return {
-        "client_id": client.get_secret_value(SecretId="<SECRET>").get("SecretString"),
-        "client_secret": client.get_secret_value(SecretId="<SECRET>").get("SecretString"),
-    }
-```
+Below a complete pipeline definition demonstrating both authentication and per-asset compute sizing.
+The two `PolarsCloud*` resources own all lifecycle: `PolarsCloudAuth` calls `authenticate(...)` once
+at run start (via `setup_for_execution`), and `PolarsCloudCompute` exposes a `session()` context
+manager that activates a fresh `ComputeContext` for the asset body and stops the underlying VM on
+exit — including on failure.
 
 ```python
-# fetch [securely injected!] secrets from environment
-@resource
-def service_account_from_env(_):
-    return {
-        "client_id": os.getenv("POLARS_CLOUD_CLIENT_ID"),
-        "client_secret": os.getenv("POLARS_CLOUD_CLIENT_SECRET"),
-    }
-```
-
-Below a few lines of _pseudo-code_ to define a Dagster flow:
-
-```python
-import os
 import polars as pl
+from contextlib import contextmanager
 
-from dagster import job, op, resource
+from dagster import asset, ConfigurableResource, Definitions, EnvVar
 from polars_cloud import ComputeContext, authenticate, set_compute_context
 
-# define two compute contexts (two instance sizes)
-vm_small = ComputeContext(cpus=2, memory=4)
-vm_large = ComputeContext(cpus=4, memory=16)
 
-# queries will execute on the small vm by default
-set_compute_context(vm_small)
+class PolarsCloudAuth(ConfigurableResource):
+    """Authenticate to Polars Cloud using a service-account secret pair.
 
-@op(required_resource_keys={"sa"})
-def prepare_dataset_1():
-    pl.scan_csv(...).remote().sink_parquet(...)
+    Source ``client_id`` and ``client_secret`` via :class:`dagster.EnvVar` so the
+    raw values are resolved at run launch time and never appear in the Dagster UI.
+    """
 
-@op(required_resource_keys={"sa"})
-def prepare_dataset_2():
-    pl.scan_ndjson(...).remote().sink_parquet(...)
+    client_id: str
+    client_secret: str
 
-# use a bigger machine for this operation
-@op(required_resource_keys={"sa"})
-@set_compute_context(vm_large)
-def join_datasets():
-    pl.scan_parquet(...).remote().sink_parquet(...)
+    def setup_for_execution(self, context) -> None:
+        authenticate(client_id=self.client_id, client_secret=self.client_secret)
 
-@job(resource_defs={"sa": service_account_from_aws})
-def report():
-    # authenticate to polars cloud with the secrets created above
-    authenticate(**sa)
 
-    prepare_dataset_1()
-    prepare_dataset_2()
-    join_datasets()
+class PolarsCloudCompute(ConfigurableResource):
+    """A managed Polars Cloud compute context.
 
-# stop the instances
-vm_small.stop()
-vm_large.stop()
+    Use the ``session()`` context manager from inside an asset (or op) body to
+    activate a ``ComputeContext`` of the configured shape and stop the underlying
+    VM on exit — including on failure.
+    """
+
+    cpus: int
+    memory: int
+
+    @contextmanager
+    def session(self):
+        ctx = ComputeContext(cpus=self.cpus, memory=self.memory)
+        try:
+            set_compute_context(ctx)
+            yield ctx
+        finally:
+            ctx.stop()
+
+
+# Each asset declares both ``auth`` (so ``PolarsCloudAuth.setup_for_execution`` is
+# invoked at run start) and the compute resource that should size its VM.
+
+@asset
+def dataset_1(auth: PolarsCloudAuth, small_vm: PolarsCloudCompute):
+    with small_vm.session():
+        pl.scan_csv(...).remote().sink_parquet(...)
+
+
+@asset
+def dataset_2(auth: PolarsCloudAuth, small_vm: PolarsCloudCompute):
+    with small_vm.session():
+        pl.scan_ndjson(...).remote().sink_parquet(...)
+
+
+# Use a bigger machine for the join.
+@asset(deps=[dataset_1, dataset_2])
+def joined(auth: PolarsCloudAuth, large_vm: PolarsCloudCompute):
+    with large_vm.session():
+        pl.scan_parquet(...).remote().sink_parquet(...)
+
+
+defs = Definitions(
+    assets=[dataset_1, dataset_2, joined],
+    resources={
+        "auth": PolarsCloudAuth(
+            client_id=EnvVar("POLARS_CLOUD_CLIENT_ID"),
+            client_secret=EnvVar("POLARS_CLOUD_CLIENT_SECRET"),
+        ),
+        "small_vm": PolarsCloudCompute(cpus=2, memory=4),
+        "large_vm": PolarsCloudCompute(cpus=4, memory=16),
+    },
+)
 ```
+
+The Dagster resource key (the dictionary key in `Definitions.resources`) must match the parameter
+name in the asset signature — the type annotation is for editor and type-checker support only.


### PR DESCRIPTION
## What

Rewrites `docs/source/polars-cloud/integrations/dagster.md` to use modern Dagster patterns, addressing all three issues called out by @danielgafni in #27384.

## Why

The previous example used three patterns that have been legacy or actively misleading for some time:

1. **`@resource`** — the legacy decorator-based resource API. The modern, type-checked replacement is [`ConfigurableResource`](https://docs.dagster.io/guides/build/external-resources/defining-resources).
2. **`os.getenv(...)` for secrets** — values get embedded into the resource config and surface in the Dagster UI. The fix is [`EnvVar`](https://docs.dagster.io/guides/operate/configuration/using-environment-variables-and-secrets#dagster-envvar-class), which resolves at launch time and *never* displays the resolved value. As @danielgafni notes in the issue, `EnvVar` *must* pair with `ConfigurableResource` to work.
3. **`vm_small.stop()` / `vm_large.stop()` at module scope** — these ran at import time, then never again. The actual job body never stopped its VM.

## How

A single end-to-end pipeline now demonstrates both authentication and per-asset compute sizing:

- **`PolarsCloudAuth(ConfigurableResource)`** wraps `authenticate(client_id, client_secret)` and runs it once per run via `setup_for_execution`. Credentials are sourced via `EnvVar(...)`.
- **`PolarsCloudCompute(ConfigurableResource)`** exposes a `@contextmanager session()` that activates a fresh `ComputeContext` of the configured shape and `stop()`s the underlying VM in `finally` — including on failure.
- The pipeline restructures around `@asset` + `Definitions` (per @danielgafni's suggestion), with two compute resources (`small_vm`, `large_vm`) and per-asset opt-in via the parameter signature.
- Each asset takes `auth: PolarsCloudAuth` so the auth resource's `setup_for_execution` is actually invoked at run start. (A resource is only set up when at least one asset/op declares it.)

## Notes for review

- The example still uses placeholder `...` for `pl.scan_csv(...)` arguments — the file is an integration example, not an executable script.
- `EnvVar` resolution on plain `str` fields is supported in Dagster 1.5+. If polars-cloud needs to support older Dagsters, happy to switch to typed `EnvVar` fields.
- Closes #27384.