### PR TITLE
fix: Remove duplicate column in match_to_schema error message formatting

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -776,7 +776,6 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                     write!(&mut formatted, ", \"{c}\"").unwrap();
                 }
 
-                write!(&mut formatted, "\"{lst}\"").unwrap();
                 polars_bail!(SchemaMismatch: "missing columns in `match_to_schema`: {formatted}");
             }
 


### PR DESCRIPTION
## Summary

Fixes the badly formatted error message in `match_to_schema` when multiple columns are missing. Previously, the first column name was duplicated at the end of the formatted list without proper separator, producing output like `"b", "c""b"` instead of `"b", "c"`.

Closes #27256

## Root Cause

In `crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs`, the missing columns error formatting had three write operations:

1. `write!(&mut formatted, "\"{}\"", found_missing_columns[0])` — writes the first column
2. Loop: `write!(&mut formatted, ", \"{c}\"")` — writes remaining columns with comma prefix
3. `write!(&mut formatted, "\"{lst}\"")` — **BUG**: re-writes the first column again without comma prefix

Line 3 was a duplicate that appended the first element at the end, corrupting the output.

## Fix

Removed the duplicate `write!(&mut formatted, "\"{lst}\"")` line (line 779). The first column is already written on the first write operation.

## Changes

- `crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs` (+0 -1)

## Testing

- ✅ Two missing columns `["b", "c"]` → now formats as `"b", "c"` (was `"b", "c""b"`)
- ✅ Single missing column `["a"]` → unchanged, still formats as `"a"` (loop body never executes)
- ✅ Extra columns error formatting (lines 787-799) is unaffected — separate code path