### PR TITLE
fix: Invalid offset in strptime

### DIFF
--- a/crates/polars-time/src/chunkedarray/string/infer.rs
+++ b/crates/polars-time/src/chunkedarray/string/infer.rs
@@ -6,7 +6,6 @@ use polars_core::prelude::*;
 use super::patterns::{self, Pattern};
 #[cfg(feature = "dtype-date")]
 use crate::chunkedarray::date::naive_date_to_date;
-use crate::chunkedarray::string::strptime;
 use crate::prelude::string::strptime::StrpTimeState;
 
 polars_utils::regex_cache::cached_regex! {
@@ -141,70 +140,54 @@ pub trait StrpTimeParser<T> {
 #[cfg(feature = "dtype-datetime")]
 impl StrpTimeParser<i64> for DatetimeInfer<Int64Type> {
     fn parse_bytes(&mut self, val: &[u8], time_unit: Option<TimeUnit>) -> Option<i64> {
-        if self.fmt_len == 0 {
-            self.fmt_len = strptime::fmt_len(self.latest_fmt.as_bytes())?;
-        }
         let transform = match time_unit {
             Some(TimeUnit::Nanoseconds) => datetime_to_timestamp_ns,
             Some(TimeUnit::Microseconds) => datetime_to_timestamp_us,
             Some(TimeUnit::Milliseconds) => datetime_to_timestamp_ms,
             _ => unreachable!(), // time_unit has to be provided for datetime
         };
-        unsafe {
-            self.transform_bytes
-                .parse(val, self.latest_fmt.as_bytes(), self.fmt_len)
-                .map(transform)
-                .or_else(|| {
-                    // TODO! this will try all patterns.
-                    // somehow we must early escape if value is invalid
-                    for fmt in self.patterns {
-                        if self.fmt_len == 0 {
-                            self.fmt_len = strptime::fmt_len(fmt.as_bytes())?;
-                        }
-                        if let Some(parsed) = self
-                            .transform_bytes
-                            .parse(val, fmt.as_bytes(), self.fmt_len)
-                            .map(datetime_to_timestamp_us)
-                        {
-                            self.latest_fmt = fmt;
-                            return Some(parsed);
-                        }
+        self.transform_bytes
+            .parse(val, self.latest_fmt.as_bytes())
+            .map(transform)
+            .or_else(|| {
+                // TODO! this will try all patterns.
+                // Somehow we must early escape if value is invalid.
+                for fmt in self.patterns {
+                    if let Some(parsed) = self
+                        .transform_bytes
+                        .parse(val, fmt.as_bytes())
+                        .map(datetime_to_timestamp_us)
+                    {
+                        self.latest_fmt = fmt;
+                        return Some(parsed);
                     }
-                    None
-                })
-        }
+                }
+                None
+            })
     }
 }
 
 #[cfg(feature = "dtype-date")]
 impl StrpTimeParser<i32> for DatetimeInfer<Int32Type> {
     fn parse_bytes(&mut self, val: &[u8], _time_unit: Option<TimeUnit>) -> Option<i32> {
-        if self.fmt_len == 0 {
-            self.fmt_len = strptime::fmt_len(self.latest_fmt.as_bytes())?;
-        }
-        unsafe {
-            self.transform_bytes
-                .parse(val, self.latest_fmt.as_bytes(), self.fmt_len)
-                .map(|ndt| naive_date_to_date(ndt.date()))
-                .or_else(|| {
-                    // TODO! this will try all patterns.
-                    // somehow we must early escape if value is invalid
-                    for fmt in self.patterns {
-                        if self.fmt_len == 0 {
-                            self.fmt_len = strptime::fmt_len(fmt.as_bytes())?;
-                        }
-                        if let Some(parsed) = self
-                            .transform_bytes
-                            .parse(val, fmt.as_bytes(), self.fmt_len)
-                            .map(|ndt| naive_date_to_date(ndt.date()))
-                        {
-                            self.latest_fmt = fmt;
-                            return Some(parsed);
-                        }
+        self.transform_bytes
+            .parse(val, self.latest_fmt.as_bytes())
+            .map(|ndt| naive_date_to_date(ndt.date()))
+            .or_else(|| {
+                // TODO! this will try all patterns.
+                // somehow we must early escape if value is invalid
+                for fmt in self.patterns {
+                    if let Some(parsed) = self
+                        .transform_bytes
+                        .parse(val, fmt.as_bytes())
+                        .map(|ndt| naive_date_to_date(ndt.date()))
+                    {
+                        self.latest_fmt = fmt;
+                        return Some(parsed);
                     }
-                    None
-                })
-        }
+                }
+                None
+            })
     }
 }
 
@@ -215,7 +198,6 @@ pub struct DatetimeInfer<T: PolarsNumericType> {
     latest_fmt: &'static str,
     transform: fn(&str, &str) -> Option<T::Native>,
     transform_bytes: StrpTimeState,
-    fmt_len: u16,
     pub logical_type: DataType,
 }
 
@@ -256,7 +238,6 @@ impl TryFromWithUnit<Pattern> for DatetimeInfer<Int64Type> {
             latest_fmt: patterns[0],
             transform,
             transform_bytes: StrpTimeState::default(),
-            fmt_len: 0,
             logical_type: DataType::Datetime(time_unit, None),
         })
     }
@@ -274,7 +255,6 @@ impl TryFromWithUnit<Pattern> for DatetimeInfer<Int32Type> {
                 latest_fmt: patterns::DATE_D_M_Y[0],
                 transform: transform_date,
                 transform_bytes: StrpTimeState::default(),
-                fmt_len: 0,
                 logical_type: DataType::Date,
             }),
             Pattern::DateYMD => Ok(DatetimeInfer {
@@ -283,7 +263,6 @@ impl TryFromWithUnit<Pattern> for DatetimeInfer<Int32Type> {
                 latest_fmt: patterns::DATE_Y_M_D[0],
                 transform: transform_date,
                 transform_bytes: StrpTimeState::default(),
-                fmt_len: 0,
                 logical_type: DataType::Date,
             }),
             _ => polars_bail!(ComputeError: "could not convert pattern"),
@@ -301,7 +280,6 @@ impl<T: PolarsNumericType> DatetimeInfer<T> {
                     return None;
                 }
                 for fmt in self.patterns {
-                    self.fmt_len = 0;
                     if let Some(parsed) = (self.transform)(val, fmt) {
                         self.latest_fmt = fmt;
                         return Some(parsed);

--- a/crates/polars-time/src/chunkedarray/string/mod.rs
+++ b/crates/polars-time/src/chunkedarray/string/mod.rs
@@ -225,12 +225,11 @@ pub trait StringMethods: AsString {
         let fmt = strptime::compile_fmt(fmt)?;
 
         // We can use the fast parser.
-        let ca = if let Some(fmt_len) = strptime::fmt_len(fmt.as_bytes()) {
+        let ca = if strptime::fast_parser_supported(fmt.as_bytes()) {
             let mut strptime_cache = StrpTimeState::default();
             let mut convert = LruCachedFunc::new(
                 |s: &str| {
-                    // SAFETY: fmt_len is correct, it was computed with this `fmt` str.
-                    match unsafe { strptime_cache.parse(s.as_bytes(), fmt.as_bytes(), fmt_len) } {
+                    match strptime_cache.parse(s.as_bytes(), fmt.as_bytes()) {
                         // Fallback to chrono.
                         None => NaiveDate::parse_from_str(s, &fmt).ok(),
                         Some(ndt) => Some(ndt.date()),
@@ -305,14 +304,12 @@ pub trait StringMethods: AsString {
                 TimeUnit::Microseconds => infer::transform_datetime_us,
                 TimeUnit::Milliseconds => infer::transform_datetime_ms,
             };
-            // We can use the fast parser.
-            let ca = if let Some(fmt_len) = self::strptime::fmt_len(fmt.as_bytes()) {
+            let ca = if strptime::fast_parser_supported(fmt.as_bytes()) {
                 let mut strptime_cache = StrpTimeState::default();
                 let mut convert = LruCachedFunc::new(
                     |s: &str| {
                         // SAFETY: fmt_len is correct, it was computed with this `fmt` str.
-                        match unsafe { strptime_cache.parse(s.as_bytes(), fmt.as_bytes(), fmt_len) }
-                        {
+                        match strptime_cache.parse(s.as_bytes(), fmt.as_bytes()) {
                             None => transform(s, &fmt),
                             Some(ndt) => Some(func(ndt)),
                         }

--- a/crates/polars-time/src/chunkedarray/string/mod.rs
+++ b/crates/polars-time/src/chunkedarray/string/mod.rs
@@ -307,12 +307,9 @@ pub trait StringMethods: AsString {
             let ca = if strptime::fast_parser_supported(fmt.as_bytes()) {
                 let mut strptime_cache = StrpTimeState::default();
                 let mut convert = LruCachedFunc::new(
-                    |s: &str| {
-                        // SAFETY: fmt_len is correct, it was computed with this `fmt` str.
-                        match strptime_cache.parse(s.as_bytes(), fmt.as_bytes()) {
-                            None => transform(s, &fmt),
-                            Some(ndt) => Some(func(ndt)),
-                        }
+                    |s: &str| match strptime_cache.parse(s.as_bytes(), fmt.as_bytes()) {
+                        None => transform(s, &fmt),
+                        Some(ndt) => Some(func(ndt)),
                     },
                     (string_ca.len() as f64).sqrt() as usize,
                 );

--- a/crates/polars-time/src/chunkedarray/string/strptime.rs
+++ b/crates/polars-time/src/chunkedarray/string/strptime.rs
@@ -219,8 +219,8 @@ impl StrpTimeState {
 pub(super) fn fast_parser_supported(fmt: &[u8]) -> bool {
     let mut iter = fmt.iter();
     while let Some(&val) = iter.next() {
-        match val {
-            b'%' => match iter.next() {
+        if val == b'%' {
+            match iter.next() {
                 Some(&next_val) => match next_val {
                     b'Y' | b'y' | b'd' | b'm' | b'b' | b'B' | b'H' | b'M' | b'S' => {},
 
@@ -232,8 +232,7 @@ pub(super) fn fast_parser_supported(fmt: &[u8]) -> bool {
                     _ => return false,
                 },
                 None => return false,
-            },
-            _ => {},
+            }
         }
     }
     true
@@ -249,7 +248,6 @@ mod test {
             (
                 "2021-01-01",
                 "%Y-%m-%d",
-                10,
                 Some(
                     NaiveDate::from_ymd_opt(2021, 1, 1)
                         .unwrap()
@@ -260,7 +258,6 @@ mod test {
             (
                 "2021-01-01 07:45:12",
                 "%Y-%m-%d %H:%M:%S",
-                19,
                 Some(
                     NaiveDate::from_ymd_opt(2021, 1, 1)
                         .unwrap()
@@ -271,7 +268,6 @@ mod test {
             (
                 "2021-01-01 07:45:12",
                 "%Y-%m-%d %H:%M:%S",
-                19,
                 Some(
                     NaiveDate::from_ymd_opt(2021, 1, 1)
                         .unwrap()
@@ -282,7 +278,6 @@ mod test {
             (
                 "2019-04-18T02:45:55.555000000",
                 "%Y-%m-%dT%H:%M:%S.%9f",
-                29,
                 Some(
                     NaiveDate::from_ymd_opt(2019, 4, 18)
                         .unwrap()
@@ -293,7 +288,6 @@ mod test {
             (
                 "2019-04-18T02:45:55.555000",
                 "%Y-%m-%dT%H:%M:%S.%6f",
-                26,
                 Some(
                     NaiveDate::from_ymd_opt(2019, 4, 18)
                         .unwrap()
@@ -304,7 +298,6 @@ mod test {
             (
                 "2019-04-18T02:45:55.555",
                 "%Y-%m-%dT%H:%M:%S.%3f",
-                23,
                 Some(
                     NaiveDate::from_ymd_opt(2019, 4, 18)
                         .unwrap()
@@ -314,7 +307,7 @@ mod test {
             ),
         ];
 
-        for (val, fmt, len, expected) in patterns {
+        for (val, fmt, expected) in patterns {
             assert_eq!(
                 StrpTimeState::default().parse(val.as_bytes(), fmt.as_bytes()),
                 expected

--- a/crates/polars-time/src/chunkedarray/string/strptime.rs
+++ b/crates/polars-time/src/chunkedarray/string/strptime.rs
@@ -33,7 +33,7 @@ fn update_and_parse<T: atoi_simd::Parse>(
 #[inline]
 fn parse_month_abbrev(val: &[u8], offset: usize) -> Option<(u32, usize)> {
     let new_offset = offset + 3;
-    match &val[offset..new_offset] {
+    match val.get(offset..new_offset)? {
         b"Jan" => Some((1, new_offset)),
         b"Feb" => Some((2, new_offset)),
         b"Mar" => Some((3, new_offset)),
@@ -49,91 +49,33 @@ fn parse_month_abbrev(val: &[u8], offset: usize) -> Option<(u32, usize)> {
         _ => None,
     }
 }
+
+static FULL_MONTH: &[&str; 12] = &[
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+];
+
 #[inline]
-fn parse_month_full(val: &[u8], offset: usize) -> Option<(u32, usize)> {
-    let min_offset = offset + 3;
-    match &val[offset..min_offset] {
-        b"Jan" => {
-            let new_offset = min_offset + 4;
-            match &val[min_offset..new_offset] {
-                b"uary" => Some((1, new_offset)),
-                _ => None,
-            }
-        },
-        b"Feb" => {
-            let new_offset = min_offset + 5;
-            match &val[min_offset..new_offset] {
-                b"ruary" => Some((2, new_offset)),
-                _ => None,
-            }
-        },
-        b"Mar" => {
-            let new_offset = min_offset + 2;
-            match &val[min_offset..new_offset] {
-                b"ch" => Some((3, new_offset)),
-                _ => None,
-            }
-        },
-        b"Apr" => {
-            let new_offset = min_offset + 2;
-            match &val[min_offset..new_offset] {
-                b"il" => Some((4, new_offset)),
-                _ => None,
-            }
-        },
-        b"May" => Some((5, min_offset)),
-        b"Jun" => {
-            let new_offset = min_offset + 1;
-            match &val[min_offset..new_offset] {
-                b"e" => Some((6, new_offset)),
-                _ => None,
-            }
-        },
-        b"Jul" => {
-            let new_offset = min_offset + 1;
-            match &val[min_offset..new_offset] {
-                b"y" => Some((7, new_offset)),
-                _ => None,
-            }
-        },
-        b"Aug" => {
-            let new_offset = min_offset + 3;
-            match &val[min_offset..new_offset] {
-                b"ust" => Some((8, new_offset)),
-                _ => None,
-            }
-        },
-        b"Sep" => {
-            let new_offset = min_offset + 6;
-            match &val[min_offset..new_offset] {
-                b"tember" => Some((9, new_offset)),
-                _ => None,
-            }
-        },
-        b"Oct" => {
-            let new_offset = min_offset + 4;
-            match &val[min_offset..new_offset] {
-                b"ober" => Some((10, new_offset)),
-                _ => None,
-            }
-        },
-        b"Nov" => {
-            let new_offset = min_offset + 5;
-            match &val[min_offset..new_offset] {
-                b"ember" => Some((11, new_offset)),
-                _ => None,
-            }
-        },
-        b"Dec" => {
-            let new_offset = min_offset + 5;
-            match &val[min_offset..new_offset] {
-                b"ember" => Some((12, new_offset)),
-                _ => None,
-            }
-        },
-        _ => None,
+fn parse_month_full_or_abbrev(val: &[u8], offset: usize) -> Option<(u32, usize)> {
+    let (month, offset) = parse_month_abbrev(val, offset)?;
+    let rest = &FULL_MONTH[(month - 1) as usize].as_bytes()[3..];
+    if val[offset..].starts_with(rest) {
+        Some((month, offset + rest.len()))
+    } else {
+        Some((month, offset))
     }
 }
+
 /// Tries to convert a chrono `fmt` to a `fmt` that the polars parser consumes.
 /// E.g. chrono supports single letter date identifiers like %F, whereas polars only consumes
 /// year, day, month distinctively with %Y, %d, %m.
@@ -168,33 +110,18 @@ pub(super) struct StrpTimeState {}
 
 impl StrpTimeState {
     #[inline]
-    // # Safety
-    // Caller must ensure that fmt adheres to the fmt rules of chrono and `fmt_len` is correct.
-    pub(super) unsafe fn parse(
-        &mut self,
-        val: &[u8],
-        fmt: &[u8],
-        fmt_len_val: u16,
-    ) -> Option<NaiveDateTime> {
+    pub(super) fn parse(&mut self, val: &[u8], fmt: &[u8]) -> Option<NaiveDateTime> {
         let mut offset = 0;
         let mut negative = false;
         if val.starts_with(b"-") && fmt.starts_with(b"%Y") {
             offset = 1;
             negative = true;
         }
-        #[allow(non_snake_case)]
-        let has_B_code = fmt.windows(2).any(|w| w == b"%B");
-        // SAFETY: this still ensures get_unchecked won't be out of bounds as val will be at least as big as we expect.
-        // After consuming the full month name, we'll double check remaining len is exactly equal.
-        let is_too_short = has_B_code && val.len() - offset < (fmt_len_val as usize);
-        if (!has_B_code && val.len() - offset != (fmt_len_val as usize)) || is_too_short {
-            return None;
-        }
 
         const ESCAPE: u8 = b'%';
+
+        // Minimal day/month is always 1, otherwise chrono may panic.
         let mut year: i32 = 1;
-        // minimal day/month is always 1
-        // otherwise chrono may panic.
         let mut month: u32 = 1;
         let mut day: u32 = 1;
         let mut hour: u32 = 0;
@@ -205,13 +132,8 @@ impl StrpTimeState {
         let mut fmt_iter = fmt.iter();
 
         while let Some(fmt_b) = fmt_iter.next() {
-            debug_assert!(offset < val.len());
-            let b = *val.get_unchecked(offset);
             if *fmt_b == ESCAPE {
-                // SAFETY: we must ensure we provide valid patterns
-                let next = fmt_iter.next();
-                debug_assert!(next.is_some());
-                match next.unwrap_unchecked() {
+                match fmt_iter.next()? {
                     b'Y' => {
                         (year, offset) = update_and_parse(4, offset, val)?;
                         if negative {
@@ -228,13 +150,7 @@ impl StrpTimeState {
                         (month, offset) = parse_month_abbrev(val, offset)?;
                     },
                     b'B' => {
-                        (month, offset) = parse_month_full(val, offset)?;
-                        // After variable sized month is consumed, verify remaining is exact len
-                        let new_fmt_len = fmt_len(fmt_iter.as_slice())?;
-                        let remaining_val_len = val.len() - offset;
-                        if remaining_val_len != (new_fmt_len as usize) {
-                            return None;
-                        }
+                        (month, offset) = parse_month_full_or_abbrev(val, offset)?;
                     },
                     b'd' => {
                         (day, offset) = update_and_parse(2, offset, val)?;
@@ -250,7 +166,7 @@ impl StrpTimeState {
                     },
                     b'y' => {
                         let new_offset = offset + 2;
-                        let bytes = val.get_unchecked(offset..new_offset);
+                        let bytes = val.get(offset..new_offset)?;
 
                         let (decade, parsed) =
                             atoi_simd::parse_prefix::<i32, true, false>(bytes).ok()?;
@@ -281,9 +197,8 @@ impl StrpTimeState {
                     },
                     _ => return None,
                 }
-            }
-            // consume
-            else if b == *fmt_b {
+            } else if val.get(offset) == Some(fmt_b) {
+                // Consume literal.
                 offset += 1;
             } else {
                 return None;
@@ -301,57 +216,27 @@ impl StrpTimeState {
     }
 }
 
-pub(super) fn fmt_len(fmt: &[u8]) -> Option<u16> {
+pub(super) fn fast_parser_supported(fmt: &[u8]) -> bool {
     let mut iter = fmt.iter();
-    let mut cnt = 0;
-
     while let Some(&val) = iter.next() {
         match val {
             b'%' => match iter.next() {
                 Some(&next_val) => match next_val {
-                    b'Y' => cnt += 4,
-                    b'y' => cnt += 2,
-                    b'd' => cnt += 2,
-                    b'm' => cnt += 2,
-                    b'b' => cnt += 3,
-                    b'B' => cnt += 3, // This is minimum size for full month
-                    b'H' => cnt += 2,
-                    b'M' => cnt += 2,
-                    b'S' => cnt += 2,
-                    b'9' => {
-                        cnt += 9;
-                        if matches!(iter.next(), Some(&b'f')) && iter.next().is_none() {
-                            return Some(cnt);
-                        } else {
-                            return None;
+                    b'Y' | b'y' | b'd' | b'm' | b'b' | b'B' | b'H' | b'M' | b'S' => {},
+
+                    b'9' | b'6' | b'3' => {
+                        if iter.next().is_some_and(|c| *c != b'f') {
+                            return false;
                         }
                     },
-                    b'6' => {
-                        cnt += 6;
-                        if matches!(iter.next(), Some(&b'f')) && iter.next().is_none() {
-                            return Some(cnt);
-                        } else {
-                            return None;
-                        }
-                    },
-                    b'3' => {
-                        cnt += 3;
-                        if matches!(iter.next(), Some(&b'f')) && iter.next().is_none() {
-                            return Some(cnt);
-                        } else {
-                            return None;
-                        }
-                    },
-                    _ => return None,
+                    _ => return false,
                 },
-                None => return None,
+                None => return false,
             },
-            _ => {
-                cnt += 1;
-            },
+            _ => {},
         }
     }
-    Some(cnt)
+    true
 }
 
 #[cfg(test)]
@@ -430,13 +315,10 @@ mod test {
         ];
 
         for (val, fmt, len, expected) in patterns {
-            assert_eq!(fmt_len(fmt.as_bytes()).unwrap(), len);
-            unsafe {
-                assert_eq!(
-                    StrpTimeState::default().parse(val.as_bytes(), fmt.as_bytes(), len),
-                    expected
-                )
-            };
+            assert_eq!(
+                StrpTimeState::default().parse(val.as_bytes(), fmt.as_bytes()),
+                expected
+            );
         }
     }
 }

--- a/crates/polars-time/src/chunkedarray/string/strptime.rs
+++ b/crates/polars-time/src/chunkedarray/string/strptime.rs
@@ -183,17 +183,17 @@ impl StrpTimeState {
                     },
                     b'9' => {
                         (nano, offset) = update_and_parse(9, offset, val)?;
-                        break;
+                        assert!(fmt_iter.next() == Some(&b'f'));
                     },
                     b'6' => {
                         (nano, offset) = update_and_parse(6, offset, val)?;
                         nano *= 1000;
-                        break;
+                        assert!(fmt_iter.next() == Some(&b'f'));
                     },
                     b'3' => {
                         (nano, offset) = update_and_parse(3, offset, val)?;
                         nano *= 1_000_000;
-                        break;
+                        assert!(fmt_iter.next() == Some(&b'f'));
                     },
                     _ => return None,
                 }

--- a/py-polars/tests/unit/operations/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/operations/namespaces/test_strptime.py
@@ -839,6 +839,10 @@ def test_polars_parser_fooled_by_trailing_nonsense_22167() -> None:
         pl.Series(["2025-04-06T18:57:42.77123Z"]).str.to_datetime(
             "%Y-%m-%dT%H:%M:%S.%6f#z"
         )
+    with pytest.raises(InvalidOperationError):
+        pl.Series(["2025-04-06T18:57:42.777561920"]).str.to_datetime(
+            "%Y-%m-%dT%H:%M:%S.%9fZ"
+        )
 
 
 def test_strptime_empty_input_22214() -> None:

--- a/py-polars/tests/unit/operations/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/operations/namespaces/test_strptime.py
@@ -906,7 +906,22 @@ def test_date_parse_omit_day_month() -> None:
             "2022 December",
         ]
     )
-    result = s.str.strptime(pl.Date, "%Y %B")
+    s_abbrev = pl.Series(
+        [
+            "2022 Jan",
+            "2022 Feb",
+            "2022 Mar",
+            "2022 Apr",
+            "2022 May",
+            "2022 Jun",
+            "2022 Jul",
+            "2022 Aug",
+            "2022 Sep",
+            "2022 Oct",
+            "2022 Nov",
+            "2022 Dec",
+        ]
+    )
     expected = pl.Series(
         [
             date(2022, 1, 1),
@@ -923,7 +938,9 @@ def test_date_parse_omit_day_month() -> None:
             date(2022, 12, 1),
         ]
     )
-    assert_series_equal(result, expected)
+    assert_series_equal(s.str.strptime(pl.Date, "%Y %B"), expected)
+    assert_series_equal(s_abbrev.str.strptime(pl.Date, "%Y %b"), expected)
+    assert_series_equal(s_abbrev.str.strptime(pl.Date, "%Y %B"), expected)
 
 
 @pytest.mark.parametrize("length", [1, 5])


### PR DESCRIPTION
This also makes the parser safe, we didn't properly check the preconditions everywhere, and I don't think there was much  benefit to it in the first place.