### PR TITLE
docs(python): Add write_iceberg example

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -4733,6 +4733,39 @@ class DataFrame:
             - If 'append', will add new data.
             - If 'overwrite', will replace table with new data.
 
+        See Also
+        --------
+        polars.scan_iceberg : Lazily read from an Apache Iceberg table.
+
+        Examples
+        --------
+        Create a local Iceberg table with PyIceberg, write a DataFrame, and read
+        it back with `polars.scan_iceberg`.
+
+        .. code-block:: python
+
+            from pathlib import Path
+            from tempfile import TemporaryDirectory
+
+            from pyiceberg.catalog.sql import SqlCatalog
+
+            df = pl.DataFrame({"id": [1, 2], "value": ["a", "b"]})
+
+            with TemporaryDirectory() as tmp_dir:
+                catalog = SqlCatalog(
+                    "local",
+                    uri="sqlite:///:memory:",
+                    warehouse=Path(tmp_dir).as_uri(),
+                )
+                catalog.create_namespace("demo")
+                table = catalog.create_table(
+                    "demo.events",
+                    schema=df.to_arrow().schema,
+                )
+
+                df.write_iceberg(table, mode="append")
+                result = pl.scan_iceberg(table).collect()
+
         """
         from pyiceberg.catalog import load_catalog
 

--- a/py-polars/src/polars/io/iceberg/functions.py
+++ b/py-polars/src/polars/io/iceberg/functions.py
@@ -102,6 +102,10 @@ def scan_iceberg(
     -------
     LazyFrame
 
+    See Also
+    --------
+    DataFrame.write_iceberg : Write a DataFrame to an Apache Iceberg table.
+
     Examples
     --------
     Creates a scan for an Iceberg table from local filesystem, or object store.


### PR DESCRIPTION
## Summary

Adds a minimal `DataFrame.write_iceberg` example that creates a local PyIceberg SQL catalog, writes a DataFrame, and reads it back with `pl.scan_iceberg`. Also adds a `scan_iceberg` see-also entry for the write API.

Closes #27798.

## Validation

- `python3 -m py_compile py-polars/src/polars/dataframe/frame.py py-polars/src/polars/io/iceberg/functions.py`
- `ruff check py-polars/src/polars/dataframe/frame.py py-polars/src/polars/io/iceberg/functions.py`
- `ruff format --check py-polars/src/polars/dataframe/frame.py py-polars/src/polars/io/iceberg/functions.py`

Tried `PYTHONPATH=py-polars/src sphinx-build -W -b html py-polars/docs/source /tmp/polars-docs-write-iceberg-html`, but the local Python environment is missing `sphinx_autosummary_accessors`, so full docs build is left to CI.