### PR TITLE
fix: Exclude debug tests from nodebug streaming run

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -143,4 +143,4 @@ jobs:
         env:
           POLARS_AUTO_STREAMING: 1
           POLARS_TIMEOUT_MS: 60000
-        run: pytest -n auto -m "not may_fail_auto_streaming and not slow and not write_disk and not release and not docs and not hypothesis and not benchmark and not ci_only"
+        run: pytest -n auto -m "not may_fail_auto_streaming and not slow and not write_disk and not release and not docs and not hypothesis and not benchmark and not debug and not ci_only"


### PR DESCRIPTION
Closes #28746