### PR TITLE
fix: validate CSPE hash matches structurally

### DIFF
--- a/crates/polars-lazy/src/tests/cse.rs
+++ b/crates/polars-lazy/src/tests/cse.rs
@@ -367,3 +367,75 @@ fn test_cse_prune_scan_filter_difference() -> PolarsResult<()> {
 
     Ok(())
 }
+
+#[test]
+#[cfg(feature = "dtype-categorical")]
+fn test_cse_distinguishes_parameterized_dtypes() -> PolarsResult<()> {
+    let enum_a = DataType::from_frozen_categories(FrozenCategories::new(["a"]).unwrap());
+    let enum_b = DataType::from_frozen_categories(FrozenCategories::new(["b"]).unwrap());
+    let base = df!["value" => ["a", "b"]]?.lazy();
+
+    let branch_a = base
+        .clone()
+        .filter(col("value").cast(enum_a).is_not_null())
+        .select([lit("group_a").alias("branch"), col("value")]);
+    let branch_b = base
+        .filter(col("value").cast(enum_b).is_not_null())
+        .select([lit("group_b").alias("branch"), col("value")]);
+
+    let out = concat(
+        &[branch_a, branch_b],
+        UnionArgs {
+            parallel: false,
+            ..Default::default()
+        },
+    )?
+    .sort(["branch"], Default::default())
+    .with_comm_subplan_elim(true)
+    .collect()?;
+
+    assert_eq!(
+        out.column("value")?
+            .str()?
+            .no_null_iter()
+            .collect::<Vec<_>>(),
+        ["a", "b"]
+    );
+
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "dtype-decimal")]
+fn test_cse_distinguishes_decimal_parameters() -> PolarsResult<()> {
+    let base = df!["value" => ["12.3", "12345.6"]]?.lazy();
+
+    let branch_p4 = base
+        .clone()
+        .filter(col("value").cast(DataType::Decimal(4, 1)).is_not_null())
+        .select([lit("p4").alias("branch"), col("value")]);
+    let branch_p6 = base
+        .filter(col("value").cast(DataType::Decimal(6, 1)).is_not_null())
+        .select([lit("p6").alias("branch"), col("value")]);
+
+    let out = concat(
+        &[branch_p4, branch_p6],
+        UnionArgs {
+            parallel: false,
+            ..Default::default()
+        },
+    )?
+    .sort(["branch", "value"], Default::default())
+    .with_comm_subplan_elim(true)
+    .collect()?;
+
+    assert_eq!(
+        out.column("value")?
+            .str()?
+            .no_null_iter()
+            .collect::<Vec<_>>(),
+        ["12.3", "12.3", "12345.6"]
+    );
+
+    Ok(())
+}

--- a/crates/polars-plan/src/plans/optimizer/cse/cspe.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/cspe.rs
@@ -2,8 +2,11 @@ use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::ops::ControlFlow;
 
-use polars_core::prelude::{InitHashMaps as _, PlIndexMap};
+use indexmap::map::RawEntryApiV1;
+use indexmap::map::raw_entry_v1::RawEntryMut;
+use polars_core::prelude::PlIndexMap;
 use polars_utils::arena::{Arena, Node};
+use polars_utils::idx_vec::UnitVec;
 use polars_utils::scratch_vec::ScratchVec;
 use polars_utils::unique_id::UniqueId;
 
