### PR TITLE
docs: add missing API behavior notes

### DIFF
--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -118,8 +118,8 @@ pub type ChunkLenIter<'a> = std::iter::Map<std::slice::Iter<'a, ArrayRef>, fn(&A
 /// Appends are cheap, because it will not lead to a full reallocation of the whole array (as could be the case with a Rust Vec).
 ///
 /// However, multiple chunks in a [`ChunkedArray`] will slow down many operations that need random access because we have an extra indirection
-/// and indexes need to be mapped to the proper chunk. Arithmetic may also be slowed down by this.
-/// When multiplying two [`ChunkedArray`]s with different chunk sizes they cannot utilize [SIMD](https://en.wikipedia.org/wiki/SIMD) for instance.
+/// and indexes need to be mapped to the proper chunk. Many operations align or rechunk inputs before doing their work, which can add allocation
+/// and copying overhead. Arithmetic on aligned chunks can still use optimized kernels such as [SIMD](https://en.wikipedia.org/wiki/SIMD).
 ///
 /// If you want to have predictable performance
 /// (no unexpected re-allocation of memory), it is advised to call the [`ChunkedArray::rechunk`] after

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -316,6 +316,24 @@ pub trait StringNameSpaceImpl: AsString {
     }
 
     /// Check if strings contain a regex pattern.
+    ///
+    /// ```
+    /// # use polars_core::prelude::*;
+    /// # use polars_ops::chunked_array::strings::StringNameSpaceImpl;
+    /// let df = df!(
+    ///     "values" => &["foo", "bar", "foobar", "baz"],
+    /// )?;
+    ///
+    /// let mask = df
+    ///     .column("values")?
+    ///     .str()?
+    ///     .contains("foo", true)?;
+    ///
+    /// let filtered = df.filter(&mask)?;
+    /// assert_eq!(filtered.column("values")?.str()?.get(0), Some("foo"));
+    /// assert_eq!(filtered.column("values")?.str()?.get(1), Some("foobar"));
+    /// # PolarsResult::Ok(())
+    /// ```
     fn contains(&self, pat: &str, strict: bool) -> PolarsResult<BooleanChunked> {
         let ca = self.as_string();
         let res_reg = polars_utils::regex_cache::compile_regex(pat);

--- a/docs/source/src/python/user-guide/expressions/expression-expansion.py
+++ b/docs/source/src/python/user-guide/expressions/expression-expansion.py
@@ -164,6 +164,11 @@ result = df.select((cs.contains("_") - cs.string()) / eur_usd_rate)
 print(result)
 # --8<-- [end:selectors-expressions]
 
+# --8<-- [start:selectors-filter]
+result = df.filter(pl.any_horizontal(cs.ends_with("_high") > 200))
+print(result)
+# --8<-- [end:selectors-filter]
+
 # --8<-- [start:selector-ambiguity]
 people = pl.DataFrame(
     {

--- a/docs/source/user-guide/expressions/expression-expansion.md
+++ b/docs/source/user-guide/expressions/expression-expansion.md
@@ -319,6 +319,19 @@ The correct solution uses `as_expr`:
 --8<-- "python/user-guide/expressions/expression-expansion.py:as_expr"
 ```
 
+### Selectors in filters
+
+Selectors can also be used in filter predicates. Because a selector may expand to multiple boolean
+expressions, combine the expanded predicates explicitly with a horizontal function such as
+`any_horizontal` or `all_horizontal`:
+
+{{code_block('user-guide/expressions/expression-expansion', 'selectors-filter', [],
+['selectors'], [])}}
+
+```python exec="on" result="text" session="expressions/expression-expansion"
+--8<-- "python/user-guide/expressions/expression-expansion.py:selectors-filter"
+```
+
 ### Debugging selectors
 
 When you are not sure whether you have a Polars selector at hand or not, you can use the function

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -12536,6 +12536,7 @@ class DataFrame:
         It is the callers responsibility that the frames
         are sorted in ascending order by that key otherwise
         the output will not make sense.
+        Null values must be sorted first.
 
         The schemas of both DataFrames must be equal.
 
@@ -12603,6 +12604,7 @@ class DataFrame:
         row order when the key is equal between the both dataframes.
 
         The key must be sorted in ascending order.
+        Null values must be sorted first.
         """
         from polars.lazyframe.opt_flags import QueryOptFlags
 

--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -3542,6 +3542,12 @@ class Expr:
         ╞═════╡
         │  0  │
         └─────┘
+
+        Empty and all-null inputs return `0` rather than `None`.
+
+        >>> df = pl.DataFrame({"a": [None, None]})
+        >>> df.select(pl.col("a").sum()).item()
+        0
         """
         return wrap_expr(self._pyexpr.sum())
 

--- a/py-polars/src/polars/functions/eager.py
+++ b/py-polars/src/polars/functions/eager.py
@@ -617,6 +617,7 @@ def merge_sorted(
     It is the callers responsibility that the frames
     are sorted in ascending order by that key otherwise
     the output will not make sense.
+    Null values must be sorted first.
 
     .. warning::
         This functionality is considered **unstable**. It may be changed

--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -210,7 +210,9 @@ def read_csv(
         This is not always possible. The set of arguments given to
         this function determines if it is possible to use pyarrow's
         native parser. Note that pyarrow and polars may have a
-        different strategy regarding type inference.
+        different strategy regarding type inference. Some Polars
+        parser options, such as `schema`, may not be respected by
+        pyarrow's parser.
     storage_options
         Extra options that make sense for `fsspec.open()` or a
         particular storage connection.

--- a/py-polars/src/polars/io/partition.py
+++ b/py-polars/src/polars/io/partition.py
@@ -41,7 +41,9 @@ class PartitionBy:
     base_path
         Base path to write to.
     file_path_provider
-        Callable for custom file output paths.
+        Callable for custom file output paths. The callable must return a
+        unique path for each pair of `partition_keys` and `index_in_partition`.
+        Otherwise, multiple output files may be written to the same location.
     key
         Expressions to partition by.
     include_key
@@ -142,10 +144,20 @@ class FileProviderArgs:
     .. warning::
         This functionality is currently considered **unstable**. It may be
         changed at any point without it being considered a breaking change.
+
+    Notes
+    -----
+    A custom `file_path_provider` must return a unique path for every
+    combination of `partition_keys` and `index_in_partition`. Polars may write
+    multiple files for a single partition, even when `max_rows_per_file` and
+    `approximate_bytes_per_file` are not set, so paths based only on
+    `partition_keys` can overwrite earlier files.
     """
 
     index_in_partition: int
+    """Zero-based index of the file within this partition."""
     partition_keys: DataFrame
+    """The partition key values for this file."""
 
 
 @dataclass(kw_only=True)

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -8982,6 +8982,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         It is the callers responsibility that the frames
         are sorted in ascending order by that key otherwise
         the output will not make sense.
+        Null values must be sorted first.
 
         The schemas of both LazyFrames must be equal.
 
@@ -9049,6 +9050,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         row order when the key is equal between the both dataframes.
 
         The key must be sorted in ascending order.
+        Null values must be sorted first.
         """
         require_same_type(self, other)
         return self._from_pyldf(self._ldf.merge_sorted(other._ldf, key, maintain_order))


### PR DESCRIPTION
## Summary
- document custom `PartitionBy` path uniqueness requirements
- add selector filtering docs and a Rust `str.contains` filtering example
- clarify all-null `Expr.sum`, `merge_sorted` null ordering, CSV `use_pyarrow`, and chunk alignment/rechunking behavior

Fixes #26885
Fixes #20360
Fixes #20581
Fixes #19953
Fixes #20991
Fixes #19886
Fixes #20190

## Testing
- git diff --check
- py-polars/.venv/bin/ruff check py-polars/src/polars/io/partition.py py-polars/src/polars/io/csv/functions.py py-polars/src/polars/expr/expr.py py-polars/src/polars/dataframe/frame.py py-polars/src/polars/lazyframe/frame.py py-polars/src/polars/functions/eager.py docs/source/src/python/user-guide/expressions/expression-expansion.py
- py-polars/.venv/bin/ruff format --check py-polars/src/polars/io/partition.py py-polars/src/polars/io/csv/functions.py py-polars/src/polars/expr/expr.py py-polars/src/polars/dataframe/frame.py py-polars/src/polars/lazyframe/frame.py py-polars/src/polars/functions/eager.py docs/source/src/python/user-guide/expressions/expression-expansion.py
- cargo fmt --check --package polars-core --package polars-ops