### PR TITLE
fix: Share `null_count_dtype` helper between Delta and Iceberg, fixing `SchemaError`

### DIFF
--- a/py-polars/src/polars/io/_utils.py
+++ b/py-polars/src/polars/io/_utils.py
@@ -21,7 +21,24 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from contextlib import AbstractContextManager as ContextManager
 
-    from polars._typing import StorageOptionsDict
+    from polars._typing import PolarsDataType, StorageOptionsDict
+
+
+def null_count_dtype(dtype: PolarsDataType) -> PolarsDataType:
+    """Statistics-frame dtype for a column's ``null_count``.
+
+    Scalar (and non-struct nested) columns carry a single row-level null count (the
+    index type). Struct columns carry a *per-field* null count mirroring the column
+    shape (each leaf replaced by the index type), so the skip-batch predicate can prune
+    on an individual struct field via ``col("<c>_nc").struct.field(..)``.
+    """
+    import polars as pl
+
+    if isinstance(dtype, pl.Struct):
+        return pl.Struct(
+            {field.name: null_count_dtype(field.dtype) for field in dtype.fields}
+        )
+    return pl.get_index_type()
 
 
 def parse_columns_arg(

--- a/py-polars/src/polars/io/delta/_utils.py
+++ b/py-polars/src/polars/io/delta/_utils.py
@@ -9,6 +9,7 @@ from polars._dependencies import _DELTALAKE_AVAILABLE, deltalake
 from polars._utils.logging import eprint
 from polars.datatypes import Null, Time
 from polars.datatypes.convert import unpack_dtypes
+from polars.io._utils import null_count_dtype
 from polars.io.cloud._utils import POLARS_STORAGE_CONFIG_KEYS, _get_path_scheme
 
 if TYPE_CHECKING:
@@ -106,23 +107,6 @@ def _check_for_unsupported_types(dtypes: list[DataType]) -> None:
         raise TypeError(msg)
 
 
-def _null_count_dtype(dtype: PolarsDataType) -> PolarsDataType:
-    """Statistics-frame dtype for a column's ``null_count``.
-
-    Scalar (and non-struct nested) columns carry a single row-level null count (the
-    index type). Struct columns carry a *per-field* null count mirroring the column
-    shape (each leaf replaced by the index type), so the skip-batch predicate can prune
-    on an individual struct field via ``col("<c>_nc").struct.field(..)``.
-    """
-    import polars as pl
-
-    if isinstance(dtype, pl.Struct):
-        return pl.Struct(
-            {field.name: _null_count_dtype(field.dtype) for field in dtype.fields}
-        )
-    return pl.get_index_type()
-
-
 def _extract_table_statistics_from_delta_add_actions(
     add_actions_df: DataFrame,
     *,
@@ -167,7 +151,7 @@ def _extract_table_statistics_from_delta_add_actions(
         dtype = schema[col_name]
         # The skip-batch predicate expects `<col>_nc` in the index type (a per-field
         # struct of index counts for struct columns), so normalise the counts here.
-        nc_dtype = _null_count_dtype(dtype)
+        nc_dtype = null_count_dtype(dtype)
         col_nc = null_count_cols.get(col_name)
         col_min = min_cols.get(col_name)
         col_max = max_cols.get(col_name)

--- a/py-polars/src/polars/io/iceberg/_utils.py
+++ b/py-polars/src/polars/io/iceberg/_utils.py
@@ -29,6 +29,7 @@ from polars._utils.convert import to_py_date, to_py_datetime
 from polars._utils.logging import eprint
 from polars._utils.wrap import wrap_s
 from polars.exceptions import ComputeError
+from polars.io._utils import null_count_dtype
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Sequence
@@ -550,7 +551,9 @@ class IcebergColumnStatisticsLoader:
         c = self.column_name
         assert len(self.null_count) == expected_height
 
-        out = pl.Series(f"{c}_nc", self.null_count, dtype=pl.UInt32).to_frame()
+        out = pl.Series(
+            f"{c}_nc", self.null_count, dtype=null_count_dtype(self.column_dtype)
+        ).to_frame()
 
         if self.load_from_bytes_impl is None:
             s = (

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -1130,6 +1130,41 @@ def test_scan_iceberg_extra_struct_fields(tmp_path: Path) -> None:
 
 
 @pytest.mark.write_disk
+def test_scan_iceberg_filter_on_struct_field_28476(tmp_path: Path) -> None:
+    tbl, _ = new_iceberg_table(
+        tmp_path,
+        schema=IcebergSchema(
+            NestedField(1, "order_id", StringType()),
+            NestedField(
+                2,
+                "order_details",
+                StructType(NestedField(3, "qid", StringType())),
+            ),
+        ),
+    )
+    df = pl.DataFrame(
+        {
+            "order_id": ["a", "b", "c"],
+            "order_details": [{"qid": "X1"}, {"qid": "X2"}, {"qid": "X3"}],
+        },
+        schema={
+            "order_id": pl.String,
+            "order_details": pl.Struct({"qid": pl.String}),
+        },
+    )
+    df.write_iceberg(tbl, mode="append")
+
+    q = pl.scan_iceberg(tbl).filter(pl.col("order_details").struct.field("qid") == "X2")
+    expected = df.slice(1, 1)
+
+    assert_frame_equal(q.collect(), expected)
+    assert_frame_equal(
+        q.collect(optimizations=pl.QueryOptFlags(predicate_pushdown=False)),
+        expected,
+    )
+
+
+@pytest.mark.write_disk
 def test_scan_iceberg_column_deletion(tmp_path: Path) -> None:
     catalog = SqlCatalog(
         "default",


### PR DESCRIPTION
Fixes #28476.

* Per-field statistics pruning in #27887 updated the Delta and Parquet code accordingly; Iceberg was missed. 

* The fix just extracts the associated `null_count_dtype` helper from the Delta code and allows it to be called from Iceberg too.
 
* Added some test coverage.

---

Note that Iceberg struct min/max aren't _actually_ loaded from upper/lower bounds, so struct columns don't really prune yet -- pending optimisation.