### PR TITLE
fix(rust): Don't hang or crash on `sqrt`/`cbrt`/`pct_change`/`ewm_*` with a Struct column

### DIFF
--- a/crates/polars-expr/src/dispatch/pow.rs
+++ b/crates/polars-expr/src/dispatch/pow.rs
@@ -203,9 +203,10 @@ pub(super) fn sqrt(base: &Column) -> PolarsResult<Column> {
             let ca = base.f64().unwrap();
             sqrt_on_floats(ca)
         },
-        _ => {
-            let base = base.cast(&DataType::Float64)?;
-            sqrt(&base)
+        dt => {
+            let casted = base.cast(&DataType::Float64)?;
+            polars_ensure!(casted.dtype() == &DataType::Float64, opq = sqrt, dt);
+            sqrt(&casted)
         },
     }
 }
@@ -234,9 +235,10 @@ pub(super) fn cbrt(base: &Column) -> PolarsResult<Column> {
             let ca = base.f64().unwrap();
             cbrt_on_floats(ca)
         },
-        _ => {
-            let base = base.cast(&DataType::Float64)?;
-            cbrt(&base)
+        dt => {
+            let casted = base.cast(&DataType::Float64)?;
+            polars_ensure!(casted.dtype() == &DataType::Float64, opq = cbrt, dt);
+            cbrt(&casted)
         },
     }
 }

--- a/crates/polars-ops/src/series/ops/ewm.rs
+++ b/crates/polars-ops/src/series/ops/ewm.rs
@@ -38,8 +38,7 @@ macro_rules! dispatch_ewm_kernel {
                 let result = $kernel;
                 Series::try_from(($s.name().clone(), Box::new(result) as ArrayRef))
             },
-            dt if cfg!(debug_assertions) => panic!("{:?}", dt),
-            _ => $fallback($s, $options),
+            dt => polars_bail!(opq = $fallback, dt),
         }
     }};
 }
@@ -105,7 +104,11 @@ pub fn ewm_std(s: &Series, options: EWMOptions) -> PolarsResult<Series> {
             );
             Series::try_from((s.name().clone(), Box::new(result) as ArrayRef))
         },
-        _ => ewm_std(&s.cast(&DataType::Float64)?, options),
+        dt => {
+            let casted = s.cast(&DataType::Float64)?;
+            polars_ensure!(casted.dtype() == &DataType::Float64, opq = ewm_std, dt);
+            ewm_std(&casted, options)
+        },
     }
 }
 
@@ -151,6 +154,10 @@ pub fn ewm_var(s: &Series, options: EWMOptions) -> PolarsResult<Series> {
             );
             Series::try_from((s.name().clone(), Box::new(result) as ArrayRef))
         },
-        _ => ewm_var(&s.cast(&DataType::Float64)?, options),
+        dt => {
+            let casted = s.cast(&DataType::Float64)?;
+            polars_ensure!(casted.dtype() == &DataType::Float64, opq = ewm_var, dt);
+            ewm_var(&casted, options)
+        },
     }
 }

--- a/crates/polars-ops/src/series/ops/pct_change.rs
+++ b/crates/polars-ops/src/series/ops/pct_change.rs
@@ -13,7 +13,11 @@ pub fn pct_change(s: &Series, n: &Series) -> PolarsResult<Series> {
         #[cfg(feature = "dtype-f16")]
         DataType::Float16 => {},
         DataType::Float64 | DataType::Float32 => {},
-        _ => return pct_change(&s.cast(&DataType::Float64)?, n),
+        dt => {
+            let casted = s.cast(&DataType::Float64)?;
+            polars_ensure!(casted.dtype() == &DataType::Float64, opq = pct_change, dt);
+            return pct_change(&casted, n);
+        },
     }
 
     let n_s = n.cast(&DataType::Int64)?;

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -672,6 +672,7 @@ impl OptimizationRule for TypeCoercionRule {
                 if dtype.is_float() {
                     return Ok(None);
                 }
+                polars_ensure!(!dtype.is_struct(), opq = ewm, dtype);
 
                 let new_function = match ewm_variant {
                     IRFunctionExpr::EwmMean { .. } => IRFunctionExpr::EwmMean {

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -1994,3 +1994,25 @@ def test_struct_with_fields_agglist_nulls_28674() -> None:
     )
 
     assert_frame_equal(out, expected)
+
+
+@pytest.mark.parametrize(
+    "op",
+    [
+        lambda x: x.sqrt(),
+        lambda x: x.cbrt(),
+        lambda x: x.pct_change(),
+        lambda x: x.ewm_mean(alpha=0.5),
+        lambda x: x.ewm_std(alpha=0.5),
+        lambda x: x.ewm_var(alpha=0.5),
+        lambda x: x.ewm_sum(alpha=0.5),
+    ],
+    ids=["sqrt", "cbrt", "pct_change", "ewm_mean", "ewm_std", "ewm_var", "ewm_sum"],
+)
+def test_numeric_op_on_struct_raises_28563(op: Any) -> None:
+    with pytest.raises(InvalidOperationError):
+        op(pl.Series("a", [{"x": 1}]))
+
+    lf = pl.LazyFrame({"meta": [{"id": 1}, {"id": 2}]})
+    with pytest.raises(InvalidOperationError):
+        lf.select(op(pl.col("meta"))).collect()


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/28563.

These functions fell back to `cast(Float64)` and recursing, which never terminates for Struct because casting a Struct casts field-wise and returns a Struct. This fix asserts the cast actually produced `Float64` and raises an `InvalidOperationError` otherwise, rather than narrowing the dispatch to numeric types. That keeps the same behavior as before, meaning working with booleans, decimals, dates, strings, and nulls, which an `is_numeric` guard would have rejected.

🤖 Claude Opus 5 for navigating the code base, asking questions, and for writing the test.
