### PR TITLE
docs(python): Add polars-bio to community plugins list

### DIFF
--- a/docs/source/user-guide/plugins/index.md
+++ b/docs/source/user-guide/plugins/index.md
@@ -33,6 +33,11 @@ Here is a curated (non-exhaustive) list of community-implemented plugins.
   the H3 discrete global grid system, so you can index points and geometries to hexagons directly in
   Polars.
 
+### Bioinformatics
+
+- [polars-bio](https://github.com/biodatageeks/polars-bio) Blazing-fast genomic interval operations
+  on Polars DataFrames, with support for overlap, closest, and window-based joins using Apache Arrow.
+
 ## Other material
 
 - [Ritchie Vink - Keynote on Polars Plugins](https://youtu.be/jKW-CBV7NUM)

--- a/docs/source/user-guide/plugins/index.md
+++ b/docs/source/user-guide/plugins/index.md
@@ -36,7 +36,8 @@ Here is a curated (non-exhaustive) list of community-implemented plugins.
 ### Bioinformatics
 
 - [polars-bio](https://github.com/biodatageeks/polars-bio) Blazing-fast genomic interval operations
-  on Polars DataFrames, with support for overlap, closest, and window-based joins using Apache Arrow.
+  on Polars DataFrames, with support for overlap, closest, and window-based joins using Apache
+  Arrow.
 
 ## Other material
 


### PR DESCRIPTION
Adds polars-bio to the community plugins page under a new Bioinformatics section. Saw the issue from J-Wall and have been using it for some genomic interval work — seems like a natural fit for the list.

Closes #28081