### PR TITLE
fix: Fix incorrect when/then after forward fill / reverse in groupby

### DIFF
--- a/crates/polars-expr/src/expressions/mod.rs
+++ b/crates/polars-expr/src/expressions/mod.rs
@@ -420,6 +420,8 @@ impl<'a> AggregationContext<'a> {
         self.groups = Cow::Owned(groups);
         // make sure that previous setting is not used
         self.update_groups = UpdateGroups::No;
+        // Conservatively set `false`, there's no guarantee `groups` matches the original.
+        self.original_len = false;
         self
     }
 

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -3125,3 +3125,32 @@ def test_group_by_sort_flag_27672() -> None:
     )
     expected = pl.DataFrame({"s": ["b", "a"], "z": [2, 1]})
     assert_frame_equal(out, expected)
+
+
+def test_group_by_when_then_with_mutated_idxs() -> None:
+    df = pl.DataFrame({"g": ["A", "A"], "v": [10.0, None], "m": [True, True]})
+    out = df.select(
+        ffill=pl.when("m").then(pl.col("v").forward_fill()).otherwise(None).over("g"),
+    )
+
+    assert_frame_equal(
+        out,
+        pl.DataFrame(
+            {
+                "ffill": [10.0, 10.0],
+            }
+        ),
+    )
+
+    out = df.select(
+        rev=pl.when("m").then(pl.col("v").reverse()).otherwise(None).over("g"),
+    )
+
+    assert_frame_equal(
+        out,
+        pl.DataFrame(
+            {
+                "rev": [None, 10.0],
+            }
+        ),
+    )


### PR DESCRIPTION
Fixes an issue reported by enterprise support

Issue due to TernaryExec did not consider the possibility of `original_len: true` but with indices out of order.
