### PR TITLE
fix: Filter at scan dropped in CSPE filter pushdown

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -52,7 +52,7 @@ impl PredicatePushDown {
         lp_arena: &mut Arena<IR>,
         expr_arena: &mut Arena<AExpr>,
     ) -> IR {
-        if let Some(predicate) = combine_predicates(local_predicates.into_iter(), expr_arena) {
+        if let Some(predicate) = combine_predicates(local_predicates, expr_arena) {
             let input = lp_arena.add(lp);
 
             IR::Filter { input, predicate }

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -52,8 +52,7 @@ impl PredicatePushDown {
         lp_arena: &mut Arena<IR>,
         expr_arena: &mut Arena<AExpr>,
     ) -> IR {
-        if !local_predicates.is_empty() {
-            let predicate = combine_predicates(local_predicates.into_iter(), expr_arena);
+        if let Some(predicate) = combine_predicates(local_predicates.into_iter(), expr_arena) {
             let input = lp_arena.add(lp);
 
             IR::Filter { input, predicate }
@@ -311,14 +310,15 @@ impl PredicatePushDown {
                 schema,
                 output_schema,
             } => {
-                let selection = predicate_at_scan(acc_predicates, None, expr_arena);
                 let mut lp = DataFrameScan {
                     df,
                     schema,
                     output_schema,
                 };
 
-                if let Some(predicate) = selection {
+                if let Some(predicate) =
+                    combine_predicates(acc_predicates.into_values(), expr_arena)
+                {
                     let input = lp_arena.add(lp);
 
                     lp = IR::Filter { input, predicate }
@@ -350,7 +350,10 @@ impl PredicatePushDown {
                         blocked_names.contains(&name.as_ref())
                     })
                 };
-                let predicate = predicate_at_scan(acc_predicates, predicate.clone(), expr_arena);
+                let predicate = combine_predicates(
+                    Option::into_iter(predicate.clone()).chain(acc_predicates.into_values()),
+                    expr_arena,
+                );
 
                 let do_optimization = predicate.is_some()
                     && match &*scan_type {
@@ -636,8 +639,9 @@ impl PredicatePushDown {
             },
             #[cfg(feature = "python")]
             PythonScan { mut options } => {
-                let predicate = predicate_at_scan(acc_predicates, None, expr_arena);
-                if let Some(predicate) = predicate {
+                if let Some(predicate) =
+                    combine_predicates(acc_predicates.into_values(), expr_arena)
+                {
                     match ExprPushdownGroup::Pushable.update_with_expr_rec(
                         expr_arena.get(predicate.node()),
                         expr_arena,

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
@@ -73,44 +73,22 @@ pub(super) fn temporary_unique_key(acc_predicates: &PlHashMap<PlSmallStr, ExprIR
     PlSmallStr::from_string(out_key)
 }
 
-pub(super) fn combine_predicates<I>(iter: I, arena: &mut Arena<AExpr>) -> ExprIR
+pub(super) fn combine_predicates<I>(iter: I, expr_arena: &mut Arena<AExpr>) -> Option<ExprIR>
 where
-    I: Iterator<Item = ExprIR>,
+    I: IntoIterator<Item = ExprIR>,
 {
-    let mut single_pred = None;
-    for e in iter {
-        single_pred = match single_pred {
-            None => Some(e.node()),
-            Some(left) => Some(arena.add(AExpr::BinaryExpr {
-                left,
-                op: Operator::And,
-                right: e.node(),
-            })),
-        };
-    }
-    single_pred
-        .map(|node| ExprIR::from_node(node, arena))
-        .expect("an empty iterator was passed")
-}
+    let mut iter = iter.into_iter();
+    let mut out = iter.next()?.node();
 
-pub(super) fn predicate_at_scan(
-    acc_predicates: PlHashMap<PlSmallStr, ExprIR>,
-    predicate: Option<ExprIR>,
-    expr_arena: &mut Arena<AExpr>,
-) -> Option<ExprIR> {
-    if !acc_predicates.is_empty() {
-        let mut new_predicate = combine_predicates(acc_predicates.into_values(), expr_arena);
-        if let Some(pred) = predicate {
-            new_predicate.set_node(combine_by_and(
-                new_predicate.node(),
-                pred.node(),
-                expr_arena,
-            ));
-        }
-        Some(new_predicate)
-    } else {
-        None
+    for e in iter {
+        out = expr_arena.add(AExpr::BinaryExpr {
+            left: out,
+            op: Operator::And,
+            right: e.node(),
+        });
     }
+
+    Some(ExprIR::from_node(out, expr_arena))
 }
 
 /// Evaluates a condition on the column name inputs of every predicate, where if

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -1479,3 +1479,36 @@ def test_cse_projection_pushdown_27569() -> None:
         q.collect(),
         pl.DataFrame({"a": [1, None, 1], "b": [None, 1, 1]}),
     )
+
+
+def test_cse_existing_predicate_at_scan_27748() -> None:
+    base_q = pl.scan_csv(
+        pl.DataFrame(
+            [
+                pl.Series("x", [True, False]),
+                pl.Series("y0", [False, False]),
+                pl.Series("y1", [True, True]),
+            ]
+        )
+        .write_csv()
+        .encode()
+    ).with_columns(x_not=pl.col("x").not_())
+
+    q = pl.concat(
+        [
+            base_q.filter(pl.col("x_not") & pl.col("y0")),
+            base_q.filter(pl.col("x_not") & pl.col("y0")),
+            base_q.filter(pl.col("x_not") & pl.col("y1")),
+        ]
+    )
+
+    plan = q.explain()
+
+    assert plan.count('SELECTION: col("y0")') == 2
+    assert plan.count('SELECTION: col("y1")') == 1
+    assert plan.count("CACHE[") == 2
+
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame({"x": False, "y0": False, "y1": True, "x_not": True}),
+    )


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/27748

Happens when `acc_predicates` is empty but the scan predicate is set.

We just remove `predicate_at_scan` and use `combine_predicates` instead (also gave that a cleanup).
