### PR TITLE
feat(python): Add strip_prefix and strip_suffix to expression names

### DIFF
--- a/py-polars/src/polars/expr/name.py
+++ b/py-polars/src/polars/expr/name.py
@@ -149,6 +149,48 @@ class ExprNameNameSpace:
         """
         return wrap_expr(self._pyexpr.name_prefix(prefix))
 
+    def strip_prefix(self, prefix: str) -> Expr:
+        """
+        Remove a prefix from the root column name of the expression.
+
+        .. engine-support:: in-memory, streaming, distributed, gpu
+
+        The prefix is removed exactly once if present. Names that do not start with
+        the prefix are unchanged.
+
+        Parameters
+        ----------
+        prefix
+            Prefix to remove from the root column name.
+
+        See Also
+        --------
+        prefix
+        strip_suffix
+        map
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "prefix_a": [1, 2, 3],
+        ...         "b": ["x", "y", "z"],
+        ...     }
+        ... )
+        >>> df.select(pl.all().name.strip_prefix("prefix_"))
+        shape: (3, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i64 ┆ str │
+        ╞═════╪═════╡
+        │ 1   ┆ x   │
+        │ 2   ┆ y   │
+        │ 3   ┆ z   │
+        └─────┴─────┘
+        """
+        return self.map(lambda name: name.removeprefix(prefix))
+
     def suffix(self, suffix: str) -> Expr:
         """
         Add a suffix to the root column name of the expression.
@@ -186,6 +228,48 @@ class ExprNameNameSpace:
         └─────┴─────┴───────────┴───────────┘
         """
         return wrap_expr(self._pyexpr.name_suffix(suffix))
+
+    def strip_suffix(self, suffix: str) -> Expr:
+        """
+        Remove a suffix from the root column name of the expression.
+
+        .. engine-support:: in-memory, streaming, distributed, gpu
+
+        The suffix is removed exactly once if present. Names that do not end with
+        the suffix are unchanged.
+
+        Parameters
+        ----------
+        suffix
+            Suffix to remove from the root column name.
+
+        See Also
+        --------
+        suffix
+        strip_prefix
+        map
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a_suffix": [1, 2, 3],
+        ...         "b": ["x", "y", "z"],
+        ...     }
+        ... )
+        >>> df.select(pl.all().name.strip_suffix("_suffix"))
+        shape: (3, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i64 ┆ str │
+        ╞═════╪═════╡
+        │ 1   ┆ x   │
+        │ 2   ┆ y   │
+        │ 3   ┆ z   │
+        └─────┴─────┘
+        """
+        return self.map(lambda name: name.removesuffix(suffix))
 
     def to_lowercase(self) -> Expr:
         """

--- a/py-polars/tests/unit/operations/namespaces/test_name.py
+++ b/py-polars/tests/unit/operations/namespaces/test_name.py
@@ -47,6 +47,29 @@ def test_name_prefix_suffix() -> None:
     )
 
 
+def test_name_strip_prefix_suffix() -> None:
+    df = pl.DataFrame(
+        schema={
+            "prefix_prefix_a_suffix_suffix": pl.Int32,
+            "b": pl.String,
+        },
+    )
+
+    assert df.select(
+        pl.all().name.strip_prefix("prefix_").name.strip_suffix("_suffix"),
+    ).schema == {
+        "prefix_a_suffix": pl.Int32,
+        "b": pl.String,
+    }
+
+    assert (
+        df.select(
+            pl.all().name.strip_prefix("").name.strip_suffix(""),
+        ).schema
+        == df.schema
+    )
+
+
 def test_name_replace() -> None:
     df = pl.DataFrame(
         schema={"n_foo": pl.Int32, "n_bar": pl.String, "misc?": pl.Float64},


### PR DESCRIPTION
Closes #28201

## Summary
- add `Expr.name.strip_prefix` and `Expr.name.strip_suffix`
- remove one exact matching affix while leaving non-matching names unchanged
- document both methods and cover chained and empty-affix behavior

## Testing
- expression-name namespace tests: 8 passed
- Ruff check and formatting: passed
- Python compile validation: passed
