### PR TITLE
test(python): Ignore deprecation warnings on `to_struct()` in doctest

### DIFF
--- a/py-polars/tests/docs/run_doctest.py
+++ b/py-polars/tests/docs/run_doctest.py
@@ -125,6 +125,16 @@ if __name__ == "__main__":
         message="datetime.datetime.utcnow\\(\\) is deprecated.*",
         category=DeprecationWarning,
     )
+    warnings.filterwarnings(
+        "ignore",
+        message=r"arr\.to_struct\(\)",
+        category=DeprecationWarning,
+    )
+    warnings.filterwarnings(
+        "ignore",
+        message=r"list\.to_struct\(\)",
+        category=DeprecationWarning,
+    )
 
     OutputChecker = doctest.OutputChecker
 


### PR DESCRIPTION
Fix CI
