### PR TITLE
fix: Align collected schemas with runtime dtypes

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/function_expr/cum.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/cum.rs
@@ -7,6 +7,11 @@ pub(super) mod dtypes {
     use super::*;
 
     pub fn cum_sum(dt: &DataType) -> DataType {
+        #[cfg(feature = "dtype-decimal")]
+        if let Decimal(_, scale) = dt {
+            return Decimal(polars_compute::decimal::DEC128_MAX_PREC, *scale);
+        }
+
         if dt.is_logical() {
             dt.clone()
         } else {
@@ -30,8 +35,8 @@ pub(super) mod dtypes {
         }
     }
 
-    pub fn cum_prod(dt: &DataType) -> DataType {
-        match dt {
+    pub fn cum_prod(dt: &DataType) -> PolarsResult<DataType> {
+        Ok(match dt {
             Boolean => Int64,
             UInt64 => UInt64,
             Int128 => Int128,
@@ -39,7 +44,9 @@ pub(super) mod dtypes {
             Float16 => Float16,
             Float32 => Float32,
             Float64 => Float64,
+            #[cfg(feature = "dtype-decimal")]
+            Decimal(..) => polars_bail!(opq = cum_prod, dt),
             _ => Int64,
-        }
+        })
     }
 }

--- a/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
@@ -65,8 +65,9 @@ impl IRFunctionExpr {
                 use IRRollingFunction::*;
                 match function {
                     Min | Max => mapper.with_same_dtype(),
-                    Mean | Quantile | Std => mapper.moment_dtype(),
-                    Var => mapper.var_dtype(),
+                    Mean | Quantile => mapper.float_dtype(true, true, false, "rolling aggregation"),
+                    Std => mapper.float_dtype(false, true, false, "rolling_std"),
+                    Var => mapper.float_dtype(false, false, false, "rolling_var"),
                     Sum => mapper.sum_dtype(),
                     Rank => match options.fn_params {
                         Some(RollingFnParams::Rank {
@@ -209,7 +210,7 @@ impl IRFunctionExpr {
             #[cfg(feature = "cum_agg")]
             CumSum { .. } => mapper.map_dtype(cum::dtypes::cum_sum),
             #[cfg(feature = "cum_agg")]
-            CumProd { .. } => mapper.map_dtype(cum::dtypes::cum_prod),
+            CumProd { .. } => mapper.try_map_dtype(cum::dtypes::cum_prod),
             #[cfg(feature = "cum_agg")]
             CumMin { .. } => mapper.with_same_dtype(),
             #[cfg(feature = "cum_agg")]
@@ -426,7 +427,7 @@ impl IRFunctionExpr {
                 f
             }),
             #[cfg(feature = "ewma")]
-            EwmMean { .. } => mapper.map_numeric_to_float_dtype(true),
+            EwmMean { .. } => mapper.float_dtype(false, true, true, "ewm_mean"),
             #[cfg(feature = "ewma_by")]
             EwmMeanBy { .. } => mapper.map_numeric_to_float_dtype(true),
             #[cfg(feature = "ewma")]
@@ -434,9 +435,9 @@ impl IRFunctionExpr {
             #[cfg(feature = "ewma_by")]
             EwmSumBy { .. } => mapper.map_numeric_to_float_dtype(true),
             #[cfg(feature = "ewma")]
-            EwmStd { .. } => mapper.map_numeric_to_float_dtype(true),
+            EwmStd { .. } => mapper.float_dtype(false, true, true, "ewm_std"),
             #[cfg(feature = "ewma")]
-            EwmVar { .. } => mapper.var_dtype(),
+            EwmVar { .. } => mapper.float_dtype(false, false, true, "ewm_var"),
             #[cfg(feature = "replace")]
             Replace => mapper.with_same_dtype(),
             #[cfg(feature = "replace")]
@@ -571,6 +572,48 @@ impl<'a> FieldsMapper<'a> {
             DataType::Array(inner, _) => map_inner(inner),
             DataType::List(inner) => map_inner(inner),
             _ => map_inner(dt),
+        })
+    }
+
+    #[cfg(any(feature = "rolling_window", feature = "ewma"))]
+    fn float_dtype(
+        &self,
+        preserve_temporal: bool,
+        allow_duration: bool,
+        preserve_float16: bool,
+        op: &'static str,
+    ) -> PolarsResult<Field> {
+        let _ = (preserve_temporal, allow_duration, preserve_float16);
+        self.try_map_dtype(|dt| {
+            let dtype = match dt {
+                DataType::Unknown(_) => dt.clone(),
+                #[cfg(feature = "dtype-duration")]
+                DataType::Duration(_) if !allow_duration => {
+                    polars_bail!(InvalidOperation: "operation `{op}` is not supported for `{dt}`")
+                },
+                #[cfg(feature = "dtype-date")]
+                DataType::Date if preserve_temporal => {
+                    DataType::Datetime(TimeUnit::Microseconds, None)
+                },
+                #[cfg(feature = "dtype-datetime")]
+                DataType::Datetime(_, _) if preserve_temporal => dt.clone(),
+                #[cfg(feature = "dtype-duration")]
+                DataType::Duration(_) if preserve_temporal => dt.clone(),
+                #[cfg(feature = "dtype-time")]
+                DataType::Time if preserve_temporal => dt.clone(),
+                #[cfg(feature = "dtype-f16")]
+                DataType::Float16 if preserve_float16 => DataType::Float16,
+                DataType::Float32 => DataType::Float32,
+                DataType::Float64 => DataType::Float64,
+                DataType::Boolean | DataType::String | DataType::Null => DataType::Float64,
+                #[cfg(feature = "dtype-decimal")]
+                DataType::Decimal(..) => DataType::Float64,
+                dt if dt.is_primitive_numeric() || dt.is_temporal() => DataType::Float64,
+                dt => {
+                    polars_bail!(InvalidOperation: "operation `{op}` is not supported for `{dt}`")
+                },
+            };
+            Ok(dtype)
         })
     }
 

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -838,6 +838,14 @@ fn get_truediv_dtype(left_dtype: &DataType, right_dtype: &DataType) -> PolarsRes
         (Boolean, Float32) => Float32,
         (Boolean, b) if b.is_numeric() => Float64,
         (Boolean, Boolean) => Float64,
+        #[cfg(feature = "dtype-decimal")]
+        (l, Decimal(_, scale)) if l.is_primitive_numeric() => {
+            if l.is_float() {
+                Float64
+            } else {
+                Decimal(DEC128_MAX_PREC, *scale)
+            }
+        },
         #[cfg(all(feature = "dtype-f16", feature = "dtype-u8"))]
         (Float16, UInt8 | Int8) => Float16,
         #[cfg(all(feature = "dtype-f16", feature = "dtype-u16"))]

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -868,11 +868,11 @@ fn get_truediv_dtype(left_dtype: &DataType, right_dtype: &DataType) -> PolarsRes
             Decimal(DEC128_MAX_PREC, *scale_left.max(scale_right))
         },
         #[cfg(feature = "dtype-decimal")]
-        (l @ Decimal(_, _), r) if r.is_primitive_numeric() => {
+        (Decimal(_, scale), r) if r.is_primitive_numeric() => {
             if r.is_float() {
                 Float64
             } else {
-                l.clone()
+                Decimal(DEC128_MAX_PREC, *scale)
             }
         },
         #[cfg(all(feature = "dtype-u8", feature = "dtype-f16"))]

--- a/py-polars/tests/unit/lazyframe/test_collect_schema.py
+++ b/py-polars/tests/unit/lazyframe/test_collect_schema.py
@@ -1,3 +1,6 @@
+from datetime import date, time, timedelta
+from decimal import Decimal
+
 import pytest
 from hypothesis import given
 
@@ -65,3 +68,109 @@ def test_arr_get_oob_errors_at_schema_26088() -> None:
     lf.select(pl.col("arr").arr.get(-1)).collect_schema()
 
     lf.select(pl.col("arr").arr.get(5, null_on_oob=True)).collect_schema()
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        pl.col("a").rolling_mean(2),
+        pl.col("a").rolling_median(2),
+        pl.col("a").rolling_std(2),
+        pl.col("a").rolling_var(2),
+        pl.col("a").ewm_mean(alpha=0.5),
+        pl.col("a").ewm_std(alpha=0.5),
+        pl.col("a").ewm_var(alpha=0.5),
+    ],
+)
+def test_collect_schema_rolling_ewm_string_28564(expr: pl.Expr) -> None:
+    q = pl.LazyFrame({"a": ["1", "2", "3"]}).select(expr)
+
+    assert q.collect_schema() == q.collect().schema == {"a": pl.Float64}
+
+
+@pytest.mark.parametrize(
+    ("series", "expr"),
+    [
+        (
+            pl.Series("a", [date(2020, 1, 1)]),
+            pl.col("a").ewm_mean(alpha=0.5),
+        ),
+        (
+            pl.Series("a", [timedelta(seconds=1)], dtype=pl.Duration("us")),
+            pl.col("a").rolling_std(1),
+        ),
+        (pl.Series("a", [time(12)]), pl.col("a").ewm_var(alpha=0.5)),
+    ],
+)
+def test_collect_schema_rolling_ewm_logical_28564(
+    series: pl.Series, expr: pl.Expr
+) -> None:
+    q = pl.LazyFrame(series).select(expr)
+
+    assert q.collect_schema() == q.collect().schema == {"a": pl.Float64}
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        pl.col("a").rolling_std(2),
+        pl.col("a").rolling_var(2),
+        pl.col("a").ewm_mean(alpha=0.5),
+    ],
+)
+def test_collect_schema_rolling_ewm_float32_28564(expr: pl.Expr) -> None:
+    q = pl.LazyFrame({"a": pl.Series([1.0, 2.0], dtype=pl.Float32)}).select(expr)
+
+    assert q.collect_schema() == q.collect().schema == {"a": pl.Float32}
+
+
+def test_collect_schema_rolling_temporal_preserved_28564() -> None:
+    q = pl.LazyFrame({"a": [date(2020, 1, 1)]}).select(
+        pl.col("a").rolling_mean(1)
+    )
+
+    assert q.collect_schema() == q.collect().schema == {
+        "a": pl.Datetime("us")
+    }
+
+
+@pytest.mark.parametrize(
+    "expr", [pl.col("a").rolling_var(1), pl.col("a").ewm_var(alpha=0.5)]
+)
+def test_collect_schema_duration_var_unsupported_28564(expr: pl.Expr) -> None:
+    q = pl.LazyFrame(
+        {"a": pl.Series([timedelta(seconds=1)], dtype=pl.Duration("us"))}
+    ).select(expr)
+
+    with pytest.raises(pl.exceptions.InvalidOperationError):
+        q.collect_schema()
+
+
+@pytest.mark.parametrize(
+    "series",
+    [
+        pl.Series("a", ["1", "2"], dtype=pl.Categorical),
+        pl.Series("a", [b"1", b"2"], dtype=pl.Binary),
+    ],
+)
+def test_collect_schema_rolling_unsupported_28564(series: pl.Series) -> None:
+    q = pl.LazyFrame(series).select(pl.col("a").rolling_mean(2))
+
+    with pytest.raises(pl.exceptions.InvalidOperationError):
+        q.collect_schema()
+
+
+@pytest.mark.parametrize("expr", [pl.col("a") / 2, pl.col("a").cum_sum()])
+def test_collect_schema_decimal_precision_28564(expr: pl.Expr) -> None:
+    series = pl.Series("a", [Decimal("1.5")] * 3, dtype=pl.Decimal(10, 2))
+    q = pl.LazyFrame(series).select(expr)
+
+    assert q.collect_schema() == q.collect().schema == {"a": pl.Decimal(38, 2)}
+
+
+def test_collect_schema_decimal_cum_prod_28564() -> None:
+    series = pl.Series("a", [Decimal("1.5")], dtype=pl.Decimal(10, 2))
+    q = pl.LazyFrame(series).select(pl.col("a").cum_prod())
+
+    with pytest.raises(pl.exceptions.InvalidOperationError):
+        q.collect_schema()

--- a/py-polars/tests/unit/lazyframe/test_collect_schema.py
+++ b/py-polars/tests/unit/lazyframe/test_collect_schema.py
@@ -125,13 +125,9 @@ def test_collect_schema_rolling_ewm_float32_28564(expr: pl.Expr) -> None:
 
 
 def test_collect_schema_rolling_temporal_preserved_28564() -> None:
-    q = pl.LazyFrame({"a": [date(2020, 1, 1)]}).select(
-        pl.col("a").rolling_mean(1)
-    )
+    q = pl.LazyFrame({"a": [date(2020, 1, 1)]}).select(pl.col("a").rolling_mean(1))
 
-    assert q.collect_schema() == q.collect().schema == {
-        "a": pl.Datetime("us")
-    }
+    assert q.collect_schema() == q.collect().schema == {"a": pl.Datetime("us")}
 
 
 @pytest.mark.parametrize(
@@ -166,6 +162,27 @@ def test_collect_schema_decimal_precision_28564(expr: pl.Expr) -> None:
     q = pl.LazyFrame(series).select(expr)
 
     assert q.collect_schema() == q.collect().schema == {"a": pl.Decimal(38, 2)}
+
+
+@pytest.mark.parametrize(
+    ("dtype", "expected"),
+    [
+        (pl.Int64, pl.Decimal(38, 2)),
+        (pl.Float16, pl.Float64),
+        (pl.Float32, pl.Float64),
+    ],
+)
+def test_collect_schema_decimal_rhs_28564(
+    dtype: pl.DataType, expected: pl.DataType
+) -> None:
+    q = pl.LazyFrame(
+        {
+            "a": pl.Series([2], dtype=dtype),
+            "b": pl.Series([Decimal("1.5")], dtype=pl.Decimal(10, 2)),
+        }
+    ).select(pl.col("a") / pl.col("b"))
+
+    assert q.collect_schema() == q.collect().schema == {"a": expected}
 
 
 def test_collect_schema_decimal_cum_prod_28564() -> None:


### PR DESCRIPTION
## Summary

- align `rolling_*` and `ewm_*` schema inference with their runtime output dtypes
- preserve Float32 and supported temporal outputs while rejecting unsupported categorical, binary, and duration variance inputs during schema resolution
- report Decimal true-division and cumulative-sum precision consistently with execution, including Decimal operands on either side of division
- reject Decimal cumulative products during schema resolution, matching runtime behavior
- add regression coverage for rolling/EWM logical dtypes, unsupported inputs, and Decimal precision

Closes #28564.

## Tests

- `cargo fmt --all -- --check`
- `cargo check -p polars-plan --all-features`
- `cargo test -p polars-plan --all-features` (5 passed, 1 ignored)
- `ruff check` and `ruff format --check` on the changed Python test
- `pytest py-polars/tests/unit/lazyframe` (918 passed, 1 skipped)
- affected rolling/EWM/Decimal suites (465 passed)
- schema/runtime parity matrix: 70/70 rolling/EWM cases
- Decimal left/right numeric division matrix: 16/16 cases
