### PR TITLE
fix: Avoid deprecated PyArrow IPC APIs

### DIFF
--- a/py-polars/src/polars/io/ipc/functions.py
+++ b/py-polars/src/polars/io/ipc/functions.py
@@ -164,16 +164,22 @@ def read_ipc(
         source, use_pyarrow=use_pyarrow, storage_options=storage_options
     ) as data:
         if use_pyarrow:
-            pyarrow_feather = import_optional(
-                "pyarrow.feather",
+            pyarrow = import_optional(
+                "pyarrow",
                 err_prefix="",
                 err_suffix="is required when using 'read_ipc(..., use_pyarrow=True)'",
             )
-            tbl = pyarrow_feather.read_table(
-                data,
-                memory_map=memory_map,
-                columns=columns,
-            )
+            if memory_map and isinstance(data, str):
+                with (
+                    pyarrow.memory_map(data, "r") as data,
+                    pyarrow.ipc.open_file(data) as reader,
+                ):
+                    tbl = reader.read_all()
+            else:
+                with pyarrow.ipc.open_file(data) as reader:
+                    tbl = reader.read_all()
+            if columns is not None:
+                tbl = tbl.select(columns)
             df = pl.DataFrame._from_arrow(tbl, rechunk=rechunk)
             if row_index_name is not None:
                 df = df.with_row_index(row_index_name, row_index_offset)

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import io
 import typing
+import warnings
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, no_type_check
 
 import pandas as pd
 import pyarrow as pa
-import pyarrow.feather as paf
 import pyarrow.ipc
 import pytest
 from hypothesis import given
@@ -106,14 +106,26 @@ def test_ipc_roundtrip_pandas_parametric(
 ) -> None:
     pd_df = df.to_pandas()
     f = io.BytesIO()
-    pd_df.to_feather(f, compression=compression)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="pyarrow.feather.write_feather is deprecated.*",
+            category=FutureWarning,
+        )
+        pd_df.to_feather(f, compression=compression)
     f.seek(0)
     df_read = pl.read_ipc(f, use_pyarrow=False)
     assert_frame_equal(df, df_read, categorical_as_str=True)
     f = io.BytesIO()
     df.write_ipc(f, compression=compression)
     f.seek(0)
-    pd_df_read = pd.read_feather(f)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="pyarrow.feather.read_feather is deprecated.*",
+            category=FutureWarning,
+        )
+        pd_df_read = pd.read_feather(f)
     assert pd_df.equals(pd_df_read)
 
 
@@ -138,11 +150,16 @@ def test_ipc_roundtrip_pyarrow_parametric(
     df.write_ipc(f, compression=compression)
     f.seek(0)
 
-    table = paf.read_table(f)
+    with pyarrow.ipc.open_file(f) as reader:
+        table = reader.read_all()
     assert_frame_equal(df, typing.cast("pl.DataFrame", pl.from_arrow(table)))
 
     f = io.BytesIO()
-    paf.write_feather(df.to_arrow(), f, compression=compression)
+    table = df.to_arrow()
+    ipc_compression = None if compression == "uncompressed" else compression
+    options = pyarrow.ipc.IpcWriteOptions(compression=ipc_compression)
+    with pyarrow.ipc.new_file(f, table.schema, options=options) as writer:
+        writer.write_table(table)
     f.seek(0)
     assert_frame_equal(df, pl.read_ipc(f, use_pyarrow=False))
 


### PR DESCRIPTION
Closing: @nameexhaustion  fixed it [here](https://github.com/pola-rs/polars/pull/28323)

Solves #28331 

Replace deprecated PyArrow IPC reader and writer usage in Polars IPC paths/tests. Initial failure was from `pyarrow.feather.read_table`, but CI also exposed `pyarrow.feather.write_feather` warnings in IPC compatibility tests.

**Important!** I added upstream `pandas` warnings suppression with the same issues. pandas repo has draft fix [here](https://github.com/pandas-dev/pandas/pull/66220), it's not ready for release. 

`make test`
<img width="895" height="248" alt="Screenshot 2026-07-10 at 12 45 23 PM" src="https://github.com/user-attachments/assets/a2208a82-45de-497d-833b-d53371eb35ef" />
