### PR TITLE
fix: Avoid panic when consumer of vertical concat is done

### DIFF
--- a/crates/polars-stream/src/nodes/ordered_union.rs
+++ b/crates/polars-stream/src/nodes/ordered_union.rs
@@ -37,6 +37,12 @@ impl ComputeNode for OrderedUnionNode {
     ) -> PolarsResult<()> {
         assert!(self.cur_input_idx <= recv.len() && send.len() == 1);
 
+        // Mark inputs as done when the output is done and stop processing.
+        if send[0] == PortState::Done {
+            recv.fill(PortState::Done);
+            return Ok(());
+        }
+
         // Skip inputs that are done.
         while self.cur_input_idx < recv.len() && recv[self.cur_input_idx] == PortState::Done {
             self.cur_input_idx += 1;

--- a/py-polars/tests/unit/functions/test_concat.py
+++ b/py-polars/tests/unit/functions/test_concat.py
@@ -146,6 +146,20 @@ def test_concat_invalid_schema_err_20355() -> None:
         pl.concat([lf1, lf2]).collect(engine="streaming")
 
 
+def test_concat_ordered_union_slice_done_28272() -> None:
+    # An ordered-union (vertical `concat`) feeding a downstream that finishes early.
+    # This created a panic because it left a pipe stranded in a non-Done state.
+    lf = pl.DataFrame({"x": [0, 1, 2, 3]}, schema={"x": pl.Int64}).lazy()
+    lf = pl.concat([lf, lf], rechunk=False)
+    lf = pl.concat([lf, lf], rechunk=False)
+    lf = lf.unique(subset="x", keep="first", maintain_order=True)
+    lf = lf.slice(0, 2)
+    assert_frame_equal(
+        lf.collect(engine="streaming"),
+        pl.DataFrame({"x": [0, 1]}, schema={"x": pl.Int64}),
+    )
+
+
 def test_concat_df() -> None:
     df1 = pl.DataFrame({"a": [2, 1, 3], "b": [1, 2, 3], "c": [1, 2, 3]})
     df2 = pl.concat([df1, df1], rechunk=True)


### PR DESCRIPTION
This commit patches a panic encountered where a vertical concat would not mark its pipes as done when the consumer done was marked as done.

The MR includes the MRE which fails on main as well as the fix, which mirrors code already existing for the unordered union node. The bug was there since the node was first written.

Regarding AI policy:
1. We were debugging a separate issue and used AI to build hundreds of evaluations plans that should yield expected results. We found multiple plans failing and realized they were all due to two bugs. The first one is this, the other one was already resolved upstream and will be included in the next release.
2. I also used AI to explore the database.
3. I confirm I have reviewed all changes myself and I believe they are relevant and correct.
