### PR TITLE
chore: Re-enable `test_extension()` for streaming engine

### DIFF
--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2042,8 +2042,6 @@ def test_filter_with_all_expansion() -> None:
     assert out.shape == (2, 3)
 
 
-# TODO: investigate this discrepancy in auto streaming
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.may_fail_cloud
 def test_extension() -> None:
     class Foo:


### PR DESCRIPTION
Don't know why but this test seems to work without issue now.

Xref: https://github.com/pola-rs/polars/issues/28529