### PR TITLE
feat(python): Support args in LazyFrame.pipe_with_schema

### DIFF
--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -988,7 +988,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     @unstable()
     def pipe_with_schema(
         self,
-        function: Callable[[LazyFrame, Schema], LazyFrame],
+        function: Callable[Concatenate[LazyFrame, Schema, P], LazyFrame],
+        *args: P.args,
+        **kwargs: P.kwargs,
     ) -> LazyFrame:
         """
         Allows to alter the lazy frame during the plan stage with the resolved schema.
@@ -1005,8 +1007,12 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         Parameters
         ----------
         function
-            Callable; will receive the frame as the first parameter and the resolved
-            schema as the second parameter.
+            Callable; will receive the frame as the first parameter, the resolved
+            schema as the second parameter, followed by any given args/kwargs.
+        *args
+            Arguments to pass to the UDF.
+        **kwargs
+            Keyword arguments to pass to the UDF.
 
         See Also
         --------
@@ -1045,6 +1051,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             return function(
                 self._from_pyldf(lf_and_schema[0][0]),
                 lf_and_schema[1][0],
+                *args,
+                **kwargs,
             )._ldf
 
         return self._from_pyldf(self._ldf.pipe_with_schema(wrapper))

--- a/py-polars/tests/unit/lazyframe/test_pipe_with_schema.py
+++ b/py-polars/tests/unit/lazyframe/test_pipe_with_schema.py
@@ -28,3 +28,36 @@ def test_pipe_with_schema_rewrite() -> None:
 
     assert result.schema == {"x": pl.Int64}
     assert result.height == 3
+
+
+def test_pipe_with_schema_args_kwargs() -> None:
+    def cast_columns(
+        lf: pl.LazyFrame,
+        schema: pl.Schema,
+        target_dtype: pl.DataType,
+        *,
+        only_non_float: bool,
+    ) -> pl.LazyFrame:
+        required_casts = [
+            pl.col(name).cast(target_dtype)
+            for name, dtype in schema.items()
+            if not only_non_float or not dtype.is_float()
+        ]
+        return lf.with_columns(required_casts)
+
+    lf = pl.LazyFrame(
+        {"a": [1.0, 2.0], "b": ["1.0", "2.5"], "c": [2.0, 3.0]},
+        schema={"a": pl.Float64, "b": pl.String, "c": pl.Float32},
+    )
+
+    result = lf.pipe_with_schema(
+        cast_columns,
+        pl.Float64(),
+        only_non_float=True,
+    ).collect()
+
+    assert result.schema == {
+        "a": pl.Float64,
+        "b": pl.Float64,
+        "c": pl.Float32,
+    }


### PR DESCRIPTION
Closes #26875.

## Summary

Adds `*args` and `**kwargs` forwarding to `LazyFrame.pipe_with_schema`, matching the behavior of `LazyFrame.pipe`.

## Tests

- `pytest tests/unit/lazyframe/test_pipe_with_schema.py`
- `mypy tests/unit/lazyframe/test_pipe_with_schema.py`