### PR TITLE
fix(rust): Re-resolve len() pushdown column when it leaves the input schema

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/edge.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/edge.rs
@@ -77,12 +77,19 @@ pub trait GetProjectionState {
                     return None;
                 }
 
-                if self.names().is_empty() {
-                    self.names_mut()
-                        .insert(min_dtype_size_col(input_schema.iter()).unwrap().clone());
-                } else {
-                    assert_eq!(self.names().len(), 1);
-                    assert!(input_schema.contains(self.names().first().unwrap()));
+                // We only need a single (cheapest) column to survive pushdown so
+                // that the row count for `len()` is preserved. A name chosen at a
+                // child node may not exist in this node's input schema (e.g. a
+                // `group_by` output column that is not an input column), so
+                // re-resolve it against `input_schema` whenever it no longer
+                // identifies a single column here.
+                let keep =
+                    self.names().len() == 1 && input_schema.contains(self.names().first().unwrap());
+                if !keep {
+                    let col = min_dtype_size_col(input_schema.iter()).unwrap().clone();
+                    let names = self.names_mut();
+                    names.clear();
+                    names.insert(col);
                 }
             },
             Projection::Names => {

--- a/py-polars/tests/unit/lazyframe/test_projections.py
+++ b/py-polars/tests/unit/lazyframe/test_projections.py
@@ -940,3 +940,24 @@ def test_projection_pushdown_select_non_column_height_27807() -> None:
     )
 
     assert_frame_equal(q.collect(), pl.Series("y", [10, 10, 10]).to_frame())
+
+
+def test_projection_pushdown_group_by_len_28094() -> None:
+    lf = pl.LazyFrame(
+        {
+            "key_a": ["x", "x", "y"],
+            "key_b": [1, 1, 2],
+            "flag": [True, False, True],
+        }
+    )
+    q = (
+        lf.group_by("key_a", "key_b")
+        .agg(any_flag=pl.col("flag").any())
+        .select(pl.len())
+    )
+
+    expected = pl.DataFrame({"len": [2]}, schema={"len": pl.UInt32})
+    assert_frame_equal(
+        q.collect(optimizations=pl.QueryOptFlags(projection_pushdown=False)), expected
+    )
+    assert_frame_equal(q.collect(), expected)


### PR DESCRIPTION
Fixes #28094

`select(len())` pushdown keeps one cheapest column alive to preserve the row count. When that column is picked at a multi-column `group_by` whose cheapest output is an aggregation rather than an input column, the carried name isn't present in a parent node's input schema, so `compute_projected_names` panicked on `assert!(input_schema.contains(...))` at `edge.rs:85`.

Re-resolve the cheapest column against the current input schema whenever the carried name no longer identifies a single column here, instead of asserting. Added a regression test that panics on the pre-fix code and collects to `len=2` after.