### PR TITLE
fix: Prevent panic in `offset_by` when target date is out-of-range

### DIFF
--- a/crates/polars-time/src/windows/duration.rs
+++ b/crates/polars-time/src/windows/duration.rs
@@ -19,7 +19,7 @@ use polars_core::prelude::{
     Ambiguous, NonExistent, PolarsResult, TimeZone, datetime_to_timestamp_ms,
     datetime_to_timestamp_ns, datetime_to_timestamp_us, polars_bail,
 };
-use polars_error::polars_ensure;
+use polars_error::{polars_ensure, polars_err};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -549,7 +549,7 @@ impl Duration {
     }
 
     #[doc(hidden)]
-    fn add_month(ts: NaiveDateTime, n_months: i64, negative: bool) -> NaiveDateTime {
+    fn add_month(ts: NaiveDateTime, n_months: i64, negative: bool) -> PolarsResult<NaiveDateTime> {
         let mut months = n_months;
         if negative {
             months = -months;
@@ -557,10 +557,10 @@ impl Duration {
 
         // Retrieve the current date and increment the values
         // based on the number of months
-        let mut year = ts.year();
         let mut month = ts.month() as i32;
         let mut day = ts.day();
-        year += (months / 12) as i32;
+        let year_i64 = ts.year() as i64 + (months / 12);
+        let mut year = i32::try_from(year_i64).map_err(|_| polars_err!(ComputeError: "cannot advance '{}' by {} months: target year {} is out of the supported range", ts, months, year_i64))?;
         month += (months % 12) as i32;
 
         // if the month overflowed or underflowed, adjust the year
@@ -588,8 +588,8 @@ impl Duration {
         let minute = ts.minute();
         let sec = ts.second();
         let nsec = ts.nanosecond();
-        new_datetime(year, month as u32, day, hour, minute, sec, nsec).expect(
-            "Expected valid datetime, please open an issue at https://github.com/pola-rs/polars/issues"
+        new_datetime(year, month as u32, day, hour, minute, sec, nsec).ok_or_else(
+            || polars_err!(ComputeError: "cannot advance '{}' by {} months: date {:04}-{:02}-{:02} is out of the supported range", ts, months, year, month, day)
         )
     }
 
@@ -951,7 +951,7 @@ impl Duration {
                     let result_dt_local = Self::add_month(original_dt_local, d.months, d.negative);
                     datetime_to_timestamp(self.localize_result_rfc_5545(
                         original_dt_utc,
-                        result_dt_local,
+                        result_dt_local?,
                         tz,
                     )?)
                 },
@@ -959,7 +959,7 @@ impl Duration {
                     timestamp_to_datetime(t),
                     d.months,
                     d.negative,
-                )),
+                )?),
             };
         }
 

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -1571,3 +1571,40 @@ def test_dt_extract_present_out_of_range_27862(method: str, tz: str | None) -> N
     assert s.null_count() == 0  # the value is present, not masked
     out = getattr(s.dt, method)()
     assert out[0] is None
+
+
+def test_offset_by_out_of_range_no_panic_29017() -> None:
+    df = pl.DataFrame({"d": [date(2023, 1, 1)]})
+    s = pl.Series("d", [date(2023, 1, 1)])
+
+    with pytest.raises(ComputeError, match="is out of the supported range"):
+        df.with_columns(pl.col("d").dt.offset_by("260120y"))
+
+    with pytest.raises(ComputeError, match="is out of the supported range"):
+        s.dt.offset_by("260120y")
+
+    with pytest.raises(ComputeError, match="is out of the supported range"):
+        s.dt.offset_by("-300000y")
+
+    with pytest.raises(ComputeError, match="is out of the supported range"):
+        s.dt.offset_by("2147483647mo")
+
+    # months large enough that months / 12 overflows i32
+    with pytest.raises(ComputeError, match="is out of the supported range"):
+        s.dt.offset_by("99999999999999999mo")
+
+
+def test_offset_by_boundary_value_succeeds_df_29017() -> None:
+    df = pl.DataFrame({"d": [date(2023, 1, 1)]})
+    result = df.with_columns(pl.col("d").dt.offset_by("260119y"))
+    assert result["d"].dt.year().item() == 262142
+    assert result["d"].dt.month().item() == 1
+    assert result["d"].dt.day().item() == 1
+
+
+def test_offset_by_boundary_value_succeeds_series_29017() -> None:
+    s = pl.Series("d", [date(2023, 1, 1)])
+    result = s.dt.offset_by("260119y")
+    assert result.dt.year().item() == 262142
+    assert result.dt.month().item() == 1
+    assert result.dt.day().item() == 1


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/29017.

🤖 Claude Fable for finding an unrelated bug and helping with tests.
