### PR TITLE
fix: Fix sink_parquet dropping a filter applied after a cross join

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -1417,6 +1417,17 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 })
             }
 
+            // Sinks always execute on the streaming engine (the in-memory
+            // engine dispatches file sinks to it), so the sink's input must be
+            // optimized as streaming. Otherwise streaming-incompatible rewrites
+            // such as fusing a filter into a cross join (`CrossAndFilter`) are
+            // produced and then silently dropped by the streaming lowering.
+            //
+            // The flag persists past this conversion (as in `resolve_join`,
+            // which sets `OptFlags::PREDICATE_PUSHDOWN`): predicate pushdown --
+            // the pass that performs the fusion -- reads `opt_flags.streaming()`
+            // only after the whole plan has been lowered to IR.
+            ctxt.opt_flags.insert(OptFlags::STREAMING);
             let input =
                 to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_here!(sink)))?;
             let input_schema = ctxt.lp_arena.get(input).schema(ctxt.lp_arena);

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -1042,6 +1042,16 @@ pub fn lower_ir(
             let mut tmp_right_col_names: Vec<Option<PlSmallStr>> = Vec::new();
             let args = options.args.clone();
             let options = options.options.clone();
+            // A cross join with a fused filter (`CrossAndFilter`) is an in-memory
+            // -only rewrite; predicate pushdown must not produce it for the
+            // streaming engine. Assert that invariant rather than silently
+            // dropping the filter.
+            assert!(
+                !(args.how.is_cross()
+                    && matches!(options, Some(JoinTypeOptionsIR::CrossAndFilter { .. }))),
+                "CrossAndFilter reached streaming cross-join lowering; predicate \
+                 pushdown should not produce it when targeting the streaming engine"
+            );
             #[cfg(feature = "asof_join")]
             let asof_options = || match args.how {
                 JoinType::AsOf(ref asof_options) => asof_options,

--- a/py-polars/tests/unit/io/test_sink.py
+++ b/py-polars/tests/unit/io/test_sink.py
@@ -471,3 +471,17 @@ def test_sinked_paths_callback(tmp_path: Path) -> None:
             ),
             _sinked_paths_callback=lambda _: None,
         )
+
+
+@pytest.mark.write_disk
+def test_sink_parquet_cross_join_filter_27922(tmp_path: Path) -> None:
+    lf = pl.LazyFrame({"a": [[1, 2], [3, 4]]}).join(
+        pl.LazyFrame({"b": [1, 5]}), how="cross"
+    )
+    q = lf.filter(pl.col("a").list.contains(pl.col("b")))
+
+    path = tmp_path / "out.parquet"
+    q.sink_parquet(path)
+
+    # The cross-join filter must be applied by the sink, matching collect().
+    assert_frame_equal(pl.read_parquet(path), q.collect())


### PR DESCRIPTION
Fixes #27922

A `filter` using `list.contains(pl.col(...))` applied after a cross join was silently dropped by `sink_parquet`, writing every row. The same query is correct with `collect()`.

Predicate pushdown folds such cross-join predicates into `JoinTypeOptionsIR::CrossAndFilter`, which the in-memory engine applies during the join. The streaming engine (used by `sink_parquet`) ignored that option when lowering the cross join, so the predicate was lost.

This applies the `CrossAndFilter` predicate as a filter after the cross join in the streaming lowering.