### PR TITLE
fix: Reject invalid JSON rows in json_decode

### DIFF
--- a/crates/polars-json/src/ndjson/deserialize.rs
+++ b/crates/polars-json/src/ndjson/deserialize.rs
@@ -21,8 +21,7 @@ pub fn deserialize_iter<'a>(
     allow_extra_fields_in_struct: bool,
 ) -> PolarsResult<ArrayRef> {
     let mut arr: Vec<Box<dyn Array>> = Vec::new();
-    let mut buf = Vec::with_capacity(std::cmp::min(buf_size + count + 2, u32::MAX as usize));
-    let mut validation_buf = Vec::new();
+    let mut buf = Vec::with_capacity(std::cmp::min(buf_size + count * 7 + 2, u32::MAX as usize));
     buf.push(b'[');
 
     fn _deserializer(
@@ -33,6 +32,13 @@ pub fn deserialize_iter<'a>(
         let out = simd_json::to_borrowed_value(s)
             .map_err(|e| PolarsError::ComputeError(format!("json parsing error: '{e}'").into()))?;
         if let BorrowedValue::Array(rows) = out {
+            let rows = rows
+                .into_iter()
+                .map(|row| match row {
+                    BorrowedValue::Object(mut row) => row.remove("v").unwrap(),
+                    _ => unreachable!(),
+                })
+                .collect::<Vec<_>>();
             super::super::json::deserialize::_deserialize(
                 &rows,
                 dtype,
@@ -45,15 +51,11 @@ pub fn deserialize_iter<'a>(
     let mut row_iter = rows.peekable();
 
     while let Some(row) = row_iter.next() {
-        validation_buf.clear();
-        validation_buf.extend_from_slice(row.as_bytes());
-        simd_json::to_borrowed_value(&mut validation_buf)
-            .map_err(|e| PolarsError::ComputeError(format!("json parsing error: '{e}'").into()))?;
-
+        buf.extend_from_slice(br#"{"v":"#);
         buf.extend_from_slice(row.as_bytes());
-        buf.push(b',');
+        buf.extend_from_slice(b"},");
 
-        let next_row_length = row_iter.peek().map(|row| row.len()).unwrap_or(0);
+        let next_row_length = row_iter.peek().map(|row| row.len() + 6).unwrap_or(0);
         if buf.len() + next_row_length >= u32::MAX as usize {
             let _ = buf.pop();
             buf.push(b']');

--- a/crates/polars-json/src/ndjson/deserialize.rs
+++ b/crates/polars-json/src/ndjson/deserialize.rs
@@ -22,6 +22,7 @@ pub fn deserialize_iter<'a>(
 ) -> PolarsResult<ArrayRef> {
     let mut arr: Vec<Box<dyn Array>> = Vec::new();
     let mut buf = Vec::with_capacity(std::cmp::min(buf_size + count + 2, u32::MAX as usize));
+    let mut validation_buf = Vec::new();
     buf.push(b'[');
 
     fn _deserializer(
@@ -44,6 +45,11 @@ pub fn deserialize_iter<'a>(
     let mut row_iter = rows.peekable();
 
     while let Some(row) = row_iter.next() {
+        validation_buf.clear();
+        validation_buf.extend_from_slice(row.as_bytes());
+        simd_json::to_borrowed_value(&mut validation_buf)
+            .map_err(|e| PolarsError::ComputeError(format!("json parsing error: '{e}'").into()))?;
+
         buf.extend_from_slice(row.as_bytes());
         buf.push(b',');
 

--- a/crates/polars-ops/src/chunked_array/strings/json_path.rs
+++ b/crates/polars-ops/src/chunked_array/strings/json_path.rs
@@ -250,6 +250,26 @@ mod tests {
     }
 
     #[test]
+    fn test_json_decode_rejects_invalid_rows() {
+        let scalar = Series::new("json".into(), ["1,2", "3"]);
+        assert!(
+            scalar
+                .str()
+                .unwrap()
+                .json_decode(Some(DataType::Int64), None)
+                .is_err()
+        );
+
+        let list = Series::new("json".into(), ["[1],[2", "3]"]);
+        assert!(
+            list.str()
+                .unwrap()
+                .json_decode(Some(DataType::List(Box::new(DataType::Int64))), None)
+                .is_err()
+        );
+    }
+
+    #[test]
     fn test_json_path_select() {
         let s = Series::new(
             "json".into(),


### PR DESCRIPTION
## Summary
- validate each input row before batched NDJSON deserialization
- reject fragments that could otherwise combine across adjacent rows
- add scalar and list regression coverage for #28552

## Testing
- `RUSTC=/Users/larry_1/.rustup/toolchains/nightly-2026-04-01-aarch64-apple-darwin/bin/rustc RUSTFLAGS="-Zcrate-attr=feature(generic_arg_infer)" rustup run nightly-2026-04-01 cargo test -p polars-ops --features "extract_jsonpath,dtype-struct" test_json_`
- `rustup run nightly-2026-04-01 cargo fmt --check`
- `git diff --check`

Resolves https://github.com/pola-rs/polars/issues/28552