### PR TITLE
docs(rust): Fix escape sequences in CSV docstrings

### DIFF
--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -231,8 +231,8 @@ def read_csv(
             This parameter is now a no-op.
     eol_char
         Single byte end of line character (default: `\\n`). When encountering a file
-        with windows line endings (`\\r\\n`), one can go with the default `\\n`. The extra
-        `\\r` will be removed when processed.
+        with windows line endings (`\\r\\n`), one can go with the default `\\n`.
+        The extra `\\r` will be removed when processed.
     raise_if_empty
         When there is no data in the source, `NoDataError` is raised. If this parameter
         is set to False, an empty DataFrame (with no columns) is returned instead.
@@ -918,8 +918,8 @@ def read_csv_batched(
             Is a no-op.
     eol_char
         Single byte end of line character (default: `\\n`). When encountering a file
-        with windows line endings (`\\r\\n`), one can go with the default `\\n`. The extra
-        `\\r` will be removed when processed.
+        with windows line endings (`\\r\\n`), one can go with the default `\\n`.
+        The extra `\\r` will be removed when processed.
     raise_if_empty
         When there is no data in the source,`NoDataError` is raised. If this parameter
         is set to False, `None` will be returned from `next_batches(n)` instead.
@@ -1253,8 +1253,8 @@ def scan_csv(
         the column remains of data type `pl.String`.
     eol_char
         Single byte end of line character (default: `\\n`). When encountering a file
-        with windows line endings (`\\r\\n`), one can go with the default `\\n`. The extra
-        `\\r` will be removed when processed.
+        with windows line endings (`\\r\\n`), one can go with the default `\\n`.
+        The extra `\\r` will be removed when processed.
     new_columns
         Provide an explicit list of string column names to use (for example, when
         scanning a headerless CSV file). If the given list is shorter than the width of

--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -230,9 +230,9 @@ def read_csv(
         .. deprecated:: 1.10.0
             This parameter is now a no-op.
     eol_char
-        Single byte end of line character (default: `\n`). When encountering a file
-        with windows line endings (`\r\n`), one can go with the default `\n`. The extra
-        `\r` will be removed when processed.
+        Single byte end of line character (default: `\\n`). When encountering a file
+        with windows line endings (`\\r\\n`), one can go with the default `\\n`. The extra
+        `\\r` will be removed when processed.
     raise_if_empty
         When there is no data in the source, `NoDataError` is raised. If this parameter
         is set to False, an empty DataFrame (with no columns) is returned instead.
@@ -917,9 +917,9 @@ def read_csv_batched(
         .. deprecated:: 1.10.0
             Is a no-op.
     eol_char
-        Single byte end of line character (default: `\n`). When encountering a file
-        with windows line endings (`\r\n`), one can go with the default `\n`. The extra
-        `\r` will be removed when processed.
+        Single byte end of line character (default: `\\n`). When encountering a file
+        with windows line endings (`\\r\\n`), one can go with the default `\\n`. The extra
+        `\\r` will be removed when processed.
     raise_if_empty
         When there is no data in the source,`NoDataError` is raised. If this parameter
         is set to False, `None` will be returned from `next_batches(n)` instead.
@@ -1252,9 +1252,9 @@ def scan_csv(
         can be inferred, as well as a handful of others. If this does not succeed,
         the column remains of data type `pl.String`.
     eol_char
-        Single byte end of line character (default: `\n`). When encountering a file
-        with windows line endings (`\r\n`), one can go with the default `\n`. The extra
-        `\r` will be removed when processed.
+        Single byte end of line character (default: `\\n`). When encountering a file
+        with windows line endings (`\\r\\n`), one can go with the default `\\n`. The extra
+        `\\r` will be removed when processed.
     new_columns
         Provide an explicit list of string column names to use (for example, when
         scanning a headerless CSV file). If the given list is shorter than the width of


### PR DESCRIPTION
This PR addresses a formatting issue in the docstring where control characters for carriage returns and newlines were rendering incorrectly. Changed `\r\n` to `\\r\\n` to fix the character escaping.
It solves issue #27959 

### Verification
I have successfully set up the local environment using the memory-restricted compiler configuration (`CARGO_BUILD_JOBS=2`) and generated the documentation site via Sphinx 7.4.7. I verified visually that the modified API page renders perfectly in the local build.

Here is a visualization of how it looks like:
<img width="1058" height="122" alt="image" src="https://github.com/user-attachments/assets/2df37b2b-020a-433c-a81a-2d426b10755b" />

