### PR TITLE
fix(rust): Incorrect length calculation in parallel hashmap

### DIFF
--- a/crates/polars-utils/src/parma/raw/key.rs
+++ b/crates/polars-utils/src/parma/raw/key.rs
@@ -35,7 +35,7 @@ impl<T: Copy> Key for [T] {
 
     #[inline(always)]
     fn size(&self) -> usize {
-        size_of::<usize>().next_multiple_of(align_of::<T>()) + self.len()
+        size_of::<usize>().next_multiple_of(align_of::<T>()) + self.len() * size_of::<T>()
     }
 
     #[inline(always)]

--- a/crates/polars-utils/src/parma/raw/key.rs
+++ b/crates/polars-utils/src/parma/raw/key.rs
@@ -35,7 +35,7 @@ impl<T: Copy> Key for [T] {
 
     #[inline(always)]
     fn size(&self) -> usize {
-        size_of::<usize>().next_multiple_of(align_of::<T>()) + self.len() * size_of::<T>()
+        size_of::<usize>().next_multiple_of(align_of::<T>()) + size_of_val(self)
     }
 
     #[inline(always)]


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/28221.

I don't believe we ever hit this case as we only used string keys.