### PR TITLE
perf: Do not materialize equal `ScalarColumn`s in `Column::append`/`extend`

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/row_encode.rs
+++ b/crates/polars-core/src/chunked_array/ops/row_encode.rs
@@ -69,11 +69,16 @@ pub fn encode_rows_vertical_par_unordered_broadcast_nulls(
     ))
 }
 
+/// Whether the row encoding has a representation for `dtype`.
+pub fn supports_row_encoding(dtype: &DataType) -> bool {
+    get_row_encoding_context(dtype).is_ok()
+}
+
 /// Get the [`RowEncodingContext`] for a certain [`DataType`].
 ///
 /// This should be given the logical type in order to communicate Polars datatype information down
 /// into the row encoding / decoding.
-pub fn get_row_encoding_context(dtype: &DataType) -> Option<RowEncodingContext> {
+pub fn get_row_encoding_context(dtype: &DataType) -> PolarsResult<Option<RowEncodingContext>> {
     match dtype {
         DataType::Boolean
         | DataType::UInt8
@@ -96,27 +101,31 @@ pub fn get_row_encoding_context(dtype: &DataType) -> Option<RowEncodingContext> 
         | DataType::Time
         | DataType::Date
         | DataType::Datetime(_, _)
-        | DataType::Duration(_) => None,
+        | DataType::Duration(_) => Ok(None),
 
         #[cfg(feature = "dtype-categorical")]
         DataType::Categorical(_, mapping) | DataType::Enum(_, mapping) => {
             use polars_row::RowEncodingCategoricalContext;
 
-            Some(RowEncodingContext::Categorical(
+            Ok(Some(RowEncodingContext::Categorical(
                 RowEncodingCategoricalContext {
                     is_enum: matches!(dtype, DataType::Enum(_, _)),
                     mapping: mapping.clone(),
                 },
-            ))
+            )))
         },
 
-        DataType::Unknown(_) => panic!("Unsupported in row encoding"),
+        DataType::Unknown(_) => {
+            polars_bail!(InvalidOperation: "cannot row encode dtype '{dtype}'")
+        },
 
         #[cfg(feature = "object")]
-        DataType::Object(_) => panic!("Unsupported in row encoding"),
+        DataType::Object(_) => {
+            polars_bail!(InvalidOperation: "cannot row encode dtype '{dtype}'")
+        },
 
         #[cfg(feature = "dtype-decimal")]
-        DataType::Decimal(precision, _) => Some(RowEncodingContext::Decimal(*precision)),
+        DataType::Decimal(precision, _) => Ok(Some(RowEncodingContext::Decimal(*precision))),
 
         #[cfg(feature = "dtype-array")]
         DataType::Array(dtype, _) => get_row_encoding_context(dtype),
@@ -126,7 +135,7 @@ pub fn get_row_encoding_context(dtype: &DataType) -> Option<RowEncodingContext> 
             let mut ctxts = Vec::new();
 
             for (i, f) in fs.iter().enumerate() {
-                if let Some(ctxt) = get_row_encoding_context(f.dtype()) {
+                if let Some(ctxt) = get_row_encoding_context(f.dtype())? {
                     ctxts.reserve(fs.len());
                     ctxts.extend(std::iter::repeat_n(None, i));
                     ctxts.push(Some(ctxt));
@@ -135,16 +144,20 @@ pub fn get_row_encoding_context(dtype: &DataType) -> Option<RowEncodingContext> 
             }
 
             if ctxts.is_empty() {
-                return None;
+                // Every field so far was context-free, but the remaining ones still have to
+                // be checked for dtypes the row encoding cannot represent.
+                for f in &fs[ctxts.len()..] {
+                    get_row_encoding_context(f.dtype())?;
+                }
+                return Ok(None);
             }
 
-            ctxts.extend(
-                fs[ctxts.len()..]
-                    .iter()
-                    .map(|f| get_row_encoding_context(f.dtype())),
-            );
+            for f in &fs[ctxts.len()..] {
+                let ctxt = get_row_encoding_context(f.dtype())?;
+                ctxts.push(ctxt);
+            }
 
-            Some(RowEncodingContext::Struct(ctxts))
+            Ok(Some(RowEncodingContext::Struct(ctxts)))
         },
         #[cfg(feature = "dtype-extension")]
         DataType::Extension(_, storage) => get_row_encoding_context(storage),
@@ -178,7 +191,7 @@ pub fn _get_rows_encoded_unordered(by: &[Column]) -> PolarsResult<RowsEncoded> {
         let by = by.as_materialized_series();
         let arr = by.to_physical_repr().rechunk().chunks()[0].to_boxed();
         let opt = RowEncodingOptions::new_unsorted();
-        let ctxt = get_row_encoding_context(by.dtype());
+        let ctxt = get_row_encoding_context(by.dtype())?;
 
         cols.push(arr);
         opts.push(opt);
@@ -213,7 +226,7 @@ pub fn _get_rows_encoded(
         let by = by.as_materialized_series();
         let arr = by.to_physical_repr().rechunk().chunks()[0].to_boxed();
         let opt = RowEncodingOptions::new_sorted(*desc, *null_last);
-        let ctxt = get_row_encoding_context(by.dtype());
+        let ctxt = get_row_encoding_context(by.dtype())?;
 
         cols.push(arr);
         opts.push(opt);
@@ -276,12 +289,12 @@ pub fn row_encoding_decode(
     let (ctxts, dtypes) = fields
         .iter()
         .map(|f| {
-            (
-                get_row_encoding_context(f.dtype()),
+            Ok((
+                get_row_encoding_context(f.dtype())?,
                 f.dtype().to_physical().to_arrow(CompatLevel::newest()),
-            )
+            ))
         })
-        .collect::<(Vec<_>, Vec<_>)>();
+        .collect::<PolarsResult<(Vec<_>, Vec<_>)>>()?;
 
     let struct_arrow_dtype = ArrowDataType::Struct(
         fields

--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -1165,18 +1165,24 @@ impl AnyValue<'_> {
         ) -> impl ExactSizeIterator<Item = AnyValue<'a>> {
             v.0.iter().map(|v| v.as_borrowed())
         }
-        fn struct_value_iter(
+        #[cfg(feature = "dtype-struct")]
+        fn struct_value_iter<'a>(
             idx: usize,
-            arr: &StructArray,
-        ) -> impl ExactSizeIterator<Item = AnyValue<'_>> {
+            arr: &'a StructArray,
+            fields: &'a [Field],
+        ) -> impl ExactSizeIterator<Item = AnyValue<'a>> {
             assert!(idx < arr.len());
+            assert_eq!(arr.values().len(), fields.len());
 
-            arr.values().iter().map(move |field_arr| unsafe {
-                // SAFETY: We asserted before that idx is smaller than the array length. Since it
-                // is an invariant of StructArray that all fields have the same length this is fine
-                // to do.
-                field_arr.get_unchecked(idx)
-            })
+            arr.values()
+                .iter()
+                .zip(fields)
+                .map(move |(field_arr, field)| unsafe {
+                    // SAFETY: We asserted before that idx is smaller than the array length. Since
+                    // it is an invariant of StructArray that all fields have the same length this
+                    // is fine to do.
+                    arr_to_any_value(field_arr.as_ref(), idx, &field.dtype)
+                })
         }
 
         fn struct_eq_missing<'a>(
@@ -1284,21 +1290,21 @@ impl AnyValue<'_> {
                 null_equal,
             ),
             #[cfg(feature = "dtype-struct")]
-            (StructOwned(l), Struct(idx, arr, _)) => struct_eq_missing(
+            (StructOwned(l), Struct(idx, arr, fields)) => struct_eq_missing(
                 struct_owned_value_iter(l.as_ref()),
-                struct_value_iter(*idx, arr),
+                struct_value_iter(*idx, arr, fields),
                 null_equal,
             ),
             #[cfg(feature = "dtype-struct")]
-            (Struct(idx, arr, _), StructOwned(r)) => struct_eq_missing(
-                struct_value_iter(*idx, arr),
+            (Struct(idx, arr, fields), StructOwned(r)) => struct_eq_missing(
+                struct_value_iter(*idx, arr, fields),
                 struct_owned_value_iter(r.as_ref()),
                 null_equal,
             ),
             #[cfg(feature = "dtype-struct")]
-            (Struct(l_idx, l_arr, _), Struct(r_idx, r_arr, _)) => struct_eq_missing(
-                struct_value_iter(*l_idx, l_arr),
-                struct_value_iter(*r_idx, r_arr),
+            (Struct(l_idx, l_arr, l_fields), Struct(r_idx, r_arr, r_fields)) => struct_eq_missing(
+                struct_value_iter(*l_idx, l_arr, l_fields),
+                struct_value_iter(*r_idx, r_arr, r_fields),
                 null_equal,
             ),
             #[cfg(feature = "dtype-decimal")]
@@ -1483,172 +1489,6 @@ fn struct_to_avs_static(idx: usize, arr: &StructArray, fields: &[Field]) -> Vec<
             unsafe { arr_to_any_value(arr.as_ref(), idx, &field.dtype) }.into_static()
         })
         .collect()
-}
-
-pub trait GetAnyValue {
-    /// # Safety
-    ///
-    /// Get an value without doing bound checks.
-    unsafe fn get_unchecked(&self, index: usize) -> AnyValue<'_>;
-}
-
-impl GetAnyValue for ArrayRef {
-    // Should only be called with physical types
-    unsafe fn get_unchecked(&self, index: usize) -> AnyValue<'_> {
-        match self.dtype() {
-            ArrowDataType::Int8 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<i8>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::Int8(v),
-                }
-            },
-            ArrowDataType::Int16 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<i16>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::Int16(v),
-                }
-            },
-            ArrowDataType::Int32 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<i32>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::Int32(v),
-                }
-            },
-            ArrowDataType::Int64 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<i64>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::Int64(v),
-                }
-            },
-            ArrowDataType::Int128 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<i128>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::Int128(v),
-                }
-            },
-            ArrowDataType::UInt8 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<u8>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::UInt8(v),
-                }
-            },
-            ArrowDataType::UInt16 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<u16>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::UInt16(v),
-                }
-            },
-            ArrowDataType::UInt32 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<u32>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::UInt32(v),
-                }
-            },
-            ArrowDataType::UInt64 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<u64>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::UInt64(v),
-                }
-            },
-            ArrowDataType::UInt128 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<u128>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::UInt128(v),
-                }
-            },
-            ArrowDataType::Float16 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<pf16>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::Float16(v),
-                }
-            },
-            ArrowDataType::Float32 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<f32>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::Float32(v),
-                }
-            },
-            ArrowDataType::Float64 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<f64>>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::Float64(v),
-                }
-            },
-            ArrowDataType::Boolean => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<BooleanArray>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::Boolean(v),
-                }
-            },
-            ArrowDataType::LargeUtf8 => {
-                let arr = self
-                    .as_any()
-                    .downcast_ref::<LargeStringArray>()
-                    .unwrap_unchecked();
-                match arr.get_unchecked(index) {
-                    None => AnyValue::Null,
-                    Some(v) => AnyValue::String(v),
-                }
-            },
-            _ => unimplemented!(),
-        }
-    }
 }
 
 impl<K: NumericNative> From<K> for AnyValue<'static> {

