### PR TITLE
docs: Document merge_sorted null ordering

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -12606,6 +12606,10 @@ class DataFrame:
         row order when the key is equal between the both dataframes.
 
         The key must be sorted in ascending order.
+
+        Null values are treated as the smallest values. Therefore, input frames
+        with null values in the key column must be sorted with nulls first.
+        Input frames sorted with nulls last do not satisfy this requirement.
         """
         from polars.lazyframe.opt_flags import QueryOptFlags
 

--- a/py-polars/src/polars/functions/eager.py
+++ b/py-polars/src/polars/functions/eager.py
@@ -677,6 +677,10 @@ def merge_sorted(
     row order when the key is equal between dataframes.
 
     The key must be sorted in ascending order.
+
+    Null values are treated as the smallest values. Therefore, input frames
+    with null values in the key column must be sorted with nulls first.
+    Input frames sorted with nulls last do not satisfy this requirement.
     """
     elems: Sequence[PolarsType] = list(items)
 

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -9158,6 +9158,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         row order when the key is equal between the both dataframes.
 
         The key must be sorted in ascending order.
+
+        Null values are treated as the smallest values. Therefore, input frames
+        with null values in the key column must be sorted with nulls first.
+        Input frames sorted with nulls last do not satisfy this requirement.
         """
         require_same_type(self, other)
         return self._from_pyldf(self._ldf.merge_sorted(other._ldf, key, maintain_order))


### PR DESCRIPTION
Closes #20991.
  
Documents that `merge_sorted` expects input frames with null values in the key column to be sorted with nulls first, since null values are treated as the smallest values.
  
Validation:
-  `python -m pytest py-polars/tests/unit/dataframe/test_merge_sorted.py py-polars/tests/unit/lazyframe/test_merged_sorted.py`