### PR TITLE
chore: Log pytest worker crashes and disable restarting

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -283,6 +283,9 @@ addopts = [
   "--strict-markers",
   "--import-mode=importlib",
   "--dist=loadgroup",
+  # A hard worker crash (e.g. a segfault) hangs under `--dist=loadgroup` when
+  # xdist tries to restart the worker and re-run the crashed group.
+  "--max-worker-restart=0",
   # Default to running fast tests only. To run ALL tests, run: pytest -m ""
   "-m not slow and not write_disk and not release and not docs and not hypothesis and not benchmark and not ci_only",
 ]

--- a/py-polars/tests/conftest.py
+++ b/py-polars/tests/conftest.py
@@ -47,7 +47,7 @@ def pytest_handlecrashitem(
 
         # Suspend pytest's output capturing so the message reaches the real
         # streams instead of being buffered (and possibly lost) on crash.
-        capman = None
+        capman: Any = None
         if _xdist_crash_config is not None:
             capman = _xdist_crash_config.pluginmanager.getplugin("capturemanager")
         if capman is not None:

--- a/py-polars/tests/conftest.py
+++ b/py-polars/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import sys
 from pathlib import PosixPath
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
@@ -19,6 +20,44 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=False,
         help="Run all queries by default of the distributed engine",
     )
+
+
+_xdist_crash_config: pytest.Config | None = None
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    # Stash the config so `pytest_handlecrashitem` (whose hookspec only receives
+    # crashitem/report/sched) can reach the capture manager to bypass capturing.
+    global _xdist_crash_config
+    _xdist_crash_config = config
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_handlecrashitem(
+    crashitem: str, report: pytest.TestReport, sched: object
+) -> None:
+    """Log which test an xdist worker was running when it crashed."""
+    try:
+        worker = getattr(report, "node", None)
+        worker_id = getattr(getattr(worker, "gateway", None), "id", "?")
+        line = f"xdist worker {worker_id} crashed while running {crashitem}"
+
+        def emit() -> None:
+            print(f"ERROR: {line}", file=sys.stderr, flush=True)
+
+        # Suspend pytest's output capturing so the message reaches the real
+        # streams instead of being buffered (and possibly lost) on crash.
+        capman = None
+        if _xdist_crash_config is not None:
+            capman = _xdist_crash_config.pluginmanager.getplugin("capturemanager")
+        if capman is not None:
+            with capman.global_and_fixture_disabled():
+                emit()
+        else:
+            emit()
+    except Exception as exc:
+        # Never let logging failures mask the underlying crash.
+        print(f"pytest_handlecrashitem logging failed: {exc!r}", file=sys.stderr)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
The main purpose of this PR is to improve our CI logs by printing *what* test a worker was running when it crashed.

After testing it locally I also noticed that worker restarting is bugged in pytest-xdist and can hang the entire thing, so I've disabled that.

I expect this will be annoying for a while until we iron out the bugs/crashes, but this should be better long-term.