### PR TITLE
fix(rust): prevent panic in hist when bins cannot be cast to Float64

### DIFF
--- a/crates/polars-compute/src/rolling/no_nulls/mean.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/mean.rs
@@ -40,3 +40,25 @@ where
         },
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_rolling_mean_window_size_zero() {
+        let values = &[1.0f64, 2.0, 3.0, 4.0];
+
+        // window_size=0: mean of empty = None
+        let out = rolling_mean(values, 0, 0, false, None, None).unwrap();
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[None, None, None, None]);
+
+        // center=true should behave the same
+        let out = rolling_mean(values, 0, 0, true, None, None).unwrap();
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[None, None, None, None]);
+    }
+}

--- a/crates/polars-compute/src/rolling/no_nulls/min_max.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/min_max.rs
@@ -143,4 +143,26 @@ mod test {
             )
         );
     }
+
+    #[test]
+    fn test_rolling_min_max_window_size_zero() {
+        let values = &[1.0f64, 5.0, 3.0, 4.0];
+
+        // window_size=0: min/max of empty = None
+        let out = rolling_min(values, 0, 0, false, None, None).unwrap();
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[None, None, None, None]);
+
+        let out = rolling_max(values, 0, 0, false, None, None).unwrap();
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[None, None, None, None]);
+
+        // center=true should behave the same
+        let out = rolling_min(values, 0, 0, true, None, None).unwrap();
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[None, None, None, None]);
+    }
 }

--- a/crates/polars-compute/src/rolling/no_nulls/moment.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/moment.rs
@@ -163,4 +163,26 @@ mod test {
         let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
         assert_eq!(out, &[None, None, None, None]);
     }
+
+    #[test]
+    fn test_rolling_skew_kurtosis_window_size_zero() {
+        let values = &[1.0f64, 5.0, 3.0, 4.0];
+        let skew_pars = Some(RollingFnParams::Skew { bias: true });
+        let kurt_pars = Some(RollingFnParams::Kurtosis {
+            fisher: true,
+            bias: true,
+        });
+
+        // skew of empty window = None
+        let out = rolling_skew(values, 0, 0, false, skew_pars).unwrap();
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[None, None, None, None]);
+
+        // kurtosis of empty window = None
+        let out = rolling_kurtosis(values, 0, 0, false, kurt_pars).unwrap();
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[None, None, None, None]);
+    }
 }

--- a/crates/polars-compute/src/rolling/no_nulls/moment.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/moment.rs
@@ -146,4 +146,21 @@ mod test {
             )
         );
     }
+
+    #[test]
+    fn test_rolling_var_window_size_zero() {
+        let values = &[1.0f64, 5.0, 3.0, 4.0];
+
+        // window_size=0: var of empty = None
+        let out = rolling_var(values, 0, 0, false, None, None).unwrap();
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[None, None, None, None]);
+
+        // center=true should behave the same
+        let out = rolling_var(values, 0, 0, true, None, None).unwrap();
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[None, None, None, None]);
+    }
 }

--- a/crates/polars-compute/src/rolling/no_nulls/quantile.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/quantile.rs
@@ -354,4 +354,26 @@ mod test {
             assert_eq!(out1, out2);
         }
     }
+
+    #[test]
+    fn test_rolling_quantile_window_size_zero() {
+        let values = &[1.0f64, 2.0, 3.0, 4.0];
+        let med_pars = Some(RollingFnParams::Quantile(RollingQuantileParams {
+            prob: 0.5,
+            method: Linear,
+        }));
+
+        // center=false: fast path via quantile_filter is bypassed, falls back to
+        // rolling_apply_agg_window; QuantileWindow returns None for empty window
+        let out = rolling_quantile(values, 0, 0, false, None, med_pars).unwrap();
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[None, None, None, None]);
+
+        // center=true: goes through rolling_apply_agg_window + det_offsets_center
+        let out = rolling_quantile(values, 0, 0, true, None, med_pars).unwrap();
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[None, None, None, None]);
+    }
 }

--- a/crates/polars-compute/src/rolling/no_nulls/sum.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/sum.rs
@@ -117,4 +117,21 @@ mod test {
             )
         );
     }
+
+    #[test]
+    fn test_rolling_sum_window_size_zero() {
+        let values = &[1.0f64, 2.0, 3.0, 4.0];
+
+        // window_size=0: every position looks at zero elements, sum of empty = 0
+        let out = rolling_sum(values, 0, 0, false, None, None).unwrap();
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[Some(0.0), Some(0.0), Some(0.0), Some(0.0)]);
+
+        // center=true should behave the same
+        let out = rolling_sum(values, 0, 0, true, None, None).unwrap();
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[Some(0.0), Some(0.0), Some(0.0), Some(0.0)]);
+    }
 }

--- a/crates/polars-compute/src/rolling/nulls/mod.rs
+++ b/crates/polars-compute/src/rolling/nulls/mod.rs
@@ -270,4 +270,37 @@ mod test {
             &[3, 10, 10, 10, 10, 10, 9, 8, 7, 6, 5, 4, 3]
         );
     }
+
+    #[test]
+    fn test_rolling_window_size_zero_nulls() {
+        // 1, None, 3, 4  (second element is null)
+        let buf = Buffer::from(vec![1.0f64, 0.0, 3.0, 4.0]);
+        let arr = &PrimitiveArray::new(
+            ArrowDataType::Float64,
+            buf,
+            Some(Bitmap::from(&[true, false, true, true])),
+        );
+
+        // sum of empty window = 0 for each position
+        let out = rolling_sum(arr, 0, 0, false, None, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[Some(0.0), Some(0.0), Some(0.0), Some(0.0)]);
+
+        // mean/min/max/var of empty window = None for each position
+        let out = rolling_mean(arr, 0, 0, false, None, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[None, None, None, None]);
+
+        let out = rolling_min(arr, 0, 0, false, None, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[None, None, None, None]);
+
+        let out = rolling_max(arr, 0, 0, false, None, None);
+        let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
+        let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
+        assert_eq!(out, &[None, None, None, None]);
+    }
 }

