### PR TITLE
ci: Add missing capture group for minor version in docs-python.yml

### DIFF
--- a/.github/workflows/docs-python.yml
+++ b/.github/workflows/docs-python.yml
@@ -39,7 +39,7 @@ jobs:
         shell: bash
         run: |
           tag="${{ github.event.inputs.polars_version || github.event.client_payload.tag }}"
-          regex="py-([0-9]+)\.[0-9]+\.[0-9]+.*"
+          regex="py-([0-9]+)\.([0-9]+)\.[0-9]+.*"
           if [[ $tag =~ $regex ]]; then
             major=${BASH_REMATCH[1]}
             minor=${BASH_REMATCH[2]}

--- a/.github/workflows/docs-python.yml
+++ b/.github/workflows/docs-python.yml
@@ -41,7 +41,7 @@ jobs:
           POLARS_VERSION_TAG: ${{ github.event.inputs.polars_version || github.event.client_payload.tag }}
         run: |
           tag="$POLARS_VERSION_TAG"
-          regex="py-([0-9]+)\.[0-9]+\.[0-9]+.*"
+          regex="py-([0-9]+)\.([0-9]+)\.[0-9]+.*"
           if [[ $tag =~ $regex ]]; then
             major=${BASH_REMATCH[1]}
             minor=${BASH_REMATCH[2]}


### PR DESCRIPTION
## Summary

The version-parsing regex in `docs-python.yml` is missing a capture group around the minor version segment. `BASH_REMATCH[2]` references a non-existent second group, so for `py-0.20.1` the workflow produces `version="0."` instead of `"0.20"`.

The fix is wrapping the minor segment in parentheses:

```diff
- regex="py-([0-9]+)\.[0-9]+\.[0-9]+.*"
+ regex="py-([0-9]+)\.([0-9]+)\.[0-9]+.*"
```

The bug is invisible for 1.x tags (the `else` branch uses only `$major`), so it only surfaces when building docs for legacy 0.x releases.

Closes #27731

---

## AI usage

I used an AI coding assistant (Kilo, model glm-5.2) to help rebase this branch onto the current `main` and resolve the resulting merge conflict in `docs-python.yml`. I have reviewed all changes myself and believe they are relevant and correct.