### PR TITLE
chore: Put numa behind feature flag

### DIFF
--- a/.github/workflows/benchmark-remote.yml
+++ b/.github/workflows/benchmark-remote.yml
@@ -65,7 +65,7 @@ jobs:
           # Make sure we use the Polars we're about to build.
           uv pip uninstall polars-runtime-32 polars-runtime-64 polars-runtime-compat
           uv pip install --no-deps -e .
-          maturin develop --manifest-path runtime/polars-runtime-32/Cargo.toml --release --uv -- -C codegen-units=4 -C lto=thin -C target-cpu=native
+          maturin develop --manifest-path runtime/polars-runtime-32/Cargo.toml --release --features numa --uv -- -C codegen-units=4 -C lto=thin -C target-cpu=native
 
       - name: Run benchmark
         working-directory: polars-benchmark

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -79,7 +79,7 @@ jobs:
           # Make sure we use the Polars we're about to build.
           uv pip uninstall polars-runtime-32 polars-runtime-64 polars-runtime-compat
           uv pip install --no-deps -e .
-          maturin build --manifest-path runtime/polars-runtime-32/Cargo.toml --profile nodebug-release -- -C codegen-units=8 -C lto=thin -C target-cpu=native
+          maturin build --manifest-path runtime/polars-runtime-32/Cargo.toml --profile nodebug-release --features numa -- -C codegen-units=8 -C lto=thin -C target-cpu=native
 
       - name: Install Polars release build
         run: |

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -345,6 +345,7 @@ jobs:
           target: ${{ matrix.target }}
           args: >
             --profile ${{ inputs.dry-run == true && 'dev' || 'dist-release' }}
+            --features numa
             --manifest-path py-polars/runtime/${{ matrix.package }}/Cargo.toml
             --out dist
           manylinux: auto

--- a/.github/workflows/test-pyodide.yml
+++ b/.github/workflows/test-pyodide.yml
@@ -53,7 +53,8 @@ jobs:
           command: build
           target: wasm32-unknown-emscripten
           args: >
-            --profile dev
             --manifest-path py-polars/runtime/polars-runtime-32/Cargo.toml
+            --profile dev
+            --features numa
             --interpreter python3.10
           maturin-version: 1.7.4

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -129,7 +129,7 @@ jobs:
           # Make sure we use the Polars we're about to build.
           uv pip uninstall polars-runtime-32 polars-runtime-64 polars-runtime-compat
           pip install --no-deps -e .
-          maturin develop --manifest-path runtime/polars-runtime-32/Cargo.toml
+          maturin develop --manifest-path runtime/polars-runtime-32/Cargo.toml --features numa
 
       - name: Run doctests
         if: github.event_name == 'pull_request' && matrix.python-version == '3.14' && matrix.os == 'ubuntu-latest' && !matrix.auto_new_streaming

--- a/crates/polars-async/Cargo.toml
+++ b/crates/polars-async/Cargo.toml
@@ -13,7 +13,7 @@ atomic-waker = { workspace = true }
 crossbeam-channel = { workspace = true }
 crossbeam-deque = { workspace = true }
 crossbeam-utils = { workspace = true }
-hwlocality-sys = { workspace = true }
+hwlocality-sys = { workspace = true, optional = true }
 parking_lot = { workspace = true }
 pin-project-lite = { workspace = true }
 rand = { workspace = true }
@@ -26,6 +26,7 @@ polars-utils = { workspace = true }
 
 [features]
 default = []
+numa = ["dep:hwlocality-sys"]
 
 [lints]
 workspace = true

--- a/crates/polars-async/src/executor/mod.rs
+++ b/crates/polars-async/src/executor/mod.rs
@@ -1,6 +1,12 @@
 #![allow(clippy::disallowed_types)]
 
+#[cfg(feature = "numa")]
 mod numa;
+
+#[cfg(not(feature = "numa"))]
+#[path = "numa/dummy.rs"]
+mod numa;
+
 mod park_group;
 mod task;
 
@@ -17,7 +23,7 @@ use std::time::{Duration, Instant};
 use crossbeam_channel::{Receiver, Sender};
 use crossbeam_deque::{Injector, Steal, Stealer, Worker as WorkQueue};
 use crossbeam_utils::CachePadded;
-use numa::{NumaRegionId, num_numa_regions};
+use numa::{NumaRegionId, cpu_idx_to_numa_region, num_numa_regions, pin_thread_to_numa_region};
 use park_group::ParkGroup;
 use parking_lot::Mutex;
 use polars_utils::relaxed_cell::RelaxedCell;
