### PR TITLE
Coerce is_between float bounds like the equivalent binary comparison chain

### DIFF
--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -1585,6 +1585,164 @@ fn test_round_after_agg() -> PolarsResult<()> {
 }
 
 #[test]
+#[cfg(feature = "is_between")]
+fn test_is_between_coerces_dyn_float_like_binary_comparison_28278() -> PolarsResult<()> {
+    let x = 1.0000001192092896_f32;
+    let larger = 1.000000149011612_f64;
+    let df = df!["x" => &[x]]?;
+
+    let out = df
+        .lazy()
+        .select([
+            (col("x").gt_eq(lit(larger)).and(col("x").lt_eq(lit(2.0)))).alias("explicit_between"),
+            col("x")
+                .is_between(
+                    lit(larger),
+                    lit(2.0),
+                    polars_ops::series::ClosedInterval::Both,
+                )
+                .alias("is_between"),
+            col("x")
+                .is_between(
+                    lit(larger),
+                    lit(2.0),
+                    polars_ops::series::ClosedInterval::Left,
+                )
+                .alias("closed_left"),
+            col("x")
+                .is_between(
+                    typed_lit(larger),
+                    typed_lit(2.0_f64),
+                    polars_ops::series::ClosedInterval::Both,
+                )
+                .alias("explicit_float64"),
+        ])
+        .collect()?;
+
+    assert_eq!(
+        Vec::from(out.column("explicit_between")?.bool()?),
+        &[Some(true)]
+    );
+    assert_eq!(Vec::from(out.column("is_between")?.bool()?), &[Some(true)]);
+    assert_eq!(Vec::from(out.column("closed_left")?.bool()?), &[Some(true)]);
+    assert_eq!(
+        Vec::from(out.column("explicit_float64")?.bool()?),
+        &[Some(false)]
+    );
+
+    let empty = DataFrame::new_infer_height(vec![
+        Series::new_empty("x".into(), &DataType::Float32).into(),
+    ])?
+    .lazy()
+    .select([col("x")
+        .is_between(
+            lit(larger),
+            lit(2.0),
+            polars_ops::series::ClosedInterval::Both,
+        )
+        .alias("is_between")])
+    .collect()?;
+
+    assert_eq!(empty.height(), 0);
+    assert_eq!(empty.column("is_between")?.dtype(), &DataType::Boolean);
+
+    Ok(())
+}
+
+/// Regression test for a gap left by the #28278 fix: when only ONE bound is a dynamic
+/// (untyped) float literal and the OTHER bound is an explicitly-typed float literal whose
+/// dtype also mismatches the needle, the per-bound dyn-float cast for the first bound must
+/// not be discarded just because the second bound has no int/datetime/duration-specific
+/// coercion available. Both bounds must independently match what the equivalent binary
+/// comparison chain produces, in both bound-orderings.
+#[test]
+#[cfg(feature = "is_between")]
+fn test_is_between_coerces_mixed_dyn_typed_float_bounds_28278() -> PolarsResult<()> {
+    use polars_ops::series::ClosedInterval;
+
+    let x = 1.0000001192092896_f32;
+    let larger = 1.000000149011612_f64;
+    let df = df!["x" => &[x]]?;
+
+    // Build the oracle binary-comparison chain using the same per-`closed` operator selection
+    // that `is_between`'s own type-coercion rewrite uses (see `cmp_op_low`/`cmp_op_high` in
+    // `TypeCoercionRule`), so the oracle is genuinely independent of the bound-literal coercion
+    // path we are testing, not accidentally hardcoded to the `Both` variant.
+    fn explicit_chain(needle: Expr, low: Expr, high: Expr, closed: ClosedInterval) -> Expr {
+        let low_cmp = match closed {
+            ClosedInterval::Both | ClosedInterval::Left => needle.clone().gt_eq(low),
+            ClosedInterval::Right | ClosedInterval::None => needle.clone().gt(low),
+        };
+        let high_cmp = match closed {
+            ClosedInterval::Both | ClosedInterval::Right => needle.lt_eq(high),
+            ClosedInterval::Left | ClosedInterval::None => needle.lt(high),
+        };
+        low_cmp.and(high_cmp)
+    }
+
+    for closed in [
+        ClosedInterval::Both,
+        ClosedInterval::Left,
+        ClosedInterval::Right,
+        ClosedInterval::None,
+    ] {
+        let out = df
+            .clone()
+            .lazy()
+            .select([
+                // dyn low bound, explicitly-typed (mismatched) high bound
+                explicit_chain(col("x"), lit(larger), typed_lit(2.0_f64), closed)
+                    .alias("explicit_dyn_low_typed_high"),
+                col("x")
+                    .is_between(lit(larger), typed_lit(2.0_f64), closed)
+                    .alias("dyn_low_typed_high"),
+                // explicitly-typed (mismatched) low bound, dyn high bound
+                explicit_chain(col("x"), typed_lit(0.0_f64), lit(larger), closed)
+                    .alias("explicit_typed_low_dyn_high"),
+                col("x")
+                    .is_between(typed_lit(0.0_f64), lit(larger), closed)
+                    .alias("typed_low_dyn_high"),
+            ])
+            .collect()?;
+
+        assert_eq!(
+            Vec::from(out.column("dyn_low_typed_high")?.bool()?),
+            Vec::from(out.column("explicit_dyn_low_typed_high")?.bool()?),
+            "dyn-low/typed-high mismatch for closed={closed:?}"
+        );
+        assert_eq!(
+            Vec::from(out.column("typed_low_dyn_high")?.bool()?),
+            Vec::from(out.column("explicit_typed_low_dyn_high")?.bool()?),
+            "typed-low/dyn-high mismatch for closed={closed:?}"
+        );
+    }
+
+    // `closed=Both` (inclusive on both bounds) is the case from the bug report: the needle
+    // must land exactly on the narrowed dyn bound and be considered "in".
+    let out = df
+        .lazy()
+        .select([
+            col("x")
+                .is_between(lit(larger), typed_lit(2.0_f64), ClosedInterval::Both)
+                .alias("dyn_low_typed_high"),
+            col("x")
+                .is_between(typed_lit(0.0_f64), lit(larger), ClosedInterval::Both)
+                .alias("typed_low_dyn_high"),
+        ])
+        .collect()?;
+    assert_eq!(
+        Vec::from(out.column("dyn_low_typed_high")?.bool()?),
+        &[Some(true)]
+    );
+    assert_eq!(
+        Vec::from(out.column("typed_low_dyn_high")?.bool()?),
+        &[Some(true)]
+    );
+
+    Ok(())
+}
+
+#[test]
 #[cfg(feature = "dtype-date")]
 fn test_fill_nan() -> PolarsResult<()> {
     let s0 = Column::new("date".into(), &[1, 2, 3]).cast(&DataType::Date)?;

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -276,6 +276,17 @@ impl OptimizationRule for TypeCoercionRule {
                 };
 
                 let needle_dtype = unpack!(try_get_dtype(expr_arena, needle.node(), schema).ok());
+                let maybe_cast_dyn_float = |lv: &LiteralValue| {
+                    if matches!(
+                        needle_dtype,
+                        DataType::Float16 | DataType::Float32 | DataType::Float64
+                    ) && matches!(lv, LiteralValue::Dyn(DynLiteralValue::Float(_)))
+                    {
+                        try_inline_literal_cast(lv, &needle_dtype, CastOptions::NonStrict)
+                    } else {
+                        Ok(None)
+                    }
+                };
 
                 let (low_ae, low_dtype) =
                     unpack!(get_aexpr_and_type(expr_arena, low.node(), schema));
@@ -285,14 +296,25 @@ impl OptimizationRule for TypeCoercionRule {
                 {
                     use crate::plans::type_coercion::binary::BoolValueAlways;
 
-                    if let LiteralValue::Scalar(lit) = lv.clone().materialize() {
-                        match unpack!(coerce_comparison_literal(
+                    if let Some(new_lit) = maybe_cast_dyn_float(lv)? {
+                        new_low = Some(ExprIR::from_node(
+                            expr_arena.add(AExpr::Literal(new_lit)),
+                            expr_arena,
+                        ));
+                    } else if let LiteralValue::Scalar(lit) = lv.clone().materialize()
+                        && let Some(rewrite) = coerce_comparison_literal(
                             needle.node(),
                             &needle_dtype,
                             cmp_op_low,
                             lit,
                             expr_arena,
-                        )) {
+                        )
+                    {
+                        // `coerce_comparison_literal` returning `None` here just means it has no
+                        // int/datetime/duration-specific optimization for this bound (e.g. a
+                        // float<->float dtype mismatch) - leave this bound untouched rather than
+                        // discarding a rewrite already computed for the sibling bound.
+                        match rewrite {
                             ReplaceLit(new_lit) => {
                                 new_low = Some(ExprIR::from_node(
                                     expr_arena.add(AExpr::Literal(LiteralValue::Scalar(new_lit))),
@@ -319,14 +341,25 @@ impl OptimizationRule for TypeCoercionRule {
                 if high_dtype != needle_dtype
                     && let AExpr::Literal(lv) = high_ae
                 {
-                    if let LiteralValue::Scalar(lit) = lv.clone().materialize() {
-                        match unpack!(coerce_comparison_literal(
+                    if let Some(new_lit) = maybe_cast_dyn_float(lv)? {
+                        new_high = Some(ExprIR::from_node(
+                            expr_arena.add(AExpr::Literal(new_lit)),
+                            expr_arena,
+                        ));
+                    } else if let LiteralValue::Scalar(lit) = lv.clone().materialize()
+                        && let Some(rewrite) = coerce_comparison_literal(
                             needle.node(),
                             &needle_dtype,
                             cmp_op_high,
                             lit,
                             expr_arena,
-                        )) {
+                        )
+                    {
+                        // See the comment on the analogous `low` branch above: a `None` here just
+                        // means no int/datetime/duration-specific optimization applies (e.g. a
+                        // float<->float dtype mismatch) - leave this bound untouched rather than
+                        // discarding a rewrite already computed for the sibling bound.
+                        match rewrite {
                             ReplaceLit(new_lit) => {
                                 new_high = Some(ExprIR::from_node(
                                     expr_arena.add(AExpr::Literal(LiteralValue::Scalar(new_lit))),

--- a/py-polars/tests/unit/operations/test_comparison.py
+++ b/py-polars/tests/unit/operations/test_comparison.py
@@ -1114,3 +1114,34 @@ def test_comparison_literal_downcast_rewrites() -> None:
         pl.col("u16").is_between(1 << 16, 1 << 17),
         'when(col("u16").is_not_null()).then(false).otherwise(null)',
     )
+
+
+def test_is_between_coerces_dyn_float_like_binary_comparison_28278() -> None:
+    x = 1.0000001192092896
+    larger = 1.000000149011612
+    lf = pl.LazyFrame({"x": [x]}, schema={"x": pl.Float32})
+
+    result = lf.select(
+        explicit_between=(pl.col("x") >= larger) & (pl.col("x") <= 2.0),
+        is_between=pl.col("x").is_between(larger, 2.0),
+        closed_left=pl.col("x").is_between(larger, 2.0, closed="left"),
+        explicit_float64=pl.col("x").is_between(
+            pl.lit(larger, dtype=pl.Float64),
+            pl.lit(2.0, dtype=pl.Float64),
+        ),
+    ).collect()
+
+    expected = pl.DataFrame(
+        {
+            "explicit_between": [True],
+            "is_between": [True],
+            "closed_left": [True],
+            "explicit_float64": [False],
+        }
+    )
+    assert_frame_equal(result, expected)
+
+    empty = pl.LazyFrame({"x": []}, schema={"x": pl.Float32}).select(
+        is_between=pl.col("x").is_between(larger, 2.0)
+    )
+    assert empty.collect().schema == {"is_between": pl.Boolean}


### PR DESCRIPTION
Coerce is_between float bounds like the equivalent binary comparison chain

## Bug

`is_between` does not coerce its bound literals the way the equivalent `low <= x AND x <= high` binary chain does, so the two produce different results for the same inputs (issue #28278). With a float column and a dynamic float literal bound near the f32/f64 representable gap, `is_between` returns a different boolean than the binary chain.

```python
import polars as pl
x = pl.Series("x", [1.0000001192092896], dtype=pl.Float32)
df = pl.DataFrame([x])
lo = 1.000000149011612  # dyn float
df.select(
    chain = (pl.col("x") >= lo) & (pl.col("x") <= 2.0),
    between = pl.col("x").is_between(lo, 2.0),
)
# chain -> true, between -> false   (should agree)
```

## Root cause

In `TypeCoercionRule`'s `IsBetween` branch (`crates/polars-plan/src/plans/conversion/type_coercion/mod.rs`) two problems compounded:

1. A dynamic float literal bound was never narrowed to the needle's float dtype. It fell through to the `Scalar`/materialize path and was compared in the wider common supertype (Float64), unlike the binary path which narrows the literal to the column dtype.
2. The per-bound rewrite went through `unpack!(coerce_comparison_literal(...))`, which aborted the entire `IsBetween` rewrite (`return Ok(None)`) whenever that function returned `None` for either bound. `coerce_comparison_literal` only recognizes int/datetime/duration mismatches, so a float to float mismatch on one bound discarded the rewrite already computed for the sibling bound.

Together these left mixed dyn/typed float bounds un-narrowed, reproducing the imprecision.

## Fix

Mirror what the binary-comparison path (`process_binary`) already does:

1. Add `maybe_cast_dyn_float`: when the needle is a float dtype and a bound is a dynamic float literal, NonStrict-cast the literal to the needle dtype.
2. Change the hard `unpack!` abort to a soft per-bound `if let Some(rewrite) = coerce_comparison_literal(...)`. A `None` now means "no int/datetime/duration-specific rewrite for this bound", leaving that bound untouched instead of discarding the sibling bound's cast. This matches how `process_binary` treats a `None` from the same function.

`coerce_comparison_literal` returns `Option`, so the change only affects the outer-`None` path; the correctness-critical `FalseOrNull` short-circuit and inner exits are preserved. Int, datetime and duration behavior (including the out-of-range literal guard and datetime unit flooring) is unchanged.

## Tests

`crates/polars-lazy/src/tests/queries.rs`:

- `test_is_between_coerces_dyn_float_like_binary_comparison_28278`: float needle vs dyn float bound matches the binary chain.
- `test_is_between_coerces_mixed_dyn_typed_float_bounds_28278`: mixed dyn/typed float bounds in both orderings across all four `ClosedInterval` variants, each compared to a per-closed correct explicit binary chain.

`py-polars/tests/unit/operations/test_comparison.py`: Python-level regression for the reported case.

```
cargo test -p polars-lazy --features is_between   # 101 passed, 24 doctests passed
cargo test -p polars-plan  --features is_between   # 4 passed
```

Reverting only the source change fails the mixed-bound test with the exact divergence (`is_between` false vs chain true) while int/datetime/duration results stay byte-identical, so the change is scoped to float bound coercion and the tests have teeth.

Fixes #28278
