### PR TITLE
fix: Ensure optimisations aren't omitted by cached IR nodes

### DIFF
--- a/crates/polars-lazy/src/frame/cached_arenas.rs
+++ b/crates/polars-lazy/src/frame/cached_arenas.rs
@@ -32,6 +32,7 @@ impl LazyFrame {
             node: Some(node),
             dsl: Arc::new(self.logical_plan.clone()),
             version: lp_arena.version(),
+            opt_flags: Some(OptFlags::schema_only()),
         };
         Ok(schema)
     }
@@ -62,6 +63,7 @@ impl LazyFrame {
                     node: Some(node),
                     dsl: Arc::new(self.logical_plan.clone()),
                     version: lp_arena.version(),
+                    opt_flags: Some(OptFlags::schema_only()),
                 };
                 *cached_arenas = Some(CachedArena {
                     lp_arena,
@@ -100,6 +102,7 @@ impl LazyFrame {
                             node: Some(node),
                             dsl: Arc::new(self.logical_plan.clone()),
                             version: arenas.lp_arena.version(),
+                            opt_flags: Some(OptFlags::schema_only()),
                         };
                         Ok(schema)
                     },

--- a/crates/polars-plan/src/dsl/plan.rs
+++ b/crates/polars-plan/src/dsl/plan.rs
@@ -183,6 +183,8 @@ pub enum DslPlan {
         version: u32,
         #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(skip))]
         node: Option<Node>,
+        #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(skip))]
+        opt_flags: Option<crate::frame::OptFlags>,
     },
 }
 
@@ -220,7 +222,7 @@ impl Clone for DslPlan {
             Self::Pivot { input, on, on_columns, index, values, agg, separator, maintain_order, column_naming }  => Self::Pivot { input: input.clone(), on: on.clone(), on_columns: on_columns.clone(), index: index.clone(), values: values.clone(), agg: agg.clone(), separator: separator.clone(), maintain_order: *maintain_order, column_naming: *column_naming },
             #[cfg(feature = "merge_sorted")]
             Self::MergeSorted { input_left, input_right, key, maintain_order } => Self::MergeSorted { input_left: input_left.clone(), input_right: input_right.clone(), key: key.clone(), maintain_order: *maintain_order },
-            Self::IR {node, dsl, version} => Self::IR {node: *node, dsl: dsl.clone(), version: *version},
+            Self::IR {node, dsl, version, opt_flags} => Self::IR {node: *node, dsl: dsl.clone(), version: *version, opt_flags: *opt_flags},
         }
     }
 }

--- a/crates/polars-plan/src/dsl/serializable_plan.rs
+++ b/crates/polars-plan/src/dsl/serializable_plan.rs
@@ -386,6 +386,7 @@ fn convert_dsl_plan_to_serializable_plan(
             dsl,
             version: _,
             node: _,
+            opt_flags: _,
         } => convert_dsl_plan_to_serializable_plan(dsl.as_ref(), arenas),
     }
 }

