### PR TITLE
fix(rust): Insert missing coercions from `Unknown(_)` in list/array arithmetic

### DIFF
--- a/crates/polars-plan/src/plans/conversion/type_coercion/binary.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/binary.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "dtype-categorical")]
 use polars_utils::matches_any_order;
 
+use polars_core::series::arithmetic::NumericListOp;
+
 use super::*;
 
 macro_rules! unpack {
@@ -94,6 +96,59 @@ fn process_struct_numeric_arithmetic(
         },
         _ => unreachable!(),
     }
+}
+
+fn process_list_numeric_arithmetic(
+    type_left: DataType,
+    type_right: DataType,
+    node_left: Node,
+    node_right: Node,
+    op: Operator,
+    expr_arena: &mut Arena<AExpr>,
+) -> PolarsResult<Option<AExpr>> {
+    let list_op = match op {
+        Operator::Plus => NumericListOp::add(),
+        Operator::Minus => NumericListOp::sub(),
+        Operator::Multiply => NumericListOp::mul(),
+        Operator::TrueDivide | Operator::RustDivide => NumericListOp::div(),
+        Operator::FloorDivide => NumericListOp::floor_div(),
+        Operator::Modulus => NumericListOp::rem(),
+        _ => return Ok(None),
+    };
+
+    let Ok(leaf_st) =
+        list_op.try_get_leaf_supertype(type_left.leaf_dtype(), type_right.leaf_dtype())
+    else {
+        return Ok(None);
+    };
+    if leaf_st.is_unknown() {
+        return Ok(None);
+    }
+
+    let cast_node = |expr_arena: &mut Arena<AExpr>, node: Node, dtype: &DataType| {
+        if dtype.leaf_dtype() == &leaf_st {
+            node
+        } else {
+            expr_arena.add(AExpr::Cast {
+                expr: node,
+                dtype: dtype.cast_leaf(leaf_st.clone()),
+                options: CastOptions::NonStrict,
+            })
+        }
+    };
+
+    let new_node_left = cast_node(expr_arena, node_left, &type_left);
+    let new_node_right = cast_node(expr_arena, node_right, &type_right);
+
+    if new_node_left == node_left && new_node_right == node_right {
+        return Ok(None);
+    }
+
+    Ok(Some(AExpr::BinaryExpr {
+        left: new_node_left,
+        op,
+        right: new_node_right,
+    }))
 }
 
 #[cfg(any(
@@ -336,6 +391,17 @@ pub(super) fn process_binary(
         )
     {
         return process_struct_numeric_arithmetic(
+            type_left, type_right, node_left, node_right, op, expr_arena,
+        );
+    }
+
+    if op.is_arithmetic()
+        && (type_left.is_list()
+            || type_right.is_list()
+            || type_left.is_array()
+            || type_right.is_array())
+    {
+        return process_list_numeric_arithmetic(
             type_left, type_right, node_left, node_right, op, expr_arena,
         );
     }

--- a/crates/polars-plan/src/plans/conversion/type_coercion/binary.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/binary.rs
@@ -124,20 +124,20 @@ fn process_list_numeric_arithmetic(
         return Ok(None);
     }
 
