### PR TITLE
perf: Add prefetching to OOC

### DIFF
--- a/crates/polars-config/src/lib.rs
+++ b/crates/polars-config/src/lib.rs
@@ -79,7 +79,7 @@ const OOC_MEMORY_BUDGET_MB: &str = "POLARS_OOC_MEMORY_BUDGET_MB";
 const DEFAULT_OOC_MEMORY_BUDGET_MB: u64 = u64::MAX;
 
 const OOC_MEMORY_PREFETCH_FRACTION: &str = "POLARS_OOC_MEMORY_PREFETCH_FRACTION";
-const DEFAULT_OOC_MEMORY_PREFETCH_FRACTION: f64 = 0.8;
+const DEFAULT_OOC_MEMORY_PREFETCH_FRACTION: f64 = 0.9;
 
 const OOC_DISK_BUDGET_MB: &str = "POLARS_OOC_DISK_BUDGET_MB";
 const DEFAULT_OOC_DISK_BUDGET_MB: u64 = u64::MAX;
@@ -391,7 +391,7 @@ impl Config {
                 Ordering::Relaxed,
             ),
             OOC_MEMORY_PREFETCH_FRACTION => self.ooc_memory_prefetch_fraction.store(
-                val.and_then(|x| parse::parse_f64_with_limits(var, x, 0.0, 0.95))
+                val.and_then(|x| parse::parse_f64_with_limits(var, x, 0.0, 0.99))
                     .unwrap_or(DEFAULT_OOC_MEMORY_PREFETCH_FRACTION)
                     .to_bits(),
                 Ordering::Relaxed,

--- a/crates/polars-config/src/lib.rs
+++ b/crates/polars-config/src/lib.rs
@@ -87,6 +87,12 @@ const DEFAULT_OOC_DISK_BUDGET_MB: u64 = u64::MAX;
 const OOC_SPILL_MIN_BYTES: &str = "POLARS_OOC_SPILL_MIN_BYTES";
 const DEFAULT_OOC_SPILL_MIN_BYTES: u64 = 64 * 1024; // 64 KB
 
+const OOC_MAX_PARALLEL_SPILL_TASKS: &str = "POLARS_OOC_MAX_PARALLEL_SPILL_TASKS";
+const DEFAULT_OOC_MAX_PARALLEL_SPILL_TASKS: u64 = 64;
+
+const OOC_MAX_PARALLEL_PREFETCH_TASKS: &str = "POLARS_OOC_MAX_PARALLEL_PREFETCH_TASKS";
+const DEFAULT_OOC_MAX_PARALLEL_PREFETCH_TASKS: u64 = 64;
+
 const OOC_LOG_METRICS: &str = "POLARS_OOC_LOG_METRICS";
 const DEFAULT_OOC_LOG_METRICS: bool = false;
 
@@ -162,6 +168,8 @@ static KNOWN_OPTIONS: &[&str] = &[
     OOC_MEMORY_PREFETCH_FRACTION,
     OOC_DISK_BUDGET_MB,
     OOC_SPILL_MIN_BYTES,
+    OOC_MAX_PARALLEL_SPILL_TASKS,
+    OOC_MAX_PARALLEL_PREFETCH_TASKS,
     OOC_LOG_METRICS,
     JOIN_SAMPLE_LIMIT,
     PROJECTION_PUSHDOWN_PRUNE_STRICT_HCONCAT_INPUTS,
@@ -196,6 +204,8 @@ pub struct Config {
     ooc_memory_prefetch_fraction: AtomicU64,
     ooc_disk_budget_bytes: AtomicU64,
     ooc_spill_min_bytes: AtomicU64,
+    ooc_max_parallel_spill_tasks: AtomicU64,
+    ooc_max_parallel_prefetch_tasks: AtomicU64,
     ooc_log_metrics: AtomicBool,
     join_sample_limit: AtomicU64,
     projection_pushdown_prune_strict_hconcat_inputs: AtomicBool,
@@ -244,6 +254,10 @@ impl Config {
                 DEFAULT_OOC_DISK_BUDGET_MB.saturating_mul(1_000_000),
             ),
             ooc_spill_min_bytes: AtomicU64::new(DEFAULT_OOC_SPILL_MIN_BYTES),
+            ooc_max_parallel_spill_tasks: AtomicU64::new(DEFAULT_OOC_MAX_PARALLEL_SPILL_TASKS),
+            ooc_max_parallel_prefetch_tasks: AtomicU64::new(
+                DEFAULT_OOC_MAX_PARALLEL_PREFETCH_TASKS,
+            ),
             ooc_log_metrics: AtomicBool::new(false),
             join_sample_limit: AtomicU64::new(DEFAULT_JOIN_SAMPLE_LIMIT),
             projection_pushdown_prune_strict_hconcat_inputs: AtomicBool::new(
@@ -405,6 +419,18 @@ impl Config {
             OOC_SPILL_MIN_BYTES => self.ooc_spill_min_bytes.store(
                 val.and_then(|x| parse::parse_u64(var, x))
                     .unwrap_or(DEFAULT_OOC_SPILL_MIN_BYTES),
+                Ordering::Relaxed,
+            ),
+            OOC_MAX_PARALLEL_SPILL_TASKS => self.ooc_max_parallel_spill_tasks.store(
+                val.and_then(|x| parse::parse_u64(var, x))
+                    .unwrap_or(DEFAULT_OOC_MAX_PARALLEL_SPILL_TASKS)
+                    .max(1), // A semaphore with zero permits would deadlock.
+                Ordering::Relaxed,
+            ),
+            OOC_MAX_PARALLEL_PREFETCH_TASKS => self.ooc_max_parallel_prefetch_tasks.store(
+                val.and_then(|x| parse::parse_u64(var, x))
+                    .unwrap_or(DEFAULT_OOC_MAX_PARALLEL_PREFETCH_TASKS)
+                    .max(1),
                 Ordering::Relaxed,
             ),
             OOC_LOG_METRICS => self.ooc_log_metrics.store(
@@ -584,6 +610,16 @@ impl Config {
     #[inline(always)]
     pub fn ooc_spill_min_bytes(&self) -> u64 {
         self.ooc_spill_min_bytes.load(Ordering::Relaxed)
+    }
+
+    #[inline(always)]
+    pub fn ooc_max_parallel_spill_tasks(&self) -> usize {
+        self.ooc_max_parallel_spill_tasks.load(Ordering::Relaxed) as usize
+    }
+
+    #[inline(always)]
+    pub fn ooc_max_parallel_prefetch_tasks(&self) -> usize {
+        self.ooc_max_parallel_prefetch_tasks.load(Ordering::Relaxed) as usize
     }
 
     #[inline(always)]

--- a/crates/polars-config/src/lib.rs
+++ b/crates/polars-config/src/lib.rs
@@ -281,7 +281,7 @@ impl Config {
 
     fn recompute_derived(&self) {
         let bytes = self.ooc_memory_budget_bytes.load(Ordering::Relaxed);
-        let frac = f64::from_bits(self.ooc_memory_budget_fraction.load(Ordering::Relaxed));
+        let frac = f64::from_bits(self.ooc_memory_prefetch_fraction.load(Ordering::Relaxed));
         self.ooc_memory_prefetch_bytes
             .store((bytes as f64 * frac) as u64, Ordering::Relaxed);
     }

--- a/crates/polars-ooc/src/memory_manager.rs
+++ b/crates/polars-ooc/src/memory_manager.rs
@@ -15,10 +15,6 @@ const EXPLORE_BEYOND_BEST_SCORE_THRESHOLD: f64 = 20.0;
 // Maximum number of SpillFrame candidates we'll consider per attempt.
 const SPILL_FRAME_BATCH_SIZE: u64 = 256;
 
-const MAX_PARALLEL_SPILL_TASKS: usize = 64;
-
-const MAX_PARALLEL_PREFETCH_TASKS: usize = 64;
-
 use crate::WeakSpillContext;
 use crate::spill_context::{
     InsertReason, PrefetchScheduleResult, RegisteredSpillToken, UNEXPLORED_SCORE,
@@ -49,8 +45,13 @@ impl MemoryManager {
             contexts: RwLock::new(Vec::new()),
             finding_spill_lock: AsyncMutex::new(()),
             finding_prefetch_lock: AsyncMutex::new(()),
-            spill_semaphore: Arc::new(AsyncSemaphore::new(MAX_PARALLEL_SPILL_TASKS)),
-            prefetch_semaphore: Arc::new(AsyncSemaphore::new(MAX_PARALLEL_PREFETCH_TASKS)),
+            // Read once here: the semaphores are sized at construction, and
+            // MEMORY_MANAGER is a LazyLock, so changing these afterwards has no
+            // effect.
+            spill_semaphore: Arc::new(AsyncSemaphore::new(config().ooc_max_parallel_spill_tasks())),
+            prefetch_semaphore: Arc::new(AsyncSemaphore::new(
+                config().ooc_max_parallel_prefetch_tasks(),
+            )),
             est_spill_in_progress: AtomicU64::new(0),
             est_prefetch_in_progress: AtomicU64::new(0),
             spills_exist: AtomicBool::new(false),

--- a/crates/polars-ooc/src/memory_manager.rs
+++ b/crates/polars-ooc/src/memory_manager.rs
@@ -6,9 +6,7 @@ use polars_async::executor::TaskPriority;
 use polars_config::config;
 use polars_utils::total_ord::TotalOrd;
 use polars_utils::with_drop::WithDrop;
-use tokio::sync::{
-    Mutex as AsyncMutex, OwnedSemaphorePermit, Semaphore as AsyncSemaphore,
-};
+use tokio::sync::{Mutex as AsyncMutex, OwnedSemaphorePermit, Semaphore as AsyncSemaphore};
 
 // How much worse than the best achieved (sample) score are we willing to look
 // for spillables.
@@ -22,7 +20,9 @@ const MAX_PARALLEL_SPILL_TASKS: usize = 64;
 const MAX_PARALLEL_PREFETCH_TASKS: usize = 64;
 
 use crate::WeakSpillContext;
-use crate::spill_context::{InsertReason, RegisteredSpillToken, UNEXPLORED_SCORE};
+use crate::spill_context::{
+    InsertReason, PrefetchScheduleResult, RegisteredSpillToken, UNEXPLORED_SCORE,
+};
 use crate::spill_token::{DynSpillToken, SpillStatus, TrySpillError};
 
 static MEMORY_MANAGER: LazyLock<MemoryManager> = LazyLock::new(MemoryManager::new);
@@ -35,9 +35,11 @@ pub fn memory_manager() -> &'static MemoryManager {
 pub struct MemoryManager {
     contexts: RwLock<Vec<WeakSpillContext>>,
     finding_spill_lock: AsyncMutex<()>,
+    finding_prefetch_lock: AsyncMutex<()>,
     spill_semaphore: Arc<AsyncSemaphore>,
     prefetch_semaphore: Arc<AsyncSemaphore>,
     est_spill_in_progress: AtomicU64,
+    est_prefetch_in_progress: AtomicU64,
     spills_exist: AtomicBool,
 }
 
@@ -46,9 +48,11 @@ impl MemoryManager {
         Self {
             contexts: RwLock::new(Vec::new()),
             finding_spill_lock: AsyncMutex::new(()),
+            finding_prefetch_lock: AsyncMutex::new(()),
             spill_semaphore: Arc::new(AsyncSemaphore::new(MAX_PARALLEL_SPILL_TASKS)),
             prefetch_semaphore: Arc::new(AsyncSemaphore::new(MAX_PARALLEL_PREFETCH_TASKS)),
             est_spill_in_progress: AtomicU64::new(0),
+            est_prefetch_in_progress: AtomicU64::new(0),
             spills_exist: AtomicBool::new(false),
         }
     }
@@ -56,7 +60,9 @@ impl MemoryManager {
     fn should_spill(&self) -> bool {
         let usage = crate::estimate_memory_usage();
         let likely_dealt_with = self.est_spill_in_progress.load(Ordering::Relaxed);
-        usage.saturating_sub(likely_dealt_with) > config().ooc_memory_budget_bytes()
+        let likely_incoming = self.est_prefetch_in_progress.load(Ordering::Relaxed);
+        (usage + likely_incoming).saturating_sub(likely_dealt_with)
+            > config().ooc_memory_budget_bytes()
     }
 
     fn should_prefetch(&self) -> bool {
@@ -65,7 +71,8 @@ impl MemoryManager {
         }
 
         let usage = crate::estimate_memory_usage();
-        usage < config().ooc_memory_prefetch_bytes()
+        let likely_incoming = self.est_prefetch_in_progress.load(Ordering::Relaxed);
+        (usage + likely_incoming) < config().ooc_memory_prefetch_bytes()
     }
 
     pub(crate) fn try_get_prefetch_permit(&self) -> Option<OwnedSemaphorePermit> {
@@ -119,7 +126,7 @@ impl MemoryManager {
                 move |(success, weak_ctx)| {
                     if !success.load(Ordering::Relaxed) {
                         if let Some(strong) = weak_ctx.upgrade() {
-                            strong.stats().finish_exploration_event(false);
+                            strong.stats().finish_spill_exploration_event(false);
                         }
                     }
                 },
@@ -138,7 +145,7 @@ impl MemoryManager {
                             if spill_success.await {
                                 if !successful_spill.0.swap(true, Ordering::Relaxed) {
                                     if let Some(strong) = ctx.upgrade() {
-                                        strong.stats().finish_exploration_event(true);
+                                        strong.stats().finish_spill_exploration_event(true);
                                     }
                                 }
 
@@ -159,7 +166,7 @@ impl MemoryManager {
                                 InsertReason::Unpin,
                             );
                         },
-                        Err(TrySpillError::AlreadySpilled) => {},
+                        Err(TrySpillError::AlreadySpilled) | Err(TrySpillError::Dropped) => {},
                     }
 
                     drop(permit);
@@ -177,7 +184,73 @@ impl MemoryManager {
 
     #[inline(never)]
     #[cold]
-    async fn do_prefetch(&self) {}
+    async fn do_prefetch(&self) {
+        let Ok(finding_prefetch_guard) = self.finding_prefetch_lock.try_lock() else {
+            // Someone else is scheduling prefetches.
+            return;
+        };
+
+        // TODO: don't loop over all contexts here, keep track of good ones and inspect those plus a couple random ones.
+        let contexts = self.contexts.read().unwrap();
+        let mut has_dead_context = false;
+        let mut live_contexts = Vec::new();
+        let mut rng = rand::rng();
+        for ctx in contexts.iter() {
+            if ctx.is_dead() {
+                has_dead_context = true;
+                continue;
+            };
+
+            // Thompson sampling.
+            let score_sample = ctx.0.stats().sample_prefetch_score(&mut rng);
+            assert!(!score_sample.is_nan());
+            live_contexts.push((ctx.clone(), score_sample));
+        }
+        drop(contexts);
+
+        // Find the best contexts and loop over their candidates. For each
+        // candidate we prefetch it.
+        live_contexts.sort_by(|a, b| a.1.tot_cmp(&b.1).reverse());
+        let best_explored_score = live_contexts
+            .iter()
+            .map(|(_ctx, score)| *score)
+            .find(|s| *s < UNEXPLORED_SCORE)
+            .unwrap_or_default();
+
+        for (ctx, score) in live_contexts {
+            if self.prefetch_semaphore.available_permits() == 0 {
+                break;
+            }
+
+            // Refuse to consider contexts which are significantly worse than
+            // the best already-explored one.
+            if score * EXPLORE_BEYOND_BEST_SCORE_THRESHOLD < best_explored_score {
+                break;
+            }
+
+            let Some(strong) = ctx.upgrade() else {
+                continue;
+            };
+
+            let stats = strong.stats();
+            stats.start_prefetch_exploration_event();
+            match ctx.0.schedule_prefetch(ctx.1) {
+                PrefetchScheduleResult::Okay => stats.finish_prefetch_exploration_event(true),
+                PrefetchScheduleResult::NoPermitsLeft => {
+                    stats.finish_prefetch_exploration_event(true);
+                    break;
+                },
+                PrefetchScheduleResult::NothingToPrefetch | PrefetchScheduleResult::StaleContext => {
+                    stats.finish_prefetch_exploration_event(false)
+                },
+            }
+        }
+
+        drop(finding_prefetch_guard);
+        if has_dead_context {
+            self.clean_contexts();
+        }
+    }
 
     #[inline(never)]
     #[cold]
@@ -206,15 +279,14 @@ impl MemoryManager {
             };
 
             // Thompson sampling.
-            let score_sample = ctx.0.stats().sample_score(&mut rng);
+            let score_sample = ctx.0.stats().sample_spill_score(&mut rng);
             assert!(!score_sample.is_nan());
             live_contexts.push((ctx.clone(), score_sample));
         }
         drop(contexts);
 
-        // Find the best context and loop over its candidates. For each
+        // Find the best contexts and loop over their candidates. For each
         // candidate we check if it can be spilled else we reinsert it.
-        let min_spill = config().ooc_spill_min_bytes();
         live_contexts.sort_by(|a, b| a.1.tot_cmp(&b.1).reverse());
         let best_explored_score = live_contexts
             .iter()
@@ -223,6 +295,7 @@ impl MemoryManager {
             .unwrap_or_default();
 
         let mut out = None;
+        let min_spill = config().ooc_spill_min_bytes();
         for (ctx, score) in live_contexts {
             // Refuse to consider contexts which are significantly worse than
             // the best already-explored one.
@@ -233,7 +306,7 @@ impl MemoryManager {
             let Some(strong) = ctx.upgrade() else {
                 continue;
             };
-            strong.stats().start_exploration_event();
+            strong.stats().start_spill_exploration_event();
 
             let mut num_considered = 0;
             let mut candidates = Vec::new();
@@ -269,7 +342,7 @@ impl MemoryManager {
             });
 
             if candidates.is_empty() {
-                strong.stats().finish_exploration_event(false);
+                strong.stats().finish_spill_exploration_event(false);
             } else {
                 out = Some((ctx, candidates));
                 break;
@@ -302,6 +375,28 @@ impl Drop for SpillInProgressTracker {
     fn drop(&mut self) {
         memory_manager()
             .est_spill_in_progress
+            .fetch_sub(self.bytes, Ordering::Relaxed);
+    }
+}
+
+/// Used to update the total bytes of estimated prefetches in progress.
+pub(crate) struct PrefetchInProgressTracker {
+    bytes: u64,
+}
+
+impl PrefetchInProgressTracker {
+    pub fn new(bytes: u64) -> Self {
+        memory_manager()
+            .est_prefetch_in_progress
+            .fetch_add(bytes, Ordering::Relaxed);
+        Self { bytes }
+    }
+}
+
+impl Drop for PrefetchInProgressTracker {
+    fn drop(&mut self) {
+        memory_manager()
+            .est_prefetch_in_progress
             .fetch_sub(self.bytes, Ordering::Relaxed);
     }
 }

--- a/crates/polars-ooc/src/memory_manager.rs
+++ b/crates/polars-ooc/src/memory_manager.rs
@@ -6,7 +6,9 @@ use polars_async::executor::TaskPriority;
 use polars_config::config;
 use polars_utils::total_ord::TotalOrd;
 use polars_utils::with_drop::WithDrop;
-use tokio::sync::{Mutex as AsyncMutex, Semaphore as AsyncSemaphore};
+use tokio::sync::{
+    Mutex as AsyncMutex, OwnedSemaphorePermit, Semaphore as AsyncSemaphore,
+};
 
 // How much worse than the best achieved (sample) score are we willing to look
 // for spillables.
@@ -16,6 +18,8 @@ const EXPLORE_BEYOND_BEST_SCORE_THRESHOLD: f64 = 20.0;
 const SPILL_FRAME_BATCH_SIZE: u64 = 256;
 
 const MAX_PARALLEL_SPILL_TASKS: usize = 64;
+
+const MAX_PARALLEL_PREFETCH_TASKS: usize = 64;
 
 use crate::WeakSpillContext;
 use crate::spill_context::{InsertReason, RegisteredSpillToken, UNEXPLORED_SCORE};
@@ -32,6 +36,7 @@ pub struct MemoryManager {
     contexts: RwLock<Vec<WeakSpillContext>>,
     finding_spill_lock: AsyncMutex<()>,
     spill_semaphore: Arc<AsyncSemaphore>,
+    prefetch_semaphore: Arc<AsyncSemaphore>,
     est_spill_in_progress: AtomicU64,
     spills_exist: AtomicBool,
 }
@@ -42,6 +47,7 @@ impl MemoryManager {
             contexts: RwLock::new(Vec::new()),
             finding_spill_lock: AsyncMutex::new(()),
             spill_semaphore: Arc::new(AsyncSemaphore::new(MAX_PARALLEL_SPILL_TASKS)),
+            prefetch_semaphore: Arc::new(AsyncSemaphore::new(MAX_PARALLEL_PREFETCH_TASKS)),
             est_spill_in_progress: AtomicU64::new(0),
             spills_exist: AtomicBool::new(false),
         }
@@ -60,6 +66,10 @@ impl MemoryManager {
 
         let usage = crate::estimate_memory_usage();
         usage < config().ooc_memory_prefetch_bytes()
+    }
+
+    pub(crate) fn try_get_prefetch_permit(&self) -> Option<OwnedSemaphorePermit> {
+        self.prefetch_semaphore.clone().try_acquire_owned().ok()
     }
 
     fn clean_contexts(&self) {

--- a/crates/polars-ooc/src/memory_manager.rs
+++ b/crates/polars-ooc/src/memory_manager.rs
@@ -223,6 +223,11 @@ impl MemoryManager {
                 break;
             }
 
+            // Rejected by the bandit; scores are sorted descending so the rest are too.
+            if score <= 0.0 {
+                break;
+            }
+
             // Refuse to consider contexts which are significantly worse than
             // the best already-explored one.
             if score * EXPLORE_BEYOND_BEST_SCORE_THRESHOLD < best_explored_score {

--- a/crates/polars-ooc/src/memory_manager.rs
+++ b/crates/polars-ooc/src/memory_manager.rs
@@ -240,7 +240,8 @@ impl MemoryManager {
                     stats.finish_prefetch_exploration_event(true);
                     break;
                 },
-                PrefetchScheduleResult::NothingToPrefetch | PrefetchScheduleResult::StaleContext => {
+                PrefetchScheduleResult::NothingToPrefetch
+                | PrefetchScheduleResult::StaleContext => {
                     stats.finish_prefetch_exploration_event(false)
                 },
             }

--- a/crates/polars-ooc/src/spill_context/mod.rs
+++ b/crates/polars-ooc/src/spill_context/mod.rs
@@ -179,6 +179,13 @@ pub(crate) enum InsertReason {
     TooSmall(Timestamp),
 }
 
+pub(crate) enum PrefetchScheduleResult {
+    NothingToPrefetch,
+    NoPermitsLeft,
+    Okay,
+    StaleContext,
+}
+
 #[derive(Default)]
 struct SharedState {
     spill_queue: SpillQueue,
@@ -327,19 +334,20 @@ impl SpillContextInner {
         }
     }
 
-    pub(crate) fn schedule_prefetch(&self, ctx_id: u64) {
+    pub(crate) fn schedule_prefetch(&self, ctx_id: u64) -> PrefetchScheduleResult {
         let mut shared = self.shared.lock().unwrap();
         if ctx_id != self.context_id.load(Ordering::Relaxed) {
-            return;
+            return PrefetchScheduleResult::StaleContext;
         }
 
         self.drain_staging(&mut shared, false);
 
+        let mut prefetched = false;
         let mm = memory_manager();
         let mut rng = rand::rng();
         for _ in 0..self.stats.suggested_prefetch_amount() {
             let Some(permit) = mm.try_get_prefetch_permit() else {
-                return;
+                return PrefetchScheduleResult::NoPermitsLeft;
             };
 
             let pop = match self.policy() {
@@ -353,11 +361,19 @@ impl SpillContextInner {
                 continue;
             };
 
+            prefetched = true;
             self.stats.add_prefetch_start();
+            let prefetch_fut = token.prefetch(); // Create fut outside of spawn to update statistics now.
             polars_async::executor::spawn(TaskPriority::Low, async move {
-                token.prefetch().await;
+                prefetch_fut.await;
                 drop(permit);
             });
+        }
+
+        if prefetched {
+            PrefetchScheduleResult::Okay
+        } else {
+            PrefetchScheduleResult::NothingToPrefetch
         }
     }
 }

--- a/crates/polars-ooc/src/spill_context/mod.rs
+++ b/crates/polars-ooc/src/spill_context/mod.rs
@@ -435,6 +435,7 @@ impl Clone for StrongSpillContext {
 impl Drop for StrongSpillContext {
     fn drop(&mut self) {
         if self.0.refcount.fetch_sub(1, Ordering::AcqRel) == 1 {
+            self.0.stats().on_drop();
             SPILL_CONTEXT_REUSE_ARENA.lock().unwrap().push(self.0);
         }
     }

--- a/crates/polars-ooc/src/spill_context/mod.rs
+++ b/crates/polars-ooc/src/spill_context/mod.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 
+use polars_async::executor::TaskPriority;
 use polars_utils::pl_str::PlSmallStr;
 use polars_utils::tick_counter::tick_counter;
 use rand::RngExt;
@@ -323,6 +324,40 @@ impl SpillContextInner {
 
         if self.staging_empty.load(Ordering::Relaxed) {
             self.staging_empty.swap(false, Ordering::AcqRel);
+        }
+    }
+
+    pub(crate) fn schedule_prefetch(&self, ctx_id: u64) {
+        let mut shared = self.shared.lock().unwrap();
+        if ctx_id != self.context_id.load(Ordering::Relaxed) {
+            return;
+        }
+
+        self.drain_staging(&mut shared, false);
+
+        let mm = memory_manager();
+        let mut rng = rand::rng();
+        for _ in 0..self.stats.suggested_prefetch_amount() {
+            let Some(permit) = mm.try_get_prefetch_permit() else {
+                return;
+            };
+
+            let pop = match self.policy() {
+                SpillContextPolicy::MostRecent => shared.unspill_queue.pop_front(),
+                SpillContextPolicy::LeastRecent => shared.unspill_queue.pop_back(),
+                SpillContextPolicy::Random => shared.unspill_queue.pop_random(&mut rng),
+            };
+
+            let Some(rt) = pop else { break };
+            let Some(token) = rt.upgrade() else {
+                continue;
+            };
+
+            self.stats.add_prefetch_start();
+            polars_async::executor::spawn(TaskPriority::Low, async move {
+                token.prefetch().await;
+                drop(permit);
+            });
         }
     }
 }

--- a/crates/polars-ooc/src/spill_context/stats.rs
+++ b/crates/polars-ooc/src/spill_context/stats.rs
@@ -45,6 +45,12 @@ impl SpillContextStatistics {
         }
     }
 
+    pub(crate) fn on_drop(&self) {
+        if polars_config::config().ooc_log_metrics() {
+            self.stats.lock().unwrap().print_metrics();
+        }
+    }
+
     pub(crate) fn reset(&self, name: PlSmallStr) {
         let mut stats = self.stats.lock().unwrap();
         self.recent_spilled_drain_events.store(0);
@@ -55,35 +61,6 @@ impl SpillContextStatistics {
             name,
             ..Default::default()
         };
-    }
-}
-
-impl Drop for SpillContextStatistics {
-    fn drop(&mut self) {
-        if polars_config::config().ooc_log_metrics() {
-            let stats = self.stats.get_mut().unwrap();
-            let name = &stats.name;
-            let relief = stats.spilled_byte_seconds / (1000.0 * 1000.0);
-            let spill_io = Duration::from_secs_f64(stats.spill_time);
-            let unspill_io = Duration::from_secs_f64(stats.unspill_time);
-            let spills_tot = stats.successful_spills + stats.failed_spills;
-            let spills_succ = 100.0 * stats.successful_spills as f64 / spills_tot as f64;
-            let spill_explore_tot = stats.total_spill_explorations;
-            let spill_explore_succ =
-                100.0 * stats.successful_spill_explorations as f64 / spill_explore_tot as f64;
-            let prefetch_explore_tot = stats.total_prefetch_explorations;
-            let prefetch_explore_succ =
-                100.0 * stats.successful_prefetch_explorations as f64 / prefetch_explore_tot as f64;
-
-            eprintln!(
-                "spill_stats({name}): \
-                relief_mb_s({relief:.2}), \
-                io(spill={spill_io:.2?}, unspill={unspill_io:.2?}), \
-                spill(succ={spills_succ:.1}%, n={spills_tot}), \
-                spill_explore(succ={spill_explore_succ:.1}%, n={spill_explore_tot}), \
-                prefetch_explore(succ={prefetch_explore_succ:.1}%, n={prefetch_explore_tot})"
-            )
-        }
     }
 }
 
@@ -526,6 +503,30 @@ impl Statistics {
 
         // Efraimidis-Spirakis weighted random sampling.
         rng.random::<f64>().powf(1.0 / (1.0 + weight))
+    }
+
+    fn print_metrics(&self) {
+        let name = &self.name;
+        let relief = self.spilled_byte_seconds / (1000.0 * 1000.0);
+        let spill_io = Duration::from_secs_f64(self.spill_time);
+        let unspill_io = Duration::from_secs_f64(self.unspill_time);
+        let spills_tot = self.successful_spills + self.failed_spills;
+        let spills_succ = 100.0 * self.successful_spills as f64 / spills_tot as f64;
+        let spill_explore_tot = self.total_spill_explorations;
+        let spill_explore_succ =
+            100.0 * self.successful_spill_explorations as f64 / spill_explore_tot as f64;
+        let prefetch_explore_tot = self.total_prefetch_explorations;
+        let prefetch_explore_succ =
+            100.0 * self.successful_prefetch_explorations as f64 / prefetch_explore_tot as f64;
+
+        eprintln!(
+            "spill_stats({name}): \
+            relief_mb_s({relief:.2}), \
+            io(spill={spill_io:.2?}, unspill={unspill_io:.2?}), \
+            spill(succ={spills_succ:.1}%, n={spills_tot}), \
+            spill_explore(succ={spill_explore_succ:.1}%, n={spill_explore_tot}), \
+            prefetch_explore(succ={prefetch_explore_succ:.1}%, n={prefetch_explore_tot})"
+        )
     }
 }
 

--- a/crates/polars-ooc/src/spill_context/stats.rs
+++ b/crates/polars-ooc/src/spill_context/stats.rs
@@ -1,4 +1,4 @@
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
 use polars_utils::pl_str::PlSmallStr;
@@ -6,25 +6,38 @@ use polars_utils::relaxed_cell::RelaxedCell;
 use rand::{Rng, RngExt};
 use rand_distr::Distribution;
 
+static EPOCH: LazyLock<Instant> = LazyLock::new(Instant::now);
+
 // Used to normalize divisor to avoid absurdly high scores. Set to 1us.
 const BASE_IO_TIME: f64 = 1e-6;
 pub(crate) const UNEXPLORED_SCORE: f64 = 1e30_f64;
 const EXPLORED_WEIGHT_THRESHOLD: f64 = 1.1; // Just over 1 so sample variance correction is stable.
-const UNSPILL_EVENT_HALF_LIFE_SEC: f64 = 5.0;
-const NANOSECONDS_IN_SECOND: f64 = 1e9;
+const BANDIT_EVENT_HALF_LIFE_SEC: f64 = 1.0;
+const NANOSECONDS_IN_SECOND: u64 = 1_000_000_000;
 
 pub struct SpillContextStatistics {
+    recent_spilled_drain_events: RelaxedCell<u64>,
+    last_recent_sync_ts: RelaxedCell<u64>,
+
     prefetch_without_spill_streak: RelaxedCell<u64>,
-    score_cache: RelaxedCell<u64>,
+
+    spill_score_cache: RelaxedCell<u64>,
+    prefetch_score_cache: RelaxedCell<u64>,
     stats: Mutex<Statistics>,
 }
 
 impl SpillContextStatistics {
     pub(crate) fn new(name: PlSmallStr) -> Self {
         Self {
+            last_recent_sync_ts: RelaxedCell::new_u64(EPOCH.elapsed().as_nanos() as u64),
+            recent_spilled_drain_events: RelaxedCell::new_u64(0),
+
             prefetch_without_spill_streak: RelaxedCell::new_u64(0),
+
             // TODO: starting score based on context.
-            score_cache: RelaxedCell::new_u64(UNEXPLORED_SCORE.to_bits()),
+            spill_score_cache: RelaxedCell::new_u64(UNEXPLORED_SCORE.to_bits()),
+            prefetch_score_cache: RelaxedCell::new_u64(UNEXPLORED_SCORE.to_bits()),
+
             stats: Mutex::new(Statistics {
                 name,
                 ..Default::default()
@@ -34,7 +47,10 @@ impl SpillContextStatistics {
 
     pub(crate) fn reset(&self, name: PlSmallStr) {
         let mut stats = self.stats.lock().unwrap();
-        self.score_cache.store(UNEXPLORED_SCORE.to_bits());
+        self.recent_spilled_drain_events.store(0);
+        self.prefetch_without_spill_streak.store(0);
+        self.spill_score_cache.store(UNEXPLORED_SCORE.to_bits());
+        self.prefetch_score_cache.store(UNEXPLORED_SCORE.to_bits());
         *stats = Statistics {
             name,
             ..Default::default()
@@ -52,15 +68,20 @@ impl Drop for SpillContextStatistics {
             let unspill_io = Duration::from_secs_f64(stats.unspill_time);
             let spills_tot = stats.successful_spills + stats.failed_spills;
             let spills_succ = 100.0 * stats.successful_spills as f64 / spills_tot as f64;
-            let explore_tot = stats.total_explorations;
-            let explore_succ = 100.0 * stats.successful_explorations as f64 / explore_tot as f64;
+            let spill_explore_tot = stats.total_spill_explorations;
+            let spill_explore_succ =
+                100.0 * stats.successful_spill_explorations as f64 / spill_explore_tot as f64;
+            let prefetch_explore_tot = stats.total_prefetch_explorations;
+            let prefetch_explore_succ =
+                100.0 * stats.successful_prefetch_explorations as f64 / prefetch_explore_tot as f64;
 
             eprintln!(
                 "spill_stats({name}): \
                 relief_mb_s({relief:.2}), \
                 io(spill={spill_io:.2?}, unspill={unspill_io:.2?}), \
                 spill(succ={spills_succ:.1}%, n={spills_tot}), \
-                explore(succ={explore_succ:.1}%, n={explore_tot})"
+                spill_explore(succ={spill_explore_succ:.1}%, n={spill_explore_tot}), \
+                prefetch_explore(succ={prefetch_explore_succ:.1}%, n={prefetch_explore_tot})"
             )
         }
     }
@@ -75,8 +96,10 @@ struct Statistics {
     unspill_time: f64,
     successful_spills: u64,
     failed_spills: u64,
-    total_explorations: u64,
-    successful_explorations: u64,
+    total_spill_explorations: u64,
+    successful_spill_explorations: u64,
+    total_prefetch_explorations: u64,
+    successful_prefetch_explorations: u64,
 
     // Historical stats for the multi-armed bandit algorithm. These are
     // discounted statistics (meaning they decay over time), where weight is the
@@ -97,11 +120,16 @@ struct Statistics {
     bandit_rt_sum: f64,
 
     // Context exploration attempts.
-    bandit_explore_weight: f64,
-    bandit_explore_success: f64,
+    bandit_spill_explore_weight: f64,
+    bandit_spill_explore_success: f64,
+    bandit_prefetch_explore_weight: f64,
+    bandit_prefetch_explore_success: f64,
 
     // Number of unspills that weren't due to prefetching.
     bandit_non_prefetch_unspill_weight: f64,
+
+    // Number of times a spilled token was unregistered (drained) from its context.
+    bandit_spilled_drain_weight: f64,
 
     // Stats of currently active spills. We prefer integers here for accuracy,
     // but have to use floats for the bigger accumulators. Those are only used
@@ -126,34 +154,66 @@ impl SpillContextStatistics {
         self.stats.lock().unwrap().name.clone()
     }
 
-    // Returns a sample of the expected performance of this context, discounting
-    // older data. The score is the number of spilled byte-seconds divided by
-    // the IO time in seconds. The discount is a time-based exponential decay
-    // which assigns lower weight to older spill events (with a half-life of
-    // UNSPILL_EVENT_HALF_LIFE_SEC), and full weight to current spills.
-    pub fn sample_score<R: Rng>(&self, rng: &mut R) -> f64 {
+    // Returns a sample of the expected spill performance of this context,
+    // discounting older data. The score is the number of spilled byte-seconds
+    // divided by the IO time in seconds. The discount is a time-based
+    // exponential decay which assigns lower weight to older spill events (with
+    // a half-life of UNSPILL_EVENT_HALF_LIFE_SEC), and full weight to current
+    // spills.
+    pub fn sample_spill_score<R: Rng>(&self, rng: &mut R) -> f64 {
         // Try to re-compute, if lock is taken just take cached value.
         if let Ok(mut stats) = self.stats.try_lock() {
-            let score = stats.sample_score(rng);
-            self.score_cache.store(score.to_bits());
+            stats.step_time(Instant::now());
+
+            let score = stats.sample_spill_score(rng);
+            self.spill_score_cache.store(score.to_bits());
             score
         } else {
-            f64::from_bits(self.score_cache.load())
+            f64::from_bits(self.spill_score_cache.load())
         }
     }
 
-    pub fn start_exploration_event(&self) {
-        // We don't bother stepping time here as it's already done in score sampling.
-        let mut stats = self.stats.lock().unwrap();
-        stats.total_explorations += 1;
-        stats.bandit_explore_weight += 1.0;
+    pub fn sample_prefetch_score<R: Rng>(&self, rng: &mut R) -> f64 {
+        // Try to re-compute, if lock is taken just take cached value.
+        if let Ok(mut stats) = self.stats.try_lock() {
+            let now = Instant::now();
+            stats.step_time(now);
+            stats.bandit_spilled_drain_weight += self.recent_spilled_drain_events.swap(0) as f64;
+
+            let score = stats.sample_prefetch_score(rng);
+            self.prefetch_score_cache.store(score.to_bits());
+            score
+        } else {
+            f64::from_bits(self.prefetch_score_cache.load())
+        }
     }
 
-    pub fn finish_exploration_event(&self, success: bool) {
+    pub fn start_spill_exploration_event(&self) {
         // We don't bother stepping time here as it's already done in score sampling.
         let mut stats = self.stats.lock().unwrap();
-        stats.successful_explorations += success as u64;
-        stats.bandit_explore_success += success as u64 as f64;
+        stats.total_spill_explorations += 1;
+        stats.bandit_spill_explore_weight += 1.0;
+    }
+
+    pub fn finish_spill_exploration_event(&self, success: bool) {
+        // We don't bother stepping time here as it's already done in score sampling.
+        let mut stats = self.stats.lock().unwrap();
+        stats.successful_spill_explorations += success as u64;
+        stats.bandit_spill_explore_success += success as u64 as f64;
+    }
+
+    pub fn start_prefetch_exploration_event(&self) {
+        // We don't bother stepping time here as it's already done in score sampling.
+        let mut stats = self.stats.lock().unwrap();
+        stats.total_prefetch_explorations += 1;
+        stats.bandit_prefetch_explore_weight += 1.0;
+    }
+
+    pub fn finish_prefetch_exploration_event(&self, success: bool) {
+        // We don't bother stepping time here as it's already done in score sampling.
+        let mut stats = self.stats.lock().unwrap();
+        stats.successful_prefetch_explorations += success as u64;
+        stats.bandit_prefetch_explore_success += success as u64 as f64;
     }
 
     pub fn add_spill_start(&self) {
@@ -166,6 +226,21 @@ impl SpillContextStatistics {
 
     pub fn add_prefetch_start(&self) {
         self.prefetch_without_spill_streak.fetch_add(1);
+    }
+
+    pub fn add_spilled_drain_event(&self) {
+        // Since this can get called quite often we do a simple atomic operation
+        // and only grab a lock every millisecond.
+        self.recent_spilled_drain_events.fetch_add(1);
+
+        let now = Instant::now();
+        let ts = (now - *EPOCH).as_nanos() as u64;
+        if ts.saturating_sub(self.last_recent_sync_ts.load()) >= NANOSECONDS_IN_SECOND / 1000 {
+            let mut stats = self.stats.lock().unwrap();
+            stats.step_time(now);
+            stats.bandit_spilled_drain_weight += self.recent_spilled_drain_events.swap(0) as f64;
+            self.last_recent_sync_ts.store(ts);
+        }
     }
 
     pub fn add_failed_spill(&self, spill_start: Instant) {
@@ -193,7 +268,7 @@ impl SpillContextStatistics {
 
         let mean_b_before = stats.active_spills_bytes as f64 / stats.active_spills.max(1) as f64;
         let mean_r_before = stats.active_spills_bytes_ns as f64
-            / (stats.active_spills.max(1) as f64 * NANOSECONDS_IN_SECOND);
+            / (stats.active_spills.max(1) as f64 * NANOSECONDS_IN_SECOND as f64);
 
         stats.spill_time += spill_time.as_secs_f64();
         stats.successful_spills += 1;
@@ -203,7 +278,7 @@ impl SpillContextStatistics {
 
         let mean_b_after = stats.active_spills_bytes as f64 / stats.active_spills as f64;
         let mean_r_after = stats.active_spills_bytes_ns as f64
-            / (stats.active_spills as f64 * NANOSECONDS_IN_SECOND);
+            / (stats.active_spills as f64 * NANOSECONDS_IN_SECOND as f64);
 
         let delta_r = -0.0;
         let delta_b = n_bytes as f64;
@@ -231,7 +306,7 @@ impl SpillContextStatistics {
 
         let mean_b_before = stats.active_spills_bytes as f64 / stats.active_spills as f64;
         let mean_r_before = stats.active_spills_bytes_ns as f64
-            / (stats.active_spills as f64 * NANOSECONDS_IN_SECOND);
+            / (stats.active_spills as f64 * NANOSECONDS_IN_SECOND as f64);
 
         let spilled_time = unspill_start - spilled_start;
         let unspill_time = now - unspill_start;
@@ -258,7 +333,7 @@ impl SpillContextStatistics {
             let delta_r = delta_b * elapsed_s;
             let mean_b_after = stats.active_spills_bytes as f64 / stats.active_spills as f64;
             let mean_r_after = stats.active_spills_bytes_ns as f64
-                / (stats.active_spills as f64 * NANOSECONDS_IN_SECOND);
+                / (stats.active_spills as f64 * NANOSECONDS_IN_SECOND as f64);
             stats.active_spills_dp_rr -= (delta_r - mean_r_before) * (delta_r - mean_r_after);
             stats.active_spills_dp_rb -= (delta_r - mean_r_before) * (delta_b - mean_b_after);
             stats.active_spills_dp_bb -= (delta_b - mean_b_before) * (delta_b - mean_b_after);
@@ -266,7 +341,7 @@ impl SpillContextStatistics {
 
         stats.add_bandit_spill_event(
             n_bytes as u64,
-            spill_time_ns as f64 / NANOSECONDS_IN_SECOND,
+            spill_time_ns as f64 / NANOSECONDS_IN_SECOND as f64,
             spilled_time.as_secs_f64(),
             unspill_time.as_secs_f64(),
         );
@@ -305,7 +380,7 @@ impl Statistics {
         self.active_spills_dp_rb += self.active_spills_dp_bb * dt_s;
 
         // Exponentially decay old bandit events.
-        let mult = -f64::ln(2.0) / UNSPILL_EVENT_HALF_LIFE_SEC;
+        let mult = -f64::ln(2.0) / BANDIT_EVENT_HALF_LIFE_SEC;
         let decay_factor = f64::exp(mult * dt_s);
         self.bandit_weight *= decay_factor;
         self.bandit_r_sum *= decay_factor;
@@ -314,10 +389,13 @@ impl Statistics {
         self.bandit_tt_sum *= decay_factor;
         self.bandit_rt_sum *= decay_factor;
 
-        self.bandit_explore_success *= decay_factor;
-        self.bandit_explore_weight *= decay_factor;
+        self.bandit_spill_explore_success *= decay_factor;
+        self.bandit_spill_explore_weight *= decay_factor;
+        self.bandit_prefetch_explore_success *= decay_factor;
+        self.bandit_prefetch_explore_weight *= decay_factor;
 
         self.bandit_non_prefetch_unspill_weight *= decay_factor;
+        self.bandit_spilled_drain_weight *= decay_factor;
 
         self.last_update = now;
     }
@@ -341,15 +419,14 @@ impl Statistics {
         self.bandit_rt_sum += r * t;
     }
 
-    fn sample_score<R: Rng>(&mut self, rng: &mut R) -> f64 {
-        self.step_time(Instant::now());
-
+    fn sample_spill_score<R: Rng>(&mut self, rng: &mut R) -> f64 {
         // Take into account how often we've tried to inspect this context and
         // didn't find anything to spill.
-        if self.bandit_explore_weight >= EXPLORED_WEIGHT_THRESHOLD {
-            // Bernoulli Thompson sampling of a probability.
-            let alpha = 1.0 + self.bandit_explore_success.max(0.0);
-            let beta = 1.0 + (self.bandit_explore_weight - self.bandit_explore_success).max(0.0);
+        if self.bandit_spill_explore_weight >= EXPLORED_WEIGHT_THRESHOLD {
+            // Bernoulli-Thompson sampling of a probability.
+            let alpha = 1.0 + self.bandit_spill_explore_success.max(0.0);
+            let beta = 1.0
+                + (self.bandit_spill_explore_weight - self.bandit_spill_explore_success).max(0.0);
             let p = rand_distr::Beta::new(alpha, beta).unwrap().sample(rng);
             if !rng.random_bool(p) {
                 return 0.0;
@@ -376,8 +453,8 @@ impl Statistics {
 
             let w = self.active_spills as f64;
             let b = self.active_spills_bytes as f64;
-            let r = self.active_spills_bytes_ns as f64 / NANOSECONDS_IN_SECOND;
-            let t = self.active_spills_io_time_ns as f64 / NANOSECONDS_IN_SECOND;
+            let r = self.active_spills_bytes_ns as f64 / NANOSECONDS_IN_SECOND as f64;
+            let t = self.active_spills_io_time_ns as f64 / NANOSECONDS_IN_SECOND as f64;
             let io_sec_per_byte = t / b;
 
             let rr = self.active_spills_dp_rr + r * (r / w);
@@ -428,6 +505,28 @@ impl Statistics {
             }
         }
     }
+
+    fn sample_prefetch_score<R: Rng>(&mut self, rng: &mut R) -> f64 {
+        // Take into account how often we've tried to inspect this context and
+        // didn't find anything to prefetch.
+        if self.bandit_prefetch_explore_weight >= EXPLORED_WEIGHT_THRESHOLD {
+            // Bernoulli-Thompson sampling of a probability.
+            let alpha = 1.0 + self.bandit_prefetch_explore_success.max(0.0);
+            let beta = 1.0
+                + (self.bandit_prefetch_explore_weight - self.bandit_prefetch_explore_success)
+                    .max(0.0);
+            let p = rand_distr::Beta::new(alpha, beta).unwrap().sample(rng);
+            if !rng.random_bool(p) {
+                return 0.0;
+            }
+        }
+
+        let weight =
+            self.bandit_non_prefetch_unspill_weight + 0.2 * self.bandit_spilled_drain_weight;
+
+        // Efraimidis-Spirakis weighted random sampling.
+        rng.random::<f64>().powf(1.0 / (1.0 + weight))
+    }
 }
 
 impl Default for Statistics {
@@ -440,9 +539,10 @@ impl Default for Statistics {
             unspill_time: 0.0,
             successful_spills: 0,
             failed_spills: 0,
-            successful_explorations: 0,
-            total_explorations: 0,
-            last_update: Instant::now(),
+            successful_spill_explorations: 0,
+            total_spill_explorations: 0,
+            successful_prefetch_explorations: 0,
+            total_prefetch_explorations: 0,
 
             bandit_weight: 0.0,
             bandit_r_sum: 0.0,
@@ -451,10 +551,13 @@ impl Default for Statistics {
             bandit_tt_sum: 0.0,
             bandit_rt_sum: 0.0,
 
-            bandit_explore_weight: 0.0,
-            bandit_explore_success: 0.0,
+            bandit_spill_explore_weight: 0.0,
+            bandit_spill_explore_success: 0.0,
+            bandit_prefetch_explore_weight: 0.0,
+            bandit_prefetch_explore_success: 0.0,
 
             bandit_non_prefetch_unspill_weight: 0.0,
+            bandit_spilled_drain_weight: 0.0,
 
             active_spills: 0,
             active_spills_io_time_ns: 0,
@@ -464,6 +567,8 @@ impl Default for Statistics {
             active_spills_dp_rr: 0.0,
             active_spills_dp_bb: 0.0,
             active_spills_dp_rb: 0.0,
+
+            last_update: Instant::now(),
         }
     }
 }

--- a/crates/polars-ooc/src/spill_context/stats.rs
+++ b/crates/polars-ooc/src/spill_context/stats.rs
@@ -14,6 +14,7 @@ const UNSPILL_EVENT_HALF_LIFE_SEC: f64 = 5.0;
 const NANOSECONDS_IN_SECOND: f64 = 1e9;
 
 pub struct SpillContextStatistics {
+    prefetch_without_spill_streak: RelaxedCell<u64>,
     score_cache: RelaxedCell<u64>,
     stats: Mutex<Statistics>,
 }
@@ -21,6 +22,7 @@ pub struct SpillContextStatistics {
 impl SpillContextStatistics {
     pub(crate) fn new(name: PlSmallStr) -> Self {
         Self {
+            prefetch_without_spill_streak: RelaxedCell::new_u64(0),
             // TODO: starting score based on context.
             score_cache: RelaxedCell::new_u64(UNEXPLORED_SCORE.to_bits()),
             stats: Mutex::new(Statistics {
@@ -152,6 +154,18 @@ impl SpillContextStatistics {
         let mut stats = self.stats.lock().unwrap();
         stats.successful_explorations += success as u64;
         stats.bandit_explore_success += success as u64 as f64;
+    }
+
+    pub fn add_spill_start(&self) {
+        self.prefetch_without_spill_streak.store(0);
+    }
+
+    pub fn suggested_prefetch_amount(&self) -> u64 {
+        self.prefetch_without_spill_streak.load()
+    }
+
+    pub fn add_prefetch_start(&self) {
+        self.prefetch_without_spill_streak.fetch_add(1);
     }
 
     pub fn add_failed_spill(&self, spill_start: Instant) {

--- a/crates/polars-ooc/src/spill_context/stats.rs
+++ b/crates/polars-ooc/src/spill_context/stats.rs
@@ -161,7 +161,7 @@ impl SpillContextStatistics {
     }
 
     pub fn suggested_prefetch_amount(&self) -> u64 {
-        self.prefetch_without_spill_streak.load()
+        1 + self.prefetch_without_spill_streak.load()
     }
 
     pub fn add_prefetch_start(&self) {

--- a/crates/polars-ooc/src/spill_frame.rs
+++ b/crates/polars-ooc/src/spill_frame.rs
@@ -116,6 +116,10 @@ impl SpillFrame {
         slf
     }
 
+    pub fn current_ctx(&self) -> Option<(WeakSpillContext, SpillContextParam)> {
+        self.token.current_ctx()
+    }
+
     pub fn unregister(&mut self) -> Option<(WeakSpillContext, SpillContextParam)> {
         self.token.unregister()
     }

--- a/crates/polars-ooc/src/spill_token.rs
+++ b/crates/polars-ooc/src/spill_token.rs
@@ -36,7 +36,7 @@ enum ValueSlot<T> {
 enum PinOrLockResult<'a, T: Spillable> {
     Pinned(PinnedRef<'a, T>),
     Locked,
-    Dropped
+    Dropped,
 }
 
 #[derive(Default)]
@@ -222,7 +222,7 @@ impl<T: Spillable> SpillTokenInner<T> {
         match Self::pin_or_lock(slf).await {
             PinOrLockResult::Pinned(p) => return Some(p),
             PinOrLockResult::Dropped => return None,
-            PinOrLockResult::Locked => {}
+            PinOrLockResult::Locked => {},
         }
 
         // We now hold the lock, meaning the value was spilled.
@@ -423,7 +423,7 @@ where
                     state: AtomicU64::new(0),
                     lock: Mutex::default(),
                 };
-            }
+            },
             PinOrLockResult::Dropped => unreachable!(),
             PinOrLockResult::Locked => {},
         }

--- a/crates/polars-ooc/src/spill_token.rs
+++ b/crates/polars-ooc/src/spill_token.rs
@@ -453,6 +453,9 @@ pub(crate) trait DynSpillToken: Send + Sync + 'static {
     /// Register this spill token at a new context, returning the registration ID.
     fn register(self: Arc<Self>, ctx: WeakSpillContext, param: SpillContextParam) -> u32;
 
+    /// Gets the current context this spill token is registered, if any.
+    fn current_ctx(&self) -> Option<(WeakSpillContext, SpillContextParam)>;
+
     /// Unregisters this spill token from its current context, returning where
     /// it was registered, if anywhere.
     fn unregister(&self) -> Option<(WeakSpillContext, SpillContextParam)>;
@@ -515,6 +518,11 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
         let dyn_arc: Arc<dyn DynSpillToken> = self;
         ctx.0.insert(&dyn_arc, reg_id, ctx.1, reason);
         reg_id
+    }
+
+    fn current_ctx(&self) -> Option<(WeakSpillContext, SpillContextParam)> {
+        let lock = self.lock.lock().unwrap();
+        lock.cur_ctx.clone()
     }
 
     fn unregister(&self) -> Option<(WeakSpillContext, SpillContextParam)> {
@@ -722,12 +730,17 @@ impl<T: Spillable> SpillToken<T> {
         let inner: Arc<SpillTokenInner<T>> = self.inner.clone();
         inner
     }
+    
+    /// Gets the current context this spill token is registered, if any.
+    pub fn current_ctx(&self) -> Option<(WeakSpillContext, SpillContextParam)> {
+        self.inner.current_ctx()
+    }
 
     /// Unregisters this spill token from its current context, if any, returning it.
     pub fn unregister(&mut self) -> Option<(WeakSpillContext, SpillContextParam)> {
         self.inner.unregister()
     }
-
+    
     /// Try to get a reference to the underlying value, returning None if it was spilled.
     pub fn try_get(&self) -> Option<PinnedRef<'_, T>> {
         SpillTokenInner::try_pin(&self.inner).ok()

--- a/crates/polars-ooc/src/spill_token.rs
+++ b/crates/polars-ooc/src/spill_token.rs
@@ -1,7 +1,7 @@
 use std::cell::UnsafeCell;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::{Poll, Waker};
 use std::time::Instant;
@@ -10,6 +10,7 @@ use polars_async::ASYNC;
 use polars_utils::UnitVec;
 use polars_utils::with_drop::WithDrop;
 
+use crate::memory_manager::PrefetchInProgressTracker;
 use crate::spill_context::InsertReason;
 use crate::{SpillContextParam, Spillable, WeakSpillContext};
 
@@ -25,12 +26,17 @@ const RO_PIN_MASK: u64 = u64::MAX << 5;
 enum ValueSlot<T> {
     InMemory(T),
     Spilled {
-        n_bytes: usize,
         spill_ctx: WeakSpillContext,
         spill_time_ns: u64,
         spilled_start: Instant,
     },
     Dropped,
+}
+
+enum PinOrLockResult<'a, T: Spillable> {
+    Pinned(PinnedRef<'a, T>),
+    Locked,
+    Dropped
 }
 
 #[derive(Default)]
@@ -47,8 +53,13 @@ struct SpillTokenInner<T: Spillable> {
     // LOCK_BIT and no pins exist.
     value_slot: UnsafeCell<ValueSlot<T>>,
 
-    // May be read+written while holding LOCK_BIT (irrespective of pins).
+    // May be read+written while holding LOCK_BIT, or in try_spill after ensuring it has the only
+    // pin going from 0 -> 1 pins.
     spilled_value: UnsafeCell<Option<T::Spilled>>,
+
+    // Contains a cached estimated byte size, or MAX if unknown. Should always
+    // be and remain known during a spill.
+    est_size: AtomicUsize,
 
     // Lock should not be held for long, only used to register/wake waiters or
     // store current registered context.
@@ -115,6 +126,19 @@ impl<T: Spillable> SpillTokenInner<T> {
         }
     }
 
+    fn cached_est_size(&self) -> Option<usize> {
+        let sz = self.est_size.load(Ordering::Relaxed);
+        if sz < usize::MAX { Some(sz) } else { None }
+    }
+
+    fn calc_est_size(&self, pin: &T) -> usize {
+        self.cached_est_size().unwrap_or_else(|| {
+            let sz = pin.estimate_byte_size();
+            self.est_size.store(sz, Ordering::Relaxed);
+            sz
+        })
+    }
+
     // Try to pin the value, returning Err if it is spilled, locked or dropped.
     fn try_pin(slf: &Arc<Self>) -> Result<PinnedRef<'_, T>, u64> {
         slf.state
@@ -130,7 +154,7 @@ impl<T: Spillable> SpillTokenInner<T> {
     // Pin the value, grabbing the lock if it is spilled.
     //
     // If the value is locked this will wait for the lock.
-    async fn pin_or_lock(slf: &Arc<Self>) -> Option<PinnedRef<'_, T>> {
+    async fn pin_or_lock(slf: &Arc<Self>) -> PinOrLockResult<'_, T> {
         let mut state = slf.state.load(Ordering::Relaxed);
         loop {
             if state & (SPILLED_BIT | LOCK_BIT | DROPPED_BIT) == 0 {
@@ -140,7 +164,7 @@ impl<T: Spillable> SpillTokenInner<T> {
                     Ordering::Acquire,
                     Ordering::Relaxed,
                 ) {
-                    Ok(_) => return Some(PinnedRef { inner: slf }),
+                    Ok(_) => return PinOrLockResult::Pinned(PinnedRef { inner: slf }),
                     Err(s) => state = s,
                 }
             } else if state & (LOCK_BIT | RO_PIN_MASK | DROPPED_BIT) == 0 {
@@ -150,11 +174,12 @@ impl<T: Spillable> SpillTokenInner<T> {
                     Ordering::Acquire,
                     Ordering::Relaxed,
                 ) {
-                    Ok(_) => return None,
+                    Ok(_) => return PinOrLockResult::Locked,
                     Err(s) => state = s,
                 }
+            } else if state & DROPPED_BIT != 0 {
+                return PinOrLockResult::Dropped;
             } else {
-                assert!(state & DROPPED_BIT == 0);
                 state = slf.wait(LOCK_BIT).await;
             }
         }
@@ -186,15 +211,18 @@ impl<T: Spillable> SpillTokenInner<T> {
             return r;
         }
 
-        Self::pin_impl(slf, false).await
+        Self::pin_impl(slf, false).await.unwrap()
     }
 
+    // Returns None iff dropped.
     #[cold]
-    async fn pin_impl(slf: &Arc<Self>, prefetch: bool) -> PinnedRef<'_, T> {
+    async fn pin_impl(slf: &Arc<Self>, prefetch: bool) -> Option<PinnedRef<'_, T>> {
         std::hint::cold_path();
 
-        if let Some(r) = Self::pin_or_lock(slf).await {
-            return r;
+        match Self::pin_or_lock(slf).await {
+            PinOrLockResult::Pinned(p) => return Some(p),
+            PinOrLockResult::Dropped => return None,
+            PinOrLockResult::Locked => {}
         }
 
         // We now hold the lock, meaning the value was spilled.
@@ -214,7 +242,7 @@ impl<T: Spillable> SpillTokenInner<T> {
                 slf.state
                     .fetch_add(RO_PIN_COUNT_UNIT - LOCK_BIT, Ordering::AcqRel),
             );
-            PinnedRef { inner: slf }
+            Some(PinnedRef { inner: slf })
         }
     }
 
@@ -239,8 +267,9 @@ impl<T: Spillable> SpillTokenInner<T> {
                 Self::unspill_while_locked(slf, false).await;
             }
 
-            // Clear the spilled value as we're about to invalidate it through mutable access.
+            // Clear the spilled value and estimated byte size as we're about to invalidate it through mutable access.
             *slf.spilled_value.get() = None;
+            slf.est_size.store(usize::MAX, Ordering::Relaxed);
 
             WithDrop::dismiss(lock_guard);
             PinnedMut { inner: slf }
@@ -274,6 +303,7 @@ impl<T: Spillable> SpillTokenInner<T> {
         }
 
         // Do the unspill.
+        let n_bytes = slf.cached_est_size().unwrap();
         let unspill_start = Instant::now();
         let spilled = unsafe { (*slf.spilled_value.get()).as_ref().unwrap() };
         let value = T::unspill(spilled).await;
@@ -281,7 +311,6 @@ impl<T: Spillable> SpillTokenInner<T> {
         slf.state.fetch_sub(SPILLED_BIT, Ordering::Release);
 
         let ValueSlot::Spilled {
-            n_bytes,
             spill_ctx,
             spill_time_ns,
             spilled_start,
@@ -384,14 +413,19 @@ where
     S: Clone,
 {
     fn clone_impl(slf: &Arc<Self>) -> Self {
-        if let Some(r) = ASYNC.block_in_place_on(Self::pin_or_lock(slf)) {
-            return SpillTokenInner {
-                value_slot: UnsafeCell::new(ValueSlot::InMemory(r.clone())),
-                spilled_value: UnsafeCell::new(None),
-                registration_id: AtomicU32::new(0),
-                state: AtomicU64::new(0),
-                lock: Mutex::default(),
-            };
+        match ASYNC.block_in_place_on(Self::pin_or_lock(slf)) {
+            PinOrLockResult::Pinned(r) => {
+                return SpillTokenInner {
+                    value_slot: UnsafeCell::new(ValueSlot::InMemory(r.clone())),
+                    spilled_value: UnsafeCell::new(None),
+                    est_size: AtomicUsize::new(slf.cached_est_size().unwrap_or(usize::MAX)),
+                    registration_id: AtomicU32::new(0),
+                    state: AtomicU64::new(0),
+                    lock: Mutex::default(),
+                };
+            }
+            PinOrLockResult::Dropped => unreachable!(),
+            PinOrLockResult::Locked => {},
         }
 
         // We now hold the lock, meaning the value was spilled.
@@ -401,7 +435,6 @@ where
             });
 
             let ValueSlot::Spilled {
-                n_bytes,
                 spill_ctx,
                 spill_time_ns: _,
                 spilled_start: _,
@@ -411,24 +444,25 @@ where
             };
 
             // Simulate a spill.
+            let n_bytes = slf.cached_est_size().unwrap();
             let clone_spill_start = Instant::now();
             let spilled_value = (&*lock_guard.spilled_value.get()).as_ref().unwrap().clone();
             let (spill_time_ns, spilled_start) = if let Some(strong) = spill_ctx.upgrade() {
                 strong
                     .stats()
-                    .add_successful_spill(*n_bytes, clone_spill_start)
+                    .add_successful_spill(n_bytes, clone_spill_start)
             } else {
                 // Dummy, context is already dead.
                 (0, Instant::now())
             };
             SpillTokenInner {
                 value_slot: UnsafeCell::new(ValueSlot::Spilled {
-                    n_bytes: *n_bytes,
                     spill_ctx: spill_ctx.clone(),
                     spill_time_ns,
                     spilled_start,
                 }),
                 spilled_value: UnsafeCell::new(Some(spilled_value)),
+                est_size: AtomicUsize::new(n_bytes),
                 registration_id: AtomicU32::new(0),
                 state: AtomicU64::new(SPILLED_BIT),
                 lock: Mutex::default(),
@@ -440,6 +474,7 @@ where
 pub enum TrySpillError {
     AlreadySpilled,
     Pinned,
+    Dropped,
 }
 
 pub enum SpillStatus {
@@ -471,6 +506,11 @@ pub(crate) trait DynSpillToken: Send + Sync + 'static {
     /// Whether this token can be spilled, and if so, its estimated in-memory
     /// size in bytes.
     fn spill_status(self: Arc<Self>) -> SpillStatus;
+
+    /// The estimated size in bytes of this value. May fail if the value is currently locked
+    /// exclusively.
+    #[expect(unused)]
+    fn estimated_byte_size(self: Arc<Self>) -> Option<usize>;
 
     /// Call this exactly once after removing a SpillToken from its context to
     /// re-insert it once it is spillable again.
@@ -505,8 +545,16 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
             .fetch_and(!REINSERT_WHEN_SPILLABLE_BIT, Ordering::Acquire);
 
         // Increment the registration ID to invalidate previous registration.
-        lock.cur_ctx = Some((ctx.clone(), param));
         let reg_id = self.registration_id.fetch_add(1, Ordering::Release) + 1;
+
+        // Set the new current context, and if we were spilled register this as a spilled drain event.
+        if let Some((old_ctx, _param)) = lock.cur_ctx.replace((ctx.clone(), param)) {
+            if state & SPILLED_BIT != 0 {
+                if let Some(strong) = old_ctx.upgrade() {
+                    strong.stats().add_spilled_drain_event();
+                }
+            }
+        }
 
         drop(lock);
 
@@ -559,6 +607,18 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
         }
     }
 
+    fn estimated_byte_size(self: Arc<Self>) -> Option<usize> {
+        // Fast-path without pinning.
+        if let Some(sz) = self.cached_est_size() {
+            return Some(sz);
+        }
+
+        match Self::try_pin(&self) {
+            Ok(p) => Some(self.calc_est_size(&p)),
+            Err(_) => self.cached_est_size(),
+        }
+    }
+
     fn cancel_spill_attempt_and_reinsert(
         self: Arc<Self>,
         reg_id: u32,
@@ -596,8 +656,10 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
     }
 
     fn prefetch(self: Arc<Self>) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+        let tracker = PrefetchInProgressTracker::new(self.cached_est_size().unwrap_or(0) as u64);
         Box::pin(async move {
             Self::pin_impl(&self, true).await;
+            drop(tracker);
         })
     }
 
@@ -605,62 +667,65 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
         self: Arc<Self>,
         stats_ctx: WeakSpillContext,
     ) -> Result<Pin<Box<dyn Future<Output = bool> + Send>>, TrySpillError> {
-        // First, we try setting the lock bit. If anyone else has a pin we don't bother.
-        let pin_update = self
-            .state
+        // First we pin to get the size estimate, and calculate the spilled value. We don't bother if anyone else
+        // has a pin or it's already spilled/dropped.
+        self.state
             .try_update(Ordering::Acquire, Ordering::Relaxed, |state| {
-                if state & (LOCK_BIT | DROPPED_BIT | RO_PIN_MASK) != 0 {
+                if state & (LOCK_BIT | RO_PIN_MASK | DROPPED_BIT | SPILLED_BIT) != 0 {
                     return None;
                 }
-                Some(state | LOCK_BIT)
-            });
+                Some(state + RO_PIN_COUNT_UNIT)
+            })
+            .map_err(|s| {
+                if s & SPILLED_BIT != 0 {
+                    TrySpillError::AlreadySpilled
+                } else if s & DROPPED_BIT != 0 {
+                    TrySpillError::Dropped
+                } else {
+                    TrySpillError::Pinned
+                }
+            })?;
 
-        let Ok(state) = pin_update else {
-            return Err(TrySpillError::Pinned);
-        };
-
-        if state & SPILLED_BIT != 0 {
-            self.wake_waiters(self.state.fetch_sub(LOCK_BIT, Ordering::AcqRel));
-            return Err(TrySpillError::AlreadySpilled);
-        }
+        let owned_pin_guard = WithDrop::new(self, |s| unsafe { SpillTokenInner::unpin(&s) });
 
         if let Some(strong) = stats_ctx.upgrade() {
             strong.stats().add_spill_start()
         }
 
         Ok(Box::pin(async move {
-            let spill_start = Instant::now();
-            let needs_spill = unsafe { (*self.spilled_value.get()).is_none() };
-            let is_exclusive = if needs_spill {
-                // Relax the lock to a pin while spilling such that new pins can
-                // come in. After all, we still have it in memory right now.
-                self.wake_waiters(
-                    self.state
-                        .fetch_add(RO_PIN_COUNT_UNIT - LOCK_BIT, Ordering::AcqRel),
-                );
-                let pin_guard = PinnedRef { inner: &self };
-                let spilled = pin_guard.spill(&stats_ctx.0.stats().name()).await;
-                core::mem::forget(pin_guard);
-                // We can simply re-acquire the lock here blindly, as we still hold
-                // our pin meaning no one else could've gotten the lock.
-                let old_state = self
-                    .state
-                    .fetch_add(LOCK_BIT.wrapping_sub(RO_PIN_COUNT_UNIT), Ordering::Acquire);
-                unsafe {
-                    self.spilled_value.get().write(Some(spilled));
-                }
-                old_state & RO_PIN_MASK == RO_PIN_COUNT_UNIT
-            } else {
-                true
-            };
+            let slf = WithDrop::dismiss(owned_pin_guard);
+            let pin_guard = PinnedRef { inner: &slf };
 
-            let state = if is_exclusive {
-                // We are the only pin and hold the lock meaning no one else can
-                // access value or create new pins.
-                let n_bytes = match unsafe { &*self.value_slot.get() } {
-                    ValueSlot::InMemory(val) => val.estimate_byte_size(),
-                    _ => unreachable!(),
-                };
+            let spill_start = Instant::now();
+
+            // We have exclusive access to spilled_value as we have an exclusive try_spill pin - no other concurrent
+            // try_spill can come here, and any other place we access spilled_value is behind LOCK_BIT or DROPPED_BIT.
+            unsafe {
+                if (*slf.spilled_value.get()).is_none() {
+                    let spilled = pin_guard.spill(&stats_ctx.0.stats().name()).await;
+                    slf.spilled_value.get().write(Some(spilled));
+                }
+            }
+
+            // Calculate size before exclusive lock to ensure `estimate_byte_size` does not spuriously return None.
+            let n_bytes = slf.calc_est_size(&pin_guard);
+
+            // Try to upgrade solo pin into exclusive lock.
+            let is_exclusive = slf
+                .state
+                .try_update(Ordering::Acquire, Ordering::Acquire, |s| {
+                    if s & (RO_PIN_MASK | LOCK_BIT) == RO_PIN_COUNT_UNIT {
+                        Some(s - RO_PIN_COUNT_UNIT + LOCK_BIT)
+                    } else {
+                        None
+                    }
+                })
+                .is_ok();
+
+            if is_exclusive {
+                core::mem::forget(pin_guard);
+
+                // We hold the lock meaning no one else can access value or create new pins.
                 let (spill_time_ns, spilled_start) = if let Some(strong) = stats_ctx.upgrade() {
                     strong.stats().add_successful_spill(n_bytes, spill_start)
                 } else {
@@ -669,8 +734,7 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
                 };
 
                 unsafe {
-                    self.value_slot.get().replace(ValueSlot::Spilled {
-                        n_bytes,
+                    slf.value_slot.get().replace(ValueSlot::Spilled {
                         spill_ctx: stats_ctx.clone(),
                         spill_time_ns,
                         spilled_start,
@@ -680,27 +744,25 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
                 // Insert as spilled in the *current* context, not the context for statistics.
                 // Marking as spilled and reading the registration must happen under the same lock,
                 // so a concurrent register either observes us as spilled or invalidates our insert.
-                let lock = self.lock.lock().unwrap();
-                let state = self
+                let lock = slf.lock.lock().unwrap();
+                let state = slf
                     .state
                     .fetch_add(SPILLED_BIT.wrapping_sub(LOCK_BIT), Ordering::AcqRel);
                 let cur_ctx = lock.cur_ctx.clone();
-                let reg_id = self.registration_id.load(Ordering::Relaxed);
+                let reg_id = slf.registration_id.load(Ordering::Relaxed);
+
                 drop(lock);
+                slf.wake_waiters(state);
 
                 if let Some((ctx, _param)) = cur_ctx {
-                    let dyn_slf: Arc<dyn DynSpillToken> = self.clone();
+                    let dyn_slf: Arc<dyn DynSpillToken> = slf.clone();
                     ctx.0.insert(&dyn_slf, reg_id, ctx.1, InsertReason::Spill);
                 }
-
-                state
             } else {
                 if let Some(strong) = stats_ctx.upgrade() {
                     strong.stats().add_failed_spill(spill_start);
                 }
-                self.state.fetch_sub(LOCK_BIT, Ordering::AcqRel)
-            };
-            self.wake_waiters(state);
+            }
 
             is_exclusive
         }))
@@ -718,6 +780,7 @@ impl<T: Spillable> SpillToken<T> {
         let inner = Arc::new(SpillTokenInner {
             value_slot: UnsafeCell::new(ValueSlot::InMemory(value)),
             spilled_value: UnsafeCell::new(None),
+            est_size: AtomicUsize::new(usize::MAX),
             registration_id: AtomicU32::new(0),
             state: AtomicU64::new(0),
             lock: Mutex::default(),
@@ -730,7 +793,7 @@ impl<T: Spillable> SpillToken<T> {
         let inner: Arc<SpillTokenInner<T>> = self.inner.clone();
         inner
     }
-    
+
     /// Gets the current context this spill token is registered, if any.
     pub fn current_ctx(&self) -> Option<(WeakSpillContext, SpillContextParam)> {
         self.inner.current_ctx()
@@ -740,7 +803,7 @@ impl<T: Spillable> SpillToken<T> {
     pub fn unregister(&mut self) -> Option<(WeakSpillContext, SpillContextParam)> {
         self.inner.unregister()
     }
-    
+
     /// Try to get a reference to the underlying value, returning None if it was spilled.
     pub fn try_get(&self) -> Option<PinnedRef<'_, T>> {
         SpillTokenInner::try_pin(&self.inner).ok()

--- a/crates/polars-ooc/src/spill_token.rs
+++ b/crates/polars-ooc/src/spill_token.rs
@@ -256,12 +256,29 @@ impl<T: Spillable> SpillTokenInner<T> {
     async unsafe fn unspill_while_locked(slf: &Arc<Self>, prefetch: bool) {
         debug_assert!(slf.state.load(Ordering::Relaxed) & SPILLED_BIT == SPILLED_BIT);
 
+        // First, before anything else, we invalidate previous entries in our
+        // bookkeeping, and ensure we reinsert when this pin ends. We hold the
+        // lock to not race with calls to register().
+        let cur_ctx = {
+            let lock = slf.lock.lock().unwrap();
+            slf.registration_id.fetch_add(1, Ordering::Release);
+            slf.state
+                .fetch_or(REINSERT_WHEN_SPILLABLE_BIT, Ordering::Release);
+            lock.cur_ctx.clone()
+        };
+
+        // Now that we have invalidated ourselves from the bookkeeping we can
+        // fire off a prefetch request to our context if possible.
+        if let Some((ctx, _param)) = cur_ctx {
+            ctx.0.schedule_prefetch(ctx.1);
+        }
+
         // Do the unspill.
         let unspill_start = Instant::now();
         let spilled = unsafe { (*slf.spilled_value.get()).as_ref().unwrap() };
         let value = T::unspill(spilled).await;
         let old_slot = unsafe { slf.value_slot.get().replace(ValueSlot::InMemory(value)) };
-        slf.state.fetch_sub(SPILLED_BIT, Ordering::Relaxed);
+        slf.state.fetch_sub(SPILLED_BIT, Ordering::Release);
 
         let ValueSlot::Spilled {
             n_bytes,
@@ -283,13 +300,6 @@ impl<T: Spillable> SpillTokenInner<T> {
                 prefetch,
             );
         }
-
-        // Invalidate previous entries in our bookkeeping, and ensure we reinsert when this pin ends.
-        // We hold the lock to not race with calls to register().
-        let _lock = slf.lock.lock().unwrap();
-        slf.registration_id.fetch_add(1, Ordering::Release);
-        slf.state
-            .fetch_or(REINSERT_WHEN_SPILLABLE_BIT, Ordering::Release);
     }
 
     /// # Safety
@@ -468,6 +478,9 @@ pub(crate) trait DynSpillToken: Send + Sync + 'static {
         reason: InsertReason,
     );
 
+    /// Loads this SpillToken from disk, if it is.
+    fn prefetch(self: Arc<Self>) -> Pin<Box<dyn Future<Output = ()> + Send>>;
+
     /// Tries to spill this token. Returns true if successful.
     ///
     /// May return Err if the token is already spilled, or is currently pinned.
@@ -574,6 +587,12 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
         }
     }
 
+    fn prefetch(self: Arc<Self>) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+        Box::pin(async move {
+            Self::pin_impl(&self, true).await;
+        })
+    }
+
     fn try_spill(
         self: Arc<Self>,
         stats_ctx: WeakSpillContext,
@@ -595,6 +614,10 @@ impl<T: Spillable> DynSpillToken for SpillTokenInner<T> {
         if state & SPILLED_BIT != 0 {
             self.wake_waiters(self.state.fetch_sub(LOCK_BIT, Ordering::AcqRel));
             return Err(TrySpillError::AlreadySpilled);
+        }
+
+        if let Some(strong) = stats_ctx.upgrade() {
+            strong.stats().add_spill_start()
         }
 
         Ok(Box::pin(async move {

--- a/crates/polars-stream/src/morsel.rs
+++ b/crates/polars-stream/src/morsel.rs
@@ -182,12 +182,12 @@ impl Morsel {
 
     pub async fn map<F: FnOnce(DataFrame) -> DataFrame>(self, f: F) -> Self {
         let Self {
-            mut sf,
+            sf,
             seq,
             source_token,
             consume_token,
         } = self;
-        let old_registry = sf.unregister();
+        let old_registry = sf.current_ctx();
         let df = f(sf.into_df().await);
         let sf = SpillFrame::new_unregistered(df);
         if let Some((ctx, param)) = old_registry {
@@ -206,12 +206,12 @@ impl Morsel {
         f: F,
     ) -> Result<Self, E> {
         let Self {
-            mut sf,
+            sf,
             seq,
             source_token,
             consume_token,
         } = self;
-        let old_registry = sf.unregister();
+        let old_registry = sf.current_ctx();
         let df = f(sf.into_df().await)?;
         let sf = SpillFrame::new_unregistered(df);
         if let Some((ctx, param)) = old_registry {
@@ -231,12 +231,12 @@ impl Morsel {
         F: Future<Output = Result<DataFrame, E>>,
     {
         let Self {
-            mut sf,
+            sf,
             seq,
             source_token,
             consume_token,
         } = self;
-        let old_registry = sf.unregister();
+        let old_registry = sf.current_ctx();
         let df = f(sf.into_df().await).await?;
         let sf = SpillFrame::new_unregistered(df);
         if let Some((ctx, param)) = old_registry {


### PR DESCRIPTION
This adds prefetching to the out-of-core support, drastically improving performance. If memory usage goes below `OOC_MEMORY_PREFETCH_FRACTION` (default 0.9) of the specified memory budget, we start reading stuff back in from disk.