### PR TITLE
perf: Improve in-memory grouped non-null count

### DIFF
--- a/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
@@ -6,10 +6,6 @@ use crate::prelude::row_encode::encode_rows_unordered;
 
 // implemented on the series because we don't need types
 impl Series {
-    fn slice_from_offsets(&self, first: IdxSize, len: IdxSize) -> Self {
-        self.slice(first as i64, len as usize)
-    }
-
     unsafe fn restore_logical(&self, out: Series) -> Series {
         if self.dtype().is_logical() && !out.dtype().is_logical() {
             out.from_physical_unchecked(self.dtype()).unwrap()
@@ -21,34 +17,29 @@ impl Series {
     #[doc(hidden)]
     pub unsafe fn agg_valid_count(&self, groups: &GroupsType) -> Series {
         // Prevent a rechunk for every individual group.
-        let s = if groups.len() > 1 && self.null_count() > 0 {
-            self.rechunk()
-        } else {
-            self.clone()
-        };
+        let valid = self.rechunk_validity();
 
         match groups {
-            GroupsType::Idx(groups) => agg_helper_idx_on_all::<IdxType, _>(groups, |idx| {
-                debug_assert!(idx.len() <= s.len());
-                if idx.is_empty() {
-                    None
-                } else if s.null_count() == 0 {
-                    Some(idx.len() as IdxSize)
+            GroupsType::Idx(groups) => agg_helper_idx_on_all::<IdxType, _>(groups, |idxs| {
+                debug_assert!(idxs.len() <= self.len());
+                if let Some(v) = &valid {
+                    let mut count = 0;
+                    for idx in idxs.iter() {
+                        count += unsafe { v.get_bit_unchecked(*idx as usize) as IdxSize };
+                    }
+                    Some(count)
                 } else {
-                    let take = unsafe { s.take_slice_unchecked(idx) };
-                    Some((take.len() - take.null_count()) as IdxSize)
+                    Some(self.len() as IdxSize)
                 }
             }),
             GroupsType::Slice { groups, .. } => {
                 _agg_helper_slice::<IdxType, _>(groups, |[first, len]| {
-                    debug_assert!(len <= s.len() as IdxSize);
-                    if len == 0 {
-                        None
-                    } else if s.null_count() == 0 {
-                        Some(len)
+                    debug_assert!(len <= self.len() as IdxSize);
+                    if let Some(v) = &valid {
+                        let m = BitMask::from_bitmap(v).sliced(first as usize, len as usize);
+                        Some(m.set_bits() as IdxSize)
                     } else {
-                        let take = s.slice_from_offsets(first, len);
-                        Some((take.len() - take.null_count()) as IdxSize)
+                        Some(self.len() as IdxSize)
                     }
                 })
             },


### PR DESCRIPTION
This was doing full gathers while it could just operate on the validity only and avoid actually materializing a gathered copy.