### PR TITLE
docs: Enable is_in source docs for polars-ops

### DIFF
--- a/crates/polars-ops/Cargo.toml
+++ b/crates/polars-ops/Cargo.toml
@@ -166,5 +166,9 @@ gather = []
 replace = ["is_in"]
 allow_unused = []
 
+[package.metadata.docs.rs]
+features = ["is_in"]
+rustdoc-args = ["--cfg", "docsrs"]
+
 [lints]
 workspace = true


### PR DESCRIPTION
Fixes #21479.

This adds docs.rs metadata for `polars-ops` so the `is_in` feature is enabled when docs.rs builds the crate documentation.

The `is_in` implementation is feature-gated in `polars-ops`, while the top-level `polars` crate re-exports it through `polars::prelude`. Without enabling the feature for the standalone `polars-ops` docs.rs build, the generated source page linked from `polars::prelude::is_in` can be missing.
