### PR TITLE
feat: Serve stale records from object_store DNS cache

### DIFF
--- a/crates/polars-io/src/cloud/dns.rs
+++ b/crates/polars-io/src/cloud/dns.rs
@@ -1,6 +1,6 @@
 use std::net::{SocketAddr, ToSocketAddrs};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, LazyLock};
 use std::time::{Duration, Instant};
 
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -29,18 +29,12 @@ static DNS_CACHE: LazyLock<RwLock<HashMap<String, CachedAddrs>>> = LazyLock::new
 /// Hard-coded DNS TTL cache, as the operating system does not return it with the
 /// calls used. Defaults to AWS TTL.
 pub(crate) fn get_dns_cache_ttl() -> Duration {
-    let ttl = Duration::from_secs(
+    Duration::from_secs(
         std::env::var("POLARS_DNS_CACHE_TTL_SECS")
             .ok()
             .and_then(|s| s.parse::<u64>().ok())
             .unwrap_or(DEFAULT_DNS_CACHE_TTL_SECS),
-    );
-
-    if polars_config::config().verbose() {
-        eprintln!("[dns_cache] ttl: {}s", ttl.as_secs());
-    }
-
-    ttl
+    )
 }
 
 const DEFAULT_DNS_MAX_STALE_SECS: u64 = 300;
@@ -53,13 +47,6 @@ pub(crate) fn get_dns_max_stale() -> Option<Duration> {
             .and_then(|s| s.parse::<u64>().ok())
             .unwrap_or(DEFAULT_DNS_MAX_STALE_SECS),
     );
-    if polars_config::config().verbose() {
-        if max_stale.is_zero() {
-            eprintln!("[dns_cache] max stale: <stale serve disabled>");
-        } else {
-            eprintln!("[dns_cache] max stale: {}s", max_stale.as_secs());
-        }
-    }
     if max_stale.is_zero() {
         None
     } else {
@@ -67,111 +54,27 @@ pub(crate) fn get_dns_max_stale() -> Option<Duration> {
     }
 }
 
+const DEFAULT_DNS_LOOKUP_ATTEMPTS: u64 = 3;
+
+/// Total DNS lookup attempts (timeout-bounded retries + one final unbounded).
+pub(crate) fn get_dns_lookup_attempts() -> u64 {
+    std::env::var("POLARS_DNS_LOOKUP_ATTEMPTS")
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_DNS_LOOKUP_ATTEMPTS)
+        .max(1)
+}
+
 const DEFAULT_DNS_ATTEMPT_TIMEOUT_MS: u64 = 500;
 
 /// DNS lookup attempt timeout before hedging kicks in.
