### PR TITLE
fix: Ensure SQL `SUM` and `CORR` aggregates return NULL for all-null inputs, add `TOTAL`

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -2416,26 +2416,8 @@ impl SQLContext {
         for (e, group_key) in projections.iter().zip(&projection_group_key) {
             let matches_group_key = group_key.is_some();
             // `Len` represents COUNT(*) so we treat as an aggregation here.
-            let is_non_group_key_expr = !matches_group_key
-                && has_expr(e, |e| {
-                    match e {
-                        Expr::Agg(_) | Expr::Len | Expr::Over { .. } => true,
-                        #[cfg(feature = "dynamic_group_by")]
-                        Expr::Rolling { .. } => true,
-                        Expr::AnonymousFunction { options, .. } => options.returns_scalar(),
-                        Expr::Function { function: func, .. }
-                            if !matches!(func, FunctionExpr::StructExpr(_)) =>
-                        {
-                            // If it's a function call containing a column NOT in the group by keys,
-                            // we treat it as an aggregation.
-                            has_expr(e, |e| match e {
-                                Expr::Column(name) => !group_by_keys_schema.contains(name),
-                                _ => false,
-                            })
-                        },
-                        _ => false,
-                    }
-                });
+            let is_non_group_key_expr =
+                !matches_group_key && expr_reduces_group(e, &group_by_keys_schema);
 
             // Note: if simple aliased expression we defer aliasing until after the group_by.
             // Use `e_inner` to track the potentially unwrapped expression for field lookup.
@@ -2496,52 +2478,22 @@ impl SQLContext {
             }
         }
 
-        // Process HAVING clause: identify aggregate expressions, reusing those already
-        // in projections, or compute as temporary columns and then post-filter/discard
-        let having_filter = if let Some(having_expr) = having {
-            let mut agg_to_name: Vec<(Expr, PlSmallStr)> = aggregation_projection
-                .iter()
-                .filter_map(|p| match p {
-                    Expr::Alias(inner, name) if matches!(**inner, Expr::Agg(_) | Expr::Len) => {
-                        Some((inner.as_ref().clone(), name.clone()))
-                    },
-                    e @ (Expr::Agg(_) | Expr::Len) => Some((
-                        e.clone(),
-                        e.to_field(&schema_before)
-                            .map(|f| f.name)
-                            .unwrap_or_default(),
-                    )),
-                    _ => None,
-                })
-                .collect();
+        // Note: HAVING is evaluated in the group context by `group_by().having(...)`,
+        // so any reference to a SELECT alias is resolved to the aggregate it names
+        let having = having.map(|having_expr| {
+            having_expr.map_expr(|e| match &e {
+                Expr::Column(name) => resolve_select_alias(name, projections, &schema_before)
+                    .map_or(e, |resolved| strip_outer_alias(&resolved)),
+                _ => e,
+            })
+        });
 
-            let mut n_having_aggs = 0;
-            let updated_having = having_expr.map_expr(|e| {
-                if !matches!(&e, Expr::Agg(_) | Expr::Len) {
-                    return e;
-                }
-                let name = agg_to_name
-                    .iter()
-                    .find_map(|(expr, n)| (*expr == e).then(|| n.clone()))
-                    .unwrap_or_else(|| {
-                        let n = format_pl_smallstr!("__POLARS_HAVING_{n_having_aggs}");
-                        aggregation_projection.push(e.clone().alias(n.clone()));
-                        agg_to_name.push((e.clone(), n.clone()));
-                        n_having_aggs += 1;
-                        n
-                    });
-                col(name)
-            });
-            Some(updated_having)
-        } else {
-            None
-        };
-
-        // Apply HAVING filter after aggregation
-        let mut aggregated = lf.group_by(group_by_keys).agg(&aggregation_projection);
-        if let Some(filter_expr) = having_filter {
-            aggregated = aggregated.filter(filter_expr);
+        let group_by = lf.group_by(group_by_keys);
+        let aggregated = match having {
+            Some(having) => group_by.having(having),
+            None => group_by,
         }
+        .agg(&aggregation_projection);
 
         let projection_schema =
             expressions_to_schema(projections, &schema_before, |duplicate_name: &str| {
@@ -2549,7 +2501,7 @@ impl SQLContext {
             })?;
 
         // A final projection to get the proper order and any deferred transforms/aliases
-        // (will also drop any temporary columns created for the HAVING post-filter).
+        // (will also drop any temporary columns created for the HAVING post-filter)
         let final_projection = projection_schema
             .iter_names()
             .zip(projections.iter().zip(&projection_group_key))
@@ -3109,6 +3061,25 @@ fn process_join_on(
             SQLInterface: "unsupported join constraint expression: {:?}", sql_expr
         ),
     }
+}
+
+/// Whether `expr` reduces a group to a scalar; shared by SELECT-projection
+/// classification and HAVING, so both agree on what counts as aggregation.
+fn expr_reduces_group(expr: &Expr, group_by_keys_schema: &Schema) -> bool {
+    has_expr(expr, |e| match e {
+        Expr::Agg(_) | Expr::Len | Expr::Over { .. } => true,
+        #[cfg(feature = "dynamic_group_by")]
+        Expr::Rolling { .. } => true,
+        Expr::AnonymousFunction { options, .. } => options.returns_scalar(),
+        Expr::Function { function: func, .. } if !matches!(func, FunctionExpr::StructExpr(_)) => {
+            // A function over a non-group-key column acts as an aggregation.
+            has_expr(
+                e,
+                |e| matches!(e, Expr::Column(name) if !group_by_keys_schema.contains(name)),
+            )
+        },
+        _ => false,
+    })
 }
 
 /// Build a unified schema from both tables; needed for multi/chained joins where suffixed

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -646,6 +646,13 @@ pub(crate) enum PolarsSQLFunctions {
     /// SELECT SUM(col1) FROM df;
     /// ```
     Sum,
+    /// SQL 'total' function.
+    /// Returns the sum of all the elements in the grouping; unlike `SUM`,
+    /// empty or all-null input returns zero rather than `NULL`.
+    /// ```sql
+    /// SELECT TOTAL(col1) FROM df;
+    /// ```
+    Total,
     /// SQL 'variance' function.
     /// Returns the variance of all the elements in the grouping.
     /// ```sql
@@ -907,6 +914,7 @@ impl PolarsSQLFunctions {
             "sum",
             "tan",
             "tand",
+            "total",
             "unnest",
             "upper",
             "var",
@@ -1041,6 +1049,7 @@ impl PolarsSQLFunctions {
             "stdev" | "stddev" | "stdev_samp" | "stddev_samp" => Self::StdDev,
             "string_agg" | "listagg" | "group_concat" => Self::StringAgg,
             "sum" => Self::Sum,
+            "total" => Self::Total,
             "var" | "variance" | "var_samp" => Self::Variance,
 
             // ----
@@ -1599,7 +1608,7 @@ impl SQLFunctionVisitor<'_> {
             // Aggregate functions
             // ----
             Avg => self.visit_unary(Expr::mean),
-            Corr => self.visit_binary(polars_lazy::dsl::pearson_corr),
+            Corr => self.visit_binary(sql_corr),
             Count => self.visit_count(),
             CovarPop => self.visit_binary(|a, b| polars_lazy::dsl::cov(a, b, 0)),
             CovarSamp => self.visit_binary(|a, b| polars_lazy::dsl::cov(a, b, 1)),
@@ -1641,7 +1650,8 @@ impl SQLFunctionVisitor<'_> {
             Min => self.visit_unary_with_opt_cumulative(Expr::min, Expr::cum_min),
             StdDev => self.visit_unary(|e| e.std(1)),
             StringAgg => self.visit_string_agg(),
-            Sum => self.visit_unary_with_opt_cumulative(Expr::sum, Expr::cum_sum),
+            Sum => self.visit_unary_with_opt_cumulative(sql_sum, Expr::cum_sum),
+            Total => self.visit_unary_with_opt_cumulative(Expr::sum, Expr::cum_sum),
             Variance => self.visit_unary(|e| e.var(1)),
 
             // ----
@@ -2194,11 +2204,16 @@ impl SQLFunctionVisitor<'_> {
         let base = self.parse_sql_arg(sql_expr)?;
         let base =
             self.apply_aggregate_clauses(base, is_distinct, &clauses, sql_expr, "STRING_AGG")?;
-        Ok(base
+        let joined = base
+            .clone()
             .cast(DataType::String)
             .implode(true)
             .list()
-            .join(separator, true))
+            .join(separator, true);
+
+        Ok(when(base.clone().null_count().lt(base.len()))
+            .then(joined)
+            .otherwise(lit(LiteralValue::untyped_null())))
     }
 
     fn visit_arr_to_string(&mut self) -> PolarsResult<Expr> {
@@ -2427,6 +2442,27 @@ impl SQLFunctionVisitor<'_> {
             self.func.to_string()
         );
     }
+}
+
+/// SQL requires `SUM` to return `NULL` when there are no non-null values to aggregate.
+fn sql_sum(expr: Expr) -> Expr {
+    when(expr.clone().null_count().lt(expr.clone().len()))
+        .then(expr.sum())
+        .otherwise(lit(LiteralValue::untyped_null()))
+}
+
+/// SQL semantics require `NULL` when there are no complete (eg: both non-null)
+/// pairs to correlate, whereas Polars' native `pearson_corr` returns `NaN`.
+fn sql_corr(a: Expr, b: Expr) -> Expr {
+    let has_corr_pairs = a
+        .clone()
+        .is_not_null()
+        .and(b.clone().is_not_null())
+        .any(true);
+
+    when(has_corr_pairs)
+        .then(polars_lazy::dsl::pearson_corr(a, b))
+        .otherwise(lit(LiteralValue::untyped_null()))
 }
 
 /// Returns true if the SQL expression is a non-null literal value (e.g. `1`, `'hello'`, `TRUE`).

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -227,7 +227,9 @@ impl SQLExprVisitor<'_> {
                 negated,
             } => {
                 let expr = self.visit_expr(expr)?;
-                let elems = self.visit_array_expr(list, true, Some(&expr))?;
+                let elems = self
+                    .visit_array_expr(list, false, Some(&expr))?
+                    .implode(false);
                 let is_in = expr.is_in(elems, false);
                 Ok(if *negated { is_in.not() } else { is_in })
             },

