### PR TITLE
fix(python): Leave stream position at end of stream in `read_ipc_stream`

### DIFF
--- a/crates/polars-python/src/dataframe/io.rs
+++ b/crates/polars-python/src/dataframe/io.rs
@@ -10,7 +10,7 @@ use pyo3::prelude::*;
 
 use super::PyDataFrame;
 use crate::conversion::Wrap;
-use crate::file::{get_file_like, get_mmap_bytes_reader};
+use crate::file::{get_file_like, get_incremental_bytes_reader, get_mmap_bytes_reader};
 use crate::prelude::PyCompatLevel;
 use crate::utils::EnterPolarsExt;
 
@@ -62,9 +62,11 @@ impl PyDataFrame {
             name: name.into(),
             offset,
         });
-        let mmap_bytes_r = get_mmap_bytes_reader(&py_f)?;
+        // Read lazily so a file handle is left positioned at the end of the stream,
+        // allowing multiple streams to be read from the same handle.
+        let bytes_r = get_incremental_bytes_reader(&py_f)?;
         py.enter_polars_df(move || {
-            IpcStreamReader::new(mmap_bytes_r)
+            IpcStreamReader::new(bytes_r)
                 .with_projection(projection)
                 .with_columns(columns)
                 .with_n_rows(n_rows)

--- a/crates/polars-python/src/file.rs
+++ b/crates/polars-python/src/file.rs
@@ -535,3 +535,29 @@ pub(crate) fn get_mmap_bytes_reader_and_path(
         }
     }
 }
+
+/// Like [`get_mmap_bytes_reader`], but reads a file-like object lazily instead of
+/// eagerly reading all of its contents. This leaves the stream position at the
+/// end of the bytes that were consumed, allowing multiple payloads to be read
+/// from a single handle (except for `BytesIO`, which uses `getvalue()` fast-path).
+pub(crate) fn get_incremental_bytes_reader(
+    py_f: &Bound<PyAny>,
+) -> PyResult<Box<dyn MmapBytesReader>> {
+    let py_f = read_if_bytesio(py_f.clone());
+
+    // bytes object
+    if let Ok(bytes) = py_f.cast::<PyBytes>() {
+        // SAFETY: we keep the underlying python object alive.
+        let slice = bytes.as_bytes();
+        let owner = bytes.clone().unbind();
+        let ss = unsafe { SharedStorage::from_slice_with_owner(slice, owner) };
+        Ok(Box::new(Cursor::new(Buffer::from_storage(ss))))
+    }
+    // string so read file
+    else {
+        match get_either_buffer_or_path(py_f.to_owned().unbind(), false)? {
+            (EitherRustPythonFile::Rust(f), _) => Ok(Box::new(f)),
+            (EitherRustPythonFile::Py(f), _) => Ok(Box::new(f)),
+        }
+    }
+}

--- a/py-polars/src/polars/io/ipc/functions.py
+++ b/py-polars/src/polars/io/ipc/functions.py
@@ -247,8 +247,10 @@ def read_ipc_stream(
         Path to a file or a file-like object (by "file-like object" we refer to objects
         that have a `read()` method, such as a file handler like the builtin `open`
         function, or a `BytesIO` instance). If `fsspec` is installed, it might be used
-        to open remote files. For file-like objects, the stream position may not be
-        updated accordingly after reading.
+        to open remote files. For file handles, the stream position is left at the end
+        of the stream that was read, so multiple streams can be read sequentially from
+        the same handle. `BytesIO` objects are read in full, so their position is not
+        updated.
     columns
         Columns to select. Accepts a list of column indices (starting at zero) or a list
         of column names.

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -57,6 +57,25 @@ def test_ipc_roundtrip_stream_parametric(
     assert_frame_equal(df, read_df, categorical_as_str=True)
 
 
+def test_read_ipc_stream_sequential_from_file_handle(tmp_path: Path) -> None:
+    # Multiple streams written to one handle should be readable one after another.
+    # https://github.com/pola-rs/polars/issues/20816
+    tmp_path.mkdir(exist_ok=True)
+    path = tmp_path / "streams.arrow"
+
+    frames = [pl.DataFrame({"a": [i], "b": [f"v{i}"]}) for i in range(3)]
+    with path.open("wb") as f:
+        for df in frames:
+            df.write_ipc_stream(f)
+
+    with path.open("rb") as f:
+        for expected in frames:
+            result = pl.read_ipc_stream(f, use_pyarrow=False)
+            assert_frame_equal(result, expected)
+        # Every stream has been consumed, so the handle is left at EOF.
+        assert f.read() == b""
+
+
 @pytest.mark.parametrize("compression", COMPRESSIONS)
 @given(
     df=dataframes(


### PR DESCRIPTION
## Description
  `read_ipc_stream` read the entire file-like object up front with a single `read()`, which left the object's stream
  position at EOF.
  As a result, reading several concatenated IPC streams from one open handle failed after the first read with `failed
  to fill whole buffer`, all while `use_pyarrow=True` worked.

  This reads the filelike object lazily instead, so the stream reader stops at the end-of-stream marker and leaves
  the position at the start of the next stream, matching pyarrow.
  It mirrors how `read_avro` already consumes file-like objects.

  Closes #20816.

  ## Changes
  - Add `get_incremental_bytes_reader` (crates/polars-python/src/file.rs): like `get_mmap_bytes_reader`, but returns
  the live file-like object instead of eagerly reading all of its contents into a buffer.
  - `read_ipc_stream` (crates/polars-python/src/dataframe/io.rs) uses it.
  - Update the `read_ipc_stream` docstring (the old "stream position may not be updated" caveat no longer applies).
  - Add regression test `test_read_ipc_stream_sequential_from_file_handle`.

  ## Scope / notes
  - Fixes file handles (e.g. `open(path, "rb")`), the reported case.
  - `BytesIO` still uses the existing `getvalue()` fast-path, so its behavior is unchanged here (could be a follow-up
  if desired).
  - `n_rows` early-stop behavior is unchanged.

  ## Testing
  - New test reads three streams sequentially from one handle and asserts each frame + EOF at the end.
  - Native reader now matches pyarrow exactly (stream positions 520 / 1040 / 1560).
  - Full IPC suite passes locally; `cargo fmt`, clippy, ruff, mypy, pyrefly, typos clean.

  PS: Made with Claude Opus 4.8, reviewed by me. +I confirm that I have reviewed all changes myself, and I believe they are relevant and correct.

<img width="665" height="329" alt="gittest" src="https://github.com/user-attachments/assets/f4df316a-2e7b-47c7-a4fe-2b24d50286bb" />

