### PR TITLE
fix: Release GIL in `SQLContext.execute()`

### DIFF
--- a/crates/polars-python/src/sql.rs
+++ b/crates/polars-python/src/sql.rs
@@ -4,6 +4,7 @@ use pyo3::prelude::*;
 
 use crate::PyLazyFrame;
 use crate::error::PyPolarsErr;
+use crate::utils::EnterPolarsExt;
 
 #[pyclass(frozen, skip_from_py_object)]
 #[repr(transparent)]
@@ -35,13 +36,9 @@ impl PySQLContext {
     }
 
     /// Execute a SQL query in the current SQLContext.
-    pub fn execute(&self, query: &str) -> PyResult<PyLazyFrame> {
-        Ok(self
-            .context
-            .write()
-            .execute(query)
-            .map_err(PyPolarsErr::from)?
-            .into())
+    pub fn execute(&self, py: Python<'_>, query: &str) -> PyResult<PyLazyFrame> {
+        py.enter_polars(|| self.context.write().execute(query))
+            .map(Into::into)
     }
 
     /// Get a list of table names registered in the current SQLContext.


### PR DESCRIPTION
Whenever we are about to do heavy operations in Rust code called from Python, we should call `enter_polars` so that the GIL can be released. We do this almost everywhere, but `PySQLContext::execute` has been missed.

Resolves https://github.com/pola-rs/polars/issues/28532
