### PR TITLE
build(rust): Propagate `bigidx` to `polars-plan` indirectly included via `pyo3-polars`

### DIFF
--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -142,6 +142,9 @@ jobs:
       - name: Run cargo hack
         run: cargo hack check -p polars --each-feature --no-dev-deps && cargo check -p polars-stream
 
+      - name: Test pyo3-polars and bigidx
+        run: cargo check -p pyo3-polars --no-default-features --features pyo3-polars/derive,polars/bigidx
+
   check-dsl-schema:
     runs-on: ubuntu-latest
     steps:

--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -586,6 +586,8 @@ allow_unused = [
   "polars-time?/allow_unused",
 ]
 
+include-polars-plan = ["dep:polars-plan"]
+
 [package.metadata.docs.rs]
 # all-features = true
 features = ["docs-selection"]

--- a/pyo3-polars/pyo3-polars-derive/Cargo.toml
+++ b/pyo3-polars/pyo3-polars-derive/Cargo.toml
@@ -29,9 +29,3 @@ syn = { version = "2", features = ["full", "extra-traits"] }
 polars-python = { workspace = true, features = ["full"] }
 pyo3-polars = { workspace = true, features = ["derive"] }
 trybuild = { version = "1", features = ["diff"] }
-
-[features]
-bigidx = [
-  "polars-core/bigidx",
-  "polars-plan/bigidx",
-]

--- a/pyo3-polars/pyo3-polars-derive/Cargo.toml
+++ b/pyo3-polars/pyo3-polars-derive/Cargo.toml
@@ -29,3 +29,9 @@ syn = { version = "2", features = ["full", "extra-traits"] }
 polars-python = { workspace = true, features = ["full"] }
 pyo3-polars = { workspace = true, features = ["derive"] }
 trybuild = { version = "1", features = ["diff"] }
+
+[features]
+bigidx = [
+  "polars-core/bigidx",
+  "polars-plan/bigidx",
+]

--- a/pyo3-polars/pyo3-polars/Cargo.toml
+++ b/pyo3-polars/pyo3-polars/Cargo.toml
@@ -29,7 +29,7 @@ thiserror = "2"
 
 [features]
 # Polars python is needed because all variants need to be activated of the DSL.
-lazy = ["polars/serde-lazy", "polars/lazy", "polars-plan", "polars-lazy/serde", "polars-utils", "polars-lazy/python"]
+lazy = ["polars/serde-lazy", "polars/lazy", "polars-plan", "polars/include-polars-plan", "polars-lazy/serde", "polars-utils", "polars-lazy/python"]
 derive = ["pyo3-polars-derive", "polars-plan/python", "polars/include-polars-plan", "serde-pickle", "serde"]
 dtype-full = ["polars/dtype-full", "dtype-decimal", "dtype-array", "dtype-struct", "dtype-categorical"]
 object = ["polars/object"]

--- a/pyo3-polars/pyo3-polars/Cargo.toml
+++ b/pyo3-polars/pyo3-polars/Cargo.toml
@@ -29,6 +29,14 @@ thiserror = "2"
 
 [features]
 # Polars python is needed because all variants need to be activated of the DSL.
+bigidx = [
+  "polars/bigidx",
+  "polars-core/bigidx",
+  "polars-lazy?/bigidx",
+  "polars-plan?/bigidx",
+  "polars-utils?/bigidx",
+  "pyo3-polars-derive?/bigidx",
+]
 lazy = ["polars/serde-lazy", "polars/lazy", "polars-plan", "polars-lazy/serde", "polars-utils", "polars-lazy/python"]
 derive = ["pyo3-polars-derive", "polars-plan/python", "serde-pickle", "serde"]
 dtype-full = ["polars/dtype-full", "dtype-decimal", "dtype-array", "dtype-struct", "dtype-categorical"]

--- a/pyo3-polars/pyo3-polars/Cargo.toml
+++ b/pyo3-polars/pyo3-polars/Cargo.toml
@@ -29,16 +29,8 @@ thiserror = "2"
 
 [features]
 # Polars python is needed because all variants need to be activated of the DSL.
-bigidx = [
-  "polars/bigidx",
-  "polars-core/bigidx",
-  "polars-lazy?/bigidx",
-  "polars-plan?/bigidx",
-  "polars-utils?/bigidx",
-  "pyo3-polars-derive?/bigidx",
-]
 lazy = ["polars/serde-lazy", "polars/lazy", "polars-plan", "polars-lazy/serde", "polars-utils", "polars-lazy/python"]
-derive = ["pyo3-polars-derive", "polars-plan/python", "serde-pickle", "serde"]
+derive = ["pyo3-polars-derive", "polars-plan/python", "polars/include-polars-plan", "serde-pickle", "serde"]
 dtype-full = ["polars/dtype-full", "dtype-decimal", "dtype-array", "dtype-struct", "dtype-categorical"]
 object = ["polars/object"]
 dtype-decimal = ["polars/dtype-decimal"]

--- a/pyo3-polars/pyo3-polars/Cargo.toml
+++ b/pyo3-polars/pyo3-polars/Cargo.toml
@@ -29,7 +29,15 @@ thiserror = "2"
 
 [features]
 # Polars python is needed because all variants need to be activated of the DSL.
-lazy = ["polars/serde-lazy", "polars/lazy", "polars-plan", "polars/include-polars-plan", "polars-lazy/serde", "polars-utils", "polars-lazy/python"]
+lazy = [
+  "polars/serde-lazy",
+  "polars/lazy",
+  "polars-plan",
+  "polars/include-polars-plan",
+  "polars-lazy/serde",
+  "polars-utils",
+  "polars-lazy/python",
+]
 derive = ["pyo3-polars-derive", "polars-plan/python", "polars/include-polars-plan", "serde-pickle", "serde"]
 dtype-full = ["polars/dtype-full", "dtype-decimal", "dtype-array", "dtype-struct", "dtype-categorical"]
 object = ["polars/object"]


### PR DESCRIPTION
`cargo check -p pyo3-polars --no-default-features --features pyo3-polars/derive,polars/bigidx --locked`

Force `polars` to include the `polars-plan` dependency when `pyo3-polars` wants it, combined with https://github.com/pola-rs/polars/pull/28396 this will propagate `bigidx` (and hopefully other feature flags as well).
