### PR TITLE
refactor(rust): Reduce code monomorphization in eager joins

### DIFF
--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -101,18 +101,14 @@ where
     let split_by_right = split_and_flatten(by_right, n_threads);
     let offsets = compute_len_offsets(split_by_left.iter().map(|s| s.len()));
 
-    let right_slices = split_by_right
+    let right_arrays = split_by_right
         .iter()
         .map(|ca| {
             assert_eq!(ca.chunks().len(), 1);
-            ca.downcast_iter()
-                .next()
-                .unwrap()
-                .iter()
-                .map(|v| v.copied())
+            ca.downcast_iter().next().unwrap()
         })
-        .collect();
-    let hash_tbls = build_tables(right_slices, false);
+        .collect::<Vec<_>>();
+    let hash_tbls = build_tables_from_arrays::<S>(&right_arrays, false);
     let n_tables = hash_tbls.len();
 
     // Now we probe the right hand side for each left hand side.

--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -17,6 +17,12 @@ use rayon::prelude::*;
 use super::*;
 use crate::frame::join::{prepare_binary, prepare_keys_multiple};
 
+/// Reduces monomorphization: the rayon plumbing is instantiated once per `R`
+/// rather than once per closure.
+fn par_map_collect<R: Send>(n: usize, f: &(dyn Fn(usize) -> R + Sync)) -> Vec<R> {
+    RAYON.install(|| (0..n).into_par_iter().map(f).collect())
+}
+
 fn compute_len_offsets<I: IntoIterator<Item = usize>>(iter: I) -> Vec<usize> {
     let mut cumlen = 0;
     iter.into_iter()
@@ -112,10 +118,11 @@ where
     let n_tables = hash_tbls.len();
 
     // Now we probe the right hand side for each left hand side.
-    let out = split_by_left
-        .into_par_iter()
-        .zip(offsets)
-        .map(|(by_left, offset)| {
+    let parts = split_by_left.into_iter().zip(offsets).collect::<Vec<_>>();
+    let bufs = par_map_collect(parts.len(), &|part_idx| {
+        let (by_left, offset) = &parts[part_idx];
+        let offset = *offset;
+        {
             let mut results = Vec::with_capacity(by_left.len());
             let mut group_states: PlHashMap<IdxSize, A> =
                 PlHashMap::with_capacity(_HASHMAP_INIT_SIZE);
@@ -152,9 +159,8 @@ where
                 results.push(materialize_nullable(id));
             }
             results
-        });
-
-    let bufs = RAYON.install(|| out.collect::<Vec<_>>());
+        }
+    });
     Ok(flatten_nullable(&bufs))
 }
 
@@ -183,10 +189,11 @@ where
     let n_tables = hash_tbls.len();
 
     // Now we probe the right hand side for each left hand side.
-    let iter = prep_by_left
-        .into_par_iter()
-        .zip(offsets)
-        .map(|(by_left, offset)| {
+    let parts = prep_by_left.into_iter().zip(offsets).collect::<Vec<_>>();
+    let bufs = par_map_collect(parts.len(), &|part_idx| {
+        let (by_left, offset) = &parts[part_idx];
+        let offset = *offset;
+        {
             let mut results = Vec::with_capacity(by_left.len());
             let mut group_states: PlHashMap<_, A> = PlHashMap::with_capacity(_HASHMAP_INIT_SIZE);
 
@@ -216,8 +223,8 @@ where
                 results.push(materialize_nullable(id));
             }
             results
-        });
-    let bufs = RAYON.install(|| iter.collect::<Vec<_>>());
+        }
+    });
     flatten_nullable(&bufs)
 }
 

--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -12,7 +12,6 @@ use polars_utils::abs_diff::AbsDiff;
 use polars_utils::hashing::{DirtyHash, hash_to_partition};
 use polars_utils::nulls::IsNull;
 use polars_utils::total_ord::{ToTotalOrd, TotalEq, TotalHash};
-use rayon::prelude::*;
 
 use super::*;
 use crate::frame::join::{prepare_binary, prepare_keys_multiple};

--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -111,48 +111,44 @@ where
     let n_tables = hash_tbls.len();
 
     // Now we probe the right hand side for each left hand side.
