### PR TITLE
fix(rust): Fix `FixedRingBuffer` allocation provenance

### DIFF
--- a/crates/polars-utils/src/fixedringbuffer.rs
+++ b/crates/polars-utils/src/fixedringbuffer.rs
@@ -215,11 +215,4 @@ mod tests {
         assert_eq!(frb.pop_front(), Some(Box::new(3)));
         assert_eq!(frb.pop_front(), None);
     }
-
-    #[test]
-    fn first_push_preserves_allocation_provenance() {
-        let mut frb = FixedRingBuffer::new(1);
-
-        assert_eq!(frb.push("a"), Some(()));
-    }
 }

--- a/crates/polars-utils/src/fixedringbuffer.rs
+++ b/crates/polars-utils/src/fixedringbuffer.rs
@@ -1,3 +1,5 @@
+use std::mem::ManuallyDrop;
+
 /// A ring-buffer with a size determined at creation-time
 ///
 /// This makes it perfectly suited for buffers that produce and consume at different speeds.
@@ -24,14 +26,14 @@ const fn wrapping_add(x: usize, n: usize, capacity: usize) -> usize {
 
 impl<T> FixedRingBuffer<T> {
     pub fn new(capacity: usize) -> Self {
-        let buffer = Vec::with_capacity(capacity);
+        let mut buffer = ManuallyDrop::new(Vec::with_capacity(capacity));
 
         Self {
             start: 0,
             length: 0,
 
             _buffer_capacity: buffer.capacity(),
-            buffer: buffer.leak() as *mut [T] as *mut T,
+            buffer: buffer.as_mut_ptr(),
             capacity,
         }
     }
@@ -212,5 +214,12 @@ mod tests {
         assert_eq!(frb.pop_front(), Some(Box::new(1)));
         assert_eq!(frb.pop_front(), Some(Box::new(3)));
         assert_eq!(frb.pop_front(), None);
+    }
+
+    #[test]
+    fn first_push_preserves_allocation_provenance() {
+        let mut frb = FixedRingBuffer::new(1);
+
+        assert_eq!(frb.push("a"), Some(()));
     }
 }


### PR DESCRIPTION
Closes #27664.

This fixes `FixedRingBuffer::new` so it stores the allocation pointer from `Vec::as_mut_ptr()` while keeping the vector allocation alive with `ManuallyDrop`, instead of deriving the stored pointer from `Vec::leak()` on a zero-length slice.

Tests:
- `cargo test -p polars-utils fixedringbuffer`
- `make test` locally: 17674 passed, 76 skipped, 9 xfailed

AI usage:
1. I used AI to help investigate the reported provenance issue, implement the small Rust change, and run local verification.
2. I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.
<img width="1701" height="1044" alt="Screenshot 2026-05-20 at 12 15 22 AM" src="https://github.com/user-attachments/assets/af7a85f4-0766-4b79-b49b-00d8a1244891" />
