### PR TITLE
fix: Address join alias state leakage in SQL CTEs

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -849,8 +849,9 @@ impl SQLContext {
                 polars_bail!(SQLInterface: "recursive CTEs are not supported")
             }
             for cte in &with.cte_tables {
+                // Note: isolate CTE execution to prevent context state leakage
                 let cte_name = cte.alias.name.value.clone();
-                let mut lf = self.execute_query(&cte.query)?;
+                let mut lf = self.execute_isolated(|ctx| ctx.execute_query(&cte.query))?;
                 lf = self.rename_columns_from_table_alias(lf, &cte.alias)?;
                 self.register_cte(&cte_name, lf);
             }

--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -866,6 +866,26 @@ def test_miscellaneous_cte_join_aliasing() -> None:
     ]
 
 
+def test_cte_join_no_leak_ambiguity_27981() -> None:
+    # the join inside the CTE body must not leak alias state into the
+    # outer query; unqualified "key" should resolve to the CTE column
+    left = pl.DataFrame({"key": [1, 2], "value": ["a", "b"]})
+    right = pl.DataFrame({"key": [2, 3]})
+
+    query = """
+        WITH join_results AS (
+            SELECT left.key AS key, value
+            FROM left
+            FULL JOIN right ON left.key = right.key
+        )
+        SELECT {col} FROM join_results ORDER BY key
+    """
+    expected = {"key": [1, 2, None]}
+    for col in ("key", "join_results.key"):
+        res = pl.sql(query.format(col=col), eager=True)
+        assert res.to_dict(as_series=False) == expected
+
+
 def test_nested_joins_17381() -> None:
     df = pl.DataFrame({"id": ["one", "two"]})
 


### PR DESCRIPTION
Fixes #27981.

CTEs should use `execute_isolated`, not a bare `execute_query`, to prevent context/state leakage to the outer scope (which includes join aliases/lookup).

## Example
```python
import polars as pl

left = pl.DataFrame({"key": [1, 2], "value": ["a", "b"]})
right = pl.DataFrame({"key": [2, 3]})

query = """
  WITH joined AS (
    SELECT left.key AS key, value
    FROM left
    FULL JOIN right ON left.key = right.key
  )
  SELECT {col} FROM joined ORDER BY key
"""
for col in ("key", "joined.key"):
    res = pl.sql(query.format(col=col), eager=True)
    print(res)
```
**Before:**
```python
# SQLInterfaceError: 
#  ambiguous reference to column "key"
#   (use one of: joined."key", "right"."key")
```
**After:**
```python
# shape: (3, 1)
# ┌──────┐
# │ key  │
# │ ---  │
# │ i64  │
# ╞══════╡
# │ 1    │
# │ 2    │
# │ null │
# └──────┘
```