### PR TITLE
feat: Cache and shuffle DNS for cloud object_store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,6 +3273,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "fast-float2",
+ "fastrand",
  "flate2",
  "fs4",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6235,8 +6235,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "tikv-jemallocator"
-version = "0.6.0"
-source = "git+https://github.com/pola-rs/jemallocator?rev=c7991e5bb6b3e9f79db6b0f48dcda67c5c3d2936#c7991e5bb6b3e9f79db6b0f48dcda67c5c3d2936"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2779,7 +2779,7 @@ dependencies = [
 [[package]]
 name = "object_store"
 version = "0.13.2"
-source = "git+https://github.com/apache/arrow-rs-object-store?rev=6f1c9acc94636e059a2b3aef5c75e815e065cc89#6f1c9acc94636e059a2b3aef5c75e815e065cc89"
+source = "git+https://github.com/kdn36/arrow-rs-object-store?branch=feat_pub_client_builder#0ee48e16f6f8f6c1f2611d2305458a0e2b2d18b9"
 dependencies = [
  "async-trait",
  "base64",
@@ -3298,6 +3298,7 @@ dependencies = [
  "polars-time",
  "polars-utils",
  "pyo3",
+ "rand 0.9.2",
  "rayon",
  "regex",
  "reqwest",
@@ -6233,3 +6234,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "git+https://github.com/pola-rs/jemallocator?rev=c7991e5bb6b3e9f79db6b0f48dcda67c5c3d2936#c7991e5bb6b3e9f79db6b0f48dcda67c5c3d2936"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2779,7 +2779,7 @@ dependencies = [
 [[package]]
 name = "object_store"
 version = "0.13.2"
-source = "git+https://github.com/kdn36/arrow-rs-object-store?branch=feat_pub_client_builder#0ee48e16f6f8f6c1f2611d2305458a0e2b2d18b9"
+source = "git+https://github.com/kdn36/arrow-rs-object-store?branch=feat_with_dns_resolver#f50a6e5c564b2b5933eca15cd20ff9b5614374a1"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,8 @@ crossbeam-utils = "0.8.20"
 either = "1.14"
 ethnum = "1.3.2"
 fallible-streaming-iterator = "0.1.9"
-fastrand = "2.3.0"
 fast-float2 = { version = "^0.2.2" }
+fastrand = "2.3.0"
 flate2 = { version = "1", default-features = false }
 foldhash = "0.2.0"
 futures = "0.3.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ collapsible_if = "allow"
 [patch.crates-io]
 # packed_simd_2 = { git = "https://github.com/rust-lang/packed_simd", rev = "e57c7ba11386147e6d2cbad7c88f376aab4bdc86" }
 # simd-json = { git = "https://github.com/ritchie46/simd-json", branch = "alignment" }
-object_store = { git = "https://github.com/kdn36/arrow-rs-object-store", branch = "feat_pub_client_builder" }
+object_store = { git = "https://github.com/kdn36/arrow-rs-object-store", branch = "feat_with_dns_resolver" }
 color-backtrace = { git = "https://github.com/orlp/color-backtrace", rev = "bb62ccf1e9eb1f6b7af5f16acff1fd7151a876dd" }
 
 [profile.mindebug-dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ collapsible_if = "allow"
 [patch.crates-io]
 # packed_simd_2 = { git = "https://github.com/rust-lang/packed_simd", rev = "e57c7ba11386147e6d2cbad7c88f376aab4bdc86" }
 # simd-json = { git = "https://github.com/ritchie46/simd-json", branch = "alignment" }
-object_store = { git = "https://github.com/apache/arrow-rs-object-store", rev = "6f1c9acc94636e059a2b3aef5c75e815e065cc89" }
+object_store = { git = "https://github.com/kdn36/arrow-rs-object-store", branch = "feat_pub_client_builder" }
 color-backtrace = { git = "https://github.com/orlp/color-backtrace", rev = "bb62ccf1e9eb1f6b7af5f16acff1fd7151a876dd" }
 
 [profile.mindebug-dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ crossbeam-utils = "0.8.20"
 either = "1.14"
 ethnum = "1.3.2"
 fallible-streaming-iterator = "0.1.9"
+fastrand = "2.3.0"
 fast-float2 = { version = "^0.2.2" }
 flate2 = { version = "1", default-features = false }
 foldhash = "0.2.0"

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -40,6 +40,7 @@ object_store = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 percent-encoding = { workspace = true }
 pyo3 = { workspace = true, optional = true }
+rand = { workspace = true, optional = true }
 rayon = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, optional = true, features = ["json"] }
@@ -135,6 +136,7 @@ cloud = [
   "serde_json",
   "serde",
   "file_cache",
+  "rand",
   "reqwest",
   "http",
 ]

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -140,7 +140,7 @@ cloud = [
   "rand",
   "reqwest",
   "http",
-  "fastrand"
+  "fastrand",
 ]
 file_cache = ["async", "dep:blake3", "dep:fs4", "dep:parking_lot", "serde_json", "cloud"]
 aws = ["object_store/aws", "cloud", "reqwest"]

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -27,6 +27,7 @@ blake3 = { workspace = true, optional = true }
 bytes = { workspace = true }
 chrono = { workspace = true, optional = true }
 chrono-tz = { workspace = true, optional = true }
+fastrand = { workspace = true, optional = true }
 fast-float2 = { workspace = true, optional = true }
 flate2 = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
@@ -139,6 +140,7 @@ cloud = [
   "rand",
   "reqwest",
   "http",
+  "fastrand"
 ]
 file_cache = ["async", "dep:blake3", "dep:fs4", "dep:parking_lot", "serde_json", "cloud"]
 aws = ["object_store/aws", "cloud", "reqwest"]

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -27,8 +27,8 @@ blake3 = { workspace = true, optional = true }
 bytes = { workspace = true }
 chrono = { workspace = true, optional = true }
 chrono-tz = { workspace = true, optional = true }
-fastrand = { workspace = true, optional = true }
 fast-float2 = { workspace = true, optional = true }
+fastrand = { workspace = true, optional = true }
 flate2 = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 glob = { version = "0.3" }

--- a/crates/polars-io/src/cloud/dns.rs
+++ b/crates/polars-io/src/cloud/dns.rs
@@ -3,19 +3,11 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use hashbrown::HashMap;
-use object_store::ClientOptions;
-use object_store::client::{HttpClient, HttpConnector};
 use rand::prelude::SliceRandom;
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use tokio::sync::RwLock;
 
 type DynErr = Box<dyn std::error::Error + Send + Sync>;
-
-/// Custom HttpConnector using a DNS resolver which does caching and shuffling.
-#[derive(Debug)]
-pub struct ReqwestDNSCachingConnector {
-    resolver: CachingResolver,
-}
 
 const DEFAULT_CLOUD_DNS_CACHE_TTL_SECS: u64 = 5;
 
@@ -26,35 +18,6 @@ pub(crate) fn get_cloud_dns_cache_ttl() -> Duration {
             .and_then(|s| s.parse::<u64>().ok())
             .unwrap_or(DEFAULT_CLOUD_DNS_CACHE_TTL_SECS),
     )
-}
-
-impl ReqwestDNSCachingConnector {
-    pub fn new(ttl: Duration) -> Self {
-        ReqwestDNSCachingConnector {
-            resolver: CachingResolver::new(ttl),
-        }
-    }
-}
-
-impl HttpConnector for ReqwestDNSCachingConnector {
-    fn connect(&self, options: &ClientOptions) -> object_store::Result<HttpClient> {
-        let mut builder = options
-            .client_builder()
-            .map_err(|e| object_store::Error::Generic {
-                store: "HTTP client",
-                source: Box::new(e),
-            })?;
-
-        // Override the DNS resolver
-        builder = builder.dns_resolver2(self.resolver.clone());
-
-        let client = builder.build().map_err(|e| object_store::Error::Generic {
-            store: "HTTP client",
-            source: Box::new(e),
-        })?;
-
-        Ok(HttpClient::new(client))
-    }
 }
 
 #[derive(Debug)]

--- a/crates/polars-io/src/cloud/dns.rs
+++ b/crates/polars-io/src/cloud/dns.rs
@@ -1,0 +1,170 @@
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use hashbrown::HashMap;
+use object_store::ClientOptions;
+use object_store::client::{HttpClient, HttpConnector};
+use rand::prelude::SliceRandom;
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
+use tokio::sync::RwLock;
+use tokio::task::JoinSet;
+
+type DynErr = Box<dyn std::error::Error + Send + Sync>;
+
+/// Custom HttpConnector using a DNS resolver which does caching and shuffling.
+#[derive(Debug)]
+pub struct ReqwestDNSCachingConnector {
+    resolver: CachingResolver,
+}
+
+const DEFAULT_CLOUD_DNS_CACHE_TTL_SECS: u64 = 5;
+
+pub(crate) fn get_cloud_dns_cache_ttl() -> Duration {
+    Duration::from_secs(
+        std::env::var("POLARS_CLOUD_DNS_CACHE_TTL_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_CLOUD_DNS_CACHE_TTL_SECS),
+    )
+}
+
+impl ReqwestDNSCachingConnector {
+    pub fn new(ttl: Duration) -> Self {
+        ReqwestDNSCachingConnector {
+            resolver: CachingResolver::new(ttl),
+        }
+    }
+}
+
+impl HttpConnector for ReqwestDNSCachingConnector {
+    fn connect(&self, options: &ClientOptions) -> object_store::Result<HttpClient> {
+        let mut builder = options
+            .client_builder()
+            .map_err(|e| object_store::Error::Generic {
+                store: "HTTP client",
+                source: Box::new(e),
+            })?;
+
+        // Override the DNS resolver
+        builder = builder.dns_resolver2(self.resolver.clone());
+
+        let client = builder.build().map_err(|e| object_store::Error::Generic {
+            store: "HTTP client",
+            source: Box::new(e),
+        })?;
+
+        Ok(HttpClient::new(client))
+    }
+}
+
+/// Non-caching shuffle resolver as used by object_store.
+#[derive(Debug)]
+#[allow(unused)]
+pub(crate) struct ShuffleResolver;
+
+impl Resolve for ShuffleResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        Box::pin(async move {
+            // use `JoinSet` to propagate cancelation to tasks that haven't started running yet.
+            let mut tasks = JoinSet::new();
+            tasks.spawn_blocking(move || {
+                let it = (name.as_str(), 0).to_socket_addrs()?;
+                let mut addrs = it.collect::<Vec<_>>();
+
+                addrs.shuffle(&mut rand::rng());
+
+                Ok(Box::new(addrs.into_iter()) as Addrs)
+            });
+
+            tasks
+                .join_next()
+                .await
+                .expect("spawned on task")
+                .map_err(|err| Box::new(err) as DynErr)?
+        })
+    }
+}
+
+#[derive(Debug)]
+struct CachedAddrs {
+    addrs: Arc<Vec<SocketAddr>>,
+    expires_at: Instant,
+}
+
+/// Shuffle resolver with basic DNS cache. TTL is fixed and set by the calling site.
+#[derive(Clone, Debug)]
+pub struct CachingResolver {
+    cache: Arc<RwLock<HashMap<String, CachedAddrs>>>,
+    // Since the OS does not return the TTL as provided by DNS, the calling site
+    // is responsible for providing one.
+    ttl: Duration,
+}
+
+impl CachingResolver {
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            cache: Arc::new(RwLock::default()),
+            ttl,
+        }
+    }
+}
+
+impl Resolve for CachingResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        let cache = self.cache.clone();
+        let ttl = self.ttl;
+        let key = name.as_str().to_string();
+
+        Box::pin(async move {
+            {
+                let read_guard = cache.read().await;
+
+                if let Some(entry) = read_guard.get(&key) {
+                    if entry.expires_at > Instant::now() {
+                        let mut addrs = (*entry.addrs).clone();
+                        addrs.shuffle(&mut rand::rng());
+                        return Ok(Box::new(addrs.into_iter()) as Addrs);
+                    }
+                }
+            }
+
+            // Cache miss or expired
+            let key_clone = key.clone();
+            let mut write_guard = cache.write().await;
+
+            // Re-check in case the cache has been populated in the meanwhile
+            if let Some(entry) = write_guard.get(&key) {
+                if entry.expires_at > Instant::now() {
+                    let mut addrs = (*entry.addrs).clone();
+                    addrs.shuffle(&mut rand::rng());
+                    return Ok(Box::new(addrs.into_iter()) as Addrs);
+                }
+            }
+
+            let addrs = Arc::new(
+                tokio::task::spawn_blocking(move || {
+                    (key_clone.as_str(), 0u16)
+                        .to_socket_addrs()
+                        .map(|it| it.collect::<Vec<_>>())
+                })
+                .await
+                .map_err(DynErr::from)??,
+            );
+
+            write_guard.insert(
+                key,
+                CachedAddrs {
+                    addrs: addrs.clone(),
+                    expires_at: Instant::now() + ttl,
+                },
+            );
+            drop(write_guard);
+
+            let mut addrs = (*addrs).clone();
+            addrs.shuffle(&mut rand::rng());
+
+            Ok(Box::new(addrs.into_iter()) as Addrs)
+        })
+    }
+}

