### PR TITLE
fix: Properly propagate enum metadata for iceberg column mapping

### DIFF
--- a/crates/polars-core/src/schema/iceberg.rs
+++ b/crates/polars-core/src/schema/iceberg.rs
@@ -181,8 +181,11 @@ fn arrow_field_to_iceberg_column_rec(
             if let ADT::Dictionary(_key_type, value_type, _is_ordered) = dtype
                 && !value_type.is_nested()
             {
-                let dtype =
-                    DataType::from_arrow_field(&ArrowField::new(name.clone(), dtype.clone(), true));
+                let mut new_field = ArrowField::new(name.clone(), dtype.clone(), true);
+                if let Some(metadata) = field.metadata.as_ref() {
+                    new_field = new_field.with_metadata((**metadata).clone());
+                }
+                let dtype = DataType::from_arrow_field(&new_field);
 
                 IcebergColumnType::Primitive { dtype }
             } else if let ADT::Extension(ext_type) = dtype


### PR DESCRIPTION
# Motivation

Currently, when setting `_column_mapping` on `scan_parquet`, enums cannot be read because field metadata is not properly propagated across the entire callstack. This PR fixes the issue by passing field metadata to `DataType::from_arrow_field` for `Dictionary` arrow types.