### PR TITLE
chore: Do not run debug tests in benchmark (release) mode

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -143,4 +143,4 @@ jobs:
         env:
           POLARS_AUTO_STREAMING: 1
           POLARS_TIMEOUT_MS: 60000
-        run: pytest -n auto -m "not may_fail_auto_streaming and not slow and not write_disk and not release and not docs and not hypothesis and not benchmark and not ci_only"
+        run: pytest -n auto -m "not may_fail_auto_streaming and not slow and not write_disk and not release and not docs and not hypothesis and not benchmark and not ci_only and not debug"


### PR DESCRIPTION
In https://github.com/pola-rs/polars/pull/28675 we enabled a bunch of tests marked with `may_fail_auto_streaming`. This uncovered some hidden failures in some tests that were marked as `debug`, when running under a release build (this is used for benchmarking).

In this PR we filter out `debug` tests in the benchmark build. There are 3 tests that pass and are now disabled, all in `test_cse.py`:
 - `test_cse_expr_selection_context`
 - `test_cse_and_schema_update_projection_pd`
 - `test_cse_series_collision_16138`

...and one that fails:
```
________________________ test_array_idx_size_limit_eval ________________________
[gw1] linux -- Python 3.14.6 /home/runner/work/polars/polars/.venv/bin/python3
tests/unit/operations/namespaces/array/test_array.py:721: in test_array_idx_size_limit_eval
    assert "IdxSize limit hit; chunking branch hit" in captured
E   AssertionError: assert 'IdxSize limit hit; chunking branch hit' in 'polars-stream: updating graph state\nupdating in-memory-sink, before: [Blocked] []\nupdating in-memory-sink, after: [...] (took 49ns)\nupdating in-memory-source, before: [] [Done]\nupdating in-memory-source, after: [] [Done] (took 94ns)\n'
```
This test was marked as `may_fail_auto_streaming` and `debug`, and now it is only `debug`. This caused it to start running in benchmark mode.
