### PR TITLE
fix(rust): Don't panic in qcut on degenerate float input (all-NaN, infinite, include_breaks)

### DIFF
--- a/crates/polars-ops/src/series/ops/cut.rs
+++ b/crates/polars-ops/src/series/ops/cut.rs
@@ -189,13 +189,29 @@ pub fn qcut(
     let ca = s2.f64()?;
     let ca = ca.set(&ca.is_nan(), None)?;
 
-    if s.null_count() == s.len() {
-        // If we only have nulls we don't have any breakpoints.
-        return Ok(Series::full_null(
-            s.name().clone(),
-            s.len(),
-            &DataType::from_categories(Categories::global()),
-        ));
+    if ca.null_count() == ca.len() {
+        // No usable values (all null, all NaN, or empty): there are no
+        // breakpoints. Return nulls of the output dtype. With `include_breaks`
+        // this must be a Struct to match the non-degenerate path and the lazy
+        // schema, otherwise a downstream `.struct.field(...)` fails with a dtype
+        // mismatch. Guard on `ca` (post-NaN-removal), since an all-NaN input has
+        // no nulls in `s`.
+        let cat_dtype = DataType::from_categories(Categories::global());
+        if include_breaks {
+            let brk = Series::full_null(
+                PlSmallStr::from_static("breakpoint"),
+                s.len(),
+                &DataType::Float64,
+            );
+            let cat = Series::full_null(PlSmallStr::from_static("category"), s.len(), &cat_dtype);
+            return Ok(StructChunked::from_series(
+                s.name().clone(),
+                s.len(),
+                [&brk, &cat].into_iter(),
+            )?
+            .into_series());
+        }
+        return Ok(Series::full_null(s.name().clone(), s.len(), &cat_dtype));
     }
 
     let mut qbreaks: Vec<_> = ca
@@ -203,6 +219,15 @@ pub fn qcut(
         .into_iter()
         .map(|opt| opt.unwrap())
         .collect();
+
+    // A quantile that interpolates across an infinite value produces a NaN
+    // breakpoint, which would panic the sort below (partial_cmp returns None)
+    // and yield nonsensical bins. Reject it, mirroring the "breaks cannot be
+    // NaN" check in `cut`.
+    polars_ensure!(
+        !qbreaks.iter().any(|x| x.is_nan()),
+        ComputeError: "quantile breakpoint is NaN (the input may contain infinite values)"
+    );
 
     qbreaks.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
 

--- a/crates/polars-ops/src/series/ops/cut.rs
+++ b/crates/polars-ops/src/series/ops/cut.rs
@@ -190,12 +190,8 @@ pub fn qcut(
     let ca = ca.set(&ca.is_nan(), None)?;
 
     if ca.null_count() == ca.len() {
-        // No usable values (all null, all NaN, or empty): there are no
-        // breakpoints. Return nulls of the output dtype. With `include_breaks`
-        // this must be a Struct to match the non-degenerate path and the lazy
-        // schema, otherwise a downstream `.struct.field(...)` fails with a dtype
-        // mismatch. Guard on `ca` (post-NaN-removal), since an all-NaN input has
-        // no nulls in `s`.
+        // No usable values (all null/NaN/empty): no breakpoints. With
+        // `include_breaks` the output must still be a Struct to match the schema.
         let cat_dtype = DataType::from_categories(Categories::global());
         if include_breaks {
             let brk = Series::full_null(
@@ -220,10 +216,8 @@ pub fn qcut(
         .map(|opt| opt.unwrap())
         .collect();
 
-    // A quantile that interpolates across an infinite value produces a NaN
-    // breakpoint, which would panic the sort below (partial_cmp returns None)
-    // and yield nonsensical bins. Reject it, mirroring the "breaks cannot be
-    // NaN" check in `cut`.
+    // Interpolating across an infinity gives a NaN breakpoint that would panic
+    // the sort below; reject it, as `cut` already does.
     polars_ensure!(
         !qbreaks.iter().any(|x| x.is_nan()),
         ComputeError: "quantile breakpoint is NaN (the input may contain infinite values)"

--- a/py-polars/tests/unit/operations/test_qcut.py
+++ b/py-polars/tests/unit/operations/test_qcut.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 import polars as pl
-from polars.exceptions import DuplicateError
+from polars.exceptions import ComputeError, DuplicateError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 inf = float("inf")
@@ -154,3 +154,101 @@ def test_qcut_nan_input_values() -> None:
         dtype=pl.Categorical,
     )
     assert_series_equal(result, expected, categorical_as_str=True)
+
+
+def test_qcut_full_nan() -> None:
+    # All-NaN input used to panic (unwrap on None): NaN is converted to null
+    # internally, but the all-null early-return checked the original series,
+    # where NaN is not null, so it slipped through to quantile computation.
+    s = pl.Series("a", [float("nan"), float("nan")])
+
+    result = s.qcut([0.25, 0.50])
+
+    expected = pl.Series("a", [None, None], dtype=pl.Categorical)
+    assert_series_equal(result, expected, categorical_as_str=True)
+
+
+def test_qcut_inf_breakpoint_raises() -> None:
+    # A quantile that interpolates across an infinite value yields a NaN
+    # breakpoint; this used to panic (unwrap on None in the sort). It now raises.
+    s = pl.Series("a", [float("inf"), float("-inf")])
+    with pytest.raises(ComputeError):
+        s.qcut([0.3, 0.6])
+
+
+def test_qcut_full_nan_include_breaks() -> None:
+    # All-NaN with include_breaks must still return the Struct dtype, matching
+    # the non-degenerate path and the lazy schema (a bare Categorical would
+    # mismatch and panic downstream). The struct fields are all-null and the
+    # series keeps the input name.
+    s = pl.Series("a", [float("nan"), float("nan")])
+
+    result = s.qcut([0.25, 0.50], include_breaks=True)
+
+    assert result.name == "a"
+    assert result.dtype == pl.Struct(
+        {"breakpoint": pl.Float64, "category": pl.Categorical}
+    )
+    assert result.len() == 2
+    assert result.struct.field("breakpoint").null_count() == 2
+    assert result.struct.field("category").null_count() == 2
+
+
+def test_qcut_nan_and_inf_mixed() -> None:
+    # NaN is dropped internally, leaving the infinities, whose interpolated
+    # quantile is NaN; this must raise rather than panic.
+    s = pl.Series("a", [float("nan"), float("inf"), float("-inf")])
+    with pytest.raises(ComputeError):
+        s.qcut([0.5])
+
+
+# https://github.com/pola-rs/polars/issues/27284
+def test_qcut_empty_include_breaks_27284() -> None:
+    empty = pl.Series("x", [], dtype=pl.Float64)
+
+    result = empty.qcut(3, include_breaks=True)
+
+    assert result.dtype == pl.Struct(
+        {"breakpoint": pl.Float64, "category": pl.Categorical}
+    )
+    assert result.len() == 0
+
+
+# https://github.com/pola-rs/polars/issues/27284
+def test_qcut_empty_include_breaks_lazy_27284() -> None:
+    lf = pl.LazyFrame({"x": pl.Series([], dtype=pl.Float64)})
+
+    result = lf.select(
+        pl.col("x").qcut(3, include_breaks=True).struct.field("breakpoint")
+    ).collect()
+
+    assert result.schema == {"breakpoint": pl.Float64}
+    assert result.height == 0
+
+
+# https://github.com/pola-rs/polars/issues/27284
+def test_qcut_full_null_include_breaks_27284() -> None:
+    s = pl.Series("x", [None, None, None], dtype=pl.Float64)
+
+    result = s.qcut([0.25, 0.50], include_breaks=True)
+
+    assert result.dtype == pl.Struct(
+        {"breakpoint": pl.Float64, "category": pl.Categorical}
+    )
+    assert result.len() == 3
+
+
+# https://github.com/pola-rs/polars/issues/27284
+def test_qcut_full_null_include_breaks_lazy_unnest_27284() -> None:
+    # Unnesting the (Struct-typed) include_breaks result of an all-null series in
+    # a lazy query used to panic with a schema mismatch (bare Categorical vs the
+    # declared Struct).
+    lf = pl.LazyFrame({"a": [None, None]})
+
+    result = lf.select(
+        pl.col("a").cast(pl.Float64).qcut([0.25, 0.5], include_breaks=True).alias("q")
+    ).unnest("q")
+
+    out = result.collect()
+    assert out.schema["breakpoint"] == pl.Float64
+    assert out.height == 2

--- a/py-polars/tests/unit/operations/test_qcut.py
+++ b/py-polars/tests/unit/operations/test_qcut.py
@@ -179,13 +179,12 @@ def test_qcut_full_nan_include_breaks() -> None:
 
     result = s.qcut([0.25, 0.50], include_breaks=True)
 
-    assert result.name == "a"
-    assert result.dtype == pl.Struct(
-        {"breakpoint": pl.Float64, "category": pl.Categorical}
+    expected = pl.Series(
+        "a",
+        [{"breakpoint": None, "category": None}] * 2,
+        dtype=pl.Struct({"breakpoint": pl.Float64, "category": pl.Categorical}),
     )
-    assert result.len() == 2
-    assert result.struct.field("breakpoint").null_count() == 2
-    assert result.struct.field("category").null_count() == 2
+    assert_series_equal(result, expected, categorical_as_str=True)
 
 
 def test_qcut_nan_and_inf_mixed() -> None:
@@ -200,10 +199,10 @@ def test_qcut_empty_include_breaks_27284() -> None:
 
     result = empty.qcut(3, include_breaks=True)
 
-    assert result.dtype == pl.Struct(
-        {"breakpoint": pl.Float64, "category": pl.Categorical}
+    expected = pl.Series(
+        "x", [], dtype=pl.Struct({"breakpoint": pl.Float64, "category": pl.Categorical})
     )
-    assert result.len() == 0
+    assert_series_equal(result, expected, categorical_as_str=True)
 
 
 def test_qcut_empty_include_breaks_lazy_27284() -> None:
@@ -213,8 +212,7 @@ def test_qcut_empty_include_breaks_lazy_27284() -> None:
         pl.col("x").qcut(3, include_breaks=True).struct.field("breakpoint")
     ).collect()
 
-    assert result.schema == {"breakpoint": pl.Float64}
-    assert result.height == 0
+    assert_frame_equal(result, pl.DataFrame(schema={"breakpoint": pl.Float64}))
 
 
 def test_qcut_full_null_include_breaks_27284() -> None:
@@ -222,10 +220,12 @@ def test_qcut_full_null_include_breaks_27284() -> None:
 
     result = s.qcut([0.25, 0.50], include_breaks=True)
 
-    assert result.dtype == pl.Struct(
-        {"breakpoint": pl.Float64, "category": pl.Categorical}
+    expected = pl.Series(
+        "x",
+        [{"breakpoint": None, "category": None}] * 3,
+        dtype=pl.Struct({"breakpoint": pl.Float64, "category": pl.Categorical}),
     )
-    assert result.len() == 3
+    assert_series_equal(result, expected, categorical_as_str=True)
 
 
 def test_qcut_full_null_include_breaks_lazy_unnest_27284() -> None:
@@ -237,5 +237,8 @@ def test_qcut_full_null_include_breaks_lazy_unnest_27284() -> None:
     ).unnest("q")
 
     out = result.collect()
-    assert out.schema["breakpoint"] == pl.Float64
-    assert out.height == 2
+    expected = pl.DataFrame(
+        {"breakpoint": [None, None], "category": [None, None]},
+        schema={"breakpoint": pl.Float64, "category": pl.Categorical},
+    )
+    assert_frame_equal(out, expected, categorical_as_str=True)

--- a/py-polars/tests/unit/operations/test_qcut.py
+++ b/py-polars/tests/unit/operations/test_qcut.py
@@ -157,9 +157,7 @@ def test_qcut_nan_input_values() -> None:
 
 
 def test_qcut_full_nan() -> None:
-    # All-NaN input used to panic (unwrap on None): NaN is converted to null
-    # internally, but the all-null early-return checked the original series,
-    # where NaN is not null, so it slipped through to quantile computation.
+    # Regression: all-NaN used to panic (all-null check used the pre-NaN-drop series).
     s = pl.Series("a", [float("nan"), float("nan")])
 
     result = s.qcut([0.25, 0.50])
@@ -169,18 +167,14 @@ def test_qcut_full_nan() -> None:
 
 
 def test_qcut_inf_breakpoint_raises() -> None:
-    # A quantile that interpolates across an infinite value yields a NaN
-    # breakpoint; this used to panic (unwrap on None in the sort). It now raises.
+    # Regression: inf gives a NaN breakpoint that used to panic; now raises.
     s = pl.Series("a", [float("inf"), float("-inf")])
     with pytest.raises(ComputeError):
         s.qcut([0.3, 0.6])
 
 
 def test_qcut_full_nan_include_breaks() -> None:
-    # All-NaN with include_breaks must still return the Struct dtype, matching
-    # the non-degenerate path and the lazy schema (a bare Categorical would
-    # mismatch and panic downstream). The struct fields are all-null and the
-    # series keeps the input name.
+    # include_breaks must return the Struct dtype even on all-NaN input.
     s = pl.Series("a", [float("nan"), float("nan")])
 
     result = s.qcut([0.25, 0.50], include_breaks=True)
@@ -195,14 +189,12 @@ def test_qcut_full_nan_include_breaks() -> None:
 
 
 def test_qcut_nan_and_inf_mixed() -> None:
-    # NaN is dropped internally, leaving the infinities, whose interpolated
-    # quantile is NaN; this must raise rather than panic.
+    # NaN dropped, infinities remain, so the breakpoint is NaN -> raises.
     s = pl.Series("a", [float("nan"), float("inf"), float("-inf")])
     with pytest.raises(ComputeError):
         s.qcut([0.5])
 
 
-# https://github.com/pola-rs/polars/issues/27284
 def test_qcut_empty_include_breaks_27284() -> None:
     empty = pl.Series("x", [], dtype=pl.Float64)
 
@@ -214,7 +206,6 @@ def test_qcut_empty_include_breaks_27284() -> None:
     assert result.len() == 0
 
 
-# https://github.com/pola-rs/polars/issues/27284
 def test_qcut_empty_include_breaks_lazy_27284() -> None:
     lf = pl.LazyFrame({"x": pl.Series([], dtype=pl.Float64)})
 
@@ -226,7 +217,6 @@ def test_qcut_empty_include_breaks_lazy_27284() -> None:
     assert result.height == 0
 
 
-# https://github.com/pola-rs/polars/issues/27284
 def test_qcut_full_null_include_breaks_27284() -> None:
     s = pl.Series("x", [None, None, None], dtype=pl.Float64)
 
@@ -238,11 +228,8 @@ def test_qcut_full_null_include_breaks_27284() -> None:
     assert result.len() == 3
 
 
-# https://github.com/pola-rs/polars/issues/27284
 def test_qcut_full_null_include_breaks_lazy_unnest_27284() -> None:
-    # Unnesting the (Struct-typed) include_breaks result of an all-null series in
-    # a lazy query used to panic with a schema mismatch (bare Categorical vs the
-    # declared Struct).
+    # Regression: lazy unnest of an all-null include_breaks result used to panic.
     lf = pl.LazyFrame({"a": [None, None]})
 
     result = lf.select(


### PR DESCRIPTION
qcut panics on a few degenerate float inputs: all-NaN, infinite values, and include_breaks on empty or all-null series. The all-null early return checked the series before NaNs were dropped and handed back a Categorical instead of the Struct that include_breaks is supposed to give, and an infinite value produces a NaN breakpoint that crashes the following sort.

The fix reworks that early return: it checks the post-NaN array, returns a null Struct when include_breaks is set, and raises a ComputeError on NaN breakpoints the same way cut already does. cut itself was fine so I left it alone.

The include_breaks part overlaps kimjune01's stalled #27561, so I kept their approach for that case and credited them.

Closes #28219. Fixes #27284.

<img width="579" height="388" alt="image" src="https://github.com/user-attachments/assets/66ed9177-7a92-47bd-8c7c-aad8ef3454a9" />
