### PR TITLE
fix: Prevent panic when switching from one extension dtype to another

### DIFF
--- a/crates/polars-expr/src/dispatch/extension.rs
+++ b/crates/polars-expr/src/dispatch/extension.rs
@@ -37,9 +37,7 @@ fn ext_to(s: &Column, dtype: DataType) -> PolarsResult<Column> {
         )
     }
 
-    Ok(s.apply_unary_elementwise(|s| {
-        s.clone().into_extension(typ.clone())
-    }))
+    Ok(s.apply_unary_elementwise(|s| s.clone().into_extension(typ.clone())))
 }
 
 fn ext_storage(s: &Column) -> PolarsResult<Column> {

--- a/crates/polars-expr/src/dispatch/extension.rs
+++ b/crates/polars-expr/src/dispatch/extension.rs
@@ -18,8 +18,18 @@ fn ext_to(s: &Column, dtype: DataType) -> PolarsResult<Column> {
         polars_bail!(ComputeError: "ext.to() requires an Extension dtype")
     };
 
+    if let DataType::Extension(_, _) = s.dtype() {
+        polars_bail!(
+            InvalidOperation:
+            "cannot call `.ext.to` on a column that is already an Extension type ({}); \
+            extension-to-extension conversion is not defined — if you want to pass the underlying \
+            storage into a new extension, do so explicitly with `.ext.storage().ext.to(...)`",
+            s.dtype()
+        )
+    };
+
     Ok(s.apply_unary_elementwise(|s| {
-        assert!(*s.dtype() == **storage);
+        debug_assert!(*s.dtype() == **storage);
         s.clone().into_extension(typ.clone())
     }))
 }

--- a/crates/polars-expr/src/dispatch/extension.rs
+++ b/crates/polars-expr/src/dispatch/extension.rs
@@ -28,8 +28,16 @@ fn ext_to(s: &Column, dtype: DataType) -> PolarsResult<Column> {
         )
     };
 
+    if s.dtype() != &**storage {
+        polars_bail!(
+            SchemaMismatch:
+            "cannot convert column of type {} to extension {} with storage {}; \
+             column dtype must match the extension's storage type",
+            s.dtype(), typ.name(), **storage
+        )
+    }
+
     Ok(s.apply_unary_elementwise(|s| {
-        debug_assert!(*s.dtype() == **storage);
         s.clone().into_extension(typ.clone())
     }))
 }

--- a/py-polars/tests/unit/datatypes/test_extension.py
+++ b/py-polars/tests/unit/datatypes/test_extension.py
@@ -180,3 +180,13 @@ def test_extension_to_extension_raises_27519() -> None:
         match=r"cannot call `\.ext\.to` on a column that is already an Extension type",
     ):
         s.to_frame().select(pl.col("x").ext.to(BExtension))
+
+
+def test_ext_to_mismatched_storage_raises_27519() -> None:
+    Ext = pl.Extension(name="a.ext", storage=pl.Int64)
+    s = pl.Series("x", [1.0], dtype=pl.Float64)
+    with pytest.raises(
+        pl.exceptions.SchemaError,
+        match=r"column dtype must match",
+    ):
+        s.to_frame().select(pl.col("x").ext.to(Ext))

--- a/py-polars/tests/unit/datatypes/test_extension.py
+++ b/py-polars/tests/unit/datatypes/test_extension.py
@@ -167,3 +167,16 @@ def test_extension_native_to_extension_cast_27193() -> None:
         "inner", [[1, 2], [3, 4]], pl.Array(PythonTestExtension(storage=pl.Int8), 2)
     )
     assert_series_equal(casted, expected)
+
+
+def test_extension_to_extension_raises_27519() -> None:
+    AExtension = pl.Extension(name="a.ext", storage=pl.Int64)
+    BExtension = pl.Extension(name="b.ext", storage=pl.Int64)
+
+    s = pl.Series("x", [0], dtype=AExtension)
+
+    with pytest.raises(
+        pl.exceptions.InvalidOperationError,
+        match=r"cannot call `\.ext\.to` on a column that is already an Extension type",
+    ):
+        s.to_frame().select(pl.col("x").ext.to(BExtension))


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/27519.

In the discussion, @orlp mentions that this shouldn't panic and that it also shouldn't be allowed, given that it is undefined. Also, in https://github.com/pola-rs/polars/pull/27521 the code was changed to be allowed, but it was also closed by Orson. I figured it should error instead with the context that was given in the issue discussion. 

