### PR TITLE
ci: Add ImageVersion to rust-cache key

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -61,6 +61,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
+          env-vars: ImageVersion
           workspaces: py-polars
           save-if: ${{ github.ref_name == 'main' }}
 

--- a/.github/workflows/docs-global.yml
+++ b/.github/workflows/docs-global.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
+          env-vars: ImageVersion
           workspaces: py-polars
           save-if: ${{ github.ref_name == 'main' }}
 

--- a/.github/workflows/docs-rust.yml
+++ b/.github/workflows/docs-rust.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
+          env-vars: ImageVersion
           save-if: ${{ github.ref_name == 'main' }}
 
       - name: Build Rust documentation

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
+          env-vars: ImageVersion
           save-if: ${{ github.ref_name == 'main' }}
 
       - name: Run cargo clippy with all features enabled
@@ -65,6 +66,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
+          env-vars: ImageVersion
           save-if: ${{ github.ref_name == 'main' }}
 
       - name: Run cargo clippy

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
+          env-vars: ImageVersion
           save-if: ${{ github.ref_name == 'main' }}
 
       - name: Prepare coverage
@@ -130,6 +131,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
+          env-vars: ImageVersion
           save-if: ${{ github.ref_name == 'main' }}
 
       - name: Prepare coverage

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -118,6 +118,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
+          env-vars: ImageVersion
           workspaces: py-polars
           save-if: ${{ github.ref_name == 'main' }}
 

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
+          env-vars: ImageVersion
           save-if: ${{ github.ref_name == 'main' }}
 
       # Note that we specify --lib, --bins etc
@@ -94,6 +95,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
+          env-vars: ImageVersion
           save-if: ${{ github.ref_name == 'main' }}
 
       - name: Compile integration tests
@@ -114,6 +116,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
+          env-vars: ImageVersion
           save-if: ${{ github.ref_name == 'main' }}
 
       - name: Install cargo hack
@@ -135,6 +138,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
+          env-vars: ImageVersion
           save-if: ${{ github.ref_name == 'main' }}
 
       - name: Build DSL schema check


### PR DESCRIPTION
This was the solution found in `wgpu` for similar errors to what we're seeing: https://github.com/gfx-rs/wgpu/issues/9543.

`ImageVersion` is pseudo-documented: https://github.com/actions/runner-images/discussions/7879#discussioncomment-6414301.
