### PR TITLE
perf: Chunk-aware morsel splitting on single-file IO sink

### DIFF
--- a/crates/polars-core/src/frame/builder.rs
+++ b/crates/polars-core/src/frame/builder.rs
@@ -40,7 +40,7 @@ impl DataFrameBuilder {
             .zip(self.builders)
             .map(|(n, b)| {
                 let s = b.freeze(n.clone());
-                assert!(s.len() == self.height);
+                assert_eq!(s.len(), self.height);
                 Column::from(s)
             })
             .collect();
@@ -81,7 +81,6 @@ impl DataFrameBuilder {
     /// if other does not match the schema of this builder.
     pub fn extend(&mut self, other: &DataFrame, share: ShareStrategy) {
         self.subslice_extend(other, 0, other.height(), share);
-        self.height += other.height();
     }
 
     /// Extends this builder with the contents of the given dataframe subslice.

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/edge.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/edge.rs
@@ -3,10 +3,11 @@ use std::sync::{Arc, LazyLock};
 use polars_core::prelude::PlIndexSet;
 use polars_core::schema::Schema;
 use polars_utils::arena::{Arena, Node};
+use polars_utils::itertools::iters_eq::iters_eq;
 use polars_utils::pl_str::PlSmallStr;
 
 use crate::plans::IR;
-use crate::plans::optimizer::projection_pushdown::{iters_eq, min_dtype_size_col};
+use crate::plans::optimizer::projection_pushdown::min_dtype_size_col;
 
 #[derive(Debug, Clone)]
 pub struct Edge(ProjectionState, ParentKeyAndPort);

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -12,6 +12,7 @@ use polars_ops::frame::{JoinCoalesce, JoinType};
 use polars_utils::arena::{Arena, Node};
 use polars_utils::format_pl_smallstr;
 use polars_utils::itertools::Itertools as _;
+use polars_utils::itertools::iters_eq::iters_eq;
 use polars_utils::pl_str::PlSmallStr;
 use polars_utils::scratch_vec::ScratchVec;
 
@@ -2038,21 +2039,6 @@ fn compute_simple_projection_schema(
         let dtype = input_schema.get(name).unwrap().clone();
         (name.clone(), dtype)
     })))
