### PR TITLE
feat(python!): Always return `Series` from `from_arrow(<ArrowStreamExportable>)`

### DIFF
--- a/py-polars/src/polars/convert/general.py
+++ b/py-polars/src/polars/convert/general.py
@@ -542,20 +542,27 @@ def from_arrow(
     ]
     """  # noqa: W505
     if is_pycapsule(data) and not _check_for_pyarrow(data):
-        # 2.0: Remove warning and return a Series.
-        issue_warning(
-            "from_arrow(<ArrowStreamExportable>) will return a Series instead of "
-            "a DataFrame in 2.0. To avoid this warning, pass the ArrowStreamExportable "
-            "to either `pl.DataFrame` or `pl.Series` instead based on your desired "
-            "output type.",
-            FutureWarning,
+        unsupported_parameter = (
+            "schema"
+            if schema is not None
+            else "schema_overrides"
+            if schema_overrides is not None
+            else None
         )
-        return pycapsule_to_frame(
-            data,
-            schema=schema,
-            schema_overrides=schema_overrides,
-            rechunk=rechunk,
-        )
+
+        if unsupported_parameter:
+            msg = (
+                f"`{unsupported_parameter}` parameter has no effect when using "
+                "`from_arrow(<ArrowStreamExportable>)`"
+            )
+            raise TypeError(msg)
+
+        ret = pl.Series(data)
+
+        if rechunk:
+            ret = ret.rechunk()
+
+        return ret
 
     elif isinstance(data, (pa.Table, pa.RecordBatch)):
         return wrap_df(

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -1568,11 +1568,11 @@ def test_sliced_struct_arrow_export_19612() -> None:
 
 def test_from_arrow_capsule_24511() -> None:
     assert_series_equal(
-        pl.from_arrow(PyCapsuleStreamHolder(pl.DataFrame({"x": 1}))),
+        pl.from_arrow(PyCapsuleStreamHolder(pl.DataFrame({"x": 1}))),  # type: ignore[arg-type]
         pl.Series([{"x": 1}]),
     )
 
     assert_series_equal(
-        pl.from_arrow(PyCapsuleArrayHolder(pl.Series([{"x": 1}]).to_arrow())),
+        pl.from_arrow(PyCapsuleArrayHolder(pl.Series([{"x": 1}]).to_arrow())),  # type: ignore[arg-type]
         pl.Series([{"x": 1}]),
     )

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -1567,21 +1567,12 @@ def test_sliced_struct_arrow_export_19612() -> None:
 
 
 def test_from_arrow_capsule_24511() -> None:
-    # 2.0: Remove FutureWarning and change expected values to be struct-type Series.
-    with pytest.warns(FutureWarning):
-        out = pl.from_arrow(PyCapsuleStreamHolder(pl.DataFrame({"x": 1})))
-
-    assert isinstance(out, pl.DataFrame)
-    assert_frame_equal(
-        out,
-        pl.DataFrame({"x": 1}),
+    assert_series_equal(
+        pl.from_arrow(PyCapsuleStreamHolder(pl.DataFrame({"x": 1}))),
+        pl.Series([{"x": 1}]),
     )
 
-    with pytest.warns(FutureWarning):
-        out = pl.from_arrow(PyCapsuleArrayHolder(pl.Series([{"x": 1}]).to_arrow()))
-
-    assert isinstance(out, pl.DataFrame)
-    assert_frame_equal(
-        out,
-        pl.DataFrame({"x": 1}),
+    assert_series_equal(
+        pl.from_arrow(PyCapsuleArrayHolder(pl.Series([{"x": 1}]).to_arrow())),
+        pl.Series([{"x": 1}]),
     )


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/24511
