### PR TITLE
perf: Adaptive size dispatch to hashset or radix sort + capacity-aware reset in `agg_n_unique`

### DIFF
--- a/crates/polars-compute/src/unique/distinct.rs
+++ b/crates/polars-compute/src/unique/distinct.rs
@@ -4,10 +4,26 @@ use arrow::bitmap::bitmask::BitMask;
 use arrow::datatypes::ArrowDataType;
 use arrow::legacy::prelude::LargeBinaryArray;
 use arrow::types::{NativeType, PrimitiveType};
-use polars_utils::aliases::PlHashSet;
+use polars_utils::aliases::{InitHashMaps, PlHashSet};
 use polars_utils::float16::pf16;
 use polars_utils::total_ord::{TotalEq, TotalHash, TotalOrdWrap};
 use polars_utils::{IdxSize, UnitVec};
+
+// Rebuild the amortized hashset when capacity exceeds `needed` by this
+// factor and is above `REBUILD_MIN_CAPACITY`. `.clear()` is O(capacity);
+// rebuilding bounds worst-case clear cost under heavy group-size skew.
+// See polars#27655.
+const REBUILD_CAPACITY_RATIO: usize = 4;
+const REBUILD_MIN_CAPACITY: usize = 1024;
+
+#[inline]
+fn reset_amortized<T>(set: &mut PlHashSet<T>, needed: usize) {
+    if set.capacity() > REBUILD_CAPACITY_RATIO * needed && set.capacity() > REBUILD_MIN_CAPACITY {
+        *set = PlHashSet::with_capacity(needed);
+    } else {
+        set.clear();
+    }
+}
 
 pub trait AmortizedUnique: Send + Sync + 'static {
     fn new_empty(&self) -> Box<dyn AmortizedUnique>;
