### PR TITLE
fix: Update to new jemalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5035,8 +5035,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
-source = "git+https://github.com/pola-rs/jemallocator?rev=c7991e5bb6b3e9f79db6b0f48dcda67c5c3d2936#c7991e5bb6b3e9f79db6b0f48dcda67c5c3d2936"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
 dependencies = [
  "cc",
  "libc",
@@ -5044,8 +5045,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.6.0"
-source = "git+https://github.com/pola-rs/jemallocator?rev=c7991e5bb6b3e9f79db6b0f48dcda67c5c3d2936#c7991e5bb6b3e9f79db6b0f48dcda67c5c3d2936"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,6 @@ collapsible_if = "allow"
 [patch.crates-io]
 # packed_simd_2 = { git = "https://github.com/rust-lang/packed_simd", rev = "e57c7ba11386147e6d2cbad7c88f376aab4bdc86" }
 # simd-json = { git = "https://github.com/ritchie46/simd-json", branch = "alignment" }
-tikv-jemallocator = { git = "https://github.com/pola-rs/jemallocator", rev = "c7991e5bb6b3e9f79db6b0f48dcda67c5c3d2936" }
 object_store = { git = "https://github.com/apache/arrow-rs-object-store", rev = "6f1c9acc94636e059a2b3aef5c75e815e065cc89" }
 color-backtrace = { git = "https://github.com/orlp/color-backtrace", rev = "bb62ccf1e9eb1f6b7af5f16acff1fd7151a876dd" }
 

--- a/crates/polars-ooc/Cargo.toml
+++ b/crates/polars-ooc/Cargo.toml
@@ -22,10 +22,10 @@ mimalloc = { version = "0.1", default-features = false, optional = true }
 
 # Feature background_threads is unsupported on MacOS (https://github.com/jemalloc/jemalloc/issues/843).
 [target.'cfg(all(target_family = "unix", not(target_os = "macos"), not(target_os = "emscripten")))'.dependencies]
-tikv-jemallocator = { version = "0.6.0", features = ["disable_initial_exec_tls", "background_threads"], optional = true }
+tikv-jemallocator = { version = "0.7.0", features = ["disable_initial_exec_tls", "background_threads"], optional = true }
 
 [target.'cfg(all(target_family = "unix", target_os = "macos"))'.dependencies]
-tikv-jemallocator = { version = "0.6.0", features = ["disable_initial_exec_tls"], optional = true }
+tikv-jemallocator = { version = "0.7.0", features = ["disable_initial_exec_tls"], optional = true }
 
 [lints]
 workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -72,5 +72,4 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 unknown-git = "deny"
 allow-git = [
   "https://github.com/apache/arrow-rs-object-store",
-  "https://github.com/pola-rs/jemallocator",
 ]

--- a/py-polars/src/polars/__init__.py
+++ b/py-polars/src/polars/__init__.py
@@ -38,7 +38,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     # https://github.com/pola-rs/polars/pull/21829.
     import os
 
-    jemalloc_conf = "dirty_decay_ms:500,muzzy_decay_ms:-1"
+    jemalloc_conf = "dirty_decay_ms:500,muzzy_decay_ms:1000"
     if os.environ.get("POLARS_THP") == "1":
         jemalloc_conf += ",thp:always,metadata_thp:always"
     if override := os.environ.get("_RJEM_MALLOC_CONF"):


### PR DESCRIPTION
It seems like it fixed the `muzzy_decay_ms` bug. On my benchmarks it now is fast with `muzzy_decay_ms` enabled. Fixing the memory inceasing issues reported in #23128

closes #23128
closes #22871

# Before:

```
[]  ritchie46 /home/ritchie46/code/scratch/test_jem$ time _RJEM_MALLOC_CONF="muzzy_decay_ms:0" ./target/release/test_jem
[src/main.rs:14:5] start.elapsed() / 10_000 = 987.364µs

________________________________________________________
Executed in    9.88 secs    fish           external
   usr time    2.65 secs  583.00 micros    2.65 secs
   sys time    7.21 secs  848.00 micros    7.21 secs

[]  ritchie46 /home/ritchie46/code/scratch/test_jem$ time _RJEM_MALLOC_CONF="muzzy_decay_ms:99999" ./target/release/test_jem
[src/main.rs:14:5] start.elapsed() / 10_000 = 964.509µs

________________________________________________________
Executed in    9.65 secs    fish           external
   usr time    2.51 secs    0.08 millis    2.51 secs
   sys time    7.14 secs    1.12 millis    7.13 secs

[]  ritchie46 /home/ritchie46/code/scratch/test_jem$ time _RJEM_MALLOC_CONF="muzzy_decay_ms:-1" ./target/release/test_jem
[src/main.rs:14:5] start.elapsed() / 10_000 = 129.736µs

________________________________________________________
Executed in    1.30 secs    fish           external
   usr time    1.30 secs    0.27 millis    1.30 secs
   sys time    0.01 secs    1.21 millis    0.01 secs

```


# Now:

```
[]  ritchie46 /home/ritchie46/code/scratch/test_jem$ time _RJEM_MALLOC_CONF="muzzy_decay_ms:0" ./target/release/test_jem
[src/main.rs:14:5] start.elapsed() / 10_000 = 134.889µs

________________________________________________________
Executed in    1.35 secs    fish           external
   usr time    1.34 secs  935.00 micros    1.34 secs
   sys time    0.01 secs  442.00 micros    0.01 secs

[]  ritchie46 /home/ritchie46/code/scratch/test_jem$ time _RJEM_MALLOC_CONF="muzzy_decay_ms:99999" ./target/release/test_jem
[src/main.rs:14:5] start.elapsed() / 10_000 = 131.112µs

________________________________________________________
Executed in    1.32 secs    fish           external
   usr time    1.31 secs    0.20 millis    1.31 secs
   sys time    0.01 secs    1.18 millis    0.01 secs

[]  ritchie46 /home/ritchie46/code/scratch/test_jem$ time _RJEM_MALLOC_CONF="muzzy_decay_ms:-1" ./target/release/test_jem
[src/main.rs:14:5] start.elapsed() / 10_000 = 130.911µs

________________________________________________________
Executed in    1.31 secs    fish           external
   usr time    1.31 secs    0.30 millis    1.31 secs
   sys time    0.01 secs    1.24 millis    0.01 secs

```

#22871

<img width="964" height="344" alt="image" src="https://github.com/user-attachments/assets/1698e5fa-f0aa-42af-a46d-a8e322259696" />
