### PR TITLE
fix: Retain datetime inference across CSV fallback

### DIFF
--- a/crates/polars-io/src/csv/read/builder.rs
+++ b/crates/polars-io/src/csv/read/builder.rs
@@ -478,42 +478,59 @@ where
         }
     };
 
-    let pattern = match &buf.compiled {
-        Some(compiled) => compiled.pattern,
-        None => match infer_pattern_single(val) {
-            Some(pattern) => pattern,
-            None => {
-                if ignore_errors {
-                    buf.builder.append_null();
-                    return Ok(());
-                } else {
-                    polars_bail!(ComputeError: "could not find a 'date/datetime' pattern for '{}'", val)
-                }
-            },
+    let pattern;
+    let parsed = match &mut buf.compiled {
+        // Retain the inferred candidate state across byte-parser misses. Rebuilding
+        // from `Pattern` here would reset the preferred format for every value.
+        Some(infer) => {
+            pattern = infer.pattern;
+            infer.parse(val)
         },
-    };
-    match DatetimeInfer::try_from_with_unit(pattern, time_unit) {
-        Ok(mut infer) => {
-            let parsed = infer.parse(val);
-            let Some(parsed) = parsed else {
-                if ignore_errors {
-                    buf.builder.append_null();
-                    return Ok(());
-                } else {
-                    polars_bail!(ComputeError: "could not parse '{}' with pattern '{:?}'", val, pattern)
-                }
+        None => {
+            pattern = match infer_pattern_single(val) {
+                Some(pattern) => pattern,
+                None => {
+                    if ignore_errors {
+                        buf.builder.append_null();
+                        return Ok(());
+                    } else {
+                        polars_bail!(ComputeError: "could not find a 'date/datetime' pattern for '{}'", val)
+                    }
+                },
             };
 
-            buf.compiled = Some(infer);
+            let mut infer = match DatetimeInfer::try_from_with_unit(pattern, time_unit) {
+                Ok(infer) => infer,
+                Err(err) => {
+                    if ignore_errors {
+                        buf.builder.append_null();
+                        return Ok(());
+                    } else {
+                        return Err(err);
+                    }
+                },
+            };
+            let parsed = infer.parse(val);
+            if parsed.is_some() {
+                // Match the previous initialization behavior: only retain a parser
+                // after it has successfully parsed a value.
+                buf.compiled = Some(infer);
+            }
+            parsed
+        },
+    };
+
+    match parsed {
+        Some(parsed) => {
             buf.builder.append_value(parsed);
             Ok(())
         },
-        Err(err) => {
+        None => {
             if ignore_errors {
                 buf.builder.append_null();
                 Ok(())
             } else {
-                Err(err)
+                polars_bail!(ComputeError: "could not parse '{}' with pattern '{:?}'", val, pattern)
             }
         },
     }

--- a/crates/polars-time/src/chunkedarray/string/infer.rs
+++ b/crates/polars-time/src/chunkedarray/string/infer.rs
@@ -156,7 +156,7 @@ impl StrpTimeParser<i64> for DatetimeInfer<Int64Type> {
                     if let Some(parsed) = self
                         .transform_bytes
                         .parse(val, fmt.as_bytes())
-                        .map(datetime_to_timestamp_us)
+                        .map(transform)
                     {
                         self.latest_fmt = fmt;
                         return Some(parsed);

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1224,12 +1224,11 @@ def test_csv_datetime_fallback_independent_of_execution_chunks(
         dtype=pl.Datetime("us"),
     ).to_frame()
 
-    for n_threads, batch_size in [(1, 64), (2, 1_024)]:
+    for n_threads in [1, 2]:
         result = pl.read_csv(
             data.encode(),
             schema_overrides={"a": pl.Datetime("us")},
             n_threads=n_threads,
-            batch_size=batch_size,
         )
         assert_frame_equal(result, expected)
 

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1143,6 +1143,97 @@ def test_fallback_chrono_parser(chunk_override: None) -> None:
     assert df.null_count().row(0) == (0, 0)
 
 
+def test_csv_datetime_fallback_contract(chunk_override: None, tmp_path: Path) -> None:
+    data = """\
+a
+NULL
+2020-01-01 01:02:03
+2020-01-02 01:02:03.1
+2020-01-03T01:02:03.123
+2020-01-04T010203.123456
+invalid
+2020/01/05 01:02
+"""
+    path = tmp_path / "datetime-fallback.csv"
+    path.write_text(data)
+
+    expected = pl.DataFrame(
+        {
+            "a": pl.Series(
+                [
+                    None,
+                    datetime(2020, 1, 1, 1, 2, 3),
+                    datetime(2020, 1, 2, 1, 2, 3, 100_000),
+                    datetime(2020, 1, 3, 1, 2, 3, 123_000),
+                    datetime(2020, 1, 4, 1, 2, 3, 123_456),
+                    None,
+                    datetime(2020, 1, 5, 1, 2),
+                ],
+                dtype=pl.Datetime("us"),
+            )
+        }
+    )
+
+    assert_frame_equal(
+        pl.read_csv(
+            path,
+            schema_overrides={"a": pl.Datetime("us")},
+            null_values="NULL",
+            ignore_errors=True,
+        ),
+        expected,
+    )
+    assert_frame_equal(
+        pl.scan_csv(
+            path,
+            schema_overrides={"a": pl.Datetime("us")},
+            null_values="NULL",
+            ignore_errors=True,
+        ).collect(),
+        expected,
+    )
+
+    with pytest.raises(ComputeError):
+        pl.read_csv(
+            path,
+            schema_overrides={"a": pl.Datetime("us")},
+            null_values="NULL",
+        )
+
+
+def test_csv_datetime_fallback_independent_of_execution_chunks(
+    chunk_override: None,
+) -> None:
+    values = [
+        "2020-01-01 01:02:03",
+        "2020-01-02 01:02:03.1",
+        "2020-01-03T01:02:03.123",
+        "2020/01/04 01:02",
+    ]
+    expected_values = [
+        datetime(2020, 1, 1, 1, 2, 3),
+        datetime(2020, 1, 2, 1, 2, 3, 100_000),
+        datetime(2020, 1, 3, 1, 2, 3, 123_000),
+        datetime(2020, 1, 4, 1, 2),
+    ]
+    repeats = 1_024
+    data = "a\n" + "\n".join(values * repeats)
+    expected = pl.Series(
+        "a",
+        expected_values * repeats,
+        dtype=pl.Datetime("us"),
+    ).to_frame()
+
+    for n_threads, batch_size in [(1, 64), (2, 1_024)]:
+        result = pl.read_csv(
+            data.encode(),
+            schema_overrides={"a": pl.Datetime("us")},
+            n_threads=n_threads,
+            batch_size=batch_size,
+        )
+        assert_frame_equal(result, expected)
+
+
 def test_tz_aware_try_parse_dates(chunk_override: None) -> None:
     data = (
         "a,b,c,d\n"
@@ -1195,6 +1286,35 @@ a
                     "2020-01-03T00:00:00.132547698",
                 ]
             ).str.to_datetime(time_unit=time_unit)
+        }
+    )
+    assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("time_unit", ["ms", "us", "ns"])
+def test_csv_mixed_datetime_formats_respect_time_unit(
+    chunk_override: None, time_unit: TimeUnit
+) -> None:
+    data = """\
+a
+2020-01-01
+2020-01-02 03:04
+2020-01-03T04:05:06
+"""
+    result = pl.read_csv(
+        io.StringIO(data),
+        schema_overrides={"a": pl.Datetime(time_unit)},
+    )
+    expected = pl.DataFrame(
+        {
+            "a": pl.Series(
+                [
+                    datetime(2020, 1, 1),
+                    datetime(2020, 1, 2, 3, 4),
+                    datetime(2020, 1, 3, 4, 5, 6),
+                ],
+                dtype=pl.Datetime(time_unit),
+            )
         }
     )
     assert_frame_equal(result, expected)


### PR DESCRIPTION
Closes #28561

Retains inferred `DatetimeInfer` state across CSV fallback values and uses `ms`/`us`/`ns` unit configured by `schema_overrides` instead of hard-coded microseconds.

I assume this has been intended scope. Any additional experiments will stay in standalone branch and PR.
Optional `%.f` support could be included into this scope, but I need explicit confirmation.

All testing was conducted on macOS with Apple M4 Max and min free 30 GB RAM.

**Benchmark**

| Threads | Base elapsed | PR elapsed | Change | 
| ---: | ---: | ---: | ---: | 
| 1 | 62.183 s | 28.159 s | −54.7% | 
| 16 | 13.382 s | 3.293 s | −75.4% | 

On 16 threads, there is +13.9% in peak physical footprint (948 MB  -> 1,080 MB). That's not max RSS. Again, that's specific macOS measurement that could be misleading.

**Regression coverage**
- eager read_csv and lazy scan_csv
- mixed datetime fallback formats
- null and invalid values under strict and ignore_errors behavior
- output independence from thread count
- configured ms, us, and ns units
- exact output validation across all benchmark rows

Compression is resolved before bytes reach datetime parser. PR changes neither decompression, async scheduling,
queue depth. gzip stress testing is not required.