### PR TITLE
refactor: Expose unordered concatenation in python visitor

### DIFF
--- a/crates/polars-plan/src/plans/ir/dot.rs
+++ b/crates/polars-plan/src/plans/ir/dot.rs
@@ -102,12 +102,16 @@ impl<'a> IRDotDisplay<'a> {
 
         use IR::*;
         match root {
-            Union { inputs, .. } => {
+            Union {
+                inputs, options, ..
+            } => {
                 for input in inputs {
                     recurse!(*input);
                 }
 
-                write_label(f, id, |f| f.write_str("UNION"))?;
+                write_label(f, id, |f| {
+                    write!(f, "UNION[maintain_order: {0}]", options.maintain_order)
+                })?;
             },
             HConcat { inputs, .. } => {
                 for input in inputs {

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -161,9 +161,12 @@ impl<'a> IRDisplay<'a> {
             Union { inputs, options } => {
                 write_ir_non_recursive(f, ir_node, self.lp.expr_arena, output_schema, indent)?;
                 let name = if let Some(slice) = options.slice {
-                    format!("SLICED UNION: {slice:?}")
+                    format!(
+                        "SLICED UNION[maintain_order: {0}]: {slice:?}",
+                        options.maintain_order
+                    )
                 } else {
-                    "UNION".to_string()
+                    format!("UNION[maintain_order: {0}]", options.maintain_order)
                 };
 
                 // 3 levels of indentation
@@ -968,9 +971,12 @@ pub fn write_ir_non_recursive(
         IR::MapFunction { input: _, function } => write!(f, "{:indent$}{function}", ""),
         IR::Union { inputs: _, options } => {
             let name = if let Some(slice) = options.slice {
-                format!("SLICED UNION: {slice:?}")
+                format!(
+                    "SLICED UNION[maintain_order: {0}]: {slice:?}",
+                    options.maintain_order
+                )
             } else {
-                "UNION".to_string()
+                format!("UNION[maintain_order: {0}]", options.maintain_order)
             };
             write!(f, "{:indent$}{name}", "")
         },

--- a/crates/polars-plan/src/plans/ir/tree_format.rs
+++ b/crates/polars-plan/src/plans/ir/tree_format.rs
@@ -228,9 +228,12 @@ impl<'a> TreeFmtNode<'a> {
                     wh(
                         h,
                         &(if let Some(slice) = options.slice {
-                            format!("SLICED UNION: {slice:?}")
+                            format!(
+                                "SLICED UNION[maintain_order: {0}]: {slice:?}",
+                                options.maintain_order
+                            )
                         } else {
-                            "UNION".to_string()
+                            format!("UNION[maintain_order: {0}]", options.maintain_order)
                         }),
                     ),
                     inputs

--- a/crates/polars-python/src/lazyframe/visit.rs
+++ b/crates/polars-python/src/lazyframe/visit.rs
@@ -58,7 +58,7 @@ impl NodeTraverser {
     // Increment major on breaking changes to the IR (e.g. renaming
     // fields, reordering tuples), minor on backwards compatible
     // changes (e.g. exposing a new expression node).
-    const VERSION: Version = (12, 1);
+    const VERSION: Version = (13, 0);
 
     pub fn new(root: Node, lp_arena: Arena<IR>, expr_arena: Arena<AExpr>) -> Self {
         Self {

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -337,7 +337,11 @@ pub struct Union {
     #[pyo3(get)]
     inputs: Vec<usize>,
     #[pyo3(get)]
-    options: Option<(i64, usize)>,
+    slice: Option<(i64, usize)>,
+    #[pyo3(get)]
+    rows: (Option<usize>, usize),
+    #[pyo3(get)]
+    maintain_order: bool,
 }
 #[pyclass(frozen)]
 /// Horizontal concatenation of multiple plans
@@ -722,8 +726,10 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<Py<PyAny>> {
         .into_py_any(py),
         IR::Union { inputs, options } => Union {
             inputs: inputs.iter().map(|n| n.0).collect(),
-            // TODO: rest of options
-            options: options.slice,
+            // Remaining options are implementation detail, not logical
+            slice: options.slice,
+            rows: options.rows,
+            maintain_order: options.maintain_order,
         }
         .into_py_any(py),
         IR::HConcat {

--- a/py-polars/tests/unit/lazyframe/test_order_observability.py
+++ b/py-polars/tests/unit/lazyframe/test_order_observability.py
@@ -165,6 +165,18 @@ def test_merge_sorted_to_union() -> None:
     assert "UNION" in explain
 
 
+def test_union_drops_maintain_order() -> None:
+    lf1 = pl.LazyFrame({"a": [1, 2, 3], "b": [3, 4, 5]})
+    lf2 = pl.LazyFrame({"a": [2, 3, 4], "b": [4, 5, 6]})
+
+    lf = pl.concat([lf1, lf2]).group_by("a").agg(pl.col("b").sum())
+    explain = lf.explain(optimizations=pl.QueryOptFlags(check_order_observe=False))
+    assert "UNION[maintain_order: true]" in explain
+
+    explain = lf.explain()
+    assert "UNION[maintain_order: false]" in explain
+
+
 @pytest.mark.parametrize("n_frames", [4, 5])
 def test_merge_sorted_deep_chain_to_union(n_frames: int) -> None:
     lfs = [pl.LazyFrame({"a": [i], "b": [i]}) for i in range(n_frames)]

--- a/py-polars/tests/unit/lazyframe/test_predicates.py
+++ b/py-polars/tests/unit/lazyframe/test_predicates.py
@@ -1372,7 +1372,9 @@ def test_repeated_slice_pushdown_26815() -> None:
     )
 
     plan = q.explain()
-    assert plan.index("SLICED UNION: (3, 5)") > plan.index("SLICE[offset: -3, len: 3]")
+    assert plan.index("SLICED UNION[maintain_order: true]: (3, 5)") > plan.index(
+        "SLICE[offset: -3, len: 3]"
+    )
     assert_frame_equal(q.collect(), pl.DataFrame({"a": [5, 6, 7]}))
 
 


### PR DESCRIPTION
At some point in the last year or so, the optimizer gained the ability to remove order-preserving options from nodes that don't need it (because their consumers destroy the order). In most cases, the python visitor exposed the `maintain_order` property of IR nodes. However it did not for `Union`. Address that missing piece by doing so. This is particularly useful for multi-GPU execution since ordered concatenation of dataframes induces an all to all that one would like to avoid if the order cannot be observed.

While here, I also added the maintain_order annotation to `explain()`.