### PR TITLE
fix(python): Remove usage of deprecated `pyarrow.feather.read_table`

### DIFF
--- a/py-polars/src/polars/io/ipc/functions.py
+++ b/py-polars/src/polars/io/ipc/functions.py
@@ -13,6 +13,7 @@ from polars._utils.deprecation import (
     issue_deprecation_warning,
 )
 from polars._utils.various import (
+    is_non_empty_sequence_of,
     is_str_sequence,
     normalize_filepath,
 )
@@ -169,9 +170,26 @@ def read_ipc(
                 err_prefix="",
                 err_suffix="is required when using 'read_ipc(..., use_pyarrow=True)'",
             )
+
+            if columns is not None and is_non_empty_sequence_of(columns, str):
+                initial_pos = None
+
+                if hasattr(data, "tell") and callable(data.tell):
+                    initial_pos = data.tell()
+
+                with pyarrow_ipc.open_file(data) as ipc_f:
+                    schema = ipc_f.schema
+
+                idx_lookup = {name: i for i, name in enumerate(schema.names)}
+
+                columns = [idx_lookup[name] for name in columns]
+
+                if hasattr(data, "seek") and callable(data.seek):
+                    data.seek(initial_pos)
+
             with pyarrow_ipc.open_file(
                 data,
-                columns=columns,
+                options=pyarrow_ipc.IpcReadOptions(included_fields=columns),
             ) as ipc_f:
                 tbl = ipc_f.read_all()
 

--- a/py-polars/src/polars/io/ipc/functions.py
+++ b/py-polars/src/polars/io/ipc/functions.py
@@ -172,10 +172,15 @@ def read_ipc(
             )
 
             if columns is not None and is_non_empty_sequence_of(columns, str):
-                initial_pos = None
+                initial_pos = []
 
-                if hasattr(data, "tell") and callable(data.tell):
-                    initial_pos = data.tell()
+                if (
+                    hasattr(data, "tell")
+                    and callable(data.tell)
+                    and hasattr(data, "seek")
+                    and callable(data.seek)
+                ):
+                    initial_pos = [data.tell()]
 
                 with pyarrow_ipc.open_file(data) as ipc_f:
                     schema = ipc_f.schema
