### PR TITLE
chore(rust): Remove Rust compiler intrinsics, use nightly functions

### DIFF
--- a/crates/polars-utils/src/algebraic_ops.rs
+++ b/crates/polars-utils/src/algebraic_ops.rs
@@ -2,7 +2,7 @@
 pub fn alg_add_f64(a: f64, b: f64) -> f64 {
     #[cfg(feature = "nightly")]
     {
-        std::intrinsics::fadd_algebraic(a, b)
+        a.algebraic_add(b)
     }
     #[cfg(not(feature = "nightly"))]
     {
@@ -14,7 +14,7 @@ pub fn alg_add_f64(a: f64, b: f64) -> f64 {
 pub fn alg_mul_f64(a: f64, b: f64) -> f64 {
     #[cfg(feature = "nightly")]
     {
-        std::intrinsics::fmul_algebraic(a, b)
+        a.algebraic_mul(b)
     }
     #[cfg(not(feature = "nightly"))]
     {
@@ -23,5 +23,7 @@ pub fn alg_mul_f64(a: f64, b: f64) -> f64 {
 }
 
 pub fn alg_sum_f64(it: impl IntoIterator<Item = f64>) -> f64 {
-    it.into_iter().fold(0.0, alg_add_f64)
+    // Negative zero is identity element of floating point addition, not
+    // positive zero (since -0.0 + 0.0 = 0.0).
+    it.into_iter().fold(-0.0, alg_add_f64)
 }

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -2,7 +2,7 @@
     all(target_arch = "aarch64", feature = "nightly"),
     feature(stdarch_aarch64_prefetch)
 )]
-#![cfg_attr(feature = "nightly", feature(core_intrinsics))] // For algebraic ops, select_unpredictable.
+#![cfg_attr(feature = "nightly", feature(float_algebraic))]
 #![cfg_attr(feature = "nightly", allow(internal_features))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 pub mod abs_diff;


### PR DESCRIPTION
There's no need to use the highly unstable intrinsics anymore.