### PR TITLE
fix(python): Normalize non-native byte order in numpy array construction

### DIFF
--- a/py-polars/src/polars/_utils/construction/series.py
+++ b/py-polars/src/polars/_utils/construction/series.py
@@ -503,6 +503,10 @@ def numpy_to_pyseries(
     nan_to_null: bool = False,
 ) -> PySeries:
     """Construct a PySeries from a numpy array."""
+    if not values.dtype.isnative:
+        # the Rust <-> numpy bridge only accepts native byte order; swap to a
+        # native-order copy instead of failing with an opaque PyO3 type error
+        values = values.astype(values.dtype.newbyteorder("="))
     values = np.ascontiguousarray(values)
 
     if values.ndim == 1:

--- a/py-polars/src/polars/_utils/construction/series.py
+++ b/py-polars/src/polars/_utils/construction/series.py
@@ -504,8 +504,7 @@ def numpy_to_pyseries(
 ) -> PySeries:
     """Construct a PySeries from a numpy array."""
     if not values.dtype.isnative:
-        # the Rust <-> numpy bridge only accepts native byte order; swap to a
-        # native-order copy instead of failing with an opaque PyO3 type error
+        # Only native byte order is supported, so swap to a native-order copy.
         values = values.astype(values.dtype.newbyteorder("="))
     values = np.ascontiguousarray(values)
 

--- a/py-polars/tests/unit/interop/numpy/test_from_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_from_numpy_series.py
@@ -101,9 +101,7 @@ def test_from_numpy_records_2d(
     "dtype",
     [">f4", ">f8", ">i4", ">i8", "<f4", "<i4"],
 )
-def test_from_numpy_non_native_byteorder(dtype: str) -> None:
-    # non-native byte order previously raised an opaque PyO3 TypeError instead of
-    # being normalized like any other numpy array (issue #28174)
+def test_from_numpy_non_native_byteorder_28174(dtype: str) -> None:
     arr = np.arange(5, dtype=dtype)
     s = pl.Series("data", arr)
     assert s.to_list() == list(range(5))

--- a/py-polars/tests/unit/interop/numpy/test_from_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_from_numpy_series.py
@@ -95,3 +95,18 @@ def test_from_numpy_records_2d(
 
     round_trip_array = s.to_numpy()[0][1]
     assert_array_equal(round_trip_array, arr2d)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [">f4", ">f8", ">i4", ">i8", "<f4", "<i4"],
+)
+def test_from_numpy_non_native_byteorder(dtype: str) -> None:
+    # non-native byte order previously raised an opaque PyO3 TypeError instead of
+    # being normalized like any other numpy array (issue #28174)
+    arr = np.arange(5, dtype=dtype)
+    s = pl.Series("data", arr)
+    assert s.to_list() == list(range(5))
+
+    df = pl.DataFrame(arr)
+    assert df.to_series().to_list() == list(range(5))


### PR DESCRIPTION
Closes #28174.

## Problem

Constructing a `Series` or `DataFrame` from a numpy array with non-native byte order raises an opaque error instead of just working:

```python
import polars as pl
import numpy as np

pl.DataFrame(np.arange(5, dtype=">f4"))  # big-endian on a little-endian machine
# TypeError: argument 'array': 'ndarray' object cannot be converted to 'PyArray<T, D>'
```

`numpy_to_pyseries` (`py-polars/src/polars/_utils/construction/series.py`) only normalizes contiguity via `np.ascontiguousarray`, not byte order. The Rust/numpy bridge (PyO3) requires native byte order, so a big-endian array on a little-endian machine (or vice versa) fails the PyO3 type check with a message that gives no indication of the actual cause.

## Fix

Before the contiguity check, swap non-native arrays to a native-order copy:

```python
if not values.dtype.isnative:
    values = values.astype(values.dtype.newbyteorder("="))
```

`dtype.isnative` correctly handles single-byte/bool dtypes where byte order is meaningless (always `True` for those), so this only triggers for genuinely non-native multi-byte dtypes.

## Test

Added `test_from_numpy_non_native_byteorder` in `tests/unit/interop/numpy/test_from_numpy_series.py`, parametrized over big/little-endian int and float dtypes, covering both `Series` and `DataFrame` construction and asserting the values round-trip correctly (not byte-garbled).

Verified against a pip-installed polars build (1.36.1) with the same patch applied, since building from source requires a Rust toolchain not available in this environment — confirmed the new test fails without the fix (opaque `TypeError`) and passes with it, and that native-order arrays are unaffected.