### PR TITLE
feat(python): Add `Series.is_sorted_flag()` to read the sorted flag

### DIFF
--- a/py-polars/docs/source/reference/series/descriptive.rst
+++ b/py-polars/docs/source/reference/series/descriptive.rst
@@ -23,6 +23,7 @@ Descriptive
     Series.is_not_null
     Series.is_null
     Series.is_sorted
+    Series.is_sorted_flag
     Series.is_unique
     Series.len
     Series.lower_bound

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -4182,6 +4182,59 @@ class Series:
         """
         return self._s.is_sorted(descending, nulls_last)
 
+    def is_sorted_flag(self) -> bool:
+        """
+        Check whether the Series carries a 'sorted' flag.
+
+        This returns the value of the internal sorted flag *without* scanning the
+        data, so it is O(1). The flag is set either implicitly by operations that
+        preserve sortedness (e.g. :meth:`sort`) or explicitly via
+        :meth:`set_sorted`. It is `False` for Series whose order is simply unknown,
+        even if the underlying data happens to be sorted.
+
+        This is distinct from :meth:`is_sorted`, which performs a full element
+        scan of the data to determine the actual order.
+
+        Returns
+        -------
+        bool
+            `True` if the Series is flagged as sorted (ascending or descending),
+            `False` otherwise.
+
+        See Also
+        --------
+        is_sorted
+        set_sorted
+
+        Examples
+        --------
+        A freshly constructed Series carries no sorted flag, even when the data is
+        ordered:
+
+        >>> s = pl.Series("a", [1, 2, 3])
+        >>> s.is_sorted_flag()
+        False
+
+        Marking it as sorted sets the flag:
+
+        >>> s.set_sorted().is_sorted_flag()
+        True
+
+        The flag is also set for descending order:
+
+        >>> s.set_sorted(descending=True).is_sorted_flag()
+        True
+
+        Setting the flag lets downstream operations such as a join on pre-sorted
+        data use fast paths without a redundant sort:
+
+        >>> left = pl.Series("key", [1, 2, 3]).set_sorted()
+        >>> right = pl.Series("key", [2, 3, 4]).set_sorted()
+        >>> left.is_sorted_flag() and right.is_sorted_flag()
+        True
+        """
+        return self._s.is_sorted_ascending_flag() or self._s.is_sorted_descending_flag()
+
     def not_(self) -> Series:
         """
         Negate a boolean Series.

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -2492,6 +2492,35 @@ def test_full_null_cast_to_empty_struct_23276() -> None:
     assert s.cast(pl.Struct({})).to_list() == [None, None, None]
 
 
+def test_is_sorted_flag() -> None:
+    # an unsorted (order-unknown) Series carries no flag, even if data is ordered
+    s = pl.Series("a", [1, 2, 3])
+    assert s.is_sorted_flag() is False
+
+    # explicitly flagging ascending sets the flag
+    s_asc = s.set_sorted()
+    assert s_asc.is_sorted_flag() is True
+    assert s_asc._s.is_sorted_ascending_flag() is True
+    assert s_asc._s.is_sorted_descending_flag() is False
+
+    # flagging descending sets the flag and reflects descending order
+    s_desc = pl.Series("a", [3, 2, 1]).set_sorted(descending=True)
+    assert s_desc.is_sorted_flag() is True
+    assert s_desc._s.is_sorted_descending_flag() is True
+    assert s_desc._s.is_sorted_ascending_flag() is False
+
+    # is_sorted_flag() must not alter is_sorted()'s full-scan behavior
+    unsorted = pl.Series("a", [2, 1, 3])
+    assert unsorted.is_sorted_flag() is False
+    assert unsorted.is_sorted() is False
+
+    # using a flagged Series in a join works without error
+    left = pl.DataFrame({"key": pl.Series([1, 2, 3]).set_sorted()})
+    right = pl.DataFrame({"key": pl.Series([2, 3, 4]).set_sorted(), "val": ["b", "c", "d"]})
+    joined = left.join(right, on="key", how="inner")
+    assert joined["key"].to_list() == [2, 3]
+
+
 def test_is_sorted_struct_27613() -> None:
     s = pl.Series([{"x": 1, "y": 1}, {"x": 1, "y": 2}, {"x": 2, "y": 0}])
     assert s.is_sorted()


### PR DESCRIPTION
## Summary

Adds `Series.is_sorted_flag()` to the Python Series API. It returns the O(1) internal sorted flag — whether the Series is flagged as ascending- or descending-sorted — **without** scanning the data.

This complements the existing `Series.set_sorted()` and is intentionally distinct from `Series.is_sorted()`, which performs a full element scan. Power users working with externally-sorted data (e.g. loaded from a sorted Parquet file) can mark a Series with `set_sorted()` and cheaply verify/inspect the flag to confirm downstream fast paths (joins, filters) will engage — without paying for a redundant sort or a full scan.

## Implementation

Implemented purely in the binding layer on top of the already-exposed `is_sorted_ascending_flag` / `is_sorted_descending_flag` `PySeries` accessors, so **no Rust change is required**. `is_sorted()`'s full-scan behavior is untouched.

## Changes
- `series.py`: new `is_sorted_flag()` method with docstring (semantics, contrast with `is_sorted()`, pre-sorted join example).
- `descriptive.rst`: registered `Series.is_sorted_flag` in the API reference.
- `test_series.py`: `test_is_sorted_flag` covering unflagged → `False`, `set_sorted()` → `True`, descending flag, `is_sorted()` unaffected, and a flagged-Series join.

🤖 Generated with [Claude Code](https://claude.com/claude-code)