### PR TITLE
refactor(rust): Add (with_)context to PolarsResult for easier annotation

### DIFF
--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -626,9 +626,8 @@ impl DataFrame {
             .zip(other.columns())
             .try_for_each::<_, PolarsResult<_>>(|(left, right)| {
                 ensure_can_extend(&*left, right)?;
-                left.append(right).map_err(|e| {
-                    e.context(format!("failed to vstack column '{}'", right.name()).into())
-                })?;
+                left.append(right)
+                    .with_context(|| format!("failed to vstack column '{}'", right.name()))?;
                 Ok(())
             })?;
 
@@ -659,9 +658,8 @@ impl DataFrame {
             .try_for_each::<_, PolarsResult<_>>(|(left, right)| {
                 ensure_can_extend(&*left, &right)?;
                 let right_name = right.name().clone();
-                left.append_owned(right).map_err(|e| {
-                    e.context(format!("failed to vstack column '{right_name}'").into())
-                })?;
+                left.append_owned(right)
+                    .with_context(|| format!("failed to vstack column '{right_name}'"))?;
                 Ok(())
             })?;
 
@@ -684,9 +682,7 @@ impl DataFrame {
             .zip(other.columns())
             .for_each(|(left, right)| {
                 left.append(right)
-                    .map_err(|e| {
-                        e.context(format!("failed to vstack column '{}'", right.name()).into())
-                    })
+                    .with_context(|| format!("failed to vstack column '{}'", right.name()))
                     .expect("should not fail");
             });
 
@@ -745,9 +741,8 @@ impl DataFrame {
             .zip(other.columns())
             .try_for_each::<_, PolarsResult<_>>(|(left, right)| {
                 ensure_can_extend(&*left, right)?;
-                left.extend(right).map_err(|e| {
-                    e.context(format!("failed to extend column '{}'", right.name()).into())
-                })?;
+                left.extend(right)
+                    .with_context(|| format!("failed to extend column '{}'", right.name()))?;
                 Ok(())
             })?;
 

--- a/crates/polars-core/src/prelude.rs
+++ b/crates/polars-core/src/prelude.rs
@@ -41,7 +41,7 @@ pub use crate::chunked_array::temporal::conversion::*;
 pub use crate::datatypes::{ArrayCollectIterExt, *};
 pub use crate::error::abort::try_raise_polars_abort;
 pub use crate::error::{
-    PolarsError, PolarsResult, polars_bail, polars_ensure, polars_err, polars_warn,
+    PolarsContext, PolarsError, PolarsResult, polars_bail, polars_ensure, polars_err, polars_warn,
 };
 pub use crate::frame::column::{Column, IntoColumn};
 pub use crate::frame::explode::UnpivotArgsIR;

--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -391,6 +391,27 @@ impl PolarsError {
     }
 }
 
+pub trait PolarsContext<T> {
+    fn context(self, ctx: &'static str) -> PolarsResult<T>;
+
+    fn with_context<F>(self, f: F) -> PolarsResult<T>
+    where
+        F: FnOnce() -> String;
+}
+
+impl<T> PolarsContext<T> for PolarsResult<T> {
+    fn context(self, ctx: &'static str) -> PolarsResult<T> {
+        self.map_err(|e| e.context(ErrString::new_static(ctx)))
+    }
+
+    fn with_context<F>(self, f: F) -> PolarsResult<T>
+    where
+        F: FnOnce() -> String,
+    {
+        self.map_err(|e| e.context(f().into()))
+    }
+}
+
 pub fn map_err<E: Error>(error: E) -> PolarsError {
     PolarsError::ComputeError(format!("{error}").into())
 }

--- a/crates/polars-plan/src/plans/builder_ir.rs
+++ b/crates/polars-plan/src/plans/builder_ir.rs
@@ -46,7 +46,7 @@ impl<'a> IRBuilder<'a> {
         conversion_optimizer.fill_scratch(b.lp_arena.get(b.root).exprs(), b.expr_arena);
         conversion_optimizer
             .optimize_exprs(b.expr_arena, b.lp_arena, b.root, false)
-            .map_err(|e| e.context(format!("optimizing '{ir_name}' failed").into()))?;
+            .with_context(|| format!("optimizing '{ir_name}' failed"))?;
 
         Ok(b)
     }

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/join.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/join.rs
@@ -48,12 +48,12 @@ pub fn resolve_join(
     }
 
     let owned = Arc::unwrap_or_clone;
-    let mut input_left = input_left.map_right(Ok).right_or_else(|input| {
-        to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_here!(join left)))
-    })?;
-    let mut input_right = input_right.map_right(Ok).right_or_else(|input| {
-        to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_here!(join right)))
-    })?;
+    let mut input_left = input_left
+        .map_right(Ok)
+        .right_or_else(|input| to_alp_impl(owned(input), ctxt).context(failed_here!(join left)))?;
+    let mut input_right = input_right
+        .map_right(Ok)
+        .right_or_else(|input| to_alp_impl(owned(input), ctxt).context(failed_here!(join right)))?;
 
     let schema_left = ctxt.lp_arena.get(input_left).schema(ctxt.lp_arena);
     let schema_right = ctxt.lp_arena.get(input_right).schema(ctxt.lp_arena);
