### PR TITLE
feat(rust): Add pinning and queuing logic to polars-ooc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3393,13 +3393,16 @@ dependencies = [
 name = "polars-ooc"
 version = "0.53.0"
 dependencies = [
+ "async-trait",
  "boxcar",
  "libc",
  "mimalloc",
+ "polars-async",
  "polars-config",
  "polars-core",
  "polars-io",
  "polars-utils",
+ "thread_local",
  "tikv-jemallocator",
  "tokio",
 ]
@@ -5033,6 +5036,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.116",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ streaming-iterator = "0.1.9"
 strength_reduce = "0.2"
 strum = "0.27"
 strum_macros = "0.27"
+thread_local = "1.1.9"
 tokio = { version = "1.44", default-features = false }
 unicode-normalization = "0.1.24"
 unicode-reverse = "1.0.8"

--- a/crates/polars-ooc/Cargo.toml
+++ b/crates/polars-ooc/Cargo.toml
@@ -9,12 +9,15 @@ repository.workspace = true
 description = "Out-of-core processing support for Polars"
 
 [dependencies]
+async-trait = { workspace = true }
 boxcar = { workspace = true }
 libc = { workspace = true }
+polars-async = { workspace = true }
 polars-config = { workspace = true }
 polars-core = { workspace = true, features = ["algorithm_group_by"] }
 polars-io = { workspace = true, features = ["ipc"] }
 polars-utils = { workspace = true, features = ["sysinfo"] }
+thread_local = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 
 [target.'cfg(any(not(target_family = "unix"), target_os = "emscripten"))'.dependencies]

--- a/crates/polars-ooc/src/lib.rs
+++ b/crates/polars-ooc/src/lib.rs
@@ -79,7 +79,7 @@ impl<T: Spillable> SpillTokenInner<T> {
     }
 
     /// Wakes any waiters.
-    /// 
+    ///
     /// Should be called with the state after performing any updates that waiters
     /// could be waiting for (e.g. the pin count reaches 0 or the lock gets released).
     #[inline(always)]

--- a/crates/polars-ooc/src/lib.rs
+++ b/crates/polars-ooc/src/lib.rs
@@ -8,87 +8,430 @@ mod spill_frame;
 
 use std::cell::UnsafeCell;
 use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::task::{Poll, Waker};
 
 pub use global_alloc::{Allocator, estimate_memory_usage};
 pub use memory_manager::memory_manager;
+use polars_async::ASYNC;
+use polars_utils::UnitVec;
+use polars_utils::with_drop::WithDrop;
 pub use spill_context::{
     LeastRecentSpillContext, MostRecentSpillContext, ParameterFreeSpillContext, RandomSpillContext,
     SpillContext,
 };
 pub use spill_frame::SpillFrame;
 
-struct SpillTokenInner<T> {
-    // One-to-one with the SpillToken (which isn't Clone).
+// SpillTokenInner's state
+const SPILLED_BIT: u64 = 1; // Set when value = None and spilled is Some.
+const DROPPED_BIT: u64 = 2; // Set when the token owner has dropped. Forbids creation of new pins / lock.
+const LOCK_BIT: u64 = 4; // When set no new pins may be made, and at most 1 thread may set this bit.
+const HAS_WAITERS_BIT: u64 = 8; // Only updated while holding waiters lock.
+const RO_PIN_COUNT_UNIT: u64 = 16; // Added to the state for each active pin.
+const RO_PIN_MASK: u64 = u64::MAX << 4;
+
+struct SpillTokenInner<T: Spillable> {
+    // May be read if holding LOCK_BIT or a pin, may be written while holding
+    // LOCK_BIT and no pins exist.
     value: UnsafeCell<Option<T>>,
+
+    // May be read+written while holding LOCK_BIT (irrespective of pins).
+    spilled: UnsafeCell<Option<T::Spilled>>,
+
+    // Lock should not be held for long, only used to register/wake waiters.
+    waiters: Mutex<UnitVec<Waker>>,
+
+    // Used to register into contexts, and detect when a token has moved to a
+    // different context.
+    registration_id: AtomicU64,
+
+    // See above.
+    state: AtomicU64,
 }
 
-unsafe impl<T: Send> Send for SpillTokenInner<T> {}
-unsafe impl<T: Sync> Sync for SpillTokenInner<T> {}
+unsafe impl<T: Spillable + Send> Send for SpillTokenInner<T> {}
+unsafe impl<T: Spillable + Sync> Sync for SpillTokenInner<T> {}
 
-trait DynSpillToken {}
+impl<T: Spillable> SpillTokenInner<T> {
+    /// Waits until the state & mask is zero, returning the state.
+    async fn wait(&self, mask: u64) -> u64 {
+        std::future::poll_fn(|ctx| {
+            // Check mask while holding waiter lock to avoid missed notifications.
+            let mut waiters = self.waiters.lock().unwrap();
+            let mut state = self.state.load(Ordering::Acquire);
+            if state & mask != 0 {
+                if state & HAS_WAITERS_BIT == 0 {
+                    state = self.state.fetch_add(HAS_WAITERS_BIT, Ordering::Acquire);
+                    if state & mask == 0 {
+                        self.state.fetch_sub(HAS_WAITERS_BIT, Ordering::Relaxed);
+                        return Poll::Ready(state);
+                    }
+                }
+                waiters.push(ctx.waker().clone());
+                Poll::Pending
+            } else {
+                Poll::Ready(state)
+            }
+        })
+        .await
+    }
 
-impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {}
+    #[inline(always)]
+    fn wake_waiters(&self, state: u64) {
+        if state & HAS_WAITERS_BIT != 0 {
+            self.wake_waiters_slow();
+        }
+    }
+
+    #[inline(never)]
+    #[cold]
+    fn wake_waiters_slow(&self) {
+        // Modify HAS_WAITERS_BIT only while holding the lock. Don't notify
+        // while holding the lock to reduce critical section.
+        let mut waiters_lock = self.waiters.lock().unwrap();
+        let waiters = core::mem::take(&mut *waiters_lock);
+        self.state.fetch_sub(HAS_WAITERS_BIT, Ordering::Relaxed);
+        drop(waiters_lock);
+
+        for w in waiters {
+            w.wake();
+        }
+    }
+
+    // Try to pin the value, returning None if it is spilled, locked or dropped.
+    fn try_pin(&self) -> Option<PinnedRef<'_, T>> {
+        self.state
+            .try_update(Ordering::Relaxed, Ordering::Acquire, |state| {
+                if state & (SPILLED_BIT | LOCK_BIT | DROPPED_BIT) != 0 {
+                    return None;
+                }
+                Some(state + RO_PIN_COUNT_UNIT)
+            })
+            .ok()
+            .map(|_| PinnedRef { inner: self })
+    }
+
+    // Pin the value, grabbing the lock if it is spilled.
+    //
+    // If the value is locked this will wait for the lock.
+    async fn pin_or_lock(&self) -> Option<PinnedRef<'_, T>> {
+        let mut state = self.state.load(Ordering::Acquire);
+        loop {
+            if state & (SPILLED_BIT | LOCK_BIT | DROPPED_BIT) == 0 {
+                match self.state.compare_exchange_weak(
+                    state,
+                    state + RO_PIN_COUNT_UNIT,
+                    Ordering::Relaxed,
+                    Ordering::Acquire,
+                ) {
+                    Ok(_) => return Some(PinnedRef { inner: self }),
+                    Err(s) => state = s,
+                }
+            } else if state & (LOCK_BIT | DROPPED_BIT) == 0 {
+                match self.state.compare_exchange_weak(
+                    state,
+                    state | LOCK_BIT,
+                    Ordering::Relaxed,
+                    Ordering::Acquire,
+                ) {
+                    Ok(_) => return None,
+                    Err(s) => state = s,
+                }
+            } else {
+                assert!(state & DROPPED_BIT == 0);
+                state = self.wait(LOCK_BIT).await;
+            }
+        }
+    }
+
+    // Locks the (possibly spilled) value, waiting until it's neither pinned or locked.
+    async fn lock(&self) {
+        let mut state = self.state.load(Ordering::Acquire);
+        loop {
+            if state & (LOCK_BIT | RO_PIN_MASK | DROPPED_BIT) == 0 {
+                match self.state.compare_exchange_weak(
+                    state,
+                    state | LOCK_BIT,
+                    Ordering::Relaxed,
+                    Ordering::Acquire,
+                ) {
+                    Ok(_) => return,
+                    Err(s) => state = s,
+                }
+            } else {
+                assert!(state & DROPPED_BIT == 0);
+                state = self.wait(LOCK_BIT | RO_PIN_MASK).await;
+            }
+        }
+    }
+
+    async fn pin(&self) -> PinnedRef<'_, T> {
+        if let Some(r) = self.try_pin() {
+            return r;
+        }
+
+        std::hint::cold_path();
+
+        if let Some(r) = self.pin_or_lock().await {
+            return r;
+        }
+
+        // We now hold the lock, meaning the value was spilled.
+        unsafe {
+            debug_assert!(
+                self.state.load(Ordering::Relaxed) & (SPILLED_BIT | LOCK_BIT)
+                    == (SPILLED_BIT | LOCK_BIT)
+            );
+            let lock_guard = WithDrop::new(self, |slf| {
+                slf.wake_waiters(slf.state.fetch_and(!LOCK_BIT, Ordering::AcqRel));
+            });
+            // TODO: re-register unspilled frame?
+            let spilled = (*self.spilled.get()).as_ref().unwrap();
+            let value = T::unspill(spilled).await;
+            self.value.get().write(Some(value));
+
+            WithDrop::dismiss(lock_guard);
+            self.wake_waiters(
+                self.state
+                    .fetch_add(RO_PIN_COUNT_UNIT - LOCK_BIT - SPILLED_BIT, Ordering::AcqRel),
+            );
+            PinnedRef { inner: self }
+        }
+    }
+
+    fn pin_blocking(&self) -> PinnedRef<'_, T> {
+        if let Some(r) = self.try_pin() {
+            return r;
+        }
+
+        std::hint::cold_path();
+
+        ASYNC.block_in_place_on(self.pin())
+    }
+
+    async fn pin_mut(&self) -> PinnedMut<'_, T> {
+        unsafe {
+            self.lock().await;
+            let lock_guard = WithDrop::new(self, |slf| {
+                slf.wake_waiters(slf.state.fetch_and(!LOCK_BIT, Ordering::AcqRel));
+            });
+
+            let value = &mut *self.value.get();
+            if value.is_none() {
+                debug_assert!(self.state.load(Ordering::Relaxed) & SPILLED_BIT == SPILLED_BIT);
+                // TODO: re-register unspilled frame?
+                let spilled = (*self.spilled.get()).take().unwrap();
+                *value = Some(T::unspill(&spilled).await);
+                self.state.fetch_sub(SPILLED_BIT, Ordering::Relaxed);
+            } else {
+                // We are about to mutate, making our current spill invalid.
+                *self.spilled.get() = None;
+            }
+
+            WithDrop::dismiss(lock_guard);
+            PinnedMut { inner: self }
+        }
+    }
+
+    fn pin_mut_blocking(&self) -> PinnedMut<'_, T> {
+        ASYNC.block_in_place_on(self.pin_mut())
+    }
+
+    /// # Safety
+    /// May only be called if you currently hold a pin.
+    unsafe fn unpin(&self) {
+        let old_s = self.state.fetch_sub(RO_PIN_COUNT_UNIT, Ordering::AcqRel);
+        if old_s & RO_PIN_MASK == RO_PIN_COUNT_UNIT {
+            self.wake_waiters(old_s);
+        }
+    }
+
+    /// # Safety
+    /// May only be called if you currently hold a mutable pin.
+    unsafe fn unpin_mut(&self) {
+        self.wake_waiters(self.state.fetch_sub(LOCK_BIT, Ordering::AcqRel));
+    }
+
+    unsafe fn mark_as_dropped(&self) {
+        unsafe {
+            // The drop bit prevents new locks/pins from being acquired,
+            // allowing us to clean up here.
+            let old_state = self.state.fetch_or(DROPPED_BIT, Ordering::AcqRel);
+            if old_state & (LOCK_BIT | RO_PIN_MASK) == 0 {
+                self.value.get().replace(None);
+                self.spilled.get().replace(None);
+            }
+            self.registration_id.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+trait DynSpillToken: Send + Sync + 'static {
+    /// Assign a new context ID to this spill token, invalidating previous ids.
+    fn new_registration_id(&self) -> u64;
+
+    /// Returns the current context ID of this spill token without modifying it.
+    fn current_registration_id(&self) -> u64;
+
+    /// Whether this token can be spilled. Returns false if pinned, dropped or
+    /// already spilled.
+    #[expect(unused)]
+    fn can_spill(&self) -> bool;
+
+    /// Estimates how many bytes this object takes up in memory. Returns None
+    /// if the object is spilled or dropped.
+    #[expect(unused)]
+    fn estimate_byte_size(&self) -> Option<usize>;
+
+    /// Tries to spill this token. Returns true if successful.
+    ///
+    /// May return false if the token is already spilled, or is currently pinned.
+    /// It may also return None in those cases (to avoid the allocation of the future).
+    #[expect(unused)]
+    fn try_spill(&self) -> Option<Pin<Box<dyn Future<Output = bool> + Send + '_>>>;
+}
+
+impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
+    fn new_registration_id(&self) -> u64 {
+        self.registration_id.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    fn current_registration_id(&self) -> u64 {
+        self.registration_id.load(Ordering::Relaxed)
+    }
+
+    fn can_spill(&self) -> bool {
+        self.state.load(Ordering::Acquire) & (SPILLED_BIT | DROPPED_BIT | LOCK_BIT | RO_PIN_MASK)
+            == 0
+    }
+
+    fn estimate_byte_size(&self) -> Option<usize> {
+        self.try_pin().map(|p| p.estimate_byte_size())
+    }
+
+    fn try_spill(&self) -> Option<Pin<Box<dyn Future<Output = bool> + Send + '_>>> {
+        // First, we try pinning it while setting the lock bit. If anyone else
+        // has a pin we don't bother.
+        let pin_update = self
+            .state
+            .try_update(Ordering::Relaxed, Ordering::Acquire, |state| {
+                if state & (SPILLED_BIT | LOCK_BIT | DROPPED_BIT | RO_PIN_MASK) != 0 {
+                    return None;
+                }
+                Some(state + RO_PIN_COUNT_UNIT + LOCK_BIT)
+            });
+        if pin_update.is_err() {
+            return None;
+        }
+
+        Some(Box::pin(async {
+            let needs_spill = unsafe { (*self.spilled.get()).is_none() };
+            let has_exclusive_pin = if needs_spill {
+                // Drop the lock while spilling such that new pins can come in.
+                // After all, we still have it in memory right now.
+                self.wake_waiters(self.state.fetch_and(!LOCK_BIT, Ordering::AcqRel));
+                let pin_guard = PinnedRef { inner: self };
+                let spilled = pin_guard.spill().await;
+                core::mem::forget(pin_guard);
+                // We can simply re-acquire the lock here blindly, as we still hold
+                // our pin meaning no one else could've gotten the lock.
+                let state = self.state.fetch_add(LOCK_BIT, Ordering::Acquire);
+                unsafe {
+                    self.spilled.get().write(Some(spilled));
+                }
+                state & RO_PIN_MASK == RO_PIN_COUNT_UNIT
+            } else {
+                true
+            };
+
+            let state = if has_exclusive_pin {
+                // We are the only pin and hold the lock meaning no one else can
+                // access value or create new pins.
+                unsafe { self.value.get().replace(None) };
+                self.state.fetch_add(
+                    SPILLED_BIT.wrapping_sub(LOCK_BIT + RO_PIN_COUNT_UNIT),
+                    Ordering::AcqRel,
+                )
+            } else {
+                self.state
+                    .fetch_sub(LOCK_BIT + RO_PIN_COUNT_UNIT, Ordering::AcqRel)
+            };
+            self.wake_waiters(state);
+
+            has_exclusive_pin
+        }))
+    }
+}
 
 /// A token representing a possibly spilled object T.
