### PR TITLE
feat: Implement missing datetime options for `CastColumnsPolicy`

### DIFF
--- a/crates/polars-core/src/utils/supertype.rs
+++ b/crates/polars-core/src/utils/supertype.rs
@@ -24,7 +24,7 @@ pub fn try_get_supertype_with_options(
     )
 }
 
-/// Returns the smallest numeric dtype that `l` and `r` can both be casted to without loss of data.
+/// Returns the smallest numeric dtype that `l` and `r` can both be cast to without loss of data.
 /// If no such dtype exists, or `l` and `r` are already matching, returns `None`.
 pub fn get_numeric_upcast_supertype_lossless(l: &DataType, r: &DataType) -> Option<DataType> {
     use DataType::*;

--- a/crates/polars-plan/dsl-schema-hashes.json
+++ b/crates/polars-plan/dsl-schema-hashes.json
@@ -14,7 +14,7 @@
   "BrotliLevel": "87f82fead5f10583225fa4d288e6fd5967b40ffb90c8cbb8539bf1a98bce4a0c",
   "BusinessFunction": "1b6cb07e9df7e6e7244dd5381ac9198dcd28de984891ee52e82c188dee06a5af",
   "CallbackSinkType": "3dc3398a7ef7c9326bbfe995d459cc7bc0dc9c974e3151c376cf2b4e14c215cd",
-  "CastColumnsPolicy": "f1bda34aa256f119ee8398fdc785831cf157a1016b37b357ab2849294d1d8459",
+  "CastColumnsPolicy": "a2fceff2770d93fb66dbfcff2d816a2926af7ffa3eac603d500c736a8499cc06",
   "CastOptions": "33eacc5702ecb00e6292ea70fa7be75f1734e9b2b2e348e4140eb509a259bb32",
   "CategoricalFunction": "3c2a82bfb56cc8ebcb92f7d72fc6adbf5c268ecf3ddffc3ec9421403052f1f3b",
   "CategoricalPhysical": "7107ef2de35ebb480b9c69c20056f88ec3d2c2429e3dd3e5e08f2c70defd981b",

--- a/crates/polars-plan/src/dsl/file_scan/mod.rs
+++ b/crates/polars-plan/src/dsl/file_scan/mod.rs
@@ -271,11 +271,18 @@ pub struct CastColumnsPolicy {
     /// Allow downcasting from big floats to smaller floats
     pub float_downcast: bool,
 
-    /// Allow datetime[ns] to be casted to any lower precision. Important for
-    /// being able to read datasets written by spark.
+    /// Allow datetime[ns] to be cast to any lower precision.
+    /// (Important for being able to read datasets written by Spark).
     pub datetime_nanoseconds_downcast: bool,
-    /// Allow datetime[us] to datetime[ms]
+
+    /// Allow datetime[us] to be cast to datetime[ms]
     pub datetime_microseconds_downcast: bool,
+
+    /// Allow datetime[ms] to be cast to datetime[us] or datetime[ns].
+    pub datetime_milliseconds_upcast: bool,
+
+    /// Allow datetime[us] to be cast to datetime[ns].
+    pub datetime_microseconds_upcast: bool,
 
     /// Allow casting to change time units.
     pub datetime_convert_timezone: bool,
@@ -299,6 +306,8 @@ impl CastColumnsPolicy {
         float_downcast: false,
         datetime_nanoseconds_downcast: false,
         datetime_microseconds_downcast: false,
+        datetime_milliseconds_upcast: false,
+        datetime_microseconds_upcast: false,
         datetime_convert_timezone: false,
         null_upcast: true,
         categorical_to_string: false,
@@ -770,7 +779,6 @@ impl CastColumnsPolicy {
                         )
                     }
                 },
-
                 (DataType::Float16, DataType::Float32)
                 | (DataType::Float16, DataType::Float64)
                 | (DataType::Float32, DataType::Float64) => {
@@ -823,19 +831,35 @@ impl CastColumnsPolicy {
                             )
                         }
                     },
-
                     (TimeUnit::Microseconds, TimeUnit::Milliseconds) => {
                         if self.datetime_microseconds_downcast {
                             Ok(true)
                         } else {
-                            // TODO
                             mismatch_err(
-                                "unimplemented: 'microsecond-downcast' in scan cast options",
+                                "hint: pass cast_options=pl.ScanCastOptions(datetime_cast='microsecond-downcast')",
                             )
                         }
                     },
