### PR TITLE
docs(rust): Clarify default object_store user-agent applies to S3-compatible endpoints

### DIFF
--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -271,6 +271,8 @@ impl CloudType {
     }
 }
 
+/// Default product token for the object_store client, used for Amazon S3 and
+/// any S3-compatible object store. Resolved from the crate version.
 pub static USER_AGENT: &str = concat!("polars", "/", env!("CARGO_PKG_VERSION"),);
 
 #[cfg(any(feature = "aws", feature = "gcp", feature = "azure", feature = "http"))]
@@ -295,6 +297,7 @@ pub(super) fn get_client_options() -> ClientOptions {
                 })
                 .unwrap_or(5 * 60),
         ))
+        // Default; a user-supplied `user_agent` in storage_options overrides this.
         .with_user_agent(HeaderValue::from_static(USER_AGENT))
         .with_allow_http(true)
         .with_dns_resolver(Arc::new(CachingResolver::new(get_dns_cache_ttl())))


### PR DESCRIPTION

Related issue: (link the accepted issue here before opening; see note below).

I am an AI agent, using Claude Opus 4.8.

## Summary

Documentation-only change in `crates/polars-io/src/cloud/options.rs`. It adds two short comments clarifying the existing default `user_agent` that the `object_store` client sends, and that this default also applies to Amazon S3 and any S3-compatible object store. There is no behavior change.

## Motivation

The `USER_AGENT` static (`polars/<CARGO_PKG_VERSION>`) is already set on the cloud client via `ClientOptions::with_user_agent`, but nothing in the source says so or notes that the same client is used for any S3-compatible endpoint, not just Amazon S3. When operators inspect request headers or configure per-application user agents against object storage, the intent of this default was not obvious from the code. These comments make it explicit and point to `storage_options` as the place a user-supplied `user_agent` takes precedence.

## What changed

- Added a doc comment on the `USER_AGENT` static describing it as the default product token for the `object_store` client, resolved from the crate version, and noting it applies to Amazon S3 and any S3-compatible object store.
- Added an inline comment at the `.with_user_agent(...)` call noting it is the default and that a user-supplied `user_agent` in `storage_options` overrides it.

Net diff is +3 lines (comments only). No public API, types, or runtime behavior are affected.

## Testing

No tests added. This is a comment-only change with no functional effect, so the Python test suite exercises the surrounding cloud code unchanged. Per the contributing guidelines, the Rust test suite is intentionally kept small and Rust tests are only added when functionality cannot be covered from the Python API, which does not apply here. `make test` passes locally.

## AI usage disclosure

Per the project AI policy, disclosing extent: the two comments and this description were drafted with AI assistance (Claude Opus 4.8). I have reviewed all changes myself, and I believe they are relevant and correct.
