### PR TITLE
fix(python): lazily initialize GroupBy state in __next__ to fix #12868

### DIFF
--- a/py-polars/src/polars/dataframe/group_by.py
+++ b/py-polars/src/polars/dataframe/group_by.py
@@ -136,7 +136,7 @@ class GroupBy:
     def __next__(self) -> tuple[tuple[Any, ...], DataFrame]:
         if getattr(self, "_current_index", None) is None:
             self.__iter__()
-            
+
         if self._current_index >= len(self._group_indices):
             raise StopIteration
 

--- a/py-polars/src/polars/dataframe/group_by.py
+++ b/py-polars/src/polars/dataframe/group_by.py
@@ -134,6 +134,9 @@ class GroupBy:
         return self
 
     def __next__(self) -> tuple[tuple[Any, ...], DataFrame]:
+        if getattr(self, "_current_index", None) is None:
+            self.__iter__()
+            
         if self._current_index >= len(self._group_indices):
             raise StopIteration
 


### PR DESCRIPTION
<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
