### PR TITLE
ci: Use native jq on Windows ARM64

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -224,7 +224,7 @@ jobs:
           Expand-Archive /cmake.zip -DestinationPath /
 
           Write-Output "> Download jq.exe (github.com/jqlang) (needed for tomlq / yq)"
-          Invoke-WebRequest https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-windows-i386.exe -OutFile /jq.exe
+          Invoke-WebRequest https://github.com/jqlang/jq/releases/download/jq-1.8.2/jq-windows-arm64.exe -OutFile /jq.exe
 
           Write-Output "> Update GITHUB_PATH"
           [System.IO.File]::AppendAllText($Env:GITHUB_PATH, "`n" + "C:/git/bin/")


### PR DESCRIPTION
## Summary

Use the native Windows ARM64 jq release asset in the Windows ARM64 release setup.

The current workflow downloads the 32-bit x86 jq binary on the `windows-11-arm` runner:

```text
jq-windows-i386.exe
```

This PR switches that download to the native ARM64 binary now available in jq 1.8.2:

```text
jq-windows-arm64.exe
```

This keeps the change scoped to the existing `build-wheels` Windows ARM64 setup. It does not add new release jobs or change the Python publishing dependency chain.

## Validation

- Parsed GitHub workflow YAML locally.
- Ran `git diff --check origin/main..HEAD`.
- Verified the new release asset URL with `curl -I -L --max-time 20`:
  - GitHub release URL returned `302`;
  - release asset returned `200`;
  - final `content-disposition` filename is `jq-windows-arm64.exe`.

## AI-generated code

I used AI assistance to draft the workflow change and validation notes. I reviewed the change manually and believe it is relevant and correct.