--- a/crates/polars-plan/src/frame/opt_state.rs
+++ b/crates/polars-plan/src/frame/opt_state.rs
@@ -43,16 +43,26 @@ bitflags! {
 }
 
 impl OptFlags {
-    pub fn schema_only() -> Self {
-        Self::TYPE_COERCION | Self::TYPE_CHECK
+    pub fn cluster_with_columns(&self) -> bool {
+        self.contains(OptFlags::CLUSTER_WITH_COLUMNS)
+    }
+
+    pub fn cover_ir_conversion(&self, requested: OptFlags) -> bool {
+        let mask =  // flags that can impact DSL->IR conversion
+            Self::PREDICATE_PUSHDOWN | Self::SIMPLIFY_EXPR | Self::TYPE_COERCION | Self::TYPE_CHECK;
+        (*self & mask).contains(requested & mask)
     }
 
     pub fn eager(&self) -> bool {
         self.contains(OptFlags::EAGER)
     }
 
-    pub fn cluster_with_columns(&self) -> bool {
-        self.contains(OptFlags::CLUSTER_WITH_COLUMNS)
+    pub fn fast_projection(&self) -> bool {
+        self.contains(OptFlags::FAST_PROJECTION)
+    }
+
+    pub fn gpu(&self) -> bool {
+        self.contains(OptFlags::GPU)
     }
 
     pub fn predicate_pushdown(&self) -> bool {
@@ -62,20 +72,21 @@ impl OptFlags {
     pub fn projection_pushdown(&self) -> bool {
         self.contains(OptFlags::PROJECTION_PUSHDOWN)
     }
+
+    pub fn schema_only() -> Self {
+        Self::TYPE_COERCION | Self::TYPE_CHECK
+    }
+
     pub fn simplify_expr(&self) -> bool {
         self.contains(OptFlags::SIMPLIFY_EXPR)
     }
+
     pub fn slice_pushdown(&self) -> bool {
         self.contains(OptFlags::SLICE_PUSHDOWN)
     }
+
     pub fn streaming(&self) -> bool {
         self.contains(OptFlags::STREAMING)
-    }
-    pub fn fast_projection(&self) -> bool {
-        self.contains(OptFlags::FAST_PROJECTION)
-    }
-    pub fn gpu(&self) -> bool {
-        self.contains(OptFlags::GPU)
     }
 }
 

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -46,7 +46,7 @@ pub fn to_alp(
     lp: DslPlan,
     expr_arena: &mut Arena<AExpr>,
     lp_arena: &mut Arena<IR>,
-    // Only `SIMPLIFY_EXPR`, `TYPE_COERCION`, `TYPE_CHECK` are respected.
+    // Only `SIMPLIFY_EXPR`, `TYPE_COERCION`, `TYPE_CHECK`, and `PREDICATE_PUSHDOWN` are respected.
     opt_flags: &mut OptFlags,
 ) -> PolarsResult<Node> {
     let conversion_optimizer = ConversionOptimizer::new(
@@ -841,6 +841,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                     dsl: Arc::new(plan.clone()),
                     version: ctxt.lp_arena.version(),
                     node: Some(ir),
+                    opt_flags: Some(*ctxt.opt_flags),
                 };
                 inputs.push(dsl);
                 input_schemas.push(schema);
@@ -1590,10 +1591,18 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 maintain_order,
             }
         },
-        DslPlan::IR { node, dsl, version } => {
+        DslPlan::IR {
+            node,
+            dsl,
+            version,
+            opt_flags,
+        } => {
+            let ir_built_with_required_flags =
+                opt_flags.is_some_and(|flags| flags.cover_ir_conversion(*ctxt.opt_flags));
             return match node {
                 Some(node)
-                    if version == ctxt.lp_arena.version()
+                    if ir_built_with_required_flags  // can reuse
+                        && version == ctxt.lp_arena.version()
                         && ctxt.conversion_optimizer.used_arenas.insert(version) =>
                 {
                     Ok(node)

--- a/py-polars/tests/unit/lazyframe/test_predicates.py
+++ b/py-polars/tests/unit/lazyframe/test_predicates.py
@@ -1549,3 +1549,26 @@ def test_filter_contradiction_fallible_error_handling(
     plmonkeypatch.setenv("POLARS_PUSHDOWN_OPT_MAINTAIN_ERRORS", "1")
     with pytest.raises(InvalidOperationError):
         lf.collect()
+
+
+def test_predicate_pushdown_after_collect_schema_26882() -> None:
+    # Resolving schema mid-build caches DSL->IR conversion with schema-only `opt_flags`
+    # (eg: no predicate pushdown); subsequent `collect` should NOT skip optimisations
+    left = pl.LazyFrame({"id": [1, 2, 3, 4], "status": ["A", "B", "A", "A"]})
+    right = pl.LazyFrame({"id": [1, 2, 3, 4], "category": [1, 2, 1, 2]})
+
+    def _build() -> pl.LazyFrame:
+        return left.join(right, on="id", how="inner").filter(
+            (pl.col("status") == "A") & (pl.col("category") == 1)
+        )
+
+    expected_plan = _build().explain()
+
+    cached = _build()
+    cached.collect_schema()
+    assert cached.explain() == expected_plan
+
+    # both filters pushed *below* the join
+    join_idx = expected_plan.index("INNER JOIN")
+    assert "FILTER" not in expected_plan[:join_idx]
+    assert_frame_equal(cached.collect(), _build().collect(), check_row_order=False)


### PR DESCRIPTION
Fixes #26882 root-cause (turns out it's not a SQL-specific issue).

Each cached `DslPlan::IR` now records the `OptFlags` it was built under, and the cached node is only returned when its flags cover those needed by the conversion.

Otherwise optimisations could be skipped by (for example) calling `collect_schema()`; that creates a node with `OptFlags::schema_only()` which then gets cached and reused _without_ any other optimisation flags being applied. 

Checks `SIMPLIFY_EXPR`, `TYPE_COERCION`, `TYPE_CHECK`, and `PREDICATE_PUSHDOWN`.

## Example

```python
import polars as pl

df1 = pl.LazyFrame({
    "id": [1, 2, 3, 4],
    "status": ["A", "B", "A", "A"],
})
df2 = pl.LazyFrame({
    "id": [1, 2, 3, 4],
    "category": [1, 2, 1, 2],
})
```
Join, collect the schema, observe the query plan:
```python
res = df1.join(df2, on="id", how="inner").filter(
    (pl.col("status") == "A") & (pl.col("category") == 1)
)
res.collect_schema()
print(res.explain())
```

**Before:**
_(not optimised - predicates applied after the join)_
```python
# FILTER [([(col("status")) == ("A")]) & ([(col("category")) == (1)])]
# FROM
#   INNER JOIN:
#   LEFT PLAN ON: [col("id")]
#     DF ["id", "status"]; PROJECT */2 COLUMNS
#   RIGHT PLAN ON: [col("id")]
#     DF ["id", "category"]; PROJECT */2 COLUMNS
#   END INNER JOIN
```

**After:**
_(optimised - predicates pushed into the join)_
```python
# INNER JOIN:
# LEFT PLAN ON: [col("id")]
#   FILTER [(col("status")) == ("A")]
#   FROM
#     DF ["id", "status"]; PROJECT */2 COLUMNS
# RIGHT PLAN ON: [col("id")]
#   FILTER [(col("category")) == (1)]
#   FROM
#     DF ["id", "category"]; PROJECT */2 COLUMNS
# END INNER JOIN
```