### PR TITLE
fix(python): rows_by_key raises ValueError when all columns are keys

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -12103,7 +12103,12 @@ class DataFrame:
             data_cols = [k for k in self.schema if k not in key]
             values = self.select(data_cols)
 
-        zipped = zip(keys, values.iter_rows(named=named), strict=True)  # type: ignore[call-overload]
+        zipped: Iterable[tuple[Any, Any]]
+        if values.width == 0:
+            empty_row: Any = {} if named else ()
+            zipped = ((k, empty_row) for k in keys)
+        else:
+            zipped = zip(keys, values.iter_rows(named=named), strict=True)  # type: ignore[call-overload]
 
         # if unique, we expect to write just one entry per key; otherwise, we're
         # returning a list of rows for each key, so append into a defaultdict.

--- a/py-polars/tests/unit/dataframe/test_rows.py
+++ b/py-polars/tests/unit/dataframe/test_rows.py
@@ -164,6 +164,46 @@ def test_rows_by_key() -> None:
     }
 
 
+def test_rows_by_key_all_columns_27925() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+
+    # All columns used as keys leaves no value columns; the grouped rows are
+    # empty tuples/dicts rather than raising a length-mismatch error.
+    assert df.rows_by_key(["a", "b"]) == {
+        (1, 4): [()],
+        (2, 5): [()],
+        (3, 6): [()],
+    }
+    assert df.rows_by_key(["a", "b"], unique=True) == {
+        (1, 4): (),
+        (2, 5): (),
+        (3, 6): (),
+    }
+    assert df.rows_by_key(["a", "b"], named=True) == {
+        (1, 4): [{}],
+        (2, 5): [{}],
+        (3, 6): [{}],
+    }
+    assert df.rows_by_key(["a", "b"], include_key=True) == {
+        (1, 4): [(1, 4)],
+        (2, 5): [(2, 5)],
+        (3, 6): [(3, 6)],
+    }
+
+    # Non-unique keys must preserve multiplicity: one (empty) row per occurrence.
+    dup = pl.DataFrame({"a": [1, 2, 3, 1, 2, 3], "b": [4, 5, 6, 4, 5, 6]})
+    assert dup.rows_by_key(["a", "b"]) == {
+        (1, 4): [(), ()],
+        (2, 5): [(), ()],
+        (3, 6): [(), ()],
+    }
+    assert dup.rows_by_key(["a", "b"], named=True) == {
+        (1, 4): [{}, {}],
+        (2, 5): [{}, {}],
+        (3, 6): [{}, {}],
+    }
+
+
 def test_iter_rows() -> None:
     df = pl.DataFrame(
         {


### PR DESCRIPTION
Closes #27925.

### Problem
`DataFrame.rows_by_key` raised `ValueError` when every column was passed as a key. With no value columns left, the internal `zip(keys, values.iter_rows(), strict=True)` failed on the length mismatch (a zero-width `values`).

### Fix
Handle the zero-width case explicitly: emit an empty tuple (or `{}` when `named=True`) per key. Multiplicity for non-unique keys is preserved — the generator yields one empty row per key occurrence, so duplicate keys still map to a list with the right number of entries.

### Addressing prior review
This is a resubmission of #28001, which was closed under the first-time-contributor one-open-PR rule (now lifted after #28054 merged), **not** on technical grounds. In that PR @orlp correctly noted the first attempt mishandled non-unique rows (e.g. `{"a": [1,2,3,1,2,3], ...}` must return multiple empty rows per key). That is fixed here and covered by an explicit test asserting `[(), ()]` / `[{}, {}]` for duplicated keys.

Verified locally: `pytest tests/unit/dataframe/test_rows.py -k rows_by_key` passes.