@@ -24,7 +27,7 @@ pub fn common_subplan_elimination(
     let mut visit_stack = ScratchVec::default();
     let mut edges = vec![usize::MAX]; // Indices into `id_map`
     let mut persisted_input_edge_idxs = vec![usize::MAX]; // For tree traversal
-    let mut id_map = PlIndexMap::new();
+    let mut id_map = IDMap::default();
     let mut storage = IRTraversalStorage {
         arena: ir_arena,
         skip_subtree: |ir| {
@@ -113,6 +116,86 @@ struct IDState {
     output_state_entry_idx: usize,
 }
 
+struct Identifier {
+    hash: [u8; 32],
+    representative: Node,
+    input_ids: UnitVec<usize>,
+}
+
+impl Identifier {
+    fn raw_hash(&self) -> u64 {
+        u64::from_le_bytes(self.hash[..8].try_into().unwrap())
+    }
+
+    fn is_equal(
+        &self,
+        other: &Self,
+        storage: &IRTraversalStorage<'_>,
+        expr_arena: &Arena<AExpr>,
+    ) -> bool {
+        self.hash == other.hash
+            && self.input_ids == other.input_ids
+            && IRHashWrap::new(self.representative, storage, expr_arena, false)
+                == IRHashWrap::new(other.representative, storage, expr_arena, false)
+    }
+}
+
+#[derive(Default)]
+struct IDMap {
+    entries: PlIndexMap<Identifier, IDState>,
+}
+
+impl IDMap {
+    fn entry(
+        &mut self,
+        identifier: Identifier,
+        storage: &IRTraversalStorage<'_>,
+        expr_arena: &Arena<AExpr>,
+    ) -> usize {
+        let hash = identifier.raw_hash();
+        match self
+            .entries
+            .raw_entry_mut_v1()
+            .from_hash(hash, |candidate| {
+                candidate.is_equal(&identifier, storage, expr_arena)
+            }) {
+            RawEntryMut::Occupied(mut entry) => {
+                entry.get_mut().hits += 1;
+                entry.index()
+            },
+            RawEntryMut::Vacant(entry) => {
+                let entry_idx = entry.index();
+                entry.insert_hashed_nocheck(hash, identifier, IDState::default());
+                entry_idx
+            },
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn state(&self, entry_idx: usize) -> &IDState {
+        self.entries.get_index(entry_idx).unwrap().1
+    }
+
+    fn state_mut(&mut self, entry_idx: usize) -> &mut IDState {
+        self.entries.get_index_mut(entry_idx).unwrap().1
+    }
+
+    fn get_disjoint_states_mut(
+        &mut self,
+        left_idx: usize,
+        right_idx: usize,
+    ) -> (&mut IDState, &mut IDState) {
+        let [(_, left), (_, right)] = self
+            .entries
+            .get_disjoint_indices_mut([left_idx, right_idx])
+            .unwrap();
+        (left, right)
+    }
+}
+
 impl Default for IDState {
     fn default() -> Self {
         Self {
@@ -124,7 +207,7 @@ impl Default for IDState {
 }
 
 struct IDGeneratorVisitor<'map, 'arena> {
-    id_map: &'map mut PlIndexMap<[u8; 32], IDState>,
+    id_map: &'map mut IDMap,
     expr_arena: &'arena Arena<AExpr>,
 }
 
@@ -171,37 +254,28 @@ impl<'map, 'arena> NodeVisitor for IDGeneratorVisitor<'map, 'arena> {
 
         IRHashWrap::new(key, storage, self.expr_arena, true).hash(&mut hasher);
 
-        for entry_idx in edges.inputs().iter().copied() {
-            let input_hash: &[u8; 32] = self.id_map.get_index(entry_idx).unwrap().0;
-            hasher.write(input_hash);
+        let input_ids: UnitVec<_> = edges.inputs().iter().copied().collect();
+        for input_id in input_ids.iter().copied() {
+            // Hash the already-validated equivalence class rather than the child's digest.
+            // This prevents a deliberate local hash collision from propagating through all
+            // ancestors, while equal child plans still produce the same parent identifier.
+            hasher.write_usize(input_id);
         }
 
-        let id: [u8; 32] = hasher.finalize();
-
-        use indexmap::map::Entry;
-
-        let entry_idx = match self.id_map.entry(id) {
-            Entry::Occupied(mut e) => {
-                e.get_mut().hits += 1;
-                e.index()
+        let entry_idx = self.id_map.entry(
+            Identifier {
+                hash: hasher.finalize(),
+                representative: key,
+                input_ids,
             },
-            Entry::Vacant(e) => {
-                let idx = e.index();
-
-                e.insert(IDState::default());
-
-                idx
-            },
-        };
+            storage,
+            self.expr_arena,
+        );
 
         edges.outputs()[0] = entry_idx;
 
         for i in edges.inputs().iter().copied() {
-            self.id_map
-                .get_index_mut(i)
-                .unwrap()
-                .1
-                .output_state_entry_idx = entry_idx
+            self.id_map.state_mut(i).output_state_entry_idx = entry_idx
         }
 
         ControlFlow::Continue(())
@@ -209,7 +283,7 @@ impl<'map, 'arena> NodeVisitor for IDGeneratorVisitor<'map, 'arena> {
 }
 
 struct InsertCachesVisitor<'a, 'arena> {
-    id_map: &'a mut PlIndexMap<[u8; 32], IDState>,
+    id_map: &'a mut IDMap,
     inserted_cache: &'a mut bool,
     insert_nested_caches: bool,
     phantom: PhantomData<&'arena ()>,
@@ -238,9 +312,7 @@ impl<'a, 'arena> NodeVisitor for InsertCachesVisitor<'a, 'arena> {
         let entry_idx_curr_node = edges.outputs()[0];
         let entry_idx_output_node = self
             .id_map
-            .get_index(entry_idx_curr_node)
-            .unwrap()
-            .1
+            .state(entry_idx_curr_node)
             .output_state_entry_idx;
 
         if entry_idx_output_node == usize::MAX {
@@ -249,10 +321,9 @@ impl<'a, 'arena> NodeVisitor for InsertCachesVisitor<'a, 'arena> {
             return ControlFlow::Continue(SubtreeVisit::Visit);
         }
 
-        let [(_, output_state), (_, curr_state)] = self
+        let (output_state, curr_state) = self
             .id_map
-            .get_disjoint_indices_mut([entry_idx_output_node, entry_idx_curr_node])
-            .unwrap();
+            .get_disjoint_states_mut(entry_idx_output_node, entry_idx_curr_node);
 
         if curr_state.replacement_ir.is_some() {
             return ControlFlow::Continue(SubtreeVisit::Skip);
@@ -288,7 +359,7 @@ impl<'a, 'arena> NodeVisitor for InsertCachesVisitor<'a, 'arena> {
         storage: &mut Self::Storage,
         edges: &mut dyn NodeEdgesProvider<Self::Edge>,
     ) -> ControlFlow<Self::BreakValue> {
-        let state = self.id_map.get_index(edges.outputs()[0]).unwrap().1;
+        let state = self.id_map.state(edges.outputs()[0]);
 
         if let Some(replacement_ir) = state.replacement_ir.clone() {
             *storage.get_mut(key) = replacement_ir;

--- a/crates/polars-plan/src/plans/visitor/expr.rs
+++ b/crates/polars-plan/src/plans/visitor/expr.rs
@@ -168,9 +168,20 @@ impl Debug for AExprArena<'_> {
 
 impl AExpr {
     fn is_equal_node(&self, other: &Self) -> bool {
+        fn input_names_equal(left: &[ExprIR], right: &[ExprIR]) -> bool {
+            left.len() == right.len()
+                && left
+                    .iter()
+                    .zip(right)
+                    .all(|(left, right)| left.output_name() == right.output_name())
+        }
+
         use AExpr::*;
         match (self, other) {
+            (Element, Element) => true,
             (Column(l), Column(r)) => l == r,
+            #[cfg(feature = "dtype-struct")]
+            (StructField(l), StructField(r)) => l == r,
             (Literal(l), Literal(r)) => l == r,
             #[cfg(feature = "dynamic_group_by")]
             (
@@ -189,7 +200,22 @@ impl AExpr {
                     closed_window: r_closed_window,
                 },
             ) => l_period == r_period && l_offset == r_offset && l_closed_window == r_closed_window,
-            (Over { mapping: l, .. }, Over { mapping: r, .. }) => l == r,
+            (
+                Over {
+                    mapping: l_mapping,
+                    order_by: l_order_by,
+                    ..
+                },
+                Over {
+                    mapping: r_mapping,
+                    order_by: r_order_by,
+                    ..
+                },
+            ) => {
+                l_mapping == r_mapping
+                    && l_order_by.as_ref().map(|(_, options)| options)
+                        == r_order_by.as_ref().map(|(_, options)| options)
+            },
             (
                 Cast {
                     options: strict_l,
@@ -203,8 +229,19 @@ impl AExpr {
                 },
             ) => strict_l == strict_r && dtl == dtr,
             (Sort { options: l, .. }, Sort { options: r, .. }) => l == r,
-            (Gather { .. }, Gather { .. })
-            | (Filter { .. }, Filter { .. })
+            (
+                Gather {
+                    returns_scalar: l_returns_scalar,
+                    null_on_oob: l_null_on_oob,
+                    ..
+                },
+                Gather {
+                    returns_scalar: r_returns_scalar,
+                    null_on_oob: r_null_on_oob,
+                    ..
+                },
+            ) => l_returns_scalar == r_returns_scalar && l_null_on_oob == r_null_on_oob,
+            (Filter { .. }, Filter { .. })
             | (Ternary { .. }, Ternary { .. })
             | (Len, Len)
             | (Slice { .. }, Slice { .. }) => true,
@@ -240,31 +277,22 @@ impl AExpr {
                     function: fr,
                     options: or,
                 },
-            ) => {
-                fl == fr && ol == or && {
-                    let mut all_same_name = true;
-                    for (l, r) in il.iter().zip(ir) {
-                        all_same_name &= l.output_name() == r.output_name()
-                    }
-
-                    all_same_name
-                }
-            },
+            ) => fl == fr && ol == or && input_names_equal(il, ir),
             (
                 AnonymousFunction {
                     function: l1,
                     options: l2,
                     fmt_str: l3,
-                    input: _,
+                    input: li,
                 },
                 AnonymousFunction {
                     function: r1,
                     options: r2,
                     fmt_str: r3,
-                    input: _,
+                    input: ri,
                 },
             ) => {
-                l2 == r2 && l3 == r3 && {
+                l2 == r2 && l3 == r3 && input_names_equal(li, ri) && {
                     use LazySerde as L;
                     match (l1, r1) {
                         // We only check the pointers, so this works for python
@@ -286,6 +314,23 @@ impl AExpr {
                         _ => false,
                     }
                 }
+            },
+            (
+                AnonymousAgg {
+                    input: li,
+                    fmt_str: lf,
+                    function: lfn,
+                },
+                AnonymousAgg {
+                    input: ri,
+                    fmt_str: rf,
+                    function: rfn,
+                },
+            ) => lf == rf && lfn == rfn && input_names_equal(li, ri),
+            (Eval { variant: l, .. }, Eval { variant: r, .. }) => l == r,
+            #[cfg(feature = "dtype-struct")]
+            (StructEval { evaluation: l, .. }, StructEval { evaluation: r, .. }) => {
+                input_names_equal(l, r)
             },
             (BinaryExpr { op: l, .. }, BinaryExpr { op: r, .. }) => l == r,
             _ => false,

--- a/crates/polars-plan/src/plans/visitor/hash.rs
+++ b/crates/polars-plan/src/plans/visitor/hash.rs
@@ -6,7 +6,7 @@ use polars_utils::arena::{Arena, Node};
 use super::*;
 #[cfg(feature = "python")]
 use crate::plans::PythonOptions;
-use crate::plans::{AExpr, IR, UnoptimizedOperation};
+use crate::plans::{AExpr, FunctionIR, IR, UnoptimizedOperation};
 use crate::prelude::aexpr::traverse_and_hash_aexpr;
 use crate::prelude::{ExprIR, PlanCallback};
 
@@ -57,6 +57,153 @@ fn hash_option_expr<H: Hasher>(expr: &Option<ExprIR>, expr_arena: &Arena<AExpr>,
 fn hash_exprs<H: Hasher>(exprs: &[ExprIR], expr_arena: &Arena<AExpr>, state: &mut H) {
     for e in exprs {
         e.traverse_and_hash(expr_arena, state);
+    }
+}
+
+fn expr_ir_eq(left: &ExprIR, right: &ExprIR, expr_arena: &Arena<AExpr>) -> bool {
+    left.get_alias() == right.get_alias()
+        && AexprNode::new(left.node()).hashable_and_cmp(expr_arena)
+            == AexprNode::new(right.node()).hashable_and_cmp(expr_arena)
+}
+
+fn expr_irs_eq(left: &[ExprIR], right: &[ExprIR], expr_arena: &Arena<AExpr>) -> bool {
+    left.len() == right.len()
+        && left
+            .iter()
+            .zip(right)
+            .all(|(left, right)| expr_ir_eq(left, right, expr_arena))
+}
+
+fn opt_expr_ir_eq(
+    left: &Option<ExprIR>,
+    right: &Option<ExprIR>,
+    expr_arena: &Arena<AExpr>,
+) -> bool {
+    match (left, right) {
+        (Some(left), Some(right)) => expr_ir_eq(left, right, expr_arena),
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+fn function_ir_eq(left: &FunctionIR, right: &FunctionIR) -> bool {
+    use FunctionIR::*;
+
+    match (left, right) {
+        (
+            RowIndex {
+                name: left_name,
+                offset: left_offset,
+                ..
+            },
+            RowIndex {
+                name: right_name,
+                offset: right_offset,
+                ..
+            },
+        ) => left_name == right_name && left_offset == right_offset,
+        #[cfg(feature = "python")]
+        (OpaquePython(left), OpaquePython(right)) => {
+            left.function.0.as_ptr() == right.function.0.as_ptr()
+                && left.schema == right.schema
+                && left.predicate_pd == right.predicate_pd
+                && left.projection_pd == right.projection_pd
+                && left.streamable == right.streamable
+                && left.validate_output == right.validate_output
+        },
+        (
+            FastCount {
+                sources: left_sources,
+                scan_type: left_scan_type,
+                alias: left_alias,
+                cloud_options: left_cloud_options,
+            },
+            FastCount {
+                sources: right_sources,
+                scan_type: right_scan_type,
+                alias: right_alias,
+                cloud_options: right_cloud_options,
+            },
+        ) => {
+            left_sources == right_sources
+                && left_scan_type == right_scan_type
+                && left_alias == right_alias
+                && left_cloud_options == right_cloud_options
+        },
+        (
+            Unnest {
+                columns: left_columns,
+                separator: left_separator,
+            },
+            Unnest {
+                columns: right_columns,
+                separator: right_separator,
+            },
+        ) => left_columns == right_columns && left_separator == right_separator,
+        (Rechunk, Rechunk) => true,
+        (
+            Explode {
+                columns: left_columns,
+                options: left_options,
+                ..
+            },
+            Explode {
+                columns: right_columns,
+                options: right_options,
+                ..
+            },
+        ) => left_columns == right_columns && left_options == right_options,
+        #[cfg(feature = "pivot")]
+        (Unpivot { args: left, .. }, Unpivot { args: right, .. }) => left == right,
+        (
+            Opaque {
+                function: left_function,
+                schema: left_schema,
+                predicate_pd: left_predicate_pd,
+                projection_pd: left_projection_pd,
+                streamable: left_streamable,
+                fmt_str: left_fmt_str,
+            },
+            Opaque {
+                function: right_function,
+                schema: right_schema,
+                predicate_pd: right_predicate_pd,
+                projection_pd: right_projection_pd,
+                streamable: right_streamable,
+                fmt_str: right_fmt_str,
+            },
+        ) => {
+            Arc::ptr_eq(left_function, right_function)
+                && match (left_schema, right_schema) {
+                    (Some(left), Some(right)) => Arc::ptr_eq(left, right),
+                    (None, None) => true,
+                    _ => false,
+                }
+                && left_predicate_pd == right_predicate_pd
+                && left_projection_pd == right_projection_pd
+                && left_streamable == right_streamable
+                && left_fmt_str == right_fmt_str
+        },
+        (Hint(left), Hint(right)) => match (left, right) {
+            (
+                crate::plans::functions::HintIR::Sorted(left),
+                crate::plans::functions::HintIR::Sorted(right),
+            ) => left == right,
+        },
+        _ => false,
+    }
+}
+
+fn plan_callback_eq<Args, Out>(
+    left: &Option<PlanCallback<Args, Out>>,
+    right: &Option<PlanCallback<Args, Out>>,
+) -> bool {
+    match (left, right) {
+        (None, None) => true,
+        (Some(PlanCallback::Rust(left)), Some(PlanCallback::Rust(right))) => left == right,
+        #[cfg(feature = "python")]
+        (Some(PlanCallback::Python(left)), Some(PlanCallback::Python(right))) => left == right,
+        _ => false,
     }
 }
 
@@ -320,3 +467,249 @@ impl Hash for IRHashWrap<'_> {
         }
     }
 }
+
+impl PartialEq for IRHashWrap<'_> {
+    /// Compare one plan node while deliberately ignoring its input node indices.
+    ///
+    /// CSPE compares the inputs by their bottom-up equivalence-class identifiers. This
+    /// comparison validates the remaining semantic attributes after the strong hash has
+    /// selected a small set of candidates.
+    fn eq(&self, other: &Self) -> bool {
+        let left = self.lp_arena.get(self.node);
+        let right = other.lp_arena.get(other.node);
+
+        match (left, right) {
+            #[cfg(feature = "python")]
+            (
+                IR::PythonScan {
+                    options: left_options,
+                },
+                IR::PythonScan {
+                    options: right_options,
+                },
+            ) => {
+                use crate::prelude::PythonPredicate;
+
+                if !left_options.is_pure || !right_options.is_pure {
+                    return false;
+                }
+
+                let predicates_equal = match (&left_options.predicate, &right_options.predicate) {
+                    (PythonPredicate::None, PythonPredicate::None) => true,
+                    (PythonPredicate::PyArrow(left), PythonPredicate::PyArrow(right)) => {
+                        left.has_residual == right.has_residual
+                            && left.pyarrow_predicate.0.as_ptr()
+                                == right.pyarrow_predicate.0.as_ptr()
+                            && expr_ir_eq(&left.predicate, &right.predicate, self.expr_arena)
+                    },
+                    (PythonPredicate::Polars(left), PythonPredicate::Polars(right)) => {
+                        expr_ir_eq(left, right, self.expr_arena)
+                    },
+                    _ => false,
+                };
+
+                (match (&left_options.scan_fn, &right_options.scan_fn) {
+                    (Some(left), Some(right)) => left.0.as_ptr() == right.0.as_ptr(),
+                    _ => false,
+                }) && left_options.schema == right_options.schema
+                    && left_options.output_schema == right_options.output_schema
+                    && left_options.with_columns == right_options.with_columns
+                    && left_options.python_source == right_options.python_source
+                    && left_options.n_rows == right_options.n_rows
+                    && predicates_equal
+                    && left_options.validate_schema == right_options.validate_schema
+            },
+            (
+                IR::Slice {
+                    offset: left_offset,
+                    len: left_len,
+                    ..
+                },
+                IR::Slice {
+                    offset: right_offset,
+                    len: right_len,
+                    ..
+                },
+            ) => left_offset == right_offset && left_len == right_len,
+            (
+                IR::Filter {
+                    predicate: left, ..
+                },
+                IR::Filter {
+                    predicate: right, ..
+                },
+            ) => expr_ir_eq(left, right, self.expr_arena),
+            (
+                IR::Scan {
+                    sources: left_sources,
+                    predicate: left_predicate,
+                    scan_type: left_scan_type,
+                    unified_scan_args: left_args,
+                    ..
+                },
+                IR::Scan {
+                    sources: right_sources,
+                    predicate: right_predicate,
+                    scan_type: right_scan_type,
+                    unified_scan_args: right_args,
+                    ..
+                },
+            ) => {
+                left_sources == right_sources
+                    && left_scan_type == right_scan_type
+                    && left_args == right_args
+                    && opt_expr_ir_eq(left_predicate, right_predicate, self.expr_arena)
+            },
+            (
+                IR::DataFrameScan {
+                    df: left_df,
+                    output_schema: left_schema,
+                    ..
+                },
+                IR::DataFrameScan {
+                    df: right_df,
+                    output_schema: right_schema,
+                    ..
+                },
+            ) => Arc::ptr_eq(left_df, right_df) && left_schema == right_schema,
+            (
+                IR::SimpleProjection { columns: left, .. },
+                IR::SimpleProjection { columns: right, .. },
+            ) => left == right,
+            (
+                IR::Select {
+                    expr: left_expr,
+                    options: left_options,
+                    ..
+                },
+                IR::Select {
+                    expr: right_expr,
+                    options: right_options,
+                    ..
+                },
+            ) => {
+                left_options == right_options && expr_irs_eq(left_expr, right_expr, self.expr_arena)
+            },
+            (
+                IR::Sort {
+                    by_column: left_by,
+                    slice: left_slice,
+                    sort_options: left_options,
+                    ..
+                },
+                IR::Sort {
+                    by_column: right_by,
+                    slice: right_slice,
+                    sort_options: right_options,
+                    ..
+                },
+            ) => {
+                left_slice == right_slice
+                    && left_options == right_options
+                    && expr_irs_eq(left_by, right_by, self.expr_arena)
+            },
+            (IR::Cache { id: left, .. }, IR::Cache { id: right, .. }) => left == right,
+            (
+                IR::GroupBy {
+                    keys: left_keys,
+                    aggs: left_aggs,
+                    apply: left_apply,
+                    maintain_order: left_maintain_order,
+                    options: left_options,
+                    ..
+                },
+                IR::GroupBy {
+                    keys: right_keys,
+                    aggs: right_aggs,
+                    apply: right_apply,
+                    maintain_order: right_maintain_order,
+                    options: right_options,
+                    ..
+                },
+            ) => {
+                plan_callback_eq(left_apply, right_apply)
+                    && left_maintain_order == right_maintain_order
+                    && left_options == right_options
+                    && expr_irs_eq(left_keys, right_keys, self.expr_arena)
+                    && expr_irs_eq(left_aggs, right_aggs, self.expr_arena)
+            },
+            (
+                IR::Join {
+                    left_on: left_left_on,
+                    right_on: left_right_on,
+                    options: left_options,
+                    ..
+                },
+                IR::Join {
+                    left_on: right_left_on,
+                    right_on: right_right_on,
+                    options: right_options,
+                    ..
+                },
+            ) => {
+                left_options == right_options
+                    && expr_irs_eq(left_left_on, right_left_on, self.expr_arena)
+                    && expr_irs_eq(left_right_on, right_right_on, self.expr_arena)
+            },
+            (
+                IR::Gather {
+                    null_on_oob: left, ..
+                },
+                IR::Gather {
+                    null_on_oob: right, ..
+                },
+            ) => left == right,
+            (
+                IR::HStack {
+                    exprs: left_exprs,
+                    options: left_options,
+                    ..
+                },
+                IR::HStack {
+                    exprs: right_exprs,
+                    options: right_options,
+                    ..
+                },
+            ) => {
+                left_options == right_options
+                    && expr_irs_eq(left_exprs, right_exprs, self.expr_arena)
+            },
+            (IR::Distinct { options: left, .. }, IR::Distinct { options: right, .. }) => {
+                left == right
+            },
+            (
+                IR::MapFunction { function: left, .. },
+                IR::MapFunction {
+                    function: right, ..
+                },
+            ) => function_ir_eq(left, right),
+            (IR::Union { options: left, .. }, IR::Union { options: right, .. }) => left == right,
+            (IR::HConcat { options: left, .. }, IR::HConcat { options: right, .. }) => {
+                left == right
+            },
+            (IR::ExtContext { .. }, IR::ExtContext { .. }) => true,
+            // Sink nodes are execution boundaries, and unoptimized dispatch nodes are not meant
+            // to be optimized across. Keeping them unique is both cheap and conservative.
+            (IR::Sink { .. }, IR::Sink { .. })
+            | (IR::UnoptimizedDispatch { .. }, IR::UnoptimizedDispatch { .. }) => false,
+            (IR::SinkMultiple { .. }, IR::SinkMultiple { .. }) => true,
+            #[cfg(feature = "merge_sorted")]
+            (
+                IR::MergeSorted {
+                    key: left_key,
+                    maintain_order: left_maintain_order,
+                    ..
+                },
+                IR::MergeSorted {
+                    key: right_key,
+                    maintain_order: right_maintain_order,
+                    ..
+                },
+            ) => left_key == right_key && left_maintain_order == right_maintain_order,
+            (IR::Invalid, IR::Invalid) => unreachable!(),
+            _ => false,
+        }
+    }
+}
+
+impl Eq for IRHashWrap<'_> {}


### PR DESCRIPTION
## Summary

- Keep BLAKE3 plan hashes as a fast candidate filter, but require structural equality before reusing a CSPE class.
- Compare each IR node locally and compare its children through bottom-up equivalence-class IDs, avoiding full subplan traversal.
- Use the same context-aware `IndexMap` raw-entry pattern as expression CSE so the map owns collision buckets and preserves every structural equivalence class.
- Leave the global `DataType::Hash` behavior unchanged.

## Root cause

#25537 replaced structural subplan comparison with digest equality to avoid repeated subtree traversal. This restored linear optimizer behavior, but it made hash completeness a correctness requirement. Coarse or omitted hash inputs can therefore make distinct plans share a cache.

This addresses that invariant directly instead of making one hash implementation more specific, as attempted in #28451.

Fixes #28450.

## Complexity

Each plan node performs one expected-constant-time hash-table lookup. Equality checks only candidates in the same digest bucket, compares the local node, and compares child plans through previously computed class IDs. It never traverses child subplans, retaining expected linear time in the plan representation while resolving collisions correctly.

## Tests

- `cargo check -p polars-plan --all-features`
- `cargo test -p polars-lazy --features cse,strings,temporal,ipc,csv,parquet,streaming,dtype-categorical,dtype-decimal tests::cse::`
- `git diff --check`

## AI disclosure

Written with Codex and fully reviewed.