### PR TITLE
chore: Fix tz type difference pandas assert

### DIFF
--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -101,6 +101,9 @@ def test_ipc_roundtrip_nostream_parametric(
     )
 )
 @pytest.mark.slow
+@pytest.mark.xfail(
+    reason="until https://github.com/apache/arrow/pull/49694 is merged and released"
+)
 def test_ipc_roundtrip_pandas_parametric(
     df: pl.DataFrame, compression: IpcCompression
 ) -> None:


### PR DESCRIPTION
Until https://github.com/apache/arrow/pull/49694 gets merged there is a difference in pyarrow `to_pandas` and what pandas generates itself when reading from feather. I don't see a reason to add a workaround in Polars, so let's disable this test until upstream is consistent again.