### PR TITLE
fix: Fix `merge_sorted` panic when List in frame

### DIFF
--- a/crates/polars-ops/src/frame/join/merge_sorted.rs
+++ b/crates/polars-ops/src/frame/join/merge_sorted.rs
@@ -125,9 +125,9 @@ fn merge_series(lhs: &Series, rhs: &Series, merge_indicator: &[bool]) -> PolarsR
         #[cfg(feature = "dtype-array")]
         Array(_, _) => {
             // @Optimize. This is horrendous
+            let fields = std::slice::from_ref(lhs.array().unwrap().ref_field());
             let lhs = lhs.row_encode_unordered()?;
             let rhs = rhs.row_encode_unordered()?;
-            let fields = std::slice::from_ref(lhs.ref_field());
             merge_ca(&lhs, &rhs, merge_indicator)
                 .row_decode_unordered(fields)?
                 .fields_as_series()
@@ -136,9 +136,9 @@ fn merge_series(lhs: &Series, rhs: &Series, merge_indicator: &[bool]) -> PolarsR
         },
         List(_) => {
             // @Optimize. This is horrendous
+            let fields = std::slice::from_ref(lhs.list().unwrap().ref_field());
             let lhs = lhs.row_encode_unordered()?;
             let rhs = rhs.row_encode_unordered()?;
-            let fields = std::slice::from_ref(lhs.ref_field());
             merge_ca(&lhs, &rhs, merge_indicator)
                 .row_decode_unordered(fields)?
                 .fields_as_series()
@@ -260,10 +260,10 @@ where
     let a_len = a_iter.size_hint().0;
     let b_len = b_iter.size_hint().0;
     if a_len == 0 {
-        return vec![true; b_len];
+        return vec![B_INDICATOR; b_len];
     };
     if b_len == 0 {
-        return vec![false; a_len];
+        return vec![A_INDICATOR; a_len];
     }
 
     let mut current_a = T::default();

--- a/py-polars/tests/unit/operations/test_merge_sorted.py
+++ b/py-polars/tests/unit/operations/test_merge_sorted.py
@@ -428,3 +428,9 @@ def test_merge_sorted_deep_chain_with_sort_collect(n_frames: int) -> None:
     result = chained.sort("n", "foo").collect()
 
     assert_frame_equal(result, expected)
+
+
+def test_merge_sorted_with_list() -> None:
+    # See: https://github.com/pola-rs/polars/issues/27563
+    df = pl.DataFrame({"key": [""], "list": [[""]]})
+    df.merge_sorted(df, key="key")

--- a/py-polars/tests/unit/operations/test_merge_sorted.py
+++ b/py-polars/tests/unit/operations/test_merge_sorted.py
@@ -432,5 +432,15 @@ def test_merge_sorted_deep_chain_with_sort_collect(n_frames: int) -> None:
 
 def test_merge_sorted_with_list() -> None:
     # See: https://github.com/pola-rs/polars/issues/27563
-    df = pl.DataFrame({"key": [""], "list": [[""]]})
-    df.merge_sorted(df, key="key")
+    df1 = pl.DataFrame({"key": ["a", "c"], "list": [[1, 2], [5, 6]]})
+    df2 = pl.DataFrame({"key": ["b", "d"], "list": [[3, 4], [7, 8]]})
+
+    result = df1.merge_sorted(df2, key="key")
+
+    expected = pl.DataFrame(
+        {
+            "key": ["a", "b", "c", "d"],
+            "list": [[1, 2], [3, 4], [5, 6], [7, 8]],
+        }
+    )
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_merge_sorted.py
+++ b/py-polars/tests/unit/operations/test_merge_sorted.py
@@ -430,8 +430,7 @@ def test_merge_sorted_deep_chain_with_sort_collect(n_frames: int) -> None:
     assert_frame_equal(result, expected)
 
 
-def test_merge_sorted_with_list() -> None:
-    # See: https://github.com/pola-rs/polars/issues/27563
+def test_merge_sorted_with_list_27563() -> None:
     df1 = pl.DataFrame({"key": ["a", "c"], "list": [[1, 2], [5, 6]]})
     df2 = pl.DataFrame({"key": ["b", "d"], "list": [[3, 4], [7, 8]]})
 


### PR DESCRIPTION
This resolves an incorrect memory access that happened when `merge_sorted` was called on a DataFrame or LazyFrame with a List in the Schema.

Fixes #27563

I wrote the test case and then had AI write the fix. I'm not super familiar with Rust or Polars, but this looks reasonable to me. All tests pass, including the new one I added that caused this panic.

<details>
<summary>Screenshots of tests passing</summary>

**Python**
<img width="860" height="759" alt="Screenshot 2026-05-10 at 2 09 01 PM" src="https://github.com/user-attachments/assets/b03a1883-32e2-435d-8b37-6b6ddb15fb22" />

**Rust**
<img width="930" height="769" alt="Screenshot 2026-05-10 at 2 14 08 PM" src="https://github.com/user-attachments/assets/20578d37-6159-4cb5-a818-b31274a173e3" />


</details>

