### PR TITLE
refactor(rust): Disallow HashMap/Set in polars-plan

### DIFF
--- a/crates/polars-io/src/csv/read/schema_inference.rs
+++ b/crates/polars-io/src/csv/read/schema_inference.rs
@@ -28,7 +28,7 @@ pub(super) fn infer_file_schema_impl(
 
     let extend_header_with_unknown_column = header_line.is_none();
 
-    let mut column_types = vec![PlHashSet::<DataType>::with_capacity(4); headers.len()];
+    let mut column_types = vec![PlIndexSet::<DataType>::with_capacity(4); headers.len()];
     let mut nulls = vec![false; headers.len()];
 
     for content_line in content_lines {
@@ -93,7 +93,7 @@ fn infer_types_from_line(
     headers: &mut Vec<PlSmallStr>,
     extend_header_with_unknown_column: bool,
     parse_options: &CsvParseOptions,
-    column_types: &mut Vec<PlHashSet<DataType>>,
+    column_types: &mut Vec<PlIndexSet<DataType>>,
     nulls: &mut Vec<bool>,
 ) {
     let line_len = line.len();
@@ -193,7 +193,7 @@ fn infer_types_from_line(
 
 fn build_schema(
     headers: &[PlSmallStr],
-    column_types: &[PlHashSet<DataType>],
+    column_types: &[PlIndexSet<DataType>],
     schema_overwrite: Option<&Schema>,
 ) -> Schema {
     assert!(headers.len() == column_types.len());
@@ -227,7 +227,7 @@ fn build_schema(
     )
 }
 
-pub fn finish_infer_field_schema(possibilities: &PlHashSet<DataType>) -> DataType {
+pub fn finish_infer_field_schema(possibilities: &PlIndexSet<DataType>) -> DataType {
     // determine data type based on possible types
     // if there are incompatible types, use DataType::String
     match possibilities.len() {
@@ -362,7 +362,7 @@ mod tests {
     #[test]
     #[cfg(feature = "dtype-i128")]
     fn test_finish_infer_field_schema_i64_and_i128() {
-        let mut possibilities = PlHashSet::new();
+        let mut possibilities = PlIndexSet::new();
         possibilities.insert(DataType::Int64);
         possibilities.insert(DataType::Int128);
         assert_eq!(finish_infer_field_schema(&possibilities), DataType::Int128);

--- a/crates/polars-plan/clippy.toml
+++ b/crates/polars-plan/clippy.toml
@@ -1,0 +1,6 @@
+disallowed-types = [
+  { path = "std::collections::HashMap", reason = "use deterministic PlIndexMap" },
+  { path = "polars_utils::aliases::PlHashMap", reason = "use deterministic PlIndexMap" },
+  { path = "std::collections::HashSet", reason = "use deterministic PlIndexSet" },
+  { path = "polars_utils::aliases::PlHashSet", reason = "use deterministic PlIndexSet" },
+]

--- a/crates/polars-plan/src/dsl/datatype_expr.rs
+++ b/crates/polars-plan/src/dsl/datatype_expr.rs
@@ -196,8 +196,8 @@ fn into_datatype_impl(
             )
         }),
         D::StructWithFields(field_exprs) => feature_gated!("dtype-struct", {
-            use polars_core::prelude::{Field, InitHashMaps, PlHashSet};
-            let mut seen = PlHashSet::with_capacity(field_exprs.len());
+            use polars_core::prelude::{Field, InitHashMaps, PlIndexSet};
+            let mut seen = PlIndexSet::with_capacity(field_exprs.len());
             let mut fields = Vec::with_capacity(field_exprs.len());
             for (name, dt_expr) in field_exprs {
                 let dt = into_datatype_impl(dt_expr, schema, self_dtype)?;

--- a/crates/polars-plan/src/dsl/file_scan/deletion.rs
+++ b/crates/polars-plan/src/dsl/file_scan/deletion.rs
@@ -18,7 +18,7 @@ pub enum DeletionFilesList {
     // * There may be data files without deletion files.
     // * A single data file may have multiple associated deletion files.
     //
-    // Note that this uses `PlIndexMap` instead of `PlHashMap` for schemars compatibility.
+    // Note that this uses `PlIndexMap` instead of `PlIndexMap` for schemars compatibility.
     //
     // Other possible options:
     // * ListArray(inner: Utf8Array)

--- a/crates/polars-plan/src/dsl/file_scan/mod.rs
+++ b/crates/polars-plan/src/dsl/file_scan/mod.rs
@@ -624,7 +624,7 @@ impl CastColumnsPolicy {
                 return mismatch_err("");
             };
 
-            let incoming_fields_schema = PlHashMap::from_iter(
+            let incoming_fields_schema = PlIndexMap::from_iter(
                 incoming_fields
                     .iter()
                     .enumerate()

--- a/crates/polars-plan/src/dsl/options/sink.rs
+++ b/crates/polars-plan/src/dsl/options/sink.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use polars_core::error::PolarsResult;
 use polars_core::frame::DataFrame;
-use polars_core::prelude::PlHashSet;
+use polars_core::prelude::PlIndexSet;
 use polars_core::schema::Schema;
 use polars_error::feature_gated;
 use polars_io::cloud::CloudOptions;
@@ -408,7 +408,7 @@ impl PartitionedSinkOptionsIR {
                 if keys.is_empty() {
                     Cow::Borrowed(input_schema)
                 } else if !include_keys {
-                    let key_output_names: PlHashSet<&PlSmallStr> =
+                    let key_output_names: PlIndexSet<&PlSmallStr> =
                         keys.iter().map(|e| e.output_name()).collect();
 
                     Cow::Owned(

--- a/crates/polars-plan/src/dsl/selector.rs
+++ b/crates/polars-plan/src/dsl/selector.rs
@@ -172,7 +172,7 @@ pub enum Selector {
 
 fn dtype_selector(
     schema: &Schema,
-    ignored_columns: &PlHashSet<PlSmallStr>,
+    ignored_columns: &PlIndexSet<PlSmallStr>,
     f: impl Fn(&DataType) -> bool,
 ) -> PlIndexSet<PlSmallStr> {
     PlIndexSet::from_iter(
@@ -192,7 +192,7 @@ impl Selector {
     pub fn into_columns(
         &self,
         schema: &Schema,
-        ignored_columns: &PlHashSet<PlSmallStr>,
+        ignored_columns: &PlIndexSet<PlSmallStr>,
     ) -> PolarsResult<PlIndexSet<PlSmallStr>> {
         let out = match self {
             Self::Union(lhs, rhs) => {
@@ -406,7 +406,7 @@ impl DataTypeSelector {
     fn into_columns(
         &self,
         schema: &Schema,
-        ignored_columns: &PlHashSet<PlSmallStr>,
+        ignored_columns: &PlIndexSet<PlSmallStr>,
     ) -> PolarsResult<PlIndexSet<PlSmallStr>> {
         Ok(match self {
             Self::Union(lhs, rhs) => {
@@ -446,7 +446,7 @@ impl DataTypeSelector {
                 .collect(),
             Self::Empty => Default::default(),
             Self::AnyOf(dtypes) => {
-                let dtypes = PlHashSet::from_iter(dtypes.iter().cloned());
+                let dtypes = PlIndexSet::from_iter(dtypes.iter().cloned());
                 dtype_selector(schema, ignored_columns, |dtype| dtypes.contains(dtype))
             },
             Self::Integer => dtype_selector(schema, ignored_columns, |dtype| dtype.is_integer()),

--- a/crates/polars-plan/src/plans/aexpr/function_expr/plugin.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/plugin.rs
@@ -10,7 +10,7 @@ use pyo3::{Python, types::PyAnyMethods};
 use super::*;
 
 type PluginAndVersion = (Library, u16, u16);
-static LOADED: LazyLock<RwLock<PlHashMap<String, Arc<PluginAndVersion>>>> =
+static LOADED: LazyLock<RwLock<PlIndexMap<String, Arc<PluginAndVersion>>>> =
     LazyLock::new(Default::default);
 
 fn get_lib(lib: &str) -> PolarsResult<Arc<PluginAndVersion>> {

--- a/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
@@ -164,7 +164,7 @@ impl IRFunctionExpr {
             AsList => mapper.map_to_list_of_dtypes(),
             #[cfg(feature = "dtype-struct")]
             AsStruct => {
-                let mut field_names = PlHashSet::with_capacity(fields.len() - 1);
+                let mut field_names = PlIndexSet::with_capacity(fields.len() - 1);
                 let struct_fields = fields
                     .iter()
                     .map(|f| {

--- a/crates/polars-plan/src/plans/aexpr/or_factoring.rs
+++ b/crates/polars-plan/src/plans/aexpr/or_factoring.rs
@@ -73,7 +73,7 @@ fn collect_or_branches(root: Node, expr_arena: &Arena<AExpr>, out: &mut Vec<Node
 fn try_factor_or(or_node: Node, expr_arena: &mut Arena<AExpr>) -> Option<AExpr> {
     use std::hash::{BuildHasher, Hasher};
 
-    use polars_utils::aliases::{InitHashMaps, PlFixedStateQuality, PlHashMap};
+    use polars_utils::aliases::{InitHashMaps, PlFixedStateQuality, PlIndexMap};
     use polars_utils::scratch_vec::ScratchVec;
 
     use crate::plans::aexpr::{
@@ -107,10 +107,10 @@ fn try_factor_or(or_node: Node, expr_arena: &mut Arena<AExpr>) -> Option<AExpr> 
         traverse_and_hash_aexpr(n, arena, &mut h);
         h.finish()
     };
-    let buckets: Vec<PlHashMap<u64, Vec<usize>>> = branch_terms
+    let buckets: Vec<PlIndexMap<u64, Vec<usize>>> = branch_terms
         .iter()
         .map(|terms| {
-            let mut m: PlHashMap<u64, Vec<usize>> = PlHashMap::with_capacity(terms.len());
+            let mut m: PlIndexMap<u64, Vec<usize>> = PlIndexMap::with_capacity(terms.len());
             for (i, &n) in terms.iter().enumerate() {
                 m.entry(hash_of(n, expr_arena)).or_default().push(i);
             }

--- a/crates/polars-plan/src/plans/aexpr/predicates/column_expr.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/column_expr.rs
@@ -6,7 +6,7 @@ use polars_core::scalar::Scalar;
 use polars_core::schema::Schema;
 use polars_io::predicates::SpecializedColumnPredicate;
 use polars_ops::series::ClosedInterval;
-use polars_utils::aliases::PlHashMap;
+use polars_utils::aliases::PlIndexMap;
 use polars_utils::arena::{Arena, Node};
 use polars_utils::pl_str::PlSmallStr;
 
@@ -18,7 +18,7 @@ use crate::plans::{
 };
 
 pub struct ColumnPredicates {
-    pub predicates: PlHashMap<PlSmallStr, (Node, Option<SpecializedColumnPredicate>)>,
+    pub predicates: PlIndexMap<PlSmallStr, (Node, Option<SpecializedColumnPredicate>)>,
 
     /// Are all column predicates AND-ed together the original predicate.
     pub is_sumwise_complete: bool,
@@ -30,7 +30,7 @@ pub fn aexpr_to_column_predicates(
     schema: &Schema,
 ) -> ColumnPredicates {
     let mut predicates =
-        PlHashMap::<PlSmallStr, (Node, Option<SpecializedColumnPredicate>)>::default();
+        PlIndexMap::<PlSmallStr, (Node, Option<SpecializedColumnPredicate>)>::default();
     let mut is_sumwise_complete = true;
 
     let minterms = MintermIter::new(root, expr_arena).collect::<Vec<_>>();

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_expansion.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_expansion.rs
@@ -10,7 +10,7 @@ pub fn prepare_projection(
     schema: &Schema,
     opt_flags: &mut OptFlags,
 ) -> PolarsResult<(Vec<Expr>, Schema)> {
-    let exprs = rewrite_projections(exprs, &PlHashSet::new(), schema, opt_flags)?;
+    let exprs = rewrite_projections(exprs, &PlIndexSet::new(), schema, opt_flags)?;
     let schema = expressions_to_schema(&exprs, schema, |duplicate_name: &str| {
         format!("projections contained duplicate output name '{duplicate_name}'")
     })?;
@@ -23,7 +23,7 @@ pub fn is_regex_projection(name: &str) -> bool {
 
 pub fn expand_expression(
     expr: &Expr,
-    ignored_selector_columns: &PlHashSet<PlSmallStr>,
+    ignored_selector_columns: &PlIndexSet<PlSmallStr>,
     schema: &Schema,
     out: &mut Vec<Expr>,
     opt_flags: &mut OptFlags,
@@ -41,7 +41,7 @@ pub fn expand_expression(
 /// In other cases replace the wildcard with an expression with all columns
 pub fn rewrite_projections(
     exprs: Vec<Expr>,
-    ignored_selector_columns: &PlHashSet<PlSmallStr>,
+    ignored_selector_columns: &PlIndexSet<PlSmallStr>,
     schema: &Schema,
     opt_flags: &mut OptFlags,
 ) -> PolarsResult<Vec<Expr>> {
@@ -129,7 +129,7 @@ fn function_input_wildcard_expansion(function: &FunctionExpr) -> FunctionExpansi
 
 fn expand_expression_by_combination(
     exprs: &[Expr],
-    ignored_selector_columns: &PlHashSet<PlSmallStr>,
+    ignored_selector_columns: &PlIndexSet<PlSmallStr>,
     schema: &Schema,
     out: &mut Vec<Expr>,
     opt_flags: &mut OptFlags,
@@ -200,7 +200,7 @@ fn expand_expression_by_combination(
 
 fn expand_single(
     subexpr: &Expr,
-    ignored_selector_columns: &PlHashSet<PlSmallStr>,
+    ignored_selector_columns: &PlIndexSet<PlSmallStr>,
     schema: &Schema,
     out: &mut Vec<Expr>,
     opt_flags: &mut OptFlags,
@@ -218,7 +218,7 @@ fn expand_single(
 
 fn try_expand_single(
     subexpr: &Expr,
-    ignored_selector_columns: &PlHashSet<PlSmallStr>,
+    ignored_selector_columns: &PlIndexSet<PlSmallStr>,
     schema: &Schema,
     out: &mut Vec<Expr>,
     opt_flags: &mut OptFlags,
@@ -257,7 +257,7 @@ fn needs_expansion(expr: &Expr) -> bool {
 
 fn expand_expression_rec(
     expr: &Expr,
-    ignored_selector_columns: &PlHashSet<PlSmallStr>,
+    ignored_selector_columns: &PlIndexSet<PlSmallStr>,
     schema: &Schema,
     out: &mut Vec<Expr>,
     opt_flags: &mut OptFlags,

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_to_ir.rs
@@ -540,7 +540,7 @@ pub(super) fn to_aexpr_impl(
 
             let mut eval_ir = Vec::with_capacity(evaluation.len());
 
-            let mut field_names = PlHashSet::new();
+            let mut field_names = PlIndexSet::new();
             for e in evaluation {
                 let mut eval_ctx = ExprToIRContext {
                     with_fields: Some(struct_schema.clone()),

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/join.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/join.rs
@@ -131,7 +131,7 @@ pub fn resolve_join(
             )
         })
         .collect::<PolarsResult<Vec<_>>>()?;
-    let mut joined_on = PlHashSet::new();
+    let mut joined_on = PlIndexSet::new();
 
     #[cfg(feature = "iejoin")]
     let check = !matches!(options.args.how, JoinType::IEJoin);

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -259,7 +259,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             let mut out = Vec::with_capacity(1);
             expr_expansion::expand_expression(
                 &predicate,
-                &PlHashSet::default(),
+                &PlIndexSet::default(),
                 input_schema.as_ref().as_ref(),
                 &mut out,
                 ctxt.opt_flags,
@@ -1045,7 +1045,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 .map(|i| AExprBuilder::col(i.clone(), ctxt.expr_arena).expr_ir(i))
                 .collect();
 
-            let mut uniq_names = PlHashSet::new();
+            let mut uniq_names = PlIndexSet::new();
             for expr in keys.iter().chain(aggs.iter()) {
                 let name = expr.output_name();
                 let is_uniq = uniq_names.insert(name.clone());
@@ -1065,7 +1065,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             let (input, subset, temp_cols) = if let Some(exprs) = options.subset {
                 let exprs = rewrite_projections(
                     exprs,
-                    &PlHashSet::default(),
+                    &PlIndexSet::default(),
                     &input_schema,
                     ctxt.opt_flags,
                 )?;
@@ -1660,8 +1660,8 @@ fn resolve_with_columns(
 ) -> PolarsResult<(Vec<ExprIR>, SchemaRef)> {
     let input_schema = lp_arena.get(input).schema(lp_arena);
     let mut output_schema = (**input_schema).clone();
-    let exprs = rewrite_projections(exprs, &PlHashSet::new(), &input_schema, opt_flags)?;
-    let mut output_names = PlHashSet::with_capacity(exprs.len());
+    let exprs = rewrite_projections(exprs, &PlIndexSet::new(), &input_schema, opt_flags)?;
+    let mut output_names = PlIndexSet::with_capacity(exprs.len());
 
     let eirs = to_expr_irs(
         exprs,
@@ -1697,13 +1697,13 @@ fn resolve_group_by(
 ) -> PolarsResult<(Vec<ExprIR>, Vec<ExprIR>, SchemaRef)> {
     let input_schema = lp_arena.get(input).schema(lp_arena);
     let input_schema = input_schema.as_ref();
-    let mut keys = rewrite_projections(keys, &PlHashSet::default(), input_schema, opt_flags)?;
+    let mut keys = rewrite_projections(keys, &PlIndexSet::default(), input_schema, opt_flags)?;
 
     // Initialize schema from keys
     let mut output_schema = expressions_to_schema(&keys, input_schema, |duplicate_name: &str| {
         format!("group_by keys contained duplicate output name '{duplicate_name}'")
     })?;
-    let mut key_names: PlHashSet<PlSmallStr> = output_schema.iter_names().cloned().collect();
+    let mut key_names: PlIndexSet<PlSmallStr> = output_schema.iter_names().cloned().collect();
 
     #[allow(unused_mut)]
     let mut pop_keys = false;
@@ -1753,7 +1753,7 @@ fn resolve_group_by(
 
     // Make sure aggregation columns do not contain duplicates
     if aggs_schema.len() < aggs.len() {
-        let mut names = PlHashSet::with_capacity(aggs.len());
+        let mut names = PlIndexSet::with_capacity(aggs.len());
         for agg in aggs.iter() {
             let name = agg.output_name();
             polars_ensure!(names.insert(name.clone()), duplicate = name)
@@ -1780,7 +1780,7 @@ fn resolve_group_by(
 
     // Make sure aggregation columns do not contain keys or index columns
     if output_schema.len() < (keys_index_len + aggs.len()) {
-        let mut names = PlHashSet::with_capacity(output_schema.len());
+        let mut names = PlIndexSet::with_capacity(output_schema.len());
         for agg in aggs.iter().chain(keys.iter()) {
             let name = agg.output_name();
             polars_ensure!(names.insert(name.clone()), duplicate = name)

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
@@ -1068,7 +1068,7 @@ enum CachedSourceKey {
 
 #[derive(Default, Clone)]
 pub(super) struct SourcesToFileInfo {
-    inner: Arc<RwLock<PlHashMap<CachedSourceKey, (FileInfo, FileScanIR)>>>,
+    inner: Arc<RwLock<PlIndexMap<CachedSourceKey, (FileInfo, FileScanIR)>>>,
 }
 
 impl SourcesToFileInfo {

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/utils.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/utils.rs
@@ -10,7 +10,7 @@ pub(super) struct DslConversionContext<'a> {
     pub(super) cache_file_info: SourcesToFileInfo,
     pub(super) pushdown_maintain_errors: bool,
     pub(super) verbose: bool,
-    pub(super) seen_caches: PlHashMap<UniqueId, Node>,
+    pub(super) seen_caches: PlIndexMap<UniqueId, Node>,
 }
 
 pub(super) fn expand_expressions(

--- a/crates/polars-plan/src/plans/conversion/stack_opt.rs
+++ b/crates/polars-plan/src/plans/conversion/stack_opt.rs
@@ -17,7 +17,7 @@ pub struct ConversionOptimizer {
     // then it can occur that we take a slot multiple times.
     // So we keep track of the arena versions used and allow only
     // one unique IR cache to be reused.
-    pub(super) used_arenas: PlHashSet<u32>,
+    pub(super) used_arenas: PlIndexSet<u32>,
 }
 
 struct ExtendVec<'a> {

--- a/crates/polars-plan/src/plans/hive.rs
+++ b/crates/polars-plan/src/plans/hive.rs
@@ -113,8 +113,8 @@ pub fn hive_partitions_from_paths(
         let path = path.sliced(hive_start_idx..path.as_str().len());
 
         let mut hive_schema = Schema::with_capacity(16);
-        let mut schema_inference_map: PlHashMap<&str, PlHashSet<DataType>> =
-            PlHashMap::with_capacity(16);
+        let mut schema_inference_map: PlIndexMap<&str, PlIndexSet<DataType>> =
+            PlIndexMap::with_capacity(16);
 
         for (name, _) in get_hive_parts_iter!(&path) {
             // If the column is also in the file we can use the dtype stored there.
@@ -130,7 +130,7 @@ pub fn hive_partitions_from_paths(
             }
 
             hive_schema.insert_at_index(hive_schema.len(), name.into(), DataType::String)?;
-            schema_inference_map.insert(name, PlHashSet::with_capacity(4));
+            schema_inference_map.insert(name, PlIndexSet::with_capacity(4));
         }
 
         if hive_schema.is_empty() && schema_inference_map.is_empty() {
@@ -153,7 +153,7 @@ pub fn hive_partitions_from_paths(
                 }
             }
 
-            for (name, ref possibilities) in schema_inference_map.drain() {
+            for (name, ref possibilities) in schema_inference_map.drain(..) {
                 let dtype = finish_infer_field_schema(possibilities);
                 *hive_schema.try_get_mut(name).unwrap() = dtype;
             }

--- a/crates/polars-plan/src/plans/ir/dot.rs
+++ b/crates/polars-plan/src/plans/ir/dot.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::path::PathBuf;
 
-use polars_core::prelude::{InitHashMaps, PlHashSet};
+use polars_core::prelude::{InitHashMaps, PlIndexSet};
 use polars_core::schema::Schema;
 use polars_utils::pl_str::PlSmallStr;
 use polars_utils::unique_id::UniqueId;
@@ -77,7 +77,7 @@ impl<'a> IRDotDisplay<'a> {
         f: &mut fmt::Formatter<'_>,
         parent: Option<DotNode>,
         last: &mut usize,
-        visited_caches: &mut PlHashSet<UniqueId>,
+        visited_caches: &mut PlIndexSet<UniqueId>,
     ) -> std::fmt::Result {
         use fmt::Write;
 
@@ -473,7 +473,7 @@ impl fmt::Display for IRDotDisplay<'_> {
         writeln!(f, "{INDENT}node [fontname=\"Monospace\", shape=\"box\"]")?;
 
         let mut last = 0;
-        let mut visited_caches = PlHashSet::new();
+        let mut visited_caches = PlIndexSet::new();
         self._format(f, None, &mut last, &mut visited_caches)?;
 
         writeln!(f, "}}")?;

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Display, Formatter, Write};
 use polars_core::frame::DataFrame;
 use polars_core::schema::Schema;
 use polars_io::RowIndex;
-use polars_utils::aliases::{InitHashMaps as _, PlHashSet};
+use polars_utils::aliases::{InitHashMaps as _, PlIndexSet};
 use polars_utils::format_list_truncated;
 use polars_utils::slice_enum::Slice;
 use polars_utils::unique_id::UniqueId;
@@ -152,7 +152,7 @@ impl<'a> IRDisplay<'a> {
         &self,
         f: &mut Formatter,
         indent: usize,
-        seen_caches: &mut PlHashSet<UniqueId>,
+        seen_caches: &mut PlIndexSet<UniqueId>,
     ) -> fmt::Result {
         if indent != 0 {
             writeln!(f)?;
@@ -313,7 +313,7 @@ impl<'a> ExprIRDisplay<'a> {
 
 impl Display for IRDisplay<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let mut seen_caches = PlHashSet::new();
+        let mut seen_caches = PlIndexSet::new();
         self._format(f, 0, &mut seen_caches)
     }
 }

--- a/crates/polars-plan/src/plans/ir/schema.rs
+++ b/crates/polars-plan/src/plans/ir/schema.rs
@@ -133,6 +133,7 @@ impl IR {
 
     /// Get the schema of the logical plan node, using caching.
     #[recursive]
+    #[allow(clippy::disallowed_types)] // We don't iterate over cache.
     pub fn schema_with_cache<'a>(
         node: Node,
         arena: &'a Arena<IR>,

--- a/crates/polars-plan/src/plans/ir/tree_format.rs
+++ b/crates/polars-plan/src/plans/ir/tree_format.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Write};
 
 use polars_core::error::*;
-use polars_utils::aliases::PlHashSet;
+use polars_utils::aliases::PlIndexSet;
 use polars_utils::format_list_truncated;
 use polars_utils::unique_id::UniqueId;
 
@@ -470,7 +470,7 @@ pub(crate) struct TreeFmtVisitor {
     prev_depth: usize,
     depth: usize,
     width: usize,
-    seen_caches: PlHashSet<UniqueId>,
+    seen_caches: PlIndexSet<UniqueId>,
     pub(crate) display: TreeFmtVisitorDisplay,
 }
 

--- a/crates/polars-plan/src/plans/optimizer/cluster_with_columns.rs
+++ b/crates/polars-plan/src/plans/optimizer/cluster_with_columns.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use polars_core::prelude::{PlHashSet, PlIndexMap};
+use polars_core::prelude::{PlIndexMap, PlIndexSet};
 use polars_utils::aliases::InitHashMaps;
 use polars_utils::arena::{Arena, Node};
 
@@ -15,10 +15,10 @@ pub fn optimize(root: Node, lp_arena: &mut Arena<IR>, expr_arena: &Arena<AExpr>)
 
     // key: output_name, value: (expr, is_original)
     let mut input_name_to_expr_map: PlIndexMap<PlSmallStr, (ExprIR, bool)> = PlIndexMap::new();
-    let mut input_names_accessed_by_non_candidates: PlHashSet<PlSmallStr> = PlHashSet::new();
+    let mut input_names_accessed_by_non_candidates: PlIndexSet<PlSmallStr> = PlIndexSet::new();
     let mut push_candidate_idxs: Vec<usize> = vec![];
     let mut new_current_exprs: Vec<ExprIR> = vec![];
-    let mut visited_caches = PlHashSet::new();
+    let mut visited_caches = PlIndexSet::new();
 
     while let Some(current_node) = ir_stack.pop() {
         let current_ir = lp_arena.get(current_node);

--- a/crates/polars-plan/src/plans/optimizer/collect_members.rs
+++ b/crates/polars-plan/src/plans/optimizer/collect_members.rs
@@ -7,7 +7,7 @@ use super::*;
 #[cfg(feature = "cse")]
 #[derive(Default)]
 struct UniqueScans {
-    ids: PlHashSet<u64>,
+    ids: PlIndexSet<u64>,
     count: usize,
 }
 

--- a/crates/polars-plan/src/plans/optimizer/cse/cache_states.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/cache_states.rs
@@ -1,8 +1,7 @@
 use std::ops::ControlFlow;
 
-use polars_core::prelude::{PlHashMap, PlHashSet};
 use polars_error::PolarsResult;
-use polars_utils::aliases::{InitHashMaps, PlIndexMap};
+use polars_utils::aliases::{InitHashMaps, PlIndexMap, PlIndexSet};
 use polars_utils::arena::{Arena, Node};
 use polars_utils::pl_str::PlSmallStr;
 use polars_utils::unique_id::UniqueId;
@@ -150,9 +149,9 @@ pub(crate) fn set_cache_states(
         parents: Vec<TwoParents>,
         cache_nodes: Vec<Node>,
         // Union over projected names.
-        names_union: PlHashSet<PlSmallStr>,
+        names_union: PlIndexSet<PlSmallStr>,
         // Union over predicates.
-        predicate_union: PlHashMap<Expr, u32>,
+        predicate_union: PlIndexMap<Expr, u32>,
     }
     let mut cache_schema_and_children = PlIndexMap::new();
 

--- a/crates/polars-plan/src/plans/optimizer/cse/csee.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/csee.rs
@@ -1,9 +1,10 @@
 use std::hash::BuildHasher;
 
-use hashbrown::hash_map::RawEntryMut;
+use indexmap::map::RawEntryApiV1;
+use indexmap::map::raw_entry_v1::RawEntryMut;
 use polars_core::CHEAP_SERIES_HASH_LIMIT;
 use polars_core::config::verbose;
-use polars_core::prelude::PlHashMap;
+use polars_core::prelude::PlIndexMap;
 use polars_core::schema::Schema;
 use polars_error::PolarsResult;
 use polars_utils::aliases::PlFixedStateQuality;
@@ -143,13 +144,13 @@ impl Identifier {
 
 #[derive(Default)]
 struct IdentifierMap<V> {
-    inner: PlHashMap<Identifier, V>,
+    inner: PlIndexMap<Identifier, V>,
 }
 
 impl<V> IdentifierMap<V> {
     fn get(&self, id: &Identifier, arena: &Arena<AExpr>) -> Option<&V> {
         self.inner
-            .raw_entry()
+            .raw_entry_v1()
             .from_hash(id.hash(), |k| k.is_equal(id, arena))
             .map(|(_k, v)| v)
     }
@@ -163,12 +164,12 @@ impl<V> IdentifierMap<V> {
         let h = id.hash();
         match self
             .inner
-            .raw_entry_mut()
+            .raw_entry_mut_v1()
             .from_hash(h, |k| k.is_equal(&id, arena))
         {
             RawEntryMut::Occupied(entry) => entry.into_mut(),
             RawEntryMut::Vacant(entry) => {
-                let (_, v) = entry.insert_with_hasher(h, id, v(), |id| id.hash());
+                let (_, v) = entry.insert_hashed_nocheck(h, id, v());
                 v
             },
         }
@@ -187,7 +188,7 @@ impl<V> IdentifierMap<V> {
 /// Does no analysis whether this leads to legal substitutions.
 #[derive(Default)]
 pub struct NaiveExprMerger {
-    node_to_uniq_id: PlHashMap<Node, u32>,
+    node_to_uniq_id: PlIndexMap<Node, u32>,
     uniq_id_to_node: Vec<Node>,
     identifier_to_uniq_id: IdentifierMap<u32>,
     arg_stack: Vec<Option<Identifier>>,
@@ -349,7 +350,7 @@ struct ExprIdentifierVisitor<'a> {
     se_count: &'a mut SubExprCount,
     /// Materialized `CSE` materialized (name) hashes can collide. So we validate that all CSE counts
     /// match name hash counts.
-    name_validation: &'a mut PlHashMap<u64, u32>,
+    name_validation: &'a mut PlIndexMap<u64, u32>,
     identifier_array: &'a mut IdentifierArray,
     // Index in pre-visit traversal order.
     pre_visit_idx: usize,
@@ -372,7 +373,7 @@ impl ExprIdentifierVisitor<'_> {
         identifier_array: &'a mut IdentifierArray,
         visit_stack: &'a mut Vec<VisitRecord>,
         is_group_by: bool,
-        name_validation: &'a mut PlHashMap<u64, u32>,
+        name_validation: &'a mut PlIndexMap<u64, u32>,
         element_wise_select_only: bool,
     ) -> ExprIdentifierVisitor<'a> {
         let id_array_offset = identifier_array.len();
@@ -729,7 +730,7 @@ pub(crate) struct CommonSubExprOptimizer {
     replaced_identifiers: IdentifierMap<()>,
     // these are cleared per expr node
     visit_stack: Vec<VisitRecord>,
-    name_validation: PlHashMap<u64, u32>,
+    name_validation: PlIndexMap<u64, u32>,
     // Set by the streaming engine
     // Only supports element-wise CSEE
     // on SELECT/HSTACK

--- a/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
+++ b/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
@@ -88,12 +88,12 @@ pub(super) fn expand_datasets(
                 let mut row_index_in_live_filter = false;
 
                 let live_filter_columns: Option<Arc<[PlSmallStr]>> = predicate.as_ref().map(|x| {
-                    use polars_core::prelude::PlHashSet;
+                    use polars_core::prelude::PlIndexSet;
 
                     use crate::utils::aexpr_to_leaf_names_iter;
 
                     let mut out: Arc<[PlSmallStr]> =
-                        PlHashSet::from_iter(aexpr_to_leaf_names_iter(x.node(), expr_arena))
+                        PlIndexSet::from_iter(aexpr_to_leaf_names_iter(x.node(), expr_arena))
                             .into_iter()
                             .filter(|&live_col| {
                                 if unified_scan_args

--- a/crates/polars-plan/src/plans/optimizer/flatten_merge_sorted.rs
+++ b/crates/polars-plan/src/plans/optimizer/flatten_merge_sorted.rs
@@ -1,5 +1,5 @@
 use polars_core::error::PolarsResult;
-use polars_core::prelude::PlHashSet;
+use polars_core::prelude::PlIndexSet;
 use polars_utils::aliases::InitHashMaps;
 use polars_utils::arena::{Arena, Node};
 use polars_utils::pl_str::PlSmallStr;
@@ -9,7 +9,7 @@ use crate::prelude::{AExpr, IR};
 
 pub struct FlattenMergeSortedRule {
     collected_inputs: Vec<Node>,
-    optimized_nodes: PlHashSet<Node>,
+    optimized_nodes: PlIndexSet<Node>,
     traversal_stack: Vec<Node>,
 }
 
@@ -17,7 +17,7 @@ impl FlattenMergeSortedRule {
     pub fn new() -> Self {
         Self {
             collected_inputs: Vec::new(),
-            optimized_nodes: PlHashSet::new(),
+            optimized_nodes: PlIndexSet::new(),
             traversal_stack: Vec::new(),
         }
     }
@@ -98,7 +98,7 @@ fn build_merge_sorted_subtree(
     key: &[PlSmallStr],
     maintain_order: bool,
     lp_arena: &mut Arena<IR>,
-    optimized_nodes: &mut PlHashSet<Node>,
+    optimized_nodes: &mut PlIndexSet<Node>,
 ) -> IR {
     debug_assert!(inputs.len() >= 2);
 
@@ -130,7 +130,7 @@ fn build_merge_sorted_subtree_node(
     key: &[PlSmallStr],
     maintain_order: bool,
     lp_arena: &mut Arena<IR>,
-    optimized_nodes: &mut PlHashSet<Node>,
+    optimized_nodes: &mut PlIndexSet<Node>,
 ) -> Node {
     match inputs {
         [node] => *node,

--- a/crates/polars-plan/src/plans/optimizer/ir_traversal/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/ir_traversal/mod.rs
@@ -2,7 +2,7 @@ pub mod storage;
 
 use std::ops::ControlFlow;
 
-use polars_core::prelude::{InitHashMaps as _, PlHashMap};
+use polars_utils::aliases::{InitHashMaps, PlIndexMap};
 use polars_utils::arena::{Arena, Node};
 use polars_utils::unique_id::UniqueId;
 use polars_utils::{UnitVec, unitvec};
@@ -22,8 +22,9 @@ pub fn get_ir_cache_hits<Key>(
     root: Node,
     mut arena: &Arena<IR>,
     visit_stack: &mut Vec<Node>,
-) -> PlHashMap<UniqueId, IRCacheNodeVisit<Key>> {
-    let mut cache_out_edge_keys_map: PlHashMap<UniqueId, IRCacheNodeVisit<Key>> = PlHashMap::new();
+) -> PlIndexMap<UniqueId, IRCacheNodeVisit<Key>> {
+    let mut cache_out_edge_keys_map: PlIndexMap<UniqueId, IRCacheNodeVisit<Key>> =
+        PlIndexMap::new();
 
     TreeTraversalImpl {
         storage: &mut arena,
@@ -35,7 +36,7 @@ pub fn get_ir_cache_hits<Key>(
             || (),
             |key, storage: &mut &Arena<IR>, _| {
                 ControlFlow::Continue(if let IR::Cache { id, .. } = storage.get(key) {
-                    use hashbrown::hash_map::Entry;
+                    use indexmap::map::Entry;
 
                     match cache_out_edge_keys_map.entry(*id) {
                         Entry::Occupied(mut e) => {

--- a/crates/polars-plan/src/plans/optimizer/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/mod.rs
@@ -70,8 +70,8 @@ pub trait Optimize {
 // arbitrary constant to reduce reallocation.
 const HASHMAP_SIZE: usize = 16;
 
-pub(crate) fn init_hashmap<K, V>(max_len: Option<usize>) -> PlHashMap<K, V> {
-    PlHashMap::with_capacity(std::cmp::min(max_len.unwrap_or(HASHMAP_SIZE), HASHMAP_SIZE))
+pub(crate) fn init_hashmap<K, V>(max_len: Option<usize>) -> PlIndexMap<K, V> {
+    PlIndexMap::with_capacity(std::cmp::min(max_len.unwrap_or(HASHMAP_SIZE), HASHMAP_SIZE))
 }
 
 pub(crate) fn init_indexmap<K, V>(max_len: Option<usize>) -> PlIndexMap<K, V> {

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/group_by.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/group_by.rs
@@ -44,7 +44,7 @@ pub(super) fn process_group_by(
     // rewriting the predicate to reference the original column name.
     let mut local_predicates = Vec::with_capacity(acc_predicates.len());
     let input_schema = lp_arena.get(input).schema(lp_arena);
-    let mut alias_rename_map: PlHashMap<PlSmallStr, PlSmallStr> = PlHashMap::new();
+    let mut alias_rename_map: PlIndexMap<PlSmallStr, PlSmallStr> = PlIndexMap::new();
     let mut key_schema = Schema::with_capacity(keys.len());
     for key in &keys {
         if let AExpr::Column(c) = expr_arena.get(key.node()) {

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
@@ -187,7 +187,7 @@ pub(super) fn process_join(
     }
 
     // Key columns of the left table that are coalesced into an output column of the right table.
-    let coalesced_to_right: PlHashSet<PlSmallStr> =
+    let coalesced_to_right: PlIndexSet<PlSmallStr> =
         if matches!(&options.args.how, JoinType::Right) && options.args.should_coalesce() {
             get_lhs_column_keys_iter()
                 .map(|x| x.unwrap().clone())
@@ -196,10 +196,10 @@ pub(super) fn process_join(
             Default::default()
         };
 
-    let mut output_key_to_left_input_map: PlHashMap<PlSmallStr, PlSmallStr> =
-        PlHashMap::with_capacity(get_lhs_column_keys_iter().len());
-    let mut output_key_to_right_input_map: PlHashMap<PlSmallStr, PlSmallStr> =
-        PlHashMap::with_capacity(get_rhs_column_keys_iter().len());
+    let mut output_key_to_left_input_map: PlIndexMap<PlSmallStr, PlSmallStr> =
+        PlIndexMap::with_capacity(get_lhs_column_keys_iter().len());
+    let mut output_key_to_right_input_map: PlIndexMap<PlSmallStr, PlSmallStr> =
+        PlIndexMap::with_capacity(get_rhs_column_keys_iter().len());
 
     for (lhs_input_key, rhs_input_key) in get_lhs_column_keys_iter().zip(get_rhs_column_keys_iter())
     {
@@ -873,11 +873,11 @@ fn try_rewrite_join_type(
         }};
     }
 
-    let mut coalesced_to_right: PlHashSet<PlSmallStr> = Default::default();
+    let mut coalesced_to_right: PlIndexSet<PlSmallStr> = Default::default();
     // Removing NULLs on these columns do not allow for join downgrading.
     // We only need to track these for full-join - e.g. for left-join, removing NULLs from any left
     // column does not cause any join rewrites.
-    let mut coalesced_full_join_key_outputs: PlHashSet<PlSmallStr> = Default::default();
+    let mut coalesced_full_join_key_outputs: PlIndexSet<PlSmallStr> = Default::default();
 
     if options.args.should_coalesce() {
         match &options.args.how {
@@ -970,7 +970,7 @@ fn try_rewrite_join_type(
 
     // Maps the original join output names to the new join output names (used for mapping column
     // references of the predicates).
-    let mut original_to_new_names_map: PlHashMap<PlSmallStr, PlSmallStr> = Default::default();
+    let mut original_to_new_names_map: PlIndexMap<PlSmallStr, PlSmallStr> = Default::default();
     // Projects the new join output table back into the original join output table.
     let mut project_to_original: Option<Vec<ExprIR>> = None;
 
@@ -994,7 +994,7 @@ fn try_rewrite_join_type(
             // original_to_new_names_map: {'a': 'a_right', 'b_right': 'a'}
             //
             (JoinType::Right, JoinType::Inner) => {
-                let mut join_output_key_selectors = PlHashMap::with_capacity(right_on.len());
+                let mut join_output_key_selectors = PlIndexMap::with_capacity(right_on.len());
 
                 for (l, r) in left_on.iter().zip(right_on) {
                     // Unwrap any Cast expressions that may have been inserted for type coercion.
@@ -1118,16 +1118,16 @@ fn try_rewrite_join_type(
             // original_to_new_names_map: {'a': 'b_right', 'a_right': 'a'}
             //
             (JoinType::Full, JoinType::Right) => {
-                let mut join_output_key_selectors = PlHashMap::with_capacity(left_on.len());
+                let mut join_output_key_selectors = PlIndexMap::with_capacity(left_on.len());
 
                 // The existing one is empty because the original join type was not a right-join.
                 assert!(coalesced_to_right.is_empty());
                 // LHS input key columns that are coalesced (i.e. not projected) for the right-join.
-                let coalesced_to_right: PlHashSet<PlSmallStr> =
+                let coalesced_to_right: PlIndexSet<PlSmallStr> =
                     lhs_input_column_keys_iter!().collect();
                 // RHS input key columns that are coalesced (i.e. not projected) for the full-join.
-                let mut coalesced_to_left: PlHashSet<PlSmallStr> =
-                    PlHashSet::with_capacity(right_on.len());
+                let mut coalesced_to_left: PlIndexSet<PlSmallStr> =
+                    PlIndexSet::with_capacity(right_on.len());
 
                 for (l, r) in left_on.iter().zip(right_on) {
                     // Unwrap any Cast expressions that may have been inserted for type coercion.

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -5,7 +5,6 @@ mod keys;
 mod utils;
 
 pub use dynamic::{DynamicPred, DynamicPredWeakRef, PredicateExpr, TrivialPredicateExpr};
-use polars_core::datatypes::{PlHashMap, PlIndexMap};
 use polars_core::prelude::*;
 use polars_utils::idx_vec::UnitVec;
 use polars_utils::scratch_vec::ScratchUnitVec;
@@ -413,7 +412,7 @@ impl PredicatePushDown {
                 } else {
                     &[]
                 };
-                let mut names_set = PlHashSet::<PlSmallStr>::with_capacity(subset.len());
+                let mut names_set = PlIndexSet::<PlSmallStr>::with_capacity(subset.len());
                 for name in subset.iter() {
                     names_set.insert(name.clone());
                 }
@@ -516,7 +515,7 @@ impl PredicatePushDown {
                             columns,
                             separator: _,
                         } => {
-                            let exclude = columns.iter().cloned().collect::<PlHashSet<_>>();
+                            let exclude = columns.iter().cloned().collect::<PlIndexSet<_>>();
 
                             let local_predicates =
                                 transfer_to_local_by_name(expr_arena, &mut acc_predicates, |x| {

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/rename.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/rename.rs
@@ -3,12 +3,12 @@ use polars_utils::pl_str::PlSmallStr;
 use super::*;
 
 pub(super) fn process_rename(
-    acc_predicates: &mut PlHashMap<PlSmallStr, ExprIR>,
+    acc_predicates: &mut PlIndexMap<PlSmallStr, ExprIR>,
     expr_arena: &mut Arena<AExpr>,
     existing: &[PlSmallStr],
     new: &[PlSmallStr],
 ) {
-    let rename_map: PlHashMap<PlSmallStr, PlSmallStr> =
+    let rename_map: PlIndexMap<PlSmallStr, PlSmallStr> =
         new.iter().cloned().zip(existing.iter().cloned()).collect();
 
     if !rename_map.is_empty() {

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
@@ -165,7 +165,7 @@ pub fn pushdown_eligibility(
     scratch: &mut UnitVec<Node>,
     maintain_errors: bool,
     input_ir: &IR,
-) -> PolarsResult<(PushdownEligibility, PlHashMap<PlSmallStr, PlSmallStr>)> {
+) -> PolarsResult<(PushdownEligibility, PlIndexMap<PlSmallStr, PlSmallStr>)> {
     scratch.clear();
     let ae_nodes_stack = scratch;
 
@@ -174,20 +174,20 @@ pub fn pushdown_eligibility(
     let mut col_to_alias_map = alias_to_col_map.clone();
 
     let mut modified_projection_columns =
-        PlHashSet::<PlSmallStr>::with_capacity(projection_nodes.len());
+        PlIndexSet::<PlSmallStr>::with_capacity(projection_nodes.len());
     let mut has_window = false;
-    let mut common_window_inputs = PlHashSet::<PlSmallStr>::new();
+    let mut common_window_inputs = PlIndexSet::<PlSmallStr>::new();
 
     // Important: Names inserted into any data structure by this function are
     // all non-aliased.
     // This function returns false if pushdown cannot be performed.
     let process_projection_or_predicate = |ae_nodes_stack: &mut UnitVec<Node>,
                                            has_window: &mut bool,
-                                           common_window_inputs: &mut PlHashSet<PlSmallStr>|
+                                           common_window_inputs: &mut PlIndexSet<PlSmallStr>|
      -> ExprPushdownGroup {
         debug_assert_eq!(ae_nodes_stack.len(), 1);
 
-        let mut partition_by_names = PlHashSet::<PlSmallStr>::new();
+        let mut partition_by_names = PlIndexSet::<PlSmallStr>::new();
         let mut expr_pushdown_eligibility = ExprPushdownGroup::Pushable;
 
         while let Some(node) = ae_nodes_stack.pop() {
@@ -221,7 +221,7 @@ pub fn pushdown_eligibility(
                     }
 
                     if !*has_window {
-                        for name in partition_by_names.drain() {
+                        for name in partition_by_names.drain(..) {
                             common_window_inputs.insert(name);
                         }
 
@@ -282,7 +282,7 @@ pub fn pushdown_eligibility(
 
     if has_window && !col_to_alias_map.is_empty() {
         // Rename to aliased names.
-        let mut new = PlHashSet::<PlSmallStr>::with_capacity(2 * common_window_inputs.len());
+        let mut new = PlIndexSet::<PlSmallStr>::with_capacity(2 * common_window_inputs.len());
 
         for key in common_window_inputs.into_iter() {
             if let Some(aliased) = col_to_alias_map.get(&key) {
@@ -455,7 +455,7 @@ pub(crate) fn ir_removes_rows(ir: &IR) -> bool {
 pub(super) fn map_column_references(
     expr: &mut ExprIR,
     expr_arena: &mut Arena<AExpr>,
-    rename_map: &PlHashMap<PlSmallStr, PlSmallStr>,
+    rename_map: &PlIndexMap<PlSmallStr, PlSmallStr>,
 ) {
     if rename_map.is_empty() {
         return;
@@ -465,7 +465,7 @@ pub(super) fn map_column_references(
         .rewrite(
             &mut MapColumnReferences {
                 rename_map,
-                column_nodes: PlHashMap::with_capacity(rename_map.len()),
+                column_nodes: PlIndexMap::with_capacity(rename_map.len()),
             },
             expr_arena,
         )
@@ -475,8 +475,8 @@ pub(super) fn map_column_references(
     *expr = ExprIR::from_node(node, expr_arena);
 
     struct MapColumnReferences<'a> {
-        rename_map: &'a PlHashMap<PlSmallStr, PlSmallStr>,
-        column_nodes: PlHashMap<&'a str, Node>,
+        rename_map: &'a PlIndexMap<PlSmallStr, PlSmallStr>,
+        column_nodes: PlIndexMap<&'a str, Node>,
     }
 
     impl RewritingVisitor for MapColumnReferences<'_> {

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -5,10 +5,12 @@ use std::sync::Arc;
 
 use edge::Edge;
 use polars_core::frame::DataFrame;
-use polars_core::prelude::{Column, DataType, PlHashMap, ScratchIndexMap, ScratchIndexSet};
+use polars_core::prelude::{Column, DataType, ScratchIndexMap, ScratchIndexSet};
 use polars_core::schema::Schema;
 use polars_io::RowIndex;
 use polars_ops::frame::{JoinCoalesce, JoinType};
+#[allow(clippy::disallowed_types)]
+use polars_utils::aliases::PlHashMap;
 use polars_utils::arena::{Arena, Node};
 use polars_utils::format_pl_smallstr;
 use polars_utils::itertools::Itertools as _;
@@ -33,7 +35,7 @@ use crate::traversal::visitor::{NodeVisitor, SubtreeVisit};
 use crate::utils::{aexpr_to_leaf_names_iter, rename_columns};
 
 pub fn projection_pushdown(root: Node, ir_arena: &mut Arena<IR>, expr_arena: &mut Arena<AExpr>) {
-    let schema_cache = &mut PlHashMap::default();
+    let schema_cache = &mut Default::default();
 
     // Put a simple projection on top so that the root node has a valid ParentKeyAndPort to point to.
     let root_ir = ir_arena.take(root);
@@ -86,6 +88,7 @@ pub fn projection_pushdown(root: Node, ir_arena: &mut Arena<IR>, expr_arena: &mu
 
 pub struct ProjectionPushdownVisitor<'a, 'arena> {
     expr_arena: &'arena mut Arena<AExpr>,
+    #[allow(clippy::disallowed_types)] // We don't iterate over cache.
     schema_cache: &'a mut PlHashMap<Node, Arc<Schema>>,
     ae_nodes_scratch: &'a mut ScratchVec<Node>,
     ae_height_scratch: &'a mut ScratchVec<ExprProjectionHeight>,
@@ -277,6 +280,7 @@ impl ProjectionPushdownVisitor<'_, '_> {
             }};
         }
 
+        #[allow(clippy::disallowed_types)] // We don't iterate over cache.
         fn pushdown_with_added_names(
             key: Node,
             edges: &mut dyn NodeEdgesProvider<<ProjectionPushdownVisitor as NodeVisitor>::Edge>,

--- a/crates/polars-plan/src/plans/optimizer/simplify_ordering/expr.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_ordering/expr.rs
@@ -1,5 +1,5 @@
 use bitflags::bitflags;
-use polars_core::prelude::PlHashMap;
+use polars_core::prelude::PlIndexMap;
 use polars_utils::arena::{Arena, Node};
 
 use crate::dsl::EvalVariant;
@@ -91,7 +91,7 @@ pub(crate) struct ExprOrderSimplifier<'a> {
 
     /// Entries for nodes whose subtrees will no longer change when revisited with a de-ordering
     /// recursion state.
-    revisit_cache: &'a mut PlHashMap<Node, ObservableOrders>,
+    revisit_cache: &'a mut PlIndexMap<Node, ObservableOrders>,
     internally_observed: ObservableOrders,
 
     expr_arena: &'a mut Arena<AExpr>,
@@ -100,7 +100,7 @@ pub(crate) struct ExprOrderSimplifier<'a> {
 impl<'a> ExprOrderSimplifier<'a> {
     pub fn new(
         expr_arena: &'a mut Arena<AExpr>,
-        revisit_cache: &'a mut PlHashMap<Node, ObservableOrders>,
+        revisit_cache: &'a mut PlIndexMap<Node, ObservableOrders>,
     ) -> Self {
         Self {
             struct_field_ordering: None,

--- a/crates/polars-plan/src/plans/optimizer/simplify_ordering/ir_graph.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_ordering/ir_graph.rs
@@ -1,4 +1,4 @@
-use polars_core::prelude::{InitHashMaps, PlHashMap};
+use polars_core::prelude::{InitHashMaps, PlIndexMap};
 use polars_utils::UnitVec;
 use polars_utils::arena::{Arena, Node};
 use polars_utils::array::{array_concat, array_split};
@@ -23,7 +23,7 @@ struct CacheNodes {
 
 #[derive(Default)]
 pub(crate) struct CacheNodeUpdater {
-    inner: PlHashMap<UniqueId, CacheNodes>,
+    inner: PlIndexMap<UniqueId, CacheNodes>,
 }
 
 impl CacheNodeUpdater {
@@ -51,16 +51,16 @@ pub(crate) fn build_ir_traversal_graph<EdgeKey, Edge>(
     roots: &[Node],
     ir_arena: &mut Arena<IR>,
 ) -> (
-    Vec<Node>,                                     // Nodes in sink->source traversal order
-    PlHashMap<IRNodeKey, IRNodeEdgeKeys<EdgeKey>>, // Edge keys for each node
-    SlotMap<EdgeKey, Edge>,                        // Edges slotmap
-    CacheNodeUpdater,                              // All arena nodes that use this cache ID.
+    Vec<Node>,                                      // Nodes in sink->source traversal order
+    PlIndexMap<IRNodeKey, IRNodeEdgeKeys<EdgeKey>>, // Edge keys for each node
+    SlotMap<EdgeKey, Edge>,                         // Edges slotmap
+    CacheNodeUpdater,                               // All arena nodes that use this cache ID.
 )
 where
     EdgeKey: slotmap::Key,
     Edge: Default,
 {
-    let mut cache_track: PlHashMap<UniqueId, CacheNodes> = PlHashMap::new();
+    let mut cache_track: PlIndexMap<UniqueId, CacheNodes> = PlIndexMap::new();
     let mut num_nodes: usize = 0;
 
     let mut ir_nodes_stack = Vec::with_capacity(roots.len() + 8);
@@ -70,7 +70,7 @@ where
         let ir = ir_arena.get(ir_node);
 
         if let IR::Cache { id, .. } = ir {
-            use hashbrown::hash_map::Entry;
+            use indexmap::map::Entry;
 
             match cache_track.entry(*id) {
                 Entry::Occupied(mut v) => {
@@ -95,8 +95,8 @@ where
     num_nodes += cache_track.len();
 
     let mut all_edges_map: SlotMap<EdgeKey, Edge> = SlotMap::with_capacity_and_key(num_nodes);
-    let mut ir_node_to_edges_map: PlHashMap<IRNodeKey, IRNodeEdgeKeys<EdgeKey>> =
-        PlHashMap::with_capacity(num_nodes);
+    let mut ir_node_to_edges_map: PlIndexMap<IRNodeKey, IRNodeEdgeKeys<EdgeKey>> =
+        PlIndexMap::with_capacity(num_nodes);
 
     ir_nodes_stack.reserve_exact(num_nodes);
     ir_nodes_stack.extend_from_slice(roots);
@@ -134,22 +134,18 @@ where
         for i in 0..num_inputs {
             let input_node = ir_nodes_stack[i + inputs_start_idx];
             let input_node_key = IRNodeKey::new(input_node, ir_arena);
-            let _ = ir_node_to_edges_map.try_insert(input_node_key, IRNodeEdgeKeys::default());
             let IRNodeEdgeKeys {
                 out_edges: input_node_out_edges,
                 out_nodes: input_node_out_nodes,
                 ..
-            } = ir_node_to_edges_map.get_mut(&input_node_key).unwrap();
+            } = ir_node_to_edges_map.entry(input_node_key).or_default();
 
             input_node_out_edges.push(current_node_in_edges[i]);
             input_node_out_nodes.push(current_node);
         }
 
         let current_node_key = IRNodeKey::new(current_node, ir_arena);
-
-        let _ = ir_node_to_edges_map.try_insert(current_node_key, IRNodeEdgeKeys::default());
-        let current_edges = ir_node_to_edges_map.get_mut(&current_node_key).unwrap();
-
+        let current_edges = ir_node_to_edges_map.entry(current_node_key).or_default();
         assert!(current_edges.in_edges.is_empty());
         current_edges.in_edges = current_node_in_edges;
     }

--- a/crates/polars-plan/src/plans/optimizer/simplify_ordering/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_ordering/mod.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use ir_graph::{IRNodeEdgeKeys, build_ir_traversal_graph, unpack_edges_mut};
 use polars_core::frame::UniqueKeepStrategy;
-use polars_core::prelude::PlHashMap;
+use polars_core::prelude::PlIndexMap;
 use polars_utils::arena::{Arena, Node};
 use polars_utils::scratch_vec::ScratchVec;
 use slotmap::{SlotMap, new_key_type};
@@ -41,13 +41,13 @@ pub fn simplify_and_fetch_orderings(
     ir_arena: &mut Arena<IR>,
     expr_arena: &mut Arena<AExpr>,
 ) -> (
-    PlHashMap<IRNodeKey, IRNodeEdgeKeys<EdgeKey>>,
+    PlIndexMap<IRNodeKey, IRNodeEdgeKeys<EdgeKey>>,
     SlotMap<EdgeKey, Edge>,
 ) {
     let (mut ir_nodes_stack, mut ir_node_to_edges_map, mut all_edges_map, cache_updater) =
         build_ir_traversal_graph(roots, ir_arena);
 
-    let eos_revisit_cache = &mut PlHashMap::default();
+    let eos_revisit_cache = &mut PlIndexMap::default();
     let ae_nodes_scratch = &mut ScratchVec::default();
     let mut deleted_idxs = vec![];
 
@@ -81,11 +81,11 @@ pub fn simplify_and_fetch_orderings(
 }
 
 struct SimplifyIRNodeOrder<'a> {
-    ir_node_to_edges_map: &'a mut PlHashMap<IRNodeKey, IRNodeEdgeKeys<EdgeKey>>,
+    ir_node_to_edges_map: &'a mut PlIndexMap<IRNodeKey, IRNodeEdgeKeys<EdgeKey>>,
     all_edges_map: &'a mut EdgesMap,
     ir_arena: &'a mut Arena<IR>,
     expr_arena: &'a mut Arena<AExpr>,
-    eos_revisit_cache: &'a mut PlHashMap<Node, ObservableOrders>,
+    eos_revisit_cache: &'a mut PlIndexMap<Node, ObservableOrders>,
     ae_nodes_scratch: &'a mut ScratchVec<Node>,
 }
 

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_expr.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_expr.rs
@@ -251,7 +251,7 @@ impl SlicePushDown {
         expr_arena: &mut Arena<AExpr>,
         common_col_limit: &mut Option<CommonSlice>,
         col_hit_count: &mut Option<usize>,
-        all_slice_ae_nodes_with_direct_col_input: &mut PlHashSet<Node>,
+        all_slice_ae_nodes_with_direct_col_input: &mut PlIndexSet<Node>,
         maintain_errors: bool,
     ) {
         let mut visitor = FnVisitors::new(
@@ -290,7 +290,7 @@ fn aexpr_slice_pushdown_top(
     expr_arena: &mut Arena<AExpr>,
     common_col_limit: &mut Option<CommonSlice>,
     col_hit_count: &mut Option<usize>,
-    all_slice_ae_nodes_with_direct_col_input: &mut PlHashSet<Node>,
+    all_slice_ae_nodes_with_direct_col_input: &mut PlIndexSet<Node>,
     maintain_errors: bool,
 ) -> State {
     use ExprProjectionHeight as H;

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -14,8 +14,8 @@ pub(super) struct SlicePushDown {
     pub(super) slice_node_in_optimized_plan: bool,
     pub(super) ae_nodes_scratch: ScratchVec<Node>,
     pub(super) ae_slice_pd_state_scratch: ScratchVec<slice_pushdown_expr::State>,
-    pub(super) ae_slice_pd_direct_col_slice_nodes: ScratchHashSet<Node>,
-    optimized_cache_inputs: PlHashMap<UniqueId, Node>,
+    pub(super) ae_slice_pd_direct_col_slice_nodes: ScratchIndexSet<Node>,
+    optimized_cache_inputs: PlIndexMap<UniqueId, Node>,
 }
 
 impl SlicePushDown {
@@ -30,8 +30,8 @@ impl SlicePushDown {
             slice_node_in_optimized_plan: false,
             ae_nodes_scratch: ScratchVec::default(),
             ae_slice_pd_state_scratch: ScratchVec::default(),
-            ae_slice_pd_direct_col_slice_nodes: ScratchHashSet::default(),
-            optimized_cache_inputs: PlHashMap::default(),
+            ae_slice_pd_direct_col_slice_nodes: ScratchIndexSet::default(),
+            optimized_cache_inputs: PlIndexMap::default(),
         }
     }
 }
@@ -298,7 +298,7 @@ impl SlicePushDown {
 
             *input = new_input_node;
 
-            for node in ae_slice_pd_direct_col_slice_nodes.drain() {
+            for node in ae_slice_pd_direct_col_slice_nodes.drain(..) {
                 use slice_pushdown_expr::Slice;
                 let AExpr::Slice {
                     input: input_node,

--- a/crates/polars-plan/src/plans/optimizer/sortedness.rs
+++ b/crates/polars-plan/src/plans/optimizer/sortedness.rs
@@ -20,14 +20,14 @@ use crate::plans::{
 
 /// Container for sortedness state at each stage in an IR plan.
 #[derive(Debug)]
-pub struct IRPlanSorted(PlHashMap<Node, IRSorted>);
+pub struct IRPlanSorted(PlIndexMap<Node, IRSorted>);
 
 impl IRPlanSorted {
     pub fn resolve(root: Node, ir_arena: &Arena<IR>, expr_arena: &Arena<AExpr>) -> Self {
-        let mut seen = PlHashSet::default();
-        let mut sortedness = PlHashMap::default();
-        let mut cache_proxy = PlHashMap::default();
-        let mut names_set_scratch = ScratchHashSet::default();
+        let mut seen = PlIndexSet::default();
+        let mut sortedness = PlIndexMap::default();
+        let mut cache_proxy = PlIndexMap::default();
+        let mut names_set_scratch = ScratchIndexSet::default();
         is_sorted_rec(
             root,
             ir_arena,
@@ -168,10 +168,10 @@ pub fn expr_is_sorted(
 }
 
 pub fn is_sorted(root: Node, ir_arena: &Arena<IR>, expr_arena: &Arena<AExpr>) -> Option<IRSorted> {
-    let mut seen = PlHashSet::default();
-    let mut sortedness = PlHashMap::default();
-    let mut cache_proxy = PlHashMap::default();
-    let mut names_set_scratch = ScratchHashSet::default();
+    let mut seen = PlIndexSet::default();
+    let mut sortedness = PlIndexMap::default();
+    let mut cache_proxy = PlIndexMap::default();
+    let mut names_set_scratch = ScratchIndexSet::default();
 
     is_sorted_rec(
         root,
@@ -191,10 +191,10 @@ fn is_sorted_rec(
     root: Node,
     ir_arena: &Arena<IR>,
     expr_arena: &Arena<AExpr>,
-    seen: &mut PlHashSet<Node>,
-    sortedness: &mut PlHashMap<Node, IRSorted>,
-    cache_proxy: &mut PlHashMap<UniqueId, Option<IRSorted>>,
-    names_set_scratch: &mut ScratchHashSet<PlSmallStr>,
+    seen: &mut PlIndexSet<Node>,
+    sortedness: &mut PlIndexMap<Node, IRSorted>,
+    cache_proxy: &mut PlIndexMap<UniqueId, Option<IRSorted>>,
+    names_set_scratch: &mut ScratchIndexSet<PlSmallStr>,
     create_full_map: bool,
 ) -> Option<IRSorted> {
     if let Some(s) = sortedness.get(&root) {

--- a/crates/polars-plan/src/plans/prune.rs
+++ b/crates/polars-plan/src/plans/prune.rs
@@ -1,6 +1,6 @@
 //! IR pruning. Pruning copies the reachable IR and expressions into a set of destination arenas.
 
-use polars_core::prelude::{InitHashMaps as _, PlHashMap};
+use polars_core::prelude::{InitHashMaps as _, PlIndexMap};
 use polars_utils::arena::{Arena, Node};
 use polars_utils::unique_id::UniqueId;
 use recursive::recursive;
@@ -50,8 +50,8 @@ pub fn prune(
         src_expr,
         dst_ir,
         dst_expr,
-        dst_caches: PlHashMap::new(),
-        roots: PlHashMap::from_iter(roots.iter().map(|node| (*node, None))),
+        dst_caches: PlIndexMap::new(),
+        roots: PlIndexMap::from_iter(roots.iter().map(|node| (*node, None))),
     };
 
     let dst_roots: Vec<Node> = roots.iter().map(|&root| ctx.copy_ir(root)).collect();
@@ -67,10 +67,10 @@ struct CopyContext<'a> {
     dst_ir: &'a mut Arena<IR>,
     dst_expr: &'a mut Arena<AExpr>,
     // Caches and the matching dst nodes.
-    dst_caches: PlHashMap<UniqueId, Node>,
+    dst_caches: PlIndexMap<UniqueId, Node>,
     // Root nodes and the matching dst nodes. Needed to ensure they are visited only once,
     // in case they are reachable from other root nodes.
-    roots: PlHashMap<Node, Option<Node>>,
+    roots: PlIndexMap<Node, Option<Node>>,
 }
 
 impl<'a> CopyContext<'a> {

--- a/crates/polars-plan/src/plans/schema.rs
+++ b/crates/polars-plan/src/plans/schema.rs
@@ -130,13 +130,13 @@ pub(crate) fn det_join_schema(
         // df(cols=[B, A, B_right])
         JoinType::Right if options.args.should_coalesce() => {
             // Get join names.
-            let mut join_on_left: PlHashSet<_> = PlHashSet::with_capacity(left_on.len());
+            let mut join_on_left: PlIndexSet<_> = PlIndexSet::with_capacity(left_on.len());
             for e in left_on {
                 let field = e.field(schema_left, expr_arena)?;
                 join_on_left.insert(field.name);
             }
 
-            let mut join_on_right: PlHashSet<_> = PlHashSet::with_capacity(right_on.len());
+            let mut join_on_right: PlIndexSet<_> = PlIndexSet::with_capacity(right_on.len());
             for e in right_on {
                 let field = e.field(schema_right, expr_arena)?;
                 join_on_right.insert(field.name);
@@ -190,7 +190,7 @@ pub(crate) fn det_join_schema(
                 join_on_right.insert(field.name);
             }
 
-            let mut right_by: PlHashSet<&PlSmallStr> = PlHashSet::default();
+            let mut right_by: PlIndexSet<&PlSmallStr> = PlIndexSet::default();
             #[cfg(feature = "asof_join")]
             if let JoinType::AsOf(asof_options) = &options.args.how {
                 if let Some(v) = &asof_options.right_by {


### PR DESCRIPTION
We've ran into several non-determinism bugs due to hashmap/set iteration order, for the moment let's forbid them entirely in `polars-plan`, in favor of the deterministic `IndexMap`/`IndexSet`.
