### PR TITLE
fix: Avoid chunk fragmentation on bool agg `any` and `all`

### DIFF
--- a/crates/polars-core/src/frame/group_by/aggregations/boolean.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/boolean.rs
@@ -293,7 +293,9 @@ impl BooleanChunked {
         let values = self.rechunk();
         let values = values.downcast_as_array();
 
-        let ca: BooleanChunked = RAYON.install(|| {
+        let groups_len = groups.len();
+
+        RAYON.install(|| {
             let validity = values
                 .validity()
                 .filter(|v| v.unset_bits() > 0)
@@ -302,51 +304,45 @@ impl BooleanChunked {
 
             if !ignore_nulls && let Some(validity) = validity {
                 match groups {
-                    GroupsType::Idx(idx) => idx
-                        .into_par_iter()
-                        .map(|(_, idx)| idx_kleene(values, validity, idx))
-                        .collect(),
-                    GroupsType::Slice {
-                        groups,
-                        overlapping: _,
-                        monotonic: _,
-                    } => groups
-                        .into_par_iter()
-                        .map(|[start, length]| slice_kleene(values, validity, *start, *length))
-                        .collect(),
+                    GroupsType::Idx(idx) => {
+                        let all = idx.all();
+                        collect_bool_opt_par(name, groups_len, |g| {
+                            idx_kleene(values, validity, &all[g])
+                        })
+                    },
+                    GroupsType::Slice { groups, .. } => {
+                        collect_bool_opt_par(name, groups_len, |g| {
+                            let [s, l] = groups[g];
+                            slice_kleene(values, validity, s, l)
+                        })
+                    },
                 }
             } else {
                 match groups {
-                    GroupsType::Idx(idx) => match validity {
-                        None => idx
-                            .into_par_iter()
-                            .map(|(_, idx)| idx_no_valid(values, idx))
-                            .collect(),
-                        Some(validity) => idx
-                            .into_par_iter()
-                            .map(|(_, idx)| idx_validity(values, validity, idx))
-                            .collect(),
+                    GroupsType::Idx(idx) => {
+                        let all = idx.all();
+                        match validity {
+                            None => collect_bool_par(name, groups_len, |g| {
+                                idx_no_valid(values, &all[g])
+                            }),
+                            Some(validity) => collect_bool_par(name, groups_len, |g| {
+                                idx_validity(values, validity, &all[g])
+                            }),
+                        }
                     },
-                    GroupsType::Slice {
-                        groups,
-                        overlapping: _,
-                        monotonic: _,
-                    } => match validity {
-                        None => groups
-                            .into_par_iter()
-                            .map(|[start, length]| slice_no_valid(values, *start, *length))
-                            .collect(),
-                        Some(validity) => groups
-                            .into_par_iter()
-                            .map(|[start, length]| {
-                                slice_validity(values, validity, *start, *length)
-                            })
-                            .collect(),
+                    GroupsType::Slice { groups, .. } => match validity {
+                        None => collect_bool_par(name, groups_len, |g| {
+                            let [s, l] = groups[g];
+                            slice_no_valid(values, s, l)
+                        }),
+                        Some(validity) => collect_bool_par(name, groups_len, |g| {
+                            let [s, l] = groups[g];
+                            slice_validity(values, validity, s, l)
+                        }),
                     },
                 }
             }
-        });
-        ca.with_name(name)
+        })
     }
 
     /// # Safety
@@ -460,4 +456,60 @@ impl BooleanChunked {
             },
         )
     }
+}
+
+pub fn collect_bool_par<F>(name: PlSmallStr, len: usize, f: F) -> BooleanChunked
+where
+    F: Fn(usize) -> bool + Send + Sync,
+{
+    let n_bytes = len.div_ceil(8);
+    let mut values: Vec<u8> = Vec::with_capacity(n_bytes);
+
+    (0..n_bytes)
+        .into_par_iter()
+        .map(|b| {
+            let lo = b * 8;
+            let hi = (lo + 8).min(len);
+            let mut v = 0u8;
+            for (bit, g) in (lo..hi).enumerate() {
+                v |= (f(g) as u8) << bit;
+            }
+            v
+        })
+        .collect_into_vec(&mut values);
+
+    BooleanChunked::from_bitmap(name, Bitmap::from_u8_vec(values, len))
+}
+
+pub fn collect_bool_opt_par<F>(name: PlSmallStr, len: usize, f: F) -> BooleanChunked
+where
+    F: Fn(usize) -> Option<bool> + Send + Sync,
+{
+    let n_bytes = len.div_ceil(8);
+    let mut values: Vec<u8> = Vec::with_capacity(n_bytes);
+    let mut validity: Vec<u8> = Vec::with_capacity(n_bytes);
+
+    (0..n_bytes)
+        .into_par_iter()
+        .map(|b| {
+            let lo = b * 8;
+            let hi = (lo + 8).min(len);
+            let (mut v, mut m) = (0u8, 0u8);
+            for (bit, g) in (lo..hi).enumerate() {
+                if let Some(x) = f(g) {
+                    m |= 1 << bit;
+                    v |= (x as u8) << bit;
+                }
+            }
+            (v, m)
+        })
+        .unzip_into_vecs(&mut values, &mut validity);
+
+    let values = Bitmap::from_u8_vec(values, len);
+    let validity = Bitmap::from_u8_vec(validity, len);
+    let validity = (validity.unset_bits() > 0).then_some(validity);
+    BooleanChunked::with_chunk(
+        name,
+        BooleanArray::new(ArrowDataType::Boolean, values, validity),
+    )
 }

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -3196,11 +3196,11 @@ def test_group_by_f16_agg_28353(agg: str, args: list[float]) -> None:
     assert_frame_equal(out16, out64, check_row_order=False, rel_tol=1e-3, abs_tol=1e-4)
 
 
