### PR TITLE
perf: Eliminate filters with contradictory predicates

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/mod.rs
+++ b/crates/polars-plan/src/plans/aexpr/mod.rs
@@ -7,6 +7,7 @@ mod hash;
 mod minterm_iter;
 pub(crate) mod or_factoring;
 pub mod predicates;
+pub(crate) mod range_merge;
 mod scalar;
 mod schema;
 mod traverse;

--- a/crates/polars-plan/src/plans/aexpr/range_merge.rs
+++ b/crates/polars-plan/src/plans/aexpr/range_merge.rs
@@ -1,0 +1,349 @@
+//! Combine per-column comparisons in an `AND` chain to spot impossible filters.
+
+use std::cmp::Ordering;
+
+use polars_core::prelude::AnyValue;
+use polars_core::scalar::Scalar;
+use polars_utils::aliases::{InitHashMaps, PlHashMap};
+use polars_utils::arena::{Arena, Node};
+use polars_utils::pl_str::PlSmallStr;
+
+use super::properties::ExprPushdownGroup;
+use super::{AExpr, LiteralValue, MintermIter, Operator};
+#[cfg(feature = "is_between")]
+use super::{IRBooleanFunction, IRFunctionExpr};
+#[cfg(feature = "is_between")]
+use crate::prelude::ClosedInterval;
+
+#[derive(Default)]
+struct ColumnConstraints {
+    // The bool is whether the bound is inclusive: true for `>=`/`<=`, false for `>`/`<`.
+    lower: Option<(Scalar, bool)>,
+    upper: Option<(Scalar, bool)>,
+    equality: Option<Scalar>,
+    // Once true, stays true.
+    unsat: bool,
+}
+
+impl ColumnConstraints {
+    // Keep whichever bound is tighter. `tighter` is the ordering of (new vs
+    // existing) that means the new bound wins: `Greater` for a lower bound,
+    // `Less` for an upper bound.
+    fn tighten(
+        slot: &mut Option<(Scalar, bool)>,
+        value: Scalar,
+        inclusive: bool,
+        tighter: Ordering,
+    ) {
+        *slot = Some(match slot.take() {
+            None => (value, inclusive),
+            Some((existing, existing_inclusive)) => {
+                match value.as_any_value().partial_cmp(&existing.as_any_value()) {
+                    Some(ord) if ord == tighter => (value, inclusive),
+                    Some(Ordering::Equal) => (value, inclusive && existing_inclusive),
+                    // Less tight, or incomparable types: keep the existing bound.
+                    _ => (existing, existing_inclusive),
+                }
+            },
+        });
+    }
+
+    fn add_lower(&mut self, value: Scalar, inclusive: bool) {
+        if self.unsat {
+            return;
+        }
+        Self::tighten(&mut self.lower, value, inclusive, Ordering::Greater);
+        self.check_consistency();
+    }
+
+    fn add_upper(&mut self, value: Scalar, inclusive: bool) {
+        if self.unsat {
+            return;
+        }
+        Self::tighten(&mut self.upper, value, inclusive, Ordering::Less);
+        self.check_consistency();
+    }
+
+    fn add_equality(&mut self, value: Scalar) {
+        if self.unsat {
+            return;
+        }
+        match self.equality.take() {
+            None => self.equality = Some(value),
+            Some(existing) => match value.as_any_value().partial_cmp(&existing.as_any_value()) {
+                Some(Ordering::Equal) => self.equality = Some(existing),
+                Some(_) => self.unsat = true,
+                // Different types we can't compare; keep the existing value.
+                None => self.equality = Some(existing),
+            },
+        }
+        self.check_consistency();
+    }
+
+    // Marks the column impossible if its bounds now contradict. Run after each add.
+    fn check_consistency(&mut self) {
+        if self.unsat {
+            return;
+        }
+        // Lower bound above the upper bound is an empty range.
+        if let (Some((lo, lo_inc)), Some((hi, hi_inc))) = (&self.lower, &self.upper) {
+            match lo.as_any_value().partial_cmp(&hi.as_any_value()) {
+                Some(Ordering::Greater) => self.unsat = true,
+                Some(Ordering::Equal) if !(*lo_inc && *hi_inc) => self.unsat = true,
+                _ => {},
+            }
+        }
+        // The equal-to value must sit inside the lower bound.
+        if let (Some(eq), Some((lo, lo_inc))) = (&self.equality, &self.lower) {
+            match eq.as_any_value().partial_cmp(&lo.as_any_value()) {
+                Some(Ordering::Less) => self.unsat = true,
+                Some(Ordering::Equal) if !*lo_inc => self.unsat = true,
+                _ => {},
+            }
+        }
+        // The equal-to value must sit inside the upper bound.
+        if let (Some(eq), Some((hi, hi_inc))) = (&self.equality, &self.upper) {
+            match eq.as_any_value().partial_cmp(&hi.as_any_value()) {
+                Some(Ordering::Greater) => self.unsat = true,
+                Some(Ordering::Equal) if !*hi_inc => self.unsat = true,
+                _ => {},
+            }
+        }
+    }
+}
+
+/// If the comparisons in `predicate`'s `AND` chain can never all be true at
+/// once, returns a new `Literal(false)` node. Otherwise returns `None`.
+pub(crate) fn merge_ranges_in_predicate(
+    predicate: Node,
+    maintain_errors: bool,
+    expr_arena: &mut Arena<AExpr>,
+) -> Option<Node> {
+    // Walk each part of the AND chain and collect the bounds per column.
+    // Shapes we don't understand are simply ignored. Once one column is
+    // impossible the whole filter is false, so we can stop early.
+    let mut constraints: PlHashMap<PlSmallStr, ColumnConstraints> = PlHashMap::new();
+    let mut unsat = false;
+
+    for conjunct in MintermIter::new(predicate, expr_arena) {
+        let ae = expr_arena.get(conjunct);
+        if classify_into_constraints(ae, expr_arena, &mut constraints) {
+            unsat = true;
+            break;
+        }
+    }
+
+    if !unsat {
+        return None;
+    }
+
+    // The filter is impossible. Replacing it with `false` lets the filter
+    // collapse to an empty scan, so `predicate` is never evaluated. That means
+    // an expression that would have errored no longer runs, so we only do this
+    // when the user has not asked to keep errors (same rule as predicate
+    // pushdown). We don't need a separate check for random expressions: only
+    // `col op lit` parts decide the contradiction, and a plain column is always
+    // deterministic. Checked last so the common (satisfiable) case skips it.
+    let mut group = ExprPushdownGroup::Pushable;
+    group.update_with_expr_rec(expr_arena.get(predicate), expr_arena, None);
+    if group.blocks_pushdown(maintain_errors) {
+        return None;
+    }
+
+    Some(expr_arena.add(AExpr::Literal(Scalar::from(false).into())))
+}
+
+// Records one comparison under its column and returns `true` if that made the
+// column impossible. Shapes we don't recognize add nothing and return `false`.
+fn classify_into_constraints(
+    ae: &AExpr,
+    expr_arena: &Arena<AExpr>,
+    constraints: &mut PlHashMap<PlSmallStr, ColumnConstraints>,
+) -> bool {
+    match ae {
+        AExpr::BinaryExpr { left, op, right } => {
+            classify_comparison(*left, *op, *right, expr_arena, constraints)
+        },
+        AExpr::Function {
+            input,
+            function,
+            options: _,
+        } => {
+            #[cfg(feature = "is_between")]
+            if let IRFunctionExpr::Boolean(IRBooleanFunction::IsBetween { closed }) = function {
+                if input.len() == 3 {
+                    return classify_is_between(
+                        input[0].node(),
+                        input[1].node(),
+                        input[2].node(),
+                        *closed,
+                        expr_arena,
+                        constraints,
+                    );
+                }
+            }
+            #[cfg(not(feature = "is_between"))]
+            {
+                let _ = (input, function);
+            }
+            false
+        },
+        // These shapes aren't a `col op lit` comparison, so they add no bound.
+        // Listed one by one (no `_`) so that adding a new `AExpr` variant fails
+        // to compile here and forces a decision.
+        AExpr::Element
+        | AExpr::Explode { .. }
+        | AExpr::Column(_)
+        | AExpr::Literal(_)
+        | AExpr::Cast { .. }
+        | AExpr::Sort { .. }
+        | AExpr::Gather { .. }
+        | AExpr::SortBy { .. }
+        | AExpr::Filter { .. }
+        | AExpr::Agg(_)
+        | AExpr::Ternary { .. }
+        | AExpr::AnonymousAgg { .. }
+        | AExpr::AnonymousFunction { .. }
+        | AExpr::Eval { .. }
+        | AExpr::Over { .. }
+        | AExpr::Slice { .. }
+        | AExpr::Len => false,
+        #[cfg(feature = "dtype-struct")]
+        AExpr::StructField(_) => false,
+        #[cfg(feature = "dtype-struct")]
+        AExpr::StructEval { .. } => false,
+        #[cfg(feature = "dynamic_group_by")]
+        AExpr::Rolling { .. } => false,
+    }
+}
+
+// Handles both `col op lit` and `lit op col`. Returns `true` if the new bound
+// made the column impossible.
+fn classify_comparison(
+    left: Node,
+    op: Operator,
+    right: Node,
+    expr_arena: &Arena<AExpr>,
+    constraints: &mut PlHashMap<PlSmallStr, ColumnConstraints>,
+) -> bool {
+    let left_ae = expr_arena.get(left);
+    let right_ae = expr_arena.get(right);
+
+    // Put it in `col op lit` form. If both sides are columns or both are
+    // literals, there's no single-column bound to record.
+    let (col_name, lit, op) =
+        if let (Some(name), Some(lit)) = (as_column(left_ae), as_scalar_lit(right_ae)) {
+            (name, lit, op)
+        } else if let (Some(lit), Some(name)) = (as_scalar_lit(left_ae), as_column(right_ae)) {
+            (name, lit, flip_comparison(op))
+        } else {
+            return false;
+        };
+
+    let cc = constraints.entry(col_name).or_default();
+    match op {
+        Operator::Gt => cc.add_lower(lit, false),
+        Operator::GtEq => cc.add_lower(lit, true),
+        Operator::Lt => cc.add_upper(lit, false),
+        Operator::LtEq => cc.add_upper(lit, true),
+        Operator::Eq => cc.add_equality(lit),
+        // `!=` would need set math; not handled.
+        Operator::NotEq => return false,
+        // Null-aware comparisons don't map to a simple range (nulls behave
+        // differently here).
+        Operator::EqValidity | Operator::NotEqValidity => return false,
+        // And/or and arithmetic ops aren't a `col op lit` comparison, so skip.
+        Operator::And
+        | Operator::Or
+        | Operator::Xor
+        | Operator::LogicalAnd
+        | Operator::LogicalOr
+        | Operator::Plus
+        | Operator::Minus
+        | Operator::Multiply
+        | Operator::RustDivide
+        | Operator::TrueDivide
+        | Operator::FloorDivide
+        | Operator::Modulus => return false,
+    }
+    cc.unsat
+}
+
+// Splits `is_between(col, lo, hi, closed)` into a lower and an upper bound.
+// Returns `true` if those bounds made the column impossible.
+#[cfg(feature = "is_between")]
+fn classify_is_between(
+    col: Node,
+    lo: Node,
+    hi: Node,
+    closed: ClosedInterval,
+    expr_arena: &Arena<AExpr>,
+    constraints: &mut PlHashMap<PlSmallStr, ColumnConstraints>,
+) -> bool {
+    let Some(col_name) = as_column(expr_arena.get(col)) else {
+        return false;
+    };
+    let Some(lo_lit) = as_scalar_lit(expr_arena.get(lo)) else {
+        return false;
+    };
+    let Some(hi_lit) = as_scalar_lit(expr_arena.get(hi)) else {
+        return false;
+    };
+    let (lo_inclusive, hi_inclusive) = match closed {
+        ClosedInterval::Both => (true, true),
+        ClosedInterval::Left => (true, false),
+        ClosedInterval::Right => (false, true),
+        ClosedInterval::None => (false, false),
+    };
+    let cc = constraints.entry(col_name).or_default();
+    cc.add_lower(lo_lit, lo_inclusive);
+    cc.add_upper(hi_lit, hi_inclusive);
+    cc.unsat
+}
+
+fn as_column(ae: &AExpr) -> Option<PlSmallStr> {
+    if let AExpr::Column(name) = ae {
+        Some(name.clone())
+    } else {
+        None
+    }
+}
+
+// Returns `None` for a null literal, so we only reason about real values.
+fn as_scalar_lit(ae: &AExpr) -> Option<Scalar> {
+    if let AExpr::Literal(LiteralValue::Scalar(s)) = ae {
+        if matches!(s.value(), AnyValue::Null) {
+            return None;
+        }
+        Some(s.clone())
+    } else {
+        None
+    }
+}
+
+fn flip_comparison(op: Operator) -> Operator {
+    match op {
+        Operator::Gt => Operator::Lt,
+        Operator::GtEq => Operator::LtEq,
+        Operator::Lt => Operator::Gt,
+        Operator::LtEq => Operator::GtEq,
+        Operator::Eq => Operator::Eq,
+        Operator::NotEq => Operator::NotEq,
+        // Other operators have no flipped form; return them unchanged. They
+        // never reach a real comparison, so the value doesn't matter.
+        Operator::EqValidity
+        | Operator::NotEqValidity
+        | Operator::And
+        | Operator::Or
+        | Operator::Xor
+        | Operator::LogicalAnd
+        | Operator::LogicalOr
+        | Operator::Plus
+        | Operator::Minus
+        | Operator::Multiply
+        | Operator::RustDivide
+        | Operator::TrueDivide
+        | Operator::FloorDivide
+        | Operator::Modulus => op,
+    }
+}

