### PR TITLE
fix: scan_delta(DeltaTable) fails with delta-rs string-typed storage_options

### DIFF
--- a/py-polars/src/polars/io/delta/functions.py
+++ b/py-polars/src/polars/io/delta/functions.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from polars._utils.deprecation import issue_deprecation_warning
 from polars._utils.wrap import wrap_ldf
-from polars.io.cloud._utils import NoPickleOption
+from polars.io.cloud._utils import NoPickleOption, POLARS_STORAGE_CONFIG_KEYS
 from polars.io.delta._dataset import DeltaDataset
 
 if TYPE_CHECKING:
@@ -345,8 +345,22 @@ def scan_delta(
     if table is not None and (
         table._storage_options is not None or storage_options is not None
     ):
+        # delta-rs requires all storage-option values to be strings, but polars
+        # parses the keys below as typed values. Convert string values coming
+        # from a DeltaTable back into the expected types so the table can be
+        # re-scanned with polars.
+        table_storage_options = dict(table._storage_options or {})
+        for key in POLARS_STORAGE_CONFIG_KEYS:
+            value = table_storage_options.get(key)
+            if isinstance(value, str):
+                try:
+                    table_storage_options[key] = (
+                        float(value) if key == "retry_base_multiplier" else int(value)
+                    )
+                except ValueError:
+                    pass  # keep the original string; polars raises a clear error
         storage_options = {
-            **(table._storage_options or {}),
+            **table_storage_options,
             **(storage_options or {}),
         }
 

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -1456,3 +1456,26 @@ def test_scan_delta_predicate_pushdown_struct_is_not_null(
     # must not be pruned.
     assert_frame_equal(out, df, check_row_order=False)
     assert "skipping 1 / 2 files" not in err
+
+@pytest.mark.write_disk
+def test_scan_delta_deltatable_string_storage_options(tmp_path: Path) -> None:
+    # GH #28901: a DeltaTable created with delta-rs string-typed storage options
+    # (e.g. ``max_retries="20"``) used to fail in scan_delta with
+    # "invalid value for 'max_retries': '20' (expected int)". String values coming
+    # from the DeltaTable must be converted to the types polars expects for keys
+    # it parses itself.
+    storage_options = {
+        "connect_timeout": "30s",
+        "timeout": "120s",
+        "max_retries": "20",
+        "retry_timeout": "600s",
+        "backoff_config.init_backoff": "500ms",
+        "backoff_config.max_backoff": "20s",
+        "backoff_config.base": "2.0",
+    }
+    df = pl.DataFrame({"x": [1]})
+    df.write_delta(tmp_path)
+    delta_table = DeltaTable(str(tmp_path), storage_options=storage_options)
+
+    result = pl.scan_delta(delta_table).collect()
+    assert_frame_equal(result, df)


### PR DESCRIPTION
## Problem

`scan_delta(DeltaTable)` fails with `ValueError: invalid value for 'max_retries': '20' (expected int)` when the `DeltaTable` was created with delta-rs string-typed storage options.

Delta-rs requires all storage option values to be strings, so users create a `DeltaTable` with e.g. `max_retries="20"`. However, when that same `DeltaTable` is passed to `scan_delta`, the string values are forwarded directly to the polars typed-key parser, which expects `int` for `max_retries`.

## Fix

In `scan_delta`, when merging `table._storage_options` (delta-rs string format) with the caller-supplied `storage_options`, convert the polars-parsed keys (`POLARS_STORAGE_CONFIG_KEYS`) from string to the expected numeric type before passing them to the Rust layer.

Other keys (e.g. `connect_timeout: "30s"`, `retry_timeout: "600s"`) are left as strings — they are forwarded to `object_store` which accepts them natively.

## Testing

- Added regression test `test_scan_delta_deltatable_string_storage_options` that creates a `DeltaTable` with the full set of string-typed storage options from the bug report and verifies that `scan_delta` succeeds.
- Verified locally with polars 1.43.2 + deltalake 1.6.3.

Closes #28901
