### PR TITLE
feat: SQL esolve subquery columns by SQL scoping in the semi-join rewrite

### DIFF
--- a/crates/polars-sql/src/subquery.rs
+++ b/crates/polars-sql/src/subquery.rs
@@ -17,6 +17,7 @@ use sqlparser::ast::Distinct;
 use sqlparser::ast::{
     BinaryOperator as SQLBinaryOperator, Expr as SQLExpr, GroupByExpr, Ident, Query, Select,
     SelectItem, SetExpr, TableWithJoins, UnaryOperator as SQLUnaryOperator, VisitMut, VisitorMut,
+    visit_expressions,
 };
 
 use crate::SQLContext;
@@ -186,7 +187,7 @@ impl SQLContext {
             {
                 corr_preds.push(pred);
             } else if let Some(filter) =
-                self.try_parse_inner_only_expr(conj, inner_schema, outer_schema)?
+                self.try_parse_inner_only_expr(conj, inner_names, inner_schema)?
             {
                 local_filters.push(filter);
             } else {
@@ -293,7 +294,7 @@ impl SQLContext {
         };
         // The membership key must be a plain expression over the inner relation;
         // any alias it carries is cosmetic and not allowed in a join key.
-        let Some(right_key) = ctx.try_parse_inner_only_expr(proj, &inner_schema, outer_schema)?
+        let Some(right_key) = ctx.try_parse_inner_only_expr(proj, &inner_names, &inner_schema)?
         else {
             return Ok(None);
         };
@@ -404,7 +405,7 @@ impl SQLContext {
                 right_on.push(col(inner_key));
                 continue;
             }
-            let Some(filter) = self.try_parse_inner_only_expr(conj, inner_schema, outer_schema)?
+            let Some(filter) = self.try_parse_inner_only_expr(conj, inner_names, inner_schema)?
             else {
                 return Ok(None);
             };
@@ -423,19 +424,13 @@ impl SQLContext {
     fn try_parse_inner_only_expr(
         &mut self,
         sql_expr: &SQLExpr,
+        inner_names: &PlHashSet<String>,
         inner_schema: &Schema,
-        outer_schema: &Schema,
     ) -> PolarsResult<Option<Expr>> {
-        let expr = parse_sql_expr(sql_expr, self, Some(inner_schema))?;
-        // A nested subquery parses to `Expr::SubPlan`, which is only valid after
-        // `process_subqueries` lowering; it can't be used as a plain expression.
-        if has_expr(&expr, |e| matches!(e, Expr::SubPlan(_, _))) {
+        if !binds_to_inner_relation(sql_expr, inner_names, inner_schema) {
             return Ok(None);
         }
-        let only_inner = expr_to_leaf_column_names_iter(&expr).all(|name| {
-            inner_schema.contains(name.as_str()) && !outer_schema.contains(name.as_str())
-        });
-        Ok(only_inner.then_some(expr))
+        Ok(Some(parse_sql_expr(sql_expr, self, Some(inner_schema))?))
     }
 
     // Lower every correlated subquery reachable from `expr` into a decorrelated
@@ -533,7 +528,7 @@ impl SQLContext {
             {
                 corr_preds.push(pred);
             } else if let Some(filter) =
-                ctx.try_parse_inner_only_expr(conj, &inner_schema, outer_schema)?
+                ctx.try_parse_inner_only_expr(conj, &inner_names, &inner_schema)?
             {
                 local_filters.push(filter);
             } else {
@@ -641,7 +636,7 @@ impl SQLContext {
                 {
                     corr_preds.push(pred);
                 } else if let Some(filter) =
-                    ctx.try_parse_inner_only_expr(conj, &inner_schema, outer_schema)?
+                    ctx.try_parse_inner_only_expr(conj, &inner_names, &inner_schema)?
                 {
                     local_filters.push(filter);
                 } else {
@@ -906,6 +901,51 @@ fn correlation_key_pair(
     }
 }
 
+// Whether every column the expression references resolves to the inner relation,
+// so it can be evaluated against the inner frame alone. A qualified name resolves
+// through its qualifier: only an inner relation's name or alias counts as inner.
+// An unqualified name binds to the innermost scope that has it, so the inner
+// schema wins over the outer one.
+fn binds_to_inner_relation(
+    expr: &SQLExpr,
+    inner_names: &PlHashSet<String>,
+    inner_schema: &Schema,
+) -> bool {
+    // A nested subquery is its own scope, which this cannot resolve against.
+    if expr_contains_subquery(expr) {
+        return false;
+    }
+    visit_expressions(expr, |e| {
+        let resolves = match e {
+            SQLExpr::Identifier(_) | SQLExpr::CompoundIdentifier(_) => qualifier_and_name(e)
+                .is_some_and(|(qualifier, name)| {
+                    qualifier.is_none_or(|q| inner_names.contains(q)) && inner_schema.contains(name)
+                }),
+            _ => true,
+        };
+        if resolves {
+            ControlFlow::Continue(())
+        } else {
+            ControlFlow::Break(())
+        }
+    })
+    .is_continue()
+}
+
+// Split an identifier into its optional table qualifier and its bare column name.
+// Catalog and schema prefixes are dropped, matching how `get_table_name` builds
+// `inner_names`.
+fn qualifier_and_name(expr: &SQLExpr) -> Option<(Option<&str>, &str)> {
+    match expr {
+        SQLExpr::Identifier(ident) => Some((None, ident.value.as_str())),
+        SQLExpr::CompoundIdentifier(parts) => {
+            let (last, init) = parts.split_last()?;
+            Some((init.last().map(|q| q.value.as_str()), last.value.as_str()))
+        },
+        _ => None,
+    }
+}
+
 // Classify a correlation operand as an inner- or outer-query column and return
 // its bare name. A qualified identifier (`tbl.col`) resolves by its qualifier:
 // an inner relation's name/alias means inner, anything else means outer (so
@@ -918,19 +958,8 @@ fn classify_correlation_column(
     inner_schema: &Schema,
     outer_schema: &Schema,
 ) -> Option<(CorrelationSide, PlSmallStr)> {
-    let (qualifier, name): (Option<&str>, PlSmallStr) = match expr {
-        SQLExpr::Identifier(ident) => (None, ident.value.as_str().into()),
-        SQLExpr::CompoundIdentifier(parts) => {
-            let (last, init) = parts.split_last()?;
-            // Only the table part: catalog/schema prefixes are dropped, just
-            // as `get_table_name` drops them when building `inner_names`.
-            (
-                init.last().map(|q| q.value.as_str()),
-                last.value.as_str().into(),
-            )
-        },
-        _ => return None,
-    };
+    let (qualifier, name) = qualifier_and_name(expr)?;
+    let name: PlSmallStr = name.into();
     match qualifier {
         Some(q) if inner_names.contains(q) => inner_schema
             .contains(name.as_str())

--- a/py-polars/tests/unit/sql/test_subqueries.py
+++ b/py-polars/tests/unit/sql/test_subqueries.py
@@ -454,6 +454,20 @@ def _subquery_ctx() -> pl.SQLContext[pl.LazyFrame]:
             "ANTI JOIN",
             [(1, 10), (2, 10)],
         ),
+        # Outer query joins the same table the subquery reads.
+        (
+            "SELECT c_custkey FROM customer, lineitem WHERE l_okey = c_custkey"
+            " AND c_custkey IN (SELECT c_custkey FROM customer WHERE c_acctbal >= 20)",
+            "SEMI JOIN",
+            [2, 5],
+        ),
+        # Same, with the inner columns reached through the alias.
+        (
+            "SELECT c_custkey FROM customer, lineitem WHERE l_okey = c_custkey"
+            " AND c_custkey IN (SELECT x.c_custkey FROM customer x WHERE x.c_acctbal >= 20)",
+            "SEMI JOIN",
+            [2, 5],
+        ),
         # NOT IN should follow SQL three-valued logic (ref: issue #28433).
         (
             "SELECT c_custkey FROM customer"
@@ -513,6 +527,41 @@ def test_sql_subquery_to_join(
     expected_rows = [t if isinstance(t, tuple) else (t,) for t in expected]
     expected_df = pl.DataFrame(expected_rows, schema=result.schema, orient="row")
     assert_frame_equal(result, expected_df, check_row_order=False)
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        (
+            "SELECT a FROM t1 WHERE EXISTS"
+            " (SELECT 1 FROM t1 AS x WHERE x.b < t1.b) ORDER BY a",
+            {"a": [3]},
+        ),
+        (
+            "SELECT a FROM t1 WHERE NOT EXISTS"
+            " (SELECT 1 FROM t1 AS x WHERE x.b < t1.b) ORDER BY a",
+            {"a": [1, 2]},
+        ),
+        pytest.param(
+            "SELECT a FROM t1 WHERE b IN"
+            " (SELECT x.b FROM t1 AS x WHERE x.a < t1.a) ORDER BY a",
+            {"a": [2]},
+            marks=pytest.mark.xfail(
+                reason="generic path drops the outer qualifier on a non-equi"
+                " correlated IN",
+            ),
+        ),
+    ],
+)
+def test_self_referencing_subquery_qualified_correlation(
+    query: str, expected: dict[str, list[int]]
+) -> None:
+    assert_sql_matches(
+        frames={"t1": pl.DataFrame({"a": [1, 2, 3], "b": [10, 10, 30]})},
+        query=query,
+        compare_with="duckdb",
+        expected=expected,
+    )
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/sql/test_subqueries.py
+++ b/py-polars/tests/unit/sql/test_subqueries.py
@@ -542,15 +542,6 @@ def test_sql_subquery_to_join(
             " (SELECT 1 FROM t1 AS x WHERE x.b < t1.b) ORDER BY a",
             {"a": [1, 2]},
         ),
-        pytest.param(
-            "SELECT a FROM t1 WHERE b IN"
-            " (SELECT x.b FROM t1 AS x WHERE x.a < t1.a) ORDER BY a",
-            {"a": [2]},
-            marks=pytest.mark.xfail(
-                reason="generic path drops the outer qualifier on a non-equi"
-                " correlated IN",
-            ),
-        ),
     ],
 )
 def test_self_referencing_subquery_qualified_correlation(


### PR DESCRIPTION
Use opus 5 to improve subquery lowering.
