### PR TITLE
fix(rust): Use block_in_place_on in MultiScan::update_state

### DIFF
--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/mod.rs
@@ -76,7 +76,9 @@ impl ComputeNode for MultiScan {
             // Refresh first - in case there is an error we end here instead of ending when we go
             // into spawn.
             executor::task_scope(|s| {
-                ASYNC.block_on(s.spawn_task(TaskPriority::High, self.state.refresh(self.verbose)))
+                ASYNC.block_in_place_on(
+                    s.spawn_task(TaskPriority::High, self.state.refresh(self.verbose)),
+                )
             })?;
 
             match self.state {


### PR DESCRIPTION
`MultiScan::update_state` calls `ASYNC.block_on(...)` to drive a `task_scope` refresh. This path is reachable from `LazyFrame::collect` through `build_streaming_query_executor`, so it can run on a thread that already has a Tokio runtime context (e.g. a `#[tokio::main]` worker). Tokio then panics with "Cannot start a runtime from within a runtime".

`block_in_place_on` calls `tokio::task::block_in_place` first, which matches what `polars_io::path_utils::expand_paths` and `dsl_to_ir::to_alp_impl` already do for the same reason. Behaviour on non-runtime threads is unchanged.

Repro: scan CSVs from inside `#[tokio::main]` with the streaming engine enabled — panics in `tokio/runtime/scheduler/multi_thread/mod.rs` from `MultiScan::update_state`.