### PR TITLE
fix(rust): Don't panic in `rolling_*_by` when `by` contains nulls

### DIFF
--- a/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
@@ -92,6 +92,10 @@ where
         ca.len() == by.len(),
         InvalidOperation: "`by` column in `rolling_*_by` must be the same length as values column"
     );
+    polars_ensure!(
+        by.null_count() == 0,
+        InvalidOperation: "`by` column in `rolling_*_by` must not contain nulls"
+    );
     ensure_duration_matches_dtype(options.window_size, by.dtype(), "window_size")?;
     polars_ensure!(
         !options.window_size.is_zero() && !options.window_size.negative,

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -2449,3 +2449,14 @@ def test_rolling_rank_min_samples_28102() -> None:
     assert_series_equal(
         out, pl.Series("a", [None, None, None, 3, 3], dtype=pl.get_index_type())
     )
+
+
+@pytest.mark.parametrize("op", ["rolling_mean_by", "rolling_sum_by"])
+def test_rolling_by_with_nulls_raises_27366(op: str) -> None:
+    s = pl.Series([1.0, 2.0, 3.0])
+    null_by = pl.Series([1, None, 3], dtype=pl.Int64)
+    with pytest.raises(InvalidOperationError, match="must not contain nulls"):
+        getattr(s, op)(null_by, window_size="2i")
+
+    ok_by = pl.Series([1, 2, 3], dtype=pl.Int64)
+    assert getattr(s, op)(ok_by, window_size="2i").len() == 3

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -2516,3 +2516,14 @@ def test_min_periods_removed() -> None:
 
     with pytest.raises(ArgumentRemovedError, match=re.escape(msg)):
         pl.rolling_corr("a", "b", window_size=2, min_periods=1)  # type: ignore[call-arg]
+
+
+@pytest.mark.parametrize("op", ["rolling_mean_by", "rolling_sum_by"])
+def test_rolling_by_with_nulls_raises_27366(op: str) -> None:
+    s = pl.Series([1.0, 2.0, 3.0])
+    null_by = pl.Series([1, None, 3], dtype=pl.Int64)
+    with pytest.raises(InvalidOperationError, match="must not contain nulls"):
+        getattr(s, op)(null_by, window_size="2i")
+
+    ok_by = pl.Series([1, 2, 3], dtype=pl.Int64)
+    assert getattr(s, op)(ok_by, window_size="2i").len() == 3


### PR DESCRIPTION
Closes #27366.

A `by` column containing nulls reached `cont_slice().unwrap()` in the rolling-by kernel dispatch and panicked with `chunked array is not contiguous`, unwinding the rayon worker instead of returning an error. This rejects a null-containing `by` up front with a clear `InvalidOperationError`, right next to the existing length / window-size checks in `rolling_agg_by`, so every `rolling_*_by` variant is covered (they all route through it, `std_by` via `var_by`).

Added a parametrized test (`rolling_mean_by`, `rolling_sum_by`) that asserts the error is raised on a null `by` and that a null-free `by` still works.

---

Claude Code was used for implementation assistance (the check in `crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs` and the test in `py-polars/tests/unit/operations/rolling/test_rolling.py`). I have reviewed all changes myself and believe they are relevant and correct, and verified them locally with a full `py-polars` rebuild and the rolling test suite.