### PR TITLE
perf: Drop unused projections in filter on streaming engine

### DIFF
--- a/crates/polars-stream/src/nodes/filter.rs
+++ b/crates/polars-stream/src/nodes/filter.rs
@@ -1,3 +1,4 @@
+use polars_buffer::Buffer;
 use polars_mem_engine::column_to_mask;
 
 use super::compute_node_prelude::*;
@@ -5,11 +6,15 @@ use crate::expression::StreamExpr;
 
 pub struct FilterNode {
     predicate: StreamExpr,
+    projection: Option<Buffer<usize>>,
 }
 
 impl FilterNode {
-    pub fn new(predicate: StreamExpr) -> Self {
-        Self { predicate }
+    pub fn new(predicate: StreamExpr, projection: Option<Buffer<usize>>) -> Self {
+        Self {
+            predicate,
+            projection,
+        }
     }
 }
 
@@ -46,12 +51,24 @@ impl ComputeNode for FilterNode {
             join_handles.push(scope.spawn_task(TaskPriority::High, async move {
                 while let Ok(morsel) = recv.recv().await {
                     let morsel = morsel
-                        .async_try_map(|df| async move {
+                        .async_try_map(|mut df| async move {
                             let mask = slf
                                 .predicate
                                 .evaluate(&df, &state.in_memory_exec_state)
                                 .await?;
                             let mask = column_to_mask(&mask, df.height())?;
+
+                            if let Some(projection) = slf.projection.as_deref() {
+                                df = unsafe {
+                                    DataFrame::new_unchecked(
+                                        df.height(),
+                                        projection
+                                            .iter()
+                                            .map(|&i| df.columns()[i].clone())
+                                            .collect(),
+                                    )
+                                }
+                            }
 
                             // We already parallelize, call the sequential filter.
                             df.filter_seq(mask.as_ref())

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -280,13 +280,33 @@ fn visualize_plan_rec(
             offset,
             fill: None,
         } => ("shift".to_owned(), &[*input, *offset][..]),
-        PhysNodeKind::Filter { input, predicate } => (
-            format!(
-                "filter\\n{}",
-                fmt_exprs_to_label(from_ref(predicate), expr_arena, FormatExprStyle::Select)
-            ),
-            from_ref(input),
-        ),
+        PhysNodeKind::Filter {
+            input,
+            predicate,
+            projection,
+        } => {
+            let mut projection_fmt = String::new();
+
+            if let Some((names, len_before_drop)) = projection.as_ref() {
+                write!(
+                    EscapeLabel(&mut projection_fmt),
+                    "project {} / {}: {}",
+                    names.len(),
+                    len_before_drop,
+                    names.join(", ")
+                )
+                .unwrap();
+            }
+
+            (
+                format!(
+                    "filter\\n{}{}",
+                    fmt_exprs_to_label(from_ref(predicate), expr_arena, FormatExprStyle::Select),
+                    projection_fmt
+                ),
+                from_ref(input),
+            )
+        },
         PhysNodeKind::SimpleProjection { input, columns } => {
             let mut label = "select".to_string();
             let mut f = EscapeLabel(&mut label);

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -2009,6 +2009,7 @@ fn lower_exprs_with_ctx(
                 let kind = PhysNodeKind::Filter {
                     input: select_stream,
                     predicate,
+                    projection: None,
                 };
                 let output_schema = select_stream.output_schema(ctx.phys_sm).clone();
                 let filter_node_key = ctx.phys_sm.insert(PhysNode::new(output_schema, kind));

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -109,6 +109,7 @@ pub fn build_filter_stream(
     let filter = PhysNodeKind::Filter {
         input: trans_input,
         predicate: trans_cols_and_predicate.last().unwrap().clone(),
+        projection: None,
     };
 
     let post_filter = phys_sm.insert(PhysNode::new(filter_schema, filter));

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -889,6 +889,10 @@ fn fuse_drops(roots: Vec<PhysNodeKey>, phys_sm: &mut SlotMap<PhysNodeKey, PhysNo
 
         let has_rename = columns.iter().any(|(k, v)| k != v);
 
+        if has_rename {
+            return;
+        }
+
         match input_node.kind_mut() {
             PhysNodeKind::Filter {
                 input: _,

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -101,6 +101,10 @@ impl PhysNode {
     pub fn kind(&self) -> &PhysNodeKind {
         &self.kind
     }
+
+    pub fn kind_mut(&mut self) -> &mut PhysNodeKind {
+        &mut self.kind
+    }
 }
 
 /// A handle representing a physical stream of data with a fixed schema in the
@@ -207,6 +211,8 @@ pub enum PhysNodeKind {
     Filter {
         input: PhysStream,
         predicate: ExprIR,
+        /// (projected columns, num_input_columns).
+        projection: Option<(Vec<PlSmallStr>, usize)>,
     },
 
     SimpleProjection {
@@ -556,7 +562,24 @@ pub enum PhysNodeKind {
 fn visit_node_inputs_mut(
     roots: Vec<PhysNodeKey>,
     phys_sm: &mut SlotMap<PhysNodeKey, PhysNode>,
-    mut visit: impl FnMut(&mut PhysStream),
+    visit: impl FnMut(&mut PhysStream),
+) {
+    _visit_nodes_impl(roots, phys_sm, |_, _| (), visit)
+}
+
+fn visit_nodes_mut(
+    roots: Vec<PhysNodeKey>,
+    phys_sm: &mut SlotMap<PhysNodeKey, PhysNode>,
+    visit: impl FnMut(PhysNodeKey, &mut SlotMap<PhysNodeKey, PhysNode>),
+) {
+    _visit_nodes_impl(roots, phys_sm, visit, |_| ())
+}
+
+fn _visit_nodes_impl(
+    roots: Vec<PhysNodeKey>,
+    phys_sm: &mut SlotMap<PhysNodeKey, PhysNode>,
+    mut visit_node: impl FnMut(PhysNodeKey, &mut SlotMap<PhysNodeKey, PhysNode>),
+    mut visit_input: impl FnMut(&mut PhysStream),
 ) {
     let mut to_visit = roots;
     let mut seen: SecondaryMap<PhysNodeKey, ()> =
@@ -601,19 +624,19 @@ fn visit_node_inputs_mut(
             | PhysNodeKind::PeakMinMax { input, .. }
             | PhysNodeKind::IsSorted { input, .. } => {
                 rec!(input.node);
-                visit(input);
+                visit_input(input);
             },
 
             #[cfg(feature = "interpolate")]
             PhysNodeKind::Interpolate { input, .. } => {
                 rec!(input.node);
-                visit(input);
+                visit_input(input);
             },
 
             #[cfg(feature = "is_first_distinct")]
             PhysNodeKind::IsFirstDistinct { input, .. } => {
                 rec!(input.node);
-                visit(input);
+                visit_input(input);
             },
 
             #[cfg(any(
@@ -623,24 +646,24 @@ fn visit_node_inputs_mut(
             ))]
             PhysNodeKind::StrptimeInfer { input, .. } => {
                 rec!(input.node);
-                visit(input);
+                visit_input(input);
             },
 
             #[cfg(feature = "dynamic_group_by")]
             PhysNodeKind::DynamicGroupBy { input, .. } => {
                 rec!(input.node);
-                visit(input);
+                visit_input(input);
             },
             #[cfg(feature = "dynamic_group_by")]
             PhysNodeKind::RollingGroupBy { input, .. } => {
                 rec!(input.node);
-                visit(input);
+                visit_input(input);
             },
 
             #[cfg(feature = "cum_agg")]
             PhysNodeKind::CumAgg { input, .. } => {
                 rec!(input.node);
-                visit(input);
+                visit_input(input);
             },
 
             PhysNodeKind::InMemoryJoin {
@@ -675,8 +698,8 @@ fn visit_node_inputs_mut(
             } => {
                 rec!(input_left.node);
                 rec!(input_right.node);
-                visit(input_left);
-                visit(input_right);
+                visit_input(input_left);
+                visit_input(input_right);
             },
 
             #[cfg(feature = "iejoin")]
@@ -687,8 +710,8 @@ fn visit_node_inputs_mut(
             } => {
                 rec!(input_left.node);
                 rec!(input_right.node);
-                visit(input_left);
-                visit(input_right);
+                visit_input(input_left);
+                visit_input(input_right);
             },
 
             #[cfg(feature = "merge_sorted")]
@@ -699,22 +722,22 @@ fn visit_node_inputs_mut(
             } => {
                 rec!(input_left.node);
                 rec!(input_right.node);
-                visit(input_left);
-                visit(input_right);
+                visit_input(input_left);
+                visit_input(input_right);
             },
 
             PhysNodeKind::Gather { input, idxs, .. } => {
                 rec!(input.node);
                 rec!(idxs.node);
-                visit(input);
-                visit(idxs);
+                visit_input(input);
+                visit_input(idxs);
             },
 
             PhysNodeKind::TopK { input, k, .. } => {
                 rec!(input.node);
                 rec!(k.node);
-                visit(input);
-                visit(k);
+                visit_input(input);
+                visit_input(k);
             },
 
             PhysNodeKind::DynamicSlice {
@@ -725,9 +748,9 @@ fn visit_node_inputs_mut(
                 rec!(input.node);
                 rec!(offset.node);
                 rec!(length.node);
-                visit(input);
-                visit(offset);
-                visit(length);
+                visit_input(input);
+                visit_input(offset);
+                visit_input(length);
             },
 
             PhysNodeKind::Shift {
@@ -740,18 +763,18 @@ fn visit_node_inputs_mut(
                 if let Some(fill) = fill {
                     rec!(fill.node);
                 }
-                visit(input);
-                visit(offset);
+                visit_input(input);
+                visit_input(offset);
                 if let Some(fill) = fill {
-                    visit(fill);
+                    visit_input(fill);
                 }
             },
 
             PhysNodeKind::Repeat { value, repeats } => {
                 rec!(value.node);
                 rec!(repeats.node);
-                visit(value);
-                visit(repeats);
+                visit_input(value);
+                visit_input(repeats);
             },
 
             PhysNodeKind::GroupBy { inputs, .. }
@@ -761,14 +784,14 @@ fn visit_node_inputs_mut(
             | PhysNodeKind::ColumnarFunction { inputs, .. } => {
                 for input in inputs {
                     rec!(input.node);
-                    visit(input);
+                    visit_input(input);
                 }
             },
 
             PhysNodeKind::SinkMultiple { sinks } => {
                 for sink in sinks {
                     rec!(*sink);
-                    visit(&mut PhysStream::first(*sink));
+                    visit_input(&mut PhysStream::first(*sink));
                 }
             },
 
@@ -778,9 +801,11 @@ fn visit_node_inputs_mut(
             | PhysNodeKind::EwmVar { input, options: _ }
             | PhysNodeKind::EwmStd { input, options: _ } => {
                 rec!(input.node);
-                visit(input)
+                visit_input(input)
             },
         }
+
+        visit_node(node, phys_sm);
     }
 }
 
@@ -841,6 +866,48 @@ fn split_multiplexers(roots: Vec<PhysNodeKey>, phys_sm: &mut SlotMap<PhysNodeKey
     });
 }
 
+fn fuse_drops(roots: Vec<PhysNodeKey>, phys_sm: &mut SlotMap<PhysNodeKey, PhysNode>) {
+    visit_nodes_mut(roots, phys_sm, |key, phys_sm| {
+        let PhysNodeKind::SimpleProjection { input, .. } = phys_sm[key].kind() else {
+            return;
+        };
+        let len_before_drop = input.output_schema(phys_sm).len();
+        let input = input.node;
+
+        let Some([simple_proj_node, input_node]) = phys_sm.get_disjoint_mut([key, input]) else {
+            return;
+        };
+
+        if input_node.output_schemas.len() != 1 {
+            return;
+        }
+
+        let PhysNodeKind::SimpleProjection { input: _, columns } = simple_proj_node.kind_mut()
+        else {
+            unreachable!()
+        };
+
+        let has_rename = columns.iter().any(|(k, v)| k != v);
+
+        match input_node.kind_mut() {
+            PhysNodeKind::Filter {
+                input: _,
+                predicate: _,
+                projection: projection @ None,
+            } => *projection = Some((Vec::from_iter(columns.keys().cloned()), len_before_drop)),
+
+            _ => return,
+        }
+
+        let input_schema = input_node.output_schema_mut(0);
+        *input_schema = Arc::new(input_schema.try_project(columns.keys()).unwrap());
+
+        if !has_rename && simple_proj_node.output_schemas.len() == 1 {
+            std::mem::swap(simple_proj_node, input_node);
+        }
+    });
+}
+
 pub fn build_physical_plan(
     root: Node,
     ir_arena: &mut Arena<IR>,
@@ -864,5 +931,6 @@ pub fn build_physical_plan(
     )?;
     insert_multiplexers(vec![phys_root.node], phys_sm);
     split_multiplexers(vec![phys_root.node], phys_sm);
+    fuse_drops(vec![phys_root.node], phys_sm);
     Ok(phys_root.node)
 }

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -889,6 +889,7 @@ fn fuse_drops(roots: Vec<PhysNodeKey>, phys_sm: &mut SlotMap<PhysNodeKey, PhysNo
 
         let has_rename = columns.iter().any(|(k, v)| k != v);
 
+        // TODO: Figure out why `input_schema.try_project` fails below with e.g. "\"_POLARS_TMP_7253\" not found"
         if has_rename {
             return;
         }

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -201,12 +201,23 @@ fn to_graph_rec<'a>(
             }
         },
 
-        Filter { predicate, input } => {
+        Filter {
+            predicate,
+            input,
+            projection,
+        } => {
             let input_schema = input.output_schema(ctx.phys_sm);
             let phys_predicate_expr = create_stream_expr(predicate, ctx, input_schema)?;
             let input_key = to_graph_rec(input.node, ctx)?;
             ctx.graph.add_node(
-                nodes::filter::FilterNode::new(phys_predicate_expr),
+                nodes::filter::FilterNode::new(
+                    phys_predicate_expr,
+                    projection.as_ref().map(|(x, _)| {
+                        x.iter()
+                            .map(|name| input_schema.index_of(name).unwrap())
+                            .collect()
+                    }),
+                ),
                 [(input_key, input.port)],
             )
         },

--- a/py-polars/tests/unit/lazyframe/test_optimizations.py
+++ b/py-polars/tests/unit/lazyframe/test_optimizations.py
@@ -1289,3 +1289,16 @@ def test_predicate_pushdown_with_cse_sink_cross_filter_28287(
     f = io.BytesIO()
     lf.sink_parquet(f, engine=engine)  # type: ignore[call-overload]
     assert_frame_equal(pl.read_parquet(f), pl.DataFrame({"x": 2, "y": 20}))
+
+
+def test_streaming_engine_fused_filter_drop() -> None:
+    q = (
+        pl.LazyFrame({"x": [0, 1], "y": [False, True], "z": "Z"})
+        .filter("y")
+        .select("x", "z")
+    )
+
+    phys_plan = q.show_graph(engine="streaming", plan_stage="physical", raw_output=True)
+
+    assert phys_plan.index("project 2 / 3") > phys_plan.index("filter")
+    assert_frame_equal(q.collect(), pl.DataFrame({"x": 1, "z": "Z"}))


### PR DESCRIPTION
* ref https://github.com/pola-rs/polars/issues/26651

Benchmark - `pola-rs/polars-benchmark` SF10.0 on Apple M3 Pro 11-core, q19 goes from 0.298s -> 0.252s (1.18x speedup)
