### PR TITLE
refactor(rust): Reduce code monomorphization in asof_join

### DIFF
--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -101,18 +101,14 @@ where
     let split_by_right = split_and_flatten(by_right, n_threads);
     let offsets = compute_len_offsets(split_by_left.iter().map(|s| s.len()));
 
-    let right_slices = split_by_right
+    let right_arrays = split_by_right
         .iter()
         .map(|ca| {
             assert_eq!(ca.chunks().len(), 1);
-            ca.downcast_iter()
-                .next()
-                .unwrap()
-                .iter()
-                .map(|v| v.copied())
+            ca.downcast_iter().next().unwrap()
         })
-        .collect();
-    let hash_tbls = build_tables(right_slices, false);
+        .collect::<Vec<_>>();
+    let hash_tbls = build_tables_from_arrays::<S>(&right_arrays, false);
     let n_tables = hash_tbls.len();
 
     // Now we probe the right hand side for each left hand side.

--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -17,6 +17,12 @@ use rayon::prelude::*;
 use super::*;
 use crate::frame::join::{prepare_binary, prepare_keys_multiple};
 
+/// Reduces monomorphization: the rayon plumbing is instantiated once per `R`
+/// rather than once per closure.
+fn par_map_collect<R: Send>(n: usize, f: &(dyn Fn(usize) -> R + Sync)) -> Vec<R> {
+    RAYON.install(|| (0..n).into_par_iter().map(f).collect())
+}
+
 fn compute_len_offsets<I: IntoIterator<Item = usize>>(iter: I) -> Vec<usize> {
     let mut cumlen = 0;
     iter.into_iter()
@@ -112,10 +118,11 @@ where
     let n_tables = hash_tbls.len();
 
     // Now we probe the right hand side for each left hand side.
-    let out = split_by_left
-        .into_par_iter()
-        .zip(offsets)
-        .map(|(by_left, offset)| {
+    let parts = split_by_left.into_iter().zip(offsets).collect::<Vec<_>>();
+    let bufs = par_map_collect(parts.len(), &|part_idx| {
+        let (by_left, offset) = &parts[part_idx];
+        let offset = *offset;
+        {
             let mut results = Vec::with_capacity(by_left.len());
             let mut group_states: PlHashMap<IdxSize, A> =
                 PlHashMap::with_capacity(_HASHMAP_INIT_SIZE);
@@ -152,9 +159,8 @@ where
                 results.push(materialize_nullable(id));
             }
             results
-        });
-
-    let bufs = RAYON.install(|| out.collect::<Vec<_>>());
+        }
+    });
     Ok(flatten_nullable(&bufs))
 }
 
@@ -183,10 +189,11 @@ where
     let n_tables = hash_tbls.len();
 
     // Now we probe the right hand side for each left hand side.
-    let iter = prep_by_left
-        .into_par_iter()
-        .zip(offsets)
-        .map(|(by_left, offset)| {
+    let parts = prep_by_left.into_iter().zip(offsets).collect::<Vec<_>>();
+    let bufs = par_map_collect(parts.len(), &|part_idx| {
+        let (by_left, offset) = &parts[part_idx];
+        let offset = *offset;
+        {
             let mut results = Vec::with_capacity(by_left.len());
             let mut group_states: PlHashMap<_, A> = PlHashMap::with_capacity(_HASHMAP_INIT_SIZE);
 
@@ -216,8 +223,8 @@ where
                 results.push(materialize_nullable(id));
             }
             results
-        });
-    let bufs = RAYON.install(|| iter.collect::<Vec<_>>());
+        }
+    });
     flatten_nullable(&bufs)
 }
 

--- a/crates/polars-ops/src/frame/join/asof/mod.rs
+++ b/crates/polars-ops/src/frame/join/asof/mod.rs
@@ -11,7 +11,7 @@ use polars_utils::total_ord::TotalOrd;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use super::{_finish_join, build_tables};
+use super::{_finish_join, build_tables, build_tables_from_arrays};
 use crate::frame::IntoDf;
 use crate::series::SeriesMethods;
 

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys.rs
@@ -166,6 +166,24 @@ where
     })
 }
 
+/// Reduces monomorphization: keeps `build_tables` instantiated once per key type.
+pub(crate) fn build_tables_from_arrays<T>(
+    arrays: &[&T::Array],
+    nulls_equal: bool,
+) -> Vec<PlHashMap<<Option<T::Native> as ToTotalOrd>::TotalOrdItem, IdxVec>>
+where
+    T: PolarsNumericType,
+    Option<T::Native>: TotalHash + TotalEq + ToTotalOrd,
+    <Option<T::Native> as ToTotalOrd>::TotalOrdItem:
+        Send + Sync + Copy + Hash + Eq + DirtyHash + IsNull,
+{
+    let keys = arrays
+        .iter()
+        .map(|arr| arr.iter().map(|v| v.copied()))
+        .collect();
+    build_tables(keys, nulls_equal)
+}
+
 // we determine the offset so that we later know which index to store in the join tuples
 pub(super) fn probe_to_offsets<T, I>(probe: &[I]) -> Vec<usize>
 where


### PR DESCRIPTION
Identified the bottleneck using Claude Opus 5. Dropped clean-build compile time from 2m58s -> 2m15s.