### PR TITLE
fix(python): Preserve numeric format for `write_excel` count totals on temporal columns

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -3756,7 +3756,12 @@ class DataFrame:
         column_formats = column_formats or {}
         table_style, table_options = _xl_setup_table_options(table_style)
         table_name = table_name or _xl_unique_table_name(wb)
-        table_columns, column_formats, df = _xl_setup_table_columns(  # type: ignore[assignment]
+        (
+            table_columns,
+            column_formats,
+            count_total_overrides,
+            df,
+        ) = _xl_setup_table_columns(  # type: ignore[assignment]
             df=df,
             format_cache=fmt_cache,
             column_formats=column_formats,
@@ -3810,6 +3815,25 @@ class DataFrame:
                     **table_options,
                 },
             )
+
+            # overwrite totals-row cells for `count`/`count_nums` on temporal
+            # columns so the integer count is not rendered with the column's
+            # date/time format. See issue #27283 and `_xl_setup_table_columns`.
+            if count_total_overrides and bool(column_totals) and not is_empty:
+                _subtotal_codes = {"count": 103, "count_nums": 102}
+                totals_row = table_finish[0]
+                for col, (fn, fmt_obj) in count_total_overrides.items():
+                    col_idx = df.columns.index(col)
+                    escaped = (
+                        col.replace("'", "''")
+                        .replace("#", "'#")
+                        .replace("]", "']")
+                        .replace("[", "'[")
+                    )
+                    formula = f"=SUBTOTAL({_subtotal_codes[fn]},[{escaped}])"
+                    ws.write_formula(
+                        totals_row, table_start[1] + col_idx, formula, fmt_obj, 0
+                    )
 
             # apply conditional formats
             if conditional_formats:

--- a/py-polars/src/polars/io/spreadsheet/_write_utils.py
+++ b/py-polars/src/polars/io/spreadsheet/_write_utils.py
@@ -525,8 +525,8 @@ def _xl_setup_table_columns(
     count_total_overrides: dict[str, tuple[str, Format]] = {}
     for col, fn in column_total_funcs.items():
         if fn in _count_total_funcs:
-            tp = df.schema.get(col)
-            if tp is not None and tp.is_temporal():
+            col_tp = df.schema.get(col)
+            if col_tp is not None and col_tp.is_temporal():
                 fmt_obj = format_cache.get(
                     {"num_format": int_base_fmt, "valign": "vcenter"}
                 )

--- a/py-polars/src/polars/io/spreadsheet/_write_utils.py
+++ b/py-polars/src/polars/io/spreadsheet/_write_utils.py
@@ -346,7 +346,12 @@ def _xl_setup_table_columns(
     row_totals: RowTotalsDefinition | None = None,
     float_precision: int = 3,
     table_style: dict[str, Any] | str | None = None,
-) -> tuple[list[dict[str, Any]], dict[str | tuple[str, ...], str], DataFrame]:
+) -> tuple[
+    list[dict[str, Any]],
+    dict[str | tuple[str, ...], str],
+    dict[str, tuple[str, Format]],
+    DataFrame,
+]:
     """Setup and unify all column-related formatting/defaults."""
 
     # no excel support for compound types; cast to their simple string representation
@@ -510,6 +515,23 @@ def _xl_setup_table_columns(
     # optional custom header format
     col_header_format = format_cache.get(header_format) if header_format else None
 
+    # `count`/`count_nums` always produce an integer regardless of column dtype,
+    # so on a temporal column the totals row would otherwise inherit the column
+    # date/time number_format and render the count as a date. We compute the
+    # override format here and let the caller overwrite the totals cell after
+    # `ws.add_table()` (xlsxwriter does not honor a per-totals-cell format on
+    # the column dict). See issue #27283.
+    _count_total_funcs = {"count", "count_nums"}
+    count_total_overrides: dict[str, tuple[str, Format]] = {}
+    for col, fn in column_total_funcs.items():
+        if fn in _count_total_funcs:
+            tp = df.schema.get(col)
+            if tp is not None and tp.is_temporal():
+                fmt_obj = format_cache.get(
+                    {"num_format": int_base_fmt, "valign": "vcenter"}
+                )
+                count_total_overrides[col] = (fn, fmt_obj)
+
     # assemble table columns
     table_columns = [
         {
@@ -528,7 +550,7 @@ def _xl_setup_table_columns(
         }
         for col in df.columns
     ]
-    return table_columns, column_formats, df  # type: ignore[return-value]
+    return table_columns, column_formats, count_total_overrides, df  # type: ignore[return-value]
 
 
 def _xl_setup_table_options(

--- a/py-polars/tests/unit/io/test_spreadsheet.py
+++ b/py-polars/tests/unit/io/test_spreadsheet.py
@@ -858,6 +858,52 @@ def test_excel_round_trip(write_params: dict[str, Any]) -> None:
         assert_frame_equal(df, xldf)
 
 
+def test_excel_write_count_total_on_temporal_column() -> None:
+    # https://github.com/pola-rs/polars/issues/27283 — a `count`/`count_nums`
+    # total on a Date/Datetime/Time column was inheriting the column's temporal
+    # number_format, so the totals cell rendered as "1900-01-02" instead of "2".
+    from datetime import date, datetime, time
+
+    from openpyxl import load_workbook
+
+    df = pl.DataFrame(
+        {
+            "d": [date(2026, 4, 10), date(2026, 4, 11)],
+            "dt": [datetime(2026, 4, 10, 9, 0), datetime(2026, 4, 11, 9, 0)],
+            "t": [time(9, 0), time(10, 0)],
+            "name": ["a", "b"],
+            "amount": [10, 20],
+        }
+    )
+
+    xls = BytesIO()
+    df.write_excel(
+        xls,
+        worksheet="totals",
+        column_totals={
+            "d": "count",
+            "dt": "count",
+            "t": "count",
+            "name": "count",
+            "amount": "sum",
+        },
+    )
+
+    # Inspect the totals row directly: cells must not carry a temporal
+    # number_format that would render the integer count as a date/time.
+    xls.seek(0)
+    wb = load_workbook(xls)
+    ws = wb["totals"]
+    # 1 header row + 2 data rows + 1 totals row = row 4
+    totals_row = 4
+    for col_letter in ("A", "B", "C"):  # d, dt, t
+        cell = ws[f"{col_letter}{totals_row}"]
+        fmt = (cell.number_format or "").lower()
+        assert not any(tok in fmt for tok in ("yyyy", "mm", "dd", "hh", "ss")), (
+            f"{col_letter}{totals_row} count rendered with temporal format {cell.number_format!r}"
+        )
+
+
 @pytest.mark.parametrize("engine", ["calamine", "xlsx2csv"])
 def test_excel_write_column_and_row_totals(engine: ExcelSpreadsheetEngine) -> None:
     df = pl.DataFrame(


### PR DESCRIPTION
## What

`DataFrame.write_excel` with `column_totals={"d": "count"}` on a Date / Datetime / Time column now renders the totals cell as an integer instead of inheriting the column's temporal `number_format`.

## Why

Reported in #27283. The totals row for `count` / `count_nums` on a temporal column produced cells like `1900-01-02` instead of `2`, because xlsxwriter applies the column's `format` to the totals cell, and Polars sets that format to `yyyy-mm-dd` / `hh:mm:ss` for the data cells.

## How

xlsxwriter (3.2.9) does not honor a per-totals-cell format on the column dict — the `total_format` key is ignored by `add_table`, verified locally. Instead, after `ws.add_table(...)` we overwrite the totals-row cell for each affected column with the same `SUBTOTAL` formula and a numeric format. Data cells keep their original temporal format and only the totals row changes.

- `_xl_setup_table_columns` now also returns `count_total_overrides: dict[col, (function, Format)]`.
- `DataFrame.write_excel` consumes this dict right after `add_table` and re-writes the targeted totals cells.
- The fix is scoped to `count` and `count_nums`. Other aggregations (`sum`, `avg`, `max`, `min`) on temporal columns keep the column format because their result is itself temporal.

## Test

`test_excel_write_count_total_on_temporal_column` opens the produced xlsx with openpyxl and asserts the totals-row cells for Date / Datetime / Time columns do not carry a temporal `number_format`. Full `tests/unit/io/test_spreadsheet.py` sweep is green (106/106 locally).

Closes #27283.