-pub struct SpillToken<T> {
+pub struct SpillToken<T: Spillable> {
     inner: Arc<SpillTokenInner<T>>,
 }
 
-impl<T> SpillToken<T> {
+impl<T: Spillable> SpillToken<T> {
     /// Creates a new SpillToken containing the given value.
     pub fn new(value: T) -> Self {
         let inner = Arc::new(SpillTokenInner {
             value: UnsafeCell::new(Some(value)),
+            spilled: UnsafeCell::new(None),
+            registration_id: AtomicU64::new(0),
+            state: AtomicU64::new(0),
+            waiters: Mutex::default(),
         });
         Self { inner }
     }
 
     /// Try to get a reference to the underlying value, returning None if it was spilled.
     pub fn try_get(&self) -> Option<PinnedRef<'_, T>> {
-        Some(PinnedRef { inner: &self.inner })
+        self.inner.try_pin()
     }
 
     /// Get a reference to the underlying value, unspilling it if it was spilled.
     pub async fn get(&self) -> PinnedRef<'_, T> {
-        // TODO @ ooc: need to despill, track pin count.
-        PinnedRef { inner: &self.inner }
+        self.inner.pin().await
     }
 
     /// Blocking version of get.
     pub fn get_blocking(&self) -> PinnedRef<'_, T> {
-        // TODO @ ooc: need to despill, track pin count.
-        PinnedRef { inner: &self.inner }
+        self.inner.pin_blocking()
     }
 
     /// Get a mutable reference to the underlying value, unspilling it if it was spilled.
     pub async fn get_mut(&mut self) -> PinnedMut<'_, T> {
