### PR TITLE
docs: Drop redundant Pattern 2 from Dagster integration page

### DIFF
--- a/docs/source/polars-cloud/integrations/dagster.md
+++ b/docs/source/polars-cloud/integrations/dagster.md
@@ -1,13 +1,7 @@
 # Dagster
 
-Integrate Polars Cloud authentication and compute sizing into a Dagster pipeline. Two patterns are
-documented below; both code blocks are complete and runnable on their own.
-
-- **Single compute size** — every asset uses the same VM shape. The compute resource auto-manages
-  one `ComputeContext` per Dagster run via `yield_for_execution`; asset bodies need no per-asset
-  setup.
-- **Per-asset compute sizing** — different assets need different VM shapes. Each asset opens a
-  `session()` context manager on the compute resource it needs.
+Integrate Polars Cloud authentication and per-asset compute sizing into a Dagster pipeline using
+typed `ConfigurableResource` subclasses.
 
 Credentials are referenced through
 [`EnvVar`](https://docs.dagster.io/guides/operate/configuration/using-environment-variables-and-secrets#dagster-envvar-class)
@@ -16,16 +10,17 @@ so the raw values are resolved at run launch and never displayed in the Dagster 
 either directly or by exporting from a secret manager (e.g.
 [AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/retrieving-secrets-python.html)).
 
-In both patterns `PolarsCloudCompute` declares `PolarsCloudAuth` as a
+`PolarsCloudCompute` declares `PolarsCloudAuth` as a
 [nested resource](https://docs.dagster.io/guides/build/external-resources/defining-resources) so
 Dagster runs `PolarsCloudAuth.setup_for_execution` — which calls `authenticate(...)` — before any
-compute resource is used.
+compute resource is used. The compute resource owns the `ComputeContext` lifecycle through
+`yield_for_execution`: the VM is started before each asset that uses the resource runs and stopped
+on exit, including on failure. Asset bodies contain only Polars code.
 
-## Pattern 1: single compute size
-
-The compute resource owns the `ComputeContext` lifecycle through `yield_for_execution`: one VM is
-started at run init and stopped on exit, including on failure. Asset bodies contain only Polars
-code.
+Per-asset compute sizing falls out of the same pattern: declare one `PolarsCloudCompute` instance
+per VM shape under distinct resource keys, and each asset takes the instance sized for it. Dagster
+manages the lifecycle of each instance independently, so the asset that uses the larger VM does not
+pay the cost of spinning it up while the smaller-VM assets are running.
 
 ```python
 from contextlib import contextmanager
@@ -37,7 +32,7 @@ from polars_cloud import ComputeContext, authenticate, set_compute_context
 
 
 class PolarsCloudAuth(ConfigurableResource):
-    """Service-account authentication. Runs once per Dagster run."""
+    """Service-account authentication for Polars Cloud."""
 
     client_id: str
     client_secret: str
@@ -50,10 +45,9 @@ class PolarsCloudCompute(ConfigurableResource):
     """Polars Cloud compute context with auto-managed VM lifecycle.
 
     Declares ``PolarsCloudAuth`` as a nested resource so Dagster runs
-    ``authenticate(...)`` before this resource is used. The active
-    ``ComputeContext`` is started in ``yield_for_execution`` and stopped on
-    exit — the ``finally`` clause guarantees the VM is released even when an
-    asset raises.
+    ``authenticate(...)`` before this resource is used. ``yield_for_execution``
+    starts a ``ComputeContext`` of the configured shape and the ``finally``
+    clause guarantees the VM is released even when an asset raises.
     """
 
     auth: PolarsCloudAuth
@@ -71,104 +65,23 @@ class PolarsCloudCompute(ConfigurableResource):
 
 
 @asset
-def dataset_1(compute: PolarsCloudCompute):
+def dataset_1(small_vm: PolarsCloudCompute):
     pl.scan_csv(...).remote().sink_parquet(...)
 
 
 @asset
-def dataset_2(compute: PolarsCloudCompute):
+def dataset_2(small_vm: PolarsCloudCompute):
     pl.scan_ndjson(...).remote().sink_parquet(...)
 
 
+# Use a bigger machine for the join.
 @asset(deps=[dataset_1, dataset_2])
-def joined(compute: PolarsCloudCompute):
+def joined(large_vm: PolarsCloudCompute):
     pl.scan_parquet(...).remote().sink_parquet(...)
 
 
-defs = Definitions(
-    assets=[dataset_1, dataset_2, joined],
-    resources={
-        "compute": PolarsCloudCompute(
-            auth=PolarsCloudAuth(
-                client_id=EnvVar("POLARS_CLOUD_CLIENT_ID"),
-                client_secret=EnvVar("POLARS_CLOUD_CLIENT_SECRET"),
-            ),
-            cpus=4,
-            memory=16,
-        ),
-    },
-)
-```
-
-## Pattern 2: per-asset compute sizing
-
-`set_compute_context` is process-global state, so a single auto-managed context cannot serve
-multiple VM shapes within one run. When assets need different shapes, each compute resource exposes
-a `session()` context manager instead of starting its `ComputeContext` at run init. The asset opens
-the session of the resource sized for it; the VM is stopped on exit, including on failure.
-
-A single `PolarsCloudAuth` instance is reused for both compute resources, so the credentials are
-loaded once at run start.
-
-```python
-from contextlib import contextmanager
-
-import polars as pl
-from dagster import asset, ConfigurableResource, Definitions, EnvVar
-
-from polars_cloud import ComputeContext, authenticate, set_compute_context
-
-
-class PolarsCloudAuth(ConfigurableResource):
-    """Service-account authentication. Runs once per Dagster run."""
-
-    client_id: str
-    client_secret: str
-
-    def setup_for_execution(self, context) -> None:
-        authenticate(client_id=self.client_id, client_secret=self.client_secret)
-
-
-class PolarsCloudCompute(ConfigurableResource):
-    """Polars Cloud compute context with per-asset session management.
-
-    Each ``session()`` call starts a fresh ``ComputeContext`` of the configured
-    shape and stops the VM on exit. ``PolarsCloudAuth`` is a nested resource
-    so Dagster initialises it before any compute resource is used.
-    """
-
-    auth: PolarsCloudAuth
-    cpus: int
-    memory: int
-
-    @contextmanager
-    def session(self):
-        ctx = ComputeContext(cpus=self.cpus, memory=self.memory)
-        try:
-            set_compute_context(ctx)
-            yield ctx
-        finally:
-            ctx.stop()
-
-
-@asset
-def dataset_1(small_vm: PolarsCloudCompute):
-    with small_vm.session():
-        pl.scan_csv(...).remote().sink_parquet(...)
-
-
-@asset
-def dataset_2(small_vm: PolarsCloudCompute):
-    with small_vm.session():
-        pl.scan_ndjson(...).remote().sink_parquet(...)
-
-
-@asset(deps=[dataset_1, dataset_2])
-def joined(large_vm: PolarsCloudCompute):
-    with large_vm.session():
-        pl.scan_parquet(...).remote().sink_parquet(...)
-
-
+# Share a single ``PolarsCloudAuth`` instance between the compute resources so
+# the credentials are loaded once per run.
 auth = PolarsCloudAuth(
     client_id=EnvVar("POLARS_CLOUD_CLIENT_ID"),
     client_secret=EnvVar("POLARS_CLOUD_CLIENT_SECRET"),


### PR DESCRIPTION
Follow-up to #27560.

In a post-merge note on #27560, @danielgafni (maintainer of \`dagster-polars\`) pointed out that I framed `set_compute_context` as a run-scope process global to justify the Pattern 2 \"per-asset compute sizing\" section. That framing is wrong: each asset gets its own resource instance with its own lifecycle, so `yield_for_execution` already covers per-asset compute sizing — Pattern 2's manual `session()` indirection is redundant rather than a separate use case.

This PR collapses the page into a single example demonstrating per-asset sizing through the existing auto-managed lifecycle: two `PolarsCloudCompute` instances (`small_vm`, `large_vm`) under distinct resource keys, both using `yield_for_execution`. The single shared `PolarsCloudAuth` instance still ensures credentials load once per run.

## Diff shape

`-107 / +20` lines on `docs/source/polars-cloud/integrations/dagster.md`. No other files touched.

## Validation

```bash
dprint check docs/source/polars-cloud/integrations/dagster.md
```

Quoting @danielgafni's correction inline for reviewers' context:

> > kept manual session() because set_compute_context is process-global, so a single auto-managed context can't serve multiple VM shapes within one run.
>
> This is incorrect, each asset gets its own resource instance with its own lifecycle.