### PR TITLE
feat(python!): Remove rechunk parameter from all read/scan functions

### DIFF
--- a/py-polars/src/polars/convert/general.py
+++ b/py-polars/src/polars/convert/general.py
@@ -470,7 +470,7 @@ def from_arrow(
     schema: SchemaDefinition | None = None,
     *,
     schema_overrides: SchemaDict | None = None,
-    rechunk: bool = True,
+    rechunk: bool = False,
 ) -> DataFrame | Series:
     """
     Create a DataFrame or Series from an Arrow Table or Array.

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -577,7 +577,6 @@ class DataFrame:
         schema: SchemaDefinition | None = None,
         *,
         schema_overrides: SchemaDict | None = None,
-        rechunk: bool = True,
     ) -> DataFrame:
         """
         Construct a DataFrame from an Arrow table.
@@ -602,15 +601,13 @@ class DataFrame:
         schema_overrides : dict, default None
             Support type specification or override of one or more columns; note that
             any dtypes inferred from the columns param will be overridden.
-        rechunk : bool, default True
-            Make sure that all data is in contiguous memory.
         """
         return cls._from_pydf(
             arrow_to_pydf(
                 data,
                 schema=schema,
                 schema_overrides=schema_overrides,
-                rechunk=rechunk,
+                rechunk=False,
             )
         )
 

--- a/py-polars/src/polars/io/csv/functions.py
+++ b/py-polars/src/polars/io/csv/functions.py
@@ -84,7 +84,6 @@ def read_csv(
     n_rows: int | None = None,
     encoding: CsvEncoding | str = "utf8",
     low_memory: bool = False,
-    rechunk: bool = False,
     skip_rows_after_header: int = 0,
     row_index_name: str | None = None,
     row_index_offset: int = 0,
@@ -198,8 +197,6 @@ def read_csv(
         characters. Defaults to "utf8".
     low_memory
         Reduce memory pressure at the expense of performance.
-    rechunk
-        Reallocate to contiguous memory when all chunks/ files are parsed.
     skip_rows_after_header
         Skip this number of rows when the header is parsed.
     row_index_name
@@ -440,7 +437,7 @@ def read_csv(
             # fetched every column; pick out the requested positions now.
             tbl = tbl.select(list(projection))
 
-        df = pl.DataFrame._from_arrow(tbl, rechunk=rechunk)
+        df = pl.DataFrame._from_arrow(tbl)
 
         if new_columns:
             return _update_columns(df, new_columns)
@@ -448,9 +445,6 @@ def read_csv(
         if row_index is not None:
             name, offset = row_index
             df = df.with_row_index(name, offset)
-
-        if rechunk:
-            df = df.rechunk()
 
         return df
 
@@ -475,7 +469,6 @@ def read_csv(
             n_rows=n_rows,
             encoding=encoding,  # type: ignore[arg-type]
             low_memory=low_memory,
-            rechunk=rechunk,
             skip_rows_after_header=skip_rows_after_header,
             try_parse_dates=try_parse_dates,
             eol_char=eol_char,
@@ -514,12 +507,7 @@ def read_csv(
         name, offset = row_index
         lf = lf.with_row_index(name, offset)
 
-    ret = lf.collect()
-
-    if rechunk:
-        ret = ret.rechunk()
-
-    return ret
+    return lf.collect()
 
 
 @deprecate_renamed_parameter("dtypes", "schema_overrides", version="0.20.31")
@@ -557,7 +545,6 @@ def scan_csv(
     n_rows: int | None = None,
     encoding: CsvEncoding = "utf8",
     low_memory: bool = False,
-    rechunk: bool = False,
     skip_rows_after_header: int = 0,
     row_index_name: str | None = None,
     row_index_offset: int = 0,
@@ -669,8 +656,6 @@ def scan_csv(
         characters. Defaults to "utf8".
     low_memory
         Reduce memory pressure at the expense of performance.
-    rechunk
-        Reallocate to contiguous memory when all chunks/ files are parsed.
     skip_rows_after_header
         Skip this number of rows when the header is parsed.
     row_index_name
@@ -906,7 +891,7 @@ def scan_csv(
         infer_schema_files=infer_schema_files,
         new_columns=new_columns,
         with_schema_modify=with_column_names,
-        rechunk=rechunk,
+        rechunk=False,
         skip_rows_after_header=skip_rows_after_header,
         encoding=encoding,
         row_index=parse_row_index_args(row_index_name, row_index_offset),

--- a/py-polars/src/polars/io/delta/_dataset.py
+++ b/py-polars/src/polars/io/delta/_dataset.py
@@ -43,8 +43,6 @@ class DeltaDataset:
     use_pyarrow: bool
     pyarrow_options: dict[str, Any] | None
 
-    rechunk: bool
-
     #
     # PythonDatasetProvider interface functions
     #
@@ -223,7 +221,6 @@ class DeltaDataset:
             extra_columns="ignore",
             storage_options=self.storage_options,
             credential_provider=self.credential_provider_builder,  # type: ignore[arg-type]
-            rechunk=self.rechunk,
             _table_statistics=table_statistics,
             _deletion_files=deletion_files,
         ), version_key

--- a/py-polars/src/polars/io/delta/functions.py
+++ b/py-polars/src/polars/io/delta/functions.py
@@ -25,7 +25,6 @@ def read_delta(
     *,
     version: int | str | datetime | None = None,
     columns: list[str] | None = None,
-    rechunk: bool | None = None,
     storage_options: StorageOptionsDict | None = None,
     credential_provider: CredentialProviderFunction | Literal["auto"] | None = "auto",
     delta_table_options: dict[str, Any] | None = None,
@@ -49,9 +48,6 @@ def read_delta(
         table is read.
     columns
         Columns to select. Accepts a list of column names.
-    rechunk
-        Make sure that all columns are contiguous in memory by
-        aggregating the chunks into a single array.
     storage_options
         Extra options for the storage backends supported by `deltalake`.
         For cloud storages, this may include configurations for authentication etc.
@@ -151,7 +147,6 @@ def read_delta(
         delta_table_options=delta_table_options,
         use_pyarrow=use_pyarrow,
         pyarrow_options=pyarrow_options,
-        rechunk=rechunk,
     )
 
     if columns is not None:
@@ -168,7 +163,6 @@ def scan_delta(
     delta_table_options: dict[str, Any] | None = None,
     use_pyarrow: bool = False,
     pyarrow_options: dict[str, Any] | None = None,
-    rechunk: bool | None = None,
 ) -> LazyFrame:
     """
     Lazily read from a Delta lake table.
