### PR TITLE
fix(python): Preserve UDF exceptions in expr context

### DIFF
--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -336,31 +336,26 @@ impl PolarsError {
             #[cfg(feature = "python")]
             Python { error } => pyo3::Python::attach(|py| {
                 use pyo3::types::{PyAnyMethods, PyStringMethods};
-                use pyo3::{IntoPyObject, PyErr};
 
-                let value = error.value(py);
+                let out = error.clone_ref(py);
+                let value = out.value(py);
 
-                let msg = if let Ok(s) = value.str() {
-                    func(&s.to_string_lossy())
+                let note = if let Ok(s) = value.str() {
+                    let msg = s.to_string_lossy();
+                    let context = func(&msg);
+
+                    context
+                        .strip_prefix(msg.as_ref())
+                        .unwrap_or(&context)
+                        .trim_start_matches('\n')
+                        .to_string()
                 } else {
                     func("<exception str() failed>")
                 };
 
-                let cls = value.get_type();
-
-                let out = PyErr::from_type(cls, (msg,));
-
-                let out = if let Ok(out_with_traceback) = (|| {
-                    out.clone_ref(py)
-                        .into_pyobject(py)?
-                        .getattr("with_traceback")
-                        .unwrap()
-                        .call1((value.getattr("__traceback__").unwrap(),))
-                })() {
-                    PyErr::from_value(out_with_traceback)
-                } else {
-                    out
-                };
+                if !note.is_empty() {
+                    let _ = value.call_method1("add_note", (note,));
+                }
 
                 Python {
                     error: python::PyErrWrap(out),

--- a/py-polars/tests/unit/operations/map/test_map_batches.py
+++ b/py-polars/tests/unit/operations/map/test_map_batches.py
@@ -158,8 +158,9 @@ def test_map_batches_preserves_python_exception_28535() -> None:
             self.body = body
 
     def raises_provider_error(_series: pl.Series) -> pl.Series:
+        message = "the provider rejected the request"
         raise RequiresContext(
-            "the provider rejected the request",
+            message,
             response={"status": 400},
             body={"error": "invalid_request"},
         )

--- a/py-polars/tests/unit/operations/map/test_map_batches.py
+++ b/py-polars/tests/unit/operations/map/test_map_batches.py
@@ -165,7 +165,9 @@ def test_map_batches_preserves_python_exception_28535() -> None:
             body={"error": "invalid_request"},
         )
 
-    with pytest.raises(RequiresContext, match="the provider rejected the request") as exc_info:
+    with pytest.raises(
+        RequiresContext, match="the provider rejected the request"
+    ) as exc_info:
         pl.DataFrame({"x": [1]}).select(
             pl.col("x").map_batches(raises_provider_error, return_dtype=pl.Int64)
         )
@@ -178,8 +180,7 @@ def test_map_batches_preserves_python_exception_28535() -> None:
         notes = getattr(err, "__notes__", None)
         assert notes is not None
         assert any(
-            "This error occurred in the following expression:" in note
-            for note in notes
+            "This error occurred in the following expression:" in note for note in notes
         )
 
 

--- a/py-polars/tests/unit/operations/map/test_map_batches.py
+++ b/py-polars/tests/unit/operations/map/test_map_batches.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from functools import reduce
 
 import numpy as np
@@ -147,6 +148,38 @@ def test_map_batches_collect_schema_17327() -> None:
     )
     expected = pl.Schema({"a": pl.Int64(), "b": pl.List(pl.Int64)})
     assert q.collect_schema() == expected
+
+
+def test_map_batches_preserves_python_exception_28535() -> None:
+    class RequiresContext(Exception):
+        def __init__(self, message: str, *, response: object, body: object) -> None:
+            super().__init__(message)
+            self.response = response
+            self.body = body
+
+    def raises_provider_error(_series: pl.Series) -> pl.Series:
+        raise RequiresContext(
+            "the provider rejected the request",
+            response={"status": 400},
+            body={"error": "invalid_request"},
+        )
+
+    with pytest.raises(RequiresContext, match="the provider rejected the request") as exc_info:
+        pl.DataFrame({"x": [1]}).select(
+            pl.col("x").map_batches(raises_provider_error, return_dtype=pl.Int64)
+        )
+
+    err = exc_info.value
+    assert err.response == {"status": 400}
+    assert err.body == {"error": "invalid_request"}
+
+    if sys.version_info >= (3, 11):
+        notes = getattr(err, "__notes__", None)
+        assert notes is not None
+        assert any(
+            "This error occurred in the following expression:" in note
+            for note in notes
+        )
 
 
 @pytest.mark.may_fail_cloud  # reason: eager - return_dtype must be set


### PR DESCRIPTION
## Description:

Issue #28535 reported that expression-context wrapping for Python UDF errors could rebuild the exception from only its string message.

That breaks Python exceptions whose constructors require keyword-only arguments, replacing the original provider error with an unrelated `TypeError`.

This PR updates Python error context wrapping to preserve the original `PyErr` instead of reconstructing it from its class and message. On Python 3.11 and later, the expression context is attached as an exception note, so the original exception type, traceback, and custom attributes remain intact.

It also adds a regression test that covers `Expr.map_batches` with a keyword-only exception constructor.

Closes #28535.

## Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks using `cargo fmt --all` and `python -m ruff check py-polars/tests/unit/operations/map/test_map_batches.py`.
- [x] I have run focused tests using `pytest -q py-polars/tests/unit/operations/map/test_map_batches.py -k 28535`.