-        // TODO @ ooc: need to despill, track pin count.
-        PinnedMut { inner: &self.inner }
+        self.inner.pin_mut().await
     }
 
     /// Blocking version of get_mut.
     pub fn get_mut_blocking(&mut self) -> PinnedMut<'_, T> {
-        // TODO @ ooc: need to despill, track pin count.
-        PinnedMut { inner: &self.inner }
+        self.inner.pin_mut_blocking()
     }
 
     /// Consumes this SpillToken, unspilling it if it were spilled.
-    pub async fn into_inner(self) -> T {
-        unsafe { &mut *self.inner.value.get() }.take().unwrap()
+    pub async fn into_inner(mut self) -> T {
+        let pin = self.get_mut().await;
+        unsafe { &mut *pin.inner.value.get() }.take().unwrap()
     }
 
     /// Blocking version of into_inner.
-    pub fn into_inner_blocking(self) -> T {
-        unsafe { &mut *self.inner.value.get() }.take().unwrap()
+    pub fn into_inner_blocking(mut self) -> T {
+        let pin = self.get_mut_blocking();
+        unsafe { &mut *pin.inner.value.get() }.take().unwrap()
     }
 }
 
-pub struct PinnedRef<'a, T> {
+impl<T: Spillable> Drop for SpillToken<T> {
+    fn drop(&mut self) {
+        unsafe { self.inner.mark_as_dropped() };
+    }
+}
+
+pub struct PinnedRef<'a, T: Spillable> {
     inner: &'a SpillTokenInner<T>,
 }
 
