### PR TITLE
docs(python): Clarify compat_level export docs

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -1757,8 +1757,12 @@ class DataFrame:
         Parameters
         ----------
         compat_level
-            Use a specific compatibility level
-            when exporting Polars' internal data structures.
+            Compatibility level to use when exporting Polars data structures.
+            The default compatibility level is recommended for most users.
+            Use ``pl.CompatLevel.oldest()`` for the most compatible level.
+            ``pl.CompatLevel.newest()`` uses the highest supported compatibility
+            level, but is considered unstable and may change without it being
+            considered a breaking change.
 
         Examples
         --------

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -3570,8 +3570,12 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Choose "zstd" for good compression performance.
             Choose "lz4" for fast compression/decompression.
         compat_level
-            Use a specific compatibility level
-            when exporting Polars' internal data structures.
+            Compatibility level to use when exporting Polars data structures.
+            The default compatibility level is recommended for most users.
+            Use ``pl.CompatLevel.oldest()`` for the most compatible level.
+            ``pl.CompatLevel.newest()`` uses the highest supported compatibility
+            level, but is considered unstable and may change without it being
+            considered a breaking change.
         record_batch_size
             Size of the record batches in number of rows.
 


### PR DESCRIPTION
Related issue: #18210

## Summary

- Clarifies `compat_level` usage in `DataFrame.to_arrow`.
- Clarifies `compat_level` usage in `LazyFrame.sink_ipc`.

## Validation

- `git diff --check`
- `ruff check py-polars/src/polars/dataframe/frame.py py-polars/src/polars/lazyframe/frame.py`

## AI disclosure

1. I used AI to help identify the narrow documentation scope and review the PR text.
2. I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.