### PR TITLE
perf: Don't materialize a scalar haystack in `list/arr.contains`

### DIFF
--- a/crates/polars-expr/src/dispatch/array.rs
+++ b/crates/polars-expr/src/dispatch/array.rs
@@ -140,11 +140,7 @@ pub(super) fn contains(s: &[Column], nulls_equal: bool) -> PolarsResult<Column> 
     );
     // Don't blow up the haystack in case of scalar.
     let haystack = array.as_materialized_series_maintain_scalar();
-    let mut ca = polars_ops::series::is_in(
-        item.as_materialized_series(),
-        &haystack,
-        nulls_equal,
-    )?;
+    let mut ca = polars_ops::series::is_in(item.as_materialized_series(), &haystack, nulls_equal)?;
     ca.rename(array.name().clone());
     // In case of scalar, broadcast back to original length
     ca.into_column()

--- a/crates/polars-expr/src/dispatch/array.rs
+++ b/crates/polars-expr/src/dispatch/array.rs
@@ -5,6 +5,7 @@ use polars_ops::prelude::array::ArrayNameSpace;
 use polars_plan::dsl::DslNameGenerator;
 use polars_plan::dsl::{ColumnsUdf, SpecialEq};
 use polars_plan::plans::IRArrayFunction;
+use polars_utils::broadcast::broadcast_len;
 use polars_utils::pl_str::PlSmallStr;
 
 use super::*;
@@ -137,13 +138,17 @@ pub(super) fn contains(s: &[Column], nulls_equal: bool) -> PolarsResult<Column> 
     polars_ensure!(matches!(array.dtype(), DataType::Array(_, _)),
         SchemaMismatch: "invalid series dtype: expected `Array`, got `{}`", array.dtype(),
     );
+    // Don't blow up the haystack in case of scalar.
+    let haystack = array.as_materialized_series_maintain_scalar();
     let mut ca = polars_ops::series::is_in(
         item.as_materialized_series(),
-        array.as_materialized_series(),
+        &haystack,
         nulls_equal,
     )?;
     ca.rename(array.name().clone());
-    Ok(ca.into_column())
+    // In case of scalar, broadcast back to original length
+    ca.into_column()
+        .broadcast_owned_to(broadcast_len([array, item])?)
 }
 
 #[cfg(feature = "array_count")]

--- a/crates/polars-expr/src/dispatch/list.rs
+++ b/crates/polars-expr/src/dispatch/list.rs
@@ -69,13 +69,17 @@ pub(super) fn contains(args: &mut [Column], nulls_equal: bool) -> PolarsResult<C
     polars_ensure!(matches!(list.dtype(), DataType::List(_)),
         SchemaMismatch: "invalid series dtype: expected `List`, got `{}`", list.dtype(),
     );
+    // Don't blow up the haystack in case of scalar.
+    let haystack = list.as_materialized_series_maintain_scalar();
     let mut ca = polars_ops::prelude::is_in(
         item.as_materialized_series(),
-        list.as_materialized_series(),
+        &haystack,
         nulls_equal,
     )?;
     ca.rename(list.name().clone());
-    Ok(ca.into_column())
+    // In case of scalar, broadcast back to original length
+    ca.into_column()
+        .broadcast_owned_to(broadcast_len([list, item])?)
 }
 
 #[cfg(feature = "list_drop_nulls")]

--- a/crates/polars-expr/src/dispatch/list.rs
+++ b/crates/polars-expr/src/dispatch/list.rs
@@ -71,11 +71,7 @@ pub(super) fn contains(args: &mut [Column], nulls_equal: bool) -> PolarsResult<C
     );
     // Don't blow up the haystack in case of scalar.
     let haystack = list.as_materialized_series_maintain_scalar();
-    let mut ca = polars_ops::prelude::is_in(
-        item.as_materialized_series(),
-        &haystack,
-        nulls_equal,
-    )?;
+    let mut ca = polars_ops::prelude::is_in(item.as_materialized_series(), &haystack, nulls_equal)?;
     ca.rename(list.name().clone());
     // In case of scalar, broadcast back to original length
     ca.into_column()

--- a/py-polars/tests/unit/operations/test_scalar.py
+++ b/py-polars/tests/unit/operations/test_scalar.py
@@ -120,6 +120,7 @@ def _broadcast_and_materialized(values: list[Any]) -> tuple[pl.LazyFrame, pl.Laz
         pl.col("l").list.len(),
         pl.col("l").list.sum(),
         pl.col("l").list.contains(30),
+        pl.col("l").list.contains(pl.col("a")),
         pl.col("l").list.get(0, null_on_oob=True),
         pl.col("a").is_in(pl.col("l")),
         pl.col("a").is_in(pl.col("l"), nulls_equal=True),
@@ -127,6 +128,28 @@ def _broadcast_and_materialized(values: list[Any]) -> tuple[pl.LazyFrame, pl.Laz
 )
 def test_elementwise_over_broadcast_scalar(expr: pl.Expr) -> None:
     broadcast, materialized = _broadcast_and_materialized([10, None, 30])
+    assert_frame_equal(
+        broadcast.select(expr).collect(), materialized.select(expr).collect()
+    )
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        pl.col("l").arr.contains(30),
+        pl.col("l").arr.contains(pl.col("a")),
+        pl.col("a").is_in(pl.col("l")),
+    ],
+)
+def test_elementwise_over_broadcast_scalar_array(expr: pl.Expr) -> None:
+    values = [10, 20, 30]
+    dtype = pl.Array(pl.Int64, len(values))
+    broadcast = pl.LazyFrame({"a": [1, 2, 30]}).with_columns(
+        pl.lit(pl.Series("l", [values], dtype=dtype)).first()
+    )
+    materialized = pl.LazyFrame(
+        {"a": [1, 2, 30], "l": pl.Series([values] * 3, dtype=dtype)}
+    )
     assert_frame_equal(
         broadcast.select(expr).collect(), materialized.select(expr).collect()
     )


### PR DESCRIPTION
Made with opus 5. Follow up to https://github.com/pola-rs/polars/pull/28942

Local benchmark results:

Measured, 1e6 rows, m = haystack length:

```
┌───────────────────────────┬──────────────────┬──────────────────┬──────────────────┐
│                           │      m=100       │      m=1000      │     m=10000      │
├───────────────────────────┼──────────────────┼──────────────────┼──────────────────┤
│ list.contains(col) before │ 0.79 s / 0.99 GB │ 7.87 s / 8.0 GB  │ OOM-killed       │
├───────────────────────────┼──────────────────┼──────────────────┼──────────────────┤
│ after                     │ —                │ 0.03 s / 0.21 GB │ 0.03 s / 0.21 GB │
├───────────────────────────┼──────────────────┼──────────────────┼──────────────────┤
│ arr.contains(col) before  │ 0.89 s / 1.77 GB │ 8.29 s / 13.2 GB │ OOM-killed       │
├───────────────────────────┼──────────────────┼──────────────────┼──────────────────┤
│ after                     │ —                │ 0.03 s / 0.25 GB │ 0.03 s / 0.25 GB │
└───────────────────────────┴──────────────────┴──────────────────┴──────────────────┘
```