### PR TITLE
fix: Restore `is_in` and lower arithmetic in string pyarrow predicates

### DIFF
--- a/crates/polars-plan/src/plans/python/pyarrow.rs
+++ b/crates/polars-plan/src/plans/python/pyarrow.rs
@@ -70,13 +70,6 @@ pub(crate) fn needle_isin_haystack(lv: &LiteralValue, nulls_equal: bool) -> Opti
     Some(IsInHaystack::Series(haystack_series))
 }
 
-#[derive(Default, Copy, Clone)]
-struct PyarrowArgs {
-    // pyarrow doesn't allow `filter([True, False])`
-    // but does allow `filter(field("a").isin([True, False]))`
-    allow_literal_series: bool,
-}
-
 #[cfg(feature = "dtype-datetime")]
 fn to_py_datetime(v: i64, tu: &TimeUnit, tz: Option<&TimeZone>) -> String {
     // note: `to_py_datetime` and the `Datetime`
@@ -100,73 +93,85 @@ fn sanitize(name: &str) -> Option<&str> {
     }
 }
 
+/// Render a flat `Series` as a Python list literal, e.g. `[1,2,3]`.
+///
+/// Returns `None` for values we cannot faithfully (or safely) write out as
+/// source text.
+fn series_to_pyarrow_list(s: &Series) -> Option<String> {
+    let mut list_repr = String::with_capacity(s.len() * 5);
+    list_repr.push('[');
+    for av in s.iter() {
+        match av {
+            AnyValue::Null => list_repr.push_str("None,"),
+            AnyValue::Boolean(v) => {
+                let s = if v { "True" } else { "False" };
+                write!(list_repr, "{s},").unwrap();
+            },
+            #[cfg(feature = "dtype-datetime")]
+            AnyValue::Datetime(v, tu, tz) => {
+                let dtm = to_py_datetime(v, &tu, tz);
+                write!(list_repr, "{dtm},").unwrap();
+            },
+            #[cfg(feature = "dtype-date")]
+            AnyValue::Date(v) => {
+                write!(list_repr, "to_py_date({v}),").unwrap();
+            },
+            AnyValue::String(s) => {
+                let _ = sanitize(s)?;
+                write!(list_repr, "{av},").unwrap();
+            },
+            // Hard to sanitize
+            AnyValue::Binary(_) | AnyValue::List(_) => return None,
+            #[cfg(feature = "dtype-array")]
+            AnyValue::Array(_, _) => return None,
+            #[cfg(feature = "dtype-struct")]
+            AnyValue::Struct(_, _, _) => return None,
+            _ => {
+                write!(list_repr, "{av},").unwrap();
+            },
+        }
+    }
+    // pop last comma
+    list_repr.pop();
+    list_repr.push(']');
+    Some(list_repr)
+}
+
 // Build an eval-able / AST-walker-compatible string predicate (e.g.
 // `pa.compute.field('x') > pa.compute.scalar(1)`). Used by the iceberg and
 // delta paths which feed the string into Python (delta `eval`s it,
 // iceberg walks it via `try_convert_pyarrow_predicate`).
 pub fn predicate_to_pa(predicate: Node, expr_arena: &Arena<AExpr>) -> Option<String> {
-    predicate_to_pa_inner(predicate, expr_arena, PyarrowArgs::default())
-}
-
-fn predicate_to_pa_inner(
-    predicate: Node,
-    expr_arena: &Arena<AExpr>,
-    args: PyarrowArgs,
-) -> Option<String> {
     match expr_arena.get(predicate) {
         AExpr::BinaryExpr { left, right, op } => {
-            if op.is_comparison_or_bitwise() {
-                let left = predicate_to_pa_inner(*left, expr_arena, args)?;
-                let right = predicate_to_pa_inner(*right, expr_arena, args)?;
-                Some(format!("({left} {op} {right})"))
-            } else {
-                None
+            let symbol = binary_op_symbol(op)?;
+            let mut lhs = predicate_to_pa(*left, expr_arena)?;
+            let rhs = predicate_to_pa(*right, expr_arena)?;
+
+            if op.is_arithmetic() {
+                // PyArrow expressions define no reflected arithmetic operators, so a
+                // bare Python literal on the left raises `TypeError` instead of
+                // building an expression. (Comparisons are fine: Python falls back
+                // to the reflected comparison on the right-hand expression.)
+                if matches!(expr_arena.get(*left), AExpr::Literal(_))
+                    && !lhs.starts_with("pa.compute.")
+                {
+                    lhs = format!("pa.compute.scalar({lhs})");
+                }
+
+                if matches!(op, Operator::TrueDivide) {
+                    lhs = format!("({lhs}).cast('{FLOAT_DIVIDEND_TYPE}')");
+                }
             }
+
+            Some(format!("({lhs} {symbol} {rhs})"))
         },
         AExpr::Column(name) => {
             let name = sanitize(name)?;
             Some(format!("pa.compute.field('{name}')"))
         },
-        AExpr::Literal(LiteralValue::Series(s)) => {
-            if !args.allow_literal_series || s.is_empty() || s.len() > 100 {
-                None
-            } else {
-                let mut list_repr = String::with_capacity(s.len() * 5);
-                list_repr.push('[');
-                for av in s.iter() {
-                    match av {
-                        AnyValue::Boolean(v) => {
-                            let s = if v { "True" } else { "False" };
-                            write!(list_repr, "{s},").unwrap();
-                        },
-                        #[cfg(feature = "dtype-datetime")]
-                        AnyValue::Datetime(v, tu, tz) => {
-                            let dtm = to_py_datetime(v, &tu, tz);
-                            write!(list_repr, "{dtm},").unwrap();
-                        },
-                        #[cfg(feature = "dtype-date")]
-                        AnyValue::Date(v) => {
-                            write!(list_repr, "to_py_date({v}),").unwrap();
-                        },
-                        AnyValue::String(s) => {
-                            let _ = sanitize(s)?;
-                            write!(list_repr, "{av},").unwrap();
-                        },
-                        AnyValue::Binary(_) | AnyValue::List(_) => return None,
-                        #[cfg(feature = "dtype-array")]
-                        AnyValue::Array(_, _) => return None,
-                        #[cfg(feature = "dtype-struct")]
-                        AnyValue::Struct(_, _, _) => return None,
-                        _ => {
-                            write!(list_repr, "{av},").unwrap();
-                        },
-                    }
-                }
-                list_repr.pop();
-                list_repr.push(']');
-                Some(list_repr)
-            }
-        },
+        // Only meaningful as the haystack of an `is_in`, which formats it itself.
+        AExpr::Literal(LiteralValue::Series(_)) => None,
         AExpr::Literal(lv) => {
             let av = lv.to_any_value()?;
             let dtype = av.dtype();
@@ -206,16 +211,23 @@ fn predicate_to_pa_inner(
         },
         #[cfg(feature = "is_in")]
         AExpr::Function {
-            function: IRFunctionExpr::Boolean(IRBooleanFunction::IsIn { .. }),
+            function: IRFunctionExpr::Boolean(IRBooleanFunction::IsIn { nulls_equal }),
             input,
             ..
         } => {
-            let col = predicate_to_pa_inner(input.first()?.node(), expr_arena, args)?;
-            let mut args = args;
-            args.allow_literal_series = true;
-            let values = predicate_to_pa_inner(input.get(1)?.node(), expr_arena, args)?;
+            let col = predicate_to_pa(input.first()?.node(), expr_arena)?;
 
-            Some(format!("({col}).isin({values})"))
+            let AExpr::Literal(lv) = expr_arena.get(input.get(1)?.node()) else {
+                return None;
+            };
+
+            match needle_isin_haystack(lv, *nulls_equal)? {
+                IsInHaystack::Empty => Some("pa.compute.scalar(False)".to_string()),
+                IsInHaystack::Series(s) => {
+                    let values = series_to_pyarrow_list(&s)?;
+                    Some(format!("({col}).isin({values})"))
+                },
+            }
         },
         #[cfg(feature = "is_between")]
         AExpr::Function {
@@ -226,7 +238,7 @@ fn predicate_to_pa_inner(
             if !matches!(expr_arena.get(input.first()?.node()), AExpr::Column(_)) {
                 None
             } else {
-                let col = predicate_to_pa_inner(input.first()?.node(), expr_arena, args)?;
+                let col = predicate_to_pa(input.first()?.node(), expr_arena)?;
                 let left_cmp_op = match closed {
                     ClosedInterval::None | ClosedInterval::Right => Operator::Gt,
                     ClosedInterval::Both | ClosedInterval::Left => Operator::GtEq,
@@ -236,8 +248,8 @@ fn predicate_to_pa_inner(
                     ClosedInterval::Both | ClosedInterval::Right => Operator::LtEq,
                 };
 
-                let lower = predicate_to_pa_inner(input.get(1)?.node(), expr_arena, args)?;
-                let upper = predicate_to_pa_inner(input.get(2)?.node(), expr_arena, args)?;
+                let lower = predicate_to_pa(input.get(1)?.node(), expr_arena)?;
+                let upper = predicate_to_pa(input.get(2)?.node(), expr_arena)?;
 
                 Some(format!(
                     "(({col} {left_cmp_op} {lower}) & ({col} {right_cmp_op} {upper}))"
@@ -248,7 +260,7 @@ fn predicate_to_pa_inner(
             function, input, ..
         } => {
             let input = input.first().unwrap().node();
-            let input = predicate_to_pa_inner(input, expr_arena, args)?;
+            let input = predicate_to_pa(input, expr_arena)?;
 
             match function {
                 IRFunctionExpr::Boolean(IRBooleanFunction::Not) => Some(format!("~({input})")),
@@ -265,6 +277,35 @@ fn predicate_to_pa_inner(
     }
 }
 
+/// Polars' `/` is always float division, while PyArrow's `divide` follows the
+/// operand types and would truncate an all-integer division. Casting the
+/// dividend keeps the two in agreement.
+const FLOAT_DIVIDEND_TYPE: &str = "double";
+
+/// The Python operator reproducing `op` on a PyArrow expression, or `None` when
+/// PyArrow has no equivalent. Mirrors [`binary_op_method`].
+///
+/// Note that the arithmetic operators map onto PyArrow's *checked* kernels,
+/// which raise on integer overflow where Polars wraps.
+fn binary_op_symbol(op: &Operator) -> Option<&'static str> {
+    Some(match op {
+        Operator::Eq => "==",
+        Operator::NotEq => "!=",
+        Operator::Lt => "<",
+        Operator::LtEq => "<=",
+        Operator::Gt => ">",
+        Operator::GtEq => ">=",
+        Operator::And | Operator::LogicalAnd => "&",
+        Operator::Or | Operator::LogicalOr => "|",
+        Operator::Xor => "^",
+        Operator::Plus => "+",
+        Operator::Minus => "-",
+        Operator::Multiply => "*",
+        Operator::TrueDivide => "/",
+        _ => return None,
+    })
+}
+
 fn binary_op_method(op: &Operator) -> Option<&'static str> {
     Some(match op {
         Operator::Eq => "__eq__",
@@ -276,6 +317,10 @@ fn binary_op_method(op: &Operator) -> Option<&'static str> {
         Operator::And | Operator::LogicalAnd => "__and__",
         Operator::Or | Operator::LogicalOr => "__or__",
         Operator::Xor => "__xor__",
+        Operator::Plus => "__add__",
+        Operator::Minus => "__sub__",
+        Operator::Multiply => "__mul__",
+        Operator::TrueDivide => "__truediv__",
         _ => return None,
     })
 }
@@ -369,6 +414,11 @@ pub fn aexpr_to_pyarrow<'py>(
             let method = binary_op_method(op)?;
             let l = aexpr_to_pyarrow(py, pc, *left, expr_arena)?;
             let r = aexpr_to_pyarrow(py, pc, *right, expr_arena)?;
+            let l = if matches!(op, Operator::TrueDivide) {
+                l.call_method1("cast", (FLOAT_DIVIDEND_TYPE,)).ok()?
+            } else {
+                l
+            };
             l.call_method1(method, (r,)).ok()
         },
         AExpr::Column(name) => pc.call_method1("field", (name,)).ok(),

--- a/py-polars/src/polars/io/iceberg/_utils.py
+++ b/py-polars/src/polars/io/iceberg/_utils.py
@@ -136,12 +136,39 @@ def _ensure_boolean_expression(result: Any) -> Any:
 
 
 def try_convert_pyarrow_predicate(pyarrow_predicate: str) -> Any | None:
-    with contextlib.suppress(Exception):
+    try:
         expr_ast = _to_ast(pyarrow_predicate)
-        result = _convert_predicate(expr_ast)
-        return _ensure_boolean_expression(result)
+    except Exception:
+        return None
 
-    return None
+    # Polars hands us a conjunction of independently converted minterms, and
+    # PyIceberg has no equivalent for some of them (arithmetic, for one). Keep
+    # the conjuncts that do convert: dropping one only widens the filter, and
+    # the engine re-applies the full predicate after the scan.
+    converted: list[Any] = []
+
+    for conjunct in _split_conjuncts(expr_ast):
+        with contextlib.suppress(Exception):
+            converted.append(_ensure_boolean_expression(_convert_predicate(conjunct)))
+
+    if not converted:
+        return None
+
+    result = converted[0]
+
+    for expr in converted[1:]:
+        result = pyiceberg.expressions.And(result, expr)
+
+    return result
+
+
+def _split_conjuncts(a: ast.expr) -> Iterable[ast.expr]:
+    """Yield the operands of a (possibly nested) top-level `&`."""
+    if isinstance(a, BinOp) and isinstance(a.op, BitAnd):
+        yield from _split_conjuncts(a.left)
+        yield from _split_conjuncts(a.right)
+    else:
+        yield a
 
 
 def _to_ast(expr: str) -> ast.expr:

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -410,7 +410,7 @@ class TestIcebergExpressions:
         expr = try_convert_pyarrow_predicate("((pa.compute.field('id') * 2) > 4)")
         assert expr is None
 
-    def test_unparseable_predicate(self) -> None:
+    def test_unparsable_predicate(self) -> None:
         # Not valid Python at all - nothing to convert.
         expr = try_convert_pyarrow_predicate("pa.compute.field('id') >")
         assert expr is None

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -390,6 +390,33 @@ class TestIcebergExpressions:
         expr = try_convert_pyarrow_predicate("pa.compute.scalar(True)")
         assert expr == AlwaysTrue()
 
+    def test_unconvertible_conjunct_is_dropped(self) -> None:
+        # PyIceberg has no arithmetic, but dropping that conjunct only widens the
+        # filter - the engine re-applies the full predicate after the scan.
+        expr = try_convert_pyarrow_predicate(
+            "((pa.compute.field('id') > 10) & ((pa.compute.field('id') * 2) > 4))"
+        )
+        assert expr == GreaterThan("id", 10)
+
+        expr = try_convert_pyarrow_predicate(
+            "(((pa.compute.field('id') * 2) > 4) & (pa.compute.field('id') > 10) "
+            "& (pa.compute.field('id')).isin([1,2,3]))"
+        )
+        assert expr == And(
+            GreaterThan("id", 10), In("id", {literal(1), literal(2), literal(3)})
+        )
+
+    def test_fully_unconvertible_predicate(self) -> None:
+        expr = try_convert_pyarrow_predicate("((pa.compute.field('id') * 2) > 4)")
+        assert expr is None
+
+    def test_unconvertible_disjunct_is_not_dropped(self) -> None:
+        # Unlike a conjunct, dropping one side of an `|` would narrow the filter.
+        expr = try_convert_pyarrow_predicate(
+            "((pa.compute.field('id') > 10) | ((pa.compute.field('id') * 2) > 4))"
+        )
+        assert expr is None
+
 
 @dataclass(kw_only=True)
 class _TableDataAllTypes:
@@ -3104,6 +3131,55 @@ def test_scan_iceberg_partial_and_pushdown(
     # Verify: correctness
     assert len(result) == 2
     assert result["a"].to_list() == [2, 3]
+
+    # Arithmetic lowers to a pyarrow expression but has no PyIceberg equivalent,
+    # so only the other conjunct makes it into the table filter.
+    q = pl.scan_iceberg(tbl).filter((pl.col("a") > 1) & (pl.col("b") * 2 > 40.0))
+
+    capfd.readouterr()
+    result = q.collect()
+    capture = capfd.readouterr().err
+
+    assert "pa.compute.field('b') *" in capture
+    assert result["a"].to_list() == [3]
+
+
+@pytest.mark.write_disk
+def test_scan_iceberg_is_in_pushdown(
+    tmp_path: Path,
+    plmonkeypatch: PlMonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    plmonkeypatch.setenv("POLARS_VERBOSE_SENSITIVE", "1")
+
+    catalog = SqlCatalog(
+        "default",
+        uri="sqlite:///:memory:",
+        warehouse=format_file_uri_iceberg(tmp_path),
+    )
+    catalog.create_namespace("namespace")
+    catalog.create_table(
+        "namespace.table",
+        IcebergSchema(
+            NestedField(1, "a", LongType()),
+            NestedField(2, "b", StringType()),
+        ),
+    )
+    tbl = catalog.load_table("namespace.table")
+    pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]}).write_iceberg(
+        tbl, mode="append"
+    )
+
+    q = pl.scan_iceberg(tbl).filter(pl.col("b").is_in(["x", "z"]))
+
+    capfd.readouterr()
+    result = q.collect()
+    capture = capfd.readouterr().err
+
+    # Verify: `is_in` is lowered into the pyarrow predicate
+    assert 'isin(["x","z"])' in capture
+    # Verify: correctness
+    assert result["a"].to_list() == [1, 3]
 
 
 @pytest.mark.write_disk

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -410,6 +410,11 @@ class TestIcebergExpressions:
         expr = try_convert_pyarrow_predicate("((pa.compute.field('id') * 2) > 4)")
         assert expr is None
 
+    def test_unparseable_predicate(self) -> None:
+        # Not valid Python at all - nothing to convert.
+        expr = try_convert_pyarrow_predicate("pa.compute.field('id') >")
+        assert expr is None
+
     def test_unconvertible_disjunct_is_not_dropped(self) -> None:
         # Unlike a conjunct, dropping one side of an `|` would narrow the filter.
         expr = try_convert_pyarrow_predicate(

--- a/py-polars/tests/unit/io/test_pyarrow_dataset.py
+++ b/py-polars/tests/unit/io/test_pyarrow_dataset.py
@@ -224,8 +224,8 @@ def test_pyarrow_dataset_partial_predicate_pushdown(
     df.write_parquet(file_path)
     dset = ds.dataset(file_path, format="parquet")
 
-    # col("a") > 1 is convertible; col("a") * col("b") > 25 is not (arithmetic
-    # on two columns cannot be expressed as a pyarrow compute expression).
+    # col("a") > 1 is convertible; col("a") * col("b") > 25 is not (the mixed
+    # dtypes put a cast in the way, and casts have no lowering).
     # The optimizer pushes both terms into the scan's SELECTION, so our
     # MintermIter-based partial conversion should push the convertible part.
     q = pl.scan_pyarrow_dataset(dset).filter(
@@ -247,6 +247,58 @@ def test_pyarrow_dataset_partial_predicate_pushdown(
         df.lazy().filter((pl.col("a") > 1) & (pl.col("a") * pl.col("b") > 25)).collect()
     )
     assert_frame_equal(result, expected)
+
+
+def test_pyarrow_dataset_arithmetic_predicate_pushdown(
+    plmonkeypatch: PlMonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    plmonkeypatch.setenv("POLARS_VERBOSE_SENSITIVE", "1")
+
+    df = pl.DataFrame({"a": [1.0, 2.0, 3.0], "b": [10.0, 20.0, 30.0]})
+    dset = ds.dataset(df.to_arrow(compat_level=pl.CompatLevel.oldest()))
+
+    for pred, expected_expr in [
+        (pl.col("a") * 2 > 4.0, "(multiply_checked(a, 2) > 4)"),
+        (pl.col("a") + pl.col("b") > 25.0, "(add_checked(a, b) > 25)"),
+        (pl.col("b") - pl.col("a") > 18.0, "(subtract_checked(b, a) > 18)"),
+    ]:
+        q = pl.scan_pyarrow_dataset(dset).filter(pred)
+
+        capfd.readouterr()
+        result = q.collect()
+        capture = capfd.readouterr().err
+
+        assert (
+            f"converted pyarrow predicate: <pyarrow.compute.Expression {expected_expr}>"
+            in capture
+        )
+        assert "residual predicate: None" in capture
+        assert_frame_equal(result, df.filter(pred))
+
+
+def test_pyarrow_dataset_true_divide_predicate_pushdown(
+    plmonkeypatch: PlMonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    plmonkeypatch.setenv("POLARS_VERBOSE_SENSITIVE", "1")
+
+    # Polars' `/` is float division; PyArrow's follows the operand types, so an
+    # integer dividend has to be cast or `3 / 2` would come out as `1`.
+    df = pl.DataFrame({"a": [1, 2, 3, 7]})
+    dset = ds.dataset(df.to_arrow(compat_level=pl.CompatLevel.oldest()))
+
+    pred = pl.col("a") / 2 > 1.4
+    q = pl.scan_pyarrow_dataset(dset).filter(pred)
+
+    capfd.readouterr()
+    result = q.collect()
+    capture = capfd.readouterr().err
+
+    assert "divide_checked(cast(a, " in capture
+    assert "residual predicate: None" in capture
+    assert result["a"].to_list() == [3, 7]
+    assert_frame_equal(result, df.filter(pred))
 
 
 def test_pyarrow_dataset_is_in_predicate_pushdown(

--- a/py-polars/tests/unit/io/test_python_dataset.py
+++ b/py-polars/tests/unit/io/test_python_dataset.py
@@ -175,6 +175,8 @@ def test_dataset_provider_predicate_not_lowered(df: pl.DataFrame) -> None:
 def test_dataset_provider_predicate_partial(df: pl.DataFrame) -> None:
     # Unconvertible conjuncts are dropped, the rest is still lowered.
     assert (
-        lowered_predicate(df, (pl.col("id") > 3) & (pl.col("id") % 2 == 0), partial=True)
+        lowered_predicate(
+            df, (pl.col("id") > 3) & (pl.col("id") % 2 == 0), partial=True
+        )
         == "(pa.compute.field('id') > 3)"
     )

--- a/py-polars/tests/unit/io/test_python_dataset.py
+++ b/py-polars/tests/unit/io/test_python_dataset.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import date
 from typing import TYPE_CHECKING, Any
 
 import pyarrow as pa
@@ -132,6 +133,68 @@ def test_dataset_provider_predicate_is_in_nulls_equal(df: pl.DataFrame) -> None:
     assert (
         lowered_predicate(df, pl.col("cat").is_in(["alpha", None], nulls_equal=True))
         == "(pa.compute.field('cat')).isin([\"alpha\",None])"
+    )
+
+
+def test_dataset_provider_predicate_is_in_boolean() -> None:
+    df = pl.DataFrame({"flag": [True, False, True]})
+    assert (
+        lowered_predicate(df, pl.col("flag").is_in([True]))
+        == "(pa.compute.field('flag')).isin([True])"
+    )
+
+
+def test_dataset_provider_predicate_is_in_date() -> None:
+    df = pl.DataFrame({"d": [date(2020, 1, 1), date(2020, 1, 2), date(2020, 1, 3)]})
+    assert (
+        lowered_predicate(df, pl.col("d").is_in([date(2020, 1, 1), date(2020, 1, 3)]))
+        == "(pa.compute.field('d')).isin([to_py_date(18262),to_py_date(18264)])"
+    )
+
+
+def test_dataset_provider_predicate_is_in_not_lowered() -> None:
+    df = pl.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "bin": [b"a", b"b", b"c"],
+            "st": [{"a": 1}, {"a": 2}, {"a": 3}],
+            "ids": [[1, 2], [3], [1]],
+        }
+    )
+    # Values we cannot safely write out as Python source text.
+    assert lowered_predicate(df, pl.col("bin").is_in([b"a", b"c"])) is None
+    assert lowered_predicate(df, pl.col("st").is_in([{"a": 1}])) is None
+    # A haystack that is not a literal at all.
+    assert lowered_predicate(df, pl.col("id").is_in(pl.col("ids"))) is None
+
+
+def test_dataset_provider_predicate_series_literal_not_lowered(
+    df: pl.DataFrame,
+) -> None:
+    # A `Series` literal is only meaningful as an `is_in` haystack.
+    assert lowered_predicate(df, pl.col("id") == pl.lit(pl.Series("s", [3]))) is None
+
+
+def test_dataset_provider_predicate_is_between(df: pl.DataFrame) -> None:
+    assert (
+        lowered_predicate(df, pl.col("id").is_between(2, 4))
+        == "((pa.compute.field('id') >= 2) & (pa.compute.field('id') <= 4))"
+    )
+    assert (
+        lowered_predicate(df, pl.col("id").is_between(2, 4, closed="none"))
+        == "((pa.compute.field('id') > 2) & (pa.compute.field('id') < 4))"
+    )
+
+
+def test_dataset_provider_predicate_nested_conjunction(df: pl.DataFrame) -> None:
+    # Top-level conjuncts are lowered one by one, but an `&` nested under an `|`
+    # has to be written out as an operator of its own.
+    assert (
+        lowered_predicate(
+            df, ((pl.col("id") > 3) & (pl.col("cat") == "alpha")) | (pl.col("id") < 2)
+        )
+        == "(((pa.compute.field('id') > 3) & (pa.compute.field('cat') == 'alpha'))"
+        " | (pa.compute.field('id') < 2))"
     )
 
 

--- a/py-polars/tests/unit/io/test_python_dataset.py
+++ b/py-polars/tests/unit/io/test_python_dataset.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pyarrow as pa
+import pyarrow.dataset as ds
+import pytest
+
+import polars as pl
+from polars._plr import PyLazyFrame
+from polars._utils.wrap import wrap_ldf
+from polars.testing import assert_frame_equal
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+class CapturingDataset:
+    """Minimal dataset provider that records the predicate Polars lowers for it."""
+
+    def __init__(self, df: pl.DataFrame) -> None:
+        self.df = df
+        self.arrow_schema = df.to_arrow().schema
+        self.pyarrow_predicate: str | None = None
+
+    def schema(self) -> pa.Schema:
+        return self.arrow_schema
+
+    def to_dataset_scan(
+        self, *, pyarrow_predicate: str | None = None, **_kwargs: Any
+    ) -> tuple[pl.LazyFrame, str]:
+        self.pyarrow_predicate = pyarrow_predicate
+
+        def impl(*_args: Any, **_kwargs: Any) -> tuple[Iterator[pl.DataFrame], bool]:
+            # Return everything: the engine re-applies the predicate itself.
+            return iter([self.df]), False
+
+        lf = pl.LazyFrame._scan_python_function(
+            self.arrow_schema, impl, pyarrow=True, is_pure=True
+        )
+
+        return lf, "v1"
+
+
+def lowered_predicate(
+    df: pl.DataFrame, predicate: pl.Expr, *, partial: bool = False
+) -> str | None:
+    """
+    Return the predicate string handed to a dataset provider for `predicate`.
+
+    Also asserts that the scan produces correct results, and - when something was
+    lowered - that the string builds a PyArrow expression selecting the same rows
+    (a superset of them, if only part of the predicate was lowered).
+    """
+    dataset = CapturingDataset(df)
+    lf = wrap_ldf(PyLazyFrame.new_from_dataset_object(dataset))
+
+    expected = df.filter(predicate)
+    assert_frame_equal(lf.filter(predicate).collect(), expected)
+
+    pyarrow_predicate = dataset.pyarrow_predicate
+
+    if pyarrow_predicate is not None:
+        from polars._utils.convert import (
+            to_py_date,
+            to_py_datetime,
+            to_py_time,
+            to_py_timedelta,
+        )
+
+        # The provider protocol says this is valid Python building a PyArrow
+        # expression - the same environment `scan_delta` evaluates it in.
+        expr = eval(
+            pyarrow_predicate,
+            {
+                "pa": pa,
+                "to_py_date": to_py_date,
+                "to_py_datetime": to_py_datetime,
+                "to_py_time": to_py_time,
+                "to_py_timedelta": to_py_timedelta,
+            },
+        )
+        filtered = pl.from_arrow(ds.dataset(df.to_arrow()).to_table(filter=expr))
+        assert isinstance(filtered, pl.DataFrame)
+
+        if partial:
+            assert_frame_equal(filtered.filter(predicate), expected)
+        else:
+            assert_frame_equal(filtered, expected)
+
+    return pyarrow_predicate
+
+
+@pytest.fixture
+def df() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "id": [1, 2, 3, 4, 5, 6],
+            "cat": ["alpha", "beta", "gamma", "delta", "alpha", "beta"],
+            "val": [0.25, 0.5, 0.75, 1.0, 1.25, 1.5],
+        }
+    )
+
+
+def test_dataset_provider_predicate_comparison(df: pl.DataFrame) -> None:
+    assert lowered_predicate(df, pl.col("id") > 3) == "(pa.compute.field('id') > 3)"
+
+
+def test_dataset_provider_predicate_is_in(df: pl.DataFrame) -> None:
+    assert (
+        lowered_predicate(df, pl.col("cat").is_in(["alpha", "beta"]))
+        == '(pa.compute.field(\'cat\')).isin(["alpha","beta"])'
+    )
+    assert (
+        lowered_predicate(df, pl.col("id").is_in([1, 3, 5]))
+        == "(pa.compute.field('id')).isin([1,3,5])"
+    )
+
+
+def test_dataset_provider_predicate_is_in_empty(df: pl.DataFrame) -> None:
+    assert lowered_predicate(df, pl.col("id").is_in([])) == "pa.compute.scalar(False)"
+
+
+def test_dataset_provider_predicate_is_in_nulls_equal(df: pl.DataFrame) -> None:
+    df = df.with_columns(pl.when(pl.col("id") > 3).then(pl.col("cat")).alias("cat"))
+
+    # Nulls are dropped from the haystack unless they are to compare equal.
+    assert (
+        lowered_predicate(df, pl.col("cat").is_in(["alpha", None]))
+        == "(pa.compute.field('cat')).isin([\"alpha\"])"
+    )
+    assert (
+        lowered_predicate(df, pl.col("cat").is_in(["alpha", None], nulls_equal=True))
+        == "(pa.compute.field('cat')).isin([\"alpha\",None])"
+    )
+
+
+def test_dataset_provider_predicate_arithmetic(df: pl.DataFrame) -> None:
+    assert (
+        lowered_predicate(df, pl.col("val") * 2 > 1.0)
+        == "((pa.compute.field('val') * 2) > 1)"
+    )
+    assert (
+        lowered_predicate(df, pl.col("val") + 1.0 <= 1.5)
+        == "((pa.compute.field('val') + 1) <= 1.5)"
+    )
+    assert (
+        lowered_predicate(df, pl.col("id") * pl.col("id") > 4)
+        == "((pa.compute.field('id') * pa.compute.field('id')) > 4)"
+    )
+    # PyArrow expressions have no reflected arithmetic, so a literal on the left
+    # has to become an expression of its own.
+    assert (
+        lowered_predicate(df, 2.0 - pl.col("val") > 1.0)
+        == "((pa.compute.scalar(2) - pa.compute.field('val')) > 1)"
+    )
+
+
+def test_dataset_provider_predicate_true_divide(df: pl.DataFrame) -> None:
+    # Polars' `/` is float division, PyArrow's follows the operand types, so the
+    # dividend has to be cast for an integer column not to truncate.
+    assert (
+        lowered_predicate(df, pl.col("id") / 4 > 1.0)
+        == "(((pa.compute.field('id')).cast('double') / 4) > 1)"
+    )
+
+
+def test_dataset_provider_predicate_not_lowered(df: pl.DataFrame) -> None:
+    # `%` has no PyArrow expression form.
+    assert lowered_predicate(df, pl.col("id") % 2 == 0) is None
+    # Neither does a cast.
+    assert lowered_predicate(df, pl.col("id").cast(pl.String) == "1") is None
+
+
+def test_dataset_provider_predicate_partial(df: pl.DataFrame) -> None:
+    # Unconvertible conjuncts are dropped, the rest is still lowered.
+    assert (
+        lowered_predicate(df, (pl.col("id") > 3) & (pl.col("id") % 2 == 0), partial=True)
+        == "(pa.compute.field('id') > 3)"
+    )


### PR DESCRIPTION
## Problem

`predicate_to_pa` builds the `pyarrow_predicate` string handed to dataset providers through `to_dataset_scan` (iceberg, delta, third-party). Whatever it can't lower is filtered engine-side instead of at the source.

#27271 moved the `scan_pyarrow_dataset` lowering to PyO3 objects and, in passing, reverted the *string* path's `is_in` handling to its pre-#26811 state, where the length-1 list literal holding the haystack always hit `AnyValue::List(_) => None`. So `is_in` stopped being pushed down for every provider on that path.

## Changes

- Restore `is_in` by reusing `needle_isin_haystack` — the same explode / `nulls_equal` / item-limit handling the PyO3 path uses, so the two can't drift apart again.
- Lower `+ - * /` in both paths, via one explicit operator table each:
  - `/` casts the dividend to `double`; Polars' `/` is float division while PyArrow's follows operand types, so an all-integer division would truncate and drop rows.
  - a bare literal on the left of arithmetic becomes `pa.compute.scalar(...)`, since PyArrow expressions have no reflected arithmetic operators (the delta path `eval`s the string, so `2 * pa.compute.field('a')` would crash).
- Being explicit about operators also stops `eq_missing` emitting `==v`, which isn't valid Python; it's now simply not lowered.
- `try_convert_pyarrow_predicate` splits the top-level `&` spine and keeps the conjuncts PyIceberg can express. Arithmetic has no PyIceberg equivalent and previously failed the whole predicate, which would have re-broken #26566. Top-level only, so polarity stays positive and dropping a conjunct only widens the filter.

Note: the arithmetic operators map onto PyArrow's *checked* kernels, which raise on integer overflow where Polars wraps.

## Tests

New `test_python_dataset.py` asserts the exact string lowered for a capturing dataset provider, then `eval`s it against a real PyArrow dataset to confirm it selects the same rows as Polars (a superset, where only part of the predicate lowers). Covers `is_in` (strings, integers, booleans, dates, `nulls_equal`, and the haystacks we refuse), arithmetic, `/`, `is_between`, nested conjunctions, and the cases that stay unlowered.

`test_iceberg.py` gets converter unit tests for conjunct dropping plus an end-to-end `is_in` pushdown; `test_pyarrow_dataset.py` covers arithmetic and true division on the PyO3 path.