### PR TITLE
fix(python): Make `next()` on `GroupBy` set up iteration state if needed

### DIFF
--- a/py-polars/src/polars/dataframe/group_by.py
+++ b/py-polars/src/polars/dataframe/group_by.py
@@ -138,6 +138,9 @@ class GroupBy:
         return self
 
     def __next__(self) -> tuple[tuple[Any, ...], DataFrame]:
+        if not hasattr(self, "_current_index"):
+            # next() was called before iter(); set up iteration state.
+            iter(self)
         if self._current_index >= len(self._group_indices):
             raise StopIteration
 
@@ -919,6 +922,9 @@ class RollingGroupBy:
         return self
 
     def __next__(self) -> tuple[tuple[object, ...], DataFrame]:
+        if not hasattr(self, "_current_index"):
+            # next() was called before iter(); set up iteration state.
+            iter(self)
         if self._current_index >= len(self._group_indices):
             raise StopIteration
 
@@ -1109,6 +1115,9 @@ class DynamicGroupBy:
         return self
 
     def __next__(self) -> tuple[tuple[object, ...], DataFrame]:
+        if not hasattr(self, "_current_index"):
+            # next() was called before iter(); set up iteration state.
+            iter(self)
         if self._current_index >= len(self._group_indices):
             raise StopIteration
 

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -577,6 +577,15 @@ def test_group_by_iteration() -> None:
     assert result3 == expected3
 
 
+def test_group_by_next_without_iter() -> None:
+    df = pl.DataFrame({"foo": [1, 2, 3, 4]})
+    # next() previously raised AttributeError because _current_index was
+    # only set in __iter__; check that it now yields the first group.
+    group, data = next(df.group_by("foo", maintain_order=True))
+    assert group == (1,)
+    assert data.rows() == [(1,)]
+
+
 def test_group_by_iteration_selector() -> None:
     df = pl.DataFrame({"a": ["one", "two", "one", "two"], "b": [1, 2, 3, 4]})
     result = dict(df.group_by(cs.string()))


### PR DESCRIPTION
Closes #12868.

`next(GroupBy(...))` raised `AttributeError: 'GroupBy' object has no attribute '_current_index'` because the iteration state was only set inside `__iter__`. `next()` now calls `iter(self)` when those attributes are missing, so it behaves the same as `next(iter(gb))`.

Same fix applied to `RollingGroupBy` and `DynamicGroupBy` which share the pattern. Test covers the dataframe `GroupBy` path.

Verified locally on installed v1.34.0 (the patched group_by.py now returns the first group instead of raising).