### PR TITLE
fix(python): handle unaligned structured-array fields in DataFrame constructor

### DIFF
--- a/py-polars/src/polars/_utils/construction/dataframe.py
+++ b/py-polars/src/polars/_utils/construction/dataframe.py
@@ -1292,7 +1292,11 @@ def numpy_to_pydf(
         data_series = [
             pl.Series(
                 name=series_name,
-                values=data[record_name],
+                # A field of a structured array can be a non-contiguous and/or
+                # unaligned view (e.g. a `u2` field at an odd byte offset). The
+                # Series constructor requires an aligned, contiguous buffer, so
+                # materialize one here (a no-op when the field already is).
+                values=np.require(data[record_name], requirements=["A", "C"]),
                 dtype=schema_overrides.get(record_name),
                 strict=strict,
                 nan_to_null=nan_to_null,

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -592,6 +592,20 @@ def test_init_ndarray() -> None:
         assert_frame_equal(df, pl.DataFrame(np.asarray(df), schema=names))
 
 
+def test_init_structured_array_unaligned_field() -> None:
+    # A structured-array field can be a non-contiguous / unaligned view (here
+    # `b` is a u2 starting at an odd byte offset). This used to panic with
+    # `AsSliceError` when constructing the DataFrame. See #27794.
+    arr = np.frombuffer(b"012", dtype=[("a", "u1"), ("b", "u2")])
+    df = pl.DataFrame(arr)
+    assert df.to_dict(as_series=False) == {"a": [48], "b": [12849]}
+
+    # The aligned layout already worked and must keep working.
+    arr_aligned = np.frombuffer(b"012", dtype=[("a", "u2"), ("b", "u1")])
+    df_aligned = pl.DataFrame(arr_aligned)
+    assert df_aligned.to_dict(as_series=False) == {"a": [12592], "b": [50]}
+
+
 def test_init_ndarray_errors() -> None:
     # 2D array: orientation conflicts with columns
     with pytest.raises(ValueError):


### PR DESCRIPTION
Fixes #27794

## Problem
Constructing a `DataFrame` from a NumPy **structured array** panics with `AsSliceError` when a field is a non-contiguous / unaligned view — e.g. a `u2` field at an odd byte offset:

```python
import numpy as np, polars as pl
pl.DataFrame(np.frombuffer(b"012", dtype=[("a", "u1"), ("b", "u2")]))  # PanicException: AsSliceError
```

The aligned layout (`[("a", "u2"), ("b", "u1")]`) works. Root cause: `numpy_to_pydf` passes the field view (`data[record_name]`) straight to the `Series` constructor, which requires an aligned, contiguous buffer. Here the field is C-contiguous but `flags["ALIGNED"]` is `False`, so the Rust-side slice conversion fails.

## Fix
Materialize each structured-array field with `np.require(data[record_name], requirements=["A", "C"])`. This copies only when needed — it's a no-op when the field is already aligned and contiguous, so the common case is unaffected. (Note: `np.ascontiguousarray` is *not* sufficient here, as it preserves the misalignment.)

## Tests
Added `test_init_structured_array_unaligned_field`: the previously-panicking unaligned layout now builds correctly (`{"a": [48], "b": [12849]}`), plus an aligned-layout regression guard.

## Verification
Verified against the released `polars==1.41.2` wheel by applying the identical Python change: the panic is resolved and the values are correct. I don't have a local Rust toolchain to run the full `py-polars` suite, but the change is Python-only and the added test asserts the verified behavior.

## AI-assisted contribution disclosure
Per the contributing guidelines: the fix and the test in this PR were written with the assistance of an AI coding tool (Claude Code). The diagnosis and fix were verified against the released wheel as described above; I take full responsibility for the contribution and will respond to review feedback myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
