### PR TITLE
refactor(rust): Store current SpillContext inside SpillToken

### DIFF
--- a/crates/polars-ooc/src/lib.rs
+++ b/crates/polars-ooc/src/lib.rs
@@ -9,12 +9,12 @@ pub use global_alloc::{Allocator, estimate_memory_usage};
 pub use memory_manager::memory_manager;
 use polars_utils::relaxed_cell::RelaxedCell;
 pub use spill_context::{
-    LeastRecentSpillContext, MostRecentSpillContext, ParameterFreeSpillContext, RandomSpillContext,
-    SpillContext,
+    GenericSpillContext, LeastRecentSpillContext, MostRecentSpillContext,
+    ParameterFreeSpillContext, RandomSpillContext, SpillContextParam,
 };
 pub use spill_file::{flush_ooc_cleanup, init_ooc_cleaner};
 pub use spill_frame::SpillFrame;
-pub use spill_token::{DynSpillToken, PinnedMut, PinnedRef, SpillToken};
+pub use spill_token::{PinnedMut, PinnedRef, SpillToken};
 
 pub trait Spillable: Send + Sync + 'static {
     type Spilled;

--- a/crates/polars-ooc/src/lib.rs
+++ b/crates/polars-ooc/src/lib.rs
@@ -9,8 +9,8 @@ pub use global_alloc::{Allocator, estimate_memory_usage};
 pub use memory_manager::memory_manager;
 use polars_utils::relaxed_cell::RelaxedCell;
 pub use spill_context::{
-    WeakSpillContext, LeastRecentSpillContext, MostRecentSpillContext,
-    ParameterFreeSpillContext, RandomSpillContext, SpillContextParam,
+    LeastRecentSpillContext, MostRecentSpillContext, ParameterFreeSpillContext, RandomSpillContext,
+    SpillContextParam, WeakSpillContext,
 };
 pub use spill_file::{flush_ooc_cleanup, init_ooc_cleaner};
 pub use spill_frame::SpillFrame;

--- a/crates/polars-ooc/src/lib.rs
+++ b/crates/polars-ooc/src/lib.rs
@@ -9,7 +9,7 @@ pub use global_alloc::{Allocator, estimate_memory_usage};
 pub use memory_manager::memory_manager;
 use polars_utils::relaxed_cell::RelaxedCell;
 pub use spill_context::{
-    GenericSpillContext, LeastRecentSpillContext, MostRecentSpillContext,
+    WeakSpillContext, LeastRecentSpillContext, MostRecentSpillContext,
     ParameterFreeSpillContext, RandomSpillContext, SpillContextParam,
 };
 pub use spill_file::{flush_ooc_cleanup, init_ooc_cleaner};

--- a/crates/polars-ooc/src/memory_manager.rs
+++ b/crates/polars-ooc/src/memory_manager.rs
@@ -133,7 +133,7 @@ impl MemoryManager {
         &self,
     ) -> Option<(
         &'static SpillContextInner,
-        Vec<(Arc<dyn DynSpillToken>, u64, usize)>,
+        Vec<(Arc<dyn DynSpillToken>, u32, usize)>,
     )> {
         // TODO: don't block here under a certain memory threshold.
         let finding_spill_guard = self.finding_spill_lock.lock().await;

--- a/crates/polars-ooc/src/memory_manager.rs
+++ b/crates/polars-ooc/src/memory_manager.rs
@@ -14,6 +14,7 @@ const EXPLORE_BEYOND_BEST_SCORE_THRESHOLD: f64 = 20.0;
 
 const MAX_PARALLEL_SPILL_TASKS: usize = 64;
 
+use crate::WeakSpillContext;
 use crate::spill_context::{SpillContextInner, UNEXPLORED_SCORE};
 use crate::spill_token::{DynSpillToken, TrySpillError};
 
@@ -25,7 +26,7 @@ pub fn memory_manager() -> &'static MemoryManager {
 }
 
 pub struct MemoryManager {
-    contexts: RwLock<Vec<&'static SpillContextInner>>,
+    contexts: RwLock<Vec<WeakSpillContext>>,
     finding_spill_lock: AsyncMutex<()>,
     spill_semaphore: Arc<AsyncSemaphore>,
     est_spill_in_progress: AtomicU64,
@@ -53,7 +54,7 @@ impl MemoryManager {
         }
     }
 
