### PR TITLE
docs: Replace Typeform sign-up URL with new enterprise link

### DIFF
--- a/docs/source/polars-on-premises/bare-metal/configuration/license.md
+++ b/docs/source/polars-on-premises/bare-metal/configuration/license.md
@@ -1,8 +1,8 @@
 # License
 
 Polars On-Prem requires a license key to run. If you haven't contacted Polars yet,
-[sign up here to apply](https://w0lzyfh2w8o.typeform.com/to/zuoDgoMv). A license key looks like
-this:
+[sign up here to apply](https://w0lzyfh2w8o.typeform.com/to/f37L1SRx#form_name=enterprise&form_origin=userguide).
+A license key looks like this:
 
 ```json
 { "params": { "expiry": "2026-01-31T23:59:59Z", "name": "Company" }, "signature": "..." }

--- a/docs/source/polars-on-premises/bare-metal/getting-started.md
+++ b/docs/source/polars-on-premises/bare-metal/getting-started.md
@@ -1,7 +1,7 @@
 !!! note "Enterprise only"
 
     Bare-metal deployment requires a Polars On-Prem Enterprise license.
-    [Sign up here](https://w0lzyfh2w8o.typeform.com/to/zuoDgoMv) to obtain one.
+    [Sign up here](https://w0lzyfh2w8o.typeform.com/to/f37L1SRx#form_name=enterprise&form_origin=userguide) to obtain one.
 
 ## Downloading Polars On-Prem
 

--- a/docs/source/polars-on-premises/billing/index.md
+++ b/docs/source/polars-on-premises/billing/index.md
@@ -29,4 +29,5 @@ The following limits apply to Self-Serve deployments:
 Enterprise is priced based on your deployment. It removes resource limitations and supports fully
 air-gapped environments with no outbound connectivity required.
 
-[Contact us](https://w0lzyfh2w8o.typeform.com/to/zuoDgoMv) to discuss an Enterprise plan.
+[Contact us](https://w0lzyfh2w8o.typeform.com/to/f37L1SRx#form_name=enterprise&form_origin=userguide)
+to discuss an Enterprise plan.

--- a/docs/source/polars-on-premises/index.md
+++ b/docs/source/polars-on-premises/index.md
@@ -64,4 +64,4 @@ historical view of query performance that survives cluster restarts and teardown
 Enterprise is for teams operating in air-gapped or regulated environments. The entire control plane
 runs inside your infrastructure, no outbound traffic required.
 
-[Request an Enterprise license](https://w0lzyfh2w8o.typeform.com/to/zuoDgoMv)
+[Request an Enterprise license](https://w0lzyfh2w8o.typeform.com/to/f37L1SRx#form_name=enterprise&form_origin=userguide)

--- a/docs/source/polars-on-premises/kubernetes/index.md
+++ b/docs/source/polars-on-premises/kubernetes/index.md
@@ -233,4 +233,4 @@ Resource allocation and cluster topology configuration is under the
 
 If you are interested in deploying one or several clusters without any resource limitations nor data
 sharing, on bare-metal machines or in a Kubernetes setup, and in air-gapped environments, please
-[sign up here to apply](https://w0lzyfh2w8o.typeform.com/to/zuoDgoMv).
+[sign up here to apply](https://w0lzyfh2w8o.typeform.com/to/f37L1SRx#form_name=enterprise&form_origin=userguide).


### PR DESCRIPTION
Updates the on-premise/enterprise sign-up Typeform link across the on-premises docs to use the new URL with `form_name=enterprise&form_origin=userguide` for click-source tracking. (Helps us find out where people are coming from so we can improve the sources for their respective types of traffic).