### PR TITLE
refactor(rust): Also store spilled frames in OOC for prefetching

### DIFF
--- a/crates/polars-ooc/src/memory_manager.rs
+++ b/crates/polars-ooc/src/memory_manager.rs
@@ -18,7 +18,7 @@ const SPILL_FRAME_BATCH_SIZE: u64 = 256;
 const MAX_PARALLEL_SPILL_TASKS: usize = 64;
 
 use crate::WeakSpillContext;
-use crate::spill_context::{RegisteredSpillToken, ReinsertReason, UNEXPLORED_SCORE};
+use crate::spill_context::{InsertReason, RegisteredSpillToken, UNEXPLORED_SCORE};
 use crate::spill_token::{DynSpillToken, SpillStatus, TrySpillError};
 
 static MEMORY_MANAGER: LazyLock<MemoryManager> = LazyLock::new(MemoryManager::new);
@@ -123,7 +123,7 @@ impl MemoryManager {
 
                 polars_async::executor::spawn(TaskPriority::High, async move {
                     // Spill, or reinsert if a failure.
-                    match spillable.clone().try_spill(ctx.clone(), rt.registration_id) {
+                    match spillable.clone().try_spill(ctx.clone()) {
                         Ok(spill_success) => {
                             if spill_success.await {
                                 if !successful_spill.0.swap(true, Ordering::Relaxed) {
@@ -138,7 +138,7 @@ impl MemoryManager {
                                 spillable.cancel_spill_attempt_and_reinsert(
                                     rt.registration_id,
                                     ctx.1,
-                                    ReinsertReason::Unpin,
+                                    InsertReason::Unpin,
                                 );
                             }
                         },
@@ -146,7 +146,7 @@ impl MemoryManager {
                             spillable.cancel_spill_attempt_and_reinsert(
                                 rt.registration_id,
                                 ctx.1,
-                                ReinsertReason::Unpin,
+                                InsertReason::Unpin,
                             );
                         },
                         Err(TrySpillError::AlreadySpilled) => {},
@@ -227,7 +227,7 @@ impl MemoryManager {
 
             let mut num_considered = 0;
             let mut candidates = Vec::new();
-            ctx.0.drain_while(|rt| {
+            ctx.0.drain_live_while(|rt| {
                 let Some(cand) = rt.upgrade() else {
                     return true;
                 };
@@ -239,14 +239,14 @@ impl MemoryManager {
                         cand.cancel_spill_attempt_and_reinsert(
                             rt.registration_id,
                             ctx.1,
-                            ReinsertReason::TooSmall(rt.timestamp),
+                            InsertReason::TooSmall(rt.timestamp),
                         );
                     },
                     SpillStatus::Pinned => {
                         cand.cancel_spill_attempt_and_reinsert(
                             rt.registration_id,
                             ctx.1,
-                            ReinsertReason::Unpin,
+                            InsertReason::Unpin,
                         );
                     },
                     // A spilled token is re-inserted by whoever unspills it, a

--- a/crates/polars-ooc/src/spill_context/mod.rs
+++ b/crates/polars-ooc/src/spill_context/mod.rs
@@ -62,6 +62,7 @@ struct LocalStagingArea {
     accesses: SpillQueue,
     cancellations: SpillQueue,
     too_small: SpillQueue,
+    spilled: SpillQueue,
 }
 
 #[derive(Default)]
@@ -123,6 +124,14 @@ impl SpillQueue {
         self.retain_amort = 0;
     }
 
+    pub fn unregister_all(&mut self, context_id: u64) {
+        while let Some(rt) = self.pop_back() {
+            if let Some(t) = rt.upgrade() {
+                t.unregister_from(context_id);
+            }
+        }
+    }
+
     pub fn extend_front(&mut self, tokens: Vec<RegisteredSpillToken>) {
         for token in tokens.into_iter().rev() {
             if token.is_valid() {
@@ -158,8 +167,10 @@ impl SpillContextPolicy {
     }
 }
 
-pub(crate) enum ReinsertReason {
-    Unspill,
+pub(crate) enum InsertReason {
+    Register,
+    RegisterSpilled,
+    Spill,
     Unpin,
     // The timestamps below are the original registration time.
     #[expect(dead_code)]
@@ -167,10 +178,16 @@ pub(crate) enum ReinsertReason {
     TooSmall(Timestamp),
 }
 
+#[derive(Default)]
+struct SharedState {
+    spill_queue: SpillQueue,
+    unspill_queue: SpillQueue,
+}
+
 pub(crate) struct SpillContextInner {
     staging: ThreadLocal<Mutex<LocalStagingArea>>,
     staging_empty: AtomicBool,
-    spill_queue: Mutex<SpillQueue>,
+    shared: Mutex<SharedState>,
     stats: Arc<SpillContextStatistics>,
     policy: AtomicU8,
     refcount: AtomicU64,
@@ -183,7 +200,7 @@ impl SpillContextInner {
         Self {
             staging: ThreadLocal::default(),
             staging_empty: AtomicBool::new(true),
-            spill_queue: Mutex::default(),
+            shared: Mutex::default(),
             stats: Arc::new(SpillContextStatistics::new(name)),
             policy: AtomicU8::new(policy as u8),
             refcount: AtomicU64::new(0),
@@ -192,7 +209,7 @@ impl SpillContextInner {
     }
 
     // We need forced locking to make reset not leave orphan spillframes.
-    fn drain_staging(&self, queue: &mut SpillQueue, force_lock: bool) {
+    fn drain_staging(&self, shared: &mut SharedState, force_lock: bool) {
         if !force_lock
             && (self.staging_empty.load(Ordering::Relaxed)
                 || self.staging_empty.swap(true, Ordering::AcqRel))
@@ -203,11 +220,13 @@ impl SpillContextInner {
         let mut accesses = Vec::new();
         let mut cancellations = Vec::new();
         let mut too_small = Vec::new();
+        let mut spilled = Vec::new();
         for local in self.staging.iter() {
             let mut lock = local.lock().unwrap();
             lock.accesses.drain_into(&mut accesses);
             lock.cancellations.drain_into(&mut cancellations);
             lock.too_small.drain_into(&mut too_small);
+            lock.spilled.drain_into(&mut spilled);
         }
 
         let policy = self.policy();
@@ -216,37 +235,36 @@ impl SpillContextInner {
                 accesses.sort_by_key(|t| t.timestamp);
                 cancellations.sort_by_key(|t| t.timestamp);
                 too_small.sort_by_key(|t| t.timestamp);
+                spilled.sort_by_key(|t| t.timestamp);
             },
             SpillContextPolicy::Random => {},
         }
 
-        queue.extend_back(accesses);
+        shared.spill_queue.extend_back(accesses);
+        shared.unspill_queue.extend_back(spilled);
 
         // A cancelled spill attempt is retried with priority. A token rejected
         // for being too small would fail that same check again, so it goes on
         // the opposite end.
         if matches!(policy, SpillContextPolicy::LeastRecent) {
-            queue.extend_front(cancellations);
-            queue.extend_back(too_small);
+            shared.spill_queue.extend_front(cancellations);
+            shared.spill_queue.extend_back(too_small);
         } else {
-            queue.extend_back(cancellations);
-            queue.extend_front(too_small);
+            shared.spill_queue.extend_back(cancellations);
+            shared.spill_queue.extend_front(too_small);
         }
     }
 
     fn reset(&self, name: PlSmallStr, policy: SpillContextPolicy) {
         let ctx_id = new_context_id();
-        self.context_id.store(ctx_id, Ordering::Relaxed);
+        let old_ctx_id = self.context_id.swap(ctx_id, Ordering::Relaxed);
         self.policy.store(policy as u8, Ordering::Relaxed);
         self.stats.reset(name);
 
-        let mut queue = self.spill_queue.lock().unwrap();
-        self.drain_staging(&mut queue, true);
-        while let Some(rt) = queue.pop_back() {
-            if let Some(t) = rt.upgrade() {
-                t.unregister();
-            }
-        }
+        let mut shared = self.shared.lock().unwrap();
+        self.drain_staging(&mut shared, true);
+        shared.spill_queue.unregister_all(old_ctx_id);
+        shared.unspill_queue.unregister_all(old_ctx_id);
     }
 
     fn context_id(&self) -> u64 {
@@ -261,17 +279,17 @@ impl SpillContextInner {
         &self.stats
     }
 
-    pub(crate) fn drain_while<F: FnMut(RegisteredSpillToken) -> bool>(&self, mut f: F) {
+    pub(crate) fn drain_live_while<F: FnMut(RegisteredSpillToken) -> bool>(&self, mut f: F) {
         let mut rng = rand::rng();
         let policy = self.policy();
 
-        let mut queue = self.spill_queue.lock().unwrap();
-        self.drain_staging(&mut queue, false);
+        let mut shared = self.shared.lock().unwrap();
+        self.drain_staging(&mut shared, false);
 
         while let Some(rt) = match policy {
-            SpillContextPolicy::MostRecent => queue.pop_back(),
-            SpillContextPolicy::LeastRecent => queue.pop_front(),
-            SpillContextPolicy::Random => queue.pop_random(&mut rng),
+            SpillContextPolicy::MostRecent => shared.spill_queue.pop_back(),
+            SpillContextPolicy::LeastRecent => shared.spill_queue.pop_front(),
+            SpillContextPolicy::Random => shared.spill_queue.pop_random(&mut rng),
         } {
             if !f(rt) {
                 break;
@@ -279,37 +297,29 @@ impl SpillContextInner {
         }
     }
 
-    pub(crate) fn reinsert(
+    pub(crate) fn insert(
         &self,
         token: &Arc<dyn DynSpillToken>,
         reg_id: u32,
         ctx_id: u64,
-        reason: ReinsertReason,
+        reason: InsertReason,
     ) {
         let mut local = self.staging.get_or_default().lock().unwrap();
         if ctx_id != self.context_id.load(Ordering::Relaxed) {
             return;
         }
 
-        match reason {
-            ReinsertReason::Unspill | ReinsertReason::Unpin => {
-                local.accesses.push_back(RegisteredSpillToken::new(
-                    token,
-                    reg_id,
-                    Timestamp::now(),
-                ));
+        let (queue, ts) = match reason {
+            InsertReason::Register => (&mut local.accesses, Timestamp::now()),
+            InsertReason::Spill | InsertReason::RegisterSpilled => {
+                (&mut local.spilled, Timestamp::now())
             },
-            ReinsertReason::SpillCancelled(ts) => {
-                local
-                    .cancellations
-                    .push_back(RegisteredSpillToken::new(token, reg_id, ts));
-            },
-            ReinsertReason::TooSmall(ts) => {
-                local
-                    .too_small
-                    .push_back(RegisteredSpillToken::new(token, reg_id, ts));
-            },
-        }
+            InsertReason::Unpin => (&mut local.accesses, Timestamp::now()),
+            InsertReason::SpillCancelled(ts) => (&mut local.cancellations, ts),
+            InsertReason::TooSmall(ts) => (&mut local.too_small, ts),
+        };
+
+        queue.push_back(RegisteredSpillToken::new(token, reg_id, ts));
 
         if self.staging_empty.load(Ordering::Relaxed) {
             self.staging_empty.swap(false, Ordering::AcqRel);
@@ -351,21 +361,10 @@ impl StrongSpillContext {
         T: AsRef<SpillToken<S>>,
         S: Spillable,
     {
-        let dyn_arc = token.as_ref().upcast();
-        let reg_id = dyn_arc.register(self.downgrade(), SpillContextParam(()));
-
-        {
-            let mut local = self.0.staging.get_or_default().lock().unwrap();
-            local.accesses.push_back(RegisteredSpillToken::new(
-                &dyn_arc,
-                reg_id,
-                Timestamp::now(),
-            ));
-        }
-
-        if self.0.staging_empty.load(Ordering::Relaxed) {
-            self.0.staging_empty.swap(false, Ordering::AcqRel);
-        }
+        token
+            .as_ref()
+            .upcast()
+            .register(self.downgrade(), SpillContextParam(()));
     }
 }
 
@@ -421,23 +420,12 @@ impl WeakSpillContext {
 pub struct SpillContextParam(pub(crate) ());
 
 impl WeakSpillContext {
-    pub fn register<T, S>(&self, token: &T, param: SpillContextParam)
+    pub fn register_no_spill_check<T, S>(&self, token: &T, param: SpillContextParam)
     where
         T: AsRef<SpillToken<S>>,
         S: Spillable,
     {
-        let dyn_arc = token.as_ref().upcast();
-        let mut local = self.0.staging.get_or_default().lock().unwrap();
-        if self.0.context_id() == self.1 {
-            local.accesses.push_back(RegisteredSpillToken::new(
-                &dyn_arc,
-                dyn_arc.register(self.clone(), param),
-                Timestamp::now(),
-            ));
-            if self.0.staging_empty.load(Ordering::Relaxed) {
-                self.0.staging_empty.swap(false, Ordering::AcqRel);
-            }
-        }
+        token.as_ref().upcast().register(self.clone(), param);
     }
 }
 

--- a/crates/polars-ooc/src/spill_token.rs
+++ b/crates/polars-ooc/src/spill_token.rs
@@ -10,7 +10,7 @@ use polars_async::ASYNC;
 use polars_utils::UnitVec;
 use polars_utils::with_drop::WithDrop;
 
-use crate::spill_context::ReinsertReason;
+use crate::spill_context::InsertReason;
 use crate::{SpillContextParam, Spillable, WeakSpillContext};
 
 // SpillTokenInner's state
@@ -27,7 +27,6 @@ enum ValueSlot<T> {
     Spilled {
         n_bytes: usize,
         spill_ctx: WeakSpillContext,
-        reinsert_reg_id: u32,
         spill_time_ns: u64,
         spilled_start: Instant,
     },
@@ -208,43 +207,12 @@ impl<T: Spillable> SpillTokenInner<T> {
                 slf.wake_waiters(slf.state.fetch_and(!LOCK_BIT, Ordering::AcqRel));
             });
 
-            let unspill_start = Instant::now();
-            let spilled = (*slf.spilled_value.get()).as_ref().unwrap();
-            let value = T::unspill(spilled).await;
-            let ValueSlot::Spilled {
-                n_bytes,
-                spill_ctx,
-                reinsert_reg_id,
-                spill_time_ns,
-                spilled_start,
-            } = slf.value_slot.get().replace(ValueSlot::InMemory(value))
-            else {
-                unreachable!()
-            };
-
-            if let Some(strong) = spill_ctx.upgrade() {
-                strong.stats().add_unspill(
-                    n_bytes,
-                    spill_time_ns,
-                    spilled_start,
-                    unspill_start,
-                    prefetch,
-                );
-            }
-            if reinsert_reg_id == slf.registration_id.load(Ordering::Relaxed) {
-                let dyn_slf: Arc<dyn DynSpillToken> = slf.clone();
-                spill_ctx.0.reinsert(
-                    &dyn_slf,
-                    reinsert_reg_id,
-                    spill_ctx.1,
-                    ReinsertReason::Unspill,
-                );
-            }
+            Self::unspill_while_locked(slf, prefetch).await;
 
             WithDrop::dismiss(lock_guard);
             slf.wake_waiters(
                 slf.state
-                    .fetch_add(RO_PIN_COUNT_UNIT - LOCK_BIT - SPILLED_BIT, Ordering::AcqRel),
+                    .fetch_add(RO_PIN_COUNT_UNIT - LOCK_BIT, Ordering::AcqRel),
             );
             PinnedRef { inner: slf }
         }
@@ -267,45 +235,12 @@ impl<T: Spillable> SpillTokenInner<T> {
                 slf.wake_waiters(slf.state.fetch_and(!LOCK_BIT, Ordering::AcqRel));
             });
 
-            let value_slot = &mut *slf.value_slot.get();
-            if let ValueSlot::Spilled {
-                n_bytes,
-                spill_ctx,
-                reinsert_reg_id,
-                spill_time_ns,
-                spilled_start,
-            } = value_slot
-            {
-                debug_assert!(slf.state.load(Ordering::Relaxed) & SPILLED_BIT == SPILLED_BIT);
-                let unspill_start = Instant::now();
-                let spilled = (*slf.spilled_value.get()).take().unwrap();
-                let value = T::unspill(&spilled).await;
-
-                if let Some(strong) = spill_ctx.upgrade() {
-                    strong.stats().add_unspill(
-                        *n_bytes,
-                        *spill_time_ns,
-                        *spilled_start,
-                        unspill_start,
-                        false,
-                    );
-                }
-                if *reinsert_reg_id == slf.registration_id.load(Ordering::Relaxed) {
-                    let dyn_slf: Arc<dyn DynSpillToken> = slf.clone();
-                    spill_ctx.0.reinsert(
-                        &dyn_slf,
-                        *reinsert_reg_id,
-                        spill_ctx.1,
-                        ReinsertReason::Unspill,
-                    );
-                }
-
-                *value_slot = ValueSlot::InMemory(value);
-                slf.state.fetch_sub(SPILLED_BIT, Ordering::Relaxed);
-            } else {
-                // We are about to mutate, making our current spill invalid.
-                *slf.spilled_value.get() = None;
+            if slf.state.load(Ordering::Relaxed) & SPILLED_BIT != 0 {
+                Self::unspill_while_locked(slf, false).await;
             }
+
+            // Clear the spilled value as we're about to invalidate it through mutable access.
+            *slf.spilled_value.get() = None;
 
             WithDrop::dismiss(lock_guard);
             PinnedMut { inner: slf }
@@ -314,6 +249,47 @@ impl<T: Spillable> SpillTokenInner<T> {
 
     fn pin_mut_blocking(slf: &Arc<Self>) -> PinnedMut<'_, T> {
         ASYNC.block_in_place_on(Self::pin_mut(slf))
+    }
+
+    /// # Safety
+    /// May only be called if you currently hold the exclusive lock.
+    async unsafe fn unspill_while_locked(slf: &Arc<Self>, prefetch: bool) {
+        debug_assert!(slf.state.load(Ordering::Relaxed) & SPILLED_BIT == SPILLED_BIT);
+
+        // Do the unspill.
+        let unspill_start = Instant::now();
+        let spilled = unsafe { (*slf.spilled_value.get()).as_ref().unwrap() };
+        let value = T::unspill(spilled).await;
+        let old_slot = unsafe { slf.value_slot.get().replace(ValueSlot::InMemory(value)) };
+        slf.state.fetch_sub(SPILLED_BIT, Ordering::Relaxed);
+
+        let ValueSlot::Spilled {
+            n_bytes,
+            spill_ctx,
+            spill_time_ns,
+            spilled_start,
+        } = old_slot
+        else {
+            unreachable!()
+        };
+
+        // Update stats.
+        if let Some(strong) = spill_ctx.upgrade() {
+            strong.stats().add_unspill(
+                n_bytes,
+                spill_time_ns,
+                spilled_start,
+                unspill_start,
+                prefetch,
+            );
+        }
+
+        // Invalidate previous entries in our bookkeeping, and ensure we reinsert when this pin ends.
+        // We hold the lock to not race with calls to register().
+        let _lock = slf.lock.lock().unwrap();
+        slf.registration_id.fetch_add(1, Ordering::Release);
+        slf.state
+            .fetch_or(REINSERT_WHEN_SPILLABLE_BIT, Ordering::Release);
     }
 
     /// # Safety
@@ -341,23 +317,37 @@ impl<T: Spillable> SpillTokenInner<T> {
 
     #[cold]
     fn notify_spillable_after_unpin(slf: &Arc<Self>) {
-        // Hold registration lock during this operation to prevent races.
+        // Hold registration lock to ensure old_s, cur_ctx, and reg_id are consistent.
         let lock = slf.lock.lock().unwrap();
         let old_s = slf
             .state
             .fetch_and(!REINSERT_WHEN_SPILLABLE_BIT, Ordering::AcqRel);
-        if let Some((spill_ctx, _param)) = &lock.cur_ctx {
+        let cur_ctx = lock.cur_ctx.clone();
+        let reg_id = slf.registration_id.load(Ordering::Relaxed);
+        drop(lock);
+
+        if let Some((spill_ctx, _param)) = cur_ctx {
             if old_s & REINSERT_WHEN_SPILLABLE_BIT != 0 {
                 let dyn_slf: Arc<dyn DynSpillToken> = slf.clone();
-                let reinsert_reg_id = slf.registration_id.load(Ordering::Relaxed);
-                spill_ctx.0.reinsert(
-                    &dyn_slf,
-                    reinsert_reg_id,
-                    spill_ctx.1,
-                    ReinsertReason::Unpin,
-                );
+                spill_ctx
+                    .0
+                    .insert(&dyn_slf, reg_id, spill_ctx.1, InsertReason::Unpin);
             }
         }
+    }
+
+    /// Unregisters while holding the registration lock.
+    fn unregister_locked(
+        &self,
+        lock: &mut LockState,
+    ) -> Option<(WeakSpillContext, SpillContextParam)> {
+        // Clear the re-insert bit, this spillframe is now unregistered.
+        self.state
+            .fetch_and(!REINSERT_WHEN_SPILLABLE_BIT, Ordering::Relaxed);
+
+        // Increment the registration ID to invalidate previous registration.
+        self.registration_id.fetch_add(1, Ordering::Release);
+        lock.cur_ctx.take()
     }
 
     /// # Safety
@@ -403,7 +393,6 @@ where
             let ValueSlot::Spilled {
                 n_bytes,
                 spill_ctx,
-                reinsert_reg_id: _,
                 spill_time_ns: _,
                 spilled_start: _,
             } = &*lock_guard.value_slot.get()
@@ -426,7 +415,6 @@ where
                 value_slot: UnsafeCell::new(ValueSlot::Spilled {
                     n_bytes: *n_bytes,
                     spill_ctx: spill_ctx.clone(),
-                    reinsert_reg_id: 0,
                     spill_time_ns,
                     spilled_start,
                 }),
@@ -453,11 +441,16 @@ pub enum SpillStatus {
 
 pub(crate) trait DynSpillToken: Send + Sync + 'static {
     /// Register this spill token at a new context, returning the registration ID.
-    fn register(&self, ctx: WeakSpillContext, param: SpillContextParam) -> u32;
+    fn register(self: Arc<Self>, ctx: WeakSpillContext, param: SpillContextParam) -> u32;
 
     /// Unregisters this spill token from its current context, returning where
     /// it was registered, if anywhere.
     fn unregister(&self) -> Option<(WeakSpillContext, SpillContextParam)>;
+
+    /// Unregisters this spill token, but only if it is currently registered at
+    /// the context with the given ID. Returns where it was registered, or None
+    /// if it was registered elsewhere or nowhere.
+    fn unregister_from(&self, context_id: u64) -> Option<(WeakSpillContext, SpillContextParam)>;
 
     /// Returns the current context registration ID of this spill token without modifying it.
     fn current_registration_id(&self) -> u32;
@@ -472,7 +465,7 @@ pub(crate) trait DynSpillToken: Send + Sync + 'static {
         self: Arc<Self>,
         reg_id: u32,
         context_id: u64,
-        reason: ReinsertReason,
+        reason: InsertReason,
     );
 
     /// Tries to spill this token. Returns true if successful.
@@ -482,34 +475,46 @@ pub(crate) trait DynSpillToken: Send + Sync + 'static {
     /// occurred during spilling.
     fn try_spill(
         self: Arc<Self>,
-        context: WeakSpillContext,
-        registration_id: u32,
+        stats_ctx: WeakSpillContext,
     ) -> Result<Pin<Box<dyn Future<Output = bool> + Send>>, TrySpillError>;
 }
 
 impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
-    fn register(&self, ctx: WeakSpillContext, param: SpillContextParam) -> u32 {
+    fn register(self: Arc<Self>, ctx: WeakSpillContext, param: SpillContextParam) -> u32 {
         let mut lock = self.lock.lock().unwrap();
 
         // Clear the re-insert bit, we're registering to a new context.
-        self.state
-            .fetch_and(!REINSERT_WHEN_SPILLABLE_BIT, Ordering::Relaxed);
+        let state = self
+            .state
+            .fetch_and(!REINSERT_WHEN_SPILLABLE_BIT, Ordering::Acquire);
 
         // Increment the registration ID to invalidate previous registration.
-        lock.cur_ctx = Some((ctx, param));
-        self.registration_id.fetch_add(1, Ordering::Release) + 1
+        lock.cur_ctx = Some((ctx.clone(), param));
+        let reg_id = self.registration_id.fetch_add(1, Ordering::Release) + 1;
+
+        drop(lock);
+
+        let reason = if state & SPILLED_BIT != 0 {
+            InsertReason::RegisterSpilled
+        } else {
+            InsertReason::Register
+        };
+        let dyn_arc: Arc<dyn DynSpillToken> = self;
+        ctx.0.insert(&dyn_arc, reg_id, ctx.1, reason);
+        reg_id
     }
 
     fn unregister(&self) -> Option<(WeakSpillContext, SpillContextParam)> {
         let mut lock = self.lock.lock().unwrap();
+        self.unregister_locked(&mut lock)
+    }
 
-        // Clear the re-insert bit, this spillframe is now unregistered.
-        self.state
-            .fetch_and(!REINSERT_WHEN_SPILLABLE_BIT, Ordering::Relaxed);
-
-        // Increment the registration ID to invalidate previous registration.
-        self.registration_id.fetch_add(1, Ordering::Release);
-        lock.cur_ctx.take()
+    fn unregister_from(&self, context_id: u64) -> Option<(WeakSpillContext, SpillContextParam)> {
+        let mut lock = self.lock.lock().unwrap();
+        if lock.cur_ctx.as_ref()?.0.1 != context_id {
+            return None;
+        }
+        self.unregister_locked(&mut lock)
     }
 
     fn current_registration_id(&self) -> u32 {
@@ -537,13 +542,13 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
         self: Arc<Self>,
         reg_id: u32,
         context_id: u64,
-        reason: ReinsertReason,
+        reason: InsertReason,
     ) {
-        // Hold lock to not race with other registrations.
+        // Hold registration lock to ensure old_s and cur_ctx are consistent.
         let lock = self.lock.lock().unwrap();
 
         // Outdated registration?
-        let Some((ctx, _param)) = lock.cur_ctx.as_ref() else {
+        let Some((ctx, _param)) = lock.cur_ctx.clone() else {
             return;
         };
         if ctx.1 != context_id || self.registration_id.load(Ordering::Relaxed) != reg_id {
@@ -559,18 +564,19 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
             }
         });
 
+        drop(lock);
+
         // Not locked/pinned/spilled/dropped, reinsert now. If spilled registration of that fact was
         // done by the responsible party, if dropped it doesn't matter.
         if old_s & (LOCK_BIT | RO_PIN_MASK | SPILLED_BIT | DROPPED_BIT) == 0 {
             let dyn_slf: Arc<dyn DynSpillToken> = self.clone();
-            ctx.0.reinsert(&dyn_slf, reg_id, context_id, reason);
+            ctx.0.insert(&dyn_slf, reg_id, context_id, reason);
         }
     }
 
     fn try_spill(
         self: Arc<Self>,
-        ctx: WeakSpillContext,
-        registration_id: u32,
+        stats_ctx: WeakSpillContext,
     ) -> Result<Pin<Box<dyn Future<Output = bool> + Send>>, TrySpillError> {
         // First, we try setting the lock bit. If anyone else has a pin we don't bother.
         let pin_update = self
@@ -585,19 +591,8 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
         let Ok(state) = pin_update else {
             return Err(TrySpillError::Pinned);
         };
-        if state & SPILLED_BIT != 0 {
-            // Update re-insertion context, we hold the lock bit and there were no pins so this is safe.
-            let ValueSlot::Spilled {
-                spill_ctx: reinsert_ctx,
-                reinsert_reg_id: reinsert_id,
-                ..
-            } = (unsafe { &mut *self.value_slot.get() })
-            else {
-                unreachable!()
-            };
-            *reinsert_ctx = ctx;
-            *reinsert_id = registration_id;
 
+        if state & SPILLED_BIT != 0 {
             self.wake_waiters(self.state.fetch_sub(LOCK_BIT, Ordering::AcqRel));
             return Err(TrySpillError::AlreadySpilled);
         }
@@ -613,7 +608,7 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
                         .fetch_add(RO_PIN_COUNT_UNIT - LOCK_BIT, Ordering::AcqRel),
                 );
                 let pin_guard = PinnedRef { inner: &self };
-                let spilled = pin_guard.spill(&ctx.0.stats().name()).await;
+                let spilled = pin_guard.spill(&stats_ctx.0.stats().name()).await;
                 core::mem::forget(pin_guard);
                 // We can simply re-acquire the lock here blindly, as we still hold
                 // our pin meaning no one else could've gotten the lock.
@@ -635,25 +630,41 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
                     ValueSlot::InMemory(val) => val.estimate_byte_size(),
                     _ => unreachable!(),
                 };
-                let (spill_time_ns, spilled_start) = if let Some(strong) = ctx.upgrade() {
+                let (spill_time_ns, spilled_start) = if let Some(strong) = stats_ctx.upgrade() {
                     strong.stats().add_successful_spill(n_bytes, spill_start)
                 } else {
                     // Dummy, context is already dead.
                     (0, Instant::now())
                 };
+
                 unsafe {
                     self.value_slot.get().replace(ValueSlot::Spilled {
                         n_bytes,
-                        spill_ctx: ctx,
-                        reinsert_reg_id: registration_id,
+                        spill_ctx: stats_ctx.clone(),
                         spill_time_ns,
                         spilled_start,
                     })
                 };
-                self.state
-                    .fetch_add(SPILLED_BIT.wrapping_sub(LOCK_BIT), Ordering::AcqRel)
+
+                // Insert as spilled in the *current* context, not the context for statistics.
+                // Marking as spilled and reading the registration must happen under the same lock,
+                // so a concurrent register either observes us as spilled or invalidates our insert.
+                let lock = self.lock.lock().unwrap();
+                let state = self
+                    .state
+                    .fetch_add(SPILLED_BIT.wrapping_sub(LOCK_BIT), Ordering::AcqRel);
+                let cur_ctx = lock.cur_ctx.clone();
+                let reg_id = self.registration_id.load(Ordering::Relaxed);
+                drop(lock);
+
+                if let Some((ctx, _param)) = cur_ctx {
+                    let dyn_slf: Arc<dyn DynSpillToken> = self.clone();
+                    ctx.0.insert(&dyn_slf, reg_id, ctx.1, InsertReason::Spill);
+                }
+
+                state
             } else {
-                if let Some(strong) = ctx.upgrade() {
+                if let Some(strong) = stats_ctx.upgrade() {
                     strong.stats().add_failed_spill(spill_start);
                 }
                 self.state.fetch_sub(LOCK_BIT, Ordering::AcqRel)
@@ -726,6 +737,7 @@ impl<T: Spillable> SpillToken<T> {
         let ValueSlot::InMemory(value) = slot else {
             unreachable!()
         };
+        pin.inner.state.fetch_or(DROPPED_BIT, Ordering::Release);
         value
     }
 
@@ -736,6 +748,7 @@ impl<T: Spillable> SpillToken<T> {
         let ValueSlot::InMemory(value) = slot else {
             unreachable!()
         };
+        pin.inner.state.fetch_or(DROPPED_BIT, Ordering::Release);
         value
     }
 }

--- a/crates/polars-stream/src/morsel.rs
+++ b/crates/polars-stream/src/morsel.rs
@@ -176,7 +176,7 @@ impl Morsel {
         let sf = SpillFrame::new_unregistered(df);
         self.sf = sf;
         if let Some((ctx, param)) = old_registry {
-            ctx.register(&self.sf, param);
+            ctx.register_no_spill_check(&self.sf, param);
         }
     }
 
@@ -191,7 +191,7 @@ impl Morsel {
         let df = f(sf.into_df().await);
         let sf = SpillFrame::new_unregistered(df);
         if let Some((ctx, param)) = old_registry {
-            ctx.register(&sf, param);
+            ctx.register_no_spill_check(&sf, param);
         }
         Self {
             sf,
@@ -215,7 +215,7 @@ impl Morsel {
         let df = f(sf.into_df().await)?;
         let sf = SpillFrame::new_unregistered(df);
         if let Some((ctx, param)) = old_registry {
-            ctx.register(&sf, param);
+            ctx.register_no_spill_check(&sf, param);
         }
         Ok(Self {
             sf,
@@ -240,7 +240,7 @@ impl Morsel {
         let df = f(sf.into_df().await).await?;
         let sf = SpillFrame::new_unregistered(df);
         if let Some((ctx, param)) = old_registry {
-            ctx.register(&sf, param);
+            ctx.register_no_spill_check(&sf, param);
         }
         Ok(Self {
             sf,


### PR DESCRIPTION
By storing the spilled frames in a queue as well we can do prefetching. This PR also fixes some subtle race conditions in the whole registration system.