### PR TITLE
fix: Raise on missing struct fields when casting with strict=True

### DIFF
--- a/crates/polars-core/src/chunked_array/struct_/mod.rs
+++ b/crates/polars-core/src/chunked_array/struct_/mod.rs
@@ -249,11 +249,21 @@ impl StructChunked {
                                 s.cast_with_options(&new_field.dtype, cast_options)
                             }
                         },
-                        None => Ok(Series::full_null(
-                            new_field.name().clone(),
-                            struct_len,
-                            &new_field.dtype,
-                        )),
+                        None => {
+                            if !unchecked && cast_options.is_strict() {
+                                polars_bail!(
+                                    SchemaMismatch:
+                                    "cannot cast struct to `{}`: field `{}` not found in source struct with fields {:?}",
+                                    dtype, new_field.name(),
+                                    fields.iter().map(|s| s.name().as_str()).collect::<Vec<_>>()
+                                );
+                            }
+                            Ok(Series::full_null(
+                                new_field.name().clone(),
+                                struct_len,
+                                &new_field.dtype,
+                            ))
+                        },
                     })
                     .collect::<PolarsResult<Vec<_>>>()?;
 

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -10,7 +10,7 @@ import pytest
 
 import polars as pl
 from polars._utils.constants import MS_PER_SECOND, NS_PER_SECOND, US_PER_SECOND
-from polars.exceptions import ComputeError, InvalidOperationError
+from polars.exceptions import ComputeError, InvalidOperationError, SchemaError
 from polars.testing import assert_frame_equal
 from polars.testing.asserts.series import assert_series_equal
 from tests.unit.conftest import INTEGER_DTYPES, NUMERIC_DTYPES
@@ -928,7 +928,8 @@ def test_nested_struct_cast_22744() -> None:
 
     assert_series_equal(
         s.cast(
-            pl.Struct({"attrs": pl.Struct({"class": pl.String, "other": pl.String})})
+            pl.Struct({"attrs": pl.Struct({"class": pl.String, "other": pl.String})}),
+            strict=False,
         ),
         expected.to_series(),
     )
@@ -938,10 +939,26 @@ def test_nested_struct_cast_22744() -> None:
                 "x": pl.Struct(
                     {"attrs": pl.Struct({"class": pl.String, "other": pl.String})}
                 )
-            }
+            },
+            strict=False,
         ),
         expected,
     )
+
+
+def test_struct_cast_strict_missing_field_28587() -> None:
+    s = pl.Series([{"a": 1, "b": 2}])
+
+    with pytest.raises(SchemaError, match="not found in source struct"):
+        s.cast(pl.Struct({"x": pl.Int64, "y": pl.Int64}), strict=True)
+
+    with pytest.raises(SchemaError, match="not found in source struct"):
+        s.cast(pl.Struct({"a": pl.Int64, "c": pl.Int64}), strict=True)
+
+    # non-strict still fills missing fields with nulls
+    assert s.cast(
+        pl.Struct({"a": pl.Int64, "c": pl.Int64}), strict=False
+    ).to_list() == [{"a": 1, "c": None}]
 
 
 def test_cast_to_self_is_pruned() -> None:


### PR DESCRIPTION
Closes #28587.

## Problem

Struct casts map fields by name and unconditionally fill unmatched target
fields with nulls. Under `strict=True` this never raised:

```python
s = pl.Series([{"a": 1, "b": 2}])
s.cast(pl.Struct({"x": pl.Int64, "y": pl.Int64}), strict=True)
# [{'x': None, 'y': None}]  <- no error, all data gone
```

## Changes

- StructChunked::cast_impl: when a target field is not found in the
source struct, raise a SchemaError if the cast is strict. The error
message names the missing field and lists the available source fields.
Non-strict casts keep the existing null-filling behavior
- test_nested_struct_cast_22744 now passes strict=False: it relies on
null-filling missing fields, which remains supported for non-strict casts
(per the expected behavior in #28587).
- Added test_struct_cast_strict_missing_field_28587 covering: strict cast
raises for both zero-overlap and partial-overlap field names, and
non-strict cast still null-fills.

## Local test

<img width="3832" height="1798" alt="Screenshot From 2026-07-31 15-43-01" src="https://github.com/user-attachments/assets/ccae41fd-ec7a-4428-b924-5a3e2512307f" />
