### PR TITLE
refactor(rust): Classify fields in parquet reader by use

### DIFF
--- a/crates/polars-io/src/predicates.rs
+++ b/crates/polars-io/src/predicates.rs
@@ -403,7 +403,8 @@ pub trait SkipBatchPredicate: Send + Sync {
 pub struct ColumnPredicates {
     pub predicates:
         PlHashMap<PlSmallStr, (Arc<dyn PhysicalIoExpr>, Option<SpecializedColumnPredicate>)>,
-    pub is_sumwise_complete: bool,
+    /// The part of the scan predicate not represented by `predicates`.
+    pub residual_predicate: Option<Arc<dyn PhysicalIoExpr>>,
 }
 
 // I want to be explicit here.
@@ -412,7 +413,7 @@ impl Default for ColumnPredicates {
     fn default() -> Self {
         Self {
             predicates: PlHashMap::default(),
-            is_sumwise_complete: false,
+            residual_predicate: None,
         }
     }
 }
@@ -465,7 +466,7 @@ pub struct ScanIOPredicate {
     /// A predicate that gets given statistics and evaluates whether a batch can be skipped.
     pub skip_batch_predicate: Option<Arc<dyn SkipBatchPredicate>>,
 
-    /// A predicate that gets given statistics and evaluates whether a batch can be skipped.
+    /// Per-column predicates and a residual predicate for columnar formats.
     pub column_predicates: Arc<ColumnPredicates>,
 
     /// Predicate parts only referring to hive columns.
@@ -509,12 +510,21 @@ impl ScanIOPredicate {
         for (c, _) in constant_columns.iter() {
             column_predicates.predicates.remove(c);
         }
-        self.column_predicates = Arc::new(column_predicates);
-
         self.predicate = Arc::new(PhysicalExprWithConstCols {
-            constants: constant_columns,
+            constants: constant_columns.clone(),
             child: self.predicate.clone(),
         });
+
+        column_predicates.residual_predicate =
+            column_predicates
+                .residual_predicate
+                .map(|residual_predicate| {
+                    Arc::new(PhysicalExprWithConstCols {
+                        constants: constant_columns,
+                        child: residual_predicate,
+                    }) as Arc<dyn PhysicalIoExpr>
+                });
+        self.column_predicates = Arc::new(column_predicates);
     }
 }
 

--- a/crates/polars-mem-engine/src/scan_predicate/functions.rs
+++ b/crates/polars-mem-engine/src/scan_predicate/functions.rs
@@ -161,12 +161,18 @@ pub fn create_scan_predicate(
                 );
             }
             eprintln!("  ],");
-            eprintln!(
-                "  is_sumwise_complete: {}",
-                column_predicates.is_sumwise_complete
-            );
+            if let Some(residual_predicate) = column_predicates.residual_predicate {
+                eprintln!(
+                    "  residual: {},",
+                    ExprIRDisplay::display_node(residual_predicate, expr_arena)
+                );
+            }
             eprintln!("}}");
         }
+        let residual_predicate = column_predicates.residual_predicate.map(|node| {
+            debug_assert_eq!(node, predicate.node());
+            phys_predicate.clone()
+        });
         PhysicalColumnPredicates {
             predicates: column_predicates
                 .predicates
@@ -186,12 +192,12 @@ pub fn create_scan_predicate(
                     ))
                 })
                 .collect::<PolarsResult<PlHashMap<_, _>>>()?,
-            is_sumwise_complete: column_predicates.is_sumwise_complete,
+            residual_predicate,
         }
     } else {
         PhysicalColumnPredicates {
             predicates: PlHashMap::default(),
-            is_sumwise_complete: false,
+            residual_predicate: Some(phys_predicate.clone()),
         }
     };
 

--- a/crates/polars-mem-engine/src/scan_predicate/functions.rs
+++ b/crates/polars-mem-engine/src/scan_predicate/functions.rs
@@ -169,10 +169,17 @@ pub fn create_scan_predicate(
             }
             eprintln!("}}");
         }
