### PR TITLE
fix: Classify S3 region request failures as IO errors

### DIFF
--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -45,6 +45,14 @@ use crate::file_cache::get_env_file_cache_ttl;
 use crate::pl_async::with_concurrency_budget;
 
 #[cfg(feature = "aws")]
+fn to_io_err(err: reqwest::Error) -> PolarsError {
+    PolarsError::IO {
+        error: Arc::new(std::io::Error::other(err)),
+        msg: None,
+    }
+}
+
+#[cfg(feature = "aws")]
 static BUCKET_REGION: LazyLock<
     std::sync::Mutex<LruCache<polars_utils::pl_str::PlSmallStr, polars_utils::pl_str::PlSmallStr>>,
 > = LazyLock::new(|| std::sync::Mutex::new(LruCache::with_capacity(32)));
@@ -464,7 +472,7 @@ impl CloudOptions {
                                 .head(format!("https://{bucket}.s3.amazonaws.com"))
                                 .send()
                                 .await
-                                .map_err(to_compute_err)
+                                .map_err(to_io_err)
                         })
                         .await?;
                         if let Some(region) = result.headers().get("x-amz-bucket-region") {


### PR DESCRIPTION
Solves #28080

Warning `UserWarning: '(default_)region' not set; polars will try to get it from bucket ` was promoted to error in one of CI runs.

Fix maps failures while resolving default S3 bucket region to IO errors so nonexistent cloud paths satisfy existing IOError expectation.

`make test`
<img width="964" height="323" alt="Screenshot 2026-07-04 at 8 55 42 AM" src="https://github.com/user-attachments/assets/71db1cc1-34d0-43b3-b807-8b129e850109" />
