### PR TITLE
feat(rust): Add stopwatch-style duration string parser (towards #7397)

### DIFF
--- a/crates/polars-time/src/chunkedarray/string/mod.rs
+++ b/crates/polars-time/src/chunkedarray/string/mod.rs
@@ -1,7 +1,11 @@
 pub mod infer;
 use chrono::DateTime;
+#[cfg(feature = "dtype-duration")]
+mod parse_duration;
 mod patterns;
 mod strptime;
+#[cfg(feature = "dtype-duration")]
+use parse_duration::parse_duration_string;
 pub use patterns::Pattern;
 #[cfg(feature = "dtype-time")]
 use polars_core::chunked_array::temporal::time_to_time64ns;
@@ -341,6 +345,34 @@ pub trait StringMethods: AsString {
                 _ => Ok(dt),
             }
         }
+    }
+
+    #[cfg(feature = "dtype-duration")]
+    /// Parse string values into a [`DurationChunked`] using a stopwatch-style
+    /// colon format such as `"104:00:00"` or `"-80:00.500"`.
+    ///
+    /// `fmt` uses the specifiers documented on `parse_duration_string`
+    /// (`%d`, `%H`, `%M`, `%S`, `%f`, `%.f`). Unlike time parsing, the fields
+    /// are not range-checked, so values such as `80` minutes or `104` hours are
+    /// accepted.
+    fn as_duration(
+        &self,
+        fmt: Option<&str>,
+        tu: TimeUnit,
+        use_cache: bool,
+    ) -> PolarsResult<DurationChunked> {
+        let string_ca = self.as_string();
+        let Some(fmt) = fmt else {
+            polars_bail!(ComputeError: "`format` must be provided when parsing strings to Duration")
+        };
+        let use_cache = use_cache && string_ca.len() > 50;
+
+        let mut convert = LruCachedFunc::new(
+            |s: &str| parse_duration_string(s, fmt, tu),
+            (string_ca.len() as f64).sqrt() as usize,
+        );
+        let ca = unary_elementwise(string_ca, |opt_s| convert.eval(opt_s?, use_cache));
+        Ok(ca.with_name(string_ca.name().clone()).into_duration(tu))
     }
 }
 

