### PR TITLE
fix: Set CallerContext parallel flag for plugin expressions

### DIFF
--- a/crates/polars-expr/src/dispatch/mod.rs
+++ b/crates/polars-expr/src/dispatch/mod.rs
@@ -136,7 +136,10 @@ mod trigonometry;
 
 pub use groups_dispatch::drop_items;
 
-pub fn function_expr_to_udf(func: IRFunctionExpr) -> SpecialEq<Arc<dyn ColumnsUdf>> {
+pub fn function_expr_to_udf(
+    func: IRFunctionExpr,
+    _allow_threading: bool,
+) -> SpecialEq<Arc<dyn ColumnsUdf>> {
     use IRFunctionExpr as F;
     match func {
         // Namespaces
@@ -447,7 +450,8 @@ pub fn function_expr_to_udf(func: IRFunctionExpr) -> SpecialEq<Arc<dyn ColumnsUd
                 polars_plan::plans::plugin::call_plugin,
                 lib.as_ref(),
                 symbol.as_ref(),
-                kwargs.as_ref()
+                kwargs.as_ref(),
+                _allow_threading
             )
         },
 

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -612,7 +612,7 @@ fn create_physical_expr_inner(
 
             Ok(Arc::new(ApplyExpr::new(
                 input,
-                function_expr_to_udf(function.clone()),
+                function_expr_to_udf(function.clone(), state.allow_threading),
                 function_expr_to_groups_udf(&function),
                 node_to_expr(expression, expr_arena),
                 options,

--- a/crates/polars-plan/src/plans/aexpr/function_expr/plugin.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/plugin.rs
@@ -77,6 +77,7 @@ pub unsafe fn call_plugin(
     lib: &str,
     symbol: &str,
     kwargs: &[u8],
+    parallel: bool,
 ) -> PolarsResult<Column> {
     let plugin = get_lib(lib)?;
     let lib = &plugin.0;
@@ -113,7 +114,10 @@ pub unsafe fn call_plugin(
 
         let mut return_value = SeriesExport::empty();
         let return_value_ptr = &mut return_value as *mut SeriesExport;
-        let context = CallerContext::default();
+        let mut context = CallerContext::default();
+        if parallel {
+            context._set_parallel();
+        }
         let context_ptr = &context as *const CallerContext;
         symbol(
             slice_ptr,

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -2611,7 +2611,9 @@ fn lower_exprs_with_ctx(
                         format_str = Some(fmt_str.to_string());
                     },
                     AExpr::Function { function, .. } => {
-                        func = function_expr_to_udf(function.clone()).into_inner();
+                        // The streaming engine parallelizes across morsels, so a
+                        // plugin should not also thread internally.
+                        func = function_expr_to_udf(function.clone(), false).into_inner();
                         format_str = Some(function.to_string());
                     },
                     _ => unreachable!(),

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -1704,7 +1704,9 @@ pub fn lower_ir(
                             ctx,
                         );
                     } else {
-                        let func = function_expr_to_udf(function.clone()).into_inner();
+                        // The streaming engine parallelizes across morsels, so a
+                        // plugin should not also thread internally.
+                        let func = function_expr_to_udf(function.clone(), false).into_inner();
                         let format_str = Some(format!("COLUMNAR {function}"));
                         PhysNodeKind::ColumnarFunction {
                             inputs: trans_inputs,


### PR DESCRIPTION
Fixes #27729

When a plugin expression calls `context.parallel()` it always returned `false`, because `call_plugin` built a `CallerContext::default()` and `_set_parallel()` was never called anywhere in the codebase.

Thread the `allow_threading` state from the planner through `function_expr_to_udf` into the plugin call and set the parallel bit on the `CallerContext` accordingly. The streaming engine lowers plugin functions with `allow_threading = false`, since it parallelizes across morsels and a plugin should not also thread internally.

Validation note: this compiles and the existing plugin tests pass, but the example plugin's `pig_latinnify_with_parallelism` (the only consumer of `context.parallel()`) isn't wired into CI, so the end-to-end round-trip isn't covered by an automated test. Happy to add a harness if that's preferred.