### PR TITLE
refactor(rust): Set row count estimates for scan_iceberg

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
@@ -946,6 +946,12 @@ impl SourcesToFileInfo {
             )
         };
 
+        let exact_row_estimation = unified_scan_args.row_count.map(|(total, deleted)| {
+            let n: usize = (total - deleted) as usize;
+            ((Some(n)), n)
+        });
+        const DEFAULT_ROW_ESTIMATION: (Option<usize>, usize) = (None, usize::MAX);
+
         let cloud_options = unified_scan_args.cloud_options.as_ref();
 
         Ok(match scan_type {
@@ -961,7 +967,7 @@ impl SourcesToFileInfo {
                             reader_schema: Some(either::Either::Left(Arc::new(
                                 schema.to_arrow(CompatLevel::newest()),
                             ))),
-                            row_estimation: (None, usize::MAX),
+                            row_estimation: exact_row_estimation.unwrap_or(DEFAULT_ROW_ESTIMATION),
                         },
                         FileScanIR::Parquet {
                             options,
@@ -994,9 +1000,8 @@ this scan to succeed with an empty DataFrame.",
                             )
                             .await?;
 
-                        if let Some((total, deleted)) = unified_scan_args.row_count {
-                            let size = (total - deleted) as usize;
-                            file_info.row_estimation = (Some(size), size);
+                        if let Some(exact_row_estimation) = exact_row_estimation {
+                            file_info.row_estimation = exact_row_estimation;
                         }
 
                         if self.inner.read().unwrap().len() > max_metadata_scan_cached() {
@@ -1031,12 +1036,16 @@ this scan to succeed with an empty DataFrame.",
                     )
                 }
 
-                let (file_info, md) = scans::ipc_file_info(
+                let (mut file_info, md) = scans::ipc_file_info(
                     first_scan_source,
                     unified_scan_args.row_index.as_ref(),
                     cloud_options,
                 )
                 .await?;
+
+                if let Some(exact_row_estimation) = exact_row_estimation {
+                    file_info.row_estimation = exact_row_estimation;
+                }
 
                 PolarsResult::Ok((
                     file_info,
@@ -1049,11 +1058,11 @@ this scan to succeed with an empty DataFrame.",
             .map_err(|e| e.context(failed_here!(ipc scan)))?,
             #[cfg(feature = "csv")]
             FileScanDsl::Csv { mut options } => {
-                let file_info = if let Some(schema) = options.schema.clone() {
+                let mut file_info = if let Some(schema) = options.schema.clone() {
                     FileInfo {
                         schema: schema.clone(),
                         reader_schema: Some(either::Either::Right(schema)),
-                        row_estimation: (None, usize::MAX),
+                        row_estimation: exact_row_estimation.unwrap_or(DEFAULT_ROW_ESTIMATION),
                     }
                 } else {
                     let first_scan_source =
@@ -1077,16 +1086,20 @@ this scan to succeed with an empty DataFrame.",
                     .await?
                 };
 
+                if let Some(exact_row_estimation) = exact_row_estimation {
+                    file_info.row_estimation = exact_row_estimation;
+                }
+
                 PolarsResult::Ok((file_info, FileScanIR::Csv { options }))
             }
             .map_err(|e| e.context(failed_here!(csv scan)))?,
             #[cfg(feature = "json")]
             FileScanDsl::NDJson { options } => {
-                let file_info = if let Some(schema) = options.schema.clone() {
+                let mut file_info = if let Some(schema) = options.schema.clone() {
                     FileInfo {
                         schema: schema.clone(),
                         reader_schema: Some(either::Either::Right(schema)),
-                        row_estimation: (None, usize::MAX),
+                        row_estimation: exact_row_estimation.unwrap_or(DEFAULT_ROW_ESTIMATION),
                     }
                 } else {
                     let first_scan_source =
@@ -1109,6 +1122,10 @@ this scan to succeed with an empty DataFrame.",
                     .await?
                 };
 
+                if let Some(exact_row_estimation) = exact_row_estimation {
+                    file_info.row_estimation = exact_row_estimation;
+                }
+
                 PolarsResult::Ok((file_info, FileScanIR::NDJson { options }))
             }
             .map_err(|e| e.context(failed_here!(ndjson scan)))?,
@@ -1129,7 +1146,7 @@ this scan to succeed with an empty DataFrame.",
                     FileInfo {
                         schema,
                         reader_schema: Some(either::Either::Right(reader_schema)),
-                        row_estimation: (None, usize::MAX),
+                        row_estimation: exact_row_estimation.unwrap_or(DEFAULT_ROW_ESTIMATION),
                     },
                     FileScanIR::PythonDataset {
                         dataset_object,
@@ -1146,7 +1163,7 @@ this scan to succeed with an empty DataFrame.",
                     FileInfo {
                         schema: schema.clone(),
                         reader_schema: Some(either::Either::Right(schema.clone())),
-                        row_estimation: (None, usize::MAX),
+                        row_estimation: exact_row_estimation.unwrap_or(DEFAULT_ROW_ESTIMATION),
                     },
                     FileScanIR::Lines { name },
                 )
@@ -1164,10 +1181,16 @@ this scan to succeed with an empty DataFrame.",
                 )
             },
             FileScanDsl::Anonymous {
-                file_info,
+                mut file_info,
                 options,
                 function,
-            } => (file_info, FileScanIR::Anonymous { options, function }),
+            } => {
+                if let Some(exact_row_estimation) = exact_row_estimation {
+                    file_info.row_estimation = exact_row_estimation;
+                }
+
+                (file_info, FileScanIR::Anonymous { options, function })
+            },
         })
     }
 

--- a/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
+++ b/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
@@ -370,9 +370,7 @@ pub(super) fn expand_datasets(
             _ => {},
         }
 
-        if let Some((physical, deleted)) = unified_scan_args.row_count
-            && let (None, _) = &file_info.row_estimation
-        {
+        if let Some((physical, deleted)) = unified_scan_args.row_count {
             let row_count = u64::saturating_sub(physical, deleted) as usize;
             file_info.row_estimation = (Some(row_count), row_count);
         }

--- a/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
+++ b/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
@@ -370,6 +370,13 @@ pub(super) fn expand_datasets(
             _ => {},
         }
 
+        if let Some((physical, deleted)) = unified_scan_args.row_count
+            && let (None, _) = &file_info.row_estimation
+        {
+            let row_count = u64::saturating_sub(physical, deleted) as usize;
+            file_info.row_estimation = (Some(row_count), row_count);
+        }
+
         apply_scan_predicate_to_scan_ir(node, ir_arena, expr_arena)?;
     }
 

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -73,9 +73,13 @@ from polars.io.iceberg._utils import (
 )
 from polars.testing import assert_frame_equal
 from tests.unit.io.conftest import normalize_path_separator_pl
+from tests.unit.io.test_scan_row_deletion import write_position_deletes  # noqa: F401
 
 if TYPE_CHECKING:
     from tests.conftest import PlMonkeyPatch
+    from tests.unit.io.test_scan_row_deletion import (
+        WritePositionDeletes,
+    )
 
     # Mypy does not understand the constructors and we can't construct the inputs
     # explicitly since they are abstract base classes.
@@ -2697,3 +2701,55 @@ def test_scan_iceberg_partial_and_pushdown(
     # Verify: correctness
     assert len(result) == 2
     assert result["a"].to_list() == [2, 3]
+
+
+@pytest.mark.write_disk
+def test_scan_iceberg_row_estimate(
+    tmp_path: Path,
+    write_position_deletes: WritePositionDeletes,  # noqa: F811
+) -> None:
+    catalog = SqlCatalog(
+        "default",
+        uri="sqlite:///:memory:",
+        warehouse=format_file_uri_iceberg(tmp_path),
+    )
+    catalog.create_namespace("namespace")
+
+    catalog.create_table(
+        "namespace.table",
+        IcebergSchema(NestedField(1, "a", LongType())),
+    )
+
+    tbl = catalog.load_table("namespace.table")
+
+    pl.DataFrame({"a": [0, 1, 2, 3, 4]}).write_iceberg(tbl, mode="append")
+
+    q = pl.scan_iceberg(tbl, use_metadata_statistics=True)
+    plan = q.explain()
+
+    assert "ESTIMATED ROWS: 5" in plan
+
+    file_paths = [
+        _normalize_windows_iceberg_file_uri(x.file.file_path)
+        for x in tbl.scan().plan_files()
+    ]
+
+    deletion_files = (
+        "iceberg-position-delete",
+        {
+            0: [
+                write_position_deletes(pl.Series([1, 2])),
+            ],
+        },
+    )
+
+    q = pl.scan_parquet(
+        file_paths,
+        _deletion_files=deletion_files,  # type: ignore[arg-type]
+        _row_count=(5, 2),
+    )
+    plan = q.explain()
+
+    assert "ESTIMATED ROWS: 3" in plan
+    assert q.select(pl.len()).collect().item() == 3
+    assert q.collect().height == 3


### PR DESCRIPTION
For cloud

Sets row estimates for all scan types from the `unified_scan_args.row_count`
