### PR TITLE
docs: Unpivot pivot feature flag

### DIFF
--- a/crates/polars-ops/src/frame/mod.rs
+++ b/crates/polars-ops/src/frame/mod.rs
@@ -2,6 +2,7 @@ pub mod gather;
 pub mod is_sorted;
 pub mod join;
 #[cfg(feature = "pivot")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pivot")))]
 pub mod unpivot;
 
 pub use join::*;

--- a/crates/polars-ops/src/frame/unpivot.rs
+++ b/crates/polars-ops/src/frame/unpivot.rs
@@ -9,8 +9,11 @@ use polars_error::{PolarsResult, polars_err};
 
 use crate::frame::IntoDf;
 
+#[cfg_attr(docsrs, doc(cfg(feature = "pivot")))]
 pub trait UnpivotDF: IntoDf {
     /// Unpivot a `DataFrame` from wide to long format.
+    ///
+    /// Requires the `pivot` feature.
     ///
     /// # Example
     ///

--- a/crates/polars-ops/src/lib.rs
+++ b/crates/polars-ops/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod chunked_array;
 #[cfg(feature = "pivot")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pivot")))]
 pub use frame::unpivot;
 pub mod frame;
 pub mod prelude;

--- a/crates/polars/src/docs/eager.rs
+++ b/crates/polars/src/docs/eager.rs
@@ -478,6 +478,8 @@
 //!
 //! ## Unpivot
 //!
+//! Requires the `pivot` feature.
+//!
 //! ```
 //! use polars::prelude::*;
 //! use polars::df;


### PR DESCRIPTION
Closes #25611.

Documents that Rust `unpivot` support requires the `pivot` feature.

Changes:
- Adds `doc(cfg(feature = "pivot"))` to the `unpivot` module and re-export.
- Adds `doc(cfg(feature = "pivot"))` to the `UnpivotDF` trait.
- Adds an explicit note to the eager Rust docs.

Validation:
- `cargo fmt`
- `cargo doc -p polars-ops --features pivot --no-deps`
- `cargo doc -p polars --features pivot --no-deps`