-static DNS_ATTEMPT_TIMEOUT: LazyLock<Duration> = LazyLock::new(|| {
-    let ms = std::env::var("POLARS_DNS_ATTEMPT_TIMEOUT_MS")
+pub(crate) fn get_dns_attempt_timeout() -> Duration {
+    let timeout_ms = std::env::var("POLARS_DNS_ATTEMPT_TIMEOUT_MS")
         .ok()
         .and_then(|s| s.trim().parse::<u64>().ok())
         .unwrap_or(DEFAULT_DNS_ATTEMPT_TIMEOUT_MS);
 
-    if polars_config::config().verbose() {
-        eprintln!("[dns_cache] lookup attempt timeout: {ms}ms");
-    }
-
-    Duration::from_millis(ms)
-});
-
-const DEFAULT_DNS_LOOKUP_ATTEMPTS: u64 = 3;
-
-/// Total DNS lookup attempts (timeout-bounded retries + one final unbounded).
-static DNS_LOOKUP_ATTEMPTS: LazyLock<u64> = LazyLock::new(|| {
-    let attempts = std::env::var("POLARS_DNS_LOOKUP_ATTEMPTS")
-        .ok()
-        .and_then(|s| s.trim().parse::<u64>().ok())
-        .unwrap_or(DEFAULT_DNS_LOOKUP_ATTEMPTS)
-        .max(1);
-
-    if polars_config::config().verbose() {
-        eprintln!("[dns_cache] lookup attempts: {attempts}");
-    }
-
-    attempts
-});
-
-/// DNS lookup with hedged attempts once the timeout has been exceeded.
-async fn lookup_hedged(key: &str) -> Result<Vec<SocketAddr>, DynErr> {
-    let spawn_lookup = |key: String| {
-        ASYNC.spawn_blocking(move || {
-            (key.as_str(), 0u16)
-                .to_socket_addrs()
-                .map(|it| it.collect::<Vec<_>>())
-        })
-    };
-
-    let mut in_flight = FuturesUnordered::new();
-    in_flight.push(spawn_lookup(key.to_string()));
-    let mut launched = 1;
-
-    let t0 = Instant::now();
-
-    loop {
-        let can_hedge = launched < *DNS_LOOKUP_ATTEMPTS;
-
-        tokio::select! {
-            biased;
-
-            completed = in_flight.next() => {
-
-                let completed: Option<Result<Vec<SocketAddr>, DynErr>> = completed.map(|joined| {
-                    joined
-                        .map_err(DynErr::from)
-                        .and_then(|res| res.map_err(DynErr::from))
-                });
-
-                match completed {
-                    // First success wins.
-                    Some(Ok(addrs)) => {
-                        let elapsed = t0.elapsed();
-
-                        if let Some(threshold) = polars_config::config().dns_log_threshold()
-                            && elapsed.gt(&threshold)
-                        {
-                            let display_key = if polars_config::config().verbose_sensitive() {
-                                key
-                            } else {
-                                "<name suppressed>"
-                            };
-                            eprintln!(
-                                "[dns_cache] dns lookup for {} took {:.1} ms, exceeded threshold of {} ms",
-                                display_key,
-                                elapsed.as_secs_f64() * 1000.0,
-                                threshold.as_secs_f64() * 1000.0
-                            )
-                        };
-
-                        return Ok(addrs)},
-                    Some(Err(err)) => {
-                        if in_flight.is_empty() {
-                            if can_hedge {
-                                in_flight.push(spawn_lookup(key.to_string()));
-                                launched += 1;
-                            } else {
-                                return Err(err);
-                            }
-                        }
-                    },
-                    None => unreachable!("in_flight drained while still looping"),
-                }
-            }
-
-            _ = tokio::time::sleep(*DNS_ATTEMPT_TIMEOUT), if can_hedge => {
-                in_flight.push(spawn_lookup(key.to_string()));
-                launched += 1;
-            }
-        }
-    }
+    Duration::from_millis(timeout_ms)
 }
 
 #[derive(Debug)]
@@ -182,6 +85,25 @@ struct CachedAddrs {
     refreshing: Arc<AtomicBool>,
 }
 
+#[derive(Debug, Clone)]
+pub struct DnsResolverConfig {
+    pub ttl: Duration,
+    pub max_stale: Option<Duration>,
+    pub lookup_attempts: u64,
+    pub attempt_timeout: Duration,
+}
+
+impl DnsResolverConfig {
+    pub fn from_env() -> Self {
+        Self {
+            ttl: get_dns_cache_ttl(),
+            max_stale: get_dns_max_stale(),
+            lookup_attempts: get_dns_lookup_attempts(),
+            attempt_timeout: get_dns_attempt_timeout(),
+        }
+    }
+}
+
 /// Shuffle resolver with basic DNS cache. TTL is fixed and set by the calling site.
 /// The resolver serve policy:
 /// - case fresh: serve from cache;
@@ -190,19 +112,27 @@ struct CachedAddrs {
 #[derive(Clone, Debug)]
 pub struct CachingResolver {
     cache: &'static RwLock<HashMap<String, CachedAddrs>>,
-    // Since the OS does not return the TTL as provided by DNS, the calling site
-    // is responsible for providing one.
-    ttl: Duration,
-    // Upper limit for serve_stale DNS.
-    max_stale: Option<Duration>,
+    config: DnsResolverConfig,
 }
 
 impl CachingResolver {
-    pub fn new(ttl: Duration, max_stale: Option<Duration>) -> Self {
+    pub fn new(config: DnsResolverConfig) -> Self {
+        if polars_config::config().verbose() {
+            let max_stale = config
+                .max_stale
+                .map_or("disabled".to_string(), |m| format!("{}s", m.as_secs()));
+            eprintln!(
+                "[dns_cache] ttl: {}s, max_stale: {}, lookup_attempts: {}, attempt_timeout: {}ms",
+                config.ttl.as_secs(),
+                max_stale,
+                config.lookup_attempts,
+                config.attempt_timeout.as_millis()
+            );
+        }
+
         Self {
             cache: &DNS_CACHE,
-            ttl,
-            max_stale,
+            config,
         }
     }
 }
@@ -210,8 +140,13 @@ impl CachingResolver {
 impl Resolve for CachingResolver {
     fn resolve(&self, name: Name) -> Resolving {
         let cache = self.cache;
-        let ttl = self.ttl;
-        let max_stale = self.max_stale;
+        let DnsResolverConfig {
+            ttl,
+            max_stale,
+            lookup_attempts,
+            attempt_timeout,
+        } = self.config;
+
         let key = name.as_str().to_string();
 
         Box::pin(async move {
@@ -238,7 +173,8 @@ impl Resolve for CachingResolver {
                             let key = key.clone();
                             let refreshing = entry.refreshing.clone();
                             ASYNC.spawn(async move {
-                                let result = lookup_hedged(&key).await;
+                                let result =
+                                    lookup_hedged(&key, lookup_attempts, attempt_timeout).await;
 
                                 // Swap in the new set only on success; on failure keep
                                 // serving the old addrs (next stale hit re-triggers).
@@ -273,7 +209,7 @@ impl Resolve for CachingResolver {
                 }
             }
 
-            let addrs = Arc::new(lookup_hedged(&key).await?);
+            let addrs = Arc::new(lookup_hedged(&key, lookup_attempts, attempt_timeout).await?);
 
             write_guard.insert(
                 key,
@@ -287,6 +223,85 @@ impl Resolve for CachingResolver {
 
             Ok(shuffle_addrs(&addrs))
         })
+    }
+}
+
+/// DNS lookup with hedged attempts once the timeout has been exceeded.
+async fn lookup_hedged(
+    key: &str,
+    lookup_attempts: u64,
+    attempt_timeout: Duration,
+) -> Result<Vec<SocketAddr>, DynErr> {
+    let spawn_lookup = |key: String| {
+        ASYNC.spawn_blocking(move || {
+            (key.as_str(), 0u16)
+                .to_socket_addrs()
+                .map(|it| it.collect::<Vec<_>>())
+        })
+    };
+
+    let mut in_flight = FuturesUnordered::new();
+    in_flight.push(spawn_lookup(key.to_string()));
+    let mut launched = 1;
+
+    let t0 = Instant::now();
+
+    loop {
+        let can_hedge = launched < lookup_attempts;
+
+        tokio::select! {
+            biased;
+
+            completed = in_flight.next() => {
+
+                let completed: Option<Result<Vec<SocketAddr>, DynErr>> = completed.map(|joined| {
+                    joined
+                        .map_err(DynErr::from)
+                        .and_then(|res| res.map_err(DynErr::from))
+                });
+
+                match completed {
+                    // First success wins.
+                    Some(Ok(addrs)) => {
+                        let elapsed = t0.elapsed();
+
+                        if let Some(threshold) = polars_config::config().dns_log_threshold()
+                            && elapsed.gt(&threshold)
+                        {
+                            let display_key = if polars_config::config().verbose_sensitive() {
+                                key
+                            } else {
+                                "<name suppressed>"
+                            };
+                            eprintln!(
+                                "[dns_cache] dns lookup for {} launched {} attempt(s), took {:.1} ms, exceeded threshold of {} ms",
+                                display_key,
+                                launched,
+                                elapsed.as_secs_f64() * 1000.0,
+                                threshold.as_secs_f64() * 1000.0,
+                            )
+                        };
+
+                        return Ok(addrs)},
+                    Some(Err(err)) => {
+                        if in_flight.is_empty() {
+                            if can_hedge {
+                                in_flight.push(spawn_lookup(key.to_string()));
+                                launched += 1;
+                            } else {
+                                return Err(err);
+                            }
+                        }
+                    },
+                    None => unreachable!("in_flight drained while still looping"),
+                }
+            }
+
+            _ = tokio::time::sleep(attempt_timeout), if can_hedge => {
+                in_flight.push(spawn_lookup(key.to_string()));
+                launched += 1;
+            }
+        }
     }
 }
 

--- a/crates/polars-io/src/cloud/dns.rs
+++ b/crates/polars-io/src/cloud/dns.rs
@@ -1,6 +1,6 @@
 use std::net::{SocketAddr, ToSocketAddrs};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, LazyLock};
 use std::time::{Duration, Instant};
 
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -11,15 +11,17 @@ use tokio::sync::RwLock;
 
 type DynErr = Box<dyn std::error::Error + Send + Sync>;
 
-use std::sync::LazyLock;
-
 const DEFAULT_DNS_CACHE_TTL_SECS: u64 = 5;
 
 /// Process-wide DNS cache shared by all `CachingResolver` instances, so resolved
 /// addrs survive client teardown/rebuild (e.g. object-store cache eviction).
+/// In addition, addrs will be shared across object stores that share the same
+/// domain name, e.g., in the case of different buckets in the same region with
+/// path-style hosts in AWS.
 ///
-/// Assumes resolution is process-uniform: the key is the hostname alone, so this
-/// must not be shared if per-client resolver config is ever introduced.
+/// The hostname-only key assumes all clients resolve names identically (true
+/// today); per-client config that changes *answers* (e.g. custom nameservers)
+/// would require keying or splitting this cache.
 ///
 /// Entries are never evicted. This is ok for object-store endpoints (low cardinality).
 /// Revisit with a size cap if keys become externally driven (e.g. per-bucket
@@ -169,8 +171,6 @@ impl Resolve for CachingResolver {
                             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
                             .is_ok()
                         {
-                            let cache = cache.clone();
-                            let key = key.clone();
                             let refreshing = entry.refreshing.clone();
                             ASYNC.spawn(async move {
                                 let result =

--- a/crates/polars-io/src/cloud/dns.rs
+++ b/crates/polars-io/src/cloud/dns.rs
@@ -1,8 +1,9 @@
 use std::net::{SocketAddr, ToSocketAddrs};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, LazyLock};
 use std::time::{Duration, Instant};
 
+use futures::stream::{FuturesUnordered, StreamExt};
 use hashbrown::HashMap;
 use polars_core::runtime::ASYNC;
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};
@@ -25,6 +26,8 @@ const DEFAULT_DNS_CACHE_TTL_SECS: u64 = 5;
 /// virtual-hosted hosts at scale).
 static DNS_CACHE: LazyLock<RwLock<HashMap<String, CachedAddrs>>> = LazyLock::new(Default::default);
 
+/// Hard-coded DNS TTL cache, as the operating system does not return it with the
+/// calls used. Defaults to AWS TTL.
 pub(crate) fn get_dns_cache_ttl() -> Duration {
     let ttl = Duration::from_secs(
         std::env::var("POLARS_DNS_CACHE_TTL_SECS")
@@ -42,6 +45,7 @@ pub(crate) fn get_dns_cache_ttl() -> Duration {
 
 const DEFAULT_DNS_MAX_STALE_SECS: u64 = 300;
 
+/// Upper limit for serving stale DNS while refresh is happening in the background.
 pub(crate) fn get_dns_max_stale() -> Option<Duration> {
     let max_stale = Duration::from_secs(
         std::env::var("POLARS_DNS_MAX_STALE_SECS")
@@ -60,6 +64,114 @@ pub(crate) fn get_dns_max_stale() -> Option<Duration> {
         None
     } else {
         Some(max_stale)
+    }
+}
+
+const DEFAULT_DNS_ATTEMPT_TIMEOUT_MS: u64 = 500;
+
+/// DNS lookup attempt timeout before hedging kicks in.
+static DNS_ATTEMPT_TIMEOUT: LazyLock<Duration> = LazyLock::new(|| {
+    let ms = std::env::var("POLARS_DNS_ATTEMPT_TIMEOUT_MS")
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_DNS_ATTEMPT_TIMEOUT_MS);
+
+    if polars_config::config().verbose() {
+        eprintln!("[dns_cache] lookup attempt timeout: {ms}ms");
+    }
+
+    Duration::from_millis(ms)
+});
+
+const DEFAULT_DNS_LOOKUP_ATTEMPTS: u64 = 3;
+
+/// Total DNS lookup attempts (timeout-bounded retries + one final unbounded).
+static DNS_LOOKUP_ATTEMPTS: LazyLock<u64> = LazyLock::new(|| {
+    let attempts = std::env::var("POLARS_DNS_LOOKUP_ATTEMPTS")
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_DNS_LOOKUP_ATTEMPTS)
+        .max(1);
+
+    if polars_config::config().verbose() {
+        eprintln!("[dns_cache] lookup attempts: {attempts}");
+    }
+
+    attempts
+});
+
+/// DNS lookup with hedged attempts once the timeout has been exceeded.
+async fn lookup_hedged(key: &str) -> Result<Vec<SocketAddr>, DynErr> {
+    let spawn_lookup = |key: String| {
+        ASYNC.spawn_blocking(move || {
+            (key.as_str(), 0u16)
+                .to_socket_addrs()
+                .map(|it| it.collect::<Vec<_>>())
+        })
+    };
+
+    let mut in_flight = FuturesUnordered::new();
+    in_flight.push(spawn_lookup(key.to_string()));
+    let mut launched = 1;
+    let mut last_err: Option<DynErr>;
+
+    let t0 = Instant::now();
+
+    loop {
+        let can_hedge = launched < *DNS_LOOKUP_ATTEMPTS;
+
+        tokio::select! {
+            biased;
+
+            completed = in_flight.next() => {
+                match completed {
+                    // First success wins.
+                    Some(Ok(Ok(addrs))) => {
+                        let elapsed = t0.elapsed();
+
+                        if let Some(threshold) = polars_config::config().dns_log_threshold()
+                                && elapsed.gt(&threshold)
+                        {
+                            let display_key = if polars_config::config().verbose_sensitive() {
+                                key
+                            } else {
+                                "<name suppressed>"
+                            };
+                            eprintln!(
+                                "[dns_cache] dns lookup for {} took {:.1} ms, exceeded threshold of {} ms",
+                                display_key,
+                                elapsed.as_secs_f64() * 1000.0,
+                                threshold.as_secs_f64() * 1000.0
+                            )
+                        };
+
+                        return Ok(addrs)},
+                    Some(Ok(Err(io_err))) => {
+                        last_err = Some(io_err.into());
+                        if in_flight.is_empty() {
+                            if can_hedge {
+                                in_flight.push(spawn_lookup(key.to_string()));
+                                launched += 1;
+                            } else {
+                                return Err(last_err.unwrap());
+                            }
+                        }
+                    },
+                    Some(Err(join_err)) => {
+                        last_err = Some(join_err.into());
+                        if in_flight.is_empty() && !can_hedge {
+                            return Err(last_err.unwrap());
+                        }
+                    },
+                    None => unreachable!("in_flight drained while still looping"),
+                }
+            }
+
+            _ = tokio::time::sleep(*DNS_ATTEMPT_TIMEOUT), if can_hedge => {
+                in_flight.push(spawn_lookup(key.to_string()));
+                launched += 1;
+            }
+        }
     }
 }
 
@@ -127,18 +239,11 @@ impl Resolve for CachingResolver {
                             let key = key.clone();
                             let refreshing = entry.refreshing.clone();
                             ASYNC.spawn(async move {
-                                let key_clone = key.clone();
-                                let result = ASYNC
-                                    .spawn_blocking(move || {
-                                        (key_clone.as_str(), 0u16)
-                                            .to_socket_addrs()
-                                            .map(|it| it.collect::<Vec<_>>())
-                                    })
-                                    .await;
+                                let result = lookup_hedged(&key).await;
 
                                 // Swap in the new set only on success; on failure keep
                                 // serving the old addrs (next stale hit re-triggers).
-                                if let Ok(Ok(addrs)) = result {
+                                if let Ok(addrs) = result {
                                     let mut write_guard = cache.write().await;
                                     write_guard.insert(
                                         key,
@@ -169,19 +274,8 @@ impl Resolve for CachingResolver {
                     return Ok(shuffle_addrs(&entry.addrs));
                 }
             }
-
             let t0 = Instant::now();
-            let addrs = Arc::new(
-                ASYNC
-                    .spawn_blocking(move || {
-                        (key_clone.as_str(), 0u16)
-                            .to_socket_addrs()
-                            .map(|it| it.collect::<Vec<_>>())
-                    })
-                    .await
-                    .map_err(DynErr::from)??,
-            );
-            let elapsed = t0.elapsed();
+            let addrs = Arc::new(lookup_hedged(&key_clone).await?);
 
             write_guard.insert(
                 key.clone(),
@@ -192,22 +286,6 @@ impl Resolve for CachingResolver {
                 },
             );
             drop(write_guard);
-
-            if let Some(threshold) = polars_config::config().dns_log_threshold()
-                && elapsed.gt(&threshold)
-            {
-                let display_key = if polars_config::config().verbose_sensitive() {
-                    key.as_str()
-                } else {
-                    "<name suppressed>"
-                };
-                eprintln!(
-                    "[dns_cache] dns lookup for {} took {:.1} ms, exceeded threshold of {} ms",
-                    display_key,
-                    elapsed.as_secs_f64() * 1000.0,
-                    threshold.as_secs_f64() * 1000.0
-                )
-            }
 
             Ok(shuffle_addrs(&addrs))
         })

--- a/crates/polars-io/src/cloud/dns.rs
+++ b/crates/polars-io/src/cloud/dns.rs
@@ -113,7 +113,6 @@ async fn lookup_hedged(key: &str) -> Result<Vec<SocketAddr>, DynErr> {
     let mut in_flight = FuturesUnordered::new();
     in_flight.push(spawn_lookup(key.to_string()));
     let mut launched = 1;
-    let mut last_err: Option<DynErr>;
 
     let t0 = Instant::now();
 
@@ -124,13 +123,20 @@ async fn lookup_hedged(key: &str) -> Result<Vec<SocketAddr>, DynErr> {
             biased;
 
             completed = in_flight.next() => {
+
+                let completed: Option<Result<Vec<SocketAddr>, DynErr>> = completed.map(|joined| {
+                    joined
+                        .map_err(DynErr::from)
+                        .and_then(|res| res.map_err(DynErr::from))
+                });
+
                 match completed {
                     // First success wins.
-                    Some(Ok(Ok(addrs))) => {
+                    Some(Ok(addrs)) => {
                         let elapsed = t0.elapsed();
 
                         if let Some(threshold) = polars_config::config().dns_log_threshold()
-                                && elapsed.gt(&threshold)
+                            && elapsed.gt(&threshold)
                         {
                             let display_key = if polars_config::config().verbose_sensitive() {
                                 key
@@ -146,21 +152,14 @@ async fn lookup_hedged(key: &str) -> Result<Vec<SocketAddr>, DynErr> {
                         };
 
                         return Ok(addrs)},
-                    Some(Ok(Err(io_err))) => {
-                        last_err = Some(io_err.into());
+                    Some(Err(err)) => {
                         if in_flight.is_empty() {
                             if can_hedge {
                                 in_flight.push(spawn_lookup(key.to_string()));
                                 launched += 1;
                             } else {
-                                return Err(last_err.unwrap());
+                                return Err(err);
                             }
-                        }
-                    },
-                    Some(Err(join_err)) => {
-                        last_err = Some(join_err.into());
-                        if in_flight.is_empty() && !can_hedge {
-                            return Err(last_err.unwrap());
                         }
                     },
                     None => unreachable!("in_flight drained while still looping"),
@@ -264,7 +263,6 @@ impl Resolve for CachingResolver {
             }
 
             // Cache miss or expired
-            let key_clone = key.clone();
             let mut write_guard = cache.write().await;
 
             // Re-check in case the cache has been populated in the meanwhile
@@ -274,11 +272,11 @@ impl Resolve for CachingResolver {
                     return Ok(shuffle_addrs(&entry.addrs));
                 }
             }
-            let t0 = Instant::now();
-            let addrs = Arc::new(lookup_hedged(&key_clone).await?);
+
+            let addrs = Arc::new(lookup_hedged(&key).await?);
 
             write_guard.insert(
-                key.clone(),
+                key,
                 CachedAddrs {
                     addrs: addrs.clone(),
                     fetched_at: Instant::now(),

--- a/crates/polars-io/src/cloud/dns.rs
+++ b/crates/polars-io/src/cloud/dns.rs
@@ -1,8 +1,10 @@
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use hashbrown::HashMap;
+use polars_core::runtime::ASYNC;
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use tokio::sync::RwLock;
 
@@ -38,26 +40,58 @@ pub(crate) fn get_dns_cache_ttl() -> Duration {
     ttl
 }
 
+const DEFAULT_DNS_MAX_STALE_SECS: u64 = 300;
+
+pub(crate) fn get_dns_max_stale() -> Option<Duration> {
+    let max_stale = Duration::from_secs(
+        std::env::var("POLARS_DNS_MAX_STALE_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_DNS_MAX_STALE_SECS),
+    );
+    if polars_config::config().verbose() {
+        if max_stale.is_zero() {
+            eprintln!("[dns_cache] max stale: <stale serve disabled>");
+        } else {
+            eprintln!("[dns_cache] max stale: {}s", max_stale.as_secs());
+        }
+    }
+    if max_stale.is_zero() {
+        None
+    } else {
+        Some(max_stale)
+    }
+}
+
 #[derive(Debug)]
 struct CachedAddrs {
     addrs: Arc<Vec<SocketAddr>>,
     fetched_at: Instant,
+    /// True while a background refresh for this host is in flight (single-flight gate).
+    refreshing: Arc<AtomicBool>,
 }
 
 /// Shuffle resolver with basic DNS cache. TTL is fixed and set by the calling site.
+/// The resolver serve policy:
+/// - case fresh: serve from cache;
+/// - case expired and within max_stale (> ttl): serve stale + single-flight background refresh;
+/// - case beyond max_stale (or max_stale = None): blocking resolve
 #[derive(Clone, Debug)]
 pub struct CachingResolver {
     cache: &'static RwLock<HashMap<String, CachedAddrs>>,
     // Since the OS does not return the TTL as provided by DNS, the calling site
     // is responsible for providing one.
     ttl: Duration,
+    // Upper limit for serve_stale DNS.
+    max_stale: Option<Duration>,
 }
 
 impl CachingResolver {
-    pub fn new(ttl: Duration) -> Self {
+    pub fn new(ttl: Duration, max_stale: Option<Duration>) -> Self {
         Self {
             cache: &DNS_CACHE,
             ttl,
+            max_stale,
         }
     }
 }
@@ -66,6 +100,7 @@ impl Resolve for CachingResolver {
     fn resolve(&self, name: Name) -> Resolving {
         let cache = self.cache;
         let ttl = self.ttl;
+        let max_stale = self.max_stale;
         let key = name.as_str().to_string();
 
         Box::pin(async move {
@@ -73,7 +108,51 @@ impl Resolve for CachingResolver {
                 let read_guard = cache.read().await;
 
                 if let Some(entry) = read_guard.get(&key) {
-                    if entry.fetched_at.elapsed() < ttl {
+                    let age = entry.fetched_at.elapsed();
+                    if age < ttl {
+                        return Ok(shuffle_addrs(&entry.addrs));
+                    }
+
+                    if let Some(max_stale) = max_stale
+                        && age < max_stale
+                    {
+                        // Expired: serve stale immediately, refresh in the background.
+                        // CAS ensures a burst of stale hits spawns exactly one refresh.
+                        if entry
+                            .refreshing
+                            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                            .is_ok()
+                        {
+                            let cache = cache.clone();
+                            let key = key.clone();
+                            let refreshing = entry.refreshing.clone();
+                            ASYNC.spawn(async move {
+                                let key_clone = key.clone();
+                                let result = ASYNC
+                                    .spawn_blocking(move || {
+                                        (key_clone.as_str(), 0u16)
+                                            .to_socket_addrs()
+                                            .map(|it| it.collect::<Vec<_>>())
+                                    })
+                                    .await;
+
+                                // Swap in the new set only on success; on failure keep
+                                // serving the old addrs (next stale hit re-triggers).
+                                if let Ok(Ok(addrs)) = result {
+                                    let mut write_guard = cache.write().await;
+                                    write_guard.insert(
+                                        key,
+                                        CachedAddrs {
+                                            addrs: Arc::new(addrs),
+                                            fetched_at: Instant::now(),
+                                            refreshing: refreshing.clone(),
+                                        },
+                                    );
+                                }
+                                refreshing.store(false, Ordering::Release);
+                            });
+                        }
+
                         return Ok(shuffle_addrs(&entry.addrs));
                     }
                 }
@@ -85,14 +164,15 @@ impl Resolve for CachingResolver {
 
             // Re-check in case the cache has been populated in the meanwhile
             if let Some(entry) = write_guard.get(&key) {
-                if entry.fetched_at.elapsed() < ttl {
+                let age = entry.fetched_at.elapsed();
+                if max_stale.is_some_and(|m| age < m) || age < ttl {
                     return Ok(shuffle_addrs(&entry.addrs));
                 }
             }
 
             let t0 = Instant::now();
             let addrs = Arc::new(
-                polars_core::runtime::ASYNC
+                ASYNC
                     .spawn_blocking(move || {
                         (key_clone.as_str(), 0u16)
                             .to_socket_addrs()
@@ -108,6 +188,7 @@ impl Resolve for CachingResolver {
                 CachedAddrs {
                     addrs: addrs.clone(),
                     fetched_at: Instant::now(),
+                    refreshing: Arc::new(AtomicBool::new(false)),
                 },
             );
             drop(write_guard);

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -34,11 +34,9 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "cloud")]
 use super::credential_provider::PlCredentialProvider;
 #[cfg(feature = "cloud")]
-use super::dns::get_dns_cache_ttl;
-#[cfg(feature = "cloud")]
 use crate::cloud::ObjectStoreErrorContext;
 #[cfg(any(feature = "aws", feature = "gcp", feature = "azure", feature = "http"))]
-use crate::cloud::dns::{CachingResolver, get_dns_max_stale};
+use crate::cloud::dns::{CachingResolver, DnsResolverConfig};
 #[cfg(feature = "file_cache")]
 use crate::file_cache::get_env_file_cache_ttl;
 #[cfg(feature = "aws")]
@@ -305,10 +303,9 @@ pub(super) fn get_client_options() -> ClientOptions {
         ))
         .with_user_agent(HeaderValue::from_static(USER_AGENT))
         .with_allow_http(true)
-        .with_dns_resolver(Arc::new(CachingResolver::new(
-            get_dns_cache_ttl(),
-            get_dns_max_stale(),
-        )))
+        .with_dns_resolver(Arc::new(
+            CachingResolver::new(DnsResolverConfig::from_env()),
+        ))
 }
 
 #[cfg(feature = "aws")]

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -38,7 +38,7 @@ use super::dns::get_dns_cache_ttl;
 #[cfg(feature = "cloud")]
 use crate::cloud::ObjectStoreErrorContext;
 #[cfg(any(feature = "aws", feature = "gcp", feature = "azure", feature = "http"))]
-use crate::cloud::dns::CachingResolver;
+use crate::cloud::dns::{CachingResolver, get_dns_max_stale};
 #[cfg(feature = "file_cache")]
 use crate::file_cache::get_env_file_cache_ttl;
 #[cfg(feature = "aws")]
@@ -305,7 +305,10 @@ pub(super) fn get_client_options() -> ClientOptions {
         ))
         .with_user_agent(HeaderValue::from_static(USER_AGENT))
         .with_allow_http(true)
-        .with_dns_resolver(Arc::new(CachingResolver::new(get_dns_cache_ttl())))
+        .with_dns_resolver(Arc::new(CachingResolver::new(
+            get_dns_cache_ttl(),
+            get_dns_max_stale(),
+        )))
 }
 
 #[cfg(feature = "aws")]


### PR DESCRIPTION
closes #28252

This PR does two things: (a) serve stale records while refresh happens in the background, and (b) fast-hedge on DNS in case the result is not coming in immediately.

See code for logic and new env vars.

fyi @EndPositive 

ping @nameexhaustion for review (thx!)