### PR TITLE
fix(rust): Ensure predicate simplification is deterministically ordered

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/mod.rs
@@ -74,6 +74,10 @@ pub(crate) fn init_hashmap<K, V>(max_len: Option<usize>) -> PlHashMap<K, V> {
     PlHashMap::with_capacity(std::cmp::min(max_len.unwrap_or(HASHMAP_SIZE), HASHMAP_SIZE))
 }
 
+pub(crate) fn init_indexmap<K, V>(max_len: Option<usize>) -> PlIndexMap<K, V> {
+    PlIndexMap::with_capacity(std::cmp::min(max_len.unwrap_or(HASHMAP_SIZE), HASHMAP_SIZE))
+}
+
 pub(crate) fn pushdown_maintain_errors() -> bool {
     std::env::var("POLARS_PUSHDOWN_OPT_MAINTAIN_ERRORS").as_deref() == Ok("1")
 }

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/group_by.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/group_by.rs
@@ -12,7 +12,7 @@ pub(super) fn process_group_by(
     maintain_order: bool,
     apply: Option<PlanCallback<DataFrame, DataFrame>>,
     options: Arc<GroupbyOptions>,
-    acc_predicates: PlHashMap<PlSmallStr, ExprIR>,
+    acc_predicates: PlIndexMap<PlSmallStr, ExprIR>,
 ) -> PolarsResult<IR> {
     use IR::*;
 
@@ -58,7 +58,7 @@ pub(super) fn process_group_by(
         }
     }
 
