### PR TITLE
fix: Track visited nodes in the `cache_states` DFS

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/cse/cache_states.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/cache_states.rs
@@ -1,6 +1,8 @@
 use std::ops::ControlFlow;
 
 use polars_error::PolarsResult;
+#[expect(clippy::disallowed_types)] // We don't iterate over it.
+use polars_utils::aliases::PlHashSet;
 use polars_utils::aliases::{InitHashMaps, PlIndexMap, PlIndexSet};
 use polars_utils::arena::{Arena, Node};
 use polars_utils::pl_str::PlSmallStr;
@@ -140,6 +142,8 @@ pub(crate) fn set_cache_states(
     let mut stack = Vec::with_capacity(4);
     let mut names_scratch = vec![];
     let mut predicates_scratch = vec![];
+    #[expect(clippy::disallowed_types)] // We don't iterate over it.
+    let mut walked_cache_ids = PlHashSet::new();
 
     scratch.clear();
     stack.clear();
@@ -278,6 +282,11 @@ pub(crate) fn set_cache_states(
                 }
             }
             frame.cache_id = Some(*id);
+
+            if !walked_cache_ids.insert(*id) {
+                scratch.clear();
+                continue;
+            }
         };
 
         // Shift parents.

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -1755,6 +1755,17 @@ def test_cspe_nested_cache_under_shared_subplan_no_union_28945() -> None:
     )
 
 
+def test_cspe_nested_user_caches_28945() -> None:
+    inner = pl.LazyFrame({"x": [1, 2, 3]}).cache()
+    outer = inner.filter(pl.col("x") > 1).cache()
+    q = pl.concat([outer, outer])
+
+    assert_frame_equal(
+        q.collect(),
+        q.collect(optimizations=pl.QueryOptFlags(comm_subplan_elim=False)),
+    )
+
+
 def test_cse_single_scalar_does_not_broadcast_28407() -> None:
     e = pl.lit(5).abs()
     q = pl.LazyFrame({"a": [1, 2, 3]}).select((e + e).alias("o"))

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -1732,6 +1732,29 @@ def test_cspe_nested_cache_does_not_block_pushable_filters() -> None:
     )
 
 
+def test_cspe_nested_cache_under_shared_subplan_28945() -> None:
+    cached = pl.LazyFrame({"x": [1]}).cache()
+    base = pl.concat([pl.LazyFrame({"x": [2]}), cached.filter(pl.col("x") > 0)])
+    frames = [base.filter(pl.col("x") == 1), base.filter(pl.col("x") == 2)]
+
+    for actual, expected in zip(
+        pl.collect_all(frames),
+        pl.collect_all(frames, optimizations=pl.QueryOptFlags(comm_subplan_elim=False)),
+        strict=True,
+    ):
+        assert_frame_equal(actual, expected)
+
+
+def test_cspe_nested_cache_under_shared_subplan_no_union_28945() -> None:
+    cached = pl.LazyFrame({"x": [1, 2, 3]}).cache()
+    q = pl.concat([cached.filter(pl.col("x") > 1), cached.filter(pl.col("x") > 1)])
+
+    assert_frame_equal(
+        q.collect(),
+        q.collect(optimizations=pl.QueryOptFlags(comm_subplan_elim=False)),
+    )
+
+
 def test_cse_single_scalar_does_not_broadcast_28407() -> None:
     e = pl.lit(5).abs()
     q = pl.LazyFrame({"a": [1, 2, 3]}).select((e + e).alias("o"))


### PR DESCRIPTION
`cache_states` is a pass that tries to push projections and filters through cache nodes, aimed to address the fact that predicate/projection pushdown happens after CSPE.

It assumes that the part of the input it traverses is a tree and not a DAG. When this assumption breaks down, it tries to rewrite the same node twice and panics.

Triggered by https://github.com/pola-rs/polars/pull/28859, but this was a preexisting issue.
Resolves https://github.com/pola-rs/polars/issues/28945