### PR TITLE
fix(rust): Fixed inconsistency of type coercion on struct arithmetic (#23797)

### DIFF
--- a/crates/polars-plan/src/plans/conversion/type_coercion/binary.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/binary.rs
@@ -61,13 +61,25 @@ fn process_struct_numeric_arithmetic(
     match (&type_left, &type_right) {
         (DataType::Struct(fields), _) => {
             if let Some(first) = fields.first() {
+                let wide_fields: PolarsResult<Vec<Field>> = fields
+                    .iter()
+                    .map(|f| {
+                        let st = try_get_supertype(&f.dtype, &type_right)?;
+                        Ok(Field::new(f.name().clone(), st))
+                    })
+                    .collect();
+                let new_node_left = expr_arena.add(AExpr::Cast {
+                    expr: node_left,
+                    dtype: DataType::Struct(wide_fields.clone()?),
+                    options: CastOptions::NonStrict,
+                });
                 let new_node_right = expr_arena.add(AExpr::Cast {
                     expr: node_right,
-                    dtype: DataType::Struct(vec![first.clone()]),
+                    dtype: DataType::Struct(wide_fields.clone()?),
                     options: CastOptions::NonStrict,
                 });
                 Ok(Some(AExpr::BinaryExpr {
-                    left: node_left,
+                    left: new_node_left,
                     op,
                     right: new_node_right,
                 }))
@@ -77,16 +89,28 @@ fn process_struct_numeric_arithmetic(
         },
         (_, DataType::Struct(fields)) => {
             if let Some(first) = fields.first() {
+                let wide_fields: PolarsResult<Vec<Field>> = fields
+                    .iter()
+                    .map(|f| {
+                        let st = try_get_supertype(&f.dtype, &type_left)?;
+                        Ok(Field::new(f.name().clone(), st))
+                    })
+                    .collect();
                 let new_node_left = expr_arena.add(AExpr::Cast {
                     expr: node_left,
-                    dtype: DataType::Struct(vec![first.clone()]),
+                    dtype: DataType::Struct(wide_fields.clone()?),
+                    options: CastOptions::NonStrict,
+                });
+                let new_node_right = expr_arena.add(AExpr::Cast {
+                    expr: node_right,
+                    dtype: DataType::Struct(wide_fields.clone()?),
                     options: CastOptions::NonStrict,
                 });
 
                 Ok(Some(AExpr::BinaryExpr {
                     left: new_node_left,
                     op,
-                    right: node_right,
+                    right: new_node_right,
                 }))
             } else {
                 Ok(None)

--- a/crates/polars-plan/src/plans/conversion/type_coercion/binary.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/binary.rs
@@ -60,7 +60,7 @@ fn process_struct_numeric_arithmetic(
 ) -> PolarsResult<Option<AExpr>> {
     match (&type_left, &type_right) {
         (DataType::Struct(fields), _) => {
-            if let Some(first) = fields.first() {
+            if let Some(_first) = fields.first() {
                 let wide_fields: PolarsResult<Vec<Field>> = fields
                     .iter()
                     .map(|f| {
@@ -88,7 +88,7 @@ fn process_struct_numeric_arithmetic(
             }
         },
         (_, DataType::Struct(fields)) => {
-            if let Some(first) = fields.first() {
+            if let Some(_first) = fields.first() {
                 let wide_fields: PolarsResult<Vec<Field>> = fields
                     .iter()
                     .map(|f| {


### PR DESCRIPTION
Changed the `process_struct_numeric_arithmetic` casting procedure to widen the fields of the struct before processing the operation. Struct arithmetic now behaves more similarly to binary operation of numeric data and a list.

This change causes a lot of tests to fail because it alters the schema of the structure after the operation, keeping the operation non-lossy makes changing the schema of the struct unavoidable I think.

Addresses  #23797