### PR TITLE
feat: add join_asof_many core API

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -31,6 +31,8 @@ use polars_io::RowIndex;
 use polars_mem_engine::scan_predicate::functions::apply_scan_predicate_to_scan_ir;
 use polars_mem_engine::{Executor, create_multiple_physical_plans, create_physical_plan};
 use polars_ops::frame::{JoinBuildSide, JoinCoalesce, MaintainOrderJoin};
+#[cfg(feature = "asof_join")]
+use polars_ops::prelude::{AsOfManyOptions, AsOfOptions, AsofJoinPair, JoinType};
 #[cfg(feature = "is_between")]
 use polars_ops::prelude::ClosedInterval;
 pub use polars_plan::frame::{AllowedOptimizations, OptFlags};
@@ -1884,6 +1886,43 @@ impl LazyFrame {
         let opt_state = self.get_opt_state();
         let lp = self.get_plan_builder().map_private(function).build();
         Self::from_logical_plan(lp, opt_state)
+    }
+
+    #[cfg(feature = "asof_join")]
+    pub fn join_asof_many(
+        self,
+        other: LazyFrame,
+        pairs: Vec<AsofJoinPair>,
+        options: AsOfOptions,
+        allow_parallel: bool,
+        force_parallel: bool,
+        suffix: Option<PlSmallStr>,
+        coalesce: JoinCoalesce,
+    ) -> LazyFrame {
+        let left_on = pairs
+            .iter()
+            .map(|pair| col(pair.left_on_name.clone()))
+            .collect::<Vec<_>>();
+        let right_on = pairs
+            .iter()
+            .map(|pair| col(pair.right_on_name.clone()))
+            .collect::<Vec<_>>();
+
+        let mut builder = self
+            .join_builder()
+            .with(other)
+            .left_on(left_on)
+            .right_on(right_on)
+            .allow_parallel(allow_parallel)
+            .force_parallel(force_parallel)
+            .coalesce(coalesce)
+            .how(JoinType::AsOfMany(Box::new(AsOfManyOptions { options, pairs })));
+
+        if let Some(suffix) = suffix {
+            builder = builder.suffix(suffix);
+        }
+
+        builder.finish()
     }
 
     /// Add a new column at index 0 that counts the rows.

--- a/crates/polars-lazy/src/tests/optimization_checks.rs
+++ b/crates/polars-lazy/src/tests/optimization_checks.rs
@@ -649,3 +649,48 @@ fn test_cluster_with_columns_chain() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[test]
+#[cfg(feature = "asof_join")]
+fn test_fuse_join_asof_many_chain_rust() -> PolarsResult<()> {
+    let left = df!(
+        "ts_a" => [1i64, 3, 5],
+        "ts_b" => [2i64, 4, 6],
+        "ts_c" => [3i64, 5, 7],
+    )?
+    .lazy();
+    let right = df!(
+        "rhs_ts" => [1i64, 2, 4, 7],
+        "v" => [10i64, 20, 40, 70],
+    )?
+    .lazy();
+
+    let q = left
+        .join_builder()
+        .with(right.clone())
+        .left_on([col("ts_a")])
+        .right_on([col("rhs_ts")])
+        .how(JoinType::AsOf(Box::default()))
+        .suffix("_a")
+        .finish()
+        .join_builder()
+        .with(right.clone())
+        .left_on([col("ts_b")])
+        .right_on([col("rhs_ts")])
+        .how(JoinType::AsOf(Box::default()))
+        .suffix("_b")
+        .finish()
+        .join_builder()
+        .with(right)
+        .left_on([col("ts_c")])
+        .right_on([col("rhs_ts")])
+        .how(JoinType::AsOf(Box::default()))
+        .suffix("_c")
+        .finish();
+
+    let plan = q.describe_optimized_plan()?;
+    assert_eq!(num_occurrences(&plan, "ASOF MANY JOIN:"), 1);
+    assert_eq!(num_occurrences(&plan, "ASOF JOIN:"), 0);
+
+    Ok(())
+}

--- a/crates/polars-ops/src/frame/join/args.rs
+++ b/crates/polars-ops/src/frame/join/args.rs
@@ -1,4 +1,6 @@
 use super::*;
+#[cfg(feature = "asof_join")]
+use super::asof::AsOfManyOptions;
 
 pub(super) type JoinIds = Vec<IdxSize>;
 pub type LeftJoinIds = (ChunkJoinIds, ChunkJoinOptIds);
