### PR TITLE
feat: Support integer fixed-array dot products

### DIFF
--- a/crates/polars-ops/src/chunked_array/array/dot.rs
+++ b/crates/polars-ops/src/chunked_array/array/dot.rs
@@ -6,6 +6,12 @@ use polars_compute::arithmetic::pl_num::PlNumArithmetic;
 use polars_compute::sum::WrappingAdd;
 use polars_core::prelude::*;
 
+type ArrayDotKernel = fn(&ArrayChunked, &ArrayChunked, usize) -> PolarsResult<Series>;
+
+pub fn is_supported_array_dot_dtype(dtype: &DataType) -> bool {
+    array_dot_kernel(dtype).is_some()
+}
+
 #[inline]
 fn multiply_then_add<T>(acc: T::Sum, lhs: T, rhs: T) -> T::Sum
 where
@@ -99,6 +105,27 @@ where
     Series::try_from((lhs.name().clone(), vec![Box::new(output) as ArrayRef]))
 }
 
+fn array_dot_kernel(dtype: &DataType) -> Option<ArrayDotKernel> {
+    let kernel = match dtype {
+        DataType::Int8 => dot_primitive::<i8>,
+        DataType::Int16 => dot_primitive::<i16>,
+        DataType::Int32 => dot_primitive::<i32>,
+        DataType::Int64 => dot_primitive::<i64>,
+        #[cfg(feature = "dtype-i128")]
+        DataType::Int128 => dot_primitive::<i128>,
+        DataType::UInt8 => dot_primitive::<u8>,
+        DataType::UInt16 => dot_primitive::<u16>,
+        DataType::UInt32 => dot_primitive::<u32>,
+        DataType::UInt64 => dot_primitive::<u64>,
+        #[cfg(feature = "dtype-u128")]
+        DataType::UInt128 => dot_primitive::<u128>,
+        DataType::Float32 => dot_primitive::<f32>,
+        DataType::Float64 => dot_primitive::<f64>,
+        _ => return None,
+    };
+    Some(kernel)
+}
+
 pub(super) fn array_dot(lhs: &ArrayChunked, rhs: &ArrayChunked) -> PolarsResult<Series> {
     let (lhs_inner, lhs_width) = match lhs.dtype() {
         DataType::Array(inner, width) => (inner.as_ref(), *width),
@@ -117,10 +144,12 @@ pub(super) fn array_dot(lhs: &ArrayChunked, rhs: &ArrayChunked) -> PolarsResult<
         lhs_inner, rhs_inner,
         "arr.dot requires matching inner dtypes, got {lhs_inner} and {rhs_inner}"
     );
-    assert!(
-        lhs_inner.is_integer() || matches!(lhs_inner, DataType::Float32 | DataType::Float64),
-        "arr.dot supports integer, Float32, and Float64 arrays, got array[{lhs_inner}, {lhs_width}]"
-    );
+    let Some(kernel) = array_dot_kernel(lhs_inner) else {
+        polars_bail!(
+            InvalidOperation:
+            "arr.dot does not support inner dtype {lhs_inner}"
+        )
+    };
 
     let output_len = match (lhs.len(), rhs.len()) {
         (lhs_len, rhs_len) if lhs_len == rhs_len => lhs_len,
@@ -139,21 +168,5 @@ pub(super) fn array_dot(lhs: &ArrayChunked, rhs: &ArrayChunked) -> PolarsResult<
         ));
     }
 
-    match lhs_inner {
-        DataType::Int8 => dot_primitive::<i8>(lhs, rhs, output_len),
-        DataType::Int16 => dot_primitive::<i16>(lhs, rhs, output_len),
-        DataType::Int32 => dot_primitive::<i32>(lhs, rhs, output_len),
-        DataType::Int64 => dot_primitive::<i64>(lhs, rhs, output_len),
-        #[cfg(feature = "dtype-i128")]
-        DataType::Int128 => dot_primitive::<i128>(lhs, rhs, output_len),
-        DataType::UInt8 => dot_primitive::<u8>(lhs, rhs, output_len),
-        DataType::UInt16 => dot_primitive::<u16>(lhs, rhs, output_len),
-        DataType::UInt32 => dot_primitive::<u32>(lhs, rhs, output_len),
-        DataType::UInt64 => dot_primitive::<u64>(lhs, rhs, output_len),
-        #[cfg(feature = "dtype-u128")]
-        DataType::UInt128 => dot_primitive::<u128>(lhs, rhs, output_len),
-        DataType::Float32 => dot_primitive::<f32>(lhs, rhs, output_len),
-        DataType::Float64 => dot_primitive::<f64>(lhs, rhs, output_len),
-        _ => unreachable!(),
-    }
+    kernel(lhs, rhs, output_len)
 }

--- a/crates/polars-ops/src/chunked_array/array/dot.rs
+++ b/crates/polars-ops/src/chunked_array/array/dot.rs
@@ -1,18 +1,29 @@
-use std::iter::Sum;
-use std::ops::{AddAssign, Mul};
-
 use arrow::array::{Array, PrimitiveArray};
 use arrow::bitmap::BitmapBuilder;
 use arrow::types::NativeType;
