### PR TITLE
chore: Ignore quickxml DoS rustsec

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,9 @@ ignore = [
 
   # error[unmaintained]: Bincode is unmaintained
   "RUSTSEC-2025-0141",
+
+  # error[vulnerability]: Quadratic run time when checking a start tag for duplicate attribute names
+  "RUSTSEC-2026-0194",
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -20,8 +20,10 @@ ignore = [
   # error[unmaintained]: Bincode is unmaintained
   "RUSTSEC-2025-0141",
 
-  # error[vulnerability]: Quadratic run time when checking a start tag for duplicate attribute names
+  # error[vulnerability]: Quadratic run time when checking a start tag for duplicate attribute names in quick-xml
   "RUSTSEC-2026-0194",
+  # error[vulnerability]: Unbounded namespace-declaration allocation in `NsReader` enables memory-exhaustion denial of service in quick-xml
+  "RUSTSEC-2026-0195",
 ]
 
 [licenses]


### PR DESCRIPTION
Not particularly relevant for us and we can't resolve right now until upstream updates.