### PR TITLE
fix: Preserve scalar arrays in arr.dot dispatch

### DIFF
--- a/crates/polars-expr/src/dispatch/array.rs
+++ b/crates/polars-expr/src/dispatch/array.rs
@@ -75,9 +75,13 @@ pub(super) fn sum(s: &Column) -> PolarsResult<Column> {
 }
 
 pub(super) fn dot(s: &[Column]) -> PolarsResult<Column> {
-    let lhs = s[0].array()?;
-    let rhs = s[1].array()?;
-    lhs.array_dot(rhs).map(Column::from)
+    let lhs = s[0].as_materialized_series_maintain_scalar();
+    let rhs = s[1].as_materialized_series_maintain_scalar();
+
+    lhs.array()?
+        .array_dot(rhs.array()?)?
+        .into_column()
+        .broadcast_owned_to(broadcast_len(s)?)
 }
 
 pub(super) fn std(s: &Column, ddof: u8) -> PolarsResult<Column> {

--- a/py-polars/tests/unit/operations/test_scalar.py
+++ b/py-polars/tests/unit/operations/test_scalar.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Literal
 
 import pytest
 
@@ -152,6 +152,50 @@ def test_elementwise_over_broadcast_scalar_array(expr: pl.Expr) -> None:
     )
     assert_frame_equal(
         broadcast.select(expr).collect(), materialized.select(expr).collect()
+    )
+
+
+@pytest.mark.parametrize("engine", ["in-memory", "streaming"])
+@pytest.mark.parametrize(
+    "expr",
+    [
+        pytest.param(pl.col("lhs").arr.dot("rhs"), id="scalar-rhs"),
+        pytest.param(pl.col("rhs").arr.dot("lhs"), id="scalar-lhs"),
+    ],
+)
+def test_arr_dot_over_broadcast_scalar_array(
+    engine: Literal["in-memory", "streaming"], expr: pl.Expr
+) -> None:
+    dtype = pl.Array(pl.Int64, 3)
+    lhs = pl.Series("lhs", [[1, 2, 3], [4, None, 6], None], dtype=dtype)
+    rhs = pl.Series("rhs", [[10, None, 30]], dtype=dtype)
+    broadcast = pl.LazyFrame({"lhs": lhs}).with_columns(pl.lit(rhs).first())
+    materialized = pl.LazyFrame(
+        {
+            "lhs": lhs,
+            "rhs": pl.Series("rhs", [[10, None, 30]] * len(lhs), dtype=dtype),
+        }
+    )
+    assert_frame_equal(
+        broadcast.select(expr).collect(engine=engine),
+        materialized.select(expr).collect(engine=engine),
+    )
+
+
+@pytest.mark.parametrize("engine", ["in-memory", "streaming"])
+def test_arr_dot_over_empty_broadcast_scalar_array(
+    engine: Literal["in-memory", "streaming"],
+) -> None:
+    dtype = pl.Array(pl.Float64, 2)
+    broadcast = pl.LazyFrame(schema={"lhs": dtype}).with_columns(
+        pl.lit(pl.Series("rhs", [[10.0, 20.0]], dtype=dtype)).first()
+    )
+    materialized = pl.LazyFrame(schema={"lhs": dtype, "rhs": dtype})
+    expr = pl.col("lhs").arr.dot("rhs")
+
+    assert_frame_equal(
+        broadcast.select(expr).collect(engine=engine),
+        materialized.select(expr).collect(engine=engine),
     )
 
 


### PR DESCRIPTION
Closes #28848

Heap allocation evidence
```
100 × (composed allocation − native allocation) / (rows × width × sizeof(inner_dtype))

+100% → native avoids allocation equal to one product buffer
   0% → equal allocation
 −33% → native allocates 33% of one product buffer more
```

| Revision | Streaming-broadcast result |
| :--- | :--- |
| Old #28829 chart | −33.3290% to −33.0226% |
| #28872 fix only | approximately +0.0047% to +0.3143% |
| #28872 plus this PR | +100.0001% to +100.2425% |

Above +100% means native avoids product buffer plus small amount of additional heap capacity.
But actual reduction relative to composed total allocation is about 96.7%, so it does not exceed 100%.

More in comments