### PR TITLE
fix: Restore `monitoring` as an engine-level parameter

### DIFF
--- a/py-polars/docs/source/reference/config.rst
+++ b/py-polars/docs/source/reference/config.rst
@@ -9,6 +9,7 @@ Config options
 .. autosummary::
    :toctree: api/
 
+    Config.enable_monitoring
     Config.set_ascii_tables
     Config.set_auto_structify
     Config.set_decimal_separator

--- a/py-polars/src/polars/_utils/monitoring.py
+++ b/py-polars/src/polars/_utils/monitoring.py
@@ -1,0 +1,25 @@
+"""Shared utilities for query monitoring."""
+
+from __future__ import annotations
+
+import os
+from typing import Final
+
+MONITORING_ENV_VAR: Final[str] = "POLARS_QUERY_MONITORING"
+
+
+def monitoring_enabled_globally() -> bool:
+    return os.environ.get(MONITORING_ENV_VAR) == "1"
+
+
+def activate_monitoring() -> None:
+    """Ensure `polars_cloud` is installed and this session is authenticated."""
+    from polars._dependencies import import_optional
+
+    import_optional(
+        "polars_cloud",
+        err_prefix="query monitoring requires the",
+        install_message=(
+            "Please install using the command `pip install 'polars-cloud>=0.11.0'`."
+        ),
+    ).authenticate()

--- a/py-polars/src/polars/config.py
+++ b/py-polars/src/polars/config.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Final, Literal, TypedDict, get_args
 
 from polars._dependencies import json
 from polars._utils.deprecation import deprecated
+from polars._utils.monitoring import MONITORING_ENV_VAR, activate_monitoring
 from polars._utils.unstable import unstable
 from polars._utils.various import normalize_filepath
 from polars.lazyframe.engine import Engine
@@ -1648,6 +1649,9 @@ class Config(contextlib.ContextDecorator):
         sets the engine affinity to ``"streaming"``. Disabling it does not restore
         the previous engine affinity.
 
+        This setting is the default for engines that do not state a preference; an
+        engine constructed with an explicit ``monitoring`` argument overrides it.
+
         .. engine-support:: streaming
 
         Parameters
@@ -1666,22 +1670,12 @@ class Config(contextlib.ContextDecorator):
         ...     lf.collect()
         """
         if active:
-            try:
-                import polars_cloud as pc
-            except ImportError as e:
-                msg = (
-                    "query monitoring requires the `polars_cloud>=0.11.0` package, which could "
-                    "not be imported. Install it into this environment "
-                    f"(e.g. `pip install 'polars-cloud>=0.11.0'`). ({e})"
-                )
-                raise ModuleNotFoundError(msg) from e
+            activate_monitoring()
 
-            pc.authenticate()
-
-            os.environ["POLARS_QUERY_MONITORING"] = "1"
+            os.environ[MONITORING_ENV_VAR] = "1"
             cls.set_engine_affinity("streaming")
         else:
-            os.environ.pop("POLARS_QUERY_MONITORING", None)
+            os.environ.pop(MONITORING_ENV_VAR, None)
 
         return cls
 

--- a/py-polars/src/polars/config.py
+++ b/py-polars/src/polars/config.py
@@ -1650,9 +1650,6 @@ class Config(contextlib.ContextDecorator):
         also sets the engine affinity to ``"streaming"``. Disabling it does not
         restore the previous engine affinity.
 
-        Engines whose ``monitoring`` option is ``None`` use this setting. An explicit
-        value of ``True`` or ``False`` on an engine overrides it.
-
         .. engine-support:: in-memory, streaming
 
         Parameters

--- a/py-polars/src/polars/config.py
+++ b/py-polars/src/polars/config.py
@@ -1658,6 +1658,12 @@ class Config(contextlib.ContextDecorator):
         Examples
         --------
         >>> pl.Config.enable_monitoring()  # doctest: +SKIP
+
+        Enable monitoring temporarily with ``Config``; the previous monitoring state
+        and engine affinity are restored on exit:
+
+        >>> with pl.Config(enable_monitoring=True):  # doctest: +SKIP
+        ...     lf.collect()
         """
         if active:
             try:

--- a/py-polars/src/polars/config.py
+++ b/py-polars/src/polars/config.py
@@ -1650,7 +1650,7 @@ class Config(contextlib.ContextDecorator):
         also sets the engine affinity to ``"streaming"``. Disabling it does not
         restore the previous engine affinity.
 
-        .. engine-support:: in-memory, streaming
+        .. engine-support:: streaming
 
         Parameters
         ----------

