### PR TITLE
fix: Fix `str.to_time` was raising unnecessarily when input was all nulls

### DIFF
--- a/crates/polars-time/src/chunkedarray/string/mod.rs
+++ b/crates/polars-time/src/chunkedarray/string/mod.rs
@@ -50,32 +50,20 @@ where
         .copied()
 }
 
-fn get_first_val(ca: &StringChunked) -> PolarsResult<&str> {
-    let idx = ca.first_non_null().ok_or_else(|| {
-        polars_err!(ComputeError:
-            "unable to determine date parsing format, all values are null",
-        )
-    })?;
-    Ok(ca.get(idx).expect("should not be null"))
-}
-
 #[cfg(feature = "dtype-datetime")]
-fn sniff_fmt_datetime(ca_string: &StringChunked) -> PolarsResult<&'static str> {
-    let val = get_first_val(ca_string)?;
+fn sniff_fmt_datetime(val: &str) -> PolarsResult<&'static str> {
     datetime_pattern(val, NaiveDateTime::parse_from_str)
         .or_else(|| datetime_pattern(val, NaiveDate::parse_from_str))
         .ok_or_else(|| polars_err!(parse_fmt_idk = "datetime"))
 }
 
 #[cfg(feature = "dtype-date")]
-fn sniff_fmt_date(ca_string: &StringChunked) -> PolarsResult<&'static str> {
-    let val = get_first_val(ca_string)?;
+fn sniff_fmt_date(val: &str) -> PolarsResult<&'static str> {
     date_pattern(val, NaiveDate::parse_from_str).ok_or_else(|| polars_err!(parse_fmt_idk = "date"))
 }
 
 #[cfg(feature = "dtype-time")]
-fn sniff_fmt_time(ca_string: &StringChunked) -> PolarsResult<&'static str> {
-    let val = get_first_val(ca_string)?;
+fn sniff_fmt_time(val: &str) -> PolarsResult<&'static str> {
     time_pattern(val, NaiveTime::parse_from_str).ok_or_else(|| polars_err!(parse_fmt_idk = "time"))
 }
 
@@ -86,7 +74,16 @@ pub trait StringMethods: AsString {
         let string_ca = self.as_string();
         let fmt = match fmt {
             Some(fmt) => fmt,
-            None => sniff_fmt_time(string_ca)?,
+            None => {
+                let Some(idx) = string_ca.first_non_null() else {
+                    return Ok(
+                        Int64Chunked::full_null(string_ca.name().clone(), string_ca.len())
+                            .into_time(),
+                    );
+                };
+                let val = string_ca.get(idx).expect("should not be null");
+                sniff_fmt_time(val)?
+            },
         };
         let use_cache = use_cache && string_ca.len() > 50;
 
@@ -109,7 +106,16 @@ pub trait StringMethods: AsString {
         let string_ca = self.as_string();
         let fmt = match fmt {
             Some(fmt) => fmt,
-            None => sniff_fmt_date(string_ca)?,
+            None => {
+                let Some(idx) = string_ca.first_non_null() else {
+                    return Ok(
+                        Int32Chunked::full_null(string_ca.name().clone(), string_ca.len())
+                            .into_date(),
+                    );
+                };
+                let val = string_ca.get(idx).expect("should not be null");
+                sniff_fmt_date(val)?
+            },
         };
         let ca = unary_elementwise(string_ca, |opt_s| {
             let mut s = opt_s?;
@@ -147,7 +153,16 @@ pub trait StringMethods: AsString {
         let had_format = fmt.is_some();
         let fmt = match fmt {
             Some(fmt) => fmt,
-            None => sniff_fmt_datetime(string_ca)?,
+            None => {
+                let Some(idx) = string_ca.first_non_null() else {
+                    return Ok(
+                        Int64Chunked::full_null(string_ca.name().clone(), string_ca.len())
+                            .into_datetime(tu, tz.cloned()),
+                    );
+                };
+                let val = string_ca.get(idx).expect("should not be null");
+                sniff_fmt_datetime(val)?
+            },
         };
 
         let func = match tu {

--- a/py-polars/tests/unit/operations/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/operations/namespaces/test_strptime.py
@@ -711,6 +711,26 @@ def test_to_time_format_warning() -> None:
     assert result == time(5, 10, 10, 74)
 
 
+@pytest.mark.parametrize(
+    ("expr", "dtype"),
+    [
+        (pl.col("a").str.to_time(), pl.Time),
+        (pl.col("a").str.to_date(), pl.Date),
+        (pl.col("a").str.to_date(exact=False), pl.Date),
+        (pl.col("a").str.to_datetime(), pl.Datetime),
+        (pl.col("a").str.to_datetime(exact=False), pl.Datetime),
+    ],
+)
+def test_all_nulls_(expr: pl.Expr, dtype: pl.DataType) -> None:
+    df = pl.DataFrame(
+        {"a": [None, None]},
+        schema_overrides={"a": pl.String},
+    )
+    result = df.with_columns(expr)["a"]
+    expected = pl.Series("a", [None, None], dtype=dtype)
+    assert_series_equal(result, expected)
+
+
 @pytest.mark.parametrize("exact", [True, False])
 def test_to_datetime_ambiguous_earliest(exact: bool) -> None:
     result = (


### PR DESCRIPTION
closes #22774

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
