### PR TITLE
build(rust): Fix test compilation for polars-stream

### DIFF
--- a/crates/polars-stream/Cargo.toml
+++ b/crates/polars-stream/Cargo.toml
@@ -56,29 +56,33 @@ version_check = { workspace = true }
 nightly = ["polars-expr/nightly"]
 approx_unique = ["polars-plan/approx_unique", "polars-expr/approx_unique"]
 cov = ["polars-plan/cov", "polars-expr/cov"]
-bigidx = ["polars-core/bigidx"]
+bigidx = ["polars-core/bigidx", "polars-plan/bigidx"]
 bitwise = ["polars-core/bitwise", "polars-plan/bitwise", "polars-expr/bitwise"]
 merge_sorted = ["polars-plan/merge_sorted", "polars-mem-engine/merge_sorted"]
 dynamic_group_by = [
   "polars-plan/dynamic_group_by",
   "polars-expr/dynamic_group_by",
   "polars-mem-engine/dynamic_group_by",
+  "polars-plan/dtype-date",
+  "polars-expr/timezones",
+  "polars-plan/timezones",
   "polars-time/dtype-date",
   "polars-time/dtype-datetime",
   "arrow/timezones",
 ]
-strings = []
+strings = ["polars-expr/strings", "polars-plan/strings"]
 ipc = [
   "polars-mem-engine/ipc",
   "polars-plan/ipc",
   "polars-io/ipc",
   "dep:serde_json",
 ]
-index_of = ["polars-plan/index_of"]
+index_of = ["polars-plan/index_of", "polars-expr/index_of"]
 parquet = ["polars-mem-engine/parquet", "polars-plan/parquet", "cloud"]
 csv = ["polars-mem-engine/csv", "polars-plan/csv", "polars-io/csv"]
 json = [
   "polars-mem-engine/json",
+  "polars-expr/json",
   "polars-plan/json",
   "polars-io/json",
   "dep:polars-json",
@@ -89,9 +93,9 @@ scan_lines = [
   "polars-io/scan_lines",
 ]
 cloud = ["polars-mem-engine/cloud", "polars-plan/cloud", "polars-io/cloud"]
-diff = ["polars-ops/diff", "polars-plan/diff", "polars-plan/abs"]
-interpolate = ["polars-ops/interpolate", "polars-plan/interpolate"]
-dtype-array = ["polars-core/dtype-array"]
+diff = ["polars-ops/diff", "polars-expr/diff", "polars-plan/diff", "polars-plan/abs", "polars-expr/abs"]
+interpolate = ["polars-expr/interpolate", "polars-ops/interpolate", "polars-plan/interpolate"]
+dtype-array = ["polars-core/dtype-array", "polars-expr/dtype-array", "polars-plan/dtype-array"]
 dtype-u8 = ["polars-core/dtype-u8", "polars-plan/dtype-u8"]
 dtype-u16 = ["polars-core/dtype-u16", "polars-plan/dtype-u16"]
 dtype-u128 = ["polars-core/dtype-u128", "polars-plan/dtype-u128"]
@@ -101,14 +105,29 @@ dtype-i128 = ["polars-core/dtype-i128", "polars-plan/dtype-i128"]
 dtype-f16 = ["polars-core/dtype-f16", "polars-plan/dtype-f16"]
 dtype-date = ["polars-core/dtype-date", "polars-plan/dtype-date", "polars-time/dtype-date"]
 dtype-time = ["polars-core/dtype-time", "polars-plan/dtype-time", "polars-time/dtype-time"]
-dtype-datetime = ["polars-core/dtype-datetime", "polars-plan/dtype-datetime", "polars-time/dtype-datetime"]
-dtype-duration = ["polars-core/dtype-duration", "polars-plan/dtype-duration", "polars-time/dtype-duration"]
-dtype-categorical = ["polars-core/dtype-categorical", "polars-plan/dtype-categorical"]
-dtype-decimal = ["polars-core/dtype-decimal", "polars-plan/dtype-decimal"]
-dtype-extension = ["polars-core/dtype-extension", "polars-plan/dtype-extension"]
-ewma = ["polars-plan/ewma"]
-mode = ["polars-plan/mode"]
-moment = ["polars-plan/moment"]
+dtype-datetime = [
+  "polars-core/dtype-datetime",
+  "polars-expr/dtype-datetime",
+  "polars-plan/dtype-datetime",
+  "polars-time/dtype-datetime",
+]
+dtype-duration = [
+  "polars-core/dtype-duration",
+  "polars-expr/dtype-duration",
+  "polars-plan/dtype-duration",
+  "polars-time/dtype-duration",
+]
+dtype-categorical = [
+  "polars-core/dtype-categorical",
+  "polars-expr/dtype-categorical",
+  "polars-ops/dtype-categorical",
+  "polars-plan/dtype-categorical",
+]
+dtype-decimal = ["polars-core/dtype-decimal", "polars-expr/dtype-decimal", "polars-plan/dtype-decimal"]
+dtype-extension = ["polars-core/dtype-extension", "polars-expr/dtype-extension", "polars-plan/dtype-extension"]
+ewma = ["polars-expr/ewma", "polars-plan/ewma"]
+mode = ["polars-expr/mode", "polars-plan/mode"]
+moment = ["polars-expr/moment", "polars-plan/moment"]
 object = ["polars-ops/object"]
 physical_plan_visualization_schema = [
   "dep:schemars",
@@ -124,12 +143,12 @@ python = [
 asof_join = ["polars-plan/asof_join", "polars-ops/asof_join"]
 iejoin = ["polars-plan/iejoin", "polars-ops/iejoin"]
 semi_anti_join = ["polars-plan/semi_anti_join", "polars-ops/semi_anti_join"]
-is_in = ["polars-ops/is_in", "polars-plan/is_in", "semi_anti_join"]
-replace = ["polars-ops/replace", "polars-plan/replace"]
-range = ["polars-plan/range"]
-top_k = ["polars-plan/top_k"]
-cum_agg = ["polars-plan/cum_agg", "polars-ops/cum_agg"]
-log = ["polars-plan/log", "polars-ops/log"]
+is_in = ["polars-expr/is_in", "polars-ops/is_in", "polars-plan/is_in", "semi_anti_join"]
+replace = ["polars-expr/replace", "polars-ops/replace", "polars-plan/replace"]
+range = ["polars-expr/range", "polars-plan/range"]
+top_k = ["polars-expr/top_k", "polars-plan/top_k"]
+cum_agg = ["polars-expr/cum_agg", "polars-plan/cum_agg", "polars-ops/cum_agg"]
+log = ["polars-expr/log", "polars-plan/log", "polars-ops/log"]
 is_first_distinct = ["polars-core/is_first_distinct", "polars-expr/is_first_distinct", "polars-plan/is_first_distinct"]
 
 # We need to specify default features here to match workspace defaults.


### PR DESCRIPTION
This fixes compilation errors when running `cargo test` for tests located in polars-stream, due to missing feature activation.
