### PR TITLE
feat: Add support for the SQL `FILTER` clause for aggregate functions, and `STRING_AGG`

### DIFF
--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -33,6 +33,7 @@ pub(crate) struct SQLFunctionVisitor<'a> {
     pub(crate) func: &'a SQLFunction,
     pub(crate) ctx: &'a mut SQLContext,
     pub(crate) active_schema: Option<&'a Schema>,
+    pub(crate) filter: Option<Expr>,
 }
 
 /// SQL functions that are supported by Polars
@@ -630,6 +631,15 @@ pub(crate) enum PolarsSQLFunctions {
     /// SELECT STDDEV(col1) FROM df;
     /// ```
     StdDev,
+    /// SQL 'string_agg' function (also known as `GROUP_CONCAT`).
+    /// Concatenates the input string values into a single string,
+    /// separated by the given delimiter (`,` if unspecified).
+    /// ```sql
+    /// SELECT STRING_AGG(col1) FROM df;
+    /// SELECT STRING_AGG(col1, ',' ORDER BY col2 DESC) FROM df;
+    /// SELECT STRING_AGG(DISTINCT col1, ',' ORDER BY col1) FROM df;
+    /// ```
+    StringAgg,
     /// SQL 'sum' function.
     /// Returns the sum of all the elements in the grouping.
     /// ```sql
@@ -688,12 +698,6 @@ pub(crate) enum PolarsSQLFunctions {
     /// SELECT ARRAY_UNIQUE(col1) FROM df;
     /// ```
     ArrayUnique,
-    /// SQL 'unnest' function.
-    /// Unnest/explodes an array column into multiple rows.
-    /// ```sql
-    /// SELECT unnest(col1) FROM df;
-    /// ```
-    Explode,
     /// SQL 'array_agg' function.
     /// Concatenates the input expressions, including nulls, into an array.
     /// ```sql
@@ -719,6 +723,12 @@ pub(crate) enum PolarsSQLFunctions {
     /// SELECT ARRAY_CONTAINS(col1, 'foo') FROM df;
     /// ```
     ArrayContains,
+    /// SQL 'unnest' function.
+    /// Unnest/explodes an array column into multiple rows.
+    /// ```sql
+    /// SELECT UNNEST(col1) FROM df;
+    /// ```
+    Explode,
 
     // ----
     // Window functions
@@ -1029,6 +1039,7 @@ impl PolarsSQLFunctions {
             "quantile_cont" => Self::QuantileCont,
             "quantile_disc" => Self::QuantileDisc,
             "stdev" | "stddev" | "stdev_samp" | "stddev_samp" => Self::StdDev,
+            "string_agg" | "listagg" | "group_concat" => Self::StringAgg,
             "sum" => Self::Sum,
             "var" | "variance" | "var_samp" => Self::Variance,
 
@@ -1085,15 +1096,18 @@ impl SQLFunctionVisitor<'_> {
         let function_name = PolarsSQLFunctions::try_from_sql(self.func, self.ctx)?;
         let function = self.func;
 
-        // TODO: implement the following functions where possible
+        // TODO: implement the following modifiers where possible
         if !function.within_group.is_empty() {
             polars_bail!(SQLInterface: "'WITHIN GROUP' is not currently supported")
         }
-        if function.filter.is_some() {
-            polars_bail!(SQLInterface: "'FILTER' is not currently supported")
-        }
         if function.null_treatment.is_some() {
             polars_bail!(SQLInterface: "'IGNORE|RESPECT NULLS' is not currently supported")
+        }
+        if let Some(filter_expr) = &function.filter {
+            if function.over.is_some() {
+                polars_bail!(SQLInterface: "'FILTER' combined with 'OVER' is not supported")
+            }
+            self.filter = Some(parse_sql_expr(filter_expr, self.ctx, self.active_schema)?);
         }
 
         let log_with_base =
@@ -1626,6 +1640,7 @@ impl SQLFunctionVisitor<'_> {
             },
             Min => self.visit_unary_with_opt_cumulative(Expr::min, Expr::cum_min),
             StdDev => self.visit_unary(|e| e.std(1)),
+            StringAgg => self.visit_string_agg(),
             Sum => self.visit_unary_with_opt_cumulative(Expr::sum, Expr::cum_sum),
             Variance => self.visit_unary(|e| e.var(1)),
 
@@ -1957,6 +1972,18 @@ impl SQLFunctionVisitor<'_> {
         }
     }
 
+    /// Parse an argument of the function currently being visited.
+    ///
+    /// Behaves like [`parse_sql_expr`] but also accounts for any
+    /// active `FILTER (WHERE …)` clause from the surrounding call.
+    fn parse_sql_arg(&mut self, expr: &SQLExpr) -> PolarsResult<Expr> {
+        let parsed = parse_sql_expr(expr, self.ctx, self.active_schema)?;
+        Ok(match &self.filter {
+            Some(pred) => parsed.filter(pred.clone()),
+            None => parsed,
+        })
+    }
+
     fn visit_unary(&mut self, f: impl Fn(Expr) -> Expr) -> PolarsResult<Expr> {
         self.try_visit_unary(|e| Ok(f(e)))
     }
@@ -1964,14 +1991,10 @@ impl SQLFunctionVisitor<'_> {
     fn try_visit_unary(&mut self, f: impl Fn(Expr) -> PolarsResult<Expr>) -> PolarsResult<Expr> {
         let args = extract_args(self.func)?;
         match args.as_slice() {
-            [FunctionArgExpr::Expr(sql_expr)] => {
-                f(parse_sql_expr(sql_expr, self.ctx, self.active_schema)?)
+            [FunctionArgExpr::Expr(sql_expr)] => f(self.parse_sql_arg(sql_expr)?),
+            [FunctionArgExpr::Wildcard] => {
+                f(self.parse_sql_arg(&SQLExpr::Wildcard(AttachedToken::empty()))?)
             },
-            [FunctionArgExpr::Wildcard] => f(parse_sql_expr(
-                &SQLExpr::Wildcard(AttachedToken::empty()),
-                self.ctx,
-                self.active_schema,
-            )?),
             _ => self.not_supported_error(),
         }
         .and_then(|e| self.apply_window_spec(e, &self.func.over))
@@ -2029,8 +2052,8 @@ impl SQLFunctionVisitor<'_> {
                 FunctionArgExpr::Expr(sql_expr1),
                 FunctionArgExpr::Expr(sql_expr2),
             ] => {
-                let expr1 = parse_sql_expr(sql_expr1, self.ctx, self.active_schema)?;
-                let expr2 = Arg::from_sql_expr(sql_expr2, self.ctx)?;
+                let expr1 = self.parse_sql_arg(sql_expr1)?;
+                let expr2 = Arg::from_sql_arg(sql_expr2, self)?;
                 f(expr1, expr2)
             },
             _ => self.not_supported_error(),
@@ -2049,7 +2072,7 @@ impl SQLFunctionVisitor<'_> {
         let mut expr_args = vec![];
         for arg in args {
             if let FunctionArgExpr::Expr(sql_expr) = arg {
-                expr_args.push(parse_sql_expr(sql_expr, self.ctx, self.active_schema)?);
+                expr_args.push(self.parse_sql_arg(sql_expr)?);
             } else {
                 return self.not_supported_error();
             };
@@ -2068,9 +2091,9 @@ impl SQLFunctionVisitor<'_> {
                 FunctionArgExpr::Expr(sql_expr2),
                 FunctionArgExpr::Expr(sql_expr3),
             ] => {
-                let expr1 = parse_sql_expr(sql_expr1, self.ctx, self.active_schema)?;
-                let expr2 = Arg::from_sql_expr(sql_expr2, self.ctx)?;
-                let expr3 = Arg::from_sql_expr(sql_expr3, self.ctx)?;
+                let expr1 = self.parse_sql_arg(sql_expr1)?;
+                let expr2 = Arg::from_sql_arg(sql_expr2, self)?;
+                let expr3 = Arg::from_sql_arg(sql_expr3, self)?;
                 f(expr1, expr2, expr3)
             },
             _ => self.not_supported_error(),
@@ -2085,53 +2108,97 @@ impl SQLFunctionVisitor<'_> {
         Ok(f())
     }
 
+    /// Apply in-arg "aggregate modifiers" inside an aggregate's argument
+    /// list, eg: `ARRAY_AGG(DISTINCT x ORDER BY y LIMIT 5)`. Composes
+    /// with the visitor-level `FILTER (WHERE …)` clause.
+    fn apply_aggregate_clauses(
+        &mut self,
+        mut base: Expr,
+        is_distinct: bool,
+        clauses: &[FunctionArgumentClause],
+        base_sql_expr: &SQLExpr,
+        func_name: &str,
+    ) -> PolarsResult<Expr> {
+        let mut order_by_clause = None;
+        let mut limit_clause = None;
+        for clause in clauses {
+            match clause {
+                FunctionArgumentClause::OrderBy(order_exprs) => {
+                    order_by_clause = Some(order_exprs.as_slice());
+                },
+                FunctionArgumentClause::Limit(limit_expr) => {
+                    limit_clause = Some(limit_expr);
+                },
+                _ => {},
+            }
+        }
+        if is_distinct {
+            // DISTINCT: apply unique first, then sort the deduplicated result.
+            base = base.unique_stable();
+            if let Some(order_by) = order_by_clause {
+                base = self.apply_order_by_to_distinct_array(base, order_by, base_sql_expr)?;
+            }
+        } else if let Some(order_by) = order_by_clause {
+            base = self.apply_order_by(base, order_by)?;
+        }
+        if let Some(limit_expr) = limit_clause {
+            let limit = parse_sql_expr(limit_expr, self.ctx, self.active_schema)?;
+            match limit {
+                Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(n))) if n >= 0 => {
+                    base = base.head(Some(n as usize))
+                },
+                _ => {
+                    polars_bail!(SQLSyntax: "LIMIT in {} must be a positive integer", func_name)
+                },
+            };
+        }
+        Ok(base)
+    }
+
     fn visit_arr_agg(&mut self) -> PolarsResult<Expr> {
         let (args, is_distinct, clauses) = extract_args_and_clauses(self.func)?;
         match args.as_slice() {
             [FunctionArgExpr::Expr(sql_expr)] => {
-                let mut base = parse_sql_expr(sql_expr, self.ctx, self.active_schema)?;
-                let mut order_by_clause = None;
-                let mut limit_clause = None;
-                for clause in &clauses {
-                    match clause {
-                        FunctionArgumentClause::OrderBy(order_exprs) => {
-                            order_by_clause = Some(order_exprs.as_slice());
-                        },
-                        FunctionArgumentClause::Limit(limit_expr) => {
-                            limit_clause = Some(limit_expr);
-                        },
-                        _ => {},
-                    }
-                }
-                if !is_distinct {
-                    // No DISTINCT: apply ORDER BY normally
-                    if let Some(order_by) = order_by_clause {
-                        base = self.apply_order_by(base, order_by)?;
-                    }
-                } else {
-                    // DISTINCT: apply unique, then sort the result
-                    base = base.unique_stable();
-                    if let Some(order_by) = order_by_clause {
-                        base = self.apply_order_by_to_distinct_array(base, order_by, sql_expr)?;
-                    }
-                }
-                if let Some(limit_expr) = limit_clause {
-                    let limit = parse_sql_expr(limit_expr, self.ctx, self.active_schema)?;
-                    match limit {
-                        Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(n))) if n >= 0 => {
-                            base = base.head(Some(n as usize))
-                        },
-                        _ => {
-                            polars_bail!(SQLSyntax: "LIMIT in ARRAY_AGG must be a positive integer")
-                        },
-                    };
-                }
+                let base = self.parse_sql_arg(sql_expr)?;
+                let base = self.apply_aggregate_clauses(
+                    base,
+                    is_distinct,
+                    &clauses,
+                    sql_expr,
+                    "ARRAY_AGG",
+                )?;
                 Ok(base.implode(true))
             },
             _ => {
                 polars_bail!(SQLSyntax: "ARRAY_AGG must have exactly one argument; found {}", args.len())
             },
         }
