### PR TITLE
docs(python): Fix misleading reinterpret() docstring

### DIFF
--- a/py-polars/src/polars/expr/expr.py
+++ b/py-polars/src/polars/expr/expr.py
@@ -6913,8 +6913,7 @@ class Expr(metaclass=_Meta):
         This operation is only allowed for numeric types of the same size.
         For lower bits numbers, you can safely use the cast operation.
 
-        Either `signed` or `dtype` can be specified.
-        Defaults to `signed=True` otherwise.
+        Exactly one of `signed` or `dtype` must be specified.
 
         .. engine-support:: in-memory, streaming, distributed
 

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -8175,8 +8175,7 @@ class Series(metaclass=_Meta):
         This operation is only allowed for numeric types of the same size.
         For lower bits numbers, you can safely use the cast operation.
 
-        Either `signed` or `dtype` can be specified.
-        Defaults to `signed=True` otherwise.
+        Exactly one of `signed` or `dtype` must be specified.
 
         Parameters
         ----------


### PR DESCRIPTION
## What
Fixed misleading docstring in Expr.reinterpret and Series.reinterpret that claimed a 'Defaults to signed=True' fallback when neither signed nor dtype is given, when the code actually raises ValueError in that case.

## Why
A small, objectively-verifiable improvement (docs) found during a
daily open-source maintenance pass (2026-09-01).

## How verified
Read the implementation of both methods (expr.py:6950-6952, series.py) and confirmed they raise ValueError via `if (signed is None) == (dtype is None): raise ValueError(...)` when zero or both args are given, contradicting the old docstring's claimed default.
Automated gates: 6 changed lines across 2 files (within limits); cargo check: not needed.

---
Prepared with Claude Code assistance and reviewed by Aarush's
automation gates (diff-size, file-scope, deletion, and build checks)
before opening.