### PR TITLE
fix(python): allow Expr arguments in DataFrame.unpivot

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -9809,10 +9809,13 @@ class DataFrame:
         │ z   ┆ c        ┆ 6     │
         └─────┴──────────┴───────┘
         """
-        on = None if on is None else _expand_selectors(self, on)
-        index = [] if index is None else _expand_selectors(self, index)
+        from polars.lazyframe.opt_flags import QueryOptFlags
 
-        return self._from_pydf(self._df.unpivot(on, index, value_name, variable_name))
+        return (
+            self.lazy()
+            .unpivot(on, index=index, variable_name=variable_name, value_name=value_name)
+            .collect(optimizations=QueryOptFlags._eager())
+        )
 
     def unstack(
         self,

--- a/py-polars/tests/unit/operations/test_unpivot.py
+++ b/py-polars/tests/unit/operations/test_unpivot.py
@@ -318,3 +318,55 @@ def test_unpivot_projection_pushdown_schema_25720() -> None:
             ]
         ),
     )
+
+
+# https://github.com/pola-rs/polars/issues/27037
+def test_unpivot_expr_on_27037() -> None:
+    df = pl.DataFrame({"x": [1, 2], "y": [3, 4], "z": ["a", "b"]})
+
+    # Single Expr in `on`
+    result = df.unpivot(pl.col("x"))
+    expected = pl.DataFrame({"variable": ["x", "x"], "value": [1, 2]})
+    assert_frame_equal(result, expected, check_row_order=False)
+
+    # Single Expr in `index`
+    result = df.unpivot(pl.col("x"), index=pl.col("z"))
+    expected = pl.DataFrame(
+        {
+            "z": ["a", "b"],
+            "variable": ["x", "x"],
+            "value": [1, 2],
+        }
+    )
+    assert_frame_equal(result, expected, check_row_order=False)
+
+    # pl.col shorthand attribute access
+    result = df.unpivot(pl.col.x)
+    expected = pl.DataFrame({"variable": ["x", "x"], "value": [1, 2]})
+    assert_frame_equal(result, expected, check_row_order=False)
+
+    # Expr with pattern matching (wildcard)
+    result = df.unpivot(pl.col("^[xy]$"))
+    expected = pl.DataFrame(
+        {
+            "variable": ["x", "x", "y", "y"],
+            "value": [1, 2, 3, 4],
+        }
+    )
+    assert_frame_equal(result, expected, check_row_order=False)
+
+    # Expr in both `on` and `index`
+    result = df.unpivot(pl.col("x"), index=pl.col("z"), variable_name="var", value_name="val")
+    expected = pl.DataFrame(
+        {
+            "z": ["a", "b"],
+            "var": ["x", "x"],
+            "val": [1, 2],
+        }
+    )
+    assert_frame_equal(result, expected, check_row_order=False)
+
+    # DataFrame result matches LazyFrame result
+    lf_result = df.lazy().unpivot(pl.col("x"), index=pl.col("z")).collect()
+    df_result = df.unpivot(pl.col("x"), index=pl.col("z"))
+    assert_frame_equal(df_result, lf_result, check_row_order=False)


### PR DESCRIPTION
# Fix: Allow `Expr` arguments in `DataFrame.unpivot` (#27037)

## Summary

`DataFrame.unpivot` raised a `TypeError` when passed an `Expr` (e.g.
`pl.col.x`, `pl.col("x")`) for `on` or `index`. This made it
inconsistent with `LazyFrame.unpivot`, which handled expressions
correctly.

```python
# Before this fix — TypeError
pl.select(x=1, y=2).unpivot(pl.col.x)
# TypeError: argument 'on': 'Expr' object cannot be cast as 'str'

# After this fix — works as expected
pl.select(x=1, y=2).unpivot(pl.col.x)
# shape: (1, 2)
# ┌──────────┬───────┐
# │ variable ┆ value │
# │ ---      ┆ ---   │
# │ str      ┆ i32   │
# ╞══════════╪═══════╡
# │ x        ┆ 1     │
# └──────────┴───────┘
```

## Root Cause

`DataFrame.unpivot` called `_expand_selectors` on the `on` and `index`
arguments before forwarding them to the Rust binding. `_expand_selectors`
expands `Selector` objects into column name strings but passes everything
else through unchanged — including `Expr` objects. The Rust binding
(`self._df.unpivot`) only accepts strings, so any `Expr` caused a
`TypeError`.

`LazyFrame.unpivot` correctly handled this case by routing through
`parse_list_into_selector` → `parse_into_selector`, which calls
`expr.meta.as_selector()` to convert an `Expr` to a selector before
passing it to Rust.

## Fix

Delegate `DataFrame.unpivot` to the lazy path, using the same pattern
already established by `DataFrame.unnest`:

```python
# Before
def unpivot(self, on=None, *, index=None, variable_name=None, value_name=None):
    ...
    on = None if on is None else _expand_selectors(self, on)
    index = [] if index is None else _expand_selectors(self, index)
    return self._from_pydf(self._df.unpivot(on, index, value_name, variable_name))

# After
def unpivot(self, on=None, *, index=None, variable_name=None, value_name=None):
    ...
    from polars.lazyframe.opt_flags import QueryOptFlags
    return (
        self.lazy()
        .unpivot(on, index=index, variable_name=variable_name, value_name=value_name)
        .collect(optimizations=QueryOptFlags._eager())
    )
```

This is a net reduction in code: the eager implementation had duplicated
selector-expansion logic that is better handled once in `LazyFrame.unpivot`.
Using `QueryOptFlags._eager()` disables all query optimisations so the
eager collect is semantically equivalent to the previous direct Rust call.

## Affected Files

- `py-polars/src/polars/dataframe/frame.py` — implementation change (3
  lines removed, 6 added)
- `py-polars/tests/unit/operations/test_unpivot.py` — regression test
  covering six expression variants

## Testing

All 13 tests in `test_unpivot.py` pass, including the new
`test_unpivot_expr_on_27037` test which covers:

- `pl.col("x")` in `on`
- `pl.col.x` shorthand in `on`
- `Expr` with regex pattern matching (`pl.col("^[xy]$")`)
- `Expr` in `index`
- `Expr` in both `on` and `index` with custom `variable_name`/`value_name`
- Parity check: `DataFrame.unpivot(expr)` produces the same result as
  `LazyFrame.unpivot(expr).collect()`

All pre-existing tests for selectors, string column names, `None` `on`,
empty DataFrames, categorical types, and predicate pushdown continue to
pass.

## Checklist

- [x] Fixes the reported bug
- [x] No behaviour change for existing callers (strings, selectors, `None`)
- [x] Follows the codebase pattern established by `DataFrame.unnest`
- [x] New regression test added
- [x] All existing tests pass

Fixes #27037
