### PR TITLE
docs: update archived pyo3-polars references

### DIFF
--- a/docs/source/user-guide/plugins/expr_plugins.md
+++ b/docs/source/user-guide/plugins/expr_plugins.md
@@ -259,7 +259,7 @@ fn haversine(inputs: &[Series]) -> PolarsResult<Series> {
 
 That's all you need to know to get started.
 
-Take a look at [this repo](../../../../pyo3-polars/example/derive_expression) to
-see how this all fits together.
+Take a look at [this repo](../../../../pyo3-polars/example/derive_expression) to see how
+this all fits together.
 
 For a more thorough overview, see the tutorial.

--- a/docs/source/user-guide/plugins/expr_plugins.md
+++ b/docs/source/user-guide/plugins/expr_plugins.md
@@ -259,7 +259,7 @@ fn haversine(inputs: &[Series]) -> PolarsResult<Series> {
 
 That's all you need to know to get started.
 
-Take a look at [this repo](../../../../pyo3-polars/example/derive_expression)
-to see how this all fits together.
+Take a look at [this repo](../../../../pyo3-polars/example/derive_expression) to
+see how this all fits together.
 
 For a more thorough overview, see the tutorial.

--- a/docs/source/user-guide/plugins/expr_plugins.md
+++ b/docs/source/user-guide/plugins/expr_plugins.md
@@ -258,7 +258,7 @@ fn haversine(inputs: &[Series]) -> PolarsResult<Series> {
 ```
 
 That's all you need to know to get started. Take a look at
-[this repo](https://github.com/pola-rs/pyo3-polars/tree/main/example/derive_expression) to see how
+[this repo](https://github.com/pola-rs/polars/tree/main/pyo3-polars/example/derive_expression) to see how
 this all fits together, and at
 [this tutorial](https://marcogorelli.github.io/polars-plugins-tutorial/) to gain a more thorough
 understanding.

--- a/docs/source/user-guide/plugins/expr_plugins.md
+++ b/docs/source/user-guide/plugins/expr_plugins.md
@@ -257,8 +257,9 @@ fn haversine(inputs: &[Series]) -> PolarsResult<Series> {
 }
 ```
 
-That's all you need to know to get started. Take a look at
-[this repo](https://github.com/pola-rs/polars/tree/main/pyo3-polars/example/derive_expression)
-to see how this all fits together, and at
-[this tutorial](https://marcogorelli.github.io/polars-plugins-tutorial/)
-to gain a more thorough understanding.
+That's all you need to know to get started.
+
+Take a look at [this repo](../../../../pyo3-polars/example/derive_expression)
+to see how this all fits together.
+
+For a more thorough overview, see the tutorial.

--- a/docs/source/user-guide/plugins/expr_plugins.md
+++ b/docs/source/user-guide/plugins/expr_plugins.md
@@ -258,7 +258,7 @@ fn haversine(inputs: &[Series]) -> PolarsResult<Series> {
 ```
 
 That's all you need to know to get started. Take a look at
-[this repo](https://github.com/pola-rs/polars/tree/main/pyo3-polars/example/derive_expression) to see how
-this all fits together, and at
-[this tutorial](https://marcogorelli.github.io/polars-plugins-tutorial/) to gain a more thorough
-understanding.
+[this repo](https://github.com/pola-rs/polars/tree/main/pyo3-polars/example/derive_expression)
+to see how this all fits together, and at
+[this tutorial](https://marcogorelli.github.io/polars-plugins-tutorial/)
+to gain a more thorough understanding.

--- a/docs/source/user-guide/plugins/io_plugins.md
+++ b/docs/source/user-guide/plugins/io_plugins.md
@@ -84,8 +84,8 @@ The arguments of this function are predefined and this function must accept:
   A hint of the ideal batch size the reader's generator must produce.
 
 The inner function is the actual implementation of the IO source and can also call into Rust/C++ or
-wherever the IO plugin is written. If you want to see an IO source implemented in Rust, take a look
-at our [plugins repository](https://github.com/pola-rs/polars/tree/main/pyo3-polars/example/io_plugin).
+wherever the IO plugin is written. If you want to see an IO source implemented in Rust, take a look at
+our [plugins repository](https://github.com/pola-rs/polars/tree/main/pyo3-polars/example/io_plugin).
 
 ```python
 def my_scan_csv(csv_str: str) -> pl.LazyFrame:

--- a/docs/source/user-guide/plugins/io_plugins.md
+++ b/docs/source/user-guide/plugins/io_plugins.md
@@ -83,9 +83,11 @@ The arguments of this function are predefined and this function must accept:
 
   A hint of the ideal batch size the reader's generator must produce.
 
-The inner function is the actual implementation of the IO source and can also call into Rust/C++ or
-wherever the IO plugin is written. If you want to see an IO source implemented in Rust, take a look at
-our [plugins repository](https://github.com/pola-rs/polars/tree/main/pyo3-polars/example/io_plugin).
+The inner function is the actual implementation of the IO source and can also
+call into Rust/C++ or wherever the IO plugin is written.
+
+If you want to see an IO source implemented in Rust, take a look at our
+[plugins repository](../../../../pyo3-polars/example/io_plugin).
 
 ```python
 def my_scan_csv(csv_str: str) -> pl.LazyFrame:

--- a/docs/source/user-guide/plugins/io_plugins.md
+++ b/docs/source/user-guide/plugins/io_plugins.md
@@ -83,8 +83,8 @@ The arguments of this function are predefined and this function must accept:
 
   A hint of the ideal batch size the reader's generator must produce.
 
-The inner function is the actual implementation of the IO source and can also
-call into Rust/C++ or wherever the IO plugin is written.
+The inner function is the actual implementation of the IO source and can also call
+into Rust/C++ or wherever the IO plugin is written.
 
 If you want to see an IO source implemented in Rust, take a look at our
 [plugins repository](../../../../pyo3-polars/example/io_plugin).

--- a/docs/source/user-guide/plugins/io_plugins.md
+++ b/docs/source/user-guide/plugins/io_plugins.md
@@ -85,7 +85,7 @@ The arguments of this function are predefined and this function must accept:
 
 The inner function is the actual implementation of the IO source and can also call into Rust/C++ or
 wherever the IO plugin is written. If you want to see an IO source implemented in Rust, take a look
-at our [plugins repository](https://github.com/pola-rs/pyo3-polars/tree/main/example/io_plugin).
+at our [plugins repository](https://github.com/pola-rs/polars/tree/main/pyo3-polars/example/io_plugin).
 
 ```python
 def my_scan_csv(csv_str: str) -> pl.LazyFrame:
@@ -192,4 +192,4 @@ shape: (2, 2)
 
 ## Further reading
 
-- [Rust example (distribution source)](https://github.com/pola-rs/pyo3-polars/tree/main/example/io_plugin)
+- [Rust example (distribution source)](https://github.com/pola-rs/polars/tree/main/pyo3-polars/example/io_plugin)

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -4727,6 +4727,18 @@ class DataFrame:
             - If 'append', will add new data.
             - If 'overwrite', will replace table with new data.
 
+        Examples
+        --------
+        Write a DataFrame to a local Iceberg table.
+
+        >>> from pyiceberg.catalog.sql import SqlCatalog
+        >>> from pyiceberg.schema import NestedField, Schema
+        >>> from pyiceberg.types import LongType
+        >>> catalog = SqlCatalog("default", uri="sqlite:///:memory:", warehouse="file:/tmp/warehouse")  # doctest: +SKIP
+        >>> catalog.create_namespace("foo")  # doctest: +SKIP
+        >>> table = catalog.create_table("foo.bar", schema=Schema(NestedField(1, "a", LongType())))  # doctest: +SKIP
+        >>> pl.DataFrame({"a": [1, 2, 3]}).write_iceberg(table, mode="overwrite")  # doctest: +SKIP
+
         """
         from pyiceberg.catalog import load_catalog
 

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -4734,10 +4734,20 @@ class DataFrame:
         >>> from pyiceberg.catalog.sql import SqlCatalog
         >>> from pyiceberg.schema import NestedField, Schema
         >>> from pyiceberg.types import LongType
-        >>> catalog = SqlCatalog("default", uri="sqlite:///:memory:", warehouse="file:/tmp/warehouse")  # doctest: +SKIP
+        >>> catalog = SqlCatalog(
+        ...     "default",
+        ...     uri="sqlite:///:memory:",
+        ...     warehouse="file:/tmp/warehouse",
+        ... )  # doctest: +SKIP
         >>> catalog.create_namespace("foo")  # doctest: +SKIP
-        >>> table = catalog.create_table("foo.bar", schema=Schema(NestedField(1, "a", LongType())))  # doctest: +SKIP
-        >>> pl.DataFrame({"a": [1, 2, 3]}).write_iceberg(table, mode="overwrite")  # doctest: +SKIP
+        >>> table = catalog.create_table(
+        ...     "foo.bar",
+        ...     schema=Schema(NestedField(1, "a", LongType())),
+        ... )  # doctest: +SKIP
+        >>> pl.DataFrame({"a": [1, 2, 3]}).write_iceberg(
+        ...     table,
+        ...     mode="overwrite",
+        ... )  # doctest: +SKIP
 
         """
         from pyiceberg.catalog import load_catalog

--- a/py-polars/src/polars/io/iceberg/functions.py
+++ b/py-polars/src/polars/io/iceberg/functions.py
@@ -116,10 +116,20 @@ def scan_iceberg(
     >>> from pyiceberg.catalog.sql import SqlCatalog
     >>> from pyiceberg.schema import NestedField, Schema
     >>> from pyiceberg.types import LongType
-    >>> catalog = SqlCatalog("default", uri="sqlite:///:memory:", warehouse="file:/tmp/warehouse")  # doctest: +SKIP
+    >>> catalog = SqlCatalog(
+    ...     "default",
+    ...     uri="sqlite:///:memory:",
+    ...     warehouse="file:/tmp/warehouse",
+    ... )  # doctest: +SKIP
     >>> catalog.create_namespace("foo")  # doctest: +SKIP
-    >>> table = catalog.create_table("foo.bar", schema=Schema(NestedField(1, "a", LongType())))  # doctest: +SKIP
-    >>> pl.DataFrame({"a": [1, 2, 3]}).write_iceberg(table, mode="overwrite")  # doctest: +SKIP
+    >>> table = catalog.create_table(
+    ...     "foo.bar",
+    ...     schema=Schema(NestedField(1, "a", LongType())),
+    ... )  # doctest: +SKIP
+    >>> pl.DataFrame({"a": [1, 2, 3]}).write_iceberg(
+    ...     table,
+    ...     mode="overwrite",
+    ... )  # doctest: +SKIP
     >>> pl.scan_iceberg(table).collect()  # doctest: +SKIP
 
     Creates a scan for an Iceberg table from S3.

--- a/py-polars/src/polars/io/iceberg/functions.py
+++ b/py-polars/src/polars/io/iceberg/functions.py
@@ -105,9 +105,22 @@ def scan_iceberg(
     Examples
     --------
     Creates a scan for an Iceberg table from local filesystem, or object store.
+    If you need a minimal end-to-end write example first, see
+    `DataFrame.write_iceberg`.
 
     >>> table_path = "file:/path/to/iceberg-table/metadata.json"
     >>> pl.scan_iceberg(table_path).collect()  # doctest: +SKIP
+
+    The same table can then be read back directly.
+
+    >>> from pyiceberg.catalog.sql import SqlCatalog
+    >>> from pyiceberg.schema import NestedField, Schema
+    >>> from pyiceberg.types import LongType
+    >>> catalog = SqlCatalog("default", uri="sqlite:///:memory:", warehouse="file:/tmp/warehouse")  # doctest: +SKIP
+    >>> catalog.create_namespace("foo")  # doctest: +SKIP
+    >>> table = catalog.create_table("foo.bar", schema=Schema(NestedField(1, "a", LongType())))  # doctest: +SKIP
+    >>> pl.DataFrame({"a": [1, 2, 3]}).write_iceberg(table, mode="overwrite")  # doctest: +SKIP
+    >>> pl.scan_iceberg(table).collect()  # doctest: +SKIP
 
     Creates a scan for an Iceberg table from S3.
     See a list of supported storage options for S3 `here


### PR DESCRIPTION
I updated the Iceberg documentation to add a minimal `write_iceberg` example and linked the `scan_iceberg` docs to it. I also replaced stale `pola-rs/pyo3-polars` links with the current in-repo pyo3-polars example paths.

Testing:
- Ran the local test suite successfully.
- Attached a screenshot of the successful `make test` run.

If you used AI assistance, add:

1. I used AI to help draft the documentation changes.
2. I confirm that I reviewed all changes myself, and I believe they are relevant and correct.