+use num_traits::Zero;
+use polars_compute::arithmetic::pl_num::PlNumArithmetic;
+use polars_compute::sum::WrappingAdd;
 use polars_core::prelude::*;
 
-fn dot_primitive<T>(
+#[inline]
+fn multiply_add<T, S>(acc: S, lhs: T, rhs: T) -> S
+where
+    T: PlNumArithmetic + Into<S>,
+    S: WrappingAdd,
+{
+    let product = PlNumArithmetic::wrapping_mul(lhs, rhs).into();
+    acc.wrapping_add(&product)
+}
+
+fn dot_primitive<T, S>(
     lhs: &ArrayChunked,
     rhs: &ArrayChunked,
     output_len: usize,
 ) -> PolarsResult<Series>
 where
-    T: NativeType + Default + AddAssign + Mul<Output = T> + Sum,
+    T: NativeType + PlNumArithmetic + Into<S>,
+    S: NativeType + Zero + WrappingAdd,
 {
     let lhs = lhs.rechunk();
     let rhs = rhs.rechunk();
@@ -49,7 +60,7 @@ where
         output_validity.push(outer_valid);
 
         if !outer_valid {
-            output.push(T::default());
+            output.push(S::zero());
             continue;
         }
 
@@ -62,10 +73,9 @@ where
             lhs_row
                 .iter()
                 .zip(rhs_row)
-                .map(|(&lhs, &rhs)| lhs * rhs)
-                .sum()
+                .fold(S::zero(), |acc, (&lhs, &rhs)| multiply_add(acc, lhs, rhs))
         } else {
-            let mut value = T::default();
+            let mut value = S::zero();
             for (inner_idx, (&lhs, &rhs)) in lhs_row.iter().zip(rhs_row).enumerate() {
                 let lhs_valid = lhs_inner_validity.is_none_or(|validity| unsafe {
                     validity.get_bit_unchecked(lhs_offset + inner_idx)
@@ -74,7 +84,7 @@ where
                     validity.get_bit_unchecked(rhs_offset + inner_idx)
                 });
                 if lhs_valid && rhs_valid {
-                    value += lhs * rhs;
+                    value = multiply_add(value, lhs, rhs);
                 }
             }
             value
@@ -106,8 +116,8 @@ pub(super) fn array_dot(lhs: &ArrayChunked, rhs: &ArrayChunked) -> PolarsResult<
         "arr.dot requires matching inner dtypes, got {lhs_inner} and {rhs_inner}"
     );
     assert!(
-        matches!(lhs_inner, DataType::Float32 | DataType::Float64),
-        "arr.dot supports Float32 and Float64 arrays, got array[{lhs_inner}, {lhs_width}]"
+        lhs_inner.is_integer() || matches!(lhs_inner, DataType::Float32 | DataType::Float64),
+        "arr.dot supports integer, Float32, and Float64 arrays, got array[{lhs_inner}, {lhs_width}]"
     );
 
     let output_len = match (lhs.len(), rhs.len()) {
@@ -121,12 +131,25 @@ pub(super) fn array_dot(lhs: &ArrayChunked, rhs: &ArrayChunked) -> PolarsResult<
     };
 
     if output_len == 0 {
-        return Ok(Series::new_empty(lhs.name().clone(), lhs_inner));
+        return Ok(Series::new_empty(
+            lhs.name().clone(),
+            &sum_output_dtype(lhs_inner),
+        ));
     }
 
     match lhs_inner {
-        DataType::Float32 => dot_primitive::<f32>(lhs, rhs, output_len),
-        DataType::Float64 => dot_primitive::<f64>(lhs, rhs, output_len),
+        DataType::Int8 => dot_primitive::<i8, i64>(lhs, rhs, output_len),
+        DataType::Int16 => dot_primitive::<i16, i64>(lhs, rhs, output_len),
+        DataType::Int32 => dot_primitive::<i32, i32>(lhs, rhs, output_len),
+        DataType::Int64 => dot_primitive::<i64, i64>(lhs, rhs, output_len),
+        DataType::Int128 => dot_primitive::<i128, i128>(lhs, rhs, output_len),
+        DataType::UInt8 => dot_primitive::<u8, i64>(lhs, rhs, output_len),
+        DataType::UInt16 => dot_primitive::<u16, i64>(lhs, rhs, output_len),
+        DataType::UInt32 => dot_primitive::<u32, u32>(lhs, rhs, output_len),
+        DataType::UInt64 => dot_primitive::<u64, u64>(lhs, rhs, output_len),
+        DataType::UInt128 => dot_primitive::<u128, u128>(lhs, rhs, output_len),
+        DataType::Float32 => dot_primitive::<f32, f32>(lhs, rhs, output_len),
+        DataType::Float64 => dot_primitive::<f64, f64>(lhs, rhs, output_len),
         _ => unreachable!(),
     }
 }

