### PR TITLE
fix: Raise DuplicateError for duplicate CSV column names

### DIFF
--- a/crates/polars-io/src/csv/read/schema_inference.rs
+++ b/crates/polars-io/src/csv/read/schema_inference.rs
@@ -1,5 +1,6 @@
 use polars_buffer::Buffer;
 use polars_core::prelude::*;
+use polars_error::{PolarsResult, polars_bail};
 #[cfg(feature = "polars-time")]
 use polars_time::chunkedarray::string::infer as date_infer;
 #[cfg(feature = "polars-time")]
@@ -20,10 +21,11 @@ pub(super) fn infer_file_schema_impl(
     infer_all_as_str: bool,
     parse_options: &CsvParseOptions,
     schema_overwrite: Option<&Schema>,
-) -> Schema {
+) -> PolarsResult<Schema> {
     let mut headers = header_line
         .as_ref()
         .map(|line| infer_headers(line, parse_options))
+        .transpose()?
         .unwrap_or_else(|| Vec::with_capacity(8));
 
     let extend_header_with_unknown_column = header_line.is_none();
@@ -43,10 +45,13 @@ pub(super) fn infer_file_schema_impl(
         );
     }
 
-    build_schema(&headers, &column_types, schema_overwrite)
+    Ok(build_schema(&headers, &column_types, schema_overwrite))
 }
 
-fn infer_headers(mut header_line: &[u8], parse_options: &CsvParseOptions) -> Vec<PlSmallStr> {
+fn infer_headers(
+    mut header_line: &[u8],
+    parse_options: &CsvParseOptions,
+) -> PolarsResult<Vec<PlSmallStr>> {
     let len = header_line.len();
 
     if header_line.last().copied() == Some(b'\r') {
@@ -72,19 +77,22 @@ fn infer_headers(mut header_line: &[u8], parse_options: &CsvParseOptions) -> Vec
         .collect::<Vec<_>>();
 
     let mut deduplicated_headers = Vec::with_capacity(headers.len());
-    let mut header_names = PlHashMap::with_capacity(headers.len());
+    let mut header_names: PlHashMap<&str, usize> = PlHashMap::with_capacity(headers.len());
 
     for name in &headers {
         let count = header_names.entry(name.as_ref()).or_insert(0usize);
         if *count != 0 {
-            deduplicated_headers.push(format_pl_smallstr!("{}_duplicated_{}", name, *count - 1))
-        } else {
-            deduplicated_headers.push(PlSmallStr::from_str(name))
+            polars_bail!(
+                Duplicate:
+                "duplicate column name '{}' found in CSV, consider specifying unique column names with the `new_columns` argument",
+                name
+            )
         }
+        deduplicated_headers.push(PlSmallStr::from_str(name));
         *count += 1;
     }
 
-    deduplicated_headers
+    Ok(deduplicated_headers)
 }
 
 fn infer_types_from_line(

--- a/crates/polars-io/src/csv/read/streaming.rs
+++ b/crates/polars-io/src/csv/read/streaming.rs
@@ -781,7 +781,7 @@ fn infer_schema(
             infer_all_as_str,
             &options.parse_options,
             options.schema_overwrite.as_deref(),
-        )
+        )?
     };
 
     if let Some(schema) = &options.schema {

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1536,9 +1536,26 @@ def test_duplicated_columns(chunk_override: None) -> None:
     1,2
     """
     )
-    assert pl.read_csv(csv.encode()).columns == ["a", "a_duplicated_0"]
+    with pytest.raises(
+        pl.exceptions.DuplicateError,
+        match="duplicate column name 'a' found in CSV",
+    ):
+        pl.read_csv(csv.encode())
     new = ["c", "d"]
     assert pl.read_csv(csv.encode(), new_columns=new).columns == new
+
+
+def test_duplicated_columns_collision() -> None:
+    csv = textwrap.dedent(
+        """a,a_duplicated_0,a
+    1,2,3
+    """
+    )
+    with pytest.raises(
+        pl.exceptions.DuplicateError,
+        match="duplicate column name 'a' found in CSV",
+    ):
+        pl.read_csv(csv.encode())
 
 
 def test_error_message(chunk_override: None) -> None:


### PR DESCRIPTION
## Description

Previously, duplicate column names in CSV headers were silently renamed to `name_duplicated_N`. This could cause confusing errors if the CSV already contained a column with that name (e.g. from a previous round-trip write/read), resulting in:

```
ComputeError: found more fields than defined in 'Schema'
```

Now raises `DuplicateError` with a clear message indicating the duplicate column name, and suggests using the `new_columns` argument to provide unique names.

## Changes

- **`schema_inference.rs`**: `infer_headers()` now returns `PolarsResult` and raises `DuplicateError` when a duplicate column name is found, instead of renaming to `name_duplicated_N`
- **`streaming.rs`**: Updated `infer_file_schema_impl` call to propagate the `Result`
- **`test_csv.py`**: Updated existing test to expect `DuplicateError`, added new test for the collision case from the issue

## Example

```python
import polars as pl
import io

# Before: confusing ComputeError
# After: clear DuplicateError
data = "a,a_duplicated_0,a\n1,2,3"
pl.read_csv(io.StringIO(data))
# polars.exceptions.DuplicateError: duplicate column name 'a' found in CSV,
# consider specifying unique column names with the `new_columns` argument

# Workaround: provide unique column names
pl.read_csv(io.StringIO(data), new_columns=["x", "y", "z"])
```

Closes #28310
