### PR TITLE
fix(rust): Repair the pyarrow predicate strings handed to dataset providers

### DIFF
--- a/crates/polars-plan/src/plans/python/pyarrow.rs
+++ b/crates/polars-plan/src/plans/python/pyarrow.rs
@@ -70,13 +70,6 @@ pub(crate) fn needle_isin_haystack(lv: &LiteralValue, nulls_equal: bool) -> Opti
     Some(IsInHaystack::Series(haystack_series))
 }
 
-#[derive(Default, Copy, Clone)]
-struct PyarrowArgs {
-    // pyarrow doesn't allow `filter([True, False])`
-    // but does allow `filter(field("a").isin([True, False]))`
-    allow_literal_series: bool,
-}
-
 #[cfg(feature = "dtype-datetime")]
 fn to_py_datetime(v: i64, tu: &TimeUnit, tz: Option<&TimeZone>) -> String {
     // note: `to_py_datetime` and the `Datetime`
@@ -100,73 +93,79 @@ fn sanitize(name: &str) -> Option<&str> {
     }
 }
 
+/// Render a flat `Series` as a Python list literal, e.g. `[1,2,3]`.
+///
+/// Returns `None` for values we cannot faithfully (or safely) write out as
+/// source text.
+fn series_to_pyarrow_list(s: &Series) -> Option<String> {
+    let mut list_repr = String::with_capacity(s.len() * 5);
+    list_repr.push('[');
+    for av in s.iter() {
+        match av {
+            AnyValue::Null => list_repr.push_str("None,"),
+            AnyValue::Boolean(v) => {
+                let s = if v { "True" } else { "False" };
+                write!(list_repr, "{s},").unwrap();
+            },
+            #[cfg(feature = "dtype-datetime")]
+            AnyValue::Datetime(v, tu, tz) => {
+                let dtm = to_py_datetime(v, &tu, tz);
+                write!(list_repr, "{dtm},").unwrap();
+            },
+            #[cfg(feature = "dtype-date")]
+            AnyValue::Date(v) => {
+                write!(list_repr, "to_py_date({v}),").unwrap();
+            },
+            AnyValue::String(s) => {
+                let _ = sanitize(s)?;
+                write!(list_repr, "{av},").unwrap();
+            },
+            // Hard to sanitize
+            AnyValue::Binary(_) | AnyValue::List(_) => return None,
+            #[cfg(feature = "dtype-array")]
+            AnyValue::Array(_, _) => return None,
+            #[cfg(feature = "dtype-struct")]
+            AnyValue::Struct(_, _, _) => return None,
+            _ => {
+                write!(list_repr, "{av},").unwrap();
+            },
+        }
+    }
+    // pop last comma
+    list_repr.pop();
+    list_repr.push(']');
+    Some(list_repr)
+}
+
 // Build an eval-able / AST-walker-compatible string predicate (e.g.
 // `pa.compute.field('x') > pa.compute.scalar(1)`). Used by the iceberg and
 // delta paths which feed the string into Python (delta `eval`s it,
 // iceberg walks it via `try_convert_pyarrow_predicate`).
 pub fn predicate_to_pa(predicate: Node, expr_arena: &Arena<AExpr>) -> Option<String> {
-    predicate_to_pa_inner(predicate, expr_arena, PyarrowArgs::default())
-}
-
-fn predicate_to_pa_inner(
-    predicate: Node,
-    expr_arena: &Arena<AExpr>,
-    args: PyarrowArgs,
-) -> Option<String> {
     match expr_arena.get(predicate) {
-        AExpr::BinaryExpr { left, right, op } => {
-            if op.is_comparison_or_bitwise() {
-                let left = predicate_to_pa_inner(*left, expr_arena, args)?;
-                let right = predicate_to_pa_inner(*right, expr_arena, args)?;
-                Some(format!("({left} {op} {right})"))
-            } else {
-                None
-            }
+        AExpr::BinaryExpr { left, right, op } => match op {
+            Operator::EqValidity | Operator::NotEqValidity => {
+                validity_comparison_to_pa(*left, *right, *op, expr_arena)
+            },
+            Operator::Xor => {
+                let (lhs, rhs) = boolean_operands_to_pa(*left, *right, expr_arena)?;
+
+                Some(format!("(({lhs} | {rhs}) & ~({lhs} & {rhs}))"))
+            },
+            op => {
+                let symbol = binary_op_symbol(op)?;
+                let lhs = predicate_to_pa(*left, expr_arena)?;
+                let rhs = predicate_to_pa(*right, expr_arena)?;
+
+                Some(format!("({lhs} {symbol} {rhs})"))
+            },
         },
         AExpr::Column(name) => {
             let name = sanitize(name)?;
             Some(format!("pa.compute.field('{name}')"))
         },
-        AExpr::Literal(LiteralValue::Series(s)) => {
-            if !args.allow_literal_series || s.is_empty() || s.len() > 100 {
-                None
-            } else {
-                let mut list_repr = String::with_capacity(s.len() * 5);
-                list_repr.push('[');
-                for av in s.iter() {
-                    match av {
-                        AnyValue::Boolean(v) => {
-                            let s = if v { "True" } else { "False" };
-                            write!(list_repr, "{s},").unwrap();
-                        },
-                        #[cfg(feature = "dtype-datetime")]
-                        AnyValue::Datetime(v, tu, tz) => {
-                            let dtm = to_py_datetime(v, &tu, tz);
-                            write!(list_repr, "{dtm},").unwrap();
-                        },
-                        #[cfg(feature = "dtype-date")]
-                        AnyValue::Date(v) => {
-                            write!(list_repr, "to_py_date({v}),").unwrap();
-                        },
-                        AnyValue::String(s) => {
-                            let _ = sanitize(s)?;
-                            write!(list_repr, "{av},").unwrap();
-                        },
-                        AnyValue::Binary(_) | AnyValue::List(_) => return None,
-                        #[cfg(feature = "dtype-array")]
-                        AnyValue::Array(_, _) => return None,
-                        #[cfg(feature = "dtype-struct")]
-                        AnyValue::Struct(_, _, _) => return None,
-                        _ => {
-                            write!(list_repr, "{av},").unwrap();
-                        },
-                    }
-                }
-                list_repr.pop();
-                list_repr.push(']');
-                Some(list_repr)
-            }
-        },
+        // Only meaningful as the haystack of an `is_in`, which formats it itself.
+        AExpr::Literal(LiteralValue::Series(_)) => None,
         AExpr::Literal(lv) => {
             let av = lv.to_any_value()?;
             let dtype = av.dtype();
@@ -206,16 +205,23 @@ fn predicate_to_pa_inner(
         },
         #[cfg(feature = "is_in")]
         AExpr::Function {
-            function: IRFunctionExpr::Boolean(IRBooleanFunction::IsIn { .. }),
+            function: IRFunctionExpr::Boolean(IRBooleanFunction::IsIn { nulls_equal }),
             input,
             ..
         } => {
-            let col = predicate_to_pa_inner(input.first()?.node(), expr_arena, args)?;
-            let mut args = args;
-            args.allow_literal_series = true;
-            let values = predicate_to_pa_inner(input.get(1)?.node(), expr_arena, args)?;
+            let col = predicate_to_pa(input.first()?.node(), expr_arena)?;
 
-            Some(format!("({col}).isin({values})"))
+            let AExpr::Literal(lv) = expr_arena.get(input.get(1)?.node()) else {
+                return None;
+            };
+
+            match needle_isin_haystack(lv, *nulls_equal)? {
+                IsInHaystack::Empty => Some("pa.compute.scalar(False)".to_string()),
+                IsInHaystack::Series(s) => {
+                    let values = series_to_pyarrow_list(&s)?;
+                    Some(format!("({col}).isin({values})"))
+                },
+            }
         },
         #[cfg(feature = "is_between")]
         AExpr::Function {
@@ -226,7 +232,7 @@ fn predicate_to_pa_inner(
             if !matches!(expr_arena.get(input.first()?.node()), AExpr::Column(_)) {
                 None
             } else {
-                let col = predicate_to_pa_inner(input.first()?.node(), expr_arena, args)?;
+                let col = predicate_to_pa(input.first()?.node(), expr_arena)?;
                 let left_cmp_op = match closed {
                     ClosedInterval::None | ClosedInterval::Right => Operator::Gt,
                     ClosedInterval::Both | ClosedInterval::Left => Operator::GtEq,
@@ -236,8 +242,8 @@ fn predicate_to_pa_inner(
                     ClosedInterval::Both | ClosedInterval::Right => Operator::LtEq,
                 };
 
-                let lower = predicate_to_pa_inner(input.get(1)?.node(), expr_arena, args)?;
-                let upper = predicate_to_pa_inner(input.get(2)?.node(), expr_arena, args)?;
+                let lower = predicate_to_pa(input.get(1)?.node(), expr_arena)?;
+                let upper = predicate_to_pa(input.get(2)?.node(), expr_arena)?;
 
                 Some(format!(
                     "(({col} {left_cmp_op} {lower}) & ({col} {right_cmp_op} {upper}))"
@@ -248,7 +254,7 @@ fn predicate_to_pa_inner(
             function, input, ..
         } => {
             let input = input.first().unwrap().node();
-            let input = predicate_to_pa_inner(input, expr_arena, args)?;
+            let input = predicate_to_pa(input, expr_arena)?;
 
             match function {
                 IRFunctionExpr::Boolean(IRBooleanFunction::Not) => Some(format!("~({input})")),
@@ -265,6 +271,106 @@ fn predicate_to_pa_inner(
     }
 }
 
+/// Lower `eq_missing` / `ne_missing` against a literal, where the null handling
+/// can be spelled out with `is_null`. `None` for any other operands.
+fn validity_comparison_to_pa(
+    left: Node,
+    right: Node,
+    op: Operator,
+    expr_arena: &Arena<AExpr>,
+) -> Option<String> {
+    // The column is repeated in the output, so restrict this to plain columns.
+    let (column, literal, lv) = match (expr_arena.get(left), expr_arena.get(right)) {
+        (AExpr::Column(_), AExpr::Literal(lv)) => (left, right, lv),
+        (AExpr::Literal(lv), AExpr::Column(_)) => (right, left, lv),
+        _ => return None,
+    };
+
+    let eq = matches!(op, Operator::EqValidity);
+    let column = predicate_to_pa(column, expr_arena)?;
+
+    Some(if lv.is_null() {
+        if eq {
+            format!("({column}).is_null()")
+        } else {
+            format!("~({column}).is_null()")
+        }
+    } else {
+        let literal = predicate_to_pa(literal, expr_arena)?;
+
+        // A null column value is not equal to a non-null literal, whereas the
+        // plain comparison would evaluate to null.
+        if eq {
+            format!("(({column} == {literal}) & ~({column}).is_null())")
+        } else {
+            format!("(({column} != {literal}) | ({column}).is_null())")
+        }
+    })
+}
+
+/// Lower both operands of a boolean-only operator, or `None` if either is not
+/// known to be boolean.
+fn boolean_operands_to_pa(
+    left: Node,
+    right: Node,
+    expr_arena: &Arena<AExpr>,
+) -> Option<(String, String)> {
+    if !(returns_boolean(left, expr_arena) && returns_boolean(right, expr_arena)) {
+        return None;
+    }
+
+    Some((
+        predicate_to_pa(left, expr_arena)?,
+        predicate_to_pa(right, expr_arena)?,
+    ))
+}
+
+/// Whether the expression is known to be boolean without consulting the schema.
+/// `^`, `&` and `|` are bitwise operations on integers, which PyArrow
+/// expressions have no equivalent for.
+fn returns_boolean(node: Node, expr_arena: &Arena<AExpr>) -> bool {
+    match expr_arena.get(node) {
+        AExpr::BinaryExpr { left, right, op } => {
+            op.is_comparison()
+                || (op.is_bitwise()
+                    && returns_boolean(*left, expr_arena)
+                    && returns_boolean(*right, expr_arena))
+        },
+        AExpr::Literal(lv) => matches!(lv.get_datatype(), DataType::Boolean),
+        AExpr::Function {
+            function: IRFunctionExpr::Boolean(IRBooleanFunction::Not),
+            input,
+            ..
+        } => {
+            // `Not` is also the bitwise negation.
+            input
+                .first()
+                .is_some_and(|e| returns_boolean(e.node(), expr_arena))
+        },
+        AExpr::Function {
+            function: IRFunctionExpr::Boolean(_),
+            ..
+        } => true,
+        _ => false,
+    }
+}
+
+/// The Python operator reproducing `op` on a PyArrow expression, or `None` when
+/// PyArrow has no equivalent. Mirrors [`binary_op_method`].
+fn binary_op_symbol(op: &Operator) -> Option<&'static str> {
+    Some(match op {
+        Operator::Eq => "==",
+        Operator::NotEq => "!=",
+        Operator::Lt => "<",
+        Operator::LtEq => "<=",
+        Operator::Gt => ">",
+        Operator::GtEq => ">=",
+        Operator::And | Operator::LogicalAnd => "&",
+        Operator::Or | Operator::LogicalOr => "|",
+        _ => return None,
+    })
+}
+
 fn binary_op_method(op: &Operator) -> Option<&'static str> {
     Some(match op {
         Operator::Eq => "__eq__",
@@ -275,7 +381,6 @@ fn binary_op_method(op: &Operator) -> Option<&'static str> {
         Operator::GtEq => "__ge__",
         Operator::And | Operator::LogicalAnd => "__and__",
         Operator::Or | Operator::LogicalOr => "__or__",
-        Operator::Xor => "__xor__",
         _ => return None,
     })
 }
@@ -366,6 +471,23 @@ pub fn aexpr_to_pyarrow<'py>(
 ) -> Option<Bound<'py, PyAny>> {
     match expr_arena.get(predicate) {
         AExpr::BinaryExpr { left, right, op } => {
+            if matches!(op, Operator::Xor) {
+                if !(returns_boolean(*left, expr_arena) && returns_boolean(*right, expr_arena)) {
+                    return None;
+                }
+
+                let l = aexpr_to_pyarrow(py, pc, *left, expr_arena)?;
+                let r = aexpr_to_pyarrow(py, pc, *right, expr_arena)?;
+                let any = l.call_method1("__or__", (&r,)).ok()?;
+                let both = l
+                    .call_method1("__and__", (&r,))
+                    .ok()?
+                    .call_method0("__invert__")
+                    .ok()?;
+
+                return any.call_method1("__and__", (both,)).ok();
+            }
+
             let method = binary_op_method(op)?;
             let l = aexpr_to_pyarrow(py, pc, *left, expr_arena)?;
             let r = aexpr_to_pyarrow(py, pc, *right, expr_arena)?;

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -3106,6 +3106,44 @@ def test_scan_iceberg_partial_and_pushdown(
 
 
 @pytest.mark.write_disk
+def test_scan_iceberg_is_in_pushdown(
+    tmp_path: Path,
+    plmonkeypatch: PlMonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    plmonkeypatch.setenv("POLARS_VERBOSE_SENSITIVE", "1")
+
+    catalog = SqlCatalog(
+        "default",
+        uri="sqlite:///:memory:",
+        warehouse=format_file_uri_iceberg(tmp_path),
+    )
+    catalog.create_namespace("namespace")
+    catalog.create_table(
+        "namespace.table",
+        IcebergSchema(
+            NestedField(1, "a", LongType()),
+            NestedField(2, "b", StringType()),
+        ),
+    )
+    tbl = catalog.load_table("namespace.table")
+    pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]}).write_iceberg(
+        tbl, mode="append"
+    )
+
+    q = pl.scan_iceberg(tbl).filter(pl.col("b").is_in(["x", "z"]))
+
+    capfd.readouterr()
+    result = q.collect()
+    capture = capfd.readouterr().err
+
+    # Verify: `is_in` is lowered into the pyarrow predicate
+    assert 'isin(["x","z"])' in capture
+    # Verify: correctness
+    assert result["a"].to_list() == [1, 3]
+
+
+@pytest.mark.write_disk
 def test_scan_iceberg_row_estimate(
     tmp_path: Path,
     write_position_deletes: WritePositionDeletes,  # noqa: F811

--- a/py-polars/tests/unit/io/test_pyarrow_dataset.py
+++ b/py-polars/tests/unit/io/test_pyarrow_dataset.py
@@ -72,6 +72,28 @@ def test_pyarrow_dataset_source(df: pl.DataFrame, tmp_path: Path) -> None:
     )
     helper_dataset_test(
         file_path,
+        lambda lf: lf.filter((pl.col("int") > 1) ^ (pl.col("floats") > 2.0)).select(
+            "bools", "floats", "date"
+        ),
+        n_expected=1,
+        check_predicate_pushdown=True,
+    )
+    helper_dataset_test(
+        file_path,
+        lambda lf: lf.filter(
+            (pl.col("int_nulls") < 3) ^ (pl.col("floats") > 2.5)
+        ).select("bools", "floats", "date"),
+        n_expected=2,
+        check_predicate_pushdown=True,
+    )
+    # `^` over integers is bitwise, and is left to Polars.
+    helper_dataset_test(
+        file_path,
+        lambda lf: lf.filter((pl.col("int") ^ 1) > 2).select("bools", "floats", "date"),
+        n_expected=1,
+    )
+    helper_dataset_test(
+        file_path,
         lambda lf: lf.filter(
             pl.col("int_nulls").is_not_null() == pl.col("bools")
         ).select("bools", "floats", "date"),

--- a/py-polars/tests/unit/io/test_python_dataset.py
+++ b/py-polars/tests/unit/io/test_python_dataset.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import TYPE_CHECKING, Any
+
+import pyarrow as pa
+import pyarrow.dataset as ds
+import pytest
+
+import polars as pl
+from polars._plr import PyLazyFrame
+from polars._utils.wrap import wrap_ldf
+from polars.testing import assert_frame_equal
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+class CapturingDataset:
+    """Minimal dataset provider that records the predicate Polars lowers for it."""
+
+    def __init__(self, df: pl.DataFrame) -> None:
+        self.df = df
+        self.arrow_schema = df.to_arrow().schema
+        self.pyarrow_predicate: str | None = None
+
+    def schema(self) -> pa.Schema:
+        return self.arrow_schema
+
+    def to_dataset_scan(
+        self, *, pyarrow_predicate: str | None = None, **_kwargs: Any
+    ) -> tuple[pl.LazyFrame, str]:
+        self.pyarrow_predicate = pyarrow_predicate
+
+        def impl(*_args: Any, **_kwargs: Any) -> tuple[Iterator[pl.DataFrame], bool]:
+            # Return everything: the engine re-applies the predicate itself.
+            return iter([self.df]), False
+
+        lf = pl.LazyFrame._scan_python_function(
+            self.arrow_schema, impl, pyarrow=True, is_pure=True
+        )
+
+        return lf, "v1"
+
+
+def lowered_predicate(
+    df: pl.DataFrame, predicate: pl.Expr, *, partial: bool = False
+) -> str | None:
+    """
+    Return the predicate string handed to a dataset provider for `predicate`.
+
+    Also asserts that the scan produces correct results, and - when something was
+    lowered - that the string builds a PyArrow expression selecting the same rows
+    (a superset of them, if only part of the predicate was lowered).
+    """
+    dataset = CapturingDataset(df)
+    lf = wrap_ldf(PyLazyFrame.new_from_dataset_object(dataset))
+
+    expected = df.filter(predicate)
+    assert_frame_equal(lf.filter(predicate).collect(), expected)
+
+    pyarrow_predicate = dataset.pyarrow_predicate
+
+    if pyarrow_predicate is not None:
+        from polars._utils.convert import (
+            to_py_date,
+            to_py_datetime,
+            to_py_time,
+            to_py_timedelta,
+        )
+
+        # The provider protocol says this is valid Python building a PyArrow
+        # expression - the same environment `scan_delta` evaluates it in.
+        expr = eval(
+            pyarrow_predicate,
+            {
+                "pa": pa,
+                "to_py_date": to_py_date,
+                "to_py_datetime": to_py_datetime,
+                "to_py_time": to_py_time,
+                "to_py_timedelta": to_py_timedelta,
+            },
+        )
+        filtered = pl.from_arrow(ds.dataset(df.to_arrow()).to_table(filter=expr))
+        assert isinstance(filtered, pl.DataFrame)
+
+        if partial:
+            assert_frame_equal(filtered.filter(predicate), expected)
+        else:
+            assert_frame_equal(filtered, expected)
+
+    return pyarrow_predicate
+
+
+@pytest.fixture
+def df() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "id": [1, 2, 3, 4, 5, 6],
+            "cat": ["alpha", "beta", "gamma", "delta", "alpha", "beta"],
+            "val": [0.25, 0.5, 0.75, 1.0, 1.25, 1.5],
+        }
+    )
+
+
+def test_dataset_provider_predicate_comparison(df: pl.DataFrame) -> None:
+    assert lowered_predicate(df, pl.col("id") > 3) == "(pa.compute.field('id') > 3)"
+
+
+def test_dataset_provider_predicate_is_in(df: pl.DataFrame) -> None:
+    assert (
+        lowered_predicate(df, pl.col("cat").is_in(["alpha", "beta"]))
+        == '(pa.compute.field(\'cat\')).isin(["alpha","beta"])'
+    )
+    assert (
+        lowered_predicate(df, pl.col("id").is_in([1, 3, 5]))
+        == "(pa.compute.field('id')).isin([1,3,5])"
+    )
+
+
+def test_dataset_provider_predicate_is_in_empty(df: pl.DataFrame) -> None:
+    assert lowered_predicate(df, pl.col("id").is_in([])) == "pa.compute.scalar(False)"
+
+
+def test_dataset_provider_predicate_is_in_nulls_equal(df: pl.DataFrame) -> None:
+    df = df.with_columns(pl.when(pl.col("id") > 3).then(pl.col("cat")).alias("cat"))
+
+    # Nulls are dropped from the haystack unless they are to compare equal.
+    assert (
+        lowered_predicate(df, pl.col("cat").is_in(["alpha", None]))
+        == "(pa.compute.field('cat')).isin([\"alpha\"])"
+    )
+    assert (
+        lowered_predicate(df, pl.col("cat").is_in(["alpha", None], nulls_equal=True))
+        == "(pa.compute.field('cat')).isin([\"alpha\",None])"
+    )
+
+
+def test_dataset_provider_predicate_is_in_boolean() -> None:
+    df = pl.DataFrame({"flag": [True, False, True]})
+    assert (
+        lowered_predicate(df, pl.col("flag").is_in([True]))
+        == "(pa.compute.field('flag')).isin([True])"
+    )
+
+
+def test_dataset_provider_predicate_is_in_date() -> None:
+    df = pl.DataFrame({"d": [date(2020, 1, 1), date(2020, 1, 2), date(2020, 1, 3)]})
+    assert (
+        lowered_predicate(df, pl.col("d").is_in([date(2020, 1, 1), date(2020, 1, 3)]))
+        == "(pa.compute.field('d')).isin([to_py_date(18262),to_py_date(18264)])"
+    )
+
+
+def test_dataset_provider_predicate_is_in_not_lowered() -> None:
+    df = pl.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "bin": [b"a", b"b", b"c"],
+            "st": [{"a": 1}, {"a": 2}, {"a": 3}],
+            "ids": [[1, 2], [3], [1]],
+        }
+    )
+    # Values we cannot safely write out as Python source text.
+    assert lowered_predicate(df, pl.col("bin").is_in([b"a", b"c"])) is None
+    assert lowered_predicate(df, pl.col("st").is_in([{"a": 1}])) is None
+    # A haystack that is not a literal at all.
+    assert lowered_predicate(df, pl.col("id").is_in(pl.col("ids"))) is None
+
+    arrays = pl.DataFrame({"a": [[1, 2], [3, 4]]}, schema={"a": pl.Array(pl.Int64, 2)})
+    haystack = pl.Series([[[1, 2]]], dtype=pl.List(pl.Array(pl.Int64, 2)))
+    assert lowered_predicate(arrays, pl.col("a").is_in(pl.lit(haystack))) is None
+
+
+def test_dataset_provider_predicate_series_literal_not_lowered(
+    df: pl.DataFrame,
+) -> None:
+    # A `Series` literal is only meaningful as an `is_in` haystack.
+    assert lowered_predicate(df, pl.col("id") == pl.lit(pl.Series("s", [3]))) is None
+
+
+def test_dataset_provider_predicate_is_between(df: pl.DataFrame) -> None:
+    assert (
+        lowered_predicate(df, pl.col("id").is_between(2, 4))
+        == "((pa.compute.field('id') >= 2) & (pa.compute.field('id') <= 4))"
+    )
+    assert (
+        lowered_predicate(df, pl.col("id").is_between(2, 4, closed="none"))
+        == "((pa.compute.field('id') > 2) & (pa.compute.field('id') < 4))"
+    )
+
+
+def test_dataset_provider_predicate_nested_conjunction(df: pl.DataFrame) -> None:
+    # Top-level conjuncts are lowered one by one, but an `&` nested under an `|`
+    # has to be written out as an operator of its own.
+    assert (
+        lowered_predicate(
+            df, ((pl.col("id") > 3) & (pl.col("cat") == "alpha")) | (pl.col("id") < 2)
+        )
+        == "(((pa.compute.field('id') > 3) & (pa.compute.field('cat') == 'alpha'))"
+        " | (pa.compute.field('id') < 2))"
+    )
+
+
+def test_dataset_provider_predicate_eq_missing(df: pl.DataFrame) -> None:
+    df = df.with_columns(pl.when(pl.col("id") > 3).then(pl.col("cat")).alias("cat"))
+
+    # `==v` and `!=v` are not Python operators. A null is not equal to a non-null
+    # literal, where the plain comparison would evaluate to null.
+    assert lowered_predicate(df, pl.col("cat").eq_missing("alpha")) == (
+        "((pa.compute.field('cat') == 'alpha') & ~(pa.compute.field('cat')).is_null())"
+    )
+    assert lowered_predicate(df, pl.col("cat").ne_missing("alpha")) == (
+        "((pa.compute.field('cat') != 'alpha') | (pa.compute.field('cat')).is_null())"
+    )
+    # The column may be on either side.
+    assert lowered_predicate(df, pl.lit("alpha").eq_missing(pl.col("cat"))) == (
+        "((pa.compute.field('cat') == 'alpha') & ~(pa.compute.field('cat')).is_null())"
+    )
+    # Against a null literal the optimizer has already rewritten it to `is_null`.
+    assert (
+        lowered_predicate(df, pl.col("cat").eq_missing(None))
+        == "(pa.compute.field('cat')).is_null()"
+    )
+    assert (
+        lowered_predicate(df, pl.col("cat").ne_missing(None))
+        == "~(pa.compute.field('cat')).is_null()"
+    )
+    # Two columns are not lowered: the operands are written out twice.
+    assert lowered_predicate(df, pl.col("cat").eq_missing(pl.col("cat"))) is None
+
+
+def test_dataset_provider_predicate_xor(df: pl.DataFrame) -> None:
+    # PyArrow expressions have no `^` operator.
+    assert lowered_predicate(df, (pl.col("id") > 3) ^ (pl.col("val") > 1.0)) == (
+        "(((pa.compute.field('id') > 3) | (pa.compute.field('val') > 1))"
+        " & ~((pa.compute.field('id') > 3) & (pa.compute.field('val') > 1)))"
+    )
+    # `^` on integers is a bitwise operation, which the rewrite does not hold for.
+    assert lowered_predicate(df, (pl.col("id") ^ 1) > 2) is None
+    # A bare column is not known to be boolean without consulting the schema,
+    # not even under a `~`, which is also the bitwise negation.
+    flags = pl.DataFrame({"f": [True, False, True], "g": [False, False, True]})
+    assert lowered_predicate(flags, pl.col("f") ^ pl.col("g")) is None
+    assert lowered_predicate(flags, ~pl.col("f") ^ pl.col("g").is_null()) is None
+
+
+def test_dataset_provider_predicate_xor_operands(df: pl.DataFrame) -> None:
+    # Operands that are known to be boolean without a schema: a nested `&` over
+    # comparisons, a boolean literal, and a boolean function.
+    assert (
+        lowered_predicate(
+            df, ((pl.col("id") > 3) & (pl.col("val") > 1.0)) ^ (pl.col("id") < 2)
+        )
+        is not None
+    )
+    assert lowered_predicate(df, (pl.col("id") > 3) ^ pl.lit(True)) is not None
+    assert (
+        lowered_predicate(df, pl.col("cat").is_null() ^ (pl.col("id") > 3)) is not None
+    )
+
+
+def test_dataset_provider_predicate_not_lowered(df: pl.DataFrame) -> None:
+    # Arithmetic has no lowering.
+    assert lowered_predicate(df, pl.col("val") * 2 > 1.0) is None
+    # Neither does a cast.
+    assert lowered_predicate(df, pl.col("id").cast(pl.String) == "1") is None
+
+
+def test_dataset_provider_predicate_partial(df: pl.DataFrame) -> None:
+    # Unconvertible conjuncts are dropped, the rest is still lowered.
+    assert (
+        lowered_predicate(
+            df, (pl.col("id") > 3) & (pl.col("id") % 2 == 0), partial=True
+        )
+        == "(pa.compute.field('id') > 3)"
+    )


### PR DESCRIPTION
`predicate_to_pa` builds the `pyarrow_predicate` string that `to_dataset_scan` hands to iceberg, delta and third-party providers. Three things it emits cannot be used by the consumer.

- `is_in` lowered nothing. The haystack is a length-1 list `Series` literal, so the literal arm iterated it, hit `AnyValue::List` and bailed. Now reuses `needle_isin_haystack`, which the PyO3 path already uses.
- `eq_missing` emitted `==v`, so `scan_delta(use_pyarrow=True)` raised `SyntaxError` and `scan_iceberg` dropped the predicate. Now lowered against a literal with an explicit null check.
- `xor` emitted `^`, which pyarrow expressions do not implement. Now lowered to `(l | r) & ~(l & r)` when both sides are known to be boolean. `^` on integers stays unlowered.

Operators go through one explicit table per path instead of `Display` and a `__dunder__` guess.

