### PR TITLE
fix: Preserve interruptible syscalls when registering the SIGINT handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3280,6 +3280,7 @@ name = "polars-error"
 version = "0.55.1"
 dependencies = [
  "avro-schema",
+ "libc",
  "object_store",
  "parking_lot",
  "polars-arrow-format",

--- a/crates/polars-error/Cargo.toml
+++ b/crates/polars-error/Cargo.toml
@@ -17,6 +17,9 @@ pyo3 = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }
 simdutf8 = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 signal-hook = "0.4"
 

--- a/crates/polars-error/src/abort.rs
+++ b/crates/polars-error/src/abort.rs
@@ -63,22 +63,35 @@ pub fn register_polars_abort_mechanism() {
 
     // WASM doesn't support signals, so we just skip installing the hook there.
     #[cfg(not(target_family = "wasm"))]
-    unsafe {
-        // SAFETY: we only do an atomic op in the signal handler, which is allowed.
-        signal_hook::low_level::register(signal_hook::consts::signal::SIGINT, move || {
-            // Set the keyboard interrupt flag, but only if there are active catchers.
-            ABORT_STATE
-                .try_update(Ordering::Release, Ordering::Relaxed, |state| {
-                    let num_catchers = state >> ABORT_CATCHERS_UNIT.trailing_zeros();
-                    if num_catchers > 0 {
-                        Some(state | ABORT_KEYBOARD_INTERRUPT_BIT)
-                    } else {
-                        None
-                    }
-                })
-                .ok();
-        })
-        .unwrap();
+    {
+        // signal-hook sets SA_RESTART; restore the original behavior if it was disabled,
+        // so that SIGINT can interrupt blocking syscalls.
+        // See #21739.
+        #[cfg(target_family = "unix")]
+        let interrupts_syscalls = sigint_interrupts_syscalls();
+
+        unsafe {
+            // SAFETY: we only do an atomic op in the signal handler, which is allowed.
+            signal_hook::low_level::register(signal_hook::consts::signal::SIGINT, move || {
+                // Set the keyboard interrupt flag, but only if there are active catchers.
+                ABORT_STATE
+                    .try_update(Ordering::Release, Ordering::Relaxed, |state| {
+                        let num_catchers = state >> ABORT_CATCHERS_UNIT.trailing_zeros();
+                        if num_catchers > 0 {
+                            Some(state | ABORT_KEYBOARD_INTERRUPT_BIT)
+                        } else {
+                            None
+                        }
+                    })
+                    .ok();
+            })
+            .unwrap();
+        }
+
+        #[cfg(target_family = "unix")]
+        if interrupts_syscalls {
+            clear_sigint_restart();
+        }
     }
 }
 
@@ -163,4 +176,28 @@ fn unregister_catcher() {
             }
         })
         .ok();
+}
+
+#[cfg(target_family = "unix")]
+fn sigint_action() -> Option<libc::sigaction> {
+    let mut action = std::mem::MaybeUninit::uninit();
+    // SAFETY: a null `act` only queries the handler; `action` is valid output storage.
+    let rc = unsafe { libc::sigaction(libc::SIGINT, std::ptr::null(), action.as_mut_ptr()) };
+    // SAFETY: a return of 0 means `sigaction` initialized `action`.
+    (rc == 0).then(|| unsafe { action.assume_init() })
+}
+
+#[cfg(target_family = "unix")]
+fn sigint_interrupts_syscalls() -> bool {
+    sigint_action().is_some_and(|action| action.sa_flags & libc::SA_RESTART == 0)
+}
+
+#[cfg(target_family = "unix")]
+fn clear_sigint_restart() {
+    let Some(mut action) = sigint_action() else {
+        return;
+    };
+    action.sa_flags &= !libc::SA_RESTART;
+    // SAFETY: `action` came from `sigaction`; both pointers are valid for this call.
+    unsafe { libc::sigaction(libc::SIGINT, &action, std::ptr::null_mut()) };
 }


### PR DESCRIPTION
Resolves #21739. Before registering the SIGINT handler, we check the current state of SA_RESTART, and if it's not already set, we disable it after running `signal_hook::low_level::register`. The maintainer of signal-hook does not want to support this feature (see discourse at https://github.com/vorner/signal-hook/issues/153), so options for resolving this are either to reimplement cross-platform signal handling here or to just do this sigaction workaround.

Copying the minimal example from https://github.com/pola-rs/polars/issues/21739#issuecomment-2842423459:

```
import polars

# you can now ctrl+c this!
input()
```

Note that originally I tried to add unit tests for this fix, but getting a unit test of signal handling behavior working consistently on high-contention CI machines proved fairly difficult, and the original KeyboardInterrupt logic is already also untested AFAICT, so I dropped these tests. Happy to try to readd them if there's interest though. 

AI usage disclosure:
I used codex to write the fix, based on the workaround discussed in https://github.com/vorner/signal-hook/issues/153. This commit message and all code comments (including the SAFETY comments) were written by me. I have manually reviewed all changes and I believe they are correct.

> First-time contributors must adhere to the following rules, or your PR(s) will be closed:
> 
> - You must post a screenshot of you successfully running the test suite (`make test`),
>   locally on your machine (not the CI). The screenshot must show your terminal window
>   borders clearly, it must not be cropped to only show text.
<img width="3035" height="1051" alt="image" src="https://github.com/user-attachments/assets/6e1bc9f6-6fdb-4846-a755-5c58206a1ab1" />