### PR TITLE
chore(python): Put `DataFrame.__getattr__` in `not TYPE_CHECKING` block

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -13326,18 +13326,20 @@ class DataFrame:
             )
         ).to_series()
 
-    def __getattr__(self, name: str) -> Any:
-        raise_for_removed_attributes(
-            self,
-            name,
-            {
-                "melt": "use `DataFrame.unpivot` instead, with `index` instead of `id_vars` and `on` instead of `value_vars`",
-                "with_row_count": "use `with_row_index` instead. Note that the default column name has changed from 'row_nr' to 'index'.",
-                "approx_n_unique": "use `select(pl.all().approx_n_unique())` instead.",
-            },
-            version="2.0",
-        )
-        return getattr_fallback(self, super(), name)
+    if not TYPE_CHECKING:
+
+        def __getattr__(self, name: str) -> Any:
+            raise_for_removed_attributes(
+                self,
+                name,
+                {
+                    "melt": "use `DataFrame.unpivot` instead, with `index` instead of `id_vars` and `on` instead of `value_vars`",
+                    "with_row_count": "use `with_row_index` instead. Note that the default column name has changed from 'row_nr' to 'index'.",
+                    "approx_n_unique": "use `select(pl.all().approx_n_unique())` instead.",
+                },
+                version="2.0",
+            )
+            return getattr_fallback(self, super(), name)
 
 
 def _prepare_other_arg(other: Any, length: int | None = None) -> Series:


### PR DESCRIPTION
Pyrefly gets confused when a class has a `__getattr__` field, because it cannot check the presence of a method on that class. This leads to errors like:

```
Runtime checkable protocol `Collection` has an unsafe overlap with type `Collection[Any] | Expr | Series` [unsafe-overlap]
```

This PR puts the `__getattr__` method in a `if not TYPE_CHECKING:` block to prevent these kinds of difficulties.