### PR TITLE
fix(python): Avoid panic constructing Series from unaligned numpy arrays

### DIFF
--- a/py-polars/src/polars/_utils/construction/series.py
+++ b/py-polars/src/polars/_utils/construction/series.py
@@ -506,7 +506,9 @@ def numpy_to_pyseries(
     if not values.dtype.isnative:
         # Only native byte order is supported, so swap to a native-order copy.
         values = values.astype(values.dtype.newbyteorder("="))
-    values = np.ascontiguousarray(values)
+    # Require aligned, C-contiguous, >=1d; an unaligned view would otherwise panic.
+    values = np.atleast_1d(values)
+    values = np.require(values, requirements=["A", "C"])
 
     if values.ndim == 1:
         values, dtype = numpy_values_and_dtype(values)

--- a/py-polars/tests/unit/interop/numpy/test_from_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_from_numpy_df.py
@@ -179,3 +179,16 @@ def test_dataframe_numpy_records_mixed_dims() -> None:
         {"arr1d": 2, "arr2d": [3.0, 4.0]},
         {"arr1d": 3, "arr2d": [5.0, 6.0]},
     ]
+
+
+def test_from_numpy_unaligned_structured_array_27794() -> None:
+    # Unaligned (packed) structured-array fields are strided views that may also
+    # be unaligned; constructing a DataFrame from them must not panic.
+    for buf, dtype in [
+        (b"012", [("a", "u1"), ("b", "u2")]),  # single row, unaligned
+        (b"012345", [("a", "u1"), ("b", "u2")]),  # multiple rows, unaligned
+    ]:
+        arr = np.frombuffer(buf, dtype=dtype)
+        df = pl.DataFrame(arr)
+        assert df["a"].to_list() == arr["a"].tolist()
+        assert df["b"].to_list() == arr["b"].tolist()

--- a/py-polars/tests/unit/interop/numpy/test_from_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_from_numpy_series.py
@@ -108,3 +108,14 @@ def test_from_numpy_non_native_byteorder_28174(dtype: str) -> None:
 
     df = pl.DataFrame(arr)
     assert df.to_series().to_list() == list(range(5))
+
+
+def test_from_numpy_unaligned_ndarray_view_27794() -> None:
+    # A sliced-then-viewed ndarray can be C-contiguous but unaligned; building a
+    # Series from it must not panic.
+    a = np.array([1, 2, 3, 4, 5, 6], dtype="u1")
+    view = a[1:5].view("u2")
+    assert view.flags["C_CONTIGUOUS"]
+    assert not view.flags["ALIGNED"]
+    s = pl.Series(view)
+    assert s.to_list() == view.tolist()


### PR DESCRIPTION
Closes #27794.

Constructing a `DataFrame` from a NumPy structured array panics when a field is not aligned/contiguous (e.g. a packed dtype, or a sliced/strided view):

```python
import numpy as np, polars as pl

arr = np.array([(1, 2.0)], dtype=np.dtype([("a", "i4"), ("b", "f8")], align=False))
pl.DataFrame(arr)   # PanicException
```

Accessing a single field of a structured array (`data[name]`) yields a strided/possibly-unaligned view, which the zero-copy `Series` constructor can't take. Wrap each field with `np.require(..., requirements=["A", "C"])` so it's an aligned, contiguous array (copying only when needed) before building the Series.

This takes the same approach as #27808, which was closed under the first-time-contributor policy.