--- a/crates/polars-io/src/cloud/dns.rs
+++ b/crates/polars-io/src/cloud/dns.rs
@@ -8,7 +8,6 @@ use object_store::client::{HttpClient, HttpConnector};
 use rand::prelude::SliceRandom;
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use tokio::sync::RwLock;
-use tokio::task::JoinSet;
 
 type DynErr = Box<dyn std::error::Error + Send + Sync>;
 
@@ -58,38 +57,10 @@ impl HttpConnector for ReqwestDNSCachingConnector {
     }
 }
 
-/// Non-caching shuffle resolver as used by object_store.
-#[derive(Debug)]
-#[allow(unused)]
-pub(crate) struct ShuffleResolver;
-
-impl Resolve for ShuffleResolver {
-    fn resolve(&self, name: Name) -> Resolving {
-        Box::pin(async move {
-            // use `JoinSet` to propagate cancelation to tasks that haven't started running yet.
-            let mut tasks = JoinSet::new();
-            tasks.spawn_blocking(move || {
-                let it = (name.as_str(), 0).to_socket_addrs()?;
-                let mut addrs = it.collect::<Vec<_>>();
-
-                addrs.shuffle(&mut rand::rng());
-
-                Ok(Box::new(addrs.into_iter()) as Addrs)
-            });
-
-            tasks
-                .join_next()
-                .await
-                .expect("spawned on task")
-                .map_err(|err| Box::new(err) as DynErr)?
-        })
-    }
-}
-
 #[derive(Debug)]
 struct CachedAddrs {
     addrs: Arc<Vec<SocketAddr>>,
-    expires_at: Instant,
+    fetched_at: Instant,
 }
 
 /// Shuffle resolver with basic DNS cache. TTL is fixed and set by the calling site.
