### PR TITLE
Raise a clear error for multiple iterable positional expressions in select/with_columns/agg

### DIFF
--- a/py-polars/src/polars/_utils/parse/expr.py
+++ b/py-polars/src/polars/_utils/parse/expr.py
@@ -247,6 +247,21 @@ def _parse_inputs_as_iterable(
     if len(inputs) == 1 and _is_iterable(inputs[0]):
         return inputs[0]
 
+    # An iterable of expressions is only supported as the sole positional
+    # argument. Combining it with other positional arguments is ambiguous and
+    # previously failed deep inside the engine with a confusing error, so fail
+    # fast with an actionable message instead.
+    if any(_is_iterable(input) for input in inputs):
+        msg = (
+            "Only a single iterable can be passed as a positional argument.\n"
+            "If you meant to pass multiple expressions, either pass them as "
+            "separate positional arguments or combine them into a single "
+            "iterable, for example:\n"
+            "  \u2022 df.select(expr1, expr2)\n"
+            "  \u2022 df.select([expr1, expr2])"
+        )
+        raise TypeError(msg)
+
     return inputs
 
 

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -3329,6 +3329,28 @@ def test_with_columns_dict_unpacking() -> None:
     assert df.equals(expected)
 
 
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda df: df.select([pl.col("a")], [pl.col("a") * 2]),
+        lambda df: df.select(pl.col("a"), [pl.col("a") * 2]),
+        lambda df: df.with_columns([pl.col("a")], [pl.col("a") * 2]),
+        lambda df: df.group_by("a").agg([pl.len()], [pl.col("a").sum()]),
+    ],
+)
+def test_iterable_positional_argument_must_be_sole(
+    call: Any,
+) -> None:
+    # An iterable of expressions may only be passed as the single positional
+    # argument; combining it with other positional arguments is ambiguous and
+    # used to raise a confusing engine error. Refs: #28807
+    df = pl.DataFrame({"a": [1, 2]})
+    with pytest.raises(
+        TypeError, match="Only a single iterable can be passed as a positional argument"
+    ):
+        call(df)
+
+
 def test_with_columns_generator_alias() -> None:
     data = {"a": pl.col("a") * 2}
     df = pl.select(a=1).with_columns(expr.alias(name) for name, expr in data.items())


### PR DESCRIPTION
Fixes #28807

## Problem

`DataFrame.select` / `with_columns` and `GroupBy.agg` accept `*exprs` whose signature permits an iterable among the positional arguments, but only a *sole* iterable is actually supported (it gets unwrapped into separate expressions). Combining an iterable with other positional arguments falls through to the engine and fails with a confusing error:

```python
df.with_columns([e1], [e2])  # TypeError: not yet implemented: Nested object types
df.select(e1, [e2])          # TypeError: not yet implemented: Nested object types
df.select(["a"], ["b"])      # DuplicateError: projections contained duplicate output name 'literal'
```

## Change

`_parse_inputs_as_iterable` (the shared entry point for all three methods) now detects an iterable combined with other positional arguments and raises an actionable `TypeError` explaining that an iterable is only supported as the sole positional argument, with examples:

```
Only a single iterable can be passed as a positional argument.
If you meant to pass multiple expressions, either pass them as separate positional arguments or combine them into a single iterable, for example:
  • df.select(expr1, expr2)
  • df.select([expr1, expr2])
```

The documented usage is unaffected: multiple expressions, or a single iterable, still work exactly as before. The check sits in the shared parser, so `select`, `with_columns` and `agg` (DataFrame and LazyFrame) are all covered.

## Testing

- Regression test parametrized over the broken call shapes (`select`/`with_columns`/`agg`, two lists and expression+list).
- Verified end-to-end against a built polars engine: valid forms (`select([e1, e2])`, `select(e1, e2)`, single-iterable `agg`) unchanged; all ambiguous forms now raise the clear `TypeError`.
- `ruff` clean.

Note: I could not run the full py-polars test suite locally because the Rust engine requires the pinned `nightly-2026-04-01` toolchain; the maintainers' CI will build and run it.
