### PR TITLE
chore (rust): Update pyo3-polars version to 0.28.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2978,7 +2978,7 @@ dependencies = [
 
 [[package]]
 name = "polars"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "apache-avro",
  "avro-schema",
@@ -3011,7 +3011,7 @@ dependencies = [
 
 [[package]]
 name = "polars-arrow"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "async-stream",
  "atoi_simd",
@@ -3064,7 +3064,7 @@ dependencies = [
 
 [[package]]
 name = "polars-async"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "atomic-waker",
  "crossbeam-channel",
@@ -3082,7 +3082,7 @@ dependencies = [
 
 [[package]]
 name = "polars-buffer"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "bytemuck",
  "either",
@@ -3093,7 +3093,7 @@ dependencies = [
 
 [[package]]
 name = "polars-compute"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "atoi_simd",
  "bigdecimal",
@@ -3122,7 +3122,7 @@ dependencies = [
 
 [[package]]
 name = "polars-config"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "polars-error",
  "serde",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "polars-core"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "bincode",
  "bitflags",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "polars-doc-examples"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",
@@ -3189,7 +3189,7 @@ dependencies = [
 
 [[package]]
 name = "polars-dtype"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "boxcar",
  "hashbrown 0.17.1",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "polars-dylib"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "polars",
  "polars-arrow",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "polars-error"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "avro-schema",
  "object_store",
@@ -3231,7 +3231,7 @@ dependencies = [
 
 [[package]]
 name = "polars-expr"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "bitflags",
  "chrono-tz",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "polars-ffi"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "polars-arrow",
  "polars-core",
@@ -3266,7 +3266,7 @@ dependencies = [
 
 [[package]]
 name = "polars-io"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "async-trait",
  "atoi_simd",
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "polars-json"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -3341,7 +3341,7 @@ dependencies = [
 
 [[package]]
 name = "polars-lazy"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "bitflags",
  "bytes",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "polars-mem-engine"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "futures",
  "memmap2",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "polars-ooc"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "async-trait",
  "boxcar",
@@ -3416,7 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "polars-ops"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "aho-corasick",
  "argminmax",
@@ -3456,7 +3456,7 @@ dependencies = [
 
 [[package]]
 name = "polars-parquet"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "async-stream",
  "base64",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "polars-plan"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "bitflags",
  "blake3",
@@ -3549,7 +3549,7 @@ dependencies = [
 
 [[package]]
 name = "polars-python"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "arboard",
  "bincode",
@@ -3599,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "polars-row"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -3647,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "polars-schema"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "indexmap",
  "polars-error",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "polars-sql"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "bitflags",
  "hex",
@@ -3677,7 +3677,7 @@ dependencies = [
 
 [[package]]
 name = "polars-stream"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "polars-testing"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "polars-core",
  "polars-ops",
@@ -3731,7 +3731,7 @@ dependencies = [
 
 [[package]]
 name = "polars-time"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "atoi_simd",
  "bytemuck",
@@ -3754,7 +3754,7 @@ dependencies = [
 
 [[package]]
 name = "polars-utils"
-version = "0.54.4"
+version = "0.54.5"
 dependencies = [
  "argminmax",
  "bincode",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-polars"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "libc",
  "once_cell",
@@ -3993,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-polars-derive"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "polars-arrow",
  "polars-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 default-members = ["crates/*"]
 
 [workspace.package]
-version = "0.54.4"
+version = "0.54.5"
 authors = ["Ritchie Vink <ritchie46@gmail.com>"]
 edition = "2024"
 homepage = "https://www.pola.rs/"
@@ -112,35 +112,35 @@ xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
 zmij = "1.0.0"
 zstd = "0.13"
 
-polars = { version = "0.54.4", path = "crates/polars", default-features = false }
-polars-async = { version = "0.54.4", path = "crates/polars-async", default-features = false }
-polars-buffer = { version = "0.54.4", path = "crates/polars-buffer", default-features = false }
-polars-compute = { version = "0.54.4", path = "crates/polars-compute", default-features = false }
-polars-config = { version = "0.54.4", path = "crates/polars-config", default-features = false }
-polars-core = { version = "0.54.4", path = "crates/polars-core", default-features = false }
-polars-dtype = { version = "0.54.4", path = "crates/polars-dtype", default-features = false }
-polars-dylib = { version = "0.54.4", path = "crates/polars-dylib", default-features = false }
-polars-error = { version = "0.54.4", path = "crates/polars-error", default-features = false }
-polars-expr = { version = "0.54.4", path = "crates/polars-expr", default-features = false }
-polars-ffi = { version = "0.54.4", path = "crates/polars-ffi", default-features = false }
-polars-io = { version = "0.54.4", path = "crates/polars-io", default-features = false }
-polars-json = { version = "0.54.4", path = "crates/polars-json", default-features = false }
-polars-lazy = { version = "0.54.4", path = "crates/polars-lazy", default-features = false }
-polars-mem-engine = { version = "0.54.4", path = "crates/polars-mem-engine", default-features = false }
-polars-ooc = { version = "0.54.4", path = "crates/polars-ooc", default-features = false }
-polars-ops = { version = "0.54.4", path = "crates/polars-ops", default-features = false }
-polars-parquet = { version = "0.54.4", path = "crates/polars-parquet", default-features = false }
-polars-plan = { version = "0.54.4", path = "crates/polars-plan", default-features = false }
-polars-python = { version = "0.54.4", path = "crates/polars-python", default-features = false }
-polars-row = { version = "0.54.4", path = "crates/polars-row", default-features = false }
-polars-schema = { version = "0.54.4", path = "crates/polars-schema", default-features = false }
-polars-sql = { version = "0.54.4", path = "crates/polars-sql", default-features = false }
-polars-stream = { version = "0.54.4", path = "crates/polars-stream", default-features = false }
-polars-testing = { version = "0.54.4", path = "crates/polars-testing", default-features = false }
-polars-time = { version = "0.54.4", path = "crates/polars-time", default-features = false }
-polars-utils = { version = "0.54.4", path = "crates/polars-utils", default-features = false }
-pyo3-polars = { version = "0.27.0", path = "pyo3-polars/pyo3-polars" }
-pyo3-polars-derive = { version = "0.21.0", path = "pyo3-polars/pyo3-polars-derive" }
+polars = { version = "0.54.5", path = "crates/polars", default-features = false }
+polars-async = { version = "0.54.5", path = "crates/polars-async", default-features = false }
+polars-buffer = { version = "0.54.5", path = "crates/polars-buffer", default-features = false }
+polars-compute = { version = "0.54.5", path = "crates/polars-compute", default-features = false }
+polars-config = { version = "0.54.5", path = "crates/polars-config", default-features = false }
+polars-core = { version = "0.54.5", path = "crates/polars-core", default-features = false }
+polars-dtype = { version = "0.54.5", path = "crates/polars-dtype", default-features = false }
+polars-dylib = { version = "0.54.5", path = "crates/polars-dylib", default-features = false }
+polars-error = { version = "0.54.5", path = "crates/polars-error", default-features = false }
+polars-expr = { version = "0.54.5", path = "crates/polars-expr", default-features = false }
+polars-ffi = { version = "0.54.5", path = "crates/polars-ffi", default-features = false }
+polars-io = { version = "0.54.5", path = "crates/polars-io", default-features = false }
+polars-json = { version = "0.54.5", path = "crates/polars-json", default-features = false }
+polars-lazy = { version = "0.54.5", path = "crates/polars-lazy", default-features = false }
+polars-mem-engine = { version = "0.54.5", path = "crates/polars-mem-engine", default-features = false }
+polars-ooc = { version = "0.54.5", path = "crates/polars-ooc", default-features = false }
+polars-ops = { version = "0.54.5", path = "crates/polars-ops", default-features = false }
+polars-parquet = { version = "0.54.5", path = "crates/polars-parquet", default-features = false }
+polars-plan = { version = "0.54.5", path = "crates/polars-plan", default-features = false }
+polars-python = { version = "0.54.5", path = "crates/polars-python", default-features = false }
+polars-row = { version = "0.54.5", path = "crates/polars-row", default-features = false }
+polars-schema = { version = "0.54.5", path = "crates/polars-schema", default-features = false }
+polars-sql = { version = "0.54.5", path = "crates/polars-sql", default-features = false }
+polars-stream = { version = "0.54.5", path = "crates/polars-stream", default-features = false }
+polars-testing = { version = "0.54.5", path = "crates/polars-testing", default-features = false }
+polars-time = { version = "0.54.5", path = "crates/polars-time", default-features = false }
+polars-utils = { version = "0.54.5", path = "crates/polars-utils", default-features = false }
+pyo3-polars = { version = "0.28.0", path = "pyo3-polars/pyo3-polars" }
+pyo3-polars-derive = { version = "0.22.0", path = "pyo3-polars/pyo3-polars-derive" }
 
 [workspace.dependencies.arrow-format]
 package = "polars-arrow-format"
@@ -148,7 +148,7 @@ version = "0.2.0"
 
 [workspace.dependencies.arrow]
 package = "polars-arrow"
-version = "0.54.4"
+version = "0.54.5"
 path = "crates/polars-arrow"
 default-features = false
 features = [

--- a/pyo3-polars/pyo3-polars-derive/Cargo.toml
+++ b/pyo3-polars/pyo3-polars-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-polars-derive"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/pyo3-polars/pyo3-polars/Cargo.toml
+++ b/pyo3-polars/pyo3-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-polars"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 license = "MIT"
 readme = "../README.md"


### PR DESCRIPTION
I based this on a similar change https://github.com/pola-rs/polars/pull/27931 . The intention is to release the next version of pyo3-polars so projects can start using the latest version of pyo3 (0.29.0) see https://github.com/pola-rs/polars/pull/27970 where this upgrade was done but not released.