### PR TITLE
fix(rust): Reject non-numeric input in hist before processing bins (closes #27155)

### DIFF
--- a/crates/polars-ops/src/chunked_array/hist.rs
+++ b/crates/polars-ops/src/chunked_array/hist.rs
@@ -239,10 +239,9 @@ pub fn hist_series(
     include_category: bool,
     include_breakpoint: bool,
 ) -> PolarsResult<Series> {
-    // Reject non-numeric input before touching `bins`. Otherwise the bins
-    // processing below (cast → rechunk → cont_slice) can panic when the
-    // user calls `hist` on a non-numeric series — even though `hist` is
-    // not defined for such input. See #27155.
+    // Reject non-numeric input before processing `bins`, otherwise the
+    // cast/rechunk/cont_slice pipeline below panics on the Err from
+    // `cont_slice`. See #27155.
     polars_ensure!(s.dtype().is_primitive_numeric(), InvalidOperation: "'hist' is only supported for numeric data");
 
     let mut bins_arg = None;

--- a/crates/polars-ops/src/chunked_array/hist.rs
+++ b/crates/polars-ops/src/chunked_array/hist.rs
@@ -239,9 +239,6 @@ pub fn hist_series(
     include_category: bool,
     include_breakpoint: bool,
 ) -> PolarsResult<Series> {
-    // Reject non-numeric input before processing `bins`, otherwise the
-    // cast/rechunk/cont_slice pipeline below panics on the Err from
-    // `cont_slice`. See #27155.
     polars_ensure!(s.dtype().is_primitive_numeric(), InvalidOperation: "'hist' is only supported for numeric data");
 
     let mut bins_arg = None;

--- a/crates/polars-ops/src/chunked_array/hist.rs
+++ b/crates/polars-ops/src/chunked_array/hist.rs
@@ -239,6 +239,12 @@ pub fn hist_series(
     include_category: bool,
     include_breakpoint: bool,
 ) -> PolarsResult<Series> {
+    // Reject non-numeric input before touching `bins`. Otherwise the bins
+    // processing below (cast → rechunk → cont_slice) can panic when the
+    // user calls `hist` on a non-numeric series — even though `hist` is
+    // not defined for such input. See #27155.
+    polars_ensure!(s.dtype().is_primitive_numeric(), InvalidOperation: "'hist' is only supported for numeric data");
+
     let mut bins_arg = None;
 
     let owned_bins;
@@ -251,7 +257,6 @@ pub fn hist_series(
         let bins = bins.cont_slice().unwrap();
         bins_arg = Some(bins);
     };
-    polars_ensure!(s.dtype().is_primitive_numeric(), InvalidOperation: "'hist' is only supported for numeric data");
 
     let out = with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
          let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();

--- a/py-polars/tests/unit/operations/test_hist.py
+++ b/py-polars/tests/unit/operations/test_hist.py
@@ -167,7 +167,7 @@ def test_hist_non_numeric_dtype_raises() -> None:
     with pytest.raises(pl.exceptions.InvalidOperationError, match=msg):
         s.to_frame().select(pl.col("a").hist(bins=bins))
     with pytest.raises(pl.exceptions.InvalidOperationError, match=msg):
-        s.hist(bins=bins)
+        s.hist(bins=bins)  # type: ignore[arg-type]
     with pytest.raises(pl.exceptions.InvalidOperationError, match=msg):
         s.hist()
 

--- a/py-polars/tests/unit/operations/test_hist.py
+++ b/py-polars/tests/unit/operations/test_hist.py
@@ -160,6 +160,26 @@ def test_hist_invalid_bins() -> None:
         s.hist(bins=[1, 0])  # invalid order
 
 
+def test_hist_non_numeric_dtype_raises_not_panics() -> None:
+    # https://github.com/pola-rs/polars/issues/27155 — `hist` used to panic
+    # ("chunked array is not contiguous") when the input series was non-numeric
+    # because the `bins` argument was processed before the numeric-dtype check.
+    s = pl.Series("a", ["A", "G", "Y", "Z"])
+    bins = pl.Series("bins", ["N"])
+    with pytest.raises(
+        pl.exceptions.InvalidOperationError,
+        match="'hist' is only supported for numeric data",
+    ):
+        s.to_frame().select(pl.col("a").hist(bins=bins))
+    # Same check without `bins` — the pre-existing path that already errored
+    # cleanly; this just locks it in.
+    with pytest.raises(
+        pl.exceptions.InvalidOperationError,
+        match="'hist' is only supported for numeric data",
+    ):
+        s.hist()
+
+
 def test_hist_bin_outside_data() -> None:
     s = pl.Series([-5, 2, 0, 1, 99], dtype=pl.Int32)
     result = s.hist(bins=[-10, -9])

--- a/py-polars/tests/unit/operations/test_hist.py
+++ b/py-polars/tests/unit/operations/test_hist.py
@@ -161,30 +161,14 @@ def test_hist_invalid_bins() -> None:
 
 
 def test_hist_non_numeric_dtype_raises() -> None:
-    # https://github.com/pola-rs/polars/issues/27155 -- `hist` used to panic
-    # ("chunked array is not contiguous") when the input series was non-numeric
-    # because the `bins` argument was processed before the numeric-dtype check.
     s = pl.Series("a", ["A", "G", "Y", "Z"])
     bins = pl.Series("bins", ["N"])
-    # Lazy expression path (the original reporter's reproducer).
-    with pytest.raises(
-        pl.exceptions.InvalidOperationError,
-        match="'hist' is only supported for numeric data",
-    ):
+    msg = "'hist' is only supported for numeric data"
+    with pytest.raises(pl.exceptions.InvalidOperationError, match=msg):
         s.to_frame().select(pl.col("a").hist(bins=bins))
-    # Eager Series method with bins -- same underlying `hist_series`,
-    # different Python wrapper layer.
-    with pytest.raises(
-        pl.exceptions.InvalidOperationError,
-        match="'hist' is only supported for numeric data",
-    ):
+    with pytest.raises(pl.exceptions.InvalidOperationError, match=msg):
         s.hist(bins=bins)
-    # Eager without bins -- the pre-existing path that already errored
-    # cleanly; locked in as a regression guard.
-    with pytest.raises(
-        pl.exceptions.InvalidOperationError,
-        match="'hist' is only supported for numeric data",
-    ):
+    with pytest.raises(pl.exceptions.InvalidOperationError, match=msg):
         s.hist()
 
 

--- a/py-polars/tests/unit/operations/test_hist.py
+++ b/py-polars/tests/unit/operations/test_hist.py
@@ -160,19 +160,27 @@ def test_hist_invalid_bins() -> None:
         s.hist(bins=[1, 0])  # invalid order
 
 
-def test_hist_non_numeric_dtype_raises_not_panics() -> None:
+def test_hist_non_numeric_dtype_raises() -> None:
     # https://github.com/pola-rs/polars/issues/27155 — `hist` used to panic
     # ("chunked array is not contiguous") when the input series was non-numeric
     # because the `bins` argument was processed before the numeric-dtype check.
     s = pl.Series("a", ["A", "G", "Y", "Z"])
     bins = pl.Series("bins", ["N"])
+    # Lazy expression path (the original reporter's reproducer).
     with pytest.raises(
         pl.exceptions.InvalidOperationError,
         match="'hist' is only supported for numeric data",
     ):
         s.to_frame().select(pl.col("a").hist(bins=bins))
-    # Same check without `bins` — the pre-existing path that already errored
-    # cleanly; this just locks it in.
+    # Eager Series method with bins — same underlying `hist_series`, different
+    # Python wrapper layer.
+    with pytest.raises(
+        pl.exceptions.InvalidOperationError,
+        match="'hist' is only supported for numeric data",
+    ):
+        s.hist(bins=bins)
+    # Eager without bins — the pre-existing path that already errored cleanly;
+    # locked in as a regression guard.
     with pytest.raises(
         pl.exceptions.InvalidOperationError,
         match="'hist' is only supported for numeric data",

--- a/py-polars/tests/unit/operations/test_hist.py
+++ b/py-polars/tests/unit/operations/test_hist.py
@@ -161,7 +161,7 @@ def test_hist_invalid_bins() -> None:
 
 
 def test_hist_non_numeric_dtype_raises() -> None:
-    # https://github.com/pola-rs/polars/issues/27155 — `hist` used to panic
+    # https://github.com/pola-rs/polars/issues/27155 -- `hist` used to panic
     # ("chunked array is not contiguous") when the input series was non-numeric
     # because the `bins` argument was processed before the numeric-dtype check.
     s = pl.Series("a", ["A", "G", "Y", "Z"])
@@ -172,15 +172,15 @@ def test_hist_non_numeric_dtype_raises() -> None:
         match="'hist' is only supported for numeric data",
     ):
         s.to_frame().select(pl.col("a").hist(bins=bins))
-    # Eager Series method with bins — same underlying `hist_series`, different
-    # Python wrapper layer.
+    # Eager Series method with bins -- same underlying `hist_series`,
+    # different Python wrapper layer.
     with pytest.raises(
         pl.exceptions.InvalidOperationError,
         match="'hist' is only supported for numeric data",
     ):
         s.hist(bins=bins)
-    # Eager without bins — the pre-existing path that already errored cleanly;
-    # locked in as a regression guard.
+    # Eager without bins -- the pre-existing path that already errored
+    # cleanly; locked in as a regression guard.
     with pytest.raises(
         pl.exceptions.InvalidOperationError,
         match="'hist' is only supported for numeric data",


### PR DESCRIPTION
Closes #27155.

## Problem

`Series.hist(bins=...)` on a non-numeric series panicked at `cont_slice().unwrap()` (`crates/polars-ops/src/chunked_array/hist.rs:251`) with `chunked array is not contiguous`, rather than returning the clean `InvalidOperationError: 'hist' is only supported for numeric data` that the same call returns when `bins` is omitted.

Reproduces on polars 1.36.1:

```python
import polars as pl
s = pl.Series('a', ['A', 'G', 'Y', 'Z'])
bins = pl.Series('bins', ['N'])
s.to_frame().select(pl.col('a').hist(bins=bins))
# PanicException: called Result::unwrap() on an Err value:
#   ComputeError(ErrString("chunked array is not contiguous"))
```

## Root cause

The `polars_ensure!(s.dtype().is_primitive_numeric(), ...)` check in `hist_series` sat *after* the `bins` cast → rechunk → `cont_slice().unwrap()` pipeline. A non-numeric input series never reached the guard before the bins path tripped the unwrap.

## Fix

Move the numeric-dtype check to the top of `hist_series`. Semantics for numeric input are unchanged; the user-facing error string is identical to the pre-existing no-bins path.

## Test

`py-polars/tests/unit/operations/test_hist.py::test_hist_non_numeric_dtype_raises` exercises three surfaces — lazy expression with `bins`, eager `Series.hist(bins=...)`, eager `Series.hist()` — on a string series. The first two panicked on `main`; all three now return `InvalidOperationError`.

## Out of scope (known sibling case)

This PR only fixes the path reported in #27155 — non-numeric **input series**. A symmetric panic likely still occurs when the input series is numeric but `bins` itself is non-castable (e.g. `pl.Series([1,2,3]).hist(bins=pl.Series(["N"]))`), because the silent string→f64-null cast produces a non-contiguous f64 array that still trips `cont_slice().unwrap()`. Happy to send a follow-up if maintainers want the symmetric `bins` check; flagging now to keep this PR tight to the reported issue.

## AI disclosure

1. I used **Claude Code (Anthropic)** to locate the panic site, write the one-line move + the regression test, draft this PR description, and produce the code-and-test diff. The change went through an internal independent reviewer pass before opening this PR.
2. I confirm that I have reviewed all changes myself, manually reproduced the panic on polars 1.36.1 to verify the fix addresses the actual reported behaviour, and ran `cargo check -p polars-ops` locally.