### PR TITLE
docs: document reading from S3-compatible object stores

### DIFF
--- a/docs/source/src/python/user-guide/io/cloud-storage.py
+++ b/docs/source/src/python/user-guide/io/cloud-storage.py
@@ -43,6 +43,20 @@ storage_options = {
 df = pl.scan_parquet(source, storage_options=storage_options).collect()
 # --8<-- [end:scan_parquet_storage_options_aws]
 
+# --8<-- [start:scan_parquet_storage_options_s3_compatible]
+import polars as pl
+
+source = "s3://bucket/*.parquet"
+
+storage_options = {
+    "aws_access_key_id": "<secret>",
+    "aws_secret_access_key": "<secret>",
+    "aws_endpoint_url": "https://t3.storage.dev",
+    "aws_region": "auto",
+}
+df = pl.scan_parquet(source, storage_options=storage_options).collect()
+# --8<-- [end:scan_parquet_storage_options_s3_compatible]
+
 # --8<-- [start:credential_provider_class]
 lf = pl.scan_parquet(
     "s3://.../...",

--- a/docs/source/user-guide/io/cloud-storage.md
+++ b/docs/source/user-guide/io/cloud-storage.md
@@ -1,7 +1,8 @@
 # Cloud storage
 
-Polars can read and write to AWS S3, Azure Blob Storage and Google Cloud Storage. The API is the
-same for all three storage providers.
+Polars can read and write to AWS S3, Azure Blob Storage and Google Cloud Storage, as well as
+[S3-compatible object stores](#s3-compatible-storage). The API is the same for all storage
+providers.
 
 To read from cloud storage, additional dependencies may be needed depending on the use case and
 cloud storage provider:
@@ -74,6 +75,34 @@ use for authentication. This can be done in a few ways:
 
 {{code_block('user-guide/io/cloud-storage','credential_provider_class_global_default',['scan_parquet',
 'CredentialProviderAWS'])}}
+
+## S3-compatible storage
+
+Polars is not limited to the three providers above. Any object store that implements the S3 API,
+such as [MinIO](https://min.io), [Cloudflare R2](https://developers.cloudflare.com/r2/) or
+[Tigris](https://www.tigrisdata.com) (globally distributed, no egress fees), works with the same
+`s3://` paths and authentication options as AWS S3. Only the endpoint needs to be configured, in
+one of two ways:
+
+- Passing `aws_endpoint_url` in `storage_options`:
+
+{{code_block('user-guide/io/cloud-storage','scan_parquet_storage_options_s3_compatible',['scan_parquet'])}}
+
+- Setting the `AWS_ENDPOINT_URL` environment variable:
+
+```shell
+$ export AWS_ENDPOINT_URL="https://t3.storage.dev"
+```
+
+Note the following when using a custom endpoint:
+
+- When an endpoint is configured without a region, Polars does not attempt to resolve the bucket
+  region and signs requests as `us-east-1`. Services that validate the signing region reject such
+  requests with a `SignatureDoesNotMatch` error, so set `aws_region` to the value your service
+  expects.
+- Requests use path-style addressing (`https://host/bucket/...`) by default. If your service
+  requires virtual-hosted-style addressing (`https://bucket.host/...`), set
+  `"aws_virtual_hosted_style_request": "true"` in `storage_options`.
 
 ## Cloud retry configuration
 


### PR DESCRIPTION
This should help with issue #22131

The cloud storage page says Polars reads from AWS S3, Azure Blob Storage and Google Cloud
Storage, and never mentions that any S3-compatible store works too. People keep hitting this, for example in #18802.

1. If you set a custom endpoint but no region, Polars falls back to signing as `us-east-1`
   (the fallback added for #13042). Stores that validate the signing region then return
   `SignatureDoesNotMatch`, which is how you end up with reports like #18405 where nothing in
   the error points at the region.
2. Path-style vs virtual-hosted addressing, which some services are picky about.

I added a short "S3-compatible storage" section to `cloud-storage.md` with the two ways to
set the endpoint (`storage_options` / `AWS_ENDPOINT_URL`), a note on each of the above, and one
new snippet in `cloud-storage.py`. 

I work at Tigris and used it as the example endpoint since that's what I test against. Tested the snippet against a
live bucket.

Hope this helps. Thank you guys!

Screenshot 
<img width="876" height="685" alt="Screenshot 2026-07-13 at 10 24 29 AM" src="https://github.com/user-attachments/assets/289972ae-133c-43d2-8165-66e1131eb313" />