@@ -153,12 +153,12 @@ pub fn resolve_join(
         .fill_scratch(&left_on, ctxt.expr_arena);
     ctxt.conversion_optimizer
         .optimize_exprs(ctxt.expr_arena, ctxt.lp_arena, input_left, true)
-        .map_err(|e| e.context("'join' failed".into()))?;
+        .context("'join' failed")?;
     ctxt.conversion_optimizer
         .fill_scratch(&right_on, ctxt.expr_arena);
     ctxt.conversion_optimizer
         .optimize_exprs(ctxt.expr_arena, ctxt.lp_arena, input_right, true)
-        .map_err(|e| e.context("'join' failed".into()))?;
+        .context("'join' failed")?;
 
     // Re-evaluate because of mutable borrows earlier.
     let schema_left = ctxt.lp_arena.get(input_left).schema(ctxt.lp_arena);
@@ -380,7 +380,7 @@ pub fn resolve_join(
         &options,
         ctxt.expr_arena,
     )
-    .map_err(|e| e.context(failed_here!(join schema resolving)))?;
+    .context(failed_here!(join schema resolving))?;
 
     if key_cols_coalesced {
         input_left = if as_with_columns_l.is_empty() {
@@ -464,10 +464,10 @@ fn resolve_join_where(
         ctxt.opt_flags.set(OptFlags::PREDICATE_PUSHDOWN, true);
     }
     check_join_keys(&predicates)?;
-    let input_left = to_alp_impl(Arc::unwrap_or_clone(input_left), ctxt)
-        .map_err(|e| e.context(failed_here!(join left)))?;
-    let input_right = to_alp_impl(Arc::unwrap_or_clone(input_right), ctxt)
-        .map_err(|e| e.context(failed_here!(join left)))?;
+    let input_left =
+        to_alp_impl(Arc::unwrap_or_clone(input_left), ctxt).context(failed_here!(join left))?;
+    let input_right =
+        to_alp_impl(Arc::unwrap_or_clone(input_right), ctxt).context(failed_here!(join left))?;
 
     let schema_left = ctxt
         .lp_arena
@@ -532,7 +532,7 @@ fn resolve_join_where(
 
     ctxt.conversion_optimizer
         .optimize_exprs(ctxt.expr_arena, ctxt.lp_arena, last_node, false)
-        .map_err(|e| e.context("'join_where' failed".into()))?;
+        .context("'join_where' failed")?;
 
     Ok((last_node, join_node))
 }

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -40,7 +40,7 @@ use utils::DslConversionContext;
 
 macro_rules! failed_here {
     ($($t:tt)*) => {
-        format!("'{}'", stringify!($($t)*)).into()
+        concat!("'", stringify!($($t)*), "'")
     }
 }
 pub(super) use failed_here;
@@ -103,7 +103,7 @@ fn run_conversion(lp: IR, ctxt: &mut DslConversionContext, name: &str) -> Polars
     let lp_node = ctxt.lp_arena.add(lp);
     ctxt.conversion_optimizer
         .optimize_exprs(ctxt.expr_arena, ctxt.lp_arena, lp_node, false)
-        .map_err(|e| e.context(format!("'{name}' failed").into()))?;
+        .with_context(|| format!("'{name}' failed"))?;
 
     Ok(lp_node)
 }
@@ -205,7 +205,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 .into_iter()
                 .map(|lp| to_alp_impl(lp, ctxt))
                 .collect::<PolarsResult<Vec<_>>>()
-                .map_err(|e| e.context(failed_here!(vertical concat)))?;
+                .context(failed_here!(vertical concat))?;
 
             if args.diagonal {
                 inputs = concat::convert_diagonal_concat(inputs, ctxt.lp_arena, ctxt.expr_arena)?;
@@ -218,7 +218,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                     ctxt.expr_arena,
                     ctxt.opt_flags,
                 )
-                .map_err(|e| e.context(failed_here!(vertical concat)))?;
+                .context(failed_here!(vertical concat))?;
             }
 
             let first_n = *inputs.first().ok_or_else(
@@ -241,7 +241,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 .into_iter()
                 .map(|lp| to_alp_impl(lp, ctxt))
                 .collect::<PolarsResult<Vec<_>>>()
-                .map_err(|e| e.context(failed_here!(horizontal concat)))?;
+                .context(failed_here!(horizontal concat))?;
 
             let schema = concat::h_concat_schema(&inputs, ctxt.lp_arena)?;
 
@@ -252,8 +252,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             }
         },
         DslPlan::Filter { input, predicate } => {
-            let mut input =
-                to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_here!(filter)))?;
+            let mut input = to_alp_impl(owned(input), ctxt).context(failed_here!(filter))?;
             let input_schema = ctxt.lp_arena.get(input).schema(ctxt.lp_arena);
 
             let mut out = Vec::with_capacity(1);
