### PR TITLE
fix: Lower SQL `[NOT] IN (subquery)` to semi/anti join

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -140,6 +140,17 @@ fn disambiguate_projection_cols(
     Ok(result)
 }
 
+/// What to do with the rows whose WHERE predicate evaluates to true.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FilterMode {
+    /// `SELECT ... WHERE`: keep exactly the rows where the predicate is true
+    /// (rows where it is false or NULL are dropped).
+    KeepTrue,
+    /// `DELETE ... WHERE`: drop exactly the rows where the predicate is true
+    /// (rows where it is false or NULL are kept).
+    RemoveTrue,
+}
+
 /// The SQLContext is the main entry point for executing SQL queries.
 #[derive(Clone)]
 pub struct SQLContext {
@@ -280,7 +291,7 @@ impl SQLContext {
 }
 
 impl SQLContext {
-    fn isolated(&self) -> Self {
+    pub(crate) fn isolated(&self) -> Self {
         Self {
             // Deep clone to isolate
             table_map: Arc::new(RwLock::new(self.table_map.read().unwrap().clone())),
@@ -791,7 +802,7 @@ impl SQLContext {
                 Ok(lf.clear())
             } else {
                 // apply constraint as inverted filter (drops rows matching the selection)
-                Ok(self.process_where(lf.clone(), selection, true, None)?)
+                Ok(self.process_where(lf.clone(), selection, FilterMode::RemoveTrue, None)?)
             }
         } else {
             polars_bail!(SQLInterface: "unexpected statement type; expected DELETE")
@@ -872,7 +883,10 @@ impl SQLContext {
     }
 
     /// execute the 'FROM' part of the query
-    fn execute_from_statement(&mut self, tbl_expr: &TableWithJoins) -> PolarsResult<LazyFrame> {
+    pub(crate) fn execute_from_statement(
+        &mut self,
+        tbl_expr: &TableWithJoins,
+    ) -> PolarsResult<LazyFrame> {
         let (l_name, mut lf) = self.get_table(&tbl_expr.relation)?;
         if !tbl_expr.joins.is_empty() {
             for join in &tbl_expr.joins {
@@ -1144,7 +1158,12 @@ impl SQLContext {
 
         // Apply `WHERE` constraint
         let mut schema = self.get_frame_schema(&mut lf)?;
-        lf = self.process_where(lf, &select_stmt.selection, false, Some(schema.clone()))?;
+        lf = self.process_where(
+            lf,
+            &select_stmt.selection,
+            FilterMode::KeepTrue,
+            Some(schema.clone()),
+        )?;
 
         // Determine projections
         let mut select_modifiers = SelectModifiers {
@@ -1549,7 +1568,7 @@ impl SQLContext {
         &mut self,
         mut lf: LazyFrame,
         expr: &Option<SQLExpr>,
-        invert_filter: bool,
+        filter_mode: FilterMode,
         schema: Option<SchemaRef>,
     ) -> PolarsResult<LazyFrame> {
         if let Some(expr) = expr {
@@ -1575,22 +1594,36 @@ impl SQLContext {
                 },
                 _ => (false, false),
             };
-            if (all_true && !invert_filter) || (all_false && invert_filter) {
+            let removing = filter_mode == FilterMode::RemoveTrue;
+            if (all_true && !removing) || (all_false && removing) {
                 return Ok(lf);
-            } else if (all_false && !invert_filter) || (all_true && invert_filter) {
+            } else if (all_false && !removing) || (all_true && removing) {
                 return Ok(lf.clear());
             }
 
-            // ...otherwise parse and apply the filter as normal
-            let mut filter_expression = parse_sql_expr(expr, self, Some(schema).as_deref())?;
+            // Lower eligible `[NOT] EXISTS` / `[NOT] IN (subquery)` conjuncts
+            // to semi / anti joins; whatever remains goes through the ordinary
+            // filter path below.
+            let residual_exprs: Vec<&SQLExpr>;
+            (lf, residual_exprs) =
+                self.rewrite_subquery_conjuncts(lf, expr, filter_mode, &schema)?;
+
+            let Some(parsed_residual) = residual_exprs
+                .iter()
+                .map(|e| parse_sql_expr(e, self, Some(&*schema)))
+                .reduce(|a, b| Ok(a?.and(b?)))
+            else {
+                // Every conjunct was rewritten to a join; nothing left to filter.
+                return Ok(lf);
+            };
+            let mut filter_expression = parsed_residual?;
             if filter_expression.clone().meta().has_multiple_outputs() {
                 filter_expression = all_horizontal([filter_expression])?;
             }
             lf = self.process_subqueries(lf, vec![&mut filter_expression])?;
-            lf = if invert_filter {
-                lf.remove(filter_expression)
-            } else {
-                lf.filter(filter_expression)
+            lf = match filter_mode {
+                FilterMode::KeepTrue => lf.filter(filter_expression),
+                FilterMode::RemoveTrue => lf.remove(filter_expression),
             };
         }
         Ok(lf)
@@ -2484,7 +2517,7 @@ fn get_using_cols(op: &JoinOperator) -> Option<impl Iterator<Item = String> + '_
 }
 
 /// Extract the table name (or alias) from a TableFactor.
-fn get_table_name(factor: &TableFactor) -> Option<String> {
+pub(crate) fn get_table_name(factor: &TableFactor) -> Option<String> {
     match factor {
         TableFactor::Table { name, alias, .. } => {
             alias.as_ref().map(|a| a.name.value.clone()).or_else(|| {

--- a/crates/polars-sql/src/lib.rs
+++ b/crates/polars-sql/src/lib.rs
@@ -7,6 +7,7 @@ mod functions;
 pub mod keywords;
 mod sql_expr;
 mod sql_visitors;
+mod subquery;
 mod table_functions;
 mod types;
 

--- a/crates/polars-sql/src/subquery.rs
+++ b/crates/polars-sql/src/subquery.rs
@@ -1,0 +1,570 @@
+//! Rewrites of `[NOT] EXISTS` / `[NOT] IN (subquery)` predicates into semi /
+//! anti joins, decorrelating equi-correlation predicates into join keys.
+//! Subquery shapes the rewrites can't soundly express return `None` so the
+//! caller falls back to the generic filter path.
+use polars_core::prelude::*;
+use polars_lazy::prelude::*;
+#[cfg(feature = "semi_anti_join")]
+use polars_plan::utils::{expr_to_leaf_column_names_iter, has_expr};
+#[cfg(feature = "semi_anti_join")]
+use polars_utils::aliases::PlHashSet;
+use sqlparser::ast::{BinaryOperator as SQLBinaryOperator, Expr as SQLExpr, Query};
+#[cfg(feature = "semi_anti_join")]
+use sqlparser::ast::{Distinct, GroupByExpr, Select, SelectItem, SetExpr, TableWithJoins};
+
+use crate::SQLContext;
+use crate::context::FilterMode;
+#[cfg(feature = "semi_anti_join")]
+use crate::context::get_table_name;
+#[cfg(feature = "semi_anti_join")]
+use crate::sql_expr::parse_sql_expr;
+
+impl SQLContext {
+    // Entry point: offer each WHERE conjunct to the rewrite, returning the
+    // (possibly join-extended) frame together with the conjuncts left for the
+    // ordinary filter path. In `KeepTrue` mode each top-level AND-conjunct is
+    // offered independently. In `RemoveTrue` mode conjuncts can't be split
+    // (`NOT (a AND b)` is a disjunction), so only a sole (possibly
+    // parenthesized) subquery predicate rewrites, and anything else is
+    // returned whole as the residual.
+    pub(crate) fn rewrite_subquery_conjuncts<'a>(
+        &mut self,
+        mut lf: LazyFrame,
+        expr: &'a SQLExpr,
+        filter_mode: FilterMode,
+        schema: &Schema,
+    ) -> PolarsResult<(LazyFrame, Vec<&'a SQLExpr>)> {
+        let residual = match filter_mode {
+            FilterMode::RemoveTrue => {
+                let mut unwrapped = expr;
+                while let SQLExpr::Nested(inner) = unwrapped {
+                    unwrapped = inner;
+                }
+                match self.try_rewrite_subquery_conjunct(&lf, unwrapped, filter_mode, schema)? {
+                    Some(new_lf) => {
+                        lf = new_lf;
+                        Vec::new()
+                    },
+                    None => vec![expr],
+                }
+            },
+            FilterMode::KeepTrue => {
+                let mut residual = Vec::new();
+                for conj in MintermIter::new(expr) {
+                    if let Some(new_lf) =
+                        self.try_rewrite_subquery_conjunct(&lf, conj, filter_mode, schema)?
+                    {
+                        lf = new_lf;
+                    } else {
+                        residual.push(conj);
+                    }
+                }
+                residual
+            },
+        };
+        Ok((lf, residual))
+    }
+
+    // Dispatch one conjunct to the matching rewrite. `RemoveTrue` mode (DELETE)
+    // flips the join polarity. Removing `IN` rows keeps
+    // rows whose membership is false or NULL, exactly what an anti-join
+    // produces; removing `NOT IN` rows would additionally keep NULL keys, which
+    // a semi join can't express, so it stays on the filter path.
+    fn try_rewrite_subquery_conjunct(
+        &mut self,
+        lf: &LazyFrame,
+        conj: &SQLExpr,
+        filter_mode: FilterMode,
+        schema: &Schema,
+    ) -> PolarsResult<Option<LazyFrame>> {
+        let removing = filter_mode == FilterMode::RemoveTrue;
+        match conj {
+            SQLExpr::Exists { subquery, negated } => {
+                self.try_rewrite_exists_as_join(lf, subquery, *negated != removing, schema)
+            },
+            SQLExpr::InSubquery {
+                expr: lhs,
+                subquery,
+                negated,
+            } if !(*negated && removing) => self.try_rewrite_in_subquery_as_join(
+                lf,
+                lhs,
+                subquery,
+                *negated != removing,
+                filter_mode,
+                schema,
+            ),
+            _ => Ok(None),
+        }
+    }
+
+    // Lower `[NOT] EXISTS (SELECT ... FROM rel WHERE rel.k = outer.k ...)` to a
+    // semi / anti join by decorrelating the equi-correlation predicate(s) into
+    // join keys. DISTINCT is ignored: existence is invariant under
+    // deduplication.
+    #[cfg(feature = "semi_anti_join")]
+    fn try_rewrite_exists_as_join(
+        &mut self,
+        lf: &LazyFrame,
+        subquery: &Query,
+        negated: bool,
+        outer_schema: &Schema,
+    ) -> PolarsResult<Option<LazyFrame>> {
+        let Some(select) = eligible_subquery_select(subquery) else {
+            return Ok(None);
+        };
+        let Some(selection) = &select.selection else {
+            return Ok(None);
+        };
+        // Resolve and parse the inner relation in an isolated context so its
+        // table/alias registrations don't leak into the outer query's scope.
+        let mut ctx = self.isolated();
+        let Some((inner_names, inner_lf, inner_schema)) =
+            ctx.resolve_subquery_from(&select.from[0])?
+        else {
+            return Ok(None);
+        };
+        let Some(SubqueryConjuncts {
+            left_on,
+            right_on,
+            local_filters,
+        }) = ctx.split_subquery_conjuncts(selection, &inner_names, &inner_schema, outer_schema)?
+        else {
+            return Ok(None);
+        };
+        // An uncorrelated EXISTS (no correlation key found) has no join key to
+        // build from, so leave it to the existing path.
+        if left_on.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(ctx.finish_decorrelated_join(
+            lf,
+            inner_lf,
+            left_on,
+            right_on,
+            local_filters,
+            negated,
+        )))
+    }
+
+    // Lower `lhs [NOT] IN (SELECT col FROM rel ...)` to a semi / anti join: the
+    // projected column is the membership key and any equi-correlations in the
+    // subquery WHERE become additional join keys.
+    #[cfg(feature = "semi_anti_join")]
+    fn try_rewrite_in_subquery_as_join(
+        &mut self,
+        lf: &LazyFrame,
+        lhs: &SQLExpr,
+        subquery: &Query,
+        anti: bool,
+        filter_mode: FilterMode,
+        outer_schema: &Schema,
+    ) -> PolarsResult<Option<LazyFrame>> {
+        let Some(select) = eligible_subquery_select(subquery) else {
+            return Ok(None);
+        };
+        // DISTINCT is membership-invariant, but DISTINCT ON drops rows per key.
+        if matches!(&select.distinct, Some(Distinct::On(_))) {
+            return Ok(None);
+        }
+        let [SelectItem::UnnamedExpr(proj) | SelectItem::ExprWithAlias { expr: proj, .. }] =
+            select.projection.as_slice()
+        else {
+            return Ok(None);
+        };
+
+        let left_key = parse_sql_expr(lhs, self, Some(outer_schema))?
+            .meta()
+            .undo_aliases();
+        if has_expr(&left_key, |e| matches!(e, Expr::SubPlan(_, _)))
+            || !expr_to_leaf_column_names_iter(&left_key)
+                .all(|name| outer_schema.contains(name.as_str()))
+        {
+            return Ok(None);
+        }
+
+        let mut ctx = self.isolated();
+        let Some((inner_names, inner_lf, inner_schema)) =
+            ctx.resolve_subquery_from(&select.from[0])?
+        else {
+            return Ok(None);
+        };
+        // The membership key must be a plain expression over the inner relation;
+        // any alias it carries is cosmetic and not allowed in a join key.
+        let Some(right_key) = ctx.try_parse_inner_only_expr(proj, &inner_schema, outer_schema)?
+        else {
+            return Ok(None);
+        };
+        let right_key = right_key.meta().undo_aliases();
+
+        let SubqueryConjuncts {
+            mut left_on,
+            mut right_on,
+            local_filters,
+        } = match &select.selection {
+            Some(selection) => {
+                let Some(split) = ctx.split_subquery_conjuncts(
+                    selection,
+                    &inner_names,
+                    &inner_schema,
+                    outer_schema,
+                )?
+                else {
+                    return Ok(None);
+                };
+                split
+            },
+            None => SubqueryConjuncts::default(),
+        };
+        left_on.insert(0, left_key.clone());
+        right_on.insert(0, right_key);
+        let joined =
+            ctx.finish_decorrelated_join(lf, inner_lf, left_on, right_on, local_filters, anti);
+        // `lhs NOT IN (...)` is NULL (and so excludes the row) when `lhs` is
+        // NULL, but an anti-join keeps null keys since they match nothing; drop
+        // them. In `RemoveTrue` mode a NULL membership test keeps the row, so the
+        // anti join is already exact.
+        Ok(Some(if anti && filter_mode == FilterMode::KeepTrue {
+            joined.filter(left_key.is_not_null())
+        } else {
+            joined
+        }))
+    }
+
+    // Apply the local filters to the inner relation, hand this (isolated, now
+    // finished) context's arenas to it, and build the semi / anti join against
+    // the outer frame. Consumes the context: nothing may be parsed in the
+    // subquery's scope after the join is built.
+    #[cfg(feature = "semi_anti_join")]
+    fn finish_decorrelated_join(
+        self,
+        lf: &LazyFrame,
+        inner_lf: LazyFrame,
+        left_on: Vec<Expr>,
+        right_on: Vec<Expr>,
+        local_filters: Vec<Expr>,
+        anti: bool,
+    ) -> LazyFrame {
+        let inner_lf = local_filters.into_iter().fold(inner_lf, LazyFrame::filter);
+        inner_lf.set_cached_arena(self.lp_arena, self.expr_arena);
+
+        let join_type = if anti { JoinType::Anti } else { JoinType::Semi };
+        lf.clone()
+            .join_builder()
+            .with(inner_lf)
+            .left_on(left_on)
+            .right_on(right_on)
+            .how(join_type)
+            .finish()
+    }
+
+    // Resolve the subquery's FROM (a single relation, possibly with joins) into
+    // the inner LazyFrame, its schema, and the set of relation names/aliases
+    // used to classify qualified correlation columns.
+    #[cfg(feature = "semi_anti_join")]
+    fn resolve_subquery_from(
+        &mut self,
+        tbl_expr: &TableWithJoins,
+    ) -> PolarsResult<Option<(PlHashSet<String>, LazyFrame, SchemaRef)>> {
+        let Some(inner_names) = std::iter::once(&tbl_expr.relation)
+            .chain(tbl_expr.joins.iter().map(|j| &j.relation))
+            .map(get_table_name)
+            .collect::<Option<PlHashSet<_>>>()
+        else {
+            return Ok(None);
+        };
+        let mut inner_lf = self.execute_from_statement(tbl_expr)?;
+        let inner_schema = self.get_frame_schema(&mut inner_lf)?;
+        Ok(Some((inner_names, inner_lf, inner_schema)))
+    }
+
+    // Split a subquery's WHERE conjuncts into a `SubqueryConjuncts`, or `None`
+    // when a conjunct is neither a correlation key pair nor an inner-only
+    // filter (an outer column in a non-equi shape, an unresolvable name).
+    #[cfg(feature = "semi_anti_join")]
+    fn split_subquery_conjuncts(
+        &mut self,
+        selection: &SQLExpr,
+        inner_names: &PlHashSet<String>,
+        inner_schema: &Schema,
+        outer_schema: &Schema,
+    ) -> PolarsResult<Option<SubqueryConjuncts>> {
+        let mut left_on = Vec::new();
+        let mut right_on = Vec::new();
+        let mut local_filters = Vec::new();
+        for conj in MintermIter::new(selection) {
+            if let Some((outer_key, inner_key)) =
+                correlation_key_pair(conj, inner_names, inner_schema, outer_schema)
+            {
+                left_on.push(col(outer_key));
+                right_on.push(col(inner_key));
+                continue;
+            }
+            let Some(filter) = self.try_parse_inner_only_expr(conj, inner_schema, outer_schema)?
+            else {
+                return Ok(None);
+            };
+            local_filters.push(filter);
+        }
+        Ok(Some(SubqueryConjuncts {
+            left_on,
+            right_on,
+            local_filters,
+        }))
+    }
+
+    // Parse a subquery expression as one over the inner relation only, or `None`
+    // if it references any outer column (a correlation shape we don't handle) or
+    // contains a nested subquery.
+    #[cfg(feature = "semi_anti_join")]
+    fn try_parse_inner_only_expr(
+        &mut self,
+        sql_expr: &SQLExpr,
+        inner_schema: &Schema,
+        outer_schema: &Schema,
+    ) -> PolarsResult<Option<Expr>> {
+        let expr = parse_sql_expr(sql_expr, self, Some(inner_schema))?;
+        // A nested subquery parses to `Expr::SubPlan`, which is only valid after
+        // `process_subqueries` lowering; it can't be used as a plain expression.
+        if has_expr(&expr, |e| matches!(e, Expr::SubPlan(_, _))) {
+            return Ok(None);
+        }
+        let only_inner = expr_to_leaf_column_names_iter(&expr).all(|name| {
+            inner_schema.contains(name.as_str()) && !outer_schema.contains(name.as_str())
+        });
+        Ok(only_inner.then_some(expr))
+    }
+
+    #[cfg(not(feature = "semi_anti_join"))]
+    fn try_rewrite_exists_as_join(
+        &mut self,
+        _lf: &LazyFrame,
+        _subquery: &Query,
+        _negated: bool,
+        _outer_schema: &Schema,
+    ) -> PolarsResult<Option<LazyFrame>> {
+        Ok(None)
+    }
+
+    #[cfg(not(feature = "semi_anti_join"))]
+    #[expect(clippy::too_many_arguments)]
+    fn try_rewrite_in_subquery_as_join(
+        &mut self,
+        _lf: &LazyFrame,
+        _lhs: &SQLExpr,
+        _subquery: &Query,
+        _anti: bool,
+        _filter_mode: FilterMode,
+        _outer_schema: &Schema,
+    ) -> PolarsResult<Option<LazyFrame>> {
+        Ok(None)
+    }
+}
+
+/// An iterator over all the minterms in an SQL boolean expression: the terms
+/// that `AND` together to form it, descending through parenthesized `Nested`
+/// expressions. The SQL-AST analogue of the `AExpr`-level
+/// `polars_plan::plans::aexpr::MintermIter`.
+struct MintermIter<'a> {
+    stack: Vec<&'a SQLExpr>,
+}
+
+impl<'a> Iterator for MintermIter<'a> {
+    type Item = &'a SQLExpr;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut top = self.stack.pop()?;
+        loop {
+            match top {
+                SQLExpr::Nested(inner) => top = inner,
+                SQLExpr::BinaryOp {
+                    left,
+                    op: SQLBinaryOperator::And,
+                    right,
+                } => {
+                    self.stack.push(right);
+                    top = left;
+                },
+                _ => return Some(top),
+            }
+        }
+    }
+}
+
+impl<'a> MintermIter<'a> {
+    fn new(root: &'a SQLExpr) -> Self {
+        Self { stack: vec![root] }
+    }
+}
+
+#[cfg(feature = "semi_anti_join")]
+enum CorrelationSide {
+    Inner,
+    Outer,
+}
+
+// A subquery WHERE split into equi-correlation join keys (outer side in
+// `left_on`, inner side in `right_on`) and filters over inner columns only.
+#[cfg(feature = "semi_anti_join")]
+#[derive(Default)]
+struct SubqueryConjuncts {
+    left_on: Vec<Expr>,
+    right_on: Vec<Expr>,
+    local_filters: Vec<Expr>,
+}
+
+// An equi-correlation conjunct `inner.col = outer.col` (either way round) as a
+// `(outer key, inner key)` column-name pair, or `None` when the conjunct is
+// anything else (non-equality, unresolvable names, both columns on the same
+// side).
+#[cfg(feature = "semi_anti_join")]
+fn correlation_key_pair(
+    conj: &SQLExpr,
+    inner_names: &PlHashSet<String>,
+    inner_schema: &Schema,
+    outer_schema: &Schema,
+) -> Option<(PlSmallStr, PlSmallStr)> {
+    let SQLExpr::BinaryOp {
+        left,
+        op: SQLBinaryOperator::Eq,
+        right,
+    } = conj
+    else {
+        return None;
+    };
+    let (lside, lname) =
+        classify_correlation_column(left, inner_names, inner_schema, outer_schema)?;
+    let (rside, rname) =
+        classify_correlation_column(right, inner_names, inner_schema, outer_schema)?;
+    match (lside, rside) {
+        (CorrelationSide::Outer, CorrelationSide::Inner) => Some((lname, rname)),
+        (CorrelationSide::Inner, CorrelationSide::Outer) => Some((rname, lname)),
+        _ => None,
+    }
+}
+
+// Classify a correlation operand as an inner- or outer-query column and return
+// its bare name. A qualified identifier (`tbl.col`) resolves by its qualifier:
+// an inner relation's name/alias means inner, anything else means outer (so
+// same-named columns like `o.id = c.id` resolve). An unqualified identifier
+// resolves by schema membership. `None` for non-identifiers or names that can't
+// be placed (in neither schema, or ambiguous).
+#[cfg(feature = "semi_anti_join")]
+fn classify_correlation_column(
+    expr: &SQLExpr,
+    inner_names: &PlHashSet<String>,
+    inner_schema: &Schema,
+    outer_schema: &Schema,
+) -> Option<(CorrelationSide, PlSmallStr)> {
+    let (qualifier, name): (Option<&str>, PlSmallStr) = match expr {
+        SQLExpr::Identifier(ident) => (None, ident.value.as_str().into()),
+        SQLExpr::CompoundIdentifier(parts) => {
+            let (last, init) = parts.split_last()?;
+            // Only the table part: catalog/schema prefixes are dropped, just
+            // as `get_table_name` drops them when building `inner_names`.
+            (
+                init.last().map(|q| q.value.as_str()),
+                last.value.as_str().into(),
+            )
+        },
+        _ => return None,
+    };
+    match qualifier {
+        Some(q) if inner_names.contains(q) => inner_schema
+            .contains(name.as_str())
+            .then_some((CorrelationSide::Inner, name)),
+        // Any other qualifier is taken as outer: the outer query may span
+        // several relations and their names/aliases aren't visible here, so
+        // only the column's schema membership can be checked.
+        Some(_) => outer_schema
+            .contains(name.as_str())
+            .then_some((CorrelationSide::Outer, name)),
+        None => match (
+            inner_schema.contains(name.as_str()),
+            outer_schema.contains(name.as_str()),
+        ) {
+            (true, false) => Some((CorrelationSide::Inner, name)),
+            (false, true) => Some((CorrelationSide::Outer, name)),
+            _ => None,
+        },
+    }
+}
+
+// Shared eligibility gate for the rewrites: bail on any clause that changes
+// which rows the subquery yields. Exhaustive destructuring (no `..`) is on
+// purpose: a new sqlparser clause must not compile until it gets an explicit
+// keep-or-bail decision here.
+#[cfg(feature = "semi_anti_join")]
+fn eligible_subquery_select(subquery: &Query) -> Option<&Select> {
+    let Query {
+        with, // CTEs aren't resolved inside the rewrite: bail
+        body,
+        order_by: _,      // row order can't affect existence/membership
+        limit_clause,     // LIMIT/OFFSET change the yielded rows: bail
+        fetch,            // FETCH FIRST is LIMIT spelled differently: bail
+        locks: _,         // row locking doesn't change the rows
+        for_clause,       // FOR XML/JSON reshape the result: bail
+        settings,         // ClickHouse SETTINGS can change results: bail
+        format_clause: _, // output serialization only
+        pipe_operators,   // `|>` operators transform the rows: bail
+    } = subquery;
+    if with.is_some()
+        || limit_clause.is_some()
+        || fetch.is_some()
+        || for_clause.is_some()
+        || settings.is_some()
+        || !pipe_operators.is_empty()
+    {
+        return None;
+    }
+    let SetExpr::Select(select) = body.as_ref() else {
+        return None;
+    };
+    let Select {
+        select_token: _,
+        // Deduplication is existence/membership-invariant; the IN rewrite
+        // separately bails on `DISTINCT ON`, which is not.
+        distinct: _,
+        top,                    // TOP is LIMIT spelled differently: bail
+        top_before_distinct: _, // only meaningful with `top`
+        // The projection is validated by the callers: EXISTS ignores it, IN
+        // requires a single plain expression (which also rules out wildcards
+        // and the `exclude` modifier).
+        projection: _,
+        exclude: _,
+        into,          // SELECT INTO is not a pure subquery: bail
+        from,          // must be one (possibly joined) relation
+        lateral_views, // row-multiplying: bail
+        prewhere,      // an extra filter we don't fold in: bail
+        selection: _,  // split into join keys/filters by callers
+        group_by,      // aggregation changes the yielded rows: bail
+        cluster_by: _, // layout/order hints: row-set preserving
+        distribute_by: _,
+        sort_by: _,
+        having,                   // aggregation filter: bail
+        named_window: _,          // definitions only; uses are parsed later
+        qualify,                  // post-window filter changes the rows: bail
+        window_before_qualify: _, // only meaningful with `qualify`
+        value_table_mode,         // changes what a row is: bail
+        connect_by,               // hierarchical recursion: bail
+        flavor: _,                // surface syntax only
+    } = select.as_ref();
+    let no_group_by = matches!(
+        group_by,
+        GroupByExpr::Expressions(e, m) if e.is_empty() && m.is_empty()
+    );
+    if from.len() != 1
+        || !no_group_by
+        || top.is_some()
+        || into.is_some()
+        || having.is_some()
+        || qualify.is_some()
+        || prewhere.is_some()
+        || connect_by.is_some()
+        || value_table_mode.is_some()
+        || !lateral_views.is_empty()
+    {
+        return None;
+    }
+    Some(select)
+}

--- a/py-polars/tests/unit/sql/test_subqueries.py
+++ b/py-polars/tests/unit/sql/test_subqueries.py
@@ -323,8 +323,8 @@ def _subquery_ctx() -> pl.SQLContext:
             "SEMI JOIN",
             [2, 3, 5],
         ),
-        # A subquery conjunct must rewrite even when ANDed with ordinary
-        # predicates (which must stay behind as a filter).
+        # A subquery conjunct must rewrite even when AND-combined with
+        # ordinary predicates (which must stay behind as a filter).
         (
             "SELECT c_custkey FROM customer WHERE c_custkey > 1 AND NOT EXISTS"
             " (SELECT 1 FROM orders WHERE o_custkey = c_custkey)",

--- a/py-polars/tests/unit/sql/test_subqueries.py
+++ b/py-polars/tests/unit/sql/test_subqueries.py
@@ -285,3 +285,155 @@ def test_derived_table_alias_errors() -> None:
             query="SELECT a FROM (SELECT a, b FROM df) ORDER BY sq.a",
             eager=True,
         )
+
+
+def _subquery_ctx() -> pl.SQLContext:
+    # One shared fixture for all subquery-to-join tests. The data placement is
+    # deliberate: NULL keys on both sides (the NULL-semantics rows) and the
+    # same-named composite columns a/b in both tables (the correlation-
+    # resolution rows) — several expectations depend on exactly this layout.
+    customer = pl.LazyFrame(
+        {
+            "c_custkey": [1, 2, 3, 4, 5, None],
+            "c_acctbal": [10, 20, 30, 40, 50, 60],
+            "a": [1, 1, 2, 1, 2, 2],
+            "b": [10, 20, 10, 20, 20, 30],
+        }
+    )
+    orders = pl.LazyFrame(
+        {
+            "o_custkey": [2, 3, 5, None],
+            "o_amt": [20, 99, 99, 99],
+            "a": [1, 2, 2, 9],
+            "b": [20, 20, 30, 9],
+        }
+    )
+    lineitem = pl.LazyFrame({"l_okey": [2, 5]})
+    return pl.SQLContext(customer=customer, orders=orders, lineitem=lineitem)
+
+
+@pytest.mark.parametrize(
+    ("query", "expect_join", "expected"),
+    [
+        # Positive EXISTS must map to a semi join (every other EXISTS row
+        # below is anti).
+        (
+            "SELECT c_custkey FROM customer WHERE EXISTS"
+            " (SELECT 1 FROM orders WHERE o_custkey = c_custkey)",
+            "SEMI JOIN",
+            [2, 3, 5],
+        ),
+        # A subquery conjunct must rewrite even when ANDed with ordinary
+        # predicates (which must stay behind as a filter).
+        (
+            "SELECT c_custkey FROM customer WHERE c_custkey > 1 AND NOT EXISTS"
+            " (SELECT 1 FROM orders WHERE o_custkey = c_custkey)",
+            "ANTI JOIN",
+            [4],
+        ),
+        # DISTINCT must not prevent the rewrite (only DISTINCT ON bails).
+        (
+            "SELECT c_custkey FROM customer"
+            " WHERE c_custkey IN (SELECT DISTINCT o_custkey FROM orders)",
+            "SEMI JOIN",
+            [2, 3, 5],
+        ),
+        # Inner-only predicates must filter the inner relation before the join.
+        (
+            "SELECT c_custkey FROM customer WHERE NOT EXISTS"
+            " (SELECT 1 FROM orders WHERE o_custkey = c_custkey AND o_amt = 99)",
+            "ANTI JOIN",
+            [1, 2, 4, None],
+        ),
+        # A correlated IN must join on both the membership key and the
+        # correlation key.
+        (
+            "SELECT c_custkey FROM customer WHERE c_acctbal IN"
+            " (SELECT o_amt FROM orders WHERE o_custkey = c_custkey)",
+            "SEMI JOIN",
+            [2],
+        ),
+        (
+            "SELECT c_custkey FROM customer WHERE NOT EXISTS (SELECT 1 FROM"
+            " orders JOIN lineitem ON o_custkey = l_okey WHERE o_custkey = c_custkey)",
+            "ANTI JOIN",
+            [1, 3, 4, None],
+        ),
+        # Same-named correlation columns must resolve via the qualifier
+        # (schema membership alone is ambiguous), and composite correlation
+        # must join on all key pairs, not just the first.
+        (
+            "SELECT a, b FROM customer c"
+            " WHERE NOT EXISTS (SELECT 1 FROM orders o WHERE o.a = c.a AND o.b = c.b)",
+            "ANTI JOIN",
+            [(1, 10), (2, 10)],
+        ),
+        # NOT IN must drop a NULL key (its membership test is NULL, not true;
+        # the bare anti-join would keep it), while a NULL in the haystack must
+        # not poison the other rows (polars' is_in semantics, not strict SQL).
+        (
+            "SELECT c_custkey FROM customer"
+            " WHERE c_custkey NOT IN (SELECT o_custkey FROM orders)",
+            "ANTI JOIN",
+            [1, 4],
+        ),
+        # NOT EXISTS, by contrast, must keep a NULL outer key — even with a
+        # NULL in the haystack (NULL = NULL must not count as a match).
+        (
+            "SELECT c_custkey FROM customer"
+            " WHERE NOT EXISTS (SELECT 1 FROM orders WHERE o_custkey = c_custkey)",
+            "ANTI JOIN",
+            [1, 4, None],
+        ),
+        # DELETE must keep rows whose predicate is NULL (it drops only the
+        # predicate-true rows; DELETE yields whole rows).
+        (
+            "DELETE FROM customer WHERE c_custkey IN (SELECT o_custkey FROM orders)",
+            "ANTI JOIN",
+            [(1, 10, 1, 10), (4, 40, 1, 20), (None, 60, 2, 30)],
+        ),
+        (
+            "DELETE FROM customer"
+            " WHERE EXISTS (SELECT 1 FROM orders WHERE o_custkey = c_custkey)",
+            "ANTI JOIN",
+            [(1, 10, 1, 10), (4, 40, 1, 20), (None, 60, 2, 30)],
+        ),
+    ],
+)
+def test_sql_subquery_to_join(
+    query: str,
+    expect_join: str,
+    expected: list[int | None | tuple[int | None, ...]],
+) -> None:
+    lf = _subquery_ctx().execute(query)
+
+    plan = lf.explain(optimized=True)
+    assert expect_join in plan, plan
+    assert "implode" not in plan.lower(), plan
+
+    result = lf.collect()
+    expected_rows = [t if isinstance(t, tuple) else (t,) for t in expected]
+    expected_df = pl.DataFrame(expected_rows, schema=result.schema, orient="row")
+    assert_frame_equal(result, expected_df, check_row_order=False)
+
+
+@pytest.mark.parametrize(
+    "subquery",
+    [
+        # A nested subquery must not rewrite (its SubPlan node is only valid
+        # after subquery lowering, not inside a plain filter expression).
+        "SELECT 1 FROM orders WHERE o_custkey = c_custkey"
+        " AND o_custkey IN (SELECT l_okey FROM lineitem)",
+        # Clauses that change which rows the subquery yields must make the
+        # rewrite bail, never be silently ignored. Each clause here empties
+        # the subquery, so a rewrite that ignored it would get every row's
+        # NOT EXISTS wrong.
+        "SELECT 1 FROM orders WHERE o_custkey = c_custkey LIMIT 0",
+        "SELECT TOP 0 1 FROM orders WHERE o_custkey = c_custkey",
+        "SELECT 1 FROM orders WHERE o_custkey = c_custkey QUALIFY FALSE",
+    ],
+)
+def test_sql_subquery_not_rewritten(subquery: str) -> None:
+    sql = f"SELECT c_custkey FROM customer WHERE NOT EXISTS ({subquery})"
+    with pytest.raises(SQLInterfaceError, match="not currently supported"):
+        _subquery_ctx().execute(sql, eager=True)

--- a/py-polars/tests/unit/sql/test_subqueries.py
+++ b/py-polars/tests/unit/sql/test_subqueries.py
@@ -287,7 +287,7 @@ def test_derived_table_alias_errors() -> None:
         )
 
 
-def _subquery_ctx() -> pl.SQLContext:
+def _subquery_ctx() -> pl.SQLContext[pl.LazyFrame]:
     # One shared fixture for all subquery-to-join tests. The data placement is
     # deliberate: NULL keys on both sides (the NULL-semantics rows) and the
     # same-named composite columns a/b in both tables (the correlation-


### PR DESCRIPTION
Follow-up to #27725. The OOM reported there was mitigated at the execution level (#27758, #27782), but the plan shape remained: `NOT IN (subquery)` implodes the subquery column into a single `List`, broadcasts it, and evaluates `is_in().not()` per row, with memory scaling with subquery cardinality, plus unnecessary unique/sort work on the imploded side. This PR lowers it to a hash anti-join instead, bounding memory by the join's hash table, including for the issue's verbatim Q22 (subquery over a CTE).

`[NOT] EXISTS` and `[NOT] IN (subquery)` WHERE conjuncts are now lowered to semi/anti joins. For `NOT IN` this replaces the implode plan; `EXISTS`/`NOT EXISTS` and correlated subqueries were not supported at all before (they raised "not currently supported"), so the canonical `NOT EXISTS` form of Q22 now runs as well.

Q22 shape on local parquet, SF=10, streaming, median of 3:

| | Wall | Peak RSS |
|---|---|---|
| `NOT IN` 1.41.1 (implode/broadcast) | 90.7 ms | 610 MB |
| `NOT IN` now (anti join + null filter) | 45.9 ms (2.0×) | 434 MB |
| `NOT EXISTS` now (anti join) | 41.7 ms (2.2×) | 404 MB |

This rewrite lives at the SQL layer. As future work the same optimization can be done at the IR level (e.g. `is_in(imploded)` filters and left-join + `is_null` patterns rewritten to semi/anti joins), which would benefit the DataFrame API too.