### PR TITLE
docs: Clarify parts of the Polars Cloud and On-prem user guide

### DIFF
--- a/docs/source/polars-cloud/organization/billing.md
+++ b/docs/source/polars-cloud/organization/billing.md
@@ -32,9 +32,14 @@ Connect your AWS billing account to your Polars Cloud organization by clicking "
 following the steps in the AWS Marketplace portal. After clicking "Set up your account" you are
 redirected to Polars Cloud where you can select and confirm the organization to connect.
 
-Under `Billing`, the status will update to show your organization is connected to AWS Marketplace.
+On the Billing page the status will update to show your organization is connected to AWS Marketplace.
 If the status doesn't update within 15 minutes, contact our support team at
 [support@polars.tech](mailto:support@polars.tech).
+
+!!! Warning "Complete the steps in the AWS Marketplace portal"
+
+    If your account is subscribed without completing the steps, your AWS
+    billing account cannot be connected to your Polars Cloud organization.
 
 ### Request and Accept Private Offers
 

--- a/docs/source/polars-cloud/organization/billing.md
+++ b/docs/source/polars-cloud/organization/billing.md
@@ -32,8 +32,8 @@ Connect your AWS billing account to your Polars Cloud organization by clicking "
 following the steps in the AWS Marketplace portal. After clicking "Set up your account" you are
 redirected to Polars Cloud where you can select and confirm the organization to connect.
 
-On the Billing page the status will update to show your organization is connected to AWS Marketplace.
-If the status doesn't update within 15 minutes, contact our support team at
+On the Billing page the status will update to show your organization is connected to AWS
+Marketplace. If the status doesn't update within 15 minutes, contact our support team at
 [support@polars.tech](mailto:support@polars.tech).
 
 !!! Warning "Complete the steps in the AWS Marketplace portal"

--- a/docs/source/polars-cloud/organization/billing.md
+++ b/docs/source/polars-cloud/organization/billing.md
@@ -18,8 +18,7 @@ stopping are not charged.
 ## Subscribe to Polars Cloud
 
 Subscribing to Polars Cloud requires an AWS account with billing permissions. You can access the
