### PR TITLE
feat: Improve error message when CSV name de-duplication fails

### DIFF
--- a/crates/polars-io/src/csv/read/schema_inference.rs
+++ b/crates/polars-io/src/csv/read/schema_inference.rs
@@ -22,10 +22,11 @@ pub(super) fn infer_file_schema_impl(
     column_names_overwrite: Option<&[PlSmallStr]>,
     schema_overwrite: Option<&Schema>,
 ) -> PolarsResult<Schema> {
-    let mut headers = header_line
-        .as_ref()
-        .map(|line| infer_headers(line, parse_options))
-        .unwrap_or_else(|| Vec::with_capacity(8));
+    let mut headers = if let Some(header_line) = header_line {
+        infer_headers(header_line, parse_options)?
+    } else {
+        Vec::with_capacity(8)
+    };
 
     let extend_header_with_unknown_column = header_line.is_none();
 
@@ -67,7 +68,10 @@ pub(super) fn infer_file_schema_impl(
     Ok(build_schema(&headers, &column_types, schema_overwrite))
 }
 
-fn infer_headers(mut header_line: &[u8], parse_options: &CsvParseOptions) -> Vec<PlSmallStr> {
+fn infer_headers(
+    mut header_line: &[u8],
+    parse_options: &CsvParseOptions,
+) -> PolarsResult<Vec<PlSmallStr>> {
     let len = header_line.len();
 
     if header_line.last().copied() == Some(b'\r') {
@@ -92,20 +96,40 @@ fn infer_headers(mut header_line: &[u8], parse_options: &CsvParseOptions) -> Vec
         })
         .collect::<Vec<_>>();
 
-    let mut deduplicated_headers = Vec::with_capacity(headers.len());
+    let mut deduplicated_headers = PlIndexSet::with_capacity(headers.len());
     let mut header_names = PlHashMap::with_capacity(headers.len());
 
     for name in &headers {
         let count = header_names.entry(name.as_ref()).or_insert(0usize);
-        if *count != 0 {
-            deduplicated_headers.push(format_pl_smallstr!("{}_duplicated_{}", name, *count - 1))
+        let duplicated = *count != 0;
+        let deduplicated_name = if duplicated {
+            format_pl_smallstr!("{}_duplicated_{}", name, *count - 1)
         } else {
-            deduplicated_headers.push(PlSmallStr::from_str(name))
+            PlSmallStr::from_str(name)
+        };
+
+        if !deduplicated_headers.insert(deduplicated_name.clone()) {
+            let (deduplicated_from, nth_duplicated) = if duplicated {
+                (name.as_ref(), 1 + *count)
+            } else {
+                let i = deduplicated_name.rfind("_duplicated_").unwrap();
+                (
+                    &deduplicated_name[..i],
+                    2 + deduplicated_name[i + 12..].parse::<usize>().unwrap(),
+                )
+            };
+
+            polars_bail!(
+                Duplicate:
+                "de-duplication of occurrence #{nth_duplicated} of column name '{deduplicated_from}' \
+                failed; the name '{deduplicated_name}' also exists in the file."
+            )
         }
+
         *count += 1;
     }
 
-    deduplicated_headers
+    Ok(Vec::from_iter(deduplicated_headers))
 }
 
 fn infer_types_from_line(

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -18,7 +18,12 @@ import zstandard
 
 import polars as pl
 from polars._utils.various import normalize_filepath
-from polars.exceptions import ComputeError, InvalidOperationError, NoDataError
+from polars.exceptions import (
+    ComputeError,
+    DuplicateError,
+    InvalidOperationError,
+    NoDataError,
+)
 from polars.io.csv import BatchedCsvReader
 from polars.testing import assert_frame_equal, assert_series_equal
 from tests.conftest import PlMonkeyPatch
@@ -3219,3 +3224,23 @@ def test_read_csv_missing_utf8_is_empty_string_deprecated() -> None:
         match=r"`missing_utf8_is_empty_string` for `read_csv` is deprecated",
     ):
         pl.read_csv(b"a,b\n1,2", missing_utf8_is_empty_string=True)  # type: ignore[call-arg]
+
+
+def test_read_csv_name_deduplication_conflict_28310() -> None:
+    err_msg = "de-duplication of occurrence #2 of column name 'a' failed; the name 'a_duplicated_0' also exists in the file."
+
+    q = pl.scan_csv(b"""\
+a,a,a_duplicated_0
+1,2,3
+""")
+
+    with pytest.raises(DuplicateError, match=err_msg):
+        q.collect()
+
+    q = pl.scan_csv(b"""\
+a,a_duplicated_0,a
+1,2,3
+""")
+
+    with pytest.raises(DuplicateError, match=err_msg):
+        q.collect()


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/28310

E.g. -
```python
import polars as pl

q = pl.scan_csv(b"""\
a,a,a_duplicated_0
1,2,3
""")

print(q.collect())
```

* Before - `ComputeError: found more fields than defined in 'Schema' Consider setting 'truncate_ragged_lines=True'.`
* After - `de-duplication of occurence #2 of column name 'a' failed; the name 'a_duplicated_0' also exists in the file.`
