### PR TITLE
fix: Address 3VL issue with SQL `NOT IN` interaction with `NULL` values and joins

### DIFF
--- a/crates/polars-core/src/frame/horizontal.rs
+++ b/crates/polars-core/src/frame/horizontal.rs
@@ -79,11 +79,15 @@ pub fn concat_df_horizontal(
     strict: bool,
     unit_length_as_scalar: bool,
 ) -> PolarsResult<DataFrame> {
-    let output_height = dfs
-        .iter()
-        .map(|df| df.height())
-        .max()
-        .ok_or_else(|| polars_err!(ComputeError: "cannot concat empty dataframes"))?;
+    if dfs.is_empty() {
+        return Err(polars_err!(ComputeError: "cannot concat empty dataframes"));
+    }
+    let heights = || dfs.iter().map(|df| df.height());
+    let output_height = if unit_length_as_scalar {
+        heights().filter(|h| *h != 1).max().unwrap_or(1)
+    } else {
+        heights().max().unwrap()
+    };
 
     let owned_df;
 
@@ -177,8 +181,29 @@ mod tests {
             matches!(result, Err(PolarsError::ShapeMismatch(_))),
             "expected shape mismatch error"
         );
-
         // Ensure the DataFrame is not mutated in the error case.
         assert_eq!(df.width(), 0);
+    }
+
+    #[test]
+    fn test_scalar_broadcast_over_empty_frame() {
+        use crate::prelude::*;
+
+        // Unit-length "scalar" frame broadcast against zero-row frame should yield zero rows
+        let empty = df!["a" => Vec::<i64>::new()].unwrap();
+        let scalar = df!["b" => [1i64]].unwrap();
+        let out = super::concat_df_horizontal(&[empty, scalar], true, false, true).unwrap();
+        assert_eq!(out.height(), 0);
+        assert_eq!(out.width(), 2);
+
+        // Non-empty frame must still broadcast the scalar across all its rows
+        let non_empty = df!["a" => [10i64, 20, 30]].unwrap();
+        let scalar = df!["b" => [1i64]].unwrap();
+        let out = super::concat_df_horizontal(&[non_empty, scalar], true, false, true).unwrap();
+        assert_eq!(out.height(), 3);
+        assert_eq!(
+            out.column("b").unwrap().as_materialized_series(),
+            &Series::new("b".into(), [1i64, 1, 1])
+        );
     }
 }

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -44,6 +44,11 @@ pub fn to_sql_interface_err(err: impl Display) -> PolarsError {
     PolarsError::SQLInterface(err.to_string().into())
 }
 
+/// Represents a boolean-typed NULL literal (aka: SQL "UNKNOWN" truth value).
+fn sql_unknown() -> Expr {
+    lit(NULL).cast(DataType::Boolean)
+}
+
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, PartialEq, Debug, Eq, Hash)]
 /// Categorises the type of (allowed) subquery constraint
@@ -227,10 +232,18 @@ impl SQLExprVisitor<'_> {
                 negated,
             } => {
                 let expr = self.visit_expr(expr)?;
-                let elems = self
-                    .visit_array_expr(list, false, Some(&expr))?
-                    .implode(false);
-                let is_in = expr.is_in(elems, false);
+                let elems = self.visit_array_expr(list, false, Some(&expr))?;
+                let set_has_null = matches!(
+                    &elems,
+                    Expr::Literal(LiteralValue::Series(s)) if s.null_count() > 0
+                );
+                let membership = expr.is_in(elems.implode(false), false);
+                let is_in = if set_has_null {
+                    // Non-match against sets containing NULL is unknown, not FALSE
+                    membership.or(sql_unknown())
+                } else {
+                    membership
+                };
                 Ok(if *negated { is_in.not() } else { is_in })
             },
             SQLExpr::InSubquery {
@@ -1195,11 +1208,18 @@ impl SQLExprVisitor<'_> {
     ) -> PolarsResult<Expr> {
         let subquery_result = self.visit_subquery(subquery, SubqueryRestriction::SingleColumn)?;
         let expr = self.visit_expr(expr)?;
-        Ok(if negated {
-            expr.is_in(subquery_result, false).not()
-        } else {
-            expr.is_in(subquery_result, false)
-        })
+        let Expr::SubPlan(_, cols) = &subquery_result else {
+            unreachable!("SingleColumn subquery must lower to a SubPlan");
+        };
+        let value_set = col(cols[0].0.clone()).first();
+        let membership = expr.is_in(subquery_result, false);
+        let set_has_null = value_set.clone().list().contains(lit(NULL), true);
+        let set_is_empty = value_set.list().len().eq(lit(0u32));
+        let is_in = when(set_is_empty)
+            .then(lit(false))
+            .otherwise(membership.or(set_has_null.and(sql_unknown())));
+
+        Ok(if negated { is_in.not() } else { is_in })
     }
 
     /// Visit `CASE` control flow expression.