@@ -121,7 +92,7 @@ impl Resolve for CachingResolver {
                 let read_guard = cache.read().await;
 
                 if let Some(entry) = read_guard.get(&key) {
-                    if entry.expires_at > Instant::now() {
+                    if entry.fetched_at.elapsed() < ttl {
                         let mut addrs = (*entry.addrs).clone();
                         addrs.shuffle(&mut rand::rng());
                         return Ok(Box::new(addrs.into_iter()) as Addrs);
@@ -135,7 +106,7 @@ impl Resolve for CachingResolver {
 
             // Re-check in case the cache has been populated in the meanwhile
             if let Some(entry) = write_guard.get(&key) {
-                if entry.expires_at > Instant::now() {
+                if entry.fetched_at.elapsed() < ttl {
                     let mut addrs = (*entry.addrs).clone();
                     addrs.shuffle(&mut rand::rng());
                     return Ok(Box::new(addrs.into_iter()) as Addrs);
@@ -156,7 +127,7 @@ impl Resolve for CachingResolver {
                 key,
                 CachedAddrs {
                     addrs: addrs.clone(),
-                    expires_at: Instant::now() + ttl,
+                    fetched_at: Instant::now(),
                 },
             );
             drop(write_guard);

--- a/crates/polars-io/src/cloud/dns.rs
+++ b/crates/polars-io/src/cloud/dns.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use hashbrown::HashMap;
-use rand::prelude::SliceRandom;
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use tokio::sync::RwLock;
 
@@ -20,7 +19,7 @@ pub(crate) fn get_dns_cache_ttl() -> Duration {
     );
 
     if polars_config::config().verbose() {
-        eprintln!("[dns_cache] ttl {}s", ttl.as_secs());
+        eprintln!("[dns_cache] ttl: {}s", ttl.as_secs());
     }
 
     ttl
@@ -62,9 +61,7 @@ impl Resolve for CachingResolver {
 
                 if let Some(entry) = read_guard.get(&key) {
                     if entry.fetched_at.elapsed() < ttl {
-                        let mut addrs = (*entry.addrs).clone();
-                        addrs.shuffle(&mut rand::rng());
-                        return Ok(Box::new(addrs.into_iter()) as Addrs);
+                        return Ok(shuffle_addrs(&entry.addrs));
                     }
                 }
             }
@@ -76,20 +73,19 @@ impl Resolve for CachingResolver {
             // Re-check in case the cache has been populated in the meanwhile
             if let Some(entry) = write_guard.get(&key) {
                 if entry.fetched_at.elapsed() < ttl {
-                    let mut addrs = (*entry.addrs).clone();
-                    addrs.shuffle(&mut rand::rng());
-                    return Ok(Box::new(addrs.into_iter()) as Addrs);
+                    return Ok(shuffle_addrs(&entry.addrs));
                 }
             }
 
             let addrs = Arc::new(
-                tokio::task::spawn_blocking(move || {
-                    (key_clone.as_str(), 0u16)
-                        .to_socket_addrs()
-                        .map(|it| it.collect::<Vec<_>>())
-                })
-                .await
-                .map_err(DynErr::from)??,
+                polars_core::runtime::ASYNC
+                    .spawn_blocking(move || {
+                        (key_clone.as_str(), 0u16)
+                            .to_socket_addrs()
+                            .map(|it| it.collect::<Vec<_>>())
+                    })
+                    .await
+                    .map_err(DynErr::from)??,
             );
 
             write_guard.insert(
@@ -101,10 +97,14 @@ impl Resolve for CachingResolver {
             );
             drop(write_guard);
 
-            let mut addrs = (*addrs).clone();
-            addrs.shuffle(&mut rand::rng());
-
-            Ok(Box::new(addrs.into_iter()) as Addrs)
+            Ok(shuffle_addrs(&addrs))
         })
     }
+}
+
+fn shuffle_addrs(addrs: &Arc<Vec<SocketAddr>>) -> Addrs {
+    let mut indices: Vec<usize> = (0..addrs.len()).collect();
+    fastrand::shuffle(&mut indices);
+    let addrs = addrs.clone();
+    Box::new(indices.into_iter().map(move |i| addrs[i]))
 }

--- a/crates/polars-io/src/cloud/dns.rs
+++ b/crates/polars-io/src/cloud/dns.rs
@@ -9,15 +9,21 @@ use tokio::sync::RwLock;
 
 type DynErr = Box<dyn std::error::Error + Send + Sync>;
 
-const DEFAULT_CLOUD_DNS_CACHE_TTL_SECS: u64 = 5;
+const DEFAULT_DNS_CACHE_TTL_SECS: u64 = 5;
 
-pub(crate) fn get_cloud_dns_cache_ttl() -> Duration {
-    Duration::from_secs(
-        std::env::var("POLARS_CLOUD_DNS_CACHE_TTL_SECS")
+pub(crate) fn get_dns_cache_ttl() -> Duration {
+    let ttl = Duration::from_secs(
+        std::env::var("POLARS_DNS_CACHE_TTL_SECS")
             .ok()
             .and_then(|s| s.parse::<u64>().ok())
-            .unwrap_or(DEFAULT_CLOUD_DNS_CACHE_TTL_SECS),
-    )
+            .unwrap_or(DEFAULT_DNS_CACHE_TTL_SECS),
+    );
+
+    if polars_config::config().verbose() {
+        eprintln!("[dns_cache] ttl {}s", ttl.as_secs());
+    }
+
+    ttl
 }
 
 #[derive(Debug)]

--- a/crates/polars-io/src/cloud/mod.rs
+++ b/crates/polars-io/src/cloud/mod.rs
@@ -20,3 +20,6 @@ pub use polars_object_store::*;
 pub mod cloud_writer;
 #[cfg(feature = "cloud")]
 pub mod credential_provider;
+
+#[cfg(feature = "cloud")]
+pub mod dns;

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -34,7 +34,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "cloud")]
 use super::credential_provider::PlCredentialProvider;
 #[cfg(feature = "cloud")]
-use super::dns::get_cloud_dns_cache_ttl;
+use super::dns::get_dns_cache_ttl;
 #[cfg(feature = "cloud")]
 use crate::cloud::ObjectStoreErrorContext;
 #[cfg(any(feature = "aws", feature = "gcp", feature = "azure", feature = "http"))]
@@ -288,7 +288,7 @@ pub(super) fn get_client_options() -> ClientOptions {
         ))
         .with_user_agent(HeaderValue::from_static(USER_AGENT))
         .with_allow_http(true)
-        .with_dns_resolver(Arc::new(CachingResolver::new(get_cloud_dns_cache_ttl())))
+        .with_dns_resolver(Arc::new(CachingResolver::new(get_dns_cache_ttl())))
 }
 
 #[cfg(feature = "aws")]

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -32,6 +32,8 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "cloud")]
 use super::credential_provider::PlCredentialProvider;
 #[cfg(feature = "cloud")]
+use super::dns::{ReqwestDNSCachingConnector, get_cloud_dns_cache_ttl};
+#[cfg(feature = "cloud")]
 use crate::cloud::ObjectStoreErrorContext;
 #[cfg(feature = "file_cache")]
 use crate::file_cache::get_env_file_cache_ttl;
@@ -356,9 +358,17 @@ impl CloudOptions {
         let opt_credential_provider =
             self.initialized_credential_provider(clear_cached_credentials)?;
 
+        let connector = ReqwestDNSCachingConnector::new(get_cloud_dns_cache_ttl());
+
         let mut builder = AmazonS3Builder::from_env()
             .with_client_options(get_client_options())
+            .with_http_connector(connector)
             .with_url(url.clone().to_string());
+
+        // // kdn TODO RM
+        // let mut builder = AmazonS3Builder::from_env()
+        //     .with_client_options(get_client_options())
+        //     .with_url(url.clone().to_string());
 
         if let Some(credential_provider) = &opt_credential_provider {
             let storage_update_options = parse_untyped_config::<AmazonS3ConfigKey, _>(
@@ -526,10 +536,13 @@ impl CloudOptions {
 
         let verbose = polars_core::config::verbose();
 
+        let connector = ReqwestDNSCachingConnector::new(get_cloud_dns_cache_ttl());
+
         // The credential provider `self.credentials` is prioritized if it is set. We also need
         // `from_env()` as it may source environment configured storage account name.
-        let mut builder =
-            MicrosoftAzureBuilder::from_env().with_client_options(get_client_options());
+        let mut builder = MicrosoftAzureBuilder::from_env()
+            .with_client_options(get_client_options())
+            .with_http_connector(connector);
 
         if let Some(options) = &self.config {
             let CloudConfig::Azure(options) = options else {
@@ -593,7 +606,11 @@ impl CloudOptions {
             GoogleCloudStorageBuilder::new()
         };
 
-        let mut builder = builder.with_client_options(get_client_options());
+        let connector = ReqwestDNSCachingConnector::new(get_cloud_dns_cache_ttl());
+
+        let mut builder = builder
+            .with_client_options(get_client_options())
+            .with_http_connector(connector);
 
         if let Some(options) = &self.config {
             let CloudConfig::Gcp(options) = options else {
@@ -623,6 +640,8 @@ impl CloudOptions {
 
     #[cfg(feature = "http")]
     pub fn build_http(&self, url: PlRefPath) -> PolarsResult<impl object_store::ObjectStore> {
+        let connector = ReqwestDNSCachingConnector::new(get_cloud_dns_cache_ttl());
+
         let out = object_store::http::HttpBuilder::new()
             .with_url(url.to_string())
             .with_client_options({
@@ -634,6 +653,7 @@ impl CloudOptions {
                 }
                 opts
             })
+            .with_http_connector(connector)
             .build()
             .map_err(|e| ObjectStoreErrorContext::new(url).attach_err_info(e))?;
 

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -365,11 +365,6 @@ impl CloudOptions {
             .with_http_connector(connector)
             .with_url(url.clone().to_string());
 
-        // // kdn TODO RM
-        // let mut builder = AmazonS3Builder::from_env()
-        //     .with_client_options(get_client_options())
-        //     .with_url(url.clone().to_string());
-
         if let Some(credential_provider) = &opt_credential_provider {
             let storage_update_options = parse_untyped_config::<AmazonS3ConfigKey, _>(
                 credential_provider

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -3,6 +3,8 @@ use std::io::Read;
 #[cfg(feature = "aws")]
 use std::path::Path;
 use std::str::FromStr;
+#[cfg(any(feature = "aws", feature = "gcp", feature = "azure", feature = "http"))]
+use std::sync::Arc;
 use std::sync::LazyLock;
 
 #[cfg(any(feature = "aws", feature = "gcp", feature = "azure", feature = "http"))]
@@ -32,9 +34,11 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "cloud")]
 use super::credential_provider::PlCredentialProvider;
 #[cfg(feature = "cloud")]
-use super::dns::{ReqwestDNSCachingConnector, get_cloud_dns_cache_ttl};
+use super::dns::get_cloud_dns_cache_ttl;
 #[cfg(feature = "cloud")]
 use crate::cloud::ObjectStoreErrorContext;
+#[cfg(any(feature = "aws", feature = "gcp", feature = "azure", feature = "http"))]
+use crate::cloud::dns::CachingResolver;
 #[cfg(feature = "file_cache")]
 use crate::file_cache::get_env_file_cache_ttl;
 #[cfg(feature = "aws")]
@@ -284,6 +288,7 @@ pub(super) fn get_client_options() -> ClientOptions {
         ))
         .with_user_agent(HeaderValue::from_static(USER_AGENT))
         .with_allow_http(true)
+        .with_dns_resolver(Arc::new(CachingResolver::new(get_cloud_dns_cache_ttl())))
 }
 
 #[cfg(feature = "aws")]
@@ -358,11 +363,8 @@ impl CloudOptions {
         let opt_credential_provider =
             self.initialized_credential_provider(clear_cached_credentials)?;
 
-        let connector = ReqwestDNSCachingConnector::new(get_cloud_dns_cache_ttl());
-
         let mut builder = AmazonS3Builder::from_env()
             .with_client_options(get_client_options())
-            .with_http_connector(connector)
             .with_url(url.clone().to_string());
 
         if let Some(credential_provider) = &opt_credential_provider {
@@ -531,13 +533,10 @@ impl CloudOptions {
 
         let verbose = polars_core::config::verbose();
 
-        let connector = ReqwestDNSCachingConnector::new(get_cloud_dns_cache_ttl());
-
         // The credential provider `self.credentials` is prioritized if it is set. We also need
         // `from_env()` as it may source environment configured storage account name.
-        let mut builder = MicrosoftAzureBuilder::from_env()
-            .with_client_options(get_client_options())
-            .with_http_connector(connector);
+        let mut builder =
+            MicrosoftAzureBuilder::from_env().with_client_options(get_client_options());
 
         if let Some(options) = &self.config {
             let CloudConfig::Azure(options) = options else {
@@ -601,11 +600,7 @@ impl CloudOptions {
             GoogleCloudStorageBuilder::new()
         };
 
-        let connector = ReqwestDNSCachingConnector::new(get_cloud_dns_cache_ttl());
-
-        let mut builder = builder
-            .with_client_options(get_client_options())
-            .with_http_connector(connector);
+        let mut builder = builder.with_client_options(get_client_options());
 
         if let Some(options) = &self.config {
             let CloudConfig::Gcp(options) = options else {
@@ -635,8 +630,6 @@ impl CloudOptions {
 
     #[cfg(feature = "http")]
     pub fn build_http(&self, url: PlRefPath) -> PolarsResult<impl object_store::ObjectStore> {
-        let connector = ReqwestDNSCachingConnector::new(get_cloud_dns_cache_ttl());
-
         let out = object_store::http::HttpBuilder::new()
             .with_url(url.to_string())
             .with_client_options({
@@ -648,7 +641,6 @@ impl CloudOptions {
                 }
                 opts
             })
-            .with_http_connector(connector)
             .build()
             .map_err(|e| ObjectStoreErrorContext::new(url).attach_err_info(e))?;
 

--- a/deny.toml
+++ b/deny.toml
@@ -71,5 +71,5 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # don't use a given patch (these patches are only active in compute-plane).
 unknown-git = "deny"
 allow-git = [
-  "https://github.com/apache/arrow-rs-object-store",
+  "https://github.com/kdn36/arrow-rs-object-store",
 ]


### PR DESCRIPTION
This PR introduces a built-in lightweight DNS resolver that caches and shuffles the DNS response. 

Used for object_store cloud back-ends (AWS, Azure, GCP, HTTP).

For now, the PR uses a forked version of object_store.

Final implementation depends on https://github.com/apache/arrow-rs-object-store/issues/726, which has a number of integration proposals. See also https://github.com/apache/arrow-rs-object-store/pull/728