### PR TITLE
feat: Support `var()` for Duration on streaming engine

### DIFF
--- a/crates/polars-expr/src/reduce/var_std.rs
+++ b/crates/polars-expr/src/reduce/var_std.rs
@@ -22,7 +22,7 @@ pub fn new_var_std_reduction(
                 Box::new(VGR::new(dtype, VarStdReducer::<$T> {
                     is_std,
                     ddof,
-                    needs_cast: false,
+                    cast: None,
                     _phantom: PhantomData,
                 }))
             })
@@ -33,11 +33,20 @@ pub fn new_var_std_reduction(
             VarStdReducer::<Float64Type> {
                 is_std,
                 ddof,
-                needs_cast: true,
+                cast: Some(Cast::Float64),
                 _phantom: PhantomData,
             },
         )),
-        Duration(..) => todo!(),
+        #[cfg(feature = "dtype-duration")]
+        Duration(_) => Box::new(VGR::new(
+            dtype,
+            VarStdReducer::<Int64Type> {
+                is_std,
+                ddof,
+                cast: Some(Cast::Physical),
+                _phantom: PhantomData,
+            },
+        )),
         Null => Box::new(super::NullGroupedReduction::new(Scalar::null(
             DataType::Null,
         ))),
@@ -50,8 +59,14 @@ pub fn new_var_std_reduction(
 struct VarStdReducer<T> {
     is_std: bool,
     ddof: u8,
-    needs_cast: bool,
+    cast: Option<Cast>,
     _phantom: PhantomData<T>,
+}
+
+#[derive(Clone, Copy)]
+enum Cast {
+    Float64,
+    Physical,
 }
 
 impl<T> Clone for VarStdReducer<T> {
@@ -59,7 +74,7 @@ impl<T> Clone for VarStdReducer<T> {
         Self {
             is_std: self.is_std,
             ddof: self.ddof,
-            needs_cast: self.needs_cast,
+            cast: self.cast,
             _phantom: PhantomData,
         }
     }
@@ -74,10 +89,10 @@ impl<T: PolarsNumericType> Reducer for VarStdReducer<T> {
     }
 
     fn cast_series<'a>(&self, s: &'a Series) -> Cow<'a, Series> {
-        if self.needs_cast {
-            Cow::Owned(s.cast(&DataType::Float64).unwrap())
-        } else {
-            Cow::Borrowed(s)
+        match self.cast {
+            Some(Cast::Float64) => Cow::Owned(s.cast(&DataType::Float64).unwrap()),
+            Some(Cast::Physical) => s.to_physical_repr(),
+            None => Cow::Borrowed(s),
         }
     }
 
@@ -128,6 +143,17 @@ impl<T: PolarsNumericType> Reducer for VarStdReducer<T> {
                     })
                     .collect_ca(PlSmallStr::EMPTY);
                 Ok(ca.into_series())
+            },
+            DataType::Duration(tu) => {
+                let ca: Float64Chunked = v
+                    .into_iter()
+                    .map(|s| {
+                        let var = s.finalize(self.ddof);
+                        if self.is_std { var.map(f64::sqrt) } else { var }
+                    })
+                    .collect_ca(PlSmallStr::EMPTY);
+
+                Ok(ca.cast(&DataType::Int64).unwrap().into_duration(*tu))
             },
             _ => {
                 let ca: Float64Chunked = v


### PR DESCRIPTION
Fixes a test failure when running with `POLARS_FORCE_STREAMING` on `py-polars/tests/unit/datatypes/test_duration.py -k test_duration_std_var`

* for https://github.com/pola-rs/polars/pull/27822
