### PR TITLE
fix: Add a deprecation warning for `.explode()` without `empty_as_null` argument

### DIFF
--- a/docs/source/src/python/user-guide/expressions/lists.py
+++ b/docs/source/src/python/user-guide/expressions/lists.py
@@ -90,7 +90,7 @@ print(weather)
 # --8<-- [end:split]
 
 # --8<-- [start:explode]
-result = weather.explode("temperatures")
+result = weather.explode("temperatures", empty_as_null=False)
 print(result)
 # --8<-- [end:explode]
 

--- a/docs/source/src/python/user-guide/expressions/window.py
+++ b/docs/source/src/python/user-guide/expressions/window.py
@@ -42,7 +42,7 @@ result = (
         pl.col("Speed").rank("dense", descending=True).alias("Speed rank"),
     )
     .select(pl.col("Name"), pl.col("Type 1"), pl.col("Speed rank"))
-    .explode("Name", "Speed rank")
+    .explode("Name", "Speed rank", empty_as_null=False)
 )
 
 print(result)

--- a/py-polars/src/polars/_utils/various.py
+++ b/py-polars/src/polars/_utils/various.py
@@ -73,6 +73,9 @@ if sys.version_info >= (3, 11):
     _views: list[Reversible[Any]] = [{}.keys(), {}.values(), {}.items()]
     _reverse_mapping_views = tuple(type(reversed(view)) for view in _views)
 
+# Sentinel value to disallow None
+_Omitted = object()
+
 
 def _process_null_values(
     null_values: None | str | Sequence[str] | dict[str, str] = None,

--- a/py-polars/src/polars/_utils/various.py
+++ b/py-polars/src/polars/_utils/various.py
@@ -74,7 +74,7 @@ if sys.version_info >= (3, 11):
     _reverse_mapping_views = tuple(type(reversed(view)) for view in _views)
 
 # Sentinel value to disallow None
-_Omitted = object()
+_Omitted: Any = object()
 
 
 def _process_null_values(

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -71,6 +71,7 @@ from polars._utils.unstable import issue_unstable_warning, unstable
 from polars._utils.various import (
     NO_DEFAULT,
     _in_notebook,
+    _Omitted,
     is_bool_sequence,
     normalize_filepath,
     parse_version,
@@ -9455,7 +9456,7 @@ class DataFrame:
         self,
         columns: ColumnNameOrSelector | Iterable[ColumnNameOrSelector],
         *more_columns: ColumnNameOrSelector,
-        empty_as_null: bool | None = None,
+        empty_as_null: bool = _Omitted,
         keep_nulls: bool = True,
     ) -> DataFrame:
         """
@@ -9497,7 +9498,7 @@ class DataFrame:
         │ b       ┆ [4, 5]    │
         │ c       ┆ [6, 7, 8] │
         └─────────┴───────────┘
-        >>> df.explode("numbers")
+        >>> df.explode("numbers", empty_as_null=False)
         shape: (8, 2)
         ┌─────────┬─────────┐
         │ letters ┆ numbers │

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -9455,7 +9455,7 @@ class DataFrame:
         self,
         columns: ColumnNameOrSelector | Iterable[ColumnNameOrSelector],
         *more_columns: ColumnNameOrSelector,
-        empty_as_null: bool = True,
+        empty_as_null: bool | None = None,
         keep_nulls: bool = True,
     ) -> DataFrame:
         """

--- a/py-polars/src/polars/expr/array.py
+++ b/py-polars/src/polars/expr/array.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from polars import functions as F
+from polars._utils.deprecation import issue_deprecation_warning
 from polars._utils.parse import parse_into_expression
 from polars._utils.wrap import wrap_expr
 
@@ -786,7 +787,9 @@ class ExprArrayNameSpace:
         separator_pyexpr = parse_into_expression(separator, str_as_lit=True)
         return wrap_expr(self._pyexpr.arr_join(separator_pyexpr, ignore_nulls))
 
-    def explode(self, *, empty_as_null: bool = True, keep_nulls: bool = True) -> Expr:
+    def explode(
+        self, *, empty_as_null: bool | None = None, keep_nulls: bool = True
+    ) -> Expr:
         """
         Returns a column with a separate row for every array element.
 
@@ -822,6 +825,13 @@ class ExprArrayNameSpace:
         │ 6   │
         └─────┘
         """
+        if empty_as_null is None:
+            issue_deprecation_warning(
+                "In Polars 2.0, the default behavior for `empty_as_null` will change to `False`. "
+                "To keep the current behavior, explicitly set `empty_as_null=True`."
+            )
+            empty_as_null = True
+
         return wrap_expr(
             self._pyexpr.arr_explode(empty_as_null=empty_as_null, keep_nulls=keep_nulls)
         )

--- a/py-polars/src/polars/expr/array.py
+++ b/py-polars/src/polars/expr/array.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from polars import functions as F
 from polars._utils.deprecation import issue_deprecation_warning
 from polars._utils.parse import parse_into_expression
+from polars._utils.various import _Omitted
 from polars._utils.wrap import wrap_expr
 
 if TYPE_CHECKING:
@@ -788,7 +789,7 @@ class ExprArrayNameSpace:
         return wrap_expr(self._pyexpr.arr_join(separator_pyexpr, ignore_nulls))
 
     def explode(
-        self, *, empty_as_null: bool | None = None, keep_nulls: bool = True
+        self, *, empty_as_null: bool = _Omitted, keep_nulls: bool = True
     ) -> Expr:
         """
         Returns a column with a separate row for every array element.
@@ -825,7 +826,7 @@ class ExprArrayNameSpace:
         │ 6   │
         └─────┘
         """
-        if empty_as_null is None:
+        if empty_as_null is _Omitted:
             issue_deprecation_warning(
                 "In Polars 2.0, the default behavior for `empty_as_null` will change to `False`. "
                 "To keep the current behavior, explicitly set `empty_as_null=True`."

--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -38,6 +38,7 @@ from polars._utils.unstable import issue_unstable_warning, unstable
 from polars._utils.various import (
     BUILDING_SPHINX_DOCS,
     NO_DEFAULT,
+    _Omitted,
     extend_bool,
     normalize_filepath,
     sphinx_accessor,
@@ -5378,7 +5379,7 @@ Consider using {self}.implode() instead"""
         return self.explode(empty_as_null=True, keep_nulls=True)
 
     def explode(
-        self, *, empty_as_null: bool | None = None, keep_nulls: bool = True
+        self, *, empty_as_null: bool = _Omitted, keep_nulls: bool = True
     ) -> Expr:
         """
         Explode a list expression.
@@ -5425,7 +5426,7 @@ Consider using {self}.implode() instead"""
         │ 4      │
         └────────┘
         """
-        if empty_as_null is None:
+        if empty_as_null is _Omitted:
             issue_deprecation_warning(
                 "In Polars 2.0, the default behavior for `empty_as_null` will change to `False`. "
                 "To keep the current behavior, explicitly set `empty_as_null=True`."

--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -5377,7 +5377,9 @@ Consider using {self}.implode() instead"""
         """
         return self.explode(empty_as_null=True, keep_nulls=True)
 
-    def explode(self, *, empty_as_null: bool = True, keep_nulls: bool = True) -> Expr:
+    def explode(
+        self, *, empty_as_null: bool | None = None, keep_nulls: bool = True
+    ) -> Expr:
         """
         Explode a list expression.
 
@@ -5423,6 +5425,13 @@ Consider using {self}.implode() instead"""
         │ 4      │
         └────────┘
         """
+        if empty_as_null is None:
+            issue_deprecation_warning(
+                "In Polars 2.0, the default behavior for `empty_as_null` will change to `False`. "
+                "To keep the current behavior, explicitly set `empty_as_null=True`."
+            )
+            empty_as_null = True
+
         return wrap_expr(
             self._pyexpr.explode(empty_as_null=empty_as_null, keep_nulls=keep_nulls)
         )

--- a/py-polars/src/polars/expr/list.py
+++ b/py-polars/src/polars/expr/list.py
@@ -10,7 +10,7 @@ from polars import functions as F
 from polars._utils.deprecation import issue_deprecation_warning
 from polars._utils.parse import parse_into_expression
 from polars._utils.unstable import unstable
-from polars._utils.various import _NamespaceSuggestMixin
+from polars._utils.various import _NamespaceSuggestMixin, _Omitted
 from polars._utils.wrap import wrap_expr
 from polars._warnings import issue_warning
 
@@ -1115,7 +1115,7 @@ class ExprListNameSpace(_NamespaceSuggestMixin):
         return wrap_expr(self._pyexpr.list_tail(n_pyexpr))
 
     def explode(
-        self, *, empty_as_null: bool | None = None, keep_nulls: bool = True
+        self, *, empty_as_null: bool = _Omitted, keep_nulls: bool = True
     ) -> Expr:
         """
         Returns a column with a separate row for every list element.
@@ -1139,7 +1139,7 @@ class ExprListNameSpace(_NamespaceSuggestMixin):
         Examples
         --------
         >>> df = pl.DataFrame({"a": [[1, 2, 3], [4, 5, 6]]})
-        >>> df.select(pl.col("a").list.explode())
+        >>> df.select(pl.col("a").list.explode(empty_as_null=False))
         shape: (6, 1)
         ┌─────┐
         │ a   │
@@ -1154,7 +1154,7 @@ class ExprListNameSpace(_NamespaceSuggestMixin):
         │ 6   │
         └─────┘
         """
-        if empty_as_null is None:
+        if empty_as_null is _Omitted:
             issue_deprecation_warning(
                 "In Polars 2.0, the default behavior for `empty_as_null` will change to `False`. "
                 "To keep the current behavior, explicitly set `empty_as_null=True`."

--- a/py-polars/src/polars/expr/list.py
+++ b/py-polars/src/polars/expr/list.py
@@ -7,11 +7,12 @@ from typing import TYPE_CHECKING, Any
 import polars._reexport as pl
 from polars import exceptions
 from polars import functions as F
+from polars._utils.deprecation import issue_deprecation_warning
 from polars._utils.parse import parse_into_expression
 from polars._utils.unstable import unstable
 from polars._utils.various import _NamespaceSuggestMixin
 from polars._utils.wrap import wrap_expr
-from polars._warnings import issue_deprecation_warning, issue_warning
+from polars._warnings import issue_warning
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/py-polars/src/polars/expr/list.py
+++ b/py-polars/src/polars/expr/list.py
@@ -11,7 +11,7 @@ from polars._utils.parse import parse_into_expression
 from polars._utils.unstable import unstable
 from polars._utils.various import _NamespaceSuggestMixin
 from polars._utils.wrap import wrap_expr
-from polars._warnings import issue_warning
+from polars._warnings import issue_deprecation_warning, issue_warning
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -1113,7 +1113,9 @@ class ExprListNameSpace(_NamespaceSuggestMixin):
         n_pyexpr = parse_into_expression(n)
         return wrap_expr(self._pyexpr.list_tail(n_pyexpr))
 
-    def explode(self, *, empty_as_null: bool = True, keep_nulls: bool = True) -> Expr:
+    def explode(
+        self, *, empty_as_null: bool | None = None, keep_nulls: bool = True
+    ) -> Expr:
         """
         Returns a column with a separate row for every list element.
 
@@ -1151,6 +1153,13 @@ class ExprListNameSpace(_NamespaceSuggestMixin):
         │ 6   │
         └─────┘
         """
+        if empty_as_null is None:
+            issue_deprecation_warning(
+                "In Polars 2.0, the default behavior for `empty_as_null` will change to `False`. "
+                "To keep the current behavior, explicitly set `empty_as_null=True`."
+            )
+            empty_as_null = True
+
         return wrap_expr(
             self._pyexpr.explode(empty_as_null=empty_as_null, keep_nulls=keep_nulls)
         )

--- a/py-polars/src/polars/expr/string.py
+++ b/py-polars/src/polars/expr/string.py
@@ -2481,20 +2481,15 @@ class ExprStringNameSpace(_NamespaceSuggestMixin):
         return wrap_expr(self._pyexpr.str_tail(n_pyexpr))
 
     @deprecated(
-        '`str.explode` is deprecated; use `str.split("").explode()` instead.'
-        " Note that empty strings will result in null instead of being preserved."
-        " To get the exact same behavior, split first and then use a `pl.when...then...otherwise`"
-        " expression to handle the empty list before exploding."
+        '`str.explode` is deprecated; use `str.split("").explode(empty_as_null=False)` instead.'
     )
     def explode(self) -> Expr:
         """
         Returns a column with a separate row for every string character.
 
         .. deprecated:: 0.20.31
-            Use the `.str.split("").explode()` method instead. Note that empty strings
-            will result in null instead of being preserved. To get the exact same
-            behavior, split first and then use a `pl.when...then...otherwise`
-            expression to handle the empty list before exploding.
+            '`str.explode` is deprecated; use
+            `str.split("").explode(empty_as_null=False)` instead.'
 
         Returns
         -------

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -8126,7 +8126,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         self,
         columns: ColumnNameOrSelector | Iterable[ColumnNameOrSelector],
         *more_columns: ColumnNameOrSelector,
-        empty_as_null: bool = True,
+        empty_as_null: bool | None = None,
         keep_nulls: bool = True,
     ) -> LazyFrame:
         """
@@ -8169,6 +8169,12 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ c       ┆ 8       │
         └─────────┴─────────┘
         """
+        if empty_as_null is None:
+            issue_deprecation_warning(
+                "In Polars 2.0, the default behavior for `empty_as_null` will change to `False`. "
+                "To keep the current behavior, explicitly set `empty_as_null=True`."
+            )
+            empty_as_null = True
         subset = parse_list_into_selector(columns) | parse_list_into_selector(  # type: ignore[arg-type]
             more_columns
         )

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -54,6 +54,7 @@ from polars._utils.slice import LazyPolarsSlice
 from polars._utils.unstable import issue_unstable_warning, unstable
 from polars._utils.various import (
     _is_generator,
+    _Omitted,
     display_dot_graph,
     extend_bool,
     is_bool_sequence,
@@ -8126,7 +8127,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         self,
         columns: ColumnNameOrSelector | Iterable[ColumnNameOrSelector],
         *more_columns: ColumnNameOrSelector,
-        empty_as_null: bool | None = None,
+        empty_as_null: bool = _Omitted,
         keep_nulls: bool = True,
     ) -> LazyFrame:
         """
@@ -8152,7 +8153,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...         "numbers": [[1], [2, 3], [4, 5], [6, 7, 8]],
         ...     }
         ... )
-        >>> lf.explode("numbers").collect()
+        >>> lf.explode("numbers", empty_as_null=False).collect()
         shape: (8, 2)
         ┌─────────┬─────────┐
         │ letters ┆ numbers │
@@ -8169,7 +8170,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ c       ┆ 8       │
         └─────────┴─────────┘
         """
-        if empty_as_null is None:
+        if empty_as_null is _Omitted:
             issue_deprecation_warning(
                 "In Polars 2.0, the default behavior for `empty_as_null` will change to `False`. "
                 "To keep the current behavior, explicitly set `empty_as_null=True`."

--- a/py-polars/src/polars/series/array.py
+++ b/py-polars/src/polars/series/array.py
@@ -635,7 +635,9 @@ class ArrayNameSpace:
 
         """
 
-    def explode(self, *, empty_as_null: bool = True, keep_nulls: bool = True) -> Series:
+    def explode(
+        self, *, empty_as_null: bool | None = None, keep_nulls: bool = True
+    ) -> Series:
         """
         Returns a column with a separate row for every array element.
 

--- a/py-polars/src/polars/series/list.py
+++ b/py-polars/src/polars/series/list.py
@@ -833,7 +833,9 @@ class ListNameSpace(_NamespaceSuggestMixin):
         ]
         """
 
-    def explode(self, *, empty_as_null: bool = True, keep_nulls: bool = True) -> Series:
+    def explode(
+        self, *, empty_as_null: bool | None = None, keep_nulls: bool = True
+    ) -> Series:
         """
         Returns a column with a separate row for every list element.
 

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -4532,7 +4532,9 @@ class Series:
         ]
         """
 
-    def explode(self, *, empty_as_null: bool = True, keep_nulls: bool = True) -> Series:
+    def explode(
+        self, *, empty_as_null: bool | None = True, keep_nulls: bool = True
+    ) -> Series:
         """
         Explode a list Series.
 

--- a/py-polars/tests/benchmark/test_group_by.py
+++ b/py-polars/tests/benchmark/test_group_by.py
@@ -103,7 +103,7 @@ def test_groupby_h2oai_q8(groupby_data: pl.DataFrame) -> None:
         .drop_nulls("v3")
         .group_by("id6")
         .agg(pl.col("v3").top_k(2).alias("largest2_v3"))
-        .explode("largest2_v3")
+        .explode("largest2_v3", empty_as_null=True)
         .collect()
     )
 

--- a/py-polars/tests/benchmark/test_group_by.py
+++ b/py-polars/tests/benchmark/test_group_by.py
@@ -103,7 +103,7 @@ def test_groupby_h2oai_q8(groupby_data: pl.DataFrame) -> None:
         .drop_nulls("v3")
         .group_by("id6")
         .agg(pl.col("v3").top_k(2).alias("largest2_v3"))
-        .explode("largest2_v3", empty_as_null=True)
+        .explode("largest2_v3", empty_as_null=False)
         .collect()
     )
 

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -643,7 +643,7 @@ def test_map_columns() -> None:
 
 def test_explode() -> None:
     df = pl.DataFrame({"letters": ["c", "a"], "nrs": [[1, 2], [1, 3]]})
-    out = df.explode("nrs")
+    out = df.explode("nrs", empty_as_null=True)
     assert out["letters"].to_list() == ["c", "c", "a", "a"]
     assert out["nrs"].to_list() == [1, 2, 1, 3]
 
@@ -995,7 +995,7 @@ def test_head_group_by() -> None:
         df.sort(by="price", descending=True)
         .group_by(keys, maintain_order=True)
         .agg([pl.col("*").exclude(keys).head(2).name.keep()])
-        .explode(cs.all().exclude(keys))
+        .explode(cs.all().exclude(keys), empty_as_null=True)
     )
 
     assert out.shape == (5, 4)
