### PR TITLE
docs: Add maskops to community plugins

### DIFF
--- a/docs/source/user-guide/plugins/index.md
+++ b/docs/source/user-guide/plugins/index.md
@@ -33,6 +33,12 @@ Here is a curated (non-exhaustive) list of community-implemented plugins.
   the H3 discrete global grid system, so you can index points and geometries to hexagons directly in
   Polars.
 
+### Privacy
+
+- [maskops](https://github.com/fcarvajalbrown/maskops) High-speed PII masking as a Polars plugin —
+  powered by Rust. Detects and masks credit cards, IBANs, emails, phone numbers, and more with
+  optional format-preserving encryption (FF3-1 AES-256).
+
 ## Other material
 
 - [Ritchie Vink - Keynote on Polars Plugins](https://youtu.be/jKW-CBV7NUM)


### PR DESCRIPTION
## What

Adds [maskops](https://github.com/fcarvajalbrown/maskops) to the Privacy section of the community plugins list.

## Why

MaskOps is a native Polars expression plugin (Rust `cdylib`) for high-speed PII masking. It exposes three expressions — `mask_pii`, `contains_pii`, and `mask_pii_fpe` — and supports:

- Credit cards, IBANs, emails, phone numbers, RUT, CPF, CURP, VAT, EU national IDs, IPs
- Asterisk masking (irreversible) and FF3-1 AES-256 format-preserving encryption (reversible, same length/format)
- Available on PyPI: `pip install maskops`

Privacy/PII masking is a common pre-processing step in data pipelines and doesn't have an existing entry in the community list.