### PR TITLE
fix: Raise length mismatch in multiple `sort_by` in `group_by`

### DIFF
--- a/crates/polars-expr/src/expressions/sortby.rs
+++ b/crates/polars-expr/src/expressions/sortby.rs
@@ -391,6 +391,11 @@ impl PhysicalExpr for SortByExpr {
 
             groups?
         } else {
+            let groups_in = ac_in.groups();
+            for ac in ac_sort_by.iter() {
+                check_groups(groups_in.as_ref().as_ref(), ac.groups.as_ref().as_ref())?;
+            }
+
             let groups = ac_sort_by[0].groups();
 
             let groups = RAYON.install(|| {

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -1316,3 +1316,17 @@ def test_sort_maintain_order_all_nulls_27514(
         .collect()
     )
     assert_frame_equal(result, df)
+
+
+def test_sort_by_multiple_length_mismatch_27759() -> None:
+    df = pl.DataFrame(
+        {
+            "a": [0, 0],
+            "b": ["foo", "blah"],
+            "c": [False, True],
+            "d": [0, 0],
+            "e": [0, 0],
+        }
+    )
+    with pytest.raises(pl.exceptions.ShapeError):
+        df.group_by("a").agg(pl.col("b").filter("c").sort_by(["d", "e"]))


### PR DESCRIPTION
fixes #27759 