### PR TITLE
fix: Fix incorrect projection height when selecting only literals

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -436,7 +436,7 @@ impl ProjectionPushdownVisitor<'_, '_> {
                     let mut truncate_len = projected_names.len();
 
                     // If exprs has any column-height output, at least 1 of them must be projected.
-                    if let Some(column_height_idx) = exprs.iter().position(|e| {
+                    let first_column_height_idx = exprs.iter().position(|e| {
                         matches!(
                             aexpr_projection_height_rec(
                                 e.node(),
@@ -446,14 +446,16 @@ impl ProjectionPushdownVisitor<'_, '_> {
                             ),
                             EH::Column
                         )
-                    }) && column_height_idx >= truncate_len
+                    });
+
+                    if let Some(column_height_idx) = first_column_height_idx
+                        && column_height_idx >= truncate_len
                     {
                         exprs.swap(column_height_idx, projected_names.len());
                         truncate_len += 1;
                     }
 
-                    // Project all unknown heights to catch length mismatch errors.
-                    if self.maintain_errors {
+                    if first_column_height_idx.is_none() || self.maintain_errors {
                         let range = truncate_len..exprs.len();
                         for i in range {
                             match aexpr_projection_height_rec(

--- a/py-polars/tests/unit/lazyframe/test_projections.py
+++ b/py-polars/tests/unit/lazyframe/test_projections.py
@@ -927,3 +927,16 @@ def test_projection_pushdown_fastcount_27534(
 
     assert_frame_equal(lf.select(pl.len()).collect(), df.select(pl.len()))
     assert_frame_equal(lf.collect(), df)
+
+
+def test_projection_pushdown_select_non_column_height_27807() -> None:
+    q = (
+        pl.LazyFrame()
+        .select(
+            x=pl.Series([1, 2, 3]),
+            y=pl.lit(10, dtype=pl.Int64),
+        )
+        .select("y")
+    )
+
+    assert_frame_equal(q.collect(), pl.Series("y", [10, 10, 10]).to_frame())


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/27807

PR updates optimizer to project all exprs if we don't have a column height expr.
