### PR TITLE
fix: Do not CSE non-column height expr on streaming engine

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/cse/csee.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/csee.rs
@@ -942,6 +942,7 @@ impl CommonSubExprOptimizer {
             for id in self.replaced_identifiers.inner.keys() {
                 let (node, _count) = self.se_count.get(id, expr_arena).unwrap();
 
+                // Avoid accidentally broadcasting <scalar literal>.<elementwise_ops..>
                 if self.element_wise_select_only
                     && !matches!(
                         aexpr_projection_height_rec(

--- a/crates/polars-plan/src/plans/optimizer/cse/csee.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/csee.rs
@@ -656,7 +656,8 @@ impl RewritingVisitor for CommonSubExprRewriter<'_> {
             return Ok(RewriteRecursion::Stop);
         }
 
-        let id = &self.identifier_array[self.visited_idx + self.id_array_offset].1;
+        let (post_visit_count, id) =
+            &self.identifier_array[self.visited_idx + self.id_array_offset];
 
         // Id placeholder not overwritten, so we can skip this sub-expression.
         if !id.is_valid() {
@@ -693,6 +694,18 @@ impl RewritingVisitor for CommonSubExprRewriter<'_> {
                 self.replaced_identifiers.insert(id.clone(), (), arena);
                 RewriteRecursion::MutateAndStop
             };
+
+            self.visited_idx += 1;
+            if *post_visit_count >= self.max_post_visit_idx {
+                self.max_post_visit_idx = *post_visit_count;
+                while self.visited_idx < self.identifier_array.len() - self.id_array_offset
+                    && *post_visit_count
+                        > self.identifier_array[self.visited_idx + self.id_array_offset].0
+                {
+                    self.visited_idx += 1;
+                }
+            }
+
             // rewrite this sub-expression, don't visit its children
             Ok(recursion)
         } else {
@@ -709,25 +722,13 @@ impl RewritingVisitor for CommonSubExprRewriter<'_> {
         arena: &mut Self::Arena,
     ) -> PolarsResult<Self::Node> {
         let (post_visit_count, id) =
-            &self.identifier_array[self.visited_idx + self.id_array_offset];
-        self.visited_idx += 1;
+            &self.identifier_array[self.visited_idx - 1 + self.id_array_offset];
 
         // TODO!: check if we ever hit this branch
         if *post_visit_count < self.max_post_visit_idx {
             return Ok(node);
         }
 
-        self.max_post_visit_idx = *post_visit_count;
-        // DFS, so every post_visit that is smaller than `post_visit_count`
-        // is a subexpression of this node and we can skip that
-        //
-        // `self.visited_idx` will influence recursion strategy in `pre_visit`
-        // see call-stack comment above
-        while self.visited_idx < self.identifier_array.len() - self.id_array_offset
-            && *post_visit_count > self.identifier_array[self.visited_idx + self.id_array_offset].0
-        {
-            self.visited_idx += 1;
-        }
         // If this is not true, the traversal order in the visitor was different from the rewriter.
         debug_assert_eq!(
             node.hashable_and_cmp(arena),

--- a/crates/polars-plan/src/plans/optimizer/cse/csee.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/csee.rs
@@ -575,9 +575,6 @@ struct CommonSubExprRewriter<'a> {
     rewritten: bool,
     is_group_by: bool,
     is_element_wise_select_only: bool,
-
-    nodes_scratch: ScratchVec<Node>,
-    heights_scratch: ScratchVec<ExprProjectionHeight>,
 }
 
 impl<'a> CommonSubExprRewriter<'a> {
@@ -599,8 +596,6 @@ impl<'a> CommonSubExprRewriter<'a> {
             rewritten: false,
             is_group_by,
             is_element_wise_select_only,
-            nodes_scratch: ScratchVec::default(),
-            heights_scratch: ScratchVec::default(),
         }
     }
 }
@@ -656,8 +651,7 @@ impl RewritingVisitor for CommonSubExprRewriter<'_> {
             return Ok(RewriteRecursion::Stop);
         }
 
-        let (post_visit_count, id) =
-            &self.identifier_array[self.visited_idx + self.id_array_offset];
+        let id = &self.identifier_array[self.visited_idx + self.id_array_offset].1;
 
         // Id placeholder not overwritten, so we can skip this sub-expression.
         if !id.is_valid() {
@@ -679,35 +673,9 @@ impl RewritingVisitor for CommonSubExprRewriter<'_> {
             return Ok(RewriteRecursion::NoMutateAndContinue);
         };
         if *count > 1 {
-            let recursion = if self.is_element_wise_select_only
-                && !matches!(
-                    aexpr_projection_height_rec(
-                        ae_node.node(),
-                        arena,
-                        &mut self.nodes_scratch,
-                        &mut self.heights_scratch,
-                    ),
-                    ExprProjectionHeight::Column
-                ) {
-                RewriteRecursion::Stop
-            } else {
-                self.replaced_identifiers.insert(id.clone(), (), arena);
-                RewriteRecursion::MutateAndStop
-            };
-
-            self.visited_idx += 1;
-            if *post_visit_count >= self.max_post_visit_idx {
-                self.max_post_visit_idx = *post_visit_count;
-                while self.visited_idx < self.identifier_array.len() - self.id_array_offset
-                    && *post_visit_count
-                        > self.identifier_array[self.visited_idx + self.id_array_offset].0
-                {
-                    self.visited_idx += 1;
-                }
-            }
-
+            self.replaced_identifiers.insert(id.clone(), (), arena);
             // rewrite this sub-expression, don't visit its children
-            Ok(recursion)
+            Ok(RewriteRecursion::MutateAndStop)
         } else {
             // This is a unique expression
             // visit its children to see if they are cse
@@ -722,13 +690,25 @@ impl RewritingVisitor for CommonSubExprRewriter<'_> {
         arena: &mut Self::Arena,
     ) -> PolarsResult<Self::Node> {
         let (post_visit_count, id) =
-            &self.identifier_array[self.visited_idx - 1 + self.id_array_offset];
+            &self.identifier_array[self.visited_idx + self.id_array_offset];
+        self.visited_idx += 1;
 
         // TODO!: check if we ever hit this branch
         if *post_visit_count < self.max_post_visit_idx {
             return Ok(node);
         }
 
+        self.max_post_visit_idx = *post_visit_count;
+        // DFS, so every post_visit that is smaller than `post_visit_count`
+        // is a subexpression of this node and we can skip that
+        //
+        // `self.visited_idx` will influence recursion strategy in `pre_visit`
+        // see call-stack comment above
+        while self.visited_idx < self.identifier_array.len() - self.id_array_offset
+            && *post_visit_count > self.identifier_array[self.visited_idx + self.id_array_offset].0
+        {
+            self.visited_idx += 1;
+        }
         // If this is not true, the traversal order in the visitor was different from the rewriter.
         debug_assert_eq!(
             node.hashable_and_cmp(arena),
@@ -757,6 +737,9 @@ pub(crate) struct CommonSubExprOptimizer {
     // Only supports element-wise CSEE
     // on SELECT/HSTACK
     element_wise_select_only: bool,
+
+    nodes_scratch: ScratchVec<Node>,
+    heights_scratch: ScratchVec<ExprProjectionHeight>,
 }
 
 impl CommonSubExprOptimizer {
@@ -769,6 +752,8 @@ impl CommonSubExprOptimizer {
             replaced_identifiers: Default::default(),
             name_validation: Default::default(),
             element_wise_select_only,
+            nodes_scratch: ScratchVec::default(),
+            heights_scratch: ScratchVec::default(),
         }
     }
 
@@ -956,6 +941,21 @@ impl CommonSubExprOptimizer {
             // Add the tmp columns
             for id in self.replaced_identifiers.inner.keys() {
                 let (node, _count) = self.se_count.get(id, expr_arena).unwrap();
+
+                if self.element_wise_select_only
+                    && !matches!(
+                        aexpr_projection_height_rec(
+                            *node,
+                            expr_arena,
+                            &mut self.nodes_scratch,
+                            &mut self.heights_scratch
+                        ),
+                        ExprProjectionHeight::Column
+                    )
+                {
+                    return Ok(None);
+                }
+
                 let name = id.materialize();
                 let out_e = ExprIR::new(*node, OutputName::Alias(name));
                 new_expr.push(out_e)

--- a/crates/polars-plan/src/plans/optimizer/cse/csee.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/csee.rs
@@ -678,7 +678,6 @@ impl RewritingVisitor for CommonSubExprRewriter<'_> {
             return Ok(RewriteRecursion::NoMutateAndContinue);
         };
         if *count > 1 {
-            self.replaced_identifiers.insert(id.clone(), (), arena);
             let recursion = if self.is_element_wise_select_only
                 && !matches!(
                     aexpr_projection_height_rec(
@@ -691,6 +690,7 @@ impl RewritingVisitor for CommonSubExprRewriter<'_> {
                 ) {
                 RewriteRecursion::Stop
             } else {
+                self.replaced_identifiers.insert(id.clone(), (), arena);
                 RewriteRecursion::MutateAndStop
             };
             // rewrite this sub-expression, don't visit its children

--- a/crates/polars-plan/src/plans/optimizer/cse/csee.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/csee.rs
@@ -12,10 +12,12 @@ use polars_utils::arena::{Arena, Node};
 use polars_utils::format_pl_smallstr;
 use polars_utils::hashing::_boost_hash_combine;
 use polars_utils::pl_str::PlSmallStr;
+use polars_utils::scratch_vec::ScratchVec;
 use polars_utils::vec::CapacityByFactor;
 
 use crate::constants::CSE_REPLACED;
 use crate::plans::aexpr::is_inherently_nondeterministic_top_level;
+use crate::plans::projection_height::{ExprProjectionHeight, aexpr_projection_height_rec};
 use crate::plans::visitor::{
     IRNode, IRNodeArena, RewriteRecursion, RewritingVisitor, TreeWalker as _, VisitRecursion,
     Visitor,
@@ -573,6 +575,9 @@ struct CommonSubExprRewriter<'a> {
     rewritten: bool,
     is_group_by: bool,
     is_element_wise_select_only: bool,
+
+    nodes_scratch: ScratchVec<Node>,
+    heights_scratch: ScratchVec<ExprProjectionHeight>,
 }
 
 impl<'a> CommonSubExprRewriter<'a> {
@@ -594,6 +599,8 @@ impl<'a> CommonSubExprRewriter<'a> {
             rewritten: false,
             is_group_by,
             is_element_wise_select_only,
+            nodes_scratch: ScratchVec::default(),
+            heights_scratch: ScratchVec::default(),
         }
     }
 }
@@ -672,8 +679,22 @@ impl RewritingVisitor for CommonSubExprRewriter<'_> {
         };
         if *count > 1 {
             self.replaced_identifiers.insert(id.clone(), (), arena);
+            let recursion = if self.is_element_wise_select_only
+                && !matches!(
+                    aexpr_projection_height_rec(
+                        ae_node.node(),
+                        arena,
+                        &mut self.nodes_scratch,
+                        &mut self.heights_scratch,
+                    ),
+                    ExprProjectionHeight::Column
+                ) {
+                RewriteRecursion::Stop
+            } else {
+                RewriteRecursion::MutateAndStop
+            };
             // rewrite this sub-expression, don't visit its children
-            Ok(RewriteRecursion::MutateAndStop)
+            Ok(recursion)
         } else {
             // This is a unique expression
             // visit its children to see if they are cse

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -922,9 +922,11 @@ def test_cse_as_struct_19253() -> None:
 
 @pytest.mark.may_fail_auto_streaming
 def test_cse_as_struct_value_counts_20927() -> None:
-    assert pl.DataFrame({"x": [i for i in range(1, 6) for _ in range(i)]}).select(
+    q = pl.LazyFrame({"x": [i for i in range(1, 6) for _ in range(i)]}).select(
         pl.struct("x").value_counts().struct.unnest()
-    ).sort("count").to_dict(as_series=False) == {
+    )
+    print(q.explain())
+    assert q.collect().sort("count").to_dict(as_series=False) == {
         "x": [{"x": 1}, {"x": 2}, {"x": 3}, {"x": 4}, {"x": 5}],
         "count": [1, 2, 3, 4, 5],
     }

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -925,7 +925,6 @@ def test_cse_as_struct_value_counts_20927() -> None:
     q = pl.LazyFrame({"x": [i for i in range(1, 6) for _ in range(i)]}).select(
         pl.struct("x").value_counts().struct.unnest()
     )
-    print(q.explain())
     assert q.collect().sort("count").to_dict(as_series=False) == {
         "x": [{"x": 1}, {"x": 2}, {"x": 3}, {"x": 4}, {"x": 5}],
         "count": [1, 2, 3, 4, 5],

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -1667,3 +1667,10 @@ def test_cspe_with_pushable_filters_scan_19479(tmp_path: Path) -> None:
 
     result = pl.concat([expr1, expr2])
     assert "CACHE[id:" not in result.explain()
+
+
+def test_cse_single_scalar_does_not_broadcast_28407() -> None:
+    e = pl.lit(5).abs()
+    q = pl.LazyFrame({"a": [1, 2, 3]}).select((e + e).alias("o"))
+
+    assert_frame_equal(q.collect(), pl.DataFrame({"o": 10}, schema={"o": pl.Int32}))


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/28407

Disable the CSE for an IR node if any common subexpr is non-column height.

TODO: We should still be able to CSE just the exprs that are column height.
