### PR TITLE
perf: Factor shared conjuncts out of OR-of-ANDs predicates

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/hash.rs
+++ b/crates/polars-plan/src/plans/aexpr/hash.rs
@@ -14,6 +14,7 @@ impl Hash for AExpr {
 
         match self {
             AExpr::Column(name) => name.hash(state),
+            #[cfg(feature = "dtype-struct")]
             AExpr::StructField(name) => name.hash(state),
             AExpr::Literal(lv) => lv.hash(state),
             AExpr::Function {
@@ -100,6 +101,7 @@ impl Hash for AExpr {
                 evaluation: _,
                 variant,
             } => variant.hash(state),
+            #[cfg(feature = "dtype-struct")]
             AExpr::StructEval {
                 expr: _,
                 evaluation: _,

--- a/crates/polars-plan/src/plans/aexpr/mod.rs
+++ b/crates/polars-plan/src/plans/aexpr/mod.rs
@@ -2,9 +2,9 @@ mod builder;
 mod equality;
 mod evaluate;
 mod function_expr;
-#[cfg(feature = "cse")]
 mod hash;
 mod minterm_iter;
+pub(crate) mod or_factoring;
 pub mod predicates;
 mod scalar;
 mod schema;
@@ -13,8 +13,7 @@ mod traverse;
 use std::hash::{Hash, Hasher};
 
 pub use function_expr::*;
-#[cfg(feature = "cse")]
-pub(super) use hash::traverse_and_hash_aexpr;
+pub(crate) use hash::traverse_and_hash_aexpr;
 pub use minterm_iter::MintermIter;
 use polars_core::chunked_array::cast::CastOptions;
 use polars_core::prelude::*;

--- a/crates/polars-plan/src/plans/aexpr/or_factoring.rs
+++ b/crates/polars-plan/src/plans/aexpr/or_factoring.rs
@@ -1,0 +1,198 @@
+//! OR factoring: `(A∧X) ∨ (A∧Y) → A ∧ (X∨Y)`
+//!
+//! Pure AExpr rewrite, in place on `expr_arena`. Called from
+//! `canonicalize_predicate` before `SplitPredicates::new` walks the AND
+//! chain; factored commons become AND-conjuncts at the top, get split
+//! into their own `IR::Filter` nodes, and become visible to
+//! predicate-pushdown.
+//!
+//! Fallibility / evaluation-order: changes the set of conjuncts seen by
+//! the `Pushable | Fallible | Barrier` classifier in `SplitPredicates::new`,
+//! which may change the order in which a fallible expression is evaluated
+//! relative to other Filters or joins. Inherits Polars's AND-splitting
+//! trade-off: final result is unchanged, error-reporting order may differ
+//! as it would with a `.filter(...).filter(...)` chain.
+
+use polars_utils::arena::{Arena, Node};
+
+use crate::plans::aexpr::AExpr;
+use crate::prelude::Operator;
+
+/// Walk the AExpr tree bottom-up, applying OR factoring at every OR node.
+/// Descends into every variant (not just AND/OR) so ORs nested under `Not`,
+/// `Function`, `Cast`, etc. are found.
+///
+/// Sound under Kleene K3: distributivity of AND over OR holds for null
+/// operands by case analysis.
+pub(crate) fn factor_or_in_aexpr(node: Node, expr_arena: &mut Arena<AExpr>) {
+    // Iterative pre-order into a Vec, then iterate reversed so descendants
+    // are visited before ancestors. Matches `traverse_and_hash_aexpr` /
+    // `MintermIter`.
+    let mut work = vec![node];
+    let mut post_order = Vec::new();
+    while let Some(n) = work.pop() {
+        post_order.push(n);
+        expr_arena.get(n).children_rev(&mut work);
+    }
+
+    for &n in post_order.iter().rev() {
+        if matches!(
+            expr_arena.get(n),
+            AExpr::BinaryExpr {
+                op: Operator::Or | Operator::LogicalOr,
+                ..
+            }
+        ) {
+            if let Some(factored) = try_factor_or(n, expr_arena) {
+                expr_arena.replace(n, factored);
+            }
+        }
+    }
+}
+
+/// Collect an expression's OR-tree branches into `out` (dual of `MintermIter`).
+fn collect_or_branches(root: Node, expr_arena: &Arena<AExpr>, out: &mut Vec<Node>) {
+    let mut stack = vec![root];
+    while let Some(top) = stack.pop() {
+        match expr_arena.get(top) {
+            AExpr::BinaryExpr {
+                left,
+                op: Operator::Or | Operator::LogicalOr,
+                right,
+            } => {
+                stack.push(*right);
+                stack.push(*left);
+            },
+            _ => out.push(top),
+        }
+    }
+}
+
+/// Try OR factoring on a node known to be an OR. Returns the rewritten
+/// top-level `AExpr` on success.
+fn try_factor_or(or_node: Node, expr_arena: &mut Arena<AExpr>) -> Option<AExpr> {
+    use std::hash::{BuildHasher, Hasher};
+
+    use polars_utils::aliases::{InitHashMaps, PlFixedStateQuality, PlHashMap};
+
+    use crate::plans::aexpr::{MintermIter, traverse_and_hash_aexpr};
+
+    let mut branches = Vec::new();
+    collect_or_branches(or_node, expr_arena, &mut branches);
+    if branches.len() < 2 {
+        return None;
+    }
+
+    let mut branch_terms: Vec<Vec<Node>> = branches
+        .iter()
+        .map(|&b| MintermIter::new(b, expr_arena).collect::<Vec<_>>())
+        .collect();
+
+    // Iterate the shortest branch as candidates: max commons is bounded by
+    // the smallest branch, so fewer candidates means fewer wasted scans.
+    // OR is commutative, so the sorted branch order is semantically identical.
+    branch_terms.sort_by_key(|terms| terms.len());
+
+    // Bucket each branch's conjuncts by structural hash so the cross-branch
+    // match is a hashmap lookup plus a final structural-equality check within
+    // the bucket, instead of a linear scan over every term. Drops the matching
+    // loop from O(T² × B × S) to O(T × B × S) for large fan-outs; one tree
+    // walk per conjunct for the hash, computed inline.
+    let hb = PlFixedStateQuality::with_seed(0);
+    let hash_of = |n: Node, arena: &Arena<AExpr>| -> u64 {
+        let mut h = hb.build_hasher();
+        traverse_and_hash_aexpr(n, arena, &mut h);
+        h.finish()
+    };
+    let buckets: Vec<PlHashMap<u64, Vec<usize>>> = branch_terms
+        .iter()
+        .map(|terms| {
+            let mut m: PlHashMap<u64, Vec<usize>> = PlHashMap::with_capacity(terms.len());
+            for (i, &n) in terms.iter().enumerate() {
+                m.entry(hash_of(n, expr_arena)).or_default().push(i);
+            }
+            m
+        })
+        .collect();
+
+    // `taken[b][i]` = "term i of branch b already claimed".
+    let mut common = Vec::new();
+    let mut taken: Vec<_> = branch_terms.iter().map(|t| vec![false; t.len()]).collect();
+    let (mut l_stack, mut r_stack) = (Vec::new(), Vec::new());
+
+    for (cand_idx, &cand) in branch_terms[0].iter().enumerate() {
+        let cand_expr = expr_arena.get(cand);
+        let cand_hash = hash_of(cand, expr_arena);
+
+        let Some(other_matches): Option<Vec<usize>> = (1..branch_terms.len())
+            .map(|b_idx| {
+                buckets[b_idx].get(&cand_hash).and_then(|ixs| {
+                    ixs.iter().copied().find(|&i| {
+                        !taken[b_idx][i]
+                            && cand_expr.is_expr_equal_to_amortized(
+                                expr_arena.get(branch_terms[b_idx][i]),
+                                expr_arena,
+                                &mut l_stack,
+                                &mut r_stack,
+                            )
+                    })
+                })
+            })
+            .collect()
+        else {
+            continue;
+        };
+
+        common.push(cand);
+        taken[0][cand_idx] = true;
+        for (offset, m) in other_matches.into_iter().enumerate() {
+            taken[offset + 1][m] = true;
+        }
+    }
+
+    if common.is_empty() {
+        return None;
+    }
+
+    // Rebuild branches without claimed conjuncts. `collect::<Option<_>>`
+    // short-circuits when any branch becomes empty; `None` then signals
+    // absorption in the match below (the OR drops out entirely).
+    let residuals: Option<Vec<Node>> = branch_terms
+        .into_iter()
+        .enumerate()
+        .map(|(b_idx, terms)| {
+            let kept: Vec<_> = terms
+                .into_iter()
+                .enumerate()
+                .filter_map(|(i, n)| (!taken[b_idx][i]).then_some(n))
+                .collect();
+            (!kept.is_empty()).then(|| combine_with(kept, Operator::And, expr_arena))
+        })
+        .collect();
+
+    // Final shape: left-skewed AND(common..., OR(residuals...)). If the OR
+    // collapsed (some branch went empty), absorption (`X ∨ (X ∧ A) → X`)
+    // drops the OR entirely: result is just the AND of commons.
+    let folded_node = match residuals {
+        Some(nodes) => {
+            let or_node = combine_with(nodes, Operator::Or, expr_arena);
+            let mut all_nodes = common;
+            all_nodes.push(or_node);
+            combine_with(all_nodes, Operator::And, expr_arena)
+        },
+        None => combine_with(common, Operator::And, expr_arena),
+    };
+    Some(expr_arena.get(folded_node).clone())
+}
+
+/// Left-fold a non-empty stream of nodes with `op`.
+fn combine_with(
+    nodes: impl IntoIterator<Item = Node>,
+    op: Operator,
+    expr_arena: &mut Arena<AExpr>,
+) -> Node {
+    nodes
+        .into_iter()
+        .reduce(|left, right| expr_arena.add(AExpr::BinaryExpr { left, op, right }))
+        .expect("combine_with: non-empty iterator")
+}

--- a/crates/polars-plan/src/plans/aexpr/or_factoring.rs
+++ b/crates/polars-plan/src/plans/aexpr/or_factoring.rs
@@ -1,7 +1,7 @@
 //! OR factoring: `(A∧X) ∨ (A∧Y) → A ∧ (X∨Y)`
 //!
 //! Pure AExpr rewrite, in place on `expr_arena`. Called from
-//! `canonicalize_predicate` before `SplitPredicates::new` walks the AND
+//! `simplify_predicate` before `SplitPredicates::new` walks the AND
 //! chain; factored commons become AND-conjuncts at the top, get split
 //! into their own `IR::Filter` nodes, and become visible to
 //! predicate-pushdown.

--- a/crates/polars-plan/src/plans/conversion/convert_utils.rs
+++ b/crates/polars-plan/src/plans/conversion/convert_utils.rs
@@ -1,4 +1,13 @@
 use super::*;
+use crate::plans::aexpr::or_factoring;
+
+/// Lift conjuncts shared across every OR branch to top-level ANDs
+/// (`(A∧X) ∨ (A∧Y) → A ∧ (X∨Y)`), so the `MintermIter` walk in
+/// `SplitPredicates::new` can split them into independent `IR::Filter`
+/// nodes for predicate-pushdown to route.
+pub(super) fn canonicalize_predicate(predicate: Node, expr_arena: &mut Arena<AExpr>) {
+    or_factoring::factor_or_in_aexpr(predicate, expr_arena);
+}
 
 /// Split expression that are ANDed into multiple Filter nodes as the optimizer can then
 /// push them down independently. Especially if they refer columns from different tables
@@ -16,7 +25,13 @@ pub(super) struct SplitPredicates {
 }
 
 impl SplitPredicates {
-    /// Returns None if a barrier expression is encountered
+    /// Walk `predicate`'s AND chain via `MintermIter`, route each conjunct
+    /// through `ExprPushdownGroup`, and bucket into `pushable` / `fallible`.
+    /// Returns `None` if any conjunct classifies as `Barrier` (caller falls
+    /// back to a single un-split Filter).
+    ///
+    /// Assumes `predicate` has been canonicalized upstream by
+    /// `canonicalize_predicate`. This function only splits.
     pub(super) fn new(
         predicate: Node,
         expr_arena: &mut Arena<AExpr>,

--- a/crates/polars-plan/src/plans/conversion/convert_utils.rs
+++ b/crates/polars-plan/src/plans/conversion/convert_utils.rs
@@ -5,7 +5,7 @@ use crate::plans::aexpr::or_factoring;
 /// (`(A∧X) ∨ (A∧Y) → A ∧ (X∨Y)`), so the `MintermIter` walk in
 /// `SplitPredicates::new` can split them into independent `IR::Filter`
 /// nodes for predicate-pushdown to route.
-pub(super) fn canonicalize_predicate(predicate: Node, expr_arena: &mut Arena<AExpr>) {
+pub(super) fn simplify_predicate(predicate: Node, expr_arena: &mut Arena<AExpr>) {
     or_factoring::factor_or_in_aexpr(predicate, expr_arena);
 }
 
@@ -29,9 +29,6 @@ impl SplitPredicates {
     /// through `ExprPushdownGroup`, and bucket into `pushable` / `fallible`.
     /// Returns `None` if any conjunct classifies as `Barrier` (caller falls
     /// back to a single un-split Filter).
-    ///
-    /// Assumes `predicate` has been canonicalized upstream by
-    /// `canonicalize_predicate`. This function only splits.
     pub(super) fn new(
         predicate: Node,
         expr_arena: &mut Arena<AExpr>,

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -13,7 +13,7 @@ use polars_utils::itertools::Itertools;
 use polars_utils::pl_path::PlRefPath;
 use polars_utils::unique_id::UniqueId;
 
-use super::convert_utils::SplitPredicates;
+use super::convert_utils::{SplitPredicates, canonicalize_predicate};
 use super::stack_opt::ConversionOptimizer;
 use super::*;
 use crate::constants::get_pl_element_name;
@@ -294,6 +294,12 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                     ctxt.opt_flags,
                 ),
             )?;
+
+            // Intentionally outside the pushdown opt-flag gate. The rewrites
+            // produce a structurally smaller predicate (fewer binary ops,
+            // fewer duplicated subexpressions), so per-row evaluation is
+            // cheaper even when pushdown is off.
+            canonicalize_predicate(predicate_ae.node(), ctxt.expr_arena);
 
             if ctxt.opt_flags.predicate_pushdown() {
                 ctxt.nodes_scratch.clear();

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -13,7 +13,7 @@ use polars_utils::itertools::Itertools;
 use polars_utils::pl_path::PlRefPath;
 use polars_utils::unique_id::UniqueId;
 
-use super::convert_utils::{SplitPredicates, canonicalize_predicate};
+use super::convert_utils::{SplitPredicates, simplify_predicate};
 use super::stack_opt::ConversionOptimizer;
 use super::*;
 use crate::constants::get_pl_element_name;
@@ -299,7 +299,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             // produce a structurally smaller predicate (fewer binary ops,
             // fewer duplicated subexpressions), so per-row evaluation is
             // cheaper even when pushdown is off.
-            canonicalize_predicate(predicate_ae.node(), ctxt.expr_arena);
+            simplify_predicate(predicate_ae.node(), ctxt.expr_arena);
 
             if ctxt.opt_flags.predicate_pushdown() {
                 ctxt.nodes_scratch.clear();

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -295,11 +295,11 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 ),
             )?;
 
-            // Intentionally outside the pushdown opt-flag gate. The rewrites
-            // produce a structurally smaller predicate (fewer binary ops,
-            // fewer duplicated subexpressions), so per-row evaluation is
-            // cheaper even when pushdown is off.
-            simplify_predicate(predicate_ae.node(), ctxt.expr_arena);
+            // Gated on `simplify_expr` so the rewrite can be disabled for
+            // differential testing and debugging.
+            if ctxt.opt_flags.simplify_expr() {
+                simplify_predicate(predicate_ae.node(), ctxt.expr_arena);
+            }
 
             if ctxt.opt_flags.predicate_pushdown() {
                 ctxt.nodes_scratch.clear();

--- a/py-polars/tests/unit/lazyframe/test_predicates.py
+++ b/py-polars/tests/unit/lazyframe/test_predicates.py
@@ -466,6 +466,26 @@ def test_predicate_reduction() -> None:
         )
 
 
+def test_or_factoring_hoists_shared_conjunct() -> None:
+    # `(a > 1 AND b > 4) OR (a > 1 AND c > 7)` shares `a > 1` across both OR
+    # branches. `simplify_predicate` factors it out so the predicate becomes
+    # `a > 1 AND (b > 4 OR c > 7)`.
+    lf = pl.LazyFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
+    query = lf.filter(
+        ((pl.col("a") > 1) & (pl.col("b") > 4))
+        | ((pl.col("a") > 1) & (pl.col("c") > 7))
+    )
+    plan = query.explain()
+    # Shared conjunct hoisted out (appears once, not twice).
+    assert plan.count('(col("a")) > (1)') == 1, plan
+    # Both residual branches survive the rewrite.
+    assert '(col("b")) > (4)' in plan, plan
+    assert '(col("c")) > (7)' in plan, plan
+
+    expected = pl.DataFrame({"a": [2, 3], "b": [5, 6], "c": [8, 9]})
+    assert_frame_equal(query.collect(), expected)
+
+
 def test_all_any_cleanup_at_single_predicate_case() -> None:
     plan = pl.LazyFrame({"a": [1], "b": [2]}).select(["a"]).drop_nulls().explain()
     assert "horizontal" not in plan


### PR DESCRIPTION
Filters of the form `(A AND X) OR (A AND Y) OR (A AND Z)` block predicate pushdown today: the OR keeps the whole predicate as one indivisible unit, so nothing reaches the scans. This PR rewrites them as `A AND (X OR Y OR Z)`, hoisting conjuncts shared across every OR branch to the top. From there, the shared parts push down independently as far as they can, reaching parquet scans as SELECTION and driving row-group pruning; the residual disjunction stays put. Users writing the natural SQL or DSL form of such queries now get the same plan as users who hand-decompose them.

## Benchmark

TPC-H Q19 on SF=10 (lineitem ~60M rows, part ~2M rows), parquet on local SSD, Apple M4 Pro (14-core, 48 GB RAM)

| form | A (base, no patch) | C (this PR) | A → C |
|---|---:|---:|---:|
| **SQL** (raw OR-of-ANDs via `pl.SQLContext`) | 3986.7 ms | 239.5 ms | **16.65×** |
| **DSL raw** (raw OR-of-ANDs in Polars expression syntax) | 1389.1 ms | 199.5 ms | **6.96×** |
| **DSL decomposed** (commons hoisted manually before the OR) | 196.9 ms | 196.5 ms | **1.00×** |
