### PR TITLE
fix: Keep extension type schema consistent

### DIFF
--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -115,6 +115,8 @@ fn cast_impl_inner(
         Time => out.into_time(),
         #[cfg(feature = "dtype-decimal")]
         Decimal(precision, scale) => out.into_decimal(*precision, *scale)?,
+        #[cfg(feature = "dtype-extension")]
+        Extension(typ, _) => out.into_extension(typ.clone()),
         _ => out,
     };
 

--- a/py-polars/tests/unit/datatypes/test_extension.py
+++ b/py-polars/tests/unit/datatypes/test_extension.py
@@ -169,6 +169,16 @@ def test_extension_native_to_extension_cast_27193() -> None:
     assert_series_equal(casted, expected)
 
 
+def test_extension_cast_schema_28542() -> None:
+    dtype = PythonTestExtension(storage=pl.Int64)
+    lf = pl.LazyFrame({"a": [1, 2, 3]}).with_columns(pl.col("a").cast(dtype))
+
+    result = lf.collect()
+
+    assert result.collect_schema() == lf.collect_schema() == {"a": dtype}
+    assert result["a"].ext.storage().to_list() == [1, 2, 3]
+
+
 def test_extension_to_extension_raises_27519() -> None:
     AExtension = pl.Extension(name="a.ext", storage=pl.Int64)
     BExtension = pl.Extension(name="b.ext", storage=pl.Int64)


### PR DESCRIPTION
Fixes an inconsistency between collect_schema() and collect() when working with extension types.

Adds regression coverage for the behavior reported in the issue and keeps the schema produced by schema collection consistent with the collected result.

Fixes #28542