### PR TITLE
fix: Prevent CSE from sharing scalar aggs in group_by()

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/cse/csee.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/csee.rs
@@ -738,7 +738,6 @@ pub(crate) struct CommonSubExprOptimizer {
     // Only supports element-wise CSEE
     // on SELECT/HSTACK
     element_wise_select_only: bool,
-
     nodes_scratch: ScratchVec<Node>,
     heights_scratch: ScratchVec<ExprProjectionHeight>,
 }
@@ -1108,28 +1107,42 @@ impl RewritingVisitor for CommonSubExprOptimizer {
                     input_schema.as_ref().as_ref(),
                     self.element_wise_select_only,
                 )? {
-                    let keys = keys.clone();
-                    let options = options.clone();
-                    let schema = schema.clone();
-                    let apply = apply.clone();
-                    let maintain_order = *maintain_order;
-                    let input = *input;
+                    let all_column_height = aggs.cse_exprs().iter().all(|agg| {
+                        matches!(
+                            aexpr_projection_height_rec(
+                                agg.node(),
+                                &arena.1,
+                                &mut self.nodes_scratch,
+                                &mut self.heights_scratch,
+                            ),
+                            ExprProjectionHeight::Column
+                        )
+                    });
 
-                    let lp = IRBuilder::new(input, &mut arena.1, &mut arena.0)
-                        .with_columns(aggs.cse_exprs().to_vec(), Default::default())
-                        .build();
-                    let input = arena.0.add(lp);
+                    if all_column_height {
+                        let keys = keys.clone();
+                        let options = options.clone();
+                        let schema = schema.clone();
+                        let apply = apply.clone();
+                        let maintain_order = *maintain_order;
+                        let input = *input;
 
-                    let lp = IR::GroupBy {
-                        input,
-                        keys,
-                        aggs: aggs.default_exprs().to_vec(),
-                        options,
-                        schema,
-                        maintain_order,
-                        apply,
-                    };
-                    arena.0.replace(arena_idx, lp);
+                        let lp = IRBuilder::new(input, &mut arena.1, &mut arena.0)
+                            .with_columns(aggs.cse_exprs().to_vec(), Default::default())
+                            .build();
+                        let input = arena.0.add(lp);
+
+                        let lp = IR::GroupBy {
+                            input,
+                            keys,
+                            aggs: aggs.default_exprs().to_vec(),
+                            options,
+                            schema,
+                            maintain_order,
+                            apply,
+                        };
+                        arena.0.replace(arena_idx, lp);
+                    }
                 }
             },
             _ => {},

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -1675,3 +1675,32 @@ def test_cse_single_scalar_does_not_broadcast_28407() -> None:
     q = pl.LazyFrame({"a": [1, 2, 3]}).select((e + e).alias("o"))
 
     assert_frame_equal(q.collect(), pl.DataFrame({"o": 10}, schema={"o": pl.Int32}))
+
+
+def test_cse_groupby_agg_scalar_28653() -> None:
+    # Shared scalar literal aggregation should not be broadcast/imploded
+    # incorrectly by CSE when reused across multiple `.agg()` outputs.
+    lf = pl.LazyFrame({"g": [1, 1, 2]})
+    e = pl.lit(-1.5).abs()
+    q = lf.group_by("g", maintain_order=True).agg(a=e, b=e)
+
+    expected = pl.DataFrame({"g": [1, 2], "a": [1.5, 1.5], "b": [1.5, 1.5]})
+    assert_frame_equal(q.collect(), expected)
+    # Cross-check against the unoptimized baseline directly, not just a
+    # hardcoded expectation.
+    assert_frame_equal(q.collect(), q.collect(optimizations=pl.QueryOptFlags.none()))
+
+
+def test_cse_groupby_agg_non_scalar_still_shared_28653() -> None:
+    # Regression guard: the 28653 fix must not disable CSE sharing for
+    # genuine non-scalar shared subexpressions in a group_by/agg context.
+
+    lf = pl.LazyFrame({"g": [1, 1, 2], "x": [10, 20, 30]})
+    shared = pl.col("x") * 2
+    q = lf.group_by("g", maintain_order=True).agg(a=shared.sum(), b=shared.mean())
+
+    assert "WITH_COLUMNS" in q.explain()
+    assert_frame_equal(
+        q.collect(),
+        q.collect(optimizations=pl.QueryOptFlags.none()),
+    )


### PR DESCRIPTION
Closes #28653.

## Problem

A scalar expression shared across multiple `.agg()` outputs in `group_by()` gets incorrectly turned into a `list[...]` by CSE instead of staying scalar:

```python
lf = pl.LazyFrame({"g": [1, 1, 2]})
lit = pl.lit(-1.5).abs()
q = lf.group_by("g", maintain_order=True).agg(a=lit, b=lit)

q.collect(optimizations=pl.QueryOptFlags.none())  # correct: a, b = 1.5, 1.5 per group
q.collect()                                        # wrong: a, b = list[f64]
```

## Root cause

CSE substitutes both `a`/`b` with a shared `col("__POLARS_CSER_...")` reference, materialized via `WITH_COLUMNS`. That reference is indistinguishable from a genuine bare-column reference to downstream code, even though the underlying value is still scalar (height 1).

Same root defect as #28480 (non-column-height expr reused via a height-preserving mechanism), but that fix was scoped to
`SELECT`/`HSTACK` and doesn't cover `GroupBy`.

## Fix

Mirrors #28480: rather than patching each downstream consumer, stop CSE from creating the ambiguous substitution for `GroupBy` in the first place. After `find_cse` finds candidate shared subexpressions in the `GroupBy` arm of `CommonSubExprOptimizer`, each is checked via `aexpr_projection_height_rec`; if any isn't `ExprProjectionHeight::Column`, the rewrite is skipped for that node (recomputed instead of cached).

## Testing

- `test_cse_groupby_agg_scalar_28653` - the repro, checked against the  `QueryOptFlags.none()` baseline.
- `test_cse_groupby_agg_non_scalar_still_shared_28653` - regression guard that real shared non-scalar subexpressions are still CSE'd.
- Full suite passes locally (screenshot attached).

<img width="1920" height="1032" alt="polar_cse_groupby_agg_test_suite" src="https://github.com/user-attachments/assets/2f785695-285d-476c-93c0-6415559f63cc" />

