### PR TITLE
fix(python!): Remove `missing_utf8_is_empty_string` keyword from `read_csv`/`scan_csv`

### DIFF
--- a/py-polars/src/polars/_utils/deprecation.py
+++ b/py-polars/src/polars/_utils/deprecation.py
@@ -107,7 +107,6 @@ def deprecate_renamed_parameter(
     new_name: str,
     *,
     version: str,
-    mapper: Callable[[object], object] = lambda x: x,
 ) -> IdentityFunction:
     """
     Decorator to mark a function parameter as deprecated due to being renamed.
@@ -127,7 +126,7 @@ def deprecate_renamed_parameter(
         @wraps(function)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             _rename_keyword_argument(
-                old_name, new_name, kwargs, function.__qualname__, version, mapper
+                old_name, new_name, kwargs, function.__qualname__, version
             )
             return function(*args, **kwargs)
 
@@ -143,7 +142,6 @@ def _rename_keyword_argument(
     kwargs: dict[str, object],
     func_name: str,
     version: str,
-    mapper: Callable[[object], object],
 ) -> None:
     """Rename a keyword argument of a function."""
     if old_name in kwargs:
@@ -162,7 +160,7 @@ def _rename_keyword_argument(
             f"the argument `{old_name}` for `{func_name}` is deprecated. "
             f"It was renamed to `{new_name}`{in_version}."
         )
-        kwargs[new_name] = mapper(kwargs.pop(old_name))
+        kwargs[new_name] = kwargs.pop(old_name)
 
 
 def deprecate_nonkeyword_arguments(

--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -56,12 +56,6 @@ if TYPE_CHECKING:
 @deprecate_renamed_parameter("dtypes", "schema_overrides", version="0.20.31")
 @deprecate_renamed_parameter("row_count_name", "row_index_name", version="0.20.4")
 @deprecate_renamed_parameter("row_count_offset", "row_index_offset", version="0.20.4")
-@deprecate_renamed_parameter(
-    "missing_utf8_is_empty_string",
-    "empty_string_is_null",
-    version="1.43.0",
-    mapper=lambda x: not x,
-)
 def read_csv(
     source: str | Path | IO[str] | IO[bytes] | bytes,
     *,
@@ -775,12 +769,6 @@ def _read_csv_impl(
 @deprecate_renamed_parameter("dtypes", "schema_overrides", version="0.20.31")
 @deprecate_renamed_parameter("row_count_name", "row_index_name", version="0.20.4")
 @deprecate_renamed_parameter("row_count_offset", "row_index_offset", version="0.20.4")
-@deprecate_renamed_parameter(
-    "missing_utf8_is_empty_string",
-    "empty_string_is_null",
-    version="1.43.0",
-    mapper=lambda x: not x,
-)
 def read_csv_batched(
     source: str | Path,
     *,
@@ -1107,12 +1095,6 @@ def read_csv_batched(
 @deprecate_renamed_parameter("dtypes", "schema_overrides", version="0.20.31")
 @deprecate_renamed_parameter("row_count_name", "row_index_name", version="0.20.4")
 @deprecate_renamed_parameter("row_count_offset", "row_index_offset", version="0.20.4")
-@deprecate_renamed_parameter(
-    "missing_utf8_is_empty_string",
-    "empty_string_is_null",
-    version="1.43.0",
-    mapper=lambda x: not x,
-)
 def scan_csv(
     source: (
         str

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -3207,11 +3207,3 @@ def test_read_csv_mixed_i128_float_infers_float64_27654(chunk_override: None) ->
     csv_data = b"value\n12345678901234567890\n1.5"
     df = pl.read_csv(csv_data)
     assert df.schema["value"] == pl.Float64
-
-
-def test_read_csv_missing_utf8_is_empty_string_deprecated() -> None:
-    with pytest.warns(
-        DeprecationWarning,
-        match=r"`missing_utf8_is_empty_string` for `read_csv` is deprecated",
-    ):
-        pl.read_csv(b"a,b\n1,2", missing_utf8_is_empty_string=True)  # type: ignore[call-arg]


### PR DESCRIPTION
Related issue: https://github.com/pola-rs/polars/issues/17544

:robot: No AI was used for this PR
