### PR TITLE
fix: Release the GIL while resolving the schema in `__arrow_c_stream__`

### DIFF
--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -1640,9 +1640,11 @@ impl PyCollectBatches {
         requested_schema: Option<Py<PyAny>>,
     ) -> PyResult<Bound<'py, PyCapsule>> {
         let mut ldf = self.ldf.clone();
-        let schema = ldf
-            .collect_schema()
-            .map_err(PyPolarsErr::from)?
+        // Resolving the schema can call back into Python from another thread (e.g. a
+        // `PythonDataset` scan, as produced by `scan_delta` / `scan_iceberg`). Holding
+        // the GIL across that deadlocks, so release it for the duration.
+        let schema = py
+            .enter_polars(move || ldf.collect_schema())?
             .to_arrow(CompatLevel::newest());
 
         let dtype = ArrowDataType::Struct(schema.into_iter_values().collect());

--- a/py-polars/tests/unit/io/test_collect_batches.py
+++ b/py-polars/tests/unit/io/test_collect_batches.py
@@ -109,3 +109,47 @@ print("OK", end="")
     )
 
     assert out == b"OK"
+
+
+@pytest.mark.slow
+def test_collect_batches_arrow_c_stream_python_dataset_28583() -> None:
+    # Resolving a `PythonDataset` scan (`scan_delta` / `scan_iceberg`) calls back into
+    # Python from another thread, so `__arrow_c_stream__` must not hold the GIL while
+    # it resolves the schema. Run in a subprocess: on regression this deadlocks.
+    out = subprocess.check_output(
+        [
+            sys.executable,
+            "-c",
+            """\
+import polars as pl
+import pyarrow as pa
+from polars._plr import PyLazyFrame
+from polars._utils.wrap import wrap_ldf
+
+SCHEMA = pa.schema([pa.field("id", pa.int64())])
+BATCH = pa.record_batch([pa.array(range(1000), type=pa.int64())], schema=SCHEMA)
+
+
+class DatasetObject:
+    def schema(self):
+        return SCHEMA
+
+    def to_dataset_scan(self, **kwargs):
+        def impl(*args, **kw):
+            return iter([pl.from_arrow(BATCH)]), False
+
+        lf = pl.LazyFrame._scan_python_function(SCHEMA, impl, pyarrow=True, is_pure=True)
+        return lf, "v1"
+
+
+lf = wrap_ldf(PyLazyFrame.new_from_dataset_object(DatasetObject()))
+reader = pa.RecordBatchReader.from_stream(lf.collect_batches(engine="streaming"))
+assert reader.read_all().num_rows == 1000
+
+print("OK", end="")
+""",
+        ],
+        timeout=30,
+    )
+
+    assert out == b"OK"

--- a/py-polars/tests/unit/io/test_collect_batches.py
+++ b/py-polars/tests/unit/io/test_collect_batches.py
@@ -112,7 +112,7 @@ print("OK", end="")
 
 
 @pytest.mark.slow
-def test_collect_batches_arrow_c_stream_python_dataset_28583() -> None:
+def test_collect_batches_arrow_c_stream_python_dataset_28628() -> None:
     # Resolving a `PythonDataset` scan (`scan_delta` / `scan_iceberg`) calls back into
     # Python from another thread, so `__arrow_c_stream__` must not hold the GIL while
     # it resolves the schema. Run in a subprocess: on regression this deadlocks.


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/28628.

`PyCollectBatches::__arrow_c_stream__` called `LazyFrame::collect_schema()` while holding the GIL. For a plan containing a `PythonDataset` scan node - what `scan_delta`, `scan_iceberg` and `PyLazyFrame::new_from_dataset_object` produce - schema resolution is dispatched to a tokio blocking worker, which calls back into Python via `Python::attach`. The calling thread then blocks on the await while holding the GIL and the worker blocks acquiring it, so `pa.RecordBatchReader.from_stream(lf.collect_batches())` hung forever with all threads parked.

Resolve the schema through `py.enter_polars()` instead, the same GIL-releasing wrapper that `__next__` already uses.

Plans without a Python-resolved scan were unaffected, as was consuming `collect_batches()` as a plain Python iterator, which is why this only showed up through the Arrow C stream bridge.
