### PR TITLE
docs: Clarify rtcompat legacy CPU wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ less memory.
 
 ## Legacy
 
-Do you want Polars to run on an old CPU (e.g. dating from before 2011), or on an `x86-64` build of
-Python on Apple Silicon under Rosetta? Install `pip install polars[rtcompat]`. This version of
-Polars is compiled without [AVX](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions) target
-features.
+Do you want Polars to run on a CPU without AVX2 support, or on an `x86-64` build of Python on Apple
+Silicon under Rosetta? Install `pip install polars[rtcompat]`. This version of Polars is compiled
+without [AVX](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions) target features.


### PR DESCRIPTION
This PR:
- clarifies that `polars[rtcompat]` is for CPUs without AVX2 support rather than tying it to a specific year
- keeps the Rosetta guidance unchanged
- Ref #25116