### PR TITLE
fix: Raise on Series arithmetic between temporal and non-temporal dtypes

### DIFF
--- a/crates/polars-core/src/series/arithmetic/borrowed.rs
+++ b/crates/polars-core/src/series/arithmetic/borrowed.rs
@@ -507,6 +507,13 @@ impl Add for &Series {
             (DataType::Struct(_), DataType::Struct(_)) => {
                 _struct_arithmetic(self, rhs, |a, b| a.add(b))
             },
+            // Combining a temporal type (Date/Datetime/Duration/Time) with a
+            // non-temporal type is never valid for `+`. This mirrors
+            // `get_arithmetic_field` (polars-plan) so the eager Series path
+            // matches the expression path. See #19135.
+            (l, r) if l.is_temporal() != r.is_temporal() => {
+                polars_bail!(opq = add, l, r)
+            },
             (DataType::List(_), _) | (_, DataType::List(_)) => {
                 list::NumericListOp::add().execute(self, rhs)
             },
@@ -531,6 +538,10 @@ impl Sub for &Series {
             #[cfg(feature = "dtype-struct")]
             (DataType::Struct(_), DataType::Struct(_)) => {
                 _struct_arithmetic(self, rhs, |a, b| a.sub(b))
+            },
+            // Same temporal handling as `Add`. See #19135.
+            (l, r) if l.is_temporal() != r.is_temporal() => {
+                polars_bail!(opq = sub, l, r)
             },
             (DataType::List(_), _) | (_, DataType::List(_)) => {
                 list::NumericListOp::sub().execute(self, rhs)

--- a/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
@@ -705,6 +705,35 @@ def test_raise_invalid_temporal(a: pl.DataType, b: pl.DataType, op: str) -> None
         eval(f"_df.select(pl.col('a') {op} pl.col('b'))")
 
 
+@pytest.mark.parametrize(
+    ("a_dtype", "b_dtype", "op"),
+    [
+        (pl.Date, pl.Int32, "+"),
+        (pl.Int32, pl.Date, "+"),
+        (pl.Date, pl.Int32, "-"),
+        (pl.Int32, pl.Date, "-"),
+        (pl.Datetime, pl.Int32, "+"),
+        (pl.Int32, pl.Datetime, "+"),
+        (pl.Datetime, pl.Int32, "-"),
+        (pl.Time, pl.Int32, "+"),
+        (pl.Int32, pl.Time, "+"),
+        (pl.Time, pl.Int32, "-"),
+        (pl.Duration, pl.Int32, "+"),
+        (pl.Int32, pl.Duration, "+"),
+        (pl.Duration, pl.Int32, "-"),
+    ],
+)
+def test_series_temporal_arithmetic_raises_19135(
+    a_dtype: pl.DataType, b_dtype: pl.DataType, op: str
+) -> None:
+    # Direct Series-level arithmetic must reject temporal/non-temporal combinations
+    # for +/-, matching what the lazy/expression path already does. See #19135.
+    a = pl.Series("a", [], dtype=a_dtype)
+    b = pl.Series("b", [], dtype=b_dtype)
+    with pytest.raises(InvalidOperationError):
+        eval(f"a {op} b")
+
+
 def test_arithmetic_duration_div_multiply() -> None:
     df = pl.DataFrame([pl.Series("a", [100, 200, 3000], dtype=pl.Duration)])
 


### PR DESCRIPTION
Closes #19135.

## What was happening

`Series + Series` and `Series - Series` silently coerced a temporal operand to its physical integer representation when paired with a numeric one:

```python
import polars as pl
import datetime as dt

l = pl.Series([dt.date(2024, 1, 1)], dtype=pl.Date)
r = pl.Series([1], dtype=pl.Int32)

l + r                                    # before: Series<i32>[19724]
l.to_frame().select(pl.first() + r)      # already raised on the lazy path
```

The lazy/expression path was already rejecting this combination through `get_arithmetic_field` in `crates/polars-plan/src/plans/aexpr/schema.rs`. The eager Series path in `crates/polars-core/src/series/arithmetic/borrowed.rs` was not — it dropped into `coerce_lhs_rhs` which picked the numeric supertype.

## Fix

One guard added to `impl Add for &Series` and `impl Sub for &Series`: when exactly one of the two operands is temporal (i.e. `is_temporal()` differs), bail with `InvalidOperationError`. When both are temporal, the existing fallback continues to handle the valid combinations through `coerce_lhs_rhs` + `coerce_time_units`.

| op | before | after |
|---|---|---|
| `Date + Int32` | `Int32` silent | `InvalidOperationError` |
| `Datetime(μs) - Int32` | `Int64` silent (raw μs) | `InvalidOperationError` |
| `Time + Int32` | `Int64` silent (raw ns) | `InvalidOperationError` |
| `Int32 + Date` | `Int32` silent | `InvalidOperationError` |
| `Date + Duration` | `Date` | `Date` |
| `Date - Date` | `Duration` | `Duration` |
| `Datetime - Date` | `Duration` | `Duration` |
| `Date + Date` | `InvalidOperationError` | `InvalidOperationError` |

Scalar paths (`impl Add<T>` / `impl Sub<T>` where `T: Num + NumCast`) are deliberately untouched: they go through `to_physical_repr` / `finish_cast` so `Date - 5` keeps returning `Date`, which is a separate, intentional, semantic.

## Tests

`test_series_temporal_arithmetic_raises_19135` added in `py-polars/tests/unit/operations/arithmetic/test_arithmetic.py`, next to the existing `test_raise_invalid_temporal` which already covered the lazy/expression path. Parametrised across Date/Datetime/Time/Duration × Int32 × {+, -}.

Local sweep:

- `pytest py-polars/tests/unit/operations/arithmetic` → 172 passed
- `pytest py-polars/tests/unit/datatypes/{temporal,duration,time}.py` → 610 passed
- `pytest py-polars/tests/unit/{dataframe,lazyframe,series}` → 1676 passed, 2 skipped
- `cargo fmt --check`, `cargo clippy --locked -p polars-core --all-features`, `ruff check`, `ruff format --check`, `typos`, `mypy` — all clean

## Side note (not addressed here)

`pl.Series([t], pl.Time) + pl.Series([d], pl.Duration("us"))` raises `SchemaError: failed to determine supertype of time and duration[μs]` instead of returning `Time`. The schema-level matrix lists this as valid, so the gap is a missing arm in `crates/polars-core/src/series/implementations/time.rs`. I'll open a separate issue for it.

## AI disclosure

This PR was developed with Claude Code as a coding assistant: it helped survey the issue tracker, draft the patch and the test, and run the local lint/test loop. I reviewed every line of the diff, ran the tests and lints on my machine, and verified the behavior change against the expression path.

<img width="1722" height="862" alt="Capture d&#39;écran 2026-06-10 233853" src="https://github.com/user-attachments/assets/122fbd28-09cd-4db9-8f03-64209b461f63" />
