### PR TITLE
fix: Preserve ordering in sliced unions

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/simplify_ordering/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_ordering/mod.rs
@@ -410,7 +410,9 @@ impl SimplifyIRNodeOrder<'_> {
 
                 let out_edge_key = *out_edges.first().unwrap();
 
-                if !options.maintain_order || get_edge!(out_edge_key).is_unordered() {
+                if !options.maintain_order
+                    || (get_edge!(out_edge_key).is_unordered() && options.slice.is_none())
+                {
                     options.maintain_order = false;
                     *get_edge_mut!(out_edge_key) = Edge::Unordered;
                     for k in in_edges.iter() {

--- a/py-polars/tests/unit/lazyframe/test_order_observability.py
+++ b/py-polars/tests/unit/lazyframe/test_order_observability.py
@@ -177,6 +177,18 @@ def test_union_drops_maintain_order() -> None:
     assert "UNION[maintain_order: false]" in explain
 
 
+def test_sliced_union_keeps_maintain_order_28566() -> None:
+    lf1 = pl.LazyFrame({"a": [0, 1, 2, 3, 4]})
+    lf2 = pl.LazyFrame({"a": [5, 6, 7, 8, 9]})
+
+    lf = pl.concat([lf1, lf2]).slice(3, 4).select(pl.col("a").sum())
+
+    assert "SLICED UNION[maintain_order: true]" in lf.explain()
+
+    expected = pl.DataFrame({"a": [18]})
+    assert_frame_equal(lf.collect(), expected)
+
+
 @pytest.mark.parametrize("n_frames", [4, 5])
 def test_merge_sorted_deep_chain_to_union(n_frames: int) -> None:
     lfs = [pl.LazyFrame({"a": [i], "b": [i]}) for i in range(n_frames)]


### PR DESCRIPTION
Normally, if a `Union` node has unordered outputs (e.g. a sum), it is fine for it to not maintain the order. This is not true when we push down a slice into it.

Resolves https://github.com/pola-rs/polars/issues/28566
