### PR TITLE
fix(python!): Make `add_business_days()` keyword-only arguments strict

### DIFF
--- a/py-polars/src/polars/expr/datetime.py
+++ b/py-polars/src/polars/expr/datetime.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import polars._reexport as pl
 from polars import functions as F
 from polars._utils.convert import parse_as_duration_string
-from polars._utils.deprecation import deprecate_nonkeyword_arguments, deprecated
+from polars._utils.deprecation import deprecated
 from polars._utils.parse import parse_into_expression, parse_into_list_of_expressions
 from polars._utils.unstable import unstable
 from polars._utils.various import _NamespaceSuggestMixin, qualified_type_name
@@ -43,11 +43,10 @@ class ExprDateTimeNameSpace(_NamespaceSuggestMixin):
     def __init__(self, expr: Expr) -> None:
         self._pyexpr = expr._pyexpr
 
-    @unstable()
-    @deprecate_nonkeyword_arguments(allowed_args=["self", "n"], version="1.12.0")
     def add_business_days(
         self,
         n: int | IntoExpr,
+        *,
         week_mask: Iterable[bool] = (True, True, True, True, True, False, False),
         holidays: Iterable[dt.date] | Expr | pl.Series = (),
         roll: Roll = "raise",

--- a/py-polars/src/polars/series/datetime.py
+++ b/py-polars/src/polars/series/datetime.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from polars._utils.deprecation import deprecate_nonkeyword_arguments, deprecated
+from polars._utils.deprecation import deprecated
 from polars._utils.unstable import unstable
 from polars._utils.various import _NamespaceSuggestMixin
 from polars._utils.wrap import wrap_s
@@ -45,11 +45,10 @@ class DateTimeNameSpace(_NamespaceSuggestMixin):
         s = wrap_s(self._s)
         return s[item]
 
-    @unstable()
-    @deprecate_nonkeyword_arguments(allowed_args=["self", "n"], version="1.27.0")
     def add_business_days(
         self,
         n: int | IntoExpr,
+        *,
         week_mask: Iterable[bool] = (True, True, True, True, True, False, False),
         holidays: Iterable[dt.date] | Expr | Series = (),
         roll: Roll = "raise",


### PR DESCRIPTION
Related issue: https://github.com/pola-rs/polars/issues/19390