### PR TITLE
fix: Ensure slice expr always observes input order

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/simplify_ordering/expr.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_ordering/expr.rs
@@ -529,7 +529,7 @@ impl ExprOrderSimplifier<'_> {
 
                 let observable_in_offset = self.rec(offset, RS::NO_DEORDER);
                 let observable_in_length = self.rec(length, RS::NO_DEORDER);
-                let observable_in_input = self.rec(input, recursion);
+                let observable_in_input = self.rec(input, RS::NO_DEORDER);
 
                 let mut acc = ExprOrderAcc::default();
                 acc.add(observable_in_offset, offset);

--- a/py-polars/tests/unit/lazyframe/test_order_observability.py
+++ b/py-polars/tests/unit/lazyframe/test_order_observability.py
@@ -793,3 +793,16 @@ def test_order_simplify_exprs() -> None:
     )
 
     assert 'col("a").sort(asc).unique_stable()' in plan
+
+
+def test_order_simplify_expr_slice_28028() -> None:
+    q = pl.LazyFrame(data={"a": [0, 1, 3, 4, 2, 2], "b": [0, 1, 4, 5, 2, 3]}).select(
+        pl.col("a").sort_by("b").head(5).mode().first()
+    )
+
+    plan = q.explain()
+
+    assert ".sort_by(" in plan
+    assert ".slice(" in plan
+
+    assert q.collect().item() == 2


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/28028
