### PR TITLE
perf: Pushdown `len()` to concat/union inputs

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -4,6 +4,7 @@ use std::ops::ControlFlow;
 use std::sync::Arc;
 
 use edge::Edge;
+use polars_core::chunked_array::cast::CastOptions;
 use polars_core::frame::DataFrame;
 use polars_core::prelude::{Column, DataType, ScratchIndexMap, ScratchIndexSet};
 use polars_core::schema::Schema;
@@ -19,7 +20,8 @@ use polars_utils::pl_str::PlSmallStr;
 use polars_utils::scratch_vec::ScratchVec;
 use polars_utils::unique_id::UniqueId;
 
-use crate::dsl::{FileScanIR, JoinTypeOptionsIR, PredicateFileSkip};
+use crate::constants::get_len_name;
+use crate::dsl::{FileScanIR, JoinTypeOptionsIR, PredicateFileSkip, UnionOptions};
 use crate::plans::optimizer::ir_traversal::ir_graph_traversal;
 use crate::plans::optimizer::ir_traversal::storage::IRTraversalStorage;
 use crate::plans::optimizer::projection_pushdown::edge::{
@@ -1273,15 +1275,94 @@ impl ProjectionPushdownVisitor<'_, '_> {
                 pushdown_with_added_names!(len_before_added_names)
             },
 
-            ir @ IR::Union { .. } | ir @ IR::Slice { .. } | ir @ IR::Sort { .. } => {
+            IR::Union {
+                inputs,
+                options:
+                    UnionOptions {
+                        slice: _,
+                        rows: _,
+                        parallel: _,
+                        from_partitioned_ds: _,
+                        flattened_by_opt: _,
+                        rechunk,
+                        maintain_order,
+                    },
+            } => {
+                // concat(a, b, ..).select(len())
+                //   -> concat(a.select(len()), b.select(len()), ..).select(col('len').cast(UInt128).sum().cast(IDX_DTYPE))
+                if out_edge.projection() == Projection::Len && !inputs.is_empty() {
+                    *rechunk = false;
+                    *maintain_order = false;
+                    let len_schema =
+                        Arc::new(Schema::from_iter([(get_len_name(), DataType::IDX_DTYPE)]));
+
+                    let new_inputs: Vec<Node> = mem::take(inputs)
+                        .into_iter()
+                        .enumerate()
+                        .map(|(i, node)| {
+                            let node = storage.add(IR::Select {
+                                input: node,
+                                expr: vec![ExprIR::new(
+                                    self.expr_arena.add(AExpr::Len),
+                                    OutputName::Alias(get_len_name()),
+                                )],
+                                schema: Arc::clone(&len_schema),
+                                options: ProjectionOptions::default(),
+                            });
+
+                            let edge = &mut edges.inputs()[i];
+
+                            *edge.parent_key_and_port_mut() = ParentKeyAndPort { node, idx: 0 };
+                            *edge.projection_mut() = Projection::Len;
+
+                            node
+                        })
+                        .collect();
+
+                    let IR::Union { inputs, .. } = storage.get_mut(key) else {
+                        unreachable!()
+                    };
+                    *inputs = new_inputs;
+
+                    let sum_to_len = {
+                        let mut e = AExpr::Column(get_len_name());
+                        e = AExpr::Cast {
+                            expr: self.expr_arena.add(e),
+                            dtype: DataType::UInt128,
+                            options: CastOptions::Overflowing,
+                        };
+                        e = AExpr::Agg(IRAggExpr::Sum(self.expr_arena.add(e)));
+                        e = AExpr::Cast {
+                            expr: self.expr_arena.add(e),
+                            dtype: DataType::IDX_DTYPE,
+                            options: CastOptions::Strict,
+                        };
+                        self.expr_arena.add(e)
+                    };
+
+                    extract_select_len_expr(
+                        storage.get_mut(edges.outputs()[0].parent_key_and_port().node),
+                        self.expr_arena,
+                    )
+                    .unwrap()
+                    .set_node(sum_to_len);
+
+                    reuse_names_alloc(edges);
+                    return;
+                }
+
                 let (projected_names, _) = projected_names_subset_or_return!();
                 let len_before_added_names = projected_names.len();
+                pushdown_with_added_names!(len_before_added_names)
+            },
 
+            ir @ IR::Slice { .. } | ir @ IR::Sort { .. } => {
+                let (projected_names, _) = projected_names_subset_or_return!();
+                let len_before_added_names = projected_names.len();
                 for e in ir.exprs() {
                     projected_names
                         .extend(aexpr_to_leaf_names_iter(e.node(), self.expr_arena).cloned())
                 }
-
                 pushdown_with_added_names!(len_before_added_names)
             },
 

--- a/py-polars/tests/unit/lazyframe/test_projections.py
+++ b/py-polars/tests/unit/lazyframe/test_projections.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal
 
 
@@ -886,6 +887,44 @@ def test_projection_pushdown_filter_len_to_sum() -> None:
         q.collect(),
         pl.DataFrame({"b": 1}, schema={"b": pl.get_index_type()}),
     )
+
+
+@pytest.mark.parametrize("union_fn", [pl.concat, pl.union])
+def test_projection_pushdown_union_len_pushdown_28657(
+    union_fn: Callable[..., pl.LazyFrame],
+) -> None:
+    lf = union_fn(
+        [
+            pl.LazyFrame({"a": [1, 2, 3], "b": [1, 2, 3]})
+            .with_columns(pl.col("a").cast(pl.Float64))
+            .lazy(),
+            pl.LazyFrame({"a": [1.0, 2.0, 3.0], "b": [4, 5, 6]}),
+        ],
+    ).filter(pl.col("b") > 1)
+
+    q = lf.select(pl.len())
+    plan = q.explain()
+    assert plan.count('(col("b") > 1).sum()') == 2
+    assert "len()" not in plan
+    assert "WITH_COLUMNS" not in plan
+
+    assert q.collect().item() == 5
+
+    lf = (
+        pl.Series([{}], dtype=pl.Struct({}))
+        .new_from_index(0, (1 << (64 if pl.get_index_type() == pl.UInt64 else 32)) - 2)
+        .to_frame()
+        .lazy()
+    )
+
+    q = union_fn([lf, lf]).select(pl.len())
+    plan = q.explain()
+
+    assert plan.index("len()") > plan.index("UNION")
+    assert plan.count("len()") == 2
+
+    with pytest.raises(InvalidOperationError, match=r"conversion.*failed"):
+        q.collect()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/28567

We evaluate `len()` on each union input, then sum the concatted table. The sum is done after widening to UInt128 to ensure we catch overflows even on bigidx.

E.g.

```python
q = (
    pl.concat(
        [
            pl.LazyFrame({"a": [1, 2, 3], "b": [1, 2, 3]})
            .with_columns(pl.col("a").cast(pl.Float64))
            .lazy(),
            pl.LazyFrame({"a": [1.0, 2.0, 3.0], "b": [4, 5, 6]}),
        ],
    )
    .filter(pl.col("b") > 1)
    .select(pl.len())
)

print(q.explain())
```

Before / After - 
<img width="884" height="286" alt="image" src="https://github.com/user-attachments/assets/941477c2-903e-4075-b779-7384a7b4957e" />