--- a/crates/polars-plan/src/plans/aexpr/range_merge.rs
+++ b/crates/polars-plan/src/plans/aexpr/range_merge.rs
@@ -18,9 +18,9 @@ use crate::prelude::ClosedInterval;
 #[derive(Default)]
 struct ColumnConstraints {
     // The bool is whether the bound is inclusive: true for `>=`/`<=`, false for `>`/`<`.
+    // `== x` is stored as an inclusive lower and upper bound, both `x`.
     lower: Option<(Scalar, bool)>,
     upper: Option<(Scalar, bool)>,
-    equality: Option<Scalar>,
     // Once true, stays true.
     unsat: bool,
 }
@@ -64,48 +64,16 @@ impl ColumnConstraints {
         self.check_consistency();
     }
 
-    fn add_equality(&mut self, value: Scalar) {
-        if self.unsat {
-            return;
-        }
-        match self.equality.take() {
-            None => self.equality = Some(value),
-            Some(existing) => match value.as_any_value().partial_cmp(&existing.as_any_value()) {
-                Some(Ordering::Equal) => self.equality = Some(existing),
-                Some(_) => self.unsat = true,
-                // Different types we can't compare; keep the existing value.
-                None => self.equality = Some(existing),
-            },
-        }
-        self.check_consistency();
-    }
-
-    // Marks the column impossible if its bounds now contradict. Run after each add.
+    // Marks the column impossible if the lower bound is now above the upper
+    // bound (an empty range). Run after each add.
     fn check_consistency(&mut self) {
         if self.unsat {
             return;
         }
-        // Lower bound above the upper bound is an empty range.
         if let (Some((lo, lo_inc)), Some((hi, hi_inc))) = (&self.lower, &self.upper) {
             match lo.as_any_value().partial_cmp(&hi.as_any_value()) {
                 Some(Ordering::Greater) => self.unsat = true,
                 Some(Ordering::Equal) if !(*lo_inc && *hi_inc) => self.unsat = true,
-                _ => {},
-            }
-        }
-        // The equal-to value must sit inside the lower bound.
-        if let (Some(eq), Some((lo, lo_inc))) = (&self.equality, &self.lower) {
-            match eq.as_any_value().partial_cmp(&lo.as_any_value()) {
-                Some(Ordering::Less) => self.unsat = true,
-                Some(Ordering::Equal) if !*lo_inc => self.unsat = true,
-                _ => {},
-            }
-        }
-        // The equal-to value must sit inside the upper bound.
-        if let (Some(eq), Some((hi, hi_inc))) = (&self.equality, &self.upper) {
-            match eq.as_any_value().partial_cmp(&hi.as_any_value()) {
-                Some(Ordering::Greater) => self.unsat = true,
-                Some(Ordering::Equal) if !*hi_inc => self.unsat = true,
                 _ => {},
             }
         }
@@ -171,16 +139,19 @@ fn classify_into_constraints(
         } => {
             #[cfg(feature = "is_between")]
             if let IRFunctionExpr::Boolean(IRBooleanFunction::IsBetween { closed }) = function {
-                if input.len() == 3 {
-                    return classify_is_between(
-                        input[0].node(),
-                        input[1].node(),
-                        input[2].node(),
-                        *closed,
-                        expr_arena,
-                        constraints,
-                    );
-                }
+                assert_eq!(
+                    input.len(),
+                    3,
+                    "is_between has 3 inputs: value, lower, upper"
+                );
+                return classify_is_between(
+                    input[0].node(),
+                    input[1].node(),
+                    input[2].node(),
+                    *closed,
+                    expr_arena,
+                    constraints,
+                );
             }
             #[cfg(not(feature = "is_between"))]
             {
@@ -246,7 +217,11 @@ fn classify_comparison(
         Operator::GtEq => cc.add_lower(lit, true),
         Operator::Lt => cc.add_upper(lit, false),
         Operator::LtEq => cc.add_upper(lit, true),
-        Operator::Eq => cc.add_equality(lit),
+        // `== x` is an inclusive lower and upper bound, both `x`.
+        Operator::Eq => {
+            cc.add_lower(lit.clone(), true);
+            cc.add_upper(lit, true);
+        },
         // `!=` would need set math; not handled.
         Operator::NotEq => return false,
         // Null-aware comparisons don't map to a simple range (nulls behave

--- a/crates/polars-plan/src/plans/optimizer/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/mod.rs
@@ -28,6 +28,7 @@ mod ir_traversal;
 mod parquet_metadata_prune;
 mod predicate_pushdown;
 mod projection_pushdown;
+mod range_merge;
 mod simplify_expr;
 pub mod simplify_ordering;
 mod slice_pushdown_expr;
@@ -226,7 +227,16 @@ pub fn optimize(
     // This optimization removes branches, so we must do it when type coercion
     // is completed.
     if opt_flags.simplify_expr() {
-        rules.push(Box::new(SimplifyBooleanRule {}));
+        // RangeMergeRule turns an impossible range like `a > 5 AND a < 3` into
+        // `false`. It runs before SimplifyBooleanRule so that, in the same pass,
+        // SimplifyBooleanRule can use that `false` to collapse the whole filter
+        // into an empty scan.
+        rules.push(Box::new(range_merge::RangeMergeRule {
+            maintain_errors: pushdown_maintain_errors,
+        }));
+        rules.push(Box::new(SimplifyBooleanRule {
+            maintain_errors: pushdown_maintain_errors,
+        }));
     }
 
     if !opt_flags.eager() {

--- a/crates/polars-plan/src/plans/optimizer/range_merge.rs
+++ b/crates/polars-plan/src/plans/optimizer/range_merge.rs
@@ -1,0 +1,46 @@
+use polars_core::error::PolarsResult;
+use polars_utils::arena::{Arena, Node};
+
+use super::OptimizationRule;
+use crate::plans::aexpr::range_merge::merge_ranges_in_predicate;
+use crate::prelude::{AExpr, IR};
+
+pub struct RangeMergeRule {
+    pub maintain_errors: bool,
+}
+
+impl OptimizationRule for RangeMergeRule {
+    fn optimize_plan(
+        &mut self,
+        lp_arena: &mut Arena<IR>,
+        expr_arena: &mut Arena<AExpr>,
+        node: Node,
+    ) -> PolarsResult<Option<IR>> {
+        let IR::Filter { input, predicate } = lp_arena.get(node) else {
+            return Ok(None);
+        };
+        let input = *input;
+        let predicate_node = predicate.node();
+
+        let Some(new_predicate_node) =
+            merge_ranges_in_predicate(predicate_node, self.maintain_errors, expr_arena)
+        else {
+            return Ok(None);
+        };
+        // Today this is always a fresh `Literal(false)`, never the same node.
+        // The check just stops the optimizer looping forever if that ever
+        // changes.
+        if new_predicate_node == predicate_node {
+            return Ok(None);
+        }
+
+        // Clone only when we actually rewrite; the common path above returns
+        // first.
+        let mut new_predicate = predicate.clone();
+        new_predicate.set_node(new_predicate_node);
+        Ok(Some(IR::Filter {
+            input,
+            predicate: new_predicate,
+        }))
+    }
+}

--- a/crates/polars-plan/src/plans/optimizer/simplify_expr/arity.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_expr/arity.rs
@@ -6,6 +6,7 @@ pub(super) fn simplify_binary(
     op: Operator,
     right: Node,
     ctx: OptimizeExprContext,
+    maintain_errors: bool,
     expr_arena: &mut Arena<AExpr>,
 ) -> Option<AExpr> {
     let in_filter = ctx.in_filter;
@@ -46,6 +47,48 @@ pub(super) fn simplify_binary(
                 )
             {
                 return Some(AExpr::Literal(Scalar::from(false).into()));
+            }
+
+            if in_filter {
+                // `A AND NOT(A)` is always false (either operand may be the
+                // `NOT`). Catches cases the earlier rewrites left alone, like
+                // `NOT(col)` on a bool column or `NOT(is_in(col, values))`.
+                if is_self_negation(left, left_ae, right_ae, expr_arena, maintain_errors)
+                    || is_self_negation(right, right_ae, left_ae, expr_arena, maintain_errors)
+                {
+                    return Some(AExpr::Literal(Scalar::from(false).into()));
+                }
+
+                // Two opposite comparisons on the same operands are always
+                // false, e.g. `(col > N) AND (col <= N)`. This shows up after an
+                // earlier rewrite turns `NOT(col > N)` into `col <= N`.
+                if let (
+                    AExpr::BinaryExpr {
+                        left: l1,
+                        op: op1,
+                        right: r1,
+                    },
+                    AExpr::BinaryExpr {
+                        left: l2,
+                        op: op2,
+                        right: r2,
+                    },
+                ) = (left_ae, right_ae)
+                {
+                    if inverse_comparison_op(*op1) == Some(*op2) {
+                        let l1_ae = expr_arena.get(*l1);
+                        let l2_ae = expr_arena.get(*l2);
+                        let r1_ae = expr_arena.get(*r1);
+                        let r2_ae = expr_arena.get(*r2);
+                        if l1_ae.is_expr_equal_to(l2_ae, expr_arena)
+                            && r1_ae.is_expr_equal_to(r2_ae, expr_arena)
+                            && is_safe_to_drop(*l1, expr_arena, maintain_errors)
+                            && is_safe_to_drop(*r1, expr_arena, maintain_errors)
+                        {
+                            return Some(AExpr::Literal(Scalar::from(false).into()));
+                        }
+                    }
+                }
             }
         },
         O::Or => {
@@ -140,4 +183,67 @@ pub(super) fn simplify_ternary(
     }
 
     None
+}
+
+// Returns the inner expression if `ae` is `NOT(inner)`, else `None`.
+fn is_not_of(ae: &AExpr) -> Option<Node> {
+    if let AExpr::Function {
+        input,
+        function: IRFunctionExpr::Boolean(IRBooleanFunction::Not),
+        ..
+    } = ae
+    {
+        if input.len() == 1 {
+            return Some(input[0].node());
+        }
+    }
+    None
+}
+
+// True when `a AND b` is `A AND NOT(A)` (i.e. `b` is `NOT(a)`) and `a` is safe
+// to drop. Checking only `a` suffices: `b` is `NOT(a)`, which wraps the same
+// expression, so it is droppable whenever `a` is.
+fn is_self_negation(
+    a: Node,
+    a_ae: &AExpr,
+    b_ae: &AExpr,
+    expr_arena: &Arena<AExpr>,
+    maintain_errors: bool,
+) -> bool {
+    let Some(inner) = is_not_of(b_ae) else {
+        return false;
+    };
+    a_ae.is_expr_equal_to(expr_arena.get(inner), expr_arena)
+        && is_safe_to_drop(a, expr_arena, maintain_errors)
+}
+
+// Returns the opposite of a comparison operator: `>`<->`<=`, `<`<->`>=`,
+// `==`<->`!=`. Anything else returns `None`.
+fn inverse_comparison_op(op: Operator) -> Option<Operator> {
+    use Operator::*;
+    Some(match op {
+        Gt => LtEq,
+        LtEq => Gt,
+        Lt => GtEq,
+        GtEq => Lt,
+        Eq => NotEq,
+        NotEq => Eq,
+        EqValidity | NotEqValidity | And | Or | Xor | LogicalAnd | LogicalOr | Plus | Minus
+        | Multiply | RustDivide | TrueDivide | FloorDivide | Modulus => return None,
+    })
+}
+
+// Whether we can drop this expression when collapsing a contradiction to
+// `false`. A random (non-deterministic) expression is never safe to drop: two
+// copies of it aren't the same value, so they don't really contradict. An
+// expression that can error is safe to drop only when the user has not asked to
+// keep errors (same rule as predicate pushdown).
+fn is_safe_to_drop(node: Node, expr_arena: &Arena<AExpr>, maintain_errors: bool) -> bool {
+    if is_inherently_nondeterministic(node, expr_arena) {
+        return false;
+    }
+    let ae = expr_arena.get(node);
+    let mut group = ExprPushdownGroup::Pushable;
+    group.update_with_expr_rec(ae, expr_arena, None);
+    !group.blocks_pushdown(maintain_errors)
 }

--- a/crates/polars-plan/src/plans/optimizer/simplify_expr/arity.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_expr/arity.rs
@@ -59,9 +59,8 @@ pub(super) fn simplify_binary(
                     return Some(AExpr::Literal(Scalar::from(false).into()));
                 }
 
-                // Two opposite comparisons on the same operands are always
-                // false, e.g. `(col > N) AND (col <= N)`. This shows up after an
-                // earlier rewrite turns `NOT(col > N)` into `col <= N`.
+                // Two comparisons on the same operands that can never both hold,
+                // e.g. `(col > N) AND (col <= N)` or `(col > N) AND (col < N)`.
                 if let (
                     AExpr::BinaryExpr {
                         left: l1,
@@ -75,7 +74,7 @@ pub(super) fn simplify_binary(
                     },
                 ) = (left_ae, right_ae)
                 {
-                    if inverse_comparison_op(*op1) == Some(*op2) {
+                    if comparisons_contradict(*op1, *op2) {
                         let l1_ae = expr_arena.get(*l1);
                         let l2_ae = expr_arena.get(*l2);
                         let r1_ae = expr_arena.get(*r1);
@@ -217,20 +216,35 @@ fn is_self_negation(
         && is_safe_to_drop(a, expr_arena, maintain_errors)
 }
 
-// Returns the opposite of a comparison operator: `>`<->`<=`, `<`<->`>=`,
-// `==`<->`!=`. Anything else returns `None`.
-fn inverse_comparison_op(op: Operator) -> Option<Operator> {
+// Bitset positions for the three outcomes of comparing two values.
+const CMP_LT: u8 = 1; // x < y
+const CMP_EQ: u8 = 2; // x == y
+const CMP_GT: u8 = 4; // x > y
+
+// The cases a comparison operator is true in, as a bitset over `<` / `==` / `>`.
+// `None` for non-comparison operators.
+fn comparison_cases(op: Operator) -> Option<u8> {
     use Operator::*;
     Some(match op {
-        Gt => LtEq,
-        LtEq => Gt,
-        Lt => GtEq,
-        GtEq => Lt,
-        Eq => NotEq,
-        NotEq => Eq,
+        Lt => CMP_LT,
+        LtEq => CMP_LT | CMP_EQ,
+        Gt => CMP_GT,
+        GtEq => CMP_GT | CMP_EQ,
+        Eq => CMP_EQ,
+        NotEq => CMP_LT | CMP_GT,
         EqValidity | NotEqValidity | And | Or | Xor | LogicalAnd | LogicalOr | Plus | Minus
         | Multiply | RustDivide | TrueDivide | FloorDivide | Modulus => return None,
     })
+}
+
+// Whether `(x op1 y) AND (x op2 y)` can never both hold: the operators share no
+// case (their true-sets over `<` / `==` / `>` are disjoint). `false` if either
+// is not a comparison.
+fn comparisons_contradict(op1: Operator, op2: Operator) -> bool {
+    match (comparison_cases(op1), comparison_cases(op2)) {
+        (Some(a), Some(b)) => a & b == 0,
+        _ => false,
+    }
 }
 
 // Whether we can drop this expression when collapsing a contradiction to

--- a/crates/polars-plan/src/plans/optimizer/simplify_expr/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_expr/mod.rs
@@ -141,9 +141,41 @@ macro_rules! eval_binary_cmp_same_type {
     }}
 }
 
-pub struct SimplifyBooleanRule {}
+pub struct SimplifyBooleanRule {
+    pub maintain_errors: bool,
+}
 
 impl OptimizationRule for SimplifyBooleanRule {
+    fn optimize_plan(
+        &mut self,
+        lp_arena: &mut Arena<IR>,
+        expr_arena: &mut Arena<AExpr>,
+        node: Node,
+    ) -> PolarsResult<Option<IR>> {
+        let (input_node, predicate_node) = match lp_arena.get(node) {
+            IR::Filter { input, predicate } => (*input, predicate.node()),
+            _ => return Ok(None),
+        };
+
+        let lv = match expr_arena.get(predicate_node) {
+            AExpr::Literal(lv) => lv,
+            _ => return Ok(None),
+        };
+
+        match lv.bool() {
+            Some(false) => {
+                let schema = lp_arena.get(input_node).schema(lp_arena).into_owned();
+                Ok(Some(IR::DataFrameScan {
+                    df: Arc::new(DataFrame::empty_with_schema(&schema)),
+                    schema,
+                    output_schema: None,
+                }))
+            },
+            Some(true) => Ok(Some(lp_arena.get(input_node).clone())),
+            _ => Ok(None),
+        }
+    }
+
     fn optimize_expr(
         &mut self,
         expr_arena: &mut Arena<AExpr>,
@@ -156,7 +188,14 @@ impl OptimizationRule for SimplifyBooleanRule {
         let out = match expr {
             // true AND x => x
             AExpr::BinaryExpr { left, op, right } => {
-                return Ok(arity::simplify_binary(*left, *op, *right, ctx, expr_arena));
+                return Ok(arity::simplify_binary(
+                    *left,
+                    *op,
+                    *right,
+                    ctx,
+                    self.maintain_errors,
+                    expr_arena,
+                ));
             },
             AExpr::Ternary {
                 predicate,
@@ -371,7 +410,7 @@ impl OptimizationRule for SimplifyExprRule {
         expr_arena: &mut Arena<AExpr>,
         expr_node: Node,
         schema: &Schema,
-        _ctx: OptimizeExprContext,
+        ctx: OptimizeExprContext,
     ) -> PolarsResult<Option<AExpr>> {
         let expr = expr_arena.get(expr_node);
 
@@ -745,7 +784,13 @@ impl OptimizationRule for SimplifyExprRule {
                 options,
                 ..
             } => {
-                return optimize_functions(input.clone(), function.clone(), *options, expr_arena);
+                return optimize_functions(
+                    input.clone(),
+                    function.clone(),
+                    *options,
+                    ctx,
+                    expr_arena,
+                );
             },
             _ => None,
         };

--- a/crates/polars-plan/src/plans/optimizer/simplify_expr/simplify_functions.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_expr/simplify_functions.rs
@@ -4,6 +4,7 @@ pub(super) fn optimize_functions(
     input: Vec<ExprIR>,
     function: IRFunctionExpr,
     options: FunctionOptions,
+    ctx: OptimizeExprContext,
     expr_arena: &mut Arena<AExpr>,
 ) -> PolarsResult<Option<AExpr>> {
     let out = match function {
@@ -133,6 +134,30 @@ pub(super) fn optimize_functions(
             } else {
                 None
             }
+        },
+        #[cfg(feature = "is_in")]
+        IRFunctionExpr::Boolean(IRBooleanFunction::IsIn { .. }) if ctx.in_filter => {
+            let haystack = expr_arena.get(input[1].node());
+            let empty = match haystack {
+                AExpr::Literal(LiteralValue::Series(s)) => s.is_empty(),
+                AExpr::Literal(LiteralValue::Scalar(s)) => match s.value() {
+                    AnyValue::List(inner) => inner.is_empty(),
+                    #[cfg(feature = "dtype-array")]
+                    AnyValue::Array(inner, _) => inner.is_empty(),
+                    _ => false,
+                },
+                AExpr::Literal(LiteralValue::Dyn(DynLiteralValue::List(list))) => match list {
+                    DynListLiteralValue::Str(vs) => vs.is_empty(),
+                    DynListLiteralValue::Int(vs) => vs.is_empty(),
+                    DynListLiteralValue::Float(vs) => vs.is_empty(),
+                    DynListLiteralValue::List(vs) => vs.is_empty(),
+                },
+                _ => false,
+            };
+            if empty {
+                return Ok(Some(AExpr::Literal(Scalar::from(false).into())));
+            }
+            None
         },
         IRFunctionExpr::Boolean(IRBooleanFunction::Not) => {
             let y = expr_arena.get(input[0].node());

--- a/py-polars/tests/unit/lazyframe/test_predicates.py
+++ b/py-polars/tests/unit/lazyframe/test_predicates.py
@@ -1507,6 +1507,9 @@ def test_filter_contradiction_collapses() -> None:
         pl.LazyFrame({"b": [True, False, True]}).filter(
             pl.col("b") & ~pl.col("b")
         ),  # structural b AND NOT b
+        pl.LazyFrame({"a": [1, 2], "b": [3, 4]}).filter(
+            (pl.col("a") > pl.col("b")) & (pl.col("a") < pl.col("b"))
+        ),  # disjoint comparisons on two columns (a > b AND a < b)
     ]
     for lf in collapsing:
         # The FILTER node is gone from the optimized plan and the result is empty;
@@ -1521,6 +1524,13 @@ def test_filter_contradiction_collapses() -> None:
     lf = a.filter(pl.col("a") >= 1).filter(pl.col("a") >= 3)
     assert "FILTER" in lf.explain()
     assert_frame_equal(lf.collect(), pl.DataFrame({"a": [3]}))
+
+    # `>= AND <=` on the same operands is satisfiable (the equal rows), so it
+    # must not be folded away.
+    lf = pl.LazyFrame({"a": [1, 2, 3], "b": [3, 2, 1]}).filter(
+        (pl.col("a") >= pl.col("b")) & (pl.col("a") <= pl.col("b"))
+    )
+    assert_frame_equal(lf.collect(), pl.DataFrame({"a": [2], "b": [2]}))
 
 
 def test_filter_contradiction_fallible_error_handling(

--- a/py-polars/tests/unit/lazyframe/test_predicates.py
+++ b/py-polars/tests/unit/lazyframe/test_predicates.py
@@ -1489,3 +1489,53 @@ def test_predicate_pushdown_block_at_embedded_slice_groupby_26824() -> None:
             schema_overrides={"len": pl.get_index_type()},
         ),
     )
+
+
+def test_filter_contradiction_collapses() -> None:
+    a = pl.LazyFrame({"a": [1, 2, 3]})
+    # Each filter is always false and should collapse to an empty scan.
+    collapsing = [
+        a.filter(pl.col("a") > 1).filter(~(pl.col("a") > 1)),  # A AND NOT A
+        a.filter(pl.col("a") == 2).filter(pl.col("a") != 2),  # == AND !=
+        a.filter(pl.col("a").is_in([])),  # empty is_in
+        a.filter(pl.lit(False)),  # literal false
+        a.filter(pl.col("a") < 2).filter(pl.col("a") >= 3),  # disjoint inequalities
+        a.filter(pl.col("a").is_between(2, 3)).filter(
+            pl.col("a").is_between(0, 1)
+        ),  # disjoint is_between
+        a.filter(pl.col("a") == 5).filter(pl.col("a") > 10),  # == outside range
+        pl.LazyFrame({"b": [True, False, True]}).filter(
+            pl.col("b") & ~pl.col("b")
+        ),  # structural b AND NOT b
+    ]
+    for lf in collapsing:
+        # The FILTER node is gone from the optimized plan and the result is empty;
+        # disabling `simplify_expression` keeps it, proving the rewrite owns it.
+        assert "FILTER" not in lf.explain()
+        assert lf.collect().is_empty()
+        assert "FILTER" in lf.explain(
+            optimizations=pl.QueryOptFlags(simplify_expression=False)
+        )
+
+    # A satisfiable range keeps its rows: `a >= 1 AND a >= 3` tightens to `a >= 3`.
+    lf = a.filter(pl.col("a") >= 1).filter(pl.col("a") >= 3)
+    assert "FILTER" in lf.explain()
+    assert_frame_equal(lf.collect(), pl.DataFrame({"a": [3]}))
+
+
+def test_filter_contradiction_fallible_error_handling(
+    plmonkeypatch: PlMonkeyPatch,
+) -> None:
+    # `(cast > 0) AND (cast <= 0)` is always false, and the strict cast would
+    # overflow Int8 (so it can error).
+    cast_a = pl.col("a").cast(pl.Int8, strict=True)
+    lf = pl.LazyFrame({"a": [1000]}).filter((cast_a > 0) & (cast_a <= 0))
+
+    # By default the contradiction is dropped, so the cast never runs: empty.
+    assert lf.collect().is_empty()
+
+    # With error preservation on, the filter must NOT be dropped, so the overflow
+    # still surfaces.
+    plmonkeypatch.setenv("POLARS_PUSHDOWN_OPT_MAINTAIN_ERRORS", "1")
+    with pytest.raises(InvalidOperationError):
+        lf.collect()


### PR DESCRIPTION
Closes #21862

This PR detects filter predicates that can never be true and replaces the whole filter, along with the work feeding it, with an empty result. Previously, `df.filter(expr).filter(~expr)` would still scan the source and evaluate `expr` even though the query cannot return any rows.

The following contradictions are detected, and each one folds the predicate to `false`:

- `A AND NOT(A)`: an expression and its negation.
- Inverse comparison pairs: `(x > n) AND (x <= n)`, `(x < n) AND (x >= n)`, `(x == n) AND (x != n)`.
- Empty membership: `is_in([])`.
- Disjoint ranges: `a > 5 AND a < 3`.
- Disjoint `is_between`: `is_between(2, 3) AND is_between(0, 1)`.
- Equality outside a range: `a == 5 AND a > 10`.

**Follow-up PRs**

- Tightening: combine overlapping checks into one, so `a >= 1 AND a >= 5` becomes `a >= 5`. Right now we only handle the impossible case.
- Sets: handle `!=` and non-overlapping `is_in`, like `is_in([1, 2]) AND is_in([3, 4])` or `is_in([1, 2]) AND a != 1 AND a != 2`.
- Across columns: learn `b == 5` from `a == b AND a == 5`.