### PR TITLE
fix(python): Type `collect_batches` as `_CollectBatches`, not `Iterator[DataFrame]`

### DIFF
--- a/py-polars/src/polars/lazyframe/engine.py
+++ b/py-polars/src/polars/lazyframe/engine.py
@@ -19,7 +19,7 @@ from polars.lazyframe.in_process import InProcessQuery
 from polars.lazyframe.query_result import SingleNodeQueryResult
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Iterator, Mapping
+    from collections.abc import Callable, Iterable, Mapping
 
     from rmm.mr import DeviceMemoryResource  # type: ignore[import-not-found]
 
@@ -184,7 +184,7 @@ class Engine(ABC):
         maintain_order: bool = True,
         chunk_size: int | None = None,
         lazy: bool = False,
-    ) -> Iterator[DataFrame]:
+    ) -> _CollectBatches:
         """Execute `lf`, yielding its result in batches."""
         msg = f"`collect_batches` is not supported by {type(self).__name__}"
         raise NotImplementedError(msg)
@@ -460,7 +460,7 @@ class _LocalEngine(Engine):
         maintain_order: bool = True,
         chunk_size: int | None = None,
         lazy: bool = False,
-    ) -> Iterator[DataFrame]:
+    ) -> _CollectBatches:
         optimizations = self._with_monitoring(optimizations)
         ldf = lf._ldf.with_optimizations(optimizations._pyoptflags)
         return _CollectBatches(

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import io
 import warnings
-from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
+from collections.abc import Collection, Iterable, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from datetime import date, datetime, time, timedelta
 from functools import lru_cache, reduce
@@ -108,7 +108,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 if TYPE_CHECKING:
     import sys
     from builtins import slice as slice_
-    from collections.abc import Awaitable, Callable, Iterator
+    from collections.abc import Awaitable, Callable
     from io import IOBase
     from typing import IO, Concatenate, Literal, ParamSpec
 
@@ -118,6 +118,7 @@ if TYPE_CHECKING:
 
     import polars.io.iceberg
     from polars.io.partition import PartitionBy, SinkedPathsCallback
+    from polars.lazyframe.engine import _CollectBatches
     from polars.lazyframe.opt_flags import QueryOptFlags
 
     with contextlib.suppress(ImportError):  # Module not available when building docs
@@ -4337,7 +4338,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         lazy: bool = False,
         engine: EngineType = "auto",
         optimizations: QueryOptFlags = DEFAULT_QUERY_OPT_FLAGS,
-    ) -> Iterator[DataFrame]:
+    ) -> _CollectBatches:
         """
         Evaluate the query in streaming mode and get a generator that returns chunks.
 
@@ -4400,7 +4401,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         if engine_.name == "auto":
             engine_ = _select_engine("streaming")
 
-        return engine_.collect_batches(  # type: ignore[no-any-return]
+        return engine_.collect_batches(
             self,
             optimizations=optimizations,
             maintain_order=maintain_order,


### PR DESCRIPTION
`LazyFrame.collect_batches` returns a `_CollectBatches`, which is an iterator of `DataFrame` *and* implements `__arrow_c_stream__`. The annotation only advertises the former, so handing the result straight to a consumer of the Arrow C stream interface -- the zero-copy path, and the reason `__arrow_c_stream__` is there -- fails to type-check:

```Python
    pa.RecordBatchReader.from_stream(lf.collect_batches())
```
=>
```
    error: Argument 1 to "from_stream" of "RecordBatchReader" has incompatible
    type "Iterator[DataFrame]"; expected "SupportArrowStream"
```
