### PR TITLE
fix: Fix panic extracting datetime components from tz-aware columns with nulls

### DIFF
--- a/crates/polars-arrow/src/compute/temporal.rs
+++ b/crates/polars-arrow/src/compute/temporal.rs
@@ -293,49 +293,28 @@ fn extract_impl<T, A, F>(
 ) -> PrimitiveArray<A>
 where
     T: chrono::TimeZone,
-    A: NativeType,
+    A: NativeType + Default,
     F: Fn(chrono::DateTime<T>) -> A,
 {
-    match time_unit {
-        TimeUnit::Second => {
-            let op = |x| {
-                let datetime = timestamp_s_to_datetime(x);
-                let offset = timezone.offset_from_utc_datetime(&datetime);
-                extract(chrono::DateTime::<T>::from_naive_utc_and_offset(
-                    datetime, offset,
-                ))
-            };
-            unary(array, op, A::PRIMITIVE.into())
-        },
-        TimeUnit::Millisecond => {
-            let op = |x| {
-                let datetime = timestamp_ms_to_datetime(x);
-                let offset = timezone.offset_from_utc_datetime(&datetime);
-                extract(chrono::DateTime::<T>::from_naive_utc_and_offset(
-                    datetime, offset,
-                ))
-            };
-            unary(array, op, A::PRIMITIVE.into())
-        },
-        TimeUnit::Microsecond => {
-            let op = |x| {
-                let datetime = timestamp_us_to_datetime(x);
-                let offset = timezone.offset_from_utc_datetime(&datetime);
-                extract(chrono::DateTime::<T>::from_naive_utc_and_offset(
-                    datetime, offset,
-                ))
-            };
-            unary(array, op, A::PRIMITIVE.into())
-        },
-        TimeUnit::Nanosecond => {
-            let op = |x| {
-                let datetime = timestamp_ns_to_datetime(x);
-                let offset = timezone.offset_from_utc_datetime(&datetime);
-                extract(chrono::DateTime::<T>::from_naive_utc_and_offset(
-                    datetime, offset,
-                ))
-            };
-            unary(array, op, A::PRIMITIVE.into())
-        },
-    }
+    // Use the `_opt` timestamp conversion variants to avoid panicking on
+    // out-of-range values (e.g., i64::MIN from Pandas NaT). The validity
+    // bitmap already marks these slots as null, so the value is irrelevant.
+    let timestamp_to_datetime_opt: fn(i64) -> Option<chrono::NaiveDateTime> = match time_unit {
+        TimeUnit::Second => timestamp_s_to_datetime_opt,
+        TimeUnit::Millisecond => timestamp_ms_to_datetime_opt,
+        TimeUnit::Microsecond => timestamp_us_to_datetime_opt,
+        TimeUnit::Nanosecond => timestamp_ns_to_datetime_opt,
+    };
+
+    let op = |x| {
+        if let Some(datetime) = timestamp_to_datetime_opt(x) {
+            let offset = timezone.offset_from_utc_datetime(&datetime);
+            extract(chrono::DateTime::<T>::from_naive_utc_and_offset(
+                datetime, offset,
+            ))
+        } else {
+            A::default()
+        }
+    };
+    unary(array, op, A::PRIMITIVE.into())
 }

--- a/crates/polars-arrow/src/compute/temporal.rs
+++ b/crates/polars-arrow/src/compute/temporal.rs
@@ -293,12 +293,13 @@ fn extract_impl<T, A, F>(
 ) -> PrimitiveArray<A>
 where
     T: chrono::TimeZone,
-    A: NativeType + Default,
+    A: NativeType,
     F: Fn(chrono::DateTime<T>) -> A,
 {
-    // Use the `_opt` timestamp conversion variants to avoid panicking on
-    // out-of-range values (e.g., i64::MIN from Pandas NaT). The validity
-    // bitmap already marks these slots as null, so the value is irrelevant.
+    // Use the `_opt` timestamp conversion variants so out-of-range values (e.g.
+    // `i64::MIN` from a Pandas `NaT`) become null instead of panicking. We map
+    // over the validity-aware iterator rather than `unary`, so a value that is
+    // present but unrepresentable produces a null rather than a garbage default.
     let timestamp_to_datetime_opt: fn(i64) -> Option<chrono::NaiveDateTime> = match time_unit {
         TimeUnit::Second => timestamp_s_to_datetime_opt,
         TimeUnit::Millisecond => timestamp_ms_to_datetime_opt,
@@ -306,15 +307,15 @@ where
         TimeUnit::Nanosecond => timestamp_ns_to_datetime_opt,
     };
 
-    let op = |x| {
-        if let Some(datetime) = timestamp_to_datetime_opt(x) {
-            let offset = timezone.offset_from_utc_datetime(&datetime);
-            extract(chrono::DateTime::<T>::from_naive_utc_and_offset(
-                datetime, offset,
-            ))
-        } else {
-            A::default()
-        }
-    };
-    unary(array, op, A::PRIMITIVE.into())
+    let iter = array.iter().map(|opt| {
+        opt.and_then(|&x| {
+            timestamp_to_datetime_opt(x).map(|datetime| {
+                let offset = timezone.offset_from_utc_datetime(&datetime);
+                extract(chrono::DateTime::<T>::from_naive_utc_and_offset(
+                    datetime, offset,
+                ))
+            })
+        })
+    });
+    PrimitiveArray::from_trusted_len_iter(iter)
 }

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -1559,3 +1559,18 @@ def test_out_of_range_date_year_11991() -> None:
     # is_leap_year should also return null for out-of-range dates
     result_leap = s.dt.is_leap_year()
     assert result_leap[0] is None
+
+
+@pytest.mark.parametrize(
+    "method", ["day", "month", "year", "hour", "minute", "second", "weekday"]
+)
+def test_dt_extract_with_null_tz_aware_27862(method: str) -> None:
+    # A null in a timezone-aware column is physically i64::MIN; component
+    # extraction must not panic on it and must propagate the null.
+    s = pl.Series(
+        [datetime(2025, 6, 1), None],
+        dtype=pl.Datetime("us", "UTC"),
+    )
+    out = getattr(s.dt, method)()
+    assert out[1] is None
+    assert out[0] is not None


### PR DESCRIPTION
Fixes #27862

`dt.day()` and the other datetime component extractions panicked on a timezone-aware column containing nulls:

```
panicked at crates/polars-arrow/src/temporal_conversions.rs:175:
invalid or out-of-range datetime
```

A null timestamp is physically `i64::MIN` (e.g. from a pandas `NaT`), and the timezone-aware extraction path applied the conversion to every value — including null slots — through the panicking `timestamp_*_to_datetime` helpers.

This switches the extraction to the `_opt` conversion variants, which return `None` for out-of-range values. The validity bitmap already marks those slots as null, so the placeholder value is never observed. The timezone-naive path was already correct as it iterates over the validity.