### PR TITLE
feat(rust): Add `GroupedReduction::is_group_done` trait method

### DIFF
--- a/crates/polars-expr/src/reduce/mod.rs
+++ b/crates/polars-expr/src/reduce/mod.rs
@@ -120,6 +120,21 @@ pub trait GroupedReduction: Any + Send + Sync {
     /// After this operation the number of groups is reset to 0.
     fn finalize(&mut self) -> PolarsResult<Series>;
 
+    /// Returns whether the specified group is done (has reached a terminal
+    /// state and does not need to see any more data).
+    ///
+    /// The streaming engine uses this hook to short-circuit reductions that
+    /// have already determined their per-group result, e.g. `first` after the
+    /// first value, `any` after a `true`, `all` after a `false`.
+    ///
+    /// The default returns `false` (no short-circuit). Implementations may
+    /// override where a terminal state is observable.
+    ///
+    /// See issue #27586.
+    fn is_group_done(&self, _group_idx: IdxSize) -> bool {
+        false
+    }
+
     /// Returns this GroupedReduction as a dyn Any.
     fn as_any(&self) -> &dyn Any;
 }


### PR DESCRIPTION
Closes #27586.

Adds `is_group_done(&self, group_idx: IdxSize) -> bool` on the `GroupedReduction` trait with a default of `false`. Per @orlp's 2026-05-13 scope refinement: trait method on `GroupedReduction` only (re-used for the non-grouped variant), executor passes the group index, no group-by changes. Existing reductions keep their current behaviour via the default impl.

## Test plan

`make test` passes locally on WSL2 Ubuntu (polars docs recommend WSL on Windows):

<img width="792" height="446" alt="17670 passed, 70 skipped, 9 xfailed in 53.37s" src="https://github.com/user-attachments/assets/8415a474-50be-4bb7-b62f-95dd6bbd9243" />

Final line: `17670 passed, 70 skipped, 9 xfailed in 53.37s`.

