### PR TITLE
fix(rust): Make `cum_sum` wrap integer overflow

### DIFF
--- a/crates/polars-ops/src/series/ops/cum_agg.rs
+++ b/crates/polars-ops/src/series/ops/cum_agg.rs
@@ -4,6 +4,7 @@ use arity::unary_elementwise_values;
 use arrow::array::{Array, BooleanArray};
 use arrow::bitmap::{Bitmap, BitmapBuilder};
 use num_traits::{AsPrimitive, Bounded, One, Zero};
+use polars_compute::sum::WrappingAdd;
 use polars_core::prelude::*;
 use polars_core::series::IsSorted;
 use polars_core::utils::{CustomIterTools, NoNull};
@@ -29,9 +30,9 @@ where
 
 fn det_sum<T>(state: &mut T, v: Option<T>) -> Option<T>
 where
-    T: Copy + AddAssign,
+    T: Copy + WrappingAdd,
 {
-    *state += v?;
+    *state = state.wrapping_add(&v?);
     Some(*state)
 }
 
@@ -202,6 +203,7 @@ fn cum_sum_numeric<T>(
 ) -> ChunkedArray<T>
 where
     T: PolarsNumericType,
+    T::Native: WrappingAdd,
     ChunkedArray<T>: FromIterator<Option<T::Native>>,
 {
     let init = init.unwrap_or(T::Native::zero());
@@ -347,6 +349,22 @@ pub fn cum_sum_with_init(
 /// first cast to `Int64` to prevent overflow issues.
 pub fn cum_sum(s: &Series, reverse: bool) -> PolarsResult<Series> {
     cum_sum_with_init(s, reverse, &AnyValue::Null)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cum_sum_wraps_integer_overflow() {
+        let values = Int64Chunked::from_slice("values".into(), &[i64::MAX, 1]);
+        let result = cum_sum_numeric(&values, false, None);
+
+        assert_eq!(
+            result.into_no_null_iter().collect::<Vec<_>>(),
+            [i64::MAX, i64::MIN]
+        );
+    }
 }
 
 pub fn cum_min_with_init(

--- a/crates/polars-ops/src/series/ops/cum_agg.rs
+++ b/crates/polars-ops/src/series/ops/cum_agg.rs
@@ -351,22 +351,6 @@ pub fn cum_sum(s: &Series, reverse: bool) -> PolarsResult<Series> {
     cum_sum_with_init(s, reverse, &AnyValue::Null)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn cum_sum_wraps_integer_overflow() {
-        let values = Int64Chunked::from_slice("values".into(), &[i64::MAX, 1]);
-        let result = cum_sum_numeric(&values, false, None);
-
-        assert_eq!(
-            result.into_no_null_iter().collect::<Vec<_>>(),
-            [i64::MAX, i64::MIN]
-        );
-    }
-}
-
 pub fn cum_min_with_init(
     s: &Series,
     reverse: bool,
@@ -492,4 +476,20 @@ fn cum_count_no_nulls(name: PlSmallStr, len: usize, reverse: bool, init: IdxSize
     let mut ca = ca.into_inner();
     ca.rename(name);
     ca.into_series()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cum_sum_wraps_integer_overflow() {
+        let values = Int64Chunked::from_slice("values".into(), &[i64::MAX, 1]);
+        let result = cum_sum_numeric(&values, false, None);
+
+        assert_eq!(
+            result.into_no_null_iter().collect::<Vec<_>>(),
+            [i64::MAX, i64::MIN]
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- reuse Polars shared `WrappingAdd` semantics in cumulative numeric aggregation
- keep `cum_sum` consistent with `sum()` and binary integer addition at type boundaries
- add a regression for `Int64` `[i64::MAX, 1]`

Fixes #28660

## Root cause
The cumulative numeric helper used ordinary `AddAssign`. In debug/test builds, an `Int64` overflow therefore panicked instead of following the wrapping behavior already used by Polars aggregate `sum()` and binary arithmetic. The shared `polars_compute::sum::WrappingAdd` trait already defines the intended behavior for integer and floating-point native values.

## Validation
- `cargo test -p polars-ops --features cum_agg --lib` (2 passed)
- `rustup run nightly-aarch64-apple-darwin cargo fmt --all -- --check`
- `git diff --check`
- GitHub clippy initially found `clippy::items_after_test_module`; commit `27c838933a33ec9561db15eea048055bd8553c9e` moves the regression module to the end of the file. The rerun is queued.
- Local clippy is limited by the checkout's missing nightly component and stable's unsupported `array_windows` feature; the GitHub workflow is authoritative.

## AI disclosure
I am an AI agent, using OpenAI Codex. I used AI to help trace the overflow behavior, implement the focused change, and add the regression test. I reviewed all changes myself and believe they are relevant and correct.

## Contribution metadata
- Commit is signed off under the Developer Certificate of Origin.
- No third-party code was copied.
