### PR TITLE
chore: Enable a lot of `may_fail_auto_streaming` tests

### DIFF
--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -1722,7 +1722,6 @@ def test_array_construction() -> None:
     assert df.rows() == [("a", [1, 2, 3]), ("b", [2, 3, 4])]
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_pycapsule_interface(df: pl.DataFrame) -> None:
     df = df.rechunk()
     pyarrow_table = df.to_arrow()

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2042,8 +2042,6 @@ def test_filter_with_all_expansion() -> None:
     assert out.shape == (2, 3)
 
 
-# TODO: investigate this discrepancy in auto streaming
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.may_fail_cloud
 def test_extension() -> None:
     class Foo:

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -706,7 +706,6 @@ def test_cat_preserve_lexical_ordering_on_concat() -> None:
 
 
 @pytest.mark.may_fail_cloud  # reason: sorted flag
-@pytest.mark.may_fail_auto_streaming
 def test_cat_append_lexical_sorted_flag() -> None:
     df = pl.DataFrame({"x": [0, 1, 1], "y": ["B", "B", "A"]}).with_columns(
         pl.col("y").cast(pl.Categorical())

--- a/py-polars/tests/unit/datatypes/test_object.py
+++ b/py-polars/tests/unit/datatypes/test_object.py
@@ -80,7 +80,6 @@ def test_nullable_object_13538() -> None:
     }
 
 
-@pytest.mark.may_fail_auto_streaming  # dtype is not set
 @pytest.mark.may_fail_cloud  # reason: eager
 def test_nullable_object_17936() -> None:
     class Custom:

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -262,7 +262,6 @@ def test_from_dicts_struct() -> None:
 
 
 @pytest.mark.may_fail_cloud  # reason: eager construct
-@pytest.mark.may_fail_auto_streaming
 def test_list_to_struct() -> None:
     df = pl.DataFrame({"a": [[1, 2, 3], [1, 2]]})
     with pytest.warns(DeprecationWarning, match="to_struct"):
@@ -1222,7 +1221,6 @@ def test_zfs_row_encoding(size: int) -> None:
 
 
 @pytest.mark.may_fail_cloud  # reason: eager construct
