### PR TITLE
depr: Deprecate casts from non-nested dtypes into Lists

### DIFF
--- a/crates/polars-compute/src/cast/mod.rs
+++ b/crates/polars-compute/src/cast/mod.rs
@@ -497,6 +497,8 @@ pub fn cast(
         },
 
         (_, List(to)) => {
+            warn_cast_to_list_deprecated(from_type);
+
             // cast primitive to list's primitive
             let values = cast(array, &to.dtype, options)?;
             // create offsets, where if array.len() = 2, we have [0,1,2]
@@ -510,6 +512,8 @@ pub fn cast(
         },
 
         (_, LargeList(to)) if from_type != &LargeBinary => {
+            warn_cast_to_list_deprecated(from_type);
+
             // cast primitive to list's primitive
             let values = cast(array, &to.dtype, options)?;
             // create offsets, where if array.len() = 2, we have [0,1,2]
@@ -1263,4 +1267,12 @@ mod tests {
             vec![vec![10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10],]
         );
     }
+}
+
+fn warn_cast_to_list_deprecated(from_type: &ArrowDataType) {
+    polars_warn!(
+        Deprecation,
+        "casting from {from_type:?} to list type is deprecated\n\
+        Hint: Use pl.list(expr) to turn the {from_type:?} column into a column of single-element lists."
+    )
 }

--- a/crates/polars-compute/src/cast/mod.rs
+++ b/crates/polars-compute/src/cast/mod.rs
@@ -1158,6 +1158,14 @@ fn from_to_binview(
     Ok(binview)
 }
 
+fn warn_cast_to_list_deprecated(from_type: &ArrowDataType) {
+    polars_warn!(
+        Deprecation,
+        "casting from {from_type:?} to list type is deprecated\n\
+        Hint: Use pl.list(expr) to turn the {from_type:?} column into a column of single-element lists."
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use arrow::offset::OffsetsBuffer;
@@ -1267,12 +1275,4 @@ mod tests {
             vec![vec![10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10],]
         );
     }
-}
-
-fn warn_cast_to_list_deprecated(from_type: &ArrowDataType) {
-    polars_warn!(
-        Deprecation,
-        "casting from {from_type:?} to list type is deprecated\n\
-        Hint: Use pl.list(expr) to turn the {from_type:?} column into a column of single-element lists."
-    )
 }

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import operator
+import re
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
@@ -1072,3 +1073,14 @@ def test_strict_cast_nested() -> None:
         df.cast(struct, strict=False),
         pl.DataFrame({"a": [{"x": 42}, {"x": None}]}, schema={"a": struct}),
     )
+
+
+def test_cast_to_list_deprecated() -> None:
+    s = pl.Series("a", [1, 2, 3], dtype=pl.Int32)
+    msg = (
+        "casting from Int32 to list type is deprecated\n"
+        "Hint: Use pl.list(expr) to turn the Int32 column into a column of single-element lists."
+    )
+    with pytest.warns(DeprecationWarning, match=rf"^{re.escape(msg)}$"):
+        result = s.cast(pl.List(pl.Int32))
+    assert result.dtype == pl.List(pl.Int32)


### PR DESCRIPTION
Related issue: https://github.com/pola-rs/polars/issues/28085

:robot: No AI was used for this PR