@@ -207,9 +201,6 @@ def scan_delta(
         Keyword arguments while converting a Delta lake Table to pyarrow table.
         Use this parameter when filtering on partitioned columns or to read
         from a 'fsspec' supported filesystem.
-    rechunk
-        Make sure that all columns are contiguous in memory by
-        aggregating the chunks into a single array.
 
     Returns
     -------
@@ -329,7 +320,6 @@ def scan_delta(
         delta_table_options=delta_table_options,
         use_pyarrow=use_pyarrow,
         pyarrow_options=pyarrow_options,
-        rechunk=rechunk or False,
     )
 
     return wrap_ldf(PyLazyFrame.new_from_dataset_object(dataset))

--- a/py-polars/src/polars/io/ipc/functions.py
+++ b/py-polars/src/polars/io/ipc/functions.py
@@ -49,7 +49,6 @@ def read_ipc(
     storage_options: StorageOptionsDict | None = None,
     row_index_name: str | None = None,
     row_index_offset: int = 0,
-    rechunk: bool = True,
 ) -> DataFrame:
     """
     Read into a DataFrame from Arrow IPC (Feather v2) file.
@@ -86,8 +85,6 @@ def read_ipc(
     row_index_offset
         Start the row index at this offset. Cannot be negative.
         Only used if `row_index_name` is set.
-    rechunk
-        Make sure that all data is contiguous.
 
     Returns
     -------
@@ -163,7 +160,7 @@ def read_ipc(
             ) as ipc_f:
                 tbl = ipc_f.read_all()
 
-            df = pl.DataFrame._from_arrow(tbl, rechunk=rechunk)
+            df = pl.DataFrame._from_arrow(tbl)
 
             if n_rows is not None:
                 df = df.head(n_rows)
@@ -189,12 +186,7 @@ def read_ipc(
         name, offset = row_index
         lf = lf.with_row_index(name, offset)
 
-    df = lf.collect()
-
-    if rechunk:
-        df = df.rechunk()
-
-    return df
+    return lf.collect()
 
 
 @deprecate_renamed_parameter("row_count_name", "row_index_name", version="0.20.4")
@@ -208,7 +200,6 @@ def read_ipc_stream(
     storage_options: StorageOptionsDict | None = None,
     row_index_name: str | None = None,
     row_index_offset: int = 0,
-    rechunk: bool = True,
 ) -> DataFrame:
     """
     Read into a DataFrame from Arrow IPC record batch stream.
@@ -244,8 +235,6 @@ def read_ipc_stream(
     row_index_offset
         Start the row index at this offset. Cannot be negative.
         Only used if `row_index_name` is set.
-    rechunk
-        Make sure that all data is contiguous.
 
     Returns
     -------
@@ -262,7 +251,7 @@ def read_ipc_stream(
             )
             with pyarrow_ipc.RecordBatchStreamReader(data) as reader:
                 tbl = reader.read_all()
-                df = pl.DataFrame._from_arrow(tbl, rechunk=rechunk)
+                df = pl.DataFrame._from_arrow(tbl)
                 if row_index_name is not None:
                     df = df.with_row_index(row_index_name, row_index_offset)
                 if n_rows is not None:
@@ -275,7 +264,6 @@ def read_ipc_stream(
             n_rows=n_rows,
             row_index_name=row_index_name,
             row_index_offset=row_index_offset,
-            rechunk=rechunk,
         )
 
 
@@ -286,7 +274,6 @@ def _read_ipc_stream_impl(
     n_rows: int | None = None,
     row_index_name: str | None = None,
     row_index_offset: int = 0,
-    rechunk: bool = True,
 ) -> DataFrame:
     if isinstance(source, (str, Path)):
         source = normalize_filepath(source, check_not_directory=False)
@@ -300,7 +287,7 @@ def _read_ipc_stream_impl(
         projection,
         n_rows,
         parse_row_index_args(row_index_name, row_index_offset),
-        rechunk,
+        rechunk=False,
     )
     return wrap_df(pydf)
 
@@ -344,7 +331,6 @@ def scan_ipc(
     *,
     n_rows: int | None = None,
     cache: bool | None = None,
-    rechunk: bool = False,
     row_index_name: str | None = None,
     row_index_offset: int = 0,
     glob: bool = True,
@@ -381,8 +367,6 @@ def scan_ipc(
 
         .. deprecated:: 1.40.0
             File cache is no longer supported.
-    rechunk
-        Reallocate to contiguous memory when all chunks/ files are parsed.
     row_index_name
         If not None, this will insert a row index column with give name into the
         DataFrame
@@ -476,7 +460,7 @@ def scan_ipc(
             hive_partitioning=hive_partitioning,
             hive_schema=hive_schema,
             try_parse_hive_dates=try_parse_hive_dates,
-            rechunk=rechunk,
+            rechunk=False,
             cache=cache_deprecated,
             storage_options=storage_options,
             credential_provider=credential_provider_builder,

--- a/py-polars/src/polars/io/ndjson.py
+++ b/py-polars/src/polars/io/ndjson.py
@@ -42,7 +42,6 @@ def read_ndjson(
     batch_size: int | None = 1024,
     n_rows: int | None = None,
     low_memory: bool = False,
-    rechunk: bool = False,
     row_index_name: str | None = None,
     row_index_offset: int = 0,
     ignore_errors: bool = False,
@@ -84,8 +83,6 @@ def read_ndjson(
         Stop reading from JSON file after reading `n_rows`.
     low_memory
         Reduce memory pressure at the expense of performance.
-    rechunk
-        Reallocate to contiguous memory when all chunks/ files are parsed.
     row_index_name
         If not None, this will insert a row index column with give name into the
         DataFrame
@@ -175,7 +172,6 @@ def read_ndjson(
         batch_size=batch_size,
         n_rows=n_rows,
         low_memory=low_memory,
-        rechunk=rechunk,
         row_index_name=row_index_name,
         row_index_offset=row_index_offset,
         ignore_errors=ignore_errors,
@@ -208,7 +204,6 @@ def scan_ndjson(
     batch_size: int | None = 1024,
     n_rows: int | None = None,
     low_memory: bool = False,
-    rechunk: bool = False,
     row_index_name: str | None = None,
     row_index_offset: int = 0,
     ignore_errors: bool = False,
@@ -254,8 +249,6 @@ def scan_ndjson(
         Stop reading from JSON file after reading `n_rows`.
     low_memory
         Reduce memory pressure at the expense of performance.
-    rechunk
-        Reallocate to contiguous memory when all chunks/ files are parsed.
     row_index_name
         If not None, this will insert a row index column with give name into the
         DataFrame
@@ -343,7 +336,7 @@ def scan_ndjson(
         batch_size=batch_size,
         n_rows=n_rows,
         low_memory=low_memory,
-        rechunk=rechunk,
+        rechunk=False,
         row_index=parse_row_index_args(row_index_name, row_index_offset),
         ignore_errors=ignore_errors,
         include_file_paths=include_file_paths,

--- a/py-polars/src/polars/io/parquet/functions.py
+++ b/py-polars/src/polars/io/parquet/functions.py
@@ -67,7 +67,6 @@ def read_parquet(
     schema: SchemaDict | None = None,
     hive_schema: SchemaDict | None = None,
     try_parse_hive_dates: bool = True,
-    rechunk: bool = False,
     low_memory: bool = False,
     storage_options: StorageOptionsDict | None = None,
     credential_provider: CredentialProviderFunction | Literal["auto"] | None = "auto",
@@ -138,9 +137,6 @@ def read_parquet(
             at any point without it being considered a breaking change.
     try_parse_hive_dates
         Whether to try parsing hive values as date/datetime types.
-    rechunk
-        Make sure that all columns are contiguous in memory by
-        aggregating the chunks into a single array.
     low_memory
         Reduce memory pressure at the expense of performance.
     storage_options
@@ -242,7 +238,6 @@ def read_parquet(
             storage_options=storage_options,
             pyarrow_options=pyarrow_options,
             memory_map=memory_map,
-            rechunk=rechunk,
         )
 
         if row_index is not None:
@@ -281,12 +276,7 @@ def read_parquet(
         name, offset = row_index
         lf = lf.with_row_index(name, offset)
 
-    ret = lf.collect()
-
-    if rechunk:
-        ret = ret.rechunk()
-
-    return ret
+    return lf.collect()
 
 
 def _read_parquet_with_pyarrow(
@@ -303,7 +293,6 @@ def _read_parquet_with_pyarrow(
     storage_options: StorageOptionsDict | None = None,
     pyarrow_options: dict[str, Any] | None = None,
     memory_map: bool = True,
-    rechunk: bool = True,
 ) -> DataFrame:
     pyarrow_parquet = import_optional(
         "pyarrow.parquet",
@@ -347,7 +336,7 @@ def _read_parquet_with_pyarrow(
                 columns=resolved_columns,
                 **pyarrow_options,
             )
-        result = from_arrow(pa_table, rechunk=rechunk)
+        result = from_arrow(pa_table)
         results.append(result)  # type: ignore[arg-type]
 
     if len(results) == 1:
@@ -474,7 +463,6 @@ def scan_parquet(
     schema: SchemaDict | None = None,
     hive_schema: SchemaDict | None = None,
     try_parse_hive_dates: bool = True,
-    rechunk: bool = False,
     low_memory: bool = False,
     cache: bool = True,
     storage_options: StorageOptionsDict | None = None,
@@ -567,9 +555,6 @@ def scan_parquet(
             at any point without it being considered a breaking change.
     try_parse_hive_dates
         Whether to try parsing hive values as date/datetime types.
-    rechunk
-        In case of reading multiple files via a glob pattern rechunk the final DataFrame
-        into contiguous memory chunks.
     low_memory
         Reduce memory pressure at the expense of performance.
     cache
@@ -723,7 +708,7 @@ def scan_parquet(
             hive_partitioning=hive_partitioning,
             hive_schema=hive_schema,
             try_parse_hive_dates=try_parse_hive_dates,
-            rechunk=rechunk,
+            rechunk=False,
             cache=cache,
             storage_options=storage_options,
             credential_provider=credential_provider_builder,

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -43,7 +43,6 @@ def new_pl_delta_dataset(source: str | DeltaTable) -> DeltaDataset:
         delta_table_options=None,
         use_pyarrow=False,
         pyarrow_options=None,
-        rechunk=False,
     )
 
 

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -440,7 +440,7 @@ def test_read_ipc_only_loads_selected_columns(
     memory_usage_without_pyarrow.reset_tracking()
 
     # Only load one column:
-    df = read_ipc(stream, str(file_path), columns=["b"], rechunk=False)
+    df = read_ipc(stream, str(file_path), columns=["b"])
     del df
     # Only one column's worth of memory should be used; 2 columns would be
     # 32_000_000 at least, but there's some overhead.

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -143,7 +143,11 @@ def test_read_parquet_respects_rechunk_16416(
     buf.seek(0)
 
     rechunk, expected_chunks = rechunk_and_expected_chunks
-    result = pl.read_parquet(buf, use_pyarrow=use_pyarrow, rechunk=rechunk)
+    result = pl.read_parquet(buf, use_pyarrow=use_pyarrow)
+
+    if rechunk:
+        result = result.rechunk()
+
     assert result.n_chunks() == expected_chunks
 
 

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -1005,7 +1005,7 @@ def test_read_parquet_only_loads_selected_columns_15098(
     memory_usage_without_pyarrow.reset_tracking()
 
     # Only load one column:
-    df = pl.read_parquet([file_path], columns=["b"], rechunk=False)
+    df = pl.read_parquet([file_path], columns=["b"])
     del df
     # Only one column's worth of memory should be used; 2 columns would be
     # 16_000_000 at least, but there's some overhead.


### PR DESCRIPTION
Recommended instead to call `rechunk()` afterwards.
