### PR TITLE
fix: Fix projection pushdown dropping a column with an identity with_columns

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -696,11 +696,24 @@ impl ProjectionPushdownVisitor<'_, '_> {
                     let output_schema = Arc::make_mut(output_schema_arc);
                     let mut orig_schema = mem::take(output_schema);
 
+                    // Input columns keep their original position (whether passed
+                    // through or overwritten by an expression); this matches how
+                    // the executor places results and avoids corrupting the layout.
+                    for name in input_schema.iter_names() {
+                        if input_names_projection.contains(name) || expr_output_names.contains(name)
+                        {
+                            output_schema
+                                .extend(orig_schema.remove(name).map(|dtype| (name.clone(), dtype)));
+                        }
+                    }
+
+                    // Requested columns not present in the input schema.
                     for name in input_names_projection.iter() {
                         output_schema
                             .extend(orig_schema.remove(name).map(|dtype| (name.clone(), dtype)));
                     }
 
+                    // Brand-new expression outputs, appended in expression order.
                     for name in expr_output_names.iter() {
                         output_schema
                             .extend(orig_schema.remove(name).map(|dtype| (name.clone(), dtype)));

--- a/py-polars/tests/unit/lazyframe/test_optimizations.py
+++ b/py-polars/tests/unit/lazyframe/test_optimizations.py
@@ -1034,3 +1034,16 @@ def test_lazyframe_gather_select_len() -> None:
 
     with pytest.raises(pl.exceptions.OutOfBoundsError):
         q.collect()
+
+
+def test_projection_pushdown_identity_with_columns_27935() -> None:
+    # An identity with_columns (b=col("b")) plus a pruned expression must not
+    # reorder the remaining columns, which previously caused "a" to be dropped.
+    out = (
+        pl.LazyFrame({"a": [0], "b": [0]})
+        .with_columns(b=pl.col("b"), x=pl.lit(1.0))
+        .group_by("b")
+        .agg(pl.col("a"))
+        .collect()
+    )
+    assert_frame_equal(out, pl.DataFrame({"b": [0], "a": [[0]]}))


### PR DESCRIPTION
Fixes #27935

```python
>>> pl.DataFrame({"a": [0], "b": [0]}).lazy().with_columns(
...     b=pl.col("b"), x=pl.lit(1.0)
... ).group_by("b").agg(pl.col("a")).collect()
ColumnNotFoundError: "a" not found
```

When projection pushdown pruned an unused expression from a `with_columns`, it rebuilt the output schema using the projection's insertion order rather than the input schema order. With an identity expression (`b=col("b")`) this placed `b` before `a`, so the executor wrote the expression result into the wrong column slot and `a` was lost.

This rebuilds the schema following the input schema order, keeping input columns in their original positions and appending only brand-new expression outputs.