### PR TITLE
fix: Share last-morsel split budget across files in streaming multi-scan

### DIFF
--- a/crates/polars-stream/src/nodes/io_sources/batch.rs
+++ b/crates/polars-stream/src/nodes/io_sources/batch.rs
@@ -181,6 +181,7 @@ impl FileReader for BatchFnReader {
             cast_columns_policy: _,
             num_pipelines: _,
             disable_morsel_split: _,
+            last_morsel_pipelines: _,
             callbacks:
                 FileReaderCallbacks {
                     mut file_schema_tx,

--- a/crates/polars-stream/src/nodes/io_sources/csv/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/csv/mod.rs
@@ -170,6 +170,7 @@ impl FileReader for CsvFileReader {
             cast_columns_policy: _,
             num_pipelines,
             disable_morsel_split: _,
+            last_morsel_pipelines: _,
             callbacks:
                 FileReaderCallbacks {
                     file_schema_tx,

--- a/crates/polars-stream/src/nodes/io_sources/ipc/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ipc/mod.rs
@@ -191,6 +191,7 @@ impl FileReader for IpcFileReader {
             cast_columns_policy: _,
             num_pipelines,
             disable_morsel_split,
+            last_morsel_pipelines,
             callbacks:
                 FileReaderCallbacks {
                     file_schema_tx,
@@ -407,7 +408,9 @@ impl FileReader for IpcFileReader {
         // Task: Distributor.
         // Distributes morsels across pipelines. This does not perform any CPU or I/O bound work -
         // it is purely a dispatch loop. Run on the computational executor to reduce context switches.
-        let last_morsel_min_split = num_pipelines;
+        //
+        // `last_morsel_pipelines` is precomputed at the multi-scan layer so the split budget is
+        // shared across files in the scan.
         let distribute_task = async_executor::spawn(TaskPriority::High, async move {
             let mut morsel_seq = MorselSeq::default();
             // Note: We don't use this (it is handled by the bridge). But morsels require a source token.
@@ -464,7 +467,7 @@ impl FileReader for IpcFileReader {
                     &df,
                     ideal_morsel_size,
                     next.is_none(),
-                    last_morsel_min_split,
+                    last_morsel_pipelines,
                 ) {
                     if morsel_send
                         .send_morsel(Morsel::new(df, morsel_seq, source_token.clone()))

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/components/row_deletions.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/components/row_deletions.rs
@@ -183,6 +183,7 @@ impl DeletionFilesProvider {
                                     cast_columns_policy: CastColumnsPolicy::ERROR_ON_MISMATCH,
                                     num_pipelines,
                                     disable_morsel_split: false,
+                                    last_morsel_pipelines: 1,
                                     callbacks: FileReaderCallbacks {
                                         file_schema_tx: None,
                                         n_rows_in_file_tx: None,

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/initialization.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/initialization.rs
@@ -411,6 +411,17 @@ async fn finish_initialize_multi_scan_pipeline(
     let max_concurrent_scans = config.max_concurrent_scans();
     let disable_morsel_split = config.disable_morsel_split;
 
+    // Share the last-morsel split budget across files in the scan: divide it by the number
+    // of files that can be in flight at once, so the total morsel count at end-of-file
+    // boundaries stays bounded by `num_pipelines`.
+    let n_effective_sources = sources.len().saturating_sub(
+        skip_files_mask
+            .as_ref()
+            .map_or(0, |m| m.num_skipped_files()),
+    );
+    let last_morsel_pipelines =
+        num_pipelines.div_ceil(n_effective_sources.min(max_concurrent_scans).max(1));
+
     let (started_reader_tx, started_reader_rx) =
         tokio::sync::mpsc::channel(max_concurrent_scans.max(2) - 1);
 
@@ -435,6 +446,7 @@ async fn finish_initialize_multi_scan_pipeline(
                 forbid_extra_columns: config.forbid_extra_columns.clone(),
                 num_pipelines,
                 disable_morsel_split,
+                last_morsel_pipelines,
                 verbose,
             },
             verbose,

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/models.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/models.rs
@@ -84,6 +84,8 @@ pub(super) struct StartReaderArgsConstant {
     pub(super) forbid_extra_columns: Option<ForbidExtraColumns>,
     pub(super) num_pipelines: usize,
     pub(super) disable_morsel_split: bool,
+    /// Precomputed last-morsel split factor; see `BeginReadArgs::last_morsel_pipelines`.
+    pub(super) last_morsel_pipelines: usize,
     pub(super) verbose: bool,
 }
 

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/tasks/reader_starter.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/tasks/reader_starter.rs
@@ -419,6 +419,7 @@ async fn start_reader_impl(
         forbid_extra_columns,
         num_pipelines,
         disable_morsel_split,
+        last_morsel_pipelines,
         verbose,
     } = constant_args;
 
@@ -616,6 +617,7 @@ async fn start_reader_impl(
         cast_columns_policy: cast_columns_policy.clone(),
         num_pipelines,
         disable_morsel_split,
+        last_morsel_pipelines,
         callbacks,
     };
 

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/reader_interface/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/reader_interface/mod.rs
@@ -150,6 +150,12 @@ pub struct BeginReadArgs {
 
     pub num_pipelines: usize,
     pub disable_morsel_split: bool,
+    /// Minimum number of pieces a reader should split a file's last morsel into, to keep
+    /// downstream pipelines busy. The multi-scan layer precomputes this so the per-file
+    /// budget is shared across files in the same scan. When many files are concurrent,
+    /// file-level parallelism already saturates the pipeline and per-file last-morsel
+    /// splitting just inflates metadata overhead.
+    pub last_morsel_pipelines: usize,
     pub callbacks: FileReaderCallbacks,
     // TODO
     // We could introduce dynamic `Option<Box<dyn Any>>` for the reader to use. That would help
@@ -168,6 +174,7 @@ impl Default for BeginReadArgs {
             cast_columns_policy: CastColumnsPolicy::ERROR_ON_MISMATCH,
             num_pipelines: 1,
             disable_morsel_split: false,
+            last_morsel_pipelines: 1,
             callbacks: FileReaderCallbacks::default(),
         }
     }

--- a/crates/polars-stream/src/nodes/io_sources/ndjson/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ndjson/mod.rs
@@ -169,6 +169,7 @@ impl FileReader for NDJsonFileReader {
 
             num_pipelines,
             disable_morsel_split: _,
+            last_morsel_pipelines: _,
             callbacks:
                 FileReaderCallbacks {
                     file_schema_tx,

--- a/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
@@ -183,7 +183,10 @@ impl ParquetReadImpl {
 
         // Distributes morsels across pipelines. This does not perform any CPU or I/O bound work -
         // it is purely a dispatch loop. Run on the computational executor to reduce context switches.
-        let last_morsel_min_split = self.config.num_pipelines;
+        //
+        // `last_morsel_pipelines` is precomputed by the multi-scan layer so the split budget
+        // is shared across files in the scan.
+        let last_morsel_pipelines = self.config.last_morsel_pipelines;
         let disable_morsel_split = self.disable_morsel_split;
         let distribute_task = async_executor::spawn(TaskPriority::High, async move {
             let mut morsel_seq = MorselSeq::default();
@@ -242,7 +245,7 @@ impl ParquetReadImpl {
                     &df,
                     ideal_morsel_size,
                     next.is_none(),
-                    last_morsel_min_split,
+                    last_morsel_pipelines,
                 ) {
                     if morsel_sender
                         .send_morsel(Morsel::new(df, morsel_seq, source_token.clone()))
@@ -364,7 +367,7 @@ pub(crate) fn split_to_morsels(
     df: &DataFrame,
     ideal_morsel_size: usize,
     last_morsel: bool,
-    last_morsel_min_split: usize,
+    last_morsel_pipelines: usize,
 ) -> impl Iterator<Item = DataFrame> + '_ {
     let mut n_morsels = if df.height() > 3 * ideal_morsel_size / 2 {
         // num_rows > (1.5 * ideal_morsel_size)
@@ -374,7 +377,7 @@ pub(crate) fn split_to_morsels(
     };
 
     if last_morsel {
-        n_morsels = n_morsels.max(last_morsel_min_split);
+        n_morsels = n_morsels.max(last_morsel_pipelines);
     }
 
     let rows_per_morsel = df.height().div_ceil(n_morsels).max(1);

--- a/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
@@ -179,6 +179,7 @@ impl FileReader for ParquetFileReader {
             cast_columns_policy: _,
             num_pipelines: _,
             disable_morsel_split: true,
+            last_morsel_pipelines: _,
             callbacks:
                 FileReaderCallbacks {
                     file_schema_tx: _,
@@ -207,6 +208,7 @@ impl FileReader for ParquetFileReader {
             cast_columns_policy,
             num_pipelines,
             disable_morsel_split,
+            last_morsel_pipelines,
             callbacks:
                 FileReaderCallbacks {
                     file_schema_tx,
@@ -337,6 +339,7 @@ impl FileReader for ParquetFileReader {
                 num_pipelines,
                 row_group_prefetch_size,
                 target_values_per_thread,
+                last_morsel_pipelines,
             },
             verbose,
             memory_prefetch_func,
@@ -448,6 +451,9 @@ struct Config {
     /// Minimum number of values for a parallel spawned task to process to amortize
     /// parallelism overhead.
     target_values_per_thread: usize,
+    /// Minimum number of pieces to split this file's last morsel into. Precomputed by the
+    /// multi-scan layer to share the parallelism budget across files.
+    last_morsel_pipelines: usize,
 }
 
 impl ParquetReadImpl {


### PR DESCRIPTION
Closes #27601.

Polars's streaming readers split each file's last morsel across `num_pipelines` to keep all threads busy at end-of-file boundaries. This works well for a single file, but with many files in flight the same `num_pipelines` floor is applied independently per file. The total morsel count at end-of-file boundaries scales as `files × num_pipelines`, and each morsel carries `~500 B × cols` of per-column metadata. [#27601](https://github.com/pola-rs/polars/issues/27601) shows this concretely: a streaming `scan_parquet` on ~1000 files (5000 cols × 1000 rows each, ~20 GB on disk) consumes **~300 GB of RSS** on a 128-core box.

This PR shares one last-morsel split budget across the scan instead of giving each file the full `num_pipelines`. With many concurrent files the per-file split shrinks toward 1; a single-file scan still gets the full `num_pipelines` split (preserving #21027). IPC has the identical bug and gets the same fix.

### Benchmark

The reporter's full shape needs 300 GB of RAM, so the bench is scaled down on a 14-core / 48 GB box. Per-file fingerprint is kept identical to the reporter's (5000 cols × 1000 rows × Float32, 21.37 MB/file); only file count and thread count are reduced. Median of 3 runs at 200 files:

|           |     Wall |       RSS |
|-----------|---------:|----------:|
| Unpatched |   2.48 s |   9.55 GB |
| Patched   |   0.57 s |   4.75 GB |
|           | **4.4×** | **2.0×**  |