-}
-
-/// Returns true if both iterators have the same length, and the items at each
-/// index are equal.
-fn iters_eq<L, R, T, U>(left: L, right: R) -> bool
-where
-    L: IntoIterator<Item = T>,
-    R: IntoIterator<Item = U>,
-    T: PartialEq<U>,
-    L::IntoIter: ExactSizeIterator,
-    R::IntoIter: ExactSizeIterator,
-{
-    let left = left.into_iter();
-    let right = right.into_iter();
-    left.len() == right.len() && left.zip(right).all(|(l, r)| l == r)
 }
 
 fn set_scan_projection(scan_ir: &mut IR, projection_schema: Arc<Schema>) {

--- a/crates/polars-stream/src/nodes/io_sinks/components/df_with_offset.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/components/df_with_offset.rs
@@ -1,0 +1,30 @@
+use polars_core::frame::DataFrame;
+
+/// Wrapper that exposes `split_off_front()` that avoids allocating for the remainder.
+pub struct DfWithOffset {
+    df: DataFrame,
+    offset: usize,
+}
+
+impl DfWithOffset {
+    pub fn new(df: DataFrame) -> Self {
+        Self { df, offset: 0 }
+    }
+
+    /// Note: This performs a linear scan across chunks on each call.
+    pub fn split_off_front(&mut self, n_rows: usize) -> DataFrame {
+        let ret = self.df.slice(self.offset as i64, n_rows);
+        self.offset += n_rows;
+        assert!(self.offset <= self.df.height());
+        ret
+    }
+
+    pub fn into_df(self) -> DataFrame {
+        self.df
+            .slice(self.offset as i64, self.df.height() - self.offset)
+    }
+
+    pub fn height(&self) -> usize {
+        self.df.height() - self.offset
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sinks/components/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/components/mod.rs
@@ -1,3 +1,4 @@
+pub mod df_with_offset;
 pub mod error_capture;
 pub mod exclude_keys_projection;
 pub mod file_provider;

--- a/crates/polars-stream/src/nodes/io_sinks/components/morsel_resize_pipeline.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/components/morsel_resize_pipeline.rs
@@ -1,18 +1,24 @@
+use std::collections::VecDeque;
 use std::sync::Arc;
 
 use polars_async::primitives::connector;
+use polars_async::primitives::wait_group::WaitToken;
 use polars_core::frame::DataFrame;
+use polars_core::schema::Schema;
 use polars_error::PolarsResult;
 use polars_utils::IdxSize;
+use polars_utils::calc_morsel_split::PartSizesIter;
+use polars_utils::index::idxsize_to_u64;
 
 use crate::morsel::Morsel;
+use crate::nodes::io_sinks::components::df_with_offset::DfWithOffset;
 use crate::nodes::io_sinks::components::sink_morsel::SinkMorsel;
-use crate::nodes::io_sinks::components::size::{RowCountAndSize, TakeableRowsProvider};
+use crate::nodes::io_sinks::components::size::{RowCountAndSize, TargetSinkMorselSize};
 
 /// Splits large morsels / combines small morsels.
 pub struct MorselResizePipeline {
-    pub empty_with_schema_df: DataFrame,
-    pub takeable_rows_provider: TakeableRowsProvider,
+    pub schema: Arc<Schema>,
+    pub target_sink_morsel_size: TargetSinkMorselSize,
     pub inflight_morsel_semaphore: Arc<tokio::sync::Semaphore>,
     pub morsel_rx: connector::Receiver<Morsel>,
     pub morsel_tx: connector::Sender<SinkMorsel>,
@@ -23,78 +29,172 @@ impl MorselResizePipeline {
     /// Returns an error if number of rows overflowed `IdxSize::MAX`.
     pub async fn run(self) -> PolarsResult<RowCountAndSize> {
         let MorselResizePipeline {
-            empty_with_schema_df,
-            takeable_rows_provider,
+            schema,
+            target_sink_morsel_size,
             inflight_morsel_semaphore,
             mut morsel_rx,
             mut morsel_tx,
         } = self;
 
-        let mut buffered_rows: DataFrame = empty_with_schema_df;
-        let mut received_size: RowCountAndSize = RowCountAndSize::default();
-        // Must always be <= received_size.
+        let mut buffered_rows: VecDeque<DfWithOffset> = VecDeque::with_capacity(4);
+        // <= physical_received_size, incremented as we scan more chunks from the physically
+        // received morsel.
+        let mut logical_received_size: RowCountAndSize = RowCountAndSize::default();
+        let mut physical_received_size: RowCountAndSize = RowCountAndSize::default();
+        // Must always be <= logical_received_size.
         let mut sent_size: RowCountAndSize = RowCountAndSize::default();
 
-        let mut flush = false;
+        let mut num_rows_to_take_iter = PartSizesIter::default();
+        // Note: Lengths are reversed as we pop from this.
+        let mut next_chunk_lengths: Vec<usize> = vec![];
+        let mut wait_token: Option<WaitToken> = None;
 
         loop {
-            let buffered_size = received_size.checked_sub(sent_size).unwrap();
-            assert_eq!(
-                buffered_size.num_rows,
-                IdxSize::try_from(buffered_rows.height()).unwrap()
-            );
-
-            if let Some(num_rows_to_take) =
-                takeable_rows_provider.num_rows_takeable_from(buffered_size, flush)
-            {
-                let morsel_permit = inflight_morsel_semaphore
-                    .clone()
-                    .acquire_owned()
-                    .await
+            let df_to_send = if let Some(num_rows_to_take) = num_rows_to_take_iter.next() {
+                take_n_rows_from_buffered(Arc::clone(&schema), &mut buffered_rows, num_rows_to_take)
+            } else if let Some(n_rows) = next_chunk_lengths.pop() {
+                let next_chunk_size = logical_received_size
+                    .calc_delta(n_rows as IdxSize, physical_received_size)
                     .unwrap();
 
-                let (df, remaining) = buffered_rows.split_at(
-                    #[allow(clippy::unnecessary_fallible_conversions)]
-                    i64::try_from(num_rows_to_take).unwrap(),
+                let logical_buffered_size = logical_received_size.checked_sub(sent_size).unwrap();
+
+                let send_buffered_as_one_df;
+
+                (send_buffered_as_one_df, num_rows_to_take_iter) = target_sink_morsel_size
+                    .calc_next_splits(logical_buffered_size, next_chunk_size);
+
+                logical_received_size = logical_received_size.add(next_chunk_size)?;
+
+                if send_buffered_as_one_df {
+                    take_n_rows_from_buffered(
+                        Arc::clone(&schema),
+                        &mut buffered_rows,
+                        idxsize_to_u64(logical_buffered_size.num_rows),
+                    )
+                } else {
+                    continue;
+                }
+            } else if let Ok(morsel) = morsel_rx.recv().await {
+                assert_eq!(
+                    logical_received_size.num_rows,
+                    physical_received_size.num_rows
                 );
+                // Force num_bytes to match.
+                logical_received_size = physical_received_size;
 
-                if morsel_tx
-                    .send(SinkMorsel::new(df, morsel_permit))
-                    .await
-                    .is_err()
+                let df: DataFrame;
+                drop(wait_token.take());
+
+                (df, _, _, wait_token) = morsel.into_inner();
+
+                if df.height() == 0 {
+                    continue;
+                }
+
+                let morsel_size = RowCountAndSize::new_from_df(&df);
+                physical_received_size = physical_received_size.add(morsel_size)?;
+
+                if let Some(s) = df
+                    .columns()
+                    .iter()
+                    .filter_map(|c| c.as_series())
+                    .max_by_key(|s| s.n_chunks())
                 {
-                    return Ok(sent_size);
-                };
+                    next_chunk_lengths.extend(s.chunk_lengths().rev());
+                } else {
+                    next_chunk_lengths.push(df.height());
+                }
 
-                buffered_rows = remaining;
-
-                sent_size = sent_size
-                    .add_delta(num_rows_to_take, received_size)
-                    .unwrap();
+                buffered_rows.push_back(DfWithOffset::new(df));
 
                 continue;
-            }
+            } else {
+                assert_eq!(
+                    logical_received_size.num_rows,
+                    physical_received_size.num_rows
+                );
+                // Force num_bytes to match.
+                logical_received_size = physical_received_size;
 
-            if flush {
-                break;
-            }
+                let logical_buffered_size = logical_received_size.checked_sub(sent_size).unwrap();
 
-            let Ok(morsel) = morsel_rx.recv().await else {
-                flush = true;
-                continue;
+                if logical_buffered_size.num_rows == 0 {
+                    assert!(buffered_rows.iter().all(|df| df.height() == 0));
+                    break;
+                }
+
+                take_n_rows_from_buffered(
+                    Arc::clone(&schema),
+                    &mut buffered_rows,
+                    idxsize_to_u64(logical_buffered_size.num_rows),
+                )
             };
 
-            let df = morsel.into_df();
-            let morsel_size = RowCountAndSize::new_from_df(&df);
+            let morsel_permit = inflight_morsel_semaphore
+                .clone()
+                .acquire_owned()
+                .await
+                .unwrap();
 
-            received_size = received_size.add(morsel_size)?;
+            sent_size = sent_size
+                .add_delta(df_to_send.height() as IdxSize, logical_received_size)
+                .unwrap();
 
-            buffered_rows.vstack_mut_owned_unchecked(df);
+            if morsel_tx
+                .send(SinkMorsel::new(df_to_send, morsel_permit))
+                .await
+                .is_err()
+            {
+                return Ok(sent_size);
+            };
         }
 
-        assert_eq!(buffered_rows.height(), 0);
-        assert_eq!(received_size.num_rows, sent_size.num_rows);
+        assert!(buffered_rows.iter().all(|df| df.height() == 0));
+        assert_eq!(logical_received_size.num_rows, sent_size.num_rows);
+        assert_eq!(physical_received_size.num_rows, sent_size.num_rows);
 
-        Ok(received_size)
+        Ok(physical_received_size)
     }
+}
+
+/// # Panics
+/// Panics if `n_rows` is greater than the total number of rows in `buffered_rows`.
+fn take_n_rows_from_buffered(
+    schema: Arc<Schema>,
+    buffered_rows: &mut VecDeque<DfWithOffset>,
+    mut n_rows: u64,
+) -> DataFrame {
+    if n_rows == 0 {
+        return DataFrame::empty_with_arc_schema(schema);
+    }
+
+    let mut stacked_df: Option<DataFrame> = None;
+
+    while n_rows != 0 {
+        let next_df = buffered_rows.front_mut().unwrap();
+
+        let next_df = if next_df.height() as u64 > n_rows {
+            next_df.split_off_front(n_rows as usize)
+        } else {
+            buffered_rows.pop_front().unwrap().into_df()
+        };
+
+        if next_df.height() as u64 == n_rows && stacked_df.is_none() {
+            return next_df;
+        }
+
+        let next_df_height = next_df.height();
+
+        match stacked_df.as_mut() {
+            Some(df) => {
+                df.vstack_mut_owned_unchecked(next_df);
+            },
+            None => stacked_df = Some(next_df),
+        };
+
+        n_rows -= next_df_height as u64;
+    }
+
+    stacked_df.unwrap()
 }

--- a/crates/polars-stream/src/nodes/io_sinks/components/partition_distributor.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/components/partition_distributor.rs
@@ -108,9 +108,8 @@ impl PartitionDistributor {
 
                 let buffered_size = partition_data.buffered_size();
 
-                let num_ready_to_send_rows = partition_morsel_sender
-                    .takeable_rows_provider
-                    .num_rows_takeable_from(buffered_size, false);
+                let num_ready_to_send_rows =
+                    partition_morsel_sender.next_rows_to_take(buffered_size, false);
 
                 if num_ready_to_send_rows.is_some() {
                     if partition_data.file_sink_task_data.is_none()

--- a/crates/polars-stream/src/nodes/io_sinks/components/partition_morsel_sender.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/components/partition_morsel_sender.rs
@@ -13,12 +13,12 @@ use crate::nodes::io_sinks::components::partition_sink_starter::PartitionSinkSta
 use crate::nodes::io_sinks::components::partition_state::PartitionState;
 use crate::nodes::io_sinks::components::sink_morsel::SinkMorsel;
 use crate::nodes::io_sinks::components::size::{
-    NonZeroRowCountAndSize, RowCountAndSize, TakeableRowsProvider,
+    NonZeroRowCountAndSize, RowCountAndSize, SplitMode, TargetSinkMorselSize,
 };
 
 pub struct PartitionMorselSender {
     /// Note: Must be <= `file_size_limit` if there is one.
-    pub takeable_rows_provider: TakeableRowsProvider,
+    pub target_sink_morsel_size: TargetSinkMorselSize,
     pub file_size_limit: NonZeroRowCountAndSize,
     pub inflight_morsel_semaphore: Arc<tokio::sync::Semaphore>,
     pub open_sinks_semaphore: Arc<tokio::sync::Semaphore>,
@@ -78,21 +78,15 @@ impl PartitionMorselSender {
 
             let buffered_size = partition.buffered_size();
 
-            if buffered_size.num_rows == 0 {
-                return Ok(());
-            }
-
-            let Some(num_rows_to_take) = self
-                .takeable_rows_provider
-                .num_rows_takeable_from(buffered_size, flush)
-            else {
+            let Some(num_rows_to_take) = self.next_rows_to_take(buffered_size, flush) else {
                 return Ok(());
             };
 
-            let file_min_available_rows_for_byte_size =
-                NonZeroRowCountAndSize::get(self.takeable_rows_provider.max_size)
-                    .num_rows
-                    .saturating_sub(used_row_capacity.num_rows);
+            let file_min_available_rows_for_byte_size = self
+                .target_sink_morsel_size
+                .target_num_rows
+                .get()
+                .saturating_sub(used_row_capacity.num_rows);
 
             let max_takeable_rows: IdxSize = available_row_capacity
                 .num_rows_takeable_from(buffered_size, file_min_available_rows_for_byte_size);
@@ -101,7 +95,7 @@ impl PartitionMorselSender {
             let num_rows_to_take = if start_new_sink {
                 num_rows_to_take
             } else {
-                num_rows_to_take.min(max_takeable_rows)
+                IdxSize::min(num_rows_to_take, max_takeable_rows)
             };
 
             if start_new_sink {
@@ -156,10 +150,13 @@ impl PartitionMorselSender {
             let morsel_height: IdxSize = IdxSize::try_from(morsel.height()).unwrap();
 
             debug_assert!(
-                self.takeable_rows_provider.max_size.get().num_rows
+                self.target_sink_morsel_size.target_num_rows.get()
                     <= self.file_size_limit.get().num_rows
             );
-            debug_assert!(morsel_height <= self.takeable_rows_provider.max_size.get().num_rows);
+
+            if self.target_sink_morsel_size.target_num_rows_mode == SplitMode::Exact {
+                debug_assert!(morsel_height <= self.target_sink_morsel_size.target_num_rows.get());
+            }
 
             assert!((1..=available_row_capacity.num_rows).contains(&morsel_height));
 
@@ -185,5 +182,18 @@ impl PartitionMorselSender {
                 .add_delta(morsel_height, partition.total_size)
                 .unwrap();
         }
+    }
+
+    pub fn next_rows_to_take(
+        &self,
+        buffered_size: RowCountAndSize,
+        flush: bool,
+    ) -> Option<IdxSize> {
+        self.target_sink_morsel_size
+            .calc_next_splits(RowCountAndSize::default(), buffered_size)
+            .1
+            .next()
+            .map(|n_rows| n_rows as IdxSize)
+            .or_else(|| (flush && buffered_size.num_rows != 0).then_some(buffered_size.num_rows))
     }
 }

--- a/crates/polars-stream/src/nodes/io_sinks/components/size.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/components/size.rs
@@ -1,9 +1,11 @@
+use std::cmp;
 use std::num::NonZeroU64;
 
 use polars_core::frame::DataFrame;
 use polars_error::{PolarsResult, polars_err};
 use polars_utils::IdxSize;
-use polars_utils::index::NonZeroIdxSize;
+use polars_utils::calc_morsel_split::{PartSizesIter, calc_n_parts};
+use polars_utils::index::{NonZeroIdxSize, idxsize_to_u64};
 
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub struct RowCountAndSize {
@@ -27,7 +29,7 @@ impl RowCountAndSize {
     /// How many rows from `other` can fit into `self`.
     ///
     /// # Parameters
-    /// * `byte_size_min_rows`: Row limit calculated from byte size will be at least this value
+    /// * `byte_size_min_rows`: Row limit calculated from byte size will not fall below this value.
     pub fn num_rows_takeable_from(self, other: Self, byte_size_min_rows: IdxSize) -> IdxSize {
         let mut max_rows = self.num_rows.min(other.num_rows);
 
@@ -35,12 +37,12 @@ impl RowCountAndSize {
             byte_size_min_rows.max(if self.num_bytes < other.row_byte_size() {
                 0
             } else {
-                IdxSize::try_from(self.num_bytes.div_ceil(other.row_byte_size().max(1)))
+                IdxSize::try_from(self.num_bytes.div_ceil(u64::max(1, other.row_byte_size())))
                     .unwrap_or(IdxSize::MAX)
             });
 
         if self.num_bytes < u64::MAX {
-            max_rows = max_rows.min(limit_according_to_byte_size)
+            max_rows = IdxSize::min(max_rows, limit_according_to_byte_size)
         }
 
         max_rows
@@ -59,7 +61,7 @@ impl RowCountAndSize {
     /// Returns an error if the resulting row count exceeds `IdxSize::MAX`. `num_bytes` will use
     /// saturating addition.
     pub fn add(self, rhs: Self) -> PolarsResult<Self> {
-        let num_rows = self.num_rows.checked_add(rhs.num_rows).ok_or_else(|| {
+        self.checked_add(rhs).ok_or_else(|| {
             let consider_installing_64 = if cfg!(feature = "bigidx") {
                 ""
             } else {
@@ -73,11 +75,14 @@ impl RowCountAndSize {
                 "row count ({}) exceeded maximum supported of {}{}",
                 counter, IdxSize::MAX, consider_installing_64
             )
-        })?;
+        })
+    }
 
+    pub fn checked_add(self, rhs: Self) -> Option<Self> {
+        let num_rows = self.num_rows.checked_add(rhs.num_rows)?;
         let num_bytes = self.num_bytes.saturating_add(rhs.num_bytes);
 
-        Ok(Self {
+        Some(Self {
             num_rows,
             num_bytes,
         })
@@ -88,6 +93,11 @@ impl RowCountAndSize {
     ///
     /// Returns `None` if the incremented result would exceed `total.num_rows`.
     pub fn add_delta(self, num_rows: IdxSize, total: Self) -> Option<Self> {
+        self.checked_add(self.calc_delta(num_rows, total)?)
+    }
+
+    /// Returns `None` if `num_rows` exceeds `total.num_rows - self.num_rows`.
+    pub fn calc_delta(self, num_rows: IdxSize, total: Self) -> Option<Self> {
         let available = total.checked_sub(self)?;
 
         if num_rows > available.num_rows {
@@ -102,10 +112,9 @@ impl RowCountAndSize {
             available.num_bytes,
         );
 
-        // `total.checked_sub(self)` guarantees no overflow below.
         Some(Self {
-            num_rows: self.num_rows + num_rows,
-            num_bytes: self.num_bytes + num_bytes,
+            num_rows,
+            num_bytes,
         })
     }
 
@@ -126,8 +135,8 @@ impl RowCountAndSize {
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct NonZeroRowCountAndSize {
-    num_rows: NonZeroIdxSize,
-    num_bytes: NonZeroU64,
+    pub num_rows: NonZeroIdxSize,
+    pub num_bytes: NonZeroU64,
 }
 
 impl NonZeroRowCountAndSize {
@@ -143,6 +152,7 @@ impl NonZeroRowCountAndSize {
         })
     }
 
+    #[expect(unused)]
     pub fn min(self, other: Self) -> Self {
         Self {
             num_rows: self.num_rows.min(other.num_rows),
@@ -159,30 +169,204 @@ impl NonZeroRowCountAndSize {
     }
 }
 
-/// Calculates how many rows can be sent in a morsel to a writer.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct TakeableRowsProvider {
-    pub max_size: NonZeroRowCountAndSize,
-    pub byte_size_min_rows: NonZeroIdxSize,
-    /// If `true`, allows sending buffered rows if there are at least `self.byte_size_min_rows` number
-    /// of them. Effectively disables strict morsel combining to `self.max_size` while retaining
-    /// splitting of morsels larger than `self.max_size`.
-    pub allow_non_max_size: bool,
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
+pub enum SplitMode {
+    Approximate,
+    #[default]
+    Exact,
 }
 
-impl TakeableRowsProvider {
-    pub fn num_rows_takeable_from(self, from: RowCountAndSize, flush: bool) -> Option<IdxSize> {
-        let num_rows = self
-            .max_size
-            .get()
-            .num_rows_takeable_from(from, self.byte_size_min_rows.get());
+/// Target sink morsel size to split to.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TargetSinkMorselSize {
+    pub target_num_rows: NonZeroIdxSize,
+    /// Note: Disabled if set to u64::MAX.
+    pub target_num_bytes: NonZeroU64,
+    /// Row limit calculated from `target_num_bytes` will not fall below this value.
+    pub target_num_bytes_min_rows: NonZeroIdxSize,
+    /// * `Exact`: Split to exactly `target_num_rows`, unless either no more rows
+    ///   are available (i.e. last chunk), or if `target_num_bytes != u64::MAX` and
+    ///   the limit calculated against the `target_num_bytes` is less than
+    ///   `target_num_rows`.
+    /// * `Approximate`: Splits do not need to be exactly `target_num_rows`.
+    pub target_num_rows_mode: SplitMode,
+}
 
-        let have_full_chunk = num_rows < from.num_rows || num_rows == self.max_size.get().num_rows;
+#[derive(Debug, Default, PartialEq)]
+enum LimitedBy {
+    #[default]
+    Rows,
+    ByteSize,
+}
 
-        (num_rows > 0
-            && (flush
-                || have_full_chunk
-                || (self.allow_non_max_size && num_rows >= self.byte_size_min_rows.get())))
-        .then_some(num_rows)
+impl TargetSinkMorselSize {
+    pub fn calc_next_splits(
+        &self,
+        buffered_size: RowCountAndSize,
+        incoming_size: RowCountAndSize,
+    ) -> (bool, PartSizesIter) {
+        let combined_size = buffered_size.checked_add(incoming_size).unwrap();
+
+        let mut flush_buffered_as_one_split = false;
+        let (mut part_sizes_iter, mut limited_by) = self.build_part_sizes_iter(combined_size);
+
+        // Note: We assume the buffered amount `buffered_size` does not exceed the configured target
+        // sizes (i.e., it should always be a residual of the target size as it is what remains
+        // from the last round of sending).
+        if incoming_size.num_rows != 0
+            && !(self.target_num_rows_mode == SplitMode::Exact && limited_by == LimitedBy::Rows)
+            && match part_sizes_iter.len() {
+                0 => false,
+                1 => {
+                    incoming_size.num_rows > buffered_size.num_rows
+                        && buffered_size.num_rows != 0
+                        && incoming_size.num_rows / buffered_size.num_rows
+                            > self.target_num_rows.get() / combined_size.num_rows
+                },
+                _ => true,
+            }
+        {
+            flush_buffered_as_one_split = buffered_size.num_rows != 0;
+            (part_sizes_iter, limited_by) = self.build_part_sizes_iter(incoming_size);
+        }
+
+        if limited_by == LimitedBy::Rows
+            && part_sizes_iter.len() <= 1
+            && self.target_num_rows_mode != SplitMode::Exact
+            && part_sizes_iter.base_part_size().checked_mul(2).is_some_and(
+                // base_part_size < (4/3) * target_num_rows
+                |double_base_part_size| {
+                    u64::abs_diff(
+                        double_base_part_size,
+                        idxsize_to_u64(self.target_num_rows.get()),
+                    ) < u64::abs_diff(
+                        part_sizes_iter.base_part_size(),
+                        idxsize_to_u64(self.target_num_rows.get()),
+                    )
+                },
+            )
+        {
+            // Wait for more data to have a fuller chunk.
+            part_sizes_iter = PartSizesIter::default()
+        }
+
+        (flush_buffered_as_one_split, part_sizes_iter)
+    }
+
+    fn build_part_sizes_iter(&self, size: RowCountAndSize) -> (PartSizesIter, LimitedBy) {
+        if size.num_rows == 0 {
+            return (PartSizesIter::default(), LimitedBy::default());
+        }
+
+        let n_parts_by_num_rows = if self.target_num_rows_mode == SplitMode::Exact {
+            u64::max(
+                1,
+                idxsize_to_u64(size.num_rows / self.target_num_rows.get()),
+            )
+        } else {
+            calc_n_parts(
+                idxsize_to_u64(size.num_rows),
+                NonZeroU64::new(idxsize_to_u64(self.target_num_rows.get())).unwrap(),
+            )
+        };
+
+        let mut max_parts_by_num_bytes = 0;
+        let mut n_parts_by_num_bytes = 0;
+
+        if self.target_num_bytes.get() != u64::MAX {
+            max_parts_by_num_bytes =
+                idxsize_to_u64(size.num_rows / self.target_num_bytes_min_rows.get());
+            n_parts_by_num_bytes = calc_n_parts(size.num_bytes, self.target_num_bytes);
+        };
+
+        if match u64::cmp(
+            &n_parts_by_num_rows,
+            &u64::min(n_parts_by_num_bytes, max_parts_by_num_bytes),
+        ) {
+            cmp::Ordering::Greater => true,
+            cmp::Ordering::Equal => self.target_num_rows_mode == SplitMode::Exact,
+            cmp::Ordering::Less => false,
+        } {
+            (
+                match self.target_num_rows_mode {
+                    SplitMode::Approximate => PartSizesIter::new_from_total_size(
+                        idxsize_to_u64(size.num_rows),
+                        n_parts_by_num_rows as usize,
+                    ),
+                    SplitMode::Exact => {
+                        if size.num_rows < self.target_num_rows.get() {
+                            PartSizesIter::default()
+                        } else {
+                            PartSizesIter::new_from_part_size(
+                                idxsize_to_u64(self.target_num_rows.get()),
+                                n_parts_by_num_rows as usize,
+                            )
+                        }
+                    },
+                },
+                LimitedBy::Rows,
+            )
+        } else {
+            (
+                if n_parts_by_num_bytes < max_parts_by_num_bytes {
+                    PartSizesIter::new_from_total_size(
+                        idxsize_to_u64(size.num_rows),
+                        n_parts_by_num_bytes as usize,
+                    )
+                } else {
+                    PartSizesIter::new_from_part_size(
+                        idxsize_to_u64(self.target_num_bytes_min_rows.get()),
+                        max_parts_by_num_bytes as usize,
+                    )
+                },
+                LimitedBy::ByteSize,
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU64;
+
+    use polars_utils::index::NonZeroIdxSize;
+
+    use crate::nodes::io_sinks::components::size::{
+        RowCountAndSize, SplitMode, TargetSinkMorselSize,
+    };
+
+    fn calc_splits(
+        target_size: &TargetSinkMorselSize,
+        buffered_size: RowCountAndSize,
+        incoming_size: RowCountAndSize,
+    ) -> (bool, Vec<u64>) {
+        let (a, b) = target_size.calc_next_splits(buffered_size, incoming_size);
+
+        (a, b.collect())
+    }
+
+    #[test]
+    fn test_target_sink_morsel_size() {
+        let target_size = TargetSinkMorselSize {
+            target_num_rows: NonZeroIdxSize::new(100).unwrap(),
+            target_num_bytes: NonZeroU64::new(100).unwrap(),
+            target_num_bytes_min_rows: NonZeroIdxSize::new(5).unwrap(),
+            target_num_rows_mode: SplitMode::Exact,
+        };
+
+        assert_eq!(
+            calc_splits(
+                &target_size,
+                RowCountAndSize {
+                    num_rows: 5,
+                    num_bytes: 5,
+                },
+                RowCountAndSize {
+                    num_rows: 5,
+                    num_bytes: 5,
+                },
+            ),
+            (false, vec![])
+        )
     }
 }

--- a/crates/polars-stream/src/nodes/io_sinks/pipeline_initialization/partition_by.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/pipeline_initialization/partition_by.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroUsize;
+use std::num::{NonZeroU64, NonZeroUsize};
 use std::sync::Arc;
 
 use polars_async::executor::{self, TaskPriority};
@@ -6,6 +6,7 @@ use polars_async::primitives::connector;
 use polars_error::PolarsResult;
 use polars_io::metrics::IOMetrics;
 use polars_plan::dsl::UnifiedSinkArgs;
+use polars_utils::index::NonZeroIdxSize;
 use polars_utils::pl_str::PlSmallStr;
 
 use crate::execute::StreamingExecutionState;
@@ -20,7 +21,7 @@ use crate::nodes::io_sinks::components::partitioner_pipeline::PartitionerPipelin
 use crate::nodes::io_sinks::components::sinked_path_info_list::{
     SinkedPathInfoList, call_sinked_paths_callback,
 };
-use crate::nodes::io_sinks::components::size::NonZeroRowCountAndSize;
+use crate::nodes::io_sinks::components::size::{NonZeroRowCountAndSize, SplitMode};
 use crate::nodes::io_sinks::config::{IOSinkNodeConfig, IOSinkTarget, PartitionedTarget};
 use crate::nodes::io_sinks::writers::create_file_writer_starter;
 use crate::nodes::io_sinks::writers::interface::FileWriterStarter;
@@ -96,10 +97,18 @@ pub fn start_partition_sink_pipeline(
     let file_writer_starter: Arc<dyn FileWriterStarter> =
         create_file_writer_starter(&file_format, &file_schema)?;
 
-    let mut takeable_rows_provider = file_writer_starter.takeable_rows_provider();
+    let mut target_sink_morsel_size = file_writer_starter.target_sink_morsel_size();
 
     if let Some(file_size_limit) = file_size_limit {
-        takeable_rows_provider.max_size = takeable_rows_provider.max_size.min(file_size_limit)
+        target_sink_morsel_size.target_num_rows = NonZeroIdxSize::min(
+            target_sink_morsel_size.target_num_rows,
+            file_size_limit.num_rows,
+        );
+        target_sink_morsel_size.target_num_bytes = NonZeroU64::min(
+            target_sink_morsel_size.target_num_bytes,
+            file_size_limit.num_bytes,
+        );
+        target_sink_morsel_size.target_num_rows_mode = SplitMode::Exact;
     }
 
     if verbose {
@@ -110,7 +119,7 @@ pub fn start_partition_sink_pipeline(
             file_provider: {:?}, \
             max_open_sinks: {}, \
             inflight_morsel_limit: {}, \
-            takeable_rows_provider: {:?}, \
+            target_sink_morsel_size: {:?}, \
             file_size_limit: {:?}, \
             upload_chunk_size: {}, \
             upload_concurrency: {}, \
@@ -121,7 +130,7 @@ pub fn start_partition_sink_pipeline(
             &file_provider.provider_type,
             max_open_sinks,
             inflight_morsel_limit,
-            takeable_rows_provider,
+            target_sink_morsel_size,
             file_size_limit,
             upload_chunk_size,
             upload_max_concurrency,
@@ -162,7 +171,7 @@ pub fn start_partition_sink_pipeline(
     };
 
     let partition_morsel_sender = PartitionMorselSender {
-        takeable_rows_provider,
+        target_sink_morsel_size,
         file_size_limit: file_size_limit.unwrap_or(NonZeroRowCountAndSize::MAX),
         inflight_morsel_semaphore,
         open_sinks_semaphore: open_sinks_semaphore.clone(),

--- a/crates/polars-stream/src/nodes/io_sinks/pipeline_initialization/single_file.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/pipeline_initialization/single_file.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 
 use polars_async::executor::{self, TaskPriority};
 use polars_async::primitives::connector;
-use polars_core::frame::DataFrame;
 use polars_core::runtime::ASYNC;
 use polars_error::PolarsResult;
 use polars_io::metrics::IOMetrics;
@@ -90,20 +89,20 @@ pub fn start_single_file_sink_pipeline(
 
     let file_writer_starter: Arc<dyn FileWriterStarter> =
         create_file_writer_starter(&file_format, &file_schema)?;
-    let takeable_rows_provider = file_writer_starter.takeable_rows_provider();
+    let target_sink_morsel_size = file_writer_starter.target_sink_morsel_size();
 
     if verbose {
         eprintln!(
             "{node_name}: start_single_file_sink_pipeline: \
             file_writer_starter: {}, \
-            takeable_rows_provider: {:?}, \
+            target_sink_morsel_size: {:?}, \
             inflight_morsel_limit: {}, \
             upload_chunk_size: {}, \
             upload_concurrency: {}, \
             io_metrics: {}, \
             build_sinked_path_info_list: {}",
             file_writer_starter.writer_name(),
-            takeable_rows_provider,
+            target_sink_morsel_size,
             inflight_morsel_limit,
             upload_chunk_size,
             upload_max_concurrency,
@@ -116,13 +115,13 @@ pub fn start_single_file_sink_pipeline(
     let writer_handle =
         file_writer_starter.start_file_writer(writer_rx, file_open_task, num_pipelines_per_sink)?;
 
-    let empty_with_schema_df = DataFrame::empty_with_arc_schema(file_schema.clone());
+    let schema = Arc::clone(&file_schema);
     let inflight_morsel_semaphore =
         Arc::new(tokio::sync::Semaphore::new(inflight_morsel_limit.get()));
 
     let resize_pipeline = MorselResizePipeline {
-        empty_with_schema_df,
-        takeable_rows_provider,
+        schema,
+        target_sink_morsel_size,
         inflight_morsel_semaphore,
         morsel_rx,
         morsel_tx: writer_tx,

--- a/crates/polars-stream/src/nodes/io_sinks/writers/csv/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/writers/csv/mod.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroU64;
 use std::sync::Arc;
 
 use polars_async::executor::{self, TaskPriority};
@@ -11,7 +12,7 @@ use polars_utils::index::NonZeroIdxSize;
 
 use crate::nodes::io_sinks::components::sink_morsel::{SinkMorsel, SinkMorselPermit};
 use crate::nodes::io_sinks::components::size::{
-    NonZeroRowCountAndSize, RowCountAndSize, TakeableRowsProvider,
+    NonZeroRowCountAndSize, SplitMode, TargetSinkMorselSize,
 };
 use crate::nodes::io_sinks::writers::interface::{
     FileOpenTaskHandle, FileWriterStarter, ideal_sink_morsel_size_env,
@@ -42,9 +43,10 @@ impl CsvWriterStarter {
         if initialized_state.is_none() {
             let (env_num_rows, env_num_bytes) = ideal_sink_morsel_size_env();
 
-            let ideal_morsel_size = RowCountAndSize {
-                num_rows: env_num_rows.unwrap_or(25 * 1024),
-                num_bytes: env_num_bytes.unwrap_or(8 * 1024 * 1024),
+            let ideal_morsel_size = NonZeroRowCountAndSize {
+                num_rows: env_num_rows.unwrap_or(const { NonZeroIdxSize::new(25 * 1024).unwrap() }),
+                num_bytes: env_num_bytes
+                    .unwrap_or(const { NonZeroU64::new(8 * 1024 * 1024).unwrap() }),
             };
 
             let serialized_row_size_estimate = u64::saturating_mul(self.schema.len() as _, 25);
@@ -52,10 +54,14 @@ impl CsvWriterStarter {
             let base_allocation_size: usize = u64::min(
                 64 * 1024 * 1024,
                 u64::min(
-                    ideal_morsel_size.num_bytes.div_ceil(2).saturating_mul(5),
+                    ideal_morsel_size
+                        .num_bytes
+                        .get()
+                        .div_ceil(2)
+                        .saturating_mul(5),
                     u64::saturating_mul(
                         serialized_row_size_estimate,
-                        ideal_morsel_size.num_rows as _,
+                        ideal_morsel_size.num_rows.get() as _,
                     ),
                 ),
             ) as _;
@@ -63,8 +69,6 @@ impl CsvWriterStarter {
             if config::verbose() {
                 eprintln!("[CsvWriterStarter]: base_allocation_size: {base_allocation_size}")
             }
-
-            let ideal_morsel_size = NonZeroRowCountAndSize::new(ideal_morsel_size).unwrap();
 
             *initialized_state = Some(InitializedState {
                 ideal_morsel_size,
@@ -81,11 +85,14 @@ impl FileWriterStarter for CsvWriterStarter {
         "csv"
     }
 
-    fn takeable_rows_provider(&self) -> TakeableRowsProvider {
-        TakeableRowsProvider {
-            max_size: self.initialized_state().ideal_morsel_size,
-            byte_size_min_rows: NonZeroIdxSize::new(256).unwrap(),
-            allow_non_max_size: true,
+    fn target_sink_morsel_size(&self) -> TargetSinkMorselSize {
+        let ideal_morsel_size = self.initialized_state().ideal_morsel_size;
+
+        TargetSinkMorselSize {
+            target_num_rows: ideal_morsel_size.num_rows,
+            target_num_bytes: ideal_morsel_size.num_bytes,
+            target_num_bytes_min_rows: const { NonZeroIdxSize::new(256).unwrap() },
+            target_num_rows_mode: SplitMode::Approximate,
         }
     }
 

--- a/crates/polars-stream/src/nodes/io_sinks/writers/interface.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/writers/interface.rs
@@ -6,12 +6,11 @@ use polars_async::primitives::connector;
 use polars_error::PolarsResult;
 use polars_io::utils::file::Writable;
 use polars_io::utils::sync_on_close::SyncOnCloseType;
-use polars_utils::IdxSize;
 use polars_utils::index::NonZeroIdxSize;
 use polars_utils::pl_str::PlSmallStr;
 
 use crate::nodes::io_sinks::components::sink_morsel::SinkMorsel;
-use crate::nodes::io_sinks::components::size::TakeableRowsProvider;
+use crate::nodes::io_sinks::components::size::TargetSinkMorselSize;
 use crate::utils::tokio_handle_ext;
 
 pub const IPC_RW_RECORD_BATCH_FLAGS_KEY: PlSmallStr =
@@ -21,7 +20,7 @@ pub trait FileWriterStarter: Send + Sync + 'static {
     fn writer_name(&self) -> &str;
 
     /// Hints to the sender how morsels should be sized.
-    fn takeable_rows_provider(&self) -> TakeableRowsProvider;
+    fn target_sink_morsel_size(&self) -> TargetSinkMorselSize;
 
     fn start_file_writer(
         &self,
@@ -65,31 +64,25 @@ impl std::future::Future for FileOpenTaskHandle {
 }
 
 /// Load ideal morsel size configuration from environment variables.
-pub(super) fn ideal_sink_morsel_size_env() -> (Option<IdxSize>, Option<u64>) {
+pub(super) fn ideal_sink_morsel_size_env() -> (Option<NonZeroIdxSize>, Option<NonZeroU64>) {
     let num_rows = std::env::var("POLARS_IDEAL_SINK_MORSEL_SIZE_ROWS")
         .map(|x| {
-            x.parse::<NonZeroIdxSize>()
-                .ok()
-                .unwrap_or_else(|| {
-                    panic!("invalid value for POLARS_IDEAL_SINK_MORSEL_SIZE_ROWS: {x}")
-                })
-                .get()
+            x.parse::<NonZeroIdxSize>().ok().unwrap_or_else(|| {
+                panic!("invalid value for POLARS_IDEAL_SINK_MORSEL_SIZE_ROWS: {x}")
+            })
         })
         .ok();
 
     let num_bytes = std::env::var("POLARS_IDEAL_SINK_MORSEL_SIZE_BYTES")
         .map(|x| {
-            x.parse::<NonZeroU64>()
-                .ok()
-                .unwrap_or_else(|| {
-                    panic!("invalid value for POLARS_IDEAL_SINK_MORSEL_SIZE_BYTES: {x}")
-                })
-                .get()
+            x.parse::<NonZeroU64>().ok().unwrap_or_else(|| {
+                panic!("invalid value for POLARS_IDEAL_SINK_MORSEL_SIZE_BYTES: {x}")
+            })
         })
         .ok();
 
     (
         num_rows,
-        num_bytes.or(num_rows.is_some().then_some(u64::MAX)),
+        num_bytes.or(num_rows.is_some().then_some(NonZeroU64::MAX)),
     )
 }

--- a/crates/polars-stream/src/nodes/io_sinks/writers/ipc/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/writers/ipc/mod.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroU64;
 use std::sync::Arc;
 
 use polars_async::executor::{self, TaskPriority};
@@ -12,9 +13,7 @@ use polars_utils::IdxSize;
 use polars_utils::index::NonZeroIdxSize;
 
 use crate::nodes::io_sinks::components::sink_morsel::{SinkMorsel, SinkMorselPermit};
-use crate::nodes::io_sinks::components::size::{
-    NonZeroRowCountAndSize, RowCountAndSize, TakeableRowsProvider,
-};
+use crate::nodes::io_sinks::components::size::{SplitMode, TargetSinkMorselSize};
 use crate::nodes::io_sinks::writers::interface::{
     FileOpenTaskHandle, FileWriterStarter, ideal_sink_morsel_size_env,
 };
@@ -45,29 +44,28 @@ impl FileWriterStarter for IpcWriterStarter {
         "ipc"
     }
 
-    fn takeable_rows_provider(&self) -> TakeableRowsProvider {
-        let max_size = if let Some(record_batch_size) = self.record_batch_size
+    fn target_sink_morsel_size(&self) -> TargetSinkMorselSize {
+        let target_num_bytes_min_rows = const { NonZeroIdxSize::new(16384).unwrap() };
+
+        if let Some(record_batch_size) = self.record_batch_size
             && record_batch_size > 0
         {
-            NonZeroRowCountAndSize::new(RowCountAndSize {
-                num_rows: record_batch_size,
-                num_bytes: u64::MAX,
-            })
-            .unwrap()
+            TargetSinkMorselSize {
+                target_num_rows: record_batch_size.try_into().unwrap(),
+                target_num_bytes: NonZeroU64::MAX,
+                target_num_bytes_min_rows,
+                target_num_rows_mode: SplitMode::Exact,
+            }
         } else {
-            let (num_rows, num_bytes) = ideal_sink_morsel_size_env();
+            let (env_num_rows, env_num_bytes) = ideal_sink_morsel_size_env();
 
-            NonZeroRowCountAndSize::new(RowCountAndSize {
-                num_rows: num_rows.unwrap_or(122_880),
-                num_bytes: num_bytes.unwrap_or(u64::MAX),
-            })
-            .unwrap()
-        };
-
-        TakeableRowsProvider {
-            max_size,
-            byte_size_min_rows: NonZeroIdxSize::new(16384).unwrap(),
-            allow_non_max_size: false,
+            TargetSinkMorselSize {
+                target_num_rows: env_num_rows
+                    .unwrap_or(const { NonZeroIdxSize::new(122_880).unwrap() }),
+                target_num_bytes: env_num_bytes.unwrap_or(NonZeroU64::MAX),
+                target_num_bytes_min_rows,
+                target_num_rows_mode: SplitMode::Approximate,
+            }
         }
     }
 

--- a/crates/polars-stream/src/nodes/io_sinks/writers/ipc/record_batch_encoder.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/writers/ipc/record_batch_encoder.rs
@@ -72,7 +72,7 @@ impl RecordBatchEncoder {
                 TaskPriority::High,
                 columns.into_iter().zip(arrow_converters.drain(..)).map(
                     |(column, (mut arrow_converter, arrow_field))| async move {
-                        let rechunked = column.take_materialized_series().rechunk();
+                        let rechunked = column.as_materialized_series().rechunk();
                         let dtype = rechunked.dtype();
 
                         let array: Box<dyn Array> = arrow_converter

--- a/crates/polars-stream/src/nodes/io_sinks/writers/ndjson/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/writers/ndjson/mod.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU64;
+
 use polars_async::executor::{self, TaskPriority};
 use polars_async::primitives::connector;
 use polars_core::config;
@@ -5,13 +7,11 @@ use polars_core::runtime::ASYNC;
 use polars_core::schema::SchemaRef;
 use polars_error::PolarsResult;
 use polars_io::ndjson::NDJsonWriterOptions;
-use polars_utils::IdxSize;
 use polars_utils::index::NonZeroIdxSize;
 
-use crate::morsel::get_ideal_morsel_size;
 use crate::nodes::io_sinks::components::sink_morsel::{SinkMorsel, SinkMorselPermit};
 use crate::nodes::io_sinks::components::size::{
-    NonZeroRowCountAndSize, RowCountAndSize, TakeableRowsProvider,
+    NonZeroRowCountAndSize, SplitMode, TargetSinkMorselSize,
 };
 use crate::nodes::io_sinks::writers::interface::{
     FileOpenTaskHandle, FileWriterStarter, ideal_sink_morsel_size_env,
@@ -40,10 +40,10 @@ impl NDJsonWriterStarter {
         if initialized_state.is_none() {
             let (env_num_rows, env_num_bytes) = ideal_sink_morsel_size_env();
 
-            let ideal_morsel_size = RowCountAndSize {
-                num_rows: env_num_rows
-                    .unwrap_or(get_ideal_morsel_size().try_into().unwrap_or(IdxSize::MAX)),
-                num_bytes: env_num_bytes.unwrap_or(8 * 1024 * 1024),
+            let ideal_morsel_size = NonZeroRowCountAndSize {
+                num_rows: env_num_rows.unwrap_or(const { NonZeroIdxSize::new(25 * 1024).unwrap() }),
+                num_bytes: env_num_bytes
+                    .unwrap_or(const { NonZeroU64::new(8 * 1024 * 1024).unwrap() }),
             };
 
             let serialized_row_size_estimate = u64::saturating_mul(self.schema.len() as _, 50);
@@ -51,10 +51,10 @@ impl NDJsonWriterStarter {
             let base_allocation_size: usize = u64::min(
                 64 * 1024 * 1024,
                 u64::min(
-                    ideal_morsel_size.num_bytes.saturating_mul(3),
+                    ideal_morsel_size.num_bytes.get().saturating_mul(3),
                     u64::saturating_mul(
                         serialized_row_size_estimate,
-                        ideal_morsel_size.num_rows as _,
+                        ideal_morsel_size.num_rows.get() as _,
                     ),
                 ),
             ) as _;
@@ -62,8 +62,6 @@ impl NDJsonWriterStarter {
             if config::verbose() {
                 eprintln!("[NDJsonWriterStarter]: base_allocation_size: {base_allocation_size}")
             }
-
-            let ideal_morsel_size = NonZeroRowCountAndSize::new(ideal_morsel_size).unwrap();
 
             *initialized_state = Some(InitializedState {
                 ideal_morsel_size,
@@ -80,11 +78,14 @@ impl FileWriterStarter for NDJsonWriterStarter {
         "ndjson"
     }
 
-    fn takeable_rows_provider(&self) -> TakeableRowsProvider {
-        TakeableRowsProvider {
-            max_size: self.initialized_state().ideal_morsel_size,
-            byte_size_min_rows: NonZeroIdxSize::new(256).unwrap(),
-            allow_non_max_size: true,
+    fn target_sink_morsel_size(&self) -> TargetSinkMorselSize {
+        let ideal_morsel_size = self.initialized_state().ideal_morsel_size;
+
+        TargetSinkMorselSize {
+            target_num_rows: ideal_morsel_size.num_rows,
+            target_num_bytes: ideal_morsel_size.num_bytes,
+            target_num_bytes_min_rows: const { NonZeroIdxSize::new(256).unwrap() },
+            target_num_rows_mode: SplitMode::Approximate,
         }
     }
 

--- a/crates/polars-stream/src/nodes/io_sinks/writers/parquet/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/writers/parquet/mod.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroU64;
 use std::sync::Arc;
 
 use arrow::datatypes::ArrowSchemaRef;
@@ -14,9 +15,7 @@ use polars_utils::IdxSize;
 use polars_utils::index::NonZeroIdxSize;
 
 use crate::nodes::io_sinks::components::sink_morsel::{SinkMorsel, SinkMorselPermit};
-use crate::nodes::io_sinks::components::size::{
-    NonZeroRowCountAndSize, RowCountAndSize, TakeableRowsProvider,
-};
+use crate::nodes::io_sinks::components::size::{SplitMode, TargetSinkMorselSize};
 use crate::nodes::io_sinks::writers::interface::{
     FileOpenTaskHandle, FileWriterStarter, ideal_sink_morsel_size_env,
 };
@@ -49,29 +48,28 @@ impl FileWriterStarter for ParquetWriterStarter {
         "parquet"
     }
 
-    fn takeable_rows_provider(&self) -> TakeableRowsProvider {
-        let max_size = if let Some(row_group_size) = self.row_group_size
+    fn target_sink_morsel_size(&self) -> TargetSinkMorselSize {
+        let target_num_bytes_min_rows = const { NonZeroIdxSize::new(16384).unwrap() };
+
+        if let Some(row_group_size) = self.row_group_size
             && row_group_size > 0
         {
-            NonZeroRowCountAndSize::new(RowCountAndSize {
-                num_rows: row_group_size,
-                num_bytes: u64::MAX,
-            })
-            .unwrap()
+            TargetSinkMorselSize {
+                target_num_rows: row_group_size.try_into().unwrap(),
+                target_num_bytes: NonZeroU64::MAX,
+                target_num_bytes_min_rows,
+                target_num_rows_mode: SplitMode::Exact,
+            }
         } else {
-            let (num_rows, num_bytes) = ideal_sink_morsel_size_env();
+            let (env_num_rows, env_num_bytes) = ideal_sink_morsel_size_env();
 
-            NonZeroRowCountAndSize::new(RowCountAndSize {
-                num_rows: num_rows.unwrap_or(122_880),
-                num_bytes: num_bytes.unwrap_or(u64::MAX),
-            })
-            .unwrap()
-        };
-
-        TakeableRowsProvider {
-            max_size,
-            byte_size_min_rows: NonZeroIdxSize::new(16384).unwrap(),
-            allow_non_max_size: false,
+            TargetSinkMorselSize {
+                target_num_rows: env_num_rows
+                    .unwrap_or(const { NonZeroIdxSize::new(122_880).unwrap() }),
+                target_num_bytes: env_num_bytes.unwrap_or(NonZeroU64::MAX),
+                target_num_bytes_min_rows,
+                target_num_rows_mode: SplitMode::Approximate,
+            }
         }
     }
 

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -290,6 +290,7 @@ pub fn lower_ir(
                 maintain_order,
                 chunk_size,
             }) => {
+                disable_morsel_split.get_or_insert(true);
                 let function = function.clone();
                 let maintain_order = *maintain_order;
                 let chunk_size = *chunk_size;
@@ -303,6 +304,10 @@ pub fn lower_ir(
             },
 
             SinkTypeIR::File(options) => {
+                // Defer to the chunk-aware morsel splitting strategy in morsel_resize_pipeline.
+                // This cannot currently be done by the InMemorySource as the morsel splitting
+                // is done against a configured TargetSinkMorselSize.
+                disable_morsel_split.get_or_insert(true);
                 let options = options.clone();
                 let input = lower_ir!(*input)?;
                 PhysNodeKind::FileSink { input, options }

--- a/crates/polars-utils/src/calc_morsel_split.rs
+++ b/crates/polars-utils/src/calc_morsel_split.rs
@@ -1,0 +1,135 @@
+use std::num::NonZeroU64;
+
+#[derive(Default, Debug, Clone)]
+pub struct PartSizesIter {
+    base_part_size: u64,
+    remaining_parts: usize,
+    remainder_cutoff: usize,
+}
+
+impl PartSizesIter {
+    pub fn new_from_total_size(total_size: u64, n_parts: usize) -> Self {
+        if n_parts == 0 {
+            return Default::default();
+        }
+
+        let base_part_size = total_size / n_parts as u64;
+        let remainder = total_size % n_parts as u64;
+        let remainder_cutoff = usize::try_from(n_parts as u64 - remainder).unwrap();
+
+        Self {
+            base_part_size,
+            remaining_parts: n_parts,
+            remainder_cutoff,
+        }
+    }
+
+    pub fn new_from_part_size(part_size: u64, n_parts: usize) -> Self {
+        Self {
+            base_part_size: part_size,
+            remaining_parts: n_parts,
+            remainder_cutoff: usize::MAX,
+        }
+    }
+
+    pub fn base_part_size(&self) -> u64 {
+        self.base_part_size
+    }
+}
+
+impl Iterator for PartSizesIter {
+    type Item = u64;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.remaining_parts = self.remaining_parts.checked_sub(1)?;
+        Some(self.base_part_size + (self.remaining_parts >= self.remainder_cutoff) as u64)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let n = ExactSizeIterator::len(self);
+        (n, Some(n))
+    }
+}
+
+impl ExactSizeIterator for PartSizesIter {
+    fn len(&self) -> usize {
+        self.remaining_parts
+    }
+}
+
+/// Number of parts to split `size` to minimize the average part size difference to `target_part_size`.
+pub fn calc_n_parts(size: u64, target_part_size: NonZeroU64) -> u64 {
+    if size <= target_part_size.get() {
+        return if size == 0 { 0 } else { 1 };
+    }
+
+    let n_parts = size / target_part_size.get();
+
+    (n_parts..=n_parts.saturating_add(1))
+        .min_by_key(|n_parts| (size / *n_parts).abs_diff(target_part_size.get()))
+        .unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU64;
+
+    use crate::calc_morsel_split::{PartSizesIter, calc_n_parts};
+    use crate::itertools::Itertools;
+
+    #[test]
+    fn test_calc_n_parts() {
+        let mut prev_n_parts: u64 = 0;
+
+        let boundaries = (0..1000u64)
+            .filter(|i| {
+                let n_parts = calc_n_parts(*i, const { NonZeroU64::new(100).unwrap() });
+                let changed = n_parts != prev_n_parts;
+                prev_n_parts = n_parts;
+                changed
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(boundaries, [1, 134, 242, 345, 448, 550, 651, 752, 855, 954]);
+    }
+
+    #[test]
+    fn test_part_sizes_iter() {
+        assert_eq!(
+            PartSizesIter::new_from_total_size(0, 0).collect_vec(),
+            &[] as &[u64]
+        );
+        assert_eq!(
+            PartSizesIter::new_from_total_size(1, 0).collect_vec(),
+            &[] as &[u64]
+        );
+        assert_eq!(PartSizesIter::new_from_total_size(0, 1).collect_vec(), &[0]);
+        assert_eq!(PartSizesIter::new_from_total_size(1, 1).collect_vec(), &[1]);
+        assert_eq!(
+            PartSizesIter::new_from_total_size(1, 2).collect_vec(),
+            &[1, 0]
+        );
+        assert_eq!(PartSizesIter::new_from_total_size(2, 1).collect_vec(), &[2]);
+
+        assert_eq!(
+            PartSizesIter::new_from_total_size(100, 2).collect_vec(),
+            &[50, 50]
+        );
+        assert_eq!(
+            PartSizesIter::new_from_total_size(101, 2).collect_vec(),
+            &[51, 50]
+        );
+        assert_eq!(
+            PartSizesIter::new_from_total_size(102, 2).collect_vec(),
+            &[51, 51]
+        );
+        assert_eq!(
+            PartSizesIter::new_from_total_size(103, 2).collect_vec(),
+            &[52, 51]
+        );
+        assert_eq!(
+            PartSizesIter::new_from_total_size(104, 2).collect_vec(),
+            &[52, 52]
+        );
+    }
+}

--- a/crates/polars-utils/src/index.rs
+++ b/crates/polars-utils/src/index.rs
@@ -10,6 +10,22 @@ pub type IdxSize = u32;
 #[cfg(feature = "bigidx")]
 pub type IdxSize = u64;
 
+/// Avoids clippy::unnecessary_cast when compiling with bigidx enabled.
+#[inline]
+pub const fn idxsize_to_u64(
+    #[cfg(feature = "bigidx")] val: u64,
+    #[cfg(not(feature = "bigidx"))] val: u32,
+) -> u64 {
+    #[cfg(feature = "bigidx")]
+    {
+        val
+    }
+    #[cfg(not(feature = "bigidx"))]
+    {
+        val as u64
+    }
+}
+
 #[cfg(not(feature = "bigidx"))]
 pub type NonZeroIdxSize = std::num::NonZeroU32;
 #[cfg(feature = "bigidx")]

--- a/crates/polars-utils/src/itertools/iters_eq.rs
+++ b/crates/polars-utils/src/itertools/iters_eq.rs
@@ -1,0 +1,14 @@
+/// Returns true if both iterators have the same length, and the items at each
+/// index are equal.
+pub fn iters_eq<L, R, T, U>(left: L, right: R) -> bool
+where
+    L: IntoIterator<Item = T>,
+    R: IntoIterator<Item = U>,
+    T: PartialEq<U>,
+    L::IntoIter: ExactSizeIterator,
+    R::IntoIter: ExactSizeIterator,
+{
+    let left = left.into_iter();
+    let right = right.into_iter();
+    left.len() == right.len() && left.zip(right).all(|(l, r)| l == r)
+}

--- a/crates/polars-utils/src/itertools/mod.rs
+++ b/crates/polars-utils/src/itertools/mod.rs
@@ -4,6 +4,7 @@ use std::fmt::Write;
 use crate::IdxSize;
 
 pub mod enumerate_idx;
+pub mod iters_eq;
 pub mod zip_eq;
 
 pub use enumerate_idx::EnumerateIdx;

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -15,6 +15,7 @@ pub mod async_utils;
 pub mod binary_search;
 pub mod bool;
 pub mod cache;
+pub mod calc_morsel_split;
 pub mod cardinality_sketch;
 pub mod cell;
 pub mod chunks;

--- a/py-polars/tests/unit/io/test_lazy_ipc.py
+++ b/py-polars/tests/unit/io/test_lazy_ipc.py
@@ -309,7 +309,7 @@ def test_sink_ipc_record_batch_size(record_batch_size: int, n_chunks: int) -> No
     n_rows = 100
     buf = io.BytesIO()
 
-    df0 = pl.DataFrame({"a": list(range(n_rows))})
+    df0 = pl.DataFrame({"a": range(n_rows)})
     df = df0
     while n_chunks > 1:
         df = pl.concat([df, df0])
@@ -322,12 +322,14 @@ def test_sink_ipc_record_batch_size(record_batch_size: int, n_chunks: int) -> No
     assert_frame_equal(out, df)
 
     buf.seek(0)
-    reader = pyarrow.ipc.open_file(buf)
-    n_batches = reader.num_record_batches
-    for i in range(n_batches):
-        n_rows = reader.get_batch(i).num_rows
+    with pyarrow.ipc.open_file(buf) as reader:
+        record_batch_lengths = [
+            reader.get_batch(i).num_rows for i in range(reader.num_record_batches)
+        ]
+
+    for i, n_rows in enumerate(record_batch_lengths):
         assert n_rows == record_batch_size or (
-            i + 1 == n_batches and n_rows <= record_batch_size
+            i + 1 == len(record_batch_lengths) and n_rows <= record_batch_size
         )
 
 

--- a/py-polars/tests/unit/io/test_sink.py
+++ b/py-polars/tests/unit/io/test_sink.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Any
 
+import pyarrow.ipc
 import pytest
 
 import polars as pl
@@ -489,3 +490,92 @@ def test_sink_predicate_pushdown_streaming_flag_27922() -> None:
         pl.scan_ipc(f).collect(),
         pl.DataFrame({"role": ["ST"], "key": ["st"], "tags": [["ST"]]}),
     )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    ("input_chunk_lengths", "expected_written_chunk_lengths"),
+    [
+        ([0], []),
+        ([1], [1]),
+        # Note: Following numbers expect a default target sink morsel size (rows)
+        # of 122_880.
+        ([81_920], [81_920]),
+        ([163_840], [163_840]),
+        ([163_841], [81_921, 81_920]),  # Cutoff @ (4/3)*122_880
+        ([250_000, 250_000], [125_000, 125_000, 125_000, 125_000]),
+        # Tiny<>Large chunk splitting
+        ([1, 350], [351]),
+        ([1, 351], [1, 351]),
+        ([1, 351, 6475], [1, 6826]),
+        ([1, 351, 6476], [1, 351, 6476]),
+        ([1, 351, 6476, 25903], [1, 351, 32379]),
+        ([1, 351, 6476, 25904], [1, 351, 6476, 25904]),
+        ([1, 351, 6476, 25904, 51807], [1, 351, 6476, 77711]),
+        ([1, 351, 6476, 25904, 51808], [1, 351, 6476, 25904, 51808]),
+        ([1, 351, 6476, 25904, 51808, 71073], [1, 351, 6476, 25904, 51808, 71073]),
+        (
+            [1, 351, 6476, 25904, 51808, 71073, 71073],
+            [1, 351, 6476, 25904, 51808, 142146],
+        ),
+        (
+            [1, 351, 6476, 25904, 51808, 71073, 71074],
+            [1, 351, 6476, 25904, 51808, 71073, 71074],
+        ),
+        # Does not accept LHS(large)>RHS(tiny), this protects against
+        # [tiny, large, tiny, large] from creating too many chunks.
+        ([351, 1], [352]),
+        ([351, 1, 6474], [6826]),
+        # From 352<>6475 threshold at 3rd chunk prevents combining
+        ([351, 1, 6475], [352, 6475]),
+        # Ideal morsel size is 100_000; ensure we don't split morsels of this size.
+        ([100_000, 100_000, 100_000], [100_000, 100_000, 100_000]),
+    ],
+)
+def test_sink_morsel_splitting_without_user_configuration(
+    input_chunk_lengths: list[int],
+    expected_written_chunk_lengths: list[int],
+) -> None:
+    s = pl.Series("x", [1], dtype=pl.UInt8)
+    df = pl.concat(s.new_from_index(0, n) for n in input_chunk_lengths).to_frame()
+
+    assert df.to_series(0).chunk_lengths() == input_chunk_lengths
+
+    buf = io.BytesIO()
+    df.write_ipc(buf)
+
+    with pyarrow.ipc.open_file(buf) as f:
+        record_batch_lengths = [
+            f.get_record_batch(i).num_rows for i in range(f.num_record_batches)
+        ]
+
+    assert record_batch_lengths == expected_written_chunk_lengths
+
+
+@pytest.mark.parametrize(
+    ("input_chunk_lengths", "expected_written_chunk_lengths"),
+    [
+        ([250_000, 250_000], [122_880, 122_880, 122_880, 122_880, 8480]),
+    ],
+)
+def test_sink_morsel_splitting_with_user_configuration(
+    input_chunk_lengths: list[int],
+    expected_written_chunk_lengths: list[int],
+) -> None:
+
+    s = pl.Series("x", [1], dtype=pl.UInt8)
+    df = pl.concat(s.new_from_index(0, n) for n in input_chunk_lengths).to_frame()
+
+    assert df.to_series(0).chunk_lengths() == input_chunk_lengths
+
+    # We must split exactly when the user requests a specific record batch size,
+    # even if this causes the morsels to span across chunk boundaries.
+    buf = io.BytesIO()
+    df.write_ipc(buf, record_batch_size=122_880)
+
+    with pyarrow.ipc.open_file(buf) as f:
+        record_batch_lengths = [
+            f.get_record_batch(i).num_rows for i in range(f.num_record_batches)
+        ]
+
+    assert record_batch_lengths == expected_written_chunk_lengths


### PR DESCRIPTION
Refactors morsel splitting for single-file sinks to account for chunk boundaries when choosing splits. This reduces the number of splits containing >1 chunks (which causes data copy when the file writers call `rechunk()`), reducing memory usage.

#### Split strategy
Instead of splitting to exactly the default chunk size of N=122_880, we instead choose the closest N to 122_880 that divides the size of the chunk (and distribute the remainder accordingly). E.g. For incoming chunks of 1mil rows, this works out to 125,000, ensuring each split falls within the chunk.

#### Tiny chunk optimization
E.g., Given 2 incoming chunks with n_rows: [1, 1_000_000], we will choose to send the chunk with 1 row on its own, instead of copying 1M rows to join it with the singular row.
