### PR TITLE
docs: Document that empty CSV lines are read as null rows

### DIFF
--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -264,6 +264,10 @@ def read_csv(
     `infer_schema_length` or override the inferred dtype for those columns with
     `schema_overrides`.
 
+    Empty lines in the input are not skipped; each is read as a row of null values
+    in every column. This differs from `pandas` and `pyarrow`, which drop empty
+    lines. There is currently no option to skip empty lines.
+
     Examples
     --------
     >>> pl.read_csv("data.csv", separator="|")  # doctest: +SKIP
@@ -1322,6 +1326,12 @@ def scan_csv(
     See Also
     --------
     read_csv : Read a CSV file into a DataFrame.
+
+    Notes
+    -----
+    Empty lines in the input are not skipped; each is read as a row of null values
+    in every column. This differs from `pandas` and `pyarrow`, which drop empty
+    lines. There is currently no option to skip empty lines.
 
     Examples
     --------


### PR DESCRIPTION
Closes #27755

Since #13934, the native CSV reader keeps empty input lines as a row of `null` values in every column, e.g.:

```python
>>> import polars as pl, io
>>> pl.read_csv(io.StringIO("a,b\n1,2\n\n3,4\n")).height
3   # the empty line becomes a (null, null) row
```

This differs from `pandas.read_csv()` and `pyarrow` (both drop empty lines), so the behavior repeatedly surprises users. As requested in #27755, this PR documents the current behavior rather than changing it.

- Adds a note to the `read_csv` `Notes` section.
- Adds a `Notes` section to `scan_csv` with the same note.
- Mentions there is currently no `skip_empty_lines` option.

Docs-only change; no behavior change and no executable doctest added.

---
_Prepared with AI assistance (Claude Code)._