### PR TITLE
chore!: Do not support `list` type anymore for `Series.search_sorted()`

### DIFF
--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -2773,7 +2773,7 @@ class Expr:
         └──────┴───────┴─────┘
         """
         if isinstance(element, list):
-            msg = "passing a list to `search_sorted` is not supported; use `pl.Series([...])`"
+            msg = "passing a list to `search_sorted` is not ambiguous; use `pl.Series([...])` or `pl.lit(...)`"
             raise InvalidOperationError(msg)
         element_pyexpr = parse_into_expression(element, str_as_lit=True)
         return wrap_expr(self._pyexpr.search_sorted(element_pyexpr, side, descending))

--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -2773,7 +2773,7 @@ class Expr:
         └──────┴───────┴─────┘
         """
         if isinstance(element, list):
-            msg = "passing a list to `search_sorted` is not ambiguous; use `pl.Series([...])` or `pl.lit(...)`"
+            msg = "passing a list to `search_sorted` is ambiguous; use `pl.Series([...])` or `pl.lit(...)`"
             raise InvalidOperationError(msg)
         element_pyexpr = parse_into_expression(element, str_as_lit=True)
         return wrap_expr(self._pyexpr.search_sorted(element_pyexpr, side, descending))

--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -54,6 +54,7 @@ from polars.datatypes import (
 )
 from polars.exceptions import (
     CustomUFuncWarning,
+    InvalidOperationError,
     OutOfBoundsError,
 )
 from polars.expr.array import ExprArrayNameSpace
@@ -2771,9 +2772,10 @@ class Expr:
         │ 0    ┆ 2     ┆ 4   │
         └──────┴───────┴─────┘
         """
-        element_pyexpr = parse_into_expression(
-            element, str_as_lit=True, list_as_series=True
-        )
+        if isinstance(element, list):
+            msg = "passing a list to `search_sorted` is not supported; use `pl.Series([...])`"
+            raise InvalidOperationError(msg)
+        element_pyexpr = parse_into_expression(element, str_as_lit=True)
         return wrap_expr(self._pyexpr.search_sorted(element_pyexpr, side, descending))
 
     def sort_by(

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -33,6 +33,7 @@ from polars._dependencies import (
 from polars._dependencies import numpy as np
 from polars._dependencies import pandas as pd
 from polars._dependencies import pyarrow as pa
+from polars._plr import InvalidOperationError
 from polars._utils.construction import (
     arrow_to_pyseries,
     dataframe_to_pyseries,
@@ -4008,17 +4009,20 @@ class Series:
             3
             5
         ]
-        >>> s.search_sorted(pl.Series([1, 4, 5]), "right")
-        shape: (3,)
+        # To search for a list of values in a series, of lists, use pl.lit():
+        >>> list_s = pl.Series("lists", [[0, 1], [0, 2], [1, 4]])
+        s.search_sorted(pl.lit([0, 2]), "left")
+        shape: (1,)
         Series: 'set' [u32]
         [
             1
-            5
-            6
         ]
         """
         df = F.select(F.lit(self).search_sorted(element, side, descending=descending))
-        if isinstance(element, (Series, pl.Expr)):
+        if isinstance(element, list):
+            msg = "passing a list to `search_sorted` is not ambiguous; use `Series.search_sorted(pl.Series([...]), ...)` or `Series.search_sorted(pl.lit(...), ...)`"
+            raise InvalidOperationError(msg)
+        elif isinstance(element, (Series, pl.Expr)):
             return df.to_series()
         elif _check_for_numpy(element) and isinstance(element, np.ndarray):
             return df.to_series()

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -4009,11 +4009,11 @@ class Series:
             3
             5
         ]
-        # To search for a list of values in a series, of lists, use pl.lit():
+        >>> # To search for a list of values in a series, of lists, use pl.lit():
         >>> list_s = pl.Series("lists", [[0, 1], [0, 2], [1, 4]])
-        s.search_sorted(pl.lit([0, 2]), "left")
+        >>> list_s.search_sorted(pl.lit([0, 2]), "left")
         shape: (1,)
