### PR TITLE
fix: Correct Arrow FFI export of sliced struct arrays with nulls

### DIFF
--- a/crates/polars-arrow/src/array/struct_/ffi.rs
+++ b/crates/polars-arrow/src/array/struct_/ffi.rs
@@ -3,6 +3,7 @@ use polars_error::PolarsResult;
 use super::super::ffi::ToFfi;
 use super::super::{Array, FromFfi};
 use super::StructArray;
+use crate::bitmap::align;
 use crate::ffi;
 
 unsafe impl ToFfi for StructArray {
@@ -15,16 +16,28 @@ unsafe impl ToFfi for StructArray {
     }
 
     fn offset(&self) -> Option<usize> {
-        Some(
-            self.validity
-                .as_ref()
-                .map(|bitmap| bitmap.offset())
-                .unwrap_or_default(),
-        )
+        // The child arrays are sliced together with the struct (see `slice_unchecked`),
+        // so they already start at logical index 0. The exported offset is applied to the
+        // children by the consumer, hence it must be 0 to avoid shifting them a second time.
+        //
+        // The only buffer the struct owns is the validity bitmap. A non-zero bitmap offset
+        // cannot be expressed through a raw pointer, so we signal that the array first needs
+        // to be re-aligned via `to_ffi_aligned`.
+        match self.validity.as_ref() {
+            Some(bitmap) if bitmap.offset() != 0 => None,
+            _ => Some(0),
+        }
     }
 
     fn to_ffi_aligned(&self) -> Self {
-        self.clone()
+        // Re-align the validity bitmap to offset 0 so it matches the already-sliced children.
+        let validity = self.validity.as_ref().map(|bitmap| align(bitmap, 0));
+        Self::new(
+            self.dtype.clone(),
+            self.length,
+            self.values.clone(),
+            validity,
+        )
     }
 }
 

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -894,6 +894,22 @@ def test_sliced_struct_from_arrow() -> None:
     assert result.to_dict(as_series=False) == {"struct_col": [{"a": 2, "b": "bar"}]}
 
 
+def test_to_arrow_sliced_struct_with_nulls_23214() -> None:
+    s = pl.Series([{"a": 1}, {"a": 2}, None], dtype=pl.Struct({"a": pl.Int32}))
+
+    arr = s[1:].to_arrow()
+    arr.validate(full=True)
+    assert arr.to_pylist() == [{"a": 2}, None]
+
+    s2 = pl.Series(
+        [{"a": 1}, {"a": 2}, None, None, None, None, None, None, {"a": 4}],
+        dtype=pl.Struct({"a": pl.Int32}),
+    )
+    arr2 = s2[-2:].to_arrow()
+    arr2.validate(full=True)
+    assert arr2.to_pylist() == [None, {"a": 4}]
+
+
 def test_from_arrow_invalid_time_zone() -> None:
     arr = pa.array(
         [datetime(2021, 1, 1, 0, 0, 0, 0)],


### PR DESCRIPTION
Fixes #23214

## Problem

Slicing a struct column that contains top-level nulls and exporting it over the Arrow C Data Interface produced an **invalid** Arrow array — the struct's child arrays came out shorter than the struct itself:

```python
import polars as pl
s = pl.Series([{"a": 1}, {"a": 2}, None], dtype=pl.Struct({"a": pl.Int32}))
s[1:].to_arrow().validate(full=True)
# ArrowInvalid: Struct child array #0 has length smaller than expected (2 < 3)
```

Other shapes abort the process outright (`Check failed: (off) <= (length) Slice offset (7) greater than array length (2)`). This breaks any consumer of the C interface — pyarrow, R/nanoarrow (as reported in the issue), DuckDB, FFI. Polars' own Parquet/IPC readers happened to tolerate it, which is why it stayed hidden. `.collect()` / display were always fine; only the Arrow export was wrong.

## Root cause

In `ToFfi for StructArray`, `offset()` returned the **validity bitmap's** offset, while `children()` returned the child arrays that `slice_unchecked` had **already** sliced to start at logical index 0. The consumer applies the parent offset to the children, so the slice offset was applied **twice** to the children, leaving them shorter than the parent. This only triggered when a top-level validity buffer existed (i.e. nulls present) — without nulls, `offset()` was 0 and nothing was double-shifted.

## Fix

A `StructArray`'s children always have exactly the struct's length (enforced by `try_new`), so the struct never windows into longer children via the offset — the only offset it carries is the validity bitmap's bit-offset. So:

- `offset()` exports `0` (returning `None` to request re-alignment when the validity has a non-zero offset);
- `to_ffi_aligned()` re-aligns the validity bitmap to offset 0 instead of cloning as-is,

mirroring how `PrimitiveArray` reconciles its validity and values buffers to a single offset. The parent offset is then never applied to the children a second time.

## Tests

Added `test_to_arrow_sliced_struct_with_nulls_23214` (export + `validate(full=True)` + value check, covering both the `ArrowInvalid` and the abort variants from the issue). Verified existing `polars-arrow` (`cargo test`), interop (333), and struct/list/array datatype (406) suites still pass, plus an edge-case sweep (nested structs, multi-field, null-at-row-0, all-null, round-trips).