### PR TITLE
fix: Avoid capturing config during import

### DIFF
--- a/crates/polars-config/src/lib.rs
+++ b/crates/polars-config/src/lib.rs
@@ -498,11 +498,7 @@ impl Config {
     }
 
     pub fn ooc_spill_dir(&self) -> std::path::PathBuf {
-        if let Ok(dir) = std::env::var("POLARS_OOC_SPILL_DIR") {
-            std::path::PathBuf::from(dir)
-        } else {
-            spill_path::default_ooc_spill_dir()
-        }
+        ooc_spill_dir()
     }
 
     #[inline(always)]
@@ -522,6 +518,14 @@ impl Config {
             DNS_LOG_THRESHOLD_DISABLED => None,
             ms => Some(Duration::from_millis(ms)),
         }
+    }
+}
+
+pub fn ooc_spill_dir() -> std::path::PathBuf {
+    if let Ok(dir) = std::env::var("POLARS_OOC_SPILL_DIR") {
+        std::path::PathBuf::from(dir)
+    } else {
+        spill_path::default_ooc_spill_dir()
     }
 }
 

--- a/crates/polars-config/src/lib.rs
+++ b/crates/polars-config/src/lib.rs
@@ -497,10 +497,6 @@ impl Config {
         self.ooc_log_metrics.load(Ordering::Relaxed)
     }
 
-    pub fn ooc_spill_dir(&self) -> std::path::PathBuf {
-        ooc_spill_dir()
-    }
-
     #[inline(always)]
     pub fn join_sample_limit(&self) -> u64 {
         self.join_sample_limit.load(Ordering::Relaxed)

--- a/crates/polars-ooc/src/spill_file.rs
+++ b/crates/polars-ooc/src/spill_file.rs
@@ -14,7 +14,7 @@ use crate::BYTES_SPILLED_TO_DISK;
 ///     spill-<ctx>-<uuid>.ipc   <- individual spill file (unique per spill)
 /// ```
 static SPILL_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
-    let spill_dir = polars_config::config().ooc_spill_dir();
+    let spill_dir = polars_config::ooc_spill_dir();
     let process_dir = spill_dir.join(std::process::id().to_string());
     create_dir_owner_only(&process_dir).unwrap_or_else(|e| {
         panic!("failed to create spill directory: {e} (path = {process_dir:?})")
@@ -121,7 +121,7 @@ enum CleanRequest {
 /// Each subdirectory is named by its owning PID. Skips our own PID and
 /// any directory whose PID is still alive.
 fn cleanup_stale_dirs() {
-    let spill_dir = polars_config::config().ooc_spill_dir();
+    let spill_dir = polars_config::ooc_spill_dir();
     let Ok(entries) = std::fs::read_dir(&spill_dir) else {
         return;
     };

--- a/py-polars/tests/unit/meta/test_polars_import.py
+++ b/py-polars/tests/unit/meta/test_polars_import.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import compileall
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -124,3 +125,46 @@ def test_unknown_extension_type_behavior_invalid_does_not_panic_27004() -> None:
     assert result.returncode == 0, result.stderr
     assert "POLARS_UNKNOWN_EXTENSION_TYPE_BEHAVIOR" in result.stderr
     assert "PanicException" not in result.stderr
+
+
+def test_import_does_not_capture_max_threads_28512(tmp_path: Path) -> None:
+    env = os.environ.copy()
+    env.pop("POLARS_MAX_THREADS", None)
+    default_threads = int(
+        subprocess.check_output(
+            [
+                sys.executable,
+                "-c",
+                "import polars as pl; print(pl.thread_pool_size())",
+            ],
+            env=env,
+            text=True,
+        )
+    )
+    configured_threads = 1 if default_threads != 1 else 2
+
+    dead_pid = subprocess.check_output(
+        [sys.executable, "-c", "import os; print(os.getpid())"],
+        text=True,
+    ).strip()
+    stale_spill_dir = tmp_path / dead_pid
+    stale_spill_dir.mkdir()
+
+    code = f"""
+import os
+import time
+from pathlib import Path
+
+import polars as pl
+
+stale_spill_dir = Path({str(stale_spill_dir)!r})
+deadline = time.monotonic() + 5
+while stale_spill_dir.exists() and time.monotonic() < deadline:
+    time.sleep(0.01)
+assert not stale_spill_dir.exists()
+
+os.environ["POLARS_MAX_THREADS"] = {str(configured_threads)!r}
+assert pl.thread_pool_size() == {configured_threads}
+"""
+    env["POLARS_OOC_SPILL_DIR"] = str(tmp_path)
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
Closes #28512

**Important!** The latest commit removes `Config::ooc_spill_dir`, which may be a breaking change for downstream consumers. Without last commit, this PR preserves that older API and should not introduce a consumer-facing breakage. See my comment below for details. I leave this decision to polars maintainers.