### PR TITLE
docs: Clarify join validation disables streaming

### DIFF
--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -6380,6 +6380,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                  - One-to-many. Checks if join keys are unique in left dataset.
                * - **m:1**
                  - Many-to-one. Check if join keys are unique in right dataset.
+
+            .. note::
+                Using this parameter will result in higher memory usage, as it
+                will disable streaming for the join.
         nulls_equal
             Join on null values. By default null values will never produce matches.
         coalesce


### PR DESCRIPTION
Closes #26678.

Updates the `LazyFrame.join(validate=...)` documentation to clarify that join validation disables streaming and may increase memory usage.