@@ -339,7 +355,7 @@ impl<T: NativeType + TotalHash + TotalEq> AmortizedUnique for PrimitiveArgUnique
         let values = values.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
 
         if values.has_nulls() {
-            self.1.clear();
+            reset_amortized(&mut self.1, idxs.len());
             idxs.retain(|i| {
                 // SAFETY: function invariant.
                 let value = unsafe { values.get_unchecked(i as usize) };
@@ -347,7 +363,7 @@ impl<T: NativeType + TotalHash + TotalEq> AmortizedUnique for PrimitiveArgUnique
                 self.1.insert(value)
             });
         } else {
-            self.0.clear();
+            reset_amortized(&mut self.0, idxs.len());
             let values = values.values().as_slice();
             idxs.retain(|i| {
                 // SAFETY: function invariant.
@@ -376,7 +392,7 @@ impl<T: NativeType + TotalHash + TotalEq> AmortizedUnique for PrimitiveArgUnique
         assert!(start.saturating_add(length) as usize <= values.len());
 
         if values.has_nulls() {
-            self.1.clear();
+            reset_amortized(&mut self.1, length as usize);
             idxs.extend((start..start + length).filter(|i| {
                 // SAFETY: asserted before.
                 let value = unsafe { values.get_unchecked(*i as usize) };
@@ -384,7 +400,7 @@ impl<T: NativeType + TotalHash + TotalEq> AmortizedUnique for PrimitiveArgUnique
                 self.1.insert(value)
             }));
         } else {
-            self.0.clear();
+            reset_amortized(&mut self.0, length as usize);
             let values = values.values().as_slice();
             idxs.extend(
                 values[start as usize..][..length as usize]
@@ -406,7 +422,7 @@ impl<T: NativeType + TotalHash + TotalEq> AmortizedUnique for PrimitiveArgUnique
         let values = values.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
 
         if values.has_nulls() {
-            self.1.clear();
+            reset_amortized(&mut self.1, idxs.len());
             self.1.extend(idxs.iter().map(|&i| {
                 // SAFETY: function invariant.
                 let value = unsafe { values.get_unchecked(i as usize) };
@@ -415,7 +431,7 @@ impl<T: NativeType + TotalHash + TotalEq> AmortizedUnique for PrimitiveArgUnique
             self.1.len() as IdxSize
         } else {
             let values = values.values();
-            self.0.clear();
+            reset_amortized(&mut self.0, idxs.len());
             self.0.extend(idxs.iter().map(|&i| {
                 // SAFETY: function invariant.
                 let value = *unsafe { values.get_unchecked(i as usize) };
@@ -434,7 +450,7 @@ impl<T: NativeType + TotalHash + TotalEq> AmortizedUnique for PrimitiveArgUnique
         assert!(start.saturating_add(length) as usize <= values.len());
 
         if values.has_nulls() {
-            self.1.clear();
+            reset_amortized(&mut self.1, length as usize);
             self.1.extend((start..start + length).map(|i| {
                 // SAFETY: asserted before.
                 let value = unsafe { values.get_unchecked(i as usize) };
@@ -443,7 +459,7 @@ impl<T: NativeType + TotalHash + TotalEq> AmortizedUnique for PrimitiveArgUnique
             self.1.len() as IdxSize
         } else {
             let values = values.values();
-            self.0.clear();
+            reset_amortized(&mut self.0, length as usize);
             self.0.extend(
                 values[start as usize..][..length as usize]
                     .iter()
@@ -486,7 +502,7 @@ impl AmortizedUnique for BinaryViewUnique {
                     value.map(|v| unsafe { std::mem::transmute::<&[u8], &'static [u8]>(v) });
                 self.1.insert(value)
             }));
-            self.1.clear();
+            reset_amortized(&mut self.1, length as usize);
         } else {
             self.0.reserve(length as usize);
             if values.total_buffer_len() == 0 {
@@ -515,7 +531,7 @@ impl AmortizedUnique for BinaryViewUnique {
                     self.0.insert(value)
                 }));
             }
-            self.0.clear();
+            reset_amortized(&mut self.0, length as usize);
         }
     }
 
@@ -535,7 +551,7 @@ impl AmortizedUnique for BinaryViewUnique {
                     value.map(|v| unsafe { std::mem::transmute::<&[u8], &'static [u8]>(v) });
                 self.1.insert(value)
             });
-            self.1.clear();
+            reset_amortized(&mut self.1, idxs.len());
         } else {
             self.0.reserve(idxs.len());
             if values.total_buffer_len() == 0 {
@@ -559,7 +575,7 @@ impl AmortizedUnique for BinaryViewUnique {
                     self.0.insert(value)
                 });
             }
-            self.0.clear();
+            reset_amortized(&mut self.0, idxs.len());
         }
     }
 
@@ -579,7 +595,7 @@ impl AmortizedUnique for BinaryViewUnique {
                 value.map(|v| unsafe { std::mem::transmute::<&[u8], &'static [u8]>(v) })
             }));
             let out = self.1.len() as IdxSize;
-            self.1.clear();
+            reset_amortized(&mut self.1, idxs.len());
             out
         } else {
             self.0.reserve(idxs.len());
@@ -603,7 +619,7 @@ impl AmortizedUnique for BinaryViewUnique {
                 }));
             }
             let out = self.0.len() as IdxSize;
-            self.0.clear();
+            reset_amortized(&mut self.0, idxs.len());
             out
         }
     }
@@ -625,7 +641,7 @@ impl AmortizedUnique for BinaryViewUnique {
                 value.map(|v| unsafe { std::mem::transmute::<&[u8], &'static [u8]>(v) })
             }));
             let out = self.1.len() as IdxSize;
-            self.1.clear();
+            reset_amortized(&mut self.1, length as usize);
             out
         } else {
             self.0.reserve(length as usize);
@@ -652,7 +668,7 @@ impl AmortizedUnique for BinaryViewUnique {
                 }));
             }
             let out = self.0.len() as IdxSize;
-            self.0.clear();
+            reset_amortized(&mut self.0, length as usize);
             out
         }
     }
@@ -690,7 +706,7 @@ impl AmortizedUnique for BinaryUnique {
                     value.map(|v| unsafe { std::mem::transmute::<&[u8], &'static [u8]>(v) });
                 self.1.insert(value)
             }));
-            self.1.clear();
+            reset_amortized(&mut self.1, length as usize);
         } else {
             self.0.reserve(length as usize);
             idxs.extend((start..start + length).filter(|i| {
@@ -699,7 +715,7 @@ impl AmortizedUnique for BinaryUnique {
                 let value = unsafe { std::mem::transmute::<&[u8], &'static [u8]>(value) };
                 self.0.insert(value)
             }));
-            self.0.clear();
+            reset_amortized(&mut self.0, length as usize);
         }
     }
 
@@ -720,7 +736,7 @@ impl AmortizedUnique for BinaryUnique {
                     value.map(|v| unsafe { std::mem::transmute::<&[u8], &'static [u8]>(v) });
                 self.1.insert(value)
             });
-            self.1.clear();
+            reset_amortized(&mut self.1, idxs.len());
         } else {
             self.0.reserve(idxs.len());
             idxs.retain(|i| {
@@ -729,7 +745,7 @@ impl AmortizedUnique for BinaryUnique {
                 let value = unsafe { std::mem::transmute::<&[u8], &'static [u8]>(value) };
                 self.0.insert(value)
             });
-            self.0.clear();
+            reset_amortized(&mut self.0, idxs.len());
         }
     }
 
@@ -749,7 +765,7 @@ impl AmortizedUnique for BinaryUnique {
                 value.map(|v| unsafe { std::mem::transmute::<&[u8], &'static [u8]>(v) })
             }));
             let out = self.1.len() as IdxSize;
-            self.1.clear();
+            reset_amortized(&mut self.1, idxs.len());
             out
         } else {
             self.0.reserve(idxs.len());
@@ -760,7 +776,7 @@ impl AmortizedUnique for BinaryUnique {
                 unsafe { std::mem::transmute::<&[u8], &'static [u8]>(value) }
             }));
             let out = self.0.len() as IdxSize;
-            self.0.clear();
+            reset_amortized(&mut self.0, idxs.len());
             out
         }
     }
