### PR TITLE
fix(python): Fix some type hints and type aliases

### DIFF
--- a/py-polars/src/polars/_typing.py
+++ b/py-polars/src/polars/_typing.py
@@ -288,7 +288,7 @@ JoinStrategy: TypeAlias = Literal[
 ListToStructWidthStrategy: TypeAlias = Literal["first_non_null", "max_width"]
 
 # The following have no equivalent on the Rust side
-ConcatMethod = Literal[
+ConcatMethod: TypeAlias = Literal[
     "vertical",
     "vertical_relaxed",
     "diagonal",
@@ -305,7 +305,7 @@ CorrelationMethod: TypeAlias = Literal["pearson", "spearman"]
 DbReadEngine: TypeAlias = Literal["adbc", "connectorx"]
 DbWriteEngine: TypeAlias = Literal["sqlalchemy", "adbc"]
 DbWriteMode: TypeAlias = Literal["replace", "append", "fail"]
-EpochTimeUnit = Literal["ns", "us", "ms", "s", "d"]
+EpochTimeUnit: TypeAlias = Literal["ns", "us", "ms", "s", "d"]
 JaxExportType: TypeAlias = Literal["array", "dict"]
 Orientation: TypeAlias = Literal["col", "row"]
 SearchSortedSide: TypeAlias = Literal["any", "left", "right"]
@@ -396,7 +396,7 @@ class BasicCursor(Protocol):
         """Execute a query."""
 
 
-class Cursor(BasicCursor):
+class Cursor(BasicCursor, Protocol):
     def fetchall(self, *args: Any, **kwargs: Any) -> Any:
         """Fetch all results."""
 
@@ -454,7 +454,7 @@ FileSource: TypeAlias = (
     | list[bytes]
 )
 
-JSONEncoder = Callable[[Any], bytes] | Callable[[Any], str]
+JSONEncoder: TypeAlias = Callable[[Any], bytes | str]
 
 DeprecationType: TypeAlias = Literal[
     "function",

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -1485,9 +1485,7 @@ class Series:
         return get_series_item_by_key(self, key)
 
     def __setitem__(
-        self,
-        key: int | Series | np.ndarray[Any, Any] | Sequence[object] | tuple[object],
-        value: Any,
+        self, key: int | Series | np.ndarray[Any, Any] | Sequence[object], value: Any
     ) -> None:
         """
         Set Series values in-place using a single index, boolean mask, or index array.
@@ -2185,7 +2183,7 @@ class Series:
         stats.columns = ["statistic", "value"]
         return stats.filter(F.col("value").is_not_null())
 
-    def sum(self) -> int | float | PyDecimal:
+    def sum(self) -> Any:
         """
         Reduce this Series to the sum value.
 
@@ -2294,7 +2292,7 @@ class Series:
         return self._s.min()
 
     @unstable()
-    def min_by(self, by: IntoExpr) -> Expr:
+    def min_by(self, by: IntoExpr) -> Any | None:
         """
         Get the minimum value in this Series, ordered by an expression.
 
@@ -2332,7 +2330,7 @@ class Series:
         return self._s.max()
 
     @unstable()
-    def max_by(self, by: IntoExpr) -> Expr:
+    def max_by(self, by: IntoExpr) -> Any | None:
         """
         Get the maximum value in this Series, ordered by an expression.
 
@@ -9741,7 +9739,7 @@ class Series:
         """
         return self._s.last(ignore_nulls=ignore_nulls)
 
-    def approx_n_unique(self) -> PythonLiteral | None:
+    def approx_n_unique(self) -> int:
         """
         Approximate count of unique values.
 

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -302,7 +302,7 @@ def df() -> pl.DataFrame:
     ],
 )
 def test_group_by_shorthands(
-    df: pl.DataFrame, method: str, expected: list[tuple[Any]]
+    df: pl.DataFrame, method: str, expected: list[tuple[Any, ...]]
 ) -> None:
     gb = df.group_by("b", maintain_order=True)
     result = getattr(gb, method)()

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -117,7 +117,9 @@ def test_pivot_list() -> None:
         ("median", [("a", 3.0, None, None), ("b", None, 8.0, 10.0)]),
     ],
 )
-def test_pivot_aggregate(agg_fn: PivotAgg, expected_rows: list[tuple[Any]]) -> None:
+def test_pivot_aggregate(
+    agg_fn: PivotAgg, expected_rows: list[tuple[Any, ...]]
+) -> None:
     df = pl.DataFrame(
         {
             "a": [1, 1, 2, 2, 3],

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -766,7 +766,7 @@ def test_set_np_array(dtype: Any) -> None:
 
 
 @pytest.mark.parametrize("idx", [[0, 2], (0, 2)])
-def test_set_list_and_tuple(idx: list[int] | tuple[int]) -> None:
+def test_set_list_and_tuple(idx: list[int] | tuple[int, ...]) -> None:
     a = pl.Series("a", [1, 2, 3])
     a[idx] = 4
     assert_series_equal(a, pl.Series("a", [4, 2, 4]))

--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -698,7 +698,9 @@ def test_natural_joins_01() -> None:
         ("!= 4", [(8, 8, 6), (2, 8, 6), (0, 7, 2)]),
     ],
 )
-def test_natural_joins_02(cols_constraint: str, expect_data: list[tuple[int]]) -> None:
+def test_natural_joins_02(
+    cols_constraint: str, expect_data: list[tuple[int, ...]]
+) -> None:
     df1 = pl.DataFrame(
         {
             "x": [1, 5, 3, 8, 6, 7, 4, 0, 2],

--- a/py-polars/tests/unit/sql/test_wildcard_opts.py
+++ b/py-polars/tests/unit/sql/test_wildcard_opts.py
@@ -150,7 +150,7 @@ def test_select_rename_exclude_sort(order_by: str, df: pl.DataFrame) -> None:
 def test_select_replace(
     replacements: str,
     check_cols: list[str],
-    expected: list[tuple[Any]],
+    expected: list[tuple[Any, ...]],
     df: pl.DataFrame,
 ) -> None:
     for order_by in ("", "ORDER BY ID DESC", "ORDER BY -ID ASC"):


### PR DESCRIPTION
- Add some missing `TypeAlias` annotations
- Add missing `Protocol` in `Cursor` bases
- Fix many `tuple[Something]` that should've been `tuple[Something, ...]`
- Fix the wrong return type of some series methods
- Simplify two types `Sequence | tuple` -> `Sequence` and `Callable[..., str] | Callable[..., bytes]` -> `Callable[..., str | bytes]`