-
-                    _ => mismatch_err(""),
+                    (TimeUnit::Microseconds, TimeUnit::Nanoseconds) => {
+                        if self.datetime_microseconds_upcast {
+                            Ok(true)
+                        } else {
+                            mismatch_err(
+                                "hint: pass cast_options=pl.ScanCastOptions(datetime_cast='microsecond-upcast')",
+                            )
+                        }
+                    },
+                    (TimeUnit::Milliseconds, TimeUnit::Microseconds | TimeUnit::Nanoseconds) => {
+                        if self.datetime_milliseconds_upcast {
+                            Ok(true)
+                        } else {
+                            mismatch_err(
+                                "hint: pass cast_options=pl.ScanCastOptions(datetime_cast='millisecond-upcast')",
+                            )
+                        }
+                    },
+                    // All distinct-unit pairs are covered above.
+                    _ => unreachable!(),
                 };
             }
 

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -141,6 +141,8 @@ impl OptimizationRule for TypeCoercionRule {
                             float_downcast: true,
                             datetime_nanoseconds_downcast: true,
                             datetime_microseconds_downcast: true,
+                            datetime_milliseconds_upcast: true,
+                            datetime_microseconds_upcast: true,
                             datetime_convert_timezone: true,
                             null_upcast: true,
                             categorical_to_string: true,

--- a/crates/polars-python/src/conversion/mod.rs
+++ b/crates/polars-python/src/conversion/mod.rs
@@ -1520,6 +1520,9 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Wrap<CastColumnsPolicy> {
         })?;
 
         let mut datetime_nanoseconds_downcast = false;
+        let mut datetime_microseconds_downcast = false;
+        let mut datetime_milliseconds_upcast = false;
+        let mut datetime_microseconds_upcast = false;
         let mut datetime_convert_timezone = false;
 
         let datetime_cast_object = ob.getattr(intern!(py, "datetime_cast"))?;
