### PR TITLE
feat: Add opt-in short-circuit when-then execution

### DIFF
--- a/crates/polars-expr/src/expressions/ternary.rs
+++ b/crates/polars-expr/src/expressions/ternary.rs
@@ -1,3 +1,5 @@
+use std::ops::Not;
+
 use polars_core::prelude::*;
 use polars_core::runtime::RAYON;
 use polars_plan::prelude::*;
@@ -14,6 +16,7 @@ pub struct TernaryExpr {
     // Can be expensive on small data to run literals in parallel.
     run_par: bool,
     returns_scalar: bool,
+    short_circuit: bool,
 }
 
 impl TernaryExpr {
@@ -24,6 +27,7 @@ impl TernaryExpr {
         expr: Expr,
         run_par: bool,
         returns_scalar: bool,
+        short_circuit: bool,
     ) -> Self {
         Self {
             predicate,
@@ -32,8 +36,77 @@ impl TernaryExpr {
             expr,
             run_par,
             returns_scalar,
+            short_circuit,
         }
     }
+
+    fn finish_short_circuit_fast_path(
+        &self,
+        column: Column,
+        df: &DataFrame,
+    ) -> PolarsResult<Column> {
+        let name = self.to_field(df.schema())?.name().clone();
+        let length = if self.returns_scalar { 1 } else { df.height() };
+        Ok(broadcast_scalar_output(column, length).with_name(name))
+    }
+}
+
+fn broadcast_scalar_output(column: Column, length: usize) -> Column {
+    if column.len() == 1 && length != 1 {
+        column.new_from_index(0, length)
+    } else {
+        column
+    }
+}
+
+fn prepare_branch(column: Column, expected_len: usize, branch_name: &str) -> PolarsResult<Column> {
+    match column.len() {
+        1 => Ok(broadcast_scalar_output(column, expected_len)),
+        len if len == expected_len => Ok(column),
+        len => polars_bail!(
+            ShapeMismatch:
+            "short-circuit ternary branch produced length {len}, expected either 1 or {expected_len} for the {branch_name} branch"
+        ),
+    }
+}
+
+fn finish_short_circuit(
+    mask: &BooleanChunked,
+    truthy: Column,
+    falsy: Column,
+    output_field: Field,
+) -> PolarsResult<Column> {
+    polars_ensure!(
+        mask.len() <= IdxSize::MAX as usize,
+        ComputeError: "short-circuit ternary output exceeds the index size"
+    );
+
+    let true_count = mask.num_trues();
+    let mut values = prepare_branch(truthy, true_count, "truthy")?;
+    let falsy = prepare_branch(falsy, mask.len() - true_count, "falsy")?;
+    values.append(&falsy)?;
+
+    let mut truthy_idx = 0 as IdxSize;
+    let mut falsy_idx = true_count as IdxSize;
+    let indices = mask
+        .iter()
+        .map(|mask_value| {
+            if mask_value == Some(true) {
+                let idx = truthy_idx;
+                truthy_idx += 1;
+                idx
+            } else {
+                let idx = falsy_idx;
+                falsy_idx += 1;
+                idx
+            }
+        })
+        .collect();
+    let indices = IdxCa::from_vec(PlSmallStr::EMPTY, indices);
+
+    Ok(values
+        .take(&indices)?
+        .with_name(output_field.name().clone()))
 }
 
 fn finish_as_iters<'a>(
@@ -93,17 +166,66 @@ impl PhysicalExpr for TernaryExpr {
         let mask_series = self.predicate.evaluate(df, &state)?;
         let mask = mask_series.bool()?.clone();
 
-        let op_truthy = || self.truthy.evaluate(df, &state);
-        let op_falsy = || self.falsy.evaluate(df, &state);
-        let (truthy, falsy) = if self.run_par {
-            RAYON.install(|| rayon::join(op_truthy, op_falsy))
-        } else {
-            (op_truthy(), op_falsy())
-        };
-        let truthy = truthy?;
-        let falsy = falsy?;
+        if !self.short_circuit {
+            let op_truthy = || self.truthy.evaluate(df, &state);
+            let op_falsy = || self.falsy.evaluate(df, &state);
+            let (truthy, falsy) = if self.run_par {
+                RAYON.install(|| rayon::join(op_truthy, op_falsy))
+            } else {
+                (op_truthy(), op_falsy())
+            };
+            let truthy = truthy?;
+            let falsy = falsy?;
 
-        truthy.zip_with(&mask, &falsy)
+            return truthy.zip_with(&mask, &falsy);
+        }
+
+        let mask = mask.fill_null_with_values(false)?;
+
+        if mask.len() == 1 {
+            let branch = if mask.get(0) == Some(true) {
+                self.truthy.evaluate(df, &state)
+            } else {
+                self.falsy.evaluate(df, &state)
+            }?;
+            return self.finish_short_circuit_fast_path(branch, df);
+        }
+
+        if df.height() == 0 {
+            let output_field = self.to_field(df.schema())?;
+            return Ok(Column::full_null(
+                output_field.name().clone(),
+                0,
+                output_field.dtype(),
+            ));
+        }
+
+        let true_count = mask.num_trues();
+
+        if true_count == df.height() {
+            let truthy = self.truthy.evaluate(df, &state)?;
+            return self.finish_short_circuit_fast_path(truthy, df);
+        }
+
+        if true_count == 0 {
+            let falsy = self.falsy.evaluate(df, &state)?;
+            return self.finish_short_circuit_fast_path(falsy, df);
+        }
+
+        let falsy_mask = (&mask).not();
+        let truthy_df = df.filter(&mask)?;
+        let falsy_df = df.filter(&falsy_mask)?;
+
+        let mut truthy_state = state.split();
+        truthy_state.remove_cache_window_flag();
+        let mut falsy_state = state.split();
+        falsy_state.remove_cache_window_flag();
+
+        let truthy = self.truthy.evaluate(&truthy_df, &truthy_state)?;
+        let falsy = self.falsy.evaluate(&falsy_df, &falsy_state)?;
+        let output_field = self.to_field(df.schema())?;
+
+        finish_short_circuit(&mask, truthy, falsy, output_field)
     }
 
     fn to_field(&self, input_schema: &Schema) -> PolarsResult<Field> {
@@ -118,6 +240,12 @@ impl PhysicalExpr for TernaryExpr {
         groups: &'a GroupPositions,
         state: &ExecutionState,
     ) -> PolarsResult<AggregationContext<'a>> {
+        polars_ensure!(
+            !self.short_circuit,
+            InvalidOperation:
+                "short-circuit when-then-otherwise is not yet supported in grouped execution"
+        );
+
         let op_mask = || self.predicate.evaluate_on_groups(df, groups, state);
         let op_truthy = || self.truthy.evaluate_on_groups(df, groups, state);
         let op_falsy = || self.falsy.evaluate_on_groups(df, groups, state);

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -453,9 +453,26 @@ fn create_physical_expr_inner(
             predicate,
             truthy,
             falsy,
+            short_circuit,
         } => {
             let is_scalar = is_scalar_ae(expression, expr_arena);
             let mut lit_count = 0u8;
+
+            let short_circuit_is_safe = |node| {
+                is_row_separable_rec(node, expr_arena)
+                    && (is_length_preserving_ae(node, expr_arena) || is_scalar_ae(node, expr_arena))
+            };
+
+            if short_circuit {
+                polars_ensure!(
+                    short_circuit_is_safe(predicate)
+                        && short_circuit_is_safe(truthy)
+                        && short_circuit_is_safe(falsy),
+                    InvalidOperation:
+                        "short-circuit when-then-otherwise only supports row-separable scalar or length-preserving expressions"
+                );
+            }
+
             state.reset();
             let predicate = create_physical_expr_inner(predicate, expr_arena, schema, state)?;
             lit_count += state.local.has_lit as u8;
@@ -472,6 +489,7 @@ fn create_physical_expr_inner(
                 node_to_expr(expression, expr_arena),
                 state.allow_threading && lit_count < 2,
                 is_scalar,
+                short_circuit,
             )))
         },
         AExpr::AnonymousAgg {

--- a/crates/polars-plan/dsl-schema-hashes.json
+++ b/crates/polars-plan/dsl-schema-hashes.json
@@ -54,7 +54,7 @@
   "Either_PythonObject_or_Schema": "0d821273ba90fdd2bb0aba8d4bca9d32aae3ed5ebfac7cf7c10358ec7ae47a58",
   "EvalVariant": "6f3f2249f963d4b89339a93beace83e0be41310b4779af62ace5d4240013d7d8",
   "ExplodeOptions": "46ef78ccb0ca3a84a96dc69c4bba22790e9adc50a2862a68fa8c58c793c660bf",
-  "Expr": "03e441c5ae30ea777dd72e834e6805946c0b9d89d0c6ee19f90c6cd87c187865",
+  "Expr": "71137c74a8be3dba79a23b121a6c6fd0be895754accb9a3ec1aa19c393b45b10",
   "ExtensionFunction": "71c0d75cd439c60a5c304faba11dacceb7aeb02d146c6b9f0b34fe9aa1558391",
   "ExtensionType": "a380b26c5005eefd6e8656dc1048ac3a20269f6fd6f8e0b3c0b07e7b46495039",
   "ExternalCompression": "91815b530a206d74dd80291a7b93bbcf8df5e108278c1c5191cfab7e5a131e27",

--- a/crates/polars-plan/src/dsl/arity.rs
+++ b/crates/polars-plan/src/dsl/arity.rs
@@ -11,6 +11,7 @@ use super::*;
 #[derive(Clone)]
 pub struct When {
     condition: Expr,
+    short_circuit: bool,
 }
 
 /// Utility struct for the `when-then-otherwise` expression.
@@ -21,6 +22,8 @@ pub struct When {
 pub struct Then {
     condition: Expr,
     statement: Expr,
+    #[cfg_attr(feature = "serde", serde(default))]
+    short_circuit: bool,
 }
 
 /// Utility struct for the `when-then-otherwise` expression.
@@ -32,6 +35,7 @@ pub struct Then {
 pub struct ChainedWhen {
     conditions: Vec<Expr>,
     statements: Vec<Expr>,
+    short_circuit: bool,
 }
 
 /// Utility struct for the `when-then-otherwise` expression.
@@ -42,14 +46,25 @@ pub struct ChainedWhen {
 pub struct ChainedThen {
     conditions: Vec<Expr>,
     statements: Vec<Expr>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    short_circuit: bool,
 }
 
 impl When {
+    /// Enable experimental selective evaluation of conditional branches.
+    ///
+    /// This is limited to non-grouped, row-separable scalar or length-preserving expressions.
+    pub fn short_circuit(mut self) -> Self {
+        self.short_circuit = true;
+        self
+    }
+
     /// Add a condition to the `when-then-otherwise` expression.
     pub fn then<E: Into<Expr>>(self, expr: E) -> Then {
         Then {
             condition: self.condition,
             statement: expr.into(),
+            short_circuit: self.short_circuit,
         }
     }
 }
@@ -60,12 +75,18 @@ impl Then {
         ChainedWhen {
             conditions: vec![self.condition, condition.into()],
             statements: vec![self.statement],
+            short_circuit: self.short_circuit,
         }
     }
 
     /// Define a default for the `when-then-otherwise` expression.
     pub fn otherwise<E: Into<Expr>>(self, statement: E) -> Expr {
-        ternary_expr(self.condition, self.statement, statement.into())
+        ternary_expr_with_option(
+            self.condition,
+            self.statement,
+            statement.into(),
+            self.short_circuit,
+        )
     }
 }
 
@@ -75,6 +96,7 @@ impl ChainedWhen {
         ChainedThen {
             conditions: self.conditions,
             statements: self.statements,
+            short_circuit: self.short_circuit,
         }
     }
 }
@@ -87,6 +109,7 @@ impl ChainedThen {
         ChainedWhen {
             conditions: self.conditions,
             statements: self.statements,
+            short_circuit: self.short_circuit,
         }
     }
 
@@ -122,12 +145,13 @@ impl ChainedThen {
         let mut otherwise = expr.into();
 
         for e in conditions_iter {
-            otherwise = ternary_expr(
+            otherwise = ternary_expr_with_option(
                 e,
                 statements_iter
                     .next()
                     .expect("expr expected, did you call when().then().otherwise?"),
                 otherwise,
+                self.short_circuit,
             );
         }
 
@@ -137,16 +161,31 @@ impl ChainedThen {
 
 /// Start a `when-then-otherwise` expression.
 pub fn when<E: Into<Expr>>(condition: E) -> When {
+    when_with_options(condition, false)
+}
+
+fn when_with_options<E: Into<Expr>>(condition: E, short_circuit: bool) -> When {
     When {
         condition: condition.into(),
+        short_circuit,
     }
 }
 
 pub fn ternary_expr(predicate: Expr, truthy: Expr, falsy: Expr) -> Expr {
+    ternary_expr_with_option(predicate, truthy, falsy, false)
+}
+
+pub fn ternary_expr_with_option(
+    predicate: Expr,
+    truthy: Expr,
+    falsy: Expr,
+    short_circuit: bool,
+) -> Expr {
     Expr::Ternary {
         predicate: Arc::new(predicate),
         truthy: Arc::new(truthy),
         falsy: Arc::new(falsy),
+        short_circuit,
     }
 }
 

--- a/crates/polars-plan/src/dsl/expr/mod.rs
+++ b/crates/polars-plan/src/dsl/expr/mod.rs
@@ -105,6 +105,8 @@ pub enum Expr {
         predicate: Arc<Expr>,
         truthy: Arc<Expr>,
         falsy: Arc<Expr>,
+        #[cfg_attr(feature = "serde", serde(default))]
+        short_circuit: bool,
     },
     Function {
         /// function arguments
@@ -305,10 +307,12 @@ impl Hash for Expr {
                 predicate,
                 truthy,
                 falsy,
+                short_circuit,
             } => {
                 predicate.hash(state);
                 truthy.hash(state);
                 falsy.hash(state);
+                short_circuit.hash(state);
             },
             Expr::Function { input, function } => {
                 input.hash(state);

--- a/crates/polars-plan/src/dsl/format.rs
+++ b/crates/polars-plan/src/dsl/format.rs
@@ -202,10 +202,20 @@ impl fmt::Debug for Expr {
                 predicate,
                 truthy,
                 falsy,
-            } => write!(
-                f,
-                ".when({predicate:?}).then({truthy:?}).otherwise({falsy:?})",
-            ),
+                short_circuit,
+            } => {
+                if *short_circuit {
+                    write!(
+                        f,
+                        ".when({predicate:?}).short_circuit().then({truthy:?}).otherwise({falsy:?})",
+                    )
+                } else {
+                    write!(
+                        f,
+                        ".when({predicate:?}).then({truthy:?}).otherwise({falsy:?})"
+                    )
+                }
+            },
             Function { input, function } => {
                 #[cfg(feature = "dtype-struct")]
                 if matches!(function, FunctionExpr::AsStruct) {

--- a/crates/polars-plan/src/plans/aexpr/builder.rs
+++ b/crates/polars-plan/src/plans/aexpr/builder.rs
@@ -295,6 +295,7 @@ impl AExprBuilder {
                 predicate: self.into_aexpr_builder().node(),
                 truthy: truthy.into_aexpr_builder().node(),
                 falsy: falsy.into_aexpr_builder().node(),
+                short_circuit: false,
             },
             arena,
         )

--- a/crates/polars-plan/src/plans/aexpr/equality.rs
+++ b/crates/polars-plan/src/plans/aexpr/equality.rs
@@ -82,9 +82,14 @@ impl AExpr {
             // Discriminant check done above.
             E::Element |
             E::Filter { input: _, by: _ } |
-            E::Ternary { predicate: _, truthy: _, falsy: _ } |
             E::Slice { input: _, offset: _, length: _ } |
             E::Len => true,
+            E::Ternary {
+                predicate: _,
+                truthy: _,
+                falsy: _,
+                short_circuit: l_short_circuit,
+            } => matches!(other, E::Ternary { predicate: _, truthy: _, falsy: _, short_circuit: r_short_circuit } if l_short_circuit == r_short_circuit),
             #[cfg(feature = "dtype-struct")]
             E::StructEval { expr: _, evaluation: _} => true
         };

--- a/crates/polars-plan/src/plans/aexpr/hash.rs
+++ b/crates/polars-plan/src/plans/aexpr/hash.rs
@@ -87,7 +87,8 @@ impl Hash for AExpr {
                 predicate: _,
                 truthy: _,
                 falsy: _,
-            } => {},
+                short_circuit,
+            } => short_circuit.hash(state),
             AExpr::AnonymousAgg {
                 input: _,
                 fmt_str,

--- a/crates/polars-plan/src/plans/aexpr/mod.rs
+++ b/crates/polars-plan/src/plans/aexpr/mod.rs
@@ -220,6 +220,8 @@ pub enum AExpr {
         predicate: Node,
         truthy: Node,
         falsy: Node,
+        #[cfg_attr(feature = "ir_serde", serde(default))]
+        short_circuit: bool,
     },
     AnonymousAgg {
         input: Vec<ExprIR>,

--- a/crates/polars-plan/src/plans/aexpr/traverse.rs
+++ b/crates/polars-plan/src/plans/aexpr/traverse.rs
@@ -42,6 +42,7 @@ impl AExpr {
                 truthy,
                 falsy,
                 predicate,
+                ..
             } => {
                 container.extend([*predicate, *truthy, *falsy]);
             },
@@ -130,6 +131,7 @@ impl AExpr {
                 truthy,
                 falsy,
                 predicate,
+                ..
             } => {
                 container.extend([*predicate, *falsy, *truthy]);
             },
@@ -246,6 +248,7 @@ impl AExpr {
                 truthy,
                 falsy,
                 predicate,
+                ..
             } => {
                 container.extend([*predicate, *falsy, *truthy]);
             },
@@ -333,6 +336,7 @@ impl AExpr {
                 truthy,
                 falsy,
                 predicate,
+                ..
             } => {
                 *truthy = inputs[0];
                 *falsy = inputs[1];
@@ -443,6 +447,7 @@ impl AExpr {
                 truthy,
                 falsy,
                 predicate,
+                ..
             } => {
                 *truthy = inputs[0];
                 *falsy = inputs[1];

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_expansion.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_expansion.rs
@@ -563,6 +563,7 @@ fn expand_expression_rec(
             predicate,
             truthy,
             falsy,
+            short_circuit,
         } => {
             _ = expand_expression_by_combination(
                 &[
@@ -578,6 +579,7 @@ fn expand_expression_rec(
                     predicate: Arc::new(e[0].clone()),
                     truthy: Arc::new(e[1].clone()),
                     falsy: Arc::new(e[2].clone()),
+                    short_circuit: *short_circuit,
                 },
             )?
         },

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/expr_to_ir.rs
@@ -346,6 +346,7 @@ pub(super) fn to_aexpr_impl(
             predicate,
             truthy,
             falsy,
+            short_circuit,
         } => {
             let (p, _) = to_aexpr_mat_lit_arc!(predicate)?;
             let (t, output_name) = recurse_arc!(truthy)?;
@@ -355,6 +356,7 @@ pub(super) fn to_aexpr_impl(
                     predicate: p,
                     truthy: t,
                     falsy: f,
+                    short_circuit,
                 },
                 output_name,
             )

--- a/crates/polars-plan/src/plans/conversion/ir_to_dsl.rs
+++ b/crates/polars-plan/src/plans/conversion/ir_to_dsl.rs
@@ -187,6 +187,7 @@ pub fn node_to_expr(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
             predicate,
             truthy,
             falsy,
+            short_circuit,
         } => {
             let p = node_to_expr(predicate, expr_arena);
             let t = node_to_expr(truthy, expr_arena);
@@ -196,6 +197,7 @@ pub fn node_to_expr(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
                 predicate: Arc::new(p),
                 truthy: Arc::new(t),
                 falsy: Arc::new(f),
+                short_circuit,
             }
         },
         AExpr::AnonymousAgg {

--- a/crates/polars-plan/src/plans/conversion/type_coercion/binary.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/binary.rs
@@ -785,6 +785,7 @@ pub(super) fn coerce_comparison_literal(
                 DataType::Boolean,
                 AnyValue::Null,
             )))),
+            short_circuit: false,
         },
         output_constraint: Some(if nonnull_rows_value {
             BoolValueAlways::TrueOrNull

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -192,6 +192,7 @@ impl OptimizationRule for TypeCoercionRule {
                 truthy: truthy_node,
                 falsy: falsy_node,
                 predicate,
+                short_circuit,
             } => {
                 let (truthy, type_true) =
                     unpack!(get_aexpr_and_type(expr_arena, truthy_node, schema));
@@ -232,6 +233,7 @@ impl OptimizationRule for TypeCoercionRule {
                     truthy: new_node_truthy,
                     falsy: new_node_falsy,
                     predicate,
+                    short_circuit,
                 })
             },
             AExpr::BinaryExpr {

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -619,11 +619,19 @@ impl Display for ExprIRDisplay<'_> {
                 predicate,
                 truthy,
                 falsy,
+                short_circuit,
             } => {
                 let predicate = self.with_root(predicate);
                 let truthy = self.with_root(truthy);
                 let falsy = self.with_root(falsy);
-                write!(f, "when({predicate}).then({truthy}).otherwise({falsy})",)
+                if *short_circuit {
+                    write!(
+                        f,
+                        "when({predicate}).short_circuit().then({truthy}).otherwise({falsy})",
+                    )
+                } else {
+                    write!(f, "when({predicate}).then({truthy}).otherwise({falsy})")
+                }
             },
             Function {
                 input, function, ..

--- a/crates/polars-plan/src/plans/iterator.rs
+++ b/crates/polars-plan/src/plans/iterator.rs
@@ -63,6 +63,7 @@ macro_rules! push_expr {
                 truthy,
                 falsy,
                 predicate,
+                ..
             } => {
                 $push($c, predicate);
                 $push($c, falsy);

--- a/crates/polars-plan/src/plans/optimizer/simplify_expr/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_expr/mod.rs
@@ -317,6 +317,7 @@ impl OptimizationRule for SimplifyBooleanRule {
                 predicate,
                 truthy,
                 falsy,
+                ..
             } => {
                 return Ok(arity::simplify_ternary(
                     *predicate, *truthy, *falsy, expr_arena,

--- a/crates/polars-plan/src/plans/optimizer/simplify_ordering/expr.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_ordering/expr.rs
@@ -270,6 +270,7 @@ impl ExprOrderSimplifier<'_> {
                         predicate,
                         truthy,
                         falsy,
+                        ..
                     } => ([*truthy, *falsy], Some(*predicate)),
                     _ => unreachable!(),
                 };

--- a/crates/polars-plan/src/plans/visitor/expr.rs
+++ b/crates/polars-plan/src/plans/visitor/expr.rs
@@ -77,7 +77,7 @@ impl TreeWalker for Expr {
                 Var(x, ddf) => Var(am(x, f)?, ddf),
 
             }),
-            Ternary { predicate, truthy, falsy } => Ternary { predicate: am(predicate, &mut f)?, truthy: am(truthy, &mut f)?, falsy: am(falsy, f)? },
+            Ternary { predicate, truthy, falsy, short_circuit } => Ternary { predicate: am(predicate, &mut f)?, truthy: am(truthy, &mut f)?, falsy: am(falsy, f)?, short_circuit },
             Function { input, function } => Function { input: input.into_iter().map(f).collect::<Result<_, _>>()?, function },
             Explode { input, options } => Explode { input: am(input, f)?, options },
             Filter { input, by } => Filter { input: am(input, &mut f)?, by: am(by, f)? },

--- a/crates/polars-python/src/functions/whenthen.rs
+++ b/crates/polars-python/src/functions/whenthen.rs
@@ -37,6 +37,12 @@ pub struct PyChainedThen {
 
 #[pymethods]
 impl PyWhen {
+    fn short_circuit(&self) -> PyWhen {
+        PyWhen {
+            inner: self.inner.clone().short_circuit(),
+        }
+    }
+
     fn then(&self, statement: PyExpr) -> PyThen {
         PyThen {
             inner: self.inner.clone().then(statement.inner),

--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -456,6 +456,8 @@ pub struct Ternary {
     truthy: usize,
     #[pyo3(get)]
     falsy: usize,
+    #[pyo3(get)]
+    short_circuit: bool,
 }
 
 #[pyclass(frozen)]
@@ -900,10 +902,12 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<Py<PyAny>> {
             predicate,
             truthy,
             falsy,
+            short_circuit,
         } => Ternary {
             predicate: predicate.0,
             truthy: truthy.0,
             falsy: falsy.0,
+            short_circuit: *short_circuit,
         }
         .into_py_any(py),
         AExpr::AnonymousFunction { .. } => Err(PyNotImplementedError::new_err("anonymousfunction")),

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -206,6 +206,7 @@ pub fn is_input_independent_rec(
             predicate,
             truthy,
             falsy,
+            ..
         } => {
             is_input_independent_rec(*predicate, arena, cache)
                 && is_input_independent_rec(*truthy, arena, cache)
@@ -1852,6 +1853,7 @@ fn lower_exprs_with_ctx(
                 predicate,
                 truthy,
                 falsy,
+                short_circuit,
             } => {
                 let (trans_input, trans_exprs) =
                     lower_exprs_with_ctx(input, &[predicate, truthy, falsy], ctx)?;
@@ -1859,6 +1861,7 @@ fn lower_exprs_with_ctx(
                     predicate: trans_exprs[0],
                     truthy: trans_exprs[1],
                     falsy: trans_exprs[2],
+                    short_circuit,
                 };
                 input_streams.insert(trans_input);
                 transformed_exprs.push(ctx.expr_arena.add(tern_expr));

--- a/crates/polars-stream/src/physical_plan/lower_group_by.rs
+++ b/crates/polars-stream/src/physical_plan/lower_group_by.rs
@@ -357,8 +357,10 @@ fn try_lower_elementwise_scalar_agg_expr(
             predicate,
             truthy,
             falsy,
+            short_circuit,
         } => {
-            let (predicate, truthy, falsy) = (*predicate, *truthy, *falsy);
+            let (predicate, truthy, falsy, short_circuit) =
+                (*predicate, *truthy, *falsy, *short_circuit);
             let predicate = lower_rec!(predicate)?;
             let truthy = lower_rec!(truthy)?;
             let falsy = lower_rec!(falsy)?;
@@ -366,6 +368,7 @@ fn try_lower_elementwise_scalar_agg_expr(
                 predicate,
                 truthy,
                 falsy,
+                short_circuit,
             }))
         },
 

--- a/crates/polars/tests/it/lazy/expressions/arity.rs
+++ b/crates/polars/tests/it/lazy/expressions/arity.rs
@@ -1,3 +1,6 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use super::*;
 
 #[test]
@@ -37,6 +40,118 @@ fn ternary_expand_sizes() -> PolarsResult<()> {
         .collect()?;
     let vals = out.column("c")?.str()?.no_null_iter().collect::<Vec<_>>();
     assert_eq!(vals, &["a1", "b2", "otherwise"]);
+    Ok(())
+}
+
+#[test]
+fn ternary_short_circuit_is_opt_in() -> PolarsResult<()> {
+    fn counted_branch(counter: Arc<AtomicUsize>, multiplier: i32) -> Expr {
+        col("a").map(
+            move |s| {
+                counter.fetch_add(s.len(), Ordering::Relaxed);
+                Ok(s.i32()?.apply_values(|v| v * multiplier).into_column())
+            },
+            |_, f| Ok(f.clone()),
+        )
+    }
+
+    let df = df!["a" => [1i32, 2, 3, 4, 5]]?;
+
+    let eager_first = Arc::new(AtomicUsize::new(0));
+    let eager_second = Arc::new(AtomicUsize::new(0));
+    let eager_fallback = Arc::new(AtomicUsize::new(0));
+
+    let eager = df
+        .clone()
+        .lazy()
+        .select([when(col("a").lt(lit(3)))
+            .then(counted_branch(eager_first.clone(), 10))
+            .when(col("a").lt(lit(5)))
+            .then(counted_branch(eager_second.clone(), 100))
+            .otherwise(counted_branch(eager_fallback.clone(), 1000))
+            .alias("out")])
+        .collect()?;
+
+    assert_eq!(
+        eager
+            .column("out")?
+            .i32()?
+            .into_no_null_iter()
+            .collect::<Vec<_>>(),
+        vec![10, 20, 300, 400, 5000]
+    );
+    assert_eq!(eager_first.load(Ordering::Relaxed), 5);
+    assert_eq!(eager_second.load(Ordering::Relaxed), 5);
+    assert_eq!(eager_fallback.load(Ordering::Relaxed), 5);
+
+    let short_first = Arc::new(AtomicUsize::new(0));
+    let short_second = Arc::new(AtomicUsize::new(0));
+    let short_fallback = Arc::new(AtomicUsize::new(0));
+
+    let short = df
+        .lazy()
+        .select([when(col("a").lt(lit(3)))
+            .short_circuit()
+            .then(counted_branch(short_first.clone(), 10))
+            .when(col("a").lt(lit(5)))
+            .then(counted_branch(short_second.clone(), 100))
+            .otherwise(counted_branch(short_fallback.clone(), 1000))
+            .alias("out")])
+        .collect()?;
+
+    assert_eq!(
+        short
+            .column("out")?
+            .i32()?
+            .into_no_null_iter()
+            .collect::<Vec<_>>(),
+        vec![10, 20, 300, 400, 5000]
+    );
+    assert_eq!(short_first.load(Ordering::Relaxed), 2);
+    assert_eq!(short_second.load(Ordering::Relaxed), 2);
+    assert_eq!(short_fallback.load(Ordering::Relaxed), 1);
+
+    Ok(())
+}
+
+#[test]
+fn ternary_short_circuit_skips_unreachable_errors() -> PolarsResult<()> {
+    fn exploding_branch() -> Expr {
+        col("a").map(
+            |_| polars_bail!(ComputeError: "should not run"),
+            |_, f| Ok(f.clone()),
+        )
+    }
+
+    let df = df!["a" => [1i32, 2, 3]]?;
+
+    let short = df
+        .clone()
+        .lazy()
+        .select([when(col("a").is_not_null())
+            .short_circuit()
+            .then(lit(1i32))
+            .otherwise(exploding_branch())
+            .alias("out")])
+        .collect()?;
+    assert_eq!(
+        short
+            .column("out")?
+            .i32()?
+            .into_no_null_iter()
+            .collect::<Vec<_>>(),
+        vec![1, 1, 1]
+    );
+
+    let eager = df
+        .lazy()
+        .select([when(col("a").is_not_null())
+            .then(lit(1i32))
+            .otherwise(exploding_branch())
+            .alias("out")])
+        .collect();
+    assert!(eager.is_err());
+
     Ok(())
 }
 

--- a/py-polars/src/polars/expr/whenthen.py
+++ b/py-polars/src/polars/expr/whenthen.py
@@ -33,6 +33,14 @@ class When:
     def __init__(self, when: Any) -> None:
         self._when = when
 
+    def short_circuit(self) -> When:
+        """Enable experimental selective evaluation of conditional branches.
+
+        This is limited to non-grouped, row-separable scalar or
+        length-preserving expressions.
+        """
+        return When(self._when.short_circuit())
+
     def then(self, statement: IntoExpr) -> Then:
         """
         Attach a statement to the corresponding condition.

--- a/py-polars/src/polars/functions/whenthen.py
+++ b/py-polars/src/polars/functions/whenthen.py
@@ -46,9 +46,12 @@ def when(
 
     Warnings
     --------
-    Polars computes all expressions passed to `when-then-otherwise` in parallel and
-    filters afterwards. This means each expression must be valid on its own, regardless
-    of the conditions in the `when-then-otherwise` chain.
+    By default, Polars computes all expressions passed to `when-then-otherwise` in
+    parallel and filters afterwards. This means each expression must be valid on its
+    own, regardless of the conditions in the `when-then-otherwise` chain.
+
+    Call :meth:`When.short_circuit` to evaluate each branch only for the rows that
+    still need a value.
 
     Notes
     -----
@@ -77,7 +80,8 @@ def when(
     │ 4   ┆ 0   ┆ 1   │
     └─────┴─────┴─────┘
 
-    Note that `when-then` always executes all expressions.
+    Note that `when-then` executes all expressions unless
+    :meth:`When.short_circuit` is used.
 
     The results are folded left to right, picking the `then` value from the first `when`
     condition that is True.

--- a/py-polars/tests/unit/functions/test_when_then.py
+++ b/py-polars/tests/unit/functions/test_when_then.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import itertools
 import random
-from datetime import datetime
+from datetime import datetime, timezone
+from decimal import Decimal
 from typing import Any
 
 import pytest
@@ -54,6 +55,179 @@ def test_when_then_chained() -> None:
         }
     )
     assert_frame_equal(result, expected)
+
+
+def test_when_then_remains_eager_by_default() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3, 4, 5]})
+    first_calls = 0
+    second_calls = 0
+    fallback_calls = 0
+
+    def first(v: int) -> int:
+        nonlocal first_calls
+        first_calls += 1
+        return v * 10
+
+    def second(v: int) -> int:
+        nonlocal second_calls
+        second_calls += 1
+        return v * 100
+
+    def fallback(v: int) -> int:
+        nonlocal fallback_calls
+        fallback_calls += 1
+        return v * 1000
+
+    result = df.select(
+        pl.when(pl.col("a") < 3)
+        .then(pl.col("a").map_elements(first, return_dtype=pl.Int64))
+        .when(pl.col("a") < 5)
+        .then(pl.col("a").map_elements(second, return_dtype=pl.Int64))
+        .otherwise(pl.col("a").map_elements(fallback, return_dtype=pl.Int64))
+        .alias("out")
+    )
+
+    assert_frame_equal(result, pl.DataFrame({"out": [10, 20, 300, 400, 5000]}))
+    assert (first_calls, second_calls, fallback_calls) == (5, 5, 5)
+
+
+def test_when_then_short_circuit_evaluates_only_selected_rows() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3, 4, 5]})
+    first_calls = 0
+    second_calls = 0
+    fallback_calls = 0
+
+    def first(v: int) -> int:
+        nonlocal first_calls
+        first_calls += 1
+        return v * 10
+
+    def second(v: int) -> int:
+        nonlocal second_calls
+        second_calls += 1
+        return v * 100
+
+    def fallback(v: int) -> int:
+        nonlocal fallback_calls
+        fallback_calls += 1
+        return v * 1000
+
+    result = df.select(
+        pl.when(pl.col("a") < 3)
+        .short_circuit()
+        .then(pl.col("a").map_elements(first, return_dtype=pl.Int64))
+        .when(pl.col("a") < 5)
+        .then(pl.col("a").map_elements(second, return_dtype=pl.Int64))
+        .otherwise(pl.col("a").map_elements(fallback, return_dtype=pl.Int64))
+        .alias("out")
+    )
+
+    assert_frame_equal(result, pl.DataFrame({"out": [10, 20, 300, 400, 5000]}))
+    assert (first_calls, second_calls, fallback_calls) == (2, 2, 1)
+
+
+@pytest.mark.may_fail_auto_streaming  # Python UDF
+@pytest.mark.may_fail_cloud  # Python UDF
+def test_when_then_short_circuit_skips_unreachable_branch_errors() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3]})
+    msg = "should not run"
+
+    def explode(_: int) -> int:
+        raise RuntimeError(msg)
+
+    short_circuit = df.select(
+        pl.when(pl.col("a").is_not_null())
+        .short_circuit()
+        .then(pl.lit(1))
+        .otherwise(pl.col("a").map_elements(explode, return_dtype=pl.Int64))
+        .alias("out")
+    )
+    assert_frame_equal(short_circuit, pl.DataFrame({"out": [1, 1, 1]}))
+
+    with pytest.raises(RuntimeError, match=msg):
+        df.select(
+            pl.when(pl.col("a").is_not_null())
+            .then(pl.lit(1))
+            .otherwise(pl.col("a").map_elements(explode, return_dtype=pl.Int64))
+        )
+
+
+def test_when_then_short_circuit_preserves_output_name() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+
+    for predicate in [pl.lit(False), pl.col("a") < 0]:
+        result = df.select(
+            pl.when(predicate).short_circuit().then(pl.col("a")).otherwise(pl.col("b"))
+        )
+        assert_series_equal(result.to_series(), df["b"].rename("a"))
+
+
+def test_when_then_short_circuit_preserves_scalar_shape() -> None:
+    eager = pl.when(pl.lit(False)).then(pl.lit(1)).otherwise(pl.lit(2))
+    short_circuit = (
+        pl.when(pl.lit(False)).short_circuit().then(pl.lit(1)).otherwise(pl.lit(2))
+    )
+
+    for df in [pl.DataFrame({"a": [1, 2, 3]}), pl.DataFrame(schema={"a": pl.Int64})]:
+        assert_frame_equal(df.select(short_circuit), df.select(eager))
+
+
+def test_when_then_short_circuit_rejects_unsupported_expressions() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3]})
+
+    with pytest.raises(InvalidOperationError, match="only supports row-separable"):
+        df.select(
+            pl.when(pl.col("a") > 1)
+            .short_circuit()
+            .then(pl.col("a").sum())
+            .otherwise(pl.lit(0))
+        )
+
+
+def test_when_then_short_circuit_preserves_special_dtypes() -> None:
+    enum = pl.Enum(["a", "b", "c"])
+    df = pl.DataFrame(
+        {
+            "categorical_then": pl.Series(["a", "b", "c"], dtype=pl.Categorical),
+            "categorical_else": pl.Series(["c", "a", "b"], dtype=pl.Categorical),
+            "enum_then": pl.Series(["a", "b", "c"], dtype=enum),
+            "enum_else": pl.Series(["c", "a", "b"], dtype=enum),
+            "decimal_then": pl.Series(
+                [Decimal("1.00"), Decimal("2.00"), Decimal("3.00")],
+                dtype=pl.Decimal(10, 2),
+            ),
+            "decimal_else": pl.Series(
+                [Decimal("4.00"), Decimal("5.00"), Decimal("6.00")],
+                dtype=pl.Decimal(10, 2),
+            ),
+            "datetime_then": pl.Series(
+                [
+                    datetime(2020, 1, 1, tzinfo=timezone.utc),
+                    datetime(2020, 1, 2, tzinfo=timezone.utc),
+                    datetime(2020, 1, 3, tzinfo=timezone.utc),
+                ]
+            ),
+            "datetime_else": pl.Series(
+                [
+                    datetime(2021, 1, 1, tzinfo=timezone.utc),
+                    datetime(2021, 1, 2, tzinfo=timezone.utc),
+                    datetime(2021, 1, 3, tzinfo=timezone.utc),
+                ]
+            ),
+        }
+    )
+
+    for mask in [[True, False, True], [True] * 3, [False] * 3]:
+        test_df = df.with_columns(pl.Series("mask", mask))
+        for prefix in ["categorical", "enum", "decimal", "datetime"]:
+            eager = pl.when("mask").then(f"{prefix}_then").otherwise(f"{prefix}_else")
+            short_circuit = (
+                pl.when("mask")
+                .short_circuit()
+                .then(f"{prefix}_then")
+                .otherwise(f"{prefix}_else")
+            )
+            assert_frame_equal(test_df.select(short_circuit), test_df.select(eager))
 
 
 def test_when_then_invalid_chains() -> None:


### PR DESCRIPTION
### Overview

This commit adds short-circuiting functionality for Polars' when-then-when-then-otherwise chained expressions, e.g.

```python
(
    pl.when(pl.col("kind") == "a")
    .short_circuit()
    .then(expensive_expr_a)
    .when(pl.col("kind") == "b")
    .then(expensive_expr_b)
    .otherwise(fallback_expr)
)
```

Benchmark results on synthetic 100-chained when-then toy-problem:

| Scenario     | Eager mean (ms) | Short-circuit mean (ms) | Relative speed |
| ------------ | --------------: | ----------------------: | -------------: |
| front-loaded |          259.68 |                   10.00 |         25.97x |
| uniform      |          254.42 |                  930.30 |          0.27x |

`.short_circuit()` is ofcourse optional, so it can simply be omitted in cases where outcomes are ~uniform (or when there isn't large compute-cost discrepancies between outcomes),

Issue/Feature-request: #28417

### AI Use Note

1. I used AI to implement this experimental feature.
2. I'm not familiar with Rust, but I figured I'd open the PR since it's a relatively small (~600 line) change. I've also done a couple of review iterations with gpt-5.6-sol. I'm happy to iterate on the PR based on feedback, thanks!

### `make test` screenshot:

<img width="1710" height="779" alt="image" src="https://github.com/user-attachments/assets/85ae27ef-8bb2-4798-b5d6-23c64539c3a0" />
