### PR TITLE
fix: Support dtype-list schema overrides in scan_csv

### DIFF
--- a/crates/polars-io/src/csv/read/streaming.rs
+++ b/crates/polars-io/src/csv/read/streaming.rs
@@ -809,6 +809,10 @@ fn infer_schema(
     }
 
     if let Some(dtypes) = options.dtype_overwrite.as_deref() {
+        polars_ensure!(
+            dtypes.len() <= inferred_schema.len(),
+            InvalidOperation: "The number of schema overrides must be less than or equal to the number of fields"
+        );
         for (i, dtype) in dtypes.iter().enumerate() {
             inferred_schema.set_dtype_at_index(i, dtype.clone());
         }

--- a/crates/polars-lazy/src/scan/csv.rs
+++ b/crates/polars-lazy/src/scan/csv.rs
@@ -134,7 +134,7 @@ impl LazyCsvReader {
 
     /// Overwrite dtypes by position.
     #[must_use]
-    pub fn with_dtype_overwrite_slice(mut self, dtypes: Option<Arc<Vec<DataType>>>) -> Self {
+    pub fn with_dtype_overwrite_by_position(mut self, dtypes: Option<Arc<Vec<DataType>>>) -> Self {
         self.read_options.dtype_overwrite = dtypes;
         self
     }

--- a/crates/polars-lazy/src/scan/csv.rs
+++ b/crates/polars-lazy/src/scan/csv.rs
@@ -132,6 +132,13 @@ impl LazyCsvReader {
         self
     }
 
+    /// Overwrite dtypes by position.
+    #[must_use]
+    pub fn with_dtype_overwrite_slice(mut self, dtypes: Option<Arc<Vec<DataType>>>) -> Self {
+        self.read_options.dtype_overwrite = dtypes;
+        self
+    }
+
     /// Set whether the CSV file has headers
     #[must_use]
     pub fn with_has_header(mut self, has_header: bool) -> Self {

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
@@ -1063,6 +1063,7 @@ enum CachedSourceKey {
         paths: Buffer<PlRefPath>,
         schema: Option<SchemaRef>,
         schema_overwrite: Option<SchemaRef>,
+        dtype_overwrite: Option<Arc<Vec<DataType>>>,
     },
 }
 
@@ -1408,6 +1409,7 @@ this scan to succeed with an empty DataFrame.",
                     paths: paths.clone(),
                     schema: options.schema.clone(),
                     schema_overwrite: options.schema_overwrite.clone(),
+                    dtype_overwrite: options.dtype_overwrite.clone(),
                 };
                 let guard = self.inner.read().unwrap();
                 let v = guard.get(&key);
@@ -1419,6 +1421,7 @@ this scan to succeed with an empty DataFrame.",
                     paths: paths.clone(),
                     schema: options.schema.clone(),
                     schema_overwrite: options.schema_overwrite.clone(),
+                    dtype_overwrite: None,
                 };
                 let guard = self.inner.read().unwrap();
                 let v = guard.get(&key);

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -251,7 +251,7 @@ impl PyLazyFrame {
             .with_n_rows(n_rows)
             .with_cache(cache)
             .with_dtype_overwrite(overwrite_dtype.map(Arc::new))
-            .with_dtype_overwrite_slice(overwrite_dtype_slice.map(Arc::new))
+            .with_dtype_overwrite_by_position(overwrite_dtype_slice.map(Arc::new))
             .with_schema(schema.map(|schema| Arc::new(schema.0)))
             .with_low_memory(low_memory)
             .with_comment_prefix(comment_prefix.map(|x| x.into()))

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -150,7 +150,7 @@ impl PyLazyFrame {
 
     #[staticmethod]
     #[cfg(feature = "csv")]
-    #[pyo3(signature = (source, sources, separator, has_header, ignore_errors, skip_rows, skip_lines, n_rows, cache, overwrite_dtype,
+    #[pyo3(signature = (source, sources, separator, has_header, ignore_errors, skip_rows, skip_lines, n_rows, cache, overwrite_dtype, overwrite_dtype_slice,
         low_memory, comment_prefix, quote_char, null_values, empty_string_is_null,
         infer_schema_length, with_schema_modify, rechunk, skip_rows_after_header,
         encoding, row_index, try_parse_dates, eol_char, raise_if_empty, truncate_ragged_lines, decimal_comma, glob, schema,
@@ -168,6 +168,7 @@ impl PyLazyFrame {
         n_rows: Option<usize>,
         cache: bool,
         overwrite_dtype: Option<Vec<(PyBackedStr, Wrap<DataType>)>>,
+        overwrite_dtype_slice: Option<Vec<Wrap<DataType>>>,
         low_memory: bool,
         comment_prefix: Option<&str>,
         quote_char: Option<&str>,
@@ -216,6 +217,12 @@ impl PyLazyFrame {
                 .map(|(name, dtype)| Field::new((&*name).into(), dtype.0))
                 .collect::<Schema>()
         });
+        let overwrite_dtype_slice = overwrite_dtype_slice.map(|overwrite_dtype| {
+            overwrite_dtype
+                .into_iter()
+                .map(|dtype| dtype.0)
+                .collect::<Vec<_>>()
+        });
 
         let sources = sources.0;
         let (first_path, sources) = match source {
@@ -244,6 +251,7 @@ impl PyLazyFrame {
             .with_n_rows(n_rows)
             .with_cache(cache)
             .with_dtype_overwrite(overwrite_dtype.map(Arc::new))
+            .with_dtype_overwrite_slice(overwrite_dtype_slice.map(Arc::new))
             .with_schema(schema.map(|schema| Arc::new(schema.0)))
             .with_low_memory(low_memory)
             .with_comment_prefix(comment_prefix.map(|x| x.into()))

--- a/py-polars/src/polars/_plr.pyi
+++ b/py-polars/src/polars/_plr.pyi
@@ -860,6 +860,7 @@ class PyLazyFrame:
         n_rows: int | None,
         cache: bool,
         overwrite_dtype: Sequence[tuple[str, Any]] | None,
+        overwrite_dtype_slice: Sequence[DataType] | None,
         low_memory: bool,
         comment_prefix: str | None,
         quote_char: str | None,

--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -1403,8 +1403,6 @@ def scan_csv(
         if with_column_names:
             msg = "cannot set both `with_column_names` and `new_columns`; mutually exclusive"
             raise ValueError(msg)
-        if schema_overrides and isinstance(schema_overrides, Sequence):
-            schema_overrides = dict(zip(new_columns, schema_overrides, strict=False))
 
         # wrap new column names as a callable
         def with_column_names(cols: list[str]) -> list[str]:

--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -494,8 +494,6 @@ def read_csv(
     if not infer_schema:
         infer_schema_length = 0
 
-    # TODO: scan_csv doesn't support a "dtype slice" (i.e. list[DataType])
-    schema_overrides_is_list = isinstance(schema_overrides, Sequence)
     encoding_supported_in_lazy = encoding in {"utf8", "utf8-lossy"}
 
     streaming = (
@@ -513,7 +511,6 @@ def read_csv(
             # through by our test suite during CI.
             or (
                 os.getenv("POLARS_FORCE_ASYNC") == "1"
-                and not schema_overrides_is_list
                 and encoding_supported_in_lazy
             )
             # TODO: We can't dispatch this for all paths due to a few reasons:
@@ -534,9 +531,6 @@ def read_csv(
             source_normalized = source
 
         if not streaming:
-            if schema_overrides_is_list:
-                msg = "passing a list to `schema_overrides` is unsupported for hf:// paths"
-                raise ValueError(msg)
             if not encoding_supported_in_lazy:
                 msg = f"unsupported encoding {encoding} for hf:// paths"
                 raise ValueError(msg)
@@ -677,7 +671,7 @@ def _read_csv_impl(
             for k, v in schema_overrides.items():
                 dtype_list.append((k, parse_into_dtype(v)))
         elif isinstance(schema_overrides, Sequence):
-            dtype_slice = schema_overrides
+            dtype_slice = [parse_into_dtype(v) for v in schema_overrides]
         else:
             msg = f"`schema_overrides` should be of type list or dict, got {qualified_type_name(schema_overrides)!r}"
             raise TypeError(msg)
@@ -1408,10 +1402,7 @@ def scan_csv(
         msg = "`schema_overrides` should be of type list or dict"
         raise TypeError(msg)
 
-    if not new_columns and isinstance(schema_overrides, Sequence):
-        msg = f"expected 'schema_overrides' dict, found {qualified_type_name(schema_overrides)!r}"
-        raise TypeError(msg)
-    elif new_columns:
+    if new_columns:
         if with_column_names:
             msg = "cannot set both `with_column_names` and `new_columns`; mutually exclusive"
             raise ValueError(msg)
@@ -1513,7 +1504,7 @@ def _scan_csv_impl(
     skip_rows: int = 0,
     skip_lines: int = 0,
     schema: SchemaDict | None = None,
-    schema_overrides: SchemaDict | None = None,
+    schema_overrides: SchemaDict | Sequence[PolarsDataType] | None = None,
     null_values: str | Sequence[str] | dict[str, str] | None = None,
     empty_string_is_null: bool = True,
     ignore_errors: bool = False,
@@ -1539,13 +1530,17 @@ def _scan_csv_impl(
     missing_columns: Literal["insert", "raise"] | None = None,
 ) -> LazyFrame:
     dtype_list: list[tuple[str, PolarsDataType]] | None = None
+    dtype_slice: Sequence[PolarsDataType] | None = None
     if schema_overrides is not None:
-        if not isinstance(schema_overrides, dict):
-            msg = "expected 'schema_overrides' dict, found 'list'"
+        if isinstance(schema_overrides, dict):
+            dtype_list = []
+            for k, v in schema_overrides.items():
+                dtype_list.append((k, parse_into_dtype(v)))
+        elif isinstance(schema_overrides, Sequence):
+            dtype_slice = [parse_into_dtype(v) for v in schema_overrides]
+        else:
+            msg = f"`schema_overrides` should be of type list or dict, got {qualified_type_name(schema_overrides)!r}"
             raise TypeError(msg)
-        dtype_list = []
-        for k, v in schema_overrides.items():
-            dtype_list.append((k, parse_into_dtype(v)))
     processed_null_values = _process_null_values(null_values)
 
     if isinstance(source, list):
@@ -1571,6 +1566,7 @@ def _scan_csv_impl(
         n_rows=n_rows,
         cache=cache,
         overwrite_dtype=dtype_list,
+        overwrite_dtype_slice=dtype_slice,
         low_memory=low_memory,
         comment_prefix=comment_prefix,
         quote_char=quote_char,

--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -509,10 +509,7 @@ def read_csv(
             str(v).startswith("hf://")
             # Also dispatch on FORCE_ASYNC, so that this codepath gets run
             # through by our test suite during CI.
-            or (
-                os.getenv("POLARS_FORCE_ASYNC") == "1"
-                and encoding_supported_in_lazy
-            )
+            or (os.getenv("POLARS_FORCE_ASYNC") == "1" and encoding_supported_in_lazy)
             # TODO: We can't dispatch this for all paths due to a few reasons:
             # * `scan_csv` does not support compressed files
             # * The `storage_options` configuration keys are different between

--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -678,15 +678,9 @@ def _read_csv_impl(
     if isinstance(columns, str):
         columns = [columns]
     if isinstance(source, str) and is_glob_pattern(source):
-        dtypes_dict = None
-        if dtype_list is not None:
-            dtypes_dict = dict(dtype_list)
-        if dtype_slice is not None:
-            msg = (
-                "cannot use glob patterns and unnamed dtypes as `schema_overrides` argument"
-                "\n\nUse `schema_overrides`: Mapping[str, Type[DataType]]"
-            )
-            raise ValueError(msg)
+        scan_schema_overrides = (
+            dict(dtype_list) if dtype_list is not None else dtype_slice
+        )
         from polars import scan_csv
 
         scan = scan_csv(
@@ -698,7 +692,7 @@ def _read_csv_impl(
             skip_rows=skip_rows,
             skip_lines=skip_lines,
             schema=schema,
-            schema_overrides=dtypes_dict,
+            schema_overrides=scan_schema_overrides,
             null_values=null_values,
             empty_string_is_null=empty_string_is_null,
             ignore_errors=ignore_errors,

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import gzip
 import io
-import os
 import sys
 import textwrap
 import warnings
@@ -2143,15 +2142,10 @@ def test_read_csv_invalid_schema_overrides_length(chunk_override: None) -> None:
     )
     f = io.StringIO(csv)
 
-    # streaming dispatches read_csv -> _scan_csv_impl which does not accept a list
-    if os.getenv("POLARS_AUTO_STREAMING", os.getenv("POLARS_FORCE_STREAMING")) == "1":
-        err = TypeError
-        match = "expected 'schema_overrides' dict, found 'list'"
-    else:
-        err = InvalidOperationError  # type: ignore[assignment]
-        match = "The number of schema overrides must be less than or equal to the number of fields"
-
-    with pytest.raises(err, match=match):
+    with pytest.raises(
+        InvalidOperationError,
+        match="The number of schema overrides must be less than or equal to the number of fields",
+    ):
         pl.read_csv(f, schema_overrides=[pl.Int64, pl.String, pl.Boolean])
 
 

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -967,14 +967,6 @@ def test_csv_globbing(chunk_override: None, io_files_path: Path) -> None:
     assert df.row(-1) == ("seafood", 1)
     assert df.row(0) == ("vegetables", 2)
 
-    with PlMonkeyPatch.context() as mp:
-        mp.setenv("POLARS_FORCE_ASYNC", "0")
-
-        with pytest.raises(ValueError):
-            _ = pl.read_csv(
-                path, schema_overrides=[pl.String, pl.Int64, pl.Int64, pl.Int64]
-            )
-
     dtypes = {
         "category": pl.String,
         "calories": pl.Int32,
@@ -984,6 +976,24 @@ def test_csv_globbing(chunk_override: None, io_files_path: Path) -> None:
 
     df = pl.read_csv(path, schema_overrides=dtypes)
     assert df.dtypes == list(dtypes.values())
+
+
+@pytest.mark.parametrize("auto_streaming", ["0", "1"])
+def test_csv_globbing_schema_overrides_by_position(
+    chunk_override: None,
+    io_files_path: Path,
+    plmonkeypatch: PlMonkeyPatch,
+    auto_streaming: str,
+) -> None:
+    plmonkeypatch.setenv("POLARS_AUTO_STREAMING", auto_streaming)
+    plmonkeypatch.setenv("POLARS_FORCE_STREAMING", "0")
+    plmonkeypatch.setenv("POLARS_FORCE_ASYNC", "0")
+
+    path = io_files_path / "foods*.csv"
+    df = pl.read_csv(path, schema_overrides=[pl.String, pl.Float64, pl.String])
+
+    assert df.shape == (135, 4)
+    assert df.dtypes == [pl.String, pl.Float64, pl.String, pl.Int64]
 
 
 def test_csv_schema_offset(chunk_override: None, foods_file_path: Path) -> None:

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -176,6 +176,14 @@ def test_scan_csv_schema_new_columns_dtypes(
     assert df4.dtypes == [pl.String, pl.String, pl.Float64, pl.Int64]
     assert df4.columns == ["category", "calories", "fats_g", "sugars_g"]
 
+    df5 = pl.scan_csv(
+        file_path,
+        schema_overrides=[pl.String, pl.String],
+        new_columns=["category"],
+    ).collect()
+    assert df5.dtypes == [pl.String, pl.String, pl.Float64, pl.Int64]
+    assert df5.columns == ["category", "calories", "fats_g", "sugars_g"]
+
     # cannot have len(new_columns) > len(actual columns)
     with pytest.raises(ShapeError):
         pl.scan_csv(

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -223,6 +223,25 @@ def test_scan_csv_schema_overrides_dtype_list_17813() -> None:
     assert df.dtypes == [pl.Int64, pl.Int64, pl.Int64, pl.Int64, pl.Int64]
 
 
+@pytest.mark.write_disk
+def test_scan_csv_schema_overrides_dtype_list_file_info_cache(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "data.csv"
+    path.write_text("a,b\n1,2\n3,4\n")
+
+    strings = pl.scan_csv(path, schema_overrides=[pl.String]).select(
+        pl.col("a").alias("a_string")
+    )
+    floats = pl.scan_csv(path, schema_overrides=[pl.Float64]).select(
+        pl.col("a").alias("a_float")
+    )
+
+    result = pl.concat([strings, floats], how="horizontal_extend").collect()
+    expected = pl.DataFrame({"a_string": ["1", "3"], "a_float": [1.0, 3.0]})
+    assert_frame_equal(result, expected)
+
+
 def test_scan_csv_invalid_schema_overrides_length() -> None:
     csv = io.StringIO(
         textwrap.dedent(

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import tempfile
+import textwrap
 from collections import OrderedDict
 from pathlib import Path
 from typing import IO, TYPE_CHECKING
@@ -10,7 +11,7 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError, ShapeError
+from polars.exceptions import ComputeError, InvalidOperationError, ShapeError
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
@@ -191,6 +192,45 @@ def test_scan_csv_schema_new_columns_dtypes(
             new_columns=["category", "calories", "fats", "sugars"],
             with_column_names=lambda cols: [col.capitalize() for col in cols],
         ).collect()
+
+
+def test_scan_csv_schema_overrides_dtype_list_17813() -> None:
+    csv_data = textwrap.dedent(
+        """\
+        a,b,c,d,e
+        1,2,3,4,5
+        6,7,8,9,10
+        """
+    )
+    csv = io.StringIO(csv_data)
+
+    df = pl.scan_csv(csv, schema_overrides=4 * [pl.String]).collect()
+
+    assert df.dtypes == [pl.String, pl.String, pl.String, pl.String, pl.Int64]
+
+    # Recreate StringIO because the first scan consumes the stream.
+    csv = io.StringIO(csv_data)
+    df = pl.scan_csv(csv, schema_overrides=[pl.Int64()]).collect()
+
+    assert df.dtypes == [pl.Int64, pl.Int64, pl.Int64, pl.Int64, pl.Int64]
+
+
+def test_scan_csv_invalid_schema_overrides_length() -> None:
+    csv = io.StringIO(
+        textwrap.dedent(
+            """\
+            a,b
+            1,foo
+            2,bar
+            """
+        )
+    )
+
+    with pytest.raises(
+        InvalidOperationError,
+        match="The number of schema overrides must be less than or equal to the number of fields",
+    ):
+        pl.scan_csv(csv, schema_overrides=[pl.Int64, pl.String, pl.Boolean]).collect()
 
 
 def test_lazy_n_rows(foods_file_path: Path) -> None:


### PR DESCRIPTION
Solves #17813

**Important!** Current change applies override to each physical file by position and is fine when all files have the same ordered schema. 

One open question though. For multi-file scans using missing_columns="insert", input files may have different columns or column order. How should schema overrides behave?

`make test` 
<img width="877" height="243" alt="Screenshot 2026-07-04 at 11 37 04 AM" src="https://github.com/user-attachments/assets/247b98aa-c9cc-42f0-b65d-bd1b480d5427" />
