### PR TITLE
perf(rust): Avoid cold row gathers in streaming group-by

### DIFF
--- a/crates/polars-expr/src/hash_keys.rs
+++ b/crates/polars-expr/src/hash_keys.rs
@@ -284,6 +284,39 @@ impl HashKeys {
         }
     }
 
+    /// After this call partition_idxs[p] will be extended with the subset
+    /// indices of hashes that belong to partition p, and the cardinality
+    /// sketches are updated accordingly.
+    ///
+    /// # Safety
+    /// The indices in the subset must be in-bounds.
+    pub unsafe fn gen_idxs_per_partition_subset(
+        &self,
+        subset: &[IdxSize],
+        partitioner: &HashPartitioner,
+        partition_idxs: &mut [Vec<IdxSize>],
+        sketches: &mut [CardinalitySketch],
+        partition_nulls: bool,
+    ) {
+        if sketches.is_empty() {
+            self.gen_idxs_per_partition_subset_impl::<false>(
+                subset,
+                partitioner,
+                partition_idxs,
+                sketches,
+                partition_nulls | self.null_is_valid(),
+            );
+        } else {
+            self.gen_idxs_per_partition_subset_impl::<true>(
+                subset,
+                partitioner,
+                partition_idxs,
+                sketches,
+                partition_nulls | self.null_is_valid(),
+            );
+        }
+    }
+
     fn gen_idxs_per_partition_impl<const BUILD_SKETCHES: bool>(
         &self,
         partitioner: &HashPartitioner,
@@ -311,6 +344,34 @@ impl HashKeys {
                 }
             }
         });
