### PR TITLE
fix(rust)!: Fix `pl.datetime` to follow leftmost-argument naming rule

### DIFF
--- a/crates/polars-plan/src/dsl/functions/temporal.rs
+++ b/crates/polars-plan/src/dsl/functions/temporal.rs
@@ -213,17 +213,13 @@ pub fn datetime(args: DatetimeArgs) -> Expr {
         ambiguous,
     ];
 
-    Expr::Alias(
-        Arc::new(Expr::Function {
-            input,
-            function: FunctionExpr::TemporalExpr(TemporalFunction::DatetimeFunction {
-                time_unit,
-                time_zone,
-            }),
+    Expr::Function {
+        input,
+        function: FunctionExpr::TemporalExpr(TemporalFunction::DatetimeFunction {
+            time_unit,
+            time_zone,
         }),
-        // TODO: follow left-hand rule in Polars 2.0.
-        PlSmallStr::from_static("datetime"),
-    )
+    }
 }
 
 /// Arguments used by `duration` in order to produce an [`Expr`] of [`Duration`]

--- a/py-polars/src/polars/functions/as_datatype.py
+++ b/py-polars/src/polars/functions/as_datatype.py
@@ -91,7 +91,7 @@ def datetime_(
     ...         pl.col("hour"),
     ...         pl.col("minute"),
     ...         time_zone="Australia/Sydney",
-    ...     )
+    ...     ).alias("datetime")
     ... )
     shape: (3, 5)
     ┌───────┬─────┬──────┬────────┬────────────────────────────────┐

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1677,7 +1677,7 @@ def test_ambiguous_expressions() -> None:
             "minute",
             time_zone="Europe/London",
             ambiguous=pl.col("ambiguous"),
-        )
+        ).alias("datetime")
     )["datetime"]
     expected = pl.DataFrame(
         {"datetime": [1603584000000000, 1603587600000000]},

--- a/py-polars/tests/unit/functions/as_datatype/test_datetime.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_datetime.py
@@ -143,3 +143,17 @@ def test_datetime_from_empty_column() -> None:
 
     assert df.select(datetime=pl.datetime("year", 1, 1)).shape == (0, 1)
     assert df.with_columns(datetime=pl.datetime("year", 1, 1)).shape == (0, 2)
+
+
+def test_datetime_name() -> None:
+    df = pl.DataFrame(
+        {
+            "year": [2001, 2002, 2003],
+            "month": [1, 2, 3],
+            "day": [1, 2, 3],
+            "hour": [23, 12, 8],
+        }
+    )
+
+    assert df.select(pl.datetime("year", "month", "day", "hour")).columns == ["year"]
+    assert df.select(pl.datetime(2024, "month", "day", "hour")).columns == ["literal"]


### PR DESCRIPTION
Closes #18808