### PR TITLE
fix: Casting String to List(Enum) produced nulls instead of values

### DIFF
--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -328,6 +328,21 @@ impl ChunkCast for StringChunked {
                     Series::try_from((self.name().clone(), result))
                 },
             },
+            #[cfg(feature = "dtype-categorical")]
+            DataType::List(inner)
+                if matches!(
+                    inner.as_ref(),
+                    DataType::Enum(_, _) | DataType::Categorical(_, _)
+                ) =>
+            {
+                let list_of_string = cast_impl(
+                    self.name().clone(),
+                    &self.chunks,
+                    &DataType::List(Box::new(DataType::String)),
+                    options,
+                )?;
+                list_of_string.cast_with_options(dtype, options)
+            },
             _ => cast_impl(self.name().clone(), &self.chunks, dtype, options),
         }
     }

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -654,6 +654,18 @@ def test_invalid_inner_type_cast_list() -> None:
         s.cast(pl.List(pl.Categorical))
 
 
+def test_cast_string_to_list_enum_27336() -> None:
+    enum = pl.Enum(["cat1", "cat2"])
+    s = pl.Series(["cat1", "cat2", "cat1"])
+
+    out = s.cast(pl.List(enum))
+    assert out.dtype == pl.List(enum)
+    assert out.to_list() == [["cat1"], ["cat2"], ["cat1"]]
+
+    # Plain string -> List(String) wrapping is unaffected.
+    assert s.cast(pl.List(pl.String)).to_list() == [["cat1"], ["cat2"], ["cat1"]]
+
+
 @pytest.mark.parametrize(
     ("values", "result"),
     [


### PR DESCRIPTION
Closes #27336.

Casting a `String` column to `List(Enum)` silently produced lists of nulls instead of wrapping the values:

```python
s = pl.Series(["cat1", "cat2", "cat1"])
s.cast(pl.List(pl.Enum(["cat1", "cat2"])))
# before: [[null], [null], [null]]
# after:  [["cat1"], ["cat2"], ["cat1"]]
```

The `String -> List` cast dispatched straight to `cast_impl` with the final `List(inner)` dtype, which has no direct string-to-list-of-non-string path and fell through to nulls. Instead, wrap the strings into `List(String)` first and then cast the list's inner type to the target, reusing the existing list cast. This also makes `String -> List(Int)` and other inner types behave consistently.
