### PR TITLE
perf: Optimize not(bool_f) to not_bool_f

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/simplify_expr/simplify_functions.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_expr/simplify_functions.rs
@@ -225,10 +225,8 @@ pub(super) fn optimize_functions(
                         IRFunctionExpr::Boolean(
                             f @ IRBooleanFunction::IsNull
                             | f @ IRBooleanFunction::IsNan
-                            | f @ IRBooleanFunction::IsFinite
                             | f @ IRBooleanFunction::IsNotNull
                             | f @ IRBooleanFunction::IsNotNan
-                            | f @ IRBooleanFunction::IsInfinite,
                         ),
                     options,
                 } => Some(AExpr::Function {
@@ -236,10 +234,8 @@ pub(super) fn optimize_functions(
                     function: IRFunctionExpr::Boolean(match f {
                         IRBooleanFunction::IsNull => IRBooleanFunction::IsNotNull,
                         IRBooleanFunction::IsNan => IRBooleanFunction::IsNotNan,
-                        IRBooleanFunction::IsFinite => IRBooleanFunction::IsInfinite,
                         IRBooleanFunction::IsNotNull => IRBooleanFunction::IsNull,
                         IRBooleanFunction::IsNotNan => IRBooleanFunction::IsNan,
-                        IRBooleanFunction::IsInfinite => IRBooleanFunction::IsFinite,
                         _ => unreachable!(),
                     }),
                     options: *options,

--- a/crates/polars-plan/src/plans/optimizer/simplify_expr/simplify_functions.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_expr/simplify_functions.rs
@@ -218,24 +218,30 @@ pub(super) fn optimize_functions(
                 AExpr::Literal(lv) if lv.bool().is_some() => {
                     Some(AExpr::Literal(Scalar::from(!lv.bool().unwrap()).into()))
                 },
-                // not(x.is_null) => x.is_not_null
+                // not(x.is_y) => x.is_not_y  and  not(x.is_not_y) => x.is_y
                 AExpr::Function {
                     input,
-                    function: IRFunctionExpr::Boolean(IRBooleanFunction::IsNull),
+                    function:
+                        IRFunctionExpr::Boolean(
+                            f @ IRBooleanFunction::IsNull
+                            | f @ IRBooleanFunction::IsNan
+                            | f @ IRBooleanFunction::IsFinite
+                            | f @ IRBooleanFunction::IsNotNull
+                            | f @ IRBooleanFunction::IsNotNan
+                            | f @ IRBooleanFunction::IsInfinite,
+                        ),
                     options,
                 } => Some(AExpr::Function {
                     input: input.clone(),
-                    function: IRFunctionExpr::Boolean(IRBooleanFunction::IsNotNull),
-                    options: *options,
-                }),
-                // not(x.is_not_null) => x.is_null
-                AExpr::Function {
-                    input,
-                    function: IRFunctionExpr::Boolean(IRBooleanFunction::IsNotNull),
-                    options,
-                } => Some(AExpr::Function {
-                    input: input.clone(),
-                    function: IRFunctionExpr::Boolean(IRBooleanFunction::IsNull),
+                    function: IRFunctionExpr::Boolean(match f {
+                        IRBooleanFunction::IsNull => IRBooleanFunction::IsNotNull,
+                        IRBooleanFunction::IsNan => IRBooleanFunction::IsNotNan,
+                        IRBooleanFunction::IsFinite => IRBooleanFunction::IsInfinite,
+                        IRBooleanFunction::IsNotNull => IRBooleanFunction::IsNull,
+                        IRBooleanFunction::IsNotNan => IRBooleanFunction::IsNan,
+                        IRBooleanFunction::IsInfinite => IRBooleanFunction::IsFinite,
+                        _ => unreachable!(),
+                    }),
                     options: *options,
                 }),
                 // not(a == b) => a != b

--- a/crates/polars-plan/src/plans/optimizer/simplify_expr/simplify_functions.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_expr/simplify_functions.rs
@@ -226,7 +226,7 @@ pub(super) fn optimize_functions(
                             f @ IRBooleanFunction::IsNull
                             | f @ IRBooleanFunction::IsNan
                             | f @ IRBooleanFunction::IsNotNull
-                            | f @ IRBooleanFunction::IsNotNan
+                            | f @ IRBooleanFunction::IsNotNan,
                         ),
                     options,
                 } => Some(AExpr::Function {


### PR DESCRIPTION
We had this for `is_null` and `is_not_null` but I generalized it to `is_nan` and `is_not_nan` ~~as well as `is_finite` and `is_infinite`~~. EDIT: `!is_finite` and `is_infinite` differ due to NaN.