--- a/crates/polars-ops/src/chunked_array/array/dot.rs
+++ b/crates/polars-ops/src/chunked_array/array/dot.rs
@@ -7,23 +7,23 @@ use polars_compute::sum::WrappingAdd;
 use polars_core::prelude::*;
 
 #[inline]
-fn multiply_add<T, S>(acc: S, lhs: T, rhs: T) -> S
+fn multiply_then_add<T>(acc: T::Sum, lhs: T, rhs: T) -> T::Sum
 where
-    T: PlNumArithmetic + Into<S>,
-    S: WrappingAdd,
+    T: PlNumArithmetic + SumCast,
+    T::Sum: WrappingAdd,
 {
     let product = PlNumArithmetic::wrapping_mul(lhs, rhs).into();
     acc.wrapping_add(&product)
 }
 
-fn dot_primitive<T, S>(
+fn dot_primitive<T>(
     lhs: &ArrayChunked,
     rhs: &ArrayChunked,
     output_len: usize,
 ) -> PolarsResult<Series>
 where
-    T: NativeType + PlNumArithmetic + Into<S>,
-    S: NativeType + Zero + WrappingAdd,
+    T: NativeType + PlNumArithmetic + SumCast,
+    T::Sum: WrappingAdd,
 {
     let lhs = lhs.rechunk();
     let rhs = rhs.rechunk();
@@ -60,7 +60,7 @@ where
         output_validity.push(outer_valid);
 
         if !outer_valid {
-            output.push(S::zero());
+            output.push(T::Sum::zero());
             continue;
         }
 
@@ -73,9 +73,11 @@ where
             lhs_row
                 .iter()
                 .zip(rhs_row)
-                .fold(S::zero(), |acc, (&lhs, &rhs)| multiply_add(acc, lhs, rhs))
+                .fold(T::Sum::zero(), |acc, (&lhs, &rhs)| {
+                    multiply_then_add(acc, lhs, rhs)
+                })
         } else {
-            let mut value = S::zero();
+            let mut value = T::Sum::zero();
             for (inner_idx, (&lhs, &rhs)) in lhs_row.iter().zip(rhs_row).enumerate() {
                 let lhs_valid = lhs_inner_validity.is_none_or(|validity| unsafe {
                     validity.get_bit_unchecked(lhs_offset + inner_idx)
@@ -84,7 +86,7 @@ where
                     validity.get_bit_unchecked(rhs_offset + inner_idx)
                 });
                 if lhs_valid && rhs_valid {
-                    value = multiply_add(value, lhs, rhs);
+                    value = multiply_then_add(value, lhs, rhs);
                 }
             }
             value
@@ -138,18 +140,20 @@ pub(super) fn array_dot(lhs: &ArrayChunked, rhs: &ArrayChunked) -> PolarsResult<
     }
 
     match lhs_inner {
-        DataType::Int8 => dot_primitive::<i8, i64>(lhs, rhs, output_len),
-        DataType::Int16 => dot_primitive::<i16, i64>(lhs, rhs, output_len),
-        DataType::Int32 => dot_primitive::<i32, i32>(lhs, rhs, output_len),
-        DataType::Int64 => dot_primitive::<i64, i64>(lhs, rhs, output_len),
-        DataType::Int128 => dot_primitive::<i128, i128>(lhs, rhs, output_len),
-        DataType::UInt8 => dot_primitive::<u8, i64>(lhs, rhs, output_len),
-        DataType::UInt16 => dot_primitive::<u16, i64>(lhs, rhs, output_len),
-        DataType::UInt32 => dot_primitive::<u32, u32>(lhs, rhs, output_len),
-        DataType::UInt64 => dot_primitive::<u64, u64>(lhs, rhs, output_len),
-        DataType::UInt128 => dot_primitive::<u128, u128>(lhs, rhs, output_len),
-        DataType::Float32 => dot_primitive::<f32, f32>(lhs, rhs, output_len),
-        DataType::Float64 => dot_primitive::<f64, f64>(lhs, rhs, output_len),
+        DataType::Int8 => dot_primitive::<i8>(lhs, rhs, output_len),
+        DataType::Int16 => dot_primitive::<i16>(lhs, rhs, output_len),
+        DataType::Int32 => dot_primitive::<i32>(lhs, rhs, output_len),
+        DataType::Int64 => dot_primitive::<i64>(lhs, rhs, output_len),
+        #[cfg(feature = "dtype-i128")]
+        DataType::Int128 => dot_primitive::<i128>(lhs, rhs, output_len),
+        DataType::UInt8 => dot_primitive::<u8>(lhs, rhs, output_len),
+        DataType::UInt16 => dot_primitive::<u16>(lhs, rhs, output_len),
+        DataType::UInt32 => dot_primitive::<u32>(lhs, rhs, output_len),
+        DataType::UInt64 => dot_primitive::<u64>(lhs, rhs, output_len),
+        #[cfg(feature = "dtype-u128")]
+        DataType::UInt128 => dot_primitive::<u128>(lhs, rhs, output_len),
+        DataType::Float32 => dot_primitive::<f32>(lhs, rhs, output_len),
+        DataType::Float64 => dot_primitive::<f64>(lhs, rhs, output_len),
         _ => unreachable!(),
     }
 }

