### PR TITLE
docs(python): Clarify DataFrame.remove combines predicates with AND

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -5573,13 +5573,6 @@ class DataFrame:
 
         Notes
         -----
-        Because multiple predicates are combined with `&` (logical AND), passing
-        several predicates to a single call is *not* the same as chaining `remove`
-        calls. For example, ``df.remove(a, b)`` removes only the rows where both ``a``
-        and ``b`` are True, whereas ``df.remove(a).remove(b)`` removes every row where
-        ``a`` or ``b`` is True. To remove rows matching *any* of several predicates in a
-        single call, combine them explicitly with `|` (see examples below).
-
         If you are transitioning from Pandas, and performing filter operations based on
         the comparison of two or more columns, please note that in Polars any comparison
         involving `null` values will result in a `null` result, *not* boolean True or
@@ -5656,32 +5649,6 @@ class DataFrame:
         │ null ┆ null ┆ null │
         │ 4    ┆ null ┆ c    │
         └──────┴──────┴──────┘
-
-        Multiple predicates are combined with `&` (logical AND), so a row is only
-        removed when *all* of them are True. To instead remove rows matching *any*
-        predicate, combine them with `|` (logical OR):
-
-        >>> df2 = pl.DataFrame({"a": [1, 0, 2, 0], "b": [0, 4, 5, 0]})
-        >>> df2.remove(pl.col("a") == 0, pl.col("b") == 0)  # a == 0 AND b == 0
-        shape: (3, 2)
-        ┌─────┬─────┐
-        │ a   ┆ b   │
-        │ --- ┆ --- │
-        │ i64 ┆ i64 │
-        ╞═════╪═════╡
-        │ 1   ┆ 0   │
-        │ 0   ┆ 4   │
-        │ 2   ┆ 5   │
-        └─────┴─────┘
-        >>> df2.remove((pl.col("a") == 0) | (pl.col("b") == 0))  # a == 0 OR b == 0
-        shape: (1, 2)
-        ┌─────┬─────┐
-        │ a   ┆ b   │
-        │ --- ┆ --- │
-        │ i64 ┆ i64 │
-        ╞═════╪═════╡
-        │ 2   ┆ 5   │
-        └─────┴─────┘
 
         Provide constraints(s) using `**kwargs` syntax:
 

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -5563,7 +5563,9 @@ class DataFrame:
         Parameters
         ----------
         predicates
-            Expression that evaluates to a boolean Series.
+            Expression(s) that evaluate to a boolean Series. When multiple predicates
+            are provided they are combined using `&` (logical AND), so a row is only
+            removed when *every* predicate evaluates to True for that row.
         constraints
             Column filters; use `name = value` to filter columns using the supplied
             value. Each constraint behaves the same as `pl.col(name).eq(value)`,
@@ -5571,6 +5573,13 @@ class DataFrame:
 
         Notes
         -----
+        Because multiple predicates are combined with `&` (logical AND), passing
+        several predicates to a single call is *not* the same as chaining `remove`
+        calls. For example, ``df.remove(a, b)`` removes only the rows where both ``a``
+        and ``b`` are True, whereas ``df.remove(a).remove(b)`` removes every row where
+        ``a`` or ``b`` is True. To remove rows matching *any* of several predicates in a
+        single call, combine them explicitly with `|` (see examples below).
+
         If you are transitioning from Pandas, and performing filter operations based on
         the comparison of two or more columns, please note that in Polars any comparison
         involving `null` values will result in a `null` result, *not* boolean True or
@@ -5647,6 +5656,32 @@ class DataFrame:
         │ null ┆ null ┆ null │
         │ 4    ┆ null ┆ c    │
         └──────┴──────┴──────┘
+
+        Multiple predicates are combined with `&` (logical AND), so a row is only
+        removed when *all* of them are True. To instead remove rows matching *any*
+        predicate, combine them with `|` (logical OR):
+
+        >>> df2 = pl.DataFrame({"a": [1, 0, 2, 0], "b": [0, 4, 5, 0]})
+        >>> df2.remove(pl.col("a") == 0, pl.col("b") == 0)  # a == 0 AND b == 0
+        shape: (3, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i64 ┆ i64 │
+        ╞═════╪═════╡
+        │ 1   ┆ 0   │
+        │ 0   ┆ 4   │
+        │ 2   ┆ 5   │
+        └─────┴─────┘
+        >>> df2.remove((pl.col("a") == 0) | (pl.col("b") == 0))  # a == 0 OR b == 0
+        shape: (1, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i64 ┆ i64 │
+        ╞═════╪═════╡
+        │ 2   ┆ 5   │
+        └─────┴─────┘
 
         Provide constraints(s) using `**kwargs` syntax:
 

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -5093,7 +5093,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         Parameters
         ----------
         predicates
-            Expression that evaluates to a boolean Series.
+            Expression(s) that evaluate to a boolean Series. When multiple predicates
+            are provided they are combined using `&` (logical AND), so a row is only
+            removed when *every* predicate evaluates to True for that row.
         constraints
             Column filters; use `name = value` to filter columns using the supplied
             value. Each constraint behaves the same as `pl.col(name).eq(value)`,


### PR DESCRIPTION
Related issue: #28106.

Passing multiple predicates to `DataFrame.remove` combines them with `&` (logical AND), so a row is only removed when **every** predicate evaluates to True. This is easy to misread as OR:

```python
df.remove(a, b)          # removes rows where a AND b are True
df.remove(a).remove(b)   # removes rows where a OR b is True
```

The docstring previously described `predicates` only as "Expression that evaluates to a boolean Series" and did not state how multiple predicates combine, which led to the confusion in #28106 (`df.remove(cond_a, cond_b)` removing fewer rows than expected).

## Changes (docs only, no behavior change)

- Document in the `predicates` parameter that multiple predicates are combined with `&`.
- Add a Notes paragraph contrasting `remove(a, b)` (AND) with `remove(a).remove(b)` (OR), and pointing to `|` for matching any predicate in a single call.
- Add an example demonstrating the AND vs OR results.

The AND semantics are intentional and consistent with `DataFrame.filter`; this PR only clarifies them.

## Verification

- New doctest examples verified against polars (`python -m doctest`, all pass).
- `ruff check` passes; all lines within the 88-char limit.