### PR TITLE
fix: normalize numpy byte order before constructing Series

### DIFF
--- a/py-polars/src/polars/_utils/construction/series.py
+++ b/py-polars/src/polars/_utils/construction/series.py
@@ -505,6 +505,13 @@ def numpy_to_pyseries(
     """Construct a PySeries from a numpy array."""
     values = np.ascontiguousarray(values)
 
+    # Convert non-native byte order to native.
+    # rust-numpy expects native dtype descriptors (e.g. PyArray1<f32>) and
+    # will fail with "not an instance of ndarray" when given a non-native
+    # byte order array like >f4.
+    if values.dtype.byteorder not in ("=", "|"):
+        values = values.astype(values.dtype.newbyteorder("="))
+
     if values.ndim == 1:
         values, dtype = numpy_values_and_dtype(values)
         constructor = numpy_type_to_constructor(values, dtype)


### PR DESCRIPTION
Convert non-native byte order numpy arrays (e.g. `>f4` big-endian
float32) to native byte order before passing to the Rust interop layer.
rust-numpy expects native dtype descriptors like `PyArray1<f32>` and
raises a confusing `TypeError: 'ndarray' object is not an instance of
'ndarray'` when given a non-native byte order array.

The fix adds a byte-order check in `numpy_to_pyseries()` after the
existing `np.ascontiguousarray()` call. Arrays with non-native byte
order (`byteorder not in ("=", "|")`) are converted via `.astype()`.

Closes #28174

---

- I used AI to generate the fix code and test.
- I confirm that I have reviewed all changes myself, and I believe they
are relevant and correct.