### PR TITLE
feat(python): Expose ewm and rolling *_by expressions in Python visitor

### DIFF
--- a/crates/polars-python/src/c_api/mod.rs
+++ b/crates/polars-python/src/c_api/mod.rs
@@ -98,6 +98,7 @@ fn _expr_nodes(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<PyTemporalFunction>().unwrap();
     m.add_class::<PyStructFunction>().unwrap();
     m.add_class::<PyRollingFunction>().unwrap();
+    m.add_class::<PyEwmFunction>().unwrap();
     // Options
     m.add_class::<PyWindowMapping>().unwrap();
     m.add_class::<PyRollingGroupOptions>().unwrap();

--- a/crates/polars-python/src/c_api/mod.rs
+++ b/crates/polars-python/src/c_api/mod.rs
@@ -98,6 +98,7 @@ fn _expr_nodes(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<PyTemporalFunction>().unwrap();
     m.add_class::<PyStructFunction>().unwrap();
     m.add_class::<PyRollingFunction>().unwrap();
+    m.add_class::<PyRollingFunctionBy>().unwrap();
     m.add_class::<PyEwmFunction>().unwrap();
     // Options
     m.add_class::<PyWindowMapping>().unwrap();

--- a/crates/polars-python/src/lazyframe/visit.rs
+++ b/crates/polars-python/src/lazyframe/visit.rs
@@ -58,7 +58,7 @@ impl NodeTraverser {
     // Increment major on breaking changes to the IR (e.g. renaming
     // fields, reordering tuples), minor on backwards compatible
     // changes (e.g. exposing a new expression node).
-    const VERSION: Version = (14, 3);
+    const VERSION: Version = (14, 4);
 
     pub fn new(root: Node, lp_arena: Arena<IR>, expr_arena: Arena<AExpr>) -> Self {
         Self {

--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -645,6 +645,27 @@ impl PyGroupbyOptions {
     }
 }
 
+// Serialize the optional per-op rolling parameters into the flat tuple consumed by
+// external engines (e.g., cudf-polars).
+fn rolling_fn_params_into_py(
+    py: Python<'_>,
+    fn_params: &Option<RollingFnParams>,
+) -> PyResult<Py<PyAny>> {
+    match fn_params {
+        None => ().into_py_any(py),
+        Some(RollingFnParams::Quantile(q)) => {
+            (q.prob, Into::<&str>::into(q.method)).into_py_any(py)
+        },
+        Some(RollingFnParams::Var(v)) => (v.ddof,).into_py_any(py),
+        Some(RollingFnParams::Rank { method, seed }) => {
+            let method = Into::<&str>::into(method);
+            (method, *seed).into_py_any(py)
+        },
+        Some(RollingFnParams::Skew { bias }) => (*bias,).into_py_any(py),
+        Some(RollingFnParams::Kurtosis { fisher, bias }) => (*fisher, *bias).into_py_any(py),
+    }
+}
+
 pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<Py<PyAny>> {
     match expr {
         AExpr::Element => Err(PyNotImplementedError::new_err("element")),
@@ -1304,21 +1325,7 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<Py<PyAny>> {
                             return Err(PyNotImplementedError::new_err("rolling map"));
                         },
                     };
-                    let fn_params: Py<PyAny> = match &options.fn_params {
-                        None => ().into_py_any(py)?,
-                        Some(RollingFnParams::Quantile(q)) => {
-                            (q.prob, Into::<&str>::into(q.method)).into_py_any(py)?
-                        },
-                        Some(RollingFnParams::Var(v)) => (v.ddof,).into_py_any(py)?,
-                        Some(RollingFnParams::Rank { method, seed }) => {
-                            let method = Into::<&str>::into(method);
-                            (method, *seed).into_py_any(py)?
-                        },
-                        Some(RollingFnParams::Skew { bias }) => (*bias,).into_py_any(py)?,
-                        Some(RollingFnParams::Kurtosis { fisher, bias }) => {
-                            (*fisher, *bias).into_py_any(py)?
-                        },
-                    };
+                    let fn_params = rolling_fn_params_into_py(py, &options.fn_params)?;
                     // Tuple consumed by external engines (e.g., cudf-polars):
                     // (RollingFunction, window_size, min_periods, weights, center, fn_params)
                     (
@@ -1345,21 +1352,7 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<Py<PyAny>> {
                         IRRollingFunctionBy::StdBy => PyRollingFunctionBy::StdBy,
                         IRRollingFunctionBy::RankBy => PyRollingFunctionBy::RankBy,
                     };
-                    let fn_params: Py<PyAny> = match &options.fn_params {
-                        None => ().into_py_any(py)?,
-                        Some(RollingFnParams::Quantile(q)) => {
-                            (q.prob, Into::<&str>::into(q.method)).into_py_any(py)?
-                        },
-                        Some(RollingFnParams::Var(v)) => (v.ddof,).into_py_any(py)?,
-                        Some(RollingFnParams::Rank { method, seed }) => {
-                            let method = Into::<&str>::into(method);
-                            (method, *seed).into_py_any(py)?
-                        },
-                        Some(RollingFnParams::Skew { bias }) => (*bias,).into_py_any(py)?,
-                        Some(RollingFnParams::Kurtosis { fisher, bias }) => {
-                            (*fisher, *bias).into_py_any(py)?
-                        },
-                    };
+                    let fn_params = rolling_fn_params_into_py(py, &options.fn_params)?;
                     // Tuple consumed by external engines (e.g., cudf-polars):
                     // (RollingFunctionBy, window_size, min_periods, closed_window, fn_params)
                     (

--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -317,6 +317,22 @@ impl PyRollingFunction {
     }
 }
 
+#[pyclass(name = "EwmFunction", eq, frozen, skip_from_py_object)]
+#[derive(Copy, Clone, PartialEq)]
+pub enum PyEwmFunction {
+    Mean,
+    Std,
+    Var,
+    MeanBy,
+}
+
+#[pymethods]
+impl PyEwmFunction {
+    fn __hash__(&self) -> isize {
+        *self as isize
+    }
+}
+
 #[pyclass(frozen)]
 pub struct BinaryExpr {
     #[pyo3(get)]
@@ -1485,15 +1501,35 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<Py<PyAny>> {
                     ("mean_horizontal", ignore_nulls).into_py_any(py)
                 },
                 IRFunctionExpr::MinHorizontal => ("min_horizontal",).into_py_any(py),
-                IRFunctionExpr::EwmMean { options: _ } => {
-                    return Err(PyNotImplementedError::new_err("ewm mean"));
-                },
-                IRFunctionExpr::EwmStd { options: _ } => {
-                    return Err(PyNotImplementedError::new_err("ewm std"));
-                },
-                IRFunctionExpr::EwmVar { options: _ } => {
-                    return Err(PyNotImplementedError::new_err("ewm var"));
-                },
+                // Tuples consumed by external engines (e.g., cudf-polars):
+                // (EwmFunction, alpha, adjust, bias, min_periods, ignore_nulls)
+                IRFunctionExpr::EwmMean { options } => (
+                    PyEwmFunction::Mean,
+                    options.alpha,
+                    options.adjust,
+                    options.bias,
+                    options.min_periods,
+                    options.ignore_nulls,
+                )
+                    .into_py_any(py),
+                IRFunctionExpr::EwmStd { options } => (
+                    PyEwmFunction::Std,
+                    options.alpha,
+                    options.adjust,
+                    options.bias,
+                    options.min_periods,
+                    options.ignore_nulls,
+                )
+                    .into_py_any(py),
+                IRFunctionExpr::EwmVar { options } => (
+                    PyEwmFunction::Var,
+                    options.alpha,
+                    options.adjust,
+                    options.bias,
+                    options.min_periods,
+                    options.ignore_nulls,
+                )
+                    .into_py_any(py),
                 IRFunctionExpr::Replace => ("replace",).into_py_any(py),
                 IRFunctionExpr::ReplaceStrict { return_dtype: _ } => {
                     // Can ignore the return dtype because it is encoded in the schema.
@@ -1535,8 +1571,8 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<Py<PyAny>> {
                 },
                 #[cfg(feature = "top_k")]
                 IRFunctionExpr::TopKBy { descending } => ("top_k_by", descending).into_py_any(py),
-                IRFunctionExpr::EwmMeanBy { half_life: _ } => {
-                    return Err(PyNotImplementedError::new_err("ewm_mean_by"));
+                IRFunctionExpr::EwmMeanBy { half_life } => {
+                    (PyEwmFunction::MeanBy, Wrap(*half_life)).into_py_any(py)
                 },
                 IRFunctionExpr::RowEncode(..) => {
                     return Err(PyNotImplementedError::new_err("row_encode"));

--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -333,6 +333,26 @@ impl PyEwmFunction {
     }
 }
 
+#[pyclass(name = "RollingFunctionBy", eq, frozen, skip_from_py_object)]
+#[derive(Copy, Clone, PartialEq)]
+pub enum PyRollingFunctionBy {
+    MinBy,
+    MaxBy,
+    MeanBy,
+    SumBy,
+    QuantileBy,
+    VarBy,
+    StdBy,
+    RankBy,
+}
+
+#[pymethods]
+impl PyRollingFunctionBy {
+    fn __hash__(&self) -> isize {
+        *self as isize
+    }
+}
+
 #[pyclass(frozen)]
 pub struct BinaryExpr {
     #[pyo3(get)]
@@ -1311,31 +1331,45 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<Py<PyAny>> {
                     )
                         .into_py_any(py)
                 },
-                IRFunctionExpr::RollingExprBy { function_by, .. } => match function_by {
-                    IRRollingFunctionBy::MinBy => {
-                        return Err(PyNotImplementedError::new_err("rolling min by"));
-                    },
-                    IRRollingFunctionBy::MaxBy => {
-                        return Err(PyNotImplementedError::new_err("rolling max by"));
-                    },
-                    IRRollingFunctionBy::MeanBy => {
-                        return Err(PyNotImplementedError::new_err("rolling mean by"));
-                    },
-                    IRRollingFunctionBy::SumBy => {
-                        return Err(PyNotImplementedError::new_err("rolling sum by"));
-                    },
-                    IRRollingFunctionBy::QuantileBy => {
-                        return Err(PyNotImplementedError::new_err("rolling quantile by"));
-                    },
-                    IRRollingFunctionBy::VarBy => {
-                        return Err(PyNotImplementedError::new_err("rolling var by"));
-                    },
-                    IRRollingFunctionBy::StdBy => {
-                        return Err(PyNotImplementedError::new_err("rolling std by"));
-                    },
-                    IRRollingFunctionBy::RankBy => {
-                        return Err(PyNotImplementedError::new_err("rolling rank by"));
-                    },
+                IRFunctionExpr::RollingExprBy {
+                    function_by,
+                    options,
+                } => {
+                    let py_function = match function_by {
+                        IRRollingFunctionBy::MinBy => PyRollingFunctionBy::MinBy,
+                        IRRollingFunctionBy::MaxBy => PyRollingFunctionBy::MaxBy,
+                        IRRollingFunctionBy::MeanBy => PyRollingFunctionBy::MeanBy,
+                        IRRollingFunctionBy::SumBy => PyRollingFunctionBy::SumBy,
+                        IRRollingFunctionBy::QuantileBy => PyRollingFunctionBy::QuantileBy,
+                        IRRollingFunctionBy::VarBy => PyRollingFunctionBy::VarBy,
+                        IRRollingFunctionBy::StdBy => PyRollingFunctionBy::StdBy,
+                        IRRollingFunctionBy::RankBy => PyRollingFunctionBy::RankBy,
+                    };
+                    let fn_params: Py<PyAny> = match &options.fn_params {
+                        None => ().into_py_any(py)?,
+                        Some(RollingFnParams::Quantile(q)) => {
+                            (q.prob, Into::<&str>::into(q.method)).into_py_any(py)?
+                        },
+                        Some(RollingFnParams::Var(v)) => (v.ddof,).into_py_any(py)?,
+                        Some(RollingFnParams::Rank { method, seed }) => {
+                            let method = Into::<&str>::into(method);
+                            (method, *seed).into_py_any(py)?
+                        },
+                        Some(RollingFnParams::Skew { bias }) => (*bias,).into_py_any(py)?,
+                        Some(RollingFnParams::Kurtosis { fisher, bias }) => {
+                            (*fisher, *bias).into_py_any(py)?
+                        },
+                    };
+                    // Tuple consumed by external engines (e.g., cudf-polars):
+                    // (RollingFunctionBy, window_size, min_periods, closed_window, fn_params)
+                    (
+                        py_function,
+                        Wrap(options.window_size),
+                        options.min_periods,
+                        Wrap(options.closed_window),
+                        fn_params,
+                    )
+                        .into_py_any(py)
                 },
                 IRFunctionExpr::Rechunk => ("rechunk",).into_py_any(py),
                 IRFunctionExpr::ShiftAndFill => ("shift_and_fill",).into_py_any(py),

--- a/py-polars/tests/unit/lazyframe/cuda/test_node_visitor.py
+++ b/py-polars/tests/unit/lazyframe/cuda/test_node_visitor.py
@@ -305,22 +305,19 @@ def test_rolling_expr_visitor_rank() -> None:
     assert fn_params == ("dense", 42)
 
 
-def _collect_ewm_functions(query: pl.LazyFrame) -> list[tuple[Any, list[Any]]]:
-    """Traverse a query's IR; return (Function, resolved input nodes) for ewm exprs."""
-    results: list[tuple[Any, list[Any]]] = []
+def _collect_ewm_function_data(
+    query: pl.LazyFrame,
+) -> list[tuple[Any, ...]]:
+    """Traverse a query's IR and return function_data tuples for ewm expressions."""
+    results: list[tuple[Any, ...]] = []
 
     def callback(node_traverser: Any, query_start: int | None) -> None:
         for expr_ir in node_traverser.get_exprs():
             expr_node = node_traverser.view_expression(expr_ir.node)
             if isinstance(expr_node, _expr_nodes.Function):
-                function_data = expr_node.function_data
-                if function_data and isinstance(
-                    function_data[0], _expr_nodes.EwmFunction
-                ):
-                    inputs = [
-                        node_traverser.view_expression(i) for i in expr_node.input
-                    ]
-                    results.append((expr_node, inputs))
+                name, *options = expr_node.function_data
+                if isinstance(name, _expr_nodes.EwmFunction):
+                    results.append((name, *options))
 
     query.collect(  # pyrefly: ignore[no-matching-overload]
         post_opt_callback=callback  # type: ignore[call-overload]
@@ -333,10 +330,9 @@ def test_ewm_mean_expr_visitor() -> None:
     q = pl.LazyFrame({"x": [1.0, 2.0, 3.0, 4.0, 5.0]}).with_columns(
         pl.col("x").ewm_mean(alpha=0.5).alias("ewm_mean"),
     )
-    ewm_exprs = _collect_ewm_functions(q)
+    ewm_exprs = _collect_ewm_function_data(q)
     assert len(ewm_exprs) == 1
-    fn, _inputs = ewm_exprs[0]
-    name, alpha, adjust, bias, min_periods, ignore_nulls = fn.function_data
+    name, alpha, adjust, bias, min_periods, ignore_nulls = ewm_exprs[0]
     assert name == _expr_nodes.EwmFunction.Mean
     assert alpha == 0.5
     # `ewm_mean` has no `bias` kwarg; it is always serialized as False.
@@ -353,12 +349,11 @@ def test_ewm_std_expr_visitor() -> None:
         .ewm_std(alpha=0.3, adjust=False, bias=True, min_samples=2, ignore_nulls=True)
         .alias("ewm_std"),
     )
-    ewm_exprs = _collect_ewm_functions(q)
+    ewm_exprs = _collect_ewm_function_data(q)
     assert len(ewm_exprs) == 1
-    fn, _inputs = ewm_exprs[0]
-    name, alpha, adjust, bias, min_periods, ignore_nulls = fn.function_data
+    name, alpha, adjust, bias, min_periods, ignore_nulls = ewm_exprs[0]
     assert name == _expr_nodes.EwmFunction.Std
-    assert alpha == pytest.approx(0.3)
+    assert alpha == 0.3
     assert adjust is False
     assert bias is True
     assert min_periods == 2
@@ -370,12 +365,11 @@ def test_ewm_var_expr_visitor() -> None:
     q = pl.LazyFrame({"x": [1.0, 2.0, 3.0, 4.0, 5.0]}).with_columns(
         pl.col("x").ewm_var(alpha=0.3, bias=False).alias("ewm_var"),
     )
-    ewm_exprs = _collect_ewm_functions(q)
+    ewm_exprs = _collect_ewm_function_data(q)
     assert len(ewm_exprs) == 1
-    fn, _inputs = ewm_exprs[0]
-    name, alpha, _adjust, bias, _min_periods, _ignore_nulls = fn.function_data
+    name, alpha, _, bias, _, _ = ewm_exprs[0]
     assert name == _expr_nodes.EwmFunction.Var
-    assert alpha == pytest.approx(0.3)
+    assert alpha == 0.3
     assert bias is False
 
 
@@ -384,17 +378,16 @@ def test_ewm_mean_span_expr_visitor() -> None:
     q = pl.LazyFrame({"x": [1.0, 2.0, 3.0, 4.0, 5.0]}).with_columns(
         pl.col("x").ewm_mean(span=3).alias("ewm_mean"),
     )
-    ewm_exprs = _collect_ewm_functions(q)
+    ewm_exprs = _collect_ewm_function_data(q)
     assert len(ewm_exprs) == 1
-    fn, _inputs = ewm_exprs[0]
-    name, alpha, *_ = fn.function_data
+    name, alpha, _, _, _, _ = ewm_exprs[0]
     assert name == _expr_nodes.EwmFunction.Mean
     # span=3 -> alpha = 2 / (span + 1)
-    assert alpha == pytest.approx(2.0 / (3.0 + 1.0))
+    assert alpha == 2.0 / (3.0 + 1.0)
 
 
 def test_ewm_mean_by_expr_visitor() -> None:
-    """Test that ewm_mean_by exposes its half_life Duration and the `by` input."""
+    """Test that ewm_mean_by exposes its half_life Duration."""
     q = pl.LazyFrame(
         {
             "x": [1.0, 2.0, 3.0],
@@ -403,15 +396,9 @@ def test_ewm_mean_by_expr_visitor() -> None:
     ).with_columns(
         pl.col("x").ewm_mean_by(by="t", half_life="1w2d3h4m5s6ms").alias("ewm_mean_by"),
     )
-    ewm_exprs = _collect_ewm_functions(q)
+    ewm_exprs = _collect_ewm_function_data(q)
     assert len(ewm_exprs) == 1
-    fn, inputs = ewm_exprs[0]
-    # Two inputs: the values column, then the `by` column second.
-    assert len(inputs) == 2
-    by_node = inputs[1]
-    assert isinstance(by_node, _expr_nodes.Column)
-    assert by_node.name == "t"
-    name, half_life = fn.function_data
+    name, half_life = ewm_exprs[0]
     assert name == _expr_nodes.EwmFunction.MeanBy
     # Wrap<Duration> 6-tuple: (months, weeks, days, nanoseconds, parsed_int, negative)
     expected_ns = (3 * 3600 + 4 * 60 + 5) * 1_000_000_000 + 6 * 1_000_000
@@ -423,9 +410,102 @@ def test_ewm_mean_by_parsed_int_expr_visitor() -> None:
     q = pl.LazyFrame({"x": [1.0, 2.0, 3.0], "t": [1, 2, 3]}).with_columns(
         pl.col("x").ewm_mean_by(by="t", half_life="2i").alias("ewm_mean_by"),
     )
-    ewm_exprs = _collect_ewm_functions(q)
+    ewm_exprs = _collect_ewm_function_data(q)
     assert len(ewm_exprs) == 1
-    fn, _inputs = ewm_exprs[0]
-    name, half_life = fn.function_data
+    name, half_life = ewm_exprs[0]
     assert name == _expr_nodes.EwmFunction.MeanBy
     assert half_life == (0, 0, 0, 2, True, False)
+
+
+def _collect_rolling_by_function_data(
+    query: pl.LazyFrame,
+) -> list[tuple[Any, ...]]:
+    """Traverse a query's IR; return function_data tuples for rolling ``*_by`` exprs."""
+    results: list[tuple[Any, ...]] = []
+
+    def callback(node_traverser: Any, query_start: int | None) -> None:
+        for expr_ir in node_traverser.get_exprs():
+            expr_node = node_traverser.view_expression(expr_ir.node)
+            if isinstance(expr_node, _expr_nodes.Function):
+                name, *options = expr_node.function_data
+                if isinstance(name, _expr_nodes.RollingFunctionBy):
+                    results.append((name, *options))
+
+    query.collect(  # pyrefly: ignore[no-matching-overload]
+        post_opt_callback=callback  # type: ignore[call-overload]
+    )
+    return results
+
+
+def test_rolling_mean_by_expr_visitor() -> None:
+    """Test that rolling_mean_by exposes its Duration window and closed_window."""
+    q = pl.LazyFrame(
+        {
+            "x": [1.0, 2.0, 3.0],
+            "t": [datetime(2020, 1, 1), datetime(2020, 1, 2), datetime(2020, 1, 3)],
+        }
+    ).with_columns(
+        pl.col("x").rolling_mean_by("t", window_size="2h").alias("rmean_by"),
+    )
+    rolling_exprs = _collect_rolling_by_function_data(q)
+    assert len(rolling_exprs) == 1
+    name, window_size, min_periods, closed, fn_params = rolling_exprs[0]
+    assert name == _expr_nodes.RollingFunctionBy.MeanBy
+    # Wrap<Duration> 6-tuple: (months, weeks, days, nanoseconds, parsed_int, negative)
+    assert window_size == (0, 0, 0, 2 * 3600 * 1_000_000_000, False, False)
+    assert min_periods == 1
+    assert closed == "right"
+    assert fn_params == ()
+
+
+def test_rolling_var_by_ddof_expr_visitor() -> None:
+    """rolling_var_by serializes ddof into fn_params."""
+    q = pl.LazyFrame(
+        {
+            "x": [1.0, 2.0, 3.0],
+            "t": [datetime(2020, 1, 1), datetime(2020, 1, 2), datetime(2020, 1, 3)],
+        }
+    ).with_columns(
+        pl.col("x").rolling_var_by("t", "2h", ddof=2).alias("rvar_by"),
+    )
+    rolling_exprs = _collect_rolling_by_function_data(q)
+    assert len(rolling_exprs) == 1
+    name, _, _, _, fn_params = rolling_exprs[0]
+    assert name == _expr_nodes.RollingFunctionBy.VarBy
+    assert fn_params == (2,)
+
+
+def test_rolling_quantile_by_expr_visitor() -> None:
+    """rolling_quantile_by serializes probability and interpolation method."""
+    q = pl.LazyFrame(
+        {
+            "x": [1.0, 2.0, 3.0],
+            "t": [datetime(2020, 1, 1), datetime(2020, 1, 2), datetime(2020, 1, 3)],
+        }
+    ).with_columns(
+        pl.col("x").rolling_quantile_by("t", "2h", quantile=0.25).alias("rq_by"),
+    )
+    rolling_exprs = _collect_rolling_by_function_data(q)
+    assert len(rolling_exprs) == 1
+    name, _, _, _, fn_params = rolling_exprs[0]
+    assert name == _expr_nodes.RollingFunctionBy.QuantileBy
+    assert fn_params == (0.25, "nearest")
+
+
+def test_rolling_rank_by_expr_visitor() -> None:
+    """rolling_rank_by serializes method and seed."""
+    q = pl.LazyFrame(
+        {
+            "x": [1.0, 2.0, 3.0],
+            "t": [datetime(2020, 1, 1), datetime(2020, 1, 2), datetime(2020, 1, 3)],
+        }
+    ).with_columns(
+        pl.col("x").rolling_rank_by("t", "2h").alias("rrank_by"),
+    )
+    rolling_exprs = _collect_rolling_by_function_data(q)
+    assert len(rolling_exprs) == 1
+    name, _, _, _, fn_params = rolling_exprs[0]
+    assert name == _expr_nodes.RollingFunctionBy.RankBy
+    method, seed = fn_params
+    assert method == "average"
+    assert seed is None

--- a/py-polars/tests/unit/lazyframe/cuda/test_node_visitor.py
+++ b/py-polars/tests/unit/lazyframe/cuda/test_node_visitor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import time
+from datetime import datetime
 from functools import lru_cache, partial
 from typing import TYPE_CHECKING, Any
 
@@ -302,3 +303,129 @@ def test_rolling_expr_visitor_rank() -> None:
     name, _, _, _, _, fn_params = rolling_exprs[0]
     assert name == _expr_nodes.RollingFunction.Rank
     assert fn_params == ("dense", 42)
+
+
+def _collect_ewm_functions(query: pl.LazyFrame) -> list[tuple[Any, list[Any]]]:
+    """Traverse a query's IR; return (Function, resolved input nodes) for ewm exprs."""
+    results: list[tuple[Any, list[Any]]] = []
+
+    def callback(node_traverser: Any, query_start: int | None) -> None:
+        for expr_ir in node_traverser.get_exprs():
+            expr_node = node_traverser.view_expression(expr_ir.node)
+            if isinstance(expr_node, _expr_nodes.Function):
+                function_data = expr_node.function_data
+                if function_data and isinstance(
+                    function_data[0], _expr_nodes.EwmFunction
+                ):
+                    inputs = [
+                        node_traverser.view_expression(i) for i in expr_node.input
+                    ]
+                    results.append((expr_node, inputs))
+
+    query.collect(  # pyrefly: ignore[no-matching-overload]
+        post_opt_callback=callback  # type: ignore[call-overload]
+    )
+    return results
+
+
+def test_ewm_mean_expr_visitor() -> None:
+    """Test that ewm_mean is exposed with its EWMOptions fields."""
+    q = pl.LazyFrame({"x": [1.0, 2.0, 3.0, 4.0, 5.0]}).with_columns(
+        pl.col("x").ewm_mean(alpha=0.5).alias("ewm_mean"),
+    )
+    ewm_exprs = _collect_ewm_functions(q)
+    assert len(ewm_exprs) == 1
+    fn, _inputs = ewm_exprs[0]
+    name, alpha, adjust, bias, min_periods, ignore_nulls = fn.function_data
+    assert name == _expr_nodes.EwmFunction.Mean
+    assert alpha == 0.5
+    # `ewm_mean` has no `bias` kwarg; it is always serialized as False.
+    assert adjust is True
+    assert bias is False
+    assert min_periods == 1
+    assert ignore_nulls is False
+
+
+def test_ewm_std_expr_visitor() -> None:
+    """Test that ewm_std serializes all five EWMOptions fields, incl. non-defaults."""
+    q = pl.LazyFrame({"x": [1.0, 2.0, 3.0, 4.0, 5.0]}).with_columns(
+        pl.col("x")
+        .ewm_std(alpha=0.3, adjust=False, bias=True, min_samples=2, ignore_nulls=True)
+        .alias("ewm_std"),
+    )
+    ewm_exprs = _collect_ewm_functions(q)
+    assert len(ewm_exprs) == 1
+    fn, _inputs = ewm_exprs[0]
+    name, alpha, adjust, bias, min_periods, ignore_nulls = fn.function_data
+    assert name == _expr_nodes.EwmFunction.Std
+    assert alpha == pytest.approx(0.3)
+    assert adjust is False
+    assert bias is True
+    assert min_periods == 2
+    assert ignore_nulls is True
+
+
+def test_ewm_var_expr_visitor() -> None:
+    """Test that ewm_var is exposed and distinguished from ewm_std by its enum."""
+    q = pl.LazyFrame({"x": [1.0, 2.0, 3.0, 4.0, 5.0]}).with_columns(
+        pl.col("x").ewm_var(alpha=0.3, bias=False).alias("ewm_var"),
+    )
+    ewm_exprs = _collect_ewm_functions(q)
+    assert len(ewm_exprs) == 1
+    fn, _inputs = ewm_exprs[0]
+    name, alpha, _adjust, bias, _min_periods, _ignore_nulls = fn.function_data
+    assert name == _expr_nodes.EwmFunction.Var
+    assert alpha == pytest.approx(0.3)
+    assert bias is False
+
+
+def test_ewm_mean_span_expr_visitor() -> None:
+    """Test that only the derived alpha (not span) is visible."""
+    q = pl.LazyFrame({"x": [1.0, 2.0, 3.0, 4.0, 5.0]}).with_columns(
+        pl.col("x").ewm_mean(span=3).alias("ewm_mean"),
+    )
+    ewm_exprs = _collect_ewm_functions(q)
+    assert len(ewm_exprs) == 1
+    fn, _inputs = ewm_exprs[0]
+    name, alpha, *_ = fn.function_data
+    assert name == _expr_nodes.EwmFunction.Mean
+    # span=3 -> alpha = 2 / (span + 1)
+    assert alpha == pytest.approx(2.0 / (3.0 + 1.0))
+
+
+def test_ewm_mean_by_expr_visitor() -> None:
+    """Test that ewm_mean_by exposes its half_life Duration and the `by` input."""
+    q = pl.LazyFrame(
+        {
+            "x": [1.0, 2.0, 3.0],
+            "t": [datetime(2020, 1, 1), datetime(2020, 2, 1), datetime(2020, 3, 1)],
+        }
+    ).with_columns(
+        pl.col("x").ewm_mean_by(by="t", half_life="1w2d3h4m5s6ms").alias("ewm_mean_by"),
+    )
+    ewm_exprs = _collect_ewm_functions(q)
+    assert len(ewm_exprs) == 1
+    fn, inputs = ewm_exprs[0]
+    # Two inputs: the values column, then the `by` column second.
+    assert len(inputs) == 2
+    by_node = inputs[1]
+    assert isinstance(by_node, _expr_nodes.Column)
+    assert by_node.name == "t"
+    name, half_life = fn.function_data
+    assert name == _expr_nodes.EwmFunction.MeanBy
+    # Wrap<Duration> 6-tuple: (months, weeks, days, nanoseconds, parsed_int, negative)
+    expected_ns = (3 * 3600 + 4 * 60 + 5) * 1_000_000_000 + 6 * 1_000_000
+    assert half_life == (0, 1, 2, expected_ns, False, False)
+
+
+def test_ewm_mean_by_parsed_int_expr_visitor() -> None:
+    """Test the parsed_int path of the half_life Duration tuple (the `i` unit)."""
+    q = pl.LazyFrame({"x": [1.0, 2.0, 3.0], "t": [1, 2, 3]}).with_columns(
+        pl.col("x").ewm_mean_by(by="t", half_life="2i").alias("ewm_mean_by"),
+    )
+    ewm_exprs = _collect_ewm_functions(q)
+    assert len(ewm_exprs) == 1
+    fn, _inputs = ewm_exprs[0]
+    name, half_life = fn.function_data
+    assert name == _expr_nodes.EwmFunction.MeanBy
+    assert half_life == (0, 0, 0, 2, True, False)

--- a/py-polars/tests/unit/lazyframe/cuda/test_node_visitor.py
+++ b/py-polars/tests/unit/lazyframe/cuda/test_node_visitor.py
@@ -334,6 +334,7 @@ def test_ewm_mean_expr_visitor() -> None:
     assert len(ewm_exprs) == 1
     name, alpha, adjust, bias, min_periods, ignore_nulls = ewm_exprs[0]
     assert name == _expr_nodes.EwmFunction.Mean
+    assert hash(name) == hash(_expr_nodes.EwmFunction.Mean)
     assert alpha == 0.5
     # `ewm_mean` has no `bias` kwarg; it is always serialized as False.
     assert adjust is True
@@ -451,6 +452,7 @@ def test_rolling_mean_by_expr_visitor() -> None:
     assert len(rolling_exprs) == 1
     name, window_size, min_periods, closed, fn_params = rolling_exprs[0]
     assert name == _expr_nodes.RollingFunctionBy.MeanBy
+    assert hash(name) == hash(_expr_nodes.RollingFunctionBy.MeanBy)
     # Wrap<Duration> 6-tuple: (months, weeks, days, nanoseconds, parsed_int, negative)
     assert window_size == (0, 0, 0, 2 * 3600 * 1_000_000_000, False, False)
     assert min_periods == 1
@@ -458,54 +460,34 @@ def test_rolling_mean_by_expr_visitor() -> None:
     assert fn_params == ()
 
 
-def test_rolling_var_by_ddof_expr_visitor() -> None:
-    """rolling_var_by serializes ddof into fn_params."""
+@pytest.mark.parametrize(
+    ("expr", "expected_name", "expected_fn_params"),
+    [
+        (pl.col("x").rolling_min_by("t", "2h"), "MinBy", ()),
+        (pl.col("x").rolling_max_by("t", "2h"), "MaxBy", ()),
+        (pl.col("x").rolling_sum_by("t", "2h"), "SumBy", ()),
+        (pl.col("x").rolling_std_by("t", "2h"), "StdBy", (1,)),
+        (pl.col("x").rolling_var_by("t", "2h", ddof=2), "VarBy", (2,)),
+        (
+            pl.col("x").rolling_quantile_by("t", "2h", quantile=0.25),
+            "QuantileBy",
+            (0.25, "nearest"),
+        ),
+        (pl.col("x").rolling_rank_by("t", "2h"), "RankBy", ("average", None)),
+    ],
+)
+def test_rolling_by_variant_fn_params(
+    expr: pl.Expr, expected_name: str, expected_fn_params: tuple[Any, ...]
+) -> None:
+    """Each rolling ``*_by`` variant exposes its enum discriminant and fn_params."""
     q = pl.LazyFrame(
         {
             "x": [1.0, 2.0, 3.0],
             "t": [datetime(2020, 1, 1), datetime(2020, 1, 2), datetime(2020, 1, 3)],
         }
-    ).with_columns(
-        pl.col("x").rolling_var_by("t", "2h", ddof=2).alias("rvar_by"),
-    )
+    ).with_columns(expr.alias("out"))
     rolling_exprs = _collect_rolling_by_function_data(q)
     assert len(rolling_exprs) == 1
     name, _, _, _, fn_params = rolling_exprs[0]
-    assert name == _expr_nodes.RollingFunctionBy.VarBy
-    assert fn_params == (2,)
-
-
-def test_rolling_quantile_by_expr_visitor() -> None:
-    """rolling_quantile_by serializes probability and interpolation method."""
-    q = pl.LazyFrame(
-        {
-            "x": [1.0, 2.0, 3.0],
-            "t": [datetime(2020, 1, 1), datetime(2020, 1, 2), datetime(2020, 1, 3)],
-        }
-    ).with_columns(
-        pl.col("x").rolling_quantile_by("t", "2h", quantile=0.25).alias("rq_by"),
-    )
-    rolling_exprs = _collect_rolling_by_function_data(q)
-    assert len(rolling_exprs) == 1
-    name, _, _, _, fn_params = rolling_exprs[0]
-    assert name == _expr_nodes.RollingFunctionBy.QuantileBy
-    assert fn_params == (0.25, "nearest")
-
-
-def test_rolling_rank_by_expr_visitor() -> None:
-    """rolling_rank_by serializes method and seed."""
-    q = pl.LazyFrame(
-        {
-            "x": [1.0, 2.0, 3.0],
-            "t": [datetime(2020, 1, 1), datetime(2020, 1, 2), datetime(2020, 1, 3)],
-        }
-    ).with_columns(
-        pl.col("x").rolling_rank_by("t", "2h").alias("rrank_by"),
-    )
-    rolling_exprs = _collect_rolling_by_function_data(q)
-    assert len(rolling_exprs) == 1
-    name, _, _, _, fn_params = rolling_exprs[0]
-    assert name == _expr_nodes.RollingFunctionBy.RankBy
-    method, seed = fn_params
-    assert method == "average"
-    assert seed is None
+    assert name == getattr(_expr_nodes.RollingFunctionBy, expected_name)
+    assert fn_params == expected_fn_params


### PR DESCRIPTION
Add support for `ewm` (`ewm_mean`/`std`/`var`/`ewm_mean_by`) and rolling `*_by` families of operators to the Python expression visitor API, which previously raised `NotImplementedError`.

Bumps `NodeTraverser::VERSION` (14, 3) -> (14, 4).

---
AI usage: I used Claude Code (Claude Opus) to help implement these changes and tests; I have reviewed and verified all changes myself.
