### PR TITLE
fix(rust): Remove unsound `TrustedLen` impl for `Scan`

### DIFF
--- a/crates/polars-arrow/src/trusted_len.rs
+++ b/crates/polars-arrow/src/trusted_len.rs
@@ -1,5 +1,4 @@
 //! Declares [`TrustedLen`].
-use std::iter::Scan;
 use std::slice::{Iter, IterMut};
 
 /// An iterator of known, fixed size.
@@ -73,13 +72,6 @@ unsafe impl<T> TrustedLen for std::ops::Range<T> where std::ops::Range<T>: Itera
 unsafe impl<T> TrustedLen for std::ops::RangeInclusive<T> where std::ops::RangeInclusive<T>: Iterator
 {}
 unsafe impl<A: TrustedLen> TrustedLen for std::iter::StepBy<A> {}
-
-unsafe impl<I, St, F, B> TrustedLen for Scan<I, St, F>
-where
-    F: FnMut(&mut St, I::Item) -> Option<B>,
-    I: TrustedLen,
-{
-}
 
 unsafe impl<T: Copy> TrustedLen for polars_buffer::buffer::IntoIter<T> {}
 

--- a/crates/polars-core/src/chunked_array/ops/fill_null.rs
+++ b/crates/polars-core/src/chunked_array/ops/fill_null.rs
@@ -148,7 +148,7 @@ where
             *prev = v.map(|v| v.into()).unwrap_or(*prev);
             Some(*prev)
         })
-        .collect_trusted();
+        .collect();
 
     // Compute bitmask.
     let num_start_nulls = ca.first_non_null().unwrap_or(ca.len());
@@ -170,14 +170,18 @@ where
     T::ZeroablePhysical<'a>: Copy,
 {
     // Compute values.
-    let values: Vec<T::ZeroablePhysical<'a>> = ca
-        .iter()
-        .rev()
-        .scan(T::ZeroablePhysical::zeroed(), |prev, v| {
-            *prev = v.map(|v| v.into()).unwrap_or(*prev);
-            Some(*prev)
-        })
-        .collect_reversed();
+    let values: Vec<T::ZeroablePhysical<'a>> = {
+        let mut vals: Vec<_> = ca
+            .iter()
+            .rev()
+            .scan(T::ZeroablePhysical::zeroed(), |prev, v| {
+                *prev = v.map(|v| v.into()).unwrap_or(*prev);
+                Some(*prev)
+            })
+            .collect();
+        vals.reverse();
+        vals
+    };
 
     // Compute bitmask.
     let num_end_nulls = ca

--- a/crates/polars-ops/src/series/ops/cum_agg.rs
+++ b/crates/polars-ops/src/series/ops/cum_agg.rs
@@ -89,8 +89,12 @@ where
     F: Fn(&mut S, Option<T::Native>) -> Option<Option<T::Native>>,
 {
     let out: ChunkedArray<T> = match reverse {
-        false => ca.iter().scan(init, update).collect_trusted(),
-        true => ca.iter().rev().scan(init, update).collect_reversed(),
+        false => ca.iter().scan(init, update).collect(),
+        true => {
+            let mut out: Vec<_> = ca.iter().rev().scan(init, update).collect();
+            out.reverse();
+            out.into_iter().collect()
+        },
     };
     out.with_name(ca.name().clone())
 }

--- a/crates/polars-ops/src/series/ops/cum_agg.rs
+++ b/crates/polars-ops/src/series/ops/cum_agg.rs
@@ -6,7 +6,7 @@ use arrow::bitmap::{Bitmap, BitmapBuilder};
 use num_traits::{AsPrimitive, Bounded, One, Zero};
 use polars_core::prelude::*;
 use polars_core::series::IsSorted;
-use polars_core::utils::{CustomIterTools, NoNull};
+use polars_core::utils::NoNull;
 use polars_core::with_match_physical_numeric_polars_type;
 use polars_utils::float::IsFloat;
 use polars_utils::min_max::MinMax;


### PR DESCRIPTION
Fixes #28027

## Description

The `TrustedLen` marker trait promises consumers that the iterator yields exactly `size_hint().1` elements. However, `std::iter::Scan` can terminate early when its state closure returns `None`, while its `size_hint` still reports the upper bound of the underlying iterator. This allows safe public APIs (e.g. `from_trusted_len_values_iter`, `collect_trusted`) to set the container's initialized length beyond the number of actually written elements, exposing uninitialized heap memory.

## Changes

- `crates/polars-arrow/src/trusted_len.rs`: Remove the unsound `TrustedLen` implementation for `std::iter::Scan`
- `crates/polars-core/src/chunked_array/ops/fill_null.rs`: Replace `.collect_trusted()` / `.collect_reversed()` with standard `.collect()`
- `crates/polars-ops/src/series/ops/cum_agg.rs`: Replace `.collect_trusted()` / `.collect_reversed()` with standard `.collect()`

## Verification

- `cargo fmt --all --check` — passes
- `cargo clippy -p polars-arrow` — no new warnings
- `cargo check` — compiles clean across the entire workspace