### PR TITLE
fix: Set merge-join streaming node to `Finished` if its sending port is `Done`

### DIFF
--- a/crates/polars-stream/src/nodes/joins/merge_join.rs
+++ b/crates/polars-stream/src/nodes/joins/merge_join.rs
@@ -192,6 +192,11 @@ impl ComputeNode for MergeJoinNode {
         let input_channels_done = recv.iter().all(|r| *r == PortState::Done);
         let input_buffers_empty = self.build_unmerged.is_empty() && self.probe_unmerged.is_empty();
         let unmatched_buffers_empty = self.unmatched.is_empty();
+
+        if send[0] == PortState::Done {
+            self.state = Done;
+        }
+
         if self.params.args.maintain_order == MaintainOrderJoin::None {
             debug_assert!(unmatched_buffers_empty);
         }

--- a/py-polars/tests/unit/streaming/test_streaming_join.py
+++ b/py-polars/tests/unit/streaming/test_streaming_join.py
@@ -717,7 +717,7 @@ def test_streaming_asof_join(
     assert_frame_equal(actual, expected)
 
 
-def test_streaming_merge_join_undone_send_port_27547() -> None:
+def test_streaming_merge_join_send_port_done_27547() -> None:
     left = pl.LazyFrame({"key": [1, 2, 3], "left_payload": ["a", "b", "c"]})
     right = pl.LazyFrame({"key": [1, 2, 3], "right_payload": ["d", "e", "f"]})
     q = (

--- a/py-polars/tests/unit/streaming/test_streaming_join.py
+++ b/py-polars/tests/unit/streaming/test_streaming_join.py
@@ -715,3 +715,20 @@ def test_streaming_asof_join(
     expected = q.collect(engine="in-memory")
     actual = q.collect(engine="streaming")
     assert_frame_equal(actual, expected)
+
+
+def test_streaming_merge_join_undone_send_port_27547() -> None:
+    left = pl.LazyFrame({"key": [1, 2, 3], "left_payload": ["a", "b", "c"]})
+    right = pl.LazyFrame({"key": [1, 2, 3], "right_payload": ["d", "e", "f"]})
+    q = (
+        left.set_sorted("key")
+        .join(
+            right.set_sorted("key"),
+            on="key",
+            how="inner",
+        )
+        .head(2)
+    )
+    expected = q.collect(engine="in-memory")
+    actual = q.collect(engine="streaming")
+    assert_frame_equal(actual, expected)


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/27547

:robot: No AI was used for this PR
