### PR TITLE
docs: Document Expr.list.__getitem__

### DIFF
--- a/py-polars/docs/source/reference/expressions/list.rst
+++ b/py-polars/docs/source/reference/expressions/list.rst
@@ -9,6 +9,7 @@ The following methods are available under the `expr.list` attribute.
    :toctree: api/
    :template: autosummary/accessor_method.rst
 
+    Expr.list.__getitem__
     Expr.list.agg
     Expr.list.all
     Expr.list.any

--- a/py-polars/src/polars/expr/list.py
+++ b/py-polars/src/polars/expr/list.py
@@ -33,6 +33,31 @@ class ExprListNameSpace:
         self._pyexpr = expr._pyexpr
 
     def __getitem__(self, item: int) -> Expr:
+        """
+        Get the value by index in the sublists.
+
+        This is syntactic sugar for :meth:`Expr.list.get`.
+
+        Parameters
+        ----------
+        item
+            Index to return per sublist. Index ``0`` returns the first item, and
+            index ``-1`` returns the last item.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"a": [[3, 2, 1], [4, 5, 6]]})
+        >>> df.with_columns(get=pl.col("a").list[0])
+        shape: (2, 2)
+        ┌───────────┬─────┐
+        │ a         ┆ get │
+        │ ---       ┆ --- │
+        │ list[i64] ┆ i64 │
+        ╞═══════════╪═════╡
+        │ [3, 2, 1] ┆ 3   │
+        │ [4, 5, 6] ┆ 4   │
+        └───────────┴─────┘
+        """
         return self.get(item)
 
     def all(self, *, ignore_nulls: bool = True) -> Expr:


### PR DESCRIPTION
Closes #27571.

Documents `Expr.list.__getitem__` in the Python API reference and adds a docstring/example for list index access syntax.

Validation:
- python -m compileall py-polars/src/polars/expr/list.py
- git diff --check