-    pub(crate) fn register_ctx(&self, ctx: &'static SpillContextInner) {
+    pub(crate) fn register_ctx(&self, ctx: WeakSpillContext) {
         self.contexts.write().unwrap().push(ctx);
     }
 
@@ -81,38 +82,38 @@ impl MemoryManager {
     #[cold]
     async fn do_spill(&self) {
         while self.should_spill() {
-            let Some((ctx, spillables)) = self.find_spillables().await else {
+            let Some((ctx, ctx_id, spillables)) = self.find_spillables().await else {
                 return;
             };
 
             let successful_spill = Arc::new(WithDrop::new(
                 (AtomicBool::new(false), ctx.stats().clone()),
-                |(success, stats)| {
+                move |(success, stats)| {
                     if !success.load(Ordering::Relaxed) {
-                        stats.finish_exploration_event(false);
+                        stats.finish_exploration_event(false, ctx_id);
                     }
                 },
             ));
 
-            for (spillable, id, sz) in spillables {
+            for (spillable, reg_id, sz) in spillables {
                 let permit = self.spill_semaphore.clone().acquire_owned().await.unwrap();
 
                 let successful_spill = successful_spill.clone();
 
                 polars_async::executor::spawn(TaskPriority::High, async move {
                     // Spill, or reinsert if a failure.
-                    match spillable.try_spill(ctx.stats(), ctx, id) {
+                    match spillable.try_spill(ctx, ctx_id, reg_id) {
                         Ok(spill_success) => {
                             if spill_success.await {
                                 if !successful_spill.0.swap(true, Ordering::Relaxed) {
-                                    ctx.stats().finish_exploration_event(true);
+                                    ctx.stats().finish_exploration_event(true, ctx_id);
                                 }
                             } else {
-                                ctx.reinsert(&spillable, id);
+                                ctx.reinsert(&spillable, reg_id, ctx_id);
                             }
                         },
                         Err(TrySpillError::Pinned) => {
-                            ctx.reinsert(&spillable, id);
+                            ctx.reinsert(&spillable, reg_id, ctx_id);
                         },
                         Err(TrySpillError::AlreadySpilled) => {},
                     }
@@ -133,6 +134,7 @@ impl MemoryManager {
         &self,
     ) -> Option<(
         &'static SpillContextInner,
+        u64,
         Vec<(Arc<dyn DynSpillToken>, u32, usize)>,
     )> {
         // TODO: don't block here under a certain memory threshold.
@@ -150,9 +152,9 @@ impl MemoryManager {
             };
 
             // Thompson sampling.
-            let score_sample = ctx.stats().sample_score(&mut rng);
+            let score_sample = ctx.0.stats().sample_score(&mut rng);
             assert!(!score_sample.is_nan());
-            live_contexts.push((*ctx, score_sample));
+            live_contexts.push((ctx.clone(), score_sample));
         }
         drop(contexts);
 
@@ -174,31 +176,31 @@ impl MemoryManager {
                 break;
             }
 
-            ctx.stats().start_exploration_event();
+            ctx.0.stats().start_exploration_event(ctx.1);
 
             let mut total_est_spill = 0;
             let mut candidates = Vec::new();
-            for (cand, id) in ctx.pop() {
+            for (cand, reg_id) in ctx.0.pop() {
                 if cand.can_spill()
                     && let Some(sz) = cand.estimate_byte_size()
                     && sz as u64 >= min_spill
                 {
                     total_est_spill += sz as u64;
-                    candidates.push((cand, id, sz));
+                    candidates.push((cand, reg_id, sz));
                 } else {
                     if !cand.is_spilled_or_dropped() {
-                        ctx.reinsert(&cand, id);
+                        ctx.0.reinsert(&cand, reg_id, ctx.1);
                     }
                 }
             }
 
             if candidates.is_empty() {
-                ctx.stats().finish_exploration_event(false);
+                ctx.0.stats().finish_exploration_event(false, ctx.1);
             } else {
                 // Increment the spill-in-progress to avoid eager over-spilling.
                 self.est_spill_in_progress
                     .fetch_add(total_est_spill, Ordering::Relaxed);
-                out = Some((ctx, candidates));
+                out = Some((ctx.0, ctx.1, candidates));
                 break;
             }
         }

--- a/crates/polars-ooc/src/memory_manager.rs
+++ b/crates/polars-ooc/src/memory_manager.rs
@@ -14,9 +14,8 @@ const EXPLORE_BEYOND_BEST_SCORE_THRESHOLD: f64 = 20.0;
 
 const MAX_PARALLEL_SPILL_TASKS: usize = 64;
 
-use crate::spill_context::UNEXPLORED_SCORE;
-use crate::spill_token::TrySpillError;
-use crate::{DynSpillToken, SpillContext};
+use crate::spill_context::{SpillContextInner, UNEXPLORED_SCORE};
+use crate::spill_token::{DynSpillToken, TrySpillError};
 
 static MEMORY_MANAGER: LazyLock<MemoryManager> = LazyLock::new(MemoryManager::new);
 
@@ -26,7 +25,7 @@ pub fn memory_manager() -> &'static MemoryManager {
 }
 
 pub struct MemoryManager {
-    contexts: RwLock<Vec<Weak<dyn SpillContext>>>,
+    contexts: RwLock<Vec<Weak<SpillContextInner>>>,
     finding_spill_lock: AsyncMutex<()>,
     spill_semaphore: Arc<AsyncSemaphore>,
     est_spill_in_progress: AtomicU64,
@@ -54,7 +53,7 @@ impl MemoryManager {
         }
     }
 
-    pub fn register_ctx<C: SpillContext>(&self, ctx: &Arc<C>) {
+    pub(crate) fn register_ctx(&self, ctx: &Arc<SpillContextInner>) {
         let weak = Arc::downgrade(ctx);
         self.contexts.write().unwrap().push(weak);
     }
@@ -135,7 +134,7 @@ impl MemoryManager {
     async fn find_spillables(
         &self,
     ) -> Option<(
-        Arc<dyn SpillContext>,
+        Arc<SpillContextInner>,
         Vec<(Arc<dyn DynSpillToken>, u64, usize)>,
     )> {
         // TODO: don't block here under a certain memory threshold.

--- a/crates/polars-ooc/src/memory_manager.rs
+++ b/crates/polars-ooc/src/memory_manager.rs
@@ -177,7 +177,9 @@ impl MemoryManager {
                 break;
             }
 
-            let Some(strong) = ctx.upgrade() else { continue };
+            let Some(strong) = ctx.upgrade() else {
+                continue;
+            };
             strong.stats().start_exploration_event();
 
             let mut total_est_spill = 0;

--- a/crates/polars-ooc/src/memory_manager.rs
+++ b/crates/polars-ooc/src/memory_manager.rs
@@ -1,5 +1,5 @@
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, LazyLock, RwLock, Weak};
+use std::sync::{Arc, LazyLock, RwLock};
 
 use polars_async::ASYNC;
 use polars_async::executor::TaskPriority;
@@ -25,7 +25,7 @@ pub fn memory_manager() -> &'static MemoryManager {
 }
 
 pub struct MemoryManager {
-    contexts: RwLock<Vec<Weak<SpillContextInner>>>,
+    contexts: RwLock<Vec<&'static SpillContextInner>>,
     finding_spill_lock: AsyncMutex<()>,
     spill_semaphore: Arc<AsyncSemaphore>,
     est_spill_in_progress: AtomicU64,
@@ -49,13 +49,12 @@ impl MemoryManager {
 
     fn clean_contexts(&self) {
         if let Ok(mut ctxs) = self.contexts.try_write() {
-            ctxs.retain(|ctx| ctx.strong_count() > 0);
+            ctxs.retain(|ctx| !ctx.is_dead());
         }
     }
 
-    pub(crate) fn register_ctx(&self, ctx: &Arc<SpillContextInner>) {
-        let weak = Arc::downgrade(ctx);
-        self.contexts.write().unwrap().push(weak);
+    pub(crate) fn register_ctx(&self, ctx: &'static SpillContextInner) {
+        self.contexts.write().unwrap().push(ctx);
     }
 
     #[inline(always)]
@@ -99,11 +98,10 @@ impl MemoryManager {
                 let permit = self.spill_semaphore.clone().acquire_owned().await.unwrap();
 
                 let successful_spill = successful_spill.clone();
-                let ctx = ctx.clone();
 
                 polars_async::executor::spawn(TaskPriority::High, async move {
                     // Spill, or reinsert if a failure.
-                    match spillable.try_spill(ctx.stats(), Arc::downgrade(&ctx), id) {
+                    match spillable.try_spill(ctx.stats(), ctx, id) {
                         Ok(spill_success) => {
                             if spill_success.await {
                                 if !successful_spill.0.swap(true, Ordering::Relaxed) {
@@ -134,7 +132,7 @@ impl MemoryManager {
     async fn find_spillables(
         &self,
     ) -> Option<(
-        Arc<SpillContextInner>,
+        &'static SpillContextInner,
         Vec<(Arc<dyn DynSpillToken>, u64, usize)>,
     )> {
         // TODO: don't block here under a certain memory threshold.
@@ -145,8 +143,8 @@ impl MemoryManager {
         let mut has_dead_context = false;
         let mut live_contexts = Vec::new();
         let mut rng = rand::rng();
-        for weak_ctx in contexts.iter() {
-            let Some(ctx) = weak_ctx.upgrade() else {
+        for ctx in contexts.iter() {
+            if ctx.is_dead() {
                 has_dead_context = true;
                 continue;
             };
@@ -154,7 +152,7 @@ impl MemoryManager {
             // Thompson sampling.
             let score_sample = ctx.stats().sample_score(&mut rng);
             assert!(!score_sample.is_nan());
-            live_contexts.push((ctx, score_sample));
+            live_contexts.push((*ctx, score_sample));
         }
         drop(contexts);
 

--- a/crates/polars-ooc/src/memory_manager.rs
+++ b/crates/polars-ooc/src/memory_manager.rs
@@ -15,7 +15,7 @@ const EXPLORE_BEYOND_BEST_SCORE_THRESHOLD: f64 = 20.0;
 const MAX_PARALLEL_SPILL_TASKS: usize = 64;
 
 use crate::WeakSpillContext;
-use crate::spill_context::{SpillContextInner, UNEXPLORED_SCORE};
+use crate::spill_context::UNEXPLORED_SCORE;
 use crate::spill_token::{DynSpillToken, TrySpillError};
 
 static MEMORY_MANAGER: LazyLock<MemoryManager> = LazyLock::new(MemoryManager::new);
@@ -82,15 +82,17 @@ impl MemoryManager {
     #[cold]
     async fn do_spill(&self) {
         while self.should_spill() {
-            let Some((ctx, ctx_id, spillables)) = self.find_spillables().await else {
+            let Some((ctx, spillables)) = self.find_spillables().await else {
                 return;
             };
 
             let successful_spill = Arc::new(WithDrop::new(
-                (AtomicBool::new(false), ctx.stats().clone()),
-                move |(success, stats)| {
+                (AtomicBool::new(false), ctx.clone()),
+                move |(success, weak_ctx)| {
                     if !success.load(Ordering::Relaxed) {
-                        stats.finish_exploration_event(false, ctx_id);
+                        if let Some(strong) = weak_ctx.upgrade() {
+                            strong.stats().finish_exploration_event(false);
+                        }
                     }
                 },
             ));
@@ -99,21 +101,24 @@ impl MemoryManager {
                 let permit = self.spill_semaphore.clone().acquire_owned().await.unwrap();
 
                 let successful_spill = successful_spill.clone();
+                let ctx = ctx.clone();
 
                 polars_async::executor::spawn(TaskPriority::High, async move {
                     // Spill, or reinsert if a failure.
-                    match spillable.try_spill(ctx, ctx_id, reg_id) {
+                    match spillable.try_spill(ctx.clone(), reg_id) {
                         Ok(spill_success) => {
                             if spill_success.await {
                                 if !successful_spill.0.swap(true, Ordering::Relaxed) {
-                                    ctx.stats().finish_exploration_event(true, ctx_id);
+                                    if let Some(strong) = ctx.upgrade() {
+                                        strong.stats().finish_exploration_event(true);
+                                    }
                                 }
                             } else {
-                                ctx.reinsert(&spillable, reg_id, ctx_id);
+                                ctx.0.reinsert(&spillable, reg_id, ctx.1);
                             }
                         },
                         Err(TrySpillError::Pinned) => {
-                            ctx.reinsert(&spillable, reg_id, ctx_id);
+                            ctx.0.reinsert(&spillable, reg_id, ctx.1);
                         },
                         Err(TrySpillError::AlreadySpilled) => {},
                     }
@@ -132,11 +137,7 @@ impl MemoryManager {
     #[cold]
     async fn find_spillables(
         &self,
-    ) -> Option<(
-        &'static SpillContextInner,
-        u64,
-        Vec<(Arc<dyn DynSpillToken>, u32, usize)>,
-    )> {
+    ) -> Option<(WeakSpillContext, Vec<(Arc<dyn DynSpillToken>, u32, usize)>)> {
         // TODO: don't block here under a certain memory threshold.
         let finding_spill_guard = self.finding_spill_lock.lock().await;
 
@@ -176,7 +177,8 @@ impl MemoryManager {
                 break;
             }
 
-            ctx.0.stats().start_exploration_event(ctx.1);
+            let Some(strong) = ctx.upgrade() else { continue };
+            strong.stats().start_exploration_event();
 
             let mut total_est_spill = 0;
             let mut candidates = Vec::new();
@@ -195,12 +197,12 @@ impl MemoryManager {
             }
 
             if candidates.is_empty() {
-                ctx.0.stats().finish_exploration_event(false, ctx.1);
+                strong.stats().finish_exploration_event(false);
             } else {
                 // Increment the spill-in-progress to avoid eager over-spilling.
                 self.est_spill_in_progress
                     .fetch_add(total_est_spill, Ordering::Relaxed);
-                out = Some((ctx.0, ctx.1, candidates));
+                out = Some((ctx, candidates));
                 break;
             }
         }

--- a/crates/polars-ooc/src/spill_context.rs
+++ b/crates/polars-ooc/src/spill_context.rs
@@ -10,7 +10,8 @@ use rand::{Rng, RngExt};
 use rand_distr::Distribution;
 use thread_local::ThreadLocal;
 
-use crate::{DynSpillToken, SpillToken, Spillable, memory_manager};
+use crate::spill_token::DynSpillToken;
+use crate::{SpillToken, Spillable, memory_manager};
 
 #[derive(Default)]
 struct LocalSpillQueue {
@@ -81,10 +82,54 @@ impl LocalSpillQueue {
     }
 }
 
-pub trait SpillContext: Send + Sync + 'static {
-    fn stats(&self) -> &Arc<SpillContextStatistics>;
-    fn pop(&self) -> Vec<(Arc<dyn DynSpillToken>, u64)>;
-    fn reinsert(&self, token: &Arc<dyn DynSpillToken>, id: u64);
+enum SpillContextPolicy {
+    MostRecent,
+    LeastRecent,
+    Random,
+}
+
+pub(crate) struct SpillContextInner {
+    local: ThreadLocal<RwLock<LocalSpillQueue>>,
+    stats: Arc<SpillContextStatistics>,
+    policy: SpillContextPolicy,
+}
+
+impl SpillContextInner {
+    fn new(name: PlSmallStr, policy: SpillContextPolicy) -> Self {
+        Self {
+            local: ThreadLocal::default(),
+            stats: Arc::new(SpillContextStatistics::new(name)),
+            policy,
+        }
+    }
+
+    pub fn stats(&self) -> &Arc<SpillContextStatistics> {
+        &self.stats
+    }
+
+    pub fn pop(&self) -> Vec<(Arc<dyn DynSpillToken>, u64)> {
+        let mut out = Vec::new();
+        let mut rng = rand::rng();
+        for local_lock in self.local.iter() {
+            if let Ok(mut local) = local_lock.try_write() {
+                out.extend(match self.policy {
+                    SpillContextPolicy::MostRecent => local.pop_back(),
+                    SpillContextPolicy::LeastRecent => local.pop_front(),
+                    SpillContextPolicy::Random => local.pop_random(&mut rng),
+                });
+            }
+        }
+        out
+    }
+
+    pub fn reinsert(&self, token: &Arc<dyn DynSpillToken>, id: u64) {
+        let mut local = self.local.get_or_default().write().unwrap();
+        match self.policy {
+            SpillContextPolicy::MostRecent => local.push_front(token, id),
+            SpillContextPolicy::LeastRecent => local.push_back(token, id),
+            SpillContextPolicy::Random => local.push_back(token, id),
+        }
+    }
 }
 
 pub trait ParameterFreeSpillContext {
@@ -95,42 +140,33 @@ pub trait ParameterFreeSpillContext {
         Self: Sized;
 }
 
-/// A context that spills the most-recently registered spillable when asked.
-pub struct MostRecentSpillContext {
-    local: ThreadLocal<RwLock<LocalSpillQueue>>,
-    stats: Arc<SpillContextStatistics>,
+/// A generic handle to a context without knowing which kind it is.
+pub struct GenericSpillContext(pub(crate) Arc<SpillContextInner>);
+
+/// An opaque parameter passed into a spill context during registering.
+pub struct SpillContextParam(pub(crate) ());
+
+impl GenericSpillContext {
+    pub fn register<T, S>(&self, token: &T, _param: SpillContextParam)
+    where
+        T: AsRef<SpillToken<S>>,
+        S: Spillable,
+    {
+        let dyn_arc = token.as_ref().upcast();
+        let mut local = self.0.local.get_or_default().write().unwrap();
+        local.push_back(&dyn_arc, dyn_arc.register(&self.0));
+    }
 }
+
+/// A context that spills the most-recently registered spillable when asked.
+#[derive(Clone)]
+pub struct MostRecentSpillContext(Arc<SpillContextInner>);
 
 impl MostRecentSpillContext {
-    pub fn new(name: PlSmallStr) -> Arc<Self> {
-        let slf = Arc::new(Self {
-            local: ThreadLocal::default(),
-            stats: Arc::new(SpillContextStatistics::new(name)),
-        });
-        memory_manager().register_ctx(&slf);
-        slf
-    }
-}
-
-impl SpillContext for MostRecentSpillContext {
-    fn stats(&self) -> &Arc<SpillContextStatistics> {
-        &self.stats
-    }
-
-    fn pop(&self) -> Vec<(Arc<dyn DynSpillToken>, u64)> {
-        let mut out = Vec::new();
-        for local_lock in self.local.iter() {
-            if let Ok(mut local) = local_lock.try_write() {
-                out.extend(local.pop_back());
-            }
-        }
-        out
-    }
-
-    fn reinsert(&self, token: &Arc<dyn DynSpillToken>, id: u64) {
-        // Reinsertions always act like least recent, so we use push_front.
-        let mut local = self.local.get_or_default().write().unwrap();
-        local.push_front(token, id);
+    pub fn new(name: PlSmallStr) -> Self {
+        let ctx = Arc::new(SpillContextInner::new(name, SpillContextPolicy::MostRecent));
+        memory_manager().register_ctx(&ctx);
+        Self(ctx)
     }
 }
 
@@ -141,52 +177,31 @@ impl ParameterFreeSpillContext for MostRecentSpillContext {
         S: Spillable,
     {
         let dyn_arc = token.as_ref().upcast();
-        let mut local = self.local.get_or_default().write().unwrap();
-        local.push_back(&dyn_arc, dyn_arc.new_registration_id());
+        let mut local = self.0.local.get_or_default().write().unwrap();
+        local.push_back(&dyn_arc, dyn_arc.register(&self.0));
     }
 }
 
 impl Debug for MostRecentSpillContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MostRecentSpillContext").finish()
+        f.debug_struct("MostRecentSpillContext")
+            .field("name", &self.0.stats.name)
+            .finish()
     }
 }
 
 /// A context that spills the least-recently registered spillable when asked.
-pub struct LeastRecentSpillContext {
-    local: ThreadLocal<RwLock<LocalSpillQueue>>,
-    stats: Arc<SpillContextStatistics>,
-}
+#[derive(Clone)]
+pub struct LeastRecentSpillContext(Arc<SpillContextInner>);
 
 impl LeastRecentSpillContext {
-    pub fn new(name: PlSmallStr) -> Arc<Self> {
-        let slf = Arc::new(Self {
-            local: ThreadLocal::default(),
-            stats: Arc::new(SpillContextStatistics::new(name)),
-        });
-        memory_manager().register_ctx(&slf);
-        slf
-    }
-}
-
-impl SpillContext for LeastRecentSpillContext {
-    fn stats(&self) -> &Arc<SpillContextStatistics> {
-        &self.stats
-    }
-
-    fn pop(&self) -> Vec<(Arc<dyn DynSpillToken>, u64)> {
-        let mut out = Vec::new();
-        for local_lock in self.local.iter() {
-            if let Ok(mut local) = local_lock.try_write() {
-                out.extend(local.pop_front());
-            }
-        }
-        out
-    }
-
-    fn reinsert(&self, token: &Arc<dyn DynSpillToken>, id: u64) {
-        let mut local = self.local.get_or_default().write().unwrap();
-        local.push_back(token, id);
+    pub fn new(name: PlSmallStr) -> Self {
+        let ctx = Arc::new(SpillContextInner::new(
+            name,
+            SpillContextPolicy::LeastRecent,
+        ));
+        memory_manager().register_ctx(&ctx);
+        Self(ctx)
     }
 }
 
@@ -197,53 +212,28 @@ impl ParameterFreeSpillContext for LeastRecentSpillContext {
         S: Spillable,
     {
         let dyn_arc = token.as_ref().upcast();
-        let mut local = self.local.get_or_default().write().unwrap();
-        local.push_back(&dyn_arc, dyn_arc.new_registration_id());
+        let mut local = self.0.local.get_or_default().write().unwrap();
+        local.push_back(&dyn_arc, dyn_arc.register(&self.0));
     }
 }
 
 impl Debug for LeastRecentSpillContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("LeastRecentSpillContext").finish()
+        f.debug_struct("LeastRecentSpillContext")
+            .field("name", &self.0.stats.name)
+            .finish()
     }
 }
 
 /// A context that spills a random registered spillable when asked.
-pub struct RandomSpillContext {
-    local: ThreadLocal<RwLock<LocalSpillQueue>>,
-    stats: Arc<SpillContextStatistics>,
-}
+#[derive(Clone)]
+pub struct RandomSpillContext(Arc<SpillContextInner>);
 
 impl RandomSpillContext {
-    pub fn new(name: PlSmallStr) -> Arc<Self> {
-        let slf = Arc::new(Self {
-            local: ThreadLocal::default(),
-            stats: Arc::new(SpillContextStatistics::new(name)),
-        });
-        memory_manager().register_ctx(&slf);
-        slf
-    }
-}
-
-impl SpillContext for RandomSpillContext {
-    fn stats(&self) -> &Arc<SpillContextStatistics> {
-        &self.stats
-    }
-
-    fn pop(&self) -> Vec<(Arc<dyn DynSpillToken>, u64)> {
-        let mut out = Vec::new();
-        let mut rng = rand::rng();
-        for local_lock in self.local.iter() {
-            if let Ok(mut local) = local_lock.try_write() {
-                out.extend(local.pop_random(&mut rng));
-            }
-        }
-        out
-    }
-
-    fn reinsert(&self, token: &Arc<dyn DynSpillToken>, id: u64) {
-        let mut local = self.local.get_or_default().write().unwrap();
-        local.push_back(token, id);
+    pub fn new(name: PlSmallStr) -> Self {
+        let ctx = Arc::new(SpillContextInner::new(name, SpillContextPolicy::Random));
+        memory_manager().register_ctx(&ctx);
+        Self(ctx)
     }
 }
 
@@ -254,14 +244,16 @@ impl ParameterFreeSpillContext for RandomSpillContext {
         S: Spillable,
     {
         let dyn_arc = token.as_ref().upcast();
-        let mut local = self.local.get_or_default().write().unwrap();
-        local.push_back(&dyn_arc, dyn_arc.new_registration_id());
+        let mut local = self.0.local.get_or_default().write().unwrap();
+        local.push_back(&dyn_arc, dyn_arc.register(&self.0));
     }
 }
 
 impl Debug for RandomSpillContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RandomSpillContext").finish()
+        f.debug_struct("RandomSpillContext")
+            .field("name", &self.0.stats.name)
+            .finish()
     }
 }
 

--- a/crates/polars-ooc/src/spill_context/mod.rs
+++ b/crates/polars-ooc/src/spill_context/mod.rs
@@ -19,26 +19,26 @@ pub(crate) use stats::UNEXPLORED_SCORE;
 
 #[derive(Default)]
 struct LocalSpillQueue {
-    tokens: VecDeque<(Weak<dyn DynSpillToken>, u64)>,
+    tokens: VecDeque<(Weak<dyn DynSpillToken>, u32)>,
     retain_amort: usize,
 }
 
 impl LocalSpillQueue {
-    pub fn push_back(&mut self, token: &Arc<dyn DynSpillToken>, id: u64) {
+    pub fn push_back(&mut self, token: &Arc<dyn DynSpillToken>, id: u32) {
         self.gc();
         if token.current_registration_id() == id {
             self.tokens.push_back((Arc::downgrade(token), id));
         }
     }
 
-    pub fn push_front(&mut self, token: &Arc<dyn DynSpillToken>, id: u64) {
+    pub fn push_front(&mut self, token: &Arc<dyn DynSpillToken>, id: u32) {
         self.gc();
         if token.current_registration_id() == id {
             self.tokens.push_front((Arc::downgrade(token), id));
         }
     }
 
-    pub fn pop_front(&mut self) -> Option<(Arc<dyn DynSpillToken>, u64)> {
+    pub fn pop_front(&mut self) -> Option<(Arc<dyn DynSpillToken>, u32)> {
         loop {
             let (weak, id) = self.tokens.pop_front()?;
             if let Some(token) = weak.upgrade()
@@ -49,7 +49,7 @@ impl LocalSpillQueue {
         }
     }
 
-    pub fn pop_back(&mut self) -> Option<(Arc<dyn DynSpillToken>, u64)> {
+    pub fn pop_back(&mut self) -> Option<(Arc<dyn DynSpillToken>, u32)> {
         loop {
             let (weak, id) = self.tokens.pop_back()?;
             if let Some(token) = weak.upgrade()
@@ -60,7 +60,7 @@ impl LocalSpillQueue {
         }
     }
 
-    pub fn pop_random(&mut self, rng: &mut ThreadRng) -> Option<(Arc<dyn DynSpillToken>, u64)> {
+    pub fn pop_random(&mut self, rng: &mut ThreadRng) -> Option<(Arc<dyn DynSpillToken>, u32)> {
         while !self.tokens.is_empty() {
             let idx = rng.random_range(0..self.tokens.len());
             let (weak, id) = self.tokens.swap_remove_back(idx).unwrap();
@@ -122,7 +122,6 @@ impl SpillContextInner {
     }
     
     fn reset(&self, name: PlSmallStr, policy: SpillContextPolicy) {
-        self.stats.reset(name);
         self.policy.store(policy as u8, Ordering::Relaxed);
         for local_lock in self.local.iter() {
             let mut local = local_lock.write().unwrap();
@@ -130,6 +129,7 @@ impl SpillContextInner {
                 token.0.unregister();
             }
         }
+        self.stats.reset(name);
     }
     
     pub(crate) fn is_dead(&self) -> bool {
@@ -144,7 +144,7 @@ impl SpillContextInner {
         &self.stats
     }
 
-    pub fn pop(&self) -> Vec<(Arc<dyn DynSpillToken>, u64)> {
+    pub fn pop(&self) -> Vec<(Arc<dyn DynSpillToken>, u32)> {
         let mut out = Vec::new();
         let mut rng = rand::rng();
         let policy = self.policy();
@@ -160,7 +160,7 @@ impl SpillContextInner {
         out
     }
 
-    pub fn reinsert(&self, token: &Arc<dyn DynSpillToken>, id: u64) {
+    pub fn reinsert(&self, token: &Arc<dyn DynSpillToken>, id: u32) {
         let mut local = self.local.get_or_default().write().unwrap();
         match self.policy() {
             SpillContextPolicy::MostRecent => local.push_front(token, id),

--- a/crates/polars-ooc/src/spill_context/mod.rs
+++ b/crates/polars-ooc/src/spill_context/mod.rs
@@ -271,7 +271,9 @@ impl WeakSpillContext {
     {
         let dyn_arc = token.as_ref().upcast();
         let mut local = self.0.local.get_or_default().write().unwrap();
-        local.push_back(&dyn_arc, dyn_arc.register(self.clone()));
+        if self.0.context_id() == self.1 {
+            local.push_back(&dyn_arc, dyn_arc.register(self.clone()));
+        }
     }
 }
 

--- a/crates/polars-ooc/src/spill_context/mod.rs
+++ b/crates/polars-ooc/src/spill_context/mod.rs
@@ -121,7 +121,7 @@ impl SpillContextInner {
         let ctx_id = new_context_id();
         Self {
             local: ThreadLocal::default(),
-            stats: Arc::new(SpillContextStatistics::new(name, ctx_id)),
+            stats: Arc::new(SpillContextStatistics::new(name)),
             policy: AtomicU8::new(policy as u8),
             refcount: AtomicU64::new(0),
             context_id: AtomicU64::new(ctx_id),
@@ -138,7 +138,7 @@ impl SpillContextInner {
                 token.0.unregister();
             }
         }
-        self.stats.reset(name, ctx_id);
+        self.stats.reset(name);
     }
 
     pub fn context_id(&self) -> u64 {
@@ -210,6 +210,12 @@ impl StrongSpillContext {
 
     pub fn downgrade(&self) -> WeakSpillContext {
         WeakSpillContext(self.0, self.0.context_id())
+    }
+}
+
+impl StrongSpillContext {
+    pub fn stats(&self) -> &Arc<SpillContextStatistics> {
+        self.0.stats()
     }
 }
 

--- a/crates/polars-ooc/src/spill_context/mod.rs
+++ b/crates/polars-ooc/src/spill_context/mod.rs
@@ -1,0 +1,333 @@
+use std::collections::VecDeque;
+use std::fmt::Debug;
+use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, RwLock, Weak};
+
+use polars_utils::pl_str::PlSmallStr;
+use rand::rngs::ThreadRng;
+use rand::RngExt;
+use thread_local::ThreadLocal;
+
+use crate::spill_token::DynSpillToken;
+use crate::{SpillToken, Spillable, memory_manager};
+
+mod stats;
+
+pub use stats::SpillContextStatistics;
+pub(crate) use stats::UNEXPLORED_SCORE;
+
+
+#[derive(Default)]
+struct LocalSpillQueue {
+    tokens: VecDeque<(Weak<dyn DynSpillToken>, u64)>,
+    retain_amort: usize,
+}
+
+impl LocalSpillQueue {
+    pub fn push_back(&mut self, token: &Arc<dyn DynSpillToken>, id: u64) {
+        self.gc();
+        if token.current_registration_id() == id {
+            self.tokens.push_back((Arc::downgrade(token), id));
+        }
+    }
+
+    pub fn push_front(&mut self, token: &Arc<dyn DynSpillToken>, id: u64) {
+        self.gc();
+        if token.current_registration_id() == id {
+            self.tokens.push_front((Arc::downgrade(token), id));
+        }
+    }
+
+    pub fn pop_front(&mut self) -> Option<(Arc<dyn DynSpillToken>, u64)> {
+        loop {
+            let (weak, id) = self.tokens.pop_front()?;
+            if let Some(token) = weak.upgrade()
+                && token.current_registration_id() == id
+            {
+                return Some((token, id));
+            }
+        }
+    }
+
+    pub fn pop_back(&mut self) -> Option<(Arc<dyn DynSpillToken>, u64)> {
+        loop {
+            let (weak, id) = self.tokens.pop_back()?;
+            if let Some(token) = weak.upgrade()
+                && token.current_registration_id() == id
+            {
+                return Some((token, id));
+            }
+        }
+    }
+
+    pub fn pop_random(&mut self, rng: &mut ThreadRng) -> Option<(Arc<dyn DynSpillToken>, u64)> {
+        while !self.tokens.is_empty() {
+            let idx = rng.random_range(0..self.tokens.len());
+            let (weak, id) = self.tokens.swap_remove_back(idx).unwrap();
+            if let Some(token) = weak.upgrade()
+                && token.current_registration_id() == id
+            {
+                return Some((token, id));
+            }
+        }
+        None
+    }
+
+    fn gc(&mut self) {
+        self.retain_amort += 2; // Grows twice as fast as push.
+        if self.retain_amort >= self.tokens.len() {
+            self.retain_amort = 0;
+            self.tokens.retain(|(token, id)| {
+                token
+                    .upgrade()
+                    .is_some_and(|t| t.current_registration_id() == *id)
+            });
+        }
+    }
+}
+
+#[repr(u8)]
+pub enum SpillContextPolicy {
+    MostRecent = 0,
+    LeastRecent = 1,
+    Random = 2,
+}
+
+impl SpillContextPolicy {
+    fn from_u8(discriminant: u8) -> Self {
+        match discriminant {
+            0 => Self::MostRecent,
+            1 => Self::LeastRecent,
+            2 => Self::Random,
+            _ => unreachable!()
+        }
+    }
+}
+
+pub(crate) struct SpillContextInner {
+    local: ThreadLocal<RwLock<LocalSpillQueue>>,
+    stats: Arc<SpillContextStatistics>,
+    policy: AtomicU8,
+    refcount: AtomicU64,
+}
+
+impl SpillContextInner {
+    fn new(name: PlSmallStr, policy: SpillContextPolicy) -> Self {
+        Self {
+            local: ThreadLocal::default(),
+            stats: Arc::new(SpillContextStatistics::new(name)),
+            policy: AtomicU8::new(policy as u8),
+            refcount: AtomicU64::new(0),
+        }
+    }
+    
+    fn reset(&self, name: PlSmallStr, policy: SpillContextPolicy) {
+        self.stats.reset(name);
+        self.policy.store(policy as u8, Ordering::Relaxed);
+        for local_lock in self.local.iter() {
+            let mut local = local_lock.write().unwrap();
+            while let Some(token) = local.pop_back() {
+                token.0.unregister();
+            }
+        }
+    }
+    
+    pub(crate) fn is_dead(&self) -> bool {
+        self.refcount.load(Ordering::Acquire) == 0
+    }
+    
+    pub fn policy(&self) -> SpillContextPolicy {
+        SpillContextPolicy::from_u8(self.policy.load(Ordering::Relaxed))
+    }
+
+    pub fn stats(&self) -> &Arc<SpillContextStatistics> {
+        &self.stats
+    }
+
+    pub fn pop(&self) -> Vec<(Arc<dyn DynSpillToken>, u64)> {
+        let mut out = Vec::new();
+        let mut rng = rand::rng();
+        let policy = self.policy();
+        for local_lock in self.local.iter() {
+            if let Ok(mut local) = local_lock.try_write() {
+                out.extend(match policy {
+                    SpillContextPolicy::MostRecent => local.pop_back(),
+                    SpillContextPolicy::LeastRecent => local.pop_front(),
+                    SpillContextPolicy::Random => local.pop_random(&mut rng),
+                });
+            }
+        }
+        out
+    }
+
+    pub fn reinsert(&self, token: &Arc<dyn DynSpillToken>, id: u64) {
+        let mut local = self.local.get_or_default().write().unwrap();
+        match self.policy() {
+            SpillContextPolicy::MostRecent => local.push_front(token, id),
+            SpillContextPolicy::LeastRecent => local.push_back(token, id),
+            SpillContextPolicy::Random => local.push_back(token, id),
+        }
+    }
+}
+
+// We leak (but do re-use) contets such that a weak reference does not require any reference
+// counting. It's possible a weak reference to a spill context starts referring to a (logically)
+// different context, after the context is re-used, but it is always safe and sound.
+static SPILL_CONTEXT_REUSE_ARENA: Mutex<Vec<&'static SpillContextInner>> = Mutex::new(Vec::new());
+
+// A generic strong reference to a context without knowing which kind it is, preventing it from
+// resetting and getting re-used.
+struct StrongSpillContextInner(&'static SpillContextInner);
+
+impl StrongSpillContextInner {
+    fn new(name: PlSmallStr, policy: SpillContextPolicy) -> Self {
+        let mut arena = SPILL_CONTEXT_REUSE_ARENA.lock().unwrap();
+        let inner = if let Some(inner) = arena.pop() {
+            inner.reset(name, policy);
+            inner
+        } else {
+            Box::leak(Box::new(SpillContextInner::new(name, policy)))
+        };
+        
+        // Important: mark as live (refcnt >= 1) before registering.
+        inner.refcount.store(1, Ordering::Relaxed);
+        memory_manager().register_ctx(inner);
+        Self(inner)
+    }
+}
+
+impl Clone for StrongSpillContextInner {
+    fn clone(&self) -> Self {
+        self.0.refcount.fetch_add(1, Ordering::Relaxed);
+        Self(self.0)
+    }
+}
+
+impl Drop for StrongSpillContextInner {
+    fn drop(&mut self) {
+        if self.0.refcount.fetch_sub(1, Ordering::AcqRel) == 1 {
+            SPILL_CONTEXT_REUSE_ARENA.lock().unwrap().push(self.0);
+        }
+    }
+}
+
+/// A generic weak reference to a context without knowing which kind it is.
+pub struct WeakSpillContext(pub(crate) &'static SpillContextInner);
+
+/// An opaque parameter passed into a spill context during registering.
+pub struct SpillContextParam(pub(crate) ());
+
+impl WeakSpillContext {
+    pub fn register<T, S>(&self, token: &T, _param: SpillContextParam)
+    where
+        T: AsRef<SpillToken<S>>,
+        S: Spillable,
+    {
+        let dyn_arc = token.as_ref().upcast();
+        let mut local = self.0.local.get_or_default().write().unwrap();
+        local.push_back(&dyn_arc, dyn_arc.register(&self.0));
+    }
+}
+
+
+pub trait ParameterFreeSpillContext {
+    fn register<T, S>(&self, token: &T)
+    where
+        T: AsRef<SpillToken<S>>,
+        S: Spillable,
+        Self: Sized;
+}
+
+
+
+/// A context that spills the most-recently registered spillable when asked.
+#[derive(Clone)]
+#[repr(transparent)]
+pub struct MostRecentSpillContext(StrongSpillContextInner);
+
+impl MostRecentSpillContext {
+    pub fn new(name: PlSmallStr) -> Self {
+        Self(StrongSpillContextInner::new(name, SpillContextPolicy::MostRecent))
+    }
+}
+
+impl ParameterFreeSpillContext for MostRecentSpillContext {
+    fn register<T, S>(&self, token: &T)
+    where
+        T: AsRef<SpillToken<S>>,
+        S: Spillable,
+    {
+        let dyn_arc = token.as_ref().upcast();
+        let mut local = self.0.0.local.get_or_default().write().unwrap();
+        local.push_back(&dyn_arc, dyn_arc.register(self.0.0));
+    }
+}
+
+impl Debug for MostRecentSpillContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MostRecentSpillContext")
+            .field("name", &self.0.0.stats.name())
+            .finish()
+    }
+}
+
+/// A context that spills the least-recently registered spillable when asked.
+#[derive(Clone)]
+#[repr(transparent)]
+pub struct LeastRecentSpillContext(StrongSpillContextInner);
+
+impl LeastRecentSpillContext {
+    pub fn new(name: PlSmallStr) -> Self {
+        Self(StrongSpillContextInner::new(name, SpillContextPolicy::LeastRecent))
+    }
+}
+
+impl ParameterFreeSpillContext for LeastRecentSpillContext {
+    fn register<T, S>(&self, token: &T)
+    where
+        T: AsRef<SpillToken<S>>,
+        S: Spillable,
+    {
+        let dyn_arc = token.as_ref().upcast();
+        let mut local = self.0.0.local.get_or_default().write().unwrap();
+        local.push_back(&dyn_arc, dyn_arc.register(self.0.0));
+    }
+}
+
+impl Debug for LeastRecentSpillContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LeastRecentSpillContext")
+            .field("name", &self.0.0.stats.name())
+            .finish()
+    }
+}
+
+/// A context that spills a random registered spillable when asked.
+#[derive(Clone)]
+pub struct RandomSpillContext(StrongSpillContextInner);
+
+impl RandomSpillContext {
+    pub fn new(name: PlSmallStr) -> Self {
+        Self(StrongSpillContextInner::new(name, SpillContextPolicy::Random))
+    }
+}
+
+impl ParameterFreeSpillContext for RandomSpillContext {
+    fn register<T, S>(&self, token: &T)
+    where
+        T: AsRef<SpillToken<S>>,
+        S: Spillable,
+    {
+        let dyn_arc = token.as_ref().upcast();
+        let mut local = self.0.0.local.get_or_default().write().unwrap();
+        local.push_back(&dyn_arc, dyn_arc.register(self.0.0));
+    }
+}
+
+impl Debug for RandomSpillContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RandomSpillContext")
+            .field("name", &self.0.0.stats.name())
+            .finish()
+    }
+}

--- a/crates/polars-ooc/src/spill_context/mod.rs
+++ b/crates/polars-ooc/src/spill_context/mod.rs
@@ -189,7 +189,7 @@ static SPILL_CONTEXT_REUSE_ARENA: Mutex<Vec<&'static SpillContextInner>> = Mutex
 
 // A generic strong reference to a context without knowing which kind it is, preventing it from
 // resetting and getting re-used.
-pub struct StrongSpillContext(&'static SpillContextInner);
+pub(crate) struct StrongSpillContext(&'static SpillContextInner);
 
 impl StrongSpillContext {
     fn new(name: PlSmallStr, policy: SpillContextPolicy) -> Self {
@@ -239,7 +239,7 @@ impl Drop for StrongSpillContext {
 pub struct WeakSpillContext(pub(crate) &'static SpillContextInner, pub(crate) u64);
 
 impl WeakSpillContext {
-    pub fn upgrade(&self) -> Option<StrongSpillContext> {
+    pub(crate) fn upgrade(&self) -> Option<StrongSpillContext> {
         if self.0.context_id() != self.1 {
             return None;
         }
@@ -254,6 +254,7 @@ impl WeakSpillContext {
 
         Some(strong)
     }
+
     pub(crate) fn is_dead(&self) -> bool {
         self.0.context_id() != self.1
     }

--- a/crates/polars-ooc/src/spill_context/mod.rs
+++ b/crates/polars-ooc/src/spill_context/mod.rs
@@ -4,8 +4,8 @@ use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock, Weak};
 
 use polars_utils::pl_str::PlSmallStr;
-use rand::rngs::ThreadRng;
 use rand::RngExt;
+use rand::rngs::ThreadRng;
 use thread_local::ThreadLocal;
 
 use crate::spill_token::DynSpillToken;
@@ -16,6 +16,10 @@ mod stats;
 pub use stats::SpillContextStatistics;
 pub(crate) use stats::UNEXPLORED_SCORE;
 
+fn new_context_id() -> u64 {
+    static CONTEXT_ID_CTR: AtomicU64 = AtomicU64::new(0);
+    CONTEXT_ID_CTR.fetch_add(1, Ordering::Relaxed)
+}
 
 #[derive(Default)]
 struct LocalSpillQueue {
@@ -99,7 +103,7 @@ impl SpillContextPolicy {
             0 => Self::MostRecent,
             1 => Self::LeastRecent,
             2 => Self::Random,
-            _ => unreachable!()
+            _ => unreachable!(),
         }
     }
 }
@@ -109,19 +113,24 @@ pub(crate) struct SpillContextInner {
     stats: Arc<SpillContextStatistics>,
     policy: AtomicU8,
     refcount: AtomicU64,
+    context_id: AtomicU64,
 }
 
 impl SpillContextInner {
     fn new(name: PlSmallStr, policy: SpillContextPolicy) -> Self {
+        let ctx_id = new_context_id();
         Self {
             local: ThreadLocal::default(),
-            stats: Arc::new(SpillContextStatistics::new(name)),
+            stats: Arc::new(SpillContextStatistics::new(name, ctx_id)),
             policy: AtomicU8::new(policy as u8),
             refcount: AtomicU64::new(0),
+            context_id: AtomicU64::new(ctx_id),
         }
     }
-    
+
     fn reset(&self, name: PlSmallStr, policy: SpillContextPolicy) {
+        let ctx_id = new_context_id();
+        self.context_id.store(ctx_id, Ordering::Relaxed);
         self.policy.store(policy as u8, Ordering::Relaxed);
         for local_lock in self.local.iter() {
             let mut local = local_lock.write().unwrap();
@@ -129,13 +138,13 @@ impl SpillContextInner {
                 token.0.unregister();
             }
         }
-        self.stats.reset(name);
+        self.stats.reset(name, ctx_id);
     }
-    
-    pub(crate) fn is_dead(&self) -> bool {
-        self.refcount.load(Ordering::Acquire) == 0
+
+    pub fn context_id(&self) -> u64 {
+        self.context_id.load(Ordering::Relaxed)
     }
-    
+
     pub fn policy(&self) -> SpillContextPolicy {
         SpillContextPolicy::from_u8(self.policy.load(Ordering::Relaxed))
     }
@@ -160,26 +169,29 @@ impl SpillContextInner {
         out
     }
 
-    pub fn reinsert(&self, token: &Arc<dyn DynSpillToken>, id: u32) {
+    pub fn reinsert(&self, token: &Arc<dyn DynSpillToken>, reg_id: u32, ctx_id: u64) {
         let mut local = self.local.get_or_default().write().unwrap();
+        if ctx_id != self.context_id.load(Ordering::Relaxed) {
+            return;
+        }
+
         match self.policy() {
-            SpillContextPolicy::MostRecent => local.push_front(token, id),
-            SpillContextPolicy::LeastRecent => local.push_back(token, id),
-            SpillContextPolicy::Random => local.push_back(token, id),
+            SpillContextPolicy::MostRecent => local.push_front(token, reg_id),
+            SpillContextPolicy::LeastRecent => local.push_back(token, reg_id),
+            SpillContextPolicy::Random => local.push_back(token, reg_id),
         }
     }
 }
 
-// We leak (but do re-use) contets such that a weak reference does not require any reference
-// counting. It's possible a weak reference to a spill context starts referring to a (logically)
-// different context, after the context is re-used, but it is always safe and sound.
+// We leak (but do re-use) contexts such that a weak reference does not require any reference
+// counting.
 static SPILL_CONTEXT_REUSE_ARENA: Mutex<Vec<&'static SpillContextInner>> = Mutex::new(Vec::new());
 
 // A generic strong reference to a context without knowing which kind it is, preventing it from
 // resetting and getting re-used.
-struct StrongSpillContextInner(&'static SpillContextInner);
+pub struct StrongSpillContext(&'static SpillContextInner);
 
-impl StrongSpillContextInner {
+impl StrongSpillContext {
     fn new(name: PlSmallStr, policy: SpillContextPolicy) -> Self {
         let mut arena = SPILL_CONTEXT_REUSE_ARENA.lock().unwrap();
         let inner = if let Some(inner) = arena.pop() {
@@ -188,22 +200,27 @@ impl StrongSpillContextInner {
         } else {
             Box::leak(Box::new(SpillContextInner::new(name, policy)))
         };
-        
+
         // Important: mark as live (refcnt >= 1) before registering.
         inner.refcount.store(1, Ordering::Relaxed);
-        memory_manager().register_ctx(inner);
-        Self(inner)
+        let slf = Self(inner);
+        memory_manager().register_ctx(slf.downgrade());
+        slf
+    }
+
+    pub fn downgrade(&self) -> WeakSpillContext {
+        WeakSpillContext(self.0, self.0.context_id())
     }
 }
 
-impl Clone for StrongSpillContextInner {
+impl Clone for StrongSpillContext {
     fn clone(&self) -> Self {
         self.0.refcount.fetch_add(1, Ordering::Relaxed);
         Self(self.0)
     }
 }
 
-impl Drop for StrongSpillContextInner {
+impl Drop for StrongSpillContext {
     fn drop(&mut self) {
         if self.0.refcount.fetch_sub(1, Ordering::AcqRel) == 1 {
             SPILL_CONTEXT_REUSE_ARENA.lock().unwrap().push(self.0);
@@ -212,7 +229,29 @@ impl Drop for StrongSpillContextInner {
 }
 
 /// A generic weak reference to a context without knowing which kind it is.
-pub struct WeakSpillContext(pub(crate) &'static SpillContextInner);
+#[derive(Clone)]
+pub struct WeakSpillContext(pub(crate) &'static SpillContextInner, pub(crate) u64);
+
+impl WeakSpillContext {
+    pub fn upgrade(&self) -> Option<StrongSpillContext> {
+        if self.0.context_id() != self.1 {
+            return None;
+        }
+
+        self.0.refcount.fetch_add(1, Ordering::Relaxed);
+        let strong = StrongSpillContext(self.0);
+
+        // To avoid race conditions, we must check again.
+        if self.0.context_id() != self.1 {
+            return None;
+        }
+
+        Some(strong)
+    }
+    pub(crate) fn is_dead(&self) -> bool {
+        self.0.context_id() != self.1
+    }
+}
 
 /// An opaque parameter passed into a spill context during registering.
 pub struct SpillContextParam(pub(crate) ());
@@ -225,10 +264,9 @@ impl WeakSpillContext {
     {
         let dyn_arc = token.as_ref().upcast();
         let mut local = self.0.local.get_or_default().write().unwrap();
-        local.push_back(&dyn_arc, dyn_arc.register(&self.0));
+        local.push_back(&dyn_arc, dyn_arc.register(self.clone()));
     }
 }
-
 
 pub trait ParameterFreeSpillContext {
     fn register<T, S>(&self, token: &T)
@@ -238,16 +276,17 @@ pub trait ParameterFreeSpillContext {
         Self: Sized;
 }
 
-
-
 /// A context that spills the most-recently registered spillable when asked.
 #[derive(Clone)]
 #[repr(transparent)]
-pub struct MostRecentSpillContext(StrongSpillContextInner);
+pub struct MostRecentSpillContext(StrongSpillContext);
 
 impl MostRecentSpillContext {
     pub fn new(name: PlSmallStr) -> Self {
-        Self(StrongSpillContextInner::new(name, SpillContextPolicy::MostRecent))
+        Self(StrongSpillContext::new(
+            name,
+            SpillContextPolicy::MostRecent,
+        ))
     }
 }
 
@@ -259,7 +298,7 @@ impl ParameterFreeSpillContext for MostRecentSpillContext {
     {
         let dyn_arc = token.as_ref().upcast();
         let mut local = self.0.0.local.get_or_default().write().unwrap();
-        local.push_back(&dyn_arc, dyn_arc.register(self.0.0));
+        local.push_back(&dyn_arc, dyn_arc.register(self.0.downgrade()));
     }
 }
 
@@ -274,11 +313,14 @@ impl Debug for MostRecentSpillContext {
 /// A context that spills the least-recently registered spillable when asked.
 #[derive(Clone)]
 #[repr(transparent)]
-pub struct LeastRecentSpillContext(StrongSpillContextInner);
+pub struct LeastRecentSpillContext(StrongSpillContext);
 
 impl LeastRecentSpillContext {
     pub fn new(name: PlSmallStr) -> Self {
-        Self(StrongSpillContextInner::new(name, SpillContextPolicy::LeastRecent))
+        Self(StrongSpillContext::new(
+            name,
+            SpillContextPolicy::LeastRecent,
+        ))
     }
 }
 
@@ -290,7 +332,7 @@ impl ParameterFreeSpillContext for LeastRecentSpillContext {
     {
         let dyn_arc = token.as_ref().upcast();
         let mut local = self.0.0.local.get_or_default().write().unwrap();
-        local.push_back(&dyn_arc, dyn_arc.register(self.0.0));
+        local.push_back(&dyn_arc, dyn_arc.register(self.0.downgrade()));
     }
 }
 
@@ -304,11 +346,11 @@ impl Debug for LeastRecentSpillContext {
 
 /// A context that spills a random registered spillable when asked.
 #[derive(Clone)]
-pub struct RandomSpillContext(StrongSpillContextInner);
+pub struct RandomSpillContext(StrongSpillContext);
 
 impl RandomSpillContext {
     pub fn new(name: PlSmallStr) -> Self {
-        Self(StrongSpillContextInner::new(name, SpillContextPolicy::Random))
+        Self(StrongSpillContext::new(name, SpillContextPolicy::Random))
     }
 }
 
@@ -320,7 +362,7 @@ impl ParameterFreeSpillContext for RandomSpillContext {
     {
         let dyn_arc = token.as_ref().upcast();
         let mut local = self.0.0.local.get_or_default().write().unwrap();
-        local.push_back(&dyn_arc, dyn_arc.register(self.0.0));
+        local.push_back(&dyn_arc, dyn_arc.register(self.0.downgrade()));
     }
 }
 

--- a/crates/polars-ooc/src/spill_context/stats.rs
+++ b/crates/polars-ooc/src/spill_context/stats.rs
@@ -19,24 +19,22 @@ pub struct SpillContextStatistics {
 }
 
 impl SpillContextStatistics {
-    pub(crate) fn new(name: PlSmallStr, context_id: u64) -> Self {
+    pub(crate) fn new(name: PlSmallStr) -> Self {
         Self {
             // TODO: starting score based on context.
             score_cache: RelaxedCell::new_u64(UNEXPLORED_SCORE.to_bits()),
             stats: Mutex::new(Statistics {
                 name,
-                context_id,
                 ..Default::default()
             }),
         }
     }
 
-    pub(crate) fn reset(&self, name: PlSmallStr, context_id: u64) {
+    pub(crate) fn reset(&self, name: PlSmallStr) {
         let mut stats = self.stats.lock().unwrap();
         self.score_cache.store(UNEXPLORED_SCORE.to_bits());
         *stats = Statistics {
             name,
-            context_id,
             ..Default::default()
         };
     }
@@ -68,7 +66,6 @@ impl Drop for SpillContextStatistics {
 
 struct Statistics {
     name: PlSmallStr,
-    context_id: u64,
 
     // Total stats.
     spilled_byte_seconds: f64,
@@ -139,34 +136,22 @@ impl SpillContextStatistics {
         }
     }
 
-    pub fn start_exploration_event(&self, context_id: u64) {
+    pub fn start_exploration_event(&self) {
         // We don't bother stepping time here as it's already done in score sampling.
         let mut stats = self.stats.lock().unwrap();
-        if context_id != stats.context_id {
-            return;
-        }
-
         stats.total_explorations += 1;
         stats.bandit_explore_weight += 1.0;
     }
 
-    pub fn finish_exploration_event(&self, success: bool, context_id: u64) {
+    pub fn finish_exploration_event(&self, success: bool) {
         // We don't bother stepping time here as it's already done in score sampling.
         let mut stats = self.stats.lock().unwrap();
-        if context_id != stats.context_id {
-            return;
-        }
-
         stats.successful_explorations += success as u64;
         stats.bandit_explore_success += success as u64 as f64;
     }
 
-    pub fn add_failed_spill(&self, spill_start: Instant, context_id: u64) {
+    pub fn add_failed_spill(&self, spill_start: Instant) {
         let mut stats = self.stats.lock().unwrap();
-        if context_id != stats.context_id {
-            return;
-        }
-
         let now = Instant::now();
         stats.step_time(now); // Important: step time before mutating.
 
@@ -180,19 +165,11 @@ impl SpillContextStatistics {
     /// Instant from which we consider this value to be spilled. Both must be
     /// given back as arguments to `add_unspill`, to prevent accidental
     /// statistics drift and keep the accumulators precise.
-    pub fn add_successful_spill(
-        &self,
-        n_bytes: usize,
-        spill_start: Instant,
-        context_id: u64,
-    ) -> (u64, Instant) {
+    pub fn add_successful_spill(&self, n_bytes: usize, spill_start: Instant) -> (u64, Instant) {
         let mut stats = self.stats.lock().unwrap();
         let now = Instant::now();
         let spill_time = now - spill_start;
         let spill_time_ns = spill_time.as_nanos() as u64;
-        if context_id != stats.context_id {
-            return (spill_time_ns, now);
-        }
 
         stats.step_time(now); // Important: step time before mutating.
 
@@ -224,13 +201,8 @@ impl SpillContextStatistics {
         spill_time_ns: u64,
         spilled_start: Instant,
         unspill_start: Instant,
-        context_id: u64,
     ) {
         let mut stats = self.stats.lock().unwrap();
-        if context_id != stats.context_id {
-            return;
-        }
-
         let now = Instant::now();
         stats.step_time(now); // Important: step time before mutating.
 
@@ -437,7 +409,6 @@ impl Default for Statistics {
     fn default() -> Self {
         Self {
             name: PlSmallStr::EMPTY,
-            context_id: 0,
 
             spilled_byte_seconds: 0.0,
             spill_time: 0.0,

--- a/crates/polars-ooc/src/spill_context/stats.rs
+++ b/crates/polars-ooc/src/spill_context/stats.rs
@@ -1,5 +1,6 @@
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
+
 use polars_utils::pl_str::PlSmallStr;
 use polars_utils::relaxed_cell::RelaxedCell;
 use rand::{Rng, RngExt};
@@ -18,18 +19,26 @@ pub struct SpillContextStatistics {
 }
 
 impl SpillContextStatistics {
-    pub(crate) fn new(name: PlSmallStr) -> Self {
+    pub(crate) fn new(name: PlSmallStr, context_id: u64) -> Self {
         Self {
             // TODO: starting score based on context.
             score_cache: RelaxedCell::new_u64(UNEXPLORED_SCORE.to_bits()),
-            stats: Mutex::new(Statistics { name, ..Default::default() }),
+            stats: Mutex::new(Statistics {
+                name,
+                context_id,
+                ..Default::default()
+            }),
         }
     }
-    
-    pub(crate) fn reset(&self, name: PlSmallStr) {
+
+    pub(crate) fn reset(&self, name: PlSmallStr, context_id: u64) {
         let mut stats = self.stats.lock().unwrap();
         self.score_cache.store(UNEXPLORED_SCORE.to_bits());
-        *stats = Statistics { name, ..Default::default() };
+        *stats = Statistics {
+            name,
+            context_id,
+            ..Default::default()
+        };
     }
 }
 
@@ -59,6 +68,7 @@ impl Drop for SpillContextStatistics {
 
 struct Statistics {
     name: PlSmallStr,
+    context_id: u64,
 
     // Total stats.
     spilled_byte_seconds: f64,
@@ -129,22 +139,34 @@ impl SpillContextStatistics {
         }
     }
 
-    pub fn start_exploration_event(&self) {
+    pub fn start_exploration_event(&self, context_id: u64) {
         // We don't bother stepping time here as it's already done in score sampling.
         let mut stats = self.stats.lock().unwrap();
+        if context_id != stats.context_id {
+            return;
+        }
+
         stats.total_explorations += 1;
         stats.bandit_explore_weight += 1.0;
     }
 
-    pub fn finish_exploration_event(&self, success: bool) {
+    pub fn finish_exploration_event(&self, success: bool, context_id: u64) {
         // We don't bother stepping time here as it's already done in score sampling.
         let mut stats = self.stats.lock().unwrap();
+        if context_id != stats.context_id {
+            return;
+        }
+
         stats.successful_explorations += success as u64;
         stats.bandit_explore_success += success as u64 as f64;
     }
 
-    pub fn add_failed_spill(&self, spill_start: Instant) {
+    pub fn add_failed_spill(&self, spill_start: Instant, context_id: u64) {
         let mut stats = self.stats.lock().unwrap();
+        if context_id != stats.context_id {
+            return;
+        }
+
         let now = Instant::now();
         stats.step_time(now); // Important: step time before mutating.
 
@@ -158,17 +180,26 @@ impl SpillContextStatistics {
     /// Instant from which we consider this value to be spilled. Both must be
     /// given back as arguments to `add_unspill`, to prevent accidental
     /// statistics drift and keep the accumulators precise.
-    pub fn add_successful_spill(&self, n_bytes: usize, spill_start: Instant) -> (u64, Instant) {
+    pub fn add_successful_spill(
+        &self,
+        n_bytes: usize,
+        spill_start: Instant,
+        context_id: u64,
+    ) -> (u64, Instant) {
         let mut stats = self.stats.lock().unwrap();
         let now = Instant::now();
+        let spill_time = now - spill_start;
+        let spill_time_ns = spill_time.as_nanos() as u64;
+        if context_id != stats.context_id {
+            return (spill_time_ns, now);
+        }
+
         stats.step_time(now); // Important: step time before mutating.
 
         let mean_b_before = stats.active_spills_bytes as f64 / stats.active_spills.max(1) as f64;
         let mean_r_before = stats.active_spills_bytes_ns as f64
             / (stats.active_spills.max(1) as f64 * NANOSECONDS_IN_SECOND);
 
-        let spill_time = now - spill_start;
-        let spill_time_ns = spill_time.as_nanos() as u64;
         stats.spill_time += spill_time.as_secs_f64();
         stats.successful_spills += 1;
         stats.active_spills += 1;
@@ -193,8 +224,13 @@ impl SpillContextStatistics {
         spill_time_ns: u64,
         spilled_start: Instant,
         unspill_start: Instant,
+        context_id: u64,
     ) {
         let mut stats = self.stats.lock().unwrap();
+        if context_id != stats.context_id {
+            return;
+        }
+
         let now = Instant::now();
         stats.step_time(now); // Important: step time before mutating.
 
@@ -401,6 +437,7 @@ impl Default for Statistics {
     fn default() -> Self {
         Self {
             name: PlSmallStr::EMPTY,
+            context_id: 0,
 
             spilled_byte_seconds: 0.0,
             spill_time: 0.0,

--- a/crates/polars-ooc/src/spill_context/stats.rs
+++ b/crates/polars-ooc/src/spill_context/stats.rs
@@ -1,261 +1,9 @@
-use std::collections::VecDeque;
-use std::fmt::Debug;
-use std::sync::{Arc, Mutex, RwLock, Weak};
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
-
 use polars_utils::pl_str::PlSmallStr;
 use polars_utils::relaxed_cell::RelaxedCell;
-use rand::rngs::ThreadRng;
 use rand::{Rng, RngExt};
 use rand_distr::Distribution;
-use thread_local::ThreadLocal;
-
-use crate::spill_token::DynSpillToken;
-use crate::{SpillToken, Spillable, memory_manager};
-
-#[derive(Default)]
-struct LocalSpillQueue {
-    tokens: VecDeque<(Weak<dyn DynSpillToken>, u64)>,
-    retain_amort: usize,
-}
-
-impl LocalSpillQueue {
-    pub fn push_back(&mut self, token: &Arc<dyn DynSpillToken>, id: u64) {
-        self.gc();
-        if token.current_registration_id() == id {
-            self.tokens.push_back((Arc::downgrade(token), id));
-        }
-    }
-
-    pub fn push_front(&mut self, token: &Arc<dyn DynSpillToken>, id: u64) {
-        self.gc();
-        if token.current_registration_id() == id {
-            self.tokens.push_front((Arc::downgrade(token), id));
-        }
-    }
-
-    pub fn pop_front(&mut self) -> Option<(Arc<dyn DynSpillToken>, u64)> {
-        loop {
-            let (weak, id) = self.tokens.pop_front()?;
-            if let Some(token) = weak.upgrade()
-                && token.current_registration_id() == id
-            {
-                return Some((token, id));
-            }
-        }
-    }
-
-    pub fn pop_back(&mut self) -> Option<(Arc<dyn DynSpillToken>, u64)> {
-        loop {
-            let (weak, id) = self.tokens.pop_back()?;
-            if let Some(token) = weak.upgrade()
-                && token.current_registration_id() == id
-            {
-                return Some((token, id));
-            }
-        }
-    }
-
-    pub fn pop_random(&mut self, rng: &mut ThreadRng) -> Option<(Arc<dyn DynSpillToken>, u64)> {
-        while !self.tokens.is_empty() {
-            let idx = rng.random_range(0..self.tokens.len());
-            let (weak, id) = self.tokens.swap_remove_back(idx).unwrap();
-            if let Some(token) = weak.upgrade()
-                && token.current_registration_id() == id
-            {
-                return Some((token, id));
-            }
-        }
-        None
-    }
-
-    fn gc(&mut self) {
-        self.retain_amort += 2; // Grows twice as fast as push.
-        if self.retain_amort >= self.tokens.len() {
-            self.retain_amort = 0;
-            self.tokens.retain(|(token, id)| {
-                token
-                    .upgrade()
-                    .is_some_and(|t| t.current_registration_id() == *id)
-            });
-        }
-    }
-}
-
-enum SpillContextPolicy {
-    MostRecent,
-    LeastRecent,
-    Random,
-}
-
-pub(crate) struct SpillContextInner {
-    local: ThreadLocal<RwLock<LocalSpillQueue>>,
-    stats: Arc<SpillContextStatistics>,
-    policy: SpillContextPolicy,
-}
-
-impl SpillContextInner {
-    fn new(name: PlSmallStr, policy: SpillContextPolicy) -> Self {
-        Self {
-            local: ThreadLocal::default(),
-            stats: Arc::new(SpillContextStatistics::new(name)),
-            policy,
-        }
-    }
-
-    pub fn stats(&self) -> &Arc<SpillContextStatistics> {
-        &self.stats
-    }
-
-    pub fn pop(&self) -> Vec<(Arc<dyn DynSpillToken>, u64)> {
-        let mut out = Vec::new();
-        let mut rng = rand::rng();
-        for local_lock in self.local.iter() {
-            if let Ok(mut local) = local_lock.try_write() {
-                out.extend(match self.policy {
-                    SpillContextPolicy::MostRecent => local.pop_back(),
-                    SpillContextPolicy::LeastRecent => local.pop_front(),
-                    SpillContextPolicy::Random => local.pop_random(&mut rng),
-                });
-            }
-        }
-        out
-    }
-
-    pub fn reinsert(&self, token: &Arc<dyn DynSpillToken>, id: u64) {
-        let mut local = self.local.get_or_default().write().unwrap();
-        match self.policy {
-            SpillContextPolicy::MostRecent => local.push_front(token, id),
-            SpillContextPolicy::LeastRecent => local.push_back(token, id),
-            SpillContextPolicy::Random => local.push_back(token, id),
-        }
-    }
-}
-
-pub trait ParameterFreeSpillContext {
-    fn register<T, S>(&self, token: &T)
-    where
-        T: AsRef<SpillToken<S>>,
-        S: Spillable,
-        Self: Sized;
-}
-
-/// A generic handle to a context without knowing which kind it is.
-pub struct GenericSpillContext(pub(crate) Arc<SpillContextInner>);
-
-/// An opaque parameter passed into a spill context during registering.
-pub struct SpillContextParam(pub(crate) ());
-
-impl GenericSpillContext {
-    pub fn register<T, S>(&self, token: &T, _param: SpillContextParam)
-    where
-        T: AsRef<SpillToken<S>>,
-        S: Spillable,
-    {
-        let dyn_arc = token.as_ref().upcast();
-        let mut local = self.0.local.get_or_default().write().unwrap();
-        local.push_back(&dyn_arc, dyn_arc.register(&self.0));
-    }
-}
-
-/// A context that spills the most-recently registered spillable when asked.
-#[derive(Clone)]
-pub struct MostRecentSpillContext(Arc<SpillContextInner>);
-
-impl MostRecentSpillContext {
-    pub fn new(name: PlSmallStr) -> Self {
-        let ctx = Arc::new(SpillContextInner::new(name, SpillContextPolicy::MostRecent));
-        memory_manager().register_ctx(&ctx);
-        Self(ctx)
-    }
-}
-
-impl ParameterFreeSpillContext for MostRecentSpillContext {
-    fn register<T, S>(&self, token: &T)
-    where
-        T: AsRef<SpillToken<S>>,
-        S: Spillable,
-    {
-        let dyn_arc = token.as_ref().upcast();
-        let mut local = self.0.local.get_or_default().write().unwrap();
-        local.push_back(&dyn_arc, dyn_arc.register(&self.0));
-    }
-}
-
-impl Debug for MostRecentSpillContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MostRecentSpillContext")
-            .field("name", &self.0.stats.name)
-            .finish()
-    }
-}
-
-/// A context that spills the least-recently registered spillable when asked.
-#[derive(Clone)]
-pub struct LeastRecentSpillContext(Arc<SpillContextInner>);
-
-impl LeastRecentSpillContext {
-    pub fn new(name: PlSmallStr) -> Self {
-        let ctx = Arc::new(SpillContextInner::new(
-            name,
-            SpillContextPolicy::LeastRecent,
-        ));
-        memory_manager().register_ctx(&ctx);
-        Self(ctx)
-    }
-}
-
-impl ParameterFreeSpillContext for LeastRecentSpillContext {
-    fn register<T, S>(&self, token: &T)
-    where
-        T: AsRef<SpillToken<S>>,
-        S: Spillable,
-    {
-        let dyn_arc = token.as_ref().upcast();
-        let mut local = self.0.local.get_or_default().write().unwrap();
-        local.push_back(&dyn_arc, dyn_arc.register(&self.0));
-    }
-}
-
-impl Debug for LeastRecentSpillContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("LeastRecentSpillContext")
-            .field("name", &self.0.stats.name)
-            .finish()
-    }
-}
-
-/// A context that spills a random registered spillable when asked.
-#[derive(Clone)]
-pub struct RandomSpillContext(Arc<SpillContextInner>);
-
-impl RandomSpillContext {
-    pub fn new(name: PlSmallStr) -> Self {
-        let ctx = Arc::new(SpillContextInner::new(name, SpillContextPolicy::Random));
-        memory_manager().register_ctx(&ctx);
-        Self(ctx)
-    }
-}
-
-impl ParameterFreeSpillContext for RandomSpillContext {
-    fn register<T, S>(&self, token: &T)
-    where
-        T: AsRef<SpillToken<S>>,
-        S: Spillable,
-    {
-        let dyn_arc = token.as_ref().upcast();
-        let mut local = self.0.local.get_or_default().write().unwrap();
-        local.push_back(&dyn_arc, dyn_arc.register(&self.0));
-    }
-}
-
-impl Debug for RandomSpillContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RandomSpillContext")
-            .field("name", &self.0.stats.name)
-            .finish()
-    }
-}
 
 // Used to normalize divisor to avoid absurdly high scores. Set to 1us.
 const BASE_IO_TIME: f64 = 1e-6;
@@ -267,28 +15,32 @@ const NANOSECONDS_IN_SECOND: f64 = 1e9;
 pub struct SpillContextStatistics {
     score_cache: RelaxedCell<u64>,
     stats: Mutex<Statistics>,
-    name: PlSmallStr,
 }
 
 impl SpillContextStatistics {
-    fn new(name: PlSmallStr) -> Self {
+    pub(crate) fn new(name: PlSmallStr) -> Self {
         Self {
             // TODO: starting score based on context.
             score_cache: RelaxedCell::new_u64(UNEXPLORED_SCORE.to_bits()),
-            stats: Mutex::default(),
-            name,
+            stats: Mutex::new(Statistics { name, ..Default::default() }),
         }
+    }
+    
+    pub(crate) fn reset(&self, name: PlSmallStr) {
+        let mut stats = self.stats.lock().unwrap();
+        self.score_cache.store(UNEXPLORED_SCORE.to_bits());
+        *stats = Statistics { name, ..Default::default() };
     }
 }
 
 impl Drop for SpillContextStatistics {
     fn drop(&mut self) {
         if polars_config::config().ooc_log_metrics() {
-            let name = &self.name;
             let stats = self.stats.get_mut().unwrap();
+            let name = &stats.name;
             let relief = stats.spilled_byte_seconds / (1000.0 * 1000.0);
             let spill_io = Duration::from_secs_f64(stats.spill_time);
-            let unspill_io = Duration::from_secs_f64(stats.spill_time);
+            let unspill_io = Duration::from_secs_f64(stats.unspill_time);
             let spills_tot = stats.successful_spills + stats.failed_spills;
             let spills_succ = 100.0 * stats.successful_spills as f64 / spills_tot as f64;
             let explore_tot = stats.total_explorations;
@@ -306,6 +58,8 @@ impl Drop for SpillContextStatistics {
 }
 
 struct Statistics {
+    name: PlSmallStr,
+
     // Total stats.
     spilled_byte_seconds: f64,
     spill_time: f64,
@@ -355,8 +109,8 @@ struct Statistics {
 }
 
 impl SpillContextStatistics {
-    pub fn name(&self) -> &str {
-        &self.name
+    pub fn name(&self) -> PlSmallStr {
+        self.stats.lock().unwrap().name.clone()
     }
 
     // Returns a sample of the expected performance of this context, discounting
@@ -646,6 +400,8 @@ impl Statistics {
 impl Default for Statistics {
     fn default() -> Self {
         Self {
+            name: PlSmallStr::EMPTY,
+
             spilled_byte_seconds: 0.0,
             spill_time: 0.0,
             unspill_time: 0.0,

--- a/crates/polars-ooc/src/spill_token.rs
+++ b/crates/polars-ooc/src/spill_token.rs
@@ -217,7 +217,9 @@ impl<T: Spillable> SpillTokenInner<T> {
             };
 
             if let Some(strong) = spill_ctx.upgrade() {
-                strong.stats().add_unspill(n_bytes, spill_time_ns, spilled_start, unspill_start);
+                strong
+                    .stats()
+                    .add_unspill(n_bytes, spill_time_ns, spilled_start, unspill_start);
             }
             if reinsert_reg_id == slf.registration_id.load(Ordering::Relaxed) {
                 let dyn_slf: Arc<dyn DynSpillToken> = slf.clone();
@@ -265,11 +267,18 @@ impl<T: Spillable> SpillTokenInner<T> {
                 let value = T::unspill(&spilled).await;
 
                 if let Some(strong) = spill_ctx.upgrade() {
-                    strong.stats().add_unspill(*n_bytes, *spill_time_ns, *spilled_start, unspill_start);
+                    strong.stats().add_unspill(
+                        *n_bytes,
+                        *spill_time_ns,
+                        *spilled_start,
+                        unspill_start,
+                    );
                 }
                 if *reinsert_reg_id == slf.registration_id.load(Ordering::Relaxed) {
                     let dyn_slf: Arc<dyn DynSpillToken> = slf.clone();
-                    spill_ctx.0.reinsert(&dyn_slf, *reinsert_reg_id, spill_ctx.1);
+                    spill_ctx
+                        .0
+                        .reinsert(&dyn_slf, *reinsert_reg_id, spill_ctx.1);
                 }
 
                 *value_slot = ValueSlot::InMemory(value);

--- a/crates/polars-ooc/src/spill_token.rs
+++ b/crates/polars-ooc/src/spill_token.rs
@@ -10,7 +10,6 @@ use polars_async::ASYNC;
 use polars_utils::UnitVec;
 use polars_utils::with_drop::WithDrop;
 
-use crate::spill_context::SpillContextInner;
 use crate::{SpillContextParam, Spillable, WeakSpillContext};
 
 // SpillTokenInner's state
@@ -25,8 +24,7 @@ enum ValueSlot<T> {
     InMemory(T),
     Spilled {
         n_bytes: usize,
-        spill_ctx: &'static SpillContextInner,
-        spill_ctx_id: u64,
+        spill_ctx: WeakSpillContext,
         reinsert_reg_id: u32,
         spill_time_ns: u64,
         spilled_start: Instant,
@@ -210,7 +208,6 @@ impl<T: Spillable> SpillTokenInner<T> {
             let ValueSlot::Spilled {
                 n_bytes,
                 spill_ctx,
-                spill_ctx_id,
                 reinsert_reg_id,
                 spill_time_ns,
                 spilled_start,
@@ -219,16 +216,12 @@ impl<T: Spillable> SpillTokenInner<T> {
                 unreachable!()
             };
 
-            spill_ctx.stats().add_unspill(
-                n_bytes,
-                spill_time_ns,
-                spilled_start,
-                unspill_start,
-                spill_ctx_id,
-            );
+            if let Some(strong) = spill_ctx.upgrade() {
+                strong.stats().add_unspill(n_bytes, spill_time_ns, spilled_start, unspill_start);
+            }
             if reinsert_reg_id == slf.registration_id.load(Ordering::Relaxed) {
                 let dyn_slf: Arc<dyn DynSpillToken> = slf.clone();
-                spill_ctx.reinsert(&dyn_slf, reinsert_reg_id, spill_ctx_id);
+                spill_ctx.0.reinsert(&dyn_slf, reinsert_reg_id, spill_ctx.1);
             }
 
             WithDrop::dismiss(lock_guard);
@@ -261,7 +254,6 @@ impl<T: Spillable> SpillTokenInner<T> {
             if let ValueSlot::Spilled {
                 n_bytes,
                 spill_ctx,
-                spill_ctx_id,
                 reinsert_reg_id,
                 spill_time_ns,
                 spilled_start,
@@ -272,16 +264,12 @@ impl<T: Spillable> SpillTokenInner<T> {
                 let spilled = (*slf.spilled_value.get()).take().unwrap();
                 let value = T::unspill(&spilled).await;
 
-                spill_ctx.stats().add_unspill(
-                    *n_bytes,
-                    *spill_time_ns,
-                    *spilled_start,
-                    unspill_start,
-                    *spill_ctx_id,
-                );
+                if let Some(strong) = spill_ctx.upgrade() {
+                    strong.stats().add_unspill(*n_bytes, *spill_time_ns, *spilled_start, unspill_start);
+                }
                 if *reinsert_reg_id == slf.registration_id.load(Ordering::Relaxed) {
                     let dyn_slf: Arc<dyn DynSpillToken> = slf.clone();
-                    spill_ctx.reinsert(&dyn_slf, *reinsert_reg_id, *spill_ctx_id);
+                    spill_ctx.0.reinsert(&dyn_slf, *reinsert_reg_id, spill_ctx.1);
                 }
 
                 *value_slot = ValueSlot::InMemory(value);
@@ -367,8 +355,7 @@ pub(crate) trait DynSpillToken: Send + Sync + 'static {
     /// occurred during spilling.
     fn try_spill(
         &self,
-        context: &'static SpillContextInner,
-        ctx_id: u64,
+        context: WeakSpillContext,
         registration_id: u32,
     ) -> Result<Pin<Box<dyn Future<Output = bool> + Send + '_>>, TrySpillError>;
 }
@@ -405,8 +392,7 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
 
     fn try_spill(
         &self,
-        ctx: &'static SpillContextInner,
-        ctx_id: u64,
+        ctx: WeakSpillContext,
         registration_id: u32,
     ) -> Result<Pin<Box<dyn Future<Output = bool> + Send + '_>>, TrySpillError> {
         // First, we try setting the lock bit. If anyone else has a pin we don't bother.
@@ -450,7 +436,7 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
                         .fetch_add(RO_PIN_COUNT_UNIT - LOCK_BIT, Ordering::AcqRel),
                 );
                 let pin_guard = PinnedRef { inner: self };
-                let spilled = pin_guard.spill(&ctx.stats().name()).await;
+                let spilled = pin_guard.spill(&ctx.0.stats().name()).await;
                 core::mem::forget(pin_guard);
                 // We can simply re-acquire the lock here blindly, as we still hold
                 // our pin meaning no one else could've gotten the lock.
@@ -472,14 +458,16 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
                     ValueSlot::InMemory(val) => val.estimate_byte_size(),
                     _ => unreachable!(),
                 };
-                let (spill_time_ns, spilled_start) =
-                    ctx.stats()
-                        .add_successful_spill(n_bytes, spill_start, ctx_id);
+                let (spill_time_ns, spilled_start) = if let Some(strong) = ctx.upgrade() {
+                    strong.stats().add_successful_spill(n_bytes, spill_start)
+                } else {
+                    // Dummy, context is already dead.
+                    (0, Instant::now())
+                };
                 unsafe {
                     self.value_slot.get().replace(ValueSlot::Spilled {
                         n_bytes,
                         spill_ctx: ctx,
-                        spill_ctx_id: ctx_id,
                         reinsert_reg_id: registration_id,
                         spill_time_ns,
                         spilled_start,
@@ -488,7 +476,9 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
                 self.state
                     .fetch_add(SPILLED_BIT.wrapping_sub(LOCK_BIT), Ordering::AcqRel)
             } else {
-                ctx.stats().add_failed_spill(spill_start, ctx_id);
+                if let Some(strong) = ctx.upgrade() {
+                    strong.stats().add_failed_spill(spill_start);
+                }
                 self.state.fetch_sub(LOCK_BIT, Ordering::AcqRel)
             };
             self.wake_waiters(state);

--- a/crates/polars-ooc/src/spill_token.rs
+++ b/crates/polars-ooc/src/spill_token.rs
@@ -1,8 +1,9 @@
 use std::cell::UnsafeCell;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
+use std::ptr;
 use std::sync::atomic::{AtomicPtr, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Arc, Mutex};
 use std::task::{Poll, Waker};
 use std::time::Instant;
 
@@ -11,14 +12,8 @@ use polars_utils::UnitVec;
 use polars_utils::with_drop::WithDrop;
 
 use crate::spill_context::{SpillContextInner, SpillContextStatistics};
-use crate::{GenericSpillContext, SpillContextParam, Spillable};
+use crate::{SpillContextParam, Spillable, WeakSpillContext};
 
-unsafe fn weak_from_raw<T>(raw: *mut T) -> Option<Weak<T>> {
-    if raw.is_null() {
-        return None;
-    }
-    Some(unsafe { Weak::from_raw(raw) })
-}
 
 // SpillTokenInner's state
 const SPILLED_BIT: u64 = 1; // Set when value = None and spilled is Some.
@@ -33,7 +28,7 @@ enum ValueSlot<T> {
     Spilled {
         n_bytes: usize,
         spill_ctx_stats: Arc<SpillContextStatistics>,
-        reinsert_ctx: Weak<SpillContextInner>,
+        reinsert_ctx: &'static SpillContextInner,
         reinsert_id: u64,
         spill_time_ns: u64,
         spilled_start: Instant,
@@ -223,10 +218,8 @@ impl<T: Spillable> SpillTokenInner<T> {
 
             spill_ctx_stats.add_unspill(n_bytes, spill_time_ns, spilled_start, unspill_start);
             if reinsert_id == slf.registration_id.load(Ordering::Relaxed) {
-                if let Some(ctx) = reinsert_ctx.upgrade() {
-                    let dyn_slf: Arc<dyn DynSpillToken> = slf.clone();
-                    ctx.reinsert(&dyn_slf, reinsert_id);
-                }
+                let dyn_slf: Arc<dyn DynSpillToken> = slf.clone();
+                reinsert_ctx.reinsert(&dyn_slf, reinsert_id);
             }
 
             WithDrop::dismiss(lock_guard);
@@ -277,10 +270,8 @@ impl<T: Spillable> SpillTokenInner<T> {
                     unspill_start,
                 );
                 if *reinsert_id == slf.registration_id.load(Ordering::Relaxed) {
-                    if let Some(ctx) = reinsert_ctx.upgrade() {
-                        let dyn_slf: Arc<dyn DynSpillToken> = slf.clone();
-                        ctx.reinsert(&dyn_slf, *reinsert_id);
-                    }
+                    let dyn_slf: Arc<dyn DynSpillToken> = slf.clone();
+                    reinsert_ctx.reinsert(&dyn_slf, *reinsert_id);
                 }
 
                 *value_slot = ValueSlot::InMemory(value);
@@ -326,8 +317,7 @@ impl<T: Spillable> SpillTokenInner<T> {
                 self.spilled_value.get().replace(None);
             }
             self.registration_id.fetch_add(1, Ordering::Relaxed);
-            let ctx = self.cur_ctx.swap(core::ptr::null_mut(), Ordering::Acquire);
-            drop(weak_from_raw(ctx));
+            self.cur_ctx.store(core::ptr::null_mut(), Ordering::Release);
         }
     }
 }
@@ -339,11 +329,11 @@ pub enum TrySpillError {
 
 pub(crate) trait DynSpillToken: Send + Sync + 'static {
     /// Register this spill token at a new context, returning the registration ID.
-    fn register(&self, ctx: &Arc<SpillContextInner>) -> u64;
+    fn register(&self, ctx: &'static SpillContextInner) -> u64;
 
     /// Unregisters this spill token from its current context, returning where
     /// it was registered, if anywhere.
-    fn unregister(&self) -> Option<Weak<SpillContextInner>>;
+    fn unregister(&self) -> Option<&'static SpillContextInner>;
 
     /// Returns the current context registration ID of this spill token without modifying it.
     fn current_registration_id(&self) -> u64;
@@ -367,25 +357,21 @@ pub(crate) trait DynSpillToken: Send + Sync + 'static {
     fn try_spill(
         &self,
         stats: &Arc<SpillContextStatistics>,
-        context: Weak<SpillContextInner>,
+        context: &'static SpillContextInner,
         registration_id: u64,
     ) -> Result<Pin<Box<dyn Future<Output = bool> + Send + '_>>, TrySpillError>;
 }
 
 impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
-    fn register(&self, ctx: &Arc<SpillContextInner>) -> u64 {
-        let weak = Arc::downgrade(ctx);
-        let old_ctx = self
-            .cur_ctx
-            .swap(Weak::into_raw(weak).cast_mut(), Ordering::AcqRel);
-        drop(unsafe { weak_from_raw(old_ctx) });
+    fn register(&self, ctx: &'static SpillContextInner) -> u64 {
+        self.cur_ctx.store(ptr::from_ref(ctx).cast_mut(), Ordering::Release);
         self.registration_id.fetch_add(1, Ordering::Release) + 1
     }
 
-    fn unregister(&self) -> Option<Weak<SpillContextInner>> {
+    fn unregister(&self) -> Option<&'static SpillContextInner> {
         let old_ctx = self.cur_ctx.swap(core::ptr::null_mut(), Ordering::AcqRel);
         self.registration_id.fetch_add(1, Ordering::Release);
-        unsafe { weak_from_raw(old_ctx) }
+        unsafe { old_ctx.as_ref() }
     }
 
     fn current_registration_id(&self) -> u64 {
@@ -408,7 +394,7 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
     fn try_spill(
         &self,
         stats: &Arc<SpillContextStatistics>,
-        context: Weak<SpillContextInner>,
+        context: &'static SpillContextInner,
         registration_id: u64,
     ) -> Result<Pin<Box<dyn Future<Output = bool> + Send + '_>>, TrySpillError> {
         // First, we try setting the lock bit. If anyone else has a pin we don't bother.
@@ -453,7 +439,7 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
                         .fetch_add(RO_PIN_COUNT_UNIT - LOCK_BIT, Ordering::AcqRel),
                 );
                 let pin_guard = PinnedRef { inner: self };
-                let spilled = pin_guard.spill(stats.name()).await;
+                let spilled = pin_guard.spill(&stats.name()).await;
                 core::mem::forget(pin_guard);
                 // We can simply re-acquire the lock here blindly, as we still hold
                 // our pin meaning no one else could've gotten the lock.
@@ -526,10 +512,10 @@ impl<T: Spillable> SpillToken<T> {
     }
 
     /// Unregisters this spill token from its current context, if any, returning it.
-    pub fn unregister(&mut self) -> Option<(GenericSpillContext, SpillContextParam)> {
-        let ctx = self.inner.unregister()?.upgrade()?;
+    pub fn unregister(&mut self) -> Option<(WeakSpillContext, SpillContextParam)> {
+        let ctx = self.inner.unregister()?;
         let param = SpillContextParam(()); // TODO: get this once we support contexts with parameters.
-        Some((GenericSpillContext(ctx), param))
+        Some((WeakSpillContext(ctx), param))
     }
 
     /// Try to get a reference to the underlying value, returning None if it was spilled.

--- a/crates/polars-ooc/src/spill_token.rs
+++ b/crates/polars-ooc/src/spill_token.rs
@@ -2,7 +2,7 @@ use std::cell::UnsafeCell;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
 use std::ptr;
-use std::sync::atomic::{AtomicPtr, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicPtr, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::{Poll, Waker};
 use std::time::Instant;
@@ -29,7 +29,7 @@ enum ValueSlot<T> {
         n_bytes: usize,
         spill_ctx_stats: Arc<SpillContextStatistics>,
         reinsert_ctx: &'static SpillContextInner,
-        reinsert_id: u64,
+        reinsert_id: u32,
         spill_time_ns: u64,
         spilled_start: Instant,
     },
@@ -54,7 +54,7 @@ struct SpillTokenInner<T: Spillable> {
 
     // Used to register into contexts, and detect when a token has moved to a
     // different context.
-    registration_id: AtomicU64,
+    registration_id: AtomicU32,
 
     // See above.
     state: AtomicU64,
@@ -329,14 +329,14 @@ pub enum TrySpillError {
 
 pub(crate) trait DynSpillToken: Send + Sync + 'static {
     /// Register this spill token at a new context, returning the registration ID.
-    fn register(&self, ctx: &'static SpillContextInner) -> u64;
+    fn register(&self, ctx: &'static SpillContextInner) -> u32;
 
     /// Unregisters this spill token from its current context, returning where
     /// it was registered, if anywhere.
     fn unregister(&self) -> Option<&'static SpillContextInner>;
 
     /// Returns the current context registration ID of this spill token without modifying it.
-    fn current_registration_id(&self) -> u64;
+    fn current_registration_id(&self) -> u32;
 
     /// Whether this token can be spilled. Returns false if pinned, dropped or
     /// already spilled.
@@ -358,12 +358,12 @@ pub(crate) trait DynSpillToken: Send + Sync + 'static {
         &self,
         stats: &Arc<SpillContextStatistics>,
         context: &'static SpillContextInner,
-        registration_id: u64,
+        registration_id: u32,
     ) -> Result<Pin<Box<dyn Future<Output = bool> + Send + '_>>, TrySpillError>;
 }
 
 impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
-    fn register(&self, ctx: &'static SpillContextInner) -> u64 {
+    fn register(&self, ctx: &'static SpillContextInner) -> u32 {
         self.cur_ctx.store(ptr::from_ref(ctx).cast_mut(), Ordering::Release);
         self.registration_id.fetch_add(1, Ordering::Release) + 1
     }
@@ -374,7 +374,7 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
         unsafe { old_ctx.as_ref() }
     }
 
-    fn current_registration_id(&self) -> u64 {
+    fn current_registration_id(&self) -> u32 {
         self.registration_id.load(Ordering::Relaxed)
     }
 
@@ -395,7 +395,7 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
         &self,
         stats: &Arc<SpillContextStatistics>,
         context: &'static SpillContextInner,
-        registration_id: u64,
+        registration_id: u32,
     ) -> Result<Pin<Box<dyn Future<Output = bool> + Send + '_>>, TrySpillError> {
         // First, we try setting the lock bit. If anyone else has a pin we don't bother.
         let pin_update = self
@@ -498,7 +498,7 @@ impl<T: Spillable> SpillToken<T> {
             value_slot: UnsafeCell::new(ValueSlot::InMemory(value)),
             spilled_value: UnsafeCell::new(None),
             cur_ctx: AtomicPtr::new(core::ptr::null_mut()),
-            registration_id: AtomicU64::new(0),
+            registration_id: AtomicU32::new(0),
             state: AtomicU64::new(0),
             waiters: Mutex::default(),
         });

--- a/crates/polars-ooc/src/spill_token.rs
+++ b/crates/polars-ooc/src/spill_token.rs
@@ -1,7 +1,7 @@
 use std::cell::UnsafeCell;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicPtr, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 use std::task::{Poll, Waker};
 use std::time::Instant;
@@ -10,8 +10,15 @@ use polars_async::ASYNC;
 use polars_utils::UnitVec;
 use polars_utils::with_drop::WithDrop;
 
-use crate::spill_context::SpillContextStatistics;
-use crate::{SpillContext, Spillable};
+use crate::spill_context::{SpillContextInner, SpillContextStatistics};
+use crate::{GenericSpillContext, SpillContextParam, Spillable};
+
+unsafe fn weak_from_raw<T>(raw: *mut T) -> Option<Weak<T>> {
+    if raw.is_null() {
+        return None;
+    }
+    Some(unsafe { Weak::from_raw(raw) })
+}
 
 // SpillTokenInner's state
 const SPILLED_BIT: u64 = 1; // Set when value = None and spilled is Some.
@@ -26,7 +33,7 @@ enum ValueSlot<T> {
     Spilled {
         n_bytes: usize,
         spill_ctx_stats: Arc<SpillContextStatistics>,
-        reinsert_ctx: Weak<dyn SpillContext>,
+        reinsert_ctx: Weak<SpillContextInner>,
         reinsert_id: u64,
         spill_time_ns: u64,
         spilled_start: Instant,
@@ -44,6 +51,11 @@ struct SpillTokenInner<T: Spillable> {
 
     // Lock should not be held for long, only used to register/wake waiters.
     waiters: Mutex<UnitVec<Waker>>,
+
+    // The current context this spill token is registered at. This is a raw
+    // Weak pointer, null if not assigned to anything. This is provided as a
+    // best effort, in the case of racy registers this field may be wrong.
+    cur_ctx: AtomicPtr<SpillContextInner>,
 
     // Used to register into contexts, and detect when a token has moved to a
     // different context.
@@ -302,6 +314,8 @@ impl<T: Spillable> SpillTokenInner<T> {
         self.wake_waiters(self.state.fetch_sub(LOCK_BIT, Ordering::AcqRel));
     }
 
+    /// # Safety
+    /// May only be called once, by the owning SpillToken.
     unsafe fn mark_as_dropped(&self) {
         unsafe {
             // The drop bit prevents new locks/pins from being acquired,
@@ -312,6 +326,8 @@ impl<T: Spillable> SpillTokenInner<T> {
                 self.spilled_value.get().replace(None);
             }
             self.registration_id.fetch_add(1, Ordering::Relaxed);
+            let ctx = self.cur_ctx.swap(core::ptr::null_mut(), Ordering::Acquire);
+            drop(weak_from_raw(ctx));
         }
     }
 }
@@ -321,11 +337,15 @@ pub enum TrySpillError {
     Pinned,
 }
 
-pub trait DynSpillToken: Send + Sync + 'static {
-    /// Assign a new context ID to this spill token, invalidating previous ids.
-    fn new_registration_id(&self) -> u64;
+pub(crate) trait DynSpillToken: Send + Sync + 'static {
+    /// Register this spill token at a new context, returning the registration ID.
+    fn register(&self, ctx: &Arc<SpillContextInner>) -> u64;
 
-    /// Returns the current context ID of this spill token without modifying it.
+    /// Unregisters this spill token from its current context, returning where
+    /// it was registered, if anywhere.
+    fn unregister(&self) -> Option<Weak<SpillContextInner>>;
+
+    /// Returns the current context registration ID of this spill token without modifying it.
     fn current_registration_id(&self) -> u64;
 
     /// Whether this token can be spilled. Returns false if pinned, dropped or
@@ -347,14 +367,25 @@ pub trait DynSpillToken: Send + Sync + 'static {
     fn try_spill(
         &self,
         stats: &Arc<SpillContextStatistics>,
-        context: Weak<dyn SpillContext>,
+        context: Weak<SpillContextInner>,
         registration_id: u64,
     ) -> Result<Pin<Box<dyn Future<Output = bool> + Send + '_>>, TrySpillError>;
 }
 
 impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
-    fn new_registration_id(&self) -> u64 {
-        self.registration_id.fetch_add(1, Ordering::Relaxed) + 1
+    fn register(&self, ctx: &Arc<SpillContextInner>) -> u64 {
+        let weak = Arc::downgrade(ctx);
+        let old_ctx = self
+            .cur_ctx
+            .swap(Weak::into_raw(weak).cast_mut(), Ordering::AcqRel);
+        drop(unsafe { weak_from_raw(old_ctx) });
+        self.registration_id.fetch_add(1, Ordering::Release) + 1
+    }
+
+    fn unregister(&self) -> Option<Weak<SpillContextInner>> {
+        let old_ctx = self.cur_ctx.swap(core::ptr::null_mut(), Ordering::AcqRel);
+        self.registration_id.fetch_add(1, Ordering::Release);
+        unsafe { weak_from_raw(old_ctx) }
     }
 
     fn current_registration_id(&self) -> u64 {
@@ -377,7 +408,7 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
     fn try_spill(
         &self,
         stats: &Arc<SpillContextStatistics>,
-        context: Weak<dyn SpillContext>,
+        context: Weak<SpillContextInner>,
         registration_id: u64,
     ) -> Result<Pin<Box<dyn Future<Output = bool> + Send + '_>>, TrySpillError> {
         // First, we try setting the lock bit. If anyone else has a pin we don't bother.
@@ -480,6 +511,7 @@ impl<T: Spillable> SpillToken<T> {
         let inner = Arc::new(SpillTokenInner {
             value_slot: UnsafeCell::new(ValueSlot::InMemory(value)),
             spilled_value: UnsafeCell::new(None),
+            cur_ctx: AtomicPtr::new(core::ptr::null_mut()),
             registration_id: AtomicU64::new(0),
             state: AtomicU64::new(0),
             waiters: Mutex::default(),
@@ -488,9 +520,16 @@ impl<T: Spillable> SpillToken<T> {
     }
 
     /// Upcast to DynSpillToken.
-    pub fn upcast(&self) -> Arc<dyn DynSpillToken> {
+    pub(crate) fn upcast(&self) -> Arc<dyn DynSpillToken> {
         let inner: Arc<SpillTokenInner<T>> = self.inner.clone();
         inner
+    }
+
+    /// Unregisters this spill token from its current context, if any, returning it.
+    pub fn unregister(&mut self) -> Option<(GenericSpillContext, SpillContextParam)> {
+        let ctx = self.inner.unregister()?.upgrade()?;
+        let param = SpillContextParam(()); // TODO: get this once we support contexts with parameters.
+        Some((GenericSpillContext(ctx), param))
     }
 
     /// Try to get a reference to the underlying value, returning None if it was spilled.

--- a/crates/polars-ooc/src/spill_token.rs
+++ b/crates/polars-ooc/src/spill_token.rs
@@ -1,8 +1,7 @@
 use std::cell::UnsafeCell;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
-use std::ptr;
-use std::sync::atomic::{AtomicPtr, AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::{Poll, Waker};
 use std::time::Instant;
@@ -11,9 +10,8 @@ use polars_async::ASYNC;
 use polars_utils::UnitVec;
 use polars_utils::with_drop::WithDrop;
 
-use crate::spill_context::{SpillContextInner, SpillContextStatistics};
+use crate::spill_context::SpillContextInner;
 use crate::{SpillContextParam, Spillable, WeakSpillContext};
-
 
 // SpillTokenInner's state
 const SPILLED_BIT: u64 = 1; // Set when value = None and spilled is Some.
@@ -27,13 +25,22 @@ enum ValueSlot<T> {
     InMemory(T),
     Spilled {
         n_bytes: usize,
-        spill_ctx_stats: Arc<SpillContextStatistics>,
-        reinsert_ctx: &'static SpillContextInner,
-        reinsert_id: u32,
+        spill_ctx: &'static SpillContextInner,
+        spill_ctx_id: u64,
+        reinsert_reg_id: u32,
         spill_time_ns: u64,
         spilled_start: Instant,
     },
     Dropped,
+}
+
+#[derive(Default)]
+struct LockState {
+    // Waiter for register/wake.
+    waiters: UnitVec<Waker>,
+
+    // The current context this spill token is registered at.
+    cur_ctx: Option<WeakSpillContext>,
 }
 
 struct SpillTokenInner<T: Spillable> {
@@ -44,13 +51,9 @@ struct SpillTokenInner<T: Spillable> {
     // May be read+written while holding LOCK_BIT (irrespective of pins).
     spilled_value: UnsafeCell<Option<T::Spilled>>,
 
-    // Lock should not be held for long, only used to register/wake waiters.
-    waiters: Mutex<UnitVec<Waker>>,
-
-    // The current context this spill token is registered at. This is a raw
-    // Weak pointer, null if not assigned to anything. This is provided as a
-    // best effort, in the case of racy registers this field may be wrong.
-    cur_ctx: AtomicPtr<SpillContextInner>,
+    // Lock should not be held for long, only used to register/wake waiters or
+    // store current registered context.
+    lock: Mutex<LockState>,
 
     // Used to register into contexts, and detect when a token has moved to a
     // different context.
@@ -68,7 +71,7 @@ impl<T: Spillable> SpillTokenInner<T> {
     async fn wait(&self, mask: u64) -> u64 {
         std::future::poll_fn(|ctx| {
             // Check mask while holding waiter lock to avoid missed notifications.
-            let mut waiters = self.waiters.lock().unwrap();
+            let mut lock = self.lock.lock().unwrap();
             let mut state = self.state.load(Ordering::Acquire);
             if state & mask != 0 {
                 if state & HAS_WAITERS_BIT == 0 {
@@ -78,7 +81,7 @@ impl<T: Spillable> SpillTokenInner<T> {
                         return Poll::Ready(state);
                     }
                 }
-                waiters.push(ctx.waker().clone());
+                lock.waiters.push(ctx.waker().clone());
                 Poll::Pending
             } else {
                 Poll::Ready(state)
@@ -103,10 +106,10 @@ impl<T: Spillable> SpillTokenInner<T> {
     fn wake_waiters_slow(&self) {
         // Modify HAS_WAITERS_BIT only while holding the lock. Don't notify
         // while holding the lock to reduce critical section.
-        let mut waiters_lock = self.waiters.lock().unwrap();
-        let waiters = core::mem::take(&mut *waiters_lock);
+        let mut lock = self.lock.lock().unwrap();
+        let waiters = core::mem::take(&mut lock.waiters);
         self.state.fetch_sub(HAS_WAITERS_BIT, Ordering::Relaxed);
-        drop(waiters_lock);
+        drop(lock);
 
         for w in waiters {
             w.wake();
@@ -206,9 +209,9 @@ impl<T: Spillable> SpillTokenInner<T> {
             let value = T::unspill(spilled).await;
             let ValueSlot::Spilled {
                 n_bytes,
-                spill_ctx_stats,
-                reinsert_ctx,
-                reinsert_id,
+                spill_ctx,
+                spill_ctx_id,
+                reinsert_reg_id,
                 spill_time_ns,
                 spilled_start,
             } = slf.value_slot.get().replace(ValueSlot::InMemory(value))
@@ -216,10 +219,16 @@ impl<T: Spillable> SpillTokenInner<T> {
                 unreachable!()
             };
 
-            spill_ctx_stats.add_unspill(n_bytes, spill_time_ns, spilled_start, unspill_start);
-            if reinsert_id == slf.registration_id.load(Ordering::Relaxed) {
+            spill_ctx.stats().add_unspill(
+                n_bytes,
+                spill_time_ns,
+                spilled_start,
+                unspill_start,
+                spill_ctx_id,
+            );
+            if reinsert_reg_id == slf.registration_id.load(Ordering::Relaxed) {
                 let dyn_slf: Arc<dyn DynSpillToken> = slf.clone();
-                reinsert_ctx.reinsert(&dyn_slf, reinsert_id);
+                spill_ctx.reinsert(&dyn_slf, reinsert_reg_id, spill_ctx_id);
             }
 
             WithDrop::dismiss(lock_guard);
@@ -251,9 +260,9 @@ impl<T: Spillable> SpillTokenInner<T> {
             let value_slot = &mut *slf.value_slot.get();
             if let ValueSlot::Spilled {
                 n_bytes,
-                spill_ctx_stats,
-                reinsert_ctx,
-                reinsert_id,
+                spill_ctx,
+                spill_ctx_id,
+                reinsert_reg_id,
                 spill_time_ns,
                 spilled_start,
             } = value_slot
@@ -263,15 +272,16 @@ impl<T: Spillable> SpillTokenInner<T> {
                 let spilled = (*slf.spilled_value.get()).take().unwrap();
                 let value = T::unspill(&spilled).await;
 
-                spill_ctx_stats.add_unspill(
+                spill_ctx.stats().add_unspill(
                     *n_bytes,
                     *spill_time_ns,
                     *spilled_start,
                     unspill_start,
+                    *spill_ctx_id,
                 );
-                if *reinsert_id == slf.registration_id.load(Ordering::Relaxed) {
+                if *reinsert_reg_id == slf.registration_id.load(Ordering::Relaxed) {
                     let dyn_slf: Arc<dyn DynSpillToken> = slf.clone();
-                    reinsert_ctx.reinsert(&dyn_slf, *reinsert_id);
+                    spill_ctx.reinsert(&dyn_slf, *reinsert_reg_id, *spill_ctx_id);
                 }
 
                 *value_slot = ValueSlot::InMemory(value);
@@ -316,8 +326,9 @@ impl<T: Spillable> SpillTokenInner<T> {
                 self.value_slot.get().replace(ValueSlot::Dropped);
                 self.spilled_value.get().replace(None);
             }
+            let mut lock = self.lock.lock().unwrap();
             self.registration_id.fetch_add(1, Ordering::Relaxed);
-            self.cur_ctx.store(core::ptr::null_mut(), Ordering::Release);
+            lock.cur_ctx = None;
         }
     }
 }
@@ -329,11 +340,11 @@ pub enum TrySpillError {
 
 pub(crate) trait DynSpillToken: Send + Sync + 'static {
     /// Register this spill token at a new context, returning the registration ID.
-    fn register(&self, ctx: &'static SpillContextInner) -> u32;
+    fn register(&self, ctx: WeakSpillContext) -> u32;
 
     /// Unregisters this spill token from its current context, returning where
     /// it was registered, if anywhere.
-    fn unregister(&self) -> Option<&'static SpillContextInner>;
+    fn unregister(&self) -> Option<WeakSpillContext>;
 
     /// Returns the current context registration ID of this spill token without modifying it.
     fn current_registration_id(&self) -> u32;
@@ -356,22 +367,23 @@ pub(crate) trait DynSpillToken: Send + Sync + 'static {
     /// occurred during spilling.
     fn try_spill(
         &self,
-        stats: &Arc<SpillContextStatistics>,
         context: &'static SpillContextInner,
+        ctx_id: u64,
         registration_id: u32,
     ) -> Result<Pin<Box<dyn Future<Output = bool> + Send + '_>>, TrySpillError>;
 }
 
 impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
-    fn register(&self, ctx: &'static SpillContextInner) -> u32 {
-        self.cur_ctx.store(ptr::from_ref(ctx).cast_mut(), Ordering::Release);
+    fn register(&self, ctx: WeakSpillContext) -> u32 {
+        let mut lock = self.lock.lock().unwrap();
+        lock.cur_ctx = Some(ctx);
         self.registration_id.fetch_add(1, Ordering::Release) + 1
     }
 
-    fn unregister(&self) -> Option<&'static SpillContextInner> {
-        let old_ctx = self.cur_ctx.swap(core::ptr::null_mut(), Ordering::AcqRel);
+    fn unregister(&self) -> Option<WeakSpillContext> {
+        let mut lock = self.lock.lock().unwrap();
         self.registration_id.fetch_add(1, Ordering::Release);
-        unsafe { old_ctx.as_ref() }
+        lock.cur_ctx.take()
     }
 
     fn current_registration_id(&self) -> u32 {
@@ -393,8 +405,8 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
 
     fn try_spill(
         &self,
-        stats: &Arc<SpillContextStatistics>,
-        context: &'static SpillContextInner,
+        ctx: &'static SpillContextInner,
+        ctx_id: u64,
         registration_id: u32,
     ) -> Result<Pin<Box<dyn Future<Output = bool> + Send + '_>>, TrySpillError> {
         // First, we try setting the lock bit. If anyone else has a pin we don't bother.
@@ -413,21 +425,20 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
         if state & SPILLED_BIT != 0 {
             // Update re-insertion context, we hold the lock bit and there were no pins so this is safe.
             let ValueSlot::Spilled {
-                reinsert_ctx,
-                reinsert_id,
+                spill_ctx: reinsert_ctx,
+                reinsert_reg_id: reinsert_id,
                 ..
             } = (unsafe { &mut *self.value_slot.get() })
             else {
                 unreachable!()
             };
-            *reinsert_ctx = context;
+            *reinsert_ctx = ctx;
             *reinsert_id = registration_id;
 
             self.wake_waiters(self.state.fetch_sub(LOCK_BIT, Ordering::AcqRel));
             return Err(TrySpillError::AlreadySpilled);
         }
 
-        let stats = Arc::clone(stats);
         Ok(Box::pin(async move {
             let spill_start = Instant::now();
             let needs_spill = unsafe { (*self.spilled_value.get()).is_none() };
@@ -439,7 +450,7 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
                         .fetch_add(RO_PIN_COUNT_UNIT - LOCK_BIT, Ordering::AcqRel),
                 );
                 let pin_guard = PinnedRef { inner: self };
-                let spilled = pin_guard.spill(&stats.name()).await;
+                let spilled = pin_guard.spill(&ctx.stats().name()).await;
                 core::mem::forget(pin_guard);
                 // We can simply re-acquire the lock here blindly, as we still hold
                 // our pin meaning no one else could've gotten the lock.
@@ -462,13 +473,14 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
                     _ => unreachable!(),
                 };
                 let (spill_time_ns, spilled_start) =
-                    stats.add_successful_spill(n_bytes, spill_start);
+                    ctx.stats()
+                        .add_successful_spill(n_bytes, spill_start, ctx_id);
                 unsafe {
                     self.value_slot.get().replace(ValueSlot::Spilled {
                         n_bytes,
-                        spill_ctx_stats: stats.clone(),
-                        reinsert_ctx: context,
-                        reinsert_id: registration_id,
+                        spill_ctx: ctx,
+                        spill_ctx_id: ctx_id,
+                        reinsert_reg_id: registration_id,
                         spill_time_ns,
                         spilled_start,
                     })
@@ -476,7 +488,7 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
                 self.state
                     .fetch_add(SPILLED_BIT.wrapping_sub(LOCK_BIT), Ordering::AcqRel)
             } else {
-                stats.add_failed_spill(spill_start);
+                ctx.stats().add_failed_spill(spill_start, ctx_id);
                 self.state.fetch_sub(LOCK_BIT, Ordering::AcqRel)
             };
             self.wake_waiters(state);
@@ -497,10 +509,9 @@ impl<T: Spillable> SpillToken<T> {
         let inner = Arc::new(SpillTokenInner {
             value_slot: UnsafeCell::new(ValueSlot::InMemory(value)),
             spilled_value: UnsafeCell::new(None),
-            cur_ctx: AtomicPtr::new(core::ptr::null_mut()),
             registration_id: AtomicU32::new(0),
             state: AtomicU64::new(0),
-            waiters: Mutex::default(),
+            lock: Mutex::default(),
         });
         Self { inner }
     }
@@ -515,7 +526,7 @@ impl<T: Spillable> SpillToken<T> {
     pub fn unregister(&mut self) -> Option<(WeakSpillContext, SpillContextParam)> {
         let ctx = self.inner.unregister()?;
         let param = SpillContextParam(()); // TODO: get this once we support contexts with parameters.
-        Some((WeakSpillContext(ctx), param))
+        Some((ctx, param))
     }
 
     /// Try to get a reference to the underlying value, returning None if it was spilled.

--- a/crates/polars-stream/src/nodes/group_by.rs
+++ b/crates/polars-stream/src/nodes/group_by.rs
@@ -526,7 +526,7 @@ pub struct GroupByNode {
     num_inputs: usize,
     num_pipelines: usize,
     output_schema: Arc<Schema>,
-    spill_ctx: Arc<MostRecentSpillContext>,
+    spill_ctx: MostRecentSpillContext,
 }
 
 impl GroupByNode {

--- a/crates/polars-stream/src/nodes/in_memory_sink.rs
+++ b/crates/polars-stream/src/nodes/in_memory_sink.rs
@@ -12,7 +12,7 @@ use crate::utils::in_memory_linearize::linearize;
 pub struct InMemorySinkNode {
     morsels_per_pipe: Mutex<Vec<Vec<(MorselSeq, SpillFrame)>>>,
     schema: Arc<Schema>,
-    spill_ctx: Arc<LeastRecentSpillContext>,
+    spill_ctx: LeastRecentSpillContext,
 }
 
 impl InMemorySinkNode {
@@ -69,7 +69,7 @@ impl ComputeNode for InMemorySinkNode {
                 while let Ok(mut morsel) = recv.recv().await {
                     morsel.take_consume_token();
                     let seq = morsel.seq();
-                    let sf = SpillFrame::new(morsel.into_df(), &*slf.spill_ctx).await;
+                    let sf = SpillFrame::new(morsel.into_df(), &slf.spill_ctx).await;
                     morsels.push((seq, sf));
                 }
 

--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -1201,7 +1201,7 @@ pub struct EquiJoinNode {
     state: EquiJoinState,
     params: EquiJoinParams,
     table: Box<dyn IdxTable>,
-    spill_ctx: Arc<MostRecentSpillContext>,
+    spill_ctx: MostRecentSpillContext,
 }
 
 impl EquiJoinNode {

--- a/crates/polars-stream/src/nodes/joins/mod.rs
+++ b/crates/polars-stream/src/nodes/joins/mod.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crossbeam_queue::ArrayQueue;
 use polars_async::executor::{JoinHandle, TaskPriority, TaskScope};
 use polars_async::primitives::wait_group::WaitGroup;
@@ -33,7 +31,7 @@ const LOPSIDED_SAMPLE_FACTOR: usize = 10;
 struct BufferedStream {
     morsels: ArrayQueue<(SpillFrame, MorselSeq)>,
     post_buffer_offset: MorselSeq,
-    _spill_ctx: Option<Arc<MostRecentSpillContext>>,
+    _spill_ctx: Option<MostRecentSpillContext>,
 }
 
 impl BufferedStream {
@@ -43,7 +41,7 @@ impl BufferedStream {
         let ctx = MostRecentSpillContext::new(name);
         let queue = ArrayQueue::new(morsels.len().max(1));
         for morsel in morsels {
-            let sf = SpillFrame::new_blocking(morsel.into_df(), &*ctx);
+            let sf = SpillFrame::new_blocking(morsel.into_df(), &ctx);
             queue.push((sf, seq)).unwrap();
             seq = seq.successor();
         }

--- a/crates/polars-stream/src/nodes/multiplexer.rs
+++ b/crates/polars-stream/src/nodes/multiplexer.rs
@@ -1,5 +1,4 @@
 use std::collections::VecDeque;
-use std::sync::Arc;
 
 use polars_async::primitives::wait_group::WaitGroup;
 use polars_ooc::{MostRecentSpillContext, SpillFrame};
@@ -9,10 +8,7 @@ use super::compute_node_prelude::*;
 use crate::morsel::SourceToken;
 
 enum BufferedStream {
-    Open(
-        VecDeque<(SpillFrame, MorselSeq)>,
-        Arc<MostRecentSpillContext>,
-    ),
+    Open(VecDeque<(SpillFrame, MorselSeq)>, MostRecentSpillContext),
     Closed,
 }
 
@@ -116,11 +112,11 @@ impl ComputeNode for MultiplexerNode {
         enum Listener<'a> {
             Active(
                 UnboundedSender<(SpillFrame, MorselSeq, SourceToken)>,
-                Arc<MostRecentSpillContext>,
+                MostRecentSpillContext,
             ),
             Buffering(
                 &'a mut VecDeque<(SpillFrame, MorselSeq)>,
-                Arc<MostRecentSpillContext>,
+                MostRecentSpillContext,
             ),
             Inactive,
         }
@@ -162,7 +158,7 @@ impl ComputeNode for MultiplexerNode {
                             Listener::Active(s, ctx) => {
                                 let source_token = morsel.source_token().clone();
                                 // TODO: don't clone morsel, share same spillframe?
-                                let sf = SpillFrame::new(morsel.df().clone(), &**ctx).await;
+                                let sf = SpillFrame::new(morsel.df().clone(), &*ctx).await;
                                 match s.send((sf, seq, source_token)) {
                                     Ok(_) => {
                                         anyone_interested = true;
@@ -173,7 +169,7 @@ impl ComputeNode for MultiplexerNode {
                             },
                             Listener::Buffering(b, ctx) => {
                                 b.push_front((
-                                    SpillFrame::new(morsel.df().clone(), &**ctx).await,
+                                    SpillFrame::new(morsel.df().clone(), &*ctx).await,
                                     seq,
                                 ));
                                 anyone_interested = true;

--- a/crates/polars-stream/src/nodes/negative_slice.rs
+++ b/crates/polars-stream/src/nodes/negative_slice.rs
@@ -26,7 +26,7 @@ pub struct NegativeSliceNode {
     state: NegativeSliceState,
     slice_offset: i64,
     length: usize,
-    spill_ctx: Arc<MostRecentSpillContext>,
+    spill_ctx: MostRecentSpillContext,
 }
 
 impl NegativeSliceNode {
@@ -136,7 +136,7 @@ impl ComputeNode for NegativeSliceNode {
                         buffer.total_len += morsel.height();
                         buffer
                             .frames
-                            .push_back(SpillFrame::new(morsel.into_df(), &*spill_ctx).await);
+                            .push_back(SpillFrame::new(morsel.into_df(), &spill_ctx).await);
 
                         if buffer.total_len - buffer.frames.front().unwrap().height()
                             >= max_buffer_needed

--- a/crates/polars-stream/src/nodes/shift.rs
+++ b/crates/polars-stream/src/nodes/shift.rs
@@ -29,7 +29,7 @@ struct ShiftState {
     frames: VecDeque<SpillFrame>,
     fill: DataFrame,
     seq: MorselSeq,
-    spill_ctx: Arc<MostRecentSpillContext>,
+    spill_ctx: MostRecentSpillContext,
 }
 
 impl ShiftState {
@@ -52,7 +52,7 @@ impl ShiftState {
                     }
                     self.rows_received += morsel.height();
                     self.frames
-                        .push_back(SpillFrame::new(morsel.into_df(), &*self.spill_ctx).await);
+                        .push_back(SpillFrame::new(morsel.into_df(), &self.spill_ctx).await);
                 }
             }
 

--- a/crates/polars-stream/src/nodes/zip.rs
+++ b/crates/polars-stream/src/nodes/zip.rs
@@ -134,7 +134,7 @@ pub struct ZipNode {
     zip_behavior: ZipBehavior,
     out_seq: MorselSeq,
     input_heads: Vec<InputHead>,
-    spill_ctx: Arc<MostRecentSpillContext>,
+    spill_ctx: MostRecentSpillContext,
 }
 
 impl ZipNode {


### PR DESCRIPTION
Bit of an annoying refactor, but this moves away from `Arc<dyn SpillContext>` to an `Arc<SpillContextInner>`, which is a concrete type. This is done because then `Weak<SpillContextInner>` is a single pointer, meaning it can be easily stored in an `AtomicPtr` inside the `SpillToken`. We need this to be able to unregister a token using nothing but the token while getting back the current context for re-registration.

I ran into needing this to efficiently implement `Morsel::map` once the `SpillFrame` was inside the `Morsel`. In general an owned transformation from `SpillFrame` into a new `SpillFrame` with re-registration needs this.

I've made it general enough I think to support adding contexts where each registration has a parameter in the future. (E.g. spilling order based on morsel sequence ID, or depth in the computation graph for morsels stuck in pipes between nodes.)