### PR TITLE
chore(python): Ensure `pyrefly` checks run as part of `make pre-commit`

### DIFF
--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -51,8 +51,9 @@ fix:
 .PHONY: lint
 lint: .venv  ## Run lint checks (only)
 	$(VENV_BIN)/ruff check
-	$(VENV_BIN)/typos ..
+	$(VENV_BIN)/pyrefly check
 	$(VENV_BIN)/mypy
+	$(VENV_BIN)/typos ..
 
 .PHONY: fmt
 fmt: .venv  ## Run autoformatting (python and rust)


### PR DESCRIPTION
We now run `pyrefly` by default in CI, so we don't want to be surprised by CI lint/typing failures that could have been discovered locally first 👍 

(Added to `make lint`, which runs as part of `make pre-commit`).