### PR TITLE
chore: Deduplicate the expression equality checks

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/equality.rs
+++ b/crates/polars-plan/src/plans/aexpr/equality.rs
@@ -2,6 +2,7 @@ use polars_core::prelude::SortOptions;
 use polars_utils::arena::{Arena, Node};
 
 use super::{AExpr, IRAggExpr};
+use crate::plans::ExprIR;
 
 impl AExpr {
     pub fn is_expr_equal_to(&self, other: &Self, arena: &Arena<AExpr>) -> bool {
@@ -21,7 +22,7 @@ impl AExpr {
         r_stack.clear();
 
         // Top-Level node.
-        if !self.is_expr_equal_top_level(other) {
+        if !self.is_expr_equal_shallow(other) {
             return false;
         }
         self.children_rev(l_stack);
@@ -38,7 +39,7 @@ impl AExpr {
             let l_expr = arena.get(l_node);
             let r_expr = arena.get(r_node);
 
-            if !l_expr.is_expr_equal_top_level(r_expr) {
+            if !l_expr.is_expr_equal_shallow(r_expr) {
                 return false;
             }
             l_expr.children_rev(l_stack);
@@ -48,14 +49,16 @@ impl AExpr {
         true
     }
 
-    pub fn is_expr_equal_top_level(&self, other: &Self) -> bool {
+    /// Compares expression enums at the top level, without recursing into inner/child expressions.
+    /// Compares input arity (so that we can do parallel tree traversal in higher-level functions).
+    /// Compares input names in cases where it matters (e.g. struct constructors and some functions).
+    pub fn is_expr_equal_shallow(&self, other: &Self) -> bool {
         if std::mem::discriminant(self) != std::mem::discriminant(other) {
             // Fast path: different kind of expression.
             return false;
         }
 
-        use crate::plans::ExprIR;
-        fn function_arguments_eq(
+        fn cmp_arg_counts_names(
             l_input: &[ExprIR],
             r_input: &[ExprIR],
             compare_names: bool,
@@ -63,13 +66,11 @@ impl AExpr {
             if l_input.len() != r_input.len() {
                 return false;
             }
-            if compare_names {
+            !compare_names || {
                 l_input
                     .iter()
                     .zip(r_input)
                     .all(|(l, r)| l.output_name_inner() == r.output_name_inner())
-            } else {
-                true
             }
         }
 
@@ -89,11 +90,11 @@ impl AExpr {
             E::Sort { expr: _, options: l_options } => matches!(other, E::Sort { expr: _, options: r_options } if l_options == r_options),
             E::Gather { expr: _, idx: _, returns_scalar: l_returns_scalar, null_on_oob: l_null_on_oob } => matches!(other, E::Gather { expr: _, idx: _, returns_scalar: r_returns_scalar, null_on_oob: r_null_on_oob } if l_returns_scalar == r_returns_scalar && l_null_on_oob == r_null_on_oob),
             E::SortBy { expr: _, by: l_by, sort_options: l_sort_options } => matches!(other, E::SortBy { expr: _, by: r_by, sort_options: r_sort_options } if l_by.len() == r_by.len() && l_sort_options == r_sort_options),
-            E::Agg(l_agg) => matches!(other, E::Agg(r_agg) if l_agg.is_agg_equal_top_level(r_agg)),
-            E::AnonymousAgg { input: l_input, fmt_str: l_fmt_str, function: l_function } => matches!(other, E::AnonymousAgg { input: r_input, fmt_str: r_fmt_str, function: r_function } if function_arguments_eq(l_input, r_input, true) && l_function == r_function && l_fmt_str == r_fmt_str),
-            E::AnonymousFunction { input: l_input, function: l_function, options: l_options, fmt_str: l_fmt_str } => matches!(other, E::AnonymousFunction { input: r_input, function: r_function, options: r_options, fmt_str: r_fmt_str } if function_arguments_eq(l_input, r_input, true) && l_function == r_function && l_options == r_options && l_fmt_str == r_fmt_str),
+            E::Agg(l_agg) => matches!(other, E::Agg(r_agg) if l_agg.is_agg_equal_shallow(r_agg)),
+            E::AnonymousAgg { input: l_input, fmt_str: l_fmt_str, function: l_function } => matches!(other, E::AnonymousAgg { input: r_input, fmt_str: r_fmt_str, function: r_function } if cmp_arg_counts_names(l_input, r_input, true) && l_function == r_function && l_fmt_str == r_fmt_str),
+            E::AnonymousFunction { input: l_input, function: l_function, options: l_options, fmt_str: l_fmt_str } => matches!(other, E::AnonymousFunction { input: r_input, function: r_function, options: r_options, fmt_str: r_fmt_str } if cmp_arg_counts_names(l_input, r_input, true) && l_function == r_function && l_options == r_options && l_fmt_str == r_fmt_str),
             E::Eval { expr: _, evaluation: _, variant: l_variant } => matches!(other, E::Eval { expr: _, evaluation: _, variant: r_variant } if l_variant == r_variant),
-            E::Function { input: l_input, function: l_function, options: l_options } => matches!(other, E::Function { input: r_input, function: r_function, options: r_options } if function_arguments_eq(l_input, r_input, l_function.output_depends_on_input_names()) && l_function == r_function && l_options == r_options),
+            E::Function { input: l_input, function: l_function, options: l_options } => matches!(other, E::Function { input: r_input, function: r_function, options: r_options } if cmp_arg_counts_names(l_input, r_input, l_function.output_depends_on_input_names()) && l_function == r_function && l_options == r_options),
             #[cfg(feature = "dynamic_group_by")]
             E::Rolling { function: _, index_column: _, period: l_period, offset: l_offset, closed_window: l_closed_window } => matches!(other, E::Rolling { function: _, index_column: _, period: r_period, offset: r_offset, closed_window: r_closed_window } if l_period == r_period && l_offset == r_offset && l_closed_window == r_closed_window),
             E::Over { function: _, partition_by: l_partition_by, order_by: l_order_by, mapping: l_mapping } => matches!(other, E::Over { function: _, partition_by: r_partition_by, order_by: r_order_by, mapping: r_mapping } if l_partition_by.len() == r_partition_by.len() && l_order_by.as_ref().map(|(_, v): &(Node, SortOptions)| v) == r_order_by.as_ref().map(|(_, v): &(Node, SortOptions)| v) && l_mapping == r_mapping),
@@ -105,7 +106,7 @@ impl AExpr {
             E::Slice { input: _, offset: _, length: _ } |
             E::Len => true,
             #[cfg(feature = "dtype-struct")]
-            E::StructEval { expr: _, evaluation: l_evaluation } => matches!(other, E::StructEval { expr: _, evaluation: r_evaluation } if function_arguments_eq(l_evaluation, r_evaluation, true))
+            E::StructEval { expr: _, evaluation: l_evaluation } => matches!(other, E::StructEval { expr: _, evaluation: r_evaluation } if cmp_arg_counts_names(l_evaluation, r_evaluation, true))
         };
 
         is_equal
@@ -113,7 +114,7 @@ impl AExpr {
 }
 
 impl IRAggExpr {
-    pub fn is_agg_equal_top_level(&self, other: &Self) -> bool {
+    pub fn is_agg_equal_shallow(&self, other: &Self) -> bool {
         if std::mem::discriminant(self) != std::mem::discriminant(other) {
             // Fast path: different kind of expression.
             return false;

--- a/crates/polars-plan/src/plans/aexpr/equality.rs
+++ b/crates/polars-plan/src/plans/aexpr/equality.rs
@@ -55,11 +55,22 @@ impl AExpr {
         }
 
         use crate::plans::ExprIR;
-        fn function_arguments_eq(l_input: &[ExprIR], r_input: &[ExprIR], compare_names: bool) -> bool {
-            if l_input.len() != r_input.len() { return false; }
+        fn function_arguments_eq(
+            l_input: &[ExprIR],
+            r_input: &[ExprIR],
+            compare_names: bool,
+        ) -> bool {
+            if l_input.len() != r_input.len() {
+                return false;
+            }
             if compare_names {
-                l_input.iter().zip(r_input).all(|(l, r)| l.output_name_inner() == r.output_name_inner())
-            } else { true }
+                l_input
+                    .iter()
+                    .zip(r_input)
+                    .all(|(l, r)| l.output_name_inner() == r.output_name_inner())
+            } else {
+                true
+            }
         }
 
         use AExpr as E;

--- a/crates/polars-plan/src/plans/aexpr/equality.rs
+++ b/crates/polars-plan/src/plans/aexpr/equality.rs
@@ -54,6 +54,14 @@ impl AExpr {
             return false;
         }
 
+        use crate::plans::ExprIR;
+        fn function_arguments_eq(l_input: &[ExprIR], r_input: &[ExprIR], compare_names: bool) -> bool {
+            if l_input.len() != r_input.len() { return false; }
+            if compare_names {
+                l_input.iter().zip(r_input).all(|(l, r)| l.output_name_inner() == r.output_name_inner())
+            } else { true }
+        }
+
         use AExpr as E;
 
         // @NOTE: Intentionally written as a match statement over only `self` as it forces the
@@ -68,13 +76,13 @@ impl AExpr {
             E::BinaryExpr { left: _, op: l_op, right: _ } => matches!(other, E::BinaryExpr { left: _, op: r_op, right: _ } if l_op == r_op),
             E::Cast { expr: _, dtype: l_dtype, options: l_options } => matches!(other, E::Cast { expr: _, dtype: r_dtype, options: r_options } if l_dtype == r_dtype && l_options == r_options),
             E::Sort { expr: _, options: l_options } => matches!(other, E::Sort { expr: _, options: r_options } if l_options == r_options),
-            E::Gather { expr: _, idx: l_idx, returns_scalar: l_returns_scalar, null_on_oob: l_null_on_oob } => matches!(other, E::Gather { expr: _, idx: r_idx, returns_scalar: r_returns_scalar, null_on_oob: r_null_on_oob } if l_idx == r_idx && l_returns_scalar == r_returns_scalar && l_null_on_oob == r_null_on_oob),
+            E::Gather { expr: _, idx: _, returns_scalar: l_returns_scalar, null_on_oob: l_null_on_oob } => matches!(other, E::Gather { expr: _, idx: _, returns_scalar: r_returns_scalar, null_on_oob: r_null_on_oob } if l_returns_scalar == r_returns_scalar && l_null_on_oob == r_null_on_oob),
             E::SortBy { expr: _, by: l_by, sort_options: l_sort_options } => matches!(other, E::SortBy { expr: _, by: r_by, sort_options: r_sort_options } if l_by.len() == r_by.len() && l_sort_options == r_sort_options),
             E::Agg(l_agg) => matches!(other, E::Agg(r_agg) if l_agg.is_agg_equal_top_level(r_agg)),
-            E::AnonymousAgg { input: input_l, fmt_str: fmt_str_l, function: function_l } => matches!(other, E::AnonymousAgg { input: input_r, fmt_str: fmt_str_r, function: function_r} if input_l == input_r && function_l == function_r && fmt_str_l == fmt_str_r),
-            E::AnonymousFunction { input: l_input, function: l_function, options: l_options, fmt_str: l_fmt_str } => matches!(other, E::AnonymousFunction { input: r_input, function: r_function, options: r_options, fmt_str: r_fmt_str } if l_input.len() == r_input.len() && l_function == r_function && l_options == r_options && l_fmt_str == r_fmt_str),
+            E::AnonymousAgg { input: l_input, fmt_str: l_fmt_str, function: l_function } => matches!(other, E::AnonymousAgg { input: r_input, fmt_str: r_fmt_str, function: r_function } if function_arguments_eq(l_input, r_input, true) && l_function == r_function && l_fmt_str == r_fmt_str),
+            E::AnonymousFunction { input: l_input, function: l_function, options: l_options, fmt_str: l_fmt_str } => matches!(other, E::AnonymousFunction { input: r_input, function: r_function, options: r_options, fmt_str: r_fmt_str } if function_arguments_eq(l_input, r_input, true) && l_function == r_function && l_options == r_options && l_fmt_str == r_fmt_str),
             E::Eval { expr: _, evaluation: _, variant: l_variant } => matches!(other, E::Eval { expr: _, evaluation: _, variant: r_variant } if l_variant == r_variant),
-            E::Function { input: l_input, function: l_function, options: l_options } => matches!(other, E::Function { input: r_input, function: r_function, options: r_options } if l_input.len() == r_input.len() && l_function == r_function && l_options == r_options),
+            E::Function { input: l_input, function: l_function, options: l_options } => matches!(other, E::Function { input: r_input, function: r_function, options: r_options } if function_arguments_eq(l_input, r_input, l_function.output_depends_on_input_names()) && l_function == r_function && l_options == r_options),
             #[cfg(feature = "dynamic_group_by")]
             E::Rolling { function: _, index_column: _, period: l_period, offset: l_offset, closed_window: l_closed_window } => matches!(other, E::Rolling { function: _, index_column: _, period: r_period, offset: r_offset, closed_window: r_closed_window } if l_period == r_period && l_offset == r_offset && l_closed_window == r_closed_window),
             E::Over { function: _, partition_by: l_partition_by, order_by: l_order_by, mapping: l_mapping } => matches!(other, E::Over { function: _, partition_by: r_partition_by, order_by: r_order_by, mapping: r_mapping } if l_partition_by.len() == r_partition_by.len() && l_order_by.as_ref().map(|(_, v): &(Node, SortOptions)| v) == r_order_by.as_ref().map(|(_, v): &(Node, SortOptions)| v) && l_mapping == r_mapping),
@@ -86,7 +94,7 @@ impl AExpr {
             E::Slice { input: _, offset: _, length: _ } |
             E::Len => true,
             #[cfg(feature = "dtype-struct")]
-            E::StructEval { expr: _, evaluation: _} => true
+            E::StructEval { expr: _, evaluation: l_evaluation } => matches!(other, E::StructEval { expr: _, evaluation: r_evaluation } if function_arguments_eq(l_evaluation, r_evaluation, true))
         };
 
         is_equal

--- a/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
@@ -468,6 +468,17 @@ impl IRFunctionExpr {
             _ => None,
         }
     }
+
+    // For these functions, the output dtype depends on the input names
+    pub(crate) fn output_depends_on_input_names(&self) -> bool {
+        match self {
+            #[cfg(feature = "dtype-struct")]
+            IRFunctionExpr::AsStruct
+            | IRFunctionExpr::CumReduceHorizontal { .. }
+            | IRFunctionExpr::CumFoldHorizontal { .. } => true,
+            _ => false,
+        }
+    }
 }
 
 pub struct FieldsMapper<'a> {

--- a/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
@@ -474,6 +474,7 @@ impl IRFunctionExpr {
         match self {
             #[cfg(feature = "dtype-struct")]
             IRFunctionExpr::AsStruct
+            | IRFunctionExpr::ValueCounts { .. }
             | IRFunctionExpr::CumReduceHorizontal { .. }
             | IRFunctionExpr::CumFoldHorizontal { .. } => true,
             _ => false,

--- a/crates/polars-plan/src/plans/aexpr/mod.rs
+++ b/crates/polars-plan/src/plans/aexpr/mod.rs
@@ -95,33 +95,6 @@ impl Hash for IRAggExpr {
     }
 }
 
-impl IRAggExpr {
-    pub(super) fn equal_nodes(&self, other: &IRAggExpr) -> bool {
-        use IRAggExpr::*;
-        match (self, other) {
-            (
-                Min {
-                    propagate_nans: l, ..
-                },
-                Min {
-                    propagate_nans: r, ..
-                },
-            ) => l == r,
-            (
-                Max {
-                    propagate_nans: l, ..
-                },
-                Max {
-                    propagate_nans: r, ..
-                },
-            ) => l == r,
-            (Std(_, l), Std(_, r)) => l == r,
-            (Var(_, l), Var(_, r)) => l == r,
-            _ => std::mem::discriminant(self) == std::mem::discriminant(other),
-        }
-    }
-}
-
 impl From<IRAggExpr> for GroupByMethod {
     fn from(value: IRAggExpr) -> Self {
         use IRAggExpr::*;

--- a/crates/polars-plan/src/plans/optimizer/cse/csee.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/csee.rs
@@ -1,11 +1,11 @@
 use std::hash::BuildHasher;
 
-use indexmap::map::RawEntryApiV1;
 use indexmap::map::raw_entry_v1::RawEntryMut;
-use polars_core::CHEAP_SERIES_HASH_LIMIT;
+use indexmap::map::RawEntryApiV1;
 use polars_core::config::verbose;
 use polars_core::prelude::PlIndexMap;
 use polars_core::schema::Schema;
+use polars_core::CHEAP_SERIES_HASH_LIMIT;
 use polars_error::PolarsResult;
 use polars_utils::aliases::PlFixedStateQuality;
 use polars_utils::arena::{Arena, Node};
@@ -20,9 +20,9 @@ use crate::plans::visitor::{
     IRNode, IRNodeArena, RewriteRecursion, RewritingVisitor, TreeWalker as _, VisitRecursion,
     Visitor,
 };
-use crate::plans::{AExpr, ExprIR, IR, IRBuilder, IRFunctionExpr, LiteralValue, OutputName};
-use crate::prelude::ProjectionOptions;
+use crate::plans::{AExpr, ExprIR, IRBuilder, IRFunctionExpr, LiteralValue, OutputName, IR};
 use crate::prelude::visitor::AexprNode;
+use crate::prelude::ProjectionOptions;
 
 type Accepted = Option<(VisitRecursion, bool)>;
 // Don't allow this node in a cse.
@@ -286,6 +286,9 @@ fn skip_pre_visit(ae: &AExpr, is_groupby: bool, element_wise_select_only: bool) 
         #[cfg(feature = "dynamic_group_by")]
         AExpr::Rolling { .. } => true,
         AExpr::Over { .. } => true,
+        #[cfg(feature = "dtype-struct")]
+        AExpr::StructEval { .. } => true,
+        AExpr::Eval { .. } => true,
         #[cfg(feature = "dtype-struct")]
         AExpr::Ternary { .. } => is_groupby,
         ae => {

--- a/crates/polars-plan/src/plans/optimizer/cse/csee.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/csee.rs
@@ -1,11 +1,11 @@
 use std::hash::BuildHasher;
 
-use indexmap::map::raw_entry_v1::RawEntryMut;
 use indexmap::map::RawEntryApiV1;
+use indexmap::map::raw_entry_v1::RawEntryMut;
+use polars_core::CHEAP_SERIES_HASH_LIMIT;
 use polars_core::config::verbose;
 use polars_core::prelude::PlIndexMap;
 use polars_core::schema::Schema;
-use polars_core::CHEAP_SERIES_HASH_LIMIT;
 use polars_error::PolarsResult;
 use polars_utils::aliases::PlFixedStateQuality;
 use polars_utils::arena::{Arena, Node};
@@ -20,9 +20,9 @@ use crate::plans::visitor::{
     IRNode, IRNodeArena, RewriteRecursion, RewritingVisitor, TreeWalker as _, VisitRecursion,
     Visitor,
 };
-use crate::plans::{AExpr, ExprIR, IRBuilder, IRFunctionExpr, LiteralValue, OutputName, IR};
-use crate::prelude::visitor::AexprNode;
+use crate::plans::{AExpr, ExprIR, IR, IRBuilder, IRFunctionExpr, LiteralValue, OutputName};
 use crate::prelude::ProjectionOptions;
+use crate::prelude::visitor::AexprNode;
 
 type Accepted = Option<(VisitRecursion, bool)>;
 // Don't allow this node in a cse.

--- a/crates/polars-plan/src/plans/optimizer/cse/csee.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/csee.rs
@@ -289,7 +289,6 @@ fn skip_pre_visit(ae: &AExpr, is_groupby: bool, element_wise_select_only: bool) 
         #[cfg(feature = "dtype-struct")]
         AExpr::StructEval { .. } => true,
         AExpr::Eval { .. } => true,
-        #[cfg(feature = "dtype-struct")]
         AExpr::Ternary { .. } => is_groupby,
         ae => {
             if element_wise_select_only {

--- a/crates/polars-plan/src/plans/visitor/expr.rs
+++ b/crates/polars-plan/src/plans/visitor/expr.rs
@@ -166,133 +166,6 @@ impl Debug for AExprArena<'_> {
     }
 }
 
-impl AExpr {
-    fn is_equal_node(&self, other: &Self) -> bool {
-        use AExpr::*;
-        match (self, other) {
-            (Column(l), Column(r)) => l == r,
-            (Literal(l), Literal(r)) => l == r,
-            #[cfg(feature = "dynamic_group_by")]
-            (
-                Rolling {
-                    function: _,
-                    index_column: _,
-                    period: l_period,
-                    offset: l_offset,
-                    closed_window: l_closed_window,
-                },
-                Rolling {
-                    function: _,
-                    index_column: _,
-                    period: r_period,
-                    offset: r_offset,
-                    closed_window: r_closed_window,
-                },
-            ) => l_period == r_period && l_offset == r_offset && l_closed_window == r_closed_window,
-            (Over { mapping: l, .. }, Over { mapping: r, .. }) => l == r,
-            (
-                Cast {
-                    options: strict_l,
-                    dtype: dtl,
-                    ..
-                },
-                Cast {
-                    options: strict_r,
-                    dtype: dtr,
-                    ..
-                },
-            ) => strict_l == strict_r && dtl == dtr,
-            (Sort { options: l, .. }, Sort { options: r, .. }) => l == r,
-            (Gather { .. }, Gather { .. })
-            | (Filter { .. }, Filter { .. })
-            | (Ternary { .. }, Ternary { .. })
-            | (Len, Len)
-            | (Slice { .. }, Slice { .. }) => true,
-            (
-                Explode {
-                    expr: _,
-                    options: l_options,
-                },
-                Explode {
-                    expr: _,
-                    options: r_options,
-                },
-            ) => l_options == r_options,
-            (
-                SortBy {
-                    sort_options: l_sort_options,
-                    ..
-                },
-                SortBy {
-                    sort_options: r_sort_options,
-                    ..
-                },
-            ) => l_sort_options == r_sort_options,
-            (Agg(l), Agg(r)) => l.equal_nodes(r),
-            (
-                Function {
-                    input: il,
-                    function: fl,
-                    options: ol,
-                },
-                Function {
-                    input: ir,
-                    function: fr,
-                    options: or,
-                },
-            ) => {
-                fl == fr && ol == or && {
-                    let mut all_same_name = true;
-                    for (l, r) in il.iter().zip(ir) {
-                        all_same_name &= l.output_name() == r.output_name()
-                    }
-
-                    all_same_name
-                }
-            },
-            (
-                AnonymousFunction {
-                    function: l1,
-                    options: l2,
-                    fmt_str: l3,
-                    input: _,
-                },
-                AnonymousFunction {
-                    function: r1,
-                    options: r2,
-                    fmt_str: r3,
-                    input: _,
-                },
-            ) => {
-                l2 == r2 && l3 == r3 && {
-                    use LazySerde as L;
-                    match (l1, r1) {
-                        // We only check the pointers, so this works for python
-                        // functions that are on the same address.
-                        (L::Deserialized(l0), L::Deserialized(r0)) => l0 == r0,
-                        (L::Bytes(l0), L::Bytes(r0)) => l0 == r0,
-                        (
-                            L::Named {
-                                name: l_name,
-                                payload: l_payload,
-                                value: l_value,
-                            },
-                            L::Named {
-                                name: r_name,
-                                payload: r_payload,
-                                value: r_value,
-                            },
-                        ) => l_name == r_name && l_payload == r_payload && l_value == r_value,
-                        _ => false,
-                    }
-                }
-            },
-            (BinaryExpr { op: l, .. }, BinaryExpr { op: r, .. }) => l == r,
-            _ => false,
-        }
-    }
-}
-
 impl<'a> AExprArena<'a> {
     pub fn new(node: Node, arena: &'a Arena<AExpr>) -> Self {
         Self { node, arena }
@@ -300,40 +173,11 @@ impl<'a> AExprArena<'a> {
     pub fn to_aexpr(&self) -> &'a AExpr {
         self.arena.get(self.node)
     }
-
-    // Check single node on equality
-    pub fn is_equal_single(&self, other: &Self) -> bool {
-        let self_ae = self.to_aexpr();
-        let other_ae = other.to_aexpr();
-        self_ae.is_equal_node(other_ae)
-    }
 }
 
 impl PartialEq for AExprArena<'_> {
     fn eq(&self, other: &Self) -> bool {
-        let mut scratch1 = unitvec![];
-        let mut scratch2 = unitvec![];
-
-        scratch1.push(self.node);
-        scratch2.push(other.node);
-
-        loop {
-            match (scratch1.pop(), scratch2.pop()) {
-                (Some(l), Some(r)) => {
-                    let l = Self::new(l, self.arena);
-                    let r = Self::new(r, other.arena);
-
-                    if !l.is_equal_single(&r) {
-                        return false;
-                    }
-
-                    l.to_aexpr().inputs_rev(&mut scratch1);
-                    r.to_aexpr().inputs_rev(&mut scratch2);
-                },
-                (None, None) => return true,
-                _ => return false,
-            }
-        }
+        self.to_aexpr().is_expr_equal_to(&other.to_aexpr(), self.arena)
     }
 }
 

--- a/crates/polars-plan/src/plans/visitor/expr.rs
+++ b/crates/polars-plan/src/plans/visitor/expr.rs
@@ -177,7 +177,8 @@ impl<'a> AExprArena<'a> {
 
 impl PartialEq for AExprArena<'_> {
     fn eq(&self, other: &Self) -> bool {
-        self.to_aexpr().is_expr_equal_to(&other.to_aexpr(), self.arena)
+        self.to_aexpr()
+            .is_expr_equal_to(&other.to_aexpr(), self.arena)
     }
 }
 

--- a/crates/polars-plan/src/plans/visitor/expr.rs
+++ b/crates/polars-plan/src/plans/visitor/expr.rs
@@ -178,7 +178,7 @@ impl<'a> AExprArena<'a> {
 impl PartialEq for AExprArena<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.to_aexpr()
-            .is_expr_equal_to(&other.to_aexpr(), self.arena)
+            .is_expr_equal_to(other.to_aexpr(), self.arena)
     }
 }
 

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -3705,10 +3705,14 @@ def test_join_filter_pushdown_full_join_rewrite() -> None:
     extract = _extract_plan_joins_and_filters(plan)
 
     assert extract[0] == 'LEFT PLAN ON: [col("a"), col("b")]'
-    assert ('col("b").is_not_null()' in extract[1]) or ('col("b").alias("b_right").is_not_null()' in extract[1])
+    assert ('col("b").is_not_null()' in extract[1]) or (
+        'col("b").alias("b_right").is_not_null()' in extract[1]
+    )
 
     assert extract[2] == 'RIGHT PLAN ON: [col("a"), col("b")]'
-    assert ('col("b").is_not_null()' in extract[3]) or ('col("b").alias("b_right").is_not_null()' in extract[3])
+    assert ('col("b").is_not_null()' in extract[3]) or (
+        'col("b").alias("b_right").is_not_null()' in extract[3]
+    )
 
     assert len(extract) == 4
 

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -3705,12 +3705,10 @@ def test_join_filter_pushdown_full_join_rewrite() -> None:
     extract = _extract_plan_joins_and_filters(plan)
 
     assert extract[0] == 'LEFT PLAN ON: [col("a"), col("b")]'
-    assert 'col("b").is_not_null()' in extract[1]
-    assert 'col("b").alias("b_right").is_not_null()' in extract[1]
+    assert ('col("b").is_not_null()' in extract[1]) or ('col("b").alias("b_right").is_not_null()' in extract[1])
 
     assert extract[2] == 'RIGHT PLAN ON: [col("a"), col("b")]'
-    assert 'col("b").is_not_null()' in extract[3]
-    assert 'col("b").alias("b_right").is_not_null()' in extract[3]
+    assert ('col("b").is_not_null()' in extract[3]) or ('col("b").alias("b_right").is_not_null()' in extract[3])
 
     assert len(extract) == 4
 


### PR DESCRIPTION
We used to have two similar but slightly different equality checks for expressions. One of them was much more limited and non-exhaustive, so I replaced it with a call to the exhaustive one. This uncovered a couple of small issues with it, so I fixed those as well (including their interaction with CSEE).