### PR TITLE
perf: Optimize elementwise expressions in as-of joins

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/hoist_asof_join_exprs.rs
+++ b/crates/polars-plan/src/plans/optimizer/hoist_asof_join_exprs.rs
@@ -1,0 +1,264 @@
+use polars_core::prelude::*;
+use polars_ops::frame::JoinType;
+use polars_utils::arena::{Arena, Node};
+
+use super::{OptimizationRule, pushdown_maintain_errors};
+use crate::plans::{
+    AExpr, ExprPushdownGroup, FunctionFlags, FunctionIR, IR, IRBuilder,
+    is_inherently_nondeterministic,
+};
+use crate::prelude::Operator;
+use crate::utils::aexpr_to_leaf_names_iter;
+
+pub(super) struct HoistAsOfJoinExpressions;
+
+impl OptimizationRule for HoistAsOfJoinExpressions {
+    fn optimize_plan(
+        &mut self,
+        lp_arena: &mut Arena<IR>,
+        expr_arena: &mut Arena<AExpr>,
+        node: Node,
+    ) -> PolarsResult<Option<IR>> {
+        let IR::Join {
+            input_left,
+            input_right,
+            schema: original_schema,
+            left_on,
+            right_on,
+            options: join_options,
+        } = lp_arena.get(node)
+        else {
+            return Ok(None);
+        };
+
+        let JoinType::AsOf(asof_options) = &join_options.args.how else {
+            return Ok(None);
+        };
+
+        let IR::HStack {
+            input: right_input,
+            exprs,
+            options: hstack_options,
+            ..
+        } = lp_arena.get(*input_right)
+        else {
+            return Ok(None);
+        };
+
+        let input_left = *input_left;
+        let right_input = *right_input;
+        let original_schema = original_schema.clone();
+        let left_on = left_on.clone();
+        let right_on = right_on.clone();
+        let join_options = join_options.clone();
+        let hstack_options = *hstack_options;
+        let exprs = exprs.clone();
+
+        let (Some(left_rows), Some(right_rows)) = (
+            estimated_row_count(input_left, lp_arena),
+            estimated_row_count(right_input, lp_arena),
+        ) else {
+            return Ok(None);
+        };
+        if left_rows >= right_rows {
+            return Ok(None);
+        }
+
+        let left_schema = lp_arena.get(input_left).schema(lp_arena).into_owned();
+        let right_input_schema = lp_arena.get(right_input).schema(lp_arena).into_owned();
+
+        let mut required_right_names = PlHashSet::new();
+        for expr in &right_on {
+            required_right_names.extend(aexpr_to_leaf_names_iter(expr.node(), expr_arena).cloned());
+        }
+        if let Some(right_by) = asof_options.right_by.as_deref() {
+            required_right_names.extend(right_by.iter().cloned());
+        }
+
+        let mut output_names = PlHashSet::with_capacity(exprs.len());
+        if !exprs
+            .iter()
+            .all(|expr| output_names.insert(expr.output_name().clone()))
+        {
+            return Ok(None);
+        }
+
+        let maintain_errors = pushdown_maintain_errors();
+        let mut hoist = vec![false; exprs.len()];
+
+        for (idx, expr) in exprs.iter().enumerate() {
+            let output_name = expr.output_name();
+            if required_right_names.contains(output_name)
+                || left_schema.contains(output_name)
+                || is_inherently_nondeterministic(expr.node(), expr_arena)
+                || !is_null_on_unmatched_right(expr.node(), expr_arena)
+            {
+                continue;
+            }
+
+            let mut leaf_names = aexpr_to_leaf_names_iter(expr.node(), expr_arena);
+            if leaf_names.any(|name| {
+                !right_input_schema.contains(name)
+                    || left_schema.contains(name)
+                    || required_right_names.contains(name)
+            }) {
+                continue;
+            }
+
+            let mut pushdown_group = ExprPushdownGroup::Pushable;
+            pushdown_group.update_with_expr_rec(expr_arena.get(expr.node()), expr_arena, None);
+            if !pushdown_group.blocks_pushdown(maintain_errors) {
+                hoist[idx] = true;
+            }
+        }
+
+        // Splitting an HStack changes which version of an overwritten column a moved
+        // expression sees. Keep such expressions below the join.
+        loop {
+            let retained_outputs = exprs
+                .iter()
+                .zip(&hoist)
+                .filter(|(_, hoist)| !**hoist)
+                .map(|(expr, _)| expr.output_name().clone())
+                .collect::<PlHashSet<_>>();
+            let mut changed = false;
+            for (expr, hoist) in exprs.iter().zip(&mut hoist) {
+                if *hoist
+                    && aexpr_to_leaf_names_iter(expr.node(), expr_arena)
+                        .any(|name| retained_outputs.contains(name))
+                {
+                    *hoist = false;
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+
+        if !hoist.iter().any(|hoist| *hoist) {
+            return Ok(None);
+        }
+
+        let mut retained_exprs = Vec::with_capacity(exprs.len());
+        let mut hoisted_exprs = Vec::with_capacity(exprs.len());
+        for (expr, hoist) in exprs.into_iter().zip(hoist) {
+            if hoist {
+                hoisted_exprs.push(expr);
+            } else {
+                retained_exprs.push(expr);
+            }
+        }
+
+        let new_right_input = if retained_exprs.is_empty() {
+            right_input
+        } else {
+            IRBuilder::new(right_input, expr_arena, lp_arena)
+                .with_columns(retained_exprs, hstack_options)
+                .node()
+        };
+
+        let join = IRBuilder::new(input_left, expr_arena, lp_arena)
+            .join(new_right_input, left_on, right_on, join_options)
+            .build();
+        let builder = IRBuilder::from_lp(join, expr_arena, lp_arena)
+            .with_columns(hoisted_exprs, hstack_options);
+        let new_schema = builder.schema().into_owned();
+        let hoisted = builder.build();
+
+        if new_schema.len() != original_schema.len()
+            || original_schema.iter().any(|(name, dtype)| {
+                new_schema
+                    .get(name)
+                    .is_none_or(|new_dtype| new_dtype != dtype)
+            })
+        {
+            return Ok(None);
+        }
+
+        if new_schema == original_schema {
+            Ok(Some(hoisted))
+        } else {
+            Ok(Some(IR::SimpleProjection {
+                input: lp_arena.add(hoisted),
+                columns: original_schema,
+            }))
+        }
+    }
+}
+
+fn estimated_row_count(node: Node, lp_arena: &Arena<IR>) -> Option<usize> {
+    match lp_arena.get(node) {
+        IR::DataFrameScan { df, .. } => Some(df.height()),
+        IR::Scan { file_info, .. } if file_info.row_estimation.1 != usize::MAX => {
+            Some(file_info.row_estimation.1)
+        },
+        IR::Slice { input, len, .. } => {
+            estimated_row_count(*input, lp_arena).map(|rows| rows.min(*len as usize))
+        },
+        IR::SimpleProjection { input, .. }
+        | IR::HStack { input, .. }
+        | IR::Sort { input, .. }
+        | IR::Cache { input, .. } => estimated_row_count(*input, lp_arena),
+        IR::MapFunction {
+            input,
+            function: FunctionIR::Hint(_),
+        } => estimated_row_count(*input, lp_arena),
+        _ => None,
+    }
+}
+
+fn is_null_on_unmatched_right(node: Node, expr_arena: &Arena<AExpr>) -> bool {
+    match expr_arena.get(node) {
+        AExpr::Column(_) => true,
+        AExpr::Literal(value) => value.is_null(),
+        AExpr::BinaryExpr { left, op, right } if binary_operator_preserves_nulls(*op) => {
+            is_null_on_unmatched_right(*left, expr_arena)
+                || is_null_on_unmatched_right(*right, expr_arena)
+        },
+        AExpr::Cast { expr, dtype, .. } => {
+            !dtype.is_nested() && is_null_on_unmatched_right(*expr, expr_arena)
+        },
+        AExpr::Function { input, options, .. } => {
+            if options
+                .flags
+                .contains(FunctionFlags::PRESERVES_NULL_FIRST_INPUT)
+            {
+                input
+                    .first()
+                    .is_some_and(|expr| is_null_on_unmatched_right(expr.node(), expr_arena))
+            } else if options
+                .flags
+                .contains(FunctionFlags::PRESERVES_NULL_ALL_INPUTS)
+            {
+                input
+                    .iter()
+                    .any(|expr| is_null_on_unmatched_right(expr.node(), expr_arena))
+            } else {
+                false
+            }
+        },
+        _ => false,
+    }
+}
+
+fn binary_operator_preserves_nulls(op: Operator) -> bool {
+    use crate::prelude::Operator::*;
+
+    matches!(
+        op,
+        Eq | NotEq
+            | Lt
+            | LtEq
+            | Gt
+            | GtEq
+            | Plus
+            | Minus
+            | Multiply
+            | RustDivide
+            | TrueDivide
+            | FloorDivide
+            | Modulus
+            | Xor
+    )
+}

--- a/crates/polars-plan/src/plans/optimizer/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/mod.rs
@@ -17,6 +17,8 @@ mod flatten_merge_sorted;
 mod flatten_union;
 #[cfg(feature = "fused")]
 mod fused;
+#[cfg(feature = "asof_join")]
+mod hoist_asof_join_exprs;
 mod join_utils;
 pub(crate) use join_utils::ExprOrigin;
 mod expand_datasets;
@@ -55,6 +57,8 @@ pub use stack_opt::{OptimizationRule, OptimizeExprContext, StackOptimizer};
 #[cfg(feature = "merge_sorted")]
 use self::flatten_merge_sorted::FlattenMergeSortedRule;
 use self::flatten_union::FlattenUnionRule;
+#[cfg(feature = "asof_join")]
+use self::hoist_asof_join_exprs::HoistAsOfJoinExpressions;
 pub use crate::frame::{AllowedOptimizations, OptFlags};
 pub use crate::plans::conversion::type_coercion::TypeCoercionRule;
 #[cfg(feature = "cse")]
@@ -212,6 +216,8 @@ pub fn optimize(
 
     if opt_flags.projection_pushdown() {
         projection_pushdown(root, ir_arena, expr_arena);
+        #[cfg(feature = "asof_join")]
+        rules.push(Box::new(HoistAsOfJoinExpressions));
     }
 
     if opt_flags.fast_projection() {

--- a/py-polars/tests/unit/lazyframe/test_projections.py
+++ b/py-polars/tests/unit/lazyframe/test_projections.py
@@ -277,6 +277,107 @@ def test_asof_join_projection_() -> None:
     )
 
 
+def test_asof_join_hoists_elementwise_right_expression_25867() -> None:
+    left = pl.LazyFrame({"time": [-1, 5]}).set_sorted("time")
+    right = pl.LazyFrame(
+        {
+            "time": [0, 3, 5],
+            "a": [1.0, 1.5, 2.0],
+            "b": [2.0, 3.0, 4.0],
+            "c": [3.0, 4.5, 6.0],
+            "d": [2.0, 2.5, 3.0],
+        }
+    ).set_sorted("time")
+    metric = ((pl.col("a") + pl.col("b")) * pl.col("c") / pl.col("d")).alias("metric")
+
+    q = left.join_asof(right.with_columns(metric), on="time")
+    plan = q.explain()
+
+    assert plan.index("WITH_COLUMNS") < plan.index("ASOF JOIN")
+    assert_frame_equal(
+        q.select("time", "metric").collect(),
+        pl.DataFrame({"time": [-1, 5], "metric": [None, 12.0]}),
+    )
+
+
+def test_asof_join_does_not_hoist_without_cardinality_benefit() -> None:
+    left = pl.LazyFrame({"time": [0, 1, 2]}).set_sorted("time")
+    right = pl.LazyFrame({"time": [0, 2], "value": [1, 2]}).set_sorted("time")
+
+    q = left.join_asof(
+        right.with_columns((pl.col("value") + 1).alias("adjusted")),
+        on="time",
+    )
+    plan = q.explain()
+
+    assert plan.index("ASOF JOIN") < plan.index("WITH_COLUMNS")
+
+
+def test_asof_join_partially_hoists_right_expressions() -> None:
+    left = pl.LazyFrame({"time": [-1, 2]}).set_sorted("time")
+    right = pl.LazyFrame({"time": [0, 1, 2], "value": [1, None, 3]}).set_sorted("time")
+
+    q = left.join_asof(
+        right.with_columns(
+            (pl.col("value") + 1).alias("adjusted"),
+            pl.col("value").is_null().alias("value_is_null"),
+        ),
+        on="time",
+    )
+    plan = q.explain()
+
+    assert plan.index("WITH_COLUMNS") < plan.index("ASOF JOIN")
+    assert plan.index("ASOF JOIN") < plan.rindex("WITH_COLUMNS")
+    assert q.collect_schema().names() == [
+        "time",
+        "value",
+        "adjusted",
+        "value_is_null",
+    ]
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            {
+                "time": [-1, 2],
+                "value": [None, 3],
+                "adjusted": [None, 4],
+                "value_is_null": [None, False],
+            }
+        ),
+    )
+
+
+def test_asof_join_does_not_hoist_non_null_preserving_expression() -> None:
+    left = pl.LazyFrame({"time": [-1, 1]}).set_sorted("time")
+    right = pl.LazyFrame({"time": [0, 1, 2], "value": [1, None, 2]}).set_sorted("time")
+
+    q = left.join_asof(
+        right.with_columns(pl.col("value").is_null().alias("value_is_null")),
+        on="time",
+    )
+    plan = q.explain()
+
+    assert plan.index("ASOF JOIN") < plan.index("WITH_COLUMNS")
+    assert_frame_equal(
+        q.select("time", "value_is_null").collect(),
+        pl.DataFrame({"time": [-1, 1], "value_is_null": [None, True]}),
+    )
+
+
+def test_asof_join_does_not_hoist_ambiguous_right_expression() -> None:
+    left = pl.LazyFrame({"time": [1], "value": [100]}).set_sorted("time")
+    right = pl.LazyFrame({"time": [0, 1], "value": [0, 1]}).set_sorted("time")
+
+    q = left.join_asof(
+        right.with_columns((pl.col("value") + 1).alias("adjusted")),
+        on="time",
+    )
+    plan = q.explain()
+
+    assert plan.index("ASOF JOIN") < plan.index("WITH_COLUMNS")
+    assert q.select("adjusted").collect().item() == 2
+
+
 def test_merge_sorted_projection_pd() -> None:
     lf = pl.LazyFrame(
         {


### PR DESCRIPTION
Related to #25867.

## Summary

- Move eligible elementwise expressions from the right input of an as-of join to the smaller post-join result.
- Apply the rewrite only when both cardinalities are known and the left input is smaller than the right input.
- Preserve null behavior, join keys, column resolution, schema, and output ordering through conservative eligibility checks.

## Performance

For 2,000,000 right rows and 10,000 left rows, the median runtime improved from 22.939 ms to 2.632 ms in five-sample released-build measurements, an 8.72x speedup.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p polars-plan --features asof_join`
- `make pre-commit`
- Five release-mode native optimized-plan and result checks
- Full-feature focused tests: 5 passed
- `POLARS_FORCE_ASYNC=1 make -C py-polars test`: 17,730 passed, 76 skipped, 9 xfailed
- `git diff --check`

<img width="710" height="528" alt="image" src="https://github.com/user-attachments/assets/8ca5b5f6-bebe-4079-9a2a-5b40a8740bb8" />