--- a/crates/polars-ops/src/chunked_array/array/mod.rs
+++ b/crates/polars-ops/src/chunked_array/array/mod.rs
@@ -9,6 +9,7 @@ mod sum_mean;
 #[cfg(feature = "array_to_struct")]
 mod to_struct;
 
+pub use dot::is_supported_array_dot_dtype;
 pub use namespace::ArrayNameSpace;
 use polars_core::prelude::*;
 #[cfg(feature = "array_to_struct")]

--- a/crates/polars-plan/src/dsl/array.rs
+++ b/crates/polars-plan/src/dsl/array.rs
@@ -31,11 +31,13 @@ impl ArrayNameSpace {
             .map_unary(FunctionExpr::ArrayExpr(ArrayFunction::Sum))
     }
 
-    /// Compute the row-wise dot product with another equal-width float array expression.
+    /// Compute the row-wise dot product with another equal-width array expression.
     ///
-    /// Both arrays are cast to a common supertype, which must be `Float32` or
-    /// `Float64`. Pairs containing an inner null do not contribute to the sum. An
-    /// outer null row produces a null.
+    /// Both arrays are cast to a common supertype, which must be an integer,
+    /// `Float32`, or `Float64`. `Int8`, `UInt8`, `Int16`, and `UInt16` produce
+    /// `Int64`; other supported types retain the common type. Integer multiplication
+    /// and accumulation use wrapping arithmetic. Pairs containing an inner null do
+    /// not contribute to the sum. An outer null row produces a null.
     pub fn dot(self, other: Expr) -> Expr {
         self.0
             .map_binary(FunctionExpr::ArrayExpr(ArrayFunction::Dot), other)

--- a/crates/polars-plan/src/plans/aexpr/function_expr/array.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/array.rs
@@ -97,10 +97,9 @@ impl IRArrayFunction {
                 );
                 let inner_dtype = try_get_supertype(lhs_inner, rhs_inner)?;
                 polars_ensure!(
-                    inner_dtype.is_integer()
-                        || matches!(inner_dtype, DataType::Float32 | DataType::Float64),
+                    is_supported_array_dot_dtype(&inner_dtype),
                     InvalidOperation:
-                    "arr.dot supports inputs with an integer, Float32, or Float64 supertype, got {} and {}",
+                    "arr.dot does not support input dtypes {} and {} with supertype {inner_dtype}",
                     args[0].dtype(), args[1].dtype()
                 );
 

--- a/crates/polars-plan/src/plans/aexpr/function_expr/array.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/array.rs
@@ -1,6 +1,7 @@
 use polars_core::utils::{slice_offsets, try_get_supertype};
 use polars_ops::chunked_array::array::*;
 
+use super::schema::function_sum_output_dtype;
 use super::*;
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
@@ -96,13 +97,14 @@ impl IRArrayFunction {
                 );
                 let inner_dtype = try_get_supertype(lhs_inner, rhs_inner)?;
                 polars_ensure!(
-                    matches!(inner_dtype, DataType::Float32 | DataType::Float64),
+                    inner_dtype.is_integer()
+                        || matches!(inner_dtype, DataType::Float32 | DataType::Float64),
                     InvalidOperation:
-                    "arr.dot supports inputs with a Float32 or Float64 supertype, got {} and {}",
+                    "arr.dot supports inputs with an integer, Float32, or Float64 supertype, got {} and {}",
                     args[0].dtype(), args[1].dtype()
                 );
 
-                mapper.with_dtype(inner_dtype)
+                mapper.with_dtype(function_sum_output_dtype(&inner_dtype))
             },
             ToList => mapper
                 .ensure_is_array()?

--- a/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
@@ -4,6 +4,16 @@ use polars_core::utils::materialize_dyn_int;
 
 use super::*;
 