--- a/py-polars/docs/source/reference/sql/functions/aggregate.rst
+++ b/py-polars/docs/source/reference/sql/functions/aggregate.rst
@@ -36,6 +36,8 @@ Aggregate
      - Concatenates the input string values into a single string, separated by a delimiter.
    * - :ref:`SUM <sum>`
      - Returns the sum of all the elements in the grouping.
+   * - :ref:`TOTAL <total>`
+     - Returns the sum of all the elements in the grouping, returning zero (rather than null) if there are no non-null values.
    * - :ref:`VARIANCE <variance>`
      - Returns the variance of all the elements in the grouping.
 
@@ -470,6 +472,38 @@ Returns the sum of all the elements in the grouping.
     # ╞═════════╪═════════╡
     # │ 6       ┆ 21      │
     # └─────────┴─────────┘
+
+.. _total:
+
+TOTAL
+-----
+Returns the sum of all the elements in the grouping. Unlike :ref:`SUM <sum>` (which
+returns null for an all-null input, per the SQL standard), ``TOTAL`` returns zero.
+The result preserves the summed column's dtype.
+
+**Example:**
+
+.. code-block:: python
+
+    df = pl.DataFrame(
+        {"foo": [1, 2, 3], "bar": [None, None, None]},
+        schema={"foo": pl.Int64, "bar": pl.Int64},
+    )
+    df.sql("""
+      SELECT
+        SUM(bar) AS bar_sum,
+        TOTAL(foo) AS foo_total,
+        TOTAL(bar) AS bar_total
+      FROM self
+    """)
+    # shape: (1, 3)
+    # ┌─────────┬───────────┬───────────┐
+    # │ bar_sum ┆ foo_total ┆ bar_total │
+    # │ ---     ┆ ---       ┆ ---       │
+    # │ i64     ┆ i64       ┆ i64       │
+    # ╞═════════╪═══════════╪═══════════╡
+    # │ null    ┆ 6         ┆ 0         │
+    # └─────────┴───────────┴───────────┘
 
 .. _variance:
 

