### PR TITLE
chore: Improve backtrace path formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,8 +1015,8 @@ checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "color-backtrace"
-version = "0.7.2"
-source = "git+https://github.com/orlp/color-backtrace?rev=bb62ccf1e9eb1f6b7af5f16acff1fd7151a876dd#bb62ccf1e9eb1f6b7af5f16acff1fd7151a876dd"
+version = "0.7.4"
+source = "git+https://github.com/orlp/color-backtrace?rev=20f5eea183563bb4cfac9a4d65901d4a1002cde2#20f5eea183563bb4cfac9a4d65901d4a1002cde2"
 dependencies = [
  "btparse",
  "termcolor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,7 @@ question_mark = "allow" # https://github.com/rust-lang/rust-clippy/issues/17384
 # simd-json = { git = "https://github.com/ritchie46/simd-json", branch = "alignment" }
 # custom DNS resolver - ref https://github.com/apache/arrow-rs-object-store/pull/728
 object_store = { git = "https://github.com/kdn36/arrow-rs-object-store", rev = "f50a6e5c564b2b5933eca15cd20ff9b5614374a1" }
-color-backtrace = { git = "https://github.com/orlp/color-backtrace", rev = "bb62ccf1e9eb1f6b7af5f16acff1fd7151a876dd" }
+color-backtrace = { git = "https://github.com/orlp/color-backtrace", rev = "20f5eea183563bb4cfac9a4d65901d4a1002cde2" }
 
 # https://github.com/tikv/jemallocator/pull/168
 tikv-jemalloc-sys = { git = "https://github.com/pola-rs/jemallocator", rev = "0d683dfb157097e2075d5e0eaf25f71f514a7552" }

--- a/crates/polars-python/src/on_startup.rs
+++ b/crates/polars-python/src/on_startup.rs
@@ -138,12 +138,27 @@ pub unsafe fn register_startup_deps(catch_keyboard_interrupt: bool, warn_functio
 
             let mut btp = BacktracePrinter::default();
             if let Some(bp) = polars_base_path() {
-                btp = btp.dependency_predicate(Box::new(move |frame: &Frame| -> bool {
+                let is_non_polars_frame = Box::new(move |frame: &Frame| -> bool {
                     if let Some(file) = frame.filename.as_ref().and_then(|f| f.canonicalize().ok()) {
                         !file.starts_with(&bp)
                     } else {
                         default_is_dependency_frame(frame)
                     }
+                });
+                btp = btp.dependency_predicate(is_non_polars_frame.clone());
+
+                btp = btp.path_display(Box::new(move |path: &Path, frame: &Frame| {
+                    // Remove ./ from the start of relative paths, regularly breaks VS Code ctrl+click fuzzy find.
+                    let p = path.to_string_lossy();
+                    let p = p.strip_prefix("./").unwrap_or(&p).to_owned();
+
+                    // Dim paths of non-Polars frames.
+                    let color = is_non_polars_frame(frame).then(|| {
+                        let mut color = ColorSpec::new();
+                        color.set_dimmed(true);
+                        color
+                    });
+                    (p, color)
                 }));
             }
 


### PR DESCRIPTION
This dims the paths of non-Polars frames, and trims `./` from the relative paths as this regularly broke VS code ctrl+clicking in terminal.