### PR TITLE
depr(python): Deprecate `Expr.rechunk()`

### DIFF
--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -1517,7 +1517,7 @@ class Expr:
 
     @deprecated(
         "`Expr.rechunk()` is deprecated and will be removed in Polars 2.0. "
-        "Rechunking within a query is undefined. "
+        "Rechunking within a query is not well-defined. "
         "Use `df.rechunk()` after collecting the results instead."
     )
     def rechunk(self) -> Expr:

--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -1515,6 +1515,11 @@ class Expr:
         other_pyexpr = parse_into_expression(other)
         return wrap_expr(self._pyexpr.append(other_pyexpr, upcast))
 
+    @deprecated(
+        "`Expr.rechunk()` is deprecated and will be removed in Polars 2.0. "
+        "Rechunking within a query is undefined. "
+        "Use `df.rechunk()` after collecting the results instead."
+    )
     def rechunk(self) -> Expr:
         """
         Create a single chunk of memory for this Series.

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -410,7 +410,12 @@ def test_expression_appends() -> None:
     df = pl.DataFrame({"a": [1, 1, 2]})
 
     assert df.select(pl.repeat(None, 3).append(pl.col("a"))).n_chunks() == 2
-    assert df.select(pl.repeat(None, 3).append(pl.col("a")).rechunk()).n_chunks() == 1
+    msg = "`Expr.rechunk()` is deprecated and will be removed in Polars 2.0"
+    with pytest.deprecated_call(match=re.escape(msg)):
+        assert (
+            df.select(pl.repeat(None, 3).append(pl.col("a")).rechunk()).n_chunks() == 1
+        )
+    del msg
 
     out = df.select(pl.concat([pl.repeat(None, 3), pl.col("a")], rechunk=True))
 


### PR DESCRIPTION
Related issue: https://github.com/pola-rs/polars/issues/22279
