### PR TITLE
fix(python): Bytes scalars were not being broadcast in dataframe constructor

### DIFF
--- a/py-polars/src/polars/_utils/construction/dataframe.py
+++ b/py-polars/src/polars/_utils/construction/dataframe.py
@@ -388,7 +388,7 @@ def _expand_dict_values(
                         nan_to_null=nan_to_null,
                     )
                 elif val is None or isinstance(  # type: ignore[redundant-expr]
-                    val, (int, float, str, bool, date, datetime, time, timedelta)
+                    val, (int, float, str, bytes, bool, date, datetime, time, timedelta)
                 ):
                     updated_data[name] = F.repeat(
                         val, array_len, dtype=dtype, eager=True

--- a/py-polars/src/polars/_utils/various.py
+++ b/py-polars/src/polars/_utils/various.py
@@ -229,7 +229,7 @@ def _in_marimo_notebook() -> bool:
 def arrlen(obj: Any) -> int | None:
     """Return length of (non-string/dict) sequence; returns None for non-sequences."""
     try:
-        return None if isinstance(obj, (str, dict)) else len(obj)
+        return None if isinstance(obj, (str, bytes, dict)) else len(obj)
     except TypeError:
         return None
 

--- a/py-polars/tests/unit/constructors/test_dataframe.py
+++ b/py-polars/tests/unit/constructors/test_dataframe.py
@@ -11,6 +11,7 @@ import pytest
 
 import polars as pl
 from polars.exceptions import DataOrientationWarning, InvalidOperationError
+from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -252,3 +253,10 @@ def test_temporal_string_schema_overrides(schema_param: dict[str, SchemaDict]) -
             "datetime": datetime(2024, 1, 2, 13, 30, 0, 123456),
         },
     ]
+
+
+def test_bytes_scalar_broadcast_27620() -> None:
+    # https://github.com/pola-rs/polars/issues/27620
+    result = pl.DataFrame({"a": b"foo", "b": "foo", "c": [10, 20, 30]})
+    expected = pl.DataFrame({"a": [b"foo"] * 3, "b": ["foo"] * 3, "c": [10, 20, 30]})
+    assert_frame_equal(result, expected)


### PR DESCRIPTION
closes #27620 

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
