### PR TITLE
chore(python): Annotate untyped module constants

### DIFF
--- a/py-polars/src/polars/datatypes/convert.py
+++ b/py-polars/src/polars/datatypes/convert.py
@@ -50,7 +50,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 
 if TYPE_CHECKING:
-    from typing import TypeGuard
+    from typing import Final, TypeGuard
 
     from polars._typing import PolarsDataType, PythonDataType, TimeUnit
 
@@ -247,7 +247,7 @@ class _DataTypeMappings:
 
 
 # Initialize once (poor man's singleton :)
-DataTypeMappings = _DataTypeMappings()
+DataTypeMappings: Final[_DataTypeMappings] = _DataTypeMappings()
 
 
 def dtype_to_ffiname(dtype: PolarsDataType) -> str:

--- a/py-polars/src/polars/meta/build.py
+++ b/py-polars/src/polars/meta/build.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from polars._utils.polars_version import get_polars_version
 
+__build__: dict[str, Any]
 try:
     from polars._plr import __build__
 except ImportError:

--- a/py-polars/src/polars/testing/parametric/strategies/dtype.py
+++ b/py-polars/src/polars/testing/parametric/strategies/dtype.py
@@ -41,6 +41,7 @@ from polars.datatypes import (
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Sequence
+    from typing import Final
 
     from hypothesis.strategies import DrawFn, SearchStrategy
 
@@ -48,7 +49,7 @@ if TYPE_CHECKING:
     from polars.datatypes import DataTypeClass
 
 # A simple test extension type for parametric tests.
-TestExtension = Extension(
+TestExtension: Final[Extension] = Extension(
     name="testing.parametric_test_extension",
     storage=Int32(),
     metadata="A parametric test extension type",


### PR DESCRIPTION
As promised in #27906, this addresses the last three untyped symbols. So this, together with the other PRs I opened today, brings the type coverage of polars to 100% :partying_face:.