### PR TITLE
chore(python): Enforce 100% type coverage in CI with Pyrefly

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -59,3 +59,7 @@ jobs:
       - name: Run Pyrefly
         working-directory: py-polars
         run: pyrefly check
+
+      - name: Run Pyrefly coverage check
+        working-directory: py-polars
+        run: pyrefly coverage check --public-only src


### PR DESCRIPTION
Now that the Polars Python API has 100% type coverage (see #28790), I think it would be a good idea to ensure that it stays that way. 

This adds a new step to the `type-check` job of the `lint-python workflow`, that runs `pyrefly coverage check` ([docs](https://pyrefly.org/en/docs/report/)). This will exit non-zero if public type coverage drops under 100%.

This was originally suggested by @MarcoGorelli in  https://github.com/pola-rs/polars/pull/27906#issuecomment-5267419948 .