### PR TITLE
fix(rust): Drop non-output columns from streaming equi and semi/anti joins

### DIFF
--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -77,6 +77,7 @@ fn compute_payload_selector(
     other: &Schema,
     this_key_schema: &Schema,
     other_key_schema: &Schema,
+    output_schema: &Schema,
     is_left: bool,
     args: &JoinArgs,
 ) -> PolarsResult<Vec<Option<PlSmallStr>>> {
@@ -104,11 +105,11 @@ fn compute_payload_selector(
                     if is_left {
                         Some(c.clone())
                     } else if args.how == JoinType::Full {
-                        // We must keep the right-hand side keycols around for
-                        // coalescing.
+                        // Keep RHS keycols for coalescing. Early-return so the
+                        // internal name is not dropped by the output_schema filter.
                         let key_idx = this_key_schema.index_of(c).unwrap();
                         let name = format_pl_smallstr!("__POLARS_COALESCE_KEYCOL_{key_idx}");
-                        Some(name)
+                        return Ok(Some(name));
                     } else {
                         None
                     }
@@ -118,6 +119,8 @@ fn compute_payload_selector(
                     break 'create_and_return_selector;
                 };
 
+                // Drop key-materialization temps and other non-output columns.
+                let selector = selector.filter(|name| output_schema.contains(name.as_str()));
                 return Ok(selector);
             }
 
@@ -1211,6 +1214,7 @@ impl EquiJoinNode {
         left_key_schema: Arc<Schema>,
         right_key_schema: Arc<Schema>,
         unique_key_schema: Arc<Schema>,
+        output_schema: Arc<Schema>,
         left_key_selectors: Vec<StreamExpr>,
         right_key_selectors: Vec<StreamExpr>,
         args: JoinArgs,
@@ -1257,6 +1261,7 @@ impl EquiJoinNode {
             &right_input_schema,
             &left_key_schema,
             &right_key_schema,
+            &output_schema,
             true,
             &args,
         )?;
@@ -1265,6 +1270,7 @@ impl EquiJoinNode {
             &left_input_schema,
             &right_key_schema,
             &left_key_schema,
+            &output_schema,
             false,
             &args,
         )?;

--- a/crates/polars-stream/src/nodes/joins/semi_anti_join.rs
+++ b/crates/polars-stream/src/nodes/joins/semi_anti_join.rs
@@ -41,6 +41,7 @@ struct SemiAntiJoinParams {
     left_is_build: bool,
     left_key_selectors: Vec<StreamExpr>,
     right_key_selectors: Vec<StreamExpr>,
+    output_schema: Arc<Schema>,
     nulls_equal: bool,
     is_anti: bool,
     return_bool: bool,
@@ -56,6 +57,7 @@ pub struct SemiAntiJoinNode {
 impl SemiAntiJoinNode {
     pub fn new(
         unique_key_schema: Arc<Schema>,
+        output_schema: Arc<Schema>,
         left_key_selectors: Vec<StreamExpr>,
         right_key_selectors: Vec<StreamExpr>,
         args: JoinArgs,
@@ -73,6 +75,7 @@ impl SemiAntiJoinNode {
                 left_is_build,
                 left_key_selectors,
                 right_key_selectors,
+                output_schema,
                 random_state: PlRandomState::default(),
                 nulls_equal: args.nulls_equal,
                 return_bool,
@@ -316,7 +319,9 @@ impl ProbeState {
                     if probe_match.is_empty() {
                         continue;
                     }
-                    df.take_slice_unchecked(&probe_match)
+                    // Drop key-materialization temps; keep only planned output columns.
+                    df.select(params.output_schema.iter_names())?
+                        .take_slice_unchecked(&probe_match)
                 };
 
                 let mut morsel = Morsel::new_unregistered(out_df, in_seq, src_token.clone());

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -1149,6 +1149,7 @@ fn to_graph_rec<'a>(
             output_bool: _,
         } => {
             let args = args.clone();
+            let output_schema = node.output_schema(0).clone();
             let left_input_key = to_graph_rec(input_left.node, ctx)?;
             let right_input_key = to_graph_rec(input_right.node, ctx)?;
             let left_input_schema = input_left.output_schema(ctx.phys_sm).clone();
@@ -1201,6 +1202,7 @@ fn to_graph_rec<'a>(
                 SemiAntiJoin { output_bool, .. } => ctx.graph.add_node(
                     nodes::joins::semi_anti_join::SemiAntiJoinNode::new(
                         unique_key_schema,
+                        output_schema,
                         left_key_selectors,
                         right_key_selectors,
                         args,
@@ -1219,6 +1221,7 @@ fn to_graph_rec<'a>(
                         left_key_schema,
                         right_key_schema,
                         unique_key_schema,
+                        output_schema,
                         left_key_selectors,
                         right_key_selectors,
                         args,

--- a/py-polars/tests/unit/streaming/test_streaming_join.py
+++ b/py-polars/tests/unit/streaming/test_streaming_join.py
@@ -732,3 +732,50 @@ def test_streaming_merge_join_send_port_done_27547() -> None:
     expected = q.collect(engine="in-memory")
     actual = q.collect(engine="streaming")
     assert_frame_equal(actual, expected)
+
+
+def _assert_streaming_matches_in_memory(q: pl.LazyFrame) -> pl.DataFrame:
+    expected = q.collect(engine="in-memory")
+    actual = q.collect(engine="streaming")
+    assert_frame_equal(actual, expected, check_row_order=False)
+    return actual
+
+
+@pytest.mark.parametrize("how", ["inner", "left", "full", "semi", "anti"])
+def test_streaming_equi_join_computed_key_no_temp_leak_28264(how: JoinStrategy) -> None:
+    # Non-elementwise keys materialize as temps; they must not become payload.
+    left = pl.LazyFrame({"a": [1, 9], "x": [10, 90]})
+    right = pl.LazyFrame({"b": [1, 9], "y": [100, 900]})
+    q = left.join(
+        right,
+        left_on=pl.col("a").is_in([1]),
+        right_on=pl.col("b").is_in([1]),
+        how=how,
+    )
+    _assert_streaming_matches_in_memory(q)
+
+
+@pytest.mark.parametrize(
+    ("l_val", "select"),
+    [
+        (1, ["l_loc", "r_loc"]),
+        (1, ["l_loc", "r_loc", "l_val", "r_val"]),
+        (3, ["l_loc", "r_loc", "l_val", "r_val"]),
+    ],
+    ids=["keys_only", "full_payload", "zero_rows"],
+)
+def test_streaming_cross_join_is_in_eq_rewrite_28264(
+    l_val: int, select: list[str]
+) -> None:
+    left = pl.LazyFrame({"l_loc": ["L1"], "l_val": [l_val]})
+    right = pl.LazyFrame({"r_loc": ["L2"], "r_val": [2]})
+    group = ["L1", "L2"]
+    bool_eq = pl.col("l_loc").is_in(group) == pl.col("r_loc").is_in(group)
+    q = (
+        left.join(right, how="cross")
+        .filter(pl.col("l_val") <= pl.col("r_val"))
+        .filter(bool_eq)
+        .select(select)
+    )
+    assert "INNER JOIN" in q.explain(optimized=True)
+    _assert_streaming_matches_in_memory(q)


### PR DESCRIPTION
Fixes #28264.

Non-elementwise join keys (`is_in`, `replace`, …) are materialised as temporary columns. Streaming equi-join and semi/anti were keeping those temps as payload, which leaked `_POLARS_TMP_*` names, dropped real columns, and diverged from the in-memory engine.

Filter equi-join payload selection by the planned join `output_schema` (same idea as cleaning temps after the op). Full-join coalesce keeps internal key columns via early-return so coalescing still works. Semi/anti projects to the planned left output before emitting rows.

### Tests

Streaming vs in-memory for computed keys across join hows, plus the cross-join + `is_in == is_in` rewrite cases from the issue.

### Local tests (first-time contributor)

![make test](https://raw.githubusercontent.com/Saswatsusmoy/polars/pr-28392-make-test-screenshot/.github/make-test-screenshot.png)

`make test`: 18068 passed, 89 skipped, 9 xfailed

1. I used AI (Grok) to help investigate the issue and to summarize this PR description.
2. I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.