--- a/py-polars/tests/unit/sql/test_group_by.py
+++ b/py-polars/tests/unit/sql/test_group_by.py
@@ -393,6 +393,58 @@ def test_group_by_having_with_nulls() -> None:
     )
 
 
+def test_group_by_having_composite_aggregates() -> None:
+    df = pl.DataFrame(
+        {
+            "grp": ["a", "a", "b", "b", "c"],
+            "val": [10, 20, 5, 15, 100],
+        }
+    )
+    # SUM (null-guarded wrapper) as a bare HAVING predicate operand
+    assert_sql_matches(
+        df,
+        query="SELECT grp FROM self GROUP BY grp HAVING SUM(val) > 25 ORDER BY grp",
+        compare_with="sqlite",
+        expected={"grp": ["a", "c"]},
+    )
+    # SUM wrapped in a further scalar function
+    assert_sql_matches(
+        df,
+        query="SELECT grp FROM self GROUP BY grp HAVING ABS(SUM(val)) > 25 ORDER BY grp",
+        compare_with="sqlite",
+        expected={"grp": ["a", "c"]},
+    )
+    # composite SUM combined with another aggregate
+    assert_sql_matches(
+        df,
+        query="SELECT grp FROM self GROUP BY grp HAVING SUM(val) / COUNT(*) > 10 ORDER BY grp",
+        compare_with="sqlite",
+        expected={"grp": ["a", "c"]},
+    )
+    # STRING_AGG (implode+join composite) as a HAVING predicate
+    txt = pl.DataFrame({"grp": ["a", "a", "b"], "s": ["x", "y", "z"]})
+    assert_sql_matches(
+        txt,
+        query="SELECT grp FROM self GROUP BY grp HAVING STRING_AGG(s, ',') = 'x,y'",
+        compare_with="duckdb",
+        expected={"grp": ["a"]},
+    )
+    # CORR (null-guarded composite) as a HAVING predicate
+    corr = pl.DataFrame(
+        {
+            "grp": [1, 1, 1, 2, 2, 2],
+            "x": [1.0, 2.0, 3.0, 1.0, 2.0, 3.0],
+            "y": [2.0, 4.0, 6.0, 6.0, 4.0, 2.0],
+        }
+    )
+    assert_sql_matches(
+        corr,
+        query="SELECT grp FROM self GROUP BY grp HAVING CORR(x, y) > 0 ORDER BY grp",
+        compare_with="duckdb",
+        expected={"grp": [1]},
+    )
+
+
 @pytest.mark.parametrize(
     ("having_clause", "expected"),
     [
@@ -682,4 +734,123 @@ def test_group_by_empty_or_scalar_key_exprs_23397() -> None:
     assert_frame_equal(
         q.collect(),
         pl.DataFrame({"len": pl.Series([5], dtype=pl.get_index_type())}),
+    )
+
+
+def test_sum_and_total_28434() -> None:
+    # `SUM` over an empty/all-null input should return NULL (SQL standard).
+    # `TOTAL` is the (SQLite) non-standard counterpart that returns zero.
+    all_null = pl.DataFrame({"a": [None, None]}, schema={"a": pl.Int64})
+    grp = pl.DataFrame(
+        {"g": [1, 1, 2, 2], "a": [None, None, 3, 4]},
+        schema={"g": pl.Int64, "a": pl.Int64},
+    )
+    mixed = pl.DataFrame({"a": [1, None, 2]}, schema={"a": pl.Int64})
+
+    # scalar: all-null -> SUM is NULL, TOTAL is 0
+    expected = pl.DataFrame(
+        data={"s": [None], "t": [0]},
+        schema={"s": pl.Int64, "t": pl.Int64},
+    )
+    assert_frame_equal(
+        all_null.sql("SELECT SUM(a) AS s, TOTAL(a) AS t FROM self"), expected
+    )
+    assert_frame_equal(
+        all_null.sql("""
+            SELECT
+              SUM(a) OVER () AS s,
+              TOTAL(a) OVER () AS t,
+            FROM self
+        """),
+        expected,
+    )
+
+    # all-null group -> (NULL, 0); a group with values sums identically for both
+    assert_frame_equal(
+        grp.sql("SELECT g, SUM(a) AS s, TOTAL(a) AS t FROM self GROUP BY g ORDER BY g"),
+        pl.DataFrame(
+            {"g": [1, 2], "s": [None, 7], "t": [0, 7]},
+            schema={"g": pl.Int64, "s": pl.Int64, "t": pl.Int64},
+        ),
+    )
+    # a mix of null and non-null values sums identically for both
+    assert_frame_equal(
+        mixed.sql("SELECT SUM(a) AS s, TOTAL(a) AS t FROM self"),
+        pl.DataFrame({"s": [3], "t": [3]}, schema={"s": pl.Int64, "t": pl.Int64}),
+    )
+    # dtype is preserved across numeric types (float stays float)
+    all_null_f32 = pl.DataFrame({"a": [None, None]}, schema={"a": pl.Float32})
+    assert_frame_equal(
+        all_null_f32.sql("SELECT SUM(a) AS s, TOTAL(a) AS t FROM self"),
+        pl.DataFrame(
+            {"s": [None], "t": [0.0]}, schema={"s": pl.Float32, "t": pl.Float32}
+        ),
+    )
+
+    # `SUM`-specific NULL conformance (no `TOTAL` analog), checked against sqlite
+    assert_sql_matches(
+        all_null,
+        query="SELECT COALESCE(SUM(a), -99) AS s FROM self",
+        compare_with="sqlite",
+        expected={"s": [-99]},
+    )
+    assert_sql_matches(
+        all_null,
+        query="SELECT SUM(a) AS s, AVG(a) AS m FROM self",
+        compare_with="sqlite",
+        expected={"s": [None], "m": [None]},
+    )
+
+
+def test_corr_no_complete_pairs_returns_null() -> None:
+    # `CORR` returns NULL when there are no complete (both-non-null) pairs
+    allnull = pl.DataFrame(
+        {"a": [None, None], "b": [None, None]},
+        schema={"a": pl.Float64, "b": pl.Float64},
+    )
+    assert_sql_matches(
+        allnull,
+        query="SELECT CORR(a, b) AS c FROM self",
+        compare_with="duckdb",
+        expected={"c": [None]},
+    )
+
+    # rows exist, but no single row has both values non-null -> NULL
+    no_pairs = pl.DataFrame(
+        {"a": [1.0, None], "b": [None, 2.0]},
+        schema={"a": pl.Float64, "b": pl.Float64},
+    )
+    assert_sql_matches(
+        no_pairs,
+        query="SELECT CORR(a, b) AS c FROM self",
+        compare_with="duckdb",
+        expected={"c": [None]},
+    )
+
+    # a well-defined correlation is unaffected by the fix
+    corr = pl.DataFrame(
+        {"a": [1.0, 2.0, 3.0], "b": [2.0, 4.0, 6.0]},
+        schema={"a": pl.Float64, "b": pl.Float64},
+    )
+    assert_sql_matches(
+        corr,
+        query="SELECT CORR(a, b) AS c FROM self",
+        compare_with="duckdb",
+        expected={"c": [1.0]},
+    )
+
+    # an all-null group yields NULL; a group with a real correlation is computed
+    grp = pl.DataFrame(
+        {
+            "g": [1, 1, 2, 2, 2],
+            "a": [None, None, 1.0, 2.0, 3.0],
+            "b": [None, None, 2.0, 4.0, 6.0],
+        },
+        schema={"g": pl.Int64, "a": pl.Float64, "b": pl.Float64},
+    )
+    assert_sql_matches(
+        grp,
+        query="SELECT g, CORR(a, b) AS c FROM self GROUP BY g ORDER BY g",
+        compare_with="duckdb",
+        expected={"g": [1, 2], "c": [None, 1.0]},
     )

--- a/py-polars/tests/unit/sql/test_string_agg.py
+++ b/py-polars/tests/unit/sql/test_string_agg.py
@@ -85,3 +85,36 @@ def test_string_agg_limit(df_test: pl.LazyFrame) -> None:
         "grp": ["a", "b"],
         "v": ["x3,x2", "y3,y2"],
     }
+
+
+def test_string_agg_all_null_returns_null() -> None:
+    # `STRING_AGG` over an all-null input returns NULL (not an empty string),
+    # matching standard SQL. A non-null empty string is still concatenated.
+    df = pl.DataFrame({"a": [None, None]}, schema={"a": pl.String})
+    assert_sql_matches(
+        {"df": df},
+        query="SELECT STRING_AGG(a, ',') AS v FROM df",
+        compare_with="duckdb",
+        expected={"v": [None]},
+    )
+
+    # an all-null group yields NULL; a group with values concatenates as normal
+    grp = pl.DataFrame(
+        {"g": [1, 1, 2, 2], "a": [None, None, "p", "q"]},
+        schema={"g": pl.Int64, "a": pl.String},
+    )
+    assert_sql_matches(
+        {"df": grp},
+        query="SELECT g, STRING_AGG(a, ',') AS v FROM df GROUP BY g ORDER BY g",
+        compare_with="duckdb",
+        expected={"g": [1, 2], "v": [None, "p,q"]},
+    )
+
+    # a non-null empty string is preserved (distinct from the all-null case)
+    empty = pl.DataFrame({"a": ["", None]}, schema={"a": pl.String})
+    assert_sql_matches(
+        {"df": empty},
+        query="SELECT STRING_AGG(a, ',') AS v FROM df",
+        compare_with="duckdb",
+        expected={"v": [""]},
+    )


### PR DESCRIPTION
Fixes #28434.

* Ensure we conform to the correct/expected SQL semantics for all-NULL `SUM`.
* Checked the other aggregates, fixing `CORR` (and `STRING_AGG`) similarly.
* Added SQLite `TOTAL`[^1] function, which maps to standard Polars `sum`.

Hugely streamlined application of `HAVING`, now that we have a native Rust-side `having` that we can defer to for use with `group_by`; doing so also fixes an edge-case that was discovered by the unit tests added for the above updates.

[^1]: SQLite `SUM` and `TOTAL` aggregate functions:
https://sqlite.org/lang_aggfunc.html#sumunc