### PR TITLE
refactor: Remove `POLARS_AUTO_STREAMING` in favor of using `POLARS_FORCE_STREAMING`

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -139,6 +139,6 @@ jobs:
       - name: Run non-benchmark tests on new streaming engine
         working-directory: py-polars
         env:
-          POLARS_AUTO_STREAMING: 1
+          POLARS_FORCE_STREAMING: 1
           POLARS_TIMEOUT_MS: 60000
         run: pytest -n auto -m "not may_fail_auto_streaming and not slow and not write_disk and not release and not docs and not hypothesis and not benchmark and not ci_only"

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Run Python tests - streaming
         working-directory: py-polars
         env:
-          POLARS_AUTO_STREAMING: 1
+          POLARS_FORCE_STREAMING: 1
           POLARS_TIMEOUT_MS: 60000
         run: >
           pytest
@@ -170,7 +170,7 @@ jobs:
       - name: Run Python tests - streaming with morsel size 4
         working-directory: py-polars
         env:
-          POLARS_AUTO_STREAMING: 1
+          POLARS_FORCE_STREAMING: 1
           POLARS_IDEAL_MORSEL_SIZE: 4
           POLARS_TIMEOUT_MS: 60000
         run: >

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Run tests with new streaming engine
         if: github.ref_name != 'main' && matrix.python-version != '3.14t' && matrix.auto_new_streaming
         env:
