### PR TITLE
fix(rust): Declare MSRV 1.95 in workspace.package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ edition = "2024"
 homepage = "https://www.pola.rs/"
 license = "MIT"
 repository = "https://github.com/pola-rs/polars"
+rust-version = "1.95"
 
 [workspace.dependencies]
 aho-corasick = "1.1"

--- a/crates/polars-python/Cargo.toml
+++ b/crates/polars-python/Cargo.toml
@@ -6,6 +6,7 @@ edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+rust-version = { workspace = true }
 description = "Enable running Polars workloads in Python"
 
 [dependencies]

--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -8,6 +8,7 @@ keywords = ["dataframe", "query-engine", "arrow"]
 license = { workspace = true }
 readme = "../../README.md"
 repository = { workspace = true }
+rust-version = { workspace = true }
 description = "DataFrame library based on Apache Arrow"
 
 [dependencies]


### PR DESCRIPTION
Closes #24792.

Polars needs Rust 1.95+ to build (let-chains in plpath.rs stabilised in 1.88, std::hint::cold_path stabilised in 1.95), but the workspace never advertised an MSRV. Users on older toolchains were hitting cryptic E0658 errors about unstable features instead of getting a clean cargo error.

This adds `rust-version = "1.95"` to `[workspace.package]` and inherits it on the two published crates users actually depend on (`polars` and `polars-python`). After this, `cargo +1.94 build` against a project that uses polars will fail fast with a readable message pointing at the required toolchain.

Verified locally with `cargo metadata --no-deps --format-version 1` — both `polars` and `polars-python` now report `rust_version: "1.95"` where they previously reported null.

This is a config-only change, no source code touched, so the existing test suite should be unaffected.