### PR TITLE
docs(python): clarify API examples

### DIFF
--- a/docs/source/src/python/user-guide/expressions/categoricals.py
+++ b/docs/source/src/python/user-guide/expressions/categoricals.py
@@ -61,18 +61,12 @@ print(bears_cat == bears_str)
 # --8<-- [end:categorical-comparison-string-column]
 
 # --8<-- [start:categorical-comparison-categorical-column]
-from polars.exceptions import StringCacheMismatchError
-
 bears_cat2 = pl.Series(
     ["Panda", "Brown", "Brown", "Polar", "Polar"],
     dtype=pl.Categorical,
 )
 
-try:
-    print(bears_cat == bears_cat2)
-except StringCacheMismatchError as exc:
-    exc_str = str(exc).splitlines()[0]
-    print("StringCacheMismatchError:", exc_str)
+print(bears_cat == bears_cat2)
 # --8<-- [end:categorical-comparison-categorical-column]
 
 # --8<-- [start:stringcache-categorical-equality]

--- a/docs/source/user-guide/expressions/categorical-data-and-enums.md
+++ b/docs/source/user-guide/expressions/categorical-data-and-enums.md
@@ -116,7 +116,7 @@ efficient to compare two categorical columns. We will see how to do that next.
 
 You are told that comparing columns with the data type `Categorical` is more efficient than if one
 of them is a string column. So, you change your code so that the second column is also a categorical
-column and then you perform your comparison... But Polars raises an exception:
+column and then you perform your comparison:
 
 {{code_block('user-guide/expressions/categoricals', 'categorical-comparison-categorical-column',
 ['Categorical'])}}
@@ -125,12 +125,10 @@ column and then you perform your comparison... But Polars raises an exception:
 --8<-- "python/user-guide/expressions/categoricals.py:categorical-comparison-categorical-column"
 ```
 
-By default, the values in columns with the data type `Categorical` are
-[encoded in the order they are seen in the column](#encodings), and independently from other
-columns, which means that Polars cannot compare efficiently two categorical columns that were
-created independently.
+The comparison returns a Boolean series. Polars compares categorical columns by their string values,
+even when the categories were created independently.
 
-Enabling the Polars string cache and creating the columns with the cache enabled fixes this issue:
+You can also enable the Polars string cache before creating the columns:
 
 {{code_block('user-guide/expressions/categoricals', 'stringcache-categorical-equality',
 ['StringCache', 'Categorical'])}}

--- a/py-polars/src/polars/expr/list.py
+++ b/py-polars/src/polars/expr/list.py
@@ -33,6 +33,30 @@ class ExprListNameSpace:
         self._pyexpr = expr._pyexpr
 
     def __getitem__(self, item: int) -> Expr:
+        """
+        Get the list element at the given index.
+
+        This is shorthand for :meth:`get`.
+
+        Parameters
+        ----------
+        item
+            Index of the list element to return.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"values": [[1, 2, 3], [4, 5, 6]]})
+        >>> df.with_columns(third=pl.col("values").list[2])
+        shape: (2, 2)
+        ┌───────────┬───────┐
+        │ values    ┆ third │
+        │ ---       ┆ ---   │
+        │ list[i64] ┆ i64   │
+        ╞═══════════╪═══════╡
+        │ [1, 2, 3] ┆ 3     │
+        │ [4, 5, 6] ┆ 6     │
+        └───────────┴───────┘
+        """
         return self.get(item)
 
     def all(self, *, ignore_nulls: bool = True) -> Expr:

--- a/py-polars/src/polars/io/plugins.py
+++ b/py-polars/src/polars/io/plugins.py
@@ -45,10 +45,13 @@ def register_io_source(
                 project these columns if applied
             predicate
                 Polars expression. The reader must filter
-                their rows accordingly.
+                their rows accordingly. The expression is written against the
+                source schema before projection pushdown is applied, so the reader
+                must keep any columns needed by the predicate until after filtering.
             n_rows
                 Materialize only n rows from the source.
-                The reader can stop when `n_rows` are read.
+                The reader can stop when `n_rows` rows have been produced after
+                filtering.
             batch_size
                 A hint of the ideal batch size the reader's
                 generator must produce.

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -6296,6 +6296,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                  - One-to-many. Checks if join keys are unique in left dataset.
                * - **m:1**
                  - Many-to-one. Check if join keys are unique in right dataset.
+
+            Validation can make the join more memory intensive because it disables
+            streaming for that join.
         nulls_equal
             Join on null values. By default null values will never produce matches.
         coalesce

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -1040,6 +1040,26 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 1.0 ┆ 1.0 ┆ 2.0 │
         │ 2.0 ┆ 2.5 ┆ 3.0 │
         └─────┴─────┴─────┘
+
+        Use :func:`functools.partial` to pass extra arguments to the function.
+
+        >>> from functools import partial
+        >>> def cast_matching_columns(
+        ...     lf: pl.LazyFrame, schema: pl.Schema, dtype: pl.DataType
+        ... ) -> pl.LazyFrame:
+        ...     columns = [name for name, dt in schema.items() if dt == dtype]
+        ...     return lf.with_columns(pl.col(columns).cast(pl.String))
+        >>> cast_float32 = partial(cast_matching_columns, dtype=pl.Float32)
+        >>> lf.pipe_with_schema(cast_float32).collect()
+        shape: (2, 3)
+        ┌─────┬─────┬─────┐
+        │ a   ┆ b   ┆ c   │
+        │ --- ┆ --- ┆ --- │
+        │ f64 ┆ str ┆ str │
+        ╞═════╪═════╪═════╡
+        │ 1.0 ┆ 1.0 ┆ 2.0 │
+        │ 2.0 ┆ 2.5 ┆ 3.0 │
+        └─────┴─────┴─────┘
         """
 
         def wrapper(lf_and_schema: Any) -> PyLazyFrame:


### PR DESCRIPTION
Fixes #27571.
Fixes #26875.
Fixes #25741.
Fixes #25947.
Fixes #26678.

This updates several Python documentation examples and API notes:

- documents `Expr.list.__getitem__` with an example
- shows how to pass extra arguments to `LazyFrame.pipe_with_schema` with `functools.partial`
- clarifies IO plugin predicate/projection/row-limit ordering expectations
- updates the categorical comparison example now that independently created categoricals compare directly
- clarifies that `LazyFrame.join(validate=...)` can disable streaming and increase memory use

Validation:
- `uvx ruff check py-polars/src/polars/expr/list.py py-polars/src/polars/lazyframe/frame.py py-polars/src/polars/io/plugins.py docs/source/src/python/user-guide/expressions/categoricals.py`
- `uvx ruff format --check py-polars/src/polars/expr/list.py py-polars/src/polars/lazyframe/frame.py py-polars/src/polars/io/plugins.py docs/source/src/python/user-guide/expressions/categoricals.py`
- `git diff --check`
- `uvx ruff check py-polars/src/polars/lazyframe/frame.py`
- `uvx ruff format --check py-polars/src/polars/lazyframe/frame.py`

Note: I could not run the Python smoke examples directly because this checkout does not have a built local `polars` Python extension installed.