### PR TITLE
chore(python): Run Pyrefly on `_utils` and `functions`

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -92,7 +92,7 @@ all = [
 ]
 
 [tool.pyrefly]
-project-includes = ["tests"]
+project-includes = ["src/polars/_utils", "src/polars/functions", "tests"]
 search-path = ["./src", "."]
 ignore-missing-imports = [
   "_polars_runtime_32.*",
@@ -105,6 +105,7 @@ ignore-missing-imports = [
 ]
 # pyrefly equivalent of mypy's `follow_imports = "skip"`
 replace-imports-with-any = [
+  "marimo.*",
   "pyarrow.*",
   "pyiceberg.*",
 ]

--- a/py-polars/src/polars/_utils/construction/dataframe.py
+++ b/py-polars/src/polars/_utils/construction/dataframe.py
@@ -9,6 +9,7 @@ from operator import itemgetter
 from typing import (
     TYPE_CHECKING,
     Any,
+    cast,
 )
 
 import polars._reexport as pl
@@ -64,6 +65,8 @@ if TYPE_CHECKING:
     from polars import DataFrame, Series
     from polars._plr import PySeries
     from polars._typing import (
+        ArrayLike,
+        NonNestedLiteral,
         Orientation,
         PolarsDataType,
         SchemaDefinition,
@@ -74,7 +77,7 @@ _MIN_NUMPY_SIZE_FOR_MULTITHREADING = 1000
 
 
 def dict_to_pydf(
-    data: Mapping[str, Sequence[object] | Mapping[str, Sequence[object]] | Series],
+    data: Mapping[str, ArrayLike | NonNestedLiteral | None],
     schema: SchemaDefinition | None = None,
     *,
     schema_overrides: SchemaDict | None = None,
@@ -332,7 +335,7 @@ def _post_apply_columns(
 
 
 def _expand_dict_values(
-    data: Mapping[str, Sequence[object] | Mapping[str, Sequence[object]] | Series],
+    data: Mapping[str, ArrayLike | NonNestedLiteral | None],
     *,
     schema_overrides: SchemaDict | None = None,
     strict: bool = True,
@@ -380,6 +383,7 @@ def _expand_dict_values(
                     updated_data[name] = s
 
                 elif arrlen(val) is not None or _is_generator(val):
+                    val = cast("Iterable[Any]", val)  # help type-checkers
                     updated_data[name] = pl.Series(
                         name=name,
                         values=val,
@@ -387,7 +391,7 @@ def _expand_dict_values(
                         strict=strict,
                         nan_to_null=nan_to_null,
                     )
-                elif val is None or isinstance(  # type: ignore[redundant-expr]
+                elif val is None or isinstance(
                     val, (int, float, str, bytes, bool, date, datetime, time, timedelta)
                 ):
                     updated_data[name] = F.repeat(
@@ -400,8 +404,12 @@ def _expand_dict_values(
 
         elif all((arrlen(val) == 0) for val in data.values()):
             for name, val in data.items():
+                val = cast("Iterable[Any]", val)  # help type-checkers
                 updated_data[name] = pl.Series(
-                    name, values=val, dtype=dtypes.get(name), strict=strict
+                    name,
+                    values=val,
+                    dtype=dtypes.get(name),
+                    strict=strict,
                 )
 
         elif all((arrlen(val) is None) for val in data.values()):
@@ -418,19 +426,17 @@ def _expand_dict_values(
 
 
 def _expand_dict_data(
-    data: Mapping[str, Sequence[object] | Mapping[str, Sequence[object]] | Series],
+    data: Mapping[str, ArrayLike | NonNestedLiteral | None],
     dtypes: SchemaDict,
     *,
     strict: bool = True,
-) -> Mapping[str, Sequence[object] | Mapping[str, Sequence[object]] | Series]:
+) -> Mapping[str, ArrayLike | NonNestedLiteral | None]:
     """
     Expand any unsized generators/iterators.
 
     (Note that `range` is sized, and will take a fast-path on Series init).
     """
-    expanded_data: dict[
-        str, Sequence[object] | Mapping[str, Sequence[object]] | Series
-    ] = {}
+    expanded_data: dict[str, ArrayLike | NonNestedLiteral | None] = {}
     for name, val in data.items():
         expanded_data[name] = (
             pl.Series(name, val, dtypes.get(name), strict=strict)

--- a/py-polars/src/polars/_utils/various.py
+++ b/py-polars/src/polars/_utils/various.py
@@ -85,7 +85,10 @@ def _is_generator(val: object | Iterator[T]) -> TypeIs[Iterator[T]]:
     return (
         (isinstance(val, (Generator, Iterable)) and not isinstance(val, Sized))
         or isinstance(val, MappingView)
-        or (sys.version_info >= (3, 11) and isinstance(val, _reverse_mapping_views))
+        or (
+            sys.version_info >= (3, 11)
+            and isinstance(val, _reverse_mapping_views)  # pyrefly: ignore[unknown-name]
+        )
     )
 
 
@@ -145,6 +148,14 @@ def is_sequence(
     return (_check_for_numpy(val) and isinstance(val, np.ndarray)) or (
         isinstance(val, (pl.Series, Sequence) if include_series else Sequence)
         and not isinstance(val, str)
+    )
+
+
+def is_sequence_of(obj: Sequence[Any], tp: type[T]) -> TypeIs[Sequence[T]]:
+    # Check if an object is a sequence of `tp`, only sniffing the first element.
+    return bool(
+        (first := next(iter(obj), NO_DEFAULT)) is not NO_DEFAULT
+        and isinstance(first, tp)
     )
 
 

--- a/py-polars/src/polars/_utils/various.py
+++ b/py-polars/src/polars/_utils/various.py
@@ -151,7 +151,7 @@ def is_sequence(
     )
 
 
-def is_sequence_of(obj: Sequence[Any], tp: type[T]) -> TypeIs[Sequence[T]]:
+def is_non_empty_sequence_of(obj: Sequence[Any], tp: type[T]) -> TypeIs[Sequence[T]]:
     # Check if an object is a sequence of `tp`, only sniffing the first element.
     return bool(
         (first := next(iter(obj), NO_DEFAULT)) is not NO_DEFAULT

--- a/py-polars/src/polars/functions/eager.py
+++ b/py-polars/src/polars/functions/eager.py
@@ -11,7 +11,11 @@ from polars import functions as F
 from polars._typing import ConcatMethod
 from polars._utils.reduce_balanced import reduce_balanced
 from polars._utils.unstable import unstable
-from polars._utils.various import is_non_empty_sequence_of, ordered_unique, qualified_type_name
+from polars._utils.various import (
+    is_non_empty_sequence_of,
+    ordered_unique,
+    qualified_type_name,
+)
 from polars._utils.wrap import wrap_df, wrap_expr, wrap_ldf, wrap_s
 from polars.exceptions import InvalidOperationError
 
@@ -182,7 +186,9 @@ def concat(
         return elems[0]
 
     if how.startswith("align"):
-        if not is_non_empty_sequence_of(elems, pl.DataFrame) and not is_non_empty_sequence_of(  # type: ignore[redundant-expr]
+        if not is_non_empty_sequence_of(
+            elems, pl.DataFrame
+        ) and not is_non_empty_sequence_of(  # type: ignore[redundant-expr]
             elems, pl.LazyFrame
         ):
             msg = f"{how!r} strategy is not supported for {qualified_type_name(elems[0])!r}"
@@ -474,7 +480,9 @@ def union(
         return elems[0]
 
     if how.startswith("align"):
-        if not is_non_empty_sequence_of(elems, pl.DataFrame) and not is_non_empty_sequence_of(  # type: ignore[redundant-expr]
+        if not is_non_empty_sequence_of(
+            elems, pl.DataFrame
+        ) and not is_non_empty_sequence_of(  # type: ignore[redundant-expr]
             elems, pl.LazyFrame
         ):
             msg = f"{how!r} strategy is not supported for {qualified_type_name(elems[0])!r}"
@@ -678,7 +686,9 @@ def merge_sorted(
     if len(elems) == 1 and isinstance(elems[0], (pl.DataFrame, pl.LazyFrame)):
         return elems[0]
 
-    if not is_non_empty_sequence_of(elems, pl.DataFrame) and not is_non_empty_sequence_of(  # type: ignore[redundant-expr]
+    if not is_non_empty_sequence_of(
+        elems, pl.DataFrame
+    ) and not is_non_empty_sequence_of(  # type: ignore[redundant-expr]
         elems, pl.LazyFrame
     ):
         msg = f"merge_sorted is not supported for {qualified_type_name(elems[0])!r}"

--- a/py-polars/src/polars/functions/eager.py
+++ b/py-polars/src/polars/functions/eager.py
@@ -11,7 +11,7 @@ from polars import functions as F
 from polars._typing import ConcatMethod
 from polars._utils.reduce_balanced import reduce_balanced
 from polars._utils.unstable import unstable
-from polars._utils.various import ordered_unique, qualified_type_name
+from polars._utils.various import is_sequence_of, ordered_unique, qualified_type_name
 from polars._utils.wrap import wrap_df, wrap_expr, wrap_ldf, wrap_s
 from polars.exceptions import InvalidOperationError
 
@@ -171,7 +171,7 @@ def concat(
     └─────┴─────┴─────┴─────┘
     """  # noqa: W505
     # unpack/standardise (handles generator input)
-    elems = list(items)
+    elems: Sequence[PolarsType] = list(items)
 
     if not elems:
         msg = "cannot concat empty list"
@@ -182,7 +182,9 @@ def concat(
         return elems[0]
 
     if how.startswith("align"):
-        if not isinstance(elems[0], (pl.DataFrame, pl.LazyFrame)):
+        if not is_sequence_of(elems, pl.DataFrame) and not is_sequence_of(  # type: ignore[redundant-expr]
+            elems, pl.LazyFrame
+        ):
             msg = f"{how!r} strategy is not supported for {qualified_type_name(elems[0])!r}"
             raise TypeError(msg)
 
@@ -230,11 +232,10 @@ def concat(
         return lf.collect() if eager else lf  # type: ignore[return-value]
 
     out: Series | DataFrame | LazyFrame | Expr
-    first = elems[0]
 
     from polars.lazyframe.opt_flags import QueryOptFlags
 
-    if isinstance(first, pl.DataFrame):
+    if is_sequence_of(elems, pl.DataFrame):
         if how == "vertical":
             out = wrap_df(plr.concat_df(elems))
         elif how == "vertical_relaxed":
@@ -267,7 +268,7 @@ def concat(
             msg = f"DataFrame `how` must be one of {{{allowed}}}, got {how!r}"
             raise ValueError(msg)
 
-    elif isinstance(first, pl.LazyFrame):
+    elif is_sequence_of(elems, pl.LazyFrame):
         if how in ("vertical", "vertical_relaxed"):
             return wrap_ldf(
                 plr.concat_lf(
@@ -301,17 +302,17 @@ def concat(
             msg = f"LazyFrame `how` must be one of {{{allowed}}}, got {how!r}"
             raise ValueError(msg)
 
-    elif isinstance(first, pl.Series):
+    elif is_sequence_of(elems, pl.Series):
         if how == "vertical":
             out = wrap_s(plr.concat_series(elems))
         else:
             msg = "Series only supports 'vertical' concat strategy"
             raise ValueError(msg)
 
-    elif isinstance(first, pl.Expr):
+    elif is_sequence_of(elems, pl.Expr):
         return wrap_expr(plr.concat_expr([e._pyexpr for e in elems], rechunk))
     else:
-        msg = f"did not expect type: {qualified_type_name(first)!r} in `concat`"
+        msg = f"did not expect type: {qualified_type_name(elems[0])!r} in `concat`"
         raise TypeError(msg)
 
     if rechunk:
@@ -462,7 +463,7 @@ def union(
     └─────┴─────┴─────┴─────┘
     """  # noqa: W505
     # unpack/standardise (handles generator input)
-    elems = list(items)
+    elems: Sequence[PolarsType] = list(items)
 
     if not elems:
         msg = "cannot concat empty list"
@@ -473,7 +474,9 @@ def union(
         return elems[0]
 
     if how.startswith("align"):
-        if not isinstance(elems[0], (pl.DataFrame, pl.LazyFrame)):
+        if not is_sequence_of(elems, pl.DataFrame) and not is_sequence_of(  # type: ignore[redundant-expr]
+            elems, pl.LazyFrame
+        ):
             msg = f"{how!r} strategy is not supported for {qualified_type_name(elems[0])!r}"
             raise TypeError(msg)
 
@@ -521,11 +524,10 @@ def union(
         return lf.collect() if eager else lf  # type: ignore[return-value]
 
     out: Series | DataFrame | LazyFrame | Expr
-    first = elems[0]
 
     from polars.lazyframe.opt_flags import QueryOptFlags
 
-    if isinstance(first, pl.DataFrame):
+    if is_sequence_of(elems, pl.DataFrame):
         if how in ("vertical", "vertical_relaxed"):
             out = wrap_ldf(
                 plr.concat_lf(
@@ -553,7 +555,7 @@ def union(
             msg = f"DataFrame `how` must be one of {{{allowed}}}, got {how!r}"
             raise ValueError(msg)
 
-    elif isinstance(first, pl.LazyFrame):
+    elif is_sequence_of(elems, pl.LazyFrame):
         if how in ("vertical", "vertical_relaxed"):
             return wrap_ldf(
                 plr.concat_lf(
@@ -587,17 +589,17 @@ def union(
             msg = f"LazyFrame `how` must be one of {{{allowed}}}, got {how!r}"
             raise ValueError(msg)
 
-    elif isinstance(first, pl.Series):
+    elif is_sequence_of(elems, pl.Series):
         if how == "vertical":
             out = wrap_s(plr.concat_series(elems))
         else:
             msg = "Series only supports 'vertical' concat strategy"
             raise ValueError(msg)
 
-    elif isinstance(first, pl.Expr):
+    elif is_sequence_of(elems, pl.Expr):
         return wrap_expr(plr.concat_expr([e._pyexpr for e in elems], False))
     else:
-        msg = f"did not expect type: {qualified_type_name(first)!r} in `concat`"
+        msg = f"did not expect type: {qualified_type_name(elems[0])!r} in `concat`"
         raise TypeError(msg)
 
     return out
@@ -668,7 +670,7 @@ def merge_sorted(
 
     The key must be sorted in ascending order.
     """
-    elems = list(items)
+    elems: Sequence[PolarsType] = list(items)
 
     if not elems:
         msg = "cannot merge_sort empty list"
@@ -676,7 +678,9 @@ def merge_sorted(
     if len(elems) == 1 and isinstance(elems[0], (pl.DataFrame, pl.LazyFrame)):
         return elems[0]
 
-    if not isinstance(elems[0], (pl.DataFrame, pl.LazyFrame)):
+    if not is_sequence_of(elems, pl.DataFrame) and not is_sequence_of(  # type: ignore[redundant-expr]
+        elems, pl.LazyFrame
+    ):
         msg = f"merge_sorted is not supported for {qualified_type_name(elems[0])!r}"
         raise TypeError(msg)
 

--- a/py-polars/src/polars/functions/eager.py
+++ b/py-polars/src/polars/functions/eager.py
@@ -11,7 +11,7 @@ from polars import functions as F
 from polars._typing import ConcatMethod
 from polars._utils.reduce_balanced import reduce_balanced
 from polars._utils.unstable import unstable
-from polars._utils.various import is_sequence_of, ordered_unique, qualified_type_name
+from polars._utils.various import is_non_empty_sequence_of, ordered_unique, qualified_type_name
 from polars._utils.wrap import wrap_df, wrap_expr, wrap_ldf, wrap_s
 from polars.exceptions import InvalidOperationError
 
@@ -182,7 +182,7 @@ def concat(
         return elems[0]
 
     if how.startswith("align"):
-        if not is_sequence_of(elems, pl.DataFrame) and not is_sequence_of(  # type: ignore[redundant-expr]
+        if not is_non_empty_sequence_of(elems, pl.DataFrame) and not is_non_empty_sequence_of(  # type: ignore[redundant-expr]
             elems, pl.LazyFrame
         ):
             msg = f"{how!r} strategy is not supported for {qualified_type_name(elems[0])!r}"
@@ -235,7 +235,7 @@ def concat(
 
     from polars.lazyframe.opt_flags import QueryOptFlags
 
-    if is_sequence_of(elems, pl.DataFrame):
+    if is_non_empty_sequence_of(elems, pl.DataFrame):
         if how == "vertical":
             out = wrap_df(plr.concat_df(elems))
         elif how == "vertical_relaxed":
@@ -268,7 +268,7 @@ def concat(
             msg = f"DataFrame `how` must be one of {{{allowed}}}, got {how!r}"
             raise ValueError(msg)
 
-    elif is_sequence_of(elems, pl.LazyFrame):
+    elif is_non_empty_sequence_of(elems, pl.LazyFrame):
         if how in ("vertical", "vertical_relaxed"):
             return wrap_ldf(
                 plr.concat_lf(
@@ -302,14 +302,14 @@ def concat(
             msg = f"LazyFrame `how` must be one of {{{allowed}}}, got {how!r}"
             raise ValueError(msg)
 
-    elif is_sequence_of(elems, pl.Series):
+    elif is_non_empty_sequence_of(elems, pl.Series):
         if how == "vertical":
             out = wrap_s(plr.concat_series(elems))
         else:
             msg = "Series only supports 'vertical' concat strategy"
             raise ValueError(msg)
 
-    elif is_sequence_of(elems, pl.Expr):
+    elif is_non_empty_sequence_of(elems, pl.Expr):
         return wrap_expr(plr.concat_expr([e._pyexpr for e in elems], rechunk))
     else:
         msg = f"did not expect type: {qualified_type_name(elems[0])!r} in `concat`"
@@ -474,7 +474,7 @@ def union(
         return elems[0]
 
     if how.startswith("align"):
-        if not is_sequence_of(elems, pl.DataFrame) and not is_sequence_of(  # type: ignore[redundant-expr]
+        if not is_non_empty_sequence_of(elems, pl.DataFrame) and not is_non_empty_sequence_of(  # type: ignore[redundant-expr]
             elems, pl.LazyFrame
         ):
             msg = f"{how!r} strategy is not supported for {qualified_type_name(elems[0])!r}"
@@ -527,7 +527,7 @@ def union(
 
     from polars.lazyframe.opt_flags import QueryOptFlags
 
-    if is_sequence_of(elems, pl.DataFrame):
+    if is_non_empty_sequence_of(elems, pl.DataFrame):
         if how in ("vertical", "vertical_relaxed"):
             out = wrap_ldf(
                 plr.concat_lf(
@@ -555,7 +555,7 @@ def union(
             msg = f"DataFrame `how` must be one of {{{allowed}}}, got {how!r}"
             raise ValueError(msg)
 
-    elif is_sequence_of(elems, pl.LazyFrame):
+    elif is_non_empty_sequence_of(elems, pl.LazyFrame):
         if how in ("vertical", "vertical_relaxed"):
             return wrap_ldf(
                 plr.concat_lf(
@@ -589,14 +589,14 @@ def union(
             msg = f"LazyFrame `how` must be one of {{{allowed}}}, got {how!r}"
             raise ValueError(msg)
 
-    elif is_sequence_of(elems, pl.Series):
+    elif is_non_empty_sequence_of(elems, pl.Series):
         if how == "vertical":
             out = wrap_s(plr.concat_series(elems))
         else:
             msg = "Series only supports 'vertical' concat strategy"
             raise ValueError(msg)
 
-    elif is_sequence_of(elems, pl.Expr):
+    elif is_non_empty_sequence_of(elems, pl.Expr):
         return wrap_expr(plr.concat_expr([e._pyexpr for e in elems], False))
     else:
         msg = f"did not expect type: {qualified_type_name(elems[0])!r} in `concat`"
@@ -678,7 +678,7 @@ def merge_sorted(
     if len(elems) == 1 and isinstance(elems[0], (pl.DataFrame, pl.LazyFrame)):
         return elems[0]
 
-    if not is_sequence_of(elems, pl.DataFrame) and not is_sequence_of(  # type: ignore[redundant-expr]
+    if not is_non_empty_sequence_of(elems, pl.DataFrame) and not is_non_empty_sequence_of(  # type: ignore[redundant-expr]
         elems, pl.LazyFrame
     ):
         msg = f"merge_sorted is not supported for {qualified_type_name(elems[0])!r}"

--- a/py-polars/src/polars/functions/lit.py
+++ b/py-polars/src/polars/functions/lit.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import enum
 from datetime import date, datetime, time, timedelta, timezone
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 from zoneinfo import ZoneInfo
 
 import polars._reexport as pl
@@ -152,6 +152,7 @@ def lit(
     elif isinstance(value, timedelta):
         value_s = pl.Series("literal", [value])
         if dtype is not None and (tu := getattr(dtype, "time_unit", None)) is not None:
+            tu = cast("TimeUnit", tu)
             value_s = value_s.cast(Duration(tu))
         expr = wrap_expr(plr.lit(value_s._s, allow_object=False, is_scalar=True))
         return expr


### PR DESCRIPTION
Split off from #27722

This addresses two comments:
- https://github.com/pola-rs/polars/pull/27722#discussion_r3317198146: I've used `NoDefault` as that's already defined
- https://github.com/pola-rs/polars/pull/27722#discussion_r3317212825: I don't know if this will get fixed upstream any time soon (or at all?) so i've just used `type: ignore[redundant-expr]`

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
