### PR TITLE
feat(rust): Add field name as error context for json decode methods

### DIFF
--- a/crates/polars-io/src/ndjson/buffer.rs
+++ b/crates/polars-io/src/ndjson/buffer.rs
@@ -323,7 +323,15 @@ fn deserialize_all<'a>(
                     .iter()
                     .map(|field| {
                         if let Some(value) = document.get(field.name.as_str()) {
-                            deserialize_all(value, &field.dtype, ignore_errors)
+                            deserialize_all(value, &field.dtype, ignore_errors).map_err(|e| {
+                                e.context(
+                                    format!(
+                                        "error deserializing JSON field `{}` of struct",
+                                        field.name.as_str()
+                                    )
+                                    .into(),
+                                )
+                            })
                         } else {
                             Ok(AnyValue::Null)
                         }

--- a/crates/polars-json/src/json/deserialize.rs
+++ b/crates/polars-json/src/json/deserialize.rs
@@ -284,7 +284,15 @@ fn deserialize_struct<'a, A: Borrow<BorrowedValue<'a>>>(
         .iter()
         .map(|fld| {
             let (dtype, vals) = out_values.get(fld.name.as_str()).unwrap();
-            _deserialize(vals, (*dtype).clone(), allow_extra_fields_in_struct)
+            _deserialize(vals, (*dtype).clone(), allow_extra_fields_in_struct).map_err(|err| {
+                err.context(
+                    format!(
+                        "error deserializing JSON field `{}` of struct",
+                        fld.name.as_str()
+                    )
+                    .into(),
+                )
+            })
         })
         .collect::<PolarsResult<Vec<_>>>()?;
 

--- a/crates/polars-ops/src/chunked_array/strings/json_path.rs
+++ b/crates/polars-ops/src/chunked_array/strings/json_path.rs
@@ -125,7 +125,7 @@ pub trait Utf8JsonPathImpl: AsString {
             ca.len(),
             allow_extra_fields_in_struct,
         )
-        .map_err(|e| polars_err!(ComputeError: "error deserializing JSON: {}", e))?;
+        .map_err(|e| e.context("error deserializing JSON".into()))?;
         let s = Series::try_from((PlSmallStr::EMPTY, array))?;
         if needs_cast {
             s.strict_cast(&dtype.unwrap())


### PR DESCRIPTION
I like using polars for decoding larger than memory files with JSON. But I often have trouble conforming the schema to the data. This helps me find issues with my data or schema.



Here is a repro generated by AI:
```python
from __future__ import annotations

import json
import traceback
from pathlib import Path
from tempfile import TemporaryDirectory

import polars as pl


def ndjson_repro() -> None:
    # Infer schema from the first row only, then provide incompatible rows.
    # This forces the NDJSON deserializer down the struct mismatch path.
    rows = [
        {"payload": {"x": 1}},
        {"payload": {"x": "not-an-int"}},
    ]  # Provide a nested field with the wrong type so the error points at `payload.x`.

    with TemporaryDirectory() as tmpdir:
        path = Path(tmpdir) / "bad.ndjson"
        path.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")

        print(f"Reading {path} with infer_schema_length=1")
        pl.read_ndjson(path, infer_schema_length=1)


def json_decode_repro() -> None:
    print("Decoding JSON strings with .str.json_decode(dtype=Struct({'x': Int64}))")
    s = pl.Series(
        "payload",
        [
            '{"x": 1}',
            '{"x": "not-an-int"}',
                # '"not-a-struct"',  # Removed to isolate the x-field type mismatch
        ],
    )

    s.str.json_decode(pl.Struct([pl.Field("x", pl.Int64)]))


def main() -> None:
    for name, repro in [
        ("ndjson repro", ndjson_repro),
        (".str.json_decode repro", json_decode_repro),
    ]:
        print(f"\n=== {name} ===")
        try:
            repro()
        except Exception:
            traceback.print_exc()


if __name__ == "__main__":
    main()
```


This outputs the following with the patch applied:
```
=== ndjson repro ===
Reading /tmp/tmpx3wgnube/bad.ndjson with infer_schema_length=1
Traceback (most recent call last):
  File "/home/agiera/polars/py-polars/debug/show_json_deserialize_error.py", line 48, in main
    repro()
    ~~~~~^^
  File "/home/agiera/polars/py-polars/debug/show_json_deserialize_error.py", line 24, in ndjson_repro
    pl.read_ndjson(path, infer_schema_length=1)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/agiera/polars/py-polars/src/polars/io/ndjson.py", line 187, in read_ndjson
    ).collect()
      ~~~~~~~^^
  File "/home/agiera/polars/py-polars/src/polars/_utils/deprecation.py", line 97, in wrapper
    return function(*args, **kwargs)
  File "/home/agiera/polars/py-polars/src/polars/lazyframe/opt_flags.py", line 344, in wrapper
    return function(*args, **kwargs)
  File "/home/agiera/polars/py-polars/src/polars/lazyframe/frame.py", line 2629, in collect
    return wrap_df(ldf.collect(engine, callback))
                   ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
polars.exceptions.ComputeError: cannot parse 'not-an-int' (string) as i64

This error occurred with the following context stack:
        [1] error deserializing JSON field `x` of struct


=== .str.json_decode repro ===
Decoding JSON strings with .str.json_decode(dtype=Struct({'x': Int64}))
Traceback (most recent call last):
  File "/home/agiera/polars/py-polars/debug/show_json_deserialize_error.py", line 48, in main
    repro()
    ~~~~~^^
  File "/home/agiera/polars/py-polars/debug/show_json_deserialize_error.py", line 38, in json_decode_repro
    s.str.json_decode(pl.Struct([pl.Field("x", pl.Int64)]))
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/agiera/polars/py-polars/src/polars/series/string.py", line 780, in json_decode
    .select_seq(F.col(s.name).str.json_decode(dtype))
     ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/agiera/polars/py-polars/src/polars/dataframe/frame.py", line 10501, in select_seq
    .collect(optimizations=QueryOptFlags._eager())
     ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/agiera/polars/py-polars/src/polars/_utils/deprecation.py", line 97, in wrapper
    return function(*args, **kwargs)
  File "/home/agiera/polars/py-polars/src/polars/lazyframe/opt_flags.py", line 344, in wrapper
    return function(*args, **kwargs)
  File "/home/agiera/polars/py-polars/src/polars/lazyframe/frame.py", line 2629, in collect
    return wrap_df(ldf.collect(engine, callback))
                   ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
polars.exceptions.ComputeError: error deserializing value "String("not-an-int")" as numeric.

Try increasing `infer_schema_length` or specifying a schema.

This error occurred in the following expression:
        col("payload").str.json_decode()


This error occurred with the following context stack:
        [1] error deserializing JSON field `x` of struct
        [2] error deserializing JSON
```


I used AI to generate the patch and then edited it as appropriate.


Obligatory screenshot of `make test` as first time contributor.
<img width="2880" height="1920" alt="Screenshot From 2026-06-12 15-17-27" src="https://github.com/user-attachments/assets/32c729ba-5ff2-4d56-ac66-78e62c4ebbac" />
