### PR TITLE
chore: Print Python traceback when POLARS_TIMEOUT_MS is exceeded

### DIFF
--- a/crates/polars-python/src/timeout.rs
+++ b/crates/polars-python/src/timeout.rs
@@ -20,26 +20,35 @@ static TIMEOUT_REQUEST_HANDLER: LazyLock<Sender<TimeoutRequest>> = LazyLock::new
 });
 
 enum TimeoutRequest {
-    Start(Duration, u64),
+    Start(Duration, u64, Option<String>),
     Cancel(u64),
 }
 
-pub fn get_timeout() -> Option<Duration> {
+pub fn is_timeout_enabled() -> bool {
     static TIMEOUT_DISABLED: RelaxedCell<bool> = RelaxedCell::new_bool(false);
 
     // Fast path so we don't have to keep checking environment variables. Make
     // sure that if you want to use POLARS_TIMEOUT_MS it is set before the first
     // polars call.
     if TIMEOUT_DISABLED.load() {
+        return false;
+    }
+
+    let var = std::env::var("POLARS_TIMEOUT_MS").ok();
+    if var.is_some_and(|v| !v.is_empty()) {
+        TIMEOUT_DISABLED.store(true);
+        return false;
+    }
+
+    true
+}
+
+pub fn get_timeout() -> Option<Duration> {
+    if !is_timeout_enabled() {
         return None;
     }
 
-    let Ok(timeout) = std::env::var("POLARS_TIMEOUT_MS") else {
-        TIMEOUT_DISABLED.store(true);
-        return None;
-    };
-
-    match timeout.parse() {
+    match std::env::var("POLARS_TIMEOUT_MS").unwrap().parse() {
         Ok(ms) => Some(Duration::from_millis(ms)),
         Err(e) => {
             eprintln!("failed to parse POLARS_TIMEOUT_MS: {e:?}");
@@ -50,20 +59,27 @@ pub fn get_timeout() -> Option<Duration> {
 
 fn timeout_thread(recv: Receiver<TimeoutRequest>) {
     let mut active_timeouts: PlHashSet<u64> = PlHashSet::new();
-    let mut shortest_timeout: BinaryHeap<Priority<Reverse<Duration>, u64>> = BinaryHeap::new();
+    #[allow(clippy::type_complexity)]
+    let mut shortest_timeout: BinaryHeap<Priority<Reverse<Duration>, (u64, Option<String>)>> =
+        BinaryHeap::new();
     loop {
         // Remove cancelled requests.
-        while let Some(Priority(_, id)) = shortest_timeout.peek() {
+        while let Some(Priority(_, (id, _))) = shortest_timeout.peek() {
             if active_timeouts.contains(id) {
                 break;
             }
             shortest_timeout.pop();
         }
 
-        let request = if let Some(Priority(timeout, _)) = shortest_timeout.peek() {
+        let request = if let Some(Priority(timeout, (_, traceback))) = shortest_timeout.peek() {
             match recv.recv_timeout(timeout.0) {
                 Err(RecvTimeoutError::Timeout) => {
-                    eprintln!("exiting the process, POLARS_TIMEOUT_MS exceeded");
+                    eprint!("exiting the process, POLARS_TIMEOUT_MS exceeded");
+                    if let Some(tb) = traceback {
+                        eprintln!(", traceback:\n{tb}");
+                    } else {
+                        eprintln!(", traceback unavailable");
+                    }
                     std::thread::sleep(Duration::from_secs_f64(1.0));
                     std::process::exit(1);
                 },
@@ -74,8 +90,8 @@ fn timeout_thread(recv: Receiver<TimeoutRequest>) {
         };
 
         match request {
-            TimeoutRequest::Start(duration, id) => {
-                shortest_timeout.push(Priority(Reverse(duration), id));
+            TimeoutRequest::Start(duration, id, traceback) => {
+                shortest_timeout.push(Priority(Reverse(duration), (id, traceback)));
                 active_timeouts.insert(id);
             },
             TimeoutRequest::Cancel(id) => {
@@ -85,13 +101,13 @@ fn timeout_thread(recv: Receiver<TimeoutRequest>) {
     }
 }
 
-pub fn schedule_polars_timeout() -> Option<u64> {
+pub fn schedule_polars_timeout(traceback: Option<String>) -> Option<u64> {
     static TIMEOUT_ID: RelaxedCell<u64> = RelaxedCell::new_u64(0);
 
     let timeout = get_timeout()?;
     let id = TIMEOUT_ID.fetch_add(1);
     TIMEOUT_REQUEST_HANDLER
-        .send(TimeoutRequest::Start(timeout, id))
+        .send(TimeoutRequest::Start(timeout, id, traceback))
         .unwrap();
     Some(id)
 }

--- a/crates/polars-python/src/timeout.rs
+++ b/crates/polars-python/src/timeout.rs
@@ -35,7 +35,7 @@ pub fn is_timeout_enabled() -> bool {
     }
 
     let var = std::env::var("POLARS_TIMEOUT_MS").ok();
-    if var.is_some_and(|v| !v.is_empty()) {
+    if var.is_none_or(|v| v.is_empty()) {
         TIMEOUT_DISABLED.store(true);
         return false;
     }

--- a/crates/polars-python/src/utils.rs
+++ b/crates/polars-python/src/utils.rs
@@ -6,12 +6,13 @@ use polars_error::PolarsResult;
 use polars_error::signals::{KeyboardInterrupt, catch_keyboard_interrupt};
 use pyo3::exceptions::PyKeyboardInterrupt;
 use pyo3::marker::Ungil;
+use pyo3::types::PyAnyMethods;
 use pyo3::{PyErr, PyResult, Python};
 
 use crate::dataframe::PyDataFrame;
 use crate::error::PyPolarsErr;
 use crate::series::PySeries;
-use crate::timeout::{cancel_polars_timeout, schedule_polars_timeout};
+use crate::timeout::{cancel_polars_timeout, is_timeout_enabled, schedule_polars_timeout};
 
 /// Calls method on downcasted ChunkedArray for all possible publicly exposed Polars dtypes.
 #[macro_export]
@@ -130,7 +131,14 @@ impl EnterPolarsExt for Python<'_> {
         T: Ungil + Send,
         E: Ungil + Send + Into<PyPolarsErr>,
     {
-        let timeout = schedule_polars_timeout();
+        let timeout = if is_timeout_enabled() {
+            let tb = self.import(pyo3::intern!(self, "traceback"))?;
+            let format_stack = tb.getattr("format_stack")?;
+            let lines: Vec<String> = format_stack.call0()?.extract()?;
+            schedule_polars_timeout(Some(lines.join("\n")))
+        } else {
+            None
+        };
         let ret = self.detach(|| catch_keyboard_interrupt(AssertUnwindSafe(f)));
         cancel_polars_timeout(timeout);
         match ret {

--- a/crates/polars-python/src/utils.rs
+++ b/crates/polars-python/src/utils.rs
@@ -124,6 +124,13 @@ pub trait EnterPolarsExt {
     }
 }
 
+fn get_traceback(py: Python<'_>) -> PyResult<String> {
+    let tb = py.import(pyo3::intern!(py, "traceback"))?;
+    let format_stack = tb.getattr("format_stack")?;
+    let lines: Vec<String> = format_stack.call0()?.extract()?;
+    Ok(lines.join("\n"))
+}
+
 impl EnterPolarsExt for Python<'_> {
     fn enter_polars<T, E, F>(self, f: F) -> PyResult<T>
     where
@@ -132,10 +139,7 @@ impl EnterPolarsExt for Python<'_> {
         E: Ungil + Send + Into<PyPolarsErr>,
     {
         let timeout = if is_timeout_enabled() {
-            let tb = self.import(pyo3::intern!(self, "traceback"))?;
-            let format_stack = tb.getattr("format_stack")?;
-            let lines: Vec<String> = format_stack.call0()?.extract()?;
-            schedule_polars_timeout(Some(lines.join("\n")))
+            schedule_polars_timeout(get_traceback(self).ok())
         } else {
             None
         };

--- a/crates/polars-python/src/utils.rs
+++ b/crates/polars-python/src/utils.rs
@@ -139,6 +139,7 @@ impl EnterPolarsExt for Python<'_> {
         E: Ungil + Send + Into<PyPolarsErr>,
     {
         let timeout = if is_timeout_enabled() {
+            std::hint::cold_path();
             schedule_polars_timeout(get_traceback(self).ok())
         } else {
             None


### PR DESCRIPTION
This will allow us to more easily find out *what* failed when a test times out.

To achieve this we have to eagerly grab a traceback every time `enter_polars` is called. This is quite a performance impact, but `POLARS_TIMEOUT_MS` is only a debugging tool.