### PR TITLE
depr: Deprecate casts from `Categorical` to integer dtypes

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/categorical.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical.rs
@@ -298,7 +298,14 @@ impl<T: PolarsCategoricalType> LogicalType for CategoricalChunked<T> {
 
             // LEGACY
             // TODO @ cat-rework: remove after exposing to/from physical functions.
-            dt if dt.is_integer() => self.phys.clone().cast_with_options(dtype, options),
+            dt if dt.is_integer() => {
+                polars_warn!(
+                    "casting from {:?} to {dtype:?} is deprecated.\n\
+                    Instead of `.cast({dtype:?})`, use `.cat.physical()`.",
+                    self.dtype
+                );
+                self.phys.clone().cast_with_options(dtype, options)
+            },
 
             _ => polars_bail!(ComputeError: "cannot cast categorical types to {dtype:?}"),
         }

--- a/crates/polars-core/src/chunked_array/logical/categorical.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical.rs
@@ -300,6 +300,7 @@ impl<T: PolarsCategoricalType> LogicalType for CategoricalChunked<T> {
             // TODO @ cat-rework: remove after exposing to/from physical functions.
             dt if dt.is_integer() => {
                 polars_warn!(
+                    Deprecation,
                     "casting from {:?} to {dtype:?} is deprecated.\n\
                     Instead of `.cast({dtype:?})`, use `.cat.physical()`.",
                     self.dtype

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -1102,3 +1102,21 @@ def test_cast_int_to_categorical_deprecated(dtype: PolarsDataType) -> None:
 
     expected = pl.Series("a", ["cat2", "cat0", "cat1"], dtype=dtype)
     assert_series_equal(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pl.Categorical(pl.Categories.random(physical=pl.UInt32)),
+        pl.Enum(["cat0", "cat1", "cat2"]),
+    ],
+)
+def test_cast_categorical_to_int_deprecated(dtype: PolarsDataType) -> None:
+    _dummy = pl.Series("a", ["cat0", "cat1", "cat2"], dtype=dtype)
+
+    msg = rf"casting from {re.escape(str(dtype.base_type()))}\(\S+\) to UInt32 is deprecated."
+    with pytest.deprecated_call(match=msg):
+        actual = pl.Series("a", ["cat2", "cat0", "cat1"], dtype=dtype).cast(pl.UInt32)
+
+    expected = pl.Series("a", [2, 0, 1], dtype=pl.UInt32)
+    assert_series_equal(actual, expected)


### PR DESCRIPTION
Related issue: https://github.com/pola-rs/polars/issues/24122

:robot: No AI was used for this PR
