### PR TITLE
docs: add cookbook section to user guide

### DIFF
--- a/docs/source/src/python/user-guide/cookbook/trapz.py
+++ b/docs/source/src/python/user-guide/cookbook/trapz.py
@@ -1,0 +1,35 @@
+# --8<-- [start:setup]
+import polars as pl
+
+
+def trapz(x: pl.Expr, y: pl.Expr) -> pl.Expr:
+    """Integrate with the trapezoidal rule."""
+    return 0.5 * ((x - x.shift()) * (y + y.shift())).sum()
+
+
+# --8<-- [end:setup]
+
+# --8<-- [start:basic]
+df = pl.DataFrame(
+    {
+        "x": [1, 2, 3],
+        "y": [5, 4, 3],
+    }
+)
+
+result = df.select(trapz(pl.col("x"), pl.col("y")).alias("area"))
+print(result)
+# --8<-- [end:basic]
+
+# --8<-- [start:grouped]
+df = pl.DataFrame(
+    {
+        "group": ["a", "a", "a", "b", "b", "b"],
+        "x": [1, 2, 3, 1, 2, 3],
+        "y": [5, 4, 3, 0, 1, 2],
+    }
+)
+
+result = df.group_by("group").agg(trapz(pl.col("x"), pl.col("y")).alias("area"))
+print(result)
+# --8<-- [end:grouped]

--- a/docs/source/user-guide/cookbook/index.md
+++ b/docs/source/user-guide/cookbook/index.md
@@ -1,0 +1,12 @@
+# Cookbook
+
+This section collects common data manipulation patterns that can be expressed with Polars
+expressions, but do not have a dedicated API method. Each recipe shows a reusable approach that you
+can adapt to your own use case.
+
+For a more tutorial-oriented introduction to Polars, see the
+[Polars cookbook](https://github.com/escobar-west/polars-cookbook) by the community.
+
+<!-- dprint-ignore-start -->
+- [Trapezoidal integration](trapz.md) – compute the area under a curve defined by two columns
+<!-- dprint-ignore-end -->

--- a/docs/source/user-guide/cookbook/trapz.md
+++ b/docs/source/user-guide/cookbook/trapz.md
@@ -1,0 +1,48 @@
+# Trapezoidal integration
+
+A common operation in science and engineering is to compute the area under a curve defined by two
+columns. This is often called
+[`trapz`](https://numpy.org/doc/stable/reference/generated/numpy.trapz.html) because the
+trapezoidal rule is a simple way to approximate the integral.
+
+Given an independent variable `x` and a dependent variable `y`, the trapezoidal rule is:
+
+$$
+0.5 \cdot \sum_i (x_{i+1} - x_i) \cdot (y_{i+1} + y_i)
+$$
+
+Polars does not provide a dedicated `trapz` method, but the computation can be expressed with
+[`shift`](../expressions/window-functions.md) and basic arithmetic:
+
+{{code_block('user-guide/cookbook/trapz','trapz',[])}}
+
+```python exec="on" session="user-guide/cookbook/trapz"
+--8<-- "python/user-guide/cookbook/trapz.py:setup"
+```
+
+The expression uses `shift` to compare each row with the previous one, which is equivalent to
+slicing `x[1:] - x[:-1]` and `y[1:] + y[:-1]`. The first row evaluates to `null` because there is
+no previous value, and `sum` ignores `null` values.
+
+## Basic example
+
+{{code_block('user-guide/cookbook/trapz','basic',['DataFrame','select'])}}
+
+```python exec="on" result="text" session="user-guide/cookbook/trapz"
+--8<-- "python/user-guide/cookbook/trapz.py:basic"
+```
+
+## Per-group integration
+
+The same expression works inside `group_by` when applied with `agg`:
+
+{{code_block('user-guide/cookbook/trapz','grouped',['DataFrame','group_by','agg'])}}
+
+```python exec="on" result="text" session="user-guide/cookbook/trapz"
+--8<-- "python/user-guide/cookbook/trapz.py:grouped"
+```
+
+!!! note
+
+    The independent variable `x` should be weakly monotonically increasing within each group. If the
+    rows are not ordered, sort the data before computing the integral.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,9 @@ nav:
       - Migrating:
         - user-guide/migration/pandas.md
         - user-guide/migration/spark.md
+      - Cookbook:
+        - user-guide/cookbook/index.md
+        - user-guide/cookbook/trapz.md
       - Misc:
         - user-guide/ecosystem.md
         - user-guide/misc/multiprocessing.md


### PR DESCRIPTION
## Summary
- Add a Cookbook section to the user guide with an index page linking to the community cookbook.
- Include a trapezoidal integration (`trapz`) recipe using `shift`, with runnable Python examples.
- Wire the section into `mkdocs.yml` nav between Migrating and Misc.

Fixes #13064

## Test plan
- [ ] Run `mkdocs serve` and confirm Cookbook appears in the nav
- [ ] Check `trapz` examples render and match expected results (basic `8.0`; grouped `a=8.0`, `b=2.0`)


Made with [Cursor](https://cursor.com)