### PR TITLE
fix: Unsoundness in rayon block_on

### DIFF
--- a/crates/polars-core/src/runtime.rs
+++ b/crates/polars-core/src/runtime.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::LazyLock;
-use std::sync::mpsc::{TryRecvError, sync_channel};
 
 use polars_utils::with_drop::WithDrop;
 use rayon::{ThreadPool, ThreadPoolBuilder, Yield};
@@ -152,11 +151,13 @@ impl RAYON {
     /// If this thread isn't a rayon thread this simply calls f directly.
     pub fn block_on<R: Send, F: FnOnce() -> R + Send>(&self, f: F) -> R {
         if THREAD_POOL.current_thread_index().is_some() {
-            let (send, recv) = sync_channel(1);
+            // We wrap F such that the resulting closure no longer has F or R as
+            // parameters, and whose only limitation is that it isn't 'static.
             let mut opt_f: Option<F> = Some(f);
+            let mut out: Option<std::thread::Result<R>> = None;
             let mut wrap_f = || {
                 let f = AssertUnwindSafe(opt_f.take().unwrap());
-                send.send(catch_unwind(f)).unwrap();
+                out = Some(catch_unwind(f));
             };
 
             // SAFETY: we always await the future to completion before returning from here, meaning
@@ -166,24 +167,20 @@ impl RAYON {
             let ref_wrap_f: &mut (dyn Send + FnMut()) = &mut wrap_f;
             let static_wrap_f: &'static mut (dyn Send + FnMut() + 'static) =
                 unsafe { core::mem::transmute(ref_wrap_f) };
-            ASYNC.spawn_blocking(static_wrap_f);
+            let join_handle = ASYNC.spawn_blocking(static_wrap_f);
 
-            loop {
-                match recv.try_recv() {
-                    Ok(r) => {
-                        WithDrop::dismiss(abort);
-                        match r {
-                            Ok(v) => return v,
-                            Err(panic) => std::panic::resume_unwind(panic),
-                        }
-                    },
-                    Err(TryRecvError::Empty) => match rayon::yield_now() {
-                        Some(Yield::Executed) => {},
-                        Some(Yield::Idle) => std::thread::yield_now(),
-                        None => unreachable!(),
-                    },
-                    Err(TryRecvError::Disconnected) => unreachable!(),
+            while !join_handle.is_finished() {
+                match rayon::yield_now() {
+                    Some(Yield::Executed) => {},
+                    Some(Yield::Idle) => std::thread::yield_now(),
+                    None => unreachable!(),
                 }
+            }
+
+            WithDrop::dismiss(abort);
+            match out.unwrap() {
+                Ok(v) => v,
+                Err(panic) => std::panic::resume_unwind(panic),
             }
         } else {
             f()


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/28707.

The old code was problematic because after the return value channel was notified the task could immediately die even though there were still things running on Tokio's end. Now we properly wait for the entire task to be finished.
