### PR TITLE
docs: Add polars-bio to community plugins

### DIFF
--- a/docs/source/user-guide/plugins/index.md
+++ b/docs/source/user-guide/plugins/index.md
@@ -23,6 +23,11 @@ Here is a curated (non-exhaustive) list of community-implemented plugins.
 - [polars-ds](https://github.com/abstractqqq/polars_ds_extension) Polars extension aiming to
   simplify common numerical/string data analysis procedures
 
+### Bioinformatics
+
+- [polars-bio](https://github.com/biodatageeks/polars-bio) Python library for genomics built on top
+  of Polars, Apache Arrow and Apache DataFusion
+
 ### Geo
 
 - [polars-st](https://github.com/Oreilles/polars-st) Polars ST provides spatial operations on Polars


### PR DESCRIPTION
Adds polars-bio to the community plugins list under a new Bioinformatics section.

Closes #28081