### PR TITLE
fix: Sort flag on GroupsType only applies to first element

### DIFF
--- a/crates/polars-core/src/frame/group_by/aggregations/boolean.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/boolean.rs
@@ -76,7 +76,7 @@ impl BooleanChunked {
 impl BooleanChunked {
     pub(crate) unsafe fn agg_min(&self, groups: &GroupsType) -> Series {
         // faster paths
-        if groups.is_sorted_flag() {
+        if !self.has_nulls() || matches!(groups, GroupsType::Slice { .. }) {
             match self.is_sorted_flag() {
                 IsSorted::Ascending => {
                     return self.clone().into_series().agg_first_non_null(groups);
@@ -123,7 +123,7 @@ impl BooleanChunked {
     }
     pub(crate) unsafe fn agg_max(&self, groups: &GroupsType) -> Series {
         // faster paths
-        if groups.is_sorted_flag() {
+        if !self.has_nulls() || matches!(groups, GroupsType::Slice { .. }) {
             match self.is_sorted_flag() {
                 IsSorted::Ascending => return self.clone().into_series().agg_last_non_null(groups),
                 IsSorted::Descending => {
@@ -170,7 +170,7 @@ impl BooleanChunked {
 
     pub(crate) unsafe fn agg_arg_min(&self, groups: &GroupsType) -> Series {
         // faster paths
-        if groups.is_sorted_flag() {
+        if !self.has_nulls() || matches!(groups, GroupsType::Slice { .. }) {
             match self.is_sorted_flag() {
                 IsSorted::Ascending => {
                     return self.clone().into_series().agg_arg_first_non_null(groups);
@@ -219,7 +219,7 @@ impl BooleanChunked {
 
     pub(crate) unsafe fn agg_arg_max(&self, groups: &GroupsType) -> Series {
         // faster paths
-        if groups.is_sorted_flag() {
+        if !self.has_nulls() || matches!(groups, GroupsType::Slice { .. }) {
             match self.is_sorted_flag() {
                 IsSorted::Ascending => {
                     return self.clone().into_series().agg_arg_last_non_null(groups);

--- a/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
@@ -86,7 +86,7 @@ impl Series {
                 s.take_unchecked(&indices)
             },
         };
-        if groups.is_sorted_flag() {
+        if groups.is_sorted_by_first_idx() {
             out.set_sorted_flag(s.is_sorted_flag())
         }
         s.restore_logical(out)
@@ -143,7 +143,7 @@ impl Series {
         };
         // SAFETY: groups are always in bounds.
         let mut out = s.take_unchecked(&indices);
-        if groups.is_sorted_flag() {
+        if matches!(groups, GroupsType::Slice { .. }) && !groups.is_overlapping() {
             out.set_sorted_flag(s.is_sorted_flag())
         }
         s.restore_logical(out)
@@ -598,7 +598,7 @@ impl Series {
         };
         // SAFETY: groups are always in bounds.
         let mut out = s.take_unchecked(&indices);
-        if groups.is_sorted_flag() {
+        if groups.is_monotonic() {
             out.set_sorted_flag(s.is_sorted_flag())
         }
         s.restore_logical(out)

--- a/crates/polars-core/src/frame/group_by/aggregations/mod.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/mod.rs
@@ -450,7 +450,7 @@ where
 {
     pub(crate) unsafe fn agg_min(&self, groups: &GroupsType) -> Series {
         // faster paths
-        if groups.is_sorted_flag() {
+        if !self.has_nulls() || matches!(groups, GroupsType::Slice { .. }) {
             match self.is_sorted_flag() {
                 IsSorted::Ascending => {
                     return self.clone().into_series().agg_first_non_null(groups);
@@ -528,7 +528,7 @@ where
     where
         for<'b> &'b [T::Native]: ArgMinMax,
     {
-        if groups.is_sorted_flag() {
+        if !self.has_nulls() || matches!(groups, GroupsType::Slice { .. }) {
             match self.is_sorted_flag() {
                 IsSorted::Ascending => {
                     return self.clone().into_series().agg_arg_first_non_null(groups);
@@ -633,7 +633,7 @@ where
 
     pub(crate) unsafe fn agg_max(&self, groups: &GroupsType) -> Series {
         // faster paths
-        if groups.is_sorted_flag() {
+        if !self.has_nulls() || matches!(groups, GroupsType::Slice { .. }) {
             match self.is_sorted_flag() {
                 IsSorted::Ascending => return self.clone().into_series().agg_last_non_null(groups),
                 IsSorted::Descending => {
@@ -709,7 +709,7 @@ where
     where
         for<'b> &'b [T::Native]: ArgMinMax,
     {
-        if groups.is_sorted_flag() {
+        if !self.has_nulls() || matches!(groups, GroupsType::Slice { .. }) {
             match self.is_sorted_flag() {
                 IsSorted::Ascending => {
                     return self.clone().into_series().agg_arg_last_non_null(groups);

--- a/crates/polars-core/src/frame/group_by/aggregations/string.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/string.rs
@@ -20,7 +20,7 @@ impl BinaryChunked {
     #[allow(clippy::needless_lifetimes)]
     pub(crate) unsafe fn agg_min<'a>(&'a self, groups: &GroupsType) -> Series {
         // faster paths
-        if groups.is_sorted_flag() {
+        if !self.has_nulls() || matches!(groups, GroupsType::Slice { .. }) {
             match self.is_sorted_flag() {
                 IsSorted::Ascending => {
                     return self.clone().into_series().agg_first_non_null(groups);
@@ -84,7 +84,7 @@ impl BinaryChunked {
     #[allow(clippy::needless_lifetimes)]
     pub(crate) unsafe fn agg_max<'a>(&'a self, groups: &GroupsType) -> Series {
         // faster paths
-        if groups.is_sorted_flag() {
+        if !self.has_nulls() || matches!(groups, GroupsType::Slice { .. }) {
             match self.is_sorted_flag() {
                 IsSorted::Ascending => return self.clone().into_series().agg_last_non_null(groups),
                 IsSorted::Descending => {
@@ -145,7 +145,7 @@ impl BinaryChunked {
 
     pub(crate) unsafe fn agg_arg_min(&self, groups: &GroupsType) -> Series {
         // fast paths, consistent with other impls
-        if groups.is_sorted_flag() {
+        if !self.has_nulls() || matches!(groups, GroupsType::Slice { .. }) {
             match self.is_sorted_flag() {
                 IsSorted::Ascending => {
                     return self.clone().into_series().agg_arg_first_non_null(groups);
@@ -200,7 +200,7 @@ impl BinaryChunked {
 
     pub(crate) unsafe fn agg_arg_max(&self, groups: &GroupsType) -> Series {
         // fast paths
-        if groups.is_sorted_flag() {
+        if !self.has_nulls() || matches!(groups, GroupsType::Slice { .. }) {
             match self.is_sorted_flag() {
                 IsSorted::Ascending => {
                     return self.clone().into_series().agg_arg_last_non_null(groups);

--- a/crates/polars-core/src/frame/group_by/hashing.rs
+++ b/crates/polars-core/src/frame/group_by/hashing.rs
@@ -59,7 +59,7 @@ fn finish_group_order(mut out: Vec<Vec<IdxItem>>, sorted: bool) -> GroupsType {
         };
         out.sort_unstable_by_key(|g| g.0);
         let mut idx = GroupsIdx::from_iter(out);
-        idx.sorted = true;
+        idx.sorted_by_first_idx = true;
         GroupsType::Idx(idx)
     } else {
         // we can just take the first value, no need to flatten

--- a/crates/polars-core/src/frame/group_by/mod.rs
+++ b/crates/polars-core/src/frame/group_by/mod.rs
@@ -262,7 +262,7 @@ impl<'a> GroupBy<'a> {
                         GroupsType::Idx(groups) => {
                             // SAFETY: groups are always in bounds.
                             let mut out = unsafe { s.take_slice_unchecked(groups.first()) };
-                            if groups.sorted {
+                            if groups.sorted_by_first_idx {
                                 out.set_sorted_flag(s.is_sorted_flag());
                             };
                             out

--- a/crates/polars-core/src/frame/group_by/position.rs
+++ b/crates/polars-core/src/frame/group_by/position.rs
@@ -14,7 +14,7 @@ use crate::utils::{NoNull, flatten, slice_slice};
 /// this make sorting fast.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct GroupsIdx {
-    pub(crate) sorted: bool,
+    pub(crate) sorted_by_first_idx: bool,
     /// Positions of the start of each group.
     first: Vec<IdxSize>,
     /// Global positions of all elements of all groups.
@@ -82,7 +82,7 @@ impl From<Vec<Vec<IdxItem>>> for GroupsIdx {
             first.set_len(cap);
         }
         GroupsIdx {
-            sorted: false,
+            sorted_by_first_idx: false,
             first,
             all,
         }
@@ -90,12 +90,16 @@ impl From<Vec<Vec<IdxItem>>> for GroupsIdx {
 }
 
 impl GroupsIdx {
-    pub fn new(first: Vec<IdxSize>, all: Vec<IdxVec>, sorted: bool) -> Self {
-        Self { sorted, first, all }
+    pub fn new(first: Vec<IdxSize>, all: Vec<IdxVec>, sorted_by_first_idx: bool) -> Self {
+        Self {
+            sorted_by_first_idx,
+            first,
+            all,
+        }
     }
 
-    pub fn sort(&mut self) {
-        if self.sorted {
+    pub fn sort_by_first_idx(&mut self) {
+        if self.sorted_by_first_idx {
             return;
         }
         let mut idx = 0;
@@ -124,10 +128,10 @@ impl GroupsIdx {
         let (first, all) = RAYON.install(|| rayon::join(take_first, take_all));
         self.first = first;
         self.all = all;
-        self.sorted = true
+        self.sorted_by_first_idx = true
     }
-    pub fn is_sorted_flag(&self) -> bool {
-        self.sorted
+    pub fn is_sorted_by_first_idx(&self) -> bool {
+        self.sorted_by_first_idx
     }
 
     pub fn iter(
@@ -164,7 +168,7 @@ impl GroupsIdx {
     // Create an 'empty group', containing 1 group of length 0
     pub fn new_empty() -> Self {
         Self {
-            sorted: false,
+            sorted_by_first_idx: false,
             first: vec![0],
             all: vec![vec![].into()],
         }
@@ -175,7 +179,7 @@ impl FromIterator<IdxItem> for GroupsIdx {
     fn from_iter<T: IntoIterator<Item = IdxItem>>(iter: T) -> Self {
         let (first, all) = iter.into_iter().unzip();
         GroupsIdx {
-            sorted: false,
+            sorted_by_first_idx: false,
             first,
             all,
         }
@@ -212,7 +216,7 @@ impl FromParallelIterator<IdxItem> for GroupsIdx {
     {
         let (first, all) = par_iter.into_par_iter().unzip();
         GroupsIdx {
-            sorted: false,
+            sorted_by_first_idx: false,
             first,
             all,
         }
@@ -248,13 +252,13 @@ impl IntoParallelIterator for GroupsIdx {
 ///
 /// Only used when group values are stored together
 ///
-/// This type should have the invariant that it is always sorted in ascending order.
+/// This type should have the invariant that it is always sorted in ascending
+/// order by the start indices.
 pub type GroupsSlice = Vec<[IdxSize; 2]>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GroupsType {
     Idx(GroupsIdx),
-    /// Slice is always sorted in ascending order.
     Slice {
         // the groups slices
         groups: GroupsSlice,
@@ -408,11 +412,11 @@ impl GroupsType {
         GroupsTypeIter::new(self)
     }
 
-    pub fn sort(&mut self) {
+    pub fn sort_by_first_idx(&mut self) {
         match self {
             GroupsType::Idx(groups) => {
-                if !groups.is_sorted_flag() {
-                    groups.sort()
+                if !groups.is_sorted_by_first_idx() {
+                    groups.sort_by_first_idx()
                 }
             },
             GroupsType::Slice { .. } => {
@@ -421,9 +425,9 @@ impl GroupsType {
         }
     }
 
-    pub(crate) fn is_sorted_flag(&self) -> bool {
+    pub(crate) fn is_sorted_by_first_idx(&self) -> bool {
         match self {
-            GroupsType::Idx(groups) => groups.is_sorted_flag(),
+            GroupsType::Idx(groups) => groups.is_sorted_by_first_idx(),
             GroupsType::Slice { .. } => true,
         }
     }
@@ -755,10 +759,10 @@ impl GroupPositions {
         slice_groups(self.original.clone(), offset, len)
     }
 
-    pub fn sort(&mut self) {
-        if !self.as_ref().is_sorted_flag() {
+    pub fn sort_by_first_idx(&mut self) {
+        if !self.as_ref().is_sorted_by_first_idx() {
             let original = Arc::make_mut(&mut self.original);
-            original.sort();
+            original.sort_by_first_idx();
 
             self.sliced = slice_groups_inner(original, self.offset, self.len);
         }
@@ -834,7 +838,7 @@ fn slice_groups_inner(g: &GroupsType, offset: i64, len: usize) -> ManuallyDrop<G
             ManuallyDrop::new(GroupsType::Idx(GroupsIdx::new(
                 first,
                 all,
-                groups.is_sorted_flag(),
+                groups.is_sorted_by_first_idx(),
             )))
         },
         GroupsType::Slice {

--- a/crates/polars-expr/src/expressions/window.rs
+++ b/crates/polars-expr/src/expressions/window.rs
@@ -478,7 +478,7 @@ impl PhysicalExpr for WindowExpr {
         // the groups, so that the cached groups and join keys
         // are consistent among all windows
         if sort_groups || state.cache_window() {
-            groups.sort();
+            groups.sort_by_first_idx();
             state
                 .window_cache
                 .insert_groups(cache_key.clone(), groups.clone());

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -3120,6 +3120,8 @@ def test_group_by_sort_flag_27672() -> None:
         }
     )
 
-    out = df.sort("z").group_by("s", maintain_order=True).max().sort("z", descending=True)
+    out = (
+        df.sort("z").group_by("s", maintain_order=True).max().sort("z", descending=True)
+    )
     expected = pl.DataFrame({"s": ["b", "a"], "z": [2, 1]})
     assert_frame_equal(out, expected)

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -3110,3 +3110,16 @@ def test_group_by_max_by_min_by_string_single_element_27171() -> None:
     result = df.group_by("key", maintain_order=True).agg(pl.col("val").min_by("by"))
     assert result.filter(pl.col("key") == "a")["val"][0] == 10
     assert result.filter(pl.col("key") == "b")["val"][0] == 30
+
+
+def test_group_by_sort_flag_27672() -> None:
+    df = pl.DataFrame(
+        {
+            "s": ["a", "b", "b", "b"],
+            "z": [1, 2, 0, None],
+        }
+    )
+
+    out = df.sort("z").group_by("s", maintain_order=True).max().sort("z", descending=True)
+    expected = pl.DataFrame({"s": ["b", "a"], "z": [2, 1]})
+    assert_frame_equal(out, expected)


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/27672.

Our `GroupsType` has an `is_sorted_flag` function which was rather confusing. It seems to suggest that within each group the indices will be sorted, but it only actually guarantees the first index of each group is in a sorted order. I renamed the function and went through all places where it was used and fixed incorrect assumptions.