### PR TITLE
fix: Support scanning `file://` URIs with percent-encoded paths

### DIFF
--- a/crates/polars-io/src/path_utils/mod.rs
+++ b/crates/polars-io/src/path_utils/mod.rs
@@ -185,11 +185,26 @@ fn decode_file_uri_path(path: &str, glob: bool) -> Option<String> {
     let decoded = percent_encoding::percent_decode_str(path)
         .decode_utf8()
         .ok()?;
+    let path = strip_windows_drive_slash(&decoded);
     Some(if glob {
-        glob::Pattern::escape(&decoded)
+        glob::Pattern::escape(path)
     } else {
-        decoded.into_owned()
+        path.to_owned()
     })
+}
+
+/// `strip_scheme` leaves a Windows `file:///C:/x` URI as `/C:/x`; drop the leading slash before
+/// the drive letter so it is a valid local path (`C:/x`). The inverse of the extra slash
+/// `format_file_uri` adds on Windows. A no-op on other platforms (a leading `/` is the root).
+fn strip_windows_drive_slash(path: &str) -> &str {
+    #[cfg(target_family = "windows")]
+    {
+        let b = path.as_bytes();
+        if b.len() >= 3 && b[0] == b'/' && b[1].is_ascii_alphabetic() && b[2] == b':' {
+            return &path[1..];
+        }
+    }
+    path
 }
 
 /// Returns `true` if `expanded_paths` were expanded from a single directory

--- a/crates/polars-io/src/path_utils/mod.rs
+++ b/crates/polars-io/src/path_utils/mod.rs
@@ -135,6 +135,45 @@ fn has_glob(path: &[u8]) -> bool {
     }
 }
 
