### PR TITLE
refactor(rust): Remove trailing semicolons in fmt macros

### DIFF
--- a/crates/polars-utils/src/fmt.rs
+++ b/crates/polars-utils/src/fmt.rs
@@ -20,7 +20,7 @@ macro_rules! format_list_container {
         }
         out.push($end);
         out
-    };};
+    }};
 }
 
 #[macro_export]
@@ -28,7 +28,7 @@ macro_rules! format_list {
     ($e:expr) => {{
         use polars_utils::format_list_container;
         format_list_container!($e, '[', ']')
-    };};
+    }};
 }
 
 #[macro_export]
@@ -36,7 +36,7 @@ macro_rules! format_tuple {
     ($e:expr) => {{
         use polars_utils::format_list_container;
         format_list_container!($e, '(', ')')
-    };};
+    }};
 }
 
 #[macro_export]
@@ -68,7 +68,7 @@ macro_rules! format_list_container_truncated {
         }
         out.push($end);
         out
-    };};
+    }};
 }
 
 #[macro_export]
@@ -76,9 +76,9 @@ macro_rules! format_list_truncated {
     ($e:expr, $max:expr) => {{
         use polars_utils::format_list_container_truncated;
         format_list_container_truncated!($e, '[', ']', $max, "")
-    };};
+    }};
     ($e:expr, $max:expr, $quote:expr) => {{
         use polars_utils::format_list_container_truncated;
         format_list_container_truncated!($e, '[', ']', $max, $quote)
-    };};
+    }};
 }


### PR DESCRIPTION
Remove trailing semicolons from format macros that return values. These are silently ignored by the compiler when the macro is used in an expression context, but this behavior will be changed in the future and rust analyzer is already reporting it in some cases.

See: https://doc.rust-lang.org/rustc/lints/listing/deny-by-default.html#semicolon-in-expressions-from-macros