### PR TITLE
fix: Don't preserve sorted flag through non-monotonic `dt.date()`/`dt.truncate()`

### DIFF
--- a/crates/polars-expr/src/dispatch/datetime.rs
+++ b/crates/polars-expr/src/dispatch/datetime.rs
@@ -88,22 +88,19 @@ pub(super) fn date(s: &Column) -> PolarsResult<Column> {
     match s.dtype() {
         #[cfg(feature = "timezones")]
         DataType::Datetime(_, Some(_)) => {
-            let mut out = {
-                polars_ops::chunked_array::replace_time_zone(
-                    s.datetime().unwrap(),
-                    None,
-                    &StringChunked::from_iter(std::iter::once("raise")),
-                    NonExistent::Raise,
-                )?
-                .cast(&DataType::Date)?
-            };
-            // `replace_time_zone` may unset sorted flag. But, we're only taking the date
-            // part of the result, so we can safely preserve the sorted flag here. We may
-            // need to make an exception if a time zone introduces a change which involves
-            // "going back in time" and repeating a day, but we're not aware of that ever
-            // having happened.
-            out.set_sorted_flag(s.is_sorted_flag());
-            Ok(out.into())
+            // The sorted flag is inherited from `replace_time_zone`, which only preserves it
+            // for time zones that cannot reorder the local clock. Don't propagate it from `s`
+            // here: an offset change can move the local *date* backwards while UTC moves
+            // forwards (e.g. `Antarctica/Casey` 2010-03-04, +11 -> +08), which would leave a
+            // genuinely unsorted column claiming to be sorted.
+            polars_ops::chunked_array::replace_time_zone(
+                s.datetime().unwrap(),
+                None,
+                &StringChunked::from_iter(std::iter::once("raise")),
+                NonExistent::Raise,
+            )?
+            .cast(&DataType::Date)
+            .map(Column::from)
         },
         DataType::Datetime(_, _) => s
             .datetime()
@@ -279,20 +276,20 @@ pub(super) fn truncate(s: &[Column]) -> PolarsResult<Column> {
     let time_series = &s[0];
     let every = s[1].str()?;
 
-    let mut out = match time_series.dtype() {
+    // Note: `truncate` maintains the sorted flag itself, as only it knows whether the
+    // truncation it performed is order-preserving.
+    match time_series.dtype() {
         DataType::Datetime(_, tz) => match tz {
             #[cfg(feature = "timezones")]
-            Some(tz) => time_series
+            Some(tz) => Ok(time_series
                 .datetime()?
                 .truncate(tz.parse::<Tz>().ok().as_ref(), every)?
-                .into_column(),
-            _ => time_series.datetime()?.truncate(None, every)?.into_column(),
+                .into_column()),
+            _ => Ok(time_series.datetime()?.truncate(None, every)?.into_column()),
         },
-        DataType::Date => time_series.date()?.truncate(None, every)?.into_column(),
+        DataType::Date => Ok(time_series.date()?.truncate(None, every)?.into_column()),
         dt => polars_bail!(opq = round, got = dt, expected = "date/datetime"),
-    };
-    out.set_sorted_flag(time_series.is_sorted_flag());
-    Ok(out)
+    }
 }
 
 #[cfg(feature = "offset_by")]

--- a/crates/polars-expr/src/dispatch/datetime.rs
+++ b/crates/polars-expr/src/dispatch/datetime.rs
@@ -88,22 +88,19 @@ pub(super) fn date(s: &Column) -> PolarsResult<Column> {
     match s.dtype() {
         #[cfg(feature = "timezones")]
         DataType::Datetime(_, Some(_)) => {
-            let mut out = {
-                polars_ops::chunked_array::replace_time_zone(
-                    s.datetime().unwrap(),
-                    None,
-                    &StringChunked::from_iter(std::iter::once("raise")),
-                    NonExistent::Raise,
-                )?
-                .cast(&DataType::Date)?
-            };
-            // `replace_time_zone` may unset sorted flag. But, we're only taking the date
-            // part of the result, so we can safely preserve the sorted flag here. We may
-            // need to make an exception if a time zone introduces a change which involves
-            // "going back in time" and repeating a day, but we're not aware of that ever
-            // having happened.
-            out.set_sorted_flag(s.is_sorted_flag());
-            Ok(out.into())
+            // The sorted flag is inherited from `replace_time_zone`, which only preserves it
+            // for time zones that cannot reorder the local clock. Don't propagate it from `s`
+            // here: an offset change can move the local *date* backwards while UTC moves
+            // forwards (e.g. `Antarctica/Casey` 2010-03-04, +11 -> +08), which would leave a
+            // genuinely unsorted column claiming to be sorted.
+            polars_ops::chunked_array::replace_time_zone(
+                s.datetime().unwrap(),
+                None,
+                &StringChunked::from_iter(std::iter::once("raise")),
+                NonExistent::Raise,
+            )?
+            .cast(&DataType::Date)
+            .map(Column::from)
         },
         DataType::Datetime(_, _) => s
             .datetime()
@@ -314,20 +311,20 @@ pub(super) fn truncate(s: &[Column]) -> PolarsResult<Column> {
     let time_series = &s[0];
     let every = s[1].str()?;
 
-    let mut out = match time_series.dtype() {
+    // Note: `truncate` maintains the sorted flag itself, as only it knows whether the
+    // truncation it performed is order-preserving.
+    match time_series.dtype() {
         DataType::Datetime(_, tz) => match tz {
             #[cfg(feature = "timezones")]
-            Some(tz) => time_series
+            Some(tz) => Ok(time_series
                 .datetime()?
                 .truncate(tz.parse::<Tz>().ok().as_ref(), every)?
-                .into_column(),
-            _ => time_series.datetime()?.truncate(None, every)?.into_column(),
+                .into_column()),
+            _ => Ok(time_series.datetime()?.truncate(None, every)?.into_column()),
         },
-        DataType::Date => time_series.date()?.truncate(None, every)?.into_column(),
+        DataType::Date => Ok(time_series.date()?.truncate(None, every)?.into_column()),
         dt => polars_bail!(opq = round, got = dt, expected = "date/datetime"),
-    };
-    out.set_sorted_flag(time_series.is_sorted_flag());
-    Ok(out)
+    }
 }
 
 #[cfg(feature = "offset_by")]

--- a/crates/polars-time/src/truncate.rs
+++ b/crates/polars-time/src/truncate.rs
@@ -18,143 +18,180 @@ pub(crate) fn fast_truncate(t: i64, every: i64) -> i64 {
     t - (remainder + every * (remainder < 0) as i64)
 }
 
+/// Whether truncating by `every` in `time_zone` maps sorted input to sorted output.
+///
+/// Truncation floors each timestamp on the *local* clock, whereas the sorted flag describes the
+/// underlying instants. Those only stay in step if:
+/// - the local clock is monotone in the instants, which holds for tz-naive and UTC input but not
+///   for zones that change offset (`Asia/Magadan` moved +12 -> +10 on 2014-10-26, so two ascending
+///   instants can truncate to two descending ones), and
+/// - every row is truncated to the same window, as a per-row `every` can floor a later timestamp
+///   into an earlier bucket.
+///
+/// See <https://github.com/pola-rs/polars/issues/28560>.
+fn preserves_order(time_zone: Option<&TimeZone>, every: &StringChunked) -> bool {
+    let single_window = every.len() == 1 && every.get(0).is_some();
+    single_window && (time_zone.is_none() || time_zone == Some(&TimeZone::UTC))
+}
+
 impl PolarsTruncate for DatetimeChunked {
     fn truncate(&self, tz: Option<&Tz>, every: &StringChunked) -> PolarsResult<Self> {
-        polars_ensure!(
-            self.len() == every.len() || self.len() == 1 || every.len() == 1,
-            length_mismatch = "dt.truncate",
-            self.len(),
-            every.len()
-        );
-
-        let time_zone = self.time_zone();
-        let offset = Duration::new(0);
-
-        // Let's check if we can use a fastpath...
-        if every.len() == 1 {
-            if let Some(every) = every.get(0) {
-                let every_parsed = Duration::try_parse(every)?;
-                if every_parsed.negative {
-                    polars_bail!(ComputeError: "cannot truncate a Datetime to a negative duration")
-                }
-                if (time_zone.is_none() || time_zone.as_ref() == Some(&TimeZone::UTC))
-                    && (every_parsed.months() == 0 && every_parsed.weeks() == 0)
-                {
-                    // ... yes we can! Weeks, months, and time zones require extra logic.
-                    // But in this simple case, it's just simple integer arithmetic.
-                    let every = match self.time_unit() {
-                        TimeUnit::Milliseconds => every_parsed.duration_ms(),
-                        TimeUnit::Microseconds => every_parsed.duration_us(),
-                        TimeUnit::Nanoseconds => every_parsed.duration_ns(),
-                    };
-                    if every == 0 {
-                        return Ok(self.clone());
-                    }
-                    return Ok(self
-                        .physical()
-                        .apply_values(|t| fast_truncate(t, every))
-                        .into_datetime(self.time_unit(), time_zone.clone()));
-                } else {
-                    let w = Window::new(every_parsed, every_parsed, offset);
-                    let out = match self.time_unit() {
-                        TimeUnit::Milliseconds => self
-                            .physical()
-                            .try_apply_nonnull_values_generic(|t| w.truncate_ms(t, tz)),
-                        TimeUnit::Microseconds => self
-                            .physical()
-                            .try_apply_nonnull_values_generic(|t| w.truncate_us(t, tz)),
-                        TimeUnit::Nanoseconds => self
-                            .physical()
-                            .try_apply_nonnull_values_generic(|t| w.truncate_ns(t, tz)),
-                    };
-                    return Ok(out?.into_datetime(self.time_unit(), self.time_zone().clone()));
-                }
-            } else {
-                return Ok(Int64Chunked::full_null(self.name().clone(), self.len())
-                    .into_datetime(self.time_unit(), self.time_zone().clone()));
-            }
+        let mut out = truncate_datetime(self, tz, every)?;
+        if preserves_order(self.time_zone().as_ref(), every) {
+            out.physical_mut()
+                .set_sorted_flag(self.physical().is_sorted_flag());
         }
-
-        // A sqrt(n) cache is not too small, not too large.
-        let mut duration_cache = LruCache::with_capacity((every.len() as f64).sqrt() as usize);
-
-        let func = match self.time_unit() {
-            TimeUnit::Nanoseconds => Window::truncate_ns,
-            TimeUnit::Microseconds => Window::truncate_us,
-            TimeUnit::Milliseconds => Window::truncate_ms,
-        };
-
-        let out = broadcast_try_binary_elementwise(
-            self.physical(),
-            every,
-            |opt_timestamp, opt_every| match (opt_timestamp, opt_every) {
-                (Some(timestamp), Some(every)) => {
-                    let every =
-                        *duration_cache.try_get_or_insert_with(every, Duration::try_parse)?;
-
-                    if every.negative {
-                        polars_bail!(ComputeError: "cannot truncate a Datetime to a negative duration")
-                    }
-
-                    let w = Window::new(every, every, offset);
-                    func(&w, timestamp, tz).map(Some)
-                },
-                _ => Ok(None),
-            },
-        );
-        Ok(out?.into_datetime(self.time_unit(), self.time_zone().clone()))
+        Ok(out)
     }
 }
 
 impl PolarsTruncate for DateChunked {
     fn truncate(&self, _tz: Option<&Tz>, every: &StringChunked) -> PolarsResult<Self> {
-        polars_ensure!(
-            self.len() == every.len() || self.len() == 1 || every.len() == 1,
-            length_mismatch = "dt.truncate",
-            self.len(),
-            every.len()
-        );
+        let mut out = truncate_date(self, every)?;
+        // A `Date` has no time zone, so only a per-row `every` can break ordering.
+        if preserves_order(None, every) {
+            out.physical_mut()
+                .set_sorted_flag(self.physical().is_sorted_flag());
+        }
+        Ok(out)
+    }
+}
 
-        let offset = Duration::new(0);
-        let out = match every.len() {
-            1 => {
-                if let Some(every) = every.get(0) {
-                    let every = Duration::try_parse(every)?;
+fn truncate_datetime(
+    ca: &DatetimeChunked,
+    tz: Option<&Tz>,
+    every: &StringChunked,
+) -> PolarsResult<DatetimeChunked> {
+    polars_ensure!(
+        ca.len() == every.len() || ca.len() == 1 || every.len() == 1,
+        length_mismatch = "dt.truncate",
+        ca.len(),
+        every.len()
+    );
+
+    let time_zone = ca.time_zone();
+    let offset = Duration::new(0);
+
+    // Let's check if we can use a fastpath...
+    if every.len() == 1 {
+        if let Some(every) = every.get(0) {
+            let every_parsed = Duration::try_parse(every)?;
+            if every_parsed.negative {
+                polars_bail!(ComputeError: "cannot truncate a Datetime to a negative duration")
+            }
+            if (time_zone.is_none() || time_zone.as_ref() == Some(&TimeZone::UTC))
+                && (every_parsed.months() == 0 && every_parsed.weeks() == 0)
+            {
+                // ... yes we can! Weeks, months, and time zones require extra logic.
+                // But in this simple case, it's just simple integer arithmetic.
+                let every = match ca.time_unit() {
+                    TimeUnit::Milliseconds => every_parsed.duration_ms(),
+                    TimeUnit::Microseconds => every_parsed.duration_us(),
+                    TimeUnit::Nanoseconds => every_parsed.duration_ns(),
+                };
+                if every == 0 {
+                    return Ok(ca.clone());
+                }
+                return Ok(ca
+                    .physical()
+                    .apply_values(|t| fast_truncate(t, every))
+                    .into_datetime(ca.time_unit(), time_zone.clone()));
+            } else {
+                let w = Window::new(every_parsed, every_parsed, offset);
+                let out = match ca.time_unit() {
+                    TimeUnit::Milliseconds => ca
+                        .physical()
+                        .try_apply_nonnull_values_generic(|t| w.truncate_ms(t, tz)),
+                    TimeUnit::Microseconds => ca
+                        .physical()
+                        .try_apply_nonnull_values_generic(|t| w.truncate_us(t, tz)),
+                    TimeUnit::Nanoseconds => ca
+                        .physical()
+                        .try_apply_nonnull_values_generic(|t| w.truncate_ns(t, tz)),
+                };
+                return Ok(out?.into_datetime(ca.time_unit(), ca.time_zone().clone()));
+            }
+        } else {
+            return Ok(Int64Chunked::full_null(ca.name().clone(), ca.len())
+                .into_datetime(ca.time_unit(), ca.time_zone().clone()));
+        }
+    }
+
+    // A sqrt(n) cache is not too small, not too large.
+    let mut duration_cache = LruCache::with_capacity((every.len() as f64).sqrt() as usize);
+
+    let func = match ca.time_unit() {
+        TimeUnit::Nanoseconds => Window::truncate_ns,
+        TimeUnit::Microseconds => Window::truncate_us,
+        TimeUnit::Milliseconds => Window::truncate_ms,
+    };
+
+    let out = broadcast_try_binary_elementwise(ca.physical(), every, |opt_timestamp, opt_every| {
+        match (opt_timestamp, opt_every) {
+            (Some(timestamp), Some(every)) => {
+                let every = *duration_cache.try_get_or_insert_with(every, Duration::try_parse)?;
+
+                if every.negative {
+                    polars_bail!(ComputeError: "cannot truncate a Datetime to a negative duration")
+                }
+
+                let w = Window::new(every, every, offset);
+                func(&w, timestamp, tz).map(Some)
+            },
+            _ => Ok(None),
+        }
+    });
+    Ok(out?.into_datetime(ca.time_unit(), ca.time_zone().clone()))
+}
+
+fn truncate_date(ca: &DateChunked, every: &StringChunked) -> PolarsResult<DateChunked> {
+    polars_ensure!(
+        ca.len() == every.len() || ca.len() == 1 || every.len() == 1,
+        length_mismatch = "dt.truncate",
+        ca.len(),
+        every.len()
+    );
+
+    let offset = Duration::new(0);
+    let out = match every.len() {
+        1 => {
+            if let Some(every) = every.get(0) {
+                let every = Duration::try_parse(every)?;
+                if every.negative {
+                    polars_bail!(ComputeError: "cannot truncate a Date to a negative duration")
+                }
+                let w = Window::new(every, every, offset);
+                ca.physical().try_apply_nonnull_values_generic(|t| {
+                    Ok(
+                        (w.truncate_ms(MILLISECONDS_IN_DAY * t as i64, None)? / MILLISECONDS_IN_DAY)
+                            as i32,
+                    )
+                })
+            } else {
+                Ok(Int32Chunked::full_null(ca.name().clone(), ca.len()))
+            }
+        },
+        _ => broadcast_try_binary_elementwise(ca.physical(), every, |opt_t, opt_every| {
+            // A sqrt(n) cache is not too small, not too large.
+            let mut duration_cache = LruCache::with_capacity((every.len() as f64).sqrt() as usize);
+            match (opt_t, opt_every) {
+                (Some(t), Some(every)) => {
+                    let every =
+                        *duration_cache.try_get_or_insert_with(every, Duration::try_parse)?;
+
                     if every.negative {
                         polars_bail!(ComputeError: "cannot truncate a Date to a negative duration")
                     }
+
                     let w = Window::new(every, every, offset);
-                    self.physical().try_apply_nonnull_values_generic(|t| {
-                        Ok((w.truncate_ms(MILLISECONDS_IN_DAY * t as i64, None)?
-                            / MILLISECONDS_IN_DAY) as i32)
-                    })
-                } else {
-                    Ok(Int32Chunked::full_null(self.name().clone(), self.len()))
-                }
-            },
-            _ => broadcast_try_binary_elementwise(self.physical(), every, |opt_t, opt_every| {
-                // A sqrt(n) cache is not too small, not too large.
-                let mut duration_cache =
-                    LruCache::with_capacity((every.len() as f64).sqrt() as usize);
-                match (opt_t, opt_every) {
-                    (Some(t), Some(every)) => {
-                        let every =
-                            *duration_cache.try_get_or_insert_with(every, Duration::try_parse)?;
-
-                        if every.negative {
-                            polars_bail!(ComputeError: "cannot truncate a Date to a negative duration")
-                        }
-
-                        let w = Window::new(every, every, offset);
-                        Ok(Some(
-                            (w.truncate_ms(MILLISECONDS_IN_DAY * t as i64, None)?
-                                / MILLISECONDS_IN_DAY) as i32,
-                        ))
-                    },
-                    _ => Ok(None),
-                }
-            }),
-        };
-        Ok(out?.into_date())
-    }
+                    Ok(Some(
+                        (w.truncate_ms(MILLISECONDS_IN_DAY * t as i64, None)? / MILLISECONDS_IN_DAY)
+                            as i32,
+                    ))
+                },
+                _ => Ok(None),
+            }
+        }),
+    };
+    Ok(out?.into_date())
 }

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -126,17 +126,8 @@ def test_dt_replace_time_zone_none(time_zone: str | None, time_unit: TimeUnit) -
     assert result.item() == expected
 
 
-@pytest.mark.parametrize(
-    ("time_zone", "expected"),
-    [
-        # A time zone with offset changes may move the local date backwards while the
-        # underlying instants move forwards, so sortedness can't be preserved.
-        (None, True),
-        ("Asia/Kathmandu", False),
-        ("UTC", True),
-    ],
-)
-def test_local_date_sortedness(time_zone: str | None, expected: bool) -> None:
+@pytest.mark.parametrize("time_zone", [None, "UTC"])
+def test_local_date_sortedness(time_zone: str | None) -> None:
     # singleton - always sorted
     ser = (pl.Series([datetime(2022, 1, 1, 23)]).dt.replace_time_zone(time_zone)).sort()
     result = ser.dt.date()
@@ -147,7 +138,22 @@ def test_local_date_sortedness(time_zone: str | None, expected: bool) -> None:
         pl.Series([datetime(2022, 1, 1, 23)] * 2).dt.replace_time_zone(time_zone)
     ).sort()
     result = ser.dt.date()
-    assert result.flags["SORTED_ASC"] == expected
+    assert result.flags["SORTED_ASC"]
+    assert not result.flags["SORTED_DESC"]
+
+
+# The streaming engine derives sortedness from the values themselves, so it may report
+# this genuinely sorted result as sorted regardless of what the conversion claims.
+@pytest.mark.may_fail_auto_streaming
+def test_local_date_sortedness_tz_aware_is_conservative() -> None:
+    # A time zone with offset changes may move the local date backwards while the
+    # underlying instants move forwards, so sortedness can't be carried over.
+    ser = (
+        pl.Series([datetime(2022, 1, 1, 23)] * 2).dt.replace_time_zone("Asia/Kathmandu")
+    ).sort()
+    result = ser.dt.date()
+
+    assert not result.flags["SORTED_ASC"]
     assert not result.flags["SORTED_DESC"]
 
 

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -135,9 +135,18 @@ def test_dt_datetime_deprecated() -> None:
     assert result.item() == expected
 
 
-@pytest.mark.parametrize("time_zone", [None, "Asia/Kathmandu", "UTC"])
-def test_local_date_sortedness(time_zone: str | None) -> None:
-    # singleton
+@pytest.mark.parametrize(
+    ("time_zone", "expected"),
+    [
+        # A time zone with offset changes may move the local date backwards while the
+        # underlying instants move forwards, so sortedness can't be preserved.
+        (None, True),
+        ("Asia/Kathmandu", False),
+        ("UTC", True),
+    ],
+)
+def test_local_date_sortedness(time_zone: str | None, expected: bool) -> None:
+    # singleton - always sorted
     ser = (pl.Series([datetime(2022, 1, 1, 23)]).dt.replace_time_zone(time_zone)).sort()
     result = ser.dt.date()
     assert result.flags["SORTED_ASC"]
@@ -147,7 +156,26 @@ def test_local_date_sortedness(time_zone: str | None) -> None:
         pl.Series([datetime(2022, 1, 1, 23)] * 2).dt.replace_time_zone(time_zone)
     ).sort()
     result = ser.dt.date()
-    assert result.flags["SORTED_ASC"]
+    assert result.flags["SORTED_ASC"] == expected
+    assert not result.flags["SORTED_DESC"]
+
+
+def test_local_date_sortedness_backwards_transition_28560() -> None:
+    # `Antarctica/Casey` moved from +11 to +08 on 2010-03-04, so the local date goes
+    # backwards while UTC goes forwards.
+    utc = (
+        pl.Series(
+            "t", [datetime(2010, 3, 4, 13) + timedelta(hours=h) for h in range(4)]
+        )
+        .dt.replace_time_zone("UTC")
+        .sort()
+    )
+    result = utc.dt.convert_time_zone("Antarctica/Casey").dt.date()
+
+    assert not result.flags["SORTED_ASC"]
+    assert not result.flags["SORTED_DESC"]
+    assert result.min() == date(2010, 3, 4)
+    assert result.sort().to_list() == sorted(result.to_list())
 
 
 @pytest.mark.parametrize("time_zone", [None, "Asia/Kathmandu", "UTC"])

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -126,9 +126,18 @@ def test_dt_replace_time_zone_none(time_zone: str | None, time_unit: TimeUnit) -
     assert result.item() == expected
 
 
-@pytest.mark.parametrize("time_zone", [None, "Asia/Kathmandu", "UTC"])
-def test_local_date_sortedness(time_zone: str | None) -> None:
-    # singleton
+@pytest.mark.parametrize(
+    ("time_zone", "expected"),
+    [
+        # A time zone with offset changes may move the local date backwards while the
+        # underlying instants move forwards, so sortedness can't be preserved.
+        (None, True),
+        ("Asia/Kathmandu", False),
+        ("UTC", True),
+    ],
+)
+def test_local_date_sortedness(time_zone: str | None, expected: bool) -> None:
+    # singleton - always sorted
     ser = (pl.Series([datetime(2022, 1, 1, 23)]).dt.replace_time_zone(time_zone)).sort()
     result = ser.dt.date()
     assert result.flags["SORTED_ASC"]
@@ -138,7 +147,26 @@ def test_local_date_sortedness(time_zone: str | None) -> None:
         pl.Series([datetime(2022, 1, 1, 23)] * 2).dt.replace_time_zone(time_zone)
     ).sort()
     result = ser.dt.date()
-    assert result.flags["SORTED_ASC"]
+    assert result.flags["SORTED_ASC"] == expected
+    assert not result.flags["SORTED_DESC"]
+
+
+def test_local_date_sortedness_backwards_transition_28560() -> None:
+    # `Antarctica/Casey` moved from +11 to +08 on 2010-03-04, so the local date goes
+    # backwards while UTC goes forwards.
+    utc = (
+        pl.Series(
+            "t", [datetime(2010, 3, 4, 13) + timedelta(hours=h) for h in range(4)]
+        )
+        .dt.replace_time_zone("UTC")
+        .sort()
+    )
+    result = utc.dt.convert_time_zone("Antarctica/Casey").dt.date()
+
+    assert not result.flags["SORTED_ASC"]
+    assert not result.flags["SORTED_DESC"]
+    assert result.min() == date(2010, 3, 4)
+    assert result.sort().to_list() == sorted(result.to_list())
 
 
 @pytest.mark.parametrize("time_zone", [None, "Asia/Kathmandu", "UTC"])

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_truncate.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_truncate.py
@@ -122,6 +122,61 @@ def test_fast_path_vs_slow_path(datetimes: list[datetime], every: str) -> None:
     assert_series_equal(result, expected)
 
 
+@pytest.mark.parametrize(
+    ("time_zone", "expected"),
+    [
+        # Truncation floors on the local clock, so a time zone that changes offset can
+        # turn ascending instants into descending ones.
+        (None, True),
+        ("UTC", True),
+        ("Asia/Magadan", False),
+    ],
+)
+@pytest.mark.parametrize("every", ["1h", "1d", "1mo"])
+def test_truncate_sortedness(time_zone: str | None, expected: bool, every: str) -> None:
+    s = (
+        pl.Series(
+            "t", [datetime(2014, 10, 25, 12) + timedelta(hours=h) for h in range(4)]
+        )
+        .dt.replace_time_zone(time_zone)
+        .sort()
+    )
+    result = s.dt.truncate(every)
+    assert result.flags["SORTED_ASC"] == expected
+    assert not result.flags["SORTED_DESC"]
+
+
+def test_truncate_sortedness_backwards_transition_28560() -> None:
+    # `Asia/Magadan` moved from +12 to +10 on 2014-10-26, so the local clock repeats and
+    # ascending instants truncate to descending ones.
+    s = (
+        pl.Series(
+            "t", [datetime(2014, 10, 25, 12) + timedelta(hours=h) for h in range(4)]
+        )
+        .dt.replace_time_zone("UTC")
+        .sort()
+        .dt.convert_time_zone("Asia/Magadan")
+    )
+    result = s.dt.truncate("1h")
+
+    assert not result.is_sorted()
+    assert result.sort().to_list() == sorted(result.to_list())
+
+
+@pytest.mark.parametrize("as_date", [False, True])
+def test_truncate_per_row_every_is_not_sorted(as_date: bool) -> None:
+    # A per-row `every` can floor a later timestamp into an earlier bucket.
+    s = pl.Series("t", [datetime(2020, 1, 2, 6), datetime(2020, 1, 3, 7)]).sort()
+    if as_date:
+        s = s.dt.date()
+    assert s.flags["SORTED_ASC"]
+
+    result = s.dt.truncate(pl.Series(["1mo", "1d"]))
+    assert not result.flags["SORTED_ASC"]
+    assert not result.flags["SORTED_DESC"]
+    assert result.sort().to_list() == sorted(result.to_list())
+
+
 @pytest.mark.parametrize("as_date", [False, True])
 def test_truncate_unequal_length_22018(as_date: bool) -> None:
     s = pl.Series([datetime(2088, 8, 8, 8, 8, 8, 8)] * 2)

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_truncate.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_truncate.py
@@ -122,18 +122,9 @@ def test_fast_path_vs_slow_path(datetimes: list[datetime], every: str) -> None:
     assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize(
-    ("time_zone", "expected"),
-    [
-        # Truncation floors on the local clock, so a time zone that changes offset can
-        # turn ascending instants into descending ones.
-        (None, True),
-        ("UTC", True),
-        ("Asia/Magadan", False),
-    ],
-)
+@pytest.mark.parametrize("time_zone", [None, "UTC"])
 @pytest.mark.parametrize("every", ["1h", "1d", "1mo"])
-def test_truncate_sortedness(time_zone: str | None, expected: bool, every: str) -> None:
+def test_truncate_sortedness(time_zone: str | None, every: str) -> None:
     s = (
         pl.Series(
             "t", [datetime(2014, 10, 25, 12) + timedelta(hours=h) for h in range(4)]
@@ -142,7 +133,27 @@ def test_truncate_sortedness(time_zone: str | None, expected: bool, every: str) 
         .sort()
     )
     result = s.dt.truncate(every)
-    assert result.flags["SORTED_ASC"] == expected
+    assert result.flags["SORTED_ASC"]
+    assert not result.flags["SORTED_DESC"]
+
+
+# The streaming engine derives sortedness from the values themselves, so it may report
+# this genuinely sorted result as sorted regardless of what truncation claims.
+@pytest.mark.may_fail_auto_streaming
+@pytest.mark.parametrize("every", ["1h", "1d", "1mo"])
+def test_truncate_sortedness_tz_aware_is_conservative(every: str) -> None:
+    # Truncation floors on the local clock, so a time zone that changes offset can turn
+    # ascending instants into descending ones.
+    s = (
+        pl.Series(
+            "t", [datetime(2014, 10, 25, 12) + timedelta(hours=h) for h in range(4)]
+        )
+        .dt.replace_time_zone("Asia/Magadan")
+        .sort()
+    )
+    result = s.dt.truncate(every)
+
+    assert not result.flags["SORTED_ASC"]
     assert not result.flags["SORTED_DESC"]
 
 
@@ -165,15 +176,17 @@ def test_truncate_sortedness_backwards_transition_28560() -> None:
 
 @pytest.mark.parametrize("as_date", [False, True])
 def test_truncate_per_row_every_is_not_sorted(as_date: bool) -> None:
-    # A per-row `every` can floor a later timestamp into an earlier bucket.
-    s = pl.Series("t", [datetime(2020, 1, 2, 6), datetime(2020, 1, 3, 7)]).sort()
+    # A per-row `every` can floor a later timestamp into an earlier bucket, so ordering
+    # is not preserved even without a time zone.
+    s = pl.Series("t", [datetime(2020, 2, 5, 6), datetime(2020, 2, 6, 7)]).sort()
     if as_date:
         s = s.dt.date()
     assert s.flags["SORTED_ASC"]
 
-    result = s.dt.truncate(pl.Series(["1mo", "1d"]))
+    result = s.dt.truncate(pl.Series(["1d", "1mo"]))
+
+    assert result[1] < result[0]
     assert not result.flags["SORTED_ASC"]
-    assert not result.flags["SORTED_DESC"]
     assert result.sort().to_list() == sorted(result.to_list())
 
 


### PR DESCRIPTION
This PR was written in part with the assistance of generative AI.

Closes #28560

`dt.date()` and `dt.truncate()` copied the input's sorted flag onto their output, but neither conversion is monotonic for time-zone-aware input. The result could therefore claim `SORTED_ASC` while genuinely being unsorted, so `.sort()` became a no-op, `min()` could return a value that is not the minimum, and `join_asof` / `group_by_dynamic` silently consumed the wrong ordering.

### `dt.date()`

The old comment assumed no time zone ever moves the local date backwards. Two tzdata entries do: `Antarctica/Casey` (2010-03-04, +11 → +08) and `America/Goose_Bay` (1988-10-30, DST ending at 00:01 local).

The blanket override is removed; the flag is now inherited from `replace_time_zone`, which already preserves it only for UTC input (where the conversion really is monotone), and from the `Datetime → Date` cast.

### `dt.truncate()`

Truncation floors on the **local wall clock** while the sorted flag describes the underlying **UTC** instants, so an offset change can turn ascending instants into descending ones — e.g. `Asia/Magadan` moved +12 → +10 on 2014-10-26.

The decision now lives in `PolarsTruncate` itself rather than in the dispatch layer, since only it knows the time zone and the window. The flag is kept only for tz-naive/UTC input truncated by a single window. The `every.len() > 1` part matters even without a time zone: a per-row `every` can floor a later timestamp into an earlier bucket.

This mirrors the conservative approach `dt.offset_by` already takes (`preserve_sortedness`, added for #19608) and the reasoning in `replace_time_zone`.

### Verification

- Both repros from the issue now return correct results (`min()` → `2010-03-04`, `.sort()` actually sorts, `is_sorted()` → `False` for the Magadan case).
- Swept all 598 zones in the tz database over hourly data 2005–2016 for `dt.date()` and `dt.truncate()` with `1h`/`30m`/`1d`: no result claims `SORTED_ASC` while being unsorted. Positive controls confirm tz-naive and UTC input still keep the flag (including `1mo`/`1y` windows and `Date` input).
- `make test` and `make lint` pass.
