### PR TITLE
refactor: Update tests for non-ordered joins

### DIFF
--- a/crates/polars-lazy/src/tests/optimization_checks.rs
+++ b/crates/polars-lazy/src/tests/optimization_checks.rs
@@ -1,3 +1,5 @@
+use polars_ops::frame::MaintainOrderJoin;
+
 use super::*;
 
 #[cfg(feature = "parquet")]
@@ -111,7 +113,7 @@ fn test_no_left_join_pass() -> PolarsResult<()> {
             df2.lazy(),
             [col("idx1")],
             [col("idx2")],
-            JoinType::Left.into(),
+            JoinArgs::new(JoinType::Left).with_maintain_order(MaintainOrderJoin::LeftRight),
         )
         .filter(col("bar").eq(lit(5i32)))
         .collect()?;

--- a/crates/polars-lazy/src/tests/predicate_queries.rs
+++ b/crates/polars-lazy/src/tests/predicate_queries.rs
@@ -224,6 +224,8 @@ fn test_filter_null_creation_by_cast() -> PolarsResult<()> {
 #[test]
 #[cfg(feature = "cse")]
 fn test_predicate_on_join_suffix_4788() -> PolarsResult<()> {
+    use polars_ops::frame::MaintainOrderJoin;
+
     let lf = df![
       "x" => [1, 2],
       "y" => [1, 1],
@@ -234,6 +236,7 @@ fn test_predicate_on_join_suffix_4788() -> PolarsResult<()> {
         .left_on([col("y")])
         .right_on([col("y")])
         .suffix("_")
+        .maintain_order(MaintainOrderJoin::LeftRight)
         .finish()
         .filter(col("x").eq(1))
         .with_comm_subplan_elim(false);

--- a/crates/polars-lazy/src/tests/projection_queries.rs
+++ b/crates/polars-lazy/src/tests/projection_queries.rs
@@ -39,6 +39,8 @@ fn test_join_suffix_and_drop() -> PolarsResult<()> {
 #[test]
 #[cfg(feature = "cross_join")]
 fn test_cross_join_pd() -> PolarsResult<()> {
+    use polars_ops::frame::MaintainOrderJoin;
+
     let food = df![
         "name"=> ["Omelette", "Fried Egg"],
         "price" => [8, 5]
@@ -49,11 +51,21 @@ fn test_cross_join_pd() -> PolarsResult<()> {
         "price" => [5, 4]
     ]?;
 
-    let q = food.lazy().cross_join(drink.lazy(), None).select([
-        col("name").alias("food"),
-        col("name_right").alias("beverage"),
-        (col("price") + col("price_right")).alias("total"),
-    ]);
+    let q = food
+        .lazy()
+        .join(
+            drink.lazy(),
+            vec![],
+            vec![],
+            JoinArgs::new(JoinType::Cross)
+                .with_suffix(None)
+                .with_maintain_order(MaintainOrderJoin::LeftRight),
+        )
+        .select([
+            col("name").alias("food"),
+            col("name_right").alias("beverage"),
+            (col("price") + col("price_right")).alias("total"),
+        ]);
 
     let out = q.collect()?;
     let expected = df![

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "diff")]
 use polars_core::series::ops::NullBehavior;
+use polars_ops::frame::MaintainOrderJoin;
 
 use super::*;
 
@@ -280,7 +281,7 @@ fn test_lazy_query_4() -> PolarsResult<()> {
 
     let out = base_df
         .clone()
-        .group_by([col("uid")])
+        .group_by_stable([col("uid")])
         .agg([
             col("day").alias("day"),
             col("cumcases")
@@ -298,7 +299,7 @@ fn test_lazy_query_4() -> PolarsResult<()> {
             base_df,
             [col("uid"), col("day")],
             [col("uid"), col("day")],
-            JoinType::Inner.into(),
+            JoinArgs::new(JoinType::Inner).with_maintain_order(MaintainOrderJoin::LeftRight),
         )
         .collect()
         .unwrap();
@@ -979,7 +980,12 @@ fn test_group_by_projection_pd_same_column() -> PolarsResult<()> {
     };
 
     let out = a()
-        .left_join(a(), col("foo"), col("foo"))
+        .join(
+            a(),
+            [col("foo")],
+            [col("foo")],
+            JoinArgs::new(JoinType::Left).with_maintain_order(MaintainOrderJoin::LeftRight),
+        )
         .select([col("bar")])
         .collect()?;
 

--- a/crates/polars-ops/src/frame/join/args.rs
+++ b/crates/polars-ops/src/frame/join/args.rs
@@ -160,6 +160,11 @@ impl JoinArgs {
         self
     }
 
+    pub fn with_maintain_order(mut self, maintain_order: MaintainOrderJoin) -> Self {
+        self.maintain_order = maintain_order;
+        self
+    }
+
     pub fn with_suffix(mut self, suffix: Option<PlSmallStr>) -> Self {
         self.suffix = suffix;
         self

--- a/crates/polars-plan/src/frame/opt_state.rs
+++ b/crates/polars-plan/src/frame/opt_state.rs
@@ -1,5 +1,10 @@
 use bitflags::bitflags;
 
+const DEFAULT_OPT_FLAGS: OptFlags = OptFlags::from_bits_truncate(
+    OptFlags::all().bits()
+        & !(OptFlags::STREAMING.bits() | OptFlags::EAGER.bits() | OptFlags::GPU.bits()),
+);
+
 bitflags! {
 #[derive(Copy, Clone, Debug)]
     /// Allowed optimizations.
@@ -92,7 +97,7 @@ impl OptFlags {
 
 impl Default for OptFlags {
     fn default() -> Self {
-        Self::from_bits_truncate(u32::MAX) & !Self::STREAMING & !Self::EAGER & !Self::GPU
+        DEFAULT_OPT_FLAGS
     }
 }
 

--- a/crates/polars-sql/tests/statements.rs
+++ b/crates/polars-sql/tests/statements.rs
@@ -84,6 +84,7 @@ fn select_qualified_wildcard() {
     FROM test
     INNER JOIN test2
     USING(a)
+    ORDER BY ALL
     "#;
     let actual = ctx.execute(sql).unwrap().collect().unwrap();
     assert!(actual.equals(&expected));
@@ -117,6 +118,7 @@ fn select_qualified_column() {
     FROM test
     INNER JOIN test2
     USING(a)
+    ORDER BY ALL
     "#;
     let actual = ctx.execute(sql).unwrap().collect().unwrap();
     assert!(actual.equals(&expected));
@@ -144,6 +146,7 @@ fn test_union_all() {
     UNION ALL (
         SELECT * FROM test2
     )
+    ORDER BY b
     "#;
     let expected = polars_lazy::dsl::concat(
         vec![df1.lazy(), df2.lazy()],
@@ -181,7 +184,7 @@ fn iss_9560_join_as() {
     ctx.register("df1", df1.lazy());
     ctx.register("df2", df2.lazy());
     let sql = r#"
-        SELECT * FROM df1 AS t1 JOIN df2 AS t2 ON t1.id = t2.id
+        SELECT * FROM df1 AS t1 JOIN df2 AS t2 ON t1.id = t2.id ORDER BY ALL
     "#;
     let actual = ctx.execute(sql).unwrap().collect().unwrap();
 
@@ -229,6 +232,7 @@ fn test_compound_join_basic() {
     let sql = r#"
         SELECT * FROM df1
         INNER JOIN df2 ON df1.a = df2.a AND df1.b = df2.b
+        ORDER BY ALL
     "#;
     let actual = ctx.execute(sql).unwrap().collect().unwrap();
 
@@ -294,6 +298,7 @@ fn test_compound_join_three_tables() {
             ON df1.a = df2.a AND df1.b = df2.b
           INNER JOIN df3
             ON df3.a = df1.a AND df3.b = df1.b
+          ORDER BY ALL
     "#;
     let actual = ctx.execute(sql).unwrap().collect().unwrap();
     let expected = df! {
@@ -344,6 +349,7 @@ fn test_compound_join_nested_and() {
                     df1.b = df2.b AND
                     df1.c = df2.c AND
                     df1.d = df2.d
+            ORDER BY ALL
          "#
         );
         let actual = ctx.execute(sql.as_str()).unwrap().collect().unwrap();
@@ -434,6 +440,7 @@ fn test_compound_join_and_select_exclude_rename_replace() {
             INNER JOIN df2 ON df1.a = df2.a AND
               ((df1.b = df2.b AND df1.c = df2.c) AND df1.d = df2.d)
         ) tbl
+        ORDER BY ALL
      "#;
     let actual = ctx.execute(sql).unwrap().collect().unwrap();
     let expected = df! {
@@ -458,6 +465,7 @@ fn test_compound_join_and_select_exclude_rename_replace() {
             INNER JOIN df2 ON df1.a = df2.a AND
               ((df1.b = df2.b AND df1.c = df2.c) AND df1.d = df2.d)
         ) tbl
+        ORDER BY ALL
      "#;
     let actual = ctx.execute(sql).unwrap().collect().unwrap();
 

--- a/crates/polars/tests/it/lazy/projection_queries.rs
+++ b/crates/polars/tests/it/lazy/projection_queries.rs
@@ -54,26 +54,28 @@ fn test_full_outer_join_with_column_2988() -> PolarsResult<()> {
             ldf2,
             [col("key1"), col("key2")],
             [col("key1"), col("key2")],
-            JoinArgs::new(JoinType::Full).with_coalesce(JoinCoalesce::CoalesceColumns),
+            JoinArgs::new(JoinType::Full)
+                .with_maintain_order(MaintainOrderJoin::LeftRight)
+                .with_coalesce(JoinCoalesce::CoalesceColumns),
         )
         .with_columns([col("key1")])
         .collect()?;
     assert_eq!(out.get_column_names(), &["key1", "key2", "val1", "val2"]);
     assert_eq!(
         Vec::from(out.column("key1")?.str()?),
-        &[Some("bar"), Some("baz"), Some("foo")]
+        &[Some("foo"), Some("bar"), Some("baz")]
     );
     assert_eq!(
         Vec::from(out.column("key2")?.str()?),
-        &[Some("bar"), Some("baz"), Some("foo")]
+        &[Some("foo"), Some("bar"), Some("baz")]
     );
     assert_eq!(
         Vec::from(out.column("val1")?.i32()?),
-        &[Some(1), None, Some(3)]
+        &[Some(3), Some(1), None]
     );
     assert_eq!(
         Vec::from(out.column("val2")?.i32()?),
-        &[Some(6), Some(8), None]
+        &[None, Some(6), Some(8)]
     );
 
     Ok(())

--- a/crates/polars/tests/it/lazy/queries.rs
+++ b/crates/polars/tests/it/lazy/queries.rs
@@ -176,7 +176,12 @@ fn test_sorted_path_joins() -> PolarsResult<()> {
     let out = dfa
         .lazy()
         .with_column(col("a").set_sorted_flag(AExprSorted::default().with_desc(Some(false))))
-        .join(dfb.lazy(), [col("a")], [col("a")], JoinType::Left.into())
+        .join(
+            dfb.lazy(),
+            [col("a")],
+            [col("a")],
+            JoinArgs::new(JoinType::Left).with_maintain_order(MaintainOrderJoin::LeftRight),
+        )
         .collect()?;
 
     let s = out.column("a")?;

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -6455,7 +6455,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...         "ham": ["a", "b", "d"],
         ...     }
         ... )
-        >>> lf.join(other_lf, on="ham").collect()
+        >>> result = lf.join(other_lf, on="ham").collect()
+        >>> result.sort("*")
         shape: (2, 4)
         ┌─────┬─────┬─────┬───────┐
         │ foo ┆ bar ┆ ham ┆ apple │
@@ -6465,19 +6466,21 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 1   ┆ 6.0 ┆ a   ┆ x     │
         │ 2   ┆ 7.0 ┆ b   ┆ y     │
         └─────┴─────┴─────┴───────┘
-        >>> lf.join(other_lf, on="ham", how="full").collect()
+        >>> result = lf.join(other_lf, on="ham", how="full").collect()
+        >>> result.sort("*")
         shape: (4, 5)
         ┌──────┬──────┬──────┬───────┬───────────┐
         │ foo  ┆ bar  ┆ ham  ┆ apple ┆ ham_right │
         │ ---  ┆ ---  ┆ ---  ┆ ---   ┆ ---       │
         │ i64  ┆ f64  ┆ str  ┆ str   ┆ str       │
         ╞══════╪══════╪══════╪═══════╪═══════════╡
+        │ null ┆ null ┆ null ┆ z     ┆ d         │
         │ 1    ┆ 6.0  ┆ a    ┆ x     ┆ a         │
         │ 2    ┆ 7.0  ┆ b    ┆ y     ┆ b         │
-        │ null ┆ null ┆ null ┆ z     ┆ d         │
         │ 3    ┆ 8.0  ┆ c    ┆ null  ┆ null      │
         └──────┴──────┴──────┴───────┴───────────┘
-        >>> lf.join(other_lf, on="ham", how="left", coalesce=True).collect()
+        >>> result = lf.join(other_lf, on="ham", how="left", coalesce=True).collect()
+        >>> result.sort("*")
         shape: (3, 4)
         ┌─────┬─────┬─────┬───────┐
         │ foo ┆ bar ┆ ham ┆ apple │
@@ -6488,7 +6491,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 2   ┆ 7.0 ┆ b   ┆ y     │
         │ 3   ┆ 8.0 ┆ c   ┆ null  │
         └─────┴─────┴─────┴───────┘
-        >>> lf.join(other_lf, on="ham", how="semi").collect()
+        >>> result = lf.join(other_lf, on="ham", how="semi").collect()
+        >>> result.sort("*")
         shape: (2, 3)
         ┌─────┬─────┬─────┐
         │ foo ┆ bar ┆ ham │
@@ -6508,7 +6512,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 3   ┆ 8.0 ┆ c   │
         └─────┴─────┴─────┘
 
-        >>> lf.join(other_lf, how="cross").collect()
+        >>> result = lf.join(other_lf, how="cross").collect()
+        >>> result.sort("*")
         shape: (9, 5)
         ┌─────┬─────┬─────┬───────┬───────────┐
         │ foo ┆ bar ┆ ham ┆ apple ┆ ham_right │
@@ -6674,10 +6679,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         To OR them together, use a single expression and the `|` operator.
 
-        >>> east.join_where(
+        >>> result = east.join_where(
         ...     west,
         ...     (pl.col("dur") < pl.col("time")) | (pl.col("rev") < pl.col("cost")),
         ... ).collect()
+        >>> result.sort("id", "t_id")
         shape: (6, 8)
         ┌─────┬─────┬─────┬───────┬──────┬──────┬──────┬─────────────┐
         │ id  ┆ dur ┆ rev ┆ cores ┆ t_id ┆ time ┆ cost ┆ cores_right │

--- a/py-polars/src/polars/sql/context.py
+++ b/py-polars/src/polars/sql/context.py
@@ -254,7 +254,9 @@ class SQLContext(Generic[FrameType]):
         Join a polars LazyFrame with a pandas DataFrame (note use of the preferred
         `pl.sql` method, which is equivalent to `SQLContext.execute_global`):
 
-        >>> pl.sql("SELECT df.*, c FROM df JOIN df_pandas USING(a)").collect()
+        >>> pl.sql(
+        ...     "SELECT df.*, c FROM df JOIN df_pandas USING(a) ORDER BY ALL"
+        ... ).collect()
         shape: (2, 3)
         ┌─────┬─────┬─────┐
         │ a   ┆ b   ┆ c   │

--- a/py-polars/src/polars/sql/functions.py
+++ b/py-polars/src/polars/sql/functions.py
@@ -119,6 +119,7 @@ def sql(query: str, *, eager: bool = False) -> DataFrame | LazyFrame:
     ...         FROM pl_frame
     ...         JOIN pd_frame USING(a)
     ...         JOIN pa_table USING(a)
+    ...         ORDER BY ALL
     ...     ''',
     ... ).collect()
     shape: (2, 5)

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -131,7 +131,7 @@ def test_hive_partitioned_predicate_pushdown_skips_correct_number_of_files(
 
     # Ensure the CSE can work with hive partitions.
     q = q.filter(pl.col("a").gt(2))
-    result = q.join(q, on="a", how="left").collect(
+    result = q.join(q, on="a", how="left", maintain_order="left").collect(
         optimizations=pl.QueryOptFlags(comm_subplan_elim=True)
     )
     expected = {
@@ -140,6 +140,8 @@ def test_hive_partitioned_predicate_pushdown_skips_correct_number_of_files(
         "d_right": [3, 4],
     }
     assert result.to_dict(as_series=False) == expected
+
+    capfd.readouterr()
 
 
 @pytest.mark.write_disk

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -1310,24 +1310,9 @@ def test_join_preserve_order_inner() -> None:
     assert inner_right.get_column("a").equals(inner_right_left.get_column("a"))
 
 
-# The new streaming engine does not provide the same maintain_order="none"
-# ordering guarantee that is currently kept for compatibility on the in-memory
-# engine.
-@pytest.mark.may_fail_auto_streaming
 def test_join_preserve_order_left() -> None:
     left = pl.LazyFrame({"a": [None, 2, 1, 1, 5]})
     right = pl.LazyFrame({"a": [1, None, 2, 6], "b": [6, 7, 8, 9]})
-
-    # Right now the left join algorithm is ordered without explicitly setting any order
-    # This behaviour is deprecated but can only be removed in 2.0
-    left_none = left.join(right, on="a", how="left", maintain_order="none").collect()
-    assert left_none.get_column("a").cast(pl.UInt32).to_list() == [
-        None,
-        2,
-        1,
-        1,
-        5,
-    ]
 
     left_left = left.join(right, on="a", how="left", maintain_order="left").collect()
     assert left_left.get_column("a").cast(pl.UInt32).to_list() == [


### PR DESCRIPTION
Updates tests (Rust/Python/SQL) to explicitly set maintain_order.

Related issue: https://github.com/pola-rs/polars/issues/19576
