### PR TITLE
fix: Preserve null placement when collapsing `sort.reverse()` into single sort

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/simplify_expr/simplify_functions.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_expr/simplify_functions.rs
@@ -85,6 +85,7 @@ pub(super) fn optimize_functions(
                 AExpr::Sort { expr, options } => {
                     let mut options = *options;
                     options.descending = !options.descending;
+                    options.nulls_last = !options.nulls_last;
                     Some(AExpr::Sort {
                         expr: *expr,
                         options,
@@ -96,8 +97,8 @@ pub(super) fn optimize_functions(
                     sort_options,
                 } => {
                     let mut sort_options = sort_options.clone();
-                    let reversed_descending = sort_options.descending.iter().map(|x| !*x).collect();
-                    sort_options.descending = reversed_descending;
+                    sort_options.descending = sort_options.descending.iter().map(|x| !*x).collect();
+                    sort_options.nulls_last = sort_options.nulls_last.iter().map(|x| !*x).collect();
                     Some(AExpr::SortBy {
                         expr: *expr,
                         by: by.clone(),

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -1330,3 +1330,55 @@ def test_sort_by_multiple_length_mismatch_27759() -> None:
     )
     with pytest.raises(pl.exceptions.ShapeError):
         df.group_by("a").agg(pl.col("b").filter("c").sort_by(["d", "e"]))
+
+
+def test_sort_reverse_head_returns_top_values_not_nulls_27917() -> None:
+    df = pl.DataFrame({"x": [10, None, 30, 20, None, 40]})
+
+    assert df.select(pl.col("x").sort().reverse().head(3))["x"].to_list() == [
+        40,
+        30,
+        20,
+    ]
+
+
+@pytest.mark.parametrize("descending", [False, True])
+@pytest.mark.parametrize("nulls_last", [False, True])
+def test_sort_reverse_preserves_null_placement_27917(
+    descending: bool, nulls_last: bool
+) -> None:
+    df = pl.DataFrame({"x": [10, None, 30, 20, None, 40]})
+    expr = pl.col("x").sort(descending=descending, nulls_last=nulls_last).reverse()
+
+    assert_frame_equal(
+        df.lazy().select(expr).collect(),
+        df.lazy().select(expr).collect(optimizations=pl.QueryOptFlags.none()),
+    )
+
+
+@pytest.mark.parametrize(
+    "descending", [[False, False], [True, False], [False, True], [True, True]]
+)
+@pytest.mark.parametrize(
+    "nulls_last", [[False, False], [True, False], [False, True], [True, True]]
+)
+def test_sort_by_reverse_preserves_null_placement_27917(
+    descending: list[bool], nulls_last: list[bool]
+) -> None:
+    df = pl.DataFrame(
+        {
+            "v": [10, 20, 30, 40, 50],
+            "a": [1, 1, 2, 2, 1],
+            "b": [None, 2, None, 3, 1],
+        }
+    )
+    expr = (
+        pl.col("v")
+        .sort_by(["a", "b"], descending=descending, nulls_last=nulls_last)
+        .reverse()
+    )
+
+    assert_frame_equal(
+        df.lazy().select(expr).collect(),
+        df.lazy().select(expr).collect(optimizations=pl.QueryOptFlags.none()),
+    )


### PR DESCRIPTION
The `Reverse(Sort)` and `Reverse(SortBy)` rewrites in `simplify_functions.rs` flipped `descending` but not `nulls_last`, breaking `Expr.sort().reverse()` whenever the input contained nulls (e.g. `sort().reverse().head(N)` returned nulls instead of top values). Since `reverse` literally inverts the array including null positions, the fused single-sort must flip both flags. Added regression tests covering all `(descending x nulls_last)` combos for both `Sort` and `SortBy`.

Fixes #27917