@@ -184,8 +189,8 @@ def read_ipc(
 
                 columns = [idx_lookup[name] for name in columns]
 
-                if hasattr(data, "seek") and callable(data.seek):
-                    data.seek(initial_pos)
+                if initial_pos:
+                    data.seek(initial_pos[0])
 
             with pyarrow_ipc.open_file(
                 data,

--- a/py-polars/src/polars/io/ipc/functions.py
+++ b/py-polars/src/polars/io/ipc/functions.py
@@ -181,7 +181,6 @@ def read_ipc(
                     schema = ipc_f.schema
 
                 idx_lookup = {name: i for i, name in enumerate(schema.names)}
-
                 columns = [idx_lookup[name] for name in columns]
 
                 if (

--- a/py-polars/src/polars/io/ipc/functions.py
+++ b/py-polars/src/polars/io/ipc/functions.py
@@ -174,12 +174,7 @@ def read_ipc(
             if columns is not None and is_non_empty_sequence_of(columns, str):
                 initial_pos = []
 
-                if (
-                    hasattr(data, "tell")
-                    and callable(data.tell)
-                    and hasattr(data, "seek")
-                    and callable(data.seek)
-                ):
+                if hasattr(data, "tell") and callable(data.tell):
                     initial_pos = [data.tell()]
 
                 with pyarrow_ipc.open_file(data) as ipc_f:
@@ -189,7 +184,7 @@ def read_ipc(
 
                 columns = [idx_lookup[name] for name in columns]
 
-                if initial_pos:
+                if initial_pos and hasattr(data, "seek") and callable(data.seek):
                     data.seek(initial_pos[0])
 
             with pyarrow_ipc.open_file(

--- a/py-polars/src/polars/io/ipc/functions.py
+++ b/py-polars/src/polars/io/ipc/functions.py
@@ -164,16 +164,18 @@ def read_ipc(
         source, use_pyarrow=use_pyarrow, storage_options=storage_options
     ) as data:
         if use_pyarrow:
-            pyarrow_feather = import_optional(
-                "pyarrow.feather",
+            pyarrow_ipc = import_optional(
+                "pyarrow.ipc",
                 err_prefix="",
                 err_suffix="is required when using 'read_ipc(..., use_pyarrow=True)'",
             )
-            tbl = pyarrow_feather.read_table(
+            with pyarrow_ipc.open_file(
                 data,
                 memory_map=memory_map,
                 columns=columns,
-            )
+            ) as ipc_f:
+                tbl = ipc_f.read_all()
+
             df = pl.DataFrame._from_arrow(tbl, rechunk=rechunk)
             if row_index_name is not None:
                 df = df.with_row_index(row_index_name, row_index_offset)

--- a/py-polars/src/polars/io/ipc/functions.py
+++ b/py-polars/src/polars/io/ipc/functions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import os
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Literal
+from typing import IO, TYPE_CHECKING, Any, Literal
 
 import polars._reexport as pl
 import polars.functions as F
@@ -172,10 +172,10 @@ def read_ipc(
             )
 
             if columns is not None and is_non_empty_sequence_of(columns, str):
-                initial_pos = []
+                initial_pos: Any = None
 
                 if hasattr(data, "tell") and callable(data.tell):
-                    initial_pos = [data.tell()]
+                    initial_pos = data.tell()
 
                 with pyarrow_ipc.open_file(data) as ipc_f:
                     schema = ipc_f.schema
@@ -184,8 +184,12 @@ def read_ipc(
 
                 columns = [idx_lookup[name] for name in columns]
 
-                if initial_pos and hasattr(data, "seek") and callable(data.seek):
-                    data.seek(initial_pos[0])
+                if (
+                    initial_pos is not None
+                    and hasattr(data, "seek")
+                    and callable(data.seek)
+                ):
+                    data.seek(initial_pos)
 
             with pyarrow_ipc.open_file(
                 data,

--- a/py-polars/src/polars/io/ipc/functions.py
+++ b/py-polars/src/polars/io/ipc/functions.py
@@ -171,7 +171,6 @@ def read_ipc(
             )
             with pyarrow_ipc.open_file(
                 data,
-                memory_map=memory_map,
                 columns=columns,
             ) as ipc_f:
                 tbl = ipc_f.read_all()

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -600,3 +600,21 @@ def test_read_ipc_compressed_empty_bitmap_27532() -> None:
     f.seek(0)
 
     assert_frame_equal(pl.read_ipc(f), pl.DataFrame(schema={"bool": pl.Boolean}))
+
+
+def test_read_ipc_pyarrow() -> None:
+    f = io.BytesIO()
+
+    pl.DataFrame({"a": 1, "b": 2}).write_ipc(f)
+
+    f.seek(0)
+    assert_frame_equal(
+        pl.read_ipc(f, columns=[1], use_pyarrow=True),
+        pl.DataFrame({"b": 1}),
+    )
+
+    f.seek(0)
+    assert_frame_equal(
+        pl.read_ipc(f, columns=["b"], use_pyarrow=True),
+        pl.DataFrame({"b": 1}),
+    )

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import warnings
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, no_type_check
 
@@ -104,14 +105,19 @@ def test_ipc_roundtrip_pandas_parametric(
 ) -> None:
     pd_df = df.to_pandas()
     f = io.BytesIO()
-    pd_df.to_feather(f, compression=compression)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        pd_df.to_feather(f, compression=compression)
+
     f.seek(0)
     df_read = pl.read_ipc(f, use_pyarrow=False)
     assert_frame_equal(df, df_read, categorical_as_str=True)
     f = io.BytesIO()
     df.write_ipc(f, compression=compression)
     f.seek(0)
-    pd_df_read = pd.read_feather(f)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        pd_df_read = pd.read_feather(f)
     assert pd_df.equals(pd_df_read)
 
 

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import io
-import typing
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, no_type_check
 

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -610,11 +610,11 @@ def test_read_ipc_pyarrow() -> None:
     f.seek(0)
     assert_frame_equal(
         pl.read_ipc(f, columns=[1], use_pyarrow=True),
-        pl.DataFrame({"b": 1}),
+        pl.DataFrame({"b": 2}),
     )
 
     f.seek(0)
     assert_frame_equal(
         pl.read_ipc(f, columns=["b"], use_pyarrow=True),
-        pl.DataFrame({"b": 1}),
+        pl.DataFrame({"b": 2}),
     )

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, no_type_check
 
 import pandas as pd
 import pyarrow as pa
-import pyarrow.feather as paf
 import pyarrow.ipc
 import pytest
 from hypothesis import given
@@ -138,11 +137,20 @@ def test_ipc_roundtrip_pyarrow_parametric(
     df.write_ipc(f, compression=compression)
     f.seek(0)
 
-    table = paf.read_table(f)
-    assert_frame_equal(df, typing.cast("pl.DataFrame", pl.from_arrow(table)))
+    with pyarrow.ipc.open_file(f) as ipc_f:
+        table = ipc_f.read_all()
+    assert_frame_equal(df, pl.DataFrame(table))
 
     f = io.BytesIO()
-    paf.write_feather(df.to_arrow(), f, compression=compression)
+
+    with pyarrow.ipc.new_file(
+        f,
+        df.schema.to_arrow(compat_level=pl.CompatLevel.newest()),
+        options=pyarrow.ipc.IpcWriteOptions(
+            compression=None if compression == "uncompressed" else compression
+        ),
+    ) as ipc_f:
+        ipc_f.write_table(df.to_arrow(compat_level=pl.CompatLevel.newest()))
     f.seek(0)
     assert_frame_equal(df, pl.read_ipc(f, use_pyarrow=False))
 


### PR DESCRIPTION
* Fix CI failures

The alternate API `pyarrow.ipc.open_file` cannot accept a list of column names (only indices) - a new resolve step is added to convert names to indices according to the file schema (for `read_ipc(use_pyarrow=True)`).
