### PR TITLE
fix(rust): Classify S3 region auto-detection request failures as IO errors

### DIFF
--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -464,7 +464,7 @@ impl CloudOptions {
                                 .head(format!("https://{bucket}.s3.amazonaws.com"))
                                 .send()
                                 .await
-                                .map_err(to_compute_err)
+                                .map_err(|e| PolarsError::from(std::io::Error::other(e)))
                         })
                         .await?;
                         if let Some(region) = result.headers().get("x-amz-bucket-region") {


### PR DESCRIPTION
Closes #28080

### Problem

When neither `region` nor `default_region` is configured, polars infers the
S3 bucket region with a HEAD request to `https://{bucket}.s3.amazonaws.com`.
If that request fails (e.g. network error, non-existent bucket), the error was
wrapped with `to_compute_err`, so Python received `ComputeError` instead of
`IOError`/`OSError`.

This was pointed out in https://github.com/pola-rs/polars/pull/28066#discussion_r3469458174.

### Fix

Map the request failure through `std::io::Error::other`, which the existing
`From<io::Error> for PolarsError` impl turns into `PolarsError::IO`. This makes
region auto-detection request failures consistent with how other object-store
request failures are classified.

The UTF-8 decode of the returned `x-amz-bucket-region` header is left as
`to_compute_err`, since that is a response-parsing error rather than a request
failure.

### Verification

`cargo build -p polars-io --features aws` compiles cleanly (no new warnings on
the changed file). The repro in #28080 now takes the `PolarsError::IO { .. }`
branch instead of `ComputeError`.
