### PR TITLE
fix: Invalid unwrap_unchecked when length isn't exact

### DIFF
--- a/crates/polars-parquet/src/parquet/types.rs
+++ b/crates/polars-parquet/src/parquet/types.rs
@@ -246,6 +246,11 @@ pub fn decode<T: NativeType>(chunk: &[u8]) -> T {
 /// This is safe if the length is properly checked.
 #[inline]
 pub unsafe fn decode_unchecked<T: NativeType>(chunk: &[u8]) -> T {
-    let chunk: <T as NativeType>::Bytes = unsafe { chunk.try_into().unwrap_unchecked() };
+    let chunk: <T as NativeType>::Bytes = unsafe {
+        chunk
+            .get_unchecked(..size_of::<T>())
+            .try_into()
+            .unwrap_unchecked()
+    };
     T::from_le_bytes(chunk)
 }


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/27665.

We did check that the length was *large enough*, but the `unwrap_unchecked` would be invalid if the length wasn't *exact*. Slicing off the excess fixes it.