### PR TITLE
fix: Don't hand IO plugins a predicate they cannot evaluate

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -659,6 +659,10 @@ impl PredicatePushDown {
             },
             #[cfg(feature = "python")]
             PythonScan { mut options } => {
+                // The predicate is handed to Python as a DSL expression, but dynamic
+                // predicates have no DSL representation.
+                remove_dynamic_pred_minterms(&mut acc_predicates, expr_arena);
+
                 if let Some(predicate) =
                     combine_predicates(acc_predicates.into_values(), expr_arena)
                 {

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
@@ -95,6 +95,51 @@ where
     Some(ExprIR::from_node(out, expr_arena))
 }
 
+/// Removes the min-terms containing a dynamic predicate from every accumulated predicate,
+/// dropping the entries that end up empty.
+///
+/// Dynamic predicates are pruning hints - the operator that inserted them still applies the
+/// actual semantics - so removing them only widens the predicate. Note that min-term
+/// granularity matters here: a dynamic predicate is keyed on the column it filters, so it can
+/// share a bucket with a user predicate on that same column.
+#[cfg(feature = "python")]
+pub(super) fn remove_dynamic_pred_minterms(
+    acc_predicates: &mut PlIndexMap<PlSmallStr, ExprIR>,
+    expr_arena: &mut Arena<AExpr>,
+) {
+    fn contains_dynamic_pred(node: Node, expr_arena: &Arena<AExpr>) -> bool {
+        has_aexpr(node, expr_arena, |e| {
+            matches!(
+                e,
+                AExpr::Function {
+                    function: IRFunctionExpr::DynamicPred { .. },
+                    ..
+                }
+            )
+        })
+    }
+
+    acc_predicates.retain(|_, predicate| {
+        if !contains_dynamic_pred(predicate.node(), expr_arena) {
+            return true;
+        }
+
+        let min_terms = MintermIter::new(predicate.node(), expr_arena)
+            .filter(|node| !contains_dynamic_pred(*node, expr_arena))
+            .collect::<UnitVec<_>>();
+
+        let Some(node) = min_terms
+            .into_iter()
+            .reduce(|left, right| combine_by_and(left, right, expr_arena))
+        else {
+            return false;
+        };
+
+        predicate.set_node(node);
+        true
+    });
+}
+
 /// Evaluates a condition on the column name inputs of every predicate, where if
 /// the condition evaluates to true on any column name the predicate is
 /// transferred to local.

--- a/py-polars/tests/unit/io/test_plugins.py
+++ b/py-polars/tests/unit/io/test_plugins.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 import polars as pl
 from polars.io.plugins import register_io_source
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    from polars._typing import EngineType
 
 
 # A simple python source. But this can dispatch into a rust IO source as well.
@@ -52,3 +56,44 @@ def test_my_source() -> None:
     assert_frame_equal(
         scan_my_source().select("a").collect(), pl.DataFrame({"a": [1, 2, 3]})
     )
+
+
+@pytest.mark.parametrize("engine", ["in-memory", "streaming"])
+def test_no_dynamic_predicate_pushdown_28629(engine: EngineType) -> None:
+    df = pl.DataFrame({"a": range(10), "b": ["x", "y"] * 5})
+    received: list[pl.Expr | None] = []
+
+    def source(
+        with_columns: list[str] | None,
+        predicate: pl.Expr | None,
+        n_rows: int | None,
+        _batch_size: int | None,
+    ) -> Iterator[pl.DataFrame]:
+        received.append(predicate)
+
+        out = df
+        if predicate is not None:
+            out = out.filter(predicate)
+        if n_rows is not None:
+            out = out.head(n_rows)
+        if with_columns is not None:
+            out = out.select(with_columns)
+
+        yield out
+
+    def scan() -> pl.LazyFrame:
+        return register_io_source(source, schema=df.schema)
+
+    # `sort` + `head` inserts a dynamic predicate, which has no DSL representation
+    # and so must not be pushed into the plugin.
+    assert_frame_equal(scan().sort("a").head(3).collect(engine=engine), df.head(3))
+
+    # The dynamic predicate is keyed on the same column as the user predicate, so
+    # both end up in a single conjunction. Only the dynamic min-term may be dropped.
+    assert_frame_equal(
+        scan().filter(pl.col("a") > 4).sort("a").head(3).collect(engine=engine),
+        df.filter(pl.col("a") > 4).head(3),
+    )
+
+    assert received
+    assert not any("dynamic_pred" in str(p) for p in received if p is not None)


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/28629.

IO plugins were handed a `dynamic_pred` node they cannot evaluate, panicking with `internal error: entered unreachable code`. This strips those nodes from the predicate before it crosses into Python.

Top-k pushdown (`sort` + `head`) inserts an `IRFunctionExpr::DynamicPred` conjunct into the scan predicate. That node has no DSL representation, so serializing the predicate for the plugin produced an opaque `Expr::Display` placeholder - and a plugin doing what `register_io_source` documents ("the reader must filter their rows accordingly") panicked on it. Both engines were affected, and it did not require a `filter` in the query: `lf.sort("id").head(7)` alone sends a predicate consisting solely of that node, defeating the usual `if predicate is not None` guard.

Dynamic predicates are only pruning hints, so dropping a top-level conjunct just widens the predicate while the top-k operator downstream still applies the real limit. Where that reasoning does not hold - nothing evaluable left, or a dynamic node under a `NOT`/`OR` - no predicate is serialized and the engine filters itself. The `unreachable!()` in `to_aexpr_impl` also becomes a catchable `InvalidOperation` error. Adds a regression test for both engines, verified to fail on `main`.