### PR TITLE
perf(rust): Implement two-stage decode for parquet predicates

### DIFF
--- a/crates/polars-arrow/src/bitmap/bitmask.rs
+++ b/crates/polars-arrow/src/bitmap/bitmask.rs
@@ -286,6 +286,33 @@ impl<'a> BitMask<'a> {
         }
     }
 
+    #[inline]
+    pub fn get_u64(&self, idx: usize) -> u64 {
+        if idx >= self.len {
+            return 0;
+        }
+
+        let start_byte_idx = (self.offset + idx) / 8;
+        let byte_shift = (self.offset + idx) % 8;
+        // SAFETY: we know that at least the first byte is in-bounds.
+        let mut mask =
+            load_padded_le_u64(unsafe { self.bytes.get_unchecked(start_byte_idx..) }) >> byte_shift;
+        let available_bits = (self.len - idx).min(64);
+
+        if available_bits > 64 - byte_shift {
+            // SAFETY: there are valid bits beyond the first loaded word, so at least one byte is
+            // available here.
+            let upper =
+                load_padded_le_u64(unsafe { self.bytes.get_unchecked(start_byte_idx + 8..) });
+            mask |= upper << (64 - byte_shift);
+        }
+
+        if available_bits < 64 {
+            mask &= (1 << available_bits) - 1;
+        }
+        mask
+    }
+
     /// Computes the index of the nth set bit after start.
     ///
     /// Both are zero-indexed, so `nth_set_bit_idx(0, 0)` finds the index of the

--- a/crates/polars-compute/src/filter/boolean.rs
+++ b/crates/polars-compute/src/filter/boolean.rs
@@ -1,4 +1,5 @@
-use arrow::bitmap::Bitmap;
+use arrow::bitmap::bitmask::BitMask;
+use arrow::bitmap::{Bitmap, BitmapBuilder};
 use polars_utils::clmul::prefix_xorsum;
 
 const U56_MAX: u64 = (1 << 56) - 1;
@@ -51,6 +52,40 @@ fn pext64_polyfill(mut v: u64, mut m: u64, m_popcnt: u32) -> u64 {
     v
 }
 
+fn pdep64_polyfill(mut v: u64, mut m: u64, m_popcnt: u32) -> u64 {
+    // Empirically determined crossover for fast path.
+    if m_popcnt <= 8 {
+        let mut out = 0;
+        while m != 0 {
+            let lowest_mask_bit = m & m.wrapping_neg();
+            out |= lowest_mask_bit & (v & 1).wrapping_neg();
+            v >>= 1;
+            m &= m - 1;
+        }
+        return out;
+    }
+    // As for pext, see https://github.com/zwegner/zp7. This is Hacker's
+    // Delight 7-5, parallel suffix method for expand.
+    v &= u64::MAX >> (64 - m_popcnt);
+    let mut invm = !m;
+    let mut prefix_count_bits = [0; 6];
+    for (i, prefix_count_bit) in prefix_count_bits.iter_mut().enumerate() {
+        *prefix_count_bit = if i < 5 {
+            prefix_xorsum(invm)
+        } else {
+            invm.wrapping_neg() << 1
+        };
+        invm &= *prefix_count_bit;
+    }
+
+    for i in (0..6).rev() {
+        let shift = 1 << i;
+        let bit = prefix_count_bits[i] >> shift;
+        v = (v & !bit) + ((v & bit) << shift);
+    }
+    v
+}
+
 pub fn filter_boolean_kernel(values: &Bitmap, mask: &Bitmap) -> Bitmap {
     assert_eq!(values.len(), mask.len());
     let mask_bits_set = mask.set_bits();
@@ -98,6 +133,81 @@ pub fn filter_boolean_kernel(values: &Bitmap, mask: &Bitmap) -> Bitmap {
     }
 
     Bitmap::from_u8_vec(out_vec, mask_bits_set)
+}
+
+fn expand_boolean_kernel_impl<F: Fn(u64, u64, u32) -> u64>(
+    values: &Bitmap,
+    mask: &Bitmap,
+    pdep: F,
+) -> Bitmap {
+    let values = BitMask::from_bitmap(values);
+    let mut values_offset = 0;
+    let mut builder = BitmapBuilder::with_capacity(mask.len());
+
+    let mut mask_chunks = mask.chunks::<u64>();
+    for mask_word in &mut mask_chunks {
+        let mask_popcnt = mask_word.count_ones();
+        let values_word = values.get_u64(values_offset);
+        values_offset += mask_popcnt as usize;
+
+        // SAFETY: the builder has capacity for `mask.len()` bits and every full mask chunk adds
+        // exactly 64 bits.
+        unsafe {
+            builder.push_word_with_len_unchecked(pdep(values_word, mask_word, mask_popcnt), 64)
+        };
+    }
+
+    let remainder_len = mask_chunks.remainder_len();
+    if remainder_len > 0 {
+        let mask_word = mask_chunks.remainder();
+        let mask_popcnt = mask_word.count_ones();
+        let values_word = values.get_u64(values_offset);
+        values_offset += mask_popcnt as usize;
+
+        // SAFETY: `remainder_len` is the exact unused capacity and is at most 63 bits.
+        unsafe {
+            builder.push_word_with_len_unchecked(
+                pdep(values_word, mask_word, mask_popcnt),
+                remainder_len,
+            )
+        };
+    }
+
+    debug_assert_eq!(values_offset, values.len());
+    builder.freeze()
+}
+
+/// Expands the bits in `values` into the set positions of `mask`.
+///
+/// The returned bitmap has the length of `mask`; positions where `mask` is unset are also unset in
+/// the result. The number of bits in `values` must equal the number of set bits in `mask`.
+pub fn expand_boolean_kernel(values: &Bitmap, mask: &Bitmap) -> Bitmap {
+    let mask_bits_set = mask.set_bits();
+    assert_eq!(values.len(), mask_bits_set);
+
+    if mask_bits_set == 0 {
+        return Bitmap::new_zeroed(mask.len());
+    } else if mask_bits_set == mask.len() {
+        return values.clone();
+    }
+
+    if let Some(num_value_bits) = values.lazy_set_bits() {
+        if num_value_bits == 0 {
+            return Bitmap::new_zeroed(mask.len());
+        } else if num_value_bits == values.len() {
+            return mask.clone();
+        }
+    }
+
+    if polars_utils::cpuid::has_fast_bmi2() {
+        #[cfg(target_arch = "x86_64")]
+        return expand_boolean_kernel_impl(values, mask, |v, m, _| unsafe {
+            // SAFETY: has_fast_bmi2 ensures this is a legal instruction.
+            core::arch::x86_64::_pdep_u64(v, m)
+        });
+    }
+
+    expand_boolean_kernel_impl(values, mask, pdep64_polyfill)
 }
 
 /// # Safety
@@ -263,6 +373,28 @@ mod test {
         out
     }
 
