### PR TITLE
feat(python!): Set the output name of repeat to its leftmost argument name

### DIFF
--- a/crates/polars-plan/src/dsl/functions/repeat.rs
+++ b/crates/polars-plan/src/dsl/functions/repeat.rs
@@ -5,9 +5,5 @@ use super::*;
 /// Generally you won't need this function, as `lit(value)` already represents a column containing
 /// only `value` whose length is automatically set to the correct number of rows.
 pub fn repeat<E: Into<Expr>>(value: E, n: Expr) -> Expr {
-    let expr = Expr::n_ary(FunctionExpr::Repeat, vec![value.into(), n]);
-
-    // @NOTE: This alias should probably not be here for consistency, but it is here for backwards
-    // compatibility until 2.0.
-    expr.alias(PlSmallStr::from_static("repeat"))
+    Expr::n_ary(FunctionExpr::Repeat, vec![value.into(), n])
 }

--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -1526,18 +1526,18 @@ class Expr:
 
         >>> df.select(pl.repeat(None, 3).append(pl.col("a")).rechunk())
         shape: (6, 1)
-        ┌────────┐
-        │ repeat │
-        │ ---    │
-        │ i64    │
-        ╞════════╡
-        │ null   │
-        │ null   │
-        │ null   │
-        │ 1      │
-        │ 1      │
-        │ 2      │
-        └────────┘
+        ┌─────────┐
+        │ literal │
+        │ ---     │
+        │ i64     │
+        ╞═════════╡
+        │ null    │
+        │ null    │
+        │ null    │
+        │ 1       │
+        │ 1       │
+        │ 2       │
+        └─────────┘
         """
         return wrap_expr(self._pyexpr.rechunk())
 

--- a/py-polars/src/polars/functions/repeat.py
+++ b/py-polars/src/polars/functions/repeat.py
@@ -119,7 +119,7 @@ def repeat(
 
     >>> pl.select(pl.repeat("z", n=3)).to_series()
     shape: (3,)
-    Series: 'repeat' [str]
+    Series: 'literal' [str]
     [
             "z"
             "z"
@@ -130,7 +130,7 @@ def repeat(
 
     >>> pl.repeat(3, n=3, dtype=pl.Int8, eager=True)
     shape: (3,)
-    Series: 'repeat' [i8]
+    Series: 'literal' [i8]
     [
             3
             3

--- a/py-polars/tests/unit/datatypes/test_array.py
+++ b/py-polars/tests/unit/datatypes/test_array.py
@@ -313,7 +313,7 @@ def test_arr_median(data_dispersion: pl.DataFrame) -> None:
 def test_array_repeat() -> None:
     dtype = pl.Array(pl.UInt8, shape=1)
     s = pl.repeat([42], n=3, dtype=dtype, eager=True)
-    expected = pl.Series("repeat", [[42], [42], [42]], dtype=dtype)
+    expected = pl.Series("literal", [[42], [42], [42]], dtype=dtype)
     assert s.dtype == dtype
     assert_series_equal(s, expected)
 

--- a/py-polars/tests/unit/functions/test_repeat.py
+++ b/py-polars/tests/unit/functions/test_repeat.py
@@ -42,9 +42,10 @@ def test_repeat(
     dtype: PolarsDataType,
     expected_dtype: PolarsDataType,
 ) -> None:
-    expected = pl.Series("repeat", [value] * n).cast(expected_dtype)
+    expected = pl.Series("literal", [value] * n).cast(expected_dtype)
 
     result_eager = pl.repeat(value, n=n, dtype=dtype, eager=True)
+    print(result_eager)
     assert_series_equal(result_eager, expected)
 
     result_lazy = pl.select(pl.repeat(value, n=n, dtype=dtype, eager=False)).to_series()
@@ -53,14 +54,14 @@ def test_repeat(
 
 def test_repeat_expr_input_eager() -> None:
     result = pl.select(pl.repeat(1, n=pl.lit(3), eager=True)).to_series()
-    expected = pl.Series("repeat", [1, 1, 1], dtype=pl.Int32)
+    expected = pl.Series("literal", [1, 1, 1], dtype=pl.Int32)
     assert_series_equal(result, expected)
 
 
 def test_repeat_expr_input_lazy() -> None:
     df = pl.DataFrame({"a": [3, 2, 1]})
     result = df.select(pl.repeat(1, n=pl.col("a").first())).to_series()
-    expected = pl.Series("repeat", [1, 1, 1], dtype=pl.Int32)
+    expected = pl.Series("literal", [1, 1, 1], dtype=pl.Int32)
     assert_series_equal(result, expected)
 
     df = pl.DataFrame({"a": [3, 2, 1]})

--- a/py-polars/tests/unit/functions/test_repeat.py
+++ b/py-polars/tests/unit/functions/test_repeat.py
@@ -45,7 +45,6 @@ def test_repeat(
     expected = pl.Series("literal", [value] * n).cast(expected_dtype)
 
     result_eager = pl.repeat(value, n=n, dtype=dtype, eager=True)
-    print(result_eager)
     assert_series_equal(result_eager, expected)
 
     result_lazy = pl.select(pl.repeat(value, n=n, dtype=dtype, eager=False)).to_series()

--- a/py-polars/tests/unit/operations/test_queries.py
+++ b/py-polars/tests/unit/operations/test_queries.py
@@ -43,7 +43,7 @@ def test_repeat_expansion_in_group_by() -> None:
         .agg(pl.repeat(1, pl.len()).cum_sum())
         .to_dict(as_series=False)
     )
-    assert out == {"g": [1, 2, 3], "repeat": [[1], [1, 2], [1, 2, 3]]}
+    assert out == {"g": [1, 2, 3], "literal": [[1], [1, 2], [1, 2, 3]]}
 
 
 def test_agg_after_head() -> None:


### PR DESCRIPTION
Related issue: https://github.com/pola-rs/polars/issues/19151
