### PR TITLE
docs(python): Note numeric casts for any/all and horizontal variants

### DIFF
--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -642,7 +642,10 @@ class Expr:
         """
         Return whether any of the values in the column are `True`.
 
-        Only works on columns of data type :class:`Boolean`.
+        Boolean columns are accepted as-is. Numeric columns are cast to
+        :class:`Boolean` first (``0`` / ``0.0`` become ``False``; other values
+        become ``True``). String columns are not supported.
+        :meth:`Series.any` still requires a Boolean dtype.
 
         Parameters
         ----------
@@ -697,7 +700,10 @@ class Expr:
         """
         Return whether all values in the column are `True`.
 
-        Only works on columns of data type :class:`Boolean`.
+        Boolean columns are accepted as-is. Numeric columns are cast to
+        :class:`Boolean` first (``0`` / ``0.0`` become ``False``; other values
+        become ``True``). String columns are not supported.
+        :meth:`Series.all` still requires a Boolean dtype.
 
         .. note::
             This method is not to be confused with the function :func:`polars.all`,

--- a/py-polars/src/polars/functions/aggregation/horizontal.py
+++ b/py-polars/src/polars/functions/aggregation/horizontal.py
@@ -112,7 +112,7 @@ def any_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     │ false ┆ null  ┆ y   ┆ null  │
     │ null  ┆ null  ┆ z   ┆ null  │
     └───────┴───────┴─────┴───────┘
-    
+
 
     Numeric columns are cast to Boolean (``0`` is ``False``, non-zero is ``True``):
 
@@ -127,7 +127,7 @@ def any_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     │ false │
     │ true  │
     └───────┘
-"""
+    """
     pyexprs = parse_into_list_of_expressions(*exprs)
     return wrap_expr(plr.any_horizontal(pyexprs))
 

--- a/py-polars/src/polars/functions/aggregation/horizontal.py
+++ b/py-polars/src/polars/functions/aggregation/horizontal.py
@@ -34,6 +34,11 @@ def all_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
 
     .. _Kleene logic: https://en.wikipedia.org/wiki/Three-valued_logic
 
+    Non-boolean numeric inputs are cast to :class:`Boolean` before the operation
+    (``0`` / ``0.0`` become ``False``; other values become ``True``). String columns
+    are not supported. This differs from :meth:`~polars.Series.all`, which requires a
+    Boolean dtype.
+
     Examples
     --------
     >>> df = pl.DataFrame(
@@ -79,6 +84,11 @@ def any_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
 
     .. _Kleene logic: https://en.wikipedia.org/wiki/Three-valued_logic
 
+    Non-boolean numeric inputs are cast to :class:`Boolean` before the operation
+    (``0`` / ``0.0`` become ``False``; other values become ``True``). String columns
+    are not supported. This differs from :meth:`~polars.Series.any`, which requires a
+    Boolean dtype.
+
     Examples
     --------
     >>> df = pl.DataFrame(
@@ -102,7 +112,22 @@ def any_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     │ false ┆ null  ┆ y   ┆ null  │
     │ null  ┆ null  ┆ z   ┆ null  │
     └───────┴───────┴─────┴───────┘
-    """
+    
+
+    Numeric columns are cast to Boolean (``0`` is ``False``, non-zero is ``True``):
+
+    >>> df = pl.DataFrame({"a": [False, True], "b": [0, 2]})
+    >>> df.select(pl.any_horizontal("a", "b"))
+    shape: (2, 1)
+    ┌───────┐
+    │ a     │
+    │ ---   │
+    │ bool  │
+    ╞═══════╡
+    │ false │
+    │ true  │
+    └───────┘
+"""
     pyexprs = parse_into_list_of_expressions(*exprs)
     return wrap_expr(plr.any_horizontal(pyexprs))
 


### PR DESCRIPTION
## Description

Closes #27877

`any_horizontal` / `all_horizontal` accept non-boolean numeric columns by casting them to Boolean, while `Series.any` / `Series.all` still require a Boolean dtype. The docs did not say that, which made the difference surprising.

While checking the issue example against current Polars, `Expr.any` / `Expr.all` also cast numerics (so the old "Only works on Boolean" line was outdated). This PR updates those lines too and points at the stricter Series methods.

## Checklist

- [x] Title of this PR follows the conventional commit style
- [x] Related issue linked
- [x] Docs only - no code / test changes

<details><summary>AI assistance</summary>

Drafted with AI assistance. I reviewed the docstring edits, verified the numeric-cast behavior on Polars 1.43.2, and am responsible for the contents.

</details>