### PR TITLE
docs(python): Properly render backslashes in CSV `eol_char` docstrings

### DIFF
--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -230,9 +230,9 @@ def read_csv(
         .. deprecated:: 1.10.0
             This parameter is now a no-op.
     eol_char
-        Single byte end of line character (default: `\n`). When encountering a file
-        with windows line endings (`\r\n`), one can go with the default `\n`. The extra
-        `\r` will be removed when processed.
+        Single byte end of line character (default: ``\n``). When encountering a file
+        with windows line endings (``\r\n``), one can go with the default ``\n``. The
+        extra ``\r`` will be removed when processed.
     raise_if_empty
         When there is no data in the source, `NoDataError` is raised. If this parameter
         is set to False, an empty DataFrame (with no columns) is returned instead.
@@ -917,9 +917,9 @@ def read_csv_batched(
         .. deprecated:: 1.10.0
             Is a no-op.
     eol_char
-        Single byte end of line character (default: `\n`). When encountering a file
-        with windows line endings (`\r\n`), one can go with the default `\n`. The extra
-        `\r` will be removed when processed.
+        Single byte end of line character (default: ``\n``). When encountering a file
+        with windows line endings (``\r\n``), one can go with the default ``\n``. The
+        extra ``\r`` will be removed when processed.
     raise_if_empty
         When there is no data in the source,`NoDataError` is raised. If this parameter
         is set to False, `None` will be returned from `next_batches(n)` instead.
@@ -1252,9 +1252,9 @@ def scan_csv(
         can be inferred, as well as a handful of others. If this does not succeed,
         the column remains of data type `pl.String`.
     eol_char
-        Single byte end of line character (default: `\n`). When encountering a file
-        with windows line endings (`\r\n`), one can go with the default `\n`. The extra
-        `\r` will be removed when processed.
+        Single byte end of line character (default: ``\n``). When encountering a file
+        with windows line endings (``\r\n``), one can go with the default ``\n``. The
+        extra ``\r`` will be removed when processed.
     new_columns
         Provide an explicit list of string column names to use (for example, when
         scanning a headerless CSV file). If the given list is shorter than the width of


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/27959. 