--- a/py-polars/src/polars/config.py
+++ b/py-polars/src/polars/config.py
@@ -1645,14 +1645,15 @@ class Config(contextlib.ContextDecorator):
         - The ``polars-cloud`` package installed in this environment
           (``pip install polars-cloud``).
 
-        Monitoring is only supported by the streaming engine, so enabling it also
-        sets the engine affinity to ``"streaming"``. Disabling it does not restore
-        the previous engine affinity.
+        Monitoring is supported by the in-memory and streaming engines, but only
+        the streaming engine collects per-node metrics. Enabling monitoring therefore
+        also sets the engine affinity to ``"streaming"``. Disabling it does not
+        restore the previous engine affinity.
 
-        This setting is the default for engines that do not state a preference; an
-        engine constructed with an explicit ``monitoring`` argument overrides it.
+        Engines whose ``monitoring`` option is ``None`` use this setting. An explicit
+        value of ``True`` or ``False`` on an engine overrides it.
 
-        .. engine-support:: streaming
+        .. engine-support:: in-memory, streaming
 
         Parameters
         ----------

--- a/py-polars/src/polars/lazyframe/engine.py
+++ b/py-polars/src/polars/lazyframe/engine.py
@@ -332,9 +332,9 @@ class _LocalEngine(Engine):
 
     _name: ClassVar[str]
 
-    # Subclasses that do not call `super().__init__()` will still see the default value
+    # Subclasses that do not call `super().__init__()` still see the default value.
     monitoring: bool | None = None
-    """Whether queries run by this engine are monitored (`None` follows `Config`)."""
+    """Whether queries are monitored (``None`` uses the configured default)."""
 
     def __init__(self, *, monitoring: bool | None = None) -> None:
         if monitoring:
@@ -353,7 +353,7 @@ class _LocalEngine(Engine):
         return self._name
 
     def _with_monitoring(self, optimizations: QueryOptFlags) -> QueryOptFlags:
