### PR TITLE
fix: correct typo 'didnt't' to 'didn''t' in ADBC comment

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -4583,7 +4583,7 @@ class DataFrame:
                 if adbc_module_name.split("_")[-1] == "sqlite":
                     catalog, db_schema = db_schema, None
 
-                    # note: ADBC didnt't support 'replace' until adbc-driver-sqlite
+                    # note: ADBC didn't support 'replace' until adbc-driver-sqlite
                     # version 0.11 (it was released for other drivers in version 0.7)
                     if (
                         driver_manager_version >= (0, 7)


### PR DESCRIPTION
Fixes a typo in a code comment: `didnt't` → `didn't`