### PR TITLE
fix: Error instead of panic when exporting field names with null bytes to Arrow

### DIFF
--- a/crates/polars-arrow/src/ffi/mod.rs
+++ b/crates/polars-arrow/src/ffi/mod.rs
@@ -28,6 +28,14 @@ pub fn export_field_to_c(field: &Field) -> ArrowSchema {
     ArrowSchema::new(field)
 }
 
+/// Exports a [`Field`] to the C data interface, returning an error instead of
+/// panicking when a (possibly nested) field name cannot be represented as a
+/// null-terminated C string.
+pub fn try_export_field_to_c(field: &Field) -> PolarsResult<ArrowSchema> {
+    self::schema::ensure_c_compatible_names(field)?;
+    Ok(ArrowSchema::new(field))
+}
+
 /// Imports a [`Field`] from the C data interface.
 /// # Safety
 /// This function is intrinsically `unsafe` and relies on a [`ArrowSchema`]

--- a/crates/polars-arrow/src/ffi/schema.rs
+++ b/crates/polars-arrow/src/ffi/schema.rs
@@ -65,6 +65,35 @@ fn schema_children(dtype: &ArrowDataType, flags: &mut i64) -> Box<[*mut ArrowSch
     }
 }
 
+/// Names in the Arrow C data interface are null-terminated C strings, so a name
+/// containing an interior null byte cannot be represented. Validate a field (and
+/// its children) up front so export can return an error instead of panicking
+/// when building the underlying `CString`.
+pub(crate) fn ensure_c_compatible_names(field: &Field) -> PolarsResult<()> {
+    if field.name.as_bytes().contains(&0) {
+        polars_bail!(
+            ComputeError:
+            "cannot export field with name {:?} to Arrow: names may not contain null bytes",
+            field.name.as_str(),
+        );
+    }
+    ensure_dtype_c_compatible_names(field.dtype())
+}
+
+fn ensure_dtype_c_compatible_names(dtype: &ArrowDataType) -> PolarsResult<()> {
+    match dtype {
+        ArrowDataType::List(field)
+        | ArrowDataType::FixedSizeList(field, _)
+        | ArrowDataType::LargeList(field)
+        | ArrowDataType::Map(field, _) => ensure_c_compatible_names(field),
+        ArrowDataType::Struct(fields) => fields.iter().try_for_each(ensure_c_compatible_names),
+        ArrowDataType::Union(u) => u.fields.iter().try_for_each(ensure_c_compatible_names),
+        ArrowDataType::Dictionary(_, values, _) => ensure_dtype_c_compatible_names(values),
+        ArrowDataType::Extension(ext) => ensure_dtype_c_compatible_names(&ext.inner),
+        _ => Ok(()),
+    }
+}
+
 impl ArrowSchema {
     /// creates a new [ArrowSchema]
     pub(crate) fn new(field: &Field) -> Self {

--- a/crates/polars-python/src/interop/arrow/to_py.rs
+++ b/crates/polars-python/src/interop/arrow/to_py.rs
@@ -11,13 +11,15 @@ use pyo3::ffi::Py_uintptr_t;
 use pyo3::prelude::*;
 use pyo3::types::PyCapsule;
 
+use crate::error::PyPolarsErr;
+
 /// Arrow array to Python.
 pub(crate) fn to_py_array(
     array: ArrayRef,
     field: &ArrowField,
     pyarrow: &Bound<PyModule>,
 ) -> PyResult<Py<PyAny>> {
-    let schema = Box::new(ffi::export_field_to_c(field));
+    let schema = Box::new(ffi::try_export_field_to_c(field).map_err(PyPolarsErr::from)?);
     let array = Box::new(ffi::export_array_to_c(array));
 
     let schema_ptr: *const ffi::ArrowSchema = &*schema;
@@ -44,12 +46,15 @@ pub(crate) fn to_py_rb(
         arrays.push(array_object);
     }
 
-    let schema = Box::new(ffi::export_field_to_c(&ArrowField {
-        name: PlSmallStr::EMPTY,
-        dtype: ArrowDataType::Struct(rb.schema().iter_values().cloned().collect()),
-        is_nullable: false,
-        metadata: None,
-    }));
+    let schema = Box::new(
+        ffi::try_export_field_to_c(&ArrowField {
+            name: PlSmallStr::EMPTY,
+            dtype: ArrowDataType::Struct(rb.schema().iter_values().cloned().collect()),
+            is_nullable: false,
+            metadata: None,
+        })
+        .map_err(PyPolarsErr::from)?,
+    );
     let schema_ptr: *const ffi::ArrowSchema = &*schema;
 
     let schema = pyarrow
@@ -95,7 +100,7 @@ pub(crate) fn polars_schema_to_pycapsule<'py>(
     schema: crate::prelude::Wrap<polars::prelude::Schema>,
     compat_level: crate::prelude::PyCompatLevel,
 ) -> PyResult<Bound<'py, PyCapsule>> {
-    let schema: arrow::ffi::ArrowSchema = arrow::ffi::export_field_to_c(&ArrowField::new(
+    let schema: arrow::ffi::ArrowSchema = arrow::ffi::try_export_field_to_c(&ArrowField::new(
         PlSmallStr::EMPTY,
         ArrowDataType::Struct(
             schema
@@ -105,7 +110,8 @@ pub(crate) fn polars_schema_to_pycapsule<'py>(
                 .collect(),
         ),
         false,
-    ));
+    ))
+    .map_err(PyPolarsErr::from)?;
 
     PyCapsule::new_with_value(py, schema, c"arrow_schema")
 }

--- a/crates/polars-python/src/series/c_interface.rs
+++ b/crates/polars-python/src/series/c_interface.rs
@@ -59,7 +59,7 @@ unsafe fn export_chunk(
         s.dtype().to_arrow(CompatLevel::newest()),
         true,
     );
-    let c_schema = arrow::ffi::export_field_to_c(&field);
+    let c_schema = arrow::ffi::try_export_field_to_c(&field)?;
 
     let out_schema_ptr = out_schema_ptr as *mut arrow::ffi::ArrowSchema;
     *out_schema_ptr = c_schema;

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -1550,3 +1550,14 @@ def test_from_pandas_timestamp_17382() -> None:
     assert isinstance(result, datetime)
     assert result.tzinfo == ZoneInfo("UTC")
     assert result == datetime(2021, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("UTC"))
+
+
+def test_to_arrow_null_byte_in_name_24353() -> None:
+    # Arrow C data interface names are null-terminated, so a name with an
+    # interior null byte must error rather than panic.
+    with pytest.raises(ComputeError, match="names may not contain null bytes"):
+        pl.DataFrame({"a\x00b": [1]}).to_arrow()
+
+    # Nested field names are validated too.
+    with pytest.raises(ComputeError, match="names may not contain null bytes"):
+        pl.DataFrame({"s": [{"x\x00y": 1}]}).to_arrow()


### PR DESCRIPTION
Closes #24353.

### Problem
`DataFrame.to_arrow()` (and other Arrow export paths) panicked when a column — or a nested field — had a name containing an interior null byte:

```python
pl.DataFrame({"a\x00b": [1]}).to_arrow()
# thread panicked at crates/polars-arrow/src/ffi/schema.rs:
# called `Result::unwrap()` on an `Err` value: NulError(...)
```

Arrow C data interface names are null-terminated C strings, so such a name is genuinely unrepresentable — but it should surface as a clean error, not a panic.

### Fix
- Add `try_export_field_to_c` in `polars-arrow`, which validates field names recursively (including `Struct`/`List`/`Map`/`Union`/`Dictionary` children) and returns a `ComputeError` instead of panicking.
- Route the user-facing export paths (`to_py_array`, `to_py_rb`, `polars_schema_to_pycapsule`, series C-interface) through it.
- The infallible `export_field_to_c` is retained for the `extern "C"` callback paths, which cannot propagate a `Result` and only ever handle Polars-generated (null-free) names.

### Result
```python
>>> pl.DataFrame({"a\x00b": [1]}).to_arrow()
ComputeError: cannot export field with name "a\0cd" to Arrow: names may not contain null bytes
```

### Verified locally
- `pytest tests/unit/interop/test_interop.py -k "to_arrow"` passes (new test covers top-level and nested names).
- Normal `to_arrow()` and pyarrow C-stream roundtrip unaffected.
- `polars-arrow` clippy + `cargo fmt --check` clean.