### PR TITLE
fix(rust): Avoid dedup-name collision when a generated header already exists

### DIFF
--- a/crates/polars-io/src/csv/read/schema_inference.rs
+++ b/crates/polars-io/src/csv/read/schema_inference.rs
@@ -73,15 +73,27 @@ fn infer_headers(mut header_line: &[u8], parse_options: &CsvParseOptions) -> Vec
 
     let mut deduplicated_headers = Vec::with_capacity(headers.len());
     let mut header_names = PlHashMap::with_capacity(headers.len());
+    // Track every emitted name so a generated `_duplicated_N` name can't silently
+    // collide with a header that already appears earlier in the line (#28310).
+    let mut used: PlIndexSet<PlSmallStr> = PlIndexSet::with_capacity(headers.len());
 
     for name in &headers {
         let count = header_names.entry(name.as_ref()).or_insert(0usize);
-        if *count != 0 {
-            deduplicated_headers.push(format_pl_smallstr!("{}_duplicated_{}", name, *count - 1))
+        let mut new_name = if *count == 0 {
+            PlSmallStr::from_str(name)
         } else {
-            deduplicated_headers.push(PlSmallStr::from_str(name))
-        }
+            format_pl_smallstr!("{}_duplicated_{}", name, *count - 1)
+        };
         *count += 1;
+        // Keep bumping the suffix until the candidate is not already in use, so
+        // inputs like `a,a_duplicated_0,a` yield `a,a_duplicated_0,a_duplicated_1`
+        // instead of two columns sharing a name.
+        while used.contains(&new_name) {
+            new_name = format_pl_smallstr!("{}_duplicated_{}", name, *count - 1);
+            *count += 1;
+        }
+        used.insert(new_name.clone());
+        deduplicated_headers.push(new_name);
     }
 
     deduplicated_headers
@@ -366,5 +378,27 @@ mod tests {
         possibilities.insert(DataType::Int64);
         possibilities.insert(DataType::Int128);
         assert_eq!(finish_infer_field_schema(&possibilities), DataType::Int128);
+    }
+
+    #[test]
+    fn test_infer_headers_dedup_collision() {
+        let opts = CsvParseOptions::default();
+        let names = |line: &[u8]| {
+            infer_headers(line, &opts)
+                .iter()
+                .map(|s| s.as_str().to_string())
+                .collect::<Vec<_>>()
+        };
+
+        // A generated `_duplicated_N` name must not collide with an existing header (#28310).
+        assert_eq!(names(b"a,a_duplicated_0,a"), ["a", "a_duplicated_0", "a_duplicated_1"]);
+
+        // The reverse ordering must also stay collision-free (3 distinct names).
+        let reversed = names(b"a,a,a_duplicated_0");
+        assert_eq!(reversed.len(), 3);
+        assert_eq!(reversed.iter().collect::<PlHashSet<_>>().len(), 3);
+
+        // Regression guard: plain duplicates keep their existing numbering.
+        assert_eq!(names(b"x,x,y"), ["x", "x_duplicated_0", "y"]);
     }
 }

--- a/crates/polars-io/src/csv/read/schema_inference.rs
+++ b/crates/polars-io/src/csv/read/schema_inference.rs
@@ -391,7 +391,10 @@ mod tests {
         };
 
         // A generated `_duplicated_N` name must not collide with an existing header (#28310).
-        assert_eq!(names(b"a,a_duplicated_0,a"), ["a", "a_duplicated_0", "a_duplicated_1"]);
+        assert_eq!(
+            names(b"a,a_duplicated_0,a"),
+            ["a", "a_duplicated_0", "a_duplicated_1"]
+        );
 
         // The reverse ordering must also stay collision-free (3 distinct names).
         let reversed = names(b"a,a,a_duplicated_0");

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1532,6 +1532,20 @@ def test_duplicated_columns(chunk_override: None) -> None:
     assert pl.read_csv(csv.encode(), new_columns=new).columns == new
 
 
+def test_duplicated_columns_name_collision_28310() -> None:
+    # A generated `_duplicated_N` name must not collide with a header that already
+    # exists in the file, which previously raised "found more fields than defined".
+    assert pl.read_csv(io.StringIO("a,a_duplicated_0,a\n1,2,3")).columns == [
+        "a",
+        "a_duplicated_0",
+        "a_duplicated_1",
+    ]
+    # The reverse ordering must also stay collision-free (three distinct names).
+    cols = pl.read_csv(io.StringIO("a,a,a_duplicated_0\n1,2,3")).columns
+    assert len(cols) == 3
+    assert len(set(cols)) == 3
+
+
 def test_error_message(chunk_override: None) -> None:
     data = io.StringIO("target,wind,energy,miso\n1,2,3,4\n1,2,1e5,1\n")
     with pytest.raises(


### PR DESCRIPTION
Fixes #28310.

### Problem
When inferring CSV headers, duplicate names are renamed to `{name}_duplicated_{n}`. The generated name was never checked against names already present in the header, so a header that *already* contains such a name collides:

```python
import io, polars as pl
pl.read_csv(io.StringIO("a,a_duplicated_0,a\n1,2,3"))
# ComputeError: found more fields than defined in 'Schema'
```

The third column `a` (2nd occurrence) is renamed to `a_duplicated_0`, which already names column 2. The schema map collapses the two identical names into one field (2 fields) while the data has 3 columns → the error.

### Fix
Track every emitted name and keep bumping the suffix until the candidate is unused, so the example yields `a, a_duplicated_0, a_duplicated_1`. Headers that don't collide are unaffected (the new loop runs zero times).

### Tests
- Rust unit test in `polars-io` (`test_infer_headers_dedup_collision`) covering the collision, the reverse ordering, and a no-regression case.
- Python regression test in `tests/unit/io/test_csv.py` (`test_duplicated_columns_name_collision_28310`).
