### PR TITLE
docs(testing): fix assert_schema_equal parameter descriptions and add unit tests

### DIFF
--- a/py-polars/src/polars/testing/asserts/schema.py
+++ b/py-polars/src/polars/testing/asserts/schema.py
@@ -33,9 +33,9 @@ def assert_schema_equal(
     Parameters
     ----------
     left_schema
-        The first DataFrame or LazyFrame to compare.
+        The first schema to compare, as a Schema or schema dictionary.
     right_schema
-        The second DataFrame or LazyFrame to compare.
+        The second schema to compare, as a Schema or schema dictionary.
     check_column_order
         Requires column order to match.
     check_dtypes

--- a/py-polars/tests/unit/testing/test_assert_schema_equal.py
+++ b/py-polars/tests/unit/testing/test_assert_schema_equal.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+import polars as pl
+from polars.testing import assert_schema_equal
+
+
+def test_assert_schema_equal_matching() -> None:
+    schema1 = {"a": pl.Int64, "b": pl.String}
+    schema2 = {"a": pl.Int64, "b": pl.String}
+    assert_schema_equal(schema1, schema2)
+    assert_schema_equal(pl.Schema(schema1), pl.Schema(schema2))
+
+
+def test_assert_schema_equal_column_order() -> None:
+    schema1 = {"a": pl.Int64, "b": pl.String}
+    schema2 = {"b": pl.String, "a": pl.Int64}
+
+    with pytest.raises(AssertionError, match="columns are not in the same order"):
+        assert_schema_equal(schema1, schema2, check_column_order=True)
+
+    assert_schema_equal(schema1, schema2, check_column_order=False)
+
+
+def test_assert_schema_equal_dtypes() -> None:
+    schema1 = {"a": pl.Int64, "b": pl.Float64}
+    schema2 = {"a": pl.Int32, "b": pl.Float64}
+
+    with pytest.raises(AssertionError, match="dtypes do not match"):
+        assert_schema_equal(schema1, schema2, check_dtypes=True)
+
+    assert_schema_equal(schema1, schema2, check_dtypes=False)


### PR DESCRIPTION
## Description
In `polars.testing.assert_schema_equal`:
```python
Parameters
----------
left_schema
    The first DataFrame or LazyFrame to compare.
right_schema
    The second DataFrame or LazyFrame to compare.
```
The parameter descriptions were previously copy-pasted from `assert_frame_equal`, incorrectly describing the inputs as DataFrames or LazyFrames instead of Schemas or schema dictionaries.

This PR:
1. Updates `left_schema` and `right_schema` docstrings to clarify they accept `Schema` or schema dictionaries.
2. Adds a dedicated unit test suite in `py-polars/tests/unit/testing/test_assert_schema_equal.py` verifying column order, dtype checking, and schema matching.