### PR TITLE
fix(rust): Return correct `Struct` dtype from `qcut` when "include_breaks=True" on empty series

### DIFF
--- a/crates/polars-ops/src/series/ops/cut.rs
+++ b/crates/polars-ops/src/series/ops/cut.rs
@@ -186,11 +186,22 @@ pub fn qcut(
 
     if s.null_count() == s.len() {
         // If we only have nulls we don't have any breakpoints.
-        return Ok(Series::full_null(
-            s.name().clone(),
-            s.len(),
-            &DataType::from_categories(Categories::global()),
-        ));
+        let cat_dtype = DataType::from_categories(Categories::global());
+        if include_breaks {
+            let brk = Series::full_null(
+                PlSmallStr::from_static("breakpoint"),
+                s.len(),
+                &DataType::Float64,
+            );
+            let cat = Series::full_null(PlSmallStr::from_static("category"), s.len(), &cat_dtype);
+            return Ok(StructChunked::from_series(
+                s.name().clone(),
+                s.len(),
+                [&brk, &cat].into_iter(),
+            )?
+            .into_series());
+        }
+        return Ok(Series::full_null(s.name().clone(), s.len(), &cat_dtype));
     }
 
     let s = s.cast(&DataType::Float64)?;

--- a/py-polars/tests/unit/operations/test_qcut.py
+++ b/py-polars/tests/unit/operations/test_qcut.py
@@ -109,6 +109,36 @@ def test_qcut_full_null_with_labels() -> None:
     assert_series_equal(result, expected, categorical_as_str=True)
 
 
+def test_qcut_empty_include_breaks_27284() -> None:
+    # https://github.com/pola-rs/polars/issues/27284
+    empty = pl.Series("x", [], dtype=pl.Float64)
+    result = empty.qcut(3, include_breaks=True)
+
+    expected_dtype = pl.Struct({"breakpoint": pl.Float64, "category": pl.Categorical})
+    assert result.dtype == expected_dtype
+    assert len(result) == 0
+
+
+def test_qcut_empty_include_breaks_lazy_27284() -> None:
+    # https://github.com/pola-rs/polars/issues/27284
+    frame = pl.LazyFrame({"x": pl.Series([], dtype=pl.Float64)})
+    expr = pl.col("x").qcut(3, include_breaks=True).struct.field("breakpoint")
+    result = frame.select(expr).collect()
+
+    assert result.schema == {"breakpoint": pl.Float64}
+    assert len(result) == 0
+
+
+def test_qcut_full_null_include_breaks() -> None:
+    # Variant: all-null (not just empty) with include_breaks
+    s = pl.Series("x", [None, None, None], dtype=pl.Float64)
+    result = s.qcut([0.25, 0.50], include_breaks=True)
+
+    expected_dtype = pl.Struct({"breakpoint": pl.Float64, "category": pl.Categorical})
+    assert result.dtype == expected_dtype
+    assert len(result) == 3
+
+
 def test_qcut_allow_duplicates() -> None:
     s = pl.Series([1, 2, 2, 3])
 


### PR DESCRIPTION
Fixes #27284.

When a Series is empty (length 0), `qcut` with `include_breaks=True` hits the
early-return path at `null_count() == len()` (0 == 0) and returns a Categorical
column instead of the expected Struct with breakpoint + category fields.

This returns a properly-typed empty `StructChunked` with Float64 breakpoint and
Categorical category fields when `include_breaks` is set in the early-return path.

Tests cover empty series, empty series in lazy context, and all-null series.