### PR TITLE
feat(python!): Remove `memory_map` parameter from `scan_ipc`

### DIFF
--- a/py-polars/src/polars/io/ipc/functions.py
+++ b/py-polars/src/polars/io/ipc/functions.py
@@ -387,7 +387,6 @@ def scan_ipc(
     glob: bool = True,
     storage_options: StorageOptionsDict | None = None,
     credential_provider: CredentialProviderFunction | Literal["auto"] | None = "auto",
-    memory_map: bool = True,
     retries: int | None = None,
     file_cache_ttl: int | None = None,
     hive_partitioning: bool | None = None,
@@ -451,13 +450,6 @@ def scan_ipc(
             This functionality is considered **unstable**. It may be changed
             at any point without it being considered a breaking change.
 
-    memory_map
-        Try to memory map the file. This can greatly improve performance on repeated
-        queries as the OS may cache pages.
-        Only uncompressed IPC files can be memory mapped.
-
-        .. deprecated:: 1.40.0
-            Controlling memory map behavior is no longer supported.
     retries
         Number of retries if accessing a cloud instance fails.
 
@@ -487,9 +479,6 @@ def scan_ipc(
     include_file_paths
         Include the path of the source file(s) as a column with this name.
     """
-    # Memory Mapping is now a no-op
-    _ = memory_map
-
     sources = get_sources(source)
 
     if retries is not None:


### PR DESCRIPTION
The `memory_map` parameter in `scan_ipc` has been a no-op since 1.40.0 (deprecated in that release). This PR removes the argument.

Another option would be to only add a deprecation warning instead (https://github.com/pola-rs/polars/pull/27977).

Closes #18622

:robot: Commit and message were partially generated by Claude Sonnet 4.6, and fully reviewed by me.

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
