### PR TITLE
depr: Deprecate casting numeric types to categoricals

### DIFF
--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -175,6 +175,12 @@ where
             // TODO @ cat-rework: remove after exposing to/from physical functions.
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(cats, _mapping) => {
+                polars_warn!(
+                    Deprecation,
+                    "casting from {:?} to {dtype:?} is deprecated.\n\
+                    Instead of `.cast({dtype:?}`, use `.cat.to({dtype:?})`.",
+                    T::get_static_dtype()
+                );
                 let s = self.cast_with_options(&cats.physical().dtype(), options)?;
                 with_match_categorical_physical_type!(cats.physical(), |$C| {
                     // SAFETY: we are guarded by the type system.
@@ -189,6 +195,12 @@ where
             // TODO @ cat-rework: remove after exposing to/from physical functions.
             #[cfg(feature = "dtype-categorical")]
             DataType::Enum(fcats, _mapping) => {
+                polars_warn!(
+                    Deprecation,
+                    "casting from {:?} to {dtype:?} is deprecated.\n\
+                    Instead of `.cast({dtype:?}`, use `.cat.to({dtype:?})`.",
+                    T::get_static_dtype()
+                );
                 let s = self.cast_with_options(&fcats.physical().dtype(), options)?;
                 with_match_categorical_physical_type!(fcats.physical(), |$C| {
                     // SAFETY: we are guarded by the type system.

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -1084,3 +1084,21 @@ def test_cast_to_list_deprecated() -> None:
     with pytest.warns(DeprecationWarning, match=rf"^{re.escape(msg)}$"):
         result = s.cast(pl.List(pl.Int32))
     assert result.dtype == pl.List(pl.Int32)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pl.Categorical(pl.Categories.random(physical=pl.UInt32)),
+        pl.Enum(["cat0", "cat1", "cat2"]),
+    ],
+)
+def test_cast_int_to_categorical_deprecated(dtype: PolarsDataType) -> None:
+    _dummy = pl.Series("a", ["cat0", "cat1", "cat2"], dtype=dtype)
+
+    msg = rf"casting from UInt32 to {re.escape(str(dtype.base_type()))}\(\S+\) is deprecated."
+    with pytest.deprecated_call(match=msg):
+        actual = pl.Series("a", [2, 0, 1], dtype=pl.UInt32).cast(dtype)
+
+    expected = pl.Series("a", ["cat2", "cat0", "cat1"], dtype=dtype)
+    assert_series_equal(actual, expected)


### PR DESCRIPTION
Related issue: https://github.com/pola-rs/polars/issues/25386

