### PR TITLE
fix(rust): Run type coercion pass on pivot's internally generated group_by

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -901,9 +901,9 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
         } => {
             use polars_core::frame::PivotColumnNaming;
 
-            let input =
-                to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_here!(unique)))?;
-            let input_schema = ctxt.lp_arena.get(input).schema(ctxt.lp_arena);
+            let input_node = to_alp_impl(input.as_ref().clone(), ctxt)
+                .map_err(|e| e.context(failed_here!(pivot)))?;
+            let input_schema = ctxt.lp_arena.get(input_node).schema(ctxt.lp_arena);
 
             let on = on.into_columns(input_schema.as_ref(), &Default::default())?;
             let index = index.into_columns(input_schema.as_ref(), &Default::default())?;
@@ -933,7 +933,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
 
             let mut expr_schema = input_schema.as_ref().as_ref().clone();
             let mut out = Vec::with_capacity(1);
-            let mut aggs = Vec::<ExprIR>::with_capacity(values.len() * on_columns.height());
+            let mut aggs_dsl = Vec::<Expr>::with_capacity(values.len() * on_columns.height());
             for value in values.iter() {
                 out.clear();
                 let value_dtype = input_schema.try_get(value)?;
@@ -949,19 +949,10 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                     out.len() == 1,
                     InvalidOperation: "Pivot expression are not allowed to expand to more than 1 expression"
                 );
-                let agg = out.pop().unwrap();
-                let agg_ae = to_expr_ir(
-                    agg,
-                    &mut ExprToIRContext::new_with_opt_eager(
-                        ctxt.expr_arena,
-                        &expr_schema,
-                        ctxt.opt_flags,
-                    ),
-                )?
-                .node();
+                let agg_dsl = out.pop().unwrap();
 
                 polars_ensure!(
-                    aexpr_to_leaf_names_iter(agg_ae, ctxt.expr_arena).count() == 0,
+                    !(&agg_dsl).into_iter().any(|e| matches!(e, Expr::Column(_))),
                     InvalidOperation: "explicit column references are not allowed in the `aggregate_function` of `pivot`"
                 );
 
@@ -978,107 +969,57 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
 
                     name.push_str(on_titles.get(i).unwrap_or("null"));
 
-                    fn on_predicate(
-                        on: &PlSmallStr,
-                        on_column: &Column,
-                        i: usize,
-                        expr_arena: &mut Arena<AExpr>,
-                    ) -> AExprBuilder {
-                        let e = AExprBuilder::col(on.clone(), expr_arena);
-                        e.eq_validity(
-                            AExprBuilder::lit_scalar(
-                                Scalar::new(
-                                    on_column.dtype().clone(),
-                                    on_column.get(i).unwrap().into_static(),
-                                ),
-                                expr_arena,
-                            ),
-                            expr_arena,
-                        )
-                    }
-
                     let predicate = if on.len() == 1 {
-                        on_predicate(&on[0], &on_columns.columns()[0], i, ctxt.expr_arena)
+                        col(on[0].clone()).eq_missing(lit(Scalar::new(
+                            on_columns.columns()[0].dtype().clone(),
+                            on_columns.columns()[0].get(i).unwrap().into_static(),
+                        )))
                     } else {
-                        AExprBuilder::function(
+                        all_horizontal(
                             on.iter()
-                                .enumerate()
-                                .map(|(j, on_col)| {
-                                    on_predicate(
-                                        on_col,
-                                        &on_columns.columns()[j],
-                                        i,
-                                        ctxt.expr_arena,
-                                    )
-                                    .expr_ir(on_col.clone())
+                                .zip(on_columns.columns())
+                                .map(|(on_col, col_data)| {
+                                    col(on_col.clone()).eq_missing(lit(Scalar::new(
+                                        col_data.dtype().clone(),
+                                        col_data.get(i).unwrap().into_static(),
+                                    )))
                                 })
                                 .collect::<Vec<_>>(),
-                            IRFunctionExpr::Boolean(IRBooleanFunction::AllHorizontal),
-                            ctxt.expr_arena,
-                        )
+                        )?
                     };
 
-                    let replacement_element = AExprBuilder::col(value.clone(), ctxt.expr_arena)
-                        .filter(predicate, ctxt.expr_arena)
-                        .node();
+                    let replacement = col(value.clone()).filter(predicate);
 
-                    #[recursive::recursive]
-                    fn deep_clone_element_replace(
-                        ae: Node,
-                        arena: &mut Arena<AExpr>,
-                        replacement: Node,
-                    ) -> Node {
-                        let slf = arena.get(ae).clone();
-                        if matches!(slf, AExpr::Element) {
-                            return deep_clone_ae(replacement, arena);
-                        } else if matches!(slf, AExpr::Len) {
-                            // For backwards-compatibility, we support providing `pl.len()` to mean
-                            // the length of the group here.
-                            let element = deep_clone_ae(replacement, arena);
-                            return AExprBuilder::new_from_node(element).len(arena).node();
-                        }
-
-                        let mut children = vec![];
-                        slf.children_rev(&mut children);
-                        for child in &mut children {
-                            *child = deep_clone_element_replace(*child, arena, replacement);
-                        }
-                        children.reverse();
-
-                        arena.add(slf.replace_children(&children))
-                    }
-                    aggs.push(ExprIR::new(
-                        deep_clone_element_replace(agg_ae, ctxt.expr_arena, replacement_element),
-                        OutputName::Alias(name.into()),
-                    ));
+                    aggs_dsl.push(
+                        agg_dsl
+                            .clone()
+                            .map_expr(|e| match e {
+                                Expr::Element => replacement.clone(),
+                                Expr::Len => replacement.clone().len(),
+                                other => other,
+                            })
+                            .alias(name.as_str()),
+                    );
                 }
             }
 
