### PR TITLE
chore(python): Mark shape tests as passing

### DIFF
--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -908,8 +908,6 @@ def test_aggregate_gather_over_dtype_24632(
     assert q.collect_schema() == q.collect().schema
 
 
-@pytest.mark.may_fail_auto_streaming  # reason: issue
-# https://github.com/pola-rs/polars/issues/24865
 @pytest.mark.parametrize(
     ("expr", "mapping_strategy", "result"),
     [
@@ -970,8 +968,6 @@ def test_mapping_strategy_scalar_matrix(
         assert_frame_equal(out, expected)
 
 
-@pytest.mark.may_fail_auto_streaming  # reason: issue
-# https://github.com/pola-rs/polars/issues/24865
 @pytest.mark.parametrize(
     "expr",
     [


### PR DESCRIPTION
Cleans up ignored tests for #24865 that are now passing. Also adds the `streaming` engine explicitly.

EDIT: from further investigation, the issue has been closed by `py-1.35.0` already. 

<img width="2680" height="1862" alt="Bildschirmfoto 2026-06-29 um 18 27 14" src="https://github.com/user-attachments/assets/085f4411-8f9e-4be7-8566-c2e6f9b288ad" />
<img width="2680" height="1862" alt="Bildschirmfoto 2026-06-29 um 18 27 18" src="https://github.com/user-attachments/assets/88190f3e-6a84-4b10-aa93-851f652100ac" />

Closes #24865