### PR TITLE
feat(list): add .list.product() aggregation

### DIFF
--- a/crates/polars-expr/src/dispatch/list.rs
+++ b/crates/polars-expr/src/dispatch/list.rs
@@ -41,6 +41,7 @@ pub fn function_expr_to_udf(func: IRListFunction) -> SpecialEq<Arc<dyn ColumnsUd
         #[cfg(feature = "list_count")]
         CountMatches => map_as_slice!(count_matches),
         Sum => map!(sum),
+        Product => map!(product),
         Length => map!(length),
         Max => map!(max),
         Min => map!(min),
@@ -309,6 +310,10 @@ pub(super) fn count_matches(args: &[Column]) -> PolarsResult<Column> {
 
 pub(super) fn sum(s: &Column) -> PolarsResult<Column> {
     s.list()?.lst_sum().map(Column::from)
+}
+
+pub(super) fn product(s: &Column) -> PolarsResult<Column> {
+    s.list()?.lst_product().map(Column::from)
 }
 
 pub(super) fn length(s: &Column) -> PolarsResult<Column> {

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -9,10 +9,10 @@ use polars_core::utils::{CustomIterTools, try_get_supertype};
 
 use super::*;
 use crate::chunked_array::list::min_max::{list_max_function, list_min_function};
-use crate::chunked_array::list::sum_mean::sum_with_nulls;
+use crate::chunked_array::list::sum_mean::{product_with_nulls, sum_with_nulls};
 #[cfg(feature = "diff")]
 use crate::prelude::diff;
-use crate::prelude::list::sum_mean::{mean_list_numerical, sum_list_numerical};
+use crate::prelude::list::sum_mean::{mean_list_numerical, product_list_numerical, sum_list_numerical};
 use crate::series::{ArgAgg, convert_and_bound_index};
 
 pub(super) fn has_inner_nulls(ca: &ListChunked) -> bool {
@@ -184,6 +184,19 @@ pub trait ListNameSpaceImpl: AsList {
             DataType::Boolean => Ok(count_boolean_bits(ca).into_series()),
             dt if dt.is_primitive_numeric() => Ok(sum_list_numerical(ca, dt)),
             dt => sum_with_nulls(ca, dt),
+        }
+    }
+
+    fn lst_product(&self) -> PolarsResult<Series> {
+        let ca = self.as_list();
+
+        if has_inner_nulls(ca) {
+            return product_with_nulls(ca, ca.inner_dtype());
+        };
+
+        match ca.inner_dtype() {
+            dt if dt.is_primitive_numeric() => Ok(product_list_numerical(ca, dt)),
+            dt => product_with_nulls(ca, dt),
         }
     }
 

--- a/crates/polars-ops/src/chunked_array/list/sum_mean.rs
+++ b/crates/polars-ops/src/chunked_array/list/sum_mean.rs
@@ -3,7 +3,6 @@ use std::ops::Div;
 use arrow::array::{Array, PrimitiveArray};
 use arrow::bitmap::Bitmap;
 use arrow::compute::utils::combine_validities_and;
-use arrow::temporal_conversions::MICROSECONDS_IN_DAY as US_IN_DAY;
 use arrow::types::NativeType;
 use num_traits::{NumCast, ToPrimitive};
 use polars_utils::float16::pf16;
@@ -70,57 +69,19 @@ pub(super) fn product_list_numerical(ca: &ListChunked, inner_type: &DataType) ->
 }
 
 pub(super) fn product_with_nulls(ca: &ListChunked, inner_dtype: &DataType) -> PolarsResult<Series> {
-    use DataType::*;
-    let mut out = match inner_dtype {
-        Boolean | UInt8 | UInt16 | Int8 | Int16 => {
-            let out: Int64Chunked =
-                ca.apply_amortized_generic(|s| s.map(|s| s.as_ref().product().ok()?.try_extract::<i64>().ok()));
-            out.into_series()
-        },
-        UInt32 => {
-            let out: UInt32Chunked =
-                ca.apply_amortized_generic(|s| s.map(|s| s.as_ref().product().ok()?.try_extract::<u32>().ok()));
-            out.into_series()
-        },
-        UInt64 => {
-            let out: UInt64Chunked =
-                ca.apply_amortized_generic(|s| s.map(|s| s.as_ref().product().ok()?.try_extract::<u64>().ok()));
-            out.into_series()
-        },
-        Int32 => {
-            let out: Int32Chunked =
-                ca.apply_amortized_generic(|s| s.map(|s| s.as_ref().product().ok()?.try_extract::<i32>().ok()));
-            out.into_series()
-        },
-        Int64 | Int128 => {
-            let out: Int64Chunked =
-                ca.apply_amortized_generic(|s| s.map(|s| s.as_ref().product().ok()?.try_extract::<i64>().ok()));
-            out.into_series()
-        },
-        Float32 => {
-            let out: Float32Chunked =
-                ca.apply_amortized_generic(|s| s.map(|s| s.as_ref().product().ok()?.try_extract::<f32>().ok()));
-            out.into_series()
-        },
-        Float64 => {
-            let out: Float64Chunked =
-                ca.apply_amortized_generic(|s| s.map(|s| s.as_ref().product().ok()?.try_extract::<f64>().ok()));
-            out.into_series()
-        },
-        dt => ca
-            .try_apply_amortized_same_type(|s| {
-                s.as_ref()
-                    .product()
-                    .map(|sc| sc.into_series(PlSmallStr::EMPTY))
-            })?
-            .explode(ExplodeOptions {
-                empty_as_null: true,
-                keep_nulls: true,
-            })
-            .unwrap()
-            .into_series()
-            .cast(dt)?,
-    };
+    let mut out = ca
+        .try_apply_amortized_same_type(|s| {
+            s.as_ref()
+                .product()
+                .map(|sc| sc.into_series(PlSmallStr::EMPTY))
+        })?
+        .explode(ExplodeOptions {
+            empty_as_null: true,
+            keep_nulls: true,
+        })
+        .unwrap()
+        .into_series()
+        .cast(inner_dtype)?;
     out.rename(ca.name().clone());
     Ok(out)
 }

--- a/crates/polars-ops/src/chunked_array/list/sum_mean.rs
+++ b/crates/polars-ops/src/chunked_array/list/sum_mean.rs
@@ -11,6 +11,120 @@ use polars_utils::float16::pf16;
 use super::*;
 use crate::chunked_array::sum::sum_slice;
 
+fn product_between_offsets<T, S>(values: &[T], offset: &[i64]) -> Vec<S>
+where
+    T: NativeType + ToPrimitive,
+    S: NumCast + std::iter::Product,
+{
+    offset
+        .windows(2)
+        .map(|w| {
+            values
+                .get(w[0] as usize..w[1] as usize)
+                .map(|sl| sl.iter().map(|v| NumCast::from(*v).unwrap()).product())
+                .unwrap_or_else(|| std::iter::empty::<S>().product())
+        })
+        .collect()
+}
+
+fn dispatch_product<T, S>(arr: &dyn Array, offsets: &[i64], validity: Option<&Bitmap>) -> ArrayRef
+where
+    T: NativeType + ToPrimitive,
+    S: NativeType + NumCast + std::iter::Product,
+{
+    let values = arr.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
+    let values = values.values().as_slice();
+    Box::new(PrimitiveArray::from_data_default(
+        product_between_offsets::<_, S>(values, offsets).into(),
+        validity.cloned(),
+    )) as ArrayRef
+}
+
+pub(super) fn product_list_numerical(ca: &ListChunked, inner_type: &DataType) -> Series {
+    use DataType::*;
+    let chunks = ca
+        .downcast_iter()
+        .map(|arr| {
+            let offsets = arr.offsets().as_slice();
+            let values = arr.values().as_ref();
+
+            match inner_type {
+                Int8 => dispatch_product::<i8, i64>(values, offsets, arr.validity()),
+                Int16 => dispatch_product::<i16, i64>(values, offsets, arr.validity()),
+                Int32 => dispatch_product::<i32, i32>(values, offsets, arr.validity()),
+                Int64 => dispatch_product::<i64, i64>(values, offsets, arr.validity()),
+                Int128 => dispatch_product::<i128, i128>(values, offsets, arr.validity()),
+                UInt8 => dispatch_product::<u8, i64>(values, offsets, arr.validity()),
+                UInt16 => dispatch_product::<u16, i64>(values, offsets, arr.validity()),
+                UInt32 => dispatch_product::<u32, u32>(values, offsets, arr.validity()),
+                UInt64 => dispatch_product::<u64, u64>(values, offsets, arr.validity()),
+                UInt128 => dispatch_product::<u128, u128>(values, offsets, arr.validity()),
+                Float32 => dispatch_product::<f32, f32>(values, offsets, arr.validity()),
+                Float64 => dispatch_product::<f64, f64>(values, offsets, arr.validity()),
+                _ => unimplemented!(),
+            }
+        })
+        .collect::<Vec<_>>();
+
+    Series::try_from((ca.name().clone(), chunks)).unwrap()
+}
+
+pub(super) fn product_with_nulls(ca: &ListChunked, inner_dtype: &DataType) -> PolarsResult<Series> {
+    use DataType::*;
+    let mut out = match inner_dtype {
+        Boolean | UInt8 | UInt16 | Int8 | Int16 => {
+            let out: Int64Chunked =
+                ca.apply_amortized_generic(|s| s.map(|s| s.as_ref().product().ok()?.try_extract::<i64>().ok()));
+            out.into_series()
+        },
+        UInt32 => {
+            let out: UInt32Chunked =
+                ca.apply_amortized_generic(|s| s.map(|s| s.as_ref().product().ok()?.try_extract::<u32>().ok()));
+            out.into_series()
+        },
+        UInt64 => {
+            let out: UInt64Chunked =
+                ca.apply_amortized_generic(|s| s.map(|s| s.as_ref().product().ok()?.try_extract::<u64>().ok()));
+            out.into_series()
+        },
+        Int32 => {
+            let out: Int32Chunked =
+                ca.apply_amortized_generic(|s| s.map(|s| s.as_ref().product().ok()?.try_extract::<i32>().ok()));
+            out.into_series()
+        },
+        Int64 | Int128 => {
+            let out: Int64Chunked =
+                ca.apply_amortized_generic(|s| s.map(|s| s.as_ref().product().ok()?.try_extract::<i64>().ok()));
+            out.into_series()
+        },
+        Float32 => {
+            let out: Float32Chunked =
+                ca.apply_amortized_generic(|s| s.map(|s| s.as_ref().product().ok()?.try_extract::<f32>().ok()));
+            out.into_series()
+        },
+        Float64 => {
+            let out: Float64Chunked =
+                ca.apply_amortized_generic(|s| s.map(|s| s.as_ref().product().ok()?.try_extract::<f64>().ok()));
+            out.into_series()
+        },
+        dt => ca
+            .try_apply_amortized_same_type(|s| {
+                s.as_ref()
+                    .product()
+                    .map(|sc| sc.into_series(PlSmallStr::EMPTY))
+            })?
+            .explode(ExplodeOptions {
+                empty_as_null: true,
+                keep_nulls: true,
+            })
+            .unwrap()
+            .into_series()
+            .cast(dt)?,
+    };
+    out.rename(ca.name().clone());
+    Ok(out)
+}
+
 fn sum_between_offsets<T, S>(values: &[T], offset: &[i64]) -> Vec<S>
 where
     T: NativeType + ToPrimitive,

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -28,6 +28,7 @@ pub enum ListFunction {
     #[cfg(feature = "list_count")]
     CountMatches,
     Sum,
+    Product,
     Length,
     Max,
     Min,
@@ -80,6 +81,7 @@ impl Display for ListFunction {
             #[cfg(feature = "list_count")]
             CountMatches => "count_matches",
             Sum => "sum",
+            Product => "product",
             Min => "min",
             Max => "max",
             Mean => "mean",

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -77,6 +77,11 @@ impl ListNameSpace {
         self.0.map_unary(FunctionExpr::ListExpr(ListFunction::Sum))
     }
 
+    /// Compute the product of the items in every sublist.
+    pub fn product(self) -> Expr {
+        self.0.map_unary(FunctionExpr::ListExpr(ListFunction::Product))
+    }
+
     /// Compute the mean of every sublist and return a `Series` of dtype `Float64`
     pub fn mean(self) -> Expr {
         self.0.map_unary(FunctionExpr::ListExpr(ListFunction::Mean))

--- a/crates/polars-plan/src/plans/aexpr/function_expr/list.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/list.rs
@@ -29,6 +29,7 @@ pub enum IRListFunction {
     #[cfg(feature = "list_count")]
     CountMatches,
     Sum,
+    Product,
     Length,
     Max,
     Min,
@@ -87,6 +88,7 @@ impl IRListFunction {
             #[cfg(feature = "list_count")]
             CountMatches => mapper.ensure_is_list()?.with_dtype(IDX_DTYPE),
             Sum => mapper.nested_sum_type(),
+            Product => mapper.nested_sum_type(),
             Min => mapper.ensure_is_list()?.map_to_list_and_array_inner_dtype(),
             Max => mapper.ensure_is_list()?.map_to_list_and_array_inner_dtype(),
             Mean => mapper.nested_mean_median_type(),
@@ -182,6 +184,7 @@ impl IRListFunction {
             #[cfg(feature = "list_count")]
             L::CountMatches => FunctionOptions::elementwise(),
             L::Sum
+            | L::Product
             | L::Slice
             | L::Shift
             | L::Get(_)
@@ -241,6 +244,7 @@ impl Display for IRListFunction {
             #[cfg(feature = "list_count")]
             CountMatches => "count_matches",
             Sum => "sum",
+            Product => "product",
             Min => "min",
             Max => "max",
             Mean => "mean",

--- a/crates/polars-python/src/expr/list.rs
+++ b/crates/polars-python/src/expr/list.rs
@@ -129,6 +129,10 @@ impl PyExpr {
         self.inner.clone().list().sum().into()
     }
 
+    fn list_product(&self) -> Self {
+        self.inner.clone().list().product().into()
+    }
+
     #[cfg(feature = "list_drop_nulls")]
     fn list_drop_nulls(&self) -> Self {
         self.inner.clone().list().drop_nulls().into()

--- a/py-polars/src/polars/expr/list.py
+++ b/py-polars/src/polars/expr/list.py
@@ -268,6 +268,30 @@ class ExprListNameSpace:
         """
         return wrap_expr(self._pyexpr.list_sum())
 
+    def product(self) -> Expr:
+        """
+        Compute the product of all the elements in every sub-array.
+
+        Notes
+        -----
+        If there are no non-null elements in a row, the output is `1`.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"values": [[1, 2], [3, 4, 5]]})
+        >>> df.with_columns(product=pl.col("values").list.product())
+        shape: (2, 2)
+        ┌───────────┬─────────┐
+        │ values    ┆ product │
+        │ ---       ┆ ---     │
+        │ list[i64] ┆ i64     │
+        ╞═══════════╪═════════╡
+        │ [1, 2]    ┆ 2       │
+        │ [3, 4, 5] ┆ 60      │
+        └───────────┴─────────┘
+        """
+        return wrap_expr(self._pyexpr.list_product())
+
     def max(self) -> Expr:
         """
         Compute the max value of the lists in the array.

--- a/py-polars/src/polars/series/list.py
+++ b/py-polars/src/polars/series/list.py
@@ -209,6 +209,26 @@ class ListNameSpace:
         ]
         """
 
+    def product(self) -> Series:
+        """
+        Compute the product of all the elements in every sub-array.
+
+        Notes
+        -----
+        If there are no non-null elements in a row, the output is `1`.
+
+        Examples
+        --------
+        >>> s = pl.Series("values", [[1, 2], [3, 4, 5]])
+        >>> s.list.product()
+        shape: (2,)
+        Series: 'values' [i64]
+        [
+            2
+            60
+        ]
+        """
+
     def max(self) -> Series:
         """
         Compute the max value of the arrays in the list.


### PR DESCRIPTION
## Summary

Closes #12862.

Adds `Expr.list.product()` / `Series.list.product()` to compute the product of all elements in every sub-list, mirroring `.list.sum()`.

```python
df = pl.DataFrame({"values": [[1, 2, 3], [4, 5, 6]]})
df.with_columns(product=pl.col("values").list.product())
# shape: (2, 2)
# ┌───────────┬─────────┐
# │ values    ┆ product │
# │ list[i64] ┆ i64     │
# ╞═══════════╪═════════╡
# │ [1, 2, 3] ┆ 6       │
# │ [4, 5, 6] ┆ 120     │
# └───────────┴─────────┘
```

## Changes

| File | Change |
|------|--------|
| `polars-ops/.../list/sum_mean.rs` | `product_list_numerical`, `product_with_nulls` |
| `polars-ops/.../list/namespace.rs` | `lst_product` on `ListNameSpaceImpl` |
| `polars-expr/.../dispatch/list.rs` | `fn product` + `Product` dispatch arm |
| `polars-plan/dsl/function_expr/list.rs` | `ListFunction::Product` variant + display name |
| `polars-plan/aexpr/function_expr/list.rs` | same + type mapper + FunctionOptions arm |
| `polars-plan/dsl/list.rs` | `ListNameSpace::product()` method |
| `polars-python/src/expr/list.rs` | `list_product` Rust→Python binding |
| `py-polars/src/polars/expr/list.py` | `Expr.list.product()` with doctest |
| `py-polars/src/polars/series/list.py` | `Series.list.product()` with doctest |

## Test plan

- [ ] `pytest py-polars/tests/unit/datatypes/test_list.py`
- [ ] `cargo test -p polars-ops list` 
- [ ] Verify integer and float dtypes produce correct products
- [ ] Verify null-handling: null element → null output row