### PR TITLE
perf: Skip downloading IPC batches exceeding slice bounds

### DIFF
--- a/crates/polars-stream/src/nodes/io_sources/ipc/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ipc/mod.rs
@@ -6,15 +6,19 @@ use arrow::io::ipc::read::{Dictionaries, read_dictionary_block};
 use async_trait::async_trait;
 use polars_async::executor::{self, JoinHandle, TaskPriority};
 use polars_async::primitives::wait_group::{WaitGroup, WaitToken};
+use polars_buffer::Buffer;
+use polars_config::config;
 use polars_core::prelude::DataType;
 use polars_core::runtime::ASYNC;
 use polars_core::schema::{Schema, SchemaExt};
 use polars_core::utils::arrow::io::ipc::read::{
     BlockReader, FileMetadata, ProjectionInfo, prepare_projection, read_file_metadata,
 };
-use polars_error::{ErrString, PolarsError, PolarsResult};
+use polars_error::constants::LENGTH_LIMIT_MSG;
+use polars_error::{ErrString, PolarsError, PolarsResult, polars_err, to_compute_err};
 use polars_io::cloud::CloudOptions;
 use polars_io::ipc::IpcScanOptions;
+use polars_io::ipc::pl_ipc_metadata::{POLARS_IPC_METADATA_KEY, PlIpcMetadata};
 use polars_io::utils::byte_source::{
     BufferByteSource, ByteSource, DynByteSource, DynByteSourceBuilder,
 };
@@ -23,6 +27,7 @@ use polars_plan::dsl::ScanSource;
 use polars_utils::IdxSize;
 use polars_utils::bool::UnsafeBool;
 use polars_utils::mem::prefetch::get_memory_prefetch_func;
+use polars_utils::scratch_vec::ScratchVec;
 use polars_utils::slice_enum::Slice;
 use record_batch_data_fetch::RecordBatchDataFetcher;
 use record_batch_decode::RecordBatchDecoder;
@@ -34,7 +39,7 @@ use crate::morsel::{Morsel, MorselSeq, SourceToken, get_ideal_morsel_size};
 use crate::nodes::io_sources::ipc::metadata::read_ipc_metadata_bytes;
 use crate::nodes::io_sources::multi_scan::reader_interface::output::FileReaderOutputSend;
 use crate::nodes::io_sources::multi_scan::reader_interface::{
-    FileReader, FileReaderCallbacks, Projection,
+    FileReader, FileReaderCallbacks, Projection, calc_row_position_after_slice,
 };
 use crate::nodes::io_sources::parquet::init::split_to_morsels;
 use crate::utils::tokio_handle_ext::AbortOnDropHandle;