@@ -1528,6 +1531,17 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Wrap<CastColumnsPolicy> {
             match v {
                 "forbid" => {},
                 "nanosecond-downcast" => datetime_nanoseconds_downcast = true,
+                "microsecond-downcast" => datetime_microseconds_downcast = true,
+                "millisecond-upcast" => datetime_milliseconds_upcast = true,
+                "microsecond-upcast" => datetime_microseconds_upcast = true,
+                "downcast" => {
+                    datetime_nanoseconds_downcast = true;
+                    datetime_microseconds_downcast = true;
+                },
+                "upcast" => {
+                    datetime_milliseconds_upcast = true;
+                    datetime_microseconds_upcast = true;
+                },
                 "convert-timezone" => datetime_convert_timezone = true,
                 v => {
                     return Err(PyValueError::new_err(format!(
@@ -1584,7 +1598,9 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Wrap<CastColumnsPolicy> {
             float_upcast,
             float_downcast,
             datetime_nanoseconds_downcast,
-            datetime_microseconds_downcast: false,
+            datetime_microseconds_downcast,
+            datetime_milliseconds_upcast,
+            datetime_microseconds_upcast,
             datetime_convert_timezone,
             null_upcast: true,
             categorical_to_string,

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/components/column_selector/builder.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/components/column_selector/builder.rs
@@ -344,19 +344,44 @@ impl ColumnSelectorBuilder {
 
                     (TimeUnit::Microseconds, TimeUnit::Milliseconds) => {
                         if !self.cast_columns_policy.datetime_microseconds_downcast {
-                            // TODO
                             return mismatch_err(
-                                "unimplemented: 'microsecond-downcast' in scan cast options",
+                                "hint: pass cast_options=pl.ScanCastOptions(datetime_cast='microsecond-downcast')",
                             );
                         }
                     },
 
-                    _ => return mismatch_err(""),
+                    (TimeUnit::Microseconds, TimeUnit::Nanoseconds) => {
+                        if !self.cast_columns_policy.datetime_microseconds_upcast {
+                            return mismatch_err(
+                                "hint: pass cast_options=pl.ScanCastOptions(datetime_cast='microsecond-upcast')",
+                            );
+                        }
+                    },
+
+                    (TimeUnit::Milliseconds, TimeUnit::Microseconds | TimeUnit::Nanoseconds) => {
+                        if !self.cast_columns_policy.datetime_milliseconds_upcast {
+                            return mismatch_err(
+                                "hint: pass cast_options=pl.ScanCastOptions(datetime_cast='millisecond-upcast')",
+                            );
+                        }
+                    },
+
+                    // All distinct-unit pairs are covered above.
+                    _ => unreachable!(),
                 };
             }
 
+            // Upcasting to a finer unit (`target_unit < incoming_unit`) multiplies the values
+            // and can overflow, so use strict casting to raise if out-of-range. Downcasts and
+            // timezone-only casts only lose precision, so non-strict is fine.
+            let cast_options = if target_unit < incoming_unit {
+                CastOptions::Strict
+            } else {
+                CastOptions::NonStrict
+            };
+
             // Dtype differs and we are allowed to coerce
-            return attach_cast(CastOptions::NonStrict);
+            return attach_cast(cast_options);
         }
 
         if target_dtype.is_string() && incoming_dtype.is_categorical() {

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/components/column_selector/transform.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/components/column_selector/transform.rs
@@ -38,8 +38,9 @@ impl ColumnTransform {
 
         let out = match self {
             TF::Cast { dtype, options } => {
-                // Recursion currently does not propagate NULLs across nesting levels.
-                debug_assert!(!matches!(options, CastOptions::Strict));
+                // note: strict casts are only sound for non-nested dtypes here;
+                // recursion currently does not propagate NULLs across nesting levels
+                debug_assert!(!matches!(options, CastOptions::Strict) || !dtype.is_nested());
 
                 input.cast_with_options(dtype, *options)?
             },

--- a/crates/polars-stream/src/nodes/io_sources/parquet/projection.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/projection.rs
@@ -58,7 +58,7 @@ pub fn resolve_arrow_field_projections(
         .collect::<Arc<[ArrowFieldProjection]>>())
 }
 
-/// Represents a potentially mapped (i.e. casted and/or renamed) arrow field projection.
+/// Represents a potentially mapped (i.e. cast and/or renamed) arrow field projection.
 #[derive(Debug)]
 pub enum ArrowFieldProjection {
     Plain(ArrowField),

--- a/py-polars/src/polars/_utils/various.py
+++ b/py-polars/src/polars/_utils/various.py
@@ -226,7 +226,7 @@ def _in_notebook() -> bool:
 
         if (
             ipy := get_ipython()
-        ) and "IPKernelApp" not in ipy.config:  # pragma: no cover
+        ) is not None and "IPKernelApp" not in ipy.config:  # pragma: no cover
             return False
     except ImportError:
         return False

--- a/py-polars/src/polars/io/scan_options/cast_options.py
+++ b/py-polars/src/polars/io/scan_options/cast_options.py
@@ -9,28 +9,31 @@ if TYPE_CHECKING:
     from typing import TypeAlias
 
 
-FloatCastOption: TypeAlias = Literal["upcast", "downcast"]
-IntegerCastOption: TypeAlias = Literal["upcast", "allow-float"]
-DatetimeCastOption: TypeAlias = Literal["nanosecond-downcast", "convert-timezone"]
+FloatCastOption: TypeAlias = Literal["upcast", "downcast", "forbid"]
+IntegerCastOption: TypeAlias = Literal["upcast", "allow-float", "forbid"]
+DatetimeCastOption: TypeAlias = Literal[
+    "convert-timezone",
+    "nanosecond-downcast",
+    "microsecond-downcast",
+    "microsecond-upcast",
+    "millisecond-upcast",
+    "downcast",
+    "upcast",
+    "forbid",
+]
 
 _DEFAULT_CAST_OPTIONS_ICEBERG: ScanCastOptions | None = None
 
 
 class ScanCastOptions:
-    """Options for scanning files."""
+    """Cast options applied when scanning files."""
 
     def __init__(
         self,
         *,
-        integer_cast: Literal["forbid"]
-        | IntegerCastOption
-        | Collection[IntegerCastOption] = "forbid",
-        float_cast: Literal["forbid"]
-        | FloatCastOption
-        | Collection[FloatCastOption] = "forbid",
-        datetime_cast: Literal["forbid"]
-        | DatetimeCastOption
-        | Collection[DatetimeCastOption] = "forbid",
+        integer_cast: IntegerCastOption | Collection[IntegerCastOption] = "forbid",
+        float_cast: FloatCastOption | Collection[FloatCastOption] = "forbid",
+        datetime_cast: DatetimeCastOption | Collection[DatetimeCastOption] = "forbid",
         missing_struct_fields: Literal["insert", "raise"] = "raise",
         extra_struct_fields: Literal["ignore", "raise"] = "raise",
         categorical_to_string: Literal["allow", "forbid"] = "forbid",
@@ -49,6 +52,7 @@ class ScanCastOptions:
             Configuration for casting from integer types:
 
             * `upcast`: Allow lossless casting to wider integer types.
+            * `allow-float`: Allow casting integers to float types.
             * `forbid`: Raises an error if dtypes do not match.
 
         float_cast
@@ -61,9 +65,19 @@ class ScanCastOptions:
         datetime_cast
             Configuration for casting from datetime types:
 
-            * `nanosecond-downcast`: Allow nanosecond precision datetime to be \
-            downcasted to any lower precision. This has a similar effect to \
-            PyArrow's `coerce_int96_timestamp_unit`.
+            * `nanosecond-downcast`: Allow nanosecond precision datetime to be
+              downcasted to any lower precision. This has a similar effect to
+              PyArrow's `coerce_int96_timestamp_unit`.
+            * `microsecond-downcast`: Allow microsecond precision datetime to be
+              downcasted to millisecond precision.
+            * `microsecond-upcast`: Allow microsecond precision datetime to be
+              upcasted to nanosecond precision.
+            * `millisecond-upcast`: Allow millisecond precision datetime to be
+              upcasted to microsecond or nanosecond precision.
+            * `downcast`: Allow downcasting to any lower precision (convenience
+              aggregate of `nanosecond-downcast` and `microsecond-downcast`).
+            * `upcast`: Allow upcasting to any higher precision (convenience
+              aggregate of `millisecond-upcast` and `microsecond-upcast`).
             * `convert-timezone`: Allow casting to a different timezone.
             * `forbid`: Raises an error if dtypes do not match.
 
@@ -118,7 +132,7 @@ class ScanCastOptions:
             _DEFAULT_CAST_OPTIONS_ICEBERG = ScanCastOptions(
                 integer_cast="upcast",
                 float_cast=["upcast", "downcast"],
-                datetime_cast=["nanosecond-downcast", "convert-timezone"],
+                datetime_cast=("nanosecond-downcast", "convert-timezone"),
                 missing_struct_fields="insert",
                 extra_struct_fields="ignore",
                 categorical_to_string="allow",

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -3432,7 +3432,7 @@ def test_scan_parquet_skip_row_groups_with_cast(
         cast_options=pl.ScanCastOptions(
             integer_cast="upcast",
             float_cast=["upcast", "downcast"],
-            datetime_cast=["convert-timezone", "nanosecond-downcast"],
+            datetime_cast=("convert-timezone", "nanosecond-downcast"),
             missing_struct_fields="insert",
         ),
     ).filter(filter_expr)
@@ -3489,7 +3489,7 @@ def test_scan_parquet_skip_row_groups_with_cast_inclusions(
         cast_options=pl.ScanCastOptions(
             integer_cast="upcast",
             float_cast=["upcast", "downcast"],
-            datetime_cast=["convert-timezone", "nanosecond-downcast"],
+            datetime_cast=("convert-timezone", "nanosecond-downcast"),
             missing_struct_fields="insert",
         ),
     ).filter(filter_expr)

--- a/py-polars/tests/unit/io/test_scan_options.py
+++ b/py-polars/tests/unit/io/test_scan_options.py
@@ -15,6 +15,8 @@ from polars.testing import assert_frame_equal
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from polars._typing import EngineType
+
 
 @pytest.mark.parametrize(
     ("literal_values", "expected", "cast_options"),
@@ -34,13 +36,24 @@ if TYPE_CHECKING:
             pl.Series([1, 2], dtype=pl.Float32),
             pl.ScanCastOptions(float_cast=["upcast", "downcast"]),
         ),
+        # datetime: ns -> ms (nanosecond-downcast). The incoming value carries
+        # sub-millisecond precision so a broken (non-scaling) cast is observable.
         (
             (
-                pl.lit(datetime(2025, 1, 1), dtype=pl.Datetime(time_unit="ms")),
-                pl.lit(datetime(2025, 1, 2), dtype=pl.Datetime(time_unit="ns")),
+                pl.lit(
+                    datetime(2025, 1, 1, microsecond=111000),
+                    dtype=pl.Datetime(time_unit="ms"),
+                ),
+                pl.lit(
+                    datetime(2025, 1, 2, microsecond=123456),
+                    dtype=pl.Datetime(time_unit="ns"),
+                ),
             ),
             pl.Series(
-                [datetime(2025, 1, 1), datetime(2025, 1, 2)],
+                [
+                    datetime(2025, 1, 1, microsecond=111000),
+                    datetime(2025, 1, 2, microsecond=123000),
+                ],
                 dtype=pl.Datetime(time_unit="ms"),
             ),
             pl.ScanCastOptions(datetime_cast="nanosecond-downcast"),
@@ -64,7 +77,7 @@ if TYPE_CHECKING:
                 dtype=pl.Datetime(time_unit="ms", time_zone="Europe/Amsterdam"),
             ),
             pl.ScanCastOptions(
-                datetime_cast=["nanosecond-downcast", "convert-timezone"]
+                datetime_cast=("nanosecond-downcast", "convert-timezone")
             ),
         ),
         (
@@ -178,7 +191,7 @@ if TYPE_CHECKING:
                 ),
             ),
             pl.ScanCastOptions(
-                datetime_cast=["nanosecond-downcast", "convert-timezone"]
+                datetime_cast=("nanosecond-downcast", "convert-timezone")
             ),
         ),
         (
@@ -251,7 +264,7 @@ if TYPE_CHECKING:
                 ),
             ),
             pl.ScanCastOptions(
-                datetime_cast=["nanosecond-downcast", "convert-timezone"]
+                datetime_cast=("nanosecond-downcast", "convert-timezone")
             ),
         ),
         # Test outer validity
@@ -295,7 +308,7 @@ if TYPE_CHECKING:
                 ),
             ),
             pl.ScanCastOptions(
-                datetime_cast=["nanosecond-downcast", "convert-timezone"]
+                datetime_cast=("nanosecond-downcast", "convert-timezone")
             ),
         ),
         (
@@ -341,15 +354,167 @@ if TYPE_CHECKING:
                 ),
             ),
             pl.ScanCastOptions(
-                datetime_cast=["nanosecond-downcast", "convert-timezone"]
+                datetime_cast=("nanosecond-downcast", "convert-timezone")
+            ),
+        ),
+        # datetime: us -> ms (microsecond-downcast)
+        (
+            (
+                pl.lit(
+                    datetime(2025, 1, 1, microsecond=111000),
+                    dtype=pl.Datetime(time_unit="ms"),
+                ),
+                pl.lit(
+                    datetime(2025, 1, 2, microsecond=123456),
+                    dtype=pl.Datetime(time_unit="us"),
+                ),
+            ),
+            pl.Series(
+                [
+                    datetime(2025, 1, 1, microsecond=111000),
+                    datetime(2025, 1, 2, microsecond=123000),
+                ],
+                dtype=pl.Datetime(time_unit="ms"),
+            ),
+            pl.ScanCastOptions(datetime_cast="microsecond-downcast"),
+        ),
+        # datetime: ms -> us (millisecond-upcast). The ms value must scale up by
+        # 1000; a non-scaling cast would land 1000x off.
+        (
+            (
+                pl.lit(
+                    datetime(2025, 1, 1, microsecond=123456),
+                    dtype=pl.Datetime(time_unit="us"),
+                ),
+                pl.lit(
+                    datetime(2025, 1, 2, microsecond=789000),
+                    dtype=pl.Datetime(time_unit="ms"),
+                ),
+            ),
+            pl.Series(
+                [
+                    datetime(2025, 1, 1, microsecond=123456),
+                    datetime(2025, 1, 2, microsecond=789000),
+                ],
+                dtype=pl.Datetime(time_unit="us"),
+            ),
+            pl.ScanCastOptions(datetime_cast="millisecond-upcast"),
+        ),
+        # datetime: ms -> ns (millisecond-upcast).
+        (
+            (
+                pl.lit(
+                    datetime(2025, 1, 1, microsecond=123456),
+                    dtype=pl.Datetime(time_unit="ns"),
+                ),
+                pl.lit(
+                    datetime(2025, 1, 2, microsecond=789000),
+                    dtype=pl.Datetime(time_unit="ms"),
+                ),
+            ),
+            pl.Series(
+                [
+                    datetime(2025, 1, 1, microsecond=123456),
+                    datetime(2025, 1, 2, microsecond=789000),
+                ],
+                dtype=pl.Datetime(time_unit="ns"),
+            ),
+            pl.ScanCastOptions(datetime_cast="millisecond-upcast"),
+        ),
+        # datetime: us -> ns (microsecond-upcast).
+        (
+            (
+                pl.lit(
+                    datetime(2025, 1, 1, microsecond=123456),
+                    dtype=pl.Datetime(time_unit="ns"),
+                ),
+                pl.lit(
+                    datetime(2025, 1, 2, microsecond=654321),
+                    dtype=pl.Datetime(time_unit="us"),
+                ),
+            ),
+            pl.Series(
+                [
+                    datetime(2025, 1, 1, microsecond=123456),
+                    datetime(2025, 1, 2, microsecond=654321),
+                ],
+                dtype=pl.Datetime(time_unit="ns"),
+            ),
+            pl.ScanCastOptions(datetime_cast="microsecond-upcast"),
+        ),
+        # datetime: ms -> ns via generic 'upcast' aggregate.
+        (
+            (
+                pl.lit(
+                    datetime(2025, 1, 1, microsecond=123456),
+                    dtype=pl.Datetime(time_unit="ns"),
+                ),
+                pl.lit(
+                    datetime(2025, 1, 2, microsecond=789000),
+                    dtype=pl.Datetime(time_unit="ms"),
+                ),
+            ),
+            pl.Series(
+                [
+                    datetime(2025, 1, 1, microsecond=123456),
+                    datetime(2025, 1, 2, microsecond=789000),
+                ],
+                dtype=pl.Datetime(time_unit="ns"),
+            ),
+            pl.ScanCastOptions(datetime_cast="upcast"),
+        ),
+        # datetime: us -> ms via generic 'downcast' aggregate.
+        (
+            (
+                pl.lit(
+                    datetime(2025, 1, 1, microsecond=111000),
+                    dtype=pl.Datetime(time_unit="ms"),
+                ),
+                pl.lit(
+                    datetime(2025, 1, 2, microsecond=123456),
+                    dtype=pl.Datetime(time_unit="us"),
+                ),
+            ),
+            pl.Series(
+                [
+                    datetime(2025, 1, 1, microsecond=111000),
+                    datetime(2025, 1, 2, microsecond=123000),
+                ],
+                dtype=pl.Datetime(time_unit="ms"),
+            ),
+            pl.ScanCastOptions(datetime_cast="downcast"),
+        ),
+        # datetime: us -> ms with both directions enabled via list.
+        (
+            (
+                pl.lit(
+                    datetime(2025, 1, 1, microsecond=111000),
+                    dtype=pl.Datetime(time_unit="ms"),
+                ),
+                pl.lit(
+                    datetime(2025, 1, 2, microsecond=123456),
+                    dtype=pl.Datetime(time_unit="us"),
+                ),
+            ),
+            pl.Series(
+                [
+                    datetime(2025, 1, 1, microsecond=111000),
+                    datetime(2025, 1, 2, microsecond=123000),
+                ],
+                dtype=pl.Datetime(time_unit="ms"),
+            ),
+            pl.ScanCastOptions(
+                datetime_cast=("microsecond-downcast", "millisecond-upcast")
             ),
         ),
     ],
 )
