### PR TITLE
fix: Persist object_store rebuild state in cache

### DIFF
--- a/crates/polars-io/src/cloud/polars_object_store.rs
+++ b/crates/polars-io/src/cloud/polars_object_store.rs
@@ -81,6 +81,9 @@ mod inner {
     struct Inner {
         store: tokio::sync::RwLock<Arc<dyn ObjectStore>>,
         builder: PolarsObjectStoreBuilder,
+        /// Used for interior mutability. Doesn't need to be shared with other threads so it's not
+        /// inside `Arc<>`.
+        rebuilt: RelaxedCell<bool>,
     }
 
     /// Polars wrapper around [`ObjectStore`] functionality. This struct is cheaply cloneable.
@@ -89,9 +92,6 @@ mod inner {
         inner: Arc<Inner>,
         /// Avoid contending the Mutex `lock()` until the first re-build.
         initial_store: std::sync::Arc<dyn ObjectStore>,
-        /// Used for interior mutability. Doesn't need to be shared with other threads so it's not
-        /// inside `Arc<>`.
-        rebuilt: RelaxedCell<bool>,
         io_metrics: OptIOMetrics,
     }
 
@@ -105,9 +105,9 @@ mod inner {
                 inner: Arc::new(Inner {
                     store: tokio::sync::RwLock::new(store),
                     builder,
+                    rebuilt: RelaxedCell::from(false),
                 }),
                 initial_store,
-                rebuilt: RelaxedCell::from(false),
                 io_metrics: OptIOMetrics(None),
             }
         }
@@ -123,7 +123,7 @@ mod inner {
 
         /// Gets the underlying [`ObjectStore`] implementation.
         pub async fn to_dyn_object_store(&self) -> Cow<'_, Arc<dyn ObjectStore>> {
-            if !self.rebuilt.load() {
+            if !self.inner.rebuilt.load() {
                 Cow::Borrowed(&self.initial_store)
             } else {
                 Cow::Owned(self.inner.store.read().await.clone())
@@ -149,7 +149,7 @@ mod inner {
                         })?;
             }
 
-            self.rebuilt.store(true);
+            self.inner.rebuilt.store(true);
 
             Ok((*current_store).clone())
         }

--- a/crates/polars-io/src/cloud/polars_object_store.rs
+++ b/crates/polars-io/src/cloud/polars_object_store.rs
@@ -81,8 +81,6 @@ mod inner {
     struct Inner {
         store: tokio::sync::RwLock<Arc<dyn ObjectStore>>,
         builder: PolarsObjectStoreBuilder,
-        /// Used for interior mutability. Doesn't need to be shared with other threads so it's not
-        /// inside `Arc<>`.
         rebuilt: RelaxedCell<bool>,
     }
 


### PR DESCRIPTION
This fixes a hidden bug in the object_store rebuild logic.

As-is, the `rebuilt` state is not persisted into the cache. When a second object_store rebuild triggres on a fresh clone from the cache, it will fail to rebuild. This bug would/will get triggered when we update the object_store cache key to support the distributed/cloud use case.

ping @nameexhaustion 