### PR TITLE
docs(python): Clarify read_csv use_pyarrow behavior

### DIFF
--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -211,6 +211,8 @@ def read_csv(
         this function determines if it is possible to use pyarrow's
         native parser. Note that pyarrow and polars may have a
         different strategy regarding type inference.
+        Some Polars-specific parsing options, such as `schema`,
+        may not be applied when using the PyArrow parser.
     storage_options
         Extra options that make sense for `fsspec.open()` or a
         particular storage connection.


### PR DESCRIPTION
Closes #19886.

Clarifies that when `read_csv(use_pyarrow=True)` uses PyArrow's native CSV parser, some Polars-specific parsing options, such as `schema`, may not be applied in that code path.