### PR TITLE
feat(python): Support Iceberg snapshot properties

### DIFF
--- a/crates/polars-plan/dsl-schema-hashes.json
+++ b/crates/polars-plan/dsl-schema-hashes.json
@@ -84,7 +84,7 @@
   "IcebergPathProvider": "48246c67f808f46ea3bc370484710bd26d3fe7996c6669897a4c50421a9310a5",
   "IcebergPathProviderLayout": "d07323bbe3862bc709822f453a904a2cf33f3273624f8a157aa89bffe7870440",
   "IcebergSchema": "d254f883b2a9ebc2c0c4f2d32f40fcc951ef0e0d79d905bcec298dfcb8561e78",
-  "IcebergSinkState": "999c6e25060303d50a96d367e9f9084a78a9fc37f40a9abf92ea7a42aade89d9",
+  "IcebergSinkState": "e3c8b839e4e9acdfa874f33c154b76a8eb300e1d5d3acd05efa3674eaaa6d848",
   "IntDataTypeExpr": "cd66dcd9c44cdddd8864c0fe642e5fcef5263f6f142cce906011a0180e0fd161",
   "IntegerType": "2e73fb811a2830b8b114dfe914512bfa6031325da9ea5513875a6e49b6ab1a58",
   "InterpolationMethod": "157b72c21c66950baafe8033836c3335571d2f227dd882ba6b9c8d3e2f5928d3",

--- a/crates/polars-plan/src/dsl/options/iceberg_sink_state.rs
+++ b/crates/polars-plan/src/dsl/options/iceberg_sink_state.rs
@@ -20,6 +20,7 @@ pub struct IcebergSinkState {
 
     pub table_name: PlSmallStr,
     pub mode: IcebergCommitMode,
+    pub snapshot_properties: BTreeMap<PlSmallStr, PlSmallStr>,
     pub iceberg_storage_properties: BTreeMap<PlSmallStr, PlSmallStr>,
 
     pub sink_uuid_str: String,

--- a/py-polars/src/polars/io/iceberg/_sink.py
+++ b/py-polars/src/polars/io/iceberg/_sink.py
@@ -40,6 +40,7 @@ class IcebergSinkState:
 
     table_name: str
     mode: Literal["append", "overwrite"]
+    snapshot_properties: dict[str, str]
     iceberg_storage_properties: StorageOptionsDict
 
     sink_uuid_str: str
@@ -52,6 +53,7 @@ class IcebergSinkState:
         target: str | pyiceberg.table.Table,
         *,
         mode: Literal["append", "overwrite"] = "append",
+        snapshot_properties: dict[str, str] | None = None,
         catalog: pyiceberg.catalog.Catalog | IcebergCatalogConfig | None = None,
         storage_options: StorageOptionsDict | None = None,
     ) -> IcebergSinkState:
@@ -88,6 +90,7 @@ class IcebergSinkState:
             catalog_properties=catalog_config.properties,
             table_name=target if isinstance(target, str) else ".".join(target.name()),
             mode=mode,
+            snapshot_properties=snapshot_properties or {},
             iceberg_storage_properties=storage_options or {},
             sink_uuid_str=gen_uuid_v7().hex(),
             table_=NoPickleOption(target if not isinstance(target, str) else None),
@@ -221,7 +224,7 @@ class IcebergSinkState:
             if self.mode == "overwrite":
                 from pyiceberg.expressions import AlwaysTrue
 
-                tx.delete(AlwaysTrue())
+                tx.delete(AlwaysTrue(), snapshot_properties=self.snapshot_properties)
 
             if verbose:
                 eprint("IcebergSinkState[commit]: begin add_files")
@@ -230,6 +233,7 @@ class IcebergSinkState:
 
             tx.add_files(
                 data_file_paths,
+                snapshot_properties=self.snapshot_properties,
                 check_duplicate_files=False,
             )
 

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -3469,6 +3469,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         target: str | pyiceberg.table.Table,
         *,
         mode: Literal["append", "overwrite"],
+        snapshot_properties: dict[str, str] | None = None,
         catalog: pyiceberg.catalog.Catalog
         | polars.io.iceberg.IcebergCatalogConfig
         | None = None,
