### PR TITLE
fix: Preserve nulls when importing Arrow maps

### DIFF
--- a/crates/polars-core/src/series/from.rs
+++ b/crates/polars-core/src/series/from.rs
@@ -531,7 +531,7 @@ impl Series {
                         let arr = arr.as_any().downcast_ref::<MapArray>().unwrap();
                         let offsets: &OffsetsBuffer<i32> = arr.offsets();
 
-                        let validity = values.validity().cloned();
+                        let validity = arr.validity().cloned();
 
                         Box::from(ListArray::<i64>::new(
                             ListArray::<i64>::default_datatype(values.dtype().clone()),

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -401,6 +401,12 @@ def test_from_pyarrow_map() -> None:
     }
 
 
+def test_from_pyarrow_map_preserves_nulls_28652() -> None:
+    pa_map = pa.array([[], None, [("k", 1)]], type=pa.map_(pa.string(), pa.int64()))
+    result = pl.Series(pa_map)
+    assert result.to_list() == [[], None, [{"key": "k", "value": 1}]]
+
+
 def test_from_fixed_size_binary_list() -> None:
     val = [[b"63A0B1C66575DD5708E1EB2B"]]
     arrow_array = pa.array(val, type=pa.list_(pa.binary(24)))

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -4344,7 +4344,7 @@ def test_read_parquet_legacy_nested_maps_27159(io_files_path: Path) -> None:
                     }
                 ],
                 [{"key": "b", "value": [{"key": 1, "value": True}]}],
-                [{"key": "c", "value": []}],
+                [{"key": "c", "value": None}],
                 [{"key": "d", "value": []}],
                 [{"key": "e", "value": [{"key": 1, "value": True}]}],
                 [


### PR DESCRIPTION
Fixes #28652

## Root Cause
When importing PyArrow `MapArray`, Polars should use the MapArray's validity bitmap to preserve the null state of each map slot. The previous implementation incorrectly used the validity of `values`, which contains the flattened map entries. As a result, the resulting `ListArray` lost  the `MapArray`'s null information. A null map (`None`) could no longer be distinguished from an empty map (`[]`), so a null map was interpreted as an empty list.

## Solution
Use the outer MapArray's validity instead of the entries array's validity.

## Tests
1. Added a regression test covering non-empty, null, and empty maps.
2. Updated an existing legacy Parquet test that encoded the buggy behavior.

Verified with:
```bash
make -C py-polars test
make pre-commit
```

## AI disclosure
I used AI to help me:

1. understand the issue
2. explain the underlying mechanism
3. set up the development environment
4. review the code changes
5. check the English wording in the PR

The AI model is GPT-5.6 Sol High in Codex CLI.

I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.
