### PR TITLE
fix(rust): Only enable DynamicPred in streaming engine

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -611,6 +611,7 @@ impl PredicatePushDown {
 
                 if let Some((offset, len, None)) = slice
                     && by_column.len() == 1
+                    && self.streaming
                 {
                     let n = by_column[0].node();
                     if let AExpr::Column(_) = expr_arena.get(n) {


### PR DESCRIPTION
The dynamic predicate is a **streaming-engine** mechanism: it is evaluated lazily as the sort produces output, so the engine can prune rows beyond the requested slice. In the in-memory/batch engine the sort is materialized in full and the dynamic predicate is neither useful nor expected, so the rewrite should not apply there.
