### PR TITLE
docs: Add notes on k8s operator

### DIFF
--- a/docs/source/polars-on-premises/index.md
+++ b/docs/source/polars-on-premises/index.md
@@ -27,7 +27,7 @@ Polars On-Prem supports two deployment paths:
 - Any other CNCF-conformant Kubernetes distribution
 
 Deploy either via the Helm chart or the new
-[Kubernetes Operator](./kubernetes/index#installing-via-the-kubernetes-operator).
+[Kubernetes Operator](./kubernetes/index.md#installing-via-the-kubernetes-operator).
 
 **Bare metal:** for servers without Kubernetes. Polars On-Prem bootstraps the cluster directly on
 your machines, no Kubernetes installation required.

--- a/docs/source/polars-on-premises/index.md
+++ b/docs/source/polars-on-premises/index.md
@@ -26,6 +26,9 @@ Polars On-Prem supports two deployment paths:
 - Amazon Elastic Kubernetes Service (EKS)
 - Any other CNCF-conformant Kubernetes distribution
 
+Deploy either via the Helm chart or the new
+[Kubernetes Operator](./kubernetes/index#installing-via-the-kubernetes-operator).
+
 **Bare metal:** for servers without Kubernetes. Polars On-Prem bootstraps the cluster directly on
 your machines, no Kubernetes installation required.
 

--- a/docs/source/polars-on-premises/integrations/openlineage.md
+++ b/docs/source/polars-on-premises/integrations/openlineage.md
@@ -24,6 +24,8 @@ is the only supported transport protocol. See the dedicated cluster type pages f
 
 - [Bare metal](/polars-on-premises/bare-metal/configuration/openlineage)
 - [Kubernetes Helm Chart](https://github.com/polars-inc/helm-charts/blob/main/charts/polars/README.md#lineage)
+- [Kubernetes Operator](https://github.com/polars-inc/polars-k8s-operator/blob/main/docs/api.md#lineagespec)
+  (early access)
 
 ## Query annotation
 

--- a/docs/source/polars-on-premises/kubernetes/cloud-providers/amazon-elastic-kubernetes-service.md
+++ b/docs/source/polars-on-premises/kubernetes/cloud-providers/amazon-elastic-kubernetes-service.md
@@ -10,12 +10,28 @@ Through Pod Identity, you can securely access private S3 buckets without needing
 account keys or credentials.
 [See the guide in the official EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/service-accounts.html).
 
-```bash
-helm upgrade --install polars polars-inc/polars \
-  --set scheduler.serviceAccount.name=<YOUR_SERVICE_ACCOUNT_NAME> \
-  --set worker.serviceAccount.name=<YOUR_SERVICE_ACCOUNT_NAME> \
-# ...
-```
+=== "Helm Chart"
+
+    ```yaml
+    scheduler:
+      serviceAccount:
+        name: <YOUR_SERVICE_ACCOUNT_NAME>
+    worker:
+      serviceAccount:
+        name: <YOUR_SERVICE_ACCOUNT_NAME>
+    # ...
+    ```
+
+=== "Kubernetes Operator"
+
+    ```yaml
+    scheduler:
+      serviceAccount:
+        name: <YOUR_SERVICE_ACCOUNT_NAME>
+    workerPool:
+      serviceAccount:
+        name: <YOUR_SERVICE_ACCOUNT_NAME>
+    ```
 
 Assuming you have an S3 bucket already set up (see quick-start
 [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html)), you can
@@ -30,27 +46,59 @@ q = (
 )
 ```
 
-You may also use S3 as
-[an anonymous results location](https://github.com/polars-inc/helm-charts/tree/main/charts/polars#anonymous-results-data)
-by configuring the values as such:
+You may also use S3 as an anonymous results location by configuring the values as such:
 
-```yaml
-anonymousResults:
-  s3:
-    enabled: true
-    endpoint: "s3://YOUR_S3_BUCKET_NAME/PATH/TO/DATA/"
-```
+=== "Helm Chart"
 
-To use S3 as
-[a shuffle location](https://github.com/polars-inc/helm-charts/tree/main/charts/polars#shuffle-data),
-configure the values as such:
+    ```yaml
+    anonymousResults:
+      s3:
+        enabled: true
+        endpoint: "s3://YOUR_S3_BUCKET_NAME/PATH/TO/DATA/"
+        # ...
+    ```
 
-```yaml
-shuffleData:
-  s3:
-    enabled: true
-    endpoint: "s3://YOUR_S3_BUCKET_NAME/PATH/TO/DATA/"
-```
+    See the [`anonymousResults` section](https://github.com/polars-inc/helm-charts/tree/main/charts/polars#anonymous-results-data)
+    of the Helm chart values.
+
+=== "Kubernetes Operator"
+
+    ```yaml
+    anonymousResults:
+      s3:
+        endpoint: "s3://YOUR_S3_BUCKET_NAME/PATH/TO/DATA/"
+        # ...
+    ```
+
+    See [`AnonymousResultsS3Spec`](https://github.com/polars-inc/polars-k8s-operator/blob/main/docs/api.md#anonymousresultss3spec)
+    in the operator's CRD reference.
+
+To use S3 as a shuffle location, configure the values as such:
+
+=== "Helm Chart"
+
+    ```yaml
+    shuffleData:
+      s3:
+        enabled: true
+        endpoint: "s3://YOUR_S3_BUCKET_NAME/PATH/TO/DATA/"
+        # ...
+    ```
+
+    See the [`shuffleData` section](https://github.com/polars-inc/helm-charts/tree/main/charts/polars#shuffle-data)
+    of the Helm chart values.
+
+=== "Kubernetes Operator"
+
+    ```yaml
+    shuffleData:
+      s3:
+        endpoint: "s3://YOUR_S3_BUCKET_NAME/PATH/TO/DATA/"
+        # ...
+    ```
+
+    See [`ShuffleDataS3Spec`](https://github.com/polars-inc/polars-k8s-operator/blob/main/docs/api.md#shuffledatas3spec)
+    in the operator's CRD reference.
 
 ## Reducing NAT costs for private nodes
 

--- a/docs/source/polars-on-premises/kubernetes/cloud-providers/azure-kubernetes-service.md
+++ b/docs/source/polars-on-premises/kubernetes/cloud-providers/azure-kubernetes-service.md
@@ -11,12 +11,26 @@ to manage service account keys or credentials. You could use Microsoft Entra Wor
 purpose.
 [See the guide in the official AKS documentation](https://learn.microsoft.com/en-us/azure/aks/workload-identity-deploy-cluster).
 
-```bash
-helm upgrade --install polars polars-inc/polars \
-  --set scheduler.serviceAccount.name=<YOUR_SERVICE_ACCOUNT_NAME> \
-  --set worker.serviceAccount.name=<YOUR_SERVICE_ACCOUNT_NAME> \
-# ...
-```
+=== "Helm Chart"
+
+    ```yaml
+    scheduler:
+      serviceAccount:
+        name: <YOUR_SERVICE_ACCOUNT_NAME>
+    worker:
+      serviceAccount:
+        name: <YOUR_SERVICE_ACCOUNT_NAME>
+    # ...
+    ```
+
+=== "Kubernetes Operator"
+
+    ```yaml
+    scheduler:
+      serviceAccount: {}
+    workerPool:
+      serviceAccount: {}
+    ```
 
 Assuming you have a Blob Container already set up (see quick-start
 [here](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal#create-a-container)),
@@ -33,16 +47,34 @@ q = (
 )
 ```
 
-You may also use Azure Blob Storage as
-[an anonymous results location](https://github.com/polars-inc/helm-charts/tree/main/charts/polars#anonymous-results-data)
-by configuring the values as such:
+You may also use Azure Blob Storage as an anonymous results location by configuring the values as
+such:
 
-```yaml
-anonymousResults:
-  abs:
-    enabled: true
-    endpoint: "az://YOUR_BLOB_CONTAINER_NAME/PATH/TO/DATA/"
-    options:
-    - name: account_name
-      value: "YOUR_STORAGE_ACCOUNT_NAME"
-```
+=== "Helm Chart"
+
+    ```yaml
+    anonymousResults:
+      abs:
+        enabled: true
+        endpoint: "az://YOUR_BLOB_CONTAINER_NAME/PATH/TO/DATA/"
+        options:
+        - name: account_name
+          value: "YOUR_STORAGE_ACCOUNT_NAME"
+    ```
+
+    See the [`anonymousResults` section](https://github.com/polars-inc/helm-charts/tree/main/charts/polars#anonymous-results-data)
+    of the Helm chart values.
+
+=== "Kubernetes Operator"
+
+    ```yaml
+    anonymousResults:
+      abs:
+        endpoint: "az://YOUR_BLOB_CONTAINER_NAME/PATH/TO/DATA/"
+        options:
+        - name: account_name
+          value: "YOUR_STORAGE_ACCOUNT_NAME"
+    ```
+
+    See [`AnonymousResultsABSSpec`](https://github.com/polars-inc/polars-k8s-operator/blob/main/docs/api.md#anonymousresultsabsspec)
+    in the operator's CRD reference.

--- a/docs/source/polars-on-premises/kubernetes/cloud-providers/google-kubernetes-engine.md
+++ b/docs/source/polars-on-premises/kubernetes/cloud-providers/google-kubernetes-engine.md
@@ -12,12 +12,26 @@ enabling Workload Identity Federation, creating a Kubernetes service account, an
 policy binding.
 [See the guide in the official GKE documentation](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/workload-identity).
 
-```bash
-helm upgrade --install polars polars-inc/polars \
-  --set scheduler.serviceAccount.name=<YOUR_SERVICE_ACCOUNT_NAME> \
-  --set worker.serviceAccount.name=<YOUR_SERVICE_ACCOUNT_NAME> \
-# ...
-```
+=== "Helm Chart"
+
+    ```yaml
+    scheduler:
+      serviceAccount:
+        name: <YOUR_SERVICE_ACCOUNT_NAME>
+    worker:
+      serviceAccount:
+        name: <YOUR_SERVICE_ACCOUNT_NAME>
+    # ...
+    ```
+
+=== "Kubernetes Operator"
+
+    ```yaml
+    scheduler:
+      serviceAccount: {}
+    workerPool:
+      serviceAccount: {}
+    ```
 
 Assuming you have a bucket already set up (see quick-start
 [here](https://docs.cloud.google.com/storage/docs/creating-buckets)), you can then scan or sink
@@ -34,19 +48,37 @@ q = (
 )
 ```
 
-You may also use Google Cloud Storage as
-[an anonymous results location](https://github.com/polars-inc/helm-charts/tree/main/charts/polars#anonymous-results-data)
-by configuring the values as such:
+You may also use Google Cloud Storage as an anonymous results location by configuring the values as
+such:
 
-```yaml
-anonymousResults:
-  gcs:
-    enabled: true
-    endpoint: "gs://YOUR_BUCKET_NAME/PATH/TO/DATA/"
-    options:
-    - name: project
-      value: "YOUR_PROJECT_NAME"
-```
+=== "Helm Chart"
+
+    ```yaml
+    anonymousResults:
+      gcs:
+        enabled: true
+        endpoint: "gs://YOUR_BUCKET_NAME/PATH/TO/DATA/"
+        options:
+        - name: project
+          value: "YOUR_PROJECT_NAME"
+    ```
+
+    See the [`anonymousResults` section](https://github.com/polars-inc/helm-charts/tree/main/charts/polars#anonymous-results-data)
+    of the Helm chart values.
+
+=== "Kubernetes Operator"
+
+    ```yaml
+    anonymousResults:
+      gcs:
+        endpoint: "gs://YOUR_BUCKET_NAME/PATH/TO/DATA/"
+        options:
+        - name: project
+          value: "YOUR_PROJECT_NAME"
+    ```
+
+    See [`AnonymousResultsGCSSpec`](https://github.com/polars-inc/polars-k8s-operator/blob/main/docs/api.md#anonymousresultsgcsspec)
+    in the operator's CRD reference.
 
 ## Accessing GCS from private nodes
 

--- a/docs/source/polars-on-premises/kubernetes/index.md
+++ b/docs/source/polars-on-premises/kubernetes/index.md
@@ -174,11 +174,102 @@ The data your queries process stays entirely within your environment, and is nev
 Need an air-gapped Enterprise deployment that runs entirely in your infrastructure without outside
 connections? See the [On-Prem Enterprise](#on-prem-enterprise) section to get started.
 
+### Installing via the Kubernetes Operator
+
+!!! info "Early access"
+
+    The [Kubernetes Operator](https://github.com/polars-inc/polars-k8s-operator) is a new, early-access
+    alternative to the Helm chart above. It is **not yet recommended for production** — use the Helm
+    chart for that today. We're working towards feature parity and autoscaling support; try it out and
+    [let us know](https://github.com/polars-inc/polars-k8s-operator/issues) what you run into.
+
+Install the operator with Helm, then create a `PolarsCluster` resource to deploy a cluster:
+
+```sh
+helm repo add polars-inc https://polars-inc.github.io/helm-charts
+helm repo update
+helm install polars-k8s-operator polars-inc/polars-k8s-operator
+```
+
+```sh
+kubectl create secret generic polars-workspace \
+  --from-literal=clientID=<SERVICE ACCOUNT ID> \
+  --from-literal=clientSecret=<SERVICE ACCOUNT SECRET> \
+  --from-literal=workspaceID=<WORKSPACE ID>
+```
+
+```yaml
+apiVersion: compute.pola.rs/v1alpha1
+kind: PolarsCluster
+metadata:
+  name: polars
+spec:
+  license:
+    onPrem:
+      clientID:
+        valueFrom:
+          secretKeyRef:
+            name: polars-workspace
+            key: clientID
+      clientSecret:
+        valueFrom:
+          secretKeyRef:
+            name: polars-workspace
+            key: clientSecret
+      workspaceID:
+        valueFrom:
+          secretKeyRef:
+            name: polars-workspace
+            key: workspaceID
+  runtime:
+    composed: {}
+  scheduler:
+    podTemplate:
+      spec:
+        containers:
+        - name: scheduler
+          resources:
+            requests:
+              memory: 1Gi
+  workerPool:
+    replicas: 2
+    podTemplate:
+      spec:
+        containers:
+        - name: worker
+          resources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 4Gi
+```
+
+```sh
+kubectl apply -f polars-cluster.yaml
+```
+
+Verify the deployment the same way as with the Helm chart:
+
+```bash
+kubectl get pods
+kubectl get polarscluster
+```
+
+The full set of `PolarsCluster` fields is documented in the operator's
+[CRD reference](https://github.com/polars-inc/polars-k8s-operator/blob/main/docs/api.md), generated
+from its Go API types. Example manifests for common scenarios (checkpointing, lineage, dedicated
+nodes, object-storage shuffle, _etc._) are available in the repo's
+[`config/samples`](https://github.com/polars-inc/polars-k8s-operator/tree/main/config/samples)
+directory.
+
 ### Production configuration
 
-The complete list of configurable options is provided in the documentation of the
-[Helm chart](https://github.com/polars-inc/helm-charts/tree/main/charts/polars). The three topics
-listed below are the main configuration sections to tweak to ready your cluster for production use.
+The complete list of configurable options is provided in the
+[Helm chart](https://github.com/polars-inc/helm-charts/tree/main/charts/polars) documentation, or
+the operator's
+[CRD reference](https://github.com/polars-inc/polars-k8s-operator/blob/main/docs/api.md) if you're
+using the Kubernetes Operator. The three topics listed below are the main configuration sections to
+tweak to ready your cluster for production use.
 
 ![Deployed objects](arch-diag-pvc.png)
 
@@ -188,15 +279,21 @@ _In blue the optional PVC and S3-compatible storage._
 
 For remote queries without a specific output sink, Polars automatically adds a persistent sink. We
 call this sink the "anonymous results" sink. Infrastructure-wise, this sink is backed by
-S3-compatible storage, which must be accessible from all worker nodes and the client.
+S3-compatible storage, which must be accessible from all worker nodes and the client. In a
+production environment, any S3-compatible technology can be used (_i.e._, MinIO, DigitalOcean
+Spaces, _etc._).
 
-For a lightweight quickstart we opted for [SeaweedFS](https://github.com/seaweedfs/seaweedfs),
-backed by an `emptyDir`. In a production environment, any S3-compatible technology can be used
-(_i.e._, MinIO, DigitalOcean Spaces, _etc._). Support for Azure Blob Storage (ABS) and Google Cloud
-Storage (GCS) is currently being tested (released as beta).
+=== "Helm Chart"
 
-Anonymous results configuration is under the
-[`anonymousResults` section](https://github.com/polars-inc/helm-charts/tree/main/charts/polars#anonymous-results-data).
+    Anonymous results configuration is under the
+    [`anonymousResults` section](https://github.com/polars-inc/helm-charts/tree/main/charts/polars#anonymous-results-data)
+    of the Helm chart values.
+
+=== "Kubernetes Operator"
+
+    Anonymous results configuration is documented under
+    [`AnonymousResultsSpec`](https://github.com/polars-inc/polars-k8s-operator/blob/main/docs/api.md#anonymousresultsspec)
+    in the operator's CRD reference.
 
 #### Shuffle data
 
@@ -216,8 +313,17 @@ backend relative to local volumes. As an example, on AWS, EBS offers lower laten
 throughput. This makes EBS a better fit for workloads that produce many small shuffle files, while
 S3 will outperform it when shuffle files are large.
 
-Shuffle configuration is under the
-[`shuffleData` section](https://github.com/polars-inc/helm-charts/tree/main/charts/polars#shuffle-data).
+=== "Helm Chart"
+
+    Shuffle configuration is under the
+    [`shuffleData` section](https://github.com/polars-inc/helm-charts/tree/main/charts/polars#shuffle-data)
+    of the Helm chart values.
+
+=== "Kubernetes Operator"
+
+    Shuffle configuration is documented under
+    [`ShuffleDataSpec`](https://github.com/polars-inc/polars-k8s-operator/blob/main/docs/api.md#shuffledataspec)
+    in the operator's CRD reference.
 
 #### Resource allocation
 
@@ -228,8 +334,17 @@ are deployed), pod requests and limits should be allocated to worker nodes via t
 the same fashion, node selector, taints and tolerations should be used to optimize the topology of
 the cluster.
 
-Resource allocation and cluster topology configuration is under the
-[`worker.deployment` section](https://github.com/polars-inc/helm-charts/tree/main/charts/polars#resource-allocation-and-node-selectors).
+=== "Helm Chart"
+
+    Resource allocation and cluster topology configuration is under the
+    [`worker.deployment` section](https://github.com/polars-inc/helm-charts/tree/main/charts/polars#resource-allocation-and-node-selectors)
+    of the Helm chart values.
+
+=== "Kubernetes Operator"
+
+    Resource allocation and cluster topology configuration is documented under
+    [`WorkerPoolDeclaration`](https://github.com/polars-inc/polars-k8s-operator/blob/main/docs/api.md#workerpooldeclaration)
+    in the operator's CRD reference.
 
 #### Memory limits and OOM behavior
 

--- a/docs/source/polars-on-premises/releases.md
+++ b/docs/source/polars-on-premises/releases.md
@@ -114,6 +114,17 @@ The container images are hosted on
 [Dockerhub](https://hub.docker.com/r/polarscloud/polars-on-premises) and are tagged after the
 versions listed above.
 
+### Kubernetes operator
+
+The [Kubernetes Operator](https://github.com/polars-inc/polars-k8s-operator) is early access.
+Releases, including the CRD install bundle, are published on its
+[GitHub releases page](https://github.com/polars-inc/polars-k8s-operator/releases). It's also
+distributed as its own `polars-k8s-operator` Helm chart, in the same
+[chart repo](https://github.com/polars-inc/helm-charts/releases) as the main Polars chart.
+
+The controller image is hosted on
+[Dockerhub](https://hub.docker.com/r/polarscloud/polars-k8s-operator).
+
 ### Bare-metal binaries
 
 After obtaining an offline license for Polars On-Prem you will receive a JSON-formatted license for


### PR DESCRIPTION
Adds several back references to the new k8s operator. Will likely have its own page when we get it a bit more tested.

The main install is at: `docs/source/polars-on-premises/kubernetes/index.md` and most the others are tabs for changing schemas.