### PR TITLE
docs: Clarify CSV date inference formats

### DIFF
--- a/docs/source/user-guide/transformations/time-series/parsing.md
+++ b/docs/source/user-guide/transformations/time-series/parsing.md
@@ -27,6 +27,13 @@ is set to `True`:
 --8<-- "python/user-guide/transformations/time-series/parsing.py:df"
 ```
 
+CSV date inference supports a limited set of unambiguous date and datetime formats. The exact set of
+formats may change between Polars versions.
+
+Ambiguous or locale-specific formats, such as month-day-year dates (`MM-DD-YYYY`) or two-digit
+years, are not inferred automatically. For those formats, read the column as `String` and parse it
+explicitly with `str.strptime`.
+
 This flag will trigger schema inference on a number of rows, as configured by the
 `infer_schema_length` setting (100 rows by default). Schema inference is computationally expensive
 and can slow down file loading if a high number of rows is used.

--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -169,9 +169,10 @@ def read_csv(
         `infer_schema=False` to read all columns as `pl.String` to check which
         values might cause an issue.
     try_parse_dates
-        Try to automatically parse dates. Most ISO8601-like formats can
-        be inferred, as well as a handful of others. If this does not succeed,
-        the column remains of data type `pl.String`.
+        Try to automatically parse dates. CSV date inference supports a limited set of
+        unambiguous date and datetime formats. Ambiguous or locale-specific formats are
+        not inferred automatically. If this does not succeed, the column remains of data
+        type `pl.String`.
         If `use_pyarrow=True`, dates will always be parsed.
     n_threads
         Number of threads to use in csv parsing.
@@ -871,9 +872,10 @@ def read_csv_batched(
         First try `infer_schema_length=0` to read all columns as
         `pl.String` to check which values might cause an issue.
     try_parse_dates
-        Try to automatically parse dates. Most ISO8601-like formats can
-        be inferred, as well as a handful of others. If this does not succeed,
-        the column remains of data type `pl.String`.
+        Try to automatically parse dates. CSV date inference supports a limited set of
+        unambiguous date and datetime formats. Ambiguous or locale-specific formats are
+        not inferred automatically. If this does not succeed, the column remains of data
+        type `pl.String`.
     n_threads
         Number of threads to use in csv parsing.
         Defaults to the number of physical cpu's of your system.
@@ -1245,9 +1247,10 @@ def scan_csv(
     row_index_offset
         Offset to start the row index column (only used if the name is set).
     try_parse_dates
-        Try to automatically parse dates. Most ISO8601-like formats
-        can be inferred, as well as a handful of others. If this does not succeed,
-        the column remains of data type `pl.String`.
+        Try to automatically parse dates. CSV date inference supports a limited set of
+        unambiguous date and datetime formats. Ambiguous or locale-specific formats are
+        not inferred automatically. If this does not succeed, the column remains of data
+        type `pl.String`.
     eol_char
         Single byte end of line character (default: `\n`). When encountering a file
         with windows line endings (`\r\n`), one can go with the default `\n`. The extra


### PR DESCRIPTION
Closes #17426

Clarifies the documented scope of CSV date inference via `try_parse_dates`, including supported date orders, separators, ISO8601-like datetimes, timezone offsets, and formats that are not inferred automatically.