### PR TITLE
fix: Clamp group-by slice offset

### DIFF
--- a/crates/polars-stream/src/nodes/sorted_group_by.rs
+++ b/crates/polars-stream/src/nodes/sorted_group_by.rs
@@ -59,7 +59,7 @@ impl SortedGroupBy {
         let column = df.column(key).unwrap();
         rle_lengths(column, idxs).unwrap();
 
-        let windows_offset = windows_slice.0 as usize;
+        let windows_offset = (windows_slice.0 as usize).min(idxs.len());
         let windows_length = (windows_slice.1 as usize).min(idxs.len() - windows_offset);
 
         let df_offset = idxs[..windows_offset].iter().sum::<IdxSize>();

--- a/py-polars/tests/unit/streaming/test_streaming_group_by.py
+++ b/py-polars/tests/unit/streaming/test_streaming_group_by.py
@@ -196,6 +196,17 @@ def test_streaming_group_by_sorted_fast_path() -> None:
         assert_frame_equal(results[0], results[1])
 
 
+def test_streaming_group_by_slice_out_of_bounds_28554() -> None:
+    q = (
+        pl.LazyFrame({"k": [1], "a": [1]})
+        .group_by("k")
+        .agg(s=pl.col("a").sum())
+        .slice(2, 1)
+    )
+
+    assert_frame_equal(q.collect(engine="streaming"), q.collect(engine="in-memory"))
+
+
 @pytest.fixture(scope="module")
 def random_integers() -> pl.Series:
     np.random.seed(1)


### PR DESCRIPTION
This fixes a panic in the streaming sorted group-by path when the slice offset exceeds the number of available groups.

The slice offset is now clamped to the group count before calculating the window length. A regression test verifies that the streaming engine returns the same empty DataFrame as the in-memory engine.

Validation:
- Streaming group-by tests: 23 passed
- Streaming test suite: 317 passed
- polars-stream unit tests: 2 passed
- Ruff, rustfmt, and git diff --check passed

Resolves https://github.com/pola-rs/polars/issues/28554