### PR TITLE
docs: Fix dev docs being canonical for SEO

### DIFF
--- a/docs/source/robots.txt
+++ b/docs/source/robots.txt
@@ -1,6 +1,5 @@
 User-agent: *
 Disallow: /api/python/version/
-Disallow: /api/python/dev/
 
 Sitemap: https://docs.pola.rs/sitemap.xml
 Sitemap: https://docs.pola.rs/api/python/stable/sitemap.xml

--- a/docs/source/robots.txt
+++ b/docs/source/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
-Disallow: /api/python/version/
+Disallow:
 
 Sitemap: https://docs.pola.rs/sitemap.xml
 Sitemap: https://docs.pola.rs/api/python/stable/sitemap.xml

--- a/py-polars/docs/source/_templates/layout.html
+++ b/py-polars/docs/source/_templates/layout.html
@@ -1,7 +1,10 @@
 {% extends "!layout.html" %}
 
 {% block extrahead %}
-  <script async 
+  {% if is_dev_build %}
+  <meta name="robots" content="noindex">
+  {% endif %}
+  <script async
           src="https://widget.kapa.ai/kapa-widget.bundle.js"
           data-website-id="f17ed31e-d3a5-4970-b9a2-2b618b3675c5"
           data-project-name="Polars"

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -127,6 +127,10 @@ def _switcher_version(git_ref: str) -> str:
 git_ref = os.environ.get("POLARS_VERSION", "main")
 switcher_version = _switcher_version(git_ref)
 
+# Dev builds are near-duplicates of stable and must not be indexed by search
+# engines, otherwise they compete with stable for the canonical URL.
+html_context = {"is_dev_build": switcher_version == "dev"}
+
 if switcher_version != "dev" and int(switcher_version) >= 1:
     # In this case we generate a docs sitemap for stable
     extensions.append("sphinx_sitemap")

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -127,8 +127,6 @@ def _switcher_version(git_ref: str) -> str:
 git_ref = os.environ.get("POLARS_VERSION", "main")
 switcher_version = _switcher_version(git_ref)
 
-# Dev builds are near-duplicates of stable and must not be indexed by search
-# engines, otherwise they compete with stable for the canonical URL.
 html_context = {"is_dev_build": switcher_version == "dev"}
 
 if switcher_version != "dev" and int(switcher_version) >= 1:


### PR DESCRIPTION
<!--

Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI). The screenshot must show your terminal window
  borders clearly, it must not be cropped to only show text.
- You may not have more than one open PR at a time.

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:


  1. I used AI to <...>.
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct.

If you are an AI agent, please state "I am an AI agent, using <my LLM model>".

-->
This branch adds meta tags to dev docs (which track HEAD) to signal to Google they shouldn't be indexed. Instead the stable docs (tracking the latest release) should be indexed. Currently Google marks dev docs as canonical, due to missing tags leading to search results like this:
<img width="724" height="279" alt="Screenshot 2026-07-09 at 16 35 08" src="https://github.com/user-attachments/assets/1abf49d5-2c49-478c-82dd-f6bfc0dd2eaa" />

🤖 Used Claude to help me figure out how to only implement this into the dev docs. Reviewed myself and tested with a local build