@@ -26,8 +32,6 @@ use rand::rngs::SmallRng;
 use rand::{Rng, RngExt, SeedableRng};
 use slotmap::SlotMap;
 use task::{Cancellable, DynTask, Runnable};
-
-use crate::executor::numa::{cpu_idx_to_numa_region, pin_thread_to_numa_region};
 
 thread_local! {
     pub static ALLOW_RAYON_THREADS: Cell<bool> = const { Cell::new(true) };

--- a/crates/polars-async/src/executor/numa/dummy.rs
+++ b/crates/polars-async/src/executor/numa/dummy.rs
@@ -1,0 +1,12 @@
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct NumaRegionId(pub usize);
+
+pub fn num_numa_regions() -> usize {
+    1
+}
+
+pub fn cpu_idx_to_numa_region(_cpu_idx: usize) -> NumaRegionId {
+    NumaRegionId(0)
+}
+
+pub fn pin_thread_to_numa_region(_region: NumaRegionId) {}

--- a/crates/polars-core/Cargo.toml
+++ b/crates/polars-core/Cargo.toml
@@ -71,6 +71,7 @@ proptest = ["dep:proptest", "dtype-u8", "dtype-u16", "dtype-i8", "dtype-i16", "d
 random = ["rand", "rand_distr"]
 algorithm_group_by = []
 default = ["algorithm_group_by"]
+numa = ["polars-async/numa"]
 lazy = []
 
 # ~40% faster collect, needed until trustedlength iter stabilizes

--- a/crates/polars-python/Cargo.toml
+++ b/crates/polars-python/Cargo.toml
@@ -279,6 +279,7 @@ nightly = ["polars/nightly"]
 pymethods = []
 allow_unused = []
 
+numa = ["polars/numa"]
 fast_alloc = ["polars-ooc/fast_alloc"]
 
 full_functionality = [

--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -67,6 +67,7 @@ nightly = [
   "polars-sql?/nightly",
   "polars-expr/nightly",
 ]
+numa = ["polars-core/numa"]
 docs = ["polars-core/docs"]
 temporal = [
   "polars-core/temporal",
@@ -578,7 +579,7 @@ docs-selection = [
 
 bench = ["lazy"]
 
-# All features except python
+# All features except python, nightly and numa.
 full = ["docs-selection", "performant", "fmt"]
 allow_unused = [
   "polars-lazy?/allow_unused",

--- a/py-polars/runtime/polars-runtime-32/Cargo.toml
+++ b/py-polars/runtime/polars-runtime-32/Cargo.toml
@@ -89,6 +89,7 @@ io = ["polars-python/io"]
 
 optimizations = ["polars-python/optimizations"]
 fast_alloc = ["polars-python/fast_alloc"]
+numa = ["polars-python/numa"]
 
 full_functionality = [
   "ffi_plugin",

--- a/py-polars/runtime/polars-runtime-64/Cargo.toml
+++ b/py-polars/runtime/polars-runtime-64/Cargo.toml
@@ -89,6 +89,7 @@ io = ["polars-python/io"]
 
 optimizations = ["polars-python/optimizations"]
 fast_alloc = ["polars-python/fast_alloc"]
+numa = ["polars-python/numa"]
 
 full_functionality = [
   "ffi_plugin",

--- a/py-polars/runtime/polars-runtime-compat/Cargo.toml
+++ b/py-polars/runtime/polars-runtime-compat/Cargo.toml
@@ -89,6 +89,7 @@ io = ["polars-python/io"]
 
 optimizations = ["polars-python/optimizations"]
 fast_alloc = ["polars-python/fast_alloc"]
+numa = ["polars-python/numa"]
 
 full_functionality = [
   "ffi_plugin",

--- a/py-polars/runtime/template/Cargo.template.toml
+++ b/py-polars/runtime/template/Cargo.template.toml
@@ -89,6 +89,7 @@ io = ["polars-python/io"]
 
 optimizations = ["polars-python/optimizations"]
 fast_alloc = ["polars-python/fast_alloc"]
+numa = ["polars-python/numa"]
 
 full_functionality = [
   "ffi_plugin",


### PR DESCRIPTION
`hwlocality-sys` adds extra build requirements (libtool and automake), which aren't relevant for most developer machines anyway. This PR puts the numa functionality behind a feature flag which is set for the CI and releases but not for local development with `make`.