### PR TITLE
docs(rust): Update DataFrame code example in the eager section

### DIFF
--- a/crates/polars/src/docs/eager.rs
+++ b/crates/polars/src/docs/eager.rs
@@ -310,12 +310,12 @@
 //!
 //!
 //! // coerce numbers to floats
-//! df.try_apply("number", |s: &Series| s.cast(&DataType::Float64))?;
+//! df.try_apply("numbers", |s: &Series| s.cast(&DataType::Float64))?;
 //!
 //! // transform letters to uppercase letters
 //! df.try_apply("letters", |s: &Series| {
 //!     Ok(s.str()?.to_uppercase())
-//! });
+//! })?;
 //!
 //! # Ok(())
 //! # }


### PR DESCRIPTION
This updates the DataFrame example to fix the following issues:

* Use the correct column name `numbers` instead of `number`.
* Add the missing `?` operator to the second `try_apply()` call to match the style of the first call.