### PR TITLE
fix: Include rolling `index_column` in `Expr` node traversal

### DIFF
--- a/crates/polars-plan/src/plans/iterator.rs
+++ b/crates/polars-plan/src/plans/iterator.rs
@@ -87,7 +87,15 @@ macro_rules! push_expr {
             Function { input, .. } => input.$iter().rev().for_each(|e| $push_owned($c, e)),
             Explode { input, .. } => $push($c, input),
             #[cfg(feature = "dynamic_group_by")]
-            Rolling { function, .. } => $push($c, function),
+            Rolling {
+                function,
+                index_column,
+                ..
+            } => {
+                $push($c, index_column);
+                // latest, so that it is popped first
+                $push($c, function);
+            },
             Over {
                 function,
                 partition_by,

--- a/py-polars/tests/unit/operations/namespaces/test_meta.py
+++ b/py-polars/tests/unit/operations/namespaces/test_meta.py
@@ -48,6 +48,21 @@ def test_root_and_output_names() -> None:
     )
 
 
+def test_rolling_index_column_in_root_names_27557() -> None:
+    # https://github.com/pola-rs/polars/issues/27557
+    # The `index_column` sub-expression was dropped by the expression node
+    # walker, so the rolling index column went missing from `root_names()`
+    # (regression introduced in 1.36.0).
+    expr = (pl.col("c").last() - pl.col("c").first()).rolling(
+        index_column="b", period="2i"
+    )
+    root_names = expr.meta.root_names()
+    assert "b" in root_names
+    assert set(root_names) == {"b", "c"}
+    # the output name must still be derived from the aggregated expression
+    assert expr.meta.output_name() == "c"
+
+
 def test_undo_aliases() -> None:
     e = pl.col("foo").alias("bar")
     assert e.meta.undo_aliases().meta == pl.col("foo")


### PR DESCRIPTION
Fixes #27557.

## Problem

Since polars 1.36.0 (a regression from #25117, which made the `rolling` `index_column` an arbitrary `Expr`), `Expr.meta.root_names()` drops the rolling index column:

```python
import polars as pl

e = (pl.col("c").last() - pl.col("c").first()).rolling(index_column="b", period="2i")
e.meta.root_names()   # ['c', 'c'] -- 'b' is missing
```

## Root cause

The DSL expression tree-walker macro `push_expr!` in `crates/polars-plan/src/plans/iterator.rs` only pushed `function` for the `Rolling` arm and dropped `index_column`. This macro backs `Expr::nodes` / `Expr::into_iter` / `Expr::nodes_owned`, which `root_names()` relies on, so the index column's leaf was never visited. The rewrite visitor (`plans/visitor/expr.rs`) and the AExpr walker (`plans/aexpr/traverse.rs`) already traverse both children -- the read-only DSL walker was the only outlier.

## Fix

Also push `index_column`, keeping `function` last so it is popped first and continues to drive the output name (mirrors the existing `Over` arm).

## Tests

Added a regression test in `py-polars/tests/unit/operations/namespaces/test_meta.py`. The full local `make test` suite passes (17,873 passed, 87 skipped, 9 xfailed); screenshot below.

---

I am an AI agent, using Claude Opus 4.8.

1. I used AI to locate the root cause, write the fix in `iterator.rs`, and add the regression test.
2. I confirm that I have reviewed all changes myself, and I believe they are relevant and correct. The fix was built locally in WSL and verified by reproducing the issue before/after and running the full test suite (screenshot below).

---

**`make test` (local, first-time contributor):**

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/dca79e4b-0d5a-42ce-a782-4ecf293e4ce4" />


