### PR TITLE
docs(python): Clarify horizontal boolean operations

### DIFF
--- a/py-polars/src/polars/functions/aggregation/horizontal.py
+++ b/py-polars/src/polars/functions/aggregation/horizontal.py
@@ -21,6 +21,8 @@ def all_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     """
     Compute the logical AND horizontally across columns.
 
+    Non-boolean inputs are cast to Boolean before evaluating the result.
+
     Parameters
     ----------
     *exprs
@@ -65,6 +67,8 @@ def all_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
 def any_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     """
     Compute the logical OR horizontally across columns.
+
+    Non-boolean inputs are cast to Boolean before evaluating the result.
 
     Parameters
     ----------


### PR DESCRIPTION
Closes #16364

### Summary

Clarifies the Python docstrings for `all_horizontal` and `any_horizontal` by noting that non-boolean inputs are cast to Boolean before evaluation.

This matches the current behavior of both functions and avoids ambiguity around horizontal logical operations.

### Tests

- `python -m pytest py-polars/tests/unit/operations/aggregation/test_horizontal.py`
- `git diff --check`