### PR TITLE
fix: Struct/List/Array equality handling in sort and join

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -681,7 +681,11 @@ impl ChunkSort<StructType> for StructChunked {
 
     fn arg_sort(&self, options: SortOptions) -> IdxCa {
         let bin = self.get_row_encoded(options).unwrap();
-        bin.arg_sort(Default::default())
+        bin.arg_sort(SortOptions {
+            maintain_order: options.maintain_order,
+            multithreaded: options.multithreaded,
+            ..Default::default()
+        })
     }
 }
 
@@ -713,7 +717,11 @@ impl ChunkSort<ListType> for ListChunked {
             false,
         )
         .unwrap();
-        bin.arg_sort(Default::default())
+        bin.arg_sort(SortOptions {
+            maintain_order: options.maintain_order,
+            multithreaded: options.multithreaded,
+            ..Default::default()
+        })
     }
 }
 

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_dispatch.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_dispatch.rs
@@ -1,5 +1,7 @@
 use arrow::array::PrimitiveArray;
-use polars_core::chunked_array::ops::row_encode::encode_rows_unordered;
+use polars_core::chunked_array::ops::row_encode::{
+    encode_rows_unordered, encode_rows_vertical_par_unordered_broadcast_nulls,
+};
 use polars_core::series::BitRepr;
 use polars_core::utils::split;
 use polars_core::with_match_physical_float_polars_type;
