### PR TITLE
chore!: Remove the `'physical'`/`'lexical'` exception for `pl.Categorical()` as well as the `ordering` argument

### DIFF
--- a/py-polars/src/polars/datatypes/classes.py
+++ b/py-polars/src/polars/datatypes/classes.py
@@ -30,7 +30,6 @@ if TYPE_CHECKING:
 
     from polars import Series
     from polars._typing import (
-        CategoricalOrdering,
         PolarsDataType,
         PythonDataType,
         SchemaDict,
@@ -867,56 +866,20 @@ class Categorical(DataType):
         :py:class:`Categories`. If not provided, the global categories
         (`pl.Categories()`) are used.
 
-        For legacy reasons if the string is either `"physical"` or `"lexical"`,
-        it is ignored and a warning is issued. If you wish to use a `Categories`
-        named `"physical"` or `"lexical"`, please pass it using
-        :py:class:`Categories` explicitly.
-
-    ordering : {'lexical', 'physical'}
-        This used to specify how this type was ordered, but now does nothing.
-
-        .. deprecated:: 1.32.0
-            Parameter is now ignored. Always behaves as if `'lexical'` was passed.
-
     See Also
     --------
     Categories
     """
 
-    ordering: CategoricalOrdering | None
     categories: Categories
 
     def __init__(
         self,
         categories: Categories | str | None = None,
-        *,
-        ordering: CategoricalOrdering | None = None,
     ) -> None:
-        # Because we supported the positional 'ordering' arg in the past, we
-        # need to check for this in the categories argument.
         if isinstance(categories, str):
-            if categories == "physical" or categories == "lexical":
-                from polars._utils.deprecation import issue_deprecation_warning
-
-                msg = (
-                    "the ordering parameter on Categorical is deprecated. The ordering is now always lexical."
-                    "\n\nIf you meant to use a Categories named 'physical' or 'lexical', pass it using pl.Categories('physical') or pl.Categories('lexical')."
-                )
-                issue_deprecation_warning(msg, version="1.32.0")
-                categories = Categories()
-            else:
-                categories = Categories(name=categories)
-
-        if ordering is not None:
-            from polars._utils.deprecation import issue_deprecation_warning
-
-            issue_deprecation_warning(
-                "the ordering parameter on Categorical is deprecated. The ordering is now always lexical.",
-                version="1.32.0",
-            )
-
-        self.ordering = "lexical"
-        if categories is None:
+            self.categories = Categories(name=categories)
+        elif categories is None:
             self.categories = Categories()
         else:
             self.categories = categories

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -1026,15 +1026,6 @@ def test_misaligned_nested_arrow_19097() -> None:
     assert_series_equal(pl.Series("a", a.to_arrow()), a)
 
 
-def test_arrow_roundtrip_lex_cat_20288() -> None:
-    tb = pl.Series("a", ["A", "B"], pl.Categorical()).to_frame().to_arrow()
-    df = pl.from_arrow(tb)
-    assert isinstance(df, pl.DataFrame)
-    dt = df.schema["a"]
-    assert isinstance(dt, pl.Categorical)
-    assert dt.ordering == "lexical"
-
-
 def test_from_arrow_20271() -> None:
     df = pl.from_arrow(
         pa.table({"b": pa.DictionaryArray.from_arrays([0, 1], ["D", "E"])})

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -2744,16 +2744,6 @@ def test_parquet_cast_to_cat() -> None:
     )
 
 
-def test_parquet_roundtrip_lex_cat_20288() -> None:
-    f = io.BytesIO()
-    df = pl.Series("a", ["A", "B"], pl.Categorical()).to_frame()
-    df.write_parquet(f)
-    f.seek(0)
-    dt = pl.scan_parquet(f).collect_schema()["a"]
-    assert isinstance(dt, pl.Categorical)
-    assert dt.ordering == "lexical"
-
-
 def test_from_parquet_20271() -> None:
     f = io.BytesIO()
     df = pl.Series("b", ["D", "E"], pl.Categorical).to_frame()

--- a/py-polars/tests/unit/operations/namespaces/test_categorical.py
+++ b/py-polars/tests/unit/operations/namespaces/test_categorical.py
@@ -87,20 +87,6 @@ def test_cat_to_local() -> None:
     assert_series_equal(s, s.cat.to_local())
 
 
-def test_cat_uses_lexical_ordering() -> None:
-    with pytest.warns(DeprecationWarning, match="ordering parameter"):
-        physical_cat = pl.Categorical(ordering="physical")
-
-    for dtype in [pl.Categorical, pl.Categorical(), physical_cat]:
-        s = pl.Series(["a", "b", None, "b"]).cast(dtype)  # type: ignore[arg-type]
-
-        with pytest.warns(
-            DeprecationWarning,
-            match="Categoricals are now always ordered lexically",
-        ):
-            assert s.cat.uses_lexical_ordering()
-
-
 @pytest.mark.parametrize("dtype", [pl.Categorical, pl.Enum])
 def test_cat_len_bytes(dtype: PolarsDataType) -> None:
     # test Series


### PR DESCRIPTION
Related issue: https://github.com/pola-rs/polars/issues/25447

:robot: No AI was user for this PR