### PR TITLE
chore(python!): Remove `Expr.flatten` function

### DIFF
--- a/py-polars/docs/source/reference/expressions/modify_select.rst
+++ b/py-polars/docs/source/reference/expressions/modify_select.rst
@@ -23,7 +23,6 @@ Manipulation/selection
     Expr.fill_nan
     Expr.fill_null
     Expr.filter
-    Expr.flatten
     Expr.floor
     Expr.forward_fill
     Expr.gather

--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -5341,7 +5341,6 @@ Consider using {self}.implode() instead"""
             msg = f"strategy {strategy!r} is not supported"
             raise ValueError(msg)
 
-
     def explode(self, *, empty_as_null: bool = True, keep_nulls: bool = True) -> Expr:
         """
         Explode a list expression.

--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -5341,41 +5341,6 @@ Consider using {self}.implode() instead"""
             msg = f"strategy {strategy!r} is not supported"
             raise ValueError(msg)
 
-    @deprecated(
-        "`Expr.flatten()` is deprecated and will be removed in version 2.0. "
-        "Use `Expr.list.explode(keep_nulls=False, empty_as_null=False)` instead."
-    )
-    def flatten(self) -> Expr:
-        """
-        Flatten a list or string column.
-
-        Alias for :func:`Expr.list.explode`.
-
-        .. deprecated:: 1.38
-            `Expr.flatten()` is deprecated and will be removed in version 2.0.
-            Use `Expr.list.explode(keep_nulls=False, empty_as_null=False)` instead,
-            which provides the behavior you likely expect.
-
-        Examples
-        --------
-        >>> df = pl.DataFrame(
-        ...     {
-        ...         "group": ["a", "b", "b"],
-        ...         "values": [[1, 2], [2, 3], [4]],
-        ...     }
-        ... )
-        >>> df.group_by("group").agg(pl.col("values").flatten())  # doctest: +SKIP
-        shape: (2, 2)
-        ┌───────┬───────────┐
-        │ group ┆ values    │
-        │ ---   ┆ ---       │
-        │ str   ┆ list[i64] │
-        ╞═══════╪═══════════╡
-        │ a     ┆ [1, 2]    │
-        │ b     ┆ [2, 3, 4] │
-        └───────┴───────────┘
-        """
-        return self.explode(empty_as_null=True, keep_nulls=True)
 
     def explode(self, *, empty_as_null: bool = True, keep_nulls: bool = True) -> Expr:
         """


### PR DESCRIPTION
Removes `Expr.flatten()` which was deprecated in 1.38 in favor of `Expr.list.explode(keep_nulls=False, empty_as_null=False)`.

Closes #26402

:robot: This was generated with Claude Sonnet 4.6, but fully reviewed by me.

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
