### PR TITLE
fix: Raise on implode of `Object` dtype instead of creating invalid `List(Object)`

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -220,6 +220,10 @@ impl AExpr {
                         maintain_order: _,
                     } => {
                         let mut field = ctx.arena.get(*input).to_field_impl(ctx)?;
+                        polars_ensure!(
+                            !field.dtype().is_object(),
+                            InvalidOperation: "cannot implode 'object' dtype; nested objects are not supported"
+                        );
                         field.coerce(DataType::List(field.dtype().clone().into()));
                         Ok(field)
                     },

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -1756,6 +1756,10 @@ fn resolve_group_by(
     assert!(aggs_schema.len() == aggs.len());
     for ((_name, dtype), expr) in aggs_schema.iter_mut().zip(aggs.iter_mut()) {
         if !expr.is_scalar(expr_arena) {
+            polars_ensure!(
+                !dtype.is_object(),
+                InvalidOperation: "cannot aggregate 'object' dtype into a list; nested objects are not supported"
+            );
             expr.set_node(expr_arena.add(AExpr::Agg(IRAggExpr::Implode {
                 input: expr.node(),
                 maintain_order: true,

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2070,24 +2070,16 @@ def test_extension() -> None:
     rc = sys.getrefcount(foos[0])
     assert rc == base_count
 
+    # Aggregating objects into a list raises, as nested objects
+    # are not supported
     df = pl.DataFrame({"groups": [1, 1, 2], "a": foos})
     rc = sys.getrefcount(foos[0])
     assert rc == base_count + 1
 
-    out = df.group_by("groups", maintain_order=True).agg(pl.col("a").alias("a"))
-    rc = sys.getrefcount(foos[0])
-    assert rc == base_count + 2
-    s = out["a"].list.explode(empty_as_null=False)
-    rc = sys.getrefcount(foos[0])
-    assert rc == base_count + 3
-    del s
-    rc = sys.getrefcount(foos[0])
-    assert rc == base_count + 2
+    with pytest.raises(pl.exceptions.InvalidOperationError, match="nested objects"):
+        df.group_by("groups", maintain_order=True).agg(pl.col("a").alias("a"))
 
-    assert out["a"].list.explode(empty_as_null=False).to_list() == foos
-    rc = sys.getrefcount(foos[0])
-    assert rc == base_count + 2
-    del out
+    # The failed query must not leak references
     rc = sys.getrefcount(foos[0])
     assert rc == base_count + 1
     del df

--- a/py-polars/tests/unit/datatypes/test_object.py
+++ b/py-polars/tests/unit/datatypes/test_object.py
@@ -293,3 +293,20 @@ def test_allow_object_after_cache_26182() -> None:
         (
             pl.DataFrame({"a": [2]}).rolling(index_column="a", period="2i").agg(str)  # type: ignore[arg-type]
         )
+
+
+def test_group_by_agg_object_raises_28182() -> None:
+    df = pl.DataFrame({"group": ["a", "a", "b"], "obj": [object(), object(), object()]})
+
+    with pytest.raises(pl.exceptions.InvalidOperationError, match="nested objects"):
+        df.group_by("group").agg(pl.col("obj"))
+
+    with pytest.raises(pl.exceptions.InvalidOperationError, match="nested objects"):
+        df.lazy().group_by("group").agg(pl.col("obj")).collect()
+
+
+def test_implode_object_raises() -> None:
+    df = pl.DataFrame({"obj": [object(), object()]})
+
+    with pytest.raises(pl.exceptions.InvalidOperationError, match="nested objects"):
+        df.select(pl.col("obj").implode())


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/28182.

`test_extension` previously verified group-by aggregation of `Object` columns into `List(Object)`, which is now rejected at plan time since nested objects are unsupported, as per @orlp in the linked issue:

> Actually the problem here is that Polars does not (yet) support Python objects nested in structs/arrays/lists, but there appears to not be a check for the implicit implode from the group-by here.

🤖 Claude Fable for navigating the code and updating the `test_extension` code