-    let cast_node = |expr_arena: &mut Arena<AExpr>, node: Node, dtype: &DataType| {
-        if dtype.leaf_dtype() == &leaf_st {
-            node
-        } else {
+    let cast_unknown_leaf = |expr_arena: &mut Arena<AExpr>, node: Node, dtype: &DataType| {
+        if dtype.leaf_dtype().is_unknown() {
             expr_arena.add(AExpr::Cast {
                 expr: node,
                 dtype: dtype.cast_leaf(leaf_st.clone()),
                 options: CastOptions::NonStrict,
             })
+        } else {
+            node
         }
     };
 
-    let new_node_left = cast_node(expr_arena, node_left, &type_left);
-    let new_node_right = cast_node(expr_arena, node_right, &type_right);
+    let new_node_left = cast_unknown_leaf(expr_arena, node_left, &type_left);
+    let new_node_right = cast_unknown_leaf(expr_arena, node_right, &type_right);
 
     if new_node_left == node_left && new_node_right == node_right {
         return Ok(None);

--- a/crates/polars-plan/src/plans/conversion/type_coercion/binary.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/binary.rs
@@ -1,7 +1,6 @@
+use polars_core::series::arithmetic::NumericListOp;
 #[cfg(feature = "dtype-categorical")]
 use polars_utils::matches_any_order;
-
-use polars_core::series::arithmetic::NumericListOp;
 
 use super::*;
 

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -1576,7 +1576,7 @@ def test_csee_height_mismatch_28364() -> None:
     q1 = df.with_columns(z=pl.coalesce(pl.col.x.min(), pl.col.x.min()))
     out = df.join(q1, on="x").collect()
     expected = pl.DataFrame({"x": [1, 2], "z": [1, 1]})
-    assert_frame_equal(out, expected)
+    assert_frame_equal(out, expected, check_row_order=False)
 
 
 def test_cspe_with_non_pushable_filters_19479() -> None:

--- a/py-polars/tests/unit/operations/arithmetic/test_array.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_array.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import operator
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -304,6 +305,34 @@ def test_array_truediv_schema(
     df = pl.DataFrame({"lhs": [[None, 10]], "rhs": 2}, schema=schema)
     result = df.lazy().select(pl.col("lhs").truediv("rhs")).collect_schema()["lhs"]
     assert result == expected_dtype
+
+
+@pytest.mark.parametrize(
+    ("lhs_dtype", "literal", "arith_op", "expected_dtype"),
+    [
+        # A dynamically-typed literal (bare Python `1`) must not widen the result
+        # beyond what the array's own leaf dtype already supports.
+        (pl.Array(pl.Float32, 1), 1, operator.add, pl.Array(pl.Float32, 1)),
+        (pl.Array(pl.Float32, 1), 1, operator.sub, pl.Array(pl.Float32, 1)),
+        (pl.Array(pl.Float32, 1), 2, operator.mul, pl.Array(pl.Float32, 1)),
+        (pl.Array(pl.Int8, 1), 1, operator.add, pl.Array(pl.Int8, 1)),
+        (pl.Array(pl.Int64, 1), 1, operator.mod, pl.Array(pl.Int64, 1)),
+        (pl.Array(pl.Int64, 1), 2, operator.floordiv, pl.Array(pl.Int64, 1)),
+        # A dynamic float literal should still upcast an integer array, as normal.
+        (pl.Array(pl.Int32, 1), 1.5, operator.add, pl.Array(pl.Float64, 1)),
+    ],
+)
+def test_array_arithmetic_literal_dtype(
+    lhs_dtype: PolarsDataType,
+    literal: int | float,
+    arith_op: Callable[[Any, Any], Any],
+    expected_dtype: PolarsDataType,
+) -> None:
+    """The declared schema and the actually-produced dtype must agree (#19671)."""
+    df = pl.DataFrame({"a": [[0]]}, schema={"a": lhs_dtype})
+    q = df.lazy().select(arith_op(pl.col("a"), literal))
+    assert q.collect_schema()["a"] == expected_dtype
+    assert q.collect().schema["a"] == expected_dtype
 
 
 def test_array_literal_broadcast() -> None:

--- a/py-polars/tests/unit/operations/arithmetic/test_array.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_array.py
@@ -318,6 +318,8 @@ def test_array_truediv_schema(
         (pl.Array(pl.Int8, 1), 1, operator.add, pl.Array(pl.Int8, 1)),
         (pl.Array(pl.Int64, 1), 1, operator.mod, pl.Array(pl.Int64, 1)),
         (pl.Array(pl.Int64, 1), 2, operator.floordiv, pl.Array(pl.Int64, 1)),
+        (pl.Array(pl.Float32, 1), 1, operator.truediv, pl.Array(pl.Float32, 1)),
+        (pl.Array(pl.Int64, 1), 2, operator.truediv, pl.Array(pl.Float64, 1)),
         # A dynamic float literal should still upcast an integer array, as normal.
         (pl.Array(pl.Int32, 1), 1.5, operator.add, pl.Array(pl.Float64, 1)),
     ],

--- a/py-polars/tests/unit/operations/arithmetic/test_list.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_list.py
@@ -312,6 +312,34 @@ def test_list_truediv_schema(
     assert result == expected_dtype
 
 
+@pytest.mark.parametrize(
+    ("lhs_dtype", "literal", "arith_op", "expected_dtype"),
+    [
+        # A dynamically-typed literal (bare Python `1`) must not widen the result
+        # beyond what the list's own leaf dtype already supports.
+        (pl.List(pl.Float32), 1, operator.add, pl.List(pl.Float32)),
+        (pl.List(pl.Float32), 1, operator.sub, pl.List(pl.Float32)),
+        (pl.List(pl.Float32), 2, operator.mul, pl.List(pl.Float32)),
+        (pl.List(pl.Int8), 1, operator.add, pl.List(pl.Int8)),
+        (pl.List(pl.Int64), 1, operator.mod, pl.List(pl.Int64)),
+        (pl.List(pl.Int64), 2, operator.floordiv, pl.List(pl.Int64)),
+        # A dynamic float literal should still upcast an integer list, as normal.
+        (pl.List(pl.Int32), 1.5, operator.add, pl.List(pl.Float64)),
+    ],
+)
+def test_list_arithmetic_literal_dtype(
+    lhs_dtype: PolarsDataType,
+    literal: int | float,
+    arith_op: Callable[[Any, Any], Any],
+    expected_dtype: PolarsDataType,
+) -> None:
+    """The declared schema and the actually-produced dtype must agree (#19671)."""
+    df = pl.DataFrame({"a": [[0]]}, schema={"a": lhs_dtype})
+    q = df.lazy().select(arith_op(pl.col("a"), literal))
+    assert q.collect_schema()["a"] == expected_dtype
+    assert q.collect().schema["a"] == expected_dtype
+
+
 @pytest.mark.parametrize("exec_op", EXEC_OP_COMBINATIONS)
 def test_list_add_supertype(
     exec_op: Callable[[pl.Series, pl.Series, Any], pl.Series],

--- a/py-polars/tests/unit/operations/arithmetic/test_list.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_list.py
@@ -323,6 +323,8 @@ def test_list_truediv_schema(
         (pl.List(pl.Int8), 1, operator.add, pl.List(pl.Int8)),
         (pl.List(pl.Int64), 1, operator.mod, pl.List(pl.Int64)),
         (pl.List(pl.Int64), 2, operator.floordiv, pl.List(pl.Int64)),
+        (pl.List(pl.Float32), 1, operator.truediv, pl.List(pl.Float32)),
+        (pl.List(pl.Int64), 2, operator.truediv, pl.List(pl.Float64)),
         # A dynamic float literal should still upcast an integer list, as normal.
         (pl.List(pl.Int32), 1.5, operator.add, pl.List(pl.Float64)),
     ],

--- a/py-polars/tests/unit/operations/test_top_k.py
+++ b/py-polars/tests/unit/operations/test_top_k.py
@@ -226,17 +226,23 @@ def test_top_k() -> None:
 
     assert_frame_equal(
         df2.select(
-            pl.col("a", "b", "c").top_k_by(["c", "a"], 2).name.suffix("_top_by_ca"),
-            pl.col("a", "b", "c").top_k_by(["c", "b"], 2).name.suffix("_top_by_cb"),
+            pl.col("a", "b", "c")
+            .top_k_by(["c", "a"], 2)
+            .name.suffix("_top_by_ca")
+            .sort(),
+            pl.col("a", "b", "c")
+            .top_k_by(["c", "b"], 2)
+            .name.suffix("_top_by_cb")
+            .sort(),
         ),
         pl.DataFrame(
             {
                 "a_top_by_ca": [2, 6],
-                "b_top_by_ca": [11, 7],
-                "c_top_by_ca": ["Orange", "Banana"],
+                "b_top_by_ca": [7, 11],
+                "c_top_by_ca": ["Banana", "Orange"],
                 "a_top_by_cb": [2, 5],
-                "b_top_by_cb": [11, 8],
-                "c_top_by_cb": ["Orange", "Banana"],
+                "b_top_by_cb": [8, 11],
+                "c_top_by_cb": ["Banana", "Orange"],
             }
         ),
         check_row_order=False,


### PR DESCRIPTION
Mirror the logic from https://github.com/pola-rs/polars/blob/af17ec624add3c3e0e88654185d060e1fa38a6ac/crates/polars-plan/src/plans/aexpr/schema.rs#L491 (execution/physical time) in order to insert the correct type coercion at logical planning/optimization time. Ideally these two should be unified, but doing that in this PR is a more invasive change. I also discussed with @kdn36, seems like this part of type inference is due for an overhaul.

The cause of the bug is that at planning time we did not assign a type to `Unknown(Integer(_))` when it interacted with a list/array of a known type. This meant that we only assigned this type in 
https://github.com/pola-rs/polars/blob/7b67ac4ecc224fee5d9da21ba0cb026be6b5df79/crates/polars-core/src/series/any_value.rs#L41
This caused the type to be deduced as `Int32`, independently of the binary operation that acted on the literal.

Fixes https://github.com/pola-rs/polars/issues/19671