### PR TITLE
fix: Honor `aws_checksum_algorithm` when provided

### DIFF
--- a/crates/polars-io/src/cloud/concurrency/mod.rs
+++ b/crates/polars-io/src/cloud/concurrency/mod.rs
@@ -32,7 +32,6 @@ pub use regime::{Regime, RegimeState};
 
 // Number of samples in the queue, which gets drained on every tick.
 // At 50k requests per second and 100 ms tick window, we need 5k.
-// kdn TODO TEST & TUNE: Refactor to a run-time config-based value.
 const SAMPLE_QUEUE_CAPACITY: usize = 8192;
 
 use crate::cloud::concurrency_config::get_random_access_chunk_size;

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -517,8 +517,17 @@ impl CloudOptions {
             builder
         };
 
+        let builder = if builder
+            .get_config_value(&AmazonS3ConfigKey::Checksum)
+            .is_none()
+        {
+            // AWS default checksum, which is also more efficient than SHA256.
+            builder.with_checksum_algorithm(object_store::aws::Checksum::CRC64NVME)
+        } else {
+            builder
+        };
+
         let out = builder
-            .with_checksum_algorithm(object_store::aws::Checksum::CRC64NVME)
             .with_unsigned_payload(true)
             .build()
             .map_err(|e| ObjectStoreErrorContext::new(url).attach_err_info(e))?;


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/28322

With this PR, any `aws_checksum_algorithm` set in `storage_options` will be honored. When non set, it will default to the AWS default of `CRC64NVME`, as was set in https://github.com/pola-rs/polars/pull/26522.

Pending client testing for confirmation.