### PR TITLE
fix: Tolerate ecosystem-valid Parquet metadata

### DIFF
--- a/crates/polars-parquet/src/parquet/handwritten_thrift/file_metadata_thrift.rs
+++ b/crates/polars-parquet/src/parquet/handwritten_thrift/file_metadata_thrift.rs
@@ -66,6 +66,21 @@ macro_rules! read_struct_fields {
             last_field_id = $f.id;
         }
     };
+    ($prot:ident, |$f:ident| { $($id:literal => $arm:expr),* $(,)? }, $has_field:ident) => {
+        let mut last_field_id = 0i16;
+        loop {
+            let $f = $prot.read_field_begin(last_field_id)?;
+            if $f.field_type == FieldType::Stop {
+                break;
+            }
+            $has_field = true;
+            match $f.id {
+                $($id => { $arm; },)*
+                _ => $prot.skip($f.field_type)?,
+            }
+            last_field_id = $f.id;
+        }
+    };
 }
 
 /// Decode a Parquet `FileMetaData` footer into [`CompactFileMetaData`].
@@ -121,7 +136,7 @@ fn read_file_metadata(
         3 => num_rows = Some(prot.read_i64()?),
         4 => row_groups = Some(read_list(prot, |p| read_row_group(p, origin_ptr))?),
         5 => key_value_metadata = Some(read_list(prot, read_key_value)?),
-        6 => created_by = Some(prot.read_string()?.to_owned()),
+        6 => created_by = Some(String::from_utf8_lossy(prot.read_bytes()?).into_owned()),
         7 => column_orders = Some(read_list(prot, read_column_order)?),
     });
 