-        """Register the query observer, and flag `optimizations` accordingly."""
+        """Register the query observer when enabled and update `optimizations`."""
         from polars._utils.monitoring import monitoring_enabled_globally
 
         monitor = (
@@ -852,12 +852,9 @@ class InMemoryEngine(_LocalEngine):
     Parameters
     ----------
     monitoring : bool, default None
-        Whether queries run by this engine are monitored. Overrides
-        :meth:`Config.enable_monitoring`, which `None` follows.
-        Requires the `polars-cloud` package.
-
-        Only the streaming engine collects per-node metrics; this engine reports
-        the query plan and its overall duration.
+        Whether to monitor queries run by this engine. ``None`` uses the setting from
+        :meth:`Config.enable_monitoring`; ``True`` or ``False`` overrides it. Setting
+        this to ``True`` requires the ``polars-cloud`` package.
     """
 
     _name = "in-memory"
@@ -870,9 +867,9 @@ class StreamingEngine(_LocalEngine):
     Parameters
     ----------
     monitoring : bool, default None
-        Whether queries run by this engine are monitored. Overrides
-        :meth:`Config.enable_monitoring`, which `None` follows.
-        Requires the `polars-cloud` package.
+        Whether to monitor queries run by this engine. ``None`` uses the setting from
+        :meth:`Config.enable_monitoring`; ``True`` or ``False`` overrides it. Setting
+        this to ``True`` requires the ``polars-cloud`` package.
 
     Examples
     --------
@@ -911,9 +908,6 @@ class GPUEngine(_LocalEngine):
         Whether queries run by this engine are monitored. Overrides
         :meth:`Config.enable_monitoring`, which `None` follows.
         Requires the `polars-cloud` package.
-
-        Only the streaming engine collects per-node metrics; this engine reports
-        the query plan and its overall duration.
 
     """
 

--- a/py-polars/src/polars/lazyframe/engine.py
+++ b/py-polars/src/polars/lazyframe/engine.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import io
-import os
 from abc import ABC, abstractmethod
 from functools import partial
 from pathlib import Path
@@ -62,19 +61,6 @@ def _to_sink_target(
     else:
         msg = f"`path` argument has invalid type {qualified_type_name(path)!r}, and cannot be turned into a sink target"
         raise TypeError(msg)
-
-
-def _with_monitoring(optimizations: QueryOptFlags) -> QueryOptFlags:
-    """Register the query observer, and flag `optimizations` accordingly."""
-    monitor = os.environ.get("POLARS_QUERY_MONITORING") == "1"
-    if monitor:
-        import polars._plr as plr
-
-        plr.set_query_monitoring(True)
-
-    optimizations = optimizations.__copy__()
-    optimizations._pyoptflags.query_monitoring = monitor
-    return optimizations
 
 
 def _apply_retries_deprecation(
@@ -346,10 +332,43 @@ class _LocalEngine(Engine):
 
     _name: ClassVar[str]
 
+    # Subclasses that do not call `super().__init__()` will still see the default value
+    monitoring: bool | None = None
+    """Whether queries run by this engine are monitored (`None` follows `Config`)."""
+
+    def __init__(self, *, monitoring: bool | None = None) -> None:
+        if monitoring:
+            from polars._utils.monitoring import activate_monitoring
+
+            activate_monitoring()
+        self.monitoring = monitoring
+
+    def __repr__(self) -> str:
+        args = "" if self.monitoring is None else f"monitoring={self.monitoring!r}"
+        return f"{type(self).__name__}({args})"
+
     @property
     def name(self) -> str:
         """Name of the engine."""
         return self._name
+
+    def _with_monitoring(self, optimizations: QueryOptFlags) -> QueryOptFlags:
+        """Register the query observer, and flag `optimizations` accordingly."""
+        from polars._utils.monitoring import monitoring_enabled_globally
+
+        monitor = (
+            monitoring_enabled_globally()
+            if self.monitoring is None
+            else self.monitoring
+        )
+        if monitor:
+            import polars._plr as plr
+
+            plr.set_query_monitoring(True)
+
+        optimizations = optimizations.__copy__()
+        optimizations._pyoptflags.query_monitoring = monitor
+        return optimizations
 
     def execute(self, lf: LazyFrame, *, optimizations: QueryOptFlags) -> QueryResult:
         df = self.collect(lf, optimizations=optimizations)
@@ -404,7 +423,7 @@ class _LocalEngine(Engine):
         callback = self._post_opt_callback(
             background=background, eager=optimizations._pyoptflags.eager
         )
-        optimizations = _with_monitoring(optimizations)
+        optimizations = self._with_monitoring(optimizations)
 
         ldf = lf._ldf.with_optimizations(optimizations._pyoptflags)
         if background:
@@ -425,6 +444,7 @@ class _LocalEngine(Engine):
         if self.name == "streaming":
             issue_unstable_warning("streaming mode is considered unstable.")
 
+        optimizations = self._with_monitoring(optimizations)
         ldf = lf._ldf.with_optimizations(optimizations._pyoptflags)
         result: AsyncResult[DataFrame] = (
             _GeventDataFrameResult() if gevent else _AioDataFrameResult()
@@ -441,6 +461,7 @@ class _LocalEngine(Engine):
         chunk_size: int | None = None,
         lazy: bool = False,
     ) -> Iterator[DataFrame]:
+        optimizations = self._with_monitoring(optimizations)
         ldf = lf._ldf.with_optimizations(optimizations._pyoptflags)
         return _CollectBatches(
             ldf.collect_batches(
@@ -456,6 +477,7 @@ class _LocalEngine(Engine):
     ) -> list[DataFrame]:
         import polars._plr as plr
 
+        optimizations = self._with_monitoring(optimizations)
         out = plr.collect_all(
             [lf._ldf for lf in lfs], self.name, optimizations._pyoptflags
         )
@@ -470,6 +492,7 @@ class _LocalEngine(Engine):
     ) -> AsyncResult[list[DataFrame]]:
         import polars._plr as plr
 
+        optimizations = self._with_monitoring(optimizations)
         result: AsyncResult[list[DataFrame]] = (
             _GeventDataFrameResult() if gevent else _AioDataFrameResult()
         )
@@ -823,13 +846,40 @@ class _AutoEngine(_LocalEngine):
 
 
 class InMemoryEngine(_LocalEngine):
-    """The in-memory engine."""
+    """
+    The in-memory engine.
+
+    Parameters
+    ----------
+    monitoring : bool, default None
+        Whether queries run by this engine are monitored. Overrides
+        :meth:`Config.enable_monitoring`, which `None` follows.
+        Requires the `polars-cloud` package.
+
+        Only the streaming engine collects per-node metrics; this engine reports
+        the query plan and its overall duration.
+    """
 
     _name = "in-memory"
 
 
 class StreamingEngine(_LocalEngine):
-    """The streaming engine."""
+    """
+    The streaming engine.
+
+    Parameters
+    ----------
+    monitoring : bool, default None
+        Whether queries run by this engine are monitored. Overrides
+        :meth:`Config.enable_monitoring`, which `None` follows.
+        Requires the `polars-cloud` package.
+
+    Examples
+    --------
+    Monitor a single query, regardless of the configured default:
+
+    >>> lf.collect(engine=pl.StreamingEngine(monitoring=True))  # doctest: +SKIP
+    """
 
     _name = "streaming"
 
@@ -857,6 +907,13 @@ class GPUEngine(_LocalEngine):
     raise_on_fail : bool, default False
         If True, do not fall back to the Polars CPU engine if the GPU
         engine cannot execute the query, but instead raise an error.
+    monitoring : bool, default None
+        Whether queries run by this engine are monitored. Overrides
+        :meth:`Config.enable_monitoring`, which `None` follows.
+        Requires the `polars-cloud` package.
+
+        Only the streaming engine collects per-node metrics; this engine reports
+        the query plan and its overall duration.
 
     """
 
@@ -880,8 +937,10 @@ class GPUEngine(_LocalEngine):
         device: int | None = None,
         memory_resource: Any | None = None,
         raise_on_fail: bool = False,
+        monitoring: bool | None = None,
         **kwargs: Any,
     ) -> None:
+        super().__init__(monitoring=monitoring)
         self.device = device
         self.memory_resource = memory_resource
         # Avoids need for changes in cudf-polars

--- a/py-polars/src/polars/lazyframe/engine.py
+++ b/py-polars/src/polars/lazyframe/engine.py
@@ -930,7 +930,8 @@ class GPUEngine(_LocalEngine):
         monitoring: bool = False,
         **kwargs: Any,
     ) -> None:
-        # We do want a named param for `monitoring`, because otherwise it will silently end up in `kwargs`
+        # We do want a named param for `monitoring`, because otherwise it will silently
+        # end up in `kwargs`
         if monitoring:
             msg = "query monitoring is not supported by the GPU engine"
             raise NotImplementedError(msg)

--- a/py-polars/src/polars/lazyframe/engine.py
+++ b/py-polars/src/polars/lazyframe/engine.py
@@ -904,10 +904,6 @@ class GPUEngine(_LocalEngine):
     raise_on_fail : bool, default False
         If True, do not fall back to the Polars CPU engine if the GPU
         engine cannot execute the query, but instead raise an error.
-    monitoring : bool, default None
-        Whether queries run by this engine are monitored. Overrides
-        :meth:`Config.enable_monitoring`, which `None` follows.
-        Requires the `polars-cloud` package.
 
     """
 
@@ -931,10 +927,15 @@ class GPUEngine(_LocalEngine):
         device: int | None = None,
         memory_resource: Any | None = None,
         raise_on_fail: bool = False,
-        monitoring: bool | None = None,
+        monitoring: bool = False,
         **kwargs: Any,
     ) -> None:
-        super().__init__(monitoring=monitoring)
+        # We do want a named param for `monitoring`, because otherwise it will silently end up in `kwargs`
+        if monitoring:
+            msg = "query monitoring is not supported by the GPU engine"
+            raise NotImplementedError(msg)
+        super().__init__(monitoring=False)
+
         self.device = device
         self.memory_resource = memory_resource
         # Avoids need for changes in cudf-polars

--- a/py-polars/tests/unit/lazyframe/test_engine.py
+++ b/py-polars/tests/unit/lazyframe/test_engine.py
@@ -176,6 +176,7 @@ def test_gpu_engine_construction_unchanged() -> None:
     engine = pl.GPUEngine(raise_on_fail=True)
     assert engine.config == {"raise_on_fail": True}
     assert engine.name == "gpu"
+    assert engine.monitoring is False
 
     engine = pl.GPUEngine(monitoring=False)
     assert engine.config == {"raise_on_fail": False}

--- a/py-polars/tests/unit/lazyframe/test_engine.py
+++ b/py-polars/tests/unit/lazyframe/test_engine.py
@@ -194,7 +194,7 @@ def test_gpu_engine_stays_hashable_and_picklable() -> None:
 
 
 def test_named_engines_are_unmonitored_singletons() -> None:
-    # named engines resolve to shared instances, so nothing may mutate `monitoring`
+    # Named engines resolve to shared instances, so nothing may mutate `monitoring`.
     for name in ("streaming", "in-memory"):
         selected = _select_engine(name)  # type: ignore[arg-type]
         assert isinstance(selected, _LocalEngine)

--- a/py-polars/tests/unit/lazyframe/test_engine.py
+++ b/py-polars/tests/unit/lazyframe/test_engine.py
@@ -177,12 +177,29 @@ def test_gpu_engine_construction_unchanged() -> None:
     assert engine.config == {"raise_on_fail": True}
     assert engine.name == "gpu"
 
+    engine = pl.GPUEngine(monitoring=False)
+    assert engine.config == {"raise_on_fail": False}
+    assert engine.monitoring is False
+
 
 def test_gpu_engine_stays_hashable_and_picklable() -> None:
     # Defining `__eq__` on `Engine` without `__hash__` would break both.
     engine = pl.GPUEngine(device=1)
     assert hash(engine) is not None
     assert pickle.loads(pickle.dumps(engine)).config == engine.config
+
+    assert (
+        pickle.loads(pickle.dumps(pl.GPUEngine(monitoring=False))).monitoring is False
+    )
+
+
+def test_named_engines_are_unmonitored_singletons() -> None:
+    # named engines resolve to shared instances, so nothing may mutate `monitoring`
+    for name in ("streaming", "in-memory"):
+        selected = _select_engine(name)  # type: ignore[arg-type]
+        assert isinstance(selected, _LocalEngine)
+        assert selected.monitoring is None
+        assert _select_engine(name) is selected  # type: ignore[arg-type]
 
 
 class _CountingEngine(pl.Engine):

--- a/py-polars/tests/unit/lazyframe/test_engine.py
+++ b/py-polars/tests/unit/lazyframe/test_engine.py
@@ -189,10 +189,6 @@ def test_gpu_engine_stays_hashable_and_picklable() -> None:
     assert hash(engine) is not None
     assert pickle.loads(pickle.dumps(engine)).config == engine.config
 
-    assert (
-        pickle.loads(pickle.dumps(pl.GPUEngine(monitoring=False))).monitoring is False
-    )
-
 
 def test_named_engines_are_unmonitored_singletons() -> None:
     # Named engines resolve to shared instances, so nothing may mutate `monitoring`.

--- a/py-polars/tests/unit/lazyframe/test_query_monitoring.py
+++ b/py-polars/tests/unit/lazyframe/test_query_monitoring.py
@@ -43,15 +43,26 @@ def _sample_lf() -> pl.LazyFrame:
 
 
 def test_config_enable_monitoring() -> None:
-    module, _observer = fake_cloud_observer()
+    module, observer = fake_cloud_observer()
     with mock_module_import("polars_cloud", module, replace_if_exists=True):
+        assert "POLARS_ENGINE_AFFINITY" not in os.environ
+
         pl.Config.enable_monitoring()
         module.authenticate.assert_called_once()
         assert os.environ["POLARS_QUERY_MONITORING"] == "1"
         assert os.environ["POLARS_ENGINE_AFFINITY"] == "streaming"
 
+        # no engine argument: monitoring switches the affinity to streaming
+        _sample_lf().collect()
+        _sample_lf().collect()
+        assert observer.on_query_started.call_count == 2
+
+        # disabling stops monitoring; the affinity is left as it is
         pl.Config.enable_monitoring(False)
         assert "POLARS_QUERY_MONITORING" not in os.environ
+        _sample_lf().collect()
+
+    assert observer.on_query_started.call_count == 2
 
 
 def test_collect_calls_observer() -> None:
@@ -71,18 +82,6 @@ def test_collect_calls_observer() -> None:
     planned_id = observer.on_query_planned.call_args.args[0]
     assert isinstance(started_id, uuid.UUID)
     assert started_id == planned_id
-
-
-def test_config_enable_monitoring_globally() -> None:
-    """A bare `Config.enable_monitoring()` monitors every subsequent query."""
-    module, observer = fake_cloud_observer()
-    with mock_module_import("polars_cloud", module, replace_if_exists=True):
-        pl.Config.enable_monitoring()
-        # no engine argument: monitoring switches the affinity to streaming
-        _sample_lf().collect()
-        _sample_lf().collect()
-
-    assert observer.on_query_started.call_count == 2
 
 
 def test_config_scope_monitoring() -> None:

--- a/py-polars/tests/unit/lazyframe/test_query_monitoring.py
+++ b/py-polars/tests/unit/lazyframe/test_query_monitoring.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import os
+import sys
+import tempfile
 import uuid
+from pathlib import Path
 from types import ModuleType
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
@@ -14,7 +18,7 @@ from polars.lazyframe.engine import StreamingEngine
 from tests.unit.conftest import mock_module_import
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
 
 
 def fake_cloud_observer() -> tuple[ModuleType, MagicMock]:
@@ -114,13 +118,124 @@ def test_engine_object_follows_config() -> None:
 
 
 def test_engine_object_without_config_is_not_monitored() -> None:
-    """An engine object cannot enable monitoring on its own."""
+    """An engine with `monitoring=None` follows the Config; here it is off."""
     module, observer = fake_cloud_observer()
     with mock_module_import("polars_cloud", module, replace_if_exists=True):
         _sample_lf().collect(engine=StreamingEngine())
 
     module.QueryCloudObserver.assert_not_called()
     observer.on_query_started.assert_not_called()
+
+
+def test_engine_monitoring_overrides_config_off() -> None:
+    """`monitoring=True` monitors the query without the Config being enabled."""
+    module, observer = fake_cloud_observer()
+    with mock_module_import("polars_cloud", module, replace_if_exists=True):
+        engine = StreamingEngine(monitoring=True)
+        module.authenticate.assert_called_once()
+
+        _sample_lf().collect(engine=engine)
+
+    observer.on_query_started.assert_called_once()
+    # the engine must not touch global state
+    assert "POLARS_QUERY_MONITORING" not in os.environ
+
+
+def test_engine_monitoring_overrides_config_on() -> None:
+    """`monitoring=False` exempts the query while the Config is enabled."""
+    module, observer = fake_cloud_observer()
+    with mock_module_import("polars_cloud", module, replace_if_exists=True):
+        pl.Config.enable_monitoring()
+        _sample_lf().collect(engine=StreamingEngine(monitoring=False))
+
+    # the observer is registered by the Config, but never invoked for this query
+    observer.on_query_started.assert_not_called()
+
+
+def test_engine_monitoring_requires_polars_cloud(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(sys.modules, "polars_cloud", None)
+    with pytest.raises(ModuleNotFoundError, match="polars_cloud"):
+        StreamingEngine(monitoring=True)
+
+
+def test_in_memory_engine_monitoring() -> None:
+    module, observer = fake_cloud_observer()
+    with mock_module_import("polars_cloud", module, replace_if_exists=True):
+        _sample_lf().collect(engine=pl.InMemoryEngine(monitoring=True))
+
+    observer.on_query_started.assert_called_once()
+    observer.on_query_planned.assert_called_once()
+
+
+def test_engine_affinity_object_carries_monitoring() -> None:
+    """A configured engine object monitors every query in its scope."""
+    module, observer = fake_cloud_observer()
+    with mock_module_import("polars_cloud", module, replace_if_exists=True):
+        with pl.Config(engine_affinity=StreamingEngine(monitoring=True)):
+            _sample_lf().collect()
+        observer.on_query_started.assert_called_once()
+
+        # leaving the scope restores the unmonitored affinity
+        _sample_lf().collect()
+
+    observer.on_query_started.assert_called_once()
+    assert "POLARS_QUERY_MONITORING" not in os.environ
+
+
+def _run_collect(lf: pl.LazyFrame, engine: StreamingEngine) -> None:
+    lf.collect(engine=engine)
+
+
+def _run_collect_all(lf: pl.LazyFrame, engine: StreamingEngine) -> None:
+    pl.collect_all([lf], engine=engine)
+
+
+def _run_collect_batches(lf: pl.LazyFrame, engine: StreamingEngine) -> None:
+    list(lf.collect_batches(engine=engine))
+
+
+def _run_collect_async(lf: pl.LazyFrame, engine: StreamingEngine) -> None:
+    async def run() -> None:
+        await lf.collect_async(engine=engine)
+
+    asyncio.run(run())
+
+
+def _run_collect_all_async(lf: pl.LazyFrame, engine: StreamingEngine) -> None:
+    async def run() -> None:
+        await pl.collect_all_async([lf], engine=engine)
+
+    asyncio.run(run())
+
+
+def _run_sink(lf: pl.LazyFrame, engine: StreamingEngine) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        lf.sink_parquet(Path(tmp) / "out.parquet", engine=engine)
+
+
+@pytest.mark.parametrize(
+    "run",
+    [
+        _run_collect,
+        _run_collect_all,
+        _run_collect_batches,
+        _run_collect_async,
+        _run_collect_all_async,
+        _run_sink,
+    ],
+)
+def test_monitoring_covers_local_execution_paths(
+    run: Callable[[pl.LazyFrame, StreamingEngine], None],
+) -> None:
+    """Every way of executing a query locally reports to the observer."""
+    module, observer = fake_cloud_observer()
+    with mock_module_import("polars_cloud", module, replace_if_exists=True):
+        run(_sample_lf(), StreamingEngine(monitoring=True))
+
+    observer.on_query_started.assert_called_once()
+    observer.on_query_planned.assert_called_once()
 
 
 def test_planned_payload_decodes() -> None:

--- a/py-polars/tests/unit/lazyframe/test_query_monitoring.py
+++ b/py-polars/tests/unit/lazyframe/test_query_monitoring.py
@@ -14,6 +14,7 @@ import pytest
 
 import polars as pl
 import polars._plr as plr
+from polars._utils.monitoring import MONITORING_ENV_VAR
 from polars.lazyframe.engine import StreamingEngine
 from tests.unit.conftest import mock_module_import
 
@@ -53,7 +54,7 @@ def test_config_enable_monitoring() -> None:
 
         pl.Config.enable_monitoring()
         module.authenticate.assert_called_once()
-        assert os.environ["POLARS_QUERY_MONITORING"] == "1"
+        assert os.environ[MONITORING_ENV_VAR] == "1"
         assert os.environ["POLARS_ENGINE_AFFINITY"] == "streaming"
 
         # no engine argument: monitoring switches the affinity to streaming
@@ -63,7 +64,7 @@ def test_config_enable_monitoring() -> None:
 
         # disabling stops monitoring; the affinity is left as it is
         pl.Config.enable_monitoring(False)
-        assert "POLARS_QUERY_MONITORING" not in os.environ
+        assert MONITORING_ENV_VAR not in os.environ
         _sample_lf().collect()
 
     assert observer.on_query_started.call_count == 2
@@ -94,7 +95,7 @@ def test_config_scope_monitoring() -> None:
         assert "POLARS_ENGINE_AFFINITY" not in os.environ
 
         with pl.Config(enable_monitoring=True):
-            assert os.environ["POLARS_QUERY_MONITORING"] == "1"
+            assert os.environ[MONITORING_ENV_VAR] == "1"
             assert os.environ["POLARS_ENGINE_AFFINITY"] == "streaming"
             _sample_lf().collect()
         observer.on_query_started.assert_called_once()
@@ -102,7 +103,7 @@ def test_config_scope_monitoring() -> None:
         # leaving the scope stops monitoring
         _sample_lf().collect()
 
-        assert "POLARS_QUERY_MONITORING" not in os.environ
+        assert MONITORING_ENV_VAR not in os.environ
         assert "POLARS_ENGINE_AFFINITY" not in os.environ
 
     observer.on_query_started.assert_called_once()
@@ -138,7 +139,7 @@ def test_engine_monitoring_overrides_config_off() -> None:
 
     observer.on_query_started.assert_called_once()
     # The engine override must not modify the environment-backed Config setting.
-    assert "POLARS_QUERY_MONITORING" not in os.environ
+    assert MONITORING_ENV_VAR not in os.environ
 
 
 def test_engine_monitoring_overrides_config_on() -> None:
@@ -182,7 +183,7 @@ def test_engine_affinity_object_carries_monitoring() -> None:
         _sample_lf().collect()
 
     observer.on_query_started.assert_called_once()
-    assert "POLARS_QUERY_MONITORING" not in os.environ
+    assert MONITORING_ENV_VAR not in os.environ
 
 
 def _run_collect(lf: pl.LazyFrame, engine: StreamingEngine) -> None:

--- a/py-polars/tests/unit/lazyframe/test_query_monitoring.py
+++ b/py-polars/tests/unit/lazyframe/test_query_monitoring.py
@@ -137,7 +137,7 @@ def test_engine_monitoring_overrides_config_off() -> None:
         _sample_lf().collect(engine=engine)
 
     observer.on_query_started.assert_called_once()
-    # the engine must not touch global state
+    # The engine override must not modify the environment-backed Config setting.
     assert "POLARS_QUERY_MONITORING" not in os.environ
 
 
@@ -148,7 +148,7 @@ def test_engine_monitoring_overrides_config_on() -> None:
         pl.Config.enable_monitoring()
         _sample_lf().collect(engine=StreamingEngine(monitoring=False))
 
-    # the observer is registered by the Config, but never invoked for this query
+    # The explicit engine setting prevents observer construction for this query.
     observer.on_query_started.assert_not_called()
 
 
@@ -177,7 +177,7 @@ def test_engine_affinity_object_carries_monitoring() -> None:
             _sample_lf().collect()
         observer.on_query_started.assert_called_once()
 
-        # leaving the scope restores the unmonitored affinity
+        # Leaving the scope restores the unmonitored affinity.
         _sample_lf().collect()
 
     observer.on_query_started.assert_called_once()
@@ -229,7 +229,7 @@ def _run_sink(lf: pl.LazyFrame, engine: StreamingEngine) -> None:
 def test_monitoring_covers_local_execution_paths(
     run: Callable[[pl.LazyFrame, StreamingEngine], None],
 ) -> None:
-    """Every way of executing a query locally reports to the observer."""
+    """The primary local collection and sink paths report to the observer."""
     module, observer = fake_cloud_observer()
     with mock_module_import("polars_cloud", module, replace_if_exists=True):
         run(_sample_lf(), StreamingEngine(monitoring=True))

--- a/py-polars/tests/unit/lazyframe/test_query_monitoring.py
+++ b/py-polars/tests/unit/lazyframe/test_query_monitoring.py
@@ -160,6 +160,7 @@ def test_engine_monitoring_requires_polars_cloud(
         StreamingEngine(monitoring=True)
 
 
+@pytest.mark.may_fail_auto_streaming
 def test_in_memory_engine_monitoring() -> None:
     module, observer = fake_cloud_observer()
     with mock_module_import("polars_cloud", module, replace_if_exists=True):
@@ -304,6 +305,7 @@ def test_no_monitoring_no_observer() -> None:
     module.QueryCloudObserver.assert_not_called()
 
 
+@pytest.mark.may_fail_auto_streaming
 def test_in_memory_engine_planned_without_physical() -> None:
     """The in-memory engine is observed with an IR-only planned query.
 

--- a/py-polars/tests/unit/lazyframe/test_query_monitoring.py
+++ b/py-polars/tests/unit/lazyframe/test_query_monitoring.py
@@ -73,6 +73,38 @@ def test_collect_calls_observer() -> None:
     assert started_id == planned_id
 
 
+def test_config_enable_monitoring_globally() -> None:
+    """A bare `Config.enable_monitoring()` monitors every subsequent query."""
+    module, observer = fake_cloud_observer()
+    with mock_module_import("polars_cloud", module, replace_if_exists=True):
+        pl.Config.enable_monitoring()
+        # no engine argument: monitoring switches the affinity to streaming
+        _sample_lf().collect()
+        _sample_lf().collect()
+
+    assert observer.on_query_started.call_count == 2
+
+
+def test_config_scope_monitoring() -> None:
+    module, observer = fake_cloud_observer()
+    with mock_module_import("polars_cloud", module, replace_if_exists=True):
+        assert "POLARS_ENGINE_AFFINITY" not in os.environ
+
+        with pl.Config(enable_monitoring=True):
+            assert os.environ["POLARS_QUERY_MONITORING"] == "1"
+            assert os.environ["POLARS_ENGINE_AFFINITY"] == "streaming"
+            _sample_lf().collect()
+        observer.on_query_started.assert_called_once()
+
+        # leaving the scope stops monitoring
+        _sample_lf().collect()
+
+        assert "POLARS_QUERY_MONITORING" not in os.environ
+        assert "POLARS_ENGINE_AFFINITY" not in os.environ
+
+    observer.on_query_started.assert_called_once()
+
+
 def test_engine_object_follows_config() -> None:
     module, observer = fake_cloud_observer()
     with mock_module_import("polars_cloud", module, replace_if_exists=True):


### PR DESCRIPTION
This was originally introduced in https://github.com/pola-rs/polars/pull/28757, and in https://github.com/pola-rs/polars/pull/28800 we made it a config-only option.

In this PR we restore the engine option, giving us 4 ways to control whether a query is monitored.
```python
# 1. globally, for every query from here on
pl.Config.enable_monitoring()
lf.collect()

# 2. scoped to a block
with pl.Config(enable_monitoring=True):
    lf.collect()

# 3. per query, overriding whatever the config says
lf.collect(engine=pl.StreamingEngine(monitoring=True))   # monitor just this one
lf.collect(engine=pl.StreamingEngine(monitoring=False))  # ... or exempt just this one

# a configured engine can also become the default for a scope
with pl.Config(engine_affinity=pl.StreamingEngine(monitoring=True)):
    lf.collect()
```

Engine support:
 - `StreamingEngine` - full support
 - `InMemoryEngine` - no node-level monitoring
 - `GPUEngine` - currently not supported, missing Rust-side support
 - `RemoteEngine` - enabled by default, not configurable.

🤖 AI Policy - contains a bunch of tests to validate that all combinations of config do what we expect