--- a/crates/polars-sql/src/subquery.rs
+++ b/crates/polars-sql/src/subquery.rs
@@ -8,6 +8,8 @@ use polars_lazy::prelude::*;
 use polars_plan::utils::{expr_to_leaf_column_names_iter, has_expr};
 #[cfg(feature = "semi_anti_join")]
 use polars_utils::aliases::PlHashSet;
+#[cfg(feature = "semi_anti_join")]
+use polars_utils::unique_column_name;
 use sqlparser::ast::{BinaryOperator as SQLBinaryOperator, Expr as SQLExpr, Query};
 #[cfg(feature = "semi_anti_join")]
 use sqlparser::ast::{Distinct, GroupByExpr, Select, SelectItem, SetExpr, TableWithJoins};
@@ -216,19 +218,30 @@ impl SQLContext {
             },
             None => SubqueryConjuncts::default(),
         };
+
+        // Correlation keys for the "NOT IN" 3VL correction
+        let corr_outer = left_on.clone();
+        let corr_inner = right_on.clone();
         left_on.insert(0, left_key.clone());
-        right_on.insert(0, right_key);
-        let joined =
-            ctx.finish_decorrelated_join(lf, inner_lf, left_on, right_on, local_filters, anti);
-        // `lhs NOT IN (...)` is NULL (and so excludes the row) when `lhs` is
-        // NULL, but an anti-join keeps null keys since they match nothing; drop
-        // them. In `RemoveTrue` mode a NULL membership test keeps the row, so the
-        // anti join is already exact.
-        Ok(Some(if anti && filter_mode == FilterMode::KeepTrue {
-            joined.filter(left_key.is_not_null())
-        } else {
-            joined
-        }))
+        right_on.insert(0, right_key.clone());
+
+        // Inline, so filtered inner frame can be reused for the correction
+        let inner_lf = local_filters.into_iter().fold(inner_lf, LazyFrame::filter);
+        inner_lf.set_cached_arena(ctx.lp_arena, ctx.expr_arena);
+        let joined = build_semi_anti_join(lf, inner_lf.clone(), left_on, right_on, anti);
+
+        // Only `KeepTrue` "NOT IN" needs 3VL correction.
+        if !(anti && filter_mode == FilterMode::KeepTrue) {
+            return Ok(Some(joined));
+        }
+        Ok(Some(refine_not_in_anti_join(
+            joined,
+            inner_lf,
+            &left_key,
+            &right_key,
+            &corr_outer,
+            &corr_inner,
+        )))
     }
 
     // Apply the local filters to the inner relation, hand this (isolated, now
@@ -247,15 +260,7 @@ impl SQLContext {
     ) -> LazyFrame {
         let inner_lf = local_filters.into_iter().fold(inner_lf, LazyFrame::filter);
         inner_lf.set_cached_arena(self.lp_arena, self.expr_arena);
-
-        let join_type = if anti { JoinType::Anti } else { JoinType::Semi };
-        lf.clone()
-            .join_builder()
-            .with(inner_lf)
-            .left_on(left_on)
-            .right_on(right_on)
-            .how(join_type)
-            .finish()
+        build_semi_anti_join(lf, inner_lf, left_on, right_on, anti)
     }
 
     // Resolve the subquery's FROM (a single relation, possibly with joins) into
@@ -359,6 +364,78 @@ impl SQLContext {
     ) -> PolarsResult<Option<LazyFrame>> {
         Ok(None)
     }