@@ -68,6 +70,8 @@ pub enum JoinType {
     // Box is okay because this is inside a `Arc<JoinOptionsIR>`
     #[cfg(feature = "asof_join")]
     AsOf(Box<AsOfOptions>),
+    #[cfg(feature = "asof_join")]
+    AsOfMany(Box<AsOfManyOptions>),
     #[cfg(feature = "semi_anti_join")]
     Semi,
     #[cfg(feature = "semi_anti_join")]
@@ -106,7 +110,7 @@ impl JoinCoalesce {
                 matches!(self, CoalesceColumns)
             },
             #[cfg(feature = "asof_join")]
-            AsOf(_) => matches!(self, JoinSpecific | CoalesceColumns),
+            AsOf(_) | AsOfMany(_) => matches!(self, JoinSpecific | CoalesceColumns),
             #[cfg(feature = "iejoin")]
             IEJoin | Range => false,
             Cross => false,
@@ -244,6 +248,8 @@ impl Display for JoinType {
             Full => "FULL",
             #[cfg(feature = "asof_join")]
             AsOf(_) => "ASOF",
+            #[cfg(feature = "asof_join")]
+            AsOfMany(_) => "ASOF MANY",
             #[cfg(feature = "iejoin")]
             IEJoin => "IEJOIN",
             #[cfg(feature = "iejoin")]

--- a/crates/polars-ops/src/frame/join/asof/mod.rs
+++ b/crates/polars-ops/src/frame/join/asof/mod.rs
@@ -218,6 +218,23 @@ pub struct AsOfOptions {
     pub check_sortedness: bool,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
+pub struct AsofJoinPair {
+    pub left_on_name: PlSmallStr,
+    pub right_on_name: PlSmallStr,
+    pub suffix: Option<PlSmallStr>,
+}
+
+#[derive(Clone, Debug, PartialEq, Default, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
+pub struct AsOfManyOptions {
+    pub options: AsOfOptions,
+    pub pairs: Vec<AsofJoinPair>,
+}
+
 pub fn _check_asof_columns(
     a: &Series,
     b: &Series,

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -19,7 +19,8 @@ pub use args::*;
 use arrow::trusted_len::TrustedLen;
 #[cfg(feature = "asof_join")]
 pub use asof::{
-    _check_asof_columns, _join_asof_dispatch, AsOfOptions, AsofJoin, AsofJoinBy, AsofStrategy,
+    _check_asof_columns, _join_asof_dispatch, AsOfManyOptions, AsOfOptions, AsofJoin,
+    AsofJoinBy, AsofJoinPair, AsofStrategy,
 };
 pub use cross_join::CrossJoin;
 #[cfg(feature = "chunked_ids")]
@@ -251,6 +252,58 @@ pub trait DataFrameJoinOps: IntoDf {
             );
         }
 
+        #[cfg(feature = "asof_join")]
+        if let JoinType::AsOfMany(ref options) = args.how {
+            let mut out = left_df.clone();
+
+            for ((s_left, s_right), pair) in selected_left
+                .iter()
+                .zip(&selected_right)
+                .zip(options.pairs.iter())
+            {
+                let mut pair_args = args.clone();
+                pair_args.how = JoinType::AsOf(Box::new(options.options.clone()));
+                pair_args.suffix = pair.suffix.clone().or_else(|| pair_args.suffix.clone());
+
+                out = match (
+                    options.options.left_by.clone(),
+                    options.options.right_by.clone(),
+                ) {
+                    (Some(left_by), Some(right_by)) => out._join_asof_by(
+                        other,
+                        s_left,
+                        s_right,
+                        left_by,
+                        right_by,
+                        options.options.strategy,
+                        options.options.tolerance.clone().map(|v| v.into_value()),
+                        pair_args.suffix.clone(),
+                        pair_args.slice,
+                        pair_args.should_coalesce(),
+                        options.options.allow_eq,
+                        options.options.check_sortedness,
+                    )?,
+                    (None, None) => out._join_asof(
+                        other,
+                        s_left,
+                        s_right,
+                        options.options.strategy,
+                        options.options.tolerance.clone().map(|v| v.into_value()),
+                        pair_args.suffix.clone(),
+                        pair_args.slice,
+                        pair_args.should_coalesce(),
+                        options.options.allow_eq,
+                        options.options.check_sortedness,
+                    )?,
+                    _ => {
+                        panic!("expected by arguments on both sides")
+                    },
+                };
+            }
+
+            return Ok(out);
+        }
+
         // Single keys.
         if selected_left.len() == 1 {
             let s_left = &selected_left[0];
@@ -327,6 +380,8 @@ pub trait DataFrameJoinOps: IntoDf {
                         panic!("expected by arguments on both sides")
                     },
                 },
+                #[cfg(feature = "asof_join")]
+                JoinType::AsOfMany(_) => unreachable!(),
                 #[cfg(feature = "iejoin")]
                 JoinType::IEJoin | JoinType::Range => {
                     unreachable!()
@@ -370,7 +425,7 @@ pub trait DataFrameJoinOps: IntoDf {
         // Multiple keys.
         match args.how {
             #[cfg(feature = "asof_join")]
-            JoinType::AsOf(_) => polars_bail!(
+            JoinType::AsOf(_) | JoinType::AsOfMany(_) => polars_bail!(
                 ComputeError: "asof join not supported for join on multiple keys"
             ),
             #[cfg(feature = "iejoin")]

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/join.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/join.rs
@@ -94,6 +94,22 @@ pub fn resolve_join(
                     polars_bail!(InvalidOperation: "expected both 'by_left' and 'by_right' to be set in 'asof_join'")
                 },
             }
+        } else if let JoinType::AsOfMany(options) = &options.args.how {
+            polars_ensure!(
+                !options.pairs.is_empty(),
+                InvalidOperation: "expected at least one pair in 'join_asof_many'"
+            );
+            match (&options.options.left_by, &options.options.right_by) {
+                (None, None) => {},
+                (Some(l), Some(r)) => {
+                    polars_ensure!(l.len() == r.len(), InvalidOperation: "expected equal number of columns in 'by_left' and 'by_right' in 'join_asof_many'");
+                    validate_columns_in_input(l, &schema_left, "join_asof_many")?;
+                    validate_columns_in_input(r, &schema_right, "join_asof_many")?;
+                },
+                _ => {
+                    polars_bail!(InvalidOperation: "expected both 'by_left' and 'by_right' to be set in 'join_asof_many'")
+                },
+            }
         }
 
         polars_ensure!(
@@ -358,6 +374,44 @@ pub fn resolve_join(
                 Time => {
                     let tolerance = duration.duration_ns();
                     options.tolerance = Some(Scalar::from(tolerance))
+                },
+                _ => {
+                    panic!(
+                        "can only use timedelta string language with Date/Datetime/Duration/Time dtypes"
+                    )
+                },
+            }
+        }
+    } else if let JoinType::AsOfMany(options) = &mut options.args.how {
+        use polars_core::utils::arrow::temporal_conversions::MILLISECONDS_IN_DAY;
+
+        if let Some(tol) = &options.options.tolerance_str {
+            let duration = polars_time::Duration::try_parse(tol)?;
+            polars_ensure!(
+                duration.months() == 0,
+                ComputeError: "cannot use month offset in timedelta of an asof join; consider using 4 weeks"
+            );
+            use DataType::*;
+            match ctxt
+                .expr_arena
+                .get(left_on[0].node())
+                .to_dtype(&ToFieldContext::new(ctxt.expr_arena, &schema_left))?
+            {
+                Datetime(tu, _) | Duration(tu) => {
+                    let tolerance = match tu {
+                        TimeUnit::Nanoseconds => duration.duration_ns(),
+                        TimeUnit::Microseconds => duration.duration_us(),
+                        TimeUnit::Milliseconds => duration.duration_ms(),
+                    };
+                    options.options.tolerance = Some(Scalar::from(tolerance))
+                },
+                Date => {
+                    let days = (duration.duration_ms() / MILLISECONDS_IN_DAY) as i32;
+                    options.options.tolerance = Some(Scalar::from(days))
+                },
+                Time => {
+                    let tolerance = duration.duration_ns();
+                    options.options.tolerance = Some(Scalar::from(tolerance))
                 },
                 _ => {
                     panic!(

--- a/crates/polars-plan/src/plans/optimizer/fuse_asof_many.rs
+++ b/crates/polars-plan/src/plans/optimizer/fuse_asof_many.rs
@@ -1,0 +1,204 @@
+use std::sync::Arc;
+
+use polars_core::prelude::PolarsResult;
+use polars_ops::frame::{AsOfManyOptions, AsofJoinPair};
+
+use crate::plans::aexpr::AExpr;
+use crate::plans::schema::det_join_schema;
+use crate::prelude::*;
+
+pub struct FuseAsofMany {}
+
+impl OptimizationRule for FuseAsofMany {
+    fn optimize_plan(
+        &mut self,
+        lp_arena: &mut Arena<IR>,
+        expr_arena: &mut Arena<AExpr>,
+        node: Node,
+    ) -> PolarsResult<Option<IR>> {
+        let IR::Join {
+            input_left,
+            input_right,
+            schema,
+            left_on,
+            right_on,
+            options,
+        } = lp_arena.get(node)
+        else {
+            return Ok(None);
+        };
+
+        let (top_asof, top_pairs) = match &options.args.how {
+            JoinType::AsOf(top_asof) => {
+                if left_on.len() != 1 || right_on.len() != 1 {
+                    return Ok(None);
+                }
+
+                (
+                    top_asof.as_ref(),
+                    vec![AsofJoinPair {
+                        left_on_name: left_on[0].output_name().clone(),
+                        right_on_name: right_on[0].output_name().clone(),
+                        suffix: options.args.suffix.clone(),
+                    }],
+                )
+            },
+            JoinType::AsOfMany(top_asof_many) => {
+                if left_on.len() != top_asof_many.pairs.len()
+                    || right_on.len() != top_asof_many.pairs.len()
+                {
+                    return Ok(None);
+                }
+
+                (&top_asof_many.options, top_asof_many.pairs.clone())
+            },
+            _ => return Ok(None),
+        };
+
+        let IR::Join {
+            input_left: previous_left,
+            input_right: previous_right,
+            schema: _,
+            left_on: prev_left_on,
+            right_on: prev_right_on,
+            options: prev_options,
+        } = lp_arena.get(*input_left)
+        else {
+            return Ok(None);
+        };
+
+        let (original_left, prev_pairs) = match &prev_options.args.how {
+            JoinType::AsOf(_prev_asof) => {
+                if prev_left_on.len() != 1 || prev_right_on.len() != 1 {
+                    return Ok(None);
+                }
+
+                (
+                    *previous_left,
+                    vec![AsofJoinPair {
+                        left_on_name: prev_left_on[0].output_name().clone(),
+                        right_on_name: prev_right_on[0].output_name().clone(),
+                        suffix: prev_options.args.suffix.clone(),
+                    }],
+                )
+            },
+            JoinType::AsOfMany(prev_asof_many) => (
+                *previous_left,
+                prev_asof_many.pairs.clone(),
+            ),
+            _ => return Ok(None),
+        };
+
+        let same_right_input = if input_right == previous_right {
+            true
+        } else {
+            matches!(
+                (lp_arena.get(*input_right), lp_arena.get(*previous_right)),
+                (IR::Cache { id: left_id, .. }, IR::Cache { id: right_id, .. }) if left_id == right_id
+            )
+        };
+        if !same_right_input {
+            return Ok(None);
+        }
+
+        if prev_left_on.len() != prev_pairs.len() || prev_right_on.len() != prev_pairs.len() {
+            return Ok(None);
+        }
+
+        if top_asof != match &prev_options.args.how {
+            JoinType::AsOf(prev_asof) => prev_asof.as_ref(),
+            JoinType::AsOfMany(prev_asof_many) => &prev_asof_many.options,
+            _ => unreachable!(),
+        }
+            || options.allow_parallel != prev_options.allow_parallel
+            || options.force_parallel != prev_options.force_parallel
+            || options.args.coalesce != prev_options.args.coalesce
+        {
+            return Ok(None);
+        }
+
+        let original_left_schema = lp_arena.get(original_left).schema(lp_arena);
+        for expr in prev_left_on
+            .iter()
+            .cloned()
+            .chain(left_on.iter().cloned())
+        {
+            let all_from_original_left = aexpr_to_leaf_names_iter(expr.node(), expr_arena)
+                .all(|name| original_left_schema.contains(name.as_str()));
+            if !all_from_original_left {
+                return Ok(None);
+            }
+        }
+
+        if prev_pairs.iter().any(|existing| {
+            top_pairs
+                .iter()
+                .any(|top_pair| existing.suffix == top_pair.suffix)
+        }) {
+            return Ok(None);
+        }
+
+        let pairs = prev_pairs
+            .iter()
+            .cloned()
+            .chain(top_pairs.iter().cloned())
+            .collect::<Vec<_>>();
+
+        let fused_options = JoinOptionsIR {
+            allow_parallel: options.allow_parallel,
+            force_parallel: options.force_parallel,
+            args: JoinArgs {
+                how: JoinType::AsOfMany(Box::new(AsOfManyOptions {
+                    options: top_asof.clone(),
+                    pairs: pairs.clone(),
+                })),
+                validation: options.args.validation,
+                suffix: options.args.suffix.clone(),
+                slice: options.args.slice,
+                nulls_equal: options.args.nulls_equal,
+                coalesce: options.args.coalesce,
+                maintain_order: options.args.maintain_order,
+                build_side: options.args.build_side.clone(),
+            },
+            options: options.options.clone(),
+        };
+
+        let fused_schema = det_join_schema(
+            &original_left_schema,
+            &lp_arena.get(*input_right).schema(lp_arena),
+            &prev_left_on
+                .iter()
+                .cloned()
+                .chain(left_on.iter().cloned())
+                .collect::<Vec<_>>(),
+            &prev_right_on
+                .iter()
+                .cloned()
+                .chain(right_on.iter().cloned())
+                .collect::<Vec<_>>(),
+            &fused_options,
+            expr_arena,
+        )?;
+
+        if fused_schema.as_ref() != schema.as_ref() {
+            return Ok(None);
+        }
+
+        Ok(Some(IR::Join {
+            input_left: original_left,
+            input_right: *input_right,
+            schema: schema.clone(),
+            left_on: prev_left_on
+                .iter()
+                .cloned()
+                .chain(left_on.iter().cloned())
+                .collect(),
+            right_on: prev_right_on
+                .iter()
+                .cloned()
+                .chain(right_on.iter().cloned())
+                .collect(),
+            options: Arc::new(fused_options),
+        }))
+    }
+}

--- a/crates/polars-plan/src/plans/optimizer/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/mod.rs
@@ -19,6 +19,8 @@ mod fused;
 mod join_utils;
 pub(crate) use join_utils::ExprOrigin;
 mod expand_datasets;
+#[cfg(feature = "asof_join")]
+mod fuse_asof_many;
 #[cfg(feature = "python")]
 pub use expand_datasets::ExpandedPythonScan;
 mod collapse_sort;
@@ -38,6 +40,8 @@ use collapse_and_project::SimpleProjectionAndCollapse;
 pub use cse::NaiveExprMerger;
 use delay_rechunk::DelayRechunk;
 pub use expand_datasets::ExpandedDataset;
+#[cfg(feature = "asof_join")]
+use fuse_asof_many::FuseAsofMany;
 use polars_core::config::verbose;
 pub use predicate_pushdown::{
     DynamicPred, DynamicPredWeakRef, PredicateExpr, PredicatePushDown, TrivialPredicateExpr,
@@ -227,6 +231,8 @@ pub fn optimize(
         #[cfg(feature = "merge_sorted")]
         rules.push(Box::new(FlattenMergeSortedRule::new()));
         rules.push(Box::new(FlattenUnionRule {}));
+        #[cfg(feature = "asof_join")]
+        rules.push(Box::new(FuseAsofMany {}));
     }
 
     root = opt.optimize_loop(&mut rules, expr_arena, ir_arena, root)?;

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
@@ -77,6 +77,10 @@ pub(super) fn process_join(
             JoinType::AsOf(asof_options) => {
                 asof_options.left_by.as_deref().unwrap_or_default().len()
             },
+            #[cfg(feature = "asof_join")]
+            JoinType::AsOfMany(asof_options) => {
+                asof_options.options.left_by.as_deref().unwrap_or_default().len()
+            },
             _ => left_on.len(),
         };
 
@@ -84,6 +88,16 @@ pub(super) fn process_join(
             #[cfg(feature = "asof_join")]
             JoinType::AsOf(asof_options) => Some(
                 asof_options
+                    .left_by
+                    .as_deref()
+                    .unwrap_or_default()
+                    .get(i)
+                    .unwrap(),
+            ),
+            #[cfg(feature = "asof_join")]
+            JoinType::AsOfMany(asof_options) => Some(
+                asof_options
+                    .options
                     .left_by
                     .as_deref()
                     .unwrap_or_default()
@@ -119,6 +133,10 @@ pub(super) fn process_join(
             JoinType::AsOf(asof_options) => {
                 asof_options.right_by.as_deref().unwrap_or_default().len()
             },
+            #[cfg(feature = "asof_join")]
+            JoinType::AsOfMany(asof_options) => {
+                asof_options.options.right_by.as_deref().unwrap_or_default().len()
+            },
             _ => right_on.len(),
         };
 
@@ -126,6 +144,16 @@ pub(super) fn process_join(
             #[cfg(feature = "asof_join")]
             JoinType::AsOf(asof_options) => Some(
                 asof_options
+                    .right_by
+                    .as_deref()
+                    .unwrap_or_default()
+                    .get(i)
+                    .unwrap(),
+            ),
+            #[cfg(feature = "asof_join")]
+            JoinType::AsOfMany(asof_options) => Some(
+                asof_options
+                    .options
                     .right_by
                     .as_deref()
                     .unwrap_or_default()
@@ -158,7 +186,7 @@ pub(super) fn process_join(
     if cfg!(debug_assertions) && options.args.should_coalesce() {
         match &options.args.how {
             #[cfg(feature = "asof_join")]
-            JoinType::AsOf(_) => {},
+            JoinType::AsOf(_) | JoinType::AsOfMany(_) => {},
 
             _ => {
                 assert!(get_lhs_column_keys_iter().len() > 0);
@@ -199,7 +227,7 @@ pub(super) fn process_join(
             Left | Inner | Full => true,
 
             #[cfg(feature = "asof_join")]
-            AsOf(_) => true,
+            AsOf(_) | AsOfMany(_) => true,
             #[cfg(feature = "semi_anti_join")]
             Semi | Anti => true,
 
@@ -307,7 +335,7 @@ pub(super) fn process_join(
             // Behaves similarly to left-join on "by" columns (takes a single match instead of
             // all matches according to asof strategy).
             #[cfg(feature = "asof_join")]
-            JoinType::AsOf(_) => {
+            JoinType::AsOf(_) | JoinType::AsOfMany(_) => {
                 push_right &= push_left;
                 !push_left
             },

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -847,6 +847,23 @@ impl ProjectionPushdownVisitor<'_, '_> {
                     unreachable!()
                 };
 
+                #[cfg(feature = "asof_join")]
+                if matches!(&options.args.how, JoinType::AsOfMany(_)) {
+                    *edges.inputs()[0].projection_state_mut() = ProjectionState {
+                        projection: Projection::Names,
+                        names: Some(Box::new(
+                            input_schema_left.iter_names_cloned().collect(),
+                        )),
+                    };
+                    *edges.inputs()[1].projection_state_mut() = ProjectionState {
+                        projection: Projection::Names,
+                        names: Some(Box::new(
+                            input_schema_right.iter_names_cloned().collect(),
+                        )),
+                    };
+                    return;
+                }
+
                 let opt_projected_names = out_edge.compute_projected_names(output_schema_arc);
 
                 let is_projected_in_output = |name: &str| {
@@ -947,18 +964,34 @@ impl ProjectionPushdownVisitor<'_, '_> {
                 }
 
                 #[cfg(feature = "asof_join")]
-                if let JoinType::AsOf(asof_options) = &options.args.how {
-                    if let Some(left_by) = asof_options.left_by.as_deref() {
-                        for name in left_by {
-                            project_left.insert(name.clone());
+                match &options.args.how {
+                    JoinType::AsOf(asof_options) => {
+                        if let Some(left_by) = asof_options.left_by.as_deref() {
+                            for name in left_by {
+                                project_left.insert(name.clone());
+                            }
                         }
-                    }
 
-                    if let Some(right_by) = asof_options.right_by.as_deref() {
-                        for name in right_by {
-                            project_right.insert(name.clone());
+                        if let Some(right_by) = asof_options.right_by.as_deref() {
+                            for name in right_by {
+                                project_right.insert(name.clone());
+                            }
                         }
-                    }
+                    },
+                    JoinType::AsOfMany(asof_many_options) => {
+                        if let Some(left_by) = asof_many_options.options.left_by.as_deref() {
+                            for name in left_by {
+                                project_left.insert(name.clone());
+                            }
+                        }
+
+                        if let Some(right_by) = asof_many_options.options.right_by.as_deref() {
+                            for name in right_by {
+                                project_right.insert(name.clone());
+                            }
+                        }
+                    },
+                    _ => {},
                 }
 
                 // Turn on coalesce if non-coalesced keys are not included in projection. Reduces materialization.

--- a/crates/polars-plan/src/plans/optimizer/simplify_ordering/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_ordering/mod.rs
@@ -340,7 +340,7 @@ impl SimplifyIRNodeOrder<'_> {
                 assert!(!eos.internally_observed_orders().contains(O::COLUMN));
 
                 #[cfg(feature = "asof_join")]
-                if let JoinType::AsOf(_) = &options.args.how {
+                if matches!(&options.args.how, JoinType::AsOf(_) | JoinType::AsOfMany(_)) {
                     if in_edge_lhs.is_unordered()
                         || (out_edge.is_unordered() && in_edge_rhs.is_unordered())
                     {

--- a/crates/polars-plan/src/plans/schema.rs
+++ b/crates/polars-plan/src/plans/schema.rs
@@ -116,6 +116,41 @@ pub(crate) fn det_join_schema(
     expr_arena: &Arena<AExpr>,
 ) -> PolarsResult<SchemaRef> {
     match &options.args.how {
+        #[cfg(feature = "asof_join")]
+        JoinType::AsOfMany(asof_many_options) => {
+            let mut current_left = schema_left.clone();
+            for ((left_expr, right_expr), pair) in left_on
+                .iter()
+                .zip(right_on.iter())
+                .zip(asof_many_options.pairs.iter())
+            {
+                let pair_options = JoinOptionsIR {
+                    allow_parallel: options.allow_parallel,
+                    force_parallel: options.force_parallel,
+                    args: JoinArgs {
+                        how: JoinType::AsOf(Box::new(asof_many_options.options.clone())),
+                        validation: options.args.validation,
+                        suffix: pair.suffix.clone().or_else(|| options.args.suffix.clone()),
+                        slice: options.args.slice,
+                        nulls_equal: options.args.nulls_equal,
+                        coalesce: options.args.coalesce,
+                        maintain_order: options.args.maintain_order,
+                        build_side: options.args.build_side.clone(),
+                    },
+                    options: options.options.clone(),
+                };
+                current_left = det_join_schema(
+                    &current_left,
+                    schema_right,
+                    std::slice::from_ref(left_expr),
+                    std::slice::from_ref(right_expr),
+                    &pair_options,
+                    expr_arena,
+                )?;
+            }
+
+            Ok(current_left)
+        },
         // semi and anti joins are just filtering operations
         // the schema will never change.
         #[cfg(feature = "semi_anti_join")]
@@ -192,10 +227,18 @@ pub(crate) fn det_join_schema(
 
             let mut right_by: PlHashSet<&PlSmallStr> = PlHashSet::default();
             #[cfg(feature = "asof_join")]
-            if let JoinType::AsOf(asof_options) = &options.args.how {
-                if let Some(v) = &asof_options.right_by {
-                    right_by.extend(v.iter());
-                }
+            match &options.args.how {
+                JoinType::AsOf(asof_options) => {
+                    if let Some(v) = &asof_options.right_by {
+                        right_by.extend(v.iter());
+                    }
+                },
+                JoinType::AsOfMany(asof_options) => {
+                    if let Some(v) = &asof_options.options.right_by {
+                        right_by.extend(v.iter());
+                    }
+                },
+                _ => {},
             }
 
             for (name, dtype) in schema_right.iter() {
@@ -215,7 +258,7 @@ pub(crate) fn det_join_schema(
                         // so the columns that are joined on, may have different
                         // values so if the right has a different name, it is added to the schema
                         #[cfg(feature = "asof_join")]
-                        if matches!(how, JoinType::AsOf(_)) {
+                        if matches!(how, JoinType::AsOf(_) | JoinType::AsOfMany(_)) {
                             let field_left = left_on[idx].field(schema_left, expr_arena)?;
                             need_to_include_column = field_left.name != name;
                         }

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -1449,6 +1449,80 @@ impl PyLazyFrame {
         ldf.with_row_index(name, offset).into()
     }
 
+    #[cfg(feature = "asof_join")]
+    #[pyo3(signature = (other, pairs, left_by, right_by, allow_parallel, force_parallel, suffix, strategy, tolerance, tolerance_str, coalesce, allow_eq, check_sortedness))]
+    fn join_asof_many(
+        &self,
+        other: Self,
+        pairs: Vec<(PyExpr, PyExpr, Option<PyBackedStr>)>,
+        left_by: Option<Vec<PyBackedStr>>,
+        right_by: Option<Vec<PyBackedStr>>,
+        allow_parallel: bool,
+        force_parallel: bool,
+        suffix: String,
+        strategy: Wrap<AsofStrategy>,
+        tolerance: Option<Wrap<AnyValue<'_>>>,
+        tolerance_str: Option<String>,
+        coalesce: bool,
+        allow_eq: bool,
+        check_sortedness: bool,
+    ) -> PyResult<Self> {
+        let coalesce = if coalesce {
+            JoinCoalesce::CoalesceColumns
+        } else {
+            JoinCoalesce::KeepColumns
+        };
+        let pairs = pairs
+            .into_iter()
+            .map(|(left_on, right_on, pair_suffix)| {
+                Ok(AsofJoinPair {
+                    left_on_name: left_on
+                        .inner
+                        .clone()
+                        .meta()
+                        .output_name()
+                        .map_err(PyPolarsErr::from)?
+                        .clone(),
+                    right_on_name: right_on
+                        .inner
+                        .clone()
+                        .meta()
+                        .output_name()
+                        .map_err(PyPolarsErr::from)?
+                        .clone(),
+                    suffix: pair_suffix.map(|s| PlSmallStr::from_str(s.as_ref())),
+                })
+            })
+            .collect::<PyResult<Vec<_>>>()?;
+
+        Ok(self
+            .ldf
+            .read()
+            .clone()
+            .join_asof_many(
+                other.ldf.into_inner(),
+                pairs,
+                AsOfOptions {
+                    strategy: strategy.0,
+                    left_by: left_by.map(strings_to_pl_smallstr),
+                    right_by: right_by.map(strings_to_pl_smallstr),
+                    tolerance: tolerance.map(|t| {
+                        let av = t.0.into_static();
+                        let dtype = av.dtype();
+                        Scalar::new(dtype, av)
+                    }),
+                    tolerance_str: tolerance_str.map(Into::into),
+                    allow_eq,
+                    check_sortedness,
+                },
+                allow_parallel,
+                force_parallel,
+                Some(suffix.into()),
+                coalesce,
+            )
+            .into())
+    }
+
     #[pyo3(signature = (function, predicate_pushdown, projection_pushdown, slice_pushdown, streamable, schema, validate_output))]
     fn map_batches(
         &self,

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -558,7 +558,7 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<Py<PyAny>> {
                 (
                     match how {
                         #[cfg(feature = "asof_join")]
-                        JoinType::AsOf(_) => {
+                        JoinType::AsOf(_) | JoinType::AsOfMany(_) => {
                             return Err(PyNotImplementedError::new_err("asof join"));
                         },
                         #[cfg(feature = "iejoin")]

--- a/py-polars/src/polars/__init__.py
+++ b/py-polars/src/polars/__init__.py
@@ -251,6 +251,7 @@ from polars.io.cloud import (
     CredentialProviderFunctionReturn,
     CredentialProviderGCP,
 )
+from polars.join import AsofJoinPair
 from polars.lazyframe import GPUEngine, LazyFrame, QueryOptFlags
 from polars.meta import (
     build_info,
@@ -401,6 +402,7 @@ __all__ = [
     # polars.functions.aggregation
     "all",
     "all_horizontal",
+    "AsofJoinPair",
     "any",
     "any_horizontal",
     "cum_sum",

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -8199,6 +8199,55 @@ class DataFrame:
             .collect(optimizations=QueryOptFlags._eager())
         )
 
+    @unstable()
+    def join_asof_many(
+        self,
+        other: DataFrame,
+        *,
+        pairs: Sequence[pl.AsofJoinPair],
+        by_left: str | Sequence[str] | None = None,
+        by_right: str | Sequence[str] | None = None,
+        by: str | Sequence[str] | None = None,
+        strategy: AsofJoinStrategy = "backward",
+        suffix: str = "_right",
+        allow_exact_matches: bool = True,
+        allow_parallel: bool = True,
+        force_parallel: bool = False,
+        coalesce: bool = True,
+        tolerance: str | int | float | timedelta | None = None,
+        check_sortedness: bool = True,
+    ) -> DataFrame:
+        """
+        Perform multiple asof joins against the same right-hand frame.
+
+        This is similar to :meth:`join_asof`, except that multiple asof matches are
+        computed against the same ``other`` frame in pair order.
+
+        This functionality is experimental. It may be changed at any point without it
+        being considered a breaking change.
+        """
+        from polars.lazyframe.opt_flags import QueryOptFlags
+
+        return (
+            self.lazy()
+            .join_asof_many(
+                other.lazy(),
+                pairs=pairs,
+                by_left=by_left,
+                by_right=by_right,
+                by=by,
+                strategy=strategy,
+                suffix=suffix,
+                allow_exact_matches=allow_exact_matches,
+                allow_parallel=allow_parallel,
+                force_parallel=force_parallel,
+                coalesce=coalesce,
+                tolerance=tolerance,
+                check_sortedness=check_sortedness,
+            )
+            .collect(optimizations=QueryOptFlags._eager())
+        )
+
     @deprecate_renamed_parameter("join_nulls", "nulls_equal", version="1.24")
     def join(
         self,

--- a/py-polars/src/polars/join.py
+++ b/py-polars/src/polars/join.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from polars._utils.unstable import unstable
+
+if TYPE_CHECKING:
+    import polars._reexport as pl
+
+
+@unstable()
+@dataclass(frozen=True, slots=True)
+class AsofJoinPair:
+    left_on: str | pl.Expr
+    right_on: str | pl.Expr
+    suffix: str | None = None

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -6200,6 +6200,111 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             )
         )
 
+    @unstable()
+    def join_asof_many(
+        self,
+        other: LazyFrame,
+        *,
+        pairs: Sequence[pl.AsofJoinPair],
+        by_left: str | Sequence[str] | None = None,
+        by_right: str | Sequence[str] | None = None,
+        by: str | Sequence[str] | None = None,
+        strategy: AsofJoinStrategy = "backward",
+        suffix: str = "_right",
+        allow_exact_matches: bool = True,
+        allow_parallel: bool = True,
+        force_parallel: bool = False,
+        coalesce: bool = True,
+        tolerance: str | int | float | timedelta | None = None,
+        check_sortedness: bool = True,
+    ) -> LazyFrame:
+        """
+        Perform multiple asof joins against the same right-hand frame.
+
+        This is similar to ``join_asof``, except that multiple asof joins are
+        performed in pair order against the same ``other`` frame.
+
+        Parameters
+        ----------
+        other
+            Lazy DataFrame to join with.
+        pairs
+            Sequence of ``AsofJoinPair`` specifications.
+        by_left
+            Join on these columns before doing asof join.
+        by_right
+            Join on these columns before doing asof join.
+        by
+            Join on these columns before doing asof join.
+        strategy : {'backward', 'forward', 'nearest'}
+            Join strategy.
+        suffix
+            Default suffix to append to columns with a duplicate name.
+        allow_exact_matches
+            Whether exact matches are valid join predicates.
+        allow_parallel
+            Allow the physical plan to optionally evaluate the computation of both
+            DataFrames up to the join in parallel.
+        force_parallel
+            Force the physical plan to evaluate the computation of both DataFrames up to
+            the join in parallel.
+        coalesce
+            Whether to coalesce join columns.
+        tolerance
+            Numeric or temporal tolerance, following ``join_asof`` semantics.
+        check_sortedness
+            Check the sortedness of the asof keys.
+
+        Notes
+        -----
+        This functionality is experimental. It may be changed at any point without it
+        being considered a breaking change.
+        """
+        require_same_type(self, other)
+
+        if by is not None:
+            by_left_ = [by] if isinstance(by, str) else by
+            by_right_ = by_left_
+        elif (by_left is not None) or (by_right is not None):
+            by_left_ = [by_left] if isinstance(by_left, str) else by_left  # type: ignore[assignment]
+            by_right_ = [by_right] if isinstance(by_right, str) else by_right  # type: ignore[assignment]
+        else:
+            by_left_ = None
+            by_right_ = None
+
+        tolerance_str: str | None = None
+        tolerance_num: float | int | None = None
+        if isinstance(tolerance, str):
+            tolerance_str = tolerance
+        elif isinstance(tolerance, timedelta):
+            tolerance_str = parse_as_duration_string(tolerance)
+        else:
+            tolerance_num = tolerance
+
+        parsed_pairs = []
+        for pair in pairs:
+            left_on = pair.left_on if isinstance(pair.left_on, pl.Expr) else F.col(pair.left_on)
+            right_on = pair.right_on if isinstance(pair.right_on, pl.Expr) else F.col(pair.right_on)
+            parsed_pairs.append((left_on._pyexpr, right_on._pyexpr, pair.suffix))
+
+        return self._from_pyldf(
+            self._ldf.join_asof_many(
+                other._ldf,
+                parsed_pairs,
+                by_left_,
+                by_right_,
+                allow_parallel,
+                force_parallel,
+                suffix,
+                strategy,
+                tolerance_num,
+                tolerance_str,
+                coalesce,
+                allow_exact_matches,
+                check_sortedness,
+            )
+        )
+
     @deprecate_renamed_parameter("join_nulls", "nulls_equal", version="1.24")
     def join(
         self,

--- a/py-polars/tests/unit/lazyframe/test_optimizations.py
+++ b/py-polars/tests/unit/lazyframe/test_optimizations.py
@@ -279,6 +279,48 @@ def test_collapse_joins() -> None:
     )
 
 
+def test_fuse_join_asof_many() -> None:
+    left = pl.LazyFrame({"ts_a": [1, 3, 5], "ts_b": [2, 4, 6]})
+    right = pl.LazyFrame({"ts": [1, 2, 4, 7], "v": [10, 20, 40, 70]})
+
+    q = (
+        left.join_asof(right, left_on="ts_a", right_on="ts", suffix="_a")
+        .join_asof(right, left_on="ts_b", right_on="ts", suffix="_right_b")
+    )
+
+    plan = q.explain()
+    assert "ASOF MANY JOIN" in plan
+
+
+def test_fuse_join_asof_many_chain() -> None:
+    left = pl.LazyFrame({"ts_a": [1, 3, 5], "ts_b": [2, 4, 6], "ts_c": [3, 5, 7]})
+    right = pl.LazyFrame({"rhs_ts": [1, 2, 4, 7], "v": [10, 20, 40, 70]})
+
+    q = (
+        left.join_asof(right, left_on="ts_a", right_on="rhs_ts", suffix="_a")
+        .join_asof(right, left_on="ts_b", right_on="rhs_ts", suffix="_b")
+        .join_asof(right, left_on="ts_c", right_on="rhs_ts", suffix="_c")
+    )
+
+    plan = q.explain()
+    assert plan.count("ASOF MANY JOIN:") == 1
+
+
+def test_do_not_fuse_join_asof_many_when_second_join_depends_on_first() -> None:
+    left = pl.LazyFrame({"ts_a": [1, 3, 5]})
+    right = pl.LazyFrame({"ts": [1, 2, 4, 7], "v": [10, 20, 40, 70]})
+
+    q = left.join_asof(right, left_on="ts_a", right_on="ts", suffix="_a").join_asof(
+        right,
+        left_on="v",
+        right_on="ts",
+        suffix="_b",
+    )
+
+    plan = q.explain()
+    assert "ASOF MANY JOIN" not in plan
+
+
 @pytest.mark.slow
 def test_collapse_joins_combinations() -> None:
     # This just tests all possible combinations for expressions on a cross join.

--- a/py-polars/tests/unit/operations/test_join_asof_many.py
+++ b/py-polars/tests/unit/operations/test_join_asof_many.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+
+def test_join_asof_many_forward() -> None:
+    left = pl.DataFrame(
+        {
+            "ts_a": [1, 2, 3],
+            "ts_b": [2, 3, 4],
+            "value": [10, 20, 30],
+        }
+    )
+    right = pl.DataFrame(
+        {
+            "ts_a": [2, 4, 5],
+            "ts_b": [1, 3, 6],
+            "payload": [100, 200, 300],
+        }
+    )
+
+    result = left.join_asof_many(
+        right,
+        pairs=[
+            pl.AsofJoinPair(left_on="ts_a", right_on="ts_a", suffix="_a"),
+            pl.AsofJoinPair(left_on="ts_b", right_on="ts_b", suffix="_b"),
+        ],
+        strategy="forward",
+        coalesce=False,
+    )
+
+    expected = (
+        left.join_asof(
+            right,
+            left_on="ts_a",
+            right_on="ts_a",
+            strategy="forward",
+            suffix="_a",
+            coalesce=False,
+        )
+        .join_asof(
+            right,
+            left_on="ts_b",
+            right_on="ts_b",
+            strategy="forward",
+            suffix="_b",
+            coalesce=False,
+        )
+    )
+
+    assert_frame_equal(result, expected)
+
+
+def test_join_asof_many_lazy() -> None:
+    left = pl.LazyFrame(
+        {
+            "ts_a": [1, 3, 5],
+            "ts_b": [2, 4, 6],
+        }
+    )
+    right = pl.LazyFrame(
+        {
+            "ts_a": [2, 4, 6],
+            "ts_b": [1, 5, 7],
+            "payload": [5, 6, 7],
+        }
+    )
+
+    result = left.join_asof_many(
+        right,
+        pairs=[
+            pl.AsofJoinPair(left_on="ts_a", right_on="ts_a", suffix="_a"),
+            pl.AsofJoinPair(left_on="ts_b", right_on="ts_b", suffix="_b"),
+        ],
+        strategy="backward",
+        coalesce=False,
+    ).collect()
+
+    expected = (
+        left.join_asof(
+            right,
+            left_on="ts_a",
+            right_on="ts_a",
+            strategy="backward",
+            suffix="_a",
+            coalesce=False,
+        )
+        .join_asof(
+            right,
+            left_on="ts_b",
+            right_on="ts_b",
+            strategy="backward",
+            suffix="_b",
+            coalesce=False,
+        )
+        .collect()
+    )
+
+    assert_frame_equal(result, expected)


### PR DESCRIPTION
# PR Overview: `join_asof_many`

This core API change adds a public `join_asof_many` entrypoint in Rust and Python for joining one left frame against the same right frame across multiple asof key pairs in a single call.

On this branch, the scope is the public API and direct eager/lazy execution path. Optimizer fusion, pushdown-specific follow-ups, and broader streaming integration are intentionally left for later stacked PRs.

Minimal Python API comparison:

```python
# Before: repeated chained join_asof calls
result = (
    left.lazy()
    .join_asof(right.lazy(), left_on="ts_a", right_on="ts", suffix="_a")
    .join_asof(right.lazy(), left_on="ts_b", right_on="ts", suffix="_b")
    .join_asof(right.lazy(), left_on="ts_c", right_on="ts", suffix="_c")
    .join_asof(right.lazy(), left_on="ts_d", right_on="ts", suffix="_d")
)

# After: one join_asof_many call
result = left.lazy().join_asof_many(
    right.lazy(),
    pairs=[
        pl.AsofJoinPair("ts_a", "ts", suffix="_a"),
        pl.AsofJoinPair("ts_b", "ts", suffix="_b"),
        pl.AsofJoinPair("ts_c", "ts", suffix="_c"),
        pl.AsofJoinPair("ts_d", "ts", suffix="_d"),
    ],
)
```

Verified benchmark rerun on this core API branch (`feature/join-asof-many-split-1-core`) for the same synthetic lazy workload, using stable Polars chained `join_asof` from `TakechipCentralStable` as the baseline:

| Pairs | Stable chained plan | Core `join_asof_many` plan | Stable chained collect | Core `join_asof_many` collect |
| --- | ---: | ---: | ---: | ---: |
| 1 | `0.000363s` | `0.000285s` | `0.007853s` | `0.008026s` |
| 2 | `0.000547s` | `0.000440s` | `0.019620s` | `0.013314s` |
| 4 | `0.000676s` | `0.000571s` | `0.040625s` | `0.028842s` |
| 8 | `0.001194s` | `0.000722s` | `0.102854s` | `0.052320s` |
| 16 | `0.002364s` | `0.000983s` | `0.188489s` | `0.101457s` |

On this run, the core `join_asof_many` branch is already competitive at `1` pair and shows clear planning and execution wins from `2` pairs onward.

Follow-up stacked changes on `feature/join-asof-many-split-3-full` add optimizer fusion and pushdown integration. Rerunning the same lazy benchmark on that branch, again against stable chained `join_asof`, gives:

| Pairs | Stable chained plan | Final `join_asof_many` plan | Stable chained collect | Final `join_asof_many` collect |
| --- | ---: | ---: | ---: | ---: |
| 1 | `0.000373s` | `0.000389s` | `0.008481s` | `0.007757s` |
| 2 | `0.000533s` | `0.000498s` | `0.020488s` | `0.015782s` |
| 4 | `0.000724s` | `0.000613s` | `0.044430s` | `0.029755s` |
| 8 | `0.001507s` | `0.000791s` | `0.097239s` | `0.051290s` |
| 16 | `0.002677s` | `0.001287s` | `0.201743s` | `0.101959s` |

This follow-up branch keeps the same strong multi-join speedups and further improves planning as the chained join count grows.

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.
