### PR TITLE
fix: handle reordered streaming projections

### DIFF
--- a/crates/polars-stream/src/nodes/simple_projection.rs
+++ b/crates/polars-stream/src/nodes/simple_projection.rs
@@ -60,17 +60,20 @@ impl ComputeNode for SimpleProjectionNode {
             let slf = &*self;
             join_handles.push(scope.spawn_task(TaskPriority::High, async move {
                 while let Ok(morsel) = recv.recv().await {
-                    let morsel = morsel.try_map(|df| unsafe {
+                    let morsel = morsel.try_map(|df| {
                         let mut cols = Vec::with_capacity(slf.projection.len());
                         for (idx, name, rename) in &slf.projection {
-                            let mut col = df.columns()[*idx].clone();
+                            let mut col = match df.columns().get(*idx) {
+                                Some(col) if col.name() == name => col.clone(),
+                                _ => df.column(name)?.clone(),
+                            };
                             debug_assert_eq!(col.name(), name);
                             if let Some(name) = rename {
                                 col.rename(name.clone())
                             }
                             cols.push(col)
                         }
-                        PolarsResult::Ok(DataFrame::new_unchecked(df.height(), cols))
+                        PolarsResult::Ok(unsafe { DataFrame::new_unchecked(df.height(), cols) })
                     })?;
 
                     if send.send(morsel).await.is_err() {

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import os
 import time
 from datetime import date
@@ -474,4 +475,33 @@ def test_streaming_hconcat_strict_27372() -> None:
 
     result = lf.collect(engine="streaming")
     expected = lf.collect(engine="in-memory")
+    assert_frame_equal(result, expected)
+
+
+def test_streaming_hconcat_reordered_projection_sink_27818() -> None:
+    df1 = pl.LazyFrame(
+        [{"B": None, "C": None}],
+        {"B": pl.Boolean, "C": pl.Categorical},
+    )
+    df2 = pl.LazyFrame(
+        [{"D": "1"}],
+        {"D": pl.String},
+    )
+    lf = pl.concat(
+        [
+            df1.select("C", "B"),
+            df2,
+        ],
+        how="horizontal",
+    ).select("B", "C")
+
+    with io.BytesIO() as f:
+        lf.sink_parquet(f, engine="streaming")
+        f.seek(0)
+        result = pl.read_parquet(f)
+
+    expected = pl.DataFrame(
+        {"B": [None], "C": [None]},
+        schema={"B": pl.Boolean, "C": pl.Categorical},
+    )
     assert_frame_equal(result, expected)


### PR DESCRIPTION
Fixes #27818

### Summary

- make the streaming `SimpleProjectionNode` fall back to name lookup when a precomputed column index no longer points at the expected input column
- keep the existing fast path when the index still matches, and handle stale/out-of-bounds indexes without panicking before lookup
- add a regression test for horizontal concat plus reordered projection before `sink_parquet(engine="streaming")`

### Tests

- `rustfmt --edition 2024 --check crates/polars-stream/src/nodes/simple_projection.rs`
- `python -m ruff check py-polars/tests/unit/streaming/test_streaming.py`
- `cargo check -p polars-stream`
- `git diff --check`

I could not run the new Python regression locally because building the Python runtime extension with `maturin develop -m py-polars/runtime/polars-runtime-32/Cargo.toml --features backtrace_filter --profile mindebug-dev` exhausted the available system-drive space while downloading the full runtime dependency graph.
