### PR TITLE
feat: Improve plan-time row estimates for multi-file parquet scans

### DIFF
--- a/crates/polars-config/src/lib.rs
+++ b/crates/polars-config/src/lib.rs
@@ -453,10 +453,9 @@ impl Config {
         ResolveMode::from_discriminant(self.resolve_metadata_level.load(Ordering::Relaxed))
     }
 
-    /// Caps the footer sample size of a `Sampled` metadata resolve: for `n`
-    /// sources the sample is `min(max(sqrt(n), 16), limit, n)`. `None` (the
-    /// default) uses the concurrency budget, floored at 16, as the limit; an
-    /// explicit value is authoritative.
+    /// Caps how many footers a `Sampled` metadata resolve reads. `None` (the
+    /// default) leaves the cap to the resolver; an explicit value is
+    /// authoritative, even a low one.
     #[inline(always)]
     pub fn resolve_sample_limit(&self) -> Option<u64> {
         match self.resolve_sample_limit.load(Ordering::Relaxed) {

--- a/crates/polars-config/src/lib.rs
+++ b/crates/polars-config/src/lib.rs
@@ -47,6 +47,10 @@ const DEFAULT_PRUNE_PARQUET_METADATA: bool = false;
 
 const RESOLVE_METADATA_LEVEL: &str = "POLARS_RESOLVE_METADATA_LEVEL";
 
+const RESOLVE_SAMPLE_LIMIT: &str = "POLARS_RESOLVE_SAMPLE_LIMIT";
+// 0 = auto (see `resolve_sample_limit()`).
+const DEFAULT_RESOLVE_SAMPLE_LIMIT: u64 = 0;
+
 // Private.
 const VERBOSE_SENSITIVE: &str = "POLARS_VERBOSE_SENSITIVE";
 const DEFAULT_VERBOSE_SENSITIVE: bool = false;
@@ -112,6 +116,7 @@ static KNOWN_OPTIONS: &[&str] = &[
     PRUNE_PARQUET_METADATA,
     ALLOW_NESTED_CSPE,
     RESOLVE_METADATA_LEVEL,
+    RESOLVE_SAMPLE_LIMIT,
     /*
     Not yet supported public options:
 
@@ -163,6 +168,7 @@ pub struct Config {
     prune_parquet_metadata: AtomicBool,
     allow_nested_cspe: AtomicBool,
     resolve_metadata_level: AtomicU8,
+    resolve_sample_limit: AtomicU64,
 
     // Private.
     verbose_sensitive: AtomicBool,
@@ -195,6 +201,7 @@ impl Config {
             ),
             prune_parquet_metadata: AtomicBool::new(DEFAULT_PRUNE_PARQUET_METADATA),
             resolve_metadata_level: AtomicU8::new(ResolveMode::default() as u8),
+            resolve_sample_limit: AtomicU64::new(DEFAULT_RESOLVE_SAMPLE_LIMIT),
 
             // Private.
             verbose_sensitive: AtomicBool::new(DEFAULT_VERBOSE_SENSITIVE),
@@ -292,6 +299,11 @@ impl Config {
             RESOLVE_METADATA_LEVEL => self.resolve_metadata_level.store(
                 val.and_then(|x| parse::parse_resolve_mode(var, x))
                     .unwrap_or_default() as u8,
+                Ordering::Relaxed,
+            ),
+            RESOLVE_SAMPLE_LIMIT => self.resolve_sample_limit.store(
+                val.and_then(|x| parse::parse_u64(var, x))
+                    .unwrap_or(DEFAULT_RESOLVE_SAMPLE_LIMIT),
                 Ordering::Relaxed,
             ),
 
@@ -439,6 +451,18 @@ impl Config {
     #[inline(always)]
     pub fn resolve_metadata_level(&self) -> ResolveMode {
         ResolveMode::from_discriminant(self.resolve_metadata_level.load(Ordering::Relaxed))
+    }
+
+    /// Caps the footer sample size of a `Sampled` metadata resolve: for `n`
+    /// sources the sample is `min(max(sqrt(n), 16), limit, n)`. `None` (the
+    /// default) uses the concurrency budget, floored at 16, as the limit; an
+    /// explicit value is authoritative.
+    #[inline(always)]
+    pub fn resolve_sample_limit(&self) -> Option<u64> {
+        match self.resolve_sample_limit.load(Ordering::Relaxed) {
+            0 => None,
+            n => Some(n),
+        }
     }
 
     /// Whether we should do verbose printing on sensitive information.

--- a/crates/polars-config/src/resolve_mode.rs
+++ b/crates/polars-config/src/resolve_mode.rs
@@ -4,11 +4,11 @@ use std::str::FromStr;
 #[repr(u8)]
 #[derive(Clone, Debug, Copy, Default, Eq, PartialEq, Hash)]
 pub enum ResolveMode {
-    #[default]
     None = 0,
     RowCounts = 1,
     Full = 2,
     /// Sample a one-wave subset of footers and extrapolate; exact when the whole set fits.
+    #[default]
     Sampled = 3,
 }
 

--- a/crates/polars-io/src/cloud/glob.rs
+++ b/crates/polars-io/src/cloud/glob.rs
@@ -239,8 +239,7 @@ pub async fn glob(
             store
                 .list(path)
                 .try_filter_map(|x| async move {
-                    // Keep the LIST-reported byte size alongside the path; it
-                    // is free here and feeds size-weighted scan distribution.
+                    // Keep the LIST-reported byte size alongside the path.
                     let out = (x.size > 0 && matcher.is_matching(x.location.as_ref()))
                         .then_some((x.location, x.size));
                     Ok(out)

--- a/crates/polars-io/src/cloud/glob.rs
+++ b/crates/polars-io/src/cloud/glob.rs
@@ -209,7 +209,7 @@ impl Matcher {
 pub async fn glob(
     url: PlRefPath,
     cloud_options: Option<&CloudOptions>,
-) -> PolarsResult<Vec<String>> {
+) -> PolarsResult<Vec<(String, u64)>> {
     // Find the fixed prefix, up to the first '*'.
 
     let (
@@ -239,8 +239,10 @@ pub async fn glob(
             store
                 .list(path)
                 .try_filter_map(|x| async move {
+                    // Keep the LIST-reported byte size alongside the path; it
+                    // is free here and feeds size-weighted scan distribution.
                     let out = (x.size > 0 && matcher.is_matching(x.location.as_ref()))
-                        .then_some(x.location);
+                        .then_some((x.location, x.size));
                     Ok(out)
                 })
                 .try_collect::<Vec<_>>()
@@ -248,10 +250,10 @@ pub async fn glob(
         })
         .await?;
 
-    locations.sort_unstable();
+    locations.sort_unstable_by(|a, b| a.0.cmp(&b.0));
     Ok(locations
         .into_iter()
-        .map(|l| full_url(scheme, &bucket, l))
+        .map(|(l, size)| (full_url(scheme, &bucket, l), size))
         .collect::<Vec<_>>())
 }
 

--- a/crates/polars-io/src/path_utils/mod.rs
+++ b/crates/polars-io/src/path_utils/mod.rs
@@ -1,11 +1,12 @@
 use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use polars_buffer::Buffer;
 use polars_core::config;
 use polars_core::error::{PolarsResult, polars_bail, to_compute_err};
+use polars_utils::aliases::PlHashMap;
 use polars_utils::pl_path::{CloudScheme, PlRefPath};
 use polars_utils::pl_str::PlSmallStr;
 
@@ -236,6 +237,15 @@ pub async fn expand_paths(
         .map(|x| x.0)
 }
 
+/// Byte size per expanded path, as returned by [`expand_paths_hive`].
+///
+/// One slot per path, in the same order as the expanded paths. `Some` only
+/// when every path has a known size (the cloud LIST / fs stat provides them
+/// for free). A scan that mixes a glob with an explicit file, or any source
+/// we can't size cheaply, yields `None` and the consumer falls back to
+/// count-based behaviour.
+pub type BytesPerSource = Option<Arc<[u64]>>;
+
 struct HiveIdxTracker<'a> {
     idx: usize,
     paths: &'a [PlRefPath],
@@ -272,7 +282,7 @@ async fn expand_path_cloud(
     cloud_options: Option<&CloudOptions>,
     glob: bool,
     first_path_has_scheme: bool,
-) -> PolarsResult<(usize, Vec<PlRefPath>)> {
+) -> PolarsResult<(usize, Vec<(PlRefPath, Option<u64>)>)> {
     let format_path = |scheme: &str, bucket: &str, location: &str| {
         if first_path_has_scheme {
             format!("{scheme}://{bucket}/{location}")
@@ -298,12 +308,16 @@ async fn expand_path_cloud(
         path.has_scheme() || path.as_std_path().is_file()
     } {
         (
+            // A concrete file / prefix, not a LIST result, so no size is known.
             0,
-            vec![PlRefPath::new(format_path(
-                cloud_location.scheme,
-                &cloud_location.bucket,
-                prefix.as_ref(),
-            ))],
+            vec![(
+                PlRefPath::new(format_path(
+                    cloud_location.scheme,
+                    &cloud_location.bucket,
+                    prefix.as_ref(),
+                )),
+                None,
+            )],
         )
     } else {
         use futures::TryStreamExt;
@@ -326,14 +340,18 @@ async fn expand_path_cloud(
                 let out = s
                     .list(Some(prefix_ref))
                     .try_filter_map(|x| async move {
+                        // Retain the LIST-reported byte size (free) with the path.
                         let out = (x.size > 0).then(|| {
-                            PlRefPath::new({
-                                format_path(
-                                    cloud_location.scheme,
-                                    &cloud_location.bucket,
-                                    x.location.as_ref(),
-                                )
-                            })
+                            (
+                                PlRefPath::new({
+                                    format_path(
+                                        cloud_location.scheme,
+                                        &cloud_location.bucket,
+                                        x.location.as_ref(),
+                                    )
+                                }),
+                                Some(x.size),
+                            )
                         });
                         Ok(out)
                     })
@@ -376,9 +394,9 @@ pub async fn expand_paths_hive(
     hidden_file_prefix: &[PlSmallStr],
     #[allow(unused_variables)] cloud_options: &mut Option<CloudOptions>,
     check_directory_level: bool,
-) -> PolarsResult<(Buffer<PlRefPath>, usize)> {
+) -> PolarsResult<(Buffer<PlRefPath>, usize, BytesPerSource)> {
     let Some(first_path) = paths.first() else {
-        return Ok((vec![].into(), 0));
+        return Ok((vec![].into(), 0, None));
     };
 
     let first_path_has_scheme = first_path.has_scheme();
@@ -398,6 +416,11 @@ pub async fn expand_paths_hive(
         exts: [None, None],
         is_hidden_file: &is_hidden_file,
     };
+
+    // Byte size per expanded path, collected where it is free (cloud LIST,
+    // fs stat). Order-independent, so the path sorting below need not touch
+    // it; the aligned size vector is built by lookup after expansion.
+    let mut sizes_by_path: PlHashMap<PlRefPath, u64> = PlHashMap::default();
 
     let mut hive_idx_tracker = HiveIdxTracker {
         idx: usize::MAX,
@@ -419,7 +442,8 @@ pub async fn expand_paths_hive(
                 )
                 .await?;
 
-                return Ok((paths.into(), expand_start_idx));
+                // HF listing doesn't surface per-file sizes here; degrade to None.
+                return Ok((paths.into(), expand_start_idx, None));
             }
 
             for (path_idx, path) in paths.iter().enumerate() {
@@ -484,13 +508,17 @@ pub async fn expand_paths_hive(
 
                     let iter = crate::async_glob(path.into_owned(), cloud_options.as_ref()).await?;
 
-                    if first_path_has_scheme {
-                        out_paths.extend(iter.into_iter().map(PlRefPath::new))
-                    } else {
-                        // FORCE_ASYNC, remove leading file:// as the caller may not be expecting a
-                        // URI result.
-                        out_paths.extend(iter.iter().map(|x| &x[7..]).map(PlRefPath::new))
-                    };
+                    for (url, size) in iter {
+                        // FORCE_ASYNC (no scheme on first path): strip the leading
+                        // `file://` the caller may not be expecting.
+                        let p = if first_path_has_scheme {
+                            PlRefPath::new(url)
+                        } else {
+                            PlRefPath::new(&url[7..])
+                        };
+                        sizes_by_path.insert(p.clone(), size);
+                        out_paths.push(p);
+                    }
                 } else {
                     let (expand_start_idx, paths) = expand_path_cloud(
                         path.into_owned(),
@@ -499,7 +527,12 @@ pub async fn expand_paths_hive(
                         first_path_has_scheme,
                     )
                     .await?;
-                    out_paths.extend_from_slice(&paths);
+                    for (p, size) in paths {
+                        if let Some(size) = size {
+                            sizes_by_path.insert(p.clone(), size);
+                        }
+                        out_paths.push(p);
+                    }
                     hive_idx_tracker.update(expand_start_idx, path_idx)?;
                 };
 
@@ -547,7 +580,9 @@ pub async fn expand_paths_hive(
                         if md.is_dir() {
                             stack.push_back(Cow::Owned(path));
                         } else if md.len() > 0 {
-                            out_paths.push(PlRefPath::try_from_path(&path)?);
+                            let p = PlRefPath::try_from_path(&path)?;
+                            sizes_by_path.insert(p.clone(), md.len());
+                            out_paths.push(p);
                         }
                     }
                 }
@@ -562,7 +597,9 @@ pub async fn expand_paths_hive(
                     let path = path.map_err(to_compute_err)?;
                     let md = path.metadata()?;
                     if !md.is_dir() && md.len() > 0 {
-                        out_paths.push(PlRefPath::try_from_path(&path)?);
+                        let p = PlRefPath::try_from_path(&path)?;
+                        sizes_by_path.insert(p.clone(), md.len());
+                        out_paths.push(p);
                     }
                 }
             } else {
@@ -587,7 +624,20 @@ pub async fn expand_paths_hive(
         }
     }
 
-    return Ok((out_paths.paths.into(), hive_idx_tracker.idx));
+    // Build the per-source size vector aligned with the final (sorted) path
+    // order. All-or-nothing: `Some` only if every path has a known size.
+    let bytes_per_source: BytesPerSource = out_paths
+        .paths
+        .iter()
+        .map(|p| sizes_by_path.get(p).copied())
+        .collect::<Option<Vec<u64>>>()
+        .map(Arc::from);
+
+    return Ok((
+        out_paths.paths.into(),
+        hive_idx_tracker.idx,
+        bytes_per_source,
+    ));
 
     /// Wrapper around `Vec<PathBuf>` that also tracks file extensions, so that
     /// we don't have to traverse the entire list again to validate extensions.
@@ -610,23 +660,6 @@ pub async fn expand_paths_hive(
             Self::update_ext_status(exts, &value);
 
             self.paths.push(value)
-        }
-
-        fn extend(&mut self, values: impl IntoIterator<Item = PlRefPath>) {
-            let exts = &mut self.exts;
-
-            self.paths.extend(
-                values
-                    .into_iter()
-                    .filter(|x| !(self.is_hidden_file)(x))
-                    .inspect(|x| {
-                        Self::update_ext_status(exts, x);
-                    }),
-            )
-        }
-
-        fn extend_from_slice(&mut self, values: &[PlRefPath]) {
-            self.extend(values.iter().cloned())
         }
 
         fn update_ext_status(exts: &mut [Option<(PlSmallStr, PlRefPath)>; 2], value: &PlRefPath) {

--- a/crates/polars-io/src/path_utils/mod.rs
+++ b/crates/polars-io/src/path_utils/mod.rs
@@ -239,11 +239,8 @@ pub async fn expand_paths(
 
 /// Byte size per expanded path, as returned by [`expand_paths_hive`].
 ///
-/// One slot per path, in the same order as the expanded paths. `Some` only
-/// when every path has a known size (the cloud LIST / fs stat provides them
-/// for free). A scan that mixes a glob with an explicit file, or any source
-/// we can't size cheaply, yields `None` and the consumer falls back to
-/// count-based behaviour.
+/// One slot per path, in expanded-path order; `Some` only when every path
+/// has a known size.
 pub type BytesPerSource = Option<Arc<[u64]>>;
 
 struct HiveIdxTracker<'a> {
@@ -340,7 +337,7 @@ async fn expand_path_cloud(
                 let out = s
                     .list(Some(prefix_ref))
                     .try_filter_map(|x| async move {
-                        // Retain the LIST-reported byte size (free) with the path.
+                        // Retain the LIST-reported byte size with the path.
                         let out = (x.size > 0).then(|| {
                             (
                                 PlRefPath::new({
@@ -417,9 +414,8 @@ pub async fn expand_paths_hive(
         is_hidden_file: &is_hidden_file,
     };
 
-    // Byte size per expanded path, collected where it is free (cloud LIST,
-    // fs stat). Order-independent, so the path sorting below need not touch
-    // it; the aligned size vector is built by lookup after expansion.
+    // Order-independent, so the path sorting below need not carry sizes; the
+    // aligned vector is built by lookup after expansion.
     let mut sizes_by_path: PlHashMap<PlRefPath, u64> = PlHashMap::default();
 
     let mut hive_idx_tracker = HiveIdxTracker {
@@ -624,8 +620,7 @@ pub async fn expand_paths_hive(
         }
     }
 
-    // Build the per-source size vector aligned with the final (sorted) path
-    // order. All-or-nothing: `Some` only if every path has a known size.
+    // All-or-nothing: `Some` only if every path has a known size.
     let bytes_per_source: BytesPerSource = out_paths
         .paths
         .iter()

--- a/crates/polars-plan/src/dsl/file_scan/mod.rs
+++ b/crates/polars-plan/src/dsl/file_scan/mod.rs
@@ -94,21 +94,113 @@ const _: () = {
     assert!(std::mem::size_of::<FileScanIR>() <= 80);
 };
 
-/// Footer metadata per scan source.
+/// Footer metadata retained per scan source.
 ///
-/// `None` if the scan retained no per-source metadata. Otherwise the vector
-/// has one slot per source (a scanned file or in-memory buffer), in the same
-/// order as the scan's `sources` list: slot `i` holds the decoded footer of
-/// source `i`, or `None` if that footer was never read. `Full` resolve fills
-/// every slot; `Sampled` fills only the slots its wave read.
-///
-/// A `None` slot means "unknown": consumers must fall back, never guess.
-// TODO: Follow-up refactor of this type, in two parts: (1) promote the outer
-// `Option` to a three-state enum (unresolved / sparse / full); (2) replace the
-// inner `Option` with per-slot knowledge states (footer / row-count-only /
-// unread / failed). Gated on the first consumer that branches on these.
+/// Source indices refer to the scan's source list; a source not covered by
+/// the variant is unknown.
 #[cfg(feature = "parquet")]
-pub type MetadataPerSource = Option<Arc<[Option<FileMetadataRef>]>>;
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum MetadataPerSource {
+    /// No per-source metadata retained.
+    #[default]
+    Unresolved,
+    /// Footers of a strict subset of the sources.
+    Partial(Arc<PartialMetadata>),
+    /// Every source's footer: entry `i` is the footer of source `i`.
+    Full(Arc<[FileMetadataRef]>),
+}
+
+/// The resolved subset held by [`MetadataPerSource::Partial`].
+#[cfg(feature = "parquet")]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct PartialMetadata {
+    /// Source indices of the resolved footers, ascending.
+    indices: Vec<usize>,
+    /// Dense footers: `metadata[j]` is the footer of source `indices[j]`.
+    metadata: Vec<FileMetadataRef>,
+}
+
+#[cfg(feature = "parquet")]
+impl MetadataPerSource {
+    /// Build from `(source index, footer)` entries; coverage picks the
+    /// variant.
+    pub(crate) fn new(
+        entries: impl IntoIterator<Item = (usize, FileMetadataRef)>,
+        n_sources: usize,
+    ) -> Self {
+        let mut entries: Vec<_> = entries.into_iter().collect();
+        // Sorted storage; strictness also rules out duplicate indices.
+        entries.sort_unstable_by_key(|&(i, _)| i);
+        debug_assert!(entries.windows(2).all(|w| w[0].0 < w[1].0));
+        debug_assert!(entries.last().is_none_or(|(i, _)| *i < n_sources));
+        if entries.is_empty() {
+            Self::Unresolved
+        } else if entries.len() == n_sources {
+            Self::Full(entries.into_iter().map(|(_, m)| m).collect())
+        } else {
+            let (indices, metadata) = entries.into_iter().unzip();
+            Self::Partial(Arc::new(PartialMetadata { indices, metadata }))
+        }
+    }
+
+    /// Footer of the scan's current source 0, when resolved.
+    ///
+    /// Every resolve that reads source 0's footer retains it, so this is
+    /// `Some` for any non-`Unresolved` value produced by resolve;
+    /// [`Self::gather`] can drop it.
+    pub fn first_metadata(&self) -> Option<&FileMetadataRef> {
+        match self {
+            Self::Unresolved => None,
+            Self::Partial(p) => (p.indices.first() == Some(&0)).then(|| &p.metadata[0]),
+            Self::Full(s) => s.first(),
+        }
+    }
+
+    /// Re-index to the sources surviving a filter.
+    ///
+    /// `surviving` yields ascending pre-filter source indices.
+    fn gather(&self, surviving: impl Iterator<Item = usize>) -> Self {
+        match self {
+            // A sampled subset is not worth renumbering across a filter;
+            // per-source estimates re-derive from the byte sizes.
+            Self::Unresolved | Self::Partial(_) => Self::Unresolved,
+            Self::Full(s) => {
+                let gathered: Vec<FileMetadataRef> = surviving.map(|i| s[i].clone()).collect();
+                if gathered.is_empty() {
+                    Self::Unresolved
+                } else {
+                    Self::Full(gathered.into())
+                }
+            },
+        }
+    }
+
+    /// Apply `f` to every retained footer, keeping the variant and indices.
+    pub(crate) fn map_footers(
+        &self,
+        mut f: impl FnMut(&FileMetadataRef) -> FileMetadataRef,
+    ) -> Self {
+        match self {
+            Self::Unresolved => Self::Unresolved,
+            Self::Partial(p) => Self::Partial(Arc::new(PartialMetadata {
+                indices: p.indices.clone(),
+                metadata: p.metadata.iter().map(&mut f).collect(),
+            })),
+            Self::Full(s) => Self::Full(s.iter().map(f).collect()),
+        }
+    }
+
+    /// Allocation identity, for pointer-based eq/hash.
+    pub(crate) fn as_arc_ptr(&self) -> Option<usize> {
+        match self {
+            Self::Unresolved => None,
+            Self::Partial(p) => Some(Arc::as_ptr(p) as *const () as usize),
+            Self::Full(f) => Some(Arc::as_ptr(f) as *const () as usize),
+        }
+    }
+}
 
 #[derive(Clone, Debug, IntoStaticStr)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -128,23 +220,12 @@ pub enum FileScanIR {
     #[cfg(feature = "parquet")]
     Parquet {
         options: ParquetOptions,
-        /// Pre-decoded first-file metadata. Consumed by the streaming
-        /// `ParquetReaderBuilder` as its initial hint.
-        #[cfg_attr(feature = "dsl-schema", serde(skip))]
-        first_metadata: Option<FileMetadataRef>,
-        /// Per-source footer metadata for the distributed scheduler (slot
-        /// semantics on [`MetadataPerSource`]). Slot 0 always holds
-        /// `first_metadata`, since source 0 is always read; unknown slots
-        /// fall back (e.g. to `bytes_per_source`).
+        /// Per-source footer metadata.
         #[cfg_attr(feature = "dsl-schema", serde(skip))]
         metadata_per_source: MetadataPerSource,
-        /// Byte size per scan source, retained from path expansion (the
-        /// cloud LIST / fs stat already returns them). One slot per source,
-        /// in the same order as `sources`; present only when every source
-        /// has a known size, `None` otherwise. Unlike `metadata_per_source`
-        /// these are available in any resolve mode (they come from the
-        /// listing, not the footers), and drive the cloud scheduler's
-        /// size-weighted multi-file scan distribution.
+        /// Byte size per scan source, retained from path expansion. One slot
+        /// per source in `sources` order; `Some` only when every source has
+        /// a known size.
         #[cfg_attr(feature = "dsl-schema", serde(skip))]
         bytes_per_source: Option<Arc<[u64]>>,
     },
@@ -212,33 +293,24 @@ impl FileScanIR {
     /// Re-index pre-decoded per-source state after a source-list filter.
     ///
     /// `surviving_indices` yields ascending indices into the pre-filter list.
-    pub fn gather_after_filter<I>(&mut self, first_file_dropped: bool, surviving_indices: I)
-    where
+    pub fn gather_after_filter<I>(
+        &mut self,
+        #[allow(unused)] first_file_dropped: bool,
+        surviving_indices: I,
+    ) where
         I: Iterator<Item = usize> + Clone,
     {
-        // Parquet: clear `first_metadata` if file 0 dropped; gather
-        // `metadata_per_source` by surviving indices so slice[i] still
-        // matches sources[i]. We re-index instead of clearing because
-        // the surviving footers are already decoded; tossing them would
-        // force the scheduler to refetch and re-decode the same bytes.
+        // Parquet: gather per-source state by surviving indices so entry `i`
+        // still matches sources[i].
         // Ipc / PythonDataset: file-0-keyed state cleared when file 0 dropped.
         match self {
             #[cfg(feature = "parquet")]
             Self::Parquet {
                 options: _,
-                first_metadata,
                 metadata_per_source,
                 bytes_per_source,
             } => {
-                if first_file_dropped {
-                    *first_metadata = None;
-                }
-                if let Some(slice) = metadata_per_source {
-                    *slice = surviving_indices
-                        .clone()
-                        .map(|i| slice[i].clone())
-                        .collect();
-                }
+                *metadata_per_source = metadata_per_source.gather(surviving_indices.clone());
                 if let Some(slice) = bytes_per_source {
                     *slice = surviving_indices.map(|i| slice[i]).collect();
                 }
@@ -524,7 +596,6 @@ mod _file_scan_eq_hash {
         #[cfg(feature = "parquet")]
         Parquet {
             options: &'a polars_io::prelude::ParquetOptions,
-            first_metadata: Option<usize>,
             metadata_per_source: Option<usize>,
             bytes_per_source: Option<usize>,
         },
@@ -572,13 +643,11 @@ mod _file_scan_eq_hash {
                 #[cfg(feature = "parquet")]
                 FileScanIR::Parquet {
                     options,
-                    first_metadata,
                     metadata_per_source,
                     bytes_per_source,
                 } => FileScanEqHashWrap::Parquet {
                     options,
-                    first_metadata: first_metadata.as_ref().map(arc_as_ptr),
-                    metadata_per_source: metadata_per_source.as_ref().map(arc_as_ptr),
+                    metadata_per_source: metadata_per_source.as_arc_ptr(),
                     bytes_per_source: bytes_per_source.as_ref().map(arc_as_ptr),
                 },
 

--- a/crates/polars-plan/src/dsl/file_scan/mod.rs
+++ b/crates/polars-plan/src/dsl/file_scan/mod.rs
@@ -94,6 +94,22 @@ const _: () = {
     assert!(std::mem::size_of::<FileScanIR>() <= 80);
 };
 
+/// Footer metadata per scan source.
+///
+/// `None` if the scan retained no per-source metadata. Otherwise the vector
+/// has one slot per source (a scanned file or in-memory buffer), in the same
+/// order as the scan's `sources` list: slot `i` holds the decoded footer of
+/// source `i`, or `None` if that footer was never read. `Full` resolve fills
+/// every slot; `Sampled` fills only the slots its wave read.
+///
+/// A `None` slot means "unknown": consumers must fall back, never guess.
+// TODO: Follow-up refactor of this type, in two parts: (1) promote the outer
+// `Option` to a three-state enum (unresolved / sparse / full); (2) replace the
+// inner `Option` with per-slot knowledge states (footer / row-count-only /
+// unread / failed). Gated on the first consumer that branches on these.
+#[cfg(feature = "parquet")]
+pub type MetadataPerSource = Option<Arc<[Option<FileMetadataRef>]>>;
+
 #[derive(Clone, Debug, IntoStaticStr)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "dsl-schema", derive(schemars::JsonSchema))]
@@ -116,12 +132,21 @@ pub enum FileScanIR {
         /// `ParquetReaderBuilder` as its initial hint.
         #[cfg_attr(feature = "dsl-schema", serde(skip))]
         first_metadata: Option<FileMetadataRef>,
-        /// Per-source metadata for the distributed scheduler. `Some(s)`
-        /// only in `Full` resolve mode, with `s[i]` for `sources[i]`.
-        /// `s[0] == first_metadata` so callers iterate uniformly
-        /// without special-casing the first source.
+        /// Per-source footer metadata for the distributed scheduler (slot
+        /// semantics on [`MetadataPerSource`]). Slot 0 always holds
+        /// `first_metadata`, since source 0 is always read; unknown slots
+        /// fall back (e.g. to `bytes_per_source`).
         #[cfg_attr(feature = "dsl-schema", serde(skip))]
-        metadata_per_source: Option<Arc<[FileMetadataRef]>>,
+        metadata_per_source: MetadataPerSource,
+        /// Byte size per scan source, retained from path expansion (the
+        /// cloud LIST / fs stat already returns them). One slot per source,
+        /// in the same order as `sources`; present only when every source
+        /// has a known size, `None` otherwise. Unlike `metadata_per_source`
+        /// these are available in any resolve mode (they come from the
+        /// listing, not the footers), and drive the cloud scheduler's
+        /// size-weighted multi-file scan distribution.
+        #[cfg_attr(feature = "dsl-schema", serde(skip))]
+        bytes_per_source: Option<Arc<[u64]>>,
     },
 
     #[cfg(feature = "ipc")]
@@ -189,7 +214,7 @@ impl FileScanIR {
     /// `surviving_indices` yields ascending indices into the pre-filter list.
     pub fn gather_after_filter<I>(&mut self, first_file_dropped: bool, surviving_indices: I)
     where
-        I: Iterator<Item = usize>,
+        I: Iterator<Item = usize> + Clone,
     {
         // Parquet: clear `first_metadata` if file 0 dropped; gather
         // `metadata_per_source` by surviving indices so slice[i] still
@@ -203,12 +228,19 @@ impl FileScanIR {
                 options: _,
                 first_metadata,
                 metadata_per_source,
+                bytes_per_source,
             } => {
                 if first_file_dropped {
                     *first_metadata = None;
                 }
                 if let Some(slice) = metadata_per_source {
-                    *slice = surviving_indices.map(|i| slice[i].clone()).collect();
+                    *slice = surviving_indices
+                        .clone()
+                        .map(|i| slice[i].clone())
+                        .collect();
+                }
+                if let Some(slice) = bytes_per_source {
+                    *slice = surviving_indices.map(|i| slice[i]).collect();
                 }
             },
             #[cfg(feature = "ipc")]
@@ -494,6 +526,7 @@ mod _file_scan_eq_hash {
             options: &'a polars_io::prelude::ParquetOptions,
             first_metadata: Option<usize>,
             metadata_per_source: Option<usize>,
+            bytes_per_source: Option<usize>,
         },
 
         #[cfg(feature = "ipc")]
@@ -541,10 +574,12 @@ mod _file_scan_eq_hash {
                     options,
                     first_metadata,
                     metadata_per_source,
+                    bytes_per_source,
                 } => FileScanEqHashWrap::Parquet {
                     options,
                     first_metadata: first_metadata.as_ref().map(arc_as_ptr),
                     metadata_per_source: metadata_per_source.as_ref().map(arc_as_ptr),
+                    bytes_per_source: bytes_per_source.as_ref().map(arc_as_ptr),
                 },
 
                 #[cfg(feature = "ipc")]

--- a/crates/polars-plan/src/dsl/scan_sources.rs
+++ b/crates/polars-plan/src/dsl/scan_sources.rs
@@ -11,7 +11,8 @@ use polars_io::file_cache::FileCacheEntry;
 use polars_io::metrics::IOMetrics;
 use polars_io::utils::byte_source::{DynByteSource, DynByteSourceBuilder};
 use polars_io::{
-    decode_file_uri_paths, expand_paths, expand_paths_hive, expanded_from_single_directory,
+    BytesPerSource, decode_file_uri_paths, expand_paths, expand_paths_hive,
+    expanded_from_single_directory,
 };
 use polars_utils::mmap::MMapSemaphore;
 use polars_utils::pl_path::PlRefPath;
@@ -208,7 +209,7 @@ impl ScanSources {
     pub async fn expand_paths_with_hive_update(
         &self,
         scan_args: &mut UnifiedScanArgs,
-    ) -> PolarsResult<Self> {
+    ) -> PolarsResult<(Self, BytesPerSource)> {
         match self {
             Self::Paths(paths) => {
                 // Decode up front so expansion, single-directory detection, and hive parsing
@@ -216,7 +217,7 @@ impl ScanSources {
                 let paths = decode_file_uri_paths(paths, scan_args.glob);
                 let paths = paths.as_ref();
 
-                let (expanded_paths, hive_start_idx) = expand_paths_hive(
+                let (expanded_paths, hive_start_idx, bytes_per_source) = expand_paths_hive(
                     paths,
                     scan_args.glob,
                     scan_args.hidden_file_prefix.as_deref().unwrap_or_default(),
@@ -232,9 +233,9 @@ impl ScanSources {
                 }
                 scan_args.hive_options.hive_start_idx = hive_start_idx;
 
-                Ok(Self::Paths(expanded_paths))
+                Ok((Self::Paths(expanded_paths), bytes_per_source))
             },
-            v => Ok(v.clone()),
+            v => Ok((v.clone(), None)),
         }
     }
 

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
@@ -51,18 +51,25 @@ pub(super) async fn dsl_to_ir(
 
         let sources_before_expansion = &sources;
 
+        // Per-source byte sizes retained from path expansion; only parquet
+        // consumes them today (stored on `FileScanIR::Parquet` for the cloud
+        // scheduler's weighted distribution).
+        let mut bytes_per_source: Option<Arc<[u64]>> = None;
         let sources = match &*scan_type {
             #[cfg(feature = "parquet")]
             FileScanDsl::Parquet { .. } => {
-                sources
+                let (sources, bytes) = sources
                     .expand_paths_with_hive_update(unified_scan_args)
-                    .await?
+                    .await?;
+                bytes_per_source = bytes;
+                sources
             },
             #[cfg(feature = "ipc")]
             FileScanDsl::Ipc { .. } => {
                 sources
                     .expand_paths_with_hive_update(unified_scan_args)
                     .await?
+                    .0
             },
             #[cfg(feature = "csv")]
             FileScanDsl::Csv { .. } => sources.expand_paths(unified_scan_args).await?,
@@ -88,6 +95,7 @@ pub(super) async fn dsl_to_ir(
                     &scan_type,
                     &sources,
                     sources_before_expansion,
+                    bytes_per_source,
                     unified_scan_args,
                     #[cfg(feature = "python")]
                     py_scan_resolve_threadpool,
@@ -244,12 +252,12 @@ fn prepare_schemas(
 pub(super) async fn parquet_file_info(
     sources: &ScanSources,
     row_index: Option<&RowIndex>,
+    // Per-source byte sizes from path expansion, aligned with `sources`. When
+    // present, the `Sampled` arm weights its row extrapolation by bytes
+    // (skew-robust) instead of assuming every file has the sample's mean count.
+    bytes_per_source: Option<&[u64]>,
     #[allow(unused)] cloud_options: Option<&polars_io::cloud::CloudOptions>,
-) -> PolarsResult<(
-    FileInfo,
-    Option<FileMetadataRef>,
-    Option<Arc<[FileMetadataRef]>>,
-)> {
+) -> PolarsResult<(FileInfo, Option<FileMetadataRef>, MetadataPerSource)> {
     use futures::stream::{FuturesOrdered, FuturesUnordered, StreamExt};
     use polars_core::error::feature_gated;
 
@@ -286,10 +294,11 @@ pub(super) async fn parquet_file_info(
 
     // Resolve metadata for sources past the first, dispatched by
     // `POLARS_RESOLVE_METADATA_LEVEL`:
-    // - `None` (default): extrapolate `first_num_rows * n_sources`, no extra reads.
+    // - `None`: extrapolate `first_num_rows * n_sources`, no extra reads.
     // - `RowCounts`: per-source thrift field 3 only, exact total.
-    // - `Sampled`: read one concurrency wave of footers and extrapolate (exact
-    //   when the whole set fits in the wave).
+    // - `Sampled`: read one concurrency wave of full footers, retain them
+    //   sparsely in `metadata_per_source`, and extrapolate (exact when the
+    //   whole set fits in the wave).
     // - `Full`: per-source footer, populates `metadata_per_source` for the
     //   distributed scheduler.
     //
@@ -301,7 +310,7 @@ pub(super) async fn parquet_file_info(
     struct Resolution {
         reader_schema: ArrowSchemaRef,
         first_metadata: FileMetadataRef,
-        metadata_per_source: Option<Arc<[FileMetadataRef]>>,
+        metadata_per_source: MetadataPerSource,
         known_size: Option<usize>,
         estimated_size: usize,
     }
@@ -319,6 +328,27 @@ pub(super) async fn parquet_file_info(
         }
     } else {
         use polars_config::ResolveMode;
+
+        // For `Sampled`: the strided footer sample, `Some` only when it does
+        // NOT already span every source. A wave that covers the whole set
+        // routes through the `Full` arm instead (same bytes, zero extra
+        // requests).
+        let partial_sample = matches!(mode, ResolveMode::Sampled)
+            .then(|| {
+                // Cap on the sample size (the size itself is derived in
+                // `sampled_source_indices`). The default cap is the IO budget
+                // floored at `SAMPLE_FLOOR`: a small budget must not push the
+                // sample below the statistical minimum (reads beyond the
+                // budget merely queue, at most one extra wave). An explicit
+                // limit is authoritative, even below the floor.
+                let limit = polars_config::config().resolve_sample_limit().map_or_else(
+                    || (polars_io::pl_async::get_concurrency_limit() as usize).max(SAMPLE_FLOOR),
+                    |o| o as usize,
+                );
+                sampled_source_indices(n_sources, limit)
+            })
+            .filter(|sample| sample.len() + 1 != n_sources);
+
         match mode {
             ResolveMode::None => {
                 // No other-source reads; extrapolate from file 0 alone.
@@ -365,54 +395,127 @@ pub(super) async fn parquet_file_info(
                     estimated_size: total,
                 }
             },
-            ResolveMode::Sampled => {
-                // Sample `sqrt(n)` footers (`sampled_source_indices`) and
-                // extrapolate the per-file mean. Exact when the sample spans
-                // every file; otherwise `estimated_size` only, not `known_size`.
-                //
-                // TODO: byte-weight (`rows_per_byte * total_bytes`, skew-robust)
-                // once per-file LIST sizes reach plan time.
-                let limit = polars_io::pl_async::get_concurrency_limit() as usize;
-                let sample = sampled_source_indices(n_sources, limit);
-                // file 0 plus the sample; if that spans every file we read all.
-                let read_all = sample.len() + 1 == n_sources;
+            // `Sampled` whose wave does NOT span every source: read the sample's
+            // full footers and retain them (sparse; unread slots are `None`).
+            // The total is extrapolated: overhead-calibrated byte weighting
+            // when sizes are known (see `byte_estimate` below), else the
+            // per-file mean (`sampled_rows * n / n_read`). Same footer bytes
+            // as a row-count read, just decoded fully so the metadata is
+            // retained.
+            ResolveMode::Sampled if partial_sample.is_some() => {
+                let sample = partial_sample.expect("guarded to a partial sample");
+                // Per-source listing sizes for the byte-weighted estimate,
+                // consumed after the reads so the calibration only uses the
+                // slots that actually resolved.
+                let known_sizes = bytes_per_source.filter(|b| !b.is_empty()).inspect(|b| {
+                    // Aligned with `sources` by construction: path expansion
+                    // builds both, and `gather_after_filter` re-indexes both
+                    // by the same surviving indices.
+                    debug_assert_eq!(b.len(), n_sources);
+                });
+                // Place each footer at its source index; the wave completes out
+                // of order, so we index rather than push.
                 let rest_fut = async move {
                     let mut futures = sample
                         .iter()
                         .map(|&i| async move {
-                            read_parquet_num_rows(sources.at(i), cloud_options).await
+                            (
+                                i,
+                                read_parquet_metadata(sources.at(i), cloud_options)
+                                    .await
+                                    .ok(),
+                            )
                         })
                         .collect::<FuturesUnordered<_>>();
+                    let mut slots: Vec<Option<FileMetadataRef>> = vec![None; n_sources];
                     let mut rows = 0usize;
-                    let mut read = 0usize;
-                    while let Some(res) = futures.next().await {
-                        if let Ok(n) = res {
-                            rows = rows.saturating_add(n as usize);
-                            read += 1;
+                    while let Some((i, meta)) = futures.next().await {
+                        if let Some(m) = meta {
+                            rows = rows.saturating_add(m.num_rows);
+                            slots[i] = Some(m);
                         }
                     }
-                    PolarsResult::Ok((rows, read))
+                    PolarsResult::Ok((slots, rows))
                 };
-                let ((reader_schema, first_num_rows, first_metadata), (other_rows, other_read)) =
+                let ((reader_schema, first_num_rows, first_metadata), (mut slots, other_rows)) =
                     futures::future::try_join(first_fut, rest_fut).await?;
-                // file 0 always counts toward the sample.
+                // file 0 is always read.
+                slots[0] = Some(first_metadata.clone());
                 let sampled_rows = first_num_rows.saturating_add(other_rows);
-                let n_read = 1 + other_read;
-                // Extrapolate the per-file mean across all sources. `n_read` is
-                // always >= 1 (file 0), so the division is safe; when every file
-                // was read successfully this is exact, so report it as known.
-                let estimated =
-                    ((sampled_rows as u128 * n_sources as u128) / n_read as u128) as usize;
-                let known = (read_all && n_read == n_sources).then_some(estimated);
+                let n_read = slots.iter().filter(|s| s.is_some()).count();
+                let byte_estimate = known_sizes.and_then(|bytes| {
+                    // A parquet file is fixed overhead (schema, footer, page
+                    // headers) plus data pages, so raw file-size ratios badly
+                    // overstate rows on small files. Learn rows-per-data-byte
+                    // and the mean per-file overhead from the sampled footers,
+                    // then size the unread files' data bytes from their listed
+                    // sizes. Mirrored in
+                    // `test_resolve_metadata_sampled_byte_weighted`; keep in sync.
+                    // TODO: Extract into a unit-testable function to retire the mirror.
+                    let mut sampled_data: u128 = 0;
+                    let mut sampled_overhead: u128 = 0;
+                    // Unresolved = never sampled OR the read failed; both get
+                    // their rows estimated from their listed bytes.
+                    let mut unresolved_bytes: u128 = 0;
+                    for (&size, slot) in bytes.iter().zip(&slots) {
+                        match slot {
+                            Some(m) => {
+                                // Clamped to the listed size so a malformed
+                                // footer cannot underflow the overhead.
+                                let data = m
+                                    .row_groups
+                                    .iter()
+                                    .map(|rg| rg.compressed_size() as u128)
+                                    .sum::<u128>()
+                                    .min(size as u128);
+                                sampled_data += data;
+                                sampled_overhead += size as u128 - data;
+                            },
+                            None => unresolved_bytes += size as u128,
+                        }
+                    }
+                    // A 0-row sample has no density to learn from; fall back.
+                    (sampled_data > 0).then(|| {
+                        let mean_overhead = sampled_overhead / n_read as u128;
+                        let unresolved_files = (n_sources - n_read) as u128;
+                        let unresolved_data =
+                            unresolved_bytes.saturating_sub(mean_overhead * unresolved_files);
+                        (sampled_rows as u128
+                            + unresolved_data * sampled_rows as u128 / sampled_data)
+                            as usize
+                    })
+                });
+                let byte_weighted = byte_estimate.is_some();
+                let estimated = byte_estimate.unwrap_or_else(|| {
+                    // `n_read` is always >= 1 (file 0), so the division is safe.
+                    ((sampled_rows as u128 * n_sources as u128) / n_read as u128) as usize
+                });
+                if verbose() {
+                    eprintln!(
+                        "parquet sampled resolve: read {n_read} / {n_sources} footers, \
+                         estimated rows: {estimated} ({})",
+                        if byte_weighted {
+                            "byte-weighted"
+                        } else {
+                            "count-based"
+                        },
+                    );
+                }
+                // Partial coverage: retain what we read, but the total is an
+                // estimate, not known.
                 Resolution {
                     reader_schema,
                     first_metadata,
-                    metadata_per_source: None,
-                    known_size: known,
+                    metadata_per_source: Some(slots.into()),
+                    known_size: None,
                     estimated_size: estimated,
                 }
             },
-            ResolveMode::Full => {
+            // `Full`, or `Sampled` whose wave already spans every source: read
+            // every footer fully and retain per-file metadata. For `Sampled`
+            // this is free (those footer bytes were going to be read anyway)
+            // and gives the cloud scheduler exact per-file row groups.
+            ResolveMode::Full | ResolveMode::Sampled => {
                 // Each file decoded with its own schema: per-file schemas may
                 // differ in columns, dtypes, or column order. Read concurrently
                 // with file 0; `None` marks a file that failed to decode.
@@ -429,27 +532,28 @@ pub(super) async fn parquet_file_info(
                 let ((reader_schema, first_num_rows, first_metadata), rest) =
                     futures::future::try_join(first_fut, rest_fut).await?;
 
-                // Slot 0 satisfies the `metadata_per_source[0] == first_metadata`
-                // invariant; a failed read falls back to file 0's metadata (the
-                // cloud scheduler re-fetches if it needs accurate row_groups).
-                let mut per_file: Vec<FileMetadataRef> = Vec::with_capacity(n_sources);
-                per_file.push(first_metadata.clone());
+                // Slot 0 is always source 0; a failed read stays `None`
+                // (unknown), which consumers fall back on (e.g. to
+                // `bytes_per_source`).
+                let mut per_source: Vec<Option<FileMetadataRef>> = Vec::with_capacity(n_sources);
+                per_source.push(Some(first_metadata.clone()));
                 let mut total: usize = first_num_rows;
+                let mut n_read = 1usize;
                 for slot in rest {
-                    match slot {
-                        Some(m) => {
-                            total = total.saturating_add(m.num_rows);
-                            per_file.push(m);
-                        },
-                        None => per_file.push(first_metadata.clone()),
+                    if let Some(m) = &slot {
+                        total = total.saturating_add(m.num_rows);
+                        n_read += 1;
                     }
+                    per_source.push(slot);
                 }
-                let dense: Arc<[FileMetadataRef]> = per_file.into();
+                // Exact only if every footer resolved; a failed read leaves a
+                // gap, so the total is an estimate.
+                let known = (n_read == n_sources).then_some(total);
                 Resolution {
                     reader_schema,
                     first_metadata,
-                    metadata_per_source: Some(dense),
-                    known_size: Some(total),
+                    metadata_per_source: Some(per_source.into()),
+                    known_size: known,
                     estimated_size: total,
                 }
             },
@@ -474,14 +578,20 @@ pub(super) async fn parquet_file_info(
     ))
 }
 
+/// Minimum sample so a scan still extrapolates from enough files; below this,
+/// two-mode datasets can miss a mode entirely and misestimate badly.
+#[cfg(feature = "parquet")]
+const SAMPLE_FLOOR: usize = 16;
+
 /// Pick an evenly-strided sample of indices in `1..n_sources` for
 /// [`ResolveMode::Sampled`] (file 0 is read separately). Size is `sqrt(n)`,
-/// floored at `SAMPLE_FLOOR`, capped at `limit` (the shared concurrency budget)
-/// so one scan does not starve others, never above the file count.
+/// floored at `SAMPLE_FLOOR`, capped at `limit`, never above the file count.
+///
+/// Strided is a policy choice: it spreads the sample across the sorted
+/// (roughly chronological, for hive layouts) file order, which is robust to
+/// row-count drift over the dataset; it is deliberately size-blind.
 #[cfg(feature = "parquet")]
 fn sampled_source_indices(n_sources: usize, limit: usize) -> Vec<usize> {
-    // Minimum sample so a small scan still extrapolates from enough files.
-    const SAMPLE_FLOOR: usize = 16;
     // `k` = total footers this wave (incl. file 0); `limit` last so it stays a
     // hard ceiling.
     let k = ((n_sources as f64).sqrt().ceil() as usize)
@@ -497,8 +607,7 @@ fn sampled_source_indices(n_sources: usize, limit: usize) -> Vec<usize> {
     (0..extra).map(|j| 1 + (j * span) / extra).collect()
 }
 
-/// Fetch one source's full footer. Used by [`parquet_file_info`] in
-/// `Full` resolve mode.
+/// Fetch one source's full footer for [`parquet_file_info`].
 #[cfg(feature = "parquet")]
 async fn read_parquet_metadata(
     source: ScanSourceRef<'_>,
@@ -1078,6 +1187,9 @@ impl SourcesToFileInfo {
         scan_type: FileScanDsl,
         sources: &ScanSources,
         sources_before_expansion: &ScanSources,
+        // Per-source byte sizes retained from path expansion, aligned with
+        // `sources`. Stored on `FileScanIR::Parquet` for the cloud scheduler.
+        bytes_per_source: Option<Arc<[u64]>>,
         unified_scan_args: &mut UnifiedScanArgs,
         #[cfg(feature = "python")] py_scan_resolve_threadpool: Arc<
             LazyLock<PyScanResolveThreadPool>,
@@ -1120,6 +1232,7 @@ impl SourcesToFileInfo {
                             // Schema was passed in; no footer was resolved.
                             first_metadata: None,
                             metadata_per_source: None,
+                            bytes_per_source: bytes_per_source.clone(),
                         },
                     )
                 } else {
@@ -1142,6 +1255,7 @@ this scan to succeed with an empty DataFrame.",
                             scans::parquet_file_info(
                                 sources,
                                 unified_scan_args.row_index.as_ref(),
+                                bytes_per_source.as_deref(),
                                 cloud_options,
                             )
                             .await?;
@@ -1164,6 +1278,7 @@ this scan to succeed with an empty DataFrame.",
                                 options,
                                 first_metadata,
                                 metadata_per_source,
+                                bytes_per_source,
                             },
                         ))
                     }
@@ -1351,11 +1466,13 @@ this scan to succeed with an empty DataFrame.",
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(super) async fn get_or_insert(
         &self,
         scan_type: &FileScanDsl,
         sources: &ScanSources,
         sources_before_expansion: &ScanSources,
+        bytes_per_source: Option<Arc<[u64]>>,
         unified_scan_args: &mut UnifiedScanArgs,
         #[cfg(feature = "python")] py_scan_resolve_threadpool: Arc<
             LazyLock<PyScanResolveThreadPool>,
@@ -1372,6 +1489,7 @@ this scan to succeed with an empty DataFrame.",
                         scan_type.clone(),
                         sources,
                         sources_before_expansion,
+                        bytes_per_source,
                         unified_scan_args,
                         #[cfg(feature = "python")]
                         py_scan_resolve_threadpool,
@@ -1433,6 +1551,7 @@ this scan to succeed with an empty DataFrame.",
                         scan_type.clone(),
                         sources,
                         sources_before_expansion,
+                        bytes_per_source,
                         unified_scan_args,
                         #[cfg(feature = "python")]
                         py_scan_resolve_threadpool,
@@ -1452,6 +1571,7 @@ this scan to succeed with an empty DataFrame.",
                     scan_type.clone(),
                     sources,
                     sources_before_expansion,
+                    bytes_per_source,
                     unified_scan_args,
                     #[cfg(feature = "python")]
                     py_scan_resolve_threadpool,

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
@@ -13,6 +13,8 @@ use polars_io::utils::compression::{ByteSourceReader, CompressedReader, Supporte
 use polars_io::utils::stream_buf_reader::ReaderSource;
 
 use super::*;
+#[cfg(feature = "parquet")]
+use crate::dsl::MetadataPerSource::Unresolved;
 
 pub(super) async fn dsl_to_ir(
     sources: ScanSources,
@@ -23,8 +25,8 @@ pub(super) async fn dsl_to_ir(
     #[cfg(feature = "python")] py_scan_resolve_threadpool: Arc<LazyLock<PyScanResolveThreadPool>>,
     verbose: bool,
 ) -> PolarsResult<()> {
-    // Note that the first metadata can still end up being `None` later if the files were
-    // filtered from predicate pushdown.
+    // Note that resolved footer metadata can still be re-indexed or dropped
+    // later if the files were filtered from predicate pushdown.
     // Check and drop the lock in its own scope
     let is_not_cached = {
         let cached_ir_guard = cached_ir.lock().unwrap();
@@ -51,9 +53,6 @@ pub(super) async fn dsl_to_ir(
 
         let sources_before_expansion = &sources;
 
-        // Per-source byte sizes retained from path expansion; only parquet
-        // consumes them today (stored on `FileScanIR::Parquet` for the cloud
-        // scheduler's weighted distribution).
         let mut bytes_per_source: Option<Arc<[u64]>> = None;
         let sources = match &*scan_type {
             #[cfg(feature = "parquet")]
@@ -252,12 +251,10 @@ fn prepare_schemas(
 pub(super) async fn parquet_file_info(
     sources: &ScanSources,
     row_index: Option<&RowIndex>,
-    // Per-source byte sizes from path expansion, aligned with `sources`. When
-    // present, the `Sampled` arm weights its row extrapolation by bytes
-    // (skew-robust) instead of assuming every file has the sample's mean count.
+    // Per-source byte sizes from path expansion, aligned with `sources`.
     bytes_per_source: Option<&[u64]>,
     #[allow(unused)] cloud_options: Option<&polars_io::cloud::CloudOptions>,
-) -> PolarsResult<(FileInfo, Option<FileMetadataRef>, MetadataPerSource)> {
+) -> PolarsResult<(FileInfo, MetadataPerSource)> {
     use futures::stream::{FuturesOrdered, FuturesUnordered, StreamExt};
     use polars_core::error::feature_gated;
 
@@ -296,20 +293,17 @@ pub(super) async fn parquet_file_info(
     // `POLARS_RESOLVE_METADATA_LEVEL`:
     // - `None`: extrapolate `first_num_rows * n_sources`, no extra reads.
     // - `RowCounts`: per-source thrift field 3 only, exact total.
-    // - `Sampled`: read one concurrency wave of full footers, retain them
-    //   sparsely in `metadata_per_source`, and extrapolate (exact when the
-    //   whole set fits in the wave).
-    // - `Full`: per-source footer, populates `metadata_per_source` for the
-    //   distributed scheduler.
+    // - `Sampled`: read one concurrency wave of full footers and extrapolate.
+    // - `Full`: read every footer, exact total.
     //
     // Every multi-source arm reads file 0 concurrently with the other sources
     // via `try_join`, so the schema read does not cost an extra serial round
     // trip; a file-0 error short-circuits and cancels the other reads.
-    // Per-scan size resolution. `reader_schema`/`first_metadata` always come
-    // from file 0; only the size fields vary by mode.
+    // Per-scan size resolution. `reader_schema` always comes from file 0;
+    // only the size fields vary by mode. File 0's footer is always retained
+    // in `metadata_per_source`.
     struct Resolution {
         reader_schema: ArrowSchemaRef,
-        first_metadata: FileMetadataRef,
         metadata_per_source: MetadataPerSource,
         known_size: Option<usize>,
         estimated_size: usize,
@@ -321,33 +315,28 @@ pub(super) async fn parquet_file_info(
         let (reader_schema, first_num_rows, first_metadata) = first_fut.await?;
         Resolution {
             reader_schema,
-            first_metadata,
-            metadata_per_source: None,
+            metadata_per_source: MetadataPerSource::new([(0, first_metadata)], 1),
             known_size: Some(first_num_rows),
             estimated_size: first_num_rows,
         }
     } else {
         use polars_config::ResolveMode;
 
-        // For `Sampled`: the strided footer sample, `Some` only when it does
-        // NOT already span every source. A wave that covers the whole set
-        // routes through the `Full` arm instead (same bytes, zero extra
-        // requests).
+        // The strided footer sample; `Some` only when it does not already
+        // span every source (a spanning wave routes through the `Full` arm).
         let partial_sample = matches!(mode, ResolveMode::Sampled)
             .then(|| {
-                // Cap on the sample size (the size itself is derived in
-                // `sampled_source_indices`). The default cap is the IO budget
-                // floored at `SAMPLE_FLOOR`: a small budget must not push the
-                // sample below the statistical minimum (reads beyond the
-                // budget merely queue, at most one extra wave). An explicit
-                // limit is authoritative, even below the floor.
+                // Default cap: the IO concurrency budget floored at
+                // `SAMPLE_FLOOR`. An explicit limit is authoritative, even
+                // below the floor.
                 let limit = polars_config::config().resolve_sample_limit().map_or_else(
                     || (polars_io::pl_async::get_concurrency_limit() as usize).max(SAMPLE_FLOOR),
                     |o| o as usize,
                 );
-                sampled_source_indices(n_sources, limit)
+                sample_size(n_sources, limit)
             })
-            .filter(|sample| sample.len() + 1 != n_sources);
+            .filter(|&k| k != n_sources)
+            .map(|k| sampled_source_indices(n_sources, k));
 
         match mode {
             ResolveMode::None => {
@@ -355,8 +344,7 @@ pub(super) async fn parquet_file_info(
                 let (reader_schema, first_num_rows, first_metadata) = first_fut.await?;
                 Resolution {
                     reader_schema,
-                    first_metadata,
-                    metadata_per_source: None,
+                    metadata_per_source: MetadataPerSource::new([(0, first_metadata)], n_sources),
                     known_size: None,
                     estimated_size: first_num_rows.saturating_mul(n_sources),
                 }
@@ -389,32 +377,19 @@ pub(super) async fn parquet_file_info(
                 let total = first_num_rows.saturating_add(others);
                 Resolution {
                     reader_schema,
-                    first_metadata,
-                    metadata_per_source: None,
+                    metadata_per_source: MetadataPerSource::new([(0, first_metadata)], n_sources),
                     known_size: Some(total),
                     estimated_size: total,
                 }
             },
-            // `Sampled` whose wave does NOT span every source: read the sample's
-            // full footers and retain them (sparse; unread slots are `None`).
-            // The total is extrapolated: overhead-calibrated byte weighting
-            // when sizes are known (see `byte_estimate` below), else the
-            // per-file mean (`sampled_rows * n / n_read`). Same footer bytes
-            // as a row-count read, just decoded fully so the metadata is
-            // retained.
-            ResolveMode::Sampled if partial_sample.is_some() => {
-                let sample = partial_sample.expect("guarded to a partial sample");
-                // Per-source listing sizes for the byte-weighted estimate,
-                // consumed after the reads so the calibration only uses the
-                // slots that actually resolved.
-                let known_sizes = bytes_per_source.filter(|b| !b.is_empty()).inspect(|b| {
-                    // Aligned with `sources` by construction: path expansion
-                    // builds both, and `gather_after_filter` re-indexes both
-                    // by the same surviving indices.
+            // Partial `Sampled`: read the sample's footers, retain them, and
+            // extrapolate the total (byte-weighted when sizes are known, else
+            // the per-file mean).
+            ResolveMode::Sampled if let Some(ref sample) = partial_sample => {
+                let known_sizes = bytes_per_source.inspect(|b| {
                     debug_assert_eq!(b.len(), n_sources);
+                    debug_assert!(b.iter().all(|&size| size > 0));
                 });
-                // Place each footer at its source index; the wave completes out
-                // of order, so we index rather than push.
                 let rest_fut = async move {
                     let mut futures = sample
                         .iter()
@@ -427,53 +402,45 @@ pub(super) async fn parquet_file_info(
                             )
                         })
                         .collect::<FuturesUnordered<_>>();
-                    let mut slots: Vec<Option<FileMetadataRef>> = vec![None; n_sources];
+                    let mut pairs: Vec<(usize, FileMetadataRef)> = Vec::with_capacity(sample.len());
                     let mut rows = 0usize;
                     while let Some((i, meta)) = futures.next().await {
                         if let Some(m) = meta {
                             rows = rows.saturating_add(m.num_rows);
-                            slots[i] = Some(m);
+                            pairs.push((i, m));
                         }
                     }
-                    PolarsResult::Ok((slots, rows))
+                    PolarsResult::Ok((pairs, rows))
                 };
-                let ((reader_schema, first_num_rows, first_metadata), (mut slots, other_rows)) =
+                let ((reader_schema, first_num_rows, first_metadata), (mut pairs, other_rows)) =
                     futures::future::try_join(first_fut, rest_fut).await?;
                 // file 0 is always read.
-                slots[0] = Some(first_metadata.clone());
+                pairs.push((0, first_metadata));
                 let sampled_rows = first_num_rows.saturating_add(other_rows);
-                let n_read = slots.iter().filter(|s| s.is_some()).count();
+                let n_read = pairs.len();
                 let byte_estimate = known_sizes.and_then(|bytes| {
-                    // A parquet file is fixed overhead (schema, footer, page
-                    // headers) plus data pages, so raw file-size ratios badly
-                    // overstate rows on small files. Learn rows-per-data-byte
-                    // and the mean per-file overhead from the sampled footers,
-                    // then size the unread files' data bytes from their listed
-                    // sizes. Mirrored in
-                    // `test_resolve_metadata_sampled_byte_weighted`; keep in sync.
-                    // TODO: Extract into a unit-testable function to retire the mirror.
+                    // A file is fixed overhead plus data pages, so raw size
+                    // ratios overstate rows on small files. Learn
+                    // rows-per-data-byte and mean overhead from the sample,
+                    // then estimate the unread files from their listed sizes.
                     let mut sampled_data: u128 = 0;
                     let mut sampled_overhead: u128 = 0;
-                    // Unresolved = never sampled OR the read failed; both get
-                    // their rows estimated from their listed bytes.
-                    let mut unresolved_bytes: u128 = 0;
-                    for (&size, slot) in bytes.iter().zip(&slots) {
-                        match slot {
-                            Some(m) => {
-                                // Clamped to the listed size so a malformed
-                                // footer cannot underflow the overhead.
-                                let data = m
-                                    .row_groups
-                                    .iter()
-                                    .map(|rg| rg.compressed_size() as u128)
-                                    .sum::<u128>()
-                                    .min(size as u128);
-                                sampled_data += data;
-                                sampled_overhead += size as u128 - data;
-                            },
-                            None => unresolved_bytes += size as u128,
-                        }
+                    for (i, m) in &pairs {
+                        let size = bytes[*i] as u128;
+                        // Clamp so a malformed footer cannot underflow the
+                        // overhead.
+                        let data = m
+                            .row_groups
+                            .iter()
+                            .map(|rg| rg.compressed_size() as u128)
+                            .sum::<u128>()
+                            .min(size);
+                        sampled_data += data;
+                        sampled_overhead += size - data;
                     }
+                    // Unresolved covers unsampled and failed reads alike.
+                    let total_bytes = bytes.iter().map(|&b| b as u128).sum::<u128>();
+                    let unresolved_bytes = total_bytes - (sampled_data + sampled_overhead);
                     // A 0-row sample has no density to learn from; fall back.
                     (sampled_data > 0).then(|| {
                         let mean_overhead = sampled_overhead / n_read as u128;
@@ -501,20 +468,15 @@ pub(super) async fn parquet_file_info(
                         },
                     );
                 }
-                // Partial coverage: retain what we read, but the total is an
-                // estimate, not known.
                 Resolution {
                     reader_schema,
-                    first_metadata,
-                    metadata_per_source: Some(slots.into()),
+                    metadata_per_source: MetadataPerSource::new(pairs, n_sources),
                     known_size: None,
                     estimated_size: estimated,
                 }
             },
-            // `Full`, or `Sampled` whose wave already spans every source: read
-            // every footer fully and retain per-file metadata. For `Sampled`
-            // this is free (those footer bytes were going to be read anyway)
-            // and gives the cloud scheduler exact per-file row groups.
+            // `Full`, or `Sampled` whose wave already spans every source:
+            // read and retain every footer.
             ResolveMode::Full | ResolveMode::Sampled => {
                 // Each file decoded with its own schema: per-file schemas may
                 // differ in columns, dtypes, or column order. Read concurrently
@@ -532,27 +494,23 @@ pub(super) async fn parquet_file_info(
                 let ((reader_schema, first_num_rows, first_metadata), rest) =
                     futures::future::try_join(first_fut, rest_fut).await?;
 
-                // Slot 0 is always source 0; a failed read stays `None`
-                // (unknown), which consumers fall back on (e.g. to
-                // `bytes_per_source`).
-                let mut per_source: Vec<Option<FileMetadataRef>> = Vec::with_capacity(n_sources);
-                per_source.push(Some(first_metadata.clone()));
+                // Source 0 is always read; a failed read is simply absent.
+                let mut entries: Vec<(usize, FileMetadataRef)> = Vec::with_capacity(n_sources);
+                entries.push((0, first_metadata));
                 let mut total: usize = first_num_rows;
-                let mut n_read = 1usize;
-                for slot in rest {
-                    if let Some(m) = &slot {
+                for (i, slot) in rest.into_iter().enumerate() {
+                    if let Some(m) = slot {
                         total = total.saturating_add(m.num_rows);
-                        n_read += 1;
+                        entries.push((i + 1, m));
                     }
-                    per_source.push(slot);
                 }
-                // Exact only if every footer resolved; a failed read leaves a
-                // gap, so the total is an estimate.
-                let known = (n_read == n_sources).then_some(total);
+                let metadata_per_source = MetadataPerSource::new(entries, n_sources);
+                // Exact only when every footer resolved.
+                let known =
+                    matches!(metadata_per_source, MetadataPerSource::Full(_)).then_some(total);
                 Resolution {
                     reader_schema,
-                    first_metadata,
-                    metadata_per_source: Some(per_source.into()),
+                    metadata_per_source,
                     known_size: known,
                     estimated_size: total,
                 }
@@ -571,11 +529,7 @@ pub(super) async fn parquet_file_info(
         (resolved.known_size, resolved.estimated_size),
     );
 
-    Ok((
-        file_info,
-        Some(resolved.first_metadata),
-        resolved.metadata_per_source,
-    ))
+    Ok((file_info, resolved.metadata_per_source))
 }
 
 /// Minimum sample so a scan still extrapolates from enough files; below this,
@@ -583,25 +537,24 @@ pub(super) async fn parquet_file_info(
 #[cfg(feature = "parquet")]
 const SAMPLE_FLOOR: usize = 16;
 
-/// Pick an evenly-strided sample of indices in `1..n_sources` for
-/// [`ResolveMode::Sampled`] (file 0 is read separately). Size is `sqrt(n)`,
+/// Footer-wave size (incl. file 0) for [`ResolveMode::Sampled`]: `sqrt(n)`,
 /// floored at `SAMPLE_FLOOR`, capped at `limit`, never above the file count.
-///
-/// Strided is a policy choice: it spreads the sample across the sorted
-/// (roughly chronological, for hive layouts) file order, which is robust to
-/// row-count drift over the dataset; it is deliberately size-blind.
 #[cfg(feature = "parquet")]
-fn sampled_source_indices(n_sources: usize, limit: usize) -> Vec<usize> {
-    // `k` = total footers this wave (incl. file 0); `limit` last so it stays a
-    // hard ceiling.
-    let k = ((n_sources as f64).sqrt().ceil() as usize)
+fn sample_size(n_sources: usize, limit: usize) -> usize {
+    // `limit` last so it stays a hard ceiling.
+    ((n_sources as f64).sqrt().ceil() as usize)
         .max(SAMPLE_FLOOR)
         .min(limit.max(1))
-        .min(n_sources);
+        .min(n_sources)
+}
+
+/// Evenly-strided sample of `k - 1` indices in `1..n_sources` (file 0 is
+/// read separately).
+#[cfg(feature = "parquet")]
+fn sampled_source_indices(n_sources: usize, k: usize) -> Vec<usize> {
     if k <= 1 {
         return Vec::new();
     }
-    // `k - 1` more, evenly strided over `1..n_sources`.
     let extra = k - 1;
     let span = n_sources - 1;
     (0..extra).map(|j| 1 + (j * span) / extra).collect()
@@ -1187,8 +1140,7 @@ impl SourcesToFileInfo {
         scan_type: FileScanDsl,
         sources: &ScanSources,
         sources_before_expansion: &ScanSources,
-        // Per-source byte sizes retained from path expansion, aligned with
-        // `sources`. Stored on `FileScanIR::Parquet` for the cloud scheduler.
+        // Per-source byte sizes from path expansion, aligned with `sources`.
         bytes_per_source: Option<Arc<[u64]>>,
         unified_scan_args: &mut UnifiedScanArgs,
         #[cfg(feature = "python")] py_scan_resolve_threadpool: Arc<
@@ -1217,7 +1169,8 @@ impl SourcesToFileInfo {
             FileScanDsl::Parquet { options } => {
                 if let Some(schema) = &options.schema {
                     // We were passed a schema, we don't have to call `parquet_file_info`,
-                    // but this does mean we don't have `row_estimation` and `first_metadata`.
+                    // but this does mean we don't have `row_estimation` or any
+                    // resolved footer metadata.
 
                     (
                         FileInfo {
@@ -1229,9 +1182,7 @@ impl SourcesToFileInfo {
                         },
                         FileScanIR::Parquet {
                             options,
-                            // Schema was passed in; no footer was resolved.
-                            first_metadata: None,
-                            metadata_per_source: None,
+                            metadata_per_source: Unresolved,
                             bytes_per_source: bytes_per_source.clone(),
                         },
                     )
@@ -1251,32 +1202,29 @@ this scan to succeed with an empty DataFrame.",
                             )
                         }
 
-                        let (mut file_info, mut first_metadata, mut metadata_per_source) =
-                            scans::parquet_file_info(
-                                sources,
-                                unified_scan_args.row_index.as_ref(),
-                                bytes_per_source.as_deref(),
-                                cloud_options,
-                            )
-                            .await?;
+                        let (mut file_info, mut metadata_per_source) = scans::parquet_file_info(
+                            sources,
+                            unified_scan_args.row_index.as_ref(),
+                            bytes_per_source.as_deref(),
+                            cloud_options,
+                        )
+                        .await?;
 
                         if let Some(exact_row_estimation) = exact_row_estimation {
                             file_info.row_estimation = exact_row_estimation;
                         }
 
                         if self.inner.read().unwrap().len() > max_metadata_scan_cached() {
-                            // Cache pressure: drop both pre-decoded slots so
+                            // Cache pressure: drop the pre-decoded footers so
                             // we don't blow memory. Streaming readers fall
                             // back to fetching footers at scan time.
-                            first_metadata = None;
-                            metadata_per_source = None;
+                            metadata_per_source = Unresolved;
                         }
 
                         PolarsResult::Ok((
                             file_info,
                             FileScanIR::Parquet {
                                 options,
-                                first_metadata,
                                 metadata_per_source,
                                 bytes_per_source,
                             },

--- a/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
+++ b/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
@@ -384,6 +384,7 @@ fn expand_python_dataset(
                     // Metadata is resolved later in `parquet_file_info`.
                     first_metadata: None,
                     metadata_per_source: None,
+                    bytes_per_source: None,
                 },
 
                 #[cfg(feature = "json")]

--- a/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
+++ b/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
@@ -15,6 +15,8 @@ use polars_utils::python_function::PythonObject;
 use polars_utils::slice_enum::Slice;
 use polars_utils::{format_pl_smallstr, unitvec};
 
+#[cfg(feature = "parquet")]
+use crate::dsl::MetadataPerSource::Unresolved;
 #[cfg(feature = "python")]
 use crate::dsl::python_dsl::PythonScanSource;
 use crate::dsl::{DslPlan, FileScanIR, UnifiedScanArgs};
@@ -382,8 +384,7 @@ fn expand_python_dataset(
                 FileScanDsl::Parquet { options } => FileScanIR::Parquet {
                     options,
                     // Metadata is resolved later in `parquet_file_info`.
-                    first_metadata: None,
-                    metadata_per_source: None,
+                    metadata_per_source: Unresolved,
                     bytes_per_source: None,
                 },
 

--- a/crates/polars-plan/src/plans/optimizer/parquet_metadata_prune.rs
+++ b/crates/polars-plan/src/plans/optimizer/parquet_metadata_prune.rs
@@ -95,7 +95,7 @@ pub(super) fn prune_parquet_metadata(
         *first_metadata = first_metadata.as_ref().map(prune_one);
         *metadata_per_source = metadata_per_source
             .as_ref()
-            .map(|s| s.iter().map(prune_one).collect());
+            .map(|s| s.iter().map(|m| m.as_ref().map(prune_one)).collect());
     }
 }
 

--- a/crates/polars-plan/src/plans/optimizer/parquet_metadata_prune.rs
+++ b/crates/polars-plan/src/plans/optimizer/parquet_metadata_prune.rs
@@ -1,5 +1,5 @@
-//! Prune `FileScanIR::Parquet`'s pre-decoded metadata (`first_metadata`
-//! and `metadata_per_source`) to projected + predicate columns.
+//! Prune `FileScanIR::Parquet`'s pre-decoded `metadata_per_source` to
+//! projected + predicate columns.
 //!
 //! Runs at the end of the optimizer pipeline, after projection and predicate
 //! pushdown have resolved each scan's projection / predicate. Walks the IR
@@ -56,7 +56,6 @@ pub(super) fn prune_parquet_metadata(
         // Variant check first: skip the projection/predicate work entirely
         // for non-Parquet scans (CSV, IPC, NDJson, Python, Anonymous).
         let FileScanIR::Parquet {
-            first_metadata,
             metadata_per_source,
             ..
         } = scan_type.as_mut()
@@ -92,10 +91,7 @@ pub(super) fn prune_parquet_metadata(
                 .unwrap_or_else(|| m.clone())
         };
 
-        *first_metadata = first_metadata.as_ref().map(prune_one);
-        *metadata_per_source = metadata_per_source
-            .as_ref()
-            .map(|s| s.iter().map(|m| m.as_ref().map(prune_one)).collect());
+        *metadata_per_source = metadata_per_source.map_footers(prune_one);
     }
 }
 

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -752,16 +752,15 @@ pub fn lower_ir(
                     #[cfg(feature = "parquet")]
                     FileScanIR::Parquet {
                         options,
-                        first_metadata,
-                        // Used at plan time (optimizer passes, cloud
-                        // scheduler). The streaming reader reads per-file
-                        // footers at scan time and only needs `first_metadata`.
-                        metadata_per_source: _,
+                        // The streaming reader reads per-file footers at scan
+                        // time; it only takes source 0's footer as its
+                        // initial hint.
+                        metadata_per_source,
                         bytes_per_source: _,
                     } => Arc::new(
                         crate::nodes::io_sources::parquet::builder::ParquetReaderBuilder {
                             options: Arc::new(options.clone()),
-                            first_metadata: first_metadata.clone(),
+                            first_metadata: metadata_per_source.first_metadata().cloned(),
                             pipeline_budget: std::sync::OnceLock::new(),
                             shared_prefetch_wait_group_slot: Default::default(),
                             io_metrics: std::sync::OnceLock::new(),

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -757,6 +757,7 @@ pub fn lower_ir(
                         // scheduler). The streaming reader reads per-file
                         // footers at scan time and only needs `first_metadata`.
                         metadata_per_source: _,
+                        bytes_per_source: _,
                     } => Arc::new(
                         crate::nodes::io_sources::parquet::builder::ParquetReaderBuilder {
                             options: Arc::new(options.clone()),

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -4366,8 +4366,8 @@ def test_multi_file_resolve_metadata_level(
 ) -> None:
     # Skewed layout: file 0 = 2 rows, files 1-2 = 3 each (true total 8).
     # `none` extrapolates 2 * 3 = 6; `row_counts`/`full` sum exactly. (`sampled`
-    # is budget-dependent, so it is tested in a subprocess below where the budget
-    # is pinned, not here where this process's budget is uncontrolled.)
+    # is covered by the dedicated test below, with its sample wave pinned via
+    # `POLARS_RESOLVE_SAMPLE_LIMIT`.)
     for i, n in enumerate([2, 3, 3]):
         pl.DataFrame({"x": range(n)}).write_parquet(tmp_path / f"part_{i}.parquet")
 
@@ -4380,42 +4380,92 @@ def test_multi_file_resolve_metadata_level(
 
 
 @pytest.mark.write_disk
-def test_resolve_metadata_sampled_extrapolates(tmp_path: Path) -> None:
-    # `sampled` only extrapolates when the file count exceeds the concurrency
-    # budget; at or below it the whole set is read and the count is exact. The
-    # budget is a process-wide OnceLock (not refreshed by `reload_env_vars`), so
-    # cap it to 2 in a fresh subprocess. Layout [2, 3, 3]: budget 2 samples
-    # file 0 + file 1 and extrapolates (2 + 3) * 3 // 2 = 7.
-    for i, n in enumerate([2, 3, 3]):
+def test_resolve_metadata_sampled_byte_weighted(
+    plmonkeypatch: PlMonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    # `sampled` weights its row extrapolation by per-file byte size (retained
+    # from path expansion) when every source has a known size, and falls back
+    # to the per-file mean otherwise. Pin the sample wave to 2 footers so the
+    # 3-file layout stays a *partial* sample regardless of this machine's
+    # concurrency budget. Layout [2, 2, 1000]: the wave reads file 0 + file 1
+    # (a two-footer wave is always file 0 plus index 1; the strided spread
+    # only kicks in from three footers up); file 2 (large) is not read.
+    rows = [2, 2, 1000]
+    for i, n in enumerate(rows):
         pl.DataFrame({"x": range(n)}).write_parquet(tmp_path / f"part_{i}.parquet")
 
     if sys.platform.startswith("win"):
         return
 
-    glob = str(tmp_path / "part_*.parquet")
-    out = subprocess.check_output(
-        [
-            sys.executable,
-            "-c",
-            f"""\
-import os
-import sys
+    sizes = [(tmp_path / f"part_{i}.parquet").stat().st_size for i in range(3)]
+    sampled_rows = rows[0] + rows[1]
+    # Mirror the engine's overhead-calibrated estimate: from the sampled
+    # footers (files 0 and 1), data bytes = sum of column-chunk compressed
+    # sizes; the mean per-file overhead then sizes the unread file's data
+    # bytes from its listed size.
+    metas = [pq.ParquetFile(tmp_path / f"part_{i}.parquet").metadata for i in range(2)]
+    data = [
+        min(
+            sum(
+                md.row_group(rg).column(c).total_compressed_size
+                for rg in range(md.num_row_groups)
+                for c in range(md.num_columns)
+            ),
+            sizes[i],
+        )
+        for i, md in enumerate(metas)
+    ]
+    sampled_data = data[0] + data[1]
+    mean_overhead = ((sizes[0] - data[0]) + (sizes[1] - data[1])) // 2
+    unresolved_data = max(sizes[2] - mean_overhead, 0)
+    byte_weighted = sampled_rows + unresolved_data * sampled_rows // sampled_data
+    count_based = sampled_rows * 3 // 2
+    # Must differ, else the scenarios below cannot distinguish byte weighting
+    # from the count-based fallback.
+    assert byte_weighted != count_based
 
-os.environ["POLARS_CONCURRENCY_BUDGET"] = "2"
-os.environ["POLARS_RESOLVE_METADATA_LEVEL"] = "sampled"
+    plmonkeypatch.setenv("POLARS_RESOLVE_METADATA_LEVEL", "sampled")
+    plmonkeypatch.setenv("POLARS_RESOLVE_SAMPLE_LIMIT", "2")
+    plmonkeypatch.setenv("POLARS_VERBOSE", "1")
 
-import polars as pl
+    def check(lf: pl.LazyFrame, expected_est: int, expected_kind: str) -> None:
+        capfd.readouterr()
+        # Resolution runs on the first plan build and prints its verbose trace.
+        plan = lf.explain(optimized=True)
+        assert f"ESTIMATED ROWS: {expected_est}" in plan, plan
+        assert (
+            f"parquet sampled resolve: read 2 / 3 footers, "
+            f"estimated rows: {expected_est} ({expected_kind})"
+        ) in capfd.readouterr().err
+        assert lf.collect().height == sum(rows)
 
-lf = pl.scan_parquet({glob!r})
-assert lf.collect().height == 8
-assert "ESTIMATED ROWS: 7" in lf.explain(optimized=True)
-print("OK", end="", file=sys.stderr)
-""",
-        ],
-        stderr=subprocess.STDOUT,
-        timeout=30,
-    )
-    assert out == b"OK"
+    # Globbed scan, local sync expansion: sizes retained -> byte-weighted.
+    check(pl.scan_parquet(tmp_path / "part_*.parquet"), byte_weighted, "byte-weighted")
+
+    # Globbed scan through the object-store expansion path (the same route
+    # cloud scans take): sizes come from the listing -> byte-weighted.
+    plmonkeypatch.setenv("POLARS_FORCE_ASYNC", "1")
+    check(pl.scan_parquet(tmp_path / "part_*.parquet"), byte_weighted, "byte-weighted")
+    plmonkeypatch.setenv("POLARS_FORCE_ASYNC", "0")
+
+    # Explicit file list: no listing happens, so no sizes are known -> the
+    # estimate falls back to the per-file mean over the sampled row counts.
+    paths = [tmp_path / f"part_{i}.parquet" for i in range(3)]
+    check(pl.scan_parquet(paths), count_based, "count-based")
+
+    # Wave covers the whole set (2 files, wave 2): `sampled` classifies as
+    # read-all and routes through the `Full` arm. The count is the exact sum
+    # of both footers, and the partial-sample trace must NOT appear -- its
+    # absence is the proof of the routing, since a wave that covers every
+    # file lands on the exact total through either arm.
+    capfd.readouterr()
+    lf = pl.scan_parquet([tmp_path / "part_0.parquet", tmp_path / "part_2.parquet"])
+    plan = lf.explain(optimized=True)
+    assert f"ESTIMATED ROWS: {rows[0] + rows[2]}" in plan, plan
+    assert "parquet sampled resolve" not in capfd.readouterr().err
+    assert lf.collect().height == rows[0] + rows[2]
 
 
 def test_parquet_prefilter_fixed_size_binary_27781() -> None:


### PR DESCRIPTION
For a multi-file parquet scan we estimate the row count at plan time. A bad estimate can lead the distributed planner to e.g. a bad distribution of the scan over the workers. Reading all footers gives the exact answer, but on cloud storage that is one GET per file: on a 12,500 file dataset, even at 64 concurrent connections, that is 12,500 / 64 ≈ 195 round trips × ~80ms ≈ 16 seconds of plan time, paid again on every fresh resolve.

That is why the `sampled` resolve level reads only ~16 footers spread over the file list, in one concurrent wave. But extrapolating from the sample by the average rows per file assumes all files are alike, and if the files have very different sizes (small streaming files mixed with big compacted ones), the estimate can still be far off when the sample misses the big files.

## Solution

When we expand the paths at scan time, the listing already returns the size of every file, we just didn't keep it. This PR keeps those sizes (`bytes_per_source`) in the scan IR and uses them in the `sampled` estimate: from the sampled footers we learn the rows-per-byte ratio, and every unread file is then estimated from its listed size. So a file we never opened, but that is 10x bigger, counts for ~10x the rows, whether it was sampled or not. The overhead stays the same ~16 footer reads.

Sampled footers are now kept on the IR in a new `MetadataPerSource` enum (`Unresolved` / `Partial` / `Full`). `known_size` is only set when all footers were read.

## Results

The table below shows `(estimate - truth) / truth` for the total row count: 0% is perfect, +100% means the planner thinks the scan is twice as big as it really is, -50% means it thinks it is half as big. Layouts are generated fixtures (300 files) where the true row counts are known:

| layout | 1 footer | sampled, rows only | sampled + sizes (this PR) |
|---|---:|---:|---:|
| uniform | +0.0% | +0.0% | -0.1% |
| big file at position 0 | +2635.6% | +138.1% | -1.2% |
| compacted (few big + many small) | +525.0% | +56.2% | -0.5% |
| heavy tail (lognormal) | -95.4% | +28.9% | -0.3% |
| codec mix (sizes differ, rows equal) | +0.0% | +0.0% | +2.3% |

Worst case for the new estimator is ~2.5% (codec mix, where sizes genuinely mislead about rows). On a 12,500 file dataset with a compacted layout, sampling 16 of the files gets the estimate from +30% (rows only) to -0.3% (with sizes).

I used Claude to implement this. I reviewed the code myself.