### PR TITLE
fix(rust): Fix `filter_scan_ir` usize integer underflow

### DIFF
--- a/crates/polars-mem-engine/src/scan_predicate/functions.rs
+++ b/crates/polars-mem-engine/src/scan_predicate/functions.rs
@@ -541,7 +541,9 @@ where
             for (out_idx, source_idx) in selected_path_indices.clone().enumerate() {
                 if let Some(v) = deletions.get(&source_idx) {
                     out.get_or_insert_with(|| {
-                        PlIndexMap::with_capacity(selected_path_indices.size_hint().0 - out_idx)
+                        PlIndexMap::with_capacity(
+                            selected_path_indices.size_hint().0.saturating_sub(out_idx),
+                        )
                     })
                     .insert(out_idx, v.clone());
                 }


### PR DESCRIPTION
Issue: #27631 

This change fixes a `usize` integer underflow I encountered in `scan_parquet` when there is both a stats prune and a delete prune (passed via the kwargs `_table_statistics` and `_deletion_files`). The change is to use saturating_sub in place of regular subtraction on line 544 of `crates/polars-mem-engine/src/scan_predicate/functions.rs`.

1. I used AI to research and generate code to solve this issue.
2. I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.

Screenshots running `make test` as I am a first-time contributor:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0da03bf5-8a2e-4b44-beb2-b3d71ecf48bc" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7d5dc0e3-5a79-4645-88b6-3f94cd2e86a0" />

