### PR TITLE
fix(rust): Move `split_to_morsels` to shared so `ipc` builds without `parquet`

### DIFF
--- a/crates/polars-stream/src/nodes/io_sources/ipc/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ipc/mod.rs
@@ -41,7 +41,7 @@ use crate::nodes::io_sources::multi_scan::reader_interface::output::FileReaderOu
 use crate::nodes::io_sources::multi_scan::reader_interface::{
     FileReader, FileReaderCallbacks, Projection, calc_row_position_after_slice,
 };
-use crate::nodes::io_sources::parquet::init::split_to_morsels;
+use crate::nodes::io_sources::shared::morsel_split::split_to_morsels;
 use crate::nodes::io_sources::shared::pipeline_budget::PipelineBudget;
 use crate::utils::tokio_handle_ext::AbortOnDropHandle;
 

--- a/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use arrow::datatypes::ArrowDataType;
 use polars_async::executor;
-use polars_core::frame::DataFrame;
 use polars_core::runtime::ASYNC;
 use polars_error::{PolarsResult, polars_ensure};
 use polars_io::prelude::_internal::PrefilterMaskSetting;
@@ -16,6 +15,7 @@ use crate::morsel::{Morsel, SourceToken, get_ideal_morsel_size};
 use crate::nodes::io_sources::multi_scan::reader_interface::output::FileReaderOutputSend;
 use crate::nodes::io_sources::parquet::projection::ArrowFieldProjection;
 use crate::nodes::io_sources::parquet::statistics::calculate_row_group_pred_pushdown_skip_mask;
+use crate::nodes::io_sources::shared::morsel_split::split_to_morsels;
 use crate::nodes::{MorselSeq, TaskPriority};
 use crate::utils::tokio_handle_ext::{self, AbortOnDropHandle};
 
@@ -405,31 +405,6 @@ fn filtered_range(exclude: &[usize], len: usize) -> impl Iterator<Item = usize> 
             false
         }
     })