-@pytest.mark.parametrize("agg", [pl.col.b.any, pl.col.b.all])
+@pytest.mark.parametrize("agg", ["any", "all"])
 @pytest.mark.parametrize("ignore_nulls", [True, False])
 @pytest.mark.parametrize("null_frac", [0.0, 0.3])
 def test_group_by_bool_agg_single_chunk_28684(
-    agg: pl.Expr, ignore_nulls: bool, null_frac: float
+    agg: str, ignore_nulls: bool, null_frac: float
 ) -> None:
     # must be large enough to trigger chunk fragmentation
     n = 20_000
@@ -3212,10 +3212,10 @@ def test_group_by_bool_agg_single_chunk_28684(
     df = pl.DataFrame({"g": np.arange(n), "b": pl.Series(b, dtype=pl.Boolean)})
 
     out = df.group_by("g", maintain_order=True).agg(
-        agg(ignore_nulls=ignore_nulls)
+        getattr(pl.col("b"), agg)(ignore_nulls=ignore_nulls)
     )
 
     assert out["b"].n_chunks() == 1
 
-    expected = df["b"] if not ignore_nulls else df["b"].fill_null(agg.__name__ == "all")
+    expected = df["b"] if not ignore_nulls else df["b"].fill_null(agg == "all")
     assert_series_equal(out["b"], expected, check_names=False)

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -3194,3 +3194,28 @@ def test_group_by_f16_agg_28353(agg: str, args: list[float]) -> None:
     df16 = df64.with_columns(pl.col.x.cast(pl.Float16))
     out16 = df16.group_by("g").agg(getattr(pl.col.x, agg)(*args).cast(pl.Float64))
     assert_frame_equal(out16, out64, check_row_order=False, rel_tol=1e-3, abs_tol=1e-4)
+
+
+@pytest.mark.parametrize("agg", [pl.col.b.any, pl.col.b.all])
+@pytest.mark.parametrize("ignore_nulls", [True, False])
+@pytest.mark.parametrize("null_frac", [0.0, 0.3])
+def test_group_by_bool_agg_single_chunk_28684(
+    agg: pl.Expr, ignore_nulls: bool, null_frac: float
+) -> None:
+    # must be large enough to trigger chunk fragmentation
+    n = 20_000
+    rng = np.random.default_rng(0)
+
+    vals = rng.random(n) < 0.5
+    nulls = rng.random(n) < null_frac
+    b = [None if is_null else bool(v) for v, is_null in zip(vals, nulls, strict=True)]
+    df = pl.DataFrame({"g": np.arange(n), "b": pl.Series(b, dtype=pl.Boolean)})
+
+    out = df.group_by("g", maintain_order=True).agg(
+        agg(ignore_nulls=ignore_nulls)
+    )
+
+    assert out["b"].n_chunks() == 1
+
+    expected = df["b"] if not ignore_nulls else df["b"].fill_null(agg.__name__ == "all")
+    assert_series_equal(out["b"], expected, check_names=False)

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -3196,6 +3196,7 @@ def test_group_by_f16_agg_28353(agg: str, args: list[float]) -> None:
     assert_frame_equal(out16, out64, check_row_order=False, rel_tol=1e-3, abs_tol=1e-4)
 
 
+@pytest.mark.may_fail_auto_streaming  # n_chunks is an implementation detail for in-memory
 @pytest.mark.parametrize("agg", ["any", "all"])
 @pytest.mark.parametrize("ignore_nulls", [True, False])
 @pytest.mark.parametrize("null_frac", [0.0, 0.3])


### PR DESCRIPTION
fixes #28684 

This PR collects aggregation results directly into a single Vec, avoiding chunk fragmentation, which otherwise may lead to performance issues (e.g. on `filter` of a wide dataframe).

PRs to follow:
(a) similar for boolean agg `min` and `max` etc
(b) similar for Primitive types
(c) change `should_rechunk` conditions
(d) check chunk on `Dataframe::filter` entry

Results on the original issue (release 1.4.3 then make build-release on PR), 24 vCPU dev machine:
```
$  python issue_orig.py && pp issue_orig.py
  threads=  1  best=   35.4 ms | loops:    71.7    37.2    35.4    36.6    35.9
  threads=  4  best=   50.0 ms | loops:    55.3    50.2    56.2    50.0    53.3
  threads=  8  best=  123.8 ms | loops:   143.8   131.1   130.5   127.1   123.8
  threads= 16  best=  206.9 ms | loops:   217.9   214.3   206.9   208.8   217.3
  threads= 32  best= 1581.5 ms | loops:  1717.3  1652.0  1723.7  1581.5  1731.5
  threads= 64  best= 3951.5 ms | loops:  4228.5  4197.4  3951.5  4114.0  4046.9
  threads=  1  best=   29.7 ms | loops:    48.4    33.2    30.5    29.9    29.7
  threads=  4  best=   44.2 ms | loops:    50.3    44.4    45.1    44.2    48.4
  threads=  8  best=   80.4 ms | loops:    92.4    90.2    85.3    80.4    85.5
  threads= 16  best=  141.4 ms | loops:   155.3   162.5   150.9   157.9   141.4
  threads= 32  best=  219.7 ms | loops:   238.7   243.9   246.8   219.7   220.0
  threads= 64  best=  124.4 ms | loops:   126.6   125.0   124.4   128.1   135.8
  ```
