### PR TITLE
fix(python): Honor `strict` in row-oriented DataFrame construction

### DIFF
--- a/crates/polars-core/src/frame/row/av_buffer.rs
+++ b/crates/polars-core/src/frame/row/av_buffer.rs
@@ -12,6 +12,18 @@ use super::*;
 use crate::chunked_array::builder::NullChunkedBuilder;
 #[cfg(feature = "dtype-struct")]
 use crate::prelude::any_value::arr_to_any_value;
+#[cfg(feature = "dtype-date")]
+use crate::series::any_value::av_to_date_strict;
+#[cfg(feature = "dtype-datetime")]
+use crate::series::any_value::av_to_datetime_strict;
+#[cfg(feature = "dtype-duration")]
+use crate::series::any_value::av_to_duration_strict;
+#[cfg(feature = "dtype-time")]
+use crate::series::any_value::av_to_time_strict;
+use crate::series::any_value::{
+    av_to_bool_strict, av_to_f32_strict, av_to_f64_strict, av_to_integer_strict, av_to_str_strict,
+    invalid_value_error,
+};
 
 #[derive(Clone)]
 pub enum AnyValueBuffer<'a> {
@@ -163,6 +175,52 @@ impl<'a> AnyValueBuffer<'a> {
                 it might also be that a value overflows the data-type's capacity", val, val.dtype()
             )
         })
+    }
+
+    /// Add a value to the buffer, rejecting values that do not match the buffer's dtype.
+    ///
+    /// The accepted conversions are defined by the per-value `av_to_*_strict` helpers
+    /// shared with `Series::from_any_values_and_dtype`, so that both construction
+    /// paths have identical strict semantics.
+    #[inline]
+    pub(crate) fn add_strict(&mut self, value: &AnyValue<'a>) -> PolarsResult<()> {
+        use AnyValueBuffer::*;
+        match self {
+            Boolean(builder) => builder.append_option(av_to_bool_strict(value)?),
+            #[cfg(feature = "dtype-i8")]
+            Int8(builder) => builder.append_option(av_to_integer_strict::<Int8Type>(value)?),
+            #[cfg(feature = "dtype-i16")]
+            Int16(builder) => builder.append_option(av_to_integer_strict::<Int16Type>(value)?),
+            Int32(builder) => builder.append_option(av_to_integer_strict::<Int32Type>(value)?),
+            Int64(builder) => builder.append_option(av_to_integer_strict::<Int64Type>(value)?),
+            #[cfg(feature = "dtype-u8")]
+            UInt8(builder) => builder.append_option(av_to_integer_strict::<UInt8Type>(value)?),
+            #[cfg(feature = "dtype-u16")]
+            UInt16(builder) => builder.append_option(av_to_integer_strict::<UInt16Type>(value)?),
+            UInt32(builder) => builder.append_option(av_to_integer_strict::<UInt32Type>(value)?),
+            UInt64(builder) => builder.append_option(av_to_integer_strict::<UInt64Type>(value)?),
+            #[cfg(feature = "dtype-date")]
+            Date(builder) => builder.append_option(av_to_date_strict(value)?),
+            #[cfg(feature = "dtype-datetime")]
+            Datetime(builder, time_unit, time_zone) => builder.append_option(
+                av_to_datetime_strict(value, *time_unit, time_zone.as_ref())?,
+            ),
+            #[cfg(feature = "dtype-duration")]
+            Duration(builder, time_unit) => {
+                builder.append_option(av_to_duration_strict(value, *time_unit)?)
+            },
+            #[cfg(feature = "dtype-time")]
+            Time(builder) => builder.append_option(av_to_time_strict(value)?),
+            Float32(builder) => builder.append_option(av_to_f32_strict(value)?),
+            Float64(builder) => builder.append_option(av_to_f64_strict(value)?),
+            String(builder) => builder.append_option(av_to_str_strict(value)?),
+            Null(builder) => match value {
+                AnyValue::Null => builder.append_null(),
+                value => return Err(invalid_value_error(&DataType::Null, value)),
+            },
+            All(_, values) => values.push(value.clone().into_static()),
+        }
+        Ok(())
     }
 
     pub fn reset(&mut self, capacity: usize, strict: bool) -> PolarsResult<Series> {

--- a/crates/polars-core/src/frame/row/dataframe.rs
+++ b/crates/polars-core/src/frame/row/dataframe.rs
@@ -249,6 +249,13 @@ mod tests {
             ),
             (DataType::Null, AnyValue::Null, AnyValue::Int64(1)),
         ];
