### PR TITLE
fix: Clear sortedness flags in `StringChunked` substring kernels

### DIFF
--- a/crates/polars-ops/src/chunked_array/strings/substring.rs
+++ b/crates/polars-ops/src/chunked_array/strings/substring.rs
@@ -1,6 +1,7 @@
 use arrow::array::View;
 use polars_core::prelude::arity::{binary_elementwise, ternary_elementwise, unary_elementwise};
 use polars_core::prelude::{ChunkFullNull, Int64Chunked, StringChunked, UInt64Chunked};
+use polars_core::series::IsSorted;
 use polars_error::{PolarsResult, polars_ensure};
 
 fn is_utf8_codepoint_start(b: u8) -> bool {
@@ -248,12 +249,17 @@ pub(super) fn substring(
                 return StringChunked::full_null(ca.name().clone(), ca.len());
             };
 
-            unsafe {
+            let mut out = unsafe {
                 ca.apply_views(|view, val| {
                     let (start, end) = substring_ternary_offsets_value(val, offset, length);
                     update_view(view, start, end, val)
                 })
+            };
+            // the array only remains sorted if we take a prefix
+            if offset != 0 {
+                out.set_sorted_flag(IsSorted::Not);
             }
+            out
         },
         (1, _, 1) => {
             let str_val = ca.get(0);
@@ -329,12 +335,14 @@ pub(super) fn tail(ca: &StringChunked, n: &Int64Chunked) -> PolarsResult<StringC
             let Some(n) = n else {
                 return Ok(StringChunked::full_null(ca.name().clone(), len));
             };
-            unsafe {
+            let mut out = unsafe {
                 ca.apply_views(|view, val| {
                     let start = tail_binary_values(val, n);
                     update_view(view, start, val.len(), val)
                 })
-            }
+            };
+            out.set_sorted_flag(IsSorted::Not);
+            out
         },
         // TODO! below should also work on only views
         (1, _) => {

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -62,6 +62,28 @@ def test_str_slice_wrong_length() -> None:
         df.select(pl.col("num").str.slice(pl.Series([1, 2])))
 
 
+@pytest.mark.parametrize("descending", [False, True])
+def test_str_slice_sorted_flag(descending: bool) -> None:
+    s = pl.Series("a", ["xb", "ya", "zc"]).sort(descending=descending)
+    flag = "SORTED_DESC" if descending else "SORTED_ASC"
+    kept = ["z", "y", "x"] if descending else ["x", "y", "z"]
+    assert s.flags[flag]
+
+    # prefix -> order preserved, flag kept (in whichever direction it was set)
+    for prefix in (s.str.head(1), s.str.slice(0, 1)):
+        assert prefix.to_list() == kept
+        assert prefix.flags[flag]
+        assert prefix.min() == "x"
+        assert prefix.max() == "z"
+
+    # non-prefix -> order not preserved, flag cleared in both directions
+    for sliced in (s.str.slice(1), s.str.tail(1)):
+        assert not sliced.flags["SORTED_ASC"]
+        assert not sliced.flags["SORTED_DESC"]
+        assert sliced.min() == "a"
+        assert sliced.max() == "c"
+
+
 @pytest.mark.parametrize(
     ("input", "n", "output"),
     [


### PR DESCRIPTION
Some substring operations clone the source `StringChunked` array together with its flags field. Arbitrary substrings, however, do not preserve sortedness -- only prefixes do.

The alternative would be to clear all flags here https://github.com/pola-rs/polars/blob/a33dc3db435a3e0cbaa63253c951e4bf0a433b95/crates/polars-core/src/chunked_array/ops/apply.rs#L580-L586
but I think that the blast radius of this is much higher and would require all callers to manually set all flags on all operations.

Resolves https://github.com/pola-rs/polars/issues/28559
