### PR TITLE
fix: expand multi-column expressions in DataFrame.n_unique() subset (closes #28903)

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -64,7 +64,10 @@ from polars._utils.deprecation import (
     issue_deprecation_warning,
 )
 from polars._utils.getitem import get_df_item_by_key
-from polars._utils.parse import parse_into_expression
+from polars._utils.parse import (
+    parse_into_expression,
+    parse_into_list_of_expressions_require_selectors,
+)
 from polars._utils.pycapsule import is_pycapsule, pycapsule_to_frame
 from polars._utils.serde import serialize_polars_object
 from polars._utils.unstable import issue_unstable_warning, unstable
@@ -11545,15 +11548,14 @@ class DataFrame:
         ... )
         3
         """
-        if isinstance(subset, str):
-            expr = F.col(subset)
-        elif isinstance(subset, pl.Expr):
-            expr = subset
-        elif isinstance(subset, Sequence) and len(subset) == 1:
-            expr = wrap_expr(parse_into_expression(subset[0]))
+        if subset is None:
+            expr = F.struct(F.all())
         else:
-            struct_fields = F.all() if (subset is None) else subset
-            expr = F.struct(struct_fields)
+            expanded = [
+                wrap_expr(e)
+                for e in parse_into_list_of_expressions_require_selectors(subset)
+            ]
+            expr = F.struct(expanded)
 
         from polars.lazyframe.opt_flags import QueryOptFlags
 

--- a/py-polars/tests/unit/operations/unique/test_n_unique.py
+++ b/py-polars/tests/unit/operations/unique/test_n_unique.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+import polars.selectors as cs
 
 
 def test_n_unique() -> None:
@@ -77,3 +78,24 @@ def test_n_unique_array() -> None:
     assert df["arr"].dtype == pl.Array
     assert df.select(pl.col("arr")).n_unique() == 3
     assert df.select(pl.col("arr").n_unique()).item() == 3
+
+
+def test_n_unique_multi_column_expression_gh28903() -> None:
+    # gh-28903: n_unique() was ignoring additional columns when subset is a
+    # multi-column expression or selector.
+    df = pl.DataFrame(
+        {
+            "id": [1, 2, 3, 4, 5, 6],
+            "A": [1, 2, 3, 4, 1, 2],
+            "B": [1, 2, 3, 1, 1, 1],
+        }
+    )
+    # A & B together have 5 unique rows: (1,1),(2,2),(3,3),(4,1),(1,1),(2,1) -> 5
+    assert df.n_unique(subset=pl.col("A", "B")) == 5
+    assert df.n_unique(subset=cs.by_name("B", "A")) == 5
+    assert df.n_unique(subset=pl.exclude("id")) == 5
+    assert df.n_unique(subset=[cs.by_name("A", "B")]) == 5
+    assert df.n_unique(subset=[pl.col("B", "id")]) == 6
+    # single-column and list paths must still work
+    assert df.n_unique(subset="A") == 4
+    assert df.n_unique(subset=["A", "B"]) == 5


### PR DESCRIPTION
## What this fixes

Closes #28903.

`DataFrame.n_unique(subset=...)` silently ignored additional columns when `subset` was:
- a multi-column expression (`pl.col(A, B)`)
- a selector (`cs.by_name(A, B)`)
- a single-element list containing either of the above

In each case only the first resolved column was counted; the rest were dropped.

## Root cause

The previous dispatch branched on the input type, and for a bare `Expr` or a length-1 sequence it passed the raw expression directly to `.n_unique()` without expanding it. This is in contrast to `DataFrame.unique()`, which routes through `parse_into_list_of_expressions_require_selectors` to flatten multi-column inputs before use.

## Fix

Align `n_unique()` with `unique()`:
- pass every `subset` value through `parse_into_list_of_expressions_require_selectors` to expand multi-column expressions / selectors
- wrap the resolved columns in `F.struct(...)` and call `.n_unique()` on the struct

The struct approach is already used for the list-of-multiple-columns path, so this simply extends it to the previously mishandled cases.

## Verification

```python
df = pl.DataFrame({
    id: [1, 2, 3, 4, 5, 6],
    A:  [1, 2, 3, 4, 1, 2],
    B:  [1, 2, 3, 1, 1, 1],
})

# All of these now return 5 (was returning 4 or 3 before)
assert df.n_unique(subset=pl.col(A, B)) == 5
assert df.n_unique(subset=cs.by_name(B, A)) == 5
assert df.n_unique(subset=pl.exclude(id)) == 5
assert df.n_unique(subset=[cs.by_name(A, B)]) == 5
assert df.n_unique(subset=[pl.col(B, id)]) == 6
# Existing paths are unaffected
assert df.n_unique(subset=A) == 4
assert df.n_unique(subset=[A, B]) == 5
assert df.n_unique() == 6
```

A regression test covering all of these cases is added to `py-polars/tests/unit/operations/unique/test_n_unique.py`.

---
*[This is Claude Code on behalf of Venkateswarlu Nagineni]*
