### PR TITLE
docs(python): Correct cost/connectivity sections

### DIFF
--- a/docs/source/polars-on-premises/kubernetes/cloud-providers/amazon-elastic-kubernetes-service.md
+++ b/docs/source/polars-on-premises/kubernetes/cloud-providers/amazon-elastic-kubernetes-service.md
@@ -26,7 +26,7 @@ path = f"s3://YOUR_S3_BUCKET_NAME/PATH/TO/DATA/"
 
 q = (
     pl.scan_parquet(path)
-# ..
+# ...
 )
 ```
 
@@ -52,16 +52,12 @@ shuffleData:
     endpoint: "s3://YOUR_S3_BUCKET_NAME/PATH/TO/DATA/"
 ```
 
-## Reducing egress costs
+## Reducing NAT costs for private nodes
 
-!!! warning "Egress charges"
-
-    When Polars workers access S3 over the public internet, AWS charges data transfer (egress) fees
-    that can grow significantly with large or frequent queries.
-
-Creating a **VPC Gateway Endpoint for S3** routes all S3 traffic through the AWS private network at
-no additional cost and requires no changes to your Polars deployment. Once the endpoint is attached
-to your VPC and route tables are updated, traffic is routed privately and automatically.
+In clusters where nodes have no public IP addresses, S3 traffic is typically routed through a NAT
+Gateway, billed according to the volume of data processed. Creating a **VPC Gateway Endpoint for
+S3** bypasses the NAT Gateway entirely: S3 traffic is then routed directly over the AWS private
+network at no additional cost, with no changes required to your Polars deployment.
 
 Note that the S3 bucket must be in the same region as the EKS cluster (cross-region traffic incurs
 charges regardless of the endpoint configuration).

--- a/docs/source/polars-on-premises/kubernetes/cloud-providers/azure-kubernetes-service.md
+++ b/docs/source/polars-on-premises/kubernetes/cloud-providers/azure-kubernetes-service.md
@@ -29,7 +29,7 @@ storage_options = {
 }
 q = (
     pl.scan_parquet(path, storage_options=storage_options)
-# ..
+# ...
 )
 ```
 
@@ -46,22 +46,3 @@ anonymousResults:
     - name: account_name
       value: "YOUR_STORAGE_ACCOUNT_NAME"
 ```
-
-## Reducing egress costs
-
-!!! warning "Egress charges"
-
-    When Polars workers access Azure Blob Storage (ABS) over the public internet, Azure charges
-    data transfer (egress) fees that can grow significantly with large or frequent queries.
-
-Enabling a **Service Endpoint** for `Microsoft.Storage` on your AKS subnet routes all Blob Storage
-traffic over the Microsoft backbone network at no additional cost and requires no changes to your
-Polars deployment. Once the endpoint is in place and the storage account network rules are updated
-to allow access from your subnet, traffic is routed privately and automatically.
-
-Note that the storage account must be in the same region as the AKS cluster (cross-region traffic
-incurs charges regardless of the endpoint configuration).
-
-See the related
-[guide](https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security) in the
-official Azure documentation.

--- a/docs/source/polars-on-premises/kubernetes/cloud-providers/google-kubernetes-engine.md
+++ b/docs/source/polars-on-premises/kubernetes/cloud-providers/google-kubernetes-engine.md
@@ -6,10 +6,10 @@
 
 ## Data access using Workload Identity
 
-Through GKE Workload Identity, you can securely access private Google Cloud Storage buckets without
-needing to manage service account keys or credentials. In most scencarios, it comes down to enabling
-Workload Identity Federation, creating a Kubernetes service account, and creating an IAM policy
-binding.
+Through GKE Workload Identity, you can securely access private Google Cloud Storage (GCS) buckets
+without needing to manage service account keys or credentials. In most scenarios, it comes down to
+enabling Workload Identity Federation, creating a Kubernetes service account, and creating an IAM
+policy binding.
 [See the guide in the official GKE documentation](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/workload-identity).
 
 ```bash
@@ -30,7 +30,7 @@ storage_options = {
 }
 q = (
     pl.scan_parquet(path, storage_options=storage_options)
-# ..
+# ...
 )
 ```
 
@@ -48,20 +48,17 @@ anonymousResults:
       value: "YOUR_PROJECT_NAME"
 ```
 
-## Reducing egress costs
+## Accessing GCS from private nodes
 
-!!! warning "Egress charges"
-
-    When Polars workers access Google Cloud Storage (GCS) over the public internet, Google charges
-    data transfer (egress) fees that can grow significantly with large or frequent queries.
-
-Enabling **Private Google Access** on your GKE node subnet allows nodes to reach Google APIs and
-services using GCP-internal IP addresses only, without routing through the public internet. No
-changes are required to your Polars deployment. Once Private Google Access is enabled on the subnet,
-traffic is routed privately and automatically.
+In clusters where nodes have no external IP addresses, GCS is unreachable without Cloud NAT; if the
+latter is deployed, GCS traffic is billed according to the volume of data processed. Enabling
+**Private Google Access** (PGA) on your GKE node subnet gives internally-addressed nodes a direct
+path to Google APIs (including GCS) and requires no changes to your Polars deployment. In case both
+Cloud NAT and PGA are deployed the latter takes precedence for Google APIs and no costs are
+incurred.
 
 Note that the GCS bucket must be in the same region as the GKE cluster (cross-region traffic incurs
 charges regardless of whether Private Google Access is enabled).
 
-See the related [guide](https://cloud.google.com/vpc/docs/configure-private-google-access) in the
-official GCP documentation.
+See the related [guide](https://docs.cloud.google.com/vpc/docs/configure-private-google-access) in
+the official GCP documentation.


### PR DESCRIPTION
Reworded the docs a little:

- VPC Endpoint for AWS S3 is relevant because well-known but often forgotten; might happen for a newly-deployed cluster. I reframed the title a bit as well. In case a NAT Gateway is not involved (especially rare I would expect) readers can simply skip the section.
- Removed the Azure section entirely as they seem to have more sensible/elegant defaults there. Adding NAT Gateway and Service Endpoint is a security choice but is not required. It might still be useful to mention, but not sure this is the place.
- Made it about connectivity instead of cost for GCP. Most Kubernetes clusters will be deployed in private subnets, and a GPA is there simply required to access GCS. If Cloud NAT is deployed, it becomes the same cost argument as AWS.