### PR TITLE
fix(frame): filter/remove with all-bool predicates raises TypeError

### DIFF
--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -4271,8 +4271,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             F.col(name).eq(value) for name, value in constraints.items()
         )
         if not (all_predicates or boolean_masks):
-            msg = "at least one predicate or constraint must be provided"
-            raise TypeError(msg)
+            return self.clone()
 
         # if multiple predicates, combine as 'horizontal' expression
         combined_predicate = (
@@ -4469,9 +4468,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         if not constraints:
             # early-exit conditions (exclude/include all rows)
-            if not predicates or (len(predicates) == 1 and predicates[0] is True):
+            if not predicates or all(p is True for p in predicates):
                 return self.clone()
-            if len(predicates) == 1 and predicates[0] is False:
+            if all(p is False for p in predicates):
                 return self.clear()
 
         return self._filter(
@@ -4627,9 +4626,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         if not constraints:
             # early-exit conditions (exclude/include all rows)
-            if not predicates or (len(predicates) == 1 and predicates[0] is True):
+            if not predicates or all(p is True for p in predicates):
                 return self.clear()
-            if len(predicates) == 1 and predicates[0] is False:
+            if all(p is False for p in predicates):
                 return self.clone()
 
         return self._filter(


### PR DESCRIPTION
## What

`df.filter(True, True)` and `df.remove(False, False)` raise an unexpected `TypeError` while the single-scalar variants (`df.filter(True)`, `df.remove(False)`) work correctly. Closes #28943.

## Root cause

`_filter()` short-circuits each bool scalar via `continue` — correctly avoiding adding it to the filter expression — but then hits this guard:

```python
if not (all_predicates or boolean_masks):
    raise TypeError("at least one predicate or constraint must be provided")
```

When **every** supplied predicate is a bool scalar, all of them hit `continue` and `all_predicates` / `boolean_masks` are left empty, triggering the error even though the caller did supply predicates.

The public-api early-exit in `filter()` / `remove()` only caught the single-predicate case (`len(predicates) == 1`), so the multi-predicate all-bool case fell through to `_filter()`.

## Fix

Two layers:

1. **`filter()` / `remove()` early-exits** — generalise the checks from `len(predicates) == 1` to `all(p is True …)` / `all(p is False …)` across all predicates, so the correct result is returned before `_filter()` is reached.

2. **`_filter()` fallback** — the remaining guard is now effectively dead code for well-formed calls, but is changed from `raise TypeError` to `return self.clone()` for defensive correctness.

## Behaviour

| Call | Before | After |
|---|---|---|
| `df.filter()` | all rows | all rows |
| `df.filter(True)` | all rows | all rows |
| `df.filter(True, True)` | **TypeError** | all rows ✓ |
| `df.filter(False)` | 0 rows | 0 rows |
| `df.filter(False, False)` | 0 rows | 0 rows |
| `df.remove(False)` | all rows | all rows |
| `df.remove(False, False)` | **TypeError** | all rows ✓ |
| `df.remove(True)` | 0 rows | 0 rows |
| `df.filter(True, pl.col("a") > 1)` | filtered | filtered |

The last row shows that mixed bool+Expr predicates are unaffected.

Signed-off-by: Aftabbs <aftabbs.wwe@gmail.com>