### PR TITLE
fix!: Make coercion casts for `is_in()` strict instead of lossy

### DIFF
--- a/crates/polars-core/src/utils/supertype.rs
+++ b/crates/polars-core/src/utils/supertype.rs
@@ -24,39 +24,6 @@ pub fn try_get_supertype_with_options(
     )
 }
 
-pub fn get_nested_numeric_upcast_supertype_lossless(
-    l: &DataType,
-    r: &DataType,
-) -> Option<DataType> {
-    use DataType::*;
-
-    match (l, r) {
-        (List(inner_left), List(inner_right)) => {
-            let st = get_nested_numeric_upcast_supertype_lossless(inner_left, inner_right)?;
-            Some(List(Box::new(st)))
-        },
-        #[cfg(feature = "dtype-array")]
-        (List(inner_left), Array(inner_right, _)) | (Array(inner_left, _), List(inner_right)) => {
-            let st = get_nested_numeric_upcast_supertype_lossless(inner_left, inner_right)?;
-            Some(List(Box::new(st)))
-        },
-        #[cfg(feature = "dtype-array")]
-        (Array(inner_left, width_left), Array(inner_right, width_right))
-            if *width_left == *width_right =>
-        {
-            let st = get_nested_numeric_upcast_supertype_lossless(inner_left, inner_right)?;
-            Some(Array(Box::new(st), *width_left))
-        },
-        #[cfg(feature = "dtype-array")]
-        (Array(inner_left, _), Array(inner_right, _)) => {
-            let st = get_nested_numeric_upcast_supertype_lossless(inner_left, inner_right)?;
-            Some(List(Box::new(st)))
-        },
-
-        (l, r) => get_numeric_upcast_supertype_lossless(l, r),
-    }
-}
-
 /// Returns the smallest numeric dtype that `l` and `r` can both be casted to without loss of data.
 /// If no such dtype exists, or `l` and `r` are already matching, returns `None`.
 pub fn get_numeric_upcast_supertype_lossless(l: &DataType, r: &DataType) -> Option<DataType> {

--- a/crates/polars-core/src/utils/supertype.rs
+++ b/crates/polars-core/src/utils/supertype.rs
@@ -24,6 +24,39 @@ pub fn try_get_supertype_with_options(
     )
 }
 