-    let mut new_acc_predicates = PlHashMap::with_capacity(acc_predicates.len());
+    let mut new_acc_predicates = init_indexmap(Some(acc_predicates.len()));
 
     for (pred_name, predicate) in acc_predicates {
         // Counts change due to groupby's

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
@@ -16,7 +16,7 @@ pub(super) fn process_join(
     mut right_on: Vec<ExprIR>,
     mut schema: SchemaRef,
     mut options: Arc<JoinOptionsIR>,
-    mut acc_predicates: PlHashMap<PlSmallStr, ExprIR>,
+    mut acc_predicates: PlIndexMap<PlSmallStr, ExprIR>,
     streaming: bool,
 ) -> PolarsResult<IR> {
     if options.args.slice.is_some() {
@@ -254,9 +254,10 @@ pub(super) fn process_join(
         }
     }
 
-    let mut pushdown_left: PlHashMap<PlSmallStr, ExprIR> = init_hashmap(Some(acc_predicates.len()));
-    let mut pushdown_right: PlHashMap<PlSmallStr, ExprIR> =
-        init_hashmap(Some(acc_predicates.len()));
+    let mut pushdown_left: PlIndexMap<PlSmallStr, ExprIR> =
+        init_indexmap(Some(acc_predicates.len()));
+    let mut pushdown_right: PlIndexMap<PlSmallStr, ExprIR> =
+        init_indexmap(Some(acc_predicates.len()));
     let mut local_predicates = Vec::with_capacity(acc_predicates.len());
 
     for (_, predicate) in acc_predicates {
@@ -460,8 +461,8 @@ fn try_reduce_redundant_join_keys(
     }
 
     let mut remove_key = vec![false; left_on.len()];
-    let mut pushdown_left = init_hashmap(None);
-    let mut pushdown_right = init_hashmap(None);
+    let mut pushdown_left = init_indexmap(None);
+    let mut pushdown_right = init_indexmap(None);
 
     if reduce_left {
         collect_redundant_join_key_filters(
@@ -542,7 +543,7 @@ fn collect_redundant_join_key_filters(
     other_side_on: &[ExprIR],
     nulls_equal: bool,
     remove_key: &mut [bool],
-    pushdown: &mut PlHashMap<PlSmallStr, ExprIR>,
+    pushdown: &mut PlIndexMap<PlSmallStr, ExprIR>,
     expr_arena: &mut Arena<AExpr>,
 ) {
     let op = if nulls_equal {
@@ -609,7 +610,7 @@ fn try_rewrite_join_type(
     options: &mut Arc<JoinOptionsIR>,
     left_on: &mut Vec<ExprIR>,
     right_on: &mut Vec<ExprIR>,
-    acc_predicates: &mut PlHashMap<PlSmallStr, ExprIR>,
+    acc_predicates: &mut PlIndexMap<PlSmallStr, ExprIR>,
     expr_arena: &mut Arena<AExpr>,
     streaming: bool,
 ) -> PolarsResult<Option<(Vec<ExprIR>, SchemaRef)>> {
@@ -1273,12 +1274,12 @@ struct InnerJoinKeys {
 
 /// Removes all equality predicates that can be used as inner-join conditions from `acc_predicates`.
 fn take_inner_join_compatible_filters(
-    acc_predicates: &mut PlHashMap<PlSmallStr, ExprIR>,
+    acc_predicates: &mut PlIndexMap<PlSmallStr, ExprIR>,
     expr_arena: &mut Arena<AExpr>,
     schema_left: &Schema,
     schema_right: &Schema,
     suffix: &str,
-) -> PolarsResult<hashbrown::hash_map::IntoValues<Node, InnerJoinKeys>> {
+) -> PolarsResult<indexmap::map::IntoValues<Node, InnerJoinKeys>> {
     take_predicates_mut(acc_predicates, expr_arena, |ae, _ae_node, expr_arena| {
         Ok(match ae {
             AExpr::BinaryExpr {
@@ -1333,13 +1334,13 @@ struct IEJoinCompatiblePredicate {
 #[cfg(feature = "iejoin")]
 /// Removes all inequality filters that can be used as iejoin conditions from `acc_predicates`.
 fn take_iejoin_compatible_filters(
-    acc_predicates: &mut PlHashMap<PlSmallStr, ExprIR>,
+    acc_predicates: &mut PlIndexMap<PlSmallStr, ExprIR>,
     expr_arena: &mut Arena<AExpr>,
     schema_left: &Schema,
     schema_right: &Schema,
     output_schema: &Schema,
     suffix: &str,
-) -> PolarsResult<hashbrown::hash_map::IntoValues<Node, IEJoinCompatiblePredicate>> {
+) -> PolarsResult<indexmap::map::IntoValues<Node, IEJoinCompatiblePredicate>> {
     return take_predicates_mut(acc_predicates, expr_arena, |ae, ae_node, expr_arena| {
         Ok(match ae {
             AExpr::BinaryExpr { left, op, right } => {
@@ -1416,7 +1417,7 @@ fn take_iejoin_compatible_filters(
 
 #[cfg(feature = "iejoin")]
 fn take_double_bounded_range_join_filter(
-    acc_predicates: &mut PlHashMap<PlSmallStr, ExprIR>,
+    acc_predicates: &mut PlIndexMap<PlSmallStr, ExprIR>,
     expr_arena: &mut Arena<AExpr>,
     schema_left: &Schema,
     schema_right: &Schema,
@@ -1505,12 +1506,12 @@ fn take_double_bounded_range_join_filter(
 /// Note that filters that refer only to a single side are not removed so that they can be pushed
 /// into the LHS/RHS tables.
 fn take_nested_loop_join_compatible_filters(
-    acc_predicates: &mut PlHashMap<PlSmallStr, ExprIR>,
+    acc_predicates: &mut PlIndexMap<PlSmallStr, ExprIR>,
     expr_arena: &mut Arena<AExpr>,
     schema_left: &Schema,
     schema_right: &Schema,
     suffix: &str,
-) -> PolarsResult<hashbrown::hash_map::IntoValues<Node, Node>> {
+) -> PolarsResult<indexmap::map::IntoValues<Node, Node>> {
     take_predicates_mut(acc_predicates, expr_arena, |_ae, ae_node, expr_arena| {
         Ok(
             match ExprOrigin::get_expr_origin(
@@ -1531,14 +1532,14 @@ fn take_nested_loop_join_compatible_filters(
 
 /// Removes predicates from the map according to a function.
 fn take_predicates_mut<F, T>(
-    acc_predicates: &mut PlHashMap<PlSmallStr, ExprIR>,
+    acc_predicates: &mut PlIndexMap<PlSmallStr, ExprIR>,
     expr_arena: &mut Arena<AExpr>,
     take_predicate: F,
-) -> PolarsResult<hashbrown::hash_map::IntoValues<Node, T>>
+) -> PolarsResult<indexmap::map::IntoValues<Node, T>>
 where
     F: Fn(&AExpr, Node, &Arena<AExpr>) -> PolarsResult<Option<T>>,
 {
-    let mut selected_predicates: PlHashMap<Node, T> = PlHashMap::new();
+    let mut selected_predicates: PlIndexMap<Node, T> = init_indexmap(None);
 
     for predicate in acc_predicates.values() {
         for node in MintermIter::new(predicate.node(), expr_arena) {
@@ -1560,11 +1561,11 @@ where
 
     #[inline(never)]
     fn remove_min_terms(
-        acc_predicates: &mut PlHashMap<PlSmallStr, ExprIR>,
+        acc_predicates: &mut PlIndexMap<PlSmallStr, ExprIR>,
         expr_arena: &mut Arena<AExpr>,
         should_remove: &dyn Fn(&Node) -> bool,
     ) {
-        let mut remove_keys = PlHashSet::new();
+        let mut remove_keys = PlIndexSet::new();
         let mut nodes_scratch = vec![];
 
         for (k, predicate) in acc_predicates.iter_mut() {
@@ -1601,7 +1602,7 @@ where
         }
 
         for k in remove_keys {
-            let v = acc_predicates.remove(&k);
+            let v = acc_predicates.swap_remove(&k);
             assert!(v.is_some());
         }
     }

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -318,7 +318,7 @@ impl PredicatePushDown {
                 };
 
                 if let Some(predicate) =
-                    combine_predicates(acc_predicates.into_values(), expr_arena)
+                    combine_keyed_predicates(acc_predicates.into_iter(), expr_arena)
                 {
                     let input = lp_arena.add(lp);
 
@@ -352,7 +352,10 @@ impl PredicatePushDown {
                     })
                 };
                 let predicate = combine_predicates(
-                    Option::into_iter(predicate.clone()).chain(acc_predicates.into_values()),
+                    Option::into_iter(predicate.clone()).chain(
+                        combine_keyed_predicates(acc_predicates.into_iter(), expr_arena)
+                            .into_iter(),
+                    ),
                     expr_arena,
                 );
 
@@ -653,7 +656,7 @@ impl PredicatePushDown {
             #[cfg(feature = "python")]
             PythonScan { mut options } => {
                 if let Some(predicate) =
-                    combine_predicates(acc_predicates.into_values(), expr_arena)
+                    combine_keyed_predicates(acc_predicates.into_iter(), expr_arena)
                 {
                     match ExprPushdownGroup::Pushable.update_with_expr_rec(
                         expr_arena.get(predicate.node()),

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -5,7 +5,7 @@ mod keys;
 mod utils;
 
 pub use dynamic::{DynamicPred, DynamicPredWeakRef, PredicateExpr, TrivialPredicateExpr};
-use polars_core::datatypes::PlHashMap;
+use polars_core::datatypes::{PlHashMap, PlIndexMap};
 use polars_core::prelude::*;
 use polars_utils::idx_vec::UnitVec;
 use polars_utils::scratch_vec::ScratchUnitVec;
@@ -65,7 +65,7 @@ impl PredicatePushDown {
     fn pushdown_and_assign(
         &mut self,
         input: Node,
-        acc_predicates: PlHashMap<PlSmallStr, ExprIR>,
+        acc_predicates: PlIndexMap<PlSmallStr, ExprIR>,
         lp_arena: &mut Arena<IR>,
         expr_arena: &mut Arena<AExpr>,
     ) -> PolarsResult<()> {
@@ -79,7 +79,7 @@ impl PredicatePushDown {
     fn pushdown_and_continue(
         &mut self,
         lp: IR,
-        mut acc_predicates: PlHashMap<PlSmallStr, ExprIR>,
+        mut acc_predicates: PlIndexMap<PlSmallStr, ExprIR>,
         lp_arena: &mut Arena<IR>,
         expr_arena: &mut Arena<AExpr>,
         has_projections: bool,
@@ -112,7 +112,7 @@ impl PredicatePushDown {
                 PushdownEligibility::Partial { to_local } => {
                     let mut out = Vec::with_capacity(to_local.len());
                     for key in to_local {
-                        out.push(acc_predicates.remove(&key).unwrap());
+                        out.push(acc_predicates.swap_remove(&key).unwrap());
                     }
                     out
                 },
@@ -145,7 +145,7 @@ impl PredicatePushDown {
                     // it could be that this node just added the column where we base the predicate on
                     let input_schema = lp_arena.get(node).schema(lp_arena);
                     let mut pushdown_predicates =
-                        optimizer::init_hashmap(Some(acc_predicates.len()));
+                        optimizer::init_indexmap(Some(acc_predicates.len()));
                     for (_, predicate) in acc_predicates.iter() {
                         // we can pushdown the predicate
                         if check_input_node(predicate.node(), &input_schema, expr_arena) {
@@ -173,23 +173,23 @@ impl PredicatePushDown {
     fn no_pushdown_restart_opt(
         &mut self,
         lp: IR,
-        mut acc_predicates: PlHashMap<PlSmallStr, ExprIR>,
+        mut acc_predicates: PlIndexMap<PlSmallStr, ExprIR>,
         lp_arena: &mut Arena<IR>,
         expr_arena: &mut Arena<AExpr>,
     ) -> PolarsResult<IR> {
         let inputs = lp.inputs();
 
-        let local_predicates: Vec<ExprIR> = acc_predicates.drain().map(|x| x.1).collect();
+        let local_predicates: Vec<ExprIR> = acc_predicates.drain(..).map(|x| x.1).collect();
 
         assert!(acc_predicates.is_empty());
-        let mut reuse_hashmap: Option<PlHashMap<_, _>> = Some(acc_predicates);
+        let mut reuse_hashmap: Option<PlIndexMap<_, _>> = Some(acc_predicates);
 
         let new_inputs = inputs
             .map(|node| {
                 let alp = lp_arena.take(node);
                 let alp = self.push_down(
                     alp,
-                    reuse_hashmap.take().unwrap_or_else(|| init_hashmap(None)),
+                    reuse_hashmap.take().unwrap_or_else(|| init_indexmap(None)),
                     lp_arena,
                     expr_arena,
                 )?;
@@ -205,7 +205,7 @@ impl PredicatePushDown {
     fn no_pushdown(
         &mut self,
         lp: IR,
-        acc_predicates: PlHashMap<PlSmallStr, ExprIR>,
+        acc_predicates: PlIndexMap<PlSmallStr, ExprIR>,
         lp_arena: &mut Arena<IR>,
         expr_arena: &mut Arena<AExpr>,
     ) -> PolarsResult<IR> {
@@ -229,7 +229,7 @@ impl PredicatePushDown {
     fn push_down(
         &mut self,
         lp: IR,
-        mut acc_predicates: PlHashMap<PlSmallStr, ExprIR>,
+        mut acc_predicates: PlIndexMap<PlSmallStr, ExprIR>,
         lp_arena: &mut Arena<IR>,
         expr_arena: &mut Arena<AExpr>,
     ) -> PolarsResult<IR> {
@@ -274,18 +274,18 @@ impl PredicatePushDown {
                     PushdownEligibility::Partial { to_local } => {
                         let mut out = Vec::with_capacity(to_local.len());
                         for key in to_local {
-                            out.push(acc_predicates.remove(&key).unwrap());
+                            out.push(acc_predicates.swap_remove(&key).unwrap());
                         }
                         out
                     },
                     PushdownEligibility::NoPushdown => {
-                        let out = acc_predicates.drain().map(|t| t.1).collect();
+                        let out = acc_predicates.drain(..).map(|t| t.1).collect();
                         acc_predicates.clear();
                         out
                     },
                 };
 
-                if let Some(predicate) = acc_predicates.remove(&tmp_key) {
+                if let Some(predicate) = acc_predicates.swap_remove(&tmp_key) {
                     insert_predicate_dedup(&mut acc_predicates, &predicate, expr_arena);
                 }
 
@@ -318,7 +318,7 @@ impl PredicatePushDown {
                 };
 
                 if let Some(predicate) =
-                    combine_keyed_predicates(acc_predicates.into_iter(), expr_arena)
+                    combine_predicates(acc_predicates.into_values(), expr_arena)
                 {
                     let input = lp_arena.add(lp);
 
@@ -352,10 +352,7 @@ impl PredicatePushDown {
                     })
                 };
                 let predicate = combine_predicates(
-                    Option::into_iter(predicate.clone()).chain(
-                        combine_keyed_predicates(acc_predicates.into_iter(), expr_arena)
-                            .into_iter(),
-                    ),
+                    Option::into_iter(predicate.clone()).chain(acc_predicates.into_values()),
                     expr_arena,
                 );
 
@@ -591,7 +588,7 @@ impl PredicatePushDown {
                 let mut local_predicates = Vec::new();
 
                 if slice.is_some() && !acc_predicates.is_empty() {
-                    local_predicates.extend(acc_predicates.drain().map(|x| x.1));
+                    local_predicates.extend(acc_predicates.drain(..).map(|x| x.1));
                 }
 
                 if let Some((offset, len, None)) = slice
@@ -656,7 +653,7 @@ impl PredicatePushDown {
             #[cfg(feature = "python")]
             PythonScan { mut options } => {
                 if let Some(predicate) =
-                    combine_keyed_predicates(acc_predicates.into_iter(), expr_arena)
+                    combine_predicates(acc_predicates.into_values(), expr_arena)
                 {
                     match ExprPushdownGroup::Pushable.update_with_expr_rec(
                         expr_arena.get(predicate.node()),
@@ -702,7 +699,7 @@ impl PredicatePushDown {
         lp_arena: &mut Arena<IR>,
         expr_arena: &mut Arena<AExpr>,
     ) -> PolarsResult<IR> {
-        let acc_predicates = PlHashMap::new();
+        let acc_predicates = init_indexmap(None);
         self.push_down(logical_plan, acc_predicates, lp_arena, expr_arena)
     }
 }

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
@@ -74,14 +74,11 @@ pub(super) fn temporary_unique_key(acc_predicates: &PlHashMap<PlSmallStr, ExprIR
     PlSmallStr::from_string(out_key)
 }
 
-pub(super) fn combine_predicates<I>(iter: I, expr_arena: &mut Arena<AExpr>) -> Option<ExprIR>
+fn combine_predicates_ordered<I>(iter: I, expr_arena: &mut Arena<AExpr>) -> Option<ExprIR>
 where
     I: IntoIterator<Item = ExprIR>,
 {
-    // Order the predicates so that CSE can hit them.
-    let mut exprs = iter.into_iter().collect_vec();
-    exprs.sort_unstable_by(|a, b| a.output_name().cmp(b.output_name()));
-    let mut iter = exprs.iter();
+    let mut iter = iter.into_iter();
     let mut out = iter.next()?.node();
 
     for e in iter {
@@ -93,6 +90,32 @@ where
     }
 
     Some(ExprIR::from_node(out, expr_arena))
+}
+
+pub(super) fn combine_keyed_predicates<I>(iter: I, expr_arena: &mut Arena<AExpr>) -> Option<ExprIR>
+where
+    I: IntoIterator<Item = (PlSmallStr, ExprIR)>,
+{
+    let mut predicates = iter.into_iter().collect_vec();
+    // If we collected a hashmap of predicates that refer to expressions
+    // with the same output name, we need a tie-breaker to decide the sort order.
+    // The hashmap's key str is that thing.
+    predicates.sort_unstable_by(|(lk, l), (rk, r)| {
+        l.output_name()
+            .cmp(r.output_name())
+            .then_with(|| lk.cmp(rk))
+    });
+    combine_predicates_ordered(predicates.into_iter().map(|(_, expr)| expr), expr_arena)
+}
+
+pub(super) fn combine_predicates<I>(iter: I, expr_arena: &mut Arena<AExpr>) -> Option<ExprIR>
+where
+    I: IntoIterator<Item = ExprIR>,
+{
+    // Order the predicates so that CSE can hit them.
+    let mut exprs = iter.into_iter().collect_vec();
+    exprs.sort_unstable_by(|a, b| a.output_name().cmp(b.output_name()));
+    combine_predicates_ordered(exprs, expr_arena)
 }
 
 /// Evaluates a condition on the column name inputs of every predicate, where if

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
@@ -21,7 +21,7 @@ fn combine_by_and(left: Node, right: Node, arena: &mut Arena<AExpr>) -> Node {
 /// The map is keyed in a way that may cause some predicates to fall into the same bucket. In that
 /// case the predicate is AND'ed with the existing node in that bucket.
 pub(super) fn insert_predicate_dedup(
-    acc_predicates: &mut PlHashMap<PlSmallStr, ExprIR>,
+    acc_predicates: &mut PlIndexMap<PlSmallStr, ExprIR>,
     predicate: &ExprIR,
     expr_arena: &mut Arena<AExpr>,
 ) {
@@ -62,7 +62,7 @@ pub(super) fn insert_predicate_dedup(
         .or_insert_with(|| predicate.clone());
 }
 
-pub(super) fn temporary_unique_key(acc_predicates: &PlHashMap<PlSmallStr, ExprIR>) -> PlSmallStr {
+pub(super) fn temporary_unique_key(acc_predicates: &PlIndexMap<PlSmallStr, ExprIR>) -> PlSmallStr {
     // TODO: Don't heap allocate during construction.
     let mut out_key = '\u{1D17A}'.to_string();
     let mut existing_keys = acc_predicates.keys();
@@ -74,11 +74,14 @@ pub(super) fn temporary_unique_key(acc_predicates: &PlHashMap<PlSmallStr, ExprIR
     PlSmallStr::from_string(out_key)
 }
 
-fn combine_predicates_ordered<I>(iter: I, expr_arena: &mut Arena<AExpr>) -> Option<ExprIR>
+pub(super) fn combine_predicates<I>(iter: I, expr_arena: &mut Arena<AExpr>) -> Option<ExprIR>
 where
     I: IntoIterator<Item = ExprIR>,
 {
-    let mut iter = iter.into_iter();
+    // Order the predicates so that CSE can hit them.
+    let mut exprs = iter.into_iter().collect_vec();
+    exprs.sort_by(|a, b| a.output_name().cmp(b.output_name()));
+    let mut iter = exprs.iter();
     let mut out = iter.next()?.node();
 
     for e in iter {
@@ -92,38 +95,12 @@ where
     Some(ExprIR::from_node(out, expr_arena))
 }
 
-pub(super) fn combine_keyed_predicates<I>(iter: I, expr_arena: &mut Arena<AExpr>) -> Option<ExprIR>
-where
-    I: IntoIterator<Item = (PlSmallStr, ExprIR)>,
-{
-    let mut predicates = iter.into_iter().collect_vec();
-    // If we collected a hashmap of predicates that refer to expressions
-    // with the same output name, we need a tie-breaker to decide the sort order.
-    // The hashmap's key str is that thing.
-    predicates.sort_unstable_by(|(lk, l), (rk, r)| {
-        l.output_name()
-            .cmp(r.output_name())
-            .then_with(|| lk.cmp(rk))
-    });
-    combine_predicates_ordered(predicates.into_iter().map(|(_, expr)| expr), expr_arena)
-}
-
-pub(super) fn combine_predicates<I>(iter: I, expr_arena: &mut Arena<AExpr>) -> Option<ExprIR>
-where
-    I: IntoIterator<Item = ExprIR>,
-{
-    // Order the predicates so that CSE can hit them.
-    let mut exprs = iter.into_iter().collect_vec();
-    exprs.sort_unstable_by(|a, b| a.output_name().cmp(b.output_name()));
-    combine_predicates_ordered(exprs, expr_arena)
-}
-
 /// Evaluates a condition on the column name inputs of every predicate, where if
 /// the condition evaluates to true on any column name the predicate is
 /// transferred to local.
 pub(super) fn transfer_to_local_by_name<F>(
     expr_arena: &Arena<AExpr>,
-    acc_predicates: &mut PlHashMap<PlSmallStr, ExprIR>,
+    acc_predicates: &mut PlIndexMap<PlSmallStr, ExprIR>,
     mut condition: F,
 ) -> Vec<ExprIR>
 where
@@ -142,7 +119,7 @@ where
     }
     let mut local_predicates = Vec::with_capacity(remove_keys.len());
     for key in remove_keys {
-        if let Some(pred) = acc_predicates.remove(&*key) {
+        if let Some(pred) = acc_predicates.swap_remove(&*key) {
             local_predicates.push(pred)
         }
     }
@@ -183,7 +160,7 @@ pub fn pushdown_eligibility(
     // Predicates that need to be checked (key, expr_ir)
     new_predicates: &[(&PlSmallStr, ExprIR)],
     // Note: These predicates have already passed checks.
-    acc_predicates: &PlHashMap<PlSmallStr, ExprIR>,
+    acc_predicates: &PlIndexMap<PlSmallStr, ExprIR>,
     expr_arena: &mut Arena<AExpr>,
     scratch: &mut UnitVec<Node>,
     maintain_errors: bool,

--- a/py-polars/tests/unit/lazyframe/test_predicates.py
+++ b/py-polars/tests/unit/lazyframe/test_predicates.py
@@ -1810,3 +1810,14 @@ def test_predicate_normalization() -> None:
     assert out == 1
     out = scans(lambda lf: lf.filter(A & B & C), lambda lf: lf.filter(C & B & A))
     assert out == 1
+
+
+def test_predicate_simplification_stable_28267() -> None:
+    df = pl.LazyFrame({"value": [2, 3, 3, None]})
+    q = df.filter(
+        pl.col("value").is_between(1, 2) & pl.col("value").is_between(2, 3).not_()
+    )
+
+    plan = q.explain()
+
+    assert plan.find("is_between") < plan.find("&")

--- a/py-polars/tests/unit/lazyframe/test_predicates.py
+++ b/py-polars/tests/unit/lazyframe/test_predicates.py
@@ -1820,4 +1820,4 @@ def test_predicate_simplification_stable_28267() -> None:
 
     plan = q.explain()
 
-    assert plan.find("is_between") < plan.find("&")
+    assert plan.find("is_between") > plan.find("&")


### PR DESCRIPTION
Previously we used PlHashMap, which doesn't have a deterministic iteration
order, to collect predicates. We would then sort the collected predicates
by their column output names, however, if two predicates had the same
output name their order would be indeterminate.

With an IndexMap, as long as we process insertions and removals in a
consistent order, the iteration order is always the same.

- Closes https://github.com/pola-rs/polars/issues/28267