### PR TITLE
fix(python): Fix reverse arithmetic operations for Series

### DIFF
--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -1158,6 +1158,8 @@ class Series:
             other = pl.Series("", [None])
 
         if isinstance(other, Series):
+            if "rhs" in op_ffi:
+                return self._from_pyseries(getattr(other._s, op_s)(self._s))
             return self._from_pyseries(getattr(self._s, op_s)(other._s))
         elif _check_for_numpy(other) and isinstance(other, np.ndarray):
             return self._from_pyseries(getattr(self._s, op_s)(Series(other)._s))
@@ -1365,7 +1367,7 @@ class Series:
             msg = "first cast to integer before dividing datelike dtypes"
             raise TypeError(msg)
         if self.dtype.is_float():
-            self.__rfloordiv__(other)
+            return self.cast(Float64).__rfloordiv__(other)
         if isinstance(other, (int, float)) and self.dtype.is_decimal():
             return self.to_frame().select(other / F.col(self.name)).to_series()
 


### PR DESCRIPTION
## Problem

Python's reflected operator protocol means that `lhs.__rsub__(rhs)` should compute `rhs - lhs`, and the same applies to other reflected non-commutative operators (`__rtruediv__`, `__rfloordiv__`, `__rmod__`).

Polars already follows this behavior when the other operand is a scalar. However, when the other operand is also a Series, the reflected arithmetic methods incorrectly compute `self op other` instead of `other op self`.

## Root Cause

In `_arithmetic()`, the Series-to-Series case (line 1160-1161) always computes `getattr(self._s, op_s)(other._s)` without checking if the operation is a reflected one (`"rhs" in op_ffi`). The `"rhs"` check is only done for non-Series types (timedelta, float, etc.).

Additionally, `__rtruediv__` calls `self.__rfloordiv__(other)` without a `return` statement, causing the result to be silently discarded.

## Fix

1. **`_arithmetic` method**: Add `"rhs"` check for Series operands, swapping to `getattr(other._s, op_s)(self._s)` when appropriate.

2. **`__rtruediv__` method**: Add missing `return` statement.

## Reproducer

```python
import polars as pl

lhs = pl.Series("lhs", [2, 3, 4])
rhs = pl.Series("rhs", [5, 7, 9])

# Before fix: [-3, -4, -5] (wrong - same as lhs - rhs)
# After fix:  [3, 4, 5]   (correct - same as rhs - lhs)
print(lhs.__rsub__(rhs).to_list())

# Before fix: [0.4, 0.428..., 0.444...] (wrong)
# After fix:  [2.5, 2.333..., 2.25]    (correct)
print(lhs.__rtruediv__(rhs).to_list())

# Before fix: [0, 0, 0] (wrong)
# After fix:  [2, 2, 2] (correct)
print(lhs.__rfloordiv__(rhs).to_list())

# Before fix: [2, 3, 4] (wrong)
# After fix:  [1, 1, 1] (correct)
print(lhs.__rmod__(rhs).to_list())
```

Fixes #27752