--- a/crates/polars-time/src/chunkedarray/string/parse_duration.rs
+++ b/crates/polars-time/src/chunkedarray/string/parse_duration.rs
@@ -1,0 +1,229 @@
+use polars_core::datatypes::TimeUnit;
+
+const NS_PER_SECOND: i128 = 1_000_000_000;
+const NS_PER_MINUTE: i128 = 60 * NS_PER_SECOND;
+const NS_PER_HOUR: i128 = 60 * NS_PER_MINUTE;
+const NS_PER_DAY: i128 = 24 * NS_PER_HOUR;
+
+/// Read a run of ASCII digits starting at `pos`, returning
+/// `(value, new_pos, n_digits)`. Returns `None` if no digit is found or the
+/// value overflows an `i128`.
+fn read_uint(bytes: &[u8], mut pos: usize) -> Option<(i128, usize, usize)> {
+    let start = pos;
+    let mut val: i128 = 0;
+    while pos < bytes.len() && bytes[pos].is_ascii_digit() {
+        val = val.checked_mul(10)?;
+        val = val.checked_add((bytes[pos] - b'0') as i128)?;
+        pos += 1;
+    }
+    if pos == start {
+        return None;
+    }
+    Some((val, pos, pos - start))
+}
+
+/// Parse a "stopwatch"/colon-style duration string into an integer number of
+/// `time_unit`s, according to `fmt`.
+///
+/// Unlike chrono's time parsing, fields are **not** range-checked, so elapsed
+/// time values such as `80` minutes or `104` hours parse successfully. This
+/// makes it suitable for parsing stopwatch / duration strings such as
+/// `"80:00"`, `"-04:00:00"` or `"104:00:00.250"`.
+///
+/// Supported format specifiers:
+/// * `%d` - days
+/// * `%H` - hours
+/// * `%M` - minutes
+/// * `%S` - whole seconds
+/// * `%f` - fractional seconds digits (the value is right-padded to nanoseconds;
+///   extra digits beyond nanosecond resolution are truncated)
+/// * `%.f` - an optional `.` followed by fractional seconds (like chrono)
+/// * `%%` - a literal `%`
+///
+/// A leading `-` or `+` in the input sets the sign of the whole duration. Any
+/// other character in `fmt` must match the input literally. The entire input
+/// must be consumed, otherwise `None` is returned.
+pub(super) fn parse_duration_string(input: &str, fmt: &str, time_unit: TimeUnit) -> Option<i64> {
+    let bytes = input.as_bytes();
+    let fbytes = fmt.as_bytes();
+    let mut ipos = 0usize;
+    let mut fpos = 0usize;
+
+    // Optional leading sign applies to the whole duration.
+    let negative = match bytes.first() {
+        Some(b'-') => {
+            ipos += 1;
+            true
+        },
+        Some(b'+') => {
+            ipos += 1;
+            false
+        },
+        _ => false,
+    };
+
+    let mut total_ns: i128 = 0;
+
+    while fpos < fbytes.len() {
+        if fbytes[fpos] == b'%' {
+            // A specifier must follow the '%'.
+            let spec = *fbytes.get(fpos + 1)?;
+            match spec {
+                b'd' | b'H' | b'M' | b'S' => {
+                    let (val, npos, _) = read_uint(bytes, ipos)?;
+                    let scale = match spec {
+                        b'd' => NS_PER_DAY,
+                        b'H' => NS_PER_HOUR,
+                        b'M' => NS_PER_MINUTE,
+                        b'S' => NS_PER_SECOND,
+                        _ => unreachable!(),
+                    };
+                    total_ns = total_ns.checked_add(val.checked_mul(scale)?)?;
+                    ipos = npos;
+                    fpos += 2;
+                },
+                b'f' => {
+                    let (frac_ns, npos) = read_fraction(bytes, ipos)?;
+                    total_ns = total_ns.checked_add(frac_ns)?;
+                    ipos = npos;
+                    fpos += 2;
+                },
+                b'.' => {
+                    // `%.f`: an optional '.' followed by fractional seconds.
+                    if *fbytes.get(fpos + 2)? != b'f' {
+                        return None;
+                    }
+                    if ipos < bytes.len() && bytes[ipos] == b'.' {
+                        ipos += 1;
+                        let (frac_ns, npos) = read_fraction(bytes, ipos)?;
+                        total_ns = total_ns.checked_add(frac_ns)?;
+                        ipos = npos;
+                    }
+                    fpos += 3;
+                },
+                b'%' => {
+                    if ipos >= bytes.len() || bytes[ipos] != b'%' {
+                        return None;
+                    }
+                    ipos += 1;
+                    fpos += 2;
+                },
+                _ => return None,
+            }
+        } else {
+            // Literal character: must match the input exactly.
+            if ipos >= bytes.len() || bytes[ipos] != fbytes[fpos] {
+                return None;
+            }
+            ipos += 1;
+            fpos += 1;
+        }
+    }
+
+    // The whole input must have been consumed.
+    if ipos != bytes.len() {
+        return None;
+    }
+
+    let total = match time_unit {
+        TimeUnit::Nanoseconds => total_ns,
+        TimeUnit::Microseconds => total_ns / 1_000,
+        TimeUnit::Milliseconds => total_ns / 1_000_000,
+    };
+    let total = if negative { -total } else { total };
+    i64::try_from(total).ok()
+}
+
+/// Read fractional-second digits and return their value in nanoseconds along
+/// with the new input position. Digits beyond nanosecond resolution (9 digits)
+/// are consumed but truncated.
+fn read_fraction(bytes: &[u8], pos: usize) -> Option<(i128, usize)> {
+    let (_, npos, n_digits) = read_uint(bytes, pos)?;
+    let mut frac_ns: i128 = 0;
+    let mut scale: i128 = 100_000_000; // value of the first fractional digit in ns
+    for &b in &bytes[pos..npos] {
+        if scale == 0 {
+            break;
+        }
+        frac_ns += (b - b'0') as i128 * scale;
+        scale /= 10;
+    }
+    debug_assert!(n_digits >= 1);
+    Some((frac_ns, npos))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const NS: TimeUnit = TimeUnit::Nanoseconds;
+    const US: TimeUnit = TimeUnit::Microseconds;
+    const MS: TimeUnit = TimeUnit::Milliseconds;
+
+    #[test]
+    fn parses_issue_examples() {
+        // "80:00" meaning 80 minutes (format %M:%S).
+        assert_eq!(
+            parse_duration_string("80:00", "%M:%S", NS),
+            Some(80 * 60 * 1_000_000_000)
+        );
+        // "-04:00:00" minus 4 hours.
+        assert_eq!(
+            parse_duration_string("-04:00:00", "%H:%M:%S", NS),
+            Some(-4 * 3_600 * 1_000_000_000)
+        );
+        // "104:00:00" -> 104 hours (note: not range-checked).
+        assert_eq!(
+            parse_duration_string("104:00:00", "%H:%M:%S", NS),
+            Some(104 * 3_600 * 1_000_000_000)
+        );
+    }
+
+    #[test]
+    fn fractional_seconds() {
+        // "80:00.000" should parse with an optional fraction.
+        assert_eq!(
+            parse_duration_string("80:00.000", "%M:%S%.f", NS),
+            Some(80 * 60 * 1_000_000_000)
+        );
+        assert_eq!(
+            parse_duration_string("00:00.250", "%M:%S%.f", MS),
+            Some(250)
+        );
+        // %f without a leading dot (standalone fractional seconds).
+        assert_eq!(parse_duration_string("250", "%f", MS), Some(250));
+        // Sub-nanosecond digits are truncated, not rejected.
+        assert_eq!(
+            parse_duration_string("1.1234567899", "%S%.f", NS),
+            Some(1_123_456_789)
+        );
+    }
+
+    #[test]
+    fn time_units() {
+        assert_eq!(parse_duration_string("1", "%S", NS), Some(1_000_000_000));
+        assert_eq!(parse_duration_string("1", "%S", US), Some(1_000_000));
+        assert_eq!(parse_duration_string("1", "%S", MS), Some(1_000));
+    }
+
+    #[test]
+    fn days_and_signs() {
+        assert_eq!(
+            parse_duration_string("2:03:04:05", "%d:%H:%M:%S", NS),
+            Some(((2 * 86_400 + 3 * 3_600 + 4 * 60 + 5) as i64) * 1_000_000_000)
+        );
+        assert_eq!(parse_duration_string("+30", "%S", NS), Some(30_000_000_000));
+    }
+
+    #[test]
+    fn rejects_invalid() {
+        // Trailing characters not covered by the format.
+        assert_eq!(parse_duration_string("01:02:03x", "%H:%M:%S", NS), None);
+        // Missing separator.
+        assert_eq!(parse_duration_string("0102", "%H:%M", NS), None);
+        // Non-numeric where a number is expected.
+        assert_eq!(parse_duration_string("ab:00", "%M:%S", NS), None);
+        // Empty input where digits are required.
+        assert_eq!(parse_duration_string("", "%S", NS), None);
+    }
+}