-            let keys: Vec<_> = index
-                .into_iter()
-                .map(|i| AExprBuilder::col(i.clone(), ctxt.expr_arena).expr_ir(i))
-                .collect();
+            let keys_dsl: Vec<Expr> = index.iter().map(|i| col(i.clone())).collect();
 
-            let mut uniq_names = PlIndexSet::new();
-            for expr in keys.iter().chain(aggs.iter()) {
-                let name = expr.output_name();
-                let is_uniq = uniq_names.insert(name.clone());
-                polars_ensure!(is_uniq, duplicate = name);
-            }
-
-            let lp = IRBuilder::new(input, ctxt.expr_arena, ctxt.lp_arena)
-                .group_by(keys, aggs, None, maintain_order, Default::default())?
-                .build();
-            if let IR::GroupBy {
-                ref keys, ref aggs, ..
-            } = lp
-            {
-                ctxt.conversion_optimizer
-                    .fill_scratch(keys, ctxt.expr_arena);
-                ctxt.conversion_optimizer
-                    .fill_scratch(aggs, ctxt.expr_arena);
-            }
-            return run_conversion(lp, ctxt, "pivot");
+            let input = DslPlan::IR {
+                dsl: input,
+                version: ctxt.lp_arena.version(),
+                node: Some(input_node),
+            };
+            let lp = DslPlan::GroupBy {
+                input: Arc::new(input),
+                keys: keys_dsl,
+                predicates: vec![],
+                aggs: aggs_dsl,
+                maintain_order,
+                options: Default::default(),
+                apply: None,
+            };
+            return to_alp_impl(lp, ctxt).map_err(|e| e.context(failed_here!(pivot)));
         },
         DslPlan::Distinct { input, options } => {
             let input =

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -1066,9 +1066,19 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 polars_ensure!(is_uniq, duplicate = name);
             }
 
-            IRBuilder::new(input, ctxt.expr_arena, ctxt.lp_arena)
+            let lp = IRBuilder::new(input, ctxt.expr_arena, ctxt.lp_arena)
                 .group_by(keys, aggs, None, maintain_order, Default::default())?
-                .build()
+                .build();
+            if let IR::GroupBy {
+                ref keys, ref aggs, ..
+            } = lp
+            {
+                ctxt.conversion_optimizer
+                    .fill_scratch(keys, ctxt.expr_arena);
+                ctxt.conversion_optimizer
+                    .fill_scratch(aggs, ctxt.expr_arena);
+            }
+            return run_conversion(lp, ctxt, "pivot");
         },
         DslPlan::Distinct { input, options } => {
             let input =

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -1009,6 +1009,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 dsl: input,
                 version: ctxt.lp_arena.version(),
                 node: Some(input_node),
+                opt_flags: Some(*ctxt.opt_flags),
             };
             let lp = DslPlan::GroupBy {
                 input: Arc::new(input),

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -769,3 +769,12 @@ def test_pivot_null_on_values_27272() -> None:
         {"id": ["a", "b"], '{"X","p"}': [1, 0], "null": [2, 3]},
     )
     assert_frame_equal(result2, expected2)
+
+
+def test_pivot_fill_null_type_coercion_26843() -> None:
+    df = pl.DataFrame({"x": [1, 2], "y": [3, 4], "z": [5, 6]})
+    result = df.pivot(
+        "x", index="y", aggregate_function=pl.element().first().fill_null(0)
+    )
+    expected = pl.DataFrame({"y": [3, 4], "1": [5, 0], "2": [0, 6]})
+    assert_frame_equal(result, expected, check_row_order=False)


### PR DESCRIPTION
Closes #26843

**The bug**

`pivot` with a custom `aggregate_function` containing `fill_null` panicked with:
```
PanicException: implementation error, cannot get ref Int64 from Int32
```

```python
df = pl.DataFrame({"x": [1, 2], "y": [3, 4], "z": [5, 6]})
df.pivot("x", index="y", aggregate_function=pl.element().first().fill_null(0))
# PanicException: implementation error, cannot get ref Int64 from Int32
```

**Root cause**

`pivot` internally rewrites to a `group_by`. The `DslPlan::Pivot` arm in `dsl_to_ir/mod.rs` built that group_by IR directly via `IRBuilder` and returned it through the generic `lp_arena.add(v)` fallthrough — bypassing `run_conversion` and the `ConversionOptimizer` entirely. The `TypeCoercionRule` that would normally insert a `Cast` to align `lit(0)` (`Int32`) with the `Int64` value column never ran, so `zip_with_same_type` received mismatched dtypes and panicked.

**Fix**

Instead of hand-building the group_by IR, the `Pivot` arm now recurses back into the DSL generator (as suggested in review): it builds the key and aggregation expressions at the DSL level — `map_expr` substitutes `pl.element()` / `pl.len()` with the filtered value column, and the per-pivot-column predicates use `col().eq_missing(lit(...))` / `all_horizontal` — wraps the already-converted input in a `DslPlan::IR` node (same pattern as `DslPlan::PipeWithSchema`) so it isn't converted twice, and returns `to_alp_impl` on a regular `DslPlan::GroupBy`.

The standard group_by path then takes care of selector expansion, `resolve_group_by` (including duplicate output-name validation and auto-implode of non-scalar aggs), the empty-keys-to-select rewrite, and — crucially — type coercion via `run_conversion`, which fixes the panic.

This also allowed deleting the pivot-specific IR helpers (`on_predicate`, `deep_clone_element_replace`) and the manual duplicate-name check (net −49 lines).

**Testing**

Added a regression test in `test_pivot.py` reproducing the exact case from the issue.

---

*I used AI (Claude) as an assistant while working through this fix.*
