### PR TITLE
fix: Computed GROUP keys in SQL projections

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -2171,8 +2171,8 @@ impl SQLContext {
         let mut projection_aliases = PlHashSet::new();
         let mut group_key_aliases = PlHashSet::new();
 
-        // Pre-compute group key data (stripped expression + output name) to avoid repeated work.
-        // We check both expression AND output name match to avoid cross-aliasing issues.
+        // Pre-compute group key data (alias-stripped expression + aggregated output
+        // name) to avoid repeated work matching projections against the group keys
         let group_key_data: Vec<_> = group_by_keys
             .iter()
             .map(|gk| {
@@ -2183,18 +2183,20 @@ impl SQLContext {
             })
             .collect();
 
-        let projection_matches_group_key: Vec<bool> = projections
+        let projection_group_key: Vec<Option<PlSmallStr>> = projections
             .iter()
             .map(|p| {
                 let p_stripped = strip_outer_alias(p);
-                let p_name = p.to_field(&schema_before).ok().map(|f| f.name);
-                group_key_data
-                    .iter()
-                    .any(|(gk_stripped, gk_name)| *gk_stripped == p_stripped && *gk_name == p_name)
+                group_key_data.iter().find_map(|(gk_stripped, gk_name)| {
+                    (*gk_stripped == p_stripped)
+                        .then(|| gk_name.clone())
+                        .flatten()
+                })
             })
             .collect();
 
-        for (e, &matches_group_key) in projections.iter().zip(&projection_matches_group_key) {
+        for (e, group_key) in projections.iter().zip(&projection_group_key) {
+            let matches_group_key = group_key.is_some();
             // `Len` represents COUNT(*) so we treat as an aggregation here.
             let is_non_group_key_expr = !matches_group_key
                 && has_expr(e, |e| {
@@ -2256,9 +2258,9 @@ impl SQLContext {
                 // If aggregation colname conflicts with a group key,
                 // alias it to avoid duplicate/mis-tracked columns
                 if group_by_keys_schema.get(&field.name).is_some() {
-                    let alias_name = format!("__POLARS_AGG_{}", field.name);
-                    e = e.alias(alias_name.as_str());
-                    aliased_aggregations.insert(field.name.clone(), alias_name.as_str().into());
+                    let alias_name = format_pl_smallstr!("__POLARS_AGG_{}", field.name);
+                    e = e.alias(alias_name.clone());
+                    aliased_aggregations.insert(field.name.clone(), alias_name);
                 }
                 aggregation_projection.push(e);
             } else if !matches_group_key {
@@ -2332,14 +2334,20 @@ impl SQLContext {
         // (will also drop any temporary columns created for the HAVING post-filter).
         let final_projection = projection_schema
             .iter_names()
-            .zip(projections.iter().zip(&projection_matches_group_key))
-            .map(|(name, (projection_expr, &matches_group_key))| {
+            .zip(projections.iter().zip(&projection_group_key))
+            .map(|(name, (projection_expr, group_key))| {
                 if let Some(expr) = projection_overrides.get(name.as_str()) {
                     expr.clone()
                 } else if let Some(aliased_name) = aliased_aggregations.get(name) {
                     col(aliased_name.clone()).alias(name.clone())
-                } else if group_by_keys_schema.get(name).is_some() && matches_group_key {
-                    col(name.clone())
+                } else if let Some(key_name) = group_key {
+                    // projection is a group key; reference aggregated key col rather than
+                    // re-evaluating against aggregated frame (incorrect for computed keys)
+                    if key_name == name {
+                        col(name.clone())
+                    } else {
+                        col(key_name.clone()).alias(name.clone())
+                    }
                 } else if group_by_keys_schema.get(name).is_some()
                     || projection_aliases.contains(name.as_str())
                     || group_key_aliases.contains(name.as_str())
@@ -2365,10 +2373,10 @@ impl SQLContext {
                 output_projection.push(col(key_name.clone()));
             } else if group_by_keys.iter().any(|k| is_simple_col_ref(k, key_name)) {
                 // Original col name in output - check if cross-aliased
-                let is_cross_aliased = projections.iter().any(|p| {
-                    p.to_field(&schema_before).is_ok_and(|f| f.name == key_name)
-                        && !is_simple_col_ref(p, key_name)
-                });
+                let is_cross_aliased = projection_schema
+                    .iter_names()
+                    .zip(projections.iter())
+                    .any(|(name, p)| name == key_name && !is_simple_col_ref(p, key_name));
                 if is_cross_aliased {
                     // Add original name under a prefixed alias for subsequent ORDER BY resolution
                     let internal_name = format_pl_smallstr!("__POLARS_ORIG_{}", key_name);

--- a/py-polars/tests/unit/sql/asserts.py
+++ b/py-polars/tests/unit/sql/asserts.py
@@ -84,9 +84,9 @@ def assert_sql_matches(
     frames: pl.DataFrame | pl.LazyFrame | Mapping[str, pl.DataFrame | pl.LazyFrame],
     *,
     query: str,
-    compare_with: Literal["sqlite", "duckdb"]
-    | Collection[Literal["sqlite", "duckdb"]]
-    | None,
+    compare_with: (
+        Literal["sqlite", "duckdb"] | Collection[Literal["sqlite", "duckdb"]] | None
+    ),
     check_dtypes: bool = False,
     check_row_order: bool = True,
     check_column_names: bool = True,

--- a/py-polars/tests/unit/sql/test_group_by.py
+++ b/py-polars/tests/unit/sql/test_group_by.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import date
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -9,6 +10,9 @@ import polars as pl
 from polars.exceptions import SQLSyntaxError
 from polars.testing import assert_frame_equal
 from tests.unit.sql import assert_sql_matches
+
+if TYPE_CHECKING:
+    from typing import Literal
 
 
 @pytest.fixture
@@ -502,6 +506,7 @@ def test_group_by_struct_cat_24049(maintain_order: bool) -> None:
     b = {"k1": "b2", "k2": "b2"}
     c = {"k1": "c2", "k2": "c2"}
     s = pl.Struct({"k1": pl.Categorical, "k2": pl.Categorical})
+
     df = pl.DataFrame(
         {
             "x": [a, b, a, a, c, b],
@@ -554,15 +559,15 @@ def test_group_by_aggregate_name_is_group_key() -> None:
     "query",
     [
         # GROUP BY referencing SELECT alias for arithmetic expression
-        "SELECT COUNT(*) AS n, value / 10 AS bucket FROM self GROUP BY bucket ORDER BY bucket",
+        "SELECT COUNT(*) AS n, value / 10.0 AS bucket FROM self GROUP BY bucket ORDER BY bucket",
         # Multiple aliased expressions in GROUP BY
-        "SELECT COUNT(*) AS n, value / 10 AS tens, value % 3 AS rem FROM self GROUP BY tens, rem ORDER BY tens, rem",
+        "SELECT COUNT(*) AS n, value / 10.0 AS tens, value % 3 AS rem FROM self GROUP BY tens, rem ORDER BY tens, rem",
         # GROUP BY alias with additional aggregation
-        "SELECT SUM(id) AS total, value / 20 AS grp FROM self GROUP BY grp ORDER BY grp",
+        "SELECT SUM(id) AS total, value / 20.0 AS grp FROM self GROUP BY grp ORDER BY grp",
         # GROUP BY ordinal position with aliased column
         "SELECT value / 10 AS bucket, COUNT(*) AS n FROM self GROUP BY 1 ORDER BY 1",
         # GROUP BY ordinal with multiple aliased columns
-        "SELECT id % 2 AS parity, value / 10 AS tens, SUM(id) AS total FROM self GROUP BY 1, 2 ORDER BY 1, 2",
+        "SELECT id % 2 AS parity, value / 10.0 AS tens, SUM(id) AS total FROM self GROUP BY 1, 2 ORDER BY 1, 2",
     ],
 )
 def test_group_by_select_alias(query: str) -> None:
@@ -573,7 +578,28 @@ def test_group_by_select_alias(query: str) -> None:
             "value": [10, 20, 30, 40, 50],
         }
     )
-    assert_sql_matches(df, query=query, compare_with="duckdb")
+    assert_sql_matches(df, query=query, compare_with="sqlite")
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT (x >= 5) AS x_gt_5, COUNT(*) AS n FROM self GROUP BY (x >= 5) ORDER BY x_gt_5",
+        "SELECT (x * 10) AS x10, COUNT(*) AS n FROM self GROUP BY (x * 10) ORDER BY x10",
+        "SELECT (x = 5) AS x_eq_5, COUNT(*) AS n FROM self GROUP BY (x = 5) ORDER BY x_eq_5",
+        "SELECT (x >= 5) AS x_gt_5, COUNT(*) AS n FROM self GROUP BY ALL ORDER BY x_gt_5",
+    ],
+)
+def test_group_by_computed_key_repeated_27735(query: str) -> None:
+    comparison_backend: Literal["sqlite", "duckdb"] = (
+        "duckdb" if "GROUP BY ALL" in query else "sqlite"
+    )
+    df = pl.DataFrame({"x": [3, 5, 7]})
+    assert_sql_matches(
+        frames=df,
+        query=query,
+        compare_with=comparison_backend,
+    )
 
 
 def test_group_by_empty_or_scalar_key_exprs_23397() -> None:


### PR DESCRIPTION
Fixes #27735.

Ensures we carry projected/computed group key aliases through.