### PR TITLE
fix(rust,python): don't drop broadcast holidays after a leading null in business day ops

### DIFF
--- a/crates/polars-ops/src/series/ops/business.rs
+++ b/crates/polars-ops/src/series/ops/business.rs
@@ -83,10 +83,14 @@ pub fn business_day_count(
 
     let out: ChunkedArray<Int32Type> = (0..output_height)
         .map(|i| {
+            // Advance the holidays getter first: it caches the broadcast row and
+            // must run for every `i` even when `start`/`end` are null, otherwise a
+            // leading null would leave the cache empty and later out-of-bounds rows
+            // would silently see no holidays (GH #28018).
+            let holidays = holidays_getter.holidays_at_idx_last_ret_on_oob(i)?;
             let start =
                 unsafe { start_dates.get_unchecked(if start_dates.len() == 1 { 0 } else { i }) }?;
             let end = unsafe { end_dates.get_unchecked(if end_dates.len() == 1 { 0 } else { i }) }?;
-            let holidays = holidays_getter.holidays_at_idx_last_ret_on_oob(i)?;
 
             Some(business_day_count_impl(
                 start,
@@ -273,11 +277,13 @@ pub fn add_business_days(
 
         (0..output_height)
             .map(|i| {
+                // Advance the holidays getter first so its broadcast cache is
+                // populated for every `i`, even when `start`/`n` are null (GH #28018).
+                let holidays_list = holidays_getter.holidays_at_idx_last_ret_on_oob(i)?;
                 let start = unsafe {
                     start_dates.get_unchecked(if start_dates.len() == 1 { 0 } else { i })
                 }?;
                 let n = unsafe { n.get_unchecked(if n.len() == 1 { 0 } else { i }) }?;
-                let holidays_list = holidays_getter.holidays_at_idx_last_ret_on_oob(i)?;
 
                 Some(roll_start_date(start, roll, &week_mask, holidays_list).map(
                     |(start, day_of_week)| {
@@ -413,8 +419,10 @@ pub fn is_business_day(
 
     let out: BooleanChunked = (0..output_height)
         .map(|i| {
-            let date = unsafe { dates.get_unchecked(if dates.len() == 1 { 0 } else { i }) }?;
+            // Advance the holidays getter first so its broadcast cache is populated
+            // for every `i`, even when `date` is null (GH #28018).
             let holidays_list = holidays_getter.holidays_at_idx_last_ret_on_oob(i)?;
+            let date = unsafe { dates.get_unchecked(if dates.len() == 1 { 0 } else { i }) }?;
 
             let day_of_week = get_day_of_week(date);
 

--- a/py-polars/tests/unit/functions/test_business_day_count.py
+++ b/py-polars/tests/unit/functions/test_business_day_count.py
@@ -120,6 +120,25 @@ def test_business_day_count_schema() -> None:
     assert 'col("start").business_day_count([col("end"), Series])' in result.explain()
 
 
+def test_business_day_count_leading_null_broadcast_holidays_28018() -> None:
+    # A leading null must not stop the broadcast holidays from applying to the
+    # remaining rows.
+    holiday = date(2023, 11, 23)  # Thanksgiving (Thursday)
+    end = date(2023, 11, 24)
+    df = pl.DataFrame(
+        {"start": [holiday, holiday], "end": [None, end]},
+        schema={"start": pl.Date, "end": pl.Date},
+    )
+    expr = pl.business_day_count("start", "end", holidays=[holiday])
+
+    result = df.select(expr).to_series()
+    # row 1: only business day in [23rd, 24th) is the 23rd, which is a holiday -> 0
+    assert result.to_list() == [None, 0]
+    # order must not matter
+    assert df.reverse().select(expr).to_series().to_list() == [0, None]
+    assert df.tail(1).select(expr).to_series().to_list() == [0]
+
+
 def test_business_day_count_w_holidays() -> None:
     df = pl.DataFrame(
         {

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_add_business_days.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_add_business_days.py
@@ -391,3 +391,17 @@ def test_against_np_busday_offset(
 def test_unequal_lengths_22018() -> None:
     with pytest.raises(pl.exceptions.ShapeError):
         pl.Series([date(2088, 8, 5)] * 2).dt.add_business_days(pl.Series([1] * 3))
+
+
+def test_add_business_days_leading_null_broadcast_holidays_28018() -> None:
+    # A leading null must not stop the broadcast holidays from applying to the
+    # remaining rows (see GH #28018 for business_day_count).
+    holiday = date(2020, 1, 2)  # Thursday
+    df = pl.DataFrame(
+        {"start": [None, date(2020, 1, 1)], "n": [1, 1]},
+        schema={"start": pl.Date, "n": pl.Int32},
+    )
+    expr = pl.col("start").dt.add_business_days(pl.col("n"), holidays=[holiday])
+    # from 2020-01-01 (Wed), one business day forward skipping the 2nd -> 2020-01-03
+    assert df.select(expr).to_series().to_list() == [None, date(2020, 1, 3)]
+    assert df.reverse().select(expr).to_series().to_list() == [date(2020, 1, 3), None]

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_is_business_day.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_is_business_day.py
@@ -221,3 +221,13 @@ def test_is_business_day_invalid_holidays() -> None:
 
 def test_is_business_day_repr() -> None:
     assert "is_business_day" in repr(pl.col("date").dt.is_business_day())
+
+
+def test_is_business_day_leading_null_broadcast_holidays_28018() -> None:
+    # A leading null must not stop the broadcast holidays from applying to the
+    # remaining rows (see GH #28018 for business_day_count).
+    holiday = date(2020, 1, 2)  # Thursday
+    df = pl.DataFrame({"date": [None, holiday]}, schema={"date": pl.Date})
+    expr = pl.col("date").dt.is_business_day(holidays=[holiday])
+    assert df.select(expr).to_series().to_list() == [None, False]
+    assert df.reverse().select(expr).to_series().to_list() == [False, None]


### PR DESCRIPTION
Fixes #28018.

`business_day_count` (and its siblings `add_business_days` / `is_business_day`) fetch the broadcast holidays for each row through `HolidayListsGetter`, which caches the single broadcast row on first access and returns that cache for every out-of-bounds index afterwards.

The per-row closures evaluated the `start`/`end`/`n`/`date` values with `?` *before* calling the holidays getter:

```rust
let start = start_dates.get_unchecked(...)?;   // null short-circuits the closure
let end   = end_dates.get_unchecked(...)?;     // null short-circuits the closure
let holidays = holidays_getter.holidays_at_idx_last_ret_on_oob(i)?;  // never reached
```

So when the **first** row has a null date, the closure returns early and the holidays getter is never advanced for `i = 0`. Its cache stays at its initial empty value, and every following row (which is out of bounds for a length-1 broadcast holidays list) receives that empty cache — silently dropping all holidays.

The reported symptom: with a leading null, the holidays are ignored for the remaining rows, so the result depends on row order.

The fix advances the holidays getter first in each per-row closure, so the broadcast cache is always populated regardless of null dates. Null handling is unchanged: the getter still returns `None` for a null holidays row, and the subsequent `?` on `start`/`end`/`n`/`date` still yields a null output for null inputs.

The same closure-ordering bug existed in `add_business_days` and `is_business_day`; both are fixed the same way.

## Testing

Added a regression test for each of the three functions (`business_day_count`, `add_business_days`, `is_business_day`) that puts a null in the first row with a length-1 broadcast holidays list and asserts the result is independent of row order. Each test fails on the current code (holidays ignored after the leading null) and passes with the fix. Existing business-day tests continue to pass.
