### PR TITLE
feat(reduce): add `GroupedReduction::is_group_done` trait method

### DIFF
--- a/crates/polars-expr/src/reduce/mod.rs
+++ b/crates/polars-expr/src/reduce/mod.rs
@@ -120,6 +120,21 @@ pub trait GroupedReduction: Any + Send + Sync {
     /// After this operation the number of groups is reset to 0.
     fn finalize(&mut self) -> PolarsResult<Series>;
 
+    /// Returns whether the specified group is done (has reached a terminal
+    /// state and does not need to see any more data).
+    ///
+    /// The streaming engine uses this hook to short-circuit reductions that
+    /// have already determined their per-group result, e.g. `first` after the
+    /// first value, `any` after a `true`, `all` after a `false`.
+    ///
+    /// The default returns `false` (no short-circuit). Implementations may
+    /// override where a terminal state is observable.
+    ///
+    /// See issue #27586.
+    fn is_group_done(&self, _group_idx: IdxSize) -> bool {
+        false
+    }
+
     /// Returns this GroupedReduction as a dyn Any.
     fn as_any(&self) -> &dyn Any;
 }


### PR DESCRIPTION
Closes #27586.

Adds `is_group_done(&self, group_idx: IdxSize) -> bool` on the `GroupedReduction` trait with a default of `false`. Per @orlp's 2026-05-13 scope refinement: trait method on `GroupedReduction` only (re-used for the non-grouped variant), executor passes the group index, no group-by changes. Existing reductions keep their current behaviour via the default impl.

## Test plan

Honest disclosure: I attempted the `make test` screenshot from Windows native per CONTRIBUTING.md but hit `LNK4003: invalid library format` on `libpolars_ops.rlib` from MSVC's linker after working through multiple toolchain layers. `nightly-2026-04-01` is verified active in the repo dir. I'll redo locally on WSL2 / Linux if you'd like the screenshot before merge - just let me know.

The change is purely additive (new trait method with default `false`, +15 lines on one file) and no existing implementation overrides it.