--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -1089,13 +1089,30 @@ impl Column {
             .vec_hash_combine(build_hasher, hashes)
     }
 
+    /// Try to append `other` to `self` without materializing, when both are scalar columns.
+    ///
+    /// Returns whether that was possible.
+    fn try_append_scalar(&mut self, other: &Column) -> bool {
+        let (Column::Scalar(lhs), Column::Scalar(rhs)) = (&mut *self, other) else {
+            return false;
+        };
+        lhs.try_append(rhs)
+    }
+
     pub fn append(&mut self, other: &Column) -> PolarsResult<&mut Self> {
-        // @scalar-opt
+        if self.try_append_scalar(other) {
+            return Ok(self);
+        }
+
         self.into_materialized_series()
             .append(other.as_materialized_series())?;
         Ok(self)
     }
     pub fn append_owned(&mut self, other: Column) -> PolarsResult<&mut Self> {
+        if self.try_append_scalar(&other) {
+            return Ok(self);
+        }
+
         self.into_materialized_series()
             .append_owned(other.take_materialized_series())?;
         Ok(self)
@@ -1266,7 +1283,12 @@ impl Column {
     }
 
     pub fn extend(&mut self, other: &Column) -> PolarsResult<&mut Self> {
-        // @scalar-opt
+        // `extend` only differs from `append` in the chunk layout of the result, and a
+        // `ScalarColumn` has no chunks to lay out.
+        if self.try_append_scalar(other) {
+            return Ok(self);
+        }
+
         self.into_materialized_series()
             .extend(other.as_materialized_series())?;
         Ok(self)

--- a/crates/polars-core/src/frame/column/scalar.rs
+++ b/crates/polars-core/src/frame/column/scalar.rs
@@ -13,7 +13,7 @@ use crate::chunked_array::cast::CastOptions;
 #[derive(Debug, Clone)]
 pub struct ScalarColumn {
     name: PlSmallStr,
-    // The value of this scalar may be incoherent when `length == 0`.
+    // The value of this scalar may be unspecified when `length == 0`.
     scalar: Scalar,
     length: usize,
 
@@ -193,6 +193,35 @@ impl ScalarColumn {
         }
 
         resized
+    }
+
+    /// Append `other` to `self`, keeping both unmaterialized.
+    ///
+    /// Returns whether that was possible. `self` is left untouched when it was not.
+    pub fn try_append(&mut self, other: &Self) -> bool {
+        // Unequal dtypes either need a cast or must raise.
+        if self.dtype() != other.dtype() {
+            return false;
+        }
+
+        // The value of a length-0 column is unspecified, so it takes on the other's.
+        if other.is_empty() {
+            return true;
+        }
+        if self.is_empty() {
+            let name = std::mem::take(&mut self.name);
+            *self = other.clone();
+            self.rename(name);
+            return true;
+        }
+
+        // The dtypes are already known to be equal, so only the values still differ.
+        if self.scalar.value() != other.scalar.value() {
+            return false;
+        }
+
+        *self = self.resize(self.length + other.length);
+        true
     }
 
     pub fn cast_with_options(&self, dtype: &DataType, options: CastOptions) -> PolarsResult<Self> {

--- a/crates/polars-core/src/frame/group_by/into_groups.rs
+++ b/crates/polars-core/src/frame/group_by/into_groups.rs
@@ -328,9 +328,9 @@ impl IntoGroupsType for ListChunked {
         multithreaded &= RAYON.current_num_threads() > 1;
         let by = &[self.clone().into_column()];
         let ca = if multithreaded {
-            encode_rows_vertical_par_unordered(by).unwrap()
+            encode_rows_vertical_par_unordered(by)?
         } else {
-            _get_rows_encoded_ca_unordered(PlSmallStr::EMPTY, by).unwrap()
+            _get_rows_encoded_ca_unordered(PlSmallStr::EMPTY, by)?
         };
 
         ca.group_tuples(multithreaded, sorted)
@@ -349,9 +349,9 @@ impl IntoGroupsType for ArrayChunked {
         multithreaded &= RAYON.current_num_threads() > 1;
         let by = &[self.clone().into_column()];
         let ca = if multithreaded {
-            encode_rows_vertical_par_unordered(by).unwrap()
+            encode_rows_vertical_par_unordered(by)?
         } else {
-            _get_rows_encoded_ca_unordered(PlSmallStr::EMPTY, by).unwrap()
+            _get_rows_encoded_ca_unordered(PlSmallStr::EMPTY, by)?
         };
         ca.group_tuples(multithreaded, sorted)
     }

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -3029,6 +3029,27 @@ mod test {
     }
 
     #[test]
+    fn test_vstack_scalar_chunk_alignment() {
+        // Appending equal scalars keeps the column unmaterialized.
+        let mut df = df! {
+            "int" => [0],
+            "str" => ["a"],
+        }
+        .unwrap();
+        df.vstack_mut(&df! { "int" => [1], "str" => ["a"] }.unwrap())
+            .unwrap();
+
+        assert_eq!(df.column("int").unwrap().n_chunks(), 2);
+        assert!(df.column("str").unwrap().as_scalar_column().is_some());
+        assert!(!df.should_rechunk());
+
+        let batches = df
+            .iter_chunks(CompatLevel::newest(), false)
+            .collect::<Vec<_>>();
+        assert_eq!(batches.iter().map(|b| b.len()).collect::<Vec<_>>(), [1, 1]);
+    }
+
+    #[test]
     fn test_vstack_on_empty_dataframe() {
         let mut df = DataFrame::empty();
 

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -316,14 +316,17 @@ impl DataFrame {
     /// Returns true if the chunks of the columns do not align and re-chunking should be done
     pub fn should_rechunk(&self) -> bool {
         // Fast check. It is also needed for correctness, as code below doesn't check if the number
-        // of chunks is equal.
-        if !self.columns().iter().map(Column::n_chunks).all_equal() {
+        // of chunks is equal. Columns without chunks of their own align with any layout.
+        if !self
+            .columns()
+            .iter()
+            .filter_map(Column::lazy_as_materialized_series)
+            .map(|s| s.n_chunks())
+            .all_equal()
+        {
             return true;
         }
 
-        // From here we check chunk lengths. Skipping the columns without chunks is
-        // safe because the counts are equal: either every count is 1, or there is
-        // no such column left.
         let mut chunk_lengths = self
             .columns()
             .iter()
@@ -2147,8 +2150,7 @@ impl DataFrame {
                     .map(|c| c.field().to_arrow(compat_level))
                     .collect(),
             ),
-            idx: 0,
-            n_chunks: usize::max(1, self.first_col_n_chunks()),
+            cursor: ChunkCursor::new(self),
             compat_level,
             parallel,
         })
@@ -2171,16 +2173,14 @@ impl DataFrame {
         }
 
         RecordBatchIterWrap::PhysicalBatches(PhysRecordBatchIter {
+            df: self,
             schema: Arc::new(
                 self.columns()
                     .iter()
                     .map(|c| c.field().to_arrow(CompatLevel::newest()))
                     .collect(),
             ),
-            arr_iters: self
-                .materialized_column_iter()
-                .map(|s| s.chunks().iter())
-                .collect(),
+            cursor: ChunkCursor::new(self),
         })
     }
 
@@ -2671,11 +2671,57 @@ impl DataFrame {
     }
 }
 
+/// Cursor over the chunks a [`DataFrame`] is laid out along.
+struct ChunkCursor<'a> {
+    /// The chunks of the first column that has any; empty when no column does.
+    chunks: &'a [ArrayRef],
+    height: usize,
+    idx: usize,
+}
+
+impl<'a> ChunkCursor<'a> {
+    fn new(df: &'a DataFrame) -> Self {
+        let chunks = match df
+            .columns()
+            .iter()
+            .find_map(Column::lazy_as_materialized_series)
+        {
+            Some(s) => s.chunks().as_slice(),
+            None => &[],
+        };
+
+        Self {
+            chunks,
+            height: df.height(),
+            idx: 0,
+        }
+    }
+
+    fn n_chunks(&self) -> usize {
+        usize::max(1, self.chunks.len())
+    }
+
+    /// The index and number of rows of the next chunk.
+    fn next(&mut self) -> Option<(usize, usize)> {
+        let idx = self.idx;
+        if idx >= self.n_chunks() {
+            return None;
+        }
+
+        self.idx += 1;
+        Some((idx, self.chunks.get(idx).map_or(self.height, |c| c.len())))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let n = self.n_chunks() - self.idx;
+        (n, Some(n))
+    }
+}
+
 pub struct RecordBatchIter<'a> {
     df: &'a DataFrame,
     schema: ArrowSchemaRef,
-    idx: usize,
-    n_chunks: usize,
+    cursor: ChunkCursor<'a>,
     compat_level: CompatLevel,
     parallel: bool,
 }
@@ -2684,66 +2730,55 @@ impl Iterator for RecordBatchIter<'_> {
     type Item = RecordBatch;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.idx >= self.n_chunks {
-            return None;
-        }
+        let (idx, length) = self.cursor.next()?;
 
-        // Create a batch of the columns with the same chunk no.
-        let batch_cols: Vec<ArrayRef> = if self.parallel {
-            let iter = self
-                .df
-                .columns()
-                .par_iter()
-                .map(Column::as_materialized_series)
-                .map(|s| s.to_arrow(self.idx, self.compat_level));
-            RAYON.install(|| iter.collect())
-        } else {
-            self.df
-                .columns()
-                .iter()
-                .map(Column::as_materialized_series)
-                .map(|s| s.to_arrow(self.idx, self.compat_level))
-                .collect()
+        let to_arrow = |c: &Column| match c.lazy_as_materialized_series() {
+            Some(s) => s.to_arrow(idx, self.compat_level),
+            None => c.slice(0, length).rechunk_to_arrow(self.compat_level),
         };
 
-        let length = batch_cols.first().map_or(0, |arr| arr.len());
-
-        self.idx += 1;
+        let batch_cols: Vec<ArrayRef> = if self.parallel {
+            let iter = self.df.columns().par_iter().map(to_arrow);
+            RAYON.install(|| iter.collect())
+        } else {
+            self.df.columns().iter().map(to_arrow).collect()
+        };
 
         Some(RecordBatch::new(length, self.schema.clone(), batch_cols))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let n = self.n_chunks - self.idx;
-        (n, Some(n))
+        self.cursor.size_hint()
     }
 }
 
 pub struct PhysRecordBatchIter<'a> {
+    df: &'a DataFrame,
     schema: ArrowSchemaRef,
-    arr_iters: Vec<std::slice::Iter<'a, ArrayRef>>,
+    cursor: ChunkCursor<'a>,
 }
 
 impl Iterator for PhysRecordBatchIter<'_> {
     type Item = RecordBatch;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let arrs = self
