### PR TITLE
build: Set the default `dev` profile to `line-tables-only`

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -344,7 +344,7 @@ jobs:
           command: build
           target: ${{ matrix.target }}
           args: >
-            --profile ${{ inputs.dry-run == true && 'mindebug-dev' || 'dist-release' }}
+            --profile ${{ inputs.dry-run == true && 'dev' || 'dist-release' }}
             --manifest-path py-polars/runtime/${{ matrix.package }}/Cargo.toml
             --out dist
           manylinux: auto

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,9 +172,12 @@ color-backtrace = { git = "https://github.com/orlp/color-backtrace", rev = "bb62
 # https://github.com/tikv/jemallocator/pull/168
 tikv-jemalloc-sys = { git = "https://github.com/pola-rs/jemallocator", rev = "0d683dfb157097e2075d5e0eaf25f71f514a7552" }
 
-[profile.mindebug-dev]
-inherits = "dev"
+[profile.dev]
 debug = "line-tables-only"
+
+[profile.debug-dev]
+inherits = "dev"
+debug = true
 
 [profile.release]
 lto = "thin"

--- a/Makefile
+++ b/Makefile
@@ -110,15 +110,18 @@ update-cargo-env: $(VENV_BIN)/python
 	@RUSTFLAGS="$(RUSTFLAGS)" CFLAGS="$(CFLAGS)" $(VENV_BIN)/python tools/update-cargo-env.py
 
 .PHONY: build
-build: update-cargo-env ## Compile and install Python Polars for development
+build: build-mindebug  ## Compile and install Python Polars for development (alias for build-mindebug)
+
+.PHONY: build-debug
+build-debug: update-cargo-env  ## Compile and install Python Polars for development with full debug symbols
 	@unset CONDA_PREFIX \
-	&& $(VENV_BIN)/maturin develop -m $(RUNTIME_CARGO_TOML) --features backtrace_filter $(ARGS) --uv \
+	&& $(VENV_BIN)/maturin develop -m $(RUNTIME_CARGO_TOML) --features backtrace_filter --profile debug-dev $(ARGS) --uv \
 	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-mindebug
-build-mindebug: update-cargo-env  ## Same as build, but don't include full debug information
+build-mindebug: update-cargo-env  ## Compile and install Python Polars for development with reduced debug symbols
 	@unset CONDA_PREFIX \
-	&& $(VENV_BIN)/maturin develop -m $(RUNTIME_CARGO_TOML) --features backtrace_filter --profile mindebug-dev $(ARGS) --uv \
+	&& $(VENV_BIN)/maturin develop -m $(RUNTIME_CARGO_TOML) --features backtrace_filter $(ARGS) --uv \
 	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-release

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ This can be done by going through the following steps in sequence:
 1. Install the latest [Rust compiler](https://www.rust-lang.org/tools/install)
 2. Install [maturin](https://maturin.rs/): `pip install maturin`
 3. `cd py-polars` and choose one of the following:
-   - `make build`, slow binary with debug assertions and symbols, fast compile times
+   - `make build`, slow binary with debug assertions and limited symbols, fast compile times
+   - `make build-debug`, same as `make build`, but with all symbols, produces large binaries
    - `make build-release`, fast binary without debug assertions, minimal debug symbols, long compile
      times
    - `make build-nodebug-release`, same as build-release but without any debug symbols, slightly

--- a/docs/source/development/contributing/ide.md
+++ b/docs/source/development/contributing/ide.md
@@ -111,6 +111,8 @@ for more information about the `launch.json` file.
 
 #### Running the debugger
 
+0. First, compile Polars with full debug information using `make build-debug`.
+
 1. Create a Python script containing Polars code. Ensure that your virtual environment is activated.
 
 2. Set breakpoints in any `.rs` or `.py` file.

--- a/flake.nix
+++ b/flake.nix
@@ -160,7 +160,7 @@
                   pybuild-debug = {
                     pwd = "py-polars";
                     cmd = buildPy "debug" "maturin develop --profile debug-dev \"$@\" --uv";
-                    doc = "Build the python library with minimal debug information";
+                    doc = "Build the python library with full debug information";
                   };
                   pybuild-nodebug-release = {
                     pwd = "py-polars";
@@ -271,7 +271,7 @@
                     cmd = ''
                       ${aliasToScript precommit}
                       ${step "Rust Tests" rstest}
-                      ${step "Python Build" pybuild-mindebug}
+                      ${step "Python Build" pybuild}
                       ${step "Python Tests" pytest-all}
                     '';
                     doc = "Run the checks to do before pushing";

--- a/flake.nix
+++ b/flake.nix
@@ -157,9 +157,9 @@
                     cmd = buildPy "debug" "maturin develop -m $WORKSPACE_ROOT/py-polars/runtime/polars-runtime-32/Cargo.toml \"$@\" --uv";
                     doc = "Build the python library";
                   };
-                  pybuild-mindebug = {
+                  pybuild-debug = {
                     pwd = "py-polars";
-                    cmd = buildPy "mindebug" "maturin develop --profile mindebug-dev \"$@\" --uv";
+                    cmd = buildPy "debug" "maturin develop --profile debug-dev \"$@\" --uv";
                     doc = "Build the python library with minimal debug information";
                   };
                   pybuild-nodebug-release = {

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -28,6 +28,10 @@ requirements-all: .venv  ## Install/refresh all Python requirements (including t
 build: .venv  ## Compile and install Python Polars for development
 	@$(MAKE) -s -C .. $@
 
+.PHONY: build-debug
+build: .venv  ## Compile and install Python Polars for development with full debug symbols
+	@$(MAKE) -s -C .. $@
+
 .PHONY: build-release
 build-release: .venv  ## Compile and install Python Polars binary with optimizations, with minimal debug symbols
 	@$(MAKE) -s -C .. $@

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -29,7 +29,7 @@ build: .venv  ## Compile and install Python Polars for development
 	@$(MAKE) -s -C .. $@
 
 .PHONY: build-debug
-build: .venv  ## Compile and install Python Polars for development with full debug symbols
+build-debug: .venv  ## Compile and install Python Polars for development with full debug symbols
 	@$(MAKE) -s -C .. $@
 
 .PHONY: build-release


### PR DESCRIPTION
We are experiencing that development builds often take a long time to compile, bottlenecked on IO rather than CPU. That's because a clean debug build is **28G**.

I have personally used mindebug builds (which are **16G**). I think it is a good idea to set this as the default. Not many people actually attach a debugger anyway; and if they do, they can still compile with `make debug`.