### PR TITLE
fix(python): Avoid panic constructing DataFrame from unaligned structured array

### DIFF
--- a/py-polars/src/polars/_utils/construction/dataframe.py
+++ b/py-polars/src/polars/_utils/construction/dataframe.py
@@ -1289,10 +1289,13 @@ def numpy_to_pydf(
 
     # Convert data to series
     if structured_array:
+        # A structured-array field is a strided view that may be unaligned (e.g.
+        # for packed/unaligned dtypes); require an aligned, contiguous array,
+        # copying only when needed.
         data_series = [
             pl.Series(
                 name=series_name,
-                values=data[record_name],
+                values=np.require(data[record_name], requirements=["A", "C"]),
                 dtype=schema_overrides.get(record_name),
                 strict=strict,
                 nan_to_null=nan_to_null,

--- a/py-polars/tests/unit/interop/numpy/test_from_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_from_numpy_df.py
@@ -179,3 +179,16 @@ def test_dataframe_numpy_records_mixed_dims() -> None:
         {"arr1d": 2, "arr2d": [3.0, 4.0]},
         {"arr1d": 3, "arr2d": [5.0, 6.0]},
     ]
+
+
+def test_from_numpy_unaligned_structured_array_27794() -> None:
+    # Unaligned (packed) structured-array fields are strided views that may also
+    # be unaligned; constructing a DataFrame from them must not panic.
+    for buf, dtype in [
+        (b"012", [("a", "u1"), ("b", "u2")]),  # single row, unaligned
+        (b"012345", [("a", "u1"), ("b", "u2")]),  # multiple rows, unaligned
+    ]:
+        arr = np.frombuffer(buf, dtype=dtype)
+        df = pl.DataFrame(arr)
+        assert df["a"].to_list() == arr["a"].tolist()
+        assert df["b"].to_list() == arr["b"].tolist()


### PR DESCRIPTION
Fixes #27794

Constructing a `DataFrame` from a packed/unaligned numpy structured array panicked:

```python
>>> ar = np.frombuffer(b"012", dtype=[("a", "u1"), ("b", "u2")])
>>> pl.DataFrame(ar)
PanicException: called `Result::unwrap()` on an `Err` value: AsSliceError
```

A structured-array field is a strided view that may also be unaligned. For single-row arrays numpy still reports the view as contiguous, so the field reached the Rust constructor unaligned and it panicked — which is why the two-row case in the report worked while the single-row case didn't.

Use `np.require(..., ["A", "C"])` to obtain an aligned, contiguous array per field, copying only when necessary.