### PR TITLE
fix(docs): Grammar corrections (recommend to → recommend, allows to → allows using)

### DIFF
--- a/docs/source/polars-cloud/index.md
+++ b/docs/source/polars-cloud/index.md
@@ -9,7 +9,7 @@ own APIs and limitations.
 
 Polars is bridging this gap with **Polars Cloud**. Build on top of the popular open source project,
 Polars Cloud enables you to write DataFrame code once and run it anywhere. The distributed engine
-available with Polars Cloud allows to scale your Polars queries beyond a single machine.
+available with Polars Cloud lets you scale your Polars queries beyond a single machine.
 
 ## Key Features of Polars Cloud
 

--- a/docs/source/polars-on-premises/bare-metal/configuration/monitoring.md
+++ b/docs/source/polars-on-premises/bare-metal/configuration/monitoring.md
@@ -50,7 +50,7 @@ a cluster with 32 worker nodes, with a history of 1 hour, you would need around
 
 The host metrics exporter supports collecting CPU and memory usage metrics from the process tree,
 and cgroups v1 and v2. Since traversing the process tree, and collecting metrics for each process is
-quite compute expensive, and a cgroup's usage can be instantly queried, we recommend to always run
+quite compute expensive, and a cgroup's usage can be instantly queried, we recommend always running
 Polars On-Prem in a cgroup.
 
 If you don't use the dashboard's host metrics feature, we recommend disabling the host metrics

--- a/docs/source/user-guide/ecosystem.md
+++ b/docs/source/user-guide/ecosystem.md
@@ -116,7 +116,7 @@ transformations of Polars dataframes, or selecting points on a Polars-backed rea
 #### Narwhals
 
 [Narwhals](https://narwhals-dev.github.io/narwhals/) is a lightweight compatibility layer between
-dataframe libraries. It mirrors the Polars API and allows to run Polars natively, without any
+dataframe libraries. It mirrors the Polars API and lets you run Polars natively, without any
 conversion overhead, in libraries like Plotly and others that have adopted it for dataframe
 interoperability.
 

--- a/docs/source/user-guide/sql/intro.md
+++ b/docs/source/user-guide/sql/intro.md
@@ -82,7 +82,7 @@ SQL queries can be executed just as easily from multiple sources. In the example
 - a NDJSON file (loaded lazily)
 - a Pandas DataFrame
 
-And join them together using SQL. Lazy reading allows to only load the necessary rows and columns
+And join them together using SQL. Lazy reading lets you only load the necessary rows and columns
 from the files.
 
 In the same way, it's possible to register cloud datalakes (S3, Azure Data Lake). A PyArrow dataset

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -998,7 +998,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         Allows to alter the lazy frame during the plan stage with the resolved schema.
 
         In contrast to `pipe`, this method does not execute `function` immediately but
-        only during the plan stage. This allows to use the resolved schema of the input
+        only during the plan stage. This allows using the resolved schema of the input
         to dynamically alter the lazy frame. This also means that any exceptions raised
         by `function` will only be emitted during the plan stage.
 


### PR DESCRIPTION
Fixes grammar issues in documentation and docstrings:

- 'recommend to always run' → 'recommend always running'
- 'allows to run' → 'lets you run'
- 'allows to only' → 'lets you only'
- 'allows to scale' → 'lets you scale'
- 'allows to use' → 'allows using'