### PR TITLE
perf: Add private env var toggle for HTTP rate limit

### DIFF
--- a/crates/polars-config/src/lib.rs
+++ b/crates/polars-config/src/lib.rs
@@ -109,6 +109,9 @@ const DEFAULT_NUMA_AWARE: bool = false;
 const NUMA_MOCK_REGIONS: &str = "POLARS_NUMA_MOCK_REGIONS";
 const DEFAULT_NUMA_MOCK_REGIONS: u64 = 0;
 
+const DISABLE_RATE_LIMIT: &str = "POLARS_DISABLE_RATE_LIMIT";
+const DEFAULT_DISABLE_RATE_LIMIT: bool = false;
+
 static KNOWN_OPTIONS: &[&str] = &[
     // Public.
     VERBOSE,
@@ -162,6 +165,7 @@ static KNOWN_OPTIONS: &[&str] = &[
     DNS_LOG_THRESHOLD_MS,
     NUMA_AWARE,
     NUMA_MOCK_REGIONS,
+    DISABLE_RATE_LIMIT,
 ];
 
 pub struct Config {
@@ -194,6 +198,7 @@ pub struct Config {
     dns_log_threshold_ms: AtomicU64,
     numa_aware: AtomicBool,
     numa_mock_regions: AtomicU64,
+    disable_rate_limit: AtomicBool,
 }
 
 impl Config {
@@ -238,6 +243,7 @@ impl Config {
             dns_log_threshold_ms: AtomicU64::new(DNS_LOG_THRESHOLD_DISABLED),
             numa_aware: AtomicBool::new(DEFAULT_NUMA_AWARE),
             numa_mock_regions: AtomicU64::new(DEFAULT_NUMA_MOCK_REGIONS),
+            disable_rate_limit: AtomicBool::new(DEFAULT_DISABLE_RATE_LIMIT),
         };
         cfg.reload_env_vars();
         cfg
@@ -403,6 +409,11 @@ impl Config {
             NUMA_MOCK_REGIONS => self.numa_mock_regions.store(
                 val.and_then(|x| parse::parse_u64(var, x))
                     .unwrap_or(DEFAULT_NUMA_MOCK_REGIONS),
+                Ordering::Relaxed,
+            ),
+            DISABLE_RATE_LIMIT => self.disable_rate_limit.store(
+                val.and_then(|x| parse::parse_bool(var, x))
+                    .unwrap_or(DEFAULT_DISABLE_RATE_LIMIT),
                 Ordering::Relaxed,
             ),
             _ => {
@@ -577,6 +588,11 @@ impl Config {
     #[inline(always)]
     pub fn numa_mock_regions(&self) -> u64 {
         self.numa_mock_regions.load(Ordering::Relaxed)
+    }
+
+    #[inline(always)]
+    pub fn disable_rate_limit(&self) -> bool {
+        self.disable_rate_limit.load(Ordering::Relaxed)
     }
 }
 

--- a/crates/polars-config/src/lib.rs
+++ b/crates/polars-config/src/lib.rs
@@ -109,8 +109,8 @@ const DEFAULT_NUMA_AWARE: bool = false;
 const NUMA_MOCK_REGIONS: &str = "POLARS_NUMA_MOCK_REGIONS";
 const DEFAULT_NUMA_MOCK_REGIONS: u64 = 0;
 
-const DISABLE_RATE_LIMIT: &str = "POLARS_DISABLE_RATE_LIMIT";
-const DEFAULT_DISABLE_RATE_LIMIT: bool = false;
+const DISABLE_HTTP_RATE_LIMIT: &str = "POLARS_DISABLE_HTTP_RATE_LIMIT";
+const DEFAULT_DISABLE_HTTP_RATE_LIMIT: bool = false;
 
 static KNOWN_OPTIONS: &[&str] = &[
     // Public.
@@ -165,7 +165,7 @@ static KNOWN_OPTIONS: &[&str] = &[
     DNS_LOG_THRESHOLD_MS,
     NUMA_AWARE,
     NUMA_MOCK_REGIONS,
-    DISABLE_RATE_LIMIT,
+    DISABLE_HTTP_RATE_LIMIT,
 ];
 
 pub struct Config {
@@ -198,7 +198,7 @@ pub struct Config {
     dns_log_threshold_ms: AtomicU64,
     numa_aware: AtomicBool,
     numa_mock_regions: AtomicU64,
-    disable_rate_limit: AtomicBool,
+    disable_http_rate_limit: AtomicBool,
 }
 
 impl Config {
@@ -243,7 +243,7 @@ impl Config {
             dns_log_threshold_ms: AtomicU64::new(DNS_LOG_THRESHOLD_DISABLED),
             numa_aware: AtomicBool::new(DEFAULT_NUMA_AWARE),
             numa_mock_regions: AtomicU64::new(DEFAULT_NUMA_MOCK_REGIONS),
-            disable_rate_limit: AtomicBool::new(DEFAULT_DISABLE_RATE_LIMIT),
+            disable_http_rate_limit: AtomicBool::new(DEFAULT_DISABLE_HTTP_RATE_LIMIT),
         };
         cfg.reload_env_vars();
         cfg
@@ -411,9 +411,9 @@ impl Config {
                     .unwrap_or(DEFAULT_NUMA_MOCK_REGIONS),
                 Ordering::Relaxed,
             ),
-            DISABLE_RATE_LIMIT => self.disable_rate_limit.store(
+            DISABLE_HTTP_RATE_LIMIT => self.disable_http_rate_limit.store(
                 val.and_then(|x| parse::parse_bool(var, x))
-                    .unwrap_or(DEFAULT_DISABLE_RATE_LIMIT),
+                    .unwrap_or(DEFAULT_DISABLE_HTTP_RATE_LIMIT),
                 Ordering::Relaxed,
             ),
             _ => {
@@ -591,8 +591,8 @@ impl Config {
     }
 
     #[inline(always)]
-    pub fn disable_rate_limit(&self) -> bool {
-        self.disable_rate_limit.load(Ordering::Relaxed)
+    pub fn disable_http_rate_limit(&self) -> bool {
+        self.disable_http_rate_limit.load(Ordering::Relaxed)
     }
 }
 

--- a/crates/polars-io/src/cloud/http_rate_limit.rs
+++ b/crates/polars-io/src/cloud/http_rate_limit.rs
@@ -52,8 +52,8 @@ use crate::cloud::{CloudDirectionalRateLimitConfig, CloudRateLimitConfig};
 static CONTROLLER_ID: AtomicU32 = AtomicU32::new(0);
 
 // Verbose.
-static LOG_RATE_LIMIT: LazyLock<bool> =
-    LazyLock::new(|| std::env::var("POLARS_LOG_RATE_LIMIT").is_ok());
+static LOG_HTTP_RATE_LIMIT: LazyLock<bool> =
+    LazyLock::new(|| std::env::var("POLARS_LOG_HTTP_RATE_LIMIT").is_ok());
 
 // Request/s rate init and boundaries.
 const DEFAULT_INIT_RATE: f64 = 1000.0;
@@ -553,7 +553,7 @@ impl AdaptiveRateController {
         };
 
         // Log.
-        if *LOG_RATE_LIMIT {
+        if *LOG_HTTP_RATE_LIMIT {
             eprintln!(
                 "[http rate_limit #{}_{} {}] ..cut (anchored): rate: {:.1}, success_rate: {:.1}, last_max: {:.1}",
                 self.id,
@@ -709,7 +709,7 @@ impl AdaptiveRateController {
             .store(now_ns + TICK_INTERVAL.as_nanos() as u64, Relaxed);
 
         // Logging.
-        if *LOG_RATE_LIMIT {
+        if *LOG_HTTP_RATE_LIMIT {
             eprintln!(
                 "[http rate_limit #{}_{} {}] {}: rate: {:.1}, success_rate_ewma: {:.1}, last_max: {:.1}, \
                     elapsed: {:.1}s, win_admit: {}, win_deny: {}, win_success: {}, win_throttle: {},  q_depth: {}",

--- a/crates/polars-io/src/cloud/object_store_setup.rs
+++ b/crates/polars-io/src/cloud/object_store_setup.rs
@@ -458,9 +458,9 @@ pub async fn build_object_store(
         .map_or(CloudType::File, CloudType::from_cloud_scheme);
     let cloud_location = CloudLocation::new(path.clone(), glob)?;
 
-    let disable_rate_limit = polars_config::config().disable_rate_limit();
+    let disable_http_rate_limit = polars_config::config().disable_http_rate_limit();
     let rate_limiter = match cloud_type {
-        CloudType::Aws | CloudType::Azure | CloudType::Gcp if !disable_rate_limit => {
+        CloudType::Aws | CloudType::Azure | CloudType::Gcp if !disable_http_rate_limit => {
             Some(Arc::new(RateLimiter::new(
                 options
                     .map(|options| options.rate_limit_config)

--- a/crates/polars-io/src/cloud/object_store_setup.rs
+++ b/crates/polars-io/src/cloud/object_store_setup.rs
@@ -458,13 +458,16 @@ pub async fn build_object_store(
         .map_or(CloudType::File, CloudType::from_cloud_scheme);
     let cloud_location = CloudLocation::new(path.clone(), glob)?;
 
+    let disable_rate_limit = polars_config::config().disable_rate_limit();
     let rate_limiter = match cloud_type {
-        CloudType::Aws | CloudType::Azure | CloudType::Gcp => Some(Arc::new(RateLimiter::new(
-            options
-                .map(|options| options.rate_limit_config)
-                .unwrap_or_default()
-                .into(),
-        ))),
+        CloudType::Aws | CloudType::Azure | CloudType::Gcp if !disable_rate_limit => {
+            Some(Arc::new(RateLimiter::new(
+                options
+                    .map(|options| options.rate_limit_config)
+                    .unwrap_or_default()
+                    .into(),
+            )))
+        },
         _ => None,
     };
 


### PR DESCRIPTION
Adds a private env var that allows disabling the HTTP rate limiter. For dev/test/benchmark purposes only, not intended for long-term use.