### PR TITLE
docs: Clarify NaN ordering for quantiles

### DIFF
--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -3611,9 +3611,9 @@ class Expr:
 
         Notes
         -----
-        NaN values are ordered after all other floating-point values. They
-        are not treated
-        as nulls, so call ``drop_nans`` first when NaN values should be excluded.
+        NaN values are ordered after all other floating-point values. They are
+        not treated as nulls, so call ``drop_nans`` first when NaN values
+        should be excluded.
 
         Examples
         --------
@@ -4454,9 +4454,9 @@ class Expr:
 
         Notes
         -----
-        NaN values are ordered after all other floating-point values. They
-        are not treated
-        as nulls, so call ``drop_nans`` first when NaN values should be excluded.
+        NaN values are ordered after all other floating-point values. They are
+        not treated as nulls, so call ``drop_nans`` first when NaN values
+        should be excluded.
 
         Examples
         --------

--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -3611,7 +3611,8 @@ class Expr:
 
         Notes
         -----
-        NaN values are ordered after all other floating-point values. They are not treated
+        NaN values are ordered after all other floating-point values. They
+        are not treated
         as nulls, so call ``drop_nans`` first when NaN values should be excluded.
 
         Examples
@@ -4453,7 +4454,8 @@ class Expr:
 
         Notes
         -----
-        NaN values are ordered after all other floating-point values. They are not treated
+        NaN values are ordered after all other floating-point values. They
+        are not treated
         as nulls, so call ``drop_nans`` first when NaN values should be excluded.
 
         Examples

--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -3609,6 +3609,11 @@ class Expr:
         """
         Get median value using linear interpolation.
 
+        Notes
+        -----
+        NaN values are ordered after all other floating-point values. They are not treated
+        as nulls, so call ``drop_nans`` first when NaN values should be excluded.
+
         Examples
         --------
         >>> df = pl.DataFrame({"a": [-1, 0, 1]})
@@ -4445,6 +4450,11 @@ class Expr:
             - If a list of floats, returns a list of f64 values per row (one value per quantile).
         interpolation : {'nearest', 'higher', 'lower', 'midpoint', 'linear', 'equiprobable'}
             Interpolation method.
+
+        Notes
+        -----
+        NaN values are ordered after all other floating-point values. They are not treated
+        as nulls, so call ``drop_nans`` first when NaN values should be excluded.
 
         Examples
         --------

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -2439,7 +2439,8 @@ class Series:
 
         Notes
         -----
-        NaN values are ordered after all other floating-point values. They are not treated
+        NaN values are ordered after all other floating-point values. They
+        are not treated
         as nulls, so call ``drop_nans`` first when NaN values should be excluded.
 
         Examples
@@ -2475,7 +2476,8 @@ class Series:
 
         Notes
         -----
-        NaN values are ordered after all other floating-point values. They are not treated
+        NaN values are ordered after all other floating-point values. They
+        are not treated
         as nulls, so call ``drop_nans`` first when NaN values should be excluded.
 
         Returns

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -2437,6 +2437,11 @@ class Series:
         """
         Get the median of this Series.
 
+        Notes
+        -----
+        NaN values are ordered after all other floating-point values. They are not treated
+        as nulls, so call ``drop_nans`` first when NaN values should be excluded.
+
         Examples
         --------
         >>> s = pl.Series("a", [1, 2, 3])
@@ -2467,6 +2472,11 @@ class Series:
             Quantile(s) between 0.0 and 1.0. Can be a single float or a list of floats.
         interpolation : {'nearest', 'higher', 'lower', 'midpoint', 'linear', 'equiprobable'}
             Interpolation method.
+
+        Notes
+        -----
+        NaN values are ordered after all other floating-point values. They are not treated
+        as nulls, so call ``drop_nans`` first when NaN values should be excluded.
 
         Returns
         -------

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -2439,9 +2439,9 @@ class Series:
 
         Notes
         -----
-        NaN values are ordered after all other floating-point values. They
-        are not treated
-        as nulls, so call ``drop_nans`` first when NaN values should be excluded.
+        NaN values are ordered after all other floating-point values. They are
+        not treated as nulls, so call ``drop_nans`` first when NaN values
+        should be excluded.
 
         Examples
         --------
@@ -2476,9 +2476,9 @@ class Series:
 
         Notes
         -----
-        NaN values are ordered after all other floating-point values. They
-        are not treated
-        as nulls, so call ``drop_nans`` first when NaN values should be excluded.
+        NaN values are ordered after all other floating-point values. They are
+        not treated as nulls, so call ``drop_nans`` first when NaN values
+        should be excluded.
 
         Returns
         -------


### PR DESCRIPTION
Fixes #28368

Document that NaN values sort after other floating-point values and are therefore included in the ordering used by `quantile` and `median`. The affected docstrings now point users to `drop_nans` when NaNs should be excluded.