@@ -66,20 +68,20 @@ pub trait SeriesJoin: SeriesSealed + Sized {
                 )
             },
             T::List(_) => {
-                let lhs = &encode_rows_unordered(&[lhs.into_owned().into()])?.into_series();
-                let rhs = &encode_rows_unordered(&[rhs.into_owned().into()])?.into_series();
+                let lhs = &encode_join_nested_key(lhs.into_owned(), nulls_equal)?;
+                let rhs = &encode_join_nested_key(rhs.into_owned(), nulls_equal)?;
                 lhs.hash_join_left(rhs, validate, nulls_equal)
             },
             #[cfg(feature = "dtype-array")]
             T::Array(_, _) => {
-                let lhs = &encode_rows_unordered(&[lhs.into_owned().into()])?.into_series();
-                let rhs = &encode_rows_unordered(&[rhs.into_owned().into()])?.into_series();
+                let lhs = &encode_join_nested_key(lhs.into_owned(), nulls_equal)?;
+                let rhs = &encode_join_nested_key(rhs.into_owned(), nulls_equal)?;
                 lhs.hash_join_left(rhs, validate, nulls_equal)
             },
             #[cfg(feature = "dtype-struct")]
             T::Struct(_) => {
-                let lhs = &encode_rows_unordered(&[lhs.into_owned().into()])?.into_series();
-                let rhs = &encode_rows_unordered(&[rhs.into_owned().into()])?.into_series();
+                let lhs = &encode_join_nested_key(lhs.into_owned(), nulls_equal)?;
+                let rhs = &encode_join_nested_key(rhs.into_owned(), nulls_equal)?;
                 lhs.hash_join_left(rhs, validate, nulls_equal)
             },
             x if x.is_float() => {
@@ -169,20 +171,20 @@ pub trait SeriesJoin: SeriesSealed + Sized {
                 }
             },
             T::List(_) => {
-                let lhs = &encode_rows_unordered(&[lhs.into_owned().into()])?.into_series();
-                let rhs = &encode_rows_unordered(&[rhs.into_owned().into()])?.into_series();
+                let lhs = &encode_join_nested_key(lhs.into_owned(), nulls_equal)?;
+                let rhs = &encode_join_nested_key(rhs.into_owned(), nulls_equal)?;
                 lhs.hash_join_semi_anti(rhs, anti, nulls_equal)?
             },
             #[cfg(feature = "dtype-array")]
             T::Array(_, _) => {
-                let lhs = &encode_rows_unordered(&[lhs.into_owned().into()])?.into_series();
-                let rhs = &encode_rows_unordered(&[rhs.into_owned().into()])?.into_series();
+                let lhs = &encode_join_nested_key(lhs.into_owned(), nulls_equal)?;
+                let rhs = &encode_join_nested_key(rhs.into_owned(), nulls_equal)?;
                 lhs.hash_join_semi_anti(rhs, anti, nulls_equal)?
             },
             #[cfg(feature = "dtype-struct")]
             T::Struct(_) => {
-                let lhs = &encode_rows_unordered(&[lhs.into_owned().into()])?.into_series();
-                let rhs = &encode_rows_unordered(&[rhs.into_owned().into()])?.into_series();
+                let lhs = &encode_join_nested_key(lhs.into_owned(), nulls_equal)?;
+                let rhs = &encode_join_nested_key(rhs.into_owned(), nulls_equal)?;
                 lhs.hash_join_semi_anti(rhs, anti, nulls_equal)?
             },
             x if x.is_float() => {
@@ -295,20 +297,20 @@ pub trait SeriesJoin: SeriesSealed + Sized {
                 ))
             },
             T::List(_) => {
-                let lhs = &encode_rows_unordered(&[lhs.into_owned().into()])?.into_series();
-                let rhs = &encode_rows_unordered(&[rhs.into_owned().into()])?.into_series();
+                let lhs = &encode_join_nested_key(lhs.into_owned(), nulls_equal)?;
+                let rhs = &encode_join_nested_key(rhs.into_owned(), nulls_equal)?;
                 lhs.hash_join_inner(rhs, validate, nulls_equal)
             },
             #[cfg(feature = "dtype-array")]
             T::Array(_, _) => {
-                let lhs = &encode_rows_unordered(&[lhs.into_owned().into()])?.into_series();
-                let rhs = &encode_rows_unordered(&[rhs.into_owned().into()])?.into_series();
+                let lhs = &encode_join_nested_key(lhs.into_owned(), nulls_equal)?;
+                let rhs = &encode_join_nested_key(rhs.into_owned(), nulls_equal)?;
                 lhs.hash_join_inner(rhs, validate, nulls_equal)
             },
             #[cfg(feature = "dtype-struct")]
             T::Struct(_) => {
-                let lhs = &encode_rows_unordered(&[lhs.into_owned().into()])?.into_series();
-                let rhs = &encode_rows_unordered(&[rhs.into_owned().into()])?.into_series();
+                let lhs = &encode_join_nested_key(lhs.into_owned(), nulls_equal)?;
+                let rhs = &encode_join_nested_key(rhs.into_owned(), nulls_equal)?;
                 lhs.hash_join_inner(rhs, validate, nulls_equal)
             },
             x if x.is_float() => {
@@ -390,20 +392,20 @@ pub trait SeriesJoin: SeriesSealed + Sized {
                 hash_join_tuples_outer(lhs, rhs, swapped, validate, nulls_equal)
             },
             T::List(_) => {
-                let lhs = &encode_rows_unordered(&[lhs.into_owned().into()])?.into_series();
-                let rhs = &encode_rows_unordered(&[rhs.into_owned().into()])?.into_series();
+                let lhs = &encode_join_nested_key(lhs.into_owned(), nulls_equal)?;
+                let rhs = &encode_join_nested_key(rhs.into_owned(), nulls_equal)?;
                 lhs.hash_join_outer(rhs, validate, nulls_equal)
             },
             #[cfg(feature = "dtype-array")]
             T::Array(_, _) => {
-                let lhs = &encode_rows_unordered(&[lhs.into_owned().into()])?.into_series();
-                let rhs = &encode_rows_unordered(&[rhs.into_owned().into()])?.into_series();
+                let lhs = &encode_join_nested_key(lhs.into_owned(), nulls_equal)?;
+                let rhs = &encode_join_nested_key(rhs.into_owned(), nulls_equal)?;
                 lhs.hash_join_outer(rhs, validate, nulls_equal)
             },
             #[cfg(feature = "dtype-struct")]
             T::Struct(_) => {
-                let lhs = &encode_rows_unordered(&[lhs.into_owned().into()])?.into_series();
-                let rhs = &encode_rows_unordered(&[rhs.into_owned().into()])?.into_series();
+                let lhs = &encode_join_nested_key(lhs.into_owned(), nulls_equal)?;
+                let rhs = &encode_join_nested_key(rhs.into_owned(), nulls_equal)?;
                 lhs.hash_join_outer(rhs, validate, nulls_equal)
             },
             x if x.is_float() => {
@@ -455,6 +457,16 @@ where
         .iter()
         .flat_map(|ca| ca.downcast_iter().map(|arr| arr.values().as_slice()))
         .collect()
+}
+
+fn encode_join_nested_key(s: Series, nulls_equal: bool) -> PolarsResult<Series> {
+    let by = [s.into_column()];
+    let encoded = if nulls_equal {
+        encode_rows_unordered(&by)?
+    } else {
+        encode_rows_vertical_par_unordered_broadcast_nulls(&by)?
+    };
+    Ok(encoded.into_series())
 }
 
 fn get_arrays<T: PolarsDataType>(cas: &[ChunkedArray<T>]) -> Vec<&T::Array> {

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -4414,3 +4414,40 @@ def test_join_slice_maintain_order_negative_offset_overshoot_28538() -> None:
         q.collect(optimizations=pl.QueryOptFlags().update(slice_pushdown=False)),
         expected,
     )
+
+
+@pytest.mark.parametrize(
+    ("dtype", "present", "missing", "inner_null"),
+    [
+        (pl.List(pl.Int64), [1], None, [None]),
+        (pl.Array(pl.Int64, 1), [1], None, [None]),
+        (pl.Struct({"a": pl.Int64}), {"a": 1}, None, {"a": None}),
+    ],
+)
+def test_join_nested_key_nulls_not_equal_28584(
+    dtype: pl.DataType, present: Any, missing: Any, inner_null: Any
+) -> None:
+    left = pl.DataFrame({"k": pl.Series([present, missing], dtype=dtype), "l": [0, 1]})
+    right = pl.DataFrame({"k": pl.Series([missing, present], dtype=dtype), "r": [10, 11]})
+
+    # default, nulls_equal=False
+    assert left.join(right, on="k", how="inner").height == 1
+    assert left.join(right, on="k", how="left").sort("l")["r"].to_list() == [11, None]
+    assert left.join(right, on="k", how="full").height == 3
+    assert left.join(right, on="k", how="semi").height == 1
+    assert left.join(right, on="k", how="anti").height == 1
+
+    # inner nulls still match
+    left2 = pl.DataFrame({"k": pl.Series([inner_null], dtype=dtype), "l": [0]})
+    right2 = pl.DataFrame({"k": pl.Series([inner_null], dtype=dtype), "r": [9]})
+    assert left2.join(right2, on="k", how="inner").height == 1
+
+    # nulls_equal=True
+    assert left.join(right, on="k", how="inner", nulls_equal=True).height == 2
+    lr = left.join(right, on="k", how="left", nulls_equal=True)
+    assert lr.sort("l")["r"].to_list() == [11, 10]
+    assert left.join(right, on="k", how="right", nulls_equal=True).height == 2
+    assert left.join(right, on="k", how="full", nulls_equal=True).height == 2
+    assert left.join(right, on="k", how="semi", nulls_equal=True).height == 2
+    assert left.join(right, on="k", how="anti", nulls_equal=True).height == 0
+

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -4428,7 +4428,9 @@ def test_join_nested_key_nulls_not_equal_28584(
     dtype: pl.DataType, present: Any, missing: Any, inner_null: Any
 ) -> None:
     left = pl.DataFrame({"k": pl.Series([present, missing], dtype=dtype), "l": [0, 1]})
-    right = pl.DataFrame({"k": pl.Series([missing, present], dtype=dtype), "r": [10, 11]})
+    right = pl.DataFrame(
+        {"k": pl.Series([missing, present], dtype=dtype), "r": [10, 11]}
+    )
 
     # default, nulls_equal=False
     assert left.join(right, on="k", how="inner").height == 1
@@ -4450,4 +4452,3 @@ def test_join_nested_key_nulls_not_equal_28584(
     assert left.join(right, on="k", how="full", nulls_equal=True).height == 2
     assert left.join(right, on="k", how="semi", nulls_equal=True).height == 2
     assert left.join(right, on="k", how="anti", nulls_equal=True).height == 0
-

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -1407,3 +1407,16 @@ def test_sort_scalar_broadcast_in_memory_28387() -> None:
     )
     expected = pl.DataFrame({"a": [1, 2, 3], "s": [9, 9, 9]})
     assert_frame_equal(lf.collect(), expected)
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        pl.Series([[i % 2] for i in range(100)], dtype=pl.List(pl.Int64)),
+        pl.Series([[i % 2, 0] for i in range(100)], dtype=pl.Array(pl.Int64, 2)),
+        pl.Series([{"a": i % 2} for i in range(100)], dtype=pl.Struct({"a": pl.Int64})),
+    ],
+)
+def test_sort_maintain_order_nested_keys_28586(key: pl.Series) -> None:
+    df = pl.DataFrame({"k": key, "r": range(key.len())})
+    assert_frame_equal(df.sort("k", maintain_order=True), df.sort(["k", "r"]))


### PR DESCRIPTION
This PR fixes two issues related to comparing Struct/List/Array columns.
 - In https://github.com/pola-rs/polars/issues/28584 outer nullability was lost when preparing a column of this type as a join key
 - In https://github.com/pola-rs/polars/issues/28586 we forgot to forward `maintain_order` when sorting with a composite row as the sort key

Resolves https://github.com/pola-rs/polars/issues/28584
Resolves https://github.com/pola-rs/polars/issues/28586