-    let parts = split_by_left.into_iter().zip(offsets).collect::<Vec<_>>();
-    let bufs = par_map_collect(parts.len(), &|part_idx| {
-        let (by_left, offset) = &parts[part_idx];
-        let offset = *offset;
-        {
-            let mut results = Vec::with_capacity(by_left.len());
-            let mut group_states: PlHashMap<IdxSize, A> =
-                PlHashMap::with_capacity(_HASHMAP_INIT_SIZE);
+    let bufs = par_map_collect(split_by_left.len(), &|part_idx| {
+        let by_left = &split_by_left[part_idx];
+        let offset = offsets[part_idx];
+        let mut results = Vec::with_capacity(by_left.len());
+        let mut group_states: PlHashMap<IdxSize, A> = PlHashMap::with_capacity(_HASHMAP_INIT_SIZE);
 
-            assert_eq!(by_left.chunks().len(), 1);
-            let by_left_chunk = by_left.downcast_iter().next().unwrap();
-            for (rel_idx_left, opt_by_left_k) in by_left_chunk.iter().enumerate() {
-                let Some(by_left_k) = opt_by_left_k else {
-                    results.push(NullableIdxSize::null());
-                    continue;
-                };
-                let by_left_k = Some(*by_left_k).to_total_ord();
-                let idx_left = (rel_idx_left + offset) as IdxSize;
-                let Some(left_val) = left_val_arr.get(idx_left as usize) else {
-                    results.push(NullableIdxSize::null());
-                    continue;
-                };
+        assert_eq!(by_left.chunks().len(), 1);
+        let by_left_chunk = by_left.downcast_iter().next().unwrap();
+        for (rel_idx_left, opt_by_left_k) in by_left_chunk.iter().enumerate() {
+            let Some(by_left_k) = opt_by_left_k else {
+                results.push(NullableIdxSize::null());
+                continue;
+            };
+            let by_left_k = Some(*by_left_k).to_total_ord();
+            let idx_left = (rel_idx_left + offset) as IdxSize;
+            let Some(left_val) = left_val_arr.get(idx_left as usize) else {
+                results.push(NullableIdxSize::null());
+                continue;
+            };
 
-                let group_probe_table = unsafe {
-                    hash_tbls.get_unchecked(hash_to_partition(by_left_k.dirty_hash(), n_tables))
-                };
-                let Some(right_grp_idxs) = group_probe_table.get(&by_left_k) else {
-                    results.push(NullableIdxSize::null());
-                    continue;
-                };
-                let id = asof_in_group::<T, A, &F>(
-                    left_val,
-                    right_val_arr,
-                    right_grp_idxs.as_slice(),
-                    &mut group_states,
-                    &filter,
-                    allow_eq,
-                );
-                results.push(materialize_nullable(id));
-            }
-            results
+            let group_probe_table = unsafe {
+                hash_tbls.get_unchecked(hash_to_partition(by_left_k.dirty_hash(), n_tables))
+            };
+            let Some(right_grp_idxs) = group_probe_table.get(&by_left_k) else {
+                results.push(NullableIdxSize::null());
+                continue;
+            };
+            let id = asof_in_group::<T, A, &F>(
+                left_val,
+                right_val_arr,
+                right_grp_idxs.as_slice(),
+                &mut group_states,
+                &filter,
+                allow_eq,
+            );
+            results.push(materialize_nullable(id));
         }
+        results
     });
     Ok(flatten_nullable(&bufs))
 }
@@ -182,41 +178,38 @@ where
     let n_tables = hash_tbls.len();
 
     // Now we probe the right hand side for each left hand side.
-    let parts = prep_by_left.into_iter().zip(offsets).collect::<Vec<_>>();
-    let bufs = par_map_collect(parts.len(), &|part_idx| {
-        let (by_left, offset) = &parts[part_idx];
-        let offset = *offset;
-        {
-            let mut results = Vec::with_capacity(by_left.len());
-            let mut group_states: PlHashMap<_, A> = PlHashMap::with_capacity(_HASHMAP_INIT_SIZE);
+    let bufs = par_map_collect(prep_by_left.len(), &|part_idx| {
+        let by_left = &prep_by_left[part_idx];
+        let offset = offsets[part_idx];
+        let mut results = Vec::with_capacity(by_left.len());
+        let mut group_states: PlHashMap<_, A> = PlHashMap::with_capacity(_HASHMAP_INIT_SIZE);
 
-            for (rel_idx_left, by_left_k) in by_left.iter().enumerate() {
-                let idx_left = (rel_idx_left + offset) as IdxSize;
-                let Some(left_val) = left_val_arr.get(idx_left as usize) else {
-                    results.push(NullableIdxSize::null());
-                    continue;
-                };
+        for (rel_idx_left, by_left_k) in by_left.iter().enumerate() {
+            let idx_left = (rel_idx_left + offset) as IdxSize;
+            let Some(left_val) = left_val_arr.get(idx_left as usize) else {
+                results.push(NullableIdxSize::null());
+                continue;
+            };
 
-                let group_probe_table = unsafe {
-                    hash_tbls.get_unchecked(hash_to_partition(by_left_k.dirty_hash(), n_tables))
-                };
-                let Some(right_grp_idxs) = group_probe_table.get(by_left_k) else {
-                    results.push(NullableIdxSize::null());
-                    continue;
-                };
-                let id = asof_in_group::<T, A, &F>(
-                    left_val,
-                    right_val_arr,
-                    right_grp_idxs.as_slice(),
-                    &mut group_states,
-                    &filter,
-                    allow_eq,
-                );
+            let group_probe_table = unsafe {
+                hash_tbls.get_unchecked(hash_to_partition(by_left_k.dirty_hash(), n_tables))
+            };
+            let Some(right_grp_idxs) = group_probe_table.get(by_left_k) else {
+                results.push(NullableIdxSize::null());
+                continue;
+            };
+            let id = asof_in_group::<T, A, &F>(
+                left_val,
+                right_val_arr,
+                right_grp_idxs.as_slice(),
+                &mut group_states,
+                &filter,
+                allow_eq,
+            );
 
-                results.push(materialize_nullable(id));
-            }
-            results
+            results.push(materialize_nullable(id));
         }
+        results
     });
     flatten_nullable(&bufs)
 }

--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -17,12 +17,6 @@ use rayon::prelude::*;
 use super::*;
 use crate::frame::join::{prepare_binary, prepare_keys_multiple};
 
-/// Reduces monomorphization: the rayon plumbing is instantiated once per `R`
-/// rather than once per closure.
-fn par_map_collect<R: Send>(n: usize, f: &(dyn Fn(usize) -> R + Sync)) -> Vec<R> {
-    RAYON.install(|| (0..n).into_par_iter().map(f).collect())
-}
-
 fn compute_len_offsets<I: IntoIterator<Item = usize>>(iter: I) -> Vec<usize> {
     let mut cumlen = 0;
     iter.into_iter()

--- a/crates/polars-ops/src/frame/join/asof/mod.rs
+++ b/crates/polars-ops/src/frame/join/asof/mod.rs
@@ -11,7 +11,7 @@ use polars_utils::total_ord::TotalOrd;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use super::{_finish_join, build_tables, build_tables_from_arrays};
+use super::{_finish_join, build_tables, build_tables_from_arrays, par_map_collect};
 use crate::frame::IntoDf;
 use crate::series::SeriesMethods;
 

--- a/crates/polars-ops/src/frame/join/asof/mod.rs
+++ b/crates/polars-ops/src/frame/join/asof/mod.rs
@@ -11,7 +11,7 @@ use polars_utils::total_ord::TotalOrd;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use super::{_finish_join, build_tables};
+use super::{_finish_join, build_tables, build_tables_from_arrays};
 use crate::frame::IntoDf;
 use crate::series::SeriesMethods;
 

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys.rs
@@ -166,6 +166,24 @@ where
     })
 }
 
+/// Reduces monomorphization: keeps `build_tables` instantiated once per key type.
+pub(crate) fn build_tables_from_arrays<T>(
+    arrays: &[&T::Array],
+    nulls_equal: bool,
+) -> Vec<PlHashMap<<Option<T::Native> as ToTotalOrd>::TotalOrdItem, IdxVec>>
+where
+    T: PolarsNumericType,
+    Option<T::Native>: TotalHash + TotalEq + ToTotalOrd,
+    <Option<T::Native> as ToTotalOrd>::TotalOrdItem:
+        Send + Sync + Copy + Hash + Eq + DirtyHash + IsNull,
+{
+    let keys = arrays
+        .iter()
+        .map(|arr| arr.iter().map(|v| v.copied()))
+        .collect();
+    build_tables(keys, nulls_equal)
+}
+
 // we determine the offset so that we later know which index to store in the join tuples
 pub(super) fn probe_to_offsets<T, I>(probe: &[I]) -> Vec<usize>
 where

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_outer.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_outer.rs
@@ -51,47 +51,43 @@ where
     // We use the hash to partition the keys to the matching hashtable.
     // Every thread traverses all keys/hashes and ignores the ones that doesn't fall in that partition.
     par_map_collect(n_partitions, &|partition_no| {
-        {
-            {
-                let hashes_and_keys = &hashes_and_keys;
-                let mut hash_tbl: PlHashMap<T::TotalOrdItem, (bool, IdxVec)> =
-                    PlHashMap::with_hasher(build_hasher.clone());
+        let hashes_and_keys = &hashes_and_keys;
+        let mut hash_tbl: PlHashMap<T::TotalOrdItem, (bool, IdxVec)> =
+            PlHashMap::with_hasher(build_hasher.clone());
 
-                let mut offset = 0;
-                for hashes_and_keys in hashes_and_keys {
-                    let len = hashes_and_keys.len();
-                    hashes_and_keys
-                        .iter()
-                        .enumerate()
-                        .for_each(|(idx, (h, k))| {
-                            let k = k.to_total_ord();
-                            let idx = idx as IdxSize;
-                            // partition hashes by thread no.
-                            // So only a part of the hashes go to this hashmap
-                            if partition_no == hash_to_partition(*h, n_partitions) {
-                                let idx = idx + offset;
-                                let entry = hash_tbl
-                                    .raw_entry_mut()
-                                    // uses the key to check equality to find and entry
-                                    .from_key_hashed_nocheck(*h, &k);
+        let mut offset = 0;
+        for hashes_and_keys in hashes_and_keys {
+            let len = hashes_and_keys.len();
+            hashes_and_keys
+                .iter()
+                .enumerate()
+                .for_each(|(idx, (h, k))| {
+                    let k = k.to_total_ord();
+                    let idx = idx as IdxSize;
+                    // partition hashes by thread no.
+                    // So only a part of the hashes go to this hashmap
+                    if partition_no == hash_to_partition(*h, n_partitions) {
+                        let idx = idx + offset;
+                        let entry = hash_tbl
+                            .raw_entry_mut()
+                            // uses the key to check equality to find and entry
+                            .from_key_hashed_nocheck(*h, &k);
 
-                                match entry {
-                                    RawEntryMut::Vacant(entry) => {
-                                        entry.insert_hashed_nocheck(*h, k, (false, unitvec![idx]));
-                                    },
-                                    RawEntryMut::Occupied(mut entry) => {
-                                        let (_k, v) = entry.get_key_value_mut();
-                                        v.1.push(idx);
-                                    },
-                                }
-                            }
-                        });
+                        match entry {
+                            RawEntryMut::Vacant(entry) => {
+                                entry.insert_hashed_nocheck(*h, k, (false, unitvec![idx]));
+                            },
+                            RawEntryMut::Occupied(mut entry) => {
+                                let (_k, v) = entry.get_key_value_mut();
+                                v.1.push(idx);
+                            },
+                        }
+                    }
+                });
 
-                    offset += len as IdxSize;
-                }
-                hash_tbl
-            }
+            offset += len as IdxSize;
         }
+        hash_tbl
     })
 }
 

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_outer.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_outer.rs
@@ -50,10 +50,9 @@ where
     // We will create a hashtable in every thread.
     // We use the hash to partition the keys to the matching hashtable.
     // Every thread traverses all keys/hashes and ignores the ones that doesn't fall in that partition.
-    RAYON.install(|| {
-        (0..n_partitions)
-            .into_par_iter()
-            .map(|partition_no| {
+    par_map_collect(n_partitions, &|partition_no| {
+        {
+            {
                 let hashes_and_keys = &hashes_and_keys;
                 let mut hash_tbl: PlHashMap<T::TotalOrdItem, (bool, IdxVec)> =
                     PlHashMap::with_hasher(build_hasher.clone());
@@ -91,8 +90,8 @@ where
                     offset += len as IdxSize;
                 }
                 hash_tbl
-            })
-            .collect()
+            }
+        }
     })
 }
 

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_semi_anti.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_semi_anti.rs
@@ -1,3 +1,4 @@
+use polars_core::utils::flatten::flatten_par;
 use polars_utils::hashing::{DirtyHash, hash_to_partition};
 use polars_utils::nulls::IsNull;
 use polars_utils::total_ord::{ToTotalOrd, TotalEq, TotalHash};
@@ -19,7 +20,7 @@ where
     // We will create a hashtable in every thread.
     // We use the hash to partition the keys to the matching hashtable.
     // Every thread traverses all keys/hashes and ignores the ones that doesn't fall in that partition.
-    let par_iter = (0..n_partitions).into_par_iter().map(|partition_no| {
+    par_map_collect(n_partitions, &|partition_no| {
         let mut hash_tbl: PlHashSet<T::TotalOrdItem> = PlHashSet::with_capacity(_HASHMAP_INIT_SIZE);
         for keys in &keys {
             keys.into_iter().for_each(|k| {
@@ -32,17 +33,18 @@ where
             });
         }
         hash_tbl
-    });
-    RAYON.install(|| par_iter.collect())
+    })
 }
 
-/// Construct a ParallelIterator, but doesn't iterate it. This means the caller
-/// context (or wherever it gets iterated) should be in POOL.install.
+/// Per-partition probe indices whose match status equals `keep_matches`
+/// (`true` = semi, `false` = anti). Returns `Vec<Vec<IdxSize>>` rather than a
+/// `ParallelIterator` so the rayon plumbing isn't monomorphized per `T`/`I`.
 fn semi_anti_impl<T, I>(
     probe: Vec<I>,
     build: Vec<I>,
     nulls_equal: bool,
-) -> impl ParallelIterator<Item = (IdxSize, bool)>
+    keep_matches: bool,
+) -> Vec<Vec<IdxSize>>
 where
     I: IntoIterator<Item = T> + Copy + Send + Sync,
     T: TotalHash + TotalEq + DirtyHash + ToTotalOrd,
