### PR TITLE
perf: Improve performance of when/then/otherwise by masking out unevaluated elements

### DIFF
--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -1279,6 +1279,28 @@ impl Column {
         self.as_materialized_series().shift(periods).into()
     }
 
+    pub fn with_validity(&self, validity: Option<Bitmap>) -> Column {
+        match self {
+            Column::Series(s) => Column::from(s.with_validity(validity)),
+            Column::Scalar(s) => match validity {
+                Some(v) => Column::from(s.as_materialized_series().with_validity(Some(v))),
+                None => Column::Scalar(s.clone()),
+            },
+        }
+    }
+
+    pub fn mask(&self, validity: &Bitmap) -> Column {
+        if validity.len() == 1 {
+            if validity.get_bit(0) {
+                self.clone()
+            } else {
+                Self::full_null(self.name().clone(), self.len(), self.dtype())
+            }
+        } else {
+            Column::from(self.as_materialized_series().mask(validity))
+        }
+    }
+
     #[cfg(feature = "zip_with")]
     pub fn zip_with(&self, mask: &BooleanChunked, other: &Self) -> PolarsResult<Self> {
         // @scalar-opt

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -2,6 +2,7 @@ use std::any::Any;
 use std::borrow::Cow;
 
 use arrow::bitmap::{Bitmap, BitmapBuilder};
+use arrow::compute::utils::combine_validities_and;
 use polars_compute::rolling::QuantileMethod;
 
 use crate::chunked_array::cast::CastOptions;
@@ -342,6 +343,24 @@ pub trait SeriesTrait:
 
     /// Sets the validity mask of this Series to the given bitmap.
     fn with_validity(&self, validity: Option<Bitmap>) -> Series;
+
+    /// Applies the given mask to this Series, returning a new Series. If a
+    /// validity bit is true nothing changes, if it is false the corresponding
+    /// element becomes null.
+    fn mask(&self, validity: &Bitmap) -> Series {
+        if validity.len() == 1 {
+            if validity.get_bit(0) {
+                Series(self.clone_inner())
+            } else {
+                Series::full_null(self._field().name().clone(), self.len(), self._dtype())
+            }
+        } else {
+            self.with_validity(combine_validities_and(
+                self.rechunk_validity().as_ref(),
+                Some(validity),
+            ))
+        }
+    }
 
     /// Drop all null values and return a new Series.
     fn drop_nulls(&self) -> Series {

--- a/crates/polars-expr/src/expressions/ternary.rs
+++ b/crates/polars-expr/src/expressions/ternary.rs
@@ -14,6 +14,8 @@ pub struct TernaryExpr {
     // Can be expensive on small data to run literals in parallel.
     run_par: bool,
     returns_scalar: bool,
+    truthy_mask_columns: Vec<PlSmallStr>,
+    falsy_mask_columns: Vec<PlSmallStr>,
 }
 
 impl TernaryExpr {
@@ -24,6 +26,8 @@ impl TernaryExpr {
         expr: Expr,
         run_par: bool,
         returns_scalar: bool,
+        truthy_mask_columns: Vec<PlSmallStr>,
+        falsy_mask_columns: Vec<PlSmallStr>,
     ) -> Self {
         Self {
             predicate,
@@ -32,6 +36,8 @@ impl TernaryExpr {
             expr,
             run_par,
             returns_scalar,
+            truthy_mask_columns,
+            falsy_mask_columns,
         }
     }
 }
@@ -91,30 +97,70 @@ impl PhysicalExpr for TernaryExpr {
         // Don't cache window functions as they run in parallel.
         state.remove_cache_window_flag();
         let mask_series = self.predicate.evaluate(df, &state)?;
-        let mask = mask_series.bool()?.clone();
+        let mut mask = mask_series.bool()?.clone();
 
-        let op_truthy = || self.truthy.evaluate(df, &state);
-        let op_falsy = || self.falsy.evaluate(df, &state);
-        
+        if !self.truthy_mask_columns.is_empty() || !self.falsy_mask_columns.is_empty() {
+            mask.rechunk_mut();
+        }
+
+        let op_truthy = || {
+            let mut mask_df = df.clone();
+            if !self.truthy_mask_columns.is_empty() {
+                let mask = mask.downcast_as_array().values();
+                for c in &self.truthy_mask_columns {
+                    mask_df.with_column(df.column(c).unwrap().mask(mask))?;
+                }
+            }
+            self.truthy.evaluate(&mask_df, &state)
+        };
+        let op_falsy = || {
+            let mut mask_df = df.clone();
+            if !self.falsy_mask_columns.is_empty() {
+                let mask = !mask.downcast_as_array().values();
+                for c in &self.falsy_mask_columns {
+                    mask_df.with_column(df.column(c).unwrap().mask(&mask))?;
+                }
+            }
+            self.falsy.evaluate(&mask_df, &state)
+        };
+
         // Nulls count as false.
         let true_count = mask.num_trues();
         let false_count = mask.len() - true_count;
-        
-        if true_count == 0 {
-            return op_falsy();
-        }
-        
-        if false_count == 0 {
-            return op_truthy();
-        }
 
-        let (truthy, falsy) = if self.run_par {
-            RAYON.install(|| rayon::join(op_truthy, op_falsy))
+        let (truthy, falsy);
+        if true_count == 0 {
+            falsy = op_falsy()?;
+            match (mask.len(), falsy.len()) {
+                (l, 1) if l != 1 => return Ok(falsy.new_from_index(0, l)),
+                (1, r) if r != 1 => return Ok(falsy),
+                (1, 1) => {}, // Forced to evaluate truthy to resolve broadcast height.
+                (l, r) => {
+                    polars_ensure!(l == r, ShapeMismatch: "mismatch between condition height and falsy height in when/then/otherwise");
+                    return Ok(falsy);
+                }
+            }
+            truthy = op_truthy()?;
+        } else if false_count == 0 {
+            truthy = op_truthy()?;
+            match (mask.len(), truthy.len()) {
+                (l, 1) if l != 1 => return Ok(truthy.new_from_index(0, l)),
+                (1, r) if r != 1 => return Ok(truthy),
+                (1, 1) => {}, // Forced to evaluate truthy to resolve broadcast height.
+                (l, r) => {
+                    polars_ensure!(l == r, ShapeMismatch: "mismatch between condition height and truthy height in when/then/otherwise");
+                    return Ok(truthy);
+                }
+            }
+            falsy = op_falsy()?; // Forced to evaluate truthy to resolve broadcast height.
+        } else if self.run_par {
+            let (t, f) = RAYON.install(|| rayon::join(op_truthy, op_falsy));
+            truthy = t?;
+            falsy = f?;
         } else {
-            (op_truthy(), op_falsy())
+            truthy = op_truthy()?;
+            falsy = op_falsy()?;
         };
-        let truthy = truthy?;
-        let falsy = falsy?;
 
         truthy.zip_with(&mask, &falsy)
     }

--- a/crates/polars-expr/src/expressions/ternary.rs
+++ b/crates/polars-expr/src/expressions/ternary.rs
@@ -103,9 +103,13 @@ impl PhysicalExpr for TernaryExpr {
             mask.rechunk_mut();
         }
 
+        // Nulls count as false.
+        let true_count = mask.num_trues();
+        let false_count = mask.len() - true_count;
+
         let op_truthy = || {
             let mut mask_df = df.clone();
-            if !self.truthy_mask_columns.is_empty() {
+            if !self.truthy_mask_columns.is_empty() && false_count != 0 {
                 let mask = mask.downcast_as_array().values();
                 for c in &self.truthy_mask_columns {
                     mask_df.with_column(df.column(c).unwrap().mask(mask))?;
@@ -115,7 +119,7 @@ impl PhysicalExpr for TernaryExpr {
         };
         let op_falsy = || {
             let mut mask_df = df.clone();
-            if !self.falsy_mask_columns.is_empty() {
+            if !self.falsy_mask_columns.is_empty() && true_count != 0 {
                 let mask = !mask.downcast_as_array().values();
                 for c in &self.falsy_mask_columns {
                     mask_df.with_column(df.column(c).unwrap().mask(&mask))?;
@@ -123,10 +127,6 @@ impl PhysicalExpr for TernaryExpr {
             }
             self.falsy.evaluate(&mask_df, &state)
         };
-
-        // Nulls count as false.
-        let true_count = mask.num_trues();
-        let false_count = mask.len() - true_count;
 
         let (truthy, falsy);
         if true_count == 0 {

--- a/crates/polars-expr/src/expressions/ternary.rs
+++ b/crates/polars-expr/src/expressions/ternary.rs
@@ -95,6 +95,19 @@ impl PhysicalExpr for TernaryExpr {
 
         let op_truthy = || self.truthy.evaluate(df, &state);
         let op_falsy = || self.falsy.evaluate(df, &state);
+        
+        // Nulls count as false.
+        let true_count = mask.num_trues();
+        let false_count = mask.len() - true_count;
+        
+        if true_count == 0 {
+            return op_falsy();
+        }
+        
+        if false_count == 0 {
+            return op_truthy();
+        }
+
         let (truthy, falsy) = if self.run_par {
             RAYON.install(|| rayon::join(op_truthy, op_falsy))
         } else {

--- a/crates/polars-expr/src/expressions/ternary.rs
+++ b/crates/polars-expr/src/expressions/ternary.rs
@@ -19,6 +19,7 @@ pub struct TernaryExpr {
 }
 
 impl TernaryExpr {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         predicate: Arc<dyn PhysicalExpr>,
         truthy: Arc<dyn PhysicalExpr>,

--- a/crates/polars-expr/src/expressions/ternary.rs
+++ b/crates/polars-expr/src/expressions/ternary.rs
@@ -138,7 +138,7 @@ impl PhysicalExpr for TernaryExpr {
                 (l, r) => {
                     polars_ensure!(l == r, ShapeMismatch: "mismatch between condition height and falsy height in when/then/otherwise");
                     return Ok(falsy);
-                }
+                },
             }
             truthy = op_truthy()?;
         } else if false_count == 0 {
@@ -150,7 +150,7 @@ impl PhysicalExpr for TernaryExpr {
                 (l, r) => {
                     polars_ensure!(l == r, ShapeMismatch: "mismatch between condition height and truthy height in when/then/otherwise");
                     return Ok(truthy);
-                }
+                },
             }
             falsy = op_falsy()?; // Forced to evaluate truthy to resolve broadcast height.
         } else if self.run_par {

--- a/crates/polars-expr/src/expressions/ternary.rs
+++ b/crates/polars-expr/src/expressions/ternary.rs
@@ -16,6 +16,9 @@ pub struct TernaryExpr {
     returns_scalar: bool,
     truthy_mask_columns: Vec<PlSmallStr>,
     falsy_mask_columns: Vec<PlSmallStr>,
+    // The dtype of this expression, which is the supertype of the arms and thus
+    // can differ from the dtype of an individual arm.
+    output_dtype: Option<DataType>,
 }
 
 impl TernaryExpr {
@@ -29,6 +32,7 @@ impl TernaryExpr {
         returns_scalar: bool,
         truthy_mask_columns: Vec<PlSmallStr>,
         falsy_mask_columns: Vec<PlSmallStr>,
+        output_dtype: Option<DataType>,
     ) -> Self {
         Self {
             predicate,
@@ -39,6 +43,15 @@ impl TernaryExpr {
             returns_scalar,
             truthy_mask_columns,
             falsy_mask_columns,
+            output_dtype,
+        }
+    }
+
+    /// Casts an arm we return directly to the output dtype of this expression.
+    fn cast_arm(&self, arm: Column) -> PolarsResult<Column> {
+        match &self.output_dtype {
+            Some(dtype) if arm.dtype() != dtype => arm.cast(dtype),
+            _ => Ok(arm),
         }
     }
 }
@@ -133,24 +146,24 @@ impl PhysicalExpr for TernaryExpr {
         if true_count == 0 {
             falsy = op_falsy()?;
             match (mask.len(), falsy.len()) {
-                (l, 1) if l != 1 => return Ok(falsy.new_from_index(0, l)),
-                (1, r) if r != 1 => return Ok(falsy),
+                (l, 1) if l != 1 => return self.cast_arm(falsy.new_from_index(0, l)),
+                (1, r) if r != 1 => return self.cast_arm(falsy),
                 (1, 1) => {}, // Forced to evaluate truthy to resolve broadcast height.
                 (l, r) => {
                     polars_ensure!(l == r, ShapeMismatch: "mismatch between condition height and falsy height in when/then/otherwise");
-                    return Ok(falsy);
+                    return self.cast_arm(falsy);
                 },
             }
             truthy = op_truthy()?;
         } else if false_count == 0 {
             truthy = op_truthy()?;
             match (mask.len(), truthy.len()) {
-                (l, 1) if l != 1 => return Ok(truthy.new_from_index(0, l)),
-                (1, r) if r != 1 => return Ok(truthy),
+                (l, 1) if l != 1 => return self.cast_arm(truthy.new_from_index(0, l)),
+                (1, r) if r != 1 => return self.cast_arm(truthy),
                 (1, 1) => {}, // Forced to evaluate truthy to resolve broadcast height.
                 (l, r) => {
                     polars_ensure!(l == r, ShapeMismatch: "mismatch between condition height and truthy height in when/then/otherwise");
-                    return Ok(truthy);
+                    return self.cast_arm(truthy);
                 },
             }
             falsy = op_falsy()?; // Forced to evaluate truthy to resolve broadcast height.

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -467,9 +467,9 @@ fn create_physical_expr_inner(
             lit_count += state.local.has_lit as u8;
 
             let mask_truthy = is_elementwise_rec(truthy, expr_arena)
-                && !matches!(expr_arena.get(truthy), AExpr::Column(_));
+                && !matches!(expr_arena.get(truthy), AExpr::Column(_) | AExpr::Literal(_));
             let mask_falsy = is_elementwise_rec(falsy, expr_arena)
-                && !matches!(expr_arena.get(falsy), AExpr::Column(_));
+                && !matches!(expr_arena.get(falsy), AExpr::Column(_) | AExpr::Literal(_));
             let truthy_mask_columns = if mask_truthy {
                 aexpr_to_leaf_names(truthy, expr_arena)
             } else {

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -457,21 +457,38 @@ fn create_physical_expr_inner(
             let is_scalar = is_scalar_ae(expression, expr_arena);
             let mut lit_count = 0u8;
             state.reset();
-            let predicate = create_physical_expr_inner(predicate, expr_arena, schema, state)?;
+            let predicate_phys = create_physical_expr_inner(predicate, expr_arena, schema, state)?;
             lit_count += state.local.has_lit as u8;
             state.reset();
-            let truthy = create_physical_expr_inner(truthy, expr_arena, schema, state)?;
+            let truthy_phys = create_physical_expr_inner(truthy, expr_arena, schema, state)?;
             lit_count += state.local.has_lit as u8;
             state.reset();
-            let falsy = create_physical_expr_inner(falsy, expr_arena, schema, state)?;
+            let falsy_phys = create_physical_expr_inner(falsy, expr_arena, schema, state)?;
             lit_count += state.local.has_lit as u8;
+
+            let mask_truthy = is_elementwise_rec(truthy, expr_arena)
+                && !matches!(expr_arena.get(truthy), AExpr::Column(_));
+            let mask_falsy = is_elementwise_rec(falsy, expr_arena)
+                && !matches!(expr_arena.get(falsy), AExpr::Column(_));
+            let truthy_mask_columns = if mask_truthy {
+                aexpr_to_leaf_names(truthy, expr_arena)
+            } else {
+                Vec::new()
+            };
+            let falsy_mask_columns = if mask_falsy {
+                aexpr_to_leaf_names(falsy, expr_arena)
+            } else {
+                Vec::new()
+            };
             Ok(Arc::new(TernaryExpr::new(
-                predicate,
-                truthy,
-                falsy,
+                predicate_phys,
+                truthy_phys,
+                falsy_phys,
                 node_to_expr(expression, expr_arena),
                 state.allow_threading && lit_count < 2,
                 is_scalar,
+                truthy_mask_columns,
+                falsy_mask_columns,
             )))
         },
         AExpr::AnonymousAgg {

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -480,6 +480,16 @@ fn create_physical_expr_inner(
             } else {
                 Vec::new()
             };
+
+            // The output dtype is the supertype of the arms, which normally is
+            // resolved by the zip. As the ternary may return an arm as-is we
+            // have to cast it to the output dtype ourselves.
+            let output_dtype = expr_arena
+                .get(expression)
+                .to_dtype(&ToFieldContext::new(expr_arena, schema))
+                .ok()
+                .filter(|dtype| !dtype.is_unknown());
+
             Ok(Arc::new(TernaryExpr::new(
                 predicate_phys,
                 truthy_phys,
@@ -489,6 +499,7 @@ fn create_physical_expr_inner(
                 is_scalar,
                 truthy_mask_columns,
                 falsy_mask_columns,
+                output_dtype,
             )))
         },
         AExpr::AnonymousAgg {

--- a/py-polars/tests/unit/functions/test_when_then.py
+++ b/py-polars/tests/unit/functions/test_when_then.py
@@ -9,7 +9,7 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
-from polars.exceptions import InvalidOperationError, ShapeError
+from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 

--- a/py-polars/tests/unit/functions/test_when_then.py
+++ b/py-polars/tests/unit/functions/test_when_then.py
@@ -342,27 +342,6 @@ def test_single_element_broadcast(
     assert_frame_equal(result, expected, check_row_order=maintain_order)
 
 
-@pytest.mark.parametrize(
-    "df",
-    [pl.DataFrame({"x": range(5)}), pl.DataFrame({"x": 5 * [[*range(5)]]})],
-)
-@pytest.mark.parametrize(
-    "ternary_expr",
-    [
-        pl.when(True).then(pl.col("x").head(2)).otherwise(pl.col("x")),
-        pl.when(False).then(pl.col("x").head(2)).otherwise(pl.col("x")),
-    ],
-)
-def test_mismatched_height_should_raise(
-    df: pl.DataFrame, ternary_expr: pl.Expr
-) -> None:
-    with pytest.raises(ShapeError):
-        df.select(ternary_expr)
-
-    with pytest.raises(ShapeError):
-        df.group_by(pl.lit(True).alias("key")).agg(ternary_expr)
-
-
 @pytest.mark.parametrize("maintain_order", [False, True])
 def test_when_then_output_name_12380(maintain_order: bool) -> None:
     df = pl.DataFrame(


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/28592.

This PR adds two improvements to when/then/otherwise.

1. If the condition is always true or false it won't evaluate the other side.
2. If a side is elementwise it will have irrelevant elements masked out to `null` before evaluating it.

This means if one side is rather expensive to evaluate (e.g. a string regex) it will be cheaper as it's simply a null.