### PR TITLE
feat: Support SQL's implicit `JOIN` syntax

### DIFF
--- a/crates/polars-sql/Cargo.toml
+++ b/crates/polars-sql/Cargo.toml
@@ -13,7 +13,7 @@ polars-core = { workspace = true, features = ["rows"] }
 polars-error = { workspace = true }
 polars-lazy = { workspace = true, features = ["abs", "binary_encoding", "concat_str", "cov", "cross_join", "cum_agg", "dtype-array", "dtype-date", "dtype-decimal", "dtype-struct", "is_in", "list_eval", "log", "meta", "offset_by", "range", "regex", "round_series", "sign", "string_normalize", "string_pad", "string_reverse", "strings", "timezones", "trigonometry"] }
 polars-ops = { workspace = true }
-polars-plan = { workspace = true }
+polars-plan = { workspace = true, features = ["iejoin"] }
 polars-time = { workspace = true }
 polars-utils = { workspace = true }
 

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -1110,18 +1110,18 @@ impl SQLContext {
         self.register_named_windows(&select_stmt.named_window)?;
 
         // Get `FROM` table/data
+        let mut implicit_join_filter: Option<SQLExpr> = None;
         let (mut lf, base_table_name) = if select_stmt.from.is_empty() {
             (DataFrame::empty().lazy(), None)
         } else {
-            // Note: implicit joins need more work to support properly,
-            // explicit joins are preferred for now (ref: #16662)
-            let from = select_stmt.clone().from;
+            let from = &select_stmt.from;
+            let first = from.first().unwrap();
+            let mut lf = self.execute_from_statement(first)?;
+            let base_name = get_table_name(&first.relation);
             if from.len() > 1 {
-                polars_bail!(SQLInterface: "multiple tables in FROM clause are not currently supported (found {}); use explicit JOIN syntax instead", from.len())
+                implicit_join_filter =
+                    self.process_implicit_joins(&mut lf, from, &select_stmt.selection)?;
             }
-            let tbl_expr = from.first().unwrap();
-            let lf = self.execute_from_statement(tbl_expr)?;
-            let base_name = get_table_name(&tbl_expr.relation);
             (lf, base_name)
         };
 
@@ -1156,11 +1156,16 @@ impl SQLContext {
             }
         }
 
-        // Apply `WHERE` constraint
+        // Apply `WHERE` constraint (using residual filter for implicit joins)
+        let effective_where = if implicit_join_filter.is_some() {
+            &implicit_join_filter
+        } else {
+            &select_stmt.selection
+        };
         let mut schema = self.get_frame_schema(&mut lf)?;
         lf = self.process_where(
             lf,
-            &select_stmt.selection,
+            effective_where,
             FilterMode::KeepTrue,
             Some(schema.clone()),
         )?;
