### PR TITLE
fix: Avoid chunk fragmentation on bool agg `min` and `max`

### DIFF
--- a/crates/polars-core/src/frame/group_by/aggregations/boolean.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/boolean.rs
@@ -8,7 +8,12 @@ pub fn _agg_helper_idx_bool<F>(groups: &GroupsIdx, f: F) -> Series
 where
     F: Fn((IdxSize, &IdxVec)) -> Option<bool> + Send + Sync,
 {
-    let ca: BooleanChunked = RAYON.install(|| groups.into_par_iter().map(f).collect());
+    let ca: BooleanChunked = RAYON.install(|| {
+        let groups_len = groups.len();
+        let first = groups.first();
+        let all = groups.all();
+        collect_bool_opt_par(PlSmallStr::EMPTY, groups_len, |g| f((first[g], &all[g])))
+    });
     ca.into_series()
 }
 
@@ -16,7 +21,8 @@ pub fn _agg_helper_slice_bool<F>(groups: &[[IdxSize; 2]], f: F) -> Series
 where
     F: Fn([IdxSize; 2]) -> Option<bool> + Send + Sync,
 {
-    let ca: BooleanChunked = RAYON.install(|| groups.par_iter().copied().map(f).collect());
+    let ca: BooleanChunked =
+        RAYON.install(|| collect_bool_opt_par(PlSmallStr::EMPTY, groups.len(), |g| f(groups[g])));
     ca.into_series()
 }
 

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -3232,7 +3232,7 @@ def test_group_by_f16_agg_28353(agg: str, args: list[float]) -> None:
 @pytest.mark.parametrize("agg", ["any", "all"])
 @pytest.mark.parametrize("ignore_nulls", [True, False])
 @pytest.mark.parametrize("null_frac", [0.0, 0.3])
-def test_group_by_bool_agg_single_chunk_28684(
+def test_group_by_bool_agg_any_all_single_chunk_28684(
     agg: str, ignore_nulls: bool, null_frac: float
 ) -> None:
     # must be large enough to trigger chunk fragmentation
@@ -3251,4 +3251,30 @@ def test_group_by_bool_agg_single_chunk_28684(
     assert out["b"].n_chunks() == 1
 
     expected = df["b"] if not ignore_nulls else df["b"].fill_null(agg == "all")
+    assert_series_equal(out["b"], expected, check_names=False)
+
+
+@pytest.mark.may_fail_auto_streaming  # n_chunks is an implementation detail for in-memory
+@pytest.mark.parametrize("agg", ["min", "max"])
+@pytest.mark.parametrize("set_sorted", [False, True])
+@pytest.mark.parametrize("null_frac", [0.0, 0.3])
+def test_group_by_bool_agg_min_max_single_chunk_28684(
+    agg: str, set_sorted: bool, null_frac: float
+) -> None:
+    # must be large enough to trigger chunk fragmentation
+    n = 20_000
+    rng = np.random.default_rng(0)
+
+    vals = rng.random(n) < 0.5
+    nulls = rng.random(n) < null_frac
+    b = [None if is_null else bool(v) for v, is_null in zip(vals, nulls, strict=True)]
+    df = pl.DataFrame({"g": np.arange(n), "b": pl.Series(b, dtype=pl.Boolean)})
+
+    if set_sorted:
+        df = df.sort("b")
+
+    out = df.group_by("g", maintain_order=True).agg(getattr(pl.col("b"), agg)())
+    assert out["b"].n_chunks() == 1
+
+    expected = df["b"]
     assert_series_equal(out["b"], expected, check_names=False)


### PR DESCRIPTION
Follow-up to PR #28754.

Scope: boolean `min()` and `max()` in aggregation context will collect directly into a single chunk.