### PR TITLE
fix(rust): Add missing Send bounds in Connector

### DIFF
--- a/crates/polars-async/src/primitives/connector.rs
+++ b/crates/polars-async/src/primitives/connector.rs
@@ -209,7 +209,7 @@ pub struct SenderExt<T, S> {
     connector: Arc<Connector<T, S>>,
 }
 
-unsafe impl<T: Send, S: Sync> Send for SenderExt<T, S> {}
+unsafe impl<T: Send, S: Send + Sync> Send for SenderExt<T, S> {}
 
 impl<T, S> Drop for SenderExt<T, S> {
     fn drop(&mut self) {
@@ -221,7 +221,7 @@ pub struct ReceiverExt<T, S> {
     connector: Arc<Connector<T, S>>,
 }
 
-unsafe impl<T: Send, S: Sync> Send for ReceiverExt<T, S> {}
+unsafe impl<T: Send, S: Send + Sync> Send for ReceiverExt<T, S> {}
 
 impl<T, S> Drop for ReceiverExt<T, S> {
     fn drop(&mut self) {


### PR DESCRIPTION
Found with AI, didn't result in any bugs since all uses already satisfied `Send`, but this bound was missing.