+}
+
+// Semi/anti join the outer frame against the (filtered, arena-cached) inner.
+#[cfg(feature = "semi_anti_join")]
+fn build_semi_anti_join(
+    lf: &LazyFrame,
+    inner_lf: LazyFrame,
+    left_on: Vec<Expr>,
+    right_on: Vec<Expr>,
+    anti: bool,
+) -> LazyFrame {
+    let join_type = if anti { JoinType::Anti } else { JoinType::Semi };
+    lf.clone()
+        .join_builder()
+        .with(inner_lf)
+        .left_on(left_on)
+        .right_on(right_on)
+        .how(join_type)
+        .finish()
+}
+
+// Account for 3VL interaction with NULL values
+#[cfg(feature = "semi_anti_join")]
+fn refine_not_in_anti_join(
+    joined: LazyFrame,
+    inner_lf: LazyFrame,
+    left_key: &Expr,
+    right_key: &Expr,
+    corr_outer: &[Expr],
+    corr_inner: &[Expr],
+) -> LazyFrame {
+    let flag_name = unique_column_name();
+    let has_null = right_key.clone().is_null().any(true);
+
+    let with_flag = if corr_inner.is_empty() {
+        // Uncorrelated: one flag cross-joined onto every row; empty set -> NULL
+        // flag, keeping it distinct from a NULL-free set.
+        let flag = when(len().eq(lit(0u32)))
+            .then(lit(NULL).cast(DataType::Boolean))
+            .otherwise(has_null);
+        let stats = inner_lf.select([flag.alias(flag_name.clone())]);
+        joined
+            .join_builder()
+            .with(stats)
+            .how(JoinType::Cross)
+            .finish()
+    } else {
+        // Correlated: one flag per group; the left join leaves it NULL for
+        // groups with no inner rows (an empty set).
+        let flags = inner_lf
+            .group_by(corr_inner)
+            .agg([has_null.alias(flag_name.clone())]);
+        joined
+            .join_builder()
+            .with(flags)
+            .left_on(corr_outer)
+            .right_on(corr_inner)
+            .how(JoinType::Left)
+            .finish()
+    };
+
+    let flag = col(flag_name.clone());
+    let keep = when(flag.clone().is_null())
+        .then(lit(true)) // empty set
+        .when(flag) // set has a NULL
+        .then(lit(false))
+        .otherwise(left_key.clone().is_not_null());
+
+    with_flag.filter(keep).drop(Selector::ByName {
+        names: [flag_name].into(),
+        strict: true,
+    })
 }
 
 /// An iterator over all the minterms in an SQL boolean expression: the terms

--- a/crates/polars-sql/src/subquery.rs
+++ b/crates/polars-sql/src/subquery.rs
@@ -395,47 +395,59 @@ fn refine_not_in_anti_join(
     corr_outer: &[Expr],
     corr_inner: &[Expr],
 ) -> LazyFrame {
-    let flag_name = unique_column_name();
-    let has_null = right_key.clone().is_null().any(true);
-
-    let with_flag = if corr_inner.is_empty() {
-        // Uncorrelated: one flag cross-joined onto every row; empty set -> NULL
-        // flag, keeping it distinct from a NULL-free set.
+    if corr_inner.is_empty() {
+        // Uncorrelated
+        let flag_name = unique_column_name();
         let flag = when(len().eq(lit(0u32)))
             .then(lit(NULL).cast(DataType::Boolean))
-            .otherwise(has_null);
-        let stats = inner_lf.select([flag.alias(flag_name.clone())]);
-        joined
+            .otherwise(right_key.clone().is_null().any(true))
+            .alias(flag_name.clone());
+        let keep = when(col(flag_name.clone()).is_null())
+            .then(lit(true)) // empty set
+            .when(col(flag_name.clone())) // set has a NULL
+            .then(lit(false))
+            .otherwise(left_key.clone().is_not_null());
+
+        return joined
             .join_builder()
-            .with(stats)
+            .with(inner_lf.select([flag]))
             .how(JoinType::Cross)
             .finish()
-    } else {
-        // Correlated: one flag per group; the left join leaves it NULL for
-        // groups with no inner rows (an empty set).
-        let flags = inner_lf
-            .group_by(corr_inner)
-            .agg([has_null.alias(flag_name.clone())]);
-        joined
-            .join_builder()
-            .with(flags)
+            .filter(keep)
+            .drop(Selector::ByName {
+                names: [flag_name].into(),
+                strict: true,
+            });
+    }
+
+    // Correlated
+    let corr_keys = |lf: LazyFrame| lf.select(corr_inner).unique(None, UniqueKeepStrategy::Any);
+    let exclude_groups = |rows: LazyFrame, groups: LazyFrame| {
+        rows.join_builder()
+            .with(groups)
             .left_on(corr_outer)
             .right_on(corr_inner)
-            .how(JoinType::Left)
+            .how(JoinType::Anti)
             .finish()
     };
+    let kept_non_null = exclude_groups(
+        joined.clone().filter(left_key.clone().is_not_null()),
+        corr_keys(inner_lf.clone().filter(right_key.clone().is_null())),
+    );
+    let kept_null = exclude_groups(
+        joined.filter(left_key.clone().is_null()),
+        corr_keys(inner_lf),
+    );
 
-    let flag = col(flag_name.clone());
-    let keep = when(flag.clone().is_null())
-        .then(lit(true)) // empty set
-        .when(flag) // set has a NULL
-        .then(lit(false))
-        .otherwise(left_key.clone().is_not_null());
-
-    with_flag.filter(keep).drop(Selector::ByName {
-        names: [flag_name].into(),
-        strict: true,
-    })
+    concat(
+        [kept_non_null, kept_null],
+        UnionArgs {
+            rechunk: false,
+            parallel: true,
+            ..Default::default()
+        },
+    )
+    .expect("'NOT IN' 3VL union has identical schemas")
 }
 
 /// An iterator over all the minterms in an SQL boolean expression: the terms

--- a/py-polars/tests/unit/sql/test_operators.py
+++ b/py-polars/tests/unit/sql/test_operators.py
@@ -117,6 +117,46 @@ def test_in_not_in(in_clause: str) -> None:
     }
 
 