-        Series: 'set' [u32]
+        Series: 'lists' [u32]
         [
             1
         ]

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -33,7 +33,6 @@ from polars._dependencies import (
 from polars._dependencies import numpy as np
 from polars._dependencies import pandas as pd
 from polars._dependencies import pyarrow as pa
-from polars._plr import InvalidOperationError
 from polars._utils.construction import (
     arrow_to_pyseries,
     dataframe_to_pyseries,
@@ -97,7 +96,12 @@ from polars.datatypes import (
     supported_numpy_char_code,
 )
 from polars.datatypes._utils import dtype_to_init_repr
-from polars.exceptions import ComputeError, ModuleUpgradeRequiredError, ShapeError
+from polars.exceptions import (
+    ComputeError,
+    InvalidOperationError,
+    ModuleUpgradeRequiredError,
+    ShapeError,
+)
 from polars.interchange.protocol import CompatLevel
 from polars.series.array import ArrayNameSpace
 from polars.series.binary import BinaryNameSpace

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -4024,7 +4024,7 @@ class Series:
         """
         df = F.select(F.lit(self).search_sorted(element, side, descending=descending))
         if isinstance(element, list):
-            msg = "passing a list to `search_sorted` is not ambiguous; use `Series.search_sorted(pl.Series([...]), ...)` or `Series.search_sorted(pl.lit(...), ...)`"
+            msg = "passing a list to `search_sorted` is ambiguous; use `Series.search_sorted(pl.Series([...]), ...)` or `Series.search_sorted(pl.lit(...), ...)`"
             raise InvalidOperationError(msg)
         elif isinstance(element, (Series, pl.Expr)):
             return df.to_series()

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -3953,7 +3953,7 @@ class Series:
     @overload
     def search_sorted(
         self,
-        element: list_[Any] | np.ndarray[Any, Any] | Expr | Series,
+        element: np.ndarray[Any, Any] | Expr | Series,
         side: SearchSortedSide = ...,
         *,
         descending: bool = ...,
@@ -3992,7 +3992,7 @@ class Series:
         3
         >>> s.search_sorted(4, "right")
         5
-        >>> s.search_sorted([1, 4, 5])
+        >>> s.search_sorted(pl.Series([1, 4, 5]))
         shape: (3,)
         Series: 'set' [u32]
         [
@@ -4000,7 +4000,7 @@ class Series:
             3
             5
         ]
-        >>> s.search_sorted([1, 4, 5], "left")
+        >>> s.search_sorted(pl.Series([1, 4, 5]), "left")
         shape: (3,)
         Series: 'set' [u32]
         [
@@ -4008,7 +4008,7 @@ class Series:
             3
             5
         ]
-        >>> s.search_sorted([1, 4, 5], "right")
+        >>> s.search_sorted(pl.Series([1, 4, 5]), "right")
         shape: (3,)
         Series: 'set' [u32]
         [
@@ -4018,7 +4018,7 @@ class Series:
         ]
         """
         df = F.select(F.lit(self).search_sorted(element, side, descending=descending))
-        if isinstance(element, (list, Series, pl.Expr)):
+        if isinstance(element, (Series, pl.Expr)):
             return df.to_series()
         elif _check_for_numpy(element) and isinstance(element, np.ndarray):
             return df.to_series()

--- a/py-polars/tests/unit/operations/test_search_sorted.py
+++ b/py-polars/tests/unit/operations/test_search_sorted.py
@@ -96,6 +96,9 @@ def test_raise_literal_numeric_search_sorted_18096() -> None:
         df.with_columns(idx=pl.col("foo").search_sorted("bar"))
 
 
-def test_search_sorted_typing_26937() -> None:
-    targets: list[float] = [0.1, 0.3, 0.8]
-    indices = pl.Series().search_sorted(targets)
+def test_search_sorted_list_22058() -> None:
+    with pytest.raises(pl.exceptions.InvalidOperationError):
+        pl.Series([1, 2, 3]).search_sorted([1, 2])
+
+    with pytest.raises(pl.exceptions.InvalidOperationError):
+        pl.DataFrame({"a": [1, 2, 3]}).select(pl.col("a").search_sorted([1, 2]))

--- a/py-polars/tests/unit/operations/test_search_sorted.py
+++ b/py-polars/tests/unit/operations/test_search_sorted.py
@@ -96,7 +96,7 @@ def test_raise_literal_numeric_search_sorted_18096() -> None:
         df.with_columns(idx=pl.col("foo").search_sorted("bar"))
 
 
-def test_search_sorted_list_22058() -> None:
+def test_search_sorted_list_ambiguous_22058() -> None:
     with pytest.raises(pl.exceptions.InvalidOperationError):
         pl.Series([1, 2, 3]).search_sorted([1, 2])  # type: ignore[call-overload]
 

--- a/py-polars/tests/unit/operations/test_search_sorted.py
+++ b/py-polars/tests/unit/operations/test_search_sorted.py
@@ -98,7 +98,7 @@ def test_raise_literal_numeric_search_sorted_18096() -> None:
 
 def test_search_sorted_list_22058() -> None:
     with pytest.raises(pl.exceptions.InvalidOperationError):
-        pl.Series([1, 2, 3]).search_sorted([1, 2])
+        pl.Series([1, 2, 3]).search_sorted([1, 2])  # type: ignore[call-overload]
 
     with pytest.raises(pl.exceptions.InvalidOperationError):
         pl.DataFrame({"a": [1, 2, 3]}).select(pl.col("a").search_sorted([1, 2]))

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -2308,7 +2308,8 @@ def test_search_sorted(
     single_s = s.search_sorted(single)
     assert single_s == single_expected
 
-    multiple_s = s.search_sorted(multiple)
+    multiple_elements = pl.Series(multiple) if isinstance(multiple, list) else multiple
+    multiple_s = s.search_sorted(multiple_elements)
     assert_series_equal(
         multiple_s, pl.Series(multiple_expected, dtype=pl.get_index_type())
     )

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -2308,8 +2308,7 @@ def test_search_sorted(
     single_s = s.search_sorted(single)
     assert single_s == single_expected
 
-    multiple_elements = pl.Series(multiple) if isinstance(multiple, list) else multiple
-    multiple_s = s.search_sorted(multiple_elements)
+    multiple_s = s.search_sorted(pl.Series(multiple))
     assert_series_equal(
         multiple_s, pl.Series(multiple_expected, dtype=pl.get_index_type())
     )


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/22058

:robot: Initial changes were done by Claude Sonnet 4.6, but it was incomplete so I fixed a lot of it by hand.

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
