### PR TITLE
feat(python): More accurate rolling moments

### DIFF
--- a/crates/polars-compute/src/moment.rs
+++ b/crates/polars-compute/src/moment.rs
@@ -99,18 +99,6 @@ impl VarState {
         self.clear_zero_weight_nan();
     }
 
-    pub fn remove_one(&mut self, x: f64) {
-        // Just a specialized version of
-        // self.combine(&Self { weight: -1.0, mean: x, dp: 0.0 })
-        let new_weight = self.weight - 1.0;
-        let delta_mean = x - self.mean;
-        let new_mean = self.mean - delta_mean / new_weight;
-        self.dp -= (x - new_mean) * delta_mean;
-        self.weight = new_weight;
-        self.mean = new_mean;
-        self.clear_zero_weight_nan();
-    }
-
     pub fn combine(&mut self, other: &Self) {
         if other.weight == 0.0 {
             return;
@@ -375,25 +363,6 @@ impl SkewState {
         self.clear_zero_weight_nan();
     }
 
-    pub fn remove_one(&mut self, x: f64) {
-        // Specialization of self.combine(&SkewState { weight: -1.0, mean: x, m2: 0.0, m3: 0.0 });
-        let new_weight = self.weight - 1.0;
-        let delta_mean = x - self.mean;
-        let delta_mean_weight = delta_mean / new_weight;
-        let new_mean = self.mean - delta_mean_weight;
-
-        let weight_diff = self.weight + 1.0;
-        let m2_update = (new_mean - x) * delta_mean;
-        let new_m2 = self.m2 + m2_update;
-        let new_m3 = self.m3 + delta_mean_weight * (m2_update * weight_diff + 3.0 * self.m2);
-
-        self.weight = new_weight;
-        self.mean = new_mean;
-        self.m2 = new_m2;
-        self.m3 = new_m3;
-        self.clear_zero_weight_nan();
-    }
-
     pub fn combine(&mut self, other: &Self) {
         if other.weight == 0.0 {
             return;
@@ -533,31 +502,6 @@ impl KurtosisState {
                 * (delta_mean_weight
                     * (m2_update * (self.weight * weight_diff + 1.0) + 6.0 * self.m2)
                     - 4.0 * self.m3);
-
-        self.weight = new_weight;
-        self.mean = new_mean;
-        self.m2 = new_m2;
-        self.m3 = new_m3;
-        self.m4 = new_m4;
-        self.clear_zero_weight_nan();
-    }
-
-    pub fn remove_one(&mut self, x: f64) {
-        // Specialization of self.combine(&KurtosisState { weight: -1.0, mean: x, m2: 0.0, m3: 0.0, m4: 0.0 });
-        let new_weight = self.weight - 1.0;
-        let delta_mean = x - self.mean;
-        let delta_mean_weight = delta_mean / new_weight;
-        let new_mean = self.mean - delta_mean_weight;
-
-        let weight_diff = self.weight + 1.0;
-        let m2_update = (new_mean - x) * delta_mean;
-        let new_m2 = self.m2 + m2_update;
-        let new_m3 = self.m3 + delta_mean_weight * (m2_update * weight_diff + 3.0 * self.m2);
-        let new_m4 = self.m4
-            + delta_mean_weight
-                * (delta_mean_weight
-                    * (m2_update * (self.weight * weight_diff + 1.0) + 6.0 * self.m2)
-                    + 4.0 * self.m3);
 
         self.weight = new_weight;
         self.mean = new_mean;

--- a/crates/polars-compute/src/rolling/moment.rs
+++ b/crates/polars-compute/src/rolling/moment.rs
@@ -5,20 +5,21 @@ use super::nulls::RollingAggWindowNulls;
 use super::*;
 use crate::moment::{KurtosisState, SkewState, VarState};
 
-pub trait StateUpdate {
+pub trait RollingMomentAlgo {
+    type State: Default + Clone;
     fn new(params: Option<RollingFnParams>) -> Self;
-    fn reset(&mut self);
-    fn insert_one(&mut self, x: f64);
-    fn remove_one(&mut self, x: f64);
-    fn finalize(&self) -> Option<f64>;
+    fn insert_one(state: &mut Self::State, x: f64);
+    fn combine(state: &mut Self::State, other: &Self::State);
+    fn finalize(&self, state: &Self::State) -> Option<f64>;
 }
 
 pub struct VarianceMoment {
-    state: VarState,
     ddof: u8,
 }
 
-impl StateUpdate for VarianceMoment {
+impl RollingMomentAlgo for VarianceMoment {
+    type State = VarState;
+
     fn new(params: Option<RollingFnParams>) -> Self {
         let ddof = if let Some(RollingFnParams::Var(params)) = params {
             params.ddof
@@ -26,40 +27,33 @@ impl StateUpdate for VarianceMoment {
             1
         };
 
-        Self {
-            state: VarState::default(),
-            ddof,
-        }
+        Self { ddof }
     }
 
     #[inline(always)]
-    fn reset(&mut self) {
-        self.state = VarState::default();
+    fn insert_one(state: &mut Self::State, x: f64) {
+        state.insert_one(x);
     }
 
     #[inline(always)]
-    fn insert_one(&mut self, x: f64) {
-        self.state.insert_one(x);
+    fn combine(state: &mut Self::State, other: &Self::State) {
+        state.combine(other);
     }
 
     #[inline(always)]
-    fn remove_one(&mut self, x: f64) {
-        self.state.remove_one(x);
-    }
-
-    #[inline(always)]
-    fn finalize(&self) -> Option<f64> {
-        self.state.finalize(self.ddof)
+    fn finalize(&self, state: &Self::State) -> Option<f64> {
+        state.finalize(self.ddof)
     }
 }
 
 pub struct KurtosisMoment {
-    state: KurtosisState,
     fisher: bool,
     bias: bool,
 }
 
-impl StateUpdate for KurtosisMoment {
+impl RollingMomentAlgo for KurtosisMoment {
+    type State = KurtosisState;
+
     fn new(params: Option<RollingFnParams>) -> Self {
         let (fisher, bias) = if let Some(RollingFnParams::Kurtosis { fisher, bias }) = params {
             (fisher, bias)
@@ -67,40 +61,32 @@ impl StateUpdate for KurtosisMoment {
             (false, false)
         };
 
-        Self {
-            state: KurtosisState::default(),
-            fisher,
-            bias,
-        }
+        Self { fisher, bias }
     }
 
     #[inline(always)]
-    fn reset(&mut self) {
-        self.state = KurtosisState::default();
+    fn insert_one(state: &mut Self::State, x: f64) {
+        state.insert_one(x);
     }
 
     #[inline(always)]
-    fn insert_one(&mut self, x: f64) {
-        self.state.insert_one(x);
+    fn combine(state: &mut Self::State, other: &Self::State) {
+        state.combine(other);
     }
 
     #[inline(always)]
-    fn remove_one(&mut self, x: f64) {
-        self.state.remove_one(x);
-    }
-
-    #[inline(always)]
-    fn finalize(&self) -> Option<f64> {
-        self.state.finalize(self.fisher, self.bias)
+    fn finalize(&self, state: &Self::State) -> Option<f64> {
+        state.finalize(self.fisher, self.bias)
     }
 }
 
 pub struct SkewMoment {
-    state: SkewState,
     bias: bool,
 }
 
-impl StateUpdate for SkewMoment {
+impl RollingMomentAlgo for SkewMoment {
+    type State = SkewState;
+
     fn new(params: Option<RollingFnParams>) -> Self {
         let bias = if let Some(RollingFnParams::Skew { bias }) = params {
             bias
@@ -108,34 +94,26 @@ impl StateUpdate for SkewMoment {
             false
         };
 
-        Self {
-            state: SkewState::default(),
-            bias,
-        }
+        Self { bias }
     }
 
     #[inline(always)]
-    fn reset(&mut self) {
-        self.state = SkewState::default();
+    fn insert_one(state: &mut Self::State, x: f64) {
+        state.insert_one(x);
     }
 
     #[inline(always)]
-    fn insert_one(&mut self, x: f64) {
-        self.state.insert_one(x);
+    fn combine(state: &mut Self::State, other: &Self::State) {
+        state.combine(other);
     }
 
     #[inline(always)]
-    fn remove_one(&mut self, x: f64) {
-        self.state.remove_one(x);
-    }
-
-    #[inline(always)]
-    fn finalize(&self) -> Option<f64> {
-        self.state.finalize(self.bias)
+    fn finalize(&self, state: &Self::State) -> Option<f64> {
+        state.finalize(self.bias)
     }
 }
 
-pub struct MomentWindow<'a, T, M: StateUpdate> {
+pub struct MomentWindow<'a, T, M: RollingMomentAlgo> {
     slice: &'a [T],
     validity: Option<&'a Bitmap>,
     moment: M,
@@ -143,12 +121,15 @@ pub struct MomentWindow<'a, T, M: StateUpdate> {
     null_count: usize,
     start: usize,
     end: usize,
+    front: Vec<M::State>,
+    back: Vec<f64>,
+    agg_back: M::State,
 }
 
 impl<'a, T, M> MomentWindow<'a, T, M>
 where
     T: NativeType + ToPrimitive + IsFloat + FromPrimitive,
-    M: StateUpdate,
+    M: RollingMomentAlgo,
 {
     fn new_impl(
         slice: &'a [T],
@@ -163,44 +144,65 @@ where
             null_count: 0,
             start: 0,
             end: 0,
+            front: Vec::new(),
+            back: Vec::new(),
+            agg_back: M::State::default(),
         }
     }
 
     #[inline(always)]
     fn reset(&mut self) {
-        self.moment.reset();
         self.non_finite_count = 0;
         self.null_count = 0;
+        self.front.clear();
+        self.back.clear();
+        self.agg_back = M::State::default();
     }
 
     #[inline(always)]
-    fn insert(&mut self, val: T) {
+    fn push(&mut self, val: T) {
         if val.is_finite() {
-            self.moment.insert_one(NumCast::from(val).unwrap());
+            let x = NumCast::from(val).unwrap();
+            self.back.push(x);
+            M::insert_one(&mut self.agg_back, x);
         } else {
-            self.moment.insert_one(0.0); // A hack to replicate ddof null behavior.
+            // A hack to replicate ddof null behavior.
+            self.back.push(0.0);
+            M::insert_one(&mut self.agg_back, 0.0);
             self.non_finite_count += 1;
         }
     }
 
     #[inline(always)]
-    fn remove(&mut self, val: T) {
-        if val.is_finite() {
-            self.moment.remove_one(NumCast::from(val).unwrap());
-        } else {
-            self.moment.remove_one(0.0); // A hack to replicate ddof null behavior.
-            self.non_finite_count -= 1;
+    fn pop(&mut self, val: T) {
+        if self.front.is_empty() {
+            self.flip();
         }
+        self.front.pop();
+        self.non_finite_count -= !val.is_finite() as usize;
+    }
+
+    fn flip(&mut self) {
+        let mut agg = M::State::default();
+        while let Some(x) = self.back.pop() {
+            M::insert_one(&mut agg, x);
+            self.front.push(agg.clone());
+        }
+
+        self.agg_back = M::State::default();
     }
 
     #[inline(always)]
     fn get_moment(&self) -> Option<T> {
+        let mut state = self.agg_back.clone();
+        if let Some(front_agg) = self.front.last() {
+            M::combine(&mut state, front_agg);
+        }
+        let agg = self.moment.finalize(&state);
         if self.non_finite_count > 0 {
-            self.moment
-                .finalize()
-                .map(|_v| T::from_f64(f64::NAN).unwrap())
+            agg.map(|_v| T::from_f64(f64::NAN).unwrap())
         } else {
-            self.moment.finalize().map(|v| T::from_f64(v).unwrap())
+            agg.map(|v| T::from_f64(v).unwrap())
         }
     }
 }
@@ -208,7 +210,7 @@ where
 impl<T, M> RollingAggWindowNoNulls<T> for MomentWindow<'_, T, M>
 where
     T: NativeType + ToPrimitive + IsFloat + FromPrimitive,
-    M: StateUpdate,
+    M: RollingMomentAlgo,
 {
     type This<'a> = MomentWindow<'a, T, M>;
 
@@ -235,11 +237,11 @@ where
         }
 
         for val in &self.slice[self.start..new_start] {
-            self.remove(*val);
+            self.pop(*val);
         }
 
         for val in &self.slice[self.end..new_end] {
-            self.insert(*val);
+            self.push(*val);
         }
 
         self.start = new_start;
@@ -258,7 +260,7 @@ where
 impl<T, M> RollingAggWindowNulls<T> for MomentWindow<'_, T, M>
 where
     T: NativeType + ToPrimitive + IsFloat + FromPrimitive,
-    M: StateUpdate,
+    M: RollingMomentAlgo,
 {
     type This<'a> = MomentWindow<'a, T, M>;
 
@@ -292,7 +294,7 @@ where
         for idx in self.start..new_start {
             let valid = unsafe { validity.get_bit_unchecked(idx) };
             if valid {
-                self.remove(unsafe { *self.slice.get_unchecked(idx) });
+                self.pop(unsafe { *self.slice.get_unchecked(idx) });
             } else {
                 self.null_count -= 1;
             }
@@ -301,7 +303,7 @@ where
         for idx in self.end..new_end {
             let valid = unsafe { validity.get_bit_unchecked(idx) };
             if valid {
-                self.insert(unsafe { *self.slice.get_unchecked(idx) });
+                self.push(unsafe { *self.slice.get_unchecked(idx) });
             } else {
                 self.null_count += 1;
             }

--- a/crates/polars-compute/src/rolling/no_nulls/moment.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/moment.rs
@@ -141,7 +141,7 @@ mod test {
                     Some(f64::nan()),
                     Some(f64::nan()),
                     Some(f64::nan()),
-                    Some(0.9999999999999911)
+                    Some(1.0)
                 ]
             )
         );

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -744,7 +744,7 @@ def test_rolling_cov_corr() -> None:
         pl.rolling_corr("x", "y", window_size=3).alias("corr"),
     ).to_dict(as_series=False)
     assert res["cov"][2:] == pytest.approx([0.0, 0.0, 5.333333333333336])
-    assert res["corr"][2:] == pytest.approx([nan, 0.0, 0.9176629354822473], nan_ok=True)
+    assert res["corr"][2:] == pytest.approx([nan, nan, 0.9176629354822473], nan_ok=True)
     assert res["cov"][:2] == [None] * 2
     assert res["corr"][:2] == [None] * 2
 


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/28290.
Fixes https://github.com/pola-rs/polars/issues/22099.

This now uses a two-stack algorithm that only ever adds values to aggregates and combines aggregates. We no longer simulate removal by adding one with weight -1, once a value falls outside the window it truly no longer affects the result whatsoever.

The trade-off is an extra `O(w)` memory usage, but runtime is still `O(n)`, not `O(nw)` which you would get by recomputing every window.

We might want to consider doing something similar for other rolling kernels.