-@pytest.mark.may_fail_auto_streaming
 def test_list_to_struct_19208() -> None:
     df = pl.DataFrame(
         {

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
@@ -28,7 +28,6 @@ def assert_zero_copy(s: pl.Series, arr: np.ndarray[Any, Any]) -> None:
 
 
 @pytest.mark.may_fail_cloud
-@pytest.mark.may_fail_auto_streaming
 @given(
     s=series(
         min_size=6,

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2565,7 +2565,6 @@ def test_csv_invalid_quoted_comment_line(chunk_override: None) -> None:
     ).to_dict(as_series=False) == {"ColA": [1], "ColB": [2]}
 
 
-@pytest.mark.may_fail_auto_streaming  # missing_columns parameter for CSV
 def test_csv_compressed_new_columns_19916(chunk_override: None) -> None:
     n_rows = 100
 

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -903,7 +903,6 @@ def test_hive_write_dates(tmp_path: Path) -> None:
 
 
 @pytest.mark.write_disk
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.may_fail_cloud  # reason: inspects logs
 def test_hive_predicate_dates_14712(
     tmp_path: Path, plmonkeypatch: PlMonkeyPatch, capfd: Any

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -84,7 +84,6 @@ def test_row_index(foods_file_path: Path) -> None:
 
 
 @pytest.mark.parametrize("file_name", ["foods1.csv", "foods*.csv"])
-@pytest.mark.may_fail_auto_streaming  # missing_columns parameter for CSV
 def test_scan_csv_schema_overwrite_and_dtypes_overwrite(
     io_files_path: Path, file_name: str
 ) -> None:
@@ -110,7 +109,6 @@ def test_scan_csv_schema_overwrite_and_dtypes_overwrite(
 
 @pytest.mark.parametrize("file_name", ["foods1.csv", "foods*.csv"])
 @pytest.mark.parametrize("dtype", [pl.Int8, pl.UInt8, pl.Int16, pl.UInt16])
-@pytest.mark.may_fail_auto_streaming  # missing_columns parameter for CSV
 def test_scan_csv_schema_overwrite_and_small_dtypes_overwrite(
     io_files_path: Path, file_name: str, dtype: pl.DataType
 ) -> None:
@@ -130,7 +128,6 @@ def test_scan_csv_schema_overwrite_and_small_dtypes_overwrite(
 
 
 @pytest.mark.parametrize("file_name", ["foods1.csv", "foods*.csv"])
-@pytest.mark.may_fail_auto_streaming  # missing_columns parameter for CSV
 def test_scan_csv_schema_new_columns_dtypes(
     io_files_path: Path, file_name: str
 ) -> None:
@@ -444,7 +441,6 @@ A,B,C
         ],
     ],
 )
-@pytest.mark.may_fail_auto_streaming  # missing_columns parameter for CSV
 def test_file_list_schema_mismatch(
     tmp_path: Path, dfs: list[pl.DataFrame], streaming: bool
 ) -> None:
@@ -487,7 +483,6 @@ def test_scan_csv_missing_columns_insert() -> None:
     assert_frame_equal(result, expected)
 
 
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.parametrize("streaming", [True, False])
 def test_file_list_schema_supertype(tmp_path: Path, streaming: bool) -> None:
     tmp_path.mkdir(exist_ok=True)

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -130,6 +130,7 @@ def test_to_from_buffer(
 
 @pytest.mark.parametrize("use_pyarrow", [True, False])
 @pytest.mark.parametrize("rechunk_and_expected_chunks", [(True, 1), (False, 3)])
+@pytest.mark.may_fail_auto_streaming
 @pytest.mark.may_fail_cloud  # reason: chunking
 def test_read_parquet_respects_rechunk_16416(
     use_pyarrow: bool, rechunk_and_expected_chunks: tuple[bool, int]

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -44,7 +44,6 @@ if TYPE_CHECKING:
     from tests.unit.conftest import MemoryUsage
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_round_trip(df: pl.DataFrame) -> None:
     f = io.BytesIO()
     df.write_parquet(f)
@@ -52,7 +51,6 @@ def test_round_trip(df: pl.DataFrame) -> None:
     assert_frame_equal(pl.read_parquet(f), df)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_scan_round_trip(df: pl.DataFrame) -> None:
     f = io.BytesIO()
     df.write_parquet(f)
@@ -132,7 +130,6 @@ def test_to_from_buffer(
 
 @pytest.mark.parametrize("use_pyarrow", [True, False])
 @pytest.mark.parametrize("rechunk_and_expected_chunks", [(True, 1), (False, 3)])
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.may_fail_cloud  # reason: chunking
 def test_read_parquet_respects_rechunk_16416(
     use_pyarrow: bool, rechunk_and_expected_chunks: tuple[bool, int]
@@ -828,7 +825,6 @@ def test_parquet_string_rle_encoding() -> None:
     )
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_sliced_dict_with_nulls_14904() -> None:
     df = (
         pl.DataFrame({"x": [None, None]})
@@ -2566,7 +2562,6 @@ def test_dict_masked(
     )
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_categorical_sliced_20017() -> None:
     f = io.BytesIO()
     df = (
@@ -2742,7 +2737,6 @@ def test_parquet_unsupported_dictionary_to_pl_17945() -> None:
     )
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_parquet_cast_to_cat() -> None:
     t = pa.table(
         {

--- a/py-polars/tests/unit/io/test_scan.py
+++ b/py-polars/tests/unit/io/test_scan.py
@@ -696,7 +696,6 @@ def test_async_path_expansion_bracket_17629(tmp_path: Path) -> None:
     "method",
     ["parquet", "csv", "ipc", "ndjson"],
 )
-@pytest.mark.may_fail_auto_streaming  # unsupported negative slice offset -1 for CSV source
 def test_scan_in_memory(method: str) -> None:
     f = io.BytesIO()
     df = pl.DataFrame(

--- a/py-polars/tests/unit/io/test_spreadsheet.py
+++ b/py-polars/tests/unit/io/test_spreadsheet.py
@@ -503,7 +503,6 @@ def test_read_invalid_worksheet(
         (pl.read_ods, "path_ods_mixed", {}),
     ],
 )
-@pytest.mark.may_fail_auto_streaming
 def test_read_mixed_dtype_columns(
     read_spreadsheet: Callable[..., dict[str, pl.DataFrame]],
     source: str,

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -891,7 +891,6 @@ def test_cse_chunks_18124() -> None:
     ).collect().shape == (4, 4)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_eager_cse_during_struct_expansion_18411() -> None:
     df = pl.DataFrame({"foo": [0, 0, 0, 1, 1]})
     vc = pl.col("foo").value_counts()

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -891,6 +891,7 @@ def test_cse_chunks_18124() -> None:
     ).collect().shape == (4, 4)
 
 
+@pytest.mark.may_fail_auto_streaming
 def test_eager_cse_during_struct_expansion_18411() -> None:
     df = pl.DataFrame({"foo": [0, 0, 0, 1, 1]})
     vc = pl.col("foo").value_counts()

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -375,7 +375,6 @@ def test_inspect(capsys: CaptureFixture[str]) -> None:
     assert len(res.out) > 0
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_fetch(fruits_cars: pl.DataFrame) -> None:
     with pytest.warns(
         DeprecationWarning,

--- a/py-polars/tests/unit/lazyframe/test_projections.py
+++ b/py-polars/tests/unit/lazyframe/test_projections.py
@@ -125,7 +125,6 @@ def test_hconcat_projection_pushdown_length_maintained() -> None:
     assert_frame_equal(out, expected)
 
 
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.may_fail_cloud
 def test_unnest_columns_available() -> None:
     df = pl.DataFrame(

--- a/py-polars/tests/unit/operations/aggregation/test_aggregations.py
+++ b/py-polars/tests/unit/operations/aggregation/test_aggregations.py
@@ -636,7 +636,6 @@ def test_agg_filter_over_empty_df_13610() -> None:
 
 
 @pytest.mark.may_fail_cloud  # reason: output order is defined for this in cloud
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.slow
 def test_agg_empty_sum_after_filter_14734() -> None:
     f = (

--- a/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
+++ b/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
@@ -341,7 +341,6 @@ def test_parse_invalid_function(func: str) -> None:
     "ignore:invalid value encountered:RuntimeWarning",
     "ignore:.*without specifying `return_dtype`:polars.exceptions.MapWithoutReturnDtypeWarning",
 )
-@pytest.mark.may_fail_auto_streaming  # dtype not set
 @pytest.mark.may_fail_cloud  # reason: eager - return_dtype must be set
 def test_parse_apply_functions(
     col: str, func: str, expr_repr: str, dtype: Literal["self"] | pl.DataType | None
@@ -398,7 +397,6 @@ def test_parse_apply_functions(
     "ignore:invalid value encountered:RuntimeWarning",
     "ignore:.*without specifying `return_dtype`:polars.exceptions.MapWithoutReturnDtypeWarning",
 )
-@pytest.mark.may_fail_auto_streaming  # dtype is not set
 def test_parse_apply_raw_functions() -> None:
     lf = pl.LazyFrame({"a": [1.1, 2.0, 3.4]})
 
@@ -552,7 +550,6 @@ def test_parse_apply_series(
     assert_series_equal(expected_series, result_series, check_dtypes=False)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_expr_exact_warning_message() -> None:
     red, green, end_escape = (
         ("\x1b[31m", "\x1b[32m", "\x1b[0m")

--- a/py-polars/tests/unit/operations/map/test_map_elements.py
+++ b/py-polars/tests/unit/operations/map/test_map_elements.py
@@ -17,7 +17,6 @@ pytestmark = pytest.mark.filterwarnings(
 )
 
 
-@pytest.mark.may_fail_auto_streaming  # dtype not set
 @pytest.mark.may_fail_cloud  # reason: eager - return_dtype must be set
 def test_map_elements_infer_list() -> None:
     df = pl.DataFrame(
@@ -184,7 +183,6 @@ def test_map_elements_type_propagation() -> None:
     ).to_dict(as_series=False) == {"a": [1, 2, 3], "b": [1.0, 2.0, None]}
 
 
-@pytest.mark.may_fail_auto_streaming  # dtype not set
 @pytest.mark.may_fail_cloud  # reason: eager - return_dtype must be set
 def test_empty_list_in_map_elements() -> None:
     df = pl.DataFrame(
@@ -248,7 +246,6 @@ def test_map_elements_explicit_list_output_type() -> None:
     assert out.to_dict(as_series=False) == {"str": [[1, 2, 3], [1, 2, 3]]}
 
 
-@pytest.mark.may_fail_auto_streaming  # dtype not set
 def test_map_elements_dict() -> None:
     df = pl.DataFrame({"abc": ['{"A":"Value1"}', '{"B":"Value2"}']})
     with pytest.warns(

--- a/py-polars/tests/unit/operations/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_array.py
@@ -700,7 +700,6 @@ def test_array_get_broadcast_26217() -> None:
     assert_frame_equal(out, expected)
 
 
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.debug
 def test_array_idx_size_limit_eval(capfd: Any, plmonkeypatch: PlMonkeyPatch) -> None:
     plmonkeypatch.setenv("POLARS_VERBOSE", "1")

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -2136,7 +2136,6 @@ def test_group_by_any_all(expr: Callable[[pl.Expr], pl.Expr]) -> None:
         allow_chunks=False,  # bug: See #24960
     )
 )
-@pytest.mark.may_fail_auto_streaming  # bug: See #24960
 def test_group_by_skew_kurtosis(s: pl.Series) -> None:
     df = s.to_frame()
 

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -399,7 +399,6 @@ def test_join_chunks_alignment_4720() -> None:
     )
 
 
-@pytest.mark.may_fail_auto_streaming  # SORTED_ASC flags
 def test_jit_sort_joins() -> None:
     n = 200
     # Explicitly specify numpy dtype because of different defaults on Windows

--- a/py-polars/tests/unit/operations/test_queries.py
+++ b/py-polars/tests/unit/operations/test_queries.py
@@ -117,7 +117,6 @@ def test_maintain_order_after_sampling() -> None:
     assert result.to_dict(as_series=False) == expected
 
 
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.parametrize("descending", [False, True])
 @pytest.mark.parametrize("nulls_last", [False, True])
 @pytest.mark.parametrize("maintain_order", [False, True])

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -271,7 +271,6 @@ def test_rolling_non_negative_offset_9077(
     assert_frame_equal(result, expected)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_rolling_dynamic_sortedness_check() -> None:
     # when the by argument is passed, the sortedness flag
     # will be unset as the take shuffles data, so we must explicitly

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -53,7 +53,6 @@ def test_streaming_block_on_literals_6054() -> None:
     ).sort("col_1").to_dict(as_series=False) == {"col_1": [0, 1], "col_2": [0, 5]}
 
 
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.may_fail_cloud  # reason: non-pure map_batches
 def test_streaming_streamable_functions(
     plmonkeypatch: PlMonkeyPatch, capfd: Any
@@ -83,7 +82,6 @@ def test_streaming_streamable_functions(
 
 
 @pytest.mark.slow
-@pytest.mark.may_fail_auto_streaming
 @pytest.mark.may_fail_cloud  # reason: timing
 def test_cross_join_stack() -> None:
     morsel_size = os.environ.get("POLARS_IDEAL_MORSEL_SIZE")
@@ -129,7 +127,6 @@ def test_streaming_literal_expansion() -> None:
     }
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_streaming_apply(plmonkeypatch: PlMonkeyPatch, capfd: Any) -> None:
     plmonkeypatch.setenv("POLARS_VERBOSE", "1")
 

--- a/py-polars/tests/unit/testing/parametric/strategies/test_core.py
+++ b/py-polars/tests/unit/testing/parametric/strategies/test_core.py
@@ -252,7 +252,6 @@ def test_strategy_dtypes(
 @given(s=series(allow_chunks=False))
 @settings(max_examples=10)
 @pytest.mark.may_fail_cloud
-@pytest.mark.may_fail_auto_streaming
 def test_series_allow_chunks(s: pl.Series) -> None:
     assert s.n_chunks() == 1
 
@@ -260,7 +259,6 @@ def test_series_allow_chunks(s: pl.Series) -> None:
 @given(df=dataframes(allow_chunks=False))
 @settings(max_examples=10)
 @pytest.mark.may_fail_cloud
-@pytest.mark.may_fail_auto_streaming
 def test_dataframes_allow_chunks(df: pl.DataFrame) -> None:
     assert df.n_chunks("first") == 1
     assert df.n_chunks("all") == [1] * df.width


### PR DESCRIPTION
Related issue: https://github.com/pola-rs/polars/issues/28529

I deliberately left out some tests that had a reason that sounded like they would not work, and also everything that was related to the `read_csv -> scan_csv` rework in the 2.0 branch.

:robot: AI was used to do some bulk code edits.