### PR TITLE
feat!: Preserve height for with_columns() of (0, 0) input

### DIFF
--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -895,10 +895,6 @@ impl DataFrame {
         index: usize,
         column: Column,
     ) -> PolarsResult<&mut Self> {
-        if self.shape() == (0, 0) {
-            unsafe { self.set_height(column.len()) };
-        }
-
         polars_ensure!(
             column.len() == self.height(),
             ShapeMismatch:
@@ -926,10 +922,6 @@ impl DataFrame {
     /// Add a new column to this [`DataFrame`] or replace an existing one. Broadcasts unit-length
     /// columns.
     pub fn with_column(&mut self, mut column: Column) -> PolarsResult<&mut Self> {
-        if self.shape() == (0, 0) {
-            unsafe { self.set_height(column.len()) };
-        }
-
         if column.len() != self.height() && column.len() == 1 {
             column = column.new_from_index(0, self.height());
         }
@@ -985,10 +977,6 @@ impl DataFrame {
         mut column: Column,
         output_schema: &Schema,
     ) -> PolarsResult<&mut Self> {
-        if self.shape() == (0, 0) {
-            unsafe { self.set_height(column.len()) };
-        }
-
         if column.len() != self.height() && column.len() == 1 {
             column = column.new_from_index(0, self.height());
         }

--- a/crates/polars-mem-engine/src/executors/stack.rs
+++ b/crates/polars-mem-engine/src/executors/stack.rs
@@ -69,7 +69,7 @@ impl StackExec {
                 // possibly mismatching column lengths.
                 unsafe { df.columns_mut() }.extend(res);
             } else {
-                let (df_height, df_width) = df.shape();
+                let df_height = df.height();
 
                 // When we have CSE we cannot verify scalars yet.
                 let verify_scalar = if !df.columns().is_empty() {
@@ -81,7 +81,7 @@ impl StackExec {
                 };
                 for (i, c) in res.iter().enumerate() {
                     let len = c.len();
-                    if verify_scalar && len != df_height && len == 1 && df_width > 0 {
+                    if verify_scalar && len != df_height && len == 1 {
                         #[allow(clippy::collapsible_if)]
                         if !self.exprs[i].is_scalar()
                             && std::env::var("POLARS_ALLOW_NON_SCALAR_EXP").as_deref() != Ok("1")

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -702,20 +702,6 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             exprs,
             options,
         } => {
-            // The (0, 0) DataFrame is an exception - with_columns on it acts like select.
-            if let DslPlan::DataFrameScan { df, schema: _ } = input.as_ref() {
-                if df.shape() == (0, 0) {
-                    return to_alp_impl(
-                        DslPlan::Select {
-                            expr: exprs,
-                            input,
-                            options,
-                        },
-                        ctxt,
-                    );
-                }
-            }
-
             let input = to_alp_impl(owned(input), ctxt)
                 .map_err(|e| e.context(failed_here!(with_columns)))?;
             let (exprs, schema) =

--- a/crates/polars-plan/src/plans/optimizer/cluster_with_columns.rs
+++ b/crates/polars-plan/src/plans/optimizer/cluster_with_columns.rs
@@ -3,22 +3,36 @@ use std::sync::Arc;
 use polars_core::prelude::{PlIndexMap, PlIndexSet};
 use polars_utils::aliases::InitHashMaps;
 use polars_utils::arena::{Arena, Node};
+use polars_utils::scratch_vec::ScratchVec;
 
 use super::aexpr::AExpr;
 use super::ir::IR;
 use super::{PlSmallStr, aexpr_to_leaf_names_iter};
 use crate::plans::ExprIR;
+use crate::plans::projection_height::aexpr_projection_height_rec;
+use crate::prelude::projection_height::ExprProjectionHeight;
+
+enum ExprSource {
+    Original { non_scalar_output_height: bool },
+    Replaced,
+}
 
 pub fn optimize(root: Node, lp_arena: &mut Arena<IR>, expr_arena: &Arena<AExpr>) {
+    use ExprProjectionHeight as EH;
+
     let mut ir_stack = Vec::with_capacity(16);
     ir_stack.push(root);
 
-    // key: output_name, value: (expr, is_original)
-    let mut input_name_to_expr_map: PlIndexMap<PlSmallStr, (ExprIR, bool)> = PlIndexMap::new();
+    // key: output_name, value: (expr, _)
+    let mut input_name_to_expr_map: PlIndexMap<PlSmallStr, (ExprIR, ExprSource)> =
+        PlIndexMap::new();
     let mut input_names_accessed_by_non_candidates: PlIndexSet<PlSmallStr> = PlIndexSet::new();
     let mut push_candidate_idxs: Vec<usize> = vec![];
     let mut new_current_exprs: Vec<ExprIR> = vec![];
     let mut visited_caches = PlIndexSet::new();
+
+    let mut ae_nodes_stack = ScratchVec::default();
+    let mut ae_heights_stack = ScratchVec::default();
 
     while let Some(current_node) = ir_stack.pop() {
         let current_ir = lp_arena.get(current_node);
@@ -63,12 +77,33 @@ pub fn optimize(root: Node, lp_arena: &mut Arena<IR>, expr_arena: &Arena<AExpr>)
         input_names_accessed_by_non_candidates.clear();
         push_candidate_idxs.clear();
         new_current_exprs.clear();
+        let mut input_non_scalar_output_height_count: usize = 0;
 
-        input_name_to_expr_map.extend(
-            input_exprs
-                .iter()
-                .map(|e| (e.output_name().clone(), (e.clone(), true))),
-        );
+        input_name_to_expr_map.extend(input_exprs.iter().map(|e| {
+            let non_scalar_output_height = !matches!(
+                aexpr_projection_height_rec(
+                    e.node(),
+                    expr_arena,
+                    &mut ae_nodes_stack,
+                    &mut ae_heights_stack
+                ),
+                EH::Scalar
+            );
+
+            if non_scalar_output_height {
+                input_non_scalar_output_height_count += 1;
+            }
+
+            (
+                e.output_name().clone(),
+                (
+                    e.clone(),
+                    ExprSource::Original {
+                        non_scalar_output_height,
+                    },
+                ),
+            )
+        }));
 
         if input_name_to_expr_map.len() != input_exprs.len() {
             if cfg!(debug_assertions) {
@@ -111,6 +146,46 @@ pub fn optimize(root: Node, lp_arena: &mut Arena<IR>, expr_arena: &Arena<AExpr>)
             !input_names_accessed_by_non_candidates.contains(e.output_name())
         });
 
+        // E.g. `LazyFrame().with_columns(a=int_range(5)).with_columns(a=1)`, we cannot prune the int_range as
+        // otherwise the query may succeed with 1 row instead of erroring.
+        let mut last_match_idx: usize = 0;
+        if input_non_scalar_output_height_count != 0
+            && push_candidate_idxs.len() >= input_non_scalar_output_height_count
+            && push_candidate_idxs
+                .iter()
+                .map(|&i| {
+                    let e = &current_exprs[i];
+
+                    let would_replace_non_scalar_with_scalar = matches!(
+                        input_name_to_expr_map.get(e.output_name()),
+                        Some((
+                            _,
+                            ExprSource::Original {
+                                non_scalar_output_height: true
+                            }
+                        ))
+                    ) && matches!(
+                        aexpr_projection_height_rec(
+                            e.node(),
+                            expr_arena,
+                            &mut ae_nodes_stack,
+                            &mut ae_heights_stack
+                        ),
+                        EH::Scalar
+                    );
+
+                    if would_replace_non_scalar_with_scalar {
+                        last_match_idx = i;
+                    }
+
+                    usize::from(would_replace_non_scalar_with_scalar)
+                })
+                .sum::<usize>()
+                == input_non_scalar_output_height_count
+        {
+            push_candidate_idxs.remove(last_match_idx);
+        }
+
         let mut candidate_idx: usize = 0;
 
         for (i, e) in current_exprs.iter().enumerate() {
@@ -123,7 +198,8 @@ pub fn optimize(root: Node, lp_arena: &mut Arena<IR>, expr_arena: &Arena<AExpr>)
 
             if push_candidate_idxs.get(candidate_idx) == Some(&i) {
                 candidate_idx += 1;
-                input_name_to_expr_map.insert(e.output_name().clone(), (e.clone(), false));
+                input_name_to_expr_map
+                    .insert(e.output_name().clone(), (e.clone(), ExprSource::Replaced));
                 continue;
             }
 
@@ -136,13 +212,10 @@ pub fn optimize(root: Node, lp_arena: &mut Arena<IR>, expr_arena: &Arena<AExpr>)
 
         input_exprs.clear();
 
-        for (output_name, (e, is_original)) in input_name_to_expr_map
-            .iter()
-            .map(|x| (x.0.clone(), x.1.clone()))
-        {
-            input_exprs.push(e);
+        for (output_name, (e, e_src)) in input_name_to_expr_map.iter().map(|x| (x.0.clone(), x.1)) {
+            input_exprs.push(e.clone());
 
-            if !is_original {
+            if !matches!(e_src, ExprSource::Original { .. }) {
                 let dtype = current_schema.get(&output_name).unwrap().clone();
                 Arc::make_mut(input_schema).insert(output_name, dtype);
             }

--- a/crates/polars-plan/src/plans/optimizer/cluster_with_columns.rs
+++ b/crates/polars-plan/src/plans/optimizer/cluster_with_columns.rs
@@ -148,7 +148,7 @@ pub fn optimize(root: Node, lp_arena: &mut Arena<IR>, expr_arena: &Arena<AExpr>)
 
         // E.g. `LazyFrame().with_columns(a=int_range(5)).with_columns(a=1)`, we cannot prune the int_range as
         // otherwise the query may succeed with 1 row instead of erroring.
-        let mut last_match_idx: usize = 0;
+        let mut last_match_idx: usize = usize::MAX;
         if input_non_scalar_output_height_count != 0
             && push_candidate_idxs.len() >= input_non_scalar_output_height_count
             && push_candidate_idxs

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -1574,10 +1574,13 @@ impl SQLContext {
                 // * There is already a projection that projects to the table height.
                 // * All projection heights inherit from context (e.g. all scalar literals that
                 //   are to be broadcasted to table height).
-                if projection_heights.contains(ExprSqlProjectionHeightBehavior::MaintainsColumn)
+                if select_stmt.from.is_empty() {
+                    lf = lf.select(projections);
+                } else if projection_heights
+                    .contains(ExprSqlProjectionHeightBehavior::MaintainsColumn)
                     || projection_heights == ExprSqlProjectionHeightBehavior::InheritsContext
                 {
-                    lf = lf.with_columns(projections);
+                    lf = lf.with_columns(projections)
                 } else {
                     // We hit this branch if the output height is not guaranteed to match the table
                     // height. E.g.:
@@ -1620,6 +1623,7 @@ impl SQLContext {
             // Note: If `have_order_by`, with_columns is already done above.
             if projection_heights == ExprSqlProjectionHeightBehavior::InheritsContext
                 && !have_order_by
+                && !select_stmt.from.is_empty()
             {
                 // All projections need to be broadcasted to table height, so evaluate in `with_columns()`
                 lf = lf.with_columns(retained_cols).select(retained_names);

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -2,6 +2,7 @@ use std::ops::ControlFlow;
 use std::sync::Arc;
 
 use polars_core::chunked_array::cast::CastOptions;
+use polars_core::datatypes::AnyValue;
 use polars_core::frame::DataFrame;
 use polars_core::prelude::{
     DataType, Field, IDX_DTYPE, InitHashMaps, PlHashMap, PlHashSet, PlIndexMap, PlIndexSet,
@@ -2924,7 +2925,7 @@ pub fn build_length_preserving_select_stream(
         .iter()
         .any(|expr| is_length_preserving_ctx(expr.node(), &mut ctx));
     let input_schema = input.output_schema(ctx.phys_sm);
-    if exprs.is_empty() || input_schema.is_empty() || already_length_preserving {
+    if exprs.is_empty() || already_length_preserving {
         return build_select_stream_with_ctx(input, exprs, &mut ctx);
     }
 
@@ -2932,12 +2933,34 @@ pub fn build_length_preserving_select_stream(
     // remove it from the final selector. This should ensure scalars gets zipped
     // back to the input to broadcast them.
     let tmp_name = unique_column_name();
-    let first_col = ctx.expr_arena.add(AExpr::Column(
-        input_schema.iter_names_cloned().next().unwrap(),
-    ));
+    let height_ae = if let Some(name) = input_schema.iter_names_cloned().next() {
+        AExpr::Column(name)
+    } else {
+        let function = IRFunctionExpr::Repeat;
+        let options = function.function_options();
+
+        // repeat(lit({}), len()) within each morsel.
+        let value = ctx
+            .expr_arena
+            .add(AExpr::Literal(LiteralValue::Scalar(Scalar::new(
+                DataType::Struct(vec![]),
+                AnyValue::StructOwned(Box::new((vec![], vec![]))),
+            ))));
+        let n = ctx.expr_arena.add(AExpr::Len);
+        AExpr::Function {
+            input: vec![
+                ExprIR::from_node(value, ctx.expr_arena),
+                ExprIR::from_node(n, ctx.expr_arena),
+            ],
+            function,
+            options,
+        }
+    };
+
+    let height_col = ctx.expr_arena.add(height_ae);
     let mut tmp_exprs = Vec::with_capacity(exprs.len() + 1);
     tmp_exprs.extend(exprs.iter().cloned());
-    tmp_exprs.push(ExprIR::new(first_col, OutputName::Alias(tmp_name.clone())));
+    tmp_exprs.push(ExprIR::new(height_col, OutputName::Alias(tmp_name.clone())));
 
     let out_stream = build_select_stream_with_ctx(input, &tmp_exprs, &mut ctx)?;
     let PhysNodeKind::Select { selectors, .. } = &mut ctx.phys_sm[out_stream.node].kind else {

--- a/py-polars/tests/unit/dataframe/test_extend.py
+++ b/py-polars/tests/unit/dataframe/test_extend.py
@@ -85,17 +85,6 @@ def test_extend_column_name_mismatch() -> None:
         df1.extend(df2)
 
 
-def test_initialize_df_18736() -> None:
-    # Completely empty initialization
-    df = pl.DataFrame()
-    s_0 = pl.Series([])
-    s_1 = pl.Series([None])
-    s_2 = pl.Series([None, None])
-    assert df.with_columns(s_0).shape == (0, 1)
-    assert df.with_columns(s_1).shape == (1, 1)
-    assert df.with_columns(s_2).shape == (2, 1)
-
-
 def test_extend_bad_input_type() -> None:
     a = pl.DataFrame({"x": [1, 2, 3]})
     b = pl.DataFrame({"x": [4, 5, 6]})

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -655,7 +655,7 @@ def test_scan_csv_progressive_infer_schema_length(
 
     n_rows = 60_000
     df = (
-        pl.DataFrame()
+        pl.DataFrame(height=n_rows)
         .with_columns(pl.int_range(n_rows).alias("a"))
         .with_columns(pl.col.a.cast(pl.Float64).alias("b"))
     )

--- a/py-polars/tests/unit/io/test_lazy_json.py
+++ b/py-polars/tests/unit/io/test_lazy_json.py
@@ -379,7 +379,7 @@ def test_scan_ndjson_progressive_infer_schema_length(
 
     n_rows = 60_000
     df = (
-        pl.DataFrame()
+        pl.DataFrame(height=n_rows)
         .with_columns(pl.int_range(n_rows).alias("a"))
         .with_columns(pl.col.a.cast(pl.String).alias("b"))
     )

--- a/py-polars/tests/unit/lazyframe/test_cwc.py
+++ b/py-polars/tests/unit/lazyframe/test_cwc.py
@@ -269,7 +269,7 @@ def test_neighbour_live_expr() -> None:
 
 
 def test_cluster_with_columns_collect_all_panic_26092() -> None:
-    lf = pl.LazyFrame()
+    lf = pl.LazyFrame(height=1)
     lf = lf.with_columns(pl.lit(1.0).cast(pl.Float64()).alias("numbers1"))
     lf = lf.with_columns(pl.lit(2.0).cast(pl.Float64()).alias("numbers2"))
 

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -631,7 +631,7 @@ def test_bool_numeric_supertype(dtype: PolarsDataType) -> None:
 
 @pytest.mark.parametrize("dtype", [pl.String(), pl.String, str])
 def test_cast_consistency(dtype: PolarsDataType | PythonDataType) -> None:
-    assert pl.DataFrame().with_columns(a=pl.lit(0.0)).with_columns(
+    assert pl.DataFrame(height=1).with_columns(a=pl.lit(0.0)).with_columns(
         b=pl.col("a").cast(dtype), c=pl.lit(0.0).cast(dtype)
     ).to_dict(as_series=False) == {"a": [0.0], "b": ["0.0"], "c": ["0.0"]}
 

--- a/py-polars/tests/unit/operations/test_slice.py
+++ b/py-polars/tests/unit/operations/test_slice.py
@@ -224,7 +224,7 @@ def test_slice_pushdown_literal_projection_14349() -> None:
     assert_frame_equal(expect, out)
 
     assert pl.LazyFrame().select(x=1).head(1).collect().height == 1
-    assert pl.LazyFrame().with_columns(x=1).head(1).collect().height == 1
+    assert pl.LazyFrame(height=1).with_columns(x=1).head(1).collect().height == 1
 
     q = lf.select(x=1).head(1)
     assert q.collect().height == 1

--- a/py-polars/tests/unit/operations/test_with_columns.py
+++ b/py-polars/tests/unit/operations/test_with_columns.py
@@ -1,6 +1,7 @@
 import pytest
 
 import polars as pl
+from polars.exceptions import ShapeError
 from polars.testing import assert_frame_equal
 
 
@@ -180,10 +181,16 @@ def test_with_columns_scalar_20981() -> None:
 
 
 def test_lazy_with_columns_to_select_28285() -> None:
-    out = (
+    q = (
         pl.LazyFrame()
         .with_columns(a=pl.int_range(5))
         .with_columns(a=pl.lit(2, dtype=pl.Int64))
     )
-    expected = pl.LazyFrame({"a": [2, 2, 2, 2, 2]})
-    assert_frame_equal(out, expected)
+
+    with pytest.raises(ShapeError):
+        q.collect()
+
+    q = pl.LazyFrame().with_columns(a=pl.int_range(5), b=1).with_columns(a=2, b=2)
+
+    with pytest.raises(ShapeError):
+        q.collect()

--- a/py-polars/tests/unit/sql/test_literals.py
+++ b/py-polars/tests/unit/sql/test_literals.py
@@ -11,7 +11,7 @@ from tests.unit.sql import assert_sql_matches
 
 
 def test_bit_hex_literals() -> None:
-    with pl.SQLContext(df=None, eager=True) as ctx:
+    with pl.SQLContext(df=pl.DataFrame(height=1), eager=True) as ctx:
         out = ctx.execute(
             """
             SELECT *,
@@ -123,7 +123,7 @@ def test_dollar_quoted_literals() -> None:
 
 
 def test_fixed_intervals() -> None:
-    with pl.SQLContext(df=None, eager=True) as ctx:
+    with pl.SQLContext(df=pl.DataFrame(height=1), eager=True) as ctx:
         out = ctx.execute(
             """
             SELECT
@@ -234,6 +234,13 @@ def test_interval_comparisons(interval_comparison: str, expected_result: bool) -
 
 def test_select_literals_no_table() -> None:
     res = pl.sql("SELECT 1 AS one, '2' AS two, 3.0 AS three", eager=True)
+    assert res.to_dict(as_series=False) == {
+        "one": [1],
+        "two": ["2"],
+        "three": [3.0],
+    }
+
+    res = pl.sql("SELECT 1 AS one, '2' AS two, 3.0 AS three ORDER BY 1", eager=True)
     assert res.to_dict(as_series=False) == {
         "one": [1],
         "two": ["2"],


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/28307

Existing usages of the form `pl.DataFrame().with_columns()` should instead do `pl.DataFrame(height=n).with_columns(..)`.

Note, the `cluster_with_columns` optimization is updated in this PR to avoid pruning the following case (from https://github.com/pola-rs/polars/issues/28285):

* `LazyFrame().with_columns(a=int_range(5)).with_columns(a=1)`

This ensures we raise the appropriate `ShapeError` from the attempted `with_columns` of a length-5 `int_range` to a 0-height `LazyFrame`
