### PR TITLE
depr: Deprecate casts from string to temporal dtypes

### DIFF
--- a/crates/polars-compute/src/cast/mod.rs
+++ b/crates/polars-compute/src/cast/mod.rs
@@ -29,7 +29,7 @@ use binview_to::{
 };
 pub use binview_to::{binview_to_fixed_size_list_dyn, binview_to_primitive_dyn};
 use dictionary_to::*;
-use polars_error::{PolarsResult, polars_bail, polars_ensure, polars_err};
+use polars_error::{PolarsResult, polars_bail, polars_ensure, polars_err, polars_warn};
 use polars_utils::IdxSize;
 use polars_utils::float16::pf16;
 pub use primitive_to::*;
@@ -550,16 +550,35 @@ pub fn cast(
                 Float32 => utf8view_to_primitive_dyn::<f32>(arr, to_type, options),
                 Float64 => utf8view_to_primitive_dyn::<f64>(arr, to_type, options),
                 Timestamp(time_unit, None) => {
+                    polars_warn!(
+                        Deprecation,
+                        "Casting from String to DateTime is deprecated and will be removed in Polars 2.0.\n\
+                        Use `str.to_datetime()` instead."
+                    );
                     utf8view_to_naive_timestamp_dyn(array, time_unit.to_owned())
                 },
-                Timestamp(time_unit, Some(time_zone)) => utf8view_to_timestamp(
-                    array.as_any().downcast_ref().unwrap(),
-                    RFC3339,
-                    time_zone.clone(),
-                    time_unit.to_owned(),
-                )
-                .map(|arr| arr.boxed()),
-                Date32 => utf8view_to_date32_dyn(array),
+                Timestamp(time_unit, Some(time_zone)) => {
+                    polars_warn!(
+                        Deprecation,
+                        "Casting from String to DateTime is deprecated and will be removed in Polars 2.0.\n\
+                        Use `str.to_datetime(..., \"time_zone={time_zone}\")` instead."
+                    );
+                    utf8view_to_timestamp(
+                        array.as_any().downcast_ref().unwrap(),
+                        RFC3339,
+                        time_zone.clone(),
+                        time_unit.to_owned(),
+                    )
+                    .map(|arr| arr.boxed())
+                },
+                Date32 => {
+                    polars_warn!(
+                        Deprecation,
+                        "Casting from String to DateTime is deprecated and will be removed in Polars 2.0.\n\
+                        Use `str.to_date()` instead."
+                    );
+                    utf8view_to_date32_dyn(array)
+                },
                 #[cfg(feature = "dtype-decimal")]
                 Decimal(precision, scale) => {
                     Ok(binview_to_decimal(&arr.to_binview(), *precision, *scale).to_boxed())

--- a/crates/polars-compute/src/cast/mod.rs
+++ b/crates/polars-compute/src/cast/mod.rs
@@ -574,7 +574,7 @@ pub fn cast(
                 Date32 => {
                     polars_warn!(
                         Deprecation,
-                        "Casting from String to DateTime is deprecated and will be removed in Polars 2.0.\n\
+                        "Casting from String to Date is deprecated and will be removed in Polars 2.0.\n\
                         Use `str.to_date()` instead."
                     );
                     utf8view_to_date32_dyn(array)

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2526,3 +2526,22 @@ def test_timezone_ignore_error(
         match="unable to parse time zone: 'non-existent'",
     ):
         pl.DataFrame(tbl)
+
+
+def test_string_to_temporal_cast_deprecated() -> None:
+    with pytest.warns(
+        DeprecationWarning, match="Casting from String to DateTime is deprecated"
+    ):
+        pl.Series(["2022-08-30T10:30:45"]).cast(pl.Datetime("us"))
+
+    with pytest.warns(
+        DeprecationWarning, match="Casting from String to DateTime is deprecated"
+    ):
+        pl.Series(["2022-08-30T10:30:45+00:00"]).cast(
+            pl.Datetime("us", "Europe/Amsterdam")
+        )
+
+    with pytest.warns(
+        DeprecationWarning, match="Casting from String to Date is deprecated"
+    ):
+        pl.Series(["2022-08-30"]).cast(pl.Date)


### PR DESCRIPTION
Related issue: https://github.com/pola-rs/polars/issues/23363

:robot: Claude Opus 4.8 generated the test