### PR TITLE
docs(python): Document non-boolean input for any_horizontal/all_horizontal

### DIFF
--- a/py-polars/src/polars/functions/aggregation/horizontal.py
+++ b/py-polars/src/polars/functions/aggregation/horizontal.py
@@ -34,7 +34,9 @@ def all_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     vertical :meth:`Expr.all` aggregation, which requires boolean input.
 
     `Kleene logic`_ is used to deal with nulls: if the column contains any null values
-    and no `False` values, the output is null.
+    and no `False` values, the output is null. This null handling also differs from
+    the vertical :meth:`Expr.all`, which ignores nulls by default
+    (``ignore_nulls=True``).
 
     .. _Kleene logic: https://en.wikipedia.org/wiki/Three-valued_logic
 
@@ -83,7 +85,9 @@ def any_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     vertical :meth:`Expr.any` aggregation, which requires boolean input.
 
     `Kleene logic`_ is used to deal with nulls: if the column contains any null values
-    and no `True` values, the output is null.
+    and no `True` values, the output is null. This null handling also differs from
+    the vertical :meth:`Expr.any`, which ignores nulls by default
+    (``ignore_nulls=True``).
 
     .. _Kleene logic: https://en.wikipedia.org/wiki/Three-valued_logic
 

--- a/py-polars/src/polars/functions/aggregation/horizontal.py
+++ b/py-polars/src/polars/functions/aggregation/horizontal.py
@@ -38,6 +38,11 @@ def all_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     the vertical :meth:`Expr.all`, which ignores nulls by default
     (``ignore_nulls=True``).
 
+    .. warning::
+        From Polars 2.0, the null handling will change to match the vertical
+        :meth:`Expr.all` (nulls ignored by default). See
+        https://github.com/pola-rs/polars/issues/17827.
+
     .. _Kleene logic: https://en.wikipedia.org/wiki/Three-valued_logic
 
     Examples
@@ -88,6 +93,11 @@ def any_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     and no `True` values, the output is null. This null handling also differs from
     the vertical :meth:`Expr.any`, which ignores nulls by default
     (``ignore_nulls=True``).
+
+    .. warning::
+        From Polars 2.0, the null handling will change to match the vertical
+        :meth:`Expr.any` (nulls ignored by default). See
+        https://github.com/pola-rs/polars/issues/17827.
 
     .. _Kleene logic: https://en.wikipedia.org/wiki/Three-valued_logic
 

--- a/py-polars/src/polars/functions/aggregation/horizontal.py
+++ b/py-polars/src/polars/functions/aggregation/horizontal.py
@@ -29,6 +29,10 @@ def all_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
 
     Notes
     -----
+    Non-boolean columns are automatically cast to boolean using truthiness evaluation
+    (0 and 0.0 are ``False``, all other values are ``True``). This differs from the
+    vertical :meth:`Expr.all` aggregation, which requires boolean input.
+
     `Kleene logic`_ is used to deal with nulls: if the column contains any null values
     and no `False` values, the output is null.
 
@@ -74,6 +78,10 @@ def any_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
 
     Notes
     -----
+    Non-boolean columns are automatically cast to boolean using truthiness evaluation
+    (0 and 0.0 are ``False``, all other values are ``True``). This differs from the
+    vertical :meth:`Expr.any` aggregation, which requires boolean input.
+
     `Kleene logic`_ is used to deal with nulls: if the column contains any null values
     and no `True` values, the output is null.
 


### PR DESCRIPTION
Fixes #27877

`pl.any_horizontal`/`pl.all_horizontal` accept non-boolean columns (casting them via truthiness), whereas the vertical `pl.any()`/`pl.all()` aggregations require boolean input. This adds a note to both docstrings clarifying the difference.