### PR TITLE
docs(rust): Clarify "that that side" comment in asof_join

### DIFF
--- a/crates/polars-stream/src/nodes/joins/asof_join.rs
+++ b/crates/polars-stream/src/nodes/joins/asof_join.rs
@@ -92,7 +92,7 @@ pub struct AsOfJoinNode {
     right_buffer: DataFrameSearchBuffer,
     output_seq: MorselSeq,
     // Slots to store the last non-null row of the previous morsel.
-    // Used to check that that side is sorted across morsel boundaries.
+    // Used to check that each side is sorted across morsel boundaries.
     last_non_null_row_left: Option<DataFrame>,
     last_non_null_row_right: Option<DataFrame>,
 }


### PR DESCRIPTION
## What
Reword the comment above `last_non_null_row_left`/`last_non_null_row_right` in `asof_join.rs`: "check that that side is sorted" → "check that each side is sorted". The doubled "that" was awkward and its referent ambiguous, since the comment documents two slots (left and right).

## Why
A small, objectively-verifiable docs improvement found during a weekly open-source maintenance pass (2026-W34).

## How verified
Comment-only change; re-read in context of the two fields it documents. Automated gates: 2 changed lines across 1 file (within limits); cargo check: passed (polars-stream).

---
Prepared with Claude Code assistance and reviewed by Aarush's automation gates (diff-size, file-scope, deletion, and build checks) before opening.