### PR TITLE
feat: Add tiered multi-file parquet metadata resolver

### DIFF
--- a/crates/polars-config/src/lib.rs
+++ b/crates/polars-config/src/lib.rs
@@ -3,12 +3,14 @@ use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 
 mod engine;
 mod parse;
+mod resolve_mode;
 mod spill_format;
 pub mod spill_path;
 mod spill_policy;
 
 pub use engine::Engine;
 use polars_error::polars_warn;
+pub use resolve_mode::ResolveMode;
 pub use spill_format::SpillFormat;
 pub use spill_policy::SpillPolicy;
 
@@ -43,6 +45,9 @@ const DEFAULT_PARQUET_BINARY_STATISTICS_TRUNCATE_LENGTH: u64 = 64;
 
 const PRUNE_PARQUET_METADATA: &str = "POLARS_PRUNE_PARQUET_METADATA";
 const DEFAULT_PRUNE_PARQUET_METADATA: bool = false;
+
+const RESOLVE_METADATA_LEVEL: &str = "POLARS_RESOLVE_METADATA_LEVEL";
+const DEFAULT_RESOLVE_METADATA_LEVEL: ResolveMode = ResolveMode::RowCounts;
 
 // Private.
 const VERBOSE_SENSITIVE: &str = "POLARS_VERBOSE_SENSITIVE";
