### PR TITLE
fix(python): Preserve Fast Explode On Arrow DataFrame Import

### DIFF
--- a/crates/polars-python/src/interop/arrow/to_rust.rs
+++ b/crates/polars-python/src/interop/arrow/to_rust.rs
@@ -1,3 +1,4 @@
+use arrow::array::Array;
 use polars_core::prelude::*;
 use polars_core::runtime::RAYON;
 use polars_core::utils::accumulate_dataframes_vertical_unchecked;
@@ -49,6 +50,36 @@ pub fn array_to_rust(obj: &Bound<PyAny>) -> PyResult<ArrayRef> {
         let array = ffi::import_array_from_c(*array, field.dtype).map_err(PyPolarsErr::from)?;
         Ok(array)
     }
+}
+
+pub(crate) fn can_fast_explode(array: &dyn Array) -> bool {
+    array
+        .as_any()
+        .downcast_ref::<LargeListArray>()
+        .is_some_and(|a| a.offsets().as_slice().windows(2).all(|w| w[0] != w[1]))
+}
+
+fn series_from_arrow(field: &ArrowField, arr: ArrayRef) -> PolarsResult<Series> {
+    // Compute first. The physical conversion retains offsets so the flag remains valid.
+    let fast_explode = can_fast_explode(arr.as_ref());
+
+    // SAFETY: The array comes from a record batch with this field's schema.
+    let mut series = unsafe {
+        Series::_try_from_arrow_unchecked_with_md(
+            field.name.clone(),
+            vec![arr],
+            field.dtype(),
+            field.metadata.as_deref(),
+        )
+    }?;
+
+    if fast_explode && series.dtype().is_list() {
+        let mut ca = series.list()?.clone();
+        ca.set_fast_explode();
+        series = ca.into_series();
+    }
+
+    Ok(series)
 }
 
 pub fn to_rust_df(
@@ -137,16 +168,9 @@ pub fn to_rust_df(
                             .enumerate()
                             .map(|(i, arr)| {
                                 let (_, field) = schema.get_at_index(i).unwrap();
-                                let s = unsafe {
-                                    Series::_try_from_arrow_unchecked_with_md(
-                                        field.name.clone(),
-                                        vec![arr],
-                                        field.dtype(),
-                                        field.metadata.as_deref(),
-                                    )
-                                }
-                                .map_err(PyPolarsErr::from)?
-                                .into_column();
+                                let s = series_from_arrow(field, arr)
+                                    .map_err(PyPolarsErr::from)?
+                                    .into_column();
                                 Ok(s)
                             })
                             .collect::<PyResult<Vec<_>>>()
@@ -158,16 +182,9 @@ pub fn to_rust_df(
                     .enumerate()
                     .map(|(i, arr)| {
                         let (_, field) = schema.get_at_index(i).unwrap();
-                        let s = unsafe {
-                            Series::_try_from_arrow_unchecked_with_md(
-                                field.name.clone(),
-                                vec![arr],
-                                field.dtype(),
-                                field.metadata.as_deref(),
-                            )
-                        }
-                        .map_err(PyPolarsErr::from)?
-                        .into_column();
+                        let s = series_from_arrow(field, arr)
+                            .map_err(PyPolarsErr::from)?
+                            .into_column();
                         Ok(s)
                     })
                     .collect::<PyResult<Vec<_>>>()

--- a/crates/polars-python/src/series/construction.rs
+++ b/crates/polars-python/src/series/construction.rs
@@ -14,7 +14,7 @@ use crate::PySeries;
 use crate::conversion::Wrap;
 use crate::conversion::any_value::py_object_to_any_value;
 use crate::error::PyPolarsErr;
-use crate::interop::arrow::to_rust::array_to_rust;
+use crate::interop::arrow::to_rust::{array_to_rust, can_fast_explode};
 use crate::prelude::ObjectValue;
 use crate::utils::EnterPolarsExt;
 
@@ -384,10 +384,7 @@ impl PySeries {
         let arr = array_to_rust(array)?;
 
         // Compute first. The physical conversion retains offsets so the flag remains valid.
-        let fast_explode = arr
-            .as_any()
-            .downcast_ref::<LargeListArray>()
-            .is_some_and(|a| a.offsets().as_slice().windows(2).all(|w| w[0] != w[1]));
+        let fast_explode = can_fast_explode(arr.as_ref());
 
         // Normal conversion handling nested types recursively.
         let mut series: Series = Series::try_new(name.into(), arr).map_err(PyPolarsErr::from)?;

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -1678,3 +1678,51 @@ def test_series_from_arrow_large_list_keeps_fast_explode_28626(
     assert imported.to_list() == values
     assert imported.flags["FAST_EXPLODE"] is fast_explode
     assert imported.explode(empty_as_null=True, keep_nulls=True).to_list() == exploded
+
+
+@pytest.mark.parametrize(
+    ("values", "fast_explode", "exploded"),
+    [
+        ([["a", "b"], ["c"]], True, ["a", "b", "c"]),
+        ([["a"], [], ["b"]], False, ["a", None, "b"]),
+        ([["a"], None, ["b"]], False, ["a", None, "b"]),
+    ],
+)
+@pytest.mark.parametrize("parallel", [False, True])
+def test_dataframe_from_arrow_large_list_keeps_fast_explode_28633(
+    values: list[Any], fast_explode: bool, exploded: list[Any], parallel: bool
+) -> None:
+    table = pl.DataFrame({"c": values}).to_arrow()
+    if parallel:
+        table = table.append_column(
+            "trigger_parallel", pa.array(["value"] * len(values), type=pa.string())
+        )
+
+    imported = cast("pl.DataFrame", pl.from_arrow(table))["c"]
+
+    assert imported.to_list() == values
+    assert imported.flags["FAST_EXPLODE"] is fast_explode
+    assert imported.explode(empty_as_null=True, keep_nulls=True).to_list() == exploded
+
+
+@pytest.mark.parametrize(
+    ("chunks", "fast_explode"),
+    [
+        ([[["a"]], [["b", "c"]]], True),
+        ([[["a"]], [[]]], False),
+        ([[["a"]], [None]], False),
+    ],
+)
+@pytest.mark.parametrize("rechunk", [False, True])
+def test_dataframe_from_arrow_chunked_large_list_keeps_fast_explode_28633(
+    chunks: list[list[list[str] | None]], fast_explode: bool, rechunk: bool
+) -> None:
+    dtype = pa.large_list(pa.string())
+    arrays = [pa.array(values, type=dtype) for values in chunks]
+    table = pa.table({"c": pa.chunked_array(arrays)})
+
+    imported = cast("pl.DataFrame", pl.from_arrow(table, rechunk=rechunk))["c"]
+
+    assert imported.to_list() == [value for chunk in chunks for value in chunk]
+    assert imported.n_chunks() == (1 if rechunk else len(chunks))
+    assert imported.flags["FAST_EXPLODE"] is fast_explode


### PR DESCRIPTION
This PR Closes #28633

## Description

This PR Resolves the `FAST_EXPLODE` optimization flag loss issue which was caused for DataFrames when coverting Arrow Tables to Polars Dataframes through ArrowTable/DataFrame. This was causing the fallback to slower explode path even with no empty or null lists present  

## Key Changes

* **Shared Offset Check:** Added `can_fast_explode` in `to_rust.rs` to inspect Arrow `LargeListArray` offsets by verifying `offset[i + 1] != offset[i]` for every consecutive pair. This logic is now shared across both `Series` (`construction.rs`) and `DataFrame` conversions to eliminate duplicate code and guarantee identical flag rules.
* **Unified Conversion Paths:** Wrapped DataFrame conversion branches in a `series_from_arrow` helper so that both serial and parallel execution paths properly retain the `FAST_EXPLODE` state.
* **Comprehensive Test Coverage:** Added unit test coverage in `test_interop.py` for non-empty, empty, and null lists across serial, parallel, multi-chunk, and rechunked Arrow Table conversions.

## Test Results

```text
18450 passed, 126 skipped, 8 xfailed
```

## Visual Verification

<img width="1366" height="768" alt="Polars_Make_Test_Passed_2026-08-06" src="https://github.com/user-attachments/assets/e926fcba-5007-4718-bda5-b3d97bad0c28" />

## AI Disclosure and Review Confirmation

* **AI Assistance:** I have used Codex for this as assistant and Codex provided assistance across the following areas:
* Codebase exploration and root-cause analysis
* Python regression-test preparation
* Native Windows build troubleshooting
* Running the repository-required validations

## Personal Review & Testing: 
I have personally reviewed, verified, and approved all code changes and logic. I also ran the 15 focused unit tests to validate the fix, and executed the repository-required `make test` command on my machine.