### PR TITLE
chore: Tighten first-time-contributor screenshot requirements

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,8 @@ Please see the contribution guidelines: https://docs.pola.rs/development/contrib
 First-time contributors must adhere to the following rules, or your PR(s) will be closed:
 
 - You must post a screenshot of you successfully running the test suite (`make test`),
-  locally on your machine (not the CI).
+  locally on your machine (not the CI). The screenshot must show your terminal window
+  borders clearly, it must not be cropped to only show text.
 - You may not have more than one open PR at a time.
 
 Note that if you used AI to generate code there are additional requirements you

--- a/docs/source/development/contributing/index.md
+++ b/docs/source/development/contributing/index.md
@@ -331,8 +331,9 @@ We unfortunately are overwhelmed by the amount of low-quality contributions crea
 AI. These cost us a lot of time (and regularly simply don't work), while the author has barely spent
 any effort, so for first-time contributors there are some more rules:
 
-- You must post a screenshot of you successfully running the test suite (`make test`), locally on
-  your machine (not the CI).
+- You must post a screenshot of you successfully running the test suite (`make test`),
+  locally on your machine (not the CI). The screenshot must show your terminal window
+  borders clearly, it must not be cropped to only show text.
 - You may not have more than one open PR at a time.
 
 ## Contributing to documentation

--- a/docs/source/development/contributing/index.md
+++ b/docs/source/development/contributing/index.md
@@ -331,9 +331,9 @@ We unfortunately are overwhelmed by the amount of low-quality contributions crea
 AI. These cost us a lot of time (and regularly simply don't work), while the author has barely spent
 any effort, so for first-time contributors there are some more rules:
 
-- You must post a screenshot of you successfully running the test suite (`make test`),
-  locally on your machine (not the CI). The screenshot must show your terminal window
-  borders clearly, it must not be cropped to only show text.
+- You must post a screenshot of you successfully running the test suite (`make test`), locally on
+  your machine (not the CI). The screenshot must show your terminal window borders clearly, it must
+  not be cropped to only show text.
 - You may not have more than one open PR at a time.
 
 ## Contributing to documentation


### PR DESCRIPTION
We have now seen several attempts by agents to generate 'screenshots' of them running the test suite, by generating images from the logs. Luckily they've been relatively easy to spot still, but to make this even easier I've added the requirement that the terminal window borders are clearly visible, rather than being a close-up of just text.