### PR TITLE
chore!: Remove deprecated `Enum.union`

### DIFF
--- a/py-polars/src/polars/datatypes/classes.py
+++ b/py-polars/src/polars/datatypes/classes.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar, overload
 
 import polars._reexport as pl
 import polars.datatypes
-import polars.functions as F
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars._plr as plr

--- a/py-polars/src/polars/datatypes/classes.py
+++ b/py-polars/src/polars/datatypes/classes.py
@@ -1017,7 +1017,6 @@ class Enum(DataType):
         return f"{class_name}(categories={self.categories.to_list()!r})"
 
 
-
 class Object(ObjectType):
     """Data type for wrapping arbitrary Python objects."""
 

--- a/py-polars/src/polars/datatypes/classes.py
+++ b/py-polars/src/polars/datatypes/classes.py
@@ -1017,26 +1017,6 @@ class Enum(DataType):
         class_name = self.__class__.__name__
         return f"{class_name}(categories={self.categories.to_list()!r})"
 
-    def union(self, other: Enum) -> Enum:
-        """
-        Union of two Enums.
-
-        .. deprecated:: 1.38
-            `Enum.union()` is deprecated and will be removed in version 2.0.
-            Enums are ordered sets and union cannot preserve both orderings.
-        """
-        from polars._utils.deprecation import issue_deprecation_warning
-
-        issue_deprecation_warning(
-            "`Enum.union()` is deprecated and will be removed in version 2.0. "
-            "Enums are ordered sets and union cannot preserve both orderings.",
-            version="1.38",
-        )
-        return Enum(
-            F.concat((self.categories, other.categories)).unique(maintain_order=True)
-        )
-
-    __or__ = union
 
 
 class Object(ObjectType):

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -155,7 +155,6 @@ def test_nested_enum_creation() -> None:
     assert s.dtype == dtype
 
 
-
 def test_nested_enum_concat() -> None:
     dtype = pl.List(pl.Enum(["a", "b", "c", "d"]))
     s1 = pl.Series([[None, "a"], ["b", "c"]], dtype=dtype)

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -6,7 +6,6 @@ import io
 import operator
 import re
 import sys
-import warnings
 from datetime import date
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any
@@ -155,16 +154,6 @@ def test_nested_enum_creation() -> None:
     assert s.len() == 2
     assert s.dtype == dtype
 
-
-# Test can be removed after 2.0 release
-def test_enum_union() -> None:
-    e1 = pl.Enum(["a", "b"])
-    e2 = pl.Enum(["b", "c"])
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        assert e1 | e2 == pl.Enum(["a", "b", "c"])
-        assert e1.union(e2) == pl.Enum(["a", "b", "c"])
 
 
 def test_nested_enum_concat() -> None:


### PR DESCRIPTION
Removes `Enum.union()` and `Enum.__or__` which were deprecated in 1.38.

Closes #22001

:robot: Generated with Claude Sonnet 4.6 but fully reviewed by me.

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->


