### PR TITLE
fix: Select with expr slice and len gave incorrect len

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_expr.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_expr.rs
@@ -354,7 +354,7 @@ fn aexpr_slice_pushdown_top(
     )
     .unwrap();
 
-    if let AExpr::Column(_) = ae {
+    if let AExpr::Column(_) | AExpr::Len = ae {
         *col_hit_count = col_hit_count.map(|x| x + 1);
     }
 

--- a/py-polars/tests/unit/lazyframe/test_optimizations.py
+++ b/py-polars/tests/unit/lazyframe/test_optimizations.py
@@ -911,6 +911,19 @@ def test_slice_pushdown_expr_height_rules() -> None:
     assert_frame_equal(q.collect(), pl.DataFrame({"a": 3}))
 
 
+def test_slice_pushdown_expr_leaf_ae_without_col_input_27820() -> None:
+    lf = pl.LazyFrame({"a": [1, 2, 3]})
+    q = lf.select(pl.first("a"), pl.len().cast(pl.Int64))
+    out = q.collect()
+
+    assert_frame_equal(out, pl.DataFrame({"a": 1, "len": 3}))
+
+    q = lf.select(pl.first("a"), pl.lit(pl.Series("s", [-1, -2, -3])).first())
+    out = q.collect()
+
+    assert_frame_equal(out, pl.DataFrame({"a": 1, "s": -1}))
+
+
 def test_slice_pushdown_joins_27199() -> None:
     lhs = pl.LazyFrame({"a": [0, 0]})
     rhs = pl.LazyFrame({"a": [0, 0]})


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/27820

`AExpr::Len` does not reference a column node but requires the full column to be projected.
