### PR TITLE
fix: Infer Float64 schema for temporal rolling and ewm functions

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
@@ -65,8 +65,9 @@ impl IRFunctionExpr {
                 use IRRollingFunction::*;
                 match function {
                     Min | Max => mapper.with_same_dtype(),
-                    Mean | Quantile | Std => mapper.moment_dtype(),
-                    Var => mapper.var_dtype(),
+                    Mean | Quantile => mapper.moment_dtype(),
+                    Std => mapper.moment_dtype().map(temporal_to_float),
+                    Var => mapper.var_dtype().map(temporal_to_float),
                     Sum => mapper.sum_dtype(),
                     Rank => match options.fn_params {
                         Some(RollingFnParams::Rank {
@@ -109,8 +110,9 @@ impl IRFunctionExpr {
                 use IRRollingFunctionBy::*;
                 match function_by {
                     MinBy | MaxBy => mapper.with_same_dtype(),
-                    MeanBy | QuantileBy | StdBy => mapper.moment_dtype(),
-                    VarBy => mapper.var_dtype(),
+                    MeanBy | QuantileBy => mapper.moment_dtype(),
+                    StdBy => mapper.moment_dtype().map(temporal_to_float),
+                    VarBy => mapper.var_dtype().map(temporal_to_float),
                     SumBy => mapper.sum_dtype(),
                     RankBy => match options.fn_params {
                         Some(RollingFnParams::Rank {
@@ -428,17 +430,23 @@ impl IRFunctionExpr {
                 f
             }),
             #[cfg(feature = "ewma")]
-            EwmMean { .. } => mapper.map_numeric_to_float_dtype(true),
+            EwmMean { .. } => mapper
+                .map_numeric_to_float_dtype(true)
+                .map(temporal_to_float),
             #[cfg(feature = "ewma_by")]
             EwmMeanBy { .. } => mapper.map_numeric_to_float_dtype(true),
             #[cfg(feature = "ewma")]
-            EwmSum { .. } => mapper.map_numeric_to_float_dtype(true),
+            EwmSum { .. } => mapper
+                .map_numeric_to_float_dtype(true)
+                .map(temporal_to_float),
             #[cfg(feature = "ewma_by")]
             EwmSumBy { .. } => mapper.map_numeric_to_float_dtype(true),
             #[cfg(feature = "ewma")]
-            EwmStd { .. } => mapper.map_numeric_to_float_dtype(true),
+            EwmStd { .. } => mapper
+                .map_numeric_to_float_dtype(true)
+                .map(temporal_to_float),
             #[cfg(feature = "ewma")]
-            EwmVar { .. } => mapper.var_dtype(),
+            EwmVar { .. } => mapper.var_dtype().map(temporal_to_float),
             #[cfg(feature = "replace")]
             Replace => mapper.with_same_dtype(),
             #[cfg(feature = "replace")]
@@ -482,6 +490,20 @@ impl IRFunctionExpr {
             _ => false,
         }
     }
+}
+
+/// Coerce a temporal dtype to `Float64`.
+///
+/// Reductions such as `rolling_std` and `ewm_mean` compute over the physical
+/// representation of their input, so temporal input yields a plain float rather
+/// than a temporal value: there is no meaningful standard deviation *as a
+/// `Date`*. `moment_dtype` keeps the temporal type because it also serves
+/// `mean` and `median`, where that is the correct result.
+fn temporal_to_float(mut field: Field) -> Field {
+    if field.dtype().is_temporal() {
+        field.coerce(DataType::Float64);
+    }
+    field
 }
 
 pub struct FieldsMapper<'a> {

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -2449,3 +2449,43 @@ def test_rolling_rank_min_samples_28102() -> None:
     assert_series_equal(
         out, pl.Series("a", [None, None, None, 3, 3], dtype=pl.get_index_type())
     )
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [pl.Date, pl.Datetime("us"), pl.Time, pl.Duration("us")],
+)
+def test_rolling_std_schema_temporal_28564(dtype: PolarsDataType) -> None:
+    # `rolling_std` reduces over the physical representation, so temporal input
+    # produces a float rather than a temporal value.
+    lf = pl.LazyFrame({"a": pl.Series([1, 2, 3]).cast(dtype)}).select(
+        pl.col("a").rolling_std(2)
+    )
+    assert lf.collect_schema()["a"] == pl.Float64
+    assert lf.collect_schema() == lf.collect().schema
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [pl.Date, pl.Datetime("us"), pl.Time],
+)
+def test_rolling_var_schema_temporal_28564(dtype: PolarsDataType) -> None:
+    # `Duration` is excluded: `rolling_var` rejects it at plan time already.
+    lf = pl.LazyFrame({"a": pl.Series([1, 2, 3]).cast(dtype)}).select(
+        pl.col("a").rolling_var(2)
+    )
+    assert lf.collect_schema()["a"] == pl.Float64
+    assert lf.collect_schema() == lf.collect().schema
+
+
+def test_rolling_std_var_by_schema_temporal_28564() -> None:
+    lf = pl.LazyFrame(
+        {
+            "a": pl.Series([1, 2, 3]).cast(pl.Date),
+            "t": pl.Series([1, 2, 3]).cast(pl.Datetime("us")),
+        }
+    ).select(
+        std=pl.col("a").rolling_std_by("t", "2d"),
+        var=pl.col("a").rolling_var_by("t", "2d"),
+    )
+    assert lf.collect_schema() == lf.collect().schema

--- a/py-polars/tests/unit/operations/test_ewm.py
+++ b/py-polars/tests/unit/operations/test_ewm.py
@@ -366,3 +366,41 @@ def test_ewm_methods(
             ewm_var_pl = s.ewm_var(bias=bias, **pl_params).fill_nan(None)
             ewm_var_pd = pl.Series(p.ewm(**pd_params).var(bias=bias))
             assert_series_equal(ewm_var_pl, ewm_var_pd, abs_tol=1e-07)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [pl.Date, pl.Datetime("us"), pl.Time, pl.Duration("us")],
+)
+def test_ewm_mean_std_schema_temporal_28564(dtype: pl.DataType) -> None:
+    # The ewm kernels reduce over the physical representation, so temporal input
+    # produces a float rather than a temporal value.
+    lf = pl.LazyFrame({"a": pl.Series([1, 2, 3]).cast(dtype)}).select(
+        mean=pl.col("a").ewm_mean(alpha=0.5),
+        std=pl.col("a").ewm_std(alpha=0.5),
+    )
+    schema = lf.collect_schema()
+    assert schema["mean"] == pl.Float64
+    assert schema["std"] == pl.Float64
+    assert schema == lf.collect().schema
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [pl.Date, pl.Datetime("us"), pl.Time],
+)
+def test_ewm_var_schema_temporal_28564(dtype: pl.DataType) -> None:
+    # `Duration` is excluded: `ewm_var` rejects it at plan time already.
+    lf = pl.LazyFrame({"a": pl.Series([1, 2, 3]).cast(dtype)}).select(
+        pl.col("a").ewm_var(alpha=0.5)
+    )
+    assert lf.collect_schema()["a"] == pl.Float64
+    assert lf.collect_schema() == lf.collect().schema
+
+
+def test_ewm_sum_schema_temporal_28564() -> None:
+    lf = pl.LazyFrame({"a": pl.Series([1, 2, 3]).cast(pl.Date)}).select(
+        pl.col("a").ewm_sum(alpha=0.5)
+    )
+    assert lf.collect_schema()["a"] == pl.Float64
+    assert lf.collect_schema() == lf.collect().schema


### PR DESCRIPTION
rolling_std/var and EWM functions produce Float64 for temporal inputs at runtime, while collect_schema() currently preserves the temporal dtype.

Coerce temporal results to Float64 at the affected call sites rather than changing moment_dtype(), since that helper is also used by operations such as mean and median where preserving the temporal dtype is correct.

Add regression tests covering the temporal schema mismatches from #28564.
  1. I used Claude Code to reproduce to issue, to write the Rust change and the regression tests. 
  2. I confirm that I have reviewed all changes myself, wrote the commit message and this description; and ran the full test suite

<img width="972" height="611" alt="Screenshot 2026-08-12 at 22 57 27" src="https://github.com/user-attachments/assets/dbca7765-3e6b-4e74-b16d-8a090958f4ba" />
