### PR TITLE
chore: Add Morsel::height

### DIFF
--- a/crates/polars-stream/src/morsel.rs
+++ b/crates/polars-stream/src/morsel.rs
@@ -109,6 +109,10 @@ impl Morsel {
         (self.df, self.seq, self.source_token, self.consume_token)
     }
 
+    pub fn height(&self) -> usize {
+        self.df.height()
+    }
+
     pub fn into_df(self) -> DataFrame {
         self.df
     }

--- a/crates/polars-stream/src/nodes/cum_agg.rs
+++ b/crates/polars-stream/src/nodes/cum_agg.rs
@@ -75,7 +75,7 @@ impl ComputeNode for CumAggNode {
         join_handles.push(scope.spawn_task(TaskPriority::High, async move {
             while let Ok(mut m) = recv.recv().await {
                 assert_eq!(m.df().width(), 1);
-                if m.df().height() == 0 {
+                if m.height() == 0 {
                     continue;
                 }
 

--- a/crates/polars-stream/src/nodes/filter.rs
+++ b/crates/polars-stream/src/nodes/filter.rs
@@ -58,7 +58,7 @@ impl ComputeNode for FilterNode {
                         })
                         .await?;
 
-                    if morsel.df().height() == 0 {
+                    if morsel.height() == 0 {
                         continue;
                     }
 

--- a/crates/polars-stream/src/nodes/forward_fill.rs
+++ b/crates/polars-stream/src/nodes/forward_fill.rs
@@ -71,7 +71,7 @@ impl ComputeNode for ForwardFillNode {
         // count for each morsel, then distributes (morsel, last, consecutive_nulls) to workers.
         join_handles.push(scope.spawn_task(TaskPriority::High, async move {
             while let Ok(morsel) = receiver.recv().await {
-                if morsel.df().height() == 0 {
+                if morsel.height() == 0 {
                     continue;
                 }
 

--- a/crates/polars-stream/src/nodes/gather_every.rs
+++ b/crates/polars-stream/src/nodes/gather_every.rs
@@ -57,7 +57,7 @@ impl ComputeNode for GatherEveryNode {
         // To figure out the correct offsets we need to be serial.
         join_handles.push(scope.spawn_task(TaskPriority::High, async move {
             while let Ok(morsel) = receiver.recv().await {
-                let height = morsel.df().height();
+                let height = morsel.height();
                 if self.offset >= height {
                     self.offset -= height;
                     continue;

--- a/crates/polars-stream/src/nodes/io_sinks/components/partition_morsel_sender.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/components/partition_morsel_sender.rs
@@ -153,7 +153,7 @@ impl PartitionMorselSender {
 
             let mut morsel = SinkMorsel::new(df, morsel_permit);
 
-            let morsel_height: IdxSize = IdxSize::try_from(morsel.df().height()).unwrap();
+            let morsel_height: IdxSize = IdxSize::try_from(morsel.height()).unwrap();
 
             debug_assert!(
                 self.takeable_rows_provider.max_size.get().num_rows
@@ -165,7 +165,7 @@ impl PartitionMorselSender {
 
             if let Some(hstack_keys) = self.hstack_keys.as_ref() {
                 let columns = morsel.df().columns();
-                let height = morsel.df().height();
+                let height = morsel.height();
                 let new_columns = hstack_keys.hstack_columns_broadcast(
                     height,
                     columns,

--- a/crates/polars-stream/src/nodes/io_sinks/components/sink_morsel.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/components/sink_morsel.rs
@@ -19,6 +19,10 @@ impl SinkMorsel {
         (self.df, self.permit)
     }
 
+    pub fn height(&self) -> usize {
+        self.df.height()
+    }
+
     pub fn df(&self) -> &DataFrame {
         &self.df
     }

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/tasks/post_apply_extra_ops.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/tasks/post_apply_extra_ops.rs
@@ -64,7 +64,7 @@ impl PostApplyExtraOps {
 
                 loop {
                     let row_count_this_morsel = {
-                        let physical_rows = morsel.df().height();
+                        let physical_rows = morsel.height();
                         // # Multiple cases
                         // * If row deletions are being done in post-apply, we'll have the deleted row count here.
                         // * If row deletions were pushed to the reader, `external_filter_mask` here is `None`, so we'll
@@ -74,7 +74,7 @@ impl PostApplyExtraOps {
                         let deleted_rows = external_filter_mask.as_ref().map_or(0, |mask| {
                             let Slice::Positive { offset, len } = Slice::Positive {
                                 offset: row_counter.num_physical_rows(),
-                                len: morsel.df().height(),
+                                len: morsel.height(),
                             }
                             .restrict_to_bounds(mask.len()) else {
                                 unreachable!()
@@ -124,9 +124,9 @@ impl PostApplyExtraOps {
 
                 AbortOnDropHandle::new(executor::spawn(TaskPriority::Low, async move {
                     while let Ok((mut morsel, row_offset)) = morsel_rx.recv().await {
-                        rows_before.fetch_add(morsel.df().height() as u64);
+                        rows_before.fetch_add(morsel.height() as u64);
                         ops_applier.apply_to_df(morsel.df_mut(), row_offset)?;
-                        rows_after.fetch_add(morsel.df().height() as u64);
+                        rows_after.fetch_add(morsel.height() as u64);
                         if morsel_tx.insert(morsel).await.is_err() {
                             break;
                         }

--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -220,11 +220,11 @@ fn estimate_cardinality(
     let mut total_height = 0;
     let mut to_process_end = 0;
     while to_process_end < morsels.len() && total_height < sample_limit {
-        total_height += morsels[to_process_end].df().height();
+        total_height += morsels[to_process_end].height();
         to_process_end += 1;
     }
     let last_morsel_idx = to_process_end - 1;
-    let last_morsel_len = morsels[last_morsel_idx].df().height();
+    let last_morsel_len = morsels[last_morsel_idx].height();
     let last_morsel_slice = last_morsel_len - total_height.saturating_sub(sample_limit);
 
     RAYON.install(|| {
@@ -259,7 +259,7 @@ fn estimate_size_per_row(morsels: &[Morsel]) -> f64 {
     let mut total_height = 0;
     for m in morsels {
         total_size += m.df().estimated_size();
-        total_height += m.df().height();
+        total_height += m.height();
     }
     total_size as f64 / total_height as f64
 }
@@ -282,7 +282,7 @@ impl SampleState {
         join_sample_limit: usize,
     ) -> PolarsResult<()> {
         while let Ok(mut morsel) = recv.recv().await {
-            *len += morsel.df().height();
+            *len += morsel.height();
             if *len >= join_sample_limit
                 || *len
                     >= other_final_len

--- a/crates/polars-stream/src/nodes/negative_slice.rs
+++ b/crates/polars-stream/src/nodes/negative_slice.rs
@@ -133,7 +133,7 @@ impl ComputeNode for NegativeSliceNode {
                 let spill_ctx = self.spill_ctx.clone();
                 join_handles.push(scope.spawn_task(TaskPriority::High, async move {
                     while let Ok(morsel) = recv.recv().await {
-                        buffer.total_len += morsel.df().height();
+                        buffer.total_len += morsel.height();
                         buffer
                             .frames
                             .push_back(SpillFrame::new(morsel.into_df(), &*spill_ctx).await);

--- a/crates/polars-stream/src/nodes/rle.rs
+++ b/crates/polars-stream/src/nodes/rle.rs
@@ -128,7 +128,7 @@ impl ComputeNode for RleNode {
                     let mut lengths = Vec::new();
                     while let Ok(mut m) = recv.recv().await {
                         self.seq = m.seq();
-                        if m.df().height() == 0 {
+                        if m.height() == 0 {
                             continue;
                         }
 

--- a/crates/polars-stream/src/nodes/shift.rs
+++ b/crates/polars-stream/src/nodes/shift.rs
@@ -47,10 +47,10 @@ impl ShiftState {
                 if let Some(r) = &mut recv {
                     let Ok(morsel) = r.recv().await else { break };
                     source_token = morsel.source_token().clone();
-                    if morsel.df().height() == 0 {
+                    if morsel.height() == 0 {
                         continue;
                     }
-                    self.rows_received += morsel.df().height();
+                    self.rows_received += morsel.height();
                     self.frames
                         .push_back(SpillFrame::new(morsel.into_df(), &*self.spill_ctx).await);
                 }
@@ -96,18 +96,18 @@ impl ShiftState {
 
         while let Ok(mut morsel) = recv.recv().await {
             let shift_needed = shift.saturating_sub(self.rows_received);
-            self.rows_received += morsel.df().height();
+            self.rows_received += morsel.height();
             if shift_needed > 0 {
                 morsel =
                     morsel.map(|df| df.slice(shift_needed.min(df.height()) as i64, df.height()));
             }
-            if morsel.df().height() == 0 {
+            if morsel.height() == 0 {
                 continue;
             }
 
             morsel.set_seq(self.seq);
             self.seq = self.seq.successor();
-            self.rows_sent += morsel.df().height();
+            self.rows_sent += morsel.height();
             if send.send(morsel).await.is_err() {
                 break;
             }

--- a/crates/polars-stream/src/nodes/sorted_unique.rs
+++ b/crates/polars-stream/src/nodes/sorted_unique.rs
@@ -144,7 +144,7 @@ impl ComputeNode for SortedUnique {
                         df.filter_seq(mask.as_ref())
                     })?;
 
-                    if morsel.df().height() == 0 {
+                    if morsel.height() == 0 {
                         continue;
                     }
 

--- a/crates/polars-stream/src/nodes/streaming_slice.rs
+++ b/crates/polars-stream/src/nodes/streaming_slice.rs
@@ -81,7 +81,7 @@ impl ComputeNode for StreamingSliceNode {
                     morsel.source_token().stop();
                 }
 
-                if morsel.df().height() > 0 && send.send(morsel).await.is_err() {
+                if morsel.height() > 0 && send.send(morsel).await.is_err() {
                     break;
                 }
 

--- a/crates/polars-stream/src/nodes/zip.rs
+++ b/crates/polars-stream/src/nodes/zip.rs
@@ -48,7 +48,7 @@ impl InputHead {
     }
 
     async fn add_morsel(&mut self, mut morsel: Morsel, ctx: &MostRecentSpillContext) {
-        self.total_len += morsel.df().height();
+        self.total_len += morsel.height();
 
         if self.is_broadcast.is_none() {
             if self.total_len > 1 {
@@ -60,7 +60,7 @@ impl InputHead {
             }
         }
 
-        if morsel.df().height() > 0 {
+        if morsel.height() > 0 {
             // Zip is the exception: we keep the consume token alive until
             // the drain loop rather than dropping it before buffering.
             let consume_token = morsel.take_consume_token();

--- a/crates/polars-stream/src/pipe.rs
+++ b/crates/polars-stream/src/pipe.rs
@@ -27,7 +27,7 @@ pub struct PortReceiver(ReceiverExt<Morsel, Option<Arc<PipeMetrics>>>);
 impl PortSender {
     #[inline]
     pub async fn send(&mut self, morsel: Morsel) -> Result<(), Morsel> {
-        let rows = morsel.df().height() as u64;
+        let rows = morsel.height() as u64;
         self.0.send(morsel).await?;
         if let Some(metrics) = self.0.shared() {
             metrics.morsels_sent.fetch_add(1);
@@ -42,7 +42,7 @@ impl PortReceiver {
     #[inline]
     pub async fn recv(&mut self) -> Result<Morsel, ()> {
         let morsel = self.0.recv().await?;
-        let rows = morsel.df().height() as u64;
+        let rows = morsel.height() as u64;
         if let Some(metrics) = self.0.shared() {
             metrics.morsels_received.fetch_add(1);
             metrics.rows_received.fetch_add(rows);


### PR DESCRIPTION
A prepatory PR for putting `SpillFrame`s in `Morsel`s. It would be rather silly to get the entire `DataFrame` from disk just to check its height.