### PR TITLE
fix(python): Fix _in_notebook() reporting True with no active IPython shell

### DIFF
--- a/py-polars/src/polars/_utils/various.py
+++ b/py-polars/src/polars/_utils/various.py
@@ -223,15 +223,18 @@ def _in_notebook() -> bool:
     try:
         from IPython import get_ipython
 
-        if (
-            ipy := get_ipython()
-        ) is not None and "IPKernelApp" not in ipy.config:  # pragma: no cover
+        ipy = get_ipython()
+        if ipy is None:
+            # IPython is importable, but no shell/kernel is actually running
+            # (e.g. a plain script executed where IPython merely happens to
+            # be installed as a dependency of something else).
             return False
+        else:
+            return "IPKernelApp" in ipy.config  # pragma: no cover
     except ImportError:
         return False
     except AttributeError:
         return False
-    return True
 
 
 def _in_marimo_notebook() -> bool:

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import types
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING, Any
 from zoneinfo import ZoneInfo
@@ -25,6 +26,7 @@ from polars._utils.various import (
     parse_percentiles,
     parse_version,
 )
+from tests.unit.conftest import mock_module_import
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -197,6 +199,32 @@ def test_parse_version(v1: Any, v2: Any) -> None:
 def test_in_notebook() -> None:
     # private function, but easier to test this separately and mock it in the callers
     assert not _in_notebook()
+
+
+def _make_fake_ipython_module(ipython_shell: Any) -> types.ModuleType:
+    module = types.ModuleType("IPython")
+    module.get_ipython = lambda: ipython_shell  # type: ignore[attr-defined]
+    return module
+
+
+@pytest.mark.parametrize(
+    ("ipython_shell", "expected"),
+    [
+        # IPython is importable, but there is no active shell/kernel at all
+        # (e.g. a plain script where IPython merely happens to be installed
+        # as a dependency of something else) -> not a notebook.
+        (None, False),
+        # a plain IPython terminal shell (no Jupyter kernel) -> not a notebook.
+        (types.SimpleNamespace(config={}), False),
+        # an actual Jupyter kernel -> is a notebook.
+        (types.SimpleNamespace(config={"IPKernelApp": {}}), True),
+    ],
+)
+def test_in_notebook_with_ipython_shell(ipython_shell: Any, expected: bool) -> None:
+    with mock_module_import(
+        "IPython", _make_fake_ipython_module(ipython_shell), replace_if_exists=True
+    ):
+        assert _in_notebook() is expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #28501

## Root cause

`_in_notebook()` (`py-polars/src/polars/_utils/various.py`) had an inverted fallthrough:

```python
if (
    ipy := get_ipython()
) is not None and "IPKernelApp" not in ipy.config:  # pragma: no cover
    return False
return True
```

When `get_ipython()` returns `None` — IPython is importable, but there's no active shell/kernel at all (e.g. a plain script where IPython happens to be installed as a transitive dependency of something else) — the condition short-circuits `False` and falls through to the unconditional `return True`. So `_in_notebook()` incorrectly reports "in a notebook" any time IPython is merely on `sys.path`, not actually running inside one.

## Why this explains #28501

`DataFrame.show()` uses `_in_notebook()` to choose between `display_html(df)` (rich HTML) and `print(df)` (plain text, which honors `Config`). I verified `DataFrame._repr_html_()` produces byte-identical output regardless of `tbl_formatting`, `ascii_tables`, etc. — an HTML `<table>` has no concept of ASCII borders, so **every text-table-formatting kwarg to `show()` is silently a no-op whenever the (mis-detected) notebook branch is taken.** `limit` still works because it's applied to the data (`self.head(limit)`) before the branch is chosen — matching the reporter's exact "except for limit."

## Scope

This fixes the false-positive detection, which is unambiguously wrong on its own merits. It does **not** fully resolve the report if the user is genuinely inside a real Jupyter kernel — there, `_in_notebook()` will (correctly) still return `True`, and `show()`'s formatting kwargs will still be no-ops against `_repr_html_()`. Whether `show()` should ever prefer `display_html()` at all — given its whole purpose is applying these overrides — is a separate, more opinionated design question I'm leaving to maintainers rather than deciding unilaterally.

## Testing

Rust core is untouched (pure Python fix); verified by patching an installed wheel and running the real test suite against it in a local venv, then mirrored into this branch:

- Confirmed the false positive directly: `_in_notebook()` returns `True` in a plain script with IPython merely installed but no active shell.
- Added `test_in_notebook_with_ipython_shell`, parametrized over: no active shell (`None`), a plain IPython terminal (`config={}`), and a real Jupyter kernel (`config={"IPKernelApp": {}}`) — using the existing `mock_module_import` test helper.
- Verified this is a true regression guard: fails without the fix, passes with it.
- Full `tests/unit/utils/test_utils.py`: 198 passed, 0 regressions.
- `ruff check` / `ruff format --check`: clean (one unrelated pre-existing `RUF036` finding in the same file confirmed via `git stash` to predate this change).