### PR TITLE
fix: Prevent datetime overflow

### DIFF
--- a/crates/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/crates/polars-core/src/chunked_array/temporal/datetime.rs
@@ -98,13 +98,28 @@ impl DatetimeChunked {
         v: I,
         tu: TimeUnit,
     ) -> Self {
-        let func = match tu {
-            TimeUnit::Nanoseconds => datetime_to_timestamp_ns,
-            TimeUnit::Microseconds => datetime_to_timestamp_us,
-            TimeUnit::Milliseconds => datetime_to_timestamp_ms,
-        };
-        let vals = v.into_iter().map(func).collect::<Vec<_>>();
-        Int64Chunked::from_vec(name, vals).into_datetime(tu, None)
+        match tu {
+            TimeUnit::Nanoseconds => {
+                let vals = v
+                    .into_iter()
+                    .map(|ndt| ndt.and_utc().timestamp_nanos_opt());
+                Int64Chunked::from_iter_options(name, vals).into_datetime(tu, None)
+            },
+            TimeUnit::Microseconds => {
+                let vals = v
+                    .into_iter()
+                    .map(datetime_to_timestamp_us)
+                    .collect::<Vec<_>>();
+                Int64Chunked::from_vec(name, vals).into_datetime(tu, None)
+            },
+            TimeUnit::Milliseconds => {
+                let vals = v
+                    .into_iter()
+                    .map(datetime_to_timestamp_ms)
+                    .collect::<Vec<_>>();
+                Int64Chunked::from_vec(name, vals).into_datetime(tu, None)
+            },
+        }
     }
 
     pub fn from_naive_datetime_options<I: IntoIterator<Item = Option<NaiveDateTime>>>(
@@ -112,13 +127,26 @@ impl DatetimeChunked {
         v: I,
         tu: TimeUnit,
     ) -> Self {
-        let func = match tu {
-            TimeUnit::Nanoseconds => datetime_to_timestamp_ns,
-            TimeUnit::Microseconds => datetime_to_timestamp_us,
-            TimeUnit::Milliseconds => datetime_to_timestamp_ms,
-        };
-        let vals = v.into_iter().map(|opt_nd| opt_nd.map(func));
-        Int64Chunked::from_iter_options(name, vals).into_datetime(tu, None)
+        match tu {
+            TimeUnit::Nanoseconds => {
+                let vals = v
+                    .into_iter()
+                    .map(|opt_nd| opt_nd.and_then(|ndt| ndt.and_utc().timestamp_nanos_opt()));
+                Int64Chunked::from_iter_options(name, vals).into_datetime(tu, None)
+            },
+            TimeUnit::Microseconds => {
+                let vals = v
+                    .into_iter()
+                    .map(|opt_nd| opt_nd.map(datetime_to_timestamp_us));
+                Int64Chunked::from_iter_options(name, vals).into_datetime(tu, None)
+            },
+            TimeUnit::Milliseconds => {
+                let vals = v
+                    .into_iter()
+                    .map(|opt_nd| opt_nd.map(datetime_to_timestamp_ms));
+                Int64Chunked::from_iter_options(name, vals).into_datetime(tu, None)
+            },
+        }
     }
 
     /// Change the underlying [`TimeUnit`]. And update the data accordingly.
@@ -196,7 +224,7 @@ impl DatetimeChunked {
 
 #[cfg(test)]
 mod test {
-    use chrono::NaiveDateTime;
+    use chrono::{DateTime, NaiveDate, NaiveDateTime};
 
     use crate::prelude::*;
 
@@ -224,6 +252,52 @@ mod test {
                 1_356_048_000_000_000_000
             ],
             dt.physical().cont_slice().unwrap()
+        );
+    }
+
+    #[test]
+    fn from_datetime_nanosecond_boundaries() {
+        let datetimes = [
+            DateTime::from_timestamp_nanos(i64::MIN).naive_utc(),
+            DateTime::from_timestamp_nanos(i64::MAX).naive_utc(),
+        ];
+
+        let dt = DatetimeChunked::from_naive_datetime(
+            PlSmallStr::from_static("name"),
+            datetimes,
+            TimeUnit::Nanoseconds,
+        );
+
+        assert_eq!(dt.physical().cont_slice().unwrap(), &[i64::MIN, i64::MAX]);
+    }
+
+    #[test]
+    fn from_datetime_out_of_nanosecond_range() {
+        let valid = DateTime::from_timestamp_nanos(i64::MIN).naive_utc();
+        let out_of_range = NaiveDate::from_ymd_opt(1600, 1, 1)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap();
+        assert_eq!(out_of_range.and_utc().timestamp_nanos_opt(), None);
+
+        let dt = DatetimeChunked::from_naive_datetime(
+            PlSmallStr::from_static("name"),
+            [valid, out_of_range],
+            TimeUnit::Nanoseconds,
+        );
+        assert_eq!(
+            dt.physical().iter().collect::<Vec<_>>(),
+            [Some(i64::MIN), None]
+        );
+
+        let dt = DatetimeChunked::from_naive_datetime_options(
+            PlSmallStr::from_static("name"),
+            [Some(valid), Some(out_of_range), None],
+            TimeUnit::Nanoseconds,
+        );
+        assert_eq!(
+            dt.physical().iter().collect::<Vec<_>>(),
+            [Some(i64::MIN), None, None]
         );
     }
 }

--- a/crates/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/crates/polars-core/src/chunked_array/temporal/datetime.rs
@@ -100,9 +100,7 @@ impl DatetimeChunked {
     ) -> Self {
         match tu {
             TimeUnit::Nanoseconds => {
-                let vals = v
-                    .into_iter()
-                    .map(|ndt| ndt.and_utc().timestamp_nanos_opt());
+                let vals = v.into_iter().map(|ndt| ndt.and_utc().timestamp_nanos_opt());
                 Int64Chunked::from_iter_options(name, vals).into_datetime(tu, None)
             },
             TimeUnit::Microseconds => {

--- a/crates/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/crates/polars-core/src/chunked_array/temporal/datetime.rs
@@ -298,4 +298,33 @@ mod test {
             [Some(i64::MIN), None, None]
         );
     }
+
+    #[test]
+    fn from_datetime_non_nanosecond_units() {
+        let datetime = DateTime::from_timestamp(1, 234_567_890)
+            .unwrap()
+            .naive_utc();
+
+        for (time_unit, expected) in [
+            (TimeUnit::Microseconds, 1_234_567),
+            (TimeUnit::Milliseconds, 1_234),
+        ] {
+            let dt = DatetimeChunked::from_naive_datetime(
+                PlSmallStr::from_static("name"),
+                [datetime],
+                time_unit,
+            );
+            assert_eq!(dt.physical().get(0), Some(expected));
+
+            let dt = DatetimeChunked::from_naive_datetime_options(
+                PlSmallStr::from_static("name"),
+                [Some(datetime), None],
+                time_unit,
+            );
+            assert_eq!(
+                dt.physical().iter().collect::<Vec<_>>(),
+                [Some(expected), None]
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fix the panic in DatetimeChunked::from_naive_datetime when a nanosecond datetime is outside the range representable by i64.

The conversion now handles out-of-range datetime values without overflowing.

Fixes #28804