### PR TITLE
chore(python): Remove unnecessary ``not isinstance(v, DataType)`` check

### DIFF
--- a/py-polars/src/polars/schema.py
+++ b/py-polars/src/polars/schema.py
@@ -123,7 +123,7 @@ class Schema(BaseSchema):
         for v in input:
             name, tp = (
                 polars_schema_field_from_arrow_c_schema(v)
-                if hasattr(v, "__arrow_c_schema__") and not isinstance(v, DataType)
+                if hasattr(v, "__arrow_c_schema__")
                 else v
             )
 


### PR DESCRIPTION
@nameexhaustion the `not isinstance(v, DataType)` doesn't seem needed. Once we get here, `input` is
```py
Iterable[tuple[str, SchemaInitDataType] | ArrowSchemaExportable]
```
and so either `v` is `ArrowSchemaExportable`, or it's a mapping of `str` to `SchemaInitDataType`, it can't be `DataType`

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
