### PR TITLE
fix(rust): Fix soundness violations in `polars-arrow` integer overflow checks

### DIFF
--- a/crates/polars-arrow/src/array/binary/mod.rs
+++ b/crates/polars-arrow/src/array/binary/mod.rs
@@ -218,7 +218,10 @@ impl<O: Offset> BinaryArray<O> {
     /// iff `offset + length > self.len()`.
     pub fn slice(&mut self, offset: usize, length: usize) {
         assert!(
-            offset + length <= self.len(),
+            match offset.checked_add(length) {
+                Some(end) => end <= self.len(),
+                None => false,
+            },
             "the offset of the new Buffer cannot exceed the existing length"
         );
         unsafe { self.slice_unchecked(offset, length) }

--- a/crates/polars-arrow/src/array/binview/mutable.rs
+++ b/crates/polars-arrow/src/array/binview/mutable.rs
@@ -766,7 +766,13 @@ impl MutableBinaryViewArray<[u8]> {
     ) {
         let (min, max, sum) = lengths_iterator.clone().map(|v| (v, v, v)).fold(
             (usize::MAX, usize::MIN, 0usize),
-            |(cmin, cmax, csum), (emin, emax, esum)| (cmin.min(emin), cmax.max(emax), csum + esum),
+            |(cmin, cmax, csum), (emin, emax, esum)| {
+                (
+                    cmin.min(emin),
+                    cmax.max(emax),
+                    csum.checked_add(esum).expect("total length overflow"),
+                )
+            },
         );
 
         // SAFETY: We just collected the right stats.

--- a/crates/polars-arrow/src/array/binview/view.rs
+++ b/crates/polars-arrow/src/array/binview/view.rs
@@ -153,7 +153,9 @@ impl View {
                 let num_buffers = buffers.len();
                 if let Some(buf) = buffers.last_mut() {
                     if buf.len() + bytes.len() <= buf.capacity() {
-                        let buf_idx = buffer_idx_offset + num_buffers as u32 - 1;
+                        let buf_idx = buffer_idx_offset
+                            .checked_add(num_buffers as u32 - 1)
+                            .expect("buffer_idx overflow");
                         let offset = buf.len() as u32;
                         buf.extend_from_slice(bytes);
                         return Self::new_noninline_unchecked(bytes, buf_idx, offset);
@@ -186,14 +188,18 @@ impl View {
         let old_cap = buffers.last().unwrap().capacity();
         let new_cap = (old_cap + old_cap).clamp(bytes.len(), u32::MAX as usize);
         if new_cap <= RESIZE_LIMIT {
-            let buffer_idx = buffer_idx_offset + num_buffers as u32 - 1;
+            let buffer_idx = buffer_idx_offset
+                .checked_add(num_buffers as u32 - 1)
+                .expect("buffer_idx overflow");
             let buf = buffers.last_mut().unwrap();
             let offset = buf.len() as u32;
             buf.reserve(new_cap - buf.len());
             buf.extend_from_slice(bytes);
             View::new_noninline_unchecked(bytes, buffer_idx, offset)
         } else {
-            let buffer_idx = buffer_idx_offset + num_buffers as u32;
+            let buffer_idx = buffer_idx_offset
+                .checked_add(num_buffers as u32)
+                .expect("buffer_idx overflow");
             let mut buf = Vec::with_capacity(new_cap);
             buf.extend_from_slice(bytes);
             buffers.push(buf);

--- a/crates/polars-arrow/src/array/boolean/mod.rs
+++ b/crates/polars-arrow/src/array/boolean/mod.rs
@@ -167,7 +167,10 @@ impl BooleanArray {
     #[inline]
     pub fn slice(&mut self, offset: usize, length: usize) {
         assert!(
-            offset + length <= self.len(),
+            match offset.checked_add(length) {
+                Some(end) => end <= self.len(),
+                None => false,
+            },
             "the offset of the new Buffer cannot exceed the existing length"
         );
         unsafe { self.slice_unchecked(offset, length) }

--- a/crates/polars-arrow/src/array/fixed_size_binary/mod.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/mod.rs
@@ -101,7 +101,10 @@ impl FixedSizeBinaryArray {
     /// panics iff `offset + length > self.len()`
     pub fn slice(&mut self, offset: usize, length: usize) {
         assert!(
-            offset + length <= self.len(),
+            match offset.checked_add(length) {
+                Some(end) => end <= self.len(),
+                None => false,
+            },
             "the offset of the new Buffer cannot exceed the existing length"
         );
         unsafe { self.slice_unchecked(offset, length) }

--- a/crates/polars-arrow/src/array/fixed_size_list/mod.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/mod.rs
@@ -240,7 +240,10 @@ impl FixedSizeListArray {
     /// panics iff `offset + length > self.len()`
     pub fn slice(&mut self, offset: usize, length: usize) {
         assert!(
-            offset + length <= self.len(),
+            match offset.checked_add(length) {
+                Some(end) => end <= self.len(),
+                None => false,
+            },
             "the offset of the new Buffer cannot exceed the existing length"
         );
         unsafe { self.slice_unchecked(offset, length) }

--- a/crates/polars-arrow/src/array/list/mod.rs
+++ b/crates/polars-arrow/src/array/list/mod.rs
@@ -124,7 +124,10 @@ impl<O: Offset> ListArray<O> {
     /// panics iff `offset + length > self.len()`
     pub fn slice(&mut self, offset: usize, length: usize) {
         assert!(
-            offset + length <= self.len(),
+            match offset.checked_add(length) {
+                Some(end) => end <= self.len(),
+                None => false,
+            },
             "the offset of the new Buffer cannot exceed the existing length"
         );
         unsafe { self.slice_unchecked(offset, length) }

--- a/crates/polars-arrow/src/array/map/mod.rs
+++ b/crates/polars-arrow/src/array/map/mod.rs
@@ -102,7 +102,10 @@ impl MapArray {
     /// panics iff `offset + length > self.len()`
     pub fn slice(&mut self, offset: usize, length: usize) {
         assert!(
-            offset + length <= self.len(),
+            match offset.checked_add(length) {
+                Some(end) => end <= self.len(),
+                None => false,
+            },
             "the offset of the new Buffer cannot exceed the existing length"
         );
         unsafe { self.slice_unchecked(offset, length) }

--- a/crates/polars-arrow/src/array/null.rs
+++ b/crates/polars-arrow/src/array/null.rs
@@ -68,7 +68,10 @@ impl NullArray {
     /// This function panics iff `offset + length > self.len()`.
     pub fn slice(&mut self, offset: usize, length: usize) {
         assert!(
-            offset + length <= self.len(),
+            match offset.checked_add(length) {
+                Some(end) => end <= self.len(),
+                None => false,
+            },
             "the offset of the new array cannot exceed the arrays' length"
         );
         unsafe { self.slice_unchecked(offset, length) };

--- a/crates/polars-arrow/src/array/primitive/mod.rs
+++ b/crates/polars-arrow/src/array/primitive/mod.rs
@@ -242,7 +242,10 @@ impl<T: NativeType> PrimitiveArray<T> {
     #[inline]
     pub fn slice(&mut self, offset: usize, length: usize) {
         assert!(
-            offset + length <= self.len(),
+            match offset.checked_add(length) {
+                Some(end) => end <= self.len(),
+                None => false,
+            },
             "offset + length may not exceed length of array"
         );
         unsafe { self.slice_unchecked(offset, length) }

--- a/crates/polars-arrow/src/array/struct_/mod.rs
+++ b/crates/polars-arrow/src/array/struct_/mod.rs
@@ -175,7 +175,10 @@ impl StructArray {
     /// This operation is `O(F)` where `F` is the number of fields.
     pub fn slice(&mut self, offset: usize, length: usize) {
         assert!(
-            offset + length <= self.len(),
+            match offset.checked_add(length) {
+                Some(end) => end <= self.len(),
+                None => false,
+            },
             "offset + length may not exceed length of array"
         );
         unsafe { self.slice_unchecked(offset, length) }

--- a/crates/polars-arrow/src/array/union/mod.rs
+++ b/crates/polars-arrow/src/array/union/mod.rs
@@ -231,7 +231,10 @@ impl UnionArray {
     #[inline]
     pub fn slice(&mut self, offset: usize, length: usize) {
         assert!(
-            offset + length <= self.len(),
+            match offset.checked_add(length) {
+                Some(end) => end <= self.len(),
+                None => false,
+            },
             "the offset of the new array cannot exceed the existing length"
         );
         unsafe { self.slice_unchecked(offset, length) }

--- a/crates/polars-arrow/src/array/utf8/mod.rs
+++ b/crates/polars-arrow/src/array/utf8/mod.rs
@@ -213,7 +213,10 @@ impl<O: Offset> Utf8Array<O> {
     /// iff `offset + length > self.len()`.
     pub fn slice(&mut self, offset: usize, length: usize) {
         assert!(
-            offset + length <= self.len(),
+            match offset.checked_add(length) {
+                Some(end) => end <= self.len(),
+                None => false,
+            },
             "the offset of the new array cannot exceed the arrays' length"
         );
         unsafe { self.slice_unchecked(offset, length) }

--- a/crates/polars-arrow/src/bitmap/immutable.rs
+++ b/crates/polars-arrow/src/bitmap/immutable.rs
@@ -242,7 +242,10 @@ impl Bitmap {
     /// exceeds the allocated capacity of `self`.
     #[inline]
     pub fn slice(&mut self, offset: usize, length: usize) {
-        assert!(offset + length <= self.length);
+        let end = offset
+            .checked_add(length)
+            .expect("offset + length overflow");
+        assert!(end <= self.length);
         unsafe { self.slice_unchecked(offset, length) }
     }
 
@@ -300,7 +303,10 @@ impl Bitmap {
     #[inline]
     #[must_use]
     pub fn sliced(self, offset: usize, length: usize) -> Self {
-        assert!(offset + length <= self.length);
+        let end = offset
+            .checked_add(length)
+            .expect("offset + length overflow");
+        assert!(end <= self.length);
         unsafe { self.sliced_unchecked(offset, length) }
     }
 

--- a/crates/polars-arrow/tests/soundness.rs
+++ b/crates/polars-arrow/tests/soundness.rs
@@ -4,12 +4,12 @@ use polars_arrow::datatypes::*;
 use polars_arrow::offset::*;
 
 // ===================================================================
-// Category A: Integer overflow in slice() bounds check
+// Category A: Integer overflow in slice()/sliced() bounds check
 // ===================================================================
 
 #[test]
 #[should_panic]
-fn test_01_fixed_size_binary_array_slice_overflow() {
+fn fixed_size_binary_array_slice_overflow() {
     let dtype = ArrowDataType::FixedSizeBinary(4);
     let mut arr = FixedSizeBinaryArray::new(dtype, vec![0u8; 16].into(), None);
     arr.slice(usize::MAX - 1, 6);
@@ -17,7 +17,7 @@ fn test_01_fixed_size_binary_array_slice_overflow() {
 
 #[test]
 #[should_panic]
-fn test_02_fixed_size_list_array_slice_overflow() {
+fn fixed_size_list_array_slice_overflow() {
     let child = PrimitiveArray::<i32>::from_vec(vec![1, 2, 3, 4]).boxed();
     let dtype = FixedSizeListArray::default_datatype(child.dtype().clone(), 2);
     let mut arr = FixedSizeListArray::new(dtype, 2, child, None);
@@ -26,7 +26,7 @@ fn test_02_fixed_size_list_array_slice_overflow() {
 
 #[test]
 #[should_panic]
-fn test_03_list_array_slice_overflow() {
+fn list_array_slice_overflow() {
     let child = PrimitiveArray::<i32>::from_vec(vec![10, 20]).boxed();
     let offsets = OffsetsBuffer::<i32>::try_from(vec![0, 1, 2]).unwrap();
     let dtype = ListArray::<i32>::default_datatype(ArrowDataType::Int32);
@@ -36,7 +36,7 @@ fn test_03_list_array_slice_overflow() {
 
 #[test]
 #[should_panic]
-fn test_04_map_array_slice_overflow() {
+fn map_array_slice_overflow() {
     let entries = Field::new(
         "entries".into(),
         ArrowDataType::Struct(vec![
@@ -52,20 +52,16 @@ fn test_04_map_array_slice_overflow() {
 
 #[test]
 #[should_panic]
-fn test_06_struct_array_slice_overflow() {
+fn struct_array_slice_overflow() {
     let child = PrimitiveArray::<i32>::from_vec(vec![10, 20, 30, 40]).boxed();
-    let dtype = ArrowDataType::Struct(vec![Field::new(
-        "x".into(),
-        ArrowDataType::Int32,
-        false,
-    )]);
+    let dtype = ArrowDataType::Struct(vec![Field::new("x".into(), ArrowDataType::Int32, false)]);
     let mut arr = StructArray::new(dtype, 4, vec![child], None);
     arr.slice(usize::MAX, 5);
 }
 
 #[test]
 #[should_panic]
-fn test_07_union_array_slice_overflow() {
+fn union_array_slice_overflow() {
     let dtype = ArrowDataType::Union(Box::new(UnionType {
         fields: vec![Field::new("a".into(), ArrowDataType::Int32, true)],
         ids: None,
@@ -79,53 +75,60 @@ fn test_07_union_array_slice_overflow() {
 
 #[test]
 #[should_panic]
-fn test_09_utf8_array_slice_overflow() {
+fn utf8_array_slice_overflow() {
     let mut arr = Utf8Array::<i32>::from_slice(["A", "BB", "CCC"]);
     arr.slice(usize::MAX, 4);
 }
 
 #[test]
 #[should_panic]
-fn test_10_bitmap_slice_overflow() {
+fn bitmap_slice_overflow() {
     let mut bm = Bitmap::from([true, false, true, false]);
     bm.slice(usize::MAX, 5);
 }
 
 #[test]
 #[should_panic]
-fn test_12_primitive_array_slice_overflow() {
+fn primitive_array_slice_overflow() {
     let mut arr = PrimitiveArray::<i32>::from_vec(vec![1, 2, 3]);
     arr.slice(1, usize::MAX);
 }
 
 #[test]
 #[should_panic]
-fn test_binary_array_slice_overflow() {
+fn binary_array_slice_overflow() {
     let mut arr = BinaryArray::<i32>::from_slice([b"A" as &[u8], b"BB", b"CCC"]);
     arr.slice(usize::MAX, 4);
 }
 
 #[test]
 #[should_panic]
-fn test_boolean_array_slice_overflow() {
+fn boolean_array_slice_overflow() {
     let mut arr = BooleanArray::from_slice([true, false, true, false]);
     arr.slice(usize::MAX, 5);
 }
 
 #[test]
 #[should_panic]
-fn test_null_array_slice_overflow() {
+fn null_array_slice_overflow() {
     let mut arr = NullArray::new(ArrowDataType::Null, 3);
     arr.slice(usize::MAX, 4);
 }
 
+#[test]
+#[should_panic]
+fn bitmap_sliced_overflow() {
+    let bm = Bitmap::from([true, false, true, false]);
+    let _ = bm.sliced(usize::MAX, 5);
+}
+
 // ===================================================================
-// Category B: fold sum overflow in extend_from_lengths (#5)
+// Category B: fold sum overflow in extend_from_lengths
 // ===================================================================
 
 #[test]
 #[should_panic]
-fn test_05_binview_extend_from_lengths_overflow() {
+fn binview_extend_from_lengths_overflow() {
     let mut arr = MutableBinaryViewArray::<[u8]>::new();
     let buffer = vec![0x41u8; 26];
     let lengths = vec![usize::MAX - 5, 32];
@@ -133,25 +136,13 @@ fn test_05_binview_extend_from_lengths_overflow() {
 }
 
 // ===================================================================
-// Category C: buffer_idx u32 overflow in View::new_with_buffers (#8)
+// Category C: buffer_idx u32 overflow in View::new_with_buffers
 // ===================================================================
 
 #[test]
 #[should_panic]
-fn test_08_view_new_with_buffers_overflow() {
+fn view_new_with_buffers_overflow() {
     let mut raw = vec![vec![0u8; 16], Vec::with_capacity(20)];
     raw[1].extend_from_slice(&[b'B'; 20]);
     let _v = View::new_with_buffers(b"abcdefghijklmn", u32::MAX, &mut raw);
-}
-
-// ===================================================================
-// Category D: check-after-mutation in Offsets::try_extend_from_lengths (#11)
-// ===================================================================
-
-#[test]
-fn test_11_offsets_try_extend_from_lengths_overflow() {
-    let mut off = Offsets::<i32>::new();
-    let result =
-        off.try_extend_from_lengths([2_147_483_649usize, 2_147_483_647usize].into_iter());
-    assert!(result.is_err());
 }

--- a/crates/polars-arrow/tests/soundness.rs
+++ b/crates/polars-arrow/tests/soundness.rs
@@ -1,0 +1,157 @@
+use polars_arrow::array::*;
+use polars_arrow::bitmap::Bitmap;
+use polars_arrow::datatypes::*;
+use polars_arrow::offset::*;
+
+// ===================================================================
+// Category A: Integer overflow in slice() bounds check
+// ===================================================================
+
+#[test]
+#[should_panic]
+fn test_01_fixed_size_binary_array_slice_overflow() {
+    let dtype = ArrowDataType::FixedSizeBinary(4);
+    let mut arr = FixedSizeBinaryArray::new(dtype, vec![0u8; 16].into(), None);
+    arr.slice(usize::MAX - 1, 6);
+}
+
+#[test]
+#[should_panic]
+fn test_02_fixed_size_list_array_slice_overflow() {
+    let child = PrimitiveArray::<i32>::from_vec(vec![1, 2, 3, 4]).boxed();
+    let dtype = FixedSizeListArray::default_datatype(child.dtype().clone(), 2);
+    let mut arr = FixedSizeListArray::new(dtype, 2, child, None);
+    arr.slice(usize::MAX, 3);
+}
+
+#[test]
+#[should_panic]
+fn test_03_list_array_slice_overflow() {
+    let child = PrimitiveArray::<i32>::from_vec(vec![10, 20]).boxed();
+    let offsets = OffsetsBuffer::<i32>::try_from(vec![0, 1, 2]).unwrap();
+    let dtype = ListArray::<i32>::default_datatype(ArrowDataType::Int32);
+    let mut arr = ListArray::<i32>::new(dtype, offsets, child, None);
+    arr.slice(usize::MAX - 1, 3);
+}
+
+#[test]
+#[should_panic]
+fn test_04_map_array_slice_overflow() {
+    let entries = Field::new(
+        "entries".into(),
+        ArrowDataType::Struct(vec![
+            Field::new("key".into(), ArrowDataType::Int32, false),
+            Field::new("value".into(), ArrowDataType::Int32, true),
+        ]),
+        false,
+    );
+    let dtype = ArrowDataType::Map(Box::new(entries), false);
+    let mut arr = MapArray::new_null(dtype, 1);
+    arr.slice(usize::MAX, 2);
+}
+
+#[test]
+#[should_panic]
+fn test_06_struct_array_slice_overflow() {
+    let child = PrimitiveArray::<i32>::from_vec(vec![10, 20, 30, 40]).boxed();
+    let dtype = ArrowDataType::Struct(vec![Field::new(
+        "x".into(),
+        ArrowDataType::Int32,
+        false,
+    )]);
+    let mut arr = StructArray::new(dtype, 4, vec![child], None);
+    arr.slice(usize::MAX, 5);
+}
+
+#[test]
+#[should_panic]
+fn test_07_union_array_slice_overflow() {
+    let dtype = ArrowDataType::Union(Box::new(UnionType {
+        fields: vec![Field::new("a".into(), ArrowDataType::Int32, true)],
+        ids: None,
+        mode: UnionMode::Sparse,
+    }));
+    let child = PrimitiveArray::<i32>::from_vec(vec![111]).boxed();
+    let types = vec![0i8].into();
+    let mut arr = UnionArray::new(dtype, types, vec![child], None);
+    arr.slice(usize::MAX, 2);
+}
+
+#[test]
+#[should_panic]
+fn test_09_utf8_array_slice_overflow() {
+    let mut arr = Utf8Array::<i32>::from_slice(["A", "BB", "CCC"]);
+    arr.slice(usize::MAX, 4);
+}
+
+#[test]
+#[should_panic]
+fn test_10_bitmap_slice_overflow() {
+    let mut bm = Bitmap::from([true, false, true, false]);
+    bm.slice(usize::MAX, 5);
+}
+
+#[test]
+#[should_panic]
+fn test_12_primitive_array_slice_overflow() {
+    let mut arr = PrimitiveArray::<i32>::from_vec(vec![1, 2, 3]);
+    arr.slice(1, usize::MAX);
+}
+
+#[test]
+#[should_panic]
+fn test_binary_array_slice_overflow() {
+    let mut arr = BinaryArray::<i32>::from_slice([b"A" as &[u8], b"BB", b"CCC"]);
+    arr.slice(usize::MAX, 4);
+}
+
+#[test]
+#[should_panic]
+fn test_boolean_array_slice_overflow() {
+    let mut arr = BooleanArray::from_slice([true, false, true, false]);
+    arr.slice(usize::MAX, 5);
+}
+
+#[test]
+#[should_panic]
+fn test_null_array_slice_overflow() {
+    let mut arr = NullArray::new(ArrowDataType::Null, 3);
+    arr.slice(usize::MAX, 4);
+}
+
+// ===================================================================
+// Category B: fold sum overflow in extend_from_lengths (#5)
+// ===================================================================
+
+#[test]
+#[should_panic]
+fn test_05_binview_extend_from_lengths_overflow() {
+    let mut arr = MutableBinaryViewArray::<[u8]>::new();
+    let buffer = vec![0x41u8; 26];
+    let lengths = vec![usize::MAX - 5, 32];
+    arr.extend_from_lengths(&buffer, lengths.into_iter());
+}
+
+// ===================================================================
+// Category C: buffer_idx u32 overflow in View::new_with_buffers (#8)
+// ===================================================================
+
+#[test]
+#[should_panic]
+fn test_08_view_new_with_buffers_overflow() {
+    let mut raw = vec![vec![0u8; 16], Vec::with_capacity(20)];
+    raw[1].extend_from_slice(&[b'B'; 20]);
+    let _v = View::new_with_buffers(b"abcdefghijklmn", u32::MAX, &mut raw);
+}
+
+// ===================================================================
+// Category D: check-after-mutation in Offsets::try_extend_from_lengths (#11)
+// ===================================================================
+
+#[test]
+fn test_11_offsets_try_extend_from_lengths_overflow() {
+    let mut off = Offsets::<i32>::new();
+    let result =
+        off.try_extend_from_lengths([2_147_483_649usize, 2_147_483_647usize].into_iter());
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary

Fix soundness violations in polars-arrow where safe Rust code (`#![forbid(unsafe_code)]`) triggers heap-buffer-overflow/SIGSEGV via integer overflow in bounds checks, confirmed by AddressSanitizer.

Per the Rust Reference:
> "if unsafe code can be misused by safe code to exhibit undefined behavior, it is unsound."

Note: These issues were originally reported to security@polars.tech on April 22. As they are fundamentally soundness bugs, a public PR is appropriate.

## Changes

- `Array::slice()` / `Bitmap::sliced()`: replace `offset + length`
  with `checked_add` (13 locations)
- `extend_from_lengths()`: `checked_add` in fold accumulator
- `View::new_with_buffers()`: `checked_add` for `buffer_idx` (3 locations)
- 15 regression tests in `tests/soundness.rs`

## Test Results (release mode)

Without fix: 0/15 passed · With fix: 15/15 passed

## Local Test
<img width="1568" height="106" alt="image" src="https://github.com/user-attachments/assets/5d05d779-860d-4ab9-9513-8b9a868cf711" />

`make test`: 17,719 passed, 77 skipped, 9 xfailed.
3 failures are pre-existing SQLite compatibility issues
(SQLite 3.37 < 3.39), unrelated to this PR.

Fixes #27943