### PR TITLE
fix: Allow bitwise ops between boolean and integer Series

### DIFF
--- a/crates/polars-core/src/series/arithmetic/bitops.rs
+++ b/crates/polars-core/src/series/arithmetic/bitops.rs
@@ -13,6 +13,10 @@ macro_rules! impl_bitop {
             fn $f(self, rhs: Self) -> Self::Output {
                 use DataType as DT;
                 match self.dtype() {
+                    DT::Boolean if rhs.dtype().is_integer() => {
+                        let lhs = self.cast(rhs.dtype())?;
+                        <&Series as std::ops::$trait>::$f(&lhs, rhs)
+                    },
                     DT::Boolean => {
                         let lhs: &BooleanChunked = self.as_ref().as_ref().as_ref();
                         let rhs = lhs.unpack_series_matching_type(rhs)?;

--- a/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
@@ -983,3 +983,36 @@ def test_log_broadcast(dtype: pl.DataType) -> None:
         pl.Series("a", [81], dtype=dtype).log(b),
         pl.Series("a", [4, 4, 2, 4, 2], dtype=dtype),
     )
+
+
+@pytest.mark.parametrize(
+    ("op", "lhs", "rhs", "expected"),
+    [
+        (
+            operator.and_,
+            pl.Series([True, False]),
+            pl.Series([1, 1]),
+            pl.Series([1, 0], dtype=pl.Int64),
+        ),
+        (
+            operator.or_,
+            pl.Series([True, False]),
+            pl.Series([0, 1]),
+            pl.Series([1, 1], dtype=pl.Int64),
+        ),
+        (
+            operator.xor,
+            pl.Series([True, False]),
+            pl.Series([1, 1]),
+            pl.Series([0, 1], dtype=pl.Int64),
+        ),
+    ],
+)
+def test_series_bitwise_bool_int_rhs_22132(
+    op: Callable[[pl.Series, pl.Series], pl.Series],
+    lhs: pl.Series,
+    rhs: pl.Series,
+    expected: pl.Series,
+) -> None:
+    result = op(lhs, rhs)
+    assert_series_equal(result, expected)


### PR DESCRIPTION
Fixes #22132.

This makes Series bitwise operations symmetric when the left-hand side is Boolean and the right-hand side is an integer dtype.

Previously, `pl.Series([True]) & pl.Series([1])` failed because the Boolean branch attempted to unpack the RHS as Boolean. The fix casts the Boolean LHS to the RHS integer dtype and dispatches through the existing integer bitwise implementation.

Also adds regression coverage for `&`, `|`, and `^`.