### PR TITLE
chore(python): Match NumPy signature in `DataFrame.__array__` and `Series.__array__`

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -133,7 +133,6 @@ if TYPE_CHECKING:
 
     import deltalake
     import jax
-    import numpy.typing as npt
     import pyiceberg
     from great_tables import GT
     from xlsxwriter import Workbook
@@ -992,7 +991,7 @@ class DataFrame:
 
     def __array__(
         self,
-        dtype: npt.DTypeLike | None = None,
+        dtype: np.dtype[Any] | None = None,
         copy: bool | None = None,  # noqa: FBT001
     ) -> np.ndarray[Any, Any]:
         """

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -125,7 +125,6 @@ if TYPE_CHECKING:
     from collections.abc import Collection, Generator, Mapping
 
     import jax
-    import numpy.typing as npt
 
     from polars import DataFrame, DataType, Expr
     from polars._typing import (
@@ -1574,7 +1573,7 @@ class Series:
 
     def __array__(
         self,
-        dtype: npt.DTypeLike | None = None,
+        dtype: np.dtype[Any] | None = None,
         copy: bool | None = None,  # noqa: FBT001
     ) -> np.ndarray[Any, Any]:
         """


### PR DESCRIPTION
NumPy devs recommend using `np.dtype` as the type variable here https://github.com/numpy/numpy/issues/30873 (this also helps avoid some typing issues which would come up in #27049 )

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