+    fn naive_pdep64(word: u64, mask: u64) -> u64 {
+        let mut out = 0;
+        let mut word_idx = 0;
+
+        for i in 0..64 {
+            if (mask >> i) & 1 == 1 {
+                out |= ((word >> word_idx) & 1) << i;
+                word_idx += 1;
+            }
+        }
+
+        out
+    }
+
+    fn naive_expand(values: &Bitmap, mask: &Bitmap) -> Bitmap {
+        assert_eq!(values.len(), mask.set_bits());
+        let mut values = values.iter();
+        mask.iter()
+            .map(|selected| selected && values.next().unwrap())
+            .collect()
+    }
+
     #[test]
     fn test_pext64() {
         // Verify polyfill against naive implementation.
@@ -289,6 +421,68 @@ mod test {
                 naive_pext64(x, mask),
                 pext64_polyfill(x, mask, mask.count_ones())
             );
+        }
+    }
+
+    #[test]
+    fn test_pdep64() {
+        let mut rng = StdRng::seed_from_u64(0xdeadbeef);
+        for _ in 0..100 {
+            let x = rng.random();
+            let y: u64 = rng.random();
+            assert_eq!(naive_pdep64(x, y), pdep64_polyfill(x, y, y.count_ones()));
+
+            assert_eq!(naive_pdep64(0, y), pdep64_polyfill(0, y, y.count_ones()));
+            assert_eq!(
+                naive_pdep64(u64::MAX, y),
+                pdep64_polyfill(u64::MAX, y, y.count_ones())
+            );
+            assert_eq!(naive_pdep64(x, 0), pdep64_polyfill(x, 0, 0));
+            assert_eq!(naive_pdep64(x, u64::MAX), pdep64_polyfill(x, u64::MAX, 64));
+        }
+    }
+
+    #[test]
+    fn test_expand_boolean_kernel() {
+        let mask: Bitmap = [false, true, true, false, true, false]
+            .into_iter()
+            .collect();
+        let values: Bitmap = [true, false, true].into_iter().collect();
+        let expected: Bitmap = [false, true, false, false, true, false]
+            .into_iter()
+            .collect();
+        assert_eq!(expand_boolean_kernel(&values, &mask), expected);
+
+        let mut rng = StdRng::seed_from_u64(0xc0ffee);
+        for len in [0, 1, 7, 8, 55, 56, 57, 63, 64, 65, 127, 128, 129, 257] {
+            for mask_offset in 0..8 {
+                let mask_storage: Bitmap =
+                    (0..len + mask_offset + 8).map(|_| rng.random()).collect();
+                let mask = mask_storage.sliced(mask_offset, len);
+                let num_values = mask.set_bits();
+
+                for values_offset in 0..8 {
+                    let values_storage: Bitmap = (0..num_values + values_offset + 8)
+                        .map(|_| rng.random())
+                        .collect();
+                    let values = values_storage.sliced(values_offset, num_values);
+                    let expected = naive_expand(&values, &mask);
+
+                    assert_eq!(expand_boolean_kernel(&values, &mask), expected);
+                    assert_eq!(
+                        expand_boolean_kernel_impl(&values, &mask, pdep64_polyfill),
+                        expected,
+                    );
+                    assert_eq!(filter_boolean_kernel(&expected, &mask), values);
+                }
+
+                let original_storage: Bitmap =
+                    (0..len + mask_offset + 8).map(|_| rng.random()).collect();
+                let original = original_storage.sliced(mask_offset, len);
+                let compressed = filter_boolean_kernel(&original, &mask);
+                let expanded = expand_boolean_kernel(&compressed, &mask);
+                assert_eq!(expanded, &original & &mask);
+            }
         }
     }
 }

--- a/crates/polars-compute/src/filter/mod.rs
+++ b/crates/polars-compute/src/filter/mod.rs
@@ -13,7 +13,7 @@ use arrow::array::{
 use arrow::bitmap::Bitmap;
 use arrow::bitmap::utils::SlicesIterator;
 use arrow::with_match_primitive_type_full;
-pub use boolean::filter_boolean_kernel;
+pub use boolean::{expand_boolean_kernel, filter_boolean_kernel};
 
 pub fn filter(array: &dyn Array, mask: &BooleanArray) -> Box<dyn Array> {
     assert_eq!(array.len(), mask.len());

--- a/crates/polars-io/src/predicates.rs
+++ b/crates/polars-io/src/predicates.rs
@@ -403,7 +403,8 @@ pub trait SkipBatchPredicate: Send + Sync {
 pub struct ColumnPredicates {
     pub predicates:
         PlHashMap<PlSmallStr, (Arc<dyn PhysicalIoExpr>, Option<SpecializedColumnPredicate>)>,
-    pub is_sumwise_complete: bool,
+    /// The part of the scan predicate not represented by `predicates`.
+    pub residual_predicate: Option<Arc<dyn PhysicalIoExpr>>,
 }
 
 // I want to be explicit here.
@@ -412,7 +413,7 @@ impl Default for ColumnPredicates {
     fn default() -> Self {
         Self {
             predicates: PlHashMap::default(),
-            is_sumwise_complete: false,
+            residual_predicate: None,
         }
     }
 }
@@ -465,7 +466,7 @@ pub struct ScanIOPredicate {
     /// A predicate that gets given statistics and evaluates whether a batch can be skipped.
     pub skip_batch_predicate: Option<Arc<dyn SkipBatchPredicate>>,
 
-    /// A predicate that gets given statistics and evaluates whether a batch can be skipped.
+    /// Per-column predicates and a residual predicate for columnar formats.
     pub column_predicates: Arc<ColumnPredicates>,
 
     /// Predicate parts only referring to hive columns.
@@ -509,12 +510,21 @@ impl ScanIOPredicate {
         for (c, _) in constant_columns.iter() {
             column_predicates.predicates.remove(c);
         }
-        self.column_predicates = Arc::new(column_predicates);
-
         self.predicate = Arc::new(PhysicalExprWithConstCols {
-            constants: constant_columns,
+            constants: constant_columns.clone(),
             child: self.predicate.clone(),
         });
+
+        column_predicates.residual_predicate =
+            column_predicates
+                .residual_predicate
+                .map(|residual_predicate| {
+                    Arc::new(PhysicalExprWithConstCols {
+                        constants: constant_columns,
+                        child: residual_predicate,
+                    }) as Arc<dyn PhysicalIoExpr>
+                });
+        self.column_predicates = Arc::new(column_predicates);
     }
 }
 

--- a/crates/polars-mem-engine/src/scan_predicate/functions.rs
+++ b/crates/polars-mem-engine/src/scan_predicate/functions.rs
@@ -161,12 +161,18 @@ pub fn create_scan_predicate(
                 );
             }
             eprintln!("  ],");
-            eprintln!(
-                "  is_sumwise_complete: {}",
-                column_predicates.is_sumwise_complete
-            );
+            if let Some(residual_predicate) = column_predicates.residual_predicate {
+                eprintln!(
+                    "  residual: {},",
+                    ExprIRDisplay::display_node(residual_predicate, expr_arena)
+                );
+            }
             eprintln!("}}");
         }
+        let residual_predicate = column_predicates.residual_predicate.map(|node| {
+            debug_assert_eq!(node, predicate.node());
+            phys_predicate.clone()
+        });
         PhysicalColumnPredicates {
             predicates: column_predicates
                 .predicates
@@ -186,12 +192,12 @@ pub fn create_scan_predicate(
                     ))
                 })
                 .collect::<PolarsResult<PlHashMap<_, _>>>()?,
-            is_sumwise_complete: column_predicates.is_sumwise_complete,
+            residual_predicate,
         }
     } else {
         PhysicalColumnPredicates {
             predicates: PlHashMap::default(),
-            is_sumwise_complete: false,
+            residual_predicate: Some(phys_predicate.clone()),
         }
     };
 

--- a/crates/polars-mem-engine/src/scan_predicate/functions.rs
+++ b/crates/polars-mem-engine/src/scan_predicate/functions.rs
@@ -169,10 +169,17 @@ pub fn create_scan_predicate(
             }
             eprintln!("}}");
         }
