### PR TITLE
depr: Deprecate `struct.rename_fields()` with an incorrect number of fields

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/function_expr/struct_.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/struct_.rs
@@ -32,6 +32,21 @@ impl IRStructFunction {
             }),
             RenameFields(names) => mapper.map_dtype(|dt| match dt {
                 DataType::Struct(fields) => {
+                    if names.len() != fields.len() {
+                        let dropped_str = match fields.len() as isize - names.len() as isize {
+                            1 => String::from("field of the struct"),
+                            -1 => String::from("name of the argument"),
+                            n if n > 0 => format!("{n} fields of the struct"),
+                            n  => format!("{n} names of the argument"),
+                        };
+                        polars_warn!(
+                            Deprecation,
+                            "struct.rename_fields() argument has a different number of fields than the struct it operates on ({} vs {}).\n\
+                            This silently drops the last {dropped_str}, and it will become an error in Polars 2.0.\n\
+                            To replicate the old behavior and suppress this warning, use struct.drop_fields() to drop the trailing struct fields first (if any) and then call struct.rename_fields() normally.",
+                            names.len(), fields.len(),
+                        )
+                    }
                     let fields = fields
                         .iter()
                         .zip(names.as_ref())

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import operator
+import re
 from dataclasses import dataclass
 from datetime import datetime, time
 from typing import TYPE_CHECKING, Any
@@ -1102,6 +1103,17 @@ def test_struct_null_zip() -> None:
     )
 
 
+def test_rename_fields_len_mismatch_deprecated() -> None:
+    s = pl.Series("s", [{"a": 1, "b": 2}])
+    s.struct.rename_fields(["x"])  # Should not warn
+
+    msg = "struct.rename_fields() argument has a different number of fields than the struct it operates on"
+    with pytest.warns(DeprecationWarning, match=re.escape(f"{msg} (1 vs 2)")):
+        s.struct.rename_fields(["x"])
+    with pytest.warns(DeprecationWarning, match=re.escape(f"{msg} (3 vs 2)")):
+        s.struct.rename_fields(["x", "y", "z"])
+
+
 @pytest.mark.may_fail_cloud  # reason: ZFS
 @pytest.mark.parametrize("size", [0, 1, 2, 5, 9, 13, 42])
 def test_zfs_construction(size: int) -> None:
@@ -1185,11 +1197,7 @@ def test_zfs_struct_fns() -> None:
     a = pl.Series("a", [{}], pl.Struct([]))
 
     assert a.struct.fields == []
-
-    # @TODO: This should really throw an error as per #19132
-    assert a.struct.rename_fields(["a"]).struct.unnest().shape == (1, 0)
     assert a.struct.rename_fields([]).struct.unnest().shape == (1, 0)
-
     assert_series_equal(a.struct.json_encode(), pl.Series("a", ["{}"], pl.String))
 
 


### PR DESCRIPTION
After: https://github.com/pola-rs/polars/pull/28666

Related issue: https://github.com/pola-rs/polars/issues/26002