### PR TITLE
fix: Traverse caches only once in explain

### DIFF
--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -3,8 +3,10 @@ use std::fmt::{self, Display, Formatter, Write};
 use polars_core::frame::DataFrame;
 use polars_core::schema::Schema;
 use polars_io::RowIndex;
+use polars_utils::aliases::{InitHashMaps as _, PlHashSet};
 use polars_utils::format_list_truncated;
 use polars_utils::slice_enum::Slice;
+use polars_utils::unique_id::UniqueId;
 use recursive::recursive;
 
 use self::ir::dot::ScanSourcesDisplay;
@@ -146,7 +148,12 @@ impl<'a> IRDisplay<'a> {
     }
 
     #[recursive]
-    fn _format(&self, f: &mut Formatter, indent: usize) -> fmt::Result {
+    fn _format(
+        &self,
+        f: &mut Formatter,
+        indent: usize,
+        seen_caches: &mut PlHashSet<UniqueId>,
+    ) -> fmt::Result {
         if indent != 0 {
             writeln!(f)?;
         }
@@ -158,6 +165,13 @@ impl<'a> IRDisplay<'a> {
         let output_schema = ir_node.schema(self.lp.lp_arena);
         let output_schema = output_schema.as_ref();
         match ir_node {
+            Cache { input, id } => {
+                write_ir_non_recursive(f, ir_node, self.lp.expr_arena, output_schema, indent)?;
+                if seen_caches.insert(*id) {
+                    self.with_root(*input)._format(f, sub_indent, seen_caches)?;
+                }
+                Ok(())
+            },
             Union { inputs, options } => {
                 write_ir_non_recursive(f, ir_node, self.lp.expr_arena, output_schema, indent)?;
                 let name = if let Some(slice) = options.slice {
@@ -176,7 +190,8 @@ impl<'a> IRDisplay<'a> {
                 let sub_sub_indent = sub_indent + INDENT_INCREMENT;
                 for (i, plan) in inputs.iter().enumerate() {
                     write!(f, "\n{:sub_indent$}PLAN {i}:", "")?;
-                    self.with_root(*plan)._format(f, sub_sub_indent)?;
+                    self.with_root(*plan)
+                        ._format(f, sub_sub_indent, seen_caches)?;
                 }
                 write!(f, "\n{:indent$}END {name}", "")
             },
@@ -185,14 +200,15 @@ impl<'a> IRDisplay<'a> {
                 write_ir_non_recursive(f, ir_node, self.lp.expr_arena, output_schema, indent)?;
                 for (i, plan) in inputs.iter().enumerate() {
                     write!(f, "\n{:sub_indent$}PLAN {i}:", "")?;
-                    self.with_root(*plan)._format(f, sub_sub_indent)?;
+                    self.with_root(*plan)
+                        ._format(f, sub_sub_indent, seen_caches)?;
                 }
                 write!(f, "\n{:indent$}END HCONCAT", "")
             },
             GroupBy { input, .. } => {
                 write_ir_non_recursive(f, ir_node, self.lp.expr_arena, output_schema, indent)?;
                 write!(f, "\n{:sub_indent$}FROM", "")?;
-                self.with_root(*input)._format(f, sub_indent)?;
+                self.with_root(*input)._format(f, sub_indent, seen_caches)?;
                 Ok(())
             },
             Join {
@@ -212,23 +228,27 @@ impl<'a> IRDisplay<'a> {
                     let name = "NESTED LOOP";
                     write!(f, "{:indent$}{name} JOIN ON {predicate}:", "")?;
                     write!(f, "\n{:indent$}LEFT PLAN:", "")?;
-                    self.with_root(*input_left)._format(f, sub_indent)?;
+                    self.with_root(*input_left)
+                        ._format(f, sub_indent, seen_caches)?;
                     write!(f, "\n{:indent$}RIGHT PLAN:", "")?;
-                    self.with_root(*input_right)._format(f, sub_indent)?;
+                    self.with_root(*input_right)
+                        ._format(f, sub_indent, seen_caches)?;
                     write!(f, "\n{:indent$}END {name} JOIN", "")
                 } else {
                     let how = &options.args.how;
                     write!(f, "{:indent$}{how} JOIN:", "")?;
                     write!(f, "\n{:indent$}LEFT PLAN ON: {left_on}", "")?;
-                    self.with_root(*input_left)._format(f, sub_indent)?;
+                    self.with_root(*input_left)
+                        ._format(f, sub_indent, seen_caches)?;
                     write!(f, "\n{:indent$}RIGHT PLAN ON: {right_on}", "")?;
-                    self.with_root(*input_right)._format(f, sub_indent)?;
+                    self.with_root(*input_right)
+                        ._format(f, sub_indent, seen_caches)?;
                     write!(f, "\n{:indent$}END {how} JOIN", "")
                 }
             },
             MapFunction { input, .. } => {
                 write_ir_non_recursive(f, ir_node, self.lp.expr_arena, output_schema, indent)?;
-                self.with_root(*input)._format(f, sub_indent)
+                self.with_root(*input)._format(f, sub_indent, seen_caches)
             },
             SinkMultiple { inputs } => {
                 write_ir_non_recursive(f, ir_node, self.lp.expr_arena, output_schema, indent)?;
@@ -240,7 +260,8 @@ impl<'a> IRDisplay<'a> {
                 let sub_sub_indent = sub_indent + 2;
                 for (i, plan) in inputs.iter().enumerate() {
                     write!(f, "\n{:sub_indent$}PLAN {i}:", "")?;
-                    self.with_root(*plan)._format(f, sub_sub_indent)?;
+                    self.with_root(*plan)
+                        ._format(f, sub_sub_indent, seen_caches)?;
                 }
                 write!(f, "\n{:indent$}END SINK_MULTIPLE", "")
             },
@@ -255,15 +276,17 @@ impl<'a> IRDisplay<'a> {
                 write!(f, ":")?;
 
                 write!(f, "\n{:indent$}LEFT PLAN:", "")?;
-                self.with_root(*input_left)._format(f, sub_indent)?;
+                self.with_root(*input_left)
+                    ._format(f, sub_indent, seen_caches)?;
                 write!(f, "\n{:indent$}RIGHT PLAN:", "")?;
-                self.with_root(*input_right)._format(f, sub_indent)?;
+                self.with_root(*input_right)
+                    ._format(f, sub_indent, seen_caches)?;
                 write!(f, "\n{:indent$}END MERGE_SORTED", "")
             },
             ir_node => {
                 write_ir_non_recursive(f, ir_node, self.lp.expr_arena, output_schema, indent)?;
                 for input in ir_node.inputs() {
-                    self.with_root(input)._format(f, sub_indent)?;
+                    self.with_root(input)._format(f, sub_indent, seen_caches)?;
                 }
                 Ok(())
             },
@@ -290,7 +313,8 @@ impl<'a> ExprIRDisplay<'a> {
 
 impl Display for IRDisplay<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        self._format(f, 0)
+        let mut seen_caches = PlHashSet::new();
+        self._format(f, 0, &mut seen_caches)
     }
 }
 

--- a/crates/polars-plan/src/plans/ir/tree_format.rs
+++ b/crates/polars-plan/src/plans/ir/tree_format.rs
@@ -1,7 +1,9 @@
 use std::fmt::{self, Write};
 
 use polars_core::error::*;
+use polars_utils::aliases::PlHashSet;
 use polars_utils::format_list_truncated;
+use polars_utils::unique_id::UniqueId;
 
 use crate::constants;
 use crate::plans::ir::IRPlanRef;
@@ -98,6 +100,21 @@ pub enum TreeFmtNodeContent<'a> {
     LogicalPlan(Node),
 }
 
+impl<'a> TreeFmtNodeContent<'a> {
+    pub fn cache_id(&self, arena: &Arena<IR>) -> Option<UniqueId> {
+        match self {
+            Self::Expression(_) => None,
+            Self::LogicalPlan(node) => {
+                if let IR::Cache { id, .. } = arena.get(*node) {
+                    Some(*id)
+                } else {
+                    None
+                }
+            },
+        }
+    }
+}
+
 struct TreeFmtNodeData<'a>(String, Vec<TreeFmtNode<'a>>);
 
 fn with_header(header: &Option<String>, text: &str) -> String {
@@ -158,8 +175,14 @@ impl<'a> TreeFmtNode<'a> {
         visitor.prev_depth = visitor.depth;
         visitor.depth += 1;
 
-        for child in &child_nodes {
-            child.traverse(visitor);
+        if self
+            .content
+            .cache_id(self.lp.lp_arena)
+            .is_none_or(|id| visitor.seen_caches.insert(id))
+        {
+            for child in &child_nodes {
+                child.traverse(visitor);
+            }
         }
 
         visitor.depth -= 1;
@@ -443,6 +466,7 @@ pub(crate) struct TreeFmtVisitor {
     prev_depth: usize,
     depth: usize,
     width: usize,
+    seen_caches: PlHashSet<UniqueId>,
     pub(crate) display: TreeFmtVisitorDisplay,
 }
 

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -1422,8 +1422,6 @@ def test_cspe_projection_between_filter_and_cache_drop_filter_column() -> None:
                 1,  # select(a + 1)
                 1,  # select(a + 1)
                 2,  # concat(lf2, lf2)
-                1,  # select(a + 1)
-                1,  # select(a + 1)
             ],
         ),
     ],
@@ -1519,7 +1517,7 @@ def test_cse_existing_predicate_at_scan_27748() -> None:
 
     plan = q.explain()
 
-    assert plan.count('SELECTION: col("y0")') == 2
+    assert plan.count('SELECTION: col("y0")') == 1
     assert plan.count('SELECTION: col("y1")') == 1
     assert plan.count("CACHE[") == 2
 

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -3157,16 +3157,22 @@ def test_join_filter_pushdown_iejoin() -> None:
         'RIGHT PLAN ON: [col("a"), col("b")]',
         'RIGHT PLAN ON: [col("b"), col("a")]',
     }
-    assert extract[3] in {
-        'LEFT PLAN ON: [col("a"), col("b")]',
-        'LEFT PLAN ON: [col("b"), col("a")]',
-    }
-    assert extract[4] == 'FILTER [(col("a")) > (0)]'
-    assert extract[5] in {
-        'RIGHT PLAN ON: [col("a"), col("b")]',
-        'RIGHT PLAN ON: [col("b"), col("a")]',
-    }
-    assert len(extract) == 6
+
+    cse_applied = plan.count("CACHE") == 2
+
+    if cse_applied:
+        assert len(extract) == 3
+    else:
+        assert extract[3] in {
+            'LEFT PLAN ON: [col("a"), col("b")]',
+            'LEFT PLAN ON: [col("b"), col("a")]',
+        }
+        assert extract[4] == 'FILTER [(col("a")) > (0)]'
+        assert extract[5] in {
+            'RIGHT PLAN ON: [col("a"), col("b")]',
+            'RIGHT PLAN ON: [col("b"), col("a")]',
+        }
+        assert len(extract) == 6
 
     assert_frame_equal(q.collect().sort(pl.all()), expect)
     assert_frame_equal(


### PR DESCRIPTION
This PR:
- Track seen caches in explain and tree explain to prevent printing the cache input plan multiple times. As the number of nested caches increases, the amount of output grows exponentially and can reach multiple gigabytes on moderately sized queries.
- The input plan of the cache is traversed only the first time the cache is encountered. Subsequent visits only print the cache node itself, as if it didn't have any inputs. The input can be looked up earlier in the explain string by the cache id.