+@pytest.mark.parametrize(
+    ("predicate", "expected"),
+    [
+        # Value set contains NULL
+        ("a IN (1, NULL)", [1]),
+        ("a NOT IN (1, NULL)", []),
+        ("a IN (2, NULL)", [2]),
+        ("a NOT IN (2, NULL)", []),
+        # NULL-free value set
+        ("a IN (1, 2)", [1, 2]),
+        ("a NOT IN (1)", [2, 3]),
+    ],
+)
+def test_in_not_in_null_3vl(predicate: str, expected: list[int]) -> None:
+    # See https://github.com/pola-rs/polars/issues/28433
+    df = pl.DataFrame({"a": [1, 2, None, 3]}, schema={"a": pl.Int64})
+    res = df.sql(f'SELECT a FROM self WHERE {predicate} ORDER BY "a"')
+    assert res["a"].to_list() == expected
+
+
+def test_not_in_null_subquery_3vl() -> None:
+    t = pl.DataFrame({"a": [1, 2, None, 3]}, schema={"a": pl.Int64})
+    u = pl.DataFrame({"b": [1, None, 4]}, schema={"b": pl.Int64})
+    u_no_null = pl.DataFrame({"b": [1, 4]}, schema={"b": pl.Int64})
+
+    def keys(query: str) -> list[int | None]:
+        return ctx.execute(query, eager=True)["a"].to_list()
+
+    with pl.SQLContext(t=t, u=u, u_no_null=u_no_null) as ctx:
+        assert keys("SELECT a FROM t WHERE a NOT IN (SELECT b FROM u)") == []
+        assert keys("SELECT a FROM t WHERE a IN (SELECT b FROM u) ORDER BY a") == [1]
+        assert keys(
+            "SELECT a FROM t WHERE a NOT IN (SELECT b FROM u_no_null) ORDER BY a"
+        ) == [2, 3]
+        assert keys(
+            "SELECT a FROM t WHERE a NOT IN (SELECT b FROM u WHERE b > 100)"
+            " ORDER BY a NULLS FIRST"
+        ) == [None, 1, 2, 3]
+
+
 def test_is_between(foods_ipc_path: Path) -> None:
     lf = pl.scan_ipc(foods_ipc_path)
 

--- a/py-polars/tests/unit/sql/test_subqueries.py
+++ b/py-polars/tests/unit/sql/test_subqueries.py
@@ -368,12 +368,24 @@ def _subquery_ctx() -> pl.SQLContext[pl.LazyFrame]:
             "ANTI JOIN",
             [(1, 10), (2, 10)],
         ),
-        # NOT IN must drop a NULL key (its membership test is NULL, not true;
-        # the bare anti-join would keep it), while a NULL in the haystack must
-        # not poison the other rows (polars' is_in semantics, not strict SQL).
+        # NOT IN should follow SQL three-valued logic (ref: issue #28433).
         (
             "SELECT c_custkey FROM customer"
             " WHERE c_custkey NOT IN (SELECT o_custkey FROM orders)",
+            "ANTI JOIN",
+            [],
+        ),
+        # NULL-free value set: unmatched keys are kept, but NULL outer key is dropped.
+        (
+            "SELECT c_custkey FROM customer"
+            " WHERE c_custkey NOT IN (SELECT o_custkey FROM orders WHERE o_custkey IS NOT NULL)",
+            "ANTI JOIN",
+            [1, 4],
+        ),
+        # Correlated NOT IN applies 3VL per correlation group.
+        (
+            "SELECT c_custkey FROM customer c"
+            " WHERE c_custkey NOT IN (SELECT o_custkey FROM orders o WHERE o.a = c.a)",
             "ANTI JOIN",
             [1, 4],
         ),


### PR DESCRIPTION
Fixes #28433.

Ensure the SQL interface respects 3VL behaviour consistently; also, unit-length scalar frame broadcast against zero-row frame should yield zero rows.