### PR TITLE
fix: Fix offset in arrow ffi export of sliced struct arrays

### DIFF
--- a/crates/polars-arrow/src/array/struct_/ffi.rs
+++ b/crates/polars-arrow/src/array/struct_/ffi.rs
@@ -44,8 +44,8 @@ impl<A: ffi::ArrowArrayRef> FromFfi<A> for StructArray {
             .map(|index| {
                 let child = array.child(index)?;
                 ffi::try_from(child).map(|arr| {
-                    // there is a discrepancy with how polars_arrow exports sliced
-                    // struct array and how pyarrow does it.
+                    // Old versions of polars_arrow exported sliced
+                    // struct arrays differently.
                     // # Pyarrow
                     // ## struct array len 3
                     //  * slice 1 by with len 2
@@ -53,7 +53,7 @@ impl<A: ffi::ArrowArrayRef> FromFfi<A> for StructArray {
                     //      length on struct array: 2
                     //      offset on value array: 0
                     //      length on value array: 3
-                    // # Arrow2
+                    // # polars_arrow (old)
                     // ## struct array len 3
                     //  * slice 1 by with len 2
                     //      offset on struct array: 0

--- a/crates/polars-arrow/src/array/struct_/ffi.rs
+++ b/crates/polars-arrow/src/array/struct_/ffi.rs
@@ -7,7 +7,7 @@ use crate::ffi;
 
 unsafe impl ToFfi for StructArray {
     fn buffers(&self) -> Vec<Option<*const u8>> {
-        vec![self.validity.as_ref().map(|x| x.as_ptr())]
+        vec![self.validity.as_ref().map(|x| x.as_aligned_ptr().unwrap())]
     }
 
     fn children(&self) -> Vec<Box<dyn Array>> {
@@ -15,16 +15,19 @@ unsafe impl ToFfi for StructArray {
     }
 
     fn offset(&self) -> Option<usize> {
-        Some(
-            self.validity
-                .as_ref()
-                .map(|bitmap| bitmap.offset())
-                .unwrap_or_default(),
-        )
+        Some(0)
     }
 
     fn to_ffi_aligned(&self) -> Self {
-        self.clone()
+        let mut ret = self.clone();
+
+        if let Some(validity) = ret.validity()
+            && validity.as_aligned_ptr().is_none()
+        {
+            ret.validity = Some(validity.to_aligned_bitmap());
+        }
+
+        ret
     }
 }
 

--- a/crates/polars-arrow/src/bitmap/immutable.rs
+++ b/crates/polars-arrow/src/bitmap/immutable.rs
@@ -366,7 +366,7 @@ impl Bitmap {
         self.storage.deref().as_ptr()
     }
 
-    /// If this bitmap has an offset aligned with the size of `*const u8`, returns
+    /// If this bitmap has a bit offset that is a multiple of 8, returns
     /// an offset-adjusted `Some(ptr)`.
     pub fn as_aligned_ptr(&self) -> Option<*const u8> {
         self.offset

--- a/crates/polars-arrow/src/bitmap/immutable.rs
+++ b/crates/polars-arrow/src/bitmap/immutable.rs
@@ -167,7 +167,7 @@ impl Bitmap {
         AlignedBitmapSlice::new(&self.storage, self.offset, self.length)
     }
 
-    /// Reallocates if this bitmap has an offset that is not a multiple of 8.
+    /// Reallocates if this bitmap has a bit offset that is not a multiple of 8.
     pub fn to_aligned_bitmap(&self) -> Bitmap {
         if self.offset.is_multiple_of(8) {
             self.clone()

--- a/crates/polars-arrow/src/bitmap/immutable.rs
+++ b/crates/polars-arrow/src/bitmap/immutable.rs
@@ -167,6 +167,15 @@ impl Bitmap {
         AlignedBitmapSlice::new(&self.storage, self.offset, self.length)
     }
 
+    /// Reallocates if this bitmap has an offset that is not a multiple of 8.
+    pub fn to_aligned_bitmap(&self) -> Bitmap {
+        if self.offset.is_multiple_of(8) {
+            self.clone()
+        } else {
+            Bitmap::from_trusted_len_iter(self.iter())
+        }
+    }
+
     /// Returns the byte slice of this [`Bitmap`].
     ///
     /// The returned tuple contains:
@@ -355,6 +364,14 @@ impl Bitmap {
     /// This pointer is allocated iff `self.len() > 0`.
     pub(crate) fn as_ptr(&self) -> *const u8 {
         self.storage.deref().as_ptr()
+    }
+
+    /// If this bitmap has an offset aligned with the size of `*const u8`, returns
+    /// an offset-adjusted `Some(ptr)`.
+    pub fn as_aligned_ptr(&self) -> Option<*const u8> {
+        self.offset
+            .is_multiple_of(8)
+            .then(|| unsafe { self.as_ptr().add(self.offset / 8) })
     }
 
     /// Returns a pointer to the start of this [`Bitmap`] (ignores `offsets`)

--- a/crates/polars-arrow/src/ffi/array.rs
+++ b/crates/polars-arrow/src/ffi/array.rs
@@ -100,7 +100,11 @@ impl ArrowArray {
     /// # Safety
     /// This method releases `buffers`. Consumers of this struct *must* call `release` before
     /// releasing this struct, or contents in `buffers` leak.
-    pub(crate) fn new(array: Box<dyn Array>) -> Self {
+    pub(crate) fn new(mut array: Box<dyn Array>) -> Self {
+        if let Some(struct_array) = array.as_any_mut().downcast_mut::<StructArray>() {
+            *struct_array = struct_array.to_ffi_aligned();
+        }
+
         #[allow(unused_mut)]
         let (offset, mut buffers, children, dictionary) =
             offset_buffers_children_dictionary(array.as_ref());

--- a/crates/polars-arrow/src/io/ipc/write2/array/mod.rs
+++ b/crates/polars-arrow/src/io/ipc/write2/array/mod.rs
@@ -216,17 +216,9 @@ fn write_bitmap(
 ) -> PolarsResult<()> {
     match bitmap {
         Some(bitmap) => {
-            let buf = match bitmap.as_buffer() {
-                (buf, 0, _) => buf,
-                _ => {
-                    let bytes = Bitmap::from_trusted_len_iter(bitmap.iter());
-                    let (buf, 0, _) = bytes.as_buffer() else {
-                        panic!()
-                    };
-                    buf
-                },
+            let (buf, 0, _) = bitmap.to_aligned_bitmap().as_buffer() else {
+                unreachable!()
             };
-
             write_bytes(ctx, BufferOrSlice::Buffer(&buf))?;
         },
         None => {

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -1557,17 +1557,19 @@ def test_sliced_struct_arrow_export_19612() -> None:
         {"x": [{"value": "A"}, None, {"value": "B"}, None]},
     )
 
-    tbls = [
+    arrow_tbls = [
         df.slice(0, 1).to_arrow(),
         df.slice(1, 1).to_arrow(),
         df.slice(2, 1).to_arrow(),
         df.slice(3, 1).to_arrow(),
     ]
 
-    expect_outputs = [{"value": "A"}, None, {"value": "B"}, None]
+    expected_row_values = [{"value": "A"}, None, {"value": "B"}, None]
 
-    for tbl, expect in zip(tbls, expect_outputs, strict=True):
+    for arrow_tbl, expect_row_value in zip(
+        arrow_tbls, expected_row_values, strict=True
+    ):
         assert_frame_equal(
-            pl.DataFrame(tbl),
-            pl.DataFrame({"x": [expect]}, schema=df.schema),
+            pl.DataFrame(arrow_tbl),
+            pl.DataFrame({"x": [expect_row_value]}, schema=df.schema),
         )

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -1550,3 +1550,24 @@ def test_from_pandas_timestamp_17382() -> None:
     assert isinstance(result, datetime)
     assert result.tzinfo == ZoneInfo("UTC")
     assert result == datetime(2021, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("UTC"))
+
+
+def test_sliced_struct_arrow_export_19612() -> None:
+    df = pl.DataFrame(
+        {"x": [{"value": "A"}, None, {"value": "B"}, None]},
+    )
+
+    tbls = [
+        df.slice(0, 1).to_arrow(),
+        df.slice(1, 1).to_arrow(),
+        df.slice(2, 1).to_arrow(),
+        df.slice(3, 1).to_arrow(),
+    ]
+
+    expect_outputs = [{"value": "A"}, None, {"value": "B"}, None]
+
+    for tbl, expect in zip(tbls, expect_outputs, strict=True):
+        assert_frame_equal(
+            pl.DataFrame(tbl),
+            pl.DataFrame({"x": [expect]}, schema=df.schema),
+        )


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/27450
* Fixes https://github.com/pola-rs/polars/issues/27079
