### PR TITLE
feat: Add selected predicate Parquet decoding

### DIFF
--- a/crates/polars-parquet/src/arrow/read/deserialize/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/mod.rs
@@ -11,6 +11,8 @@ mod nested_utils;
 mod null;
 mod primitive;
 mod simple;
+#[cfg(test)]
+mod tests;
 mod utils;
 
 use std::io::Cursor;
@@ -24,7 +26,7 @@ use simple::page_iter_to_array;
 
 pub use self::nested_utils::{InitNested, NestedState, init_nested};
 pub use self::utils::filter::{Filter, PredicateFilter};
-use self::utils::freeze_validity;
+use self::utils::{DecoderFilter, freeze_validity};
 use super::*;
 use crate::parquet::error::ParquetResult;
 use crate::parquet::read::get_page_iterator as _get_page_iterator;
@@ -205,4 +207,36 @@ pub fn column_iter_to_arrays(
     let (_, array, pred_true_mask) =
         columns_to_iter_recursive(columns, types, field, vec![], filter)?;
     Ok((array, pred_true_mask))
+}
+
+/// Decodes non-nested Parquet column and evaluates `predicate` only for rows
+/// selected by `input_selection`.
+///
+/// Returned predicate mask uses original column coordinates, so it can be
+/// passed as input selection when decoding another predicate column.
+pub fn column_iter_to_arrays_selected(
+    mut columns: Vec<BasicDecompressor>,
+    mut types: Vec<&PrimitiveType>,
+    field: Field,
+    predicate: PredicateFilter,
+    input_selection: Bitmap,
+) -> PolarsResult<(Vec<Box<dyn Array>>, Bitmap)> {
+    if columns.len() != 1 || types.len() != 1 || !is_primitive(&field.dtype) {
+        return Err(ParquetError::InvalidParameter(
+            "selected predicate decoding requires one non-nested Parquet column".into(),
+        )
+        .into());
+    }
+
+    let (_, arrays, pred_true_mask) = page_iter_to_array(
+        columns.pop().unwrap(),
+        types.pop().unwrap(),
+        field,
+        DecoderFilter::SelectedPredicate {
+            predicate,
+            input_selection,
+        },
+        None,
+    )?;
+    Ok((arrays, pred_true_mask))
 }

--- a/crates/polars-parquet/src/arrow/read/deserialize/simple.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/simple.rs
@@ -10,7 +10,6 @@ use polars_compute::cast::CastOptionsImpl;
 use polars_utils::float16::pf16;
 use polars_utils::pl_str::PlSmallStr;
 
-use super::utils::filter::Filter;
 use super::{
     BasicDecompressor, InitNested, NestedState, boolean, fixed_size_binary, null, primitive,
 };
