### PR TITLE
chore(python): Attribute annotations for `CatalogCredentialProvider`

### DIFF
--- a/py-polars/src/polars/catalog/unity/client.py
+++ b/py-polars/src/polars/catalog/unity/client.py
@@ -712,6 +712,10 @@ class Catalog:
 class CatalogCredentialProvider:
     """Retrieves credentials from the Unity catalog temporary credentials API."""
 
+    catalog: Catalog
+    table_id: str
+    write: bool
+
     def __init__(self, catalog: Catalog, table_id: str, *, write: bool) -> None:
         self.catalog = catalog
         self.table_id = table_id
@@ -721,9 +725,7 @@ class CatalogCredentialProvider:
         _, (creds, expiry) = self._credentials_iter()
         return creds, expiry
 
-    def _credentials_iter(
-        self,
-    ) -> Generator[Any]:
+    def _credentials_iter(self) -> Generator[Any]:
         creds, storage_update_options, expiry = self.catalog._get_table_credentials(
             self.table_id, write=self.write
         )


### PR DESCRIPTION
I noticed on the typestats dashboard (https://jorenham.github.io/typestats/dashboard/report/#polars) that the attributes of `polars.catalog.unity.client.CatalogCredentialProvider` weren't covered by type annotations. I made it so that's now a thing of the past (which assumes this gets merged, so technically this will be a thing of the past in the future).

And although I'm a first-timer here, I'm afraid that don't have enough free disk space to run the full test suite. But since nothing changed on the runtime side of things, I'm hoping that I can get away with this screenshot of a happy mypy and a happy pyrefly:

<img width="4000" height="3000" alt="20260525_170540" src="https://github.com/user-attachments/assets/e78952de-b52a-4512-882c-924d5c4ec68e" />

And just to be clear; that's a human thumb (mine, actually; and as far as I'm aware, I'm not an AI).

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->

