### PR TITLE
fix(rust): Fix `cov`/`corr` returning incorrect result for constant column

### DIFF
--- a/crates/polars-compute/src/moment.rs
+++ b/crates/polars-compute/src/moment.rs
@@ -143,8 +143,18 @@ impl CovState {
 
         let weight = x.len() as f64;
         let inv_weight = 1.0 / weight;
-        let mean_x = alg_sum_f64(x.iter().copied()) * inv_weight;
-        let mean_y = alg_sum_f64(y.iter().copied()) * inv_weight;
+
+        let mean_x = if x.iter().all(|&v| v == x[0]) {
+            x[0]
+        } else {
+            alg_sum_f64(x.iter().copied()) * inv_weight
+        };
+        let mean_y = if y.iter().all(|&v| v == y[0]) {
+            y[0]
+        } else {
+            alg_sum_f64(y.iter().copied()) * inv_weight
+        };
+
         Self {
             weight,
             mean_x,
@@ -212,8 +222,18 @@ impl PearsonState {
 
         let weight = x.len() as f64;
         let inv_weight = 1.0 / weight;
-        let mean_x = alg_sum_f64(x.iter().copied()) * inv_weight;
-        let mean_y = alg_sum_f64(y.iter().copied()) * inv_weight;
+
+        let mean_x = if x.iter().all(|&v| v == x[0]) {
+            x[0]
+        } else {
+            alg_sum_f64(x.iter().copied()) * inv_weight
+        };
+        let mean_y = if y.iter().all(|&v| v == y[0]) {
+            y[0]
+        } else {
+            alg_sum_f64(y.iter().copied()) * inv_weight
+        };
+
         let mut dp_xx = 0.0;
         let mut dp_xy = 0.0;
         let mut dp_yy = 0.0;
@@ -718,4 +738,48 @@ where
         });
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cov_constant_column_is_exact_zero() {
+        let b = [0.01, -0.02, 0.03, -0.01, 0.02];
+        for &c in &[0.01_f64, 0.3, 0.7, 0.25] {
+            let a = [c; 5];
+            let state = CovState::new(&a, &b);
+            assert_eq!(
+                state.finalize(0),
+                Some(0.0),
+                "cov should be exactly 0.0 when one column is constant (c = {c})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_cov_constant_column_across_chunks_is_exact_zero() {
+        let b: Vec<f64> = (0..300).map(|i| (i as f64 * 0.017) % 1.0 - 0.5).collect();
+        for &c in &[0.01_f64, 0.3, 0.7] {
+            let a = vec![c; 300];
+            let x = PrimitiveArray::<f64>::from_vec(a);
+            let y = PrimitiveArray::<f64>::from_vec(b.clone());
+            let state = cov(&x, &y);
+            assert_eq!(state.finalize(0), Some(0.0), "c = {c}, n = 300");
+        }
+    }
+
+    #[test]
+    fn test_pearson_corr_constant_column_is_nan() {
+        let b = [0.01, -0.02, 0.03, -0.01, 0.02];
+        for &c in &[0.01_f64, 0.3, 0.7, 0.25] {
+            let a = [c; 5];
+            let state = PearsonState::new(&a, &b);
+            assert!(
+                state.finalize().is_nan(),
+                "pearson_corr should be NaN when one column is constant (c = {c})"
+            );
+        }
+    }
 }


### PR DESCRIPTION
CovState::new and PearsonState::new computed the mean via a naive sequential fold (alg_sum_f64) followed by a multiply by 1/n. For non-dyadic constant values this doesn't round-trip exactly, so (x_i - mean_x) isn't exact zero for a constant column, leaving a tiny nonzero residue in cov instead of 0.0, and in corr causing division by a near-zero (rather than exactly-zero) denominator, producing a large finite value instead of the correctly-undefined NaN.

Fix: when a column is constant, set its mean directly to that value rather than deriving it via sum-then-divide, so the centered deviations are exact zeros.

Fixes pola-rs/polars#28516


<img width="1142" height="1051" alt="image" src="https://github.com/user-attachments/assets/0f494c1f-4379-4d2b-b747-fb44f0145090" />


AI Disclosure: 

1.) I used AI to help me trace how covariance and correlation was being computed within polars-compute/src/moment.rs.
2.) AI assisted with drafting the tests (test_cov_constant_column_is_exact_zero, test_cov_constant_column_across_chunks_is_exact_zero, and test_pearson_corr_constant_column_is_nan), and with drafting the initial fix to CovState::new/PearsonState::new.
3.) I reviewed any changed code. 
