### PR TITLE
fix: replace_strict dict order affecting inferred dtype

### DIFF
--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -11938,7 +11938,15 @@ Consider using {self}.implode() instead"""
             old = list(old.keys())
 
         old_pyexpr = parse_into_expression(old, str_as_lit=True)  # type: ignore[arg-type]
-        new_pyexpr = parse_into_expression(new, str_as_lit=True)  # type: ignore[arg-type]
+        new_pyexpr = None
+        if return_dtype is not None:
+            try:
+                new_series = pl.Series(new, dtype=return_dtype)
+                new_pyexpr = parse_into_expression(new_series, str_as_lit=True)
+            except TypeError:
+                pass
+        if new_pyexpr is None:
+            new_pyexpr = parse_into_expression(new, str_as_lit=True)
 
         dtype_pyexpr: plr.PyDataTypeExpr | None = None
         if return_dtype is not None:

--- a/py-polars/tests/unit/operations/test_replace_strict.py
+++ b/py-polars/tests/unit/operations/test_replace_strict.py
@@ -434,3 +434,24 @@ def test_replace_strict_str_enum_27060() -> None:
     enum = pl.Enum(["A", "B"])
     out = pl.Series(["A", "B"]).cast(enum).replace_strict({"A": "X", "B": "Y"})
     assert_series_equal(out, pl.Series(["X", "Y"]))
+
+
+def test_replace_strict_dict_order_28422() -> None:
+    df = pl.DataFrame({"color": ["Green", "Red", "Yellow"]})
+
+    result_a = df.select(
+        pl.col("color").replace_strict(
+            {"Red": 0.5, "Green": 1, "Yellow": 0},
+            return_dtype=pl.Float64,
+        )
+    )["color"]
+    result_b = df.select(
+        pl.col("color").replace_strict(
+            {"Green": 1, "Red": 0.5, "Yellow": 0},
+            return_dtype=pl.Float64,
+        )
+    )["color"]
+
+    expected = pl.Series("color", [1.0, 0.5, 0.0], dtype=pl.Float64)
+    assert_series_equal(result_a, expected)
+    assert_series_equal(result_b, expected)


### PR DESCRIPTION
Fixes #28422
replace_strict builds new from a dict's values as a plain Python list, then parses it into an expression without ever passing return_dtype along. Since Series construction defaults to strict=True, the output dtype ends up inferred from just the first value in that list. Whether the call succeeds or fails depends on which key happens to come first in the dict, even when return_dtype is explicitly given. {"Green": 1, "Red": 0.5, "Yellow": 0} fails because 1 locks inference to Int64, but {"Red": 0.5, "Green": 1, "Yellow": 0} works because 0.5 locks it to Float64. Same mapping, same explicit return_dtype=pl.Float64, different outcome.

Fix is to build new as a properly-typed Series up front whenever return_dtype is a concrete dtype, so there's nothing left to infer. Falls back to the old behavior when return_dtype is None or a DataTypeExpr, since there's no concrete dtype available to build against in those cases.

Added a test covering both orderings from the issue. test_replace_strict.py passes locally (41/41). I ran into some pre-existing, unrelated failures in the wider suite that also show up on unmodified main, so they aren't from this change.

I used AI (Claude Sonnet 5) to help set up my environment and trace the bug through the call path and to help draft the fix and test. I've reviewed all the changes myself and believe they're correct.".

