### PR TITLE
Fix soundness violation: integer overflow in slice() causing heap-buffer-overflow

### DIFF
--- a/crates/polars-arrow/src/array/binary/mod.rs
+++ b/crates/polars-arrow/src/array/binary/mod.rs
@@ -217,6 +217,9 @@ impl<O: Offset> BinaryArray<O> {
     /// # Panics
     /// iff `offset + length > self.len()`.
     pub fn slice(&mut self, offset: usize, length: usize) {
+        let _ = offset
+            .checked_add(length)
+            .expect("offset + length overflowed");
         assert!(
             offset + length <= self.len(),
             "the offset of the new Buffer cannot exceed the existing length"

--- a/crates/polars-arrow/src/array/boolean/mod.rs
+++ b/crates/polars-arrow/src/array/boolean/mod.rs
@@ -166,6 +166,9 @@ impl BooleanArray {
     /// This function panics iff `offset + length > self.len()`.
     #[inline]
     pub fn slice(&mut self, offset: usize, length: usize) {
+        let _ = offset
+            .checked_add(length)
+            .expect("offset + length overflowed");
         assert!(
             offset + length <= self.len(),
             "the offset of the new Buffer cannot exceed the existing length"

--- a/crates/polars-arrow/src/array/dictionary/mod.rs
+++ b/crates/polars-arrow/src/array/dictionary/mod.rs
@@ -317,6 +317,13 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     /// # Panics
     /// iff `offset + length > self.len()`.
     pub fn slice(&mut self, offset: usize, length: usize) {
+        let _ = offset
+            .checked_add(length)
+            .expect("offset + length overflowed");
+        assert!(
+            offset + length <= self.len(),
+            "the offset of the new array cannot exceed the arrays' length"
+        );
         self.keys.slice(offset, length);
     }
 

--- a/crates/polars-arrow/src/array/fixed_size_binary/mod.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/mod.rs
@@ -100,6 +100,9 @@ impl FixedSizeBinaryArray {
     /// # Panics
     /// panics iff `offset + length > self.len()`
     pub fn slice(&mut self, offset: usize, length: usize) {
+        let _ = offset
+            .checked_add(length)
+            .expect("offset + length overflowed");
         assert!(
             offset + length <= self.len(),
             "the offset of the new Buffer cannot exceed the existing length"

--- a/crates/polars-arrow/src/array/fixed_size_list/mod.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/mod.rs
@@ -239,6 +239,9 @@ impl FixedSizeListArray {
     /// # Panics
     /// panics iff `offset + length > self.len()`
     pub fn slice(&mut self, offset: usize, length: usize) {
+        let _ = offset
+            .checked_add(length)
+            .expect("offset + length overflowed");
         assert!(
             offset + length <= self.len(),
             "the offset of the new Buffer cannot exceed the existing length"

--- a/crates/polars-arrow/src/array/list/mod.rs
+++ b/crates/polars-arrow/src/array/list/mod.rs
@@ -123,6 +123,9 @@ impl<O: Offset> ListArray<O> {
     /// # Panics
     /// panics iff `offset + length > self.len()`
     pub fn slice(&mut self, offset: usize, length: usize) {
+        let _ = offset
+            .checked_add(length)
+            .expect("offset + length overflowed");
         assert!(
             offset + length <= self.len(),
             "the offset of the new Buffer cannot exceed the existing length"

--- a/crates/polars-arrow/src/array/map/mod.rs
+++ b/crates/polars-arrow/src/array/map/mod.rs
@@ -101,6 +101,9 @@ impl MapArray {
     /// # Panics
     /// panics iff `offset + length > self.len()`
     pub fn slice(&mut self, offset: usize, length: usize) {
+        let _ = offset
+            .checked_add(length)
+            .expect("offset + length overflowed");
         assert!(
             offset + length <= self.len(),
             "the offset of the new Buffer cannot exceed the existing length"

--- a/crates/polars-arrow/src/array/null.rs
+++ b/crates/polars-arrow/src/array/null.rs
@@ -67,6 +67,9 @@ impl NullArray {
     /// # Panic
     /// This function panics iff `offset + length > self.len()`.
     pub fn slice(&mut self, offset: usize, length: usize) {
+        let _ = offset
+            .checked_add(length)
+            .expect("offset + length overflowed");
         assert!(
             offset + length <= self.len(),
             "the offset of the new array cannot exceed the arrays' length"

--- a/crates/polars-arrow/src/array/primitive/mod.rs
+++ b/crates/polars-arrow/src/array/primitive/mod.rs
@@ -241,6 +241,9 @@ impl<T: NativeType> PrimitiveArray<T> {
     /// This operation is `O(1)`.
     #[inline]
     pub fn slice(&mut self, offset: usize, length: usize) {
+        let _ = offset
+            .checked_add(length)
+            .expect("offset + length overflowed");
         assert!(
             offset + length <= self.len(),
             "offset + length may not exceed length of array"

--- a/crates/polars-arrow/src/array/struct_/mod.rs
+++ b/crates/polars-arrow/src/array/struct_/mod.rs
@@ -174,6 +174,9 @@ impl StructArray {
     /// # Implementation
     /// This operation is `O(F)` where `F` is the number of fields.
     pub fn slice(&mut self, offset: usize, length: usize) {
+        let _ = offset
+            .checked_add(length)
+            .expect("offset + length overflowed");
         assert!(
             offset + length <= self.len(),
             "offset + length may not exceed length of array"

--- a/crates/polars-arrow/src/array/union/mod.rs
+++ b/crates/polars-arrow/src/array/union/mod.rs
@@ -230,6 +230,9 @@ impl UnionArray {
     /// This function panics iff `offset + length > self.len()`.
     #[inline]
     pub fn slice(&mut self, offset: usize, length: usize) {
+        let _ = offset
+            .checked_add(length)
+            .expect("offset + length overflowed");
         assert!(
             offset + length <= self.len(),
             "the offset of the new array cannot exceed the existing length"

--- a/crates/polars-arrow/src/array/utf8/mod.rs
+++ b/crates/polars-arrow/src/array/utf8/mod.rs
@@ -212,6 +212,9 @@ impl<O: Offset> Utf8Array<O> {
     /// # Panics
     /// iff `offset + length > self.len()`.
     pub fn slice(&mut self, offset: usize, length: usize) {
+        let _ = offset
+            .checked_add(length)
+            .expect("offset + length overflowed");
         assert!(
             offset + length <= self.len(),
             "the offset of the new array cannot exceed the arrays' length"

--- a/crates/polars-arrow/src/bitmap/immutable.rs
+++ b/crates/polars-arrow/src/bitmap/immutable.rs
@@ -268,6 +268,9 @@ impl Bitmap {
     /// exceeds the allocated capacity of `self`.
     #[inline]
     pub fn slice(&mut self, offset: usize, length: usize) {
+        let _ = offset
+            .checked_add(length)
+            .expect("offset + length overflowed");
         assert!(offset + length <= self.length);
         unsafe { self.slice_unchecked(offset, length) }
     }
@@ -326,6 +329,9 @@ impl Bitmap {
     #[inline]
     #[must_use]
     pub fn sliced(self, offset: usize, length: usize) -> Self {
+        let _ = offset
+            .checked_add(length)
+            .expect("offset + length overflowed");
         assert!(offset + length <= self.length);
         unsafe { self.sliced_unchecked(offset, length) }
     }


### PR DESCRIPTION
Fixes #27943

## Problem
Multiple slice() implementations in polars-arrow use 'offset + length' without checked_add, allowing integer overflow in release mode. This lets safe Rust code (#![forbid(unsafe_code)]) trigger heap-buffer-overflow via use of uninit memory.

## Root Cause
13 slice()/sliced() implementations across polars-arrow array types use:

In release mode, offset + length wraps silently. E.g., offset=1, length=usize::MAX wraps to 0, and 0 <= 3 passes the assertion. The subsequent unsafe slice_unchecked then reads beyond allocated memory.

## Fix
Added checked_add().expect() before each assertion to catch overflow early:


## Files Changed
- crates/polars-arrow/src/array/primitive/mod.rs
- crates/polars-arrow/src/array/binary/mod.rs
- crates/polars-arrow/src/array/boolean/mod.rs
- crates/polars-arrow/src/array/dictionary/mod.rs
- crates/polars-arrow/src/array/fixed_size_binary/mod.rs
- crates/polars-arrow/src/array/fixed_size_list/mod.rs
- crates/polars-arrow/src/array/list/mod.rs
- crates/polars-arrow/src/array/map/mod.rs
- crates/polars-arrow/src/array/null.rs
- crates/polars-arrow/src/array/struct_/mod.rs
- crates/polars-arrow/src/array/union/mod.rs
- crates/polars-arrow/src/array/utf8/mod.rs
- crates/polars-arrow/src/bitmap/immutable.rs (slice + sliced)

## Verification
- **Without fix**: PR #27942 test reproduces heap-buffer-overflow (exit code 139, segfault)
- **With fix**: clean panic with 'offset + length overflowed' (exit code 101), no UB
- All existing tests pass