### PR TITLE
feat: Accept `os.PathLike` objects in IO functions (#17828)

### DIFF
--- a/py-polars/src/polars/_typing.py
+++ b/py-polars/src/polars/_typing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import (
@@ -446,10 +447,12 @@ PlanStage: TypeAlias = Literal["ir", "physical"]
 FileSource: TypeAlias = (
     str
     | Path
+    | os.PathLike[str]
     | IO[bytes]
     | bytes
     | list[str]
     | list[Path]
+    | list[os.PathLike[str]]
     | list[IO[bytes]]
     | list[bytes]
 )

--- a/py-polars/src/polars/_utils/serde.py
+++ b/py-polars/src/polars/_utils/serde.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import os
 from io import BytesIO, StringIO
-from pathlib import Path
 from typing import TYPE_CHECKING, Literal, overload
 
 from polars._utils.various import normalize_filepath
@@ -11,6 +11,7 @@ from polars._utils.various import normalize_filepath
 if TYPE_CHECKING:
     from collections.abc import Callable
     from io import IOBase
+    from pathlib import Path
 
     from polars._typing import SerializationFormat
 
@@ -26,14 +27,14 @@ def serialize_polars_object(
 @overload
 def serialize_polars_object(
     serializer: Callable[[IOBase | str], None],
-    file: IOBase | str | Path,
+    file: IOBase | str | Path | os.PathLike[str],
     format: SerializationFormat,
 ) -> None: ...
 
 
 def serialize_polars_object(
     serializer: Callable[[IOBase | str], None],
-    file: IOBase | str | Path | None,
+    file: IOBase | str | Path | os.PathLike[str] | None,
     format: SerializationFormat,
 ) -> bytes | str | None:
     """Serialize a Polars object (DataFrame/LazyFrame/Expr)."""
@@ -55,7 +56,7 @@ def serialize_polars_object(
         serialized = serialize_to_bytes()
         file.write(serialized)
         return None
-    elif isinstance(file, (str, Path)):
+    elif isinstance(file, (str, os.PathLike)):
         file = normalize_filepath(file)
         serializer(file)
         return None

--- a/py-polars/src/polars/_utils/various.py
+++ b/py-polars/src/polars/_utils/various.py
@@ -103,7 +103,7 @@ def _is_iterable_of(val: Iterable[object], eltype: type | tuple[type, ...]) -> b
 
 def is_path_or_str_sequence(
     val: object, *, allow_str: bool = False, include_series: bool = False
-) -> TypeGuard[Sequence[str | Path]]:
+) -> TypeGuard[Sequence[str | os.PathLike[str]]]:
     """
     Check that `val` is a sequence of strings or paths.
 
@@ -119,7 +119,7 @@ def is_path_or_str_sequence(
     return (
         not isinstance(val, bytes)
         and isinstance(val, Sequence)
-        and _is_iterable_of(val, (Path, str))
+        and _is_iterable_of(val, (str, os.PathLike))
     )
 
 
@@ -251,7 +251,9 @@ def arrlen(obj: Any) -> int | None:
         return None
 
 
-def normalize_filepath(path: str | Path, *, check_not_directory: bool = True) -> str:
+def normalize_filepath(
+    path: str | os.PathLike[str], *, check_not_directory: bool = True
+) -> str:
     """Create a string path, expanding the home directory if present."""
     # don't use pathlib here as it modifies slashes (s3:// -> s3:/)
     path = os.path.expanduser(path)  # noqa: PTH111
@@ -626,7 +628,7 @@ def display_dot_graph(
     *,
     dot: str,
     show: bool = True,
-    output_path: str | Path | None = None,
+    output_path: str | Path | os.PathLike[str] | None = None,
     raw_output: bool = False,
     figsize: tuple[float, float] = (16.0, 12.0),
 ) -> str | None:
@@ -636,7 +638,7 @@ def display_dot_graph(
 
     output_type = (
         "svg"
-        if (output_path is not None and str(output_path).endswith(".svg"))
+        if (output_path is not None and os.fspath(output_path).endswith(".svg"))
         or _in_notebook()
         or _in_marimo_notebook()
         or "POLARS_DOT_SVG_VIEWER" in os.environ

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -14,7 +14,6 @@ from collections.abc import (
     Sized,
 )
 from io import BytesIO, StringIO
-from pathlib import Path
 from typing import (
     IO,
     TYPE_CHECKING,
@@ -130,6 +129,7 @@ if TYPE_CHECKING:
     )
     from datetime import timedelta
     from io import IOBase
+    from pathlib import Path
     from typing import Concatenate, Literal, ParamSpec
 
     import deltalake
@@ -498,7 +498,7 @@ class DataFrame:
     @classmethod
     def deserialize(
         cls,
-        source: str | bytes | Path | IOBase,
+        source: str | bytes | Path | os.PathLike[str] | IOBase,
         *,
         format: SerializationFormat = "binary",
     ) -> DataFrame:
@@ -545,7 +545,7 @@ class DataFrame:
         """
         if isinstance(source, StringIO):
             source = BytesIO(source.getvalue().encode())
-        elif isinstance(source, (str, Path)):
+        elif isinstance(source, (str, os.PathLike)):
             source = normalize_filepath(source)
         elif isinstance(source, bytes):
             source = io.BytesIO(source)
@@ -2791,12 +2791,15 @@ class DataFrame:
 
     @overload
     def serialize(
-        self, file: IOBase | str | Path, *, format: SerializationFormat = ...
+        self,
+        file: IOBase | str | Path | os.PathLike[str],
+        *,
+        format: SerializationFormat = ...,
     ) -> None: ...
 
     def serialize(
         self,
-        file: IOBase | str | Path | None = None,
+        file: IOBase | str | Path | os.PathLike[str] | None = None,
         *,
         format: SerializationFormat = "binary",
     ) -> bytes | str | None:
@@ -2862,9 +2865,11 @@ class DataFrame:
     def write_json(self, file: None = ...) -> str: ...
 
     @overload
-    def write_json(self, file: IOBase | str | Path) -> None: ...
+    def write_json(self, file: IOBase | str | Path | os.PathLike[str]) -> None: ...
 
-    def write_json(self, file: IOBase | str | Path | None = None) -> str | None:
+    def write_json(
+        self, file: IOBase | str | Path | os.PathLike[str] | None = None
+    ) -> str | None:
         """
         Serialize to JSON representation.
 
@@ -2902,7 +2907,7 @@ class DataFrame:
             json_str = write_json_to_string()
             file.write(json_str)
             return None
-        elif isinstance(file, (str, Path)):
+        elif isinstance(file, (str, os.PathLike)):
             file = normalize_filepath(file)
             self._df.write_json(file)
             return None
@@ -2923,7 +2928,7 @@ class DataFrame:
     @overload
     def write_ndjson(
         self,
-        file: str | Path | IO[bytes] | IO[str],
+        file: str | Path | os.PathLike[str] | IO[bytes] | IO[str],
         *,
         compression: Literal["uncompressed", "gzip", "zstd"] = "uncompressed",
         compression_level: int | None = None,
@@ -2932,7 +2937,7 @@ class DataFrame:
 
     def write_ndjson(
         self,
-        file: str | Path | IO[bytes] | IO[str] | None = None,
+        file: str | Path | os.PathLike[str] | IO[bytes] | IO[str] | None = None,
         *,
         compression: Literal["uncompressed", "gzip", "zstd"] = "uncompressed",
         compression_level: int | None = None,
@@ -2982,7 +2987,7 @@ class DataFrame:
         '{"foo":1,"bar":6}\n{"foo":2,"bar":7}\n{"foo":3,"bar":8}\n'
         """
         should_return_buffer = False
-        target: str | Path | IO[bytes] | IO[str]
+        target: str | Path | os.PathLike[str] | IO[bytes] | IO[str]
         if file is None:
             target = cast("IO[bytes]", BytesIO())
             should_return_buffer = True
@@ -3039,7 +3044,7 @@ class DataFrame:
     @overload
     def write_csv(
         self,
-        file: str | Path | IO[str] | IO[bytes],
+        file: str | Path | os.PathLike[str] | IO[str] | IO[bytes],
         *,
         include_bom: bool = ...,
         compression: Literal["uncompressed", "gzip", "zstd"] = ...,
@@ -3065,7 +3070,7 @@ class DataFrame:
 
     def write_csv(
         self,
-        file: str | Path | IO[str] | IO[bytes] | None = None,
+        file: str | Path | os.PathLike[str] | IO[str] | IO[bytes] | None = None,
         *,
         include_bom: bool = False,
         compression: Literal["uncompressed", "gzip", "zstd"] = "uncompressed",
@@ -3225,7 +3230,7 @@ class DataFrame:
             null_value = None
 
         should_return_buffer = False
-        target: str | Path | IO[bytes] | IO[str]
+        target: str | Path | os.PathLike[str] | IO[bytes] | IO[str]
         if file is None:
             target = cast("IO[bytes]", BytesIO())
             should_return_buffer = True
@@ -3292,7 +3297,7 @@ class DataFrame:
 
     def write_avro(
         self,
-        file: str | Path | IO[bytes],
+        file: str | Path | os.PathLike[str] | IO[bytes],
         compression: AvroCompression = "uncompressed",
         name: str = "",
     ) -> None:
@@ -3324,7 +3329,7 @@ class DataFrame:
         """
         if compression is None:
             compression = "uncompressed"
-        if isinstance(file, (str, Path)):
+        if isinstance(file, (str, os.PathLike)):
             file = normalize_filepath(file)
         if name is None:
             name = ""
@@ -3333,7 +3338,7 @@ class DataFrame:
 
     def write_excel(
         self,
-        workbook: str | Workbook | IO[bytes] | Path | None = None,
+        workbook: str | Workbook | IO[bytes] | Path | os.PathLike[str] | None = None,
         worksheet: str | Worksheet | None = None,
         *,
         position: tuple[int, int] | str = "A1",
@@ -3931,7 +3936,7 @@ class DataFrame:
     @overload
     def write_ipc(
         self,
-        file: str | Path | IO[bytes],
+        file: str | Path | os.PathLike[str] | IO[bytes],
         *,
         compression: IpcCompression = "uncompressed",
         compat_level: CompatLevel | None = None,
@@ -3946,7 +3951,7 @@ class DataFrame:
     @deprecate_renamed_parameter("future", "compat_level", version="1.1")
     def write_ipc(
         self,
-        file: str | Path | IO[bytes] | None,
+        file: str | Path | os.PathLike[str] | IO[bytes] | None,
         *,
         compression: IpcCompression = "uncompressed",
         compat_level: CompatLevel | None = None,
@@ -4034,7 +4039,7 @@ class DataFrame:
         True
         """
         return_bytes = file is None
-        target: str | Path | IO[bytes]
+        target: str | Path | os.PathLike[str] | IO[bytes]
         if file is None:
             target = BytesIO()
         else:
@@ -4068,7 +4073,7 @@ class DataFrame:
     @overload
     def write_ipc_stream(
         self,
-        file: str | Path | IO[bytes],
+        file: str | Path | os.PathLike[str] | IO[bytes],
         *,
         compression: IpcCompression = "uncompressed",
         compat_level: CompatLevel | None = None,
@@ -4077,7 +4082,7 @@ class DataFrame:
     @deprecate_renamed_parameter("future", "compat_level", version="1.1")
     def write_ipc_stream(
         self,
-        file: str | Path | IO[bytes] | None,
+        file: str | Path | os.PathLike[str] | IO[bytes] | None,
         *,
         compression: IpcCompression = "uncompressed",
         compat_level: CompatLevel | None = None,
@@ -4118,7 +4123,7 @@ class DataFrame:
         return_bytes = file is None
         if return_bytes:
             file = BytesIO()
-        elif isinstance(file, (str, Path)):
+        elif isinstance(file, (str, os.PathLike)):
             file = normalize_filepath(file)
 
         compat_level_py: int | bool
@@ -4135,7 +4140,7 @@ class DataFrame:
 
     def write_parquet(
         self,
-        file: str | Path | IO[bytes],
+        file: str | Path | os.PathLike[str] | IO[bytes],
         *,
         compression: ParquetCompression = "zstd",
         compression_level: int | None = None,
@@ -4295,7 +4300,7 @@ class DataFrame:
         """
         if compression is None:
             compression = "uncompressed"
-        if isinstance(file, (str, Path)):
+        if isinstance(file, (str, os.PathLike)):
             if partition_by is not None or (
                 pyarrow_options is not None and pyarrow_options.get("partition_cols")
             ):
@@ -4354,7 +4359,7 @@ class DataFrame:
 
             return
 
-        target: str | Path | IO[bytes] | PartitionBy = file
+        target: str | Path | os.PathLike[str] | IO[bytes] | PartitionBy = file
         engine: EngineType = "streaming"
         if partition_by is not None:
             if not isinstance(file, str):
@@ -4787,7 +4792,7 @@ class DataFrame:
     @overload
     def write_delta(
         self,
-        target: str | Path | deltalake.DeltaTable,
+        target: str | Path | os.PathLike[str] | deltalake.DeltaTable,
         *,
         mode: Literal["error", "append", "overwrite", "ignore"] = ...,
         overwrite_schema: bool | None = ...,
@@ -4799,7 +4804,7 @@ class DataFrame:
     @overload
     def write_delta(
         self,
-        target: str | Path | deltalake.DeltaTable,
+        target: str | Path | os.PathLike[str] | deltalake.DeltaTable,
         *,
         mode: Literal["merge"],
         overwrite_schema: bool | None = ...,
@@ -4810,7 +4815,7 @@ class DataFrame:
 
     def write_delta(
         self,
-        target: str | Path | deltalake.DeltaTable,
+        target: str | Path | os.PathLike[str] | deltalake.DeltaTable,
         *,
         mode: Literal["error", "append", "overwrite", "ignore", "merge"] = "error",
         overwrite_schema: bool | None = None,
@@ -5001,8 +5006,8 @@ class DataFrame:
 
         _check_for_unsupported_types(self.dtypes)
 
-        if isinstance(target, (str, Path)):
-            target = _resolve_delta_lake_uri(str(target), strict=False)
+        if isinstance(target, (str, os.PathLike)):
+            target = _resolve_delta_lake_uri(target, strict=False)
 
         from polars.io.cloud.credential_provider._builder import (
             _init_credential_provider_builder,

--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import math
 import operator
+import os
 import sys
 import warnings
 from collections.abc import Collection, Mapping, Sequence
@@ -10,7 +11,6 @@ from datetime import timedelta
 from decimal import Decimal
 from functools import reduce
 from io import BytesIO, StringIO
-from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -76,6 +76,8 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     from polars._plr import PyExpr
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     with contextlib.suppress(ImportError):  # Module not available when building docs
         from polars._plr import PySeries
 
@@ -531,7 +533,7 @@ class Expr:
     @classmethod
     def deserialize(
         cls,
-        source: str_ | Path | IOBase | bytes,
+        source: str_ | Path | os.PathLike[str_] | IOBase | bytes,
         *,
         format: SerializationFormat = "binary",
     ) -> Expr:
@@ -575,7 +577,7 @@ class Expr:
         """
         if isinstance(source, StringIO):
             source = BytesIO(source.getvalue().encode())
-        elif isinstance(source, (str, Path)):
+        elif isinstance(source, (str, os.PathLike)):
             source = normalize_filepath(source)
         elif isinstance(source, bytes):
             source = BytesIO(source)

--- a/py-polars/src/polars/expr/meta.py
+++ b/py-polars/src/polars/expr/meta.py
@@ -10,6 +10,7 @@ from polars._utils.wrap import wrap_expr
 from polars.exceptions import ComputeError
 
 if TYPE_CHECKING:
+    import os
     import sys
     from io import IOBase
     from pathlib import Path
@@ -307,12 +308,15 @@ class ExprMetaNameSpace:
 
     @overload
     def serialize(
-        self, file: IOBase | str | Path, *, format: SerializationFormat = ...
+        self,
+        file: IOBase | str | Path | os.PathLike[str],
+        *,
+        format: SerializationFormat = ...,
     ) -> None: ...
 
     def serialize(
         self,
-        file: IOBase | str | Path | None = None,
+        file: IOBase | str | Path | os.PathLike[str] | None = None,
         *,
         format: SerializationFormat = "binary",
     ) -> bytes | str | None:

--- a/py-polars/src/polars/io/_utils.py
+++ b/py-polars/src/polars/io/_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import glob
+import os
 import re
 from collections.abc import Sequence
 from contextlib import contextmanager
@@ -101,7 +102,7 @@ def parse_row_index_args(
 
 @overload
 def prepare_file_arg(
-    file: str | Path | list[str] | IO[bytes] | bytes,
+    file: str | Path | os.PathLike[str] | list[str] | IO[bytes] | bytes,
     encoding: str | None = ...,
     *,
     use_pyarrow: bool = ...,
@@ -112,7 +113,7 @@ def prepare_file_arg(
 
 @overload
 def prepare_file_arg(
-    file: str | Path | IO[str] | IO[bytes] | bytes,
+    file: str | Path | os.PathLike[str] | IO[str] | IO[bytes] | bytes,
     encoding: str | None = ...,
     *,
     use_pyarrow: bool = ...,
@@ -123,7 +124,7 @@ def prepare_file_arg(
 
 @overload
 def prepare_file_arg(
-    file: str | Path | list[str] | IO[str] | IO[bytes] | bytes,
+    file: str | Path | os.PathLike[str] | list[str] | IO[str] | IO[bytes] | bytes,
     encoding: str | None = ...,
     *,
     use_pyarrow: bool = ...,
@@ -133,7 +134,7 @@ def prepare_file_arg(
 
 
 def prepare_file_arg(
-    file: str | Path | list[str] | IO[str] | IO[bytes] | bytes,
+    file: str | Path | os.PathLike[str] | list[str] | IO[str] | IO[bytes] | bytes,
     encoding: str | None = None,
     *,
     use_pyarrow: bool = False,
@@ -189,6 +190,11 @@ def prepare_file_arg(
     # PyArrow allows directories, so we only check that something is not
     # a dir if we are not using PyArrow
     check_not_dir = not use_pyarrow
+
+    # Normalize `os.PathLike` objects (e.g. `pathlib.Path`) to a `Path` so that
+    # the branch below handles them uniformly.
+    if isinstance(file, os.PathLike):
+        file = Path(file)
 
     if isinstance(file, bytes):
         if not has_utf8_utf8_lossy_encoding:
@@ -341,16 +347,25 @@ def is_local_file(file: str) -> bool:
 def get_sources(
     source: str
     | Path
+    | os.PathLike[str]
     | IO[bytes]
     | IO[str]
     | bytes
     | list[str]
     | list[Path]
+    | list[os.PathLike[str]]
     | list[IO[bytes]]
     | list[IO[str]]
     | list[bytes],
-) -> list[str] | list[Path] | list[IO[str]] | list[IO[bytes]] | list[bytes]:
-    if isinstance(source, (str, Path)):
+) -> (
+    list[str]
+    | list[Path]
+    | list[os.PathLike[str]]
+    | list[IO[str]]
+    | list[IO[bytes]]
+    | list[bytes]
+):
+    if isinstance(source, (str, os.PathLike)):
         source = normalize_filepath(source, check_not_directory=False)
     elif is_path_or_str_sequence(source):
         source = [

--- a/py-polars/src/polars/io/avro.py
+++ b/py-polars/src/polars/io/avro.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from pathlib import Path
+import os
 from typing import IO, TYPE_CHECKING
 
 from polars._utils.various import normalize_filepath
@@ -12,11 +12,13 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     from polars._plr import PyDataFrame
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from polars import DataFrame
 
 
 def read_avro(
-    source: str | Path | IO[bytes] | bytes,
+    source: str | Path | os.PathLike[str] | IO[bytes] | bytes,
     *,
     columns: list[int] | list[str] | None = None,
     n_rows: int | None = None,
@@ -41,7 +43,7 @@ def read_avro(
     -------
     DataFrame
     """
-    if isinstance(source, (str, Path)):
+    if isinstance(source, (str, os.PathLike)):
         source = normalize_filepath(source)
     projection, column_names = parse_columns_arg(columns)
 

--- a/py-polars/src/polars/io/cloud/_utils.py
+++ b/py-polars/src/polars/io/cloud/_utils.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any, Final, Generic, TypeVar
+import os
+from typing import TYPE_CHECKING, Any, Final, Generic, TypeVar
 
 from polars._utils.various import is_path_or_str_sequence
 from polars.io.partition import PartitionBy
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # Custom polars config keys
 POLARS_STORAGE_CONFIG_KEYS: Final[frozenset[str]] = frozenset(
@@ -48,8 +51,8 @@ class NoPickleOption(Generic[T]):
 
 def _first_scan_path(
     source: Any,
-) -> str | Path | None:
-    if isinstance(source, (str, Path)):
+) -> str | Path | os.PathLike[str] | None:
+    if isinstance(source, (str, os.PathLike)):
         return source
     elif is_path_or_str_sequence(source) and source:
         return source[0]
@@ -59,8 +62,8 @@ def _first_scan_path(
     return None
 
 
-def _get_path_scheme(path: str | Path) -> str | None:
-    path_str = str(path)
+def _get_path_scheme(path: str | os.PathLike[str]) -> str | None:
+    path_str = os.fspath(path)
     i = path_str.find("://")
 
     return path_str[:i] if i >= 0 else None

--- a/py-polars/src/polars/io/cloud/credential_provider/_builder.py
+++ b/py-polars/src/polars/io/cloud/credential_provider/_builder.py
@@ -428,7 +428,7 @@ def _init_credential_provider_builder(
             storage_account = (
                 # Prefer the one embedded in the path
                 CredentialProviderAzure._extract_adls_uri_storage_account(
-                    str(first_scan_path)
+                    os.fspath(first_scan_path)
                 )
                 or storage_account
             )
@@ -444,7 +444,7 @@ def _init_credential_provider_builder(
                 )
             )
 
-        elif _is_aws_cloud(scheme=scheme, first_scan_path=str(first_scan_path)):
+        elif _is_aws_cloud(scheme=scheme, first_scan_path=os.fspath(first_scan_path)):
             region = None
             profile = None
             default_region = None

--- a/py-polars/src/polars/io/csv/batched_reader.py
+++ b/py-polars/src/polars/io/csv/batched_reader.py
@@ -6,6 +6,7 @@ import polars as pl
 from polars.datatypes import N_INFER_DEFAULT
 
 if TYPE_CHECKING:
+    import os
     from collections.abc import Sequence
     from pathlib import Path
 
@@ -18,7 +19,7 @@ class BatchedCsvReader:
 
     def __init__(
         self,
-        source: str | Path,
+        source: str | Path | os.PathLike[str],
         *,
         has_header: bool = True,
         columns: Sequence[int] | Sequence[str] | None = None,

--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -4,7 +4,6 @@ import contextlib
 import os
 from collections.abc import Sequence
 from io import BytesIO, StringIO
-from pathlib import Path
 from typing import IO, TYPE_CHECKING, Literal
 
 import polars._reexport as pl
@@ -41,6 +40,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
+    from pathlib import Path
 
     from polars import DataFrame, LazyFrame
     from polars._typing import (
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
     mapper=lambda x: not x,
 )
 def read_csv(
-    source: str | Path | IO[str] | IO[bytes] | bytes,
+    source: str | Path | os.PathLike[str] | IO[str] | IO[bytes] | bytes,
     *,
     has_header: bool = True,
     columns: Sequence[int] | Sequence[str] | None = None,
@@ -503,10 +503,10 @@ def read_csv(
 
     if streaming or (
         # Check that it is not a BytesIO object
-        isinstance(v := source, (str, Path))
+        isinstance(v := source, (str, os.PathLike))
         and (
             # HuggingFace only for now ⊂( ◜◒◝ )⊃
-            str(v).startswith("hf://")
+            os.fspath(v).startswith("hf://")
             # Also dispatch on FORCE_ASYNC, so that this codepath gets run
             # through by our test suite during CI.
             or (os.getenv("POLARS_FORCE_ASYNC") == "1" and encoding_supported_in_lazy)
@@ -517,7 +517,7 @@ def read_csv(
         )
     ):
         source_normalized: str | list[str] | IO[str] | IO[bytes] | bytes | bytearray
-        if isinstance(source, (str, Path)):
+        if isinstance(source, (str, os.PathLike)):
             source_normalized = normalize_filepath(source, check_not_directory=False)
         elif is_path_or_str_sequence(source, allow_str=False):
             source_normalized = [
@@ -614,7 +614,7 @@ def read_csv(
 
 
 def _read_csv_impl(
-    source: str | Path | IO[bytes] | bytes,
+    source: str | Path | os.PathLike[str] | IO[bytes] | bytes,
     *,
     has_header: bool = True,
     columns: Sequence[int] | Sequence[str] | None = None,
@@ -651,7 +651,7 @@ def _read_csv_impl(
         issue_deprecation_warning(msg)
 
     path: str | None
-    if isinstance(source, (str, Path)):
+    if isinstance(source, (str, os.PathLike)):
         path = normalize_filepath(source, check_not_directory=False)
     else:
         path = None
@@ -770,7 +770,7 @@ def _read_csv_impl(
     mapper=lambda x: not x,
 )
 def read_csv_batched(
-    source: str | Path,
+    source: str | Path | os.PathLike[str],
     *,
     has_header: bool = True,
     columns: Sequence[int] | Sequence[str] | None = None,
@@ -1108,11 +1108,13 @@ def scan_csv(
     source: (
         str
         | Path
+        | os.PathLike[str]
         | IO[str]
         | IO[bytes]
         | bytes
         | list[str]
         | list[Path]
+        | list[os.PathLike[str]]
         | list[IO[str]]
         | list[IO[bytes]]
         | list[bytes]
@@ -1402,7 +1404,7 @@ def scan_csv(
     _check_arg_is_1byte("separator", separator, can_be_empty=False)
     _check_arg_is_1byte("quote_char", quote_char, can_be_empty=True)
 
-    if isinstance(source, (str, Path)):
+    if isinstance(source, (str, os.PathLike)):
         source = normalize_filepath(source, check_not_directory=False)
     elif is_path_or_str_sequence(source, allow_str=False):
         source = [
@@ -1477,6 +1479,7 @@ def _scan_csv_impl(
     | bytes
     | list[str]
     | list[Path]
+    | list[os.PathLike[str]]
     | list[IO[str]]
     | list[IO[bytes]]
     | list[bytes],

--- a/py-polars/src/polars/io/delta/_utils.py
+++ b/py-polars/src/polars/io/delta/_utils.py
@@ -13,13 +13,17 @@ from polars.io._utils import null_count_dtype
 from polars.io.cloud._utils import POLARS_STORAGE_CONFIG_KEYS, _get_path_scheme
 
 if TYPE_CHECKING:
+    import os
+
     from deltalake import DeltaTable
 
     from polars import DataFrame, DataType, Series
     from polars._typing import PolarsDataType, SchemaDict, StorageOptionsDict
 
 
-def _resolve_delta_lake_uri(table_uri: str | Path, *, strict: bool = True) -> str:
+def _resolve_delta_lake_uri(
+    table_uri: str | Path | os.PathLike[str], *, strict: bool = True
+) -> str:
     resolved_uri = str(
         Path(table_uri).expanduser().resolve(strict)
         if _get_path_scheme(table_uri) is None
@@ -30,7 +34,7 @@ def _resolve_delta_lake_uri(table_uri: str | Path, *, strict: bool = True) -> st
 
 
 def _get_delta_lake_table(
-    table_path: str | Path | DeltaTable,
+    table_path: str | Path | os.PathLike[str] | DeltaTable,
     version: int | str | datetime | None = None,
     storage_options: StorageOptionsDict | None = None,
     delta_table_options: dict[str, Any] | None = None,

--- a/py-polars/src/polars/io/delta/functions.py
+++ b/py-polars/src/polars/io/delta/functions.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
-from typing import TYPE_CHECKING, Any
+import os
+from typing import TYPE_CHECKING, Any, cast
 
 from polars._utils.wrap import wrap_ldf
 from polars.io.cloud._utils import NoPickleOption
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
 
 
 def read_delta(
-    source: str | Path | DeltaTable,
+    source: str | Path | os.PathLike[str] | DeltaTable,
     *,
     version: int | str | datetime | None = None,
     columns: list[str] | None = None,
@@ -160,7 +161,7 @@ def read_delta(
 
 
 def scan_delta(
-    source: str | Path | DeltaTable,
+    source: str | Path | os.PathLike[str] | DeltaTable,
     *,
     version: int | str | datetime | None = None,
     storage_options: StorageOptionsDict | None = None,
@@ -320,9 +321,12 @@ def scan_delta(
             **(storage_options or {}),
         }
 
+    # When `table is None`, `source` is a path rather than a `DeltaTable`.
+    source_path = cast("str | os.PathLike[str]", source)
+
     dataset = DeltaDataset(
         table_=NoPickleOption(table),
-        table_uri_=str(source) if table is None else None,
+        table_uri_=os.fspath(source_path) if table is None else None,
         version=version,
         storage_options=storage_options,
         credential_provider_builder=credential_provider_builder,

--- a/py-polars/src/polars/io/ipc/functions.py
+++ b/py-polars/src/polars/io/ipc/functions.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import os
-from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, Literal
 
 import polars._reexport as pl
@@ -37,6 +36,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from pathlib import Path
 
     from polars import DataFrame, DataType, LazyFrame
     from polars._typing import SchemaDict, StorageOptionsDict
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 @deprecate_renamed_parameter("row_count_name", "row_index_name", version="0.20.4")
 @deprecate_renamed_parameter("row_count_offset", "row_index_offset", version="0.20.4")
 def read_ipc(
-    source: str | Path | IO[bytes] | bytes,
+    source: str | Path | os.PathLike[str] | IO[bytes] | bytes,
     *,
     columns: list[int] | list[str] | None = None,
     n_rows: int | None = None,
@@ -124,10 +124,10 @@ def read_ipc(
     """
     if (
         # Check that it is not a BytesIO object
-        isinstance(v := source, (str, Path))
+        isinstance(v := source, (str, os.PathLike))
     ) and (
         # HuggingFace only for now ⊂( ◜◒◝ )⊃
-        (is_hf := str(v).startswith("hf://"))
+        (is_hf := os.fspath(v).startswith("hf://"))
         # Also dispatch on FORCE_ASYNC, so that this codepath gets run
         # through by our test suite during CI.
         or os.getenv("POLARS_FORCE_ASYNC") == "1"
@@ -215,7 +215,7 @@ def read_ipc(
 
 
 def _read_ipc_impl(
-    source: str | Path | IO[bytes] | bytes,
+    source: str | Path | os.PathLike[str] | IO[bytes] | bytes,
     *,
     columns: Sequence[int] | Sequence[str] | None = None,
     n_rows: int | None = None,
@@ -224,7 +224,7 @@ def _read_ipc_impl(
     rechunk: bool = True,
     memory_map: bool = True,
 ) -> DataFrame:
-    if isinstance(source, (str, Path)):
+    if isinstance(source, (str, os.PathLike)):
         source = normalize_filepath(source, check_not_directory=False)
     if isinstance(columns, str):
         columns = [columns]
@@ -264,7 +264,7 @@ def _read_ipc_impl(
 @deprecate_renamed_parameter("row_count_name", "row_index_name", version="0.20.4")
 @deprecate_renamed_parameter("row_count_offset", "row_index_offset", version="0.20.4")
 def read_ipc_stream(
-    source: str | Path | IO[bytes] | bytes,
+    source: str | Path | os.PathLike[str] | IO[bytes] | bytes,
     *,
     columns: list[int] | list[str] | None = None,
     n_rows: int | None = None,
@@ -344,7 +344,7 @@ def read_ipc_stream(
 
 
 def _read_ipc_stream_impl(
-    source: str | Path | IO[bytes] | bytes,
+    source: str | Path | os.PathLike[str] | IO[bytes] | bytes,
     *,
     columns: Sequence[int] | Sequence[str] | None = None,
     n_rows: int | None = None,
@@ -352,7 +352,7 @@ def _read_ipc_stream_impl(
     row_index_offset: int = 0,
     rechunk: bool = True,
 ) -> DataFrame:
-    if isinstance(source, (str, Path)):
+    if isinstance(source, (str, os.PathLike)):
         source = normalize_filepath(source, check_not_directory=False)
     if isinstance(columns, str):
         columns = [columns]
@@ -369,7 +369,9 @@ def _read_ipc_stream_impl(
     return wrap_df(pydf)
 
 
-def read_ipc_schema(source: str | Path | IO[bytes] | bytes) -> dict[str, DataType]:
+def read_ipc_schema(
+    source: str | Path | os.PathLike[str] | IO[bytes] | bytes,
+) -> dict[str, DataType]:
     """
     Get the schema of an IPC file without reading data.
 
@@ -386,7 +388,7 @@ def read_ipc_schema(source: str | Path | IO[bytes] | bytes) -> dict[str, DataTyp
     dict
         Dictionary mapping column names to datatypes
     """
-    if isinstance(source, (str, Path)):
+    if isinstance(source, (str, os.PathLike)):
         source = normalize_filepath(source, check_not_directory=False)
 
     return _read_ipc_schema(source)
@@ -398,10 +400,12 @@ def scan_ipc(
     source: (
         str
         | Path
+        | os.PathLike[str]
         | IO[bytes]
         | bytes
         | list[str]
         | list[Path]
+        | list[os.PathLike[str]]
         | list[IO[bytes]]
         | list[bytes]
     ),

--- a/py-polars/src/polars/io/json/read.py
+++ b/py-polars/src/polars/io/json/read.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import contextlib
+import os
 from io import BytesIO, StringIO
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from polars._utils.various import normalize_filepath
@@ -14,13 +14,14 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     from io import IOBase
+    from pathlib import Path
 
     from polars import DataFrame
     from polars._typing import SchemaDefinition
 
 
 def read_json(
-    source: str | Path | IOBase | bytes,
+    source: str | Path | os.PathLike[str] | IOBase | bytes,
     *,
     schema: SchemaDefinition | None = None,
     schema_overrides: SchemaDefinition | None = None,
@@ -89,7 +90,7 @@ def read_json(
     """
     if isinstance(source, StringIO):
         source = BytesIO(source.getvalue().encode())
-    elif isinstance(source, (str, Path)):
+    elif isinstance(source, (str, os.PathLike)):
         source = normalize_filepath(source)
 
     pydf = PyDataFrame.read_json(

--- a/py-polars/src/polars/io/ndjson.py
+++ b/py-polars/src/polars/io/ndjson.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from pathlib import Path
+import os
 from typing import IO, TYPE_CHECKING, Literal
 
 from polars._utils.deprecation import (
@@ -20,6 +20,8 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     from polars._plr import PyLazyFrame
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from polars import DataFrame, LazyFrame
     from polars._typing import SchemaDefinition, StorageOptionsDict
     from polars.io.cloud import CredentialProviderFunction
@@ -28,11 +30,13 @@ if TYPE_CHECKING:
 def read_ndjson(
     source: str
     | Path
+    | os.PathLike[str]
     | IO[str]
     | IO[bytes]
     | bytes
     | list[str]
     | list[Path]
+    | list[os.PathLike[str]]
     | list[IO[str]]
     | list[IO[bytes]],
     *,
@@ -193,11 +197,13 @@ def scan_ndjson(
     source: (
         str
         | Path
+        | os.PathLike[str]
         | IO[str]
         | IO[bytes]
         | bytes
         | list[str]
         | list[Path]
+        | list[os.PathLike[str]]
         | list[IO[str]]
         | list[IO[bytes]]
     ),
@@ -300,8 +306,14 @@ def scan_ndjson(
     include_file_paths
         Include the path of the source file(s) as a column with this name.
     """
-    sources: list[str] | list[Path] | list[IO[str]] | list[IO[bytes]] = []
-    if isinstance(source, (str, Path)):
+    sources: (
+        list[str]
+        | list[Path]
+        | list[os.PathLike[str]]
+        | list[IO[str]]
+        | list[IO[bytes]]
+    ) = []
+    if isinstance(source, (str, os.PathLike)):
         source = normalize_filepath(source, check_not_directory=False)
     elif isinstance(source, list):
         if is_path_or_str_sequence(source):

--- a/py-polars/src/polars/io/parquet/functions.py
+++ b/py-polars/src/polars/io/parquet/functions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import io
-from pathlib import Path
+import os
 from typing import IO, TYPE_CHECKING, Any
 
 import polars.functions as F
@@ -34,6 +34,7 @@ with contextlib.suppress(ImportError):
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from pathlib import Path
     from typing import Literal
 
     from polars import DataFrame, DataType, LazyFrame
@@ -296,10 +297,12 @@ def read_parquet(
 def _read_parquet_with_pyarrow(
     source: str
     | Path
+    | os.PathLike[str]
     | IO[bytes]
     | bytes
     | list[str]
     | list[Path]
+    | list[os.PathLike[str]]
     | list[IO[bytes]]
     | list[bytes],
     *,
@@ -316,7 +319,9 @@ def _read_parquet_with_pyarrow(
     )
     pyarrow_options = pyarrow_options or {}
 
-    sources: list[str | Path | IO[bytes] | bytes | list[str] | list[Path]] = []
+    sources: list[
+        str | Path | os.PathLike[str] | IO[bytes] | bytes | list[str] | list[Path]
+    ] = []
     if isinstance(source, list):
         if len(source) > 0 and isinstance(source[0], (bytes, io.IOBase)):
             sources = source  # type: ignore[assignment]
@@ -360,7 +365,9 @@ def _read_parquet_with_pyarrow(
         return plconcat(results)
 
 
-def read_parquet_schema(source: str | Path | IO[bytes] | bytes) -> dict[str, DataType]:
+def read_parquet_schema(
+    source: str | Path | os.PathLike[str] | IO[bytes] | bytes,
+) -> dict[str, DataType]:
     """
     Get the schema of a Parquet file without reading data.
 
@@ -389,7 +396,7 @@ def read_parquet_schema(source: str | Path | IO[bytes] | bytes) -> dict[str, Dat
 
 
 def read_parquet_metadata(
-    source: str | Path | IO[bytes] | bytes,
+    source: str | Path | os.PathLike[str] | IO[bytes] | bytes,
     storage_options: StorageOptionsDict | None = None,
     credential_provider: CredentialProviderFunction | Literal["auto"] | None = "auto",
     retries: int | None = None,
@@ -441,7 +448,7 @@ def read_parquet_metadata(
     dict
         Dictionary with the metadata. Empty if no custom metadata is available.
     """
-    if isinstance(source, (str, Path)):
+    if isinstance(source, (str, os.PathLike)):
         source = normalize_filepath(source, check_not_directory=False)
 
     if retries is not None:

--- a/py-polars/src/polars/io/spreadsheet/_write_utils.py
+++ b/py-polars/src/polars/io/spreadsheet/_write_utils.py
@@ -583,7 +583,7 @@ def _xl_worksheet_in_workbook(
 
 
 def _xl_setup_workbook(
-    workbook: Workbook | IO[bytes] | Path | str | None,
+    workbook: Workbook | IO[bytes] | Path | str | PathLike[str] | None,
     worksheet: str | Worksheet | None = None,
     *,
     use_zip64: bool = False,
@@ -622,7 +622,7 @@ def _xl_setup_workbook(
             file: Path | IO[bytes]
             if workbook is None:
                 file = Path("dataframe.xlsx")
-            elif isinstance(workbook, str):
+            elif isinstance(workbook, (str, PathLike)):
                 file = Path(workbook)
             else:
                 file = workbook

--- a/py-polars/src/polars/io/spreadsheet/functions.py
+++ b/py-polars/src/polars/io/spreadsheet/functions.py
@@ -67,7 +67,7 @@ def _sources(source: FileSource | memoryview[int]) -> tuple[Any, bool]:
 
     for src in source:  # type: ignore[union-attr]
         if isinstance(src, (str, os.PathLike)) and not Path(src).exists():
-            src = os.path.expanduser(str(src))  # noqa: PTH111
+            src = os.path.expanduser(os.fspath(src))  # noqa: PTH111
             if looks_like_url(src):
                 sources.append(src)
                 continue
@@ -78,7 +78,7 @@ def _sources(source: FileSource | memoryview[int]) -> tuple[Any, bool]:
             read_multiple_workbooks = True
         else:
             if isinstance(src, os.PathLike):
-                src = str(src)
+                src = os.fspath(src)
             sources.append(src)
 
     return sources, read_multiple_workbooks

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import io
+import os
 import warnings
 from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
@@ -9,7 +10,6 @@ from datetime import date, datetime, time, timedelta
 from functools import lru_cache, partial, reduce
 from io import BytesIO, StringIO
 from operator import and_
-from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -114,6 +114,7 @@ if TYPE_CHECKING:
     from builtins import slice as slice_
     from collections.abc import Awaitable, Callable, Iterator
     from io import IOBase
+    from pathlib import Path
     from typing import IO, Concatenate, Literal, ParamSpec
 
     import deltalake
@@ -192,11 +193,11 @@ def _select_engine(engine: EngineType) -> EngineType:
 
 
 def _to_sink_target(
-    path: str | Path | IO[bytes] | IO[str] | PartitionBy,
-) -> str | Path | IO[bytes] | IO[str] | PartitionBy:
+    path: str | Path | os.PathLike[str] | IO[bytes] | IO[str] | PartitionBy,
+) -> str | Path | os.PathLike[str] | IO[bytes] | IO[str] | PartitionBy:
     from polars.io.partition import PartitionBy
 
-    if isinstance(path, (str, Path)):
+    if isinstance(path, (str, os.PathLike)):
         return normalize_filepath(path)
     elif isinstance(path, io.IOBase):
         return path
@@ -495,7 +496,7 @@ class LazyFrame:
     @classmethod
     def deserialize(
         cls,
-        source: str | bytes | Path | IOBase,
+        source: str | bytes | Path | os.PathLike[str] | IOBase,
         *,
         format: SerializationFormat = "binary",
     ) -> LazyFrame:
@@ -546,7 +547,7 @@ class LazyFrame:
         """
         if isinstance(source, StringIO):
             source = BytesIO(source.getvalue().encode())
-        elif isinstance(source, (str, Path)):
+        elif isinstance(source, (str, os.PathLike)):
             source = normalize_filepath(source)
         elif isinstance(source, bytes):
             source = io.BytesIO(source)
@@ -849,12 +850,15 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     @overload
     def serialize(
-        self, file: IOBase | str | Path, *, format: SerializationFormat = ...
+        self,
+        file: IOBase | str | Path | os.PathLike[str],
+        *,
+        format: SerializationFormat = ...,
     ) -> None: ...
 
     def serialize(
         self,
-        file: IOBase | str | Path | None = None,
+        file: IOBase | str | Path | os.PathLike[str] | None = None,
         *,
         format: SerializationFormat = "binary",
     ) -> bytes | str | None:
@@ -1447,7 +1451,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         *,
         optimized: bool = ...,
         show: bool = ...,
-        output_path: str | Path | None = ...,
+        output_path: str | Path | os.PathLike[str] | None = ...,
         raw_output: Literal[True],
         figsize: tuple[float, float] = ...,
         engine: EngineType = ...,
@@ -1461,7 +1465,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         *,
         optimized: bool = ...,
         show: bool = ...,
-        output_path: str | Path | None = ...,
+        output_path: str | Path | os.PathLike[str] | None = ...,
         raw_output: Literal[False] = ...,
         figsize: tuple[float, float] = ...,
         engine: EngineType = ...,
@@ -1475,7 +1479,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         *,
         optimized: bool = ...,
         show: bool = ...,
-        output_path: str | Path | None = ...,
+        output_path: str | Path | os.PathLike[str] | None = ...,
         raw_output: bool = ...,
         figsize: tuple[float, float] = ...,
         engine: EngineType = ...,
@@ -1490,7 +1494,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         *,
         optimized: bool = True,
         show: bool = True,
-        output_path: str | Path | None = None,
+        output_path: str | Path | os.PathLike[str] | None = None,
         raw_output: bool = False,
         figsize: tuple[float, float] = (16.0, 12.0),
         type_coercion: bool = True,  # noqa: ARG002
@@ -2796,7 +2800,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     @overload
     def sink_parquet(
         self,
-        path: str | Path | IO[bytes] | PartitionBy,
+        path: str | Path | os.PathLike[str] | IO[bytes] | PartitionBy,
         *,
         compression: str = "zstd",
         compression_level: int | None = None,
@@ -2822,7 +2826,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     @overload
     def sink_parquet(
         self,
-        path: str | Path | IO[bytes] | PartitionBy,
+        path: str | Path | os.PathLike[str] | IO[bytes] | PartitionBy,
         *,
         compression: str = "zstd",
         compression_level: int | None = None,
@@ -2847,7 +2851,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def sink_parquet(
         self,
-        path: str | Path | IO[bytes] | PartitionBy,
+        path: str | Path | os.PathLike[str] | IO[bytes] | PartitionBy,
         *,
         compression: str = "zstd",
         compression_level: int | None = None,
@@ -3123,7 +3127,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     @overload
     def sink_delta(
         self,
-        target: str | Path | deltalake.DeltaTable,
+        target: str | Path | os.PathLike[str] | deltalake.DeltaTable,
         *,
         mode: Literal["error", "append", "overwrite", "ignore"] = ...,
         storage_options: StorageOptionsDict | None = ...,
@@ -3135,7 +3139,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     @overload
     def sink_delta(
         self,
-        target: str | Path | deltalake.DeltaTable,
+        target: str | Path | os.PathLike[str] | deltalake.DeltaTable,
         *,
         mode: Literal["merge"],
         storage_options: StorageOptionsDict | None = ...,
@@ -3147,7 +3151,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     @unstable()
     def sink_delta(
         self,
-        target: str | Path | deltalake.DeltaTable,
+        target: str | Path | os.PathLike[str] | deltalake.DeltaTable,
         *,
         mode: Literal["error", "append", "overwrite", "ignore", "merge"] = "error",
         storage_options: StorageOptionsDict | None = None,
@@ -3364,8 +3368,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         _check_for_unsupported_types(self.collect_schema().dtypes())
 
-        if isinstance(target, (str, Path)):
-            target = _resolve_delta_lake_uri(str(target), strict=False)
+        if isinstance(target, (str, os.PathLike)):
+            target = _resolve_delta_lake_uri(target, strict=False)
 
         from polars.io.cloud.credential_provider._builder import (
             _init_credential_provider_builder,
@@ -3491,7 +3495,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     @overload
     def sink_ipc(
         self,
-        path: str | Path | IO[bytes] | PartitionBy,
+        path: str | Path | os.PathLike[str] | IO[bytes] | PartitionBy,
         *,
         compression: IpcCompression | None = "uncompressed",
         compat_level: CompatLevel | None = None,
@@ -3513,7 +3517,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     @overload
     def sink_ipc(
         self,
-        path: str | Path | IO[bytes] | PartitionBy,
+        path: str | Path | os.PathLike[str] | IO[bytes] | PartitionBy,
         *,
         compression: IpcCompression | None = "uncompressed",
         compat_level: CompatLevel | None = None,
@@ -3534,7 +3538,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def sink_ipc(
         self,
-        path: str | Path | IO[bytes] | PartitionBy,
+        path: str | Path | os.PathLike[str] | IO[bytes] | PartitionBy,
         *,
         compression: IpcCompression | None = "uncompressed",
         compat_level: CompatLevel | None = None,
@@ -3748,7 +3752,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     @overload
     def sink_csv(
         self,
-        path: str | Path | IO[bytes] | IO[str] | PartitionBy,
+        path: str | Path | os.PathLike[str] | IO[bytes] | IO[str] | PartitionBy,
         *,
         include_bom: bool = False,
         compression: Literal["uncompressed", "gzip", "zstd"] = "uncompressed",
@@ -3783,7 +3787,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     @overload
     def sink_csv(
         self,
-        path: str | Path | IO[bytes] | IO[str] | PartitionBy,
+        path: str | Path | os.PathLike[str] | IO[bytes] | IO[str] | PartitionBy,
         *,
         include_bom: bool = False,
         compression: Literal["uncompressed", "gzip", "zstd"] = "uncompressed",
@@ -3817,7 +3821,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def sink_csv(
         self,
-        path: str | Path | IO[bytes] | IO[str] | PartitionBy,
+        path: str | Path | os.PathLike[str] | IO[bytes] | IO[str] | PartitionBy,
         *,
         include_bom: bool = False,
         compression: Literal["uncompressed", "gzip", "zstd"] = "uncompressed",
@@ -4111,7 +4115,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     @overload
     def sink_ndjson(
         self,
-        path: str | Path | IO[bytes] | IO[str] | PartitionBy,
+        path: str | Path | os.PathLike[str] | IO[bytes] | IO[str] | PartitionBy,
         *,
         compression: Literal["uncompressed", "gzip", "zstd"] = "uncompressed",
         compression_level: int | None = None,
@@ -4132,7 +4136,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     @overload
     def sink_ndjson(
         self,
-        path: str | Path | IO[bytes] | IO[str] | PartitionBy,
+        path: str | Path | os.PathLike[str] | IO[bytes] | IO[str] | PartitionBy,
         *,
         compression: Literal["uncompressed", "gzip", "zstd"] = "uncompressed",
         compression_level: int | None = None,
@@ -4152,7 +4156,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def sink_ndjson(
         self,
-        path: str | Path | IO[bytes] | IO[str] | PartitionBy,
+        path: str | Path | os.PathLike[str] | IO[bytes] | IO[str] | PartitionBy,
         *,
         compression: Literal["uncompressed", "gzip", "zstd"] = "uncompressed",
         compression_level: int | None = None,

--- a/py-polars/tests/unit/dataframe/test_serde.py
+++ b/py-polars/tests/unit/dataframe/test_serde.py
@@ -14,6 +14,7 @@ import polars as pl
 from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 from polars.testing.parametric import dataframes
+from tests.unit.utils.pathlike import HostilePathLike
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -94,6 +95,34 @@ def test_df_serde_to_from_file(df: pl.DataFrame, tmp_path: Path) -> None:
     out = pl.DataFrame.deserialize(file_path)
 
     assert_frame_equal(df, out, categorical_as_str=True)
+
+
+@pytest.mark.write_disk
+def test_df_serde_to_from_os_pathlike_17828(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    file_path = tmp_path / "small.bin"
+    df.serialize(HostilePathLike(file_path))
+    out = pl.DataFrame.deserialize(HostilePathLike(file_path))
+
+    assert_frame_equal(df, out)
+
+
+@pytest.mark.write_disk
+def test_df_serde_to_from_open_file_handle(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+
+    # An open file handle is neither a path nor a `BytesIO`/`StringIO`, so it
+    # exercises the fall-through (non-path) branch of `serialize_polars_object`.
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    file_path = tmp_path / "small.bin"
+    with file_path.open("wb") as f:
+        df.serialize(f)
+    with file_path.open("rb") as f:
+        out = pl.DataFrame.deserialize(f)
+
+    assert_frame_equal(df, out)
 
 
 def test_df_serde2(df: pl.DataFrame) -> None:

--- a/py-polars/tests/unit/expr/test_serde.py
+++ b/py-polars/tests/unit/expr/test_serde.py
@@ -1,9 +1,16 @@
+from __future__ import annotations
+
 import io
+from typing import TYPE_CHECKING
 
 import pytest
 
 import polars as pl
 from polars.exceptions import ComputeError
+from tests.unit.utils.pathlike import HostilePathLike
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.mark.parametrize(
@@ -42,6 +49,18 @@ def test_expr_serde_roundtrip_json(expr: pl.Expr) -> None:
 def test_expr_deserialize_file_not_found() -> None:
     with pytest.raises(FileNotFoundError):
         pl.Expr.deserialize("abcdef")
+
+
+@pytest.mark.write_disk
+def test_expr_serde_to_from_os_pathlike_17828(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+
+    expr = pl.col("foo").sum().over("bar")
+    file_path = tmp_path / "expr.bin"
+    expr.meta.serialize(HostilePathLike(file_path))
+    round_tripped = pl.Expr.deserialize(HostilePathLike(file_path))
+
+    assert round_tripped.meta == expr
 
 
 def test_expr_deserialize_invalid_json() -> None:

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -23,6 +23,7 @@ from polars.io.delta._dataset import DeltaDataset
 from polars.io.delta._utils import _extract_table_statistics_from_delta_add_actions
 from polars.meta import get_index_type
 from polars.testing import assert_frame_equal, assert_frame_not_equal
+from tests.unit.utils.pathlike import HostilePathLike
 
 if TYPE_CHECKING:
     from tests.conftest import PlMonkeyPatch
@@ -1456,3 +1457,39 @@ def test_scan_delta_predicate_pushdown_struct_is_not_null(
     # must not be pruned.
     assert_frame_equal(out, df, check_row_order=False)
     assert "skipping 1 / 2 files" not in err
+
+
+@pytest.mark.write_disk
+def test_delta_os_pathlike_17828(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+
+    # Write, read, and scan a Delta table entirely via a hostile `os.PathLike`.
+    write_path = tmp_path / "table"
+    df.write_delta(HostilePathLike(write_path))
+    assert_frame_equal(
+        pl.read_delta(HostilePathLike(write_path)), df, check_row_order=False
+    )
+    assert_frame_equal(
+        pl.scan_delta(HostilePathLike(write_path)).collect(), df, check_row_order=False
+    )
+
+    # `sink_delta` must accept an `os.PathLike` target too.
+    sink_path = tmp_path / "sink"
+    df.lazy().sink_delta(HostilePathLike(sink_path))
+    assert_frame_equal(
+        pl.read_delta(HostilePathLike(sink_path)), df, check_row_order=False
+    )
+
+
+@pytest.mark.write_disk
+def test_sink_delta_to_delta_table_target_17828(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    path = tmp_path / "table"
+    df.write_delta(path)
+
+    # Passing a `DeltaTable` object (not a path) covers the non-path branch of
+    # the `isinstance(target, (str, os.PathLike))` check widened for gh #17828.
+    df.lazy().sink_delta(DeltaTable(str(path)), mode="append")
+    assert_frame_equal(pl.read_delta(path), pl.concat([df, df]), check_row_order=False)

--- a/py-polars/tests/unit/io/test_other.py
+++ b/py-polars/tests/unit/io/test_other.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import io
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -9,6 +10,7 @@ import pytest
 
 import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
+from tests.unit.utils.pathlike import HostilePathLike
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -68,6 +70,158 @@ def test_write_missing_directory(write_method_name: str) -> None:
     write_method = getattr(df, write_method_name)
     with pytest.raises(FileNotFoundError):
         write_method(non_existing_path)
+
+
+@pytest.mark.parametrize(
+    ("write_method", "read_function", "scan_function", "read_supports_list"),
+    [
+        # `read_supports_list` reflects existing behavior: the eager CSV/IPC
+        # readers do not accept a list of paths (only their `scan_*` variants
+        # do), while `read_parquet`/`read_ndjson` dispatch lists to a scan.
+        ("write_parquet", pl.read_parquet, pl.scan_parquet, True),
+        ("write_csv", pl.read_csv, pl.scan_csv, False),
+        ("write_ipc", pl.read_ipc, pl.scan_ipc, False),
+        ("write_ndjson", pl.read_ndjson, pl.scan_ndjson, True),
+        ("write_avro", pl.read_avro, None, False),
+        ("write_json", pl.read_json, None, False),
+    ],
+)
+def test_read_scan_os_pathlike_17828(
+    tmp_path: Path,
+    write_method: str,
+    read_function: Callable[[Any], pl.DataFrame],
+    scan_function: Callable[[Any], pl.LazyFrame] | None,
+    read_supports_list: bool,
+) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    path = tmp_path / "data"
+    getattr(df, write_method)(path)
+
+    source = HostilePathLike(path)
+
+    # A single `os.PathLike` must be treated as a path, not iterated over.
+    assert_frame_equal(read_function(source), df)
+    if scan_function is not None:
+        assert_frame_equal(scan_function(source).collect(), df)
+
+    # A list of `os.PathLike` must also be accepted where lists are supported.
+    if read_supports_list:
+        assert_frame_equal(read_function([source]), df)
+    if scan_function is not None:
+        assert_frame_equal(scan_function([source]).collect(), df)
+
+
+@pytest.mark.parametrize(
+    ("write_method", "read_function"),
+    [
+        ("write_parquet", pl.read_parquet),
+        ("write_csv", pl.read_csv),
+        ("write_ipc", pl.read_ipc),
+        ("write_ipc_stream", pl.read_ipc_stream),
+        ("write_ndjson", pl.read_ndjson),
+        ("write_json", pl.read_json),
+        ("write_avro", pl.read_avro),
+    ],
+)
+def test_write_os_pathlike_17828(
+    tmp_path: Path,
+    write_method: str,
+    read_function: Callable[[Any], pl.DataFrame],
+) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    path = tmp_path / "data"
+
+    # Writing must accept an `os.PathLike` target (not fall through to the
+    # file-object branch).
+    getattr(df, write_method)(HostilePathLike(path))
+
+    assert_frame_equal(read_function(path), df)
+
+
+def test_read_parquet_pyarrow_os_pathlike_17828(tmp_path: Path) -> None:
+    pytest.importorskip("pyarrow")
+    tmp_path.mkdir(exist_ok=True)
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    path = tmp_path / "data.parquet"
+    df.write_parquet(path)
+
+    # The PyArrow reader takes a separate code path from the native reader.
+    assert_frame_equal(pl.read_parquet(HostilePathLike(path), use_pyarrow=True), df)
+
+
+def test_read_schema_metadata_os_pathlike_17828(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+
+    parquet_path = tmp_path / "data.parquet"
+    ipc_path = tmp_path / "data.ipc"
+    ipc_stream_path = tmp_path / "data.ipcstream"
+    df.write_parquet(parquet_path)
+    df.write_ipc(ipc_path)
+    df.write_ipc_stream(ipc_stream_path)
+
+    assert set(pl.read_parquet_schema(HostilePathLike(parquet_path))) == {"a", "b"}
+    assert set(pl.read_ipc_schema(HostilePathLike(ipc_path))) == {"a", "b"}
+    assert isinstance(pl.read_parquet_metadata(HostilePathLike(parquet_path)), dict)
+
+    # `read_ipc_stream` also accepts `os.PathLike`.
+    assert_frame_equal(pl.read_ipc_stream(HostilePathLike(ipc_stream_path)), df)
+
+
+def test_read_csv_batched_os_pathlike_17828(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    csv_path = tmp_path / "data.csv"
+    df.write_csv(csv_path)
+
+    with pytest.deprecated_call():
+        batched = pl.read_csv_batched(HostilePathLike(csv_path))
+    batches = batched.next_batches(1)
+    assert batches is not None
+    assert_frame_equal(batches[0], df)
+
+
+@pytest.mark.parametrize(
+    ("write_method", "read_function"),
+    [
+        ("write_csv", pl.read_csv),
+        ("write_ipc", pl.read_ipc),
+    ],
+)
+def test_read_os_pathlike_force_async_17828(
+    plmonkeypatch: PlMonkeyPatch,
+    tmp_path: Path,
+    write_method: str,
+    read_function: Callable[[Any], pl.DataFrame],
+) -> None:
+    # The async dispatch checks `os.fspath(source).startswith("hf://")`; a
+    # path-like with a non-path `__str__` would break that check if `str()`
+    # were used instead of `os.fspath()`.
+    plmonkeypatch.setenv("POLARS_FORCE_ASYNC", "1")
+
+    tmp_path.mkdir(exist_ok=True)
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    path = tmp_path / "data"
+    getattr(df, write_method)(path)
+
+    assert_frame_equal(read_function(HostilePathLike(path)), df)
+
+
+def test_read_csv_streaming_io_source_17828(plmonkeypatch: PlMonkeyPatch) -> None:
+    # Under streaming, `read_csv` enters the scan-dispatch block regardless of
+    # source type; a non-path (`BytesIO`) source covers the `False` side of the
+    # `isinstance(source, (str, os.PathLike))` check widened for gh #17828 (the
+    # path/`os.PathLike` side is covered by `test_read_os_pathlike_force_async`).
+    plmonkeypatch.setenv("POLARS_FORCE_STREAMING", "1")
+
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    buf = io.BytesIO()
+    df.write_csv(buf)
+    buf.seek(0)
+
+    assert_frame_equal(pl.read_csv(buf), df)
 
 
 def test_read_missing_file_path_truncated() -> None:

--- a/py-polars/tests/unit/io/test_sink.py
+++ b/py-polars/tests/unit/io/test_sink.py
@@ -16,6 +16,7 @@ import polars as pl
 from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 from tests.unit.io.conftest import format_file_uri
+from tests.unit.utils.pathlike import HostilePathLike
 
 if TYPE_CHECKING:
     from polars._typing import EngineType
@@ -29,6 +30,28 @@ SINKS = [
     (pl.scan_csv, pl.LazyFrame.sink_csv),
     (pl.scan_ndjson, pl.LazyFrame.sink_ndjson),
 ]
+
+
+@pytest.mark.parametrize(("scan", "sink"), SINKS)
+@pytest.mark.write_disk
+def test_sink_os_pathlike_17828(tmp_path: Path, scan: Any, sink: Any) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    path = tmp_path / "data"
+
+    # `sink_*` must accept an `os.PathLike` target (via `_to_sink_target`).
+    sink(df.lazy(), HostilePathLike(path))
+
+    assert_frame_equal(scan(HostilePathLike(path)).collect(), df)
+
+
+def test_sink_to_io_target() -> None:
+    # A writable buffer exercises the non-path (IO) branch of `_to_sink_target`.
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    buf = io.BytesIO()
+    df.lazy().sink_parquet(buf)
+    buf.seek(0)
+    assert_frame_equal(pl.read_parquet(buf), df)
 
 
 @pytest.mark.parametrize(("scan", "sink"), SINKS)

--- a/py-polars/tests/unit/io/test_spreadsheet.py
+++ b/py-polars/tests/unit/io/test_spreadsheet.py
@@ -18,6 +18,7 @@ from polars.exceptions import (
 )
 from polars.testing import assert_frame_equal, assert_series_equal
 from tests.unit.conftest import FLOAT_DTYPES, NUMERIC_DTYPES
+from tests.unit.utils.pathlike import HostilePathLike
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -1499,3 +1500,28 @@ def test_spreadsheet_no_resource_warning(
         warnings.simplefilter("error", ResourceWarning)
         read_spreadsheet(spreadsheet_path, **params)
         read_spreadsheet(spreadsheet_path, sheet_id=0, **params)
+
+
+@pytest.mark.write_disk
+def test_read_write_excel_os_pathlike_17828(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    path = tmp_path / "data.xlsx"
+
+    # Both `write_excel` and `read_excel` must accept an `os.PathLike` and
+    # resolve it with `os.fspath`, not `str`.
+    df.write_excel(HostilePathLike(path))
+    out = pl.read_excel(HostilePathLike(path))
+    assert_frame_equal(out, df, check_dtypes=False)
+
+
+@pytest.mark.write_disk
+def test_read_excel_glob_os_pathlike_17828(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    df.write_excel(tmp_path / "data.xlsx")
+
+    # A path that does not exist as-is takes the glob branch, which expands the
+    # path-like via `os.fspath` (not `str`).
+    out = pl.read_excel(HostilePathLike(tmp_path / "*.xlsx"))
+    assert_frame_equal(out, df, check_dtypes=False)

--- a/py-polars/tests/unit/io/test_utils.py
+++ b/py-polars/tests/unit/io/test_utils.py
@@ -1,14 +1,26 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import pytest
 
 import polars as pl
-from polars.io._utils import looks_like_url, parse_columns_arg, parse_row_index_args
-from polars.io.cloud._utils import _get_path_scheme
+from polars._utils.various import is_path_or_str_sequence, normalize_filepath
+from polars.io._utils import (
+    get_sources,
+    looks_like_url,
+    parse_columns_arg,
+    parse_row_index_args,
+)
+from polars.io.cloud._utils import _first_scan_path, _get_path_scheme
+from polars.io.cloud.credential_provider._builder import (
+    _init_credential_provider_builder,
+)
+from tests.unit.utils.pathlike import HostilePathLike
 
 if TYPE_CHECKING:
+    import os
     from collections.abc import Sequence
 
 
@@ -78,3 +90,54 @@ def test_get_path_scheme() -> None:
     assert _get_path_scheme("scheme://") == "scheme"
     assert _get_path_scheme("://") == ""
     assert _get_path_scheme("://...") == ""
+
+
+def test_get_path_scheme_os_pathlike_17828() -> None:
+    # Must use `os.fspath`, not `str`, on the path-like.
+    assert _get_path_scheme(HostilePathLike("scheme://bucket/key")) == "scheme"
+    assert _get_path_scheme(HostilePathLike("/local/path")) is None
+
+
+def test_normalize_filepath_os_pathlike_17828() -> None:
+    # The path-like is resolved via `os.fspath`, yielding a plain string.
+    result = normalize_filepath(HostilePathLike("/some/path"))
+    assert result == "/some/path"
+    assert isinstance(result, str)
+
+
+def test_is_path_or_str_sequence_os_pathlike_17828() -> None:
+    assert is_path_or_str_sequence([HostilePathLike("a"), Path("b"), "c"])
+    assert is_path_or_str_sequence([HostilePathLike("a")])
+    # A single path-like is not a sequence.
+    assert not is_path_or_str_sequence(HostilePathLike("a"))
+    # A non-path element disqualifies the sequence.
+    assert not is_path_or_str_sequence([HostilePathLike("a"), 123])
+
+
+def test_get_sources_os_pathlike_17828() -> None:
+    # Single-component names so `os.fspath` is identical across platforms
+    # (`os.fspath(Path("a/b"))` would use `\` separators on Windows).
+    # A single path-like is normalized to a one-element list of strings.
+    assert get_sources(HostilePathLike("a.parquet")) == ["a.parquet"]
+    # A sequence of path-likes is normalized element-wise.
+    sources: list[os.PathLike[str]] = [HostilePathLike("a.parquet"), Path("b.parquet")]
+    assert get_sources(sources) == ["a.parquet", "b.parquet"]
+
+
+def test_first_scan_path_os_pathlike_17828() -> None:
+    single = HostilePathLike("/a/b")
+    assert _first_scan_path(single) is single
+
+    seq = [HostilePathLike("/a/b"), HostilePathLike("/c/d")]
+    assert _first_scan_path(seq) is seq[0]
+
+
+@pytest.mark.parametrize(
+    "uri", ["s3://bucket/data.parquet", "az://container/data.parquet"]
+)
+def test_init_credential_provider_builder_os_pathlike_17828(uri: str) -> None:
+    # The AWS/Azure branches resolve the path with `os.fspath`, not `str`.
+    builder = _init_credential_provider_builder(
+        "auto", HostilePathLike(uri), None, "scan_parquet"
+    )
+    assert builder is not None

--- a/py-polars/tests/unit/lazyframe/test_serde.py
+++ b/py-polars/tests/unit/lazyframe/test_serde.py
@@ -10,6 +10,7 @@ import polars as pl
 from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 from polars.testing.parametric import dataframes
+from tests.unit.utils.pathlike import HostilePathLike
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -94,6 +95,18 @@ def test_lf_serde_to_from_file(lf: pl.LazyFrame, tmp_path: Path) -> None:
     file_path = tmp_path / "small.bin"
     lf.serialize(file_path)
     result = pl.LazyFrame.deserialize(file_path)
+
+    assert_frame_equal(lf, result)
+
+
+@pytest.mark.write_disk
+def test_lf_serde_to_from_os_pathlike_17828(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+
+    lf = pl.LazyFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    file_path = tmp_path / "small.bin"
+    lf.serialize(HostilePathLike(file_path))
+    result = pl.LazyFrame.deserialize(HostilePathLike(file_path))
 
     assert_frame_equal(lf, result)
 

--- a/py-polars/tests/unit/lazyframe/test_show_graph.py
+++ b/py-polars/tests/unit/lazyframe/test_show_graph.py
@@ -1,6 +1,15 @@
+from __future__ import annotations
+
+import shutil
+from typing import TYPE_CHECKING
+
 import pytest
 
 import polars as pl
+from tests.unit.utils.pathlike import HostilePathLike
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.fixture
@@ -45,3 +54,22 @@ def test_show_graph_phys_not_streaming(query: pl.LazyFrame) -> None:
 def test_show_graph_invalid_stage(query: pl.LazyFrame) -> None:
     with pytest.raises(TypeError, match="invalid plan stage 'invalid-stage'"):
         query.show_graph(raw_output=True, plan_stage="invalid-stage")  # type: ignore[call-overload]
+
+
+@pytest.mark.write_disk
+@pytest.mark.skipif(
+    shutil.which("dot") is None, reason="graphviz `dot` binary is required"
+)
+def test_show_graph_output_path_os_pathlike_17828(
+    query: pl.LazyFrame, tmp_path: Path
+) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    output_path = tmp_path / "graph.png"
+
+    # `output_path` must accept an `os.PathLike`; the `.svg` suffix check uses
+    # `os.fspath`, not `str`.
+    result = query.show_graph(show=False, output_path=HostilePathLike(output_path))
+
+    assert result is None
+    assert output_path.exists()
+    assert output_path.stat().st_size > 0

--- a/py-polars/tests/unit/utils/pathlike.py
+++ b/py-polars/tests/unit/utils/pathlike.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class HostilePathLike(os.PathLike[str]):
+    """An ``os.PathLike`` whose ``str()`` is deliberately *not* the path.
+
+    Its ``__str__`` returns a non-path value, so consuming it correctly requires
+    ``os.fspath()`` rather than ``str()`` — a regression guard for gh #17828.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = os.fspath(path)
+
+    def __fspath__(self) -> str:
+        return self._path
+
+    def __repr__(self) -> str:
+        return "<HostilePathLike: path hidden>"
+
+    __str__ = __repr__


### PR DESCRIPTION
Closes #17828.

`read_*`/`scan_*` (and, for consistency, the write, sink, and serialize/deserialize functions) previously gated paths on `isinstance(x, (str, Path))`, so a custom `os.PathLike` fell through to the "iterable of sources" branch and raised `TypeError: not iterable`.

## Changes

- Broaden the runtime path checks from `(str, Path)` to `(str, os.PathLike)`, and teach `is_path_or_str_sequence`, `get_sources`, and `prepare_file_arg` to handle path-likes (and lists of them).
- Resolve raw sources with `os.fspath()` rather than `str()` wherever the un-normalized source is inspected (`hf://` dispatch in csv/ipc, cloud scheme detection, the credential-provider path, spreadsheet, Delta URIs, and `show_graph`'s `output_path`) — so a custom `__str__` cannot corrupt the path.
- Extend the type hints to `os.PathLike[str]` across `FileSource`, the readers/scanners/writers/sinks, serialize/deserialize, the Delta read/scan/write/sink functions, and `output_path`.

`normalize_filepath` itself needs no change: `os.path.expanduser` already `os.fspath`-converts to `str`.

## Tests

Added `#17828` regression tests covering read/scan (single + list), write round-trips, schema/stream/metadata, the batched CSV reader, force-async dispatch, DataFrame/LazyFrame/Expr serialize+deserialize, `read_excel`, Delta read/scan/write/sink, and `show_graph(output_path=...)`, plus pure-Python helper unit tests. They use a shared `HostilePathLike` helper (in `tests/unit/utils/pathlike.py`) whose `__str__` deliberately is not the path, locking in the `os.fspath` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)