### PR TITLE
perf: Collect primitive group-by aggregations into single chunk

### DIFF
--- a/crates/polars-core/src/chunked_array/from_iterator_par.rs
+++ b/crates/polars-core/src/chunked_array/from_iterator_par.rs
@@ -1,12 +1,26 @@
-//! Implementations of upstream traits for [`ChunkedArray<T>`]
+//! Parallel iterator collection into [`ChunkedArray<T>`]
+//!
+//! Two strategies:
+//!
+//! - `collect_into_linked_list*` — for iterators of unknown length. Folds into
+//!   one accumulator per rayon task and concatenates, so the resulting chunk
+//!   count equals the task count and varies with thread count and stealing.
+//!   `optional_rechunk` is the only backstop.
+//!
+//! - `collect_*_par` — for callers with O(1) random access and a known output
+//!   length. Writes into a single preallocated buffer, so the result is always
+//!   one chunk regardless of how rayon split the work. Preferable.
+
 use std::collections::LinkedList;
 use std::sync::Mutex;
 
+use arrow::bitmap::Bitmap;
 use arrow::pushable::{NoOption, Pushable};
 use rayon::prelude::*;
 
 use super::from_iterator::PolarsAsRef;
 use crate::chunked_array::builder::get_list_builder;
+use crate::datatypes::BooleanChunked;
 use crate::prelude::*;
 use crate::utils::NoNull;
 use crate::utils::flatten::flatten_par;
@@ -318,4 +332,105 @@ where
             None => Ok(collection),
         }
     }
+}
+
+// Collect directly into a single chunk. For directly addressable fixed-size types only.
+pub(crate) fn collect_bool_par<F>(len: usize, f: F) -> BooleanChunked
+where
+    F: Fn(usize) -> bool + Send + Sync,
+{
+    let n_bytes = len.div_ceil(8);
+    let mut values: Vec<u8> = Vec::with_capacity(n_bytes);
+
+    (0..n_bytes)
+        .into_par_iter()
+        .map(|b| {
+            let lo = b * 8;
+            let hi = (lo + 8).min(len);
+            let mut v = 0u8;
+            for (bit, g) in (lo..hi).enumerate() {
+                v |= (f(g) as u8) << bit;
+            }
+            v
+        })
+        .collect_into_vec(&mut values);
+
+    BooleanChunked::from_bitmap(PlSmallStr::EMPTY, Bitmap::from_u8_vec(values, len))
+}
+
+pub(crate) fn collect_bool_opt_par<F>(len: usize, f: F) -> BooleanChunked
+where
+    F: Fn(usize) -> Option<bool> + Send + Sync,
+{
+    let n_bytes = len.div_ceil(8);
+    let mut values: Vec<u8> = Vec::with_capacity(n_bytes);
+    let mut validity: Vec<u8> = Vec::with_capacity(n_bytes);
+
+    (0..n_bytes)
+        .into_par_iter()
+        .map(|b| {
+            let lo = b * 8;
+            let hi = (lo + 8).min(len);
+            let (mut v, mut m) = (0u8, 0u8);
+            for (bit, g) in (lo..hi).enumerate() {
+                if let Some(x) = f(g) {
+                    m |= 1 << bit;
+                    v |= (x as u8) << bit;
+                }
+            }
+            (v, m)
+        })
+        .unzip_into_vecs(&mut values, &mut validity);
+
+    let values = Bitmap::from_u8_vec(values, len);
+    let validity = Bitmap::from_u8_vec(validity, len);
+    let validity = (validity.unset_bits() > 0).then_some(validity);
+    BooleanChunked::with_chunk(
+        PlSmallStr::EMPTY,
+        BooleanArray::new(ArrowDataType::Boolean, values, validity),
+    )
+}
+
+// TODO: Placeholder for the NoNull helpers, future PR.
+#[allow(unused)]
+pub(crate) fn collect_primitive_par<T, F>(len: usize, f: F) -> ChunkedArray<T>
+where
+    T: PolarsNumericType,
+    F: Fn(usize) -> T::Native + Send + Sync,
+{
+    let mut values: Vec<T::Native> = Vec::new();
+    (0..len)
+        .into_par_iter()
+        .map(f)
+        .collect_into_vec(&mut values);
+    ChunkedArray::from_vec(PlSmallStr::EMPTY, values)
+}
+
+pub(crate) fn collect_primitive_opt_par<T, F>(len: usize, f: F) -> ChunkedArray<T>
+where
+    T: PolarsNumericType,
+    F: Fn(usize) -> Option<T::Native> + Send + Sync,
+{
+    let mut values: Vec<T::Native> = vec![T::Native::default(); len];
+    let mut validity: Vec<u8> = Vec::with_capacity(len.div_ceil(8));
+
+    values
+        .par_chunks_mut(8)
+        .enumerate()
+        .map(|(b, out)| {
+            let lo = b * 8;
+            let mut m = 0u8;
+            for (bit, slot) in out.iter_mut().enumerate() {
+                if let Some(x) = f(lo + bit) {
+                    *slot = x;
+                    m |= 1 << bit;
+                }
+            }
+            m
+        })
+        .collect_into_vec(&mut validity);
+
+    let validity = Bitmap::from_u8_vec(validity, len);
+    let validity = (validity.unset_bits() > 0).then_some(validity);
+    ChunkedArray::from_vec_validity(PlSmallStr::EMPTY, values, validity)
 }

