### PR TITLE
feat(python): Add extra_columns parameter to scan_ipc

### DIFF
--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -866,6 +866,9 @@ pub fn lower_ir(
                         #[cfg(feature = "parquet")]
                         FileScanIR::Parquet { .. } => unified_scan_args.extra_columns_policy,
 
+                        #[cfg(feature = "ipc")]
+                        FileScanIR::Ipc { .. } => unified_scan_args.extra_columns_policy,
+
                         _ => {
                             if unified_scan_args.projection.is_some() {
                                 ExtraColumnsPolicy::Ignore

--- a/py-polars/src/polars/io/ipc/functions.py
+++ b/py-polars/src/polars/io/ipc/functions.py
@@ -452,6 +452,7 @@ def scan_ipc(
     hive_schema: SchemaDict | None = None,
     try_parse_hive_dates: bool = True,
     include_file_paths: str | None = None,
+    extra_columns: Literal["ignore", "raise"] = "raise",
     _record_batch_statistics: bool = False,
 ) -> LazyFrame:
     """
@@ -547,6 +548,12 @@ def scan_ipc(
         Whether to try parsing hive values as date/datetime types.
     include_file_paths
         Include the path of the source file(s) as a column with this name.
+    extra_columns
+        Configuration for behavior when extra columns outside of the
+        defined schema are encountered in the data:
+
+        * `ignore`: Silently ignores.
+        * `raise`: Raises an error.
     """
     # Memory Mapping is now a no-op
     _ = memory_map
@@ -599,6 +606,7 @@ def scan_ipc(
             cache=cache_deprecated,
             storage_options=storage_options,
             credential_provider=credential_provider_builder,
+            extra_columns=extra_columns,
         ),
     )
 

--- a/py-polars/tests/unit/io/test_scan_options.py
+++ b/py-polars/tests/unit/io/test_scan_options.py
@@ -800,8 +800,7 @@ def test_cast_options_ignore_extra_columns() -> None:
     ("scan_func", "write_func"),
     [
         (pl.scan_parquet, pl.DataFrame.write_parquet),
-        # TODO: Fix for all other formats
-        # (pl.scan_ipc, pl.DataFrame.write_ipc),
+        (pl.scan_ipc, pl.DataFrame.write_ipc),
         # (pl.scan_csv, pl.DataFrame.write_csv),
         # (pl.scan_ndjson, pl.DataFrame.write_ndjson),
     ],


### PR DESCRIPTION
Part of #22782

## Summary

Add the `extra_columns` parameter to `scan_ipc`, allowing users to:

- raise an error when encountering columns outside the schema; or
- ignore these extra columns.

The default behavior remains `"raise"`.

## Implementation

Pass the `extra_columns` parameter from the Python API into `ScanOptions`, and apply this policy when lowering an IPC scan into a physical execution plan.

## Tests

Enabled the IPC case in the existing parameterized regression test for handling extra columns.

Verified with:

```bash
make -C py-polars test PYTEST_ARGS='tests/unit/io/test_scan_options.py -q'
make pre-commit
```

## AI disclosure

I used AI to help me:

1. understand the issue and the underlying mechanism
2. set up the development environment and run tests
3. review the code changes and check the English wording in the PR

The AI model is GPT-5.6 Sol High in Codex CLI.

I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.
