### PR TITLE
chore(python): Update `mypy` to the new `2.x` release

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -125,6 +125,7 @@ bad-return = false
 
 [tool.mypy]
 files = ["src/polars", "tests"]
+num_workers = 4
 strict = true
 enable_error_code = [
   "redundant-expr",

--- a/py-polars/requirements-lint.txt
+++ b/py-polars/requirements-lint.txt
@@ -1,4 +1,4 @@
-mypy[faster-cache]==1.19.1
+mypy[faster-cache]==2.1.0
 pyrefly==1.0.0
 ruff==0.15.0
 typos==1.43.3

--- a/py-polars/src/polars/_utils/construction/dataframe.py
+++ b/py-polars/src/polars/_utils/construction/dataframe.py
@@ -698,7 +698,7 @@ def _sequence_of_tuple_to_pydf(
 @_sequence_to_pydf_dispatcher.register(Mapping)
 @_sequence_to_pydf_dispatcher.register(dict)
 def _sequence_of_dict_to_pydf(
-    first_element: dict[str, Any],  # noqa: ARG001
+    first_element: Mapping[str, Any],  # noqa: ARG001
     data: Sequence[Any],
     schema: SchemaDefinition | None,
     *,

--- a/py-polars/src/polars/io/cloud/credential_provider/_providers.py
+++ b/py-polars/src/polars/io/cloud/credential_provider/_providers.py
@@ -221,6 +221,8 @@ class CredentialProviderAWS(CachingCredentialProvider):
         return creds_dict, expiry
 
     def _finish_assume_role(self, session: Any) -> CredentialProviderFunctionReturn:
+        assert self.assume_role is not None
+
         client = session.client("sts")
 
         sts_response = client.assume_role(**self.assume_role)

--- a/py-polars/src/polars/selectors.py
+++ b/py-polars/src/polars/selectors.py
@@ -393,7 +393,7 @@ class Selector(Expr):
                     concrete_dtypes += [pldt.String()]
                 elif dt is bytes:
                     concrete_dtypes += [pldt.Binary()]
-                elif dt is object:
+                elif dt is builtins.object:
                     selectors += [object()]
                 elif dt is NoneType:
                     concrete_dtypes += [pldt.Null()]

--- a/py-polars/tests/unit/io/test_write.py
+++ b/py-polars/tests/unit/io/test_write.py
@@ -97,7 +97,7 @@ def test_write_with_storage_options_22873(tmp_path: Path) -> None:
             with pytest.raises(
                 TypeError, match="unexpected keyword argument 'storage_options'"
             ):
-                func(df, path, storage_options={"test": "1"})  # type: ignore[operator]
+                func(df, path, storage_options={"test": "1"})  # type: ignore[call-overload]
 
             continue
 


### PR DESCRIPTION
The newer `mypy 2.x` series of releases [support](https://pydevtools.com/blog/mypy-2-0-parallel-type-checking/) basic parallelism.
Doesn't get close to `pyrefly`, but it _is_ still about a ~3x speedup over `1.x` for us 👍 

## Timings

With a cold cache, benchmarking against `py-polars/` shows the following:

| Library | Version | Extra config | Time |
|---:|:---|:---|---:|
| **mypy** 🐍  | 1.19.1  |  | 27.3s |
| **mypy** 🐍 | 2.1.0  | `num_workers = 4` | 9.5s |
| **pyrefly** 🦀  | 1.0.0  |  | 1.1s |