### PR TITLE
fix: Fix portstate assertion error on is_in

### DIFF
--- a/crates/polars-stream/src/nodes/columnar_function.rs
+++ b/crates/polars-stream/src/nodes/columnar_function.rs
@@ -108,11 +108,11 @@ impl ComputeNode for ColumnarFunctionNode {
                 send[0] = PortState::Blocked;
             },
             Self::Source(source_node) => {
-                recv.iter_mut().for_each(|v| *v = PortState::Done);
+                recv.fill(PortState::Done);
                 source_node.update_state(&mut [], send, state)?;
             },
             Self::Done => {
-                recv.iter_mut().for_each(|v| *v = PortState::Done);
+                recv.fill(PortState::Done);
                 send[0] = PortState::Done;
             },
         }

--- a/crates/polars-stream/src/nodes/columnar_function.rs
+++ b/crates/polars-stream/src/nodes/columnar_function.rs
@@ -108,11 +108,11 @@ impl ComputeNode for ColumnarFunctionNode {
                 send[0] = PortState::Blocked;
             },
             Self::Source(source_node) => {
-                recv[0] = PortState::Done;
+                recv.iter_mut().for_each(|v| *v = PortState::Done);
                 source_node.update_state(&mut [], send, state)?;
             },
             Self::Done => {
-                recv[0] = PortState::Done;
+                recv.iter_mut().for_each(|v| *v = PortState::Done);
                 send[0] = PortState::Done;
             },
         }


### PR DESCRIPTION
* Found in https://github.com/pola-rs/polars/issues/27725

```rust
thread '<unnamed>' (106642926) panicked at crates/polars-stream/src/execute.rs:389:9:
assertion failed: pipe.send_state == PortState::Done && pipe.recv_state == PortState::Done
```
