### PR TITLE
fix: Fix skip_batches logic for NaN

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
@@ -37,6 +37,7 @@ pub fn aexpr_to_skip_batch_predicate(
 /// Rejects nested, null, and categorical types. For floats, Parquet stats exclude NaN
 /// but data may contain it. Since NaN is largest under TotalOrd, `col < x` is safe
 /// (NaN never matches) but `col > x` is not (NaN always matches).
+/// col >= NaN matches NaN == NaN, but stats exclude NaN so max < NaN can't detect them -> unsafe
 fn can_use_min_max_stats(
     dtype: &DataType,
     op: Option<&Operator>,
@@ -56,7 +57,7 @@ fn can_use_min_max_stats(
     match op {
         Some(O::Lt | O::LtEq) => true,
         None | Some(O::Eq | O::EqValidity) => !lv_is_nan && lv.is_some(),
-        Some(O::Gt | O::GtEq) => lv_is_nan,
+        Some(O::Gt) => lv_is_nan,
         _ => false,
     }
 }

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -1889,3 +1889,38 @@ def test_sink_parquet_lazy_and_collect() -> None:
     assert q.collect().shape == (0, 0)
 
     assert_frame_equal(pl.scan_parquet(f).collect(), df)
+
+
+def test_gteq_nan_skip_batch_predicate() -> None:
+    """Col >= NaN must not skip batches that contain NaN values.
+
+    Under TotalOrd semantics, NaN >= NaN is True, so a batch with NaN
+    values must not be skipped.  However, min/max stats exclude NaN, so
+    the predicate incorrectly concludes max(col) < NaN => can skip.
+    """
+    NaN = float("nan")
+
+    for dtype in [pl.Float16(), pl.Float32(), pl.Float64()]:
+        s = pl.Series("x", [NaN, None, 0.0, None], dtype=dtype)
+        expr = pl.col("x") >= pl.lit(NaN, dtype)
+
+        sbp = expr._skip_batch_predicate({"x": dtype})
+        if sbp is None:
+            continue  # Already conservative — no issue.
+
+        df = pl.DataFrame(
+            [
+                pl.Series("x_min", [s.min()], dtype),
+                pl.Series("x_max", [s.max()], dtype),
+                pl.Series("x_nc", [s.null_count()], pl.get_index_type()),
+                pl.Series("len", [s.len()], pl.get_index_type()),
+            ]
+        )
+        can_skip = df.select(can_skip=sbp).fill_null(False).to_series()[0]
+
+        # Invariant: if the predicate says can_skip, the filter must return 0 rows.
+        if can_skip:
+            assert s.to_frame().filter(expr).height == 0, (
+                f"dtype={dtype}: skip_batch_predicate said can_skip=True but "
+                f"filter returned {s.to_frame().filter(expr)} rows"
+            )

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -1889,38 +1889,3 @@ def test_sink_parquet_lazy_and_collect() -> None:
     assert q.collect().shape == (0, 0)
 
     assert_frame_equal(pl.scan_parquet(f).collect(), df)
-
-
-def test_gteq_nan_skip_batch_predicate() -> None:
-    """Col >= NaN must not skip batches that contain NaN values.
-
-    Under TotalOrd semantics, NaN >= NaN is True, so a batch with NaN
-    values must not be skipped.  However, min/max stats exclude NaN, so
-    the predicate incorrectly concludes max(col) < NaN => can skip.
-    """
-    NaN = float("nan")
-
-    for dtype in [pl.Float16(), pl.Float32(), pl.Float64()]:
-        s = pl.Series("x", [NaN, None, 0.0, None], dtype=dtype)
-        expr = pl.col("x") >= pl.lit(NaN, dtype)
-
-        sbp = expr._skip_batch_predicate({"x": dtype})
-        if sbp is None:
-            continue  # Already conservative — no issue.
-
-        df = pl.DataFrame(
-            [
-                pl.Series("x_min", [s.min()], dtype),
-                pl.Series("x_max", [s.max()], dtype),
-                pl.Series("x_nc", [s.null_count()], pl.get_index_type()),
-                pl.Series("len", [s.len()], pl.get_index_type()),
-            ]
-        )
-        can_skip = df.select(can_skip=sbp).fill_null(False).to_series()[0]
-
-        # Invariant: if the predicate says can_skip, the filter must return 0 rows.
-        if can_skip:
-            assert s.to_frame().filter(expr).height == 0, (
-                f"dtype={dtype}: skip_batch_predicate said can_skip=True but "
-                f"filter returned {s.to_frame().filter(expr)} rows"
-            )

--- a/py-polars/tests/unit/io/test_skip_batch_predicate.py
+++ b/py-polars/tests/unit/io/test_skip_batch_predicate.py
@@ -252,7 +252,8 @@ def test_float_skip_batch_predicate() -> None:
     assert sbp(pl.col("x") > 5.0) is None  # No skip. Hidden NaN satisfies >.
     assert sbp(pl.col("x") > NaN) is not None  # Can skip. Nothing > NaN under TotalOrd.
     assert sbp(pl.col("x") >= 5.0) is None  # No skip. Hidden NaN satisfies >=.
-    assert sbp(pl.col("x") >= NaN) is not None  # Can skip. Nothing > NaN.
+    assert sbp(pl.col("x") > NaN) is not None  # Can skip. Nothing > NaN.
+    assert sbp(pl.col("x") >= NaN) is None  # No skip. Stats exclude NaN.
     assert (
         sbp(pl.lit(5.0) > pl.col("x")) is not None
     )  # Can skip. 5.0 > col is col < 5.0.
@@ -262,3 +263,4 @@ def test_float_skip_batch_predicate() -> None:
     )  # Can skip. Non-NaN bounds.
     assert sbp(pl.col("x").is_between(NaN, 4.0)) is None  # No skip. NaN left bound.
     assert sbp(pl.col("x").is_between(1.0, NaN)) is None  # No skip. NaN right bound.
+

--- a/py-polars/tests/unit/io/test_skip_batch_predicate.py
+++ b/py-polars/tests/unit/io/test_skip_batch_predicate.py
@@ -263,4 +263,3 @@ def test_float_skip_batch_predicate() -> None:
     )  # Can skip. Non-NaN bounds.
     assert sbp(pl.col("x").is_between(NaN, 4.0)) is None  # No skip. NaN left bound.
     assert sbp(pl.col("x").is_between(1.0, NaN)) is None  # No skip. NaN right bound.
-


### PR DESCRIPTION
This was a flaky hypothesis test. Hitting test case found with AI.

`GtEq` is not safe under total order as stats exclude `NaN`.