### PR TITLE
feat(python): Expose Iceberg sink writer options

### DIFF
--- a/crates/polars-plan/dsl-schema-hashes.json
+++ b/crates/polars-plan/dsl-schema-hashes.json
@@ -86,7 +86,7 @@
   "IcebergPathProviderLayout": "d07323bbe3862bc709822f453a904a2cf33f3273624f8a157aa89bffe7870440",
   "IcebergSchema": "d254f883b2a9ebc2c0c4f2d32f40fcc951ef0e0d79d905bcec298dfcb8561e78",
   "IcebergSchemaMode": "228cf0532593a1e06dd78fdda1b6dc527200b7f0381ac2ad983b8867dcb587e7",
-  "IcebergSinkState": "162dd0ede4d1eb1c7130ef23c7fa21bfe581dd1eebdcff79e01d8abced7b0f5d",
+  "IcebergSinkState": "766e232226d4564a89c3c243af93a9cbcd4e171b1bd2886b1969c9400a729a39",
   "IntDataTypeExpr": "cd66dcd9c44cdddd8864c0fe642e5fcef5263f6f142cce906011a0180e0fd161",
   "IntegerType": "2e73fb811a2830b8b114dfe914512bfa6031325da9ea5513875a6e49b6ab1a58",
   "InterpolationMethod": "157b72c21c66950baafe8033836c3335571d2f227dd882ba6b9c8d3e2f5928d3",

--- a/crates/polars-plan/src/dsl/options/iceberg_sink_state.rs
+++ b/crates/polars-plan/src/dsl/options/iceberg_sink_state.rs
@@ -23,6 +23,10 @@ pub struct IcebergSinkState {
     pub schema_mode: Option<IcebergSchemaMode>,
     pub snapshot_properties: BTreeMap<PlSmallStr, PlSmallStr>,
     pub iceberg_storage_properties: BTreeMap<PlSmallStr, PlSmallStr>,
+    pub compression: PlSmallStr,
+    pub compression_level: Option<i32>,
+    pub row_group_size: Option<usize>,
+    pub maintain_order: bool,
 
     pub sink_uuid_str: String,
 

--- a/py-polars/src/polars/io/iceberg/_sink.py
+++ b/py-polars/src/polars/io/iceberg/_sink.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
 
     import polars as pl
     from polars._plr import PyLazyFrame
-    from polars._typing import StorageOptionsDict
+    from polars._typing import ParquetCompression, StorageOptionsDict
 
 
 def _nested_partition_source_ids(schema: Schema, spec: PartitionSpec) -> set[int]:
@@ -355,6 +355,10 @@ class IcebergSinkState:
     schema_mode: Literal["merge", "overwrite"] | None
     snapshot_properties: dict[str, str]
     iceberg_storage_properties: StorageOptionsDict
+    compression: ParquetCompression
+    compression_level: int | None
+    row_group_size: int | None
+    maintain_order: bool
 
     sink_uuid_str: str
 
@@ -371,6 +375,10 @@ class IcebergSinkState:
         snapshot_properties: dict[str, str] | None = None,
         catalog: pyiceberg.catalog.Catalog | IcebergCatalogConfig | None = None,
         storage_options: StorageOptionsDict | None = None,
+        compression: ParquetCompression = "zstd",
+        compression_level: int | None = None,
+        row_group_size: int | None = None,
+        maintain_order: bool = True,
     ) -> IcebergSinkState:
         if schema_mode == "overwrite" and mode != "overwrite":
             msg = "schema_mode='overwrite' requires mode='overwrite'"
@@ -412,6 +420,10 @@ class IcebergSinkState:
             schema_mode=schema_mode,
             snapshot_properties=snapshot_properties or {},
             iceberg_storage_properties=storage_options or {},
