### PR TITLE
fix: Invalidate suborders on projection

### DIFF
--- a/crates/polars-plan/src/plans/functions/hint.rs
+++ b/crates/polars-plan/src/plans/functions/hint.rs
@@ -34,20 +34,15 @@ impl HintIR {
     {
         match self {
             Self::Sorted(s) => {
-                let Some(i) = s.iter().position(|s| f(&s.column)) else {
-                    return false;
-                };
-
-                *s = s
-                    .get(i)
-                    .into_iter()
-                    .chain(s.iter().skip(1 + i).filter(|s| f(&s.column)))
-                    .cloned()
-                    .collect()
-            },
+                // If a column was removed all later columns in the sort order are also
+                // invalid.
+                if let Some(first_invalidated) = s.iter().position(|s| !f(&s.column)) {
+                    *s = s[..first_invalidated].iter().cloned().collect();
+                }
+                
+                !s.is_empty()
+            }
         }
-
-        true
     }
 }
 

--- a/crates/polars-plan/src/plans/functions/hint.rs
+++ b/crates/polars-plan/src/plans/functions/hint.rs
@@ -39,9 +39,9 @@ impl HintIR {
                 if let Some(first_invalidated) = s.iter().position(|s| !f(&s.column)) {
                     *s = s[..first_invalidated].iter().cloned().collect();
                 }
-                
+
                 !s.is_empty()
-            }
+            },
         }
     }
 }

--- a/py-polars/tests/unit/lazyframe/test_order_observability.py
+++ b/py-polars/tests/unit/lazyframe/test_order_observability.py
@@ -828,3 +828,9 @@ def test_order_simplify_expr_slice_28028() -> None:
     assert ".slice(" in plan
 
     assert q.collect().item() == 2
+
+
+def test_order_project_invalidates_suborder_28831() -> None:
+    lf = pl.LazyFrame({"a": [1, 1, 2, 2], "b": [5, 10, 2, 4]})
+    out = lf.set_sorted("a", "b").select(pl.col("b").max()).collect().item()
+    assert out == 4

--- a/py-polars/tests/unit/lazyframe/test_order_observability.py
+++ b/py-polars/tests/unit/lazyframe/test_order_observability.py
@@ -833,4 +833,4 @@ def test_order_simplify_expr_slice_28028() -> None:
 def test_order_project_invalidates_suborder_28831() -> None:
     lf = pl.LazyFrame({"a": [1, 1, 2, 2], "b": [5, 10, 2, 4]})
     out = lf.set_sorted("a", "b").select(pl.col("b").max()).collect().item()
-    assert out == 4
+    assert out == 10


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/28831.

If a DataFrame is sorted on `a, b` and we project out `a`, we can't keep the sortedness of `b` since it was dependent on being sorted on `a` first.