### PR TITLE
fix(python): Prefer `__arrow_c_stream__` over `__arrow_c_array__` in pycapsule conversion

### DIFF
--- a/py-polars/src/polars/_utils/pycapsule.py
+++ b/py-polars/src/polars/_utils/pycapsule.py
@@ -30,18 +30,18 @@ def pycapsule_to_frame(
     rechunk: bool = False,
 ) -> DataFrame:
     """Convert PyCapsule object to DataFrame."""
-    if hasattr(obj, "__arrow_c_array__"):
-        # This uses the fact that PySeries.from_arrow_c_array will create a
-        # struct-typed Series. Then we unpack that to a DataFrame.
-        tmp_col_name = ""
-        s = wrap_s(PySeries.from_arrow_c_array(obj))
-        df = s.to_frame(tmp_col_name).unnest(tmp_col_name)
-
-    elif hasattr(obj, "__arrow_c_stream__"):
+    if hasattr(obj, "__arrow_c_stream__"):
         # This uses the fact that PySeries.from_arrow_c_stream will create a
         # struct-typed Series. Then we unpack that to a DataFrame.
         tmp_col_name = ""
         s = wrap_s(PySeries.from_arrow_c_stream(obj))
+        df = s.to_frame(tmp_col_name).unnest(tmp_col_name)
+
+    elif hasattr(obj, "__arrow_c_array__"):
+        # This uses the fact that PySeries.from_arrow_c_array will create a
+        # struct-typed Series. Then we unpack that to a DataFrame.
+        tmp_col_name = ""
+        s = wrap_s(PySeries.from_arrow_c_array(obj))
         df = s.to_frame(tmp_col_name).unnest(tmp_col_name)
     else:
         msg = f"object does not support PyCapsule interface; found {obj!r} "

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -1907,3 +1907,36 @@ def test_dataframe_height() -> None:
 
     with pytest.raises(AssertionError):
         assert_frame_equal(pl.DataFrame(), pl.DataFrame(height=10))
+
+
+class _BothDunders:
+    """Object exposing both Arrow PyCapsule dunders to test priority."""
+
+    def __init__(self) -> None:
+        self.called: list[str] = []
+        inner = pa.table({"x": [1, 2, 3]})
+
+        def _stream(*args: object, **kwargs: object) -> object:
+            self.called.append("__arrow_c_stream__")
+            return inner.__arrow_c_stream__(*args, **kwargs)
+
+        def _array(*args: object, **kwargs: object) -> object:
+            self.called.append("__arrow_c_array__")
+            return inner.__arrow_c_array__(*args, **kwargs)
+
+        self._stream = _stream
+        self._array = _array
+
+    def __arrow_c_stream__(self, requested_schema: object = None) -> object:
+        return self._stream(requested_schema)
+
+    def __arrow_c_array__(self, requested_schema: object = None) -> object:
+        return self._array(requested_schema)
+
+
+def test_pycapsule_priority_stream_over_array_27921() -> None:
+    obj = _BothDunders()
+    result = pl.DataFrame(obj)
+    assert obj.called == ["__arrow_c_stream__"], f"Expected stream, got {obj.called}"
+    expected = pl.DataFrame({"x": [1, 2, 3]})
+    assert_frame_equal(result, expected)


### PR DESCRIPTION
## Description

Fixes #27921

When an object exposes both `__arrow_c_stream__` (table) and `__arrow_c_array__` (array) dunders, the stream/table representation is closer to a DataFrame and should take priority. Prior to this fix, `__arrow_c_array__` was checked first, which meant objects that offer both interfaces would be converted via the single-array path instead of the table path.

### Changes

- `py-polars/src/polars/_utils/pycapsule.py`: Swap the if/elif order so `__arrow_c_stream__` is checked before `__arrow_c_array__`
- `py-polars/tests/unit/constructors/test_constructors.py`: Add `test_pycapsule_priority_stream_over_array_27921` regression test

### Verification

- `ruff check` — passes
- `pytest test_pycapsule_interface` — 1 passed
- `pytest test_pycapsule_priority_stream_over_array_27921` — 1 passed