### PR TITLE
fix(python): Remove POLARS_AUTO_STRUCTIFY env var backdoor

### DIFF
--- a/py-polars/src/polars/_utils/parse/expr.py
+++ b/py-polars/src/polars/_utils/parse/expr.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-import os
 from collections.abc import Collection, Iterable, Mapping
 from typing import TYPE_CHECKING, Any, Literal, overload
 
@@ -102,10 +101,9 @@ def parse_into_list_of_expressions(
     -------
     list of PyExpr
     """
-    structify = bool(int(os.environ.get("POLARS_AUTO_STRUCTIFY", 0)))
-    exprs = _parse_positional_inputs(inputs, structify=structify)  # type: ignore[arg-type]
+    exprs = _parse_positional_inputs(inputs)  # type: ignore[arg-type]
     if named_inputs:
-        named_exprs = _parse_named_inputs(named_inputs, structify=structify)
+        named_exprs = _parse_named_inputs(named_inputs)
         exprs.extend(named_exprs)
     return exprs
 
@@ -129,14 +127,12 @@ def parse_into_list_of_expressions_require_selectors(
     -------
     list of PyExpr
     """
-    structify = bool(int(os.environ.get("POLARS_AUTO_STRUCTIFY", 0)))
     exprs = _parse_positional_inputs(
         inputs,  # type: ignore[arg-type]
-        structify=structify,
         require_selectors=True,
     )
     if named_inputs:
-        named_exprs = _parse_named_inputs(named_inputs, structify=structify)
+        named_exprs = _parse_named_inputs(named_inputs)
         exprs.extend(named_exprs)
     return exprs
 

--- a/py-polars/tests/unit/meta/test_config.py
+++ b/py-polars/tests/unit/meta/test_config.py
@@ -1020,3 +1020,13 @@ def test_removed_set_auto_structify() -> None:
     msg = "`set_auto_structify` was removed in version 2.0"
     with pytest.raises(AttributeRemovedError, match=re.escape(msg)):
         pl.Config.set_auto_structify(True)  # type: ignore[attr-defined]
+
+
+def test_auto_structify_env_var_removed_28776(monkeypatch: pytest.MonkeyPatch) -> None:
+    # `POLARS_AUTO_STRUCTIFY` used to be the mechanism behind the now-removed
+    # `Config.set_auto_structify`. Setting it directly must no longer have any effect.
+    monkeypatch.setenv("POLARS_AUTO_STRUCTIFY", "1")
+    df = pl.DataFrame({"v": [1, 2, 3], "v2": [4, 5, 6]})
+    result = df.select(pl.all())
+
+    assert result.schema == pl.Schema({"v": pl.Int64, "v2": pl.Int64})


### PR DESCRIPTION
Closes #28776.

`Config.set_auto_structify` was removed in 2.0, but the `POLARS_AUTO_STRUCTIFY` env var it used to set under the hood was still read directly in `parse_into_list_of_expressions` / `parse_into_list_of_expressions_require_selectors`, so the behavior stayed reachable even after the public API was removed.

This drops that env var check so the feature is actually gone, and adds a test confirming the env var no longer has any effect.