@@ -1915,7 +1915,7 @@ def test_group_by_cat_list() -> None:
         .agg([pl.col("cat_column")])["cat_column"]
     )
 
-    out = grouped.explode()
+    out = grouped.explode(empty_as_null=True)
     assert out.dtype == pl.Categorical
     assert out[0] == "a"
 
@@ -2077,14 +2077,14 @@ def test_extension() -> None:
     out = df.group_by("groups", maintain_order=True).agg(pl.col("a").alias("a"))
     rc = sys.getrefcount(foos[0])
     assert rc == base_count + 2
-    s = out["a"].list.explode()
+    s = out["a"].list.explode(empty_as_null=True)
     rc = sys.getrefcount(foos[0])
     assert rc == base_count + 3
     del s
     rc = sys.getrefcount(foos[0])
     assert rc == base_count + 2
 
-    assert out["a"].list.explode().to_list() == foos
+    assert out["a"].list.explode(empty_as_null=True).to_list() == foos
     rc = sys.getrefcount(foos[0])
     assert rc == base_count + 2
     del out
@@ -2407,7 +2407,7 @@ def test_group_by_slice_expression_args() -> None:
     out = (
         df.group_by("groups", maintain_order=True)
         .agg([pl.col("vals").slice((pl.len() * 0.1).cast(int), (pl.len() // 5))])
-        .explode("vals")
+        .explode("vals", empty_as_null=True)
     )
 
     expected = pl.DataFrame(
@@ -2434,14 +2434,14 @@ def test_explode_empty() -> None:
         .group_by("x", maintain_order=True)
         .agg(pl.col("y").gather([]))
     )
-    assert df.explode("y").to_dict(as_series=False) == {
+    assert df.explode("y", empty_as_null=True).to_dict(as_series=False) == {
         "x": ["a", "b"],
         "y": [None, None],
     }
 
     df = pl.DataFrame({"x": ["1", "2", "4"], "y": [["a", "b", "c"], ["d"], []]})
     assert_frame_equal(
-        df.explode("y"),
+        df.explode("y", empty_as_null=True),
         pl.DataFrame({"x": ["1", "1", "1", "2", "4"], "y": ["a", "b", "c", "d", None]}),
     )
 
@@ -2451,7 +2451,7 @@ def test_explode_empty() -> None:
             "numbers": [[]],
         }
     )
-    assert df.explode("numbers").to_dict(as_series=False) == {
+    assert df.explode("numbers", empty_as_null=True).to_dict(as_series=False) == {
         "letters": ["a"],
         "numbers": [None],
     }

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -643,7 +643,7 @@ def test_map_columns() -> None:
 
 def test_explode() -> None:
     df = pl.DataFrame({"letters": ["c", "a"], "nrs": [[1, 2], [1, 3]]})
-    out = df.explode("nrs", empty_as_null=True)
+    out = df.explode("nrs", empty_as_null=False)
     assert out["letters"].to_list() == ["c", "c", "a", "a"]
     assert out["nrs"].to_list() == [1, 2, 1, 3]
 
@@ -995,7 +995,7 @@ def test_head_group_by() -> None:
         df.sort(by="price", descending=True)
         .group_by(keys, maintain_order=True)
         .agg([pl.col("*").exclude(keys).head(2).name.keep()])
-        .explode(cs.all().exclude(keys), empty_as_null=True)
+        .explode(cs.all().exclude(keys), empty_as_null=False)
     )
 
     assert out.shape == (5, 4)
@@ -1915,7 +1915,7 @@ def test_group_by_cat_list() -> None:
         .agg([pl.col("cat_column")])["cat_column"]
     )
 
-    out = grouped.explode(empty_as_null=True)
+    out = grouped.explode(empty_as_null=False)
     assert out.dtype == pl.Categorical
     assert out[0] == "a"
 
@@ -2077,14 +2077,14 @@ def test_extension() -> None:
     out = df.group_by("groups", maintain_order=True).agg(pl.col("a").alias("a"))
     rc = sys.getrefcount(foos[0])
     assert rc == base_count + 2
-    s = out["a"].list.explode(empty_as_null=True)
+    s = out["a"].list.explode(empty_as_null=False)
     rc = sys.getrefcount(foos[0])
     assert rc == base_count + 3
     del s
     rc = sys.getrefcount(foos[0])
     assert rc == base_count + 2
 
-    assert out["a"].list.explode(empty_as_null=True).to_list() == foos
+    assert out["a"].list.explode(empty_as_null=False).to_list() == foos
     rc = sys.getrefcount(foos[0])
     assert rc == base_count + 2
     del out
@@ -2407,7 +2407,7 @@ def test_group_by_slice_expression_args() -> None:
     out = (
         df.group_by("groups", maintain_order=True)
         .agg([pl.col("vals").slice((pl.len() * 0.1).cast(int), (pl.len() // 5))])
-        .explode("vals", empty_as_null=True)
+        .explode("vals", empty_as_null=False)
     )
 
     expected = pl.DataFrame(

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -510,7 +510,7 @@ def test_decimal_explode() -> None:
             "bar": [[D("3.4"), D("3.4")], [D("4.5")]],
         }
     )
-    df = nested_decimal_df.explode("bar")
+    df = nested_decimal_df.explode("bar", empty_as_null=True)
     expected_df = pl.DataFrame(
         {
             "bar": [D("3.4"), D("3.4"), D("4.5")],

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -510,7 +510,7 @@ def test_decimal_explode() -> None:
             "bar": [[D("3.4"), D("3.4")], [D("4.5")]],
         }
     )
-    df = nested_decimal_df.explode("bar", empty_as_null=True)
+    df = nested_decimal_df.explode("bar", empty_as_null=False)
     expected_df = pl.DataFrame(
         {
             "bar": [D("3.4"), D("3.4"), D("4.5")],

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -206,7 +206,7 @@ def test_categorical_list() -> None:
     assert s.dtype == pl.List
     assert s.dtype.inner == pl.Categorical  # type: ignore[attr-defined]
     assert s.to_list() == values
-    assert s.explode(empty_as_null=True).to_list() == ["a", "b", "c", "a", "d", "d"]
+    assert s.explode(empty_as_null=False).to_list() == ["a", "b", "c", "a", "d", "d"]
 
 
 def test_group_by_list_column() -> None:
@@ -342,7 +342,7 @@ def test_list_sum_and_dtypes() -> None:
         )
 
         assert_frame_equal(
-            df.select("a").explode("a", empty_as_null=True).sum(),
+            df.select("a").explode("a", empty_as_null=False).sum(),
             pl.DataFrame(pl.Series("a", [32], dtype=dt_out)),
             check_dtypes=True,
             check_exact=True,
@@ -546,7 +546,7 @@ def test_logical_parallel_list_collect() -> None:
         )
         .group_by("Group")
         .agg(pl.col("Values").value_counts(sort=True))
-        .explode("Values", empty_as_null=True)
+        .explode("Values", empty_as_null=False)
         .unnest("Values")
     )
     assert out.dtypes == [pl.String, pl.Categorical, pl.get_index_type()]
@@ -638,7 +638,7 @@ def test_struct_with_nulls_as_list() -> None:
 def test_list_amortized_iter_clear_settings_10126() -> None:
     out = (
         pl.DataFrame({"a": [[1], [1], [2]], "b": [[1, 2], [1, 3], [4]]})
-        .explode("a", empty_as_null=True)
+        .explode("a", empty_as_null=False)
         .group_by("a")
         .agg(pl.col("b").list.explode(keep_nulls=False, empty_as_null=False))
         .with_columns(pl.col("b").list.unique())
@@ -887,7 +887,7 @@ def test_sort() -> None:
 def test_list_agg_temporal(inner_dtype: PolarsDataType, agg: str) -> None:
     lf = pl.LazyFrame({"a": [[1, 3]]}, schema={"a": pl.List(inner_dtype)})
     result = lf.select(getattr(pl.col("a").list, agg)())
-    expected = lf.select(getattr(pl.col("a").explode(empty_as_null=True), agg)())
+    expected = lf.select(getattr(pl.col("a").explode(empty_as_null=False), agg)())
     assert result.collect_schema() == expected.collect_schema()
     assert_frame_equal(result.collect(), expected.collect())
 

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -206,7 +206,7 @@ def test_categorical_list() -> None:
     assert s.dtype == pl.List
     assert s.dtype.inner == pl.Categorical  # type: ignore[attr-defined]
     assert s.to_list() == values
-    assert s.explode().to_list() == ["a", "b", "c", "a", "d", "d"]
+    assert s.explode(empty_as_null=True).to_list() == ["a", "b", "c", "a", "d", "d"]
 
 
 def test_group_by_list_column() -> None:
@@ -283,7 +283,7 @@ def test_fast_explode_on_list_struct_6208() -> None:
     )
 
     assert not df["parents"].flags["FAST_EXPLODE"]
-    assert df.explode("parents").to_dict(as_series=False) == {
+    assert df.explode("parents", empty_as_null=True).to_dict(as_series=False) == {
         "label": ["l", "l"],
         "tag": ["t", "t"],
         "ref": [1, 1],
@@ -342,7 +342,7 @@ def test_list_sum_and_dtypes() -> None:
         )
 
         assert_frame_equal(
-            df.select("a").explode("a").sum(),
+            df.select("a").explode("a", empty_as_null=True).sum(),
             pl.DataFrame(pl.Series("a", [32], dtype=dt_out)),
             check_dtypes=True,
             check_exact=True,
@@ -356,7 +356,7 @@ def test_list_sum_and_dtypes() -> None:
 
         # include nulls in the list
         assert_frame_equal(
-            df.select("b").explode("b").sum(),
+            df.select("b").explode("b", empty_as_null=True).sum(),
             pl.DataFrame(pl.Series("b", [19], dtype=dt_out)),
             check_dtypes=True,
             check_exact=True,
@@ -546,7 +546,7 @@ def test_logical_parallel_list_collect() -> None:
         )
         .group_by("Group")
         .agg(pl.col("Values").value_counts(sort=True))
-        .explode("Values")
+        .explode("Values", empty_as_null=True)
         .unnest("Values")
     )
     assert out.dtypes == [pl.String, pl.Categorical, pl.get_index_type()]
@@ -638,7 +638,7 @@ def test_struct_with_nulls_as_list() -> None:
 def test_list_amortized_iter_clear_settings_10126() -> None:
     out = (
         pl.DataFrame({"a": [[1], [1], [2]], "b": [[1, 2], [1, 3], [4]]})
-        .explode("a")
+        .explode("a", empty_as_null=True)
         .group_by("a")
         .agg(pl.col("b").list.explode(keep_nulls=False, empty_as_null=False))
         .with_columns(pl.col("b").list.unique())
@@ -804,9 +804,9 @@ def test_take_list_15719() -> None:
         {"a": [None, None], "b": [None, [[1, 2]]]}, schema={"a": schema, "b": schema}
     )
     df = df.select(
-        a_explode=pl.col("a").explode(),
+        a_explode=pl.col("a").explode(empty_as_null=True),
         a_get=pl.col("a").list.get(0, null_on_oob=True),
-        b_explode=pl.col("b").explode(),
+        b_explode=pl.col("b").explode(empty_as_null=True),
         b_get=pl.col("b").list.get(0, null_on_oob=True),
     )
 
@@ -887,7 +887,7 @@ def test_sort() -> None:
 def test_list_agg_temporal(inner_dtype: PolarsDataType, agg: str) -> None:
     lf = pl.LazyFrame({"a": [[1, 3]]}, schema={"a": pl.List(inner_dtype)})
     result = lf.select(getattr(pl.col("a").list, agg)())
-    expected = lf.select(getattr(pl.col("a").explode(), agg)())
+    expected = lf.select(getattr(pl.col("a").explode(empty_as_null=True), agg)())
     assert result.collect_schema() == expected.collect_schema()
     assert_frame_equal(result.collect(), expected.collect())
 

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -515,7 +515,7 @@ def test_nested_explode_4026() -> None:
         }
     )
 
-    assert df.explode("data").to_dict(as_series=False) == {
+    assert df.explode("data", empty_as_null=True).to_dict(as_series=False) == {
         "data": [
             {"account_id": 10, "values": [1, 2]},
             {"account_id": 11, "values": [10, 20]},
@@ -1362,7 +1362,7 @@ def test_struct_arithmetic_broadcast_21376() -> None:
     )
     out = (
         df.with_row_index()
-        .explode("list_struct")
+        .explode("list_struct", empty_as_null=True)
         .select((pl.col("struct1") + pl.col("list_struct")).alias("add_struct"))
     )
     assert_frame_equal(out, expected)

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -502,7 +502,8 @@ def test_list_of_struct_unique() -> None:
     assert {"a": 1, "b": 11} in unique_el
 
 
-def test_nested_explode_4026() -> None:
+@pytest.mark.parametrize("empty_as_null", [False, True])
+def test_nested_explode_4026(empty_as_null: bool) -> None:
     df = pl.DataFrame(
         {
             "data": [
@@ -515,7 +516,7 @@ def test_nested_explode_4026() -> None:
         }
     )
 
-    assert df.explode("data", empty_as_null=True).to_dict(as_series=False) == {
+    assert df.explode("data", empty_as_null=empty_as_null).to_dict(as_series=False) == {
         "data": [
             {"account_id": 10, "values": [1, 2]},
             {"account_id": 11, "values": [10, 20]},
@@ -1346,7 +1347,8 @@ def test_zip_outer_validity_infinite_recursion_21267() -> None:
     )
 
 
-def test_struct_arithmetic_broadcast_21376() -> None:
+@pytest.mark.parametrize("empty_as_null", [False, True])
+def test_struct_arithmetic_broadcast_21376(empty_as_null: bool) -> None:
     df = pl.DataFrame(
         {
             "struct1": [{"low": 1, "mid": 2, "up": 3}],
@@ -1362,7 +1364,7 @@ def test_struct_arithmetic_broadcast_21376() -> None:
     )
     out = (
         df.with_row_index()
-        .explode("list_struct", empty_as_null=True)
+        .explode("list_struct", empty_as_null=empty_as_null)
         .select((pl.col("struct1") + pl.col("list_struct")).alias("add_struct"))
     )
     assert_frame_equal(out, expected)

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -507,7 +507,7 @@ def test_explode_date() -> None:
         out = (
             df.group_by("b", maintain_order=True)
             .agg([pl.col("a"), pl.col("c").pct_change()])
-            .explode(["a", "c"])
+            .explode(["a", "c"], empty_as_null=True)
         )
         assert out.shape == (4, 3)
         assert out.rows() == [

--- a/py-polars/tests/unit/functions/range/test_datetime_ranges.py
+++ b/py-polars/tests/unit/functions/range/test_datetime_ranges.py
@@ -114,7 +114,7 @@ def test_datetime_ranges_schema(
         .dt.replace_time_zone(values_time_zone)
         .dt.cast_time_unit(values_time_unit),
         pl.col("datetime_range")
-        .explode(empty_as_null=True)
+        .explode(empty_as_null=False)
         .dt.replace_time_zone(output_time_zone)
         .dt.cast_time_unit(output_time_unit)
         .implode(),
@@ -214,7 +214,7 @@ def test_datetime_ranges_schema_upcasts_to_datetime(
         }
     ).with_columns(
         pl.col("datetime_range")
-        .explode(empty_as_null=True)
+        .explode(empty_as_null=False)
         .dt.cast_time_unit(output_dtype.time_unit)  # type: ignore[union-attr]
         .dt.replace_time_zone(output_dtype.time_zone)  # type: ignore[union-attr]
         .implode(),
@@ -232,7 +232,7 @@ def test_datetime_ranges_schema_upcasts_to_datetime(
     ).alias("datetime")
     assert_series_equal(
         result_single,
-        expected["datetime_range"].explode(empty_as_null=True).rename("datetime"),
+        expected["datetime_range"].explode(empty_as_null=False).rename("datetime"),
     )
 
 

--- a/py-polars/tests/unit/functions/range/test_datetime_ranges.py
+++ b/py-polars/tests/unit/functions/range/test_datetime_ranges.py
@@ -114,7 +114,7 @@ def test_datetime_ranges_schema(
         .dt.replace_time_zone(values_time_zone)
         .dt.cast_time_unit(values_time_unit),
         pl.col("datetime_range")
-        .explode()
+        .explode(empty_as_null=True)
         .dt.replace_time_zone(output_time_zone)
         .dt.cast_time_unit(output_time_unit)
         .implode(),
@@ -214,7 +214,7 @@ def test_datetime_ranges_schema_upcasts_to_datetime(
         }
     ).with_columns(
         pl.col("datetime_range")
-        .explode()
+        .explode(empty_as_null=True)
         .dt.cast_time_unit(output_dtype.time_unit)  # type: ignore[union-attr]
         .dt.replace_time_zone(output_dtype.time_zone)  # type: ignore[union-attr]
         .implode(),
@@ -231,7 +231,8 @@ def test_datetime_ranges_schema_upcasts_to_datetime(
         eager=True,
     ).alias("datetime")
     assert_series_equal(
-        result_single, expected["datetime_range"].explode().rename("datetime")
+        result_single,
+        expected["datetime_range"].explode(empty_as_null=True).rename("datetime"),
     )
 
 

--- a/py-polars/tests/unit/functions/range/test_time_range.py
+++ b/py-polars/tests/unit/functions/range/test_time_range.py
@@ -147,7 +147,7 @@ def test_time_range_lit_eager() -> None:
         ).alias("tm")
     )
     if not eager:
-        tm = tm.select(pl.col("tm").explode(empty_as_null=True))
+        tm = tm.select(pl.col("tm").explode(empty_as_null=False))
     assert tm["tm"].to_list() == [
         time(6, 47, 13, 333000),
         time(12, 32, 23, 666000),
@@ -162,7 +162,7 @@ def test_time_range_lit_eager() -> None:
         ).alias("tm")
     )
     if not eager:
-        tm = tm.select(pl.col("tm").explode(empty_as_null=True))
+        tm = tm.select(pl.col("tm").explode(empty_as_null=False))
     assert tm["tm"].to_list() == [
         time(0, 0),
         time(5, 45, 10, 333000),
@@ -178,7 +178,7 @@ def test_time_range_lit_eager() -> None:
             eager=eager,
         ).alias("tm")
     )
-    tm = tm.select(pl.col("tm").explode(empty_as_null=True))
+    tm = tm.select(pl.col("tm").explode(empty_as_null=False))
     assert tm["tm"].to_list() == [
         time(23, 59, 59, 999980),
         time(23, 59, 59, 999990),

--- a/py-polars/tests/unit/functions/range/test_time_range.py
+++ b/py-polars/tests/unit/functions/range/test_time_range.py
@@ -147,7 +147,7 @@ def test_time_range_lit_eager() -> None:
         ).alias("tm")
     )
     if not eager:
-        tm = tm.select(pl.col("tm").explode())
+        tm = tm.select(pl.col("tm").explode(empty_as_null=True))
     assert tm["tm"].to_list() == [
         time(6, 47, 13, 333000),
         time(12, 32, 23, 666000),
@@ -162,7 +162,7 @@ def test_time_range_lit_eager() -> None:
         ).alias("tm")
     )
     if not eager:
-        tm = tm.select(pl.col("tm").explode())
+        tm = tm.select(pl.col("tm").explode(empty_as_null=True))
     assert tm["tm"].to_list() == [
         time(0, 0),
         time(5, 45, 10, 333000),
@@ -178,7 +178,7 @@ def test_time_range_lit_eager() -> None:
             eager=eager,
         ).alias("tm")
     )
-    tm = tm.select(pl.col("tm").explode())
+    tm = tm.select(pl.col("tm").explode(empty_as_null=True))
     assert tm["tm"].to_list() == [
         time(23, 59, 59, 999980),
         time(23, 59, 59, 999990),

--- a/py-polars/tests/unit/functions/test_when_then.py
+++ b/py-polars/tests/unit/functions/test_when_then.py
@@ -338,7 +338,7 @@ def test_single_element_broadcast(
         .drop("key")
     )
     if expected.height > 1:
-        result = result.explode(cs.all())
+        result = result.explode(cs.all(), empty_as_null=True)
     assert_frame_equal(result, expected, check_row_order=maintain_order)
 
 
@@ -382,7 +382,7 @@ def test_when_then_output_name_12380(maintain_order: bool) -> None:
             df.group_by(pl.lit(True).alias("key"), maintain_order=maintain_order)
             .agg(ternary_expr)
             .drop("key")
-            .explode(cs.all())
+            .explode(cs.all(), empty_as_null=True)
         )
         assert_frame_equal(expect, actual, check_row_order=maintain_order)
 
@@ -406,7 +406,7 @@ def test_when_then_output_name_12380(maintain_order: bool) -> None:
             df.group_by(pl.lit(True).alias("key"))
             .agg(ternary_expr)
             .drop("key")
-            .explode(cs.all())
+            .explode(cs.all(), empty_as_null=True)
         )
         assert_frame_equal(
             expect,

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -1274,7 +1274,9 @@ def test_pycapsule_stream_interface_all_types() -> None:
     assert_frame_equal(
         df.map_columns(
             pl.selectors.all(),
-            lambda s: pl.Series(PyCapsuleStreamHolder(s.implode())).explode(),
+            lambda s: pl.Series(PyCapsuleStreamHolder(s.implode())).explode(
+                empty_as_null=True
+            ),
         ),
         df,
     )
@@ -1292,7 +1294,9 @@ def test_pycapsule_stream_interface_all_types() -> None:
         pl.DataFrame(PyCapsuleStreamHolder(df.select(pl.struct("*")))).unnest("*"), df
     )
     assert_frame_equal(
-        pl.DataFrame(PyCapsuleStreamHolder(df.select(pl.all().implode()))).explode("*"),
+        pl.DataFrame(PyCapsuleStreamHolder(df.select(pl.all().implode()))).explode(
+            "*", empty_as_null=True
+        ),
         df,
     )
     assert_frame_equal(

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -414,7 +414,9 @@ def test_parquet_different_schema(tmp_path: Path, streaming: bool) -> None:
 @pytest.mark.write_disk
 def test_nested_slice_12480(tmp_path: Path) -> None:
     path = tmp_path / "data.parquet"
-    df = pl.select(pl.lit(1).repeat_by(10_000).explode().cast(pl.List(pl.Int32)))
+    df = pl.select(
+        pl.lit(1).repeat_by(10_000).explode(empty_as_null=True).cast(pl.List(pl.Int32))
+    )
 
     df.write_parquet(path, use_pyarrow=True, pyarrow_options={"data_page_size": 1})
 

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -415,7 +415,7 @@ def test_parquet_different_schema(tmp_path: Path, streaming: bool) -> None:
 def test_nested_slice_12480(tmp_path: Path) -> None:
     path = tmp_path / "data.parquet"
     df = pl.select(
-        pl.lit(1).repeat_by(10_000).explode(empty_as_null=True).cast(pl.List(pl.Int32))
+        pl.lit(1).repeat_by(10_000).explode(empty_as_null=False).cast(pl.List(pl.Int32))
     )
 
     df.write_parquet(path, use_pyarrow=True, pyarrow_options={"data_page_size": 1})

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -1362,7 +1362,7 @@ def test_parquet_pyarrow_map() -> None:
         schema={"x": pl.Struct({"key": pl.Int32, "value": pl.Int32})},
     )
     f.seek(0)
-    assert_frame_equal(pl.read_parquet(f).explode(["x"], empty_as_null=True), expected)
+    assert_frame_equal(pl.read_parquet(f).explode(["x"], empty_as_null=False), expected)
 
     # Test for https://github.com/pola-rs/polars/issues/21317
     # Specifying schema/allow_missing_columns
@@ -1373,7 +1373,7 @@ def test_parquet_pyarrow_map() -> None:
                 f,
                 schema={"x": pl.List(pl.Struct({"key": pl.Int32, "value": pl.Int32}))},
                 missing_columns=missing_columns,  # type: ignore[arg-type]
-            ).explode(["x"], empty_as_null=True),
+            ).explode(["x"], empty_as_null=False),
             expected,
         )
 

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -1362,7 +1362,7 @@ def test_parquet_pyarrow_map() -> None:
         schema={"x": pl.Struct({"key": pl.Int32, "value": pl.Int32})},
     )
     f.seek(0)
-    assert_frame_equal(pl.read_parquet(f).explode(["x"]), expected)
+    assert_frame_equal(pl.read_parquet(f).explode(["x"], empty_as_null=True), expected)
 
     # Test for https://github.com/pola-rs/polars/issues/21317
     # Specifying schema/allow_missing_columns
@@ -1373,7 +1373,7 @@ def test_parquet_pyarrow_map() -> None:
                 f,
                 schema={"x": pl.List(pl.Struct({"key": pl.Int32, "value": pl.Int32}))},
                 missing_columns=missing_columns,  # type: ignore[arg-type]
-            ).explode(["x"]),
+            ).explode(["x"], empty_as_null=True),
             expected,
         )
 

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -210,7 +210,7 @@ def test_schema_row_index_cse(maintain_order: bool) -> None:
         # Sort the lists to make sure that the result is correctly ordered
         list_cols = [c for c in result.columns if c != "A"]
         result = (
-            result.explode(list_cols, empty_as_null=True)
+            result.explode(list_cols, empty_as_null=False)
             .sort("Idx")
             .group_by("A", maintain_order=True)
             .all()

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -210,7 +210,7 @@ def test_schema_row_index_cse(maintain_order: bool) -> None:
         # Sort the lists to make sure that the result is correctly ordered
         list_cols = [c for c in result.columns if c != "A"]
         result = (
-            result.explode(list_cols)
+            result.explode(list_cols, empty_as_null=True)
             .sort("Idx")
             .group_by("A", maintain_order=True)
             .all()

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -455,7 +455,7 @@ def test_head_group_by() -> None:
         ldf.sort(by="price", descending=True)
         .group_by(keys, maintain_order=True)
         .agg([pl.col("*").exclude(keys).head(2).name.keep()])
-        .explode(cs.all().exclude(keys))
+        .explode(cs.all().exclude(keys), empty_as_null=True)
     )
 
     assert out.collect().rows() == [

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -455,7 +455,7 @@ def test_head_group_by() -> None:
         ldf.sort(by="price", descending=True)
         .group_by(keys, maintain_order=True)
         .agg([pl.col("*").exclude(keys).head(2).name.keep()])
-        .explode(cs.all().exclude(keys), empty_as_null=True)
+        .explode(cs.all().exclude(keys), empty_as_null=False)
     )
 
     assert out.collect().rows() == [

--- a/py-polars/tests/unit/lazyframe/test_order_observability.py
+++ b/py-polars/tests/unit/lazyframe/test_order_observability.py
@@ -217,9 +217,9 @@ def test_merge_sorted_deep_chain_explain_matches_balanced(n_frames: int) -> None
         pl.arange(0, pl.len()),
         pl.int_range(pl.len()),
         pl.row_index().cast(pl.Int64),
-        pl.lit([0, 1, 2, 3, 4], dtype=pl.List(pl.Int64)).explode(),
+        pl.lit([0, 1, 2, 3, 4], dtype=pl.List(pl.Int64)).explode(empty_as_null=True),
         pl.lit(pl.Series([0, 1, 2, 3, 4])),
-        pl.lit(pl.Series([[0], [1], [2], [3], [4]])).explode(),
+        pl.lit(pl.Series([[0], [1], [2], [3], [4]])).explode(empty_as_null=True),
         pl.col("y").sort(),
         pl.col("y").sort_by(pl.col("y"), maintain_order=True),
         pl.col("y").sort_by(pl.col("y"), maintain_order=False),
@@ -333,7 +333,12 @@ lf6 = pl.LazyFrame({"a": [[1], [2]], "b": [[3], [4]]})
         (lf2, pl.col.a + 1, [3, 2, 4], False),
         (lf2, pl.lit(pl.Series("a", [2, 1, 3, 4])).gather([0, 2]), [2, 3], False),
         (lf2, pl.col.a.filter(pl.col.a != 1), [2, 3], False),
-        (lf3, pl.col.a.explode() * pl.col.b.explode(), [3, 8, 15], True),
+        (
+            lf3,
+            pl.col.a.explode(empty_as_null=True) * pl.col.b.explode(empty_as_null=True),
+            [3, 8, 15],
+            True,
+        ),
         (lf4, pl.col.a.sort() + pl.col.b, [5, 8], True),
         (lf4, pl.col.a.sort() + pl.col.b.sort(), [5, 7, 9], False),
         (lf4, pl.col.a + pl.col.b, pl.Series("a", [6, 7, 8]), False),
@@ -366,14 +371,18 @@ def test_with_columns_implicit_columns() -> None:
     q = (
         lf6.select("a")
         .unique(maintain_order=True)
-        .with_columns(pl.col.a.explode())
+        .with_columns(pl.col.a.explode(empty_as_null=True))
         .unique()
     )
     assert "UNIQUE[maintain_order: true" not in q.explain()
     assert_series_equal(
         q.collect().to_series(), pl.Series("a", [1, 2]), check_order=False
     )
-    q = lf6.unique(maintain_order=True).with_columns(pl.col.a.explode()).unique()
+    q = (
+        lf6.unique(maintain_order=True)
+        .with_columns(pl.col.a.explode(empty_as_null=True))
+        .unique()
+    )
     assert "UNIQUE[maintain_order: true" in q.explain()
     assert_frame_equal(
         q.collect(),
@@ -414,7 +423,7 @@ def test_with_columns_implicit_columns() -> None:
         (
             pl.col.a.cast(pl.List(pl.Int64))
             .map_batches(lambda x: x, is_elementwise=True)
-            .explode(),
+            .explode(empty_as_null=True),
             [1, 2, 3],
             True,
             False,
@@ -452,7 +461,7 @@ def test_group_by_key_sensitivity(
         (
             pl.col.a.cast(pl.List(pl.Int64))
             .map_batches(lambda x: x, is_elementwise=True)
-            .explode(),
+            .explode(empty_as_null=True),
             True,
         ),
         (pl.col.a.sort(), True),
@@ -558,7 +567,7 @@ def test_group_by_input_ordering() -> None:
         (
             pl.col.a.cast(pl.List(pl.Int64))
             .map_batches(lambda x: x, is_elementwise=True)
-            .explode(),
+            .explode(empty_as_null=True),
             True,
         ),
         (pl.col.a.cum_prod(), True),
@@ -586,7 +595,7 @@ def test_sort_key_sensitivity(expr: pl.Expr, is_ordered: bool) -> None:
         (
             pl.col.a.cast(pl.List(pl.Int64))
             .map_batches(lambda x: x, is_elementwise=True)
-            .explode(),
+            .explode(empty_as_null=True),
             True,
         ),
         (pl.col.a.cum_prod(), True),

--- a/py-polars/tests/unit/lazyframe/test_order_observability.py
+++ b/py-polars/tests/unit/lazyframe/test_order_observability.py
@@ -217,9 +217,9 @@ def test_merge_sorted_deep_chain_explain_matches_balanced(n_frames: int) -> None
         pl.arange(0, pl.len()),
         pl.int_range(pl.len()),
         pl.row_index().cast(pl.Int64),
-        pl.lit([0, 1, 2, 3, 4], dtype=pl.List(pl.Int64)).explode(empty_as_null=True),
+        pl.lit([0, 1, 2, 3, 4], dtype=pl.List(pl.Int64)).explode(empty_as_null=False),
         pl.lit(pl.Series([0, 1, 2, 3, 4])),
-        pl.lit(pl.Series([[0], [1], [2], [3], [4]])).explode(empty_as_null=True),
+        pl.lit(pl.Series([[0], [1], [2], [3], [4]])).explode(empty_as_null=False),
         pl.col("y").sort(),
         pl.col("y").sort_by(pl.col("y"), maintain_order=True),
         pl.col("y").sort_by(pl.col("y"), maintain_order=False),
@@ -335,7 +335,8 @@ lf6 = pl.LazyFrame({"a": [[1], [2]], "b": [[3], [4]]})
         (lf2, pl.col.a.filter(pl.col.a != 1), [2, 3], False),
         (
             lf3,
-            pl.col.a.explode(empty_as_null=True) * pl.col.b.explode(empty_as_null=True),
+            pl.col.a.explode(empty_as_null=False)
+            * pl.col.b.explode(empty_as_null=False),
             [3, 8, 15],
             True,
         ),
@@ -371,7 +372,7 @@ def test_with_columns_implicit_columns() -> None:
     q = (
         lf6.select("a")
         .unique(maintain_order=True)
-        .with_columns(pl.col.a.explode(empty_as_null=True))
+        .with_columns(pl.col.a.explode(empty_as_null=False))
         .unique()
     )
     assert "UNIQUE[maintain_order: true" not in q.explain()
@@ -380,7 +381,7 @@ def test_with_columns_implicit_columns() -> None:
     )
     q = (
         lf6.unique(maintain_order=True)
-        .with_columns(pl.col.a.explode(empty_as_null=True))
+        .with_columns(pl.col.a.explode(empty_as_null=False))
         .unique()
     )
     assert "UNIQUE[maintain_order: true" in q.explain()
@@ -423,7 +424,7 @@ def test_with_columns_implicit_columns() -> None:
         (
             pl.col.a.cast(pl.List(pl.Int64))
             .map_batches(lambda x: x, is_elementwise=True)
-            .explode(empty_as_null=True),
+            .explode(empty_as_null=False),
             [1, 2, 3],
             True,
             False,
@@ -461,7 +462,7 @@ def test_group_by_key_sensitivity(
         (
             pl.col.a.cast(pl.List(pl.Int64))
             .map_batches(lambda x: x, is_elementwise=True)
-            .explode(empty_as_null=True),
+            .explode(empty_as_null=False),
             True,
         ),
         (pl.col.a.sort(), True),
@@ -567,7 +568,7 @@ def test_group_by_input_ordering() -> None:
         (
             pl.col.a.cast(pl.List(pl.Int64))
             .map_batches(lambda x: x, is_elementwise=True)
-            .explode(empty_as_null=True),
+            .explode(empty_as_null=False),
             True,
         ),
         (pl.col.a.cum_prod(), True),
@@ -595,7 +596,7 @@ def test_sort_key_sensitivity(expr: pl.Expr, is_ordered: bool) -> None:
         (
             pl.col.a.cast(pl.List(pl.Int64))
             .map_batches(lambda x: x, is_elementwise=True)
-            .explode(empty_as_null=True),
+            .explode(empty_as_null=False),
             True,
         ),
         (pl.col.a.cum_prod(), True),

--- a/py-polars/tests/unit/lazyframe/test_schema.py
+++ b/py-polars/tests/unit/lazyframe/test_schema.py
@@ -235,13 +235,15 @@ def test_lazy_explode_in_agg_schema_19562() -> None:
         q.collect(), new_df_check_schema({"a": [1], "b": [[[1]]]}, schema)
     )
 
-    q = lf.group_by("a").agg(pl.col("b").explode())
+    q = lf.group_by("a").agg(pl.col("b").explode(empty_as_null=True))
     schema = {"a": pl.Int64, "b": pl.List(pl.Int64)}
 
     assert q.collect_schema() == schema
     assert_frame_equal(q.collect(), new_df_check_schema({"a": [1], "b": [[1]]}, schema))
 
-    q = lf.group_by("a").agg(pl.col("b").explode().explode())
+    q = lf.group_by("a").agg(
+        pl.col("b").explode(empty_as_null=True).explode(empty_as_null=True)
+    )
     schema = {"a": pl.Int64, "b": pl.List(pl.Int64)}
 
     assert q.collect_schema() == schema
@@ -261,7 +263,7 @@ def test_lazy_explode_in_agg_schema_19562() -> None:
         q.collect(), new_df_check_schema({"a": [1], "b": [[[[1]]]]}, schema)
     )
 
-    q = lf.group_by("a").agg(pl.col("b").explode())
+    q = lf.group_by("a").agg(pl.col("b").explode(empty_as_null=True))
     schema = {"a": pl.Int64, "b": pl.List(pl.List(pl.Int64))}
 
     assert q.collect_schema() == schema
@@ -269,7 +271,9 @@ def test_lazy_explode_in_agg_schema_19562() -> None:
         q.collect(), new_df_check_schema({"a": [1], "b": [[[1]]]}, schema)
     )
 
-    q = lf.group_by("a").agg(pl.col("b").explode().explode())
+    q = lf.group_by("a").agg(
+        pl.col("b").explode(empty_as_null=True).explode(empty_as_null=True)
+    )
     schema = {"a": pl.Int64, "b": pl.List(pl.Int64)}
 
     assert q.collect_schema() == schema
@@ -324,7 +328,7 @@ def test_lazy_agg_lit_explode() -> None:
     q = (
         pl.LazyFrame({"k": [1]})
         .group_by("k")
-        .agg(pl.lit(1, dtype=pl.Int64).explode().alias("o"))
+        .agg(pl.lit(1, dtype=pl.Int64).explode(empty_as_null=True).alias("o"))
     )
 
     schema = {"k": pl.Int64, "o": pl.List(pl.Int64)}
@@ -386,18 +390,18 @@ def test_lazy_window_schema(expr: pl.Expr, mapping_strategy: str) -> None:
 def test_lazy_explode_schema() -> None:
     lf = pl.LazyFrame({"k": [1], "x": pl.Series([[1]], dtype=pl.Array(pl.Int64, 1))})
 
-    q = lf.select(pl.col("x").explode())
+    q = lf.select(pl.col("x").explode(empty_as_null=True))
     assert q.collect_schema() == {"x": pl.Int64}
 
-    q = lf.select(pl.col("x").arr.explode())
+    q = lf.select(pl.col("x").arr.explode(empty_as_null=True))
     assert q.collect_schema() == {"x": pl.Int64}
 
     lf = pl.LazyFrame({"k": [1], "x": pl.Series([[1]], dtype=pl.List(pl.Int64))})
 
-    q = lf.select(pl.col("x").explode())
+    q = lf.select(pl.col("x").explode(empty_as_null=True))
     assert q.collect_schema() == {"x": pl.Int64}
 
-    q = lf.select(pl.col("x").list.explode())
+    q = lf.select(pl.col("x").list.explode(empty_as_null=True))
     assert q.collect_schema() == {"x": pl.Int64}
 
     # `LazyFrame.explode()` goes through a different codepath than `Expr.expode`
@@ -406,10 +410,10 @@ def test_lazy_explode_schema() -> None:
         pl.Series([[1]], dtype=pl.Array(pl.Int64, 1)).alias("array"),
     )
 
-    q = lf.explode("*")
+    q = lf.explode("*", empty_as_null=True)
     assert q.collect_schema() == {"list": pl.Int64, "array": pl.Int64}
 
-    q = lf.explode("list")
+    q = lf.explode("list", empty_as_null=True)
     assert q.collect_schema() == {"list": pl.Int64, "array": pl.Array(pl.Int64, 1)}
 
 

--- a/py-polars/tests/unit/operations/aggregation/test_implode.py
+++ b/py-polars/tests/unit/operations/aggregation/test_implode.py
@@ -25,7 +25,7 @@ def test_implode_explode_agg() -> None:
     assert_frame_equal(
         pl.DataFrame({"a": [1, 2]})
         .group_by(pl.lit(1, pl.Int64))
-        .agg(pl.col.a.implode().explode().sum()),
+        .agg(pl.col.a.implode().explode(empty_as_null=True).sum()),
         pl.DataFrame({"literal": [1], "a": [3]}),
     )
 

--- a/py-polars/tests/unit/operations/aggregation/test_implode.py
+++ b/py-polars/tests/unit/operations/aggregation/test_implode.py
@@ -25,7 +25,7 @@ def test_implode_explode_agg() -> None:
     assert_frame_equal(
         pl.DataFrame({"a": [1, 2]})
         .group_by(pl.lit(1, pl.Int64))
-        .agg(pl.col.a.implode().explode(empty_as_null=True).sum()),
+        .agg(pl.col.a.implode().explode(empty_as_null=False).sum()),
         pl.DataFrame({"literal": [1], "a": [3]}),
     )
 

--- a/py-polars/tests/unit/operations/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_array.py
@@ -440,7 +440,7 @@ def test_array_explode() -> None:
             "logical": pl.Array(pl.Date, 2),
         },
     )
