### PR TITLE
fix(csv): avoid duplicate CSV header names colliding with existing literal names

### DIFF
--- a/crates/polars-io/src/csv/read/schema_inference.rs
+++ b/crates/polars-io/src/csv/read/schema_inference.rs
@@ -94,14 +94,25 @@ fn infer_headers(mut header_line: &[u8], parse_options: &CsvParseOptions) -> Vec
 
     let mut deduplicated_headers = Vec::with_capacity(headers.len());
     let mut header_names = PlHashMap::with_capacity(headers.len());
+    let mut used_names = PlHashSet::with_capacity(headers.len());
 
     for name in &headers {
         let count = header_names.entry(name.as_ref()).or_insert(0usize);
-        if *count != 0 {
-            deduplicated_headers.push(format_pl_smallstr!("{}_duplicated_{}", name, *count - 1))
+        let mut candidate = if *count == 0 {
+            PlSmallStr::from_str(name)
         } else {
-            deduplicated_headers.push(PlSmallStr::from_str(name))
+            format_pl_smallstr!("{}_duplicated_{}", name, *count - 1)
+        };
+        // The generated name can collide with a name that already exists in the
+        // header (e.g. the file itself contains a literal "a_duplicated_0" column
+        // next to a repeated "a" column), so keep bumping the counter until the
+        // candidate is actually unique.
+        while used_names.contains(&candidate) {
+            *count += 1;
+            candidate = format_pl_smallstr!("{}_duplicated_{}", name, *count - 1);
         }
+        used_names.insert(candidate.clone());
+        deduplicated_headers.push(candidate);
         *count += 1;
     }
 
@@ -387,5 +398,46 @@ mod tests {
         possibilities.insert(DataType::Int64);
         possibilities.insert(DataType::Int128);
         assert_eq!(finish_infer_field_schema(&possibilities), DataType::Int128);
+    }
+
+    #[test]
+    fn test_infer_headers_dedup_collides_with_existing_literal_name() {
+        // "a" repeats, so the second occurrence is renamed to "a_duplicated_0" -
+        // but the header already contains a literal column named "a_duplicated_0",
+        // so the generated name must keep bumping until it's actually unique
+        // instead of silently colliding with it (polars-io#28310).
+        let parse_options = CsvParseOptions::default();
+        let headers = infer_headers(b"a,a_duplicated_0,a", &parse_options);
+        assert_eq!(
+            headers,
+            vec![
+                PlSmallStr::from_static("a"),
+                PlSmallStr::from_static("a_duplicated_0"),
+                PlSmallStr::from_static("a_duplicated_1"),
+            ]
+        );
+        // Every generated name must be unique - this is really the property the
+        // fix is about, the exact suffix chosen matters less than never colliding.
+        let mut seen = PlHashSet::new();
+        for name in &headers {
+            assert!(seen.insert(name.clone()), "duplicate header name: {name}");
+        }
+    }
+
+    #[test]
+    fn test_infer_headers_dedup_no_collision_case() {
+        // Sanity check the common case is unaffected: two genuinely repeated
+        // names still get sequential suffixes with no literal collision involved.
+        let parse_options = CsvParseOptions::default();
+        let headers = infer_headers(b"a,b,a,a", &parse_options);
+        assert_eq!(
+            headers,
+            vec![
+                PlSmallStr::from_static("a"),
+                PlSmallStr::from_static("b"),
+                PlSmallStr::from_static("a_duplicated_0"),
+                PlSmallStr::from_static("a_duplicated_1"),
+            ]
+        );
     }
 }


### PR DESCRIPTION
Picked this one up because it looked like a well scoped bug with a clear repro and it was already labeled "good first issue", figured it would be a nice way to get a bit more familiar with the csv reader code.

## What I changed

`infer_headers()` in `crates/polars-io/src/csv/read/schema_inference.rs` renames repeated header names to `{name}_duplicated_{n}`, but it only counted how many times the *original* name had shown up. So if a CSV already had a literal column named something like `a_duplicated_0` sitting next to a repeated `a` column, the generated name for the second `a` would collide with that existing literal name instead of being unique. That collision means the final schema ends up with fewer distinct fields than the dataframe actually has, which surfaces later as a pretty confusing `ComputeError` ("found more fields than defined in 'Schema'") instead of something that points at the real issue.

I changed it to keep a set of names that have already been assigned, and keep bumping the counter until the generated name is actually not in that set yet, instead of just trusting the per-name count. Ran through the example from the issue by hand and it now gives `["a", "a_duplicated_0", "a_duplicated_1"]` like the issue described as the expected output.

## Testing

- `cargo test -p polars-io --lib --features csv` — all passing except one pre-existing unrelated failure (`path_utils::tests::test_http_path_with_query_parameters_is_not_expanded_as_glob`) that needs the `cloud` feature enabled to pass and isn't touched by this change at all.
- Added two regression tests in the same file's `tests` module, one matching the exact repro from #28310 and one sanity-checking the normal non-colliding dedup case still works.
- Double checked the new test actually catches the bug: reverted just the fix locally, reran, watched it fail with `["a", "a_duplicated_0", "a_duplicated_0"]` instead of the expected output, then put the fix back and confirmed it passes clean again.
- `cargo fmt -p polars-io -- --check` clean.

Still fairly new to the codebase so let me know if I'm missing some convention here or if there's a better way you'd want this handled, happy to adjust.