@@ -3490,6 +3491,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
             - If 'append', will add new data.
             - If 'overwrite', will replace table with new data.
+        snapshot_properties
+            Custom properties to add to the Iceberg snapshot summary.
         catalog
             PyIceberg catalog to load the table from if the provided `target`
             was a table identifier.
@@ -3509,6 +3512,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         sink_state = IcebergSinkState.new(
             target,
             mode=mode,
+            snapshot_properties=snapshot_properties,
             catalog=catalog,
             storage_options=storage_options,
         )

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -548,6 +548,46 @@ def test_sink_iceberg_all_types(tmp_path: Path) -> None:
     )
 
 
+@pytest.mark.write_disk
+def test_sink_iceberg_snapshot_properties(tmp_path: Path) -> None:
+    tbl, _ = new_iceberg_table(
+        tmp_path,
+        schema=IcebergSchema(NestedField(1, "a", LongType())),
+    )
+    snapshot_properties = {"application": "polars", "run-id": "run-123"}
+
+    def snapshot_ids() -> set[int]:
+        return {snapshot.snapshot_id for snapshot in tbl.snapshots()}
+
+    def assert_snapshot_properties(new_snapshot_ids: set[int]) -> None:
+        snapshots = [
+            snapshot
+            for snapshot in tbl.snapshots()
+            if snapshot.snapshot_id in new_snapshot_ids
+        ]
+        assert snapshots
+        for snapshot in snapshots:
+            assert snapshot.summary is not None
+            summary_properties = snapshot.summary.additional_properties
+            assert snapshot_properties.items() <= summary_properties.items()
+
+    before_append = snapshot_ids()
+    pl.LazyFrame({"a": [1, 2]}).sink_iceberg(
+        tbl,
+        mode="append",
+        snapshot_properties=snapshot_properties,
+    )
+    assert_snapshot_properties(snapshot_ids() - before_append)
+
+    before_overwrite = snapshot_ids()
+    pl.LazyFrame({"a": [3]}).sink_iceberg(
+        tbl,
+        mode="overwrite",
+        snapshot_properties=snapshot_properties,
+    )
+    assert_snapshot_properties(snapshot_ids() - before_overwrite)
+
+
 @pytest.mark.parametrize(
     ("partitioned_paths", "custom_data_path"),
     [
@@ -713,7 +753,8 @@ def test_sink_iceberg_pickle(tmp_path: Path) -> None:
     assert_frame_equal(pl.scan_iceberg(tbl).collect(), pl.DataFrame({"a": 1}))
     assert new_md_path == tbl.metadata_location
 
-    sink_state = IcebergSinkState.new(tbl)
+    snapshot_properties = {"run-id": "pickled-run"}
+    sink_state = IcebergSinkState.new(tbl, snapshot_properties=snapshot_properties)
     sink_q = sink_state.attach_sink(pl.LazyFrame({"a": 2}))
     sink_q = pickle.loads(pickle.dumps(sink_q))
     sink_q.collect()
@@ -729,6 +770,11 @@ def test_sink_iceberg_pickle(tmp_path: Path) -> None:
         pl.scan_iceberg(tbl).collect(),
         pl.DataFrame({"a": [2, 1]}),
     )
+    current_snapshot = tbl.current_snapshot()
+    assert current_snapshot is not None
+    assert current_snapshot.summary is not None
+    summary_properties = current_snapshot.summary.additional_properties
+    assert snapshot_properties.items() <= summary_properties.items()
 
     assert new_md_path == tbl.metadata_location
 


### PR DESCRIPTION
Closes #28792.

- add a `snapshot_properties` argument to `LazyFrame.sink_iceberg`
- preserve the properties through lazy-plan serialization
- apply the properties to every append and overwrite snapshot
- test append, overwrite, and pickled sink-state behavior

Tests:
- full Iceberg Python test module: 59 passed, 1 xfailed
- `make fmt`
- `make py-lint`
- targeted `polars-plan` Clippy
- DSL schema-hash verification

Generated with assistance of GPT-5.6-Sol, human reviewed.