### PR TITLE
test(python): Ignore all deprecation warnings in Python doctest

### DIFF
--- a/py-polars/tests/docs/run_doctest.py
+++ b/py-polars/tests/docs/run_doctest.py
@@ -115,24 +115,9 @@ if __name__ == "__main__":
 
     # Set doctests to fail on warnings
     warnings.simplefilter("error", Warning)
+    # TODO: Remove in 2.0.
     warnings.filterwarnings(
         "ignore",
-        message="datetime.datetime.utcfromtimestamp\\(\\) is deprecated.*",
-        category=DeprecationWarning,
-    )
-    warnings.filterwarnings(
-        "ignore",
-        message="datetime.datetime.utcnow\\(\\) is deprecated.*",
-        category=DeprecationWarning,
-    )
-    warnings.filterwarnings(
-        "ignore",
-        message=r"arr\.to_struct\(\)",
-        category=DeprecationWarning,
-    )
-    warnings.filterwarnings(
-        "ignore",
-        message=r"list\.to_struct\(\)",
         category=DeprecationWarning,
     )
 


### PR DESCRIPTION
Fix doctests in CI.

Blanket ignore all deprecation warnings. In the 2.0 branch this ignore can be removed.
