### PR TITLE
feat(rust): Implement dictionary encodings for decimals in parquet

### DIFF
--- a/crates/polars-compute/src/cast/mod.rs
+++ b/crates/polars-compute/src/cast/mod.rs
@@ -1126,6 +1126,7 @@ fn cast_to_dictionary<K: DictionaryKey>(
         ArrowDataType::Time64(_) => primitive_to_dictionary_dyn::<i64, K>(array, ordered),
         ArrowDataType::Timestamp(_, _) => primitive_to_dictionary_dyn::<i64, K>(array, ordered),
         ArrowDataType::Date32 => primitive_to_dictionary_dyn::<i32, K>(array, ordered),
+        ArrowDataType::Decimal(_, _) => primitive_to_dictionary_dyn::<i128, K>(array, ordered),
         _ => polars_bail!(ComputeError:
             "unsupported output type for dictionary packing: {dict_value_type:?}"
         ),

--- a/crates/polars-parquet/src/arrow/write/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/write/dictionary.rs
@@ -1,5 +1,6 @@
 use arrow::array::{
-    Array, BinaryViewArray, DictionaryArray, DictionaryKey, PrimitiveArray, Utf8ViewArray,
+    Array, BinaryViewArray, DictionaryArray, DictionaryKey, FixedSizeBinaryArray, PrimitiveArray,
+    Utf8ViewArray,
 };
 use arrow::bitmap::{Bitmap, MutableBitmap};
 use arrow::compute::aggregate::estimated_bytes_size;
@@ -7,6 +8,7 @@ use arrow::datatypes::{ArrowDataType, IntegerType, PhysicalType};
 use arrow::legacy::utils::CustomIterTools;
 use arrow::trusted_len::TrustMyLength;
 use arrow::types::NativeType;
+use num_traits::AsPrimitive;
 use polars_buffer::Buffer;
 use polars_compute::min_max::MinMaxKernel;
 use polars_error::{PolarsResult, polars_bail};
@@ -16,7 +18,9 @@ use super::binary::{
     build_statistics as binary_build_statistics, encode_plain as binary_encode_plain,
 };
 use super::fixed_size_binary::{
-    build_statistics as fixed_binary_build_statistics, encode_plain as fixed_binary_encode_plain,
+    build_statistics as fixed_binary_build_statistics,
+    build_statistics_decimal as fixed_binary_build_statistics_decimal,
+    encode_plain as fixed_binary_encode_plain,
 };
 use super::primitive::{
     build_statistics as primitive_build_statistics, encode_plain as primitive_encode_plain,
@@ -32,6 +36,7 @@ use crate::parquet::encoding::hybrid_rle::encode;
 use crate::parquet::page::{DictPage, Page};
 use crate::parquet::schema::types::PrimitiveType;
 use crate::parquet::statistics::ParquetStatistics;
+use crate::parquet::types::NativeType as ParquetNativeType;
 use crate::write::DynIter;
 
 trait MinMaxThreshold {
@@ -430,26 +435,58 @@ fn serialize_keys_range<K: DictionaryKey>(
 macro_rules! dyn_prim {
     ($from:ty, $to:ty, $array:expr, $options:expr, $type_:expr) => {{
         let values = $array.values().as_any().downcast_ref().unwrap();
-
-        let buffer =
-            primitive_encode_plain::<$from, $to>(values, EncodeNullability::new(false), vec![]);
-
-        let stats: Option<ParquetStatistics> = if !$options.statistics.is_empty() {
-            let mut stats = primitive_build_statistics::<$from, $to>(
-                values,
-                $type_.clone(),
-                &$options.statistics,
-            );
-            stats.null_count = Some($array.null_count() as i64);
-            Some(stats.serialize())
-        } else {
-            None
-        };
-        (
-            DictPage::new(CowBuffer::Owned(buffer), values.len(), false),
-            stats,
-        )
+        primitive_dict_page::<$from, $to>(values, $array.null_count(), &$type_, $options)
     }};
+}
+
+fn primitive_dict_page<T, P>(
+    values: &PrimitiveArray<T>,
+    array_null_count: usize,
+    type_: &PrimitiveType,
+    options: WriteOptions,
+) -> (DictPage, Option<ParquetStatistics>)
+where
+    T: NativeType + AsPrimitive<P>,
+    P: ParquetNativeType,
+{
+    let buffer = primitive_encode_plain::<T, P>(values, EncodeNullability::new(false), vec![]);
+
+    let stats: Option<ParquetStatistics> = if !options.statistics.is_empty() {
+        let mut stats =
+            primitive_build_statistics::<T, P>(values, type_.clone(), &options.statistics);
+        stats.null_count = Some(array_null_count as i64);
+        Some(stats.serialize())
+    } else {
+        None
+    };
+    (
+        DictPage::new(CowBuffer::Owned(buffer), values.len(), false),
+        stats,
+    )
+}
+
+fn decimal_dict_page_integer<T>(
+    values: &PrimitiveArray<i128>,
+    dtype: ArrowDataType,
+    array_null_count: usize,
+    type_: &PrimitiveType,
+    options: WriteOptions,
+) -> (DictPage, Option<ParquetStatistics>)
+where
+    T: NativeType + ParquetNativeType + AsPrimitive<T>,
+    i128: AsPrimitive<T>,
+{
+    let values = PrimitiveArray::<T>::new(
+        dtype,
+        values
+            .values()
+            .iter()
+            .map(|x| (*x).as_())
+            .collect::<Vec<_>>()
+            .into(),
+        values.validity().cloned(),
+    );
+    primitive_dict_page::<T, T>(&values, array_null_count, type_, options)
 }
 
 pub fn array_to_pages<K: DictionaryKey>(
@@ -593,6 +630,64 @@ pub fn array_to_pages<K: DictionaryKey>(
                         DictPage::new(CowBuffer::Owned(buffer), array.len(), false),
                         stats,
                     )
+                },
+                ArrowDataType::Decimal(precision, _) => {
+                    let precision = *precision;
+                    let values = array
+                        .values()
+                        .as_any()
+                        .downcast_ref::<PrimitiveArray<i128>>()
+                        .unwrap();
+                    if precision <= 9 {
+                        decimal_dict_page_integer::<i32>(
+                            values,
+                            ArrowDataType::Int32,
+                            array.null_count(),
+                            &type_,
+                            options,
+                        )
+                    } else if precision <= 18 {
+                        decimal_dict_page_integer::<i64>(
+                            values,
+                            ArrowDataType::Int64,
+                            array.null_count(),
+                            &type_,
+                            options,
+                        )
+                    } else {
+                        let size = super::decimal_length_from_precision(precision);
+                        let stats = if options.has_statistics() {
+                            let stats = fixed_binary_build_statistics_decimal(
+                                values,
+                                type_.clone(),
+                                size,
+                                &options.statistics,
+                            );
+                            Some(stats.serialize())
+                        } else {
+                            None
+                        };
+                        let mut bytes = Vec::<u8>::with_capacity(size * values.len());
+                        values
+                            .values()
+                            .iter()
+                            .for_each(|x| bytes.extend_from_slice(&x.to_be_bytes()[16 - size..]));
+                        let values = FixedSizeBinaryArray::new(
+                            ArrowDataType::FixedSizeBinary(size),
+                            bytes.into(),
+                            values.validity().cloned(),
+                        );
+                        let mut buffer = vec![];
+                        fixed_binary_encode_plain(
+                            &values,
+                            EncodeNullability::Required,
+                            &mut buffer,
+                        );
+                        (
+                            DictPage::new(CowBuffer::Owned(buffer), values.len(), false),
+                            stats,
+                        )
+                    }
                 },
                 other => {
                     polars_bail!(

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -828,6 +828,74 @@ def test_parquet_string_rle_encoding() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("precision", "physical_type"),
+    [
+        (5, "INT32"),
+        (9, "INT32"),
+        (10, "INT64"),
+        (15, "INT64"),
+        (18, "INT64"),
+        (19, "FIXED_LEN_BYTE_ARRAY"),
+        (28, "FIXED_LEN_BYTE_ARRAY"),
+        (30, "FIXED_LEN_BYTE_ARRAY"),
+        (38, "FIXED_LEN_BYTE_ARRAY"),
+    ],
+)
+def test_parquet_decimal_dictionary_encoding(
+    precision: int, physical_type: str
+) -> None:
+    # Build from strings: Decimal arithmetic (including unary minus) rounds to the
+    # context precision of 28 significant digits, which would corrupt hi/lo.
+    hi = Decimal("9" * (precision - 2) + ".99")
+    lo = Decimal("-" + "9" * (precision - 2) + ".99")
+    values = [hi, lo, None, Decimal("1.50")] * 100
+    df = pl.DataFrame(
+        {"a": values, "all_null": [None] * len(values)},
+        schema={"a": pl.Decimal(precision, 2), "all_null": pl.Decimal(precision, 2)},
+    )
+
+    f = io.BytesIO()
+    df.write_parquet(f)
+    f.seek(0)
+
+    meta = pq.read_metadata(f)
+    col = meta.row_group(0).column(0)
+    assert col.physical_type == physical_type
+    assert "RLE_DICTIONARY" in col.encodings
+    assert col.statistics.min == lo
+    assert col.statistics.max == hi
+    assert col.statistics.null_count == 100
+
+    null_col = meta.row_group(0).column(1)
+    assert "RLE_DICTIONARY" in null_col.encodings
+    assert null_col.statistics.null_count == len(values)
+
+    f.seek(0)
+    assert_frame_equal(df, pl.read_parquet(f))
+
+    f.seek(0)
+    assert_frame_equal(df, cast("pl.DataFrame", pl.from_arrow(pq.read_table(f))))
+
+
+def test_parquet_decimal_dictionary_encoding_multiple_pages() -> None:
+    values = [Decimal("1.50"), None, Decimal("-2.50")] * 1000
+    df = pl.DataFrame({"a": values}, schema={"a": pl.Decimal(30, 2)})
+
+    f = io.BytesIO()
+    df.write_parquet(f, data_page_size=1024)
+    f.seek(0)
+
+    col = pq.read_metadata(f).row_group(0).column(0)
+    assert "RLE_DICTIONARY" in col.encodings
+
+    f.seek(0)
+    assert_frame_equal(df, pl.read_parquet(f))
+
+    f.seek(0)
+    assert_frame_equal(df, cast("pl.DataFrame", pl.from_arrow(pq.read_table(f))))
+
+
 @pytest.mark.may_fail_auto_streaming
 def test_sliced_dict_with_nulls_14904() -> None:
     df = (


### PR DESCRIPTION


Please see the contribution guidelines: https://docs.pola.rs/development/contributing/#pull-requests.

First-time contributors must adhere to the following rules, or your PR(s) will be closed:

- You must post a screenshot of you successfully running the test suite (`make test`),
  locally on your machine (not the CI). The screenshot must show your terminal window
  borders clearly, it must not be cropped to only show text.
- You may not have more than one open PR at a time.
<img width="1681" height="662" alt="Screenshot 2026-07-28 at 22 19 56" src="https://github.com/user-attachments/assets/a21d2f48-97f4-4d51-928e-9b16a382948c" />

Note that if you used AI to generate code there are additional requirements you
must fulfill for your PR to be reviewed. See the contribution guidelines for
details, afterwards you can use the following template if you wish:

  1. I used AI to research about the code base, help with rust (don't know rust very well at this point), as a reviewer to make sure it fits in, claude code
  2. I confirm that I have reviewed all changes myself, and I believe they are
  relevant and correct. Yes


The pattern follows the plain encoding path, there is probably an opportunity to unify some more stuff, but didn't want to touch too many things on my first PR.

closes #28467

