### PR TITLE
fix: Flip `nulls_last` after `Expr.reverse()`

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/sortedness.rs
+++ b/crates/polars-plan/src/plans/optimizer/sortedness.rs
@@ -748,15 +748,8 @@ pub fn function_expr_sortedness(
                 return None;
             };
 
-            let mut sortedness = rec_ae!(e.node())?;
-
-            if let Some(d) = &mut sortedness.descending {
-                *d = !*d;
-            }
-            if let Some(n) = &mut sortedness.nulls_last {
-                *n ^= !*n;
-            }
-            Some(sortedness)
+            let sortedness = rec_ae!(e.node())?;
+            Some(sortedness.reverse())
         },
 
         #[cfg(all(feature = "strings", feature = "concat_str"))]

--- a/py-polars/tests/unit/lazyframe/test_sort_collapse.py
+++ b/py-polars/tests/unit/lazyframe/test_sort_collapse.py
@@ -107,6 +107,19 @@ def test_sort_node_prune_hint_multiple() -> None:
     assert 'SORT BY [maintain_order: true] [col("a"), col("b")]' in q.explain()
 
 
+def test_reverse_sortedness_nulls_last_28558() -> None:
+    q = (
+        pl.LazyFrame({"a": [1, 2, 3, None, None]})
+        .sort("a", nulls_last=True)
+        .reverse()
+        .sort("a", descending=True, nulls_last=True)
+    )
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame({"a": [3, 2, 1, None, None]}),
+    )
+
+
 @pytest.mark.parametrize("idx_descending", [False, True])
 @pytest.mark.parametrize("output_descending", [False, True])
 def test_sort_node_collapse_gather_28491(


### PR DESCRIPTION
Previously we used to unconditionally set `nulls_last` to `true` via a xor-assignment and a negation.

Resolves https://github.com/pola-rs/polars/issues/28558
