### PR TITLE
docs(python): Direct filter users to semi joins

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -5424,8 +5424,13 @@ class DataFrame:
         False. As a result, these rows will not be retained. Ensure that null values
         are handled appropriately to avoid unexpected behaviour (see examples below).
 
+        To retain rows based on whether their values occur in another DataFrame, use
+        a semi join instead of passing the other frame to `Expr.is_in`.
+
         See Also
         --------
+        join
+            Join with another DataFrame; use `how="semi"` to filter by matching rows.
         remove
 
         Examples


### PR DESCRIPTION
## Summary

Direct users of `DataFrame.filter` toward a semi join when retaining rows based on values in another DataFrame, and add `join` to the method's See Also section.

Fixes #24466.

## Validation

- Ruff check passed for `py-polars/src/polars/dataframe/frame.py`
- Ruff formatting check passed for the changed file

## Before marking ready

- [ ] Attach the required first-contribution screenshot showing a successful local `make test` run with the terminal window borders visible.

## AI assistance

Codex, an AI agent using GPT-5, assisted with drafting the docstring changes. I confirm that I manually reviewed all changes and believe they are relevant and correct.