+pub(super) fn function_sum_output_dtype(dtype: &DataType) -> DataType {
+    match dtype {
+        // Preserve existing function-expression schema behavior. Core reductions
+        // promote Decimal precision, while these expressions currently do not.
+        #[cfg(feature = "dtype-decimal")]
+        DataType::Decimal(_, _) => dtype.clone(),
+        dtype => sum_output_dtype(dtype),
+    }
+}
+
 impl IRFunctionExpr {
     pub(crate) fn get_field(&self, fields: &[Field]) -> PolarsResult<Field> {
         use IRFunctionExpr::*;
@@ -718,17 +728,11 @@ impl<'a> FieldsMapper<'a> {
     }
 
     pub fn sum_dtype(&self) -> PolarsResult<Field> {
-        use DataType::*;
-        self.map_dtype(|dtype| match dtype {
-            Int8 | UInt8 | Int16 | UInt16 => Int64,
-            Boolean => IDX_DTYPE,
-            dt => dt.clone(),
-        })
+        self.map_dtype(function_sum_output_dtype)
     }
 
     pub fn nested_sum_type(&self) -> PolarsResult<Field> {
         let mut first = self.fields[0].clone();
-        use DataType::*;
         let dt = first.dtype().inner_dtype().cloned().ok_or_else(|| {
             polars_err!(
                 InvalidOperation:"expected List or Array type, got dtype: {}",
@@ -736,11 +740,7 @@ impl<'a> FieldsMapper<'a> {
             )
         })?;
 
-        match dt {
-            Boolean => first.coerce(IDX_DTYPE),
-            UInt8 | Int8 | Int16 | UInt16 => first.coerce(Int64),
-            _ => first.coerce(dt),
-        }
+        first.coerce(function_sum_output_dtype(&dt));
         Ok(first)
     }
 

--- a/py-polars/src/polars/expr/array.py
+++ b/py-polars/src/polars/expr/array.py
@@ -304,12 +304,13 @@ class ExprArrayNameSpace:
         Pairs where either element is null do not contribute to the sum. If a
         non-null row has no pairs where both elements are valid, the result is zero.
 
-        Multiplication uses the common input data type. Accumulation and output
-        follow ``arr.sum`` promotion: ``Int8``, ``UInt8``, ``Int16``, and ``UInt16``
-        use an ``Int64`` accumulator; other supported types retain the common data
-        type. Integer multiplication wraps in the common input type, and accumulation
-        wraps in the output type. Cast inputs before calling ``dot`` when wider
-        multiplication is required.
+        Integer operations use wrapping arithmetic. Each pair is multiplied in the
+        common inner data type before the product is converted to the ``arr.sum``
+        accumulator type. Therefore, an ``Int64`` output does not prevent
+        multiplication from overflowing in ``Int8``, ``UInt8``, ``Int16``, or
+        ``UInt16``. Accumulation may also wrap in the output type. To avoid wrapping,
+        cast both Array inputs to a type that can represent each product and the final
+        sum before calling ``dot``.
 
         NaN and infinity follow floating-point multiplication and addition
         semantics. Floating-point results are not guaranteed to be bitwise identical
@@ -351,6 +352,28 @@ class ExprArrayNameSpace:
         │ 8.0  │
         │ 18.0 │
         └──────┘
+
+        Integer multiplication can wrap before accumulator promotion.
+
+        >>> a = pl.Series("a", [[100, 100]], dtype=pl.Array(pl.Int8, 2))
+        >>> b = pl.Series("b", [[2, 2]], dtype=pl.Array(pl.Int8, 2))
+        >>> a.arr.dot(b)
+        shape: (1,)
+        Series: 'a' [i64]
+        [
+            -112
+        ]
+
+        Cast both inputs before ``dot`` to perform multiplication and accumulation in
+        a type that can represent the result.
+
+        >>> wide = pl.Array(pl.Int64, 2)
+        >>> a.cast(wide).arr.dot(b.cast(wide))
+        shape: (1,)
+        Series: 'a' [i64]
+        [
+            400
+        ]
         """
         if isinstance(other, Sequence) and not isinstance(other, (str, bytes)):
             other = list(other)

--- a/py-polars/src/polars/expr/array.py
+++ b/py-polars/src/polars/expr/array.py
@@ -286,7 +286,7 @@ class ExprArrayNameSpace:
         .. engine-support:: in-memory, streaming, distributed
 
         Both inputs must contain equal-width arrays. Their inner data types are cast
-        to a common supertype, which must be ``Float32`` or ``Float64``.
+        to a common supertype, which must be an integer, ``Float32``, or ``Float64``.
         An input with one row is broadcast against the other input.
         If either input Array is null for a row, the result for that row is null.
 
@@ -302,13 +302,18 @@ class ExprArrayNameSpace:
         Elements are paired by position.
 
         Pairs where either element is null do not contribute to the sum. If a
-        non-null row has no pairs where both elements are valid, the result is
-        ``0.0``.
+        non-null row has no pairs where both elements are valid, the result is zero.
 
-        Accumulation and output use the common floating-point data type. NaN and
-        infinity follow floating-point multiplication and addition semantics.
-        Results are not guaranteed to be bitwise identical to mathematically
-        equivalent expressions that use a different reduction path.
+        Multiplication uses the common input data type. Accumulation and output
+        follow ``arr.sum`` promotion: ``Int8``, ``UInt8``, ``Int16``, and ``UInt16``
+        use an ``Int64`` accumulator; other supported types retain the common data
+        type. Integer multiplication wraps in the common input type, and accumulation
+        wraps in the output type. Cast inputs before calling ``dot`` when wider
+        multiplication is required.
+
+        NaN and infinity follow floating-point multiplication and addition
+        semantics. Floating-point results are not guaranteed to be bitwise identical
+        to mathematically equivalent expressions that use a different reduction path.
 
         Examples
         --------

--- a/py-polars/src/polars/series/array.py
+++ b/py-polars/src/polars/series/array.py
@@ -94,12 +94,13 @@ class ArrayNameSpace:
         Pairs where either element is null do not contribute to the sum. If a
         non-null row has no pairs where both elements are valid, the result is zero.
 
-        Multiplication uses the common input data type. Accumulation and output
-        follow ``arr.sum`` promotion: ``Int8``, ``UInt8``, ``Int16``, and ``UInt16``
-        use an ``Int64`` accumulator; other supported types retain the common data
-        type. Integer multiplication wraps in the common input type, and accumulation
-        wraps in the output type. Cast inputs before calling ``dot`` when wider
-        multiplication is required.
+        Integer operations use wrapping arithmetic. Each pair is multiplied in the
+        common inner data type before the product is converted to the ``arr.sum``
+        accumulator type. Therefore, an ``Int64`` output does not prevent
+        multiplication from overflowing in ``Int8``, ``UInt8``, ``Int16``, or
+        ``UInt16``. Accumulation may also wrap in the output type. To avoid wrapping,
+        cast both Array inputs to a type that can represent each product and the final
+        sum before calling ``dot``.
 
         NaN and infinity follow floating-point multiplication and addition
         semantics. Floating-point results are not guaranteed to be bitwise identical
@@ -125,6 +126,28 @@ class ArrayNameSpace:
         [
             8.0
             18.0
+        ]
+
+        Integer multiplication can wrap before accumulator promotion.
+
+        >>> a = pl.Series("a", [[100, 100]], dtype=pl.Array(pl.Int8, 2))
+        >>> b = pl.Series("b", [[2, 2]], dtype=pl.Array(pl.Int8, 2))
+        >>> a.arr.dot(b)
+        shape: (1,)
+        Series: 'a' [i64]
+        [
+            -112
+        ]
+
+        Cast both inputs before ``dot`` to perform multiplication and accumulation in
+        a type that can represent the result.
+
+        >>> wide = pl.Array(pl.Int64, 2)
+        >>> a.cast(wide).arr.dot(b.cast(wide))
+        shape: (1,)
+        Series: 'a' [i64]
+        [
+            400
         ]
         """
 

--- a/py-polars/src/polars/series/array.py
+++ b/py-polars/src/polars/series/array.py
@@ -81,7 +81,7 @@ class ArrayNameSpace:
         Compute row-wise dot product with another Array Series or query vector.
 
         Both inputs must contain equal-width arrays. Their inner data types are cast
-        to a common supertype, which must be ``Float32`` or ``Float64``.
+        to a common supertype, which must be an integer, ``Float32``, or ``Float64``.
         An input with one row is broadcast against the other input.
         A Python sequence or one-dimensional NumPy array is treated as a one-row
         Array query.
@@ -92,13 +92,18 @@ class ArrayNameSpace:
         Elements are paired by position.
 
         Pairs where either element is null do not contribute to the sum. If a
-        non-null row has no pairs where both elements are valid, the result is
-        ``0.0``.
+        non-null row has no pairs where both elements are valid, the result is zero.
 
-        Accumulation and output use the common floating-point data type. NaN and
-        infinity follow floating-point multiplication and addition semantics.
-        Results are not guaranteed to be bitwise identical to mathematically
-        equivalent expressions that use a different reduction path.
+        Multiplication uses the common input data type. Accumulation and output
+        follow ``arr.sum`` promotion: ``Int8``, ``UInt8``, ``Int16``, and ``UInt16``
+        use an ``Int64`` accumulator; other supported types retain the common data
+        type. Integer multiplication wraps in the common input type, and accumulation
+        wraps in the output type. Cast inputs before calling ``dot`` when wider
+        multiplication is required.
+
+        NaN and infinity follow floating-point multiplication and addition
+        semantics. Floating-point results are not guaranteed to be bitwise identical
+        to mathematically equivalent expressions that use a different reduction path.
 
         Examples
         --------

--- a/py-polars/tests/unit/operations/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_array.py
@@ -453,6 +453,27 @@ def test_arr_dot_integer_overflow() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("dtype", "maximum", "expected"),
+    [
+        (pl.Int32, 2**31 - 1, -(2**31)),
+        (pl.UInt32, 2**32 - 1, 0),
+    ],
+)
+def test_arr_dot_integer_accumulation_overflow(
+    dtype: pl.DataType,
+    maximum: int,
+    expected: int,
+) -> None:
+    lhs = pl.Series("lhs", [[maximum, 1]], dtype=pl.Array(dtype, 2))
+    rhs = pl.Series("rhs", [[1, 1]], dtype=pl.Array(dtype, 2))
+
+    assert_series_equal(
+        lhs.arr.dot(rhs),
+        pl.Series("lhs", [expected], dtype=dtype),
+    )
+
+
 @pytest.mark.parametrize("dtype", [pl.Boolean, pl.Float16, pl.Decimal(10, 2)])
 def test_arr_dot_unsupported_inner_dtype(dtype: pl.DataType) -> None:
     lf = pl.LazyFrame(schema={"a": pl.Array(dtype, 2)})

--- a/py-polars/tests/unit/operations/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_array.py
@@ -453,6 +453,15 @@ def test_arr_dot_integer_overflow() -> None:
     )
 
 
+def test_arr_dot_integer_query_vector_coercion() -> None:
+    lhs = pl.Series("lhs", [[100, 100]], dtype=pl.Array(pl.Int8, 2))
+
+    assert_series_equal(
+        lhs.arr.dot([2, 2]),
+        pl.Series("lhs", [400], dtype=pl.Int64),
+    )
+
+
 @pytest.mark.parametrize(
     ("dtype", "maximum", "expected"),
     [

--- a/py-polars/tests/unit/operations/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_array.py
@@ -10,6 +10,7 @@ import polars as pl
 import polars.selectors as cs
 from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
+from tests.unit.conftest import INTEGER_DTYPES
 
 if TYPE_CHECKING:
     from tests.conftest import PlMonkeyPatch
@@ -231,6 +232,7 @@ def test_arr_dot_query_vector_expansion() -> None:
     [
         pytest.param(pl.Float32, pl.Float64, pl.Float64, id="f32-f64"),
         pytest.param(pl.Int32, pl.Float32, pl.Float64, id="i32-f32"),
+        pytest.param(pl.Int8, pl.Int16, pl.Int64, id="i8-i16"),
         pytest.param(pl.UInt64, pl.Int64, pl.Float64, id="u64-i64"),
     ],
 )
@@ -405,20 +407,61 @@ def test_arr_dot_wide(
     )
 
 
-@pytest.mark.parametrize(
-    "values",
-    [
-        pytest.param([[1, 2]], id="non-empty"),
-        pytest.param([], id="empty"),
-    ],
-)
-def test_arr_dot_unsupported_integer_dtype(values: list[list[int]]) -> None:
-    ints = pl.Series("a", values, dtype=pl.Array(pl.Int64, 2))
+@pytest.mark.parametrize("dtype", INTEGER_DTYPES)
+def test_arr_dot_integer_dtype(dtype: pl.DataType) -> None:
+    lhs = pl.Series(
+        "a",
+        [[1, None], [None, None], [3, 4]],
+        dtype=pl.Array(dtype, 2),
+    )
+    rhs = pl.Series(
+        "b",
+        [[10, 20], [30, 40], [50, 60]],
+        dtype=pl.Array(dtype, 2),
+    )
+    assert_series_equal(lhs.arr.dot(rhs), (lhs * rhs).arr.sum())
+
+    empty = pl.Series("a", [], dtype=pl.Array(dtype, 2))
+    assert_series_equal(empty.arr.dot(empty), (empty * empty).arr.sum())
+
+
+def test_arr_dot_integer_overflow() -> None:
+    df = pl.DataFrame(
+        {
+            "lhs": [[100, 100]],
+            "rhs": [[2, 2]],
+        },
+        schema={
+            "lhs": pl.Array(pl.Int8, 2),
+            "rhs": pl.Array(pl.Int8, 2),
+        },
+    )
+    q = df.lazy().select(pl.col("lhs").arr.dot("rhs"))
+
+    assert q.collect_schema() == {"lhs": pl.Int64}
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame({"lhs": [-112]}, schema={"lhs": pl.Int64}),
+    )
+
+    wide_dtype = pl.Array(pl.Int64, 2)
+    assert (
+        df.select(
+            pl.col("lhs").cast(wide_dtype).arr.dot(pl.col("rhs").cast(wide_dtype))
+        ).item()
+        == 400
+    )
+
+
+@pytest.mark.parametrize("dtype", [pl.Boolean, pl.Float16, pl.Decimal(10, 2)])
+def test_arr_dot_unsupported_inner_dtype(dtype: pl.DataType) -> None:
+    lf = pl.LazyFrame(schema={"a": pl.Array(dtype, 2)})
+
     with pytest.raises(
         InvalidOperationError,
-        match="supports inputs with a Float32 or Float64 supertype",
+        match="supports inputs with an integer, Float32, or Float64 supertype",
     ):
-        ints.arr.dot(ints)
+        lf.select(pl.col("a").arr.dot("a")).collect_schema()
 
 
 def test_arr_dot_non_array_operand() -> None:

--- a/py-polars/tests/unit/operations/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_array.py
@@ -489,7 +489,7 @@ def test_arr_dot_unsupported_inner_dtype(dtype: pl.DataType) -> None:
 
     with pytest.raises(
         InvalidOperationError,
-        match="supports inputs with an integer, Float32, or Float64 supertype",
+        match=r"arr\.dot does not support input dtypes",
     ):
         lf.select(pl.col("a").arr.dot("a")).collect_schema()
 

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -1005,6 +1005,12 @@ def test_list_sum_bool_schema() -> None:
     assert q.select(pl.col("x").list.sum()).collect_schema()["x"] == pl.get_index_type()
 
 
+def test_list_sum_decimal_schema() -> None:
+    dtype = pl.Decimal(10, 2)
+    q = pl.LazyFrame(schema={"x": pl.List(dtype)})
+    assert q.select(pl.col("x").list.sum()).collect_schema()["x"] == dtype
+
+
 def test_list_concat_struct_19279() -> None:
     df = pl.select(
         pl.struct(


### PR DESCRIPTION
Closes #28771

> Optimization implications and follow-up read in comments [here](https://github.com/pola-rs/polars/pull/28829#issuecomment-5309892611)

**Biggest lesson**

Integer arr.dot behavior is compatibility-driven rather than overflow-safe, which can be counterintuitive. It follows existing Polars arithmetic and arr.sum promotion rules, consistent with fixed-width NumPy and pandas dot-product semantics.

**Overflow**

Inputs first use standard supertype coercion. Multiplication occurs in that common inner dtype, then each product is converted to `arr.sum` output dtype and accumulated using wrapping addition.

Output dtype after standard supertype coercion:
- `Int8`, `UInt8`, `Int16`, and `UInt16` produce `Int64`
- `Int32`, `UInt32`, `Int64`, `UInt64`, `Int128`, and `UInt128` preserve that common inner dtype

In the following example `Int64` is only reduction/accumulator dtype.  Multiplication still occurs in `Int8`:
  ```text
Array(Int8)[100, 100] dot Array(Int8)[2, 2]

products in Int8: [100 × 2, 100 × 2] → [-56, -56]
sum in Int64:     -56 + -56 → -112
  ```
 Accumulation also wraps in output dtype:
  ```text
Array(Int32)[2147483647, 1] dot Array(Int32)[1, 1]

products in Int32: [2147483647 × 1, 1 × 1] → [2147483647, 1]
sum in Int32:      2147483647 + 1 → -2147483648
 ```
Mathematical result, 2147483648, cannot be represented by `Int32`, so wrapping addition returns -2147483648. This specific result also matches pandas.Series.dot and NumPy.dot.

```python
import numpy as np
import pandas as pd

a = pd.Series([2**31 - 1, 1], dtype="int32")
b = pd.Series([1, 1], dtype="int32")

pandas_result = a.dot(b)
numpy_result = np.dot(a.to_numpy(), b.to_numpy())

print(pandas_result, pandas_result.dtype)
print(numpy_result, numpy_result.dtype)
```
Output:

```
-2147483648 int32
-2147483648 int32
```
Promoting `Int32` only inside arr.dot would diverge from `(lhs * rhs).arr.sum()` and still would not prevent multiplication or arbitrary-length accumulation overflow.

**Benchmark**

My original Float32/Float64 arr.dot benchmark used small workload to demonstrate immediate benefit of native arr.dot over composed expression `(lhs * rhs).arr.sum()`. After implementing support for all signed and unsigned integer types from 8 to 128 bits, I reran and expanded benchmark across both execution engines, broadcast and row-wise inputs, and multiple thread-pool sizes. Everything on my Apple M4 Max 64GB RAM (32GB free), no cloud, no renting. 

I ran two benchmark families. Same-revision native-vs-composed comparison uses 65,280 (small) and 4,194,048 (large) multiplications per collection. A separate native-only thread-scaling experiment uses 16,776,960 multiplications.

Decluttered the following 2 plot-groups by keeping only 3 thread variants. Same-code-revision.

Primary evidence: same-revision native versus composed performance across all integer types and both engines.
<img width="950" height="1152" alt="m4-integer-dual-engine-large-speedup" src="https://github.com/user-attachments/assets/43297e5c-378b-4341-9fb2-cc5ab58b1ef3" />

Latency guard: shows small-workload behavior and prevents large-workload cherry-picking.
<img width="950" height="1152" alt="m4-integer-dual-engine-small-guard" src="https://github.com/user-attachments/assets/f37b737f-2a66-4633-ba88-32c3cf4bc9c3" />

Allocation evidence: paired heap-capacity requests during `collect`. Positive values mean native requests less allocation. Percentages are relative to the size of one intermediate product array, not total process memory.

```text
100 × (composed allocation − native allocation) / (rows × width × sizeof(inner_dtype))

+100% → native avoids allocation equal to one product buffer
   0% → equal allocation
 −33% → native allocates 33% of one product buffer more
```
<img width="979" height="979" alt="m4-integer-arr-dot-portable-allocation" src="https://github.com/user-attachments/assets/db19ba8d-6831-40cd-82e3-ac112b60b89e" />


> So, native kernel is very efficient, but in-memory engine executes output-row loop serially. Streaming engine partitions input into morsels and evaluates same kernel concurrently. 
> 
> Throughput shows absolute native arr.dot capacity and thread scaling. On :point_down: plot, in-memory throughput stays nearly flat as threads increase, while streaming throughput scales materially.

<img width="950" height="1152" alt="m4-integer-native-sustained-throughput" src="https://github.com/user-attachments/assets/31e0722a-0d69-4697-b2b3-cf910b97fb6f" />

> Unrelated: I wanted to understand advantages of each engine on my local machine and confirm that Polars Cloud does not rely on a secret private engine :smile: