### PR TITLE
refactor(rust): Add arg mapper to unoptimized dispatch

### DIFF
--- a/crates/polars-plan/src/plans/ir/dot.rs
+++ b/crates/polars-plan/src/plans/ir/dot.rs
@@ -341,8 +341,12 @@ impl<'a> IRDotDisplay<'a> {
                     )
                 })?;
             },
-            UnoptimizedDispatch { inputs, operation } => {
-                for input in inputs {
+            UnoptimizedDispatch {
+                inputs,
+                operation,
+                arg_map,
+            } => {
+                for input in arg_map.iter_arg_inputs().map(|(i, _c)| &inputs[i]) {
                     recurse!(*input);
                 }
                 write_label(f, id, |f| write!(f, "DISPATCH {operation}"))?;

--- a/crates/polars-plan/src/plans/ir/dot.rs
+++ b/crates/polars-plan/src/plans/ir/dot.rs
@@ -346,7 +346,7 @@ impl<'a> IRDotDisplay<'a> {
                 operation,
                 arg_map,
             } => {
-                for input in arg_map.iter_arg_inputs().map(|(i, _c)| &inputs[i]) {
+                for input in arg_map.iter().map(|(i, _c, _n)| &inputs[i]) {
                     recurse!(*input);
                 }
                 write_label(f, id, |f| write!(f, "DISPATCH {operation}"))?;

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -1007,6 +1007,7 @@ pub fn write_ir_non_recursive(
         ),
         IR::UnoptimizedDispatch {
             inputs: _,
+            arg_map: _,
             operation,
         } => write!(f, "{:indent$}DISPATCH {operation}", ""),
         IR::Invalid => write!(f, "{:indent$}INVALID", ""),

--- a/crates/polars-plan/src/plans/ir/mod.rs
+++ b/crates/polars-plan/src/plans/ir/mod.rs
@@ -16,7 +16,7 @@ use polars_utils::unique_id::UniqueId;
 #[cfg(feature = "ir_serde")]
 use serde::{Deserialize, Serialize};
 use strum_macros::IntoStaticStr;
-pub use unoptimized::UnoptimizedOperation;
+pub use unoptimized::{FunctionArgMap, UnoptimizedOperation};
 
 use self::hive::HivePartitionsDf;
 use crate::prelude::*;
@@ -169,6 +169,7 @@ pub enum IR {
     },
     UnoptimizedDispatch {
         inputs: Vec<Node>,
+        arg_map: FunctionArgMap,
         operation: UnoptimizedOperation,
     },
     #[default]

--- a/crates/polars-plan/src/plans/ir/schema.rs
+++ b/crates/polars-plan/src/plans/ir/schema.rs
@@ -115,12 +115,16 @@ impl IR {
             ExtContext { schema, .. } => schema,
             #[cfg(feature = "merge_sorted")]
             MergeSorted { input_left, .. } => return arena.get(*input_left).schema(arena),
-            UnoptimizedDispatch { inputs, operation } => {
+            UnoptimizedDispatch {
+                inputs,
+                arg_map,
+                operation,
+            } => {
                 let input_schemas = inputs
                     .iter()
                     .map(|input| arena.get(*input).schema(arena).into_owned())
                     .collect_vec();
-                return Cow::Owned(operation.schema(&input_schemas));
+                return Cow::Owned(operation.schema(&input_schemas, arg_map));
             },
             Invalid => unreachable!(),
         };
@@ -183,12 +187,16 @@ impl IR {
             },
             #[cfg(feature = "merge_sorted")]
             MergeSorted { input_left, .. } => IR::schema_with_cache(*input_left, arena, cache),
-            UnoptimizedDispatch { inputs, operation } => {
+            UnoptimizedDispatch {
+                inputs,
+                arg_map,
+                operation,
+            } => {
                 let input_schemas = inputs
                     .iter()
                     .map(|input| IR::schema_with_cache(*input, arena, cache))
                     .collect_vec();
-                operation.schema(&input_schemas)
+                operation.schema(&input_schemas, arg_map)
             },
             Invalid => unreachable!(),
         };

--- a/crates/polars-plan/src/plans/ir/tree_format.rs
+++ b/crates/polars-plan/src/plans/ir/tree_format.rs
@@ -416,8 +416,8 @@ impl<'a> TreeFmtNode<'a> {
                 } => ND(
                     wh(h, &format!("DISPATCH {operation}")),
                     arg_map
-                        .iter_arg_inputs()
-                        .map(|(input_idx, _col_idx)| &inputs[input_idx])
+                        .iter()
+                        .map(|(input_idx, _col_idx, _arg_name)| &inputs[input_idx])
                         .map(|input| self.lp_node(None, *input))
                         .collect(),
                 ),

--- a/crates/polars-plan/src/plans/ir/tree_format.rs
+++ b/crates/polars-plan/src/plans/ir/tree_format.rs
@@ -409,10 +409,15 @@ impl<'a> TreeFmtNode<'a> {
                         .chain([self.lp_node(Some("RIGHT PLAN:".to_string()), *input_right)])
                         .collect(),
                 ),
-                UnoptimizedDispatch { inputs, operation } => ND(
+                UnoptimizedDispatch {
+                    inputs,
+                    operation,
+                    arg_map,
+                } => ND(
                     wh(h, &format!("DISPATCH {operation}")),
-                    inputs
-                        .iter()
+                    arg_map
+                        .iter_arg_inputs()
+                        .map(|(input_idx, _col_idx)| &inputs[input_idx])
                         .map(|input| self.lp_node(None, *input))
                         .collect(),
                 ),

--- a/crates/polars-plan/src/plans/ir/unoptimized.rs
+++ b/crates/polars-plan/src/plans/ir/unoptimized.rs
@@ -104,8 +104,7 @@ impl FunctionArgMap {
         self.map
             .iter()
             .map(|(input_idx, column_idx, arg_name)| {
-                let (input_name, dtype) =
-                    input_schemas[*input_idx].get_at_index(*column_idx).unwrap();
+                let (_, dtype) = input_schemas[*input_idx].get_at_index(*column_idx).unwrap();
                 Field::new(arg_name.clone(), dtype.clone())
             })
             .collect()

--- a/crates/polars-plan/src/plans/ir/unoptimized.rs
+++ b/crates/polars-plan/src/plans/ir/unoptimized.rs
@@ -20,16 +20,12 @@ pub enum UnoptimizedOperation {
     ColumnarFunction {
         function: IRFunctionExpr,
         options: FunctionOptions,
-        // Arg names for functions that use them. At the time of writing, it was
-        // AsStruct, FoldHorizontal, ReduceHorizontal, CumReduceHorizontal, CumFoldHorizontal
-        arg_names: Option<Vec<PlSmallStr>>,
         output_name: PlSmallStr,
     },
 
     AnonymousColumnsUdf {
         function: OpaqueColumnUdf,
         options: FunctionOptions,
-        arg_names: Vec<PlSmallStr>,
         output_name: PlSmallStr,
         fmt_str: Box<PlSmallStr>,
         ctx_schema: Arc<Schema>,
@@ -42,10 +38,9 @@ impl UnoptimizedOperation {
             UnoptimizedOperation::ColumnarFunction {
                 function,
                 options: _,
-                arg_names: input_names,
                 output_name,
             } => {
-                let input_fields = arg_map.arg_fields(inputs, input_names.as_deref());
+                let input_fields = arg_map.arg_fields(inputs);
                 let output_field = function.get_field(&input_fields).unwrap();
                 Arc::new(Schema::from_iter([
                     output_field.with_name(output_name.clone())
@@ -54,11 +49,10 @@ impl UnoptimizedOperation {
 
             UnoptimizedOperation::AnonymousColumnsUdf {
                 function,
-                arg_names: input_names,
                 ctx_schema,
                 ..
             } => {
-                let input_fields = arg_map.arg_fields(inputs, Some(input_names));
+                let input_fields = arg_map.arg_fields(inputs);
                 let output_field = function
                     .clone()
                     .materialize()
@@ -67,13 +61,6 @@ impl UnoptimizedOperation {
                     .unwrap();
                 Arc::new(Schema::from_iter([output_field]))
             },
-        }
-    }
-
-    pub fn arg_names(&self) -> Option<&[PlSmallStr]> {
-        match self {
-            Self::ColumnarFunction { arg_names, .. } => arg_names.as_deref(),
-            Self::AnonymousColumnsUdf { arg_names, .. } => Some(arg_names),
         }
     }
 }
@@ -103,32 +90,23 @@ pub type ColumnIdx = usize;
 #[cfg_attr(feature = "ir_serde", derive(Serialize, Deserialize))]
 pub struct FunctionArgMap {
     /// Mapping from function args to input columns
-    /// arg[i] = inputs[arg_map[i].0].column_by_idx(arg_map[i].1)
-    map: Vec<(InputIdx, ColumnIdx)>,
+    /// arg[i] = inputs[arg_map[i].0].column_by_idx(arg_map[i].1).alias(arg_map[i].2)
+    map: Vec<(InputIdx, ColumnIdx, PlSmallStr)>,
 }
 
 impl FunctionArgMap {
-    pub fn new(map: Vec<(InputIdx, ColumnIdx)>) -> Self {
+    pub fn new(map: Vec<(InputIdx, ColumnIdx, PlSmallStr)>) -> Self {
         Self { map }
     }
 
     /// Returns a collection of `Field`s representing the args. Renaming is applied.
-    pub fn arg_fields(
-        &self,
-        input_schemas: &[SchemaRef],
-        arg_names: Option<&[PlSmallStr]>,
-    ) -> Vec<Field> {
-        if let Some(arg_names) = arg_names {
-            assert_eq!(self.map.len(), arg_names.len());
-        }
+    pub fn arg_fields(&self, input_schemas: &[SchemaRef]) -> Vec<Field> {
         self.map
             .iter()
-            .enumerate()
-            .map(|(i, &(input_idx, column_idx))| {
+            .map(|(input_idx, column_idx, arg_name)| {
                 let (input_name, dtype) =
-                    input_schemas[input_idx].get_at_index(column_idx).unwrap();
-                let arg_name = arg_names.map(|a| &a[i]).unwrap_or(input_name).clone();
-                Field::new(arg_name, dtype.clone())
+                    input_schemas[*input_idx].get_at_index(*column_idx).unwrap();
+                Field::new(arg_name.clone(), dtype.clone())
             })
             .collect()
     }
@@ -137,34 +115,19 @@ impl FunctionArgMap {
     pub fn arg_selectors(
         &self,
         input_schemas: &[SchemaRef],
-        arg_names: Option<&[PlSmallStr]>,
         expr_arena: &mut Arena<AExpr>,
     ) -> Vec<ExprIR> {
-        self.iter_args_with_names(input_schemas, arg_names)
-            .map(|(_, col_name, arg_name)| {
+        self.map
+            .iter()
+            .map(|(input, col, arg_name)| {
+                let col_name = input_schemas[*input].get_at_index(*col).unwrap().0;
                 AExprBuilder::col(col_name.clone(), expr_arena).expr_ir(arg_name.clone())
             })
             .collect()
     }
 
-    /// Returns an iterator over `(input_idx, input_col_name, arg_name)` tuples.
-    pub fn iter_args_with_names<'a>(
-        &'a self,
-        input_schemas: &'a [SchemaRef],
-        arg_names: Option<&'a [PlSmallStr]>,
-    ) -> impl Iterator<Item = (InputIdx, &'a PlSmallStr, &'a PlSmallStr)> + 'a {
-        if let Some(arg_names) = arg_names {
-            assert_eq!(self.map.len(), arg_names.len());
-        }
-        self.map.iter().enumerate().map(move |(i, (input, col))| {
-            let col_name = input_schemas[*input].get_at_index(*col).unwrap().0;
-            let arg_name = arg_names.map(|r| &r[i]).unwrap_or(col_name);
-            (*input, col_name, arg_name)
-        })
-    }
-
-    /// Returns an iterator over `(input_idx, column_idx)` tuples.
-    pub fn iter_arg_inputs(&self) -> impl Iterator<Item = (InputIdx, ColumnIdx)> + '_ {
-        self.map.iter().copied()
+    /// Returns an iterator over `(input_idx, column_idx, arg_name)` tuples.
+    pub fn iter(&self) -> impl Iterator<Item = (InputIdx, ColumnIdx, &'_ PlSmallStr)> + '_ {
+        self.map.iter().map(|(c, i, name)| (*c, *i, name))
     }
 }

--- a/crates/polars-plan/src/plans/ir/unoptimized.rs
+++ b/crates/polars-plan/src/plans/ir/unoptimized.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 use std::sync::Arc;
 
-use polars_core::schema::{Schema, SchemaExt};
-use polars_utils::itertools::Itertools;
+use polars_core::datatypes::Field;
+use polars_core::schema::{Schema, SchemaRef};
 use polars_utils::pl_str::PlSmallStr;
 #[cfg(feature = "ir_serde")]
 use serde::{Deserialize, Serialize};
@@ -15,17 +15,21 @@ use crate::prelude::*;
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "ir_serde", derive(Serialize, Deserialize))]
 pub enum UnoptimizedOperation {
-    /// Calls the given IRFunctionExpr with the columns of the inputs in order.
+    /// Calls the given IRFunctionExpr with the columns selected from the inputs.
     /// The inputs do not have to be the same height.
     ColumnarFunction {
         function: IRFunctionExpr,
         options: FunctionOptions,
+        // Arg names for functions that use them. At the time of writing, it was
+        // AsStruct, FoldHorizontal, ReduceHorizontal, CumReduceHorizontal, CumFoldHorizontal
+        arg_names: Option<Vec<PlSmallStr>>,
         output_name: PlSmallStr,
     },
 
     AnonymousColumnsUdf {
         function: OpaqueColumnUdf,
         options: FunctionOptions,
+        arg_names: Vec<PlSmallStr>,
         output_name: PlSmallStr,
         fmt_str: Box<PlSmallStr>,
         ctx_schema: Arc<Schema>,
@@ -33,14 +37,15 @@ pub enum UnoptimizedOperation {
 }
 
 impl UnoptimizedOperation {
-    pub fn schema(&self, inputs: &[Arc<Schema>]) -> Arc<Schema> {
+    pub fn schema(&self, inputs: &[Arc<Schema>], arg_map: &FunctionArgMap) -> Arc<Schema> {
         match self {
             UnoptimizedOperation::ColumnarFunction {
                 function,
                 options: _,
+                arg_names: input_names,
                 output_name,
             } => {
-                let input_fields = inputs.iter().flat_map(|i| i.iter_fields()).collect_vec();
+                let input_fields = arg_map.arg_fields(inputs, input_names.as_deref());
                 let output_field = function.get_field(&input_fields).unwrap();
                 Arc::new(Schema::from_iter([
                     output_field.with_name(output_name.clone())
@@ -49,10 +54,11 @@ impl UnoptimizedOperation {
 
             UnoptimizedOperation::AnonymousColumnsUdf {
                 function,
+                arg_names: input_names,
                 ctx_schema,
                 ..
             } => {
-                let input_fields = inputs.iter().flat_map(|i| i.iter_fields()).collect_vec();
+                let input_fields = arg_map.arg_fields(inputs, Some(input_names));
                 let output_field = function
                     .clone()
                     .materialize()
@@ -61,6 +67,13 @@ impl UnoptimizedOperation {
                     .unwrap();
                 Arc::new(Schema::from_iter([output_field]))
             },
+        }
+    }
+
+    pub fn arg_names(&self) -> Option<&[PlSmallStr]> {
+        match self {
+            Self::ColumnarFunction { arg_names, .. } => arg_names.as_deref(),
+            Self::AnonymousColumnsUdf { arg_names, .. } => Some(arg_names),
         }
     }
 }
@@ -80,5 +93,78 @@ impl fmt::Display for UnoptimizedOperation {
                 ..
             } => write!(f, "{output_name} = {}(...)", fmt_str),
         }
+    }
+}
+
+pub type InputIdx = usize;
+pub type ColumnIdx = usize;
+
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "ir_serde", derive(Serialize, Deserialize))]
+pub struct FunctionArgMap {
+    /// Mapping from function args to input columns
+    /// arg[i] = inputs[arg_map[i].0].column_by_idx(arg_map[i].1)
+    map: Vec<(InputIdx, ColumnIdx)>,
+}
+
+impl FunctionArgMap {
+    pub fn new(map: Vec<(InputIdx, ColumnIdx)>) -> Self {
+        Self { map }
+    }
+
+    /// Returns a collection of `Field`s representing the args. Renaming is applied.
+    pub fn arg_fields(
+        &self,
+        input_schemas: &[SchemaRef],
+        arg_names: Option<&[PlSmallStr]>,
+    ) -> Vec<Field> {
+        if let Some(arg_names) = arg_names {
+            assert_eq!(self.map.len(), arg_names.len());
+        }
+        self.map
+            .iter()
+            .enumerate()
+            .map(|(i, &(input_idx, column_idx))| {
+                let (input_name, dtype) =
+                    input_schemas[input_idx].get_at_index(column_idx).unwrap();
+                let arg_name = arg_names.map(|a| &a[i]).unwrap_or(input_name).clone();
+                Field::new(arg_name, dtype.clone())
+            })
+            .collect()
+    }
+
+    /// Returns a collection of `ExprIR`s that select args from zipped inputs. Renaming is applied.
+    pub fn arg_selectors(
+        &self,
+        input_schemas: &[SchemaRef],
+        arg_names: Option<&[PlSmallStr]>,
+        expr_arena: &mut Arena<AExpr>,
+    ) -> Vec<ExprIR> {
+        self.iter_args_with_names(input_schemas, arg_names)
+            .map(|(_, col_name, arg_name)| {
+                AExprBuilder::col(col_name.clone(), expr_arena).expr_ir(arg_name.clone())
+            })
+            .collect()
+    }
+
+    /// Returns an iterator over `(input_idx, input_col_name, arg_name)` tuples.
+    pub fn iter_args_with_names<'a>(
+        &'a self,
+        input_schemas: &'a [SchemaRef],
+        arg_names: Option<&'a [PlSmallStr]>,
+    ) -> impl Iterator<Item = (InputIdx, &'a PlSmallStr, &'a PlSmallStr)> + 'a {
+        if let Some(arg_names) = arg_names {
+            assert_eq!(self.map.len(), arg_names.len());
+        }
+        self.map.iter().enumerate().map(move |(i, (input, col))| {
+            let col_name = input_schemas[*input].get_at_index(*col).unwrap().0;
+            let arg_name = arg_names.map(|r| &r[i]).unwrap_or(col_name);
+            (*input, col_name, arg_name)
+        })
+    }
+
+    /// Returns an iterator over `(input_idx, column_idx)` tuples.
+    pub fn iter_arg_inputs(&self) -> impl Iterator<Item = (InputIdx, ColumnIdx)> + '_ {
+        self.map.iter().copied()
     }
 }

--- a/crates/polars-plan/src/plans/visitor/hash.rs
+++ b/crates/polars-plan/src/plans/visitor/hash.rs
@@ -284,27 +284,32 @@ impl Hash for IRHashWrap<'_> {
             },
             IR::UnoptimizedDispatch {
                 inputs: _,
+                arg_map: _,
                 operation,
             } => match operation {
                 UnoptimizedOperation::ColumnarFunction {
                     function,
                     options,
+                    arg_names,
                     output_name,
                 } => {
                     function.hash(state);
                     options.hash(state);
+                    arg_names.hash(state);
                     output_name.hash(state);
                 },
 
                 UnoptimizedOperation::AnonymousColumnsUdf {
                     function,
                     options,
+                    arg_names,
                     output_name,
                     fmt_str: _,
                     ctx_schema: _,
                 } => {
                     function.hash(state);
                     options.hash(state);
+                    arg_names.hash(state);
                     output_name.hash(state);
                 },
             },

--- a/crates/polars-plan/src/plans/visitor/hash.rs
+++ b/crates/polars-plan/src/plans/visitor/hash.rs
@@ -290,26 +290,22 @@ impl Hash for IRHashWrap<'_> {
                 UnoptimizedOperation::ColumnarFunction {
                     function,
                     options,
-                    arg_names,
                     output_name,
                 } => {
                     function.hash(state);
                     options.hash(state);
-                    arg_names.hash(state);
                     output_name.hash(state);
                 },
 
                 UnoptimizedOperation::AnonymousColumnsUdf {
                     function,
                     options,
-                    arg_names,
                     output_name,
                     fmt_str: _,
                     ctx_schema: _,
                 } => {
                     function.hash(state);
                     options.hash(state);
-                    arg_names.hash(state);
                     output_name.hash(state);
                 },
             },

--- a/crates/polars-stream/src/nodes/columnar_function.rs
+++ b/crates/polars-stream/src/nodes/columnar_function.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use polars_core::schema::Schema;
 use polars_plan::dsl::ColumnsUdf;
+use polars_plan::plans::FunctionArgMap;
 use polars_utils::itertools::Itertools;
 use polars_utils::pl_str::PlSmallStr;
 
@@ -13,6 +14,7 @@ pub enum ColumnarFunctionNode {
     Sink {
         sink_nodes: Vec<InMemorySinkNode>,
         func: Arc<dyn ColumnsUdf>,
+        arg_map: Option<FunctionArgMap>,
         output_name: PlSmallStr,
     },
     Source(InMemorySourceNode),
@@ -23,6 +25,7 @@ impl ColumnarFunctionNode {
     pub fn new(
         input_schemas: Vec<Arc<Schema>>,
         func: Arc<dyn ColumnsUdf>,
+        arg_map: Option<FunctionArgMap>,
         output_name: PlSmallStr,
     ) -> Self {
         Self::Sink {
@@ -31,6 +34,7 @@ impl ColumnarFunctionNode {
                 .map(InMemorySinkNode::new)
                 .collect(),
             func,
+            arg_map,
             output_name,
         }
     }
@@ -58,16 +62,35 @@ impl ComputeNode for ColumnarFunctionNode {
         if let Self::Sink {
             sink_nodes,
             func,
+            arg_map,
             output_name,
         } = self
         {
             assert!(recv.len() == sink_nodes.len());
             if recv.iter().all(|p| *p == PortState::Done) {
-                let mut cols = Vec::new();
+                let mut dfs = Vec::new();
                 for sink_node in sink_nodes {
                     let df = sink_node.get_output()?.unwrap();
-                    cols.extend(df.into_columns());
+                    dfs.push(df);
                 }
+
+                let mut cols = if let Some(arg_map) = arg_map {
+                    arg_map
+                        .iter()
+                        .map(|(input_idx, col_idx, arg_name)| {
+                            dfs[input_idx].columns()[col_idx]
+                                .clone()
+                                .with_name(arg_name.clone())
+                        })
+                        .collect()
+                } else {
+                    let mut cols = Vec::new();
+                    for df in dfs {
+                        cols.extend(df.into_columns());
+                    }
+                    cols
+                };
+
                 let out_col = func.call_udf(&mut cols)?.with_name(output_name.clone());
                 let source_node = InMemorySourceNode::new(
                     Arc::new(DataFrame::new(out_col.len(), vec![out_col])?),

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -365,6 +365,7 @@ fn visualize_plan_rec(
         PhysNodeKind::ColumnarFunction {
             inputs,
             func: _,
+            arg_map: _,
             output_name,
             format_str,
         } => {

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -2619,6 +2619,7 @@ fn lower_exprs_with_ctx(
                 let kind = PhysNodeKind::ColumnarFunction {
                     inputs,
                     func,
+                    arg_map: None,
                     output_name: out_name.clone(),
                     format_str,
                 };

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -29,7 +29,7 @@ use polars_utils::relaxed_cell::RelaxedCell;
 use polars_utils::row_counter::RowCounter;
 use polars_utils::slice_enum::Slice;
 use polars_utils::unique_id::UniqueId;
-use polars_utils::{IdxSize, UnitVec, format_pl_smallstr, unique_column_name};
+use polars_utils::{IdxSize, format_pl_smallstr, unique_column_name};
 use slotmap::SlotMap;
 
 use super::lower_expr::build_hstack_stream;
@@ -1623,7 +1623,7 @@ pub fn lower_ir(
             let inputs = inputs.clone();
             let arg_map = arg_map.clone();
 
-            let trans_inputs: Vec<PhysStream> =
+            let trans_inputs: Vec<_> =
                 inputs.iter().map(|input| lower_ir!(*input)).try_collect()?;
 
             let trans_schemas: Vec<Arc<Schema>> = trans_inputs
@@ -1631,38 +1631,15 @@ pub fn lower_ir(
                 .map(|i| i.output_schema(phys_sm).clone())
                 .collect();
 
-            let phys_stream_for_arg =
-                |(input_idx, col_name, arg_name): (usize, &PlSmallStr, &PlSmallStr)| {
-                    let input = trans_inputs[input_idx];
-                    if trans_schemas[input_idx].len() == 1 && arg_name == col_name {
-                        // Use the input as is.
-                        Ok(input)
-                    } else {
-                        // Select a single column from the input, with an optional rename.
-                        let selector = AExprBuilder::col(col_name.clone(), expr_arena)
-                            .expr_ir(arg_name.clone());
-                        build_select_stream(
-                            input,
-                            &[selector],
-                            expr_arena,
-                            phys_sm,
-                            expr_cache,
-                            ctx,
-                        )
-                    }
-                };
-
             match operation {
                 UnoptimizedOperation::ColumnarFunction {
                     function,
                     options,
-                    arg_names,
                     output_name,
                 } => {
                     if trans_inputs.len() == 1 {
                         // Single input, can directly dispatch through a select.
-                        let expr_input =
-                            arg_map.arg_selectors(&trans_schemas, arg_names.as_deref(), expr_arena);
+                        let expr_input = arg_map.arg_selectors(&trans_schemas, expr_arena);
                         let expr = ExprIR::from_node(
                             expr_arena.add(AExpr::Function {
                                 input: expr_input,
@@ -1683,59 +1660,14 @@ pub fn lower_ir(
                     } else if options.is_row_separable() {
                         // We can zip the inputs together and dispatch through a select.
 
-                        let zip_schemas = |schemas: &[Arc<Schema>]| {
+                        let zip_schema = {
                             let mut zip_schema = Schema::default();
-                            for schema in schemas {
+                            for schema in &trans_schemas {
+                                // Will panic on column name collision
                                 zip_schema.hstack_mut(schema.as_ref().clone())?;
                             }
-                            PolarsResult::Ok(Arc::new(zip_schema))
+                            Arc::new(zip_schema)
                         };
-
-                        let (trans_inputs, trans_schemas, zip_schema) =
-                            if let Ok(zip_schema) = zip_schemas(&trans_schemas) {
-                                // Use the inputs as-is.
-                                (trans_inputs, trans_schemas, zip_schema)
-                            } else {
-                                // Column name collision, rename.
-                                let orig_trans_schemas = trans_schemas;
-
-                                // Generate unique names for all input columns.
-                                let trans_schemas: Vec<Arc<Schema>> = orig_trans_schemas
-                                    .iter()
-                                    .map(|ts| {
-                                        ts.iter_values()
-                                            .map(|dt| (unique_column_name(), dt.clone()))
-                                            .collect::<Schema>()
-                                            .into()
-                                    })
-                                    .collect();
-
-                                // Rename all input columns.
-                                let trans_inputs = trans_inputs
-                                    .into_iter()
-                                    .enumerate()
-                                    .map(|(i, ti)| {
-                                        let in_schema = &orig_trans_schemas[i];
-                                        let out_schema = &trans_schemas[i];
-                                        let selectors: UnitVec<_> = in_schema
-                                            .iter_names()
-                                            .zip(out_schema.iter_names())
-                                            .map(|(from, to)| {
-                                                ExprIR::from_column_name(from.clone(), expr_arena)
-                                                    .with_alias(to.clone())
-                                            })
-                                            .collect();
-                                        build_select_stream(
-                                            ti, &selectors, expr_arena, phys_sm, expr_cache, ctx,
-                                        )
-                                    })
-                                    .collect::<PolarsResult<Vec<_>>>()?;
-
-                                let zip_schema = zip_schemas(&trans_schemas)
-                                    .expect("all columns have unique names");
-
-                                (trans_inputs, trans_schemas, zip_schema)
-                            };
 
                         let zip_node = phys_sm.insert(PhysNode::new(
                             zip_schema,
@@ -1745,8 +1677,7 @@ pub fn lower_ir(
                             },
                         ));
 
-                        let expr_input =
-                            arg_map.arg_selectors(&trans_schemas, arg_names.as_deref(), expr_arena);
+                        let expr_input = arg_map.arg_selectors(&trans_schemas, expr_arena);
                         let expr = ExprIR::from_node(
                             expr_arena.add(AExpr::Function {
                                 input: expr_input,
@@ -1765,15 +1696,12 @@ pub fn lower_ir(
                             ctx,
                         );
                     } else {
-                        let arg_inputs = arg_map
-                            .iter_args_with_names(&trans_schemas, arg_names.as_deref())
-                            .map(phys_stream_for_arg)
-                            .try_collect()?;
                         let func = function_expr_to_udf(function.clone()).into_inner();
                         let format_str = Some(format!("COLUMNAR {function}"));
                         PhysNodeKind::ColumnarFunction {
-                            inputs: arg_inputs,
+                            inputs: trans_inputs,
                             func,
+                            arg_map: Some(arg_map),
                             output_name,
                             format_str,
                         }
@@ -1783,15 +1711,10 @@ pub fn lower_ir(
                 UnoptimizedOperation::AnonymousColumnsUdf {
                     function,
                     options: _,
-                    arg_names,
                     output_name,
                     fmt_str,
                     ctx_schema: _,
                 } => {
-                    let arg_inputs = arg_map
-                        .iter_args_with_names(&trans_schemas, Some(&arg_names))
-                        .map(phys_stream_for_arg)
-                        .try_collect()?;
                     let func = function
                         .clone()
                         .materialize()
@@ -1800,8 +1723,9 @@ pub fn lower_ir(
                         .as_column_udf();
                     let format_str = Some(format!("ANONYMOUS {fmt_str}"));
                     PhysNodeKind::ColumnarFunction {
-                        inputs: arg_inputs,
+                        inputs: trans_inputs,
                         func,
+                        arg_map: Some(arg_map),
                         output_name,
                         format_str,
                     }

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -29,7 +29,7 @@ use polars_utils::relaxed_cell::RelaxedCell;
 use polars_utils::row_counter::RowCounter;
 use polars_utils::slice_enum::Slice;
 use polars_utils::unique_id::UniqueId;
-use polars_utils::{IdxSize, format_pl_smallstr, unique_column_name};
+use polars_utils::{IdxSize, UnitVec, format_pl_smallstr, unique_column_name};
 use slotmap::SlotMap;
 
 use super::lower_expr::build_hstack_stream;
@@ -1614,38 +1614,139 @@ pub fn lower_ir(
             return Ok(stream);
         },
         IR::ExtContext { .. } => todo!(),
-        IR::UnoptimizedDispatch { inputs, operation } => {
+        IR::UnoptimizedDispatch {
+            inputs,
+            arg_map,
+            operation,
+        } => {
             let operation = operation.clone();
             let inputs = inputs.clone();
-            let trans_inputs = inputs.iter().map(|input| lower_ir!(*input)).try_collect()?;
+            let arg_map = arg_map.clone();
+
+            let trans_inputs: Vec<PhysStream> =
+                inputs.iter().map(|input| lower_ir!(*input)).try_collect()?;
+
+            let trans_schemas: Vec<Arc<Schema>> = trans_inputs
+                .iter()
+                .map(|i| i.output_schema(phys_sm).clone())
+                .collect();
+
+            let phys_stream_for_arg =
+                |(input_idx, col_name, arg_name): (usize, &PlSmallStr, &PlSmallStr)| {
+                    let input = trans_inputs[input_idx];
+                    if trans_schemas[input_idx].len() == 1 && arg_name == col_name {
+                        // Use the input as is.
+                        Ok(input)
+                    } else {
+                        // Select a single column from the input, with an optional rename.
+                        let selector = AExprBuilder::col(col_name.clone(), expr_arena)
+                            .expr_ir(arg_name.clone());
+                        build_select_stream(
+                            input,
+                            &[selector],
+                            expr_arena,
+                            phys_sm,
+                            expr_cache,
+                            ctx,
+                        )
+                    }
+                };
 
             match operation {
                 UnoptimizedOperation::ColumnarFunction {
                     function,
                     options,
+                    arg_names,
                     output_name,
                 } => {
-                    if options.is_elementwise() {
-                        // If it is elementwise we can just zip the inputs together.
-                        let mut zip_schema = Schema::default();
-                        for input in inputs {
-                            zip_schema.hstack_mut(
-                                (*IR::schema_with_cache(input, ir_arena, schema_cache)).clone(),
-                            )?;
-                        }
-                        let zip_schema = Arc::new(zip_schema);
+                    if trans_inputs.len() == 1 {
+                        // Single input, can directly dispatch through a select.
+                        let expr_input =
+                            arg_map.arg_selectors(&trans_schemas, arg_names.as_deref(), expr_arena);
+                        let expr = ExprIR::from_node(
+                            expr_arena.add(AExpr::Function {
+                                input: expr_input,
+                                function,
+                                options,
+                            }),
+                            expr_arena,
+                        )
+                        .with_alias(output_name);
+                        return build_select_stream(
+                            trans_inputs[0],
+                            &[expr],
+                            expr_arena,
+                            phys_sm,
+                            expr_cache,
+                            ctx,
+                        );
+                    } else if options.is_row_separable() {
+                        // We can zip the inputs together and dispatch through a select.
+
+                        let zip_schemas = |schemas: &[Arc<Schema>]| {
+                            let mut zip_schema = Schema::default();
+                            for schema in schemas {
+                                zip_schema.hstack_mut(schema.as_ref().clone())?;
+                            }
+                            PolarsResult::Ok(Arc::new(zip_schema))
+                        };
+
+                        let (trans_inputs, trans_schemas, zip_schema) =
+                            if let Ok(zip_schema) = zip_schemas(&trans_schemas) {
+                                // Use the inputs as-is.
+                                (trans_inputs, trans_schemas, zip_schema)
+                            } else {
+                                // Column name collision, rename.
+                                let orig_trans_schemas = trans_schemas;
+
+                                // Generate unique names for all input columns.
+                                let trans_schemas: Vec<Arc<Schema>> = orig_trans_schemas
+                                    .iter()
+                                    .map(|ts| {
+                                        ts.iter_values()
+                                            .map(|dt| (unique_column_name(), dt.clone()))
+                                            .collect::<Schema>()
+                                            .into()
+                                    })
+                                    .collect();
+
+                                // Rename all input columns.
+                                let trans_inputs = trans_inputs
+                                    .into_iter()
+                                    .enumerate()
+                                    .map(|(i, ti)| {
+                                        let in_schema = &orig_trans_schemas[i];
+                                        let out_schema = &trans_schemas[i];
+                                        let selectors: UnitVec<_> = in_schema
+                                            .iter_names()
+                                            .zip(out_schema.iter_names())
+                                            .map(|(from, to)| {
+                                                ExprIR::from_column_name(from.clone(), expr_arena)
+                                                    .with_alias(to.clone())
+                                            })
+                                            .collect();
+                                        build_select_stream(
+                                            ti, &selectors, expr_arena, phys_sm, expr_cache, ctx,
+                                        )
+                                    })
+                                    .collect::<PolarsResult<Vec<_>>>()?;
+
+                                let zip_schema = zip_schemas(&trans_schemas)
+                                    .expect("all columns have unique names");
+
+                                (trans_inputs, trans_schemas, zip_schema)
+                            };
+
                         let zip_node = phys_sm.insert(PhysNode::new(
-                            zip_schema.clone(),
+                            zip_schema,
                             PhysNodeKind::Zip {
                                 inputs: trans_inputs,
                                 zip_behavior: ZipBehavior::Broadcast,
                             },
                         ));
 
-                        let expr_input = zip_schema
-                            .iter_names()
-                            .map(|n| ExprIR::from_column_name(n.clone(), expr_arena))
-                            .collect_vec();
+                        let expr_input =
+                            arg_map.arg_selectors(&trans_schemas, arg_names.as_deref(), expr_arena);
                         let expr = ExprIR::from_node(
                             expr_arena.add(AExpr::Function {
                                 input: expr_input,
@@ -1664,10 +1765,14 @@ pub fn lower_ir(
                             ctx,
                         );
                     } else {
+                        let arg_inputs = arg_map
+                            .iter_args_with_names(&trans_schemas, arg_names.as_deref())
+                            .map(phys_stream_for_arg)
+                            .try_collect()?;
                         let func = function_expr_to_udf(function.clone()).into_inner();
                         let format_str = Some(format!("COLUMNAR {function}"));
                         PhysNodeKind::ColumnarFunction {
-                            inputs: trans_inputs,
+                            inputs: arg_inputs,
                             func,
                             output_name,
                             format_str,
@@ -1678,10 +1783,15 @@ pub fn lower_ir(
                 UnoptimizedOperation::AnonymousColumnsUdf {
                     function,
                     options: _,
+                    arg_names,
                     output_name,
                     fmt_str,
                     ctx_schema: _,
                 } => {
+                    let arg_inputs = arg_map
+                        .iter_args_with_names(&trans_schemas, Some(&arg_names))
+                        .map(phys_stream_for_arg)
+                        .try_collect()?;
                     let func = function
                         .clone()
                         .materialize()
@@ -1690,7 +1800,7 @@ pub fn lower_ir(
                         .as_column_udf();
                     let format_str = Some(format!("ANONYMOUS {fmt_str}"));
                     PhysNodeKind::ColumnarFunction {
-                        inputs: trans_inputs,
+                        inputs: arg_inputs,
                         func,
                         output_name,
                         format_str,

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -27,7 +27,7 @@ use polars_plan::dsl::{
 };
 use polars_plan::plans::expr_ir::ExprIR;
 use polars_plan::plans::hive::HivePartitionsDf;
-use polars_plan::plans::{AExpr, DataFrameUdf, DynamicPred, IR};
+use polars_plan::plans::{AExpr, DataFrameUdf, DynamicPred, FunctionArgMap, IR};
 
 mod fmt;
 mod io;
@@ -260,6 +260,7 @@ pub enum PhysNodeKind {
     ColumnarFunction {
         inputs: Vec<PhysStream>,
         func: Arc<dyn ColumnsUdf>,
+        arg_map: Option<FunctionArgMap>,
         output_name: PlSmallStr,
         format_str: Option<String>,
     },

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -519,6 +519,7 @@ fn to_graph_rec<'a>(
             inputs,
             func,
             output_name,
+            arg_map,
             format_str: _,
         } => {
             let input_schemas = inputs
@@ -533,6 +534,7 @@ fn to_graph_rec<'a>(
                 nodes::columnar_function::ColumnarFunctionNode::new(
                     input_schemas,
                     func.clone(),
+                    arg_map.clone(),
                     output_name.clone(),
                 ),
                 input_keys,


### PR DESCRIPTION
Adds an input mapper and arg names to unoptimized dispatch. This allows a single input to be used for several args without having to manually insert multiplexers, and to insert names for nodes that use them (`AsStruct`, horizontal fold family, and anonymous function).