### PR TITLE
feat: Optimize len and null_count comparisons

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/simplify_expr/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_expr/mod.rs
@@ -19,6 +19,101 @@ fn new_null_count(input: &[ExprIR]) -> AExpr {
     }
 }
 
+fn integer_literal_value(ae: &AExpr) -> Option<i64> {
+    match ae {
+        AExpr::Literal(lv) => lv.extract_i64().ok(),
+        _ => None,
+    }
+}
+
+enum CountCmpInput {
+    Len(Node),
+    NullCount(Node),
+}
+
+fn maybe_negate(ae: AExpr, negate: bool, expr_arena: &mut Arena<AExpr>) -> AExpr {
+    if negate {
+        AExprBuilder::new_from_aexpr(ae, expr_arena)
+            .not(expr_arena)
+            .build(expr_arena)
+    } else {
+        ae
+    }
+}
+
+fn optimize_len_or_null_count_cmp(
+    left: Node,
+    op: Operator,
+    right: Node,
+    expr_arena: &mut Arena<AExpr>,
+) -> Option<AExpr> {
+    let left_ae = expr_arena.get(left);
+    let right_ae = expr_arena.get(right);
+
+    let (count_expr_node, op, literal) = if let Some(value) = integer_literal_value(right_ae) {
+        (left, op, value)
+    } else if let Some(value) = integer_literal_value(left_ae) {
+        let op = match op {
+            Operator::Eq => Operator::Eq,
+            Operator::NotEq => Operator::NotEq,
+            Operator::Gt => Operator::Lt,
+            Operator::GtEq => Operator::LtEq,
+            Operator::Lt => Operator::Gt,
+            Operator::LtEq => Operator::GtEq,
+            _ => return None,
+        };
+        (right, op, value)
+    } else {
+        return None;
+    };
+
+    let input = match expr_arena.get(count_expr_node) {
+        AExpr::Agg(IRAggExpr::Count {
+            input,
+            include_nulls: true,
+        }) => CountCmpInput::Len(*input),
+        AExpr::Function {
+            input,
+            function: IRFunctionExpr::NullCount,
+            ..
+        } if input.len() == 1 => CountCmpInput::NullCount(input[0].node()),
+        _ => return None,
+    };
+
+    match input {
+        CountCmpInput::Len(input) => {
+            let is_empty = match op {
+                Operator::Eq if literal == 0 => true,
+                Operator::Lt if literal == 1 => true,
+                Operator::LtEq if literal == 0 => true,
+                Operator::NotEq | Operator::Gt if literal == 0 => false,
+                Operator::GtEq if literal == 1 => false,
+                _ => return None,
+            };
+
+            let out = AExprBuilder::new_from_node(input)
+                .is_empty(false, expr_arena)
+                .build(expr_arena);
+            Some(maybe_negate(out, !is_empty, expr_arena))
+        },
+        CountCmpInput::NullCount(input) => {
+            let has_nulls = match op {
+                Operator::Eq if literal == 0 => false,
+                Operator::Lt if literal == 1 => false,
+                Operator::LtEq if literal == 0 => false,
+                Operator::NotEq | Operator::Gt if literal == 0 => true,
+                Operator::GtEq if literal == 1 => true,
+                _ => return None,
+            };
+
+            let out = AExprBuilder::new_from_node(input)
+                .has_nulls(expr_arena)
+                .build(expr_arena);
+            Some(maybe_negate(out, !has_nulls, expr_arena))
+        },
+    }
+}
+
 macro_rules! eval_binary_same_type {
     ($lhs:expr, $rhs:expr, |$l: ident, $r: ident| $ret: expr) => {{
         if let (AExpr::Literal(lit_left), AExpr::Literal(lit_right)) = ($lhs, $rhs) {
@@ -412,6 +507,15 @@ impl OptimizationRule for SimplifyExprRule {
         schema: &Schema,
         ctx: OptimizeExprContext,
     ) -> PolarsResult<Option<AExpr>> {
+        let expr = expr_arena.get(expr_node);
+
+        if let AExpr::BinaryExpr { left, op, right } = expr {
+            let (left, op, right) = (*left, *op, *right);
+            if let Some(out) = optimize_len_or_null_count_cmp(left, op, right, expr_arena) {
+                return Ok(Some(out));
+            }
+        }
+
         let expr = expr_arena.get(expr_node);
 
         let out = match &expr {

--- a/py-polars/tests/unit/lazyframe/test_optimizations.py
+++ b/py-polars/tests/unit/lazyframe/test_optimizations.py
@@ -46,6 +46,10 @@ def test_is_null_followed_by_any() -> None:
     result_lf = lf.group_by("group", maintain_order=True).agg(
         pl.col("val").is_null().any()
     )
+    plan = result_lf.explain()
+    assert ".has_nulls()" in plan
+    assert "null_count" not in plan
+    assert "is_null" not in plan
     assert_frame_equal(expected_df, result_lf.collect())
 
     # edge case of empty series
@@ -206,6 +210,52 @@ def test_drop_nulls_followed_by_count() -> None:
     )
     assert "null_count" not in non_optimized_result_plan
     assert "drop_nulls" in non_optimized_result_plan
+
+
+@pytest.mark.parametrize(
+    ("expr", "optimized_expr"),
+    [
+        (pl.col("val").len() == 0, ".is_empty()"),
+        (pl.col("val").len() < 1, ".is_empty()"),
+        (pl.col("val").len() <= 0, ".is_empty()"),
+        (pl.col("val").len() != 0, ".is_empty().not()"),
+        (pl.col("val").len() > 0, ".is_empty().not()"),
+        (pl.col("val").len() >= 1, ".is_empty().not()"),
+        (pl.lit(0) == pl.col("val").len(), ".is_empty()"),
+        (pl.lit(1) > pl.col("val").len(), ".is_empty()"),
+        (pl.lit(0) >= pl.col("val").len(), ".is_empty()"),
+        (pl.lit(0) != pl.col("val").len(), ".is_empty().not()"),
+        (pl.lit(0) < pl.col("val").len(), ".is_empty().not()"),
+        (pl.lit(1) <= pl.col("val").len(), ".is_empty().not()"),
+        (pl.col("val").null_count() == 0, ".has_nulls().not()"),
+        (pl.col("val").null_count() < 1, ".has_nulls().not()"),
+        (pl.col("val").null_count() <= 0, ".has_nulls().not()"),
+        (pl.col("val").null_count() != 0, ".has_nulls()"),
+        (pl.col("val").null_count() > 0, ".has_nulls()"),
+        (pl.col("val").null_count() >= 1, ".has_nulls()"),
+        (pl.lit(0) == pl.col("val").null_count(), ".has_nulls().not()"),
+        (pl.lit(1) > pl.col("val").null_count(), ".has_nulls().not()"),
+        (pl.lit(0) >= pl.col("val").null_count(), ".has_nulls().not()"),
+        (pl.lit(0) != pl.col("val").null_count(), ".has_nulls()"),
+        (pl.lit(0) < pl.col("val").null_count(), ".has_nulls()"),
+        (pl.lit(1) <= pl.col("val").null_count(), ".has_nulls()"),
+    ],
+)
+def test_len_null_count_comparison_optimized(
+    expr: pl.Expr, optimized_expr: str
+) -> None:
+    lf = pl.LazyFrame({"group": [0, 0, 1, 2], "val": [6, None, 5, None]})
+    result_lf = lf.group_by("group", maintain_order=True).agg(expr.alias("out"))
+
+    plan = result_lf.explain()
+    assert optimized_expr in plan
+    assert ".len()" not in plan
+    assert ".null_count()" not in plan
+
+    assert_frame_equal(
+        result_lf.collect(),
+        result_lf.collect(optimizations=pl.QueryOptFlags(simplify_expression=False)),
+    )
 
 
 def test_collapse_joins() -> None:


### PR DESCRIPTION
Solves #27585.

I measured this locally with a grouped aggregation microbenchmark comparing normal collection against collection with `simplify_expression=False` in the same build.

For `null_count` comparisons optimized path was modestly faster:
  - 10M rows / 1K groups: ~1.02x-1.04x median speedup
  - 50M rows / 10 groups: ~1.03x-1.13x median speedup, with higher run-to-run variance

`len` comparison cases were effectively neutral, as expected, since grouped `len` is already cheap. The main benefit of those rewrites is plan simplification/consistency with `is_empty`.

Once the plan says has_nulls instead of null_count > 0, execution engines can specialize it more easily:
- use boolean aggregate state instead of integer count state
- potentially short-circuit within partitions/groups in future engine work

Local make test  screen:
<img width="1015" height="706" alt="Screenshot 2026-05-23 at 1 24 22 AM" src="https://github.com/user-attachments/assets/99dea080-3914-4ed1-98fc-0292dcefdc50" />

AI assistance disclosure: I used AI assistance while working on this PR. I have reviewed all changes myself and believe they are relevant and correct.