### PR TITLE
fix: Fix casting String to List(Enum) producing nulls

### DIFF
--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -328,6 +328,15 @@ impl ChunkCast for StringChunked {
                     Series::try_from((self.name().clone(), result))
                 },
             },
+            DataType::List(_) => {
+                let list_of_string = cast_impl(
+                    self.name().clone(),
+                    &self.chunks,
+                    &DataType::List(Box::new(DataType::String)),
+                    options,
+                )?;
+                list_of_string.cast_with_options(dtype, options)
+            },
             _ => cast_impl(self.name().clone(), &self.chunks, dtype, options),
         }
     }

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -654,6 +654,18 @@ def test_invalid_inner_type_cast_list() -> None:
         s.cast(pl.List(pl.Categorical))
 
 
+def test_cast_string_to_list_enum_27336() -> None:
+    enum = pl.Enum(["cat1", "cat2"])
+    s = pl.Series(["cat1", "cat2", "cat1"])
+
+    out = s.cast(pl.List(enum))
+    assert out.dtype == pl.List(enum)
+    assert out.to_list() == [["cat1"], ["cat2"], ["cat1"]]
+
+    # Plain string -> List(String) wrapping is unaffected.
+    assert s.cast(pl.List(pl.String)).to_list() == [["cat1"], ["cat2"], ["cat1"]]
+
+
 @pytest.mark.parametrize(
     ("values", "result"),
     [


### PR DESCRIPTION
Fixes #27336

Casting a `String` Series to `List(Enum)` produced nulls instead of the values:

```python
>>> pl.Series(["cat1"]).cast(pl.List(pl.Enum(["cat1", "cat2"])))
[[None]]  # expected [["cat1"]]
```

`StringChunked::cast_with_options` had no `List(_)` arm, so the target fell through to the physical cast, which turned `List(Enum)` into `List(UInt32)` and then tried to parse the strings as integers.

This adds a `List(_)` arm that first wraps each value into a one-element `List(String)` and then casts the inner type through the regular cast path, so the Enum mapping is applied correctly. `List(String) -> List(Enum)` already worked and is unchanged.