### PR DESCRIPTION
Towards #7397.

## What

Adds a stopwatch / "duration stamp" string parser on the Rust side, exposed as
`StringMethods::as_duration`, which parses colon-style elapsed-time strings into
a `DurationChunked`. This is the Rust-side parsing functionality requested as
step 1 in #7397.

Examples that now parse (none of which `chrono` handles, since it range-checks
hours/minutes/seconds):

| input          | format        | result          |
|----------------|---------------|-----------------|
| `"80:00"`      | `%M:%S`       | 80 minutes      |
| `"-04:00:00"`  | `%H:%M:%S`    | minus 4 hours   |
| `"104:00:00"`  | `%H:%M:%S`    | 104 hours       |
| `"80:00.250"`  | `%M:%S%.f`    | 80 min 250 ms   |

## Design

The parser is **format-driven** (the caller supplies the layout), which resolves
the ambiguity raised in the issue around whether `04:00` is hours:minutes or
minutes:seconds. Supported specifiers: `%d`, `%H`, `%M`, `%S`, `%f`, `%.f`, `%%`.
Unlike time parsing, fields are **not** range-checked, so `80` minutes and `104`
hours are accepted. A leading `-`/`+` sets the sign of the whole duration; the
entire input must be consumed or parsing fails.

## Notes / open questions for maintainers

- This PR intentionally scopes to the Rust parser + a usable `as_duration`
  ChunkedArray method, with unit tests. Per the issue, the remaining work is the
  Python-facing exposure (`strptime(dtype=Duration)` / a `to_duration` method).
  Happy to follow up with the expression/`pyo3` plumbing once the parser design
  and format-specifier set are agreed — flagging now to get directional feedback
  before wiring the full public API surface.
- Open to aligning the specifier set with chrono's `strftime` names (done) or a
  different convention if preferred.

## Tests

`cargo test -p polars-time parse_duration` covers the issue examples, time-unit
scaling (ns/us/ms), days, signs, fractional truncation, and rejection of
malformed input.