@@ -93,6 +98,7 @@ static KNOWN_OPTIONS: &[&str] = &[
     PARQUET_BINARY_STATISTICS_TRUNCATE_LENGTH,
     PRUNE_PARQUET_METADATA,
     ALLOW_NESTED_CSPE,
+    RESOLVE_METADATA_LEVEL,
     /*
     Not yet supported public options:
 
@@ -139,6 +145,7 @@ pub struct Config {
     parquet_binary_statistics_truncate_length: AtomicU64,
     prune_parquet_metadata: AtomicBool,
     allow_nested_cspe: AtomicBool,
+    resolve_metadata_level: AtomicU8,
 
     // Private.
     verbose_sensitive: AtomicBool,
@@ -166,6 +173,7 @@ impl Config {
                 DEFAULT_PARQUET_BINARY_STATISTICS_TRUNCATE_LENGTH,
             ),
             prune_parquet_metadata: AtomicBool::new(DEFAULT_PRUNE_PARQUET_METADATA),
+            resolve_metadata_level: AtomicU8::new(DEFAULT_RESOLVE_METADATA_LEVEL as u8),
 
             // Private.
             verbose_sensitive: AtomicBool::new(DEFAULT_VERBOSE_SENSITIVE),
@@ -250,6 +258,11 @@ impl Config {
             ALLOW_NESTED_CSPE => self.allow_nested_cspe.store(
                 val.and_then(|x| parse::parse_bool(var, x))
                     .unwrap_or(DEFAULT_ALLOW_NESTED_CSPE),
+                Ordering::Relaxed,
+            ),
+            RESOLVE_METADATA_LEVEL => self.resolve_metadata_level.store(
+                val.and_then(|x| parse::parse_resolve_mode(var, x))
+                    .unwrap_or(DEFAULT_RESOLVE_METADATA_LEVEL) as u8,
                 Ordering::Relaxed,
             ),
 
@@ -359,6 +372,13 @@ impl Config {
     /// Nested common subplan elimination.
     pub fn allow_nested_cspe(&self) -> bool {
         self.allow_nested_cspe.load(Ordering::Relaxed)
+    }
+
+    /// How much per-file metadata `parquet_file_info` resolves at planning
+    /// time. See [`ResolveMode`] for the variants and their cost / IR-shape
+    /// trade-offs.
+    pub fn resolve_metadata_level(&self) -> ResolveMode {
+        ResolveMode::from_discriminant(self.resolve_metadata_level.load(Ordering::Relaxed))
     }
 
     /// Whether we should do verbose printing on sensitive information.

--- a/crates/polars-config/src/parse.rs
+++ b/crates/polars-config/src/parse.rs
@@ -1,6 +1,6 @@
 use polars_error::polars_warn;
 
-use crate::{Engine, SpillFormat, SpillPolicy};
+use crate::{Engine, ResolveMode, SpillFormat, SpillPolicy};
 
 pub fn parse_bool(var: &str, val: &str) -> Option<bool> {
     match val.trim_ascii() {
@@ -51,6 +51,16 @@ pub fn parse_spill_policy(var: &str, val: &str) -> Option<SpillPolicy> {
 
 pub fn parse_spill_format(var: &str, val: &str) -> Option<SpillFormat> {
     match val.trim_ascii().parse::<SpillFormat>() {
+        Ok(x) => Some(x),
+        Err(e) => {
+            polars_warn!("illegal value '{val}' found while parsing option '{var}' ({e})");
+            None
+        },
+    }
+}
+
+pub fn parse_resolve_mode(var: &str, val: &str) -> Option<ResolveMode> {
+    match val.trim_ascii().parse::<ResolveMode>() {
         Ok(x) => Some(x),
         Err(e) => {
             polars_warn!("illegal value '{val}' found while parsing option '{var}' ({e})");

--- a/crates/polars-config/src/resolve_mode.rs
+++ b/crates/polars-config/src/resolve_mode.rs
@@ -4,8 +4,8 @@ use std::str::FromStr;
 #[repr(u8)]
 #[derive(Clone, Debug, Copy, Default, Eq, PartialEq, Hash)]
 pub enum ResolveMode {
-    None = 0,
     #[default]
+    None = 0,
     RowCounts = 1,
     Full = 2,
 }

--- a/crates/polars-config/src/resolve_mode.rs
+++ b/crates/polars-config/src/resolve_mode.rs
@@ -1,0 +1,51 @@
+use std::fmt;
+use std::str::FromStr;
+
+#[repr(u8)]
+#[derive(Clone, Debug, Copy, Default, Eq, PartialEq, Hash)]
+pub enum ResolveMode {
+    None = 0,
+    #[default]
+    RowCounts = 1,
+    Full = 2,
+}
+
+impl fmt::Display for ResolveMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_static_str())
+    }
+}
+
+impl FromStr for ResolveMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "none" => Ok(Self::None),
+            "row_counts" => Ok(Self::RowCounts),
+            "full" => Ok(Self::Full),
+            v => Err(format!(
+                "`resolve_metadata_level` must be one of {{'none', 'row_counts', 'full'}}, got {v}",
+            )),
+        }
+    }
+}
+
+impl ResolveMode {
+    pub(crate) fn from_discriminant(d: u8) -> Self {
+        match d {
+            0 => Self::None,
+            1 => Self::RowCounts,
+            2 => Self::Full,
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn as_static_str(&self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::RowCounts => "row_counts",
+            Self::Full => "full",
+        }
+    }
+}

--- a/crates/polars-io/src/parquet/read/async_impl.rs
+++ b/crates/polars-io/src/parquet/read/async_impl.rs
@@ -2,7 +2,14 @@
 
 use arrow::datatypes::ArrowSchemaRef;
 use object_store::path::Path as ObjectPath;
+use polars_buffer::Buffer;
 use polars_core::prelude::*;
+use polars_parquet::parquet::error::ParquetError;
+use polars_parquet::parquet::metadata::SchemaDescriptor;
+use polars_parquet::parquet::read::{
+    deserialize_metadata, deserialize_metadata_with_shared_schema, deserialize_num_rows,
+};
+use polars_parquet::parquet::{DEFAULT_FOOTER_READ_SIZE, FOOTER_SIZE, PARQUET_MAGIC};
 use polars_parquet::write::FileMetadata;
 use polars_utils::pl_path::PlRefPath;
 
@@ -65,6 +72,29 @@ impl ParquetObjectStore {
         Ok(self.metadata.as_ref().unwrap())
     }
 
+    /// Like [`Self::get_metadata`] but skips thrift field 2 (schema) and
+    /// reuses the supplied [`SchemaDescriptor`]. Result is memoized.
+    pub async fn get_metadata_with_shared_schema(
+        &mut self,
+        schema_descr: SchemaDescriptor,
+    ) -> PolarsResult<&FileMetadataRef> {
+        if self.metadata.is_none() {
+            let length = self.length().await?;
+            let md =
+                fetch_metadata_with_shared_schema(&self.store, &self.path, length, schema_descr)
+                    .await?;
+            self.metadata = Some(Arc::new(md));
+        }
+        Ok(self.metadata.as_ref().unwrap())
+    }
+
+    /// Decode only `FileMetaData.num_rows` from the remote footer.
+    /// Not memoized. Used by `RowCounts` resolve mode.
+    pub async fn num_rows_only(&mut self) -> PolarsResult<i64> {
+        let length = self.length().await?;
+        fetch_num_rows(&self.store, &self.path, length).await
+    }
+
     pub async fn schema(&mut self) -> PolarsResult<ArrowSchemaRef> {
         self.schema = Some(match self.schema.as_ref() {
             Some(schema) => Arc::clone(schema),
@@ -93,57 +123,96 @@ fn read_i32le(reader: &mut &[u8]) -> Option<i32> {
     read_n(reader).map(i32::from_le_bytes)
 }
 
-/// Asynchronously reads the files' metadata
+/// Speculatively read `DEFAULT_FOOTER_READ_SIZE` from the tail. If the
+/// footer fits in the prefetch (the common case), we're done in one range
+/// request; otherwise re-fetch the full footer. Mirrors the sync
+/// `fetch_footer_buf` strategy.
+async fn fetch_footer_bytes(
+    store: &PolarsObjectStore,
+    path: &ObjectPath,
+    file_byte_length: usize,
+) -> PolarsResult<Buffer<u8>> {
+    let out_of_spec = |msg: &str| ParquetError::OutOfSpec(msg.to_string());
+
+    let prefetch_len = std::cmp::min(DEFAULT_FOOTER_READ_SIZE as usize, file_byte_length);
+    let prefetched = store
+        .get_range(
+            path,
+            file_byte_length
+                .checked_sub(prefetch_len)
+                .ok_or_else(|| out_of_spec("not enough bytes to contain parquet footer"))?
+                ..file_byte_length,
+        )
+        .await?;
+
+    if prefetched.len() < FOOTER_SIZE as usize {
+        return Err(out_of_spec("not enough bytes to contain parquet footer").into());
+    }
+
+    // Trailing 8 bytes: footer size (i32 LE) + magic.
+    let footer_byte_length: usize = {
+        let tail_start = prefetched.len() - FOOTER_SIZE as usize;
+        let reader = &mut &prefetched.as_ref()[tail_start..];
+        let footer_byte_size = read_i32le(reader).unwrap();
+        let magic = read_n(reader).unwrap();
+        debug_assert!(reader.is_empty());
+        if magic != PARQUET_MAGIC {
+            return Err(out_of_spec("incorrect magic in parquet footer").into());
+        }
+        footer_byte_size
+            .try_into()
+            .map_err(|_| out_of_spec("negative footer byte length"))?
+    };
+
+    let footer_len = FOOTER_SIZE as usize + footer_byte_length;
+    if footer_len <= prefetched.len() {
+        // Common case: footer already in the prefetch; zero extra round trips.
+        let start = prefetched.len() - footer_len;
+        Ok(prefetched.sliced(start..))
+    } else {
+        // Fallback: footer larger than the prefetch; re-fetch the full footer.
+        store
+            .get_range(
+                path,
+                file_byte_length
+                    .checked_sub(footer_len)
+                    .ok_or_else(|| out_of_spec("not enough bytes to contain parquet footer"))?
+                    ..file_byte_length,
+            )
+            .await
+    }
+}
+
+/// Asynchronously reads the files' metadata.
 pub async fn fetch_metadata(
     store: &PolarsObjectStore,
     path: &ObjectPath,
     file_byte_length: usize,
 ) -> PolarsResult<FileMetadata> {
-    let footer_header_bytes = store
-        .get_range(
-            path,
-            file_byte_length
-                .checked_sub(polars_parquet::parquet::FOOTER_SIZE as usize)
-                .ok_or_else(|| {
-                    polars_parquet::parquet::error::ParquetError::OutOfSpec(
-                        "not enough bytes to contain parquet footer".to_string(),
-                    )
-                })?..file_byte_length,
-        )
-        .await?;
+    let footer = fetch_footer_bytes(store, path, file_byte_length).await?;
+    Ok(deserialize_metadata(footer)?)
+}
 
-    let footer_byte_length: usize = {
-        let reader = &mut footer_header_bytes.as_ref();
-        let footer_byte_size = read_i32le(reader).unwrap();
-        let magic = read_n(reader).unwrap();
-        debug_assert!(reader.is_empty());
-        if magic != polars_parquet::parquet::PARQUET_MAGIC {
-            return Err(polars_parquet::parquet::error::ParquetError::OutOfSpec(
-                "incorrect magic in parquet footer".to_string(),
-            )
-            .into());
-        }
-        footer_byte_size.try_into().map_err(|_| {
-            polars_parquet::parquet::error::ParquetError::OutOfSpec(
-                "negative footer byte length".to_string(),
-            )
-        })?
-    };
-
-    let footer_bytes = store
-        .get_range(
-            path,
-            file_byte_length
-                .checked_sub(polars_parquet::parquet::FOOTER_SIZE as usize + footer_byte_length)
-                .ok_or_else(|| {
-                    polars_parquet::parquet::error::ParquetError::OutOfSpec(
-                        "not enough bytes to contain parquet footer".to_string(),
-                    )
-                })?..file_byte_length,
-        )
-        .await?;
-
-    Ok(polars_parquet::parquet::read::deserialize_metadata(
-        footer_bytes,
+/// Like [`fetch_metadata`] but skips schema and reuses the supplied descriptor.
+pub async fn fetch_metadata_with_shared_schema(
+    store: &PolarsObjectStore,
+    path: &ObjectPath,
+    file_byte_length: usize,
+    schema_descr: SchemaDescriptor,
+) -> PolarsResult<FileMetadata> {
+    let footer = fetch_footer_bytes(store, path, file_byte_length).await?;
+    Ok(deserialize_metadata_with_shared_schema(
+        footer,
+        schema_descr,
     )?)
+}
+
+/// Fetch only `FileMetaData.num_rows` from a remote parquet footer.
+pub async fn fetch_num_rows(
+    store: &PolarsObjectStore,
+    path: &ObjectPath,
+    file_byte_length: usize,
+) -> PolarsResult<i64> {
+    let footer = fetch_footer_bytes(store, path, file_byte_length).await?;
+    Ok(deserialize_num_rows(footer)?)
 }

--- a/crates/polars-io/src/parquet/read/async_impl.rs
+++ b/crates/polars-io/src/parquet/read/async_impl.rs
@@ -5,10 +5,7 @@ use object_store::path::Path as ObjectPath;
 use polars_buffer::Buffer;
 use polars_core::prelude::*;
 use polars_parquet::parquet::error::ParquetError;
-use polars_parquet::parquet::metadata::SchemaDescriptor;
-use polars_parquet::parquet::read::{
-    deserialize_metadata, deserialize_metadata_with_shared_schema, deserialize_num_rows,
-};
+use polars_parquet::parquet::read::{deserialize_metadata, deserialize_num_rows};
 use polars_parquet::parquet::{DEFAULT_FOOTER_READ_SIZE, FOOTER_SIZE, PARQUET_MAGIC};
 use polars_parquet::write::FileMetadata;
 use polars_utils::pl_path::PlRefPath;
@@ -68,22 +65,6 @@ impl ParquetObjectStore {
     pub async fn get_metadata(&mut self) -> PolarsResult<&FileMetadataRef> {
         if self.metadata.is_none() {
             self.metadata = Some(Arc::new(self.fetch_metadata().await?));
-        }
-        Ok(self.metadata.as_ref().unwrap())
-    }
-
-    /// Like [`Self::get_metadata`] but skips thrift field 2 (schema) and
-    /// reuses the supplied [`SchemaDescriptor`]. Result is memoized.
-    pub async fn get_metadata_with_shared_schema(
-        &mut self,
-        schema_descr: SchemaDescriptor,
-    ) -> PolarsResult<&FileMetadataRef> {
-        if self.metadata.is_none() {
-            let length = self.length().await?;
-            let md =
-                fetch_metadata_with_shared_schema(&self.store, &self.path, length, schema_descr)
-                    .await?;
-            self.metadata = Some(Arc::new(md));
         }
         Ok(self.metadata.as_ref().unwrap())
     }
@@ -191,20 +172,6 @@ pub async fn fetch_metadata(
 ) -> PolarsResult<FileMetadata> {
     let footer = fetch_footer_bytes(store, path, file_byte_length).await?;
     Ok(deserialize_metadata(footer)?)
-}
-
-/// Like [`fetch_metadata`] but skips schema and reuses the supplied descriptor.
-pub async fn fetch_metadata_with_shared_schema(
-    store: &PolarsObjectStore,
-    path: &ObjectPath,
-    file_byte_length: usize,
-    schema_descr: SchemaDescriptor,
-) -> PolarsResult<FileMetadata> {
-    let footer = fetch_footer_bytes(store, path, file_byte_length).await?;
-    Ok(deserialize_metadata_with_shared_schema(
-        footer,
-        schema_descr,
-    )?)
 }
 
 /// Fetch only `FileMetaData.num_rows` from a remote parquet footer.

--- a/crates/polars-mem-engine/src/scan_predicate/functions.rs
+++ b/crates/polars-mem-engine/src/scan_predicate/functions.rs
@@ -14,7 +14,7 @@ use polars_plan::dsl::default_values::{
 };
 use polars_plan::dsl::deletion::DeletionFilesList;
 use polars_plan::dsl::{
-    FileScanIR, Operator, PredicateFileSkip, ScanSources, TableStatistics, UnifiedScanArgs,
+    Operator, PredicateFileSkip, ScanSources, TableStatistics, UnifiedScanArgs,
 };
 use polars_plan::plans::expr_ir::{ExprIR, OutputName};
 use polars_plan::plans::hive::HivePartitionsDf;
@@ -483,49 +483,16 @@ where
         panic!("{unified_scan_args:?}")
     };
 
+    // Reconcile pre-decoded state with the filter: clear what's stale,
+    // gather what survives.
     *row_count = None;
 
-    if selected_path_indices.clone().next() != Some(0) {
+    let first_surviving_idx = selected_path_indices.clone().next();
+    let first_file_dropped = first_surviving_idx != Some(0);
+    if first_file_dropped {
         *reader_schema = None;
-
-        // Ensure the metadata is unset, otherwise it may incorrectly be used at
-        // scan. This is especially important for Parquet as it requires the
-        // correct `is_nullable` in the arrow field.
-        match scan_type.as_mut() {
-            #[cfg(feature = "parquet")]
-            FileScanIR::Parquet {
-                options: _,
-                metadata,
-            } => *metadata = None,
-
-            #[cfg(feature = "ipc")]
-            FileScanIR::Ipc {
-                options: _,
-                metadata,
-            } => *metadata = None,
-
-            #[cfg(feature = "csv")]
-            FileScanIR::Csv { options: _ } => {},
-
-            #[cfg(feature = "json")]
-            FileScanIR::NDJson { options: _ } => {},
-
-            #[cfg(feature = "python")]
-            FileScanIR::PythonDataset {
-                dataset_object: _,
-                cached_ir,
-            } => *cached_ir.lock().unwrap() = None,
-
-            #[cfg(feature = "scan_lines")]
-            FileScanIR::Lines { name: _ } => {},
-            FileScanIR::ExpandedPaths { name: _ } => {},
-
-            FileScanIR::Anonymous {
-                options: _,
-                function: _,
-            } => {},
-        }
     }
+    scan_type.gather_after_filter(first_file_dropped, selected_path_indices.clone());
 
     let selected_path_indices_idxsize = LazyCell::new(|| {
         selected_path_indices

--- a/crates/polars-parquet/src/parquet/handwritten_thrift/file_metadata_thrift.rs
+++ b/crates/polars-parquet/src/parquet/handwritten_thrift/file_metadata_thrift.rs
@@ -101,55 +101,6 @@ pub(crate) fn decode_num_rows(footer: Buffer<u8>) -> ParquetResult<i64> {
     num_rows.require("FileMetaData.num_rows")
 }
 
-/// Decode `FileMetaData` while skipping field 2 (`schema`). Multi-file
-/// scans pair the result with the first file's shared `SchemaDescriptor`
-/// via `FileMetadata::from_compact_with_schema_descr`, avoiding the
-/// `Vec<SchemaElement>` decode cost on wide schemas. Result has
-/// `schema: Vec::new()`.
-pub(crate) fn decode_file_metadata_skip_schema(
-    footer: Buffer<u8>,
-) -> ParquetResult<CompactFileMetaData> {
-    let buf: &[u8] = footer.as_ref();
-    let origin_ptr = buf.as_ptr();
-    let mut prot = ThriftSliceInputProtocol::new(buf);
-    read_file_metadata_skip_schema(&mut prot, origin_ptr, &footer)
-}
-
-fn read_file_metadata_skip_schema(
-    prot: &mut ThriftSliceInputProtocol<'_>,
-    origin_ptr: *const u8,
-    footer: &Buffer<u8>,
-) -> ParquetResult<CompactFileMetaData> {
-    let mut version: Option<i32> = None;
-    let mut num_rows: Option<i64> = None;
-    let mut row_groups: Option<Vec<CompactRowGroup>> = None;
-    let mut key_value_metadata: Option<Vec<KeyValue>> = None;
-    let mut created_by: Option<String> = None;
-    let mut column_orders: Option<Vec<ColumnOrder>> = None;
-
-    // 2 (schema), 8/9 (encryption): fall through to skip.
-    read_struct_fields!(prot, |f| {
-        1 => version = Some(prot.read_i32()?),
-        3 => num_rows = Some(prot.read_i64()?),
-        4 => row_groups = Some(read_list(prot, |p| read_row_group(p, origin_ptr))?),
-        5 => key_value_metadata = Some(read_list(prot, read_key_value)?),
-        6 => created_by = Some(prot.read_string()?.to_owned()),
-        7 => column_orders = Some(read_list(prot, read_column_order)?),
-    });
-
-    Ok(CompactFileMetaData {
-        version: version.require("FileMetaData.version")?,
-        // Empty: caller wires up the shared `SchemaDescriptor` instead.
-        schema: Vec::new(),
-        num_rows: num_rows.require("FileMetaData.num_rows")?,
-        row_groups: row_groups.require("FileMetaData.row_groups")?,
-        key_value_metadata,
-        created_by,
-        column_orders,
-        footer_buf: footer.clone(),
-    })
-}
-
 fn read_file_metadata(
     prot: &mut ThriftSliceInputProtocol<'_>,
     origin_ptr: *const u8,

--- a/crates/polars-parquet/src/parquet/handwritten_thrift/file_metadata_thrift.rs
+++ b/crates/polars-parquet/src/parquet/handwritten_thrift/file_metadata_thrift.rs
@@ -85,6 +85,71 @@ pub(crate) fn decode_file_metadata(footer: Buffer<u8>) -> ParquetResult<CompactF
     read_file_metadata(&mut prot, origin_ptr, &footer)
 }
 
+/// Decode just `FileMetaData.num_rows` (field 3) for the `RowCounts`
+/// resolve mode. Thrift field ids are ascending, so we can `break` once
+/// field 3 is read and leave the rest of the footer untouched.
+pub(crate) fn decode_num_rows(footer: Buffer<u8>) -> ParquetResult<i64> {
+    let buf: &[u8] = footer.as_ref();
+    let mut prot = ThriftSliceInputProtocol::new(buf);
+    let mut num_rows: Option<i64> = None;
+    read_struct_fields!(prot, |f| {
+        3 => {
+            num_rows = Some(prot.read_i64()?);
+            break;
+        },
+    });
+    num_rows.require("FileMetaData.num_rows")
+}
+
+/// Decode `FileMetaData` while skipping field 2 (`schema`). Multi-file
+/// scans pair the result with the first file's shared `SchemaDescriptor`
+/// via `FileMetadata::from_compact_with_schema_descr`, avoiding the
+/// `Vec<SchemaElement>` decode cost on wide schemas. Result has
+/// `schema: Vec::new()`.
+pub(crate) fn decode_file_metadata_skip_schema(
+    footer: Buffer<u8>,
+) -> ParquetResult<CompactFileMetaData> {
+    let buf: &[u8] = footer.as_ref();
+    let origin_ptr = buf.as_ptr();
+    let mut prot = ThriftSliceInputProtocol::new(buf);
+    read_file_metadata_skip_schema(&mut prot, origin_ptr, &footer)
+}
+
+fn read_file_metadata_skip_schema(
+    prot: &mut ThriftSliceInputProtocol<'_>,
+    origin_ptr: *const u8,
+    footer: &Buffer<u8>,
+) -> ParquetResult<CompactFileMetaData> {
+    let mut version: Option<i32> = None;
+    let mut num_rows: Option<i64> = None;
+    let mut row_groups: Option<Vec<CompactRowGroup>> = None;
+    let mut key_value_metadata: Option<Vec<KeyValue>> = None;
+    let mut created_by: Option<String> = None;
+    let mut column_orders: Option<Vec<ColumnOrder>> = None;
+
+    // 2 (schema), 8/9 (encryption): fall through to skip.
+    read_struct_fields!(prot, |f| {
+        1 => version = Some(prot.read_i32()?),
+        3 => num_rows = Some(prot.read_i64()?),
+        4 => row_groups = Some(read_list(prot, |p| read_row_group(p, origin_ptr))?),
+        5 => key_value_metadata = Some(read_list(prot, read_key_value)?),
+        6 => created_by = Some(prot.read_string()?.to_owned()),
+        7 => column_orders = Some(read_list(prot, read_column_order)?),
+    });
+
+    Ok(CompactFileMetaData {
+        version: version.require("FileMetaData.version")?,
+        // Empty: caller wires up the shared `SchemaDescriptor` instead.
+        schema: Vec::new(),
+        num_rows: num_rows.require("FileMetaData.num_rows")?,
+        row_groups: row_groups.require("FileMetaData.row_groups")?,
+        key_value_metadata,
+        created_by,
+        column_orders,
+        footer_buf: footer.clone(),
+    })
+}
+
 fn read_file_metadata(
     prot: &mut ThriftSliceInputProtocol<'_>,
     origin_ptr: *const u8,

--- a/crates/polars-parquet/src/parquet/handwritten_thrift/mod.rs
+++ b/crates/polars-parquet/src/parquet/handwritten_thrift/mod.rs
@@ -14,4 +14,6 @@ mod parquet_macros;
 mod file_metadata_thrift;
 mod parquet_thrift;
 
-pub(crate) use file_metadata_thrift::decode_file_metadata;
+pub(crate) use file_metadata_thrift::{
+    decode_file_metadata, decode_file_metadata_skip_schema, decode_num_rows,
+};

--- a/crates/polars-parquet/src/parquet/handwritten_thrift/mod.rs
+++ b/crates/polars-parquet/src/parquet/handwritten_thrift/mod.rs
@@ -14,6 +14,4 @@ mod parquet_macros;
 mod file_metadata_thrift;
 mod parquet_thrift;
 
-pub(crate) use file_metadata_thrift::{
-    decode_file_metadata, decode_file_metadata_skip_schema, decode_num_rows,
-};
+pub(crate) use file_metadata_thrift::{decode_file_metadata, decode_num_rows};

--- a/crates/polars-parquet/src/parquet/metadata/file_metadata.rs
+++ b/crates/polars-parquet/src/parquet/metadata/file_metadata.rs
@@ -181,33 +181,9 @@ impl FileMetadata {
     /// [`crate::parquet::read::deserialize_metadata`] which combines the
     /// hand-written decoder with this constructor.
     pub(crate) fn from_compact(compact: CompactFileMetaData) -> ParquetResult<Self> {
-        let schema_descr = SchemaDescriptor::try_from_thrift(&compact.schema)?;
-        Self::build_with_schema(compact, schema_descr)
-    }
-
-    /// Like [`Self::from_compact`] but reuses a pre-built [`SchemaDescriptor`],
-    /// for multi-file scans where all sources share the first file's schema
-    /// (paired with `decode_file_metadata_skip_schema`).
-    pub(crate) fn from_compact_with_schema_descr(
-        compact: CompactFileMetaData,
-        schema_descr: SchemaDescriptor,
-    ) -> ParquetResult<Self> {
-        debug_assert!(
-            compact.schema.is_empty(),
-            "from_compact_with_schema_descr called with a non-empty schema list; \
-             use from_compact instead"
-        );
-        Self::build_with_schema(compact, schema_descr)
-    }
-
-    /// Shared body of the two `from_compact*` constructors.
-    fn build_with_schema(
-        compact: CompactFileMetaData,
-        schema_descr: SchemaDescriptor,
-    ) -> ParquetResult<Self> {
         let CompactFileMetaData {
             version,
-            schema: _, // resolved by the caller
+            schema,
             num_rows,
             row_groups,
             key_value_metadata,
@@ -215,6 +191,8 @@ impl FileMetadata {
             column_orders,
             footer_buf,
         } = compact;
+
+        let schema_descr = SchemaDescriptor::try_from_thrift(&schema)?;
 
         let mut max_row_group_height = 0;
         let row_groups = row_groups

--- a/crates/polars-parquet/src/parquet/metadata/file_metadata.rs
+++ b/crates/polars-parquet/src/parquet/metadata/file_metadata.rs
@@ -1,12 +1,14 @@
 use polars_buffer::Buffer;
 use polars_parquet_format::ColumnOrder as TColumnOrder;
+use polars_utils::aliases::{InitHashMaps, PlHashMap};
 
 use super::RowGroupMetadata;
 use super::column_order::ColumnOrder;
-use super::compact::CompactFileMetaData;
+use super::compact::{CompactColumnChunk, CompactFileMetaData, CompactRowGroup};
 use super::schema_descriptor::SchemaDescriptor;
 use crate::parquet::error::ParquetResult;
 use crate::parquet::metadata::get_sort_order;
+use crate::parquet::schema::types::ParquetType;
 pub use crate::parquet::thrift_format::KeyValue;
 
 /// Metadata for a Parquet file.
@@ -107,18 +109,13 @@ impl FileMetadata {
         // Column name → keep-stats flag. Names not in the map are pruned
         // entirely. O(1) lookup per chunk keeps this scalable to
         // wide-column workloads (10k+ columns × many row groups).
-        use polars_utils::aliases::{InitHashMaps, PlHashMap};
         let mut keep: PlHashMap<&str, bool> = PlHashMap::with_capacity(keep_top_level_names.len());
-        for name in keep_top_level_names {
-            keep.insert(name.as_str(), false);
-        }
-        for name in predicate_top_level_names {
-            // Promotes from false to true if already present.
-            keep.insert(name.as_str(), true);
-        }
+        keep.extend(keep_top_level_names.iter().map(|n| (n.as_str(), false)));
+        // Promotes from false to true if already present.
+        keep.extend(predicate_top_level_names.iter().map(|n| (n.as_str(), true)));
 
         // 1. Filter top-level fields, preserving order from the source schema.
-        let pruned_fields: Vec<crate::parquet::schema::types::ParquetType> = self
+        let pruned_fields: Vec<ParquetType> = self
             .schema_descr
             .fields()
             .iter()
@@ -136,7 +133,7 @@ impl FileMetadata {
             .row_groups
             .iter()
             .map(|rg| {
-                let kept_chunks: Vec<crate::parquet::metadata::compact::CompactColumnChunk> = rg
+                let kept_chunks: Vec<CompactColumnChunk> = rg
                     .parquet_columns()
                     .iter()
                     .filter_map(|c| {
@@ -149,7 +146,7 @@ impl FileMetadata {
                     })
                     .collect();
 
-                let compact_rg = crate::parquet::metadata::compact::CompactRowGroup {
+                let compact_rg = CompactRowGroup {
                     columns: kept_chunks,
                     total_byte_size: rg.total_byte_size() as i64,
                     num_rows: rg.num_rows() as i64,
@@ -184,9 +181,33 @@ impl FileMetadata {
     /// [`crate::parquet::read::deserialize_metadata`] which combines the
     /// hand-written decoder with this constructor.
     pub(crate) fn from_compact(compact: CompactFileMetaData) -> ParquetResult<Self> {
+        let schema_descr = SchemaDescriptor::try_from_thrift(&compact.schema)?;
+        Self::build_with_schema(compact, schema_descr)
+    }
+
+    /// Like [`Self::from_compact`] but reuses a pre-built [`SchemaDescriptor`],
+    /// for multi-file scans where all sources share the first file's schema
+    /// (paired with `decode_file_metadata_skip_schema`).
+    pub(crate) fn from_compact_with_schema_descr(
+        compact: CompactFileMetaData,
+        schema_descr: SchemaDescriptor,
+    ) -> ParquetResult<Self> {
+        debug_assert!(
+            compact.schema.is_empty(),
+            "from_compact_with_schema_descr called with a non-empty schema list; \
+             use from_compact instead"
+        );
+        Self::build_with_schema(compact, schema_descr)
+    }
+
+    /// Shared body of the two `from_compact*` constructors.
+    fn build_with_schema(
+        compact: CompactFileMetaData,
+        schema_descr: SchemaDescriptor,
+    ) -> ParquetResult<Self> {
         let CompactFileMetaData {
             version,
-            schema,
+            schema: _, // resolved by the caller
             num_rows,
             row_groups,
             key_value_metadata,
@@ -194,8 +215,6 @@ impl FileMetadata {
             column_orders,
             footer_buf,
         } = compact;
-
-        let schema_descr = SchemaDescriptor::try_from_thrift(&schema)?;
 
         let mut max_row_group_height = 0;
         let row_groups = row_groups
@@ -207,7 +226,7 @@ impl FileMetadata {
             })
             .collect::<ParquetResult<_>>()?;
 
-        let column_orders = column_orders.map(|orders| parse_column_orders(&orders, &schema_descr));
+        let column_orders = column_orders.map(|o| parse_column_orders(&o, &schema_descr));
 
         Ok(FileMetadata {
             version,

--- a/crates/polars-parquet/src/parquet/mod.rs
+++ b/crates/polars-parquet/src/parquet/mod.rs
@@ -24,8 +24,8 @@ pub const HEADER_SIZE: u64 = PARQUET_MAGIC.len() as u64;
 pub const FOOTER_SIZE: u64 = 8;
 pub const PARQUET_MAGIC: [u8; 4] = [b'P', b'A', b'R', b'1'];
 
-/// The number of bytes read at the end of the parquet file on first read
-const DEFAULT_FOOTER_READ_SIZE: u64 = 64 * 1024;
+/// The number of bytes read at the end of the parquet file on first read.
+pub const DEFAULT_FOOTER_READ_SIZE: u64 = 64 * 1024;
 
 /// A copy-on-write buffer over bytes
 #[derive(Debug, Clone)]

--- a/crates/polars-parquet/src/parquet/read/metadata.rs
+++ b/crates/polars-parquet/src/parquet/read/metadata.rs
@@ -3,12 +3,10 @@ use std::io::{Read, Seek, SeekFrom};
 
 use polars_buffer::Buffer;
 
-use super::super::metadata::{FileMetadata, SchemaDescriptor};
+use super::super::metadata::FileMetadata;
 use super::super::{DEFAULT_FOOTER_READ_SIZE, FOOTER_SIZE, HEADER_SIZE, PARQUET_MAGIC};
 use crate::parquet::error::{ParquetError, ParquetResult};
-use crate::parquet::handwritten_thrift::{
-    decode_file_metadata, decode_file_metadata_skip_schema, decode_num_rows,
-};
+use crate::parquet::handwritten_thrift::{decode_file_metadata, decode_num_rows};
 
 pub(super) fn metadata_len(buffer: &[u8]) -> u32 {
     let len = buffer.len();
@@ -53,39 +51,6 @@ pub fn read_metadata_with_size<R: Read + Seek>(
 pub fn deserialize_metadata(footer: Buffer<u8>) -> ParquetResult<FileMetadata> {
     let compact = decode_file_metadata(footer)?;
     FileMetadata::from_compact(compact)
-}
-
-/// Parse `footer` with thrift field 2 (schema) skipped, reusing
-/// `schema_descr`. See [`deserialize_metadata`] for the buffer-lifetime
-/// contract and [`crate::parquet::handwritten_thrift::decode_file_metadata_skip_schema`]
-/// for the decode rationale.
-pub fn deserialize_metadata_with_shared_schema(
-    footer: Buffer<u8>,
-    schema_descr: SchemaDescriptor,
-) -> ParquetResult<FileMetadata> {
-    let compact = decode_file_metadata_skip_schema(footer)?;
-    FileMetadata::from_compact_with_schema_descr(compact, schema_descr)
-}
-
-/// Sync variant of [`deserialize_metadata_with_shared_schema`] that owns the
-/// reader. Fetches the footer the same way [`read_metadata`] does, then
-/// parses with the schema field skipped.
-pub fn read_metadata_with_shared_schema<R: Read + Seek>(
-    reader: &mut R,
-    schema_descr: SchemaDescriptor,
-) -> ParquetResult<FileMetadata> {
-    let file_size = stream_len(reader)?;
-    read_metadata_with_shared_schema_with_size(reader, file_size, schema_descr)
-}
-
-/// As [`read_metadata_with_shared_schema`] but with a pre-fetched file size.
-pub(crate) fn read_metadata_with_shared_schema_with_size<R: Read + Seek>(
-    reader: &mut R,
-    file_size: u64,
-    schema_descr: SchemaDescriptor,
-) -> ParquetResult<FileMetadata> {
-    let footer = fetch_footer_buf(reader, file_size)?;
-    deserialize_metadata_with_shared_schema(footer, schema_descr)
 }
 
 /// Decode only `FileMetaData.num_rows` (thrift field 3) from `footer`.

--- a/crates/polars-parquet/src/parquet/read/metadata.rs
+++ b/crates/polars-parquet/src/parquet/read/metadata.rs
@@ -3,10 +3,12 @@ use std::io::{Read, Seek, SeekFrom};
 
 use polars_buffer::Buffer;
 
-use super::super::metadata::FileMetadata;
+use super::super::metadata::{FileMetadata, SchemaDescriptor};
 use super::super::{DEFAULT_FOOTER_READ_SIZE, FOOTER_SIZE, HEADER_SIZE, PARQUET_MAGIC};
 use crate::parquet::error::{ParquetError, ParquetResult};
-use crate::parquet::handwritten_thrift::decode_file_metadata;
+use crate::parquet::handwritten_thrift::{
+    decode_file_metadata, decode_file_metadata_skip_schema, decode_num_rows,
+};
 
 pub(super) fn metadata_len(buffer: &[u8]) -> u32 {
     let len = buffer.len();
@@ -39,57 +41,8 @@ pub fn read_metadata_with_size<R: Read + Seek>(
     reader: &mut R,
     file_size: u64,
 ) -> ParquetResult<FileMetadata> {
-    if file_size < HEADER_SIZE + FOOTER_SIZE {
-        return Err(ParquetError::oos(
-            "A Parquet file must contain a header and footer with at least 12 bytes",
-        ));
-    }
-
-    // read and cache up to DEFAULT_FOOTER_READ_SIZE bytes from the end and process the footer
-    let default_end_len = min(DEFAULT_FOOTER_READ_SIZE, file_size) as usize;
-    reader.seek(SeekFrom::End(-(default_end_len as i64)))?;
-
-    let mut buffer = vec![];
-    buffer.try_reserve(default_end_len)?;
-    reader
-        .take(default_end_len as u64)
-        .read_to_end(&mut buffer)?;
-
-    // check this is indeed a parquet file
-    if buffer[default_end_len - 4..] != PARQUET_MAGIC {
-        return Err(ParquetError::oos("The file must end with PAR1"));
-    }
-
-    let metadata_len: u32 = metadata_len(&buffer);
-    let metadata_len: u64 = metadata_len as u64;
-
-    let footer_len = FOOTER_SIZE + metadata_len;
-    if footer_len > file_size {
-        return Err(ParquetError::oos(
-            "The footer size must be smaller or equal to the file's size",
-        ));
-    }
-
-    // Footer bytes need to outlive the FileMetadata so stats `ByteRange`s
-    // stay resolvable, wrap in a `Buffer`. Both branches end with a
-    // zero-copy move from the source `Vec<u8>` into the buffer.
-    let footer_buf: Buffer<u8> = if (footer_len as usize) <= buffer.len() {
-        // The full footer is already in the bytes we prefetched, slice into
-        // the existing buffer.
-        let remaining = buffer.len() - footer_len as usize;
-        Buffer::from_vec(buffer).sliced(remaining..)
-    } else {
-        // the end of file read by default is not long enough, read again
-        // including the metadata.
-        reader.seek(SeekFrom::End(-(footer_len as i64)))?;
-
-        buffer.clear();
-        buffer.try_reserve(footer_len as usize)?;
-        reader.take(footer_len).read_to_end(&mut buffer)?;
-
-        Buffer::from_vec(buffer)
-    };
-    deserialize_metadata(footer_buf)
+    let footer = fetch_footer_buf(reader, file_size)?;
+    deserialize_metadata(footer)
 }
 
 /// Parse loaded metadata bytes via the hand-written Thrift compact decoder.
@@ -100,4 +53,110 @@ pub fn read_metadata_with_size<R: Read + Seek>(
 pub fn deserialize_metadata(footer: Buffer<u8>) -> ParquetResult<FileMetadata> {
     let compact = decode_file_metadata(footer)?;
     FileMetadata::from_compact(compact)
+}
+
+/// Parse `footer` with thrift field 2 (schema) skipped, reusing
+/// `schema_descr`. See [`deserialize_metadata`] for the buffer-lifetime
+/// contract and [`crate::parquet::handwritten_thrift::decode_file_metadata_skip_schema`]
+/// for the decode rationale.
+pub fn deserialize_metadata_with_shared_schema(
+    footer: Buffer<u8>,
+    schema_descr: SchemaDescriptor,
+) -> ParquetResult<FileMetadata> {
+    let compact = decode_file_metadata_skip_schema(footer)?;
+    FileMetadata::from_compact_with_schema_descr(compact, schema_descr)
+}
+
+/// Sync variant of [`deserialize_metadata_with_shared_schema`] that owns the
+/// reader. Fetches the footer the same way [`read_metadata`] does, then
+/// parses with the schema field skipped.
+pub fn read_metadata_with_shared_schema<R: Read + Seek>(
+    reader: &mut R,
+    schema_descr: SchemaDescriptor,
+) -> ParquetResult<FileMetadata> {
+    let file_size = stream_len(reader)?;
+    read_metadata_with_shared_schema_with_size(reader, file_size, schema_descr)
+}
+
+/// As [`read_metadata_with_shared_schema`] but with a pre-fetched file size.
+pub(crate) fn read_metadata_with_shared_schema_with_size<R: Read + Seek>(
+    reader: &mut R,
+    file_size: u64,
+    schema_descr: SchemaDescriptor,
+) -> ParquetResult<FileMetadata> {
+    let footer = fetch_footer_buf(reader, file_size)?;
+    deserialize_metadata_with_shared_schema(footer, schema_descr)
+}
+
+/// Decode only `FileMetaData.num_rows` (thrift field 3) from `footer`.
+/// Used by Polars multi-file scans in `RowCounts` resolve mode. See
+/// [`crate::parquet::handwritten_thrift::decode_num_rows`].
+pub fn deserialize_num_rows(footer: Buffer<u8>) -> ParquetResult<i64> {
+    decode_num_rows(footer)
+}
+
+/// Sync variant of [`deserialize_num_rows`] that owns the reader.
+pub fn read_num_rows<R: Read + Seek>(reader: &mut R) -> ParquetResult<i64> {
+    let file_size = stream_len(reader)?;
+    read_num_rows_with_size(reader, file_size)
+}
+
+/// As [`read_num_rows`] but with a pre-fetched file size.
+pub(crate) fn read_num_rows_with_size<R: Read + Seek>(
+    reader: &mut R,
+    file_size: u64,
+) -> ParquetResult<i64> {
+    let footer = fetch_footer_buf(reader, file_size)?;
+    decode_num_rows(footer)
+}
+
+/// Fetch the trailing footer bytes from a [`Read`] + [`Seek`]. Returns a
+/// [`Buffer<u8>`] (not a `Vec<u8>`) because [`FileMetadata`] holds the buffer
+/// for the lifetime of the metadata; column-chunk statistics store
+/// `ByteRange`s into it instead of allocating per-stat byte vecs.
+fn fetch_footer_buf<R: Read + Seek>(reader: &mut R, file_size: u64) -> ParquetResult<Buffer<u8>> {
+    if file_size < HEADER_SIZE + FOOTER_SIZE {
+        return Err(ParquetError::oos(
+            "A Parquet file must contain a header and footer with at least 12 bytes",
+        ));
+    }
+
+    // Read and cache up to DEFAULT_FOOTER_READ_SIZE bytes from the end.
+    let default_end_len = min(DEFAULT_FOOTER_READ_SIZE, file_size) as usize;
+    reader.seek(SeekFrom::End(-(default_end_len as i64)))?;
+
+    let mut buffer = vec![];
+    buffer.try_reserve(default_end_len)?;
+    reader
+        .take(default_end_len as u64)
+        .read_to_end(&mut buffer)?;
+
+    // Check this is indeed a parquet file.
+    if buffer[default_end_len - 4..] != PARQUET_MAGIC {
+        return Err(ParquetError::oos("The file must end with PAR1"));
+    }
+
+    let metadata_len = metadata_len(&buffer) as u64;
+    let footer_len = FOOTER_SIZE + metadata_len;
+    if footer_len > file_size {
+        return Err(ParquetError::oos(
+            "The footer size must be smaller or equal to the file's size",
+        ));
+    }
+
+    // Both branches end with a zero-copy move from `Vec<u8>` into `Buffer`.
+    let footer_buf: Buffer<u8> = if (footer_len as usize) <= buffer.len() {
+        // Full footer already in the prefetched bytes; slice the tail.
+        let remaining = buffer.len() - footer_len as usize;
+        Buffer::from_vec(buffer).sliced(remaining..)
+    } else {
+        // Prefetch wasn't long enough; re-read the whole footer.
+        reader.seek(SeekFrom::End(-(footer_len as i64)))?;
+        buffer.clear();
+        buffer.try_reserve(footer_len as usize)?;
+        reader.take(footer_len).read_to_end(&mut buffer)?;
+        Buffer::from_vec(buffer)
+    };
+
+    Ok(footer_buf)
 }

--- a/crates/polars-parquet/src/parquet/read/mod.rs
+++ b/crates/polars-parquet/src/parquet/read/mod.rs
@@ -10,7 +10,10 @@ use std::io::{Cursor, Seek, SeekFrom};
 
 pub use column::*;
 pub use compression::{BasicDecompressor, decompress};
-pub use metadata::{deserialize_metadata, read_metadata, read_metadata_with_size};
+pub use metadata::{
+    deserialize_metadata, deserialize_metadata_with_shared_schema, deserialize_num_rows,
+    read_metadata, read_metadata_with_shared_schema, read_metadata_with_size, read_num_rows,
+};
 pub use page::{PageIterator, PageMetaData, PageReader};
 #[cfg(feature = "async")]
 pub use page::{get_page_stream, get_page_stream_from_column_start};

--- a/crates/polars-parquet/src/parquet/read/mod.rs
+++ b/crates/polars-parquet/src/parquet/read/mod.rs
@@ -11,8 +11,8 @@ use std::io::{Cursor, Seek, SeekFrom};
 pub use column::*;
 pub use compression::{BasicDecompressor, decompress};
 pub use metadata::{
-    deserialize_metadata, deserialize_metadata_with_shared_schema, deserialize_num_rows,
-    read_metadata, read_metadata_with_shared_schema, read_metadata_with_size, read_num_rows,
+    deserialize_metadata, deserialize_num_rows, read_metadata, read_metadata_with_size,
+    read_num_rows,
 };
 pub use page::{PageIterator, PageMetaData, PageReader};
 #[cfg(feature = "async")]

--- a/crates/polars-plan/src/dsl/file_scan/mod.rs
+++ b/crates/polars-plan/src/dsl/file_scan/mod.rs
@@ -112,9 +112,16 @@ pub enum FileScanIR {
     #[cfg(feature = "parquet")]
     Parquet {
         options: ParquetOptions,
-        // `dsl-schema` only: `FileMetadata` has no `JsonSchema` impl.
+        /// Pre-decoded first-file metadata. Consumed by the streaming
+        /// `ParquetReaderBuilder` as its initial hint.
         #[cfg_attr(feature = "dsl-schema", serde(skip))]
-        metadata: Option<FileMetadataRef>,
+        first_metadata: Option<FileMetadataRef>,
+        /// Per-source metadata for the distributed scheduler. `Some(s)`
+        /// only in `Full` resolve mode, with `s[i]` for `sources[i]`.
+        /// `s[0] == first_metadata` so callers iterate uniformly
+        /// without special-casing the first source.
+        #[cfg_attr(feature = "dsl-schema", serde(skip))]
+        metadata_per_source: Option<Arc<[FileMetadataRef]>>,
     },
 
     #[cfg(feature = "ipc")]
@@ -174,6 +181,45 @@ impl FileScanIR {
             Self::NDJson { .. } => false,
             #[allow(unreachable_patterns)]
             _ => false,
+        }
+    }
+
+    /// Re-index pre-decoded per-source state after a source-list filter.
+    ///
+    /// `surviving_indices` yields ascending indices into the pre-filter list.
+    pub fn gather_after_filter<I>(&mut self, first_file_dropped: bool, surviving_indices: I)
+    where
+        I: Iterator<Item = usize>,
+    {
+        // Parquet: clear `first_metadata` if file 0 dropped; gather
+        // `metadata_per_source` by surviving indices so slice[i] still
+        // matches sources[i]. We re-index instead of clearing because
+        // the surviving footers are already decoded; tossing them would
+        // force the scheduler to refetch and re-decode the same bytes.
+        // Ipc / PythonDataset: file-0-keyed state cleared when file 0 dropped.
+        match self {
+            #[cfg(feature = "parquet")]
+            Self::Parquet {
+                first_metadata,
+                metadata_per_source,
+                ..
+            } => {
+                if first_file_dropped {
+                    *first_metadata = None;
+                }
+                if let Some(slice) = metadata_per_source {
+                    let gathered: Arc<[FileMetadataRef]> =
+                        surviving_indices.map(|i| slice[i].clone()).collect();
+                    *slice = gathered;
+                }
+            },
+            #[cfg(feature = "ipc")]
+            Self::Ipc { metadata, .. } if first_file_dropped => *metadata = None,
+            #[cfg(feature = "python")]
+            Self::PythonDataset { cached_ir, .. } if first_file_dropped => {
+                *cached_ir.lock().unwrap() = None;
+            },
+            _ => {},
         }
     }
 }
@@ -415,7 +461,8 @@ mod _file_scan_eq_hash {
         #[cfg(feature = "parquet")]
         Parquet {
             options: &'a polars_io::prelude::ParquetOptions,
-            metadata: Option<usize>,
+            first_metadata: Option<usize>,
+            metadata_per_source: Option<usize>,
         },
 
         #[cfg(feature = "ipc")]
@@ -459,9 +506,14 @@ mod _file_scan_eq_hash {
                 FileScanIR::NDJson { options } => FileScanEqHashWrap::NDJson { options },
 
                 #[cfg(feature = "parquet")]
-                FileScanIR::Parquet { options, metadata } => FileScanEqHashWrap::Parquet {
+                FileScanIR::Parquet {
                     options,
-                    metadata: metadata.as_ref().map(arc_as_ptr),
+                    first_metadata,
+                    metadata_per_source,
+                } => FileScanEqHashWrap::Parquet {
+                    options,
+                    first_metadata: first_metadata.as_ref().map(arc_as_ptr),
+                    metadata_per_source: metadata_per_source.as_ref().map(arc_as_ptr),
                 },
 
                 #[cfg(feature = "ipc")]

--- a/crates/polars-plan/src/dsl/file_scan/mod.rs
+++ b/crates/polars-plan/src/dsl/file_scan/mod.rs
@@ -200,26 +200,46 @@ impl FileScanIR {
         match self {
             #[cfg(feature = "parquet")]
             Self::Parquet {
+                options: _,
                 first_metadata,
                 metadata_per_source,
-                ..
             } => {
                 if first_file_dropped {
                     *first_metadata = None;
                 }
                 if let Some(slice) = metadata_per_source {
-                    let gathered: Arc<[FileMetadataRef]> =
-                        surviving_indices.map(|i| slice[i].clone()).collect();
-                    *slice = gathered;
+                    *slice = surviving_indices.map(|i| slice[i].clone()).collect();
                 }
             },
             #[cfg(feature = "ipc")]
-            Self::Ipc { metadata, .. } if first_file_dropped => *metadata = None,
-            #[cfg(feature = "python")]
-            Self::PythonDataset { cached_ir, .. } if first_file_dropped => {
-                *cached_ir.lock().unwrap() = None;
+            Self::Ipc {
+                options: _,
+                metadata,
+            } => {
+                if first_file_dropped {
+                    *metadata = None;
+                }
             },
-            _ => {},
+            #[cfg(feature = "csv")]
+            Self::Csv { options: _ } => {},
+            #[cfg(feature = "json")]
+            Self::NDJson { options: _ } => {},
+            #[cfg(feature = "python")]
+            Self::PythonDataset {
+                dataset_object: _,
+                cached_ir,
+            } => {
+                if first_file_dropped {
+                    *cached_ir.lock().unwrap() = None;
+                }
+            },
+            #[cfg(feature = "scan_lines")]
+            Self::Lines { name: _ } => {},
+            Self::ExpandedPaths { name: _ } => {},
+            Self::Anonymous {
+                options: _,
+                function: _,
+            } => {},
         }
     }
 }

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
@@ -238,14 +238,23 @@ fn prepare_schemas(
 
 #[cfg(feature = "parquet")]
 pub(super) async fn parquet_file_info(
-    first_scan_source: ScanSourceRef<'_>,
+    sources: &ScanSources,
     row_index: Option<&RowIndex>,
     #[allow(unused)] cloud_options: Option<&polars_io::cloud::CloudOptions>,
-    n_sources: usize,
-) -> PolarsResult<(FileInfo, Option<FileMetadataRef>)> {
+) -> PolarsResult<(
+    FileInfo,
+    Option<FileMetadataRef>,
+    Option<Arc<[FileMetadataRef]>>,
+)> {
+    use futures::stream::{FuturesUnordered, StreamExt};
     use polars_core::error::feature_gated;
 
-    let (reader_schema, num_rows, metadata) = {
+    let n_sources = sources.len();
+    let first_scan_source = sources.iter().next().expect("at least one source");
+
+    // First file: schema + num_rows + full metadata. Schema comes from
+    // file 0 only (no cross-file schema evolution).
+    let (reader_schema, first_num_rows, first_metadata) = {
         if first_scan_source.is_cloud_url() {
             let first_path = first_scan_source.as_path().unwrap();
             feature_gated!("cloud", {
@@ -260,7 +269,7 @@ pub(super) async fn parquet_file_info(
             })
         } else {
             let memslice = first_scan_source.to_memslice()?;
-            let mut reader = ParquetReader::new(std::io::Cursor::new(memslice));
+            let mut reader = ParquetReader::new(Cursor::new(memslice));
             (
                 reader.schema()?,
                 reader.num_rows()?,
@@ -272,15 +281,127 @@ pub(super) async fn parquet_file_info(
     let schema =
         prepare_output_schema(Schema::from_arrow_schema(reader_schema.as_ref()), row_index)?;
 
-    let known_size = if n_sources == 1 { Some(num_rows) } else { None };
+    // Resolve metadata for sources past the first, dispatched by
+    // `POLARS_RESOLVE_METADATA_LEVEL`:
+    // - `None`: extrapolate `first_num_rows * n_sources`.
+    // - `RowCounts` (OSS default): per-source thrift field 3 only.
+    // - `Full` (cloud default): per-source footer, populates
+    //   `metadata_per_source` for the distributed scheduler.
+    let mode = polars_config::config().resolve_metadata_level();
+    let (metadata_per_source, known_size, estimated_size) = if n_sources == 1 {
+        (None, Some(first_num_rows), first_num_rows)
+    } else {
+        use polars_config::ResolveMode;
+        match mode {
+            ResolveMode::None => (None, None, first_num_rows * n_sources),
+            ResolveMode::RowCounts => {
+                let mut futures = (1..n_sources)
+                    .map(|i| async move {
+                        let n = read_parquet_num_rows(sources.at(i), cloud_options).await?;
+                        PolarsResult::Ok(n)
+                    })
+                    .collect::<FuturesUnordered<_>>();
+
+                let mut total: usize = first_num_rows;
+                while let Some(res) = futures.next().await {
+                    total = total.saturating_add(res? as usize);
+                }
+                (None, Some(total), total)
+            },
+            ResolveMode::Full => {
+                // Reuse file 0's `SchemaDescriptor` for files 1..N so each
+                // decoder skips thrift field 2 (cheap Arc clone, big win on
+                // wide schemas).
+                let shared_schema = first_metadata.schema_descr.clone();
+                let mut futures = (1..n_sources)
+                    .map(|i| {
+                        let shared = shared_schema.clone();
+                        async move {
+                            let m =
+                                read_parquet_metadata(sources.at(i), cloud_options, shared).await?;
+                            PolarsResult::Ok((i, m))
+                        }
+                    })
+                    .collect::<FuturesUnordered<_>>();
+
+                // Pre-fill with `first_metadata`; futures overwrite slots
+                // 1..n as they resolve. Slot 0 stays untouched, satisfying
+                // the `metadata_per_source[0] == first_metadata` invariant.
+                let mut per_file: Vec<FileMetadataRef> = vec![first_metadata.clone(); n_sources];
+                let mut total: usize = first_num_rows;
+                while let Some(res) = futures.next().await {
+                    let (i, m) = res?;
+                    total = total.saturating_add(m.num_rows);
+                    per_file[i] = m;
+                }
+                let dense: Arc<[FileMetadataRef]> = per_file.into();
+                (Some(dense), Some(total), total)
+            },
+        }
+    };
 
     let file_info = FileInfo::new(
         schema,
         Some(Either::Left(reader_schema)),
-        (known_size, num_rows * n_sources),
+        (known_size, estimated_size),
     );
 
-    Ok((file_info, Some(metadata)))
+    Ok((file_info, Some(first_metadata), metadata_per_source))
+}
+
+/// Fetch one source's full footer, borrowing the first file's schema.
+/// Used by [`parquet_file_info`] in `Full` resolve mode.
+#[cfg(feature = "parquet")]
+async fn read_parquet_metadata(
+    source: ScanSourceRef<'_>,
+    #[allow(unused)] cloud_options: Option<&polars_io::cloud::CloudOptions>,
+    shared_schema: polars_parquet::parquet::metadata::SchemaDescriptor,
+) -> PolarsResult<FileMetadataRef> {
+    use polars_core::error::feature_gated;
+
+    if source.is_cloud_url() {
+        let path = source.as_path().unwrap();
+        feature_gated!("cloud", {
+            let mut reader =
+                ParquetObjectStore::from_uri(path.clone(), cloud_options, None).await?;
+            reader
+                .get_metadata_with_shared_schema(shared_schema)
+                .await
+                .cloned()
+        })
+    } else {
+        let memslice = source.to_memslice()?;
+        let mut cursor = Cursor::new(memslice);
+        let md = polars_parquet::parquet::read::read_metadata_with_shared_schema(
+            &mut cursor,
+            shared_schema,
+        )?;
+        Ok(Arc::new(md))
+    }
+}
+
+/// Fetch one source's `num_rows` (thrift field 3 only); skips
+/// schema, row_groups, and the rest. Used by [`parquet_file_info`]
+/// in `RowCounts` resolve mode.
+#[cfg(feature = "parquet")]
+async fn read_parquet_num_rows(
+    source: ScanSourceRef<'_>,
+    #[allow(unused)] cloud_options: Option<&polars_io::cloud::CloudOptions>,
+) -> PolarsResult<i64> {
+    use polars_core::error::feature_gated;
+
+    if source.is_cloud_url() {
+        let path = source.as_path().unwrap();
+        feature_gated!("cloud", {
+            let mut reader =
+                ParquetObjectStore::from_uri(path.clone(), cloud_options, None).await?;
+            reader.num_rows_only().await
+        })
+    } else {
+        let memslice = source.to_memslice()?;
+        let mut cursor = Cursor::new(memslice);
+        polars_parquet::parquet::read::read_num_rows(&mut cursor).map_err(Into::into)
+    }
 }
 
 pub fn max_metadata_scan_cached() -> usize {
@@ -822,7 +943,6 @@ impl SourcesToFileInfo {
             )
         };
 
-        let n_sources = sources.len();
         let cloud_options = unified_scan_args.cloud_options.as_ref();
 
         Ok(match scan_type {
@@ -842,7 +962,9 @@ impl SourcesToFileInfo {
                         },
                         FileScanIR::Parquet {
                             options,
-                            metadata: None,
+                            // Schema was passed in; no footer was resolved.
+                            first_metadata: None,
+                            metadata_per_source: None,
                         },
                     )
                 } else {
@@ -861,13 +983,13 @@ this scan to succeed with an empty DataFrame.",
                             )
                         }
 
-                        let (mut file_info, mut metadata) = scans::parquet_file_info(
-                            first_scan_source,
-                            unified_scan_args.row_index.as_ref(),
-                            cloud_options,
-                            n_sources,
-                        )
-                        .await?;
+                        let (mut file_info, mut first_metadata, mut metadata_per_source) =
+                            scans::parquet_file_info(
+                                sources,
+                                unified_scan_args.row_index.as_ref(),
+                                cloud_options,
+                            )
+                            .await?;
 
                         if let Some((total, deleted)) = unified_scan_args.row_count {
                             let size = (total - deleted) as usize;
@@ -875,10 +997,21 @@ this scan to succeed with an empty DataFrame.",
                         }
 
                         if self.inner.read().unwrap().len() > max_metadata_scan_cached() {
-                            _ = metadata.take();
+                            // Cache pressure: drop both pre-decoded slots so
+                            // we don't blow memory. Streaming readers fall
+                            // back to fetching footers at scan time.
+                            first_metadata = None;
+                            metadata_per_source = None;
                         }
 
-                        PolarsResult::Ok((file_info, FileScanIR::Parquet { options, metadata }))
+                        PolarsResult::Ok((
+                            file_info,
+                            FileScanIR::Parquet {
+                                options,
+                                first_metadata,
+                                metadata_per_source,
+                            },
+                        ))
                     }
                     .map_err(|e| e.context(failed_here!(parquet scan)))?
                 }

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
@@ -246,7 +246,7 @@ pub(super) async fn parquet_file_info(
     Option<FileMetadataRef>,
     Option<Arc<[FileMetadataRef]>>,
 )> {
-    use futures::stream::{FuturesUnordered, StreamExt};
+    use futures::stream::{FuturesOrdered, FuturesUnordered, StreamExt};
     use polars_core::error::feature_gated;
 
     let n_sources = sources.len();
@@ -316,33 +316,27 @@ pub(super) async fn parquet_file_info(
                 (None, Some(total), total)
             },
             ResolveMode::Full => {
-                // Reuse file 0's `SchemaDescriptor` for files 1..N so each
-                // decoder skips thrift field 2 (cheap Arc clone, big win on
-                // wide schemas).
-                let shared_schema = first_metadata.schema_descr.clone();
+                // Each file decoded with its own schema: per-file schemas
+                // may differ in columns, dtypes, or column order.
                 let mut futures = (1..n_sources)
-                    .map(|i| {
-                        let shared = shared_schema.clone();
-                        async move {
-                            let result =
-                                read_parquet_metadata(sources.at(i), cloud_options, shared).await;
-                            (i, result)
-                        }
-                    })
-                    .collect::<FuturesUnordered<_>>();
+                    .map(|i| read_parquet_metadata(sources.at(i), cloud_options))
+                    .collect::<FuturesOrdered<_>>();
 
-                // Pre-fill with `first_metadata`; futures overwrite slots
-                // 1..n as they resolve. Slot 0 stays untouched, satisfying
-                // the `metadata_per_source[0] == first_metadata` invariant.
-                // Best-effort: on error the slot keeps the pre-fill default;
-                // the cloud scheduler re-fetches if it needs accurate
-                // row_groups for that file.
-                let mut per_file: Vec<FileMetadataRef> = vec![first_metadata.clone(); n_sources];
+                // Push slot 0 (satisfying the `metadata_per_source[0] ==
+                // first_metadata` invariant), then push each future result.
+                // Best-effort: on error push `first_metadata.clone()`; the
+                // cloud scheduler re-fetches if it needs accurate row_groups
+                // for that file.
+                let mut per_file: Vec<FileMetadataRef> = Vec::with_capacity(n_sources);
+                per_file.push(first_metadata.clone());
                 let mut total: usize = first_num_rows;
-                while let Some((i, file_result)) = futures.next().await {
-                    if let Ok(m) = file_result {
-                        total = total.saturating_add(m.num_rows);
-                        per_file[i] = m;
+                while let Some(file_result) = futures.next().await {
+                    match file_result {
+                        Ok(m) => {
+                            total = total.saturating_add(m.num_rows);
+                            per_file.push(m);
+                        },
+                        Err(_) => per_file.push(first_metadata.clone()),
                     }
                 }
                 let dense: Arc<[FileMetadataRef]> = per_file.into();
@@ -360,13 +354,12 @@ pub(super) async fn parquet_file_info(
     Ok((file_info, Some(first_metadata), metadata_per_source))
 }
 
-/// Fetch one source's full footer, borrowing the first file's schema.
-/// Used by [`parquet_file_info`] in `Full` resolve mode.
+/// Fetch one source's full footer. Used by [`parquet_file_info`] in
+/// `Full` resolve mode.
 #[cfg(feature = "parquet")]
 async fn read_parquet_metadata(
     source: ScanSourceRef<'_>,
     #[allow(unused)] cloud_options: Option<&polars_io::cloud::CloudOptions>,
-    shared_schema: polars_parquet::parquet::metadata::SchemaDescriptor,
 ) -> PolarsResult<FileMetadataRef> {
     use polars_core::error::feature_gated;
 
@@ -375,18 +368,12 @@ async fn read_parquet_metadata(
         feature_gated!("cloud", {
             let mut reader =
                 ParquetObjectStore::from_uri(path.clone(), cloud_options, None).await?;
-            reader
-                .get_metadata_with_shared_schema(shared_schema)
-                .await
-                .cloned()
+            reader.get_metadata().await.cloned()
         })
     } else {
         let memslice = source.to_memslice()?;
         let mut cursor = Cursor::new(memslice);
-        let md = polars_parquet::parquet::read::read_metadata_with_shared_schema(
-            &mut cursor,
-            shared_schema,
-        )?;
+        let md = polars_parquet::parquet::read::read_metadata(&mut cursor)?;
         Ok(Arc::new(md))
     }
 }

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
@@ -297,14 +297,20 @@ pub(super) async fn parquet_file_info(
             ResolveMode::RowCounts => {
                 let mut futures = (1..n_sources)
                     .map(|i| async move {
-                        let n = read_parquet_num_rows(sources.at(i), cloud_options).await?;
-                        PolarsResult::Ok(n)
+                        read_parquet_num_rows(sources.at(i), cloud_options).await
                     })
                     .collect::<FuturesUnordered<_>>();
 
+                // Best-effort: a file that fails to decode at plan time (e.g.
+                // an invalid file in a hive partition not yet pruned) simply
+                // contributes 0 to the estimate. If execution needs the file
+                // it will error then; if predicate pushdown prunes it first,
+                // it never matters.
                 let mut total: usize = first_num_rows;
                 while let Some(res) = futures.next().await {
-                    total = total.saturating_add(res? as usize);
+                    if let Ok(n) = res {
+                        total = total.saturating_add(n as usize);
+                    }
                 }
                 (None, Some(total), total)
             },
@@ -317,9 +323,9 @@ pub(super) async fn parquet_file_info(
                     .map(|i| {
                         let shared = shared_schema.clone();
                         async move {
-                            let m =
-                                read_parquet_metadata(sources.at(i), cloud_options, shared).await?;
-                            PolarsResult::Ok((i, m))
+                            let result =
+                                read_parquet_metadata(sources.at(i), cloud_options, shared).await;
+                            (i, result)
                         }
                     })
                     .collect::<FuturesUnordered<_>>();
@@ -327,12 +333,16 @@ pub(super) async fn parquet_file_info(
                 // Pre-fill with `first_metadata`; futures overwrite slots
                 // 1..n as they resolve. Slot 0 stays untouched, satisfying
                 // the `metadata_per_source[0] == first_metadata` invariant.
+                // Best-effort: on error the slot keeps the pre-fill default;
+                // the cloud scheduler re-fetches if it needs accurate
+                // row_groups for that file.
                 let mut per_file: Vec<FileMetadataRef> = vec![first_metadata.clone(); n_sources];
                 let mut total: usize = first_num_rows;
-                while let Some(res) = futures.next().await {
-                    let (i, m) = res?;
-                    total = total.saturating_add(m.num_rows);
-                    per_file[i] = m;
+                while let Some((i, file_result)) = futures.next().await {
+                    if let Ok(m) = file_result {
+                        total = total.saturating_add(m.num_rows);
+                        per_file[i] = m;
+                    }
                 }
                 let dense: Arc<[FileMetadataRef]> = per_file.into();
                 (Some(dense), Some(total), total)

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
@@ -295,11 +295,12 @@ pub(super) async fn parquet_file_info(
         match mode {
             ResolveMode::None => (None, None, first_num_rows * n_sources),
             ResolveMode::RowCounts => {
-                let mut futures = (1..n_sources)
-                    .map(|i| async move {
-                        read_parquet_num_rows(sources.at(i), cloud_options).await
-                    })
-                    .collect::<FuturesUnordered<_>>();
+                let mut futures =
+                    (1..n_sources)
+                        .map(|i| async move {
+                            read_parquet_num_rows(sources.at(i), cloud_options).await
+                        })
+                        .collect::<FuturesUnordered<_>>();
 
                 // Best-effort: a file that fails to decode at plan time (e.g.
                 // an invalid file in a hive partition not yet pruned) simply

--- a/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
+++ b/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
@@ -292,7 +292,9 @@ pub(super) fn expand_datasets(
                             #[cfg(feature = "parquet")]
                             FileScanDsl::Parquet { options } => FileScanIR::Parquet {
                                 options,
-                                metadata: None,
+                                // Metadata is resolved later in `parquet_file_info`.
+                                first_metadata: None,
+                                metadata_per_source: None,
                             },
 
                             #[cfg(feature = "json")]

--- a/crates/polars-plan/src/plans/optimizer/parquet_metadata_prune.rs
+++ b/crates/polars-plan/src/plans/optimizer/parquet_metadata_prune.rs
@@ -13,8 +13,6 @@ use std::sync::Arc;
 
 #[cfg(feature = "parquet")]
 use polars_io::parquet::metadata::FileMetadataRef;
-#[cfg(feature = "parquet")]
-use polars_utils::aliases::PlHashSet;
 use polars_utils::arena::{Arena, Node};
 #[cfg(feature = "parquet")]
 use polars_utils::pl_str::PlSmallStr;
@@ -70,19 +68,13 @@ pub(super) fn prune_parquet_metadata(
             continue;
         };
 
-        // O(1) membership lookup; avoids O(|predicate_leaves| × |projection|)
-        // when projection is wide (10k+ cols).
-        let projection_set: PlHashSet<&str> =
-            PlHashSet::from_iter(projection.iter().map(|s| s.as_str()));
-
-        // Filter predicate cols to those in the projection. `pruned()` would
-        // otherwise keep a predicate-only column the projection dropped (its
-        // `keep` map unions both name lists).
+        // Predicate cols are a subset of the projection by this point:
+        // projection pushdown adds predicate-referenced cols to the scan
+        // (else the pushed-down predicate would `ColumnNotFound` at execute).
         let predicate_cols: Vec<PlSmallStr> = predicate
             .as_ref()
             .map(|pred_ir| {
                 aexpr_to_leaf_names_iter(pred_ir.node(), expr_arena)
-                    .filter(|name| projection_set.contains(name.as_str()))
                     .cloned()
                     .collect()
             })
@@ -92,29 +84,18 @@ pub(super) fn prune_parquet_metadata(
         // recoverable; fall back to unpruned metadata so the query still runs.
         // The wire form just stays larger for this entry. Swap-only-if-smaller
         // (leaf count) avoids allocating a new inner Arc when nothing changed.
-        let prune_one = |meta_arc: &mut FileMetadataRef| {
-            if let Ok(pruned) = meta_arc.pruned(&projection, &predicate_cols)
-                && pruned.schema_descr.columns().len() < meta_arc.schema_descr.columns().len()
-            {
-                *meta_arc = Arc::new(pruned);
-            }
+        let prune_one = |m: &FileMetadataRef| -> FileMetadataRef {
+            m.pruned(&projection, &predicate_cols)
+                .ok()
+                .filter(|p| p.schema_descr.columns().len() < m.schema_descr.columns().len())
+                .map(Arc::new)
+                .unwrap_or_else(|| m.clone())
         };
 
-        if let Some(meta) = first_metadata {
-            prune_one(meta);
-        }
-
-        // `Arc<[T]>` has no `make_mut` (slices aren't `Clone`); rebuild instead.
-        if let Some(slice) = metadata_per_source {
-            *slice = slice
-                .iter()
-                .cloned()
-                .map(|mut m| {
-                    prune_one(&mut m);
-                    m
-                })
-                .collect();
-        }
+        *first_metadata = first_metadata.as_ref().map(prune_one);
+        *metadata_per_source = metadata_per_source
+            .as_ref()
+            .map(|s| s.iter().map(prune_one).collect());
     }
 }
 

--- a/crates/polars-plan/src/plans/optimizer/parquet_metadata_prune.rs
+++ b/crates/polars-plan/src/plans/optimizer/parquet_metadata_prune.rs
@@ -14,10 +14,11 @@ use std::sync::Arc;
 #[cfg(feature = "parquet")]
 use polars_io::parquet::metadata::FileMetadataRef;
 #[cfg(feature = "parquet")]
-use polars_utils::aliases::{InitHashMaps, PlHashSet};
+use polars_utils::aliases::PlHashSet;
 use polars_utils::arena::{Arena, Node};
 #[cfg(feature = "parquet")]
 use polars_utils::pl_str::PlSmallStr;
+#[cfg(feature = "parquet")]
 use polars_utils::unitvec;
 
 #[cfg(feature = "parquet")]

--- a/crates/polars-plan/src/plans/optimizer/parquet_metadata_prune.rs
+++ b/crates/polars-plan/src/plans/optimizer/parquet_metadata_prune.rs
@@ -1,14 +1,23 @@
-//! Prune `FileScanIR::Parquet::metadata` to projected + predicate columns.
+//! Prune `FileScanIR::Parquet`'s pre-decoded metadata (`first_metadata`
+//! and `metadata_per_source`) to projected + predicate columns.
 //!
 //! Runs at the end of the optimizer pipeline, after projection and predicate
 //! pushdown have resolved each scan's projection / predicate. Walks the IR
-//! arena and replaces each parquet scan's metadata via
-//! `FileMetadata::pruned`.
+//! arena and replaces each entry via `FileMetadata::pruned`.
 //!
 //! Gated on `POLARS_PRUNE_PARQUET_METADATA=1` (default off; single-node
 //! execution gets no benefit since metadata never crosses a wire).
 
+#[cfg(feature = "parquet")]
+use std::sync::Arc;
+
+#[cfg(feature = "parquet")]
+use polars_io::parquet::metadata::FileMetadataRef;
+#[cfg(feature = "parquet")]
+use polars_utils::aliases::{InitHashMaps, PlHashSet};
 use polars_utils::arena::{Arena, Node};
+#[cfg(feature = "parquet")]
+use polars_utils::pl_str::PlSmallStr;
 use polars_utils::unitvec;
 
 #[cfg(feature = "parquet")]
@@ -45,42 +54,65 @@ pub(super) fn prune_parquet_metadata(
             continue;
         };
 
-        let Some(projection) = unified_scan_args.projection.clone() else {
-            continue;
-        };
-
-        // Extract predicate column names. Filter to those also in the
-        // projection (post-pushdown predicate cols are typically ⊆
-        // projection, but be defensive).
-        let predicate_cols: Vec<polars_utils::pl_str::PlSmallStr> = predicate
-            .as_ref()
-            .map(|pred_ir| {
-                aexpr_to_leaf_names_iter(pred_ir.node(), expr_arena)
-                    .filter(|name| projection.iter().any(|p| p == name.as_str()))
-                    .cloned()
-                    .collect()
-            })
-            .unwrap_or_default();
-
+        // Variant check first: skip the projection/predicate work entirely
+        // for non-Parquet scans (CSV, IPC, NDJson, Python, Anonymous).
         let FileScanIR::Parquet {
-            metadata: Some(meta_arc),
+            first_metadata,
+            metadata_per_source,
             ..
         } = scan_type.as_mut()
         else {
             continue;
         };
 
-        // Pruning failure (chunks-vs-leaves desync inside `from_compact`)
-        // is recoverable; fall back to unpruned metadata so the query still
-        // runs. The wire form just stays larger for this scan.
-        let Ok(pruned) = meta_arc.pruned(&projection, &predicate_cols) else {
+        let Some(projection) = unified_scan_args.projection.clone() else {
             continue;
         };
 
-        // Only swap if the pruned form is actually smaller (number of leaves).
-        // Avoids allocating a new Arc when nothing changed.
-        if pruned.schema_descr.columns().len() < meta_arc.schema_descr.columns().len() {
-            *meta_arc = std::sync::Arc::new(pruned);
+        // O(1) membership lookup; avoids O(|predicate_leaves| × |projection|)
+        // when projection is wide (10k+ cols).
+        let projection_set: PlHashSet<&str> =
+            PlHashSet::from_iter(projection.iter().map(|s| s.as_str()));
+
+        // Filter predicate cols to those in the projection. `pruned()` would
+        // otherwise keep a predicate-only column the projection dropped (its
+        // `keep` map unions both name lists).
+        let predicate_cols: Vec<PlSmallStr> = predicate
+            .as_ref()
+            .map(|pred_ir| {
+                aexpr_to_leaf_names_iter(pred_ir.node(), expr_arena)
+                    .filter(|name| projection_set.contains(name.as_str()))
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Pruning failure (chunks-vs-leaves desync inside `from_compact`) is
+        // recoverable; fall back to unpruned metadata so the query still runs.
+        // The wire form just stays larger for this entry. Swap-only-if-smaller
+        // (leaf count) avoids allocating a new inner Arc when nothing changed.
+        let prune_one = |meta_arc: &mut FileMetadataRef| {
+            if let Ok(pruned) = meta_arc.pruned(&projection, &predicate_cols)
+                && pruned.schema_descr.columns().len() < meta_arc.schema_descr.columns().len()
+            {
+                *meta_arc = Arc::new(pruned);
+            }
+        };
+
+        if let Some(meta) = first_metadata {
+            prune_one(meta);
+        }
+
+        // `Arc<[T]>` has no `make_mut` (slices aren't `Clone`); rebuild instead.
+        if let Some(slice) = metadata_per_source {
+            *slice = slice
+                .iter()
+                .cloned()
+                .map(|mut m| {
+                    prune_one(&mut m);
+                    m
+                })
+                .collect();
         }
     }
 }

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -738,7 +738,11 @@ pub fn lower_ir(
                     #[cfg(feature = "parquet")]
                     FileScanIR::Parquet {
                         options,
-                        metadata: first_metadata,
+                        first_metadata,
+                        // Used at plan time (optimizer passes, cloud
+                        // scheduler). The streaming reader reads per-file
+                        // footers at scan time and only needs `first_metadata`.
+                        metadata_per_source: _,
                     } => Arc::new(
                         crate::nodes::io_sources::parquet::builder::ParquetReaderBuilder {
                             options: Arc::new(options.clone()),

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -4261,3 +4261,27 @@ def test_read_parquet_legacy_nested_maps_27159(io_files_path: Path) -> None:
 
     assert_frame_equal(pl.read_parquet(path), expected)
     assert_frame_equal(pl.scan_parquet(path).collect(), expected)
+
+
+@pytest.mark.write_disk
+@pytest.mark.parametrize(
+    ("mode", "expected_est"),
+    [("none", 6), ("row_counts", 8), ("full", 8)],
+)
+def test_multi_file_resolve_metadata_level(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+    expected_est: int,
+) -> None:
+    # Skewed layout: file 0 = 2 rows, files 1-2 = 3 each (true total 8).
+    # `none` extrapolates 2 * 3 = 6; `row_counts`/`full` sum exactly.
+    for i, n in enumerate([2, 3, 3]):
+        pl.DataFrame({"x": range(n)}).write_parquet(tmp_path / f"part_{i}.parquet")
+
+    monkeypatch.setenv("POLARS_RESOLVE_METADATA_LEVEL", mode)
+    pl.Config.reload_env_vars()
+
+    lf = pl.scan_parquet(tmp_path / "part_*.parquet")
+    assert lf.collect().height == 8
+    assert f"ESTIMATED ROWS: {expected_est}" in lf.explain(optimized=True)


### PR DESCRIPTION
`parquet_file_info` reads only the first file's footer and extrapolates total rows as `first_file_rows × num_sources`. On skewed datasets the estimate is off by 10-100×, and the IR carries no per-file metadata for polars cloud; workers re-fetch every footer at startup. Today's OSS optimizer doesn't read `FileInfo::row_estimation`, so this PR keeps OSS behavior unchanged by default and ships the mechanism cloud needs right now.

This PR introduces a three-mode resolver controlled by `POLARS_RESOLVE_METADATA_LEVEL`. `none` (default) preserves today's behavior: read file 0 only, extrapolate. `row_counts` fans out a skip-aware thrift decoder that reads only field 3 (`num_rows`) per file, suitable for OSS once a cost-based pass consumes it. `full` decodes complete footers and stores them so the distributed scheduler plans row-group-level work units without re-fetching; cloud sets this explicitly.

Plan-time overhead (200 files × 1000 cols):

| # | Mode               | Plan time |
|---|--------------------|----------:|
| 1 | `none` (default)   | 1.79 ms   |
| 2 | `row_counts`       | 9.89 ms   |
| 3 | `full`             | 44.48 ms  |

- **optimization 1: Re-index per-source metadata across pruning.** Before: all loaded and decoded per-source footers would be thrown away on pruning, forcing every surviving file's footer to be re-fetched and re-decoded at scan time. After: surviving files keep their pre-decoded footers; the per-source metadata slice is re-indexed to match the post-pruning source list, so already-decoded footers stay usable for the cloud scheduler with no redundant work. Applies to hive-partition pruning and table-statistics pruning.

- **optimization 2: Avoid two round trips for async footer fetch.** Before: each parquet footer was fetched in two passes. First a small read of the trailing bytes to learn the footer's size, then a second read to grab the footer itself. After: one read up front grabs a fixed-size tail of the file that contains the full footer in essentially all real-world parquet files; a second fetch only fires when the footer is larger than that tail. Matters most on cloud-backed paths where each round trip is a network hop.