-            .arr_iters
-            .iter_mut()
-            .map(|phys_iter| phys_iter.next().cloned())
-            .collect::<Option<Vec<_>>>()?;
+        let (idx, length) = self.cursor.next()?;
 
-        let length = arrs.first().map_or(0, |arr| arr.len());
+        let arrs = self
+            .df
+            .columns()
+            .iter()
+            .map(|c| match c.lazy_as_materialized_series() {
+                Some(s) => s.chunks()[idx].clone(),
+                None => c.slice(0, length).as_materialized_series().chunks()[0].clone(),
+            })
+            .collect::<Vec<_>>();
+
         Some(RecordBatch::new(length, self.schema.clone(), arrs))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        if let Some(iter) = self.arr_iters.first() {
-            iter.size_hint()
-        } else {
-            (0, None)
-        }
+        self.cursor.size_hint()
     }
 }
 
@@ -2972,6 +3007,25 @@ mod test {
 
         df.vstack_mut(&df.slice(0, 3)).unwrap();
         assert_eq!(df.first_col_n_chunks(), 2)
+    }
+
+    #[test]
+    fn test_chunk_alignment_with_scalar_column() {
+        let mut df = df! { "int" => [0, 1] }.unwrap();
+        df.vstack_mut(&df! { "int" => [2] }.unwrap()).unwrap();
+        df.with_column(Column::new_scalar(
+            "str".into(),
+            Scalar::from(PlSmallStr::from_static("a")),
+            3,
+        ))
+        .unwrap();
+
+        assert!(!df.should_rechunk());
+
+        let batches = df
+            .iter_chunks(CompatLevel::newest(), false)
+            .collect::<Vec<_>>();
+        assert_eq!(batches.iter().map(|b| b.len()).collect::<Vec<_>>(), [2, 1]);
     }
 
     #[test]

