### PR TITLE
fix: Retain CSV datetime parser state across fallback formats

### DIFF
--- a/crates/polars-io/src/csv/read/builder.rs
+++ b/crates/polars-io/src/csv/read/builder.rs
@@ -478,42 +478,59 @@ where
         }
     };
 
-    let pattern = match &buf.compiled {
-        Some(compiled) => compiled.pattern,
-        None => match infer_pattern_single(val) {
-            Some(pattern) => pattern,
-            None => {
-                if ignore_errors {
-                    buf.builder.append_null();
-                    return Ok(());
-                } else {
-                    polars_bail!(ComputeError: "could not find a 'date/datetime' pattern for '{}'", val)
-                }
-            },
+    let pattern;
+    let parsed = match &mut buf.compiled {
+        // Retain the inferred candidate state across byte-parser misses. Rebuilding
+        // from `Pattern` here would reset the preferred format for every value.
+        Some(infer) => {
+            pattern = infer.pattern;
+            infer.parse(val)
         },
-    };
-    match DatetimeInfer::try_from_with_unit(pattern, time_unit) {
-        Ok(mut infer) => {
-            let parsed = infer.parse(val);
-            let Some(parsed) = parsed else {
-                if ignore_errors {
-                    buf.builder.append_null();
-                    return Ok(());
-                } else {
-                    polars_bail!(ComputeError: "could not parse '{}' with pattern '{:?}'", val, pattern)
-                }
+        None => {
+            pattern = match infer_pattern_single(val) {
+                Some(pattern) => pattern,
+                None => {
+                    if ignore_errors {
+                        buf.builder.append_null();
+                        return Ok(());
+                    } else {
+                        polars_bail!(ComputeError: "could not find a 'date/datetime' pattern for '{}'", val)
+                    }
+                },
             };
 
-            buf.compiled = Some(infer);
+            let mut infer = match DatetimeInfer::try_from_with_unit(pattern, time_unit) {
+                Ok(infer) => infer,
+                Err(err) => {
+                    if ignore_errors {
+                        buf.builder.append_null();
+                        return Ok(());
+                    } else {
+                        return Err(err);
+                    }
+                },
+            };
+            let parsed = infer.parse(val);
+            if parsed.is_some() {
+                // Match the previous initialization behavior: only retain a parser
+                // after it has successfully parsed a value.
+                buf.compiled = Some(infer);
+            }
+            parsed
+        },
+    };
+
+    match parsed {
+        Some(parsed) => {
             buf.builder.append_value(parsed);
             Ok(())
         },
-        Err(err) => {
+        None => {
             if ignore_errors {
                 buf.builder.append_null();
                 Ok(())
             } else {
-                Err(err)
+                polars_bail!(ComputeError: "could not parse '{}' with pattern '{:?}'", val, pattern)
             }
         },
     }

--- a/crates/polars-stream/src/nodes/io_sources/csv/builder.rs
+++ b/crates/polars-stream/src/nodes/io_sources/csv/builder.rs
@@ -8,18 +8,22 @@ use polars_io::cloud::concurrency_config::FetchConfig;
 #[cfg(feature = "csv")]
 use polars_io::metrics::IOMetrics;
 use polars_io::prelude::CsvReadOptions;
+use polars_io::utils::compression::ByteSourceReader;
+use polars_io::utils::stream_buf_reader::ReaderSource;
 use polars_plan::dsl::ScanSource;
 use polars_utils::relaxed_cell::RelaxedCell;
 
-use super::{CsvFileReader, DynByteSourceBuilder};
+use super::{CsvFileReader, DynByteSourceBuilder, LINE_BATCH_DISTRIBUTOR_BUFFER_SIZE};
 use crate::nodes::io_sources::multi_scan::reader_interface::FileReader;
 use crate::nodes::io_sources::multi_scan::reader_interface::builder::FileReaderBuilder;
 use crate::nodes::io_sources::multi_scan::reader_interface::capabilities::ReaderCapabilities;
+use crate::nodes::io_sources::shared::pipeline_budget::PipelineBudget;
 
 pub struct CsvReaderBuilder {
     pub options: Arc<CsvReadOptions>,
     pub prefetch_limit: RelaxedCell<usize>,
     pub prefetch_semaphore: std::sync::OnceLock<Arc<tokio::sync::Semaphore>>,
+    pub line_batch_budget: std::sync::OnceLock<PipelineBudget>,
     pub shared_prefetch_wait_group_slot: Arc<std::sync::Mutex<Option<WaitGroup>>>,
     pub io_metrics: std::sync::OnceLock<Arc<IOMetrics>>,
 }
@@ -30,6 +34,7 @@ impl std::fmt::Debug for CsvReaderBuilder {
             .field("ignore_errors", &self.options.ignore_errors)
             .field("prefetch_limit", &self.prefetch_limit)
             .field("prefetch_semaphore", &self.prefetch_semaphore)
+            .field("line_batch_budget", &self.line_batch_budget)
             .finish()
     }
 }
@@ -65,15 +70,42 @@ impl FileReaderBuilder for CsvReaderBuilder {
 
         self.prefetch_limit.store(prefetch_limit);
 
+        // Bound the mmap-backed or decompressed line batches waiting for CSV
+        // decoders. The permit lives through decoding, so the default covers
+        // one decoding and one queued batch per pipeline, plus the batch
+        // prepared by the producer before it acquires a permit. This keeps the
+        // budget out of the ordinary distributor's progress path while still
+        // bounding unusually wide or decompressed batches.
+        let ordinary_line_batch_limit = execution_state
+            .num_pipelines
+            .saturating_mul(LINE_BATCH_DISTRIBUTOR_BUFFER_SIZE.saturating_add(1))
+            .saturating_add(1)
+            .max(2);
+        let line_batch_count_limit = ordinary_line_batch_limit;
+        let ideal_line_batch_kbytes =
+            ByteSourceReader::<ReaderSource>::ideal_read_size().div_ceil(1 << 10);
+        let line_batch_kbytes_limit =
+            ordinary_line_batch_limit.saturating_mul(ideal_line_batch_kbytes);
+
         if config::verbose() {
             eprintln!(
-                "[CsvReaderBuilder]: prefetch_limit: {}",
-                self.prefetch_limit.load()
+                "[CsvReaderBuilder]: prefetch_limit: {}, \
+                line_batch_count_limit: {}, \
+                line_batch_kbytes_limit: {}",
+                self.prefetch_limit.load(),
+                line_batch_count_limit,
+                line_batch_kbytes_limit,
             );
         }
 
         self.prefetch_semaphore
             .set(Arc::new(tokio::sync::Semaphore::new(prefetch_limit)))
+            .unwrap();
+        self.line_batch_budget
+            .set(PipelineBudget::new(
+                line_batch_count_limit,
+                line_batch_kbytes_limit,
+            ))
             .unwrap()
     }
 
@@ -114,6 +146,7 @@ impl FileReaderBuilder for CsvReaderBuilder {
                 prev_all_spawned: None,
                 current_all_spawned: None,
             },
+            line_batch_budget: self.line_batch_budget.get().unwrap().clone(),
             init_data: None,
             io_metrics: OptIOMetrics(self.io_metrics.get().cloned()),
         };

--- a/crates/polars-stream/src/nodes/io_sources/csv/line_batch_source.rs
+++ b/crates/polars-stream/src/nodes/io_sources/csv/line_batch_source.rs
@@ -13,6 +13,7 @@ use polars_utils::slice_enum::Slice;
 
 use super::{NO_SLICE, SLICE_ENDED};
 use crate::nodes::MorselSeq;
+use crate::nodes::io_sources::shared::pipeline_budget::{PipelineBudget, PipelinePermit};
 use crate::utils::tokio_handle_ext;
 
 pub(super) struct LineBatch {
@@ -23,6 +24,32 @@ pub(super) struct LineBatch {
     /// Position of this chunk relative to the start of the file according to CountLines.
     pub(super) row_offset: usize,
     pub(super) morsel_seq: MorselSeq,
+    pub(super) input_permit: PipelinePermit,
+}
+
+struct PendingLineBatch {
+    mem_slice: Buffer<u8>,
+    n_lines: usize,
+    slice: (usize, usize),
+    row_offset: usize,
+    morsel_seq: MorselSeq,
+}
+
+impl PendingLineBatch {
+    fn n_bytes(&self) -> usize {
+        self.mem_slice.len()
+    }
+
+    fn with_permit(self, input_permit: PipelinePermit) -> LineBatch {
+        LineBatch {
+            mem_slice: self.mem_slice,
+            n_lines: self.n_lines,
+            slice: self.slice,
+            row_offset: self.row_offset,
+            morsel_seq: self.morsel_seq,
+            input_permit,
+        }
+    }
 }
 
 pub(super) struct LineBatchSource {
@@ -30,6 +57,7 @@ pub(super) struct LineBatchSource {
     pub(super) reader: ByteSourceReader<ReaderSource>,
     pub(super) line_counter: CountLines,
     pub(super) line_batch_tx: distributor_channel::Sender<LineBatch>,
+    pub(super) line_batch_budget: PipelineBudget,
     pub(super) pre_slice: Option<Slice>,
     pub(super) needs_full_row_count: bool,
     pub(super) use_async_prefetch: bool,
@@ -63,9 +91,15 @@ impl LineBatchSource {
             use_l2_prefetch,
         );
         let mut line_batch_tx = self.line_batch_tx;
+        let line_batch_budget = self.line_batch_budget;
 
-        while let Some(batch) = producer.next_batch()? {
-            if line_batch_tx.send(batch).await.is_err() {
+        while let Some(pending_batch) = producer.next_batch()? {
+            let input_permit = line_batch_budget.acquire(pending_batch.n_bytes()).await;
+            if line_batch_tx
+                .send(pending_batch.with_permit(input_permit))
+                .await
+                .is_err()
+            {
                 break;
             }
         }
@@ -79,6 +113,7 @@ impl LineBatchSource {
     async fn run_async(self) -> PolarsResult<usize> {
         let verbose = self.verbose;
         let mut line_batch_tx = self.line_batch_tx;
+        let line_batch_budget = self.line_batch_budget;
 
         let read_loop_handle =
             tokio_handle_ext::AbortOnDropHandle(ASYNC.spawn_blocking(move || {
@@ -97,9 +132,14 @@ impl LineBatchSource {
                     use_l2_prefetch,
                 );
 
-                while let Some(batch) = producer.next_batch()? {
+                while let Some(pending_batch) = producer.next_batch()? {
+                    let input_permit =
+                        ASYNC.block_on(line_batch_budget.acquire(pending_batch.n_bytes()));
                     // Effectively, this is `blocking_send`.
-                    if ASYNC.block_on(line_batch_tx.send(batch)).is_err() {
+                    if ASYNC
+                        .block_on(line_batch_tx.send(pending_batch.with_permit(input_permit)))
+                        .is_err()
+                    {
                         break;
                     }
                 }
@@ -164,7 +204,7 @@ impl LineBatchProducer {
     }
 
     /// Returns the next LineBatch, or None if the source is exhausted.
-    fn next_batch(&mut self) -> PolarsResult<Option<LineBatch>> {
+    fn next_batch(&mut self) -> PolarsResult<Option<PendingLineBatch>> {
         if self.finished {
             return Ok(None);
         }
@@ -228,7 +268,7 @@ impl LineBatchProducer {
 
             self.morsel_seq = self.morsel_seq.successor();
 
-            let batch = LineBatch {
+            let batch = PendingLineBatch {
                 mem_slice: batch_slice,
                 n_lines,
                 slice,

--- a/crates/polars-stream/src/nodes/io_sources/csv/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/csv/mod.rs
@@ -33,12 +33,12 @@ use polars_utils::slice_enum::Slice;
 use super::multi_scan::reader_interface::output::FileReaderOutputRecv;
 use super::multi_scan::reader_interface::{BeginReadArgs, FileReader, FileReaderCallbacks};
 use super::shared::chunk_data_fetch::ChunkDataFetcher;
-use crate::DEFAULT_DISTRIBUTOR_BUFFER_SIZE;
 use crate::morsel::SourceToken;
 use crate::nodes::TaskPriority;
 use crate::nodes::compute_node_prelude::*;
 use crate::nodes::io_sources::multi_scan::reader_interface::Projection;
 use crate::nodes::io_sources::multi_scan::reader_interface::output::FileReaderOutputSend;
+use crate::nodes::io_sources::shared::pipeline_budget::PipelineBudget;
 use crate::utils::tokio_handle_ext;
 
 /// Read all rows in the chunk
@@ -46,6 +46,9 @@ const NO_SLICE: (usize, usize) = (0, usize::MAX);
 /// This is used if we finish the slice but still need a row count. It signals to the workers to
 /// go into line-counting mode where they can skip parsing the chunks.
 const SLICE_ENDED: (usize, usize) = (usize::MAX, 0);
+/// One queued line batch per decoder keeps CSV input residency bounded while
+/// preserving producer/decoder overlap for every projected dtype.
+pub(super) const LINE_BATCH_DISTRIBUTOR_BUFFER_SIZE: usize = 1;
 
 struct CsvFileReader {
     scan_source: ScanSource,
@@ -54,6 +57,7 @@ struct CsvFileReader {
     verbose: bool,
     pub byte_source_builder: DynByteSourceBuilder,
     pub chunk_prefetch_sync: ChunkPrefetchSync,
+    pub line_batch_budget: PipelineBudget,
     pub init_data: Option<InitializedState>,
     pub io_metrics: OptIOMetrics,
 }
@@ -288,8 +292,9 @@ impl FileReader for CsvFileReader {
             tokio::sync::oneshot::channel::<PolarsResult<Arc<ChunkReader>>>();
         let chunk_reader_shared = chunk_reader_rx.shared();
         let (line_batch_tx, line_batch_receivers) =
-            distributor_channel(num_pipelines, *DEFAULT_DISTRIBUTOR_BUFFER_SIZE);
+            distributor_channel(num_pipelines, LINE_BATCH_DISTRIBUTOR_BUFFER_SIZE);
         let (morsel_senders, rx) = FileReaderOutputSend::new_parallel(num_pipelines);
+        let line_batch_budget = self.line_batch_budget.clone();
 
         // Task: Pre-read and infer schema.
         // Because StreamBufReader uses `blocking_recv`, this runs on tokio's elastic blocking pool.
@@ -379,6 +384,7 @@ impl FileReader for CsvFileReader {
                             reader,
                             line_counter,
                             line_batch_tx,
+                            line_batch_budget,
                             pre_slice,
                             needs_full_row_count,
                             use_async_prefetch,
@@ -418,6 +424,7 @@ impl FileReader for CsvFileReader {
                         slice,
                         row_offset,
                         morsel_seq,
+                        input_permit,
                     }) = line_batch_rx.recv().await
                     {
                         let (offset, len) = match slice {
@@ -425,12 +432,15 @@ impl FileReader for CsvFileReader {
                             v => v,
                         };
 
-                        let (df, n_rows_in_chunk) = chunk_reader.read_chunk(
-                            &mem_slice,
-                            n_lines,
-                            (offset, len),
-                            row_offset,
-                        )?;
+                        let read_result =
+                            chunk_reader.read_chunk(&mem_slice, n_lines, (offset, len), row_offset);
+
+                        // Decoded output owns its buffers. Release source admission
+                        // before awaiting downstream capacity.
+                        drop(mem_slice);
+                        drop(input_permit);
+
+                        let (df, n_rows_in_chunk) = read_result?;
 
                         n_rows_processed = n_rows_processed.saturating_add(n_rows_in_chunk);
 
@@ -459,6 +469,7 @@ impl FileReader for CsvFileReader {
                             slice,
                             row_offset: _,
                             morsel_seq: _,
+                            input_permit: _,
                         }) = line_batch_rx.recv().await
                         {
                             assert_eq!(slice, SLICE_ENDED);

--- a/crates/polars-stream/src/nodes/io_sources/shared/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/shared/mod.rs
@@ -1,4 +1,4 @@
 #[cfg(any(feature = "csv", feature = "json", feature = "scan_lines"))]
 pub mod chunk_data_fetch;
-#[cfg(any(feature = "parquet", feature = "ipc"))]
+#[cfg(any(feature = "parquet", feature = "ipc", feature = "csv"))]
 pub mod pipeline_budget;

--- a/crates/polars-stream/src/nodes/io_sources/shared/pipeline_budget.rs
+++ b/crates/polars-stream/src/nodes/io_sources/shared/pipeline_budget.rs
@@ -101,6 +101,9 @@ pub(crate) struct PipelinePermit {
 
 #[cfg(test)]
 mod tests {
+    use std::future::{Future, poll_fn};
+    use std::task::Poll;
+
     use polars_core::runtime::ASYNC;
 
     use super::PipelineBudget;
@@ -109,12 +112,26 @@ mod tests {
     fn oversized_request_serializes_and_releases_capacity() {
         let budget = PipelineBudget::new(2, 4);
 
-        let permit = ASYNC.block_on(budget.acquire(16 * 1024));
-        assert_eq!(budget.count.available_permits(), 1);
-        assert_eq!(budget.kbytes.available_permits(), 0);
+        ASYNC.block_on(async {
+            let oversized = budget.acquire(16 * 1024).await;
+            assert_eq!(budget.count.available_permits(), 1);
+            assert_eq!(budget.kbytes.available_permits(), 0);
 
-        drop(permit);
-        assert_eq!(budget.count.available_permits(), 2);
-        assert_eq!(budget.kbytes.available_permits(), 4);
+            let mut next = Box::pin(budget.acquire(1024));
+            // Poll once to observe blocking without a timing-based timeout.
+            let next_is_pending =
+                poll_fn(|cx| Poll::Ready(next.as_mut().poll(cx).is_pending())).await;
+            assert!(next_is_pending);
+            assert_eq!(budget.count.available_permits(), 1);
+
+            drop(oversized);
+            let next = next.await;
+            assert_eq!(budget.count.available_permits(), 1);
+            assert_eq!(budget.kbytes.available_permits(), 3);
+
+            drop(next);
+            assert_eq!(budget.count.available_permits(), 2);
+            assert_eq!(budget.kbytes.available_permits(), 4);
+        });
     }
 }

--- a/crates/polars-stream/src/nodes/io_sources/shared/pipeline_budget.rs
+++ b/crates/polars-stream/src/nodes/io_sources/shared/pipeline_budget.rs
@@ -28,6 +28,7 @@ impl PipelineBudget {
         }
     }
 
+    #[allow(unused)]
     pub(crate) fn count_limit(&self) -> usize {
         self.count_limit
     }
@@ -37,10 +38,10 @@ impl PipelineBudget {
         self.kbytes_limit
     }
 
-    /// Acquire permit for a fetch of `n_bytes`.
+    /// Acquire a permit for an input item of `n_bytes`.
     ///
     /// Acquisition order is kbytes-first, then count, so that the count_in_use
-    /// value is meaningful. All pipeline paths (parquet, IPC) must acquire
+    /// value is meaningful. All pipeline paths must acquire
     /// through this method so the order can never diverge.
     ///
     /// The requested capacity is cap'ped to avoid deadlock, at the expense of
@@ -96,4 +97,24 @@ impl PipelineBudget {
 pub(crate) struct PipelinePermit {
     _count: OwnedSemaphorePermit,
     _kbytes: OwnedSemaphorePermit,
+}
+
+#[cfg(test)]
+mod tests {
+    use polars_core::runtime::ASYNC;
+
+    use super::PipelineBudget;
+
+    #[test]
+    fn oversized_request_serializes_and_releases_capacity() {
+        let budget = PipelineBudget::new(2, 4);
+
+        let permit = ASYNC.block_on(budget.acquire(16 * 1024));
+        assert_eq!(budget.count.available_permits(), 1);
+        assert_eq!(budget.kbytes.available_permits(), 0);
+
+        drop(permit);
+        assert_eq!(budget.count.available_permits(), 2);
+        assert_eq!(budget.kbytes.available_permits(), 4);
+    }
 }

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -785,6 +785,7 @@ pub fn lower_ir(
                             options: options.clone(),
                             prefetch_limit: RelaxedCell::new_usize(0),
                             prefetch_semaphore: std::sync::OnceLock::new(),
+                            line_batch_budget: std::sync::OnceLock::new(),
                             shared_prefetch_wait_group_slot: Default::default(),
                             io_metrics: std::sync::OnceLock::new(),
                         }) as _

--- a/crates/polars-time/src/chunkedarray/string/infer.rs
+++ b/crates/polars-time/src/chunkedarray/string/infer.rs
@@ -156,7 +156,7 @@ impl StrpTimeParser<i64> for DatetimeInfer<Int64Type> {
                     if let Some(parsed) = self
                         .transform_bytes
                         .parse(val, fmt.as_bytes())
-                        .map(datetime_to_timestamp_us)
+                        .map(transform)
                     {
                         self.latest_fmt = fmt;
                         return Some(parsed);

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1234,6 +1234,62 @@ def test_csv_datetime_fallback_independent_of_execution_chunks(
         assert_frame_equal(result, expected)
 
 
+def test_csv_line_batch_byte_budget_multifile_and_slice(
+    chunk_override: None, tmp_path: Path
+) -> None:
+    value = "x" * 4_096
+    rows_per_file = 160
+    for file_idx in range(2):
+        path = tmp_path / f"part-{file_idx}.csv"
+        path.write_text("value,file\n" + f"{value},{file_idx}\n" * rows_per_file)
+
+    scan = pl.scan_csv(tmp_path / "part-*.csv")
+    result = scan.select(
+        pl.len().alias("n_rows"),
+        pl.col("value").str.len_bytes().sum().alias("n_value_bytes"),
+    ).collect(engine="streaming")
+    expected = pl.DataFrame(
+        {
+            "n_rows": [2 * rows_per_file],
+            "n_value_bytes": [2 * rows_per_file * len(value)],
+        },
+        schema={"n_rows": pl.UInt32, "n_value_bytes": pl.UInt32},
+    )
+    assert_frame_equal(result, expected)
+
+    projected = scan.select("value").collect(engine="streaming")
+    assert projected.height == 2 * rows_per_file
+    assert projected["value"].str.len_bytes().unique().item() == len(value)
+
+    sliced = scan.head(3).collect(engine="streaming")
+    assert sliced.height == 3
+    assert sliced["value"].str.len_bytes().to_list() == [len(value)] * 3
+
+
+def test_csv_line_batch_byte_budget_compressed(
+    chunk_override: None, tmp_path: Path
+) -> None:
+    value = "y" * 4_096
+    n_rows = 320
+    path = tmp_path / "budgeted.csv.gz"
+    with gzip.open(path, mode="wt") as f:
+        f.write("value\n" + f"{value}\n" * n_rows)
+
+    result = (
+        pl.scan_csv(path)
+        .select(
+            pl.len().alias("n_rows"),
+            pl.col("value").str.len_bytes().sum().alias("n_value_bytes"),
+        )
+        .collect(engine="streaming")
+    )
+    expected = pl.DataFrame(
+        {"n_rows": [n_rows], "n_value_bytes": [n_rows * len(value)]},
+        schema={"n_rows": pl.UInt32, "n_value_bytes": pl.UInt32},
+    )
+    assert_frame_equal(result, expected)
+
+
 def test_tz_aware_try_parse_dates(chunk_override: None) -> None:
     data = (
         "a,b,c,d\n"

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1290,6 +1290,49 @@ def test_csv_line_batch_byte_budget_compressed(
     assert_frame_equal(result, expected)
 
 
+def test_csv_line_batch_byte_budget_multifile_compressed_tail(
+    chunk_override: None, tmp_path: Path
+) -> None:
+    value = "z" * 4_096
+    rows_per_file = 160
+    for file_idx in range(3):
+        path = tmp_path / f"part-{file_idx}.csv.gz"
+        with gzip.open(path, mode="wt") as f:
+            f.write("value,file,row\n")
+            for row_idx in range(rows_per_file):
+                f.write(f"{value},{file_idx},{row_idx}\n")
+
+    result = (
+        pl.scan_csv(tmp_path / "part-*.csv.gz")
+        .tail(3)
+        .collect(engine="streaming")
+    )
+
+    assert result["file"].to_list() == [2, 2, 2]
+    assert result["row"].to_list() == [157, 158, 159]
+    assert result["value"].str.len_bytes().to_list() == [len(value)] * 3
+
+
+@pytest.mark.parametrize("compressed", [False, True])
+def test_csv_line_batch_byte_budget_wide_row(
+    chunk_override: None, tmp_path: Path, compressed: bool
+) -> None:
+    value = "w" * (2 * 1024 * 1024 + 17)
+    path = tmp_path / ("wide.csv.gz" if compressed else "wide.csv")
+    data = f"value,row\n{value},0\nshort,1\n"
+
+    if compressed:
+        with gzip.open(path, mode="wt") as f:
+            f.write(data)
+    else:
+        path.write_text(data)
+
+    result = pl.scan_csv(path).collect(engine="streaming")
+
+    assert result["row"].to_list() == [0, 1]
+    assert result["value"].str.len_bytes().to_list() == [len(value), 5]
+
+
 def test_tz_aware_try_parse_dates(chunk_override: None) -> None:
     data = (
         "a,b,c,d\n"

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1143,6 +1143,97 @@ def test_fallback_chrono_parser(chunk_override: None) -> None:
     assert df.null_count().row(0) == (0, 0)
 
 
+def test_csv_datetime_fallback_contract(chunk_override: None, tmp_path: Path) -> None:
+    data = """\
+a
+NULL
+2020-01-01 01:02:03
+2020-01-02 01:02:03.1
+2020-01-03T01:02:03.123
+2020-01-04T010203.123456
+invalid
+2020/01/05 01:02
+"""
+    path = tmp_path / "datetime-fallback.csv"
+    path.write_text(data)
+
+    expected = pl.DataFrame(
+        {
+            "a": pl.Series(
+                [
+                    None,
+                    datetime(2020, 1, 1, 1, 2, 3),
+                    datetime(2020, 1, 2, 1, 2, 3, 100_000),
+                    datetime(2020, 1, 3, 1, 2, 3, 123_000),
+                    datetime(2020, 1, 4, 1, 2, 3, 123_456),
+                    None,
+                    datetime(2020, 1, 5, 1, 2),
+                ],
+                dtype=pl.Datetime("us"),
+            )
+        }
+    )
+
+    assert_frame_equal(
+        pl.read_csv(
+            path,
+            schema_overrides={"a": pl.Datetime("us")},
+            null_values="NULL",
+            ignore_errors=True,
+        ),
+        expected,
+    )
+    assert_frame_equal(
+        pl.scan_csv(
+            path,
+            schema_overrides={"a": pl.Datetime("us")},
+            null_values="NULL",
+            ignore_errors=True,
+        ).collect(),
+        expected,
+    )
+
+    with pytest.raises(ComputeError):
+        pl.read_csv(
+            path,
+            schema_overrides={"a": pl.Datetime("us")},
+            null_values="NULL",
+        )
+
+
+def test_csv_datetime_fallback_independent_of_execution_chunks(
+    chunk_override: None,
+) -> None:
+    values = [
+        "2020-01-01 01:02:03",
+        "2020-01-02 01:02:03.1",
+        "2020-01-03T01:02:03.123",
+        "2020/01/04 01:02",
+    ]
+    expected_values = [
+        datetime(2020, 1, 1, 1, 2, 3),
+        datetime(2020, 1, 2, 1, 2, 3, 100_000),
+        datetime(2020, 1, 3, 1, 2, 3, 123_000),
+        datetime(2020, 1, 4, 1, 2),
+    ]
+    repeats = 1_024
+    data = "a\n" + "\n".join(values * repeats)
+    expected = pl.Series(
+        "a",
+        expected_values * repeats,
+        dtype=pl.Datetime("us"),
+    ).to_frame()
+
+    for n_threads, batch_size in [(1, 64), (2, 1_024)]:
+        result = pl.read_csv(
+            data.encode(),
+            schema_overrides={"a": pl.Datetime("us")},
+            n_threads=n_threads,
+            batch_size=batch_size,
+        )
+        assert_frame_equal(result, expected)
+
+
 def test_tz_aware_try_parse_dates(chunk_override: None) -> None:
     data = (
         "a,b,c,d\n"
@@ -1195,6 +1286,35 @@ a
                     "2020-01-03T00:00:00.132547698",
                 ]
             ).str.to_datetime(time_unit=time_unit)
+        }
+    )
+    assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("time_unit", ["ms", "us", "ns"])
+def test_csv_mixed_datetime_formats_respect_time_unit(
+    chunk_override: None, time_unit: TimeUnit
+) -> None:
+    data = """\
+a
+2020-01-01
+2020-01-02 03:04
+2020-01-03T04:05:06
+"""
+    result = pl.read_csv(
+        io.StringIO(data),
+        schema_overrides={"a": pl.Datetime(time_unit)},
+    )
+    expected = pl.DataFrame(
+        {
+            "a": pl.Series(
+                [
+                    datetime(2020, 1, 1),
+                    datetime(2020, 1, 2, 3, 4),
+                    datetime(2020, 1, 3, 4, 5, 6),
+                ],
+                dtype=pl.Datetime(time_unit),
+            )
         }
     )
     assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1302,11 +1302,7 @@ def test_csv_line_batch_byte_budget_multifile_compressed_tail(
             for row_idx in range(rows_per_file):
                 f.write(f"{value},{file_idx},{row_idx}\n")
 
-    result = (
-        pl.scan_csv(tmp_path / "part-*.csv.gz")
-        .tail(3)
-        .collect(engine="streaming")
-    )
+    result = pl.scan_csv(tmp_path / "part-*.csv.gz").tail(3).collect(engine="streaming")
 
     assert result["file"].to_list() == [2, 2, 2]
     assert result["row"].to_list() == [157, 158, 159]


### PR DESCRIPTION
**Update on Aug 3**: Regression stress testing on compressed files revealed  design gap in CSV pipeline change that is unrelated to the parser patch. Back to draft.

I started with slowdown reported in #28561. My first comparison was between reading timestamp directly as Datetime through schema_overrides and reading it as String followed by explicit conversion. These should perform comparable parsing work, but direct path was substantially slower: about 64 s with one thread and 13.3 s with 16 threads.

Following parser showed that fallback path discarded its `DatetimeInfer` state after every value. Once format-specific byte parser stopped matching, so subsequent values repeatedly searched candidate formats within the same family. I initially treated this as local parser problem: preserve inferred state and continue parsing with it. First patch reduced runtime to approx. 29 s with one thread and 2.8 s with 16 threads.

While validating fix, I found adjacent correctness bug: alternate-format fallback hard-coded microseconds instead of using Datetime unit configured in schema_overrides. Parser commit fixes both.

My initial memory follow-up reduced queue depth from 4 to 1 only for Datetime projections, lowering peak physical footprint from approx. 1,137 MB to 886 MB in initial 16-thread. #27924 provided direct precedent for shared bytes-based in-flight control. #27073 showed that blocking work in CSV reader can deadlock multi-file scans, so I treated progress under multiple files and compressed or async reads as design constraint.

**Proposed design**

Final design keeps distributor and accounts for complete ordinary batch lifecycle:
`one producer-owned batch + N queued batches + N decoder-owned batches = 2N + 1 batches`

CSV distributor uses one queued LineBatch slot per decoder for every output dtype. Scan-wide count-and-byte budget is shared across all files during execution, and its permit travels with each `LineBatch` until `read_chunk` no longer needs source bytes. Multi-file schema inference occurs earlier during planning and is controlled separately by `infer_schema_files`.

I deliberately did not expose byte limit as env variable. Testing showed that tightening byte limit independently of distributor capacity could stall pipeline.  Because permits are acquired before distribution and retained through decoding, count limit covers 2N + 1 ordinary batches, while byte limit scales that capacity by `ByteSourceReader::ideal_read_size()`, currently `512 KiB`. Neither limit is exposed for arbitrary tuning.

<img width="823" height="552" alt="batch-lifecycle-base-vs-final-n2" src="https://github.com/user-attachments/assets/696143ef-a021-42ec-9982-11044fa09dcc" />
<img width="583" height="296" alt="source-lifetime-base-vs-final" src="https://github.com/user-attachments/assets/c1ac2e9c-9cf4-4f65-be94-f310f55c349b" />


**Benchmark**

Measured on Apple M4 with release build and warm local file cache. Input is 75,748,118-row MgBench logs2 CSV. One-thread values are medians of 3 runs; 16-thread values are medians of 5 runs. All compared outputs are exactly equal. 

Physical-footprint runs repeated twice. Values are medians of 4 processes per revision. Peak physical footprint comes from macOS /usr/bin/time -l. Max RSS is misleading here because 6.1 GB CSV is memory-mapped.

<img width="291" height="74" alt="Screenshot 2026-08-02 at 8 59 31 AM" src="https://github.com/user-attachments/assets/fb12d81e-7717-46d2-b18d-3b26f5b37ec7" />
<img width="735" height="98" alt="Screenshot 2026-08-02 at 9 20 15 AM" src="https://github.com/user-attachments/assets/7e32cc1d-8dc7-4de7-a161-5616703b0350" />

**Regression**

Rerun order was base–final–final–base. Each process used Python 3.13.14, 16 threads, streaming engine, and 7 randomized repeats. Combined medians include 14 samples per revision. Every run validated expected schema and all 75,748,118 rows.

<img width="300" height="102" alt="Screenshot 2026-08-02 at 8 59 17 AM" src="https://github.com/user-attachments/assets/b811bbd0-b0ef-4e35-a217-6b0f6b572008" />

**Distributed compute in Polars Cloud** 

I do not know how to test this part without maintainers assistance.
For W workers, each using N decoder pipelines:
- Per-worker line batches:  2N + 1
- Cluster aggregate:        W × (2N + 1)

At 16 decoder pipelines:
- 1 worker:   33 ordinary batches ≈ 16.5 MiB
- 4 workers: 132 ordinary batches ≈ 66 MiB cluster-wide

This budget is created independently by each streaming executor and shared across CSV files handled by that executor. These figures cover only queued and decoding LineBatch source bytes. Raw object-store prefetch, decoded output, shuffle buffers, and scheduler partitioning are outside this budget and were not tested.

**There are two related but separable changes**:
- Parser repair fixes correctness and performance problem behind issue
- CSV pipeline change replaces Datetime-specific queue tuning with uniform queue depth and scan-wide accounting of queued and decoding input bytes

**AI disclosure**:
I used OpenAI Codex for the 2nd change to search related PRs and prior work lineage, draft only final design implementation and tests. I reviewed and edited all changes myself, verified them on my local hardware, and believe they are relevant and correct. First patch and all follow-up testing are my own work without assistance. Final tables assembled by agent and cross-validated.