### PR TITLE
build: Use split-debuginfo on linux

### DIFF
--- a/tools/update-cargo-env.py
+++ b/tools/update-cargo-env.py
@@ -33,5 +33,17 @@ else:
 
 toml["env"] = env
 
+# On linux, building with dev profile might fail at link time, because debug symbols
+# exceed 4 GB. Unless "profile.dev.split-debuginfo" is set already, set it to "unpacked"
+if sys.platform == "linux":
+    profile = toml.get("profile", {})
+    dev = profile.get("dev", {})
+
+    if dev.get("split-debuginfo") is None:
+        dev["split-debuginfo"] = "unpacked"
+        profile["dev"] = dev
+        toml["profile"] = profile
+
+
 with config_toml.open("w") as f:
     tomlkit.dump(toml, f)


### PR DESCRIPTION
On Linux, building with dev profile might fail at link time, because debug symbols exceed 4 GB. Unless "profile.dev.split-debuginfo" is set already, set it to "unpacked".

The setting is platform-specific and I didn't find a better way to enable this only on linux, so it's added to the script that updates `.cargo/config.toml`

https://doc.rust-lang.org/rustc/codegen-options/index.html#split-debuginfo