--- a/crates/polars-expr/src/expressions/eval.rs
+++ b/crates/polars-expr/src/expressions/eval.rs
@@ -507,6 +507,8 @@ impl PhysicalExpr for EvalExpr {
 
     fn evaluate_impl(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Column> {
         let input = self.input.evaluate(df, state)?;
+        // @scalar-opt: every variant but `Cumulative` maps rows independently, so a scalar
+        // input could be evaluated once and broadcast instead of expanded to full length.
         let out = match self.variant {
             EvalVariant::List => {
                 let lst = input.list()?;

--- a/crates/polars-expr/src/groups/row_encoded.rs
+++ b/crates/polars-expr/src/groups/row_encoded.rs
@@ -42,7 +42,7 @@ impl RowEncodedHashGrouper {
             .collect::<Vec<_>>();
         let ctxts = key_schema
             .iter()
-            .map(|(_, dt)| get_row_encoding_context(dt))
+            .map(|(_, dt)| get_row_encoding_context(dt).unwrap())
             .collect::<Vec<_>>();
         let fields = vec![RowEncodingOptions::new_unsorted(); key_dtypes.len()];
         let key_columns =

--- a/crates/polars-expr/src/hash_keys.rs
+++ b/crates/polars-expr/src/hash_keys.rs
@@ -109,14 +109,14 @@ impl HashKeys {
         random_state: PlRandomState,
         null_is_valid: bool,
         force_row_encoding: bool,
-    ) -> Self {
+    ) -> PolarsResult<Self> {
         let first_col_variant = hash_keys_variant_for_dtype(df[0].dtype());
         let use_row_encoding = force_row_encoding
             || df.width() > 1
             || first_col_variant == HashKeysVariant::RowEncoded;
         if use_row_encoding {
             let keys = df.columns();
-            let mut keys_encoded = _get_rows_encoded_unordered(keys).unwrap().into_array();
+            let mut keys_encoded = _get_rows_encoded_unordered(keys)?.into_array();
 
             if !null_is_valid {
                 let validities = keys
@@ -135,10 +135,10 @@ impl HashKeys {
                 .values_iter()
                 .map(|k| random_state.hash_one(k))
                 .collect();
-            Self::RowEncoded(RowEncodedKeys {
+            Ok(Self::RowEncoded(RowEncodedKeys {
                 hashes: PrimitiveArray::from_vec(hashes),
                 keys: keys_encoded,
-            })
+            }))
         } else if first_col_variant == HashKeysVariant::Binview {
             let keys = if let Ok(ca_str) = df[0].str() {
                 ca_str.as_binary()
@@ -157,17 +157,17 @@ impl HashKeys {
                     .collect()
             };
 
-            Self::Binview(BinviewKeys {
+            Ok(Self::Binview(BinviewKeys {
                 hashes: PrimitiveArray::from_vec(hashes),
                 keys,
                 null_is_valid,
-            })
+            }))
         } else {
-            Self::Single(SingleKeys {
+            Ok(Self::Single(SingleKeys {
                 random_state,
                 keys: df[0].as_materialized_series().rechunk(),
                 null_is_valid,
-            })
+            }))
         }
     }
 

--- a/crates/polars-ops/src/chunked_array/gather/chunked.rs
+++ b/crates/polars-ops/src/chunked_array/gather/chunked.rs
@@ -115,7 +115,11 @@ impl TakeChunked for Column {
         sorted: IsSorted,
         avoid_sharing: bool,
     ) -> Self {
-        // @scalar-opt
+        // A scalar column has the same value in every row, so only their number matters.
+        if let Column::Scalar(s) = self {
+            return s.resize(by.len()).into();
+        }
+
         let s = self.as_materialized_series();
         let s = unsafe { s.take_chunked_unchecked(by, sorted, avoid_sharing) };
         s.into_column()
@@ -126,7 +130,19 @@ impl TakeChunked for Column {
         by: &[ChunkId<B>],
         avoid_sharing: bool,
     ) -> Self {
-        // @scalar-opt
+        // As above, but the null ids still have to be carried over.
+        if let Column::Scalar(s) = self {
+            if !by.iter().any(ChunkId::is_null) {
+                return s.resize(by.len()).into();
+            }
+
+            let idx = IdxCa::from_iter_options(
+                PlSmallStr::EMPTY,
+                by.iter().map(|id| (!id.is_null()).then_some(0)),
+            );
+            return unsafe { self.take_unchecked(&idx) };
+        }
+
         let s = self.as_materialized_series();
         let s = unsafe { s.take_opt_chunked_unchecked(by, avoid_sharing) };
         s.into_column()

--- a/crates/polars-stream/src/nodes/group_by.rs
+++ b/crates/polars-stream/src/nodes/group_by.rs
@@ -170,7 +170,7 @@ impl GroupBySinkState {
                     let keys = unsafe {
                         DataFrame::new_unchecked_with_broadcast(df.height(), key_columns)?
                     };
-                    let hash_keys = HashKeys::from_df(&keys, random_state.clone(), true, false);
+                    let hash_keys = HashKeys::from_df(&keys, random_state.clone(), true, false)?;
 
                     let hot_grouper = &mut local.hot_grouper_per_input[input_idx];
                     hot_idxs.clear();

--- a/crates/polars-stream/src/nodes/is_first_distinct.rs
+++ b/crates/polars-stream/src/nodes/is_first_distinct.rs
@@ -67,10 +67,10 @@ impl ComputeNode for IsFirstDistinctNode {
         join_handles.push(scope.spawn_task(TaskPriority::High, async move {
             while let Ok(morsel) = recv.recv().await {
                 let morsel = morsel
-                    .map(|mut df| {
-                        let key_df = df.select(slf.key_schema.iter_names()).unwrap();
+                    .try_map(|mut df| {
+                        let key_df = df.select(slf.key_schema.iter_names())?;
                         let hash_keys =
-                            HashKeys::from_df(&key_df, slf.random_state.clone(), true, false);
+                            HashKeys::from_df(&key_df, slf.random_state.clone(), true, false)?;
                         let mut distinct = BitmapBuilder::with_capacity(df.height());
                         unsafe {
                             slf.subset
@@ -91,10 +91,10 @@ impl ComputeNode for IsFirstDistinctNode {
                         let arr = BooleanArray::from(distinct.freeze());
                         let col =
                             BooleanChunked::with_chunk(slf.out_name.clone(), arr).into_column();
-                        df.with_column(col).unwrap();
-                        df
+                        df.with_column(col)?;
+                        PolarsResult::Ok(df)
                     })
-                    .await;
+                    .await?;
                 if send.send(morsel).await.is_err() {
                     break;
                 }

--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -190,12 +190,12 @@ async fn select_keys(
         key_columns.push(selector.evaluate(df, state).await?.into_column());
     }
     let keys = unsafe { DataFrame::new_unchecked_with_broadcast(df.height(), key_columns)? };
-    Ok(HashKeys::from_df(
+    HashKeys::from_df(
         &keys,
         params.random_state.clone(),
         params.args.nulls_equal,
         false,
-    ))
+    )
 }
 
 fn select_payload(df: DataFrame, selector: &[Option<PlSmallStr>]) -> DataFrame {

--- a/crates/polars-stream/src/nodes/joins/semi_anti_join.rs
+++ b/crates/polars-stream/src/nodes/joins/semi_anti_join.rs
@@ -29,12 +29,12 @@ async fn select_keys(
         key_columns.push(selector.evaluate(df, state).await?.into_column());
     }
     let keys = unsafe { DataFrame::new_unchecked_with_broadcast(df.height(), key_columns) }?;
-    Ok(HashKeys::from_df(
+    HashKeys::from_df(
         &keys,
         params.random_state.clone(),
         params.nulls_equal,
         false,
-    ))
+    )
 }
 
 struct SemiAntiJoinParams {

--- a/crates/polars-stream/src/physical_plan/lower_group_by.rs
+++ b/crates/polars-stream/src/physical_plan/lower_group_by.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use parking_lot::Mutex;
+use polars_core::chunked_array::ops::row_encode::supports_row_encoding;
 use polars_core::frame::DataFrame;
 use polars_core::prelude::{Field, InitHashMaps, PlIndexMap, PlIndexSet, SortMultipleOptions};
 use polars_core::scalar::Scalar;
@@ -1037,7 +1038,7 @@ pub fn try_build_sorted_group_by(
         || (!are_keys_sorted && maintain_order)
         || keys.iter().any(|k| {
             k.dtype(input_schema, expr_arena)
-                .is_ok_and(|dtype| dtype.contains_unknown())
+                .is_ok_and(|dtype| !supports_row_encoding(dtype))
         })
     {
         return Ok(None);

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -4,6 +4,7 @@ use arrow::array::{MutableBinaryViewArray, Utf8ViewArray};
 use arrow::datatypes::ArrowDataType;
 use parking_lot::Mutex;
 use polars_async::executor::ALLOW_RAYON_THREADS;
+use polars_core::chunked_array::ops::row_encode::supports_row_encoding;
 use polars_core::frame::{DataFrame, UniqueKeepStrategy};
 use polars_core::prelude::{DataType, IntoColumn, PlHashMap, PlHashSet};
 use polars_core::scalar::Scalar;
@@ -1471,6 +1472,9 @@ pub fn lower_ir(
                     options.keep_strategy,
                     UniqueKeepStrategy::First | UniqueKeepStrategy::Any
                 )
+                && group_by_output_schema
+                    .iter_values()
+                    .all(supports_row_encoding)
             {
                 let sorted_uniq_node = phys_sm.insert(PhysNode::new(
                     input_schema.clone(),

--- a/py-polars/tests/unit/datatypes/test_object.py
+++ b/py-polars/tests/unit/datatypes/test_object.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 from pathlib import Path
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import numpy as np
@@ -10,6 +11,9 @@ import pytest
 import polars as pl
 from polars.exceptions import ComputeError
 from polars.testing import assert_series_equal
+
+if TYPE_CHECKING:
+    from polars._typing import EngineType
 
 
 def test_series_init_instantiated_object() -> None:
@@ -309,3 +313,34 @@ def test_implode_object_raises() -> None:
 
     with pytest.raises(pl.exceptions.InvalidOperationError, match="nested objects"):
         df.select(pl.col("obj").implode())
+
+
+def _object_key_frame(name: str) -> pl.LazyFrame:
+    return pl.LazyFrame(
+        {
+            "k": [1, 2],
+            "o": pl.Series("o", [object(), object()], dtype=pl.Object),
+            name: [3, 4],
+        }
+    )
+
+
+@pytest.mark.parametrize("engine", ["in-memory", "streaming"])
+def test_join_on_object_key_raises(engine: EngineType) -> None:
+    lhs, rhs = _object_key_frame("a"), _object_key_frame("b")
+
+    for how in ("inner", "left", "semi", "anti"):
+        with pytest.raises(
+            pl.exceptions.InvalidOperationError,
+            match="cannot row encode dtype 'object'",
+        ):
+            lhs.join(rhs, on=["k", "o"], how=how).collect(engine=engine)  # type: ignore[arg-type]
+
+
+def test_unique_maintain_order_on_object_key_raises() -> None:
+    lf = _object_key_frame("a")
+
+    with pytest.raises(
+        pl.exceptions.InvalidOperationError, match="cannot row encode dtype 'object'"
+    ):
+        lf.unique(subset=["k", "o"], maintain_order=True).collect(engine="streaming")

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -133,9 +133,9 @@ def test_to_from_buffer(
 def test_read_parquet_respects_rechunk_16416(
     use_pyarrow: bool, rechunk_and_expected_chunks: tuple[bool, int]
 ) -> None:
-    # Create a dataframe with 3 chunks:
-    df = pl.DataFrame({"a": [1]})
-    df = pl.concat([df, df, df])
+    # Create a dataframe with 3 chunks. The values have to differ: concatenating
+    # chunks that hold the same single value keeps them as one scalar column.
+    df = pl.concat([pl.DataFrame({"a": [i]}) for i in range(3)])
     buf = io.BytesIO()
     df.write_parquet(buf, row_group_size=1)
     buf.seek(0)

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -657,15 +657,18 @@ def test_list_get_logical_types() -> None:
 
 
 def test_list_gather_logical_type() -> None:
-    df = pl.DataFrame(
-        {"foo": [["foo", "foo", "bar"]], "bar": [[5.0, 10.0, 12.0]]}
-    ).with_columns(pl.col("foo").cast(pl.List(pl.Categorical)))
+    def chunk(name: str, value: float) -> pl.DataFrame:
+        return pl.DataFrame(
+            {"foo": [[name, name, "bar"]], "bar": [[value, 10.0, 12.0]]}
+        ).with_columns(pl.col("foo").cast(pl.List(pl.Categorical)))
 
-    df = pl.concat([df, df], rechunk=False)
+    # The two rows have to differ: concatenating chunks that hold the same single value
+    # keeps them as one scalar column.
+    df = pl.concat([chunk("foo", 5.0), chunk("baz", 6.0)], rechunk=False)
     assert df.n_chunks() == 2
     assert df.select(pl.all().gather([0, 1])).to_dict(as_series=False) == {
-        "foo": [["foo", "foo", "bar"], ["foo", "foo", "bar"]],
-        "bar": [[5.0, 10.0, 12.0], [5.0, 10.0, 12.0]],
+        "foo": [["foo", "foo", "bar"], ["baz", "baz", "bar"]],
+        "bar": [[5.0, 10.0, 12.0], [6.0, 10.0, 12.0]],
     }
 
 
@@ -1181,7 +1184,9 @@ def test_list_filter_null() -> None:
 @pytest.mark.may_fail_cloud  # reason: time check
 @pytest.mark.slow
 def test_list_struct_field_perf() -> None:
-    base_df = pl.concat(100 * [pl.DataFrame({"a": [[{"fld": 1}]]})]).rechunk()
+    # The values have to differ: concatenating chunks that hold the same single value
+    # keeps them as one scalar column, which `list.eval` expands on every execution.
+    base_df = pl.DataFrame({"a": [[{"fld": i}] for i in range(100)]}).rechunk()
     df = base_df
 
     q = df.lazy().select(pl.col("a").list.eval(pl.element().struct.field("fld")))

--- a/py-polars/tests/unit/operations/test_scalar.py
+++ b/py-polars/tests/unit/operations/test_scalar.py
@@ -1,9 +1,16 @@
-from typing import Any
+from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
 import pytest
 
 import polars as pl
+from polars.exceptions import SchemaError
 from polars.testing import assert_frame_equal
+
+if TYPE_CHECKING:
+    from polars._typing import EngineType
 
 
 @pytest.mark.may_fail_auto_streaming
@@ -158,3 +165,176 @@ def test_elementwise_over_broadcast_scalar_array(expr: pl.Expr) -> None:
 def test_elementwise_over_empty_scalar() -> None:
     df = pl.DataFrame({"a": [1]}).with_columns(b=pl.lit(5)).head(0)
     assert df.select(pl.col("b").is_null()).to_dict(as_series=False) == {"b": []}
+
+
+def _reprs(df: pl.DataFrame) -> list[str]:
+    return df._to_metadata()["repr"].to_list()
+
+
+def test_vstack_scalar_columns_stay_scalar() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3]}).with_columns(i=pl.lit(5), s=pl.lit("x"))
+    assert _reprs(df) == ["series", "scalar", "scalar"]
+
+    out = pl.concat([df, df, df], rechunk=False)
+    assert _reprs(out) == ["series", "scalar", "scalar"]
+    assert out.to_dict(as_series=False) == {
+        "a": [1, 2, 3] * 3,
+        "i": [5] * 9,
+        "s": ["x"] * 9,
+    }
+
+
+def test_extend_scalar_columns_stay_scalar() -> None:
+    df = pl.DataFrame({"a": [1, 2]}).with_columns(i=pl.lit(5))
+    other = pl.DataFrame({"a": [3, 4]}).with_columns(i=pl.lit(5))
+
+    df.extend(other)
+
+    assert _reprs(df) == ["series", "scalar"]
+    assert df.to_dict(as_series=False) == {"a": [1, 2, 3, 4], "i": [5] * 4}
+
+
+@pytest.mark.parametrize(
+    ("lhs", "rhs", "expected_repr", "expected"),
+    [
+        (pl.lit(5), pl.lit(5), "scalar", [5] * 4),
+        (pl.lit(5), pl.lit(6), "series", [5, 5, 6, 6]),
+        (
+            pl.lit("x", dtype=pl.Categorical),
+            pl.lit("x", dtype=pl.Categorical),
+            "scalar",
+            ["x"] * 4,
+        ),
+        (
+            pl.lit(None, dtype=pl.Int64),
+            pl.lit(None, dtype=pl.Int64),
+            "scalar",
+            [None] * 4,
+        ),
+        (
+            pl.lit(None, dtype=pl.Int64),
+            pl.lit(7, dtype=pl.Int64),
+            "series",
+            [None, None, 7, 7],
+        ),
+    ],
+)
+def test_vstack_scalar(
+    lhs: pl.Expr, rhs: pl.Expr, expected_repr: str, expected: list[Any]
+) -> None:
+    a = pl.DataFrame({"a": [1, 2]}).with_columns(v=lhs)
+    b = pl.DataFrame({"a": [3, 4]}).with_columns(v=rhs)
+
+    out = a.vstack(b)
+
+    assert _reprs(out) == ["series", expected_repr]
+    assert out["v"].to_list() == expected
+
+
+def test_vstack_scalar_empty_frame() -> None:
+    df = pl.DataFrame({"a": [1, 2]}).with_columns(i=pl.lit(5))
+    empty = df.clear()
+    expected = {"a": [1, 2], "i": [5, 5]}
+
+    assert empty.vstack(df).to_dict(as_series=False) == expected
+    assert df.vstack(empty).to_dict(as_series=False) == expected
+    assert empty.vstack(empty).to_dict(as_series=False) == {"a": [], "i": []}
+
+
+def test_vstack_scalar_signed_zero() -> None:
+    # Polars treats -0.0 and 0.0 as the same value (`Series.unique` collapses them), so
+    # the fast path may merge them, keeping the left-hand value.
+    pos = pl.DataFrame({"a": [1, 2]}).with_columns(z=pl.lit(0.0))
+    neg = pl.DataFrame({"a": [3, 4]}).with_columns(z=pl.lit(-0.0))
+
+    out = pos.vstack(neg)
+
+    assert _reprs(out) == ["series", "scalar"]
+    assert np.signbit(out["z"].to_numpy()).tolist() == [False] * 4
+
+
+def test_vstack_scalar_nan() -> None:
+    df = pl.DataFrame({"a": [1, 2]}).with_columns(f=pl.lit(float("nan")))
+
+    out = df.vstack(df)
+
+    assert _reprs(out) == ["series", "scalar"]
+    assert out["f"].is_nan().to_list() == [True] * 4
+
+
+def test_vstack_scalar_dtype_mismatch_still_raises() -> None:
+    value = pl.DataFrame({"a": [1]}).with_columns(v=pl.lit(1.0))
+    null = pl.DataFrame({"a": [2]}).with_columns(v=pl.lit(None, dtype=pl.Null))
+
+    # A null column is cast into the existing dtype; the reverse raises.
+    assert value.vstack(null)["v"].to_list() == [1.0, None]
+    with pytest.raises(SchemaError):
+        null.vstack(value)
+
+
+class _AlwaysEqual:
+    """An object whose `__eq__` reports equality with everything.
+
+    Mirrors `Foo` in `test_hashing_on_python_objects`. Polars requires object equality
+    to mean the values are the same, so it is entitled to treat these as one value -- as
+    `group_by` and `unique` already do.
+    """
+
+    def __init__(self, i: int) -> None:
+        self.i = i
+
+    def __eq__(self, other: object) -> bool:
+        return True
+
+    def __hash__(self) -> int:
+        return 0
+
+
+class _Distinct:
+    """An object with well-behaved equality: distinct values compare unequal."""
+
+    def __init__(self, i: int) -> None:
+        self.i = i
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _Distinct) and self.i == other.i
+
+    def __hash__(self) -> int:
+        return hash(self.i)
+
+
+def _object_frame(value: object) -> pl.DataFrame:
+    return pl.DataFrame({"o": pl.Series("o", [value], dtype=pl.Object)})
+
+
+def test_append_distinct_object_scalars_not_merged() -> None:
+    # Distinct values must survive the fast path. `vstack` reaches `Column::append` and
+    # `pl.concat` reaches `append_owned`, so both are worth checking.
+    a, b = _object_frame(_Distinct(1)), _object_frame(_Distinct(2))
+
+    assert [o.i for o in a.vstack(b)["o"]] == [1, 2]
+    assert [o.i for o in pl.concat([a, b])["o"]] == [1, 2]
+
+
+def test_scalar_object_column_is_sorted() -> None:
+    # A constant column is sorted whatever it holds, `Object` included. Consumers have
+    # to cope with that: `unique` used to pick the row-encoding `SortedUnique` strategy
+    # off the back of it and panic.
+    df = _object_frame(_AlwaysEqual(1)).vstack(_object_frame(_AlwaysEqual(2)))
+    md = df._to_metadata(stats=["column_name", "repr", "sorted_asc"])
+
+    assert md["repr"].to_list() == ["scalar"]
+    assert md["sorted_asc"].to_list() == [True]
+
+
+@pytest.mark.parametrize("engine", ["in-memory", "streaming"])
+def test_object_column_unique_after_append(engine: EngineType) -> None:
+    # Regression test: the streaming engine appends per-morsel results, and the
+    # resulting scalar object column used to panic in `unique` via row encoding.
+    lf = pl.LazyFrame({"a": [1, 2, 3, 4]}).with_columns(
+        pl.col("a").map_elements(_AlwaysEqual, return_dtype=pl.Object).alias("o")
+    )
+    df = lf.collect(engine=engine)
+
+    assert df.select("o").unique().height == 1
+    assert df.unique().height == 4


### PR DESCRIPTION
<details>
<summary>AI-generated description</summary>
`Column::append`, `append_owned` and `extend` were marked `@scalar-opt`: they
unconditionally materialized both sides into a `Series`, so every scalar column was
expanded to full length at the first `vstack`. That is the path every `DataFrame`-level
scalar column takes -- the Parquet/CSV/NDJSON readers accumulating chunks with their hive
columns, `pl.concat`, the in-memory engine's vertically parallel executors, and the
streaming in-memory sink.

They now defer to `ScalarColumn::try_append`, which appends two scalar columns holding
the same value in O(1) and leaves the result scalar. Anything else -- differing dtypes or
values -- falls back to `Series`, which is also what raises the dtype mismatch errors.

The empty-operand handling is load-bearing: the striped parallel gather in
`DataFrame::take_unchecked_impl` reduces with `Column::new_empty` as its identity, so
`sort` and `join` hit it constantly.

Three existing tests built their multi-chunk input from identical single-row frames, which
now collapse into one scalar column; they were changed to use differing values.

Three prerequisite fixes that were mixed into this branch have been split out into the
PRs below it; this one is now just the optimization.

xref: @scalar-opt

## AI disclosure

Implemented with Claude Code (Claude Opus 5). The model wrote the patch, ran the test
suites and split the work into this stack; I reviewed and edited every hunk before
submitting. Each commit was verified on its own: `cargo check --workspace
--all-features`, `make clippy` and `clippy-default`, `make py-lint`, the Rust test suite
over the crate list in `test-rust.yml`, `cargo test --all-features -p polars --test it`,
and the default and streaming Python suites.

This is part of an experiment to have more of this kind of work done by Claude.

## Stack

- https://github.com/pola-rs/polars/pull/29185 fix: Compare struct `AnyValue`s through their field dtypes
- https://github.com/pola-rs/polars/pull/29186 fix: Raise instead of panicking when a dtype cannot be row encoded
- https://github.com/pola-rs/polars/pull/29187 fix: Treat scalar columns as having no chunk layout
- https://github.com/pola-rs/polars/pull/28989 perf: Do not materialize equal `ScalarColumn`s in `Column::append`/`extend` <- this one

Merge in order, top to bottom. Each PR is based on the one above it, so its
diff is a single commit. The first three are independent of each other; only
the last needs all of them.
</details>

xref: `@scalar-opt`