### PR TITLE
fix(python): Give `sink_batches` `lazy: Literal[False]` overload a default

### DIFF
--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -4232,7 +4232,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         *,
         chunk_size: int | None = None,
         maintain_order: bool = True,
-        lazy: Literal[False],
+        lazy: Literal[False] = ...,
         engine: EngineType = "auto",
         optimizations: QueryOptFlags = DEFAULT_QUERY_OPT_FLAGS,
     ) -> None: ...


### PR DESCRIPTION
The two `sink_batches` overloads declare `lazy` without a default, while the implementation has `lazy: bool = False`. A call that omits `lazy` therefore matches neither overload:

```Python
    lf.sink_batches(callback, chunk_size=10_000, engine="streaming")
```
=>
```
    error: No overload variant of "sink_batches" of "LazyFrame" matches
    argument types "Callable[[DataFrame], None]", "int", "str"
```

`sink_parquet`, `sink_csv` and the other sinks in this file already spell the non-lazy overload `lazy: Literal[False] = ...`; this brings `sink_batches` into line with them.

Checked with `mypy --strict` against `polars` 1.44.0: omitting `lazy` now resolves to `None`, `lazy=True` to `LazyFrame`, and `lazy=False` to `None`.
