### PR TITLE
fix(python): Database appends with `ADBC` shouldn't require "CREATE" privileges unless the table is confirmed not to exist

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -4529,7 +4529,9 @@ class DataFrame:
                     raise ModuleUpgradeRequiredError(msg)
                 mode = "replace"
             elif if_table_exists == "append":
-                mode = "append" if driver_manager_version < (0, 7) else "create_append"
+                # 'append' inserts into an existing table; the table-existence
+                # check below can upgrade this to 'create_append'.
+                mode = "append"
             else:
                 msg = (
                     f"unexpected value for `if_table_exists`: {if_table_exists!r}"
@@ -4597,6 +4599,25 @@ class DataFrame:
                     ):
                         cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
                         mode = "create"
+
+                # 'append' requires the table to exist; if it doesn't, upgrade the mode
+                # to 'create_append'; only do this when the table is confirmed missing.
+                if mode == "append" and driver_manager_version >= (0, 7):
+                    schema_filter = {"db_schema_filter": db_schema} if db_schema else {}
+                    try:
+                        conn.adbc_get_table_schema(
+                            unpacked_table_name,
+                            catalog_filter=catalog,
+                            **schema_filter,
+                        )
+                    except driver_manager.Error as err:
+                        # only a definitive 'not found' status confirms the table is
+                        # missing; any other error is left for `adbc_ingest` to raise
+                        if (
+                            getattr(err, "status_code", None)
+                            == driver_manager.AdbcStatusCode.NOT_FOUND
+                        ):
+                            mode = "create_append"
 
                 # For Snowflake, we convert to PyArrow until string_view columns can be
                 # written. Ref: https://github.com/apache/arrow-adbc/issues/3420

--- a/py-polars/tests/unit/io/database/test_write.py
+++ b/py-polars/tests/unit/io/database/test_write.py
@@ -195,6 +195,63 @@ class TestWriteDatabase:
 
         close_connections(conn)
 
+    def test_write_database_append_existing_table_no_create(
+        self,
+        engine: DbWriteEngine,
+        uri_connection: bool,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Appending to an existing table shouldn't require CREATE (ref: #27886)."""
+        if engine != "adbc":
+            pytest.skip("mode selection only applies to the 'adbc' engine")
+
+        adbc_driver_manager = pytest.importorskip("adbc_driver_manager")
+        if parse_version(getattr(adbc_driver_manager, "__version__", "0.0")) < (0, 7):
+            pytest.skip("adbc-driver-manager < 0.7.0 always uses 'append' mode")
+
+        import adbc_driver_manager.dbapi as adbc_dbapi
+
+        # record the ingest mode used for each write, so we can assert that appending
+        # to an *existing* table uses plain 'append' (INSERT only) rather than
+        # 'create_append' (which additionally requires CREATE TABLE privileges)
+        ingest_modes: list[str | None] = []
+        original_ingest = adbc_dbapi.Cursor.adbc_ingest
+
+        def _record_mode(self: Any, *args: Any, **kwargs: Any) -> Any:
+            ingest_modes.append(kwargs.get("mode"))
+            return original_ingest(self, *args, **kwargs)
+
+        monkeypatch.setattr(adbc_dbapi.Cursor, "adbc_ingest", _record_mode)
+
+        df = pl.DataFrame({"id": [1, 2, 3], "name": ["a", "b", "c"]})
+        tmp_path.mkdir(exist_ok=True)
+        test_db_uri = (
+            f"sqlite:///{tmp_path}/test_append_existing_{int(uri_connection)}.db"
+        )
+        table_name = "test_append_existing"
+        conn = self._get_connection(test_db_uri, engine, uri_connection)
+
+        # first append creates the missing table...
+        df.write_database(
+            table_name=table_name,
+            connection=conn,
+            if_table_exists="append",
+            engine=engine,
+        )
+        # ...second append targets the now-created table
+        df.write_database(
+            table_name=table_name,
+            connection=conn,
+            if_table_exists="append",
+            engine=engine,
+        )
+        assert ingest_modes == ["create_append", "append"]
+
+        result = _read_via_uri(f"SELECT * FROM {table_name}", test_db_uri)
+        assert_frame_equal(result, pl.concat([df, df]))
+        close_connections(conn)
+
     def test_write_database_create_quoted_tablename(
         self, engine: DbWriteEngine, uri_connection: bool, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
Fixes #27886.

Shouldn't apply `create_append` by default, as this mandates the user to have table "CREATE" privileges on some backends (eg: Snowflake), even if they only have (and only require) "INSERT". We should use `append` (the common/streamlined case) unless the table is _confirmed_ not to exist.