### PR TITLE
fix: Propagate `nulls_last` in `function_expr_sortedness`

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/sortedness.rs
+++ b/crates/polars-plan/src/plans/optimizer/sortedness.rs
@@ -697,10 +697,7 @@ pub fn function_expr_sortedness(
             descending: Some(false),
             nulls_last: Some(false),
         }),
-        IRFunctionExpr::SetSortedFlag(sortedness) => match sortedness.descending {
-            Some(_) => Some(*sortedness),
-            None => None,
-        },
+        IRFunctionExpr::SetSortedFlag(sortedness) => sortedness.descending.map(|_| *sortedness),
 
         IRFunctionExpr::Unique(true)
         | IRFunctionExpr::DropNulls

--- a/crates/polars-plan/src/plans/optimizer/sortedness.rs
+++ b/crates/polars-plan/src/plans/optimizer/sortedness.rs
@@ -698,14 +698,7 @@ pub fn function_expr_sortedness(
             nulls_last: Some(false),
         }),
         IRFunctionExpr::SetSortedFlag(sortedness) => match sortedness.descending {
-            Some(false) => Some(AExprSorted {
-                descending: Some(false),
-                nulls_last: None,
-            }),
-            Some(true) => Some(AExprSorted {
-                descending: Some(true),
-                nulls_last: None,
-            }),
+            Some(_) => Some(*sortedness),
             None => None,
         },
 

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -1453,6 +1453,27 @@ def test_join_asof_not_sorted_streaming_grouped_27457(
 
 
 @pytest.mark.parametrize(
+    ("nulls_last", "groups", "expected_v"),
+    [
+        (False, [None, 0, 1], [None, 8, 9]),
+        (True, [0, 1, None], [7, 8, None]),
+    ],
+)
+def test_join_asof_streaming_by_set_sorted_28538(
+    nulls_last: bool, groups: list[int | None], expected_v: list[int | None]
+) -> None:
+    left = pl.LazyFrame({"group": groups, "time": [1, 1, 1]}).with_columns(
+        pl.col("group").set_sorted(nulls_last=nulls_last)
+    )
+    right = pl.LazyFrame(
+        {"group": groups, "time": [0, 0, 0], "v": [7, 8, 9]}
+    ).with_columns(pl.col("group").set_sorted(nulls_last=nulls_last))
+    out = left.join_asof(right, on="time", by="group").collect()
+    expected = pl.DataFrame({"group": groups, "time": [1, 1, 1], "v": expected_v})
+    assert_frame_equal(out, expected)
+
+
+@pytest.mark.parametrize(
     "dtypes",
     [
         (pl.Int64, pl.Int64),

--- a/py-polars/tests/unit/streaming/test_streaming_join.py
+++ b/py-polars/tests/unit/streaming/test_streaming_join.py
@@ -577,25 +577,31 @@ def test_merge_join_exprs() -> None:
     assert_frame_equal(q.collect(engine="streaming"), q.collect(engine="in-memory"))
 
 
+@pytest.mark.parametrize("df_level_hint", [False, True])
 @pytest.mark.parametrize("left_descending", [False, True])
 @pytest.mark.parametrize("right_descending", [False, True])
-@pytest.mark.parametrize("left_nulls_last", [False, True, None])
-@pytest.mark.parametrize("right_nulls_last", [False, True, None])
+@pytest.mark.parametrize("left_nulls_last", [False, True])
+@pytest.mark.parametrize("right_nulls_last", [False, True])
 def test_merge_join_applicable(
+    df_level_hint: bool,
     left_descending: bool,
     right_descending: bool,
-    left_nulls_last: bool | None,
-    right_nulls_last: bool | None,
+    left_nulls_last: bool,
+    right_nulls_last: bool,
 ) -> None:
-    def make_set_sorted_lf(descending: bool, nulls_last: bool | None) -> pl.LazyFrame:
+    def make_set_sorted_lf(
+        df_level_hint: bool, descending: bool, nulls_last: bool
+    ) -> pl.LazyFrame:
         lf = pl.LazyFrame({"key": [1]})
-        if nulls_last is None:
-            return lf.with_columns(pl.col("key").set_sorted(descending=descending))
-        else:
+        if df_level_hint:
             return lf.set_sorted("key", descending=descending, nulls_last=nulls_last)
+        else:
+            return lf.with_columns(
+                pl.col("key").set_sorted(descending=descending, nulls_last=nulls_last)
+            )
 
-    left = make_set_sorted_lf(left_descending, left_nulls_last)
-    right = make_set_sorted_lf(right_descending, right_nulls_last)
+    left = make_set_sorted_lf(df_level_hint, left_descending, left_nulls_last)
+    right = make_set_sorted_lf(df_level_hint, right_descending, right_nulls_last)
     q = left.join(right, on="key", how="full", maintain_order="left_right")
     dot = q.show_graph(engine="streaming", plan_stage="physical", raw_output=True)
     if (


### PR DESCRIPTION
When https://github.com/pola-rs/polars/pull/28544/ originally added the `AExprSorted` with a `nulls_last` field, we failed to correctly propagate this field in `function_expr_sortedness`. Instead, we just left the `None` that was there when sortedness was just a `bool` (descending).

Resolves https://github.com/pola-rs/polars/issues/28540