### PR TITLE
feat: Defer SQL resolving until we convert to IR

### DIFF
--- a/crates/polars-plan/dsl-schema-hashes.json
+++ b/crates/polars-plan/dsl-schema-hashes.json
@@ -46,7 +46,7 @@
   "Dimension": "68880cdb10230df6c8c1632b073c80bd8ceb5c56a368c0cb438431ca9f3d3b31",
   "DistinctOptionsDSL": "41be5ec69ef9a614f2b36ac5deadfecdea5cca847ae1ada9d4bc626ff52a5b38",
   "DslFunction": "221f1a46a043c8ed54f57be981bf24509f04f5f91f0f08e0acc180d96f842ebf",
-  "DslPlan": "a4a5bc72389eea2badfb3dfd27ab946e8ac8cb3adfd847a227196e9c533a1b6a",
+  "DslPlan": "0c2990f2087d4e36c74b3eb03e02b60c48cd4368d13432ceee8496bc2d37348b",
   "Duration": "44999d59023085cbb592ce94b30d34f9b983081fc72bd6435a49bdf0869c0074",
   "Duration2": "f251cb1bee2955a17c6defe1573bce21ddbe6cdf6eb9324a19cd37932ab29347",
   "DynListLiteralValue": "2266a553cb4a943f7097f24539eaa802453cf8742675996215235bd682dec0e8",

--- a/crates/polars-plan/src/dsl/iter.rs
+++ b/crates/polars-plan/src/dsl/iter.rs
@@ -19,6 +19,7 @@ impl DslPlan {
                 scratch.extend(inputs)
             },
             PipeWithSchema { input, .. } => scratch.extend(input.iter()),
