### PR TITLE
fix(python): Fully resolve remaining `ResourceWarning` leaks in database/iceberg tests

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -309,9 +309,6 @@ filterwarnings = [
   # Introspection under PyCharm IDE can generate this in Python 3.12
   "ignore:.*co_lnotab is deprecated, use co_lines.*:DeprecationWarning",
   "ignore:the argument `return_as_string` for `DataFrame.glimpse` is deprecated",
-  # TODO: Database tests lead to unclosed database warnings
-  # https://github.com/pola-rs/polars/issues/20296
-  "ignore:unclosed database.*:ResourceWarning",
   # Ignore invalid warnings when running earlier versions of SQLAlchemy (we
   # know they are invalid because our standard tests run the latest version)
   "ignore:Deprecated API features detected.*:DeprecationWarning",

--- a/py-polars/src/polars/_utils/various.py
+++ b/py-polars/src/polars/_utils/various.py
@@ -224,7 +224,9 @@ def _in_notebook() -> bool:
     try:
         from IPython import get_ipython
 
-        if "IPKernelApp" not in get_ipython().config:  # pragma: no cover
+        if (
+            ipy := get_ipython()
+        ) and "IPKernelApp" not in ipy.config:  # pragma: no cover
             return False
     except ImportError:
         return False

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -136,6 +136,7 @@ if TYPE_CHECKING:
     import jax
     import pyiceberg
     from great_tables import GT
+    from sqlalchemy.engine import Engine
     from xlsxwriter import Workbook
     from xlsxwriter.worksheet import Worksheet
 
@@ -4674,9 +4675,13 @@ class DataFrame:
             from sqlalchemy.engine import Connectable, create_engine
             from sqlalchemy.orm import Session
 
+            # note: we can only dispose of engines that we create ourselves;
+            # caller-supplied connectables remain the caller's responsibility
+            engine_to_dispose: Engine | None = None
             sa_object: Connectable
+
             if isinstance(connection, str):
-                sa_object = create_engine(connection)
+                sa_object = engine_to_dispose = create_engine(connection)
             elif isinstance(connection, Session):
                 sa_object = connection.connection()
             elif isinstance(connection, Connectable):
@@ -4692,18 +4697,23 @@ class DataFrame:
                 msg = f"Unexpected three-part table name; provide the database/catalog ({catalog!r}) on the connection URI"
                 raise ValueError(msg)
 
-            # ensure conversion to pandas uses the pyarrow extension array option
-            # so that we can make use of the sql/db export *without* copying data
-            res: int | None = self.to_pandas(
-                use_pyarrow_extension_array=True,
-            ).to_sql(
-                name=unpacked_table_name,
-                schema=db_schema,
-                con=sa_object,
-                if_exists=if_table_exists,
-                index=False,
-                **(engine_options or {}),
-            )
+            try:
+                # ensure conversion to pandas uses the pyarrow extension array option
+                # so that we can make use of the sql/db export *without* copying data
+                res: int | None = self.to_pandas(
+                    use_pyarrow_extension_array=True,
+                ).to_sql(
+                    name=unpacked_table_name,
+                    schema=db_schema,
+                    con=sa_object,
+                    if_exists=if_table_exists,
+                    index=False,
+                    **(engine_options or {}),
+                )
+            finally:
+                if engine_to_dispose is not None:
+                    engine_to_dispose.dispose()
+
             return -1 if res is None else res
 
         elif isinstance(engine, str):

--- a/py-polars/src/polars/io/database/_executor.py
+++ b/py-polars/src/polars/io/database/_executor.py
@@ -595,13 +595,8 @@ class ConnectionExecutor:
             )
             if frame is not None:
                 if defer_cursor_close:
