### PR TITLE
feat(python!): Compute height for `gather_every()` of 0-width input

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -12354,7 +12354,7 @@ class DataFrame:
         │ 4   ┆ 8   │
         └─────┴─────┘
         """
-        return self.select(F.col("*").gather_every(n, offset))
+        return self.lazy().gather_every(n, offset).collect()
 
     def hash_rows(
         self,

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -94,6 +94,7 @@ from polars.datatypes import (
     parse_into_datatype_expr,
     parse_into_dtype,
 )
+from polars.datatypes.classes import Struct
 from polars.datatypes.group import DataTypeGroup
 from polars.exceptions import InvalidOperationError, PerformanceWarning
 from polars.interchange.protocol import CompatLevel
@@ -7482,7 +7483,13 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 4   ┆ 8   │
         └─────┴─────┘
         """
-        return self.select(F.col("*").gather_every(n, offset))
+        return (
+            self.with_columns(
+                F.lit({}, dtype=Struct({})).alias("__POLARS_INTERNAL_HEIGHT_COLUMN")
+            )
+            .select(F.col("*").gather_every(n, offset))
+            .drop("__POLARS_INTERNAL_HEIGHT_COLUMN")
+        )
 
     def fill_null(
         self,

--- a/py-polars/tests/unit/dataframe/test_0_width_df.py
+++ b/py-polars/tests/unit/dataframe/test_0_width_df.py
@@ -4,6 +4,7 @@ import polars as pl
 def test_0_width_df() -> None:
     df = pl.DataFrame(height=5)
 
+    assert df.bottom_k(3, by="*").height == 3
     assert df.clear().height == 0
     assert df.clone().height == 5
     assert df.cast({}).height == 5
@@ -12,6 +13,8 @@ def test_0_width_df() -> None:
     assert df.equals(df)
     assert not df.equals(pl.DataFrame())
     assert df.estimated_size() == 0
+    assert df.gather_every(1).height == 5
+    assert df.gather_every(5).height == 1
     assert df.join(df, how="cross").height == 25
 
     out = df.hash_rows()
@@ -23,11 +26,14 @@ def test_0_width_df() -> None:
 def test_0_width_lf() -> None:
     lf = pl.LazyFrame(height=5)
 
+    assert lf.bottom_k(3, by="*").collect().height == 3
     assert lf.clear().collect().height == 0
     assert lf.clone().collect().height == 5
     assert lf.cast({}).collect().height == 5
     assert lf.drop_nans().collect().height == 5
     assert lf.drop_nulls().collect().height == 5
+    assert lf.gather_every(1).collect().height == 5
+    assert lf.gather_every(5).collect().height == 1
     assert lf.join(lf, how="cross").collect().height == 25
 
     assert pl.concat([lf, lf]).collect().height == 10


### PR DESCRIPTION
E.g. -

`>>> pl.DataFrame(height=4).gather_every(2)`

Before - `shape: (0, 0)`
After - `shape: (2, 0)`
