### PR TITLE
depr(python): Deprecate `strict` parameter of `pl.concat`, replace with new `how='horizontal_extend'`

### DIFF
--- a/docs/source/src/python/user-guide/transformations/concatenation.py
+++ b/docs/source/src/python/user-guide/transformations/concatenation.py
@@ -68,7 +68,7 @@ df_horizontal_concat = pl.concat(
         df_h1,
         df_h2,
     ],
-    how="horizontal",
+    how="horizontal_extend",
 )
 print(df_horizontal_concat)
 # --8<-- [end:horizontal_different_lengths]

--- a/docs/source/src/python/user-guide/transformations/concatenation.py
+++ b/docs/source/src/python/user-guide/transformations/concatenation.py
@@ -46,6 +46,7 @@ df_horizontal_concat = pl.concat(
         df_h2,
     ],
     how="horizontal",
+    strict=True,
 )
 print(df_horizontal_concat)
 # --8<-- [end:horizontal]

--- a/docs/source/user-guide/transformations/concatenation.md
+++ b/docs/source/user-guide/transformations/concatenation.md
@@ -36,10 +36,10 @@ single wider `DataFrame`.
 --8<-- "python/user-guide/transformations/concatenation.py:horizontal"
 ```
 
-Horizontal concatenation fails when dataframes have overlapping columns.
-
-When dataframes have different numbers of rows, columns will be padded with `null` values at the end
-up to the maximum length.
+Horizontal concatenation fails when dataframes have overlapping columns. Moreover, it is required
+that both dataframes have the same height. To combine dataframes with different height, use
+`how="horizontal_extend"`, which pads shorter columns with `null` values at the end to match the
+height of the longest dataframe.
 
 {{code_block('user-guide/transformations/concatenation','horizontal_different_lengths',['concat'])}}
 

--- a/py-polars/src/polars/_typing.py
+++ b/py-polars/src/polars/_typing.py
@@ -291,6 +291,7 @@ ConcatMethod = Literal[
     "diagonal",
     "diagonal_relaxed",
     "horizontal",
+    "horizontal_extend",
     "align",
     "align_full",
     "align_inner",

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -1109,7 +1109,7 @@ class DataFrame:
 
         suffix = "__POLARS_CMP_OTHER"
         other_renamed = other.select(F.all().name.suffix(suffix))
-        combined = F.concat([self, other_renamed], how="horizontal")
+        combined = F.concat([self, other_renamed], how="horizontal", strict=True)
 
         if op == "eq":
             expr = [F.col(n) == F.col(f"{n}{suffix}") for n in self.columns]
@@ -2489,7 +2489,9 @@ class DataFrame:
                 if features is not None
                 else self.drop(*label_frame.columns)
             ).cast(to_dtype)  # type: ignore[arg-type]
-            frame = F.concat([label_frame, features_frame], how="horizontal")
+            frame = F.concat(
+                [label_frame, features_frame], how="horizontal", strict=True
+            )
         else:
             label_frame = None
             features_frame = None

--- a/py-polars/src/polars/exceptions.py
+++ b/py-polars/src/polars/exceptions.py
@@ -72,7 +72,7 @@ else:
             Examples
             --------
             >>> df = pl.DataFrame({"a": [1, 1, 1]})
-            >>> pl.concat([df, df], how="horizontal")
+            >>> pl.concat([df, df], how="horizontal_extend")
             polars.exceptions.DuplicateError: unable to hstack, column with name "a" already exists
             """  # noqa: W505
 

--- a/py-polars/src/polars/exceptions.py
+++ b/py-polars/src/polars/exceptions.py
@@ -72,7 +72,7 @@ else:
             Examples
             --------
             >>> df = pl.DataFrame({"a": [1, 1, 1]})
-            >>> pl.concat([df, df], how="horizontal_extend")
+            >>> pl.concat([df, df], how="horizontal", strict=True)
             polars.exceptions.DuplicateError: unable to hstack, column with name "a" already exists
             """  # noqa: W505
 

--- a/py-polars/src/polars/functions/eager.py
+++ b/py-polars/src/polars/functions/eager.py
@@ -41,14 +41,14 @@ def _normalize_horizontal_concat(
                 "is deprecated and will require equal heights in the next breaking "
                 "release. "
                 "Use `how='horizontal_extend'` to keep the current behavior.",
-                version="1.42.0",
+                version="1.42.1",
             )
             return "horizontal_extend"
         elif strict is False:
             issue_deprecation_warning(
                 f"the `strict` parameter for `{function_name}` is deprecated. "
                 "Use `how='horizontal_extend'` instead.",
-                version="1.42.0",
+                version="1.42.1",
             )
             return "horizontal_extend"
         else:
@@ -106,7 +106,7 @@ def concat(
     strict
         When how=`horizontal`, require all DataFrames to be the same height, raising an error if not.
 
-        .. deprecated:: 1.42.0
+        .. deprecated:: 1.42.1
             Use `how='horizontal'` (equal heights) or
             `how='horizontal_extend'` (pad with null) instead.
 
@@ -421,7 +421,7 @@ def union(
     strict
         When how=`horizontal`, require all DataFrames to be the same height, raising an error if not.
 
-        .. deprecated:: 1.42.0
+        .. deprecated:: 1.42.1
             Use `how='horizontal'` (equal heights) or
             `how='horizontal_extend'` (pad with null) instead.
 

--- a/py-polars/src/polars/functions/eager.py
+++ b/py-polars/src/polars/functions/eager.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, get_args
 import polars._reexport as pl
 from polars import functions as F
 from polars._typing import ConcatMethod
+from polars._utils.deprecation import issue_deprecation_warning
 from polars._utils.reduce_balanced import reduce_balanced
 from polars._utils.unstable import unstable
 from polars._utils.various import (
@@ -29,13 +30,44 @@ if TYPE_CHECKING:
     from polars._typing import FrameType, JoinStrategy, PolarsType
 
 
+def _normalize_horizontal_concat(
+    function_name: str, how: ConcatMethod, *, strict: bool | None
+) -> ConcatMethod:
+    """Normalize deprecated horizontal concat arguments."""
+    if how == "horizontal":
+        if strict is None:
+            issue_deprecation_warning(
+                f"the default behavior of `how='horizontal'` for `{function_name}` "
+                "is deprecated and will require equal heights in the next breaking "
+                "release. "
+                "Use `how='horizontal_extend'` to keep the current behavior.",
+                version="1.41.2",
+            )
+            return "horizontal_extend"
+        elif strict is False:
+            issue_deprecation_warning(
+                f"the `strict` parameter for `{function_name}` is deprecated. "
+                "Use `how='horizontal_extend'` instead.",
+                version="1.41.2",
+            )
+            return "horizontal_extend"
+        else:
+            return "horizontal"
+
+    if how == "horizontal_extend" and strict is not None:
+        msg = "`strict` cannot be used with `how='horizontal_extend'`"
+        raise ValueError(msg)
+
+    return how
+
+
 def concat(
     items: Iterable[PolarsType],
     *,
     how: ConcatMethod = "vertical",
     rechunk: bool = False,
     parallel: bool = True,
-    strict: bool = False,
+    strict: bool | None = None,
 ) -> PolarsType:
     """
     Combine multiple DataFrames, LazyFrames, or Series into a single object.
@@ -44,7 +76,7 @@ def concat(
     ----------
     items
         DataFrames, LazyFrames, or Series to concatenate.
-    how : {'vertical', 'vertical_relaxed', 'diagonal', 'diagonal_relaxed', 'horizontal', 'align', 'align_full', 'align_inner', 'align_left', 'align_right'}
+    how : {'vertical', 'vertical_relaxed', 'diagonal', 'diagonal_relaxed', 'horizontal', 'horizontal_extend', 'align', 'align_full', 'align_inner', 'align_left', 'align_right'}
         Note that `Series` only support the `vertical` strategy.
 
         * vertical: Applies multiple `vstack` operations.
@@ -54,7 +86,9 @@ def concat(
           values with `null`.
         * diagonal_relaxed: Same as `diagonal`, but additionally coerces columns to
           their common supertype *if* they are mismatched (eg: Int32 → Int64).
-        * horizontal: Stacks Series from DataFrames horizontally and fills with `null`
+        * horizontal: Stacks Series from DataFrames horizontally. All input frames
+          must have the same height; raises a `ShapeError` otherwise.
+        * horizontal_extend: Same as `horizontal`, but pads shorter frames with `null`
           if the lengths don't match.
         * align, align_full, align_left, align_right: Combines frames horizontally,
           auto-determining the common key columns and aligning rows using the same
@@ -71,6 +105,10 @@ def concat(
         lazy computations may be executed in parallel.
     strict
         When how=`horizontal`, require all DataFrames to be the same height, raising an error if not.
+
+        .. deprecated:: 1.41.2
+            Use `how='horizontal'` (equal heights) or
+            `how='horizontal_extend'` (pad with null) instead.
 
     Examples
     --------
@@ -180,7 +218,8 @@ def concat(
     if not elems:
         msg = "cannot concat empty list"
         raise ValueError(msg)
-    elif len(elems) == 1 and isinstance(
+
+    if len(elems) == 1 and isinstance(
         elems[0], (pl.DataFrame, pl.Series, pl.LazyFrame)
     ):
         return elems[0]
@@ -242,6 +281,8 @@ def concat(
     from polars.lazyframe.opt_flags import QueryOptFlags
 
     if is_non_empty_sequence_of(elems, pl.DataFrame):
+        how = _normalize_horizontal_concat("concat", how, strict=strict)
+
         if how == "vertical":
             out = wrap_df(plr.concat_df(elems))
         elif how == "vertical_relaxed":
@@ -268,13 +309,17 @@ def concat(
                 )
             ).collect(optimizations=QueryOptFlags._eager())
         elif how == "horizontal":
-            out = wrap_df(plr.concat_df_horizontal(elems, strict=strict))
+            out = wrap_df(plr.concat_df_horizontal(elems, strict=True))
+        elif how == "horizontal_extend":
+            out = wrap_df(plr.concat_df_horizontal(elems, strict=False))
         else:
             allowed = ", ".join(repr(m) for m in get_args(ConcatMethod))
             msg = f"DataFrame `how` must be one of {{{allowed}}}, got {how!r}"
             raise ValueError(msg)
 
     elif is_non_empty_sequence_of(elems, pl.LazyFrame):
+        how = _normalize_horizontal_concat("concat", how, strict=strict)
+
         if how in ("vertical", "vertical_relaxed"):
             return wrap_ldf(
                 plr.concat_lf(
@@ -300,7 +345,15 @@ def concat(
                 plr.concat_lf_horizontal(
                     elems,
                     parallel=parallel,
-                    strict=strict,
+                    strict=True,
+                )
+            )
+        elif how == "horizontal_extend":
+            return wrap_ldf(
+                plr.concat_lf_horizontal(
+                    elems,
+                    parallel=parallel,
+                    strict=False,
                 )
             )
         else:
@@ -330,7 +383,7 @@ def union(
     items: Iterable[PolarsType],
     *,
     how: ConcatMethod = "vertical",
-    strict: bool = False,
+    strict: bool | None = None,
 ) -> PolarsType:
     """
     Combine multiple DataFrames, LazyFrames, or Series into a single object.
@@ -343,7 +396,7 @@ def union(
     ----------
     items
         DataFrames, LazyFrames, or Series to concatenate.
-    how : {'vertical', 'vertical_relaxed', 'diagonal', 'diagonal_relaxed', 'horizontal', 'align', 'align_full', 'align_inner', 'align_left', 'align_right'}
+    how : {'vertical', 'vertical_relaxed', 'diagonal', 'diagonal_relaxed', 'horizontal', 'horizontal_extend', 'align', 'align_full', 'align_inner', 'align_left', 'align_right'}
         Note that `Series` only support the `vertical` strategy.
 
         * vertical: Applies multiple `vstack` operations.
@@ -353,7 +406,9 @@ def union(
           values with `null`.
         * diagonal_relaxed: Same as `diagonal`, but additionally coerces columns to
           their common supertype *if* they are mismatched (eg: Int32 → Int64).
-        * horizontal: Stacks Series from DataFrames horizontally and fills with `null`
+        * horizontal: Stacks Series from DataFrames horizontally. All input frames
+          must have the same height; raises a `ShapeError` otherwise.
+        * horizontal_extend: Same as `horizontal`, but pads shorter frames with `null`
           if the lengths don't match.
         * align, align_full, align_left, align_right: Combines frames horizontally,
           auto-determining the common key columns and aligning rows using the same
@@ -365,6 +420,10 @@ def union(
           a suitable `join` method directly).
     strict
         When how=`horizontal`, require all DataFrames to be the same height, raising an error if not.
+
+        .. deprecated:: 1.41.2
+            Use `how='horizontal'` (equal heights) or
+            `how='horizontal_extend'` (pad with null) instead.
 
     Examples
     --------
@@ -474,7 +533,8 @@ def union(
     if not elems:
         msg = "cannot concat empty list"
         raise ValueError(msg)
-    elif len(elems) == 1 and isinstance(
+
+    if len(elems) == 1 and isinstance(
         elems[0], (pl.DataFrame, pl.Series, pl.LazyFrame)
     ):
         return elems[0]
@@ -536,6 +596,8 @@ def union(
     from polars.lazyframe.opt_flags import QueryOptFlags
 
     if is_non_empty_sequence_of(elems, pl.DataFrame):
+        how = _normalize_horizontal_concat("union", how, strict=strict)
+
         if how in ("vertical", "vertical_relaxed"):
             out = wrap_ldf(
                 plr.concat_lf(
@@ -557,13 +619,17 @@ def union(
                 )
             ).collect(optimizations=QueryOptFlags._eager())
         elif how == "horizontal":
-            out = wrap_df(plr.concat_df_horizontal(elems, strict=strict))
+            out = wrap_df(plr.concat_df_horizontal(elems, strict=True))
+        elif how == "horizontal_extend":
+            out = wrap_df(plr.concat_df_horizontal(elems, strict=False))
         else:
             allowed = ", ".join(repr(m) for m in get_args(ConcatMethod))
             msg = f"DataFrame `how` must be one of {{{allowed}}}, got {how!r}"
             raise ValueError(msg)
 
     elif is_non_empty_sequence_of(elems, pl.LazyFrame):
+        how = _normalize_horizontal_concat("union", how, strict=strict)
+
         if how in ("vertical", "vertical_relaxed"):
             return wrap_ldf(
                 plr.concat_lf(
@@ -589,7 +655,15 @@ def union(
                 plr.concat_lf_horizontal(
                     elems,
                     parallel=True,
-                    strict=strict,
+                    strict=True,
+                )
+            )
+        elif how == "horizontal_extend":
+            return wrap_ldf(
+                plr.concat_lf_horizontal(
+                    elems,
+                    parallel=True,
+                    strict=False,
                 )
             )
         else:

--- a/py-polars/src/polars/functions/eager.py
+++ b/py-polars/src/polars/functions/eager.py
@@ -140,7 +140,7 @@ def concat(
 
     >>> df_h1 = pl.DataFrame({"l1": [1, 2], "l2": [3, 4]})
     >>> df_h2 = pl.DataFrame({"r1": [5, 6], "r2": [7, 8], "r3": [9, 10]})
-    >>> pl.concat([df_h1, df_h2], how="horizontal")
+    >>> pl.concat([df_h1, df_h2], how="horizontal_extend")
     shape: (2, 5)
     ┌─────┬─────┬─────┬─────┬─────┐
     │ l1  ┆ l2  ┆ r1  ┆ r2  ┆ r3  │
@@ -455,7 +455,7 @@ def union(
 
     >>> df_h1 = pl.DataFrame({"l1": [1, 2], "l2": [3, 4]})
     >>> df_h2 = pl.DataFrame({"r1": [5, 6], "r2": [7, 8], "r3": [9, 10]})
-    >>> pl.union([df_h1, df_h2], how="horizontal")
+    >>> pl.union([df_h1, df_h2], how="horizontal_extend")
     shape: (2, 5)
     ┌─────┬─────┬─────┬─────┬─────┐
     │ l1  ┆ l2  ┆ r1  ┆ r2  ┆ r3  │

--- a/py-polars/src/polars/functions/eager.py
+++ b/py-polars/src/polars/functions/eager.py
@@ -41,14 +41,14 @@ def _normalize_horizontal_concat(
                 "is deprecated and will require equal heights in the next breaking "
                 "release. "
                 "Use `how='horizontal_extend'` to keep the current behavior.",
-                version="1.41.2",
+                version="1.42.0",
             )
             return "horizontal_extend"
         elif strict is False:
             issue_deprecation_warning(
                 f"the `strict` parameter for `{function_name}` is deprecated. "
                 "Use `how='horizontal_extend'` instead.",
-                version="1.41.2",
+                version="1.42.0",
             )
             return "horizontal_extend"
         else:
@@ -106,7 +106,7 @@ def concat(
     strict
         When how=`horizontal`, require all DataFrames to be the same height, raising an error if not.
 
-        .. deprecated:: 1.41.2
+        .. deprecated:: 1.42.0
             Use `how='horizontal'` (equal heights) or
             `how='horizontal_extend'` (pad with null) instead.
 
@@ -421,7 +421,7 @@ def union(
     strict
         When how=`horizontal`, require all DataFrames to be the same height, raising an error if not.
 
-        .. deprecated:: 1.41.2
+        .. deprecated:: 1.42.0
             Use `how='horizontal'` (equal heights) or
             `how='horizontal_extend'` (pad with null) instead.
 

--- a/py-polars/src/polars/io/iceberg/_utils.py
+++ b/py-polars/src/polars/io/iceberg/_utils.py
@@ -498,7 +498,7 @@ class IcebergStatisticsLoader:
             column_stats_df = stat_builder.finish(expected_height, p)
             out.append(column_stats_df)
 
-        return pl.concat(out, how="horizontal")
+        return pl.concat(out, how="horizontal", strict=True)
 
 
 @dataclass

--- a/py-polars/tests/unit/datatypes/test_array.py
+++ b/py-polars/tests/unit/datatypes/test_array.py
@@ -433,7 +433,9 @@ def test_zero_width_array(fn: str) -> None:
 
                 series_f(a, b)
 
-                df = pl.concat([a.to_frame(), b.to_frame()], how="horizontal")
+                df = pl.concat(
+                    [a.to_frame(), b.to_frame()], how="horizontal", strict=True
+                )
                 df.select(c=expr_f(pl.col.a, pl.col.b))
 
 

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -1082,7 +1082,7 @@ def test_struct_chunked_zip_18119() -> None:
     b = pl.concat([b_dfs[4], b_dfs[1]])
     mask = pl.concat([mask_dfs[3], mask_dfs[2]])
 
-    df = pl.concat([a, b, mask], how="horizontal")
+    df = pl.concat([a, b, mask], how="horizontal", strict=True)
 
     assert_frame_equal(
         df.select(pl.when(pl.col.f).then(pl.col.a).otherwise(pl.col.b)),
@@ -1437,7 +1437,7 @@ def test_struct_equal_missing_null_25360() -> None:
     q1 = lf.select(a1=pl.col.a.slice(1, 1).first())
     q2 = lf.group_by(pl.lit(1)).agg(a2=pl.col.a.slice(1, 1).first()).drop("literal")
 
-    q = pl.concat([q1, q2], how="horizontal").collect()
+    q = pl.concat([q1, q2], how="horizontal", strict=True).collect()
 
     result = q.select(
         eq=pl.col.a1.eq(pl.col.a2),
@@ -1920,6 +1920,8 @@ def test_with_fields_optimize_expr_fused_multiply_add_27233() -> None:
         pl.col.s.struct.with_fields(fma=pl.field("x") * pl.lit(2) + pl.field("y"))
     )
     expected = pl.concat(
-        [df.unnest("s"), pl.DataFrame({"fma": [31, 61]})], how="horizontal"
+        [df.unnest("s"), pl.DataFrame({"fma": [31, 61]})],
+        how="horizontal",
+        strict=True,
     )
     assert_frame_equal(out.unnest("s"), expected)

--- a/py-polars/tests/unit/functions/test_concat.py
+++ b/py-polars/tests/unit/functions/test_concat.py
@@ -47,7 +47,8 @@ def test_concat_horizontally_strict() -> None:
     with pytest.raises(pl.exceptions.ShapeError):
         pl.concat([df2.lazy(), df3.lazy()], how="horizontal", strict=True).collect()
 
-    out = pl.concat([df1, df3], how="horizontal", strict=False)
+    with pytest.deprecated_call(match="`strict` parameter"):
+        out = pl.concat([df1, df3], how="horizontal", strict=False)
     assert out.to_dict(as_series=False) == {
         "a": [0, 1, 2],
         "b": [1, 2, 3],
@@ -55,7 +56,8 @@ def test_concat_horizontally_strict() -> None:
         "d": [42, None, None],
     }
 
-    out = pl.concat([df2, df3], how="horizontal", strict=False)
+    with pytest.deprecated_call(match="`strict` parameter"):
+        out = pl.concat([df2, df3], how="horizontal", strict=False)
     assert out.to_dict(as_series=False) == {
         "a": [0, 1, 2],
         "b": [1, 2, 3],
@@ -294,13 +296,33 @@ def test_concat_diagonal_relaxed() -> None:
 def test_concat_horizontal() -> None:
     df1 = pl.DataFrame({"a": [1, 2, 3]})
     df2 = pl.DataFrame({"b": [4, 5]})
+    df3 = pl.DataFrame({"c": [6, 7, 8]})
+
+    with pytest.deprecated_call(match="default behavior of `how='horizontal'`"):
+        result = pl.concat([df1, df2], how="horizontal")
+    expected = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, None]})
+    assert_frame_equal(result, expected)
+
+    with pytest.deprecated_call(match="default behavior of `how='horizontal'`"):
+        result = pl.concat([df1, df3], how="horizontal")
+    expected = pl.DataFrame({"a": [1, 2, 3], "c": [6, 7, 8]})
+    assert_frame_equal(result, expected)
+
+
+def test_concat_horizontal_extend() -> None:
+    df1 = pl.DataFrame({"a": [1, 2, 3]})
+    df2 = pl.DataFrame({"b": [4, 5]})
     df3 = pl.DataFrame({"c": [6, 7, 8, 9]})
 
-    result = pl.concat([df1, df2, df3], how="horizontal")
+    result = pl.concat([df1, df2, df3], how="horizontal_extend")
     expected = pl.DataFrame(
         {"a": [1, 2, 3, None], "b": [4, 5, None, None], "c": [6, 7, 8, 9]}
     )
     assert_frame_equal(result, expected)
+
+    for strict in (True, False):
+        with pytest.raises(ValueError, match=r"strict.*horizontal_extend"):
+            pl.concat([df1, df2], how="horizontal_extend", strict=strict)
 
 
 def test_concat_align_no_common_columns() -> None:
@@ -326,15 +348,41 @@ def test_concat_align_lazy_frames() -> None:
 
 
 def test_concat_lazyframe_horizontal() -> None:
+    lf1 = pl.DataFrame({"a": [1, 2, 3]}).lazy()
+    lf2 = pl.DataFrame({"b": [4, 5]}).lazy()
+    lf3 = pl.DataFrame({"c": [6, 7, 8]}).lazy()
+
+    with pytest.deprecated_call(match="default behavior of `how='horizontal'`"):
+        result = pl.concat([lf1, lf2], how="horizontal")
+    assert isinstance(result, pl.LazyFrame)
+
+    collected = result.collect()
+    expected = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, None]})
+    assert_frame_equal(collected, expected)
+
+    with pytest.deprecated_call(match="default behavior of `how='horizontal'`"):
+        result = pl.concat([lf1, lf3], how="horizontal")
+    assert isinstance(result, pl.LazyFrame)
+
+    collected = result.collect()
+    expected = pl.DataFrame({"a": [1, 2, 3], "c": [6, 7, 8]})
+    assert_frame_equal(collected, expected)
+
+
+def test_concat_lazyframe_horizontal_extend() -> None:
     lf1 = pl.DataFrame({"a": [1, 2]}).lazy()
     lf2 = pl.DataFrame({"b": [3, 4, 5]}).lazy()
 
-    result = pl.concat([lf1, lf2], how="horizontal")
+    result = pl.concat([lf1, lf2], how="horizontal_extend")
     assert isinstance(result, pl.LazyFrame)
 
     collected = result.collect()
     expected = pl.DataFrame({"a": [1, 2, None], "b": [3, 4, 5]})
     assert_frame_equal(collected, expected)
+
+    for strict in (True, False):
+        with pytest.raises(ValueError, match=r"strict.*horizontal_extend"):
+            pl.concat([lf1, lf2], how="horizontal_extend", strict=strict)
 
 
 def test_concat_lazyframe_diagonal() -> None:
@@ -411,12 +459,12 @@ def test_concat_with_empty_dataframes_strict_25725() -> None:
 
 def test_concat_with_empty_dataframes_nonstrict_25727() -> None:
     df = pl.LazyFrame({"a": [1, 2], "b": ["x", "y"]})
-    result = pl.concat([df, df.select([])], how="horizontal", strict=False)
+    result = pl.concat([df, df.select([])], how="horizontal_extend")
     expected = pl.LazyFrame({"a": [1, 2], "b": ["x", "y"]})
     assert_frame_equal(result, expected)
 
     empty_df = pl.LazyFrame(schema={"c": pl.Int64})
-    result = pl.concat([empty_df, df], how="horizontal", strict=False)
+    result = pl.concat([empty_df, df], how="horizontal_extend")
     expected = pl.LazyFrame(
         {"c": [None, None], "a": [1, 2], "b": ["x", "y"]},
         schema={"c": pl.Int64, "a": pl.Int64, "b": pl.String},

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -142,9 +142,9 @@ def test_concat_horizontal(lazy: bool) -> None:
     b = pl.DataFrame({"c": [5, 7, 8, 9], "d": [1, 2, 1, 2], "e": [1, 2, 1, 2]})
 
     if lazy:
-        out = pl.concat([a.lazy(), b.lazy()], how="horizontal").collect()
+        out = pl.concat([a.lazy(), b.lazy()], how="horizontal_extend").collect()
     else:
-        out = pl.concat([a, b], how="horizontal")
+        out = pl.concat([a, b], how="horizontal_extend")
 
     expected = pl.DataFrame(
         {
@@ -165,9 +165,11 @@ def test_concat_horizontal_three_dfs(lazy: bool) -> None:
     c = pl.DataFrame({"c1": [1, 2, 3, 4], "c2": [5, 6, 7, 8], "c3": [9, 10, 11, 12]})
 
     if lazy:
-        out = pl.concat([a.lazy(), b.lazy(), c.lazy()], how="horizontal").collect()
+        out = pl.concat(
+            [a.lazy(), b.lazy(), c.lazy()], how="horizontal_extend"
+        ).collect()
     else:
-        out = pl.concat([a, b, c], how="horizontal")
+        out = pl.concat([a, b, c], how="horizontal_extend")
 
     expected = pl.DataFrame(
         {
@@ -187,9 +189,9 @@ def test_concat_horizontal_single_df(lazy: bool) -> None:
     a = pl.DataFrame({"a": ["a", "b"], "b": [1, 2]})
 
     if lazy:
-        out = pl.concat([a.lazy()], how="horizontal").collect()
+        out = pl.concat([a.lazy()], how="horizontal", strict=True).collect()
     else:
-        out = pl.concat([a], how="horizontal")
+        out = pl.concat([a], how="horizontal", strict=True)
 
     expected = a
     assert_frame_equal(out, expected)
@@ -200,7 +202,7 @@ def test_concat_horizontal_duplicate_col() -> None:
     b = pl.LazyFrame({"c": [5, 7, 8, 9], "d": [1, 2, 1, 2], "a": [1, 2, 1, 2]})
 
     with pytest.raises(DuplicateError):
-        pl.concat([a, b], how="horizontal").collect()
+        pl.concat([a, b], how="horizontal_extend").collect()
 
 
 def test_concat_vertical() -> None:

--- a/py-polars/tests/unit/functions/test_union.py
+++ b/py-polars/tests/unit/functions/test_union.py
@@ -110,11 +110,26 @@ def test_union_horizontal() -> None:
     df2 = pl.DataFrame({"b": [4, 5]})
     df3 = pl.DataFrame({"c": [6, 7, 8, 9]})
 
-    result = pl.union([df1, df2, df3], how="horizontal")
+    with pytest.deprecated_call(match="default behavior of `how='horizontal'`"):
+        result = pl.union([df1, df2, df3], how="horizontal")
     expected = pl.DataFrame(
         {"a": [1, 2, 3, None], "b": [4, 5, None, None], "c": [6, 7, 8, 9]}
     )
     assert_frame_equal(result, expected)
+
+    result = pl.union([df1, df2, df3], how="horizontal_extend")
+    assert_frame_equal(result, expected)
+
+    with pytest.raises(pl.exceptions.ShapeError):
+        pl.union([df1, df2], how="horizontal", strict=True)
+
+    with pytest.deprecated_call(match="`strict` parameter"):
+        result = pl.union([df1, df2, df3], how="horizontal", strict=False)
+    assert_frame_equal(result, expected)
+
+    for strict in (True, False):
+        with pytest.raises(ValueError, match=r"strict.*horizontal_extend"):
+            pl.union([df1, df2], how="horizontal_extend", strict=strict)
 
 
 def test_union_align_no_common_columns() -> None:
@@ -143,12 +158,28 @@ def test_union_lazyframe_horizontal() -> None:
     lf1 = pl.DataFrame({"a": [1, 2]}).lazy()
     lf2 = pl.DataFrame({"b": [3, 4, 5]}).lazy()
 
-    result = pl.union([lf1, lf2], how="horizontal")
+    with pytest.deprecated_call(match="default behavior of `how='horizontal'`"):
+        result = pl.union([lf1, lf2], how="horizontal")
     assert isinstance(result, pl.LazyFrame)
 
     collected = result.collect()
     expected = pl.DataFrame({"a": [1, 2, None], "b": [3, 4, 5]})
     assert_frame_equal(collected, expected)
+
+    result = pl.union([lf1, lf2], how="horizontal_extend")
+    assert isinstance(result, pl.LazyFrame)
+    assert_frame_equal(result.collect(), expected)
+
+    with pytest.raises(pl.exceptions.ShapeError):
+        pl.union([lf1, lf2], how="horizontal", strict=True).collect()
+
+    with pytest.deprecated_call(match="`strict` parameter"):
+        result = pl.union([lf1, lf2], how="horizontal", strict=False)
+    assert_frame_equal(result.collect(), expected)
+
+    for strict in (True, False):
+        with pytest.raises(ValueError, match=r"strict.*horizontal_extend"):
+            pl.union([lf1, lf2], how="horizontal_extend", strict=strict)
 
 
 def test_union_lazyframe_diagonal() -> None:

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -2247,6 +2247,7 @@ def test_scan_iceberg_min_max_statistics_filter(
             coalesced_min_max_values.select(pl.struct(pl.all()).alias("coalesced")),
         ],
         how="horizontal",
+        strict=True,
     ).filter(pl.first() != pl.last())
 
     # Float statistics are available after coalescing from an identity partition field.

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -1269,7 +1269,7 @@ def test_cse_map_batches_distinct_functions() -> None:
         lambda df: df.select(pl.col("b").alias("y")),
         schema=pl.Schema({"y": pl.Int64}),
     )
-    result = pl.concat([lf1, lf2], how="horizontal").collect(
+    result = pl.concat([lf1, lf2], how="horizontal", strict=True).collect(
         optimizations=pl.QueryOptFlags(comm_subplan_elim=True)
     )
     assert result.columns == ["x", "y"]

--- a/py-polars/tests/unit/lazyframe/test_optimizations.py
+++ b/py-polars/tests/unit/lazyframe/test_optimizations.py
@@ -1109,6 +1109,7 @@ def test_hconcat_reorder_projection_push_to_inputs() -> None:
             pl.LazyFrame(schema={"c": pl.Null, "d": pl.Null}),
         ],
         how="horizontal",
+        strict=True,
     )
 
     q = hconcat.select("b", "a", "d", "c")
@@ -1144,6 +1145,7 @@ def test_hconcat_projection_pushdown_lazy_schema_27818() -> None:
             ),
         ],
         how="horizontal",
+        strict=True,
     ).select("B", "C")
 
     f = io.BytesIO()

--- a/py-polars/tests/unit/lazyframe/test_predicates.py
+++ b/py-polars/tests/unit/lazyframe/test_predicates.py
@@ -527,6 +527,7 @@ def test_hconcat_predicate() -> None:
             lf2.filter(pl.col("b1") > 0),
         ],
         how="horizontal",
+        strict=True,
     ).filter(pl.col("b2") < 9)
 
     expected = pl.DataFrame(

--- a/py-polars/tests/unit/lazyframe/test_projections.py
+++ b/py-polars/tests/unit/lazyframe/test_projections.py
@@ -100,7 +100,7 @@ def test_unnest_projection_pushdown() -> None:
 def test_hconcat_projection_pushdown() -> None:
     lf1 = pl.LazyFrame({"a": [0, 1, 2], "b": [3, 4, 5]})
     lf2 = pl.LazyFrame({"c": [6, 7, 8], "d": [9, 10, 11]})
-    query = pl.concat([lf1, lf2], how="horizontal").select(["a", "d"])
+    query = pl.concat([lf1, lf2], how="horizontal", strict=True).select(["a", "d"])
 
     explanation = query.explain()
     assert explanation.count("1/2 COLUMNS") == 2
@@ -115,7 +115,7 @@ def test_hconcat_projection_pushdown_length_maintained() -> None:
     # the length of the result, even though no columns are used.
     lf1 = pl.LazyFrame({"a": [0, 1], "b": [2, 3]})
     lf2 = pl.LazyFrame({"c": [4, 5, 6, 7], "d": [8, 9, 10, 11]})
-    query = pl.concat([lf1, lf2], how="horizontal").select(["a"])
+    query = pl.concat([lf1, lf2], how="horizontal_extend").select(["a"])
 
     explanation = query.explain()
     assert "1/2 COLUMNS" in explanation
@@ -836,13 +836,13 @@ def test_projection_pushdown_select_len() -> None:
     assert q.collect().item() == 1
 
 
-def test_projection_pushdown_nonstrict_hconcat_select_len() -> None:
+def test_projection_pushdown_horizontal_extend_select_len() -> None:
     q = pl.concat(
         [
             pl.LazyFrame({"a": [0, 1, 2]}),
             pl.LazyFrame({"b": [0, 1, 2, 3, 4]}),
         ],
-        how="horizontal",
+        how="horizontal_extend",
     ).select(pl.len())
     plan = q.explain()
 

--- a/py-polars/tests/unit/operations/test_inequality_join.py
+++ b/py-polars/tests/unit/operations/test_inequality_join.py
@@ -781,7 +781,9 @@ def test_range_join_dtypes(
     # 50 samples should ensure that this join will have plenty of matches
     lo_df = point_df.sample(50, with_replacement=True, seed=0).rename({"point": "lo"})
     hi_df = point_df.sample(50, with_replacement=True, seed=1).rename({"point": "hi"})
-    interval_lf = pl.concat([lo_df, hi_df], how="horizontal").with_row_index().lazy()
+    interval_lf = (
+        pl.concat([lo_df, hi_df], how="horizontal", strict=True).with_row_index().lazy()
+    )
     point_lf = point_df.with_row_index().lazy()
     predicates = [
         _inequality_expression_col("point", op, col)

--- a/py-polars/tests/unit/operations/test_slice.py
+++ b/py-polars/tests/unit/operations/test_slice.py
@@ -148,7 +148,7 @@ def test_hconcat_slice_pushdown() -> None:
         pl.LazyFrame({f"column_{i}": list(range(i, i + 10))}) for i in range(num_dfs)
     ]
 
-    out = pl.concat(lfs, how="horizontal").slice(2, 3)
+    out = pl.concat(lfs, how="horizontal", strict=True).slice(2, 3)
     plan = out.explain()
 
     assert not plan.startswith("SLICE")
@@ -169,17 +169,17 @@ def test_hconcat_tail_unequal_heights_27552() -> None:
     a = pl.LazyFrame({"x": [1, 2, 3, 4, 5]})
     b = pl.LazyFrame({"y": [10, 20, 30]})
 
-    lazy_out = pl.concat([a, b], how="horizontal").tail(2).collect()
-    eager_out = pl.concat([a.collect(), b.collect()], how="horizontal").tail(2)
+    lazy_out = pl.concat([a, b], how="horizontal_extend").tail(2).collect()
+    eager_out = pl.concat([a.collect(), b.collect()], how="horizontal_extend").tail(2)
 
     assert_frame_equal(lazy_out, eager_out)
 
 
 def test_hconcat_tail_unequal_heights_strict_raises_27552() -> None:
     # Regression for https://github.com/pola-rs/polars/issues/27552
-    # With strict=True, horizontal concat of unequal-height inputs must raise,
-    # even when followed by a negative-offset slice. Before the fix, the slice
-    # was pushed into each input and equalised their post-slice heights,
+    # With strict=True, concat of unequal-height inputs must raise, even when
+    # followed by a negative-offset slice. Before the fix, the slice was pushed
+    # into each input and equalised their post-slice heights,
     # silently bypassing the strict-mode height check.
     a = pl.LazyFrame({"x": [1, 2, 3, 4, 5]})
     b = pl.LazyFrame({"y": [10, 20, 30]})

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -333,7 +333,7 @@ def test_streaming_with_hconcat(tmp_path: Path) -> None:
     lf1 = pl.scan_parquet(tmp_path / "df1.parquet")
     lf2 = pl.scan_parquet(tmp_path / "df2.parquet")
     query = (
-        pl.concat([lf1, lf2], how="horizontal")
+        pl.concat([lf1, lf2], how="horizontal", strict=True)
         .group_by("id")
         .agg(pl.all().mean())
         .sort(pl.col("id"))


### PR DESCRIPTION
Related issue: #27927 

`strict` only affected `how="horizontal"`, so we replace it with a new `how="horizontal_extend"` variant:

- `how="horizontal"` requires equal heights, otherwise raises `ShapeError` (i.e. the old `strict=True`)
- `how="horizontal_extend"` - pads the shorter frames with nulls (i.e. the old `strict=False` default)

`strict` still works but now gives a `DeprecationWarning` and for now, we translate `strict=True` → `horizontal`, `strict=False` → `horizontal_extend`.

Also migrated some existing tests that relied on the (non-strict) default to `horizontal_extend`.

Tests >.<

<img width="587" height="823" alt="image" src="https://github.com/user-attachments/assets/f5c93f82-0375-4020-99bf-ade380afc5f2" />
