### PR TITLE
docs(python): Document NaN ordering footgun for quantile/median

### DIFF
--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -3609,6 +3609,16 @@ class Expr:
         """
         Get median value using linear interpolation.
 
+        Notes
+        -----
+        NaN values are regarded as larger than any finite number (and equal to one
+        another). As a result, ``NaN`` values are treated as the largest values when
+        computing the median, which can lead to surprising results.
+
+        For example, the median of ``[1.0, 2.0, NaN, NaN, NaN, 6.0, 7.0]`` is ``7.0``,
+        not ``4.0``. To exclude ``NaN`` values from the calculation, use
+        :func:`drop_nans`. To also exclude null values, use :func:`drop_nulls` first.
+
         Examples
         --------
         >>> df = pl.DataFrame({"a": [-1, 0, 1]})
@@ -4435,6 +4445,16 @@ class Expr:
     ) -> Expr:
         """
         Get quantile value.
+
+        Notes
+        -----
+        NaN values are regarded as larger than any finite number (and equal to one
+        another). As a result, ``NaN`` values are treated as the largest values when
+        computing quantiles, which can lead to surprising results.
+
+        For example, the median of ``[1.0, 2.0, NaN, NaN, NaN, 6.0, 7.0]`` is ``7.0``,
+        not ``4.0``. To exclude ``NaN`` values from the calculation, use
+        :func:`drop_nans`. To also exclude null values, use :func:`drop_nulls` first.
 
         Parameters
         ----------

--- a/py-polars/src/polars/functions/lazy.py
+++ b/py-polars/src/polars/functions/lazy.py
@@ -446,6 +446,17 @@ def median(*columns: str) -> Expr:
 
     This function is syntactic sugar for `pl.col(columns).median()`.
 
+    Notes
+    -----
+    NaN values are regarded as larger than any finite number (and equal to one
+    another). As a result, ``NaN`` values are treated as the largest values when
+    computing the median, which can lead to surprising results.
+
+    For example, the median of ``[1.0, 2.0, NaN, NaN, NaN, 6.0, 7.0]`` is ``7.0``,
+    not ``4.0``. To exclude ``NaN`` values from the calculation, use
+    :func:`Expr.drop_nans`. To also exclude null values, use :func:`Expr.drop_nulls`
+    first.
+
     Parameters
     ----------
     columns
@@ -1906,6 +1917,17 @@ def quantile(
 ) -> Expr:
     """
     Syntactic sugar for `pl.col("foo").quantile(..)`.
+
+    Notes
+    -----
+    NaN values are regarded as larger than any finite number (and equal to one
+    another). As a result, ``NaN`` values are treated as the largest values when
+    computing quantiles, which can lead to surprising results.
+
+    For example, the median of ``[1.0, 2.0, NaN, NaN, NaN, 6.0, 7.0]`` is ``7.0``,
+    not ``4.0``. To exclude ``NaN`` values from the calculation, use
+    :func:`Expr.drop_nans`. To also exclude null values, use :func:`Expr.drop_nulls`
+    first.
 
     Parameters
     ----------

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -2437,11 +2437,26 @@ class Series:
         """
         Get the median of this Series.
 
+        Notes
+        -----
+        NaN values are regarded as larger than any finite number (and equal to one
+        another). As a result, ``NaN`` values are treated as the largest values when
+        computing the median, which can lead to surprising results.
+
+        For example, the median of ``[1.0, 2.0, NaN, NaN, NaN, 6.0, 7.0]`` is ``7.0``,
+        not ``4.0``. To exclude ``NaN`` values from the calculation, use
+        :func:`drop_nans`. To also exclude null values, use :func:`drop_nulls` first.
+
         Examples
         --------
         >>> s = pl.Series("a", [1, 2, 3])
         >>> s.median()
         2.0
+        >>> s = pl.Series([1.0, 2.0, float("nan"), float("nan"), float("nan"), 6.0, 7.0])
+        >>> s.median()
+        7.0
+        >>> s.drop_nans().median()
+        4.0
         """
         return self._s.median()
 
@@ -2460,6 +2475,16 @@ class Series:
     ) -> float | None | list_[float] | list_[None]:
         """
         Get the quantile value of this Series.
+
+        Notes
+        -----
+        NaN values are regarded as larger than any finite number (and equal to one
+        another). As a result, ``NaN`` values are treated as the largest values when
+        computing quantiles, which can lead to surprising results.
+
+        For example, the median of ``[1.0, 2.0, NaN, NaN, NaN, 6.0, 7.0]`` is ``7.0``,
+        not ``4.0``. To exclude ``NaN`` values from the calculation, use
+        :func:`drop_nans`. To also exclude null values, use :func:`drop_nulls` first.
 
         Parameters
         ----------


### PR DESCRIPTION
## Summary
- Document that `NaN` is treated as larger than any finite value when computing `median()` / `quantile()`, which can skew results.
- Add Notes on `pl.median`/`pl.quantile`, `Expr` methods, and `Series` methods, with a Series doctest showing the footgun and `drop_nans()` fix.

Fixes #28368

## Test plan
- [x] Verified runtime behavior: median/quantile of `[1.0, 2.0, NaN, NaN, NaN, 6.0, 7.0]` is `7.0`; after `drop_nans()` it is `4.0`
- [ ] Review docstring Notes on `median`/`quantile` in expr, series, and lazy APIs
- [ ] Confirm the Series doctest example is accurate


Made with [Cursor](https://cursor.com)