@@ -1636,25 +1641,134 @@ impl SQLContext {
         constraint: &JoinConstraint,
         join_type: JoinType,
     ) -> PolarsResult<LazyFrame> {
-        let (left_on, right_on) = process_join_constraint(constraint, tbl_left, tbl_right, self)?;
+        let (left_on, right_on, predicates) =
+            process_join_constraint(constraint, tbl_left, tbl_right, self)?;
         let coalesce_type = match constraint {
             // "NATURAL" joins should coalesce; otherwise we disambiguate
             JoinConstraint::Natural => JoinCoalesce::CoalesceColumns,
             _ => JoinCoalesce::KeepColumns,
         };
-        let joined = tbl_left
-            .frame
-            .clone()
-            .join_builder()
-            .with(tbl_right.frame.clone())
-            .left_on(left_on)
-            .right_on(right_on)
-            .how(join_type)
-            .suffix(format!(":{}", tbl_right.name))
-            .coalesce(coalesce_type)
-            .finish();
+        let suffix = format!(":{}", tbl_right.name);
+
+        let joined = if predicates.is_empty() {
+            // Equi-join: standard left_on/right_on path
+            tbl_left
+                .frame
+                .clone()
+                .join_builder()
+                .with(tbl_right.frame.clone())
+                .left_on(left_on)
+                .right_on(right_on)
+                .how(join_type)
+                .suffix(suffix)
+                .coalesce(coalesce_type)
+                .finish()
+        } else {
+            // Non-equi conditions: convert to predicates for `join_where`.
+            // Any equi-conditions become equality predicates with right-side
+            // columns suffixed to match their merged-schema names.
+            let mut all_predicates = predicates;
+            for (l, r) in left_on.into_iter().zip(right_on) {
+                let r_suffixed = suffix_conflicting_columns(r, tbl_left, tbl_right, &suffix);
+                all_predicates.push(l.eq(r_suffixed));
+            }
+            tbl_left
+                .frame
+                .clone()
+                .join_builder()
+                .with(tbl_right.frame.clone())
+                .how(join_type)
+                .suffix(suffix)
+                .coalesce(coalesce_type)
+                .join_where(all_predicates)
+        };
 
         Ok(joined)
+    }
+
+    /// Process implicit (comma-separated) joins from `FROM t1, t2, ...` syntax.
+    ///
+    /// Extracts join predicates from the WHERE clause, joining each additional table with
+    /// either an INNER JOIN (cross-table predicates found) or a CROSS JOIN (no predicates)
+    /// Returns the residual WHERE conditions not consumed as join predicates.
+    fn process_implicit_joins(
+        &mut self,
+        lf: &mut LazyFrame,
+        from: &[TableWithJoins],
+        where_clause: &Option<SQLExpr>,
+    ) -> PolarsResult<Option<SQLExpr>> {
+        let first = from.first().unwrap();
+        let base_name = get_table_name(&first.relation).unwrap_or_default();
+        let mut remaining_where = where_clause.clone();
+        let mut joined_table_names: Vec<String> = vec![base_name];
+
+        // Track table names from explicit joins in the first FROM entry
+        for join in &first.joins {
+            if let Some(name) = get_table_name(&join.relation) {
+                joined_table_names.push(name);
+            }
+        }
+        for tbl_expr in from.iter().skip(1) {
+            let mut rf = self.execute_from_statement(tbl_expr)?;
+            let r_name = get_table_name(&tbl_expr.relation).unwrap_or_default();
+            polars_ensure!(
+                !r_name.is_empty(),
+                SQLInterface: "implicit joins require named tables; please provide an alias"
+            );
+            let left_schema = self.get_frame_schema(lf)?;
+            let right_schema = self.get_frame_schema(&mut rf)?;
+            let (join_expr, residual) =
+                extract_join_predicates(&remaining_where, &joined_table_names, &r_name);
+
+            *lf = if let Some(on_expr) = join_expr {
+                self.process_join(
+                    &TableInfo {
+                        frame: lf.clone(),
+                        name: PlSmallStr::from_str(
+                            &joined_table_names.first().cloned().unwrap_or_default(),
+                        ),
+                        schema: left_schema.clone(),
+                    },
+                    &TableInfo {
+                        frame: rf,
+                        name: PlSmallStr::from_str(&r_name),
+                        schema: right_schema.clone(),
+                    },
+                    &JoinConstraint::On(on_expr),
+                    JoinType::Inner,
+                )?
+            } else {
+                lf.clone()
+                    .cross_join(rf, Some(format_pl_smallstr!(":{}", r_name)))
+            };
+            remaining_where = residual;
+
+            // Track join-aliased columns for later resolution
+            let joined_schema = self.get_frame_schema(lf)?;
+            self.joined_aliases.insert(
+                r_name.clone(),
+                right_schema
+                    .iter_names()
+                    .filter_map(|name| {
+                        let aliased_name = format!("{name}:{r_name}");
+                        if left_schema.contains(name)
+                            && joined_schema.contains(aliased_name.as_str())
+                        {
+                            Some((name.to_string(), aliased_name))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<PlHashMap<String, String>>(),
+            );
+            joined_table_names.push(r_name);
+            for join in &tbl_expr.joins {
+                if let Some(name) = get_table_name(&join.relation) {
+                    joined_table_names.push(name);
+                }
+            }
+        }
+        Ok(remaining_where)
     }
 
     fn process_qualify(
@@ -1835,8 +1949,11 @@ impl SQLContext {
                 alias,
             } => {
                 polars_ensure!(!(*lateral), SQLInterface: "LATERAL not supported");
+                // Execute the subquery in isolation so that outer join state
+                // doesn't leak into it and cause spurious ambiguous-column errors
                 if let Some(alias) = alias {
-                    let mut lf = self.execute_query_no_ctes(subquery)?;
+                    let mut lf =
+                        self.execute_isolated(|ctx| ctx.execute_query_no_ctes(subquery))?;
                     lf = self.rename_columns_from_table_alias(lf, alias)?;
                     self.table_map
                         .write()
@@ -1844,7 +1961,7 @@ impl SQLContext {
                         .insert(alias.name.value.clone(), lf.clone());
                     Ok((alias.name.value.clone(), lf))
                 } else {
-                    let lf = self.execute_query_no_ctes(subquery)?;
+                    let lf = self.execute_isolated(|ctx| ctx.execute_query_no_ctes(subquery))?;
                     Ok(("".to_string(), lf))
                 }
             },
@@ -1917,7 +2034,8 @@ impl SQLContext {
                 table_with_joins,
                 alias,
             } => {
-                let lf = self.execute_from_statement(table_with_joins)?;
+                let lf =
+                    self.execute_isolated(|ctx| ctx.execute_from_statement(table_with_joins))?;
                 match alias {
                     Some(a) => Ok((a.name.value.clone(), lf)),
                     None => Ok(("".to_string(), lf)),
@@ -2670,49 +2788,159 @@ fn determine_left_right_join_on(
     }
 }
 
+/// Returns `(left_on, right_on, join_where_predicates)`.
+///
+/// - Equi-conditions (`=`) are returned as paired `left_on`/`right_on` entries.
+/// - Non-equi conditions (`<`, `<=`, `>`, `>=`, `!=`) are returned as `join_where` predicates
+///   that reference columns using their merged-schema names (right columns that conflict with the
+///   left schema are suffixed).
 fn process_join_on(
     ctx: &mut SQLContext,
     sql_expr: &SQLExpr,
     tbl_left: &TableInfo,
     tbl_right: &TableInfo,
-) -> PolarsResult<(Vec<Expr>, Vec<Expr>)> {
+) -> PolarsResult<(Vec<Expr>, Vec<Expr>, Vec<Expr>)> {
     match sql_expr {
         SQLExpr::BinaryOp { left, op, right } => match op {
             SQLBinaryOperator::And => {
-                let (mut left_i, mut right_i) = process_join_on(ctx, left, tbl_left, tbl_right)?;
-                let (mut left_j, mut right_j) = process_join_on(ctx, right, tbl_left, tbl_right)?;
+                let (mut left_i, mut right_i, mut preds_i) =
+                    process_join_on(ctx, left, tbl_left, tbl_right)?;
+                let (mut left_j, mut right_j, mut preds_j) =
+                    process_join_on(ctx, right, tbl_left, tbl_right)?;
                 left_i.append(&mut left_j);
                 right_i.append(&mut right_j);
-                Ok((left_i, right_i))
+                preds_i.append(&mut preds_j);
+                Ok((left_i, right_i, preds_i))
             },
             SQLBinaryOperator::Eq => {
-                // establish unified schema with cols from both tables; needed for multi/chained
-                // joins where suffixed intermediary/joined cols aren't in an existing schema.
-                let mut join_schema =
-                    Schema::with_capacity(tbl_left.schema.len() + tbl_right.schema.len());
-                for (name, dtype) in tbl_left.schema.iter() {
-                    join_schema.insert_at_index(join_schema.len(), name.clone(), dtype.clone())?;
-                }
-                for (name, dtype) in tbl_right.schema.iter() {
-                    if !join_schema.contains(name) {
-                        join_schema.insert_at_index(
-                            join_schema.len(),
-                            name.clone(),
-                            dtype.clone(),
-                        )?;
-                    }
-                }
-                determine_left_right_join_on(ctx, left, right, tbl_left, tbl_right, &join_schema)
+                let join_schema = build_join_schema(tbl_left, tbl_right)?;
+                let (l, r) = determine_left_right_join_on(
+                    ctx,
+                    left,
+                    right,
+                    tbl_left,
+                    tbl_right,
+                    &join_schema,
+                )?;
+                Ok((l, r, vec![]))
+            },
+            SQLBinaryOperator::Lt
+            | SQLBinaryOperator::LtEq
+            | SQLBinaryOperator::Gt
+            | SQLBinaryOperator::GtEq
+            | SQLBinaryOperator::NotEq => {
+                let join_schema = build_join_schema(tbl_left, tbl_right)?;
+                let suffix = format!(":{}", tbl_right.name);
+
+                // Parse both operands and suffix each independently based on whether
+                // it references the right table (preserving SQL operand order).
+                let lhs = suffix_if_right_table(
+                    parse_sql_expr(left, ctx, Some(&join_schema))?,
+                    left,
+                    tbl_left,
+                    tbl_right,
+                    &suffix,
+                );
+                let rhs = suffix_if_right_table(
+                    parse_sql_expr(right, ctx, Some(&join_schema))?,
+                    right,
+                    tbl_left,
+                    tbl_right,
+                    &suffix,
+                );
+
+                let polars_op = match op {
+                    SQLBinaryOperator::Lt => Operator::Lt,
+                    SQLBinaryOperator::LtEq => Operator::LtEq,
+                    SQLBinaryOperator::Gt => Operator::Gt,
+                    SQLBinaryOperator::GtEq => Operator::GtEq,
+                    SQLBinaryOperator::NotEq => Operator::NotEq,
+                    _ => unreachable!(),
+                };
+                let predicate = Expr::BinaryExpr {
+                    left: Arc::new(lhs),
+                    op: polars_op,
+                    right: Arc::new(rhs),
+                };
+                Ok((vec![], vec![], vec![predicate]))
             },
             _ => polars_bail!(
-                // TODO: should be able to support more operators later (via `join_where`?)
-                SQLInterface: "only equi-join constraints (combined with 'AND') are currently supported; found op = '{:?}'", op
+                SQLInterface: "unsupported join constraint operator '{:?}'", op
             ),
         },
         SQLExpr::Nested(expr) => process_join_on(ctx, expr, tbl_left, tbl_right),
         _ => polars_bail!(
-            SQLInterface: "only equi-join constraints are currently supported; found expression = {:?}", sql_expr
+            SQLInterface: "unsupported join constraint expression: {:?}", sql_expr
         ),
+    }
+}
+
+/// Build a unified schema from both tables; needed for multi/chained joins where suffixed
+/// intermediary/joined cols aren't in an existing schema.
+fn build_join_schema(tbl_left: &TableInfo, tbl_right: &TableInfo) -> PolarsResult<Schema> {
+    let mut join_schema = Schema::with_capacity(tbl_left.schema.len() + tbl_right.schema.len());
+    for (name, dtype) in tbl_left.schema.iter() {
+        join_schema.insert_at_index(join_schema.len(), name.clone(), dtype.clone())?;
+    }
+    for (name, dtype) in tbl_right.schema.iter() {
+        if !join_schema.contains(name) {
+            join_schema.insert_at_index(join_schema.len(), name.clone(), dtype.clone())?;
+        }
+    }
+    Ok(join_schema)
+}
+
+/// Rename columns in `expr` that appear in *both* table schemas to their merged-schema
+/// (right-side suffixed) names, so they resolve against the joined frame.
+fn suffix_conflicting_columns(
+    expr: Expr,
+    tbl_left: &TableInfo,
+    tbl_right: &TableInfo,
+    suffix: &str,
+) -> Expr {
+    expr.map_expr(|e| match e {
+        Expr::Column(ref name)
+            if tbl_left.schema.contains(name.as_str())
+                && tbl_right.schema.contains(name.as_str()) =>
+        {
+            Expr::Column(PlSmallStr::from_string(format!("{name}{suffix}")))
+        },
+        other => other,
+    })
+}
+
+/// Suffix conflicting column names in `expr` if the SQL-level expression references the right
+/// table. Uses table qualifiers first, falling back to schema membership when unqualified.
+fn suffix_if_right_table(
+    expr: Expr,
+    sql_expr: &SQLExpr,
+    tbl_left: &TableInfo,
+    tbl_right: &TableInfo,
+    suffix: &str,
+) -> Expr {
+    // Strip any alias added by resolve_column
+    let expr = match expr {
+        Expr::Alias(inner, _) => Arc::unwrap_or_clone(inner),
+        e => e,
+    };
+
+    let refs_left = expr_refers_to_table(sql_expr, &tbl_left.name);
+    let refs_right = expr_refers_to_table(sql_expr, &tbl_right.name);
+
+    let is_right = if refs_right && !refs_left {
+        true
+    } else if refs_left {
+        false
+    } else {
+        // Unqualified: check schema membership
+        !expr_cols_all_in_schema(&expr, &tbl_left.schema)
+            && expr_cols_all_in_schema(&expr, &tbl_right.schema)
+    };
+
+    if is_right {
+        suffix_conflicting_columns(expr, tbl_left, tbl_right, suffix)
+    } else {
+        expr
     }
 }
 
@@ -2721,7 +2949,7 @@ fn process_join_constraint(
     tbl_left: &TableInfo,
     tbl_right: &TableInfo,
     ctx: &mut SQLContext,
-) -> PolarsResult<(Vec<Expr>, Vec<Expr>)> {
+) -> PolarsResult<(Vec<Expr>, Vec<Expr>, Vec<Expr>)> {
     match constraint {
         JoinConstraint::On(expr @ SQLExpr::BinaryOp { .. }) => {
             process_join_on(ctx, expr, tbl_left, tbl_right)
@@ -2739,7 +2967,7 @@ fn process_join_constraint(
                     }
                 })
                 .collect::<PolarsResult<Vec<_>>>()?;
-            Ok((using.clone(), using))
+            Ok((using.clone(), using, vec![]))
         },
         JoinConstraint::Natural => {
             let left_names = tbl_left.schema.iter_names().collect::<PlHashSet<_>>();
@@ -2751,10 +2979,96 @@ fn process_join_constraint(
             if on.is_empty() {
                 polars_bail!(SQLInterface: "no common columns found for NATURAL JOIN")
             }
-            Ok((on.clone(), on))
+            Ok((on.clone(), on, vec![]))
         },
         _ => polars_bail!(SQLInterface: "unsupported SQL join constraint:\n{:?}", constraint),
     }
+}
+
+/// Flatten a SQL AND-expression tree into individual leaf conditions.
+fn flatten_and_conditions(expr: &SQLExpr) -> Vec<&SQLExpr> {
+    match expr {
+        SQLExpr::BinaryOp {
+            left,
+            op: SQLBinaryOperator::And,
+            right,
+        } => {
+            let mut conditions = flatten_and_conditions(left);
+            conditions.extend(flatten_and_conditions(right));
+            conditions
+        },
+        SQLExpr::Nested(inner) => flatten_and_conditions(inner),
+        _ => vec![expr],
+    }
+}
+
+/// Reconstruct a SQL AND-expression tree from a list of conditions.
+fn combine_and_conditions(conditions: Vec<SQLExpr>) -> Option<SQLExpr> {
+    conditions
+        .into_iter()
+        .reduce(|left, right| SQLExpr::BinaryOp {
+            left: Box::new(left),
+            op: SQLBinaryOperator::And,
+            right: Box::new(right),
+        })
+}
+
+/// Check if a SQL expression is a join condition (equi or non-equi comparison) that bridges
+/// the given left table set and the right table (both sides must be qualified).
+fn is_join_comparison(expr: &SQLExpr, left_tables: &[String], right_table: &str) -> bool {
+    if let SQLExpr::BinaryOp {
+        left,
+        op:
+            SQLBinaryOperator::Eq
+            | SQLBinaryOperator::Lt
+            | SQLBinaryOperator::LtEq
+            | SQLBinaryOperator::Gt
+            | SQLBinaryOperator::GtEq
+            | SQLBinaryOperator::NotEq,
+        right,
+    } = expr
+    {
+        let left_refs_right = expr_refers_to_table(left, right_table);
+        let right_refs_right = expr_refers_to_table(right, right_table);
+
+        let left_refs_any_left = left_tables
+            .iter()
+            .any(|t| expr_refers_to_table(left, t.as_str()));
+        let right_refs_any_left = left_tables
+            .iter()
+            .any(|t| expr_refers_to_table(right, t.as_str()));
+
+        // One side references a left table, the other references the right table
+        (left_refs_right && right_refs_any_left) || (right_refs_right && left_refs_any_left)
+    } else {
+        false
+    }
+}
+
+/// Partition a WHERE clause into join predicates (bridging left tables and the
+/// right table) and residual filter conditions.
+fn extract_join_predicates(
+    where_expr: &Option<SQLExpr>,
+    left_tables: &[String],
+    right_table: &str,
+) -> (Option<SQLExpr>, Option<SQLExpr>) {
+    let Some(expr) = where_expr else {
+        return (None, None);
+    };
+    let conditions = flatten_and_conditions(expr);
+    let mut join_conds = Vec::new();
+    let mut filter_conds = Vec::new();
+    for cond in conditions {
+        if is_join_comparison(cond, left_tables, right_table) {
+            join_conds.push(cond.clone());
+        } else {
+            filter_conds.push(cond.clone());
+        }
+    }
+    (
+        combine_and_conditions(join_conds),
+        combine_and_conditions(filter_conds),
+    )
 }
 
 /// Extract table identifiers referenced in a SQL query; uses a visitor to

--- a/crates/polars-sql/tests/statements.rs
+++ b/crates/polars-sql/tests/statements.rs
@@ -593,3 +593,64 @@ fn test_compound_invalid_2() {
     let sql = "SELECT * FROM df1 INNER JOIN df2 ON df1.a = df2.a AND b";
     let _ = ctx.execute(sql).unwrap();
 }
+
+#[test]
+fn test_implicit_join_basic() {
+    let mut ctx = prepare_compound_join_context();
+
+    // Implicit join: equivalent to INNER JOIN df2 ON df1.a = df2.a AND df1.b = df2.b
+    let implicit_sql = r#"
+        SELECT * FROM df1, df2
+        WHERE df1.a = df2.a AND df1.b = df2.b
+    "#;
+    let explicit_sql = r#"
+        SELECT * FROM df1
+        INNER JOIN df2 ON df1.a = df2.a AND df1.b = df2.b
+    "#;
+
+    let actual = ctx.execute(implicit_sql).unwrap().collect().unwrap();
+    let expected = ctx.execute(explicit_sql).unwrap().collect().unwrap();
+
+    assert!(
+        actual.equals(&expected),
+        "implicit join should match explicit join\nimplicit={actual:?}\nexplicit={expected:?}"
+    );
+}
+
+#[test]
+fn test_join_non_equi_range() {
+    // Range join (two inequalities resolved via `join_where`): amount in [lo, hi]
+    let orders = df! {
+        "id" => [1, 2, 3, 4, 5],
+        "amount" => [50, 100, 200, 150, 300],
+    }
+    .unwrap();
+    let ranges = df! {
+        "label" => ["low", "mid", "high"],
+        "lo" => [0, 100, 200],
+        "hi" => [99, 199, 500],
+    }
+    .unwrap();
+    let mut ctx = SQLContext::new();
+    ctx.register("orders", orders.lazy());
+    ctx.register("ranges", ranges.lazy());
+
+    let sql = r#"
+        SELECT orders.id, orders.amount, ranges.label
+        FROM orders
+        INNER JOIN ranges ON orders.amount >= ranges.lo AND orders.amount <= ranges.hi
+        ORDER BY orders.id
+    "#;
+    let actual = ctx.execute(sql).unwrap().collect().unwrap();
+    let expected = df! {
+        "id" => [1, 2, 3, 4, 5],
+        "amount" => [50, 100, 200, 150, 300],
+        "label" => ["low", "mid", "high", "mid", "high"],
+    }
+    .unwrap();
+
+    assert!(
+        actual.equals(&expected),
+        "expected = {expected:?}\nactual={actual:?}"
+    );
+}

--- a/py-polars/docs/source/reference/sql/clauses.rst
+++ b/py-polars/docs/source/reference/sql/clauses.rst
@@ -156,6 +156,7 @@ also be used as the leading clause in a query, supporting the following variatio
 
 * ``FROM tbl`` - equivalent to ``SELECT * FROM tbl``.
 * ``FROM tbl SELECT ...`` - a reordered ``SELECT`` with explicit projections.
+* ``FROM tbl1, tbl2 ...`` - multiple comma-separated tables; see the :ref:`JOIN <join>` clause for implicit join syntax.
 
 **Example:**
 
@@ -263,6 +264,62 @@ Combines rows from two or more tables based on a related column.
     # │ 1   ┆ x     ┆ a   │
     # │ 2   ┆ y     ┆ b   │
     # └─────┴───────┴─────┘
+
+**Implicit (comma) joins**
+
+Tables can also be combined using the older comma-separated ``FROM`` syntax, with the
+join conditions given in the ``WHERE`` clause. Cross-table equality predicates are lifted
+into the join keys (resulting in an ``INNER`` join), while any remaining predicates are
+applied as filters. If no predicate bridges two tables they are combined as a ``CROSS JOIN``.
+
+.. code-block:: python
+
+    pl.sql("""
+      SELECT foo, apple, df1.ham
+      FROM df1, df2
+      WHERE df1.ham = df2.ham
+    """).collect()
+    # shape: (2, 3)
+    # ┌─────┬───────┬─────┐
+    # │ foo ┆ apple ┆ ham │
+    # │ --- ┆ ---   ┆ --- │
+    # │ i64 ┆ str   ┆ str │
+    # ╞═════╪═══════╪═════╡
+    # │ 1   ┆ x     ┆ a   │
+    # │ 2   ┆ y     ┆ b   │
+    # └─────┴───────┴─────┘
+
+.. note::
+
+   For an implicit join, the comparison columns should be qualified with their table name
+   or alias on both sides (eg: ``WHERE df1.ham = df2.ham``). Unqualified comparisons are
+   treated as ordinary filters rather than join keys.
+
+**Non-equi join conditions**
+
+Join conditions are not restricted to equality; the ``<``, ``<=``, ``>``, ``>=``, and ``!=``
+operators are also supported (in both explicit ``ON`` clauses and implicit joins), and can
+be freely combined with equi-conditions using ``AND``.
+
+.. code-block:: python
+
+    df3 = pl.DataFrame({"value": [5, 25, 45]})
+    df4 = pl.DataFrame({"lo": [0, 20], "hi": [20, 50]})
+    pl.sql("""
+      SELECT value, lo, hi
+      FROM df3 INNER JOIN df4
+      ON df3.value >= df4.lo AND df3.value < df4.hi
+    """).collect()
+    # shape: (3, 3)
+    # ┌───────┬─────┬─────┐
+    # │ value ┆ lo  ┆ hi  │
+    # │ ---   ┆ --- ┆ --- │
+    # │ i64   ┆ i64 ┆ i64 │
+    # ╞═══════╪═════╪═════╡
+    # │ 5     ┆ 0   ┆ 20  │
+    # │ 25    ┆ 20  ┆ 50  │
+    # │ 45    ┆ 20  ┆ 50  │
+    # └───────┴─────┴─────┘
 
 .. _where:
 

--- a/py-polars/tests/unit/sql/asserts.py
+++ b/py-polars/tests/unit/sql/asserts.py
@@ -11,7 +11,7 @@ from polars.datatypes.group import FLOAT_DTYPES, INTEGER_DTYPES
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
-    from collections.abc import Collection, Sequence
+    from collections.abc import Collection, Mapping, Sequence
 
     from polars.type_aliases import PolarsDataType
 
@@ -25,7 +25,7 @@ _POLARS_TO_SQLITE_: dict[PolarsDataType, str] = {
 
 
 def _execute_with_sqlite(
-    frames: dict[str, pl.DataFrame | pl.LazyFrame],
+    frames: Mapping[str, pl.DataFrame | pl.LazyFrame],
     query: str,
 ) -> pl.DataFrame:
     """Execute a SQL query against SQLite, returning a DataFrame."""
@@ -57,7 +57,7 @@ def _execute_with_sqlite(
 
 
 def _execute_with_duckdb(
-    frames: dict[str, pl.DataFrame | pl.LazyFrame],
+    frames: Mapping[str, pl.DataFrame | pl.LazyFrame],
     query: str,
 ) -> pl.DataFrame:
     """Execute a SQL query against DuckDB, returning a DataFrame."""
@@ -81,7 +81,7 @@ _COMPARISON_BACKENDS_ = {
 
 
 def assert_sql_matches(
-    frames: pl.DataFrame | pl.LazyFrame | dict[str, pl.DataFrame | pl.LazyFrame],
+    frames: pl.DataFrame | pl.LazyFrame | Mapping[str, pl.DataFrame | pl.LazyFrame],
     *,
     query: str,
     compare_with: Literal["sqlite", "duckdb"]

--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -367,49 +367,116 @@ def test_join_misc_16255() -> None:
 
 
 @pytest.mark.parametrize(
-    "constraint", ["tbl.a != tbl.b", "tbl.a > tbl.b", "a >= b", "a < b", "b <= a"]
+    "constraint",
+    [
+        # single non-equi operators (resolved via `join_where`)
+        "orders.amount > thresholds.min_amount",
+        "orders.amount >= thresholds.min_amount",
+        "orders.amount < thresholds.min_amount",
+        "orders.amount <= thresholds.min_amount",
+        "orders.amount != thresholds.min_amount",
+        # range condition (two inequalities)
+        "orders.amount > thresholds.min_amount AND orders.amount < 60",
+        # mixed equi + non-equi
+        "orders.region = thresholds.region AND orders.amount > thresholds.min_amount",
+    ],
 )
 def test_non_equi_joins(constraint: str) -> None:
-    # no support (yet) for non equi-joins in polars joins
-    # TODO: integrate awareness of new IEJoin
-    with (
-        pytest.raises(
-            SQLInterfaceError,
-            match=r"only equi-join constraints \(combined with 'AND'\) are currently supported",
+    frames = {
+        "orders": pl.DataFrame({"region": [1, 1, 2, 2], "amount": [10, 40, 20, 50]}),
+        "thresholds": pl.DataFrame({"region": [1, 2], "min_amount": [25, 25]}),
+    }
+    assert_sql_matches(
+        frames=frames,
+        query=f"""
+            SELECT orders.amount, thresholds.min_amount
+            FROM orders INNER JOIN thresholds ON {constraint}
+        """,
+        compare_with=("sqlite", "duckdb"),
+        check_dtypes=False,
+        check_row_order=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        # two-table equi-join (comma syntax with the join key in WHERE)
+        (
+            "SELECT df1.a, df1.b, df3.c FROM df1, df3 WHERE df1.a = df3.a",
+            {"a": [2, 3], "b": [3, 4], "c": [3, 4]},
         ),
-        pl.SQLContext({"tbl": pl.DataFrame({"a": [1, 2, 3], "b": [4, 3, 2]})}) as ctx,
-    ):
-        ctx.execute(
-            f"""
-            SELECT *
-            FROM tbl
-            LEFT JOIN tbl ON {constraint}  -- not an equi-join
+        # two-table join with an additional residual (non-join) filter
+        (
+            "SELECT df1.a, df3.c FROM df1, df3 WHERE df1.a = df3.a AND df1.b > 3",
+            {"a": [3], "c": [4]},
+        ),
+        # implicit join with a non-equi bridging condition (no equi key)
+        (
+            "SELECT df1.a, df3.c FROM df1, df3 WHERE df1.a < df3.a",
+            {"a": [1, 1, 1, 2, 2, 3], "c": [3, 4, 8, 4, 8, 8]},
+        ),
+        # three tables, each bridged back to the base table
+        (
             """
-        )
-
-
-def test_implicit_joins() -> None:
-    # no support for this yet; ensure we catch it
-    with (
-        pytest.raises(
-            SQLInterfaceError,
-            match=r"not currently supported .* use explicit JOIN syntax instead",
+            SELECT df1.a, df1.b, df3.c
+            FROM df1, df2, df3
+            WHERE df1.a = df2.a AND df1.b = df2.b
+              AND df3.a = df1.a AND df3.b = df1.b
+            """,
+            {"a": [2, 3], "b": [3, 4], "c": [3, 4]},
         ),
-        pl.SQLContext(
+        # three tables bridged via an *intermediate* table (df2.x = df3.x),
+        # not the base table; exercises chained-join key resolution
+        (
+            """
+            SELECT df1.a, df3.c
+            FROM df1, df2, df3
+            WHERE df1.a = df2.a AND df2.b = df3.b
+            """,
+            {"a": [2, 3], "c": [3, 4]},
+        ),
+        # no bridging predicate at all => cross join (cartesian product)
+        (
+            "SELECT df1.a, df3.c FROM df1, df3",
             {
-                "tbl": pl.DataFrame(
-                    {"a": [1, 2, 3], "b": [4, 3, 2], "c": ["x", "y", "z"]}
-                )
-            }
-        ) as ctx,
-    ):
-        ctx.execute(
-            """
-            SELECT t1.*
-            FROM tbl AS t1, tbl AS t2
-            WHERE t1.a = t2.b
-            """
-        )
+                "a": [1, 1, 1, 2, 2, 2, 3, 3, 3],
+                "c": [3, 4, 8, 3, 4, 8, 3, 4, 8],
+            },
+        ),
+    ],
+)
+def test_implicit_joins(query: str, expected: dict[str, Any]) -> None:
+    frames = {
+        "df1": pl.DataFrame({"a": [1, 2, 3], "b": [2, 3, 4]}),
+        "df2": pl.DataFrame({"a": [2, 3, 9], "b": [3, 4, 9]}),
+        "df3": pl.DataFrame({"a": [2, 3, 8], "b": [3, 4, 8], "c": [3, 4, 8]}),
+    }
+    assert_sql_matches(
+        frames=frames,
+        query=query,
+        compare_with=("sqlite", "duckdb"),
+        expected=expected,
+        check_dtypes=False,
+        check_row_order=False,
+    )
+
+
+def test_implicit_self_join() -> None:
+    # same table referenced twice via aliases in a comma join
+    frames = {"t": pl.DataFrame({"id": [1, 2, 3], "val": [10, 20, 30]})}
+    assert_sql_matches(
+        frames=frames,
+        query="""
+            SELECT a.id, a.val AS val_a, b.val AS val_b
+            FROM t AS a, t AS b
+            WHERE a.id = b.id
+        """,
+        compare_with=("sqlite", "duckdb"),
+        expected={"id": [1, 2, 3], "val_a": [10, 20, 30], "val_b": [10, 20, 30]},
+        check_dtypes=False,
+        check_row_order=False,
+    )
 
 
 @pytest.mark.parametrize(
@@ -736,6 +803,50 @@ def test_nested_join(join_clause: str) -> None:
                 "Species": "Human",
             },
         ]
+
+
+def test_join_derived_table_isolated_state() -> None:
+    # ref: https://github.com/pola-rs/polars/issues/24268
+    df1 = pl.DataFrame({"IDT": ["1"], "INFO1": ["my_info1"]})
+    df2 = pl.DataFrame({"IDT": ["1"], "INFO2": ["my_info2"], "INFO3": ["my_info3"]})
+    assert_sql_matches(
+        frames={"df1": df1, "df2": df2},
+        query="""
+            SELECT df1.*, t2.INFO2, t3.INFO3
+            FROM df1
+                LEFT JOIN (SELECT IDT, INFO2 FROM df2) t2 ON df1.IDT = t2.IDT
+                LEFT JOIN (SELECT IDT, INFO3 FROM df2) t3 ON df1.IDT = t3.IDT
+        """,
+        compare_with="duckdb",
+        expected={
+            "IDT": ["1"],
+            "INFO1": ["my_info1"],
+            "INFO2": ["my_info2"],
+            "INFO3": ["my_info3"],
+        },
+        check_dtypes=False,
+        check_row_order=False,
+    )
+
+
+def test_join_nested_isolated_state() -> None:
+    # ref: https://github.com/pola-rs/polars/issues/24268
+    base = pl.DataFrame({"id": [1, 2], "info": ["a", "b"]})
+    tbl1 = pl.DataFrame({"id": [1, 2], "val": [10, 20]})
+    tbl2 = pl.DataFrame({"id": [1, 2], "val": [30, 40]})
+
+    res = pl.SQLContext(base=base, tbl1=tbl1, tbl2=tbl2).execute(
+        """
+        SELECT base.id, val
+        FROM base
+        JOIN (tbl1 JOIN tbl2 ON tbl1.id = tbl2.id) AS nested
+        ON base.id = tbl1.id
+        ORDER BY base.id
+        """,
+        eager=True,
+    )
+    # `val` unambiguously resolves to tbl1's column (tbl2's is suffixed to "val:tbl2")
+    assert_frame_equal(res, pl.DataFrame({"id": [1, 2], "val": [10, 20]}))
 
 
 def test_miscellaneous_cte_join_aliasing() -> None:


### PR DESCRIPTION
Closes #16662.
Closes #27845.

Have had this one brewing for a while...
We can now support SQL's _implicit_ JOIN syntax 🥳

**Also:**
* Fixed the "ambiguous reference" error caused by joining on non-isolated subqueries).
* Will upgrade the `sqlparser-rs` dependency _after_ this one merges to minimise noise.

## Example

```python
import polars as pl

df1 = pl.DataFrame({
    "foo": [1, 2, 3],
    "ham": ["a", "b", "c"],
})
df2 = pl.DataFrame({
    "apple": ["x", "y", "z"],
    "ham": ["a", "b", "d"],
})
```
SQL implicit JOIN syntax:
Multiple tables in FROM, bridging predicates in the WHERE clause.
```python
pl.sql("""
    SELECT foo, apple, df1.ham
    FROM df1, df2
    WHERE df1.ham = df2.ham
""").collect()

# shape: (2, 3)
# ┌─────┬───────┬─────┐
# │ foo ┆ apple ┆ ham │
# │ --- ┆ ---   ┆ --- │
# │ i64 ┆ str   ┆ str │
# ╞═════╪═══════╪═════╡
# │ 1   ┆ x     ┆ a   │
# │ 2   ┆ y     ┆ b   │
# └─────┴───────┴─────┘
```
Previously:
```python
# SQLInterfaceError: multiple tables in FROM clause are not currently 
#  supported (found 2); use explicit JOIN syntax instead
```