### PR TITLE
`pl.coalesce` early-exit is dead code, leading to significant slowdowns

### DIFF
--- a/crates/polars-ops/src/series/ops/horizontal.rs
+++ b/crates/polars-ops/src/series/ops/horizontal.rs
@@ -351,7 +351,7 @@ pub fn coalesce_columns(s: &[Column]) -> PolarsResult<Column> {
     polars_ensure!(!s.is_empty(), NoData: "cannot coalesce empty list");
     let mut out = s[0].clone();
     for s in s {
-        if !out.null_count() == 0 {
+        if out.null_count() == 0 {
             return Ok(out);
         } else {
             let mask = out.is_not_null();


### PR DESCRIPTION
This PR fixes the documentation issue reported in #28592: corrects `!out.null_count() == 0` to `out.null_count() == 0` in `crates/polars-ops/src/series/ops/horizontal.rs`.

Fixes #28592

Fixes #28592