### PR TITLE
fix: Reset the sort-options in `Series::is_sorted()` after row-encoding columns

### DIFF
--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -97,6 +97,11 @@ pub trait SeriesMethods: SeriesSealed {
                 &[options.nulls_last],
                 false,
             )?;
+            let options = SortOptions {
+                descending: false,
+                nulls_last: false,
+                ..options
+            };
             return encoded.into_series().is_sorted(options);
         }
 

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -2490,3 +2490,28 @@ def test_full_null_cast_to_empty_struct_23276() -> None:
 
     s = pl.Series([None, None, None])
     assert s.cast(pl.Struct({})).to_list() == [None, None, None]
+
+
+def test_is_sorted_struct_27613() -> None:
+    s = pl.Series([{"x": 1, "y": 1}, {"x": 1, "y": 2}, {"x": 2, "y": 0}])
+    assert s.is_sorted()
+    assert not s.is_sorted(descending=True)
+
+    s = pl.Series([{"x": 2, "y": 0}, {"x": 1, "y": 2}, {"x": 1, "y": 1}])
+    assert s.is_sorted(descending=True)
+    assert not s.is_sorted()
+
+    # nulls first, ascending
+    s = pl.Series([None, {"x": 1}, {"x": 2}])
+    assert s.is_sorted(nulls_last=False)
+    assert not s.is_sorted(nulls_last=True)
+
+    # nulls last, ascending
+    s = pl.Series([{"x": 1}, {"x": 2}, None])
+    assert s.is_sorted(nulls_last=True)
+    assert not s.is_sorted(nulls_last=False)
+
+    # nulls last, descending
+    s = pl.Series([{"x": 2}, {"x": 1}, None])
+    assert s.is_sorted(descending=True, nulls_last=True)
+    assert not s.is_sorted(descending=True, nulls_last=False)


### PR DESCRIPTION
Fixes #27613

:robot: Incidentally, this error was found by AI. It also wrote the test. I found the cause of the bug and wrote the fix.
