### PR TITLE
perf(rust): Faster `Series::is_sorted` for logical / non-primitive types

### DIFF
--- a/crates/polars-compute/src/boolean.rs
+++ b/crates/polars-compute/src/boolean.rs
@@ -1,21 +1,6 @@
 use arrow::array::{Array, BooleanArray};
-use arrow::bitmap::utils::{leading_ones, leading_zeros};
-use arrow::bitmap::{Bitmap, binary_fold, quaternary, ternary};
+use arrow::bitmap::{binary_fold, quaternary, ternary};
 use arrow::datatypes::ArrowDataType;
-
-/// Whether the value bitmap contains any `true` (caller must ensure no nulls).
-/// Performs an early exit when the first `true` is found.
-fn any_no_null(bits: &Bitmap) -> bool {
-    let (bytes, offset, len) = bits.as_slice();
-    leading_zeros(bytes, offset, len) < len
-}
-
-/// Whether every bit in the value bitmap is `true` (caller must ensure no nulls).
-/// Performs an early exit when the first `false` is found.
-fn all_no_null(bits: &Bitmap) -> bool {
-    let (bytes, offset, len) = bits.as_slice();
-    leading_ones(bytes, offset, len) == len
-}
 
 /// Returns whether any of the non-null values in the array are `true`.
 ///
