### PR TITLE
fix(rust): Implement deserializing u128 from parquet as written by polars.

### DIFF
--- a/crates/polars-parquet/src/arrow/read/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/mod.rs
@@ -99,8 +99,8 @@ fn convert_i256(value: &[u8]) -> i256 {
     }
 }
 
-fn convert_u128(value: &[u8]) -> u128 {
+fn convert_u128(value: &[u8], n: usize) -> u128 {
     let mut bytes = [0u8; 16];
-    bytes[..16].copy_from_slice(value);
-    u128::from_be_bytes(bytes)
+    bytes[..n].copy_from_slice(value);
+    u128::from_be_bytes(bytes) >> (8 * (16 - n))
 }

--- a/crates/polars-parquet/src/arrow/read/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/mod.rs
@@ -98,3 +98,9 @@ fn convert_i256(value: &[u8]) -> i256 {
         i256::from_be_bytes(bytes)
     }
 }
+
+fn convert_u128(value: &[u8]) -> u128 {
+    let mut bytes = [0u8; 16];
+    bytes[..16].copy_from_slice(value);
+    u128::from_be_bytes(bytes)
+}

--- a/crates/polars-parquet/src/arrow/read/statistics.rs
+++ b/crates/polars-parquet/src/arrow/read/statistics.rs
@@ -531,12 +531,12 @@ pub fn deserialize_all(
                     )
                 },
 
-                (D::UInt128, PPT::FixedLenByteArray(16)) => {
+                (D::UInt128, PPT::FixedLenByteArray(n)) => {
                     rmap!(
                         expect_fixedlen,
                         MutablePrimitiveArray::<u128>,
                         @prim Vec<u8>,
-                        |x| convert_u128(&x)
+                        |x| convert_u128(&x, *n)
                     )
                 },
 

--- a/crates/polars-parquet/src/arrow/read/statistics.rs
+++ b/crates/polars-parquet/src/arrow/read/statistics.rs
@@ -17,10 +17,7 @@ use super::{ParquetTimeUnit, RowGroupMetadata};
 use crate::parquet::error::{ParquetError, ParquetResult};
 use crate::parquet::schema::types::PhysicalType as ParquetPhysicalType;
 use crate::parquet::statistics::Statistics as ParquetStatistics;
-use crate::read::{
-    ColumnChunkMetadata, PrimitiveLogicalType, convert_days_ms, convert_i128, convert_i256,
-    convert_year_month, int96_to_i64_ns,
-};
+use crate::read::{ColumnChunkMetadata, PrimitiveLogicalType, convert_days_ms, convert_i128, convert_i256, convert_year_month, int96_to_i64_ns, convert_u128};
 
 /// Parquet statistics for a nesting level
 #[derive(Debug, PartialEq)]
@@ -530,6 +527,16 @@ pub fn deserialize_all(
                         *width
                     )
                 },
+
+                (D::UInt128, PPT::FixedLenByteArray(16)) => {
+                    rmap!(
+                        expect_fixedlen,
+                        MutablePrimitiveArray::<u128>,
+                        @prim Vec<u8>,
+                        |x| convert_u128(&x)
+                    )
+                }
+
 
                 other => todo!("{:?}", other),
             };

--- a/crates/polars-parquet/src/arrow/read/statistics.rs
+++ b/crates/polars-parquet/src/arrow/read/statistics.rs
@@ -17,7 +17,10 @@ use super::{ParquetTimeUnit, RowGroupMetadata};
 use crate::parquet::error::{ParquetError, ParquetResult};
 use crate::parquet::schema::types::PhysicalType as ParquetPhysicalType;
 use crate::parquet::statistics::Statistics as ParquetStatistics;
-use crate::read::{ColumnChunkMetadata, PrimitiveLogicalType, convert_days_ms, convert_i128, convert_i256, convert_year_month, int96_to_i64_ns, convert_u128};
+use crate::read::{
+    ColumnChunkMetadata, PrimitiveLogicalType, convert_days_ms, convert_i128, convert_i256,
+    convert_u128, convert_year_month, int96_to_i64_ns,
+};
 
 /// Parquet statistics for a nesting level
 #[derive(Debug, PartialEq)]
@@ -535,8 +538,7 @@ pub fn deserialize_all(
                         @prim Vec<u8>,
                         |x| convert_u128(&x)
                     )
-                }
-
+                },
 
                 other => todo!("{:?}", other),
             };


### PR DESCRIPTION
Couldn't get `make test` to work on my machine (`make` said `make: *** No rule to make target 'test'.  Stop.`) but `cargo nextest` runs successfully against the crate I modified:
<img width="1495" height="229" alt="image" src="https://github.com/user-attachments/assets/5c82b72d-e2b4-4d3b-abdb-a0275eb81701" />

I need this merged to fix an error I got using the polars rust crate and `LazyFrame::scan_parquet`: 
```
polars-stream-0.54.4\src\nodes\io_sources\parquet\mod.rs:360:74:
called `Result::unwrap()` on an `Err` value: JoinError::Panic(Id(27), "called `Result::unwrap()` on an `Err` value: JoinError::Panic(Id(25), \"not yet implemented: (UInt128, FixedLenByteArray(16))\", ...)", ...)
```

No AI or LLMs were used in writing this PR.

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