-        let residual_predicate = column_predicates.residual_predicate.map(|node| {
-            debug_assert_eq!(node, predicate.node());
-            phys_predicate.clone()
-        });
+        let residual_predicate = column_predicates
+            .residual_predicate
+            .map(|node| {
+                create_physical_expr(
+                    &ExprIR::new(node, OutputName::Alias(PlSmallStr::EMPTY)),
+                    expr_arena,
+                    schema,
+                    state,
+                )
+            })
+            .transpose()?;
         PhysicalColumnPredicates {
             predicates: column_predicates
                 .predicates

--- a/crates/polars-mem-engine/src/scan_predicate/mod.rs
+++ b/crates/polars-mem-engine/src/scan_predicate/mod.rs
@@ -34,7 +34,7 @@ pub struct ScanPredicate {
     /// `false` even when the batch could theoretically be skipped.
     pub skip_batch_predicate: Option<Arc<dyn PhysicalExpr>>,
 
-    /// Partial predicates for each column for filter when loading columnar formats.
+    /// Per-column predicates and a residual predicate for columnar formats.
     pub column_predicates: PhysicalColumnPredicates,
 
     /// Predicate only referring to hive columns.
@@ -52,7 +52,7 @@ impl fmt::Debug for ScanPredicate {
 pub struct PhysicalColumnPredicates {
     pub predicates:
         PlHashMap<PlSmallStr, (Arc<dyn PhysicalExpr>, Option<SpecializedColumnPredicate>)>,
-    pub is_sumwise_complete: bool,
+    pub residual_predicate: Option<Arc<dyn PhysicalExpr>>,
 }
 
 /// Helper to implement [`SkipBatchPredicate`].
@@ -122,7 +122,7 @@ impl ScanPredicate {
                 Default::default()
             });
 
-        let predicate_constants = constant_columns
+        let predicate_constants: Vec<_> = constant_columns
             .filter_map(|(name, scalar): (PlSmallStr, Scalar)| {
                 if !live_columns.swap_remove(&name) {
                     return None;
@@ -149,7 +149,7 @@ impl ScanPredicate {
             .collect();
 
         let predicate = Arc::new(PhysicalExprWithConstCols {
-            constants: predicate_constants,
+            constants: predicate_constants.clone(),
             child: self.predicate.clone(),
         });
         let skip_batch_predicate = self.skip_batch_predicate.as_ref().map(|skp| {
@@ -159,12 +159,22 @@ impl ScanPredicate {
             }) as _
         });
 
+        let mut column_predicates = self.column_predicates.clone();
+        column_predicates.residual_predicate =
+            column_predicates
+                .residual_predicate
+                .map(|residual_predicate| {
+                    Arc::new(PhysicalExprWithConstCols {
+                        constants: predicate_constants,
+                        child: residual_predicate,
+                    }) as Arc<dyn PhysicalExpr>
+                });
+
         Self {
             predicate,
             live_columns: Arc::new(live_columns),
             skip_batch_predicate,
-            column_predicates: self.column_predicates.clone(), // Q? Maybe this should cull
-            // predicates.
+            column_predicates,
             hive_predicate: None,
             hive_predicate_is_full_predicate: false,
         }
@@ -200,7 +210,11 @@ impl ScanPredicate {
                     .iter()
                     .map(|(n, (p, s))| (n.clone(), (phys_expr_to_io_expr(p.clone()), s.clone())))
                     .collect(),
-                is_sumwise_complete: self.column_predicates.is_sumwise_complete,
+                residual_predicate: self
+                    .column_predicates
+                    .residual_predicate
+                    .clone()
+                    .map(phys_expr_to_io_expr),
             }),
             hive_predicate: self.hive_predicate.clone().map(phys_expr_to_io_expr),
             hive_predicate_is_full_predicate: self.hive_predicate_is_full_predicate,

--- a/crates/polars-plan/src/plans/aexpr/predicates/column_expr.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/column_expr.rs
@@ -32,7 +32,7 @@ pub fn aexpr_to_column_predicates(
 ) -> ColumnPredicates {
     let mut predicates =
         PlIndexMap::<PlSmallStr, (Node, Option<SpecializedColumnPredicate>)>::default();
-    let mut has_residual = false;
+    let mut residual_predicates = Vec::new();
 
     let minterms = MintermIter::new(root, expr_arena).collect::<Vec<_>>();
 
@@ -42,13 +42,13 @@ pub fn aexpr_to_column_predicates(
         leaf_names.extend(aexpr_to_leaf_names_iter(minterm, expr_arena).cloned());
 
         if leaf_names.len() != 1 {
-            has_residual = true;
+            residual_predicates.push(minterm);
             continue;
         }
 
         let column = leaf_names.pop().unwrap();
         let Some(dtype) = schema.get(&column) else {
-            has_residual = true;
+            residual_predicates.push(minterm);
             continue;
         };
 
@@ -57,30 +57,30 @@ pub fn aexpr_to_column_predicates(
         match dtype {
             #[cfg(feature = "dtype-categorical")]
             D::Enum(_, _) | D::Categorical(_, _) => {
-                has_residual = true;
+                residual_predicates.push(minterm);
                 continue;
             },
             #[cfg(feature = "dtype-decimal")]
             D::Decimal(_, _) => {
-                has_residual = true;
+                residual_predicates.push(minterm);
                 continue;
             },
             #[cfg(feature = "object")]
             D::Object(_) => {
-                has_residual = true;
+                residual_predicates.push(minterm);
                 continue;
             },
             #[cfg(feature = "dtype-f16")]
             D::Float16 => {
-                has_residual = true;
+                residual_predicates.push(minterm);
                 continue;
             },
             D::Float32 | D::Float64 => {
-                has_residual = true;
+                residual_predicates.push(minterm);
                 continue;
             },
             _ if dtype.is_nested() => {
-                has_residual = true;
+                residual_predicates.push(minterm);
                 continue;
             },
             _ => {},
@@ -293,12 +293,13 @@ pub fn aexpr_to_column_predicates(
             });
     }
 
-    // All-or-nothing classification. Either we can evaluate everything
-    // per-column or we can evaluate nothing per-column.
-    let residual_predicate = has_residual.then_some(root);
-    if residual_predicate.is_some() {
-        predicates.clear();
-    }
+    let residual_predicate = residual_predicates.into_iter().reduce(|left, right| {
+        expr_arena.add(AExpr::BinaryExpr {
+            left,
+            op: Operator::LogicalAnd,
+            right,
+        })
+    });
 
     ColumnPredicates {
         predicates,
@@ -393,6 +394,45 @@ mod tests {
         };
         assert_eq!(col_name, col_name2);
         Ok(predicate)
+    }
+
+    #[test]
+    fn splits_eager_and_residual_predicates() -> PolarsResult<()> {
+        let mut arena = Arena::new();
+        let schema = Schema::from_iter_check_duplicates([
+            ("integer".into(), DataType::Int64),
+            ("float_a".into(), DataType::Float64),
+            ("float_b".into(), DataType::Float64),
+        ])?;
+        let mut ctx = ExprToIRContext::new(&mut arena, &schema);
+        let expr = col("integer")
+            .gt(typed_lit(1i64))
+            .and(col("float_a").lt(typed_lit(3.0f64)))
+            .and(col("float_b").gt(typed_lit(0.0f64)));
+        let expr_ir = to_expr_ir(expr, &mut ctx)?;
+
+        let column_predicates = aexpr_to_column_predicates(expr_ir.node(), &mut arena, &schema);
+
+        assert_eq!(
+            column_predicates
+                .predicates
+                .keys()
+                .map(PlSmallStr::as_str)
+                .collect::<Vec<_>>(),
+            ["integer"],
+        );
+
+        let residual_predicate = column_predicates.residual_predicate.unwrap();
+        assert_ne!(residual_predicate, expr_ir.node());
+        assert_eq!(
+            MintermIter::new(residual_predicate, &arena)
+                .flat_map(|node| aexpr_to_leaf_names_iter(node, &arena))
+                .map(PlSmallStr::as_str)
+                .collect::<Vec<_>>(),
+            ["float_a", "float_b"],
+        );
+
+        Ok(())
     }
 
     #[test]

--- a/crates/polars-plan/src/plans/aexpr/predicates/column_expr.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/column_expr.rs
@@ -1,4 +1,5 @@
-//! This module creates predicates splits predicates into partial per-column predicates.
+//! This module splits incoming predicates into per-column predicates and a
+//! residual predicate that must be evaluated after decode/filtering.
 
 use polars_core::datatypes::DataType;
 use polars_core::prelude::AnyValue;
@@ -20,8 +21,8 @@ use crate::plans::{
 pub struct ColumnPredicates {
     pub predicates: PlIndexMap<PlSmallStr, (Node, Option<SpecializedColumnPredicate>)>,
 
-    /// Are all column predicates AND-ed together the original predicate.
-    pub is_sumwise_complete: bool,
+    /// The part of the original predicate not represented by `predicates`.
+    pub residual_predicate: Option<Node>,
 }
 
 pub fn aexpr_to_column_predicates(
@@ -31,7 +32,7 @@ pub fn aexpr_to_column_predicates(
 ) -> ColumnPredicates {
     let mut predicates =
         PlIndexMap::<PlSmallStr, (Node, Option<SpecializedColumnPredicate>)>::default();
-    let mut is_sumwise_complete = true;
+    let mut has_residual = false;
 
     let minterms = MintermIter::new(root, expr_arena).collect::<Vec<_>>();
 
@@ -41,13 +42,13 @@ pub fn aexpr_to_column_predicates(
         leaf_names.extend(aexpr_to_leaf_names_iter(minterm, expr_arena).cloned());
 
         if leaf_names.len() != 1 {
-            is_sumwise_complete = false;
+            has_residual = true;
             continue;
         }
 
         let column = leaf_names.pop().unwrap();
         let Some(dtype) = schema.get(&column) else {
-            is_sumwise_complete = false;
+            has_residual = true;
             continue;
         };
 
@@ -56,30 +57,30 @@ pub fn aexpr_to_column_predicates(
         match dtype {
             #[cfg(feature = "dtype-categorical")]
             D::Enum(_, _) | D::Categorical(_, _) => {
-                is_sumwise_complete = false;
+                has_residual = true;
                 continue;
             },
             #[cfg(feature = "dtype-decimal")]
             D::Decimal(_, _) => {
-                is_sumwise_complete = false;
+                has_residual = true;
                 continue;
             },
             #[cfg(feature = "object")]
             D::Object(_) => {
-                is_sumwise_complete = false;
+                has_residual = true;
                 continue;
             },
             #[cfg(feature = "dtype-f16")]
             D::Float16 => {
-                is_sumwise_complete = false;
+                has_residual = true;
                 continue;
             },
             D::Float32 | D::Float64 => {
-                is_sumwise_complete = false;
+                has_residual = true;
                 continue;
             },
             _ if dtype.is_nested() => {
-                is_sumwise_complete = false;
+                has_residual = true;
                 continue;
             },
             _ => {},
@@ -292,9 +293,16 @@ pub fn aexpr_to_column_predicates(
             });
     }
 
+    // All-or-nothing classification. Either we can evaluate everything
+    // per-column or we can evaluate nothing per-column.
+    let residual_predicate = has_residual.then_some(root);
+    if residual_predicate.is_some() {
+        predicates.clear();
+    }
+
     ColumnPredicates {
         predicates,
-        is_sumwise_complete,
+        residual_predicate,
     }
 }
 
@@ -373,6 +381,7 @@ mod tests {
         let mut ctx = ExprToIRContext::new(&mut arena, &schema);
         let expr_ir = to_expr_ir(expr, &mut ctx)?;
         let column_predicates = aexpr_to_column_predicates(expr_ir.node(), &mut arena, &schema);
+        assert!(column_predicates.residual_predicate.is_none());
         assert_eq!(column_predicates.predicates.len(), 1);
         let Some((col_name2, (_, predicate))) =
             column_predicates.predicates.clone().into_iter().next()

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/tasks/reader_starter.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/tasks/reader_starter.rs
@@ -599,7 +599,10 @@ async fn start_reader_impl(
                                 .unwrap_or_else(|| Scalar::null(dtype.clone())),
                         ));
 
-                        Arc::make_mut(&mut predicate.column_predicates).is_sumwise_complete = false;
+                        let residual_predicate = predicate.predicate.clone();
+                        let column_predicates = Arc::make_mut(&mut predicate.column_predicates);
+                        column_predicates.predicates.clear();
+                        column_predicates.residual_predicate = Some(residual_predicate);
                     }
                 },
                 MissingColumnsPolicy::Raise => return Err(missing_column_err(missing_col_name)),

--- a/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
@@ -10,7 +10,7 @@ use polars_io::prelude::ParallelStrategy;
 use polars_utils::IdxSize;
 
 use super::row_group_data_fetch::RowGroupDataFetcher;
-use super::row_group_decode::RowGroupDecoder;
+use super::row_group_decode::{ProjectedFieldClassification, RowGroupDecoder};
 use super::{AsyncTaskData, ParquetReadImpl};
 use crate::morsel::{Morsel, SourceToken, get_ideal_morsel_size};
 use crate::nodes::io_sources::multi_scan::reader_interface::output::FileReaderOutputSend;
@@ -326,41 +326,50 @@ impl ParquetReadImpl {
         use_prefiltered |=
             predicate.is_some() && matches!(self.options.parallel, ParallelStrategy::Auto);
 
-        let predicate_field_indices: Arc<[usize]> =
-            if use_prefiltered && let Some(predicate) = predicate.as_ref() {
-                projected_arrow_fields
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(i, projected_field)| {
-                        predicate
-                            .live_columns
-                            .contains(projected_field.output_name())
-                            .then_some(i)
-                    })
-                    .collect()
-            } else {
-                Default::default()
-            };
+        let mut eager_predicate = Vec::new();
+        let mut additional_predicate = Vec::new();
+        let mut live_predicate = Vec::new();
+
+        if use_prefiltered && let Some(predicate) = predicate.as_ref() {
+            for (i, projected_field) in projected_arrow_fields.iter().enumerate() {
+                let name = projected_field.output_name();
+                if !predicate.live_columns.contains(name) {
+                    continue;
+                }
+
+                live_predicate.push(i);
+                if predicate.column_predicates.predicates.contains_key(name) {
+                    eager_predicate.push(i);
+                } else {
+                    additional_predicate.push(i);
+                }
+            }
+        }
 
         let use_prefiltered = use_prefiltered.then(PrefilterMaskSetting::init_from_env);
 
-        let non_predicate_field_indices: Arc<[usize]> = if use_prefiltered.is_some() {
-            filtered_range(
-                predicate_field_indices.as_ref(),
-                projected_arrow_fields.len(),
-            )
-            .collect()
+        let payload: Arc<[usize]> = if use_prefiltered.is_some() {
+            filtered_range(live_predicate.as_slice(), projected_arrow_fields.len()).collect()
         } else {
             Default::default()
         };
 
         if use_prefiltered.is_some() && self.verbose {
             eprintln!(
-                "[ParquetFileReader]: Pre-filtered decode enabled ({} live, {} non-live)",
-                predicate_field_indices.len(),
-                non_predicate_field_indices.len()
+                "[ParquetFileReader]: Pre-filtered decode enabled ({} live, {} eager, {} additional, {} payload)",
+                live_predicate.len(),
+                eager_predicate.len(),
+                additional_predicate.len(),
+                payload.len()
             )
         }
+
+        let prefiltered_field_indices = ProjectedFieldClassification {
+            live_predicate: live_predicate.into(),
+            eager_predicate: eager_predicate.into(),
+            additional_predicate: additional_predicate.into(),
+            payload,
+        };
 
         let allow_column_predicates = predicate.as_ref().is_some_and(|p| {
             p.column_predicates.residual_predicate.is_none()
@@ -381,8 +390,7 @@ impl ParquetReadImpl {
             predicate,
             allow_column_predicates,
             use_prefiltered,
-            predicate_field_indices,
-            non_predicate_field_indices,
+            projected_field_classification: prefiltered_field_indices,
             target_values_per_thread,
         }
     }

--- a/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
@@ -363,7 +363,7 @@ impl ParquetReadImpl {
         }
 
         let allow_column_predicates = predicate.as_ref().is_some_and(|p| {
-            p.column_predicates.is_sumwise_complete
+            p.column_predicates.residual_predicate.is_none()
                 && !projected_arrow_fields.iter().any(|f| {
                     matches!(f.arrow_field().dtype(), ArrowDataType::FixedSizeBinary(_))
                         && p.column_predicates.predicates.contains_key(f.output_name())

--- a/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
@@ -493,7 +493,12 @@ impl RowGroupDecoder {
         }
 
         let (live_df_filtered, mut mask) = if use_column_predicates {
-            assert!(scan_predicate.column_predicates.is_sumwise_complete);
+            assert!(
+                scan_predicate
+                    .column_predicates
+                    .residual_predicate
+                    .is_none()
+            );
             if let [mask] = masks.as_slice() {
                 (
                     unsafe { DataFrame::new_unchecked_infer_height(live_columns) },
@@ -529,7 +534,17 @@ impl RowGroupDecoder {
                 DataFrame::new_unchecked(row_group_data.row_group_metadata.num_rows(), live_columns)
             };
 
-            let mask = scan_predicate.predicate.evaluate_io(&live_df)?;
+            // We can be in this branch either because we have a residual
+            // predicate to handle, or reader-level limitations disabled
+            // column predicates (for example, we have Float16 types). Thus
+            // we first check if we have a residual and if not, pick up the
+            // full predicate.
+            let mask = scan_predicate
+                .column_predicates
+                .residual_predicate
+                .as_ref()
+                .unwrap_or(&scan_predicate.predicate)
+                .evaluate_io(&live_df)?;
             let mask = mask.bool().unwrap();
 
             unsafe {

--- a/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
@@ -20,6 +20,25 @@ use polars_utils::{IdxSize, UnitVec};
 use super::row_group_data_fetch::RowGroupData;
 use crate::nodes::io_sources::parquet::projection::ArrowFieldProjection;
 
+/// Classification of projected fields. Each entry must individually be
+/// sorted in increasing order.
+/// Invariants:
+/// live_predicate = eager_predicate ∪ additional_predicate
+/// eager_predicate ∩ additional_predicate = ∅
+/// live_predicate ∪ payload = {0, ..., projected_arrow_fields.len() - 1}
+#[derive(Default)]
+pub(super) struct ProjectedFieldClassification {
+    /// All fields needed to evaluate the complete predicate.
+    pub(super) live_predicate: Arc<[usize]>,
+    /// Predicate fields that can be decoded with a column predicate.
+    pub(super) eager_predicate: Arc<[usize]>,
+    /// Additional fields, not in eager_predicate, that are needed to
+    /// evaluate the full predicate.
+    pub(super) additional_predicate: Arc<[usize]>,
+    /// Projected fields that are not needed to evaluate the predicate.
+    pub(super) payload: Arc<[usize]>,
+}
+
 /// Turns row group data into DataFrames.
 pub(super) struct RowGroupDecoder {
     pub(super) num_pipelines: usize,
@@ -28,10 +47,7 @@ pub(super) struct RowGroupDecoder {
     pub(super) row_index: Option<RowIndex>,
     pub(super) predicate: Option<ScanIOPredicate>,
     pub(super) use_prefiltered: Option<PrefilterMaskSetting>,
-    /// Indices into `projected_arrow_fields. This must be sorted.
-    pub(super) predicate_field_indices: Arc<[usize]>,
-    /// Indices into `projected_arrow_fields. This must be sorted.
-    pub(super) non_predicate_field_indices: Arc<[usize]>,
+    pub(super) projected_field_classification: ProjectedFieldClassification,
     pub(super) target_values_per_thread: usize,
 }
 
@@ -48,7 +64,10 @@ impl RowGroupDecoder {
 
         if self.use_prefiltered.is_some()
             && row_group_data.slice.is_none()
-            && !self.predicate_field_indices.is_empty()
+            && !self
+                .projected_field_classification
+                .live_predicate
+                .is_empty()
         {
             self.row_group_data_to_df_prefiltered(row_group_data).await
         } else {
@@ -159,8 +178,9 @@ impl RowGroupDecoder {
 
         // Ensure we provide the same output column order as the pre-filtered decode.
         let get_projected_field_at_output_index = {
-            let predicate_field_indices = self.predicate_field_indices.clone();
-            let non_predicate_field_indices = self.non_predicate_field_indices.clone();
+            let predicate_field_indices =
+                self.projected_field_classification.live_predicate.clone();
+            let payload_field_indices = self.projected_field_classification.payload.clone();
 
             move |i: usize| {
                 if predicate_field_indices.is_empty() {
@@ -168,7 +188,7 @@ impl RowGroupDecoder {
                 } else if i < predicate_field_indices.len() {
                     predicate_field_indices[i]
                 } else {
-                    non_predicate_field_indices[i - predicate_field_indices.len()]
+                    payload_field_indices[i - predicate_field_indices.len()]
                 }
             }
         };
@@ -396,18 +416,30 @@ impl RowGroupDecoder {
         row_group_data: RowGroupData,
     ) -> PolarsResult<DataFrame> {
         debug_assert!(row_group_data.slice.is_none()); // Invariant of the optimizer.
-        assert!(self.predicate_field_indices.len() <= self.projected_arrow_fields.len());
+        debug_assert_eq!(
+            self.projected_field_classification.live_predicate.len(),
+            self.projected_field_classification.eager_predicate.len()
+                + self
+                    .projected_field_classification
+                    .additional_predicate
+                    .len(),
+        );
+        assert!(
+            self.projected_field_classification.live_predicate.len()
+                <= self.projected_arrow_fields.len()
+        );
 
         let row_group_data = Arc::new(row_group_data);
         let projection_height = row_group_data.row_group_metadata.num_rows();
 
         let mut live_columns = Vec::with_capacity(
             self.row_index.is_some() as usize
-                + self.predicate_field_indices.len()
-                + self.non_predicate_field_indices.len(),
+                + self.projected_field_classification.live_predicate.len()
+                + self.projected_field_classification.payload.len(),
         );
         let mut masks = Vec::with_capacity(
-            self.row_index.is_some() as usize + self.predicate_field_indices.len(),
+            self.row_index.is_some() as usize
+                + self.projected_field_classification.live_predicate.len(),
         );
 
         if let Some(s) = self.materialize_row_index(
@@ -432,18 +464,20 @@ impl RowGroupDecoder {
                 });
 
         let cols_per_thread = (self
-            .predicate_field_indices
+            .projected_field_classification
+            .live_predicate
             .len()
             .div_ceil(self.num_pipelines))
         .max(1);
         let task_handles = {
-            let predicate_field_indices = self.predicate_field_indices.clone();
+            let predicate_field_indices =
+                self.projected_field_classification.live_predicate.clone();
             let projected_arrow_fields = self.projected_arrow_fields.clone();
             let row_group_data = row_group_data.clone();
 
             parallelize_first_to_local(
                 TaskPriority::Low,
-                (0..self.predicate_field_indices.len())
+                (0..self.projected_field_classification.live_predicate.len())
                     .step_by(cols_per_thread)
                     .map(move |offset| {
                         let row_group_data = row_group_data.clone();
@@ -549,7 +583,8 @@ impl RowGroupDecoder {
 
             unsafe {
                 live_df.columns_mut().truncate(
-                    self.row_index.is_some() as usize + self.predicate_field_indices.len(),
+                    self.row_index.is_some() as usize
+                        + self.projected_field_classification.live_predicate.len(),
                 )
             }
 
@@ -568,7 +603,7 @@ impl RowGroupDecoder {
             )
         };
 
-        if self.non_predicate_field_indices.is_empty() {
+        if self.projected_field_classification.payload.is_empty() {
             // User or test may have explicitly requested prefiltering
             return Ok(live_df_filtered);
         }
@@ -585,36 +620,34 @@ impl RowGroupDecoder {
         let expected_num_rows = mask_bitmap.set_bits();
 
         let cols_per_thread = (self
-            .predicate_field_indices
+            .projected_field_classification
+            .live_predicate
             .len()
             .div_ceil(self.num_pipelines))
         .max(1);
 
         let task_handles = {
-            let non_predicate_field_indices = self.non_predicate_field_indices.clone();
-            let non_predicate_len = non_predicate_field_indices.len();
+            let payload_field_indices = self.projected_field_classification.payload.clone();
+            let payload_len = payload_field_indices.len();
             let projected_arrow_fields = self.projected_arrow_fields.clone();
             let row_group_data = row_group_data.clone();
 
             parallelize_first_to_local(
                 TaskPriority::Low,
-                (0..non_predicate_len)
+                (0..payload_len)
                     .step_by(cols_per_thread)
                     .map(move |offset| {
                         let row_group_data = row_group_data.clone();
-                        let non_predicate_field_indices = non_predicate_field_indices.clone();
+                        let payload_field_indices = payload_field_indices.clone();
                         let projected_arrow_fields = projected_arrow_fields.clone();
                         let mask = mask.clone();
                         let mask_bitmap = mask_bitmap.clone();
 
                         async move {
-                            (offset
-                                ..offset
-                                    .saturating_add(cols_per_thread)
-                                    .min(non_predicate_len))
+                            (offset..offset.saturating_add(cols_per_thread).min(payload_len))
                                 .map(|i| {
                                     let projection =
-                                        &projected_arrow_fields[non_predicate_field_indices[i]];
+                                        &projected_arrow_fields[payload_field_indices[i]];
 
                                     let col = decode_column_prefiltered(
                                         projection.arrow_field(),
@@ -636,7 +669,7 @@ impl RowGroupDecoder {
 
         let live_columns = live_df_filtered.into_columns();
 
-        let mut dead_cols = Vec::with_capacity(self.non_predicate_field_indices.len());
+        let mut dead_cols = Vec::with_capacity(self.projected_field_classification.payload.len());
         for fut in task_handles {
             dead_cols.extend(fut.await?);
         }

--- a/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
@@ -568,17 +568,9 @@ impl RowGroupDecoder {
                 DataFrame::new_unchecked(row_group_data.row_group_metadata.num_rows(), live_columns)
             };
 
-            // We can be in this branch either because we have a residual
-            // predicate to handle, or reader-level limitations disabled
-            // column predicates (for example, we have Float16 types). Thus
-            // we first check if we have a residual and if not, pick up the
-            // full predicate.
-            let mask = scan_predicate
-                .column_predicates
-                .residual_predicate
-                .as_ref()
-                .unwrap_or(&scan_predicate.predicate)
-                .evaluate_io(&live_df)?;
+            // No column predicates were applied in this branch. Evaluate the complete predicate,
+            // even if part of it was classified as a residual predicate.
+            let mask = scan_predicate.predicate.evaluate_io(&live_df)?;
             let mask = mask.bool().unwrap();
 
             unsafe {

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -1855,7 +1855,7 @@ def test_scan_iceberg_parquet_prefilter_with_column_mapping(
         "[ParquetFileReader]: Predicate pushdown: reading 1 / 1 row groups" in capture
     )
     assert (
-        "[ParquetFileReader]: Pre-filtered decode enabled (1 live, 1 non-live)"
+        "[ParquetFileReader]: Pre-filtered decode enabled (1 live, 1 eager, 0 additional, 1 payload)"
         in capture
     )
 

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -1122,7 +1122,7 @@ def test_scan_parquet_prefilter_with_cast(
         capture = capfd.readouterr().err
 
     assert (
-        "[ParquetFileReader]: Pre-filtered decode enabled (1 live, 1 non-live)"
+        "[ParquetFileReader]: Pre-filtered decode enabled (1 live, 1 eager, 0 additional, 1 payload)"
         in capture
     )
     assert (

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -1891,6 +1891,29 @@ def test_general_prefiltering(df: pl.DataFrame) -> None:
     assert_frame_equal(result, df.filter(expr))
 
 
+def test_prefiltering_with_residual_predicate() -> None:
+    df = pl.DataFrame(
+        {
+            "integer": [0, 1, 2, 3, 4, 5],
+            "float": [0.5, 1.5, 2.5, 3.5, None, 5.5],
+            "value": list(range(6)),
+        }
+    )
+    predicate = (pl.col("integer") > 1) & (pl.col("float") < 5.0)
+    f = io.BytesIO()
+    df.write_parquet(f, row_group_size=3)
+
+    f.seek(0)
+    result = (
+        pl.scan_parquet(f, parallel="prefiltered")
+        .filter(predicate)
+        .select("value")
+        .collect(engine="streaming")
+    )
+
+    assert_frame_equal(result, df.filter(predicate).select("value"))
+
+
 @given(
     df=dataframes(
         min_size=0,


### PR DESCRIPTION
Previously, fields in the parquet reader were classified into two kinds:
fields that are live for predicate evaluation, and payload fields. Fields
in the predicate can, under some circumstances, be applied as filters
pre-decode. To prepare for two-stage decode, so that the existence of a
single field that cannot be applied early does not completely negate early
decode, further classify the predicate fields into "eager" and
"additional". The former are fields that can be applied pre-decode, the
latter are fields not in "eager" that appear in the "residual" part of the
predicate that must be applied later.

For supported types, and if a filter predicate is a complete conjunction of
terms, the parquet reader can apply filters to pre-decoded data. Currently,
this fast path is only applied if all terms in the filter can be applied
in this manner. If any one term does not fit the bill, we must instead
decode all "live" filter columns, compute the predicates to obtain a mask
that is then used for decode of payload columns.

This can lead to significant slowdowns in parquet read if some of the
filters could be evaluated via fast path but one is not (see #28402 for an
example).

To prepare to address this, refactor tracking of ColumnPredicates to
separate eager predicates from a "residual" predicate that cannot be
applied early. This lays the groundwork for more fine-grained
decisions for when we can apply eager predicates.


AI usage: codex-based spelunking of the reader guts and then I rewrote a bunch.