### PR TITLE
fix(rust): Apply same type coercion to IsBetween as binary comparisons

### DIFF
--- a/crates/polars-plan/src/plans/conversion/type_coercion/binary.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/binary.rs
@@ -115,6 +115,119 @@ fn err_date_str_compare() -> PolarsResult<()> {
     }
 }
 
+pub(super) fn coerced_binop_dtype(
+    expr_arena: &Arena<AExpr>,
+    node_left: Node,
+    type_left: &DataType,
+    op: Operator,
+    node_right: Node,
+    type_right: &DataType,
+) -> PolarsResult<Option<DataType>> {
+    let left = expr_arena.get(node_left);
+    let right = expr_arena.get(node_right);
+
+    use DataType::*;
+    // don't coerce string with number comparisons. They must error
+    match (&type_left, &type_right, op) {
+        #[cfg(not(feature = "dtype-categorical"))]
+        (DataType::String, dt, op) | (dt, DataType::String, op)
+            if op.is_comparison_or_bitwise() && dt.is_primitive_numeric() =>
+        {
+            return Ok(None);
+        },
+        #[cfg(feature = "dtype-categorical")]
+        (String | Unknown(UnknownKind::Str) | Categorical(_, _), dt, op)
+        | (dt, Unknown(UnknownKind::Str) | String | Categorical(_, _), op)
+            if op.is_comparison_or_bitwise() && dt.is_primitive_numeric() =>
+        {
+            return Ok(None);
+        },
+        #[cfg(feature = "dtype-categorical")]
+        (Unknown(UnknownKind::Str) | String | Enum(_, _), dt, op)
+        | (dt, Unknown(UnknownKind::Str) | String | Enum(_, _), op)
+            if op.is_comparison_or_bitwise() && dt.is_primitive_numeric() =>
+        {
+            return Ok(None);
+        },
+        #[cfg(feature = "dtype-date")]
+        (Date, String | Unknown(UnknownKind::Str), op)
+        | (String | Unknown(UnknownKind::Str), Date, op)
+            if op.is_comparison_or_bitwise() =>
+        {
+            err_date_str_compare()?
+        },
+        #[cfg(feature = "dtype-datetime")]
+        (Datetime(_, _), String | Unknown(UnknownKind::Str), op)
+        | (String | Unknown(UnknownKind::Str), Datetime(_, _), op)
+            if op.is_comparison_or_bitwise() =>
+        {
+            err_date_str_compare()?
+        },
+        #[cfg(feature = "dtype-time")]
+        (Time | Unknown(UnknownKind::Str), String, op) if op.is_comparison_or_bitwise() => {
+            err_date_str_compare()?
+        },
+        // structs can be arbitrarily nested, leave the complexity to the caller for now.
+        #[cfg(feature = "dtype-struct")]
+        (Struct(_), Struct(_), _op) => return Ok(None),
+        _ => {},
+    }
+
+    if op.is_arithmetic() {
+        match (&type_left, &type_right) {
+            (Duration(_), Duration(_)) => return Ok(None),
+            (Duration(_), r) if r.is_primitive_numeric() => return Ok(None),
+            (String, a) | (a, String) if a.is_primitive_numeric() => {
+                let fmt_side = |node: Node, ae: &AExpr| -> std::string::String {
+                    if let AExpr::Column(name) = ae {
+                        format!(" column '{name}'")
+                    } else {
+                        format!(" expression `{}`", node_to_expr(node, expr_arena))
+                    }
+                };
+                let lhs = fmt_side(node_left, left);
+                let rhs = fmt_side(node_right, right);
+                polars_bail!(
+                    InvalidOperation:
+                    "arithmetic on dtypes {type_left} and {type_right} is not allowed \
+                    (lhs:{lhs}, rhs:{rhs}); try an explicit cast first",
+                )
+            },
+            (Datetime(_, _), _)
+            | (_, Datetime(_, _))
+            | (Date, _)
+            | (_, Date)
+            | (Duration(_), _)
+            | (_, Duration(_))
+            | (Time, _)
+            | (_, Time)
+            | (List(_), _)
+            | (_, List(_)) => return Ok(None),
+            #[cfg(feature = "dtype-array")]
+            (Array(..), _) | (_, Array(..)) => return Ok(None),
+            _ => {},
+        }
+    } else if compares_cat_to_string(type_left, type_right, op) {
+        return Ok(None);
+    }
+
+    // Coerce types:
+    let st = unpack!(get_supertype(type_left, type_right));
+    let mut st = modify_supertype(st, left, right, type_left, type_right);
+
+    if is_cat_str_binary(type_left, type_right) {
+        st = String
+    }
+
+    // TODO! raise here?
+    // We should at least never cast to Unknown.
+    if matches!(st, DataType::Unknown(_)) {
+        return Ok(None);
+    }
+
+    Ok(Some(st))
+}
+
 pub(super) fn process_binary(
     expr_arena: &mut Arena<AExpr>,
     input_schema: &Schema,
@@ -122,6 +235,8 @@ pub(super) fn process_binary(
     op: Operator,
     node_right: Node,
 ) -> PolarsResult<Option<AExpr>> {
+    use DataType::*;
+
     let (left, type_left): (&AExpr, DataType) =
         unpack!(get_aexpr_and_type(expr_arena, node_left, input_schema));
     let (right, type_right): (&AExpr, DataType) =
@@ -212,113 +327,27 @@ pub(super) fn process_binary(
 
     unpack!(early_escape(&type_left, &type_right));
 
-    let left = expr_arena.get(node_left);
-    let right = expr_arena.get(node_right);
-
-    use DataType::*;
-    // don't coerce string with number comparisons. They must error
-    match (&type_left, &type_right, op) {
-        #[cfg(not(feature = "dtype-categorical"))]
-        (DataType::String, dt, op) | (dt, DataType::String, op)
-            if op.is_comparison_or_bitwise() && dt.is_primitive_numeric() =>
-        {
-            return Ok(None);
-        },
-        #[cfg(feature = "dtype-categorical")]
-        (String | Unknown(UnknownKind::Str) | Categorical(_, _), dt, op)
-        | (dt, Unknown(UnknownKind::Str) | String | Categorical(_, _), op)
-            if op.is_comparison_or_bitwise() && dt.is_primitive_numeric() =>
-        {
-            return Ok(None);
-        },
-        #[cfg(feature = "dtype-categorical")]
-        (Unknown(UnknownKind::Str) | String | Enum(_, _), dt, op)
-        | (dt, Unknown(UnknownKind::Str) | String | Enum(_, _), op)
-            if op.is_comparison_or_bitwise() && dt.is_primitive_numeric() =>
-        {
-            return Ok(None);
-        },
-        #[cfg(feature = "dtype-date")]
-        (Date, String | Unknown(UnknownKind::Str), op)
-        | (String | Unknown(UnknownKind::Str), Date, op)
-            if op.is_comparison_or_bitwise() =>
-        {
-            err_date_str_compare()?
-        },
-        #[cfg(feature = "dtype-datetime")]
-        (Datetime(_, _), String | Unknown(UnknownKind::Str), op)
-        | (String | Unknown(UnknownKind::Str), Datetime(_, _), op)
-            if op.is_comparison_or_bitwise() =>
-        {
-            err_date_str_compare()?
-        },
-        #[cfg(feature = "dtype-time")]
-        (Time | Unknown(UnknownKind::Str), String, op) if op.is_comparison_or_bitwise() => {
-            err_date_str_compare()?
-        },
-        // structs can be arbitrarily nested, leave the complexity to the caller for now.
-        #[cfg(feature = "dtype-struct")]
-        (Struct(_), Struct(_), _op) => return Ok(None),
-        _ => {},
+    #[cfg(feature = "dtype-struct")]
+    if op.is_arithmetic()
+        && matches!(
+            (&type_left, &type_right),
+            (DataType::Struct(_), a) | (a, DataType::Struct(_))
+                if a.is_primitive_numeric()
+        )
+    {
+        return process_struct_numeric_arithmetic(
+            type_left, type_right, node_left, node_right, op, expr_arena,
+        );
     }
 
-    if op.is_arithmetic() {
-        match (&type_left, &type_right) {
-            (Duration(_), Duration(_)) => return Ok(None),
-            (Duration(_), r) if r.is_primitive_numeric() => return Ok(None),
-            (String, a) | (a, String) if a.is_primitive_numeric() => {
-                let fmt_side = |node: Node, ae: &AExpr| -> std::string::String {
-                    if let AExpr::Column(name) = ae {
-                        format!(" column '{name}'")
-                    } else {
-                        format!(" expression `{}`", node_to_expr(node, expr_arena))
-                    }
-                };
-                let lhs = fmt_side(node_left, left);
-                let rhs = fmt_side(node_right, right);
-                polars_bail!(
-                    InvalidOperation:
-                    "arithmetic on dtypes {type_left} and {type_right} is not allowed \
-                    (lhs:{lhs}, rhs:{rhs}); try an explicit cast first",
-                )
-            },
-            (Datetime(_, _), _)
-            | (_, Datetime(_, _))
-            | (Date, _)
-            | (_, Date)
-            | (Duration(_), _)
-            | (_, Duration(_))
-            | (Time, _)
-            | (_, Time)
-            | (List(_), _)
-            | (_, List(_)) => return Ok(None),
-            #[cfg(feature = "dtype-array")]
-            (Array(..), _) | (_, Array(..)) => return Ok(None),
-            #[cfg(feature = "dtype-struct")]
-            (Struct(_), a) | (a, Struct(_)) if a.is_primitive_numeric() => {
-                return process_struct_numeric_arithmetic(
-                    type_left, type_right, node_left, node_right, op, expr_arena,
-                );
-            },
-            _ => {},
-        }
-    } else if compares_cat_to_string(&type_left, &type_right, op) {
-        return Ok(None);
-    }
-
-    // Coerce types:
-    let st = unpack!(get_supertype(&type_left, &type_right));
-    let mut st = modify_supertype(st, left, right, &type_left, &type_right);
-
-    if is_cat_str_binary(&type_left, &type_right) {
-        st = String
-    }
-
-    // TODO! raise here?
-    // We should at least never cast to Unknown.
-    if matches!(st, DataType::Unknown(_)) {
-        return Ok(None);
-    }
+    let st = unpack!(coerced_binop_dtype(
+        expr_arena,
+        node_left,
+        &type_left,
+        op,
+        node_right,
+        &type_right,
+    )?);
 
     // Only cast if the type is not already the super type.
     // this can prevent an expensive flattening and subsequent aggregation

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -364,6 +364,11 @@ impl OptimizationRule for TypeCoercionRule {
                         right: new_high.unwrap_or(high).node(),
                     },
                     None => {
+                        let CastingRules::Supertype(supertype_options) =
+                            unpack!(options.cast_options)
+                        else {
+                            return Ok(None);
+                        };
                         let mut low = new_low.unwrap_or(low);
                         let mut high = new_high.unwrap_or(high);
 
@@ -388,11 +393,6 @@ impl OptimizationRule for TypeCoercionRule {
                             &high_dtype,
                         )?);
 
-                        let CastingRules::Supertype(supertype_options) =
-                            unpack!(options.cast_options)
-                        else {
-                            return Ok(None);
-                        };
                         let super_type = unpack!(get_supertype_with_options(
                             &low_st,
                             &high_st,

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -249,6 +249,7 @@ impl OptimizationRule for TypeCoercionRule {
 
                 use crate::plans::type_coercion::binary::{
                     BoolValueAlways, CmpLiteralRhsRewrite, coerce_comparison_literal,
+                    coerced_binop_dtype,
                 };
 
                 let [needle, low, high] = input.as_slice() else {
@@ -285,14 +286,16 @@ impl OptimizationRule for TypeCoercionRule {
                 {
                     use crate::plans::type_coercion::binary::BoolValueAlways;
 
-                    if let LiteralValue::Scalar(lit) = lv.clone().materialize() {
-                        match unpack!(coerce_comparison_literal(
+                    if let LiteralValue::Scalar(lit) = lv.clone().materialize()
+                        && let Some(rewrite) = coerce_comparison_literal(
                             needle.node(),
                             &needle_dtype,
                             cmp_op_low,
                             lit,
                             expr_arena,
-                        )) {
+                        )
+                    {
+                        match rewrite {
                             ReplaceLit(new_lit) => {
                                 new_low = Some(ExprIR::from_node(
                                     expr_arena.add(AExpr::Literal(LiteralValue::Scalar(new_lit))),
@@ -319,14 +322,16 @@ impl OptimizationRule for TypeCoercionRule {
                 if high_dtype != needle_dtype
                     && let AExpr::Literal(lv) = high_ae
                 {
-                    if let LiteralValue::Scalar(lit) = lv.clone().materialize() {
-                        match unpack!(coerce_comparison_literal(
+                    if let LiteralValue::Scalar(lit) = lv.clone().materialize()
+                        && let Some(rewrite) = coerce_comparison_literal(
                             needle.node(),
                             &needle_dtype,
                             cmp_op_high,
                             lit,
                             expr_arena,
-                        )) {
+                        )
+                    {
+                        match rewrite {
                             ReplaceLit(new_lit) => {
                                 new_high = Some(ExprIR::from_node(
                                     expr_arena.add(AExpr::Literal(LiteralValue::Scalar(new_lit))),
@@ -359,12 +364,74 @@ impl OptimizationRule for TypeCoercionRule {
                         right: new_high.unwrap_or(high).node(),
                     },
                     None => {
-                        if new_low.is_none() && new_high.is_none() {
-                            return Ok(None);
-                        }
+                        let mut low = new_low.unwrap_or(low);
+                        let mut high = new_high.unwrap_or(high);
 
+                        let low_dtype = unpack!(try_get_dtype(expr_arena, low.node(), schema).ok());
+                        let high_dtype =
+                            unpack!(try_get_dtype(expr_arena, high.node(), schema).ok());
+
+                        let low_st = unpack!(coerced_binop_dtype(
+                            expr_arena,
+                            needle.node(),
+                            &needle_dtype,
+                            cmp_op_low,
+                            low.node(),
+                            &low_dtype,
+                        )?);
+                        let high_st = unpack!(coerced_binop_dtype(
+                            expr_arena,
+                            needle.node(),
+                            &needle_dtype,
+                            cmp_op_high,
+                            high.node(),
+                            &high_dtype,
+                        )?);
+
+                        let CastingRules::Supertype(supertype_options) =
+                            unpack!(options.cast_options)
+                        else {
+                            return Ok(None);
+                        };
+                        let super_type = unpack!(get_supertype_with_options(
+                            &low_st,
+                            &high_st,
+                            supertype_options,
+                        ));
+
+                        let mut needle = needle;
+                        // TODO: NonStrict casts are what process_binary
+                        // inserts for binops. cast_expr_ir always ignores
+                        // the input CastOptions and sets strict casts.
+                        // Should probably be consistent.
+                        cast_expr_ir(
+                            &mut needle,
+                            &needle_dtype,
+                            &super_type,
+                            expr_arena,
+                            CastOptions::NonStrict,
+                        )?;
+                        cast_expr_ir(
+                            &mut low,
+                            &low_dtype,
+                            &super_type,
+                            expr_arena,
+                            CastOptions::NonStrict,
+                        )?;
+                        cast_expr_ir(
+                            &mut high,
+                            &high_dtype,
+                            &super_type,
+                            expr_arena,
+                            CastOptions::NonStrict,
+                        )?;
+                        // We've already applied all the casts, so switch
+                        // off casting for this newly rewritten isbetween
+                        // node.
+                        let mut options = options;
+                        options.cast_options = None;
                         AExpr::Function {
-                            input: vec![needle, new_low.unwrap_or(low), new_high.unwrap_or(high)],
+                            input: vec![needle, low, high],
                             function: IRFunctionExpr::Boolean(IRBooleanFunction::IsBetween {
                                 closed,
                             }),

--- a/py-polars/tests/unit/operations/test_comparison.py
+++ b/py-polars/tests/unit/operations/test_comparison.py
@@ -10,7 +10,7 @@ import pytest
 
 import polars as pl
 from polars.datatypes.group import INTEGER_DTYPES
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -1114,3 +1114,62 @@ def test_comparison_literal_downcast_rewrites() -> None:
         pl.col("u16").is_between(1 << 16, 1 << 17),
         'when(col("u16").is_not_null()).then(false).otherwise(null)',
     )
+
+
+def test_is_between_coerces_dynamic_float_bounds_28278() -> None:
+    # These are distinct in float64, but the same in float32
+    x = 1.0000001192092896  # == 1 + eps_f32
+    lower_bound = 1.00000015  # < 1 + 2*eps_f32
+
+    q = pl.LazyFrame({"x": [x]}, schema={"x": pl.Float32}).select(
+        binary=pl.col("x") >= lower_bound,
+        is_between=pl.col("x").is_between(lower_bound, 2.0),
+    )
+
+    assert q.collect().row(0) == (True, True)
+    assert "dyn float" not in q.explain()
+
+    q_f64 = pl.LazyFrame({"x": [x]}, schema={"x": pl.Float64}).select(
+        binary=pl.col("x") >= lower_bound,
+        is_between=pl.col("x").is_between(lower_bound, 2.0),
+    )
+    assert q_f64.collect().row(0) == (False, False)
+    assert "dyn float" not in q_f64.explain()
+
+
+def test_is_between_coerces_dynamic_numeric_bounds() -> None:
+    q = pl.LazyFrame(
+        {"x": [0.5, 3.5, 7.5]},
+        schema={"x": pl.Float64},
+    ).select(
+        integer_bounds=pl.col("x").is_between(3, 7),
+        mixed_bounds=pl.col("x").is_between(3, 7.0),
+    )
+
+    plan = q.explain()
+    assert "dyn int" not in plan
+    assert "dyn float" not in plan
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            {
+                "integer_bounds": [False, True, False],
+                "mixed_bounds": [False, True, False],
+            }
+        ),
+    )
+
+
+@pytest.mark.parametrize("dtype", [pl.Date(), pl.Datetime("us")])
+def test_is_between_rejects_datetime_string_28253(dtype: pl.DataType) -> None:
+    df = pl.LazyFrame({"value": []}, schema={"value": dtype})
+
+    q = df.select(
+        pl.col("value").is_between(pl.lit("2000-01-01"), pl.lit("2000-01-02"))
+    )
+
+    with pytest.raises(
+        InvalidOperationError,
+        match="cannot compare 'date/datetime/time' to a string value",
+    ):
+        q.explain()


### PR DESCRIPTION
Previously, IsBetween had special type coercion rules. This could lead to
some odd behaviour where two equivalent looking expressions would result in
different answers depending on whether they were phrased as binary
expressions or IsBetween comparisons. To fix this, apply the same casting
rules to IsBetween as are applied to binary comparisons.

Consider an expression a.is_between(b, c). After special case handling to
treat bounds that must be always true or false, we now coerce this
comparison to be on supertype(supertype(a, b), supertype(a, c)), matching
the equivalent binary expression b <= a <= c.

- Closes https://github.com/pola-rs/polars/issues/28278
- Closes https://github.com/pola-rs/polars/issues/28253