### PR TITLE
fix(rust): deposit() on struct arrays uses set_outer_validity instead of set_validity

### DIFF
--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -710,11 +710,35 @@ where
         }));
 
         let mut ca = unsafe { ChunkTakeUnchecked::take_unchecked(self, &gather_idxs) };
-        ca.set_validity(combine_validities_and(
+        let combined_validity = combine_validities_and(
             Some(validity),
             ca.rechunk_validity().as_ref(),
-        ));
-        ca
+        );
+
+        if self.dtype().is_struct() {
+            // `set_validity` panics for struct dtypes (it requires
+            // `set_outer_validity` instead). Route through
+            // `Series::with_validity`, which dispatches to
+            // `with_outer_validity` for structs.
+            let chunks = ca.chunks().clone();
+            let name = ca.name().clone();
+            // SAFETY: chunks came from a `ChunkedArray<T>`.
+            let s = unsafe {
+                Series::from_chunks_and_dtype_unchecked(name, chunks, self.dtype())
+            };
+            let s = s.with_validity(combined_validity);
+            // SAFETY: chunks came from a `Series` with the same type.
+            unsafe {
+                Self::from_chunks_and_dtype(
+                    s.name().clone(),
+                    s.chunks().clone(),
+                    self.dtype().clone(),
+                )
+            }
+        } else {
+            ca.set_validity(combined_validity);
+            ca
+        }
     }
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes #28932 — `.item()` on `List[struct]` with null values panics with `set_outer_validity should be used for struct types`.

### Root cause

`ChunkedArray::deposit()` calls `set_validity()` which asserts `!self.dtype().is_struct()`. For struct dtypes, `set_outer_validity` must be used instead.

The code path is triggered by `EvalExpr::evaluate_on_list_chunked` → `Column::deposit` → `Series::deposit` → `ChunkedArray::deposit` when `list.item()` is applied to a `List[struct]` column with null values.

### Fix

In `ChunkedArray::deposit`, when the dtype is struct, route through `Series::with_validity` which dispatches to `StructChunked::with_outer_validity` (via `SeriesWrap<ChunkedArray<StructType>>::with_validity`). For non-struct types, the existing `set_validity` path is preserved.