### PR TITLE
fix: Preserve List inner dtype when reversing all-null columns (#28409)

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/reverse.rs
+++ b/crates/polars-core/src/chunked_array/ops/reverse.rs
@@ -50,9 +50,6 @@ impl ChunkReverse for ListChunked {
         if self.is_empty() {
             return self.clone();
         };
-        // take_unchecked preserves the declared List inner dtype (via ca.dtype()),
-        // unlike series_iter().rev().collect_trusted() which rebuilds from values
-        // and degrades all-null List(T) to List(Null). See #28409.
         let idx = IdxCa::from_vec(
             PlSmallStr::EMPTY,
             (0..self.len() as IdxSize).rev().collect(),

--- a/crates/polars-core/src/chunked_array/ops/reverse.rs
+++ b/crates/polars-core/src/chunked_array/ops/reverse.rs
@@ -50,8 +50,14 @@ impl ChunkReverse for ListChunked {
         if self.is_empty() {
             return self.clone();
         };
-        let ca: Self = self.series_iter().rev().collect_trusted();
-        ca.with_name(self.name().clone())
+        // take_unchecked preserves the declared List inner dtype (via ca.dtype()),
+        // unlike series_iter().rev().collect_trusted() which rebuilds from values
+        // and degrades all-null List(T) to List(Null). See #28409.
+        let idx = IdxCa::from_vec(
+            PlSmallStr::EMPTY,
+            (0..self.len() as IdxSize).rev().collect(),
+        );
+        unsafe { self.take_unchecked(&idx) }
     }
 }
 

--- a/py-polars/tests/unit/operations/test_reverse.py
+++ b/py-polars/tests/unit/operations/test_reverse.py
@@ -22,6 +22,37 @@ def test_reverse_series() -> None:
     assert s.reverse().to_list() == ["x", "y", None, "b", "a"]
 
 
+def test_reverse_all_null_list_keeps_inner_dtype_28409() -> None:
+    # An all-null List column must keep its declared inner dtype after reverse,
+    # and the executed schema must match the schema the planner reports.
+    lf = pl.LazyFrame(
+        {"L": [None]}, schema={"L": pl.List(pl.Int64)}
+    ).reverse()
+
+    planned = lf.collect_schema()["L"]
+    assert planned == pl.List(pl.Int64)
+    assert lf.collect().schema["L"] == planned
+    assert lf.collect(engine="streaming").schema["L"] == planned
+
+
+def test_reverse_diagonal_concat_null_fill_28409() -> None:
+    # diagonal concat null-fills the missing "L" column of the right branch;
+    # when the left branch is empty the whole "L" column is null. Reversing it
+    # must not degrade List(Int64) into List(Null), and both engines must agree
+    # with the planned schema.
+    a = pl.LazyFrame({"L": [[1, 2]], "b": [1]})
+    b = pl.LazyFrame({"z": [7]})
+    q = pl.concat(
+        [a.sort("b").filter(pl.col("b") < -9), b],  # left branch is empty
+        how="diagonal",
+    ).reverse()
+
+    planned = q.collect_schema()["L"]
+    assert planned == pl.List(pl.Int64)
+    assert q.collect().schema["L"] == planned
+    assert q.collect(engine="streaming").schema["L"] == planned
+
+
 def test_reverse_binary() -> None:
     # single chunk
     s = pl.Series("values", ["a", "b", "c", "d"]).cast(pl.Binary)

--- a/py-polars/tests/unit/operations/test_reverse.py
+++ b/py-polars/tests/unit/operations/test_reverse.py
@@ -23,8 +23,6 @@ def test_reverse_series() -> None:
 
 
 def test_reverse_all_null_list_keeps_inner_dtype_28409() -> None:
-    # An all-null List column must keep its declared inner dtype after reverse,
-    # and the executed schema must match the schema the planner reports.
     lf = pl.LazyFrame({"L": [None]}, schema={"L": pl.List(pl.Int64)}).reverse()
 
     planned = lf.collect_schema()["L"]
@@ -34,14 +32,11 @@ def test_reverse_all_null_list_keeps_inner_dtype_28409() -> None:
 
 
 def test_reverse_diagonal_concat_null_fill_28409() -> None:
-    # diagonal concat null-fills the missing "L" column of the right branch;
-    # when the left branch is empty the whole "L" column is null. Reversing it
-    # must not degrade List(Int64) into List(Null), and both engines must agree
-    # with the planned schema.
+    # repro from #28409: empty left branch → all-null List after diagonal concat
     a = pl.LazyFrame({"L": [[1, 2]], "b": [1]})
     b = pl.LazyFrame({"z": [7]})
     q = pl.concat(
-        [a.sort("b").filter(pl.col("b") < -9), b],  # left branch is empty
+        [a.sort("b").filter(pl.col("b") < -9), b],
         how="diagonal",
     ).reverse()
 

--- a/py-polars/tests/unit/operations/test_reverse.py
+++ b/py-polars/tests/unit/operations/test_reverse.py
@@ -25,9 +25,7 @@ def test_reverse_series() -> None:
 def test_reverse_all_null_list_keeps_inner_dtype_28409() -> None:
     # An all-null List column must keep its declared inner dtype after reverse,
     # and the executed schema must match the schema the planner reports.
-    lf = pl.LazyFrame(
-        {"L": [None]}, schema={"L": pl.List(pl.Int64)}
-    ).reverse()
+    lf = pl.LazyFrame({"L": [None]}, schema={"L": pl.List(pl.Int64)}).reverse()
 
     planned = lf.collect_schema()["L"]
     assert planned == pl.List(pl.Int64)


### PR DESCRIPTION
Fixes #28409

## What

Reversing an all-null `List` column (e.g. after diagonal concat null-fills an empty branch) dropped the inner dtype: planned `List(Int64)`, executed `List(Null)`. In-memory and streaming both disagreed with the planner.

Cause: `ListChunked::reverse` did `series_iter().rev().collect_trusted()`, which rebuilds from values and loses the declared inner type when everything is null.

## Fix

Reverse with index `take_unchecked`, same idea as multi-chunk `BinaryChunked` / `ObjectChunked`, so dtype comes from `ca.dtype()`.

## Tests

Added two regression tests in `test_reverse.py` (all-null list + the diagonal-concat case from the issue). Local run:

pytest py-polars/tests/unit/operations/test_reverse.py -v


Screenshot of the full terminal window is attached below.

## AI disclosure

1. I used AI (Claude Code) for root-cause investigation and drafting the regression tests.
2. I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.

## Checklist

- [x] Local tests: `pytest py-polars/tests/unit/operations/test_reverse.py` — 6 passed
- [x] Screenshot of successful local test run attached (first-time contributor rule)
- 
<img width="1115" height="628" alt="image" src="https://github.com/user-attachments/assets/a25ab5b3-cf74-4680-ae08-559d3200d1d2" />