@@ -353,8 +352,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             return run_conversion(lp, ctxt, "filter");
         },
         DslPlan::Slice { input, offset, len } => {
-            let input =
-                to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_here!(slice)))?;
+            let input = to_alp_impl(owned(input), ctxt).context(failed_here!(slice))?;
 
             if len == 0 {
                 let input_schema = ctxt
@@ -383,11 +381,10 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             input,
             options,
         } => {
-            let input =
-                to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_here!(select)))?;
+            let input = to_alp_impl(owned(input), ctxt).context(failed_here!(select))?;
             let input_schema = ctxt.lp_arena.get(input).schema(ctxt.lp_arena);
             let (exprs, schema) = prepare_projection(expr, &input_schema, ctxt.opt_flags)
-                .map_err(|e| e.context(failed_here!(select)))?;
+                .context(failed_here!(select))?;
 
             if exprs.is_empty() {
                 ctxt.lp_arena.replace(input, utils::empty_df());
@@ -413,7 +410,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 options,
             };
 
-            return run_conversion(lp, ctxt, "select").map_err(|e| e.context(failed_here!(select)));
+            return run_conversion(lp, ctxt, "select").context(failed_here!(select));
         },
         DslPlan::Sort {
             input,
@@ -421,8 +418,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             slice,
             mut sort_options,
         } => {
-            let input =
-                to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_here!(select)))?;
+            let input = to_alp_impl(owned(input), ctxt).context(failed_here!(select))?;
             let input_schema = ctxt.lp_arena.get(input).schema(ctxt.lp_arena);
 
             // note: if given an Expr::Columns, count the individual cols
@@ -466,7 +462,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                     ctxt.expr_arena,
                     ctxt.opt_flags,
                 )
-                .map_err(|e| e.context(failed_here!(sort)))?;
+                .context(failed_here!(sort))?;
 
                 nulls_last.extend(std::iter::repeat_n(n, exprs.len()));
                 descending.extend(std::iter::repeat_n(d, exprs.len()));
