### PR TITLE
fix(rust): Decrement ParkGroup worker count when worker exits

### DIFF
--- a/crates/polars-async/src/executor/park_group.rs
+++ b/crates/polars-async/src/executor/park_group.rs
@@ -52,6 +52,12 @@ pub struct ParkGroupWorker {
     version: u32,
 }
 
+impl Drop for ParkGroupWorker {
+    fn drop(&mut self) {
+        self.inner.num_workers.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
 impl ParkGroup {
     pub fn new() -> Self {
         Self::default()


### PR DESCRIPTION
Spotted by AI while investigating another bug.

Don't think we'd ever hit this, but in theory after enough `spawn_blocking` calls eventually we will exceed 2^32 workers in the lifetime of the program (while this counter is supposed to prevent >= 2^32 *simultaneous* workers).