### PR TITLE
docs(python): Correct that `merge_sorted()` null inputs should be nulls first

### DIFF
--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -9130,7 +9130,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         The output of this operation will also be sorted.
         It is the callers responsibility that the frames
         are sorted in ascending order by the key, with null
-        keys at the end, otherwise the order of the output
+        keys at the start, otherwise the order of the output
         will not make sense.
 
         The schemas of both LazyFrames must be equal.


### PR DESCRIPTION
In https://github.com/pola-rs/polars/pull/27743, I accidentally mentioned that nulls should be at the **end**, when being input to `merge_sorted()`. However, the default for `nulls_last` in Polars is `False`. This PR fixes that