### PR TITLE
fix: Any operation on `Unknown(Int)` and `Unknown(Float)` should result in `Unknown(Float)`

### DIFF
--- a/crates/polars-plan/src/plans/conversion/type_coercion/binary.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/binary.rs
@@ -273,10 +273,11 @@ pub(super) fn coerced_binop_dtype(
         st = String
     }
 
-    // TODO! raise here?
-    // We should at least never cast to Unknown.
     if matches!(st, DataType::Unknown(_)) {
-        return Ok(None);
+        st = st.materialize_unknown(true)?;
+        if matches!(st, DataType::Unknown(_)) {
+            return Ok(None);
+        }
     }
 
     Ok(Some(st))

--- a/crates/polars-plan/src/plans/conversion/type_coercion/binary.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/binary.rs
@@ -273,11 +273,10 @@ pub(super) fn coerced_binop_dtype(
         st = String
     }
 
+    // TODO! raise here?
+    // We should at least never cast to Unknown.
     if matches!(st, DataType::Unknown(_)) {
-        st = st.materialize_unknown(true)?;
-        if matches!(st, DataType::Unknown(_)) {
-            return Ok(None);
-        }
+        return Ok(None);
     }
 
     Ok(Some(st))
@@ -323,6 +322,30 @@ pub(super) fn process_binary(
                 left,
                 op,
                 right: node_right,
+            }));
+        },
+        (Unknown(UnknownKind::Int(_)), Unknown(UnknownKind::Float)) => {
+            let left = expr_arena.add(AExpr::Cast {
+                expr: node_left,
+                dtype: Unknown(UnknownKind::Float),
+                options: CastOptions::NonStrict,
+            });
+            return Ok(Some(AExpr::BinaryExpr {
+                left,
+                op,
+                right: node_right,
+            }));
+        },
+        (Unknown(UnknownKind::Float), Unknown(UnknownKind::Int(_))) => {
+            let right = expr_arena.add(AExpr::Cast {
+                expr: node_right,
+                dtype: Unknown(UnknownKind::Float),
+                options: CastOptions::NonStrict,
+            });
+            return Ok(Some(AExpr::BinaryExpr {
+                left: node_left,
+                op,
+                right,
             }));
         },
         _ => {},