--- a/crates/polars-ops/src/chunked_array/hist.rs
+++ b/crates/polars-ops/src/chunked_array/hist.rs
@@ -239,19 +239,20 @@ pub fn hist_series(
     include_category: bool,
     include_breakpoint: bool,
 ) -> PolarsResult<Series> {
+    polars_ensure!(s.dtype().is_primitive_numeric(), InvalidOperation: "'hist' is only supported for numeric data");
+
     let mut bins_arg = None;
 
     let owned_bins;
     if let Some(bins) = bins {
-        polars_ensure!(bins.null_count() == 0, InvalidOperation: "nulls not supported in 'bins' argument");
         let bins = bins.cast(&DataType::Float64)?;
+        polars_ensure!(bins.null_count() == 0, InvalidOperation: "'bins' contains values that could not be cast to Float64");
         let bins_s = bins.rechunk();
         owned_bins = bins_s;
         let bins = owned_bins.f64().unwrap();
-        let bins = bins.cont_slice().unwrap();
+        let bins = bins.cont_slice()?;
         bins_arg = Some(bins);
     };
-    polars_ensure!(s.dtype().is_primitive_numeric(), InvalidOperation: "'hist' is only supported for numeric data");
 
     let out = with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
          let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();

--- a/py-polars/tests/unit/operations/test_hist.py
+++ b/py-polars/tests/unit/operations/test_hist.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal
 
 inf = float("inf")
@@ -519,3 +519,22 @@ def test_hist_ulp_edge_22234() -> None:
     # Manual path
     result = s.hist(bins=[-1, 0, 1])
     assert result["count"].to_list() == [1, 3]
+
+
+@pytest.mark.parametrize(
+    "bins",
+    [
+        pl.Series(["N"]),
+        pl.Series(["1.0", "not_a_number", "3.0"]),
+    ],
+)
+def test_hist_non_castable_string_bins_27155(bins: pl.Series) -> None:
+    df = pl.DataFrame({"a": [1.0, 2.0, 3.0]})
+    with pytest.raises(InvalidOperationError, match="Float64"):
+        df.select(pl.col("a").hist(bins=bins))
+
+
+def test_hist_string_data_raises_27155() -> None:
+    df = pl.DataFrame({"a": ["A", "G", "Y", "Z"]})
+    with pytest.raises(InvalidOperationError, match="numeric"):
+        df.select(pl.col("a").hist(bins=pl.Series([1.0, 2.0])))

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -954,6 +954,7 @@ def test_rolling_by_temporal_null_min_samples_27661() -> None:
         ("rolling_median", [None, None, None]),
         ("rolling_skew", [None, None, None]),
         ("rolling_kurtosis", [None, None, None]),
+        ("rolling_rank", [None, None, None]),
     ],
 )
 def test_rolling_window_size_zero_23434(

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -953,6 +953,7 @@ def test_rolling_by_temporal_null_min_samples_27661() -> None:
         ("rolling_var", [None, None, None]),
         ("rolling_median", [None, None, None]),
         ("rolling_skew", [None, None, None]),
+        ("rolling_kurtosis", [None, None, None]),
     ],
 )
 def test_rolling_window_size_zero_23434(
@@ -963,4 +964,13 @@ def test_rolling_window_size_zero_23434(
     assert_series_equal(
         getattr(s, method)(window_size=0),
         pl.Series(expected, dtype=pl.Float64),
+    )
+
+
+def test_rolling_quantile_window_size_zero_23434() -> None:
+    """rolling_quantile with window_size=0 should return None for every position."""
+    s = pl.Series([1.0, 2.0, 3.0], dtype=pl.Float64)
+    assert_series_equal(
+        s.rolling_quantile(quantile=0.5, window_size=0),
+        pl.Series([None, None, None], dtype=pl.Float64),
     )


### PR DESCRIPTION
Closes #27155

## What changed

When you pass a `pl.String` series as bins via the expression API, `hist` was panicking with `PanicException: called Result::unwrap() on an Err value: ComputeError(...)` instead of raising a proper `InvalidOperationError`.

The root cause was the order of operations in `hist_series()`:

1. The null check ran on the original bins series before the cast, so it passed even for `["N"]` (null count is 0 on the original).
2. `bins.cast(&DataType::Float64)` silently turned unparseable strings into nulls.
3. `bins.cont_slice().unwrap()` then panicked because the post-cast series had nulls.

There was also a second issue: the `is_primitive_numeric` check for the data series ran after the bins block, so passing a String series as data also hit the bins panic before reaching the actual error.

## Fix

Three small changes inside `hist_series()`:

Move `is_primitive_numeric` to the top of the function so non-numeric data is rejected immediately before touching bins. Move the null check to after the cast and update the error message to explain that bins couldnt be cast to Float64. Change `.unwrap()` to `?` on `cont_slice` so any remaining contiguity error propagates cleanly.

## Tests

Two new tests in `test_hist.py`, both going through the expression API since thats where `bins` accepts a `Series`:

`test_hist_non_castable_string_bins_27155` is parametrized over `["N"]` and `["1.0", "not_a_number", "3.0"]` and checks that an `InvalidOperationError` mentioning Float64 is raised.

`test_hist_string_data_raises_27155` checks that a String data series raises an `InvalidOperationError` mentioning numeric data.

All 40 existing hist tests still pass.

## Disclosure

I used AI assistance (Claude) to help work through this fix.