### PR TITLE
chore: Change `object_store` custom DNS resolver patch to rev-based

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2770,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "object_store"
 version = "0.13.2"
-source = "git+https://github.com/kdn36/arrow-rs-object-store?branch=feat_with_dns_resolver#f50a6e5c564b2b5933eca15cd20ff9b5614374a1"
+source = "git+https://github.com/kdn36/arrow-rs-object-store?rev=f50a6e5c564b2b5933eca15cd20ff9b5614374a1#f50a6e5c564b2b5933eca15cd20ff9b5614374a1"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,8 @@ collapsible_if = "allow"
 [patch.crates-io]
 # packed_simd_2 = { git = "https://github.com/rust-lang/packed_simd", rev = "e57c7ba11386147e6d2cbad7c88f376aab4bdc86" }
 # simd-json = { git = "https://github.com/ritchie46/simd-json", branch = "alignment" }
-object_store = { git = "https://github.com/kdn36/arrow-rs-object-store", branch = "feat_with_dns_resolver" }
+# custom DNS resolver - ref https://github.com/apache/arrow-rs-object-store/pull/728
+object_store = { git = "https://github.com/kdn36/arrow-rs-object-store", rev = "f50a6e5c564b2b5933eca15cd20ff9b5614374a1" }
 color-backtrace = { git = "https://github.com/orlp/color-backtrace", rev = "bb62ccf1e9eb1f6b7af5f16acff1fd7151a876dd" }
 
 # https://github.com/tikv/jemallocator/pull/168


### PR DESCRIPTION
This PR pins the upstream patch dependency for `object_store` to a specific rev commit. This will avoid issues as the interface for `with_dns_resolver` from object_store is expected to change, see discussion (https://github.com/apache/arrow-rs-object-store/pull/728).