### PR TITLE
fix: Fix self-referencing `field` in `struct.with_fields` with `over`

### DIFF
--- a/crates/polars-expr/src/expressions/field.rs
+++ b/crates/polars-expr/src/expressions/field.rs
@@ -51,17 +51,28 @@ impl PhysicalExpr for FieldExpr {
             .as_ref()
             .ok_or_else(|| polars_err!(invalid_field_use))?;
 
-        let col = ac.flat_naive().clone();
-        let ca = col.struct_()?;
-        let out = ca.field_by_name(self.name.as_str()).map(Column::from)?;
+        let name = self.name.as_str();
+
+        let state = match ac.agg_state() {
+            AggState::AggregatedList(c) => {
+                let out = c
+                    .list()?
+                    .apply_to_inner(&|s| s.struct_()?.field_by_name(name))?;
+                AggState::AggregatedList(out.into_column())
+            },
+            AggState::NotAggregated(c) => {
+                AggState::NotAggregated(c.struct_()?.field_by_name(name)?.into_column())
+            },
+            AggState::AggregatedScalar(c) => {
+                AggState::AggregatedScalar(c.struct_()?.field_by_name(name)?.into_column())
+            },
+            AggState::LiteralScalar(c) => {
+                AggState::LiteralScalar(c.struct_()?.field_by_name(name)?.into_column())
+            },
+        };
 
         Ok(AggregationContext {
-            state: match ac.agg_state() {
-                AggState::AggregatedList(_) => AggState::AggregatedList(out),
-                AggState::NotAggregated(_) => AggState::NotAggregated(out),
-                AggState::AggregatedScalar(_) => AggState::AggregatedScalar(out),
-                AggState::LiteralScalar(_) => AggState::LiteralScalar(out),
-            },
+            state,
             groups: ac.groups.clone(),
             update_groups: ac.update_groups,
             original_groups: ac.original_groups,

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -1930,3 +1930,59 @@ def test_with_fields_optimize_expr_fused_multiply_add_27233() -> None:
         strict=True,
     )
     assert_frame_equal(out.unnest("s"), expected)
+
+
+def test_with_fields_agglist_in_over_unary_28674() -> None:
+    lf = pl.LazyFrame(
+        {
+            "g": ["a", "a", "b", "a", "b", "b"],
+            "x": [1, 2, 10, 3, 20, 30],
+        }
+    )
+
+    s = pl.struct(v=pl.col("x").cum_sum())
+    ext = s.struct.with_fields(pl.field("v").abs().alias("abs"))
+
+    out = lf.select("g", ext.over("g")).collect()
+
+    ref = pl.struct(s.struct.field("v"), s.struct.field("v").abs().alias("abs"))
+    expected = lf.select("g", ref.over("g")).collect()
+
+    assert_frame_equal(out, expected)
+
+
+def test_with_fields_agglist_in_over_binary_28674() -> None:
+    lf = pl.LazyFrame(
+        {
+            "g": ["a", "a", "b", "a", "b", "b"],
+            "x": [1, 2, 10, 3, 20, 30],
+        }
+    )
+
+    s = pl.struct(v=pl.col("x").cum_sum())
+    ext = s.struct.with_fields((pl.field("v") * 2).alias("double"))
+
+    out = lf.select("g", ext.over("g")).collect()
+
+    ref = pl.struct(s.struct.field("v"), (s.struct.field("v") * 2).alias("double"))
+    expected = lf.select("g", ref.over("g")).collect()
+
+    assert_frame_equal(out, expected)
+
+
+def test_struct_with_fields_agglist_nulls_28674() -> None:
+
+    lf = pl.LazyFrame({"g": ["a", "b", "a", "b"], "x": [1, None, None, 20]})
+    s = pl.struct(v=pl.col("x").cum_sum())
+    ext = s.struct.with_fields(pl.field("v").abs().alias("abs"))
+
+    out = lf.select("g", ext.over("g").alias("m")).collect().unnest("m")
+    expected = pl.DataFrame(
+        {
+            "g": ["a", "b", "a", "b"],
+            "v": [1, None, None, 20],
+            "abs": [1, None, None, 20],
+        }
+    )
+
+    assert_frame_equal(out, expected)


### PR DESCRIPTION
fixes #28674

Underlying issue: the `AggregatedList` was handled as `flat_naive` and not the inner.