### PR TITLE
fix: Propagate adjusted sortedness through Gather

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/sortedness.rs
+++ b/crates/polars-plan/src/plans/optimizer/sortedness.rs
@@ -508,7 +508,7 @@ fn is_sorted_rec(
                     }
                 },
             }
-            Some(input_sorted)
+            Some(IRSorted(out_sorted.into()))
         },
         IR::MapFunction { input, function } => match function {
             FunctionIR::Hint(hint) => match hint {

--- a/py-polars/tests/unit/lazyframe/test_sort_collapse.py
+++ b/py-polars/tests/unit/lazyframe/test_sort_collapse.py
@@ -105,3 +105,22 @@ def test_sort_node_prune_hint_multiple() -> None:
         .select(pl.col("idx"))
     )
     assert 'SORT BY [maintain_order: true] [col("a"), col("b")]' in q.explain()
+
+
+@pytest.mark.parametrize("idx_descending", [False, True])
+@pytest.mark.parametrize("output_descending", [False, True])
+def test_sort_node_collapse_gather_28491(
+    idx_descending: bool, output_descending: bool
+) -> None:
+    indices = pl.LazyFrame({"idx": [0, 1, 2]}, schema={"idx": pl.UInt32}).sort(
+        "idx", descending=idx_descending
+    )
+    q = (
+        pl.LazyFrame({"a": [1, 2, 3]})
+        .sort("a")
+        .gather(indices)
+        .sort("a", descending=output_descending)
+    )
+
+    values = [3, 2, 1] if output_descending else [1, 2, 3]
+    assert_frame_equal(q.collect(), pl.DataFrame({"a": values}))


### PR DESCRIPTION
## Summary

`Gather` returned the input sortedness metadata instead of the adjusted output metadata. This could cause a later sort to be incorrectly removed and return wrong rows.

This fix returns the adjusted metadata and adds regression coverage.

Closes #28491.

## Testing

Added `test_sort_node_collapse_gather_28491`, covering all four ascending/descending combinations for gather indices and output sorting.

- `make test-all` — passed locally

## AI assistance

Codex generated the Rust fix and regression test. I fully reviewed all changes and believe they are relevant and correct.