### PR TITLE
feat(python!): Automatically disable `raise_if_empty` when `has_header=False` and schema is specified for `read/scan_csv`

### DIFF
--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -88,7 +88,7 @@ def read_csv(
     row_index_offset: int = 0,
     sample_size: int = 1024,
     eol_char: str = "\n",
-    raise_if_empty: bool = True,
+    raise_if_empty: bool | None = None,
     truncate_ragged_lines: bool = False,
     decimal_comma: bool = False,
     glob: bool = True,
@@ -233,8 +233,14 @@ def read_csv(
         with windows line endings (``\r\n``), one can go with the default ``\n``. The
         extra ``\r`` will be removed when processed.
     raise_if_empty
-        When there is no data in the source, `NoDataError` is raised. If this parameter
-        is set to False, an empty DataFrame (with no columns) is returned instead.
+        Control behavior when scanning empty files:
+
+        * `True`: Raise a `NoDataError`.
+        * `False`: Return 0 rows.
+
+        This defaults to `False` if `has_header=False` and a `schema` is specified,
+        and `True` otherwise.
+        and `True` otherwise.
     truncate_ragged_lines
         Truncate lines that are longer than the schema.
     decimal_comma
@@ -313,6 +319,9 @@ def read_csv(
     ):
         msg = "`schema_overrides` should be of type list or dict"
         raise TypeError(msg)
+
+    if raise_if_empty is None:
+        raise_if_empty = schema is None or has_header
 
     if (
         use_pyarrow
@@ -788,7 +797,7 @@ def scan_csv(
     try_parse_dates: bool = False,
     eol_char: str = "\n",
     new_columns: Sequence[str] | None = None,
-    raise_if_empty: bool = True,
+    raise_if_empty: bool | None = None,
     truncate_ragged_lines: bool = False,
     decimal_comma: bool = False,
     glob: bool = True,
@@ -911,8 +920,13 @@ def scan_csv(
         scanning a headerless CSV file). If the given list is shorter than the width of
         the DataFrame the remaining columns will have their original name.
     raise_if_empty
-        When there is no data in the source, `NoDataError` is raised. If this parameter
-        is set to False, an empty LazyFrame (with no columns) is returned instead.
+        Control behavior when scanning empty files:
+
+        * `True`: Raise a `NoDataError`.
+        * `False`: Return 0 rows.
+
+        This defaults to `False` if `has_header=False` and a `schema` is specified,
+        and `True` otherwise.
     truncate_ragged_lines
         Truncate lines that are longer than the schema.
     decimal_comma
@@ -1046,6 +1060,9 @@ def scan_csv(
 
     _check_arg_is_1byte("separator", separator, can_be_empty=False)
     _check_arg_is_1byte("quote_char", quote_char, can_be_empty=True)
+
+    if raise_if_empty is None:
+        raise_if_empty = schema is None or has_header
 
     if isinstance(source, (str, Path)):
         source = normalize_filepath(source, check_not_directory=False)

--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -240,7 +240,6 @@ def read_csv(
 
         This defaults to `False` if `has_header=False` and a `schema` is specified,
         and `True` otherwise.
-        and `True` otherwise.
     truncate_ragged_lines
         Truncate lines that are longer than the schema.
     decimal_comma

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -8,7 +8,7 @@ import warnings
 import zlib
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal as D
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import numpy as np
 import pyarrow as pa
@@ -22,6 +22,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
 from tests.conftest import PlMonkeyPatch
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
     from typing import Any
 
@@ -3110,3 +3111,37 @@ def test_read_csv_mixed_i128_float_infers_float64_27654(chunk_override: None) ->
     csv_data = b"value\n12345678901234567890\n1.5"
     df = pl.read_csv(csv_data)
     assert df.schema["value"] == pl.Float64
+
+
+@pytest.mark.parametrize(
+    "read_csv",
+    [
+        pl.read_csv,
+        lambda *a, **kw: pl.scan_csv(*a, **kw).collect(),
+    ],
+)
+def test_read_csv_default_raise_if_empty(
+    read_csv: Callable[..., pl.DataFrame],
+) -> None:
+    schema = {"a": pl.Int64}
+    assert_frame_equal(
+        read_csv(b"", has_header=False, schema=schema),
+        pl.DataFrame(schema=schema),
+    )
+
+    with pytest.raises(NoDataError):
+        read_csv(b"", has_header=False, schema=schema, raise_if_empty=True)
+
+    with pytest.raises(NoDataError):
+        read_csv(b"", has_header=False)
+
+    for has_header in [True, False]:
+        assert_frame_equal(
+            read_csv(b"", has_header=has_header, raise_if_empty=False),
+            pl.DataFrame(),
+        )
+
+        assert_frame_equal(
+            read_csv(b"", has_header=has_header, schema=schema, raise_if_empty=False),
+            pl.DataFrame(schema=schema),
+        )

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -11,7 +11,11 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError, InvalidOperationError, ShapeError
+from polars.exceptions import (
+    ComputeError,
+    InvalidOperationError,
+    ShapeError,
+)
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/25864
