### PR TITLE
docs(python): Fix invalid output in DataFrame.sample example

### DIFF
--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -11576,8 +11576,8 @@ class DataFrame:
         │ --- ┆ --- ┆ --- │
         │ i64 ┆ i64 ┆ str │
         ╞═════╪═════╪═════╡
-        │ 3   ┆ 8   ┆ c   │
         │ 2   ┆ 7   ┆ b   │
+        │ 3   ┆ 8   ┆ c   │
         └─────┴─────┴─────┘
         """
         if n is not None and fraction is not None:


### PR DESCRIPTION
The `DataFrame.sample` example passes `shuffle=False` but the output rows are in a different relative order to the input.

From testing with Polars 1.44.1, this doesn't match the actual behaviour and `shuffle=False` does work as expected, except when passing `with_replacement=True`, which was reported in #28988.