+    }
+
+    unsafe fn gen_idxs_per_partition_subset_impl<const BUILD_SKETCHES: bool>(
+        &self,
+        subset: &[IdxSize],
+        partitioner: &HashPartitioner,
+        partition_idxs: &mut [Vec<IdxSize>],
+        sketches: &mut [CardinalitySketch],
+        partition_nulls: bool,
+    ) {
+        assert!(partition_idxs.len() == partitioner.num_partitions());
+        assert!(!BUILD_SKETCHES || sketches.len() == partitioner.num_partitions());
+
+        let null_p = partitioner.null_partition();
+        unsafe {
+            self.for_each_hash_subset(subset, |idx, opt_h| {
+                if let Some(h) = opt_h {
+                    // SAFETY: we assured the number of partitions matches.
+                    let p = partitioner.hash_to_partition(h);
+                    partition_idxs.get_unchecked_mut(p).push(idx);
+                    if BUILD_SKETCHES {
+                        sketches.get_unchecked_mut(p).insert(h);
+                    }
+                } else if partition_nulls {
+                    partition_idxs.get_unchecked_mut(null_p).push(idx);
+                }
+            });
+        }
     }
 
     pub fn sketch_cardinality(&self, sketch: &mut CardinalitySketch) {

--- a/crates/polars-expr/src/hash_keys.rs
+++ b/crates/polars-expr/src/hash_keys.rs
@@ -607,3 +607,84 @@ unsafe fn for_each_hash_subset_single<T, F>(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gen_idxs_per_partition_subset_matches_gathered_keys() {
+        let s = Series::new(
+            PlSmallStr::from_static("k"),
+            &[Some(1i32), None, Some(2), Some(3), None, Some(4)],
+        );
+        let df = DataFrame::new(6, vec![Column::from(s)]).unwrap();
+        let hash_keys = HashKeys::from_df(&df, PlRandomState::default(), false, false);
+        let subset = [0, 1, 3, 4, 5];
+        let partitioner = HashPartitioner::new(4, 0);
+
+        let mut subset_idxs = vec![Vec::new(); partitioner.num_partitions()];
+        let mut no_sketches = Vec::new();
+        unsafe {
+            hash_keys.gen_idxs_per_partition_subset(
+                &subset,
+                &partitioner,
+                &mut subset_idxs,
+                &mut no_sketches,
+                true,
+            );
+        }
+
+        let gathered = unsafe { hash_keys.gather_unchecked(&subset) };
+        let mut gathered_idxs = vec![Vec::new(); partitioner.num_partitions()];
+        let mut gathered_no_sketches = Vec::new();
+        gathered.gen_idxs_per_partition(
+            &partitioner,
+            &mut gathered_idxs,
+            &mut gathered_no_sketches,
+            true,
+        );
+
+        let gathered_original_idxs = gathered_idxs
+            .into_iter()
+            .map(|idxs| {
+                idxs.into_iter()
+                    .map(|idx| subset[idx as usize])
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(subset_idxs, gathered_original_idxs);
+
+        let mut subset_idxs = vec![Vec::new(); partitioner.num_partitions()];
+        let mut subset_sketches = vec![CardinalitySketch::new(); partitioner.num_partitions()];
+        unsafe {
+            hash_keys.gen_idxs_per_partition_subset(
+                &subset,
+                &partitioner,
+                &mut subset_idxs,
+                &mut subset_sketches,
+                true,
+            );
+        }
+
+        let mut gathered_idxs = vec![Vec::new(); partitioner.num_partitions()];
+        let mut gathered_sketches = vec![CardinalitySketch::new(); partitioner.num_partitions()];
+        gathered.gen_idxs_per_partition(
+            &partitioner,
+            &mut gathered_idxs,
+            &mut gathered_sketches,
+            true,
+        );
+
+        assert_eq!(
+            subset_sketches
+                .iter()
+                .map(CardinalitySketch::estimate)
+                .collect::<Vec<_>>(),
+            gathered_sketches
+                .iter()
+                .map(CardinalitySketch::estimate)
+                .collect::<Vec<_>>()
+        );
+    }
+}

--- a/crates/polars-stream/src/nodes/group_by.rs
+++ b/crates/polars-stream/src/nodes/group_by.rs
@@ -215,18 +215,29 @@ impl GroupBySinkState {
                     }
 
                     // Store cold keys.
-                    // TODO: don't always gather, if majority cold simply store all and remember offsets into it.
                     if !cold_idxs.is_empty() {
                         unsafe {
-                            let cold_keys = hash_keys.gather_unchecked(&cold_idxs);
-                            let cold_df = df.take_slice_unchecked_impl(&cold_idxs, false);
-
-                            cold_keys.gen_idxs_per_partition(
-                                &partitioner,
-                                &mut local.morsel_idxs_values_per_p,
-                                &mut local.sketch_per_p,
-                                true,
-                            );
+                            let (cold_keys, cold_df) =
+                                if cold_idxs.len() >= df.height() - cold_idxs.len() {
+                                    hash_keys.gen_idxs_per_partition_subset(
+                                        &cold_idxs,
+                                        &partitioner,
+                                        &mut local.morsel_idxs_values_per_p,
+                                        &mut local.sketch_per_p,
+                                        true,
+                                    );
+                                    (hash_keys, df)
+                                } else {
+                                    let cold_keys = hash_keys.gather_unchecked(&cold_idxs);
+                                    let cold_df = df.take_slice_unchecked_impl(&cold_idxs, false);
+                                    cold_keys.gen_idxs_per_partition(
+                                        &partitioner,
+                                        &mut local.morsel_idxs_values_per_p,
+                                        &mut local.sketch_per_p,
+                                        true,
+                                    );
+                                    (cold_keys, cold_df)
+                                };
                             local
                                 .morsel_idxs_offsets_per_p
                                 .extend(local.morsel_idxs_values_per_p.iter().map(|vp| vp.len()));

--- a/py-polars/tests/benchmark/conftest.py
+++ b/py-polars/tests/benchmark/conftest.py
@@ -7,3 +7,14 @@ from tests.benchmark.data import generate_group_by_data
 @pytest.fixture(scope="session")
 def groupby_data() -> pl.DataFrame:
     return generate_group_by_data(10_000, 100, null_ratio=0.05)
+
+
+@pytest.fixture(scope="session")
+def high_cardinality_groupby_data() -> pl.DataFrame:
+    n = 200_000
+    return pl.DataFrame(
+        {
+            "k": range(n),
+            "v": [i % 97 for i in range(n)],
+        }
+    )

--- a/py-polars/tests/benchmark/conftest.py
+++ b/py-polars/tests/benchmark/conftest.py
@@ -14,7 +14,7 @@ def high_cardinality_groupby_data() -> pl.DataFrame:
     n = 200_000
     return pl.DataFrame(
         {
-            "k": range(n),
+            "k": [(i * 7919) % n for i in range(n)],
             "v": [i % 97 for i in range(n)],
         }
     )

--- a/py-polars/tests/benchmark/test_group_by.py
+++ b/py-polars/tests/benchmark/test_group_by.py
@@ -127,3 +127,17 @@ def test_groupby_h2oai_q10(groupby_data: pl.DataFrame) -> None:
         )
         .collect()
     )
+
+
+def test_groupby_streaming_mostly_cold(
+    high_cardinality_groupby_data: pl.DataFrame, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("POLARS_HOT_TABLE_SIZE", "1")
+    monkeypatch.setenv("POLARS_STREAMING_CHUNK_SIZE", "4096")
+
+    (
+        high_cardinality_groupby_data.lazy()
+        .group_by("k")
+        .agg(pl.col("v").sum())
+        .collect(engine="streaming")
+    )

--- a/py-polars/tests/benchmark/test_group_by.py
+++ b/py-polars/tests/benchmark/test_group_by.py
@@ -132,7 +132,7 @@ def test_groupby_h2oai_q10(groupby_data: pl.DataFrame) -> None:
 def test_groupby_streaming_mostly_cold(
     high_cardinality_groupby_data: pl.DataFrame, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv("POLARS_HOT_TABLE_SIZE", "1")
+    monkeypatch.setenv("POLARS_HOT_TABLE_SIZE", "2")
     monkeypatch.setenv("POLARS_STREAMING_CHUNK_SIZE", "4096")
 
     (

--- a/py-polars/tests/unit/streaming/test_streaming_group_by.py
+++ b/py-polars/tests/unit/streaming/test_streaming_group_by.py
@@ -534,11 +534,11 @@ def test_streaming_group_by_nested_agg_fallback() -> None:
 
 def test_streaming_group_by_mostly_cold_morsels(plmonkeypatch: PlMonkeyPatch) -> None:
     n = 4096
-    plmonkeypatch.setenv("POLARS_HOT_TABLE_SIZE", "1")
+    plmonkeypatch.setenv("POLARS_HOT_TABLE_SIZE", "2")
     plmonkeypatch.setenv("POLARS_STREAMING_CHUNK_SIZE", "512")
     df = pl.DataFrame(
         {
-            "k": range(n),
+            "k": [(i * 7919) % n for i in range(n)],
             "v": [i % 13 for i in range(n)],
         }
     )
@@ -549,4 +549,8 @@ def test_streaming_group_by_mostly_cold_morsels(plmonkeypatch: PlMonkeyPatch) ->
         .agg(pl.col("v").sum().alias("v_sum"), pl.len().alias("len"))
         .sort("k")
     )
+    plan = q.show_graph(engine="streaming", plan_stage="physical", raw_output=True)
+    assert 'label="group-by' in plan
+    assert 'label="sorted-group-by' not in plan
+
     assert_frame_equal(q.collect(engine="streaming"), q.collect(engine="in-memory"))

--- a/py-polars/tests/unit/streaming/test_streaming_group_by.py
+++ b/py-polars/tests/unit/streaming/test_streaming_group_by.py
@@ -530,3 +530,23 @@ def test_streaming_group_by_nested_agg_fallback() -> None:
     )
     expected = {("aaa", n // 3), ("bbb", n - n // 3)}
     assert expected == set(res.rows())
+
+
+def test_streaming_group_by_mostly_cold_morsels(plmonkeypatch: PlMonkeyPatch) -> None:
+    n = 4096
+    plmonkeypatch.setenv("POLARS_HOT_TABLE_SIZE", "1")
+    plmonkeypatch.setenv("POLARS_STREAMING_CHUNK_SIZE", "512")
+    df = pl.DataFrame(
+        {
+            "k": range(n),
+            "v": [i % 13 for i in range(n)],
+        }
+    )
+
+    q = (
+        df.lazy()
+        .group_by("k")
+        .agg(pl.col("v").sum().alias("v_sum"), pl.len().alias("len"))
+        .sort("k")
+    )
+    assert_frame_equal(q.collect(engine="streaming"), q.collect(engine="in-memory"))


### PR DESCRIPTION
## Summary

Avoid materializing gathered cold-only `HashKeys` and payload `DataFrame`s in
streaming hash `group_by` when cold rows are at least half of a morsel.

The cold path now keeps the full reduced-column morsel and stores partition-local
cold row indices in the original morsel index space. The existing downstream
`insert_keys_subset` and `update_groups_subset` paths can then consume the cold
subset without a separate gather.

No Python API, config, or user-facing behavior changes.

## Implementation

- Add `HashKeys::gen_idxs_per_partition_subset`, using the existing
  `for_each_hash_subset` helper.
- Preserve original row indices for partition-local cold rows.
- Update cardinality sketches with the same semantics as
  `gen_idxs_per_partition`.
- Keep the existing gather path when cold rows are the minority.
- Store the full `HashKeys` and reduced-column `DataFrame` only when cold rows
  are at least half the morsel.
- Keep `POLARS_HOT_TABLE_SIZE` as the only tuning knob.

## Performance

Local setup:

- Apple Silicon macOS
- dev/debug local Python build
- 200k unsorted unique groups: `k = (i * 7919) % n`
- `POLARS_HOT_TABLE_SIZE=2`
- `POLARS_STREAMING_CHUNK_SIZE=4096`
- `POLARS_MAX_THREADS=1`
- physical plan asserted to contain hash `group-by`, not `sorted-group-by`
- median of measured iterations after warmup

| Case | `main` | this PR | delta |
| --- | ---: | ---: | ---: |
| 1 payload column, `sum` | 0.0723s | 0.0693s | ~4.1% faster |

The benchmark uses unsorted keys and `POLARS_HOT_TABLE_SIZE=2`, the smallest
valid hot-table size, so it exercises the hash streaming group-by path changed by
this PR.

## Correctness

- Added a high-cardinality mostly-cold streaming group-by test.
- The test compares sorted streaming output against in-memory output.
- The test covers both payload indexing and key indexing with `sum` and `len`.
- The test asserts the physical plan hits hash `group-by`, not `sorted-group-by`.

## Tests

- `cargo check -p polars-expr -p polars-stream`
- `cargo test -p polars-expr gen_idxs_per_partition_subset_matches_gathered_keys`
- `CARGO_TARGET_DIR=/tmp/polars-target UV_CACHE_DIR=/tmp/uv-cache ../.venv/bin/pytest tests/unit/streaming/test_streaming_group_by.py::test_streaming_group_by_mostly_cold_morsels -q`
- `CARGO_TARGET_DIR=/tmp/polars-target UV_CACHE_DIR=/tmp/uv-cache ../.venv/bin/pytest tests/benchmark/test_group_by.py::test_groupby_streaming_mostly_cold -m benchmark -q`
- `git diff --check`
