### PR TITLE
fix: Avoid duplicate column name collision when reading CSV (#28310)

### DIFF
--- a/crates/polars-io/src/csv/read/schema_inference.rs
+++ b/crates/polars-io/src/csv/read/schema_inference.rs
@@ -93,16 +93,17 @@ fn infer_headers(mut header_line: &[u8], parse_options: &CsvParseOptions) -> Vec
         .collect::<Vec<_>>();
 
     let mut deduplicated_headers = Vec::with_capacity(headers.len());
-    let mut header_names = PlHashMap::with_capacity(headers.len());
+    let mut header_names = PlHashSet::with_capacity(headers.len());
 
     for name in &headers {
-        let count = header_names.entry(name.as_ref()).or_insert(0usize);
-        if *count != 0 {
-            deduplicated_headers.push(format_pl_smallstr!("{}_duplicated_{}", name, *count - 1))
-        } else {
-            deduplicated_headers.push(PlSmallStr::from_str(name))
+        let mut new_name = PlSmallStr::from_str(name);
+        let mut count = 0usize;
+        while header_names.contains(&new_name) {
+            new_name = format_pl_smallstr!("{}_duplicated_{}", name, count);
+            count += 1;
         }
-        *count += 1;
+        header_names.insert(new_name.clone());
+        deduplicated_headers.push(new_name);
     }
 
     deduplicated_headers
@@ -387,5 +388,30 @@ mod tests {
         possibilities.insert(DataType::Int64);
         possibilities.insert(DataType::Int128);
         assert_eq!(finish_infer_field_schema(&possibilities), DataType::Int128);
+    }
+
+    #[test]
+    fn test_infer_headers_deduplicates() {
+        let parse_options = CsvParseOptions::default();
+        assert_eq!(
+            infer_headers(b"a,a", &parse_options),
+            vec![
+                PlSmallStr::from_static("a"),
+                PlSmallStr::from_static("a_duplicated_0"),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_infer_headers_deduplicates_without_collision() {
+        let parse_options = CsvParseOptions::default();
+        assert_eq!(
+            infer_headers(b"a,a_duplicated_0,a", &parse_options),
+            vec![
+                PlSmallStr::from_static("a"),
+                PlSmallStr::from_static("a_duplicated_0"),
+                PlSmallStr::from_static("a_duplicated_1"),
+            ],
+        );
     }
 }

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1541,6 +1541,19 @@ def test_duplicated_columns(chunk_override: None) -> None:
     assert pl.read_csv(csv.encode(), new_columns=new).columns == new
 
 
+def test_duplicated_columns_deduplicate_collision(chunk_override: None) -> None:
+    csv = textwrap.dedent(
+        """a,a_duplicated_0,a
+    1,2,3
+    """
+    )
+    assert pl.read_csv(csv.encode()).columns == [
+        "a",
+        "a_duplicated_0",
+        "a_duplicated_1",
+    ]
+
+
 def test_error_message(chunk_override: None) -> None:
     data = io.StringIO("target,wind,energy,miso\n1,2,3,4\n1,2,1e5,1\n")
     with pytest.raises(


### PR DESCRIPTION
Fixes #28310

### Problem

When a CSV file has duplicate column names, Polars renames them to `name_duplicated_N`. However, if the generated name already exists in the file, the previous entry in the schema was silently overwritten, so the schema ended up with fewer fields than the file actually has. This produced a confusing error:

```
polars.exceptions.ComputeError: found more fields than defined in 'Schema'
Consider setting 'truncate_ragged_lines=True'.
```

Reproducer from the issue:

```python
import io
import polars as pl
data = "a,a_duplicated_0,a\n1,2,3"
print(pl.read_csv(io.StringIO(data)))
```

### Fix

In `infer_headers`, instead of tracking a per-name counter, track the set of names already emitted and keep incrementing the `_duplicated_N` suffix until the generated name is actually unique.

Now the reproducer yields the expected result:

```
shape: (1, 3)
┌─────┬────────────────┬────────────────┐
│ a   ┆ a_duplicated_0 ┆ a_duplicated_1 │
│ --- ┆ ---            ┆ ---            │
│ i64 ┆ i64            ┆ i64            │
╞═════╪════════════════╪════════════════╡
│ 1   ┆ 2              ┆ 3              │
└─────┴────────────────┴────────────────┘
```

### Tests

- Added two Rust unit tests for `infer_headers` (basic dedup + collision case).
- Added a Python test `test_duplicated_columns_deduplicate_collision` in `test_csv.py`.