### PR TITLE
fix(rust): Do not evaluate pushed parquet predicates over the slots behind nulls

### DIFF
--- a/crates/polars-lazy/src/tests/io.rs
+++ b/crates/polars-lazy/src/tests/io.rs
@@ -810,3 +810,119 @@ fn scan_small_dtypes() -> PolarsResult<()> {
     }
     Ok(())
 }
+
+/// A fallible predicate that is pushed into a parquet scan must not be evaluated over the
+/// physical slots that sit behind nulls. Those slots hold whatever the decoder left there,
+/// which for string views is the empty string, so a strict `strptime` failed on rows that do
+/// not exist in the file and took the whole scan down with a panic. See #28521.
+#[test]
+#[cfg(all(
+    feature = "parquet",
+    feature = "strings",
+    feature = "temporal",
+    feature = "dtype-datetime"
+))]
+fn test_fallible_predicate_pushdown_over_nulls_28521() -> PolarsResult<()> {
+    use std::sync::Arc;
+
+    use polars_buffer::Buffer;
+    use polars_config::Engine;
+    use polars_core::query_result::QueryResult;
+    use polars_plan::dsl::ScanSources;
+
+    fn collect(lf: LazyFrame, engine: Engine) -> PolarsResult<DataFrame> {
+        lf.collect_with_engine(engine).map(|r| match r {
+            QueryResult::Single(df) => df,
+            QueryResult::Multiple(_) => DataFrame::empty(),
+        })
+    }
+
+    fn write(values: &[Option<&str>]) -> PolarsResult<Arc<[Buffer<u8>]>> {
+        let mut df = df!["t" => values]?;
+        let mut buf = Cursor::new(Vec::new());
+        ParquetWriter::new(&mut buf).finish(&mut df)?;
+        Ok(Arc::from(vec![Buffer::from(buf.into_inner())]))
+    }
+
+    fn scan(sources: &Arc<[Buffer<u8>]>) -> PolarsResult<LazyFrame> {
+        LazyFrame::scan_parquet_sources(
+            ScanSources::Buffers(sources.clone()),
+            ScanArgsParquet {
+                hive_options: HiveOptions {
+                    enabled: Some(false),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+    }
+
+    let parsed = || {
+        col("t").str().strptime(
+            DataType::Datetime(TimeUnit::Microseconds, None),
+            StrptimeOptions {
+                format: Some("%Y-%m-%d".into()),
+                strict: true,
+                exact: true,
+                cache: true,
+            },
+            lit("raise"),
+        )
+    };
+
+    // The exact file from the report, and one where the nulls are interleaved with values so
+    // the null slots are not all at the end of the page.
+    let report = write(&[Some("2021-01-01"), None, None])?;
+    let interleaved = write(&[
+        Some("2021-01-01"),
+        None,
+        Some("2021-01-02"),
+        None,
+        None,
+        Some("2021-01-03"),
+    ])?;
+
+    for engine in [Engine::InMemory, Engine::Streaming] {
+        let out = collect(scan(&report)?.filter(parsed().is_not_null()), engine)?;
+        assert_eq!(
+            out.column("t")?.str()?.iter().collect::<Vec<_>>(),
+            vec![Some("2021-01-01")],
+            "{engine}"
+        );
+
+        for (name, predicate) in [
+            ("is_not_null", parsed().is_not_null()),
+            ("is_null", parsed().is_null()),
+        ] {
+            // The same query without predicate pushdown is the oracle. There the predicate
+            // runs on the materialized column, nulls and all.
+            let expected = collect(
+                scan(&interleaved)?
+                    .filter(predicate.clone())
+                    .with_predicate_pushdown(false),
+                engine,
+            )?;
+            let actual = collect(scan(&interleaved)?.filter(predicate), engine)?;
+            assert!(
+                actual.equals_missing(&expected),
+                "{engine} {name}: pushed-down result {actual:?} differs from {expected:?}"
+            );
+        }
+
+        let out = collect(scan(&interleaved)?.filter(parsed().is_not_null()), engine)?;
+        assert_eq!(
+            out.column("t")?.str()?.iter().collect::<Vec<_>>(),
+            vec![Some("2021-01-01"), Some("2021-01-02"), Some("2021-01-03")],
+            "{engine}"
+        );
+
+        let out = collect(scan(&interleaved)?.filter(parsed().is_null()), engine)?;
+        assert_eq!(
+            out.column("t")?.str()?.iter().collect::<Vec<_>>(),
+            vec![None, None, None],
+            "{engine}"
+        );
+    }
+
+    Ok(())
+}

--- a/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
@@ -6,6 +6,7 @@ use std::ops::Range;
 use std::sync::OnceLock;
 
 use arrow::array::{Array, IntoBoxedArray, Splitable};
+use arrow::bitmap::utils::SlicesIterator;
 use arrow::bitmap::{Bitmap, BitmapBuilder};
 use arrow::datatypes::ArrowDataType;
 use arrow::pushable::Pushable;
@@ -362,17 +363,57 @@ pub(super) trait Decoder: Sized {
         }
         .into_boxed();
 
-        let mask = if let Some(validity) = intermediate_array.validity() {
-            let ignore_validity_array = intermediate_array.with_validity(None);
-            let mask = predicate.predicate.evaluate(ignore_validity_array.as_ref());
+        let mask = match intermediate_array.validity() {
+            // No validity at all, every slot holds a value the writer actually wrote.
+            None => predicate.predicate.evaluate(intermediate_array.as_ref()),
 
-            if predicate.predicate.evaluate_null() {
-                arrow::bitmap::or_not(&mask, validity)
-            } else {
-                &mask & validity
-            }
-        } else {
-            predicate.predicate.evaluate(intermediate_array.as_ref())
+            // A validity bitmap that marks nothing as null. Dropping it is enough.
+            Some(validity) if validity.unset_bits() == 0 => {
+                let ignore_validity_array = intermediate_array.with_validity(None);
+                predicate.predicate.evaluate(ignore_validity_array.as_ref())
+            },
+
+            // Actual nulls, and a predicate that cannot fail on any input. Evaluating over
+            // the physical slots behind the nulls is wasted work but it is safe, so keep
+            // the cheap path and mask the answer afterwards.
+            Some(validity) if predicate.predicate.as_specialized().is_some() => {
+                let ignore_validity_array = intermediate_array.with_validity(None);
+                let mask = predicate.predicate.evaluate(ignore_validity_array.as_ref());
+
+                if predicate.predicate.evaluate_null() {
+                    arrow::bitmap::or_not(&mask, validity)
+                } else {
+                    &mask & validity
+                }
+            },
+
+            // Actual nulls and an arbitrary expression. The physical slots behind the nulls
+            // hold whatever the decoder left there, which for views is the empty string and
+            // for primitives is zero. Those are not values the user ever wrote, so they must
+            // not reach the predicate: a fallible expression such as a strict `strptime`
+            // raises on them and the error is unwrapped into a panic that takes the whole
+            // scan down. Evaluate over the valid values only and scatter the result back
+            // into place, filling the null slots with the answer `evaluate_null` gives.
+            Some(validity) => {
+                let null_matches = predicate.predicate.evaluate_null();
+
+                let valid_only = polars_compute::filter::filter_with_bitmap(
+                    intermediate_array.as_ref(),
+                    validity,
+                );
+                let valid_only = valid_only.with_validity(None);
+                let valid_mask = predicate.predicate.evaluate(valid_only.as_ref());
+
+                let mut mask = BitmapBuilder::with_capacity(intermediate_array.len());
+                let mut valid_offset = 0;
+                for (start, length) in SlicesIterator::new(validity) {
+                    mask.extend_constant(start - mask.len(), null_matches);
+                    mask.subslice_extend_from_bitmap(&valid_mask, valid_offset, length);
+                    valid_offset += length;
+                }
+                mask.extend_constant(intermediate_array.len() - mask.len(), null_matches);
+                mask.freeze()
+            },
         };
 
         let filtered =


### PR DESCRIPTION
Closes #28521.

A pushed-down parquet predicate runs over the slots hidden behind nulls. The decoder drops the validity bitmap, evaluates the predicate over every physical slot including ones that were never written, then repairs the mask afterwards. That is harmless for a comparison, which cannot fail. It is not harmless for an arbitrary expression. A strict str.strptime gets handed the empty strings sitting in those null slots, raises, and the error becomes a panic on an executor thread instead of a catchable InvalidOperationError.

The fix filters down to the valid values first, evaluates the predicate over only those, then scatters the results back and fills the null positions with evaluate_null. That keeps the same null semantics as before. Specialized comparisons keep the old fast path, so ordinary filters do not start paying for a copy. The test uses the file from the report plus a variant with nulls interleaved, and compares the pushed-down result against the same query with pushdown disabled, on both engines.

The second defect in that report is still open. evaluate_mut returns unit and has nowhere to put an error, so I left it out to keep this diff focused on the wrong-results bug.

Written with AI assistance using Claude Code. I reviewed and tested the change myself and I am responsible for it.
