### PR TITLE
ci(python): Skip pandas 3.0.4 due to `pd.TimeDelta` segfault

### DIFF
--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -19,7 +19,7 @@ polars-cloud
 # Interop
 numba >= 0.54
 numpy
-pandas
+pandas!=3.0.4
 pyarrow
 pydantic>=2.0.0
 # Datetime / time zones


### PR DESCRIPTION
Upstream issue(s): https://github.com/pandas-dev/pandas/issues/66083 / https://github.com/pandas-dev/pandas/issues/66085
