### PR TITLE
fix: Do not rewrite `sort().reverse()` to `sort(descending=True)` when `maintain_order=True`

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/simplify_expr/simplify_functions.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_expr/simplify_functions.rs
@@ -82,7 +82,7 @@ pub(super) fn optimize_functions(
         IRFunctionExpr::Reverse => {
             let input = expr_arena.get(input[0].node());
             match input {
-                AExpr::Sort { expr, options } => {
+                AExpr::Sort { expr, options } if !options.maintain_order => {
                     let mut options = *options;
                     options.descending = !options.descending;
                     options.nulls_last = !options.nulls_last;
@@ -95,7 +95,7 @@ pub(super) fn optimize_functions(
                     expr,
                     by,
                     sort_options,
-                } => {
+                } if !sort_options.maintain_order => {
                     let mut sort_options = sort_options.clone();
                     sort_options.descending = sort_options.descending.iter().map(|x| !*x).collect();
                     sort_options.nulls_last = sort_options.nulls_last.iter().map(|x| !*x).collect();

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -1382,3 +1382,18 @@ def test_sort_by_reverse_preserves_null_placement_27917(
         df.lazy().select(expr).collect(),
         df.lazy().select(expr).collect(optimizations=pl.QueryOptFlags.none()),
     )
+
+
+@pytest.mark.parametrize("descending", [False, True])
+def test_sort_by_reverse_preserves_tie_order_with_maintain_order_28386(
+    descending: bool,
+) -> None:
+    df = pl.DataFrame({"k": [1, 1, 1], "v": [10, 20, 30]})
+    expr = (
+        pl.col("v").sort_by("k", descending=descending, maintain_order=True).reverse()
+    )
+
+    assert_frame_equal(
+        df.lazy().select(expr).collect(),
+        df.lazy().select(expr).collect(optimizations=pl.QueryOptFlags.none()),
+    )


### PR DESCRIPTION
This is an incorrect optimization if `maintain_order=True` and we have equivalent keys. The former is a no-op sort (all keys are the same) followed by a reverse, whereas the latter is just a no-op in this case.

Resolves https://github.com/pola-rs/polars/issues/28386.