-                    frame = (
-                        df
-                        for df in CloseAfterFrameIter(
-                            frame,
-                            cursor=self.result,
-                        )
-                    )
+                    frame_cursor = CloseAfterFrameIter(frame, cursor=self.cursor)
+                    frame = (df for df in frame_cursor)
                 return frame
 
         msg = (

--- a/py-polars/tests/unit/io/database/conftest.py
+++ b/py-polars/tests/unit/io/database/conftest.py
@@ -2,12 +2,29 @@ from __future__ import annotations
 
 import sqlite3
 from datetime import date
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+def close_connections(*connections: Any) -> None:
+    """Fully release the underlying DB-API connection for each given object."""
+    from sqlalchemy.engine import Connection, Engine
+
+    for conn in connections:
+        if isinstance(conn, str):
+            continue  # eg: connection URI, nothing to close
+        elif isinstance(conn, Engine):
+            conn.dispose()
+        elif isinstance(conn, Connection):
+            engine = conn.engine
+            conn.close()
+            engine.dispose()
+        elif hasattr(conn, "close"):
+            conn.close()
 
 
 @pytest.fixture

--- a/py-polars/tests/unit/io/database/conftest.py
+++ b/py-polars/tests/unit/io/database/conftest.py
@@ -7,7 +7,13 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
+
+    from sqlalchemy.engine import Engine
+
+
+
 
 
 def close_connections(*connections: Any) -> None:
@@ -25,6 +31,23 @@ def close_connections(*connections: Any) -> None:
             engine.dispose()
         elif hasattr(conn, "close"):
             conn.close()
+
+def create_sqlite_engine(target: str | Path, **kwargs: Any) -> Engine:
+    """Create a sqlite SQLAlchemy ``Engine`` that uses NullPool connections."""
+    from sqlalchemy import create_engine
+    from sqlalchemy.pool import NullPool
+
+    if not (uri := str(target)).startswith("sqlite:"):
+        uri = f"sqlite:///{uri}"
+    return create_engine(uri, poolclass=NullPool, **kwargs)
+@pytest.fixture
+def sqlite_engine(tmp_sqlite_db: Path) -> Iterator[Engine]:
+    """A NullPool SQLAlchemy engine bound to the standard test database."""
+    engine = create_sqlite_engine(tmp_sqlite_db)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
 
 
 @pytest.fixture

--- a/py-polars/tests/unit/io/database/conftest.py
+++ b/py-polars/tests/unit/io/database/conftest.py
@@ -13,9 +13,6 @@ if TYPE_CHECKING:
     from sqlalchemy.engine import Engine
 
 
-
-
-
 def close_connections(*connections: Any) -> None:
     """Fully release the underlying DB-API connection for each given object."""
     from sqlalchemy.engine import Connection, Engine
@@ -32,14 +29,17 @@ def close_connections(*connections: Any) -> None:
         elif hasattr(conn, "close"):
             conn.close()
 
+
 def create_sqlite_engine(target: str | Path, **kwargs: Any) -> Engine:
-    """Create a sqlite SQLAlchemy ``Engine`` that uses NullPool connections."""
+    """Create a SQLite Engine that uses NullPool connections."""
     from sqlalchemy import create_engine
     from sqlalchemy.pool import NullPool
 
     if not (uri := str(target)).startswith("sqlite:"):
         uri = f"sqlite:///{uri}"
     return create_engine(uri, poolclass=NullPool, **kwargs)
+
+
 @pytest.fixture
 def sqlite_engine(tmp_sqlite_db: Path) -> Iterator[Engine]:
     """A NullPool SQLAlchemy engine bound to the standard test database."""

--- a/py-polars/tests/unit/io/database/test_read.py
+++ b/py-polars/tests/unit/io/database/test_read.py
@@ -15,9 +15,8 @@ with suppress(ModuleNotFoundError):  # not available on windows
 import pyarrow as pa
 import pytest
 import sqlalchemy
-from sqlalchemy import Integer, MetaData, Table, create_engine, func, select, text
+from sqlalchemy import Integer, MetaData, Table, func, select, text
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import NullPool
 from sqlalchemy.sql.expression import cast as alchemy_cast
 
 import polars as pl
@@ -25,8 +24,11 @@ from polars._utils.various import parse_version
 from polars.exceptions import DuplicateError, UnsuitableSQLError
 from polars.io.database._arrow_registry import ARROW_DRIVER_REGISTRY
 from polars.testing import assert_frame_equal, assert_series_equal
+from tests.unit.io.database.conftest import create_sqlite_engine
 
 if TYPE_CHECKING:
+    from sqlalchemy.engine import Engine
+
     from polars._typing import (
         DbReadEngine,
         SchemaDefinition,
@@ -230,10 +232,9 @@ class ExceptionTestParams(NamedTuple):
         pytest.param(
             *DatabaseReadTestParams(
                 read_method="read_database",
-                connect_using=lambda path: create_engine(
-                    f"sqlite:///{path}",
+                connect_using=lambda path: create_sqlite_engine(
+                    path,
                     connect_args={"detect_types": sqlite3.PARSE_DECLTYPES},
-                    poolclass=NullPool,
                 ).connect(),
                 expected_dtypes={
                     "id": pl.Int64,
@@ -381,10 +382,9 @@ def test_read_database(
         pytest.param(
             *DatabaseReadTestParams(
                 read_method="read_database",
-                connect_using=lambda path: create_engine(
-                    f"sqlite:///{path}",
+                connect_using=lambda path: create_sqlite_engine(
+                    path,
                     connect_args={"detect_types": sqlite3.PARSE_DECLTYPES},
-                    poolclass=NullPool,
                 ).connect(),
                 expected_dtypes={
                     "id": pl.Int64,
@@ -504,14 +504,13 @@ def test_read_database_iter_batches(
     assert df_empty["date"].to_list() == []
 
 
-def test_read_database_alchemy_selectable(tmp_sqlite_db: Path) -> None:
+def test_read_database_alchemy_selectable(sqlite_engine: Engine) -> None:
     # various flavours of alchemy connection
-    alchemy_engine = create_engine(f"sqlite:///{tmp_sqlite_db}", poolclass=NullPool)
     with (
-        sessionmaker(bind=alchemy_engine)() as alchemy_session,
-        alchemy_engine.connect() as alchemy_conn,
+        sessionmaker(bind=sqlite_engine)() as alchemy_session,
+        sqlite_engine.connect() as alchemy_conn,
     ):
-        t = Table("test_data", MetaData(), autoload_with=alchemy_engine)
+        t = Table("test_data", MetaData(), autoload_with=sqlite_engine)
 
         # establish sqlalchemy "selectable" and validate usage
         selectable_query = select(
@@ -522,7 +521,7 @@ def test_read_database_alchemy_selectable(tmp_sqlite_db: Path) -> None:
 
         expected = pl.DataFrame({"year": [2021], "name": ["other"], "value": [-99.5]})
 
-        for conn in (alchemy_session, alchemy_engine, alchemy_conn):
+        for conn in (alchemy_session, sqlite_engine, alchemy_conn):
             assert_frame_equal(
                 pl.read_database(selectable_query, connection=conn),
                 expected,
@@ -540,12 +539,11 @@ def test_read_database_alchemy_selectable(tmp_sqlite_db: Path) -> None:
             assert_frame_equal(batches[0], expected)
 
 
-def test_read_database_alchemy_textclause(tmp_sqlite_db: Path) -> None:
+def test_read_database_alchemy_textclause(sqlite_engine: Engine) -> None:
     # various flavours of alchemy connection
-    alchemy_engine = create_engine(f"sqlite:///{tmp_sqlite_db}", poolclass=NullPool)
     with (
-        sessionmaker(bind=alchemy_engine)() as alchemy_session,
-        alchemy_engine.connect() as alchemy_conn,
+        sessionmaker(bind=sqlite_engine)() as alchemy_session,
+        sqlite_engine.connect() as alchemy_conn,
     ):
         # establish sqlalchemy "textclause" and validate usage
         textclause_query = text(
@@ -558,7 +556,7 @@ def test_read_database_alchemy_textclause(tmp_sqlite_db: Path) -> None:
 
         expected = pl.DataFrame({"year": [2021], "name": ["other"], "value": [-99.5]})
 
-        for conn in (alchemy_session, alchemy_engine, alchemy_conn):
+        for conn in (alchemy_session, sqlite_engine, alchemy_conn):
             assert_frame_equal(
                 pl.read_database(textclause_query, connection=conn),
                 expected,
@@ -585,13 +583,12 @@ def test_read_database_alchemy_textclause(tmp_sqlite_db: Path) -> None:
     ],
 )
 def test_read_database_parameterised(
-    param: str, param_value: Any, tmp_sqlite_db: Path
+    param: str, param_value: Any, tmp_sqlite_db: Path, sqlite_engine: Engine
 ) -> None:
     # raw cursor "execute" only takes positional params, alchemy cursor takes kwargs
-    alchemy_engine = create_engine(f"sqlite:///{tmp_sqlite_db}", poolclass=NullPool)
     with (
-        alchemy_engine.connect() as alchemy_conn,
-        sessionmaker(bind=alchemy_engine)() as alchemy_session,
+        sqlite_engine.connect() as alchemy_conn,
+        sessionmaker(bind=sqlite_engine)() as alchemy_session,
         closing(sqlite3.connect(tmp_sqlite_db)) as raw_conn,
     ):
         # establish parameterised queries and validate usage
@@ -604,7 +601,7 @@ def test_read_database_parameterised(
             {"year": [2021], "name": ["other"], "value": [-99.5]}
         )
 
-        for conn in (alchemy_session, alchemy_engine, alchemy_conn, raw_conn):
+        for conn in (alchemy_session, sqlite_engine, alchemy_conn, raw_conn):
             if conn is alchemy_session and param == "?":
                 continue  # alchemy session.execute() doesn't support positional params
             if parse_version(sqlalchemy.__version__) < (2, 0) and param == ":n":
@@ -679,7 +676,7 @@ def test_read_database_parameterised_adbc(
     ],
 )
 def test_read_database_parameterised_multiple(
-    params: list[str], param_value: Any, tmp_sqlite_db: Path
+    params: list[str], param_value: Any, tmp_sqlite_db: Path, sqlite_engine: Engine
 ) -> None:
     param_1, param_2 = params
     # establish parameterised queries and validate usage
@@ -691,13 +688,12 @@ def test_read_database_parameterised_multiple(
     expected_frame = pl.DataFrame({"year": [2020], "name": ["misc"], "value": [100.0]})
 
     # raw cursor "execute" only takes positional params, alchemy cursor takes kwargs
-    alchemy_engine = create_engine(f"sqlite:///{tmp_sqlite_db}", poolclass=NullPool)
     with (
-        alchemy_engine.connect() as alchemy_conn,
-        sessionmaker(bind=alchemy_engine)() as alchemy_session,
+        sqlite_engine.connect() as alchemy_conn,
+        sessionmaker(bind=sqlite_engine)() as alchemy_session,
         closing(sqlite3.connect(tmp_sqlite_db)) as raw_conn,
     ):
-        for conn in (alchemy_session, alchemy_engine, alchemy_conn, raw_conn):
+        for conn in (alchemy_session, sqlite_engine, alchemy_conn, raw_conn):
             if alchemy_session is conn and param_1 == "?":
                 continue  # alchemy session.execute() doesn't support positional params
             if parse_version(sqlalchemy.__version__) < (2, 0) and isinstance(
@@ -789,7 +785,7 @@ def test_read_database_parameterised_multiple_adbc(
 def test_read_database_uri_parameterised(
     param: str, param_value: Any, tmp_sqlite_db: Path
 ) -> None:
-    alchemy_engine = create_engine(f"sqlite:///{tmp_sqlite_db}")
+    alchemy_engine = create_sqlite_engine(tmp_sqlite_db)
     uri = alchemy_engine.url.render_as_string(hide_password=False)
     query = """
         SELECT CAST(STRFTIME('%Y',"date") AS INT) as "year", name, value
@@ -847,7 +843,7 @@ def test_read_database_uri_parameterised_multiple(
     params: list[str], param_value: Any, tmp_sqlite_db: Path
 ) -> None:
     param_1, param_2 = params
-    alchemy_engine = create_engine(f"sqlite:///{tmp_sqlite_db}")
+    alchemy_engine = create_sqlite_engine(tmp_sqlite_db)
     uri = alchemy_engine.url.render_as_string(hide_password=False)
     query = """
         SELECT CAST(STRFTIME('%Y',"date") AS INT) as "year", name, value
@@ -1146,11 +1142,11 @@ def test_read_database_exceptions(
         'SELECT name, value AS "name" FROM test_data',
     ],
 )
-def test_read_database_duplicate_column_error(tmp_sqlite_db: Path, query: str) -> None:
+def test_read_database_duplicate_column_error(
+    sqlite_engine: Engine, query: str
+) -> None:
     with (
-        create_engine(
-            f"sqlite:///{tmp_sqlite_db}", poolclass=NullPool
-        ).connect() as alchemy_conn,
+        sqlite_engine.connect() as alchemy_conn,
         pytest.raises(
             DuplicateError,
             match=r"column .+ appears more than once in the query/result cursor",
@@ -1171,7 +1167,7 @@ def test_read_database_cx_credentials(uri: str) -> None:
         pl.read_database_uri("SELECT * FROM data", uri=uri, engine="connectorx")
 
 
-def test_sqlalchemy_row_init(tmp_sqlite_db: Path) -> None:
+def test_sqlalchemy_row_init(sqlite_engine: Engine) -> None:
     expected_frame = pl.DataFrame(
         {
             "id": [1, 2],
@@ -1180,10 +1176,9 @@ def test_sqlalchemy_row_init(tmp_sqlite_db: Path) -> None:
             "date": ["2020-01-01", "2021-12-31"],
         }
     )
-    alchemy_engine = create_engine(f"sqlite:///{tmp_sqlite_db}", poolclass=NullPool)
     query = text("SELECT * FROM test_data ORDER BY name")
 
-    with alchemy_engine.connect() as conn:
+    with sqlite_engine.connect() as conn:
         # note: sqlalchemy `Row` is a NamedTuple-like object; it additionally has
         # a `_mapping` attribute that returns a `RowMapping` dict-like object. we
         # validate frame/series init from each flavour of query result.

--- a/py-polars/tests/unit/io/database/test_read.py
+++ b/py-polars/tests/unit/io/database/test_read.py
@@ -17,6 +17,7 @@ import pytest
 import sqlalchemy
 from sqlalchemy import Integer, MetaData, Table, create_engine, func, select, text
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import NullPool
 from sqlalchemy.sql.expression import cast as alchemy_cast
 
 import polars as pl
@@ -232,6 +233,7 @@ class ExceptionTestParams(NamedTuple):
                 connect_using=lambda path: create_engine(
                     f"sqlite:///{path}",
                     connect_args={"detect_types": sqlite3.PARSE_DECLTYPES},
+                    poolclass=NullPool,
                 ).connect(),
                 expected_dtypes={
                     "id": pl.Int64,
@@ -382,6 +384,7 @@ def test_read_database(
                 connect_using=lambda path: create_engine(
                     f"sqlite:///{path}",
                     connect_args={"detect_types": sqlite3.PARSE_DECLTYPES},
+                    poolclass=NullPool,
                 ).connect(),
                 expected_dtypes={
                     "id": pl.Int64,
@@ -503,7 +506,7 @@ def test_read_database_iter_batches(
 
 def test_read_database_alchemy_selectable(tmp_sqlite_db: Path) -> None:
     # various flavours of alchemy connection
-    alchemy_engine = create_engine(f"sqlite:///{tmp_sqlite_db}")
+    alchemy_engine = create_engine(f"sqlite:///{tmp_sqlite_db}", poolclass=NullPool)
     with (
         sessionmaker(bind=alchemy_engine)() as alchemy_session,
         alchemy_engine.connect() as alchemy_conn,
@@ -539,7 +542,7 @@ def test_read_database_alchemy_selectable(tmp_sqlite_db: Path) -> None:
 
 def test_read_database_alchemy_textclause(tmp_sqlite_db: Path) -> None:
     # various flavours of alchemy connection
-    alchemy_engine = create_engine(f"sqlite:///{tmp_sqlite_db}")
+    alchemy_engine = create_engine(f"sqlite:///{tmp_sqlite_db}", poolclass=NullPool)
     with (
         sessionmaker(bind=alchemy_engine)() as alchemy_session,
         alchemy_engine.connect() as alchemy_conn,
@@ -585,7 +588,7 @@ def test_read_database_parameterised(
     param: str, param_value: Any, tmp_sqlite_db: Path
 ) -> None:
     # raw cursor "execute" only takes positional params, alchemy cursor takes kwargs
-    alchemy_engine = create_engine(f"sqlite:///{tmp_sqlite_db}")
+    alchemy_engine = create_engine(f"sqlite:///{tmp_sqlite_db}", poolclass=NullPool)
     with (
         alchemy_engine.connect() as alchemy_conn,
         sessionmaker(bind=alchemy_engine)() as alchemy_session,
@@ -688,7 +691,7 @@ def test_read_database_parameterised_multiple(
     expected_frame = pl.DataFrame({"year": [2020], "name": ["misc"], "value": [100.0]})
 
     # raw cursor "execute" only takes positional params, alchemy cursor takes kwargs
-    alchemy_engine = create_engine(f"sqlite:///{tmp_sqlite_db}")
+    alchemy_engine = create_engine(f"sqlite:///{tmp_sqlite_db}", poolclass=NullPool)
     with (
         alchemy_engine.connect() as alchemy_conn,
         sessionmaker(bind=alchemy_engine)() as alchemy_session,
@@ -1145,7 +1148,9 @@ def test_read_database_exceptions(
 )
 def test_read_database_duplicate_column_error(tmp_sqlite_db: Path, query: str) -> None:
     with (
-        create_engine(f"sqlite:///{tmp_sqlite_db}").connect() as alchemy_conn,
+        create_engine(
+            f"sqlite:///{tmp_sqlite_db}", poolclass=NullPool
+        ).connect() as alchemy_conn,
         pytest.raises(
             DuplicateError,
             match=r"column .+ appears more than once in the query/result cursor",
@@ -1175,7 +1180,7 @@ def test_sqlalchemy_row_init(tmp_sqlite_db: Path) -> None:
             "date": ["2020-01-01", "2021-12-31"],
         }
     )
-    alchemy_engine = create_engine(f"sqlite:///{tmp_sqlite_db}")
+    alchemy_engine = create_engine(f"sqlite:///{tmp_sqlite_db}", poolclass=NullPool)
     query = text("SELECT * FROM test_data ORDER BY name")
 
     with alchemy_engine.connect() as conn:

--- a/py-polars/tests/unit/io/database/test_write.py
+++ b/py-polars/tests/unit/io/database/test_write.py
@@ -4,15 +4,13 @@ import sys
 from typing import TYPE_CHECKING, Any
 
 import pytest
-from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
-from sqlalchemy.pool import NullPool
 
 import polars as pl
 from polars._utils.various import parse_version
 from polars.io.database._utils import _open_adbc_connection
 from polars.testing import assert_frame_equal
-from tests.unit.io.database.conftest import close_connections
+from tests.unit.io.database.conftest import close_connections, create_sqlite_engine
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -22,7 +20,7 @@ if TYPE_CHECKING:
 
 def _read_via_uri(query: str, uri: str) -> pl.DataFrame:
     """Read a query result via a throwaway engine, disposing it afterwards."""
-    engine = create_engine(uri)
+    engine = create_sqlite_engine(uri)
     try:
         return pl.read_database(query=query, connection=engine)
     finally:
@@ -61,7 +59,7 @@ class TestWriteDatabase:
         if uri_connection:
             return uri
         elif engine == "sqlalchemy":
-            return create_engine(uri)
+            return create_sqlite_engine(uri)
         else:
             return _open_adbc_connection(uri)
 
@@ -300,7 +298,7 @@ def test_write_database_using_sa_session(tmp_path: str) -> None:
     )
     table_name = "test_sa_session"
     test_db_uri = f"sqlite:///{tmp_path}/test_sa_session.db"
-    engine = create_engine(test_db_uri, poolclass=NullPool)
+    engine = create_sqlite_engine(test_db_uri)
     with Session(engine) as session:
         df.write_database(table_name, session)
         session.commit()
@@ -325,7 +323,7 @@ def test_write_database_sa_rollback(tmp_path: str, pass_connection: bool) -> Non
     )
     table_name = "test_sa_rollback"
     test_db_uri = f"sqlite:///{tmp_path}/test_sa_rollback.db"
-    engine = create_engine(test_db_uri, poolclass=NullPool)
+    engine = create_sqlite_engine(test_db_uri)
     with Session(engine) as session:
         if pass_connection:
             conn = session.connection()
@@ -355,7 +353,7 @@ def test_write_database_sa_commit(tmp_path: str, pass_connection: bool) -> None:
     )
     table_name = "test_sa_commit"
     test_db_uri = f"sqlite:///{tmp_path}/test_sa_commit.db"
-    engine = create_engine(test_db_uri, poolclass=NullPool)
+    engine = create_sqlite_engine(test_db_uri)
     with Session(engine) as session:
         if pass_connection:
             conn = session.connection()

--- a/py-polars/tests/unit/io/database/test_write.py
+++ b/py-polars/tests/unit/io/database/test_write.py
@@ -12,11 +12,21 @@ import polars as pl
 from polars._utils.various import parse_version
 from polars.io.database._utils import _open_adbc_connection
 from polars.testing import assert_frame_equal
+from tests.unit.io.database.conftest import close_connections
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from polars._typing import DbWriteEngine
+
+
+def _read_via_uri(query: str, uri: str) -> pl.DataFrame:
+    """Read a query result via a throwaway engine, disposing it afterwards."""
+    engine = create_engine(uri)
+    try:
+        return pl.read_database(query=query, connection=engine)
+    finally:
+        engine.dispose()
 
 
 @pytest.mark.write_disk
@@ -80,14 +90,10 @@ class TestWriteDatabase:
             )
             == 2
         )
-        result = pl.read_database(
-            query=f"SELECT * FROM {table_name}",
-            connection=create_engine(test_db_uri),
-        )
+        result = _read_via_uri(f"SELECT * FROM {table_name}", test_db_uri)
         assert_frame_equal(result, df)
 
-        if hasattr(conn, "close"):
-            conn.close()
+        close_connections(conn)
 
     def test_write_database_append_replace(
         self, engine: DbWriteEngine, uri_connection: bool, tmp_path: Path
@@ -131,10 +137,7 @@ class TestWriteDatabase:
             )
             == 3
         )
-        result = pl.read_database(
-            query=f"SELECT * FROM {table_name}",
-            connection=create_engine(test_db_uri),
-        )
+        result = _read_via_uri(f"SELECT * FROM {table_name}", test_db_uri)
         assert_frame_equal(result, df)
 
         assert (
@@ -146,17 +149,13 @@ class TestWriteDatabase:
             )
             == 2
         )
-        result = pl.read_database(
-            query=f"SELECT * FROM {table_name}",
-            connection=create_engine(test_db_uri),
-        )
+        result = _read_via_uri(f"SELECT * FROM {table_name}", test_db_uri)
         assert_frame_equal(result, pl.concat([df, df[:2]]))
 
         if engine == "adbc" and not uri_connection:
             assert conn._closed is False
 
-        if hasattr(conn, "close"):
-            conn.close()
+        close_connections(conn)
 
     def test_write_database_append_creates_missing_table(
         self, engine: DbWriteEngine, uri_connection: bool, tmp_path: Path
@@ -193,14 +192,10 @@ class TestWriteDatabase:
             )
             == 3
         )
-        result = pl.read_database(
-            query=f"SELECT * FROM {table_name}",
-            connection=create_engine(test_db_uri),
-        )
+        result = _read_via_uri(f"SELECT * FROM {table_name}", test_db_uri)
         assert_frame_equal(result, df)
 
-        if hasattr(conn, "close"):
-            conn.close()
+        close_connections(conn)
 
     def test_write_database_create_quoted_tablename(
         self, engine: DbWriteEngine, uri_connection: bool, tmp_path: Path
@@ -237,17 +232,13 @@ class TestWriteDatabase:
             )
             == 3
         )
-        result = pl.read_database(
-            query=f"SELECT * FROM {qualified_table_name}",
-            connection=create_engine(test_db_uri),
-        )
+        result = _read_via_uri(f"SELECT * FROM {qualified_table_name}", test_db_uri)
         assert_frame_equal(result, df)
 
         if engine == "adbc" and not uri_connection:
             assert conn._closed is False
 
-        if hasattr(conn, "close"):
-            conn.close()
+        close_connections(conn)
 
     def test_write_database_errors(
         self, engine: DbWriteEngine, uri_connection: bool, tmp_path: Path
@@ -410,5 +401,4 @@ def test_write_database_adbc_temporary_table() -> None:
     actual_temp_table_create_sql = temp_tbl_sql_df["sql"][0]
     assert expected_temp_table_create_sql == actual_temp_table_create_sql
 
-    if hasattr(conn, "close"):
-        conn.close()
+    close_connections(conn)

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -123,6 +123,33 @@ with warnings.catch_warnings():
     from pyiceberg.io.pyarrow import schema_to_pyarrow
 
 
+@pytest.fixture(autouse=True)
+def sqlcatalog_uses_null_pool_connections(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    # note: SqlCatalog is sqlite-backed, and pyiceberg builds its engine with
+    # a SingletonThreadPool that can raise a ResourceWarning on test shutdown;
+    # we ensure it uses a NullPool instead, resolving the connection "leak"
+    import pyiceberg.catalog.sql as pyiceberg_sql
+    from sqlalchemy.pool import NullPool
+
+    tmp_path = tmp_path_factory.mktemp("iceberg_catalogs")
+    original_create_engine = pyiceberg_sql.create_engine
+    counter = itertools.count()
+
+    def create_engine(url: str, **kwargs: Any) -> Any:
+        if url == "sqlite:///:memory:":
+            # need to use a file-backed catalog, otherwise NullPool connections
+            # will be working with different in-memory databases on each call
+            url = f"sqlite:///{tmp_path}/catalog_{next(counter)}.db"
+
+        kwargs["poolclass"] = NullPool
+        return original_create_engine(url, **kwargs)
+
+    monkeypatch.setattr(pyiceberg_sql, "create_engine", create_engine)
+
+
 def new_iceberg_scan_resolver(
     source: str | pyiceberg.table.Table,
 ) -> IcebergScanResolver:


### PR DESCRIPTION
Fully closes #28065 (builds on #28066).
Also closes #20296.

---

There were still some 20+ `ResourceWarning` leaks remaining, disguised by the "filterwarnings" entry in `pyproject.toml`. This PR fixes **_all_** remaining leaks and removes the "filterwarnings" entry. 

Additional use of `NullPool` helps, as it ensures that closing the connection does not simply return it to the default `QueuePool` (where it would continue to exist, and potentially leak).