### PR TITLE
docs: Clarify IO plugin filtering order

### DIFF
--- a/docs/source/user-guide/plugins/io_plugins.md
+++ b/docs/source/user-guide/plugins/io_plugins.md
@@ -69,15 +69,18 @@ The arguments of this function are predefined and this function must accept:
 
 - `with_columns`
 
-  Columns that are projected. The reader must project these columns if applied
+  Columns projected in the final output. If `predicate` is also provided, apply the predicate before
+  this projection, as the predicate may depend on columns that are not part of `with_columns`.
 
 - `predicate`
 
-  Polars expression. The reader must filter their rows accordingly.
+  Polars expression. If provided, the reader must filter its rows accordingly before applying the
+  final projection.
 
 - `n_rows`
 
-  Materialize only n rows from the source. The reader can stop when `n_rows` are read.
+  Maximum number of source rows to materialize when slice pushdown is applicable. This is an
+  early-stop hint for the source, not a guarantee about the number of rows after filtering.
 
 - `batch_size`
 
@@ -127,15 +130,16 @@ def my_scan_csv(csv_str: str) -> pl.LazyFrame:
             df = pl.from_records(rows, schema=schema, orient="row")
             n_rows -= df.height
 
+            # If the source supports predicate pushdown, the expression can be parsed
+            # to skip rows/groups. Apply it before the final projection, as it may
+            # reference columns that are not included in `with_columns`.
+            if predicate is not None:
+                df = df.filter(predicate)
+
             # If we would make a performant reader, we would not read these
             # columns at all.
             if with_columns is not None:
                 df = df.select(with_columns)
-
-            # If the source supports predicate pushdown, the expression can be parsed
-            # to skip rows/groups.
-            if predicate is not None:
-                df = df.filter(predicate)
 
             yield df
 

--- a/py-polars/src/polars/io/plugins.py
+++ b/py-polars/src/polars/io/plugins.py
@@ -41,14 +41,16 @@ def register_io_source(
     io_source
         Function that accepts the following arguments:
             with_columns
-                Columns that are projected. The reader must
-                project these columns if applied
+                Columns projected in the final output. If a predicate is also
+                provided, the predicate must be applied before this projection,
+                as it may depend on columns that are not part of `with_columns`.
             predicate
-                Polars expression. The reader must filter
-                their rows accordingly.
+                Polars expression. If provided, the reader must filter its rows
+                accordingly before applying the final projection.
             n_rows
-                Materialize only n rows from the source.
-                The reader can stop when `n_rows` are read.
+                Maximum number of source rows to materialize when slice pushdown is
+                applicable. This is an early-stop hint for the source, not a
+                guarantee about the number of rows after filtering.
             batch_size
                 A hint of the ideal batch size the reader's
                 generator must produce.


### PR DESCRIPTION
Closes #25741

Clarifies the expected order for IO plugin predicate handling and final projection.

This updates both the `register_io_source` docstring and the IO plugins user guide to state that predicates must be applied before the final `with_columns` projection, since predicates may reference columns that are not included in the projected output.

Also clarifies that `n_rows` is an early-stop hint for source materialization rather than a guarantee about the number of rows after filtering.