+/// Returns `true` for a `file://` URI whose path component carries a percent-escape.
+fn is_file_uri_with_escape(path: &PlRefPath) -> bool {
+    path.scheme().is_some_and(|s| s.is_file()) && path.strip_scheme().contains('%')
+}
+
+/// Decode `%` escapes in `file://` paths and return them as plain local paths
+/// (e.g. `file:///x/foo%3Dbar` -> `/x/foo=bar`).
+///
+/// The `file://` is dropped before decoding, so the result is a plain path, not a URI.
+/// That keeps decoded `?`/`#` as literal filename characters; kept as a URI they'd be read
+/// as a query or fragment and cut the path short.
+///
+/// Everything else is returned unchanged: `file://` paths with no `%`, plain paths, and
+/// cloud keys (`s3://`, ...), which are taken literally.
+pub fn decode_file_uri_paths(paths: &[PlRefPath]) -> Cow<'_, [PlRefPath]> {
+    // Nothing to decode: borrow the input untouched.
+    if !paths.iter().any(is_file_uri_with_escape) {
+        return Cow::Borrowed(paths);
+    }
+
+    Cow::Owned(
+        paths
+            .iter()
+            .map(|path| {
+                if is_file_uri_with_escape(path)
+                    && let Ok(decoded) =
+                        percent_encoding::percent_decode_str(path.strip_scheme()).decode_utf8()
+                {
+                    PlRefPath::new(decoded.into_owned())
+                } else {
+                    // Not an encoded file URI, or the escape isn't valid UTF-8: leave the
+                    // path literal and let the downstream open surface any not-found error.
+                    path.clone()
+                }
+            })
+            .collect(),
+    )
+}
+
 /// Returns `true` if `expanded_paths` were expanded from a single directory
 pub fn expanded_from_single_directory(paths: &[PlRefPath], expanded_paths: &[PlRefPath]) -> bool {
     // Single input that isn't a glob

--- a/crates/polars-io/src/path_utils/mod.rs
+++ b/crates/polars-io/src/path_utils/mod.rs
@@ -147,9 +147,14 @@ fn is_file_uri_with_escape(path: &PlRefPath) -> bool {
 /// That keeps decoded `?`/`#` as literal filename characters; kept as a URI they'd be read
 /// as a query or fragment and cut the path short.
 ///
+/// When `glob` is set, a percent-encoded path is treated as a literal: every glob
+/// metacharacter in the decoded result is escaped (`?` -> `[?]`), so a decoded `?`/`*`
+/// matches the literal character instead of acting as a wildcard. A path with no `%` is
+/// never decoded (see below), so a plain `file:///x/*.parquet` still globs as usual.
+///
 /// Everything else is returned unchanged: `file://` paths with no `%`, plain paths, and
 /// cloud keys (`s3://`, ...), which are taken literally.
-pub fn decode_file_uri_paths(paths: &[PlRefPath]) -> Cow<'_, [PlRefPath]> {
+pub fn decode_file_uri_paths(paths: &[PlRefPath], glob: bool) -> Cow<'_, [PlRefPath]> {
     // Nothing to decode: borrow the input untouched.
     if !paths.iter().any(is_file_uri_with_escape) {
         return Cow::Borrowed(paths);
@@ -160,10 +165,9 @@ pub fn decode_file_uri_paths(paths: &[PlRefPath]) -> Cow<'_, [PlRefPath]> {
             .iter()
             .map(|path| {
                 if is_file_uri_with_escape(path)
-                    && let Ok(decoded) =
-                        percent_encoding::percent_decode_str(path.strip_scheme()).decode_utf8()
+                    && let Some(decoded) = decode_file_uri_path(path.strip_scheme(), glob)
                 {
-                    PlRefPath::new(decoded.into_owned())
+                    PlRefPath::new(decoded)
                 } else {
                     // Not an encoded file URI, or the escape isn't valid UTF-8: leave the
                     // path literal and let the downstream open surface any not-found error.
@@ -172,6 +176,20 @@ pub fn decode_file_uri_paths(paths: &[PlRefPath]) -> Cow<'_, [PlRefPath]> {
             })
             .collect(),
     )
+}
+
+/// Percent-decode a path component. When `glob` is set the decoded result is glob-escaped
+/// (via `glob::Pattern::escape`), so a decoded `?`/`*`/`[`/`]` matches the literal character
+/// instead of acting as a wildcard. Returns `None` if the decoded bytes are not valid UTF-8.
+fn decode_file_uri_path(path: &str, glob: bool) -> Option<String> {
+    let decoded = percent_encoding::percent_decode_str(path)
+        .decode_utf8()
+        .ok()?;
+    Some(if glob {
+        glob::Pattern::escape(&decoded)
+    } else {
+        decoded.into_owned()
+    })
 }
 
 /// Returns `true` if `expanded_paths` were expanded from a single directory

--- a/crates/polars-plan/src/dsl/scan_sources.rs
+++ b/crates/polars-plan/src/dsl/scan_sources.rs
@@ -10,7 +10,9 @@ use polars_io::cloud::CloudOptions;
 use polars_io::file_cache::FileCacheEntry;
 use polars_io::metrics::IOMetrics;
 use polars_io::utils::byte_source::{DynByteSource, DynByteSourceBuilder};
-use polars_io::{expand_paths, expand_paths_hive, expanded_from_single_directory};
+use polars_io::{
+    decode_file_uri_paths, expand_paths, expand_paths_hive, expanded_from_single_directory,
+};
 use polars_utils::mmap::MMapSemaphore;
 use polars_utils::pl_path::PlRefPath;
 use polars_utils::pl_str::PlSmallStr;
@@ -182,15 +184,20 @@ impl Eq for ScanSources {}
 impl ScanSources {
     pub async fn expand_paths(&self, scan_args: &mut UnifiedScanArgs) -> PolarsResult<Self> {
         match self {
-            Self::Paths(paths) => Ok(Self::Paths(
-                expand_paths(
-                    paths,
-                    scan_args.glob,
-                    scan_args.hidden_file_prefix.as_deref().unwrap_or_default(),
-                    &mut scan_args.cloud_options,
-                )
-                .await?,
-            )),
+            Self::Paths(paths) => {
+                // csv/ndjson/lines decode here; parquet/ipc decode in the hive variant.
+                let paths = decode_file_uri_paths(paths);
+
+                Ok(Self::Paths(
+                    expand_paths(
+                        paths.as_ref(),
+                        scan_args.glob,
+                        scan_args.hidden_file_prefix.as_deref().unwrap_or_default(),
+                        &mut scan_args.cloud_options,
+                    )
+                    .await?,
+                ))
+            },
             v => Ok(v.clone()),
         }
     }
@@ -204,6 +211,11 @@ impl ScanSources {
     ) -> PolarsResult<Self> {
         match self {
             Self::Paths(paths) => {
+                // Decode up front so expansion, single-directory detection, and hive parsing
+                // all see the same literal path; decoding later misfires hive detection.
+                let paths = decode_file_uri_paths(paths);
+                let paths = paths.as_ref();
+
                 let (expanded_paths, hive_start_idx) = expand_paths_hive(
                     paths,
                     scan_args.glob,

--- a/crates/polars-plan/src/dsl/scan_sources.rs
+++ b/crates/polars-plan/src/dsl/scan_sources.rs
@@ -186,7 +186,7 @@ impl ScanSources {
         match self {
             Self::Paths(paths) => {
                 // csv/ndjson/lines decode here; parquet/ipc decode in the hive variant.
-                let paths = decode_file_uri_paths(paths);
+                let paths = decode_file_uri_paths(paths, scan_args.glob);
 
                 Ok(Self::Paths(
                     expand_paths(
@@ -213,7 +213,7 @@ impl ScanSources {
             Self::Paths(paths) => {
                 // Decode up front so expansion, single-directory detection, and hive parsing
                 // all see the same literal path; decoding later misfires hive detection.
-                let paths = decode_file_uri_paths(paths);
+                let paths = decode_file_uri_paths(paths, scan_args.glob);
                 let paths = paths.as_ref();
 
                 let (expanded_paths, hive_start_idx) = expand_paths_hive(

--- a/crates/polars-utils/src/pl_path.rs
+++ b/crates/polars-utils/src/pl_path.rs
@@ -407,6 +407,11 @@ impl CloudScheme {
         Self::from_scheme_str(&path[..path.find("://")?])
     }
 
+    /// Local-filesystem scheme (`file://` with an authority, or bare `file:`).
+    pub fn is_file(&self) -> bool {
+        matches!(self, Self::File | Self::FileNoHostname)
+    }
+
     /// Returns `i` such that `&self.as_str()[i..]` strips the scheme, as well as the `://` if it
     /// exists.
     pub fn strip_scheme_index(&self) -> usize {

--- a/py-polars/tests/unit/io/test_scan.py
+++ b/py-polars/tests/unit/io/test_scan.py
@@ -1338,7 +1338,7 @@ def test_scan_file_uri_hostname_component() -> None:
     [
         # the reported issue: hive `key=value` directory
         (pl.scan_parquet, pl.DataFrame.write_parquet, "foo=bar", "=", "%3D"),
-        # URI delimiter must stay literal, not truncate the path
+        # the decoded `?` (from `%3F`) must stay literal, not act as a glob wildcard
         pytest.param(
             pl.scan_parquet,
             pl.DataFrame.write_parquet,

--- a/py-polars/tests/unit/io/test_scan.py
+++ b/py-polars/tests/unit/io/test_scan.py
@@ -1333,6 +1333,49 @@ def test_scan_file_uri_hostname_component() -> None:
 
 
 @pytest.mark.write_disk
+@pytest.mark.parametrize(
+    ("scan_func", "write_func", "subdir", "raw_char", "encoded_char"),
+    [
+        # the reported issue: hive `key=value` directory
+        (pl.scan_parquet, pl.DataFrame.write_parquet, "foo=bar", "=", "%3D"),
+        # URI delimiter must stay literal, not truncate the path
+        pytest.param(
+            pl.scan_parquet,
+            pl.DataFrame.write_parquet,
+            "foo?bar",
+            "?",
+            "%3F",
+            marks=pytest.mark.skipif(
+                sys.platform == "win32",
+                reason="'?' is not a legal filename character on Windows",
+            ),
+        ),
+        # the other expansion method (`expand_paths`)
+        (pl.scan_csv, pl.DataFrame.write_csv, "foo=bar", "=", "%3D"),
+    ],
+)
+def test_scan_percent_encoded_file_uri_27840(
+    tmp_path: Path,
+    scan_func: Callable[[Any], pl.LazyFrame],
+    write_func: Callable[[pl.DataFrame, Path], None],
+    subdir: str,
+    raw_char: str,
+    encoded_char: str,
+) -> None:
+    # `file://` URIs are percent-decoded (RFC 3986) before reaching the filesystem.
+    d = tmp_path / subdir
+    d.mkdir()
+
+    df = pl.DataFrame({"a": 1})
+    path = d / "data.bin"
+    write_func(df, path)
+
+    encoded_uri = format_file_uri(path).replace(raw_char, encoded_char)
+
+    assert_frame_equal(scan_func(encoded_uri).collect(), df)
+
+
+@pytest.mark.write_disk
 @pytest.mark.parametrize("polars_force_async", ["0", "1"])
 @pytest.mark.parametrize("n_repeats", [1, 2])
 @pytest.mark.parametrize("use_expand_paths_pyfn", [True, False])


### PR DESCRIPTION
Closes #27840