### PR TITLE
fix: Clarify GPU installation guidance

### DIFF
--- a/docs/source/user-guide/gpu-support.md
+++ b/docs/source/user-guide/gpu-support.md
@@ -37,6 +37,11 @@ pip install polars[gpu]
     pip install polars cudf-polars-cu13
     ```
 
+    `cudf-polars` supports a bounded range of Polars versions. If the Polars version is
+    not pinned, the package resolver may select an older compatible Polars release. Pin
+    the required Polars version when such fallback is unacceptable; incompatible
+    combinations will then fail dependency resolution.
+
 ### Usage
 
 Having built a query using the lazy API [as normal](lazy/index.md), GPU-enabled execution is

--- a/py-polars/src/polars/lazyframe/engine.py
+++ b/py-polars/src/polars/lazyframe/engine.py
@@ -931,12 +931,11 @@ class GPUEngine(_LocalEngine):
         cudf_polars = import_optional(
             "cudf_polars",
             err_prefix="GPU engine requested, but required package",
+            err_suffix="could not be imported",
             install_message=(
-                "Please install using the command "
-                "`pip install cudf-polars-cu12` "
-                "(CUDA 12 is required for RAPIDS cuDF v25.08 and later). "
-                "If your system has a CUDA 11 driver, install with "
-                "`pip install cudf-polars-cu11==25.06` "
+                "Please install the cuDF Polars distribution matching your CUDA "
+                "version. See the GPU support documentation for installation "
+                "instructions: https://docs.pola.rs/user-guide/gpu-support/."
             ),
         )
         return partial(cudf_polars.execute_with_cudf, config=self)

--- a/py-polars/tests/unit/lazyframe/test_engine_selection.py
+++ b/py-polars/tests/unit/lazyframe/test_engine_selection.py
@@ -49,11 +49,15 @@ def test_engine_selection_eager_quiet(df: pl.LazyFrame, engine: EngineType) -> N
 
 
 def test_engine_import_error_raises(df: pl.LazyFrame, engine: EngineType) -> None:
-    with pytest.raises(
-        ImportError,
-        match="GPU engine requested",
-    ):
+    with pytest.raises(ModuleNotFoundError) as exc_info:
         df.collect(engine=engine)
+
+    error = str(exc_info.value)
+    assert "GPU engine requested" in error
+    assert "'cudf_polars' could not be imported" in error
+    assert "cuDF Polars distribution matching your CUDA version" in error
+    assert "https://docs.pola.rs/user-guide/gpu-support/" in error
+    assert "CUDA 12 is required" not in error
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #28930

Before fix:

```text
'cudf_polars' not found.
Please install ... cudf-polars-cu12
(CUDA 12 is required ...)
```

After fix:
```text
'cudf_polars' could not be imported.
Please install the cuDF Polars distribution matching your CUDA version.
See the GPU support documentation ...
```