+            SQL { relations, .. } => scratch.extend(relations.iter().map(|(_, plan)| plan)),
             Join {
                 input_left,
                 input_right,

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -77,7 +77,7 @@ use polars_core::series::ops::NullBehavior;
 #[cfg(feature = "is_close")]
 use polars_utils::total_ord::TotalOrdWrap;
 pub use selector::{DataTypeSelector, Selector, TimeUnitSet, TimeZoneSet};
-pub use sql::{SqlResolver, get_sql_resolver, set_sql_resolver};
+pub use sql::{CachedSqlStatement, SqlResolver, get_sql_resolver, set_sql_resolver};
 #[cfg(feature = "dtype-struct")]
 pub use struct_::*;
 pub use udf::UserDefinedFunction;

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -38,6 +38,7 @@ mod scan_sources;
 mod selector;
 #[cfg(feature = "serde")]
 mod serializable_plan;
+mod sql;
 mod statistics;
 #[cfg(feature = "strings")]
 pub mod string;
@@ -76,6 +77,7 @@ use polars_core::series::ops::NullBehavior;
 #[cfg(feature = "is_close")]
 use polars_utils::total_ord::TotalOrdWrap;
 pub use selector::{DataTypeSelector, Selector, TimeUnitSet, TimeZoneSet};
+pub use sql::{SqlResolver, get_sql_resolver, set_sql_resolver};
 #[cfg(feature = "dtype-struct")]
 pub use struct_::*;
 pub use udf::UserDefinedFunction;

--- a/crates/polars-plan/src/dsl/plan.rs
+++ b/crates/polars-plan/src/dsl/plan.rs
@@ -169,6 +169,12 @@ pub enum DslPlan {
         key: Arc<[PlSmallStr]>,
         maintain_order: bool,
     },
+    /// A SQL query that is resolved during DSL -> IR conversion.
+    SQL {
+        query: Arc<String>,
+        /// The named relations that the query may reference.
+        relations: Vec<(PlSmallStr, DslPlan)>,
+    },
     IR {
         // Keep the original Dsl around as we need that for serialization.
         dsl: Arc<DslPlan>,
@@ -213,6 +219,7 @@ impl Clone for DslPlan {
             Self::Pivot { input, on, on_columns, index, values, agg, separator, maintain_order, column_naming }  => Self::Pivot { input: input.clone(), on: on.clone(), on_columns: on_columns.clone(), index: index.clone(), values: values.clone(), agg: agg.clone(), separator: separator.clone(), maintain_order: *maintain_order, column_naming: *column_naming },
             #[cfg(feature = "merge_sorted")]
             Self::MergeSorted { input_left, input_right, key, maintain_order } => Self::MergeSorted { input_left: input_left.clone(), input_right: input_right.clone(), key: key.clone(), maintain_order: *maintain_order },
+            Self::SQL { query, relations } => Self::SQL { query: query.clone(), relations: relations.clone() },
             Self::IR {node, dsl, version, opt_flags} => Self::IR {node: *node, dsl: dsl.clone(), version: *version, opt_flags: *opt_flags},
         }
     }

--- a/crates/polars-plan/src/dsl/plan.rs
+++ b/crates/polars-plan/src/dsl/plan.rs
@@ -174,6 +174,8 @@ pub enum DslPlan {
         query: Arc<String>,
         /// The named relations that the query may reference.
         relations: Vec<(PlSmallStr, DslPlan)>,
+        #[cfg_attr(any(feature = "serde", feature = "dsl-schema"), serde(skip))]
+        cached_stmt: crate::dsl::CachedSqlStatement,
     },
     IR {
         // Keep the original Dsl around as we need that for serialization.
@@ -219,7 +221,7 @@ impl Clone for DslPlan {
             Self::Pivot { input, on, on_columns, index, values, agg, separator, maintain_order, column_naming }  => Self::Pivot { input: input.clone(), on: on.clone(), on_columns: on_columns.clone(), index: index.clone(), values: values.clone(), agg: agg.clone(), separator: separator.clone(), maintain_order: *maintain_order, column_naming: *column_naming },
             #[cfg(feature = "merge_sorted")]
             Self::MergeSorted { input_left, input_right, key, maintain_order } => Self::MergeSorted { input_left: input_left.clone(), input_right: input_right.clone(), key: key.clone(), maintain_order: *maintain_order },
-            Self::SQL { query, relations } => Self::SQL { query: query.clone(), relations: relations.clone() },
+            Self::SQL { query, relations, cached_stmt } => Self::SQL { query: query.clone(), relations: relations.clone(), cached_stmt: cached_stmt.clone() },
             Self::IR {node, dsl, version, opt_flags} => Self::IR {node: *node, dsl: dsl.clone(), version: *version, opt_flags: *opt_flags},
         }
     }

--- a/crates/polars-plan/src/dsl/serializable_plan.rs
+++ b/crates/polars-plan/src/dsl/serializable_plan.rs
@@ -370,7 +370,11 @@ fn convert_dsl_plan_to_serializable_plan(
             key: key.clone(),
             maintain_order: *maintain_order,
         },
-        DP::SQL { query, relations } => SP::SQL {
+        DP::SQL {
+            query,
+            relations,
+            cached_stmt: _,
+        } => SP::SQL {
             query: query.clone(),
             relations: relations
                 .iter()
@@ -635,6 +639,7 @@ fn try_convert_serializable_plan_to_dsl_plan(
                     Ok((name.clone(), Arc::unwrap_or_clone(plan)))
                 })
                 .collect::<PolarsResult<Vec<_>>>()?,
+            cached_stmt: Default::default(),
         }),
         SP::IR {
             dsl: dsl_key,

--- a/crates/polars-plan/src/dsl/serializable_plan.rs
+++ b/crates/polars-plan/src/dsl/serializable_plan.rs
@@ -147,6 +147,11 @@ pub(crate) enum SerializableDslPlanNode {
         key: Arc<[PlSmallStr]>,
         maintain_order: bool,
     },
+    #[allow(clippy::upper_case_acronyms)]
+    SQL {
+        query: Arc<String>,
+        relations: Vec<(PlSmallStr, DslPlanKey)>,
+    },
     IR {
         dsl: DslPlanKey,
         version: u32,
@@ -364,6 +369,13 @@ fn convert_dsl_plan_to_serializable_plan(
             input_right: dsl_plan_key(input_right, arenas),
             key: key.clone(),
             maintain_order: *maintain_order,
+        },
+        DP::SQL { query, relations } => SP::SQL {
+            query: query.clone(),
+            relations: relations
+                .iter()
+                .map(|(name, plan)| (name.clone(), dsl_plan_key_from_ref(plan, arenas)))
+                .collect(),
         },
         DP::IR {
             dsl,
@@ -613,6 +625,16 @@ fn try_convert_serializable_plan_to_dsl_plan(
             input_right: get_dsl_plan(*input_right, ser_dsl_plan, arenas)?,
             key: key.clone(),
             maintain_order: *maintain_order,
+        }),
+        SP::SQL { query, relations } => Ok(DP::SQL {
+            query: query.clone(),
+            relations: relations
+                .iter()
+                .map(|(name, key)| {
+                    let plan = get_dsl_plan(*key, ser_dsl_plan, arenas)?;
+                    Ok((name.clone(), Arc::unwrap_or_clone(plan)))
+                })
+                .collect::<PolarsResult<Vec<_>>>()?,
         }),
         SP::IR {
             dsl: dsl_key,

--- a/crates/polars-plan/src/dsl/sql.rs
+++ b/crates/polars-plan/src/dsl/sql.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+use std::fmt;
 use std::sync::{Arc, LazyLock, RwLock};
 
 use polars_error::PolarsResult;
@@ -7,6 +9,28 @@ use polars_utils::pl_str::PlSmallStr;
 use crate::dsl::DslPlan;
 use crate::plans::{AExpr, IR};
 
+/// The parsed form of a SQL query, cached so that resolving does not have to parse again.
+///
+/// Opaque here because the parser lives in `polars-sql`. Empty after deserialization.
+#[derive(Clone, Default)]
+pub struct CachedSqlStatement(Option<Arc<dyn Any + Send + Sync>>);
+
+impl CachedSqlStatement {
+    pub fn new(statement: Arc<dyn Any + Send + Sync>) -> Self {
+        Self(Some(statement))
+    }
+
+    pub fn get(&self) -> Option<&(dyn Any + Send + Sync)> {
+        self.0.as_deref()
+    }
+}
+
+impl fmt::Debug for CachedSqlStatement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("CachedSqlStatement")
+    }
+}
+
 /// Resolves a SQL query into a [`DslPlan`].
 ///
 /// Implemented by `polars-sql` and registered through [`set_sql_resolver`], as `polars-plan`
@@ -14,10 +38,13 @@ use crate::plans::{AExpr, IR};
 pub trait SqlResolver: Send + Sync {
     /// `relations` are the named relations the query may reference. The arenas are those of
     /// the ongoing DSL -> IR conversion.
+    ///
+    /// `cached` holds the already-parsed `query` when the node has not been deserialized.
     fn resolve(
         &self,
         query: &str,
         relations: Vec<(PlSmallStr, DslPlan)>,
+        cached: Option<&(dyn Any + Send + Sync)>,
         lp_arena: &mut Arena<IR>,
         expr_arena: &mut Arena<AExpr>,
     ) -> PolarsResult<DslPlan>;

--- a/crates/polars-plan/src/dsl/sql.rs
+++ b/crates/polars-plan/src/dsl/sql.rs
@@ -1,0 +1,36 @@
+use std::sync::{Arc, LazyLock, RwLock};
+
+use polars_error::PolarsResult;
+use polars_utils::arena::Arena;
+use polars_utils::pl_str::PlSmallStr;
+
+use crate::dsl::DslPlan;
+use crate::plans::{AExpr, IR};
+
+/// Resolves a SQL query into a [`DslPlan`].
+///
+/// Implemented by `polars-sql` and registered through [`set_sql_resolver`], as `polars-plan`
+/// cannot depend on `polars-sql`.
+pub trait SqlResolver: Send + Sync {
+    /// `relations` are the named relations the query may reference. The arenas are those of
+    /// the ongoing DSL -> IR conversion.
+    fn resolve(
+        &self,
+        query: &str,
+        relations: Vec<(PlSmallStr, DslPlan)>,
+        lp_arena: &mut Arena<IR>,
+        expr_arena: &mut Arena<AExpr>,
+    ) -> PolarsResult<DslPlan>;
+}
+
+static SQL_RESOLVER: LazyLock<RwLock<Option<Arc<dyn SqlResolver>>>> =
+    LazyLock::new(Default::default);
+
+pub fn set_sql_resolver(resolver: Arc<dyn SqlResolver>) {
+    let mut lock = SQL_RESOLVER.write().unwrap();
+    *lock = Some(resolver);
+}
+
+pub fn get_sql_resolver() -> Option<Arc<dyn SqlResolver>> {
+    SQL_RESOLVER.read().unwrap().clone()
+}

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -847,6 +847,17 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             };
             return run_conversion(lp, ctxt, "match_to_schema");
         },
+        DslPlan::SQL { query, relations } => {
+            let resolver = crate::dsl::get_sql_resolver().ok_or_else(|| {
+                polars_err!(
+                    ComputeError:
+                    "cannot resolve SQL: no SQL resolver registered; \
+                     build polars with the 'sql' feature"
+                )
+            })?;
+            let resolved = resolver.resolve(&query, relations, ctxt.lp_arena, ctxt.expr_arena)?;
+            return to_alp_impl(resolved, ctxt);
+        },
         DslPlan::PipeWithSchema { input, callback } => {
             // Derive the schema from the input
             let mut inputs = Vec::with_capacity(input.len());

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir/mod.rs
@@ -847,7 +847,11 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             };
             return run_conversion(lp, ctxt, "match_to_schema");
         },