-marketplace listing either through the Billing page in your Polars Cloud organization or by
-searching "Polars Cloud" directly in AWS Marketplace.
+marketplace listing either through the Billing page in your Polars Cloud organization, searching "Polars Cloud" directly in AWS Marketplace or by [clicking here to go the listing](https://aws.amazon.com/marketplace/pp/prodview-xrx4wmwctfrcc).
 
 The subscription process connects your Polars Cloud organization to AWS billing, after which your
 organization status updates to reflect the marketplace connection. This typically completes within
@@ -27,7 +26,8 @@ minutes, though allow up to an hour for status propagation.
 
 ### Verify Your Organization Connection
 
-After subscribing via Marketplace, you'll be redirected to the Polars Cloud organization dashboard.
+Connect your AWS billing account to your Polars Cloud organization by clicking "Set up product" and following the steps in the AWS Marketplace portal. After clicking "Set up your account" you are redirected to Polars Cloud where you can select and confirm the organization to connect.
+
 Under `Billing`, the status will update to show your organization is connected to AWS Marketplace.
 If the status doesn't update within 15 minutes, contact our support team at
 [support@polars.tech](mailto:support@polars.tech).

--- a/docs/source/polars-cloud/organization/billing.md
+++ b/docs/source/polars-cloud/organization/billing.md
@@ -18,7 +18,9 @@ stopping are not charged.
 ## Subscribe to Polars Cloud
 
 Subscribing to Polars Cloud requires an AWS account with billing permissions. You can access the
-marketplace listing either through the Billing page in your Polars Cloud organization, searching "Polars Cloud" directly in AWS Marketplace or by [clicking here to go the listing](https://aws.amazon.com/marketplace/pp/prodview-xrx4wmwctfrcc).
+marketplace listing either through the Billing page in your Polars Cloud organization, searching
+"Polars Cloud" directly in AWS Marketplace or by
+[clicking here to go the listing](https://aws.amazon.com/marketplace/pp/prodview-xrx4wmwctfrcc).
 
 The subscription process connects your Polars Cloud organization to AWS billing, after which your
 organization status updates to reflect the marketplace connection. This typically completes within
@@ -26,7 +28,9 @@ minutes, though allow up to an hour for status propagation.
 
 ### Verify Your Organization Connection
 
-Connect your AWS billing account to your Polars Cloud organization by clicking "Set up product" and following the steps in the AWS Marketplace portal. After clicking "Set up your account" you are redirected to Polars Cloud where you can select and confirm the organization to connect.
+Connect your AWS billing account to your Polars Cloud organization by clicking "Set up product" and
+following the steps in the AWS Marketplace portal. After clicking "Set up your account" you are
+redirected to Polars Cloud where you can select and confirm the organization to connect.
 
 Under `Billing`, the status will update to show your organization is connected to AWS Marketplace.
 If the status doesn't update within 15 minutes, contact our support team at

--- a/docs/source/polars-on-premises/bare-metal/getting-started.md
+++ b/docs/source/polars-on-premises/bare-metal/getting-started.md
@@ -1,7 +1,7 @@
 !!! note "Enterprise only"
 
     Bare-metal deployment requires a Polars On-Prem Enterprise license.
-    [Sign up here](https://w0lzyfh2w8o.typeform.com/to/f37L1SRx#form_name=enterprise&form_origin=userguide) to obtain one.
+    [Contact the team](https://w0lzyfh2w8o.typeform.com/to/f37L1SRx#form_name=enterprise&form_origin=userguide) to discuss your setup.
 
 ## Downloading Polars On-Prem
 

--- a/docs/source/polars-on-premises/kubernetes/index.md
+++ b/docs/source/polars-on-premises/kubernetes/index.md
@@ -171,7 +171,8 @@ troubleshoot queries.
 
 The data your queries process stays entirely within your environment, and is never shared with us.
 
-Need an air-gapped Enterprise deployment that runs entirely in your infrastructure without outside connections? See the [On-Prem Enterprise](#on-prem-enterprise) section to get started.
+Need an air-gapped Enterprise deployment that runs entirely in your infrastructure without outside
+connections? See the [On-Prem Enterprise](#on-prem-enterprise) section to get started.
 
 ### Production configuration
 
@@ -256,4 +257,7 @@ unavailable on managed clusters, so prefer shared shuffle storage where possible
 
 ## On-Prem Enterprise
 
-Looking to run multiple concurrent clusters, in an air-gapped environment, or on bare-metal machines? [Contact the team](https://w0lzyfh2w8o.typeform.com/to/f37L1SRx#form_name=enterprise&form_origin=userguide) to discuss your setup.
+Looking to run multiple concurrent clusters, in an air-gapped environment, or on bare-metal
+machines?
+[Contact the team](https://w0lzyfh2w8o.typeform.com/to/f37L1SRx#form_name=enterprise&form_origin=userguide)
+to discuss your setup.

--- a/docs/source/polars-on-premises/kubernetes/index.md
+++ b/docs/source/polars-on-premises/kubernetes/index.md
@@ -171,9 +171,7 @@ troubleshoot queries.
 
 The data your queries process stays entirely within your environment, and is never shared with us.
 
-We also offer custom solutions for running Polars On-Prem in air-gapped environments in which
-registration with our servers is not required, and no data is shared with us (see
-[On-Prem Enterprise](#on-prem-enterprise) section).
+Need an air-gapped Enterprise deployment that runs entirely in your infrastructure without outside connections? See the [On-Prem Enterprise](#on-prem-enterprise) section to get started.
 
 ### Production configuration
 
@@ -258,6 +256,4 @@ unavailable on managed clusters, so prefer shared shuffle storage where possible
 
 ## On-Prem Enterprise
 
-If you are interested in deploying one or several clusters without any resource limitations nor data
-sharing, on bare-metal machines or in a Kubernetes setup, and in air-gapped environments, please
-[sign up here to apply](https://w0lzyfh2w8o.typeform.com/to/f37L1SRx#form_name=enterprise&form_origin=userguide).
+Looking to run multiple concurrent clusters, in an air-gapped environment, or on bare-metal machines? [Contact the team](https://w0lzyfh2w8o.typeform.com/to/f37L1SRx#form_name=enterprise&form_origin=userguide) to discuss your setup.


### PR DESCRIPTION
The PR covers some minor changes in the user guide to clarify two sections.

- Billing docs: clarified the AWS Marketplace subscription and organization connection flow ("Set up product" then "Set up your account"), added a direct link to the listing.
- On-Prem docs: updated wording for consistency across bare-metal and Kubernetes sections on the Enterprise tier.