### PR TITLE
ci(rust): Added `jlumbroso/free-disk-space` cleaning action where relevant

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,6 +31,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Free some disk space (remove unused packages)
+        uses: jlumbroso/free-disk-space@v1.3.1
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -39,9 +39,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Free some disk space (remove unused packages)
-        uses: jlumbroso/free-disk-space@v1.3.1
-
       - name: Set up Rust
         run: rustup component add clippy
 
@@ -59,9 +56,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-
-      - name: Free some disk space (remove unused packages)
-        uses: jlumbroso/free-disk-space@v1.3.1
 
       - name: Set up Rust
         run: rustup override set stable && rustup update

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -39,6 +39,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Free some disk space (remove unused packages)
+        uses: jlumbroso/free-disk-space@v1.3.1
+
       - name: Set up Rust
         run: rustup component add clippy
 
@@ -56,6 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Free some disk space (remove unused packages)
+        uses: jlumbroso/free-disk-space@v1.3.1
 
       - name: Set up Rust
         run: rustup override set stable && rustup update
@@ -89,6 +95,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Free some disk space (remove unused packages)
+        uses: jlumbroso/free-disk-space@v1.3.1
 
       - name: Set up Rust
         run: rustup component add miri

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -249,6 +249,10 @@ jobs:
         with:
           ref: ${{ inputs.sha }}
 
+      - name: Free some disk space (remove unused packages)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        if: ${{ runner.os == 'Linux' }}
+
       - name: Download base package
         uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Free some disk space (remove unused packages)
         uses: jlumbroso/free-disk-space@v1.3.1
-        if: ${{ matrix.os != 'windows-latest' }}
+        if: ${{ runner.os == 'Linux' }}
 
       - name: Enable long paths on Windows
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -35,6 +35,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Free some disk space (remove unused packages)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        if: ${{ runner.os == 'Linux' }}
+
       - name: Set up Rust
         run: rustup show
 
@@ -89,6 +93,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Free some disk space (remove unused packages)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        if: ${{ runner.os == 'Linux' }}
+
       - name: Set up Rust
         run: rustup show
 
@@ -109,6 +117,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Free some disk space (remove unused packages)
+        uses: jlumbroso/free-disk-space@v1.3.1
 
       - name: Set up Rust
         run: rustup show
@@ -131,6 +142,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Free some disk space (remove unused packages)
+        uses: jlumbroso/free-disk-space@v1.3.1
 
       - name: Set up Rust
         run: rustup show


### PR DESCRIPTION
Added the cleaning step for all relevant workflows (I think I did not let any slip, but that might be worth an extra check), and where possible since this action only supports Linux-based runners.

The `test-coverage.yml` workflow could also be relevant but OSX runners come with less bloat installed (?) and have a lot more disk by default. And no GitHub Action offer the same cleaning capability anyhow.

1.3.1 is still the latest version for the GitHub Action.