### PR TITLE
docs(python): Clarify meaning of ambiguous in datetime docstrings

### DIFF
--- a/py-polars/src/polars/expr/datetime.py
+++ b/py-polars/src/polars/expr/datetime.py
@@ -438,12 +438,14 @@ class ExprDateTimeNameSpace(_NamespaceSuggestMixin):
         microsecond
             Column or literal, ranging from 0-999999.
         ambiguous
-            Determine how to deal with ambiguous datetimes:
+            Determine how to deal with datetimes that are ambiguous due to a daylight
+            saving time transition, i.e. wall-clock times that occur twice because the
+            clock is moved backward:
 
-            - `'raise'` (default): raise
-            - `'earliest'`: use the earliest datetime
-            - `'latest'`: use the latest datetime
-            - `'null'`: set to null
+            - `'raise'` (default): raise an error
+            - `'earliest'`: use the earliest of the two datetimes
+            - `'latest'`: use the latest of the two datetimes
+            - `'null'`: set the value to null
 
         Returns
         -------
@@ -2050,12 +2052,14 @@ class ExprDateTimeNameSpace(_NamespaceSuggestMixin):
         time_zone
             Time zone for the `Datetime` expression. Pass `None` to unset time zone.
         ambiguous
-            Determine how to deal with ambiguous datetimes:
+            Determine how to deal with datetimes that are ambiguous due to a daylight
+            saving time transition, i.e. wall-clock times that occur twice because the
+            clock is moved backward:
 
-            - `'raise'` (default): raise
-            - `'earliest'`: use the earliest datetime
-            - `'latest'`: use the latest datetime
-            - `'null'`: set to null
+            - `'raise'` (default): raise an error
+            - `'earliest'`: use the earliest of the two datetimes
+            - `'latest'`: use the latest of the two datetimes
+            - `'null'`: set the value to null
         non_existent
             Determine how to deal with non-existent datetimes:
 

--- a/py-polars/src/polars/expr/string.py
+++ b/py-polars/src/polars/expr/string.py
@@ -149,12 +149,14 @@ class ExprStringNameSpace(_NamespaceSuggestMixin):
         cache
             Use a cache of unique, converted datetimes to apply the conversion.
         ambiguous
-            Determine how to deal with ambiguous datetimes:
+            Determine how to deal with datetimes that are ambiguous due to a daylight
+            saving time transition, i.e. wall-clock times that occur twice because the
+            clock is moved backward:
 
-            - `'raise'` (default): raise
-            - `'earliest'`: use the earliest datetime
-            - `'latest'`: use the latest datetime
-            - `'null'`: set to null
+            - `'raise'` (default): raise an error
+            - `'earliest'`: use the earliest of the two datetimes
+            - `'latest'`: use the latest of the two datetimes
+            - `'null'`: set the value to null
 
         Examples
         --------
@@ -257,12 +259,14 @@ class ExprStringNameSpace(_NamespaceSuggestMixin):
         cache
             Use a cache of unique, converted dates to apply the datetime conversion.
         ambiguous
-            Determine how to deal with ambiguous datetimes:
+            Determine how to deal with datetimes that are ambiguous due to a daylight
+            saving time transition, i.e. wall-clock times that occur twice because the
+            clock is moved backward:
 
-            - `'raise'` (default): raise
-            - `'earliest'`: use the earliest datetime
-            - `'latest'`: use the latest datetime
-            - `'null'`: set to null
+            - `'raise'` (default): raise an error
+            - `'earliest'`: use the earliest of the two datetimes
+            - `'latest'`: use the latest of the two datetimes
+            - `'null'`: set the value to null
 
         Notes
         -----

--- a/py-polars/src/polars/functions/as_datatype.py
+++ b/py-polars/src/polars/functions/as_datatype.py
@@ -61,12 +61,14 @@ def datetime_(
     time_zone
         Time zone of the resulting expression.
     ambiguous
-        Determine how to deal with ambiguous datetimes:
+        Determine how to deal with datetimes that are ambiguous due to a daylight
+        saving time transition, i.e. wall-clock times that occur twice because the
+        clock is moved backward:
 
-        - `'raise'` (default): raise
-        - `'earliest'`: use the earliest datetime
-        - `'latest'`: use the latest datetime
-        - `'null'`: set to null
+        - `'raise'` (default): raise an error
+        - `'earliest'`: use the earliest of the two datetimes
+        - `'latest'`: use the latest of the two datetimes
+        - `'null'`: set the value to null
 
     Returns
     -------


### PR DESCRIPTION
## What

Clarifies the docstring for the `ambiguous` parameter, which is currently described only as "Determine how to deal with ambiguous datetimes" without explaining what "ambiguous" means.

Following the discussion in the issue (maintainer confirmation that `ambiguous` "refers to datetimes which are daylight-savings-ambiguous"), the wording now makes explicit that an ambiguous datetime is a wall-clock time that occurs twice because of a daylight saving time transition (when the clock is moved backward), and describes each option value more precisely (`'raise'`, `'earliest'`, `'latest'`, `'null'`).

## Scope

Applies the clarified wording consistently to every docstring where `ambiguous` appears:

- `pl.datetime` (`py-polars/src/polars/functions/as_datatype.py`)
- `str.to_datetime` and `str.strptime` (`py-polars/src/polars/expr/string.py`)
- `dt.replace` and `dt.replace_time_zone` (`py-polars/src/polars/expr/datetime.py`)

Documentation-only change; no behavior change.

## Acceptance criteria

- [x] `ambiguous` docstring explains that it refers to DST-ambiguous (clock moved backward) wall-clock times
- [x] Wording is consistent across all locations where `ambiguous` appears
- [x] `ruff check` passes on the changed files
- [x] `ruff format --check` passes on the changed files

Closes #28833