### PR TITLE
chore: Update `pyo3` and `rust-numpy` to `0.29.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2660,9 +2660,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778da78c64ddc928ebf5ad9df5edf0789410ff3bdbf3619aed51cd789a6af1e2"
+checksum = "6a5b15d63a5ff39e378daed0e1340d3a5964703ea9712eb09a0dc66fade996f4"
 dependencies = [
  "half",
  "libc",
@@ -3906,9 +3906,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -3923,18 +3923,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3942,9 +3942,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3954,13 +3954,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.117",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,13 +73,13 @@ ndarray = { version = "0.17", default-features = false }
 num-bigint = "0.4.6"
 num-derive = "0.4.2"
 num-traits = "0.2"
-numpy = "0.28"
+numpy = "0.29"
 object_store = { version = "0.13.1", default-features = false, features = ["fs"] }
 parking_lot = "0.12"
 percent-encoding = "2.3"
 pin-project-lite = "0.2"
 proptest = { version = "1.6", default-features = false, features = ["std"] }
-pyo3 = "0.28"
+pyo3 = "0.29"
 rand = "0.10"
 rand_distr = "0.6"
 raw-cpuid = "11"

--- a/crates/polars-python/src/interop/arrow/to_py.rs
+++ b/crates/polars-python/src/interop/arrow/to_py.rs
@@ -1,5 +1,3 @@
-use std::ffi::CString;
-
 use arrow::datatypes::ArrowDataType;
 use arrow::ffi;
 use arrow::record_batch::RecordBatch;
@@ -77,8 +75,7 @@ pub(crate) fn series_to_stream<'py>(
     ) as _;
 
     let stream = ffi::export_iterator(iter, field);
-    let stream_capsule_name = CString::new("arrow_array_stream").unwrap();
-    PyCapsule::new(py, stream, Some(stream_capsule_name))
+    PyCapsule::new_with_value(py, stream, c"arrow_array_stream")
 }
 
 pub(crate) fn dataframe_to_stream<'py>(
@@ -88,8 +85,7 @@ pub(crate) fn dataframe_to_stream<'py>(
     let iter = Box::new(DataFrameStreamIterator::new(df));
     let field = iter.field();
     let stream = ffi::export_iterator(iter, field);
-    let stream_capsule_name = CString::new("arrow_array_stream").unwrap();
-    PyCapsule::new(py, stream, Some(stream_capsule_name))
+    PyCapsule::new_with_value(py, stream, c"arrow_array_stream")
 }
 
 #[cfg(feature = "c_api")]
@@ -111,8 +107,7 @@ pub(crate) fn polars_schema_to_pycapsule<'py>(
         false,
     ));
 
-    let capsule_name = CString::new("arrow_schema").unwrap();
-    PyCapsule::new(py, schema, Some(capsule_name))
+    PyCapsule::new_with_value(py, schema, c"arrow_schema")
 }
 
 pub struct DataFrameStreamIterator {

--- a/crates/polars-python/src/interop/numpy/utils.rs
+++ b/crates/polars-python/src/interop/numpy/utils.rs
@@ -30,7 +30,7 @@ where
     // See: https://numpy.org/doc/stable/reference/c-api/array.html
     let array = PY_ARRAY_API.PyArray_NewFromDescr(
         py,
-        PY_ARRAY_API.get_type_object(py, npyffi::NpyTypes::PyArray_Type),
+        npyffi::get_type_object(py, npyffi::NpyTypes::PyArray_Type),
         dtype.into_dtype_ptr(),
         shape.ndim_cint(),
         shape.as_dims_ptr(),

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::ffi::CString;
 use std::num::NonZeroUsize;
 
 use arrow::ffi::export_iterator;
@@ -1632,8 +1631,7 @@ impl PyCollectBatches {
         let iter = Box::new(ArrowStreamIterator::new(self.inner.clone(), dtype.clone()));
         let field = ArrowField::new(PlSmallStr::EMPTY, dtype, false);
         let stream = export_iterator(iter, field);
-        let stream_capsule_name = CString::new("arrow_array_stream").unwrap();
-        PyCapsule::new(py, stream, Some(stream_capsule_name))
+        PyCapsule::new_with_value(py, stream, c"arrow_array_stream")
     }
 }
 

--- a/crates/polars-python/src/series/import.rs
+++ b/crates/polars-python/src/series/import.rs
@@ -64,8 +64,12 @@ pub(crate) fn import_array_pycapsules(
     // array_capsule holds a valid C ArrowArray pointer, as defined by the Arrow PyCapsule
     // Interface
     unsafe {
-        #[allow(deprecated)]
-        let array_ptr = std::ptr::replace(array_capsule.pointer() as _, ArrowArray::empty());
+        let array_ptr = std::ptr::replace(
+            array_capsule
+                .pointer_checked(Some(c"arrow_array"))?
+                .as_ptr() as _,
+            ArrowArray::empty(),
+        );
         let array = ffi::import_array_from_c(array_ptr, field.dtype().clone()).unwrap();
 
         Ok((field, array))
@@ -81,8 +85,10 @@ pub(crate) fn import_schema_pycapsule(
     // schema_capsule holds a valid C ArrowSchema pointer, as defined by the Arrow PyCapsule
     // Interface
     unsafe {
-        #[allow(deprecated)]
-        let schema_ptr = schema_capsule.reference::<ArrowSchema>();
+        let schema_ptr = schema_capsule
+            .pointer_checked(Some(c"arrow_schema"))?
+            .cast::<ArrowSchema>()
+            .as_ref();
         let field = ffi::import_field_from_c(schema_ptr).unwrap();
 
         Ok(field)
@@ -108,11 +114,10 @@ pub(crate) fn import_stream_pycapsule(capsule: &Bound<PyCapsule>) -> PyResult<Py
     // capsule holds a valid C ArrowArrayStream pointer, as defined by the Arrow PyCapsule
     // Interface
     let mut stream = unsafe {
-        // Takes ownership of the pointed to ArrowArrayStream
-        // This acts to move the data out of the capsule pointer, setting the release callback to NULL
-        #[allow(deprecated)]
         let stream_ptr = Box::new(std::ptr::replace(
-            capsule.pointer() as _,
+            capsule
+                .pointer_checked(Some(c"arrow_array_stream"))?
+                .as_ptr() as _,
             ArrowArrayStream::empty(),
         ));
         ArrowArrayStreamReader::try_new(stream_ptr)

--- a/crates/polars-python/src/series/import.rs
+++ b/crates/polars-python/src/series/import.rs
@@ -11,25 +11,6 @@ use pyo3::types::{PyCapsule, PyTuple, PyType};
 use super::PySeries;
 use crate::error::PyPolarsErr;
 
-/// Validate PyCapsule has provided name
-fn validate_pycapsule_name(capsule: &Bound<PyCapsule>, expected_name: &str) -> PyResult<()> {
-    let capsule_name = capsule.name()?;
-    if let Some(capsule_name) = capsule_name {
-        let capsule_name = unsafe { capsule_name.as_cstr() };
-        if capsule_name.to_str() != Ok(expected_name) {
-            return Err(PyValueError::new_err(format!(
-                "Expected name '{expected_name}' in PyCapsule, instead got '{capsule_name:?}'"
-            )));
-        }
-    } else {
-        return Err(PyValueError::new_err(
-            "Expected schema PyCapsule to have name set.",
-        ));
-    }
-
-    Ok(())
-}
-
 /// Import `__arrow_c_array__` across Python boundary
 pub(crate) fn call_arrow_c_array<'py>(
     ob: &Bound<'py, PyAny>,
@@ -58,8 +39,6 @@ pub(crate) fn import_array_pycapsules(
 ) -> PyResult<(arrow::datatypes::Field, Box<dyn Array>)> {
     let field = import_schema_pycapsule(schema_capsule)?;
 
-    validate_pycapsule_name(array_capsule, "arrow_array")?;
-
     // # Safety
     // array_capsule holds a valid C ArrowArray pointer, as defined by the Arrow PyCapsule
     // Interface
@@ -79,8 +58,6 @@ pub(crate) fn import_array_pycapsules(
 pub(crate) fn import_schema_pycapsule(
     schema_capsule: &Bound<PyCapsule>,
 ) -> PyResult<arrow::datatypes::Field> {
-    validate_pycapsule_name(schema_capsule, "arrow_schema")?;
-
     // # Safety
     // schema_capsule holds a valid C ArrowSchema pointer, as defined by the Arrow PyCapsule
     // Interface
@@ -108,8 +85,6 @@ fn call_arrow_c_stream<'py>(ob: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyCap
 }
 
 pub(crate) fn import_stream_pycapsule(capsule: &Bound<PyCapsule>) -> PyResult<PySeries> {
-    validate_pycapsule_name(capsule, "arrow_array_stream")?;
-
     // # Safety
     // capsule holds a valid C ArrowArrayStream pointer, as defined by the Arrow PyCapsule
     // Interface

--- a/crates/polars-python/src/series/numpy_ufunc.rs
+++ b/crates/polars-python/src/series/numpy_ufunc.rs
@@ -35,7 +35,7 @@ unsafe fn aligned_array<T: Element + NativeType>(
 
     let ptr = PY_ARRAY_API.PyArray_NewFromDescr(
         py,
-        PY_ARRAY_API.get_type_object(py, npyffi::NpyTypes::PyArray_Type),
+        npyffi::get_type_object(py, npyffi::NpyTypes::PyArray_Type),
         T::get_dtype(py).into_dtype_ptr(),
         dims.ndim_cint(),
         dims.as_dims_ptr(),
@@ -56,7 +56,7 @@ unsafe fn aligned_array<T: Element + NativeType>(
 ///   - For CPython: Get reference counter.
 ///   - For PyPy: Reference counters for a live PyPy object = refcnt + 2 << 60.
 fn get_refcnt<T>(pyarray: &Bound<'_, PyArray1<T>>) -> isize {
-    let refcnt = pyarray.get_refcnt();
+    let refcnt = unsafe { pyo3::ffi::Py_REFCNT(pyarray.as_ptr()) };
     #[cfg(target_pointer_width = "64")]
     if refcnt >= (2 << 60) {
         return refcnt - (2 << 60);

--- a/deny.toml
+++ b/deny.toml
@@ -19,14 +19,6 @@ ignore = [
 
   # error[unmaintained]: Bincode is unmaintained
   "RUSTSEC-2025-0141",
-
-  # error[vulnerability]: Out-of-bounds read in `nth` / `nth_back` for `PyList` and `PyTuple` iterators
-  # Fixed in pyo3 0.29.0, but upgrade is blocked until numpy and pyo3-polars
-  # publish releases compatible with pyo3 0.29 (numpy is at 0.28.0 / pyo3 0.28).
-  "RUSTSEC-2026-0176",
-  # error[vulnerability]: Missing `Sync` bound on `PyCFunction::new_closure` closures
-  # Same blocker as above; remove both once pyo3 is bumped to >=0.29.
-  "RUSTSEC-2026-0177",
 ]
 
 [licenses]


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/27966 and is a follow-up to https://github.com/pola-rs/polars/pull/27949 (removes the now unncessary ignores from `deny.toml`).

Had to deal with some minor breakage after bumping the versions.

🤖 Claude Opus 4.8 for helping deal with some of the breakage. 
