### PR TITLE
feat(python): Remove hard block on native scan for Iceberg V3 tables

### DIFF
--- a/py-polars/src/polars/io/iceberg/_dataset.py
+++ b/py-polars/src/polars/io/iceberg/_dataset.py
@@ -357,8 +357,6 @@ class IcebergScanResolver:
         fallback_reason = (
             "forced reader_override='pyiceberg'"
             if reader_override == "pyiceberg"
-            else f"unsupported table format version: {tbl.format_version}"
-            if not tbl.format_version <= 2
             else None
         )
 
@@ -369,6 +367,12 @@ class IcebergScanResolver:
             if selected_fields == ("*",)
             else iceberg_schema.select(*selected_fields)
         )
+
+        if fallback_reason is None and any(
+            projected_iceberg_schema.find_field(x).initial_default is not None
+            for x in projected_iceberg_schema.field_ids
+        ):
+            fallback_reason = "unsupported field 'initial-default'"
 
         sources = []
         missing_field_defaults = IdentityTransformedPartitionValuesBuilder(


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/28088

We instead fallback to python only if there are unsupported V3 features being used in the table. E.g. possible fallback logs under `POLARS_VERBOSE=1`:
* Use of V3 deletion files: `IcebergScanResolver: to_dataset_scan(): fallback to python[pyiceberg] scan: unsupported deletion file format: FileFormat.PUFFIN`
* Use of V3 field 'initial-default': `IcebergScanResolver: to_dataset_scan(): fallback to python[pyiceberg] scan: unsupported field 'initial-default'`