-    out = df.select(pl.all().arr.explode())
+    out = df.select(pl.all().arr.explode(empty_as_null=True))
     expected = pl.DataFrame(
         {
             "str": ["a", "b", "c", None, None],
@@ -464,7 +464,7 @@ def test_array_explode() -> None:
         ],
         dtype=pl.Array(pl.Date, 2),
     )
-    out_s = s.arr.explode()
+    out_s = s.arr.explode(empty_as_null=True)
     expected_s = pl.Series(
         [
             datetime.date(1998, 1, 1),
@@ -565,7 +565,7 @@ def test_array_n_unique() -> None:
 
 def test_explode_19049() -> None:
     df = pl.DataFrame({"a": [[1, 2, 3]]}, schema={"a": pl.Array(pl.Int64, 3)})
-    result_df = df.select(pl.col.a.arr.explode())
+    result_df = df.select(pl.col.a.arr.explode(empty_as_null=True))
     expected_df = pl.DataFrame({"a": [1, 2, 3]}, schema={"a": pl.Int64})
     assert_frame_equal(result_df, expected_df)
 
@@ -574,7 +574,7 @@ def test_explode_19049() -> None:
         InvalidOperationError,
         match="expected Array datatype for array operation, got: Int64",
     ):
-        df.select(pl.col.a.arr.explode())
+        df.select(pl.col.a.arr.explode(empty_as_null=True))
 
 
 def test_array_join_unequal_lengths_22018() -> None:
@@ -653,7 +653,7 @@ def test_arr_contains() -> None:
     "expr",
     [
         pl.col("a").arr.contains("z"),
-        pl.col("a").arr.explode(),
+        pl.col("a").arr.explode(empty_as_null=True),
         pl.col("a").arr.sum(),
         pl.col("a").arr.to_list(),
         pl.col("a").arr.to_struct(),

--- a/py-polars/tests/unit/operations/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_array.py
@@ -464,7 +464,7 @@ def test_array_explode() -> None:
         ],
         dtype=pl.Array(pl.Date, 2),
     )
