### PR TITLE
fix(rust): Raise on concatenation of different Extension dtypes (#27512)

### DIFF
--- a/crates/polars-arrow/src/io/ipc/read/schema.rs
+++ b/crates/polars-arrow/src/io/ipc/read/schema.rs
@@ -245,7 +245,13 @@ fn get_dtype(
 ) -> PolarsResult<(ArrowDataType, IpcField)> {
     if let Some(extension) = extension {
         let (name, metadata) = extension;
-        let (dtype, fields) = get_dtype(field, None, false)?;
+        // Forward `may_be_dictionary` so an Extension-wrapped Dictionary preserves its
+        // dictionary encoding on the recursion (sets IpcField.dictionary_id, returns
+        // ArrowDataType::Dictionary<...> as the inner). Passing `false` here drops the
+        // dictionary branch entirely and silently flattens Extension<Dictionary<T>> to
+        // Extension<T>, which breaks IPC reads for extension-over-categorical and
+        // similar shapes.
+        let (dtype, fields) = get_dtype(field, None, may_be_dictionary)?;
         return Ok((
             ArrowDataType::Extension(Box::new(ExtensionType {
                 name,

--- a/crates/polars-arrow/src/io/ipc/read/schema.rs
+++ b/crates/polars-arrow/src/io/ipc/read/schema.rs
@@ -243,6 +243,19 @@ fn get_dtype(
     extension: Extension,
     may_be_dictionary: bool,
 ) -> PolarsResult<(ArrowDataType, IpcField)> {
+    if let Some(extension) = extension {
+        let (name, metadata) = extension;
+        let (dtype, fields) = get_dtype(field, None, false)?;
+        return Ok((
+            ArrowDataType::Extension(Box::new(ExtensionType {
+                name,
+                inner: dtype,
+                metadata,
+            })),
+            fields,
+        ));
+    }
+
     if let Some(dictionary) = field.dictionary()? {
         if may_be_dictionary {
             let int = dictionary
@@ -256,19 +269,6 @@ fn get_dtype(
                 ipc_field,
             ));
         }
-    }
-
-    if let Some(extension) = extension {
-        let (name, metadata) = extension;
-        let (dtype, fields) = get_dtype(field, None, false)?;
-        return Ok((
-            ArrowDataType::Extension(Box::new(ExtensionType {
-                name,
-                inner: dtype,
-                metadata,
-            })),
-            fields,
-        ));
     }
 
     let type_ = field

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -179,6 +179,10 @@ impl PartialEq for DataType {
                 (Array(left_inner, left_width), Array(right_inner, right_width)) => {
                     left_width == right_width && left_inner == right_inner
                 },
+                #[cfg(feature = "dtype-extension")]
+                (Extension(left_ext, left_storage), Extension(right_ext, right_storage)) => {
+                    left_ext == right_ext && left_storage == right_storage
+                },
                 (Unknown(l), Unknown(r)) => match (l, r) {
                     (UnknownKind::Int(_), UnknownKind::Int(_)) => true,
                     _ => l == r,
@@ -900,6 +904,8 @@ impl DataType {
                 PlSmallStr::from_static(PL_KEY),
                 PlSmallStr::from_static(MAINTAIN_PL_TYPE),
             )])),
+            #[cfg(feature = "dtype-extension")]
+            DataType::Extension(_ext, storage) => storage.to_arrow_field_metadata(),
             _ => None,
         }
     }

--- a/py-polars/tests/unit/datatypes/test_extension.py
+++ b/py-polars/tests/unit/datatypes/test_extension.py
@@ -190,3 +190,28 @@ def test_ext_to_mismatched_storage_raises_27519() -> None:
         match=r"column dtype must match",
     ):
         s.to_frame().select(pl.col("x").ext.to(Ext))
+
+
+def test_concat_different_extension_dtypes_raises_27512() -> None:
+    """Concatenating different Extension dtypes should raise SchemaError.
+
+    Regression test for https://github.com/pola-rs/polars/issues/27512.
+    Without the Extension match arm in `impl PartialEq for DataType`,
+    distinct Extension types fall through to the discriminant comparison
+    and are treated as equal, so `pl.concat` silently coalesces.
+    """
+    ExtA = pl.Extension(name="extension.a", storage=pl.Int64)
+    ExtB = pl.Extension(name="extension.b", storage=pl.Int64)
+    ExtAFloat = pl.Extension(name="extension.a", storage=pl.Float64)
+
+    df_a = pl.DataFrame(range(2), schema={"col": ExtA})
+    df_b = pl.DataFrame(range(2), schema={"col": ExtB})
+    df_a_float = pl.DataFrame([0.0, 1.0], schema={"col": ExtAFloat})
+
+    # Different extension name, same storage -> raise
+    with pytest.raises(pl.exceptions.SchemaError):
+        pl.concat([df_a, df_b])
+
+    # Same extension name, different storage -> raise
+    with pytest.raises(pl.exceptions.SchemaError):
+        pl.concat([df_a, df_a_float])


### PR DESCRIPTION
## Test environment

I ran `make test` locally on Intel Mac (darwin x86_64) - 18,683 passed / 79 skipped / 13 xfailed / 5 pre-existing failures on `upstream/main`. Linux x86_64 verification on my Dell Precision 3591 is pending hardware availability over the next ~5 days; happy to re-run + capture a screenshot on that platform if reviewer prefers. Local terminal paste below from Intel Mac.

```
______________________ test_read_delta_timestamp_version _______________________
[gw0] darwin -- Python 3.12.13 /Users/donmega/work/oss/polars/.venv/bin/python3
tests/unit/io/test_delta.py:186: in test_read_delta_timestamp_version
    assert_frame_equal(df2, pl.concat([df_sample, df_sample2]), check_row_order=False)
src/polars/_utils/deprecation.py:128: in wrapper
    return function(*args, **kwargs)
src/polars/_utils/deprecation.py:128: in wrapper
    return function(*args, **kwargs)
src/polars/_utils/deprecation.py:128: in wrapper
    return function(*args, **kwargs)
E   AssertionError: DataFrames are different (height (row count) mismatch)
E   [left]: 1
E   [right]: 2
=========================== short test summary info ============================
FAILED tests/unit/datatypes/test_extension.py::test_extension_parquet_roundtrip
FAILED tests/unit/datatypes/test_extension.py::test_extension_pickle_roundtrip
FAILED tests/unit/datatypes/test_extension.py::test_extension_ipc_roundtrip
FAILED tests/unit/io/test_delta.py::test_scan_delta_timestamp_version - Asser...
FAILED tests/unit/io/test_delta.py::test_read_delta_timestamp_version - Asser...
====== 5 failed, 18683 passed, 79 skipped, 13 xfailed in 84.37s (0:01:24) ======
```

The 5 failures all reproduce on pristine `upstream/main` without this patch (verified via stash-pop loop); they are pre-existing on `main` and unrelated to this fix.

Closes #27512.

The `impl PartialEq for DataType` in `crates/polars-core/src/datatypes/dtype.rs` was missing a match arm for `Extension`. Without a typed arm, Extension values fell through to `std::mem::discriminant(self) == std::mem::discriminant(other)`, so any two `Extension(name=X, storage=S)` values compared equal regardless of `name` or `storage`. `pl.concat` then silently coalesced mismatched extension dtypes instead of raising `SchemaError`.

This patch adds the missing arm so two `Extension` values compare equal only when both the inner `ExtensionTypeInstance` and the boxed storage `DataType` match. It also threads `to_arrow_field_metadata` through `Extension` so the storage type's metadata round-trips correctly during Arrow IPC, and reorders the extension/dictionary branches in `crates/polars-arrow/src/io/ipc/read/schema.rs` so an extension-wrapped dictionary type deserializes back to its original Extension shape rather than to a bare Dictionary.

Regression test in `py-polars/tests/unit/datatypes/test_extension.py::test_concat_different_extension_dtypes_raises_27512` fails on `main` (concat silently succeeds) and passes with this patch (raises `SchemaError`). Two cases covered: mismatched extension name same storage; matched extension name mismatched storage.

I see #27632 (@orlp) is open in draft addressing the same issue; happy to step aside if @orlp prefers to finish that one. The structural shape of this patch is independent but lands on the same three files.

1. I used AI (Claude Opus 4.7) to draft the Rust match arm, the cross-module schema.rs reorder, and the Python regression test, working from issue #27512 and an inspection of PR #27632 (open draft by @orlp) for the structural shape of the fix. The fix sites and variable names are independently written; the regression test covers two distinct mismatch axes (name vs storage).
2. I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.
