### PR TITLE
refactor(rust): Use thread-local only for staging new morsels in ooc

### DIFF
--- a/crates/polars-ooc/src/memory_manager.rs
+++ b/crates/polars-ooc/src/memory_manager.rs
@@ -12,8 +12,8 @@ use tokio::sync::{Mutex as AsyncMutex, Semaphore as AsyncSemaphore};
 // for spillables.
 const EXPLORE_BEYOND_BEST_SCORE_THRESHOLD: f64 = 20.0;
 
-// Size in bytes of SpillFrame candidates we'll drain per attempt for a context.
-const SPILL_FRAME_BATCH_SIZE: u64 = 1024 * 1024 * 16;
+// Maximum number of SpillFrame candidates we'll consider per attempt.
+const SPILL_FRAME_BATCH_SIZE: u64 = 256;
 
 const MAX_PARALLEL_SPILL_TASKS: usize = 64;
 
@@ -186,6 +186,7 @@ impl MemoryManager {
             strong.stats().start_exploration_event();
 
             let mut total_est_spill = 0;
+            let mut num_considered = 0;
             let mut candidates = Vec::new();
             ctx.0.drain_while(|cand, reg_id| {
                 if cand.can_spill()
@@ -199,7 +200,9 @@ impl MemoryManager {
                         ctx.0.reinsert(&cand, reg_id, ctx.1);
                     }
                 }
-                total_est_spill < SPILL_FRAME_BATCH_SIZE
+
+                num_considered += 1;
+                num_considered < SPILL_FRAME_BATCH_SIZE
             });
 
             if candidates.is_empty() {

--- a/crates/polars-ooc/src/memory_manager.rs
+++ b/crates/polars-ooc/src/memory_manager.rs
@@ -12,6 +12,9 @@ use tokio::sync::{Mutex as AsyncMutex, Semaphore as AsyncSemaphore};
 // for spillables.
 const EXPLORE_BEYOND_BEST_SCORE_THRESHOLD: f64 = 20.0;
 
+// Size in bytes of SpillFrame candidates we'll drain per attempt for a context.
+const SPILL_FRAME_BATCH_SIZE: u64 = 1024 * 1024 * 16;
+
 const MAX_PARALLEL_SPILL_TASKS: usize = 64;
 
 use crate::WeakSpillContext;
@@ -184,7 +187,7 @@ impl MemoryManager {
 
             let mut total_est_spill = 0;
             let mut candidates = Vec::new();
-            for (cand, reg_id) in ctx.0.pop() {
+            ctx.0.drain_while(|cand, reg_id| {
                 if cand.can_spill()
                     && let Some(sz) = cand.estimate_byte_size()
                     && sz as u64 >= min_spill
@@ -196,7 +199,8 @@ impl MemoryManager {
                         ctx.0.reinsert(&cand, reg_id, ctx.1);
                     }
                 }
-            }
+                total_est_spill < SPILL_FRAME_BATCH_SIZE
+            });
 
             if candidates.is_empty() {
                 strong.stats().finish_exploration_event(false);

--- a/crates/polars-ooc/src/spill_context/mod.rs
+++ b/crates/polars-ooc/src/spill_context/mod.rs
@@ -1,4 +1,3 @@
-use std::cmp::Reverse;
 use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
@@ -59,7 +58,7 @@ impl LocalStagingArea {
     }
 
     pub fn drain_into(&mut self, target: &mut Vec<RegisteredSpillToken>) {
-        target.extend(self.tokens.drain(..));
+        target.append(&mut self.tokens);
         self.retain_amort = 0;
     }
 
@@ -82,11 +81,6 @@ impl SpillQueue {
     pub fn push_back(&mut self, token: &Arc<dyn DynSpillToken>, id: u32) {
         self.gc();
         self.tokens.push_back(RegisteredSpillToken::new(token, id));
-    }
-
-    pub fn push_front(&mut self, token: &Arc<dyn DynSpillToken>, id: u32) {
-        self.gc();
-        self.tokens.push_front(RegisteredSpillToken::new(token, id));
     }
 
     pub fn pop_front(&mut self) -> Option<(Arc<dyn DynSpillToken>, u32)> {
@@ -169,9 +163,11 @@ impl SpillContextInner {
         }
     }
 
-    fn drain_staging(&self, queue: &mut SpillQueue) {
-        if self.staging_empty.load(Ordering::Relaxed)
-            || self.staging_empty.swap(true, Ordering::AcqRel)
+    // We need forced locking to make reset not leave orphan spillframes.
+    fn drain_staging(&self, queue: &mut SpillQueue, force_lock: bool) {
+        if !force_lock
+            && (self.staging_empty.load(Ordering::Relaxed)
+                || self.staging_empty.swap(true, Ordering::AcqRel))
         {
             return;
         }
@@ -202,7 +198,7 @@ impl SpillContextInner {
         self.stats.reset(name);
 
         let mut queue = self.spill_queue.lock().unwrap();
-        self.drain_staging(&mut queue);
+        self.drain_staging(&mut queue, true);
         while let Some(t) = queue.pop_back() {
             t.0.unregister();
         }
@@ -225,7 +221,7 @@ impl SpillContextInner {
         let policy = self.policy();
 
         let mut queue = self.spill_queue.lock().unwrap();
-        self.drain_staging(&mut queue);
+        self.drain_staging(&mut queue, false);
 
         while let Some((cand, reg_id)) = match policy {
             SpillContextPolicy::MostRecent => queue.pop_back(),
@@ -239,14 +235,11 @@ impl SpillContextInner {
     }
 
     pub(crate) fn reinsert(&self, token: &Arc<dyn DynSpillToken>, reg_id: u32, ctx_id: u64) {
+        let mut local = self.staging.get_or_default().lock().unwrap();
         if ctx_id != self.context_id.load(Ordering::Relaxed) {
             return;
         }
-
-        {
-            let mut local = self.staging.get_or_default().lock().unwrap();
-            local.push(token, reg_id);
-        }
+        local.push(token, reg_id);
 
         if self.staging_empty.load(Ordering::Relaxed) {
             self.staging_empty.swap(false, Ordering::AcqRel);

--- a/crates/polars-ooc/src/spill_context/mod.rs
+++ b/crates/polars-ooc/src/spill_context/mod.rs
@@ -182,18 +182,15 @@ impl SpillContextInner {
         }
 
         match self.policy() {
-            SpillContextPolicy::MostRecent => staged_tokens.sort_by_key(|t| Reverse(t.timestamp)),
-            SpillContextPolicy::LeastRecent => staged_tokens.sort_by_key(|t| t.timestamp),
+            SpillContextPolicy::MostRecent | SpillContextPolicy::LeastRecent => {
+                staged_tokens.sort_by_key(|t| t.timestamp)
+            },
             SpillContextPolicy::Random => {},
         }
 
         for token in staged_tokens {
             if let Some(t) = token.token.upgrade() {
-                match self.policy() {
-                    SpillContextPolicy::MostRecent => queue.push_front(&t, token.registration_id),
-                    SpillContextPolicy::LeastRecent => queue.push_back(&t, token.registration_id),
-                    SpillContextPolicy::Random => queue.push_back(&t, token.registration_id),
-                }
+                queue.push_back(&t, token.registration_id);
             }
         }
     }
@@ -366,6 +363,9 @@ impl WeakSpillContext {
         let mut local = self.0.staging.get_or_default().lock().unwrap();
         if self.0.context_id() == self.1 {
             local.push(&dyn_arc, dyn_arc.register(self.clone(), param));
+            if self.0.staging_empty.load(Ordering::Relaxed) {
+                self.0.staging_empty.swap(false, Ordering::AcqRel);
+            }
         }
     }
 }

--- a/crates/polars-ooc/src/spill_context/mod.rs
+++ b/crates/polars-ooc/src/spill_context/mod.rs
@@ -1,9 +1,11 @@
+use std::cmp::Reverse;
 use std::collections::VecDeque;
 use std::fmt::Debug;
-use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, RwLock, Weak};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, Weak};
 
 use polars_utils::pl_str::PlSmallStr;
+use polars_utils::tick_counter::tick_counter;
 use rand::RngExt;
 use rand::rngs::ThreadRng;
 use thread_local::ThreadLocal;
@@ -21,45 +23,86 @@ fn new_context_id() -> u64 {
     CONTEXT_ID_CTR.fetch_add(1, Ordering::Relaxed)
 }
 
+pub struct RegisteredSpillToken {
+    token: Weak<dyn DynSpillToken>,
+    registration_id: u32,
+    timestamp: u64,
+}
+
+impl RegisteredSpillToken {
+    fn new(token: &Arc<dyn DynSpillToken>, registration_id: u32) -> Self {
+        RegisteredSpillToken {
+            token: Arc::downgrade(token),
+            registration_id,
+            timestamp: tick_counter(),
+        }
+    }
+
+    fn upgrade(&self) -> Option<(Arc<dyn DynSpillToken>, u32)> {
+        self.token
+            .upgrade()
+            .filter(|t| t.current_registration_id() == self.registration_id)
+            .map(|t| (t, self.registration_id))
+    }
+}
+
 #[derive(Default)]
-struct LocalSpillQueue {
-    tokens: VecDeque<(Weak<dyn DynSpillToken>, u32)>,
+struct LocalStagingArea {
+    tokens: Vec<RegisteredSpillToken>,
     retain_amort: usize,
 }
 
-impl LocalSpillQueue {
+impl LocalStagingArea {
+    pub fn push(&mut self, token: &Arc<dyn DynSpillToken>, id: u32) {
+        self.gc();
+        self.tokens.push(RegisteredSpillToken::new(token, id));
+    }
+
+    pub fn drain_into(&mut self, target: &mut Vec<RegisteredSpillToken>) {
+        target.extend(self.tokens.drain(..));
+        self.retain_amort = 0;
+    }
+
+    fn gc(&mut self) {
+        self.retain_amort += 2; // Grows twice as fast as push.
+        if self.retain_amort >= self.tokens.len() {
+            self.retain_amort = 0;
+            self.tokens.retain(|t| t.upgrade().is_some());
+        }
+    }
+}
+
+#[derive(Default)]
+struct SpillQueue {
+    tokens: VecDeque<RegisteredSpillToken>,
+    retain_amort: usize,
+}
+
+impl SpillQueue {
     pub fn push_back(&mut self, token: &Arc<dyn DynSpillToken>, id: u32) {
         self.gc();
-        if token.current_registration_id() == id {
-            self.tokens.push_back((Arc::downgrade(token), id));
-        }
+        self.tokens.push_back(RegisteredSpillToken::new(token, id));
     }
 
     pub fn push_front(&mut self, token: &Arc<dyn DynSpillToken>, id: u32) {
         self.gc();
-        if token.current_registration_id() == id {
-            self.tokens.push_front((Arc::downgrade(token), id));
-        }
+        self.tokens.push_front(RegisteredSpillToken::new(token, id));
     }
 
     pub fn pop_front(&mut self) -> Option<(Arc<dyn DynSpillToken>, u32)> {
         loop {
-            let (weak, id) = self.tokens.pop_front()?;
-            if let Some(token) = weak.upgrade()
-                && token.current_registration_id() == id
-            {
-                return Some((token, id));
+            let front = self.tokens.pop_front()?;
+            if let Some(r) = front.upgrade() {
+                return Some(r);
             }
         }
     }
 
     pub fn pop_back(&mut self) -> Option<(Arc<dyn DynSpillToken>, u32)> {
         loop {
-            let (weak, id) = self.tokens.pop_back()?;
-            if let Some(token) = weak.upgrade()
-                && token.current_registration_id() == id
-            {
-                return Some((token, id));
+            let back = self.tokens.pop_back()?;
+            if let Some(r) = back.upgrade() {
+                return Some(r);
             }
         }
     }
@@ -67,11 +110,9 @@ impl LocalSpillQueue {
     pub fn pop_random(&mut self, rng: &mut ThreadRng) -> Option<(Arc<dyn DynSpillToken>, u32)> {
         while !self.tokens.is_empty() {
             let idx = rng.random_range(0..self.tokens.len());
-            let (weak, id) = self.tokens.swap_remove_back(idx).unwrap();
-            if let Some(token) = weak.upgrade()
-                && token.current_registration_id() == id
-            {
-                return Some((token, id));
+            let back = self.tokens.swap_remove_back(idx)?;
+            if let Some(r) = back.upgrade() {
+                return Some(r);
             }
         }
         None
@@ -81,11 +122,7 @@ impl LocalSpillQueue {
         self.retain_amort += 2; // Grows twice as fast as push.
         if self.retain_amort >= self.tokens.len() {
             self.retain_amort = 0;
-            self.tokens.retain(|(token, id)| {
-                token
-                    .upgrade()
-                    .is_some_and(|t| t.current_registration_id() == *id)
-            });
+            self.tokens.retain(|t| t.upgrade().is_some());
         }
     }
 }
@@ -109,7 +146,9 @@ impl SpillContextPolicy {
 }
 
 pub(crate) struct SpillContextInner {
-    local: ThreadLocal<RwLock<LocalSpillQueue>>,
+    staging: ThreadLocal<Mutex<LocalStagingArea>>,
+    staging_empty: AtomicBool,
+    spill_queue: Mutex<SpillQueue>,
     stats: Arc<SpillContextStatistics>,
     policy: AtomicU8,
     refcount: AtomicU64,
@@ -120,7 +159,9 @@ impl SpillContextInner {
     fn new(name: PlSmallStr, policy: SpillContextPolicy) -> Self {
         let ctx_id = new_context_id();
         Self {
-            local: ThreadLocal::default(),
+            staging: ThreadLocal::default(),
+            staging_empty: AtomicBool::new(true),
+            spill_queue: Mutex::default(),
             stats: Arc::new(SpillContextStatistics::new(name)),
             policy: AtomicU8::new(policy as u8),
             refcount: AtomicU64::new(0),
@@ -128,57 +169,90 @@ impl SpillContextInner {
         }
     }
 
+    fn drain_staging(&self, queue: &mut SpillQueue) {
+        if self.staging_empty.load(Ordering::Relaxed)
+            || self.staging_empty.swap(true, Ordering::AcqRel)
+        {
+            return;
+        }
+
+        let mut staged_tokens = Vec::new();
+        for local in self.staging.iter() {
+            local.lock().unwrap().drain_into(&mut staged_tokens);
+        }
+
+        match self.policy() {
+            SpillContextPolicy::MostRecent => staged_tokens.sort_by_key(|t| Reverse(t.timestamp)),
+            SpillContextPolicy::LeastRecent => staged_tokens.sort_by_key(|t| t.timestamp),
+            SpillContextPolicy::Random => {},
+        }
+
+        for token in staged_tokens {
+            if let Some(t) = token.token.upgrade() {
+                match self.policy() {
+                    SpillContextPolicy::MostRecent => queue.push_front(&t, token.registration_id),
+                    SpillContextPolicy::LeastRecent => queue.push_back(&t, token.registration_id),
+                    SpillContextPolicy::Random => queue.push_back(&t, token.registration_id),
+                }
+            }
+        }
+    }
+
     fn reset(&self, name: PlSmallStr, policy: SpillContextPolicy) {
         let ctx_id = new_context_id();
         self.context_id.store(ctx_id, Ordering::Relaxed);
         self.policy.store(policy as u8, Ordering::Relaxed);
-        for local_lock in self.local.iter() {
-            let mut local = local_lock.write().unwrap();
-            while let Some(token) = local.pop_back() {
-                token.0.unregister();
-            }
-        }
         self.stats.reset(name);
+
+        let mut queue = self.spill_queue.lock().unwrap();
+        self.drain_staging(&mut queue);
+        while let Some(t) = queue.pop_back() {
+            t.0.unregister();
+        }
     }
 
-    pub fn context_id(&self) -> u64 {
+    fn context_id(&self) -> u64 {
         self.context_id.load(Ordering::Relaxed)
     }
 
-    pub fn policy(&self) -> SpillContextPolicy {
+    fn policy(&self) -> SpillContextPolicy {
         SpillContextPolicy::from_u8(self.policy.load(Ordering::Relaxed))
     }
 
-    pub fn stats(&self) -> &Arc<SpillContextStatistics> {
+    pub(crate) fn stats(&self) -> &Arc<SpillContextStatistics> {
         &self.stats
     }
 
-    pub fn pop(&self) -> Vec<(Arc<dyn DynSpillToken>, u32)> {
-        let mut out = Vec::new();
+    pub(crate) fn drain_while<F: FnMut(Arc<dyn DynSpillToken>, u32) -> bool>(&self, mut f: F) {
         let mut rng = rand::rng();
         let policy = self.policy();
-        for local_lock in self.local.iter() {
-            if let Ok(mut local) = local_lock.try_write() {
-                out.extend(match policy {
-                    SpillContextPolicy::MostRecent => local.pop_back(),
-                    SpillContextPolicy::LeastRecent => local.pop_front(),
-                    SpillContextPolicy::Random => local.pop_random(&mut rng),
-                });
+
+        let mut queue = self.spill_queue.lock().unwrap();
+        self.drain_staging(&mut queue);
+
+        while let Some((cand, reg_id)) = match policy {
+            SpillContextPolicy::MostRecent => queue.pop_back(),
+            SpillContextPolicy::LeastRecent => queue.pop_front(),
+            SpillContextPolicy::Random => queue.pop_random(&mut rng),
+        } {
+            if !f(cand, reg_id) {
+                break;
             }
         }
-        out
     }
 
-    pub fn reinsert(&self, token: &Arc<dyn DynSpillToken>, reg_id: u32, ctx_id: u64) {
-        let mut local = self.local.get_or_default().write().unwrap();
+    pub(crate) fn reinsert(&self, token: &Arc<dyn DynSpillToken>, reg_id: u32, ctx_id: u64) {
         if ctx_id != self.context_id.load(Ordering::Relaxed) {
             return;
         }
 
-        match self.policy() {
-            SpillContextPolicy::MostRecent => local.push_front(token, reg_id),
-            SpillContextPolicy::LeastRecent => local.push_back(token, reg_id),
-            SpillContextPolicy::Random => local.push_back(token, reg_id),
+        {
+            let mut local = self.staging.get_or_default().lock().unwrap();
+            local.push(token, reg_id);
+        }
+
+        if self.staging_empty.load(Ordering::Relaxed) {
+            self.staging_empty.swap(false, Ordering::AcqRel);
         }
     }
 }
@@ -210,6 +284,24 @@ impl StrongSpillContext {
 
     pub fn downgrade(&self) -> WeakSpillContext {
         WeakSpillContext(self.0, self.0.context_id())
+    }
+
+    fn register_no_spill_check<T, S>(&self, token: &T)
+    where
+        T: AsRef<SpillToken<S>>,
+        S: Spillable,
+    {
+        let dyn_arc = token.as_ref().upcast();
+        let reg_id = dyn_arc.register(self.downgrade(), SpillContextParam(()));
+
+        {
+            let mut local = self.0.staging.get_or_default().lock().unwrap();
+            local.push(&dyn_arc, reg_id);
+        }
+
+        if self.0.staging_empty.load(Ordering::Relaxed) {
+            self.0.staging_empty.swap(false, Ordering::AcqRel);
+        }
     }
 }
 
@@ -271,9 +363,9 @@ impl WeakSpillContext {
         S: Spillable,
     {
         let dyn_arc = token.as_ref().upcast();
-        let mut local = self.0.local.get_or_default().write().unwrap();
+        let mut local = self.0.staging.get_or_default().lock().unwrap();
         if self.0.context_id() == self.1 {
-            local.push_back(&dyn_arc, dyn_arc.register(self.clone(), param));
+            local.push(&dyn_arc, dyn_arc.register(self.clone(), param));
         }
     }
 }
@@ -316,12 +408,7 @@ impl ParameterFreeSpillContext for MostRecentSpillContext {
         T: AsRef<SpillToken<S>>,
         S: Spillable,
     {
-        let dyn_arc = token.as_ref().upcast();
-        let mut local = self.0.0.local.get_or_default().write().unwrap();
-        local.push_back(
-            &dyn_arc,
-            dyn_arc.register(self.0.downgrade(), SpillContextParam(())),
-        );
+        self.0.register_no_spill_check(token);
     }
 }
 
@@ -353,12 +440,7 @@ impl ParameterFreeSpillContext for LeastRecentSpillContext {
         T: AsRef<SpillToken<S>>,
         S: Spillable,
     {
-        let dyn_arc = token.as_ref().upcast();
-        let mut local = self.0.0.local.get_or_default().write().unwrap();
-        local.push_back(
-            &dyn_arc,
-            dyn_arc.register(self.0.downgrade(), SpillContextParam(())),
-        );
+        self.0.register_no_spill_check(token);
     }
 }
 
@@ -386,12 +468,7 @@ impl ParameterFreeSpillContext for RandomSpillContext {
         T: AsRef<SpillToken<S>>,
         S: Spillable,
     {
-        let dyn_arc = token.as_ref().upcast();
-        let mut local = self.0.0.local.get_or_default().write().unwrap();
-        local.push_back(
-            &dyn_arc,
-            dyn_arc.register(self.0.downgrade(), SpillContextParam(())),
-        );
+        self.0.register_no_spill_check(token);
     }
 }
 

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -68,6 +68,7 @@ pub mod small_bytes;
 pub mod sort;
 pub mod sparse_init_vec;
 pub mod sync;
+pub mod tick_counter;
 pub mod total_ord;
 pub mod unique_id;
 pub mod vec;

--- a/crates/polars-utils/src/tick_counter.rs
+++ b/crates/polars-utils/src/tick_counter.rs
@@ -1,0 +1,36 @@
+/// **Unsynchronized** tick counter.
+///
+/// This is intended to be used to *roughly* organize events across threads in
+/// their received order but without any actual guarantees around monotonicity
+/// or synchronization, for maximum speed.
+///
+/// This does not guarantee monotonicity or any particular (fixed) time unit.
+/// If correctness matters use Instant::now().
+#[inline]
+pub fn tick_counter() -> u64 {
+    cfg_select! {
+        target_arch = "x86_64" => {
+            unsafe { core::arch::x86_64::_rdtsc() }
+        }
+
+        target_arch = "aarch64" => {
+            let cnt: u64;
+            unsafe {
+                core::arch::asm!(
+                    "mrs {cnt}, cntvct_el0",
+                    cnt = out(reg) cnt,
+                    options(nomem, nostack, preserves_flags),
+                );
+            }
+            cnt
+        }
+
+        _ => {
+            use std::sync::LazyLock;
+            use std::time::Instant;
+
+            static REFERENCE_INSTANT: LazyLock<Instant> = LazyLock::new(Instant::now);
+            REFERENCE_INSTANT.elapsed().as_nanos() as u64
+        }
+    }
+}

--- a/crates/polars-utils/src/tick_counter.rs
+++ b/crates/polars-utils/src/tick_counter.rs
@@ -9,9 +9,7 @@
 #[inline]
 pub fn tick_counter() -> u64 {
     cfg_select! {
-        target_arch = "x86_64" => {
-            unsafe { core::arch::x86_64::_rdtsc() }
-        }
+        target_arch = "x86_64" => unsafe { core::arch::x86_64::_rdtsc() },
 
         target_arch = "aarch64" => {
             let cnt: u64;
@@ -23,7 +21,7 @@ pub fn tick_counter() -> u64 {
                 );
             }
             cnt
-        }
+        },
 
         _ => {
             use std::sync::LazyLock;
@@ -31,6 +29,6 @@ pub fn tick_counter() -> u64 {
 
             static REFERENCE_INSTANT: LazyLock<Instant> = LazyLock::new(Instant::now);
             REFERENCE_INSTANT.elapsed().as_nanos() as u64
-        }
+        },
     }
 }


### PR DESCRIPTION
Instead of storing the entire state in thread-locals we only stage morsels in thread-locals,  moving them to a shared data structure when actually making spilling decisions.