@@ -21,19 +20,24 @@ use crate::parquet::schema::types::{
 use crate::parquet::types::int96_to_i64_ns;
 use crate::read::ParquetError;
 use crate::read::deserialize::categorical::CategoricalDecoder;
-use crate::read::deserialize::utils::PageDecoder;
+use crate::read::deserialize::utils::{DecoderFilter, PageDecoder};
 use crate::read::deserialize::{binary, binview};
 
 /// An iterator adapter that maps an iterator of Pages a boxed [`Array`] of [`ArrowDataType`]
 /// `dtype` with a maximum of `num_rows` elements.
-pub fn page_iter_to_array(
+pub fn page_iter_to_array<F>(
     pages: BasicDecompressor,
     type_: &PrimitiveType,
     field: Field,
-    filter: Option<Filter>,
+    filter: F,
     init_nested: Option<Vec<InitNested>>,
-) -> ParquetResult<(Option<NestedState>, Vec<Box<dyn Array>>, Bitmap)> {
+) -> ParquetResult<(Option<NestedState>, Vec<Box<dyn Array>>, Bitmap)>
+where
+    F: Into<DecoderFilter>,
+{
     use ArrowDataType::*;
+
+    let filter = filter.into();
 
     let physical_type = &type_.physical_type;
     let logical_type = &type_.logical_type;
@@ -718,7 +722,7 @@ fn timestamp(
     physical_type: &PhysicalType,
     logical_type: &Option<PrimitiveLogicalType>,
     dtype: ArrowDataType,
-    filter: Option<Filter>,
+    filter: DecoderFilter,
     time_unit: TimeUnit,
     nested: Option<Vec<InitNested>>,
 ) -> ParquetResult<(Option<NestedState>, Vec<Box<dyn Array>>, Bitmap)> {

--- a/crates/polars-parquet/src/arrow/read/deserialize/tests.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/tests.rs
@@ -1,0 +1,292 @@
+use std::io::Cursor;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use arrow::array::{Array, PrimitiveArray};
+use arrow::bitmap::{Bitmap, BitmapBuilder};
+use arrow::datatypes::{ArrowDataType, ArrowSchema, Field};
+use arrow::record_batch::RecordBatchT;
+use polars_buffer::Buffer;
+use polars_error::{PolarsError, PolarsResult};
+
+use super::{Filter, PredicateFilter, column_iter_to_arrays, column_iter_to_arrays_selected};
+use crate::arrow::read::expr::{ParquetColumnExpr, SpecializedParquetColumnExpr};
+use crate::parquet::read::{BasicDecompressor, PageReader, read_metadata};
+use crate::write::{
+    CompressionOptions, Encoding, FileWriter, RowGroupIterator, StatisticsOptions, Version,
+    WriteOptions,
+};
+
+struct GreaterThan {
+    threshold: i32,
+    null_matches: bool,
+    evaluated_rows: Option<Arc<AtomicUsize>>,
+}
+
+impl ParquetColumnExpr for GreaterThan {
+    fn evaluate_mut(&self, values: &dyn Array, mask: &mut BitmapBuilder) {
+        let values = values
+            .as_any()
+            .downcast_ref::<PrimitiveArray<i32>>()
+            .unwrap();
+        if let Some(evaluated_rows) = self.evaluated_rows.as_ref() {
+            evaluated_rows.fetch_add(values.len(), Ordering::Relaxed);
+        }
+        mask.reserve(values.len());
+        for value in values.values().iter() {
+            mask.push(*value > self.threshold);
+        }
+    }
+
+    fn evaluate_null(&self) -> bool {
+        self.null_matches
+    }
+
+    fn as_specialized(&self) -> Option<&SpecializedParquetColumnExpr> {
+        None
+    }
+}
+
+fn write_primitive(values: PrimitiveArray<i32>) -> PolarsResult<Vec<u8>> {
+    let field = Field::new("value".into(), ArrowDataType::Int32, true);
+    let schema = ArrowSchema::from_iter([field]);
+    let options = WriteOptions {
+        statistics: StatisticsOptions::full(),
+        compression: CompressionOptions::Uncompressed,
+        version: Version::V1,
+        data_page_size: Some(256),
+    };
+    let batch = RecordBatchT::try_new(
+        values.len(),
+        Arc::new(schema.clone()),
+        vec![Box::new(values) as Box<dyn Array>],
+    )?;
+    let row_groups = RowGroupIterator::try_new(
+        std::iter::once(Ok::<_, PolarsError>(batch)),
+        &schema,
+        options,
+        Buffer::from_iter([vec![Encoding::Plain]]),
+    )?;
+
+    let mut writer = FileWriter::try_new(Cursor::new(Vec::new()), schema, options)?;
+    for row_group in row_groups {
+        writer.write(u64::MAX, row_group?)?;
+    }
+    writer.end(None)?;
+    Ok(writer.into_inner().into_inner())
+}
+
+fn decode_primitive(
+    data: Vec<u8>,
+    predicate: PredicateFilter,
+    input_selection: Option<Bitmap>,
+) -> PolarsResult<(Vec<Option<i32>>, Bitmap)> {
+    let mut reader = Cursor::new(&data);
+    let metadata = read_metadata(&mut reader)?;
+    let column = &metadata.row_groups[0].parquet_columns()[0];
+    let byte_range = column.byte_range();
+    let column_data =
+        Buffer::from_vec(data[byte_range.start as usize..byte_range.end as usize].to_vec());
+    let max_page_size = column_data.len() * 2 + 1024;
+    let pages = PageReader::new(Cursor::new(column_data), column, vec![], max_page_size);
+    let decompressor = BasicDecompressor::new(pages, vec![]);
+    let field = Field::new("value".into(), ArrowDataType::Int32, true);
+    let columns = vec![decompressor];
+    let types = vec![&column.descriptor().descriptor.primitive_type];
+    let (arrays, mask) = match input_selection {
+        Some(input_selection) => {
+            column_iter_to_arrays_selected(columns, types, field, predicate, input_selection)?
+        },
+        None => column_iter_to_arrays(columns, types, field, Some(Filter::Predicate(predicate)))?,
+    };
+    let values = arrays
+        .iter()
+        .flat_map(|array| {
+            array
+                .as_any()
+                .downcast_ref::<PrimitiveArray<i32>>()
+                .unwrap()
+                .iter()
+                .map(|value| value.copied())
+        })
+        .collect();
+    Ok((values, mask))
+}
+
+fn input_values(len: usize) -> PrimitiveArray<i32> {
+    PrimitiveArray::from_iter((0..len).map(|index| (index % 11 != 0).then_some(index as i32)))
+}
+
+#[test]
+fn selected_predicate_refines_mask_in_column_coordinates() -> PolarsResult<()> {
+    let len = 1_024;
+    let input_selection = Bitmap::from_iter((0..len).map(|index| index % 3 == 0));
+    let evaluated_rows = Arc::new(AtomicUsize::new(0));
+    let predicate = PredicateFilter {
+        predicate: Arc::new(GreaterThan {
+            threshold: 500,
+            null_matches: false,
+            evaluated_rows: Some(evaluated_rows.clone()),
+        }),
+        include_values: true,
+    };
+
+    let (values, mask) = decode_primitive(
+        write_primitive(input_values(len))?,
+        predicate,
+        Some(input_selection.clone()),
+    )?;
+    let expected_mask = Bitmap::from_iter(
+        (0..len).map(|index| input_selection.get_bit(index) && index % 11 != 0 && index > 500),
+    );
+    let expected_values = (0..len)
+        .filter(|&index| expected_mask.get_bit(index))
+        .map(|index| Some(index as i32))
+        .collect::<Vec<_>>();
+
+    assert_eq!(mask, expected_mask);
+    assert_eq!(values, expected_values);
+    assert_eq!(
+        evaluated_rows.load(Ordering::Relaxed),
+        input_selection.set_bits(),
+    );
+    Ok(())
+}
+
+#[test]
+fn selected_predicate_respects_matching_nulls() -> PolarsResult<()> {
+    let len = 1_024;
+    let input_selection = Bitmap::from_iter((0..len).map(|index| index % 5 != 0));
+    let predicate = PredicateFilter {
+        predicate: Arc::new(GreaterThan {
+            threshold: 900,
+            null_matches: true,
+            evaluated_rows: None,
+        }),
+        include_values: true,
+    };
+
+    let (values, mask) = decode_primitive(
+        write_primitive(input_values(len))?,
+        predicate,
+        Some(input_selection.clone()),
+    )?;
+    let expected_mask = Bitmap::from_iter(
+        (0..len).map(|index| input_selection.get_bit(index) && (index % 11 == 0 || index > 900)),
+    );
+    let expected_values = (0..len)
+        .filter(|&index| expected_mask.get_bit(index))
+        .map(|index| (index % 11 != 0).then_some(index as i32))
+        .collect::<Vec<_>>();
+
+    assert_eq!(mask, expected_mask);
+    assert_eq!(values, expected_values);
+    Ok(())
+}
+
+#[test]
+fn selected_predicate_can_return_only_the_mask() -> PolarsResult<()> {
+    let len = 1_024;
+    let input_selection = Bitmap::from_iter((0..len).map(|index| index % 7 == 0));
+    let predicate = PredicateFilter {
+        predicate: Arc::new(GreaterThan {
+            threshold: 700,
+            null_matches: false,
+            evaluated_rows: None,
+        }),
+        include_values: false,
+    };
+
+    let (values, mask) = decode_primitive(
+        write_primitive(input_values(len))?,
+        predicate,
+        Some(input_selection.clone()),
+    )?;
+    let expected_mask = Bitmap::from_iter(
+        (0..len).map(|index| input_selection.get_bit(index) && index % 11 != 0 && index > 700),
+    );
+
+    assert_eq!(mask, expected_mask);
+    assert!(values.is_empty());
+    Ok(())
+}
+
+#[test]
+fn selected_predicate_handles_an_empty_selection() -> PolarsResult<()> {
+    let len = 1_024;
+    let predicate = PredicateFilter {
+        predicate: Arc::new(GreaterThan {
+            threshold: 0,
+            null_matches: true,
+            evaluated_rows: None,
+        }),
+        include_values: true,
+    };
+
+    let (values, mask) = decode_primitive(
+        write_primitive(input_values(len))?,
+        predicate,
+        Some(Bitmap::new_zeroed(len)),
+    )?;
+
+    assert_eq!(mask, Bitmap::new_zeroed(len));
+    assert!(values.is_empty());
+    Ok(())
+}
+
+#[test]
+fn selected_predicate_dense_selection_matches_unselected_decode() -> PolarsResult<()> {
+    let len = 1_024;
+    let data = write_primitive(input_values(len))?;
+    let predicate = || GreaterThan {
+        threshold: 500,
+        null_matches: true,
+        evaluated_rows: None,
+    };
+    let (expected_values, expected_mask) = decode_primitive(
+        data.clone(),
+        PredicateFilter {
+            predicate: Arc::new(predicate()),
+            include_values: true,
+        },
+        None,
+    )?;
+    let (values, mask) = decode_primitive(
+        data,
+        PredicateFilter {
+            predicate: Arc::new(predicate()),
+            include_values: true,
+        },
+        Some(Bitmap::new_with_value(true, len)),
+    )?;
+
+    assert_eq!(mask, expected_mask);
+    assert_eq!(values, expected_values);
+    Ok(())
+}
+
+#[test]
+fn selected_predicate_rejects_wrong_selection_length() -> PolarsResult<()> {
+    let len = 1_024;
+    let predicate = PredicateFilter {
+        predicate: Arc::new(GreaterThan {
+            threshold: 500,
+            null_matches: false,
+            evaluated_rows: None,
+        }),
+        include_values: true,
+    };
+
+    let error = decode_primitive(
+        write_primitive(input_values(len))?,
+        predicate,
+        Some(Bitmap::new_with_value(true, len - 1)),
+    )
+    .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("input selection has length 1023")
+    );
+    Ok(())
+}

--- a/crates/polars-parquet/src/arrow/read/deserialize/tests.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/tests.rs
@@ -117,6 +117,22 @@ fn input_values(len: usize) -> PrimitiveArray<i32> {
     PrimitiveArray::from_iter((0..len).map(|index| (index % 11 != 0).then_some(index as i32)))
 }
 
+fn primitive_page_lengths(data: &[u8]) -> PolarsResult<Vec<usize>> {
+    let mut reader = Cursor::new(data);
+    let metadata = read_metadata(&mut reader)?;
+    let column = &metadata.row_groups[0].parquet_columns()[0];
+    let byte_range = column.byte_range();
+    let column_data =
+        Buffer::from_vec(data[byte_range.start as usize..byte_range.end as usize].to_vec());
+    let max_page_size = column_data.len() * 2 + 1024;
+    let pages = PageReader::new(Cursor::new(column_data), column, vec![], max_page_size);
+    let mut decompressor = BasicDecompressor::new(pages, vec![]);
+    decompressor.read_dict_page()?;
+    decompressor
+        .map(|page| -> PolarsResult<_> { Ok(page?.num_values()) })
+        .collect()
+}
+
 #[test]
 fn selected_predicate_refines_mask_in_column_coordinates() -> PolarsResult<()> {
     let len = 1_024;
@@ -185,7 +201,7 @@ fn selected_predicate_respects_matching_nulls() -> PolarsResult<()> {
 }
 
 #[test]
-fn selected_predicate_can_return_only_the_mask() -> PolarsResult<()> {
+fn selected_predicate_mask_only() -> PolarsResult<()> {
     let len = 1_024;
     let input_selection = Bitmap::from_iter((0..len).map(|index| index % 7 == 0));
     let predicate = PredicateFilter {
@@ -212,7 +228,7 @@ fn selected_predicate_can_return_only_the_mask() -> PolarsResult<()> {
 }
 
 #[test]
-fn selected_predicate_handles_an_empty_selection() -> PolarsResult<()> {
+fn selected_predicate_handles_empty_selection() -> PolarsResult<()> {
     let len = 1_024;
     let predicate = PredicateFilter {
         predicate: Arc::new(GreaterThan {
@@ -262,6 +278,45 @@ fn selected_predicate_dense_selection_matches_unselected_decode() -> PolarsResul
 
     assert_eq!(mask, expected_mask);
     assert_eq!(values, expected_values);
+    Ok(())
+}
+
+#[test]
+fn selected_predicate_handles_adjacent_empty_and_full_pages() -> PolarsResult<()> {
+    let len = 4_096;
+    let data = write_primitive(input_values(len))?;
+    let page_lengths = primitive_page_lengths(&data)?;
+    assert!(page_lengths.len() >= 2);
+
+    for selected_page in [0, 1] {
+        let selected_start = page_lengths[..selected_page].iter().sum::<usize>();
+        let selected_end = selected_start + page_lengths[selected_page];
+        let input_selection = Bitmap::from_iter(
+            (0..len).map(|index| (selected_start..selected_end).contains(&index)),
+        );
+        let evaluated_rows = Arc::new(AtomicUsize::new(0));
+        let predicate = PredicateFilter {
+            predicate: Arc::new(GreaterThan {
+                threshold: -1,
+                null_matches: true,
+                evaluated_rows: Some(evaluated_rows.clone()),
+            }),
+            include_values: true,
+        };
+
+        let (values, mask) =
+            decode_primitive(data.clone(), predicate, Some(input_selection.clone()))?;
+        let expected_values = (selected_start..selected_end)
+            .map(|index| (index % 11 != 0).then_some(index as i32))
+            .collect::<Vec<_>>();
+
+        assert_eq!(mask, input_selection);
+        assert_eq!(values, expected_values);
+        assert_eq!(
+            evaluated_rows.load(Ordering::Relaxed),
+            page_lengths[selected_page],
+        );
+    }
     Ok(())
 }
 

--- a/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
@@ -424,8 +424,11 @@ pub(super) trait Decoder: Sized {
             Some(Filter::Mask(input_selection.clone())),
             &mut chunks,
         )?;
-        let intermediate_array = if !chunks.is_empty() {
-            chunks.pop().unwrap()
+        // Each call decodes one page. Chunked decoders may emit one array;
+        // other decoders append to `intermediate_array`.
+        debug_assert!(chunks.len() <= 1);
+        let intermediate_array = if let Some(chunk) = chunks.pop() {
+            chunk
         } else {
             self.finalize(dtype.underlying_physical_type(), dict, intermediate_array)?
         }
@@ -453,7 +456,7 @@ pub(super) trait Decoder: Sized {
                 && selected_predicate_iter
                     .next()
                     .expect("input selection cardinality must match decoded values");
-            // SAFETY: Capacity for the full input selection was reserved above.
+            // SAFETY: Capacity for full input selection was reserved above.
             unsafe { pred_true_mask.push_unchecked(is_predicate_true) };
         }
         debug_assert!(selected_predicate_iter.next().is_none());

--- a/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
@@ -20,6 +20,20 @@ use crate::parquet::page::{DataPage, DictPage, split_buffer};
 use crate::parquet::schema::Repetition;
 use crate::read::expr::{ParquetScalar, SpecializedParquetColumnExpr};
 
+pub(super) enum DecoderFilter {
+    Filter(Option<Filter>),
+    SelectedPredicate {
+        predicate: PredicateFilter,
+        input_selection: Bitmap,
+    },
+}
+
+impl From<Option<Filter>> for DecoderFilter {
+    fn from(filter: Option<Filter>) -> Self {
+        Self::Filter(filter)
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct State<'a, D: Decoder> {
     pub(crate) dict: Option<&'a D::Dict>,
@@ -383,6 +397,78 @@ pub(super) trait Decoder: Sized {
         Ok(())
     }
 
+    /// Decodes incoming selection, evaluates predicate on compact values,
+    /// and expands result back into page coordinate space.
+    fn selected_predicate_decode(
+        &mut self,
+        state: State<'_, Self>,
+        decoded: &mut Self::DecodedState,
+        predicate: &PredicateFilter,
+        input_selection: Bitmap,
+        dict: Option<Self::Dict>,
+        dtype: &ArrowDataType,
+    ) -> ParquetResult<Bitmap> {
+        let is_optional = state.is_optional;
+        let selected_rows = input_selection.set_bits();
+
+        let mut intermediate_array =
+            self.with_capacity(if Self::CHUNKED { 0 } else { selected_rows });
+        if let Some(dict) = dict.as_ref() {
+            self.apply_dictionary(&mut intermediate_array, dict)?;
+        }
+
+        let mut chunks = Vec::new();
+        self.extend_filtered_with_state(
+            state,
+            &mut intermediate_array,
+            Some(Filter::Mask(input_selection.clone())),
+            &mut chunks,
+        )?;
+        let intermediate_array = if !chunks.is_empty() {
+            chunks.pop().unwrap()
+        } else {
+            self.finalize(dtype.underlying_physical_type(), dict, intermediate_array)?
+        }
+        .into_boxed();
+
+        debug_assert_eq!(intermediate_array.len(), selected_rows);
+        let selected_predicate_mask = if let Some(validity) = intermediate_array.validity() {
+            let ignore_validity_array = intermediate_array.with_validity(None);
+            let mask = predicate.predicate.evaluate(ignore_validity_array.as_ref());
+
+            if predicate.predicate.evaluate_null() {
+                arrow::bitmap::or_not(&mask, validity)
+            } else {
+                &mask & validity
+            }
+        } else {
+            predicate.predicate.evaluate(intermediate_array.as_ref())
+        };
+
+        debug_assert_eq!(selected_predicate_mask.len(), selected_rows);
+        let mut selected_predicate_iter = selected_predicate_mask.iter();
+        let mut pred_true_mask = BitmapBuilder::with_capacity(input_selection.len());
+        for is_selected in input_selection.iter() {
+            let is_predicate_true = is_selected
+                && selected_predicate_iter
+                    .next()
+                    .expect("input selection cardinality must match decoded values");
+            // SAFETY: Capacity for the full input selection was reserved above.
+            unsafe { pred_true_mask.push_unchecked(is_predicate_true) };
+        }
+        debug_assert!(selected_predicate_iter.next().is_none());
+
+        if predicate.include_values {
+            let filtered = polars_compute::filter::filter_with_bitmap(
+                intermediate_array.as_ref(),
+                &selected_predicate_mask,
+            );
+            self.extend_decoded(decoded, filtered.as_ref(), is_optional)?;
+        }
+
+        Ok(pred_true_mask.freeze())
+    }
+
     fn extend_filtered_with_state(
         &mut self,
         state: State<'_, Self>,
@@ -509,31 +595,54 @@ impl<D: Decoder> PageDecoder<D> {
         })
     }
 
-    pub fn collect(
+    pub fn collect<F>(
         self,
-        filter: Option<Filter>,
-    ) -> ParquetResult<(Option<NestedState>, Vec<D::Output>, Bitmap)> {
-        if self.init_nested.is_some() {
-            self.collect_nested(filter)
-                .map(|(nested, arr, ptm)| (Some(nested), arr, ptm))
-        } else {
-            match filter {
-                Some(Filter::Predicate(p)) => self
-                    .collect_predicate_flat(&p)
-                    .map(|(arr, ptm)| (None, arr, ptm)),
-                filter => self
-                    .collect_flat(filter)
-                    .map(|arrays| (None, arrays, Bitmap::new())),
-            }
+        filter: F,
+    ) -> ParquetResult<(Option<NestedState>, Vec<D::Output>, Bitmap)>
+    where
+        F: Into<DecoderFilter>,
+    {
+        match filter.into() {
+            DecoderFilter::Filter(filter) if self.init_nested.is_some() => self
+                .collect_nested(filter)
+                .map(|(nested, arr, ptm)| (Some(nested), arr, ptm)),
+            DecoderFilter::Filter(Some(Filter::Predicate(p))) => self
+                .collect_predicate_flat(&p, None)
+                .map(|(arr, ptm)| (None, arr, ptm)),
+            DecoderFilter::Filter(filter) => self
+                .collect_flat(filter)
+                .map(|arrays| (None, arrays, Bitmap::new())),
+            DecoderFilter::SelectedPredicate { .. } if self.init_nested.is_some() => {
+                Err(ParquetError::InvalidParameter(
+                    "selected predicate decoding is only supported for non-nested columns".into(),
+                ))
+            },
+            DecoderFilter::SelectedPredicate {
+                predicate,
+                input_selection,
+            } => self
+                .collect_predicate_flat(&predicate, Some(&input_selection))
+                .map(|(arr, ptm)| (None, arr, ptm)),
         }
     }
 
     pub fn collect_predicate_flat(
         mut self,
         p: &PredicateFilter,
+        input_selection: Option<&Bitmap>,
     ) -> ParquetResult<(Vec<D::Output>, Bitmap)> {
+        if let Some(input_selection) = input_selection {
+            let expected_len = self.iter.total_num_values();
+            if input_selection.len() != expected_len {
+                return Err(ParquetError::InvalidParameter(format!(
+                    "predicate input selection has length {}, expected {expected_len}",
+                    input_selection.len(),
+                )));
+            }
+        }
         let mut target = self.decoder.with_capacity(0);
         let mut pred_true_mask = BitmapBuilder::with_capacity(self.iter.total_num_values());
+        let mut row_offset = 0;
 
         let specialized_pred = p.predicate.as_specialized();
         let pred_is_eq_null = matches!(
@@ -558,6 +667,22 @@ impl<D: Decoder> PageDecoder<D> {
         let mut chunks = Vec::new();
         while let Some(page) = self.iter.next() {
             let page = page?;
+            let page_num_values = page.num_values();
+            let page_selection = input_selection
+                .map(|selection| selection.clone().sliced(row_offset, page_num_values));
+            row_offset += page_num_values;
+
+            let page_selection = match page_selection {
+                Some(selection) => match selection.set_bits() {
+                    0 => {
+                        pred_true_mask.extend_constant(page_num_values, false);
+                        continue;
+                    },
+                    selected if selected == page_num_values => None,
+                    _ => Some(selection),
+                },
+                None => None,
+            };
 
             let mut can_skip_page = false;
 
@@ -577,7 +702,7 @@ impl<D: Decoder> PageDecoder<D> {
                     || page.page().null_count() == Some(0));
 
             if can_skip_page {
-                pred_true_mask.extend_constant(page.num_values(), false);
+                pred_true_mask.extend_constant(page_num_values, false);
                 continue;
             }
 
@@ -599,6 +724,19 @@ impl<D: Decoder> PageDecoder<D> {
             let state = State::new(&self.decoder, &page, self.dict.as_ref())?;
 
             let (result, time) = option_time(self.metrics.is_some(), || {
+                if let Some(input_selection) = page_selection {
+                    let page_pred_true_mask = self.decoder.selected_predicate_decode(
+                        state,
+                        &mut target,
+                        p,
+                        input_selection,
+                        self.dict.clone(),
+                        &self.dtype,
+                    )?;
+                    pred_true_mask.extend_from_bitmap(&page_pred_true_mask);
+                    return Ok(());
+                }
+
                 // Handle the case where column is held equal to Null. This can be the same for all
                 // non-nested columns.
                 if matches!(
@@ -699,6 +837,7 @@ impl<D: Decoder> PageDecoder<D> {
 
             self.iter.reuse_page_buffer(page);
         }
+        debug_assert_eq!(row_offset, self.iter.total_num_values());
 
         if let Some(metrics) = self.metrics.as_ref() {
             eprintln!(
@@ -820,10 +959,13 @@ impl<D: Decoder> PageDecoder<D> {
         Ok(chunks)
     }
 
-    pub fn collect_boxed(
+    pub fn collect_boxed<F>(
         self,
-        filter: Option<Filter>,
-    ) -> ParquetResult<(Option<NestedState>, Vec<Box<dyn Array>>, Bitmap)> {
+        filter: F,
+    ) -> ParquetResult<(Option<NestedState>, Vec<Box<dyn Array>>, Bitmap)>
+    where
+        F: Into<DecoderFilter>,
+    {
         use arrow::array::IntoBoxedArray;
         let (nested, array, ptm) = self.collect(filter)?;
         let array = array.into_iter().map(|arr| arr.into_boxed()).collect();

--- a/crates/polars-parquet/src/arrow/read/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/mod.rs
@@ -10,8 +10,9 @@ use std::io::{Read, Seek};
 
 use arrow::types::{NativeType, i256};
 pub use deserialize::{
-    Filter, InitNested, NestedState, PredicateFilter, column_iter_to_arrays, create_list,
-    create_map, get_page_iterator, init_nested, n_columns,
+    Filter, InitNested, NestedState, PredicateFilter, column_iter_to_arrays,
+    column_iter_to_arrays_selected, create_list, create_map, get_page_iterator, init_nested,
+    n_columns,
 };
 #[cfg(feature = "async")]
 use futures::{AsyncRead, AsyncSeek};


### PR DESCRIPTION
Part of #28304.

Draft reason: blocked on predicate-grouping policy; primitive here has no production consumer yet.

This PR adds `column_iter_to_arrays_selected`, which evaluates a predicate only for rows selected by an existing bitmap and returns a refined mask in original column coordinates. Pages with no selected rows skip decompression, fully selected pages use the existing predicate path, and partial selections decode into compact arrays. Existing decode API and default reader behavior remain unchanged.

It enables staged plans such as `[l_shipmode, l_shipinstruct] -> [l_quantity]`, where `l_shipmode` and `l_shipinstruct` decode concurrently and their combined mask limits decoding of `l_quantity`.

It does not choose groups or change default plan execution. Grouping policy remains separate because staging trades reduced decoding and materialization against cross-column parallelism.