### PR TITLE
fix(python): Fix `scan_delta(DeltaTable)` with delta-rs string `storage_options`

### DIFF
--- a/py-polars/src/polars/io/cloud/_utils.py
+++ b/py-polars/src/polars/io/cloud/_utils.py
@@ -18,6 +18,25 @@ POLARS_STORAGE_CONFIG_KEYS: Final[frozenset[str]] = frozenset(
     ]
 )
 
+_POLARS_STORAGE_CONFIG_FLOAT_KEYS: Final[frozenset[str]] = frozenset(
+    ["retry_base_multiplier"]
+)
+
+
+def coerce_polars_storage_config_values(
+    storage_options: dict[str, Any],
+) -> dict[str, Any]:
+    out = dict(storage_options)
+    for key in POLARS_STORAGE_CONFIG_KEYS:
+        value = out.get(key)
+        if isinstance(value, str):
+            if key in _POLARS_STORAGE_CONFIG_FLOAT_KEYS:
+                out[key] = float(value)
+            else:
+                out[key] = int(value)
+    return out
+
+
 T = TypeVar("T")
 
 

--- a/py-polars/src/polars/io/delta/functions.py
+++ b/py-polars/src/polars/io/delta/functions.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from polars._utils.expired import RemovedParameter, removed_parameters
 from polars._utils.wrap import wrap_ldf
-from polars.io.cloud._utils import NoPickleOption
+from polars.io.cloud._utils import NoPickleOption, coerce_polars_storage_config_values
 from polars.io.delta._dataset import DeltaDataset
 
 if TYPE_CHECKING:
@@ -322,10 +322,12 @@ def scan_delta(
     if table is not None and (
         table._storage_options is not None or storage_options is not None
     ):
-        storage_options = {
-            **(table._storage_options or {}),
-            **(storage_options or {}),
-        }
+        storage_options = coerce_polars_storage_config_values(
+            {
+                **(table._storage_options or {}),
+                **(storage_options or {}),
+            }
+        )
 
     dataset = DeltaDataset(
         table_=NoPickleOption(table),

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -1452,3 +1452,22 @@ def test_scan_delta_predicate_pushdown_struct_is_not_null(
     # must not be pruned.
     assert_frame_equal(out, df, check_row_order=False)
     assert "skipping 1 / 2 files" not in err
+
+
+@pytest.mark.write_disk
+def test_scan_delta_deltatable_string_storage_options(tmp_path: Path) -> None:
+    storage_options = {
+        "connect_timeout": "30s",
+        "timeout": "120s",
+        "max_retries": "20",
+        "retry_timeout": "600s",
+        "backoff_config.init_backoff": "500ms",
+        "backoff_config.max_backoff": "20s",
+        "backoff_config.base": "2.0",
+    }
+    df = pl.DataFrame({"x": [1]})
+    df.write_delta(tmp_path)
+    delta_table = DeltaTable(str(tmp_path), storage_options=storage_options)
+
+    result = pl.scan_delta(delta_table).collect()
+    assert_frame_equal(result, df)


### PR DESCRIPTION
Fixes `scan_delta(DeltaTable)` failing when the `DeltaTable` was opened with delta-rs `storage_options` (`max_retries="20"` is the only parameter that is used both by delta-rs and Polars).
delta-rs requires all storage option values to be strings, but Polars parses keys in `POLARS_STORAGE_CONFIG_KEYS` as `int` or `float` in Rust.
In this PR, I added `coerce_polars_storage_config_values()` to convert string values to `int` or `float` before passing them to Rust.

I used AI (Composer 2.5) to validate my idea and generate the code for the test. I confirm that I have reviewed all changes myself, and I believe they are relevant and correct (I am very much open to comments though, I might be missing something since it's my first PR to Polars).

Here is the screenshot of the test suite run.
<img width="1392" height="313" alt="image" src="https://github.com/user-attachments/assets/8ec81686-34ba-4f64-806a-2c975764f025" />

Closes #28901.