### PR TITLE
docs: Clarify legacy CPU install guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ less memory.
 
 ## Legacy
 
-Do you want Polars to run on an old CPU (e.g. dating from before 2011), or on an `x86-64` build of
-Python on Apple Silicon under Rosetta? Install `pip install polars[rtcompat]`. This version of
-Polars is compiled without [AVX](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions) target
-features.
+Do you want Polars to run on an old CPU without
+[AVX2](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#Advanced_Vector_Extensions_2)
+support, or on an `x86-64` build of Python on Apple Silicon under Rosetta? Install
+`pip install polars[rtcompat]`. This version of Polars is compiled without
+[AVX](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions) target features.

--- a/docs/source/user-guide/installation.md
+++ b/docs/source/user-guide/installation.md
@@ -46,7 +46,8 @@ $2^{64}$ (~18 quintillion) by enabling the big index extension:
 ## Legacy CPU
 
 To install Polars for Python on an old CPU without
-[AVX](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions) support, run:
+[AVX2](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#Advanced_Vector_Extensions_2)
+support, run:
 
 === ":fontawesome-brands-python: Python"
 


### PR DESCRIPTION
Fixes #25116.

This removes year-based wording for legacy CPU support and describes the compatibility case in terms of AVX2 support instead.

It also aligns the user guide's Legacy CPU section with the existing installation comment that already refers to legacy CPUs without AVX2 support.