### PR TITLE
chore(python): Attribute annotations for `CredentialProviderAWS` and `CredentialProviderAzure`

### DIFF
--- a/py-polars/src/polars/io/cloud/credential_provider/_providers.py
+++ b/py-polars/src/polars/io/cloud/credential_provider/_providers.py
@@ -155,6 +155,10 @@ class CredentialProviderAWS(CachingCredentialProvider):
         at any point without it being considered a breaking change.
     """
 
+    profile_name: str | None
+    region_name: str | None
+    assume_role: AWSAssumeRoleKWArgs | None
+
     def __init__(  # noqa: D417 (TODO)
         self,
         *,
@@ -324,6 +328,11 @@ class CredentialProviderAzure(CachingCredentialProvider):
         This functionality is considered **unstable**. It may be changed
         at any point without it being considered a breaking change.
     """
+
+    account_name: str | None
+    scopes: list[str]
+    tenant_id: str | None
+    credential: Any | None
 
     def __init__(
         self,


### PR DESCRIPTION
As noted in https://github.com/pola-rs/polars/pull/27906#issuecomment-5268687053, the type coverage apparently wasn't quite at 100% yet. So this adds the remaining missing attribute annotations.

Before:

```console
$ uvx pyrefly coverage check --public-only --output-format=min-text src
 WARN src/polars/io/cloud/credential_provider/_providers.py:183:14-26: `polars.io.cloud.credential_provider._providers.CredentialProviderAWS.profile_name` is untyped [coverage-missing]
 WARN src/polars/io/cloud/credential_provider/_providers.py:184:14-25: `polars.io.cloud.credential_provider._providers.CredentialProviderAWS.region_name` is untyped [coverage-missing]
 WARN src/polars/io/cloud/credential_provider/_providers.py:185:14-25: `polars.io.cloud.credential_provider._providers.CredentialProviderAWS.assume_role` is untyped [coverage-missing]
 WARN src/polars/io/cloud/credential_provider/_providers.py:355:14-26: `polars.io.cloud.credential_provider._providers.CredentialProviderAzure.account_name` is untyped [coverage-missing]
 WARN src/polars/io/cloud/credential_provider/_providers.py:356:14-20: `polars.io.cloud.credential_provider._providers.CredentialProviderAzure.scopes` is untyped [coverage-missing]
 WARN src/polars/io/cloud/credential_provider/_providers.py:359:14-23: `polars.io.cloud.credential_provider._providers.CredentialProviderAzure.tenant_id` is untyped [coverage-missing]
 WARN src/polars/io/cloud/credential_provider/_providers.py:360:14-24: `polars.io.cloud.credential_provider._providers.CredentialProviderAzure.credential` is untyped [coverage-missing]
ERROR type coverage 99.87% (5,189 of 5,196 typable) is below the 100.00% threshold
```

After:

```console
❯ uvx pyrefly coverage check --public-only src
 INFO type coverage 100.00% (5,197 of 5,197 typable)
```

Oh and I didn't use AI for this (not even a little bit).