--- a/crates/polars-core/src/frame/group_by/aggregations/boolean.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/boolean.rs
@@ -2,6 +2,7 @@ use arrow::bitmap::bitmask::BitMask;
 
 use super::*;
 use crate::chunked_array::cast::CastOptions;
+use crate::chunked_array::from_iterator_par::{collect_bool_opt_par, collect_bool_par};
 use crate::chunked_array::{arg_max_bool, arg_min_bool};
 
 pub fn _agg_helper_idx_bool<F>(groups: &GroupsIdx, f: F) -> Series
@@ -12,7 +13,7 @@ where
         let groups_len = groups.len();
         let first = groups.first();
         let all = groups.all();
-        collect_bool_opt_par(PlSmallStr::EMPTY, groups_len, |g| f((first[g], &all[g])))
+        collect_bool_opt_par(groups_len, |g| f((first[g], &all[g])))
     });
     ca.into_series()
 }
@@ -21,8 +22,7 @@ pub fn _agg_helper_slice_bool<F>(groups: &[[IdxSize; 2]], f: F) -> Series
 where
     F: Fn([IdxSize; 2]) -> Option<bool> + Send + Sync,
 {
-    let ca: BooleanChunked =
-        RAYON.install(|| collect_bool_opt_par(PlSmallStr::EMPTY, groups.len(), |g| f(groups[g])));
+    let ca: BooleanChunked = RAYON.install(|| collect_bool_opt_par(groups.len(), |g| f(groups[g])));
     ca.into_series()
 }
 