+@pytest.mark.parametrize("engine", ["in-memory", "streaming"])
 def test_scan_cast_options(
     literal_values: tuple[pl.Expr, pl.Expr],
     expected: pl.Series,
     cast_options: pl.ScanCastOptions | None,
+    engine: EngineType,
 ) -> None:
     expected = expected.alias("literal")
     lv1, lv2 = literal_values
@@ -382,12 +547,162 @@ def test_scan_cast_options(
         q = pl.scan_parquet(files)
 
         with pytest.raises(pl.exceptions.SchemaError, match=r"hint: .*pass"):
-            q.collect()
+            q.collect(engine=engine)
 
     assert_frame_equal(
-        pl.scan_parquet(files, cast_options=cast_options).collect(),
+        pl.scan_parquet(files, cast_options=cast_options).collect(engine=engine),
         expected.to_frame(),
     )
+
+
+@pytest.mark.parametrize(
+    ("target_unit", "incoming_unit", "cast_str", "incoming_phys", "expected_phys"),
+    [
+        ("ms", "us", "microsecond-downcast", 1_734_567_891_123_456, 1_734_567_891_123),
+        ("us", "ms", "millisecond-upcast", 1_734_567_891_789, 1_734_567_891_789_000),
+        (
+            "ns",
+            "ms",
+            "millisecond-upcast",
+            1_734_567_891_789,
+            1_734_567_891_789_000_000,
+        ),
+        (
+            "ns",
+            "us",
+            "microsecond-upcast",
+            1_734_567_891_123_456,
+            1_734_567_891_123_456_000,
+        ),
+        (
+            "ms",
+            "ns",
+            "nanosecond-downcast",
+            1_734_567_891_123_456_789,
+            1_734_567_891_123,
+        ),
+    ],
+)
+@pytest.mark.parametrize("engine", ["in-memory", "streaming"])
+def test_scan_cast_options_datetime_physical_scaling(
+    target_unit: str,
+    incoming_unit: str,
+    cast_str: str,
+    incoming_phys: int,
+    expected_phys: int,
+    engine: EngineType,
+) -> None:
+    target = pl.Series([0], dtype=pl.Int64).cast(pl.Datetime(time_unit=target_unit))  # type: ignore[arg-type]
+    incoming = pl.Series([incoming_phys], dtype=pl.Int64).cast(
+        pl.Datetime(time_unit=incoming_unit)  # type: ignore[arg-type]
+    )
+    files: list[IO[bytes]] = [io.BytesIO(), io.BytesIO()]
+    target.to_frame().write_parquet(files[0])
+    incoming.to_frame().write_parquet(files[1])
+    for f in files:
+        f.seek(0)
+
+    out = pl.scan_parquet(
+        files,
+        cast_options=pl.ScanCastOptions(datetime_cast=cast_str),  # type: ignore[arg-type]
+    ).collect(engine=engine)
+
+    result = out.to_series()
+    assert result.dtype == pl.Datetime(time_unit=target_unit)  # type: ignore[arg-type]
+    assert result.to_physical().to_list()[1] == expected_phys
+
+
+@pytest.mark.parametrize(
+    ("target_unit", "incoming_unit", "cast_str", "incoming_phys"),
+    [
+        # ms -> ns scales by 1e6; value is a valid datetime but overflows
+        ("ns", "ms", "millisecond-upcast", 9_300_000_000_000),
+        # us -> ns scales by 1e3; overflows once scaled (> i64::MAX / 1e3).
+        ("ns", "us", "microsecond-upcast", 9_000_000_000_000_000_00),
+    ],
+)
+# note: `nested` also exercises the nested cast path (datetime inside a list)
+@pytest.mark.parametrize("nested", [False, True])
+@pytest.mark.parametrize("engine", ["in-memory", "streaming"])
+def test_scan_cast_options_datetime_upcast_overflow_raises(
+    target_unit: str,
+    incoming_unit: str,
+    cast_str: str,
+    incoming_phys: int,
+    nested: bool,
+    engine: EngineType,
+) -> None:
+    # upcasting to a finer unit multiplies the physical values and can overflow
+    target = pl.Series([0], dtype=pl.Int64).cast(pl.Datetime(time_unit=target_unit))  # type: ignore[arg-type]
+    incoming = pl.Series([incoming_phys], dtype=pl.Int64).cast(
+        pl.Datetime(time_unit=incoming_unit)  # type: ignore[arg-type]
+    )
+    if nested:
+        target = target.implode()
+        incoming = incoming.implode()
+
+    files: list[IO[bytes]] = [io.BytesIO(), io.BytesIO()]
+    target.to_frame().write_parquet(files[0])
+    incoming.to_frame().write_parquet(files[1])
+    for f in files:
+        f.seek(0)
+
+    scan_opts = pl.ScanCastOptions(datetime_cast=cast_str)  # type: ignore[arg-type]
+    lf = pl.scan_parquet(files, cast_options=scan_opts)
+    with pytest.raises(
+        pl.exceptions.InvalidOperationError, match=r"conversion.*failed"
+    ):
+        lf.collect(engine=engine)
+
+
+@pytest.mark.parametrize(
+    ("target_unit", "incoming_unit", "cast_options"),
+    [
+        ("ns", "us", pl.ScanCastOptions(datetime_cast="microsecond-downcast")),
+        ("ms", "us", pl.ScanCastOptions(datetime_cast="microsecond-upcast")),
+        ("ms", "us", pl.ScanCastOptions(datetime_cast="millisecond-upcast")),
+        ("ms", "us", pl.ScanCastOptions(datetime_cast="upcast")),
+        ("ns", "ms", pl.ScanCastOptions(datetime_cast="downcast")),
+    ],
+)
+@pytest.mark.parametrize("engine", ["in-memory", "streaming"])
+def test_scan_cast_options_datetime_wrong_direction(
+    target_unit: str,
+    incoming_unit: str,
+    cast_options: pl.ScanCastOptions,
+    engine: EngineType,
+) -> None:
+    # an option enabling one direction should not silently permit a cast in
+    # the other direction (eg: enabling upcasts should still forbid downcasts)
+    lv1 = pl.lit(datetime(2025, 1, 1), dtype=pl.Datetime(time_unit=target_unit))  # type: ignore[arg-type]
+    lv2 = pl.lit(datetime(2025, 1, 2), dtype=pl.Datetime(time_unit=incoming_unit))  # type: ignore[arg-type]
+
+    files: list[IO[bytes]] = [io.BytesIO(), io.BytesIO()]
+
+    pl.select(lv1).write_parquet(files[0])
+    pl.select(lv2).write_parquet(files[1])
+    for f in files:
+        f.seek(0)
+
+    q = pl.scan_parquet(files, cast_options=cast_options)
+    with pytest.raises(pl.exceptions.SchemaError, match=r"hint: .*pass"):
+        q.collect(engine=engine)
+
+
+def test_scan_cast_options_datetime_unknown_option() -> None:
+    f = io.BytesIO()
+    pl.select(
+        pl.lit(datetime(2025, 1, 1), dtype=pl.Datetime(time_unit="ms"))
+    ).write_parquet(f)
+    f.seek(0)
+
+    with pytest.raises(TypeError) as excinfo:
+        pl.scan_parquet(
+            f,
+            cast_options=pl.ScanCastOptions(datetime_cast="bogus"),  # type: ignore[arg-type]
+        )
+
+    assert "unknown option for datetime_cast: bogus" in str(excinfo.value.__cause__)
 
 
 def test_scan_cast_options_forbid_int_downcast() -> None:


### PR DESCRIPTION
Needed support for `millisecond-upcast` from S3 parquet today, so took a look :)

Currently we only have `nanoseconds-downcast` and (with a todo) `microseconds-downcast`; this PR adds the missing datetime upcasts to `ScanCastOptions` and finishes implementing `microsecond-downcast`.

| Option | Description |
|:--|:--|
| `microsecond-downcast` | `us` → `ms` *(was defined, but unimplemented)* |
| `millisecond-upcast` | `ms` → `us`/`ns` |
| `microsecond-upcast` | `us` → `ns` |
| `downcast` _(python)_ | `nanosecond-downcast` + `microsecond-downcast` |
| `upcast` _(python)_ | `microsecond-upcast` + `millisecond-upcast` |

**Note:** the generic `upcast` and `downcast` are Python-side conveniences that set the associated granular flags; the Rust side just adds `datetime_milliseconds_upcast` and `datetime_microseconds_upcast`.
