### PR TITLE
chore: Update `spin` dependency to `v0.10.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4841,9 +4841,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"


### PR DESCRIPTION
The previous version, `v0.10.0` was yanked and CI (`cargo deny`) was failing in PRs, so this updates it to `v0.10.1`.

<img width="720" height="249" alt="image" src="https://github.com/user-attachments/assets/f943dc25-aa48-4013-911b-d554dc76f32d" />