@@ -516,14 +512,13 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 sort_options,
             };
 
-            return run_conversion(lp, ctxt, "sort").map_err(|e| e.context(failed_here!(sort)));
+            return run_conversion(lp, ctxt, "sort").context(failed_here!(sort));
         },
         DslPlan::Cache { input, id } => {
             let input = match ctxt.seen_caches.get(&id) {
                 Some(input) => *input,
                 None => {
-                    let input = to_alp_impl(owned(input), ctxt)
-                        .map_err(|e| e.context(failed_here!(cache)))?;
+                    let input = to_alp_impl(owned(input), ctxt).context(failed_here!(cache))?;
                     let seen_before = ctxt.seen_caches.insert(id, input);
                     assert!(
                         seen_before.is_none(),
@@ -583,8 +578,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             }
 
             // NOTE: As we went into this branch, we know that no predicates are provided.
-            let input =
-                to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_here!(group_by)))?;
+            let input = to_alp_impl(owned(input), ctxt).context(failed_here!(group_by))?;
 
             // Rolling + group-by sorts the whole table, so remove unneeded columns
             if ctxt.opt_flags.eager() && options.is_rolling() && !keys.is_empty() {
@@ -600,7 +594,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 ctxt.expr_arena,
                 ctxt.opt_flags,
             )
-            .map_err(|e| e.context(failed_here!(group_by)))?;
+            .context(failed_here!(group_by))?;
 
             let (apply, schema) = if let Some((apply, schema)) = apply {
                 (Some(apply), schema)
@@ -655,8 +649,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 }
             };
 
-            return run_conversion(lp, ctxt, "group_by")
-                .map_err(|e| e.context(failed_here!(group_by)));
+            return run_conversion(lp, ctxt, "group_by").context(failed_here!(group_by));
         },
         DslPlan::Join {
             input_left,
@@ -675,7 +668,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 JoinOptionsIR::from(Arc::unwrap_or_clone(options)),
                 ctxt,
             )
-            .map_err(|e| e.context(failed_here!(join)))
+            .context(failed_here!(join))
             .map(|t| t.0);
         },
         DslPlan::Gather {
@@ -683,10 +676,8 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             idxs,
             null_on_oob,
         } => {
-            let input =
-                to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_here!(gather)))?;
-            let idxs =
-                to_alp_impl(owned(idxs), ctxt).map_err(|e| e.context(failed_here!(gather)))?;
+            let input = to_alp_impl(owned(input), ctxt).context(failed_here!(gather))?;
+            let idxs = to_alp_impl(owned(idxs), ctxt).context(failed_here!(gather))?;
             let idxs_schema = ctxt.lp_arena.get(idxs).schema(ctxt.lp_arena);
             polars_ensure!(idxs_schema.len() == 1, InvalidOperation: "'gather' indices DataFrame should have a single column");
             let idx_dtype = &idxs_schema.get_at_index(0).unwrap().1;
@@ -716,11 +707,10 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 }
             }
 
-            let input = to_alp_impl(owned(input), ctxt)
-                .map_err(|e| e.context(failed_here!(with_columns)))?;
+            let input = to_alp_impl(owned(input), ctxt).context(failed_here!(with_columns))?;
             let (exprs, schema) =
                 resolve_with_columns(exprs, input, ctxt.lp_arena, ctxt.expr_arena, ctxt.opt_flags)
-                    .map_err(|e| e.context(failed_here!(with_columns)))?;
+                    .context(failed_here!(with_columns))?;
 
             if !ctxt.opt_flags.eager() && std::env::var("POLARS_STRICT_MODE").as_deref() == Ok("1")
             {
@@ -731,7 +721,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                     let invalid_e = &exprs[pos];
 
                     let err = polars_err!(InvalidOperation: "all expressions should return the same length or scalar;\n\nInvalid expression: {}", node_to_expr(invalid_e.node(), ctxt.expr_arena));
-                    return Err(err.context(failed_here!(with_columns)));
+                    return Err(err.context(failed_here!(with_columns).into()));
                 }
             }
             ctxt.conversion_optimizer
