### PR TITLE
refactor(rust): Update `typos` to `v1.48.0`

### DIFF
--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Lint Markdown and TOML
         uses: dprint/check@v2.3
       - name: Spell Check with Typos
-        uses: crate-ci/typos@v1.42.0
+        uses: crate-ci/typos@v1.48.0
       - name: Install ripgrep
         run: sudo apt-get update && sudo apt-get install -y ripgrep
       - name: Check for FIXME comments

--- a/.typos.toml
+++ b/.typos.toml
@@ -20,10 +20,14 @@ arange = "arange"
 ser = "ser"
 splitted = "splitted"
 strat = "strat"
+striter = "striter"
 typ = "typ"
 
 [default.extend-identifiers]
 AKS = "AKS"
+
+[type.py]
+extend-ignore-re = ['\.flags\.writeable\b']
 
 [type.py.extend-identifiers]
 ba = "ba"

--- a/crates/polars-arrow/src/ffi/array.rs
+++ b/crates/polars-arrow/src/ffi/array.rs
@@ -576,7 +576,7 @@ pub trait ArrowArrayRef: std::fmt::Debug {
 /// Furthermore, this struct assumes that the incoming data agrees with the C data interface.
 #[derive(Debug, Clone)]
 pub struct InternalArrowArray {
-    // Arc is used for sharability since this is immutable
+    // Arc is used for shareability since this is immutable
     array: Arc<ArrowArray>,
     // Arced to reduce cost of cloning
     dtype: Arc<ArrowDataType>,

--- a/crates/polars-io/src/cloud/cloud_writer/io_trait_wrap.rs
+++ b/crates/polars-io/src/cloud/cloud_writer/io_trait_wrap.rs
@@ -6,7 +6,7 @@ use futures::FutureExt;
 use polars_core::runtime::ASYNC;
 
 use crate::cloud::cloud_writer::CloudWriter;
-use crate::utils::file::WriteableTrait;
+use crate::utils::file::WritableTrait;
 
 /// Wrapper on [`CloudWriter`] that implements [`std::io::Write`] and [`tokio::io::AsyncWrite`].
 pub struct CloudWriterIoTraitWrap {
@@ -187,7 +187,7 @@ impl std::io::Write for CloudWriterIoTraitWrap {
     }
 }
 
-impl WriteableTrait for CloudWriterIoTraitWrap {
+impl WritableTrait for CloudWriterIoTraitWrap {
     fn close(&mut self) -> std::io::Result<()> {
         ASYNC.block_in_place_on(async {
             self.finish_active_poll().await?;

--- a/crates/polars-io/src/utils/compression.rs
+++ b/crates/polars-io/src/utils/compression.rs
@@ -5,7 +5,7 @@ use polars_buffer::Buffer;
 use polars_core::prelude::*;
 use polars_error::{feature_gated, to_compute_err};
 
-use crate::utils::file::{Writeable, WriteableTrait};
+use crate::utils::file::{Writable, WritableTrait};
 use crate::utils::stream_buf_reader::ReaderSource;
 use crate::utils::sync_on_close::SyncOnCloseType;
 
@@ -388,16 +388,16 @@ impl ByteSourceReader<ReaderSource> {
     }
 }
 
-/// Constructor for `WriteableTrait` compressed encoders.
+/// Constructor for `WritableTrait` compressed encoders.
 pub enum CompressedWriter {
     #[cfg(feature = "decompress")]
-    Gzip(Option<flate2::write::GzEncoder<Writeable>>),
+    Gzip(Option<flate2::write::GzEncoder<Writable>>),
     #[cfg(feature = "decompress")]
-    Zstd(Option<zstd::Encoder<'static, Writeable>>),
+    Zstd(Option<zstd::Encoder<'static, Writable>>),
 }
 
 impl CompressedWriter {
-    pub fn gzip(writer: Writeable, level: Option<u32>) -> Self {
+    pub fn gzip(writer: Writable, level: Option<u32>) -> Self {
         feature_gated!("decompress", {
             Self::Gzip(Some(flate2::write::GzEncoder::new(
                 writer,
@@ -406,7 +406,7 @@ impl CompressedWriter {
         })
     }
 
-    pub fn zstd(writer: Writeable, level: Option<u32>) -> std::io::Result<Self> {
+    pub fn zstd(writer: Writable, level: Option<u32>) -> std::io::Result<Self> {
         feature_gated!("decompress", {
             zstd::Encoder::new(writer, level.unwrap_or(3) as i32)
                 .map(Some)
@@ -435,7 +435,7 @@ impl Write for CompressedWriter {
     }
 }
 
-impl WriteableTrait for CompressedWriter {
+impl WritableTrait for CompressedWriter {
     fn close(&mut self) -> std::io::Result<()> {
         feature_gated!("decompress", {
             let writer = match self {

--- a/crates/polars-io/src/utils/file.rs
+++ b/crates/polars-io/src/utils/file.rs
@@ -5,7 +5,7 @@ use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
 #[cfg(feature = "cloud")]
-pub use async_writeable::{AsyncDynWriteable, AsyncWriteable};
+pub use async_writable::{AsyncDynWritable, AsyncWritable};
 use polars_error::{PolarsResult, feature_gated, polars_err};
 use polars_utils::create_file;
 use polars_utils::file::close_file;
@@ -18,29 +18,29 @@ use crate::metrics::IOMetrics;
 use crate::resolve_homedir;
 
 // TODO document precise contract.
-pub trait WriteableTrait: std::io::Write {
+pub trait WritableTrait: std::io::Write {
     fn close(&mut self) -> std::io::Result<()>;
     fn sync_all(&self) -> std::io::Result<()>;
     fn sync_data(&self) -> std::io::Result<()>;
 }
 
-/// Holds a non-async writeable file, abstracted over local files or cloud files.
+/// Holds a non-async writable file, abstracted over local files or cloud files.
 ///
 /// This implements `DerefMut` to a trait object implementing [`std::io::Write`].
 ///
-/// Also see: `Writeable::try_into_async_writeable` and `AsyncWriteable`.
+/// Also see: `Writable::try_into_async_writable` and `AsyncWritable`.
 #[allow(clippy::large_enum_variant)] // It will be boxed
-pub enum Writeable {
+pub enum Writable {
     /// An abstract implementation for writable.
     ///
     /// This is used to implement writing to in-memory and arbitrary file descriptors.
-    Dyn(Box<dyn WriteableTrait + Send>),
+    Dyn(Box<dyn WritableTrait + Send>),
     Local(std::fs::File),
     #[cfg(feature = "cloud")]
     Cloud(crate::cloud::cloud_writer::CloudWriterIoTraitWrap),
 }
 
-impl Writeable {
+impl Writable {
     pub fn try_new(
         path: PlRefPath,
         #[cfg_attr(not(feature = "cloud"), expect(unused))] cloud_options: Option<&CloudOptions>,
@@ -100,22 +100,22 @@ impl Writeable {
     /// This returns `Result<>` - if a write was performed before calling this,
     /// `CloudWriter` can be in an Err(_) state.
     #[cfg(feature = "cloud")]
-    pub fn try_into_async_writeable(self) -> PolarsResult<AsyncWriteable> {
-        use self::async_writeable::AsyncDynWriteable;
+    pub fn try_into_async_writable(self) -> PolarsResult<AsyncWritable> {
+        use self::async_writable::AsyncDynWritable;
 
         match self {
-            Self::Dyn(v) => Ok(AsyncWriteable::Dyn(AsyncDynWriteable(v))),
-            Self::Local(v) => Ok(AsyncWriteable::Local(tokio::fs::File::from_std(v))),
-            Self::Cloud(v) => Ok(AsyncWriteable::Cloud(v)),
+            Self::Dyn(v) => Ok(AsyncWritable::Dyn(AsyncDynWritable(v))),
+            Self::Local(v) => Ok(AsyncWritable::Local(tokio::fs::File::from_std(v))),
+            Self::Cloud(v) => Ok(AsyncWritable::Cloud(v)),
         }
     }
 
-    pub fn as_buffered(&mut self) -> BufferedWriteable<'_> {
+    pub fn as_buffered(&mut self) -> BufferedWritable<'_> {
         match self {
-            Writeable::Dyn(v) => BufferedWriteable::BufWriter(std::io::BufWriter::new(v.as_mut())),
-            Writeable::Local(v) => BufferedWriteable::BufWriter(std::io::BufWriter::new(v)),
+            Writable::Dyn(v) => BufferedWritable::BufWriter(std::io::BufWriter::new(v.as_mut())),
+            Writable::Local(v) => BufferedWritable::BufWriter(std::io::BufWriter::new(v)),
             #[cfg(feature = "cloud")]
-            Writeable::Cloud(v) => BufferedWriteable::Direct(v as _),
+            Writable::Cloud(v) => BufferedWritable::Direct(v as _),
         }
     }
 
@@ -153,7 +153,7 @@ impl Writeable {
     }
 }
 
-impl io::Write for Writeable {
+impl io::Write for Writable {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         match self {
             Self::Dyn(v) => v.write(buf),
@@ -168,7 +168,7 @@ impl io::Write for Writeable {
     }
 }
 
-impl Deref for Writeable {
+impl Deref for Writable {
     type Target = dyn io::Write + Send;
 
     fn deref(&self) -> &Self::Target {
@@ -181,7 +181,7 @@ impl Deref for Writeable {
     }
 }
 
-impl DerefMut for Writeable {
+impl DerefMut for Writable {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
             Self::Dyn(v) => v,
@@ -193,12 +193,12 @@ impl DerefMut for Writeable {
 }
 
 /// Avoid BufWriter wrapping on writers that already have internal buffering.
-pub enum BufferedWriteable<'a> {
+pub enum BufferedWritable<'a> {
     BufWriter(std::io::BufWriter<&'a mut (dyn std::io::Write + Send)>),
     Direct(&'a mut (dyn std::io::Write + Send)),
 }
 
-impl<'a> Deref for BufferedWriteable<'a> {
+impl<'a> Deref for BufferedWritable<'a> {
     type Target = dyn io::Write + Send + 'a;
 
     fn deref(&self) -> &Self::Target {
@@ -209,7 +209,7 @@ impl<'a> Deref for BufferedWriteable<'a> {
     }
 }
 
-impl DerefMut for BufferedWriteable<'_> {
+impl DerefMut for BufferedWritable<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
             Self::BufWriter(v) => v as _,
@@ -246,7 +246,7 @@ async fn new_cloud_writer(
 }
 
 #[cfg(feature = "cloud")]
-mod async_writeable {
+mod async_writable {
     use std::io;
     use std::ops::{Deref, DerefMut};
     use std::pin::Pin;
@@ -260,15 +260,15 @@ mod async_writeable {
     use tokio::io::AsyncWriteExt;
     use tokio::task;
 
-    use super::{Writeable, WriteableTrait};
+    use super::{Writable, WritableTrait};
     use crate::cloud::CloudOptions;
     use crate::metrics::IOMetrics;
     use crate::utils::sync_on_close::SyncOnCloseType;
 
     /// Turn an abstract io::Write into an abstract tokio::io::AsyncWrite.
-    pub struct AsyncDynWriteable(pub Box<dyn WriteableTrait + Send>);
+    pub struct AsyncDynWritable(pub Box<dyn WritableTrait + Send>);
 
-    impl tokio::io::AsyncWrite for AsyncDynWriteable {
+    impl tokio::io::AsyncWrite for AsyncDynWritable {
         fn poll_write(
             self: Pin<&mut Self>,
             _cx: &mut Context<'_>,
@@ -288,19 +288,19 @@ mod async_writeable {
         }
     }
 
-    /// Holds an async writeable file, abstracted over local files or cloud files.
+    /// Holds an async writable file, abstracted over local files or cloud files.
     ///
     /// This implements `DerefMut` to a trait object implementing [`tokio::io::AsyncWrite`].
     ///
     /// Note: It is important that you do not call `shutdown()` on the deref'ed `AsyncWrite` object.
-    /// You should instead call the [`AsyncWriteable::close`] at the end.
-    pub enum AsyncWriteable {
-        Dyn(AsyncDynWriteable),
+    /// You should instead call the [`AsyncWritable::close`] at the end.
+    pub enum AsyncWritable {
+        Dyn(AsyncDynWritable),
         Local(tokio::fs::File),
         Cloud(crate::cloud::cloud_writer::CloudWriterIoTraitWrap),
     }
 
-    impl AsyncWriteable {
+    impl AsyncWritable {
         pub async fn try_new(
             path: PlRefPath,
             cloud_options: Option<&CloudOptions>,
@@ -309,14 +309,14 @@ mod async_writeable {
             io_metrics: Option<Arc<IOMetrics>>,
         ) -> PolarsResult<Self> {
             // TODO: Native async impl
-            Writeable::try_new(
+            Writable::try_new(
                 path,
                 cloud_options,
                 cloud_upload_chunk_size,
                 cloud_upload_concurrency,
                 io_metrics,
             )
-            .and_then(|x| x.try_into_async_writeable())
+            .and_then(|x| x.try_into_async_writable())
         }
 
         /// If this writer holds a cloud writer, it will `mem::take(T)`. `T` is unmodified for other
@@ -371,7 +371,7 @@ mod async_writeable {
         }
     }
 
-    impl Deref for AsyncWriteable {
+    impl Deref for AsyncWritable {
         type Target = dyn tokio::io::AsyncWrite + Send + Unpin;
 
         fn deref(&self) -> &Self::Target {
@@ -383,7 +383,7 @@ mod async_writeable {
         }
     }
 
-    impl DerefMut for AsyncWriteable {
+    impl DerefMut for AsyncWritable {
         fn deref_mut(&mut self) -> &mut Self::Target {
             match self {
                 Self::Dyn(v) => v,

--- a/crates/polars-plan/src/dsl/options/file_provider.rs
+++ b/crates/polars-plan/src/dsl/options/file_provider.rs
@@ -5,7 +5,7 @@ use polars_core::frame::DataFrame;
 use polars_core::prelude::{Column, DataType};
 use polars_error::PolarsResult;
 use polars_io::hive::HivePathFormatter;
-use polars_io::utils::file::Writeable;
+use polars_io::utils::file::Writable;
 use polars_utils::pl_str::PlSmallStr;
 
 use crate::prelude::PlanCallback;
@@ -19,7 +19,7 @@ pub struct FileProviderArgs {
 
 pub enum FileProviderReturn {
     Path(String),
-    Writeable(Writeable),
+    Writable(Writable),
 }
 
 pub type FileProviderFunction = PlanCallback<FileProviderArgs, FileProviderReturn>;

--- a/crates/polars-plan/src/dsl/options/sink.rs
+++ b/crates/polars-plan/src/dsl/options/sink.rs
@@ -11,7 +11,7 @@ use polars_core::schema::Schema;
 use polars_error::feature_gated;
 use polars_io::cloud::CloudOptions;
 use polars_io::metrics::IOMetrics;
-use polars_io::utils::file::Writeable;
+use polars_io::utils::file::Writable;
 use polars_io::utils::sync_on_close::SyncOnCloseType;
 use polars_utils::IdxSize;
 use polars_utils::arena::Arena;
@@ -25,7 +25,7 @@ use crate::dsl::{AExpr, Expr, SpecialEq};
 use crate::plans::{ExprIR, ToFieldContext};
 use crate::prelude::PlanCallback;
 
-type DynSinkTarget = SpecialEq<Arc<std::sync::Mutex<Option<Writeable>>>>;
+type DynSinkTarget = SpecialEq<Arc<std::sync::Mutex<Option<Writable>>>>;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
@@ -87,21 +87,21 @@ impl SinkTarget {
         }
     }
 
-    pub fn open_into_writeable(
+    pub fn open_into_writable(
         &self,
         cloud_options: Option<&CloudOptions>,
         mkdir: bool,
         cloud_upload_chunk_size: usize,
         cloud_upload_concurrency: usize,
         io_metrics: Option<Arc<IOMetrics>>,
-    ) -> PolarsResult<Writeable> {
+    ) -> PolarsResult<Writable> {
         match self {
             SinkTarget::Path(path) => {
                 if mkdir {
                     polars_io::utils::mkdir::mkdir_recursive(path)?;
                 }
 
-                polars_io::utils::file::Writeable::try_new(
+                polars_io::utils::file::Writable::try_new(
                     path.clone(),
                     cloud_options,
                     cloud_upload_chunk_size,
@@ -113,14 +113,14 @@ impl SinkTarget {
         }
     }
 
-    pub async fn open_into_writeable_async(
+    pub async fn open_into_writable_async(
         &self,
         cloud_options: Option<&CloudOptions>,
         mkdir: bool,
         cloud_upload_chunk_size: usize,
         cloud_upload_concurrency: usize,
         io_metrics: Option<Arc<IOMetrics>>,
-    ) -> PolarsResult<Writeable> {
+    ) -> PolarsResult<Writable> {
         #[cfg(feature = "cloud")]
         {
             match self {
@@ -129,7 +129,7 @@ impl SinkTarget {
                         polars_io::utils::mkdir::tokio_mkdir_recursive(path).await?;
                     }
 
-                    polars_io::utils::file::Writeable::try_new(
+                    polars_io::utils::file::Writable::try_new(
                         path.clone(),
                         cloud_options,
                         cloud_upload_chunk_size,
@@ -143,7 +143,7 @@ impl SinkTarget {
 
         #[cfg(not(feature = "cloud"))]
         {
-            self.open_into_writeable(
+            self.open_into_writable(
                 cloud_options,
                 mkdir,
                 cloud_upload_chunk_size,

--- a/crates/polars-python/src/file.rs
+++ b/crates/polars-python/src/file.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 
 use polars::io::mmap::MmapBytesReader;
 use polars::prelude::PlRefPath;
-use polars::prelude::file::{Writeable, WriteableTrait};
+use polars::prelude::file::{Writable, WritableTrait};
 use polars_buffer::{Buffer, SharedStorage};
 use polars_error::polars_err;
 use polars_utils::create_file;
@@ -31,7 +31,7 @@ pub(crate) struct PyFileLikeObject {
     has_flush: bool,
 }
 
-impl WriteableTrait for PyFileLikeObject {
+impl WritableTrait for PyFileLikeObject {
     fn close(&mut self) -> io::Result<()> {
         Ok(())
     }
@@ -295,10 +295,10 @@ impl EitherRustPythonFile {
         }
     }
 
-    pub(crate) fn into_writeable(self) -> Writeable {
+    pub(crate) fn into_writable(self) -> Writable {
         match self {
-            Self::Py(f) => Writeable::Dyn(Box::new(f)),
-            Self::Rust(f) => Writeable::Local(f),
+            Self::Py(f) => Writable::Dyn(Box::new(f)),
+            Self::Rust(f) => Writable::Local(f),
         }
     }
 }

--- a/crates/polars-python/src/lazyframe/sink.rs
+++ b/crates/polars-python/src/lazyframe/sink.rs
@@ -23,7 +23,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Wrap<polars_plan::dsl::SinkTarget> {
                 PyResult::Ok(
                     crate::file::try_get_pyfile(py, py_f, true)?
                         .0
-                        .into_writeable(),
+                        .into_writable(),
                 )
             })?;
 
@@ -49,11 +49,11 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Wrap<FileProviderReturn> {
         } else {
             let py = ob.py();
 
-            let writeable = crate::file::try_get_pyfile(py, ob.to_owned(), true)?
+            let writable = crate::file::try_get_pyfile(py, ob.to_owned(), true)?
                 .0
-                .into_writeable();
+                .into_writable();
 
-            Ok(Wrap(FileProviderReturn::Writeable(writeable)))
+            Ok(Wrap(FileProviderReturn::Writable(writable)))
         }
     }
 }

--- a/crates/polars-stream/src/nodes/io_sinks/components/file_provider.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/components/file_provider.rs
@@ -4,7 +4,7 @@ use polars_core::runtime::ASYNC;
 use polars_error::{PolarsResult, polars_ensure};
 use polars_io::cloud::CloudOptions;
 use polars_io::metrics::IOMetrics;
-use polars_io::utils::file::Writeable;
+use polars_io::utils::file::Writable;
 use polars_plan::dsl::file_provider::{FileProviderReturn, FileProviderType};
 use polars_plan::dsl::sink::SinkedPathInfo;
 use polars_plan::prelude::file_provider::FileProviderArgs;
@@ -23,9 +23,9 @@ pub struct FileProvider {
 }
 
 impl FileProvider {
-    pub async fn open_file(&self, args: FileProviderArgs) -> PolarsResult<Writeable> {
+    pub async fn open_file(&self, args: FileProviderArgs) -> PolarsResult<Writable> {
         let provided_path: String = 'provided_path: {
-            let provided_writeable = match &self.provider_type {
+            let provided_writable = match &self.provider_type {
                 FileProviderType::Hive(p) => break 'provided_path p.get_path(args)?,
                 FileProviderType::Iceberg(p) => break 'provided_path p.get_path(args)?,
                 FileProviderType::Function(f) => {
@@ -38,7 +38,7 @@ impl FileProvider {
 
                     match out {
                         FileProviderReturn::Path(p) => break 'provided_path p,
-                        FileProviderReturn::Writeable(v) => v,
+                        FileProviderReturn::Writable(v) => v,
                     }
                 },
             };
@@ -47,7 +47,7 @@ impl FileProvider {
                 return Err(v.non_path_error());
             }
 
-            return Ok(provided_writeable);
+            return Ok(provided_writable);
         };
 
         let path = self.base_path.join(&provided_path);
@@ -73,7 +73,7 @@ impl FileProvider {
         if !path.has_scheme()
             && let Some(path) = path.parent()
         {
-            // Ignore errors from directory creation - the `Writeable::try_new()` below will raise
+            // Ignore errors from directory creation - the `Writable::try_new()` below will raise
             // appropriate errors.
             let _ = tokio::fs::DirBuilder::new()
                 .recursive(true)
@@ -87,7 +87,7 @@ impl FileProvider {
                 .push(SinkedPathInfo { path: path.clone() });
         }
 
-        Writeable::try_new(
+        Writable::try_new(
             path,
             self.cloud_options.as_deref(),
             self.upload_chunk_size,

--- a/crates/polars-stream/src/nodes/io_sinks/pipeline_initialization/single_file.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/pipeline_initialization/single_file.rs
@@ -76,7 +76,7 @@ pub fn start_single_file_sink_pipeline(
         let io_metrics = io_metrics.clone();
         tokio_handle_ext::AbortOnDropHandle(ASYNC.spawn(async move {
             target
-                .open_into_writeable_async(
+                .open_into_writable_async(
                     cloud_options.as_deref(),
                     mkdir,
                     upload_chunk_size,

--- a/crates/polars-stream/src/nodes/io_sinks/writers/csv/io_writer.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/writers/csv/io_writer.rs
@@ -42,12 +42,12 @@ impl IOWriter {
             // `task::block_in_place` provided by `AsyncDynWritable`. In theory this could
             // bottleneck the pipeline if there are a large number of files being written into in
             // parallel, since the tokio thread-pool is smaller than the computation thread-pool.
-            ExternalCompression::Gzip { level } => AsyncWritable::Dyn(AsyncDynWritable(
-                Box::new(CompressedWriter::gzip(writable, level)),
-            )),
-            ExternalCompression::Zstd { level } => AsyncWritable::Dyn(AsyncDynWritable(
-                Box::new(CompressedWriter::zstd(writable, level)?),
-            )),
+            ExternalCompression::Gzip { level } => AsyncWritable::Dyn(AsyncDynWritable(Box::new(
+                CompressedWriter::gzip(writable, level),
+            ))),
+            ExternalCompression::Zstd { level } => AsyncWritable::Dyn(AsyncDynWritable(Box::new(
+                CompressedWriter::zstd(writable, level)?,
+            ))),
         };
 
         if options.include_bom {

--- a/crates/polars-stream/src/nodes/io_sinks/writers/csv/io_writer.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/writers/csv/io_writer.rs
@@ -5,7 +5,7 @@ use polars_core::schema::SchemaRef;
 use polars_error::PolarsResult;
 use polars_io::prelude::{CsvWriterOptions, ExternalCompression, UTF8_BOM, csv_header};
 use polars_io::utils::compression::CompressedWriter;
-use polars_io::utils::file::{AsyncDynWriteable, AsyncWriteable};
+use polars_io::utils::file::{AsyncDynWritable, AsyncWritable};
 use tokio::io::AsyncWriteExt as _;
 
 use crate::nodes::io_sinks::components::sink_morsel::SinkMorselPermit;
@@ -36,16 +36,16 @@ impl IOWriter {
         let (writable, sync_on_close) = file.await?;
 
         let mut writer = match options.compression {
-            // Natively convert into `AsyncWriteable` to allow native async optimizations.
-            ExternalCompression::Uncompressed => writable.try_into_async_writeable()?,
+            // Natively convert into `AsyncWritable` to allow native async optimizations.
+            ExternalCompression::Uncompressed => writable.try_into_async_writable()?,
             // Our compression encoders only offer sync `io::Write` capabilities, so we wrap them in
-            // `task::block_in_place` provided by `AsyncDynWriteable`. In theory this could
+            // `task::block_in_place` provided by `AsyncDynWritable`. In theory this could
             // bottleneck the pipeline if there are a large number of files being written into in
             // parallel, since the tokio thread-pool is smaller than the computation thread-pool.
-            ExternalCompression::Gzip { level } => AsyncWriteable::Dyn(AsyncDynWriteable(
+            ExternalCompression::Gzip { level } => AsyncWritable::Dyn(AsyncDynWritable(
                 Box::new(CompressedWriter::gzip(writable, level)),
             )),
-            ExternalCompression::Zstd { level } => AsyncWriteable::Dyn(AsyncDynWriteable(
+            ExternalCompression::Zstd { level } => AsyncWritable::Dyn(AsyncDynWritable(
                 Box::new(CompressedWriter::zstd(writable, level)?),
             )),
         };

--- a/crates/polars-stream/src/nodes/io_sinks/writers/interface.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/writers/interface.rs
@@ -4,7 +4,7 @@ use futures::FutureExt;
 use polars_async::executor;
 use polars_async::primitives::connector;
 use polars_error::PolarsResult;
-use polars_io::utils::file::Writeable;
+use polars_io::utils::file::Writable;
 use polars_io::utils::sync_on_close::SyncOnCloseType;
 use polars_utils::IdxSize;
 use polars_utils::index::NonZeroIdxSize;
@@ -32,13 +32,13 @@ pub trait FileWriterStarter: Send + Sync + 'static {
 }
 
 pub struct FileOpenTaskHandle {
-    handle: tokio_handle_ext::AbortOnDropHandle<PolarsResult<Writeable>>,
+    handle: tokio_handle_ext::AbortOnDropHandle<PolarsResult<Writable>>,
     sync_on_close: SyncOnCloseType,
 }
 
 impl FileOpenTaskHandle {
     pub fn new(
-        handle: tokio_handle_ext::AbortOnDropHandle<PolarsResult<Writeable>>,
+        handle: tokio_handle_ext::AbortOnDropHandle<PolarsResult<Writable>>,
         sync_on_close: SyncOnCloseType,
     ) -> Self {
         Self {
@@ -49,7 +49,7 @@ impl FileOpenTaskHandle {
 }
 
 impl std::future::Future for FileOpenTaskHandle {
-    type Output = PolarsResult<(Writeable, SyncOnCloseType)>;
+    type Output = PolarsResult<(Writable, SyncOnCloseType)>;
 
     fn poll(
         mut self: std::pin::Pin<&mut Self>,
@@ -58,7 +58,7 @@ impl std::future::Future for FileOpenTaskHandle {
         use std::task::Poll;
 
         let file: Result<_, tokio::task::JoinError> = futures::ready!(self.handle.poll_unpin(cx));
-        let file: PolarsResult<Writeable> = file.unwrap();
+        let file: PolarsResult<Writable> = file.unwrap();
 
         Poll::Ready(file.map(|file| (file, self.sync_on_close)))
     }

--- a/crates/polars-stream/src/nodes/io_sinks/writers/ipc/io_writer.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/writers/ipc/io_writer.rs
@@ -10,7 +10,7 @@ use polars_core::utils::arrow;
 use polars_error::{PolarsResult, to_compute_err};
 use polars_io::ipc::pl_ipc_metadata::{POLARS_IPC_METADATA_KEY, PlIpcMetadata};
 use polars_io::ipc::{IpcWriter, IpcWriterOptions};
-use polars_io::utils::file::Writeable;
+use polars_io::utils::file::Writable;
 use polars_io::{SerWriter, schema_to_arrow_checked};
 
 use crate::nodes::io_sinks::writers::interface::FileOpenTaskHandle;
@@ -41,7 +41,7 @@ impl IOWriter {
         let mut custom_pl_metadata = write_custom_pl_metadata.then_some(PlIpcMetadata::default());
 
         match file {
-            Writeable::Cloud(cloudwriter) => {
+            Writable::Cloud(cloudwriter) => {
                 // The zero-copy implementation takes ownership of the encoded data and, after
                 // framing and aligning, passes it to the object_store via the BufWriter::put() method.
                 let mut cloud_writer = cloudwriter.into_cloud_writer().await?;

--- a/crates/polars-stream/src/nodes/io_sinks/writers/ndjson/io_writer.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/writers/ndjson/io_writer.rs
@@ -38,12 +38,12 @@ impl IOWriter {
             // `task::block_in_place` provided by `AsyncDynWritable`. In theory this could
             // bottleneck the pipeline if there are a large number of files being written into in
             // parallel, since the tokio thread-pool is smaller than the computation thread-pool.
-            ExternalCompression::Gzip { level } => AsyncWritable::Dyn(AsyncDynWritable(
-                Box::new(CompressedWriter::gzip(writable, level)),
-            )),
-            ExternalCompression::Zstd { level } => AsyncWritable::Dyn(AsyncDynWritable(
-                Box::new(CompressedWriter::zstd(writable, level)?),
-            )),
+            ExternalCompression::Gzip { level } => AsyncWritable::Dyn(AsyncDynWritable(Box::new(
+                CompressedWriter::gzip(writable, level),
+            ))),
+            ExternalCompression::Zstd { level } => AsyncWritable::Dyn(AsyncDynWritable(Box::new(
+                CompressedWriter::zstd(writable, level)?,
+            ))),
         };
 
         while let Some((handle, permit)) = filled_serializer_rx.recv().await {

--- a/crates/polars-stream/src/nodes/io_sinks/writers/ndjson/io_writer.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/writers/ndjson/io_writer.rs
@@ -3,7 +3,7 @@ use polars_error::PolarsResult;
 use polars_io::ExternalCompression;
 use polars_io::ndjson::NDJsonWriterOptions;
 use polars_io::utils::compression::CompressedWriter;
-use polars_io::utils::file::{AsyncDynWriteable, AsyncWriteable};
+use polars_io::utils::file::{AsyncDynWritable, AsyncWritable};
 use tokio::io::AsyncWriteExt as _;
 
 use crate::nodes::io_sinks::components::sink_morsel::SinkMorselPermit;
@@ -32,16 +32,16 @@ impl IOWriter {
         let (writable, sync_on_close) = file.await?;
 
         let mut writer = match options.compression {
-            // Natively convert into `AsyncWriteable` to allow native async optimizations.
-            ExternalCompression::Uncompressed => writable.try_into_async_writeable()?,
+            // Natively convert into `AsyncWritable` to allow native async optimizations.
+            ExternalCompression::Uncompressed => writable.try_into_async_writable()?,
             // Our compression encoders only offer sync `io::Write` capabilities, so we wrap them in
-            // `task::block_in_place` provided by `AsyncDynWriteable`. In theory this could
+            // `task::block_in_place` provided by `AsyncDynWritable`. In theory this could
             // bottleneck the pipeline if there are a large number of files being written into in
             // parallel, since the tokio thread-pool is smaller than the computation thread-pool.
-            ExternalCompression::Gzip { level } => AsyncWriteable::Dyn(AsyncDynWriteable(
+            ExternalCompression::Gzip { level } => AsyncWritable::Dyn(AsyncDynWritable(
                 Box::new(CompressedWriter::gzip(writable, level)),
             )),
-            ExternalCompression::Zstd { level } => AsyncWriteable::Dyn(AsyncDynWriteable(
+            ExternalCompression::Zstd { level } => AsyncWritable::Dyn(AsyncDynWritable(
                 Box::new(CompressedWriter::zstd(writable, level)?),
             )),
         };

--- a/crates/polars/tests/it/io/parquet/mod.rs
+++ b/crates/polars/tests/it/io/parquet/mod.rs
@@ -222,7 +222,7 @@ fn test_ext_store_sink_and_scan_parquet() -> PolarsResult<()> {
         deregister_object_store_builder, register_object_store_builder,
     };
     use polars_io::prelude::ParquetWriter;
-    use polars_io::utils::file::WriteableTrait;
+    use polars_io::utils::file::WritableTrait;
     use polars_utils::pl_path::PlRefPath;
 
     struct MemoryBuilder {

--- a/py-polars/requirements-lint.txt
+++ b/py-polars/requirements-lint.txt
@@ -1,4 +1,4 @@
 mypy[faster-cache]==2.1.0
 pyrefly==1.1.1
 ruff==0.15.0
-typos==1.43.3
+typos==1.48.0

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
@@ -175,7 +175,7 @@ def test_to_numpy_zero_copy_path_writable() -> None:
     x[:, 1] = 2.0
     df = pl.DataFrame(x)
     x = df.to_numpy(writable=True)
-    assert x.flags["WRITEABLE"]
+    assert x.flags.writeable
 
 
 def test_df_to_numpy_structured_not_zero_copy() -> None:


### PR DESCRIPTION
Unblocks https://github.com/pola-rs/polars/pull/28159

Alternative of fixing the spelling of "writeable" to "writable" is to add the incorrect spelling to the ignore list.

:robot: Spelling updates were done by Claude Opus 4.8. Additions to `.typos.toml` were done by hand.
