### PR TITLE
fix(rust): Fix qcut panic and incorrect bins on NaN input

### DIFF
--- a/crates/polars-ops/src/series/ops/cut.rs
+++ b/crates/polars-ops/src/series/ops/cut.rs
@@ -184,6 +184,11 @@ pub fn qcut(
 ) -> PolarsResult<Series> {
     polars_ensure!(!probs.iter().any(|x| x.is_nan()), ComputeError: "quantiles cannot be NaN");
 
+    let s = s.cast(&DataType::Float64)?;
+    let s2 = s.sort(SortOptions::default())?;
+    let ca = s2.f64()?;
+    let ca = ca.set(&ca.is_nan(), None)?;
+
     if s.null_count() == s.len() {
         // If we only have nulls we don't have any breakpoints.
         return Ok(Series::full_null(
@@ -192,10 +197,6 @@ pub fn qcut(
             &DataType::from_categories(Categories::global()),
         ));
     }
-
-    let s = s.cast(&DataType::Float64)?;
-    let s2 = s.sort(SortOptions::default())?;
-    let ca = s2.f64()?;
 
     let mut qbreaks: Vec<_> = ca
         .quantiles(&probs, QuantileMethod::Linear)?

--- a/py-polars/tests/unit/operations/test_qcut.py
+++ b/py-polars/tests/unit/operations/test_qcut.py
@@ -141,3 +141,16 @@ def test_qcut_over() -> None:
         dtype=pl.Categorical,
     )
     assert_series_equal(out, expected, categorical_as_str=True)
+
+
+def test_qcut_nan_input_values() -> None:
+    s = pl.Series("a", [1.0, 2.0, 3.0, 4.0, float("nan")])
+
+    result = s.qcut([0.5, 1.0])
+
+    expected = pl.Series(
+        "a",
+        ["(-inf, 2.5]", "(-inf, 2.5]", "(2.5, 4]", "(2.5, 4]", None],
+        dtype=pl.Categorical,
+    )
+    assert_series_equal(result, expected, categorical_as_str=True)


### PR DESCRIPTION
## Problem

`qcut` validated `NaN` only in `probs`, never in the input series. Under polars' total order `NaN` is the **largest** value, so it propagates into the quantile computation:

- **Panic** — when a requested quantile lands on the trailing `NaN` region, `qbreaks` contains `NaN` and `qbreaks.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap())` panics at `cut.rs:206`.
- **Silently wrong bins (even without panic)** — `NaN` is not `null`, so it is counted in `length` inside `quantile_idx`. This shifts every quantile position, so non-panicking calls still return bins that don't match the real distribution.

## Fix 

Treat `NaN` as `null` before computing the breaks, then rely on the existing null handling; also make the sort `NaN`-safe:

## Behavior — before vs after vs pandas

Input `[1, 2, 3, 4, NaN]`, `qcut([0.25, 0.5, 0.75])`:

| value | `pandas.qcut` | polars **before** | polars **after** |
|---|---|---|---|
| 1   | `(0.999, 1.75]` | `(-inf, 2]` | `(-inf, 1.75]` |
| 2   | `(1.75, 2.5]`   | `(-inf, 2]` | `(1.75, 2.5]` |
| 3   | `(2.5, 3.25]`   | `(2, 3]`    | `(2.5, 3.25]` |
| 4   | `(3.25, 4.0]`   | `(3, 4]`    | `(3.25, inf]` |
| NaN | `nan`           | `null` / panic | `null` |

```python
import pandas as pd
import polars as pl

x = [1.0, 2.0, 3.0, 4.0, float("nan")] 

# pandas — qcut takes quantile edges (must include 0 and 1)
list(map(str, pd.qcut(x, [0, 0.25, 0.5, 0.75, 1])))
# ['(0.999, 1.75]', '(1.75, 2.5]', '(2.5, 3.25]', '(3.25, 4.0]', 'nan']

# polars (after fix) — probs are internal breakpoints (0/1 implicit as ±inf)
list(pl.Series("a", x).qcut([0.25, 0.5, 0.75]))
# ['(-inf, 1.75]', '(1.75, 2.5]', '(2.5, 3.25]', '(3.25, inf]', None]
```

