### PR TITLE
fix(rust): Don't panic in `log`/`log1p`/`exp` on non-numeric input

### DIFF
--- a/crates/polars-expr/src/dispatch/misc.rs
+++ b/crates/polars-expr/src/dispatch/misc.rs
@@ -703,11 +703,25 @@ pub(super) fn entropy(s: &Column, base: f64, normalize: bool) -> PolarsResult<Co
     }
 }
 
+// The log/exp kernels cast to Float64 and unwrap, so input that can't be cast
+// crashes (nested and categorical/binary panic, Struct segfaults). Require
+// numeric input, like `pow` and the trigonometric functions do.
+#[cfg(feature = "log")]
+fn ensure_numeric(c: &Column, op: &str) -> PolarsResult<()> {
+    polars_ensure!(
+        c.dtype().is_numeric(),
+        InvalidOperation: "`{}` operation not supported for dtype `{}`", op, c.dtype()
+    );
+    Ok(())
+}
+
 #[cfg(feature = "log")]
 pub(super) fn log(columns: &[Column]) -> PolarsResult<Column> {
     use polars_ops::series::LogSeries;
 
     assert_eq!(columns.len(), 2);
+    ensure_numeric(&columns[0], "log")?;
+    ensure_numeric(&columns[1], "log")?;
     Column::apply_broadcasting_binary_elementwise(&columns[0], &columns[1], Series::log)
 }
 
@@ -715,6 +729,7 @@ pub(super) fn log(columns: &[Column]) -> PolarsResult<Column> {
 pub(super) fn log1p(s: &Column) -> PolarsResult<Column> {
     use polars_ops::series::LogSeries;
 
+    ensure_numeric(s, "log1p")?;
     Ok(s.as_materialized_series().log1p().into())
 }
 
@@ -722,6 +737,7 @@ pub(super) fn log1p(s: &Column) -> PolarsResult<Column> {
 pub(super) fn exp(s: &Column) -> PolarsResult<Column> {
     use polars_ops::series::LogSeries;
 
+    ensure_numeric(s, "exp")?;
     Ok(s.as_materialized_series().exp().into())
 }
 

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -253,6 +253,27 @@ def test_exp_log1p(dtype_in: PolarsDataType, dtype_out: PolarsDataType) -> None:
     assert result.collect_schema() == expected.schema
 
 
+@pytest.mark.parametrize(
+    "s",
+    [
+        pl.Series("a", [[1, 2], [3]], dtype=pl.List(pl.Int64)),
+        pl.Series("a", [[1, 2], [3, 4]], dtype=pl.Array(pl.Int64, 2)),
+        pl.Series("a", [{"x": 1.0}], dtype=pl.Struct({"x": pl.Float64})),
+        pl.Series("a", ["x", "y"], dtype=pl.Categorical),
+        pl.Series("a", ["x"], dtype=pl.Enum(["x", "y"])),
+        pl.Series("a", [b"x"], dtype=pl.Binary),
+    ],
+)
+@pytest.mark.parametrize(
+    "op", [pl.col("a").log(2.0), pl.col("a").log1p(), pl.col("a").exp()]
+)
+def test_log_exp_non_numeric_input_raises(s: pl.Series, op: pl.Expr) -> None:
+    # non-numeric input used to reach an infallible cast in the kernel and crash
+    # (nested and categorical panic, Struct segfaults); it should raise instead
+    with pytest.raises(InvalidOperationError, match="not supported for dtype"):
+        s.to_frame().select(op)
+
+
 def test_dot_in_group_by() -> None:
     df = pl.DataFrame(
         {


### PR DESCRIPTION
`log`, `log1p` and `exp` crash on non-numeric input. List and Array panic, Struct segfaults, and Categorical/Enum/Binary panic too:

```python
import polars as pl
pl.Series("a", [[1, 2], [3]], dtype=pl.List(pl.Int64)).exp()      # panics
pl.select(pl.struct(a=pl.lit(1.0)).log(2))                        # segfaults
pl.Series("a", ["x", "y"], dtype=pl.Categorical).log(2)           # panics
```

The kernels cast to Float64 and `unwrap`, which is fine for numeric input but blows up on anything that can't be cast. The trait methods return `Series` not `PolarsResult`, so they can't return that cast error - the first place that can is the expr dispatch, so I put the check there and require numeric input, like `pow` and the trig functions already do. I used `is_numeric` rather than pow's `is_primitive_numeric` so decimal keeps working, since log already supported it. The side effect is that log/exp no longer silently coerce bool/string/temporal input - that matches pow and trig, and nothing in the tests relied on it.

Found by fuzzing expression calls with degenerate inputs. Added a parametrized test over list/array/struct/categorical/enum/binary for the three ops.
