### PR TITLE
fix: Block predicate pushdown past overwritten window keys

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
@@ -325,7 +325,7 @@ pub fn pushdown_eligibility(
     // Note: has_window is constant.
     let can_use_column = |col: &str| {
         if has_window {
-            common_window_inputs.contains(col)
+            common_window_inputs.contains(col) && !modified_projection_columns.contains(col)
         } else {
             !modified_projection_columns.contains(col)
         }

--- a/py-polars/tests/unit/lazyframe/test_predicates.py
+++ b/py-polars/tests/unit/lazyframe/test_predicates.py
@@ -446,6 +446,37 @@ def test_predicate_pushdown_with_window_projections_12637() -> None:
     )
 
 
+def test_predicate_pushdown_with_overwritten_window_key_28428() -> None:
+    lf = pl.LazyFrame(
+        {
+            "group": ["a", "a", "b", "b"],
+            "value": [10, 1, 100, -20],
+            "row_id": [0, 1, 2, 3],
+        }
+    )
+
+    q = (
+        lf.with_columns(
+            pl.col("value").sum().over("group").alias("group_sum"),
+            pl.lit("x").alias("group"),
+        )
+        .filter(pl.col("group") == "x")
+        .select("row_id", "group", "value", "group_sum")
+    )
+
+    expected = pl.DataFrame(
+        {
+            "row_id": [0, 1, 2, 3],
+            "group": ["x", "x", "x", "x"],
+            "value": [10, 1, 100, -20],
+            "group_sum": [11, 11, 80, 80],
+        }
+    )
+
+    assert_frame_equal(q.collect(), expected)
+    assert_frame_equal(q.collect(optimizations=pl.QueryOptFlags.none()), expected)
+
+
 def test_predicate_reduction() -> None:
     # ensure we get clean reduction without casts
     lf = pl.LazyFrame({"a": [1], "b": [2]})


### PR DESCRIPTION
## Summary

- require predicate columns to remain unmodified when pushing filters through window projections
- preserve predicate pushdown for unchanged common window partition keys
- add a regression test for an overwritten partition key returning incorrect rows

Closes #28428.

## Testing

- Predicate tests: 108 passed
- Rust and Python formatting/lint checks passed
- Clippy passed with all features

## AI assistance

Codex generated the Rust guard and regression test. The complete diff was reviewed.