--- a/py-polars/tests/unit/datatypes/test_datatypes.py
+++ b/py-polars/tests/unit/datatypes/test_datatypes.py
@@ -264,7 +264,6 @@ def test_max_min(
 
 
 def test_unknown_resolve() -> None:
-
     q = pl.LazyFrame({"dec": [D("0.25")]})
     assert "Float64" in q.select(pl.col("dec") * (1.0 * 1)).explain()
     q = pl.LazyFrame({"x": 76}, schema={"x": pl.Int32}).select(
@@ -273,6 +272,13 @@ def test_unknown_resolve() -> None:
     plan = q.explain()
     assert "Float64" in plan
     assert "dyn" not in plan
+
+
+def test_unknown_binary_dyn_int_float_non_literal_28539() -> None:
+    assert_frame_equal(
+        pl.select(pl.lit(-2).abs() // pl.lit(0.5)),
+        pl.DataFrame({"literal": pl.Series([4.0], dtype=pl.Float64)}),
+    )
 
 
 def test_unknown_lit_right_arithmetic_28180() -> None:

--- a/py-polars/tests/unit/datatypes/test_datatypes.py
+++ b/py-polars/tests/unit/datatypes/test_datatypes.py
@@ -274,11 +274,48 @@ def test_unknown_resolve() -> None:
     assert "dyn" not in plan
 
 
-def test_unknown_binary_dyn_int_float_non_literal_28539() -> None:
+@pytest.mark.parametrize(
+    ("expr", "expected_dtype", "expected_value"),
+    [
+        (pl.lit(-2).abs() // pl.lit(0.5), pl.Float64, 4.0),
+        (pl.lit(-2).abs() + pl.lit(0.5), pl.Float64, 2.5),
+        (pl.lit(0.5) + pl.lit(-2).abs(), pl.Float64, 2.5),
+        (pl.lit(1.0).abs() + pl.lit(2).abs(), pl.Float64, 3.0),
+
+        (pl.lit(-1).abs() + pl.lit(-1).abs(), pl.Int32, 2),
+        (pl.lit(2**40).abs() + pl.lit(-1).abs(), pl.Int64, 2**40 + 1),
+    ],
+)
+def test_unknown_binary_dyn_int_float_non_literal_28539(
+    expr: pl.Expr, expected_dtype: pl.DataType, expected_value: object
+) -> None:
     assert_frame_equal(
-        pl.select(pl.lit(-2).abs() // pl.lit(0.5)),
-        pl.DataFrame({"literal": pl.Series([4.0], dtype=pl.Float64)}),
+        pl.select(expr),
+        pl.DataFrame({"literal": pl.Series([expected_value], dtype=expected_dtype)}),
     )
+
+
+@pytest.mark.parametrize(
+    ("expr", "expected_value"),
+    [
+        (pl.lit(1.0).abs() + pl.lit(1.0).abs() + pl.col("f"), 3.0),
+        (pl.lit(1.0).abs() * pl.lit(2.0).abs() + pl.col("f"), 3.0),
+        (pl.lit(2).abs() + pl.col("f"), 3.0),
+
+        ((pl.lit(1.0).abs() + pl.lit(2).abs()) + pl.col("f"), 4.0),
+        ((pl.lit(1.0).abs() + pl.lit(2).abs()) // pl.col("f"), 3.0),
+    ],
+)
+def test_dyn_int_float_abs_adapts_to_float32_28539(
+    expr: pl.Expr, expected_value: float
+) -> None:
+    lf = pl.LazyFrame({"f": pl.Series([1.0], dtype=pl.Float32)})
+    out = lf.select(x=expr)
+    assert_frame_equal(
+        out.collect(),
+        pl.DataFrame({"x": pl.Series([expected_value], dtype=pl.Float32)}),
+    )
+    assert_schema_equal(out.collect_schema(), pl.Schema({"x": pl.Float32}))
 
 
 def test_unknown_lit_right_arithmetic_28180() -> None:

--- a/py-polars/tests/unit/datatypes/test_datatypes.py
+++ b/py-polars/tests/unit/datatypes/test_datatypes.py
@@ -281,7 +281,6 @@ def test_unknown_resolve() -> None:
         (pl.lit(-2).abs() + pl.lit(0.5), pl.Float64, 2.5),
         (pl.lit(0.5) + pl.lit(-2).abs(), pl.Float64, 2.5),
         (pl.lit(1.0).abs() + pl.lit(2).abs(), pl.Float64, 3.0),
-
         (pl.lit(-1).abs() + pl.lit(-1).abs(), pl.Int32, 2),
         (pl.lit(2**40).abs() + pl.lit(-1).abs(), pl.Int64, 2**40 + 1),
     ],
@@ -301,7 +300,6 @@ def test_unknown_binary_dyn_int_float_non_literal_28539(
         (pl.lit(1.0).abs() + pl.lit(1.0).abs() + pl.col("f"), 3.0),
         (pl.lit(1.0).abs() * pl.lit(2.0).abs() + pl.col("f"), 3.0),
         (pl.lit(2).abs() + pl.col("f"), 3.0),
-
         ((pl.lit(1.0).abs() + pl.lit(2).abs()) + pl.col("f"), 4.0),
         ((pl.lit(1.0).abs() + pl.lit(2).abs()) // pl.col("f"), 3.0),
     ],


### PR DESCRIPTION
In https://github.com/pola-rs/polars/pull/28145 we tried to be more careful about inserting casts any `Unknown` types (and not just `Unknown(Any)`). This mostly works in the case of arithmetic with direct literals, because they can just be constant-folded. However, this logic breaks if the literal is behind a function, e.g. `pl.lit(-1).abs()`, in this case we just don't insert the casts that are necessary.

We address this by inserting a missing cast to `Unknown(Float)` when the operands are `Unknown(Int)` and `Unknown(Float)`.

Resolves #28539
