### PR TITLE
build(rust): Propagate bigidx to `polars-plan` from `polars`

### DIFF
--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -348,7 +348,7 @@ bigidx = [
   "polars-core/bigidx",
   "polars-lazy?/bigidx",
   "polars-ops/big_idx",
-  "polars-plan/bigidx",
+  "polars-plan?/bigidx",
   "polars-utils/bigidx",
 ]
 polars_cloud_client = ["polars-lazy?/polars_cloud_client"]

--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -348,6 +348,7 @@ bigidx = [
   "polars-core/bigidx",
   "polars-lazy?/bigidx",
   "polars-ops/big_idx",
+  "polars-plan/bigidx",
   "polars-utils/bigidx",
 ]
 polars_cloud_client = ["polars-lazy?/polars_cloud_client"]


### PR DESCRIPTION
Follow-up to #27944 and the maintainer direction on #28382.

## Summary

- propagate the top-level `polars/bigidx` feature to `polars-plan/bigidx`;
- keep the optimizer implementation unchanged;
- fix the feature mismatch when `pyo3-polars/derive` brings `polars-plan` into the graph independently.

On current `main`, `polars/bigidx` makes `IdxSize` a `u64` through `polars-core`, while `polars-plan` still evaluates its local `bigidx` configuration as disabled. The added feature edge keeps both crates on the same index width.

## Validation

The original dependency combination was reproduced on current `main` with:

```sh
cargo check -p pyo3-polars --no-default-features \
  --features pyo3-polars/derive,polars/bigidx --locked
```

Before this change it fails with the two `UInt32`/`UInt64` type errors from #27944. With this change it passes. Also validated:

```sh
cargo check -p pyo3-polars --no-default-features --features derive --locked
cargo check -p polars --no-default-features --features bigidx --locked
cargo fmt --all -- --check
```

`cargo tree` confirms `polars-plan/bigidx` is activated by `polars/bigidx`.