### PR TITLE
fix(rust): Make slice lengths independent of local bigidx feature

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_expr.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_expr.rs
@@ -1,5 +1,6 @@
 use std::ops::ControlFlow;
 
+use num_traits::NumCast;
 use polars_core::chunked_array::cast::CastOptions;
 use polars_utils::UnitVec;
 use polars_utils::collection::{Collection, CollectionWrap, MappedCollection};
@@ -116,8 +117,7 @@ impl CommonSlice {
                 assert!(max_end <= 0);
 
                 let len = min_offset.abs_diff(max_end);
-                #[cfg_attr(feature = "bigidx", expect(clippy::useless_conversion))]
-                let len: IdxSize = len.try_into().unwrap_or(IdxSize::MAX);
+                let len = NumCast::from(len).unwrap_or(IdxSize::MAX);
 
                 (
                     ExtractedSlice {
@@ -157,9 +157,7 @@ impl Slice {
                         Some(IdxSize::MAX)
                     }
                 },
-                AnyValue::UInt64(len) => len.try_into().ok(),
-                AnyValue::UInt32(len) => len.try_into().ok(),
-                _ => None,
+                len => len.extract::<IdxSize>(),
             }
         {
             return Self::Extracted(ExtractedSlice { offset, len });

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_expr.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_expr.rs
@@ -157,10 +157,8 @@ impl Slice {
                         Some(IdxSize::MAX)
                     }
                 },
-                #[cfg(feature = "bigidx")]
-                AnyValue::UInt64(len) => Some(len),
-                #[cfg(not(feature = "bigidx"))]
-                AnyValue::UInt32(len) => Some(len),
+                AnyValue::UInt64(len) => len.try_into().ok(),
+                AnyValue::UInt32(len) => len.try_into().ok(),
                 _ => None,
             }
         {
@@ -203,16 +201,7 @@ impl Slice {
                 )))),
                 expr_arena.add(AExpr::Literal(LiteralValue::Scalar(Scalar::new(
                     DataType::IDX_DTYPE,
-                    {
-                        #[cfg(not(feature = "bigidx"))]
-                        {
-                            AnyValue::UInt32(*len)
-                        }
-                        #[cfg(feature = "bigidx")]
-                        {
-                            AnyValue::UInt64(*len)
-                        }
-                    },
+                    AnyValue::from(*len),
                 )))),
             ),
             Self::Opaque { offset, len } => (*offset, *len),
@@ -482,4 +471,34 @@ fn aexpr_slice_pushdown_top(
     }
 
     state
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slice_length_uses_idx_dtype() {
+        let mut arena = Arena::new();
+        let offset = arena.add(AExpr::Literal(Scalar::from(1_i64).into()));
+        let length = arena.add(AExpr::Literal(Scalar::from(2 as IdxSize).into()));
+
+        let slice = Slice::from_nodes(offset, length, &arena);
+        assert_eq!(
+            slice,
+            Slice::Extracted(ExtractedSlice { offset: 1, len: 2 })
+        );
+
+        let input = arena.add(AExpr::Literal(Scalar::from(0_i64).into()));
+        slice.slice_arena_node(input, &mut arena);
+
+        let AExpr::Slice { length, .. } = arena.get(input) else {
+            panic!("expected a slice expression");
+        };
+        let AExpr::Literal(LiteralValue::Scalar(length)) = arena.get(*length) else {
+            panic!("expected a scalar slice length");
+        };
+        assert_eq!(length.dtype(), &DataType::IDX_DTYPE);
+        assert_eq!(length.as_any_value().idx(), 2);
+    }
 }


### PR DESCRIPTION
Fixes #27944.

## Summary

Slice pushdown currently chooses the scalar representation for a slice length using `polars-plan`'s local `bigidx` feature. That feature can be disabled while `polars-core/bigidx` is enabled by a downstream crate, so `IdxSize` is `u64` but the optimizer still expects and constructs `UInt32` values. This produces the incompatible-type build errors reported in the issue.

This change makes the optimizer independent of its local feature flag:

- accept both `UInt32` and `UInt64` scalar lengths and convert them to `IdxSize` with a checked conversion;
- rebuild extracted slice lengths through `AnyValue::from(IdxSize)`, which selects the representation that matches the actual index type;
- add a focused regression test that verifies the extracted length is rebuilt with `DataType::IDX_DTYPE`.

## Validation

- `cargo check -p polars-plan --no-default-features --features polars-core/bigidx --locked`
- `cargo test -p polars-plan --lib --no-default-features --features is_between slice_length_uses_idx_dtype --locked`
- `cargo test -p polars-plan --lib --no-default-features --features polars-core/bigidx,is_between slice_length_uses_idx_dtype --locked`
- `cargo test -p polars-plan --lib --no-default-features --features bigidx,is_between slice_length_uses_idx_dtype --locked`
- `cargo fmt --all -- --check`
