### PR TITLE
fix: Set CallerContext parallel flag for plugin expressions

### DIFF
--- a/crates/polars-expr/src/dispatch/mod.rs
+++ b/crates/polars-expr/src/dispatch/mod.rs
@@ -136,7 +136,10 @@ mod trigonometry;
 
 pub use groups_dispatch::drop_items;
 
-pub fn function_expr_to_udf(func: IRFunctionExpr) -> SpecialEq<Arc<dyn ColumnsUdf>> {
+pub fn function_expr_to_udf(
+    func: IRFunctionExpr,
+    _allow_threading: bool,
+) -> SpecialEq<Arc<dyn ColumnsUdf>> {
     use IRFunctionExpr as F;
     match func {
         // Namespaces
@@ -448,7 +451,8 @@ pub fn function_expr_to_udf(func: IRFunctionExpr) -> SpecialEq<Arc<dyn ColumnsUd
                 polars_plan::plans::plugin::call_plugin,
                 lib.as_ref(),
                 symbol.as_ref(),
-                kwargs.as_ref()
+                kwargs.as_ref(),
+                _allow_threading
             )
         },
 

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -612,7 +612,7 @@ fn create_physical_expr_inner(
 
             Ok(Arc::new(ApplyExpr::new(
                 input,
-                function_expr_to_udf(function.clone()),
+                function_expr_to_udf(function.clone(), state.allow_threading),
                 function_expr_to_groups_udf(&function),
                 node_to_expr(expression, expr_arena),
                 options,

--- a/crates/polars-plan/src/plans/aexpr/function_expr/plugin.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/plugin.rs
@@ -66,12 +66,21 @@ fn retrieve_error_msg(lib: &Library) -> String {
     }
 }
 
+fn caller_context(parallel: bool) -> polars_ffi::version_0::CallerContext {
+    let mut context = polars_ffi::version_0::CallerContext::default();
+    if parallel {
+        context._set_parallel();
+    }
+    context
+}
+
 #[doc(hidden)]
 pub unsafe fn call_plugin(
     s: &[Column],
     lib: &str,
     symbol: &str,
     kwargs: &[u8],
+    parallel: bool,
 ) -> PolarsResult<Column> {
     let plugin = get_lib(lib)?;
     let lib = &plugin.0;
@@ -108,7 +117,7 @@ pub unsafe fn call_plugin(
 
         let mut return_value = SeriesExport::empty();
         let return_value_ptr = &mut return_value as *mut SeriesExport;
-        let context = CallerContext::default();
+        let context = caller_context(parallel);
         let context_ptr = &context as *const CallerContext;
         symbol(
             slice_ptr,
@@ -219,4 +228,15 @@ pub(super) unsafe fn plugin_field(
 fn check_panic(msg: &str) -> PolarsResult<()> {
     polars_ensure!(msg != "PANIC", ComputeError: "the plugin panicked\n\nThe message is suppressed. Set POLARS_VERBOSE=1 to send the panic message to stderr.");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::caller_context;
+
+    #[test]
+    fn caller_context_reflects_parallel_flag() {
+        assert!(!caller_context(false).parallel());
+        assert!(caller_context(true).parallel());
+    }
 }

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -2640,7 +2640,9 @@ fn lower_exprs_with_ctx(
                         format_str = Some(fmt_str.to_string());
                     },
                     AExpr::Function { function, .. } => {
-                        func = function_expr_to_udf(function.clone()).into_inner();
+                        // The streaming engine parallelizes across morsels, so a
+                        // plugin should not also thread internally.
+                        func = function_expr_to_udf(function.clone(), false).into_inner();
                         format_str = Some(function.to_string());
                     },
                     _ => unreachable!(),

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -1716,7 +1716,9 @@ pub fn lower_ir(
                             ctx,
                         );
                     } else {
-                        let func = function_expr_to_udf(function.clone()).into_inner();
+                        // The streaming engine parallelizes across morsels, so a
+                        // plugin should not also thread internally.
+                        let func = function_expr_to_udf(function.clone(), false).into_inner();
                         let format_str = Some(format!("COLUMNAR {function}"));
                         PhysNodeKind::ColumnarFunction {
                             inputs: trans_inputs,


### PR DESCRIPTION
Closes #27729.

Plugin expressions built the FFI `CallerContext` with `::default()`, so the parallel bit was never set and `CallerContext::parallel()` always returned `false` inside a plugin — a plugin could never tell whether Polars was already parallelizing the call.

Threads the planner's `allow_threading` through into `call_plugin` so the flag is set correctly, and forces it off in the streaming lowering paths since the engine already parallelizes across morsels.