### PR TITLE
test: Fix flaky ordering expectation in top_k_by

### DIFF
--- a/py-polars/tests/unit/operations/test_top_k.py
+++ b/py-polars/tests/unit/operations/test_top_k.py
@@ -226,17 +226,17 @@ def test_top_k() -> None:
 
     assert_frame_equal(
         df2.select(
-            pl.col("a", "b", "c").top_k_by(["c", "a"], 2).name.suffix("_top_by_ca"),
-            pl.col("a", "b", "c").top_k_by(["c", "b"], 2).name.suffix("_top_by_cb"),
+            pl.col("a", "b", "c").top_k_by(["c", "a"], 2).name.suffix("_top_by_ca").sort(),
+            pl.col("a", "b", "c").top_k_by(["c", "b"], 2).name.suffix("_top_by_cb").sort(),
         ),
         pl.DataFrame(
             {
                 "a_top_by_ca": [2, 6],
-                "b_top_by_ca": [11, 7],
-                "c_top_by_ca": ["Orange", "Banana"],
+                "b_top_by_ca": [7, 11],
+                "c_top_by_ca": ["Banana", "Orange"],
                 "a_top_by_cb": [2, 5],
-                "b_top_by_cb": [11, 8],
-                "c_top_by_cb": ["Orange", "Banana"],
+                "b_top_by_cb": [8, 11],
+                "c_top_by_cb": ["Banana", "Orange"],
             }
         ),
         check_row_order=False,

--- a/py-polars/tests/unit/operations/test_top_k.py
+++ b/py-polars/tests/unit/operations/test_top_k.py
@@ -226,8 +226,14 @@ def test_top_k() -> None:
 
     assert_frame_equal(
         df2.select(
-            pl.col("a", "b", "c").top_k_by(["c", "a"], 2).name.suffix("_top_by_ca").sort(),
-            pl.col("a", "b", "c").top_k_by(["c", "b"], 2).name.suffix("_top_by_cb").sort(),
+            pl.col("a", "b", "c")
+            .top_k_by(["c", "a"], 2)
+            .name.suffix("_top_by_ca")
+            .sort(),
+            pl.col("a", "b", "c")
+            .top_k_by(["c", "b"], 2)
+            .name.suffix("_top_by_cb")
+            .sort(),
         ),
         pl.DataFrame(
             {


### PR DESCRIPTION
The root cause of the failure is that there is no guarantee of the ordering of the `top_k` outputs. Therefore the `top_k` outputs in different columns are allowed to be ordered differently with respect to each other, meaning that `check_row_order=False` is still too strict of a check. 

The surrounding code already sorts the `top_k` outputs independently, so we just repeat the same pattern here.

This test was [failing](https://github.com/pola-rs/polars/actions/runs/29636129742/job/88058682094) on the coverage build in CI, leading to the mistaken [issue report](https://github.com/pola-rs/polars/issues/28405).