### PR TITLE
refactor(rust): Remove unused suspect AsRef impl

### DIFF
--- a/crates/polars-plan/src/dsl/expr/mod.rs
+++ b/crates/polars-plan/src/dsl/expr/mod.rs
@@ -61,31 +61,6 @@ pub enum AggExpr {
     Var(Arc<Expr>, u8),
 }
 
-impl AsRef<Expr> for AggExpr {
-    fn as_ref(&self) -> &Expr {
-        use AggExpr::*;
-        match self {
-            Min { input, .. } => input,
-            Max { input, .. } => input,
-            Median(e) => e,
-            NUnique(e) => e,
-            First(e) => e,
-            FirstNonNull(e) => e,
-            Last(e) => e,
-            LastNonNull(e) => e,
-            Item { input, .. } => input,
-            Mean(e) => e,
-            Implode { input, .. } => input,
-            Count { input, .. } => input,
-            Quantile { expr, .. } => expr,
-            Sum(e) => e,
-            AggGroups(e) => e,
-            Std(e, _) => e,
-            Var(e, _) => e,
-        }
-    }
-}
-
 /// Expressions that can be used in various contexts.
 ///
 /// Queries consist of multiple expressions.


### PR DESCRIPTION
This wasn't used and really shouldn't exist in the first place.