### PR TITLE
refactor(rust): Improve (re-)insertion order for cancelled spills

### DIFF
--- a/crates/polars-ooc/src/memory_manager.rs
+++ b/crates/polars-ooc/src/memory_manager.rs
@@ -18,8 +18,8 @@ const SPILL_FRAME_BATCH_SIZE: u64 = 256;
 const MAX_PARALLEL_SPILL_TASKS: usize = 64;
 
 use crate::WeakSpillContext;
-use crate::spill_context::UNEXPLORED_SCORE;
-use crate::spill_token::{DynSpillToken, TrySpillError};
+use crate::spill_context::{RegisteredSpillToken, ReinsertReason, UNEXPLORED_SCORE};
+use crate::spill_token::{DynSpillToken, SpillStatus, TrySpillError};
 
 static MEMORY_MANAGER: LazyLock<MemoryManager> = LazyLock::new(MemoryManager::new);
 
@@ -115,7 +115,7 @@ impl MemoryManager {
                 },
             ));
 
-            for (spillable, reg_id, sz) in spillables {
+            for (spillable, spill_in_progress, rt) in spillables {
                 let permit = self.spill_semaphore.clone().acquire_owned().await.unwrap();
 
                 let successful_spill = successful_spill.clone();
@@ -123,7 +123,7 @@ impl MemoryManager {
 
                 polars_async::executor::spawn(TaskPriority::High, async move {
                     // Spill, or reinsert if a failure.
-                    match spillable.clone().try_spill(ctx.clone(), reg_id) {
+                    match spillable.clone().try_spill(ctx.clone(), rt.registration_id) {
                         Ok(spill_success) => {
                             if spill_success.await {
                                 if !successful_spill.0.swap(true, Ordering::Relaxed) {
@@ -135,20 +135,25 @@ impl MemoryManager {
                                 MEMORY_MANAGER.spills_exist.store(true, Ordering::Release);
                             } else {
                                 // A racy pin interrupted us, the value is still in memory.
-                                spillable.cancel_spill_attempt_and_reinsert(reg_id, ctx.1);
+                                spillable.cancel_spill_attempt_and_reinsert(
+                                    rt.registration_id,
+                                    ctx.1,
+                                    ReinsertReason::Unpin,
+                                );
                             }
                         },
                         Err(TrySpillError::Pinned) => {
-                            spillable.cancel_spill_attempt_and_reinsert(reg_id, ctx.1);
+                            spillable.cancel_spill_attempt_and_reinsert(
+                                rt.registration_id,
+                                ctx.1,
+                                ReinsertReason::Unpin,
+                            );
                         },
                         Err(TrySpillError::AlreadySpilled) => {},
                     }
 
-                    MEMORY_MANAGER
-                        .est_spill_in_progress
-                        .fetch_sub(sz as u64, Ordering::Relaxed);
-
                     drop(permit);
+                    drop(spill_in_progress);
                 });
             }
         }
@@ -168,7 +173,14 @@ impl MemoryManager {
     #[cold]
     async fn find_spillables(
         &self,
-    ) -> Option<(WeakSpillContext, Vec<(Arc<dyn DynSpillToken>, u32, usize)>)> {
+    ) -> Option<(
+        WeakSpillContext,
+        Vec<(
+            Arc<dyn DynSpillToken>,
+            SpillInProgressTracker,
+            RegisteredSpillToken,
+        )>,
+    )> {
         // TODO: don't block here under a certain memory threshold.
         let finding_spill_guard = self.finding_spill_lock.lock().await;
 
@@ -213,18 +225,33 @@ impl MemoryManager {
             };
             strong.stats().start_exploration_event();
 
-            let mut total_est_spill = 0;
             let mut num_considered = 0;
             let mut candidates = Vec::new();
-            ctx.0.drain_while(|cand, reg_id| {
-                if cand.can_spill()
-                    && let Some(sz) = cand.clone().estimate_byte_size()
-                    && sz as u64 >= min_spill
-                {
-                    total_est_spill += sz as u64;
-                    candidates.push((cand, reg_id, sz));
-                } else {
-                    cand.cancel_spill_attempt_and_reinsert(reg_id, ctx.1);
+            ctx.0.drain_while(|rt| {
+                let Some(cand) = rt.upgrade() else {
+                    return true;
+                };
+                match cand.clone().spill_status() {
+                    SpillStatus::InMemory(sz) if sz >= min_spill => {
+                        candidates.push((cand, SpillInProgressTracker::new(sz), rt));
+                    },
+                    SpillStatus::InMemory(_) => {
+                        cand.cancel_spill_attempt_and_reinsert(
+                            rt.registration_id,
+                            ctx.1,
+                            ReinsertReason::TooSmall(rt.timestamp),
+                        );
+                    },
+                    SpillStatus::Pinned => {
+                        cand.cancel_spill_attempt_and_reinsert(
+                            rt.registration_id,
+                            ctx.1,
+                            ReinsertReason::Unpin,
+                        );
+                    },
+                    // A spilled token is re-inserted by whoever unspills it, a
+                    // dropped one does not need re-inserting at all.
+                    SpillStatus::Spilled | SpillStatus::Dropped => {},
                 }
 
                 num_considered += 1;
@@ -234,9 +261,6 @@ impl MemoryManager {
             if candidates.is_empty() {
                 strong.stats().finish_exploration_event(false);
             } else {
-                // Increment the spill-in-progress to avoid eager over-spilling.
-                self.est_spill_in_progress
-                    .fetch_add(total_est_spill, Ordering::Relaxed);
                 out = Some((ctx, candidates));
                 break;
             }
@@ -247,5 +271,27 @@ impl MemoryManager {
             self.clean_contexts();
         }
         out
+    }
+}
+
+/// Used to update the total bytes of estimated spills in progress.
+struct SpillInProgressTracker {
+    bytes: u64,
+}
+
+impl SpillInProgressTracker {
+    pub fn new(bytes: u64) -> Self {
+        memory_manager()
+            .est_spill_in_progress
+            .fetch_add(bytes, Ordering::Relaxed);
+        Self { bytes }
+    }
+}
+
+impl Drop for SpillInProgressTracker {
+    fn drop(&mut self) {
+        memory_manager()
+            .est_spill_in_progress
+            .fetch_sub(self.bytes, Ordering::Relaxed);
     }
 }

--- a/crates/polars-ooc/src/spill_context/mod.rs
+++ b/crates/polars-ooc/src/spill_context/mod.rs
@@ -22,53 +22,46 @@ fn new_context_id() -> u64 {
     CONTEXT_ID_CTR.fetch_add(1, Ordering::Relaxed)
 }
 
-pub struct RegisteredSpillToken {
+#[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq)]
+pub struct Timestamp(pub u64);
+
+impl Timestamp {
+    pub fn now() -> Self {
+        Self(tick_counter())
+    }
+}
+
+pub(crate) struct RegisteredSpillToken {
     token: Weak<dyn DynSpillToken>,
-    registration_id: u32,
-    timestamp: u64,
+    pub registration_id: u32,
+    pub timestamp: Timestamp,
 }
 
 impl RegisteredSpillToken {
-    fn new(token: &Arc<dyn DynSpillToken>, registration_id: u32) -> Self {
+    fn new(token: &Arc<dyn DynSpillToken>, registration_id: u32, timestamp: Timestamp) -> Self {
         RegisteredSpillToken {
             token: Arc::downgrade(token),
             registration_id,
-            timestamp: tick_counter(),
+            timestamp,
         }
     }
 
-    fn upgrade(&self) -> Option<(Arc<dyn DynSpillToken>, u32)> {
+    pub fn upgrade(&self) -> Option<Arc<dyn DynSpillToken>> {
         self.token
             .upgrade()
             .filter(|t| t.current_registration_id() == self.registration_id)
-            .map(|t| (t, self.registration_id))
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.upgrade().is_some()
     }
 }
 
 #[derive(Default)]
 struct LocalStagingArea {
-    tokens: Vec<RegisteredSpillToken>,
-    retain_amort: usize,
-}
-
-impl LocalStagingArea {
-    pub fn push(&mut self, token: &Arc<dyn DynSpillToken>, id: u32) {
-        self.gc();
-        self.tokens.push(RegisteredSpillToken::new(token, id));
-    }
-
-    pub fn drain_into(&mut self, target: &mut Vec<RegisteredSpillToken>) {
-        target.append(&mut self.tokens);
-        self.retain_amort = 0;
-    }
-
-    fn gc(&mut self) {
-        self.retain_amort += 2; // Grows twice as fast as push.
-        if self.retain_amort >= self.tokens.len() {
-            self.retain_amort = 0;
-            self.tokens.retain(|t| t.upgrade().is_some());
-        }
-    }
+    accesses: SpillQueue,
+    cancellations: SpillQueue,
+    too_small: SpillQueue,
 }
 
 #[derive(Default)]
@@ -78,35 +71,40 @@ struct SpillQueue {
 }
 
 impl SpillQueue {
-    pub fn push_back(&mut self, token: &Arc<dyn DynSpillToken>, id: u32) {
+    pub fn push_back(&mut self, token: RegisteredSpillToken) {
         self.gc();
-        self.tokens.push_back(RegisteredSpillToken::new(token, id));
+        self.tokens.push_back(token);
     }
 
-    pub fn pop_front(&mut self) -> Option<(Arc<dyn DynSpillToken>, u32)> {
+    pub fn push_front(&mut self, token: RegisteredSpillToken) {
+        self.gc();
+        self.tokens.push_front(token);
+    }
+
+    pub fn pop_front(&mut self) -> Option<RegisteredSpillToken> {
         loop {
             let front = self.tokens.pop_front()?;
-            if let Some(r) = front.upgrade() {
-                return Some(r);
+            if front.is_valid() {
+                return Some(front);
             }
         }
     }
 
-    pub fn pop_back(&mut self) -> Option<(Arc<dyn DynSpillToken>, u32)> {
+    pub fn pop_back(&mut self) -> Option<RegisteredSpillToken> {
         loop {
             let back = self.tokens.pop_back()?;
-            if let Some(r) = back.upgrade() {
-                return Some(r);
+            if back.is_valid() {
+                return Some(back);
             }
         }
     }
 
-    pub fn pop_random(&mut self, rng: &mut ThreadRng) -> Option<(Arc<dyn DynSpillToken>, u32)> {
+    pub fn pop_random(&mut self, rng: &mut ThreadRng) -> Option<RegisteredSpillToken> {
         while !self.tokens.is_empty() {
             let idx = rng.random_range(0..self.tokens.len());
             let back = self.tokens.swap_remove_back(idx)?;
-            if let Some(r) = back.upgrade() {
-                return Some(r);
+            if back.is_valid() {
+                return Some(back);
             }
         }
         None
@@ -116,7 +114,28 @@ impl SpillQueue {
         self.retain_amort += 2; // Grows twice as fast as push.
         if self.retain_amort >= self.tokens.len() {
             self.retain_amort = 0;
-            self.tokens.retain(|t| t.upgrade().is_some());
+            self.tokens.retain(|t| t.is_valid());
+        }
+    }
+
+    pub fn drain_into(&mut self, target: &mut Vec<RegisteredSpillToken>) {
+        target.extend(self.tokens.drain(..));
+        self.retain_amort = 0;
+    }
+
+    pub fn extend_front(&mut self, tokens: Vec<RegisteredSpillToken>) {
+        for token in tokens.into_iter().rev() {
+            if token.is_valid() {
+                self.push_front(token);
+            }
+        }
+    }
+
+    pub fn extend_back(&mut self, tokens: Vec<RegisteredSpillToken>) {
+        for token in tokens {
+            if token.is_valid() {
+                self.push_back(token);
+            }
         }
     }
 }
@@ -142,7 +161,10 @@ impl SpillContextPolicy {
 pub(crate) enum ReinsertReason {
     Unspill,
     Unpin,
-    SpillCancelled,
+    // The timestamps below are the original registration time.
+    #[expect(dead_code)]
+    SpillCancelled(Timestamp),
+    TooSmall(Timestamp),
 }
 
 pub(crate) struct SpillContextInner {
@@ -178,22 +200,37 @@ impl SpillContextInner {
             return;
         }
 
-        let mut staged_tokens = Vec::new();
+        let mut accesses = Vec::new();
+        let mut cancellations = Vec::new();
+        let mut too_small = Vec::new();
         for local in self.staging.iter() {
-            local.lock().unwrap().drain_into(&mut staged_tokens);
+            let mut lock = local.lock().unwrap();
+            lock.accesses.drain_into(&mut accesses);
+            lock.cancellations.drain_into(&mut cancellations);
+            lock.too_small.drain_into(&mut too_small);
         }
 
-        match self.policy() {
+        let policy = self.policy();
+        match policy {
             SpillContextPolicy::MostRecent | SpillContextPolicy::LeastRecent => {
-                staged_tokens.sort_by_key(|t| t.timestamp)
+                accesses.sort_by_key(|t| t.timestamp);
+                cancellations.sort_by_key(|t| t.timestamp);
+                too_small.sort_by_key(|t| t.timestamp);
             },
             SpillContextPolicy::Random => {},
         }
 
-        for token in staged_tokens {
-            if let Some(t) = token.token.upgrade() {
-                queue.push_back(&t, token.registration_id);
-            }
+        queue.extend_back(accesses);
+
+        // A cancelled spill attempt is retried with priority. A token rejected
+        // for being too small would fail that same check again, so it goes on
+        // the opposite end.
+        if matches!(policy, SpillContextPolicy::LeastRecent) {
+            queue.extend_front(cancellations);
+            queue.extend_back(too_small);
+        } else {
+            queue.extend_back(cancellations);
+            queue.extend_front(too_small);
         }
     }
 
@@ -205,8 +242,10 @@ impl SpillContextInner {
 
         let mut queue = self.spill_queue.lock().unwrap();
         self.drain_staging(&mut queue, true);
-        while let Some(t) = queue.pop_back() {
-            t.0.unregister();
+        while let Some(rt) = queue.pop_back() {
+            if let Some(t) = rt.upgrade() {
+                t.unregister();
+            }
         }
     }
 
@@ -222,19 +261,19 @@ impl SpillContextInner {
         &self.stats
     }
 
-    pub(crate) fn drain_while<F: FnMut(Arc<dyn DynSpillToken>, u32) -> bool>(&self, mut f: F) {
+    pub(crate) fn drain_while<F: FnMut(RegisteredSpillToken) -> bool>(&self, mut f: F) {
         let mut rng = rand::rng();
         let policy = self.policy();
 
         let mut queue = self.spill_queue.lock().unwrap();
         self.drain_staging(&mut queue, false);
 
-        while let Some((cand, reg_id)) = match policy {
+        while let Some(rt) = match policy {
             SpillContextPolicy::MostRecent => queue.pop_back(),
             SpillContextPolicy::LeastRecent => queue.pop_front(),
             SpillContextPolicy::Random => queue.pop_random(&mut rng),
         } {
-            if !f(cand, reg_id) {
+            if !f(rt) {
                 break;
             }
         }
@@ -245,14 +284,32 @@ impl SpillContextInner {
         token: &Arc<dyn DynSpillToken>,
         reg_id: u32,
         ctx_id: u64,
-        _reason: ReinsertReason,
+        reason: ReinsertReason,
     ) {
-        // TODO: use reason to place token in appropriate spot.
         let mut local = self.staging.get_or_default().lock().unwrap();
         if ctx_id != self.context_id.load(Ordering::Relaxed) {
             return;
         }
-        local.push(token, reg_id);
+
+        match reason {
+            ReinsertReason::Unspill | ReinsertReason::Unpin => {
+                local.accesses.push_back(RegisteredSpillToken::new(
+                    token,
+                    reg_id,
+                    Timestamp::now(),
+                ));
+            },
+            ReinsertReason::SpillCancelled(ts) => {
+                local
+                    .cancellations
+                    .push_back(RegisteredSpillToken::new(token, reg_id, ts));
+            },
+            ReinsertReason::TooSmall(ts) => {
+                local
+                    .too_small
+                    .push_back(RegisteredSpillToken::new(token, reg_id, ts));
+            },
+        }
 
         if self.staging_empty.load(Ordering::Relaxed) {
             self.staging_empty.swap(false, Ordering::AcqRel);
@@ -299,7 +356,11 @@ impl StrongSpillContext {
 
         {
             let mut local = self.0.staging.get_or_default().lock().unwrap();
-            local.push(&dyn_arc, reg_id);
+            local.accesses.push_back(RegisteredSpillToken::new(
+                &dyn_arc,
+                reg_id,
+                Timestamp::now(),
+            ));
         }
 
         if self.0.staging_empty.load(Ordering::Relaxed) {
@@ -368,7 +429,11 @@ impl WeakSpillContext {
         let dyn_arc = token.as_ref().upcast();
         let mut local = self.0.staging.get_or_default().lock().unwrap();
         if self.0.context_id() == self.1 {
-            local.push(&dyn_arc, dyn_arc.register(self.clone(), param));
+            local.accesses.push_back(RegisteredSpillToken::new(
+                &dyn_arc,
+                dyn_arc.register(self.clone(), param),
+                Timestamp::now(),
+            ));
             if self.0.staging_empty.load(Ordering::Relaxed) {
                 self.0.staging_empty.swap(false, Ordering::AcqRel);
             }

--- a/crates/polars-ooc/src/spill_token.rs
+++ b/crates/polars-ooc/src/spill_token.rs
@@ -116,8 +116,8 @@ impl<T: Spillable> SpillTokenInner<T> {
         }
     }
 
-    // Try to pin the value, returning None if it is spilled, locked or dropped.
-    fn try_pin(slf: &Arc<Self>) -> Option<PinnedRef<'_, T>> {
+    // Try to pin the value, returning Err if it is spilled, locked or dropped.
+    fn try_pin(slf: &Arc<Self>) -> Result<PinnedRef<'_, T>, u64> {
         slf.state
             .try_update(Ordering::Acquire, Ordering::Relaxed, |state| {
                 if state & (SPILLED_BIT | LOCK_BIT | DROPPED_BIT) != 0 {
@@ -125,7 +125,6 @@ impl<T: Spillable> SpillTokenInner<T> {
                 }
                 Some(state + RO_PIN_COUNT_UNIT)
             })
-            .ok()
             .map(|_| PinnedRef { inner: slf })
     }
 
@@ -184,7 +183,7 @@ impl<T: Spillable> SpillTokenInner<T> {
     }
 
     async fn pin(slf: &Arc<Self>) -> PinnedRef<'_, T> {
-        if let Some(r) = Self::try_pin(slf) {
+        if let Ok(r) = Self::try_pin(slf) {
             return r;
         }
 
@@ -252,7 +251,7 @@ impl<T: Spillable> SpillTokenInner<T> {
     }
 
     fn pin_blocking(slf: &Arc<Self>) -> PinnedRef<'_, T> {
-        if let Some(r) = Self::try_pin(slf) {
+        if let Ok(r) = Self::try_pin(slf) {
             return r;
         }
 
@@ -445,6 +444,13 @@ pub enum TrySpillError {
     Pinned,
 }
 
+pub enum SpillStatus {
+    InMemory(u64),
+    Spilled,
+    Pinned,
+    Dropped,
+}
+
 pub(crate) trait DynSpillToken: Send + Sync + 'static {
     /// Register this spill token at a new context, returning the registration ID.
     fn register(&self, ctx: WeakSpillContext, param: SpillContextParam) -> u32;
@@ -456,17 +462,18 @@ pub(crate) trait DynSpillToken: Send + Sync + 'static {
     /// Returns the current context registration ID of this spill token without modifying it.
     fn current_registration_id(&self) -> u32;
 
-    /// Whether this token can be spilled. Returns false if pinned, dropped or
-    /// already spilled.
-    fn can_spill(&self) -> bool;
+    /// Whether this token can be spilled, and if so, its estimated in-memory
+    /// size in bytes.
+    fn spill_status(self: Arc<Self>) -> SpillStatus;
 
     /// Call this exactly once after removing a SpillToken from its context to
     /// re-insert it once it is spillable again.
-    fn cancel_spill_attempt_and_reinsert(self: Arc<Self>, reg_id: u32, context_id: u64);
-
-    /// Estimates how many bytes this object takes up in memory. Returns None
-    /// if the object cannot be pinned.
-    fn estimate_byte_size(self: Arc<Self>) -> Option<usize>;
+    fn cancel_spill_attempt_and_reinsert(
+        self: Arc<Self>,
+        reg_id: u32,
+        context_id: u64,
+        reason: ReinsertReason,
+    );
 
     /// Tries to spill this token. Returns true if successful.
     ///
@@ -509,12 +516,29 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
         self.registration_id.load(Ordering::Relaxed)
     }
 
-    fn can_spill(&self) -> bool {
-        self.state.load(Ordering::Acquire) & (SPILLED_BIT | DROPPED_BIT | LOCK_BIT | RO_PIN_MASK)
-            == 0
+    fn spill_status(self: Arc<Self>) -> SpillStatus {
+        match Self::try_pin(&self) {
+            Ok(p) => SpillStatus::InMemory(p.estimate_byte_size() as u64),
+            Err(s) => {
+                if s & DROPPED_BIT != 0 {
+                    SpillStatus::Dropped
+                } else if s & SPILLED_BIT != 0 {
+                    SpillStatus::Spilled
+                } else if s & (LOCK_BIT | RO_PIN_MASK) != 0 {
+                    SpillStatus::Pinned
+                } else {
+                    unreachable!()
+                }
+            }
+        }
     }
 
-    fn cancel_spill_attempt_and_reinsert(self: Arc<Self>, reg_id: u32, context_id: u64) {
+    fn cancel_spill_attempt_and_reinsert(
+        self: Arc<Self>,
+        reg_id: u32,
+        context_id: u64,
+        reason: ReinsertReason,
+    ) {
         // Hold lock to not race with other registrations.
         let lock = self.lock.lock().unwrap();
 
@@ -539,13 +563,8 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
         // done by the responsible party, if dropped it doesn't matter.
         if old_s & (LOCK_BIT | RO_PIN_MASK | SPILLED_BIT | DROPPED_BIT) == 0 {
             let dyn_slf: Arc<dyn DynSpillToken> = self.clone();
-            ctx.0
-                .reinsert(&dyn_slf, reg_id, context_id, ReinsertReason::SpillCancelled);
+            ctx.0.reinsert(&dyn_slf, reg_id, context_id, reason);
         }
-    }
-
-    fn estimate_byte_size(self: Arc<Self>) -> Option<usize> {
-        Self::try_pin(&self).map(|p| p.estimate_byte_size())
     }
 
     fn try_spill(
@@ -677,7 +696,7 @@ impl<T: Spillable> SpillToken<T> {
 
     /// Try to get a reference to the underlying value, returning None if it was spilled.
     pub fn try_get(&self) -> Option<PinnedRef<'_, T>> {
-        SpillTokenInner::try_pin(&self.inner)
+        SpillTokenInner::try_pin(&self.inner).ok()
     }
 
     /// Get a reference to the underlying value, unspilling it if it was spilled.

--- a/crates/polars-ooc/src/spill_token.rs
+++ b/crates/polars-ooc/src/spill_token.rs
@@ -529,7 +529,7 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
                 } else {
                     unreachable!()
                 }
-            }
+            },
         }
     }
 


### PR DESCRIPTION
If an attempted spill goes wrong for any reason it may need to be put back into our registry. Some reasons they can go wrong and the resulting behavior:

 - The `SpillFrame` is dropped -> not reinserted.
 - The `SpillFrame` is already spilled -> not reinserted, once we track spilled frames as well for prefetching whoever spilled it will have already registered it as such.
 - The `SpillFrame` is pinned -> reinserted once the pin drops by the `unpin` handler. It's reinserted as a fresh register/access.
 - The `SpillFrame` is too small to be worth spilling -> reinserted, but with the lowest priority. This frame might become larger in the future due to mutation, or perhaps in the future we'll have a dynamic threshold that can be less picky about what to spill if in trouble.

In an initial version we also had spill attempt cancellations which we might re-introduce instead of waiting for spill permits, so I've left the unused code in place that handles cancellations.