### PR TITLE
fix: Fix cross-join predicates not applied when using `sink_*` functions

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -12,6 +12,7 @@ use polars_utils::format_pl_smallstr;
 use polars_utils::itertools::Itertools;
 use polars_utils::pl_path::PlRefPath;
 use polars_utils::unique_id::UniqueId;
+use polars_utils::with_drop::WithDrop;
 
 use super::convert_utils::{SplitPredicates, simplify_predicate};
 use super::stack_opt::ConversionOptimizer;
@@ -1386,6 +1387,13 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             }
         },
         DslPlan::Sink { input, payload } => {
+            let orig_opt_flags = *ctxt.opt_flags;
+            *ctxt.opt_flags |= OptFlags::STREAMING;
+
+            let mut ctxt = WithDrop::new(ctxt, |ctxt| {
+                *ctxt.opt_flags = orig_opt_flags;
+            });
+
             if let SinkType::Iceberg(state) = payload {
                 feature_gated!("python", {
                     use polars_utils::python_convert_registry::get_python_convert_registry;
@@ -1425,13 +1433,13 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                     unified_sink_args.sinked_paths_callback =
                         Some(SinkedPathsCallback::IcebergCommit(state));
 
-                    return to_alp_impl(*plan, ctxt);
+                    return to_alp_impl(*plan, &mut ctxt);
                 })
             }
 
             let input =
-                to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_here!(sink)))?;
-            let input_schema = ctxt.lp_arena.get(input).schema(ctxt.lp_arena);
+                to_alp_impl(owned(input), &mut ctxt).map_err(|e| e.context(failed_here!(sink)))?;
+            let input_schema = ctxt.lp_arena.get(input).schema(ctxt.lp_arena).into_owned();
             let payload = match payload {
                 SinkType::Iceberg(_) => unreachable!(),
                 SinkType::Memory => SinkTypeIR::Memory,
@@ -1493,6 +1501,8 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                     max_rows_per_file,
                     approximate_bytes_per_file,
                 }) => {
+                    let ctxt = &mut **ctxt;
+
                     let expr_to_ir_cx = &mut ExprToIRContext::new_with_opt_eager(
                         ctxt.expr_arena,
                         &input_schema,
@@ -1538,7 +1548,6 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
 
                     #[cfg(feature = "parquet")]
                     {
-                        let input_schema = input_schema.into_owned();
                         let file_schema =
                             options.file_output_schema(&input_schema, ctxt.expr_arena)?;
 
@@ -1563,7 +1572,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             };
 
             let lp = IR::Sink { input, payload };
-            return run_conversion(lp, ctxt, "sink");
+            return run_conversion(lp, &mut ctxt, "sink");
         },
         DslPlan::SinkMultiple { inputs } => {
             let inputs = inputs

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -9,6 +9,7 @@ use polars_core::datatypes::PlHashMap;
 use polars_core::prelude::*;
 use polars_utils::idx_vec::UnitVec;
 use polars_utils::scratch_vec::ScratchUnitVec;
+use polars_utils::with_drop::WithDrop;
 use recursive::recursive;
 use utils::*;
 
@@ -613,7 +614,19 @@ impl PredicatePushDown {
                     self.pushdown_and_continue(lp, acc_predicates, lp_arena, expr_arena, true)?;
                 Ok(self.optional_apply_predicate(lp, local_predicates, lp_arena, expr_arena))
             },
-            lp @ Sink { .. } | lp @ SinkMultiple { .. } => {
+            lp @ Sink { .. } => {
+                let orig_streaming = self.streaming;
+                self.streaming = true;
+
+                WithDrop::new(self, |slf| slf.streaming = orig_streaming).pushdown_and_continue(
+                    lp,
+                    acc_predicates,
+                    lp_arena,
+                    expr_arena,
+                    false,
+                )
+            },
+            lp @ SinkMultiple { .. } => {
                 self.pushdown_and_continue(lp, acc_predicates, lp_arena, expr_arena, false)
             },
             // Pushed down passed these nodes

--- a/py-polars/tests/unit/io/test_sink.py
+++ b/py-polars/tests/unit/io/test_sink.py
@@ -471,3 +471,21 @@ def test_sinked_paths_callback(tmp_path: Path) -> None:
             ),
             _sinked_paths_callback=lambda _: None,
         )
+
+
+def test_sink_predicate_pushdown_streaming_flag_27922() -> None:
+    q = (
+        pl.LazyFrame({"role": ["ST"]})
+        .join(
+            pl.LazyFrame({"key": ["cb", "st"], "tags": [["CB"], ["ST"]]}), how="cross"
+        )
+        .filter(pl.col("tags").list.contains(pl.col("role")))
+    )
+
+    f = io.BytesIO()
+    q.sink_ipc(f)
+
+    assert_frame_equal(
+        pl.scan_ipc(f).collect(),
+        pl.DataFrame({"role": ["ST"], "key": ["st"], "tags": [["ST"]]}),
+    )


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/27922

Set the streaming flag in opt-state when we traverse into a subtree under scan
