### PR TITLE
chore: Stop coercing `pl.col(...)` to selector in selector `&`, `|`, and `^`

### DIFF
--- a/py-polars/src/polars/selectors.py
+++ b/py-polars/src/polars/selectors.py
@@ -471,9 +471,6 @@ class Selector(Expr):
     def __and__(self, other: Any) -> Expr: ...
 
     def __and__(self, other: Any) -> Selector | Expr:
-        if is_column(other):  # @2.0: remove
-            colname = other.meta.output_name()
-            other = by_name(colname)
         if is_selector(other):
             return Selector._from_pyselector(
                 PySelector.intersect(self._pyselector, other._pyselector)
@@ -491,8 +488,6 @@ class Selector(Expr):
     def __or__(self, other: Any) -> Expr: ...
 
     def __or__(self, other: Any) -> Selector | Expr:
-        if is_column(other):  # @2.0: remove
-            other = by_name(other.meta.output_name())
         if is_selector(other):
             return Selector._from_pyselector(
                 PySelector.union(self._pyselector, other._pyselector)
@@ -530,8 +525,6 @@ class Selector(Expr):
     def __xor__(self, other: Any) -> Expr: ...
 
     def __xor__(self, other: Any) -> Selector | Expr:
-        if is_column(other):  # @2.0: remove
-            other = by_name(other.meta.output_name())
         if is_selector(other):
             return Selector._from_pyselector(
                 PySelector.exclusive_or(self._pyselector, other._pyselector)
@@ -540,8 +533,6 @@ class Selector(Expr):
             return self.as_expr().__xor__(other)
 
     def __rxor__(self, other: Any) -> Expr:
-        if is_column(other):  # @2.0: remove
-            other = by_name(other.meta.output_name())
         return self.as_expr().__rxor__(other)
 
     def exclude(

--- a/py-polars/src/polars/selectors.py
+++ b/py-polars/src/polars/selectors.py
@@ -496,8 +496,6 @@ class Selector(Expr):
             return self.as_expr().__or__(other)
 
     def __ror__(self, other: Any) -> Expr:
-        if is_column(other):
-            other = by_name(other.meta.output_name())
         return self.as_expr().__ror__(other)
 
     @overload

--- a/py-polars/tests/unit/operations/test_selectors.py
+++ b/py-polars/tests/unit/operations/test_selectors.py
@@ -1150,3 +1150,18 @@ def test_multiline_colname_matches() -> None:
         cs.contains(prefix).alias("contains"),
     )
     assert res.columns == ["starts_with", "ends_with", "contains"]
+
+
+def test_bitwise_ops_eval_on_expr(df: pl.DataFrame) -> None:
+    with pytest.raises(
+        pl.exceptions.InvalidOperationError, match="& not allowed on time and u16"
+    ):
+        df.select(cs.all() & pl.col("abc"))
+    with pytest.raises(
+        pl.exceptions.InvalidOperationError, match=r"\| not allowed on time and u16"
+    ):
+        df.select(cs.all() | pl.col("abc"))
+    with pytest.raises(
+        pl.exceptions.InvalidOperationError, match=r"\^ not allowed on time and u16"
+    ):
+        df.select(cs.all() ^ pl.col("abc"))

--- a/py-polars/tests/unit/operations/test_selectors.py
+++ b/py-polars/tests/unit/operations/test_selectors.py
@@ -728,7 +728,7 @@ def test_selector_sets(df: pl.DataFrame) -> None:
     # exclusive or
     for selected in (
         df.select((cs.matches("e|g")) ^ cs.numeric()),
-        df.select((cs.contains("b", "g")) ^ pl.col("eee")),
+        df.select((cs.contains("b", "g")) ^ cs.by_name("eee")),
     ):
         assert selected.schema == OrderedDict(
             {

--- a/py-polars/tests/unit/operations/test_selectors.py
+++ b/py-polars/tests/unit/operations/test_selectors.py
@@ -50,7 +50,7 @@ def test_selector_all(df: pl.DataFrame) -> None:
     assert df.schema == df.select(cs.all()).schema
     assert df.select(~cs.all()).schema == {}
     assert df.schema == df.select(~(~cs.all())).schema
-    assert df.select(cs.all() & pl.col("abc")).schema == {"abc": pl.UInt16}
+    assert df.select(cs.all() & cs.by_name("abc")).schema == {"abc": pl.UInt16}
 
 
 def test_selector_alpha() -> None:
@@ -211,11 +211,7 @@ def test_selector_by_index(df: pl.DataFrame) -> None:
 
 
 def test_selector_by_name(df: pl.DataFrame) -> None:
-    for selector in (
-        cs.by_name("abc", "cde"),
-        cs.by_name("abc") | pl.col("cde"),
-    ):
-        assert df.select(selector).columns == ["abc", "cde"]
+    assert df.select(cs.by_name("abc", "cde")).columns == ["abc", "cde"]
 
     assert df.select(~cs.by_name("abc", "cde", "ghi", "Lmn", "opp", "eee")).columns == [
         "bbb",
@@ -234,13 +230,9 @@ def test_selector_by_name(df: pl.DataFrame) -> None:
     for missing_column in ("missing", "???"):
         assert df.select(cs.by_name(missing_column, require_all=False)).columns == []
 
-    # check "by_name & col"
-    for selector_expr, expected in (
-        (cs.by_name("abc", "cde") & pl.col("ghi"), []),
-        (cs.by_name("abc", "cde") & pl.col("cde"), ["cde"]),
-        (cs.by_name("cde") & cs.by_name("cde", "abc"), ["cde"]),
-    ):
-        assert df.select(selector_expr).columns == expected
+    # check "by_name & by_name"
+    assert df.select(cs.by_name("abc", "cde") & cs.by_name("cde")).columns == ["cde"]
+    assert df.select(cs.by_name("cde") & cs.by_name("cde", "abc")).columns == ["cde"]
 
     # check "by_name & by_name"
     assert df.select(
@@ -815,7 +807,7 @@ def test_regex_expansion_exclude_10002() -> None:
 def test_is_selector() -> None:
     # only actual/compound selectors should pass this check
     assert is_selector(cs.numeric())
-    assert is_selector(cs.by_dtype(pl.UInt32) | pl.col("xyz"))
+    assert is_selector(cs.by_dtype(pl.UInt32) | cs.by_name("xyz"))
 
     # expressions (and literals, etc) should fail
     assert not is_selector(pl.col("xyz"))


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/27988

:robot: The first commit was generated using Claude Sonnet 4.6
