### PR TITLE
fix(python): CloseAfterFrameIter should close cursor, not result set

### DIFF
--- a/py-polars/src/polars/io/database/_executor.py
+++ b/py-polars/src/polars/io/database/_executor.py
@@ -597,7 +597,7 @@ class ConnectionExecutor:
                         df
                         for df in CloseAfterFrameIter(
                             frame,
-                            cursor=self.result,
+                            cursor=self.cursor,
                         )
                     )
                 return frame


### PR DESCRIPTION
## Summary

`CloseAfterFrameIter` was being initialized with `self.result` (the query result set) instead of `self.cursor` (the actual database cursor/connection). When iterating over batches finished, `self._cursor.close()` closed the result set rather than returning the real cursor to the pool, causing connection leaks.

## Changes

Changed `CloseAfterFrameIter(frame, cursor=self.result)` to `CloseAfterFrameIter(frame, cursor=self.cursor)` in `to_polars()`.

## Testing

- The fix targets a single one-line change in the cursor reference passed to `CloseAfterFrameIter`
- Existing tests should continue to pass as the rest of the logic is unchanged

Fixes pola-rs/polars#27821

AI assistance disclosure: this PR was co-authored by an AI assistant (OpenClaw Buck) under human supervision.