### PR TITLE
fix: Correct over(nulls_last) with multiple order_by columns

### DIFF
--- a/crates/polars-expr/src/expressions/sortby.rs
+++ b/crates/polars-expr/src/expressions/sortby.rs
@@ -70,6 +70,44 @@ pub(super) fn update_groups_sort_by(
     Ok(GroupsType::Idx(groups))
 }
 
+/// Sort the groups by *multiple* `order_by` columns.
+///
+/// A multi-column `order_by` (e.g. `over(order_by=[a, b], nulls_last=...)`) is packed into a single
+/// struct upstream. Sorting that struct as a whole only applies `nulls_last`/`descending` to the
+/// struct's outer validity, not to each inner field, which produces incorrect orderings (see
+/// <https://github.com/pola-rs/polars/issues/27819>). This routes the individual order-by columns
+/// through the multi-key `arg_sort_multiple` path instead, mirroring `sort_by`'s per-column
+/// semantics by broadcasting the single `descending`/`nulls_last` flag to every column.
+pub(super) fn update_groups_sort_by_multiple(
+    groups: &GroupsType,
+    sort_by_s: &[Series],
+    options: &SortOptions,
+) -> PolarsResult<GroupsType> {
+    // Will trigger a gather for every group, so rechunk before.
+    let by = sort_by_s.iter().map(|s| s.rechunk()).collect::<Vec<_>>();
+    let descending = vec![options.descending; by.len()];
+    let nulls_last = vec![options.nulls_last; by.len()];
+
+    let groups = RAYON.install(|| {
+        groups
+            .par_iter()
+            .map(|indicator| {
+                sort_by_groups_multiple_by(
+                    indicator,
+                    &by,
+                    &descending,
+                    &nulls_last,
+                    // We are already in a par iter.
+                    false,
+                    options.maintain_order,
+                )
+            })
+            .collect::<PolarsResult<_>>()
+    })?;
+
+    Ok(GroupsType::Idx(groups))
+}
+
 fn sort_by_groups_single_by(
     indicator: GroupsIndicator,
     sort_by_s: &Series,

--- a/crates/polars-expr/src/expressions/window.rs
+++ b/crates/polars-expr/src/expressions/window.rs
@@ -26,7 +26,12 @@ pub struct WindowExpr {
     /// the root column that the Function will be applied on.
     /// This will be used to create a smaller DataFrame to prevent taking unneeded columns by index
     pub(crate) group_by: Vec<Arc<dyn PhysicalExpr>>,
-    pub(crate) order_by: Option<(Arc<dyn PhysicalExpr>, SortOptions)>,
+    /// Columns to order each window partition by.
+    ///
+    /// More than one column is produced when the user passes multiple `order_by` columns. These
+    /// must be sorted with per-column null placement (like `sort_by`); see
+    /// <https://github.com/pola-rs/polars/issues/27819>.
+    pub(crate) order_by: Option<(Vec<Arc<dyn PhysicalExpr>>, SortOptions)>,
     pub(crate) apply_columns: Vec<PlSmallStr>,
     pub(crate) phys_function: Arc<dyn PhysicalExpr>,
     pub(crate) mapping: WindowMapping,
@@ -434,10 +439,20 @@ impl PhysicalExpr for WindowExpr {
             let mut groups = gb.into_groups();
 
             if let Some((order_by, options)) = &self.order_by {
-                let order_by = order_by.evaluate(df, state)?;
-                polars_ensure!(order_by.len() == df.height(), ShapeMismatch: "the order by expression evaluated to a length: {} that doesn't match the input DataFrame: {}", order_by.len(), df.height());
-                groups = update_groups_sort_by(&groups, order_by.as_materialized_series(), options)?
-                    .into_sliceable()
+                let order_by = order_by
+                    .iter()
+                    .map(|e| {
+                        let s = e.evaluate(df, state)?;
+                        polars_ensure!(s.len() == df.height(), ShapeMismatch: "the order by expression evaluated to a length: {} that doesn't match the input DataFrame: {}", s.len(), df.height());
+                        Ok(s.as_materialized_series().clone())
+                    })
+                    .collect::<PolarsResult<Vec<_>>>()?;
+                groups = if order_by.len() == 1 {
+                    update_groups_sort_by(&groups, &order_by[0], options)?
+                } else {
+                    update_groups_sort_by_multiple(&groups, &order_by, options)?
+                }
+                .into_sliceable();
             }
 
             let out: PolarsResult<GroupPositions> = Ok(groups);
@@ -451,14 +466,16 @@ impl PhysicalExpr for WindowExpr {
             for s in &group_by_columns {
                 cache_key.push_str(s.name());
             }
-            if let Some((e, options)) = &self.order_by {
-                let e = match e.as_expression() {
-                    Some(e) => e,
-                    None => {
-                        polars_bail!(InvalidOperation: "cannot order by this expression in window function")
-                    },
-                };
-                window_function_format_order_by(&mut cache_key, e, options)
+            if let Some((order_by, options)) = &self.order_by {
+                for e in order_by {
+                    let e = match e.as_expression() {
+                        Some(e) => e,
+                        None => {
+                            polars_bail!(InvalidOperation: "cannot order by this expression in window function")
+                        },
+                    };
+                    window_function_format_order_by(&mut cache_key, e, options)
+                }
             }
 
             let groups = match state.window_cache.get_groups(&cache_key) {
@@ -687,19 +704,56 @@ impl PhysicalExpr for WindowExpr {
             .collect::<PolarsResult<Vec<_>>>()?;
         let order_by = match &self.order_by {
             None => None,
-            Some((e, options)) => {
-                let mut e = e.evaluate(df, state)?;
-                if e.len() == 1 {
-                    e = e.new_from_index(0, length_preserving_height);
+            Some((order_by, options)) => {
+                let mut columns = order_by
+                    .iter()
+                    .map(|e| {
+                        let mut s = e.evaluate(df, state)?.as_materialized_series().clone();
+                        if s.len() == 1 {
+                            s = s.new_from_index(0, length_preserving_height);
+                        }
+                        // Sanity check: Length Preserving.
+                        assert_eq!(s.len(), length_preserving_height);
+                        Ok(s)
+                    })
+                    .collect::<PolarsResult<Vec<_>>>()?;
+
+                // For multiple `order_by` columns we need per-column null placement (like
+                // `sort_by`). Collapse the columns into a single ordinal rank that already encodes
+                // the multi-key order, so the per-group reordering below stays single-column.
+                // See https://github.com/pola-rs/polars/issues/27819.
+                let mut options = *options;
+                if columns.len() > 1 {
+                    let descending = vec![options.descending; columns.len()];
+                    let nulls_last = vec![options.nulls_last; columns.len()];
+                    let sort_options = SortMultipleOptions {
+                        descending,
+                        nulls_last,
+                        multithreaded: true,
+                        maintain_order: options.maintain_order,
+                        limit: None,
+                    };
+                    let by = columns
+                        .iter()
+                        .map(|s| Column::from(s.clone()))
+                        .collect::<Vec<_>>();
+                    let sorted_idx = by[0]
+                        .as_materialized_series()
+                        .arg_sort_multiple(&by[1..], &sort_options)?;
+                    // Invert the permutation into an ordinal rank: rank[row] = sorted position.
+                    let rank = sorted_idx.arg_sort(Default::default());
+                    columns = vec![rank.into_series()];
+                    // The rank fully encodes ordering; sort it ascending with nulls (none) first.
+                    options = SortOptions::default();
                 }
-                // Sanity check: Length Preserving.
-                assert_eq!(e.len(), length_preserving_height);
+                let e = columns.into_iter().next().unwrap();
+
                 let arr: Option<PrimitiveArray<IdxSize>> = if needs_remap_to_rows {
                     feature_gated!("rank", {
                         // Performance: precompute the rank here, so we can avoid dispatching per group
                         // later.
                         use polars_ops::series::SeriesRank;
-                        let arr = e.as_materialized_series().rank(
+                        let arr = e.rank(
                             RankOptions {
                                 method: RankMethod::Ordinal,
                                 descending: false,
@@ -714,7 +768,7 @@ impl PhysicalExpr for WindowExpr {
                     None
                 };
 
-                Some((e.clone(), arr, *options))
+                Some((Column::from(e), arr, options))
             },
         };
 

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -204,6 +204,7 @@ fn create_physical_expr_inner(
                     // the struct as a whole. See
                     // https://github.com/pola-rs/polars/issues/27819.
                     let by_nodes: Vec<Node> = match expr_arena.get(node) {
+                        #[cfg(feature = "dtype-struct")]
                         AExpr::Function {
                             input,
                             function: IRFunctionExpr::AsStruct,

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -198,10 +198,24 @@ fn create_physical_expr_inner(
             let order_by = order_by
                 .map(|(node, options)| {
                     order_by_is_elementwise |= is_elementwise_rec(node, expr_arena);
-                    PolarsResult::Ok((
-                        create_physical_expr_inner(node, expr_arena, schema, state)?,
-                        options,
-                    ))
+                    // A multi-column `order_by` is packed into a single `as_struct` upstream.
+                    // Unpack it back into its individual columns so the window sort can apply
+                    // `nulls_last`/`descending` per column (like `sort_by`), instead of sorting
+                    // the struct as a whole. See
+                    // https://github.com/pola-rs/polars/issues/27819.
+                    let by_nodes: Vec<Node> = match expr_arena.get(node) {
+                        AExpr::Function {
+                            input,
+                            function: IRFunctionExpr::AsStruct,
+                            ..
+                        } => input.iter().map(|e| e.node()).collect(),
+                        _ => vec![node],
+                    };
+                    let by = by_nodes
+                        .into_iter()
+                        .map(|n| create_physical_expr_inner(n, expr_arena, schema, state))
+                        .collect::<PolarsResult<Vec<_>>>()?;
+                    PolarsResult::Ok((by, options))
                 })
                 .transpose()?;
 

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -1984,6 +1984,68 @@ fn test_sort_maintain_order_true() -> PolarsResult<()> {
 }
 
 #[test]
+#[cfg(feature = "dtype-struct")]
+fn test_over_order_by_multiple_nulls_last() -> PolarsResult<()> {
+    // https://github.com/pola-rs/polars/issues/27819
+    // `over(order_by=[...], nulls_last=True)` with MULTIPLE order-by columns must
+    // apply `nulls_last`/`descending` per order-by column (like `sort_by`), not to a
+    // packed struct as a whole.
+    let df = df![
+        "v" => [1i64, 2, 3, 4],
+        "o1" => [None, Some(2i64), Some(1), Some(2)],
+        "o2" => [Some(1i64), None, None, Some(-1)],
+    ]?;
+
+    let nulls_first_opts = SortOptions {
+        nulls_last: false,
+        ..Default::default()
+    };
+    let nulls_last_opts = SortOptions {
+        nulls_last: true,
+        ..Default::default()
+    };
+
+    let out = df
+        .lazy()
+        .select([
+            col("v")
+                .first()
+                .over_with_options(
+                    Option::<[Expr; 2]>::None,
+                    Some(([col("o1"), col("o2")], nulls_first_opts)),
+                    WindowMapping::GroupsToRows,
+                )?
+                .alias("nulls_first"),
+            col("v")
+                .first()
+                .over_with_options(
+                    Option::<[Expr; 2]>::None,
+                    Some(([col("o1"), col("o2")], nulls_last_opts)),
+                    WindowMapping::GroupsToRows,
+                )?
+                .alias("nulls_last"),
+        ])
+        .collect()?;
+
+    // Cross-check against the equivalent `sort_by(...).first()`.
+    let nulls_first: Vec<i64> = out
+        .column("nulls_first")?
+        .i64()?
+        .into_no_null_iter()
+        .collect();
+    let nulls_last: Vec<i64> = out
+        .column("nulls_last")?
+        .i64()?
+        .into_no_null_iter()
+        .collect();
+
+    assert_eq!(nulls_first, vec![1, 1, 1, 1]);
+    assert_eq!(nulls_last, vec![3, 3, 3, 3]);
+
+    Ok(())
+}
+
+#[test]
 fn test_over_with_options_empty_join() -> PolarsResult<()> {
     let empty_df = DataFrame::new_infer_height(vec![
         Series::new_empty("a".into(), &DataType::Int32).into(),

--- a/py-polars/tests/unit/operations/test_over.py
+++ b/py-polars/tests/unit/operations/test_over.py
@@ -183,6 +183,30 @@ def test_nulls_last_over_24989() -> None:
     assert_frame_equal(out, expected)
 
 
+def test_over_multiple_order_by_nulls_last_27819() -> None:
+    # `over(order_by=[...], nulls_last=...)` with MULTIPLE order-by columns must apply
+    # the null placement per order-by column (like `sort_by`), not to the packed struct
+    # as a whole. https://github.com/pola-rs/polars/issues/27819
+    df = pl.DataFrame(
+        {"v": [1, 2, 3, 4], "o1": [None, 2, 1, 2], "o2": [1, None, None, -1]}
+    )
+    col = pl.col("v")
+    order_by = ("o1", "o2")
+
+    result = df.with_columns(
+        nulls_first=col.first().over(order_by=order_by),
+        nulls_last=col.first().over(order_by=order_by, nulls_last=True),
+    )
+    expected = df.with_columns(
+        nulls_first=col.sort_by(order_by).first(),
+        nulls_last=col.sort_by(order_by, nulls_last=True).first(),
+    )
+
+    assert_frame_equal(result, expected)
+    assert result["nulls_first"].to_list() == [1, 1, 1, 1]
+    assert result["nulls_last"].to_list() == [3, 3, 3, 3]
+
+
 def test_over_order_by_descending_nulls_agg_context() -> None:
     df = pl.DataFrame({"g": ["a", "a", "a"], "v": [1, 2, 3], "d": [1, None, 2]})
     expr = pl.col("v").cum_sum().over("g", order_by="d", descending=True)


### PR DESCRIPTION
Fixes #27819.

## Problem
`over(order_by=[a, b], nulls_last=True)` produced incorrect results with MULTIPLE
order-by columns. A multi-column `order_by` is packed into a single `as_struct`
upstream, and sorting that struct as a whole applies `nulls_last`/`descending` only
to the struct's outer validity, not to each inner field — so per-column null
placement was lost. Single-column `order_by` was unaffected.

Repro (from the issue):
```python
df = pl.DataFrame({"v": [1, 2, 3, 4], "o1": [None, 2, 1, 2], "o2": [1, None, None, -1]})
col = pl.col("v"); order_by = ("o1", "o2")
df.with_columns(
    nulls_first=col.first().over(order_by=order_by),
    nulls_last=col.first().over(order_by=order_by, nulls_last=True),
)
# nulls_last was [1,1,1,1], should be [3,3,3,3]
```

## Fix
Implements approach (b) from the issue discussion (confirmed by @orlp as the only
feasible option): the multi-column `order_by` struct is unpacked back into its
individual columns in the window planner, and each partition is sorted via the
existing `arg_sort_multiple` path that `sort_by` uses, applying null placement per
column. For non-scalar window functions (row-remap path) the columns are collapsed
into a single ordinal rank that encodes the multi-key order.

Note on scope: only the synthetic `AsStruct` node that `over` creates for multi-column
`order_by` is unpacked. A genuine struct-*dtype* column passed as `order_by`
(`AExpr::Column`) is untouched and keeps total-order semantics. An inline
`over(order_by=pl.struct("a","b"))` is itself an `AsStruct` node and will now be
unpacked to per-column ordering (it was already mis-ordered before this change); if
total-order-over-a-struct is desired, pass a materialized struct column.

## Tests
- Rust: `test_over_order_by_multiple_nulls_last` in `polars-lazy` (fails on `main`, passes with the fix).
- Python: `test_over_multiple_order_by_nulls_last_27819` in `tests/unit/operations/test_over.py`,
  mirroring the issue and cross-checking against `sort_by`.

I used AI to help locate the root cause and draft the change. I confirm that I have
reviewed all changes myself, and I believe they are relevant and correct.