### PR TITLE
fix: Use block_in_place_on for calls which can come from executor thread

### DIFF
--- a/crates/polars-stream/src/execute.rs
+++ b/crates/polars-stream/src/execute.rs
@@ -287,7 +287,7 @@ fn run_subgraph(
         }
 
         // Wait until all tasks are done.
-        ASYNC.block_on(async move {
+        ASYNC.block_in_place_on(async move {
             for handle in join_handles {
                 handle.await?;
             }
@@ -336,7 +336,7 @@ pub fn execute_graph(
             m.lock().flush(&graph.pipes);
         }
 
-        ASYNC.block_on(async {
+        ASYNC.block_in_place_on(async {
             // TODO: track this in metrics.
             while let Ok(handle) = subphase_tasks_recv.try_recv() {
                 handle.await.unwrap()?;
@@ -368,7 +368,7 @@ pub fn execute_graph(
             &state,
             metrics.clone(),
         )?;
-        ASYNC.block_on(async {
+        ASYNC.block_in_place_on(async {
             // TODO: track this in metrics.
             while let Ok(handle) = subphase_tasks_recv.try_recv() {
                 handle.await.unwrap()?;
@@ -386,7 +386,7 @@ pub fn execute_graph(
     }
 
     // Finalize query tasks.
-    ASYNC.block_on(async {
+    ASYNC.block_in_place_on(async {
         // TODO: track this in metrics.
         while let Ok(handle) = query_tasks_recv.try_recv() {
             handle.await.unwrap()?;

--- a/crates/polars-stream/src/nodes/group_by.rs
+++ b/crates/polars-stream/src/nodes/group_by.rs
@@ -475,7 +475,7 @@ impl GroupBySinkState {
             drop(arc_pre_aggs_per_local);
             drop(drop_q_send);
 
-            ASYNC.block_on(async move {
+            ASYNC.block_in_place_on(async move {
                 for handle in join_handles {
                     handle.await?;
                 }

--- a/crates/polars-stream/src/nodes/io_sinks/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/mod.rs
@@ -96,7 +96,7 @@ impl ComputeNode for IOSinkNode {
                         );
                     }
                     drop(phase_channel_tx);
-                    ASYNC.block_on(task_handle)?;
+                    ASYNC.block_in_place_on(task_handle)?;
                 },
                 IOSinkNodeState::Finished => {},
                 IOSinkNodeState::Uninitialized { .. } => unreachable!(),

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/mod.rs
@@ -76,7 +76,7 @@ impl ComputeNode for MultiScan {
             // Refresh first - in case there is an error we end here instead of ending when we go
             // into spawn.
             executor::task_scope(|s| {
-                ASYNC.block_on(s.spawn_task(TaskPriority::High, self.state.refresh(self.verbose)))
+                ASYNC.block_in_place_on(s.spawn_task(TaskPriority::High, self.state.refresh(self.verbose)))
             })?;
 
             match self.state {

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/mod.rs
@@ -76,7 +76,9 @@ impl ComputeNode for MultiScan {
             // Refresh first - in case there is an error we end here instead of ending when we go
             // into spawn.
             executor::task_scope(|s| {
-                ASYNC.block_in_place_on(s.spawn_task(TaskPriority::High, self.state.refresh(self.verbose)))
+                ASYNC.block_in_place_on(
+                    s.spawn_task(TaskPriority::High, self.state.refresh(self.verbose)),
+                )
             })?;
 
             match self.state {

--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -418,7 +418,7 @@ impl SampleState {
                     ));
                 }
 
-                ASYNC.block_on(async move {
+                ASYNC.block_in_place_on(async move {
                     for handle in join_handles {
                         handle.await?;
                     }
@@ -738,7 +738,7 @@ impl BuildState {
             drop(arc_morsels_per_local_builder);
             drop(morsel_drop_q_send);
 
-            ASYNC.block_on(async move {
+            ASYNC.block_in_place_on(async move {
                 for handle in join_handles {
                     handle.await;
                 }

--- a/crates/polars-stream/src/nodes/joins/semi_anti_join.rs
+++ b/crates/polars-stream/src/nodes/joins/semi_anti_join.rs
@@ -248,7 +248,7 @@ impl BuildState {
             drop(arc_keys_per_local_builder);
             drop(key_drop_q_send);
 
-            ASYNC.block_on(async move {
+            ASYNC.block_in_place_on(async move {
                 for handle in join_handles {
                     handle.await;
                 }


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/27839.

These blocking calls are reachable from an executor thread through `collect_all`.