-        DslPlan::SQL { query, relations } => {
+        DslPlan::SQL {
+            query,
+            relations,
+            cached_stmt,
+        } => {
             let resolver = crate::dsl::get_sql_resolver().ok_or_else(|| {
                 polars_err!(
                     ComputeError:
@@ -855,7 +859,13 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                      build polars with the 'sql' feature"
                 )
             })?;
-            let resolved = resolver.resolve(&query, relations, ctxt.lp_arena, ctxt.expr_arena)?;
+            let resolved = resolver.resolve(
+                &query,
+                relations,
+                cached_stmt.get(),
+                ctxt.lp_arena,
+                ctxt.expr_arena,
+            )?;
             return to_alp_impl(resolved, ctxt);
         },
         DslPlan::PipeWithSchema { input, callback } => {

--- a/crates/polars-python/src/on_startup.rs
+++ b/crates/polars-python/src/on_startup.rs
@@ -315,6 +315,11 @@ pub unsafe fn register_startup_deps(catch_keyboard_interrupt: bool, warn_functio
         // Register warning function for `polars_warn!`.
         polars_error::set_warning_function(warning_function);
 
+        // Makes `DslPlan::SQL` resolvable, also for plans deserialized without an
+        // `SQLContext` being constructed here.
+        #[cfg(feature = "sql")]
+        polars::sql::register_sql_resolver();
+
         if catch_keyboard_interrupt {
             register_polars_abort_mechanism();
         }

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -317,7 +317,7 @@ impl SQLContext {
         let mut stmt = parse_single_statement(query)?;
 
         if self.can_defer(&stmt) {
-            return Ok(LazyFrame::from(self.defer_query(query, &stmt)));
+            return Ok(LazyFrame::from(self.defer_query(query, stmt)));
         }
 
         desugar_quantified_subqueries(&mut stmt);
@@ -344,8 +344,10 @@ impl SQLContext {
     }
 
     /// Build a [`DslPlan::SQL`] holding `query` and a snapshot of the relations it references.
-    fn defer_query(&self, query: &str, stmt: &Statement) -> DslPlan {
-        let relations = statement_table_identifiers(stmt, false, true)
+    ///
+    /// `stmt` is kept alongside so that resolving does not parse `query` again.
+    fn defer_query(&self, query: &str, mut stmt: Statement) -> DslPlan {
+        let relations = statement_table_identifiers(&stmt, false, true)
             .into_iter()
             .filter_map(|name| {
                 let lf = self.get_table_from_current_scope(&name)?;
@@ -353,28 +355,40 @@ impl SQLContext {
             })
             .collect();
 
+        desugar_quantified_subqueries(&mut stmt);
         DslPlan::SQL {
             query: Arc::new(query.to_owned()),
             relations,
+            cached_stmt: CachedSqlStatement::new(Arc::new(stmt)),
         }
     }
 
     /// Execute `query` eagerly against the given arenas, returning the resulting DSL.
     ///
     /// Resolves a [`DslPlan::SQL`] node. The caller's arenas are used so that input schemas
-    /// resolve into the arenas of the ongoing conversion.
+    /// resolve into the arenas of the ongoing conversion. `cached` is the desugared statement
+    /// the node was built with, and `query` is only parsed when it is absent.
     pub(crate) fn execute_with_arenas(
         &mut self,
         query: &str,
+        cached: Option<&Statement>,
         lp_arena: &mut Arena<IR>,
         expr_arena: &mut Arena<AExpr>,
     ) -> PolarsResult<DslPlan> {
-        let mut stmt = parse_single_statement(query)?;
-        desugar_quantified_subqueries(&mut stmt);
+        let parsed;
+        let stmt = match cached {
+            Some(stmt) => stmt,
+            None => {
+                let mut stmt = parse_single_statement(query)?;
+                desugar_quantified_subqueries(&mut stmt);
+                parsed = stmt;
+                &parsed
+            },
+        };
 
         std::mem::swap(&mut self.lp_arena, lp_arena);
         std::mem::swap(&mut self.expr_arena, expr_arena);
-        let res = self.execute_statement(&stmt);
+        let res = self.execute_statement(stmt);
         std::mem::swap(&mut self.lp_arena, lp_arena);
         std::mem::swap(&mut self.expr_arena, expr_arena);
 

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -32,7 +32,7 @@ use crate::sql_expr::{
 use crate::sql_visitors::{
     QualifyExpression, TableIdentifierCollector, check_for_ambiguous_column_refs,
     expr_contains_subquery, expr_has_window_functions, expr_references_any_column,
-    expr_refers_to_table, sql_expr_cols_all_in_schema,
+    expr_refers_to_table, sql_expr_cols_all_in_schema, statement_registers_table,
 };
 use crate::subquery::{LowerScope, SubqueryBindings, desugar_quantified_subqueries};
 use crate::table_functions::PolarsTableFunctions;
@@ -219,6 +219,9 @@ pub(crate) enum FilterMode {
 pub struct SQLContext {
     pub(crate) table_map: Arc<RwLock<PlHashMap<String, LazyFrame>>>,
     pub(crate) function_registry: Arc<dyn FunctionRegistry>,
+    /// Set once a caller installs their own registry; user-defined functions cannot be
+    /// carried in the DSL, so such a context resolves its queries eagerly.
+    custom_function_registry: bool,
     pub(crate) lp_arena: Arena<IR>,
     pub(crate) expr_arena: Arena<AExpr>,
 
@@ -233,8 +236,10 @@ pub struct SQLContext {
 
 impl Default for SQLContext {
     fn default() -> Self {
+        crate::register_sql_resolver();
         Self {
             function_registry: Arc::new(DefaultFunctionRegistry {}),
+            custom_function_registry: false,
             table_map: Default::default(),
             cte_map: Default::default(),
             table_aliases: Default::default(),
@@ -309,22 +314,14 @@ impl SQLContext {
     /// # }
     ///```
     pub fn execute(&mut self, query: &str) -> PolarsResult<LazyFrame> {
-        let mut parser = Parser::new(&GenericDialect);
-        parser = parser.with_options(ParserOptions {
-            trailing_commas: true,
-            ..Default::default()
-        });
+        let mut stmt = parse_single_statement(query)?;
 
-        let mut ast = parser
-            .try_with_sql(query)
-            .map_err(to_sql_interface_err)?
-            .parse_statements()
-            .map_err(to_sql_interface_err)?;
+        if self.can_defer(&stmt) {
+            return Ok(LazyFrame::from(self.defer_query(query, &stmt)));
+        }
 
-        polars_ensure!(ast.len() == 1, SQLInterface: "one (and only one) statement can be parsed at a time");
-        let stmt = ast.first_mut().unwrap();
-        desugar_quantified_subqueries(stmt);
-        let res = self.execute_statement(stmt)?;
+        desugar_quantified_subqueries(&mut stmt);
+        let res = self.execute_statement(&stmt)?;
 
         // Ensure the result uses the proper arenas.
         // This will instantiate new arenas with a new version.
@@ -332,19 +329,71 @@ impl SQLContext {
         let expr_arena = std::mem::take(&mut self.expr_arena);
         res.set_cached_arena(lp_arena, expr_arena);
 
-        // Every execution should clear the statement-level maps.
+        self.clear_statement_state();
+        Ok(res)
+    }
+
+    /// Whether resolving `stmt` can be deferred to the DSL -> IR conversion.
+    ///
+    /// Neither a registered relation nor a user-defined function survives the round trip
+    /// through the DSL, so a statement that needs either runs eagerly.
+    fn can_defer(&self, stmt: &Statement) -> bool {
+        !self.custom_function_registry
+            && is_read_only_query(stmt)
+            && !statement_registers_table(stmt)
+    }
+
+    /// Build a [`DslPlan::SQL`] holding `query` and a snapshot of the relations it references.
+    fn defer_query(&self, query: &str, stmt: &Statement) -> DslPlan {
+        let relations = statement_table_identifiers(stmt, false, true)
+            .into_iter()
+            .filter_map(|name| {
+                let lf = self.get_table_from_current_scope(&name)?;
+                Some((PlSmallStr::from_string(name), lf.logical_plan))
+            })
+            .collect();
+
+        DslPlan::SQL {
+            query: Arc::new(query.to_owned()),
+            relations,
+        }
+    }
+
+    /// Execute `query` eagerly against the given arenas, returning the resulting DSL.
+    ///
+    /// Resolves a [`DslPlan::SQL`] node. The caller's arenas are used so that input schemas
+    /// resolve into the arenas of the ongoing conversion.
+    pub(crate) fn execute_with_arenas(
+        &mut self,
+        query: &str,
+        lp_arena: &mut Arena<IR>,
+        expr_arena: &mut Arena<AExpr>,
+    ) -> PolarsResult<DslPlan> {
+        let mut stmt = parse_single_statement(query)?;
+        desugar_quantified_subqueries(&mut stmt);
+
+        std::mem::swap(&mut self.lp_arena, lp_arena);
+        std::mem::swap(&mut self.expr_arena, expr_arena);
+        let res = self.execute_statement(&stmt);
+        std::mem::swap(&mut self.lp_arena, lp_arena);
+        std::mem::swap(&mut self.expr_arena, expr_arena);
+
+        self.clear_statement_state();
+        Ok(res?.logical_plan)
+    }
+
+    fn clear_statement_state(&mut self) {
         self.cte_map.clear();
         self.table_aliases.clear();
         self.joined_aliases.clear();
         self.named_windows.clear();
-
-        Ok(res)
     }
 
     /// Add a function registry to the SQLContext.
     /// The registry provides the ability to add custom functions to the SQLContext.
     pub fn with_function_registry(mut self, function_registry: Arc<dyn FunctionRegistry>) -> Self {
         self.function_registry = function_registry;
+        self.custom_function_registry = true;
         self
     }
 
@@ -355,6 +404,7 @@ impl SQLContext {
 
     /// Get a mutable reference to the function registry of the SQLContext
     pub fn registry_mut(&mut self) -> &mut dyn FunctionRegistry {
+        self.custom_function_registry = true;
         Arc::get_mut(&mut self.function_registry).unwrap()
     }
 }
@@ -370,6 +420,7 @@ impl SQLContext {
             // Context-level; needs to remain visible in nested scopes.
             // (Note: shared by Arc, no need to deep-copy)
             function_registry: self.function_registry.clone(),
+            custom_function_registry: self.custom_function_registry,
 
             ..Default::default()
         }
@@ -3994,25 +4045,34 @@ pub fn extract_table_identifiers(
     include_schema: bool,
     unique: bool,
 ) -> PolarsResult<Vec<String>> {
-    let mut parser = Parser::new(&GenericDialect);
-    parser = parser.with_options(ParserOptions {
-        trailing_commas: true,
-        ..Default::default()
-    });
-    let ast = parser
-        .try_with_sql(query)
-        .map_err(to_sql_interface_err)?
-        .parse_statements()
-        .map_err(to_sql_interface_err)?;
+    let ast = parse_sql(query)?;
+    let mut tables = Vec::new();
+    for stmt in &ast {
+        tables.extend(statement_table_identifiers(stmt, include_schema, false));
+    }
+    Ok(if unique {
+        tables
+            .into_iter()
+            .collect::<PlIndexSet<_>>()
+            .into_iter()
+            .collect()
+    } else {
+        tables
+    })
+}
 
+/// Table identifiers referenced by a single parsed statement.
+fn statement_table_identifiers(
+    stmt: &Statement,
+    include_schema: bool,
+    unique: bool,
+) -> Vec<String> {
     let mut collector = TableIdentifierCollector {
         include_schema,
         ..Default::default()
     };
-    for stmt in &ast {
-        let _ = stmt.visit(&mut collector);
-    }
-    Ok(if unique {
+    let _ = stmt.visit(&mut collector);
+    if unique {
         collector
             .tables
             .into_iter()
@@ -4021,7 +4081,36 @@ pub fn extract_table_identifiers(
             .collect()
     } else {
         collector.tables
-    })
+    }
+}
+
+/// Whether `stmt` is a query that only reads; `INSERT`/`UPDATE` bodies write to the context.
+fn is_read_only_query(stmt: &Statement) -> bool {
+    match stmt {
+        Statement::Query(query) => {
+            !matches!(query.body.as_ref(), SetExpr::Insert(_) | SetExpr::Update(_))
+        },
+        _ => false,
+    }
+}
+
+fn parse_single_statement(query: &str) -> PolarsResult<Statement> {
+    let ast = parse_sql(query)?;
+    polars_ensure!(ast.len() == 1, SQLInterface: "one (and only one) statement can be parsed at a time");
+    Ok(ast.into_iter().next().unwrap())
+}
+
+fn parse_sql(query: &str) -> PolarsResult<Vec<Statement>> {
+    let mut parser = Parser::new(&GenericDialect);
+    parser = parser.with_options(ParserOptions {
+        trailing_commas: true,
+        ..Default::default()
+    });
+    parser
+        .try_with_sql(query)
+        .map_err(to_sql_interface_err)?
+        .parse_statements()
+        .map_err(to_sql_interface_err)
 }
 
 bitflags::bitflags! {

--- a/crates/polars-sql/src/lib.rs
+++ b/crates/polars-sql/src/lib.rs
@@ -5,6 +5,7 @@ mod context;
 pub mod function_registry;
 mod functions;
 pub mod keywords;
+mod resolver;
 mod sql_expr;
 mod sql_visitors;
 mod subquery;
@@ -12,4 +13,5 @@ mod table_functions;
 mod types;
 
 pub use context::{SQLContext, extract_table_identifiers};
+pub use resolver::register_sql_resolver;
 pub use sql_expr::sql_expr;

--- a/crates/polars-sql/src/resolver.rs
+++ b/crates/polars-sql/src/resolver.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::sync::{Arc, Once};
 
 use polars_error::PolarsResult;
@@ -6,6 +7,7 @@ use polars_plan::dsl::{DslPlan, SqlResolver, set_sql_resolver};
 use polars_plan::plans::{AExpr, IR};
 use polars_utils::arena::Arena;
 use polars_utils::pl_str::PlSmallStr;
+use sqlparser::ast::Statement;
 
 use crate::context::SQLContext;
 
@@ -16,6 +18,7 @@ impl SqlResolver for DslSqlResolver {
         &self,
         query: &str,
         relations: Vec<(PlSmallStr, DslPlan)>,
+        cached: Option<&(dyn Any + Send + Sync)>,
         lp_arena: &mut Arena<IR>,
         expr_arena: &mut Arena<AExpr>,
     ) -> PolarsResult<DslPlan> {
@@ -23,7 +26,8 @@ impl SqlResolver for DslSqlResolver {
         for (name, plan) in relations {
             ctx.register(&name, LazyFrame::from(plan));
         }
-        ctx.execute_with_arenas(query, lp_arena, expr_arena)
+        let cached = cached.and_then(|stmt| stmt.downcast_ref::<Statement>());
+        ctx.execute_with_arenas(query, cached, lp_arena, expr_arena)
     }
 }
 

--- a/crates/polars-sql/src/resolver.rs
+++ b/crates/polars-sql/src/resolver.rs
@@ -1,0 +1,35 @@
+use std::sync::{Arc, Once};
+
+use polars_error::PolarsResult;
+use polars_lazy::prelude::LazyFrame;
+use polars_plan::dsl::{DslPlan, SqlResolver, set_sql_resolver};
+use polars_plan::plans::{AExpr, IR};
+use polars_utils::arena::Arena;
+use polars_utils::pl_str::PlSmallStr;
+
+use crate::context::SQLContext;
+
+struct DslSqlResolver;
+
+impl SqlResolver for DslSqlResolver {
+    fn resolve(
+        &self,
+        query: &str,
+        relations: Vec<(PlSmallStr, DslPlan)>,
+        lp_arena: &mut Arena<IR>,
+        expr_arena: &mut Arena<AExpr>,
+    ) -> PolarsResult<DslPlan> {
+        let mut ctx = SQLContext::new();
+        for (name, plan) in relations {
+            ctx.register(&name, LazyFrame::from(plan));
+        }
+        ctx.execute_with_arenas(query, lp_arena, expr_arena)
+    }
+}
+
+static REGISTERED: Once = Once::new();
+
+/// Make [`DslPlan::SQL`] resolvable during DSL -> IR conversion.
+pub fn register_sql_resolver() {
+    REGISTERED.call_once(|| set_sql_resolver(Arc::new(DslSqlResolver)));
+}

--- a/crates/polars-sql/src/sql_visitors.rs
+++ b/crates/polars-sql/src/sql_visitors.rs
@@ -7,7 +7,8 @@ use std::ops::ControlFlow;
 
 use polars_core::prelude::*;
 use sqlparser::ast::{
-    Expr as SQLExpr, ObjectName, Query, SetExpr, Visit, Visitor as SQLVisitor, visit_expressions,
+    Expr as SQLExpr, ObjectName, Query, SetExpr, Statement, TableFactor, Visit,
+    Visitor as SQLVisitor, visit_expressions,
 };
 use sqlparser::keywords::ALL_KEYWORDS;
 
@@ -358,4 +359,36 @@ pub(crate) fn expr_contains_subquery(expr: &SQLExpr) -> bool {
         }
     })
     .is_break()
+}
+
+// ---------------------------------------------------------------------------
+// TableRegisteringFinder
+// ---------------------------------------------------------------------------
+
+/// Visitor that detects a relation whose execution inserts into the context's table map:
+/// an aliased derived table, an aliased `UNNEST`, or a table function.
+struct TableRegisteringFinder;
+
+impl SQLVisitor for TableRegisteringFinder {
+    type Break = ();
+
+    fn pre_visit_table_factor(&mut self, table_factor: &TableFactor) -> ControlFlow<Self::Break> {
+        let registers = match table_factor {
+            TableFactor::Derived { alias, .. } | TableFactor::UNNEST { alias, .. } => {
+                alias.is_some()
+            },
+            TableFactor::Table { args, .. } => args.is_some(),
+            _ => false,
+        };
+        if registers {
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
+        }
+    }
+}
+
+/// Check whether executing `stmt` registers a relation into the context's table map.
+pub(crate) fn statement_registers_table(stmt: &Statement) -> bool {
+    stmt.visit(&mut TableRegisteringFinder).is_break()
 }

--- a/crates/polars-sql/tests/empty_table_function.rs
+++ b/crates/polars-sql/tests/empty_table_function.rs
@@ -11,7 +11,9 @@ use polars_sql::*;
 #[cfg(feature = "csv")]
 fn test_empty_table_csv_function() {
     let mut ctx = SQLContext::new();
-    let actual = ctx.execute("SELECT * FROM read_csv()");
+    let actual = ctx
+        .execute("SELECT * FROM read_csv()")
+        .and_then(|lf| lf.collect());
     assert!(actual.is_err());
 }
 
@@ -19,7 +21,9 @@ fn test_empty_table_csv_function() {
 #[cfg(feature = "parquet")]
 fn test_empty_table_parquet_function() {
     let mut ctx = SQLContext::new();
-    let actual = ctx.execute("SELECT * FROM read_parquet()");
+    let actual = ctx
+        .execute("SELECT * FROM read_parquet()")
+        .and_then(|lf| lf.collect());
     assert!(actual.is_err());
 }
 
@@ -27,7 +31,9 @@ fn test_empty_table_parquet_function() {
 #[cfg(feature = "ipc")]
 fn test_empty_table_ipc_function() {
     let mut ctx = SQLContext::new();
-    let actual = ctx.execute("SELECT * FROM read_ipc()");
+    let actual = ctx
+        .execute("SELECT * FROM read_ipc()")
+        .and_then(|lf| lf.collect());
     assert!(actual.is_err());
 }
 
@@ -35,6 +41,8 @@ fn test_empty_table_ipc_function() {
 #[cfg(feature = "json")]
 fn test_empty_table_json_function() {
     let mut ctx = SQLContext::new();
-    let actual = ctx.execute("SELECT * FROM read_json()");
+    let actual = ctx
+        .execute("SELECT * FROM read_json()")
+        .and_then(|lf| lf.collect());
     assert!(actual.is_err());
 }

--- a/crates/polars-sql/tests/functions_aggregate.rs
+++ b/crates/polars-sql/tests/functions_aggregate.rs
@@ -82,7 +82,7 @@ fn test_quantile_out_of_range() {
             let query = format!("SELECT {func}(Data, {q})");
             let mut ctx = SQLContext::new();
             ctx.register("df", create_df());
-            let actual = ctx.execute(&query);
+            let actual = ctx.execute(&query).and_then(|lf| lf.collect());
             assert!(actual.is_err())
         }
     }

--- a/crates/polars-sql/tests/functions_windows.rs
+++ b/crates/polars-sql/tests/functions_windows.rs
@@ -45,7 +45,7 @@ fn ensure_error(sql: &str, expected_error: &str) {
 
     let mut ctx = SQLContext::new();
     ctx.register("df", df);
-    match ctx.execute(&query) {
+    match ctx.execute(&query).and_then(|lf| lf.collect()) {
         Ok(_) => panic!("expected error: {expected_error}"),
         Err(e) => {
             assert!(

--- a/crates/polars-sql/tests/simple_exprs.rs
+++ b/crates/polars-sql/tests/simple_exprs.rs
@@ -840,7 +840,7 @@ fn test_ctes() -> PolarsResult<()> {
     assert!(context.execute(sql1).is_ok());
 
     let sql2 = r#"SELECT * FROM df0"#;
-    assert!(context.execute(sql2).is_err());
+    assert!(context.execute(sql2).and_then(|lf| lf.collect()).is_err());
 
     Ok(())
 }
@@ -985,7 +985,7 @@ fn test_iss_9471() {
     SELECT
         ABS(a,a,a,a,1,2,3,XYZRandomLetters,"XYZRandomLetters") AS "abs",
     FROM df"#;
-    let res = context.execute(sql);
+    let res = context.execute(sql).and_then(|lf| lf.collect());
 
     assert!(res.is_err())
 }

--- a/crates/polars-sql/tests/statements.rs
+++ b/crates/polars-sql/tests/statements.rs
@@ -174,7 +174,7 @@ fn test_drop_table() {
     "#;
     let actual = ctx.execute(sql);
     assert!(actual.is_ok());
-    let res = ctx.execute("SELECT * FROM df");
+    let res = ctx.execute("SELECT * FROM df").and_then(|lf| lf.collect());
     assert!(res.is_err());
 }
 
@@ -601,7 +601,7 @@ fn test_compound_invalid_1() {
 fn test_compound_invalid_2() {
     let mut ctx = prepare_compound_join_context();
     let sql = "SELECT * FROM df1 INNER JOIN df2 ON df1.a = df2.a AND b";
-    let _ = ctx.execute(sql).unwrap();
+    let _ = ctx.execute(sql).unwrap().collect().unwrap();
 }
 
 #[test]

--- a/crates/polars/src/sql.rs
+++ b/crates/polars/src/sql.rs
@@ -1,2 +1,4 @@
 pub use polars_sql::function_registry::*;
-pub use polars_sql::{SQLContext, extract_table_identifiers, keywords, sql_expr};
+pub use polars_sql::{
+    SQLContext, extract_table_identifiers, keywords, register_sql_resolver, sql_expr,
+};

--- a/py-polars/tests/unit/sql/test_array.py
+++ b/py-polars/tests/unit/sql/test_array.py
@@ -225,4 +225,4 @@ def test_array_typed_literals_mixed_error() -> None:
         SQLInterfaceError,
         match="expected consistent dtypes",
     ):
-        pl.sql("SELECT ARRAY[DATE '2024-01-01', TIME '12:00:00']")
+        pl.sql("SELECT ARRAY[DATE '2024-01-01', TIME '12:00:00']").collect()

--- a/py-polars/tests/unit/sql/test_conditional.py
+++ b/py-polars/tests/unit/sql/test_conditional.py
@@ -91,7 +91,9 @@ def test_control_flow(foods_ipc_path: Path) -> None:
             SQLSyntaxError,
             match=r"(IFNULL|NULLIF) expects 2 arguments \(found 3\)",
         ):
-            pl.SQLContext(df=nums).execute(f"SELECT {null_func}(x,y,z) FROM df")
+            pl.SQLContext(df=nums).execute(
+                f"SELECT {null_func}(x,y,z) FROM df"
+            ).collect()
 
 
 def test_greatest_least() -> None:

--- a/py-polars/tests/unit/sql/test_filter_clause.py
+++ b/py-polars/tests/unit/sql/test_filter_clause.py
@@ -129,4 +129,6 @@ def test_filter_clause_multi_parameter_func() -> None:
 def test_filter_clause_filter_plus_over_unsupported() -> None:
     df = pl.DataFrame({"grp": ["a", "b"], "x": [1, 2], "y": [10, 30]})
     with pytest.raises(SQLInterfaceError, match=r"FILTER.*OVER"):
-        pl.sql("SELECT SUM(x) FILTER (WHERE y > 20) OVER (PARTITION BY grp) FROM df")
+        pl.sql(
+            "SELECT SUM(x) FILTER (WHERE y > 20) OVER (PARTITION BY grp) FROM df"
+        ).collect()

--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -811,10 +811,10 @@ def test_natural_joins_01() -> None:
 
     # misc errors
     with pytest.raises(SQLSyntaxError, match=r"did you mean COLUMNS\(\*\)\?"):
-        pl.sql("SELECT * FROM df1 NATURAL JOIN df2 WHERE COLUMNS('*') >= 5")
+        pl.sql("SELECT * FROM df1 NATURAL JOIN df2 WHERE COLUMNS('*') >= 5").collect()
 
     with pytest.raises(SQLSyntaxError, match=r"COLUMNS expects a regex"):
-        pl.sql("SELECT COLUMNS(1234) FROM df1 NATURAL JOIN df2")
+        pl.sql("SELECT COLUMNS(1234) FROM df1 NATURAL JOIN df2").collect()
 
 
 @pytest.mark.parametrize(
@@ -1050,7 +1050,7 @@ def test_unnamed_nested_join_relation() -> None:
             JOIN (right JOIN right ON right.a = right.a)
             ON left.a = right.a
             """
-        )
+        ).collect()
 
 
 def test_nulls_equal_19624() -> None:
@@ -1467,7 +1467,7 @@ def test_unsupported_join_conditions(join_condition: str, expected_error: str) -
     df2 = pl.DataFrame({"id": [2, 3, 4], "val": [20, 30, 40]})
 
     with pytest.raises(SQLInterfaceError, match=expected_error):
-        pl.sql(f"SELECT * FROM df1 INNER JOIN df2 ON {join_condition}")
+        pl.sql(f"SELECT * FROM df1 INNER JOIN df2 ON {join_condition}").collect()
 
 
 def test_ambiguous_column_detection_in_joins() -> None:

--- a/py-polars/tests/unit/sql/test_miscellaneous.py
+++ b/py-polars/tests/unit/sql/test_miscellaneous.py
@@ -280,7 +280,7 @@ def test_nested_subquery_table_leakage() -> None:
         SQLInterfaceError,
         match="relation 'derived' was not found",
     ):
-        ctx.execute("SELECT * FROM derived")
+        ctx.execute("SELECT * FROM derived").collect()
 
 
 def test_register_context() -> None:
@@ -344,7 +344,7 @@ def test_sql_on_compatible_frame_types() -> None:
 
     # don't register all compatible objects
     with pytest.raises(SQLInterfaceError, match="relation 'dfp' was not found"):
-        pl.SQLContext(register_globals=True).execute("SELECT * FROM dfp")
+        pl.SQLContext(register_globals=True).execute("SELECT * FROM dfp").collect()
 
 
 def test_nested_cte_column_aliasing() -> None:
@@ -418,7 +418,7 @@ def test_read_csv(tmp_path: Path) -> None:
         SQLSyntaxError,
         match="`read_csv` expects a single file path; found 3 arguments",
     ):
-        pl.sql("SELECT * FROM read_csv('a','b','c')")
+        pl.sql("SELECT * FROM read_csv('a','b','c')").collect()
 
 
 def test_global_variable_inference_17398() -> None:
@@ -648,7 +648,7 @@ def test_unsupported_select_clauses(query: str) -> None:
             match=r"not.*supported",
         ),
     ):
-        ctx.execute(query)
+        ctx.execute(query).collect()
 
 
 def test_sql_context_eager_execution_removed() -> None:

--- a/py-polars/tests/unit/sql/test_regex.py
+++ b/py-polars/tests/unit/sql/test_regex.py
@@ -129,16 +129,18 @@ def test_regexp_like_errors() -> None:
             SQLSyntaxError,
             match="invalid/empty 'flags' for REGEXP_LIKE",
         ):
-            ctx.execute("SELECT * FROM df WHERE REGEXP_LIKE(scol,'[x-z]+','')")
+            ctx.execute(
+                "SELECT * FROM df WHERE REGEXP_LIKE(scol,'[x-z]+','')"
+            ).collect()
 
         with pytest.raises(
             SQLSyntaxError,
             match="invalid arguments for REGEXP_LIKE",
         ):
-            ctx.execute("SELECT * FROM df WHERE REGEXP_LIKE(scol,999,999)")
+            ctx.execute("SELECT * FROM df WHERE REGEXP_LIKE(scol,999,999)").collect()
 
         with pytest.raises(
             SQLSyntaxError,
             match=r"REGEXP_LIKE expects 2-3 arguments \(found 1\)",
         ):
-            ctx.execute("SELECT * FROM df WHERE REGEXP_LIKE(scol)")
+            ctx.execute("SELECT * FROM df WHERE REGEXP_LIKE(scol)").collect()

--- a/py-polars/tests/unit/sql/test_serialization.py
+++ b/py-polars/tests/unit/sql/test_serialization.py
@@ -108,3 +108,29 @@ def test_table_function_stays_registered(tmp_path: Path) -> None:
     with pl.SQLContext(eager=True) as ctx:
         ctx.execute(f"SELECT a FROM read_csv('{path}')")
         assert ctx.tables() == [str(path)]
+
+
+def test_quantified_subquery_survives_roundtrip() -> None:
+    # the statement is desugared before being cached on the node, so the cached and the
+    # re-parsed path must agree
+    t1 = pl.LazyFrame({"a": [1, 5, 9], "b": [2, 5, 6]})
+
+    q = pl.sql(
+        "SELECT a FROM t1 o WHERE b = ANY (SELECT x.b FROM t1 AS x WHERE x.a = o.a) "
+        "ORDER BY a"
+    )
+    expected = [1, 5, 9]
+
+    assert q.collect().to_series().to_list() == expected
+    assert (
+        pl.LazyFrame.deserialize(q.serialize()).collect().to_series().to_list()
+        == expected
+    )
+
+
+def test_collect_schema_then_collect_agree() -> None:
+    lf = pl.LazyFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    q = lf.sql("SELECT b, a * 2 AS d FROM self WHERE a > 1")
+
+    assert q.collect_schema().names() == ["b", "d"]
+    assert q.collect().to_dict(as_series=False) == {"b": ["y", "z"], "d": [4, 6]}

--- a/py-polars/tests/unit/sql/test_serialization.py
+++ b/py-polars/tests/unit/sql/test_serialization.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+import polars as pl
+from polars.exceptions import SQLInterfaceError
+from polars.testing import assert_frame_equal
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_sql_plan_roundtrip() -> None:
+    lf = pl.LazyFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    q = lf.sql("SELECT b, a * 2 AS a2 FROM self WHERE a > 1")
+
+    roundtripped = pl.LazyFrame.deserialize(q.serialize())
+    assert_frame_equal(roundtripped.collect(), q.collect())
+
+
+def test_sql_query_is_stored_unexpanded() -> None:
+    lf = pl.LazyFrame({"a": [1, 2, 3]})
+    query = "SELECT a FROM self WHERE a > 1"
+
+    assert query.encode() in lf.sql(query).serialize()
+
+
+def test_sql_join_roundtrip() -> None:
+    lf1 = pl.LazyFrame({"a": [1, 2, 3], "b": [6, 7, 8]})
+    lf2 = pl.LazyFrame({"a": [3, 2, 1], "d": [125, -654, 888]})
+
+    q = pl.sql("SELECT lf1.a, b, d FROM lf1 INNER JOIN lf2 USING (a) ORDER BY a")
+    roundtripped = pl.LazyFrame.deserialize(q.serialize())
+
+    assert roundtripped.collect().to_dict(as_series=False) == {
+        "a": [1, 2, 3],
+        "b": [6, 7, 8],
+        "d": [888, -654, 125],
+    }
+
+
+def test_sql_schema_resolved_at_collect(tmp_path: Path) -> None:
+    # the wildcard is expanded against the data as it is at collect time; the
+    # serialized plan carries the query, not a schema frozen when it was built
+    path = tmp_path / "data.parquet"
+    pl.DataFrame({"a": [1, 2]}).write_parquet(path)
+
+    serialized = pl.scan_parquet(path).sql("SELECT * FROM self").serialize()
+    assert pl.LazyFrame.deserialize(serialized).collect().columns == ["a"]
+
+    pl.DataFrame({"a": [1, 2], "b": [3, 4]}).write_parquet(path)
+    assert pl.LazyFrame.deserialize(serialized).collect().columns == ["a", "b"]
+
+
+def test_sql_errors_surface_at_collect() -> None:
+    lf = pl.LazyFrame({"a": [1, 2, 3]})
+    q = lf.sql("SELECT does_not_exist FROM self")
+
+    with pytest.raises(pl.exceptions.ColumnNotFoundError):
+        q.collect()
+
+
+def test_sql_snapshots_registered_tables() -> None:
+    ctx = pl.SQLContext(tbl=pl.LazyFrame({"a": [1, 2, 3]}))
+    q = ctx.execute("SELECT a FROM tbl")
+    ctx.unregister("tbl")
+
+    assert q.collect().to_series().to_list() == [1, 2, 3]
+
+
+def test_sql_unknown_table_errors_at_collect() -> None:
+    ctx = pl.SQLContext()
+    q = ctx.execute("SELECT * FROM nope")
+
+    with pytest.raises(SQLInterfaceError, match="relation 'nope' was not found"):
+        q.collect()
+
+
+def test_sql_defers_with_case_insensitive_table_name() -> None:
+    ctx = pl.SQLContext()
+    ctx.register("MyTbl", pl.LazyFrame({"a": [1, 2, 3]}))
+
+    assert ctx.execute("SELECT a FROM mytbl").collect().to_series().to_list() == [
+        1,
+        2,
+        3,
+    ]
+
+
+def test_unnest_alias_stays_registered() -> None:
+    with pl.SQLContext(eager=True) as ctx:
+        assert ctx.execute(
+            "SELECT x FROM UNNEST([1,2,3]) AS u(x)"
+        ).to_series().to_list() == [
+            1,
+            2,
+            3,
+        ]
+        assert "u" in ctx.tables()
+
+
+def test_table_function_stays_registered(tmp_path: Path) -> None:
+    path = tmp_path / "data.csv"
+    path.write_text("a\n1\n2\n")
+
+    with pl.SQLContext(eager=True) as ctx:
+        ctx.execute(f"SELECT a FROM read_csv('{path}')")
+        assert ctx.tables() == [str(path)]

--- a/py-polars/tests/unit/sql/test_serialization.py
+++ b/py-polars/tests/unit/sql/test_serialization.py
@@ -106,8 +106,13 @@ def test_table_function_stays_registered(tmp_path: Path) -> None:
     path.write_text("a\n1\n2\n")
 
     with pl.SQLContext(eager=True) as ctx:
-        ctx.execute(f"SELECT a FROM read_csv('{path}')")
-        assert ctx.tables() == [str(path)]
+        ctx.execute(f"SELECT a FROM read_csv('{path.as_posix()}')")
+
+        # the name a table function registers under is the path it was given, whose
+        # spelling is platform-dependent; only the registration itself matters here
+        tables = ctx.tables()
+        assert len(tables) == 1
+        assert tables[0].endswith("data.csv")
 
 
 def test_quantified_subquery_survives_roundtrip() -> None:

--- a/py-polars/tests/unit/sql/test_strings.py
+++ b/py-polars/tests/unit/sql/test_strings.py
@@ -80,7 +80,7 @@ def test_string_concat_errors(invalid_concat: str) -> None:
         SQLSyntaxError,
         match=r"CONCAT.*expects at least \d argument[s]? \(found \d\)",
     ):
-        pl.SQLContext(data=lf).execute(f"SELECT {invalid_concat} FROM data")
+        pl.SQLContext(data=lf).execute(f"SELECT {invalid_concat} FROM data").collect()
 
 
 def test_string_left_right_reverse() -> None:
@@ -367,7 +367,7 @@ def test_string_replace() -> None:
         with pytest.raises(
             SQLSyntaxError, match=r"REPLACE expects 3 arguments \(found 2\)"
         ):
-            ctx.execute("SELECT REPLACE(words,'coffee') FROM df")
+            ctx.execute("SELECT REPLACE(words,'coffee') FROM df").collect()
 
 
 def test_string_split() -> None:
@@ -438,7 +438,7 @@ def test_string_substr() -> None:
                 SQLSyntaxError,
                 match=r"SUBSTR does not support negative length \(-99\)",
             ):
-                ctx.execute("SELECT SUBSTR(scol,2,-99) FROM df")
+                ctx.execute("SELECT SUBSTR(scol,2,-99) FROM df").collect()
 
             with pytest.raises(
                 SQLSyntaxError,
@@ -512,4 +512,6 @@ def test_string_trim(foods_ipc_path: Path) -> None:
         match="unsupported TRIM syntax",
     ):
         # currently unsupported (snowflake-style) trim syntax
-        lf.sql("SELECT DISTINCT TRIM('*^xxxx^*', '^*') as new_category FROM self")
+        lf.sql(
+            "SELECT DISTINCT TRIM('*^xxxx^*', '^*') as new_category FROM self"
+        ).collect()


### PR DESCRIPTION
This enables us to send the SQL query to polars-cloud and support SQL there as well. A nice side effect is that it can now work directly on the arena's we have during IR creation, speeding up the SQL -> IR. 

Debug build results:

```
┌──────────────────────────────────────────────┬─────────┬────────────────┐
│                                              │ before  │     after      │
├──────────────────────────────────────────────┼─────────┼────────────────┤
│ execute() — building a query                 │ ~1.1 ms │ 199 µs (~5×)   │
├──────────────────────────────────────────────┼─────────┼────────────────┤
│ collect_schema() then collect() — extra cost │ 999 µs  │ 271 µs (~3.7×) │
└──────────────────────────────────────────────┴─────────┴────────────────┘

```