+    }
+
+    fn visit_string_agg(&mut self) -> PolarsResult<Expr> {
+        let (args, is_distinct, clauses) = extract_args_and_clauses(self.func)?;
+        let (sql_expr, separator) = match args.as_slice() {
+            [FunctionArgExpr::Expr(sql_expr)] => (sql_expr, lit(",")),
+            [
+                FunctionArgExpr::Expr(sql_expr),
+                FunctionArgExpr::Expr(sep_sql_expr),
+            ] => (
+                sql_expr,
+                parse_sql_expr(sep_sql_expr, self.ctx, self.active_schema)?,
+            ),
+            _ => polars_bail!(
+                SQLSyntax: "STRING_AGG expects 1-2 arguments (found {})",
+                args.len()
+            ),
+        };
+        let base = self.parse_sql_arg(sql_expr)?;
+        let base =
+            self.apply_aggregate_clauses(base, is_distinct, &clauses, sql_expr, "STRING_AGG")?;
+        Ok(base
+            .cast(DataType::String)
+            .implode(true)
+            .list()
+            .join(separator, true))
     }
 
     fn visit_arr_to_string(&mut self) -> PolarsResult<Expr> {
@@ -2219,19 +2286,26 @@ impl SQLFunctionVisitor<'_> {
                 }
             }
         }
