### PR TITLE
fix(rust): avoid panic when formatting out-of-range datetimes

### DIFF
--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -990,10 +990,16 @@ fn fmt_datetime(
     tu: TimeUnit,
     tz: Option<&self::datatypes::TimeZone>,
 ) -> fmt::Result {
+    // Use the non-panicking conversions: a timestamp can be outside the range
+    // that can be represented as a calendar datetime (e.g. far-future values),
+    // and formatting must not panic. Fall back to the raw value in that case.
     let ndt = match tu {
-        TimeUnit::Nanoseconds => timestamp_ns_to_datetime(v),
-        TimeUnit::Microseconds => timestamp_us_to_datetime(v),
-        TimeUnit::Milliseconds => timestamp_ms_to_datetime(v),
+        TimeUnit::Nanoseconds => timestamp_ns_to_datetime_opt(v),
+        TimeUnit::Microseconds => timestamp_us_to_datetime_opt(v),
+        TimeUnit::Milliseconds => timestamp_ms_to_datetime_opt(v),
+    };
+    let Some(ndt) = ndt else {
+        return write!(f, "{v}");
     };
     match tz {
         None => std::fmt::Display::fmt(&ndt, f),

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2377,6 +2377,16 @@ def test_year_null_backed_by_out_of_range_15313() -> None:
     assert_series_equal(result, expected)
 
 
+def test_repr_out_of_range_datetime_25742() -> None:
+    # Formatting a datetime whose value falls outside the range representable
+    # as a calendar datetime must not panic; it falls back to the raw value.
+    s = pl.Series([8_210_266_876_800_000]).cast(pl.Datetime("ms"))
+    assert "8210266876800000" in str(s)
+
+    s_neg = pl.Series([-8_334_601_228_800_001]).cast(pl.Datetime("ms"))
+    assert "-8334601228800001" in str(s_neg)
+
+
 @pytest.mark.parametrize(
     "dtype",
     [*TEMPORAL_DTYPES, pl.Datetime("ms", "UTC"), pl.Datetime("ns", "Europe/Amsterdam")],


### PR DESCRIPTION
Fixes #25742

## Problem
Formatting a `Datetime` value that falls outside the range representable as a calendar datetime panics:

```python
import polars as pl
s = pl.Series([8_210_266_876_800_000]).cast(pl.Datetime("ms"))
str(s)  # PanicException: invalid or out-of-range datetime
```

`fmt_datetime` (in `crates/polars-core/src/fmt.rs`) used the panicking `timestamp_{ns,us,ms}_to_datetime` conversions, which `.expect(...)` on out-of-range values. Display must not panic.

## Fix
Use the non-panicking `timestamp_*_to_datetime_opt` variants and fall back to the raw integer value when the timestamp can't be represented as a calendar datetime. In-range datetimes are unaffected.

## Tests
Added `test_repr_out_of_range_datetime_25742` (in `tests/unit/datatypes/test_temporal.py`): asserts that both a positive and a negative out-of-range `Datetime("ms")` value format to their raw value without panicking.

## Verification
Built polars from source and confirmed: the out-of-range cases now display the raw value instead of panicking, and a normal datetime (`2024-01-02 03:04:05`) still formats correctly. `cargo fmt` clean on the changed file; the new Python test passes.

## AI-assisted contribution disclosure
Per the contributing guidelines: the fix and test were written with the assistance of an AI coding tool (Claude Code), built and verified from source as described above. I take responsibility for the contribution and will address review feedback myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
