### PR TITLE
fix: Fix panic on scan_parquet filter of fixed-size binary column

### DIFF
--- a/crates/polars-arrow/src/array/fixed_size_binary/mutable.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/mutable.rs
@@ -112,8 +112,8 @@ impl MutableFixedSizeBinaryArray {
                 if self.size != bytes.len() {
                     polars_bail!(
                         ComputeError:
-                        "FixedSizeBinaryArray requires every item to be of its length \
-                        (self.size: {}, bytes.len(): {})",
+                        "MutableFixedSizeBinaryArray(row_width: {}): attempted to push \
+                        row with {} bytes",
                         self.size, bytes.len(),
                     )
                 }

--- a/crates/polars-arrow/src/array/fixed_size_binary/mutable.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/mutable.rs
@@ -110,7 +110,12 @@ impl MutableFixedSizeBinaryArray {
             Some(bytes) => {
                 let bytes = bytes.as_ref();
                 if self.size != bytes.len() {
-                    polars_bail!(ComputeError: "FixedSizeBinaryArray requires every item to be of its length")
+                    polars_bail!(
+                        ComputeError:
+                        "FixedSizeBinaryArray requires every item to be of its length \
+                        (self.size: {}, bytes.len(): {})",
+                        self.size, bytes.len(),
+                    )
                 }
                 self.values.extend_from_slice(bytes);
 

--- a/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary.rs
@@ -1,4 +1,4 @@
-use arrow::array::{FixedSizeBinaryArray, Splitable};
+use arrow::array::{BinaryViewArray, FixedSizeBinaryArray, Splitable, View};
 use arrow::bitmap::{Bitmap, BitmapBuilder};
 use arrow::datatypes::ArrowDataType;
 use arrow::pushable::Pushable;
@@ -17,6 +17,7 @@ use crate::parquet::encoding::hybrid_rle::{HybridRleChunk, HybridRleDecoder};
 use crate::parquet::encoding::{Encoding, hybrid_rle};
 use crate::parquet::error::{ParquetError, ParquetResult};
 use crate::parquet::page::{DataPage, DictPage, split_buffer};
+use crate::read::PredicateFilter;
 use crate::read::deserialize::dictionary_encoded::constrain_page_validity;
 use crate::read::deserialize::utils::{self, Decoded};
 use crate::read::expr::{ParquetScalar, SpecializedParquetColumnExpr};
@@ -542,6 +543,21 @@ impl Decoder for BinaryDecoder {
             target.into_bytes_buffer(),
             None,
         ))
+    }
+
+    fn evaluate_dict_predicate(
+        &self,
+        dict: &Self::Dict,
+        predicate: &PredicateFilter,
+    ) -> ParquetResult<Bitmap> {
+        // Dispatch to this codepath disabled from crates/polars-stream/src/nodes/io_sources/parquet/init.rs
+        //
+        // This would panic attempting to create a polars DataType::Binary Series from a
+        // dyn Array of type ArrowDataType::FixedSizeBinary(_).
+        //
+        // Performant fix would involve refactoring this (BinaryDecoder) to also store Views
+        // in the intermediate state, and only when a predicate is being applied on this column.
+        unimplemented!("parquet: fixed-size binary prefilter");
     }
 
     fn evaluate_predicate(

--- a/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary.rs
@@ -1,4 +1,4 @@
-use arrow::array::{BinaryViewArray, FixedSizeBinaryArray, Splitable, View};
+use arrow::array::{FixedSizeBinaryArray, Splitable};
 use arrow::bitmap::{Bitmap, BitmapBuilder};
 use arrow::datatypes::ArrowDataType;
 use arrow::pushable::Pushable;
@@ -547,8 +547,8 @@ impl Decoder for BinaryDecoder {
 
     fn evaluate_dict_predicate(
         &self,
-        dict: &Self::Dict,
-        predicate: &PredicateFilter,
+        _dict: &Self::Dict,
+        _predicate: &PredicateFilter,
     ) -> ParquetResult<Bitmap> {
         // Dispatch to this codepath disabled from crates/polars-stream/src/nodes/io_sources/parquet/init.rs
         //

--- a/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary.rs
@@ -556,7 +556,7 @@ impl Decoder for BinaryDecoder {
         // dyn Array of type ArrowDataType::FixedSizeBinary(_) (via Series::from_chunk_and_dtype
         // in predicate.evaluate_mut()).
         //
-        // Performant fix would involve refactoring this (BinaryDecoder) to also store Views
+        // TODO: Performant fix would involve refactoring this (BinaryDecoder) to also store Views
         // in the intermediate state, and only when a predicate is being applied on this column.
         unimplemented!("parquet: fixed-size binary prefilter");
     }

--- a/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary.rs
@@ -553,7 +553,8 @@ impl Decoder for BinaryDecoder {
         // Dispatch to this codepath disabled from crates/polars-stream/src/nodes/io_sources/parquet/init.rs
         //
         // This would panic attempting to create a polars DataType::Binary Series from a
-        // dyn Array of type ArrowDataType::FixedSizeBinary(_).
+        // dyn Array of type ArrowDataType::FixedSizeBinary(_) (via Series::from_chunk_and_dtype
+        // in predicate.evaluate_mut()).
         //
         // Performant fix would involve refactoring this (BinaryDecoder) to also store Views
         // in the intermediate state, and only when a predicate is being applied on this column.

--- a/crates/polars-parquet/src/arrow/read/statistics.rs
+++ b/crates/polars-parquet/src/arrow/read/statistics.rs
@@ -523,10 +523,21 @@ pub fn deserialize_all(
                 (D::Utf8View, _) => rmap!(@string),
 
                 (D::FixedSizeBinary(width), _) => {
+                    struct FixedSizeBinaryArray2;
+
+                    impl FixedSizeBinaryArray2 {
+                        fn with_capacity(
+                            row_groups_len: usize,
+                            row_width: usize,
+                        ) -> MutableFixedSizeBinaryArray {
+                            MutableFixedSizeBinaryArray::with_capacity(row_width, row_groups_len)
+                        }
+                    }
+
                     rmap!(
                         expect_fixedlen,
                         |x: Option<Vec<u8>>| ParquetResult::Ok(x),
-                        MutableFixedSizeBinaryArray,
+                        FixedSizeBinaryArray2,
                         *width
                     )
                 },

--- a/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
@@ -354,19 +354,16 @@ impl ParquetReadImpl {
             )
         }
 
-        let allow_column_predicates = predicate
-            .as_ref()
-            .is_some_and(|x| x.column_predicates.is_sumwise_complete)
-            && row_index.is_none()
-            && !projected_arrow_fields.iter().any(|x| {
-                x.arrow_field().dtype().is_nested()
-                    || matches!(x, ArrowFieldProjection::Mapped { .. })
-            })
-            && !predicate.as_ref().is_none_or(|p| {
-                projected_arrow_fields.iter().any(|f| {
+        let allow_column_predicates = predicate.as_ref().is_some_and(|p| {
+            p.column_predicates.is_sumwise_complete
+                && !projected_arrow_fields.iter().any(|f| {
                     matches!(f.arrow_field().dtype(), ArrowDataType::FixedSizeBinary(_))
                         && p.column_predicates.predicates.contains_key(f.output_name())
                 })
+        }) && row_index.is_none()
+            && !projected_arrow_fields.iter().any(|x| {
+                x.arrow_field().dtype().is_nested()
+                    || matches!(x, ArrowFieldProjection::Mapped { .. })
             });
 
         RowGroupDecoder {

--- a/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use arrow::datatypes::ArrowDataType;
 use polars_async::executor;
 use polars_core::frame::DataFrame;
 use polars_core::runtime::ASYNC;
@@ -360,6 +361,12 @@ impl ParquetReadImpl {
             && !projected_arrow_fields.iter().any(|x| {
                 x.arrow_field().dtype().is_nested()
                     || matches!(x, ArrowFieldProjection::Mapped { .. })
+            })
+            && !predicate.as_ref().is_none_or(|p| {
+                projected_arrow_fields.iter().any(|f| {
+                    matches!(f.arrow_field().dtype(), ArrowDataType::FixedSizeBinary(_))
+                        && p.column_predicates.predicates.contains_key(f.output_name())
+                })
             });
 
         RowGroupDecoder {

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -4375,3 +4375,23 @@ def test_multi_file_resolve_metadata_level(
     lf = pl.scan_parquet(tmp_path / "part_*.parquet")
     assert lf.collect().height == 8
     assert f"ESTIMATED ROWS: {expected_est}" in lf.explain(optimized=True)
+
+
+def test_parquet_prefilter_fixed_size_binary_27781() -> None:
+    val = b"0x004521bdf6bf838e71c0b977678adae368c3ac5d5c665cef09cbd61a9d591d3f"
+
+    table = pa.table(
+        {
+            "market": pa.array([val, val], type=pa.binary(66)),
+            "asset_id": ["abc", "def"],
+        }
+    )
+
+    f = io.BytesIO()
+    pq.write_table(table, f)
+    f.seek(0)
+
+    assert_frame_equal(
+        pl.scan_parquet(f).filter(pl.col("market") == val).collect(),
+        pl.DataFrame(table),
+    )


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/27781#issuecomment-4821932740

---

* Fixed: `rmap!(` macro panic due to flipped argument order
* (2) However, after fixing the above, we still ended up panicking, from 2 separate places  in the Parquet decode:
  * `evaluate_dict_predicate()`
  * `unspecialized_predicate_decode()`

To address 2), I've simply just disabled prefiltering if a predicate is being applied to a fixed-size binary column (a fix that keeps prefiltering on would be much more involved).
 