### PR TITLE
refactor(rust): Improve OOC SpillContext reinsertion logic with reason

### DIFF
--- a/crates/polars-ooc/src/memory_manager.rs
+++ b/crates/polars-ooc/src/memory_manager.rs
@@ -123,7 +123,7 @@ impl MemoryManager {
 
                 polars_async::executor::spawn(TaskPriority::High, async move {
                     // Spill, or reinsert if a failure.
-                    match spillable.try_spill(ctx.clone(), reg_id) {
+                    match spillable.clone().try_spill(ctx.clone(), reg_id) {
                         Ok(spill_success) => {
                             if spill_success.await {
                                 if !successful_spill.0.swap(true, Ordering::Relaxed) {
@@ -131,14 +131,15 @@ impl MemoryManager {
                                         strong.stats().finish_exploration_event(true);
                                     }
                                 }
-                            } else {
-                                ctx.0.reinsert(&spillable, reg_id, ctx.1);
-                            }
 
-                            MEMORY_MANAGER.spills_exist.store(true, Ordering::Release);
+                                MEMORY_MANAGER.spills_exist.store(true, Ordering::Release);
+                            } else {
+                                // A racy pin interrupted us, the value is still in memory.
+                                spillable.cancel_spill_attempt_and_reinsert(reg_id, ctx.1);
+                            }
                         },
                         Err(TrySpillError::Pinned) => {
-                            ctx.0.reinsert(&spillable, reg_id, ctx.1);
+                            spillable.cancel_spill_attempt_and_reinsert(reg_id, ctx.1);
                         },
                         Err(TrySpillError::AlreadySpilled) => {},
                     }
@@ -217,15 +218,13 @@ impl MemoryManager {
             let mut candidates = Vec::new();
             ctx.0.drain_while(|cand, reg_id| {
                 if cand.can_spill()
-                    && let Some(sz) = cand.estimate_byte_size()
+                    && let Some(sz) = cand.clone().estimate_byte_size()
                     && sz as u64 >= min_spill
                 {
                     total_est_spill += sz as u64;
                     candidates.push((cand, reg_id, sz));
                 } else {
-                    if !cand.is_spilled_or_dropped() {
-                        ctx.0.reinsert(&cand, reg_id, ctx.1);
-                    }
+                    cand.cancel_spill_attempt_and_reinsert(reg_id, ctx.1);
                 }
 
                 num_considered += 1;

--- a/crates/polars-ooc/src/spill_context/mod.rs
+++ b/crates/polars-ooc/src/spill_context/mod.rs
@@ -139,6 +139,12 @@ impl SpillContextPolicy {
     }
 }
 
+pub(crate) enum ReinsertReason {
+    Unspill,
+    Unpin,
+    SpillCancelled,
+}
+
 pub(crate) struct SpillContextInner {
     staging: ThreadLocal<Mutex<LocalStagingArea>>,
     staging_empty: AtomicBool,
@@ -234,7 +240,14 @@ impl SpillContextInner {
         }
     }
 
-    pub(crate) fn reinsert(&self, token: &Arc<dyn DynSpillToken>, reg_id: u32, ctx_id: u64) {
+    pub(crate) fn reinsert(
+        &self,
+        token: &Arc<dyn DynSpillToken>,
+        reg_id: u32,
+        ctx_id: u64,
+        _reason: ReinsertReason,
+    ) {
+        // TODO: use reason to place token in appropriate spot.
         let mut local = self.staging.get_or_default().lock().unwrap();
         if ctx_id != self.context_id.load(Ordering::Relaxed) {
             return;

--- a/crates/polars-ooc/src/spill_token.rs
+++ b/crates/polars-ooc/src/spill_token.rs
@@ -10,15 +10,17 @@ use polars_async::ASYNC;
 use polars_utils::UnitVec;
 use polars_utils::with_drop::WithDrop;
 
+use crate::spill_context::ReinsertReason;
 use crate::{SpillContextParam, Spillable, WeakSpillContext};
 
 // SpillTokenInner's state
 const SPILLED_BIT: u64 = 1; // Set when value = None and spilled is Some.
 const DROPPED_BIT: u64 = 2; // Set when the token owner has dropped. Forbids creation of new pins / lock.
 const LOCK_BIT: u64 = 4; // When set no new pins may be made, and at most 1 thread may set this bit.
-const HAS_WAITERS_BIT: u64 = 8; // Only updated while holding waiters lock.
-const RO_PIN_COUNT_UNIT: u64 = 16; // Added to the state for each active pin.
-const RO_PIN_MASK: u64 = u64::MAX << 4;
+const HAS_WAITERS_BIT: u64 = 8; // Only updated while holding waiters lock, allows checking for waiters without locking.
+const REINSERT_WHEN_SPILLABLE_BIT: u64 = 16; // When set the SpillToken should insert into its registered context once spillable.
+const RO_PIN_COUNT_UNIT: u64 = 32; // Added to the state for each active pin.
+const RO_PIN_MASK: u64 = u64::MAX << 5;
 
 enum ValueSlot<T> {
     InMemory(T),
@@ -115,8 +117,8 @@ impl<T: Spillable> SpillTokenInner<T> {
     }
 
     // Try to pin the value, returning None if it is spilled, locked or dropped.
-    fn try_pin(&self) -> Option<PinnedRef<'_, T>> {
-        self.state
+    fn try_pin(slf: &Arc<Self>) -> Option<PinnedRef<'_, T>> {
+        slf.state
             .try_update(Ordering::Acquire, Ordering::Relaxed, |state| {
                 if state & (SPILLED_BIT | LOCK_BIT | DROPPED_BIT) != 0 {
                     return None;
@@ -124,27 +126,27 @@ impl<T: Spillable> SpillTokenInner<T> {
                 Some(state + RO_PIN_COUNT_UNIT)
             })
             .ok()
-            .map(|_| PinnedRef { inner: self })
+            .map(|_| PinnedRef { inner: slf })
     }
 
     // Pin the value, grabbing the lock if it is spilled.
     //
     // If the value is locked this will wait for the lock.
-    async fn pin_or_lock(&self) -> Option<PinnedRef<'_, T>> {
-        let mut state = self.state.load(Ordering::Relaxed);
+    async fn pin_or_lock(slf: &Arc<Self>) -> Option<PinnedRef<'_, T>> {
+        let mut state = slf.state.load(Ordering::Relaxed);
         loop {
             if state & (SPILLED_BIT | LOCK_BIT | DROPPED_BIT) == 0 {
-                match self.state.compare_exchange_weak(
+                match slf.state.compare_exchange_weak(
                     state,
                     state + RO_PIN_COUNT_UNIT,
                     Ordering::Acquire,
                     Ordering::Relaxed,
                 ) {
-                    Ok(_) => return Some(PinnedRef { inner: self }),
+                    Ok(_) => return Some(PinnedRef { inner: slf }),
                     Err(s) => state = s,
                 }
             } else if state & (LOCK_BIT | RO_PIN_MASK | DROPPED_BIT) == 0 {
-                match self.state.compare_exchange_weak(
+                match slf.state.compare_exchange_weak(
                     state,
                     state | LOCK_BIT,
                     Ordering::Acquire,
@@ -155,7 +157,7 @@ impl<T: Spillable> SpillTokenInner<T> {
                 }
             } else {
                 assert!(state & DROPPED_BIT == 0);
-                state = self.wait(LOCK_BIT).await;
+                state = slf.wait(LOCK_BIT).await;
             }
         }
     }
@@ -182,7 +184,7 @@ impl<T: Spillable> SpillTokenInner<T> {
     }
 
     async fn pin(slf: &Arc<Self>) -> PinnedRef<'_, T> {
-        if let Some(r) = slf.try_pin() {
+        if let Some(r) = Self::try_pin(slf) {
             return r;
         }
 
@@ -193,7 +195,7 @@ impl<T: Spillable> SpillTokenInner<T> {
     async fn pin_impl(slf: &Arc<Self>, prefetch: bool) -> PinnedRef<'_, T> {
         std::hint::cold_path();
 
-        if let Some(r) = slf.pin_or_lock().await {
+        if let Some(r) = Self::pin_or_lock(slf).await {
             return r;
         }
 
@@ -232,7 +234,12 @@ impl<T: Spillable> SpillTokenInner<T> {
             }
             if reinsert_reg_id == slf.registration_id.load(Ordering::Relaxed) {
                 let dyn_slf: Arc<dyn DynSpillToken> = slf.clone();
-                spill_ctx.0.reinsert(&dyn_slf, reinsert_reg_id, spill_ctx.1);
+                spill_ctx.0.reinsert(
+                    &dyn_slf,
+                    reinsert_reg_id,
+                    spill_ctx.1,
+                    ReinsertReason::Unspill,
+                );
             }
 
             WithDrop::dismiss(lock_guard);
@@ -245,7 +252,7 @@ impl<T: Spillable> SpillTokenInner<T> {
     }
 
     fn pin_blocking(slf: &Arc<Self>) -> PinnedRef<'_, T> {
-        if let Some(r) = slf.try_pin() {
+        if let Some(r) = Self::try_pin(slf) {
             return r;
         }
 
@@ -286,9 +293,12 @@ impl<T: Spillable> SpillTokenInner<T> {
                 }
                 if *reinsert_reg_id == slf.registration_id.load(Ordering::Relaxed) {
                     let dyn_slf: Arc<dyn DynSpillToken> = slf.clone();
-                    spill_ctx
-                        .0
-                        .reinsert(&dyn_slf, *reinsert_reg_id, spill_ctx.1);
+                    spill_ctx.0.reinsert(
+                        &dyn_slf,
+                        *reinsert_reg_id,
+                        spill_ctx.1,
+                        ReinsertReason::Unspill,
+                    );
                 }
 
                 *value_slot = ValueSlot::InMemory(value);
@@ -309,17 +319,46 @@ impl<T: Spillable> SpillTokenInner<T> {
 
     /// # Safety
     /// May only be called if you currently hold a pin.
-    unsafe fn unpin(&self) {
-        let old_s = self.state.fetch_sub(RO_PIN_COUNT_UNIT, Ordering::AcqRel);
+    unsafe fn unpin(slf: &Arc<Self>) {
+        let old_s = slf.state.fetch_sub(RO_PIN_COUNT_UNIT, Ordering::AcqRel);
         if old_s & RO_PIN_MASK == RO_PIN_COUNT_UNIT {
-            self.wake_waiters(old_s);
+            if old_s & REINSERT_WHEN_SPILLABLE_BIT != 0 {
+                Self::notify_spillable_after_unpin(slf);
+            }
+
+            slf.wake_waiters(old_s);
         }
     }
 
     /// # Safety
     /// May only be called if you currently hold a mutable pin.
-    unsafe fn unpin_mut(&self) {
-        self.wake_waiters(self.state.fetch_sub(LOCK_BIT, Ordering::AcqRel));
+    unsafe fn unpin_mut(slf: &Arc<Self>) {
+        let old_s = slf.state.fetch_sub(LOCK_BIT, Ordering::AcqRel);
+        if old_s & REINSERT_WHEN_SPILLABLE_BIT != 0 {
+            Self::notify_spillable_after_unpin(slf);
+        }
+        slf.wake_waiters(old_s);
+    }
+
+    #[cold]
+    fn notify_spillable_after_unpin(slf: &Arc<Self>) {
+        // Hold registration lock during this operation to prevent races.
+        let lock = slf.lock.lock().unwrap();
+        let old_s = slf
+            .state
+            .fetch_and(!REINSERT_WHEN_SPILLABLE_BIT, Ordering::AcqRel);
+        if let Some((spill_ctx, _param)) = &lock.cur_ctx {
+            if old_s & REINSERT_WHEN_SPILLABLE_BIT != 0 {
+                let dyn_slf: Arc<dyn DynSpillToken> = slf.clone();
+                let reinsert_reg_id = slf.registration_id.load(Ordering::Relaxed);
+                spill_ctx.0.reinsert(
+                    &dyn_slf,
+                    reinsert_reg_id,
+                    spill_ctx.1,
+                    ReinsertReason::Unpin,
+                );
+            }
+        }
     }
 
     /// # Safety
@@ -340,13 +379,13 @@ impl<T: Spillable> SpillTokenInner<T> {
     }
 }
 
-impl<T, S> Clone for SpillTokenInner<T>
+impl<T, S> SpillTokenInner<T>
 where
     T: Clone + Spillable<Spilled = S>,
     S: Clone,
 {
-    fn clone(&self) -> Self {
-        if let Some(r) = ASYNC.block_in_place_on(self.pin_or_lock()) {
+    fn clone_impl(slf: &Arc<Self>) -> Self {
+        if let Some(r) = ASYNC.block_in_place_on(Self::pin_or_lock(slf)) {
             return SpillTokenInner {
                 value_slot: UnsafeCell::new(ValueSlot::InMemory(r.clone())),
                 spilled_value: UnsafeCell::new(None),
@@ -358,7 +397,7 @@ where
 
         // We now hold the lock, meaning the value was spilled.
         unsafe {
-            let lock_guard = WithDrop::new(self, |slf| {
+            let lock_guard = WithDrop::new(slf, |slf| {
                 slf.wake_waiters(slf.state.fetch_and(!LOCK_BIT, Ordering::AcqRel));
             });
 
@@ -421,12 +460,13 @@ pub(crate) trait DynSpillToken: Send + Sync + 'static {
     /// already spilled.
     fn can_spill(&self) -> bool;
 
-    /// Whether this token is spilled or dropped.
-    fn is_spilled_or_dropped(&self) -> bool;
+    /// Call this exactly once after removing a SpillToken from its context to
+    /// re-insert it once it is spillable again.
+    fn cancel_spill_attempt_and_reinsert(self: Arc<Self>, reg_id: u32, context_id: u64);
 
     /// Estimates how many bytes this object takes up in memory. Returns None
     /// if the object cannot be pinned.
-    fn estimate_byte_size(&self) -> Option<usize>;
+    fn estimate_byte_size(self: Arc<Self>) -> Option<usize>;
 
     /// Tries to spill this token. Returns true if successful.
     ///
@@ -434,21 +474,33 @@ pub(crate) trait DynSpillToken: Send + Sync + 'static {
     /// If Ok the future may still return false, in which case a racy pin
     /// occurred during spilling.
     fn try_spill(
-        &self,
+        self: Arc<Self>,
         context: WeakSpillContext,
         registration_id: u32,
-    ) -> Result<Pin<Box<dyn Future<Output = bool> + Send + '_>>, TrySpillError>;
+    ) -> Result<Pin<Box<dyn Future<Output = bool> + Send>>, TrySpillError>;
 }
 
 impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
     fn register(&self, ctx: WeakSpillContext, param: SpillContextParam) -> u32 {
         let mut lock = self.lock.lock().unwrap();
+
+        // Clear the re-insert bit, we're registering to a new context.
+        self.state
+            .fetch_and(!REINSERT_WHEN_SPILLABLE_BIT, Ordering::Relaxed);
+
+        // Increment the registration ID to invalidate previous registration.
         lock.cur_ctx = Some((ctx, param));
         self.registration_id.fetch_add(1, Ordering::Release) + 1
     }
 
     fn unregister(&self) -> Option<(WeakSpillContext, SpillContextParam)> {
         let mut lock = self.lock.lock().unwrap();
+
+        // Clear the re-insert bit, this spillframe is now unregistered.
+        self.state
+            .fetch_and(!REINSERT_WHEN_SPILLABLE_BIT, Ordering::Relaxed);
+
+        // Increment the registration ID to invalidate previous registration.
         self.registration_id.fetch_add(1, Ordering::Release);
         lock.cur_ctx.take()
     }
@@ -462,23 +514,49 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
             == 0
     }
 
-    fn is_spilled_or_dropped(&self) -> bool {
-        self.state.load(Ordering::Acquire) & (SPILLED_BIT | DROPPED_BIT) != 0
+    fn cancel_spill_attempt_and_reinsert(self: Arc<Self>, reg_id: u32, context_id: u64) {
+        // Hold lock to not race with other registrations.
+        let lock = self.lock.lock().unwrap();
+
+        // Outdated registration?
+        let Some((ctx, _param)) = lock.cur_ctx.as_ref() else {
+            return;
+        };
+        if ctx.1 != context_id || self.registration_id.load(Ordering::Relaxed) != reg_id {
+            return;
+        }
+
+        // Set reinsert bit if locked/pinned.
+        let old_s = self.state.update(Ordering::AcqRel, Ordering::Relaxed, |s| {
+            if s & (LOCK_BIT | RO_PIN_MASK) != 0 {
+                s | REINSERT_WHEN_SPILLABLE_BIT
+            } else {
+                s
+            }
+        });
+
+        // Not locked/pinned/spilled/dropped, reinsert now. If spilled registration of that fact was
+        // done by the responsible party, if dropped it doesn't matter.
+        if old_s & (LOCK_BIT | RO_PIN_MASK | SPILLED_BIT | DROPPED_BIT) == 0 {
+            let dyn_slf: Arc<dyn DynSpillToken> = self.clone();
+            ctx.0
+                .reinsert(&dyn_slf, reg_id, context_id, ReinsertReason::SpillCancelled);
+        }
     }
 
-    fn estimate_byte_size(&self) -> Option<usize> {
-        self.try_pin().map(|p| p.estimate_byte_size())
+    fn estimate_byte_size(self: Arc<Self>) -> Option<usize> {
+        Self::try_pin(&self).map(|p| p.estimate_byte_size())
     }
 
     fn try_spill(
-        &self,
+        self: Arc<Self>,
         ctx: WeakSpillContext,
         registration_id: u32,
-    ) -> Result<Pin<Box<dyn Future<Output = bool> + Send + '_>>, TrySpillError> {
+    ) -> Result<Pin<Box<dyn Future<Output = bool> + Send>>, TrySpillError> {
         // First, we try setting the lock bit. If anyone else has a pin we don't bother.
         let pin_update = self
             .state
-            .try_update(Ordering::Relaxed, Ordering::Acquire, |state| {
+            .try_update(Ordering::Acquire, Ordering::Relaxed, |state| {
                 if state & (LOCK_BIT | DROPPED_BIT | RO_PIN_MASK) != 0 {
                     return None;
                 }
@@ -515,7 +593,7 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
                     self.state
                         .fetch_add(RO_PIN_COUNT_UNIT - LOCK_BIT, Ordering::AcqRel),
                 );
-                let pin_guard = PinnedRef { inner: self };
+                let pin_guard = PinnedRef { inner: &self };
                 let spilled = pin_guard.spill(&ctx.0.stats().name()).await;
                 core::mem::forget(pin_guard);
                 // We can simply re-acquire the lock here blindly, as we still hold
@@ -599,7 +677,7 @@ impl<T: Spillable> SpillToken<T> {
 
     /// Try to get a reference to the underlying value, returning None if it was spilled.
     pub fn try_get(&self) -> Option<PinnedRef<'_, T>> {
-        self.inner.try_pin()
+        SpillTokenInner::try_pin(&self.inner)
     }
 
     /// Get a reference to the underlying value, unspilling it if it was spilled.
@@ -651,7 +729,7 @@ where
     fn clone(&self) -> Self {
         // Note: we don't register the clone, perhaps we should?
         Self {
-            inner: Arc::new((*self.inner).clone()),
+            inner: Arc::new(SpillTokenInner::clone_impl(&self.inner)),
         }
     }
 }
@@ -663,7 +741,7 @@ impl<T: Spillable> Drop for SpillToken<T> {
 }
 
 pub struct PinnedRef<'a, T: Spillable> {
-    inner: &'a SpillTokenInner<T>,
+    inner: &'a Arc<SpillTokenInner<T>>,
 }
 
 impl<'a, T: Spillable> Deref for PinnedRef<'a, T> {
@@ -680,12 +758,12 @@ impl<'a, T: Spillable> Deref for PinnedRef<'a, T> {
 
 impl<'a, T: Spillable> Drop for PinnedRef<'a, T> {
     fn drop(&mut self) {
-        unsafe { self.inner.unpin() }
+        unsafe { SpillTokenInner::unpin(self.inner) }
     }
 }
 
 pub struct PinnedMut<'a, T: Spillable> {
-    inner: &'a SpillTokenInner<T>,
+    inner: &'a Arc<SpillTokenInner<T>>,
 }
 
 impl<'a, T: Spillable> Deref for PinnedMut<'a, T> {
@@ -712,6 +790,6 @@ impl<'a, T: Spillable> DerefMut for PinnedMut<'a, T> {
 
 impl<'a, T: Spillable> Drop for PinnedMut<'a, T> {
     fn drop(&mut self) {
-        unsafe { self.inner.unpin_mut() }
+        unsafe { SpillTokenInner::unpin_mut(self.inner) }
     }
 }


### PR DESCRIPTION
This was quite tricky, but now we should be able to use the reason to re-insert the `SpillToken` in the right order, while also avoiding livelocks/iterating over pinned values because any pinned values are removed from the `SpillContext` until they unpin.