### PR TITLE
fix(rust): avoid collision when deduplicating CSV header names

### DIFF
--- a/crates/polars-io/src/csv/read/schema_inference.rs
+++ b/crates/polars-io/src/csv/read/schema_inference.rs
@@ -94,12 +94,25 @@ fn infer_headers(mut header_line: &[u8], parse_options: &CsvParseOptions) -> Vec
 
     let mut deduplicated_headers = Vec::with_capacity(headers.len());
     let mut header_names = PlHashMap::with_capacity(headers.len());
+    let mut used_names = PlIndexSet::with_capacity(headers.len());
 
     for name in &headers {
         let count = header_names.entry(name.as_ref()).or_insert(0usize);
         if *count != 0 {
-            deduplicated_headers.push(format_pl_smallstr!("{}_duplicated_{}", name, *count - 1))
+            // Generate a unique name, bumping the suffix if the generated name
+            // collides with an existing or previously generated one.
+            let mut suffix = *count - 1;
+            let unique_name = loop {
+                let candidate = format_pl_smallstr!("{}_duplicated_{}", name, suffix);
+                if !used_names.contains(&candidate) {
+                    break candidate;
+                }
+                suffix += 1;
+            };
+            used_names.insert(unique_name.clone());
+            deduplicated_headers.push(unique_name)
         } else {
+            used_names.insert(PlSmallStr::from_str(name));
             deduplicated_headers.push(PlSmallStr::from_str(name))
         }
         *count += 1;
@@ -387,5 +400,18 @@ mod tests {
         possibilities.insert(DataType::Int64);
         possibilities.insert(DataType::Int128);
         assert_eq!(finish_infer_field_schema(&possibilities), DataType::Int128);
+    }
+
+    #[test]
+    fn test_infer_headers_deduplicates() {
+        let parse_options = CsvParseOptions::default();
+        assert_eq!(
+            infer_headers(b"a,a_duplicated_0,a", &parse_options),
+            vec![
+                PlSmallStr::from_str("a"),
+                PlSmallStr::from_str("a_duplicated_0"),
+                PlSmallStr::from_str("a_duplicated_1"),
+            ],
+        );
     }
 }

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1541,6 +1541,19 @@ def test_duplicated_columns(chunk_override: None) -> None:
     assert pl.read_csv(csv.encode(), new_columns=new).columns == new
 
 
+def test_duplicated_columns_colliding_with_generated_name(chunk_override: None) -> None:
+    csv = textwrap.dedent(
+        """a,a_duplicated_0,a
+    1,2,3
+    """
+    )
+    assert pl.read_csv(csv.encode()).columns == [
+        "a",
+        "a_duplicated_0",
+        "a_duplicated_1",
+    ]
+
+
 def test_error_message(chunk_override: None) -> None:
     data = io.StringIO("target,wind,energy,miso\n1,2,3,4\n1,2,1e5,1\n")
     with pytest.raises(


### PR DESCRIPTION
Fixes #28310

## Problem

When a CSV file contains duplicate column names, Polars renames duplicates to `<name>_duplicated_<N>`. However, the generated name is not checked for collisions with existing column names. For example, with headers `a,a_duplicated_0,a`, the generated name `a_duplicated_0` collides with the existing second column, producing a schema with fewer fields than the data and an obscure error:

```
ComputeError: found more fields than defined in 'Schema'
```

## Fix

In `infer_headers` (crates/polars-io/src/csv/read/schema_inference.rs), track all names already used (both original and generated) and bump the suffix until the generated name is unique:

- `a,a_duplicated_0,a` now deduplicates to `a, a_duplicated_0, a_duplicated_1` (matching the expected behavior in the issue)

## Tests

- Rust unit test `test_infer_headers_deduplicates` in `schema_inference.rs` covering the collision case (verified passing locally: `cargo test -p polars-io --lib --features csv`)
- Python test `test_duplicated_columns_colliding_with_generated_name` in `py-polars/tests/unit/io/test_csv.py` mirroring the issue reproduction

## AI Disclosure

Per the [Polars AI Usage Policy](https://github.com/pola-rs/polars/blob/main/AI_POLICY.md): this PR was written with AI assistance (code generated via an LLM coding assistant and reviewed/verified by a human, including running the Rust test suite locally). The issue is labeled `accepted` and is not marked `good first issue`.