@@ -301,7 +301,7 @@ impl BooleanChunked {
 
         let groups_len = groups.len();
 
-        RAYON.install(|| {
+        let ca = RAYON.install(|| {
             let validity = values
                 .validity()
                 .filter(|v| v.unset_bits() > 0)
@@ -312,43 +312,38 @@ impl BooleanChunked {
                 match groups {
                     GroupsType::Idx(idx) => {
                         let all = idx.all();
-                        collect_bool_opt_par(name, groups_len, |g| {
-                            idx_kleene(values, validity, &all[g])
-                        })
+                        collect_bool_opt_par(groups_len, |g| idx_kleene(values, validity, &all[g]))
                     },
-                    GroupsType::Slice { groups, .. } => {
-                        collect_bool_opt_par(name, groups_len, |g| {
-                            let [s, l] = groups[g];
-                            slice_kleene(values, validity, s, l)
-                        })
-                    },
+                    GroupsType::Slice { groups, .. } => collect_bool_opt_par(groups_len, |g| {
+                        let [s, l] = groups[g];
+                        slice_kleene(values, validity, s, l)
+                    }),
                 }
             } else {
                 match groups {
                     GroupsType::Idx(idx) => {
                         let all = idx.all();
                         match validity {
-                            None => collect_bool_par(name, groups_len, |g| {
-                                idx_no_valid(values, &all[g])
-                            }),
-                            Some(validity) => collect_bool_par(name, groups_len, |g| {
+                            None => collect_bool_par(groups_len, |g| idx_no_valid(values, &all[g])),
+                            Some(validity) => collect_bool_par(groups_len, |g| {
                                 idx_validity(values, validity, &all[g])
                             }),
                         }
                     },
                     GroupsType::Slice { groups, .. } => match validity {
-                        None => collect_bool_par(name, groups_len, |g| {
+                        None => collect_bool_par(groups_len, |g| {
                             let [s, l] = groups[g];
                             slice_no_valid(values, s, l)
                         }),
-                        Some(validity) => collect_bool_par(name, groups_len, |g| {
+                        Some(validity) => collect_bool_par(groups_len, |g| {
                             let [s, l] = groups[g];
                             slice_validity(values, validity, s, l)
                         }),
                     },
                 }
             }
-        })
+        });
+        ca.with_name(name)
     }
 
     /// # Safety
@@ -462,60 +457,4 @@ impl BooleanChunked {
             },
         )
     }
-}
-
-pub fn collect_bool_par<F>(name: PlSmallStr, len: usize, f: F) -> BooleanChunked
-where
-    F: Fn(usize) -> bool + Send + Sync,
-{
-    let n_bytes = len.div_ceil(8);
-    let mut values: Vec<u8> = Vec::with_capacity(n_bytes);
-
-    (0..n_bytes)
-        .into_par_iter()
-        .map(|b| {
-            let lo = b * 8;
-            let hi = (lo + 8).min(len);
-            let mut v = 0u8;
-            for (bit, g) in (lo..hi).enumerate() {
-                v |= (f(g) as u8) << bit;
-            }
-            v
-        })
-        .collect_into_vec(&mut values);
-
-    BooleanChunked::from_bitmap(name, Bitmap::from_u8_vec(values, len))
-}
-
-pub fn collect_bool_opt_par<F>(name: PlSmallStr, len: usize, f: F) -> BooleanChunked
-where
-    F: Fn(usize) -> Option<bool> + Send + Sync,
-{
-    let n_bytes = len.div_ceil(8);
-    let mut values: Vec<u8> = Vec::with_capacity(n_bytes);
-    let mut validity: Vec<u8> = Vec::with_capacity(n_bytes);
-
-    (0..n_bytes)
-        .into_par_iter()
-        .map(|b| {
-            let lo = b * 8;
-            let hi = (lo + 8).min(len);
-            let (mut v, mut m) = (0u8, 0u8);
-            for (bit, g) in (lo..hi).enumerate() {
-                if let Some(x) = f(g) {
-                    m |= 1 << bit;
-                    v |= (x as u8) << bit;
-                }
-            }
-            (v, m)
-        })
-        .unzip_into_vecs(&mut values, &mut validity);
-
-    let values = Bitmap::from_u8_vec(values, len);
-    let validity = Bitmap::from_u8_vec(validity, len);
-    let validity = (validity.unset_bits() > 0).then_some(validity);
-    BooleanChunked::with_chunk(
-        name,
-        BooleanArray::new(ArrowDataType::Boolean, values, validity),
-    )
 }

--- a/crates/polars-core/src/frame/group_by/aggregations/categorical.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/categorical.rs
@@ -12,29 +12,29 @@ impl<T: PolarsCategoricalType> CategoricalChunked<T> {
         let arr = phys.downcast_as_array();
         let cats: ChunkedArray<T::PolarsPhysical> = match groups {
             GroupsType::Idx(groups) => {
+                let groups_len = groups.len();
+                let first = groups.first();
+                let all = groups.all();
                 RAYON.install(|| {
-                    groups
-                        .into_par_iter()
-                        .map(|(first, idx)| {
-                            if idx.is_empty() {
-                                None
-                            } else if idx.len() == 1 {
+                    collect_primitive_opt_par(groups_len, |g| {
+                        let (first, idx) = (first[g], &all[g]);
+                        if idx.is_empty() {
+                            None
+                        } else if idx.len() == 1 {
+                            // SAFETY: group indices are valid by GroupsType invariant
+                            unsafe { arr.get_unchecked(first as usize) }
+                        } else {
+                            let min_pos = arg_min_opt_iter(idx.iter().map(|&i| {
                                 // SAFETY: group indices are valid by GroupsType invariant
-                                unsafe { arr.get_unchecked(first as usize) }
-                            } else {
-                                let min_pos = arg_min_opt_iter(idx.iter().map(|&i| {
-                                    // SAFETY: group indices are valid by GroupsType invariant
-                                    unsafe { arr.get_unchecked(i as usize) }.map(|cat| unsafe {
-                                        mapping.cat_to_str_unchecked(cat.as_cat())
-                                    })
-                                }));
-                                // SAFETY: min_pos points to a non-null element by arg_min_opt_iter contract
-                                min_pos.map(|pos| {
-                                    unsafe { arr.get_unchecked(idx[pos] as usize) }.unwrap()
+                                unsafe { arr.get_unchecked(i as usize) }.map(|cat| unsafe {
+                                    mapping.cat_to_str_unchecked(cat.as_cat())
                                 })
-                            }
-                        })
-                        .collect()
+                            }));
+                            // SAFETY: min_pos points to a non-null element by arg_min_opt_iter contract
+                            min_pos
+                                .map(|pos| unsafe { arr.get_unchecked(idx[pos] as usize) }.unwrap())
+                        }
+                    })
                 })
             },
             GroupsType::Slice {
@@ -42,24 +42,20 @@ impl<T: PolarsCategoricalType> CategoricalChunked<T> {
                 ..
             } => {
                 RAYON.install(|| {
-                    groups_slice
-                        .par_iter()
-                        .copied()
-                        .map(|[first, len]| {
-                            let min_pos = arg_min_opt_iter(
-                                (first as usize..first as usize + len as usize).map(|i| {
-                                    // SAFETY: slice bounds are valid by GroupsType invariant
-                                    unsafe { arr.get_unchecked(i) }.map(|cat| unsafe {
-                                        mapping.cat_to_str_unchecked(cat.as_cat())
-                                    })
-                                }),
-                            );
-                            // SAFETY: min_pos is within [0, len), so first+min_pos is a valid non-null index
-                            min_pos.map(|pos| {
-                                unsafe { arr.get_unchecked(first as usize + pos) }.unwrap()
-                            })
-                        })
-                        .collect()
+                    collect_primitive_opt_par(groups_slice.len(), |g| {
+                        let [first, len] = groups_slice[g];
+                        let min_pos = arg_min_opt_iter(
+                            (first as usize..first as usize + len as usize).map(|i| {
+                                // SAFETY: slice bounds are valid by GroupsType invariant
+                                unsafe { arr.get_unchecked(i) }.map(|cat| unsafe {
+                                    mapping.cat_to_str_unchecked(cat.as_cat())
+                                })
+                            }),
+                        );
+                        // SAFETY: min_pos is within [0, len), so first+min_pos is a valid non-null index
+                        min_pos
+                            .map(|pos| unsafe { arr.get_unchecked(first as usize + pos) }.unwrap())
+                    })
                 })
             },
         };
@@ -78,29 +74,29 @@ impl<T: PolarsCategoricalType> CategoricalChunked<T> {
         let arr = phys.downcast_as_array();
         let cats: ChunkedArray<T::PolarsPhysical> = match groups {
             GroupsType::Idx(groups) => {
+                let groups_len = groups.len();
+                let first = groups.first();
+                let all = groups.all();
                 RAYON.install(|| {
-                    groups
-                        .into_par_iter()
-                        .map(|(first, idx)| {
-                            if idx.is_empty() {
-                                None
-                            } else if idx.len() == 1 {
+                    collect_primitive_opt_par(groups_len, |g| {
+                        let (first, idx) = (first[g], &all[g]);
+                        if idx.is_empty() {
+                            None
+                        } else if idx.len() == 1 {
+                            // SAFETY: group indices are valid by GroupsType invariant
+                            unsafe { arr.get_unchecked(first as usize) }
+                        } else {
+                            let max_pos = arg_max_opt_iter(idx.iter().map(|&i| {
                                 // SAFETY: group indices are valid by GroupsType invariant
-                                unsafe { arr.get_unchecked(first as usize) }
-                            } else {
-                                let max_pos = arg_max_opt_iter(idx.iter().map(|&i| {
-                                    // SAFETY: group indices are valid by GroupsType invariant
-                                    unsafe { arr.get_unchecked(i as usize) }.map(|cat| unsafe {
-                                        mapping.cat_to_str_unchecked(cat.as_cat())
-                                    })
-                                }));
-                                // SAFETY: max_pos points to a non-null element by arg_max_opt_iter contract
-                                max_pos.map(|pos| {
-                                    unsafe { arr.get_unchecked(idx[pos] as usize) }.unwrap()
+                                unsafe { arr.get_unchecked(i as usize) }.map(|cat| unsafe {
+                                    mapping.cat_to_str_unchecked(cat.as_cat())
                                 })
-                            }
-                        })
-                        .collect()
+                            }));
+                            // SAFETY: max_pos points to a non-null element by arg_max_opt_iter contract
+                            max_pos
+                                .map(|pos| unsafe { arr.get_unchecked(idx[pos] as usize) }.unwrap())
+                        }
+                    })
                 })
             },
             GroupsType::Slice {
@@ -108,24 +104,20 @@ impl<T: PolarsCategoricalType> CategoricalChunked<T> {
                 ..
             } => {
                 RAYON.install(|| {
-                    groups_slice
-                        .par_iter()
-                        .copied()
-                        .map(|[first, len]| {
-                            let max_pos = arg_max_opt_iter(
-                                (first as usize..first as usize + len as usize).map(|i| {
-                                    // SAFETY: slice bounds are valid by GroupsType invariant
-                                    unsafe { arr.get_unchecked(i) }.map(|cat| unsafe {
-                                        mapping.cat_to_str_unchecked(cat.as_cat())
-                                    })
-                                }),
-                            );
-                            // SAFETY: max_pos is within [0, len), so first+max_pos is a valid non-null index
-                            max_pos.map(|pos| {
-                                unsafe { arr.get_unchecked(first as usize + pos) }.unwrap()
-                            })
-                        })
-                        .collect()
+                    collect_primitive_opt_par(groups_slice.len(), |g| {
+                        let [first, len] = groups_slice[g];
+                        let max_pos = arg_max_opt_iter(
+                            (first as usize..first as usize + len as usize).map(|i| {
+                                // SAFETY: slice bounds are valid by GroupsType invariant
+                                unsafe { arr.get_unchecked(i) }.map(|cat| unsafe {
+                                    mapping.cat_to_str_unchecked(cat.as_cat())
+                                })
+                            }),
+                        );
+                        // SAFETY: max_pos is within [0, len), so first+max_pos is a valid non-null index
+                        max_pos
+                            .map(|pos| unsafe { arr.get_unchecked(first as usize + pos) }.unwrap())
+                    })
                 })
             },
         };

--- a/crates/polars-core/src/frame/group_by/aggregations/mod.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/mod.rs
@@ -34,6 +34,7 @@ use polars_utils::min_max::MinMax;
 use rayon::prelude::*;
 
 use crate::chunked_array::cast::CastOptions;
+use crate::chunked_array::from_iterator_par::collect_primitive_opt_par;
 #[cfg(feature = "object")]
 use crate::chunked_array::object::extension::create_extension;
 use crate::chunked_array::{arg_max_numeric, arg_min_numeric};
@@ -43,7 +44,7 @@ use crate::prelude::*;
 use crate::runtime::RAYON;
 use crate::series::IsSorted;
 use crate::series::implementations::SeriesWrap;
-use crate::utils::NoNull;
+use crate::utils::{Container, NoNull};
 
 fn idx2usize(idx: &[IdxSize]) -> impl ExactSizeIterator<Item = usize> + '_ {
     idx.iter().map(|i| *i as usize)
@@ -186,7 +187,11 @@ where
     F: Fn((IdxSize, &IdxVec)) -> Option<T::Native> + Send + Sync,
     T: PolarsNumericType,
 {
-    let ca: ChunkedArray<T> = RAYON.install(|| groups.into_par_iter().map(f).collect());
+    let ca: ChunkedArray<T> = RAYON.install(|| {
+        let first = groups.first();
+        let all = groups.all();
+        collect_primitive_opt_par(groups.len(), |g| f((first[g], &all[g])))
+    });
     ca.into_series()
 }
 
@@ -207,7 +212,10 @@ where
     F: Fn(&IdxVec) -> Option<T::Native> + Send + Sync,
     T: PolarsNumericType,
 {
-    let ca: ChunkedArray<T> = RAYON.install(|| groups.all().into_par_iter().map(f).collect());
+    let ca: ChunkedArray<T> = RAYON.install(|| {
+        let all = groups.all();
+        collect_primitive_opt_par(groups.len(), |g| f(&all[g]))
+    });
     ca.into_series()
 }
 
@@ -216,7 +224,8 @@ where
     F: Fn([IdxSize; 2]) -> Option<T::Native> + Send + Sync,
     T: PolarsNumericType,
 {
-    let ca: ChunkedArray<T> = RAYON.install(|| groups.par_iter().copied().map(f).collect());
+    let ca: ChunkedArray<T> =
+        RAYON.install(|| collect_primitive_opt_par(groups.len(), |g| f(groups[g])));
     ca.into_series()
 }
 
@@ -224,7 +233,10 @@ pub fn _agg_helper_idx_idx<'a, F>(groups: &'a GroupsIdx, f: F) -> Series
 where
     F: Fn((IdxSize, &'a IdxVec)) -> Option<IdxSize> + Send + Sync,
 {
-    let ca: IdxCa = RAYON.install(|| groups.into_par_iter().map(f).collect());
+    let first = groups.first();
+    let all = groups.all();
+    let ca: IdxCa =
+        RAYON.install(|| collect_primitive_opt_par(groups.len(), |g| f((first[g], &all[g]))));
     ca.into_series()
 }
 
@@ -232,7 +244,7 @@ pub fn _agg_helper_slice_idx<F>(groups: &[[IdxSize; 2]], f: F) -> Series
 where
     F: Fn([IdxSize; 2]) -> Option<IdxSize> + Send + Sync,
 {
-    let ca: IdxCa = RAYON.install(|| groups.par_iter().copied().map(f).collect());
+    let ca: IdxCa = RAYON.install(|| collect_primitive_opt_par(groups.len(), |g| f(groups[g])));
     ca.into_series()
 }
 

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -3279,3 +3279,52 @@ def test_group_by_bool_agg_min_max_single_chunk_28684(
 
     expected = df["b"]
     assert_series_equal(out["b"], expected, check_names=False)
+
+
+@pytest.mark.may_fail_auto_streaming  # n_chunks is an implementation detail for in-memory
+def test_group_by_agg_primitive_opt_single_chunk_28684() -> None:
+    # must be large enough to trigger chunk fragmentation
+    n = 20_000
+    rng = np.random.default_rng(0)
+    v = rng.random(n)
+    v[rng.random(n) < 0.2] = np.nan
+
+    df = pl.DataFrame(
+        {
+            "g": np.arange(n),
+            "v": v,
+            "b": rng.random(n) < 0.5,
+            "i": rng.integers(0, 1000, n),
+            "c": pl.Series(rng.choice(["a", "b", "c"], n)).cast(pl.Categorical),
+            "d": pl.Series(np.arange(n).astype("datetime64[ms]")),
+        }
+    )
+
+    out = df.group_by("g").agg(
+        pl.col("v").min(),
+        pl.col("v").max().alias("max"),
+        pl.col("v").mean().alias("mean"),
+        pl.col("v").median().alias("median"),
+        pl.col("v").std().alias("std"),
+        pl.col("v").var().alias("var"),
+        pl.col("v").quantile(0.5).alias("quantile"),
+        pl.col("v").first().alias("first"),
+        pl.col("v").n_unique().alias("n_unique"),
+        pl.col("v").arg_min().alias("arg_min"),
+        pl.col("v").arg_max().alias("arg_max"),
+        pl.col("b").arg_min().alias("b_arg_min"),
+        pl.col("b").arg_max().alias("b_arg_max"),
+        pl.col("v").nan_max().alias("nan_max"),
+        pl.col("v").nan_min().alias("nan_min"),
+        pl.col("i").min().alias("i_min"),
+        pl.col("i").max().alias("i_max"),
+        pl.col("b").min().alias("b_min"),
+        pl.col("b").max().alias("b_max"),
+        pl.col("c").min().alias("c_min"),
+        pl.col("c").max().alias("c_max"),
+        pl.col("d").min().alias("d_min"),
+        pl.col("d").max().alias("d_max"),
+        pl.col("d").mean().alias("d_mean"),
+    )
+
+    assert [s.n_chunks() for s in out.select(pl.exclude("g"))] == [1] * (out.width - 1)


### PR DESCRIPTION
Follow-up to #28754 and #28789.

With this PR, all group-by aggregations into primitive types collect into a single chunk (see test for a list). This should improve the performance of downstream expressions.

Future work:
(a) Similar for NoNull (such as `sum` and `count`). These already collect into single chunk but with a copy.
(b) Change the logic for `optional_rechunk()` so any chunking left is limited. Needed for the variable-length types (next point). 
(c) Optionally: refactor collections for variable-length aggregation outcomes (e.g. `String`).

Micro-benchmark on a non-isolated machine shows no material regression (not all results captured). The resulting column layout is in better shape for downstream operations.

before
```
$ ~/tmp/polars/.venv/bin/python bench_mean.py
1.43.2, threads=24
duration: 13.1ms N: 100000 n_groups=: 997993 chunks: 10037
duration: 28.2ms N: 1000000 n_groups=: 997993 chunks: 14671
duration: 1109.0ms N: 100000000 n_groups=: 997993 chunks: 15382
duration: 12577.6ms N: 1000000000 n_groups=: 997993 chunks: 15519
```
after
```
$ pp bench_mean.py
1.43.2, threads=24
duration: 10.5ms N: 100000 n_groups=: 997993 chunks: 1
duration: 17.1ms N: 1000000 n_groups=: 997993 chunks: 1
duration: 1041.3ms N: 100000000 n_groups=: 997993 chunks: 1
duration: 13410.9ms N: 1000000000 n_groups=: 997993 chunks: 1
```