@@ -782,7 +798,7 @@ impl AmortizedUnique for BinaryUnique {
                 value.map(|v| unsafe { std::mem::transmute::<&[u8], &'static [u8]>(v) })
             }));
             let out = self.1.len() as IdxSize;
-            self.1.clear();
+            reset_amortized(&mut self.1, length as usize);
             out
         } else {
             self.0.reserve(length as usize);
@@ -793,7 +809,7 @@ impl AmortizedUnique for BinaryUnique {
                 unsafe { std::mem::transmute::<&[u8], &'static [u8]>(value) }
             }));
             let out = self.0.len() as IdxSize;
-            self.0.clear();
+            reset_amortized(&mut self.0, length as usize);
             out
         }
     }

--- a/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
@@ -4,6 +4,13 @@ use polars_compute::unique::{AmortizedUnique, amortized_unique_from_dtype};
 use super::*;
 use crate::prelude::row_encode::encode_rows_unordered;
 
+// Groups larger than this route to `Series::n_unique` (radix sort + scan
+// for primitives, hashset for binary) instead of the amortized
+// `AmortizedUnique` hashset: sort wins on cost, and keeping big groups
+// out of the amortized hashset bounds its capacity, which avoids the
+// O(capacity) `.clear()` storm of polars#27655.
+const N_UNIQUE_SORT_FALLBACK_THRESHOLD: usize = 16384;
+
 // implemented on the series because we don't need types
 impl Series {
     unsafe fn restore_logical(&self, out: Series) -> Series {
@@ -290,6 +297,9 @@ impl Series {
             values.into_owned().into_column()
         };
 
+        // Keep the Column for the sort-fallback path. Big groups go through
+        // `Series::n_unique`, bypassing the amortized hashset.
+        let col = values.clone();
         let values = values.rechunk_to_arrow(CompatLevel::newest());
         let values = values.as_ref();
         let state = amortized_unique_from_dtype(values.dtype());
@@ -301,13 +311,22 @@ impl Series {
             }
         }
 
+        // SAFETY for the `.unwrap()` on `Series::n_unique()` below: we've
+        // already filtered out dtypes that can fail (objects panic above;
+        // nested types are row-encoded to binary). All remaining dtypes
+        // have a `ChunkUnique` impl that infallibly returns `Ok(_)`.
         RAYON
             .install(|| match groups {
                 GroupsType::Idx(idx) => idx
                     .all()
                     .into_par_iter()
                     .map_with(CloneWrapper(state), |state, idxs| unsafe {
-                        state.0.n_unique_idx(values, idxs.as_slice())
+                        let idxs = idxs.as_slice();
+                        if idxs.len() > N_UNIQUE_SORT_FALLBACK_THRESHOLD {
+                            col.take_slice_unchecked(idxs).n_unique().unwrap() as IdxSize
+                        } else {
+                            state.0.n_unique_idx(values, idxs)
+                        }
                     })
                     .collect::<NoNull<IdxCa>>(),
                 GroupsType::Slice {
@@ -316,8 +335,13 @@ impl Series {
                     monotonic: _,
                 } => groups
                     .into_par_iter()
-                    .map_with(CloneWrapper(state), |state, [start, len]| {
-                        state.0.n_unique_slice(values, *start, *len)
+                    .map_with(CloneWrapper(state), |state, &[start, len]| unsafe {
+                        let len_us = len as usize;
+                        if len_us > N_UNIQUE_SORT_FALLBACK_THRESHOLD {
+                            col.slice(start as i64, len_us).n_unique().unwrap() as IdxSize
+                        } else {
+                            state.0.n_unique_slice(values, start, len)
+                        }
                     })
                     .collect::<NoNull<IdxCa>>(),
             })

--- a/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
@@ -335,7 +335,7 @@ impl Series {
                     monotonic: _,
                 } => groups
                     .into_par_iter()
-                    .map_with(CloneWrapper(state), |state, &[start, len]| unsafe {
+                    .map_with(CloneWrapper(state), |state, &[start, len]| {
                         let len_us = len as usize;
                         if len_us > N_UNIQUE_SORT_FALLBACK_THRESHOLD {
                             col.slice(start as i64, len_us).n_unique().unwrap() as IdxSize


### PR DESCRIPTION
Closes #27655.

#24976 replaced per-group `Series::n_unique()` with a per-thread amortized `PlHashSet`. Real win on many-small-groups workloads, but `PlHashSet::clear()` is **O(capacity)** and capacity sticks. One big group followed by many small ones means every small group pays the big group's clear cost. On extreme case fixture 1 below, that's a 58× slowdown vs 1.34.

This PR first adds a threshold to reset `PlHashSet` so it stays adaptive to different group sizes rather than getting stuck at the high-water-mark capacity. On top of that, it dispatches adaptively between radix sort and `PlHashSet`: for large groups `PlHashSet` would degenerate into pure random memory access (and eventually exceed RAM), while radix sort stays sequential and cache-friendly.

## Benchmark spectrum

| # | Workload | 1.34.0 | Patched | 1.35.1 | vs 1.34 | vs 1.35.1 |
|---|---|---:|---:|---:|---:|---:|
| 1 | 1 big group + 1M tiny groups of 2 (the regression's worst case) | 0.294 s | **0.302 s** | 17.578 s | parity | **58.2×** |
| 2 | Same shape with f64 id_place (float radix path) | 0.294 s | **0.296 s** | 17.494 s | parity | **59.1×** |
| 3 | 50M rows, Zipf(1.5) group sizes (heavy tail) | 0.817 s | 0.605 s | 4.239 s | 1.35× | 7.0× |
| 4 | 5 groups of 1M + 500K groups of 4 (power-user shape) | 0.103 s | 0.055 s | 0.692 s | 1.87× | 12.6× |
| 5 | Groups of 2, string id_place (BinaryViewUnique path) | 3.169 s | **0.348 s** | 0.477 s | **9.1×** | 1.37× |
| 6 | Groups of 2, int id_place (amortization win) | 0.964 s | 0.298 s | 0.461 s | 3.23× | 1.55× |
| 7 | Single 10M-row group (isolates big-group algorithm) | 0.131 s | 0.135 s | 0.237 s | parity | 1.76× |
| 8 | 50K groups of ~200 rows (uniform medium) | 0.058 s | 0.056 s | 0.051 s | parity | parity |
| 9 | 1M groups of 20, id_place constant (n_unique = 1) | 0.163 s | 0.125 s | 0.115 s | 1.30× | parity |
| 10 | 1M groups of 20, id_place all distinct (hashset fills) | 0.158 s | 0.128 s | 0.121 s | 1.23× | parity |
| 11 | Groups straddling the dispatch threshold | 0.044 s | 0.042 s | 0.036 s | parity | parity |
| 12 | 100K groups of 100, 30% nulls in id_place | 0.058 s | 0.058 s | 0.049 s | parity | parity |
| 13 | 100 groups of 100K, string id_place | 0.067 s | 0.069 s | 0.063 s | parity | parity |
| 14 | 1K groups of 10K rows | 0.062 s | 0.053 s | 0.046 s | 1.17× | parity |

Reporter confirmed on production data: ~2 h → ~15–16 s.