### PR TITLE
fix(rust): Fix rolling aggregations with window_size=0

### DIFF
--- a/crates/polars-compute/src/rolling/mod.rs
+++ b/crates/polars-compute/src/rolling/mod.rs
@@ -68,9 +68,15 @@ pub enum RollingFnParams {
 }
 
 fn det_offsets(i: Idx, window_size: WindowSize, _len: Len) -> (usize, usize) {
+    if window_size == 0 {
+        return (i, i);
+    }
     (i.saturating_sub(window_size - 1), i + 1)
 }
 fn det_offsets_center(i: Idx, window_size: WindowSize, len: Len) -> (usize, usize) {
+    if window_size == 0 {
+        return (i, i);
+    }
     let right_window = window_size.div_ceil(2);
     (
         i.saturating_sub(window_size - right_window),

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -951,6 +951,7 @@ def test_rolling_window_size_zero_23434() -> None:
     s_float = pl.Series([1.0, 2.0, 3.0, 4.0, 5.0], dtype=pl.Float64)
     n = len(s_int)
 
+    # --- core aggregations ---
     assert_series_equal(
         s_int.rolling_sum(window_size=0),
         pl.Series([0] * n, dtype=pl.Int64),
@@ -980,6 +981,21 @@ def test_rolling_window_size_zero_23434() -> None:
         pl.Series([None] * n, dtype=pl.Float64),
     )
 
+    # --- functions with their own aggregation windows ---
+    assert_series_equal(
+        s_float.rolling_median(window_size=0),
+        pl.Series([None] * n, dtype=pl.Float64),
+    )
+    assert_series_equal(
+        s_float.rolling_quantile(quantile=0.5, window_size=0),
+        pl.Series([None] * n, dtype=pl.Float64),
+    )
+    assert_series_equal(
+        s_float.rolling_skew(window_size=0),
+        pl.Series([None] * n, dtype=pl.Float64),
+    )
+
+    # --- center=True uses det_offsets_center, must behave identically ---
     assert_series_equal(
         s_int.rolling_sum(window_size=0, center=True),
         pl.Series([0] * n, dtype=pl.Int64),
@@ -989,6 +1005,7 @@ def test_rolling_window_size_zero_23434() -> None:
         pl.Series([None] * n, dtype=pl.Float64),
     )
 
+    # --- edge cases ---
     assert_series_equal(
         pl.Series([42], dtype=pl.Int64).rolling_sum(window_size=0),
         pl.Series([0], dtype=pl.Int64),
@@ -998,6 +1015,7 @@ def test_rolling_window_size_zero_23434() -> None:
         pl.Series([], dtype=pl.Int64),
     )
 
+    # --- expression API ---
     result = pl.DataFrame({"a": [1, 2, 3]}).select(
         pl.col("a").rolling_sum(window_size=0).alias("sum"),
         pl.col("a").cast(pl.Float64).rolling_mean(window_size=0).alias("mean"),
@@ -1006,3 +1024,7 @@ def test_rolling_window_size_zero_23434() -> None:
     assert_series_equal(
         result["mean"], pl.Series("mean", [None, None, None], dtype=pl.Float64)
     )
+
+    # --- min_periods > window_size is rejected regardless of window_size value ---
+    with pytest.raises(InvalidOperationError):
+        s_int.rolling_sum(window_size=0, min_periods=1)

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -940,3 +940,69 @@ def test_rolling_by_temporal_null_min_samples_27661() -> None:
         ),
     )
     assert_series_equal(df["avg_power_2s"].alias("avg_power_2i"), df["avg_power_2i"])
+
+
+def test_rolling_window_size_zero_23434() -> None:
+    """
+    window_size=0 means every position looks at zero elements.
+    Each result must equal the aggregation of an empty series for that dtype.
+    """
+    s_int = pl.Series([1, 2, 3, 4, 5], dtype=pl.Int64)
+    s_float = pl.Series([1.0, 2.0, 3.0, 4.0, 5.0], dtype=pl.Float64)
+    n = len(s_int)
+
+    assert_series_equal(
+        s_int.rolling_sum(window_size=0),
+        pl.Series([0] * n, dtype=pl.Int64),
+    )
+    assert_series_equal(
+        s_float.rolling_sum(window_size=0),
+        pl.Series([0.0] * n, dtype=pl.Float64),
+    )
+    assert_series_equal(
+        s_float.rolling_mean(window_size=0),
+        pl.Series([None] * n, dtype=pl.Float64),
+    )
+    assert_series_equal(
+        s_int.rolling_min(window_size=0),
+        pl.Series([None] * n, dtype=pl.Int64),
+    )
+    assert_series_equal(
+        s_int.rolling_max(window_size=0),
+        pl.Series([None] * n, dtype=pl.Int64),
+    )
+    assert_series_equal(
+        s_float.rolling_std(window_size=0),
+        pl.Series([None] * n, dtype=pl.Float64),
+    )
+    assert_series_equal(
+        s_float.rolling_var(window_size=0),
+        pl.Series([None] * n, dtype=pl.Float64),
+    )
+
+    assert_series_equal(
+        s_int.rolling_sum(window_size=0, center=True),
+        pl.Series([0] * n, dtype=pl.Int64),
+    )
+    assert_series_equal(
+        s_float.rolling_mean(window_size=0, center=True),
+        pl.Series([None] * n, dtype=pl.Float64),
+    )
+
+    assert_series_equal(
+        pl.Series([42], dtype=pl.Int64).rolling_sum(window_size=0),
+        pl.Series([0], dtype=pl.Int64),
+    )
+    assert_series_equal(
+        pl.Series([], dtype=pl.Int64).rolling_sum(window_size=0),
+        pl.Series([], dtype=pl.Int64),
+    )
+
+    result = pl.DataFrame({"a": [1, 2, 3]}).select(
+        pl.col("a").rolling_sum(window_size=0).alias("sum"),
+        pl.col("a").cast(pl.Float64).rolling_mean(window_size=0).alias("mean"),
+    )
+    assert_series_equal(result["sum"], pl.Series("sum", [0, 0, 0], dtype=pl.Int64))
+    assert_series_equal(
+        result["mean"], pl.Series("mean", [None, None, None], dtype=pl.Float64)
+    )


### PR DESCRIPTION
Closes #23434

## What was wrong

\`det_offsets\` computed \`window_size - 1\` unconditionally. When \`window_size=0\`
this underflows for \`usize\`, causing a panic in debug builds and silently wrong
results (a cumulative sum instead of all zeros) in release builds.

## Fix

Return \`(i, i)\` — an empty window — before any arithmetic when \`window_size=0\`.
The same guard is added to \`det_offsets_center\` for consistency. The existing
aggregation windows already handle empty ranges correctly:
\`SumWindow\` returns \`0\`, all other windows (\`MeanWindow\`, \`MinMaxWindow\`,
\`QuantileWindow\`, \`MomentWindow\`) return \`null\`, matching the result of calling
each aggregation on an empty \`Series\`.

## Scope

- Fixed-window rolling: all functions (\`sum\`, \`mean\`, \`min\`, \`max\`, \`std\`,
  \`var\`, \`median\`, \`quantile\`, \`skew\`), both \`center=False\` and \`center=True\`.
- Dynamic rolling (\`rolling_*_by\`): already raises \`InvalidOperation\` for
  \`window_size=0\` via a separate guard — not changed.
- \`min_periods > window_size\`: already rejected by the existing
  \`min_periods <= window_size\` validation — not changed.

## AI disclosure

This fix was implemented with assistance from Claude Code. All code was reviewed,
understood, and tested manually by me. The test suite was run locally and all
tests passed.