### PR TITLE
fix: Correctly write parquet field IDs for enums and categoricals

### DIFF
--- a/crates/polars-parquet/src/arrow/write/schema.rs
+++ b/crates/polars-parquet/src/arrow/write/schema.rs
@@ -252,7 +252,10 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
         },
         ArrowDataType::Dictionary(_, value, _) => {
             assert!(!value.is_nested());
-            let dict_field = Field::new(name, value.as_ref().clone(), field.is_nullable);
+            let mut dict_field = Field::new(name, value.as_ref().clone(), field.is_nullable);
+            if let Some(metadata) = &field.metadata {
+                dict_field = dict_field.with_metadata((**metadata).clone());
+            }
             return to_parquet_type(&dict_field);
         },
         ArrowDataType::FixedSizeBinary(size) => {

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -4436,3 +4436,28 @@ def test_parquet_prefilter_fixed_size_binary_27781() -> None:
         pl.scan_parquet(f).filter(pl.col("market") == val).collect(),
         pl.DataFrame(table),
     )
+
+
+def test_parquet_writes_field_id(tmp_path: Path) -> None:
+    lf = pl.LazyFrame(
+        {"a": [1, 2, 3], "b": ["a", "b", "c"], "c": ["x", "y", "z"]},
+        schema={"a": pl.Int32, "b": pl.Enum(["a", "b", "c"]), "c": pl.Categorical},
+    )
+
+    schema = lf.collect_schema().to_arrow()
+    schema = pa.schema(
+        [
+            schema.field(i).with_metadata({"PARQUET:field_id": str(i + 1)})
+            for i in range(len(schema))
+        ]
+    )
+
+    path = tmp_path / "test.parquet"
+    lf.sink_parquet(path, arrow_schema=schema)
+
+    written_schema = pq.read_schema(path)
+    field_ids = [
+        written_schema.field(i).metadata[b"PARQUET:field_id"]
+        for i in range(len(written_schema))
+    ]
+    assert field_ids == [b"1", b"2", b"3"]


### PR DESCRIPTION
# Motivation

Similarly to #28580, field metadata was not correctly propagated, causing columns with enum or categorical values to be written without field IDs.