### PR TITLE
ci: Add `1.x` to the list of ci branches

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - main
       - "2.0"
+      - "1.x"
     paths:
       - crates/**
       - Cargo.toml

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -17,6 +17,7 @@ on:
     branches:
       - main
       - "2.0"
+      - "1.x"
     paths:
       - crates/**
       - docs/source/src/rust/**

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
       - "2.0"
+      - "1.x"
     paths:
       - '**.rs'
       - '**.py'

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - main
       - "2.0"
+      - "1.x"
     paths:
       - Cargo.lock
       - crates/**

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - main
       - "2.0"
+      - "1.x"
     paths:
       - crates/**
       - examples/**


### PR DESCRIPTION
I have just crated the [`1.x`](https://github.com/pola-rs/polars/tree/1.x) branch, to be used for version-1 backports. This PR adds this branch to the ci workflow (just like 2.0).
