### PR TITLE
chore(python): Refactor to avoid `unbound-name` Pyright/Pyrefly errors

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -2486,6 +2486,8 @@ class DataFrame:
             ).cast(to_dtype)  # type: ignore[arg-type]
             frame = F.concat([label_frame, features_frame], how="horizontal")
         else:
+            label_frame = None
+            features_frame = None
             frame = (self.select(features) if features is not None else self).cast(
                 to_dtype  # type: ignore[arg-type]
             )
@@ -2498,7 +2500,7 @@ class DataFrame:
             return torch.from_numpy(arr)
 
         elif return_type == "dict":
-            if label is not None:
+            if label_frame is not None and features_frame is not None:
                 # return a {"label": tensor(s), "features": tensor(s)} dict
                 return {
                     "label": label_frame.to_torch(),
@@ -2512,7 +2514,7 @@ class DataFrame:
             # return a torch Dataset object
             from polars.ml.torch import PolarsDataset
 
-            pds_label = None if label is None else label_frame.columns
+            pds_label = None if label_frame is None else label_frame.columns
             return PolarsDataset(frame, label=pds_label, features=features)
         else:
             valid_torch_types = ", ".join(get_args(TorchExportType))

--- a/py-polars/src/polars/io/iceberg/_dataset.py
+++ b/py-polars/src/polars/io/iceberg/_dataset.py
@@ -383,6 +383,7 @@ class IcebergScanResolver:
         deletion_files: dict[int, list[str]] = {}
         total_physical_rows: int = 0
         total_deleted_rows: int = 0
+        total_deletion_files = 0
 
         if reader_override != "pyiceberg" and not fallback_reason:
             from pyiceberg.manifest import DataFileContent, FileFormat
@@ -400,8 +401,6 @@ class IcebergScanResolver:
 
             if iceberg_table_filter is not None:
                 scan = scan.filter(iceberg_table_filter)
-
-            total_deletion_files = 0
 
             for i, file_info in enumerate(scan.plan_files()):
                 if file_info.file.file_format != FileFormat.PARQUET:

--- a/py-polars/src/polars/io/iceberg/_sink.py
+++ b/py-polars/src/polars/io/iceberg/_sink.py
@@ -231,6 +231,8 @@ class IcebergSinkState:
             eprint(
                 f"IcebergSinkState[commit]: finish transaction commit ({elapsed:.3f}s)"
             )
+        else:
+            now = None
 
         new_metadata_location = table.metadata_location
 
@@ -244,7 +246,7 @@ class IcebergSinkState:
             )
         )
 
-        if verbose:
+        if now is not None:
             total_elapsed = now - function_start_instant
 
             eprint(

--- a/py-polars/src/polars/io/spreadsheet/functions.py
+++ b/py-polars/src/polars/io/spreadsheet/functions.py
@@ -1193,13 +1193,13 @@ def _read_spreadsheet_openpyxl(
     header: list[str | None] = []
 
     if table_name and not sheet_name:
-        sheet_name, n_tables = None, 0
+        ws, sheet_name, n_tables = None, None, 0
         for sheet in parser.worksheets:
             n_tables += 1
             if table_name in sheet.tables:
                 ws, sheet_name = sheet, sheet.title
                 break
-        if sheet_name is None:
+        if ws is None:
             msg = (
                 f"table named {table_name!r} not found in sheet {sheet_name!r}"
                 if n_tables

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -9366,11 +9366,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             msg = f"`how` must be one of {{'left', 'inner', 'full'}}; found {how!r}"
             raise ValueError(msg)
 
-        row_index_used = False
+        row_index_name = None
         if on is None:
             if left_on is None and right_on is None:
                 # no keys provided--use row index
-                row_index_used = True
                 row_index_name = "__POLARS_ROW_INDEX"
                 self = self.with_row_index(row_index_name)
                 other = other.with_row_index(row_index_name)
@@ -9405,7 +9404,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         # no need to join if *only* join columns are in other (inner/left update only)
         if how != "full" and len(right_schema) == len(right_on):
-            if row_index_used:
+            if row_index_name is not None:
                 return self.drop(row_index_name)
             return self
 
@@ -9447,7 +9446,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             )
             .drop(drop_columns)
         )
-        if row_index_used:
+        if row_index_name is not None:
             result = result.drop(row_index_name)
 
         return self._from_pyldf(result._ldf)


### PR DESCRIPTION
Splitting this out from #27722 , per @nameexhaustion 's suggestion

Aside from solving type-checker errors, I think that the changes to `py-polars/src/polars/lazyframe/frame.py` make it clearer than using `row_index_used` boolean. I think the other changes are no better and no worse

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
