### PR TITLE
fix: Keep list arithmetic sink schemas consistent

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -483,6 +483,27 @@ fn func_args_to_fields(input: &[ExprIR], ctx: &ToFieldContext) -> PolarsResult<V
         .collect()
 }
 
+fn materialize_list_arithmetic_leaf_dtypes(
+    left_dtype: &DataType,
+    right_dtype: &DataType,
+) -> PolarsResult<(DataType, DataType)> {
+    let left_leaf_dtype = left_dtype.leaf_dtype().clone().materialize_unknown(true)?;
+    let right_leaf_dtype = right_dtype.leaf_dtype().clone().materialize_unknown(true)?;
+
+    Ok((left_leaf_dtype, right_leaf_dtype))
+}
+
+fn get_list_arithmetic_leaf_supertype(
+    op: NumericListOp,
+    left_dtype: &DataType,
+    right_dtype: &DataType,
+) -> PolarsResult<DataType> {
+    let (left_leaf_dtype, right_leaf_dtype) =
+        materialize_list_arithmetic_leaf_dtypes(left_dtype, right_dtype)?;
+
+    op.try_get_leaf_supertype(&left_leaf_dtype, &right_leaf_dtype)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn get_arithmetic_field(
     left: Node,
@@ -558,9 +579,10 @@ fn get_arithmetic_field(
                     // This currently doesn't cause any problems because the list arithmetic implementation checks and raises errors
                     // if the leaf types aren't numeric, but it means we don't raise an error until execution and the DSL schema
                     // may be incorrect.
-                    list_dtype.cast_leaf(NumericListOp::sub().try_get_leaf_supertype(
-                        list_dtype.leaf_dtype(),
-                        other_dtype.leaf_dtype(),
+                    list_dtype.cast_leaf(get_list_arithmetic_leaf_supertype(
+                        NumericListOp::sub(),
+                        list_dtype,
+                        other_dtype,
                     )?)
                 },
                 #[cfg(feature = "dtype-array")]
@@ -620,9 +642,10 @@ fn get_arithmetic_field(
                     )
                 },
                 (list_dtype @ List(_), other_dtype) | (other_dtype, list_dtype @ List(_)) => {
-                    list_dtype.cast_leaf(NumericListOp::add().try_get_leaf_supertype(
-                        list_dtype.leaf_dtype(),
-                        other_dtype.leaf_dtype(),
+                    list_dtype.cast_leaf(get_list_arithmetic_leaf_supertype(
+                        NumericListOp::add(),
+                        list_dtype,
+                        other_dtype,
                     )?)
                 },
                 #[cfg(feature = "dtype-array")]
@@ -702,10 +725,10 @@ fn get_arithmetic_field(
                 // List<->primitive operations can be done directly after casting the to the primitive
                 // supertype for the primitive values on both sides.
                 (list_dtype @ List(_), other_dtype) | (other_dtype, list_dtype @ List(_)) => {
-                    let dtype = list_dtype.cast_leaf(try_get_supertype(
-                        list_dtype.leaf_dtype(),
-                        other_dtype.leaf_dtype(),
-                    )?);
+                    let (list_leaf_dtype, other_leaf_dtype) =
+                        materialize_list_arithmetic_leaf_dtypes(list_dtype, other_dtype)?;
+                    let dtype = list_dtype
+                        .cast_leaf(try_get_supertype(&list_leaf_dtype, &other_leaf_dtype)?);
                     left_field.coerce(dtype);
                     return Ok(left_field);
                 },

--- a/py-polars/tests/unit/operations/arithmetic/test_list.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_list.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import operator
 from typing import TYPE_CHECKING, Any
 
@@ -17,6 +18,33 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from polars._typing import PolarsDataType
+
+
+@pytest.mark.parametrize(
+    "op",
+    [operator.add, operator.sub, operator.mul, operator.floordiv, operator.mod],
+)
+@pytest.mark.parametrize("reverse", [False, True])
+def test_list_arithmetic_dynamic_literal_schema_26054(
+    op: Callable[[Any, Any], Any],
+    *,
+    reverse: bool,
+) -> None:
+    lf = pl.LazyFrame({"x": pl.Series([[2], [3]], dtype=pl.List(pl.Int16))})
+    expr = op(1, pl.col("x")) if reverse else op(pl.col("x"), 1)
+    query = lf.select(expr.alias("x"))
+
+    expected_schema = pl.Schema({"x": pl.List(pl.Int32)})
+    assert query.collect_schema() == expected_schema
+    assert query.collect().schema == expected_schema
+
+
+def test_list_arithmetic_dynamic_literal_sink_26054() -> None:
+    query = pl.LazyFrame({"x": pl.Series([[1], [2]], dtype=pl.List(pl.Int16))}).select(
+        pl.col("x") + 1
+    )
+
+    query.sink_parquet(io.BytesIO())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #26054

List arithmetic with dynamic literals could infer a narrower schema during planning than the dtype produced during execution. That mismatch caused sinks such as Parquet to fail even though collecting the same query succeeded.

This materializes dynamic literal leaf dtypes while inferring list arithmetic schemas, keeping the planned, collected, and written schemas consistent. It also adds regression coverage for the failing sink case.

Validation:
- Manually reproduced the failure before the change and verified the same query writes and reads back successfully afterward.
- Focused regression tests: 11 passed.
- List arithmetic tests: 446 passed.
- Full Python test suite: 17,909 passed, 87 skipped, 9 xfailed.
- Python lint, Rust formatting, and `cargo clippy -p polars-plan --all-features` passed.

AI usage disclosure:
1. I used OpenAI Codex to reproduce the issue, assist with the code changes, and run the validation.
2. I confirm that I reviewed all changes myself, and I believe they are relevant and correct.

Local `make test` run:

![Local make test run](https://gist.githubusercontent.com/vismaytiwari/0ed0f64190b9b883947b3013d8feadc7/raw/polars-make-test-summary.png)