### PR TITLE
feat: Skip Delta files and parquet row groups using per-field struct statistics

### DIFF
--- a/crates/polars-mem-engine/src/scan_predicate/functions.rs
+++ b/crates/polars-mem-engine/src/scan_predicate/functions.rs
@@ -18,7 +18,9 @@ use polars_plan::dsl::{
 };
 use polars_plan::plans::expr_ir::{ExprIR, OutputName};
 use polars_plan::plans::hive::HivePartitionsDf;
-use polars_plan::plans::predicates::{aexpr_to_column_predicates, aexpr_to_skip_batch_predicate};
+use polars_plan::plans::predicates::{
+    aexpr_to_column_predicates, aexpr_to_skip_batch_predicate, null_count_dtype,
+};
 use polars_plan::plans::{AExpr, ExprIRDisplay, FileInfo, IR, MintermIter};
 use polars_plan::utils::aexpr_to_leaf_names_iter;
 use polars_utils::arena::{Arena, Node};
@@ -136,7 +138,7 @@ pub fn create_scan_predicate(
 
                 skip_batch_schema.insert(format_pl_smallstr!("{col}_min"), dtype.clone());
                 skip_batch_schema.insert(format_pl_smallstr!("{col}_max"), dtype.clone());
-                skip_batch_schema.insert(format_pl_smallstr!("{col}_nc"), IDX_DTYPE);
+                skip_batch_schema.insert(format_pl_smallstr!("{col}_nc"), null_count_dtype(dtype));
             }
 
             skip_batch_predicate = Some(create_physical_expr(

--- a/crates/polars-plan/src/plans/aexpr/predicates/mod.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/mod.rs
@@ -4,8 +4,11 @@ mod skip_batches;
 use std::borrow::Cow;
 
 pub use column_expr::*;
+#[cfg(feature = "dtype-struct")]
+use polars_core::prelude::Field;
 #[cfg(feature = "is_in")]
-use polars_core::prelude::{AnyValue, DataType, Series};
+use polars_core::prelude::{AnyValue, Series};
+use polars_core::prelude::{DataType, IDX_DTYPE};
 use polars_core::schema::Schema;
 use polars_utils::arena::{Arena, Node};
 use polars_utils::pl_str::PlSmallStr;
@@ -13,6 +16,26 @@ pub use skip_batches::*;
 
 use super::evaluate::{constant_evaluate, into_column};
 use super::{AExpr, LiteralValue};
+
+/// Statistics-frame dtype of a column's `<col>_nc` (null-count) column.
+///
+/// Scalar (and non-struct nested) columns carry a single row-level count ([`IDX_DTYPE`]); a
+/// struct column carries a *per-field* count whose shape mirrors the column (each leaf replaced
+/// by [`IDX_DTYPE`]), so the skip-batch predicate can prune on an individual struct field via
+/// `col("<col>_nc").struct.field(..)`. The parquet/Delta producers build the `_nc` array to
+/// match this dtype.
+pub fn null_count_dtype(dtype: &DataType) -> DataType {
+    match dtype {
+        #[cfg(feature = "dtype-struct")]
+        DataType::Struct(fields) => DataType::Struct(
+            fields
+                .iter()
+                .map(|f| Field::new(f.name().clone(), null_count_dtype(f.dtype())))
+                .collect(),
+        ),
+        _ => IDX_DTYPE,
+    }
+}
 
 #[allow(clippy::type_complexity)]
 fn get_binary_expr_col_and_lv<'a>(

--- a/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
@@ -1,6 +1,8 @@
 //! This module creates predicates that can skip record batches of rows based on statistics about
 //! that record batch.
 
+use std::borrow::Cow;
+
 use polars_core::prelude::{AnyValue, DataType, Scalar};
 use polars_core::schema::Schema;
 use polars_utils::aliases::PlIndexMap;
@@ -8,13 +10,146 @@ use polars_utils::arena::{Arena, Node};
 use polars_utils::format_pl_smallstr;
 use polars_utils::pl_str::PlSmallStr;
 
-use super::super::evaluate::{constant_evaluate, into_column};
+#[cfg(feature = "dtype-struct")]
+use super::super::IRStructFunction;
+use super::super::evaluate::constant_evaluate;
 use super::super::{AExpr, IRBooleanFunction, IRFunctionExpr, LiteralValue, Operator};
 use crate::plans::aexpr::builder::IntoAExprBuilder;
-use crate::plans::predicates::get_binary_expr_col_and_lv;
+#[cfg(feature = "dtype-struct")]
+use crate::plans::expr_ir::ExprIR;
 #[cfg(feature = "is_in")]
 use crate::plans::predicates::try_extract_is_in_haystack;
 use crate::plans::{AExprBuilder, aexpr_to_leaf_names_iter, is_scalar_ae, rename_columns};
+
+/// A resolved reference to a (possibly nested) statistics target: a top-level column,
+/// optionally followed by a struct-field path.
+///
+/// The skip-batch statistics frame carries `<col>_min` / `<col>_max` / `<col>_nc` columns
+/// whose shape mirrors the data column. A struct field `s.a` is therefore read out of the
+/// struct-typed statistics column as `col("s_min").struct.field("a")` (and likewise for
+/// `_max` / `_nc`), letting the existing scalar handlers prune on an individual field even
+/// when sibling fields vary.
+#[derive(Clone)]
+struct StatTarget {
+    col: PlSmallStr,
+    /// Field path into a struct column, outermost first. Empty for a whole column.
+    #[cfg_attr(not(feature = "dtype-struct"), allow(dead_code))]
+    path: Vec<PlSmallStr>,
+}
+
+impl StatTarget {
+    /// Build the `<col>_<suffix>` statistics accessor, indexing into the struct field path.
+    fn stat(&self, suffix: &str, arena: &mut Arena<AExpr>) -> AExprBuilder {
+        #[allow(unused_mut)]
+        let mut b = AExprBuilder::new_from_node(
+            arena.add(AExpr::Column(format_pl_smallstr!("{}_{suffix}", self.col))),
+        );
+        #[cfg(feature = "dtype-struct")]
+        {
+            for field in &self.path {
+                b = struct_field(b, field.clone(), arena);
+            }
+        }
+        b
+    }
+
+    fn min(&self, arena: &mut Arena<AExpr>) -> AExprBuilder {
+        self.stat("min", arena)
+    }
+    fn max(&self, arena: &mut Arena<AExpr>) -> AExprBuilder {
+        self.stat("max", arena)
+    }
+    fn null_count(&self, arena: &mut Arena<AExpr>) -> AExprBuilder {
+        self.stat("nc", arena)
+    }
+}
+
+#[cfg(feature = "dtype-struct")]
+fn struct_field(base: AExprBuilder, name: PlSmallStr, arena: &mut Arena<AExpr>) -> AExprBuilder {
+    AExprBuilder::function(
+        vec![ExprIR::from_node(base.node(), arena)],
+        IRFunctionExpr::StructExpr(IRStructFunction::FieldByName(name)),
+        arena,
+    )
+}
+
+/// Resolve a `col(..)` or chained `col(..).struct.field(..)` expression to a [`StatTarget`].
+/// Returns `None` for anything else (literals, computed expressions, ...).
+fn resolve_stat_target(e: Node, arena: &Arena<AExpr>) -> Option<StatTarget> {
+    match arena.get(e) {
+        AExpr::Column(c) => Some(StatTarget {
+            col: c.clone(),
+            path: Vec::new(),
+        }),
+        #[cfg(feature = "dtype-struct")]
+        AExpr::Function {
+            input,
+            function: IRFunctionExpr::StructExpr(IRStructFunction::FieldByName(name)),
+            ..
+        } if input.len() == 1 => {
+            let mut inner = resolve_stat_target(input[0].node(), arena)?;
+            inner.path.push(name.clone());
+            Some(inner)
+        },
+        _ => None,
+    }
+}
+
+/// The leaf dtype a [`StatTarget`] points at, walking the struct-field path through `schema`.
+fn target_leaf_dtype<'a>(target: &StatTarget, schema: &'a Schema) -> Option<&'a DataType> {
+    #[allow(unused_mut)]
+    let mut dtype = schema.get(&target.col)?;
+    #[cfg(feature = "dtype-struct")]
+    {
+        for field in &target.path {
+            let DataType::Struct(fields) = dtype else {
+                return None;
+            };
+            dtype = fields
+                .iter()
+                .find(|f| f.name() == field)
+                .map(|f| f.dtype())?;
+        }
+    }
+    Some(dtype)
+}
+
+/// Collect every scalar leaf reachable from `base` under a struct `dtype`. Used to express
+/// whole-struct null tests as a conjunction over the per-field null counts.
+#[cfg(feature = "dtype-struct")]
+fn struct_leaf_targets(base: &StatTarget, dtype: &DataType, out: &mut Vec<StatTarget>) {
+    match dtype {
+        DataType::Struct(fields) => {
+            for f in fields {
+                let mut child = base.clone();
+                child.path.push(f.name().clone());
+                struct_leaf_targets(&child, f.dtype(), out);
+            }
+        },
+        _ => out.push(base.clone()),
+    }
+}
+
+/// Like `get_binary_expr_col_and_lv`, but resolving the column side to a [`StatTarget`] so a
+/// `struct.field(..)` comparison is recognised too.
+#[allow(clippy::type_complexity)]
+fn get_binary_expr_target_and_lv<'a>(
+    left: Node,
+    right: Node,
+    arena: &'a Arena<AExpr>,
+    schema: &Schema,
+) -> Option<((StatTarget, Node), (Option<Cow<'a, LiteralValue>>, Node))> {
+    match (
+        resolve_stat_target(left, arena),
+        resolve_stat_target(right, arena),
+        constant_evaluate(left, arena, schema, 0),
+        constant_evaluate(right, arena, schema, 0),
+    ) {
+        (Some(target), _, _, Some(lv)) => Some(((target, left), (lv, right))),
+        (_, Some(target), Some(lv), _) => Some(((target, right), (lv, left))),
+        _ => None,
+    }
+}
 
 /// Return a new boolean expression determines whether a batch can be skipped based on min, max and
 /// null count statistics.
@@ -149,16 +284,15 @@ fn aexpr_to_skip_batch_predicate_rec(
 
                 match op {
                     O::Eq | O::EqValidity => {
-                        let ((col, _), (lv, lv_node)) =
-                            get_binary_expr_col_and_lv(left, right, arena, schema)?;
-                        let dtype = schema.get(col)?;
+                        let ((target, _), (lv, lv_node)) =
+                            get_binary_expr_target_and_lv(left, right, arena, schema)?;
+                        let dtype = target_leaf_dtype(&target, schema)?;
 
                         if !can_use_min_max_stats(dtype, Some(op), lv.as_deref()) {
                             return None;
                         }
 
                         let op = *op;
-                        let col = col.clone();
 
                         // col(A) == B -> {
                         //     null_count(A) == 0                              , if B.is_null(),
@@ -171,14 +305,14 @@ fn aexpr_to_skip_batch_predicate_rec(
                                 if matches!(op, O::Eq) {
                                     lv!(false).node()
                                 } else {
-                                    let col_nc = col!(null_count: col);
+                                    let col_nc = target.null_count(arena);
                                     let idx_zero = lv!(idx: 0);
                                     col_nc.eq(idx_zero, arena).node()
                                 }
                             },
                             not_null: {
-                                let col_min = col!(min: col);
-                                let col_max = col!(max: col);
+                                let col_min = target.min(arena);
+                                let col_max = target.max(arena);
 
                                 let min_is_defined = is_stat_defined(col_min.node(), dtype, arena);
                                 let max_is_defined = is_stat_defined(col_max.node(), dtype, arena);
@@ -189,7 +323,7 @@ fn aexpr_to_skip_batch_predicate_rec(
                                 let max_lt = col_max.lt(lv_node, arena);
                                 let max_lt = max_lt.and(max_is_defined, arena);
 
-                                let col_nc = col!(null_count: col);
+                                let col_nc = target.null_count(arena);
                                 let len = col!(len);
                                 let all_nulls = col_nc.eq(len, arena);
 
@@ -198,16 +332,15 @@ fn aexpr_to_skip_batch_predicate_rec(
                         ))
                     },
                     O::NotEq | O::NotEqValidity => {
-                        let ((col, _), (lv, lv_node)) =
-                            get_binary_expr_col_and_lv(left, right, arena, schema)?;
-                        let dtype = schema.get(col)?;
+                        let ((target, _), (lv, lv_node)) =
+                            get_binary_expr_target_and_lv(left, right, arena, schema)?;
+                        let dtype = target_leaf_dtype(&target, schema)?;
 
                         if !can_use_min_max_stats(dtype, Some(op), lv.as_deref()) {
                             return None;
                         }
 
                         let op = *op;
-                        let col = col.clone();
 
                         // col(A) != B -> {
                         //     null_count(A) == LEN                            , if B.is_null(),
@@ -220,18 +353,18 @@ fn aexpr_to_skip_batch_predicate_rec(
                                 if matches!(op, O::NotEq) {
                                     lv!(false).node()
                                 } else {
-                                    let col_nc = col!(null_count: col);
+                                    let col_nc = target.null_count(arena);
                                     let len = col!(len);
                                     col_nc.eq(len, arena).node()
                                 }
                             },
                             not_null: {
-                                let col_min = col!(min: col);
-                                let col_max = col!(max: col);
+                                let col_min = target.min(arena);
+                                let col_max = target.max(arena);
                                 let min_eq = col_min.eq(lv_node, arena);
                                 let max_eq = col_max.eq(lv_node, arena);
 
-                                let col_nc = col!(null_count: col);
+                                let col_nc = target.null_count(arena);
                                 let idx_zero = lv!(idx: 0);
                                 let no_nulls = col_nc.eq(idx_zero, arena);
 
@@ -240,9 +373,9 @@ fn aexpr_to_skip_batch_predicate_rec(
                         ))
                     },
                     O::Lt | O::Gt | O::LtEq | O::GtEq => {
-                        let ((col, col_node), (lv, lv_node)) =
-                            get_binary_expr_col_and_lv(left, right, arena, schema)?;
-                        let dtype = schema.get(col)?;
+                        let ((target, col_node), (lv, lv_node)) =
+                            get_binary_expr_target_and_lv(left, right, arena, schema)?;
+                        let dtype = target_leaf_dtype(&target, schema)?;
                         let col_is_left = col_node == left;
 
                         let effective_op = if col_is_left { *op } else { op.swap_operands() };
@@ -251,7 +384,6 @@ fn aexpr_to_skip_batch_predicate_rec(
                         }
 
                         let op = *op;
-                        let col = col.clone();
                         let lv_may_be_null = lv.is_none_or(|lv| lv.is_null());
 
                         // If B is null, this is always true.
@@ -269,8 +401,8 @@ fn aexpr_to_skip_batch_predicate_rec(
                         //     null_count(A) == LEN || max(A) < B
 
                         let stat = match (op, col_is_left) {
-                            (O::Lt | O::LtEq, true) | (O::Gt | O::GtEq, false) => col!(min: col),
-                            (O::Lt | O::LtEq, false) | (O::Gt | O::GtEq, true) => col!(max: col),
+                            (O::Lt | O::LtEq, true) | (O::Gt | O::GtEq, false) => target.min(arena),
+                            (O::Lt | O::LtEq, false) | (O::Gt | O::GtEq, true) => target.max(arena),
                             _ => unreachable!(),
                         };
                         let cmp_op = match (op, col_is_left) {
@@ -341,13 +473,13 @@ fn aexpr_to_skip_batch_predicate_rec(
                         let nulls_equal = *nulls_equal;
                         let lv_node = input[1].node();
                         match (
-                            into_column(input[0].node(), arena),
+                            resolve_stat_target(input[0].node(), arena),
                             constant_evaluate(lv_node, arena, schema, 0),
                         ) {
-                            (Some(col), Some(_)) => {
+                            (Some(target), Some(_)) => {
                                 use polars_core::prelude::ExplodeOptions;
 
-                                let dtype = schema.get(col)?;
+                                let dtype = target_leaf_dtype(&target, schema)?;
                                 if !can_use_min_max_stats(dtype, None, None) {
                                     return None;
                                 }
@@ -368,7 +500,6 @@ fn aexpr_to_skip_batch_predicate_rec(
                                 // and conditionally in the fallback path.
                                 const LIST_ITEM_LIMIT: usize = 100;
 
-                                let col = col.clone();
                                 let values = try_extract_is_in_haystack(
                                     lv_node,
                                     arena,
@@ -386,8 +517,8 @@ fn aexpr_to_skip_batch_predicate_rec(
                                     },
                                 );
 
-                                let col_min = col!(min: col);
-                                let col_max = col!(max: col);
+                                let col_min = target.min(arena);
+                                let col_max = target.max(arena);
                                 let min_is_defined = is_stat_defined(col_min, dtype, arena);
                                 let max_is_defined = is_stat_defined(col_max, dtype, arena);
 
@@ -395,7 +526,7 @@ fn aexpr_to_skip_batch_predicate_rec(
                                 // null in this group. Sound for both paths; the per-case
                                 // null_count(A) == 0 guards suppress skip when haystack and column
                                 // both have nulls under nulls_equal=true.
-                                let col_nc = col!(null_count: col);
+                                let col_nc = target.null_count(arena);
                                 let len = col!(len);
                                 let idx_zero = lv!(idx: 0);
                                 let all_nulls = col_nc.eq(len, arena);
@@ -459,16 +590,15 @@ fn aexpr_to_skip_batch_predicate_rec(
                         }
                     },
                     IRBooleanFunction::Not => {
-                        let col = into_column(input[0].node(), arena)?;
-                        let dtype = schema.get(col)?;
+                        let target = resolve_stat_target(input[0].node(), arena)?;
+                        let dtype = target_leaf_dtype(&target, schema)?;
                         if !matches!(dtype, DataType::Boolean) {
                             return None;
                         }
 
-                        let col = col.clone();
-                        let col_nc = col!(null_count: col);
+                        let col_nc = target.null_count(arena);
                         let len = col!(len);
-                        let col_min = col!(min: col);
+                        let col_min = target.min(arena);
                         let col_min_is_true = col_min.eq(lv!(true), arena);
                         let min_is_defined = is_stat_defined(col_min, dtype, arena);
 
@@ -480,25 +610,64 @@ fn aexpr_to_skip_batch_predicate_rec(
                         Some(all_null.or(min, arena).node())
                     },
                     IRBooleanFunction::IsNull => {
-                        let col = into_column(input[0].node(), arena)?;
+                        let target = resolve_stat_target(input[0].node(), arena)?;
 
                         // col(A).is_null() -> null_count(A) == 0
-                        let col_nc = col!(null_count: col);
+                        //
+                        // For a struct target the row-level null count is unrecoverable from
+                        // per-field counts. But a null struct nulls *every* field, so a single
+                        // field that is never null proves no struct row is null either
+                        // (null_count(field) bounds the struct null count from above). Skip when
+                        // *any* per-field `null_count == 0`: the disjunction over the leaves.
+                        #[cfg(feature = "dtype-struct")]
+                        {
+                            let dtype = target_leaf_dtype(&target, schema)?;
+                            if matches!(dtype, DataType::Struct(_)) {
+                                let mut leaves = Vec::new();
+                                struct_leaf_targets(&target, dtype, &mut leaves);
+                                let mut acc: Option<AExprBuilder> = None;
+                                for leaf in &leaves {
+                                    let leaf_nc = leaf.null_count(arena);
+                                    let idx_zero = lv!(idx: 0);
+                                    let term = leaf_nc.eq(idx_zero, arena);
+                                    acc = Some(match acc {
+                                        Some(acc) => acc.or(term, arena),
+                                        None => term,
+                                    });
+                                }
+                                // Empty struct: no leaves to reason about -> cannot skip.
+                                return acc.map(|acc| acc.node());
+                            }
+                        }
+
+                        let col_nc = target.null_count(arena);
                         let idx_zero = lv!(idx: 0);
                         Some(col_nc.eq(idx_zero, arena).node())
                     },
                     IRBooleanFunction::IsNotNull => {
-                        let col = into_column(input[0].node(), arena)?;
+                        let target = resolve_stat_target(input[0].node(), arena)?;
+
+                        // A struct row with null *fields* is still a non-null *struct*, and the
+                        // struct's row-level null count is unrecoverable from per-field counts, so
+                        // whole-struct is_not_null cannot be pruned. A scalar struct *field* is
+                        // fine: its per-field null count is exact.
+                        #[cfg(feature = "dtype-struct")]
+                        {
+                            let dtype = target_leaf_dtype(&target, schema)?;
+                            if matches!(dtype, DataType::Struct(_)) {
+                                return None;
+                            }
+                        }
 
                         // col(A).is_not_null() -> null_count(A) == LEN
-                        let col_nc = col!(null_count: col);
+                        let col_nc = target.null_count(arena);
                         let len = col!(len);
                         Some(col_nc.eq(len, arena).node())
                     },
                     #[cfg(feature = "is_between")]
                     IRBooleanFunction::IsBetween { closed } => {
-                        let col = into_column(input[0].node(), arena)?;
-                        let dtype = schema.get(col)?;
+                        let target = resolve_stat_target(input[0].node(), arena)?;
+                        let dtype = target_leaf_dtype(&target, schema)?;
 
                         // col(A).is_between(X, Y) ->
                         //     null_count(A) == LEN ||
@@ -517,14 +686,13 @@ fn aexpr_to_skip_batch_predicate_rec(
                             return None;
                         }
 
-                        let col = col.clone();
                         let closed = *closed;
 
                         let lhs_no_nulls = left_node.into_aexpr_builder().has_no_nulls(arena);
                         let rhs_no_nulls = right_node.into_aexpr_builder().has_no_nulls(arena);
 
-                        let col_min = col!(min: col);
-                        let col_max = col!(max: col);
+                        let col_min = target.min(arena);
+                        let col_max = target.max(arena);
 
                         use polars_ops::series::ClosedInterval;
                         let (left, right) = match closed {
@@ -580,11 +748,13 @@ fn aexpr_to_skip_batch_predicate_rec(
     }));
 
     // We cannot do proper equalities for these. For floats, min/max stats exclude
-    // NaN, so substituting col=min doesn't account for hidden NaN values.
+    // NaN, so substituting col=min doesn't account for hidden NaN values. Nested columns
+    // (e.g. structs) carry struct-shaped stats that cannot be substituted as a whole; their
+    // individual fields are handled by the specialized per-field handlers above.
     if live_columns.iter().any(|(c, _)| {
         schema
             .get(c)
-            .is_none_or(|dt| dt.is_categorical() || dt.is_float())
+            .is_none_or(|dt| dt.is_categorical() || dt.is_float() || dt.is_nested())
     }) {
         return None;
     }

--- a/crates/polars-stream/src/nodes/io_sources/parquet/statistics.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/statistics.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use arrow::array::{MutablePrimitiveArray, PrimitiveArray};
+use arrow::array::{Array, MutablePrimitiveArray, PrimitiveArray, StructArray};
 use arrow::bitmap::Bitmap;
 use arrow::pushable::Pushable;
 use polars_async::executor::{self, TaskPriority};
@@ -10,6 +10,7 @@ use polars_io::predicates::ScanIOPredicate;
 use polars_io::prelude::FileMetadata;
 use polars_parquet::read::RowGroupMetadata;
 use polars_parquet::read::statistics::{ArrowColumnStatisticsArrays, deserialize_all};
+use polars_plan::plans::predicates::null_count_dtype;
 use polars_utils::format_pl_smallstr;
 
 use crate::nodes::io_sources::parquet::projection::ArrowFieldProjection;
@@ -25,7 +26,7 @@ impl StatisticsColumns {
         Self {
             min: Column::full_null(PlSmallStr::EMPTY, height, dtype),
             max: Column::full_null(PlSmallStr::EMPTY, height, dtype),
-            null_count: Column::full_null(PlSmallStr::EMPTY, height, &IDX_DTYPE),
+            null_count: Column::full_null(PlSmallStr::EMPTY, height, &null_count_dtype(dtype)),
         }
     }
 
@@ -170,6 +171,147 @@ pub(super) async fn calculate_row_group_pred_pushdown_skip_mask(
     Ok(Some(skip_row_group_mask))
 }
 
+/// Assembled `min` / `max` / `null_count` statistics arrays for a (possibly nested) struct field.
+struct StructStatisticsArrays {
+    min: Box<dyn Array>,
+    max: Box<dyn Array>,
+    null_count: Box<dyn Array>,
+}
+
+/// Recursively assemble per-field `min` / `max` / `null_count` statistics arrays for a
+/// (possibly nested) struct field, consuming one parquet leaf column per scalar leaf. Returns
+/// `None` (signalling the caller to fall back to null statistics) for an empty struct, an
+/// unsupported leaf type (e.g. a nested list), or if the leaves run out before the fields do.
+fn build_struct_statistics_arrays(
+    field: &ArrowField,
+    row_groups: &[RowGroupMetadata],
+    leaf_idxs: &[usize],
+    cursor: &mut usize,
+    footer_buf: &[u8],
+) -> PolarsResult<Option<StructStatisticsArrays>> {
+    let height = row_groups.len();
+    match field.dtype() {
+        ArrowDataType::Struct(children) => {
+            // An empty struct has no leaf statistics to reason about, and `StructArray::new`
+            // panics on a struct dtype with no children, so bail to null statistics.
+            if children.is_empty() {
+                return Ok(None);
+            }
+
+            let mut mins = Vec::with_capacity(children.len());
+            let mut maxs = Vec::with_capacity(children.len());
+            let mut ncs = Vec::with_capacity(children.len());
+
+            // Pairs each arrow struct field with the next parquet leaf by position. Both derive
+            // from the same parquet schema, so their leaf orders match; the caller's `cursor`
+            // length check catches a leaf-count mismatch.
+            for child in children {
+                let Some(child) = build_struct_statistics_arrays(
+                    child, row_groups, leaf_idxs, cursor, footer_buf,
+                )?
+                else {
+                    return Ok(None);
+                };
+                mins.push(child.min);
+                maxs.push(child.max);
+                ncs.push(child.null_count);
+            }
+
+            let min = StructArray::new(field.dtype().clone(), height, mins, None).to_boxed();
+            let max = StructArray::new(field.dtype().clone(), height, maxs, None).to_boxed();
+
+            // The null-count struct mirrors the field's shape with each leaf replaced by the
+            // index type; read that shape straight off the assembled per-field arrays.
+            let nc_fields: Vec<ArrowField> = children
+                .iter()
+                .zip(ncs.iter())
+                .map(|(child, nc)| ArrowField::new(child.name.clone(), nc.dtype().clone(), true))
+                .collect();
+            let null_count =
+                StructArray::new(ArrowDataType::Struct(nc_fields), height, ncs, None).to_boxed();
+
+            Ok(Some(StructStatisticsArrays {
+                min,
+                max,
+                null_count,
+            }))
+        },
+        _ => {
+            // Scalar leaf: consume the next parquet leaf column.
+            if *cursor >= leaf_idxs.len() {
+                return Ok(None);
+            }
+            let idx = leaf_idxs[*cursor];
+            *cursor += 1;
+
+            match deserialize_all(field, row_groups, idx, footer_buf)? {
+                Some(statistics) => Ok(Some(StructStatisticsArrays {
+                    min: statistics.min_value,
+                    max: statistics.max_value,
+                    null_count: statistics.null_count.to_boxed(),
+                })),
+                // Unsupported leaf type (e.g. a list nested inside the struct).
+                None => Ok(None),
+            }
+        },
+    }
+}
+
+fn load_struct_column_statistics(
+    arrow_field: &ArrowField,
+    row_groups: &[RowGroupMetadata],
+    leaf_idxs: &[usize],
+    footer_buf: &[u8],
+) -> PolarsResult<Option<StatisticsColumns>> {
+    let mut cursor = 0;
+    let Some(StructStatisticsArrays {
+        min,
+        max,
+        null_count,
+    }) = build_struct_statistics_arrays(
+        arrow_field,
+        row_groups,
+        leaf_idxs,
+        &mut cursor,
+        footer_buf,
+    )?
+    else {
+        return Ok(None);
+    };
+
+    // Only trust the assembled stats if every parquet leaf mapped to a struct field; a
+    // mismatch means the schema and parquet layout disagree and the stats could be misaligned.
+    if cursor != leaf_idxs.len() {
+        return Ok(None);
+    }
+
+    let min = unsafe {
+        Series::_try_from_arrow_unchecked_with_md(
+            PlSmallStr::EMPTY,
+            vec![min],
+            arrow_field.dtype(),
+            arrow_field.metadata.as_deref(),
+        )
+    }?
+    .into_column();
+    let max = unsafe {
+        Series::_try_from_arrow_unchecked_with_md(
+            PlSmallStr::EMPTY,
+            vec![max],
+            arrow_field.dtype(),
+            arrow_field.metadata.as_deref(),
+        )
+    }?
+    .into_column();
+    let null_count = Series::from_arrow(PlSmallStr::EMPTY, null_count)?.into_column();
+
+    Ok(Some(StatisticsColumns {
+        min,
+        max,
+        null_count,
+    }))
+}
+
 fn load_parquet_column_statistics(
     row_groups: &[RowGroupMetadata],
     projection: &ArrowFieldProjection,
@@ -189,10 +331,21 @@ fn load_parquet_column_statistics(
         return null_statistics();
     };
 
-    // 0 is possible for possible for empty structs.
-    //
-    // 2+ is for structs. We don't support reading nested statistics for now. It does not
-    // really make any sense at the moment with how we structure statistics.
+    // Structs span multiple parquet leaf columns; assemble per-field statistics so the
+    // skip-batch predicate can prune on an individual struct field. Falls back to (struct-
+    // shaped) null statistics if any leaf is unsupported.
+    if matches!(arrow_field.dtype(), ArrowDataType::Struct(_)) {
+        let Some(statistics) =
+            load_struct_column_statistics(arrow_field, row_groups, idxs, footer_buf)?
+        else {
+            return null_statistics();
+        };
+        return Ok(statistics);
+    }
+
+    // Structs are handled above, so only non-struct columns reach here. A scalar occupies
+    // exactly one leaf and is read below; multi-leaf nested types (lists, maps) don't have
+    // statistics we read. The empty case is defensive: a present root always has >= 1 leaf.
     if idxs.is_empty() || idxs.len() > 1 {
         return null_statistics();
     }

--- a/py-polars/src/polars/io/delta/_utils.py
+++ b/py-polars/src/polars/io/delta/_utils.py
@@ -14,8 +14,8 @@ from polars.io.cloud._utils import POLARS_STORAGE_CONFIG_KEYS, _get_path_scheme
 if TYPE_CHECKING:
     from deltalake import DeltaTable
 
-    from polars import DataFrame, DataType
-    from polars._typing import SchemaDict, StorageOptionsDict
+    from polars import DataFrame, DataType, Series
+    from polars._typing import PolarsDataType, SchemaDict, StorageOptionsDict
 
 
 def _resolve_delta_lake_uri(table_uri: str | Path, *, strict: bool = True) -> str:
@@ -106,6 +106,23 @@ def _check_for_unsupported_types(dtypes: list[DataType]) -> None:
         raise TypeError(msg)
 
 
+def _null_count_dtype(dtype: PolarsDataType) -> PolarsDataType:
+    """Statistics-frame dtype for a column's ``null_count``.
+
+    Scalar (and non-struct nested) columns carry a single row-level null count (the
+    index type). Struct columns carry a *per-field* null count mirroring the column
+    shape (each leaf replaced by the index type), so the skip-batch predicate can prune
+    on an individual struct field via ``col("<c>_nc").struct.field(..)``.
+    """
+    import polars as pl
+
+    if isinstance(dtype, pl.Struct):
+        return pl.Struct(
+            {field.name: _null_count_dtype(field.dtype) for field in dtype.fields}
+        )
+    return pl.get_index_type()
+
+
 def _extract_table_statistics_from_delta_add_actions(
     add_actions_df: DataFrame,
     *,
@@ -141,23 +158,37 @@ def _extract_table_statistics_from_delta_add_actions(
         else {}
     )
 
+    height = add_actions_df.height
+
+    def null_col(dt: PolarsDataType) -> Series:
+        return pl.Series([None], dtype=dt).new_from_index(0, height)
+
     for col_name in filter_columns:
-        if (col_nc := null_count_cols.get(col_name)) is None:
-            col_nc = pl.Series([None], dtype=pl.get_index_type()).new_from_index(
-                0, add_actions_df.height
-            )
-        if (col_min := min_cols.get(col_name)) is None:
-            col_min = pl.Series([None], dtype=schema[col_name]).new_from_index(
-                0, add_actions_df.height
-            )
+        dtype = schema[col_name]
+        # The skip-batch predicate expects `<col>_nc` in the index type (a per-field
+        # struct of index counts for struct columns), so normalise the counts here.
+        nc_dtype = _null_count_dtype(dtype)
+        col_nc = null_count_cols.get(col_name)
+        col_min = min_cols.get(col_name)
+        col_max = max_cols.get(col_name)
 
-        if (col_max := max_cols.get(col_name)) is None:
-            col_max = pl.Series([None], dtype=schema[col_name]).new_from_index(
-                0, add_actions_df.height
+        out[f"{col_name}_nc"] = (
+            col_nc.cast(nc_dtype) if col_nc is not None else null_col(nc_dtype)
+        )
+
+        if isinstance(dtype, pl.Struct):
+            # Delta records struct min/max field-wise as a struct mirroring the column
+            # schema. Cast to the column dtype so every schema field is present and
+            # resolvable, letting the skip-batch predicate prune on an individual struct
+            # field via `col("<c>_min").struct.field(..)`.
+            out[f"{col_name}_min"] = (
+                col_min.cast(dtype) if col_min is not None else null_col(dtype)
             )
+            out[f"{col_name}_max"] = (
+                col_max.cast(dtype) if col_max is not None else null_col(dtype)
+            )
+        else:
+            out[f"{col_name}_min"] = col_min if col_min is not None else null_col(dtype)
+            out[f"{col_name}_max"] = col_max if col_max is not None else null_col(dtype)
 
-        out[f"{col_name}_nc"] = col_nc
-        out[f"{col_name}_min"] = col_min
-        out[f"{col_name}_max"] = col_max
-
-    return pl.DataFrame(out, height=add_actions_df.height)
+    return pl.DataFrame(out, height=height)

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -21,6 +21,7 @@ from polars.io.cloud.credential_provider._builder import (
 )
 from polars.io.delta._dataset import DeltaDataset
 from polars.io.delta._utils import _extract_table_statistics_from_delta_add_actions
+from polars.meta import get_index_type
 from polars.testing import assert_frame_equal, assert_frame_not_equal
 
 if TYPE_CHECKING:
@@ -981,9 +982,15 @@ def _df_many_types() -> pl.DataFrame:
         pl.col.decimal <= pl.lit(2.0).cast(pl.Decimal(10, 2)),
         pl.col.decimal < pl.lit(3.0).cast(pl.Decimal(10, 2)),
         pl.col.decimal.is_null(),
-        # Struct # see github issue #26239
+        # Struct whole-column null-count pushdown
+        pl.col.struct.is_null(),
+        # Struct per-field pushdown
+        pl.col.struct.struct.field("x") == 2,
+        pl.col.struct.struct.field("x") < 3,
+        pl.col.struct.struct.field("x").is_null(),
+        # whole-struct `==` is excluded: comparing structs needs ordering, which is
+        # unimplemented and panics (a kernel gap, not a pushdown one). e.g.:
         # pl.col.struct == {"x": 2, "y": 20},
-        # pl.col.struct.is_null(),
         # Date & datetime
         pl.col.date == pl.date(2020, 1, 1),
         pl.col.datetime == pl.datetime(2020, 1, 1),
@@ -1036,34 +1043,34 @@ def test_scan_delta_extract_table_statistics_df(tmp_path: Path) -> None:
         pl.DataFrame(
             [
                 pl.Series('len', [2, 2, 2], dtype=pl.Int64),
-                pl.Series('p_nc', [None, None, None], dtype=pl.UInt32),
+                pl.Series('p_nc', [None, None, None], dtype=get_index_type()),
                 pl.Series('p_min', [None, None, None], dtype=pl.Int64),
                 pl.Series('p_max', [None, None, None], dtype=pl.Int64),
-                pl.Series('a_nc', [0, 1, 0], dtype=pl.Int64),
+                pl.Series('a_nc', [0, 1, 0], dtype=get_index_type()),
                 pl.Series('a_min', [1, 5, 3], dtype=pl.Int64),
                 pl.Series('a_max', [2, 5, 4], dtype=pl.Int64),
-                pl.Series('bool_nc', [0, 1, 0], dtype=pl.Int64),
+                pl.Series('bool_nc', [0, 1, 0], dtype=get_index_type()),
                 pl.Series('bool_min', [False, True, True], dtype=pl.Boolean),
                 pl.Series('bool_max', [False, True, True], dtype=pl.Boolean),
-                pl.Series('int_nc', [0, 1, 0], dtype=pl.Int64),
+                pl.Series('int_nc', [0, 1, 0], dtype=get_index_type()),
                 pl.Series('int_min', [1, 5, 3], dtype=pl.Int64),
                 pl.Series('int_max', [2, 5, 4], dtype=pl.Int64),
-                pl.Series('float_nc', [0, 1, 0], dtype=pl.Int64),
+                pl.Series('float_nc', [0, 1, 0], dtype=get_index_type()),
                 pl.Series('float_min', [1.0, 5.0, 3.0], dtype=pl.Float64),
                 pl.Series('float_max', [2.0, 5.0, 4.0], dtype=pl.Float64),
-                pl.Series('string_nc', [0, 1, 0], dtype=pl.Int64),
+                pl.Series('string_nc', [0, 1, 0], dtype=get_index_type()),
                 pl.Series('string_min', ['a', 'ccc', 'c'], dtype=pl.String),
                 pl.Series('string_max', ['b', 'ccc', 'cc'], dtype=pl.String),
-                pl.Series('struct_nc', [{'x': 0, 'y': 0}, {'x': 1, 'y': 1}, {'x': 0, 'y': 0}], dtype=pl.Struct({'x': pl.Int64, 'y': pl.Int64})),
+                pl.Series('struct_nc', [{'x': 0, 'y': 0}, {'x': 1, 'y': 1}, {'x': 0, 'y': 0}], dtype=pl.Struct({'x': get_index_type(), 'y': get_index_type()})),
                 pl.Series('struct_min', [{'x': 1, 'y': 10}, {'x': 5, 'y': 50}, {'x': 3, 'y': 30}], dtype=pl.Struct({'x': pl.Int64, 'y': pl.Int64})),
                 pl.Series('struct_max', [{'x': 2, 'y': 20}, {'x': 5, 'y': 50}, {'x': 4, 'y': 40}], dtype=pl.Struct({'x': pl.Int64, 'y': pl.Int64})),
-                pl.Series('decimal_nc', [0, 1, 0], dtype=pl.Int64),
+                pl.Series('decimal_nc', [0, 1, 0], dtype=get_index_type()),
                 pl.Series('decimal_min', [Decimal('1.00'), Decimal('5.00'), Decimal('3.00')], dtype=pl.Decimal(precision=10, scale=2)),
                 pl.Series('decimal_max', [Decimal('2.00'), Decimal('5.00'), Decimal('4.00')], dtype=pl.Decimal(precision=10, scale=2)),
-                pl.Series('date_nc', [0, 0, 0], dtype=pl.Int64),
+                pl.Series('date_nc', [0, 0, 0], dtype=get_index_type()),
                 pl.Series('date_min', [datetime.date(2020, 1, 1), datetime.date(2020, 1, 5), datetime.date(2020, 1, 3)], dtype=pl.Date),
                 pl.Series('date_max', [datetime.date(2020, 1, 2), datetime.date(2020, 1, 6), datetime.date(2020, 1, 4)], dtype=pl.Date),
-                pl.Series('datetime_nc', [0, 0, 0], dtype=pl.Int64),
+                pl.Series('datetime_nc', [0, 0, 0], dtype=get_index_type()),
                 pl.Series('datetime_min', [datetime.datetime(2020, 1, 1, 0, 0), datetime.datetime(2020, 1, 5, 0, 0), datetime.datetime(2020, 1, 3, 0, 0)], dtype=pl.Datetime(time_unit='us', time_zone=None)),
                 pl.Series('datetime_max', [datetime.datetime(2020, 1, 2, 0, 0), datetime.datetime(2020, 1, 6, 0, 0), datetime.datetime(2020, 1, 4, 0, 0)], dtype=pl.Datetime(time_unit='us', time_zone=None)),
             ]
@@ -1396,3 +1403,56 @@ def test_scan_delta_literal_filter_empty_df_27242(tmp_path: Path) -> None:
 
     out = pl.scan_delta(tmp_path).filter(pl.lit(True)).collect()
     assert_frame_equal(df, out)
+
+
+def test_scan_delta_predicate_pushdown_struct_column_27857(tmp_path: Path) -> None:
+    df = pl.DataFrame(
+        {
+            "error_flags": pl.Series(
+                [
+                    {"length_issue": True, "incomplete": True},
+                    {"length_issue": False, "incomplete": False},
+                ]
+            )
+        }
+    )
+    df.write_delta(tmp_path)
+
+    predicate = pl.any_horizontal(pl.col("error_flags").struct.unnest())
+    out = pl.scan_delta(tmp_path).filter(predicate).collect()
+
+    expected = pl.DataFrame(
+        {"error_flags": pl.Series([{"length_issue": True, "incomplete": True}])}
+    )
+    assert_frame_equal(out, expected)
+
+
+@pytest.mark.write_disk
+def test_scan_delta_predicate_pushdown_struct_is_not_null(
+    tmp_path: Path,
+    plmonkeypatch: PlMonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    # A struct row with a null *field* is still a non-null *struct*, so `is_not_null()`
+    # must keep it. The per-field null count must not be read as the struct's row-level
+    # null count, or it would wrongly skip the first file (`a` all-null, structs valid).
+    st = pl.Struct({"a": pl.Int64, "b": pl.Int64})
+    df = pl.DataFrame(
+        {
+            "s": pl.Series(
+                [{"a": None, "b": 1}, {"a": None, "b": 2}, {"a": 5, "b": 5}], dtype=st
+            )
+        }
+    )
+    df[:2].write_delta(tmp_path)
+    df[2:].write_delta(tmp_path, mode="append")
+
+    plmonkeypatch.setenv("POLARS_VERBOSE", "1")
+    capfd.readouterr()
+    out = pl.scan_delta(tmp_path).filter(pl.col("s").is_not_null()).collect()
+    err = capfd.readouterr().err
+
+    # Every struct is non-null, so all rows are kept; the first file (`a` all-null)
+    # must not be pruned.
+    assert_frame_equal(out, df, check_row_order=False)
+    assert "skipping 1 / 2 files" not in err

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -3504,7 +3504,7 @@ def test_scan_parquet_skip_row_groups_with_cast_inclusions(
 
 @pytest.mark.may_fail_cloud  # reason: looks at stdout
 @pytest.mark.parametrize(
-    ("df", "predicate"),
+    ("df", "predicate", "reading"),
     [
         # Per-field pruning: `s.field("a")` uses field a's own min/max, so rg0 (a == 0)
         # and rg2 (a == 2) are skipped even though sibling b varies within every group.
@@ -3522,6 +3522,7 @@ def test_scan_parquet_skip_row_groups_with_cast_inclusions(
                 }
             ),
             pl.col("s").struct.field("a") == 1,
+            "1 / 3",
             id="field",
         ),
         # Whole-struct is_null via per-field null counts: a struct is null only where
@@ -3540,11 +3541,14 @@ def test_scan_parquet_skip_row_groups_with_cast_inclusions(
                 }
             ),
             pl.col("s").is_null(),
+            "1 / 3",
             id="is_null_26239",
         ),
-        # is_null only needs *one* never-null field to rule out a null struct (a null
-        # struct nulls every field). rg0 has a field-null but no null struct, so a
-        # single null-free field must still prune it; rg2 is fully non-null.
+        # is_null needs only *one* never-null field to rule out a null struct (a null
+        # struct nulls every field), so rg0 is pruned via x despite y's field-null and
+        # rg2 is non-null. rg1's genuine null structs are matched (read). rg3's present
+        # all-null structs ({x: None, y: None}) are not null structs but bump x_nc/y_nc
+        # like one, so rg3 is read on its own merit and excluded by is_null.
         pytest.param(
             pl.DataFrame(
                 {
@@ -3555,10 +3559,13 @@ def test_scan_parquet_skip_row_groups_with_cast_inclusions(
                         None,
                         {"x": 3, "y": 30},
                         {"x": 4, "y": 40},
+                        {"x": None, "y": None},
+                        {"x": None, "y": None},
                     ]
                 }
             ),
             pl.col("s").is_null(),
+            "2 / 4",
             id="is_null_field_null_pruned",
         ),
     ],
@@ -3566,12 +3573,13 @@ def test_scan_parquet_skip_row_groups_with_cast_inclusions(
 def test_scan_parquet_skip_row_groups_struct(
     df: pl.DataFrame,
     predicate: pl.Expr,
+    reading: str,
     plmonkeypatch: PlMonkeyPatch,
     capfd: pytest.CaptureFixture[str],
 ) -> None:
-    # Struct statistics prune parquet row groups: with three groups of two rows, only
-    # the one group that can match the predicate is read; the other two are skipped
-    # using the struct's per-field min/max/null-count statistics.
+    # Struct statistics prune parquet row groups: only the groups that can match the
+    # predicate are read; the rest are skipped using the struct's per-field
+    # min/max/null-count statistics.
     f = io.BytesIO()
     df.write_parquet(f, row_group_size=2, statistics="full")
     f.seek(0)
@@ -3581,7 +3589,7 @@ def test_scan_parquet_skip_row_groups_struct(
     out = pl.scan_parquet(f).filter(predicate).collect()
 
     assert_frame_equal(out, df.filter(predicate))
-    assert "Predicate pushdown: reading 1 / 3 row groups" in capfd.readouterr().err
+    assert f"Predicate pushdown: reading {reading} row groups" in capfd.readouterr().err
 
 
 @pytest.mark.may_fail_cloud  # reason: looks at stdout

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -3503,6 +3503,88 @@ def test_scan_parquet_skip_row_groups_with_cast_inclusions(
 
 
 @pytest.mark.may_fail_cloud  # reason: looks at stdout
+@pytest.mark.parametrize(
+    ("df", "predicate"),
+    [
+        # Per-field pruning: `s.field("a")` uses field a's own min/max, so rg0 (a == 0)
+        # and rg2 (a == 2) are skipped even though sibling b varies within every group.
+        pytest.param(
+            pl.DataFrame(
+                {
+                    "s": [
+                        {"a": 0, "b": 100},
+                        {"a": 0, "b": 200},
+                        {"a": 1, "b": 300},
+                        {"a": 1, "b": 400},
+                        {"a": 2, "b": 500},
+                        {"a": 2, "b": 600},
+                    ]
+                }
+            ),
+            pl.col("s").struct.field("a") == 1,
+            id="field",
+        ),
+        # Whole-struct is_null via per-field null counts: a struct is null only where
+        # every field is null, so groups with no null struct are skipped (#26239).
+        pytest.param(
+            pl.DataFrame(
+                {
+                    "s": [
+                        None,
+                        None,
+                        {"x": 1, "y": 1},
+                        {"x": 2, "y": 2},
+                        {"x": 3, "y": 3},
+                        {"x": 4, "y": 4},
+                    ]
+                }
+            ),
+            pl.col("s").is_null(),
+            id="is_null_26239",
+        ),
+        # is_null only needs *one* never-null field to rule out a null struct (a null
+        # struct nulls every field). rg0 has a field-null but no null struct, so a
+        # single null-free field must still prune it; rg2 is fully non-null.
+        pytest.param(
+            pl.DataFrame(
+                {
+                    "s": [
+                        {"x": 1, "y": None},
+                        {"x": 2, "y": 20},
+                        None,
+                        None,
+                        {"x": 3, "y": 30},
+                        {"x": 4, "y": 40},
+                    ]
+                }
+            ),
+            pl.col("s").is_null(),
+            id="is_null_field_null_pruned",
+        ),
+    ],
+)
+def test_scan_parquet_skip_row_groups_struct(
+    df: pl.DataFrame,
+    predicate: pl.Expr,
+    plmonkeypatch: PlMonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    # Struct statistics prune parquet row groups: with three groups of two rows, only
+    # the one group that can match the predicate is read; the other two are skipped
+    # using the struct's per-field min/max/null-count statistics.
+    f = io.BytesIO()
+    df.write_parquet(f, row_group_size=2, statistics="full")
+    f.seek(0)
+
+    plmonkeypatch.setenv("POLARS_VERBOSE", "1")
+    capfd.readouterr()
+    out = pl.scan_parquet(f).filter(predicate).collect()
+
+    assert_frame_equal(out, df.filter(predicate))
+    assert "Predicate pushdown: reading 1 / 3 row groups" in capfd.readouterr().err
+
+
+@pytest.mark.may_fail_cloud  # reason: looks at stdout
 def test_is_in_string_pushdown_27416(
     plmonkeypatch: PlMonkeyPatch,
     capfd: pytest.CaptureFixture[str],

--- a/py-polars/tests/unit/io/test_skip_batch_predicate.py
+++ b/py-polars/tests/unit/io/test_skip_batch_predicate.py
@@ -14,7 +14,7 @@ from polars.testing.parametric.strategies import series
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from polars._typing import PythonLiteral
+    from polars._typing import PolarsDataType, PythonLiteral
 
 
 class Case(TypedDict):
@@ -164,6 +164,33 @@ def test_datetimes() -> None:
     )
 
 
+def _null_count_dtype(dtype: PolarsDataType) -> PolarsDataType:
+    """Statistics-frame dtype of the ``<col>_nc`` column, mirroring the Rust producer.
+
+    Scalar (and non-struct nested) columns carry a single index-typed null count;
+    struct columns carry a per-field count mirroring the column shape (each leaf
+    replaced by the index type), so the predicate can read an individual field's
+    count via ``col("<col>_nc").struct.field(..)``.
+    """
+    if isinstance(dtype, pl.Struct):
+        return pl.Struct(
+            [pl.Field(f.name, _null_count_dtype(f.dtype)) for f in dtype.fields]
+        )
+    return get_index_type()
+
+
+def _null_count_value(s: pl.Series) -> Any:
+    """Per-field null counts mirroring the struct shape.
+
+    A null struct nulls every leaf, so each leaf count includes parent-null rows.
+    """
+    if isinstance(s.dtype, pl.Struct):
+        return {
+            f.name: _null_count_value(s.struct.field(f.name)) for f in s.dtype.fields
+        }
+    return s.null_count()
+
+
 @given(
     s=series(
         name="x",
@@ -227,14 +254,14 @@ def test_skip_batch_predicate_parametric(s: pl.Series) -> None:
         with contextlib.suppress(Exception):
             maxs = [s.max()]
 
-        null_counts = [s.null_count()]
+        null_counts = [_null_count_value(s)]
         lengths = [s.len()]
 
         df = pl.DataFrame(
             [
                 pl.Series(f"{name}_min", mins, dtype),
                 pl.Series(f"{name}_max", maxs, dtype),
-                pl.Series(f"{name}_nc", null_counts, get_index_type()),
+                pl.Series(f"{name}_nc", null_counts, _null_count_dtype(dtype)),
                 pl.Series("len", lengths, get_index_type()),
             ]
         )


### PR DESCRIPTION
Closes #27857
Closes #26239

This PR implements per-field statistics pruning for struct columns, at both the Delta file level and the parquet row-group level.

The gap: predicate pushdown can skip an entire batch (a row group for parquet, a file for Delta) when the batch's column statistics prove no row matches the filter. Per column these are min, max, and null count. min and max already mirrored the column's shape (a struct column carried struct-typed min/max), but the null count was modeled as a single scalar for every column. That broke structs two ways. Delta produces a per-field (struct-shaped) null count, which clashed with the scalar model and raised `SchemaError`. Parquet sidestepped it only by discarding statistics for any column spanning more than one leaf, so struct columns were never pruned at all.

This PR makes the null count mirror the column's shape too; the parquet reader now assembles per-field statistics instead of discarding them. For a struct column `s = {a: Int64, b: Int64}` the null-count statistic changes:

```
before:  s_nc : UInt32                        # one scalar per column (Delta emitted a Struct here -> SchemaError)
after:   s_nc : Struct({a: UInt32, b: UInt32})    # one null count per field
```

Comparisons on a struct field prune using that field's own statistics, on both Delta files and parquet row groups. Whole-struct `is_null` is also supported.

Future work: whole-struct `is_not_null` pruning (only possible via a non-nullable field, since a struct's row-level null count is otherwise unrecoverable from per-field counts), and element-level statistics for other nested types (list/map `contains`, `min`/`max`).