### PR TITLE
feat(python): Issue FutureWarning on using `from_arrow` of ArrowStreamExportable

### DIFF
--- a/py-polars/src/polars/convert/general.py
+++ b/py-polars/src/polars/convert/general.py
@@ -542,6 +542,14 @@ def from_arrow(
     ]
     """  # noqa: W505
     if is_pycapsule(data) and not _check_for_pyarrow(data):
+        # 2.0: Remove warning and return a Series.
+        issue_warning(
+            "from_arrow(<ArrowStreamExportable>) will return a Series instead of "
+            "a DataFrame in 2.0. To avoid this warning, pass the ArrowStreamExportable "
+            "to either `pl.DataFrame` or `pl.Series` instead based on your desired "
+            "output type.",
+            FutureWarning,
+        )
         return pycapsule_to_frame(
             data,
             schema=schema,

--- a/py-polars/src/polars/io/database/_executor.py
+++ b/py-polars/src/polars/io/database/_executor.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Coroutine, Sequence
+from collections.abc import Coroutine, Iterable, Sequence
 from contextlib import suppress
 from inspect import Parameter, signature
 from typing import TYPE_CHECKING, Any, Final, cast
 
 from polars import functions as F
 from polars._utils.various import parse_version, qualified_type_name
-from polars.convert import from_arrow
 from polars.datatypes import N_INFER_DEFAULT
 from polars.exceptions import (
     DuplicateError,
@@ -26,7 +25,7 @@ from polars.io.database._utils import _run_async
 
 if TYPE_CHECKING:
     import sys
-    from collections.abc import Iterable, Iterator
+    from collections.abc import Iterator
     from types import TracebackType
 
     import pyarrow as pa
@@ -162,7 +161,12 @@ class ConnectionExecutor:
         fetch_batches = driver_properties["fetch_batches"]
         if not iter_batches or fetch_batches is None:
             fetch_method = driver_properties["fetch_all"]
-            yield getattr(self.result, fetch_method)()
+            res = getattr(self.result, fetch_method)()
+
+            if isinstance(res, Iterable):
+                yield from res
+            else:
+                yield res
         else:
             size = [batch_size] if driver_properties["exact_batch_size"] else []
             repeat_batch_calls = driver_properties["repeat_batch_calls"]
@@ -244,7 +248,7 @@ class ConnectionExecutor:
                 frames = (
                     self._apply_overrides(batch, (schema_overrides or {}))
                     if isinstance(batch, DataFrame)
-                    else from_arrow(batch, schema_overrides=schema_overrides)
+                    else DataFrame(batch)
                     for batch in self._fetch_arrow(
                         driver_properties,
                         iter_batches=iter_batches,

--- a/py-polars/src/polars/io/database/_utils.py
+++ b/py-polars/src/polars/io/database/_utils.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any
 
 from polars._dependencies import _PYARROW_AVAILABLE, import_optional
 from polars._utils.various import parse_version
-from polars.convert import from_arrow
 from polars.exceptions import ModuleUpgradeRequiredError
 
 if TYPE_CHECKING:
@@ -43,6 +42,8 @@ def _read_sql_connectorx(
     schema_overrides: SchemaDict | None = None,
     pre_execution_query: str | list[str] | None = None,
 ) -> DataFrame:
+    from polars import DataFrame
+
     cx = import_optional("connectorx")
 
     if parse_version(cx.__version__) < (0, 4, 2):
@@ -71,7 +72,7 @@ def _read_sql_connectorx(
         errmsg = re.sub("://[^:]+:[^:]+@", "://***:***@", str(err))
         raise type(err)(errmsg) from err
 
-    return from_arrow(tbl, schema_overrides=schema_overrides)  # type: ignore[return-value]
+    return DataFrame(tbl, schema_overrides=schema_overrides)  # type: ignore[return-value]
 
 
 def _read_sql_adbc(
@@ -114,10 +115,12 @@ def _read_sql_adbc(
         "fetch_arrow" if adbc_version >= (1, 6, 0) else "fetch_arrow_table"
     )
 
+    from polars import DataFrame
+
     with _open_adbc_connection(connection_uri) as conn, conn.cursor() as cursor:
         cursor.execute(query, **(execute_options or {}))
         tbl = getattr(cursor, fetch_method_name)()
-        return from_arrow(tbl, schema_overrides=schema_overrides)  # type: ignore[return-value]
+        return DataFrame(tbl, schema_overrides=schema_overrides)  # type: ignore[return-value]
 
 
 def _get_adbc_driver_name_from_uri(connection_uri: str) -> str:

--- a/py-polars/src/polars/sql/context.py
+++ b/py-polars/src/polars/sql/context.py
@@ -16,7 +16,7 @@ from polars._utils.pycapsule import is_pycapsule
 from polars._utils.unstable import issue_unstable_warning
 from polars._utils.various import _get_stack_locals, qualified_type_name
 from polars._utils.wrap import wrap_ldf
-from polars.convert import from_arrow, from_pandas
+from polars.convert import from_pandas
 from polars.dataframe import DataFrame
 from polars.lazyframe import LazyFrame
 from polars.series import Series
@@ -71,7 +71,7 @@ def _ensure_lazyframe(obj: Any) -> LazyFrame:
     elif is_pycapsule(obj) or (
         _check_for_pyarrow(obj) and isinstance(obj, (pa.Table, pa.RecordBatch))
     ):
-        return from_arrow(obj).lazy()  # type: ignore[union-attr]
+        return DataFrame(obj).lazy()  # type: ignore[union-attr]
     else:
         msg = f"unrecognised frame type: {qualified_type_name(obj)}"
         raise ValueError(msg)

--- a/py-polars/tests/unit/interop/test_arrow_stream_error.py
+++ b/py-polars/tests/unit/interop/test_arrow_stream_error.py
@@ -29,4 +29,4 @@ def test_arrow_stream_error_raises_compute_error() -> None:
             return reader.__arrow_c_stream__(requested_schema)
 
     with pytest.raises(ComputeError, match=error_msg):
-        pl.from_arrow(FailingStream())
+        pl.DataFrame(FailingStream())

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -22,7 +22,7 @@ from polars.exceptions import (
 )
 from polars.interchange.protocol import CompatLevel
 from polars.testing import assert_frame_equal, assert_series_equal
-from tests.unit.utils.pycapsule_utils import PyCapsuleStreamHolder
+from tests.unit.utils.pycapsule_utils import PyCapsuleArrayHolder, PyCapsuleStreamHolder
 
 if TYPE_CHECKING:
     from tests.conftest import PlMonkeyPatch
@@ -1009,10 +1009,10 @@ def test_df_pycapsule_interface() -> None:
     expected_schema = pl.Schema([("a", pl.Int128), ("b", pl.String), ("c", pl.String)])
 
     for arrow_obj in (
-        pl.from_arrow(capsule_df),  # capsule
+        pl.DataFrame(capsule_df),  # capsule
         out,  # table loaded from capsule
     ):
-        df_res = pl.from_arrow(arrow_obj, schema_overrides=schema_overrides)
+        df_res = pl.DataFrame(arrow_obj, schema_overrides=schema_overrides)
         assert expected_schema == df_res.schema  # type: ignore[union-attr]
         assert isinstance(df_res, pl.DataFrame)
         assert df.equals(df_res)
@@ -1573,3 +1573,24 @@ def test_sliced_struct_arrow_export_19612() -> None:
             pl.DataFrame(arrow_tbl),
             pl.DataFrame({"x": [expect_row_value]}, schema=df.schema),
         )
+
+
+def test_from_arrow_capsule_24511() -> None:
+    # 2.0: Remove FutureWarning and change expected values to be struct-type Series.
+    with pytest.warns(FutureWarning):
+        out = pl.from_arrow(PyCapsuleStreamHolder(pl.DataFrame({"x": 1})))
+
+    assert isinstance(out, pl.DataFrame)
+    assert_frame_equal(
+        out,
+        pl.DataFrame({"x": 1}),
+    )
+
+    with pytest.warns(FutureWarning):
+        out = pl.from_arrow(PyCapsuleArrayHolder(pl.Series([{"x": 1}]).to_arrow()))
+
+    assert isinstance(out, pl.DataFrame)
+    assert_frame_equal(
+        out,
+        pl.DataFrame({"x": 1}),
+    )

--- a/py-polars/tests/unit/io/database/test_read.py
+++ b/py-polars/tests/unit/io/database/test_read.py
@@ -1296,10 +1296,10 @@ def test_sqlalchemy_row_init(sqlite_engine: Engine) -> None:
             assert_series_equal(expected_series, s)
 
 
-@patch("polars.io.database._utils.from_arrow")
+@patch("polars.DataFrame")
 @patch("polars.io.database._utils.import_optional")
 def test_read_database_uri_pre_execution_query_success(
-    import_mock: Mock, from_arrow_mock: Mock
+    import_mock: Mock, DataFrame_mock: Mock
 ) -> None:
     cx_mock = Mock()
     cx_mock.__version__ = "0.4.2"
@@ -1343,10 +1343,10 @@ def test_read_database_uri_pre_execution_not_supported_exception(
         )
 
 
-@patch("polars.io.database._utils.from_arrow")
+@patch("polars.DataFrame")
 @patch("polars.io.database._utils.import_optional")
 def test_read_database_uri_pre_execution_query_not_supported_success(
-    import_mock: Mock, from_arrow_mock: Mock
+    import_mock: Mock, DataFrame_mock: Mock
 ) -> None:
     cx_mock = Mock()
     cx_mock.__version__ = "0.4.0"


### PR DESCRIPTION
* ref https://github.com/pola-rs/polars/issues/24511

Also replaced all usages of `from_arrow()` internally and in tests with `DataFrame()`. A new single test is added with `pytest.warns` to test the deprecated `from_arrow()` behavior.
