### PR TITLE
fix: Rewrite with_columns on empty df to select during DSL -> IR

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -702,6 +702,20 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             exprs,
             options,
         } => {
+            // The (0, 0) DataFrame is an exception - with_columns on it acts like select.
+            if let DslPlan::DataFrameScan { df, schema: _ } = input.as_ref() {
+                if df.shape() == (0, 0) {
+                    return to_alp_impl(
+                        DslPlan::Select {
+                            expr: exprs,
+                            input,
+                            options,
+                        },
+                        ctxt,
+                    );
+                }
+            }
+
             let input = to_alp_impl(owned(input), ctxt)
                 .map_err(|e| e.context(failed_here!(with_columns)))?;
             let (exprs, schema) =

--- a/py-polars/tests/unit/operations/test_with_columns.py
+++ b/py-polars/tests/unit/operations/test_with_columns.py
@@ -177,3 +177,13 @@ def test_with_columns_scalar_20981() -> None:
     lf = pl.LazyFrame({"a": [1.0, 2.0, 3.0]})
     assert_frame_equal(lf.with_columns(a=2.0).collect(), expected)
     assert_frame_equal(lf.with_columns(pl.col.a.mean()).collect(), expected)
+
+
+def test_lazy_with_columns_to_select_28285() -> None:
+    out = (
+        pl.LazyFrame()
+        .with_columns(a=pl.int_range(5))
+        .with_columns(a=pl.lit(2, dtype=pl.Int64))
+    )
+    expected = pl.LazyFrame({"a": [2, 2, 2, 2, 2]})
+    assert_frame_equal(out, expected)


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/28285.

Should also simplify future implementation by not having to deal with the empty LazyFrame exception downstream anymore.