@@ -25,7 +10,7 @@ pub fn any(arr: &BooleanArray) -> Option<bool> {
     if null_count == arr.len() {
         None
     } else if null_count == 0 {
-        Some(any_no_null(arr.values()))
+        Some(arr.values().set_bits() > 0)
     } else {
         Some(arr.values().intersects_with(arr.validity().unwrap()))
     }
@@ -39,7 +24,7 @@ pub fn all(arr: &BooleanArray) -> Option<bool> {
     if null_count == arr.len() {
         None
     } else if null_count == 0 {
-        Some(all_no_null(arr.values()))
+        Some(arr.values().unset_bits() == 0)
     } else {
         let false_found = binary_fold(
             arr.values(),

--- a/crates/polars-compute/src/boolean.rs
+++ b/crates/polars-compute/src/boolean.rs
@@ -1,6 +1,23 @@
 use arrow::array::{Array, BooleanArray};
-use arrow::bitmap::{binary_fold, quaternary, ternary};
+use arrow::bitmap::utils::{leading_ones, leading_zeros};
+use arrow::bitmap::{Bitmap, binary_fold, quaternary, ternary};
 use arrow::datatypes::ArrowDataType;
+
+/// Whether the value bitmap contains any `true` (caller must ensure no nulls).
+/// Performs an early exit when the first `true` is found.
+#[inline]
+fn any_no_null(bits: &Bitmap) -> bool {
+    let (bytes, offset, len) = bits.as_slice();
+    leading_zeros(bytes, offset, len) < len
+}
+
+/// Whether every bit in the value bitmap is `true` (caller must ensure no nulls).
+/// Performs an early exit when the first `false` is found.
+#[inline]
+fn all_no_null(bits: &Bitmap) -> bool {
+    let (bytes, offset, len) = bits.as_slice();
+    leading_ones(bytes, offset, len) == len
+}
 
 /// Returns whether any of the non-null values in the array are `true`.
 ///
@@ -10,7 +27,7 @@ pub fn any(arr: &BooleanArray) -> Option<bool> {
     if null_count == arr.len() {
         None
     } else if null_count == 0 {
-        Some(arr.values().set_bits() > 0)
+        Some(any_no_null(arr.values()))
     } else {
         Some(arr.values().intersects_with(arr.validity().unwrap()))
     }
@@ -24,7 +41,7 @@ pub fn all(arr: &BooleanArray) -> Option<bool> {
     if null_count == arr.len() {
         None
     } else if null_count == 0 {
-        Some(arr.values().unset_bits() == 0)
+        Some(all_no_null(arr.values()))
     } else {
         let false_found = binary_fold(
             arr.values(),

--- a/crates/polars-compute/src/boolean.rs
+++ b/crates/polars-compute/src/boolean.rs
@@ -5,7 +5,6 @@ use arrow::datatypes::ArrowDataType;
 
 /// Whether the value bitmap contains any `true` (caller must ensure no nulls).
 /// Performs an early exit when the first `true` is found.
-#[inline]
 fn any_no_null(bits: &Bitmap) -> bool {
     let (bytes, offset, len) = bits.as_slice();
     leading_zeros(bytes, offset, len) < len
@@ -13,7 +12,6 @@ fn any_no_null(bits: &Bitmap) -> bool {
 
 /// Whether every bit in the value bitmap is `true` (caller must ensure no nulls).
 /// Performs an early exit when the first `false` is found.
-#[inline]
 fn all_no_null(bits: &Bitmap) -> bool {
     let (bytes, offset, len) = bits.as_slice();
     leading_ones(bytes, offset, len) == len

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -288,15 +288,15 @@ fn is_sorted_ca_bool(ca: &BooleanChunked, descending: bool) -> bool {
         "internal error: `is_sorted_ca_bool` expects a non-null boolean slice"
     );
     if descending {
-        match ca.first_false_idx() {
-            None => true,
-            Some(k) => ca.num_trues() == k,
-        }
+        let Some(idx) = ca.first_false_idx() else {
+            return true;
+        };
+        !ca.slice(idx as i64, ca.len() - idx).any()
     } else {
-        match ca.first_true_idx() {
-            None => true,
-            Some(k) => ca.num_falses() == k,
-        }
+        let Some(idx) = ca.first_true_idx() else {
+            return true;
+        };
+        ca.slice(idx as i64, ca.len() - idx).all()
     }
 }
 

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -254,7 +254,7 @@ fn is_sorted_categorical_lexical_adjacent(s: &Series, options: SortOptions) -> P
             ComputeError: "internal error: categorical physical array unexpectedly contains nulls"
         );
 
-        // `ca.null_count() == 0` implies each `phys` row decodes via `iter_str` to `Some(..)` (see 
+        // `ca.null_count() == 0` implies each `phys` row decodes via `iter_str` to `Some(..)` (see
         // [`CategoricalChunked::iter_str`]).
         Ok(is_sorted_adjacent_total_ord(
             ca.iter_str().map(|opt| {

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -130,9 +130,9 @@ pub trait SeriesMethods: SeriesSealed {
         // Logical non-primitive types (e.g. String, Categorical, List, …): take only the contiguous
         // non-null values (`non_null`). For ordinary `Categorical` use `iter_str` (below); otherwise
         // `to_physical_repr`, then
-        // (1) reuse `is_sorted_ca_num` when the physical type is primitive numeric (temporal /
+        // (1) for ordinary [`DataType::Categorical`], compare adjacent **decoded strings** (`iter_str`),
+        // (2) reuse `is_sorted_ca_num` when the physical type is primitive numeric (temporal /
         //     Decimal, Enum-as-integer, …) after `to_physical_repr`;
-        // (2) for ordinary [`DataType::Categorical`], compare adjacent **decoded strings** (`iter_str`),
         // (3) uses a dedicated kernel for boolean values,
         // (4) else scans string / binary values with `TotalOrd`,
         // (5) else fall back to pairwise `Series::lt_eq` / `gt_eq` (nested types, etc.).
@@ -237,28 +237,30 @@ fn is_sorted_adjacent_total_ord<T: TotalOrd>(
     true
 }
 
-/// Ordinary [`DataType::Categorical`] uses **lexical string order** in `Series::lt_eq` / `gt_eq` (decoded
-/// labels via `iter_str`). This scans adjacent decoded strings—same semantics, no pairwise boolean mask.
+/// Ordinary [`DataType::Categorical`]: lexical order via adjacent decoded strings (`iter_str`), same as
+/// `Series::lt_eq` / `gt_eq`, but without a Boolean series. Caller must pass a contiguous **non-null**
+/// slice.
 #[cfg(feature = "dtype-categorical")]
 fn is_sorted_categorical_lexical_adjacent(s: &Series, options: SortOptions) -> PolarsResult<bool> {
-    polars_ensure!(
+    debug_assert!(
         matches!(s.dtype(), DataType::Categorical(_, _)),
-        ComputeError: "internal error: expected Categorical in lexical `is_sorted` path",
+        "expected Categorical in lexical `is_sorted` path"
     );
-    polars_ensure!(
-        s.null_count() == 0,
-        ComputeError: "internal error: lexical categorical `is_sorted` expects no nulls in slice"
+    debug_assert_eq!(
+        s.null_count(),
+        0,
+        "internal error: lexical categorical `is_sorted` expects no nulls in slice"
     );
 
     with_match_categorical_physical_type!(s.dtype().cat_physical().unwrap(), |$C| {
         let ca = s.cat::<$C>()?;
-        polars_ensure!(
-            ca.null_count() == 0,
-            ComputeError: "internal error: categorical physical array unexpectedly contains nulls"
+        debug_assert_eq!(
+            ca.null_count(),
+            0,
+            "internal error: categorical physical array unexpectedly contains nulls"
         );
 
-        // `ca.null_count() == 0` implies each `phys` row decodes via `iter_str` to `Some(..)` (see
-        // [`CategoricalChunked::iter_str`]).
+        // `ca.null_count() == 0` implies each `phys` row decodes via `iter_str` to `Some(..)`
         Ok(is_sorted_adjacent_total_ord(
             ca.iter_str().map(|opt| {
                 opt.expect(

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -1,5 +1,3 @@
-use arrow::bitmap::Bitmap;
-use arrow::bitmap::aligned::AlignedBitmapSlice;
 use num_traits::Bounded;
 #[cfg(feature = "dtype-struct")]
 use polars_core::chunked_array::ops::row_encode::_get_rows_encoded_ca;
@@ -272,96 +270,11 @@ fn is_sorted_categorical_lexical_adjacent(s: &Series, options: SortOptions) -> P
     })
 }
 
-/// Returns [`true`] if the adjacent pair `prev` → `curr` violates monotonic order for booleans.
-///
-/// Ascending (**non‑decreasing**): violates iff `prev && !curr` (`true` then `false`).
-/// Descending (**non‑increasing**): violates iff `!prev && curr` (`false` then `true`).
-#[inline(always)]
-fn bool_pair_is_unsorted(prev: bool, curr: bool, descending: bool) -> bool {
-    if descending {
-        !prev && curr
-    } else {
-        prev && !curr
-    }
-}
-
-/// Scan one contiguous boolean **values** [`Bitmap`] for monotonic adjacent order (`false < true`).
-///
-/// Bit **`i`** is logical row **`i`** within this slice (Arrow / Polars LSB‑first indexing, same notion as `get_bit_unchecked`).
-///
-/// On success, updates **`prev`** to [`Some`] with this slice's **last** row value so callers can enforce the pair
-/// across **(last row here → first row of the next bitmap or chunk)**.
-///
-/// Implemented as **`AlignedBitmapSlice<u64>`**: scalar **prefix**, **`u64` bulk** bitmask checks for interior adjacent
-/// pairs, then scalar **suffix**. Used by boolean `Series::is_sorted` in this module.
-fn is_sorted_boolean_bitmap_slice(
-    bits: &Bitmap,
-    descending: bool,
-    prev: &mut Option<bool>,
-) -> bool {
-    if bits.is_empty() {
-        return true;
-    }
-
-    // Split bitmap into prefix | aligned u64 chunks | suffix — see `AlignedBitmapSlice`.
-    let (bytes, offset, length) = bits.as_slice();
-    let aligned = AlignedBitmapSlice::<u64>::new(bytes, offset, length);
-
-    // Prefix: first `< 64` logical bits, already packed into one u64 (LSB = lowest index in this slice).
-    let p = aligned.prefix();
-    for i in 0..aligned.prefix_bitlen() {
-        // the boolean at index i in this prefix slice
-        let b = ((p >> i) & 1) != 0;
-        if let Some(pb) = *prev {
-            if bool_pair_is_unsorted(pb, b, descending) {
-                return false;
-            }
-        }
-        *prev = Some(b);
-    }
-
-    // Bulk: 64 rows per word. Bit i = row i within the word (LSB-first).
-    // Descending interior check must ignore bit 0: its left neighbor is `prev`, not bit 63 of the same word.
-    const DESC_INTERIOR_MASK: u64 = u64::MAX << 1;
-
-    for w in aligned.bulk_iter() {
-        // Bridge (last row before this word) -> (row 0 of this word).
-        if let Some(pb) = *prev {
-            let first = (w & 1) != 0;
-            if bool_pair_is_unsorted(pb, first, descending) {
-                return false;
-            }
-        }
-        if descending {
-            // Nonzero iff some adjacent pair wholly inside bits 1..=63 forms `01` (forbidden descending).
-            if (w & !(w << 1)) & DESC_INTERIOR_MASK != 0 {
-                return false;
-            }
-        } else if (!w) & (w << 1) != 0 {
-            // Nonzero iff some adjacent pair wholly inside bits 1..=63 forms `10` (forbidden ascending).
-            return false;
-        }
-        // Last row in this word; pairs with row 0 of the next bulk word / suffix via `prev`.
-        *prev = Some(((w >> 63) & 1) != 0);
-    }
-
-    // Suffix: trailing bits after the last full u64, same scalar walk as prefix.
-    let s = aligned.suffix();
-    for i in 0..aligned.suffix_bitlen() {
-        // the boolean at index i in this suffix slice
-        let b = ((s >> i) & 1) != 0;
-        if let Some(pb) = *prev {
-            if bool_pair_is_unsorted(pb, b, descending) {
-                return false;
-            }
-        }
-        *prev = Some(b);
-    }
-
-    true
-}
-
 /// Booleans ordered as [`false`] < [`true`] (same as inequality comparisons on [`BooleanChunked`]).
+///
+/// Monotone order is equivalent to at most one plateau change: ascending is `F…FT…T`, descending is
+/// `T…TF…F`. Implemented with `first_true_idx` / `first_false_idx` plus a global false/true count
+/// check.
 ///
 /// Caller must ensure **`ca` has no nulls** on the flattened series (see `non_null` slice above).
 fn is_sorted_ca_bool(ca: &BooleanChunked, descending: bool) -> bool {
@@ -369,22 +282,22 @@ fn is_sorted_ca_bool(ca: &BooleanChunked, descending: bool) -> bool {
     if len <= 1 {
         return true;
     }
-    // Defensive fallback if chunked metadata disagrees with per-chunk values.
-    if ca.null_count() != 0 {
-        return is_sorted_adjacent_total_ord(ca.into_no_null_iter(), descending);
-    }
-
-    let mut prev_row = None::<bool>;
-    for arr in ca.downcast_iter() {
-        let bits = arr.values();
-        if bits.is_empty() {
-            continue;
+    debug_assert_eq!(
+        ca.null_count(),
+        0,
+        "internal error: `is_sorted_ca_bool` expects a non-null boolean slice"
+    );
+    if descending {
+        match ca.first_false_idx() {
+            None => true,
+            Some(k) => ca.num_trues() == k,
         }
-        if !is_sorted_boolean_bitmap_slice(bits, descending, &mut prev_row) {
-            return false;
+    } else {
+        match ca.first_true_idx() {
+            None => true,
+            Some(k) => ca.num_falses() == k,
         }
     }
-    true
 }
 
 fn check_cmp<T: NumericNative, Cmp: Fn(&T, &T) -> bool>(
@@ -454,125 +367,3 @@ fn is_sorted_ca_num<T: PolarsNumericType>(ca: &ChunkedArray<T>, options: SortOpt
 }
 
 impl SeriesMethods for Series {}
-
-#[cfg(test)]
-mod is_sorted_tests {
-    use arrow::bitmap::Bitmap;
-    use polars_core::prelude::*;
-
-    use super::{SeriesMethods, is_sorted_boolean_bitmap_slice, is_sorted_ca_bool};
-
-    #[test]
-    fn is_sorted_boolean_long_series() {
-        // `AlignedBitmapSlice` only uses `bulk_iter()` when the bitmap does not fit entirely in one
-        // `u64` packed prefix (`offset + len > 64`; e.g. length 137 → two bulk words on typical layout).
-        let v = vec![false; 137];
-        let s = Series::new("bitmap_bulk_ascending".into(), &v);
-        assert!(s.is_sorted(SortOptions::default()).unwrap());
-    }
-
-    #[test]
-    fn is_sorted_boolean_bitmap() {
-        let mut bits = vec![false, false, true];
-        bits.resize(137, true);
-        let bmp = Bitmap::from_iter(bits);
-        let mut prev = None;
-        assert!(
-            !is_sorted_boolean_bitmap_slice(&bmp, true, &mut prev),
-            "false→true at rows 1→2 is forbidden for descending"
-        );
-    }
-
-    #[test]
-    fn is_sorted_non_primitive_len_one_short_circuits() {
-        let s = Series::new("b".into(), &[true]);
-        assert_eq!(s.len(), 1);
-        assert!(!s.dtype().is_primitive_numeric());
-
-        assert!(s.is_sorted(SortOptions::default()).unwrap());
-    }
-
-    // calls `is_sorted_ca_bool` via `s_phys.bool()`
-    #[test]
-    fn is_sorted_ca_bool_len_at_most_one_short_circuits() {
-        // `Series::is_sorted` short-circuits when `non_null_len <= 1` before reaching
-        // `is_sorted_ca_bool`; call the helper to cover the `len <= 1` guard.
-        assert!(is_sorted_ca_bool(
-            &BooleanChunked::from_slice(PlSmallStr::EMPTY, &[]),
-            false,
-        ));
-        assert!(is_sorted_ca_bool(
-            &BooleanChunked::from_slice(PlSmallStr::EMPTY, &[]),
-            true,
-        ));
-        assert!(is_sorted_ca_bool(
-            &BooleanChunked::from_slice(PlSmallStr::EMPTY, &[false]),
-            false,
-        ));
-        assert!(is_sorted_ca_bool(
-            &BooleanChunked::from_slice(PlSmallStr::EMPTY, &[true]),
-            true,
-        ));
-    }
-
-    #[test]
-    fn is_sorted_boolean() {
-        let s = Series::new("boolean_test".into(), &[false, true, true]);
-        assert_eq!(s.dtype(), &DataType::Boolean);
-        assert_eq!(s.len(), 3);
-        assert!(!s.dtype().is_primitive_numeric());
-
-        assert!(s.is_sorted(SortOptions::default()).unwrap());
-        assert!(
-            !s.is_sorted(SortOptions::default().with_order_descending(true))
-                .unwrap()
-        );
-    }
-
-    #[test]
-    fn is_sorted_binary_offset() {
-        let s = Series::from_any_values_and_dtype(
-            "binary_offset_test".into(),
-            &[
-                AnyValue::Binary(&[1]),
-                AnyValue::Binary(&[2, 2]),
-                AnyValue::Binary(&[3, 3, 3]),
-            ],
-            &DataType::BinaryOffset,
-            true,
-        )
-        .unwrap();
-        assert_eq!(s.dtype(), &DataType::BinaryOffset);
-        assert_eq!(s.len(), 3);
-        assert!(!s.dtype().is_primitive_numeric());
-
-        assert!(s.is_sorted(SortOptions::default()).unwrap());
-        assert!(
-            !s.is_sorted(SortOptions::default().with_order_descending(true))
-                .unwrap()
-        );
-    }
-
-    /// [`DataType::List`]: not primitive numeric, not the dedicated string/binary arms — `match`
-    /// falls through to adjacent-row `Series::lt_eq` / `gt_eq`. Polars does not implement `<=` for
-    /// list columns, so this returns [`Err`](PolarsResult::Err) after entering the wildcard arm.
-    #[test]
-    fn is_sorted_list_pairwise_fallback_returns_comparison_error() {
-        let ca: ListChunked = ListChunked::from_iter([
-            Series::new("_".into(), &[1i64]),
-            Series::new("_".into(), &[2i64]),
-            Series::new("_".into(), &[3i64]),
-        ]);
-        let s = ca.into_series();
-        assert!(matches!(s.dtype(), DataType::List(_)));
-        assert_eq!(s.len(), 3);
-        assert!(!s.dtype().is_primitive_numeric());
-
-        let err = s.is_sorted(SortOptions::default()).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("<=") && msg.contains("list"),
-            "unexpected error message: {msg}"
-        );
-    }
-}

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -1,3 +1,5 @@
+use arrow::bitmap::Bitmap;
+use arrow::bitmap::aligned::AlignedBitmapSlice;
 use num_traits::Bounded;
 #[cfg(feature = "dtype-struct")]
 use polars_core::chunked_array::ops::row_encode::_get_rows_encoded_ca;
@@ -133,7 +135,7 @@ pub trait SeriesMethods: SeriesSealed {
         // (1) reuse `is_sorted_ca_num` when the physical type is primitive numeric (temporal /
         //     Decimal, Enum-as-integer, …) after `to_physical_repr`;
         // (2) for ordinary [`DataType::Categorical`], compare adjacent **decoded strings** (`iter_str`),
-        // (3) else scan bool / string / binary values with `TotalOrd` (no full boolean compare series),
+        // (3) else scan booleans via a bitmap/`u64` word kernel / string+binary with `TotalOrd`,
         // (4) else fall back to pairwise `Series::lt_eq` / `gt_eq` (nested types, etc.).
         let non_null_len = s_len - null_count;
         if non_null_len <= 1 {
@@ -161,10 +163,7 @@ pub trait SeriesMethods: SeriesSealed {
         match s_phys.dtype() {
             DataType::Boolean => {
                 let ca = s_phys.bool()?;
-                Ok(is_sorted_adjacent_total_ord(
-                    ca.into_no_null_iter(),
-                    options.descending,
-                ))
+                Ok(is_sorted_ca_bool(ca, options.descending))
             },
             DataType::String => {
                 let ca = s_phys.str()?;
@@ -188,9 +187,10 @@ pub trait SeriesMethods: SeriesSealed {
                 ))
             },
             _ => {
-                let cmp_len = s_len - null_count - 1;
-                let offset = (!options.nulls_last as i64) * (null_count as i64);
-                let (s1, s2) = (s.slice(offset, cmp_len), s.slice(offset + 1, cmp_len));
+                // `non_null` excludes nulls already; compare `non_null[..-1]` with `non_null[1..]`.
+                let cmp_len = non_null_len - 1;
+                let s1 = non_null.slice(0, cmp_len);
+                let s2 = non_null.slice(1, cmp_len);
                 let cmp_op = if options.descending {
                     Series::gt_eq
                 } else {
@@ -267,6 +267,121 @@ fn is_sorted_categorical_lexical_adjacent(s: &Series, options: SortOptions) -> P
     })
 }
 
+/// Returns [`true`] if the adjacent pair `prev` → `curr` violates monotonic order for booleans.
+///
+/// Ascending (**non‑decreasing**): violates iff `prev && !curr` (`true` then `false`).
+/// Descending (**non‑increasing**): violates iff `!prev && curr` (`false` then `true`).
+#[inline(always)]
+fn bool_pair_is_unsorted(prev: bool, curr: bool, descending: bool) -> bool {
+    if descending {
+        !prev && curr
+    } else {
+        prev && !curr
+    }
+}
+
+/// Scan one contiguous boolean **values** [`Bitmap`] for monotonic adjacent order (`false < true`).
+///
+/// Bit **`i`** is logical row **`i`** within this slice (Arrow / Polars LSB‑first indexing, same notion as `get_bit_unchecked`).
+///
+/// On success, updates **`prev`** to [`Some`] with this slice's **last** row value so callers can enforce the pair
+/// across **(last row here → first row of the next bitmap or chunk)**.
+///
+/// Implemented as **`AlignedBitmapSlice<u64>`**: scalar **prefix**, **`u64` bulk** bitmask checks for interior adjacent
+/// pairs, then scalar **suffix**. Used by boolean `Series::is_sorted` in this module.
+fn is_sorted_boolean_bitmap_slice(
+    bits: &Bitmap,
+    descending: bool,
+    prev: &mut Option<bool>,
+) -> bool {
+    if bits.is_empty() {
+        return true;
+    }
+
+    // Split bitmap into prefix | aligned u64 chunks | suffix — see `AlignedBitmapSlice`.
+    let (bytes, offset, length) = bits.as_slice();
+    let aligned = AlignedBitmapSlice::<u64>::new(bytes, offset, length);
+
+    // Prefix: first `< 64` logical bits, already packed into one u64 (LSB = lowest index in this slice).
+    let p = aligned.prefix();
+    for i in 0..aligned.prefix_bitlen() {
+        // the boolean at index i in this prefix slice
+        let b = ((p >> i) & 1) != 0;
+        if let Some(pb) = *prev {
+            if bool_pair_is_unsorted(pb, b, descending) {
+                return false;
+            }
+        }
+        *prev = Some(b);
+    }
+
+    // Bulk: 64 rows per word. Bit i = row i within the word (LSB-first).
+    // Descending interior check must ignore bit 0: its left neighbor is `prev`, not bit 63 of the same word.
+    const DESC_INTERIOR_MASK: u64 = u64::MAX << 1;
+
+    for w in aligned.bulk_iter() {
+        // Bridge (last row before this word) -> (row 0 of this word).
+        if let Some(pb) = *prev {
+            let first = (w & 1) != 0;
+            if bool_pair_is_unsorted(pb, first, descending) {
+                return false;
+            }
+        }
+        if descending {
+            // Nonzero iff some adjacent pair wholly inside bits 1..=63 forms `01` (forbidden descending).
+            if (w & !(w << 1)) & DESC_INTERIOR_MASK != 0 {
+                return false;
+            }
+        } else if (!w) & (w << 1) != 0 {
+            // Nonzero iff some adjacent pair wholly inside bits 1..=63 forms `10` (forbidden ascending).
+            return false;
+        }
+        // Last row in this word; pairs with row 0 of the next bulk word / suffix via `prev`.
+        *prev = Some(((w >> 63) & 1) != 0);
+    }
+
+    // Suffix: trailing bits after the last full u64, same scalar walk as prefix.
+    let s = aligned.suffix();
+    for i in 0..aligned.suffix_bitlen() {
+        // the boolean at index i in this suffix slice
+        let b = ((s >> i) & 1) != 0;
+        if let Some(pb) = *prev {
+            if bool_pair_is_unsorted(pb, b, descending) {
+                return false;
+            }
+        }
+        *prev = Some(b);
+    }
+
+    true
+}
+
+/// Booleans ordered as [`false`] < [`true`] (same as inequality comparisons on [`BooleanChunked`]).
+///
+/// Caller must ensure **`ca` has no nulls** on the flattened series (see `non_null` slice above).
+fn is_sorted_ca_bool(ca: &BooleanChunked, descending: bool) -> bool {
+    let len = ca.len();
+    if len <= 1 {
+        return true;
+    }
+    // Defensive fallback if chunked metadata disagrees with per-chunk values.
+    if ca.null_count() != 0 {
+        return is_sorted_adjacent_total_ord(ca.into_no_null_iter(), descending);
+    }
+
+    let mut prev_row = None::<bool>;
+    for arr in ca.downcast_iter() {
+        let bits = arr.values();
+        if bits.is_empty() {
+            continue;
+        }
+        if !is_sorted_boolean_bitmap_slice(bits, descending, &mut prev_row) {
+            return false;
+        }
+    }
+    true
+}
+
 fn check_cmp<T: NumericNative, Cmp: Fn(&T, &T) -> bool>(
     vals: &[T],
     f: Cmp,
@@ -334,3 +449,19 @@ fn is_sorted_ca_num<T: PolarsNumericType>(ca: &ChunkedArray<T>, options: SortOpt
 }
 
 impl SeriesMethods for Series {}
+
+#[cfg(test)]
+mod is_sorted_tests {
+    use polars_core::prelude::*;
+
+    use super::SeriesMethods;
+
+    #[test]
+    fn is_sorted_non_primitive_len_one_short_circuits() {
+        let s = Series::new("b".into(), &[true]);
+        assert_eq!(s.len(), 1);
+        assert!(!s.dtype().is_primitive_numeric());
+
+        assert!(s.is_sorted(SortOptions::default()).unwrap());
+    }
+}

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -452,9 +452,31 @@ impl SeriesMethods for Series {}
 
 #[cfg(test)]
 mod is_sorted_tests {
+    use arrow::bitmap::Bitmap;
     use polars_core::prelude::*;
 
-    use super::SeriesMethods;
+    use super::{SeriesMethods, is_sorted_boolean_bitmap_slice, is_sorted_ca_bool};
+
+    #[test]
+    fn is_sorted_boolean_long_series() {
+        // `AlignedBitmapSlice` only uses `bulk_iter()` when the bitmap does not fit entirely in one
+        // `u64` packed prefix (`offset + len > 64`; e.g. length 137 → two bulk words on typical layout).
+        let v = vec![false; 137];
+        let s = Series::new("bitmap_bulk_ascending".into(), &v);
+        assert!(s.is_sorted(SortOptions::default()).unwrap());
+    }
+
+    #[test]
+    fn is_sorted_boolean_bitmap() {
+        let mut bits = vec![false, false, true];
+        bits.resize(137, true);
+        let bmp = Bitmap::from_iter(bits);
+        let mut prev = None;
+        assert!(
+            !is_sorted_boolean_bitmap_slice(&bmp, true, &mut prev),
+            "false→true at rows 1→2 is forbidden for descending"
+        );
+    }
 
     #[test]
     fn is_sorted_non_primitive_len_one_short_circuits() {
@@ -466,6 +488,28 @@ mod is_sorted_tests {
     }
 
     // calls `is_sorted_ca_bool` via `s_phys.bool()`
+    #[test]
+    fn is_sorted_ca_bool_len_at_most_one_short_circuits() {
+        // `Series::is_sorted` short-circuits when `non_null_len <= 1` before reaching
+        // `is_sorted_ca_bool`; call the helper to cover the `len <= 1` guard.
+        assert!(is_sorted_ca_bool(
+            &BooleanChunked::from_slice(PlSmallStr::EMPTY, &[]),
+            false,
+        ));
+        assert!(is_sorted_ca_bool(
+            &BooleanChunked::from_slice(PlSmallStr::EMPTY, &[]),
+            true,
+        ));
+        assert!(is_sorted_ca_bool(
+            &BooleanChunked::from_slice(PlSmallStr::EMPTY, &[false]),
+            false,
+        ));
+        assert!(is_sorted_ca_bool(
+            &BooleanChunked::from_slice(PlSmallStr::EMPTY, &[true]),
+            true,
+        ));
+    }
+
     #[test]
     fn is_sorted_boolean() {
         let s = Series::new("boolean_test".into(), &[false, true, true]);

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -242,9 +242,9 @@ fn is_sorted_adjacent_total_ord<T: TotalOrd>(
 /// slice.
 #[cfg(feature = "dtype-categorical")]
 fn is_sorted_categorical_lexical_adjacent(s: &Series, options: SortOptions) -> PolarsResult<bool> {
-    debug_assert!(
+    polars_ensure!(
         matches!(s.dtype(), DataType::Categorical(_, _)),
-        "expected Categorical in lexical `is_sorted` path"
+        ComputeError: "internal error: expected Categorical in lexical `is_sorted` path",
     );
     debug_assert_eq!(
         s.null_count(),

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -127,18 +127,91 @@ pub trait SeriesMethods: SeriesSealed {
             })
         }
 
-        let cmp_len = s_len - null_count - 1; // Number of comparisons we might have to do
-        // TODO! Change this, allocation of a full boolean series is too expensive and doesn't fail fast.
-        // Compare adjacent elements with no-copy slices that don't include any nulls
-        let offset = !options.nulls_last as i64 * null_count as i64;
-        let (s1, s2) = (s.slice(offset, cmp_len), s.slice(offset + 1, cmp_len));
-        let cmp_op = if options.descending {
-            Series::gt_eq
-        } else {
-            Series::lt_eq
-        };
-        Ok(cmp_op(&s1, &s2)?.all())
+        // Logical non-primitive types (e.g. String, Categorical, List, …): take only the contiguous
+        // non-null values (`non_null`), convert to physical storage with `to_physical_repr`, then
+        // (1) reuse `is_sorted_ca_num` when the physical type is primitive numeric,
+        // (2) else scan bool / string / binary values with `TotalOrd` (no full boolean compare series),
+        // (3) else fall back to pairwise `Series::lt_eq` / `gt_eq` (nested types, etc.).
+        let non_null_len = s_len - null_count;
+        if non_null_len <= 1 {
+            return Ok(true);
+        }
+
+        let offset = (!options.nulls_last as i64) * (null_count as i64);
+        let non_null = s.slice(offset, non_null_len);
+        polars_ensure!(non_null.null_count() == 0, ComputeError: "internal error: `is_sorted` non-null slice contains nulls");
+
+        let phys = non_null.to_physical_repr();
+        let s_phys = phys.as_ref();
+        if s_phys.dtype().is_primitive_numeric() {
+            with_match_physical_numeric_polars_type!(s_phys.dtype(), |$T| {
+                let ca: &ChunkedArray<$T> = s_phys.as_ref().as_ref().as_ref();
+                return Ok(is_sorted_ca_num::<$T>(ca, options))
+            })
+        }
+
+        match s_phys.dtype() {
+            DataType::Boolean => {
+                let ca = s_phys.bool()?;
+                Ok(is_sorted_adjacent_total_ord(ca.into_no_null_iter(), options.descending))
+            },
+            DataType::String => {
+                let ca = s_phys.str()?;
+                Ok(is_sorted_adjacent_total_ord(ca.into_no_null_iter(), options.descending))
+            },
+            DataType::Binary => {
+                let ca = s_phys.binary()?;
+                Ok(is_sorted_adjacent_total_ord(ca.into_no_null_iter(), options.descending))
+            },
+            DataType::BinaryOffset => {
+                let ca = s_phys.binary_offset()?;
+                Ok(is_sorted_adjacent_total_ord(ca.into_no_null_iter(), options.descending))
+            },
+            _ => {
+                let cmp_len = s_len - null_count - 1;
+                let offset = (!options.nulls_last as i64) * (null_count as i64);
+                let (s1, s2) = (s.slice(offset, cmp_len), s.slice(offset + 1, cmp_len));
+                let cmp_op = if options.descending {
+                    Series::gt_eq
+                } else {
+                    Series::lt_eq
+                };
+                Ok(cmp_op(&s1, &s2)?.all())
+            },
+        }
     }
+}
+
+/// Returns whether iterator elements are non-decreasing (`descending == false`) or non-increasing
+/// (`descending == true`) under [`TotalOrd`].
+///
+/// Assumes the iterator `it` yields **only** the non-null values in row order (one item per row). An empty
+/// iterator is considered sorted. Stops at the first pair that violates the ordering.
+fn is_sorted_adjacent_total_ord<T: TotalOrd>(
+    it: impl Iterator<Item = T>,
+    descending: bool,
+) -> bool {
+    let mut it = it;
+    // Sliding window: `prev` is always the previous element; seed with the first value.
+    let Some(mut prev) = it.next() else {
+        return true;
+    };
+    if descending {
+        for v in it {
+            if !prev.tot_ge(&v) {
+                return false;
+            }
+            prev = v;
+        }
+    } else {
+        for v in it {
+            if !prev.tot_le(&v) {
+                return false;
+            }
+            prev = v;
+        }
+    }
+    true
 }
 
 fn check_cmp<T: NumericNative, Cmp: Fn(&T, &T) -> bool>(

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -128,10 +128,13 @@ pub trait SeriesMethods: SeriesSealed {
         }
 
         // Logical non-primitive types (e.g. String, Categorical, List, …): take only the contiguous
-        // non-null values (`non_null`), convert to physical storage with `to_physical_repr`, then
-        // (1) reuse `is_sorted_ca_num` when the physical type is primitive numeric,
-        // (2) else scan bool / string / binary values with `TotalOrd` (no full boolean compare series),
-        // (3) else fall back to pairwise `Series::lt_eq` / `gt_eq` (nested types, etc.).
+        // non-null values (`non_null`). For ordinary `Categorical` use `iter_str` (below); otherwise
+        // `to_physical_repr`, then
+        // (1) reuse `is_sorted_ca_num` when the physical type is primitive numeric (temporal /
+        //     Decimal, Enum-as-integer, …) after `to_physical_repr`;
+        // (2) for ordinary [`DataType::Categorical`], compare adjacent **decoded strings** (`iter_str`),
+        // (3) else scan bool / string / binary values with `TotalOrd` (no full boolean compare series),
+        // (4) else fall back to pairwise `Series::lt_eq` / `gt_eq` (nested types, etc.).
         let non_null_len = s_len - null_count;
         if non_null_len <= 1 {
             return Ok(true);
@@ -140,6 +143,11 @@ pub trait SeriesMethods: SeriesSealed {
         let offset = (!options.nulls_last as i64) * (null_count as i64);
         let non_null = s.slice(offset, non_null_len);
         polars_ensure!(non_null.null_count() == 0, ComputeError: "internal error: `is_sorted` non-null slice contains nulls");
+
+        #[cfg(feature = "dtype-categorical")]
+        if matches!(non_null.dtype(), DataType::Categorical(_, _)) {
+            return is_sorted_categorical_lexical_adjacent(&non_null, options);
+        }
 
         let phys = non_null.to_physical_repr();
         let s_phys = phys.as_ref();
@@ -153,19 +161,31 @@ pub trait SeriesMethods: SeriesSealed {
         match s_phys.dtype() {
             DataType::Boolean => {
                 let ca = s_phys.bool()?;
-                Ok(is_sorted_adjacent_total_ord(ca.into_no_null_iter(), options.descending))
+                Ok(is_sorted_adjacent_total_ord(
+                    ca.into_no_null_iter(),
+                    options.descending,
+                ))
             },
             DataType::String => {
                 let ca = s_phys.str()?;
-                Ok(is_sorted_adjacent_total_ord(ca.into_no_null_iter(), options.descending))
+                Ok(is_sorted_adjacent_total_ord(
+                    ca.into_no_null_iter(),
+                    options.descending,
+                ))
             },
             DataType::Binary => {
                 let ca = s_phys.binary()?;
-                Ok(is_sorted_adjacent_total_ord(ca.into_no_null_iter(), options.descending))
+                Ok(is_sorted_adjacent_total_ord(
+                    ca.into_no_null_iter(),
+                    options.descending,
+                ))
             },
             DataType::BinaryOffset => {
                 let ca = s_phys.binary_offset()?;
-                Ok(is_sorted_adjacent_total_ord(ca.into_no_null_iter(), options.descending))
+                Ok(is_sorted_adjacent_total_ord(
+                    ca.into_no_null_iter(),
+                    options.descending,
+                ))
             },
             _ => {
                 let cmp_len = s_len - null_count - 1;
@@ -212,6 +232,39 @@ fn is_sorted_adjacent_total_ord<T: TotalOrd>(
         }
     }
     true
+}
+
+/// Ordinary [`DataType::Categorical`] uses **lexical string order** in `Series::lt_eq` / `gt_eq` (decoded
+/// labels via `iter_str`). This scans adjacent decoded strings—same semantics, no pairwise boolean mask.
+#[cfg(feature = "dtype-categorical")]
+fn is_sorted_categorical_lexical_adjacent(s: &Series, options: SortOptions) -> PolarsResult<bool> {
+    polars_ensure!(
+        matches!(s.dtype(), DataType::Categorical(_, _)),
+        ComputeError: "internal error: expected Categorical in lexical `is_sorted` path",
+    );
+    polars_ensure!(
+        s.null_count() == 0,
+        ComputeError: "internal error: lexical categorical `is_sorted` expects no nulls in slice"
+    );
+
+    with_match_categorical_physical_type!(s.dtype().cat_physical().unwrap(), |$C| {
+        let ca = s.cat::<$C>()?;
+        polars_ensure!(
+            ca.null_count() == 0,
+            ComputeError: "internal error: categorical physical array unexpectedly contains nulls"
+        );
+
+        // SAFETY CONTRACT: physical null count is zero, so each `phys` row resolves to `Some(..)` via
+        // `iter_str` (see [`CategoricalChunked::iter_str`]).
+        Ok(is_sorted_adjacent_total_ord(
+            ca.iter_str().map(|opt| {
+                opt.expect(
+                    "`iter_str` produced None while categorical null_count reported 0 (`is_sorted`)"
+                )
+            }),
+            options.descending,
+        ))
+    })
 }
 
 fn check_cmp<T: NumericNative, Cmp: Fn(&T, &T) -> bool>(

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -254,8 +254,8 @@ fn is_sorted_categorical_lexical_adjacent(s: &Series, options: SortOptions) -> P
             ComputeError: "internal error: categorical physical array unexpectedly contains nulls"
         );
 
-        // SAFETY CONTRACT: physical null count is zero, so each `phys` row resolves to `Some(..)` via
-        // `iter_str` (see [`CategoricalChunked::iter_str`]).
+        // `ca.null_count() == 0` implies each `phys` row decodes via `iter_str` to `Some(..)` (see 
+        // [`CategoricalChunked::iter_str`]).
         Ok(is_sorted_adjacent_total_ord(
             ca.iter_str().map(|opt| {
                 opt.expect(

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -464,4 +464,66 @@ mod is_sorted_tests {
 
         assert!(s.is_sorted(SortOptions::default()).unwrap());
     }
+
+    // calls `is_sorted_ca_bool` via `s_phys.bool()`
+    #[test]
+    fn is_sorted_boolean() {
+        let s = Series::new("boolean_test".into(), &[false, true, true]);
+        assert_eq!(s.dtype(), &DataType::Boolean);
+        assert_eq!(s.len(), 3);
+        assert!(!s.dtype().is_primitive_numeric());
+
+        assert!(s.is_sorted(SortOptions::default()).unwrap());
+        assert!(
+            !s.is_sorted(SortOptions::default().with_order_descending(true))
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn is_sorted_binary_offset() {
+        let s = Series::from_any_values_and_dtype(
+            "binary_offset_test".into(),
+            &[
+                AnyValue::Binary(&[1]),
+                AnyValue::Binary(&[2, 2]),
+                AnyValue::Binary(&[3, 3, 3]),
+            ],
+            &DataType::BinaryOffset,
+            true,
+        )
+        .unwrap();
+        assert_eq!(s.dtype(), &DataType::BinaryOffset);
+        assert_eq!(s.len(), 3);
+        assert!(!s.dtype().is_primitive_numeric());
+
+        assert!(s.is_sorted(SortOptions::default()).unwrap());
+        assert!(
+            !s.is_sorted(SortOptions::default().with_order_descending(true))
+                .unwrap()
+        );
+    }
+
+    /// [`DataType::List`]: not primitive numeric, not the dedicated string/binary arms — `match`
+    /// falls through to adjacent-row `Series::lt_eq` / `gt_eq`. Polars does not implement `<=` for
+    /// list columns, so this returns [`Err`](PolarsResult::Err) after entering the wildcard arm.
+    #[test]
+    fn is_sorted_list_pairwise_fallback_returns_comparison_error() {
+        let ca: ListChunked = ListChunked::from_iter([
+            Series::new("_".into(), &[1i64]),
+            Series::new("_".into(), &[2i64]),
+            Series::new("_".into(), &[3i64]),
+        ]);
+        let s = ca.into_series();
+        assert!(matches!(s.dtype(), DataType::List(_)));
+        assert_eq!(s.len(), 3);
+        assert!(!s.dtype().is_primitive_numeric());
+
+        let err = s.is_sorted(SortOptions::default()).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("<=") && msg.contains("list"),
+            "unexpected error message: {msg}"
+        );
+    }
 }

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -135,8 +135,9 @@ pub trait SeriesMethods: SeriesSealed {
         // (1) reuse `is_sorted_ca_num` when the physical type is primitive numeric (temporal /
         //     Decimal, Enum-as-integer, …) after `to_physical_repr`;
         // (2) for ordinary [`DataType::Categorical`], compare adjacent **decoded strings** (`iter_str`),
-        // (3) else scan booleans via a bitmap/`u64` word kernel / string+binary with `TotalOrd`,
-        // (4) else fall back to pairwise `Series::lt_eq` / `gt_eq` (nested types, etc.).
+        // (3) uses a dedicated kernel for boolean values,
+        // (4) else scans string / binary values with `TotalOrd`,
+        // (5) else fall back to pairwise `Series::lt_eq` / `gt_eq` (nested types, etc.).
         let non_null_len = s_len - null_count;
         if non_null_len <= 1 {
             return Ok(true);
@@ -144,7 +145,11 @@ pub trait SeriesMethods: SeriesSealed {
 
         let offset = (!options.nulls_last as i64) * (null_count as i64);
         let non_null = s.slice(offset, non_null_len);
-        polars_ensure!(non_null.null_count() == 0, ComputeError: "internal error: `is_sorted` non-null slice contains nulls");
+        debug_assert_eq!(
+            non_null.null_count(),
+            0,
+            "internal error: `is_sorted` non-null slice contains nulls"
+        );
 
         #[cfg(feature = "dtype-categorical")]
         if matches!(non_null.dtype(), DataType::Categorical(_, _)) {

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -246,19 +246,9 @@ fn is_sorted_categorical_lexical_adjacent(s: &Series, options: SortOptions) -> P
         matches!(s.dtype(), DataType::Categorical(_, _)),
         ComputeError: "internal error: expected Categorical in lexical `is_sorted` path",
     );
-    debug_assert_eq!(
-        s.null_count(),
-        0,
-        "internal error: lexical categorical `is_sorted` expects no nulls in slice"
-    );
 
     with_match_categorical_physical_type!(s.dtype().cat_physical().unwrap(), |$C| {
         let ca = s.cat::<$C>()?;
-        debug_assert_eq!(
-            ca.null_count(),
-            0,
-            "internal error: categorical physical array unexpectedly contains nulls"
-        );
 
         // `ca.null_count() == 0` implies each `phys` row decodes via `iter_str` to `Some(..)`
         Ok(is_sorted_adjacent_total_ord(

--- a/py-polars/tests/unit/operations/test_is_sorted.py
+++ b/py-polars/tests/unit/operations/test_is_sorted.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 import polars as pl
+from polars.exceptions import InvalidOperationError
 from polars.testing import assert_series_equal
 
 
@@ -447,3 +448,60 @@ def test_is_sorted_time() -> None:
     s = pl.Series("a", [1, 1]).sort(descending=True).cast(pl.Time)
     assert s.flags["SORTED_DESC"]
     assert not s.flags["SORTED_ASC"]
+
+
+def test_is_sorted_boolean_long_all_false() -> None:
+    # Long all-`False` row-major boolean series (regression for `BooleanChunked::is_sorted` fast path).
+    s = pl.Series("all_false_monotone", [False] * 137)
+    assert s.is_sorted()
+
+
+def test_is_sorted_boolean_false_true_transition_descending_large() -> None:
+    # false→true transition invalid for descending; long series stresses multi-chunk / wide bitmap layouts.
+    values = [False, False] + [True] * (137 - 2)
+    assert not pl.Series(values).is_sorted(descending=True)
+
+
+def test_is_sorted_boolean_singleton_short_circuit() -> None:
+    s = pl.Series("b", [True])
+    assert s.len() == 1
+    assert s.dtype == pl.Boolean
+    assert s.is_sorted()
+
+
+def test_is_sorted_boolean_empty_ca_short_circuits() -> None:
+    for descending in False, True:
+        assert pl.Series([], dtype=pl.Boolean).is_sorted(descending=descending)
+    assert pl.Series([False]).is_sorted()
+    assert pl.Series([True]).is_sorted(descending=True)
+
+
+def test_is_sorted_boolean_three_values_orders() -> None:
+    s = pl.Series("boolean_test", [False, True, True])
+    assert s.dtype == pl.Boolean
+    assert s.len() == 3
+    assert s.is_sorted()
+    assert not s.is_sorted(descending=True)
+
+
+def test_is_sorted_binary_asc_desc() -> None:
+    s = pl.Series(
+        "binary_test",
+        [b"\x01", b"\x02\x02", b"\x03\x03\x03"],
+        dtype=pl.Binary,
+    )
+    assert s.dtype == pl.Binary
+    assert s.len() == 3
+    assert s.is_sorted()
+    assert not s.is_sorted(descending=True)
+
+
+def test_is_sorted_list_pairwise_fallback_error() -> None:
+    # List dtype falls through to row-wise comparison; `<`/`<=` for lists are unsupported.
+    s = pl.Series("_", [[1], [2], [3]])
+    assert isinstance(s.dtype, pl.List)
+
+    with pytest.raises(InvalidOperationError) as exc:
+        s.is_sorted()
+    msg = str(exc.value)
+    assert "<=" in msg and "list" in msg.lower()

--- a/py-polars/tests/unit/operations/test_is_sorted.py
+++ b/py-polars/tests/unit/operations/test_is_sorted.py
@@ -451,13 +451,11 @@ def test_is_sorted_time() -> None:
 
 
 def test_is_sorted_boolean_long_all_false() -> None:
-    # Long all-`False` row-major boolean series (regression for `BooleanChunked::is_sorted` fast path).
     s = pl.Series("all_false_monotone", [False] * 137)
     assert s.is_sorted()
 
 
 def test_is_sorted_boolean_false_true_transition_descending_large() -> None:
-    # false→true transition invalid for descending; long series stresses multi-chunk / wide bitmap layouts.
     values = [False, False] + [True] * (137 - 2)
     assert not pl.Series(values).is_sorted(descending=True)
 
@@ -497,11 +495,13 @@ def test_is_sorted_binary_asc_desc() -> None:
 
 
 def test_is_sorted_list_pairwise_fallback_error() -> None:
-    # List dtype falls through to row-wise comparison; `<`/`<=` for lists are unsupported.
+    # List dtype falls through to row-wise comparison; but
+    # `<`/`<=` for lists are unsupported, so this raises an error.
     s = pl.Series("_", [[1], [2], [3]])
     assert isinstance(s.dtype, pl.List)
 
     with pytest.raises(InvalidOperationError) as exc:
         s.is_sorted()
-    msg = str(exc.value)
-    assert "<=" in msg and "list" in msg.lower()
+    msg = str(exc.value).lower()
+    assert "<=" in msg
+    assert "list" in msg


### PR DESCRIPTION
This PR is an attempt to tackle a TODO left in the codebase from a 2 year old [PR](https://github.com/pola-rs/polars/pull/16333) by @ritchie46 . Informal timings (e.g. sorting 200k strings) suggest a significant speed improvement, even when the series is already sorted (tested on an M4 Max); for Boolean values the dedicated kernel (suggested by @orlp below) seems to yield a ~45x speedup.

The behaviour is intended to match existing `Series` ordering. I was hoping that this PR would be much simpler by extracting a comparison closure from somewhere; instead it is a bit bulky, so might not be ideal:

(1) it reuses `is_sorted_ca_num` when the physical type is primitive numeric (temporal /
    Decimal, Enum-as-integer, …) after `to_physical_repr`;
(2) for ordinary [`DataType::Categorical`], compares adjacent **decoded strings** (`iter_str`), just as in `cat_compare_helper`,
(3) uses a dedicated kernel for boolean values,
(4) else scans string / binary values with `TotalOrd`,
(5) else falls back to pairwise `Series::lt_eq` / `gt_eq` as in the original code.

Cowritten with Cursor (I've reviewed every line, but I'm new to this codebase).

`make test`:
<img width="838" height="392" alt="Screenshot 2026-05-10 at 18 30 39" src="https://github.com/user-attachments/assets/f6051c27-4883-44d0-a63c-ce0b2c90c390" />