-impl<'a, T> Deref for PinnedRef<'a, T> {
+impl<'a, T: Spillable> Deref for PinnedRef<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -96,11 +439,17 @@ impl<'a, T> Deref for PinnedRef<'a, T> {
     }
 }
 
-pub struct PinnedMut<'a, T> {
+impl<'a, T: Spillable> Drop for PinnedRef<'a, T> {
+    fn drop(&mut self) {
+        unsafe { self.inner.unpin() }
+    }
+}
+
+pub struct PinnedMut<'a, T: Spillable> {
     inner: &'a SpillTokenInner<T>,
 }
 
-impl<'a, T> Deref for PinnedMut<'a, T> {
+impl<'a, T: Spillable> Deref for PinnedMut<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -108,10 +457,27 @@ impl<'a, T> Deref for PinnedMut<'a, T> {
     }
 }
 
-impl<'a, T> DerefMut for PinnedMut<'a, T> {
+impl<'a, T: Spillable> DerefMut for PinnedMut<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { &mut *self.inner.value.get() }.as_mut().unwrap()
     }
 }
 
-pub trait Spillable {}
+impl<'a, T: Spillable> Drop for PinnedMut<'a, T> {
+    fn drop(&mut self) {
+        unsafe { self.inner.unpin_mut() }
+    }
+}
+
+pub trait Spillable: Send + Sync + 'static {
+    type Spilled;
+
+    /// Estimates how many bytes this object takes up in memory.
+    fn estimate_byte_size(&self) -> usize;
+
+    /// Spills this value, returning a spilled representation.
+    fn spill(&self) -> impl Future<Output = Self::Spilled> + Send;
+
+    /// Given a previously spilled representation
+    fn unspill(location: &Self::Spilled) -> impl Future<Output = Self> + Send;
+}

