### PR TITLE
docs: Add robots.txt disallowing stale docs and added sitemap for better SEO

### DIFF
--- a/docs/source/robots.txt
+++ b/docs/source/robots.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Disallow: /api/python/version/
+Disallow: /api/python/dev/
 
 Sitemap: https://docs.pola.rs/sitemap.xml
 Sitemap: https://docs.pola.rs/api/python/stable/sitemap.xml

--- a/docs/source/robots.txt
+++ b/docs/source/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Disallow: /api/python/version/
+
+Sitemap: https://docs.pola.rs/sitemap.xml
+Sitemap: https://docs.pola.rs/api/python/stable/sitemap.xml

--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -14,6 +14,7 @@ sphinx-copybutton==0.5.2
 sphinx-design==0.6.1
 sphinx-favicon==1.0.1
 sphinx-reredirects==0.1.5
+sphinx-sitemap==2.9.0
 sphinx-toolbox==3.8.1
 
 livereload==2.7.0

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -115,10 +115,23 @@ static_assets_root = "https://raw.githubusercontent.com/pola-rs/polars-static/ma
 github_root = "https://github.com/pola-rs/polars"
 web_root = "https://docs.pola.rs"
 
+
 # Specify version for version switcher dropdown menu
+def _switcher_version(git_ref: str) -> str:
+    # Returns the major version digit for a release tag (e.g. "py-1.23.4" -> "1"),
+    # or "dev" if the ref doesn't match a release tag.
+    match = re.fullmatch(r"py-(\d+)\.\d+\.\d+.*", git_ref)
+    return match.group(1) if match else "dev"
+
+
 git_ref = os.environ.get("POLARS_VERSION", "main")
-version_match = re.fullmatch(r"py-(\d+)\.\d+\.\d+.*", git_ref)
-switcher_version = version_match.group(1) if version_match is not None else "dev"
+switcher_version = _switcher_version(git_ref)
+
+if switcher_version != "dev" and int(switcher_version) >= 1:
+    # In this case we generate a docs sitemap for stable
+    extensions.append("sphinx_sitemap")
+    html_baseurl = f"{web_root}/api/python/stable/"
+    sitemap_url_scheme = "{link}"
 
 html_js_files = [
     "js/announcement-dismiss.js",


### PR DESCRIPTION
<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->

In an effort to create visibility on search engines and LLMs we're improving SEO of the docs.
- `robots.txt` disallows indexing stale docs versions.
- Sitemaps are generated for the stable version of the docs for better indexing of our API

🤖 AI was used to integrate sphinx-sitemap, I verified the build locally and it works as intended.

I will have to check if the CI/deploy works correctly as well, since I don't have a full overview of how Sphinx deploys this.

Fixes #3716 