### PR TITLE
fix(rust): Don't attribute untimed execution to optimization in profile

### DIFF
--- a/crates/polars-expr/src/state/execution_state.rs
+++ b/crates/polars-expr/src/state/execution_state.rs
@@ -157,8 +157,8 @@ impl ExecutionState {
     }
 
     /// Toggle this to measure execution times.
-    pub fn time_nodes(&mut self, start: std::time::Instant) {
-        self.node_timer = Some(NodeTimer::new(start))
+    pub fn time_nodes(&mut self, query_start: std::time::Instant, optimization_duration: Duration) {
+        self.node_timer = Some(NodeTimer::new(query_start, optimization_duration))
     }
     pub fn has_node_timer(&self) -> bool {
         self.node_timer.is_some()

--- a/crates/polars-expr/src/state/node_timer.rs
+++ b/crates/polars-expr/src/state/node_timer.rs
@@ -17,10 +17,13 @@ pub(super) struct NodeTimer {
 }
 
 impl NodeTimer {
-    pub(super) fn new(query_start: Instant) -> Self {
+    pub(super) fn new(query_start: Instant, optimization_duration: Duration) -> Self {
+        let (mut nodes, mut ticks) = (Vec::with_capacity(16), Vec::with_capacity(16));
+        nodes.push("optimization".to_string());
+        ticks.push((Duration::ZERO, optimization_duration));
         Self {
             query_start,
-            data: Arc::new(Mutex::new((Vec::with_capacity(16), Vec::with_capacity(16)))),
+            data: Arc::new(Mutex::new((nodes, ticks))),
         }
     }
 
@@ -42,14 +45,8 @@ impl NodeTimer {
 
     pub(super) fn finish(self) -> PolarsResult<DataFrame> {
         let mut data = self.data.lock().unwrap();
-        let mut nodes = std::mem::take(&mut data.0);
-        nodes.push("optimization".to_string());
-
-        let mut ticks = std::mem::take(&mut data.1);
-        // first value is end of optimization
-        polars_ensure!(!ticks.is_empty(), ComputeError: "no data to time");
-        let start = ticks[0].0;
-        ticks.push((Duration::from_nanos(0), start));
+        let nodes = std::mem::take(&mut data.0);
+        let ticks = std::mem::take(&mut data.1);
         let nodes_s = Column::new(PlSmallStr::from_static("node"), nodes);
         let start: NoNull<UInt64Chunked> = ticks
             .iter()

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -797,7 +797,7 @@ impl LazyFrame {
         let query_start = std::time::Instant::now();
         let (mut state, mut physical_plan, _) =
             self.prepare_collect_post_opt(false, Some(query_start), post_opt)?;
-        state.time_nodes(query_start);
+        state.time_nodes(query_start, query_start.elapsed());
         let out = physical_plan.execute(&mut state)?;
         let timer_df = state.finish_timer()?;
         Ok((out, timer_df))


### PR DESCRIPTION
- Closes #28271

Note, I'm not sure how much love it is worth lavishing on `LazyFrame.profile`, but this change was useful to me writing some optimisation passes so that I didn't up accidentally attributing to the optimiser what was in fact a change in compute time.