--- a/crates/polars-ooc/src/lib.rs
+++ b/crates/polars-ooc/src/lib.rs
@@ -63,7 +63,7 @@ impl<T: Spillable> SpillTokenInner<T> {
             let mut state = self.state.load(Ordering::Acquire);
             if state & mask != 0 {
                 if state & HAS_WAITERS_BIT == 0 {
-                    state = self.state.fetch_add(HAS_WAITERS_BIT, Ordering::Acquire);
+                    state = self.state.fetch_add(HAS_WAITERS_BIT, Ordering::AcqRel);
                     if state & mask == 0 {
                         self.state.fetch_sub(HAS_WAITERS_BIT, Ordering::Relaxed);
                         return Poll::Ready(state);

--- a/crates/polars-ooc/src/lib.rs
+++ b/crates/polars-ooc/src/lib.rs
@@ -312,15 +312,14 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
     }
 
     fn try_spill(&self) -> Option<Pin<Box<dyn Future<Output = bool> + Send + '_>>> {
-        // First, we try pinning it while setting the lock bit. If anyone else
-        // has a pin we don't bother.
+        // First, we try setting the lock bit. If anyone else has a pin we don't bother.
         let pin_update = self
             .state
             .try_update(Ordering::Relaxed, Ordering::Acquire, |state| {
                 if state & (SPILLED_BIT | LOCK_BIT | DROPPED_BIT | RO_PIN_MASK) != 0 {
                     return None;
                 }
-                Some(state + RO_PIN_COUNT_UNIT + LOCK_BIT)
+                Some(state | LOCK_BIT)
             });
         if pin_update.is_err() {
             return None;
@@ -328,39 +327,41 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
 
         Some(Box::pin(async {
             let needs_spill = unsafe { (*self.spilled.get()).is_none() };
-            let has_exclusive_pin = if needs_spill {
-                // Drop the lock while spilling such that new pins can come in.
-                // After all, we still have it in memory right now.
-                self.wake_waiters(self.state.fetch_and(!LOCK_BIT, Ordering::AcqRel));
+            let is_exclusive = if needs_spill {
+                // Relax the lock to a pin while spilling such that new pins can
+                // come in. After all, we still have it in memory right now.
+                self.wake_waiters(
+                    self.state
+                        .fetch_add(RO_PIN_COUNT_UNIT - LOCK_BIT, Ordering::AcqRel),
+                );
                 let pin_guard = PinnedRef { inner: self };
                 let spilled = pin_guard.spill().await;
                 core::mem::forget(pin_guard);
                 // We can simply re-acquire the lock here blindly, as we still hold
                 // our pin meaning no one else could've gotten the lock.
-                let state = self.state.fetch_add(LOCK_BIT, Ordering::Acquire);
+                let old_state = self
+                    .state
+                    .fetch_add(LOCK_BIT.wrapping_sub(RO_PIN_COUNT_UNIT), Ordering::Acquire);
                 unsafe {
                     self.spilled.get().write(Some(spilled));
                 }
-                state & RO_PIN_MASK == RO_PIN_COUNT_UNIT
+                old_state & RO_PIN_MASK == RO_PIN_COUNT_UNIT
             } else {
                 true
             };
 
-            let state = if has_exclusive_pin {
+            let state = if is_exclusive {
                 // We are the only pin and hold the lock meaning no one else can
                 // access value or create new pins.
                 unsafe { self.value.get().replace(None) };
-                self.state.fetch_add(
-                    SPILLED_BIT.wrapping_sub(LOCK_BIT + RO_PIN_COUNT_UNIT),
-                    Ordering::AcqRel,
-                )
-            } else {
                 self.state
-                    .fetch_sub(LOCK_BIT + RO_PIN_COUNT_UNIT, Ordering::AcqRel)
+                    .fetch_add(SPILLED_BIT.wrapping_sub(LOCK_BIT), Ordering::AcqRel)
+            } else {
+                self.state.fetch_sub(LOCK_BIT, Ordering::AcqRel)
             };
             self.wake_waiters(state);
 
-            has_exclusive_pin
+            is_exclusive
         }))
     }
 }

--- a/crates/polars-ooc/src/lib.rs
+++ b/crates/polars-ooc/src/lib.rs
@@ -103,7 +103,7 @@ impl<T: Spillable> SpillTokenInner<T> {
     // Try to pin the value, returning None if it is spilled, locked or dropped.
     fn try_pin(&self) -> Option<PinnedRef<'_, T>> {
         self.state
-            .try_update(Ordering::Relaxed, Ordering::Acquire, |state| {
+            .try_update(Ordering::Acquire, Ordering::Relaxed, |state| {
                 if state & (SPILLED_BIT | LOCK_BIT | DROPPED_BIT) != 0 {
                     return None;
                 }
@@ -117,24 +117,24 @@ impl<T: Spillable> SpillTokenInner<T> {
     //
     // If the value is locked this will wait for the lock.
     async fn pin_or_lock(&self) -> Option<PinnedRef<'_, T>> {
-        let mut state = self.state.load(Ordering::Acquire);
+        let mut state = self.state.load(Ordering::Relaxed);
         loop {
             if state & (SPILLED_BIT | LOCK_BIT | DROPPED_BIT) == 0 {
                 match self.state.compare_exchange_weak(
                     state,
                     state + RO_PIN_COUNT_UNIT,
-                    Ordering::Relaxed,
                     Ordering::Acquire,
+                    Ordering::Relaxed,
                 ) {
                     Ok(_) => return Some(PinnedRef { inner: self }),
                     Err(s) => state = s,
                 }
-            } else if state & (LOCK_BIT | DROPPED_BIT) == 0 {
+            } else if state & (LOCK_BIT | RO_PIN_MASK | DROPPED_BIT) == 0 {
                 match self.state.compare_exchange_weak(
                     state,
                     state | LOCK_BIT,
-                    Ordering::Relaxed,
                     Ordering::Acquire,
+                    Ordering::Relaxed,
                 ) {
                     Ok(_) => return None,
                     Err(s) => state = s,
@@ -148,14 +148,14 @@ impl<T: Spillable> SpillTokenInner<T> {
 
     // Locks the (possibly spilled) value, waiting until it's neither pinned or locked.
     async fn lock(&self) {
-        let mut state = self.state.load(Ordering::Acquire);
+        let mut state = self.state.load(Ordering::Relaxed);
         loop {
             if state & (LOCK_BIT | RO_PIN_MASK | DROPPED_BIT) == 0 {
                 match self.state.compare_exchange_weak(
                     state,
                     state | LOCK_BIT,
-                    Ordering::Relaxed,
                     Ordering::Acquire,
+                    Ordering::Relaxed,
                 ) {
                     Ok(_) => return,
                     Err(s) => state = s,

--- a/crates/polars-ooc/src/lib.rs
+++ b/crates/polars-ooc/src/lib.rs
@@ -78,6 +78,10 @@ impl<T: Spillable> SpillTokenInner<T> {
         .await
     }
 
+    /// Wakes any waiters.
+    /// 
+    /// Should be called with the state after performing any updates that waiters
+    /// could be waiting for (e.g. the pin count reaches 0 or the lock gets released).
     #[inline(always)]
     fn wake_waiters(&self, state: u64) {
         if state & HAS_WAITERS_BIT != 0 {
@@ -181,7 +185,7 @@ impl<T: Spillable> SpillTokenInner<T> {
         // We now hold the lock, meaning the value was spilled.
         unsafe {
             debug_assert!(
-                self.state.load(Ordering::Relaxed) & (SPILLED_BIT | LOCK_BIT)
+                self.state.load(Ordering::Relaxed) & (SPILLED_BIT | LOCK_BIT | RO_PIN_MASK)
                     == (SPILLED_BIT | LOCK_BIT)
             );
             let lock_guard = WithDrop::new(self, |slf| {
@@ -258,7 +262,7 @@ impl<T: Spillable> SpillTokenInner<T> {
         unsafe {
             // The drop bit prevents new locks/pins from being acquired,
             // allowing us to clean up here.
-            let old_state = self.state.fetch_or(DROPPED_BIT, Ordering::AcqRel);
+            let old_state = self.state.fetch_or(DROPPED_BIT, Ordering::Acquire);
             if old_state & (LOCK_BIT | RO_PIN_MASK) == 0 {
                 self.value.get().replace(None);
                 self.spilled.get().replace(None);

--- a/crates/polars-ooc/src/spill_context.rs
+++ b/crates/polars-ooc/src/spill_context.rs
@@ -1,7 +1,65 @@
+use std::collections::VecDeque;
 use std::fmt::Debug;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock, Weak};
+
+use thread_local::ThreadLocal;
 
 use crate::{DynSpillToken, SpillToken, SpillTokenInner, Spillable, memory_manager};
+
+#[derive(Default)]
+struct LocalSpillQueue {
+    tokens: VecDeque<(Weak<dyn DynSpillToken>, u64)>,
+    retain_amort: usize,
+}
+
+impl LocalSpillQueue {
+    pub fn push_back(&mut self, token: &Arc<dyn DynSpillToken>, id: u64) {
+        self.gc();
+        self.tokens.push_front((Arc::downgrade(token), id));
+    }
+
+    #[expect(unused)]
+    pub fn push_front(&mut self, token: &Arc<dyn DynSpillToken>, id: u64) {
+        self.gc();
+        self.tokens.push_front((Arc::downgrade(token), id));
+    }
+
+    #[expect(unused)]
+    pub fn pop_front(&mut self) -> Option<Arc<dyn DynSpillToken>> {
+        loop {
+            let (weak, id) = self.tokens.pop_front()?;
+            if let Some(token) = weak.upgrade()
+                && token.current_registration_id() == id
+            {
+                return Some(token);
+            }
+        }
+    }
+
+    #[expect(unused)]
+    pub fn pop_back(&mut self) -> Option<Arc<dyn DynSpillToken>> {
+        loop {
+            let (weak, id) = self.tokens.pop_back()?;
+            if let Some(token) = weak.upgrade()
+                && token.current_registration_id() == id
+            {
+                return Some(token);
+            }
+        }
+    }
+
+    fn gc(&mut self) {
+        self.retain_amort += 2; // Grows twice as fast as push.
+        if self.retain_amort >= self.tokens.len() {
+            self.retain_amort = 0;
+            self.tokens.retain(|(token, id)| {
+                token
+                    .upgrade()
+                    .is_some_and(|t| t.current_registration_id() == *id)
+            });
+        }
+    }
+}
 
 pub trait SpillContext: Send + Sync + 'static {}
 
@@ -13,11 +71,15 @@ pub trait ParameterFreeSpillContext {
 }
 
 /// A context that spills the most-recently registered spillable when asked.
-pub struct MostRecentSpillContext {}
+pub struct MostRecentSpillContext {
+    local: ThreadLocal<RwLock<LocalSpillQueue>>,
+}
 
 impl MostRecentSpillContext {
     pub fn new() -> Arc<Self> {
-        let slf = Arc::new(Self {});
+        let slf = Arc::new(Self {
+            local: ThreadLocal::default(),
+        });
         memory_manager().register_ctx(&slf);
         slf
     }
@@ -32,8 +94,8 @@ impl ParameterFreeSpillContext for MostRecentSpillContext {
         let token: &SpillToken<S> = token.as_ref();
         let inner: Arc<SpillTokenInner<S>> = token.inner.clone();
         let inner: Arc<dyn DynSpillToken> = inner;
-        let _ = inner;
-        // TODO @ ooc
+        let mut local = self.local.get_or_default().write().unwrap();
+        local.push_back(&inner, inner.new_registration_id());
     }
 }
 
@@ -46,11 +108,15 @@ impl Debug for MostRecentSpillContext {
 }
 
 /// A context that spills the least-recently registered spillable when asked.
-pub struct LeastRecentSpillContext {}
+pub struct LeastRecentSpillContext {
+    local: ThreadLocal<RwLock<LocalSpillQueue>>,
+}
 
 impl LeastRecentSpillContext {
     pub fn new() -> Arc<Self> {
-        let slf = Arc::new(Self {});
+        let slf = Arc::new(Self {
+            local: ThreadLocal::default(),
+        });
         memory_manager().register_ctx(&slf);
         slf
     }
@@ -65,8 +131,8 @@ impl ParameterFreeSpillContext for LeastRecentSpillContext {
         let token: &SpillToken<S> = token.as_ref();
         let inner: Arc<SpillTokenInner<S>> = token.inner.clone();
         let inner: Arc<dyn DynSpillToken> = inner;
-        let _ = inner;
-        // TODO @ ooc
+        let mut local = self.local.get_or_default().write().unwrap();
+        local.push_back(&inner, inner.new_registration_id());
     }
 }
 
@@ -79,11 +145,15 @@ impl Debug for LeastRecentSpillContext {
 }
 
 /// A context that spills a random registered spillable when asked.
-pub struct RandomSpillContext {}
+pub struct RandomSpillContext {
+    local: ThreadLocal<RwLock<LocalSpillQueue>>,
+}
 
 impl RandomSpillContext {
     pub fn new() -> Arc<Self> {
-        let slf = Arc::new(Self {});
+        let slf = Arc::new(Self {
+            local: ThreadLocal::default(),
+        });
         memory_manager().register_ctx(&slf);
         slf
     }
@@ -98,8 +168,8 @@ impl ParameterFreeSpillContext for RandomSpillContext {
         let token: &SpillToken<S> = token.as_ref();
         let inner: Arc<SpillTokenInner<S>> = token.inner.clone();
         let inner: Arc<dyn DynSpillToken> = inner;
-        let _ = inner;
-        // TODO @ ooc
+        let mut local = self.local.get_or_default().write().unwrap();
+        local.push_back(&inner, inner.new_registration_id());
     }
 }
 

--- a/crates/polars-ooc/src/spill_frame.rs
+++ b/crates/polars-ooc/src/spill_frame.rs
@@ -6,7 +6,22 @@ use polars_core::frame::DataFrame;
 use crate::spill_context::ParameterFreeSpillContext;
 use crate::{PinnedMut, PinnedRef, SpillToken, Spillable, memory_manager};
 
-impl Spillable for DataFrame {}
+impl Spillable for DataFrame {
+    // TODO: just a dummy spill for now. Boxed to reduce size.
+    type Spilled = Box<DataFrame>;
+
+    fn estimate_byte_size(&self) -> usize {
+        self.estimated_size()
+    }
+
+    async fn spill(&self) -> Self::Spilled {
+        Box::new(self.clone())
+    }
+
+    async fn unspill(location: &Self::Spilled) -> Self {
+        (**location).clone()
+    }
+}
 
 pub struct SpillFrame {
     token: SpillToken<DataFrame>,


### PR DESCRIPTION
Part of the out-of-core infrastructure, this allows us to keep track of when a `SpillFrame` is being accessed or not, and to allow for iteration over all available `SpillFrame`s through contexts to select an appropriate one for spilling.