### PR TITLE
fix(rust): Do not require ordering on sql joins

### DIFF
--- a/crates/polars-sql/tests/statements.rs
+++ b/crates/polars-sql/tests/statements.rs
@@ -641,8 +641,18 @@ fn test_implicit_join_unqualified_column() {
             SELECT df1.a, df1.b, df3.c FROM df1
             INNER JOIN df3 ON df1.a = df3.c
         "#;
-        let actual = implicit_lf.collect().unwrap();
-        let expected = ctx.execute(explicit_sql).unwrap().collect().unwrap();
+        let actual = implicit_lf
+            .collect()
+            .unwrap()
+            .sort(["a", "b", "c"], Default::default())
+            .unwrap();
+        let expected = ctx
+            .execute(explicit_sql)
+            .unwrap()
+            .collect()
+            .unwrap()
+            .sort(["a", "b", "c"], Default::default())
+            .unwrap();
         assert!(
             actual.equals(&expected),
             "implicit join with unqualified column should match explicit join\nimplicit={actual:?}\nexplicit={expected:?}"


### PR DESCRIPTION
In `2.0` the execution is updated to the streaming engine, which does not have order-maintaining joins. That breaks this test. This patch updates this test so that we preemptively allow the join output to be shuffled.

Related PR: https://github.com/pola-rs/polars/pull/28854