### PR TITLE
fix: Avoid panic when union slice skips all rows

### DIFF
--- a/crates/polars-mem-engine/src/executors/union.rs
+++ b/crates/polars-mem-engine/src/executors/union.rs
@@ -57,7 +57,7 @@ impl Executor for UnionExec {
                 if slice_offset > height {
                     slice_offset -= height;
                     // Keep the union schema when the offset skips every input.
-                    if idx + 1 == n_inputs {
+                    if dfs.is_empty() && idx + 1 == n_inputs {
                         dfs.push(df.clear());
                     }
                 }

--- a/crates/polars-mem-engine/src/executors/union.rs
+++ b/crates/polars-mem-engine/src/executors/union.rs
@@ -19,6 +19,7 @@ impl Executor for UnionExec {
             }
         }
         let mut inputs = std::mem::take(&mut self.inputs);
+        let n_inputs = inputs.len();
 
         let sliced_path = if let Some((offset, _)) = self.options.slice {
             offset >= 0
@@ -55,6 +56,10 @@ impl Executor for UnionExec {
                 // TODO!: don't read the file yet!
                 if slice_offset > height {
                     slice_offset -= height;
+                    // Keep the union schema when the offset skips every input.
+                    if idx + 1 == n_inputs {
+                        dfs.push(df.clear());
+                    }
                 }
                 // applying the slice
                 // continue iteration

--- a/py-polars/tests/unit/lazyframe/test_optimizations.py
+++ b/py-polars/tests/unit/lazyframe/test_optimizations.py
@@ -699,6 +699,13 @@ def test_slice_pushdown_with_cache_arena_take_panic_26905() -> None:
     )
 
 
+def test_slice_pushdown_past_empty_union_28408() -> None:
+    lf = pl.LazyFrame({"x": [1]})
+    q = pl.concat([lf, lf]).filter(pl.col("x") == 0).slice(1, 1)
+
+    assert_frame_equal(q.collect(), pl.DataFrame(schema={"x": pl.Int64}))
+
+
 def test_slice_pushdown_shared_join_input_28127() -> None:
     lf = pl.LazyFrame({"a": ["x"]}).filter(pl.lit(True)).select("a").slice(0, 1)
     q = lf.join(lf, on="a", how="inner")


### PR DESCRIPTION
## Summary
- retain an empty frame when a pushed-down positive slice skips every Union input
- preserve the Union schema so concatenation returns an empty frame instead of panicking
- add a regression test for the optimized in-memory query from #28408

## Validation
- `PYTHONPATH=py-polars/src .venv/bin/pytest py-polars/tests/unit/lazyframe/test_optimizations.py::test_slice_pushdown_past_empty_union_28408 -q`
- `.venv/bin/ruff check py-polars/tests/unit/lazyframe/test_optimizations.py`
- `.venv/bin/ruff format --check py-polars/tests/unit/lazyframe/test_optimizations.py`
- `cargo fmt --all -- --check`
- rebuilt the Python runtime with Maturin and reran the original reproducer

Fixes #28408