### PR TITLE
fix(rust): Lower `eq_missing` / `ne_missing` to a valid pyarrow predicate

### DIFF
--- a/crates/polars-plan/src/plans/python/pyarrow.rs
+++ b/crates/polars-plan/src/plans/python/pyarrow.rs
@@ -114,14 +114,18 @@ fn predicate_to_pa_inner(
     args: PyarrowArgs,
 ) -> Option<String> {
     match expr_arena.get(predicate) {
-        AExpr::BinaryExpr { left, right, op } => {
-            if op.is_comparison_or_bitwise() {
+        AExpr::BinaryExpr { left, right, op } => match op {
+            // `==v` / `!=v` are not Python operators, so they cannot be formatted
+            // like the other comparisons.
+            Operator::EqValidity | Operator::NotEqValidity => {
+                validity_comparison_to_pa(*left, *right, *op, expr_arena, args)
+            },
+            op if op.is_comparison_or_bitwise() => {
                 let left = predicate_to_pa_inner(*left, expr_arena, args)?;
                 let right = predicate_to_pa_inner(*right, expr_arena, args)?;
                 Some(format!("({left} {op} {right})"))
-            } else {
-                None
-            }
+            },
+            _ => None,
         },
         AExpr::Column(name) => {
             let name = sanitize(name)?;
@@ -263,6 +267,48 @@ fn predicate_to_pa_inner(
         },
         _ => None,
     }
+}
+
+/// Lower `eq_missing` / `ne_missing` against a literal, where the null handling
+/// can be spelled out with `is_null`. Returns `None` for any other operands.
+fn validity_comparison_to_pa(
+    left: Node,
+    right: Node,
+    op: Operator,
+    expr_arena: &Arena<AExpr>,
+    args: PyarrowArgs,
+) -> Option<String> {
+    // The column is repeated in the output, so restrict this to plain columns.
+    let (column, literal) = match (expr_arena.get(left), expr_arena.get(right)) {
+        (AExpr::Column(_), AExpr::Literal(_)) => (left, right),
+        (AExpr::Literal(_), AExpr::Column(_)) => (right, left),
+        _ => return None,
+    };
+
+    let AExpr::Literal(lv) = expr_arena.get(literal) else {
+        unreachable!()
+    };
+
+    let eq = matches!(op, Operator::EqValidity);
+    let column = predicate_to_pa_inner(column, expr_arena, args)?;
+
+    Some(if lv.is_null() {
+        if eq {
+            format!("({column}).is_null()")
+        } else {
+            format!("~({column}).is_null()")
+        }
+    } else {
+        let literal = predicate_to_pa_inner(literal, expr_arena, args)?;
+
+        // A null column value is not equal to a non-null literal, whereas the
+        // plain comparison would evaluate to null.
+        if eq {
+            format!("(({column} == {literal}) & ~({column}).is_null())")
+        } else {
+            format!("(({column} != {literal}) | ({column}).is_null())")
+        }
+    })
 }
 
 fn binary_op_method(op: &Operator) -> Option<&'static str> {

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -1222,6 +1222,30 @@ def test_scan_delta_use_pyarrow_single_file(tmp_path: Path, use_pyarrow: bool) -
     )
 
 
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+@pytest.mark.write_disk
+def test_scan_delta_predicate_eq_missing(tmp_path: Path, use_pyarrow: bool) -> None:
+    df = pl.DataFrame({"a": [1, 2, None], "b": [1, 2, 3]})
+    df.write_delta(tmp_path)
+
+    for predicate in [
+        pl.col("a").eq_missing(2),
+        pl.col("a").eq_missing(None),
+        pl.col("a").ne_missing(2),
+        pl.col("a").ne_missing(None),
+        ~pl.col("a").eq_missing(2),
+        ~pl.col("a").ne_missing(2),
+        pl.col("a").ne_missing(2) & (pl.col("b") > 1),
+    ]:
+        assert_frame_equal(
+            pl.scan_delta(tmp_path, use_pyarrow=use_pyarrow)
+            .filter(predicate)
+            .collect(),
+            df.filter(predicate),
+            check_row_order=False,
+        )
+
+
 @pytest.mark.write_disk
 def test_delta_dataset_does_not_pickle_table_object(tmp_path: Path) -> None:
     df = pl.DataFrame({"row_index": [0, 1, 2, 3, 4]})


### PR DESCRIPTION
`predicate_to_pa` formats binary operators with their `Display` impl, so `EqValidity` and `NotEqValidity` come out as `==v` and `!=v`. The string is handed to dataset providers as `pyarrow_predicate`:

```python
pl.scan_delta(path, use_pyarrow=True).filter(pl.col("a").eq_missing(2)).collect()
# SyntaxError: invalid syntax
#   (pa.compute.field('a') ==v 2)
```

Delta `eval`s the string and raises, iceberg suppresses the parse failure and loses the pushdown. (`eq_missing(None)` was fine already, the optimizer rewrites it to `is_null`.)

Lower the operators explicitly instead, for `<column> op <literal>`:

```
((pa.compute.field('a') == 2) & ~(pa.compute.field('a')).is_null())
```

The extra null check keeps the lowering exact rather than only equivalent under a filter, so it stays correct under `~`. Anything else (two columns, two literals) is not lowered.

Test: `test_scan_delta_predicate_eq_missing`, parametrized over `use_pyarrow`, covering a literal and a null literal, negation, and a conjunction. It fails with the `SyntaxError` above without the fix.
