### PR TITLE
chore(rust): Bump spin dependency to `0.10.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4841,9 +4841,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"


### PR DESCRIPTION
This should resolve the current cargo-deny CI failure