### PR TITLE
feat(python): Expose the registered source as `scan_fn.io_source`

### DIFF
--- a/docs/source/user-guide/plugins/io_plugins.md
+++ b/docs/source/user-guide/plugins/io_plugins.md
@@ -190,6 +190,30 @@ shape: (2, 2)
 └─────┴─────┘
 ```
 
+## For engine authors: identifying a source
+
+This section is for people writing a Polars execution engine. If you are writing an IO source, you
+can skip it.
+
+Polars does not call your source directly. It calls a wrapper that deserializes the predicate and
+forwards the call. Engines may need to identify sources they know about, for example to provide
+execution context or call additional methods.
+
+To make that possible, the wrapper satisfies the `IOSourceScanFunction` protocol, which exposes the
+registered source:
+
+```python
+from polars.io.plugins import IOSourceScanFunction
+
+# `scan_fn` is the scan function of the `PythonScan` node being executed.
+if isinstance(scan_fn, IOSourceScanFunction):
+    source = scan_fn.io_source  # exactly the object passed to register_io_source
+    if isinstance(source, MyEngineSource):
+        ...
+```
+
+This is as unstable as the rest of the IO plugin API.
+
 ## Further reading
 
 - [Rust example (distribution source)](https://github.com/pola-rs/pyo3-polars/tree/main/example/io_plugin)

--- a/py-polars/docs/source/reference/plugins.rst
+++ b/py-polars/docs/source/reference/plugins.rst
@@ -45,3 +45,5 @@ for more information.
     :toctree: api/
 
     io.plugins.register_io_source
+    io.plugins.IOSourceScanFunction
+    io.plugins.IOSourceScanFunction.io_source

--- a/py-polars/src/polars/io/plugins.py
+++ b/py-polars/src/polars/io/plugins.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import sys
 from collections.abc import Callable, Iterator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
 
 import polars._reexport as pl
 from polars._utils.unstable import unstable
@@ -13,6 +13,50 @@ if TYPE_CHECKING:
 
     from polars import DataFrame, Expr, LazyFrame
     from polars._typing import SchemaDict
+
+
+@runtime_checkable
+class IOSourceScanFunction(Protocol):
+    """
+    The callable Polars invokes for a source registered with `register_io_source`.
+
+    This is for authors of Polars execution engines. If you are writing an IO
+    source, you do not need it.
+
+    Polars does not call the registered source directly. It calls this wrapper,
+    which deserializes the predicate and forwards the call. An engine holding
+    the scan function of a `PythonScan` node can use this protocol to identify
+    the sources it knows about.
+
+    .. warning::
+        This functionality is considered **unstable**. It may be changed
+        at any point without it being considered a breaking change.
+
+    Examples
+    --------
+    >>> # `scan_fn` is the scan function of the `PythonScan` node being executed.
+    >>> if isinstance(scan_fn, IOSourceScanFunction):  # doctest: +SKIP
+    ...     source = scan_fn.io_source
+    """
+
+    io_source: Callable[
+        [list[str] | None, Expr | None, int | None, int | None], Iterator[DataFrame]
+    ]
+    """The source that was passed to :func:`register_io_source`."""
+
+    def __call__(
+        self,
+        with_columns: list[str] | None,
+        predicate: bytes | None,
+        n_rows: int | None,
+        batch_size: int | None,
+    ) -> tuple[Iterator[DataFrame], bool]:
+        """
+        Call the source.
+
+        Returns the source's chunks and whether it applied the predicate.
+        """
+        ...
 
 
 @unstable()
@@ -95,9 +139,12 @@ def register_io_source(
             with_columns, parsed_predicate, n_rows, batch_size
         ), parsed_predicate_success
 
+    scan_fn = cast("IOSourceScanFunction", wrap)
+    scan_fn.io_source = io_source
+
     return pl.LazyFrame._scan_python_function(
         schema=schema,
-        scan_fn=wrap,
+        scan_fn=scan_fn,
         pyarrow=False,
         validate_schema=validate_schema,
         is_pure=is_pure,

--- a/py-polars/tests/unit/io/test_io_plugin.py
+++ b/py-polars/tests/unit/io/test_io_plugin.py
@@ -4,13 +4,13 @@ import datetime
 import io
 import subprocess
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pytest
 
 import polars as pl
-from polars.io.plugins import register_io_source
+from polars.io.plugins import IOSourceScanFunction, register_io_source
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -310,3 +310,54 @@ def test_io_plugin_object_dtype_25740() -> None:
     out = lf.collect()
     assert out.schema == df.schema
     assert out.to_dict(as_series=False) == {"a": [dummy, None]}
+
+
+def _scan_fn(lf: pl.LazyFrame) -> Any:
+    """Reach the registered scan function the way an execution engine does."""
+    return lf._ldf.visit().view_current_node().options[0]
+
+
+def _source(
+    with_columns: list[str] | None,
+    predicate: pl.Expr | None,
+    n_rows: int | None,
+    batch_size: int | None,
+) -> Iterator[pl.DataFrame]:
+    yield pl.DataFrame({"a": [1, 2, 3]})
+
+
+class _CallableSource:
+    """A source that is a class instance, which is how engines define their own."""
+
+    def __call__(
+        self,
+        with_columns: list[str] | None,
+        predicate: pl.Expr | None,
+        n_rows: int | None,
+        batch_size: int | None,
+    ) -> Iterator[pl.DataFrame]:
+        yield pl.DataFrame({"a": [1, 2, 3]})
+
+
+@pytest.mark.parametrize(
+    "source", [_source, _CallableSource()], ids=["function", "callable-instance"]
+)
+def test_io_plugin_exposes_io_source(source: Any) -> None:
+    lf = register_io_source(source, schema={"a": pl.Int64})
+    scan_fn = _scan_fn(lf)
+
+    assert isinstance(scan_fn, IOSourceScanFunction)
+    assert scan_fn.io_source is source
+    assert_frame_equal(lf.collect(), pl.DataFrame({"a": [1, 2, 3]}))
+
+
+def test_io_plugin_non_source_fails_protocol_check() -> None:
+    assert not isinstance(_source, IOSourceScanFunction)
+
+
+def test_io_plugin_io_source_survives_serialization() -> None:
+    lf = register_io_source(_CallableSource(), schema={"a": pl.Int64})
+    roundtripped = pl.LazyFrame.deserialize(io.BytesIO(lf.serialize()))
+
+    assert isinstance(_scan_fn(roundtripped).io_source, _CallableSource)
+    assert_frame_equal(roundtripped.collect(), pl.DataFrame({"a": [1, 2, 3]}))


### PR DESCRIPTION
Resolves #28835.

`register_io_source` now records the registered source on the wrapper it returns, described by a new public `IOSourceScanFunction` protocol. This lets an execution engine identify the source it is about to run instead of walking `scan_fn.__closure__`. 
No Rust change, no change to how sources are called, and nothing a source author needs to know about.



🤖 AI Policy: Initially generated by Claude Opus 5, reviewed and edited manually.


### Test screenshot
<img width="2093" height="1382" alt="polars-first-pr-screenshot" src="https://github.com/user-attachments/assets/328e878d-ef65-44b2-b3c5-8f8ad67ea029" />