@@ -166,7 +181,7 @@ fn read_schema_element(prot: &mut ThriftSliceInputProtocol<'_>) -> ParquetResult
         7 => scale = Some(prot.read_i32()?),
         8 => precision = Some(prot.read_i32()?),
         9 => field_id = Some(prot.read_i32()?),
-        10 => logical_type = Some(read_logical_type(prot)?),
+        10 => logical_type = read_logical_type(prot)?,
     });
 
     Ok(SchemaElement {
@@ -367,8 +382,8 @@ fn read_key_value(prot: &mut ThriftSliceInputProtocol<'_>) -> ParquetResult<KeyV
     let mut value: Option<String> = None;
 
     read_struct_fields!(prot, |f| {
-        1 => key = Some(prot.read_string()?.to_owned()),
-        2 => value = Some(prot.read_string()?.to_owned()),
+        1 => key = Some(String::from_utf8_lossy(prot.read_bytes()?).into_owned()),
+        2 => value = Some(String::from_utf8_lossy(prot.read_bytes()?).into_owned()),
     });
 
     Ok(KeyValue {
@@ -400,6 +415,7 @@ fn read_sorting_column(prot: &mut ThriftSliceInputProtocol<'_>) -> ParquetResult
 /// only the union id matters: 1 = `TypeDefinedOrder`, 2 = `IEEE754TotalOrder`.
 fn read_column_order(prot: &mut ThriftSliceInputProtocol<'_>) -> ParquetResult<ColumnOrderTag> {
     let mut ret: Option<ColumnOrderTag> = None;
+    let mut has_field = false;
     read_struct_fields!(prot, |f| {
         1 => {
             read_empty_struct(prot)?;
@@ -409,8 +425,12 @@ fn read_column_order(prot: &mut ThriftSliceInputProtocol<'_>) -> ParquetResult<C
             read_empty_struct(prot)?;
             ret.get_or_insert(ColumnOrderTag::IEEE754TotalOrder);
         },
-    });
-    ret.ok_or_else(|| ParquetError::oos("ColumnOrder union has no variant set"))
+    }, has_field);
+    match (ret, has_field) {
+        (Some(order), _) => Ok(order),
+        (None, true) => Ok(ColumnOrderTag::Unknown),
+        (None, false) => Err(ParquetError::oos("ColumnOrder union has no variant set")),
+    }
 }
 
 /// Decode a `LogicalType` union.
@@ -420,13 +440,14 @@ fn read_column_order(prot: &mut ThriftSliceInputProtocol<'_>) -> ParquetResult<C
 /// always has.
 fn read_logical_type(
     prot: &mut ThriftSliceInputProtocol<'_>,
-) -> ParquetResult<polars_parquet_format::LogicalType> {
+) -> ParquetResult<Option<polars_parquet_format::LogicalType>> {
     use polars_parquet_format::{
         BsonType, DateType, EnumType, Float16Type, JsonType, ListType, LogicalType, MapType,
         NullType, StringType, UUIDType,
     };
 
     let mut ret: Option<LogicalType> = None;
+    let mut has_field = false;
     read_struct_fields!(prot, |f| {
         1 => {
             read_empty_struct(prot)?;
@@ -453,12 +474,14 @@ fn read_logical_type(
             ret.get_or_insert(LogicalType::DATE(DateType {}));
         },
         7 => {
-            let v = read_time_type(prot)?;
-            ret.get_or_insert(LogicalType::TIME(v));
+            if let Some(v) = read_time_type(prot)? {
+                ret.get_or_insert(LogicalType::TIME(v));
+            }
         },
         8 => {
-            let v = read_timestamp_type(prot)?;
-            ret.get_or_insert(LogicalType::TIMESTAMP(v));
+            if let Some(v) = read_timestamp_type(prot)? {
+                ret.get_or_insert(LogicalType::TIMESTAMP(v));
+            }
         },
         10 => {
             let v = read_int_type(prot)?;
@@ -484,8 +507,12 @@ fn read_logical_type(
             read_empty_struct(prot)?;
             ret.get_or_insert(LogicalType::FLOAT16(Float16Type {}));
         },
-    });
-    ret.ok_or_else(|| ParquetError::oos("LogicalType union has no variant set"))
+    }, has_field);
+    if has_field {
+        Ok(ret)
+    } else {
+        Err(ParquetError::oos("LogicalType union has no variant set"))
+    }
 }
 
 fn read_empty_struct(prot: &mut ThriftSliceInputProtocol<'_>) -> ParquetResult<()> {
@@ -511,9 +538,10 @@ fn read_decimal_type(
 
 fn read_time_unit(
     prot: &mut ThriftSliceInputProtocol<'_>,
-) -> ParquetResult<polars_parquet_format::TimeUnit> {
+) -> ParquetResult<Option<polars_parquet_format::TimeUnit>> {
     use polars_parquet_format::{MicroSeconds, MilliSeconds, NanoSeconds, TimeUnit};
     let mut ret: Option<TimeUnit> = None;
+    let mut has_field = false;
     read_struct_fields!(prot, |f| {
         1 => {
             read_empty_struct(prot)?;
@@ -527,40 +555,52 @@ fn read_time_unit(
             read_empty_struct(prot)?;
             ret.get_or_insert(TimeUnit::NANOS(NanoSeconds {}));
         },
-    });
-    ret.ok_or_else(|| ParquetError::oos("TimeUnit union has no variant set"))
+    }, has_field);
+    if has_field {
+        Ok(ret)
+    } else {
+        Err(ParquetError::oos("TimeUnit union has no variant set"))
+    }
 }
 
 fn read_time_type(
     prot: &mut ThriftSliceInputProtocol<'_>,
-) -> ParquetResult<polars_parquet_format::TimeType> {
+) -> ParquetResult<Option<polars_parquet_format::TimeType>> {
     use polars_parquet_format::TimeType;
     let mut is_adjusted: Option<bool> = None;
-    let mut unit: Option<polars_parquet_format::TimeUnit> = None;
+    let mut unit: Option<Option<polars_parquet_format::TimeUnit>> = None;
     read_struct_fields!(prot, |f| {
         1 => is_adjusted = Some(f.bool_val.expect("thrift bool field")),
         2 => unit = Some(read_time_unit(prot)?),
     });
-    Ok(TimeType {
-        is_adjusted_to_u_t_c: is_adjusted.require("TimeType.is_adjusted_to_u_t_c")?,
-        unit: unit.require("TimeType.unit")?,
-    })
+    let is_adjusted_to_u_t_c = is_adjusted.require("TimeType.is_adjusted_to_u_t_c")?;
+    let Some(unit) = unit.require("TimeType.unit")? else {
+        return Ok(None);
+    };
+    Ok(Some(TimeType {
+        is_adjusted_to_u_t_c,
+        unit,
+    }))
 }
 
 fn read_timestamp_type(
     prot: &mut ThriftSliceInputProtocol<'_>,
-) -> ParquetResult<polars_parquet_format::TimestampType> {
+) -> ParquetResult<Option<polars_parquet_format::TimestampType>> {
     use polars_parquet_format::TimestampType;
     let mut is_adjusted: Option<bool> = None;
-    let mut unit: Option<polars_parquet_format::TimeUnit> = None;
+    let mut unit: Option<Option<polars_parquet_format::TimeUnit>> = None;
     read_struct_fields!(prot, |f| {
         1 => is_adjusted = Some(f.bool_val.expect("thrift bool field")),
         2 => unit = Some(read_time_unit(prot)?),
     });
-    Ok(TimestampType {
-        is_adjusted_to_u_t_c: is_adjusted.require("TimestampType.is_adjusted_to_u_t_c")?,
-        unit: unit.require("TimestampType.unit")?,
-    })
+    let is_adjusted_to_u_t_c = is_adjusted.require("TimestampType.is_adjusted_to_u_t_c")?;
+    let Some(unit) = unit.require("TimestampType.unit")? else {
+        return Ok(None);
+    };
+    Ok(Some(TimestampType {
+        is_adjusted_to_u_t_c,
+        unit,
+    }))
 }
 
 fn read_int_type(
@@ -588,6 +628,15 @@ mod tests {
         read_column_order(&mut prot)
     }
 
+    fn decode_logical_type(
+        bytes: &[u8],
+    ) -> ParquetResult<Option<polars_parquet_format::LogicalType>> {
+        let mut prot = ThriftSliceInputProtocol::new(bytes);
+        let logical_type = read_logical_type(&mut prot)?;
+        assert!(prot.as_slice().is_empty());
+        Ok(logical_type)
+    }
+
     #[test]
     fn column_order_type_defined() {
         assert_eq!(
@@ -605,7 +654,71 @@ mod tests {
     }
 
     #[test]
+    fn column_order_unknown() {
+        assert_eq!(
+            decode_column_order(&[0x3C, 0x00, 0x00]).unwrap(),
+            ColumnOrderTag::Unknown
+        );
+    }
+
+    #[test]
     fn column_order_no_variant_is_an_error() {
         assert!(decode_column_order(&[0x00]).is_err());
+    }
+
+    #[test]
+    fn unknown_logical_types_are_ignored() {
+        for field_id in [0x20, 0x22, 0x24] {
+            assert!(
+                decode_logical_type(&[0x0C, field_id, 0x00, 0x00])
+                    .unwrap()
+                    .is_none()
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_logical_type_payload_is_fully_skipped() {
+        assert!(
+            decode_logical_type(&[0x0C, 0x22, 0x18, 0x03, b'c', b'r', b's', 0x00, 0x00,])
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn logical_type_no_variant_is_an_error() {
+        assert!(decode_logical_type(&[0x00]).is_err());
+    }
+
+    #[test]
+    fn unknown_time_unit_ignores_logical_type() {
+        assert!(
+            decode_logical_type(&[0x7C, 0x11, 0x1C, 0x4C, 0x00, 0x00, 0x00, 0x00])
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn key_value_metadata_is_lossy_utf8() {
+        let mut prot =
+            ThriftSliceInputProtocol::new(&[0x18, 0x01, b'k', 0x18, 0x02, 0xFF, 0xFE, 0x00]);
+        let key_value = read_key_value(&mut prot).unwrap();
+        assert_eq!(key_value.key, "k");
+        assert_eq!(key_value.value.as_deref(), Some("��"));
+        assert!(prot.as_slice().is_empty());
+    }
+
+    #[test]
+    fn unknown_codec_is_deferred() {
+        let bytes = [
+            0x15, 0x02, 0x19, 0x15, 0x00, 0x19, 0x18, 0x01, b'a', 0x15, 0x54, 0x16, 0x00, 0x16,
+            0x00, 0x16, 0x00, 0x26, 0x08, 0x00,
+        ];
+        let mut prot = ThriftSliceInputProtocol::new(&bytes);
+        let metadata = read_column_meta_data(&mut prot, bytes.as_ptr()).unwrap();
+        assert_eq!(metadata.codec, Compression::Unknown(42));
+        assert!(prot.as_slice().is_empty());
     }
 }

--- a/crates/polars-parquet/src/parquet/handwritten_thrift/parquet_thrift.rs
+++ b/crates/polars-parquet/src/parquet/handwritten_thrift/parquet_thrift.rs
@@ -202,8 +202,9 @@ impl TryFrom<ElementType> for FieldType {
             ElementType::Double => Ok(Self::Double),
             ElementType::Binary => Ok(Self::Binary),
             ElementType::List => Ok(Self::List),
+            ElementType::Set => Ok(Self::Set),
+            ElementType::Map => Ok(Self::Map),
             ElementType::Struct => Ok(Self::Struct),
-            _ => Err(ThriftProtocolError::InvalidFieldType(value as u8)),
         }
     }
 }
@@ -558,16 +559,45 @@ pub(crate) trait ThriftCompactInputProtocol<'a> {
                 }
                 Ok(())
             },
-            FieldType::List => {
+            FieldType::List | FieldType::Set => {
                 let list_ident = self.read_list_begin()?;
                 for _ in 0..list_ident.size {
-                    let element_type = FieldType::try_from(list_ident.element_type)?;
-                    self.skip_till_depth(element_type, depth - 1)?;
+                    self.skip_collection_element(list_ident.element_type, depth - 1)?;
                 }
                 Ok(())
             },
-            // no list or map types in parquet format
+            FieldType::Map => {
+                let size = self.read_vlq()?;
+                if size == 0 {
+                    return Ok(());
+                }
+                let types = self.read_byte()?;
+                let key_type = ElementType::try_from(types >> 4)?;
+                let value_type = ElementType::try_from(types & 0x0f)?;
+                for _ in 0..size {
+                    self.skip_collection_element(key_type, depth - 1)?;
+                    self.skip_collection_element(value_type, depth - 1)?;
+                }
+                Ok(())
+            },
             _ => Err(ThriftProtocolError::SkipUnsupportedType(field_type)),
+        }
+    }
+
+    fn skip_collection_element(
+        &mut self,
+        element_type: ElementType,
+        depth: i8,
+    ) -> ThriftProtocolResult<()> {
+        if depth == 0 {
+            return Err(ThriftProtocolError::SkipDepth(FieldType::try_from(
+                element_type,
+            )?));
+        }
+        if element_type == ElementType::Bool {
+            self.read_bool().map(|_| ())
+        } else {
+            self.skip_till_depth(FieldType::try_from(element_type)?, depth)
         }
     }
 }
@@ -1157,5 +1187,21 @@ pub(crate) mod tests {
         let header = prot.read_list_begin().expect("error reading list header");
         assert_eq!(header.size, 0);
         assert_eq!(header.element_type, ElementType::Byte);
+    }
+
+    #[test]
+    fn test_skip_map() {
+        let data = [0x02, 0x58, 0x02, 0x01, b'a', 0x04, 0x01, b'b', 0x7F];
+        let mut prot = ThriftSliceInputProtocol::new(&data);
+        prot.skip(FieldType::Map).unwrap();
+        assert_eq!(prot.as_slice(), &[0x7F]);
+    }
+
+    #[test]
+    fn test_skip_set() {
+        let data = [0x25, 0x02, 0x04, 0x7F];
+        let mut prot = ThriftSliceInputProtocol::new(&data);
+        prot.skip(FieldType::Set).unwrap();
+        assert_eq!(prot.as_slice(), &[0x7F]);
     }
 }

--- a/crates/polars-parquet/src/parquet/metadata/column_chunk_metadata.rs
+++ b/crates/polars-parquet/src/parquet/metadata/column_chunk_metadata.rs
@@ -186,11 +186,50 @@ fn compact_stats_to_parquet(s: &CompactStatistics, footer_buf: &[u8]) -> Parquet
 pub(super) fn column_metadata_byte_range_compact(
     column_metadata: &CompactColumnMetaData,
 ) -> core::ops::Range<u64> {
-    let offset = if let Some(dict_page_offset) = column_metadata.dictionary_page_offset {
-        dict_page_offset as u64
-    } else {
-        column_metadata.data_page_offset as u64
-    };
+    // Match parquet-java ColumnChunkMetaData#getStartingPos: non-positive or
+    // non-preceding dictionary offsets mean that the data page starts the chunk.
+    let offset = column_metadata
+        .dictionary_page_offset
+        .filter(|&dict_offset| dict_offset > 0 && dict_offset < column_metadata.data_page_offset)
+        .unwrap_or(column_metadata.data_page_offset) as u64;
     let len = column_metadata.total_compressed_size as u64;
-    offset..offset.checked_add(len).unwrap()
+    offset..offset.saturating_add(len)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn byte_range(
+        dictionary_page_offset: Option<i64>,
+        data_page_offset: i64,
+    ) -> core::ops::Range<u64> {
+        column_metadata_byte_range_compact(&CompactColumnMetaData {
+            codec: Compression::Uncompressed,
+            num_values: 0,
+            total_uncompressed_size: 0,
+            total_compressed_size: 10,
+            data_page_offset,
+            index_page_offset: None,
+            dictionary_page_offset,
+            statistics: None,
+            bloom_filter_offset: None,
+            bloom_filter_length: None,
+        })
+    }
+
+    #[test]
+    fn byte_range_ignores_zero_dictionary_offset() {
+        assert_eq!(byte_range(Some(0), 4), 4..14);
+    }
+
+    #[test]
+    fn byte_range_ignores_dictionary_offset_after_data() {
+        assert_eq!(byte_range(Some(100), 50), 50..60);
+    }
+
+    #[test]
+    fn byte_range_uses_dictionary_offset_before_data() {
+        assert_eq!(byte_range(Some(4), 50), 4..14);
+    }
 }

--- a/crates/polars-parquet/src/parquet/metadata/column_order.rs
+++ b/crates/polars-parquet/src/parquet/metadata/column_order.rs
@@ -22,6 +22,8 @@ pub enum ColumnOrder {
     /// Undefined column order, means legacy behaviour before parquet-format 2.4.0.
     /// Sort order is always SIGNED.
     Undefined,
+    /// The file declared a column order unknown to this reader.
+    Unknown,
 }
 
 impl ColumnOrder {
@@ -32,6 +34,7 @@ impl ColumnOrder {
             // Not signed comparison: total order positions NaNs and -0.0 < +0.0.
             ColumnOrder::IEEE754TotalOrder => SortOrder::IEEE754TotalOrder,
             ColumnOrder::Undefined => SortOrder::Signed,
+            ColumnOrder::Unknown => SortOrder::Undefined,
         }
     }
 }
@@ -42,4 +45,5 @@ impl ColumnOrder {
 pub(crate) enum ColumnOrderTag {
     TypeDefined,
     IEEE754TotalOrder,
+    Unknown,
 }

--- a/crates/polars-parquet/src/parquet/metadata/file_metadata.rs
+++ b/crates/polars-parquet/src/parquet/metadata/file_metadata.rs
@@ -238,6 +238,7 @@ fn parse_column_orders(
                 ColumnOrder::TypeDefinedOrder(sort_order)
             },
             ColumnOrderTag::IEEE754TotalOrder => ColumnOrder::IEEE754TotalOrder,
+            ColumnOrderTag::Unknown => ColumnOrder::Unknown,
         })
         .collect()
 }

--- a/crates/polars-parquet/src/parquet/parquet_bridge.rs
+++ b/crates/polars-parquet/src/parquet/parquet_bridge.rs
@@ -58,6 +58,7 @@ pub enum Compression {
     Lz4,
     Zstd,
     Lz4Raw,
+    Unknown(i32),
 }
 
 impl TryFrom<CompressionCodec> for Compression {
@@ -73,7 +74,7 @@ impl TryFrom<CompressionCodec> for Compression {
             CompressionCodec::LZ4 => Compression::Lz4,
             CompressionCodec::ZSTD => Compression::Zstd,
             CompressionCodec::LZ4_RAW => Compression::Lz4Raw,
-            _ => return Err(ParquetError::oos("Thrift out of range")),
+            CompressionCodec(value) => Compression::Unknown(value),
         })
     }
 }
@@ -89,6 +90,7 @@ impl From<Compression> for CompressionCodec {
             Compression::Lz4 => CompressionCodec::LZ4,
             Compression::Zstd => CompressionCodec::ZSTD,
             Compression::Lz4Raw => CompressionCodec::LZ4_RAW,
+            Compression::Unknown(value) => CompressionCodec(value),
         }
     }
 }

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -3359,6 +3359,23 @@ def test_read_write_metadata(static: bool, lazy: bool) -> None:
     assert metadata == {k: v for k, v in actual.items() if k != "ARROW:schema"}
 
 
+def test_non_utf8_parquet_metadata_23211() -> None:
+    nested = io.BytesIO()
+    pq.write_table(pa.table({"nested": [1]}), nested)
+
+    expected = pl.DataFrame({"a": [1, 2, 3]})
+    table = pa.table(expected.to_dict(as_series=False)).replace_schema_metadata(
+        {b"k": nested.getvalue()}
+    )
+    parquet = io.BytesIO()
+    pq.write_table(table, parquet)
+    parquet_bytes = parquet.getvalue()
+
+    assert pl.read_parquet_schema(io.BytesIO(parquet_bytes)) == expected.schema
+    assert_frame_equal(pl.read_parquet(io.BytesIO(parquet_bytes)), expected)
+    assert_frame_equal(pl.scan_parquet(io.BytesIO(parquet_bytes)).collect(), expected)
+
+
 @pytest.mark.write_disk
 def test_metadata_callback_info(tmp_path: Path) -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})


### PR DESCRIPTION
Fixes #23211.

## Summary
- follow parquet-java chunk-start semantics for absent or invalid dictionary offsets and avoid range-overflow panics
- ignore unknown logical-type and column-order union arms while retaining errors for empty unions
- decode arbitrary file metadata bytes lossily and defer unknown codec failures until the affected column is read
- support skipping Thrift compact map and set fields

## Tests
- `cargo test -p polars-parquet --all-features`
- `cargo clippy -p polars-parquet --all-features --all-targets`
- `pytest py-polars/tests/unit/io/test_parquet.py` (1694 passed)
- manually verified Apache parquet-testing GEOMETRY, GEOGRAPHY, and shredded VARIANT fixtures