### PR TITLE
refactor(rust): Use `Vec` instead of `PlHashMap` for `ProjectionInfo.map`

### DIFF
--- a/crates/polars-arrow/src/io/ipc/read/common.rs
+++ b/crates/polars-arrow/src/io/ipc/read/common.rs
@@ -3,7 +3,6 @@ use std::io::{Read, Seek};
 use std::sync::Arc;
 
 use polars_error::{PolarsResult, polars_bail, polars_err};
-use polars_utils::aliases::PlHashMap;
 use polars_utils::bool::UnsafeBool;
 use polars_utils::pl_str::PlSmallStr;
 
@@ -317,7 +316,7 @@ pub fn read_dictionary<R: Read + Seek>(
 #[derive(Clone)]
 pub struct ProjectionInfo {
     pub columns: Vec<usize>,
-    pub map: PlHashMap<usize, usize>,
+    pub map: Vec<usize>,
     pub schema: ArrowSchema,
 }
 
@@ -330,16 +329,8 @@ pub fn prepare_projection(schema: &ArrowSchema, mut projection: Vec<usize>) -> P
         })
         .collect();
 
-    // todo: find way to do this more efficiently
-    let mut indices = (0..projection.len()).collect::<Vec<_>>();
-    indices.sort_unstable_by_key(|&i| &projection[i]);
-    let map = indices.iter().copied().enumerate().fold(
-        PlHashMap::default(),
-        |mut acc, (index, new_index)| {
-            acc.insert(index, new_index);
-            acc
-        },
-    );
+    let mut map = (0..projection.len()).collect::<Vec<_>>();
+    map.sort_unstable_by_key(|&i| &projection[i]);
     projection.sort_unstable();
 
     // check unique
@@ -364,7 +355,7 @@ pub fn prepare_projection(schema: &ArrowSchema, mut projection: Vec<usize>) -> P
 
 pub fn apply_projection(
     chunk: RecordBatchT<Box<dyn Array>>,
-    map: &PlHashMap<usize, usize>,
+    map: &[usize],
 ) -> RecordBatchT<Box<dyn Array>> {
     let length = chunk.len();
 
@@ -373,14 +364,14 @@ pub fn apply_projection(
     let mut new_schema = schema.as_ref().clone();
     let mut new_arrays = arrays.clone();
 
-    map.iter().for_each(|(old, new)| {
-        let (old_name, old_field) = schema.get_at_index(*old).unwrap();
+    map.iter().enumerate().for_each(|(old, new)| {
+        let (old_name, old_field) = schema.get_at_index(old).unwrap();
         let (new_name, new_field) = new_schema.get_at_index_mut(*new).unwrap();
 
         *new_name = old_name.clone();
         *new_field = old_field.clone();
 
-        new_arrays[*new] = arrays[*old].clone();
+        new_arrays[*new] = arrays[old].clone();
     });
 
     RecordBatchT::new(length, Arc::new(new_schema), new_arrays)

--- a/crates/polars-stream/src/nodes/io_sources/ipc/record_batch_decode.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ipc/record_batch_decode.rs
@@ -6,7 +6,6 @@ use arrow::io::ipc::read::{Dictionaries, ProjectionInfo};
 use arrow::io::ipc::write::KeyValueRef;
 use polars_core::chunked_array::flags::StatisticsFlags;
 use polars_core::frame::DataFrame;
-use polars_core::prelude::PlHashMap;
 use polars_core::schema::Schema;
 use polars_core::utils::arrow::io::ipc::read::common::apply_projection;
 use polars_core::utils::arrow::io::ipc::read::{BlockReader, FileMetadata, read_batch};
@@ -150,7 +149,7 @@ fn get_flags(
 fn project_flags(
     flags: Option<Vec<Option<StatisticsFlags>>>,
     columns: &[usize],
-    map: &PlHashMap<usize, usize>,
+    map: &[usize],
 ) -> Option<Vec<Option<StatisticsFlags>>> {
     if let Some(inner) = flags {
         let cols: Vec<_> = columns.iter().map(|i| inner[*i]).collect();
@@ -159,8 +158,8 @@ fn project_flags(
         // NOTE. Because of the way the projection map is generated, the scenario
         // where old != new is not reachable at the time of writing, and therefore
         // not tested.
-        map.iter().for_each(|(old, new)| {
-            out[*new] = cols[*old];
+        map.iter().enumerate().for_each(|(old, new)| {
+            out[*new] = cols[old];
         });
         Some(out)
     } else {


### PR DESCRIPTION
Does not resolve any particular issue. I was looking for improvement and learning opportunities in the codebase and I found a `//todo` left by Ritchie quite some time ago and I gave it a shot. 

The original code was creating `map` by iterating over `indices` and using `.fold()` to append `(index, new_index)` pairs onto a `PlHashMap`. The `PlHashMap` keys came from `enumerate()`, so they were always the dense range `(0, 1, ...)`. But, if the keys are just counting numbers starting at `0`, the key is equal to the position, which can be translated easily into a `Vec`. 

The benefit of changing this is that we:
* No longer iterate over `indices` and use `.fold()` to create a `PlHashMap` - the performance gain of this is most likely negligible, but it was still an unnecessary operation that could be removed. 
* We use a `Vec` over a `PlHashMap`, which avoids the machinery that exists to handle arbitrary sparse keys, instead relying on `Vec`'s natural indexing properties. 
* We no longer build `map` by folding over `indices`, avoiding making a copy of a vector that already existed in the first place.

Other files and functions using `ProjectionInfo.map` were also updated to match the new functionality. 

🤖 Claude Opus 4.8 helping me navigate code and explaining concepts. 