@@ -77,6 +82,7 @@ struct RecordBatchPrefetchSync {
 #[derive(Clone)]
 struct InitializedState {
     file_metadata: Arc<FileMetadata>,
+    file_pl_metadata: Option<Arc<PlIpcMetadata>>,
     byte_source: Arc<DynByteSource>,
     dictionaries: Arc<Option<Dictionaries>>,
 }
@@ -144,10 +150,20 @@ impl FileReader for IpcFileReader {
             Arc::new(Some(dictionaries))
         };
 
+        let file_pl_metadata = file_metadata
+            .custom_metadata
+            .as_ref()
+            .and_then(|md| md.get(POLARS_IPC_METADATA_KEY))
+            .map(|md_str| serde_json::from_str::<PlIpcMetadata>(md_str))
+            .transpose()
+            .map_err(to_compute_err)?
+            .map(Arc::new);
+
         self.init_data = Some(InitializedState {
             file_metadata,
             byte_source,
             dictionaries,
+            file_pl_metadata,
         });
 
         Ok(())
@@ -179,6 +195,7 @@ impl FileReader for IpcFileReader {
         // Initialize.
         let InitializedState {
             file_metadata,
+            file_pl_metadata,
             byte_source,
             dictionaries,
         } = self.init_data.clone().unwrap();
@@ -195,8 +212,8 @@ impl FileReader for IpcFileReader {
             callbacks:
                 FileReaderCallbacks {
                     file_schema_tx,
-                    n_rows_in_file_tx,
-                    row_position_on_end_tx,
+                    mut n_rows_in_file_tx,
+                    mut row_position_on_end_tx,
                 },
         } = args
         else {
@@ -214,43 +231,31 @@ impl FileReader for IpcFileReader {
             _ = file_schema_tx.send(file_schema_pl.clone());
         }
 
-        // @NOTE. Negative slicing takes a 2-pass approach. The first pass gets the total row count
-        // by setting slice.len to 0, and uses this to convert the negative slice into a positive slice.
-        // The second pass uses the positive slice to fetch and slice the data.
-        let fetch_metadata_only = pre_slice_arg.as_ref().is_some_and(|x| x.len() == 0);
-
         // Always create a slice. If no slice was given, just make the biggest slice possible.
         let slice_range: Range<usize> = pre_slice_arg
             .clone()
             .map_or(0..usize::MAX, Range::<usize>::from);
-        let n_rows_limit = if pre_slice_arg.is_some() {
-            Some(slice_range.end)
-        } else {
-            None
-        };
 
         // Avoid materializing projection info if we are projecting all the columns of this file.
-        let projection_indices: Option<Vec<usize>> = if let Some(first_mismatch_idx) =
-            (0..file_metadata.schema.len().min(projected_schema.len())).find(|&i| {
+        let projection_indices: Option<Arc<[usize]>> = if let Some(first_mismatch_idx) =
+            (0..usize::min(file_metadata.schema.len(), projected_schema.len())).find(|&i| {
                 file_metadata.schema.get_at_index(i).unwrap().0
                     != projected_schema.get_at_index(i).unwrap().0
             }) {
-            let mut out = Vec::with_capacity(file_metadata.schema.len());
-
-            out.extend(0..first_mismatch_idx);
-
-            out.extend(
-                (first_mismatch_idx..projected_schema.len()).filter_map(|i| {
-                    file_metadata
-                        .schema
-                        .index_of(projected_schema.get_at_index(i).unwrap().0)
-                }),
-            );
-
-            Some(out)
+            Some(
+                (0..first_mismatch_idx)
+                    .chain(
+                        (first_mismatch_idx..projected_schema.len()).filter_map(|i| {
+                            file_metadata
+                                .schema
+                                .index_of(projected_schema.get_at_index(i).unwrap().0)
+                        }),
+                    )
+                    .collect(),
+            )
         } else if file_metadata.schema.len() > projected_schema.len() {
             // Names match up to projected schema len.
-            Some((0..projected_schema.len()).collect::<Vec<_>>())
+            Some((0..projected_schema.len()).collect())
         } else {
             // Name order matches up to `file_metadata.schema.len()`, we are projecting all columns
             // in this file.
@@ -276,8 +281,9 @@ impl FileReader for IpcFileReader {
             )
         }
 
-        let projection_info: Option<ProjectionInfo> =
-            projection_indices.map(|indices| prepare_projection(&file_metadata.schema, indices));
+        let projection_info: Option<ProjectionInfo> = projection_indices
+            .as_deref()
+            .map(|indices| prepare_projection(&file_metadata.schema, indices.to_vec()));
         let projection_info = Arc::new(projection_info);
 
         let schema = projection_info.as_ref().as_ref().map_or(
@@ -336,18 +342,106 @@ impl FileReader for IpcFileReader {
 
         // Task: Prefetch.
         let byte_source = byte_source.clone();
-        let metadata = file_metadata.clone();
+        let mut base_rb_metadata_fetch_count: u64 = 0;
+
         let prefetch_task = AbortOnDropHandle(ASYNC.spawn(async move {
-            let mut record_batch_data_fetcher = RecordBatchDataFetcher {
-                memory_prefetch_func,
-                metadata,
+            let record_batch_cum_len = if let Some(file_pl_metadata) = file_pl_metadata {
+                struct CumLenWrap(Arc<PlIpcMetadata>);
+
+                impl AsRef<[IdxSize]> for CumLenWrap {
+                    fn as_ref(&self) -> &[IdxSize] {
+                        self.0.record_batch_cum_len.as_slice()
+                    }
+                }
+
+                Some(Buffer::from_owner(CumLenWrap(file_pl_metadata)))
+            } else if pre_slice_arg.is_some()
+                || n_rows_in_file_tx.is_some()
+                || row_position_on_end_tx.is_some()
+            {
+                let mut metadata_ranges: Vec<Range<usize>> = file_metadata
+                    .blocks
+                    .iter()
+                    .map(|block| {
+                        block.offset as usize
+                            ..block.offset as usize + block.meta_data_length as usize
+                    })
+                    .collect();
+
+                base_rb_metadata_fetch_count += metadata_ranges.len() as u64;
+
+                if config().verbose() {
+                    eprintln!(
+                        "[IpcFileReader]: Read all record batch metadata (num_batches: {})",
+                        metadata_ranges.len()
+                    )
+                }
+
+                let record_batch_metadata_map = byte_source
+                    .get_ranges(metadata_ranges.as_mut_slice())
+                    .await?;
+
+                let mut message_scratch = ScratchVec::default();
+
+                Some(
+                    file_metadata
+                        .blocks
+                        .iter()
+                        .map(|block| {
+                            let fetched_bytes = record_batch_metadata_map
+                                .get(&(block.offset as usize))
+                                .unwrap();
+
+                            let mut reader =
+                                BlockReader::new(Cursor::new(fetched_bytes.as_slice()));
+                            reader
+                                .record_batch_num_rows(message_scratch.get())?
+                                .try_into()
+                                .map_err(|_| polars_err!(ComputeError: LENGTH_LIMIT_MSG))
+                        })
+                        .scan(0, |offset: &mut IdxSize, v: PolarsResult<IdxSize>| {
+                            Some(v.and_then(|num_rows_this_batch| {
+                                *offset = offset
+                                    .checked_add(num_rows_this_batch)
+                                    .ok_or_else(|| polars_err!(ComputeError: LENGTH_LIMIT_MSG))?;
+
+                                Ok(*offset)
+                            }))
+                        })
+                        .collect::<PolarsResult<_>>()?,
+                )
+            } else {
+                None
+            };
+
+            if let Some(record_batch_cum_len) = record_batch_cum_len.as_deref() {
+                let n_rows_in_file = *record_batch_cum_len.last().unwrap();
+
+                if let Some(n_rows_in_file_tx) = n_rows_in_file_tx.take() {
+                    _ = n_rows_in_file_tx.send(n_rows_in_file);
+                }
+
+                if let Some(row_position_on_end_tx) = row_position_on_end_tx.take() {
+                    _ = row_position_on_end_tx.send(calc_row_position_after_slice(
+                        n_rows_in_file,
+                        pre_slice_arg.clone(),
+                    ));
+                }
+            }
+
+            let record_batch_data_fetcher = RecordBatchDataFetcher {
+                file_metadata,
+                record_batch_cum_len,
+
                 byte_source,
-                record_batch_idx: 0,
-                fetch_metadata_only,
-                n_rows_limit,
-                n_rows_in_file_tx,
-                row_position_on_end_tx,
+                memory_prefetch_func,
+
+                subset_projection_idxs: projection_indices,
+                pre_slice: pre_slice_arg,
+
                 prefetch_send,
+                base_rb_metadata_fetch_count,
+
                 rb_prefetch_semaphore,
                 rb_prefetch_current_all_spawned,
             };
@@ -356,18 +450,20 @@ impl FileReader for IpcFileReader {
                 rb_prefetch_prev_all_spawned.wait().await;
             }
 
-            record_batch_data_fetcher.run().await?;
-
-            PolarsResult::Ok(())
+            record_batch_data_fetcher.run().await
         }));
 
-        // Task: Decode.
-        let decode_task = AbortOnDropHandle(ASYNC.spawn(async move {
+        // Receives fetched record batches and synchronizes row position, then calls decode.
+        let decode_dispatch_task = AbortOnDropHandle(ASYNC.spawn(async move {
             let mut current_row_offset: IdxSize = 0;
 
             while let Some((prefetch_task, permit)) = prefetch_recv.recv().await {
                 let mut record_batch_data = prefetch_task.await.unwrap()?;
-                record_batch_data.row_offset = Some(current_row_offset);
+
+                match record_batch_data.row_offset {
+                    Some(row_offset) => current_row_offset = row_offset,
+                    None => record_batch_data.row_offset = Some(current_row_offset),
+                };
 
                 // Fetch every record batch so we can track the total row count.
                 let rb_num_rows = record_batch_data.num_rows;
@@ -485,7 +581,7 @@ impl FileReader for IpcFileReader {
         // Orchestration.
         let join_task = ASYNC.spawn(async move {
             prefetch_task.await.unwrap()?;
-            decode_task.await.unwrap()?;
+            decode_dispatch_task.await.unwrap()?;
             distribute_task.await?;
             Ok(())
         });

--- a/crates/polars-stream/src/nodes/io_sources/ipc/record_batch_data_fetch.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ipc/record_batch_data_fetch.rs
@@ -1,234 +1,208 @@
 use std::io::Cursor;
+use std::ops::Range;
 use std::sync::Arc;
 
-use polars_async::primitives::oneshot_channel;
-use polars_async::primitives::wait_group::{WaitGroup, WaitToken};
+use polars_async::primitives::wait_group::WaitToken;
 use polars_buffer::Buffer;
+use polars_config::config;
 use polars_core::runtime::ASYNC;
-use polars_core::utils::arrow::io::ipc::read::{
-    BlockReader, FileMetadata, get_row_count_from_blocks,
-};
+use polars_core::utils::arrow::io::ipc::read::{BlockReader, FileMetadata};
+use polars_error::constants::LENGTH_LIMIT_MSG;
 use polars_error::{PolarsResult, polars_err};
-use polars_io::utils::byte_source::{BufferByteSource, ByteSource, DynByteSource};
+use polars_io::utils::byte_source::{ByteSource, DynByteSource};
+use polars_io::utils::slice::SplitSlicePosition;
 use polars_utils::IdxSize;
-use polars_utils::relaxed_cell::RelaxedCell;
+use polars_utils::slice_enum::Slice;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
-use crate::nodes::io_sources::ipc::ROW_COUNT_OVERFLOW_ERR;
 use crate::utils::tokio_handle_ext;
 
 /// Represents byte-data that can be transformed into a DataFrame after some computation.
 pub(super) struct RecordBatchData {
     pub(super) fetched_bytes: Buffer<u8>,
-    pub(super) block_index: usize,
-    pub(super) num_rows: usize,
-    // Lazily updated.
+    pub(super) record_batch_idx: usize,
+    pub(super) num_rows: IdxSize,
     pub(super) row_offset: Option<IdxSize>,
 }
 
 pub(super) struct RecordBatchDataFetcher {
-    pub(super) memory_prefetch_func: fn(&[u8]) -> (),
-    pub(super) metadata: Arc<FileMetadata>,
+    pub(super) file_metadata: Arc<FileMetadata>,
+    pub(super) record_batch_cum_len: Option<Buffer<IdxSize>>,
+
     pub(super) byte_source: Arc<DynByteSource>,
-    pub(super) record_batch_idx: usize,
-    pub(super) fetch_metadata_only: bool,
-    pub(super) n_rows_limit: Option<usize>,
-    pub(super) n_rows_in_file_tx: Option<oneshot_channel::Sender<IdxSize>>,
-    pub(super) row_position_on_end_tx: Option<oneshot_channel::Sender<IdxSize>>,
+    pub(super) memory_prefetch_func: fn(&[u8]) -> (),
+
+    /// Column indices. Full projection if `None`.
+    pub(super) subset_projection_idxs: Option<Arc<[usize]>>,
+    pub(super) pre_slice: Option<Slice>,
+
     pub(super) prefetch_send: Sender<(
         tokio_handle_ext::AbortOnDropHandle<PolarsResult<RecordBatchData>>,
-        OwnedSemaphorePermit,
+        Option<OwnedSemaphorePermit>,
     )>,
+    pub(super) base_rb_metadata_fetch_count: u64,
+
     pub(super) rb_prefetch_semaphore: Arc<Semaphore>,
     pub(super) rb_prefetch_current_all_spawned: Option<WaitToken>,
 }
 
 impl RecordBatchDataFetcher {
-    pub(super) async fn run(&mut self) -> PolarsResult<()> {
-        let current_row_offset: Arc<RelaxedCell<u64>> = Arc::new(RelaxedCell::new_u64(0));
-        let row_count_updated: WaitGroup = WaitGroup::default();
-        let n_record_batches = self.metadata.blocks.len();
+    pub(super) async fn run(self) -> PolarsResult<()> {
+        let Self {
+            file_metadata,
+            record_batch_cum_len,
 
-        if !self.fetch_metadata_only {
-            // Fetch all record batch data until n_rows_limit.
+            byte_source,
+            memory_prefetch_func,
 
-            while self.record_batch_idx < n_record_batches {
-                if let Some(n_rows_limit) = self.n_rows_limit {
-                    if current_row_offset.as_ref().load() > n_rows_limit as u64 {
-                        break;
+            subset_projection_idxs,
+            pre_slice,
+
+            prefetch_send,
+            base_rb_metadata_fetch_count,
+
+            rb_prefetch_semaphore,
+            rb_prefetch_current_all_spawned,
+        } = self;
+
+        let global_slice = pre_slice.clone().map(Range::<usize>::from);
+        let mut rb_fetch_count: u64 = 0;
+
+        for record_batch_idx in 0..file_metadata.blocks.len() {
+            let mut num_rows_this_rb: Option<IdxSize> = None;
+            let mut row_offset: Option<IdxSize> = None;
+
+            if let Some(record_batch_cum_len) = record_batch_cum_len.as_deref() {
+                row_offset = Some(
+                    record_batch_idx
+                        .checked_sub(1)
+                        .map_or(0, |prev_idx| record_batch_cum_len[prev_idx]),
+                );
+                num_rows_this_rb =
+                    Some(record_batch_cum_len[record_batch_idx] - row_offset.unwrap());
+
+                if let Some(global_slice) = global_slice.clone() {
+                    match SplitSlicePosition::split_slice_at_file(
+                        row_offset.unwrap() as usize,
+                        num_rows_this_rb.unwrap() as usize,
+                        global_slice,
+                    ) {
+                        SplitSlicePosition::Before => continue,
+                        SplitSlicePosition::Overlapping(_, _) => {},
+                        SplitSlicePosition::After => break,
                     }
                 }
-
-                let fetch_permit = self
-                    .rb_prefetch_semaphore
-                    .clone()
-                    .acquire_owned()
-                    .await
-                    .unwrap();
-
-                let block_index = self.record_batch_idx;
-                let file_metadata = self.metadata.clone();
-                let current_byte_source = self.byte_source.clone();
-                let memory_prefetch_func = self.memory_prefetch_func;
-                let current_row_offset = current_row_offset.clone();
-                let wait_token = row_count_updated.token();
-
-                let handle = ASYNC.spawn(async move {
-                    let block = file_metadata.blocks.get(block_index).unwrap();
-                    let range = block.offset as usize
-                        ..block.offset as usize
-                            + block.meta_data_length as usize
-                            + block.body_length as usize;
-
-                    let fetched_bytes =
-                        if let DynByteSource::Buffer(mem_slice) = current_byte_source.as_ref() {
-                            let slice = mem_slice.0.as_ref();
-
-                            if !std::ptr::eq(
-                                memory_prefetch_func as *const (),
-                                polars_utils::mem::prefetch::no_prefetch as *const (),
-                            ) {
-                                debug_assert!(range.end <= slice.len());
-                                memory_prefetch_func(unsafe { slice.get_unchecked(range.clone()) })
-                            }
-
-                            mem_slice.0.clone().sliced(range)
-                        } else {
-                            // @NOTE. Performance can be optimized by grouping requests and downloading
-                            // through `get_ranges()`.
-                            current_byte_source.get_range(range).await?
-                        };
-
-                    // We extract the length (i.e., nr of rows) at the earliest possible opportunity.
-                    let num_rows = {
-                        let mut reader = BlockReader::new(Cursor::new(fetched_bytes.as_ref()));
-                        let mut message_scratch = Vec::new();
-                        reader.record_batch_num_rows(&mut message_scratch)?
-                    };
-
-                    current_row_offset.fetch_add(num_rows as u64);
-                    drop(wait_token);
-
-                    PolarsResult::Ok(RecordBatchData {
-                        fetched_bytes,
-                        block_index,
-                        num_rows,
-                        row_offset: None,
-                    })
-                });
-
-                let handle = tokio_handle_ext::AbortOnDropHandle(handle);
-                if self
-                    .prefetch_send
-                    .send((handle, fetch_permit))
-                    .await
-                    .is_err()
-                {
-                    break;
-                }
-
-                self.record_batch_idx += 1;
             }
-        };
 
-        // Remaining row count task.
-        let rb_prefetch_current_all_spawned = self.rb_prefetch_current_all_spawned.take();
-        let remaining_rows_fetch_task =
-            if self.n_rows_in_file_tx.is_some() && self.record_batch_idx < n_record_batches {
-                let byte_source = self.byte_source.clone();
-                let file_metadata = self.metadata.clone();
-                let current_idx = self.record_batch_idx;
+            #[derive(Debug, PartialEq)]
+            enum RbFetch {
+                All,
+                Metadata,
+                None,
+            }
 
-                Some(ASYNC.spawn(async move {
-                    let out =
-                        Self::fetch_row_count(byte_source, file_metadata, Some(current_idx)).await;
-                    drop(rb_prefetch_current_all_spawned);
-                    out
-                }))
+            let rb_fetch = if subset_projection_idxs
+                .as_ref()
+                .is_some_and(|x| x.is_empty())
+            {
+                // 0-length projection or slice.
+                if num_rows_this_rb.is_some() {
+                    RbFetch::None
+                } else {
+                    rb_fetch_count += 1 << 32;
+                    RbFetch::Metadata
+                }
             } else {
-                drop(rb_prefetch_current_all_spawned);
+                rb_fetch_count += 1;
+                RbFetch::All
+            };
+
+            let file_metadata = file_metadata.clone();
+            let current_byte_source = byte_source.clone();
+            let fetch_permit = if rb_fetch != RbFetch::None {
+                Some(rb_prefetch_semaphore.clone().acquire_owned().await.unwrap())
+            } else {
                 None
             };
 
-        // Handle callback for rows fetched until the 'end', i.e. when the requested
-        // slice request has been fulfilled, or somewhat higher due to latency.
-        if let Some(row_position_on_end_tx) = self.row_position_on_end_tx.take() {
-            row_count_updated.wait().await;
+            let fetch_handle = ASYNC.spawn(async move {
+                let block = file_metadata.blocks.get(record_batch_idx).unwrap();
+                let fetch_length = match rb_fetch {
+                    RbFetch::None => 0,
+                    RbFetch::Metadata => block.meta_data_length as usize,
+                    RbFetch::All => block.meta_data_length as usize + block.body_length as usize,
+                };
 
-            let current_row_offset = IdxSize::try_from(current_row_offset.as_ref().load())
-                .map_err(|_| ROW_COUNT_OVERFLOW_ERR)?;
-            _ = row_position_on_end_tx.send(current_row_offset);
+                let range = block.offset as usize
+                    ..usize::checked_add(block.offset as _, fetch_length).unwrap();
+
+                let fetched_bytes = if range.is_empty() {
+                    Buffer::new()
+                } else if let DynByteSource::Buffer(mem_slice) = current_byte_source.as_ref() {
+                    let slice = mem_slice.0.as_ref();
+
+                    if !std::ptr::eq(
+                        memory_prefetch_func as *const (),
+                        polars_utils::mem::prefetch::no_prefetch as *const (),
+                    ) {
+                        debug_assert!(range.end <= slice.len());
+                        memory_prefetch_func(unsafe { slice.get_unchecked(range.clone()) })
+                    }
+
+                    mem_slice.0.clone().sliced(range)
+                } else {
+                    // @NOTE. Performance can be optimized by grouping requests and downloading
+                    // through `get_ranges()`.
+                    current_byte_source.get_range(range).await?
+                };
+
+                // We extract the length (i.e., nr of rows) at the earliest possible opportunity.
+                let num_rows = if let Some(num_rows_this_rb) = num_rows_this_rb {
+                    num_rows_this_rb
+                } else {
+                    let mut reader = BlockReader::new(Cursor::new(fetched_bytes.as_ref()));
+                    let mut message_scratch = vec![];
+                    reader
+                        .record_batch_num_rows(&mut message_scratch)?
+                        .try_into()
+                        .map_err(|_| polars_err!(ComputeError: LENGTH_LIMIT_MSG))?
+                };
+
+                PolarsResult::Ok(RecordBatchData {
+                    fetched_bytes,
+                    record_batch_idx,
+                    num_rows,
+                    row_offset,
+                })
+            });
+
+            let fetch_handle = tokio_handle_ext::AbortOnDropHandle(fetch_handle);
+
+            if prefetch_send
+                .send((fetch_handle, fetch_permit))
+                .await
+                .is_err()
+            {
+                break;
+            }
         }
 
-        // Handle callback for total rows in file.
-        // Fetch record batch metadata only.
-        if let Some(n_rows_in_file_tx) = self.n_rows_in_file_tx.take() {
-            row_count_updated.wait().await;
+        drop(rb_prefetch_current_all_spawned);
 
-            let current_row_offset = IdxSize::try_from(current_row_offset.as_ref().load())
-                .map_err(|_| ROW_COUNT_OVERFLOW_ERR)?;
+        if config().verbose() {
+            let rb_total_count = file_metadata.blocks.len();
+            let rb_full_fetch_count = rb_fetch_count & ((1 << 32) - 1);
+            let rb_metadata_fetch_count = (rb_fetch_count >> 32) + base_rb_metadata_fetch_count;
 
-            let remaining_rows = if let Some(handle) = remaining_rows_fetch_task {
-                handle.await.unwrap()?
-            } else {
-                0
-            };
-            let n_rows = current_row_offset
-                .checked_add(remaining_rows)
-                .ok_or(ROW_COUNT_OVERFLOW_ERR)?;
-            _ = n_rows_in_file_tx.send(n_rows);
+            eprintln!(
+                "[IpcFileReader]: RecordBatchDataFetcher: \
+                rb_total_count: {rb_total_count}, \
+                rb_full_fetch_count: {rb_full_fetch_count}, \
+                rb_metadata_fetch_count: {rb_metadata_fetch_count}"
+            )
         }
 
         Ok(())
-    }
-
-    /// Total row count for all record batches starting at `start_offset`
-    async fn fetch_row_count(
-        byte_source: Arc<DynByteSource>,
-        file_metadata: Arc<FileMetadata>,
-        start_offset: Option<usize>,
-    ) -> PolarsResult<IdxSize> {
-        let start_offset = start_offset.unwrap_or_default();
-
-        let n_rows = match &*byte_source {
-            DynByteSource::Buffer(BufferByteSource(memslice)) => {
-                let n_rows: i64 = get_row_count_from_blocks(
-                    &mut std::io::Cursor::new(memslice.as_ref()),
-                    &file_metadata.blocks[start_offset..],
-                )?;
-
-                IdxSize::try_from(n_rows)
-                    .map_err(|_| polars_err!(bigidx, ctx = "ipc file", size = n_rows))?
-            },
-            DynByteSource::Cloud(_) => {
-                let mut n_rows = 0;
-                let mut message_scratch = Vec::new();
-                let mut ranges: Vec<_> = file_metadata.blocks[start_offset..]
-                    .iter()
-                    .map(|block| {
-                        block.offset as usize
-                            ..block.offset as usize + block.meta_data_length as usize
-                    })
-                    .collect();
-                let ranges_len = ranges.len();
-
-                let bytes_map = ASYNC
-                    .spawn(async move { byte_source.get_ranges(&mut ranges).await })
-                    .await
-                    .unwrap()?;
-                assert_eq!(bytes_map.len(), ranges_len);
-
-                for bytes in bytes_map.into_values() {
-                    let mut reader = BlockReader::new(Cursor::new(bytes.as_ref()));
-                    n_rows += reader.record_batch_num_rows(&mut message_scratch)?;
-                }
-
-                IdxSize::try_from(n_rows)
-                    .map_err(|_| polars_err!(bigidx, ctx = "ipc file", size = n_rows))?
-            },
-        };
-
-        Ok(n_rows)
     }
 }

--- a/crates/polars-stream/src/nodes/io_sources/ipc/record_batch_decode.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ipc/record_batch_decode.rs
@@ -40,7 +40,7 @@ impl RecordBatchDecoder {
         let pl_schema = self.pl_schema.clone();
         let projection_info = self.projection_info.as_ref().clone();
         let bytes = record_batch_data.fetched_bytes;
-        let block_index = record_batch_data.block_index;
+        let block_index = record_batch_data.record_batch_idx;
 
         let mut reader = BlockReader::new(Cursor::new(bytes.as_ref()));
         let dictionaries = self.dictionaries.as_ref().as_ref().unwrap();

--- a/py-polars/tests/unit/io/test_lazy_ipc.py
+++ b/py-polars/tests/unit/io/test_lazy_ipc.py
@@ -411,6 +411,160 @@ def test_sink_ipc_custom_metadata() -> None:
         assert reader.metadata is None
 
 
+def test_scan_ipc_slicing_and_count_with_custom_metadata(
+    plmonkeypatch: PlMonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    df = pl.DataFrame({"a": range(37)})
+
+    f = io.BytesIO()
+    df.lazy().sink_ipc(
+        f,
+        record_batch_size=10,
+        _record_batch_statistics=True,
+    )
+
+    buf = f.getvalue()
+    q = pl.scan_ipc(buf).slice(10, 10)
+
+    plmonkeypatch.setenv("POLARS_VERBOSE", "1")
+    capfd.readouterr()
+    out = q.collect()
+    capture = capfd.readouterr().err
+    plmonkeypatch.setenv("POLARS_VERBOSE", "0")
+
+    assert (
+        "rb_total_count: 4, rb_full_fetch_count: 1, rb_metadata_fetch_count: 0"
+        in capture
+    )
+
+    assert_frame_equal(out, pl.DataFrame({"a": range(10, 20)}))
+
+    footer_header_len = 10
+    footer_md_and_header_len = footer_header_len + int.from_bytes(
+        buf[-10:][:4], byteorder="little"
+    )
+    footer_md_only_buf = buf[-footer_md_and_header_len:]
+
+    # All the following should pass without needing to access record batch data.
+
+    plmonkeypatch.setenv("POLARS_VERBOSE", "1")
+    assert pl.scan_ipc(footer_md_only_buf).select(pl.len()).collect().item() == 37
+    capture = capfd.readouterr().err
+    plmonkeypatch.setenv("POLARS_VERBOSE", "0")
+
+    # 0 fetches; record batch row counts sourced from custom metadata.
+    assert (
+        "rb_total_count: 4, rb_full_fetch_count: 0, rb_metadata_fetch_count: 0"
+        in capture
+    )
+
+    assert (
+        pl.scan_ipc(3 * [footer_md_only_buf]).select(pl.len()).collect().item() == 111
+    )
+
+    for offset_len in [(0, 0), (-1, 0), (1, 0), (-999, 1), (999, 1)]:
+        assert (
+            pl.scan_ipc([footer_md_only_buf, footer_md_only_buf])
+            .slice(*offset_len)
+            .collect()
+            .height
+            == 0
+        )
+
+    assert (
+        pl.scan_ipc([footer_md_only_buf, footer_md_only_buf])
+        .slice(47, 1)
+        .select(pl.len())
+        .collect()
+        .item()
+        == 1
+    )
+    assert (
+        pl.scan_ipc([footer_md_only_buf, footer_md_only_buf])
+        .slice(47, 999)
+        .select(pl.len())
+        .collect()
+        .item()
+        == 27
+    )
+
+
+def test_scan_ipc_fast_count_does_not_read_row_values(
+    plmonkeypatch: PlMonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    df = pl.DataFrame({"a": range(3)})
+    f = io.BytesIO()
+    df.lazy().sink_ipc(
+        f,
+        record_batch_size=999,
+        _record_batch_statistics=False,
+    )
+
+    q = pl.scan_ipc(f.getvalue()).select(pl.len())
+
+    plmonkeypatch.setenv("POLARS_VERBOSE", "1")
+    capfd.readouterr()
+    out = q.collect()
+    capture = capfd.readouterr().err
+    plmonkeypatch.setenv("POLARS_VERBOSE", "0")
+
+    assert (
+        "rb_total_count: 1, rb_full_fetch_count: 0, rb_metadata_fetch_count: 1"
+        in capture
+    )
+    assert out.item() == 3
+
+
+def test_scan_ipc_slicing_and_count(
+    plmonkeypatch: PlMonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    df = pl.DataFrame({"a": range(3)})
+    f = io.BytesIO()
+    df.lazy().sink_ipc(
+        f,
+        record_batch_size=1,
+        _record_batch_statistics=False,
+    )
+
+    buf = f.getvalue()
+    q = pl.scan_ipc(buf).select(pl.len())
+
+    plmonkeypatch.setenv("POLARS_VERBOSE", "1")
+    capfd.readouterr()
+    out = q.collect()
+    capture = capfd.readouterr().err
+    plmonkeypatch.setenv("POLARS_VERBOSE", "0")
+
+    assert (
+        "rb_total_count: 3, rb_full_fetch_count: 0, rb_metadata_fetch_count: 3"
+        in capture
+    )
+    assert out.item() == 3
+
+    q = pl.scan_ipc(buf).slice(1, 1)
+
+    plmonkeypatch.setenv("POLARS_VERBOSE", "1")
+    capfd.readouterr()
+    out = q.collect()
+    capture = capfd.readouterr().err
+    plmonkeypatch.setenv("POLARS_VERBOSE", "0")
+
+    # rb_metadata_fetch_count == rb_total_count, we fetched all record batch
+    # metadatas to resolve slice.
+    assert (
+        "rb_total_count: 3, rb_full_fetch_count: 1, rb_metadata_fetch_count: 3"
+        in capture
+    )
+
+    assert_frame_equal(
+        out,
+        pl.DataFrame({"a": 1}),
+    )
+
+
 @pytest.mark.parametrize(
     "selection",
     [["b"], ["a", "b", "c", "d"], ["d", "c", "a", "b"], ["d", "a", "b"]],


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/27285

Skips downloading record batches that are before slice start / after slice end.
* If the file was written with `record_batch_statistics=true`, record batch row counts will be available / loaded from footer metadata under `__POLARS_IPC_METADATA`. (needs https://github.com/pola-rs/polars/pull/27549). Then we can immediately determine which ranges to fetch from the file.
  * Otherwise, we will first download the metadata sections of each individual record batch to determine the record batch row counts.

#### Benchmarks
System - EC2 c6gn.16xlarge
Description - Scan single IPC file from S3
File - 100M rows x 50 cols IPC file

##### With footer metadata
| Slice                        | Before | After | Speedup |
| ---------------------------- | ------ | ----- | ------- |
| head(5_000_000)              | 8.27s  | 2.07s | 3.99x   |
| slice(50_000_000, 5_000_000) | 28.68s | 2.07s | 13.85x  |
| tail(5_000_000)              | 56.16s | 2.07s | 27.13x  |

##### Without footer metadata
| Slice                        | Before | After | Speedup |
| ---------------------------- | ------ | ----- | ------- |
| head(5_000_000)              | 8.27s  | 4.45s | 1.85x   |
| slice(50_000_000, 5_000_000) | 28.68s | 4.45s | 6.44x   |
| tail(5_000_000)              | 56.16s | 4.45s | 12.62x  |

<details>
<summary>Script</summary>

```python
import polars as pl
from time import perf_counter

pl.Config.set_engine_affinity("streaming")

index_lf = pl.LazyFrame(height=100_000_000).with_columns(index=pl.row_index())

exprs = []

for i in range(1, 50):
    c = f"c{i}"
    h = pl.col("index").hash(seed=i)
    exprs.append((h if i % 2 == 0 else h.cast(pl.String)).alias(c))

lf = index_lf.with_columns(exprs, partition_key=pl.col("index") // 250_000).drop("c48")
# lf.sink_ipc(f"{out_prefix}single.ipc", _record_batch_statistics=True)
# lf.sink_ipc(f"{out_prefix}single.ipc", _record_batch_statistics=False)

q = pl.scan_ipc(f"{out_prefix}single.ipc").head(5_000_000).select(
    pl.all().last().name.prefix('last_'),
    pl.all().first().name.prefix('first_')
)
print(q.explain())
q.collect()
```

</details>