+pub fn get_nested_numeric_upcast_supertype_lossless(
+    l: &DataType,
+    r: &DataType,
+) -> Option<DataType> {
+    use DataType::*;
+
+    match (l, r) {
+        (List(inner_left), List(inner_right)) => {
+            let st = get_nested_numeric_upcast_supertype_lossless(inner_left, inner_right)?;
+            Some(List(Box::new(st)))
+        },
+        #[cfg(feature = "dtype-array")]
+        (List(inner_left), Array(inner_right, _)) | (Array(inner_left, _), List(inner_right)) => {
+            let st = get_nested_numeric_upcast_supertype_lossless(inner_left, inner_right)?;
+            Some(List(Box::new(st)))
+        },
+        #[cfg(feature = "dtype-array")]
+        (Array(inner_left, width_left), Array(inner_right, width_right))
+            if *width_left == *width_right =>
+        {
+            let st = get_nested_numeric_upcast_supertype_lossless(inner_left, inner_right)?;
+            Some(Array(Box::new(st), *width_left))
+        },
+        #[cfg(feature = "dtype-array")]
+        (Array(inner_left, _), Array(inner_right, _)) => {
+            let st = get_nested_numeric_upcast_supertype_lossless(inner_left, inner_right)?;
+            Some(List(Box::new(st)))
+        },
+
+        (l, r) => get_numeric_upcast_supertype_lossless(l, r),
+    }
+}
+
 /// Returns the smallest numeric dtype that `l` and `r` can both be casted to without loss of data.
 /// If no such dtype exists, or `l` and `r` are already matching, returns `None`.
 pub fn get_numeric_upcast_supertype_lossless(l: &DataType, r: &DataType) -> Option<DataType> {

--- a/crates/polars-plan/src/plans/aexpr/function_expr/boolean.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/boolean.rs
@@ -97,7 +97,7 @@ impl IRBooleanFunction {
                 .with_flags(|f| f | FunctionFlags::PRESERVES_NULL_ALL_INPUTS),
             #[cfg(feature = "is_in")]
             B::IsIn { nulls_equal } => FunctionOptions::elementwise()
-                .with_supertyping(Default::default())
+                .with_casting_rules(CastingRules::FirstArgLossless)
                 .with_flags(|f| {
                     if !*nulls_equal {
                         f | FunctionFlags::PRESERVES_NULL_FIRST_INPUT

--- a/crates/polars-plan/src/plans/conversion/type_coercion/is_in.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/is_in.rs
@@ -8,34 +8,6 @@ pub(super) enum IsInTypeCoercionResult {
     Implode,
 }
 
-impl IsInTypeCoercionResult {
-    fn map_self<F: Fn(DataType) -> DataType>(self, f: F) -> Self {
-        use IsInTypeCoercionResult::*;
-        match self {
-            SuperType(dt1, dt2) => SuperType(f(dt1), dt2),
-            SelfCast { dtype, strict } => SelfCast {
-                dtype: f(dtype),
-                strict,
-            },
-            x @ OtherCast { .. } => x,
-            Implode => Implode,
-        }
-    }
-
-    fn map_other<F: Fn(DataType) -> DataType>(self, f: F) -> Self {
-        use IsInTypeCoercionResult::*;
-        match self {
-            SuperType(dt1, dt2) => SuperType(dt1, f(dt2)),
-            x @ SelfCast { .. } => x,
-            OtherCast { dtype, strict } => OtherCast {
-                dtype: f(dtype),
-                strict,
-            },
-            Implode => Implode,
-        }
-    }
-}
-
 #[allow(clippy::too_many_arguments)]
 pub(super) fn resolve_is_in(
     input: &[ExprIR],
@@ -72,45 +44,23 @@ See https://github.com/pola-rs/polars/issues/22149 for more information."
         return Ok(Some(IsInTypeCoercionResult::Implode));
     }
 
-    // dbg!(&type_left);
-    // dbg!(&type_other);
-
-    let wrap_other = |resolved_type_other: DataType| match &type_other {
-        DataType::List(_) => DataType::List(Box::new(resolved_type_other)),
+    let wrap_other = |resolved_inner_type: DataType| match &type_other {
+        DataType::List(_) => DataType::List(Box::new(resolved_inner_type)),
         #[cfg(feature = "dtype-array")]
-        DataType::Array(_, width) => DataType::Array(Box::new(resolved_type_other), *width),
+        DataType::Array(_, width) => DataType::Array(Box::new(resolved_inner_type), *width),
         _ => unreachable!(),
     };
 
     let type_left_materialized = type_left.clone().materialize_unknown(false)?;
     let Some(type_other_inner) = type_other.inner_dtype() else {
+        panic!();
         polars_bail!(InvalidOperation: "'{op:?}' cannot check for {type_left:?} values in {type_other:?} data.\n\
         Hint: container dtype ({type_other:?}) must be nested");
     };
 
-    Ok((resolve_is_in_inner(
-        &type_left_materialized,
-        &type_other_inner,
-        &type_left,
-        &type_other,
-        op,
-    )?
-    .map(|r| r.map_other(wrap_other))))
-}
-
-fn resolve_is_in_inner(
-    type_left: &DataType,
-    type_other_inner: &DataType,
-    top_level_left_type: &DataType,
-    top_level_nested_type: &DataType,
-    op: &'static str,
-) -> PolarsResult<Option<IsInTypeCoercionResult>> {
-    // dbg!(type_left);
-    // dbg!(type_other_inner);
-
-    let casted_inner_expr = match (type_left, type_other_inner) {
+    let casted_inner_expr = match (&type_left_materialized, type_other_inner) {
         // Types are equal, do nothing
-        (a, b) if a == b => return Ok(None),
+        (dtml, dto) if dtml == dto => return Ok(None),
 
         // All-null can represent anything (and/or empty list), so cast to target dtype
         (DataType::Null, _) => IsInTypeCoercionResult::SelfCast {
@@ -118,13 +68,13 @@ fn resolve_is_in_inner(
             strict: false,
         },
         (_, DataType::Null) => IsInTypeCoercionResult::OtherCast {
-            dtype: type_left.clone(),
+            dtype: wrap_other(type_left_materialized),
             strict: false,
         },
 
         #[cfg(feature = "dtype-categorical")]
         (DataType::Enum(_, _), DataType::String) => IsInTypeCoercionResult::OtherCast {
-            dtype: type_left.clone(),
+            dtype: wrap_other(type_left_materialized),
             strict: true,
         },
         #[cfg(feature = "dtype-categorical")]
@@ -139,20 +89,20 @@ fn resolve_is_in_inner(
         },
         #[cfg(feature = "dtype-categorical")]
         (DataType::Categorical(_, _), DataType::String) => IsInTypeCoercionResult::OtherCast {
-            dtype: type_left.clone(),
+            dtype: wrap_other(type_left_materialized),
             strict: false,
         },
 
         #[cfg(feature = "dtype-decimal")]
         (DataType::Decimal(_, _), dt) if dt.is_primitive_numeric() => {
             IsInTypeCoercionResult::OtherCast {
-                dtype: type_left.clone(),
+                dtype: wrap_other(type_left_materialized),
                 strict: false,
             }
         },
         #[cfg(feature = "dtype-decimal")]
         (DataType::Decimal(_, _), _) | (_, DataType::Decimal(_, _)) => {
-            polars_bail!(InvalidOperation: "'{op}' cannot check for {top_level_left_type:?} values in {top_level_nested_type:?} data")
+            polars_bail!(InvalidOperation: "'{op}' cannot check for {type_left:?} values in {type_other:?} data")
         },
         // can't check for more granular time_unit in less-granular time_unit data,
         // or we'll cast away valid/necessary precision (eg: nanosecs to millisecs)
@@ -173,24 +123,22 @@ fn resolve_is_in_inner(
 
         // Don't attempt to cast between obviously mismatched types. Only allow
         // to cast to a supertype if the cast is lossless.
-        (a, b) => {
-            if (a.is_primitive_numeric() && b.is_primitive_numeric()) || (a == &DataType::Null) {
-                if let Some(super_type) =
-                    get_numeric_upcast_supertype_lossless(&type_left, type_other_inner)
-                {
+        (dtml, dto) => {
+            if (dtml.is_primitive_numeric() && dto.is_primitive_numeric()) || dtml.is_null() {
+                if let Some(super_type) = get_numeric_upcast_supertype_lossless(dtml, dto) {
                     return Ok(Some(IsInTypeCoercionResult::SuperType(
                         super_type.clone(),
-                        super_type,
+                        wrap_other(super_type),
                     )));
                 } else {
                     // We disabled lossless coercion of the operands in 2.0.
-                    let lossy_supertype = try_get_supertype(&type_left, type_other_inner)?;
-                    polars_bail!(InvalidOperation: "'{op}' cannot check for {top_level_left_type:?} values in {top_level_nested_type:?} data.\n\
+                    let lossy_supertype = try_get_supertype(dtml, dto)?;
+                    polars_bail!(InvalidOperation: "'{op}' cannot check for {type_left:?} values in {type_other:?} data.\n\
                         Hint: Before version 2.0, Polars would perform this check by lossily coercing the operands to {lossy_supertype:?}. \
-                        However, since Polars 2.0 the is_in() it is required to explicitly cast (one of) the operands to a compatible type.")
+                        However, since Polars 2.0, for is_in() it is required to explicitly cast (one of) the operands to a compatible type.")
                 }
             }
-            polars_bail!(InvalidOperation: "'{op}' cannot check for {top_level_left_type:?} values in {top_level_nested_type:?} data")
+            polars_bail!(InvalidOperation: "'{op}' cannot check for {type_left:?} values in {type_other:?} data")
         },
     };
     Ok(Some(casted_inner_expr))

--- a/crates/polars-plan/src/plans/conversion/type_coercion/is_in.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/is_in.rs
@@ -1,10 +1,39 @@
 use super::*;
 
+#[derive(Debug)]
 pub(super) enum IsInTypeCoercionResult {
     SuperType(DataType, DataType),
     SelfCast { dtype: DataType, strict: bool },
     OtherCast { dtype: DataType, strict: bool },
     Implode,
+}
+
+impl IsInTypeCoercionResult {
+    fn map_self<F: Fn(DataType) -> DataType>(self, f: F) -> Self {
+        use IsInTypeCoercionResult::*;
+        match self {
+            SuperType(dt1, dt2) => SuperType(f(dt1), dt2),
+            SelfCast { dtype, strict } => SelfCast {
+                dtype: f(dtype),
+                strict,
+            },
+            x @ OtherCast { .. } => x,
+            Implode => Implode,
+        }
+    }
+
+    fn map_other<F: Fn(DataType) -> DataType>(self, f: F) -> Self {
+        use IsInTypeCoercionResult::*;
+        match self {
+            SuperType(dt1, dt2) => SuperType(dt1, f(dt2)),
+            x @ SelfCast { .. } => x,
+            OtherCast { dtype, strict } => OtherCast {
+                dtype: f(dtype),
+                strict,
+            },
+            Implode => Implode,
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -31,7 +60,7 @@ pub(super) fn resolve_is_in(
     let left_nl = type_left.nesting_level();
     let right_nl = type_other.nesting_level();
 
-    // @HACK. This needs to happen until 2.0 because we support `pl.col.a.is_in(pl.col.a)`.
+    // @HACK. This needs to happen until 3.0 because we support `pl.col.a.is_in(pl.col.a)`.
     if !is_contains && left_nl == right_nl {
         polars_warn!(
             Deprecation,
@@ -43,32 +72,59 @@ See https://github.com/pola-rs/polars/issues/22149 for more information."
         return Ok(Some(IsInTypeCoercionResult::Implode));
     }
 
-    if left_nl + 1 != right_nl {
-        polars_bail!(InvalidOperation: "'{op}' cannot check for {:?} values in {:?} data", &type_other, &type_left);
-    }
+    // dbg!(&type_left);
+    // dbg!(&type_other);
 
-    let type_other_inner = type_other.inner_dtype().unwrap();
-
-    unpack!(early_escape(&type_left, type_other_inner));
-
-    let cast_type = match &type_other {
-        DataType::List(_) => DataType::List(Box::new(type_left.clone())),
+    let wrap_other = |resolved_type_other: DataType| match &type_other {
+        DataType::List(_) => DataType::List(Box::new(resolved_type_other)),
         #[cfg(feature = "dtype-array")]
-        DataType::Array(_, width) => DataType::Array(Box::new(type_left.clone()), *width),
+        DataType::Array(_, width) => DataType::Array(Box::new(resolved_type_other), *width),
         _ => unreachable!(),
     };
 
-    let casted_expr = match (&type_left, type_other_inner) {
-        // types are equal, do nothing
+    let type_left_materialized = type_left.clone().materialize_unknown(false)?;
+    let Some(type_other_inner) = type_other.inner_dtype() else {
+        polars_bail!(InvalidOperation: "'{op:?}' cannot check for {type_left:?} values in {type_other:?} data.\n\
+        Hint: container dtype ({type_other:?}) must be nested");
+    };
+
+    Ok((resolve_is_in_inner(
+        &type_left_materialized,
+        &type_other_inner,
+        &type_left,
+        &type_other,
+        op,
+    )?
+    .map(|r| r.map_other(wrap_other))))
+}
+
+fn resolve_is_in_inner(
+    type_left: &DataType,
+    type_other_inner: &DataType,
+    top_level_left_type: &DataType,
+    top_level_nested_type: &DataType,
+    op: &'static str,
+) -> PolarsResult<Option<IsInTypeCoercionResult>> {
+    // dbg!(type_left);
+    // dbg!(type_other_inner);
+
+    let casted_inner_expr = match (type_left, type_other_inner) {
+        // Types are equal, do nothing
         (a, b) if a == b => return Ok(None),
-        // all-null can represent anything (and/or empty list), so cast to target dtype
-        (_, DataType::Null) => IsInTypeCoercionResult::OtherCast {
-            dtype: cast_type,
+
+        // All-null can represent anything (and/or empty list), so cast to target dtype
+        (DataType::Null, _) => IsInTypeCoercionResult::SelfCast {
+            dtype: type_other_inner.clone(),
             strict: false,
         },
+        (_, DataType::Null) => IsInTypeCoercionResult::OtherCast {
+            dtype: type_left.clone(),
+            strict: false,
+        },
+
         #[cfg(feature = "dtype-categorical")]
         (DataType::Enum(_, _), DataType::String) => IsInTypeCoercionResult::OtherCast {
-            dtype: cast_type,
+            dtype: type_left.clone(),
             strict: true,
         },
         #[cfg(feature = "dtype-categorical")]
@@ -81,28 +137,22 @@ See https://github.com/pola-rs/polars/issues/22149 for more information."
             dtype: type_other_inner.clone(),
             strict: false,
         },
-
         #[cfg(feature = "dtype-categorical")]
         (DataType::Categorical(_, _), DataType::String) => IsInTypeCoercionResult::OtherCast {
-            dtype: match &type_other {
-                DataType::List(_) => DataType::List(Box::new(type_left.clone())),
-                #[cfg(feature = "dtype-array")]
-                DataType::Array(_, width) => DataType::Array(Box::new(type_left.clone()), *width),
-                _ => unreachable!(),
-            },
+            dtype: type_left.clone(),
             strict: false,
         },
 
         #[cfg(feature = "dtype-decimal")]
         (DataType::Decimal(_, _), dt) if dt.is_primitive_numeric() => {
             IsInTypeCoercionResult::OtherCast {
-                dtype: cast_type,
+                dtype: type_left.clone(),
                 strict: false,
             }
         },
         #[cfg(feature = "dtype-decimal")]
         (DataType::Decimal(_, _), _) | (_, DataType::Decimal(_, _)) => {
-            polars_bail!(InvalidOperation: "'{op}' cannot check for {:?} values in {:?} data", &type_other, &type_left)
+            polars_bail!(InvalidOperation: "'{op}' cannot check for {top_level_left_type:?} values in {top_level_nested_type:?} data")
         },
         // can't check for more granular time_unit in less-granular time_unit data,
         // or we'll cast away valid/necessary precision (eg: nanosecs to millisecs)
@@ -110,84 +160,38 @@ See https://github.com/pola-rs/polars/issues/22149 for more information."
             if lhs_unit <= rhs_unit {
                 return Ok(None);
             } else {
-                polars_bail!(InvalidOperation: "'{op}' cannot check for {:?} precision values in {:?} Datetime data", &rhs_unit, &lhs_unit)
+                polars_bail!(InvalidOperation: "'{op}' cannot check for {rhs_unit:?} precision values in {lhs_unit:?} Datetime data")
             }
         },
         (DataType::Duration(lhs_unit), DataType::Duration(rhs_unit)) => {
             if lhs_unit <= rhs_unit {
                 return Ok(None);
             } else {
-                polars_bail!(InvalidOperation: "'{op}' cannot check for {:?} precision values in {:?} Duration data", &rhs_unit, &lhs_unit)
+                polars_bail!(InvalidOperation: "'{op}' cannot check for {rhs_unit:?} precision values in {lhs_unit:?} Duration data")
             }
         },
-        (_, DataType::List(_)) => {
-            polars_ensure!(
-                &type_left == type_other_inner,
-                InvalidOperation: "'{op}' cannot check for {:?} values in {:?} data",
-                &type_left, &type_other
-            );
-            return Ok(None);
-        },
-        #[cfg(feature = "dtype-array")]
-        (_, DataType::Array(_, _)) => {
-            polars_ensure!(
-                &type_left == type_other_inner,
-                InvalidOperation: "'{op}' cannot check for {:?} values in {:?} data",
-                &type_left, &type_other
-            );
-            return Ok(None);
-        },
-        #[cfg(feature = "dtype-struct")]
-        (DataType::Struct(_), _) | (_, DataType::Struct(_)) => {
-            polars_ensure!(
-                &type_left == type_other_inner,
-                InvalidOperation: "'{op}' cannot check for {:?} values in {:?} data",
-                &type_left, &type_other
-            );
-            return Ok(None);
-        },
 
-        // don't attempt to cast between obviously mismatched types, but
-        // allow integer/float comparison (will use their supertypes).
+        // Don't attempt to cast between obviously mismatched types. Only allow
+        // to cast to a supertype if the cast is lossless.
         (a, b) => {
             if (a.is_primitive_numeric() && b.is_primitive_numeric()) || (a == &DataType::Null) {
-                if a != b {
-                    // @TAG: 2.0
-                    // @HACK: `is_in` does supertype casting between primitive numerics, which
-                    // honestly makes very little sense. To stay backwards compatible we keep this,
-                    // but please in 2.0 remove this. FirstArgLossless might be a good alternative,
-                    // as used by index_of(), or build on index_of().
-                    //
-                    // Try lossless supertype first to avoid precision loss (e.g.,
-                    // UInt64 + Int64 would otherwise become Float64), then fall back
-                    // to the existing supertype behavior.
-                    let super_type = polars_core::utils::get_numeric_upcast_supertype_lossless(
-                        &type_left,
-                        type_other_inner,
-                    )
-                    .map_or_else(
-                        || polars_core::utils::try_get_supertype(&type_left, type_other_inner),
-                        Ok,
-                    )?;
-
-                    let other_type = match &type_other {
-                        DataType::List(_) => DataType::List(Box::new(super_type.clone())),
-                        #[cfg(feature = "dtype-array")]
-                        DataType::Array(_, width) => {
-                            DataType::Array(Box::new(super_type.clone()), *width)
-                        },
-                        _ => unreachable!(),
-                    };
-
+                if let Some(super_type) =
+                    get_numeric_upcast_supertype_lossless(&type_left, type_other_inner)
+                {
                     return Ok(Some(IsInTypeCoercionResult::SuperType(
-                        super_type, other_type,
+                        super_type.clone(),
+                        super_type,
                     )));
+                } else {
+                    // We disabled lossless coercion of the operands in 2.0.
+                    let lossy_supertype = try_get_supertype(&type_left, type_other_inner)?;
+                    polars_bail!(InvalidOperation: "'{op}' cannot check for {top_level_left_type:?} values in {top_level_nested_type:?} data.\n\
+                        Hint: Before version 2.0, Polars would perform this check by lossily coercing the operands to {lossy_supertype:?}. \
+                        However, since Polars 2.0 the is_in() it is required to explicitly cast (one of) the operands to a compatible type.")
                 }
-
-                return Ok(None);
             }
-            polars_bail!(InvalidOperation: "'{op}' cannot check for {:?} values in {:?} data", &type_other, &type_left)
+            polars_bail!(InvalidOperation: "'{op}' cannot check for {top_level_left_type:?} values in {top_level_nested_type:?} data")
         },
     };
-    Ok(Some(casted_expr))
+    Ok(Some(casted_inner_expr))
 }

--- a/crates/polars-plan/src/plans/conversion/type_coercion/is_in.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/is_in.rs
@@ -53,7 +53,6 @@ See https://github.com/pola-rs/polars/issues/22149 for more information."
 
     let type_left_materialized = type_left.clone().materialize_unknown(false)?;
     let Some(type_other_inner) = type_other.inner_dtype() else {
-        panic!();
         polars_bail!(InvalidOperation: "'{op:?}' cannot check for {type_left:?} values in {type_other:?} data.\n\
         Hint: container dtype ({type_other:?}) must be nested");
     };

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -142,35 +142,35 @@ def test_parquet_is_in_stats(tmp_path: Path) -> None:
 
     df1 = pd.DataFrame({"a": [None, 1, None, 2, 3, 3, 4, 4, 5, 5]})
     df1.to_parquet(file_path, engine="pyarrow")
-    df = pl.scan_parquet(file_path).filter(pl.col("a").is_in([5])).collect()
+    df = pl.scan_parquet(file_path).filter(pl.col("a").is_in([5.0])).collect()
     assert df["a"].to_list() == [5.0, 5.0]
 
     assert (
         pl.scan_parquet(file_path)
-        .filter(pl.col("a").is_in([5]))
+        .filter(pl.col("a").is_in([5.0]))
         .select(pl.col("a").sum())
     ).collect()[0, "a"] == 10.0
 
     assert (
         pl.scan_parquet(file_path)
-        .filter(pl.col("a").is_in([1, 2, 3]))
+        .filter(pl.col("a").is_in([1.0, 2.0, 3.0]))
         .select(pl.col("a").sum())
     ).collect()[0, "a"] == 9.0
 
     assert (
         pl.scan_parquet(file_path)
-        .filter(pl.col("a").is_in([1, 2, 3]))
+        .filter(pl.col("a").is_in([1.0, 2.0, 3.0]))
         .select(pl.col("a").sum())
     ).collect()[0, "a"] == 9.0
 
     assert (
         pl.scan_parquet(file_path)
-        .filter(pl.col("a").is_in([5]))
+        .filter(pl.col("a").is_in([5.0]))
         .select(pl.col("a").sum())
     ).collect()[0, "a"] == 10.0
 
     assert pl.scan_parquet(file_path).filter(
-        pl.col("a").is_in([1, 2, 3, 4, 5])
+        pl.col("a").is_in([1.0, 2.0, 3.0, 4.0, 5.0])
     ).collect().shape == (8, 1)
 
 

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -160,7 +160,12 @@ def test_is_in_struct() -> None:
 
 
 def test_is_in_null_prop() -> None:
-    assert pl.Series([None], dtype=pl.Float32).is_in(pl.Series([42])).item() is None
+    assert (
+        pl.Series([None], dtype=pl.Float32)
+        .is_in(pl.Series([42], dtype=pl.Float32))
+        .item()
+        is None
+    )
     assert pl.Series([{"a": None}, None], dtype=pl.Struct({"a": pl.Float32})).is_in(
         pl.Series([{"a": 42}], dtype=pl.Struct({"a": pl.Float32}))
     ).to_list() == [False, None]
@@ -171,7 +176,11 @@ def test_is_in_null_prop() -> None:
 
 
 def test_is_in_9070() -> None:
-    assert not pl.Series([1]).is_in(pl.Series([1.99])).item()
+    with pytest.raises(
+        InvalidOperationError,
+        match=r"'is_in' cannot check for Int64 values in List\(Float64\) data",
+    ):
+        pl.Series([1]).is_in(pl.Series([1.99])).item()
 
 
 def test_is_in_large_uint64_21966() -> None:
@@ -213,15 +222,18 @@ def test_is_in_large_uint64_21966() -> None:
     s = pl.Series([100, 200], dtype=pl.Int16)
     assert s.is_in(pl.Series([100, 300], dtype=pl.UInt16)).to_list() == [True, False]
 
-    # UInt64 max value (no lossless supertype with Int64)
+    # UInt64 max value (should use Int128)
     s = pl.Series([2**64 - 1], dtype=pl.UInt64)
     assert s.is_in(pl.Series([2**64 - 1], dtype=pl.UInt64)).item()
     assert not s.is_in(pl.Series([2**64 - 2], dtype=pl.UInt64)).item()
 
-    # Fallback to try_get_supertype for types without lossless supertype
+    # No lossless supertype for UInt128 vs Int64 available
     s = pl.Series([100], dtype=pl.UInt128)
-    assert s.is_in(pl.Series([100], dtype=pl.Int64)).item()
-    assert not s.is_in(pl.Series([99], dtype=pl.Int64)).item()
+    with pytest.raises(
+        InvalidOperationError,
+        match=r"'is_in' cannot check for UInt128 values in List\(Int64\) data",
+    ):
+        s.is_in(pl.Series([100], dtype=pl.Int64)).item()
 
 
 def test_is_in_float_list_10764() -> None:
@@ -256,7 +268,9 @@ def test_is_in_series() -> None:
         assert out.to_list() == [False, False, False]
 
     df = pl.DataFrame({"a": [1.0, 2.0], "b": [1, 4], "c": ["e", "d"]})
-    assert df.select(pl.col("a").is_in(pl.col("b"))).to_series().to_list() == [
+    assert df.select(
+        pl.col("a").is_in(pl.col("b").cast(pl.Float64))
+    ).to_series().to_list() == [
         True,
         False,
     ]
@@ -264,7 +278,7 @@ def test_is_in_series() -> None:
 
     with pytest.raises(
         InvalidOperationError,
-        match=r"'is_in' cannot check for List\(String\) values in Int64 data",
+        match=r"'is_in' cannot check for Int64 values in List\(String\) data",
     ):
         df.select(pl.col("b").is_in(["x", "x"]))
 
@@ -372,12 +386,12 @@ def test_is_in_float(dtype: PolarsDataType) -> None:
     ("df", "matches", "expected_error"),
     [
         (
-            pl.DataFrame({"a": [1, 2], "b": [[1.0, 2.5], [3.0, 4.0]]}),
+            pl.DataFrame({"a": [1, 2], "b": [[1, 2], [3, 4]]}),
             [True, False],
             None,
         ),
         (
-            pl.DataFrame({"a": [2.5, 3.0], "b": [[1, 2], [3, 4]]}),
+            pl.DataFrame({"a": [2.5, 3.0], "b": [[1.5, 2.0], [2.5, 3.0]]}),
             [False, True],
             None,
         ),
@@ -392,12 +406,12 @@ def test_is_in_float(dtype: PolarsDataType) -> None:
         (
             pl.DataFrame({"a": ["1", "2"], "b": [[1, 2], [3, 4]]}),
             None,
-            r"'is_in' cannot check for List\(Int64\) values in String data",
+            r"'is_in' cannot check for String values in List\(Int64\) data",
         ),
         (
             pl.DataFrame({"a": [date.today(), None], "b": [[1, 2], [3, 4]]}),
             None,
-            r"'is_in' cannot check for List\(Int64\) values in Date data",
+            r"'is_in' cannot check for Date values in List\(Int64\) data",
         ),
     ],
 )
@@ -416,11 +430,11 @@ def test_is_in_expr_list_series(
     ("df", "matches"),
     [
         (
-            pl.DataFrame({"a": [1, None], "b": [[1.0, 2.5, 4.0], [3.0, 4.0, 5.0]]}),
+            pl.DataFrame({"a": [1.0, None], "b": [[1.0, 2.5, 4.0], [3.0, 4.0, 5.0]]}),
             [True, False],
         ),
         (
-            pl.DataFrame({"a": [1, None], "b": [[0.0, 2.5, None], [3.0, 4.0, None]]}),
+            pl.DataFrame({"a": [1.0, None], "b": [[0.0, 2.5, None], [3.0, 4.0, None]]}),
             [False, True],
         ),
         (
@@ -779,140 +793,15 @@ def test_null_propagate_all_paths_cat(nulls_equal: bool) -> None:
 # `crates/polars-plan/src/plans/conversion/type_coercion/is_in.rs`.
 
 
-@pytest.mark.parametrize("dtype", [pl.List(pl.String), pl.Array(pl.String, 2)])
-def test_is_in_cat_str_collection(dtype: PolarsDataType) -> None:
-    # Categorical element checked against a List/Array of String: the String
-    # collection is cast to the categorical dtype (the `Categorical -> String`
-    # OtherCast arm, covering both the List and Array `cast_type` branches).
+def test_is_in_nested_struct() -> None:
     df = pl.DataFrame(
-        {
-            "a": pl.Series(["a", "b", "x"], dtype=pl.Categorical),
-            "b": pl.Series([["a", "z"], ["q", "b"], ["m", "n"]], dtype=dtype),
-        }
+        {"a": [{"x": {"y": 1}}, {"x": {"y": 2}}, {"x": {"y": 3}}, None]},
+        schema={"a": pl.Struct({"x": pl.Struct({"y": pl.Int32})})},
     )
-    result = df.select(pl.col("a").is_in("b")).to_series()
-    assert result.to_list() == [True, True, False]
-
-
-@pytest.mark.parametrize("unit", ["ns", "us"])
-def test_is_in_datetime_finer_in_coarser_unit(unit: str) -> None:
-    # Checking a finer (or equal) time-unit in coarser-unit data is allowed and
-    # performs no cast (`Datetime` arm, `lhs_unit <= rhs_unit` -> Ok(None)).
-    df = pl.DataFrame(
-        {
-            "a": pl.Series(
-                [datetime(2022, 1, 1), datetime(2022, 1, 2)], dtype=pl.Datetime(unit)  # type: ignore[arg-type]
-            ),
-            "b": pl.Series(
-                [[datetime(2030, 1, 1)], [datetime(2030, 1, 3)]],
-                dtype=pl.List(pl.Datetime("ms")),
-            ),
-        }
+    s = pl.Series(
+        [[{"x": {"y": 1}}, {"x": {"y": 3}}]],
+        dtype=pl.List(pl.Struct({"x": pl.Struct({"y": pl.Int64})})),
     )
-    # No cross-unit normalization happens, so disjoint instants are not matched.
-    result = df.select(pl.col("a").is_in("b")).to_series()
-    assert result.to_list() == [False, False]
-
-
-def test_is_in_datetime_coarser_in_finer_unit() -> None:
-    # The reverse (coarser values in finer-unit data) would discard precision
-    # and is rejected (`Datetime` arm, `lhs_unit > rhs_unit` -> bail).
-    df = pl.DataFrame(
-        {
-            "a": pl.Series([datetime(2022, 1, 1)], dtype=pl.Datetime("ms")),
-            "b": pl.Series(
-                [[datetime(2022, 1, 1)]], dtype=pl.List(pl.Datetime("ns"))
-            ),
-        }
-    )
-    with pytest.raises(
-        InvalidOperationError,
-        match=r"cannot check for Nanoseconds precision values in Milliseconds Datetime data",
-    ):
-        df.select(pl.col("a").is_in("b"))
-
-
-@pytest.mark.parametrize("unit", ["ns", "us"])
-def test_is_in_duration_finer_in_coarser_unit(unit: str) -> None:
-    # `Duration` arm, `lhs_unit <= rhs_unit` -> Ok(None) (no cast).
-    df = pl.DataFrame(
-        {
-            "a": pl.Series(
-                [timedelta(seconds=1), timedelta(seconds=2)],
-                dtype=pl.Duration(unit),  # type: ignore[arg-type]
-            ),
-            "b": pl.Series(
-                [[timedelta(seconds=5)], [timedelta(seconds=9)]],
-                dtype=pl.List(pl.Duration("ms")),
-            ),
-        }
-    )
-    result = df.select(pl.col("a").is_in("b")).to_series()
-    assert result.to_list() == [False, False]
-
-
-def test_is_in_duration_coarser_in_finer_unit() -> None:
-    # `Duration` arm, `lhs_unit > rhs_unit` -> bail.
-    df = pl.DataFrame(
-        {
-            "a": pl.Series([timedelta(seconds=1)], dtype=pl.Duration("ms")),
-            "b": pl.Series(
-                [[timedelta(seconds=1)]], dtype=pl.List(pl.Duration("ns"))
-            ),
-        }
-    )
-    with pytest.raises(
-        InvalidOperationError,
-        match=r"cannot check for Nanoseconds precision values in Milliseconds Duration data",
-    ):
-        df.select(pl.col("a").is_in("b"))
-
-
-def test_is_in_nested_list_mismatch() -> None:
-    # A List element checked against a List-of-List collection whose inner type
-    # does not match (`(_, List(_))` arm -> bail).
-    df = pl.DataFrame(
-        {
-            "a": pl.Series([[1, 2]], dtype=pl.List(pl.Int64)),
-            "b": pl.Series([[[1.0, 2.0]]], dtype=pl.List(pl.List(pl.Float64))),
-        }
-    )
-    with pytest.raises(
-        InvalidOperationError,
-        match=r"'is_in' cannot check for List\(Int64\) values in List\(List\(Float64\)\) data",
-    ):
-        df.select(pl.col("a").is_in("b"))
-
-
-def test_is_in_nested_array_mismatch() -> None:
-    # An Array element checked against a List-of-Array collection whose inner
-    # type does not match (`(_, Array(_, _))` arm -> bail).
-    df = pl.DataFrame(
-        {
-            "a": pl.Series([[1, 2]], dtype=pl.Array(pl.Int64, 2)),
-            "b": pl.Series(
-                [[[1.0, 2.0]]], dtype=pl.List(pl.Array(pl.Float64, 2))
-            ),
-        }
-    )
-    with pytest.raises(
-        InvalidOperationError,
-        match=r"'is_in' cannot check for Array\(Int64, 2\) values in List\(Array\(Float64, 2\)\) data",
-    ):
-        df.select(pl.col("a").is_in("b"))
-
-
-def test_is_in_struct_mismatch() -> None:
-    # A Struct element checked against a collection of a non-matching type
-    # (`(Struct(_), _) | (_, Struct(_))` arm -> bail).
-    df = pl.DataFrame(
-        {
-            "a": pl.Series([{"x": 1}], dtype=pl.Struct({"x": pl.Int64})),
-            "b": pl.Series([[1, 2]], dtype=pl.List(pl.Int64)),
-        }
-    )
-    with pytest.raises(
-        InvalidOperationError,
-        match=r"'is_in' cannot check for Struct\(.*\) values in List\(Int64\) data",
-    ):
-        df.select(pl.col("a").is_in("b"))
+    missing_value = None
+    expected = pl.Series("a", [True, False, True, missing_value])
+    assert_series_equal(df.select(pl.col("a").is_in(s))["a"], expected)

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Collection
-from datetime import date, datetime, timedelta
+from datetime import date
 from decimal import Decimal as D
 from typing import TYPE_CHECKING
 

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -787,21 +787,3 @@ def test_null_propagate_all_paths_cat(nulls_equal: bool) -> None:
     missing_value = True if nulls_equal else None
     expected = pl.Series([True, False, missing_value])
     assert_series_equal(result, expected)
-
-
-# The tests below exercise the type-coercion branches in
-# `crates/polars-plan/src/plans/conversion/type_coercion/is_in.rs`.
-
-
-def test_is_in_nested_struct() -> None:
-    df = pl.DataFrame(
-        {"a": [{"x": {"y": 1}}, {"x": {"y": 2}}, {"x": {"y": 3}}, None]},
-        schema={"a": pl.Struct({"x": pl.Struct({"y": pl.Int32})})},
-    )
-    s = pl.Series(
-        [[{"x": {"y": 1}}, {"x": {"y": 3}}]],
-        dtype=pl.List(pl.Struct({"x": pl.Struct({"y": pl.Int64})})),
-    )
-    missing_value = None
-    expected = pl.Series("a", [True, False, True, missing_value])
-    assert_series_equal(df.select(pl.col("a").is_in(s))["a"], expected)

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Collection
-from datetime import date
+from datetime import date, datetime, timedelta
 from decimal import Decimal as D
 from typing import TYPE_CHECKING
 
@@ -773,3 +773,146 @@ def test_null_propagate_all_paths_cat(nulls_equal: bool) -> None:
     missing_value = True if nulls_equal else None
     expected = pl.Series([True, False, missing_value])
     assert_series_equal(result, expected)
+
+
+# The tests below exercise the type-coercion branches in
+# `crates/polars-plan/src/plans/conversion/type_coercion/is_in.rs`.
+
+
+@pytest.mark.parametrize("dtype", [pl.List(pl.String), pl.Array(pl.String, 2)])
+def test_is_in_cat_str_collection(dtype: PolarsDataType) -> None:
+    # Categorical element checked against a List/Array of String: the String
+    # collection is cast to the categorical dtype (the `Categorical -> String`
+    # OtherCast arm, covering both the List and Array `cast_type` branches).
+    df = pl.DataFrame(
+        {
+            "a": pl.Series(["a", "b", "x"], dtype=pl.Categorical),
+            "b": pl.Series([["a", "z"], ["q", "b"], ["m", "n"]], dtype=dtype),
+        }
+    )
+    result = df.select(pl.col("a").is_in("b")).to_series()
+    assert result.to_list() == [True, True, False]
+
+
+@pytest.mark.parametrize("unit", ["ns", "us"])
+def test_is_in_datetime_finer_in_coarser_unit(unit: str) -> None:
+    # Checking a finer (or equal) time-unit in coarser-unit data is allowed and
+    # performs no cast (`Datetime` arm, `lhs_unit <= rhs_unit` -> Ok(None)).
+    df = pl.DataFrame(
+        {
+            "a": pl.Series(
+                [datetime(2022, 1, 1), datetime(2022, 1, 2)], dtype=pl.Datetime(unit)  # type: ignore[arg-type]
+            ),
+            "b": pl.Series(
+                [[datetime(2030, 1, 1)], [datetime(2030, 1, 3)]],
+                dtype=pl.List(pl.Datetime("ms")),
+            ),
+        }
+    )
+    # No cross-unit normalization happens, so disjoint instants are not matched.
+    result = df.select(pl.col("a").is_in("b")).to_series()
+    assert result.to_list() == [False, False]
+
+
+def test_is_in_datetime_coarser_in_finer_unit() -> None:
+    # The reverse (coarser values in finer-unit data) would discard precision
+    # and is rejected (`Datetime` arm, `lhs_unit > rhs_unit` -> bail).
+    df = pl.DataFrame(
+        {
+            "a": pl.Series([datetime(2022, 1, 1)], dtype=pl.Datetime("ms")),
+            "b": pl.Series(
+                [[datetime(2022, 1, 1)]], dtype=pl.List(pl.Datetime("ns"))
+            ),
+        }
+    )
+    with pytest.raises(
+        InvalidOperationError,
+        match=r"cannot check for Nanoseconds precision values in Milliseconds Datetime data",
+    ):
+        df.select(pl.col("a").is_in("b"))
+
+
+@pytest.mark.parametrize("unit", ["ns", "us"])
+def test_is_in_duration_finer_in_coarser_unit(unit: str) -> None:
+    # `Duration` arm, `lhs_unit <= rhs_unit` -> Ok(None) (no cast).
+    df = pl.DataFrame(
+        {
+            "a": pl.Series(
+                [timedelta(seconds=1), timedelta(seconds=2)],
+                dtype=pl.Duration(unit),  # type: ignore[arg-type]
+            ),
+            "b": pl.Series(
+                [[timedelta(seconds=5)], [timedelta(seconds=9)]],
+                dtype=pl.List(pl.Duration("ms")),
+            ),
+        }
+    )
+    result = df.select(pl.col("a").is_in("b")).to_series()
+    assert result.to_list() == [False, False]
+
+
+def test_is_in_duration_coarser_in_finer_unit() -> None:
+    # `Duration` arm, `lhs_unit > rhs_unit` -> bail.
+    df = pl.DataFrame(
+        {
+            "a": pl.Series([timedelta(seconds=1)], dtype=pl.Duration("ms")),
+            "b": pl.Series(
+                [[timedelta(seconds=1)]], dtype=pl.List(pl.Duration("ns"))
+            ),
+        }
+    )
+    with pytest.raises(
+        InvalidOperationError,
+        match=r"cannot check for Nanoseconds precision values in Milliseconds Duration data",
+    ):
+        df.select(pl.col("a").is_in("b"))
+
+
+def test_is_in_nested_list_mismatch() -> None:
+    # A List element checked against a List-of-List collection whose inner type
+    # does not match (`(_, List(_))` arm -> bail).
+    df = pl.DataFrame(
+        {
+            "a": pl.Series([[1, 2]], dtype=pl.List(pl.Int64)),
+            "b": pl.Series([[[1.0, 2.0]]], dtype=pl.List(pl.List(pl.Float64))),
+        }
+    )
+    with pytest.raises(
+        InvalidOperationError,
+        match=r"'is_in' cannot check for List\(Int64\) values in List\(List\(Float64\)\) data",
+    ):
+        df.select(pl.col("a").is_in("b"))
+
+
+def test_is_in_nested_array_mismatch() -> None:
+    # An Array element checked against a List-of-Array collection whose inner
+    # type does not match (`(_, Array(_, _))` arm -> bail).
+    df = pl.DataFrame(
+        {
+            "a": pl.Series([[1, 2]], dtype=pl.Array(pl.Int64, 2)),
+            "b": pl.Series(
+                [[[1.0, 2.0]]], dtype=pl.List(pl.Array(pl.Float64, 2))
+            ),
+        }
+    )
+    with pytest.raises(
+        InvalidOperationError,
+        match=r"'is_in' cannot check for Array\(Int64, 2\) values in List\(Array\(Float64, 2\)\) data",
+    ):
+        df.select(pl.col("a").is_in("b"))
+
+
+def test_is_in_struct_mismatch() -> None:
+    # A Struct element checked against a collection of a non-matching type
+    # (`(Struct(_), _) | (_, Struct(_))` arm -> bail).
+    df = pl.DataFrame(
+        {
+            "a": pl.Series([{"x": 1}], dtype=pl.Struct({"x": pl.Int64})),
+            "b": pl.Series([[1, 2]], dtype=pl.List(pl.Int64)),
+        }
+    )
+    with pytest.raises(
+        InvalidOperationError,
+        match=r"'is_in' cannot check for Struct\(.*\) values in List\(Int64\) data",
+    ):
+        df.select(pl.col("a").is_in("b"))

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -787,3 +787,18 @@ def test_null_propagate_all_paths_cat(nulls_equal: bool) -> None:
     missing_value = True if nulls_equal else None
     expected = pl.Series([True, False, missing_value])
     assert_series_equal(result, expected)
+
+
+def test_is_in_non_nested_container() -> None:
+    # The right-hand side (the container) must be a nested dtype.
+    df = pl.DataFrame(
+        {
+            "a": pl.Series([[1, 2], [3, 4]], dtype=pl.List(pl.Int64)),
+            "b": pl.Series([1, 3], dtype=pl.Int64),
+        }
+    )
+    with pytest.raises(
+        InvalidOperationError,
+        match=r"(?s)cannot check for List\(Int64\) values in Int64 data.*container dtype \(Int64\) must be nested",
+    ):
+        df.select(pl.col("a").is_in(pl.col("b")))

--- a/py-polars/tests/unit/sql/test_operators.py
+++ b/py-polars/tests/unit/sql/test_operators.py
@@ -213,16 +213,14 @@ def test_starts_with() -> None:
     ]
 
 
-@pytest.mark.parametrize("match_float", [False, True])
-def test_unary_ops_8890(match_float: bool) -> None:
+def test_unary_ops_8890() -> None:
     with pl.SQLContext(
         df=pl.DataFrame({"a": [-2, -1, 1, 2], "b": ["w", "x", "y", "z"]}),
     ) as ctx:
-        in_values = "(-3.0, -1.0, +2.0, +4.0)" if match_float else "(-3, -1, +2, +4)"
         res = ctx.execute(
-            f"""
+            """
             SELECT *, -(3) as c, (+4) as d
-            FROM df WHERE a IN {in_values}
+            FROM df WHERE a IN (-3, -1, +2, +4)
             """
         )
         assert res.collect().to_dict(as_series=False) == {


### PR DESCRIPTION
Closes: #25624

:robot: AI was used only to generate the new `test_is_in_non_nested_container` test