### PR TITLE
fix(python): Modify list function so first argument is positional-only

### DIFF
--- a/py-polars/src/polars/functions/as_datatype.py
+++ b/py-polars/src/polars/functions/as_datatype.py
@@ -500,7 +500,7 @@ def concat_list(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> 
     return wrap_expr(plr.concat_list(exprs))
 
 
-def list(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr:
+def list(exprs: IntoExpr | Iterable[IntoExpr], /, *more_exprs: IntoExpr) -> Expr:
     """
     Collect columns into a list column, treating each expression's value as one element.
 


### PR DESCRIPTION
This makes the api more resilient, allowing us to change the name of the `exprs` identifier in the future and it not being breaking to users. Inspired in https://github.com/pola-rs/polars/pull/27990#issuecomment-4910551569

Small enough I didn't bother with a test or issue.

@MarcoGorelli just merged this code a few days ago in https://github.com/pola-rs/polars/pull/27990, so I don't think this has been released yet to users. They are probably the best one to review it.