### PR TITLE
fix: Handle null in Expr.is_not_nan

### DIFF
--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -704,6 +704,7 @@ impl Series {
             DataType::Float16 => Ok(self.f16().unwrap().is_not_nan()),
             DataType::Float32 => Ok(self.f32().unwrap().is_not_nan()),
             DataType::Float64 => Ok(self.f64().unwrap().is_not_nan()),
+            DataType::Null => Ok(BooleanChunked::full_null(self.name().clone(), self.len())),
             dt if dt.is_primitive_numeric() => {
                 let arr = BooleanArray::full(self.len(), true, ArrowDataType::Boolean)
                     .with_validity(self.rechunk_validity());

--- a/py-polars/tests/unit/datatypes/test_null.py
+++ b/py-polars/tests/unit/datatypes/test_null.py
@@ -85,36 +85,31 @@ def test_null_lit_filter_16664() -> None:
 
 @pytest.mark.parametrize(
     "op",
-    [
-        pl.Expr.is_nan,
-        pl.Expr.is_not_nan,
-        pl.Expr.is_finite,
-        pl.Expr.is_infinite,
-    ],
+    [pl.Expr.is_nan, pl.Expr.is_not_nan, pl.Expr.is_finite, pl.Expr.is_infinite],
 )
-def test_null_is_nan_finite_28845(op: Any) -> None:
-    s = [None, None]
-    df = pl.DataFrame({"a": s})
+def test_null_fused_not_28845(op: Any) -> None:
+    two_nulls = [None, None]
+    df = pl.DataFrame({"a": two_nulls})
     assert df.schema == {"a": pl.Null}
 
     output_df = df.select(
         col=op(pl.col("a")),
-        inverted_col=~op(pl.col("a")),
         broadcast=op(pl.lit(None)),
+        inverted_col=~op(pl.col("a")),
         inverted_broadcast=~op(pl.lit(None)),
     )
 
     expected_df = pl.DataFrame(
         {
-            "col": s,
-            "inverted_col": s,
-            "broadcast": s,
-            "inverted_broadcast": s,
+            "col": two_nulls,
+            "broadcast": two_nulls,
+            "inverted_col": two_nulls,
+            "inverted_broadcast": two_nulls,
         },
         schema={
             "col": pl.Boolean,
-            "inverted_col": pl.Boolean,
             "broadcast": pl.Boolean,
+            "inverted_col": pl.Boolean,
             "inverted_broadcast": pl.Boolean,
         },
     )

--- a/py-polars/tests/unit/datatypes/test_null.py
+++ b/py-polars/tests/unit/datatypes/test_null.py
@@ -81,3 +81,41 @@ def test_null_hash_rows_14100() -> None:
 
 def test_null_lit_filter_16664() -> None:
     assert pl.DataFrame({"x": []}).filter(pl.lit(True)).shape == (0, 1)
+
+
+@pytest.mark.parametrize(
+    "op",
+    [
+        pl.Expr.is_nan,
+        pl.Expr.is_not_nan,
+        pl.Expr.is_finite,
+        pl.Expr.is_infinite,
+    ],
+)
+def test_null_is_nan_finite_28845(op: Any) -> None:
+    s = [None, None]
+    df = pl.DataFrame({"a": s})
+    assert df.schema == {"a": pl.Null}
+
+    output_df = df.select(
+        col=op(pl.col("a")),
+        inverted_col=~op(pl.col("a")),
+        broadcast=op(pl.lit(None)),
+        inverted_broadcast=~op(pl.lit(None)),
+    )
+
+    expected_df = pl.DataFrame(
+        {
+            "col": s,
+            "inverted_col": s,
+            "broadcast": s,
+            "inverted_broadcast": s,
+        },
+        schema={
+            "col": pl.Boolean,
+            "inverted_col": pl.Boolean,
+            "broadcast": pl.Boolean,
+            "inverted_broadcast": pl.Boolean,
+        },
+    )
+    assert_frame_equal(output_df, expected_df)


### PR DESCRIPTION
All similar functions do the same.
Resolves https://github.com/pola-rs/polars/issues/28845
