### PR TITLE
fix: Fix Arrow buffer offset for `Utf8` and `Binary`

### DIFF
--- a/crates/polars-arrow/src/array/binary/ffi.rs
+++ b/crates/polars-arrow/src/array/binary/ffi.rs
@@ -10,8 +10,8 @@ unsafe impl<O: Offset> ToFfi for BinaryArray<O> {
     fn buffers(&self) -> Vec<Option<*const u8>> {
         vec![
             self.validity.as_ref().map(|x| x.as_ptr()),
-            Some(self.offsets.buffer().storage_ptr().cast::<u8>()),
-            Some(self.values.storage_ptr().cast::<u8>()),
+            Some(self.offsets.buffer().as_ptr().cast::<u8>()),
+            Some(self.values.as_ptr().cast::<u8>()),
         ]
     }
 

--- a/crates/polars-arrow/src/array/utf8/ffi.rs
+++ b/crates/polars-arrow/src/array/utf8/ffi.rs
@@ -10,8 +10,8 @@ unsafe impl<O: Offset> ToFfi for Utf8Array<O> {
     fn buffers(&self) -> Vec<Option<*const u8>> {
         vec![
             self.validity.as_ref().map(|x| x.as_ptr()),
-            Some(self.offsets.buffer().storage_ptr().cast::<u8>()),
-            Some(self.values.storage_ptr().cast::<u8>()),
+            Some(self.offsets.buffer().as_ptr().cast::<u8>()),
+            Some(self.values.as_ptr().cast::<u8>()),
         ]
     }
 


### PR DESCRIPTION
Follow-up to https://github.com/pola-rs/polars/pull/28623.

Fixes latent bug. No reproducer, but all known tests (including one-off harness) pass. Other types are not affected.

Fyi @nameexhaustion 