### PR TITLE
feat(rust,python): Add 'median' strategy to fill_null

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/fill_null.rs
+++ b/crates/polars-core/src/chunked_array/ops/fill_null.rs
@@ -15,6 +15,7 @@ impl Series {
     /// * Forward fill (replace None with the previous value)
     /// * Backward fill (replace None with the next value)
     /// * Mean fill (replace None with the mean of the whole array)
+    /// * Median fill (replace None with the median of the whole array)
     /// * Min fill (replace None with the minimum of the whole array)
     /// * Max fill (replace None with the maximum of the whole array)
     /// * Zero fill (replace None with the value zero)
@@ -45,6 +46,9 @@ impl Series {
     ///     let filled = s.fill_null(FillNullStrategy::Mean)?;
     ///     assert_eq!(Vec::from(filled.i32()?), &[Some(1), Some(1), Some(2)]);
     ///
+    ///     let filled = s.fill_null(FillNullStrategy::Median)?;
+    ///     assert_eq!(Vec::from(filled.i32()?), &[Some(1), Some(1), Some(2)]);
+    ///
     ///     let filled = s.fill_null(FillNullStrategy::Zero)?;
     ///     assert_eq!(Vec::from(filled.i32()?), &[Some(1), Some(0), Some(2)]);
     ///
@@ -67,6 +71,7 @@ impl Series {
                         | FillNullStrategy::Max
                         | FillNullStrategy::Min
                         | FillNullStrategy::Mean
+                        | FillNullStrategy::Median
                 ))
         {
             return Ok(self.clone());
@@ -233,6 +238,13 @@ where
                 .map(|v| NumCast::from(v).unwrap())
                 .ok_or_else(err_fill_null)?,
         )?,
+        FillNullStrategy::Median => ca.fill_null_with_values(
+            ca.clone()
+                .into_series()
+                .median()
+                .map(|v| NumCast::from(v).unwrap())
+                .ok_or_else(err_fill_null)?,
+        )?,
         FillNullStrategy::One => return ca.fill_null_with_values(One::one()),
         FillNullStrategy::Zero => return ca.fill_null_with_values(Zero::zero()),
         FillNullStrategy::Forward(None) => fill_forward_numeric(ca),
@@ -382,6 +394,7 @@ fn fill_null_bool(ca: &BooleanChunked, strategy: FillNullStrategy) -> PolarsResu
             .fill_null_with_values(ca.max().ok_or_else(err_fill_null)?)
             .map(|ca| ca.into_series()),
         FillNullStrategy::Mean => polars_bail!(opq = mean, "Boolean"),
+        FillNullStrategy::Median => polars_bail!(opq = median, "Boolean"),
         FillNullStrategy::One => ca.fill_null_with_values(true).map(|ca| ca.into_series()),
         FillNullStrategy::Zero => ca.fill_null_with_values(false).map(|ca| ca.into_series()),
         FillNullStrategy::Forward(_) => unreachable!(),

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -438,6 +438,8 @@ pub enum FillNullStrategy {
     Forward(FillNullLimit),
     /// mean value of array
     Mean,
+    /// median value of array
+    Median,
     /// minimal value in array
     Min,
     /// maximum value in array

--- a/crates/polars-python/src/conversion/mod.rs
+++ b/crates/polars-python/src/conversion/mod.rs
@@ -1620,11 +1620,12 @@ pub(crate) fn parse_fill_null_strategy(
         "min" => FillNullStrategy::Min,
         "max" => FillNullStrategy::Max,
         "mean" => FillNullStrategy::Mean,
+        "median" => FillNullStrategy::Median,
         "zero" => FillNullStrategy::Zero,
         "one" => FillNullStrategy::One,
         e => {
             return Err(PyValueError::new_err(format!(
-                "`strategy` must be one of {{'forward', 'backward', 'min', 'max', 'mean', 'zero', 'one'}}, got {e}",
+                "`strategy` must be one of {{'forward', 'backward', 'min', 'max', 'mean', 'median', 'zero', 'one'}}, got {e}",
             )));
         },
     };

--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -2091,6 +2091,7 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<Py<PyAny>> {
                         FillNullStrategy::Min => ("min", py.None()),
                         FillNullStrategy::Max => ("max", py.None()),
                         FillNullStrategy::Mean => ("mean", py.None()),
+                        FillNullStrategy::Median => ("median", py.None()),
                         FillNullStrategy::Zero => ("zero", py.None()),
                         FillNullStrategy::One => ("one", py.None()),
                     };

--- a/crates/polars/tests/it/core/series.rs
+++ b/crates/polars/tests/it/core/series.rs
@@ -53,7 +53,10 @@ fn test_fill_null_median() -> PolarsResult<()> {
 
 #[test]
 fn test_fill_null_median_even_count() -> PolarsResult<()> {
-    let s = Series::new("a".into(), &[Some(1.0), None, Some(2.0), None, Some(4.0), Some(10.0)]);
+    let s = Series::new(
+        "a".into(),
+        &[Some(1.0), None, Some(2.0), None, Some(4.0), Some(10.0)],
+    );
     let filled = s.fill_null(FillNullStrategy::Median)?;
     let expected = Series::new("a".into(), &[1.0, 3.0, 2.0, 3.0, 4.0, 10.0]);
     assert_eq!(filled, expected);

--- a/crates/polars/tests/it/core/series.rs
+++ b/crates/polars/tests/it/core/series.rs
@@ -41,3 +41,38 @@ fn test_construct_list_of_null_series() {
     assert_eq!(s.null_count(), 0);
     assert_eq!(s.field().name(), "a");
 }
+
+#[test]
+fn test_fill_null_median() -> PolarsResult<()> {
+    let s = Series::new("a".into(), &[Some(1.0), None, Some(3.0), None, Some(5.0)]);
+    let filled = s.fill_null(FillNullStrategy::Median)?;
+    let expected = Series::new("a".into(), &[1.0, 3.0, 3.0, 3.0, 5.0]);
+    assert_eq!(filled, expected);
+    Ok(())
+}
+
+#[test]
+fn test_fill_null_median_even_count() -> PolarsResult<()> {
+    let s = Series::new("a".into(), &[Some(1.0), None, Some(2.0), None, Some(4.0), Some(10.0)]);
+    let filled = s.fill_null(FillNullStrategy::Median)?;
+    let expected = Series::new("a".into(), &[1.0, 3.0, 2.0, 3.0, 4.0, 10.0]);
+    assert_eq!(filled, expected);
+    Ok(())
+}
+
+#[test]
+fn test_fill_null_median_integer() -> PolarsResult<()> {
+    let s = Series::new("a".into(), &[Some(1), None, Some(2), None, Some(10)]);
+    let filled = s.fill_null(FillNullStrategy::Median)?;
+    let expected = Series::new("a".into(), &[Some(1), Some(2), Some(2), Some(2), Some(10)]);
+    assert_eq!(filled, expected);
+    Ok(())
+}
+
+#[test]
+fn test_fill_null_median_all_null() -> PolarsResult<()> {
+    let s = Series::new("a".into(), &[None::<f64>, None, None]);
+    let filled = s.fill_null(FillNullStrategy::Median)?;
+    assert_eq!(filled.null_count(), 3);
+    Ok(())
+}

--- a/py-polars/src/polars/_typing.py
+++ b/py-polars/src/polars/_typing.py
@@ -216,7 +216,7 @@ DeletionFiles: TypeAlias = (
     | tuple[Literal["delta-deletion-vector"], Callable[["DataFrame"], "DataFrame"]]
 )
 FillNullStrategy: TypeAlias = Literal[
-    "forward", "backward", "min", "max", "mean", "zero", "one"
+    "forward", "backward", "min", "max", "mean", "median", "zero", "one"
 ]
 FloatFmt: TypeAlias = Literal["full", "mixed"]
 IndexOrder: TypeAlias = Literal["c", "fortran"]

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -9344,7 +9344,8 @@ class DataFrame:
         ----------
         value
             Value used to fill null values.
-        strategy : {None, 'forward', 'backward', 'min', 'max', 'mean', 'median', 'zero', 'one'}
+        strategy : {None, 'forward', 'backward', 'min', 'max', 'mean',
+                    'median', 'zero', 'one'}
             Strategy used to fill null values.
         limit
             Number of consecutive null values to fill when using the 'forward' or

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -9344,7 +9344,7 @@ class DataFrame:
         ----------
         value
             Value used to fill null values.
-        strategy : {None, 'forward', 'backward', 'min', 'max', 'mean', 'zero', 'one'}
+        strategy : {None, 'forward', 'backward', 'min', 'max', 'mean', 'median', 'zero', 'one'}
             Strategy used to fill null values.
         limit
             Number of consecutive null values to fill when using the 'forward' or

--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -3206,7 +3206,7 @@ class Expr(metaclass=_Meta):
         ----------
         value
             Value used to fill null values.
-        strategy : {None, 'forward', 'backward', 'min', 'max', 'mean', 'zero', 'one'}
+        strategy : {None, 'forward', 'backward', 'min', 'max', 'mean', 'median', 'zero', 'one'}
             Strategy used to fill null values.
         limit
             Number of consecutive null values to fill when using the 'forward' or
@@ -3263,6 +3263,17 @@ class Expr(metaclass=_Meta):
         │ 1    ┆ 4   │
         │ 2    ┆ 4   │
         │ null ┆ 6   │
+        └──────┴─────┘
+        >>> df.with_columns(pl.col("b").fill_null(strategy="median"))
+        shape: (3, 2)
+        ┌──────┬─────┐
+        │ a    ┆ b   │
+        │ ---  ┆ --- │
+        │ i64  ┆ f64 │
+        ╞══════╪═════╡
+        │ 1    ┆ 4.0 │
+        │ 2    ┆ 5.0 │
+        │ null ┆ 6.0 │
         └──────┴─────┘
         >>> df.with_columns(pl.col("b").fill_null(pl.col("b").median()))
         shape: (3, 2)

--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -3206,7 +3206,8 @@ class Expr(metaclass=_Meta):
         ----------
         value
             Value used to fill null values.
-        strategy : {None, 'forward', 'backward', 'min', 'max', 'mean', 'median', 'zero', 'one'}
+        strategy : {None, 'forward', 'backward', 'min', 'max', 'mean',
+                    'median', 'zero', 'one'}
             Strategy used to fill null values.
         limit
             Number of consecutive null values to fill when using the 'forward' or

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -7113,7 +7113,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ----------
         value
             Value used to fill null values.
-        strategy : {None, 'forward', 'backward', 'min', 'max', 'mean', 'zero', 'one'}
+        strategy : {None, 'forward', 'backward', 'min', 'max', 'mean', 'median', 'zero', 'one'}
             Strategy used to fill null values.
         limit
             Number of consecutive null values to fill when using the 'forward' or

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -7113,7 +7113,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ----------
         value
             Value used to fill null values.
-        strategy : {None, 'forward', 'backward', 'min', 'max', 'mean', 'median', 'zero', 'one'}
+        strategy : {None, 'forward', 'backward', 'min', 'max', 'mean',
+                    'median', 'zero', 'one'}
             Strategy used to fill null values.
         limit
             Number of consecutive null values to fill when using the 'forward' or

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -5433,7 +5433,8 @@ class Series(metaclass=_Meta):
         ----------
         value
             Value used to fill null values.
-        strategy : {None, 'forward', 'backward', 'min', 'max', 'mean', 'median', 'zero', 'one'}
+        strategy : {None, 'forward', 'backward', 'min', 'max', 'mean',
+                    'median', 'zero', 'one'}
             Strategy used to fill null values.
         limit
             Number of consecutive null values to fill when using the 'forward' or

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -5433,7 +5433,7 @@ class Series(metaclass=_Meta):
         ----------
         value
             Value used to fill null values.
-        strategy : {None, 'forward', 'backward', 'min', 'max', 'mean', 'zero', 'one'}
+        strategy : {None, 'forward', 'backward', 'min', 'max', 'mean', 'median', 'zero', 'one'}
             Strategy used to fill null values.
         limit
             Number of consecutive null values to fill when using the 'forward' or

--- a/py-polars/tests/unit/operations/test_fill_null.py
+++ b/py-polars/tests/unit/operations/test_fill_null.py
@@ -185,3 +185,16 @@ def test_fill_null_null_dtype_24451() -> None:
 def test_fill_null_arr_nonull_cat_28247() -> None:
     s = pl.Series([["a", "b"]], dtype=pl.Array(pl.Categorical, 2))
     assert_series_equal(s, s.arr.eval(pl.element().fill_null(strategy="forward")))
+
+
+def test_fill_null_median() -> None:
+    df = pl.DataFrame({"a": [1, None, 2, None, 10]})
+    result = df.fill_null(strategy="median")
+    expected = pl.DataFrame({"a": [1.0, 2.0, 2.0, 2.0, 10.0]})
+    assert_frame_equal(result, expected)
+
+    lazy_result = df.lazy().fill_null(strategy="median").collect()
+    assert_frame_equal(lazy_result, expected)
+
+    s = pl.Series("a", [0.0, 1.0, None, 2.0, None, 3.0])
+    assert s.fill_null(strategy="median").to_list() == [0.0, 1.0, 1.5, 2.0, 1.5, 3.0]

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -799,6 +799,7 @@ def test_fill_null() -> None:
     assert a.fill_null(strategy="forward").to_list() == [0.0, 1.0, 1.0, 2.0, 2.0, 3.0]
     assert a.fill_null(strategy="backward").to_list() == [0.0, 1.0, 2.0, 2.0, 3.0, 3.0]
     assert a.fill_null(strategy="mean").to_list() == [0.0, 1.0, 1.5, 2.0, 1.5, 3.0]
+    assert a.fill_null(strategy="median").to_list() == [0.0, 1.0, 1.5, 2.0, 1.5, 3.0]
     assert a.forward_fill().to_list() == [0.0, 1.0, 1.0, 2.0, 2.0, 3.0]
     assert a.backward_fill().to_list() == [0.0, 1.0, 2.0, 2.0, 3.0, 3.0]
 


### PR DESCRIPTION
## Summary

Adds a `median` strategy to `fill_null`, matching the existing `mean`/`min`/`max` strategies. Median imputation is a common alternative to mean imputation, particularly for data with outliers.

```python
df = pl.DataFrame({"a": [1, None, 2, None, 10]})
df.fill_null(strategy="median")
# shape: (5, 1)
# ┌──────┐
# │ a    │
# │ ---  │
# │ f64  │
# ╞══════╡
# │ 1.0  │
# │ 2.0  │
# │ 2.0  │
# │ 2.0  │
# │ 10.0 │
# └──────┘
```

## Changes

- **Rust (`polars-core`)**: adds `FillNullStrategy::Median`. In `fill_null_numeric`, the fill value is computed via `Series::median()` (which returns `f64` uniformly across integer/float dtypes) and cast back to the column's native type with `NumCast`, mirroring the existing `Mean` path. Boolean raises the same `InvalidOperationError` as `Mean`. Categorical/binary types keep the existing catch-all error for unsupported strategies.
- **Python (`py-polars`)**: adds `"median"` to the `FillNullStrategy` type alias, the docstring options, and the Rust↔Python string mapping in `parse_fill_null_strategy`.
- **Tests**: Rust integration tests in `crates/polars/tests/it/core/series.rs` (float, even-count, integer, all-null) and Python tests in `tests/unit/operations/test_fill_null.py` + `tests/unit/series/test_series.py`.

## Notes

- The `median` strategy is only supported for numeric dtypes, consistent with `mean`.
- `Series::median()` is used because `ChunkQuantile`'s return type differs by dtype (integers → `f64`, Float32 → `f32`, Float64 → `f64`), so going through `Series` gives a single `f64` path that matches the existing `Mean` handling.

Closes #12077