### PR TITLE
fix: Avoid panic on temporal extraction for datetime columns with nulls

### DIFF
--- a/crates/polars-arrow/src/compute/temporal.rs
+++ b/crates/polars-arrow/src/compute/temporal.rs
@@ -197,14 +197,14 @@ where
                 .as_any()
                 .downcast_ref::<PrimitiveArray<i64>>()
                 .unwrap();
-            let func = match time_unit {
-                TimeUnit::Second => timestamp_s_to_datetime,
-                TimeUnit::Millisecond => timestamp_ms_to_datetime,
-                TimeUnit::Microsecond => timestamp_us_to_datetime,
-                TimeUnit::Nanosecond => timestamp_ns_to_datetime,
+            let func: fn(i64) -> Option<chrono::NaiveDateTime> = match time_unit {
+                TimeUnit::Second => timestamp_s_to_datetime_opt,
+                TimeUnit::Millisecond => timestamp_ms_to_datetime_opt,
+                TimeUnit::Microsecond => timestamp_us_to_datetime_opt,
+                TimeUnit::Nanosecond => timestamp_ns_to_datetime_opt,
             };
             Ok(PrimitiveArray::<O>::from_trusted_len_iter(
-                array.iter().map(|v| v.map(|x| op(func(*x)))),
+                array.iter().map(|v| v.and_then(|x| func(*x).map(&op))),
             ))
         },
         _ => unreachable!(),
@@ -296,46 +296,22 @@ where
     A: NativeType,
     F: Fn(chrono::DateTime<T>) -> A,
 {
-    match time_unit {
-        TimeUnit::Second => {
-            let op = |x| {
-                let datetime = timestamp_s_to_datetime(x);
+    let timestamp_to_datetime_opt: fn(i64) -> Option<chrono::NaiveDateTime> = match time_unit {
+        TimeUnit::Second => timestamp_s_to_datetime_opt,
+        TimeUnit::Millisecond => timestamp_ms_to_datetime_opt,
+        TimeUnit::Microsecond => timestamp_us_to_datetime_opt,
+        TimeUnit::Nanosecond => timestamp_ns_to_datetime_opt,
+    };
+
+    let iter = array.iter().map(|opt| {
+        opt.and_then(|&x| {
+            timestamp_to_datetime_opt(x).map(|datetime| {
                 let offset = timezone.offset_from_utc_datetime(&datetime);
                 extract(chrono::DateTime::<T>::from_naive_utc_and_offset(
                     datetime, offset,
                 ))
-            };
-            unary(array, op, A::PRIMITIVE.into())
-        },
-        TimeUnit::Millisecond => {
-            let op = |x| {
-                let datetime = timestamp_ms_to_datetime(x);
-                let offset = timezone.offset_from_utc_datetime(&datetime);
-                extract(chrono::DateTime::<T>::from_naive_utc_and_offset(
-                    datetime, offset,
-                ))
-            };
-            unary(array, op, A::PRIMITIVE.into())
-        },
-        TimeUnit::Microsecond => {
-            let op = |x| {
-                let datetime = timestamp_us_to_datetime(x);
-                let offset = timezone.offset_from_utc_datetime(&datetime);
-                extract(chrono::DateTime::<T>::from_naive_utc_and_offset(
-                    datetime, offset,
-                ))
-            };
-            unary(array, op, A::PRIMITIVE.into())
-        },
-        TimeUnit::Nanosecond => {
-            let op = |x| {
-                let datetime = timestamp_ns_to_datetime(x);
-                let offset = timezone.offset_from_utc_datetime(&datetime);
-                extract(chrono::DateTime::<T>::from_naive_utc_and_offset(
-                    datetime, offset,
-                ))
-            };
-            unary(array, op, A::PRIMITIVE.into())
-        },
-    }
+            })
+        })
+    });
+    PrimitiveArray::from_trusted_len_iter(iter)
 }

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -1559,3 +1559,40 @@ def test_out_of_range_date_year_11991() -> None:
     # is_leap_year should also return null for out-of-range dates
     result_leap = s.dt.is_leap_year()
     assert result_leap[0] is None
+
+
+@pytest.mark.parametrize(
+    "method", ["day", "month", "year", "hour", "minute", "second", "weekday"]
+)
+def test_dt_extract_with_null_tz_aware_27862(method: str) -> None:
+    # A null slot's backing value may be anything (only valid, initialized
+    # memory is guaranteed); pandas/pyarrow leave i64::MIN there. Extraction
+    # must skip the masked slot rather than convert it, which previously panicked.
+    pa = pytest.importorskip("pyarrow")
+    i64_min = -(2**63)
+    values = (1609459200000000).to_bytes(8, "little", signed=True) + i64_min.to_bytes(
+        8, "little", signed=True
+    )
+    arr = pa.Array.from_buffers(
+        pa.timestamp("us", tz="UTC"),
+        2,
+        [pa.py_buffer(bytes([0b01])), pa.py_buffer(values)],
+    )
+    s: pl.Series = pl.from_arrow(arr)  # type: ignore[assignment]
+    out = getattr(s.dt, method)()
+    assert out[1] is None
+    assert out[0] is not None
+
+
+@pytest.mark.parametrize("tz", [None, "UTC"])
+@pytest.mark.parametrize("method", ["day", "month", "year", "hour", "minute", "second"])
+def test_dt_extract_present_out_of_range_27862(method: str, tz: str | None) -> None:
+    # A *present* (non-null) timestamp that is out of the representable datetime
+    # range must yield null, not a garbage default value or a panic. Build it by
+    # casting a raw i64 that is far beyond chrono's range into a Datetime column.
+    s = pl.Series([9_000_000_000_000_000_000], dtype=pl.Int64).cast(
+        pl.Datetime("us", tz)
+    )
+    assert s.null_count() == 0  # the value is present, not masked
+    out = getattr(s.dt, method)()
+    assert out[0] is None


### PR DESCRIPTION
Closes #27862.

Extracting a datetime component (`dt.day`, `dt.month`, `dt.year`, ...) from a timezone-aware column that contains nulls panics with `invalid or out-of-range datetime`. It shows up when converting from pandas/pyarrow, where a null timestamp keeps `i64::MIN` in the values buffer rather than `0`.

The timezone-aware extraction kernel used `unary`, which applies the timestamp-to-datetime conversion to every physical value (including masked ones) before re-applying validity, so it converts the out-of-range sentinel and panics.

The kernel now uses the `_opt` conversion variants and iterates over the validity-aware iterator instead of `unary`. Masked values are left as null instead of the non-opt version which has an expect that leads to the panic, and a present but out-of-range value yields null instead of a garbage default. The timezone-naive kernel had the same panic on a present out-of-range value and gets the same treatment.

Resubmission of #28000.

## `make test`
<img width="1549" height="740" alt="image" src="https://github.com/user-attachments/assets/867b2ee0-f808-494b-af11-af5f0958d29d" />