### PR TITLE
feat(python): Pass the serialized predicate to Python dataset providers

### DIFF
--- a/crates/polars-plan/src/dsl/file_scan/python_dataset.rs
+++ b/crates/polars-plan/src/dsl/file_scan/python_dataset.rs
@@ -29,6 +29,7 @@ pub struct PythonDatasetProviderVTable {
         projection: Option<&[PlSmallStr]>,
         filter_columns: Option<&[PlSmallStr]>,
         pyarrow_predicate: Option<&str>,
+        serialized_predicate: Option<&[u8]>,
         py_scan_resolve_threadpool: &PyScanResolveThreadPool,
     ) -> PolarsResult<Option<(DslPlan, PlSmallStr)>>,
 }
@@ -66,6 +67,7 @@ impl PythonDatasetProvider {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn to_dataset_scan(
         &self,
         existing_resolved_version_key: Option<&str>,
@@ -73,6 +75,7 @@ impl PythonDatasetProvider {
         projection: Option<&[PlSmallStr]>,
         filter_columns: Option<&[PlSmallStr]>,
         pyarrow_predicate: Option<&str>,
+        serialized_predicate: Option<&[u8]>,
         py_scan_resolve_threadpool: &PyScanResolveThreadPool,
     ) -> PolarsResult<Option<(DslPlan, PlSmallStr)>> {
         (dataset_provider_vtable().unwrap().to_dataset_scan)(
@@ -82,6 +85,7 @@ impl PythonDatasetProvider {
             projection,
             filter_columns,
             pyarrow_predicate,
+            serialized_predicate,
             py_scan_resolve_threadpool,
         )
     }

--- a/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
+++ b/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
@@ -141,6 +141,20 @@ pub(super) fn expand_datasets(
                                 None
                             };
 
+                            // For a dataset that lowers filters into its own
+                            // language rather than the PyArrow subset. Gated like
+                            // `pyarrow_predicate`: with a row index or a slice, a
+                            // source acting on the predicate would number or
+                            // truncate the wrong rows.
+                            let serialized_predicate: Option<Vec<u8>> = if !unified_scan_args
+                                .has_row_index_or_slice()
+                                && let Some(predicate) = &predicate
+                            {
+                                serialize_scan_predicate(predicate, expr_arena)
+                            } else {
+                                None
+                            };
+
                             let ir = storage.take(key);
 
                             assert!(matches!(ir, IR::Scan { .. }));
@@ -160,6 +174,7 @@ pub(super) fn expand_datasets(
                                         live_filter_columns,
                                         row_index_in_live_filter,
                                         pyarrow_predicate,
+                                        serialized_predicate,
                                         py_scan_resolve_threadpool.as_ref(),
                                     ),
                                 )
@@ -202,7 +217,29 @@ pub(super) fn expand_datasets(
     Ok(())
 }
 
+/// Best effort: a predicate that cannot be serialized is one the provider could
+/// not have used, and the engine applies it either way.
 #[cfg(feature = "python")]
+fn serialize_scan_predicate(
+    predicate: &crate::plans::ExprIR,
+    expr_arena: &Arena<AExpr>,
+) -> Option<Vec<u8>> {
+    #[cfg(feature = "serde")]
+    {
+        crate::plans::python::predicate::serialize(&predicate.to_expr(expr_arena))
+            .ok()
+            .flatten()
+    }
+
+    #[cfg(not(feature = "serde"))]
+    {
+        let _ = (predicate, expr_arena);
+        None
+    }
+}
+
+#[cfg(feature = "python")]
+#[allow(clippy::too_many_arguments)]
 fn expand_python_dataset(
     mut scan_ir: IR,
     projection: Option<Arc<[PlSmallStr]>>,
@@ -210,6 +247,7 @@ fn expand_python_dataset(
     live_filter_columns: Option<Arc<[PlSmallStr]>>,
     row_index_in_live_filter: bool,
     pyarrow_predicate: Option<String>,
+    serialized_predicate: Option<Vec<u8>>,
     py_scan_resolve_threadpool: &PyScanResolveThreadPool,
 ) -> PolarsResult<IR> {
     let IR::Scan {
@@ -260,14 +298,19 @@ fn expand_python_dataset(
                 projection: cached_projection,
                 live_filter_columns: cached_live_filter_columns,
                 pyarrow_predicate: cached_pyarrow_predicate,
+                serialized_predicate: cached_serialized_predicate,
                 expanded_dsl: _,
                 python_scan: _,
             } = resolved;
 
+            // Two predicates over the same columns can both lower to no PyArrow
+            // expression, so the serialized form has to be part of the key for a
+            // provider that reads it.
             (&limit == cached_limit
                 && &projection == cached_projection
                 && &live_filter_columns == cached_live_filter_columns
-                && &pyarrow_predicate == cached_pyarrow_predicate)
+                && &pyarrow_predicate == cached_pyarrow_predicate
+                && &serialized_predicate == cached_serialized_predicate)
                 .then_some(version.as_str())
         },
 
@@ -280,6 +323,7 @@ fn expand_python_dataset(
         projection.as_deref(),
         live_filter_columns.as_deref(),
         pyarrow_predicate.as_deref(),
+        serialized_predicate.as_deref(),
         py_scan_resolve_threadpool,
     )? {
         *guard = Some(ExpandedDataset {
@@ -288,6 +332,7 @@ fn expand_python_dataset(
             projection,
             live_filter_columns,
             pyarrow_predicate,
+            serialized_predicate,
             expanded_dsl,
             python_scan: None,
         })
@@ -299,6 +344,7 @@ fn expand_python_dataset(
         projection: _,
         live_filter_columns: _,
         pyarrow_predicate: _,
+        serialized_predicate: _,
         expanded_dsl,
         python_scan,
     } = guard.as_mut().unwrap();
@@ -564,6 +610,7 @@ pub struct ExpandedDataset {
     projection: Option<Arc<[PlSmallStr]>>,
     live_filter_columns: Option<Arc<[PlSmallStr]>>,
     pyarrow_predicate: Option<String>,
+    serialized_predicate: Option<Vec<u8>>,
     expanded_dsl: DslPlan,
 
     /// Fallback python scan
@@ -596,6 +643,7 @@ impl Debug for ExpandedDataset {
             projection,
             live_filter_columns,
             pyarrow_predicate,
+            serialized_predicate,
             expanded_dsl,
 
             #[cfg(feature = "python")]
@@ -612,6 +660,11 @@ impl Debug for ExpandedDataset {
                 Err(e) => e.to_string(),
             },
             pyarrow_predicate: if pyarrow_predicate.is_some() {
+                "Some(<redacted>)"
+            } else {
+                "None"
+            },
+            serialized_predicate: if serialized_predicate.is_some() {
                 "Some(<redacted>)"
             } else {
                 "None"
@@ -643,6 +696,7 @@ impl Debug for ExpandedDataset {
                 pub projection: &'a Option<Arc<[PlSmallStr]>>,
                 pub live_filter_columns: &'a Option<Arc<[PlSmallStr]>>,
                 pub pyarrow_predicate: &'static str,
+                pub serialized_predicate: &'static str,
                 pub expanded_dsl: &'a str,
 
                 #[cfg(feature = "python")]

--- a/crates/polars-python/src/dataset/dataset_provider_funcs.rs
+++ b/crates/polars-python/src/dataset/dataset_provider_funcs.rs
@@ -10,7 +10,7 @@ use pyo3::call::PyCallArgs;
 use pyo3::conversion::FromPyObject;
 use pyo3::exceptions::PyValueError;
 use pyo3::pybacked::PyBackedStr;
-use pyo3::types::{PyAnyMethods, PyDict, PyList, PyListMethods};
+use pyo3::types::{PyAnyMethods, PyBytes, PyDict, PyList, PyListMethods};
 use pyo3::{Py, PyAny, PyResult, Python, intern};
 
 use crate::interned;
@@ -86,6 +86,7 @@ pub fn schema(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn to_dataset_scan(
     dataset_object: &PythonObject,
     existing_resolved_version_key: Option<&str>,
@@ -93,6 +94,7 @@ pub fn to_dataset_scan(
     projection: Option<&[PlSmallStr]>,
     filter_columns: Option<&[PlSmallStr]>,
     pyarrow_predicate: Option<&str>,
+    serialized_predicate: Option<&[u8]>,
     py_scan_resolve_threadpool: &PyScanResolveThreadPool,
 ) -> PolarsResult<Option<(DslPlan, PlSmallStr)>> {
     Python::attach(|py| {
@@ -131,14 +133,24 @@ pub fn to_dataset_scan(
             kwargs.set_item(intern!(py, "pyarrow_predicate"), pyarrow_predicate)?;
         }
 
-        let Some((scan, version)): Option<(Py<PyAny>, Wrap<PlSmallStr>)> = py_spawn_call(
-            py,
-            &dataset_object.getattr(py, intern!(py, "to_dataset_scan"))?,
-            (),
-            Some(&kwargs),
-            py_scan_resolve_threadpool,
-        )?
-        .extract(py)?
+        let function = dataset_object.getattr(py, intern!(py, "to_dataset_scan"))?;
+
+        // For a dataset that lowers filters into its own language rather than
+        // the PyArrow subset. Only passed to a provider that asks for it: an
+        // unexpected keyword would break providers written against an older
+        // Polars.
+        if let Some(serialized_predicate) = serialized_predicate
+            && accepts_keyword(py, &function, "serialized_predicate")
+        {
+            kwargs.set_item(
+                intern!(py, "serialized_predicate"),
+                PyBytes::new(py, serialized_predicate),
+            )?;
+        }
+
+        let Some((scan, version)): Option<(Py<PyAny>, Wrap<PlSmallStr>)> =
+            py_spawn_call(py, &function, (), Some(&kwargs), py_scan_resolve_threadpool)?
+                .extract(py)?
         else {
             return Ok(None);
         };
@@ -151,6 +163,35 @@ pub fn to_dataset_scan(
 
         Ok(Some((lf.logical_plan, version.0)))
     })
+}
+
+/// Whether `function` would accept `keyword`, either by name or via `**kwargs`.
+///
+/// A callable `inspect` cannot describe is treated as not accepting it.
+fn accepts_keyword(py: Python<'_>, function: &Py<PyAny>, keyword: &str) -> bool {
+    (|| {
+        let inspect = py.import(intern!(py, "inspect"))?;
+        let parameters = inspect
+            .call_method1(intern!(py, "signature"), (function,))?
+            .getattr(intern!(py, "parameters"))?;
+
+        if parameters.contains(keyword)? {
+            return PyResult::Ok(true);
+        }
+
+        let var_keyword = inspect
+            .getattr(intern!(py, "Parameter"))?
+            .getattr(intern!(py, "VAR_KEYWORD"))?;
+
+        for parameter in parameters.call_method0(intern!(py, "values"))?.try_iter()? {
+            if parameter?.getattr(intern!(py, "kind"))?.eq(&var_keyword)? {
+                return PyResult::Ok(true);
+            }
+        }
+
+        PyResult::Ok(false)
+    })()
+    .unwrap_or(false)
 }
 
 fn py_spawn_call<'a>(

--- a/py-polars/tests/unit/io/test_python_dataset_provider.py
+++ b/py-polars/tests/unit/io/test_python_dataset_provider.py
@@ -1,0 +1,200 @@
+"""Tests for the Python dataset provider interface (`new_from_dataset_object`)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pyarrow as pa
+import pytest
+
+import polars as pl
+from polars._plr import PyLazyFrame
+from polars._utils.wrap import wrap_ldf
+from polars.testing import assert_frame_equal
+
+SCHEMA = pa.schema([pa.field("a", pa.int64()), pa.field("b", pa.string())])
+TABLE = pa.table({"a": [1, 2, 3, 4], "b": ["bear", "cat", "beetle", "dog"]})
+
+
+class _Provider:
+    """Records what Polars hands it, and serves the whole table regardless."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def schema(self) -> pa.Schema:
+        return SCHEMA
+
+    def _scan(self, kwargs: dict[str, Any]) -> tuple[pl.LazyFrame, str]:
+        self.calls.append(kwargs)
+        projection = kwargs.get("projection")
+
+        def impl(*_args: Any, **_kwargs: Any) -> tuple[Any, bool]:
+            table = TABLE if projection is None else TABLE.select(projection)
+            return iter([pl.from_arrow(table)]), False
+
+        schema = (
+            SCHEMA
+            if projection is None
+            else pa.schema([SCHEMA.field(name) for name in projection])
+        )
+        lf = pl.LazyFrame._scan_python_function(
+            schema, impl, pyarrow=True, is_pure=True
+        )
+        return lf, "v1"
+
+
+class _KwargsProvider(_Provider):
+    """A provider that takes whatever Polars passes."""
+
+    def to_dataset_scan(self, **kwargs: Any) -> tuple[pl.LazyFrame, str]:
+        return self._scan(kwargs)
+
+
+class _NarrowProvider(_Provider):
+    """A provider written against a Polars that did not pass a predicate."""
+
+    def to_dataset_scan(
+        self,
+        *,
+        existing_resolved_version_key: str | None = None,
+        limit: int | None = None,
+        projection: list[str] | None = None,
+        filter_columns: list[str] | None = None,
+        pyarrow_predicate: str | None = None,
+    ) -> tuple[pl.LazyFrame, str]:
+        return self._scan(
+            {
+                "existing_resolved_version_key": existing_resolved_version_key,
+                "limit": limit,
+                "projection": projection,
+                "filter_columns": filter_columns,
+                "pyarrow_predicate": pyarrow_predicate,
+            }
+        )
+
+
+class _PredicateProvider(_Provider):
+    """A provider that asks for the whole predicate by name."""
+
+    def to_dataset_scan(
+        self,
+        *,
+        existing_resolved_version_key: str | None = None,
+        limit: int | None = None,
+        projection: list[str] | None = None,
+        filter_columns: list[str] | None = None,
+        pyarrow_predicate: str | None = None,
+        serialized_predicate: bytes | None = None,
+    ) -> tuple[pl.LazyFrame, str]:
+        return self._scan(
+            {
+                "existing_resolved_version_key": existing_resolved_version_key,
+                "limit": limit,
+                "projection": projection,
+                "filter_columns": filter_columns,
+                "pyarrow_predicate": pyarrow_predicate,
+                "serialized_predicate": serialized_predicate,
+            }
+        )
+
+
+def _lf(provider: _Provider) -> pl.LazyFrame:
+    return wrap_ldf(PyLazyFrame.new_from_dataset_object(provider))
+
+
+def test_serialized_predicate_is_passed_when_asked_for() -> None:
+    provider = _PredicateProvider()
+    predicate = pl.col("b").str.starts_with("be")
+
+    out = _lf(provider).filter(predicate).collect()
+
+    assert_frame_equal(out, pl.DataFrame(TABLE).filter(predicate))
+
+    (call,) = [c for c in provider.calls if c["filter_columns"] is not None]
+    # Polars has no PyArrow lowering for `str.starts_with`, so a provider that
+    # only reads `pyarrow_predicate` sees nothing at all here.
+    assert call["pyarrow_predicate"] is None
+    assert call["filter_columns"] == ["b"]
+
+    got = pl.Expr.deserialize(call["serialized_predicate"])
+    assert str(got) == str(predicate)
+
+
+def test_serialized_predicate_carries_the_whole_predicate() -> None:
+    """Including the parts that do lower to PyArrow, and their structure."""
+    provider = _PredicateProvider()
+    predicate = pl.col("b").str.starts_with("be") & (pl.col("a") > 1)
+
+    _lf(provider).filter(predicate).collect()
+
+    (call,) = [c for c in provider.calls if c["filter_columns"] is not None]
+    # Only one conjunct lowers to PyArrow; the serialized form has both. It is
+    # the optimizer's predicate, so conjuncts may be reordered and literals may
+    # have picked up a dtype -- what it must not do is lose a conjunct.
+    assert call["pyarrow_predicate"] is not None
+    assert "starts_with" not in call["pyarrow_predicate"]
+
+    got = str(pl.Expr.deserialize(call["serialized_predicate"]))
+    assert 'col("b").str.starts_with(["be"])' in got
+    assert 'col("a")) > (' in got
+
+
+def test_provider_without_the_parameter_is_not_passed_one() -> None:
+    """The argument list is a private protocol; adding to it must not break it."""
+    provider = _NarrowProvider()
+    predicate = pl.col("b").str.starts_with("be")
+
+    out = _lf(provider).filter(predicate).collect()
+
+    assert_frame_equal(out, pl.DataFrame(TABLE).filter(predicate))
+    assert provider.calls
+
+
+def test_kwargs_provider_receives_the_predicate() -> None:
+    provider = _KwargsProvider()
+
+    _lf(provider).filter(pl.col("a") > 2).collect()
+
+    (call,) = [c for c in provider.calls if c.get("filter_columns") is not None]
+    assert "serialized_predicate" in call
+
+
+def test_no_predicate_means_no_serialized_predicate() -> None:
+    provider = _PredicateProvider()
+
+    _lf(provider).select("a").collect()
+
+    assert all(call["serialized_predicate"] is None for call in provider.calls)
+
+
+@pytest.mark.parametrize("with_row_index", [True, False])
+def test_row_index_suppresses_the_predicate(with_row_index: bool) -> None:
+    """A source acting on the predicate would number the wrong rows."""
+    provider = _PredicateProvider()
+    lf = _lf(provider)
+
+    if with_row_index:
+        lf = lf.with_row_index()
+
+    lf.filter(pl.col("a") > 2).collect()
+
+    passed = [c["serialized_predicate"] for c in provider.calls]
+    assert (not any(p is not None for p in passed)) == with_row_index
+
+
+def test_the_resolved_scan_is_cached_per_predicate() -> None:
+    """Two predicates over the same columns must not share a resolved scan."""
+    provider = _PredicateProvider()
+    lf = _lf(provider)
+
+    assert lf.filter(pl.col("b").str.starts_with("be")).collect().height == 2
+    assert lf.filter(pl.col("b").str.starts_with("d")).collect().height == 1
+
+    serialized = [
+        call["serialized_predicate"]
+        for call in provider.calls
+        if call["serialized_predicate"] is not None
+    ]
+    assert len(serialized) == 2
+    assert serialized[0] != serialized[1]


### PR DESCRIPTION
`to_dataset_scan` only receives the predicate as `pyarrow_predicate`, the subset `predicate_to_pa` can lower. A provider whose source has its own filter language (Lance SQL, a database WHERE clause) cannot reach the rest. `expand_datasets` already holds the predicate there, so pass it as `serialized_predicate`, the same encoding `register_io_source` uses and `pl.Expr.deserialize` reads.

- Only passed to a provider that names the parameter or takes `**kwargs`, checked with `inspect.signature`, so older providers keep working.
- Gated like `pyarrow_predicate`: not sent with a row index or a slice.
- Joins the resolved-scan cache key. Two predicates over the same columns can both lower to no pyarrow expression.

The engine still applies the predicate itself, so a provider may lower only the part it understands.