+            compression=compression,
+            compression_level=compression_level,
+            row_group_size=row_group_size,
+            maintain_order=maintain_order,
             sink_uuid_str=gen_uuid_v7().hex(),
             table_=NoPickleOption(target if not isinstance(target, str) else None),
             source_schema=None,
@@ -550,6 +562,10 @@ class IcebergSinkState:
                     approximate_bytes_per_file=approximate_bytes_per_file,
                 ),
                 arrow_schema=arrow_schema,
+                compression=self.compression,
+                compression_level=self.compression_level,
+                row_group_size=self.row_group_size,
+                maintain_order=self.maintain_order,
                 storage_options=self._get_converted_storage_options(),
                 lazy=True,
             )

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -2958,6 +2958,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         | polars.io.iceberg.IcebergCatalogConfig
         | None = None,
         storage_options: StorageOptionsDict | None = None,
+        compression: ParquetCompression = "zstd",
+        compression_level: int | None = None,
+        row_group_size: int | None = None,
+        maintain_order: bool = True,
         engine: EngineType = "auto",
     ) -> pl.DataFrame:
         """
@@ -2998,6 +3002,16 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             For cloud storages, this may include configurations for authentication etc.
 
             More info is available `here <https://py.iceberg.apache.org/configuration/>`__.
+        compression
+            Parquet compression codec.
+        compression_level
+            Compression level to use. Higher compression levels usually reduce file
+            size at the expense of write throughput.
+        row_group_size
+            Row group size in number of rows.
+        maintain_order
+            Maintain the input row order in the written files. Setting this to
+            `False` can improve throughput.
         engine
             Engine used to produce rows for the local `pyiceberg` writer.
 
@@ -3029,6 +3043,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             snapshot_properties=snapshot_properties,
             catalog=catalog,
             storage_options=storage_options,
+            compression=compression,
+            compression_level=compression_level,
+            row_group_size=row_group_size,
+            maintain_order=maintain_order,
         )
 
         sink_state.attach_sink(self).collect(engine=engine)

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -558,6 +558,33 @@ def test_sink_iceberg_all_types(tmp_path: Path) -> None:
     )
 
 
+@pytest.mark.write_disk
+def test_sink_iceberg_parquet_writer_options(tmp_path: Path) -> None:
+    tbl, _ = new_iceberg_table(
+        tmp_path, schema=IcebergSchema(NestedField(1, "a", LongType()))
+    )
+
+    pl.LazyFrame({"a": [1, 2, 3, 4, 5]}).sink_iceberg(
+        tbl,
+        mode="append",
+        compression="gzip",
+        compression_level=1,
+        row_group_size=2,
+        maintain_order=False,
+    )
+
+    [task] = tbl.scan().plan_files()
+    with tbl.io.new_input(task.file.file_path).open() as input_file:
+        metadata = pq.read_metadata(input_file)
+
+    assert metadata.num_row_groups == 3
+    assert metadata.row_group(0).column(0).compression == "GZIP"
+    assert_frame_equal(
+        pl.scan_iceberg(tbl).collect().sort("a"),
+        pl.DataFrame({"a": [1, 2, 3, 4, 5]}),
+    )
+
+
 @pytest.mark.parametrize(
     ("iceberg_type", "transform", "values"),
     [


### PR DESCRIPTION
Closes #29067

## Summary

Expose the native Parquet writer controls already used by `sink_parquet` on `LazyFrame.sink_iceberg`:

- `compression`
- `compression_level`
- `row_group_size`
- `maintain_order`

The defaults preserve the current Iceberg sink behavior. This lets callers trade compression ratio, CPU cost, row-group granularity, ordering, and write throughput without bypassing the native sink.


## Tests

- writes an Iceberg data file with Gzip level 1, two-row row groups, and unordered execution
- verifies the committed file codec, row-group count, and scan result
- all-types Iceberg sink regression test
- Rust/Python build, Rust formatting, Ruff, and DSL schema hashes


Written by GPT-Sol-5.6, human reviewed.
