### PR TITLE
chore: Remove deprecated parameters on `DataFrame` methods

### DIFF
--- a/py-polars/src/polars/_utils/expired.py
+++ b/py-polars/src/polars/_utils/expired.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import inspect
+from functools import wraps
+from typing import TYPE_CHECKING, TypeVar
 
+from polars._utils.various import IdentityFunction
 from polars.exceptions import AttributeRemovedError
 
 if TYPE_CHECKING:
-    from typing import Any
+    from collections.abc import Callable
+    from typing import Any, ParamSpec
+
+    P = ParamSpec("P")
+    T = TypeVar("T")
 
 
 def raise_for_removed_attributes(
@@ -54,3 +61,69 @@ def getattr_fallback(obj: object, superclass: object, name: str) -> Any:
     else:
         msg = f"{type(obj).__name__!r} object has no attribute {name!r}"
         raise AttributeError(msg, name=name, obj=obj)
+
+
+def removed_renamed_parameter(
+    old_name: str,
+    new_name: str,
+    *,
+    deprecated_in: str | None = None,
+    removed_in: str,
+) -> IdentityFunction:
+    """
+    Decorator to mark a function parameter as removed due to being renamed.
+
+    Use as follows:
+
+        @removed_renamed_parameter("old_name", new_name="new_name")
+        def myfunc(new_name): ...
+    """
+
+    def decorate(function: Callable[P, T]) -> Callable[P, T]:
+        @wraps(function)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            _removed_keyword_argument(
+                old_name=old_name,
+                new_name=new_name,
+                kwargs=kwargs,
+                func_name=function.__qualname__,
+                deprecated_version=deprecated_in,
+                removed_version=removed_in,
+            )
+            return function(*args, **kwargs)
+
+        wrapper.__signature__ = inspect.signature(function)  # type: ignore[attr-defined]
+        return wrapper
+
+    return decorate
+
+
+def _removed_keyword_argument(
+    *,
+    old_name: str,
+    new_name: str,
+    kwargs: dict[str, object],
+    func_name: str,
+    deprecated_version: str | None = None,
+    removed_version: str,
+) -> None:
+    """Rename a keyword argument of a function."""
+    if old_name in kwargs:
+        deprecated_and = (
+            f"was deprecated in version {deprecated_version} and "
+            if deprecated_version is not None
+            else ""
+        )
+        if new_name in kwargs:
+            msg = (
+                f"`{func_name!r}` received both `{old_name!r}` and `{new_name!r}` as arguments;"
+                f" `{old_name!r}` {deprecated_and}has been removed in version {removed_version},"
+                f" use `{new_name!r}` instead"
+            )
+            raise TypeError(msg)
+
+        msg = (
+            f"the argument `{old_name}` for `{func_name}` {deprecated_and}has been removed in {removed_version}. "
+            f"It was renamed to `{new_name}`."
+        )
+        raise TypeError(msg)

--- a/py-polars/src/polars/_utils/expired.py
+++ b/py-polars/src/polars/_utils/expired.py
@@ -4,7 +4,7 @@ import inspect
 from functools import wraps
 from typing import TYPE_CHECKING, TypeVar
 
-from polars.exceptions import AttributeRemovedError
+from polars.exceptions import ArgumentRemovedError, AttributeRemovedError
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -121,10 +121,10 @@ def _removed_keyword_argument(
                 f" `{old_name!r}` {deprecated_and}has been removed in version {removed_version},"
                 f" use `{new_name!r}` instead"
             )
-            raise TypeError(msg)
+            raise ArgumentRemovedError(msg)
 
         msg = (
             f"the argument `{old_name}` for `{func_name}` {deprecated_and}has been removed in {removed_version}. "
             f"It was renamed to `{new_name}`."
         )
-        raise TypeError(msg)
+        raise ArgumentRemovedError(msg)

--- a/py-polars/src/polars/_utils/expired.py
+++ b/py-polars/src/polars/_utils/expired.py
@@ -4,12 +4,13 @@ import inspect
 from functools import wraps
 from typing import TYPE_CHECKING, TypeVar
 
-from polars._utils.various import IdentityFunction
 from polars.exceptions import AttributeRemovedError
 
 if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Any, ParamSpec
+
+    from polars._utils.various import IdentityFunction
 
     P = ParamSpec("P")
     T = TypeVar("T")

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -66,6 +66,7 @@ from polars._utils.deprecation import (
 from polars._utils.expired import (
     getattr_fallback,
     raise_for_removed_attributes,
+    removed_renamed_parameter,
 )
 from polars._utils.getitem import get_df_item_by_key
 from polars._utils.parse import parse_into_expression
@@ -1747,7 +1748,9 @@ class DataFrame:
         )
         return s.get_index_signed(row)
 
-    @deprecate_renamed_parameter("future", "compat_level", version="1.1")
+    @removed_renamed_parameter(
+        "future", "compat_level", deprecated_in="1.1", removed_in="2.0"
+    )
     def to_arrow(self, *, compat_level: CompatLevel | None = None) -> pa.Table:
         """
         Collect the underlying arrow arrays in an Arrow Table.
@@ -4080,7 +4083,9 @@ class DataFrame:
         compat_level: CompatLevel | None = None,
     ) -> None: ...
 
-    @deprecate_renamed_parameter("future", "compat_level", version="1.1")
+    @removed_renamed_parameter(
+        "future", "compat_level", deprecated_in="1.1", removed_in="2.0"
+    )
     def write_ipc_stream(
         self,
         file: str | Path | IO[bytes] | None,
@@ -5742,7 +5747,9 @@ class DataFrame:
         return_type: Literal["frame", "self"],
     ) -> DataFrame: ...
 
-    @deprecate_renamed_parameter("return_as_string", "return_type", version="1.35.0")
+    @removed_renamed_parameter(
+        "return_as_string", "return_type", deprecated_in="1.35.0", removed_in="2.0"
+    )
     def glimpse(
         self,
         *,

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -59,7 +59,6 @@ from polars._utils.construction import (
 )
 from polars._utils.convert import parse_as_duration_string
 from polars._utils.deprecation import (
-    deprecate_renamed_parameter,
     deprecated,
     issue_deprecation_warning,
 )
@@ -3952,7 +3951,9 @@ class DataFrame:
         retries: int | None = None,
     ) -> None: ...
 
-    @deprecate_renamed_parameter("future", "compat_level", version="1.1")
+    @removed_renamed_parameter(
+        "future", "compat_level", deprecated_in="1.1", removed_in="2.0"
+    )
     def write_ipc(
         self,
         file: str | Path | IO[bytes] | None,
@@ -6291,7 +6292,9 @@ class DataFrame:
             ctx.register(name=name, frame=self)
             return ctx.execute(query)
 
-    @deprecate_renamed_parameter("descending", "reverse", version="1.0.0")
+    @removed_renamed_parameter(
+        "descending", "reverse", deprecated_in="1.0.0", removed_in="2.0"
+    )
     def top_k(
         self,
         k: int,
@@ -6377,7 +6380,9 @@ class DataFrame:
             .collect(optimizations=optimizations)
         )
 
-    @deprecate_renamed_parameter("descending", "reverse", version="1.0.0")
+    @removed_renamed_parameter(
+        "descending", "reverse", deprecated_in="1.0.0", removed_in="2.0"
+    )
     def bottom_k(
         self,
         k: int,
@@ -7277,7 +7282,9 @@ class DataFrame:
             self, *by, **named_by, maintain_order=maintain_order, predicates=None
         )
 
-    @deprecate_renamed_parameter("by", "group_by", version="0.20.14")
+    @removed_renamed_parameter(
+        "by", "group_by", deprecated_in="0.20.14", removed_in="2.0"
+    )
     def rolling(
         self,
         index_column: IntoExpr,
@@ -7435,7 +7442,9 @@ class DataFrame:
             predicates=None,
         )
 
-    @deprecate_renamed_parameter("by", "group_by", version="0.20.14")
+    @removed_renamed_parameter(
+        "by", "group_by", deprecated_in="0.20.14", removed_in="2.0"
+    )
     def group_by_dynamic(
         self,
         index_column: IntoExpr,
@@ -7756,7 +7765,9 @@ class DataFrame:
             predicates=None,
         )
 
-    @deprecate_renamed_parameter("by", "group_by", version="0.20.14")
+    @removed_renamed_parameter(
+        "by", "group_by", deprecated_in="0.20.14", removed_in="2.0"
+    )
     def upsample(
         self,
         time_column: str,
@@ -8213,7 +8224,9 @@ class DataFrame:
             .collect(optimizations=QueryOptFlags._eager())
         )
 
-    @deprecate_renamed_parameter("join_nulls", "nulls_equal", version="1.24")
+    @removed_renamed_parameter(
+        "join_nulls", "nulls_equal", deprecated_in="1.24", removed_in="2.0"
+    )
     def join(
         self,
         other: DataFrame,
@@ -9558,7 +9571,7 @@ class DataFrame:
             .collect(optimizations=QueryOptFlags._eager())
         )
 
-    @deprecate_renamed_parameter("columns", "on", version="1.0.0")
+    @removed_renamed_parameter("columns", "on", deprecated_in="1.0.0", removed_in="2.0")
     def pivot(
         self,
         on: ColumnNameOrSelector | Sequence[ColumnNameOrSelector],

--- a/py-polars/src/polars/exceptions.py
+++ b/py-polars/src/polars/exceptions.py
@@ -218,6 +218,10 @@ class UnstableWarning(PolarsWarning):
     """Warning issued when unstable functionality is used."""
 
 
+class ArgumentRemovedError(TypeError):
+    """Exception raised when a function argument has been removed."""
+
+
 class AttributeRemovedError(AttributeError):
     """Exception raised when an attribute has been removed from a class."""
 
@@ -225,6 +229,7 @@ class AttributeRemovedError(AttributeError):
 __all__ = [
     # Errors
     "PolarsError",
+    "ArgumentRemovedError",
     "AttributeRemovedError",
     "ColumnNotFoundError",
     "ComputeError",

--- a/py-polars/tests/unit/dataframe/test_glimpse.py
+++ b/py-polars/tests/unit/dataframe/test_glimpse.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 
 import polars as pl
+from polars.exceptions import ArgumentRemovedError
 
 TEST_DF = pl.DataFrame(
     {
@@ -61,13 +62,11 @@ TEST_EXPECTED = textwrap.dedent(
 )
 
 
-def test_glimpse(capsys: Any) -> None:
-    for result in (
-        # check deprecated parameter still works
-        TEST_DF.glimpse(return_as_string=True),  # type: ignore[call-overload]
-        TEST_DF.glimpse(return_type="string"),
-    ):
-        assert result == TEST_EXPECTED
+def test_glimpse() -> None:
+    with pytest.raises(ArgumentRemovedError):
+        TEST_DF.glimpse(return_as_string=True)  # type: ignore[call-overload]
+
+    assert TEST_DF.glimpse(return_type="string") == TEST_EXPECTED
 
 
 @pytest.mark.parametrize("return_type", [None, "self"])

--- a/py-polars/tests/unit/dataframe/test_glimpse.py
+++ b/py-polars/tests/unit/dataframe/test_glimpse.py
@@ -7,7 +7,6 @@ from typing import Any
 import pytest
 
 import polars as pl
-from polars.exceptions import ArgumentRemovedError
 
 TEST_DF = pl.DataFrame(
     {

--- a/py-polars/tests/unit/dataframe/test_glimpse.py
+++ b/py-polars/tests/unit/dataframe/test_glimpse.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 
 import polars as pl
+from polars.exceptions import ArgumentRemovedError
 
 TEST_DF = pl.DataFrame(
     {

--- a/py-polars/tests/unit/meta/test_errors.py
+++ b/py-polars/tests/unit/meta/test_errors.py
@@ -12,6 +12,7 @@ import pytest
 import polars as pl
 from polars.datatypes.convert import dtype_to_py_type
 from polars.exceptions import (
+    ArgumentRemovedError,
     AttributeRemovedError,
     ColumnNotFoundError,
     ComputeError,
@@ -830,3 +831,12 @@ def test_dtype_mismatch_names_column_and_dtypes() -> None:
         match=r"arithmetic on dtypes i64 and str is not allowed \(lhs: column 'a', rhs: column 'b'\)",
     ):
         df.select(pl.col("a") + pl.col("b"))
+
+
+def test_join_nulls_argument_removed() -> None:
+    df = pl.DataFrame({"a": [1, None]})
+    with pytest.raises(
+        ArgumentRemovedError,
+        match=r"the argument `join_nulls` for `DataFrame.join` was deprecated in version 1.24 and has been removed in 2.0. It was renamed to `nulls_equal`",
+    ):
+        df.join(df, on="a", join_nulls=True)  # type: ignore[call-arg]

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -11,7 +11,6 @@ import pytest
 
 import polars as pl
 from polars.exceptions import (
-    ArgumentRemovedError,
     ColumnNotFoundError,
     ComputeError,
     DuplicateError,

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -11,6 +11,7 @@ import pytest
 
 import polars as pl
 from polars.exceptions import (
+    ArgumentRemovedError,
     ColumnNotFoundError,
     ComputeError,
     DuplicateError,
@@ -169,15 +170,6 @@ def test_deprecated() -> None:
         .to_numpy(),
         result.to_numpy(),
     )
-
-
-def test_deprecated_parameter_join_nulls() -> None:
-    df = pl.DataFrame({"a": [1, None]})
-    with pytest.deprecated_call(
-        match=r"the argument `join_nulls` for `DataFrame.join` is deprecated. It was renamed to `nulls_equal`"
-    ):
-        result = df.join(df, on="a", join_nulls=True)  # type: ignore[call-arg]
-    assert_frame_equal(result, df, check_row_order=False)
 
 
 def test_join_on_expressions() -> None:


### PR DESCRIPTION
~~Apply after: https://github.com/pola-rs/polars/pull/28700~~
Related issue: https://github.com/pola-rs/polars/issues/28416

:robot: The replacement was done with AI. I wrote the decorator myself.
