### PR TITLE
perf: Environment variable for logging slow DNS lookup

### DIFF
--- a/crates/polars-config/src/lib.rs
+++ b/crates/polars-config/src/lib.rs
@@ -1,5 +1,6 @@
 use std::sync::LazyLock;
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
+use std::time::Duration;
 
 mod engine;
 mod parse;
@@ -94,6 +95,10 @@ const DEFAULT_PROJECTION_PUSHDOWN_PRUNE_STRICT_HCONCAT_INPUTS: bool = false;
 const ALLOW_NESTED_CSPE: &str = "POLARS_ALLOW_NESTED_CSPE";
 const DEFAULT_ALLOW_NESTED_CSPE: bool = false;
 
+const DNS_LOG_THRESHOLD_MS: &str = "POLARS_DNS_LOG_THRESHOLD_MS";
+/// Sentinel meaning "env var not set / logging disabled".
+const DNS_LOG_THRESHOLD_DISABLED: u64 = u64::MAX;
+
 static KNOWN_OPTIONS: &[&str] = &[
     // Public.
     VERBOSE,
@@ -143,6 +148,7 @@ static KNOWN_OPTIONS: &[&str] = &[
     OOC_LOG_METRICS,
     JOIN_SAMPLE_LIMIT,
     PROJECTION_PUSHDOWN_PRUNE_STRICT_HCONCAT_INPUTS,
+    DNS_LOG_THRESHOLD_MS,
 ];
 
 pub struct Config {
@@ -171,6 +177,7 @@ pub struct Config {
     ooc_log_metrics: AtomicBool,
     join_sample_limit: AtomicU64,
     projection_pushdown_prune_strict_hconcat_inputs: AtomicBool,
+    dns_log_threshold_ms: AtomicU64,
 }
 
 impl Config {
@@ -211,6 +218,7 @@ impl Config {
                 DEFAULT_PROJECTION_PUSHDOWN_PRUNE_STRICT_HCONCAT_INPUTS,
             ),
             allow_nested_cspe: AtomicBool::new(DEFAULT_ALLOW_NESTED_CSPE),
+            dns_log_threshold_ms: AtomicU64::new(DNS_LOG_THRESHOLD_DISABLED),
         };
         cfg.reload_env_vars();
         cfg
@@ -358,6 +366,11 @@ impl Config {
                     Ordering::Relaxed,
                 )
             },
+            DNS_LOG_THRESHOLD_MS => self.dns_log_threshold_ms.store(
+                val.and_then(|x| parse::parse_u64(var, x))
+                    .unwrap_or(DNS_LOG_THRESHOLD_DISABLED),
+                Ordering::Relaxed,
+            ),
             _ => {
                 if var.starts_with("POLARS_") {
                     if self.warn_unknown_config.load(Ordering::Relaxed) {
@@ -501,6 +514,14 @@ impl Config {
     pub fn projection_pushdown_prune_strict_hconcat_inputs(&self) -> bool {
         self.projection_pushdown_prune_strict_hconcat_inputs
             .load(Ordering::Relaxed)
+    }
+
+    #[inline(always)]
+    pub fn dns_log_threshold(&self) -> Option<Duration> {
+        match self.dns_log_threshold_ms.load(Ordering::Relaxed) {
+            DNS_LOG_THRESHOLD_DISABLED => None,
+            ms => Some(Duration::from_millis(ms)),
+        }
     }
 }
 

--- a/crates/polars-io/src/cloud/dns.rs
+++ b/crates/polars-io/src/cloud/dns.rs
@@ -1,5 +1,5 @@
 use std::net::{SocketAddr, ToSocketAddrs};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::{Duration, Instant};
 
 use hashbrown::HashMap;
@@ -9,6 +9,35 @@ use tokio::sync::RwLock;
 type DynErr = Box<dyn std::error::Error + Send + Sync>;
 
 const DEFAULT_DNS_CACHE_TTL_SECS: u64 = 5;
+
+static POLARS_DNS_LOG_THRESHOLD: LazyLock<Option<Duration>> = LazyLock::new(|| {
+    let v: Option<Duration> =
+        std::env::var("POLARS_DNS_LOG_THRESHOLD_MS")
+            .ok()
+            .and_then(|x| match x.trim().parse::<u64>() {
+                Ok(ms) => Some(Duration::from_millis(ms)),
+                Err(_) => {
+                    if polars_config::config().verbose() {
+                        eprintln!(
+                            "[dns_cache] ignoring invalid POLARS_DNS_LOG_THRESHOLD_MS={x:?} \
+                         (expected integer milliseconds)"
+                        );
+                    }
+                    None
+                },
+            });
+
+    if let Some(v) = v
+        && polars_config::config().verbose()
+    {
+        eprintln!(
+            "[dns_cache] dns log threshold: {} ms",
+            v.as_secs_f64() * 1000.0
+        )
+    }
+
+    v
+});
 
 pub(crate) fn get_dns_cache_ttl() -> Duration {
     let ttl = Duration::from_secs(
@@ -77,6 +106,7 @@ impl Resolve for CachingResolver {
                 }
             }
 
+            let t0 = Instant::now();
             let addrs = Arc::new(
                 polars_core::runtime::ASYNC
                     .spawn_blocking(move || {
@@ -87,6 +117,17 @@ impl Resolve for CachingResolver {
                     .await
                     .map_err(DynErr::from)??,
             );
+            let elapsed = t0.elapsed();
+            if let Some(threshold) = POLARS_DNS_LOG_THRESHOLD.as_ref()
+                && elapsed.gt(&threshold)
+            {
+                eprintln!(
+                    "[dns_cache] dns lookup for {} took {:.1} ms, exceeded threshold of {} ms",
+                    &key,
+                    elapsed.as_secs_f64() as f64 * 1000.0,
+                    threshold.as_secs_f64() as f64 * 1000.0
+                )
+            }
 
             write_guard.insert(
                 key,

--- a/crates/polars-io/src/cloud/dns.rs
+++ b/crates/polars-io/src/cloud/dns.rs
@@ -119,13 +119,13 @@ impl Resolve for CachingResolver {
             );
             let elapsed = t0.elapsed();
             if let Some(threshold) = POLARS_DNS_LOG_THRESHOLD.as_ref()
-                && elapsed.gt(&threshold)
+                && elapsed.gt(threshold)
             {
                 eprintln!(
                     "[dns_cache] dns lookup for {} took {:.1} ms, exceeded threshold of {} ms",
                     &key,
-                    elapsed.as_secs_f64() as f64 * 1000.0,
-                    threshold.as_secs_f64() as f64 * 1000.0
+                    elapsed.as_secs_f64() * 1000.0,
+                    threshold.as_secs_f64() * 1000.0
                 )
             }
 

--- a/crates/polars-io/src/cloud/dns.rs
+++ b/crates/polars-io/src/cloud/dns.rs
@@ -118,25 +118,31 @@ impl Resolve for CachingResolver {
                     .map_err(DynErr::from)??,
             );
             let elapsed = t0.elapsed();
-            if let Some(threshold) = POLARS_DNS_LOG_THRESHOLD.as_ref()
-                && elapsed.gt(threshold)
-            {
-                eprintln!(
-                    "[dns_cache] dns lookup for {} took {:.1} ms, exceeded threshold of {} ms",
-                    &key,
-                    elapsed.as_secs_f64() * 1000.0,
-                    threshold.as_secs_f64() * 1000.0
-                )
-            }
 
             write_guard.insert(
-                key,
+                key.clone(),
                 CachedAddrs {
                     addrs: addrs.clone(),
                     fetched_at: Instant::now(),
                 },
             );
             drop(write_guard);
+
+            if let Some(threshold) = POLARS_DNS_LOG_THRESHOLD.as_ref()
+                && elapsed.gt(threshold)
+            {
+                let display_key = if polars_config::config().verbose_sensitive() {
+                    key.as_str()
+                } else {
+                    "<name suppressed>"
+                };
+                eprintln!(
+                    "[dns_cache] dns lookup for {} took {:.1} ms, exceeded threshold of {} ms",
+                    display_key,
+                    elapsed.as_secs_f64() * 1000.0,
+                    threshold.as_secs_f64() * 1000.0
+                )
+            }
 
             Ok(shuffle_addrs(&addrs))
         })

--- a/crates/polars-io/src/cloud/dns.rs
+++ b/crates/polars-io/src/cloud/dns.rs
@@ -1,5 +1,5 @@
 use std::net::{SocketAddr, ToSocketAddrs};
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use hashbrown::HashMap;

--- a/crates/polars-io/src/cloud/dns.rs
+++ b/crates/polars-io/src/cloud/dns.rs
@@ -10,35 +10,6 @@ type DynErr = Box<dyn std::error::Error + Send + Sync>;
 
 const DEFAULT_DNS_CACHE_TTL_SECS: u64 = 5;
 
-static POLARS_DNS_LOG_THRESHOLD: LazyLock<Option<Duration>> = LazyLock::new(|| {
-    let v: Option<Duration> =
-        std::env::var("POLARS_DNS_LOG_THRESHOLD_MS")
-            .ok()
-            .and_then(|x| match x.trim().parse::<u64>() {
-                Ok(ms) => Some(Duration::from_millis(ms)),
-                Err(_) => {
-                    if polars_config::config().verbose() {
-                        eprintln!(
-                            "[dns_cache] ignoring invalid POLARS_DNS_LOG_THRESHOLD_MS={x:?} \
-                         (expected integer milliseconds)"
-                        );
-                    }
-                    None
-                },
-            });
-
-    if let Some(v) = v
-        && polars_config::config().verbose()
-    {
-        eprintln!(
-            "[dns_cache] dns log threshold: {} ms",
-            v.as_secs_f64() * 1000.0
-        )
-    }
-
-    v
-});
-
 pub(crate) fn get_dns_cache_ttl() -> Duration {
     let ttl = Duration::from_secs(
         std::env::var("POLARS_DNS_CACHE_TTL_SECS")
@@ -128,8 +99,8 @@ impl Resolve for CachingResolver {
             );
             drop(write_guard);
 
-            if let Some(threshold) = POLARS_DNS_LOG_THRESHOLD.as_ref()
-                && elapsed.gt(threshold)
+            if let Some(threshold) = polars_config::config().dns_log_threshold()
+                && elapsed.gt(&threshold)
             {
                 let display_key = if polars_config::config().verbose_sensitive() {
                     key.as_str()


### PR DESCRIPTION
This PR introduces an env var to enable slow DNS logging. Unstable - for dev and test purposes only. 

For context, slow DNS lookups can be detrimental to overall query performance in a distributed environment, especially in k8s. This helps with detecting their occurrence, if any.

fyi @c-peters , @EndPositive 
