### PR TITLE
fix: Fix `write_json()` null values in `Array` columns being written incorrectly as `null`

### DIFF
--- a/crates/polars-json/src/json/write/serialize.rs
+++ b/crates/polars-json/src/json/write/serialize.rs
@@ -323,14 +323,18 @@ fn fixed_size_list_serializer<'a>(
     let mut serializer = new_serializer(
         array.values().as_ref(),
         offset * array.size(),
-        take * array.size(),
+        if take < usize::MAX {
+            take * array.size()
+        } else {
+            usize::MAX
+        },
     );
 
     Box::new(BufStreamingIterator::new(
         ZipValidity::new(0..array.len(), array.validity().map(|x| x.iter())),
         move |ix, buf| {
+            let length = array.size();
             if ix.is_some() {
-                let length = array.size();
                 buf.push(b'[');
                 let mut is_first_row = true;
                 for _ in 0..length {
@@ -343,6 +347,9 @@ fn fixed_size_list_serializer<'a>(
                 buf.push(b']');
             } else {
                 buf.extend(b"null");
+                for _ in 0..length {
+                    serializer.next();
+                }
             }
         },
         vec![],

--- a/crates/polars-json/src/json/write/serialize.rs
+++ b/crates/polars-json/src/json/write/serialize.rs
@@ -322,12 +322,8 @@ fn fixed_size_list_serializer<'a>(
 ) -> Box<dyn JsonSerializer<Item = [u8]> + 'a + Send + Sync> {
     let mut serializer = new_serializer(
         array.values().as_ref(),
-        offset * array.size(),
-        if take < usize::MAX {
-            take * array.size()
-        } else {
-            usize::MAX
-        },
+        offset.saturating_mul(array.size()),
+        take.saturating_mul(array.size()),
     );
 
     Box::new(BufStreamingIterator::new(

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -151,6 +151,40 @@ def test_write_json_list_of_arrays() -> None:
     assert value == expected
 
 
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        ([None, [0, 1]], '[{"a":null},{"a":[0,1]}]'),
+        ([[0, 1], None, [3, 3]], '[{"a":[0,1]},{"a":null},{"a":[3,3]}]'),
+        (
+            [[0, 1], None, None, [7, 7]],
+            '[{"a":[0,1]},{"a":null},{"a":null},{"a":[7,7]}]',
+        ),
+        ([None, None], '[{"a":null},{"a":null}]'),
+    ],
+)
+def test_write_json_array_with_nulls(
+    values: list[list[int] | None], expected: str
+) -> None:
+    df = pl.DataFrame({"a": values}, schema={"a": pl.Array(pl.Int8, 2)})
+    assert df.write_json() == expected
+
+
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        ([None, [0, 1]], '{"a":null}\n{"a":[0,1]}\n'),
+        ([[0, 1], None, [3, 3]], '{"a":[0,1]}\n{"a":null}\n{"a":[3,3]}\n'),
+        ([None, None], '{"a":null}\n{"a":null}\n'),
+    ],
+)
+def test_write_ndjson_array_with_nulls(
+    values: list[list[int] | None], expected: str
+) -> None:
+    df = pl.DataFrame({"a": values}, schema={"a": pl.Array(pl.Int8, 2)})
+    assert df.write_ndjson() == expected
+
+
 def test_write_json_decimal() -> None:
     df = pl.DataFrame({"a": pl.Series([D("1.00"), D("2.00"), None])})
 


### PR DESCRIPTION

> Issue: #28311 

### What

Issue with json serialization logic where `null` in Array did not proceed, causing that everything coming after a null value being null. Example code:

```python
import polars as pl

df = pl.DataFrame({"a": [None, [0,1]]}, schema={"a": pl.Array(pl.Int8, 2)})
df.write_json()

# '[{"a":null},{"a":[null,null]}]'
```

### FIX

Make iteration consume null values as well to make sure that the iterator goes on. 
Trying to reproduce the issue also found a panic (overflow) since passed `usize::MAX` multiplied by the size, and this caused issues in the debug build. 

### Screenshot of tests

<img width="3000" height="2000" alt="Screenshot from 2026-07-10 20-20-14" src="https://github.com/user-attachments/assets/6fb7c4b4-76bf-4c99-82f5-fa20c5b15eae" />

