### PR TITLE
fix: Make Schema.to_arrow default compat level match DataFrame.to_arrow

### DIFF
--- a/py-polars/src/polars/schema.py
+++ b/py-polars/src/polars/schema.py
@@ -217,7 +217,7 @@ class Schema(BaseSchema):
         Examples
         --------
         >>> pl.Schema({"x": pl.String}).to_arrow()
-        x: string_view
+        x: large_string
         """
 
         class SchemaCapsuleProvider:
@@ -232,7 +232,7 @@ class Schema(BaseSchema):
 
         return pa.schema(
             SchemaCapsuleProvider(
-                self, CompatLevel.newest() if compat_level is None else compat_level
+                self, CompatLevel.oldest() if compat_level is None else compat_level
             )
         )
 

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -1487,12 +1487,20 @@ def test_month_day_nano_from_ffi_15969(plmonkeypatch: PlMonkeyPatch) -> None:
 
 def test_schema_to_arrow_15563() -> None:
     assert pl.Schema({"x": pl.String}).to_arrow() == pa.schema(
-        [pa.field("x", pa.string_view())]
+        [pa.field("x", pa.large_string())]
     )
 
     assert pl.Schema({"x": pl.String}).to_arrow(
-        compat_level=CompatLevel.oldest()
-    ) == pa.schema([pa.field("x", pa.large_string())])
+        compat_level=CompatLevel.newest()
+    ) == pa.schema([pa.field("x", pa.string_view())])
+
+
+def test_schema_to_arrow_matches_dataframe_to_arrow_28777() -> None:
+    # Schema.to_arrow() and DataFrame.to_arrow() must agree on the default
+    # compat level, otherwise schemas derived from the two methods are
+    # inconsistent (e.g. string_view vs. large_string).
+    df = pl.DataFrame({"x": ["a", "b", "c"]})
+    assert df.schema.to_arrow() == df.to_arrow().schema
 
 
 def test_0_width_df_roundtrip() -> None:


### PR DESCRIPTION
Fixes #28777

`Schema.to_arrow()` defaulted to `CompatLevel.newest()` (producing Arrow `string_view`), while `DataFrame.to_arrow()` defaults to the oldest compat level (`large_string`). So `df.schema.to_arrow()` and `df.to_arrow().schema` disagreed on string column type, breaking consumers like PyArrow's CSV reader that reject `string_view`.

**Fix:** change `Schema.to_arrow()`'s default to `CompatLevel.oldest()` to match `DataFrame.to_arrow()`, and update its docstring example.

Added regression test `test_schema_to_arrow_matches_dataframe_to_arrow_28777` confirming both paths now produce `large_string`.
