### PR TITLE
fix: Make `collect_schema()` raise on unsupported operations

### DIFF
--- a/crates/polars-expr/src/dispatch/pow.rs
+++ b/crates/polars-expr/src/dispatch/pow.rs
@@ -189,6 +189,10 @@ pub(super) fn pow(s: &mut [Column]) -> PolarsResult<Column> {
 }
 
 pub(super) fn sqrt(base: &Column) -> PolarsResult<Column> {
+    polars_ensure!(
+        base.dtype().is_primitive_numeric(),
+        InvalidOperation: "`sqrt` operation not supported for dtype `{}`", base.dtype()
+    );
     match base.dtype() {
         #[cfg(feature = "dtype-f16")]
         DataType::Float16 => {
@@ -220,6 +224,10 @@ where
 }
 
 pub(super) fn cbrt(base: &Column) -> PolarsResult<Column> {
+    polars_ensure!(
+        base.dtype().is_primitive_numeric(),
+        InvalidOperation: "`cbrt` operation not supported for dtype `{}`", base.dtype()
+    );
     match base.dtype() {
         #[cfg(feature = "dtype-f16")]
         DataType::Float16 => {

--- a/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
@@ -33,12 +33,34 @@ impl IRFunctionExpr {
             #[cfg(feature = "business")]
             Business(func) => func.get_field(mapper),
             #[cfg(feature = "abs")]
-            Abs => mapper.with_same_dtype(),
+            Abs => {
+                let dt = mapper.args()[0].dtype();
+                polars_ensure!(
+                    dt.is_numeric() || matches!(dt, DataType::Duration(_)),
+                    InvalidOperation: "`abs` operation not supported for dtype `{}`", dt
+                );
+                mapper.with_same_dtype()
+            },
             Negate => mapper.with_same_dtype(),
             NullCount => mapper.with_dtype(IDX_DTYPE),
             Pow(pow_function) => match pow_function {
                 IRPowFunction::Generic => mapper.pow_dtype(),
-                _ => mapper.map_numeric_to_float_dtype(true),
+                IRPowFunction::Sqrt => {
+                    let dt = mapper.args()[0].dtype();
+                    polars_ensure!(
+                        dt.is_primitive_numeric(),
+                        InvalidOperation: "`sqrt` operation not supported for dtype `{}`", dt
+                    );
+                    mapper.map_numeric_to_float_dtype(true)
+                },
+                IRPowFunction::Cbrt => {
+                    let dt = mapper.args()[0].dtype();
+                    polars_ensure!(
+                        dt.is_primitive_numeric(),
+                        InvalidOperation: "`cbrt` operation not supported for dtype `{}`", dt
+                    );
+                    mapper.map_numeric_to_float_dtype(true)
+                },
             },
             Coalesce => mapper.map_to_supertype(),
             #[cfg(feature = "row_hash")]
@@ -738,6 +760,14 @@ impl<'a> FieldsMapper<'a> {
     pub(super) fn pow_dtype(&self) -> PolarsResult<Field> {
         let dtype1 = self.fields[0].dtype();
         let dtype2 = self.fields[1].dtype();
+        polars_ensure!(
+            dtype1.is_primitive_numeric(),
+            InvalidOperation: "`pow` operation not supported for dtype `{}` as base", dtype1
+        );
+        polars_ensure!(
+            dtype2.is_primitive_numeric(),
+            InvalidOperation: "`pow` operation not supported for dtype `{}` as exponent", dtype2
+        );
         let out_dtype = if dtype1.is_integer() {
             if dtype2.is_float() { dtype2 } else { dtype1 }
         } else {

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -864,6 +864,14 @@ fn get_truediv_dtype(left_dtype: &DataType, right_dtype: &DataType) -> PolarsRes
         (UInt8 | Int8, Float32) => Float32,
         #[cfg(feature = "dtype-u16")]
         (UInt16 | Int16, Float32) => Float32,
+        #[cfg(feature = "dtype-datetime")]
+        (_, Datetime(_, _)) => {
+            polars_bail!(InvalidOperation: "division of 'Datetime' datatype is not allowed")
+        },
+        #[cfg(feature = "dtype-time")]
+        (_, Time) => polars_bail!(InvalidOperation: "division of 'Time' datatype is not allowed"),
+        #[cfg(feature = "dtype-date")]
+        (_, Date) => polars_bail!(InvalidOperation: "division of 'Date' datatype is not allowed"),
         (dt, _) if dt.is_primitive_numeric() => Float64,
         #[cfg(feature = "dtype-duration")]
         (Duration(_), Duration(_)) => Float64,

--- a/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
@@ -931,6 +931,26 @@ def test_float_truediv_output_type() -> None:
 
 
 @pytest.mark.parametrize(
+    ("rhs_dtype", "rhs_name"),
+    [
+        (pl.Date, "Date"),
+        (pl.Datetime, "Datetime"),
+        (pl.Time, "Time"),
+    ],
+)
+def test_truediv_numeric_temporal_rhs_raises_in_schema(
+    rhs_dtype: pl.DataType, rhs_name: str
+) -> None:
+    lf = pl.LazyFrame(
+        {"a": [1], "b": [None]}, schema={"a": pl.Int32, "b": rhs_dtype}
+    ).select(pl.col("a") / pl.col("b"))
+    with pytest.raises(
+        InvalidOperationError, match=f"division of '{rhs_name}' datatype is not allowed"
+    ):
+        lf.collect_schema()
+
+
+@pytest.mark.parametrize(
     "dtype",
     [
         pl.Float64,

--- a/py-polars/tests/unit/operations/arithmetic/test_pow.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_pow.py
@@ -1,4 +1,7 @@
+import pytest
+
 import polars as pl
+from polars.exceptions import InvalidOperationError
 
 
 def test_pow_dtype() -> None:
@@ -57,3 +60,66 @@ def test_pow_dtype() -> None:
     ]
     assert df.collect().dtypes == expected
     assert df.collect_schema().dtypes() == expected
+
+
+def test_pow_collect_schema_raises_non_numeric_base() -> None:
+    lf = pl.LazyFrame({"a": [None]}, schema={"a": pl.String}).select(
+        pl.col("a") ** 2
+    )
+    with pytest.raises(
+        InvalidOperationError,
+        match="`pow` operation not supported for dtype `str` as base",
+    ):
+        lf.collect_schema()
+
+
+def test_pow_collect_schema_raises_non_numeric_exponent() -> None:
+    lf = pl.LazyFrame({"a": [1], "b": [None]}, schema={"a": pl.Int64, "b": pl.String}).select(
+        pl.col("a") ** pl.col("b")
+    )
+    with pytest.raises(
+        InvalidOperationError,
+        match="`pow` operation not supported for dtype `str` as exponent",
+    ):
+        lf.collect_schema()
+
+
+def test_sqrt_collect_schema_raises_non_numeric() -> None:
+    lf = pl.LazyFrame({"a": [None]}, schema={"a": pl.String}).select(
+        pl.col("a").sqrt()
+    )
+    with pytest.raises(
+        InvalidOperationError, match="`sqrt` operation not supported for dtype `str`"
+    ):
+        lf.collect_schema()
+
+
+def test_sqrt_collect_raises_non_numeric() -> None:
+    # Previously this silently auto-cast String -> Float64; now matches `pow` and raises.
+    lf = pl.LazyFrame({"a": [None]}, schema={"a": pl.String}).select(
+        pl.col("a").sqrt()
+    )
+    with pytest.raises(
+        InvalidOperationError, match="`sqrt` operation not supported for dtype `str`"
+    ):
+        lf.collect()
+
+
+def test_cbrt_collect_schema_raises_non_numeric() -> None:
+    lf = pl.LazyFrame({"a": [None]}, schema={"a": pl.String}).select(
+        pl.col("a").cbrt()
+    )
+    with pytest.raises(
+        InvalidOperationError, match="`cbrt` operation not supported for dtype `str`"
+    ):
+        lf.collect_schema()
+
+
+def test_cbrt_collect_raises_non_numeric() -> None:
+    lf = pl.LazyFrame({"a": [None]}, schema={"a": pl.String}).select(
+        pl.col("a").cbrt()
+    )
+    with pytest.raises(
+        InvalidOperationError, match="`cbrt` operation not supported for dtype `str`"
+    ):
+        lf.collect()

--- a/py-polars/tests/unit/operations/test_abs.py
+++ b/py-polars/tests/unit/operations/test_abs.py
@@ -106,6 +106,24 @@ def test_abs_date() -> None:
         df.select(pl.col("date").abs())
 
 
+def test_abs_collect_schema_raises_non_numeric() -> None:
+    lf = pl.LazyFrame({"a": [None]}, schema={"a": pl.String}).select(
+        pl.col("a").abs()
+    )
+    with pytest.raises(
+        InvalidOperationError, match="`abs` operation not supported for dtype `str`"
+    ):
+        lf.collect_schema()
+
+
+def test_abs_collect_schema_raises_date() -> None:
+    lf = pl.LazyFrame({"a": [None]}, schema={"a": pl.Date}).select(pl.col("a").abs())
+    with pytest.raises(
+        InvalidOperationError, match="`abs` operation not supported for dtype `date`"
+    ):
+        lf.collect_schema()
+
+
 def test_abs_series_builtin() -> None:
     s = pl.Series("a", [-1, 0, 1, None])
     result = abs(s)


### PR DESCRIPTION
## Which issue does this PR close?

Closes #27565.

## Rationale for this change

`LazyFrame.collect_schema()` and `LazyFrame.collect()` should agree on the output dtype of every expression. Currently they disagree for several operations — `collect_schema()` returns a concrete dtype, but `collect()` raises `InvalidOperationError`:

- `abs(non-numeric)` — schema returns the input dtype; collect raises
- `pow(non-numeric base or exponent)` — schema returns the input dtype; collect raises
- `sqrt(non-numeric)` / `cbrt(non-numeric)` — schema returns the input dtype; collect silently auto-casts to `Float64`
- `numeric / Date|Datetime|Time` — schema returns `Float64`; collect raises

This breaks downstream tooling that inspects lazy schemas before execution and assumes a returned dtype means the operation will succeed. The arithmetic operators `+ - * //` already raise correctly in `get_arithmetic_field`; this PR aligns the unary numeric ops, `pow`, `sqrt`, `cbrt`, and `truediv` to the same model.

## What changes are included in this PR?

- **`crates/polars-plan/src/plans/aexpr/function_expr/schema.rs`:**
  - `Abs`: added `polars_ensure!` that the operand is numeric or `Duration` before returning the input dtype. Mirrors the runtime kernel in `polars-ops/src/series/ops/abs.rs`.
  - `Pow(IRPowFunction::Generic)`: added `polars_ensure!` in `pow_dtype()` that both operands are `is_primitive_numeric()`. Uses the same error strings as the pow runtime kernel.
  - `Pow(IRPowFunction::Sqrt)` and `Pow(IRPowFunction::Cbrt)`: split out of the `_ => map_numeric_to_float_dtype(true)` catch-all; each now validates `is_primitive_numeric()` before computing the Float supertype.
- **`crates/polars-plan/src/plans/aexpr/schema.rs`:**
  - `get_truediv_dtype`: added symmetric `(_, Date | Datetime | Time)` bails before the `(dt, _) if dt.is_primitive_numeric() => Float64` catch-all. Pairs with the existing LHS bails 4 lines below.
- **`crates/polars-expr/src/dispatch/pow.rs`:**
  - `sqrt` and `cbrt` runtime kernels: added `polars_ensure!(is_primitive_numeric)` at the top. Previously these did `base.cast(&DataType::Float64)?` for any non-numeric input, silently producing `Float64` output (the divergence described in #27565 case 4).
- **Tests:** 9 new tests across `test_abs.py`, `test_pow.py`, and `test_arithmetic.py` — each of the 4 reporter cases is verified at the `collect_schema()` layer, and `sqrt`/`cbrt` are also verified at the `collect()` layer to lock in the new runtime behavior.

## Behavior change

`sqrt` and `cbrt` no longer silently auto-cast non-numeric inputs (e.g. `String`) to `Float64`. They now raise `InvalidOperationError`, matching `pow`. Users who relied on the implicit cast should add an explicit `.cast(pl.Float64)` before calling `sqrt` / `cbrt`.

## Are these changes tested?

Yes. The new tests:

- `test_abs_collect_schema_raises_non_numeric`
- `test_abs_collect_schema_raises_date`
- `test_pow_collect_schema_raises_non_numeric_base`
- `test_pow_collect_schema_raises_non_numeric_exponent`
- `test_sqrt_collect_schema_raises_non_numeric`
- `test_sqrt_collect_raises_non_numeric` (locks in the runtime behavior change)
- `test_cbrt_collect_schema_raises_non_numeric`
- `test_cbrt_collect_raises_non_numeric`
- `test_truediv_numeric_temporal_rhs_raises_in_schema` (parametrized over `Date` / `Datetime` / `Time`)

The existing `test_abs_non_numeric`, `test_abs_date`, and the broader `test_pow.py` / `test_arithmetic.py` suites continue to pass — the new schema validation fires before the runtime would have, with the same error message, so existing tests that exercise the eager path are unaffected.

Screenshot of `make test` passing locally: <attach screenshot here>

## Are there any user-facing changes?

Yes — see **Behavior change** above. `sqrt` / `cbrt` on non-numeric input now raises instead of auto-casting. No other API or behavioral changes.

## AI disclosure

I used AI assistance to investigate the root cause across the schema-inference helpers, draft the fix, and write the regression tests. I have reviewed all changes in this pull request myself, and I believe they are relevant and correct.
