### PR TITLE
chore: Harden against async blocking deadlocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3070,6 +3070,7 @@ dependencies = [
  "crossbeam-utils",
  "parking_lot",
  "pin-project-lite",
+ "polars-config",
  "polars-error",
  "polars-utils",
  "rand 0.9.2",

--- a/crates/polars-async/Cargo.toml
+++ b/crates/polars-async/Cargo.toml
@@ -19,6 +19,7 @@ rand = { workspace = true }
 slotmap = { workspace = true }
 tokio = { workspace = true }
 
+polars-config = { workspace = true }
 polars-error = { workspace = true }
 polars-utils = { workspace = true }
 

--- a/crates/polars-async/src/executor/mod.rs
+++ b/crates/polars-async/src/executor/mod.rs
@@ -27,11 +27,15 @@ use task::{Cancellable, DynTask, Runnable};
 
 thread_local! {
     pub static ALLOW_RAYON_THREADS: Cell<bool> = const { Cell::new(true) };
+    pub static THREAD_SPAWNED_BY_POLARS_EXECUTOR: Cell<bool> = const { Cell::new(false) };
+
+    /// Used to store which executor thread this is.
+    static TLS_THREAD_ID: Cell<usize> = const { Cell::new(usize::MAX) };
 }
 
-static NUM_EXECUTOR_THREADS: RelaxedCell<usize> = RelaxedCell::new_usize(0);
-pub fn set_num_threads(t: usize) {
-    NUM_EXECUTOR_THREADS.store(t);
+/// Returns whether this thread is actively used for scheduling tasks.
+pub fn is_scheduling_polars_executor_thread() -> bool {
+    TLS_THREAD_ID.get() != usize::MAX
 }
 
 static TRACK_METRICS: RelaxedCell<bool> = RelaxedCell::new_bool(false);
@@ -41,11 +45,6 @@ pub fn track_task_metrics(should_track: bool) {
 }
 
 static GLOBAL_SCHEDULER: OnceLock<Executor> = OnceLock::new();
-
-thread_local!(
-    /// Used to store which executor thread this is.
-    static TLS_THREAD_ID: Cell<usize> = const { Cell::new(usize::MAX) };
-);
 
 slotmap::new_key_type! {
     struct TaskKey;
@@ -281,6 +280,7 @@ impl Executor {
     fn runner(&self, initial_thread_id: Option<usize>) {
         TLS_THREAD_ID.set(initial_thread_id.unwrap_or(usize::MAX));
         ALLOW_RAYON_THREADS.set(false);
+        THREAD_SPAWNED_BY_POLARS_EXECUTOR.set(true);
 
         let mut rng = SmallRng::from_rng(&mut rand::rng());
         let mut worker = self.park_group.new_worker();
@@ -396,13 +396,7 @@ impl Executor {
 
     fn global() -> &'static Executor {
         GLOBAL_SCHEDULER.get_or_init(|| {
-            let mut n_threads = NUM_EXECUTOR_THREADS.load();
-            if n_threads == 0 {
-                n_threads = std::thread::available_parallelism()
-                    .map(|n| n.get())
-                    .unwrap_or(4);
-            }
-
+            let n_threads = polars_config::config().max_threads();
             let thread_task_lists = (0..n_threads)
                 .map(|t| {
                     std::thread::Builder::new()

--- a/crates/polars-async/src/lib.rs
+++ b/crates/polars-async/src/lib.rs
@@ -55,7 +55,7 @@ impl RuntimeManager {
     /// over this thread's task execution duties.
     ///
     /// Simply directly calls f() if this thread is not an async executor thread.
-    pub fn block_in_place<R, F: FnOnce() -> R>(f: F) -> R {
+    pub fn block_in_place<R, F: FnOnce() -> R>(&self, f: F) -> R {
         if THREAD_SPAWNED_BY_POLARS_EXECUTOR.get() {
             executor::block_in_place(f)
         } else {

--- a/crates/polars-async/src/lib.rs
+++ b/crates/polars-async/src/lib.rs
@@ -1,2 +1,119 @@
+use std::sync::{Arc, LazyLock};
+
+use polars_error::polars_warn;
+use polars_utils::relaxed_cell::RelaxedCell;
+use tokio::runtime::{Builder, Runtime};
+
+use crate::executor::{THREAD_SPAWNED_BY_POLARS_EXECUTOR, is_scheduling_polars_executor_thread};
+
 pub mod executor;
 pub mod primitives;
+
+pub struct RuntimeManager {
+    rt: Runtime,
+}
+
+impl RuntimeManager {
+    fn new() -> Self {
+        let n_threads = std::env::var("POLARS_ASYNC_THREAD_COUNT")
+            .map(|x| x.parse::<usize>().expect("integer"))
+            .unwrap_or(usize::min(polars_config::config().max_threads(), 32));
+
+        let max_blocking = std::env::var("POLARS_MAX_BLOCKING_THREAD_COUNT")
+            .map(|x| x.parse::<usize>().expect("integer"))
+            .unwrap_or(512);
+
+        if polars_config::config().verbose() {
+            eprintln!("async thread count: {n_threads}");
+            eprintln!("blocking thread count: {max_blocking}");
+        }
+
+        let max_total_threads = n_threads + max_blocking;
+        let warned = RelaxedCell::new_bool(false);
+        let tokio_thread_count_start = Arc::new(RelaxedCell::new_i64(0));
+        let tokio_thread_count_stop = tokio_thread_count_start.clone();
+
+        let rt = Builder::new_multi_thread()
+            .worker_threads(n_threads)
+            .max_blocking_threads(max_blocking)
+            .on_thread_start(move || {
+                if tokio_thread_count_start.fetch_add(1) + 1 >= (max_total_threads as i64) && !warned.load() {
+                    warned.store(true);
+                    polars_warn!("POLARS_MAX_BLOCKING_THREAD_COUNT reached ({max_blocking}), this may indicate a deadlock");
+                }
+            })
+            .on_thread_stop(move || { tokio_thread_count_stop.fetch_sub(1); })
+            .enable_io()
+            .enable_time()
+            .build()
+            .unwrap();
+
+        Self { rt }
+    }
+
+    /// Runs the given function on this thread while allowing another thread to take
+    /// over this thread's task execution duties.
+    ///
+    /// Simply directly calls f() if this thread is not an async executor thread.
+    pub fn block_in_place<R, F: FnOnce() -> R>(f: F) -> R {
+        if THREAD_SPAWNED_BY_POLARS_EXECUTOR.get() {
+            executor::block_in_place(f)
+        } else {
+            tokio::task::block_in_place(f)
+        }
+    }
+
+    /// Blocks this thread to evaluate the given future.
+    ///
+    /// This is more expensive than block_on when called from an async runtime
+    /// worker thread because other async tasks scheduled to run on this thread
+    /// have to be moved to a new thread.
+    ///
+    /// If more than POLARS_MAX_BLOCKING_THREAD_COUNT calls to this occur
+    /// simultaneously a deadlock may occur.
+    pub fn block_in_place_on<F>(&self, future: F) -> F::Output
+    where
+        F: Future,
+    {
+        if THREAD_SPAWNED_BY_POLARS_EXECUTOR.get() {
+            executor::block_in_place(|| self.rt.block_on(future))
+        } else {
+            tokio::task::block_in_place(|| self.rt.block_on(future))
+        }
+    }
+
+    /// Blocks this thread to evaluate the given future.
+    ///
+    /// Panics if the current thread is an async runtime worker thread.
+    pub fn block_on<F>(&self, future: F) -> F::Output
+    where
+        F: Future,
+    {
+        assert!(
+            !is_scheduling_polars_executor_thread(),
+            "block_on may not be called from within a polars async executor runtime worker thread"
+        );
+        self.rt.block_on(future)
+    }
+
+    /// Spawns a future onto the Tokio runtime (see [`tokio::runtime::Runtime::spawn`]).
+    pub fn spawn<F>(&self, future: F) -> tokio::task::JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        self.rt.spawn(future)
+    }
+
+    // See [`tokio::runtime::Runtime::spawn_blocking`].
+    pub fn spawn_blocking<F, R>(&self, f: F) -> tokio::task::JoinHandle<R>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        self.rt.spawn_blocking(f)
+    }
+}
+
+/// The global Polars async runtime accessor.
+pub static ASYNC: LazyLock<RuntimeManager> = LazyLock::new(RuntimeManager::new);

--- a/crates/polars-config/src/lib.rs
+++ b/crates/polars-config/src/lib.rs
@@ -23,6 +23,13 @@ const DEFAULT_WARN_UNKNOWN_CONFIG: bool = false;
 const WARN_UNSTABLE: &str = "POLARS_WARN_UNSTABLE";
 const DEFAULT_WARN_UNSTABLE: bool = true;
 
+const MAX_THREADS: &str = "POLARS_MAX_THREADS";
+fn default_max_threads() -> u64 {
+    std::thread::available_parallelism()
+        .unwrap_or(std::num::NonZeroUsize::new(4).unwrap())
+        .get() as u64
+}
+
 const IDEAL_MORSEL_SIZE: &str = "POLARS_IDEAL_MORSEL_SIZE";
 const STREAMING_CHUNK_SIZE: &str = "POLARS_STREAMING_CHUNK_SIZE"; // Backwards compatibility.
 const DEFAULT_IDEAL_MORSEL_SIZE: u64 = 100_000;
@@ -76,6 +83,7 @@ static KNOWN_OPTIONS: &[&str] = &[
     VERBOSE,
     WARN_UNKNOWN_CONFIG,
     WARN_UNSTABLE,
+    MAX_THREADS,
     IDEAL_MORSEL_SIZE,
     STREAMING_CHUNK_SIZE,
     ENGINE_AFFINITY,
@@ -121,6 +129,7 @@ pub struct Config {
     verbose: AtomicBool,
     warn_unknown_config: AtomicBool,
     warn_unstable: AtomicBool,
+    max_threads: AtomicU64,
     ideal_morsel_size: AtomicU64,
     engine_affinity: AtomicU8,
     parquet_binary_statistics_truncate_length: AtomicU64,
@@ -145,6 +154,7 @@ impl Config {
             verbose: AtomicBool::new(DEFAULT_VERBOSE),
             warn_unknown_config: AtomicBool::new(DEFAULT_WARN_UNKNOWN_CONFIG),
             warn_unstable: AtomicBool::new(DEFAULT_WARN_UNSTABLE),
+            max_threads: AtomicU64::new(default_max_threads()),
             ideal_morsel_size: AtomicU64::new(DEFAULT_IDEAL_MORSEL_SIZE),
             engine_affinity: AtomicU8::new(DEFAULT_ENGINE_AFFINITY as u8),
             parquet_binary_statistics_truncate_length: AtomicU64::new(
@@ -202,6 +212,11 @@ impl Config {
             VERBOSE => self.verbose.store(
                 val.and_then(|x| parse::parse_bool(var, x))
                     .unwrap_or(DEFAULT_VERBOSE),
+                Ordering::Relaxed,
+            ),
+            MAX_THREADS => self.max_threads.store(
+                val.and_then(|x| parse::parse_u64(var, x))
+                    .unwrap_or(default_max_threads()),
                 Ordering::Relaxed,
             ),
             IDEAL_MORSEL_SIZE | STREAMING_CHUNK_SIZE => self.ideal_morsel_size.store(
@@ -301,6 +316,11 @@ impl Config {
     /// Whether we should warn when unstable features are used.
     pub fn warn_unstable(&self) -> bool {
         self.warn_unstable.load(Ordering::Relaxed)
+    }
+
+    /// The number of threads Polars should ideally use for CPU-intensive work.
+    pub fn max_threads(&self) -> usize {
+        self.max_threads.load(Ordering::Relaxed).try_into().unwrap()
     }
 
     /// The ideal size of a morsel, in rows.

--- a/crates/polars-core/src/runtime.rs
+++ b/crates/polars-core/src/runtime.rs
@@ -5,7 +5,6 @@ use std::sync::mpsc::{TryRecvError, sync_channel};
 
 use polars_utils::with_drop::WithDrop;
 use rayon::{ThreadPool, ThreadPoolBuilder, Yield};
-use tokio::runtime::{Builder, Runtime};
 
 pub struct RAYON;
 

--- a/crates/polars-core/src/runtime.rs
+++ b/crates/polars-core/src/runtime.rs
@@ -197,15 +197,7 @@ impl RAYON {
 pub static THREAD_POOL: LazyLock<ThreadPool> = LazyLock::new(|| {
     let thread_name = std::env::var("POLARS_THREAD_NAME").unwrap_or_else(|_| "polars".to_string());
     ThreadPoolBuilder::new()
-        .num_threads(
-            std::env::var("POLARS_MAX_THREADS")
-                .map(|s| s.parse::<usize>().expect("integer"))
-                .unwrap_or_else(|_| {
-                    std::thread::available_parallelism()
-                        .unwrap_or(std::num::NonZeroUsize::new(1).unwrap())
-                        .get()
-                }),
-        )
+        .num_threads(polars_config::config().max_threads())
         .thread_name(move |i| format!("{thread_name}-{i}"))
         .build()
         .expect("could not spawn threads")
@@ -220,74 +212,4 @@ pub static THREAD_POOL: LazyLock<ThreadPool> = LazyLock::new(|| {
         .expect("could not create pool")
 });
 
-pub struct AsyncRuntime {
-    rt: Runtime,
-}
-
-impl AsyncRuntime {
-    fn new() -> Self {
-        let n_threads = std::env::var("POLARS_ASYNC_THREAD_COUNT")
-            .map(|x| x.parse::<usize>().expect("integer"))
-            .unwrap_or(usize::min(RAYON.current_num_threads(), 32));
-
-        let max_blocking = std::env::var("POLARS_MAX_BLOCKING_THREAD_COUNT")
-            .map(|x| x.parse::<usize>().expect("integer"))
-            .unwrap_or(512);
-
-        if crate::config::verbose() {
-            eprintln!("async thread count: {n_threads}");
-            eprintln!("blocking thread count: {max_blocking}");
-        }
-
-        let rt = Builder::new_multi_thread()
-            .worker_threads(n_threads)
-            .max_blocking_threads(max_blocking)
-            .enable_io()
-            .enable_time()
-            .build()
-            .unwrap();
-
-        Self { rt }
-    }
-
-    /// Forcibly blocks this thread to evaluate the given future. This can be
-    /// dangerous and lead to deadlocks if called re-entrantly on an async
-    /// worker thread as the entire thread pool can end up blocking, leading to
-    /// a deadlock. If you want to prevent this use block_on, which will panic
-    /// if called from an async thread.
-    pub fn block_in_place_on<F>(&self, future: F) -> F::Output
-    where
-        F: Future,
-    {
-        tokio::task::block_in_place(|| self.rt.block_on(future))
-    }
-
-    /// Blocks this thread to evaluate the given future. Panics if the current
-    /// thread is an async runtime worker thread.
-    pub fn block_on<F>(&self, future: F) -> F::Output
-    where
-        F: Future,
-    {
-        self.rt.block_on(future)
-    }
-
-    /// Spawns a future onto the Tokio runtime (see [`tokio::runtime::Runtime::spawn`]).
-    pub fn spawn<F>(&self, future: F) -> tokio::task::JoinHandle<F::Output>
-    where
-        F: Future + Send + 'static,
-        F::Output: Send + 'static,
-    {
-        self.rt.spawn(future)
-    }
-
-    // See [`tokio::runtime::Runtime::spawn_blocking`].
-    pub fn spawn_blocking<F, R>(&self, f: F) -> tokio::task::JoinHandle<R>
-    where
-        F: FnOnce() -> R + Send + 'static,
-        R: Send + 'static,
-    {
-        self.rt.spawn_blocking(f)
-    }
-}
-
-pub static ASYNC: LazyLock<AsyncRuntime> = LazyLock::new(AsyncRuntime::new);
+pub use polars_async::ASYNC;

--- a/crates/polars-io/src/file_cache/eviction.rs
+++ b/crates/polars-io/src/file_cache/eviction.rs
@@ -169,7 +169,8 @@ impl EvictionManager {
             loop {
                 let this: &'static mut Self = unsafe { std::mem::transmute(&mut self) };
 
-                let result = tokio::task::spawn_blocking(|| this.update_file_list())
+                let result = ASYNC
+                    .spawn_blocking(|| this.update_file_list())
                     .await
                     .unwrap();
 
@@ -186,7 +187,7 @@ impl EvictionManager {
                                 );
                             }
 
-                            tokio::task::block_in_place(|| self.evict_files(&guard));
+                            ASYNC.block_in_place(|| self.evict_files(&guard));
                             break;
                         }
                         tokio::time::sleep(Duration::from_secs(7)).await;

--- a/crates/polars-io/src/ipc/ipc_reader_async.rs
+++ b/crates/polars-io/src/ipc/ipc_reader_async.rs
@@ -5,6 +5,7 @@ use object_store::ObjectMeta;
 use object_store::path::Path;
 use polars_core::datatypes::IDX_DTYPE;
 use polars_core::frame::DataFrame;
+use polars_core::runtime::ASYNC;
 use polars_core::schema::{Schema, SchemaExt};
 use polars_error::{PolarsResult, polars_bail, polars_err, to_compute_err};
 use polars_utils::mmap::MMapSemaphore;
@@ -138,7 +139,7 @@ impl IpcReaderAsync {
     ) -> PolarsResult<DataFrame> {
         // TODO: Only download what is needed rather than the entire file by
         // making use of the projection, row limit, predicate and such.
-        let file = tokio::task::block_in_place(|| self.cache_entry.try_open_check_latest())?;
+        let file = ASYNC.block_in_place(|| self.cache_entry.try_open_check_latest())?;
         let bytes = MMapSemaphore::new_from_file(&file).unwrap();
 
         let projection = match options.projection.as_deref() {
@@ -187,7 +188,7 @@ impl IpcReaderAsync {
     pub async fn count_rows(&self, _metadata: Option<&FileMetadata>) -> PolarsResult<i64> {
         // TODO: Only download what is needed rather than the entire file by
         // making use of the projection, row limit, predicate and such.
-        let file = tokio::task::block_in_place(|| self.cache_entry.try_open_check_latest())?;
+        let file = ASYNC.block_in_place(|| self.cache_entry.try_open_check_latest())?;
         let bytes = MMapSemaphore::new_from_file(&file).unwrap();
         get_row_count(&mut std::io::Cursor::new(bytes.as_ref()))
     }

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -767,9 +767,7 @@ impl LazyFrame {
             chunk_size,
         )?;
         let runner = move || {
-            // We use a tokio spawn_blocking here as it has a high blocking
-            // thread pool limit.
-
+            // We use spawn_blocking here as it has a high blocking thread pool limit.
             polars_core::runtime::ASYNC.spawn_blocking(move || {
                 if let Err(e) = ldf.collect_with_engine(engine) {
                     runner_send.send(Err(e)).ok();

--- a/crates/polars-mem-engine/src/executors/cache.rs
+++ b/crates/polars-mem-engine/src/executors/cache.rs
@@ -105,13 +105,13 @@ impl Executor for CachePrefiller {
                 scan_handles.push(ASYNC.spawn(async move {
                     let _permit = parallel_scan_exec_limit.acquire().await.unwrap();
 
-                    tokio::task::spawn_blocking(move || {
-                        prefill.execute(&mut state)?;
-
-                        Ok(())
-                    })
-                    .await
-                    .unwrap()
+                    ASYNC
+                        .spawn_blocking(move || {
+                            prefill.execute(&mut state)?;
+                            Ok(())
+                        })
+                        .await
+                        .unwrap()
                 }));
 
                 continue;

--- a/crates/polars-stream/src/execute.rs
+++ b/crates/polars-stream/src/execute.rs
@@ -4,7 +4,7 @@ use crossbeam_channel::Sender;
 use parking_lot::Mutex;
 use polars_async::executor;
 use polars_core::frame::DataFrame;
-use polars_core::runtime::{ASYNC, RAYON};
+use polars_core::runtime::ASYNC;
 use polars_error::PolarsResult;
 use polars_expr::state::ExecutionState;
 use polars_utils::aliases::PlHashSet;
@@ -302,15 +302,11 @@ pub fn execute_graph(
     graph: &mut Graph,
     metrics: Option<Arc<Mutex<GraphMetrics>>>,
 ) -> PolarsResult<SparseSecondaryMap<GraphNodeKey, DataFrame>> {
-    // Get the number of threads from the rayon thread-pool as that respects our config.
-    let num_pipelines = RAYON.current_num_threads();
-    executor::set_num_threads(num_pipelines);
-
     let (query_tasks_send, query_tasks_recv) = crossbeam_channel::unbounded();
     let (subphase_tasks_send, subphase_tasks_recv) = crossbeam_channel::unbounded();
 
     let state = StreamingExecutionState {
-        num_pipelines,
+        num_pipelines: polars_config::config().max_threads(),
         in_memory_exec_state: ExecutionState::default(),
         query_tasks_send,
         subphase_tasks_send,

--- a/crates/polars-utils/src/relaxed_cell.rs
+++ b/crates/polars-utils/src/relaxed_cell.rs
@@ -126,6 +126,7 @@ macro_rules! impl_relaxed_cell {
 impl_relaxed_cell!(u8, new_u8, AtomicU8);
 impl_relaxed_cell!(u32, new_u32, AtomicU32);
 impl_relaxed_cell!(u64, new_u64, AtomicU64);
+impl_relaxed_cell!(i64, new_i64, AtomicI64);
 impl_relaxed_cell!(usize, new_usize, AtomicUsize);
 
 impl RelaxedCell<bool> {


### PR DESCRIPTION
Supersedes https://github.com/pola-rs/polars/pull/27545. I moved the async runtime manager to `polars_async` and made methods for `block_in_place` and `block_on` that work for both runtimes.