### PR TITLE
fix: Fix `select(len())` incorrectly returned 0 when using `scan_iceberg` with `pyiceberg` as reader override

### DIFF
--- a/py-polars/src/polars/io/iceberg/_utils.py
+++ b/py-polars/src/polars/io/iceberg/_utils.py
@@ -30,7 +30,7 @@ from polars._utils.wrap import wrap_s
 from polars.exceptions import ComputeError
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Iterator, Sequence
+    from collections.abc import Callable, Iterable, Sequence
     from datetime import date, datetime
 
     import pyiceberg
@@ -96,8 +96,6 @@ def _scan_pyarrow_dataset_impl(
     that could not be converted
     to pyarrow and need to be applied as post-predicate.
     """
-    from polars import from_arrow
-
     scan = tbl.scan(limit=n_rows, snapshot_id=snapshot_id)
 
     if with_columns is not None:
@@ -121,7 +119,7 @@ def _scan_pyarrow_dataset_impl(
 
     batches = scan.to_arrow_batch_reader()
 
-    return ((from_arrow(batch) for batch in batches), False)
+    return ((pl.DataFrame(batch) for batch in batches), False)
 
 
 def _ensure_boolean_expression(result: Any) -> Any:

--- a/py-polars/src/polars/io/iceberg/_utils.py
+++ b/py-polars/src/polars/io/iceberg/_utils.py
@@ -30,7 +30,7 @@ from polars._utils.wrap import wrap_s
 from polars.exceptions import ComputeError
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator, Sequence
+    from collections.abc import Callable, Iterable, Iterator, Sequence
     from datetime import date, datetime
 
     import pyiceberg
@@ -101,6 +101,22 @@ def _scan_pyarrow_dataset_impl(
     scan = tbl.scan(limit=n_rows, snapshot_id=snapshot_id)
 
     if with_columns is not None:
+        if not with_columns:
+            assert iceberg_table_filter is None
+
+            def gen() -> Iterable[pl.DataFrame]:
+                remaining = scan.count()
+
+                if n_rows is not None:
+                    remaining = min(remaining, n_rows)
+
+                while remaining > 0:
+                    n = min(remaining, 100_000)
+                    yield pl.DataFrame(height=n)
+                    remaining -= n
+
+            return (gen(), False)
+
         scan = scan.select(*with_columns)
 
     if iceberg_table_filter is not None:

--- a/py-polars/src/polars/io/iceberg/_utils.py
+++ b/py-polars/src/polars/io/iceberg/_utils.py
@@ -110,13 +110,7 @@ def _scan_pyarrow_dataset_impl(
                 if n_rows is not None:
                     remaining = min(remaining, n_rows)
 
-                while True:
-                    n = min(remaining, 100_000)
-                    yield pl.DataFrame(height=n)
-                    remaining -= n
-
-                    if remaining == 0:
-                        break
+                yield pl.DataFrame(height=remaining)
 
             return (gen(), False)
 

--- a/py-polars/src/polars/io/iceberg/_utils.py
+++ b/py-polars/src/polars/io/iceberg/_utils.py
@@ -66,7 +66,7 @@ def _scan_pyarrow_dataset_impl(
     n_rows: int | None = None,
     snapshot_id: int | None = None,
     **kwargs: Any,  # noqa: ARG001
-) -> tuple[Iterator[DataFrame], bool]:
+) -> tuple[Iterable[DataFrame], bool]:
     """
     Take the projected columns and materialize an arrow table.
 
@@ -121,7 +121,7 @@ def _scan_pyarrow_dataset_impl(
 
     batches = scan.to_arrow_batch_reader()
 
-    return ((from_arrow(batch) for batch in batches), False)  # type: ignore[misc]
+    return ((from_arrow(batch) for batch in batches), False)
 
 
 def _ensure_boolean_expression(result: Any) -> Any:

--- a/py-polars/src/polars/io/iceberg/_utils.py
+++ b/py-polars/src/polars/io/iceberg/_utils.py
@@ -110,10 +110,13 @@ def _scan_pyarrow_dataset_impl(
                 if n_rows is not None:
                     remaining = min(remaining, n_rows)
 
-                while remaining > 0:
+                while True:
                     n = min(remaining, 100_000)
                     yield pl.DataFrame(height=n)
                     remaining -= n
+
+                    if remaining == 0:
+                        break
 
             return (gen(), False)
 

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -2450,7 +2450,7 @@ def test_scan_iceberg_categorical_24140(tmp_path: Path) -> None:
 
 @pytest.mark.write_disk
 @pytest.mark.parametrize("reader_override", ["native", "pyiceberg"])
-def test_scan_iceberg_fast_count(tmp_path: Path, reader_override: str) -> None:
+def test_scan_iceberg_fast_count(tmp_path: Path, reader_override: Any) -> None:
     catalog = SqlCatalog(
         "default",
         uri="sqlite:///:memory:",

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -2449,7 +2449,8 @@ def test_scan_iceberg_categorical_24140(tmp_path: Path) -> None:
 
 
 @pytest.mark.write_disk
-def test_scan_iceberg_fast_count(tmp_path: Path) -> None:
+@pytest.mark.parametrize("reader_override", ["native", "pyiceberg"])
+def test_scan_iceberg_fast_count(tmp_path: Path, reader_override: str) -> None:
     catalog = SqlCatalog(
         "default",
         uri="sqlite:///:memory:",
@@ -2467,7 +2468,9 @@ def test_scan_iceberg_fast_count(tmp_path: Path) -> None:
     pl.DataFrame({"a": [0, 1, 2, 3, 4]}).write_iceberg(tbl, mode="append")
 
     assert (
-        pl.scan_iceberg(tbl, reader_override="native", use_metadata_statistics=True)
+        pl.scan_iceberg(
+            tbl, reader_override=reader_override, use_metadata_statistics=True
+        )
         .select(pl.len())
         .collect()
         .item()
@@ -2475,7 +2478,9 @@ def test_scan_iceberg_fast_count(tmp_path: Path) -> None:
     )
 
     assert (
-        pl.scan_iceberg(tbl, reader_override="native", use_metadata_statistics=True)
+        pl.scan_iceberg(
+            tbl, reader_override=reader_override, use_metadata_statistics=True
+        )
         .filter(pl.col("a") <= 2)
         .select(pl.len())
         .collect()
@@ -2484,7 +2489,9 @@ def test_scan_iceberg_fast_count(tmp_path: Path) -> None:
     )
 
     assert (
-        pl.scan_iceberg(tbl, reader_override="native", use_metadata_statistics=True)
+        pl.scan_iceberg(
+            tbl, reader_override=reader_override, use_metadata_statistics=True
+        )
         .head(3)
         .select(pl.len())
         .collect()
@@ -2493,7 +2500,9 @@ def test_scan_iceberg_fast_count(tmp_path: Path) -> None:
     )
 
     assert (
-        pl.scan_iceberg(tbl, reader_override="native", use_metadata_statistics=True)
+        pl.scan_iceberg(
+            tbl, reader_override=reader_override, use_metadata_statistics=True
+        )
         .slice(1, 3)
         .select(pl.len())
         .collect()
@@ -2516,10 +2525,18 @@ def test_scan_iceberg_fast_count(tmp_path: Path) -> None:
         p,
     )
 
+    if reader_override == "pyiceberg":
+        return
+
     # `use_metadata_statistics=False` should disable sourcing the row count from
     # Iceberg metadata.
+
     assert (
-        pl.scan_iceberg(tbl, reader_override="native", use_metadata_statistics=False)
+        pl.scan_iceberg(
+            tbl,
+            reader_override=reader_override,
+            use_metadata_statistics=False,
+        )
         .select(pl.len())
         .collect()
         .item()
@@ -2530,7 +2547,7 @@ def test_scan_iceberg_fast_count(tmp_path: Path) -> None:
         pickle.loads(
             pickle.dumps(
                 pl.scan_iceberg(
-                    tbl, reader_override="native", use_metadata_statistics=False
+                    tbl, reader_override=reader_override, use_metadata_statistics=False
                 ).select(pl.len())
             )
         )
@@ -2549,12 +2566,15 @@ def test_scan_iceberg_fast_count(tmp_path: Path) -> None:
             else "No such file or directory"
         ),
     ):
-        pl.scan_iceberg(tbl, reader_override="native").collect()
+        pl.scan_iceberg(tbl, reader_override=reader_override).collect()
 
     # `select(len())` should be able to return the result from the Iceberg metadata
     # without looking at the underlying data files.
     assert (
-        pl.scan_iceberg(tbl, reader_override="native").select(pl.len()).collect().item()
+        pl.scan_iceberg(tbl, reader_override=reader_override)
+        .select(pl.len())
+        .collect()
+        .item()
         == 5
     )
 


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/27968
