### PR TITLE
feat(python): Add `read_database` Arrow fast-path for "python-oracledb"

### DIFF
--- a/py-polars/src/polars/io/database/_arrow_registry.py
+++ b/py-polars/src/polars/io/database/_arrow_registry.py
@@ -65,6 +65,15 @@ ARROW_DRIVER_REGISTRY: Final[dict[str, list[ArrowDriverProperties]]] = {
             "minimum_version": None,
         }
     ],
+    "oracledb": [
+        {
+            "fetch_all": "fetch_df_all",
+            "fetch_batches": "fetch_df_batches",
+            "exact_batch_size": True,
+            "repeat_batch_calls": False,
+            "minimum_version": "3.0.0",
+        }
+    ],
     "snowflake": [
         {
             "fetch_all": "fetch_arrow_all",

--- a/py-polars/src/polars/io/database/_cursor_proxies.py
+++ b/py-polars/src/polars/io/database/_cursor_proxies.py
@@ -7,7 +7,7 @@ from polars.io.database._utils import _run_async
 
 if TYPE_CHECKING:
     import sys
-    from collections.abc import Coroutine, Iterable
+    from collections.abc import Coroutine, Iterable, Iterator
 
     import pyarrow as pa
 
@@ -149,3 +149,32 @@ class SurrealDBCursorProxy:
         result = self._cached_result[:size]
         del self._cached_result[:size]
         return result
+
+
+class OracleCursorProxy:
+    """Cursor proxy for `python-oracledb` connections."""
+
+    def __init__(self, connection: Any) -> None:
+        self.connection = connection
+        self.execute_options: dict[str, Any] = {}
+        self.query: str | None = None
+
+    def close(self) -> None:
+        """Close the cursor."""
+        # no-op; never close a user's connection
+
+    def execute(self, query: str, **execute_options: Any) -> Self:
+        """Execute a query (n/a: store query for the fetch* methods)."""
+        self.execute_options = execute_options
+        self.query = query
+        return self
+
+    def fetch_df_all(self) -> Any:
+        """Fetch all rows as a single Arrow-capable dataframe object."""
+        return self.connection.fetch_df_all(self.query, **self.execute_options)
+
+    def fetch_df_batches(self, size: int) -> Iterator[Any]:
+        """Fetch rows in batches, yielding Arrow-capable dataframe objects."""
+        return self.connection.fetch_df_batches(
+            self.query, size=size, **self.execute_options
+        )

--- a/py-polars/src/polars/io/database/_executor.py
+++ b/py-polars/src/polars/io/database/_executor.py
@@ -16,7 +16,11 @@ from polars.exceptions import (
     UnsuitableSQLError,
 )
 from polars.io.database._arrow_registry import ARROW_DRIVER_REGISTRY
-from polars.io.database._cursor_proxies import ODBCCursorProxy, SurrealDBCursorProxy
+from polars.io.database._cursor_proxies import (
+    ODBCCursorProxy,
+    OracleCursorProxy,
+    SurrealDBCursorProxy,
+)
 from polars.io.database._inference import dtype_from_cursor_description
 from polars.io.database._utils import _run_async
 
@@ -86,6 +90,8 @@ class ConnectionExecutor:
         )
         if self.driver_name == "surrealdb":
             connection = SurrealDBCursorProxy(client=connection)
+        elif self.driver_name == "oracledb" and hasattr(connection, "fetch_df_all"):
+            connection = OracleCursorProxy(connection)
 
         self.cursor = self._normalise_cursor(connection)
         self.result: Any = None
@@ -429,6 +435,13 @@ class ConnectionExecutor:
                 elif conn.engine.driver == "duckdb_engine":
                     self.driver_name = "duckdb"
                     return conn
+                elif conn.engine.driver == "oracledb" and hasattr(
+                    raw_conn := conn.engine.raw_connection().driver_connection,
+                    "fetch_df_all",
+                ):
+                    self.driver_name = "oracledb"
+                    self.can_close_cursor = True
+                    return cast("Cursor", OracleCursorProxy(raw_conn))
                 elif self._is_alchemy_engine(conn):
                     # note: if we create it, we can close it
                     self.can_close_cursor = True

--- a/py-polars/tests/unit/io/database/test_read.py
+++ b/py-polars/tests/unit/io/database/test_read.py
@@ -23,6 +23,8 @@ import polars as pl
 from polars._utils.various import parse_version
 from polars.exceptions import DuplicateError, UnsuitableSQLError
 from polars.io.database._arrow_registry import ARROW_DRIVER_REGISTRY
+from polars.io.database._cursor_proxies import OracleCursorProxy
+from polars.io.database._executor import ConnectionExecutor
 from polars.testing import assert_frame_equal, assert_series_equal
 from tests.unit.io.database.conftest import create_sqlite_engine
 
@@ -951,6 +953,102 @@ def test_read_database_mocked(
     res = cast("pl.DataFrame", res)
     assert expected_call in mc.cursor().called
     assert res.rows() == [(1, "aa"), (2, "bb"), (3, "cc")]
+
+
+class MockOracleConnection:
+    """Mock `python-oracledb` Connection (Arrow `fetch_df_*` on the connection)."""
+
+    def __init__(self, test_data: pa.Table, *, batched: bool) -> None:
+        self.__class__.__module__ = "oracledb"
+        self._test_data = test_data
+        self._batched = batched
+        self.called: list[str] = []
+
+    def close(self) -> None:
+        pass
+
+    def cursor(self, *args: Any, **kwargs: Any) -> Any:
+        # a real oracledb Connection is DB-API compliant and exposes `cursor()`
+        msg = "Arrow path should not fall through to Cursor"
+        raise AssertionError(msg)
+
+    def fetch_df_all(self, statement: str, *args: Any, **kwargs: Any) -> pa.Table:
+        self.called.append("fetch_df_all")
+        return self._test_data
+
+    def fetch_df_batches(
+        self, statement: str, size: int, *args: Any, **kwargs: Any
+    ) -> Any:
+        self.called.append("fetch_df_batches")
+        return iter((self._test_data,))
+
+
+@pytest.mark.parametrize(
+    ("batch_size", "iter_batches", "expected_method"),
+    [
+        (None, False, "fetch_df_all"),
+        (2, True, "fetch_df_batches"),
+    ],
+)
+def test_read_database_oracledb_arrow(
+    batch_size: int | None,
+    iter_batches: bool,
+    expected_method: str,
+) -> None:
+    pytest.importorskip("oracledb")
+
+    arrow_table = pa.table({"id": [1, 2, 3], "name": ["a", "b", "c"]})
+    mc = MockOracleConnection(arrow_table, batched=iter_batches)
+
+    res = pl.read_database(
+        query="SELECT id, name FROM test_data",
+        connection=mc,
+        iter_batches=iter_batches,
+        batch_size=batch_size,
+    )
+    if iter_batches:
+        assert isinstance(res, GeneratorType)
+        res = pl.concat(list(res))
+
+    res = cast("pl.DataFrame", res)
+    assert expected_method in mc.called
+    assert res.columns == ["id", "name"]
+    assert res.height == 3
+
+
+def test_read_database_oracledb_engine_no_arrow_fallthrough() -> None:
+    class MockRawConnection:
+        """oracledb < 3.0 raw connection: no Arrow `fetch_df_*` methods."""
+
+    class MockEngine:
+        driver = "oracledb"
+
+        def raw_connection(self) -> Any:
+            class PooledConnection:
+                driver_connection = MockRawConnection()
+
+            return PooledConnection()
+
+    class MockSAConnection:
+        engine = MockEngine()
+
+    # bypass __init__ (which would itself call `_normalise_cursor`) so we can
+    # drive the seam in isolation with `driver_name` pinned to "sqlalchemy"
+    executor = ConnectionExecutor.__new__(ConnectionExecutor)
+    executor.driver_name = "sqlalchemy"
+    executor.can_close_cursor = False
+
+    fake_conn = MockSAConnection()
+    result = executor._normalise_cursor(fake_conn)
+
+    # the arrow fast-path should NOT have been taken...
+    assert not isinstance(result, OracleCursorProxy)
+    assert executor.driver_name == "sqlalchemy"
+    assert executor.can_close_cursor is False
+
+    # ...and we should fall through to the generic path,
+    # returning the connection unchanged
+    assert cast("Any", result) is fake_conn
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #26664.

Take advantage of `PyCapsule` support in the official `python-oracledb` driver for versions >= 3.0. Needed a thin cursor-proxy shim, as Oracle put the Arrow "fetch" methods on the `Connection` instead of the `Cursor`.

Validated "for real" against a local Oracle container instance; unit tests use some light mocking.