@@ -750,8 +740,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             per_column,
             extra_columns,
         } => {
-            let input =
-                to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_here!(unique)))?;
+            let input = to_alp_impl(owned(input), ctxt).context(failed_here!(unique))?;
             let input_schema = ctxt.lp_arena.get(input).schema(ctxt.lp_arena);
 
             assert_eq!(per_column.len(), match_schema.len());
@@ -901,8 +890,8 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
         } => {
             use polars_core::frame::PivotColumnNaming;
 
-            let input_node = to_alp_impl(input.as_ref().clone(), ctxt)
-                .map_err(|e| e.context(failed_here!(pivot)))?;
+            let input_node =
+                to_alp_impl(input.as_ref().clone(), ctxt).context(failed_here!(pivot))?;
             let input_schema = ctxt.lp_arena.get(input_node).schema(ctxt.lp_arena);
 
             let on = on.into_columns(input_schema.as_ref(), &Default::default())?;
@@ -1020,11 +1009,10 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 options: Default::default(),
                 apply: None,
             };
-            return to_alp_impl(lp, ctxt).map_err(|e| e.context(failed_here!(pivot)));
+            return to_alp_impl(lp, ctxt).context(failed_here!(pivot));
         },
         DslPlan::Distinct { input, options } => {
-            let input =
-                to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_here!(unique)))?;
+            let input = to_alp_impl(owned(input), ctxt).context(failed_here!(unique))?;
             let input_schema = ctxt.lp_arena.get(input).schema(ctxt.lp_arena).into_owned();
 
             // "subset" param supports cols and/or arbitrary expressions
@@ -1122,7 +1110,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
         },
         DslPlan::MapFunction { input, function } => {
             let input = to_alp_impl(owned(input), ctxt)
-                .map_err(|e| e.context(failed_here!(format!("{}", function).to_lowercase())))?;
+                .with_context(|| format!("{}", function).to_lowercase())?;
             let input_schema = ctxt.lp_arena.get(input).schema(ctxt.lp_arena);
 
             match function {
@@ -1164,7 +1152,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                         ctxt.expr_arena,
                         ctxt.opt_flags,
                     )
-                    .map_err(|e| e.context(failed_here!(fill_nan)))?;
+                    .context(failed_here!(fill_nan))?;
 
                     ctxt.conversion_optimizer
                         .fill_scratch(&exprs, ctxt.expr_arena);
@@ -1337,13 +1325,12 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             }
         },
         DslPlan::ExtContext { input, contexts } => {
-            let input = to_alp_impl(owned(input), ctxt)
-                .map_err(|e| e.context(failed_here!(with_context)))?;
+            let input = to_alp_impl(owned(input), ctxt).context(failed_here!(with_context))?;
             let contexts = contexts
                 .into_iter()
                 .map(|lp| to_alp_impl(lp, ctxt))
                 .collect::<PolarsResult<Vec<_>>>()
-                .map_err(|e| e.context(failed_here!(with_context)))?;
+                .context(failed_here!(with_context))?;
 
             let mut schema = (**ctxt.lp_arena.get(input).schema(ctxt.lp_arena)).clone();
             for input in &contexts {
@@ -1412,8 +1399,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 })
             }
 
-            let input =
-                to_alp_impl(owned(input), &mut ctxt).map_err(|e| e.context(failed_here!(sink)))?;
+            let input = to_alp_impl(owned(input), &mut ctxt).context(failed_here!(sink))?;
             let input_schema = ctxt.lp_arena.get(input).schema(ctxt.lp_arena).into_owned();
             let payload = match payload {
                 SinkType::Iceberg(_) => unreachable!(),
@@ -1554,7 +1540,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 .into_iter()
                 .map(|lp| to_alp_impl(lp, ctxt))
                 .collect::<PolarsResult<Vec<_>>>()
-                .map_err(|e| e.context(failed_here!(vertical concat)))?;
+                .context(failed_here!(vertical concat))?;
             IR::SinkMultiple { inputs }
         },
         #[cfg(feature = "merge_sorted")]