-    out_s = s.arr.explode(empty_as_null=True)
+    out_s = s.arr.explode(empty_as_null=False)
     expected_s = pl.Series(
         [
             datetime.date(1998, 1, 1),

--- a/py-polars/tests/unit/operations/namespaces/array/test_eval.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_eval.py
@@ -256,7 +256,7 @@ def test_arr_eval_with_filter_in_agg_25384(
 
     # group_by
     q = df.lazy().group_by(keys, maintain_order=True).agg(q_inner)
-    out = q.collect().select(pl.col.a).explode("a")
+    out = q.collect().select(pl.col.a).explode("a", empty_as_null=True)
     assert_series_equal(out.to_series(), result)
 
 
@@ -309,7 +309,7 @@ def test_arr_agg_with_filter_in_agg_25384(
 
     # group_by
     q = df.lazy().group_by(keys, maintain_order=True).agg(q_inner)
-    out = q.collect().select(pl.col.a).explode("a")
+    out = q.collect().select(pl.col.a).explode("a", empty_as_null=True)
     assert_series_equal(out.to_series(), result)
 
 

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -998,7 +998,10 @@ def test_list_sum_bool_schema() -> None:
 
 def test_list_concat_struct_19279() -> None:
     df = pl.select(
-        pl.struct(s=pl.lit("abcd").str.split("").explode(), i=pl.int_range(0, 4))
+        pl.struct(
+            s=pl.lit("abcd").str.split("").explode(empty_as_null=True),
+            i=pl.int_range(0, 4),
+        )
     )
     df = pl.concat([df[:2], df[-2:]])
     assert df.select(pl.concat_list("s")).to_dict(as_series=False) == {

--- a/py-polars/tests/unit/operations/namespaces/test_categorical.py
+++ b/py-polars/tests/unit/operations/namespaces/test_categorical.py
@@ -127,7 +127,7 @@ def test_cat_len_bytes(dtype: PolarsDataType) -> None:
         pl.LazyFrame({"key": [1, 1, 1, 1, 1, 2, 2, 2, 2, 2], "value": s.extend(s)})
         .group_by("key", maintain_order=True)
         .agg(pl.col("value").cat.len_bytes().alias("len_bytes"))
-        .explode("len_bytes")
+        .explode("len_bytes", empty_as_null=True)
         .collect()
     )
     expected_df = pl.DataFrame(
@@ -167,7 +167,7 @@ def test_cat_len_chars(dtype: PolarsDataType) -> None:
         pl.LazyFrame({"key": [1, 1, 1, 1, 1, 2, 2, 2, 2, 2], "value": s.extend(s)})
         .group_by("key", maintain_order=True)
         .agg(pl.col("value").cat.len_chars().alias("len_bytes"))
-        .explode("len_bytes")
+        .explode("len_bytes", empty_as_null=True)
         .collect()
     )
     expected_df = pl.DataFrame(

--- a/py-polars/tests/unit/operations/test_drop.py
+++ b/py-polars/tests/unit/operations/test_drop.py
@@ -28,7 +28,7 @@ def test_drop_explode_6641() -> None:
     ).lazy()
 
     assert (
-        df.explode(["identifier", "alternate"], empty_as_null=True)
+        df.explode(["identifier", "alternate"], empty_as_null=False)
         .with_columns(pl.struct(["identifier", "alternate"]).alias("test"))
         .drop(["identifier", "alternate"])
         .select(pl.concat_list([pl.col("test"), pl.col("test")]))

--- a/py-polars/tests/unit/operations/test_drop.py
+++ b/py-polars/tests/unit/operations/test_drop.py
@@ -28,7 +28,7 @@ def test_drop_explode_6641() -> None:
     ).lazy()
 
     assert (
-        df.explode(["identifier", "alternate"])
+        df.explode(["identifier", "alternate"], empty_as_null=True)
         .with_columns(pl.struct(["identifier", "alternate"]).alias("test"))
         .drop(["identifier", "alternate"])
         .select(pl.concat_list([pl.col("test"), pl.col("test")]))

--- a/py-polars/tests/unit/operations/test_explode.py
+++ b/py-polars/tests/unit/operations/test_explode.py
@@ -15,9 +15,9 @@ def test_explode_multiple() -> None:
     df = pl.DataFrame({"a": [[1, 2], [3, 4]], "b": [[5, 6], [7, 8]]})
 
     expected = pl.DataFrame({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
-    assert_frame_equal(df.explode(cs.all(), empty_as_null=True), expected)
-    assert_frame_equal(df.explode(["a", "b"], empty_as_null=True), expected)
-    assert_frame_equal(df.explode("a", "b", empty_as_null=True), expected)
+    assert_frame_equal(df.explode(cs.all(), empty_as_null=False), expected)
+    assert_frame_equal(df.explode(["a", "b"], empty_as_null=False), expected)
+    assert_frame_equal(df.explode("a", "b", empty_as_null=False), expected)
 
 
 def test_group_by_flatten_list() -> None:
@@ -81,7 +81,7 @@ def test_explode_empty_list_4107() -> None:
 
 def test_explode_correct_for_slice() -> None:
     df = pl.DataFrame({"b": [[1, 1], [2, 2], [3, 3], [4, 4]]})
-    assert df.slice(2, 2).explode(["b"], empty_as_null=True)["b"].to_list() == [
+    assert df.slice(2, 2).explode(["b"], empty_as_null=False)["b"].to_list() == [
         3,
         3,
         4,
@@ -110,7 +110,7 @@ def test_explode_correct_for_slice() -> None:
         },
         schema_overrides={"index": pl.get_index_type()},
     )
-    assert_frame_equal(df.slice(0, 10).explode(["b"], empty_as_null=True), expected)
+    assert_frame_equal(df.slice(0, 10).explode(["b"], empty_as_null=False), expected)
 
 
 def test_sliced_null_explode() -> None:
@@ -151,7 +151,7 @@ def test_explode_in_agg_context(maintain_order: bool) -> None:
 
     assert_frame_equal(
         df.with_row_index()
-        .explode("idxs", empty_as_null=True)
+        .explode("idxs", empty_as_null=False)
         .group_by("index", maintain_order=maintain_order)
         .agg(pl.col("array").list.explode(keep_nulls=False, empty_as_null=False)),
         pl.DataFrame(
@@ -175,7 +175,7 @@ def test_explode_inner_lists_3985() -> None:
         .agg(pl.col("categories"))
         .with_columns(
             pl.col("categories").list.eval(
-                pl.element().list.explode(empty_as_null=True)
+                pl.element().list.explode(empty_as_null=False)
             )
         )
     ).collect().to_dict(as_series=False) == {
@@ -205,7 +205,7 @@ def test_list_struct_explode_6905() -> None:
 
 def test_explode_binary() -> None:
     assert pl.Series([[1, 2], [3]]).cast(pl.List(pl.Binary)).list.explode(
-        empty_as_null=True
+        empty_as_null=False
     ).to_list() == [
         b"1",
         b"2",
@@ -229,7 +229,7 @@ def test_explode_invalid_element_count() -> None:
     with pytest.raises(
         ShapeError, match=r"exploded columns must have matching element counts"
     ):
-        df.explode(["col1", "col2"], empty_as_null=True)
+        df.explode(["col1", "col2"], empty_as_null=False)
 
 
 def test_logical_explode() -> None:
@@ -240,7 +240,7 @@ def test_logical_explode() -> None:
         )
         .group_by(1)
         .agg(pl.struct("cats"))
-        .explode("cats", empty_as_null=True)
+        .explode("cats", empty_as_null=False)
         .unnest("cats")
     )
     assert out["cats"].dtype == pl.Categorical
@@ -262,7 +262,7 @@ def test_explode_array() -> None:
     )
     expected = pl.DataFrame({"a": [1, 2, 2, 3], "b": [1, 1, 2, 2]})
     for ex in ("a", ~cs.integer()):
-        out = df.explode(ex, empty_as_null=True).collect()
+        out = df.explode(ex, empty_as_null=False).collect()
         assert_frame_equal(out, expected)
 
 
@@ -402,7 +402,7 @@ def test_group_by_flatten_string() -> None:
     df = pl.DataFrame({"group": ["a", "b", "b"], "values": ["foo", "bar", "baz"]})
 
     result = df.group_by("group", maintain_order=True).agg(
-        pl.col("values").str.split("").explode(empty_as_null=True)
+        pl.col("values").str.split("").explode(empty_as_null=False)
     )
 
     expected = pl.DataFrame(
@@ -475,7 +475,7 @@ def test_undefined_col_15852() -> None:
     lf = pl.LazyFrame({"foo": [1]})
 
     with pytest.raises(pl.exceptions.ColumnNotFoundError):
-        lf.explode("bar", empty_as_null=True).join(lf, on="foo").collect()
+        lf.explode("bar", empty_as_null=False).join(lf, on="foo").collect()
 
 
 def test_explode_17648() -> None:
@@ -483,7 +483,7 @@ def test_explode_17648() -> None:
     assert (
         df.slice(1, 2)
         .with_columns(pl.int_ranges(pl.col("a").list.len()).alias("count"))
-        .explode("a", "count", empty_as_null=True)
+        .explode("a", "count", empty_as_null=False)
     ).to_dict(as_series=False) == {"a": [2, 6, 7, 3, 9, 2], "count": [0, 1, 2, 0, 1, 2]}
 
 

--- a/py-polars/tests/unit/operations/test_explode.py
+++ b/py-polars/tests/unit/operations/test_explode.py
@@ -15,9 +15,9 @@ def test_explode_multiple() -> None:
     df = pl.DataFrame({"a": [[1, 2], [3, 4]], "b": [[5, 6], [7, 8]]})
 
     expected = pl.DataFrame({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
-    assert_frame_equal(df.explode(cs.all()), expected)
-    assert_frame_equal(df.explode(["a", "b"]), expected)
-    assert_frame_equal(df.explode("a", "b"), expected)
+    assert_frame_equal(df.explode(cs.all(), empty_as_null=True), expected)
+    assert_frame_equal(df.explode(["a", "b"], empty_as_null=True), expected)
+    assert_frame_equal(df.explode("a", "b", empty_as_null=True), expected)
 
 
 def test_group_by_flatten_list() -> None:
@@ -32,12 +32,12 @@ def test_group_by_flatten_list() -> None:
 
 def test_explode_empty_df_3402() -> None:
     df = pl.DataFrame({"a": pa.array([], type=pa.large_list(pa.int32()))})
-    assert df.explode("a").dtypes == [pl.Int32]
+    assert df.explode("a", empty_as_null=True).dtypes == [pl.Int32]
 
 
 def test_explode_empty_df_3460() -> None:
     df = pl.DataFrame({"a": pa.array([[]], type=pa.large_list(pa.int32()))})
-    assert df.explode("a").dtypes == [pl.Int32]
+    assert df.explode("a", empty_as_null=True).dtypes == [pl.Int32]
 
 
 def test_explode_empty_df_3902() -> None:
@@ -53,7 +53,7 @@ def test_explode_empty_df_3902() -> None:
             "second": ["a", None, "b", "c", None, "d", "f", "g"],
         }
     )
-    assert_frame_equal(df.explode("second"), expected)
+    assert_frame_equal(df.explode("second", empty_as_null=True), expected)
 
 
 def test_explode_empty_list_4003() -> None:
@@ -64,7 +64,7 @@ def test_explode_empty_list_4003() -> None:
             {"id": 3, "nested": [2]},
         ]
     )
-    assert df.explode("nested").to_dict(as_series=False) == {
+    assert df.explode("nested", empty_as_null=True).to_dict(as_series=False) == {
         "id": [1, 2, 3],
         "nested": [None, 1, 2],
     }
@@ -74,13 +74,19 @@ def test_explode_empty_list_4107() -> None:
     df = pl.DataFrame({"b": [[1], [2], []] * 2}).with_row_index()
 
     assert_frame_equal(
-        df.explode(["b"]), df.explode(["b"]).drop("index").with_row_index()
+        df.explode(["b"], empty_as_null=True),
+        df.explode(["b"], empty_as_null=True).drop("index").with_row_index(),
     )
 
 
 def test_explode_correct_for_slice() -> None:
     df = pl.DataFrame({"b": [[1, 1], [2, 2], [3, 3], [4, 4]]})
-    assert df.slice(2, 2).explode(["b"])["b"].to_list() == [3, 3, 4, 4]
+    assert df.slice(2, 2).explode(["b"], empty_as_null=True)["b"].to_list() == [
+        3,
+        3,
+        4,
+        4,
+    ]
 
     df = (
         (
@@ -104,27 +110,37 @@ def test_explode_correct_for_slice() -> None:
         },
         schema_overrides={"index": pl.get_index_type()},
     )
-    assert_frame_equal(df.slice(0, 10).explode(["b"]), expected)
+    assert_frame_equal(df.slice(0, 10).explode(["b"], empty_as_null=True), expected)
 
 
 def test_sliced_null_explode() -> None:
     s = pl.Series("", [[1], [2], [3], [4], [], [6]])
-    assert s.slice(2, 4).list.explode().to_list() == [3, 4, None, 6]
-    assert s.slice(2, 2).list.explode().to_list() == [3, 4]
-    assert pl.Series("", [[1], [2], None, [4], [], [6]]).slice(
-        2, 4
-    ).list.explode().to_list() == [None, 4, None, 6]
+    assert s.slice(2, 4).list.explode(empty_as_null=True).to_list() == [3, 4, None, 6]
+    assert s.slice(2, 2).list.explode(empty_as_null=True).to_list() == [3, 4]
+    assert pl.Series("", [[1], [2], None, [4], [], [6]]).slice(2, 4).list.explode(
+        empty_as_null=True
+    ).to_list() == [None, 4, None, 6]
 
     s = pl.Series("", [["a"], ["b"], ["c"], ["d"], [], ["e"]])
-    assert s.slice(2, 4).list.explode().to_list() == ["c", "d", None, "e"]
-    assert s.slice(2, 2).list.explode().to_list() == ["c", "d"]
+    assert s.slice(2, 4).list.explode(empty_as_null=True).to_list() == [
+        "c",
+        "d",
+        None,
+        "e",
+    ]
+    assert s.slice(2, 2).list.explode(empty_as_null=True).to_list() == ["c", "d"]
     assert pl.Series("", [["a"], ["b"], None, ["d"], [], ["e"]]).slice(
         2, 4
-    ).list.explode().to_list() == [None, "d", None, "e"]
+    ).list.explode(empty_as_null=True).to_list() == [None, "d", None, "e"]
 
     s = pl.Series("", [[False], [False], [True], [False], [], [True]])
-    assert s.slice(2, 2).list.explode().to_list() == [True, False]
-    assert s.slice(2, 4).list.explode().to_list() == [True, False, None, True]
+    assert s.slice(2, 2).list.explode(empty_as_null=True).to_list() == [True, False]
+    assert s.slice(2, 4).list.explode(empty_as_null=True).to_list() == [
+        True,
+        False,
+        None,
+        True,
+    ]
 
 
 @pytest.mark.parametrize("maintain_order", [False, True])
@@ -135,7 +151,7 @@ def test_explode_in_agg_context(maintain_order: bool) -> None:
 
     assert_frame_equal(
         df.with_row_index()
-        .explode("idxs")
+        .explode("idxs", empty_as_null=True)
         .group_by("index", maintain_order=maintain_order)
         .agg(pl.col("array").list.explode(keep_nulls=False, empty_as_null=False)),
         pl.DataFrame(
@@ -157,7 +173,11 @@ def test_explode_inner_lists_3985() -> None:
     assert (
         df.group_by("id")
         .agg(pl.col("categories"))
-        .with_columns(pl.col("categories").list.eval(pl.element().list.explode()))
+        .with_columns(
+            pl.col("categories").list.eval(
+                pl.element().list.explode(empty_as_null=True)
+            )
+        )
     ).collect().to_dict(as_series=False) == {
         "id": [1],
         "categories": [["a", "b", "a", "c"]],
@@ -176,7 +196,7 @@ def test_list_struct_explode_6905() -> None:
             ]
         },
         schema={"group": pl.List(pl.Struct([pl.Field("params", pl.List(pl.Int32))]))},
-    )["group"].list.explode().to_list() == [
+    )["group"].list.explode(empty_as_null=True).to_list() == [
         None,
         {"params": [1]},
         {"params": []},
@@ -184,9 +204,9 @@ def test_list_struct_explode_6905() -> None:
 
 
 def test_explode_binary() -> None:
-    assert pl.Series([[1, 2], [3]]).cast(
-        pl.List(pl.Binary)
-    ).list.explode().to_list() == [
+    assert pl.Series([[1, 2], [3]]).cast(pl.List(pl.Binary)).list.explode(
+        empty_as_null=True
+    ).to_list() == [
         b"1",
         b"2",
         b"3",
@@ -209,7 +229,7 @@ def test_explode_invalid_element_count() -> None:
     with pytest.raises(
         ShapeError, match=r"exploded columns must have matching element counts"
     ):
-        df.explode(["col1", "col2"])
+        df.explode(["col1", "col2"], empty_as_null=True)
 
 
 def test_logical_explode() -> None:
@@ -220,7 +240,7 @@ def test_logical_explode() -> None:
         )
         .group_by(1)
         .agg(pl.struct("cats"))
-        .explode("cats")
+        .explode("cats", empty_as_null=True)
         .unnest("cats")
     )
     assert out["cats"].dtype == pl.Categorical
@@ -229,7 +249,9 @@ def test_logical_explode() -> None:
 
 def test_explode_inner_null() -> None:
     expected = pl.DataFrame({"A": [None, None]}, schema={"A": pl.Null})
-    out = pl.DataFrame({"A": [[], []]}, schema={"A": pl.List(pl.Null)}).explode("A")
+    out = pl.DataFrame({"A": [[], []]}, schema={"A": pl.List(pl.Null)}).explode(
+        "A", empty_as_null=True
+    )
     assert_frame_equal(out, expected)
 
 
@@ -240,7 +262,7 @@ def test_explode_array() -> None:
     )
     expected = pl.DataFrame({"a": [1, 2, 2, 3], "b": [1, 1, 2, 2]})
     for ex in ("a", ~cs.integer()):
-        out = df.explode(ex).collect()
+        out = df.explode(ex, empty_as_null=True).collect()
         assert_frame_equal(out, expected)
 
 
@@ -255,7 +277,9 @@ def test_string_list_agg_explode() -> None:
     df2 = pl.DataFrame({"a": [[], ["b"]]})
 
     assert_frame_equal(df, df2)
-    assert_frame_equal(df.explode("a"), df2.explode("a"))
+    assert_frame_equal(
+        df.explode("a", empty_as_null=True), df2.explode("a", empty_as_null=True)
+    )
 
 
 def test_explode_null_struct() -> None:
@@ -269,7 +293,9 @@ def test_explode_null_struct() -> None:
         },
     ]
 
-    assert pl.DataFrame(df).explode("col1").to_dict(as_series=False) == {
+    assert pl.DataFrame(df).explode("col1", empty_as_null=True).to_dict(
+        as_series=False
+    ) == {
         "col1": [
             None,
             {"field1": None, "field2": None, "field3": None},
@@ -299,7 +325,7 @@ def test_df_explode_with_array() -> None:
             "val": ["x", "x", "y", "y", "z", "q", "q"],
         }
     )
-    assert_frame_equal(df.explode("arr"), expected_by_arr)
+    assert_frame_equal(df.explode("arr", empty_as_null=True), expected_by_arr)
 
     expected_by_list = pl.DataFrame(
         {
@@ -313,7 +339,7 @@ def test_df_explode_with_array() -> None:
             "val": pl.String,
         },
     )
-    assert_frame_equal(df.explode("list"), expected_by_list)
+    assert_frame_equal(df.explode("list", empty_as_null=True), expected_by_list)
 
     df = pl.DataFrame(
         {
@@ -339,7 +365,9 @@ def test_df_explode_with_array() -> None:
             "val": pl.Int64,
         },
     )
-    assert_frame_equal(df.explode("arr", "list"), expected_by_arr_and_list)
+    assert_frame_equal(
+        df.explode("arr", "list", empty_as_null=True), expected_by_arr_and_list
+    )
 
 
 def test_explode_nullable_list() -> None:
@@ -347,7 +375,7 @@ def test_explode_nullable_list() -> None:
         layout2=pl.when(pl.col("b")).then([1, 2]),
     )
 
-    explode_df = df.explode("layout1", "layout2")
+    explode_df = df.explode("layout1", "layout2", empty_as_null=True)
     expected_df = pl.DataFrame(
         {
             "layout1": [None, 1, 2],
@@ -358,8 +386,8 @@ def test_explode_nullable_list() -> None:
     assert_frame_equal(explode_df, expected_df)
 
     explode_expr = df.select(
-        pl.col("layout1").explode(),
-        pl.col("layout2").explode(),
+        pl.col("layout1").explode(empty_as_null=True),
+        pl.col("layout2").explode(empty_as_null=True),
     )
     expected_df = pl.DataFrame(
         {
@@ -374,7 +402,7 @@ def test_group_by_flatten_string() -> None:
     df = pl.DataFrame({"group": ["a", "b", "b"], "values": ["foo", "bar", "baz"]})
 
     result = df.group_by("group", maintain_order=True).agg(
-        pl.col("values").str.split("").explode()
+        pl.col("values").str.split("").explode(empty_as_null=True)
     )
 
     expected = pl.DataFrame(
@@ -394,7 +422,7 @@ def test_fast_explode_merge_right_16923() -> None:
         ],
         how="diagonal",
         rechunk=True,
-    ).explode("foo")
+    ).explode("foo", empty_as_null=True)
 
     assert df.height == 4
 
@@ -407,7 +435,7 @@ def test_fast_explode_merge_left_16923() -> None:
         ],
         how="diagonal",
         rechunk=True,
-    ).explode("foo")
+    ).explode("foo", empty_as_null=True)
 
     assert df.height == 4
 
@@ -447,7 +475,7 @@ def test_undefined_col_15852() -> None:
     lf = pl.LazyFrame({"foo": [1]})
 
     with pytest.raises(pl.exceptions.ColumnNotFoundError):
-        lf.explode("bar").join(lf, on="foo").collect()
+        lf.explode("bar", empty_as_null=True).join(lf, on="foo").collect()
 
 
 def test_explode_17648() -> None:
@@ -455,50 +483,68 @@ def test_explode_17648() -> None:
     assert (
         df.slice(1, 2)
         .with_columns(pl.int_ranges(pl.col("a").list.len()).alias("count"))
-        .explode("a", "count")
+        .explode("a", "count", empty_as_null=True)
     ).to_dict(as_series=False) == {"a": [2, 6, 7, 3, 9, 2], "count": [0, 1, 2, 0, 1, 2]}
 
 
 def test_explode_struct_nulls() -> None:
     df = pl.DataFrame({"A": [[{"B": 1}], [None], []]})
-    assert df.explode("A").to_dict(as_series=False) == {"A": [{"B": 1}, None, None]}
+    assert df.explode("A", empty_as_null=True).to_dict(as_series=False) == {
+        "A": [{"B": 1}, None, None]
+    }
 
 
 def test_explode_basic() -> None:
     s = pl.Series
 
-    assert_series_equal(s([[1, 2, 3]]).explode(), pl.Series([1, 2, 3]))
-    assert_series_equal(s([[1, 2, 3], None]).explode(), pl.Series([1, 2, 3, None]))
-    assert_series_equal(s([[1, 2, 3], []]).explode(), pl.Series([1, 2, 3, None]))
+    assert_series_equal(
+        s([[1, 2, 3]]).explode(empty_as_null=True), pl.Series([1, 2, 3])
+    )
+    assert_series_equal(
+        s([[1, 2, 3], None]).explode(empty_as_null=True), pl.Series([1, 2, 3, None])
+    )
+    assert_series_equal(
+        s([[1, 2, 3], []]).explode(empty_as_null=True), pl.Series([1, 2, 3, None])
+    )
     masked = (
         s([[1, 2, 3], [1, 2], [1, 2]])
         .to_frame()
         .select(pl.when(pl.Series([True, False, True])).then(pl.col("")))
         .to_series()
     )
-    assert_series_equal(masked.explode(), pl.Series([1, 2, 3, None, 1, 2]))
+    assert_series_equal(
+        masked.explode(empty_as_null=True), pl.Series([1, 2, 3, None, 1, 2])
+    )
     masked = (
         s([[1, 2, 3], [], [1, 2]])
         .to_frame()
         .select(pl.when(pl.Series([True, False, True])).then(pl.col("")))
         .to_series()
     )
-    assert_series_equal(masked.explode(), pl.Series([1, 2, 3, None, 1, 2]))
+    assert_series_equal(
+        masked.explode(empty_as_null=True), pl.Series([1, 2, 3, None, 1, 2])
+    )
 
     assert_series_equal(
         s([[1, 2, 3]]).explode(empty_as_null=False, keep_nulls=False),
         pl.Series([1, 2, 3]),
     )
 
-    assert_series_equal(s([[1, 2, 3], None]).explode(), pl.Series([1, 2, 3, None]))
     assert_series_equal(
-        s([[1, 2, 3], None]).explode(keep_nulls=False), pl.Series([1, 2, 3])
+        s([[1, 2, 3], None]).explode(empty_as_null=True), pl.Series([1, 2, 3, None])
     )
     assert_series_equal(
-        s([[1, 2, 3], [None]]).explode(keep_nulls=False), pl.Series([1, 2, 3, None])
+        s([[1, 2, 3], None]).explode(keep_nulls=False, empty_as_null=True),
+        pl.Series([1, 2, 3]),
+    )
+    assert_series_equal(
+        s([[1, 2, 3], [None]]).explode(keep_nulls=False, empty_as_null=True),
+        pl.Series([1, 2, 3, None]),
     )
 
-    assert_series_equal(s([[1, 2, 3], []]).explode(), pl.Series([1, 2, 3, None]))
+    assert_series_equal(
+        s([[1, 2, 3], []]).explode(empty_as_null=True), pl.Series([1, 2, 3, None])
+    )
     assert_series_equal(
         s([[1, 2, 3], []]).explode(empty_as_null=False), pl.Series([1, 2, 3])
     )
@@ -572,20 +618,27 @@ def test_explode_parametric(
 
 def test_explode_array_parameters() -> None:
     s = pl.Series("a", [[1, 2, 3], [4, 5, 6], [7, 8, 9]], pl.Array(pl.Int64, 3))
-    assert_series_equal(s.explode(), pl.Series("a", list(range(1, 10)), pl.Int64))
+    assert_series_equal(
+        s.explode(empty_as_null=True), pl.Series("a", list(range(1, 10)), pl.Int64)
+    )
 
     s = pl.Series("a", [[1, 2, 3], [4, 5, 6], None], pl.Array(pl.Int64, 3))
     assert_series_equal(
-        s.explode(), pl.Series("a", list(range(1, 7)) + [None], pl.Int64)
+        s.explode(empty_as_null=True),
+        pl.Series("a", list(range(1, 7)) + [None], pl.Int64),
     )
     assert_series_equal(
-        s.explode(keep_nulls=False), pl.Series("a", list(range(1, 7)), pl.Int64)
+        s.explode(keep_nulls=False, empty_as_null=True),
+        pl.Series("a", list(range(1, 7)), pl.Int64),
     )
 
     s = pl.Series("a", [[], [], None], pl.Array(pl.Int64, 0))
-    assert_series_equal(s.explode(), pl.Series("a", [None] * 3, pl.Int64))
     assert_series_equal(
-        s.explode(keep_nulls=False), pl.Series("a", [None] * 2, pl.Int64)
+        s.explode(empty_as_null=True), pl.Series("a", [None] * 3, pl.Int64)
+    )
+    assert_series_equal(
+        s.explode(keep_nulls=False, empty_as_null=True),
+        pl.Series("a", [None] * 2, pl.Int64),
     )
     assert_series_equal(
         s.explode(empty_as_null=False), pl.Series("a", [None], pl.Int64)
@@ -599,7 +652,7 @@ def test_explode_params() -> None:
     df = pl.DataFrame({"a": [[1, 2, 3], None, [4, 5, 6], []], "b": [1, 2, 3, 4]})
 
     assert_frame_equal(
-        df.explode("a"),
+        df.explode("a", empty_as_null=True),
         pl.DataFrame(
             {"a": [1, 2, 3, None, 4, 5, 6, None], "b": [1, 1, 1, 2, 3, 3, 3, 4]}
         ),
@@ -609,7 +662,7 @@ def test_explode_params() -> None:
         pl.DataFrame({"a": [1, 2, 3, None, 4, 5, 6], "b": [1, 1, 1, 2, 3, 3, 3]}),
     )
     assert_frame_equal(
-        df.explode("a", keep_nulls=False),
+        df.explode("a", keep_nulls=False, empty_as_null=True),
         pl.DataFrame({"a": [1, 2, 3, 4, 5, 6, None], "b": [1, 1, 1, 3, 3, 3, 4]}),
     )
     assert_frame_equal(

--- a/py-polars/tests/unit/operations/test_explode.py
+++ b/py-polars/tests/unit/operations/test_explode.py
@@ -616,3 +616,29 @@ def test_explode_params() -> None:
         df.explode("a", empty_as_null=False, keep_nulls=False),
         pl.DataFrame({"a": [1, 2, 3, 4, 5, 6], "b": [1, 1, 1, 3, 3, 3]}),
     )
+
+
+def test_explode_empty_as_null_deprecation() -> None:
+    list_df = pl.DataFrame({"a": [[1, 2, 3], [4, 5, 6]]})
+    arr_df = pl.DataFrame(
+        {"a": [[1, 2, 3], [4, 5, 6]]}, schema={"a": pl.Array(pl.Int64, 3)}
+    )
+    list_s = list_df.to_series()
+    arr_s = arr_df.to_series()
+
+    with pytest.warns(DeprecationWarning, match="empty_as_null"):
+        list_df.select(pl.col("a").explode())
+    with pytest.warns(DeprecationWarning, match="empty_as_null"):
+        list_df.select(pl.col("a").list.explode())
+    with pytest.warns(DeprecationWarning, match="empty_as_null"):
+        arr_df.select(pl.col("a").arr.explode())
+    with pytest.warns(DeprecationWarning, match="empty_as_null"):
+        list_s.explode()
+    with pytest.warns(DeprecationWarning, match="empty_as_null"):
+        list_s.list.explode()
+    with pytest.warns(DeprecationWarning, match="empty_as_null"):
+        arr_s.arr.explode()
+    with pytest.warns(DeprecationWarning, match="empty_as_null"):
+        list_df.explode("a")
+    with pytest.warns(DeprecationWarning, match="empty_as_null"):
+        list_df.lazy().explode("a").collect()

--- a/py-polars/tests/unit/operations/test_filter.py
+++ b/py-polars/tests/unit/operations/test_filter.py
@@ -148,7 +148,7 @@ def test_predicate_order_explode_5950() -> None:
 
     assert (
         df.lazy()
-        .explode("i")
+        .explode("i", empty_as_null=True)
         .filter(pl.len().over(["i"]) == 2)
         .filter(pl.col("n").is_not_null())
     ).collect().to_dict(as_series=False) == {"i": [1], "n": [0]}

--- a/py-polars/tests/unit/operations/test_format.py
+++ b/py-polars/tests/unit/operations/test_format.py
@@ -89,7 +89,7 @@ def test_format_on_multiple_chunks_25159(plmonkeypatch: PlMonkeyPatch) -> None:
     df = pl.DataFrame({"group": ["A", "B"]})
     df = df.with_columns(
         pl.date_ranges(pl.date(2025, 1, 1), pl.date(2025, 1, 3))
-    ).explode("date", empty_as_null=True)
+    ).explode("date", empty_as_null=False)
     out = df.group_by(pl.all()).agg(
         pl.format("{}", (pl.col("date").max()).dt.to_string()).alias("label")
     )

--- a/py-polars/tests/unit/operations/test_format.py
+++ b/py-polars/tests/unit/operations/test_format.py
@@ -89,7 +89,7 @@ def test_format_on_multiple_chunks_25159(plmonkeypatch: PlMonkeyPatch) -> None:
     df = pl.DataFrame({"group": ["A", "B"]})
     df = df.with_columns(
         pl.date_ranges(pl.date(2025, 1, 1), pl.date(2025, 1, 3))
-    ).explode("date")
+    ).explode("date", empty_as_null=True)
     out = df.group_by(pl.all()).agg(
         pl.format("{}", (pl.col("date").max()).dt.to_string()).alias("label")
     )

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -60,7 +60,9 @@ def test_group_by() -> None:
     )
 
     # check if this query runs and thus column names propagate
-    df.group_by("b").agg(pl.col("c").fill_null(strategy="forward")).explode("c")
+    df.group_by("b").agg(pl.col("c").fill_null(strategy="forward")).explode(
+        "c", empty_as_null=True
+    )
 
     # get a specific column
     result = df.group_by("b", maintain_order=True).agg(pl.count("a"))
@@ -1055,11 +1057,11 @@ def test_group_by_with_expr_as_key() -> None:
 
     # tests: 11766
     result = gb.head(0)
-    expected = gb.agg(pl.col("x").head(0)).explode("x")
+    expected = gb.agg(pl.col("x").head(0)).explode("x", empty_as_null=True)
     assert_frame_equal(result, expected)
 
     result = gb.tail(0)
-    expected = gb.agg(pl.col("x").tail(0)).explode("x")
+    expected = gb.agg(pl.col("x").tail(0)).explode("x", empty_as_null=True)
     assert_frame_equal(result, expected)
 
 
@@ -2053,18 +2055,18 @@ def test_group_by_unique_parametric(
     sl = df.select(expr(pl.col.a))
     gb = df.group_by(pl.lit(1)).agg(expr(pl.col.a)).drop("literal")
     if not is_scalar:
-        gb = gb.select(pl.col.a.explode())
+        gb = gb.select(pl.col.a.explode(empty_as_null=True))
     assert_frame_equal(sl, gb, check_row_order=maintain_order)
 
     # check scalar case
     sl_first = df.select(expr(pl.col.a.first()))
     gb = df.group_by(pl.lit(1)).agg(expr(pl.col.a.first())).drop("literal")
     if not is_scalar:
-        gb = gb.select(pl.col.a.explode())
+        gb = gb.select(pl.col.a.explode(empty_as_null=True))
     assert_frame_equal(sl_first, gb, check_row_order=maintain_order)
 
     li = df.select(pl.col.a.implode().list.eval(expr(pl.element())))
-    li = li.select(pl.col.a.explode())
+    li = li.select(pl.col.a.explode(empty_as_null=True))
     assert_frame_equal(sl, li, check_row_order=maintain_order)
 
 
@@ -2218,15 +2220,17 @@ def test_group_broadcast_binary_apply_expr_25046(
 
 def test_group_by_explode_none_dtype_25045() -> None:
     df = pl.DataFrame({"a": [None, None, None], "b": [1.0, 2.0, None]})
-    out_a = df.group_by(pl.lit(1)).agg(pl.col.a.explode())
+    out_a = df.group_by(pl.lit(1)).agg(pl.col.a.explode(empty_as_null=True))
     expected_a = pl.DataFrame({"literal": 1, "a": [[None, None, None]]})
     assert_frame_equal(out_a, expected_a)
 
-    out_b = df.group_by(pl.lit(1)).agg(pl.col.b.explode())
+    out_b = df.group_by(pl.lit(1)).agg(pl.col.b.explode(empty_as_null=True))
     assert len(out_a["a"][0]) == len(out_b["b"][0])
 
     out_c = df.select(
-        pl.coalesce(pl.col.a.explode(), pl.col.b.explode())
+        pl.coalesce(
+            pl.col.a.explode(empty_as_null=True), pl.col.b.explode(empty_as_null=True)
+        )
         .implode()
         .over(pl.int_range(pl.len()))
     )
@@ -2275,17 +2279,19 @@ def test_group_by_forward_backward_fill(
 
     data = df.group_by(lit=pl.lit(1)).agg(expr(cl)).drop("lit")
     if not is_scalar:
-        data = data.explode(cs.all())
+        data = data.explode(cs.all(), empty_as_null=True)
     assert_frame_equal(df.select(expr(cl)), data)
 
     data = df.group_by("g").agg(expr(cl)).drop("g")
     if not is_scalar:
-        data = data.explode(cs.all())
+        data = data.explode(cs.all(), empty_as_null=True)
     assert_frame_equal(df.select(expr(cl)), data)
 
     assert_frame_equal(
         df.select(expr(cl)),
-        df.select(cl.implode().list.eval(expr(pl.element())).explode()),
+        df.select(
+            cl.implode().list.eval(expr(pl.element())).explode(empty_as_null=True)
+        ),
     )
 
     df = pl.Schema({"x": pl.Int64()}).to_frame()
@@ -2479,7 +2485,11 @@ def test_grouped_agg_parametric(
     if not is_window:
         types["first"] = (pl.Expr.first, True, False)
         types["slice"] = (lambda e: e.slice(1, 3), False, False)
-        types["impl_expl"] = (lambda e: e.implode().explode(), False, False)
+        types["impl_expl"] = (
+            lambda e: e.implode().explode(empty_as_null=True),
+            False,
+            False,
+        )
         types["rolling"] = (
             lambda e: e.rolling(pl.row_index(), period="3i"),
             False,

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -2055,18 +2055,18 @@ def test_group_by_unique_parametric(
     sl = df.select(expr(pl.col.a))
     gb = df.group_by(pl.lit(1)).agg(expr(pl.col.a)).drop("literal")
     if not is_scalar:
-        gb = gb.select(pl.col.a.explode(empty_as_null=True))
+        gb = gb.select(pl.col.a.explode(empty_as_null=False))
     assert_frame_equal(sl, gb, check_row_order=maintain_order)
 
     # check scalar case
     sl_first = df.select(expr(pl.col.a.first()))
     gb = df.group_by(pl.lit(1)).agg(expr(pl.col.a.first())).drop("literal")
     if not is_scalar:
-        gb = gb.select(pl.col.a.explode(empty_as_null=True))
+        gb = gb.select(pl.col.a.explode(empty_as_null=False))
     assert_frame_equal(sl_first, gb, check_row_order=maintain_order)
 
     li = df.select(pl.col.a.implode().list.eval(expr(pl.element())))
-    li = li.select(pl.col.a.explode(empty_as_null=True))
+    li = li.select(pl.col.a.explode(empty_as_null=False))
     assert_frame_equal(sl, li, check_row_order=maintain_order)
 
 

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -1266,7 +1266,9 @@ def test_join_key_type_coercion_19597() -> None:
 
 def test_array_explode_join_19763() -> None:
     q = pl.LazyFrame().select(
-        pl.lit(pl.Series([[1], [2]], dtype=pl.Array(pl.Int64, 1))).explode().alias("k")
+        pl.lit(pl.Series([[1], [2]], dtype=pl.Array(pl.Int64, 1)))
+        .explode(empty_as_null=True)
+        .alias("k")
     )
 
     q = q.join(pl.LazyFrame({"k": [1, 2]}), on="k")

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -1267,7 +1267,7 @@ def test_join_key_type_coercion_19597() -> None:
 def test_array_explode_join_19763() -> None:
     q = pl.LazyFrame().select(
         pl.lit(pl.Series([[1], [2]], dtype=pl.Array(pl.Int64, 1)))
-        .explode(empty_as_null=True)
+        .explode(empty_as_null=False)
         .alias("k")
     )
 

--- a/py-polars/tests/unit/operations/test_over.py
+++ b/py-polars/tests/unit/operations/test_over.py
@@ -14,7 +14,10 @@ def test_implode_explode_over_22188() -> None:
         }
     )
     result = df.select(
-        (pl.col.x * (pl.lit(pl.Series([1, 1, 1])).implode().explode())).over(pl.col.y),
+        (
+            pl.col.x
+            * (pl.lit(pl.Series([1, 1, 1])).implode().explode(empty_as_null=True))
+        ).over(pl.col.y),
     )
 
     assert_series_equal(result.to_series(), df.get_column("x"))
@@ -45,7 +48,11 @@ def test_over_no_partition_by_no_over() -> None:
 
 def test_over_explode_22770() -> None:
     df = pl.DataFrame({"x": [[1.0], [2.0]], "idx": [1, 2]})
-    e = pl.col("x").list.explode().over("idx", mapping_strategy="join")
+    e = (
+        pl.col("x")
+        .list.explode(empty_as_null=True)
+        .over("idx", mapping_strategy="join")
+    )
 
     assert_frame_equal(
         df.select(pl.col("x").list.diff()),
@@ -112,14 +119,14 @@ def test_over_replace_strict_22870() -> None:
 )
 def test_implode_explode_list_over_24616(col: list[Any]) -> None:
     df = pl.DataFrame({"x": col})
-    q = df.lazy().select(pl.col.x.implode().explode().over(1))
+    q = df.lazy().select(pl.col.x.implode().explode(empty_as_null=True).over(1))
     q_base = df.lazy().select(pl.col.x.over(1))
     expected = df
     assert_frame_equal(q.collect(), expected)
     assert_frame_equal(q_base.collect(), expected)
 
     df = pl.DataFrame({"g": [10, 10, 20], "x": col})
-    q = df.lazy().with_columns(pl.col.x.implode().explode().over("g"))
+    q = df.lazy().with_columns(pl.col.x.implode().explode(empty_as_null=True).over("g"))
     q_base = df.lazy().with_columns(pl.col.x.over("g"))
     expected = df
     assert_frame_equal(q.collect(), expected)

--- a/py-polars/tests/unit/operations/test_over.py
+++ b/py-polars/tests/unit/operations/test_over.py
@@ -16,7 +16,7 @@ def test_implode_explode_over_22188() -> None:
     result = df.select(
         (
             pl.col.x
-            * (pl.lit(pl.Series([1, 1, 1])).implode().explode(empty_as_null=True))
+            * (pl.lit(pl.Series([1, 1, 1])).implode().explode(empty_as_null=False))
         ).over(pl.col.y),
     )
 
@@ -50,7 +50,7 @@ def test_over_explode_22770() -> None:
     df = pl.DataFrame({"x": [[1.0], [2.0]], "idx": [1, 2]})
     e = (
         pl.col("x")
-        .list.explode(empty_as_null=True)
+        .list.explode(empty_as_null=False)
         .over("idx", mapping_strategy="join")
     )
 
@@ -119,14 +119,16 @@ def test_over_replace_strict_22870() -> None:
 )
 def test_implode_explode_list_over_24616(col: list[Any]) -> None:
     df = pl.DataFrame({"x": col})
-    q = df.lazy().select(pl.col.x.implode().explode(empty_as_null=True).over(1))
+    q = df.lazy().select(pl.col.x.implode().explode(empty_as_null=False).over(1))
     q_base = df.lazy().select(pl.col.x.over(1))
     expected = df
     assert_frame_equal(q.collect(), expected)
     assert_frame_equal(q_base.collect(), expected)
 
     df = pl.DataFrame({"g": [10, 10, 20], "x": col})
-    q = df.lazy().with_columns(pl.col.x.implode().explode(empty_as_null=True).over("g"))
+    q = df.lazy().with_columns(
+        pl.col.x.implode().explode(empty_as_null=False).over("g")
+    )
     q_base = df.lazy().with_columns(pl.col.x.over("g"))
     expected = df
     assert_frame_equal(q.collect(), expected)

--- a/py-polars/tests/unit/operations/test_top_k.py
+++ b/py-polars/tests/unit/operations/test_top_k.py
@@ -199,7 +199,7 @@ def test_top_k() -> None:
     assert_frame_equal(
         df2.group_by("c", maintain_order=True)
         .agg(pl.all().top_k_by("a", 2))
-        .explode(cs.all().exclude("c")),
+        .explode(cs.all().exclude("c"), empty_as_null=True),
         pl.DataFrame(
             {
                 "c": ["Apple", "Apple", "Orange", "Banana", "Banana"],
@@ -213,7 +213,7 @@ def test_top_k() -> None:
     assert_frame_equal(
         df2.group_by("c", maintain_order=True)
         .agg(pl.all().bottom_k_by("a", 2))
-        .explode(cs.all().exclude("c")),
+        .explode(cs.all().exclude("c"), empty_as_null=True),
         pl.DataFrame(
             {
                 "c": ["Apple", "Apple", "Orange", "Banana", "Banana"],

--- a/py-polars/tests/unit/operations/test_top_k.py
+++ b/py-polars/tests/unit/operations/test_top_k.py
@@ -199,7 +199,7 @@ def test_top_k() -> None:
     assert_frame_equal(
         df2.group_by("c", maintain_order=True)
         .agg(pl.all().top_k_by("a", 2))
-        .explode(cs.all().exclude("c"), empty_as_null=True),
+        .explode(cs.all().exclude("c"), empty_as_null=False),
         pl.DataFrame(
             {
                 "c": ["Apple", "Apple", "Orange", "Banana", "Banana"],
@@ -213,7 +213,7 @@ def test_top_k() -> None:
     assert_frame_equal(
         df2.group_by("c", maintain_order=True)
         .agg(pl.all().bottom_k_by("a", 2))
-        .explode(cs.all().exclude("c"), empty_as_null=True),
+        .explode(cs.all().exclude("c"), empty_as_null=False),
         pl.DataFrame(
             {
                 "c": ["Apple", "Apple", "Orange", "Banana", "Banana"],

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -766,7 +766,9 @@ def test_window_implode_explode() -> None:
             "y": [2, 2, 2, 3, 3, 3, 4, 4, 4],
         }
     ).select(
-        works=(pl.col.x * pl.col.x.implode().explode()).over(pl.col.y),
+        works=(pl.col.x * pl.col.x.implode().explode(empty_as_null=True)).over(
+            pl.col.y
+        ),
     ).to_dict(as_series=False) == {"works": [1, 4, 9, 1, 4, 9, 1, 4, 9]}
 
 

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -766,7 +766,7 @@ def test_window_implode_explode() -> None:
             "y": [2, 2, 2, 3, 3, 3, 4, 4, 4],
         }
     ).select(
-        works=(pl.col.x * pl.col.x.implode().explode(empty_as_null=True)).over(
+        works=(pl.col.x * pl.col.x.implode().explode(empty_as_null=False)).over(
             pl.col.y
         ),
     ).to_dict(as_series=False) == {"works": [1, 4, 9, 1, 4, 9, 1, 4, 9]}

--- a/py-polars/tests/unit/streaming/test_streaming_group_by.py
+++ b/py-polars/tests/unit/streaming/test_streaming_group_by.py
@@ -484,8 +484,8 @@ def test_streaming_group_by_boolean_mean_15610(
 
     out = (
         pl.select(
-            a=pl.repeat([True, False, True], n_repeats).explode(),
-            b=pl.repeat([True, False, False], n_repeats).explode(),
+            a=pl.repeat([True, False, True], n_repeats).explode(empty_as_null=True),
+            b=pl.repeat([True, False, False], n_repeats).explode(empty_as_null=True),
         )
         .lazy()
         .group_by("a")


### PR DESCRIPTION
Related issue: https://github.com/pola-rs/polars/issues/17664

:robot: Updating of the test suite was done using Claude Opus 4.8

<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI).
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

-->
