### PR TITLE
fix: Do not panic when exceeding Parquet metadata scan cache

### DIFF
--- a/crates/polars-plan/src/dsl/file_scan/mod.rs
+++ b/crates/polars-plan/src/dsl/file_scan/mod.rs
@@ -98,6 +98,7 @@ const _: () = {
 ///
 /// Source indices refer to the scan's source list; a source not covered by
 /// the variant is unknown.
+/// Canonical format: Partial is used iff the subset is neither empty nor full.
 #[cfg(feature = "parquet")]
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -117,39 +118,53 @@ pub enum MetadataPerSource {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PartialMetadata {
     /// Source indices of the resolved footers, ascending.
+    /// Invariant: the first index points to source 0 in the ScanSources list.
     indices: Vec<usize>,
     /// Dense footers: `metadata[j]` is the footer of source `indices[j]`.
     metadata: Vec<FileMetadataRef>,
 }
 
 #[cfg(feature = "parquet")]
+impl PartialMetadata {
+    fn new(indices: Vec<usize>, metadata: Vec<FileMetadataRef>) -> Self {
+        assert!(!indices.is_empty());
+        assert!(indices.len() == metadata.len());
+        assert_eq!(indices.first().unwrap(), &0, "Partial must retain source 0");
+
+        Self { indices, metadata }
+    }
+}
+
+#[cfg(feature = "parquet")]
 impl MetadataPerSource {
     /// Build from `(source index, footer)` entries; coverage picks the
-    /// variant.
+    /// variant. Enforces canonical format.
     pub(crate) fn new(
         entries: impl IntoIterator<Item = (usize, FileMetadataRef)>,
         n_sources: usize,
     ) -> Self {
         let mut entries: Vec<_> = entries.into_iter().collect();
+
         // Sorted storage; strictness also rules out duplicate indices.
         entries.sort_unstable_by_key(|&(i, _)| i);
+
         debug_assert!(entries.windows(2).all(|w| w[0].0 < w[1].0));
         debug_assert!(entries.last().is_none_or(|(i, _)| *i < n_sources));
+
         if entries.is_empty() {
             Self::Unresolved
         } else if entries.len() == n_sources {
             Self::Full(entries.into_iter().map(|(_, m)| m).collect())
         } else {
             let (indices, metadata) = entries.into_iter().unzip();
-            Self::Partial(Arc::new(PartialMetadata { indices, metadata }))
+            Self::Partial(Arc::new(PartialMetadata::new(indices, metadata)))
         }
     }
 
     /// Footer of the scan's current source 0, when resolved.
     ///
     /// Every resolve that reads source 0's footer retains it, so this is
-    /// `Some` for any non-`Unresolved` value produced by resolve;
-    /// [`Self::gather`] can drop it.
+    /// `Some` for any non-`Unresolved` value produced by resolve.
     pub fn first_metadata(&self) -> Option<&FileMetadataRef> {
         match self {
             Self::Unresolved => None,
@@ -165,6 +180,7 @@ impl MetadataPerSource {
         match self {
             // A sampled subset is not worth renumbering across a filter;
             // per-source estimates re-derive from the byte sizes.
+            // TODO: Apply filter to Partial.
             Self::Unresolved | Self::Partial(_) => Self::Unresolved,
             Self::Full(s) => {
                 let gathered: Vec<FileMetadataRef> = surviving.map(|i| s[i].clone()).collect();
@@ -177,50 +193,24 @@ impl MetadataPerSource {
         }
     }
 
+    /// Gather the first entry in the set.
     pub fn gather_first(&self) -> Self {
         match self {
-            Self::Partial(p) => {
-                let (Some(i), Some(md)) = (p.indices.first(), p.metadata.first()) else {
-                    return Self::Unresolved;
-                };
-
-                Self::Partial(Arc::new(PartialMetadata {
-                    indices: vec![*i],
-                    metadata: vec![md.clone()],
-                }))
-            },
-            _ => self.gather_partial(std::iter::once(1)),
-        }
-    }
-
-    // This assumes the source list does not change.
-    fn gather_partial(&self, surviving: impl Iterator<Item = usize>) -> Self {
-        match self {
             Self::Unresolved => Self::Unresolved,
-            Self::Full(s) => Self::new(surviving.map(|i| (i, s[i].clone())), s.len()),
-            Self::Partial(p) => {
-                // Both `p.indices` and `surviving` are ascending; merge-intersect them,
-                // keeping the original (unrenumbered) indices of the matches.
-                let mut resolved = p.indices.iter().copied().zip(p.metadata.iter()).peekable();
-                let mut indices = Vec::new();
-                let mut metadata = Vec::new();
-                for idx in surviving {
-                    while resolved.peek().is_some_and(|&(i, _)| i < idx) {
-                        resolved.next();
-                    }
-                    if let Some(&(i, m)) = resolved.peek() {
-                        if i == idx {
-                            indices.push(i);
-                            metadata.push(m.clone());
-                            resolved.next();
-                        }
-                    }
-                }
-                if indices.is_empty() {
-                    Self::Unresolved
-                } else {
-                    Self::Partial(Arc::new(PartialMetadata { indices, metadata }))
-                }
+            Self::Partial(p) => match (p.indices.first(), p.metadata.first()) {
+                (Some(&0), Some(md)) => {
+                    Self::Partial(Arc::new(PartialMetadata::new(vec![0], vec![md.clone()])))
+                },
+                (Some(_), Some(_)) => {
+                    debug_assert!(false, "Partial must retain source 0");
+                    Self::Unresolved // Unreachable.
+                },
+                _ => Self::Unresolved,
+            },
+            Self::Full(md) => match md.len() {
+                0 => Self::Unresolved, // Unreachable.
+                1 => self.clone(),
+                n => MetadataPerSource::new(std::iter::once((0, md[0].clone())), n),
             },
         }
     }
@@ -232,10 +222,10 @@ impl MetadataPerSource {
     ) -> Self {
         match self {
             Self::Unresolved => Self::Unresolved,
-            Self::Partial(p) => Self::Partial(Arc::new(PartialMetadata {
-                indices: p.indices.clone(),
-                metadata: p.metadata.iter().map(&mut f).collect(),
-            })),
+            Self::Partial(p) => Self::Partial(Arc::new(PartialMetadata::new(
+                p.indices.clone(),
+                p.metadata.iter().map(&mut f).collect(),
+            ))),
             Self::Full(s) => Self::Full(s.iter().map(f).collect()),
         }
     }

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/scans.rs
@@ -322,8 +322,8 @@ pub(super) async fn parquet_file_info(
     } else {
         use polars_config::ResolveMode;
 
-        // The strided footer sample; `Some` only when it does not already
-        // span every source (a spanning wave routes through the `Full` arm).
+        // Indices of the footers to be sampled. Value is `Some` only when
+        // file coverage is incomplete.
         let partial_sample = matches!(mode, ResolveMode::Sampled)
             .then(|| {
                 // Default cap: the IO concurrency budget floored at
@@ -613,9 +613,15 @@ pub fn max_metadata_scan_cached() -> usize {
             v.parse::<usize>()
                 .expect("invalid `POLARS_MAX_CACHED_METADATA_SCANS` value")
         });
+
         if value == 0 {
             return usize::MAX;
         }
+
+        if polars_config::config().verbose() {
+            eprintln!("parquet max cached metadata scans: {value}")
+        };
+
         value
     });
     *MAX_SCANS_METADATA_CACHED
@@ -1193,8 +1199,8 @@ impl SourcesToFileInfo {
                         let first_scan_source = require_first_source(
                             "failed to retrieve first file schema (parquet)",
                             "\
-passing a schema can allow \
-this scan to succeed with an empty DataFrame.",
+    passing a schema can allow \
+    this scan to succeed with an empty DataFrame.",
                         )?;
 
                         if verbose() {
@@ -1204,6 +1210,8 @@ this scan to succeed with an empty DataFrame.",
                             )
                         }
 
+                        // TODO: Reconcile the `resolve` strategy with the cache capacity to
+                        // avoid throwaway work and control it here.
                         let (mut file_info, mut metadata_per_source) = scans::parquet_file_info(
                             sources,
                             unified_scan_args.row_index.as_ref(),

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -4516,6 +4516,7 @@ def test_parquet_prefilter_fixed_size_binary_27781() -> None:
     )
 
 
+@pytest.mark.write_disk
 def test_parquet_writes_field_id(tmp_path: Path) -> None:
     lf = pl.LazyFrame(
         {"a": [1, 2, 3], "b": ["a", "b", "c"], "c": ["x", "y", "z"]},
@@ -4539,3 +4540,30 @@ def test_parquet_writes_field_id(tmp_path: Path) -> None:
         for i in range(len(written_schema))
     ]
     assert field_ids == [b"1", b"2", b"3"]
+
+
+@pytest.mark.parametrize("n", [8, 9, 10])
+@pytest.mark.write_disk
+def test_parquet_max_cached_scans_28661(
+    plmonkeypatch: PlMonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    n: int,
+) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    plmonkeypatch.setenv("POLARS_VERBOSE", "1")
+
+    frames = []
+    for i in range(n):
+        p = tmp_path / f"{i}.parquet"
+        pl.DataFrame({"a": [i], "b": [float(i)]}).write_parquet(p)
+        frames.append(pl.scan_parquet(p))
+
+    capfd.readouterr()
+    pl.concat(frames).collect()
+
+    # Test becomes stale if the following raises. Unfortunately this
+    # only works when running the test in isolation.
+    err = capfd.readouterr().err
+    if "parquet max cached metadata scans:" in err:
+        assert "parquet max cached metadata scans: 8" in err, err


### PR DESCRIPTION
fixes #28719 

The PR fixes a panic from an indexing bug in `gather_first`, and enforces the invariant that `MetadataPerSource::Partial` must always start with first index as source 0. This removes the ambiguity on the semantics of the indexing for the `Partial` variant.

Follow-up work for future PRs:
(a) Reconcile the cache strategy with the Resolve mode to avoid throwaway work, include cachekey review.
(b) Harden the invariant by adding `n_sources` to the `Partial` variant (or similar) to ensure semantics stay synchronized on filter pass.
(c) Enable `gather_partial` when filtering.
(d) Set the default `Resolve` mode in OSS back to `None` (TBC).