-}
-
-pub(crate) fn split_to_morsels(
-    df: &DataFrame,
-    ideal_morsel_size: usize,
-    last_morsel: bool,
-    last_morsel_pipelines: usize,
-) -> impl Iterator<Item = DataFrame> + '_ {
-    let mut n_morsels = if df.height() > 3 * ideal_morsel_size / 2 {
-        // num_rows > (1.5 * ideal_morsel_size)
-        (df.height() / ideal_morsel_size).max(2)
-    } else {
-        1
-    };
-
-    if last_morsel {
-        n_morsels = n_morsels.max(last_morsel_pipelines);
-    }
-
-    let rows_per_morsel = df.height().div_ceil(n_morsels).max(1);
-
-    (0..i64::try_from(df.height()).unwrap())
-        .step_by(rows_per_morsel)
-        .map(move |offset| df.slice(offset, rows_per_morsel))
-        .filter(|df| df.height() > 0)
 }
 
 mod tests {

--- a/crates/polars-stream/src/nodes/io_sources/shared/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/shared/mod.rs
@@ -1,4 +1,6 @@
 #[cfg(any(feature = "csv", feature = "json", feature = "scan_lines"))]
 pub mod chunk_data_fetch;
 #[cfg(any(feature = "parquet", feature = "ipc"))]
+pub mod morsel_split;
+#[cfg(any(feature = "parquet", feature = "ipc"))]
 pub mod pipeline_budget;

--- a/crates/polars-stream/src/nodes/io_sources/shared/morsel_split.rs
+++ b/crates/polars-stream/src/nodes/io_sources/shared/morsel_split.rs
@@ -24,3 +24,50 @@ pub(crate) fn split_to_morsels(
         .map(move |offset| df.slice(offset, rows_per_morsel))
         .filter(|df| df.height() > 0)
 }
+
+#[cfg(test)]
+mod tests {
+    use polars_core::prelude::{Column, IntoColumn, UInt32Chunked};
+
+    use super::{DataFrame, split_to_morsels};
+
+    fn df_with_height(height: usize) -> DataFrame {
+        let values: Vec<u32> = (0..height as u32).collect();
+        let column: Column = UInt32Chunked::from_vec("a".into(), values).into_column();
+        unsafe { DataFrame::new_unchecked(height, vec![column]) }
+    }
+
+    fn heights(df: &DataFrame, ideal: usize, last: bool, pipelines: usize) -> Vec<usize> {
+        split_to_morsels(df, ideal, last, pipelines)
+            .map(|df| df.height())
+            .collect()
+    }
+
+    #[test]
+    fn stays_whole_below_the_split_threshold() {
+        // height <= 1.5 * ideal_morsel_size, so n_morsels is 1
+        let df = df_with_height(6);
+        assert_eq!(heights(&df, 4, false, 1), vec![6]);
+    }
+
+    #[test]
+    fn splits_above_the_threshold() {
+        let df = df_with_height(10);
+        let out = heights(&df, 4, false, 1);
+        assert_eq!(out.iter().sum::<usize>(), 10);
+        assert!(out.len() > 1);
+    }
+
+    #[test]
+    fn last_morsel_respects_pipeline_count() {
+        // A small frame is still spread across pipelines for the last morsel.
+        let df = df_with_height(6);
+        assert_eq!(heights(&df, 4, true, 3), vec![2, 2, 2]);
+    }
+
+    #[test]
+    fn empty_frame_yields_nothing() {
+        let df = df_with_height(0);
+        assert!(heights(&df, 4, false, 1).is_empty());
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sources/shared/morsel_split.rs
+++ b/crates/polars-stream/src/nodes/io_sources/shared/morsel_split.rs
@@ -1,0 +1,26 @@
+use polars_core::frame::DataFrame;
+
+pub(crate) fn split_to_morsels(
+    df: &DataFrame,
+    ideal_morsel_size: usize,
+    last_morsel: bool,
+    last_morsel_pipelines: usize,
+) -> impl Iterator<Item = DataFrame> + '_ {
+    let mut n_morsels = if df.height() > 3 * ideal_morsel_size / 2 {
+        // num_rows > (1.5 * ideal_morsel_size)
+        (df.height() / ideal_morsel_size).max(2)
+    } else {
+        1
+    };
+
+    if last_morsel {
+        n_morsels = n_morsels.max(last_morsel_pipelines);
+    }
+
+    let rows_per_morsel = df.height().div_ceil(n_morsels).max(1);
+
+    (0..i64::try_from(df.height()).unwrap())
+        .step_by(rows_per_morsel)
+        .map(move |offset| df.slice(offset, rows_per_morsel))
+        .filter(|df| df.height() > 0)
+}

--- a/crates/polars-stream/src/nodes/io_sources/shared/morsel_split.rs
+++ b/crates/polars-stream/src/nodes/io_sources/shared/morsel_split.rs
@@ -1,0 +1,73 @@
+use polars_core::frame::DataFrame;
+
+pub(crate) fn split_to_morsels(
+    df: &DataFrame,
+    ideal_morsel_size: usize,
+    last_morsel: bool,
+    last_morsel_pipelines: usize,
+) -> impl Iterator<Item = DataFrame> + '_ {
+    let mut n_morsels = if df.height() > 3 * ideal_morsel_size / 2 {
+        // num_rows > (1.5 * ideal_morsel_size)
+        (df.height() / ideal_morsel_size).max(2)
+    } else {
+        1
+    };
+
+    if last_morsel {
+        n_morsels = n_morsels.max(last_morsel_pipelines);
+    }
+
+    let rows_per_morsel = df.height().div_ceil(n_morsels).max(1);
+
+    (0..i64::try_from(df.height()).unwrap())
+        .step_by(rows_per_morsel)
+        .map(move |offset| df.slice(offset, rows_per_morsel))
+        .filter(|df| df.height() > 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use polars_core::prelude::{Column, IntoColumn, UInt32Chunked};
+
+    use super::{DataFrame, split_to_morsels};
+
+    fn df_with_height(height: usize) -> DataFrame {
+        let values: Vec<u32> = (0..height as u32).collect();
+        let column: Column = UInt32Chunked::from_vec("a".into(), values).into_column();
+        unsafe { DataFrame::new_unchecked(height, vec![column]) }
+    }
+
+    fn heights(df: &DataFrame, ideal: usize, last: bool, pipelines: usize) -> Vec<usize> {
+        split_to_morsels(df, ideal, last, pipelines)
+            .map(|df| df.height())
+            .collect()
+    }
+
+    #[test]
+    fn stays_whole_below_the_split_threshold() {
+        // height <= 1.5 * ideal_morsel_size, so n_morsels is 1
+        let df = df_with_height(6);
+        assert_eq!(heights(&df, 4, false, 1), vec![6]);
+    }
+
+    #[test]
+    fn splits_above_the_threshold() {
+        let df = df_with_height(10);
+        let out = heights(&df, 4, false, 1);
+        assert_eq!(out.iter().sum::<usize>(), 10);
+        assert!(out.len() > 1);
+    }
+
+    #[test]
+    fn last_morsel_respects_pipeline_count() {
+        // A small frame is still spread across pipelines for the last morsel.
+        let df = df_with_height(6);
+        assert_eq!(heights(&df, 4, true, 3), vec![2, 2, 2]);
+    }
+
+    #[test]
+    fn empty_frame_yields_nothing() {
+        let df = df_with_height(0);
+        assert!(heights(&df, 4, false, 1).is_empty());
+    }
+}


### PR DESCRIPTION
Closes #27898

## Problem

`polars-stream` fails to compile with the `ipc` feature when `parquet` is disabled:

```
error[E0433]: cannot find `parquet` in `io_sources`
  --> crates/polars-stream/src/nodes/io_sources/ipc/mod.rs:44:31
   |
44 | use crate::nodes::io_sources::parquet::init::split_to_morsels;
   |                               ^^^^^^^ could not find `parquet` in `io_sources`
```

`io_sources::parquet` is gated behind `#[cfg(feature = "parquet")]`, but the IPC source
imports `split_to_morsels` from it unconditionally.

## Change

`split_to_morsels` only takes a `DataFrame` and slices it - nothing about it is
parquet-specific, it just happened to live in `parquet/init.rs`. Moved it verbatim to a new
`shared::morsel_split` module, gated the same way as the neighbouring `shared::pipeline_budget`
(`#[cfg(any(feature = "parquet", feature = "ipc"))]`), and pointed both call sites at it.

The function body is unchanged, so this is a pure relocation.

## Verification

`cargo check -p polars-stream` across feature combinations:

| features | `cannot find `parquet`` before | after |
| --- | --- | --- |
| `ipc` (no parquet) | present | **gone** |
| `parquet` | - | clean, 0 errors |
| `ipc,parquet` | - | no parquet error |
| default | - | clean, 0 errors |

Compared against a stashed baseline on the same checkout: the `error[..]` count for
`--features ipc` goes from 9 to 8, and the one that disappears is exactly the
`cannot find `parquet`` import error. No new diagnostics are introduced.

Note that `--features ipc` still does not build to completion on `main` for an unrelated
reason - there is a pre-existing cluster of `categorical` errors in that configuration
(`unresolved import polars_core::series::arrow_export::categorical`, `no field
`categorical_converter` on ToArrowConverter`, and similar). I confirmed those are present on a
clean checkout without my change, so they are out of scope here; this PR removes the
parquet-gating error only.

`cargo fmt -p polars-stream -- --check` passes.