@@ -1564,17 +1550,17 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             key,
             maintain_order,
         } => {
-            let input_left = to_alp_impl(owned(input_left), ctxt)
-                .map_err(|e| e.context(failed_here!(merge_sorted)))?;
-            let input_right = to_alp_impl(owned(input_right), ctxt)
-                .map_err(|e| e.context(failed_here!(merge_sorted)))?;
+            let input_left =
+                to_alp_impl(owned(input_left), ctxt).context(failed_here!(merge_sorted))?;
+            let input_right =
+                to_alp_impl(owned(input_right), ctxt).context(failed_here!(merge_sorted))?;
 
             let left_schema = ctxt.lp_arena.get(input_left).schema(ctxt.lp_arena);
             let right_schema = ctxt.lp_arena.get(input_right).schema(ctxt.lp_arena);
 
             left_schema
                 .ensure_is_exact_match(&right_schema)
-                .map_err(|err| err.context("merge_sorted".into()))?;
+                .context("merge_sorted")?;
 
             polars_ensure!(
                 !key.is_empty(),
@@ -1582,9 +1568,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             );
 
             for key in key.iter() {
-                left_schema
-                    .try_get(key.as_str())
-                    .map_err(|err| err.context("merge_sorted".into()))?;
+                left_schema.try_get(key.as_str()).context("merge_sorted")?;
             }
 
             IR::MergeSorted {

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
@@ -1232,7 +1232,7 @@ this scan to succeed with an empty DataFrame.",
                             },
                         ))
                     }
-                    .map_err(|e| e.context(failed_here!(parquet scan)))?
+                    .context(failed_here!(parquet scan))?
                 }
             },
             #[cfg(feature = "ipc")]
@@ -1266,7 +1266,7 @@ this scan to succeed with an empty DataFrame.",
                     },
                 ))
             }
-            .map_err(|e| e.context(failed_here!(ipc scan)))?,
+            .context(failed_here!(ipc scan))?,
             #[cfg(feature = "csv")]
             FileScanDsl::Csv { mut options } => {
                 let mut file_info = if let Some(schema) = options.schema.clone() {
@@ -1303,7 +1303,7 @@ this scan to succeed with an empty DataFrame.",
 
                 PolarsResult::Ok((file_info, FileScanIR::Csv { options }))
             }
-            .map_err(|e| e.context(failed_here!(csv scan)))?,
+            .context(failed_here!(csv scan))?,
             #[cfg(feature = "json")]
             FileScanDsl::NDJson { options } => {
                 let mut file_info = if let Some(schema) = options.schema.clone() {
@@ -1339,7 +1339,7 @@ this scan to succeed with an empty DataFrame.",
 
                 PolarsResult::Ok((file_info, FileScanIR::NDJson { options }))
             }
-            .map_err(|e| e.context(failed_here!(ndjson scan)))?,
+            .context(failed_here!(ndjson scan))?,
             #[cfg(feature = "python")]
             FileScanDsl::PythonDataset { dataset_object } => async {
                 use polars_utils::async_utils::tokio_handle_ext::AbortOnDropHandle;
@@ -1376,7 +1376,7 @@ this scan to succeed with an empty DataFrame.",
                 ))
             }
             .await
-            .map_err(|e| e.context(failed_here!(python dataset scan)))?,
+            .context(failed_here!(python dataset scan))?,
             #[cfg(feature = "scan_lines")]
             FileScanDsl::Lines { name } => {
                 let schema = Arc::new(Schema::from_iter([(name.clone(), DataType::String)]));


### PR DESCRIPTION
Instead of doing `r.map_err(|e| e.context("in join_where"))` you can now simply write `r.context("in join_where")` on `PolarsResult`. This is done with the `PolarsContext` extension trait (in the `polars_core` prelude).

In case the context string isn't a `&'static str` and you don't want to pay the overhead for computing it each time (even when there's no error), use `.with_context` which takes a closure.