### PR TITLE
feat(python): Accept expressions and selectors in read_csv columns parameter

### DIFF
--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -17,6 +17,7 @@ from polars._utils.deprecation import (
 from polars._utils.unstable import issue_unstable_warning
 from polars._utils.various import (
     _process_null_values,
+    is_int_sequence,
     is_path_or_str_sequence,
     is_str_sequence,
     normalize_filepath,
@@ -40,11 +41,12 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     from polars._plr import PyDataFrame, PyLazyFrame
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable, Iterable, Mapping
 
     from polars import DataFrame, LazyFrame
     from polars._typing import (
         CsvEncoding,
+        IntoExpr,
         PolarsDataType,
         SchemaDict,
         StorageOptionsDict,
@@ -66,7 +68,11 @@ def read_csv(
     source: str | Path | IO[str] | IO[bytes] | bytes,
     *,
     has_header: bool = True,
-    columns: Sequence[int] | Sequence[str] | None = None,
+    columns: Sequence[int]
+    | Sequence[str]
+    | IntoExpr
+    | Iterable[IntoExpr]
+    | None = None,
     new_columns: Sequence[str] | None = None,
     separator: str = ",",
     comment_prefix: str | None = None,
@@ -128,7 +134,13 @@ def read_csv(
         `x` being an enumeration over every column in the dataset, starting at 1.
     columns
         Columns to select. Accepts a list of column indices (starting
-        at zero) or a list of column names.
+        at zero) or a list of column names. Also accepts a single expression,
+        or any other selection supported by :meth:`LazyFrame.select`, such as
+        a selector (e.g. `polars.selectors.numeric()`); in that case the file
+        is read via `scan_csv` and the selection is applied afterwards, so
+        `use_pyarrow` is not supported in combination with this kind of
+        `columns` value. A plain string or list of strings is always treated
+        as a literal column name (or names), not a selector.
     new_columns
         Rename columns right after parsing the CSV file. If the given
         list is shorter than the width of the DataFrame the remaining
@@ -303,6 +315,57 @@ def read_csv(
     _check_arg_is_1byte("separator", separator, can_be_empty=False)
     _check_arg_is_1byte("quote_char", quote_char, can_be_empty=True)
     _check_arg_is_1byte("eol_char", eol_char, can_be_empty=False)
+
+    if columns is not None and not (
+        isinstance(columns, (str, int))
+        or is_str_sequence(columns, allow_str=False)
+        or is_int_sequence(columns)
+    ):
+        # `columns` is some other `.select`-compatible value (e.g. a regex
+        # pattern, `Expr`, or selector); the native reader only understands
+        # column names/indices, so read the full file lazily and apply the
+        # selection afterwards, same as `read_parquet` does for this case.
+        if use_pyarrow:
+            msg = (
+                "`use_pyarrow=True` is not supported when `columns` is not a "
+                "sequence of column names or indices"
+            )
+            raise TypeError(msg)
+
+        lf = scan_csv(
+            source,
+            has_header=has_header,
+            separator=separator,
+            comment_prefix=comment_prefix,
+            quote_char=quote_char,
+            skip_rows=skip_rows,
+            skip_lines=skip_lines,
+            schema=schema,
+            schema_overrides=schema_overrides,
+            null_values=null_values,
+            empty_string_is_null=empty_string_is_null,
+            ignore_errors=ignore_errors,
+            infer_schema=infer_schema,
+            infer_schema_length=infer_schema_length,
+            n_rows=n_rows,
+            encoding=encoding,  # type: ignore[arg-type]
+            low_memory=low_memory,
+            rechunk=rechunk,
+            skip_rows_after_header=skip_rows_after_header,
+            row_index_name=row_index_name,
+            row_index_offset=row_index_offset,
+            try_parse_dates=try_parse_dates,
+            eol_char=eol_char,
+            raise_if_empty=raise_if_empty,
+            truncate_ragged_lines=truncate_ragged_lines,
+            decimal_comma=decimal_comma,
+            glob=glob,
+            storage_options=storage_options,
+        )
+        df = lf.select(columns).collect()
+        if new_columns:
+            return _update_columns(df, new_columns)
+        return df
 
     projection, columns = parse_columns_arg(columns)
     storage_options = storage_options or {}

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2200,6 +2200,39 @@ def test_read_csv_single_column(chunk_override: None, columns: list[str] | str) 
     assert_frame_equal(df, expected)
 
 
+def test_read_csv_columns_selector_28098() -> None:
+    import polars.selectors as cs
+
+    csv = textwrap.dedent(
+        """\
+        a0,a1,b0
+        1,x,3
+        2,y,4
+        """
+    )
+
+    df = pl.read_csv(io.StringIO(csv), columns=pl.col("a0"))
+    assert_frame_equal(df, pl.DataFrame({"a0": [1, 2]}))
+
+    df = pl.read_csv(io.StringIO(csv), columns=cs.numeric())
+    assert_frame_equal(df, pl.DataFrame({"a0": [1, 2], "b0": [3, 4]}))
+
+    df = pl.read_csv(io.StringIO(csv), columns=[pl.col("a0"), pl.col("b0")])
+    assert_frame_equal(df, pl.DataFrame({"a0": [1, 2], "b0": [3, 4]}))
+
+    # `new_columns` renames after the selector-based selection is applied
+    df = pl.read_csv(io.StringIO(csv), columns=cs.numeric(), new_columns=["x", "y"])
+    assert_frame_equal(df, pl.DataFrame({"x": [1, 2], "y": [3, 4]}))
+
+    with pytest.raises(TypeError, match="use_pyarrow=True"):
+        pl.read_csv(io.StringIO(csv), columns=pl.col("a0"), use_pyarrow=True)
+
+    # plain str/int (and sequences thereof) are unaffected and keep going
+    # through the native reader's column projection, not `.select`
+    df = pl.read_csv(io.StringIO(csv), columns="a0")
+    assert_frame_equal(df, pl.DataFrame({"a0": [1, 2]}))
+
+
 def test_csv_invalid_escape_utf8_14960(chunk_override: None) -> None:
     with pytest.raises(ComputeError, match=r"Field .* is not properly escaped"):
         pl.read_csv('col1\n""•'.encode())


### PR DESCRIPTION
Closes #28098.

## Problem

`read_parquet` already accepts an `Expr`, selector, or any other `.select`-compatible value for its `columns` parameter, e.g.:

```python
pl.read_parquet(source, columns=pl.selectors.numeric())
```

This works because `read_parquet`'s non-pyarrow path always defers to `scan_parquet(...).select(...)`, and `.select()` natively accepts all of that — it's an accidental (and undocumented, see #28097) side effect of its implementation, not an intentional feature.

`read_csv` has no equivalent: it calls the native reader (or `parse_columns_arg`) directly, which only understands plain column names/indices, so anything else raises `TypeError: the columns argument should contain a list of all integers or all string values`.

## Fix

Add the same escape hatch to `read_csv`. When `columns` is not a plain `str`/`int` or a sequence of `str`/`int`, read the file lazily via `scan_csv` and apply the selection with `LazyFrame.select` afterwards — same approach `read_parquet` already uses:

```python
import polars as pl
import polars.selectors as cs

pl.read_csv(source, columns=pl.col("a"))
pl.read_csv(source, columns=cs.numeric())
pl.read_csv(source, columns=[pl.col("a"), pl.col("b")])
```

`new_columns` is applied after the selector-based selection, consistent with the rest of `read_csv`.

### Scope decision

A plain `str`/`Sequence[str]`/`int`/`Sequence[int]` (the existing, documented, and by far most common usage) is **unchanged** — it keeps going through the existing native-reader fast path exactly as before. I intentionally did *not* extend this to give bare strings new regex-pattern semantics (`read_parquet`'s example in #28097 uses `columns="^a.*$"` as a selector pattern) — only genuinely new input types (`Expr`, selectors, other iterables) get the new behavior. Changing bare-string semantics would touch the single most common call pattern for `columns` and I wasn't able to fully verify there's no performance difference between the native reader's projection pushdown and the `scan_csv` + `.select()` path for CSV specifically (unlike parquet, which is columnar on disk either way). Happy to extend if maintainers want full parity with `read_parquet`'s example.

`use_pyarrow=True` combined with a non-plain `columns` value raises a clear `TypeError`, since the pyarrow path only understands literal column names.

## Test

Added `test_read_csv_columns_selector_28098` in `tests/unit/io/test_csv.py`, covering: a bare `Expr`, a selector, a list of `Expr`, `new_columns` renaming after selection, the `use_pyarrow=True` error, and confirming a plain string still takes the unchanged literal-name path.

Verified against a pip-installed polars build (1.36.1) with the same patch applied, since building from source requires a Rust toolchain not available in this environment.