### PR TITLE
fix: Incorrect slicing when a join requires sorting

### DIFF
--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -606,7 +606,7 @@ trait DataFrameJoinOpsPrivate: IntoDf {
             df.sort_in_place(columns, options)?;
 
             if let Some((offset, len)) = args.slice {
-                df = df.slice(offset, usize::min(len, df.height()));
+                df = df.slice(offset, len);
             }
 
             let [mut a, b]: [Column; 2] = df.into_columns().try_into().unwrap();

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -4406,11 +4406,7 @@ def test_join_slice_maintain_order_28419_28448() -> None:
 
 def test_join_slice_maintain_order_negative_offset_overshoot_28538() -> None:
     lf = pl.LazyFrame({"a": [1, 2]})
-    q = (
-        lf
-        .join(lf, on="a", maintain_order="left")
-        .tail(6)
-    )
+    q = lf.join(lf, on="a", maintain_order="left").tail(6)
     expected = pl.DataFrame({"a": [1, 2]})
 
     assert_frame_equal(q.collect(), expected)

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -4402,3 +4402,19 @@ def test_join_slice_maintain_order_28419_28448() -> None:
     assert_frame_equal(
         q.collect(), pl.DataFrame({"a": [0, 1], "v": [40, 10], "jx": [9, 8]})
     )
+
+
+def test_join_slice_maintain_order_negative_offset_overshoot_28538() -> None:
+    lf = pl.LazyFrame({"a": [1, 2]})
+    q = (
+        lf
+        .join(lf, on="a", maintain_order="left")
+        .tail(6)
+    )
+    expected = pl.DataFrame({"a": [1, 2]})
+
+    assert_frame_equal(q.collect(), expected)
+    assert_frame_equal(
+        q.collect(optimizations=pl.QueryOptFlags().update(slice_pushdown=False)),
+        expected,
+    )


### PR DESCRIPTION
https://github.com/pola-rs/polars/pull/28478 introduced an issue where we started slicing (Rust) DataFrames using Python semantics. 

In particular, let's say that we have a DataFrame of length 2. Slicing it with `offset=-3, length=2` results in intersecting its indices with `[offset + len(df), length)` in case of negative offsets. This gives us the "unexpected" result containing just the first row of `df`.

There is no need to prematurely clamp the input to a slice operation.

Resolves https://github.com/pola-rs/polars/issues/28538 .
