### PR TITLE
fix(python): Fix rows_by_key when all columns are used as keys

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -11985,7 +11985,11 @@ class DataFrame:
             data_cols = [k for k in self.schema if k not in key]
             values = self.select(data_cols)
 
-        zipped = zip(keys, values.iter_rows(named=named), strict=True)  # type: ignore[call-overload]
+        if values.width == 0:
+            empty_row: Any = {} if named else ()
+            zipped = ((k, empty_row) for k in keys)
+        else:
+            zipped = zip(keys, values.iter_rows(named=named), strict=True)  # type: ignore[call-overload]
 
         # if unique, we expect to write just one entry per key; otherwise, we're
         # returning a list of rows for each key, so append into a defaultdict.

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -11985,6 +11985,7 @@ class DataFrame:
             data_cols = [k for k in self.schema if k not in key]
             values = self.select(data_cols)
 
+        zipped: Iterable[tuple[Any, Any]]
         if values.width == 0:
             empty_row: Any = {} if named else ()
             zipped = ((k, empty_row) for k in keys)

--- a/py-polars/tests/unit/dataframe/test_rows.py
+++ b/py-polars/tests/unit/dataframe/test_rows.py
@@ -164,6 +164,33 @@ def test_rows_by_key() -> None:
     }
 
 
+def test_rows_by_key_all_columns_27925() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+
+    # All columns used as keys leaves no value columns; the grouped rows are
+    # empty tuples/dicts rather than raising a length-mismatch error.
+    assert df.rows_by_key(["a", "b"]) == {
+        (1, 4): [()],
+        (2, 5): [()],
+        (3, 6): [()],
+    }
+    assert df.rows_by_key(["a", "b"], unique=True) == {
+        (1, 4): (),
+        (2, 5): (),
+        (3, 6): (),
+    }
+    assert df.rows_by_key(["a", "b"], named=True) == {
+        (1, 4): [{}],
+        (2, 5): [{}],
+        (3, 6): [{}],
+    }
+    assert df.rows_by_key(["a", "b"], include_key=True) == {
+        (1, 4): [(1, 4)],
+        (2, 5): [(2, 5)],
+        (3, 6): [(3, 6)],
+    }
+
+
 def test_iter_rows() -> None:
     df = pl.DataFrame(
         {

--- a/py-polars/tests/unit/dataframe/test_rows.py
+++ b/py-polars/tests/unit/dataframe/test_rows.py
@@ -190,6 +190,19 @@ def test_rows_by_key_all_columns_27925() -> None:
         (3, 6): [(3, 6)],
     }
 
+    # Non-unique keys must preserve multiplicity: one (empty) row per occurrence.
+    dup = pl.DataFrame({"a": [1, 2, 3, 1, 2, 3], "b": [4, 5, 6, 4, 5, 6]})
+    assert dup.rows_by_key(["a", "b"]) == {
+        (1, 4): [(), ()],
+        (2, 5): [(), ()],
+        (3, 6): [(), ()],
+    }
+    assert dup.rows_by_key(["a", "b"], named=True) == {
+        (1, 4): [{}, {}],
+        (2, 5): [{}, {}],
+        (3, 6): [{}, {}],
+    }
+
 
 def test_iter_rows() -> None:
     df = pl.DataFrame(


### PR DESCRIPTION
Fixes #27925

`DataFrame.rows_by_key` raised when every column was passed as a key and `include_key=False`:

```
ValueError: zip() argument 2 is shorter than argument 1
```

With no value columns remaining, `select([])` returns a frame with zero rows, so the `strict=True` zip against the keys iterator failed.

This handles the empty-values case directly, yielding an empty tuple (or dict, when `named=True`) per key. The other variants (`unique`, `include_key`) are unaffected.