### PR TITLE
docs(python): widen API nav sidebar on large screens

### DIFF
--- a/py-polars/docs/source/_static/css/custom.css
+++ b/py-polars/docs/source/_static/css/custom.css
@@ -29,6 +29,19 @@ div.bd-sidebar-primary {
     background-image: linear-gradient(90deg, var(--pst-gradient-sidebar-left) 0%, var(--pst-gradient-sidebar-right) 100%);
 }
 
+/*
+ * Widen the primary nav sidebar on large screens (default is 25% / col-3).
+ * Only apply at the lg breakpoint and above, where the sidebar sits beside
+ * the article; on smaller viewports the theme collapses it into a drawer.
+ * Ref: https://github.com/pola-rs/polars/issues/22580
+ */
+@media (min-width: 992px) {
+    div.bd-sidebar-primary {
+        flex: 0 0 auto;
+        width: 33.33333333%;
+    }
+}
+
 div.sd-card {
     background-image: linear-gradient(0deg, var(--pst-gradient-sidebar-left) 0%, var(--pst-gradient-sidebar-right) 100%);
 }


### PR DESCRIPTION
## Summary
- Widen the Python API primary sidebar from 25% to 33% on screens ≥992px so longer index entries wrap less awkwardly.
- Leave mobile/tablet layouts unchanged (sidebar still collapses into a drawer below the `lg` breakpoint).

Fixes #22580

## Test plan
- [ ] Build/serve Python API docs and check pages like `/reference/dataframe/group_by.html` on desktop
- [ ] Confirm sidebar still collapses correctly on viewports &lt;992px


Made with [Cursor](https://cursor.com)