@@ -57,39 +59,27 @@ where
     let n_tables = hash_sets.len();
 
     // next we probe the other relation
-    // This is not wrapped in POOL.install because it is not being iterated here
-    probe
-        .into_par_iter()
-        .zip(offsets)
-        // probes_hashes: Vec<u64> processed by this thread
-        // offset: offset index
-        .flat_map(move |(probe, offset)| {
-            // local reference
-            let hash_sets = &hash_sets;
-            let probe_iter = probe.into_iter();
+    par_map_collect(probe.len(), &|i| {
+        let probe_iter = probe[i].into_iter();
+        let offset = offsets[i];
 
-            // assume the result tuples equal length of the no. of hashes processed by this thread.
-            let mut results = Vec::with_capacity(probe_iter.size_hint().1.unwrap());
+        // assume the result tuples equal length of the no. of hashes processed by this thread.
+        let mut results = Vec::with_capacity(probe_iter.size_hint().1.unwrap());
 
-            probe_iter.enumerate().for_each(|(idx_a, k)| {
-                let k = k.to_total_ord();
-                let idx_a = (idx_a + offset) as IdxSize;
-                // probe table that contains the hashed value
-                let current_probe_table =
-                    unsafe { hash_sets.get_unchecked(hash_to_partition(k.dirty_hash(), n_tables)) };
+        probe_iter.enumerate().for_each(|(idx_a, k)| {
+            let k = k.to_total_ord();
+            let idx_a = (idx_a + offset) as IdxSize;
+            // probe table that contains the hashed value
+            let current_probe_table =
+                unsafe { hash_sets.get_unchecked(hash_to_partition(k.dirty_hash(), n_tables)) };
 
-                // we already hashed, so we don't have to hash again.
-                let value = current_probe_table.get(&k);
-
-                match value {
-                    // left and right matches
-                    Some(_) => results.push((idx_a, true)),
-                    // only left values, right = null
-                    None => results.push((idx_a, false)),
-                }
-            });
-            results
-        })
+            // we already hashed, so we don't have to hash again.
+            if current_probe_table.get(&k).is_some() == keep_matches {
+                results.push(idx_a);
+            }
+        });
+        results
+    })
 }
 
 pub(super) fn hash_join_tuples_left_anti<T, I>(
@@ -102,10 +92,8 @@ where
     T: TotalHash + TotalEq + DirtyHash + ToTotalOrd,
     <T as ToTotalOrd>::TotalOrdItem: Send + Sync + Hash + Eq + DirtyHash + IsNull,
 {
-    let par_iter = semi_anti_impl(probe, build, nulls_equal)
-        .filter(|tpls| !tpls.1)
-        .map(|tpls| tpls.0);
-    RAYON.install(|| par_iter.collect())
+    let parts = semi_anti_impl(probe, build, nulls_equal, false);
+    flatten_par(&parts)
 }
 
 pub(super) fn hash_join_tuples_left_semi<T, I>(
@@ -118,8 +106,6 @@ where
     T: TotalHash + TotalEq + DirtyHash + ToTotalOrd,
     <T as ToTotalOrd>::TotalOrdItem: Send + Sync + Hash + Eq + DirtyHash + IsNull,
 {
-    let par_iter = semi_anti_impl(probe, build, nulls_equal)
-        .filter(|tpls| tpls.1)
-        .map(|tpls| tpls.0);
-    RAYON.install(|| par_iter.collect())
+    let parts = semi_anti_impl(probe, build, nulls_equal, true);
+    flatten_par(&parts)
 }

--- a/crates/polars-ops/src/frame/join/hash_join/sort_merge.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/sort_merge.rs
@@ -23,11 +23,11 @@ where
     let slice_left = s_left.cont_slice().unwrap();
     let slice_right = s_right.cont_slice().unwrap();
 
-    let indexes = offsets.into_par_iter().map(|(offset, len)| {
+    let indexes = par_map_collect(offsets.len(), &|i| {
+        let (offset, len) = offsets[i];
         let slice_left = &slice_left[offset..offset + len];
         sorted_join::left::join(slice_left, slice_right, offset as IdxSize)
     });
-    let indexes = RAYON.install(|| indexes.collect::<Vec<_>>());
 
     let lefts = indexes.iter().map(|t| &t.0).collect::<Vec<_>>();
     let rights = indexes.iter().map(|t| &t.1).collect::<Vec<_>>();
@@ -107,11 +107,11 @@ where
     let slice_left = s_left.cont_slice().unwrap();
     let slice_right = s_right.cont_slice().unwrap();
 
-    let indexes = offsets.into_par_iter().map(|(offset, len)| {
+    let indexes = par_map_collect(offsets.len(), &|i| {
+        let (offset, len) = offsets[i];
         let slice_left = &slice_left[offset..offset + len];
         sorted_join::inner::join(slice_left, slice_right, offset as IdxSize)
     });
-    let indexes = RAYON.install(|| indexes.collect::<Vec<_>>());
 
     let lefts = indexes.iter().map(|t| &t.0).collect::<Vec<_>>();
     let rights = indexes.iter().map(|t| &t.1).collect::<Vec<_>>();

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -51,6 +51,11 @@ use rayon::prelude::*;
 use self::cross_join::fused_cross_filter;
 use super::IntoDf;
 
+/// Reduces monomorphization: rayon plumbing is instantiated per `R`, not per closure.
+pub(crate) fn par_map_collect<R: Send>(n: usize, f: &(dyn Fn(usize) -> R + Sync)) -> Vec<R> {
+    RAYON.install(|| (0..n).into_par_iter().map(f).collect())
+}
+
 pub trait DataFrameJoinOps: IntoDf {
     /// Generic join method. Can be used to join on multiple columns.
     ///


### PR DESCRIPTION
Identified the bottleneck using Claude Opus 5. Dropped clean-build compile time from 2m58s -> 2m15s. The biggest offender was `join_asof` monomorphization.