### PR TITLE
fix: Revisit nested CSPE caches after predicate removal

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/cse/cache_states.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/cache_states.rs
@@ -308,6 +308,7 @@ pub(crate) fn set_cache_states(
     if !cache_schema_and_children.is_empty() {
         let mut pred_pd =
             PredicatePushDown::new(pushdown_maintain_errors, streaming, partition_hive);
+        let mut removed_predicate_caches = false;
         // rev() the iter to visit/optimize the caches below the current cache before the current cache,
         // otherwise we get `IR::Invalid` as predicate pd `take()`s from the IR arena.
         for (cache_id, v) in cache_schema_and_children.into_iter().rev() {
@@ -382,6 +383,7 @@ pub(crate) fn set_cache_states(
                     for (node, lp) in replacements {
                         lp_arena.replace(node, lp);
                     }
+                    removed_predicate_caches = true;
                     continue;
                 }
 
@@ -460,6 +462,19 @@ pub(crate) fn set_cache_states(
                     lp_arena.replace(child, lp.clone());
                 }
             }
+        }
+
+        if removed_predicate_caches {
+            set_cache_states(
+                root,
+                lp_arena,
+                expr_arena,
+                scratch,
+                verbose,
+                pushdown_maintain_errors,
+                streaming,
+                partition_hive,
+            )?;
         }
     }
     Ok(())

--- a/py-polars/tests/unit/lazyframe/test_cse.py
+++ b/py-polars/tests/unit/lazyframe/test_cse.py
@@ -1717,7 +1717,11 @@ def test_cspe_cache_removal_keeps_nested_caches(
     )
 
 
-def test_cspe_nested_cache_does_not_block_pushable_filters() -> None:
+def test_cspe_nested_cache_does_not_block_pushable_filters(
+    plmonkeypatch: PlMonkeyPatch,
+) -> None:
+    plmonkeypatch.setenv("POLARS_ALLOW_NESTED_CSPE", "1")
+
     buffer = io.BytesIO()
     pl.DataFrame({"a": range(100), "b": range(100)}).write_parquet(buffer)
 


### PR DESCRIPTION
Closed for now while completing first-time contributor requirements. Do not review yet.

Closes #28860

Current fixed fork branch: agarwalrahul2702:fix-nested-cspe-predicate-pushdown-28860
Current fixed branch commit: 11b5f69039b888676f704a1ed7bb4d22565f59cd

When POLARS_ALLOW_NESTED_CSPE=1, cache-state analysis can remove an outer cache because the predicates above it differ and are pushable. In the nested-CSPE case that exposes inner cache nodes under the newly distributed filters, but the previous single cache-state pass never revisited those inner caches. The result was still a plan with filters above a shared cache instead of scan-level selections.

This reruns cache-state analysis only when predicate-blocking cache nodes were actually removed, allowing newly exposed nested caches to make their own keep/remove decision. Existing guards for non-pushable and mixed predicates still keep nested caches shared.

AI assistance disclosure: this change was prepared with Codex assistance. The generated code was checked against the failing repro, the final diff, and the local test results below. Rahul should personally review the final diff before maintainer review to satisfy the Polars AI-assisted contribution policy.

Local verification on the updated branch:

- Reproduced #28860 on latest main before the fix with POLARS_ALLOW_NESTED_CSPE=1: plan had filters above one shared cache and zero scan selections.
- Verified after the fix: plan has two SELECTION: col("a") > 90 and two SELECTION: col("a") < 5 entries at Parquet scans.
- make build-mindebug
- cargo fmt --check
- python -m ruff format --check py-polars/tests/unit/lazyframe/test_cse.py
- POLARS_ALLOW_NESTED_CSPE=1 Python repro script: passed
- pytest py-polars/tests/unit/lazyframe/test_cse.py::test_cspe_nested_cache_does_not_block_pushable_filters -q: passed
- Related CSPE Python regression block: 10 passed
- pytest py-polars/tests/unit/lazyframe/test_cse.py -q: 79 passed, 4 skipped, 4 deselected
- cargo test -p polars-lazy --features cse,strings,temporal,ipc,csv --lib test_cspe_revisits_nested_caches_after_predicate_cache_removal: 1 passed

First-time contributor requirement still pending: Polars asks for a screenshot showing make test succeeded with terminal borders visible.
