### PR TITLE
fix: More careful slice pushdown into joins

### DIFF
--- a/crates/polars-ops/src/frame/join/dispatch_left_right.rs
+++ b/crates/polars-ops/src/frame/join/dispatch_left_right.rs
@@ -46,8 +46,11 @@ pub fn materialize_left_join_from_series(
 ) -> PolarsResult<(DataFrame, DataFrame)> {
     let mut s_left = s_left.clone();
     // Eagerly limit left if possible.
-    if let Some((offset, len)) = args.slice {
-        if offset == 0 {
+    if let Some((0, len)) = args.slice {
+        if !matches!(
+            args.maintain_order,
+            MaintainOrderJoin::Right | MaintainOrderJoin::RightLeft
+        ) {
             left = left.slice(0, len);
             s_left = s_left.slice(0, len);
         }

--- a/crates/polars-ops/src/frame/join/hash_join/mod.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/mod.rs
@@ -154,15 +154,10 @@ pub trait JoinDispatch: IntoDf {
             s_left.hash_join_outer(s_right, args.validation, args.nulls_equal)?;
 
         try_raise_polars_abort();
-        if let Some((offset, len)) = args.slice {
-            let (offset, len) = slice_offsets(offset, len, join_idx_l.len());
-            join_idx_l.slice(offset, len);
-            join_idx_r.slice(offset, len);
-        }
-        let idx_ca_l = IdxCa::with_chunk("a".into(), join_idx_l);
-        let idx_ca_r = IdxCa::with_chunk("b".into(), join_idx_r);
 
         let (df_left, df_right) = if args.maintain_order != MaintainOrderJoin::None {
+            let idx_ca_l = IdxCa::with_chunk("a".into(), join_idx_l);
+            let idx_ca_r = IdxCa::with_chunk("b".into(), join_idx_r);
             let mut df = unsafe {
                 DataFrame::new_unchecked_infer_height(vec![
                     idx_ca_l.into_series().into(),
@@ -185,6 +180,11 @@ pub trait JoinDispatch: IntoDf {
 
             df.sort_in_place(columns, options)?;
 
+            // If the order is maintained, we can only slice after sorting
+            if let Some((offset, len)) = args.slice {
+                df = df.slice(offset, len);
+            }
+
             let join_tuples_left = df.column("a").unwrap().idx().unwrap();
             let join_tuples_right = df.column("b").unwrap().idx().unwrap();
             RAYON.join(
@@ -192,6 +192,13 @@ pub trait JoinDispatch: IntoDf {
                 || unsafe { other.take_unchecked(join_tuples_right) },
             )
         } else {
+            if let Some((offset, len)) = args.slice {
+                let (offset, len) = slice_offsets(offset, len, join_idx_l.len());
+                join_idx_l.slice(offset, len);
+                join_idx_r.slice(offset, len);
+            }
+            let idx_ca_l = IdxCa::with_chunk("a".into(), join_idx_l);
+            let idx_ca_r = IdxCa::with_chunk("b".into(), join_idx_r);
             RAYON.join(
                 || unsafe { df_self.take_unchecked(&idx_ca_l) },
                 || unsafe { other.take_unchecked(&idx_ca_r) },

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -556,10 +556,40 @@ impl SlicePushDown {
                         })
                 };
 
+                let order = options.args.maintain_order;
+                let non_negative_offset = state.offset >= 0;
+                let can_limit_left = match options.args.how {
+                    JoinType::Left => !matches!(
+                        order,
+                        MaintainOrderJoin::Right | MaintainOrderJoin::RightLeft
+                    ),
+                    JoinType::Full => {
+                        non_negative_offset
+                            && matches!(
+                                order,
+                                MaintainOrderJoin::Left | MaintainOrderJoin::LeftRight
+                            )
+                    },
+                    _ => false,
+                };
+                let can_limit_right = match options.args.how {
+                    JoinType::Right => !matches!(
+                        order,
+                        MaintainOrderJoin::Left | MaintainOrderJoin::LeftRight
+                    ),
+                    JoinType::Full => {
+                        non_negative_offset
+                            && matches!(
+                                order,
+                                MaintainOrderJoin::Right | MaintainOrderJoin::RightLeft
+                            )
+                    },
+                    _ => false,
+                };
+
                 let lp_left = self.pushdown(
                     input_left,
-                    input_limit_slice
-                        .filter(|_| matches!(&options.args.how, JoinType::Left | JoinType::Full)),
+                    input_limit_slice.filter(|_| can_limit_left),
                     lp_arena,
                     expr_arena,
                 )?;
@@ -567,8 +597,7 @@ impl SlicePushDown {
 
                 let lp_right = self.pushdown(
                     input_right,
-                    input_limit_slice
-                        .filter(|_| matches!(&options.args.how, JoinType::Right | JoinType::Full)),
+                    input_limit_slice.filter(|_| can_limit_right),
                     lp_arena,
                     expr_arena,
                 )?;

--- a/py-polars/tests/unit/lazyframe/test_optimizations.py
+++ b/py-polars/tests/unit/lazyframe/test_optimizations.py
@@ -1025,14 +1025,29 @@ def test_slice_pushdown_joins_27199() -> None:
     assert plan.index("SLICE") > plan.index("RIGHT PLAN")
     assert q.collect().height == 1
 
-    # Full join, push to both
+    # Full join, no ordering: we can not push the slice
     q = lhs.join(rhs, on="a", how="full").head(1)
+    plan = q.explain()
+
+    assert "SLICE" not in plan
+    assert q.collect().height == 1
+
+    # Full join, left ordering: we can push to left
+    q = lhs.join(rhs, on="a", how="full", maintain_order="left").head(1)
     plan = q.explain()
 
     i = plan.index("RIGHT PLAN ON")
     assert plan[:i].index("SLICE") > plan[:i].index("LEFT PLAN")
-    assert plan[i:].index("SLICE") > plan[i:].index("RIGHT PLAN")
+    assert "SLICE" not in plan[i:]
+    assert q.collect().height == 1
 
+    # Same as above, but mirrored
+    q = lhs.join(rhs, on="a", how="full", maintain_order="right").head(1)
+    plan = q.explain()
+
+    i = plan.index("RIGHT PLAN ON")
+    assert "SLICE" not in plan[:i]
+    assert plan[i:].index("SLICE") > plan[i:].index("RIGHT PLAN")
     assert q.collect().height == 1
 
 

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -4437,10 +4437,9 @@ def test_join_slice_pushdown_maintain_order_matrix_28551(
         offset, length
     )
     expected = q.collect(
-        engine="streaming",
         optimizations=pl.QueryOptFlags().update(slice_pushdown=False),
     )
-    result = q.collect(engine="streaming")
+    result = q.collect()
     assert_frame_equal(result, expected)
 
 
@@ -4452,7 +4451,7 @@ def test_full_join_slice_pushdown_no_maintain_order_28551(
     lf2 = pl.LazyFrame({"a": [4, 3, 2, 1]})
 
     q = lf1.join(lf2, on="a", how="full").slice(offset, length)
-    result = q.collect(engine="streaming")
+    result = q.collect()
 
     # We should never push the slice left or right (or both), otherwise some rows will
     # not match

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -4454,5 +4454,6 @@ def test_full_join_slice_pushdown_no_maintain_order_28551(
     q = lf1.join(lf2, on="a", how="full").slice(offset, length)
     result = q.collect(engine="streaming")
 
-    # We should never push the slice left or right (or both), otherwise some rows will not match
+    # We should never push the slice left or right (or both), otherwise some rows will
+    # not match
     assert result.null_count().sum_horizontal().item() == 0

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -23,7 +23,7 @@ from tests.unit.conftest import time_func
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from polars._typing import JoinStrategy, PolarsDataType
+    from polars._typing import JoinStrategy, MaintainOrderJoin, PolarsDataType
 
 
 def test_semi_anti_join() -> None:
@@ -4414,3 +4414,45 @@ def test_join_slice_maintain_order_negative_offset_overshoot_28538() -> None:
         q.collect(optimizations=pl.QueryOptFlags().update(slice_pushdown=False)),
         expected,
     )
+
+
+@pytest.mark.parametrize("how", ["inner", "left", "right", "full", "semi", "anti"])
+@pytest.mark.parametrize(
+    "maintain_order", ["left", "right", "left_right", "right_left"]
+)
+@pytest.mark.parametrize(
+    ("offset", "length"),
+    [(0, 1), (0, 3), (1, 2), (2, 4), (0, 100), (3, 10), (-1, 1), (-3, 2), (-100, 3)],
+)
+def test_join_slice_pushdown_maintain_order_matrix_28551(
+    how: JoinStrategy,
+    maintain_order: MaintainOrderJoin,
+    offset: int,
+    length: int,
+) -> None:
+    lf1 = pl.LazyFrame({"a": [2, 5, 1, 3], "v": [20, 50, 10, 30]})  # left-only key: 5
+    lf2 = pl.LazyFrame({"a": [3, 1, 4, 2], "w": [300, 100, 400, 200]})  # right-only: 4
+
+    q = lf1.join(lf2, on="a", how=how, maintain_order=maintain_order).slice(
+        offset, length
+    )
+    expected = q.collect(
+        engine="streaming",
+        optimizations=pl.QueryOptFlags().update(slice_pushdown=False),
+    )
+    result = q.collect(engine="streaming")
+    assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(("offset", "length"), [(0, 2), (0, 4), (1, 2), (2, 5)])
+def test_full_join_slice_pushdown_no_maintain_order_28551(
+    offset: int, length: int
+) -> None:
+    lf1 = pl.LazyFrame({"a": [1, 2, 3, 4]})
+    lf2 = pl.LazyFrame({"a": [4, 3, 2, 1]})
+
+    q = lf1.join(lf2, on="a", how="full").slice(offset, length)
+    result = q.collect(engine="streaming")
+
+    # We should never push the slice left or right (or both), otherwise some rows will not match
+    assert result.null_count().sum_horizontal().item() == 0


### PR DESCRIPTION
There are many situations in which we can not actually push down a slice into the left/right side of a join. This PR should cover them exhaustively now, and I am also adding a parameterized test for comparing the outputs with vs without slice pushdown.

These tests also required fixing the in-memory engine (issue https://github.com/pola-rs/polars/issues/28556), where we filtered too eagerly, even in the presence of `maintain_order`.

Resolves https://github.com/pola-rs/polars/issues/28551
Resolves https://github.com/pola-rs/polars/issues/28556
