### PR TITLE
chore(python): Covariant `classinstmethod` and attribute annotation

### DIFF
--- a/py-polars/src/polars/datatypes/classes.py
+++ b/py-polars/src/polars/datatypes/classes.py
@@ -39,17 +39,18 @@ if TYPE_CHECKING:
     )
 
 
-T = TypeVar("T")
-R = TypeVar("R")
+R_co = TypeVar("R_co", covariant=True)
 
 
-class classinstmethod(Generic[R]):
+class classinstmethod(Generic[R_co]):
     """Decorator that allows a method to be called from the class OR instance."""
 
-    def __init__(self, func: Callable[..., R]) -> None:
+    func: Callable[..., R_co]
+
+    def __init__(self, func: Callable[..., R_co]) -> None:
         self.func = func
 
-    def __get__(self, instance: Any, type_: Any) -> Callable[..., R]:
+    def __get__(self, instance: Any, type_: Any) -> Callable[..., R_co]:
         if instance is not None:
             return self.func.__get__(instance, type_)
         return self.func.__get__(type_, type_)


### PR DESCRIPTION
This annotates the `func` attribute of the internal `classinstmethod` helper descriptor class in `polars.datatypes.classes`, increasing type coverage by a whopping 0.02%.

I also noticed that the generic (return) type parameter of `classinstmethod` was invariant. But because it's only used in output positions, it should be covariant, so I took the liberty of correcting this. It wasn't causing any issues or anything, but perhaps it would have in the future.

```bash
$ mypy src
Success: no issues found in 205 source files

$ pyrefly check
 INFO Checking project configured at `/home/joren/Workspace/polars/py-polars/pyproject.toml`
 INFO 0 errors (1,270 suppressed, 90 warnings not shown)
```