### PR TITLE
docs: Broken link to AI Policy corrected

### DIFF
--- a/docs/source/development/contributing/index.md
+++ b/docs/source/development/contributing/index.md
@@ -309,7 +309,7 @@ in the Polars repository. Please adhere to the following guidelines:
     - Explicitly state that you yourself have reviewed *all* changes in your pull request, and believe
       that they are relevant and correct.
     - Not try to solve an issue marked as "good first issue".
-    - Adhere to the rest of our [AI policy](/AI_POLICY.md).
+    - Adhere to the rest of our [AI policy](https://github.com/pola-rs/polars/blob/main/AI_POLICY.md).
   If you fail either requirement the maintainer may simply close your pull request.
 <!-- dprint-ignore-end -->
 


### PR DESCRIPTION
The AI Policy in the documentation pointed to a local file at the repo root called 'AI_Policy.md' which is not present in the doc builder root. It has been made to point at the GitHub URL which hosts the latest version of this file on the main branch.

Closes #27792 

As a first time contributor, here is a screenshot of me successfully running the tests locally:
<img width="941" height="964" alt="image" src="https://github.com/user-attachments/assets/73ad9819-257b-43da-a38a-3a533fbe0c8d" />

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
