### PR TITLE
fix: Handle out-of-range streaming group-by slices

### DIFF
--- a/crates/polars-stream/src/nodes/sorted_group_by.rs
+++ b/crates/polars-stream/src/nodes/sorted_group_by.rs
@@ -59,7 +59,7 @@ impl SortedGroupBy {
         let column = df.column(key).unwrap();
         rle_lengths(column, idxs).unwrap();
 
-        let windows_offset = windows_slice.0 as usize;
+        let windows_offset = (windows_slice.0 as usize).min(idxs.len());
         let windows_length = (windows_slice.1 as usize).min(idxs.len() - windows_offset);
 
         let df_offset = idxs[..windows_offset].iter().sum::<IdxSize>();

--- a/py-polars/tests/unit/streaming/test_streaming_group_by.py
+++ b/py-polars/tests/unit/streaming/test_streaming_group_by.py
@@ -19,6 +19,21 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.xdist_group("streaming")
 
 
+def test_streaming_group_by_slice_out_of_range_28554() -> None:
+    query = (
+        pl.DataFrame({"k": [1], "a": [1]})
+        .lazy()
+        .group_by("k")
+        .agg(s=pl.col("a").sum())
+        .slice(2, 1)
+    )
+
+    assert_frame_equal(
+        query.collect(engine="streaming"),
+        pl.DataFrame(schema={"k": pl.Int64, "s": pl.Int64}),
+    )
+
+
 @pytest.mark.slow
 def test_streaming_group_by_sorted_fast_path_nulls_10273() -> None:
     df = pl.Series(


### PR DESCRIPTION
## Summary

Fixes #28554.

Clamp the sorted streaming group-by slice offset to the available group count, so an out-of-range slice returns an empty result instead of overflowing.

## Test

- `pytest py-polars/tests/unit/streaming/test_streaming_group_by.py -q`
  - 23 passed, 5 deselected
- Reproduced the reported query before the fix and verified it returns an empty `k`/`s` frame after the fix.