+        // COUNT(*), COUNT(1) with FILTER: count rows where the predicate is true.
+        let count_star = || match &self.filter {
+            Some(pred) => pred.clone().sum(),
+            None => len(),
+        };
         let count_expr = match (is_distinct, args.as_slice()) {
             // COUNT(*), COUNT()
-            (false, [FunctionArgExpr::Wildcard] | []) => len(),
+            (false, [FunctionArgExpr::Wildcard] | []) => count_star(),
             // COUNT(<non-null literal>) is equivalent to COUNT(*)
-            (false, [FunctionArgExpr::Expr(sql_expr)]) if is_non_null_literal(sql_expr) => len(),
+            (false, [FunctionArgExpr::Expr(sql_expr)]) if is_non_null_literal(sql_expr) => {
+                count_star()
+            },
             // COUNT(col)
             (false, [FunctionArgExpr::Expr(sql_expr)]) => {
-                let expr = parse_sql_expr(sql_expr, self.ctx, self.active_schema)?;
+                let expr = self.parse_sql_arg(sql_expr)?;
                 expr.count()
             },
             // COUNT(DISTINCT col)
             (true, [FunctionArgExpr::Expr(sql_expr)]) => {
-                let expr = parse_sql_expr(sql_expr, self.ctx, self.active_schema)?;
+                let expr = self.parse_sql_arg(sql_expr)?;
                 expr.clone().n_unique().sub(expr.null_count().gt(lit(0)))
             },
             _ => self.not_supported_error()?,
@@ -2246,9 +2320,11 @@ impl SQLFunctionVisitor<'_> {
 
         for ob in order_by {
             // Note: if not specified 'NULLS FIRST' is default for DESC, 'NULLS LAST' otherwise
-            // https://www.postgresql.org/docs/current/queries-order.html
+            // https://www.postgresql.org/docs/current/queries-order.html. Also: ORDER BY exprs
+            // share their length with the (possibly filtered) base, so they have to go through
+            // `parse_sql_arg` to apply any active FILTER.
             let desc_order = !ob.options.asc.unwrap_or(true);
-            by.push(parse_sql_expr(&ob.expr, self.ctx, self.active_schema)?);
+            by.push(self.parse_sql_arg(&ob.expr)?);
             nulls_last.push(!ob.options.nulls_first.unwrap_or(desc_order));
             descending.push(desc_order);
         }
@@ -2419,6 +2495,16 @@ pub(crate) trait FromSQLExpr {
     fn from_sql_expr(expr: &SQLExpr, ctx: &mut SQLContext) -> PolarsResult<Self>
     where
         Self: Sized;
+
+    /// Parse SQL expression as an argument of the function being visited, taking
+    /// the surrounding visitor into account. Allows active `FILTER (WHERE …)`
+    /// clauses to be applied to all args without each call knowing about FILTER.
+    fn from_sql_arg(expr: &SQLExpr, visitor: &mut SQLFunctionVisitor<'_>) -> PolarsResult<Self>
+    where
+        Self: Sized,
+    {
+        Self::from_sql_expr(expr, visitor.ctx)
+    }
 }
 
 impl FromSQLExpr for f64 {
@@ -2492,5 +2578,9 @@ impl FromSQLExpr for Expr {
         Self: Sized,
     {
         parse_sql_expr(expr, ctx, None)
+    }
+
+    fn from_sql_arg(expr: &SQLExpr, visitor: &mut SQLFunctionVisitor<'_>) -> PolarsResult<Self> {
+        visitor.parse_sql_arg(expr)
     }
 }

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -807,6 +807,7 @@ impl SQLExprVisitor<'_> {
             func: function,
             ctx: self.ctx,
             active_schema: self.active_schema,
+            filter: None,
         };
         visitor.visit_function()
     }

--- a/py-polars/docs/source/reference/sql/functions/aggregate.rst
+++ b/py-polars/docs/source/reference/sql/functions/aggregate.rst
@@ -32,10 +32,58 @@ Aggregate
        value associated with the subinterval where the quantile value falls.
    * - :ref:`STDDEV <stddev>`
      - Returns the standard deviation of all the elements in the grouping.
+   * - :ref:`STRING_AGG <string_agg>`
+     - Concatenates the input string values into a single string, separated by a delimiter.
    * - :ref:`SUM <sum>`
      - Returns the sum of all the elements in the grouping.
    * - :ref:`VARIANCE <variance>`
      - Returns the variance of all the elements in the grouping.
+
+
+.. _filter:
+
+Filtering aggregates
+--------------------
+Any aggregate function call can be qualified with a ``FILTER (WHERE …)`` clause
+that restricts it to the rows where the predicate is true. The clause is attached
+to an individual aggregate call and is independent of the query's ``WHERE`` clause,
+so multiple aggregates in the same ``SELECT`` can see different row sets.
+
+.. note::
+
+   ``FILTER`` cannot be combined with ``OVER`` on the same aggregate call.
+
+**Example:**
+
+.. code-block:: python
+
+    df = pl.DataFrame(
+        {
+            "category": ["A", "B", "A", "B", "A", "B"],
+            "value":    [10, 20, 30, 40, 50, 60],
+        }
+    )
+    df.sql("""
+      SELECT
+        category,
+        SUM(value) AS total,
+        SUM(value) FILTER (WHERE value > 25) AS total_high,
+        SUM(value) FILTER (WHERE value <= 25) AS total_low,
+        COUNT(*) FILTER (WHERE value >= 40) AS n_top
+      FROM self
+      GROUP BY category
+      ORDER BY category
+    """)
+    # shape: (2, 5)
+    # ┌──────────┬───────┬────────────┬───────────┬───────┐
+    # │ category ┆ total ┆ total_high ┆ total_low ┆ n_top │
+    # │ ---      ┆ ---   ┆ ---        ┆ ---       ┆ ---   │
+    # │ str      ┆ i64   ┆ i64        ┆ i64       ┆ u32   │
+    # ╞══════════╪═══════╪════════════╪═══════════╪═══════╡
+    # │ A        ┆ 90    ┆ 80         ┆ 10        ┆ 1     │
+    # │ B        ┆ 120   ┆ 100        ┆ 20        ┆ 2     │
+    # └──────────┴───────┴────────────┴───────────┴───────┘
+
 
 .. _avg:
 
@@ -119,12 +167,12 @@ Returns the amount of elements in the grouping.
 .. _covar:
 
 COVAR
----
+-----
 Returns the covariance between two columns.
 
 .. admonition:: Aliases
     
-   `COVAR`, `COVAR_SAMP`
+   `COVAR_SAMP`
 
 **Example:**
 
@@ -349,6 +397,50 @@ Returns the sample standard deviation of all the elements in the grouping.
     # ╞══════════╪══════════╡
     # │ 6.429101 ┆ 5.686241 │
     # └──────────┴──────────┘
+
+.. _string_agg:
+
+STRING_AGG
+----------
+Concatenates the input string values into a single string, separated by the given
+delimiter. Supports ``DISTINCT`` and in-argument ``ORDER BY`` and ``LIMIT``
+clauses to control which values are concatenated and in what order; the
+separator is optional, defaulting to ``","``.
+
+.. admonition:: Aliases
+
+   `GROUP_CONCAT`, `LISTAGG`
+
+**Example:**
+
+.. code-block:: python
+
+    df = pl.DataFrame(
+        {
+            "category": ["A", "B", "A", "B", "A", "B"],
+            "label": ["x1", "y1", "x2", "y2", "x3", "y3"],
+            "value": [10, 20, 30, 40, 50, 60],
+        }
+    )
+    df.sql("""
+      SELECT
+        category,
+        STRING_AGG(label LIMIT 2) AS two_labels,
+        STRING_AGG(label, ':' ORDER BY value DESC) AS labels_desc,
+        STRING_AGG(label, ',' ORDER BY value ASC) FILTER(WHERE label !~ '1$') AS labels_omit_1,
+      FROM self
+      GROUP BY category
+      ORDER BY category
+    """)
+    # shape: (2, 4)
+    # ┌──────────┬────────────┬─────────────┬───────────────┐
+    # │ category ┆ two_labels ┆ labels_desc ┆ labels_omit_1 │
+    # │ ---      ┆ ---        ┆ ---         ┆ ---           │
+    # │ str      ┆ str        ┆ str         ┆ str           │
+    # ╞══════════╪════════════╪═════════════╪═══════════════╡
+    # │ A        ┆ x1,x2      ┆ x3:x2:x1    ┆ x2,x3         │
+    # │ B        ┆ y1,y2      ┆ y3:y2:y1    ┆ y2,y3         │
+    # └──────────┴────────────┴─────────────┴───────────────┘
 
 .. _sum:
 

--- a/py-polars/docs/source/reference/sql/functions/string.rst
+++ b/py-polars/docs/source/reference/sql/functions/string.rst
@@ -897,7 +897,7 @@ unless a strftime-compatible formatting string is provided as the second paramet
 
    `DATETIME`
 
-.. tip::
+.. note::
 
   `TIMESTAMP` is also supported as a typed literal (this form does not allow a format string).
 

--- a/py-polars/tests/unit/sql/asserts.py
+++ b/py-polars/tests/unit/sql/asserts.py
@@ -84,7 +84,9 @@ def assert_sql_matches(
     frames: pl.DataFrame | pl.LazyFrame | dict[str, pl.DataFrame | pl.LazyFrame],
     *,
     query: str,
-    compare_with: Literal["sqlite", "duckdb"] | Collection[Literal["sqlite", "duckdb"]],
+    compare_with: Literal["sqlite", "duckdb"]
+    | Collection[Literal["sqlite", "duckdb"]]
+    | None,
     check_dtypes: bool = False,
     check_row_order: bool = True,
     check_column_names: bool = True,
@@ -108,6 +110,7 @@ def assert_sql_matches(
         One or more named SQL engines to use as a reference for comparison.
         - 'sqlite': Use Python's built-in `sqlite3` module.
         - 'duckdb': Use DuckDB (requires `duckdb` to be installed separately).
+        - None: Don't compare against a backend (requires that "expected" is set).
     check_dtypes
         Require that the comparison frame dtypes match; defaults to False, as different
         backends may use different type systems, and we care about the values.
@@ -153,7 +156,12 @@ def assert_sql_matches(
     with pl.SQLContext(frames=frames, eager=True) as ctx:
         polars_result = ctx.execute(query=query, eager=True)
 
-    if isinstance(compare_with, str):
+    if not compare_with:
+        if expected is None:
+            msg = "if no comparison backend specified, `expected` is required"
+            raise ValueError(msg)
+        compare_with = []
+    elif isinstance(compare_with, str):
         compare_with = [compare_with]
 
     for comparison_backend in compare_with:

--- a/py-polars/tests/unit/sql/test_filter_clause.py
+++ b/py-polars/tests/unit/sql/test_filter_clause.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import pytest
+
+import polars as pl
+from polars.exceptions import SQLInterfaceError
+from tests.unit.sql import assert_sql_matches
+
+
+@pytest.fixture
+def lf() -> pl.LazyFrame:
+    return pl.LazyFrame(
+        {
+            "grp": ["a", "b", "a", "b", "a", "b"],
+            "x": [1, 2, 3, 4, None, 6],
+            "y": [10, 20, 30, 40, 50, 60],
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("agg", "values"),
+    [
+        ("SUM(x) FILTER (WHERE y > 20)", [3, 10]),
+        ("AVG(x) FILTER (WHERE y > 20)", [3.0, 5.0]),
+        ("MIN(x) FILTER (WHERE grp = 'a')", [1, None]),
+        ("MAX(x) FILTER (WHERE grp = 'a')", [3, None]),
+        ("COUNT(*) FILTER (WHERE grp = 'a')", [3, 0]),
+        ("COUNT(1) FILTER (WHERE grp = 'a')", [3, 0]),
+        ("COUNT(x) FILTER (WHERE grp = 'a')", [2, 0]),
+        ("COUNT(x) FILTER (WHERE y > 20)", [1, 2]),
+        ("COUNT(DISTINCT x) FILTER (WHERE y > 20)", [1, 2]),
+    ],
+)
+def test_filter_clause_grouped(lf: pl.LazyFrame, agg: str, values: list[Any]) -> None:
+    assert_sql_matches(
+        frames=lf,
+        query=f"SELECT grp, {agg} AS v FROM self GROUP BY grp ORDER BY grp",
+        compare_with="sqlite",
+        expected={"grp": ["a", "b"], "v": values},
+    )
+
+
+@pytest.mark.parametrize(
+    ("agg", "values"),
+    [
+        ("MEDIAN(x) FILTER (WHERE y > 20)", [3.0, 5.0]),
+        ("STDDEV_SAMP(x) FILTER (WHERE y > 20)", [None, math.sqrt(2.0)]),
+        ("VAR_SAMP(x) FILTER (WHERE y > 20)", [None, 2.0]),
+    ],
+)
+def test_filter_clause_misc_aggfuncs(
+    lf: pl.LazyFrame, agg: str, values: list[Any]
+) -> None:
+    assert_sql_matches(
+        frames=lf,
+        query=f"SELECT grp, {agg} AS v FROM self GROUP BY grp ORDER BY grp",
+        compare_with="duckdb",
+        expected={"grp": ["a", "b"], "v": values},
+    )
+
+
+@pytest.mark.parametrize(
+    ("agg", "value"),
+    [
+        ("SUM(x) FILTER (WHERE y > 20)", 13),
+        ("AVG(x) FILTER (WHERE y > 20)", 13.0 / 3.0),
+        ("COUNT(*) FILTER (WHERE grp = 'a')", 3),
+        ("COUNT(x) FILTER (WHERE y > 20)", 3),
+        ("COUNT(DISTINCT x) FILTER (WHERE grp = 'b')", 3),
+    ],
+)
+def test_filter_clause_no_group_by(lf: pl.LazyFrame, agg: str, value: Any) -> None:
+    assert_sql_matches(
+        frames=lf,
+        query=f"SELECT {agg} AS v FROM self",
+        compare_with="sqlite",
+        expected={"v": [value]},
+    )
+
+
+def test_filter_clause_multiple_aggs(lf: pl.LazyFrame) -> None:
+    assert_sql_matches(
+        frames=lf,
+        query="""
+            SELECT
+                grp,
+                SUM(x) FILTER (WHERE y > 20) AS sum_high,
+                COUNT(*) FILTER (WHERE x IS NOT NULL) AS n_not_null,
+                AVG(y) FILTER (WHERE grp = 'a') AS avg_a
+            FROM self
+            GROUP BY grp
+            ORDER BY grp
+        """,
+        compare_with="sqlite",
+        expected={
+            "grp": ["a", "b"],
+            "sum_high": [3, 10],
+            "n_not_null": [2, 3],
+            "avg_a": [30.0, None],
+        },
+    )
+
+
+def test_filter_clause_multi_parameter_func() -> None:
+    lf = pl.LazyFrame(
+        {
+            "a": [1, 2, 3, 4, 5, 6],
+            "b": [2, 4, 10, 8, 9, 13],
+            "c": ["a", "b", "a", "a", "b", "b"],
+        }
+    )
+    expected_b = 165.0 / math.sqrt(78.0 * 366.0)
+    assert_sql_matches(
+        frames=lf,
+        query="""
+            SELECT c, CORR(a, b) FILTER (WHERE a > 1) AS r
+            FROM self GROUP BY c
+            ORDER BY c
+        """,
+        compare_with="duckdb",
+        expected={"c": ["a", "b"], "r": [-1.0, expected_b]},
+    )
+
+
+def test_filter_clause_filter_plus_over_unsupported() -> None:
+    df = pl.DataFrame({"grp": ["a", "b"], "x": [1, 2], "y": [10, 30]})
+    with pytest.raises(SQLInterfaceError, match=r"FILTER.*OVER"):
+        pl.sql("SELECT SUM(x) FILTER (WHERE y > 20) OVER (PARTITION BY grp) FROM df")

--- a/py-polars/tests/unit/sql/test_group_by.py
+++ b/py-polars/tests/unit/sql/test_group_by.py
@@ -583,7 +583,6 @@ def test_group_by_empty_or_scalar_key_exprs_23397() -> None:
     plan = q.explain()
 
     assert plan.startswith("SELECT")
-
     assert_frame_equal(
         q.collect(),
         pl.DataFrame({"len": pl.Series([5], dtype=pl.get_index_type())}),
@@ -593,7 +592,6 @@ def test_group_by_empty_or_scalar_key_exprs_23397() -> None:
     plan = q.explain()
 
     assert plan.startswith("SELECT")
-
     assert_frame_equal(
         q.collect(),
         pl.DataFrame({"a": pl.Series([[0, 1, 2, 3, 4]])}),
@@ -603,7 +601,6 @@ def test_group_by_empty_or_scalar_key_exprs_23397() -> None:
     plan = q.explain()
 
     assert plan.startswith("SELECT")
-
     assert_frame_equal(
         q.collect(),
         pl.DataFrame({"a": pl.Series([[0, 1, 2, 3, 4]])}),
@@ -613,7 +610,6 @@ def test_group_by_empty_or_scalar_key_exprs_23397() -> None:
     plan = q.explain()
 
     assert plan.startswith("SELECT")
-
     assert_frame_equal(
         q.collect(),
         pl.DataFrame(
@@ -630,7 +626,6 @@ def test_group_by_empty_or_scalar_key_exprs_23397() -> None:
     plan = q.explain()
 
     assert plan.startswith("SELECT")
-
     assert_frame_equal(
         q.collect(),
         pl.DataFrame(
@@ -645,24 +640,19 @@ def test_group_by_empty_or_scalar_key_exprs_23397() -> None:
     )
 
     q = lf.group_by().map_groups(lambda df: df, schema=lf.collect_schema())
-
     with pytest.raises(pl.exceptions.ComputeError, match="not implemented"):
         q.collect()
 
     q = lf.group_by().having(pl.len() != 5).agg(pl.len())
-
     plan = q.explain()
 
     assert "AGGREGATE" not in plan
-
     assert q.collect().shape == (0, 1)
 
     q = lf.group_by().having(pl.len() == 5).agg(pl.len())
-
     plan = q.explain()
 
     assert "AGGREGATE" not in plan
-
     assert_frame_equal(
         q.collect(),
         pl.DataFrame({"len": pl.Series([5], dtype=pl.get_index_type())}),

--- a/py-polars/tests/unit/sql/test_string_agg.py
+++ b/py-polars/tests/unit/sql/test_string_agg.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import pytest
+
+import polars as pl
+from tests.unit.sql import assert_sql_matches
+
+
+@pytest.fixture
+def df_test() -> pl.LazyFrame:
+    return pl.LazyFrame(
+        {
+            "grp": ["a", "b", "a", "b", "a", "b"],
+            "x": ["x1", "y1", "x2", "y2", "x3", "y3"],
+            "y": [10, 20, 30, 40, 50, 60],
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("agg", "values"),
+    [
+        # plain aggregation, no per-group ordering
+        ("STRING_AGG(x, ',')", ["x1,x2,x3", "y1,y2,y3"]),
+        # separator is optional and defaults to ","
+        ("STRING_AGG(x)", ["x1,x2,x3", "y1,y2,y3"]),
+        # in-arg ORDER BY (asc/desc): sorts the input before concatenation
+        ("STRING_AGG(x, '|' ORDER BY y DESC)", ["x3|x2|x1", "y3|y2|y1"]),
+        ("STRING_AGG(x, '%' ORDER BY y ASC)", ["x1%x2%x3", "y1%y2%y3"]),
+        # DISTINCT + ORDER BY: dedupes then sorts
+        ("STRING_AGG(DISTINCT x, ',' ORDER BY x)", ["x1,x2,x3", "y1,y2,y3"]),
+        # FILTER composes with ORDER BY (predicate restricts
+        # the row set, ORDER BY operates on what's left)
+        (
+            "STRING_AGG(x, ',' ORDER BY y) FILTER (WHERE y > 25)",
+            ["x2,x3", "y2,y3"],
+        ),
+    ],
+)
+def test_string_agg_grouped(df_test: pl.LazyFrame, agg: str, values: list[str]) -> None:
+    assert_sql_matches(
+        {"df": df_test},
+        query=f"SELECT grp, {agg} AS v FROM df GROUP BY grp ORDER BY grp",
+        compare_with="duckdb",
+        expected={"grp": ["a", "b"], "v": values},
+    )
+
+
+@pytest.mark.parametrize(
+    "func_alias",
+    ["STRING_AGG", "GROUP_CONCAT", "LISTAGG"],
+)
+def test_string_agg_aliases(df_test: pl.LazyFrame, func_alias: str) -> None:
+    assert_sql_matches(
+        {"df": df_test},
+        query=f"""
+            SELECT grp, {func_alias}(x, ',' ORDER BY x) AS v
+            FROM df GROUP BY grp
+            ORDER BY grp
+        """,
+        compare_with=("sqlite" if func_alias != "LISTAGG" else None),
+        expected={"grp": ["a", "b"], "v": ["x1,x2,x3", "y1,y2,y3"]},
+    )
+
+
+def test_string_agg_no_group_by(df_test: pl.LazyFrame) -> None:
+    assert_sql_matches(
+        {"df": df_test},
+        query="SELECT STRING_AGG(x, ',' ORDER BY y) AS v FROM df",
+        compare_with="duckdb",
+        expected={"v": ["x1,y1,x2,y2,x3,y3"]},
+    )
+
+
+def test_string_agg_limit(df_test: pl.LazyFrame) -> None:
+    out = pl.SQLContext(df=df_test).execute(
+        query="""
+            SELECT grp, STRING_AGG(x, ',' ORDER BY y DESC LIMIT 2) AS v
+            FROM df GROUP BY grp
+            ORDER BY grp
+        """,
+        eager=True,
+    )
+    assert out.to_dict(as_series=False) == {
+        "grp": ["a", "b"],
+        "v": ["x3,x2", "y3,y2"],
+    }


### PR DESCRIPTION
Closes #27115.

* The "FILTER" aggregate modifier is a nice/useful piece of SQL syntax, and maps cleanly to native Polars.
* Also added support for the `STRING_AGG` function (aka: `GROUP_CONCAT`).
* Updated the Sphinx docs to cover both new additions.

## Example

```python
import polars as pl

lf = pl.LazyFrame({
    "grp": ["aa", "bb", "aa", "bb", "aa", "bb"],
    "x": [60.5, -50.25, 42.75, -3.5, 2.125, 10.0],
    "y": [100, 200, 300, 400, 500, 600],
    "z": ["t", "u", "v", "w", "x", "y"],
}).sql("""
    SELECT
        grp,
        SUM(x) AS sum_x,
        SUM(x) FILTER (WHERE y > 250) AS sum_x_when_y_gt_250,
        STRING_AGG(z, ':' ORDER BY y DESC) AS zzz
    FROM self
    GROUP BY grp
    ORDER BY grp
""")

lf.collect()
# shape: (2, 4)
# ┌─────┬─────────┬─────────────────────┬───────┐
# │ grp ┆ sum_x   ┆ sum_x_when_y_gt_250 ┆ zzz   │
# │ --- ┆ ---     ┆ ---                 ┆ ---   │
# │ str ┆ f64     ┆ f64                 ┆ str   │
# ╞═════╪═════════╪═════════════════════╪═══════╡
# │ aa  ┆ 105.375 ┆ 44.875              ┆ x:v:t │
# │ bb  ┆ -43.75  ┆ 6.5                 ┆ y:w:u │
# └─────┴─────────┴─────────────────────┴───────┘
```

**Note:** not supporting `<aggfunc> FILTER … OVER …` for now, as mixing agg/window funcs isn't so straightforward.