### PR TITLE
fix: broadcast CSE temporary columns to dataframe height

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/cse/csee.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/csee.rs
@@ -999,13 +999,15 @@ impl RewritingVisitor for CommonSubExprOptimizer {
                             ProjectionOptions {
                                 run_parallel: options.run_parallel,
                                 duplicate_check: options.duplicate_check,
-                                // These columns might have different
-                                // lengths from the dataframe, but
-                                // they are only temporaries that will
+                                // These columns are temporaries that will
                                 // be removed by the evaluation of the
                                 // default_exprs and the subsequent
-                                // projection.
-                                should_broadcast: false,
+                                // projection. We must broadcast them to
+                                // the dataframe height so that expressions
+                                // that produce 0-length columns (e.g.
+                                // coalesce with non-matching selectors)
+                                // work correctly.
+                                should_broadcast: true,
                             },
                         )
                         .build();
@@ -1042,16 +1044,18 @@ impl RewritingVisitor for CommonSubExprOptimizer {
                     let lp = IRBuilder::new(input, &mut arena.1, &mut arena.0)
                         .with_columns(
                             exprs.cse_exprs().to_vec(),
-                            // These columns might have different
-                            // lengths from the dataframe, but they
-                            // are only temporaries that will be
-                            // removed by the evaluation of the
+                            // These columns are temporaries that will
+                            // be removed by the evaluation of the
                             // default_exprs and the subsequent
-                            // projection.
+                            // projection. We must broadcast them to
+                            // the dataframe height so that expressions
+                            // that produce 0-length columns (e.g.
+                            // coalesce with non-matching selectors)
+                            // work correctly.
                             ProjectionOptions {
                                 run_parallel: options.run_parallel,
                                 duplicate_check: options.duplicate_check,
-                                should_broadcast: false,
+                                should_broadcast: true,
                             },
                         )
                         .with_columns(exprs.default_exprs().to_vec(), options)


### PR DESCRIPTION
## Description

When the common subexpression elimination (CSE) optimization creates temporary columns, it was setting `should_broadcast: false`. This caused expressions that produce 0-length columns (e.g. `coalesce` with non-matching regex selectors) to fail when used in the outer `with_columns`, producing a `ShapeError: unable to add a column of length 0 to a DataFrame of height 1`.

## Root Cause

The CSE optimization in `crates/polars-plan/src/plans/optimizer/cse/csee.rs` creates an inner `WITH_COLUMNS` node to compute the common sub-expression, then an outer `WITH_COLUMNS` to use the result. The inner node had `should_broadcast: false`, which meant the temporary column was not broadcast to the dataframe height. When the coalesce expression with a non-matching regex selector (e.g. `pl.coalesce("^C$", 0.0)` where column C does not exist) was evaluated without broadcasting, it produced a 0-length column. This 0-length column then failed when the outer `WITH_COLUMNS` tried to use it.

## Fix

Changed `should_broadcast: false` to `should_broadcast: true` for the CSE temporary columns in both the `Select` and `HStack` paths. This ensures the temporary columns are broadcast to the dataframe height before being used in subsequent operations.

## Testing

- Reproduced the issue with the minimal reproducer from the bug report
- Verified the fix resolves the issue
- The change is minimal and only affects the CSE optimization path

## AI Assistance Disclosure

1. I used AI to help analyze the root cause of the issue by tracing through the codebase and identifying the `should_broadcast: false` setting in the CSE optimizer.
2. I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.

Closes #27974