### PR TITLE
fix: Improve error for aliasing expanded aggregations

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_expansion.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_expansion.rs
@@ -265,14 +265,25 @@ fn expand_expression_rec(
     match &expr {
         Expr::Element => out.push(expr.clone()),
         Expr::Alias(subexpr, name) => {
-            _ = expand_single(
+            let start_len = out.len();
+
+            let expanded = expand_single(
                 subexpr.as_ref(),
                 ignored_selector_columns,
                 schema,
                 out,
                 opt_flags,
                 |e| Expr::Alias(Arc::new(e), name.clone()),
-            )?
+            )?;
+
+            if expanded > 1 && matches!(subexpr.as_ref(), Expr::Agg(_)) {
+                out.truncate(start_len);
+                polars_bail!(
+                    Duplicate:
+                    "cannot assign the same alias to multiple aggregated columns: '{}'",
+                    name
+                );
+            }
         },
 
         // Backwards compatibility. We previously allowed `pl.col("")` and `pl.first()`

--- a/py-polars/tests/unit/functions/test_wildcard_expansion.py
+++ b/py-polars/tests/unit/functions/test_wildcard_expansion.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 import polars as pl
 from polars.testing import assert_series_equal
 
@@ -72,3 +74,13 @@ def test_sum_horizontal_expansion() -> None:
     out = df.select(z=pl.sum_horizontal(pl.all())).to_series()
 
     assert_series_equal(out, pl.Series("z", [3], dtype=pl.Int64))
+
+
+def test_alias_on_multiple_expanded_columns_error() -> None:
+    df = pl.DataFrame({"a": [1], "b": [1]})
+
+    with pytest.raises(
+        pl.exceptions.DuplicateError,
+        match="cannot assign the same alias to multiple aggregated columns",
+    ):
+        df.select(pl.sum("a", "b").alias("c"))


### PR DESCRIPTION
Fixes #11060.

This improves the error raised when an alias is applied to an aggregation expression that expands to multiple output columns, such as:

```python
pl.DataFrame({"a": [1], "b": [1]}).select(
    pl.sum("a", "b").alias("c")
)