### PR TITLE
fix(python): count all selected columns in DataFrame.n_unique

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -64,7 +64,6 @@ from polars._utils.deprecation import (
     issue_deprecation_warning,
 )
 from polars._utils.getitem import get_df_item_by_key
-from polars._utils.parse import parse_into_expression
 from polars._utils.pycapsule import is_pycapsule, pycapsule_to_frame
 from polars._utils.serde import serialize_polars_object
 from polars._utils.unstable import issue_unstable_warning, unstable
@@ -80,7 +79,7 @@ from polars._utils.various import (
     scale_bytes,
     warn_null_comparison,
 )
-from polars._utils.wrap import wrap_expr, wrap_ldf, wrap_s
+from polars._utils.wrap import wrap_ldf, wrap_s
 from polars.config import Config
 from polars.dataframe._html import NotebookFormatter
 from polars.dataframe.group_by import DynamicGroupBy, GroupBy, RollingGroupBy
@@ -11510,14 +11509,14 @@ class DataFrame:
         ... )
         3
         """
-        if isinstance(subset, str):
-            expr = F.col(subset)
-        elif isinstance(subset, pl.Expr):
-            expr = subset
-        elif isinstance(subset, Sequence) and len(subset) == 1:
-            expr = wrap_expr(parse_into_expression(subset[0]))
+        if subset is None:
+            expr = F.struct(F.all())
         else:
-            struct_fields = F.all() if (subset is None) else subset
+            # Bind the requested columns/expressions into a single struct column
+            # so they are counted jointly. A raw expression or selector like
+            # ``pl.col("a", "b")`` may expand to multiple columns, and calling
+            # ``expr.n_unique()`` on it directly only counts the first one.
+            struct_fields = [subset] if isinstance(subset, (str, pl.Expr)) else subset
             expr = F.struct(struct_fields)
 
         from polars.lazyframe.opt_flags import QueryOptFlags


### PR DESCRIPTION
This PR was drafted with AI assistance; I verified the fix logic locally against polars 1.43.2 with the issue's reproducer.

Fixes pola-rs/polars#28903

## Summary
`DataFrame.n_unique(subset=...)` only counted the **first** column when `subset` was an expression or selector that expands to multiple columns — e.g. `pl.col("a", "b")`, `cs.by_name("a", "b")`, `pl.exclude("id")`, or a single-element sequence wrapping one of those. `DataFrame.unique()` handled these correctly; `n_unique` did not.

Root cause: the method used `expr.n_unique()` directly for a single expression/selector, which only observes the first output column. It only built a `struct` in the "list of columns" branch — and the `struct` was exactly what makes multi-column subsets count jointly.

Fix: when `subset` is not `None`, always bind the requested columns/expressions into a single `struct` column before `.n_unique()`, so all selected columns are counted together. `subset=None` still uses `F.all()`. Removed the now-unused `wrap_expr`/`parse_into_expression` imports.

A first pass tried delegating to `unique(subset=...)`, but that panics on the expression-subset case the method is documented to support (`cannot get ref Int64 from Int32`), so the `struct` wrapper is the correct path. It only applies when `subset` is passed; the no-argument call is unchanged.

## Verification
| call | before | after |
|---|---|---|
| `n_unique(pl.col("A","B"))` | 4 | **5** ✅ |
| `n_unique(cs.by_name("B","A"))` | 3 | **5** ✅ |
| `n_unique(pl.exclude("id"))` | 4 | **5** ✅ |
| `n_unique(["A","B"])` | — | **5** ✅ |
| `n_unique([pl.col("A","B")])` | 4 | **5** ✅ |
| `n_unique("A")` | 4 | **4** (single-column unchanged) |
| docstring `subset=[expr, expr]` | — | **3** ✅ |

`py_compile` clean; verified locally on the issue's reproducer and the docstring case.
