### PR TITLE
docs(python): Document year padding in datetime parsing

### DIFF
--- a/py-polars/src/polars/expr/string.py
+++ b/py-polars/src/polars/expr/string.py
@@ -67,6 +67,10 @@ class ExprStringNameSpace:
             Format to use for conversion. Refer to the `chrono crate documentation
             <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
             for the full specification. Example: `"%Y-%m-%d"`.
+            Note that `"%Y"` can parse years with fewer than four digits by padding
+            them with leading zeroes. For example, parsing `"12-AUG-20"` with
+            `"%d-%b-%Y"` yields the year 20, not 2020. Use `"%y"` when parsing
+            two-digit years.
             If set to None (default), the format is inferred from the data.
         strict
             Raise an error if any conversion fails.
@@ -115,6 +119,10 @@ class ExprStringNameSpace:
             Format to use for conversion. Refer to the `chrono crate documentation
             <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
             for the full specification. Example: `"%Y-%m-%d %H:%M:%S"`.
+            Note that `"%Y"` can parse years with fewer than four digits by padding
+            them with leading zeroes. For example, parsing `"12-AUG-20"` with
+            `"%d-%b-%Y"` yields the year 20, not 2020. Use `"%y"` when parsing
+            two-digit years.
             If set to None (default), the format is inferred from the data.
         time_unit : {None, 'us', 'ns', 'ms'}
             Unit of time for the resulting Datetime column. If set to None (default),
@@ -236,6 +244,10 @@ class ExprStringNameSpace:
             Format to use for conversion. Refer to the `chrono crate documentation
             <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
             for the full specification. Example: `"%Y-%m-%d %H:%M:%S"`.
+            Note that `"%Y"` can parse years with fewer than four digits by padding
+            them with leading zeroes. For example, parsing `"12-AUG-20"` with
+            `"%d-%b-%Y"` yields the year 20, not 2020. Use `"%y"` when parsing
+            two-digit years.
             If set to None (default), the format is inferred from the data.
         strict
             Raise an error if any conversion fails.

--- a/py-polars/src/polars/series/string.py
+++ b/py-polars/src/polars/series/string.py
@@ -64,6 +64,10 @@ class StringNameSpace:
             Format to use for conversion. Refer to the `chrono crate documentation
             <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
             for the full specification. Example: `"%Y-%m-%d"`.
+            Note that `"%Y"` can parse years with fewer than four digits by padding
+            them with leading zeroes. For example, parsing `"12-AUG-20"` with
+            `"%d-%b-%Y"` yields the year 20, not 2020. Use `"%y"` when parsing
+            two-digit years.
             If set to None (default), the format is inferred from the data.
         strict
             Raise an error if any conversion fails.
@@ -110,6 +114,10 @@ class StringNameSpace:
             Format to use for conversion. Refer to the `chrono crate documentation
             <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
             for the full specification. Example: `"%Y-%m-%d %H:%M:%S"`.
+            Note that `"%Y"` can parse years with fewer than four digits by padding
+            them with leading zeroes. For example, parsing `"12-AUG-20"` with
+            `"%d-%b-%Y"` yields the year 20, not 2020. Use `"%y"` when parsing
+            two-digit years.
             If set to None (default), the format is inferred from the data.
         time_unit : {None, 'us', 'ns', 'ms'}
             Unit of time for the resulting Datetime column. If set to None (default),
@@ -247,6 +255,10 @@ class StringNameSpace:
             Format to use for conversion. Refer to the `chrono crate documentation
             <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
             for the full specification. Example: `"%Y-%m-%d %H:%M:%S"`.
+            Note that `"%Y"` can parse years with fewer than four digits by padding
+            them with leading zeroes. For example, parsing `"12-AUG-20"` with
+            `"%d-%b-%Y"` yields the year 20, not 2020. Use `"%y"` when parsing
+            two-digit years.
             If set to None (default), the format is inferred from the data.
         strict
             Raise an error if any conversion fails.


### PR DESCRIPTION
Closes #18791

Documents the current datetime parsing behavior for `%Y` when the input year
has fewer than four digits.

Confirmed locally:

```python
import polars as pl

s = pl.Series(["12-AUG-20"])

assert s.str.strptime(pl.Date, "%d-%b-%Y")[0].year == 20
assert s.str.strptime(pl.Date, "%d-%b-%y")[0].year == 2020