### PR TITLE
fix: Hash DataType parameters to prevent CSPE reusing distinct branches (#28450)

### DIFF
--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -150,7 +150,79 @@ pub trait AsRefDataType {
 
 impl Hash for DataType {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        std::mem::discriminant(self).hash(state)
+        std::mem::discriminant(self).hash(state);
+        // Every field that `PartialEq` compares must also be hashed here.
+        //
+        // For most `Hash` consumers (e.g. `HashMap`) hashing only the
+        // discriminant would merely cause collisions, resolved by a follow-up
+        // `==` check. But common-subplan elimination hashes plans with blake3
+        // and treats hash equality *as* plan equality, with no `==` fallback
+        // (see `polars-plan`'s `aexpr::hash`). Any parameter that `==`
+        // distinguishes but `Hash` omits therefore lets CSPE merge distinct
+        // subplans and silently reuse one branch's result for another -- e.g.
+        // `Enum(["a"])` vs `Enum(["b"])`, or `Datetime`s with different time
+        // zones. See #28450.
+        //
+        // The match is intentionally exhaustive (no `_` arm) so that adding a
+        // new parameterized dtype is a compile error until its parameters are
+        // hashed here.
+        match self {
+            #[cfg(feature = "dtype-decimal")]
+            DataType::Decimal(precision, scale) => {
+                precision.hash(state);
+                scale.hash(state);
+            },
+            DataType::Datetime(time_unit, time_zone) => {
+                time_unit.hash(state);
+                time_zone.hash(state);
+            },
+            DataType::Duration(time_unit) => time_unit.hash(state),
+            #[cfg(feature = "dtype-array")]
+            DataType::Array(inner, width) => {
+                inner.hash(state);
+                width.hash(state);
+            },
+            DataType::List(inner) => inner.hash(state),
+            #[cfg(feature = "object")]
+            DataType::Object(name) => name.hash(state),
+            #[cfg(feature = "dtype-categorical")]
+            DataType::Categorical(categories, _) => categories.hash().hash(state),
+            #[cfg(feature = "dtype-categorical")]
+            DataType::Enum(frozen_categories, _) => frozen_categories.hash().hash(state),
+            #[cfg(feature = "dtype-struct")]
+            DataType::Struct(fields) => fields.hash(state),
+            #[cfg(feature = "dtype-extension")]
+            DataType::Extension(instance, storage) => {
+                instance.hash(state);
+                storage.hash(state);
+            },
+            // `PartialEq` treats all `UnknownKind::Int(_)` as equal regardless of
+            // the held value, so only hash the discriminant to stay consistent.
+            DataType::Unknown(kind) => std::mem::discriminant(kind).hash(state),
+            // Parameter-less dtypes: the discriminant hashed above is enough.
+            // Listed explicitly (rather than `_`) to force a compile error when
+            // a new dtype variant is introduced.
+            DataType::Boolean
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64
+            | DataType::UInt128
+            | DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::Int128
+            | DataType::Float16
+            | DataType::Float32
+            | DataType::Float64
+            | DataType::String
+            | DataType::Binary
+            | DataType::BinaryOffset
+            | DataType::Date
+            | DataType::Time
+            | DataType::Null => {},
+        }
     }
 }
 
@@ -1641,5 +1713,85 @@ mod tests {
         expected.insert(DataType::Float64);
 
         assert_eq!(result, expected)
+    }
+
+    fn hash_of(dtype: &DataType) -> u64 {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut hasher = DefaultHasher::new();
+        dtype.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    // Parameterized dtypes that only differ in their parameters must not hash to
+    // the same value, otherwise strong-hash-based dedup (e.g. common-subplan
+    // elimination) treats them as equal. See #28450.
+    #[test]
+    fn test_parameterized_dtype_hash_distinguishes_params_28450() {
+        let pairs = [
+            (
+                DataType::Datetime(TimeUnit::Microseconds, None),
+                DataType::Datetime(TimeUnit::Nanoseconds, None),
+            ),
+            (
+                DataType::Datetime(TimeUnit::Microseconds, Some(TimeZone::UTC)),
+                DataType::Datetime(
+                    TimeUnit::Microseconds,
+                    Some(
+                        TimeZone::opt_try_new(Some("Europe/Amsterdam"))
+                            .unwrap()
+                            .unwrap(),
+                    ),
+                ),
+            ),
+            (
+                DataType::List(Box::new(DataType::Int32)),
+                DataType::List(Box::new(DataType::Int64)),
+            ),
+        ];
+
+        for (a, b) in pairs {
+            assert_ne!(a, b);
+            assert_ne!(
+                hash_of(&a),
+                hash_of(&b),
+                "hashes collided for {a:?} vs {b:?}"
+            );
+            // Equal dtypes must still hash equally.
+            assert_eq!(hash_of(&a), hash_of(&a.clone()));
+        }
+    }
+
+    #[cfg(feature = "dtype-decimal")]
+    #[test]
+    fn test_decimal_dtype_hash_distinguishes_params_28450() {
+        let a = DataType::Decimal(10, 2);
+        let b = DataType::Decimal(20, 4);
+        assert_ne!(a, b);
+        assert_ne!(hash_of(&a), hash_of(&b));
+    }
+
+    #[cfg(feature = "dtype-duration")]
+    #[test]
+    fn test_duration_dtype_hash_distinguishes_params_28450() {
+        let a = DataType::Duration(TimeUnit::Microseconds);
+        let b = DataType::Duration(TimeUnit::Nanoseconds);
+        assert_ne!(a, b);
+        assert_ne!(hash_of(&a), hash_of(&b));
+    }
+
+    #[cfg(feature = "dtype-categorical")]
+    #[test]
+    fn test_enum_dtype_hash_distinguishes_categories_28450() {
+        let make = |cats: &[&str]| {
+            let frozen = FrozenCategories::new(cats.iter().copied()).unwrap();
+            let mapping = frozen.mapping().clone();
+            DataType::Enum(frozen, mapping)
+        };
+        let a = make(&["a"]);
+        let b = make(&["b"]);
+        assert_ne!(a, b);
+        assert_ne!(hash_of(&a), hash_of(&b));
+        assert_eq!(hash_of(&a), hash_of(&make(&["a"])));
     }
 }

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -1667,3 +1667,87 @@ def test_cspe_with_pushable_filters_scan_19479(tmp_path: Path) -> None:
 
     result = pl.concat([expr1, expr2])
     assert "CACHE[id:" not in result.explain()
+
+
+@pytest.mark.parametrize(
+    ("dtype_a", "dtype_b"),
+    [
+        # Enum categories: only "a"/"b" respectively survives the cast.
+        (pl.Enum(["a"]), pl.Enum(["b"])),
+        # Decimal precision: 123456 overflows precision 3 (-> null) but fits 12.
+        (pl.Decimal(3, 0), pl.Decimal(12, 0)),
+    ],
+)
+def test_cspe_parameterized_filter_branches_28450(
+    dtype_a: pl.DataType, dtype_b: pl.DataType
+) -> None:
+    # CSPE must not treat two branches as identical when they only differ in the
+    # parameters of an otherwise equal dtype family. Previously the dtype hash
+    # only considered the dtype's discriminant, so e.g. `Enum(["a"])` and
+    # `Enum(["b"])` hashed the same and CSPE reused one branch's filtered result
+    # for the other.
+    base = pl.DataFrame({"value": [1, 123456]}).lazy()
+    if dtype_a == pl.Enum(["a"]):
+        base = pl.DataFrame({"value": ["a", "b"]}).lazy()
+
+    def branch(dtype: pl.DataType, name: str) -> pl.LazyFrame:
+        return base.filter(
+            pl.col("value").cast(dtype, strict=False).is_not_null()
+        ).select(pl.lit(name).alias("branch"), "value")
+
+    q = pl.concat([branch(dtype_a, "group_a"), branch(dtype_b, "group_b")]).sort(
+        ["branch", "value"]
+    )
+
+    # Sanity: the two branches genuinely differ, so a spurious merge is visible.
+    no_cspe = q.collect(optimizations=pl.QueryOptFlags(comm_subplan_elim=False))
+    assert_frame_equal(q.collect(), no_cspe)
+
+
+@pytest.mark.parametrize(
+    ("dtype_a", "dtype_b"),
+    [
+        (pl.Datetime("us", "UTC"), pl.Datetime("us", "Asia/Kolkata")),
+        (pl.Datetime("us"), pl.Datetime("ns")),
+    ],
+)
+def test_cspe_parameterized_temporal_branches_28450(
+    dtype_a: pl.DataType, dtype_b: pl.DataType
+) -> None:
+    # Same bug, exercised through a shared subplan whose *value* depends on the
+    # dtype parameter (time zone / time unit): casting an integer to a
+    # parameterized `Datetime` and formatting it produces different strings, so a
+    # spurious CSPE merge reuses one branch's timestamps for the other.
+    base = pl.DataFrame({"value": [0, 3_600_000_000]}).lazy()
+
+    def branch(dtype: pl.DataType, name: str) -> pl.LazyFrame:
+        shared = base.select(pl.col("value").cast(dtype).dt.to_string().alias("ts"))
+        return shared.select(pl.lit(name).alias("branch"), "ts")
+
+    q = pl.concat([branch(dtype_a, "group_a"), branch(dtype_b, "group_b")]).sort(
+        ["branch", "ts"]
+    )
+
+    no_cspe = q.collect(optimizations=pl.QueryOptFlags(comm_subplan_elim=False))
+    assert_frame_equal(q.collect(), no_cspe)
+
+
+def test_cspe_identical_parameterized_branches_still_shared_28450() -> None:
+    # The complement of the fix: branches that share the *same* parameterized
+    # dtype must still be de-duplicated, so we did not fix correctness by simply
+    # disabling the optimization.
+    base = pl.DataFrame({"value": ["a", "b"]}).lazy()
+
+    def branch(name: str) -> pl.LazyFrame:
+        return base.filter(
+            pl.col("value").cast(pl.Enum(["a", "b"]), strict=False).is_not_null()
+        ).select(pl.lit(name).alias("branch"), "value")
+
+    q = pl.concat([branch("group_a"), branch("group_b")])
+
+    # The identical filter subplan is still shared across both branches.
+    assert q.explain().count("CACHE[id:") == 2
+    assert_frame_equal(
+        q.collect(),
+        q.collect(optimizations=pl.QueryOptFlags(comm_subplan_elim=False)),
+    )


### PR DESCRIPTION


`Hash for DataType` only hashed the enum discriminant, while `PartialEq` compares the full dtype including its parameters. Common-subplan elimination hashes plans with blake3 and treats hash equality *as* plan equality, with no `==` fallback, so two branches that differed only in a parameterized dtype -- e.g. `Enum(["a"])` vs `Enum(["b"])`, different `Datetime` time zones/units, `Decimal` precision/scale, or `Duration` units -- collided, and one branch's result was silently reused for the other, producing incorrect results.

This hashes the dtype parameters as well, keeping `Hash` consistent with `PartialEq`. Categorical/Enum use their stable interned `.hash()`, and `Unknown` only hashes the kind's discriminant to match `PartialEq` (which treats all `UnknownKind::Int(_)` as equal). The match is exhaustive (no `_` arm) so a newly added parameterized dtype fails to compile until its parameters are hashed here.

Closes #28450.

### Tests

- Rust unit tests in `dtype.rs`: distinct parameters hash distinctly, equal dtypes hash equally (Datetime tz/unit, List, Decimal, Duration, Enum).
- Python regression tests in `test_cse.py` exercising CSPE end-to-end for Enum categories, Decimal precision, and Datetime time zone/unit, plus a positive test that identical branches are still de-duplicated. These fail on the current release (bug present) and pass with this change.

### AI usage

1. I used Claude Code (Opus 4.8) to diagnose the issue, implement the fix in `dtype.rs`, and write the Rust and Python tests.
2. I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.
