### PR TITLE
fix: Avoid IEJoin rewrite for Categorical comparisons

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join/predicate_pruning.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join/predicate_pruning.rs
@@ -35,16 +35,21 @@ pub fn take_iejoin_compatible_filters(
                     None,
                 )?;
 
-                let is_supported_type = |node: Node| -> PolarsResult<bool> {
-                    let field = expr_arena
-                        .get(node)
-                        .to_field(&ToFieldContext::new(expr_arena, output_schema))?;
-                    let dtype = field.dtype();
-                    let phys = dtype.to_physical();
-                    Ok(!dtype.is_nested() && phys.is_primitive_numeric())
-                };
+                let is_supported_type =
+                    |node: Node| -> PolarsResult<bool> {
+                        let field = expr_arena
+                            .get(node)
+                            .to_field(&ToFieldContext::new(expr_arena, output_schema))?;
+                        let dtype = field.dtype();
+                        let phys = dtype.to_physical();
+                        Ok(!dtype.is_nested()
+                            && phys.is_primitive_numeric()
+                            && !dtype.is_categorical())
+                    };
 
-                // IEJoin only supports numeric.
+                // IEJoin only supports physical representations whose ordering matches the
+                // logical dtype. Categorical codes are in first-appearance order, whereas
+                // Categorical comparisons are lexical.
                 if !is_supported_type(*left)? || !is_supported_type(*right)? {
                     return Ok(None);
                 }

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -3240,6 +3240,37 @@ def test_join_filter_pushdown_cross_join() -> None:
     assert_frame_equal(q.collect(optimizations=pl.QueryOptFlags.none()), expect)
 
 
+def test_join_filter_pushdown_categorical_28426() -> None:
+    categories = pl.Categories("test_join_filter_pushdown_categorical_28426")
+    dtype = pl.Categorical(categories)
+
+    left = pl.LazyFrame(
+        {
+            "left_id": [1, 2],
+            "left_category": pl.Series(["cc", "aa"], dtype=dtype),
+        }
+    )
+    right = pl.LazyFrame(
+        {
+            "right_id": [101, 102],
+            "right_category": pl.Series(["bb", "cc"], dtype=dtype),
+        }
+    )
+
+    q = (
+        left.join(right, how="cross")
+        .filter(pl.col("left_category") < pl.col("right_category"))
+        .select("left_id", "right_id")
+        .sort("left_id", "right_id")
+    )
+
+    expected = pl.DataFrame({"left_id": [2, 2], "right_id": [101, 102]})
+
+    assert "IEJOIN JOIN" not in q.explain()
+    assert_frame_equal(q.collect(), expected)
+    assert_frame_equal(q.collect(optimizations=pl.QueryOptFlags.none()), expected)
+
+
 def test_join_filter_pushdown_iejoin() -> None:
     lhs = pl.LazyFrame(
         {"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, 4, None], "c": ["a", "b", "c", "d", "e"]}


### PR DESCRIPTION
## Summary

- exclude `Categorical` operands from the cross-join-to-IEJoin rewrite because their physical codes use first-appearance order while comparisons are lexical
- preserve IEJoin optimization for order-compatible physical numeric representations, including Enum and temporal types
- add a regression test covering optimized and unoptimized results

Closes #28426.

## Testing
<img width="3200" height="1920" alt="image" src="https://github.com/user-attachments/assets/d86df0c2-cd49-4223-b7d3-2f8c535e9c49" />

- Local `make test`: 18,100 passed, 89 skipped, 9 xfailed (screenshot attached).
- Targeted eager `join_where` reproduction: both expected rows returned.
- Formatting, linting, typo, and targeted `polars-plan` clippy checks pass.


## AI assistance

Codex generated the Rust guard and regression test. The complete diff was reviewed.