### PR TITLE
docs: clarify API edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ less memory.
 
 ## Legacy
 
-Do you want Polars to run on an old CPU (e.g. dating from before 2011), or on an `x86-64` build of
-Python on Apple Silicon under Rosetta? Install `pip install polars[rtcompat]`. This version of
-Polars is compiled without [AVX](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions) target
-features.
+Do you want Polars to run on a CPU without AVX2 support, or on an `x86-64` build of Python on Apple
+Silicon under Rosetta? Install `pip install polars[rtcompat]`. This version of Polars is compiled
+without [AVX2](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions) target features.

--- a/docs/source/src/python/user-guide/io/cloud-storage.py
+++ b/docs/source/src/python/user-guide/io/cloud-storage.py
@@ -43,6 +43,20 @@ storage_options = {
 df = pl.scan_parquet(source, storage_options=storage_options).collect()
 # --8<-- [end:scan_parquet_storage_options_aws]
 
+# --8<-- [start:scan_parquet_storage_options_s3_compatible]
+import polars as pl
+
+source = "s3://bucket/*.parquet"
+
+storage_options = {
+    "aws_access_key_id": "<secret>",
+    "aws_secret_access_key": "<secret>",
+    "aws_region": "fr-par",
+    "aws_endpoint_url": "https://s3.fr-par.scw.cloud",
+}
+df = pl.scan_parquet(source, storage_options=storage_options).collect()
+# --8<-- [end:scan_parquet_storage_options_s3_compatible]
+
 # --8<-- [start:credential_provider_class]
 lf = pl.scan_parquet(
     "s3://.../...",

--- a/docs/source/user-guide/expressions/expression-expansion.md
+++ b/docs/source/user-guide/expressions/expression-expansion.md
@@ -50,6 +50,13 @@ expanded to a list of five expressions:
 --8<-- "python/user-guide/expressions/expression-expansion.py:expression-list"
 ```
 
+The expansion happens at the point where the expression is used by a context such as `select`,
+`with_columns`, or `group_by(...).agg(...)`. If you pass an expanding expression as an argument to
+another expression function, the context expands the resulting expression rather than calling the
+Python function once per selected column. For example, `pl.concat_list(pl.col("a", "b"))` creates a
+single list expression from the expanded inputs, while `pl.col("a", "b").round(2)` expands to one
+rounded expression per selected column.
+
 ### Expansion by data type
 
 We had to type five column names in the previous example but the function `col` can also

--- a/docs/source/user-guide/installation.md
+++ b/docs/source/user-guide/installation.md
@@ -8,7 +8,7 @@ corresponding programming language.
     ``` bash
     pip install polars
 
-    # Or for legacy CPUs without AVX2 support
+    # Or for CPUs that do not support AVX2
     pip install polars[rtcompat]
     ```
 
@@ -45,8 +45,8 @@ $2^{64}$ (~18 quintillion) by enabling the big index extension:
 
 ## Legacy CPU
 
-To install Polars for Python on an old CPU without
-[AVX](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions) support, run:
+To install Polars for Python on a CPU without
+[AVX2](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions) support, run:
 
 === ":fontawesome-brands-python: Python"
 
@@ -216,6 +216,7 @@ The opt-in features are:
       - zlib
       - zstd
 - Dataframe operations:
+    - `pivot` - Pivot and unpivot dataframes.
     - `dynamic_group_by` - Group by based on a time window instead of predefined keys.
     Also activates rolling window group by operations.
     - `sort_multiple` - Allow sorting a dataframe on multiple columns.

--- a/docs/source/user-guide/io/cloud-storage.md
+++ b/docs/source/user-guide/io/cloud-storage.md
@@ -1,7 +1,8 @@
 # Cloud storage
 
-Polars can read and write to AWS S3, Azure Blob Storage and Google Cloud Storage. The API is the
-same for all three storage providers.
+Polars can read and write to AWS S3, Azure Blob Storage and Google Cloud Storage. S3-compatible
+providers can also be used by configuring the S3 endpoint in `storage_options`. The API is the same
+for these storage providers.
 
 To read from cloud storage, additional dependencies may be needed depending on the use case and
 cloud storage provider:
@@ -44,6 +45,12 @@ use for authentication. This can be done in a few ways:
 - Credentials can be passed as configuration keys in a dict with the `storage_options` parameter:
 
 {{code_block('user-guide/io/cloud-storage','scan_parquet_storage_options_aws',['scan_parquet'])}}
+
+- For S3-compatible providers, set the provider endpoint. For example, to use Scaleway object
+  storage:
+
+{{code_block('user-guide/io/cloud-storage','scan_parquet_storage_options_s3_compatible',
+['scan_parquet'])}}
 
 ### Using one of the available `CredentialProvider*` utility classes
 

--- a/docs/source/user-guide/plugins/io_plugins.md
+++ b/docs/source/user-guide/plugins/io_plugins.md
@@ -73,7 +73,9 @@ The arguments of this function are predefined and this function must accept:
 
 - `predicate`
 
-  Polars expression. The reader must filter their rows accordingly.
+  Polars expression. The reader must filter their rows accordingly. If the reader can push down
+  only part of the predicate into the source system, it must still apply the original Polars
+  predicate before yielding the batch.
 
 - `n_rows`
 
@@ -125,22 +127,40 @@ def my_scan_csv(csv_str: str) -> pl.LazyFrame:
                 rows.append(row)
 
             df = pl.from_records(rows, schema=schema, orient="row")
-            n_rows -= df.height
+
+            # If the source supports predicate pushdown, the expression can be parsed
+            # to skip rows/groups. You can use `predicate.meta` to inspect the
+            # expression tree and map supported cases to source-native filters.
+            #
+            # This slow example applies the predicate in Polars before projection so
+            # that filters on non-projected columns still work.
+            if predicate is not None:
+                df = df.filter(predicate)
 
             # If we would make a performant reader, we would not read these
             # columns at all.
             if with_columns is not None:
                 df = df.select(with_columns)
 
-            # If the source supports predicate pushdown, the expression can be parsed
-            # to skip rows/groups.
-            if predicate is not None:
-                df = df.filter(predicate)
-
+            if n_rows is not None:
+                n_rows -= df.height
             yield df
 
     return register_io_source(io_source=source_generator, schema=schema)
 ```
+
+### Predicate introspection
+
+The `predicate` argument is a regular Polars expression. IO plugins can inspect it with the
+`Expr.meta` namespace and translate the parts they understand to the underlying source. For example,
+`predicate.meta.root_names()` shows which columns are referenced. More advanced plugins can use
+`predicate.meta.serialize(format="json")` for debugging or best-effort translation, but the
+serialized expression format is not a stable public API.
+
+When a plugin cannot translate the predicate completely, it should still evaluate the original
+Polars expression with `df.filter(predicate)` before yielding rows. This preserves correctness while
+letting the plugin opportunistically skip row groups, partitions, or remote records for the
+predicate fragments it does understand.
 
 ### Taking it for a (very slow) spin
 

--- a/docs/source/user-guide/transformations/unpivot.md
+++ b/docs/source/user-guide/transformations/unpivot.md
@@ -19,3 +19,11 @@ Unpivot unpivots a DataFrame from wide format to long format
 ```python exec="on" result="text" session="user-guide/transformations/unpivot"
 --8<-- "python/user-guide/transformations/unpivot.py:unpivot"
 ```
+
+## Rust feature flag
+
+Rust users must enable the `pivot` feature to use `unpivot`:
+
+```shell
+cargo add polars -F lazy,pivot
+```

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -8877,6 +8877,8 @@ class DataFrame:
         *columns
             Names of the columns that should be removed from the dataframe.
             Accepts column selector input.
+            The string `"*"` is parsed as a wildcard selector. To drop a column
+            literally named `"*"`, use `polars.selectors.by_name("*")`.
         strict
             Validate that all column names exist in the current schema,
             and throw an exception if any do not.
@@ -8945,6 +8947,21 @@ class DataFrame:
         │ 6.0 │
         │ 7.0 │
         │ 8.0 │
+        └─────┘
+
+        Drop a column literally named ``"*"`` by using a selector.
+
+        >>> import polars.selectors as cs
+        >>> df = pl.DataFrame({"*": [1, 2], "foo": [3, 4]})
+        >>> df.drop(cs.by_name("*"))
+        shape: (2, 1)
+        ┌─────┐
+        │ foo │
+        │ --- │
+        │ i64 │
+        ╞═════╡
+        │ 3   │
+        │ 4   │
         └─────┘
         """
         from polars.lazyframe.opt_flags import QueryOptFlags

--- a/py-polars/src/polars/datatypes/classes.py
+++ b/py-polars/src/polars/datatypes/classes.py
@@ -778,6 +778,9 @@ class Categories:
         """
         Creates a new `Categories` with a random name.
 
+        Use this when categorical columns should not share category mappings with
+        other categorical columns.
+
         Parameters
         ----------
         namespace
@@ -786,6 +789,13 @@ class Categories:
         physical : {UInt8, UInt16, UInt32}
             The physical type used to represent the categories. Defaults
             to :py:class:`UInt32`.
+
+        Examples
+        --------
+        >>> categories = pl.Categories.random()
+        >>> dtype = pl.Categorical(categories)
+        >>> dtype.categories is categories
+        True
         """
         if physical == pldt.UInt32:
             internal_phys = "u32"

--- a/py-polars/src/polars/expr/list.py
+++ b/py-polars/src/polars/expr/list.py
@@ -1274,6 +1274,9 @@ class ExprListNameSpace:
         """
         Run any polars expression against the lists' elements.
 
+        Unlike :meth:`list.agg`, this method preserves list output for each row
+        even when the expression returns a scalar.
+
         Parameters
         ----------
         expr
@@ -1304,7 +1307,8 @@ class ExprListNameSpace:
 
         See Also
         --------
-        polars.Expr.list.agg: Evaluate any expression and automatically explode.
+        polars.Expr.list.agg: Evaluate expressions with aggregation-like
+            scalar inference.
         polars.Expr.arr.eval: Same for the Array datatype.
         """
         return wrap_expr(self._pyexpr.list_eval(expr._pyexpr, parallel))
@@ -1312,6 +1316,10 @@ class ExprListNameSpace:
     def agg(self, expr: Expr) -> Expr:
         """
         Run any polars aggregation expression against the lists' elements.
+
+        If Polars can determine statically that the expression returns a scalar,
+        this method returns one value per input row. Otherwise, it returns a list.
+        This mirrors the behaviour of expressions in a group-by aggregation.
 
         Parameters
         ----------
@@ -1346,7 +1354,7 @@ class ExprListNameSpace:
 
         See Also
         --------
-        polars.Expr.list.eval: Evaluates expressions without automatically exploding.
+        polars.Expr.list.eval: Evaluate expressions while preserving list output.
         polars.Expr.arr.agg: Same for the Array datatype.
         """
         return wrap_expr(self._pyexpr.list_agg(expr._pyexpr))

--- a/py-polars/src/polars/functions/whenthen.py
+++ b/py-polars/src/polars/functions/whenthen.py
@@ -48,7 +48,9 @@ def when(
     --------
     Polars computes all expressions passed to `when-then-otherwise` in parallel and
     filters afterwards. This means each expression must be valid on its own, regardless
-    of the conditions in the `when-then-otherwise` chain.
+    of the conditions in the `when-then-otherwise` chain. Expressions are not
+    short-circuited, so every `then`, `otherwise`, and predicate expression must be
+    independently valid for all input rows.
 
     Notes
     -----
@@ -101,6 +103,26 @@ def when(
     │ 3   ┆ 4   ┆ true  ┆ 1    ┆ 5         ┆ 1   │
     │ 4   ┆ 0   ┆ true  ┆ 1    ┆ 1         ┆ 1   │
     └─────┴─────┴───────┴──────┴───────────┴─────┘
+
+    Because all expressions are evaluated independently, guards do not prevent
+    invalid computations in later branches. For example, the aggregation below is
+    evaluated before the `when` condition is applied.
+
+    >>> df = pl.DataFrame({"groups": ["a", "a", "b"], "vals": [1, 2, 3]})
+    >>> df.group_by("groups", maintain_order=True).agg(
+    ...     pl.when(pl.len() > 1)
+    ...     .then(pl.col("vals").first())
+    ...     .otherwise(pl.col("vals").sum())
+    ... )
+    shape: (2, 2)
+    ┌────────┬──────┐
+    │ groups ┆ vals │
+    │ ---    ┆ ---  │
+    │ str    ┆ i64  │
+    ╞════════╪══════╡
+    │ a      ┆ 1    │
+    │ b      ┆ 3    │
+    └────────┴──────┘
 
     Note that in regular Polars usage, a single string is parsed as a column name.
 

--- a/py-polars/src/polars/io/parquet/functions.py
+++ b/py-polars/src/polars/io/parquet/functions.py
@@ -146,7 +146,9 @@ def read_parquet(
     storage_options
         Options that indicate how to connect to a cloud provider.
 
-        The cloud providers currently supported are AWS, GCP, and Azure.
+        The cloud providers currently supported are AWS, GCP, and Azure. S3-compatible
+        providers can be used by setting an S3 endpoint, for example
+        `{"aws_endpoint_url": "https://s3.fr-par.scw.cloud"}`.
         See supported keys here:
 
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
@@ -411,7 +413,9 @@ def read_parquet_metadata(
     storage_options
         Options that indicate how to connect to a cloud provider.
 
-        The cloud providers currently supported are AWS, GCP, and Azure.
+        The cloud providers currently supported are AWS, GCP, and Azure. S3-compatible
+        providers can be used by setting an S3 endpoint, for example
+        `{"aws_endpoint_url": "https://s3.fr-par.scw.cloud"}`.
         See supported keys here:
 
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
@@ -581,7 +585,9 @@ def scan_parquet(
     storage_options
         Options that indicate how to connect to a cloud provider.
 
-        The cloud providers currently supported are AWS, GCP, and Azure.
+        The cloud providers currently supported are AWS, GCP, and Azure. S3-compatible
+        providers can be used by setting an S3 endpoint, for example
+        `{"aws_endpoint_url": "https://s3.fr-par.scw.cloud"}`.
         See supported keys here:
 
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_

--- a/py-polars/src/polars/io/plugins.py
+++ b/py-polars/src/polars/io/plugins.py
@@ -45,7 +45,11 @@ def register_io_source(
                 project these columns if applied
             predicate
                 Polars expression. The reader must filter
-                their rows accordingly.
+                their rows accordingly. Plugins can use the
+                :attr:`polars.Expr.meta` namespace to inspect the predicate and
+                push down supported fragments to the source system, but must still
+                apply the original predicate before yielding rows if the pushdown
+                is incomplete.
             n_rows
                 Materialize only n rows from the source.
                 The reader can stop when `n_rows` are read.

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -6915,6 +6915,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         *columns
             Names of the columns that should be removed from the dataframe.
             Accepts column selector input.
+            The string `"*"` is parsed as a wildcard selector. To drop a column
+            literally named `"*"`, use `polars.selectors.by_name("*")`.
         strict
             Validate that all column names exist in the current schema,
             and throw an exception if any do not.
@@ -6969,6 +6971,21 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 6.0 │
         │ 7.0 │
         │ 8.0 │
+        └─────┘
+
+        Drop a column literally named ``"*"`` by using a selector.
+
+        >>> import polars.selectors as cs
+        >>> lf = pl.LazyFrame({"*": [1, 2], "foo": [3, 4]})
+        >>> lf.drop(cs.by_name("*")).collect()
+        shape: (2, 1)
+        ┌─────┐
+        │ foo │
+        │ --- │
+        │ i64 │
+        ╞═════╡
+        │ 3   │
+        │ 4   │
         └─────┘
         """
         selectors: list[ColumnNameOrSelector] = []

--- a/py-polars/src/polars/series/list.py
+++ b/py-polars/src/polars/series/list.py
@@ -516,6 +516,11 @@ class ListNameSpace:
         """
 
     def __getitem__(self, item: int) -> Series:
+        """
+        Retrieve an element from each list by index.
+
+        This is shorthand for :meth:`get`.
+        """
         return self.get(item)
 
     def join(self, separator: IntoExprColumn, *, ignore_nulls: bool = True) -> Series:
@@ -989,6 +994,9 @@ class ListNameSpace:
         """
         Run any polars expression against the lists' elements.
 
+        Unlike :meth:`list.agg`, this method preserves list output for each row
+        even when the expression returns a scalar.
+
         Parameters
         ----------
         expr
@@ -1017,7 +1025,11 @@ class ListNameSpace:
     def agg(self, expr: Expr) -> Series:
         """
 
-        Run any polars aggregation expression against the list' elements.
+        Run any polars aggregation expression against the lists' elements.
+
+        If Polars can determine statically that the expression returns a scalar,
+        this method returns one value per input row. Otherwise, it returns a list.
+        This mirrors the behaviour of expressions in a group-by aggregation.
 
         Parameters
         ----------

--- a/py-polars/src/polars/series/struct.py
+++ b/py-polars/src/polars/series/struct.py
@@ -34,6 +34,11 @@ class StructNameSpace:
         self._s: PySeries = series._s
 
     def __getitem__(self, item: int | str) -> Series:
+        """
+        Return a struct field by name or by index.
+
+        This is shorthand for :meth:`field` when indexing by field name.
+        """
         if isinstance(item, int):
             return self.field(self.fields[item])
         elif isinstance(item, str):


### PR DESCRIPTION
## Summary
- clarify IO plugin predicate introspection/pushdown responsibilities
- document unpivot Rust feature flag, legacy CPU wording, S3-compatible endpoints, wildcard drop behavior, and expression expansion intuition
- improve API docs for when/then evaluation, list eval/agg semantics, dunder accessors, and Categories.random

Fixes #26814
Fixes #25611
Fixes #25457
Fixes #25336
Fixes #25325
Fixes #25317
Fixes #25116
Fixes #25102
Fixes #25086
Fixes #25050

## Testing
- git diff --check
- py-polars/.venv/bin/ruff check py-polars/src/polars/functions/whenthen.py py-polars/src/polars/datatypes/classes.py py-polars/src/polars/expr/list.py py-polars/src/polars/series/list.py py-polars/src/polars/series/struct.py py-polars/src/polars/io/plugins.py py-polars/src/polars/io/parquet/functions.py py-polars/src/polars/dataframe/frame.py py-polars/src/polars/lazyframe/frame.py
- py-polars/.venv/bin/ruff format --check py-polars/src/polars/functions/whenthen.py py-polars/src/polars/datatypes/classes.py py-polars/src/polars/expr/list.py py-polars/src/polars/series/list.py py-polars/src/polars/series/struct.py py-polars/src/polars/io/plugins.py py-polars/src/polars/io/parquet/functions.py py-polars/src/polars/dataframe/frame.py py-polars/src/polars/lazyframe/frame.py

Note: `uv run --project py-polars ruff check ...` failed during dependency resolution before linting because the local project shadows the `polars` dependency required by the optional `polars[gpu]` extra; after that, I ran the created local ruff binary directly.