### PR TITLE
fix: Put AsOf join buffered Morsels back the front of the deque if we cannot process them rn

### DIFF
--- a/crates/polars-stream/src/nodes/joins/asof_join.rs
+++ b/crates/polars-stream/src/nodes/joins/asof_join.rs
@@ -309,7 +309,7 @@ async fn distribute_work_task(
             } else {
                 // The right pipe is empty at this stage, we will need to wait for
                 // a new stage and try again.
-                left_buffer.push_back(left_df);
+                left_buffer.push_front(left_df);
                 stop_and_buffer_pipe_contents(recv_left.as_mut(), &mut |df| {
                     left_buffer.push_back(df)
                 })

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -1818,3 +1818,21 @@ def test_join_asof_maintain_order_left_27526() -> None:
     assert q.collect(engine="streaming")["id"].is_sorted(), (
         "expected asof_join to maintain left ordering"
     )
+
+
+def test_join_asof_buffer_ordering_27619() -> None:
+    n = 10
+    for n_dataframes in range(1, 20):
+        linspace = pl.select(pl.linear_space(0, 1, n).alias("a"))
+        left_dfs = pl.concat(
+            [linspace.lazy()]
+            + [linspace.slice(0, 0).lazy() for _ in range(n_dataframes - 1)]
+        )
+        left_lazy = left_dfs.set_sorted("a")
+        right_lazy = left_dfs.select(pl.col("a") - 0.5).set_sorted("a")
+        q = left_lazy.join_asof(
+            right_lazy,
+            on="a",
+            check_sortedness=False,
+        )
+        assert_frame_equal(q.collect(engine="streaming"), q.collect(engine="in-memory"))


### PR DESCRIPTION
Fixes #27619

:robot: After breaking my head on this for several hours, AI (copilot+sonnet 4.6) found the cause of the bug (after 60 mins of breaking its head on it). I wrote all of the code myself.
