### PR TITLE
fix: Reduce memory in multi_scan pipeline `PostApplyExtraOps`

### DIFF
--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/initialization.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/initialization.rs
@@ -446,6 +446,7 @@ async fn finish_initialize_multi_scan_pipeline(
                 missing_columns_policy,
                 forbid_extra_columns: config.forbid_extra_columns.clone(),
                 num_pipelines,
+                max_concurrent_scans,
                 disable_morsel_split,
                 last_morsel_pipelines,
                 verbose,

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/models.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/models.rs
@@ -84,6 +84,7 @@ pub(super) struct StartReaderArgsConstant {
     pub(super) missing_columns_policy: MissingColumnsPolicy,
     pub(super) forbid_extra_columns: Option<ForbidExtraColumns>,
     pub(super) num_pipelines: usize,
+    pub(super) max_concurrent_scans: usize,
     pub(super) disable_morsel_split: bool,
     /// Precomputed last-morsel split factor; see `BeginReadArgs::last_morsel_pipelines`.
     pub(super) last_morsel_pipelines: usize,

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/tasks/post_apply_extra_ops.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/tasks/post_apply_extra_ops.rs
@@ -19,6 +19,7 @@ pub struct PostApplyExtraOps {
     pub first_morsel: Morsel,
     pub first_morsel_position: RowCounter,
     pub num_pipelines: usize,
+    pub max_concurrent_scans: usize,
 }
 
 impl PostApplyExtraOps {
@@ -29,13 +30,16 @@ impl PostApplyExtraOps {
             first_morsel,
             first_morsel_position,
             num_pipelines,
+            max_concurrent_scans,
         } = self;
 
         let verbose = polars_core::config::verbose();
         let rows_before = Arc::new(RelaxedCell::new_u64(0));
         let rows_after = Arc::new(RelaxedCell::new_u64(0));
 
-        let (mut distr_tx, distr_receivers) = distributor_channel(num_pipelines, 1);
+        // Avoid O(n^2) memory for concurrent scans, with n being the number of threads.
+        let stage_pipelines = num_pipelines.div_ceil(max_concurrent_scans).max(1);
+        let (mut distr_tx, distr_receivers) = distributor_channel(stage_pipelines, 1);
 
         // Distributor
         {

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/tasks/reader_starter.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/pipeline/tasks/reader_starter.rs
@@ -419,6 +419,7 @@ async fn start_reader_impl(
         missing_columns_policy,
         forbid_extra_columns,
         num_pipelines,
+        max_concurrent_scans,
         disable_morsel_split,
         last_morsel_pipelines,
         verbose,
@@ -694,6 +695,7 @@ async fn start_reader_impl(
                 first_morsel,
                 first_morsel_position,
                 num_pipelines,
+                max_concurrent_scans,
             }
             .run();
 


### PR DESCRIPTION
fixes #28912 

This PR reduces the pipeline `distributor` fan-out in case of concurrent scans, thus avoiding `O(n^2)` memory with `n` being the number of threads.

before/after (hot cache, TPC-H SF=100, simple aggregation on 4 out-of-order columns):
```
$  SF=100 EXPR=1 /usr/bin/time -v python multi.py 2>&1 | grep -e Max -e wall
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:19.36
        Maximum resident set size (kbytes): 26368216
$  SF=100 EXPR=1 /usr/bin/time -v ~/polars/.venv/bin/python multi.py 2>&1 | grep -e Max -e wall
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:08.09
        Maximum resident set size (kbytes): 3235520
```

Note, the given MRE is a permutation, and could be mitigated in a different manner, i.e. by in-lining the column remapping. But that would be too narrow for all use cases. It is still worth pursuing.

ping @nameexhaustion 
