### PR TITLE
docs(python): Correct `merge_sorted()` docs also for `DataFrame`

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -12632,7 +12632,7 @@ class DataFrame:
         The output of this operation will also be sorted.
         It is the callers responsibility that the frames
         are sorted in ascending order by the key, with null
-        keys at the end, otherwise the order of the output
+        keys at the start, otherwise the order of the output
         will not make sense.
 
         The schemas of both DataFrames must be equal.


### PR DESCRIPTION
It turns out that I forgot to stage the docstring for `DataFrame` in https://github.com/pola-rs/polars/pull/28177 because I was in a rush. This PR also updates that docstring.