### PR TITLE
perf: Do not materialize `ScalarColumn` in Column `split_at`

### DIFF
--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -588,7 +588,6 @@ impl Column {
     }
 
     pub fn split_at(&self, offset: i64) -> (Column, Column) {
-        // @scalar-opt
         match self {
             Column::Scalar(c) => {
                 let len = c.len();

--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -589,8 +589,29 @@ impl Column {
 
     pub fn split_at(&self, offset: i64) -> (Column, Column) {
         // @scalar-opt
-        let (l, r) = self.as_materialized_series().split_at(offset);
-        (l.into(), r.into())
+        match self {
+            Column::Scalar(c) => {
+                let len = c.len();
+                let offset = if offset < 0 {
+                    let offset_abs = usize::try_from(offset.strict_abs())
+                        .expect("offset exceeds usize limits")
+                        .min(len);
+                    len - offset_abs
+                } else {
+                    usize::try_from(offset)
+                        .expect("offset exceeds usize limits")
+                        .min(len)
+                };
+                (
+                    Column::Scalar(c.resize(offset)),
+                    Column::Scalar(c.resize(len - offset)),
+                )
+            },
+            Column::Series(_) => {
+                let (l, r) = self.as_materialized_series().split_at(offset);
+                (l.into(), r.into())
+            },
+        }
     }
 
     #[inline]


### PR DESCRIPTION
Related to #27725

Calling `Column::split_at` on the `ScalarColumn` variant will no longer materialize the column. Instead, it will generate 2 `ScalarColumn`s.

This mitigates the memory bloat and OOM as reported in #27725.

Applying this PR directly on the respective commit a8ed42d (which triggered the OOM), now succeeds (on the newly generated plan):
```
 $ /usr/bin/time -v ~/tmp/polars/.venv/bin/python issue.py 2>& 1 | grep "Max"
        Maximum resident set size (kbytes): 478732
```
