### PR TITLE
fix(rust): Lower `xor` to a valid pyarrow predicate

### DIFF
--- a/crates/polars-plan/src/plans/python/pyarrow.rs
+++ b/crates/polars-plan/src/plans/python/pyarrow.rs
@@ -115,7 +115,15 @@ fn predicate_to_pa_inner(
 ) -> Option<String> {
     match expr_arena.get(predicate) {
         AExpr::BinaryExpr { left, right, op } => {
-            if op.is_comparison_or_bitwise() {
+            if matches!(op, Operator::Xor) {
+                // pyarrow expressions have no `^` operator.
+                if !(returns_boolean(*left, expr_arena) && returns_boolean(*right, expr_arena)) {
+                    return None;
+                }
+                let left = predicate_to_pa_inner(*left, expr_arena, args)?;
+                let right = predicate_to_pa_inner(*right, expr_arena, args)?;
+                Some(format!("(({left} | {right}) & ~({left} & {right}))"))
+            } else if op.is_comparison_or_bitwise() {
                 let left = predicate_to_pa_inner(*left, expr_arena, args)?;
                 let right = predicate_to_pa_inner(*right, expr_arena, args)?;
                 Some(format!("({left} {op} {right})"))
@@ -265,6 +273,36 @@ fn predicate_to_pa_inner(
     }
 }
 
+/// Whether the expression is known to be boolean without consulting the schema.
+/// `^`, `&` and `|` are bitwise operations on integers, which have no pyarrow
+/// expression equivalent.
+fn returns_boolean(node: Node, expr_arena: &Arena<AExpr>) -> bool {
+    match expr_arena.get(node) {
+        AExpr::BinaryExpr { left, right, op } => {
+            op.is_comparison()
+                || (op.is_bitwise()
+                    && returns_boolean(*left, expr_arena)
+                    && returns_boolean(*right, expr_arena))
+        },
+        AExpr::Literal(lv) => matches!(lv.get_datatype(), DataType::Boolean),
+        AExpr::Function {
+            function: IRFunctionExpr::Boolean(IRBooleanFunction::Not),
+            input,
+            ..
+        } => {
+            // `Not` is also the bitwise negation.
+            input
+                .first()
+                .is_some_and(|e| returns_boolean(e.node(), expr_arena))
+        },
+        AExpr::Function {
+            function: IRFunctionExpr::Boolean(_),
+            ..
+        } => true,
+        _ => false,
+    }
+}
+
 fn binary_op_method(op: &Operator) -> Option<&'static str> {
     Some(match op {
         Operator::Eq => "__eq__",
@@ -275,7 +313,6 @@ fn binary_op_method(op: &Operator) -> Option<&'static str> {
         Operator::GtEq => "__ge__",
         Operator::And | Operator::LogicalAnd => "__and__",
         Operator::Or | Operator::LogicalOr => "__or__",
-        Operator::Xor => "__xor__",
         _ => return None,
     })
 }
@@ -366,6 +403,19 @@ pub fn aexpr_to_pyarrow<'py>(
 ) -> Option<Bound<'py, PyAny>> {
     match expr_arena.get(predicate) {
         AExpr::BinaryExpr { left, right, op } => {
+            if matches!(op, Operator::Xor) {
+                // pyarrow expressions have no `^` operator.
+                if !(returns_boolean(*left, expr_arena) && returns_boolean(*right, expr_arena)) {
+                    return None;
+                }
+                let l = aexpr_to_pyarrow(py, pc, *left, expr_arena)?;
+                let r = aexpr_to_pyarrow(py, pc, *right, expr_arena)?;
+                let any = l.call_method1("__or__", (&r,)).ok()?;
+                let both = l.call_method1("__and__", (&r,)).ok()?;
+                return any
+                    .call_method1("__and__", (both.call_method0("__invert__").ok()?,))
+                    .ok();
+            }
             let method = binary_op_method(op)?;
             let l = aexpr_to_pyarrow(py, pc, *left, expr_arena)?;
             let r = aexpr_to_pyarrow(py, pc, *right, expr_arena)?;

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -1222,6 +1222,26 @@ def test_scan_delta_use_pyarrow_single_file(tmp_path: Path, use_pyarrow: bool) -
     )
 
 
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+@pytest.mark.write_disk
+def test_scan_delta_predicate_xor(tmp_path: Path, use_pyarrow: bool) -> None:
+    df = pl.DataFrame({"a": [1, 2, 3, None], "b": [3, 2, None, 4]})
+    df.write_delta(tmp_path)
+
+    for predicate in [
+        (pl.col("a") > 1) ^ (pl.col("b") > 1),
+        ~((pl.col("a") > 1) ^ (pl.col("b") > 1)),
+        ((pl.col("a") > 1) ^ (pl.col("b") > 1)) & (pl.col("a").is_not_null()),
+    ]:
+        assert_frame_equal(
+            pl.scan_delta(tmp_path, use_pyarrow=use_pyarrow)
+            .filter(predicate)
+            .collect(),
+            df.filter(predicate),
+            check_row_order=False,
+        )
+
+
 @pytest.mark.write_disk
 def test_delta_dataset_does_not_pickle_table_object(tmp_path: Path) -> None:
     df = pl.DataFrame({"row_index": [0, 1, 2, 3, 4]})

--- a/py-polars/tests/unit/io/test_pyarrow_dataset.py
+++ b/py-polars/tests/unit/io/test_pyarrow_dataset.py
@@ -64,6 +64,22 @@ def test_pyarrow_dataset_source(df: pl.DataFrame, tmp_path: Path) -> None:
     )
     helper_dataset_test(
         file_path,
+        lambda lf: lf.filter((pl.col("int") > 1) ^ (pl.col("floats") > 2.0)).select(
+            "bools", "floats", "date"
+        ),
+        n_expected=1,
+        check_predicate_pushdown=True,
+    )
+    helper_dataset_test(
+        file_path,
+        lambda lf: lf.filter(
+            (pl.col("int_nulls") < 3) ^ (pl.col("floats") > 2.5)
+        ).select("bools", "floats", "date"),
+        n_expected=2,
+        check_predicate_pushdown=True,
+    )
+    helper_dataset_test(
+        file_path,
         lambda lf: lf.filter(pl.col("int_nulls").is_not_null()).select(
             "bools", "floats", "date"
         ),


### PR DESCRIPTION
pyarrow expressions have no `^` operator, but both converters emitted one. The string path produced `(... ^ ...)`:

```python
pl.scan_delta(path, use_pyarrow=True).filter((pl.col("a") > 1) ^ (pl.col("b") > 1)).collect()
# TypeError: unsupported operand type(s) for ^:
#   'pyarrow._compute.Expression' and 'pyarrow._compute.Expression'
```

and `binary_op_method` mapped `Xor` to `__xor__`, which always raised, so `scan_pyarrow_dataset` never pushed a xor down.

Lower it to `(l | r) & ~(l & r)` in both paths, which matches Kleene semantics for nulls. Only when both sides are known to be boolean without a schema (comparisons, boolean functions, boolean literals, and `&`/`|`/`^` over those). `^` on integers is a bitwise operation with no pyarrow equivalent, and `&`/`|` on integer fields already fail there, so those keep falling back to the engine instead of erroring at scan time.

Tests: `test_scan_delta_predicate_xor` for the string path, plus two cases in `test_pyarrow_dataset_source` for the expression path, which assert the filter is gone from the plan and that the rows match `scan_ipc`.

## Verification

Local build (`make build`), `pytest tests/unit/io` green on both branches (3085 passed). Each fix was also confirmed to fail before the change on a rebuilt binary. The lowered strings were checked by capturing `pyarrow_predicate` from a dataset provider, and the expression path by recording the filter that reaches `dataset.to_batches`.

