### PR TITLE
chore(python): Attribute annotations for `ScanCastOptions`

### DIFF
--- a/py-polars/src/polars/io/scan_options/cast_options.py
+++ b/py-polars/src/polars/io/scan_options/cast_options.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from collections.abc import Collection
+from typing import TYPE_CHECKING, Literal, TypeVar
 
 from polars._utils.unstable import issue_unstable_warning
 
 if TYPE_CHECKING:
-    from collections.abc import Collection
     from typing import TypeAlias
 
 
@@ -22,18 +22,28 @@ DatetimeCastOption: TypeAlias = Literal[
     "forbid",
 ]
 
+_OptionT = TypeVar("_OptionT", bound=str)
+_CastConfig: TypeAlias = _OptionT | Collection[_OptionT]
+
 _DEFAULT_CAST_OPTIONS_ICEBERG: ScanCastOptions | None = None
 
 
 class ScanCastOptions:
     """Cast options applied when scanning files."""
 
+    integer_cast: _CastConfig[IntegerCastOption]
+    float_cast: _CastConfig[FloatCastOption]
+    datetime_cast: _CastConfig[DatetimeCastOption]
+    missing_struct_fields: Literal["insert", "raise"]
+    extra_struct_fields: Literal["ignore", "raise"]
+    categorical_to_string: Literal["allow", "forbid"]
+
     def __init__(
         self,
         *,
-        integer_cast: IntegerCastOption | Collection[IntegerCastOption] = "forbid",
-        float_cast: FloatCastOption | Collection[FloatCastOption] = "forbid",
-        datetime_cast: DatetimeCastOption | Collection[DatetimeCastOption] = "forbid",
+        integer_cast: _CastConfig[IntegerCastOption] = "forbid",
+        float_cast: _CastConfig[FloatCastOption] = "forbid",
+        datetime_cast: _CastConfig[DatetimeCastOption] = "forbid",
         missing_struct_fields: Literal["insert", "raise"] = "raise",
         extra_struct_fields: Literal["ignore", "raise"] = "raise",
         categorical_to_string: Literal["allow", "forbid"] = "forbid",


### PR DESCRIPTION
Like #27739, here's yet another type coverage PR. This time featuring the 6 attributes of `polars.io.scan_options.cast_options.ScanCastOptions`. 

In order to avoid a bunch of duplication, I introduced a private `_CastConfig` generic type alias. The `__init__` is also a bit easier to read now.

The type coverage increased by a juicy 0.12%. If we include the other two type-coverage PRs that I opened earlier today, we're almost at 100% coverage :tada:.
The 4 remaining missing annotations are spread over 4 modules, so I think I'll just bundle them in one PR, for the sake of your gh notifications :).