-        let residual_predicate = column_predicates.residual_predicate.map(|node| {
-            debug_assert_eq!(node, predicate.node());
-            phys_predicate.clone()
-        });
+        let residual_predicate = column_predicates
+            .residual_predicate
+            .map(|node| {
+                create_physical_expr(
+                    &ExprIR::new(node, OutputName::Alias(PlSmallStr::EMPTY)),
+                    expr_arena,
+                    schema,
+                    state,
+                )
+            })
+            .transpose()?;
         PhysicalColumnPredicates {
             predicates: column_predicates
                 .predicates

--- a/crates/polars-mem-engine/src/scan_predicate/mod.rs
+++ b/crates/polars-mem-engine/src/scan_predicate/mod.rs
@@ -34,7 +34,7 @@ pub struct ScanPredicate {
     /// `false` even when the batch could theoretically be skipped.
     pub skip_batch_predicate: Option<Arc<dyn PhysicalExpr>>,
 
-    /// Partial predicates for each column for filter when loading columnar formats.
+    /// Per-column predicates and a residual predicate for columnar formats.
     pub column_predicates: PhysicalColumnPredicates,
 
     /// Predicate only referring to hive columns.
@@ -52,7 +52,7 @@ impl fmt::Debug for ScanPredicate {
 pub struct PhysicalColumnPredicates {
     pub predicates:
         PlHashMap<PlSmallStr, (Arc<dyn PhysicalExpr>, Option<SpecializedColumnPredicate>)>,
-    pub is_sumwise_complete: bool,
+    pub residual_predicate: Option<Arc<dyn PhysicalExpr>>,
 }
 
 /// Helper to implement [`SkipBatchPredicate`].
@@ -122,7 +122,7 @@ impl ScanPredicate {
                 Default::default()
             });
 
-        let predicate_constants = constant_columns
+        let predicate_constants: Vec<_> = constant_columns
             .filter_map(|(name, scalar): (PlSmallStr, Scalar)| {
                 if !live_columns.swap_remove(&name) {
                     return None;
@@ -149,7 +149,7 @@ impl ScanPredicate {
             .collect();
 
         let predicate = Arc::new(PhysicalExprWithConstCols {
-            constants: predicate_constants,
+            constants: predicate_constants.clone(),
             child: self.predicate.clone(),
         });
         let skip_batch_predicate = self.skip_batch_predicate.as_ref().map(|skp| {
@@ -159,12 +159,22 @@ impl ScanPredicate {
             }) as _
         });
 
+        let mut column_predicates = self.column_predicates.clone();
+        column_predicates.residual_predicate =
+            column_predicates
+                .residual_predicate
+                .map(|residual_predicate| {
+                    Arc::new(PhysicalExprWithConstCols {
+                        constants: predicate_constants,
+                        child: residual_predicate,
+                    }) as Arc<dyn PhysicalExpr>
+                });
+
         Self {
             predicate,
             live_columns: Arc::new(live_columns),
             skip_batch_predicate,
-            column_predicates: self.column_predicates.clone(), // Q? Maybe this should cull
-            // predicates.
+            column_predicates,
             hive_predicate: None,
             hive_predicate_is_full_predicate: false,
         }
@@ -200,7 +210,11 @@ impl ScanPredicate {
                     .iter()
                     .map(|(n, (p, s))| (n.clone(), (phys_expr_to_io_expr(p.clone()), s.clone())))
                     .collect(),
-                is_sumwise_complete: self.column_predicates.is_sumwise_complete,
+                residual_predicate: self
+                    .column_predicates
+                    .residual_predicate
+                    .clone()
+                    .map(phys_expr_to_io_expr),
             }),
             hive_predicate: self.hive_predicate.clone().map(phys_expr_to_io_expr),
             hive_predicate_is_full_predicate: self.hive_predicate_is_full_predicate,

--- a/crates/polars-plan/src/plans/aexpr/predicates/column_expr.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/column_expr.rs
@@ -32,7 +32,7 @@ pub fn aexpr_to_column_predicates(
 ) -> ColumnPredicates {
     let mut predicates =
         PlIndexMap::<PlSmallStr, (Node, Option<SpecializedColumnPredicate>)>::default();
-    let mut has_residual = false;
+    let mut residual_predicates = Vec::new();
 
     let minterms = MintermIter::new(root, expr_arena).collect::<Vec<_>>();
 
@@ -42,13 +42,13 @@ pub fn aexpr_to_column_predicates(
         leaf_names.extend(aexpr_to_leaf_names_iter(minterm, expr_arena).cloned());
 
         if leaf_names.len() != 1 {
-            has_residual = true;
+            residual_predicates.push(minterm);
             continue;
         }
 
         let column = leaf_names.pop().unwrap();
         let Some(dtype) = schema.get(&column) else {
-            has_residual = true;
+            residual_predicates.push(minterm);
             continue;
         };
 
@@ -57,30 +57,30 @@ pub fn aexpr_to_column_predicates(
         match dtype {
             #[cfg(feature = "dtype-categorical")]
             D::Enum(_, _) | D::Categorical(_, _) => {
-                has_residual = true;
+                residual_predicates.push(minterm);
                 continue;
             },
             #[cfg(feature = "dtype-decimal")]
             D::Decimal(_, _) => {
-                has_residual = true;
+                residual_predicates.push(minterm);
                 continue;
             },
             #[cfg(feature = "object")]
             D::Object(_) => {
-                has_residual = true;
+                residual_predicates.push(minterm);
                 continue;
             },
             #[cfg(feature = "dtype-f16")]
             D::Float16 => {
-                has_residual = true;
+                residual_predicates.push(minterm);
                 continue;
             },
             D::Float32 | D::Float64 => {
-                has_residual = true;
+                residual_predicates.push(minterm);
                 continue;
             },
             _ if dtype.is_nested() => {
-                has_residual = true;
+                residual_predicates.push(minterm);
                 continue;
             },
             _ => {},
@@ -293,12 +293,13 @@ pub fn aexpr_to_column_predicates(
             });
     }
 
-    // All-or-nothing classification. Either we can evaluate everything
-    // per-column or we can evaluate nothing per-column.
-    let residual_predicate = has_residual.then_some(root);
-    if residual_predicate.is_some() {
-        predicates.clear();
-    }
+    let residual_predicate = residual_predicates.into_iter().reduce(|left, right| {
+        expr_arena.add(AExpr::BinaryExpr {
+            left,
+            op: Operator::LogicalAnd,
+            right,
+        })
+    });
 
     ColumnPredicates {
         predicates,
@@ -393,6 +394,45 @@ mod tests {
         };
         assert_eq!(col_name, col_name2);
         Ok(predicate)
+    }
+
+    #[test]
+    fn splits_eager_and_residual_predicates() -> PolarsResult<()> {
+        let mut arena = Arena::new();
+        let schema = Schema::from_iter_check_duplicates([
+            ("integer".into(), DataType::Int64),
+            ("float_a".into(), DataType::Float64),
+            ("float_b".into(), DataType::Float64),
+        ])?;
+        let mut ctx = ExprToIRContext::new(&mut arena, &schema);
+        let expr = col("integer")
+            .gt(typed_lit(1i64))
+            .and(col("float_a").lt(typed_lit(3.0f64)))
+            .and(col("float_b").gt(typed_lit(0.0f64)));
+        let expr_ir = to_expr_ir(expr, &mut ctx)?;
+
+        let column_predicates = aexpr_to_column_predicates(expr_ir.node(), &mut arena, &schema);
+
+        assert_eq!(
+            column_predicates
+                .predicates
+                .keys()
+                .map(PlSmallStr::as_str)
+                .collect::<Vec<_>>(),
+            ["integer"],
+        );
+
+        let residual_predicate = column_predicates.residual_predicate.unwrap();
+        assert_ne!(residual_predicate, expr_ir.node());
+        assert_eq!(
+            MintermIter::new(residual_predicate, &arena)
+                .flat_map(|node| aexpr_to_leaf_names_iter(node, &arena))
+                .map(PlSmallStr::as_str)
+                .collect::<Vec<_>>(),
+            ["float_a", "float_b"],
+        );
+
+        Ok(())
     }
 
     #[test]

--- a/crates/polars-plan/src/plans/aexpr/predicates/column_expr.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/column_expr.rs
@@ -1,4 +1,5 @@
-//! This module creates predicates splits predicates into partial per-column predicates.
+//! This module splits incoming predicates into per-column predicates and a
+//! residual predicate that must be evaluated after decode/filtering.
 
 use polars_core::datatypes::DataType;
 use polars_core::prelude::AnyValue;
@@ -20,8 +21,8 @@ use crate::plans::{
 pub struct ColumnPredicates {
     pub predicates: PlIndexMap<PlSmallStr, (Node, Option<SpecializedColumnPredicate>)>,
 
-    /// Are all column predicates AND-ed together the original predicate.
-    pub is_sumwise_complete: bool,
+    /// The part of the original predicate not represented by `predicates`.
+    pub residual_predicate: Option<Node>,
 }
 
 pub fn aexpr_to_column_predicates(
@@ -31,7 +32,7 @@ pub fn aexpr_to_column_predicates(
 ) -> ColumnPredicates {
     let mut predicates =
         PlIndexMap::<PlSmallStr, (Node, Option<SpecializedColumnPredicate>)>::default();
-    let mut is_sumwise_complete = true;
+    let mut has_residual = false;
 
     let minterms = MintermIter::new(root, expr_arena).collect::<Vec<_>>();
 
@@ -41,13 +42,13 @@ pub fn aexpr_to_column_predicates(
         leaf_names.extend(aexpr_to_leaf_names_iter(minterm, expr_arena).cloned());
 
         if leaf_names.len() != 1 {
-            is_sumwise_complete = false;
+            has_residual = true;
             continue;
         }
 
         let column = leaf_names.pop().unwrap();
         let Some(dtype) = schema.get(&column) else {
-            is_sumwise_complete = false;
+            has_residual = true;
             continue;
         };
 
@@ -56,30 +57,30 @@ pub fn aexpr_to_column_predicates(
         match dtype {
             #[cfg(feature = "dtype-categorical")]
             D::Enum(_, _) | D::Categorical(_, _) => {
-                is_sumwise_complete = false;
+                has_residual = true;
                 continue;
             },
             #[cfg(feature = "dtype-decimal")]
             D::Decimal(_, _) => {
-                is_sumwise_complete = false;
+                has_residual = true;
                 continue;
             },
             #[cfg(feature = "object")]
             D::Object(_) => {
-                is_sumwise_complete = false;
+                has_residual = true;
                 continue;
             },
             #[cfg(feature = "dtype-f16")]
             D::Float16 => {
-                is_sumwise_complete = false;
+                has_residual = true;
                 continue;
             },
             D::Float32 | D::Float64 => {
-                is_sumwise_complete = false;
+                has_residual = true;
                 continue;
             },
             _ if dtype.is_nested() => {
-                is_sumwise_complete = false;
+                has_residual = true;
                 continue;
             },
             _ => {},
@@ -292,9 +293,16 @@ pub fn aexpr_to_column_predicates(
             });
     }
 
+    // All-or-nothing classification. Either we can evaluate everything
+    // per-column or we can evaluate nothing per-column.
+    let residual_predicate = has_residual.then_some(root);
+    if residual_predicate.is_some() {
+        predicates.clear();
+    }
+
     ColumnPredicates {
         predicates,
-        is_sumwise_complete,
+        residual_predicate,
     }
 }
 
@@ -373,6 +381,7 @@ mod tests {
         let mut ctx = ExprToIRContext::new(&mut arena, &schema);
         let expr_ir = to_expr_ir(expr, &mut ctx)?;
         let column_predicates = aexpr_to_column_predicates(expr_ir.node(), &mut arena, &schema);
+        assert!(column_predicates.residual_predicate.is_none());
         assert_eq!(column_predicates.predicates.len(), 1);
         let Some((col_name2, (_, predicate))) =
             column_predicates.predicates.clone().into_iter().next()

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/tasks/reader_starter.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/tasks/reader_starter.rs
@@ -599,7 +599,10 @@ async fn start_reader_impl(
                                 .unwrap_or_else(|| Scalar::null(dtype.clone())),
                         ));
 
-                        Arc::make_mut(&mut predicate.column_predicates).is_sumwise_complete = false;
+                        let residual_predicate = predicate.predicate.clone();
+                        let column_predicates = Arc::make_mut(&mut predicate.column_predicates);
+                        column_predicates.predicates.clear();
+                        column_predicates.residual_predicate = Some(residual_predicate);
                     }
                 },
                 MissingColumnsPolicy::Raise => return Err(missing_column_err(missing_col_name)),

--- a/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
@@ -10,7 +10,7 @@ use polars_io::prelude::ParallelStrategy;
 use polars_utils::IdxSize;
 
 use super::row_group_data_fetch::RowGroupDataFetcher;
-use super::row_group_decode::RowGroupDecoder;
+use super::row_group_decode::{ProjectedFieldClassification, RowGroupDecoder};
 use super::{AsyncTaskData, ParquetReadImpl};
 use crate::morsel::{Morsel, SourceToken, get_ideal_morsel_size};
 use crate::nodes::io_sources::multi_scan::reader_interface::output::FileReaderOutputSend;
@@ -326,41 +326,50 @@ impl ParquetReadImpl {
         use_prefiltered |=
             predicate.is_some() && matches!(self.options.parallel, ParallelStrategy::Auto);
 
-        let predicate_field_indices: Arc<[usize]> =
-            if use_prefiltered && let Some(predicate) = predicate.as_ref() {
-                projected_arrow_fields
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(i, projected_field)| {
-                        predicate
-                            .live_columns
-                            .contains(projected_field.output_name())
-                            .then_some(i)
-                    })
-                    .collect()
-            } else {
-                Default::default()
-            };
+        let mut eager_predicate = Vec::new();
+        let mut additional_predicate = Vec::new();
+        let mut live_predicate = Vec::new();
+
+        if use_prefiltered && let Some(predicate) = predicate.as_ref() {
+            for (i, projected_field) in projected_arrow_fields.iter().enumerate() {
+                let name = projected_field.output_name();
+                if !predicate.live_columns.contains(name) {
+                    continue;
+                }
+
+                live_predicate.push(i);
+                if predicate.column_predicates.predicates.contains_key(name) {
+                    eager_predicate.push(i);
+                } else {
+                    additional_predicate.push(i);
+                }
+            }
+        }
 
         let use_prefiltered = use_prefiltered.then(PrefilterMaskSetting::init_from_env);
 
-        let non_predicate_field_indices: Arc<[usize]> = if use_prefiltered.is_some() {
-            filtered_range(
-                predicate_field_indices.as_ref(),
-                projected_arrow_fields.len(),
-            )
-            .collect()
+        let payload: Arc<[usize]> = if use_prefiltered.is_some() {
+            filtered_range(live_predicate.as_slice(), projected_arrow_fields.len()).collect()
         } else {
             Default::default()
         };
 
         if use_prefiltered.is_some() && self.verbose {
             eprintln!(
-                "[ParquetFileReader]: Pre-filtered decode enabled ({} live, {} non-live)",
-                predicate_field_indices.len(),
-                non_predicate_field_indices.len()
+                "[ParquetFileReader]: Pre-filtered decode enabled ({} live, {} eager, {} additional, {} payload)",
+                live_predicate.len(),
+                eager_predicate.len(),
+                additional_predicate.len(),
+                payload.len()
             )
         }
+
+        let prefiltered_field_indices = ProjectedFieldClassification {
+            live_predicate: live_predicate.into(),
+            eager_predicate: eager_predicate.into(),
+            additional_predicate: additional_predicate.into(),
+            payload,
+        };
 
         let allow_column_predicates = predicate.as_ref().is_some_and(|p| {
             p.column_predicates.residual_predicate.is_none()
@@ -381,8 +390,7 @@ impl ParquetReadImpl {
             predicate,
             allow_column_predicates,
             use_prefiltered,
-            predicate_field_indices,
-            non_predicate_field_indices,
+            projected_field_classification: prefiltered_field_indices,
             target_values_per_thread,
         }
     }

--- a/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
@@ -363,7 +363,7 @@ impl ParquetReadImpl {
         }
 
         let allow_column_predicates = predicate.as_ref().is_some_and(|p| {
-            p.column_predicates.is_sumwise_complete
+            p.column_predicates.residual_predicate.is_none()
                 && !projected_arrow_fields.iter().any(|f| {
                     matches!(f.arrow_field().dtype(), ArrowDataType::FixedSizeBinary(_))
                         && p.column_predicates.predicates.contains_key(f.output_name())

--- a/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
@@ -372,11 +372,10 @@ impl ParquetReadImpl {
         };
 
         let allow_column_predicates = predicate.as_ref().is_some_and(|p| {
-            p.column_predicates.residual_predicate.is_none()
-                && !projected_arrow_fields.iter().any(|f| {
-                    matches!(f.arrow_field().dtype(), ArrowDataType::FixedSizeBinary(_))
-                        && p.column_predicates.predicates.contains_key(f.output_name())
-                })
+            !projected_arrow_fields.iter().any(|f| {
+                matches!(f.arrow_field().dtype(), ArrowDataType::FixedSizeBinary(_))
+                    && p.column_predicates.predicates.contains_key(f.output_name())
+            })
         }) && row_index.is_none()
             && !projected_arrow_fields.iter().any(|x| {
                 x.arrow_field().dtype().is_nested()

--- a/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
@@ -493,7 +493,12 @@ impl RowGroupDecoder {
         }
 
         let (live_df_filtered, mut mask) = if use_column_predicates {
-            assert!(scan_predicate.column_predicates.is_sumwise_complete);
+            assert!(
+                scan_predicate
+                    .column_predicates
+                    .residual_predicate
+                    .is_none()
+            );
             if let [mask] = masks.as_slice() {
                 (
                     unsafe { DataFrame::new_unchecked_infer_height(live_columns) },
@@ -529,7 +534,17 @@ impl RowGroupDecoder {
                 DataFrame::new_unchecked(row_group_data.row_group_metadata.num_rows(), live_columns)
             };
 
-            let mask = scan_predicate.predicate.evaluate_io(&live_df)?;
+            // We can be in this branch either because we have a residual
+            // predicate to handle, or reader-level limitations disabled
+            // column predicates (for example, we have Float16 types). Thus
+            // we first check if we have a residual and if not, pick up the
+            // full predicate.
+            let mask = scan_predicate
+                .column_predicates
+                .residual_predicate
+                .as_ref()
+                .unwrap_or(&scan_predicate.predicate)
+                .evaluate_io(&live_df)?;
             let mask = mask.bool().unwrap();
 
             unsafe {

--- a/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
@@ -20,6 +20,25 @@ use polars_utils::{IdxSize, UnitVec};
 use super::row_group_data_fetch::RowGroupData;
 use crate::nodes::io_sources::parquet::projection::ArrowFieldProjection;
 
+/// Classification of projected fields. Each entry must individually be
+/// sorted in increasing order.
+/// Invariants:
+/// live_predicate = eager_predicate ∪ additional_predicate
+/// eager_predicate ∩ additional_predicate = ∅
+/// live_predicate ∪ payload = {0, ..., projected_arrow_fields.len() - 1}
+#[derive(Default)]
+pub(super) struct ProjectedFieldClassification {
+    /// All fields needed to evaluate the complete predicate.
+    pub(super) live_predicate: Arc<[usize]>,
+    /// Predicate fields that can be decoded with a column predicate.
+    pub(super) eager_predicate: Arc<[usize]>,
+    /// Additional fields, not in eager_predicate, that are needed to
+    /// evaluate the full predicate.
+    pub(super) additional_predicate: Arc<[usize]>,
+    /// Projected fields that are not needed to evaluate the predicate.
+    pub(super) payload: Arc<[usize]>,
+}
+
 /// Turns row group data into DataFrames.
 pub(super) struct RowGroupDecoder {
     pub(super) num_pipelines: usize,
@@ -28,10 +47,7 @@ pub(super) struct RowGroupDecoder {
     pub(super) row_index: Option<RowIndex>,
     pub(super) predicate: Option<ScanIOPredicate>,
     pub(super) use_prefiltered: Option<PrefilterMaskSetting>,
-    /// Indices into `projected_arrow_fields. This must be sorted.
-    pub(super) predicate_field_indices: Arc<[usize]>,
-    /// Indices into `projected_arrow_fields. This must be sorted.
-    pub(super) non_predicate_field_indices: Arc<[usize]>,
+    pub(super) projected_field_classification: ProjectedFieldClassification,
     pub(super) target_values_per_thread: usize,
 }
 
@@ -48,7 +64,10 @@ impl RowGroupDecoder {
 
         if self.use_prefiltered.is_some()
             && row_group_data.slice.is_none()
-            && !self.predicate_field_indices.is_empty()
+            && !self
+                .projected_field_classification
+                .live_predicate
+                .is_empty()
         {
             self.row_group_data_to_df_prefiltered(row_group_data).await
         } else {
@@ -159,8 +178,9 @@ impl RowGroupDecoder {
 
         // Ensure we provide the same output column order as the pre-filtered decode.
         let get_projected_field_at_output_index = {
-            let predicate_field_indices = self.predicate_field_indices.clone();
-            let non_predicate_field_indices = self.non_predicate_field_indices.clone();
+            let predicate_field_indices =
+                self.projected_field_classification.live_predicate.clone();
+            let payload_field_indices = self.projected_field_classification.payload.clone();
 
             move |i: usize| {
                 if predicate_field_indices.is_empty() {
@@ -168,7 +188,7 @@ impl RowGroupDecoder {
                 } else if i < predicate_field_indices.len() {
                     predicate_field_indices[i]
                 } else {
-                    non_predicate_field_indices[i - predicate_field_indices.len()]
+                    payload_field_indices[i - predicate_field_indices.len()]
                 }
             }
         };
@@ -396,18 +416,30 @@ impl RowGroupDecoder {
         row_group_data: RowGroupData,
     ) -> PolarsResult<DataFrame> {
         debug_assert!(row_group_data.slice.is_none()); // Invariant of the optimizer.
-        assert!(self.predicate_field_indices.len() <= self.projected_arrow_fields.len());
+        debug_assert_eq!(
+            self.projected_field_classification.live_predicate.len(),
+            self.projected_field_classification.eager_predicate.len()
+                + self
+                    .projected_field_classification
+                    .additional_predicate
+                    .len(),
+        );
+        assert!(
+            self.projected_field_classification.live_predicate.len()
+                <= self.projected_arrow_fields.len()
+        );
 
         let row_group_data = Arc::new(row_group_data);
         let projection_height = row_group_data.row_group_metadata.num_rows();
 
         let mut live_columns = Vec::with_capacity(
             self.row_index.is_some() as usize
-                + self.predicate_field_indices.len()
-                + self.non_predicate_field_indices.len(),
+                + self.projected_field_classification.live_predicate.len()
+                + self.projected_field_classification.payload.len(),
         );
         let mut masks = Vec::with_capacity(
-            self.row_index.is_some() as usize + self.predicate_field_indices.len(),
+            self.row_index.is_some() as usize
+                + self.projected_field_classification.live_predicate.len(),
         );
 
         if let Some(s) = self.materialize_row_index(
@@ -432,18 +464,20 @@ impl RowGroupDecoder {
                 });
 
         let cols_per_thread = (self
-            .predicate_field_indices
+            .projected_field_classification
+            .live_predicate
             .len()
             .div_ceil(self.num_pipelines))
         .max(1);
         let task_handles = {
-            let predicate_field_indices = self.predicate_field_indices.clone();
+            let predicate_field_indices =
+                self.projected_field_classification.live_predicate.clone();
             let projected_arrow_fields = self.projected_arrow_fields.clone();
             let row_group_data = row_group_data.clone();
 
             parallelize_first_to_local(
                 TaskPriority::Low,
-                (0..self.predicate_field_indices.len())
+                (0..self.projected_field_classification.live_predicate.len())
                     .step_by(cols_per_thread)
                     .map(move |offset| {
                         let row_group_data = row_group_data.clone();
@@ -549,7 +583,8 @@ impl RowGroupDecoder {
 
             unsafe {
                 live_df.columns_mut().truncate(
-                    self.row_index.is_some() as usize + self.predicate_field_indices.len(),
+                    self.row_index.is_some() as usize
+                        + self.projected_field_classification.live_predicate.len(),
                 )
             }
 
@@ -568,7 +603,7 @@ impl RowGroupDecoder {
             )
         };
 
-        if self.non_predicate_field_indices.is_empty() {
+        if self.projected_field_classification.payload.is_empty() {
             // User or test may have explicitly requested prefiltering
             return Ok(live_df_filtered);
         }
@@ -585,36 +620,34 @@ impl RowGroupDecoder {
         let expected_num_rows = mask_bitmap.set_bits();
 
         let cols_per_thread = (self
-            .predicate_field_indices
+            .projected_field_classification
+            .live_predicate
             .len()
             .div_ceil(self.num_pipelines))
         .max(1);
 
         let task_handles = {
-            let non_predicate_field_indices = self.non_predicate_field_indices.clone();
-            let non_predicate_len = non_predicate_field_indices.len();
+            let payload_field_indices = self.projected_field_classification.payload.clone();
+            let payload_len = payload_field_indices.len();
             let projected_arrow_fields = self.projected_arrow_fields.clone();
             let row_group_data = row_group_data.clone();
 
             parallelize_first_to_local(
                 TaskPriority::Low,
-                (0..non_predicate_len)
+                (0..payload_len)
                     .step_by(cols_per_thread)
                     .map(move |offset| {
                         let row_group_data = row_group_data.clone();
-                        let non_predicate_field_indices = non_predicate_field_indices.clone();
+                        let payload_field_indices = payload_field_indices.clone();
                         let projected_arrow_fields = projected_arrow_fields.clone();
                         let mask = mask.clone();
                         let mask_bitmap = mask_bitmap.clone();
 
                         async move {
-                            (offset
-                                ..offset
-                                    .saturating_add(cols_per_thread)
-                                    .min(non_predicate_len))
+                            (offset..offset.saturating_add(cols_per_thread).min(payload_len))
                                 .map(|i| {
                                     let projection =
-                                        &projected_arrow_fields[non_predicate_field_indices[i]];
+                                        &projected_arrow_fields[payload_field_indices[i]];
 
                                     let col = decode_column_prefiltered(
                                         projection.arrow_field(),
@@ -636,7 +669,7 @@ impl RowGroupDecoder {
 
         let live_columns = live_df_filtered.into_columns();
 
-        let mut dead_cols = Vec::with_capacity(self.non_predicate_field_indices.len());
+        let mut dead_cols = Vec::with_capacity(self.projected_field_classification.payload.len());
         for fut in task_handles {
             dead_cols.extend(fut.await?);
         }

--- a/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
@@ -568,17 +568,9 @@ impl RowGroupDecoder {
                 DataFrame::new_unchecked(row_group_data.row_group_metadata.num_rows(), live_columns)
             };
 
-            // We can be in this branch either because we have a residual
-            // predicate to handle, or reader-level limitations disabled
-            // column predicates (for example, we have Float16 types). Thus
-            // we first check if we have a residual and if not, pick up the
-            // full predicate.
-            let mask = scan_predicate
-                .column_predicates
-                .residual_predicate
-                .as_ref()
-                .unwrap_or(&scan_predicate.predicate)
-                .evaluate_io(&live_df)?;
+            // No column predicates were applied in this branch. Evaluate the complete predicate,
+            // even if part of it was classified as a residual predicate.
+            let mask = scan_predicate.predicate.evaluate_io(&live_df)?;
             let mask = mask.bool().unwrap();
 
             unsafe {

--- a/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
@@ -526,7 +526,7 @@ impl RowGroupDecoder {
             }
         }
 
-        let (live_df_filtered, mut mask) = if use_column_predicates {
+        let (live_df_filtered, mask) = if use_column_predicates {
             assert!(
                 scan_predicate
                     .column_predicates
@@ -595,11 +595,22 @@ impl RowGroupDecoder {
             )
         };
 
+        self.finish_prefiltered_decode(row_group_data, live_df_filtered, mask)
+            .await
+    }
+
+    async fn finish_prefiltered_decode(
+        &self,
+        row_group_data: Arc<RowGroupData>,
+        live_df_filtered: DataFrame,
+        mut mask: BooleanChunked,
+    ) -> PolarsResult<DataFrame> {
         if self.projected_field_classification.payload.is_empty() {
             // User or test may have explicitly requested prefiltering
             return Ok(live_df_filtered);
         }
 
+        let projection_height = row_group_data.row_group_metadata.num_rows();
         mask.rechunk_mut();
         let mask_bitmap = mask.downcast_as_array();
         let mask_bitmap = match mask_bitmap.validity() {
@@ -611,65 +622,82 @@ impl RowGroupDecoder {
 
         let expected_num_rows = mask_bitmap.set_bits();
 
+        let payload_columns = self
+            .decode_columns_prefiltered(
+                row_group_data,
+                self.projected_field_classification.payload.clone(),
+                &mask,
+                &mask_bitmap,
+                expected_num_rows,
+            )
+            .await?;
+
+        let live_columns = live_df_filtered.into_columns();
+
+        let mut merged = live_columns;
+        merged.extend(payload_columns);
+        let df = unsafe { DataFrame::new_unchecked(expected_num_rows, merged) };
+        Ok(df)
+    }
+
+    async fn decode_columns_prefiltered(
+        &self,
+        row_group_data: Arc<RowGroupData>,
+        field_indices: Arc<[usize]>,
+        mask: &BooleanChunked,
+        mask_bitmap: &Bitmap,
+        expected_num_rows: usize,
+    ) -> PolarsResult<Vec<Column>> {
+        let num_fields = field_indices.len();
         let cols_per_thread = (self
             .projected_field_classification
             .live_predicate
             .len()
             .div_ceil(self.num_pipelines))
         .max(1);
-
         let task_handles = {
-            let payload_field_indices = self.projected_field_classification.payload.clone();
-            let payload_len = payload_field_indices.len();
             let projected_arrow_fields = self.projected_arrow_fields.clone();
             let row_group_data = row_group_data.clone();
+            let mask = mask.clone();
+            let mask_bitmap = mask_bitmap.clone();
 
             parallelize_first_to_local(
                 TaskPriority::Low,
-                (0..payload_len)
-                    .step_by(cols_per_thread)
-                    .map(move |offset| {
-                        let row_group_data = row_group_data.clone();
-                        let payload_field_indices = payload_field_indices.clone();
-                        let projected_arrow_fields = projected_arrow_fields.clone();
-                        let mask = mask.clone();
-                        let mask_bitmap = mask_bitmap.clone();
+                (0..num_fields).step_by(cols_per_thread).map(move |offset| {
+                    let row_group_data = row_group_data.clone();
+                    let field_indices = field_indices.clone();
+                    let projected_arrow_fields = projected_arrow_fields.clone();
+                    let mask = mask.clone();
+                    let mask_bitmap = mask_bitmap.clone();
 
-                        async move {
-                            (offset..offset.saturating_add(cols_per_thread).min(payload_len))
-                                .map(|i| {
-                                    let projection =
-                                        &projected_arrow_fields[payload_field_indices[i]];
+                    async move {
+                        (offset..offset.saturating_add(cols_per_thread).min(num_fields))
+                            .map(|i| {
+                                let projection = &projected_arrow_fields[field_indices[i]];
 
-                                    let col = decode_column_prefiltered(
-                                        projection.arrow_field(),
-                                        row_group_data.as_ref(),
-                                        &mask,
-                                        &mask_bitmap,
-                                        expected_num_rows,
-                                    )?;
+                                let col = decode_column_prefiltered(
+                                    projection.arrow_field(),
+                                    row_group_data.as_ref(),
+                                    &mask,
+                                    &mask_bitmap,
+                                    expected_num_rows,
+                                )?;
 
-                                    projection.apply_transform(col)
-                                })
-                                .collect::<PolarsResult<UnitVec<_>>>()
-                        }
-                    }),
+                                projection.apply_transform(col)
+                            })
+                            .collect::<PolarsResult<UnitVec<_>>>()
+                    }
+                }),
             )
         };
 
         drop(row_group_data);
 
-        let live_columns = live_df_filtered.into_columns();
-
-        let mut dead_cols = Vec::with_capacity(self.projected_field_classification.payload.len());
+        let mut columns = Vec::with_capacity(num_fields);
         for fut in task_handles {
-            dead_cols.extend(fut.await?);
+            columns.extend(fut.await?);
         }
-
-        let mut merged = live_columns;
-        merged.extend(dead_cols);
-        let df = unsafe { DataFrame::new_unchecked(expected_num_rows, merged) };
-        Ok(df)
+        Ok(columns)
     }
 }
 

--- a/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
@@ -603,19 +603,22 @@ impl RowGroupDecoder {
                 let residual_mask = residual_predicate.evaluate_io(&live_df)?;
                 let mut residual_mask = residual_mask.bool().unwrap().clone();
                 let residual_mask_bitmap = materialize_mask(&mut residual_mask);
-                // Splat residual's mask back into row group coordinate
-                // space, anding with the eager bitmap.
-                let mask = BooleanChunked::from_bitmap(
-                    PlSmallStr::EMPTY,
-                    expand_boolean_kernel(&residual_mask_bitmap, &eager_mask_bitmap),
-                );
                 let live_columns = filter_cols(
                     live_df.into_columns(),
                     &residual_mask,
                     self.target_values_per_thread,
                 )
                 .await?;
-
+                let mask = if self.projected_field_classification.payload.is_empty() {
+                    None
+                } else {
+                    // Splat residual's mask back into row group coordinate
+                    // space, anding with the eager bitmap.
+                    Some(BooleanChunked::from_bitmap(
+                        PlSmallStr::EMPTY,
+                        expand_boolean_kernel(&residual_mask_bitmap, &eager_mask_bitmap),
+                    ))
+                };
                 (
                     unsafe {
                         DataFrame::new_unchecked(residual_mask_bitmap.set_bits(), live_columns)
@@ -623,7 +626,7 @@ impl RowGroupDecoder {
                     mask,
                 )
             } else {
-                (eager_df, eager_mask)
+                (eager_df, Some(eager_mask))
             }
         } else {
             let mut live_df = unsafe {
@@ -653,12 +656,17 @@ impl RowGroupDecoder {
 
             (
                 unsafe { DataFrame::new_unchecked(filtered_height, filtered) },
-                mask.clone(),
+                Some(mask.clone()),
             )
         };
 
-        self.finish_prefiltered_decode(row_group_data, live_df_filtered, mask)
-            .await
+        if self.projected_field_classification.payload.is_empty() {
+            Ok(live_df_filtered)
+        } else {
+            debug_assert!(mask.is_some());
+            self.finish_prefiltered_decode(row_group_data, live_df_filtered, mask.unwrap())
+                .await
+        }
     }
 
     async fn finish_prefiltered_decode(
@@ -667,11 +675,6 @@ impl RowGroupDecoder {
         live_df_filtered: DataFrame,
         mut mask: BooleanChunked,
     ) -> PolarsResult<DataFrame> {
-        if self.projected_field_classification.payload.is_empty() {
-            // User or test may have explicitly requested prefiltering
-            return Ok(live_df_filtered);
-        }
-
         let projection_height = row_group_data.row_group_metadata.num_rows();
         let mask_bitmap = materialize_mask(&mut mask);
 

--- a/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use polars_async::executor::TaskPriority;
 use polars_async::primitives::opt_spawned_future::parallelize_first_to_local;
+use polars_compute::filter::expand_boolean_kernel;
 use polars_core::frame::DataFrame;
 use polars_core::prelude::{ArrowField, BooleanChunked, ChunkFilter, Column, DataType, IntoColumn};
 use polars_core::series::Series;
@@ -452,6 +453,10 @@ impl RowGroupDecoder {
         let scan_predicate = self.predicate.as_ref().unwrap();
 
         let use_column_predicates = self.allow_column_predicates
+            && !self
+                .projected_field_classification
+                .eager_predicate
+                .is_empty()
             && !row_group_data
                 .row_group_metadata
                 .parquet_columns()
@@ -463,21 +468,19 @@ impl RowGroupDecoder {
                     )
                 });
 
-        let cols_per_thread = (self
-            .projected_field_classification
-            .live_predicate
-            .len()
-            .div_ceil(self.num_pipelines))
-        .max(1);
+        let predicate_field_indices = if use_column_predicates {
+            self.projected_field_classification.eager_predicate.clone()
+        } else {
+            self.projected_field_classification.live_predicate.clone()
+        };
+        let cols_per_thread = (predicate_field_indices.len().div_ceil(self.num_pipelines)).max(1);
         let task_handles = {
-            let predicate_field_indices =
-                self.projected_field_classification.live_predicate.clone();
             let projected_arrow_fields = self.projected_arrow_fields.clone();
             let row_group_data = row_group_data.clone();
 
             parallelize_first_to_local(
                 TaskPriority::Low,
-                (0..self.projected_field_classification.live_predicate.len())
+                (0..predicate_field_indices.len())
                     .step_by(cols_per_thread)
                     .map(move |offset| {
                         let row_group_data = row_group_data.clone();
@@ -527,13 +530,7 @@ impl RowGroupDecoder {
         }
 
         let (live_df_filtered, mask) = if use_column_predicates {
-            assert!(
-                scan_predicate
-                    .column_predicates
-                    .residual_predicate
-                    .is_none()
-            );
-            if let [mask] = masks.as_slice() {
+            let (eager_df, mut eager_mask) = if let [mask] = masks.as_slice() {
                 (
                     unsafe { DataFrame::new_unchecked_infer_height(live_columns) },
                     BooleanChunked::from_bitmap(PlSmallStr::EMPTY, mask.clone()),
@@ -562,6 +559,71 @@ impl RowGroupDecoder {
                     unsafe { DataFrame::new_unchecked_infer_height(live_columns) },
                     mask,
                 )
+            };
+
+            if let Some(residual_predicate) =
+                scan_predicate.column_predicates.residual_predicate.as_ref()
+            {
+                let eager_mask_bitmap = materialize_mask(&mut eager_mask);
+                let num_candidates = eager_mask_bitmap.set_bits();
+                let additional_columns = self
+                    .decode_columns_prefiltered(
+                        row_group_data.clone(),
+                        self.projected_field_classification
+                            .additional_predicate
+                            .clone(),
+                        &eager_mask,
+                        &eager_mask_bitmap,
+                        num_candidates,
+                    )
+                    .await?;
+
+                let mut live_columns = self
+                    .projected_field_classification
+                    .eager_predicate
+                    .iter()
+                    .copied()
+                    .zip(eager_df.into_columns())
+                    .chain(
+                        self.projected_field_classification
+                            .additional_predicate
+                            .iter()
+                            .copied()
+                            .zip(additional_columns),
+                    )
+                    .collect::<Vec<_>>();
+                live_columns.sort_unstable_by_key(|(field_idx, _)| *field_idx);
+                let live_df = unsafe {
+                    DataFrame::new_unchecked(
+                        num_candidates,
+                        live_columns.into_iter().map(|(_, column)| column).collect(),
+                    )
+                };
+
+                let residual_mask = residual_predicate.evaluate_io(&live_df)?;
+                let mut residual_mask = residual_mask.bool().unwrap().clone();
+                let residual_mask_bitmap = materialize_mask(&mut residual_mask);
+                // Splat residual's mask back into row group coordinate
+                // space, anding with the eager bitmap.
+                let mask = BooleanChunked::from_bitmap(
+                    PlSmallStr::EMPTY,
+                    expand_boolean_kernel(&residual_mask_bitmap, &eager_mask_bitmap),
+                );
+                let live_columns = filter_cols(
+                    live_df.into_columns(),
+                    &residual_mask,
+                    self.target_values_per_thread,
+                )
+                .await?;
+
+                (
+                    unsafe {
+                        DataFrame::new_unchecked(residual_mask_bitmap.set_bits(), live_columns)
+                    },
+                    mask,
+                )
+            } else {
+                (eager_df, eager_mask)
             }
         } else {
             let mut live_df = unsafe {
@@ -611,12 +673,7 @@ impl RowGroupDecoder {
         }
 
         let projection_height = row_group_data.row_group_metadata.num_rows();
-        mask.rechunk_mut();
-        let mask_bitmap = mask.downcast_as_array();
-        let mask_bitmap = match mask_bitmap.validity() {
-            None => mask_bitmap.values().clone(),
-            Some(v) => mask_bitmap.values() & v,
-        };
+        let mask_bitmap = materialize_mask(&mut mask);
 
         assert_eq!(mask_bitmap.len(), projection_height);
 
@@ -698,6 +755,15 @@ impl RowGroupDecoder {
             columns.extend(fut.await?);
         }
         Ok(columns)
+    }
+}
+
+fn materialize_mask(mask: &mut BooleanChunked) -> Bitmap {
+    mask.rechunk_mut();
+    let array = mask.downcast_as_array();
+    match array.validity() {
+        None => array.values().clone(),
+        Some(validity) => array.values() & validity,
     }
 }
 

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -1855,7 +1855,7 @@ def test_scan_iceberg_parquet_prefilter_with_column_mapping(
         "[ParquetFileReader]: Predicate pushdown: reading 1 / 1 row groups" in capture
     )
     assert (
-        "[ParquetFileReader]: Pre-filtered decode enabled (1 live, 1 non-live)"
+        "[ParquetFileReader]: Pre-filtered decode enabled (1 live, 1 eager, 0 additional, 1 payload)"
         in capture
     )
 

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -1122,7 +1122,7 @@ def test_scan_parquet_prefilter_with_cast(
         capture = capfd.readouterr().err
 
     assert (
-        "[ParquetFileReader]: Pre-filtered decode enabled (1 live, 1 non-live)"
+        "[ParquetFileReader]: Pre-filtered decode enabled (1 live, 1 eager, 0 additional, 1 payload)"
         in capture
     )
     assert (

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -1891,6 +1891,29 @@ def test_general_prefiltering(df: pl.DataFrame) -> None:
     assert_frame_equal(result, df.filter(expr))
 
 
+def test_prefiltering_with_residual_predicate() -> None:
+    df = pl.DataFrame(
+        {
+            "integer": [0, 1, 2, 3, 4, 5],
+            "float": [0.5, 1.5, 2.5, 3.5, None, 5.5],
+            "value": list(range(6)),
+        }
+    )
+    predicate = (pl.col("integer") > 1) & (pl.col("float") < 5.0)
+    f = io.BytesIO()
+    df.write_parquet(f, row_group_size=3)
+
+    f.seek(0)
+    result = (
+        pl.scan_parquet(f, parallel="prefiltered")
+        .filter(predicate)
+        .select("value")
+        .collect(engine="streaming")
+    )
+
+    assert_frame_equal(result, df.filter(predicate).select("value"))
+
+
 @given(
     df=dataframes(
         min_size=0,

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -1807,6 +1807,35 @@ def test_parametric_small_page_mask_filtering(df: pl.DataFrame) -> None:
     assert_frame_equal(result, df.filter(expr))
 
 
+@pytest.mark.parametrize("expr", [("payload", "eager_b"), ("eager_b", "residual")])
+def test_prefiltered_mixed_eager_and_residual_predicates(expr: tuple[str, ...]) -> None:
+    df = pl.DataFrame(
+        {
+            "residual": [float(i % 5) if i % 11 else None for i in range(130)],
+            "payload": [f"value-{i}" for i in range(130)],
+            "eager_a": range(130),
+            "eager_b": range(129, -1, -1),
+        }
+    )
+    predicate = (
+        (pl.col("eager_a") >= 17)
+        & (pl.col("eager_b") < 100)
+        & (pl.col("residual") < 2.0)
+    )
+
+    f = io.BytesIO()
+    df.write_parquet(f, data_page_size=128)
+
+    f.seek(0)
+    result = (
+        pl.scan_parquet(f, parallel="prefiltered")
+        .filter(predicate)
+        .select(*expr)
+        .collect(engine="streaming")
+    )
+    assert_frame_equal(result, df.filter(predicate).select(*expr))
+
+
 @pytest.mark.parametrize(
     "value",
     [

--- a/tools/update-cargo-env.py
+++ b/tools/update-cargo-env.py
@@ -26,6 +26,8 @@ if os.environ.get("RUSTFLAGS"):
 else:
     build.pop("rustflags", None)
 
+toml["build"] = build
+
 if os.environ.get("CFLAGS"):
     env["CFLAGS"] = os.environ.get("CFLAGS")
 else:


### PR DESCRIPTION
Previously, if only some of the predicates in parquet filters could be
applied eagerly, we would apply none of them. This forced full decode of
all predicate columns before then decoding payload columns with a complete
mask. Since often we might have some predicates that we can apply eagerly,
implement a two-stage decode process. First, those predicates we can decode
eagerly we do so as previously. Then we use that partial mask to decode the
additional columns required for the residual predicate. Finally the full
mask is constructed and used, as before, to decode the remaining payload
columns.

AI usage: codex-based initial draft followed by my rewrite