### PR TITLE
feat(rust): Implement context selection & spill dispatch logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,6 +3403,8 @@ dependencies = [
  "polars-core",
  "polars-io",
  "polars-utils",
+ "rand 0.10.1",
+ "rand_distr",
  "thread_local",
  "tikv-jemallocator",
  "tokio",

--- a/crates/polars-config/src/lib.rs
+++ b/crates/polars-config/src/lib.rs
@@ -68,11 +68,15 @@ const DEFAULT_OOC_SPILL_POLICY: SpillPolicy = SpillPolicy::NoSpill;
 const OOC_SPILL_FORMAT: &str = "POLARS_OOC_SPILL_FORMAT";
 const DEFAULT_OOC_SPILL_FORMAT: SpillFormat = SpillFormat::Ipc;
 
+// Unused at the moment.
 const OOC_MEMORY_BUDGET_FRACTION: &str = "POLARS_OOC_MEMORY_BUDGET_FRACTION";
 const DEFAULT_OOC_MEMORY_BUDGET_FRACTION: f64 = 0.8;
 
+const OOC_MEMORY_BUDGET_MB: &str = "POLARS_OOC_MEMORY_BUDGET_MB";
+const DEFAULT_OOC_MEMORY_BUDGET_MB: u64 = u64::MAX;
+
 const OOC_SPILL_MIN_BYTES: &str = "POLARS_OOC_SPILL_MIN_BYTES";
-const DEFAULT_OOC_SPILL_MIN_BYTES: u64 = 100 * 1024; // 100 KB
+const DEFAULT_OOC_SPILL_MIN_BYTES: u64 = 64 * 1024; // 64 KB
 
 const JOIN_SAMPLE_LIMIT: &str = "POLARS_JOIN_SAMPLE_LIMIT";
 const DEFAULT_JOIN_SAMPLE_LIMIT: u64 = 10_000_000;
@@ -129,6 +133,7 @@ static KNOWN_OPTIONS: &[&str] = &[
     OOC_SPILL_POLICY,
     OOC_SPILL_FORMAT,
     OOC_MEMORY_BUDGET_FRACTION,
+    OOC_MEMORY_BUDGET_MB,
     OOC_SPILL_MIN_BYTES,
     JOIN_SAMPLE_LIMIT,
     PROJECTION_PUSHDOWN_PRUNE_STRICT_HCONCAT_INPUTS,
@@ -154,6 +159,7 @@ pub struct Config {
     ooc_spill_policy: AtomicU8,
     ooc_spill_format: AtomicU8,
     ooc_memory_budget_fraction: AtomicU64,
+    ooc_memory_budget_bytes: AtomicU64,
     ooc_spill_min_bytes: AtomicU64,
     join_sample_limit: AtomicU64,
     projection_pushdown_prune_strict_hconcat_inputs: AtomicBool,
@@ -183,6 +189,9 @@ impl Config {
             ooc_spill_format: AtomicU8::new(DEFAULT_OOC_SPILL_FORMAT as u8),
             ooc_memory_budget_fraction: AtomicU64::new(
                 DEFAULT_OOC_MEMORY_BUDGET_FRACTION.to_bits(),
+            ),
+            ooc_memory_budget_bytes: AtomicU64::new(
+                DEFAULT_OOC_MEMORY_BUDGET_MB.saturating_mul(1_000_000),
             ),
             ooc_spill_min_bytes: AtomicU64::new(DEFAULT_OOC_SPILL_MIN_BYTES),
             join_sample_limit: AtomicU64::new(DEFAULT_JOIN_SAMPLE_LIMIT),
@@ -303,6 +312,12 @@ impl Config {
                     .to_bits(),
                 Ordering::Relaxed,
             ),
+            OOC_MEMORY_BUDGET_MB => self.ooc_memory_budget_bytes.store(
+                val.and_then(|x| parse::parse_u64(var, x))
+                    .unwrap_or(DEFAULT_OOC_MEMORY_BUDGET_MB)
+                    .saturating_mul(1_000_000),
+                Ordering::Relaxed,
+            ),
             OOC_SPILL_MIN_BYTES => self.ooc_spill_min_bytes.store(
                 val.and_then(|x| parse::parse_u64(var, x))
                     .unwrap_or(DEFAULT_OOC_SPILL_MIN_BYTES),
@@ -333,31 +348,37 @@ impl Config {
     }
 
     /// Whether we should do verbose printing.
+    #[inline(always)]
     pub fn verbose(&self) -> bool {
         self.verbose.load(Ordering::Relaxed)
     }
 
     /// Whether we should warn when unstable features are used.
+    #[inline(always)]
     pub fn warn_unstable(&self) -> bool {
         self.warn_unstable.load(Ordering::Relaxed)
     }
 
     /// The number of threads Polars should ideally use for CPU-intensive work.
+    #[inline(always)]
     pub fn max_threads(&self) -> usize {
         self.max_threads.load(Ordering::Relaxed).try_into().unwrap()
     }
 
     /// The ideal size of a morsel, in rows.
+    #[inline(always)]
     pub fn ideal_morsel_size(&self) -> u64 {
         self.ideal_morsel_size.load(Ordering::Relaxed)
     }
 
     /// Which engine to use by default.
+    #[inline(always)]
     pub fn engine_affinity(&self) -> Engine {
         Engine::from_discriminant(self.engine_affinity.load(Ordering::Relaxed))
     }
 
     /// Target byte length to truncate statistics to for binary/string columns in parquet.
+    #[inline(always)]
     pub fn parquet_binary_statistics_truncate_length(&self) -> u64 {
         self.parquet_binary_statistics_truncate_length
             .load(Ordering::Relaxed)
@@ -365,11 +386,13 @@ impl Config {
 
     /// Whether the optimizer should prune parquet metadata to projected/predicate columns
     /// before serializing the IR plan. See `parquet_metadata_prune` in `polars-plan`.
+    #[inline(always)]
     pub fn prune_parquet_metadata(&self) -> bool {
         self.prune_parquet_metadata.load(Ordering::Relaxed)
     }
 
     /// Nested common subplan elimination.
+    #[inline(always)]
     pub fn allow_nested_cspe(&self) -> bool {
         self.allow_nested_cspe.load(Ordering::Relaxed)
     }
@@ -377,39 +400,53 @@ impl Config {
     /// How much per-file metadata `parquet_file_info` resolves at planning
     /// time. See [`ResolveMode`] for the variants and their cost / IR-shape
     /// trade-offs.
+    #[inline(always)]
     pub fn resolve_metadata_level(&self) -> ResolveMode {
         ResolveMode::from_discriminant(self.resolve_metadata_level.load(Ordering::Relaxed))
     }
 
     /// Whether we should do verbose printing on sensitive information.
+    #[inline(always)]
     pub fn verbose_sensitive(&self) -> bool {
         self.verbose_sensitive.load(Ordering::Relaxed)
     }
 
+    #[inline(always)]
     pub fn force_async(&self) -> bool {
         self.force_async.load(Ordering::Relaxed)
     }
 
+    #[inline(always)]
     pub fn import_interval_as_struct(&self) -> bool {
         self.import_interval_as_struct.load(Ordering::Relaxed)
     }
 
+    #[inline(always)]
     pub fn ooc_drift_threshold(&self) -> u64 {
         get_ooc_drift_threshold()
     }
 
+    #[inline(always)]
     pub fn ooc_spill_policy(&self) -> SpillPolicy {
         SpillPolicy::from_discriminant(self.ooc_spill_policy.load(Ordering::Relaxed))
     }
 
+    #[inline(always)]
     pub fn ooc_spill_format(&self) -> SpillFormat {
         SpillFormat::from_discriminant(self.ooc_spill_format.load(Ordering::Relaxed))
     }
 
+    #[inline(always)]
     pub fn ooc_memory_budget_fraction(&self) -> f64 {
         f64::from_bits(self.ooc_memory_budget_fraction.load(Ordering::Relaxed))
     }
 
+    #[inline(always)]
+    pub fn ooc_memory_budget_bytes(&self) -> u64 {
+        self.ooc_memory_budget_bytes.load(Ordering::Relaxed)
+    }
+
+    #[inline(always)]
     pub fn ooc_spill_min_bytes(&self) -> u64 {
         self.ooc_spill_min_bytes.load(Ordering::Relaxed)
     }
@@ -422,10 +459,12 @@ impl Config {
         }
     }
 
+    #[inline(always)]
     pub fn join_sample_limit(&self) -> u64 {
         self.join_sample_limit.load(Ordering::Relaxed)
     }
 
+    #[inline(always)]
     pub fn projection_pushdown_prune_strict_hconcat_inputs(&self) -> bool {
         self.projection_pushdown_prune_strict_hconcat_inputs
             .load(Ordering::Relaxed)

--- a/crates/polars-ooc/Cargo.toml
+++ b/crates/polars-ooc/Cargo.toml
@@ -17,6 +17,8 @@ polars-config = { workspace = true }
 polars-core = { workspace = true, features = ["algorithm_group_by"] }
 polars-io = { workspace = true, features = ["ipc"] }
 polars-utils = { workspace = true, features = ["sysinfo"] }
+rand = { workspace = true }
+rand_distr = { workspace = true }
 thread_local = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 

--- a/crates/polars-ooc/src/memory_manager.rs
+++ b/crates/polars-ooc/src/memory_manager.rs
@@ -1,6 +1,14 @@
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, RwLock, Weak};
 
-use crate::SpillContext;
+use polars_async::ASYNC;
+use polars_config::config;
+use polars_utils::total_ord::TotalOrd;
+use rand_distr::Distribution;
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::spill_token::TrySpillError;
+use crate::{DynSpillToken, SpillContext};
 
 static MEMORY_MANAGER: LazyLock<MemoryManager> = LazyLock::new(MemoryManager::new);
 
@@ -11,12 +19,28 @@ pub fn memory_manager() -> &'static MemoryManager {
 
 pub struct MemoryManager {
     contexts: RwLock<Vec<Weak<dyn SpillContext>>>,
+    finding_spill_lock: AsyncMutex<()>,
+    est_spill_in_progress: AtomicU64,
 }
 
 impl MemoryManager {
     fn new() -> Self {
         Self {
             contexts: RwLock::new(Vec::new()),
+            finding_spill_lock: AsyncMutex::new(()),
+            est_spill_in_progress: AtomicU64::new(0),
+        }
+    }
+
+    fn should_spill(&self) -> bool {
+        let usage = crate::estimate_memory_usage();
+        let likely_dealt_with = self.est_spill_in_progress.load(Ordering::Relaxed);
+        usage.saturating_sub(likely_dealt_with) > config().ooc_memory_budget_bytes()
+    }
+
+    fn clean_contexts(&self) {
+        if let Ok(mut ctxs) = self.contexts.try_write() {
+            ctxs.retain(|ctx| ctx.strong_count() > 0);
         }
     }
 
@@ -25,7 +49,120 @@ impl MemoryManager {
         self.contexts.write().unwrap().push(weak);
     }
 
-    pub async fn spill(&self) {}
+    #[inline(always)]
+    pub async fn spill(&self) {
+        if self.should_spill() {
+            self.do_spill().await
+        }
+    }
 
-    pub fn spill_blocking(&self) {}
+    #[inline(always)]
+    pub fn spill_blocking(&self) {
+        if self.should_spill() {
+            self.do_spill_blocking()
+        }
+    }
+
+    #[inline(never)]
+    #[cold]
+    fn do_spill_blocking(&self) {
+        ASYNC.block_in_place_on(self.do_spill())
+    }
+
+    #[inline(never)]
+    #[cold]
+    async fn do_spill(&self) {
+        while self.should_spill() {
+            let Some((ctx, spillables)) = self.find_spillables().await else {
+                return;
+            };
+
+            for (spillable, id, sz) in spillables {
+                // Spill, or reinsert if a failure.
+                match spillable.try_spill(ctx.stats(), Arc::downgrade(&ctx), id) {
+                    Ok(spill_success) => {
+                        if !spill_success.await {
+                            ctx.reinsert(&spillable, id);
+                        }
+                    },
+                    Err(TrySpillError::Pinned) => {
+                        ctx.reinsert(&spillable, id);
+                    },
+                    Err(TrySpillError::AlreadySpilled) => {},
+                }
+
+                self.est_spill_in_progress
+                    .fetch_sub(sz as u64, Ordering::Relaxed);
+            }
+        }
+    }
+
+    #[inline(never)]
+    #[cold]
+    async fn find_spillables(
+        &self,
+    ) -> Option<(
+        Arc<dyn SpillContext>,
+        Vec<(Arc<dyn DynSpillToken>, u64, usize)>,
+    )> {
+        // TODO: don't block here under a certain memory threshold.
+        let finding_spill_guard = self.finding_spill_lock.lock().await;
+
+        // TODO: don't loop over all contexts here, keep track of good ones and inspect those plus a couple random ones.
+        let contexts = self.contexts.read().unwrap();
+        let mut has_dead_context = false;
+        let mut live_contexts = Vec::new();
+        let mut rng = rand::rng();
+        for weak_ctx in contexts.iter() {
+            let Some(ctx) = weak_ctx.upgrade() else {
+                has_dead_context = true;
+                continue;
+            };
+
+            // Thompson sampling
+            let (mean, var) = ctx.stats().score();
+            let distr = rand_distr::Normal::new(mean, var.sqrt()).unwrap();
+            let score_sample = distr.sample(&mut rng);
+            live_contexts.push((ctx, score_sample));
+        }
+        drop(contexts);
+
+        // Find the best context and loop over its candidates. For each
+        // candidate we check if it can be spilled else we reinsert it.
+        let min_spill = config().ooc_spill_min_bytes();
+        let best_ctx = live_contexts.into_iter().max_by(|a, b| a.1.tot_cmp(&b.1));
+        let out = if let Some((best_ctx, _score)) = best_ctx {
+            let mut total_est_spill = 0;
+            let mut candidates = Vec::new();
+            for (cand, id) in best_ctx.pop() {
+                if cand.can_spill()
+                    && let Some(sz) = cand.estimate_byte_size()
+                    && sz as u64 >= min_spill
+                {
+                    total_est_spill += sz as u64;
+                    candidates.push((cand, id, sz));
+                } else {
+                    if !cand.is_spilled_or_dropped() {
+                        best_ctx.reinsert(&cand, id);
+                    }
+                }
+            }
+
+            // Increment the spill-in-progress to avoid eager over-spilling.
+            self.est_spill_in_progress
+                .fetch_add(total_est_spill, Ordering::Relaxed);
+
+            // TODO: penalize context also for time spent finding candidates, so an all-pinned
+            // context or all-tiny frame context doesn't keep being chosen.
+            Some((best_ctx, candidates))
+        } else {
+            None
+        };
+
+        drop(finding_spill_guard);
+        if has_dead_context {
+            self.clean_contexts();
+        }
+        out
+    }
 }

--- a/crates/polars-ooc/src/spill_context.rs
+++ b/crates/polars-ooc/src/spill_context.rs
@@ -4,6 +4,8 @@ use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::Instant;
 
 use polars_utils::relaxed_cell::RelaxedCell;
+use rand::RngExt;
+use rand::rngs::ThreadRng;
 use thread_local::ThreadLocal;
 
 use crate::{DynSpillToken, SpillToken, Spillable, memory_manager};
@@ -29,28 +31,39 @@ impl LocalSpillQueue {
         }
     }
 
-    #[expect(unused)]
-    pub fn pop_front(&mut self) -> Option<Arc<dyn DynSpillToken>> {
+    pub fn pop_front(&mut self) -> Option<(Arc<dyn DynSpillToken>, u64)> {
         loop {
             let (weak, id) = self.tokens.pop_front()?;
             if let Some(token) = weak.upgrade()
                 && token.current_registration_id() == id
             {
-                return Some(token);
+                return Some((token, id));
             }
         }
     }
 
-    #[expect(unused)]
-    pub fn pop_back(&mut self) -> Option<Arc<dyn DynSpillToken>> {
+    pub fn pop_back(&mut self) -> Option<(Arc<dyn DynSpillToken>, u64)> {
         loop {
             let (weak, id) = self.tokens.pop_back()?;
             if let Some(token) = weak.upgrade()
                 && token.current_registration_id() == id
             {
-                return Some(token);
+                return Some((token, id));
             }
         }
+    }
+
+    pub fn pop_random(&mut self, rng: &mut ThreadRng) -> Option<(Arc<dyn DynSpillToken>, u64)> {
+        while !self.tokens.is_empty() {
+            let idx = rng.random_range(0..self.tokens.len());
+            let (weak, id) = self.tokens.swap_remove_back(idx).unwrap();
+            if let Some(token) = weak.upgrade()
+                && token.current_registration_id() == id
+            {
+                return Some((token, id));
+            }
+        }
+        None
     }
 
     fn gc(&mut self) {
@@ -68,6 +81,7 @@ impl LocalSpillQueue {
 
 pub trait SpillContext: Send + Sync + 'static {
     fn stats(&self) -> &Arc<SpillContextStatistics>;
+    fn pop(&self) -> Vec<(Arc<dyn DynSpillToken>, u64)>;
     fn reinsert(&self, token: &Arc<dyn DynSpillToken>, id: u64);
 }
 
@@ -99,6 +113,16 @@ impl MostRecentSpillContext {
 impl SpillContext for MostRecentSpillContext {
     fn stats(&self) -> &Arc<SpillContextStatistics> {
         &self.stats
+    }
+
+    fn pop(&self) -> Vec<(Arc<dyn DynSpillToken>, u64)> {
+        let mut out = Vec::new();
+        for local_lock in self.local.iter() {
+            if let Ok(mut local) = local_lock.try_write() {
+                out.extend(local.pop_back());
+            }
+        }
+        out
     }
 
     fn reinsert(&self, token: &Arc<dyn DynSpillToken>, id: u64) {
@@ -148,6 +172,16 @@ impl SpillContext for LeastRecentSpillContext {
         &self.stats
     }
 
+    fn pop(&self) -> Vec<(Arc<dyn DynSpillToken>, u64)> {
+        let mut out = Vec::new();
+        for local_lock in self.local.iter() {
+            if let Ok(mut local) = local_lock.try_write() {
+                out.extend(local.pop_front());
+            }
+        }
+        out
+    }
+
     fn reinsert(&self, token: &Arc<dyn DynSpillToken>, id: u64) {
         let mut local = self.local.get_or_default().write().unwrap();
         local.push_back(token, id);
@@ -194,6 +228,17 @@ impl SpillContext for RandomSpillContext {
         &self.stats
     }
 
+    fn pop(&self) -> Vec<(Arc<dyn DynSpillToken>, u64)> {
+        let mut out = Vec::new();
+        let mut rng = rand::rng();
+        for local_lock in self.local.iter() {
+            if let Ok(mut local) = local_lock.try_write() {
+                out.extend(local.pop_random(&mut rng));
+            }
+        }
+        out
+    }
+
     fn reinsert(&self, token: &Arc<dyn DynSpillToken>, id: u64) {
         let mut local = self.local.get_or_default().write().unwrap();
         local.push_back(token, id);
@@ -218,91 +263,221 @@ impl Debug for RandomSpillContext {
     }
 }
 
-// Used to normalize divisor to avoid absurdly high scores. Set to 0.1ms.
-const BASE_IO_TIME: f64 = 1.0 / 10_000.0;
-const UNEXPLORED_SCORE: f64 = 1e100_f64;
+fn f32_pair_to_u64(a: f32, b: f32) -> u64 {
+    ((a.to_bits() as u64) << 32) | b.to_bits() as u64
+}
+
+fn u64_to_f32_pair(u: u64) -> (f32, f32) {
+    (f32::from_bits((u >> 32) as u32), f32::from_bits(u as u32))
+}
+
+// Used to normalize divisor to avoid absurdly high scores. Set to 1us.
+const BASE_IO_TIME: f64 = 1e-6;
+const UNEXPLORED_SCORE: f32 = 1e10_f32;
+const UNEXPLORED_VARIANCE: f32 = 1e5_f32;
+const STABLE_WEIGHT_THRESHOLD: f64 = 0.1; // Weights under this are considered unreliable (division).
+const EXPLORED_WEIGHT_THRESHOLD: f64 = 1.0 + STABLE_WEIGHT_THRESHOLD; // Just over 1 so sample variance correction is stable.
+const UNSPILL_EVENT_HALF_LIFE_SEC: f64 = 5.0;
+const NANOSECONDS_IN_SECOND: f64 = 1e9;
 
 pub struct SpillContextStatistics {
-    score: RelaxedCell<u64>,
+    score_cache: RelaxedCell<u64>,
     stats: Mutex<Statistics>,
-    explorations: RelaxedCell<u64>,
 }
 
 impl Default for SpillContextStatistics {
     fn default() -> Self {
         Self {
             // TODO: starting score based on context.
-            score: RelaxedCell::new_u64(UNEXPLORED_SCORE.to_bits()),
+            score_cache: RelaxedCell::new_u64(f32_pair_to_u64(
+                UNEXPLORED_SCORE,
+                UNEXPLORED_VARIANCE,
+            )),
             stats: Mutex::default(),
-            explorations: RelaxedCell::new_u64(0),
         }
     }
 }
 
 impl SpillContextStatistics {
-    pub fn score(&self) -> f64 {
+    // Returns the discounted mean and discounted variance of the 'score' of
+    // this context. The score is the number of spilled byte-seconds divided by
+    // the IO time in seconds. The discount is a time-based exponential decay
+    // which assigns lower weight to older spill events (with a half-life of
+    // UNSPILL_EVENT_HALF_LIFE_SEC), and full weight to current spills.
+    pub fn score(&self) -> (f32, f32) {
         // Try to re-compute, if lock is taken just take cached value.
         if let Ok(mut stats) = self.stats.try_lock() {
-            if self.explorations.load() == 0 {
-                UNEXPLORED_SCORE
-            } else {
-                stats.update(Instant::now());
-                let io_time = stats.spill_time + stats.unspill_time;
-                let score = stats.spilled_byte_seconds / (BASE_IO_TIME + io_time);
-                self.score.store(score.to_bits());
-                score
-            }
+            let (mean, var) = stats.score();
+            self.score_cache.store(f32_pair_to_u64(mean, var));
+            (mean, var)
         } else {
-            f64::from_bits(self.score.load())
+            u64_to_f32_pair(self.score_cache.load())
         }
     }
 
-    pub fn add_exploration(&self) {
-        self.explorations.fetch_add(1);
-    }
-
     pub fn add_failed_spill(&self, spill_start: Instant) {
-        let spill_time_sec = spill_start.elapsed().as_secs_f64();
         let mut stats = self.stats.lock().unwrap();
+        let spill_time_sec = spill_start.elapsed().as_secs_f64();
         stats.spill_time += spill_time_sec;
         stats.failed_spills += 1;
+        stats.add_bandit_event(0, spill_time_sec, 0.0, 0.0);
     }
 
-    pub fn add_successful_spill(&self, n_bytes: usize, spill_start: Instant) {
+    /// Returns the number of nanoseconds the spilling took, as well as the
+    /// Instant from which we consider this value to be spilled. Both must be
+    /// given back as arguments to `add_unspill`, to prevent accidental
+    /// statistics drift and keep the accumulators precise.
+    pub fn add_successful_spill(&self, n_bytes: usize, spill_start: Instant) -> (u64, Instant) {
         let mut stats = self.stats.lock().unwrap();
         let now = Instant::now();
-        let spill_time_sec = (now - spill_start).as_secs_f64();
-        stats.update(now); // Update before mutating bytes_currently_spilled.
-        stats.spill_time += spill_time_sec;
-        stats.bytes_currently_spilled += n_bytes as u64;
+        stats.step_time(now); // Important: step time before mutating.
+
+        let spill_time = now - spill_start;
+        let spill_time_ns = spill_time.as_nanos() as u64;
+        stats.spill_time += spill_time.as_secs_f64();
         stats.successful_spills += 1;
+        stats.active_spills += 1;
+        stats.bytes_currently_spilled += n_bytes as u64;
+        stats.active_spills_io_time_ns += spill_time_ns;
+        (spill_time_ns, now)
     }
 
-    pub fn add_unspill(&self, n_bytes: usize, unspill_start: Instant) {
+    pub fn add_unspill(
+        &self,
+        n_bytes: usize,
+        spill_time_ns: u64,
+        spilled_start: Instant,
+        unspill_start: Instant,
+    ) {
         let mut stats = self.stats.lock().unwrap();
         let now = Instant::now();
-        let spill_time_sec = (now - unspill_start).as_secs_f64();
-        stats.update(now); // Update before mutating bytes_currently_spilled.
-        stats.unspill_time += spill_time_sec;
+        stats.step_time(now); // Important: step time before mutating.
+
+        let spilled_time = unspill_start - spilled_start;
+        let unspill_time = now - unspill_start;
+        stats.unspill_time += unspill_time.as_secs_f64();
+        stats.active_spills -= 1;
         stats.bytes_currently_spilled -= n_bytes as u64;
+        stats.active_spills_io_time_ns -= spill_time_ns;
+
+        // The unspill time was also included in active_spilled_byte_nanoseconds
+        // due to our consistent stepping of time, so to cancel everything out
+        // we have to count from spilled_start until now. Otherwise
+        // active_spilled_byte_nanoseconds would slowly drift upward over time.
+        stats.active_spilled_byte_nanoseconds -= n_bytes as u128 * (now - spilled_start).as_nanos();
+
+        stats.add_bandit_event(
+            n_bytes as u64,
+            spill_time_ns as f64 / NANOSECONDS_IN_SECOND,
+            spilled_time.as_secs_f64(),
+            unspill_time.as_secs_f64(),
+        );
     }
 }
 
 struct Statistics {
+    // Total stats.
     spilled_byte_seconds: f64,
-    bytes_currently_spilled: u64,
-    last_update: Instant,
     spill_time: f64,
     unspill_time: f64,
     successful_spills: u64,
     failed_spills: u64,
+
+    // Stats of currently active spills. These are tracked as integers so they
+    // remain exact.
+    active_spills: u64,
+    active_spilled_byte_nanoseconds: u128,
+    active_spills_io_time_ns: u64,
+    bytes_currently_spilled: u64,
+
+    // Historical stats for the multi-armed bandit algorithm. These are
+    // discounted statistics (meaning they decay over time), where weight is the
+    // (decaying) number of observations, and each observation is of the form
+    // spilled_byte_seconds / spill_time.
+    //
+    // The multi-armed bandit algorithm in use is adapted from
+    // "Discounted Thompson Sampling for Non-Stationary Bandit Problems" https://arxiv.org/pdf/2305.10718
+    // Adaptations made: use direct sample mean/variance, discount based on time
+    // rather than arm pulls.
+    bandit_weight: f64,
+    bandit_reward: f64,
+    bandit_sq_reward: f64,
+
+    last_update: Instant,
 }
 
 impl Statistics {
-    fn update(&mut self, now: Instant) {
-        let delta = now - self.last_update;
-        self.spilled_byte_seconds += self.bytes_currently_spilled as f64 * delta.as_secs_f64();
+    fn step_time(&mut self, now: Instant) {
+        let dt = now - self.last_update;
+        let dt_s = dt.as_secs_f64();
+        let dt_ns = dt.as_nanos();
+        self.active_spilled_byte_nanoseconds += self.bytes_currently_spilled as u128 * dt_ns;
+        self.spilled_byte_seconds += self.bytes_currently_spilled as f64 * dt_s;
+
+        // Exponentially decay old bandit events.
+        let mult = -f64::ln(2.0) / UNSPILL_EVENT_HALF_LIFE_SEC;
+        let decay_factor = f64::exp(mult * dt_s);
+        self.bandit_weight *= decay_factor;
+        self.bandit_reward *= decay_factor;
+        self.bandit_sq_reward *= decay_factor;
+
         self.last_update = now;
+    }
+
+    // An event to update the multi-armed bandit algorithm.
+    fn add_bandit_event(
+        &mut self,
+        n_bytes: u64,
+        spill_time: f64,
+        spilled_time: f64,
+        unspill_time: f64,
+    ) {
+        let spilled_byte_seconds = n_bytes as f64 * spilled_time;
+        let io_time = spill_time + unspill_time;
+        let r = spilled_byte_seconds / (BASE_IO_TIME + io_time);
+        self.bandit_weight += 1.0;
+        self.bandit_reward += r;
+        self.bandit_sq_reward += r * r;
+    }
+
+    fn score(&mut self) -> (f32, f32) {
+        self.step_time(Instant::now());
+
+        let mut reward_weight = 0.0;
+        let mut reward_sum = 0.0;
+        let mut reward_sum_of_sq = 0.0;
+
+        let active_reward_weight = self.active_spills as f64;
+        if active_reward_weight >= STABLE_WEIGHT_THRESHOLD {
+            // We don't keep track of the variance of active spills, so we
+            // just assume it has no variance, that is, each active spill is
+            // accounted for as the mean active spill.
+            let active_spill_byte_seconds =
+                self.active_spilled_byte_nanoseconds as f64 / NANOSECONDS_IN_SECOND;
+            let active_spill_io_time = self.active_spills_io_time_ns as f64 / NANOSECONDS_IN_SECOND;
+            let active_reward_mean = active_spill_byte_seconds
+                / (BASE_IO_TIME * active_reward_weight + active_spill_io_time);
+            let active_reward_sum = active_reward_mean * active_reward_weight;
+
+            reward_weight += active_reward_weight;
+            reward_sum += active_reward_sum;
+            reward_sum_of_sq += active_reward_mean * active_reward_sum;
+        }
+
+        if self.bandit_weight >= STABLE_WEIGHT_THRESHOLD {
+            reward_weight += self.bandit_weight;
+            reward_sum += self.bandit_reward;
+            reward_sum_of_sq += self.bandit_sq_reward;
+        }
+
+        if reward_weight < EXPLORED_WEIGHT_THRESHOLD {
+            return (UNEXPLORED_SCORE, UNEXPLORED_VARIANCE);
+        }
+
+        let mean = reward_sum / reward_weight;
+        let var = reward_sum_of_sq / reward_weight - mean * mean;
+        let corr = reward_weight / (reward_weight - 1.0);
+        (mean as f32, (var * corr) as f32)
     }
 }
 
@@ -310,12 +485,20 @@ impl Default for Statistics {
     fn default() -> Self {
         Self {
             spilled_byte_seconds: 0.0,
-            bytes_currently_spilled: 0,
-            last_update: Instant::now(),
             spill_time: 0.0,
             unspill_time: 0.0,
             successful_spills: 0,
             failed_spills: 0,
+            last_update: Instant::now(),
+
+            active_spills: 0,
+            active_spills_io_time_ns: 0,
+            active_spilled_byte_nanoseconds: 0,
+            bytes_currently_spilled: 0,
+
+            bandit_weight: 0.0,
+            bandit_reward: 0.0,
+            bandit_sq_reward: 0.0,
         }
     }
 }

--- a/crates/polars-ooc/src/spill_token.rs
+++ b/crates/polars-ooc/src/spill_token.rs
@@ -28,6 +28,8 @@ enum ValueSlot<T> {
         spill_ctx_stats: Arc<SpillContextStatistics>,
         reinsert_ctx: Weak<dyn SpillContext>,
         reinsert_id: u64,
+        spill_time_ns: u64,
+        spilled_start: Instant,
     },
     Dropped,
 }
@@ -191,7 +193,7 @@ impl<T: Spillable> SpillTokenInner<T> {
             let lock_guard = WithDrop::new(slf, |slf| {
                 slf.wake_waiters(slf.state.fetch_and(!LOCK_BIT, Ordering::AcqRel));
             });
-            // TODO: re-register unspilled frame?
+
             let unspill_start = Instant::now();
             let spilled = (*slf.spilled_value.get()).as_ref().unwrap();
             let value = T::unspill(spilled).await;
@@ -200,12 +202,14 @@ impl<T: Spillable> SpillTokenInner<T> {
                 spill_ctx_stats,
                 reinsert_ctx,
                 reinsert_id,
+                spill_time_ns,
+                spilled_start,
             } = slf.value_slot.get().replace(ValueSlot::InMemory(value))
             else {
                 unreachable!()
             };
 
-            spill_ctx_stats.add_unspill(n_bytes, unspill_start);
+            spill_ctx_stats.add_unspill(n_bytes, spill_time_ns, spilled_start, unspill_start);
             if reinsert_id == slf.registration_id.load(Ordering::Relaxed) {
                 if let Some(ctx) = reinsert_ctx.upgrade() {
                     let dyn_slf: Arc<dyn DynSpillToken> = slf.clone();
@@ -245,15 +249,21 @@ impl<T: Spillable> SpillTokenInner<T> {
                 spill_ctx_stats,
                 reinsert_ctx,
                 reinsert_id,
+                spill_time_ns,
+                spilled_start,
             } = value_slot
             {
                 debug_assert!(slf.state.load(Ordering::Relaxed) & SPILLED_BIT == SPILLED_BIT);
-                // TODO: re-register unspilled frame?
                 let unspill_start = Instant::now();
                 let spilled = (*slf.spilled_value.get()).take().unwrap();
                 let value = T::unspill(&spilled).await;
 
-                spill_ctx_stats.add_unspill(*n_bytes, unspill_start);
+                spill_ctx_stats.add_unspill(
+                    *n_bytes,
+                    *spill_time_ns,
+                    *spilled_start,
+                    unspill_start,
+                );
                 if *reinsert_id == slf.registration_id.load(Ordering::Relaxed) {
                     if let Some(ctx) = reinsert_ctx.upgrade() {
                         let dyn_slf: Arc<dyn DynSpillToken> = slf.clone();
@@ -322,8 +332,11 @@ pub trait DynSpillToken: Send + Sync + 'static {
     /// already spilled.
     fn can_spill(&self) -> bool;
 
+    /// Whether this token is spilled or dropped.
+    fn is_spilled_or_dropped(&self) -> bool;
+
     /// Estimates how many bytes this object takes up in memory. Returns None
-    /// if the object is spilled or dropped.
+    /// if the object cannot be pinned.
     fn estimate_byte_size(&self) -> Option<usize>;
 
     /// Tries to spill this token. Returns true if successful.
@@ -351,6 +364,10 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
     fn can_spill(&self) -> bool {
         self.state.load(Ordering::Acquire) & (SPILLED_BIT | DROPPED_BIT | LOCK_BIT | RO_PIN_MASK)
             == 0
+    }
+
+    fn is_spilled_or_dropped(&self) -> bool {
+        self.state.load(Ordering::Acquire) & (SPILLED_BIT | DROPPED_BIT) != 0
     }
 
     fn estimate_byte_size(&self) -> Option<usize> {
@@ -427,15 +444,18 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
                     ValueSlot::InMemory(val) => val.estimate_byte_size(),
                     _ => unreachable!(),
                 };
+                let (spill_time_ns, spilled_start) =
+                    stats.add_successful_spill(n_bytes, spill_start);
                 unsafe {
                     self.value_slot.get().replace(ValueSlot::Spilled {
                         n_bytes,
                         spill_ctx_stats: stats.clone(),
                         reinsert_ctx: context,
                         reinsert_id: registration_id,
+                        spill_time_ns,
+                        spilled_start,
                     })
                 };
-                stats.add_successful_spill(n_bytes, spill_start);
                 self.state
                     .fetch_add(SPILLED_BIT.wrapping_sub(LOCK_BIT), Ordering::AcqRel)
             } else {


### PR DESCRIPTION
Spilling is still a no-op (and untested), but now we should be dispatching to it when `POLARS_OOC_MEMORY_BUDGET_MB` is set.