### PR TITLE
feat: Add `indicator` parameter to full outer joins

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -1377,6 +1377,7 @@ impl LazyFrame {
             nulls_equal,
             coalesce,
             maintain_order,
+            indicator,
             build_side,
         } = args;
 
@@ -1394,6 +1395,7 @@ impl LazyFrame {
             .join_nulls(nulls_equal)
             .coalesce(coalesce)
             .maintain_order(maintain_order)
+            .indicator(indicator)
             .build_side(build_side);
 
         if let Some(suffix) = suffix {
@@ -2154,6 +2156,7 @@ pub struct JoinBuilder {
     nulls_equal: bool,
     coalesce: JoinCoalesce,
     maintain_order: MaintainOrderJoin,
+    indicator: Option<PlSmallStr>,
     build_side: Option<JoinBuildSide>,
 }
 impl JoinBuilder {
@@ -2172,6 +2175,7 @@ impl JoinBuilder {
             nulls_equal: false,
             coalesce: Default::default(),
             maintain_order: Default::default(),
+            indicator: None,
             build_side: None,
         }
     }
@@ -2259,6 +2263,11 @@ impl JoinBuilder {
         self
     }
 
+    pub fn indicator(mut self, indicator: Option<PlSmallStr>) -> Self {
+        self.indicator = indicator;
+        self
+    }
+
     /// Whether to prefer a specific build side.
     pub fn build_side(mut self, build_side: Option<JoinBuildSide>) -> Self {
         self.build_side = build_side;
@@ -2278,6 +2287,7 @@ impl JoinBuilder {
             nulls_equal: self.nulls_equal,
             coalesce: self.coalesce,
             maintain_order: self.maintain_order,
+            indicator: self.indicator,
             build_side: self.build_side,
         };
 
@@ -2370,6 +2380,7 @@ impl JoinBuilder {
             nulls_equal: self.nulls_equal,
             coalesce: self.coalesce,
             maintain_order: self.maintain_order,
+            indicator: self.indicator,
             build_side: self.build_side,
         };
         let options = JoinOptions {

--- a/crates/polars-ops/src/frame/join/args.rs
+++ b/crates/polars-ops/src/frame/join/args.rs
@@ -48,6 +48,7 @@ pub struct JoinArgs {
     pub coalesce: JoinCoalesce,
     pub maintain_order: MaintainOrderJoin,
     pub build_side: Option<JoinBuildSide>,
+    pub indicator: Option<PlSmallStr>,
 }
 
 impl JoinArgs {
@@ -152,6 +153,7 @@ impl JoinArgs {
             coalesce: Default::default(),
             maintain_order: Default::default(),
             build_side: None,
+            indicator: None,
         }
     }
 
@@ -168,6 +170,25 @@ impl JoinArgs {
     pub fn with_build_side(mut self, build_side: Option<JoinBuildSide>) -> Self {
         self.build_side = build_side;
         self
+    }
+
+    pub fn with_indicator(mut self, indicator: Option<PlSmallStr>) -> Self {
+        self.indicator = indicator;
+        self
+    }
+
+    pub fn validate_indicator(
+        &self,
+        schema_left: &Schema,
+        schema_right: &Schema,
+    ) -> PolarsResult<()> {
+        if let Some(ref name) = self.indicator {
+            polars_ensure!(
+                !schema_left.contains(name.as_str()) && !schema_right.contains(name.as_str()),
+                Duplicate: "cannot use name of an existing column for indicator column"
+            );
+        }
+        Ok(())
     }
 
     pub fn suffix(&self) -> &PlSmallStr {

--- a/crates/polars-ops/src/frame/join/hash_join/mod.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/mod.rs
@@ -148,6 +148,7 @@ pub trait JoinDispatch: IntoDf {
         args: JoinArgs,
     ) -> PolarsResult<DataFrame> {
         let df_self = self.to_df();
+        args.validate_indicator(df_self.schema(), other.schema())?;
 
         // Get the indexes of the joined relations
         let (mut join_idx_l, mut join_idx_r) =
@@ -162,44 +163,78 @@ pub trait JoinDispatch: IntoDf {
         let idx_ca_l = IdxCa::with_chunk("a".into(), join_idx_l);
         let idx_ca_r = IdxCa::with_chunk("b".into(), join_idx_r);
 
-        let (df_left, df_right) = if args.maintain_order != MaintainOrderJoin::None {
-            let mut df = unsafe {
-                DataFrame::new_unchecked_infer_height(vec![
-                    idx_ca_l.into_series().into(),
-                    idx_ca_r.into_series().into(),
-                ])
-            };
-
-            let options = SortMultipleOptions::new()
-                .with_order_descending(false)
-                .with_maintain_order(true)
-                .with_nulls_last(true);
-
-            let columns = match args.maintain_order {
-                MaintainOrderJoin::Left => vec!["a"],
-                MaintainOrderJoin::LeftRight => vec!["a", "b"],
-                MaintainOrderJoin::Right => vec!["b"],
-                MaintainOrderJoin::RightLeft => vec!["b", "a"],
-                _ => unreachable!(),
-            };
-
-            df.sort_in_place(columns, options)?;
-
-            let join_tuples_left = df.column("a").unwrap().idx().unwrap();
-            let join_tuples_right = df.column("b").unwrap().idx().unwrap();
-            RAYON.join(
-                || unsafe { df_self.take_unchecked(join_tuples_left) },
-                || unsafe { other.take_unchecked(join_tuples_right) },
-            )
-        } else {
-            RAYON.join(
-                || unsafe { df_self.take_unchecked(&idx_ca_l) },
-                || unsafe { other.take_unchecked(&idx_ca_r) },
-            )
+        // Helper: derive indicator values from two index ChunkedArrays.
+        // IdxCa::iter() yields Option<IdxSize>; None means "no match on that side".
+        //   left None  -> row came from right only
+        //   right None -> row came from left only
+        //   both Some  -> row matched on both sides
+        let build_indicator = |name: &PlSmallStr, l: &IdxCa, r: &IdxCa| -> Series {
+            let values: Vec<&str> = l
+                .iter()
+                .zip(r.iter())
+                .map(|(lv, rv)| match (lv, rv) {
+                    (None, _) => "right_only",
+                    (_, None) => "left_only",
+                    _ => "both",
+                })
+                .collect();
+            Series::new(name.clone(), values)
         };
 
+        let (df_left, df_right, indicator_series) =
+            if args.maintain_order != MaintainOrderJoin::None {
+                let mut df = unsafe {
+                    DataFrame::new_unchecked_infer_height(vec![
+                        idx_ca_l.into_series().into(),
+                        idx_ca_r.into_series().into(),
+                    ])
+                };
+
+                let options = SortMultipleOptions::new()
+                    .with_order_descending(false)
+                    .with_maintain_order(true)
+                    .with_nulls_last(true);
+
+                let columns = match args.maintain_order {
+                    MaintainOrderJoin::Left => vec!["a"],
+                    MaintainOrderJoin::LeftRight => vec!["a", "b"],
+                    MaintainOrderJoin::Right => vec!["b"],
+                    MaintainOrderJoin::RightLeft => vec!["b", "a"],
+                    _ => unreachable!(),
+                };
+
+                df.sort_in_place(columns, options)?;
+
+                let join_tuples_left = df.column("a").unwrap().idx().unwrap();
+                let join_tuples_right = df.column("b").unwrap().idx().unwrap();
+
+                // Build indicator from the sorted index arrays before RAYON moves them.
+                let ind = args
+                    .indicator
+                    .as_ref()
+                    .map(|name| build_indicator(name, join_tuples_left, join_tuples_right));
+
+                let (dfl, dfr) = RAYON.join(
+                    || unsafe { df_self.take_unchecked(join_tuples_left) },
+                    || unsafe { other.take_unchecked(join_tuples_right) },
+                );
+                (dfl, dfr, ind)
+            } else {
+                // Build indicator before RAYON borrows the arrays.
+                let ind = args
+                    .indicator
+                    .as_ref()
+                    .map(|name| build_indicator(name, &idx_ca_l, &idx_ca_r));
+
+                let (dfl, dfr) = RAYON.join(
+                    || unsafe { df_self.take_unchecked(&idx_ca_l) },
+                    || unsafe { other.take_unchecked(&idx_ca_r) },
+                );
+                (dfl, dfr, ind)
+            };
+
         let coalesce = args.coalesce.coalesce(&JoinType::Full);
-        if coalesce {
+        let mut out = if coalesce {
             let tmp_right_name = unique_column_name();
             let mut df_right = df_right;
             df_right.rename(s_right.name().as_str(), tmp_right_name.clone())?;
@@ -213,7 +248,13 @@ pub trait JoinDispatch: IntoDf {
             ))
         } else {
             _finish_join(df_left, df_right, args.suffix.clone())
+        }?;
+
+        if let Some(ind) = indicator_series {
+            out.with_column(ind.into())?;
         }
+
+        Ok(out)
     }
 }
 

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -1055,7 +1055,7 @@ impl PyLazyFrame {
             .into())
     }
 
-    #[pyo3(signature = (other, left_on, right_on, allow_parallel, force_parallel, nulls_equal, how, suffix, validate, maintain_order, coalesce=None))]
+    #[pyo3(signature = (other, left_on, right_on, allow_parallel, force_parallel, nulls_equal, how, suffix, validate, maintain_order, coalesce=None, indicator=None))]
     fn join(
         &self,
         other: Self,
@@ -1069,6 +1069,7 @@ impl PyLazyFrame {
         validate: Wrap<JoinValidation>,
         maintain_order: Wrap<MaintainOrderJoin>,
         coalesce: Option<bool>,
+        indicator: Option<String>,
     ) -> PyResult<Self> {
         let coalesce = match coalesce {
             None => JoinCoalesce::JoinSpecific,
@@ -1099,6 +1100,7 @@ impl PyLazyFrame {
             .validate(validate.0)
             .coalesce(coalesce)
             .maintain_order(maintain_order.0)
+            .indicator(indicator.map(PlSmallStr::from))
             .finish()
             .into())
     }

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -1372,6 +1372,7 @@ impl SQLContext {
                                 nulls_equal: false,
                                 coalesce: Default::default(),
                                 maintain_order: MaintainOrderJoin::Left,
+                                indicator: None,
                                 build_side: None,
                             },
                         );

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -1134,6 +1134,7 @@ fn lower_exprs_with_ctx(
                         nulls_equal,
                         coalesce: Default::default(),
                         maintain_order: Default::default(),
+                        indicator: None,
                         build_side: None,
                     },
                     output_bool: true,

--- a/py-polars/src/polars/_plr.pyi
+++ b/py-polars/src/polars/_plr.pyi
@@ -1081,6 +1081,7 @@ class PyLazyFrame:
         validate: JoinValidation,
         maintain_order: MaintainOrderJoin,
         coalesce: bool | None,
+        indicator: str | None,
     ) -> PyLazyFrame: ...
     def join_where(
         self, other: PyLazyFrame, predicates: Sequence[PyExpr], suffix: str

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -8223,6 +8223,7 @@ class DataFrame:
         nulls_equal: bool = False,
         coalesce: bool | None = None,
         maintain_order: MaintainOrderJoin | None = None,
+        indicator: str | None = None,
     ) -> DataFrame:
         """
         Join in SQL-like fashion.
@@ -8326,6 +8327,11 @@ class DataFrame:
                  - First preserves the order of the left DataFrame, then the right.
                * - **right_left**
                  - First preserves the order of the right DataFrame, then the left.
+
+        indicator
+            If given, adds a string column with this name to the result indicating
+            the source of each row. Values are ``"left_only"``, ``"right_only"``,
+            or ``"both"``. Only supported for ``how="full"`` joins.
 
         See Also
         --------
@@ -8434,6 +8440,10 @@ class DataFrame:
         │ 3   ┆ 8.0 ┆ c   ┆ z     ┆ d         │
         └─────┴─────┴─────┴───────┴───────────┘
         """
+        if indicator is not None and how not in ("full", "outer"):
+            msg = "`indicator` is only supported for `how='full'` joins"
+            raise InvalidOperationError(msg)
+
         require_same_type(self, other)
 
         from polars.lazyframe.opt_flags import QueryOptFlags
@@ -8451,6 +8461,7 @@ class DataFrame:
                 nulls_equal=nulls_equal,
                 coalesce=coalesce,
                 maintain_order=maintain_order,
+                indicator=indicator,
             )
             .collect(optimizations=QueryOptFlags._eager())
         )

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -6327,6 +6327,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         maintain_order: MaintainOrderJoin | None = None,
         allow_parallel: bool = True,
         force_parallel: bool = False,
+        indicator: str | None = None,
     ) -> LazyFrame:
         """
         Add a join operation to the Logical Plan.
@@ -6411,6 +6412,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Do not rely on any observed ordering without explicitly setting this
             parameter, as your code may break in a future release.
             Not specifying any ordering can improve performance.
+
+        indicator
+            If given, adds a string column with this name to the result indicating
+            the source of each row. Values are ``"left_only"``, ``"right_only"``,
+            or ``"both"``. Only supported for ``how="full"`` joins.
 
             .. list-table ::
                :header-rows: 0
@@ -6553,6 +6559,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 "use of `how='outer_coalesce'` should be replaced with `how='full', coalesce=True`.",
                 version="0.20.29",
             )
+
+        if indicator is not None and how not in ("full", "outer"):
+            msg = "`indicator` is only supported for `how='full'` joins"
+            raise InvalidOperationError(msg)
+
         elif how == "cross":
             if uses_on or uses_lr_on:
                 msg = "cross join should not pass join keys"
@@ -6570,6 +6581,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                     validate,
                     maintain_order,
                     coalesce=None,
+                    indicator=indicator,
                 )
             )
 
@@ -6597,6 +6609,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 validate,
                 maintain_order,
                 coalesce,
+                indicator=indicator,
             )
         )
 

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -4056,3 +4056,97 @@ def test_full_join_coalesce_empty_suffix_non_key_collision_27368() -> None:
 
     with pytest.raises(DuplicateError):
         df1.join(df2, how="full", on="a", coalesce=True, suffix="")
+
+
+def test_full_join_indicator() -> None:
+    df_left = pl.DataFrame({"id": [1, 2, 3], "val": ["a", "b", "c"]})
+    df_right = pl.DataFrame({"id": [2, 3, 4], "val": ["x", "y", "z"]})
+
+    result = df_left.join(
+        df_right, on="id", how="full", coalesce=True, indicator="_merge"
+    )
+
+    expected = pl.DataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "val": ["a", "b", "c", None],
+            "val_right": [None, "x", "y", "z"],
+            "_merge": ["left_only", "both", "both", "right_only"],
+        }
+    )
+
+    assert_frame_equal(result, expected, check_row_order=False)
+
+    # lazy
+    result_lazy = (
+        df_left.lazy()
+        .join(df_right.lazy(), on="id", how="full", coalesce=True, indicator="_merge")
+        .collect()
+    )
+
+    assert_frame_equal(result_lazy, expected, check_row_order=False)
+
+
+def test_full_join_indicator_null_keys() -> None:
+    df_left = pl.DataFrame({"id": [1, None], "val": ["a", "b"]})
+    df_right = pl.DataFrame({"id": [1, None], "val": ["x", "y"]})
+
+    result = df_left.join(
+        df_right,
+        on="id",
+        how="full",
+        coalesce=True,
+        nulls_equal=False,
+        indicator="_merge",
+    )
+
+    # null keys never match when nulls_equal=False, so both nulls are unmatched
+    assert result["_merge"].is_in(["left_only", "right_only", "both"]).all()
+    assert result.filter(pl.col("id") == 1)["_merge"].to_list() == ["both"]
+
+
+def test_full_join_indicator_maintain_order() -> None:
+    df_left = pl.DataFrame({"id": [3, 1, 2], "val": ["c", "a", "b"]})
+    df_right = pl.DataFrame({"id": [2, 4, 3], "val": ["x", "y", "z"]})
+
+    result = (
+        df_left.lazy()
+        .join(
+            df_right.lazy(),
+            on="id",
+            how="full",
+            coalesce=True,
+            maintain_order="left",
+            indicator="_merge",
+        )
+        .collect()
+    )
+
+    # left order (3, 1, 2) is preserved, unmatched right (4) appended
+    assert result["id"].to_list() == [3, 1, 2, 4]
+    assert result["_merge"].to_list() == ["both", "left_only", "both", "right_only"]
+
+
+def test_full_join_indicator_non_full_join_raises() -> None:
+    df_left = pl.DataFrame({"id": [1, 2], "val": ["a", "b"]})
+    df_right = pl.DataFrame({"id": [1, 2], "val": ["x", "y"]})
+
+    with pytest.raises(InvalidOperationError):
+        df_left.join(df_right, on="id", how="left", indicator="_merge")
+
+    with pytest.raises(InvalidOperationError):
+        df_left.join(df_right, on="id", how="inner", indicator="_merge")
+
+
+def test_full_join_indicator_existing_column_raises() -> None:
+    df_left = pl.DataFrame({"id": [1, 2], "_merge": ["a", "b"]})
+    df_right = pl.DataFrame({"id": [1, 2], "val": ["x", "y"]})
+
+    with pytest.raises(DuplicateError):
+        df_left.join(df_right, on="id", how="full", indicator="_merge")
+
+    df_left2 = pl.DataFrame({"id": [1, 2], "val": ["a", "b"]})
+    df_right2 = pl.DataFrame({"id": [1, 2], "_merge": ["x", "y"]})
+
+    with pytest.raises(DuplicateError):
+        df_left2.join(df_right2, on="id", how="full", indicator="_merge")


### PR DESCRIPTION
Closes #15096

<img width="1652" height="1193" alt="Screenshot 2026-06-18 at 10 51 32 PM" src="https://github.com/user-attachments/assets/e57d40ec-e78c-4169-91d3-db45b7f744ca" />


This adds an indicator parameter to DataFrame.join() and LazyFrame.join() for full outer joins. When provided, a string column is appended to the result with values "left_only", "right_only", or "both" indicating the source of each row.
Unlike pandas, which accepts either a boolean or a string, this implementation requires an explicit string for the column name. This was done so the user has to be intentional about what the indicator column is called. I made sure to include a validation check as well to raise a DuplicateError if the chosen name conflicts with an existing column in either input.
This is currently limited to how="full" where it is most meaningful, but Left and right join support could follow in a future PR. This is my first contribution, so I wanted to start a little smaller. It passed all tests.

AI disclosure: This implementation was developed with AI assistance (Claude by Anthropic). Specifically, AI was used to help navigate the Polars codebase and identify the correct location and approach for the implementation, understand how hash_join_outer returns index arrays and how null values encode unmatched rows, structure the build_indicator closure and where to place it relative to the RAYON.join calls to avoid borrow checker issues, identify that the check needed to live in args.rs as a validate_indicator method following existing validation patterns, add the indicator field to JoinArgs and wire it through the PyO3 bindings and type stubs, and write the test cases. All code was reviewed by me. I believe all changes are relevant and correct.
