### PR TITLE
fix: Double-counted offset for Arrow export of sliced `Series(Array)`

### DIFF
--- a/crates/polars-arrow/src/array/fixed_size_list/ffi.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/ffi.rs
@@ -7,7 +7,7 @@ use crate::ffi;
 
 unsafe impl ToFfi for FixedSizeListArray {
     fn buffers(&self) -> Vec<Option<*const u8>> {
-        vec![self.validity.as_ref().map(|x| x.as_ptr())]
+        vec![self.validity.as_ref().map(|x| x.as_aligned_ptr().unwrap())]
     }
 
     fn children(&self) -> Vec<Box<dyn Array>> {
@@ -15,16 +15,19 @@ unsafe impl ToFfi for FixedSizeListArray {
     }
 
     fn offset(&self) -> Option<usize> {
-        Some(
-            self.validity
-                .as_ref()
-                .map(|bitmap| bitmap.offset())
-                .unwrap_or_default(),
-        )
+        Some(0)
     }
 
     fn to_ffi_aligned(&self) -> Self {
-        self.clone()
+        let mut ret = self.clone();
+
+        if let Some(validity) = ret.validity()
+            && validity.as_aligned_ptr().is_none()
+        {
+            ret.validity = Some(validity.to_aligned_bitmap());
+        }
+
+        ret
     }
 }
 

--- a/crates/polars-arrow/src/ffi/array.rs
+++ b/crates/polars-arrow/src/ffi/array.rs
@@ -103,6 +103,8 @@ impl ArrowArray {
     pub(crate) fn new(mut array: Box<dyn Array>) -> Self {
         if let Some(struct_array) = array.as_any_mut().downcast_mut::<StructArray>() {
             *struct_array = struct_array.to_ffi_aligned();
+        } else if let Some(fsl_array) = array.as_any_mut().downcast_mut::<FixedSizeListArray>() {
+            *fsl_array = fsl_array.to_ffi_aligned();
         }
 
         #[allow(unused_mut)]

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -1575,6 +1575,31 @@ def test_sliced_struct_arrow_export_19612() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("values", "dtype", "expected"),
+    [
+        (
+            [[0, 0], [1, 2], [3, 4], None, [7, 8]],
+            pl.Array(pl.Int64, 2),
+            [[1, 2], [3, 4], None],
+        ),
+        (
+            [[0], [1, 2], [3, 4, 5], None, [7, 8]],
+            pl.List(pl.Int64),
+            [[1, 2], [3, 4, 5], None],
+        ),
+    ],
+)
+def test_sliced_nested_arrow_export_28583(
+    values: list[Any], dtype: pl.DataType, expected: list[Any]
+) -> None:
+    s = pl.Series(values, dtype=dtype).slice(1, 3)
+
+    assert s.to_list() == expected
+    assert s.to_arrow().to_pylist() == expected
+    assert pa.table(s.to_frame()).column(0).to_pylist() == expected
+
+
 def test_from_arrow_capsule_24511() -> None:
     # 2.0: Remove FutureWarning and change expected values to be struct-type Series.
     with pytest.warns(FutureWarning):


### PR DESCRIPTION
In https://github.com/pola-rs/polars/pull/28369 we already fixed the arrow export of sliced struct arrays. This PR applies the same fix to sliced arrays of arrays.

Resolves https://github.com/pola-rs/polars/issues/28583
