### PR TITLE
docs: add maskops to plugin list

### DIFF
--- a/docs/source/user-guide/plugins/index.md
+++ b/docs/source/user-guide/plugins/index.md
@@ -18,9 +18,7 @@ Here is a curated (non-exhaustive) list of community-implemented plugins.
 
 ### Security
 
-- [maskops](https://github.com/fcarvajalbrown/maskops) High-speed PII masking and detection
-  as a native Polars expression plugin, powered by Rust. Supports asterisk masking, HMAC
-  deterministic pseudonymization, and FF3-1 format-preserving encryption.
+- [maskops](https://github.com/fcarvajalbrown/maskops) Native Polars expression plugin for high-speed PII masking and detection, powered by Rust, with asterisk masking, HMAC-SHA256 pseudonymization, and FF3-1 format-preserving encryption
 
 ### Data science
 

--- a/docs/source/user-guide/plugins/index.md
+++ b/docs/source/user-guide/plugins/index.md
@@ -16,6 +16,12 @@ Here is a curated (non-exhaustive) list of community-implemented plugins.
 - [polars-hash](https://github.com/ion-elgreco/polars-hash) Stable non-cryptographic and
   cryptographic hashing functions for Polars
 
+### Security
+
+- [maskops](https://github.com/fcarvajalbrown/maskops) High-speed PII masking and detection
+  as a native Polars expression plugin, powered by Rust. Supports asterisk masking, HMAC
+  deterministic pseudonymization, and FF3-1 format-preserving encryption.
+
 ### Data science
 
 - [polars-distance](https://github.com/ion-elgreco/polars-distance) Polars plugin for pairwise


### PR DESCRIPTION
Adding [maskops](https://github.com/fcarvajalbrown/maskops) to the Polars plugin list.

**maskops** is a native Polars expression plugin for PII masking and detection, powered by Rust.
- Expressions: `mask_pii`, `contains_pii`, `mask_pii_fpe`
- Zero Python overhead per row — compiled Rust running on Arrow buffers
- Coverage: EU, LatAm, US, APAC identifiers + contact/financial PII
- PyPI: https://pypi.org/project/maskops/