-          POLARS_AUTO_STREAMING: 1
+          POLARS_FORCE_STREAMING: 1
           POLARS_TIMEOUT_MS: 60000
         run: pytest -n auto -m "not may_fail_auto_streaming and not release and not benchmark and not docs"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3661,6 +3661,7 @@ dependencies = [
  "polars-lazy",
  "polars-ops",
  "polars-plan",
+ "polars-testing",
  "polars-time",
  "polars-utils",
  "regex",

--- a/crates/polars-core/src/chunked_array/object/extension/drop.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/drop.rs
@@ -15,8 +15,6 @@ pub(crate) unsafe fn drop_list(ca: &ListChunked) {
         if nested_count != 0 {
             panic!("multiple nested objects not yet supported")
         }
-        // if empty the memory is leaked somewhere
-        assert!(!ca.chunks.is_empty());
         for lst_arr in &ca.chunks {
             if let ArrowDataType::LargeList(fld) = lst_arr.dtype() {
                 let dtype = fld.dtype();

--- a/crates/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/mod.rs
@@ -47,8 +47,9 @@ struct ExtensionSentinel {
 
 impl Drop for ExtensionSentinel {
     fn drop(&mut self) {
-        let mut drop_fn = self.drop_fn.take().unwrap();
-        drop_fn()
+        if let Some(mut drop_fn) = self.drop_fn.take() {
+            (drop_fn)()
+        }
     }
 }
 

--- a/crates/polars-expr/src/reduce/var_std.rs
+++ b/crates/polars-expr/src/reduce/var_std.rs
@@ -22,7 +22,7 @@ pub fn new_var_std_reduction(
                 Box::new(VGR::new(dtype, VarStdReducer::<$T> {
                     is_std,
                     ddof,
-                    needs_cast: false,
+                    cast: None,
                     _phantom: PhantomData,
                 }))
             })
@@ -33,11 +33,20 @@ pub fn new_var_std_reduction(
             VarStdReducer::<Float64Type> {
                 is_std,
                 ddof,
-                needs_cast: true,
+                cast: Some(Cast::Float64),
                 _phantom: PhantomData,
             },
         )),
-        Duration(..) => todo!(),
+        #[cfg(feature = "dtype-duration")]
+        Duration(_) => Box::new(VGR::new(
+            dtype,
+            VarStdReducer::<Int64Type> {
+                is_std,
+                ddof,
+                cast: Some(Cast::Physical),
+                _phantom: PhantomData,
+            },
+        )),
         Null => Box::new(super::NullGroupedReduction::new(Scalar::null(
             DataType::Null,
         ))),
@@ -50,8 +59,14 @@ pub fn new_var_std_reduction(
 struct VarStdReducer<T> {
     is_std: bool,
     ddof: u8,
-    needs_cast: bool,
+    cast: Option<Cast>,
     _phantom: PhantomData<T>,
+}
+
+#[derive(Clone, Copy)]
+enum Cast {
+    Float64,
+    Physical,
 }
 
 impl<T> Clone for VarStdReducer<T> {
@@ -59,7 +74,7 @@ impl<T> Clone for VarStdReducer<T> {
         Self {
             is_std: self.is_std,
             ddof: self.ddof,
-            needs_cast: self.needs_cast,
+            cast: self.cast,
             _phantom: PhantomData,
         }
     }
@@ -74,10 +89,10 @@ impl<T: PolarsNumericType> Reducer for VarStdReducer<T> {
     }
 
     fn cast_series<'a>(&self, s: &'a Series) -> Cow<'a, Series> {
-        if self.needs_cast {
-            Cow::Owned(s.cast(&DataType::Float64).unwrap())
-        } else {
-            Cow::Borrowed(s)
+        match self.cast {
+            Some(Cast::Float64) => Cow::Owned(s.cast(&DataType::Float64).unwrap()),
+            Some(Cast::Physical) => s.to_physical_repr(),
+            None => Cow::Borrowed(s),
         }
     }
 
@@ -128,6 +143,17 @@ impl<T: PolarsNumericType> Reducer for VarStdReducer<T> {
                     })
                     .collect_ca(PlSmallStr::EMPTY);
                 Ok(ca.into_series())
+            },
+            DataType::Duration(tu) => {
+                let ca: Float64Chunked = v
+                    .into_iter()
+                    .map(|s| {
+                        let var = s.finalize(self.ddof);
+                        if self.is_std { var.map(f64::sqrt) } else { var }
+                    })
+                    .collect_ca(PlSmallStr::EMPTY);
+
+                Ok(ca.cast(&DataType::Int64).unwrap().into_duration(*tu))
             },
             _ => {
                 let ca: Float64Chunked = v

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -621,7 +621,7 @@ impl LazyFrame {
     /// `engine`.
     ///
     /// The query is optimized prior to execution.
-    pub fn collect_with_engine(mut self, engine: Engine) -> PolarsResult<QueryResult> {
+    pub fn collect_with_engine(mut self, mut engine: Engine) -> PolarsResult<QueryResult> {
         fn is_scan_with_rechunk(dsl: &DslPlan) -> bool {
             match dsl {
                 DslPlan::Scan {
@@ -632,31 +632,24 @@ impl LazyFrame {
             }
         }
 
-        let engine = match engine {
-            Engine::Streaming => Engine::Streaming,
-            _ if std::env::var("POLARS_FORCE_STREAMING").as_deref() == Ok("1") => Engine::Streaming,
-            Engine::Auto => {
-                if self.opt_state.eager() || is_scan_with_rechunk(&self.logical_plan) {
-                    Engine::InMemory
-                } else {
-                    self.opt_state |= OptFlags::AUTO_SELECTED_STREAMING;
-                    Engine::Streaming
-                }
-            },
-            v => v,
+        engine = if std::env::var("POLARS_FORCE_STREAMING").as_deref() == Ok("1") {
+            Engine::Streaming
+        } else if engine == Engine::Auto {
+            match polars_config::config().engine_affinity() {
+                Engine::Auto => {
+                    if self.opt_state.eager() || is_scan_with_rechunk(&self.logical_plan) {
+                        Engine::InMemory
+                    } else {
+                        self.opt_state |= OptFlags::AUTO_SELECTED_STREAMING;
+                        Engine::Streaming
+                    }
+                },
+                engine => engine,
+            }
+        } else {
+            engine
         };
 
-        if engine != Engine::Streaming
-            && std::env::var("POLARS_AUTO_STREAMING").as_deref() == Ok("1")
-        {
-            self.opt_state |= OptFlags::AUTO_SELECTED_STREAMING;
-
-            feature_gated!("streaming", {
-                if let Some(r) = self.clone()._collect_with_streaming_suppress_todo_panic() {
-                    return r;
-                }
-            })
-        }
         match engine {
             Engine::Streaming => {
                 feature_gated!("streaming", self = self.with_streaming(true))
@@ -856,48 +849,6 @@ impl LazyFrame {
         };
 
         Ok(self)
-    }
-
-    /// Collect with the streaming engine. Returns `None` if the streaming engine panics with a todo!.
-    #[cfg(feature = "streaming")]
-    fn _collect_with_streaming_suppress_todo_panic(
-        mut self,
-    ) -> Option<PolarsResult<polars_core::query_result::QueryResult>> {
-        self.opt_state |= OptFlags::STREAMING;
-        let mut ir_plan = match self.to_alp_optimized() {
-            Ok(v) => v,
-            Err(e) => return Some(Err(e)),
-        };
-
-        ir_plan.ensure_root_node_is_sink();
-
-        let f = || {
-            polars_stream::run_query(
-                ir_plan.lp_top,
-                &mut ir_plan.lp_arena,
-                &mut ir_plan.expr_arena,
-            )
-        };
-
-        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
-            Ok(v) => Some(v),
-            Err(e) => {
-                // Fallback to normal engine if error is due to not being implemented
-                // and auto_streaming is set, otherwise propagate error.
-                if e.downcast_ref::<&str>()
-                    .is_some_and(|s| s.starts_with("not yet implemented"))
-                {
-                    if polars_core::config::verbose() {
-                        eprintln!(
-                            "caught unimplemented error in new streaming engine, falling back to normal engine"
-                        );
-                    }
-                    None
-                } else {
-                    std::panic::resume_unwind(e)
-                }
-            },
-        }
     }
 
     pub fn sink(

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -622,16 +622,35 @@ impl LazyFrame {
     ///
     /// The query is optimized prior to execution.
     pub fn collect_with_engine(mut self, engine: Engine) -> PolarsResult<QueryResult> {
+        fn is_scan_with_rechunk(dsl: &DslPlan) -> bool {
+            match dsl {
+                DslPlan::Scan {
+                    unified_scan_args, ..
+                } => unified_scan_args.rechunk,
+                DslPlan::Sink { input, .. } => is_scan_with_rechunk(input),
+                _ => false,
+            }
+        }
+
         let engine = match engine {
             Engine::Streaming => Engine::Streaming,
             _ if std::env::var("POLARS_FORCE_STREAMING").as_deref() == Ok("1") => Engine::Streaming,
-            Engine::Auto => Engine::InMemory,
+            Engine::Auto => {
+                if self.opt_state.eager() || is_scan_with_rechunk(&self.logical_plan) {
+                    Engine::InMemory
+                } else {
+                    self.opt_state |= OptFlags::AUTO_SELECTED_STREAMING;
+                    Engine::Streaming
+                }
+            },
             v => v,
         };
 
         if engine != Engine::Streaming
             && std::env::var("POLARS_AUTO_STREAMING").as_deref() == Ok("1")
         {
+            self.opt_state |= OptFlags::AUTO_SELECTED_STREAMING;
+
             feature_gated!("streaming", {
                 if let Some(r) = self.clone()._collect_with_streaming_suppress_todo_panic() {
                     return r;

--- a/crates/polars-lazy/src/lib.rs
+++ b/crates/polars-lazy/src/lib.rs
@@ -146,7 +146,7 @@
 //!         col("column_a")
 //!         // apply a custom closure Series => Result<Series>
 //!         .map(
-//!             |_s| Ok(Column::new("".into(), &[6.0f32, 6.0, 6.0, 6.0, 6.0])),
+//!             |c| c.clone() + c,
 //!             // return type of the closure
 //!             |_, f| Ok(Field::new(f.name().clone(), DataType::Float64))
 //!         ).alias("new_column"),

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -280,7 +280,7 @@ fn test_lazy_query_4() -> PolarsResult<()> {
 
     let out = base_df
         .clone()
-        .group_by([col("uid")])
+        .group_by_stable([col("uid")])
         .agg([
             col("day").alias("day"),
             col("cumcases")
@@ -1883,15 +1883,10 @@ fn test_partitioned_gb_mean() -> PolarsResult<()> {
     .lazy()
     .with_columns([lit("a").alias("str"), lit(1).alias("int")])
     .group_by([col("key")])
-    .agg([
-        col("str").mean().alias("mean_str"),
-        col("int").mean().alias("mean_int"),
-    ])
+    .agg([col("int").mean().alias("mean_int")])
     .collect()?;
 
-    assert_eq!(out.shape(), (1, 3));
-    let str_col = out.column("mean_str")?;
-    assert_eq!(str_col.get(0)?, AnyValue::Null);
+    assert_eq!(out.shape(), (1, 2));
     let int_col = out.column("mean_int")?;
     assert_eq!(int_col.get(0)?, AnyValue::Float64(1.0));
 

--- a/crates/polars-plan/src/frame/opt_state.rs
+++ b/crates/polars-plan/src/frame/opt_state.rs
@@ -1,5 +1,13 @@
 use bitflags::bitflags;
 
+const DEFAULT_OPT_FLAGS: OptFlags = OptFlags::from_bits_truncate(
+    OptFlags::all().bits()
+        & !(OptFlags::STREAMING.bits()
+            | OptFlags::EAGER.bits()
+            | OptFlags::GPU.bits()
+            | OptFlags::AUTO_SELECTED_STREAMING.bits()),
+);
+
 bitflags! {
 #[derive(Copy, Clone, Debug)]
     /// Allowed optimizations.
@@ -39,6 +47,9 @@ bitflags! {
         const CHECK_ORDER_OBSERVE = 1 << 15;
         /// Collapse consecutive sort nodes and pull them up through selecting nodes.
         const SORT_COLLAPSE = 1 << 16;
+        /// The streaming engine was selected automatically. Used in DSl->IR conversion to maintain
+        /// behavior of in-memory engine (e.g. forcing joins to maintain order).
+        const AUTO_SELECTED_STREAMING = 1 << 17;
     }
 }
 
@@ -81,7 +92,7 @@ impl OptFlags {
 
 impl Default for OptFlags {
     fn default() -> Self {
-        Self::from_bits_truncate(u32::MAX) & !Self::STREAMING & !Self::EAGER & !Self::GPU
+        DEFAULT_OPT_FLAGS
     }
 }
 

--- a/crates/polars-plan/src/plans/optimizer/force_maintain_order_join.rs
+++ b/crates/polars-plan/src/plans/optimizer/force_maintain_order_join.rs
@@ -1,0 +1,32 @@
+use std::sync::Arc;
+
+use polars_error::PolarsResult;
+use polars_ops::frame::MaintainOrderJoin;
+
+use crate::plans::{IR, OptimizationRule};
+
+pub struct ForceMaintainOrderJoin;
+
+impl OptimizationRule for ForceMaintainOrderJoin {
+    fn optimize_plan(
+        &mut self,
+        ir_arena: &mut polars_utils::arena::Arena<IR>,
+        _expr_arena: &mut polars_utils::arena::Arena<crate::prelude::AExpr>,
+        node: polars_utils::arena::Node,
+    ) -> PolarsResult<Option<IR>> {
+        let IR::Join { options, .. } = ir_arena.get_mut(node) else {
+            return Ok(None);
+        };
+
+        let maintain_order = match options.args.maintain_order {
+            MaintainOrderJoin::None => MaintainOrderJoin::LeftRight,
+            MaintainOrderJoin::Left => MaintainOrderJoin::LeftRight,
+            MaintainOrderJoin::Right => MaintainOrderJoin::RightLeft,
+            MaintainOrderJoin::LeftRight | MaintainOrderJoin::RightLeft => return Ok(None),
+        };
+
+        Arc::make_mut(options).args.maintain_order = maintain_order;
+
+        Ok(Some(ir_arena.take(node)))
+    }
+}

--- a/crates/polars-plan/src/plans/optimizer/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/mod.rs
@@ -1,6 +1,7 @@
 use polars_core::prelude::*;
 use polars_error::feature_gated;
 
+use crate::plans::optimizer::force_maintain_order_join::ForceMaintainOrderJoin;
 use crate::plans::optimizer::parquet_metadata_prune::prune_parquet_metadata;
 use crate::plans::optimizer::projection_pushdown::projection_pushdown;
 use crate::prelude::*;
@@ -15,6 +16,7 @@ mod cse;
 #[cfg(feature = "merge_sorted")]
 mod flatten_merge_sorted;
 mod flatten_union;
+mod force_maintain_order_join;
 #[cfg(feature = "fused")]
 mod fused;
 mod join_utils;
@@ -133,6 +135,10 @@ pub fn optimize(
         () => {
             _get_or_init_members(_opt_members, root, ir_arena, expr_arena)
         };
+    }
+
+    if opt_flags.contains(OptFlags::AUTO_SELECTED_STREAMING) {
+        rules.push(Box::new(ForceMaintainOrderJoin));
     }
 
     // Run before slice pushdown

--- a/crates/polars-python/src/lazyframe/optflags.rs
+++ b/crates/polars-python/src/lazyframe/optflags.rs
@@ -62,5 +62,6 @@ flag_getter_setters! {
 
     (EAGER, get_eager, set_eager, clear=true)
     (STREAMING, get_streaming, set_streaming, clear=true)
+    (AUTO_SELECTED_STREAMING, get_auto_selected_streaming, set_auto_selected_streaming, clear=true)
     (GPU, get_gpu, set_gpu, clear=true)
 }

--- a/crates/polars-sql/Cargo.toml
+++ b/crates/polars-sql/Cargo.toml
@@ -14,6 +14,7 @@ polars-error = { workspace = true }
 polars-lazy = { workspace = true, features = ["abs", "binary_encoding", "concat_str", "cov", "cross_join", "cum_agg", "dtype-array", "dtype-date", "dtype-decimal", "dtype-struct", "is_in", "list_eval", "log", "meta", "offset_by", "range", "regex", "round_series", "sign", "string_normalize", "string_pad", "string_reverse", "strings", "timezones", "trigonometry"] }
 polars-ops = { workspace = true }
 polars-plan = { workspace = true }
+polars-testing = { workspace = true }
 polars-time = { workspace = true }
 polars-utils = { workspace = true }
 

--- a/crates/polars-sql/tests/functions_aggregate.rs
+++ b/crates/polars-sql/tests/functions_aggregate.rs
@@ -2,6 +2,7 @@ use polars_core::prelude::*;
 use polars_lazy::prelude::*;
 use polars_plan::dsl::Expr;
 use polars_sql::*;
+use polars_testing::asserts::assert_dataframe_equal;
 
 fn create_df() -> LazyFrame {
     df! {
@@ -148,12 +149,12 @@ fn test_corr() {
     let sql = r#"
     SELECT
         CORR(a, b) as corr,
-        COVAR(a, b) as covar,
-        COVAR_POP(a, b) as covar_pop
+        COVAR(a, b) as cov,
+        COVAR_POP(a, b) as cov_pop
     FROM df"#;
     let actual = ctx.execute(sql).unwrap().collect().unwrap();
 
-    assert_eq!(expected, actual, "expected {expected:?}, got {actual:?}");
+    assert_dataframe_equal(&actual, &expected, Default::default()).unwrap();
 }
 
 #[test]
@@ -177,11 +178,11 @@ fn test_corr_group_by() {
     SELECT
         c,
         CORR(a, b) AS corr,
-        COVAR(a, b) AS covar
+        COVAR(a, b) AS cov
     FROM df
     GROUP BY c
     ORDER BY c"#;
     let actual = ctx.execute(sql).unwrap().collect().unwrap();
 
-    assert_eq!(expected, actual, "expected {expected:?}, got {actual:?}");
+    assert_dataframe_equal(&actual, &expected, Default::default()).unwrap();
 }

--- a/crates/polars-sql/tests/statements.rs
+++ b/crates/polars-sql/tests/statements.rs
@@ -1,6 +1,7 @@
 use polars_core::prelude::*;
 use polars_lazy::prelude::*;
 use polars_sql::*;
+use polars_testing::asserts::{DataFrameEqualOptions, assert_dataframe_equal};
 
 fn create_ctx() -> SQLContext {
     let a = Column::new("a".into(), (1..10i64).map(|i| i / 100).collect::<Vec<_>>());
@@ -158,7 +159,13 @@ fn test_union_all() {
     .unwrap();
 
     let actual = ctx.execute(sql).unwrap().collect().unwrap();
-    assert!(actual.equals(&expected));
+
+    assert_dataframe_equal(
+        &actual,
+        &expected,
+        DataFrameEqualOptions::new().with_check_row_order(false),
+    )
+    .unwrap();
 }
 
 #[test]

--- a/crates/polars-stream/src/physical_plan/lower_group_by.rs
+++ b/crates/polars-stream/src/physical_plan/lower_group_by.rs
@@ -1215,113 +1215,128 @@ pub fn build_group_by_stream(
     ctx: StreamingLowerIRContext<'_>,
     are_keys_sorted: bool,
 ) -> PolarsResult<PhysStream> {
-    #[cfg(feature = "dynamic_group_by")]
-    if let Some(rolling_options) = options.as_ref().rolling.as_ref()
-        && keys.is_empty()
-        && apply.is_none()
-    {
-        let mut input = PhysStream::first(
-            phys_sm.insert(PhysNode::new(
-                output_schema.clone(),
-                PhysNodeKind::RollingGroupBy {
-                    input,
-                    index_column: rolling_options.index_column.clone(),
-                    period: rolling_options.period,
-                    offset: rolling_options.offset,
-                    closed: rolling_options.closed_window,
-                    slice: options
-                        .slice
-                        .filter(|(o, _)| *o >= 0)
-                        .map(|(o, l)| (o as IdxSize, l as IdxSize)),
-                    aggs: aggs.to_vec(),
-                },
-            )),
-        );
-        if let Some((offset, length)) = options.slice.as_ref().filter(|(o, _)| *o < 0) {
-            input = build_slice_stream(input, *offset, *length, phys_sm);
+    'build_streaming_group_by: {
+        // Fallback to in-mem for objects. Otherwise we get an error in CI:
+        //   FAILED tests/unit/dataframe/test_df.py::test_hashing_on_python_objects
+        //   pyo3_runtime.PanicException: Unsupported in row encoding
+        if input
+            .output_schema(phys_sm)
+            .iter_values()
+            .any(|dtype| dtype.contains_objects())
+        {
+            break 'build_streaming_group_by;
         }
-        return Ok(input);
-    } else if let Some(dynamic_options) = options.as_ref().dynamic.as_ref()
-        && keys.is_empty()
-        && apply.is_none()
-    {
-        let mut input = PhysStream::first(
-            phys_sm.insert(PhysNode::new(
-                output_schema.clone(),
-                PhysNodeKind::DynamicGroupBy {
-                    input,
-                    options: dynamic_options.clone(),
-                    aggs: aggs.to_vec(),
-                    slice: options
-                        .slice
-                        .filter(|(o, _)| *o >= 0)
-                        .map(|(o, l)| (o as IdxSize, l as IdxSize)),
-                },
-            )),
-        );
-        if let Some((offset, length)) = options.slice.as_ref().filter(|(o, _)| *o < 0) {
-            input = build_slice_stream(input, *offset, *length, phys_sm);
-        }
-        return Ok(input);
-    }
 
-    if (are_keys_sorted || std::env::var("POLARS_FORCE_SORTED_GROUP_BY").is_ok_and(|v| v == "1"))
-        && let Some(stream) = try_build_sorted_group_by(
+        #[cfg(feature = "dynamic_group_by")]
+        if let Some(rolling_options) = options.as_ref().rolling.as_ref()
+            && keys.is_empty()
+            && apply.is_none()
+        {
+            let mut input = PhysStream::first(
+                phys_sm.insert(PhysNode::new(
+                    output_schema.clone(),
+                    PhysNodeKind::RollingGroupBy {
+                        input,
+                        index_column: rolling_options.index_column.clone(),
+                        period: rolling_options.period,
+                        offset: rolling_options.offset,
+                        closed: rolling_options.closed_window,
+                        slice: options
+                            .slice
+                            .filter(|(o, _)| *o >= 0)
+                            .map(|(o, l)| (o as IdxSize, l as IdxSize)),
+                        aggs: aggs.to_vec(),
+                    },
+                )),
+            );
+            if let Some((offset, length)) = options.slice.as_ref().filter(|(o, _)| *o < 0) {
+                input = build_slice_stream(input, *offset, *length, phys_sm);
+            }
+            return Ok(input);
+        } else if let Some(dynamic_options) = options.as_ref().dynamic.as_ref()
+            && keys.is_empty()
+            && apply.is_none()
+        {
+            let mut input = PhysStream::first(
+                phys_sm.insert(PhysNode::new(
+                    output_schema.clone(),
+                    PhysNodeKind::DynamicGroupBy {
+                        input,
+                        options: dynamic_options.clone(),
+                        aggs: aggs.to_vec(),
+                        slice: options
+                            .slice
+                            .filter(|(o, _)| *o >= 0)
+                            .map(|(o, l)| (o as IdxSize, l as IdxSize)),
+                    },
+                )),
+            );
+            if let Some((offset, length)) = options.slice.as_ref().filter(|(o, _)| *o < 0) {
+                input = build_slice_stream(input, *offset, *length, phys_sm);
+            }
+            return Ok(input);
+        }
+
+        return if (are_keys_sorted
+            || std::env::var("POLARS_FORCE_SORTED_GROUP_BY").is_ok_and(|v| v == "1"))
+            && let Some(stream) = try_build_sorted_group_by(
+                input,
+                keys,
+                aggs,
+                output_schema.clone(),
+                maintain_order,
+                options.clone(),
+                apply.clone(),
+                expr_arena,
+                phys_sm,
+                expr_cache,
+                ctx,
+                are_keys_sorted,
+            )? {
+            Ok(stream)
+        } else if let Some(stream) = try_build_streaming_group_by(
             input,
             keys,
             aggs,
-            output_schema.clone(),
             maintain_order,
             options.clone(),
             apply.clone(),
+            GroupByLowerKind::Groups,
             expr_arena,
             phys_sm,
             expr_cache,
             ctx,
-            are_keys_sorted,
-        )?
-    {
-        Ok(stream)
-    } else if let Some(stream) = try_build_streaming_group_by(
+        )? {
+            Ok(stream)
+        } else {
+            break 'build_streaming_group_by;
+        };
+    }
+
+    let format_str = ctx.prepare_visualization.then(|| {
+        let mut buffer = String::new();
+        write_group_by(
+            &mut buffer,
+            0,
+            expr_arena,
+            keys,
+            aggs,
+            apply.as_ref(),
+            maintain_order,
+        )
+        .unwrap();
+        buffer
+    });
+    build_group_by_fallback(
         input,
         keys,
         aggs,
+        output_schema,
         maintain_order,
-        options.clone(),
-        apply.clone(),
-        GroupByLowerKind::Groups,
+        options,
+        apply,
         expr_arena,
         phys_sm,
-        expr_cache,
-        ctx,
-    )? {
-        Ok(stream)
-    } else {
-        let format_str = ctx.prepare_visualization.then(|| {
-            let mut buffer = String::new();
-            write_group_by(
-                &mut buffer,
-                0,
-                expr_arena,
-                keys,
-                aggs,
-                apply.as_ref(),
-                maintain_order,
-            )
-            .unwrap();
-            buffer
-        });
-        build_group_by_fallback(
-            input,
-            keys,
-            aggs,
-            output_schema,
-            maintain_order,
-            options,
-            apply,
-            expr_arena,
-            phys_sm,
-            format_str,
-        )
-    }
+        format_str,
+    )
 }

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -191,6 +191,23 @@ pub fn lower_ir(
 
     let ir_node = ir_arena.get(node);
     let output_schema = IR::schema_with_cache(node, ir_arena, schema_cache);
+
+    // IR::ExtContext fallback. This must dispatch the IR node directly on top of the ExtContext
+    // into the in-memory engine, as that performs the selection of columns.
+    if ir_node
+        .inputs()
+        .any(|node| matches!(ir_arena.get(node), IR::ExtContext { .. }))
+    {
+        return lower_subtree_to_inmem_engine(
+            node,
+            output_schema,
+            ir_arena,
+            expr_arena,
+            phys_sm,
+            ctx,
+        );
+    }
+
     let node_kind = match ir_node {
         IR::SimpleProjection { input, columns } => {
             disable_morsel_split.get_or_insert(true);
@@ -818,7 +835,16 @@ pub fn lower_ir(
 
                     FileScanIR::ExpandedPaths { name: _ } => unreachable!(),
 
-                    FileScanIR::Anonymous { .. } => todo!("unimplemented: AnonymousScan"),
+                    FileScanIR::Anonymous { .. } => {
+                        return lower_subtree_to_inmem_engine(
+                            node,
+                            output_schema,
+                            ir_arena,
+                            expr_arena,
+                            phys_sm,
+                            ctx,
+                        );
+                    },
                 };
 
                 {
@@ -1621,7 +1647,8 @@ pub fn lower_ir(
 
             return Ok(stream);
         },
-        IR::ExtContext { .. } => todo!(),
+        // Cannot execute IR::ExtContext as the root node.
+        IR::ExtContext { .. } => panic!(),
         IR::UnoptimizedDispatch {
             inputs,
             arg_map,
@@ -1856,4 +1883,57 @@ fn append_sorted_key_column(
         (phys_input, None)
     };
     Ok((phys_output, key_exprs, key_col_name))
+}
+
+/// Lowers the IR tree rooted at `ir_node` to the in-memory engine.
+fn lower_subtree_to_inmem_engine(
+    ir_node: Node,
+    ir_node_output_schema: Arc<Schema>,
+    ir_arena: &mut Arena<IR>,
+    expr_arena: &mut Arena<AExpr>,
+    phys_sm: &mut SlotMap<PhysNodeKey, PhysNode>,
+    ctx: StreamingLowerIRContext<'_>,
+) -> PolarsResult<PhysStream> {
+    let mem_engine_executor = create_physical_plan(
+        ir_node,
+        ir_arena,
+        expr_arena,
+        Some(crate::dispatch::build_streaming_query_executor),
+    )?;
+
+    let input = phys_sm.insert(PhysNode::new(
+        Arc::new(Default::default()),
+        PhysNodeKind::InMemorySource {
+            df: Arc::new(DataFrame::empty_with_height(1)),
+            disable_morsel_split: true,
+        },
+    ));
+
+    let format_str = ctx.prepare_visualization.then(|| {
+        format!(
+            "{}",
+            IRPlanRef {
+                lp_top: ir_node,
+                lp_arena: ir_arena,
+                expr_arena,
+            }
+            .display()
+        )
+    });
+
+    let exec = parking_lot::Mutex::new(Some(mem_engine_executor));
+
+    Ok(PhysStream::first(phys_sm.insert(PhysNode::new(
+        ir_node_output_schema,
+        PhysNodeKind::InMemoryMap {
+            input: PhysStream::first(input),
+            map: Arc::new(move |_| {
+                exec.lock()
+                    .take()
+                    .unwrap()
+                    .execute(&mut ExecutionState::new())
+            }),
+            format_str,
+        },
+    ))))
 }

--- a/crates/polars-testing/Cargo.toml
+++ b/crates/polars-testing/Cargo.toml
@@ -10,7 +10,7 @@ description = "Testing suite for the Polars DataFrame library"
 
 [dependencies]
 polars-core = { workspace = true, features = ["dtype-array", "dtype-categorical", "dtype-struct"] }
-polars-ops = { workspace = true, features = ["abs", "is_close"] }
+polars-ops = { workspace = true, features = ["abs", "dtype-categorical", "is_close"] }
 
 [lints]
 workspace = true

--- a/crates/polars/tests/it/lazy/projection_queries.rs
+++ b/crates/polars/tests/it/lazy/projection_queries.rs
@@ -61,19 +61,19 @@ fn test_full_outer_join_with_column_2988() -> PolarsResult<()> {
     assert_eq!(out.get_column_names(), &["key1", "key2", "val1", "val2"]);
     assert_eq!(
         Vec::from(out.column("key1")?.str()?),
-        &[Some("bar"), Some("baz"), Some("foo")]
+        &[Some("foo"), Some("bar"), Some("baz")]
     );
     assert_eq!(
         Vec::from(out.column("key2")?.str()?),
-        &[Some("bar"), Some("baz"), Some("foo")]
+        &[Some("foo"), Some("bar"), Some("baz")]
     );
     assert_eq!(
         Vec::from(out.column("val1")?.i32()?),
-        &[Some(1), None, Some(3)]
+        &[Some(3), Some(1), None]
     );
     assert_eq!(
         Vec::from(out.column("val2")?.i32()?),
-        &[Some(6), Some(8), None]
+        &[None, Some(6), Some(8)]
     );
 
     Ok(())

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -73,7 +73,7 @@ test: .venv build  ## Run fast unittests
 
 .PHONY: test-streaming
 test-streaming: .venv build  ## Run fast unittests with the streaming engine
-	POLARS_TIMEOUT_MS=60000 POLARS_AUTO_STREAMING=1 $(VENV_BIN)/pytest -n auto -m "not may_fail_auto_streaming and not docs and not benchmark and not ci_only" $(PYTEST_ARGS)
+	POLARS_TIMEOUT_MS=60000 POLARS_FORCE_STREAMING=1 $(VENV_BIN)/pytest -n auto -m "not may_fail_auto_streaming and not docs and not benchmark and not ci_only" $(PYTEST_ARGS)
 
 .PHONY: test-all
 test-all: .venv build  ## Run all tests

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -6317,17 +6317,14 @@ class DataFrame:
         """
         from polars.lazyframe.opt_flags import QueryOptFlags
 
+        optimizations = QueryOptFlags._eager()
+        optimizations.slice_pushdown = True
+        optimizations.predicate_pushdown = True
+
         return (
             self.lazy()
             .top_k(k, by=by, reverse=reverse)
-            .collect(
-                optimizations=QueryOptFlags(
-                    projection_pushdown=False,
-                    predicate_pushdown=False,
-                    comm_subplan_elim=False,
-                    slice_pushdown=True,
-                )
-            )
+            .collect(optimizations=optimizations)
         )
 
     @deprecate_renamed_parameter("descending", "reverse", version="1.0.0")
@@ -6406,17 +6403,14 @@ class DataFrame:
         """
         from polars.lazyframe.opt_flags import QueryOptFlags
 
+        optimizations = QueryOptFlags._eager()
+        optimizations.slice_pushdown = True
+        optimizations.predicate_pushdown = True
+
         return (
             self.lazy()
             .bottom_k(k, by=by, reverse=reverse)
-            .collect(
-                optimizations=QueryOptFlags(
-                    projection_pushdown=False,
-                    predicate_pushdown=False,
-                    comm_subplan_elim=False,
-                    slice_pushdown=True,
-                )
-            )
+            .collect(optimizations=optimizations)
         )
 
     def equals(self, other: DataFrame, *, null_equal: bool = True) -> bool:

--- a/py-polars/src/polars/dataframe/group_by.py
+++ b/py-polars/src/polars/dataframe/group_by.py
@@ -372,7 +372,7 @@ class GroupBy:
         return (
             self._lgb()
             .agg(*aggs, **named_aggs)
-            .collect(optimizations=QueryOptFlags.none())
+            .collect(optimizations=QueryOptFlags._eager())
         )
 
     def map_groups(self, function: Callable[[DataFrame], DataFrame]) -> DataFrame:
@@ -1046,7 +1046,7 @@ class RollingGroupBy:
             group_by = group_by.having(self.predicates)
 
         return group_by.agg(*aggs, **named_aggs).collect(
-            optimizations=QueryOptFlags.none()
+            optimizations=QueryOptFlags._eager()
         )
 
     def map_groups(
@@ -1232,7 +1232,7 @@ class DynamicGroupBy:
             group_by = group_by.having(self.predicates)
 
         return group_by.agg(*aggs, **named_aggs).collect(
-            optimizations=QueryOptFlags.none()
+            optimizations=QueryOptFlags._eager()
         )
 
     def map_groups(

--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -23,6 +23,7 @@ from polars._utils.various import (
     qualified_type_name,
 )
 from polars._utils.wrap import wrap_df, wrap_ldf
+from polars._warnings import issue_warning
 from polars.datatypes import N_INFER_DEFAULT, String, parse_into_dtype
 from polars.io._utils import (
     is_glob_pattern,
@@ -1381,6 +1382,14 @@ def scan_csv(
     │ 4   ┆ read │
     └─────┴──────┘
     """
+    if rechunk:
+        issue_warning(
+            "rechunk=True no longer has effect on scan_csv(). "
+            "Consider first collecting the scan to a DataFrame, then calling "
+            "df.rechunk() on the result.",
+            category=UserWarning,
+        )
+
     if schema_overrides is not None and not isinstance(
         schema_overrides, (dict, Sequence)
     ):

--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -492,10 +492,7 @@ def read_csv(
     schema_overrides_is_list = isinstance(schema_overrides, Sequence)
     encoding_supported_in_lazy = encoding in {"utf8", "utf8-lossy"}
 
-    streaming = (
-        os.getenv("POLARS_FORCE_STREAMING") == "1"
-        or os.getenv("POLARS_AUTO_STREAMING") == "1"
-    )
+    streaming = os.getenv("POLARS_FORCE_STREAMING") == "1"
 
     if streaming or (
         # Check that it is not a BytesIO object

--- a/py-polars/src/polars/io/ipc/functions.py
+++ b/py-polars/src/polars/io/ipc/functions.py
@@ -17,6 +17,7 @@ from polars._utils.various import (
     normalize_filepath,
 )
 from polars._utils.wrap import wrap_df, wrap_ldf
+from polars._warnings import issue_warning
 from polars.io._utils import (
     get_sources,
     is_glob_pattern,
@@ -138,7 +139,6 @@ def read_ipc(
             storage_options=storage_options,
             row_index_name=row_index_name,
             row_index_offset=row_index_offset,
-            rechunk=rechunk,
         )
 
         if columns:
@@ -148,6 +148,9 @@ def read_ipc(
                 lf = lf.select(columns)
 
         df = lf.collect()
+
+        if rechunk:
+            df = df.rechunk()
 
         return df
 
@@ -206,7 +209,6 @@ def _read_ipc_impl(
         scan = scan_ipc(
             source,
             n_rows=n_rows,
-            rechunk=rechunk,
             row_index_name=row_index_name,
             row_index_offset=row_index_offset,
         )
@@ -220,6 +222,10 @@ def _read_ipc_impl(
                 "\n\nUse columns: List[str]"
             )
             raise TypeError(msg)
+
+        if rechunk:
+            df = df.rechunk()
+
         return df
 
     projection, columns = parse_columns_arg(columns)
@@ -489,6 +495,14 @@ def scan_ipc(
     """
     # Memory Mapping is now a no-op
     _ = memory_map
+
+    if rechunk:
+        issue_warning(
+            "rechunk=True no longer has effect on scan_ipc(). "
+            "Consider first collecting the scan to a DataFrame, then calling "
+            "df.rechunk() on the result.",
+            category=UserWarning,
+        )
 
     sources = get_sources(source)
 

--- a/py-polars/src/polars/io/ndjson.py
+++ b/py-polars/src/polars/io/ndjson.py
@@ -10,6 +10,7 @@ from polars._utils.deprecation import (
 )
 from polars._utils.various import is_path_or_str_sequence, normalize_filepath
 from polars._utils.wrap import wrap_ldf
+from polars._warnings import issue_warning
 from polars.datatypes import N_INFER_DEFAULT
 from polars.io._utils import parse_row_index_args
 from polars.io.cloud.credential_provider._builder import (
@@ -300,6 +301,14 @@ def scan_ndjson(
     include_file_paths
         Include the path of the source file(s) as a column with this name.
     """
+    if rechunk:
+        issue_warning(
+            "rechunk=True no longer has effect on scan_ndjson(). "
+            "Consider first collecting the scan to a DataFrame, then calling "
+            "df.rechunk() on the result.",
+            category=UserWarning,
+        )
+
     sources: list[str] | list[Path] | list[IO[str]] | list[IO[bytes]] = []
     if isinstance(source, (str, Path)):
         source = normalize_filepath(source, check_not_directory=False)

--- a/py-polars/src/polars/io/parquet/functions.py
+++ b/py-polars/src/polars/io/parquet/functions.py
@@ -18,6 +18,7 @@ from polars._utils.various import (
     normalize_filepath,
 )
 from polars._utils.wrap import wrap_ldf
+from polars._warnings import issue_warning
 from polars.convert import from_arrow
 from polars.io._utils import (
     get_sources,
@@ -242,7 +243,8 @@ def read_parquet(
                 "\n\nHint: Pass `pyarrow_options` instead with a 'partitioning' entry."
             )
             raise TypeError(msg)
-        return _read_parquet_with_pyarrow(
+
+        ret = _read_parquet_with_pyarrow(
             source,
             columns=columns,
             storage_options=storage_options,
@@ -250,6 +252,8 @@ def read_parquet(
             memory_map=memory_map,
             rechunk=rechunk,
         )
+
+        return ret
 
     if allow_missing_columns is not None:
         issue_deprecation_warning(
@@ -273,7 +277,6 @@ def read_parquet(
         schema=schema,
         hive_schema=hive_schema,
         try_parse_hive_dates=try_parse_hive_dates,
-        rechunk=rechunk,
         low_memory=low_memory,
         cache=False,
         storage_options=storage_options,
@@ -290,7 +293,12 @@ def read_parquet(
         else:
             lf = lf.select(columns)
 
-    return lf.collect()
+    ret = lf.collect()
+
+    if rechunk:
+        ret = ret.rechunk()
+
+    return ret
 
 
 def _read_parquet_with_pyarrow(
@@ -661,6 +669,14 @@ def scan_parquet(
     ... }
     >>> pl.scan_parquet(source, storage_options=storage_options)  # doctest: +SKIP
     """
+    if rechunk:
+        issue_warning(
+            "rechunk=True no longer has effect on scan_parquet(). "
+            "Consider first collecting the scan to a DataFrame, then calling "
+            "df.rechunk() on the result.",
+            category=UserWarning,
+        )
+
     if schema is not None:
         msg = "the `schema` parameter of `scan_parquet` is considered unstable."
         issue_unstable_warning(msg)

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -1926,7 +1926,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         Get the rows which contain the 4 largest values in column b.
 
-        >>> lf.top_k(4, by="b").collect()
+        >>> lf.top_k(4, by="b").collect()  # doctest: +SKIP
         shape: (4, 2)
         ┌─────┬─────┐
         │ a   ┆ b   │
@@ -2004,7 +2004,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         Get the rows which contain the 4 smallest values in column b.
 
-        >>> lf.bottom_k(4, by="b").collect()
+        >>> lf.bottom_k(4, by="b").collect()  # doctest: +SKIP
         shape: (4, 2)
         ┌─────┬─────┐
         │ a   ┆ b   │
@@ -2019,7 +2019,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         Get the rows which contain the 4 smallest values when sorting on column a and b.
 
-        >>> lf.bottom_k(4, by=["a", "b"]).collect()
+        >>> lf.bottom_k(4, by=["a", "b"]).collect()  # doctest: +SKIP
         shape: (4, 2)
         ┌─────┬─────┐
         │ a   ┆ b   │
@@ -2483,9 +2483,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
             * ``"auto"``: use the engine set by
               :meth:`Config.set_engine_affinity <polars.Config.set_engine_affinity>`
-              or the ``POLARS_ENGINE_AFFINITY`` environment variable, falling
-              back to ``"in-memory"`` if unset (this default may change in
-              a future release).
+              or the ``POLARS_ENGINE_AFFINITY`` environment variable. Otherwise
+              defaults to the streaming engine.
             * ``"in-memory"``: use the in-memory engine, this is the default engine.
             * ``"streaming"``: use the streaming engine, which processes
               queries in batches, reducing memory pressure and often
@@ -2677,9 +2676,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
             * ``"auto"``: use the engine set by
               :meth:`Config.set_engine_affinity <polars.Config.set_engine_affinity>`
-              or the ``POLARS_ENGINE_AFFINITY`` environment variable, falling
-              back to ``"in-memory"`` if unset (this default may change in
-              a future release).
+              or the ``POLARS_ENGINE_AFFINITY`` environment variable. Otherwise
+              defaults to the streaming engine..
             * ``"in-memory"``: use the in-memory engine, this is the default engine.
             * ``"streaming"``: use the streaming engine, which processes
               queries in batches, reducing memory pressure and often
@@ -6472,8 +6470,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ╞══════╪══════╪══════╪═══════╪═══════════╡
         │ 1    ┆ 6.0  ┆ a    ┆ x     ┆ a         │
         │ 2    ┆ 7.0  ┆ b    ┆ y     ┆ b         │
-        │ null ┆ null ┆ null ┆ z     ┆ d         │
         │ 3    ┆ 8.0  ┆ c    ┆ null  ┆ null      │
+        │ null ┆ null ┆ null ┆ z     ┆ d         │
         └──────┴──────┴──────┴───────┴───────────┘
         >>> lf.join(other_lf, on="ham", how="left", coalesce=True).collect()
         shape: (3, 4)
@@ -8801,7 +8799,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...     }
         ... )
         >>> import polars.selectors as cs
-        >>> lf.unpivot(cs.numeric(), index="a").collect()
+        >>> result = lf.unpivot(cs.numeric(), index="a").collect()
+        >>> result.sort("*")
         shape: (6, 3)
         ┌─────┬──────────┬───────┐
         │ a   ┆ variable ┆ value │
@@ -8809,10 +8808,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ str ┆ str      ┆ i64   │
         ╞═════╪══════════╪═══════╡
         │ x   ┆ b        ┆ 1     │
-        │ y   ┆ b        ┆ 3     │
-        │ z   ┆ b        ┆ 5     │
         │ x   ┆ c        ┆ 2     │
+        │ y   ┆ b        ┆ 3     │
         │ y   ┆ c        ┆ 4     │
+        │ z   ┆ b        ┆ 5     │
         │ z   ┆ c        ┆ 6     │
         └─────┴──────────┴───────┘
         """

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1833,7 +1833,6 @@ def test_hash_collision_multiple_columns_equal_values_15390(e: pl.Expr) -> None:
         assert max_bucket_size == 1
 
 
-@pytest.mark.may_fail_auto_streaming  # Python objects not yet supported in row encoding
 @pytest.mark.may_fail_cloud
 def test_hashing_on_python_objects() -> None:
     # see if we can do a group_by, drop_duplicates on a DataFrame with objects.

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2144,7 +2144,7 @@ def test_read_csv_invalid_schema_overrides_length(chunk_override: None) -> None:
     f = io.StringIO(csv)
 
     # streaming dispatches read_csv -> _scan_csv_impl which does not accept a list
-    if os.getenv("POLARS_AUTO_STREAMING", os.getenv("POLARS_FORCE_STREAMING")) == "1":
+    if os.getenv("POLARS_FORCE_STREAMING") == "1":
         err = TypeError
         match = "expected 'schema_overrides' dict, found 'list'"
     else:

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -109,7 +109,6 @@ def test_hive_partitioned_predicate_pushdown_single_threaded_async_17155(
 
 
 @pytest.mark.write_disk
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.may_fail_cloud  # reason: inspects logs
 def test_hive_partitioned_predicate_pushdown_skips_correct_number_of_files(
     tmp_path: Path, plmonkeypatch: PlMonkeyPatch, capfd: Any

--- a/py-polars/tests/unit/io/test_io_plugin.py
+++ b/py-polars/tests/unit/io/test_io_plugin.py
@@ -63,7 +63,9 @@ def test_defer_validate_false() -> None:
         schema={"a": pl.Boolean},
         validate_schema=False,
     )
-    assert lf.collect().to_dict(as_series=False) == {"a": [1.0, 1.0, 1.0]}
+    assert lf.collect(engine="in-memory").to_dict(as_series=False) == {
+        "a": [1.0, 1.0, 1.0]
+    }
 
 
 def test_empty_iterator_io_plugin() -> None:
@@ -135,16 +137,17 @@ This allows it to read into multiple rows.
 
 
 @pytest.mark.may_fail_cloud
-@pytest.mark.may_fail_auto_streaming  # IO plugin validate=False schema mismatch
 def test_datetime_io_predicate_pushdown_21790() -> None:
     recorded: dict[str, pl.Expr | None] = {"predicate": None}
+    schema = {"timestamp": pl.Datetime(time_unit="ns")}
     df = pl.DataFrame(
         {
             "timestamp": [
                 datetime.datetime(2024, 1, 1, 0),
                 datetime.datetime(2024, 1, 3, 0),
             ]
-        }
+        },
+        schema=schema,
     )
 
     def _source(
@@ -163,7 +166,6 @@ def test_datetime_io_predicate_pushdown_21790() -> None:
 
         yield inner_df
 
-    schema = {"timestamp": pl.Datetime(time_unit="ns")}
     lf = register_io_source(io_source=_source, schema=schema)
 
     cutoff = datetime.datetime(2024, 1, 4)

--- a/py-polars/tests/unit/io/test_multiscan.py
+++ b/py-polars/tests/unit/io/test_multiscan.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import re
 import sys
+import warnings
 from functools import partial
 from typing import IO, TYPE_CHECKING, Any
 
@@ -946,3 +947,37 @@ def test_hive_predicate_filtering_edge_case_25630(
         schema={"index": pl.get_index_type()},
     )
     assert_frame_equal(res, expected)
+
+
+@pytest.mark.parametrize(("scan", "write"), SCAN_AND_WRITE_FUNCS)
+def test_warn_on_scan_with_requested_rechunk(
+    scan: Callable[..., pl.LazyFrame], write: Callable[[pl.DataFrame, Any], Any]
+) -> None:
+    f = io.BytesIO()
+    write(pl.DataFrame({"x": 1}), f)
+
+    with pytest.raises(
+        UserWarning,
+        match=f"rechunk=True no longer has effect.*{scan.__name__}",
+    ):
+        scan(f, rechunk=True)
+
+
+@pytest.mark.may_fail_auto_streaming
+def test_scan_rechunk_arg() -> None:
+    df = pl.DataFrame({"x": [0, 1, 2, 3, 4]})
+    f = io.BytesIO()
+
+    df.write_parquet(f, row_group_size=1)
+
+    assert pl.scan_parquet(f).collect().n_chunks() == 5
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+
+        # Parameter is ignored / unsupported on the streaming engine.
+        assert (
+            pl.scan_parquet(f, rechunk=True).collect(engine="streaming").n_chunks() != 1
+        )
+
+        assert pl.scan_parquet(f, rechunk=True).collect().n_chunks() == 1

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -132,7 +132,6 @@ def test_to_from_buffer(
 
 @pytest.mark.parametrize("use_pyarrow", [True, False])
 @pytest.mark.parametrize("rechunk_and_expected_chunks", [(True, 1), (False, 3)])
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.may_fail_cloud  # reason: chunking
 def test_read_parquet_respects_rechunk_16416(
     use_pyarrow: bool, rechunk_and_expected_chunks: tuple[bool, int]
@@ -2621,7 +2620,6 @@ c0,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10
     q = (
         pl.scan_parquet(
             f,
-            rechunk=True,
             parallel="prefiltered",
         )
         .filter(

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -743,7 +743,6 @@ def test_cse_and_schema_update_projection_pd() -> None:
 
 
 @pytest.mark.debug
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.parametrize("use_custom_io_source", [True, False])
 def test_cse_predicate_self_join(
     capfd: Any, plmonkeypatch: PlMonkeyPatch, use_custom_io_source: bool
@@ -758,8 +757,13 @@ def test_cse_predicate_self_join(
 
     y_xf_c = y_xf.select("a", "b")
     assert y_xf_c.collect().to_dict(as_series=False) == {"a": [1], "b": [2]}
-    captured = capfd.readouterr().err
-    assert "CACHE HIT" in captured
+
+    capture = capfd.readouterr().err
+
+    assert {
+        "CACHE HIT" in capture,
+        re.search(r"multiplexer.*[\w+] [\w+, \w+]", capture) is not None,
+    } == {True, False}
 
 
 def test_cse_manual_cache_15688() -> None:

--- a/py-polars/tests/unit/lazyframe/test_engine_selection.py
+++ b/py-polars/tests/unit/lazyframe/test_engine_selection.py
@@ -66,7 +66,6 @@ def test_default_engine_and_affinity(
     capfd: pytest.CaptureFixture[str],
 ) -> None:
     plmonkeypatch.setenv("POLARS_FORCE_STREAMING", "0")
-    plmonkeypatch.setenv("POLARS_AUTO_STREAMING", "0")
 
     if engine_affinity is not None:
         plmonkeypatch.setenv("POLARS_ENGINE_AFFINITY", engine_affinity)

--- a/py-polars/tests/unit/lazyframe/test_engine_selection.py
+++ b/py-polars/tests/unit/lazyframe/test_engine_selection.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from typing import TYPE_CHECKING
 
 import pytest
@@ -9,6 +10,7 @@ from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
     from polars._typing import EngineType
+    from tests.conftest import PlMonkeyPatch
 
 
 @pytest.fixture
@@ -52,3 +54,39 @@ def test_engine_import_error_raises(df: pl.LazyFrame, engine: EngineType) -> Non
         match="GPU engine requested",
     ):
         df.collect(engine=engine)
+
+
+@pytest.mark.parametrize(
+    "engine_affinity",
+    ["in-memory", "streaming", None],
+)
+def test_default_engine_and_affinity(
+    engine_affinity: str | None,
+    plmonkeypatch: PlMonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    plmonkeypatch.setenv("POLARS_FORCE_STREAMING", "0")
+    plmonkeypatch.setenv("POLARS_AUTO_STREAMING", "0")
+
+    if engine_affinity is not None:
+        plmonkeypatch.setenv("POLARS_ENGINE_AFFINITY", engine_affinity)
+    else:
+        with contextlib.suppress(KeyError):
+            plmonkeypatch.delenv("POLARS_ENGINE_AFFINITY")
+
+    capfd.readouterr()
+    plmonkeypatch.setenv("POLARS_VERBOSE", "1")
+    pl.LazyFrame().collect()
+    capture = capfd.readouterr().err
+    plmonkeypatch.setenv("POLARS_VERBOSE", "0")
+
+    used_engine = (
+        "streaming" if "polars-stream: updating graph state" in capture else "in-memory"
+    )
+
+    if engine_affinity is not None:
+        assert used_engine == engine_affinity
+    else:
+        assert used_engine == "streaming"
+
+    capfd.readouterr()

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -1241,8 +1241,12 @@ def test_lazy_cache_hit(plmonkeypatch: PlMonkeyPatch, capfd: Any) -> None:
     expected = pl.LazyFrame({"a": [0, 0, 0], "c": ["x", "y", "z"]})
     assert_frame_equal(result, expected, check_row_order=False)
 
-    (_, err) = capfd.readouterr()
-    assert "CACHE HIT" in err
+    capture = capfd.readouterr().err
+
+    assert {
+        "CACHE HIT" in capture,
+        re.search(r"multiplexer.*[\w+] [\w+, \w+]", capture) is not None,
+    } == {True, False}
 
 
 @pytest.mark.may_fail_cloud  # reason: impure udf

--- a/py-polars/tests/unit/lazyframe/test_order_observability.py
+++ b/py-polars/tests/unit/lazyframe/test_order_observability.py
@@ -119,8 +119,8 @@ def test_sort_agg_with_nested_windowing_22918(func: pl.Expr, result: int) -> Non
 
 def test_remove_sorts_on_unordered() -> None:
     lf = pl.LazyFrame({"a": [1, 2, 3]}).sort("a").sort("a").sort("a")
-    explain = lf.explain()
-    assert explain.count("SORT") == 1
+    plan = lf.explain()
+    assert plan.count("SORT") == 1
 
     lf = (
         pl.LazyFrame({"a": [1, 2, 3]})
@@ -134,20 +134,20 @@ def test_remove_sorts_on_unordered() -> None:
         .group_by("a")
         .agg([])
     )
-    explain = lf.explain()
-    assert explain.count("SORT") == 0
+    plan = lf.explain()
+    assert plan.count("SORT") == 0
 
     lf = (
         pl.LazyFrame({"a": [1, 2, 3]})
         .sort("a")
         .join(pl.LazyFrame({"b": [1, 2, 3]}), on=pl.lit(1))
     )
-    explain = lf.explain()
-    assert explain.count("SORT") == 0
+    plan = lf.explain(engine="streaming")
+    assert plan.count("SORT") == 0
 
     lf = pl.LazyFrame({"a": [1, 2, 3]}).sort("a").unique()
-    explain = lf.explain()
-    assert explain.count("SORT") == 0
+    plan = lf.explain()
+    assert plan.count("SORT") == 0
 
 
 def test_merge_sorted_to_union() -> None:

--- a/py-polars/tests/unit/lazyframe/test_predicates.py
+++ b/py-polars/tests/unit/lazyframe/test_predicates.py
@@ -1240,7 +1240,10 @@ def test_predicate_pushdown_map_elements_io_plugin_22860() -> None:
     plan = q.explain()
     assert plan.index("SELECTION") > plan.index("PYTHON SCAN")
 
-    assert_frame_equal(q.collect(), pl.DataFrame({"row_nr": [2, 4, 5], "y": [1, 1, 1]}))
+    assert_frame_equal(
+        q.collect(engine="in-memory"),
+        pl.DataFrame({"row_nr": [2, 4, 5], "y": [1, 1, 1]}),
+    )
 
 
 def test_duplicate_filter_removal_23243() -> None:

--- a/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
+++ b/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
@@ -398,7 +398,6 @@ def test_parse_apply_functions(
     "ignore:invalid value encountered:RuntimeWarning",
     "ignore:.*without specifying `return_dtype`:polars.exceptions.MapWithoutReturnDtypeWarning",
 )
-@pytest.mark.may_fail_auto_streaming  # dtype is not set
 def test_parse_apply_raw_functions() -> None:
     lf = pl.LazyFrame({"a": [1.1, 2.0, 3.4]})
 
@@ -413,7 +412,7 @@ def test_parse_apply_raw_functions() -> None:
         # ...but we ARE still able to warn
         with pytest.warns(
             PolarsInefficientMapWarning,
-            match=rf"(?s)Expr\.map_elements.*Replace this expression.*np\.{func_name}",
+            match=rf"(?s)\.map_elements.*Replace this expression.*np\.{func_name}",
         ):
             df1 = lf.select(
                 pl.col("a").map_elements(func, return_dtype=pl.self_dtype())
@@ -426,7 +425,7 @@ def test_parse_apply_raw_functions() -> None:
     expr_native = pl.col("value").str.json_decode(json_dtype)
     with pytest.warns(
         PolarsInefficientMapWarning,
-        match=r"(?s)Expr\.map_elements.*with this one instead:.*\.str\.json_decode",
+        match=r"(?s)\.map_elements.*with this one instead:.*\.str\.json_decode",
     ):
         expr_pyfunc = pl.col("value").map_elements(json.loads, return_dtype=json_dtype)
 

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -1198,7 +1198,7 @@ def test_list_struct_field_perf() -> None:
     # Timings (Apple M3 Pro 11-core)
     # * Debug build w/ elementwise: 1x
     # * Release pypi 1.29.0: 80x
-    threshold = 5
+    threshold = 30
 
     if slowdown > threshold:
         msg = f"slowdown ({slowdown}) > {threshold}x ({t0 = }, {t1 = })"

--- a/py-polars/tests/unit/operations/test_group_by_dynamic.py
+++ b/py-polars/tests/unit/operations/test_group_by_dynamic.py
@@ -327,7 +327,7 @@ def test_rolling_kernels_group_by_dynamic_7548() -> None:
     }
 
 
-@pytest.mark.may_fail_auto_streaming
+@pytest.mark.may_fail_auto_streaming  # Inconsistently fails in CI
 def test_rolling_dynamic_sortedness_check() -> None:
     # when the by argument is passed, the sortedness flag
     # will be unset as the take shuffles data, so we must explicitly

--- a/py-polars/tests/unit/operations/test_inequality_join.py
+++ b/py-polars/tests/unit/operations/test_inequality_join.py
@@ -864,7 +864,7 @@ def test_cross_join_validity_bitmap_offset_26925(
     plmonkeypatch: PlMonkeyPatch,
 ) -> None:
     plmonkeypatch.setenv("POLARS_MAX_THREADS", "2")
-    plmonkeypatch.setenv("POLARS_AUTO_STREAMING", "1")
+    plmonkeypatch.setenv("POLARS_FORCE_STREAMING", "1")
 
     left = pl.DataFrame({"id": [0, 1], "x": pl.Series([0, 0], dtype=pl.Int64)})
     right = pl.DataFrame(

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -271,7 +271,6 @@ def test_rolling_non_negative_offset_9077(
     assert_frame_equal(result, expected)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_rolling_dynamic_sortedness_check() -> None:
     # when the by argument is passed, the sortedness flag
     # will be unset as the take shuffles data, so we must explicitly

--- a/py-polars/tests/unit/streaming/test_streaming_join.py
+++ b/py-polars/tests/unit/streaming/test_streaming_join.py
@@ -570,7 +570,7 @@ def test_merge_join_exprs() -> None:
         left_on="key",
         right_on=pl.concat_str(pl.col("key"), ignore_nulls=False),
         how="full",
-        maintain_order="none",
+        maintain_order="left_right",
     )
     dot = q.show_graph(engine="streaming", plan_stage="physical", raw_output=True)
     assert "merge-join" in dot, "merge-join not used in plan"


### PR DESCRIPTION
After the streaming engine has been made the default for LazyFrame.collect, we no longer hit any `todo!()` panics in the test suite.

* On top of https://github.com/pola-rs/polars/pull/27822
* CI test run at https://github.com/nameexhaustion/polars/pull/41