+        #[cfg(feature = "dtype-f16")]
+        {
+            use polars_utils::float16::pf16;
+            let f16 = AnyValue::Float16(pf16::from(1.0f32));
+            cases.push((DataType::Float32, f16.clone(), AnyValue::Int64(1)));
+            cases.push((DataType::Float64, f16, AnyValue::Int64(1)));
+        }
         #[cfg(feature = "dtype-date")]
         cases.push((
             DataType::Date,

--- a/crates/polars-core/src/frame/row/dataframe.rs
+++ b/crates/polars-core/src/frame/row/dataframe.rs
@@ -43,32 +43,11 @@ impl DataFrame {
         Self::from_rows_iter_and_schema(rows.iter(), schema)
     }
 
-    /// Create a new [`DataFrame`] from rows, respecting the `strict` parameter
-    /// when constructing fallback data types.
-    pub fn from_rows_and_schema_strict(
-        rows: &[Row],
-        schema: &Schema,
-        strict: bool,
-    ) -> PolarsResult<Self> {
-        Self::from_rows_iter_and_schema_impl(rows.iter(), schema, strict)
-    }
-
     /// Create a new [`DataFrame`] from an iterator over rows.
     ///
     /// This should only be used when you have row wise data, as this is a lot slower
     /// than creating the [`Series`] in a columnar fashion.
-    pub fn from_rows_iter_and_schema<'a, I>(rows: I, schema: &Schema) -> PolarsResult<Self>
-    where
-        I: Iterator<Item = &'a Row<'a>>,
-    {
-        Self::from_rows_iter_and_schema_impl(rows, schema, false)
-    }
-
-    fn from_rows_iter_and_schema_impl<'a, I>(
-        mut rows: I,
-        schema: &Schema,
-        strict: bool,
-    ) -> PolarsResult<Self>
+    pub fn from_rows_iter_and_schema<'a, I>(mut rows: I, schema: &Schema) -> PolarsResult<Self>
     where
         I: Iterator<Item = &'a Row<'a>>,
     {
@@ -100,17 +79,8 @@ impl DataFrame {
         let v = buffers
             .into_iter()
             .zip(schema.iter_names())
-            .map(|(mut b, name)| {
-                let mut c = b
-                    .reset(0, strict)
-                    .map_err(|err| {
-                        if strict {
-                            polars_err!(SchemaMismatch: "{err}")
-                        } else {
-                            err
-                        }
-                    })?
-                    .into_column();
+            .map(|(b, name)| {
+                let mut c = b.into_series()?.into_column();
                 // if the schema adds a column not in the rows, we
                 // fill it with nulls
                 if c.is_empty() {

--- a/crates/polars-core/src/frame/row/dataframe.rs
+++ b/crates/polars-core/src/frame/row/dataframe.rs
@@ -43,11 +43,32 @@ impl DataFrame {
         Self::from_rows_iter_and_schema(rows.iter(), schema)
     }
 
+    /// Create a new [`DataFrame`] from rows, respecting the `strict` parameter
+    /// when constructing fallback data types.
+    pub fn from_rows_and_schema_strict(
+        rows: &[Row],
+        schema: &Schema,
+        strict: bool,
+    ) -> PolarsResult<Self> {
+        Self::from_rows_iter_and_schema_impl(rows.iter(), schema, strict)
+    }
+
     /// Create a new [`DataFrame`] from an iterator over rows.
     ///
     /// This should only be used when you have row wise data, as this is a lot slower
     /// than creating the [`Series`] in a columnar fashion.
-    pub fn from_rows_iter_and_schema<'a, I>(mut rows: I, schema: &Schema) -> PolarsResult<Self>
+    pub fn from_rows_iter_and_schema<'a, I>(rows: I, schema: &Schema) -> PolarsResult<Self>
+    where
+        I: Iterator<Item = &'a Row<'a>>,
+    {
+        Self::from_rows_iter_and_schema_impl(rows, schema, false)
+    }
+
+    fn from_rows_iter_and_schema_impl<'a, I>(
+        mut rows: I,
+        schema: &Schema,
+        strict: bool,
+    ) -> PolarsResult<Self>
     where
         I: Iterator<Item = &'a Row<'a>>,
     {
@@ -79,8 +100,17 @@ impl DataFrame {
         let v = buffers
             .into_iter()
             .zip(schema.iter_names())
-            .map(|(b, name)| {
-                let mut c = b.into_series()?.into_column();
+            .map(|(mut b, name)| {
+                let mut c = b
+                    .reset(0, strict)
+                    .map_err(|err| {
+                        if strict {
+                            polars_err!(SchemaMismatch: "{err}")
+                        } else {
+                            err
+                        }
+                    })?
+                    .into_column();
                 // if the schema adds a column not in the rows, we
                 // fill it with nulls
                 if c.is_empty() {

--- a/crates/polars-core/src/frame/row/dataframe.rs
+++ b/crates/polars-core/src/frame/row/dataframe.rs
@@ -43,11 +43,50 @@ impl DataFrame {
         Self::from_rows_iter_and_schema(rows.iter(), schema)
     }
 
+    /// Create a new [`DataFrame`] from rows, rejecting values that do not match the schema.
+    ///
+    /// A value is accepted exactly when strict [`Series::from_any_values_and_dtype`]
+    /// accepts it for the column's dtype. If `strict_columns` is given, only the
+    /// columns where it is true are validated; values in the remaining columns are
+    /// coerced as in [`DataFrame::from_rows_and_schema`].
+    ///
+    /// This should only be used when you have row wise data, as this is a lot slower
+    /// than creating the [`Series`] in a columnar fashion.
+    pub fn from_rows_and_schema_strict(
+        rows: &[Row],
+        schema: &Schema,
+        strict_columns: Option<&[bool]>,
+    ) -> PolarsResult<Self> {
+        if let Some(strict_columns) = strict_columns {
+            polars_ensure!(
+                strict_columns.len() == schema.len(),
+                ShapeMismatch:
+                "length of `strict_columns` ({}) does not match the schema width ({})",
+                strict_columns.len(),
+                schema.len(),
+            );
+        }
+        Self::from_rows_iter_and_schema_impl::<_, true>(rows.iter(), schema, strict_columns)
+    }
+
     /// Create a new [`DataFrame`] from an iterator over rows.
     ///
     /// This should only be used when you have row wise data, as this is a lot slower
     /// than creating the [`Series`] in a columnar fashion.
-    pub fn from_rows_iter_and_schema<'a, I>(mut rows: I, schema: &Schema) -> PolarsResult<Self>
+    pub fn from_rows_iter_and_schema<'a, I>(rows: I, schema: &Schema) -> PolarsResult<Self>
+    where
+        I: Iterator<Item = &'a Row<'a>>,
+    {
+        Self::from_rows_iter_and_schema_impl::<_, false>(rows, schema, None)
+    }
+
+    // `STRICT` is a const generic so that the all-lenient instantiation folds the
+    // per-column flags away; a runtime flag measures ~3-4% slower in that hot loop.
+    fn from_rows_iter_and_schema_impl<'a, I, const STRICT: bool>(
+        mut rows: I,
+        schema: &Schema,
+        strict_columns: Option<&[bool]>,
+    ) -> PolarsResult<Self>
     where
         I: Iterator<Item = &'a Row<'a>>,
     {
@@ -61,17 +100,23 @@ impl DataFrame {
 
         let mut buffers: Vec<_> = schema
             .iter_values()
-            .map(|dtype| {
+            .enumerate()
+            .map(|(i, dtype)| {
                 let buf: AnyValueBuffer = (dtype, capacity).into();
-                buf
+                let strict = STRICT && strict_columns.is_none_or(|cols| cols[i]);
+                (buf, strict)
             })
             .collect();
 
         let mut expected_len = 0;
         rows.try_for_each::<_, PolarsResult<()>>(|row| {
             expected_len += 1;
-            for (value, buf) in row.0.iter().zip(&mut buffers) {
-                buf.add_fallible(value)?
+            for (value, (buf, strict)) in row.0.iter().zip(&mut buffers) {
+                if *strict {
+                    buf.add_strict(value)?
+                } else {
+                    buf.add_fallible(value)?
+                }
             }
             Ok(())
         })?;
@@ -79,8 +124,8 @@ impl DataFrame {
         let v = buffers
             .into_iter()
             .zip(schema.iter_names())
-            .map(|(b, name)| {
-                let mut c = b.into_series()?.into_column();
+            .map(|((mut b, strict), name)| {
+                let mut c = b.reset(0, strict)?.into_column();
                 // if the schema adds a column not in the rows, we
                 // fill it with nulls
                 if c.is_empty() {
@@ -149,5 +194,117 @@ impl DataFrame {
             !has_nulls, ComputeError: "unable to infer row types because of null values"
         );
         Self::from_rows_and_schema(rows, &schema)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_strict(dtype: DataType, values: Vec<AnyValue<'static>>) -> PolarsResult<DataFrame> {
+        let rows = values
+            .into_iter()
+            .map(|value| Row(vec![value]))
+            .collect::<Vec<_>>();
+        let schema = Schema::from_iter([Field::new("a".into(), dtype)]);
+        DataFrame::from_rows_and_schema_strict(&rows, &schema, None)
+    }
+
+    #[test]
+    fn test_add_strict_per_buffer_arm() {
+        // One matching and one mismatching value per buffer arm; the value-level
+        // semantics themselves are shared with `Series::from_any_values_and_dtype`
+        // and tested through the Python API.
+        #[allow(unused_mut)]
+        let mut cases: Vec<(DataType, AnyValue, AnyValue)> = vec![
+            (
+                DataType::Boolean,
+                AnyValue::Boolean(true),
+                AnyValue::Int64(1),
+            ),
+            (DataType::Int32, AnyValue::Int64(1), AnyValue::Float64(1.0)),
+            // integers are range-checked: a value outside the target width errors
+            (
+                DataType::Int32,
+                AnyValue::Int64(i32::MAX as i64),
+                AnyValue::Int64(i32::MAX as i64 + 1),
+            ),
+            (DataType::Int64, AnyValue::UInt64(1), AnyValue::Float64(1.0)),
+            (DataType::UInt32, AnyValue::Int64(1), AnyValue::Int64(-1)),
+            (DataType::UInt64, AnyValue::Int64(1), AnyValue::Int64(-1)),
+            (
+                DataType::Float32,
+                AnyValue::Float32(1.0),
+                AnyValue::Float64(1.0),
+            ),
+            (
+                DataType::Float64,
+                AnyValue::Float32(1.0),
+                AnyValue::Int64(1),
+            ),
+            (
+                DataType::String,
+                AnyValue::StringOwned("a".into()),
+                AnyValue::BinaryOwned(b"a".to_vec()),
+            ),
+            (DataType::Null, AnyValue::Null, AnyValue::Int64(1)),
+        ];
+        #[cfg(feature = "dtype-date")]
+        cases.push((
+            DataType::Date,
+            AnyValue::Date(19000),
+            AnyValue::Int32(19000),
+        ));
+        #[cfg(feature = "dtype-time")]
+        cases.push((
+            DataType::Time,
+            AnyValue::Time(1_000),
+            AnyValue::Int64(1_000),
+        ));
+        #[cfg(feature = "dtype-datetime")]
+        cases.push((
+            DataType::Datetime(TimeUnit::Microseconds, None),
+            AnyValue::Datetime(1_000, TimeUnit::Microseconds, None),
+            // a mismatched time unit is not rescaled under strict construction
+            AnyValue::Datetime(1_000, TimeUnit::Nanoseconds, None),
+        ));
+        #[cfg(feature = "dtype-duration")]
+        cases.push((
+            DataType::Duration(TimeUnit::Milliseconds),
+            AnyValue::Duration(1_000, TimeUnit::Milliseconds),
+            AnyValue::Duration(1_000, TimeUnit::Microseconds),
+        ));
+
+        for (dtype, valid, invalid) in cases {
+            assert!(
+                build_strict(dtype.clone(), vec![valid, AnyValue::Null]).is_ok(),
+                "valid value rejected for {dtype:?}"
+            );
+            assert!(
+                build_strict(dtype.clone(), vec![invalid]).is_err(),
+                "invalid value accepted for {dtype:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_strict_row_per_column_strictness() {
+        let schema = Schema::from_iter([
+            Field::new("a".into(), DataType::Float64),
+            Field::new("b".into(), DataType::Float64),
+        ]);
+        let rows = vec![Row(vec![AnyValue::Int64(1), AnyValue::Int64(1)])];
+
+        // Int64 into a strict Float64 column errors, a lenient column coerces.
+        assert!(DataFrame::from_rows_and_schema_strict(&rows, &schema, None).is_err());
+        let df =
+            DataFrame::from_rows_and_schema_strict(&rows, &schema, Some(&[false, false])).unwrap();
+        assert_eq!(df.column("a").unwrap().dtype(), &DataType::Float64);
+        assert!(
+            DataFrame::from_rows_and_schema_strict(&rows, &schema, Some(&[false, true])).is_err()
+        );
+
+        // The mask length must match the schema width.
+        assert!(DataFrame::from_rows_and_schema_strict(&rows, &schema, Some(&[false])).is_err());
     }
 }

--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -187,6 +187,121 @@ fn any_values_to_primitive_nonstrict<T: PolarsNumericType>(values: &[AnyValue]) 
         .collect_trusted()
 }
 
+/// Convert a single [`AnyValue`] to the physical value of the target dtype,
+/// rejecting values of any other type. `Ok(None)` represents a null value.
+///
+/// These per-value conversions define the strict semantics shared by the
+/// columnar constructors below and the row-wise `AnyValueBuffer::add_strict`.
+// `inline(always)` on this helper group measures 3-7% faster than `inline`
+// in the row construction hot loop.
+#[inline(always)]
+pub(crate) fn av_to_integer_strict<T: PolarsIntegerType>(
+    av: &AnyValue,
+) -> PolarsResult<Option<T::Native>> {
+    match av {
+        AnyValue::Null => Ok(None),
+        av if av.is_integer() => {
+            let val = av
+                .extract::<T::Native>()
+                .ok_or_else(|| invalid_value_error(&T::get_static_dtype(), av))?;
+            Ok(Some(val))
+        },
+        av => Err(invalid_value_error(&T::get_static_dtype(), av)),
+    }
+}
+
+#[inline(always)]
+pub(crate) fn av_to_f32_strict(av: &AnyValue) -> PolarsResult<Option<f32>> {
+    match av {
+        AnyValue::Float32(v) => Ok(Some(*v)),
+        AnyValue::Float16(v) => Ok(Some(v.as_())),
+        AnyValue::Null => Ok(None),
+        av => Err(invalid_value_error(&DataType::Float32, av)),
+    }
+}
+
+#[inline(always)]
+pub(crate) fn av_to_f64_strict(av: &AnyValue) -> PolarsResult<Option<f64>> {
+    match av {
+        AnyValue::Float64(v) => Ok(Some(*v)),
+        AnyValue::Float32(v) => Ok(Some(*v as f64)),
+        AnyValue::Float16(v) => Ok(Some(v.as_())),
+        AnyValue::Null => Ok(None),
+        av => Err(invalid_value_error(&DataType::Float64, av)),
+    }
+}
+
+#[inline(always)]
+pub(crate) fn av_to_bool_strict(av: &AnyValue) -> PolarsResult<Option<bool>> {
+    match av {
+        AnyValue::Boolean(b) => Ok(Some(*b)),
+        AnyValue::Null => Ok(None),
+        av => Err(invalid_value_error(&DataType::Boolean, av)),
+    }
+}
+
+#[inline(always)]
+pub(crate) fn av_to_str_strict<'a>(av: &'a AnyValue<'_>) -> PolarsResult<Option<&'a str>> {
+    match av {
+        AnyValue::String(s) => Ok(Some(s)),
+        AnyValue::StringOwned(s) => Ok(Some(s.as_str())),
+        AnyValue::Null => Ok(None),
+        av => Err(invalid_value_error(&DataType::String, av)),
+    }
+}
+
+#[cfg(feature = "dtype-date")]
+#[inline(always)]
+pub(crate) fn av_to_date_strict(av: &AnyValue) -> PolarsResult<Option<i32>> {
+    match av {
+        AnyValue::Date(v) => Ok(Some(*v)),
+        AnyValue::Null => Ok(None),
+        av => Err(invalid_value_error(&DataType::Date, av)),
+    }
+}
+
+#[cfg(feature = "dtype-time")]
+#[inline(always)]
+pub(crate) fn av_to_time_strict(av: &AnyValue) -> PolarsResult<Option<i64>> {
+    match av {
+        AnyValue::Time(v) => Ok(Some(*v)),
+        AnyValue::Null => Ok(None),
+        av => Err(invalid_value_error(&DataType::Time, av)),
+    }
+}
+
+#[cfg(feature = "dtype-datetime")]
+#[inline(always)]
+pub(crate) fn av_to_datetime_strict(
+    av: &AnyValue,
+    time_unit: TimeUnit,
+    time_zone: Option<&TimeZone>,
+) -> PolarsResult<Option<i64>> {
+    match av {
+        AnyValue::Null => Ok(None),
+        AnyValue::Datetime(v, tu, _) | AnyValue::DatetimeOwned(v, tu, _) if *tu == time_unit => {
+            Ok(Some(*v))
+        },
+        av => Err(invalid_value_error(
+            &DataType::Datetime(time_unit, time_zone.cloned()),
+            av,
+        )),
+    }
+}
+
+#[cfg(feature = "dtype-duration")]
+#[inline(always)]
+pub(crate) fn av_to_duration_strict(
+    av: &AnyValue,
+    time_unit: TimeUnit,
+) -> PolarsResult<Option<i64>> {
+    match av {
+        AnyValue::Null => Ok(None),
+        AnyValue::Duration(v, tu) if *tu == time_unit => Ok(Some(*v)),
+        av => Err(invalid_value_error(&DataType::Duration(time_unit), av)),
+    }
+}
+
 fn any_values_to_integer<T: PolarsIntegerType>(
     values: &[AnyValue],
     strict: bool,
@@ -196,17 +311,9 @@ fn any_values_to_integer<T: PolarsIntegerType>(
     ) -> PolarsResult<ChunkedArray<T>> {
         let mut builder = PrimitiveChunkedBuilder::<T>::new(PlSmallStr::EMPTY, values.len());
         for av in values {
-            match &av {
-                av if av.is_integer() => {
-                    let opt_val = av.extract::<T::Native>();
-                    let val = match opt_val {
-                        Some(v) => v,
-                        None => return Err(invalid_value_error(&T::get_static_dtype(), av)),
-                    };
-                    builder.append_value(val)
-                },
-                AnyValue::Null => builder.append_null(),
-                av => return Err(invalid_value_error(&T::get_static_dtype(), av)),
+            match av_to_integer_strict::<T>(av)? {
+                Some(v) => builder.append_value(v),
+                None => builder.append_null(),
             }
         }
         Ok(builder.finish())
@@ -245,11 +352,9 @@ fn any_values_to_f32(values: &[AnyValue], strict: bool) -> PolarsResult<Float32C
         let mut builder =
             PrimitiveChunkedBuilder::<Float32Type>::new(PlSmallStr::EMPTY, values.len());
         for av in values {
-            match av {
-                AnyValue::Float32(i) => builder.append_value(*i),
-                AnyValue::Float16(i) => builder.append_value(i.as_()),
-                AnyValue::Null => builder.append_null(),
-                av => return Err(invalid_value_error(&DataType::Float32, av)),
+            match av_to_f32_strict(av)? {
+                Some(v) => builder.append_value(v),
+                None => builder.append_null(),
             }
         }
         Ok(builder.finish())
@@ -265,12 +370,9 @@ fn any_values_to_f64(values: &[AnyValue], strict: bool) -> PolarsResult<Float64C
         let mut builder =
             PrimitiveChunkedBuilder::<Float64Type>::new(PlSmallStr::EMPTY, values.len());
         for av in values {
-            match av {
-                AnyValue::Float64(i) => builder.append_value(*i),
-                AnyValue::Float32(i) => builder.append_value(*i as f64),
-                AnyValue::Float16(i) => builder.append_value(i.as_()),
-                AnyValue::Null => builder.append_null(),
-                av => return Err(invalid_value_error(&DataType::Float64, av)),
+            match av_to_f64_strict(av)? {
+                Some(v) => builder.append_value(v),
+                None => builder.append_null(),
             }
         }
         Ok(builder.finish())
@@ -285,17 +387,19 @@ fn any_values_to_f64(values: &[AnyValue], strict: bool) -> PolarsResult<Float64C
 fn any_values_to_bool(values: &[AnyValue], strict: bool) -> PolarsResult<BooleanChunked> {
     let mut builder = BooleanChunkedBuilder::new(PlSmallStr::EMPTY, values.len());
     for av in values {
+        if strict {
+            match av_to_bool_strict(av)? {
+                Some(b) => builder.append_value(b),
+                None => builder.append_null(),
+            }
+            continue;
+        }
         match av {
             AnyValue::Boolean(b) => builder.append_value(*b),
             AnyValue::Null => builder.append_null(),
-            av => {
-                if strict {
-                    return Err(invalid_value_error(&DataType::Boolean, av));
-                }
-                match av.cast(&DataType::Boolean) {
-                    AnyValue::Boolean(b) => builder.append_value(b),
-                    _ => builder.append_null(),
-                }
+            av => match av.cast(&DataType::Boolean) {
+                AnyValue::Boolean(b) => builder.append_value(b),
+                _ => builder.append_null(),
             },
         }
     }
@@ -306,11 +410,9 @@ fn any_values_to_string(values: &[AnyValue], strict: bool) -> PolarsResult<Strin
     fn any_values_to_string_strict(values: &[AnyValue]) -> PolarsResult<StringChunked> {
         let mut builder = StringChunkedBuilder::new(PlSmallStr::EMPTY, values.len());
         for av in values {
-            match av {
-                AnyValue::String(s) => builder.append_value(s),
-                AnyValue::StringOwned(s) => builder.append_value(s),
-                AnyValue::Null => builder.append_null(),
-                av => return Err(invalid_value_error(&DataType::String, av)),
+            match av_to_str_strict(av)? {
+                Some(s) => builder.append_value(s),
+                None => builder.append_null(),
             }
         }
         Ok(builder.finish())
@@ -476,17 +578,19 @@ fn any_values_to_binary_offset(
 fn any_values_to_date(values: &[AnyValue], strict: bool) -> PolarsResult<DateChunked> {
     let mut builder = PrimitiveChunkedBuilder::<Int32Type>::new(PlSmallStr::EMPTY, values.len());
     for av in values {
+        if strict {
+            match av_to_date_strict(av)? {
+                Some(i) => builder.append_value(i),
+                None => builder.append_null(),
+            }
+            continue;
+        }
         match av {
             AnyValue::Date(i) => builder.append_value(*i),
             AnyValue::Null => builder.append_null(),
-            av => {
-                if strict {
-                    return Err(invalid_value_error(&DataType::Date, av));
-                }
-                match av.cast(&DataType::Date) {
-                    AnyValue::Date(i) => builder.append_value(i),
-                    _ => builder.append_null(),
-                }
+            av => match av.cast(&DataType::Date) {
+                AnyValue::Date(i) => builder.append_value(i),
+                _ => builder.append_null(),
             },
         }
     }
@@ -497,17 +601,19 @@ fn any_values_to_date(values: &[AnyValue], strict: bool) -> PolarsResult<DateChu
 fn any_values_to_time(values: &[AnyValue], strict: bool) -> PolarsResult<TimeChunked> {
     let mut builder = PrimitiveChunkedBuilder::<Int64Type>::new(PlSmallStr::EMPTY, values.len());
     for av in values {
+        if strict {
+            match av_to_time_strict(av)? {
+                Some(i) => builder.append_value(i),
+                None => builder.append_null(),
+            }
+            continue;
+        }
         match av {
             AnyValue::Time(i) => builder.append_value(*i),
             AnyValue::Null => builder.append_null(),
-            av => {
-                if strict {
-                    return Err(invalid_value_error(&DataType::Time, av));
-                }
-                match av.cast(&DataType::Time) {
-                    AnyValue::Time(i) => builder.append_value(i),
-                    _ => builder.append_null(),
-                }
+            av => match av.cast(&DataType::Time) {
+                AnyValue::Time(i) => builder.append_value(i),
+                _ => builder.append_null(),
             },
         }
     }
@@ -524,19 +630,21 @@ fn any_values_to_datetime(
     let mut builder = PrimitiveChunkedBuilder::<Int64Type>::new(PlSmallStr::EMPTY, values.len());
     let target_dtype = DataType::Datetime(time_unit, time_zone.clone());
     for av in values {
+        if strict {
+            match av_to_datetime_strict(av, time_unit, time_zone.as_ref())? {
+                Some(i) => builder.append_value(i),
+                None => builder.append_null(),
+            }
+            continue;
+        }
         match av {
             AnyValue::Datetime(i, tu, _) if *tu == time_unit => builder.append_value(*i),
             AnyValue::DatetimeOwned(i, tu, _) if *tu == time_unit => builder.append_value(*i),
             AnyValue::Null => builder.append_null(),
-            av => {
-                if strict {
-                    return Err(invalid_value_error(&target_dtype, av));
-                }
-                match av.cast(&target_dtype) {
-                    AnyValue::Datetime(i, _, _) => builder.append_value(i),
-                    AnyValue::DatetimeOwned(i, _, _) => builder.append_value(i),
-                    _ => builder.append_null(),
-                }
+            av => match av.cast(&target_dtype) {
+                AnyValue::Datetime(i, _, _) => builder.append_value(i),
+                AnyValue::DatetimeOwned(i, _, _) => builder.append_value(i),
+                _ => builder.append_null(),
             },
         }
     }
@@ -552,17 +660,19 @@ fn any_values_to_duration(
     let mut builder = PrimitiveChunkedBuilder::<Int64Type>::new(PlSmallStr::EMPTY, values.len());
     let target_dtype = DataType::Duration(time_unit);
     for av in values {
+        if strict {
+            match av_to_duration_strict(av, time_unit)? {
+                Some(i) => builder.append_value(i),
+                None => builder.append_null(),
+            }
+            continue;
+        }
         match av {
             AnyValue::Duration(i, tu) if *tu == time_unit => builder.append_value(*i),
             AnyValue::Null => builder.append_null(),
-            av => {
-                if strict {
-                    return Err(invalid_value_error(&target_dtype, av));
-                }
-                match av.cast(&target_dtype) {
-                    AnyValue::Duration(i, _) => builder.append_value(i),
-                    _ => builder.append_null(),
-                }
+            av => match av.cast(&target_dtype) {
+                AnyValue::Duration(i, _) => builder.append_value(i),
+                _ => builder.append_null(),
             },
         }
     }
@@ -968,7 +1078,7 @@ fn any_values_to_object(values: &[AnyValue]) -> PolarsResult<Series> {
     Ok(builder.to_series())
 }
 
-fn invalid_value_error(dtype: &DataType, value: &AnyValue) -> PolarsError {
+pub(crate) fn invalid_value_error(dtype: &DataType, value: &AnyValue) -> PolarsError {
     polars_err!(
         SchemaMismatch:
         "unexpected value while building Series of type {:?}; found value of type {:?}: {}",

--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -160,7 +160,14 @@ impl Series {
             DataType::Struct(fields) => any_values_to_struct(values, fields, strict)?,
             #[cfg(feature = "object")]
             DataType::Object(_) => any_values_to_object(values)?,
-            DataType::Null => Series::new_null(PlSmallStr::EMPTY, values.len()),
+            DataType::Null => {
+                if strict {
+                    if let Some(value) = values.iter().find(|value| !value.is_null()) {
+                        return Err(invalid_value_error(dtype, value));
+                    }
+                }
+                Series::new_null(PlSmallStr::EMPTY, values.len())
+            },
             dt => {
                 polars_bail!(
                     InvalidOperation:
@@ -602,9 +609,13 @@ fn any_values_to_categorical(
                 },
             };
 
-            if let Err(e) = ret {
+            if let Err(err) = ret {
                 if strict {
-                    return Err(e);
+                    return Err(if dtype.is_enum() {
+                        invalid_value_error(dtype, av)
+                    } else {
+                        err
+                    });
                 } else {
                     builder.append_null();
                 }

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -16,7 +16,7 @@ macro_rules! invalid_operation_panic {
 }
 
 pub mod amortized_iter;
-mod any_value;
+pub(crate) mod any_value;
 pub mod arithmetic;
 pub mod arrow_export;
 pub mod builder;

--- a/crates/polars-python/src/dataframe/construction.rs
+++ b/crates/polars-python/src/dataframe/construction.rs
@@ -89,45 +89,27 @@ fn finish_from_rows(
     strict: bool,
     infer_schema_length: Option<usize>,
 ) -> PyResult<PyDataFrame> {
-    let schema = if let Some(mut schema) = schema {
+    // Strictly validate values only against dtypes the caller specified; dtypes
+    // inferred from the data are supertypes the values are meant to be coerced to.
+    let (schema, strict_columns) = if let Some(mut schema) = schema {
         resolve_schema_overrides(&mut schema, schema_overrides);
+        let strict_columns: Vec<bool> =
+            schema.iter_values().map(|dtype| dtype.is_known()).collect();
         update_schema_from_rows(&mut schema, &rows, infer_schema_length)?;
-        schema
+        (schema, strict_columns)
     } else {
-        rows_to_schema_supertypes(&rows, infer_schema_length).map_err(PyPolarsErr::from)?
+        let schema =
+            rows_to_schema_supertypes(&rows, infer_schema_length).map_err(PyPolarsErr::from)?;
+        let strict_columns = vec![false; schema.len()];
+        (schema, strict_columns)
     };
 
-    let num_rows = rows.len();
-
-    if strict && !rows.windows(2).all(|w| w[0].0.len() == w[1].0.len()) {
-        return Err(PyPolarsErr::from(polars_err!(
-            ComputeError: "rows must be of equal length"
-        ))
-        .into());
+    let df = if strict {
+        DataFrame::from_rows_and_schema_strict(&rows, &schema, Some(&strict_columns))
+    } else {
+        DataFrame::from_rows_and_schema(&rows, &schema)
     }
-
-    let mut column_values = (0..schema.len())
-        .map(|_| Vec::with_capacity(num_rows))
-        .collect::<Vec<_>>();
-
-    for row in rows {
-        let mut values = row.0.into_iter();
-        for column in &mut column_values {
-            column.push(values.next().unwrap_or(AnyValue::Null));
-        }
-    }
-
-    let columns: Vec<Column> = schema
-        .iter()
-        .zip(column_values)
-        .map(|((name, dtype), values)| {
-            Series::from_any_values_and_dtype(name.clone(), &values, dtype, strict)
-                .map(|series| series.into_column())
-        })
-        .collect::<PolarsResult<Vec<_>>>()
-        .map_err(PyPolarsErr::from)?;
-
-    let df = DataFrame::new(num_rows, columns).map_err(PyPolarsErr::from)?;
+    .map_err(PyPolarsErr::from)?;
     Ok(df.into())
 }
 

--- a/crates/polars-python/src/dataframe/construction.rs
+++ b/crates/polars-python/src/dataframe/construction.rs
@@ -97,8 +97,37 @@ fn finish_from_rows(
         rows_to_schema_supertypes(&rows, infer_schema_length).map_err(PyPolarsErr::from)?
     };
 
-    let df = DataFrame::from_rows_and_schema_strict(&rows, &schema, strict)
+    let num_rows = rows.len();
+
+    if strict && !rows.windows(2).all(|w| w[0].0.len() == w[1].0.len()) {
+        return Err(PyPolarsErr::from(polars_err!(
+            ComputeError: "rows must be of equal length"
+        ))
+        .into());
+    }
+
+    let mut column_values = (0..schema.len())
+        .map(|_| Vec::with_capacity(num_rows))
+        .collect::<Vec<_>>();
+
+    for row in rows {
+        let mut values = row.0.into_iter();
+        for column in &mut column_values {
+            column.push(values.next().unwrap_or(AnyValue::Null));
+        }
+    }
+
+    let columns: Vec<Column> = schema
+        .iter()
+        .zip(column_values)
+        .map(|((name, dtype), values)| {
+            Series::from_any_values_and_dtype(name.clone(), &values, dtype, strict)
+                .map(|series| series.into_column())
+        })
+        .collect::<PolarsResult<Vec<_>>>()
         .map_err(PyPolarsErr::from)?;
+
+    let df = DataFrame::new(num_rows, columns).map_err(PyPolarsErr::from)?;
     Ok(df.into())
 }
 

--- a/crates/polars-python/src/dataframe/construction.rs
+++ b/crates/polars-python/src/dataframe/construction.rs
@@ -13,16 +13,17 @@ use crate::utils::EnterPolarsExt;
 #[pymethods]
 impl PyDataFrame {
     #[staticmethod]
-    #[pyo3(signature = (data, schema=None, infer_schema_length=None))]
+    #[pyo3(signature = (data, schema=None, strict=true, infer_schema_length=None))]
     pub fn from_rows(
         py: Python<'_>,
         data: Vec<Wrap<Row>>,
         schema: Option<Wrap<Schema>>,
+        strict: bool,
         infer_schema_length: Option<usize>,
     ) -> PyResult<Self> {
         let data = vec_extract_wrapped(data);
         let schema = schema.map(|wrap| wrap.0);
-        py.enter_polars(move || finish_from_rows(data, schema, None, infer_schema_length))
+        py.enter_polars(move || finish_from_rows(data, schema, None, strict, infer_schema_length))
     }
 
     #[staticmethod]
@@ -66,7 +67,7 @@ impl PyDataFrame {
             ))
         });
         py.enter_polars(move || {
-            finish_from_rows(rows, schema, schema_overrides, infer_schema_length)
+            finish_from_rows(rows, schema, schema_overrides, strict, infer_schema_length)
         })
     }
 
@@ -85,6 +86,7 @@ fn finish_from_rows(
     rows: Vec<Row>,
     schema: Option<Schema>,
     schema_overrides: Option<Schema>,
+    strict: bool,
     infer_schema_length: Option<usize>,
 ) -> PyResult<PyDataFrame> {
     let schema = if let Some(mut schema) = schema {
@@ -95,7 +97,8 @@ fn finish_from_rows(
         rows_to_schema_supertypes(&rows, infer_schema_length).map_err(PyPolarsErr::from)?
     };
 
-    let df = DataFrame::from_rows_and_schema(&rows, &schema).map_err(PyPolarsErr::from)?;
+    let df = DataFrame::from_rows_and_schema_strict(&rows, &schema, strict)
+        .map_err(PyPolarsErr::from)?;
     Ok(df.into())
 }
 

--- a/py-polars/src/polars/_plr.pyi
+++ b/py-polars/src/polars/_plr.pyi
@@ -723,6 +723,7 @@ class PyDataFrame:
     def from_rows(
         data: Sequence[PySeries],
         schema: Any | None,
+        strict: bool,
         infer_schema_length: int | None,
     ) -> PyDataFrame: ...
     @staticmethod

--- a/py-polars/src/polars/_utils/construction/dataframe.py
+++ b/py-polars/src/polars/_utils/construction/dataframe.py
@@ -1047,6 +1047,10 @@ def iterable_to_pydf(
             df = frame_chunk
             if not original_schema:
                 original_schema = list(df.schema.items())
+                # later chunks are built against this inferred schema; coerce to
+                # it rather than validate, so that chunk boundaries do not
+                # change inference semantics
+                strict = False
             if chunk_size != adaptive_chunk_size:
                 if (n_columns := df.width) > 0:
                     chunk_size = adaptive_chunk_size = n_chunk_elems // n_columns

--- a/py-polars/src/polars/_utils/construction/dataframe.py
+++ b/py-polars/src/polars/_utils/construction/dataframe.py
@@ -600,6 +600,7 @@ def _sequence_of_sequence_to_pydf(
             pydf = PyDataFrame.from_rows(
                 data,
                 schema=local_schema_override or None,
+                strict=strict,
                 infer_schema_length=infer_schema_length,
             )
         if column_names or schema_overrides:
@@ -825,6 +826,7 @@ def _sequence_of_dataclasses_to_pydf(
         pydf = PyDataFrame.from_rows(
             rows,  # type: ignore[arg-type]
             schema=overrides or None,
+            strict=strict,
             infer_schema_length=infer_schema_length,
         )
 
@@ -885,7 +887,10 @@ def _sequence_of_pydantic_models_to_pydf(
         get_values = itemgetter(*model_fields)
         rows = [get_values(md.__dict__) for md in data]
         pydf = PyDataFrame.from_rows(
-            rows, schema=overrides, infer_schema_length=infer_schema_length
+            rows,
+            schema=overrides,
+            strict=strict,
+            infer_schema_length=infer_schema_length,
         )
     else:
         # ...and 'from_dicts' is faster otherwise

--- a/py-polars/src/polars/_utils/construction/series.py
+++ b/py-polars/src/polars/_utils/construction/series.py
@@ -215,6 +215,7 @@ def sequence_to_pyseries(
             data=data,
             schema=struct_schema,
             orient="row",
+            strict=strict,
         ).to_struct(name, invalid)
 
     if python_dtype is None:

--- a/py-polars/src/polars/io/database/_executor.py
+++ b/py-polars/src/polars/io/database/_executor.py
@@ -313,6 +313,8 @@ class ConnectionExecutor:
                         schema_overrides=schema_overrides,
                         infer_schema_length=infer_schema_length,
                         orient="row",
+                        # driver-native Python values are cast to the target types
+                        strict=False,
                     )
                     for rows in (
                         self._fetchmany_rows(

--- a/py-polars/src/polars/testing/parametric/strategies/core.py
+++ b/py-polars/src/polars/testing/parametric/strategies/core.py
@@ -230,7 +230,10 @@ def series(  # noqa: D417
             )
         )
 
-    s = Series(name=name, values=values, dtype=dtype)
+    # Drawn values are logically valid for the dtype but may extract with a
+    # different physical representation (e.g. Python floats for Float16 fields);
+    # construct leniently so they are coerced rather than rejected.
+    s = Series(name=name, values=values, dtype=dtype, strict=False)
 
     # Apply masking out of values
     if do_mask_out:

--- a/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
+++ b/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     [
         (pl.Int64, [-1, 0, 100_000, None]),
         (pl.Float64, [-1.5, 0.0, 10.0, None]),
+        (pl.Null, [None, None]),
         (pl.Boolean, [True, False, None]),
         (pl.Binary, [b"123", b"xyz", None]),
         (pl.String, ["123", "xyz", None]),
@@ -54,6 +55,7 @@ def test_fallback_with_dtype_strict(
     [
         (pl.Int64, [1.0, 2.0]),
         (pl.Float64, [1, 2]),
+        (pl.Null, [1]),
         (pl.Boolean, [0, 1]),
         (pl.Binary, ["123", "xyz"]),
         (pl.String, [b"123", b"xyz"]),
@@ -95,6 +97,7 @@ def test_fallback_with_dtype_strict_failure(
             [False, True, 0, -1, 0.0, 2.5, date(1970, 1, 2), "5", "xyz"],
             [0.0, 1.0, 0.0, -1.0, 0.0, 2.5, 1.0, 5.0, None],
         ),
+        (pl.Null, [1, None], [None, None]),
         (
             pl.Boolean,
             [False, True, 0, -1, 0.0, 2.5, date(1970, 1, 1), "true"],
@@ -404,7 +407,7 @@ def test_fallback_with_dtype_strict_failure_enum_casting() -> None:
     dtype = pl.Enum(["a", "b"])
     values = ["a", "b", "c", None]
 
-    with pytest.raises(TypeError, match="attempted to insert 'c'"):
+    with pytest.raises(TypeError, match=r'unexpected value.*"c"'):
         PySeries.new_from_any_values_and_dtype("", values, dtype, strict=True)
 
 

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -242,6 +242,7 @@ def test_init_structured_objects() -> None:
             df = DF(
                 data=trades,
                 schema_overrides={"timestamp": pl.Datetime("ms"), "size": pl.Int32},
+                strict=False,
             )
             assert df.schema == {
                 "timestamp": pl.Datetime("ms"),
@@ -259,6 +260,7 @@ def test_init_structured_objects() -> None:
                 ("pc", pl.Float64),
                 ("sz", pl.UInt16),
             ],
+            strict=False,
         )
         assert df.schema == {
             "ts": pl.Datetime("ms"),
@@ -528,6 +530,7 @@ def test_init_ndarray() -> None:
         data=[[1, 2.0, "a"], [None, None, None]],
         schema=[("x", pl.Boolean), ("y", pl.Int32), "z"],
         orient="row",
+        strict=False,
     )
     assert df.rows() == [(True, 2, "a"), (None, None, None)]
     assert df.schema == {"x": pl.Boolean, "y": pl.Int32, "z": pl.String}
@@ -901,7 +904,10 @@ def test_init_seq_of_seq() -> None:
     assert_frame_equal(df, expected)
 
     df = pl.DataFrame(
-        ((1, 2), (3, 4)), schema=(("a", pl.Float32), ("b", pl.Float32)), orient="row"
+        ((1, 2), (3, 4)),
+        schema=(("a", pl.Float32), ("b", pl.Float32)),
+        orient="row",
+        strict=False,
     )
     assert df.schema == {"a": pl.Float32, "b": pl.Float32}
     assert df.rows() == [(1.0, 2.0), (3.0, 4.0)]

--- a/py-polars/tests/unit/constructors/test_convert.py
+++ b/py-polars/tests/unit/constructors/test_convert.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError, NoDataError
+from polars.exceptions import NoDataError, SchemaError
 
 
 def test_from_records_schema_inference() -> None:
@@ -23,7 +23,7 @@ def test_from_records_schema_inference() -> None:
 
 def test_from_dicts_schema_inference() -> None:
     data = [{"a": 1, "b": 2}, {"a": 3.1, "b": 4.5}]
-    result = pl.from_dicts(data)  # type: ignore[arg-type]
+    result = pl.from_dicts(data, strict=False)  # type: ignore[arg-type]
     assert result.to_dict(as_series=False) == {
         "a": [1.0, 3.1],
         "b": [2.0, 4.5],
@@ -43,9 +43,7 @@ def test_from_dicts_empty() -> None:
 def test_from_dicts_all_cols_6716() -> None:
     dicts: list[dict[str, Any]] = [{"a": None} for _ in range(20)] + [{"a": "crash"}]
 
-    with pytest.raises(
-        ComputeError, match="make sure that all rows have the same schema"
-    ):
+    with pytest.raises(SchemaError, match="Series of type Null"):
         pl.from_dicts(dicts, infer_schema_length=20)
     assert pl.from_dicts(dicts, infer_schema_length=None).dtypes == [pl.String]
 

--- a/py-polars/tests/unit/constructors/test_convert.py
+++ b/py-polars/tests/unit/constructors/test_convert.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 
 import polars as pl
-from polars.exceptions import NoDataError, SchemaError
+from polars.exceptions import ComputeError, NoDataError
 
 
 def test_from_records_schema_inference() -> None:
@@ -23,7 +23,7 @@ def test_from_records_schema_inference() -> None:
 
 def test_from_dicts_schema_inference() -> None:
     data = [{"a": 1, "b": 2}, {"a": 3.1, "b": 4.5}]
-    result = pl.from_dicts(data, strict=False)  # type: ignore[arg-type]
+    result = pl.from_dicts(data)  # type: ignore[arg-type]
     assert result.to_dict(as_series=False) == {
         "a": [1.0, 3.1],
         "b": [2.0, 4.5],
@@ -43,7 +43,9 @@ def test_from_dicts_empty() -> None:
 def test_from_dicts_all_cols_6716() -> None:
     dicts: list[dict[str, Any]] = [{"a": None} for _ in range(20)] + [{"a": "crash"}]
 
-    with pytest.raises(SchemaError, match="Series of type Null"):
+    with pytest.raises(
+        ComputeError, match="make sure that all rows have the same schema"
+    ):
         pl.from_dicts(dicts, infer_schema_length=20)
     assert pl.from_dicts(dicts, infer_schema_length=None).dtypes == [pl.String]
 

--- a/py-polars/tests/unit/constructors/test_dataframe.py
+++ b/py-polars/tests/unit/constructors/test_dataframe.py
@@ -10,7 +10,11 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 import polars as pl
-from polars.exceptions import DataOrientationWarning, InvalidOperationError, SchemaError
+from polars.exceptions import (
+    DataOrientationWarning,
+    InvalidOperationError,
+    SchemaError,
+)
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
@@ -118,7 +122,7 @@ def test_df_init_strict() -> None:
     assert df["a"].dtype == pl.Int8
 
 
-def test_df_init_rows_strict() -> None:
+def test_df_init_rows_strict_enum() -> None:
     data = [{"id": 10, "status": "draft"}, {"id": 10, "status": "archived"}]
     enum_dtype = pl.Enum(["draft", "published"])
 
@@ -135,6 +139,13 @@ def test_df_init_rows_strict() -> None:
     with pytest.raises(SchemaError, match="archived"):
         pl.DataFrame(data, schema_overrides={"status": enum_dtype})
 
+    with pytest.raises(InvalidOperationError, match="archived"):
+        pl.DataFrame(
+            [(10, "draft"), (10, "archived")],
+            schema={"id": pl.Int64, "status": enum_dtype},
+            orient="row",
+        )
+
     result = pl.DataFrame(
         data,
         schema={"id": pl.Int64, "status": enum_dtype},
@@ -144,6 +155,19 @@ def test_df_init_rows_strict() -> None:
         "id": [10, 10],
         "status": ["draft", None],
     }
+
+
+def test_df_init_rows_strict_numeric() -> None:
+    data = [{"a": 10.1}, {"a": 10.2}]
+
+    with pytest.raises(SchemaError, match="Float64"):
+        pl.DataFrame(data, schema={"a": pl.Int64})
+
+    with pytest.raises(SchemaError, match="Float64"):
+        pl.DataFrame([(10.1,), (10.2,)], schema={"a": pl.Int64}, orient="row")
+
+    result = pl.DataFrame(data, schema={"a": pl.Int64}, strict=False)
+    assert result.to_dict(as_series=False) == {"a": [10, 10]}
 
 
 def test_df_init_from_series_strict() -> None:

--- a/py-polars/tests/unit/constructors/test_dataframe.py
+++ b/py-polars/tests/unit/constructors/test_dataframe.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 import polars as pl
-from polars.exceptions import DataOrientationWarning, InvalidOperationError
+from polars.exceptions import DataOrientationWarning, InvalidOperationError, SchemaError
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
@@ -116,6 +116,34 @@ def test_df_init_strict() -> None:
     df = pl.DataFrame(data, schema=schema, strict=False)
     assert df["a"].to_list() == [1, 2, 3]
     assert df["a"].dtype == pl.Int8
+
+
+def test_df_init_rows_strict() -> None:
+    data = [{"id": 10, "status": "draft"}, {"id": 10, "status": "archived"}]
+    enum_dtype = pl.Enum(["draft", "published"])
+
+    with pytest.raises(SchemaError, match="archived"):
+        pl.DataFrame(data, schema={"id": pl.Int64, "status": enum_dtype})
+
+    with pytest.raises(SchemaError, match="archived"):
+        pl.DataFrame(
+            data,
+            schema={"id": pl.Int64, "status": None},
+            schema_overrides={"status": enum_dtype},
+        )
+
+    with pytest.raises(SchemaError, match="archived"):
+        pl.DataFrame(data, schema_overrides={"status": enum_dtype})
+
+    result = pl.DataFrame(
+        data,
+        schema={"id": pl.Int64, "status": enum_dtype},
+        strict=False,
+    )
+    assert result.to_dict(as_series=False) == {
+        "id": [10, 10],
+        "status": ["draft", None],
+    }
 
 
 def test_df_init_from_series_strict() -> None:

--- a/py-polars/tests/unit/constructors/test_dataframe.py
+++ b/py-polars/tests/unit/constructors/test_dataframe.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import enum
 import sys
 from collections import OrderedDict
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from datetime import date, datetime, time
 from typing import TYPE_CHECKING, Any
 
@@ -139,6 +139,8 @@ def test_df_init_rows_strict_enum() -> None:
     with pytest.raises(SchemaError, match="archived"):
         pl.DataFrame(data, schema_overrides={"status": enum_dtype})
 
+    # Tuple rows build Enum columns as String and cast afterwards, so this
+    # (known) divergence surfaces the error as InvalidOperationError instead.
     with pytest.raises(InvalidOperationError, match="archived"):
         pl.DataFrame(
             [(10, "draft"), (10, "archived")],
@@ -155,6 +157,44 @@ def test_df_init_rows_strict_enum() -> None:
         "id": [10, 10],
         "status": ["draft", None],
     }
+
+
+def test_df_init_rows_strict_inferred_columns_coerce() -> None:
+    # Strictness applies to dtypes the caller specified; dtypes inferred from
+    # the data are supertypes, and the values are coerced to them.
+    result = pl.DataFrame([{"a": 1}, {"a": 2.5}])
+    assert result["a"].to_list() == [1.0, 2.5]
+    assert result["a"].dtype == pl.Float64
+
+    result = pl.DataFrame([("x", 1), ("y", 2.5)], orient="row")
+    assert result.to_series(1).to_list() == [1.0, 2.5]
+
+    # A partial schema only validates the specified columns strictly.
+    result = pl.DataFrame(
+        [{"a": 1, "b": 1}, {"a": 2.5, "b": 2}],
+        schema={"a": None, "b": pl.Int64},
+    )
+    assert result["a"].to_list() == [1.0, 2.5]
+    assert result["b"].dtype == pl.Int64
+
+    with pytest.raises(SchemaError, match="Float64"):
+        pl.DataFrame(
+            [{"a": 1, "b": 1}, {"a": 2.5, "b": 2.5}],
+            schema={"a": None, "b": pl.Int64},
+        )
+
+
+def test_df_init_chunked_generator_inferred_schema_coerces() -> None:
+    # Chunks after the first are built against the schema inferred from the
+    # first chunk; those dtypes must be coerced to, not strictly validated,
+    # so that chunk boundaries do not change inference semantics.
+    def gen() -> Iterator[dict[str, Any]]:
+        yield from ({"x": i} for i in range(1000))
+        yield {"x": 2.5}
+
+    result = pl.DataFrame(gen())
+    assert result.height == 1001
+    assert result["x"].dtype == pl.Int64
 
 
 def test_df_init_rows_strict_numeric() -> None:

--- a/py-polars/tests/unit/constructors/test_series.py
+++ b/py-polars/tests/unit/constructors/test_series.py
@@ -45,6 +45,14 @@ def test_series_mixed_dtypes_object() -> None:
     assert s[1] == b"foo"
 
 
+def test_series_struct_strict_false() -> None:
+    dtype = pl.Struct({"a": pl.Float16})
+    result = pl.Series([{"a": 1.0}], dtype=dtype, strict=False)
+
+    assert result.dtype == dtype
+    assert result.to_list() == [{"a": 1.0}]
+
+
 # https://github.com/pola-rs/polars/issues/15139
 @pytest.mark.parametrize("dtype", [pl.List(pl.Int64), None])
 def test_sequence_of_series_with_dtype(dtype: PolarsDataType | None) -> None:

--- a/py-polars/tests/unit/dataframe/test_describe.py
+++ b/py-polars/tests/unit/dataframe/test_describe.py
@@ -133,6 +133,7 @@ def test_df_describe_nested() -> None:
         schema=["statistic"] + df.columns,
         schema_overrides={"struct": pl.Float64, "list": pl.Float64},
         orient="row",
+        strict=False,
     )
     assert_frame_equal(result, expected)
 

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1245,6 +1245,7 @@ def test_literal_series() -> None:
             ],
             schema=expected_schema,  # type: ignore[arg-type]
             orient="row",
+            strict=False,
         ),
         out,
         abs_tol=0.00001,
@@ -1355,6 +1356,7 @@ def test_from_generator_or_iterable() -> None:
         data=chain(repeat({"col": 1}, length_minus_1 := 100), repeat({"col": 1.1}, 1)),
         infer_schema_length=None,
         chunk_size=length_minus_1,
+        strict=False,
     )
     assert d.dtypes() == [pl.Float64()]
 
@@ -1369,6 +1371,7 @@ def test_from_generator_or_iterable() -> None:
         pl.DataFrame(
             data=gen_named(1),
             schema_overrides={"a": pl.Float64(), "c": pl.Float64()},
+            strict=False,
         ),
         pl.DataFrame([{"a": 0.0, "b": 0, "c": 1.0, "d": 1}]),
     )
@@ -1467,7 +1470,11 @@ def test_from_records_with_schema_overrides_12032() -> None:
         {"id": 9223671840084328467, "x": 666.5, "y": 1698177261953686},
         {"id": 9187643043065364505, "x": 999, "y": 9223372036854775807},
     ]
-    df = pl.from_records(rec, schema_overrides={"x": pl.Float32, "id": pl.UInt64})
+    df = pl.from_records(
+        rec,
+        schema_overrides={"x": pl.Float32, "id": pl.UInt64},
+        strict=False,
+    )
     assert df.schema == OrderedDict(
         [
             ("id", pl.UInt64),
@@ -3225,7 +3232,7 @@ def test_from_dicts_with_override() -> None:
         {"a": "1", "b": "1", "c": "-5.0"},
     ]
     override = {"a": pl.Int32, "b": pl.UInt64, "c": pl.Float32}
-    result = pl.from_dicts(data, schema_overrides=override)
+    result = pl.from_dicts(data, schema_overrides=override, strict=False)
     assert_frame_equal(
         result,
         pl.DataFrame(

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1356,7 +1356,6 @@ def test_from_generator_or_iterable() -> None:
         data=chain(repeat({"col": 1}, length_minus_1 := 100), repeat({"col": 1.1}, 1)),
         infer_schema_length=None,
         chunk_size=length_minus_1,
-        strict=False,
     )
     assert d.dtypes() == [pl.Float64()]
 

--- a/py-polars/tests/unit/dataframe/test_from_dict.py
+++ b/py-polars/tests/unit/dataframe/test_from_dict.py
@@ -252,6 +252,7 @@ def test_from_dict_cast_logical_type(dtype: pl.DataType, data: Any) -> None:
             }
         ],
         schema=schema,
+        strict=False,
     )
 
     assert_frame_equal(df_from_dicts, df)

--- a/py-polars/tests/unit/dataframe/test_serde.py
+++ b/py-polars/tests/unit/dataframe/test_serde.py
@@ -28,7 +28,13 @@ def test_df_serde_roundtrip_binary(df: pl.DataFrame) -> None:
 
 
 @given(df=dataframes())
-@example(df=pl.DataFrame({"a": {"a": 1.0}}, schema={"a": pl.Struct({"a": pl.Float16})}))
+@example(
+    df=pl.DataFrame(
+        {"a": {"a": 1.0}},
+        schema={"a": pl.Struct({"a": pl.Float16})},
+        strict=False,
+    )
+)
 @example(df=pl.DataFrame({"a": [None, None]}, schema={"a": pl.Null}))
 @example(df=pl.DataFrame(schema={"a": pl.List(pl.String)}))
 def test_df_serde_roundtrip_json(df: pl.DataFrame) -> None:

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -13,7 +13,7 @@ import pyarrow as pa
 import pytest
 
 import polars as pl
-from polars.exceptions import InvalidOperationError
+from polars.exceptions import InvalidOperationError, SchemaError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -138,10 +138,17 @@ def test_decimal_convert_to_float_by_schema() -> None:
 
 def test_df_constructor_convert_decimal_to_float_9873() -> None:
     result = pl.DataFrame(
-        [[D("45.0000")], [D("45.0000")]], schema={"a": pl.Float64}, orient="row"
+        [[D("45.0000")], [D("45.0000")]],
+        schema={"a": pl.Float64},
+        orient="row",
+        strict=False,
     )
     expected = pl.DataFrame({"a": [45.0, 45.0]})
     assert_frame_equal(result, expected)
+
+    # Under strict construction, a Decimal value does not match a Float64 schema.
+    with pytest.raises(SchemaError, match="Float64"):
+        pl.DataFrame([[D("45.0000")]], schema={"a": pl.Float64}, orient="row")
 
 
 def test_decimal_cast() -> None:

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -20,6 +20,7 @@ from polars.exceptions import (
     ComputeError,
     InvalidOperationError,
     PolarsInefficientMapWarning,
+    SchemaError,
 )
 from polars.testing import (
     assert_frame_equal,
@@ -90,6 +91,7 @@ def test_fill_null_temporal() -> None:
             ("j", pl.Duration("ns")),
         ],
         orient="row",
+        strict=False,
     )
 
     # fill literals
@@ -852,6 +854,7 @@ def test_temporal_dtypes_map_elements(
             "time": pl.Time,
         },
         orient="row",
+        strict=False,
     )
     assert_frame_equal(result, expected)
 
@@ -878,8 +881,14 @@ def test_timedelta_timeunit_init() -> None:
             ("z", pl.Duration("ns")),
         ],
         orient="row",
+        strict=False,
     )
     assert df.rows() == [(td_ms, td_us, td_us)]
+
+    # A timedelta extracts with microsecond precision; under strict construction
+    # it does not match a Duration column with a different time unit.
+    with pytest.raises(SchemaError, match="Duration"):
+        pl.DataFrame([[td_us]], schema=[("x", pl.Duration("ms"))], orient="row")
 
 
 def test_duration_filter() -> None:

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -1419,6 +1419,7 @@ def test_month_day_nano_from_ffi_15969(plmonkeypatch: PlMonkeyPatch) -> None:
                         "nanoseconds": pl.Duration(time_unit="ns"),
                     }
                 ),
+                strict=False,
             ),
         ]
     )

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -755,6 +755,7 @@ def test_scan_delta_nanosecond_timestamp_nested(tmp_path: Path) -> None:
             ]
         },
         schema={"c1": pl.Struct({"timestamp": pl.Datetime("ns", time_zone=None)})},
+        strict=False,
     )
 
     root = tmp_path / "delta"

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -2171,7 +2171,7 @@ def test_decimal_precision_nested_roundtrip(
         decimal_dtype = pl.Decimal(precision=precision)
         values, dtype = nesting(decimal_dtype)
 
-    df = pl.Series("a", values, dtype).to_frame()
+    df = pl.Series("a", values, dtype, strict=False).to_frame()
 
     test_round_trip(df)
 

--- a/py-polars/tests/unit/io/test_scan_options.py
+++ b/py-polars/tests/unit/io/test_scan_options.py
@@ -127,40 +127,52 @@ if TYPE_CHECKING:
         (
             (
                 pl.lit(
-                    [
-                        {
-                            "field": datetime(
-                                2025, 1, 1, tzinfo=ZoneInfo("Europe/Amsterdam")
+                    pl.Series(
+                        "literal",
+                        [
+                            [
+                                {
+                                    "field": datetime(
+                                        2025, 1, 1, tzinfo=ZoneInfo("Europe/Amsterdam")
+                                    )
+                                }
+                            ]
+                        ],
+                        dtype=pl.List(
+                            pl.Struct(
+                                {
+                                    "field": pl.Datetime(
+                                        time_unit="ms", time_zone="Europe/Amsterdam"
+                                    )
+                                }
                             )
-                        }
-                    ],
-                    dtype=pl.List(
-                        pl.Struct(
-                            {
-                                "field": pl.Datetime(
-                                    time_unit="ms", time_zone="Europe/Amsterdam"
-                                )
-                            }
-                        )
-                    ),
+                        ),
+                        strict=False,
+                    )
                 ),
                 pl.lit(
-                    [
-                        {
-                            "field": datetime(
-                                2025, 1, 2, tzinfo=ZoneInfo("Australia/Sydney")
+                    pl.Series(
+                        "literal",
+                        [
+                            [
+                                {
+                                    "field": datetime(
+                                        2025, 1, 2, tzinfo=ZoneInfo("Australia/Sydney")
+                                    )
+                                }
+                            ]
+                        ],
+                        dtype=pl.List(
+                            pl.Struct(
+                                {
+                                    "field": pl.Datetime(
+                                        time_unit="ns", time_zone="Australia/Sydney"
+                                    )
+                                }
                             )
-                        }
-                    ],
-                    dtype=pl.List(
-                        pl.Struct(
-                            {
-                                "field": pl.Datetime(
-                                    time_unit="ns", time_zone="Australia/Sydney"
-                                )
-                            }
-                        )
-                    ),
+                        ),
+                        strict=False,
+                    )
                 ),
             ),
             pl.Series(
@@ -189,6 +201,7 @@ if TYPE_CHECKING:
                         }
                     )
                 ),
+                strict=False,
             ),
             pl.ScanCastOptions(
                 datetime_cast=("nanosecond-downcast", "convert-timezone")
@@ -197,42 +210,54 @@ if TYPE_CHECKING:
         (
             (
                 pl.lit(
-                    [
-                        {
-                            "field": datetime(
-                                2025, 1, 1, tzinfo=ZoneInfo("Europe/Amsterdam")
-                            )
-                        }
-                    ],
-                    dtype=pl.Array(
-                        pl.Struct(
-                            {
-                                "field": pl.Datetime(
-                                    time_unit="ms", time_zone="Europe/Amsterdam"
-                                )
-                            }
+                    pl.Series(
+                        "literal",
+                        [
+                            [
+                                {
+                                    "field": datetime(
+                                        2025, 1, 1, tzinfo=ZoneInfo("Europe/Amsterdam")
+                                    )
+                                }
+                            ]
+                        ],
+                        dtype=pl.Array(
+                            pl.Struct(
+                                {
+                                    "field": pl.Datetime(
+                                        time_unit="ms", time_zone="Europe/Amsterdam"
+                                    )
+                                }
+                            ),
+                            shape=1,
                         ),
-                        shape=1,
-                    ),
+                        strict=False,
+                    )
                 ),
                 pl.lit(
-                    [
-                        {
-                            "field": datetime(
-                                2025, 1, 2, tzinfo=ZoneInfo("Australia/Sydney")
-                            )
-                        }
-                    ],
-                    dtype=pl.Array(
-                        pl.Struct(
-                            {
-                                "field": pl.Datetime(
-                                    time_unit="ns", time_zone="Australia/Sydney"
-                                )
-                            }
+                    pl.Series(
+                        "literal",
+                        [
+                            [
+                                {
+                                    "field": datetime(
+                                        2025, 1, 2, tzinfo=ZoneInfo("Australia/Sydney")
+                                    )
+                                }
+                            ]
+                        ],
+                        dtype=pl.Array(
+                            pl.Struct(
+                                {
+                                    "field": pl.Datetime(
+                                        time_unit="ns", time_zone="Australia/Sydney"
+                                    )
+                                }
+                            ),
+                            shape=1,
                         ),
-                        shape=1,
-                    ),
+                        strict=False,
+                    )
                 ),
             ),
             pl.Series(
@@ -262,6 +287,7 @@ if TYPE_CHECKING:
                     ),
                     shape=1,
                 ),
+                strict=False,
             ),
             pl.ScanCastOptions(
                 datetime_cast=("nanosecond-downcast", "convert-timezone")

--- a/py-polars/tests/unit/meta/test_errors.py
+++ b/py-polars/tests/unit/meta/test_errors.py
@@ -512,8 +512,8 @@ def test_invalid_group_by_arg() -> None:
 
 def test_overflow_msg() -> None:
     with pytest.raises(
-        ComputeError,
-        match=r"could not append value: 2147483648 of type: i64 to the builder",
+        SchemaError,
+        match=r"unexpected value while building Series of type Int32.*2147483648",
     ):
         pl.DataFrame([[2**31]], [("a", pl.Int32)], orient="row")
 

--- a/py-polars/tests/unit/operations/aggregation/test_aggregations.py
+++ b/py-polars/tests/unit/operations/aggregation/test_aggregations.py
@@ -1284,7 +1284,7 @@ def test_first_last_nested(
     first_value: Any,
     last_value: Any,
 ) -> None:
-    s = pl.Series([first_value, last_value], dtype=dtype)
+    s = pl.Series([first_value, last_value], dtype=dtype, strict=False)
     if null_endpoints:
         # Test the case where the first/last value is null
         null = pl.Series([None], dtype=dtype)
@@ -1299,6 +1299,7 @@ def test_first_last_nested(
             "a": pl.Series(
                 [None if null_endpoints and not ignore_nulls else first_value],
                 dtype=dtype,
+                strict=False,
             )
         }
     )
@@ -1311,6 +1312,7 @@ def test_first_last_nested(
             "a": pl.Series(
                 [None if null_endpoints and not ignore_nulls else last_value],
                 dtype=dtype,
+                strict=False,
             ),
         }
     )

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -2248,6 +2248,7 @@ def test_json_decode_decimal_25789() -> None:
     expected = pl.Series(
         [{"a": 1.23}, {"a": 4.56}, {"a": None}, {"a": 30.13}],
         dtype=pl.Struct({"a": pl.Decimal(4, 2)}),
+        strict=False,
     )
     assert_series_equal(result, expected)
 

--- a/py-polars/tests/unit/operations/namespaces/test_struct.py
+++ b/py-polars/tests/unit/operations/namespaces/test_struct.py
@@ -137,6 +137,7 @@ def test_json_encode_decimal_25881() -> None:
     s = pl.Series(
         [{"a": 1.23}, {"a": 4.56}, {"a": None}, {"a": 30.13}],
         dtype=pl.Struct({"a": pl.Decimal(4, 2)}),
+        strict=False,
     )
     result = s.struct.json_encode()
     expected = pl.Series(

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -162,11 +162,11 @@ def test_is_in_struct() -> None:
 def test_is_in_null_prop() -> None:
     assert pl.Series([None], dtype=pl.Float32).is_in(pl.Series([42])).item() is None
     assert pl.Series([{"a": None}, None], dtype=pl.Struct({"a": pl.Float32})).is_in(
-        pl.Series([{"a": 42}], dtype=pl.Struct({"a": pl.Float32}))
+        pl.Series([{"a": 42}], dtype=pl.Struct({"a": pl.Float32}), strict=False)
     ).to_list() == [False, None]
 
     assert pl.Series([{"a": None}, None], dtype=pl.Struct({"a": pl.Boolean})).is_in(
-        pl.Series([{"a": 42}], dtype=pl.Struct({"a": pl.Boolean}))
+        pl.Series([{"a": 42}], dtype=pl.Struct({"a": pl.Boolean}), strict=False)
     ).to_list() == [False, None]
 
 

--- a/py-polars/tests/unit/operations/test_is_sorted.py
+++ b/py-polars/tests/unit/operations/test_is_sorted.py
@@ -296,7 +296,7 @@ def test_series_is_sorted_parametric(
     s: pl.Series, descending: bool, nulls_last: bool
 ) -> None:
     s = s.sort(descending=descending, nulls_last=nulls_last)
-    s = pl.Series(s.to_list(), dtype=s.dtype)  # Remove the sorted flags
+    s = pl.Series(s.to_list(), dtype=s.dtype, strict=False)  # Remove the sorted flags
     assert s.is_sorted(descending=descending, nulls_last=nulls_last)
     if s.drop_nulls().n_unique() > 1:
         assert not s.is_sorted(descending=not descending, nulls_last=nulls_last)

--- a/py-polars/tests/unit/operations/test_queries.py
+++ b/py-polars/tests/unit/operations/test_queries.py
@@ -176,6 +176,7 @@ def test_group_by_agg_equals_zero_3535() -> None:
             ("val2", pl.Float32),
         ],
         orient="row",
+        strict=False,
     )
     # group by the key, aggregating the two numeric cols
     assert df.group_by(pl.col("key"), maintain_order=True).agg(

--- a/py-polars/tests/unit/operations/test_row_encoding_sort.py
+++ b/py-polars/tests/unit/operations/test_row_encoding_sort.py
@@ -176,7 +176,8 @@ def test_series_sort_parametric(s: pl.Series) -> None:
             )
 
             assert_series_equal(
-                pl.Series("s", rows, s.dtype), re_decoded.struct.unnest().to_series()
+                pl.Series("s", rows, s.dtype, strict=False),
+                re_decoded.struct.unnest().to_series(),
             )
 
 
@@ -221,7 +222,8 @@ def test_df_sort_parametric(df: pl.DataFrame) -> None:
         )
 
         assert_frame_equal(
-            pl.DataFrame(rows, df.schema, orient="row"), re_decoded.struct.unnest()
+            pl.DataFrame(rows, df.schema, orient="row", strict=False),
+            re_decoded.struct.unnest(),
         )
 
 

--- a/py-polars/tests/unit/series/test_to_list.py
+++ b/py-polars/tests/unit/series/test_to_list.py
@@ -17,5 +17,5 @@ from polars.testing.parametric import series
 @example(s=pl.Series(dtype=pl.Array(pl.Date, 1)))
 def test_to_list(s: pl.Series) -> None:
     values = s.to_list()
-    result = pl.Series(values, dtype=s.dtype)
+    result = pl.Series(values, dtype=s.dtype, strict=False)
     assert_series_equal(s, result, categorical_as_str=True)


### PR DESCRIPTION
Fixes #26282. Fixes the reported cases of #17375. Related to #23152.

## Problem

The Python row constructors (`from_dicts`, `from_rows`) accepted `strict` but did
not honor it: values that did not match the schema were silently coerced or
nulled. For the reported case, an invalid `Enum` value became null under
`strict=True`.

As noted in
[#26282 (comment)](https://github.com/pola-rs/polars/issues/26282#issuecomment-3827864717),
this is not limited to `Enum`: the `add_fallible` path does not honor strictness
for any dtype (e.g. `Float64` values are silently cast into an `Int64` column
under `strict=True`, unlike the columnar constructors —
[#26282 (comment)](https://github.com/pola-rs/polars/issues/26282#issuecomment-3822398409)).
The fix direction suggested there — Series-codepath semantics, pending
performance — is what this PR implements.

## Changes

- `AnyValueBuffer::add_strict`: a strict row-wise insert whose accepted
  conversions are defined by per-value `av_to_*_strict` helpers in
  `series/any_value.rs`, shared with the columnar
  `Series::from_any_values_and_dtype` strict path — the two paths cannot drift
  apart. Parity tests additionally assert identical behavior for primitives,
  temporal types (incl. time-unit mismatches), Float16, and overflow boundaries.
- `DataFrame::from_rows_and_schema_strict(rows, schema, strict_columns:
  Option<&[bool]>)`: strictness applies per column. The Python bindings pass a
  mask marking **caller-specified** dtypes strict; dtypes inferred from the data
  are supertypes the values are meant to be coerced to, so validating them
  strictly would reject the very values the supertype was inferred from
  (e.g. `pl.DataFrame([{"x": 1}, {"x": 2.5}])`). The same rule is threaded
  through chunked generator construction (`iterable_to_pydf`), so chunk
  boundaries do not change inference semantics.
- Performance: the strict buffer avoids both the per-value cloning of the
  transpose approach and the fallible-cast dispatch of the lenient buffer.
  Release-mode medians on rows of 10 columns (100k int rows / 10k string rows):
  strict construction is roughly 30% faster than the lenient buffer on integers
  (with or without nulls) and ~8% faster on strings. End-to-end Python
  construction from dict rows is 5–18% faster than released 1.43.1
  (int 100k rows x 10 cols: 34.6 vs 39.8 ms strict; str 10k x 10: 4.3 vs
  5.2 ms; schema inference: 36.5 vs 39.5 ms — medians of 15 runs).
- Of the ~700 added lines, roughly half are updates to existing py-polars tests
  whose expectations changed with the strictness fix; the core change shares its
  conversion logic with the existing Series codepath rather than duplicating it.

## Behavior changes (beyond the Enum fix)

With user-specified schemas and (default) `strict=True`, row-based and
struct-backed construction now rejects values that previously coerced silently,
matching the documented contract ("Throw an error if any data value does not
exactly match the given or inferred data type"). Affected conversions include
`Float64` → `Int64`/`Float32`, `Decimal` → `Float64`, and temporal values with a
different time unit than the target column. The temporal behavior follows the
semantics #15146 already established for strict AnyValue construction in the
columnar path (a mismatched time unit is a strict failure); this PR extends the
same rule to the row path, which previously rescaled silently. `strict=False` retains the previous
casting behavior. Existing tests that relied on silent coercion were updated
accordingly (`strict=False` where the cast was intentional, error assertions
where the test codified constructor behavior).

Consequences handled inside this PR: `read_database` and the chunked generator
path construct leniently (driver values and inferred dtypes are cast, as
before), and the hypothesis `parametric` strategies construct drawn values
leniently. One user-visible caveat: round-tripping struct-backed Series through
Python values (`pl.Series(s.to_list(), dtype=s.dtype)`) now requires
`strict=False` when a struct field's dtype is not the canonical extraction type
(e.g. `Float16`, `Datetime('ns')` fields), since the values re-extract as
`Float64`/microseconds.

Known remaining inconsistencies, intentionally out of scope:

- The columnar Python paths (`pl.Series([1], dtype=pl.Float64)`) extract values
  dtype-aware via typed constructors and therefore accept e.g. int → float under
  `strict=True`, while the AnyValue-based row paths reject it. Unifying these
  requires dtype-aware row extraction (the "struct builder" TODO in
  `construction/series.py`).
- The missing-schema-column half of #23152 is not addressed: rejecting missing
  dict keys would break heterogeneous-dict construction
  (`pl.DataFrame([{"a": 1}, {"b": 2}])`), so it needs a separate design
  decision.
- Enum errors still differ by input path (dict rows raise `SchemaError`; tuple
  rows raise `InvalidOperationError` because that path builds Enum columns as
  `String` and casts afterwards).

## AI assistance

OpenAI Codex and Claude Code (Claude Fable 5) were used to investigate the
issue, implement the Rust and Python changes, write the tests and benchmarks,
and draft this description. I reviewed the changes and verified them locally
(`make test`, `cargo test -p polars-core`, release-mode benchmarks).
