### PR TITLE
perf: Replace `mmap` with file I/O for parquet scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3384,6 +3384,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "home",
  "itoa",
+ "libc",
  "memchr",
  "memmap2",
  "num-traits",

--- a/crates/polars-config/src/file_advice.rs
+++ b/crates/polars-config/src/file_advice.rs
@@ -1,0 +1,61 @@
+use std::fmt;
+use std::str::FromStr;
+
+/// Access pattern hint applied to a file when it is opened for reading.
+#[repr(u8)]
+#[derive(Clone, Debug, Copy, Default, Eq, PartialEq, Hash)]
+pub enum FileAdvice {
+    /// Leave the OS default in place.
+    Normal = 0,
+    /// Double read-ahead.
+    Sequential = 1,
+    /// Suppresses read-ahead.
+    #[default]
+    Random = 2,
+    /// For prefetch only.
+    WillNeed = 3,
+}
+
+impl fmt::Display for FileAdvice {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_static_str())
+    }
+}
+
+impl FromStr for FileAdvice {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "normal" => Ok(Self::Normal),
+            "sequential" => Ok(Self::Sequential),
+            "random" => Ok(Self::Random),
+            "willneed" => Ok(Self::WillNeed),
+            v => Err(format!(
+                "`file_advice` must be one of \
+                {{'normal', 'sequential', 'random', 'willneed'}}, got {v}",
+            )),
+        }
+    }
+}
+
+impl FileAdvice {
+    pub(crate) fn from_discriminant(d: u8) -> Self {
+        match d {
+            0 => Self::Normal,
+            1 => Self::Sequential,
+            2 => Self::Random,
+            3 => Self::WillNeed,
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn as_static_str(&self) -> &'static str {
+        match self {
+            Self::Normal => "normal",
+            Self::Sequential => "sequential",
+            Self::Random => "random",
+            Self::WillNeed => "willneed",
+        }
+    }
+}

--- a/crates/polars-config/src/lib.rs
+++ b/crates/polars-config/src/lib.rs
@@ -3,12 +3,14 @@ use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 use std::time::Duration;
 
 mod engine;
+mod file_advice;
 mod parse;
 mod resolve_mode;
 mod spill_format;
 pub mod spill_path;
 
 pub use engine::Engine;
+pub use file_advice::FileAdvice;
 use polars_error::polars_warn;
 pub use resolve_mode::ResolveMode;
 pub use spill_format::SpillFormat;
@@ -122,6 +124,10 @@ const DEFAULT_DIRECT_IO: bool = false;
 const FILE_READ_CONCURRENCY: &str = "POLARS_FILE_READ_CONCURRENCY";
 const DEFAULT_FILE_READ_CONCURRENCY: u64 = 32;
 
+/// Access pattern hint for local file reads (Linux: `posix_fadvise`).
+const FILE_POSIX_FADV: &str = "POLARS_FILE_POSIX_FADV";
+const DEFAULT_FILE_POSIX_FADV: FileAdvice = FileAdvice::Random;
+
 static KNOWN_OPTIONS: &[&str] = &[
     // Public.
     VERBOSE,
@@ -178,6 +184,7 @@ static KNOWN_OPTIONS: &[&str] = &[
     DISABLE_HTTP_RATE_LIMIT,
     DIRECT_IO,
     FILE_READ_CONCURRENCY,
+    FILE_POSIX_FADV,
 ];
 
 pub struct Config {
@@ -214,6 +221,7 @@ pub struct Config {
     disable_http_rate_limit: AtomicBool,
     direct_io: AtomicBool,
     file_read_concurrency: AtomicU64,
+    file_posix_fadv: AtomicU8,
 
     // Derived from others.
     ooc_memory_prefetch_bytes: AtomicU64,
@@ -267,6 +275,7 @@ impl Config {
             disable_http_rate_limit: AtomicBool::new(DEFAULT_DISABLE_HTTP_RATE_LIMIT),
             direct_io: AtomicBool::new(DEFAULT_DIRECT_IO),
             file_read_concurrency: AtomicU64::new(DEFAULT_FILE_READ_CONCURRENCY),
+            file_posix_fadv: AtomicU8::new(DEFAULT_FILE_POSIX_FADV as u8),
             ooc_memory_prefetch_bytes: AtomicU64::new(0),
         };
         cfg.reload_env_vars();
@@ -466,6 +475,11 @@ impl Config {
                     .unwrap_or(DEFAULT_FILE_READ_CONCURRENCY),
                 Ordering::Relaxed,
             ),
+            FILE_POSIX_FADV => self.file_posix_fadv.store(
+                val.and_then(|x| parse::parse_file_advice(var, x))
+                    .unwrap_or(DEFAULT_FILE_POSIX_FADV) as u8,
+                Ordering::Relaxed,
+            ),
             _ => {
                 if var.starts_with("POLARS_") {
                     if self.warn_unknown_config.load(Ordering::Relaxed) {
@@ -663,6 +677,11 @@ impl Config {
     #[inline(always)]
     pub fn file_read_concurrency(&self) -> u64 {
         self.file_read_concurrency.load(Ordering::Relaxed)
+    }
+
+    #[inline(always)]
+    pub fn file_posix_fadv(&self) -> FileAdvice {
+        FileAdvice::from_discriminant(self.file_posix_fadv.load(Ordering::Relaxed))
     }
 }
 

--- a/crates/polars-config/src/lib.rs
+++ b/crates/polars-config/src/lib.rs
@@ -115,6 +115,13 @@ const DEFAULT_NUMA_MOCK_REGIONS: u64 = 0;
 const DISABLE_HTTP_RATE_LIMIT: &str = "POLARS_DISABLE_HTTP_RATE_LIMIT";
 const DEFAULT_DISABLE_HTTP_RATE_LIMIT: bool = false;
 
+/// Use direct I/O (Linux: `O_DIRECT`), bypassing the page cache.
+const DIRECT_IO: &str = "POLARS_DIRECT_IO";
+const DEFAULT_DIRECT_IO: bool = false;
+
+const FILE_READ_CONCURRENCY: &str = "POLARS_FILE_READ_CONCURRENCY";
+const DEFAULT_FILE_READ_CONCURRENCY: u64 = 32;
+
 static KNOWN_OPTIONS: &[&str] = &[
     // Public.
     VERBOSE,
@@ -169,6 +176,8 @@ static KNOWN_OPTIONS: &[&str] = &[
     NUMA_AWARE,
     NUMA_MOCK_REGIONS,
     DISABLE_HTTP_RATE_LIMIT,
+    DIRECT_IO,
+    FILE_READ_CONCURRENCY,
 ];
 
 pub struct Config {
@@ -203,6 +212,8 @@ pub struct Config {
     numa_aware: AtomicBool,
     numa_mock_regions: AtomicU64,
     disable_http_rate_limit: AtomicBool,
+    direct_io: AtomicBool,
+    file_read_concurrency: AtomicU64,
 
     // Derived from others.
     ooc_memory_prefetch_bytes: AtomicU64,
@@ -254,7 +265,8 @@ impl Config {
             numa_aware: AtomicBool::new(DEFAULT_NUMA_AWARE),
             numa_mock_regions: AtomicU64::new(DEFAULT_NUMA_MOCK_REGIONS),
             disable_http_rate_limit: AtomicBool::new(DEFAULT_DISABLE_HTTP_RATE_LIMIT),
-
+            direct_io: AtomicBool::new(DEFAULT_DIRECT_IO),
+            file_read_concurrency: AtomicU64::new(DEFAULT_FILE_READ_CONCURRENCY),
             ooc_memory_prefetch_bytes: AtomicU64::new(0),
         };
         cfg.reload_env_vars();
@@ -444,6 +456,16 @@ impl Config {
                     .unwrap_or(DEFAULT_DISABLE_HTTP_RATE_LIMIT),
                 Ordering::Relaxed,
             ),
+            DIRECT_IO => self.direct_io.store(
+                val.and_then(|x| parse::parse_bool(var, x))
+                    .unwrap_or(DEFAULT_DIRECT_IO),
+                Ordering::Relaxed,
+            ),
+            FILE_READ_CONCURRENCY => self.file_read_concurrency.store(
+                val.and_then(|x| parse::parse_u64(var, x))
+                    .unwrap_or(DEFAULT_FILE_READ_CONCURRENCY),
+                Ordering::Relaxed,
+            ),
             _ => {
                 if var.starts_with("POLARS_") {
                     if self.warn_unknown_config.load(Ordering::Relaxed) {
@@ -631,6 +653,16 @@ impl Config {
     #[inline(always)]
     pub fn disable_http_rate_limit(&self) -> bool {
         self.disable_http_rate_limit.load(Ordering::Relaxed)
+    }
+
+    #[inline(always)]
+    pub fn direct_io(&self) -> bool {
+        self.direct_io.load(Ordering::Relaxed)
+    }
+
+    #[inline(always)]
+    pub fn file_read_concurrency(&self) -> u64 {
+        self.file_read_concurrency.load(Ordering::Relaxed)
     }
 }
 

--- a/crates/polars-config/src/parse.rs
+++ b/crates/polars-config/src/parse.rs
@@ -1,6 +1,6 @@
 use polars_error::polars_warn;
 
-use crate::{Engine, ResolveMode, SpillFormat};
+use crate::{Engine, FileAdvice, ResolveMode, SpillFormat};
 
 pub fn parse_bool(var: &str, val: &str) -> Option<bool> {
     match val.trim_ascii() {
@@ -56,6 +56,16 @@ pub fn parse_engine(var: &str, val: &str) -> Option<Engine> {
 
 pub fn parse_spill_format(var: &str, val: &str) -> Option<SpillFormat> {
     match val.trim_ascii().parse::<SpillFormat>() {
+        Ok(x) => Some(x),
+        Err(e) => {
+            polars_warn!("illegal value '{val}' found while parsing option '{var}' ({e})");
+            None
+        },
+    }
+}
+
+pub fn parse_file_advice(var: &str, val: &str) -> Option<FileAdvice> {
+    match val.trim_ascii().parse::<FileAdvice>() {
         Ok(x) => Some(x),
         Err(e) => {
             polars_warn!("illegal value '{val}' found while parsing option '{var}' ({e})");

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -27,7 +27,6 @@ blake3 = { workspace = true, optional = true }
 bytes = { workspace = true }
 chrono = { workspace = true, optional = true }
 chrono-tz = { workspace = true, optional = true }
-# kdn TODO CHECK
 crossbeam-queue = { workspace = true }
 fast-float2 = { workspace = true, optional = true }
 fastrand = { workspace = true, optional = true }
@@ -36,6 +35,7 @@ futures = { workspace = true, optional = true }
 glob = { version = "0.3" }
 hashbrown = { workspace = true }
 itoa = { workspace = true, optional = true }
+libc = { workspace = true }
 memchr = { workspace = true }
 memmap = { workspace = true }
 num-traits = { workspace = true }

--- a/crates/polars-io/src/utils/byte_source.rs
+++ b/crates/polars-io/src/utils/byte_source.rs
@@ -1,13 +1,20 @@
+use std::cmp::Ordering;
 use std::ops::Range;
+#[cfg(target_os = "linux")]
+use std::os::fd::AsRawFd;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
+use dio_align::DioAlign;
+use futures::{StreamExt, TryStreamExt};
 use polars_buffer::Buffer;
 use polars_core::prelude::PlHashMap;
-use polars_error::{PolarsResult, feature_gated};
+use polars_error::{PolarsResult, feature_gated, polars_err};
+use polars_utils::aliases::InitHashMaps;
 use polars_utils::io::_limit_path_len_io_err;
 use polars_utils::mmap::MMapSemaphore;
 use polars_utils::pl_path::PlRefPath;
+use tokio::sync::Semaphore;
 
 use crate::cloud::concurrency_config::{ConcurrencyStrategy, FetchConfig};
 use crate::cloud::options::CloudOptions;
@@ -15,7 +22,41 @@ use crate::cloud::options::CloudOptions;
 use crate::cloud::{
     CloudLocation, ObjectStorePath, PolarsObjectStore, build_object_store, object_path_from_str,
 };
-use crate::metrics::IOMetrics;
+use crate::metrics::{IOMetrics, OptIOMetrics};
+
+#[cfg(target_os = "linux")]
+pub mod dio_align;
+#[cfg(target_os = "linux")]
+mod direct_io;
+
+//kdn DEV CONTROL STATICS
+#[cfg(target_os = "linux")]
+static PLDEV_OPEN_FADV: LazyLock<usize> = LazyLock::new(|| {
+    std::env::var("PLDEV_OPEN_FADV").map_or(0, |x| {
+        let fadv = x.parse::<usize>().unwrap();
+
+        if polars_config::config().verbose() {
+            //defaults to POSIX_FADV_NORMAL
+            match fadv {
+                0 => {
+                    eprintln!("PLDEV_OPEN_FADV posix_adv_normal");
+                },
+                1 => {
+                    eprintln!("PLDEV_OPEN_FADV posix_adv_sequential");
+                },
+                2 => {
+                    eprintln!("PLDEV_OPEN_FADV posix_adv_random");
+                },
+                3 => {
+                    eprintln!("PLDEV_OPEN_FADV posix_adv_willneed");
+                },
+                _ => panic!("illegal value for PLDEV_OPEN_FADV: {}", fadv),
+            }
+        };
+
+        fadv
+    })
+});
 
 #[allow(async_fn_in_trait)]
 pub trait ByteSource: Send + Sync {
@@ -70,6 +111,318 @@ impl ByteSource for BufferByteSource {
             .iter()
             .map(|x| (x.start, self.0.clone().sliced(x.clone())))
             .collect())
+    }
+}
+
+/// Byte source backed by a `File`.
+pub struct FileByteSource {
+    file: Arc<std::fs::File>,
+    // Alignment for O_DIRECT, if supported.
+    o_direct_align: Option<DioAlign>,
+    // Manage concurrency.
+    concurrency: usize,
+    permits: Arc<Semaphore>,
+    // File size.
+    size: u64,
+    io_metrics: OptIOMetrics,
+}
+
+#[derive(Clone)]
+pub struct FileReadContext {
+    pub enable_o_direct: bool,
+    pub concurrency: usize,
+    pub permits: Arc<Semaphore>,
+}
+
+impl std::fmt::Debug for FileReadContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FileReadContext")
+            .field("available_permits", &self.permits.available_permits())
+            .field("enable_odirect", &self.enable_o_direct)
+            .field("concurrency", &self.concurrency)
+            .finish()
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn _fadvise(file: &std::fs::File) {
+    match *PLDEV_OPEN_FADV {
+        0 => {}, //defaults to POSIX_FADV_NORMAL
+        1 => unsafe {
+            libc::posix_fadvise(file.as_raw_fd(), 0, 0, libc::POSIX_FADV_SEQUENTIAL);
+        },
+        2 => unsafe {
+            libc::posix_fadvise(file.as_raw_fd(), 0, 0, libc::POSIX_FADV_RANDOM);
+        },
+        3 => {
+            unsafe {
+                // Makes little sense in this context.
+                libc::posix_fadvise(file.as_raw_fd(), 0, 0, libc::POSIX_FADV_WILLNEED);
+            }
+        },
+        _ => unreachable!("unexpected PLDEV_OPEN_FADV"),
+    };
+}
+
+#[cfg(unix)]
+pub(crate) fn pread_exact(
+    file: &std::fs::File,
+    buf: &mut [u8],
+    offset: u64,
+) -> std::io::Result<()> {
+    use std::os::unix::fs::FileExt;
+    file.read_exact_at(buf, offset)
+}
+
+#[cfg(windows)]
+fn pread_exact(file: &std::fs::File, buf: &mut [u8], offset: u64) -> std::io::Result<()> {
+    use std::os::windows::fs::FileExt;
+    let mut filled = 0;
+    while filled < buf.len() {
+        match file.seek_read(&mut buf[filled..], offset + filled as u64)? {
+            0 => return Err(std::io::ErrorKind::UnexpectedEof.into()),
+            n => filled += n,
+        }
+    }
+    Ok(())
+}
+
+impl FileByteSource {
+    async fn try_new_from_path(
+        path: PlRefPath,
+        read_context: FileReadContext,
+        io_metrics: Option<Arc<IOMetrics>>,
+    ) -> PolarsResult<Self> {
+        let path = path.as_std_path();
+        let enable_o_direct = read_context.enable_o_direct;
+
+        let file = {
+            #[cfg(target_os = "linux")]
+            let f = if enable_o_direct {
+                direct_io::open_o_direct(path)
+            } else {
+                std::fs::File::open(path)
+            };
+            #[cfg(not(target_os = "linux"))]
+            let f = std::fs::File::open(path);
+
+            f.map_err(|e| _limit_path_len_io_err(path, e))?
+        };
+
+        let file = Arc::new(file);
+
+        #[cfg(target_os = "linux")]
+        let o_direct_align = if enable_o_direct {
+            direct_io::probe_fd(&file)
+        } else {
+            None
+        };
+
+        #[cfg(not(target_os = "linux"))]
+        let o_direct_align = None;
+
+        #[cfg(target_os = "linux")]
+        if o_direct_align.is_none() {
+            // Inert under O_DIRECT: there is no page cache to advise.
+            _fadvise(&file);
+        }
+
+        let concurrency = read_context.concurrency;
+        let permits = read_context.permits;
+
+        let size = file
+            .metadata()
+            .map_err(|e| _limit_path_len_io_err(path, e))?
+            .len();
+
+        if polars_config::config().verbose() {
+            let name = if polars_config::config().verbose_sensitive() {
+                path.display().to_string()
+            } else {
+                "<file>".to_string()
+            };
+            match (enable_o_direct, o_direct_align) {
+                (true, Some(a)) => eprintln!(
+                    "[FileByteSource]: {name}: direct IO active, \
+                        alignment offset: {}, memory: {}",
+                    a.offset, a.memory
+                ),
+                (true, None) => eprintln!(
+                    "[FileByteSource]: {name}: direct IO requested but not active, \
+                        using buffered reads"
+                ),
+                (false, _) => {},
+            }
+        }
+
+        Ok(FileByteSource {
+            file,
+            o_direct_align,
+            concurrency,
+            permits,
+            size,
+            io_metrics: OptIOMetrics(io_metrics),
+        })
+    }
+
+    pub fn try_new_from_std(
+        file: std::fs::File,
+        read_context: FileReadContext,
+        io_metrics: Option<Arc<IOMetrics>>,
+    ) -> PolarsResult<Self> {
+        let size = file.metadata()?.len();
+
+        #[cfg(target_os = "linux")]
+        let o_direct_align = {
+            let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFL) };
+            // Explicitly check it is enabled.
+            (flags >= 0 && (flags & libc::O_DIRECT) != 0)
+                .then(|| DioAlign::probe(&file))
+                .flatten()
+        };
+
+        #[cfg(not(target_os = "linux"))]
+        let o_direct_align = None;
+
+        let concurrency = read_context.concurrency;
+        let permits = read_context.permits;
+
+        // For verbose logging only. We cannot enable since the file_handle was handed to us.
+        let enable_o_direct = read_context.enable_o_direct;
+
+        if polars_config::config().verbose() {
+            match (enable_o_direct, o_direct_align) {
+                (true, Some(a)) => eprintln!(
+                    "[FileByteSource]: direct IO active, alignment offset: {}, memory: {}",
+                    a.offset, a.memory
+                ),
+                (true, None) => eprintln!(
+                    "[FileByteSource]: direct IO requested but not active, using buffered reads",
+                ),
+                (false, _) => {},
+            }
+        }
+
+        Ok(Self {
+            file: Arc::new(file),
+            o_direct_align,
+            concurrency,
+            permits,
+            size,
+            io_metrics: OptIOMetrics(io_metrics),
+        })
+    }
+
+    pub fn set_io_metrics(&mut self, io_metrics: Option<Arc<IOMetrics>>) -> &mut Self {
+        self.io_metrics = OptIOMetrics(io_metrics);
+        self
+    }
+
+    pub fn io_metrics(&self) -> &OptIOMetrics {
+        &self.io_metrics
+    }
+}
+
+impl ByteSource for FileByteSource {
+    async fn get_size(&self) -> PolarsResult<usize> {
+        usize::try_from(self.size)
+            .map_err(|_| polars_err!(ComputeError: "file size {} does not fit in usize", self.size))
+    }
+
+    async fn get_range(&self, range: Range<usize>) -> PolarsResult<Buffer<u8>> {
+        assert!(range.end as u64 <= self.size);
+
+        let file = self.file.clone();
+        let offset = range.start as u64;
+        let len = range.len();
+        let size = self.size;
+        let o_direct = self.o_direct_align;
+
+        let _permit = self.permits.acquire().await.unwrap();
+
+        self.io_metrics()
+            .record_io_read(len as u64, async move {
+                tokio::task::spawn_blocking(move || -> PolarsResult<Buffer<u8>> {
+                    #[cfg(target_os = "linux")]
+                    if let Some(align) = o_direct {
+                        return direct_io::read_aligned(&file, align, offset, len, size);
+                    }
+                    let mut buf = vec![0u8; len];
+                    pread_exact(&file, &mut buf, offset)?;
+                    Ok(Buffer::from(buf))
+                })
+                .await
+            })
+            .await
+            .expect("blocking task panicked")
+    }
+
+    async fn get_ranges(
+        &self,
+        ranges: &mut [Range<usize>],
+    ) -> PolarsResult<PlHashMap<usize, Buffer<u8>>> {
+        if let [range] = ranges {
+            let mut out = PlHashMap::with_capacity(1);
+            out.insert(range.start, self.get_range(range.clone()).await?);
+            return Ok(out);
+        }
+
+        // Sort by original start and merge.
+        ranges.sort_unstable_by_key(|r| r.start);
+
+        let mut spans: Vec<Range<usize>> = Vec::with_capacity(ranges.len());
+
+        // Note: threshold for coalescing; individual ranges may exceed MAX_SPAN.
+        const MAX_SPAN: usize = 8 << 20;
+        let max_gap = self.o_direct_align.map_or(4096, |a| a.offset);
+
+        for r in ranges.iter() {
+            match spans.last_mut() {
+                Some(last)
+                    if r.start.saturating_sub(last.end) <= max_gap
+                        && r.end.saturating_sub(last.start) <= MAX_SPAN =>
+                {
+                    last.end = last.end.max(r.end)
+                },
+                _ => spans.push(r.clone()),
+            }
+        }
+
+        let mut fetched: Vec<(Range<usize>, Buffer<u8>)> = futures::stream::iter(spans)
+            .map(|span| async move {
+                let buf = self.get_range(span.clone()).await?;
+                PolarsResult::Ok((span, buf))
+            })
+            .buffer_unordered(self.concurrency)
+            .try_collect()
+            .await?;
+
+        // Slice out of the containing span into the original ranges.
+        // Sort enables binary search.
+        fetched.sort_unstable_by_key(|(s, _)| s.start);
+
+        let mut out = PlHashMap::with_capacity(ranges.len());
+        for r in ranges.iter() {
+            let idx = fetched
+                .binary_search_by(|(s, _)| {
+                    if s.end <= r.start {
+                        Ordering::Less
+                    } else if s.start > r.start {
+                        Ordering::Greater
+                    } else {
+                        Ordering::Equal
+                    }
+                })
+                .expect("every range lies within a span");
+
+            let (span, buf) = &fetched[idx];
+
+            let off = r.start - span.start;
+            out.insert(r.start, buf.clone().sliced(off..off + r.len()));
+        }
+
+        debug_assert_eq!(out.len(), ranges.len());
+        Ok(out)
     }
 }
 
@@ -138,6 +491,7 @@ impl ByteSource for ObjectStoreByteSource {
 /// Dynamic dispatch to async functions.
 pub enum DynByteSource {
     Buffer(BufferByteSource),
+    File(FileByteSource),
     #[cfg(feature = "cloud")]
     Cloud(ObjectStoreByteSource),
 }
@@ -146,6 +500,7 @@ impl DynByteSource {
     pub fn variant_name(&self) -> &str {
         match self {
             Self::Buffer(_) => "Buffer",
+            Self::File(_) => "File",
             #[cfg(feature = "cloud")]
             Self::Cloud(_) => "Cloud",
         }
@@ -154,6 +509,7 @@ impl DynByteSource {
     pub fn is_cloud(&self) -> bool {
         match self {
             Self::Buffer(_) => false,
+            Self::File(_) => false,
             #[cfg(feature = "cloud")]
             Self::Cloud(_) => true,
         }
@@ -162,6 +518,7 @@ impl DynByteSource {
     pub fn chunk_size(&self) -> Option<usize> {
         match self {
             Self::Buffer(_) => None,
+            Self::File(_) => None,
             #[cfg(feature = "cloud")]
             Self::Cloud(source) => Some(source.config.chunk_size),
         }
@@ -170,6 +527,8 @@ impl DynByteSource {
     pub fn concurrency_strategy(&self) -> Option<ConcurrencyStrategy> {
         match self {
             Self::Buffer(_) => None,
+            // Concurrency is handled directly inside FileByteSource.
+            Self::File(_) => None,
             #[cfg(feature = "cloud")]
             Self::Cloud(source) => Some(source.concurrency_strategy()),
         }
@@ -186,6 +545,7 @@ impl ByteSource for DynByteSource {
     async fn get_size(&self) -> PolarsResult<usize> {
         match self {
             Self::Buffer(v) => v.get_size().await,
+            Self::File(v) => v.get_size().await,
             #[cfg(feature = "cloud")]
             Self::Cloud(v) => v.get_size().await,
         }
@@ -194,6 +554,7 @@ impl ByteSource for DynByteSource {
     async fn get_range(&self, range: Range<usize>) -> PolarsResult<Buffer<u8>> {
         match self {
             Self::Buffer(v) => v.get_range(range).await,
+            Self::File(v) => v.get_range(range).await,
             #[cfg(feature = "cloud")]
             Self::Cloud(v) => v.get_range(range).await,
         }
@@ -205,6 +566,7 @@ impl ByteSource for DynByteSource {
     ) -> PolarsResult<PlHashMap<usize, Buffer<u8>>> {
         match self {
             Self::Buffer(v) => v.get_ranges(ranges).await,
+            Self::File(v) => v.get_ranges(ranges).await,
             #[cfg(feature = "cloud")]
             Self::Cloud(v) => v.get_ranges(ranges).await,
         }
@@ -214,6 +576,12 @@ impl ByteSource for DynByteSource {
 impl From<BufferByteSource> for DynByteSource {
     fn from(value: BufferByteSource) -> Self {
         Self::Buffer(value)
+    }
+}
+
+impl From<FileByteSource> for DynByteSource {
+    fn from(value: FileByteSource) -> Self {
+        Self::File(value)
     }
 }
 
@@ -233,6 +601,8 @@ impl From<Buffer<u8>> for DynByteSource {
 #[derive(Clone, Debug)]
 pub enum DynByteSourceBuilder {
     Mmap,
+    /// Use std::fs::File positional read (pread).
+    FilePread(FileReadContext),
     /// Supports both cloud and local files, requires cloud feature.
     ObjectStore(FetchConfig),
 }
@@ -244,9 +614,14 @@ impl DynByteSourceBuilder {
         cloud_options: Option<&CloudOptions>,
         io_metrics: Option<Arc<IOMetrics>>,
     ) -> PolarsResult<DynByteSource> {
-        Ok(match *self {
+        Ok(match self {
             Self::Mmap => {
                 BufferByteSource::try_new_mmap_from_path(path.as_std_path(), cloud_options)
+                    .await?
+                    .into()
+            },
+            Self::FilePread(read_context) => {
+                FileByteSource::try_new_from_path(path, read_context.clone(), io_metrics)
                     .await?
                     .into()
             },
@@ -255,7 +630,7 @@ impl DynByteSourceBuilder {
                     path,
                     cloud_options,
                     io_metrics,
-                    fetch_config,
+                    *fetch_config,
                 )
                 .await?
                 .into()
@@ -266,6 +641,7 @@ impl DynByteSourceBuilder {
     pub fn chunk_size(&self) -> Option<usize> {
         match self {
             Self::Mmap => None,
+            Self::FilePread(_) => None,
             Self::ObjectStore(fetch_config) => Some(fetch_config.chunk_size),
         }
     }
@@ -273,6 +649,7 @@ impl DynByteSourceBuilder {
     pub fn concurrency_strategy(&self) -> Option<&ConcurrencyStrategy> {
         match self {
             Self::Mmap => None,
+            Self::FilePread(_) => None,
             Self::ObjectStore(fetch_config) => Some(&fetch_config.strategy),
         }
     }

--- a/crates/polars-io/src/utils/byte_source.rs
+++ b/crates/polars-io/src/utils/byte_source.rs
@@ -352,12 +352,15 @@ impl ByteSource for FileByteSource {
         let size = self.size;
         let o_direct = self.o_direct_align;
 
-        let _permit = self.permits.acquire().await.unwrap();
+        let permit = self.permits.clone().acquire_owned().await.unwrap();
 
         self.io_metrics()
             .record_io_read(len as u64, async move {
                 ASYNC
-                    .spawn_blocking(move || read_at(&file, o_direct, offset, len, size))
+                    .spawn_blocking(move || {
+                        let _permit = permit;
+                        read_at(&file, o_direct, offset, len, size)
+                    })
                     .await
             })
             .await

--- a/crates/polars-io/src/utils/byte_source.rs
+++ b/crates/polars-io/src/utils/byte_source.rs
@@ -9,6 +9,7 @@ use dio_align::DioAlign;
 use futures::{StreamExt, TryStreamExt};
 use polars_buffer::Buffer;
 use polars_core::prelude::PlHashMap;
+use polars_core::runtime::ASYNC;
 use polars_error::{PolarsResult, feature_gated, polars_err};
 use polars_utils::aliases::InitHashMaps;
 use polars_utils::io::_limit_path_len_io_err;
@@ -24,7 +25,6 @@ use crate::cloud::{
 };
 use crate::metrics::{IOMetrics, OptIOMetrics};
 
-#[cfg(target_os = "linux")]
 pub mod dio_align;
 #[cfg(target_os = "linux")]
 mod direct_io;
@@ -187,8 +187,53 @@ fn pread_exact(file: &std::fs::File, buf: &mut [u8], offset: u64) -> std::io::Re
     Ok(())
 }
 
+fn read_buffered(file: &std::fs::File, offset: u64, len: usize) -> PolarsResult<Buffer<u8>> {
+    let mut buf = vec![0u8; len];
+    pread_exact(file, &mut buf, offset)?;
+    Ok(Buffer::from(buf))
+}
+
+/// Read `len` bytes at `offset`, through direct I/O when `align` says the file
+/// supports it and through the page cache otherwise.
+#[cfg(target_os = "linux")]
+fn read_at(
+    file: &std::fs::File,
+    align: Option<DioAlign>,
+    offset: u64,
+    len: usize,
+    size: u64,
+) -> PolarsResult<Buffer<u8>> {
+    match align {
+        Some(align) => direct_io::read_aligned(file, align, offset, len, size),
+        None => read_buffered(file, offset, len),
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn read_at(
+    file: &std::fs::File,
+    _align: Option<DioAlign>,
+    offset: u64,
+    len: usize,
+    _size: u64,
+) -> PolarsResult<Buffer<u8>> {
+    read_buffered(file, offset, len)
+}
+
 impl FileByteSource {
     async fn try_new_from_path(
+        path: PlRefPath,
+        read_context: FileReadContext,
+        io_metrics: Option<Arc<IOMetrics>>,
+    ) -> PolarsResult<Self> {
+        // The open path is `open`, `fcntl`, `statx` and `fstat` - all blocking.
+        ASYNC
+            .spawn_blocking(move || Self::open_blocking(path, read_context, io_metrics))
+            .await
+            .expect("blocking task panicked")
+    }
+
+    fn open_blocking(
         path: PlRefPath,
         read_context: FileReadContext,
         io_metrics: Option<Arc<IOMetrics>>,
@@ -199,7 +244,11 @@ impl FileByteSource {
         let file = {
             #[cfg(target_os = "linux")]
             let f = if enable_o_direct {
-                direct_io::open_o_direct(path)
+                direct_io::open_o_direct(path).or_else(|e| match e.raw_os_error() {
+                    // The filesystem does not support O_DIRECT.
+                    Some(libc::EINVAL) => std::fs::File::open(path),
+                    _ => Err(e),
+                })
             } else {
                 std::fs::File::open(path)
             };
@@ -212,11 +261,8 @@ impl FileByteSource {
         let file = Arc::new(file);
 
         #[cfg(target_os = "linux")]
-        let o_direct_align = if enable_o_direct {
-            direct_io::probe_fd(&file)
-        } else {
-            None
-        };
+        let o_direct_align =
+            direct_io::probe_or_disable(&file).map_err(|e| _limit_path_len_io_err(path, e))?;
 
         #[cfg(not(target_os = "linux"))]
         let o_direct_align = None;
@@ -273,13 +319,7 @@ impl FileByteSource {
         let size = file.metadata()?.len();
 
         #[cfg(target_os = "linux")]
-        let o_direct_align = {
-            let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFL) };
-            // Explicitly check it is enabled.
-            (flags >= 0 && (flags & libc::O_DIRECT) != 0)
-                .then(|| DioAlign::probe(&file))
-                .flatten()
-        };
+        let o_direct_align = direct_io::probe_or_disable(&file)?;
 
         #[cfg(not(target_os = "linux"))]
         let o_direct_align = None;
@@ -342,16 +382,9 @@ impl ByteSource for FileByteSource {
 
         self.io_metrics()
             .record_io_read(len as u64, async move {
-                tokio::task::spawn_blocking(move || -> PolarsResult<Buffer<u8>> {
-                    #[cfg(target_os = "linux")]
-                    if let Some(align) = o_direct {
-                        return direct_io::read_aligned(&file, align, offset, len, size);
-                    }
-                    let mut buf = vec![0u8; len];
-                    pread_exact(&file, &mut buf, offset)?;
-                    Ok(Buffer::from(buf))
-                })
-                .await
+                ASYNC
+                    .spawn_blocking(move || read_at(&file, o_direct, offset, len, size))
+                    .await
             })
             .await
             .expect("blocking task panicked")
@@ -372,8 +405,9 @@ impl ByteSource for FileByteSource {
 
         let mut spans: Vec<Range<usize>> = Vec::with_capacity(ranges.len());
 
-        // Note: threshold for coalescing; individual ranges may exceed MAX_SPAN.
+        // Threshold for coalescing. Note, individual ranges may exceed MAX_SPAN.
         const MAX_SPAN: usize = 8 << 20;
+        // Tolerate small gaps.
         let max_gap = self.o_direct_align.map_or(4096, |a| a.offset);
 
         for r in ranges.iter() {
@@ -403,6 +437,13 @@ impl ByteSource for FileByteSource {
 
         let mut out = PlHashMap::with_capacity(ranges.len());
         for r in ranges.iter() {
+            // A column chunk may declare a zero length, and an empty range at
+            // the end of its span matches no span in the search below.
+            if r.is_empty() {
+                out.insert(r.start, Buffer::new());
+                continue;
+            }
+
             let idx = fetched
                 .binary_search_by(|(s, _)| {
                     if s.end <= r.start {

--- a/crates/polars-io/src/utils/byte_source.rs
+++ b/crates/polars-io/src/utils/byte_source.rs
@@ -1,4 +1,3 @@
-use std::cmp::Ordering;
 use std::ops::Range;
 #[cfg(target_os = "linux")]
 use std::os::fd::AsRawFd;
@@ -11,7 +10,7 @@ use polars_buffer::Buffer;
 use polars_config::FileAdvice;
 use polars_core::prelude::PlHashMap;
 use polars_core::runtime::ASYNC;
-use polars_error::{PolarsResult, feature_gated, polars_err};
+use polars_error::{PolarsResult, feature_gated, polars_bail, polars_err};
 use polars_utils::aliases::InitHashMaps;
 use polars_utils::io::_limit_path_len_io_err;
 use polars_utils::mmap::MMapSemaphore;
@@ -377,7 +376,6 @@ impl ByteSource for FileByteSource {
             return Ok(out);
         }
 
-        // Sort by original start and merge.
         ranges.sort_unstable_by_key(|r| r.start);
 
         let mut spans: Vec<Range<usize>> = Vec::with_capacity(ranges.len());
@@ -409,31 +407,29 @@ impl ByteSource for FileByteSource {
             .await?;
 
         // Slice out of the containing span into the original ranges.
-        // Sort enables binary search.
         fetched.sort_unstable_by_key(|(s, _)| s.start);
+
+        if let Some(w) = ranges.windows(2).find(|w| w[0].start == w[1].start) {
+            polars_bail!(
+                ComputeError:
+                "duplicate range start {} in read request ({:?} and {:?})",
+                w[0].start, w[0], w[1]
+            );
+        }
 
         let mut out = PlHashMap::with_capacity(ranges.len());
         for r in ranges.iter() {
-            // A column chunk may declare a zero length, and an empty range at
-            // the end of its span matches no span in the search below.
+            // No span available.
             if r.is_empty() {
                 out.insert(r.start, Buffer::new());
                 continue;
             }
 
-            let idx = fetched
-                .binary_search_by(|(s, _)| {
-                    if s.end <= r.start {
-                        Ordering::Less
-                    } else if s.start > r.start {
-                        Ordering::Greater
-                    } else {
-                        Ordering::Equal
-                    }
-                })
-                .expect("every range lies within a span");
-
-            let (span, buf) = &fetched[idx];
+            // Spans are sorted by start and each range lies within one, so the
+            // containing span is the last one starting at or before `r.start`.
+            let idx = fetched.partition_point(|(s, _)| s.start <= r.start);
+            let (span, buf) = &fetched[idx - 1];
+            debug_assert!(span.start <= r.start && r.end <= span.end);
 
             let off = r.start - span.start;
             out.insert(r.start, buf.clone().sliced(off..off + r.len()));
@@ -669,6 +665,83 @@ impl DynByteSourceBuilder {
             Self::Mmap => None,
             Self::FilePread(_) => None,
             Self::ObjectStore(fetch_config) => Some(&fetch_config.strategy),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MIB: usize = 1 << 20;
+
+    /// A file source over `len` bytes of `(i % 251)`, plus those bytes.
+    fn source(dir: &std::path::Path, len: usize) -> (FileByteSource, Vec<u8>) {
+        let path = dir.join("f.bin");
+        let contents: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+        std::fs::write(&path, &contents).unwrap();
+
+        let read_context = FileReadContext {
+            enable_o_direct: false,
+            concurrency: 4,
+            permits: Arc::new(Semaphore::new(4)),
+            advice: FileAdvice::Normal,
+        };
+        let source = FileByteSource::try_new_from_std(
+            std::fs::File::open(&path).unwrap(),
+            read_context,
+            None,
+        )
+        .unwrap();
+        (source, contents)
+    }
+
+    fn runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn get_ranges_resolves_every_range() {
+        let dir = tempfile::tempdir().unwrap();
+        let (source, contents) = source(dir.path(), 17 * MIB);
+        let rt = runtime();
+
+        let cases: [(&str, &[Range<usize>]); 6] = [
+            ("disjoint", &[0..100, 500..600, 900..1000]),
+            ("unsorted", &[900..1000, 0..100, 500..600]),
+            ("partial overlap", &[0..100, 50..150]),
+            ("contained", &[0..200, 50..100]),
+            // A zero-length column chunk is declarable in file metadata.
+            ("empty range at a span end", &[0..100, 100..100]),
+            // Spans become [0..4096, 5M..14M, 13M..16M]: the last two overlap,
+            // and both contain 13.5M, but only the third covers 16M.
+            (
+                "overlapping spans",
+                &[
+                    0..4096,
+                    5_000_000..14_000_000,
+                    13_000_000..13_500_000,
+                    13_500_000..16_000_000,
+                ],
+            ),
+        ];
+
+        for (name, ranges) in cases {
+            let mut ranges = ranges.to_vec();
+            let expect = ranges.clone();
+            let out = rt.block_on(source.get_ranges(&mut ranges)).unwrap();
+
+            assert_eq!(out.len(), expect.len(), "{name}");
+            for r in &expect {
+                let got = out
+                    .get(&r.start)
+                    .unwrap_or_else(|| panic!("{name}: {r:?} missing"));
+                assert_eq!(got.as_ref(), &contents[r.clone()], "{name}: {r:?}");
+            }
         }
     }
 }

--- a/crates/polars-io/src/utils/byte_source.rs
+++ b/crates/polars-io/src/utils/byte_source.rs
@@ -4,12 +4,11 @@ use std::ops::Range;
 use std::os::fd::AsRawFd;
 use std::path::Path;
 use std::sync::Arc;
-#[cfg(target_os = "linux")]
-use std::sync::LazyLock;
 
 use dio_align::DioAlign;
 use futures::{StreamExt, TryStreamExt};
 use polars_buffer::Buffer;
+use polars_config::FileAdvice;
 use polars_core::prelude::PlHashMap;
 use polars_core::runtime::ASYNC;
 use polars_error::{PolarsResult, feature_gated, polars_err};
@@ -30,36 +29,6 @@ use crate::metrics::{IOMetrics, OptIOMetrics};
 pub mod dio_align;
 #[cfg(target_os = "linux")]
 mod direct_io;
-
-//kdn DEV CONTROL STATICS
-#[cfg(target_os = "linux")]
-static PLDEV_OPEN_FADV: LazyLock<usize> = LazyLock::new(|| {
-    std::env::var("PLDEV_OPEN_FADV").map_or(0, |x| {
-        let fadv = x.parse::<usize>().unwrap();
-
-        if polars_config::config().verbose() {
-            //defaults to POSIX_FADV_NORMAL
-            match fadv {
-                0 => {
-                    eprintln!("PLDEV_OPEN_FADV posix_adv_normal");
-                },
-                1 => {
-                    eprintln!("PLDEV_OPEN_FADV posix_adv_sequential");
-                },
-                2 => {
-                    eprintln!("PLDEV_OPEN_FADV posix_adv_random");
-                },
-                3 => {
-                    eprintln!("PLDEV_OPEN_FADV posix_adv_willneed");
-                },
-                _ => panic!("illegal value for PLDEV_OPEN_FADV: {}", fadv),
-            }
-        };
-
-        fadv
-    })
-});
-
 #[allow(async_fn_in_trait)]
 pub trait ByteSource: Send + Sync {
     async fn get_size(&self) -> PolarsResult<usize>;
@@ -134,6 +103,8 @@ pub struct FileReadContext {
     pub enable_o_direct: bool,
     pub concurrency: usize,
     pub permits: Arc<Semaphore>,
+    /// Ignored when direct I/O is active: there is no page cache to advise.
+    pub advice: FileAdvice,
 }
 
 impl std::fmt::Debug for FileReadContext {
@@ -142,28 +113,24 @@ impl std::fmt::Debug for FileReadContext {
             .field("available_permits", &self.permits.available_permits())
             .field("enable_odirect", &self.enable_o_direct)
             .field("concurrency", &self.concurrency)
+            .field("advice", &self.advice)
             .finish()
     }
 }
 
 #[cfg(target_os = "linux")]
-fn _fadvise(file: &std::fs::File) {
-    match *PLDEV_OPEN_FADV {
-        0 => {}, //defaults to POSIX_FADV_NORMAL
-        1 => unsafe {
-            libc::posix_fadvise(file.as_raw_fd(), 0, 0, libc::POSIX_FADV_SEQUENTIAL);
-        },
-        2 => unsafe {
-            libc::posix_fadvise(file.as_raw_fd(), 0, 0, libc::POSIX_FADV_RANDOM);
-        },
-        3 => {
-            unsafe {
-                // Makes little sense in this context.
-                libc::posix_fadvise(file.as_raw_fd(), 0, 0, libc::POSIX_FADV_WILLNEED);
-            }
-        },
-        _ => unreachable!("unexpected PLDEV_OPEN_FADV"),
+fn _fadvise(file: &std::fs::File, advice: FileAdvice) {
+    let advice = match advice {
+        // The OS default is already POSIX_FADV_NORMAL.
+        FileAdvice::Normal => return,
+        FileAdvice::Sequential => libc::POSIX_FADV_SEQUENTIAL,
+        FileAdvice::Random => libc::POSIX_FADV_RANDOM,
+        FileAdvice::WillNeed => libc::POSIX_FADV_WILLNEED,
     };
+
+    unsafe {
+        libc::posix_fadvise(file.as_raw_fd(), 0, 0, advice);
+    }
 }
 
 #[cfg(unix)]
@@ -272,7 +239,7 @@ impl FileByteSource {
         #[cfg(target_os = "linux")]
         if o_direct_align.is_none() {
             // Inert under O_DIRECT: there is no page cache to advise.
-            _fadvise(&file);
+            _fadvise(&file, read_context.advice);
         }
 
         let concurrency = read_context.concurrency;
@@ -325,6 +292,11 @@ impl FileByteSource {
 
         #[cfg(not(target_os = "linux"))]
         let o_direct_align: Option<DioAlign> = None;
+
+        #[cfg(target_os = "linux")]
+        if o_direct_align.is_none() {
+            _fadvise(&file, read_context.advice);
+        }
 
         let concurrency = read_context.concurrency;
         let permits = read_context.permits;
@@ -409,13 +381,13 @@ impl ByteSource for FileByteSource {
 
         // Threshold for coalescing. Note, individual ranges may exceed MAX_SPAN.
         const MAX_SPAN: usize = 8 << 20;
-        // Tolerate small gaps.
-        let max_gap = self.o_direct_align.map_or(4096, |a| a.offset);
+        // Tolerate small gaps. We match typical page size for now; this could be tuned.
+        const MAX_GAP: usize = 4096;
 
         for r in ranges.iter() {
             match spans.last_mut() {
                 Some(last)
-                    if r.start.saturating_sub(last.end) <= max_gap
+                    if r.start.saturating_sub(last.end) <= MAX_GAP
                         && r.end.saturating_sub(last.start) <= MAX_SPAN =>
                 {
                     last.end = last.end.max(r.end)

--- a/crates/polars-io/src/utils/byte_source.rs
+++ b/crates/polars-io/src/utils/byte_source.rs
@@ -3,7 +3,9 @@ use std::ops::Range;
 #[cfg(target_os = "linux")]
 use std::os::fd::AsRawFd;
 use std::path::Path;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
+#[cfg(target_os = "linux")]
+use std::sync::LazyLock;
 
 use dio_align::DioAlign;
 use futures::{StreamExt, TryStreamExt};
@@ -265,7 +267,7 @@ impl FileByteSource {
             direct_io::probe_or_disable(&file).map_err(|e| _limit_path_len_io_err(path, e))?;
 
         #[cfg(not(target_os = "linux"))]
-        let o_direct_align = None;
+        let o_direct_align: Option<DioAlign> = None;
 
         #[cfg(target_os = "linux")]
         if o_direct_align.is_none() {
@@ -322,7 +324,7 @@ impl FileByteSource {
         let o_direct_align = direct_io::probe_or_disable(&file)?;
 
         #[cfg(not(target_os = "linux"))]
-        let o_direct_align = None;
+        let o_direct_align: Option<DioAlign> = None;
 
         let concurrency = read_context.concurrency;
         let permits = read_context.permits;

--- a/crates/polars-io/src/utils/byte_source/dio_align.rs
+++ b/crates/polars-io/src/utils/byte_source/dio_align.rs
@@ -1,0 +1,165 @@
+//! O_DIRECT alignment discovery.
+//!
+//! `O_DIRECT` requires the file offset, the transfer length, and the buffer
+//! address to be aligned.
+//!
+//! Sources, in order of accuracy:
+//!  1. `statx(STATX_DIOALIGN)` (Linux 6.1+) - authoritative, per-file, and
+//!     distinguishes memory alignment from offset/length alignment. It can
+//!     also say *definitively* that a file does not support direct I/O.
+//!  2. `/sys/dev/block/<major>:<minor>/queue/logical_block_size` - the device
+//!     sector size. Right for most filesystems, but misses cases where the
+//!     filesystem imposes something stricter.
+//!  3. `FALLBACK_ALIGN` - a safe over-alignment when nothing else is known.
+
+use std::os::fd::AsRawFd;
+
+/// Used only when the alignment is *unknown*.
+const FALLBACK_ALIGN: usize = 4096;
+
+#[derive(Debug, Clone, Copy)]
+pub struct DioAlign {
+    /// Alignment required for the file offset and the transfer length.
+    pub offset: usize,
+    /// Alignment required for the buffer address.
+    pub memory: usize,
+}
+
+/// What `statx` was able to tell us.
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone)]
+enum StatxAlign {
+    /// The kernel reported concrete alignments.
+    Known(DioAlign),
+    /// The kernel reported zero: this file does not support direct I/O.
+    /// Distinct from `Unknown` - here we must not guess.
+    Unsupported,
+    /// The syscall failed or the mask is unavailable (kernel < 6.1).
+    Unknown,
+}
+
+impl DioAlign {
+    /// Round `offset` down and `end` up to the offset alignment.
+    ///
+    /// Returns `(lo, hi, pad)` where `pad` is how far into the aligned span the
+    /// caller's data begins. Note `hi` is deliberately *not* clamped to the
+    /// file size: the length must stay aligned, so a read at EOF is expected to
+    /// come up short and the caller must handle the tail.
+    pub fn span(&self, offset: u64, len: usize) -> (u64, u64, usize) {
+        debug_assert!(self.offset > 0);
+
+        let a = self.offset as u64;
+        let lo = offset & !(a - 1);
+        let hi = (offset + len as u64).next_multiple_of(a);
+        (lo, hi, (offset - lo) as usize)
+    }
+
+    /// Query the alignment `O_DIRECT` requires for this file.
+    ///
+    /// `None` means direct I/O is not supported here and the caller should use
+    /// buffered reads.
+    #[cfg(target_os = "linux")]
+    pub fn probe(file: &std::fs::File) -> Option<Self> {
+        match statx_dioalign(file) {
+            StatxAlign::Unsupported => None,
+            StatxAlign::Known(a) => Some(Self {
+                offset: normalize(a.offset),
+                memory: normalize(a.memory),
+            }),
+            // statx could not tell us; fall back to the device sector size,
+            // then to a safe over-alignment.
+            StatxAlign::Unknown => Some(match sysfs_logical_block_size(file) {
+                Some(a) => Self {
+                    offset: normalize(a.offset),
+                    memory: normalize(a.memory),
+                },
+                None => Self {
+                    offset: FALLBACK_ALIGN,
+                    memory: FALLBACK_ALIGN,
+                },
+            }),
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub fn probe(_file: &std::fs::File) -> Option<Self> {
+        None
+    }
+}
+
+fn normalize(v: usize) -> usize {
+    if v == 0 || !v.is_power_of_two() {
+        FALLBACK_ALIGN
+    } else {
+        v
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn statx_dioalign(file: &std::fs::File) -> StatxAlign {
+    let mut stx: libc::statx = unsafe { std::mem::zeroed() };
+    let rc = unsafe {
+        libc::statx(
+            file.as_raw_fd(),
+            c"".as_ptr(),
+            libc::AT_EMPTY_PATH,
+            libc::STATX_DIOALIGN,
+            &mut stx,
+        )
+    };
+    if rc != 0 || stx.stx_mask & libc::STATX_DIOALIGN == 0 {
+        return StatxAlign::Unknown;
+    }
+
+    let offset = stx.stx_dio_offset_align as usize;
+    let memory = stx.stx_dio_mem_align as usize;
+
+    if offset == 0 || memory == 0 {
+        StatxAlign::Unsupported
+    } else {
+        StatxAlign::Known(DioAlign { offset, memory })
+    }
+}
+
+/// `/sys/dev/block/<major>:<minor>/queue/logical_block_size`.
+///
+/// Keyed by device number, so this needs no device-name lookup. Used when the
+/// kernel predates `STATX_DIOALIGN`.
+#[cfg(target_os = "linux")]
+fn sysfs_logical_block_size(file: &std::fs::File) -> Option<DioAlign> {
+    use std::os::unix::fs::MetadataExt;
+
+    let dev = file.metadata().ok()?.dev();
+    let (major, minor) = (libc::major(dev), libc::minor(dev));
+    let path = format!("/sys/dev/block/{major}:{minor}/queue/logical_block_size");
+    let v: usize = std::fs::read_to_string(path).ok()?.trim().parse().ok()?;
+
+    // The device sector size constrains offset and length. Buffer alignment is
+    // not reported here, so assume the same per historical behavior.
+    Some(DioAlign {
+        offset: v,
+        memory: v,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn span_invariants() {
+        for align in [512usize, 4096] {
+            let a = DioAlign {
+                offset: align,
+                memory: align,
+            };
+            for (off, len) in [(206959u64, 206955usize), (4095, 2), (0, 1), (0, align)] {
+                let (lo, hi, pad) = a.span(off, len);
+                assert_eq!(lo as usize % align, 0, "lo unaligned");
+                assert_eq!((hi - lo) as usize % align, 0, "span unaligned");
+                assert!(hi >= off + len as u64, "span does not cover the range");
+                assert!(pad + len <= (hi - lo) as usize, "pad + len exceeds span");
+            }
+        }
+    }
+}

--- a/crates/polars-io/src/utils/byte_source/dio_align.rs
+++ b/crates/polars-io/src/utils/byte_source/dio_align.rs
@@ -10,18 +10,30 @@
 //!  2. `/sys/dev/block/<major>:<minor>/queue/logical_block_size` - the device
 //!     sector size. Right for most filesystems, but misses cases where the
 //!     filesystem imposes something stricter.
-//!  3. `FALLBACK_ALIGN` - a safe over-alignment when nothing else is known.
+//!
+//! When neither can answer, the alignment stays unknown and the caller reads
+//! through the page cache.
 
+#[cfg(target_os = "linux")]
 use std::os::fd::AsRawFd;
 
-/// Used only when the alignment is *unknown*.
+/// Substituted for a reported value that cannot be an alignment.
+#[cfg(target_os = "linux")]
 const FALLBACK_ALIGN: usize = 4096;
+
+/// Floor for the buffer alignment, applied even when the kernel reports less.
+///
+/// `statx` can report a memory alignment below the sector size (ext4 reports 4),
+/// and the other two probes infer the alignment rather than being told it.
+#[cfg(target_os = "linux")]
+const MIN_MEM_ALIGN: usize = 512;
 
 #[derive(Debug, Clone, Copy)]
 pub struct DioAlign {
     /// Alignment required for the file offset and the transfer length.
     pub offset: usize,
     /// Alignment required for the buffer address.
+    /// Invariant: no less than `MIN_MEM_ALIGN`.
     pub memory: usize,
 }
 
@@ -62,22 +74,10 @@ impl DioAlign {
     pub fn probe(file: &std::fs::File) -> Option<Self> {
         match statx_dioalign(file) {
             StatxAlign::Unsupported => None,
-            StatxAlign::Known(a) => Some(Self {
-                offset: normalize(a.offset),
-                memory: normalize(a.memory),
-            }),
-            // statx could not tell us; fall back to the device sector size,
-            // then to a safe over-alignment.
-            StatxAlign::Unknown => Some(match sysfs_logical_block_size(file) {
-                Some(a) => Self {
-                    offset: normalize(a.offset),
-                    memory: normalize(a.memory),
-                },
-                None => Self {
-                    offset: FALLBACK_ALIGN,
-                    memory: FALLBACK_ALIGN,
-                },
-            }),
+            StatxAlign::Known(a) => Some(Self::new(a.offset, a.memory)),
+            StatxAlign::Unknown => {
+                sysfs_logical_block_size(file).map(|a| Self::new(a.offset, a.memory))
+            },
         }
     }
 
@@ -85,8 +85,18 @@ impl DioAlign {
     pub fn probe(_file: &std::fs::File) -> Option<Self> {
         None
     }
+
+    /// Satisfy type invariants.
+    #[cfg(target_os = "linux")]
+    fn new(offset: usize, memory: usize) -> Self {
+        Self {
+            offset: normalize(offset),
+            memory: normalize(memory).max(MIN_MEM_ALIGN),
+        }
+    }
 }
 
+#[cfg(target_os = "linux")]
 fn normalize(v: usize) -> usize {
     if v == 0 || !v.is_power_of_two() {
         FALLBACK_ALIGN

--- a/crates/polars-io/src/utils/byte_source/direct_io.rs
+++ b/crates/polars-io/src/utils/byte_source/direct_io.rs
@@ -1,0 +1,92 @@
+use std::alloc::{Layout, alloc, dealloc};
+use std::fs::{File, OpenOptions};
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::FileExt;
+use std::path::Path;
+
+use polars_buffer::Buffer;
+use polars_error::PolarsResult;
+
+use super::dio_align::DioAlign;
+
+/// Aligned buffer, required for O_DIRECT
+struct AlignedBuf {
+    ptr: *mut u8,
+    len: usize,
+    layout: Layout,
+}
+
+// Safety: exclusive ownership of a heap allocation; no interior mutability.
+unsafe impl Send for AlignedBuf {}
+unsafe impl Sync for AlignedBuf {}
+
+impl AsRef<[u8]> for AlignedBuf {
+    fn as_ref(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.ptr, self.len) }
+    }
+}
+
+impl Drop for AlignedBuf {
+    fn drop(&mut self) {
+        unsafe { dealloc(self.ptr, self.layout) }
+    }
+}
+
+pub(crate) fn open_o_direct(path: &Path) -> std::io::Result<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECT)
+        .open(path)
+}
+
+pub(crate) fn probe_fd(file: &std::fs::File) -> Option<DioAlign> {
+    let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFL) };
+    (flags >= 0 && (flags & libc::O_DIRECT) != 0)
+        .then(|| DioAlign::probe(file))
+        .flatten()
+}
+
+pub(crate) fn read_aligned(
+    file: &File,
+    align: DioAlign,
+    offset: u64,
+    len: usize,
+    size: u64,
+) -> PolarsResult<Buffer<u8>> {
+    let (lo, hi, pad) = align.span(offset, len);
+    let span = (hi - lo) as usize;
+
+    // Memory alignment may be smaller than the offset alignment (4 is common).
+    let align_memory = align.memory.max(512);
+
+    let layout = Layout::from_size_align(span, align_memory).unwrap();
+    let ptr = unsafe { alloc(layout) };
+    if ptr.is_null() {
+        std::alloc::handle_alloc_error(layout)
+    }
+    let owner = AlignedBuf {
+        ptr,
+        len: span,
+        layout,
+    };
+    let raw = unsafe { std::slice::from_raw_parts_mut(ptr, span) };
+
+    if hi <= size {
+        file.read_exact_at(raw, lo)?;
+    } else {
+        // Last block: O_DIRECT rejects an unaligned length, and the aligned
+        // length runs past EOF. Read what exists, leave the tail untouched.
+        let mut filled = 0;
+        while (lo + filled as u64) < size {
+            let n = file.read_at(&mut raw[filled..], lo + filled as u64)?;
+            if n == 0 {
+                break;
+            }
+            filled += n;
+        }
+    }
+
+    Ok(Buffer::from_owner(owner).sliced(pad..pad + len))
+}

--- a/crates/polars-io/src/utils/byte_source/direct_io.rs
+++ b/crates/polars-io/src/utils/byte_source/direct_io.rs
@@ -5,11 +5,14 @@ use std::os::unix::fs::FileExt;
 use std::path::Path;
 
 use polars_buffer::Buffer;
-use polars_error::PolarsResult;
+use polars_error::{PolarsResult, polars_bail};
 
 use super::dio_align::DioAlign;
 
-/// Aligned buffer, required for O_DIRECT
+/// Aligned buffer, required for O_DIRECT.
+///
+/// Invariant: the first `len` bytes are initialized, and `as_ref` exposes only
+/// those. `len` may be less than the allocation when a read stops short at EOF.
 struct AlignedBuf {
     ptr: *mut u8,
     len: usize,
@@ -22,6 +25,7 @@ unsafe impl Sync for AlignedBuf {}
 
 impl AsRef<[u8]> for AlignedBuf {
     fn as_ref(&self) -> &[u8] {
+        // Safety: `ptr` owns `len` initialized bytes (see the type's docs).
         unsafe { std::slice::from_raw_parts(self.ptr, self.len) }
     }
 }
@@ -41,11 +45,42 @@ pub(crate) fn open_o_direct(path: &Path) -> std::io::Result<std::fs::File> {
         .open(path)
 }
 
-pub(crate) fn probe_fd(file: &std::fs::File) -> Option<DioAlign> {
-    let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFL) };
-    (flags >= 0 && (flags & libc::O_DIRECT) != 0)
-        .then(|| DioAlign::probe(file))
-        .flatten()
+/// Returns the alignment `O_DIRECT` requires for `file`, or `None` if `file`
+/// must be read through the page cache instead.
+///
+/// Clears `O_DIRECT` when the fd has it set but no workable alignment exists,
+/// so that unaligned reads work. The flag lives on the open file description,
+/// which `dup(2)` - and so `File::try_clone` - shares, making that visible
+/// through every descriptor sharing it.
+pub(crate) fn probe_or_disable(file: &File) -> std::io::Result<Option<DioAlign>> {
+    let fd = file.as_raw_fd();
+
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    if flags & libc::O_DIRECT == 0 {
+        // Already buffered: nothing to probe, and nothing to undo.
+        return Ok(None);
+    }
+
+    if let Some(align) = DioAlign::probe(file) {
+        return Ok(Some(align));
+    }
+
+    clear_o_direct(fd, flags)?;
+
+    Ok(None)
+}
+
+/// Turn `O_DIRECT` off on an already-open fd.
+fn clear_o_direct(fd: std::os::fd::RawFd, flags: libc::c_int) -> std::io::Result<()> {
+    if unsafe { libc::fcntl(fd, libc::F_SETFL, flags & !libc::O_DIRECT) } < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    Ok(())
 }
 
 pub(crate) fn read_aligned(
@@ -55,29 +90,32 @@ pub(crate) fn read_aligned(
     len: usize,
     size: u64,
 ) -> PolarsResult<Buffer<u8>> {
+    if len == 0 {
+        return Ok(Buffer::new());
+    }
+
     let (lo, hi, pad) = align.span(offset, len);
     let span = (hi - lo) as usize;
 
-    // Memory alignment may be smaller than the offset alignment (4 is common).
-    let align_memory = align.memory.max(512);
-
-    let layout = Layout::from_size_align(span, align_memory).unwrap();
+    let layout = Layout::from_size_align(span, align.memory).unwrap();
     let ptr = unsafe { alloc(layout) };
     if ptr.is_null() {
         std::alloc::handle_alloc_error(layout)
     }
-    let owner = AlignedBuf {
+
+    let mut owner = AlignedBuf {
         ptr,
-        len: span,
+        len: 0,
         layout,
     };
     let raw = unsafe { std::slice::from_raw_parts_mut(ptr, span) };
 
-    if hi <= size {
+    let filled = if hi <= size {
         file.read_exact_at(raw, lo)?;
+        span
     } else {
         // Last block: O_DIRECT rejects an unaligned length, and the aligned
-        // length runs past EOF. Read what exists, leave the tail untouched.
+        // length runs past EOF. Read what exists and leave the tail unread.
         let mut filled = 0;
         while (lo + filled as u64) < size {
             let n = file.read_at(&mut raw[filled..], lo + filled as u64)?;
@@ -86,6 +124,16 @@ pub(crate) fn read_aligned(
             }
             filled += n;
         }
+        filled
+    };
+    owner.len = filled;
+
+    if pad + len > filled {
+        polars_bail!(
+            ComputeError:
+            "direct IO read at offset {lo} returned {filled} bytes, expected at least {}",
+            pad + len
+        );
     }
 
     Ok(Buffer::from_owner(owner).sliced(pad..pad + len))

--- a/crates/polars-io/src/utils/mod.rs
+++ b/crates/polars-io/src/utils/mod.rs
@@ -3,7 +3,7 @@ pub mod compression;
 mod other;
 
 pub use other::*;
-#[cfg(any(feature = "async", feature = "cloud"))]
+#[cfg(feature = "async")]
 pub mod byte_source;
 pub mod file;
 pub mod mkdir;

--- a/crates/polars-plan/src/dsl/scan_sources.rs
+++ b/crates/polars-plan/src/dsl/scan_sources.rs
@@ -9,7 +9,7 @@ use polars_io::cloud::CloudOptions;
 #[cfg(feature = "cloud")]
 use polars_io::file_cache::FileCacheEntry;
 use polars_io::metrics::IOMetrics;
-use polars_io::utils::byte_source::{DynByteSource, DynByteSourceBuilder};
+use polars_io::utils::byte_source::{DynByteSource, DynByteSourceBuilder, FileByteSource};
 use polars_io::{
     BytesPerSource, decode_file_uri_paths, expand_paths, expand_paths_hive,
     expanded_from_single_directory,
@@ -132,6 +132,10 @@ impl ScanSource {
         } else {
             false
         }
+    }
+
+    pub fn is_buffer(&self) -> bool {
+        matches!(self, ScanSource::Buffer(_))
     }
 }
 
@@ -503,9 +507,19 @@ impl ScanSourceRef<'_> {
                     .try_build_from_path((*path).clone(), cloud_options, io_metrics)
                     .await
             },
-            Self::File(file) => Ok(DynByteSource::from(Buffer::from_owner(
-                MMapSemaphore::new_from_file(file)?,
-            ))),
+            Self::File(file) => match builder {
+                DynByteSourceBuilder::FilePread(read_context) => {
+                    Ok(FileByteSource::try_new_from_std(
+                        file.try_clone()?,
+                        read_context.clone(),
+                        io_metrics,
+                    )?
+                    .into())
+                },
+                _ => Ok(DynByteSource::from(Buffer::from_owner(
+                    MMapSemaphore::new_from_file(file)?,
+                ))),
+            },
             Self::Buffer(buff) => Ok(DynByteSource::from((*buff).clone())),
         }
     }

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan/components/row_deletions.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan/components/row_deletions.rs
@@ -84,6 +84,7 @@ impl DeletionFilesProvider {
                     }),
                     pipeline_budget: std::sync::OnceLock::new(),
                     shared_prefetch_wait_group_slot: Default::default(),
+                    file_read_context: std::sync::OnceLock::new(),
                     io_metrics: io_metrics.map(OnceLock::from).unwrap_or_default(),
                 };
 

--- a/crates/polars-stream/src/nodes/io_sources/parquet/builder.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/builder.rs
@@ -146,6 +146,9 @@ impl FileReaderBuilder for ParquetReaderBuilder {
                     let cfg = polars_config::config();
                     let enable_o_direct = cfg.direct_io();
                     let concurrency = cfg.file_read_concurrency().max(1) as usize;
+
+                    // TODO: Posix_fadv should follow the access-pattern, which varies
+                    // by file type and projection.
                     let fadv = cfg.file_posix_fadv();
 
                     if config::verbose() {

--- a/crates/polars-stream/src/nodes/io_sources/parquet/builder.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/builder.rs
@@ -143,8 +143,11 @@ impl FileReaderBuilder for ParquetReaderBuilder {
                 DynByteSourceBuilder::Mmap
             } else {
                 let read_context = self.file_read_context.get_or_init(|| {
-                    let enable_o_direct = polars_config::config().direct_io();
-                    let concurrency = polars_config::config().file_read_concurrency() as usize;
+                    let cfg = polars_config::config();
+                    let enable_o_direct = cfg.direct_io();
+                    // Zero leaves the semaphore permanently empty and makes
+                    // `buffer_unordered` unbounded, hanging the scan.
+                    let concurrency = cfg.file_read_concurrency().max(1) as usize;
 
                     if config::verbose() {
                         eprintln!(

--- a/crates/polars-stream/src/nodes/io_sources/parquet/builder.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/builder.rs
@@ -145,14 +145,15 @@ impl FileReaderBuilder for ParquetReaderBuilder {
                 let read_context = self.file_read_context.get_or_init(|| {
                     let cfg = polars_config::config();
                     let enable_o_direct = cfg.direct_io();
-                    // Zero leaves the semaphore permanently empty and makes
-                    // `buffer_unordered` unbounded, hanging the scan.
                     let concurrency = cfg.file_read_concurrency().max(1) as usize;
+                    let fadv = cfg.file_posix_fadv();
 
                     if config::verbose() {
                         eprintln!(
                             "[ParquetReaderBuilder]: file read_context as configured: \
-                                o_direct: {enable_o_direct}, read_concurrency: {concurrency}"
+                                read_concurrency: {concurrency}, \
+                                posix_fadv: {fadv}, \
+                                o_direct: {enable_o_direct}"
                         );
                     }
 
@@ -162,6 +163,7 @@ impl FileReaderBuilder for ParquetReaderBuilder {
                         enable_o_direct,
                         concurrency,
                         permits,
+                        advice: fadv,
                     }
                 });
                 DynByteSourceBuilder::FilePread(read_context.clone())

--- a/crates/polars-stream/src/nodes/io_sources/parquet/builder.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/builder.rs
@@ -7,8 +7,9 @@ use polars_io::cloud::CloudOptions;
 use polars_io::cloud::concurrency::get_request_budget;
 use polars_io::cloud::concurrency_config::FetchConfig;
 use polars_io::prelude::{FileMetadata, ParallelStrategy, ParquetOptions};
-use polars_io::utils::byte_source::DynByteSourceBuilder;
+use polars_io::utils::byte_source::{DynByteSourceBuilder, FileReadContext};
 use polars_plan::dsl::ScanSource;
+use tokio::sync::Semaphore;
 
 use super::super::shared::pipeline_budget::PipelineBudget;
 use super::{FileReader, ParquetFileReader};
@@ -22,6 +23,8 @@ pub struct ParquetReaderBuilder {
     pub options: Arc<ParquetOptions>,
     pub pipeline_budget: std::sync::OnceLock<PipelineBudget>,
     pub shared_prefetch_wait_group_slot: Arc<std::sync::Mutex<Option<WaitGroup>>>,
+    /// Shared with every file in the scan. Only relevant for `DynByteSourceBuilder::FilePread`.
+    pub file_read_context: std::sync::OnceLock<FileReadContext>,
     pub io_metrics: std::sync::OnceLock<Arc<IOMetrics>>,
 }
 
@@ -31,6 +34,7 @@ impl std::fmt::Debug for ParquetReaderBuilder {
             .field("first_metadata", &self.first_metadata)
             .field("options", &self.options)
             .field("pipeline_budget", &self.pipeline_budget)
+            .field("read_context", &self.file_read_context)
             .finish()
     }
 }
@@ -135,8 +139,29 @@ impl FileReaderBuilder for ParquetReaderBuilder {
         let byte_source_builder =
             if scan_source.is_cloud_url() || polars_config::config().force_async() {
                 DynByteSourceBuilder::ObjectStore(FetchConfig::random_access())
-            } else {
+            } else if scan_source.is_buffer() {
                 DynByteSourceBuilder::Mmap
+            } else {
+                let read_context = self.file_read_context.get_or_init(|| {
+                    let enable_o_direct = polars_config::config().direct_io();
+                    let concurrency = polars_config::config().file_read_concurrency() as usize;
+
+                    if config::verbose() {
+                        eprintln!(
+                            "[ParquetReaderBuilder]: file read_context as configured: \
+                                o_direct: {enable_o_direct}, read_concurrency: {concurrency}"
+                        );
+                    }
+
+                    let permits = Arc::new(Semaphore::new(concurrency));
+
+                    FileReadContext {
+                        enable_o_direct,
+                        concurrency,
+                        permits,
+                    }
+                });
+                DynByteSourceBuilder::FilePread(read_context.clone())
             };
 
         let pipeline_budget = self

--- a/crates/polars-stream/src/nodes/io_sources/parquet/row_group_data_fetch.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/row_group_data_fetch.rs
@@ -126,8 +126,8 @@ impl RowGroupDataFetcher {
 
             let handle = ASYNC.spawn(async move {
                 let row_group_metadata = &metadata.row_groups[idx];
-                let fetched_bytes =
-                    if let DynByteSource::Buffer(mem_slice) = current_byte_source.as_ref() {
+                let fetched_bytes = match current_byte_source.as_ref() {
+                    DynByteSource::Buffer(mem_slice) => {
                         // Skip byte range calculation for `no_prefetch`.
                         if memory_prefetch_func as usize
                             != polars_utils::mem::prefetch::no_prefetch as *const () as usize
@@ -157,39 +157,65 @@ impl RowGroupDataFetcher {
                             offset: 0,
                             buffer: mem_slice,
                         }
-                    } else if !is_full_projection {
-                        let mut ranges = get_row_group_byte_ranges_for_projection(
-                            row_group_metadata,
-                            &mut projection.iter().map(|x| &x.arrow_field().name),
-                        )
-                        .collect::<Vec<_>>();
+                    },
+                    DynByteSource::File(source) => {
+                        let mut ranges = if !is_full_projection {
+                            get_row_group_byte_ranges_for_projection(
+                                row_group_metadata,
+                                &mut projection.iter().map(|x| &x.arrow_field().name),
+                            )
+                            .collect::<Vec<_>>()
+                        } else {
+                            row_group_metadata
+                                .byte_ranges_iter()
+                                .map(|x| x.start as usize..x.end as usize)
+                                .collect::<Vec<_>>()
+                        };
 
                         let n_ranges = ranges.len();
 
-                        let bytes_map = current_byte_source.get_ranges(&mut ranges).await?;
+                        let bytes_map = source.get_ranges(&mut ranges).await?;
 
                         assert_eq!(bytes_map.len(), n_ranges);
 
                         FetchedBytes::BytesMap(bytes_map)
-                    } else {
-                        // We still prefer `get_ranges()` over a single `get_range()` for downloading
-                        // the entire row group, as it can have less memory-copying. A single `get_range()`
-                        // would naively concatenate the memory blocks of the entire row group, while
-                        // `get_ranges()` can skip concatenation since the downloaded blocks are
-                        // aligned to the columns.
-                        let mut ranges = row_group_metadata
-                            .byte_ranges_iter()
-                            .map(|x| x.start as usize..x.end as usize)
+                    },
+                    DynByteSource::Cloud(_) => {
+                        if !is_full_projection {
+                            let mut ranges = get_row_group_byte_ranges_for_projection(
+                                row_group_metadata,
+                                &mut projection.iter().map(|x| &x.arrow_field().name),
+                            )
                             .collect::<Vec<_>>();
 
-                        let n_ranges = ranges.len();
+                            let n_ranges = ranges.len();
 
-                        let bytes_map = current_byte_source.get_ranges(&mut ranges).await?;
+                            let bytes_map = current_byte_source.get_ranges(&mut ranges).await?;
 
-                        assert_eq!(bytes_map.len(), n_ranges);
+                            assert_eq!(bytes_map.len(), n_ranges);
 
-                        FetchedBytes::BytesMap(bytes_map)
-                    };
+                            FetchedBytes::BytesMap(bytes_map)
+                        } else {
+                            // We still prefer `get_ranges()` over a single `get_range()` for downloading
+                            // the entire row group, as it can have less memory-copying. A single `get_range()`
+                            // would naively concatenate the memory blocks of the entire row group, while
+                            // `get_ranges()` can skip concatenation since the downloaded blocks are
+                            // aligned to the columns.
+                            let mut ranges = row_group_metadata
+                                .byte_ranges_iter()
+                                .map(|x| x.start as usize..x.end as usize)
+                                .collect::<Vec<_>>();
+
+                            let n_ranges = ranges.len();
+
+                            let bytes_map = current_byte_source.get_ranges(&mut ranges).await?;
+
+                            assert_eq!(bytes_map.len(), n_ranges);
+
+                            FetchedBytes::BytesMap(bytes_map)
+                        }
+                    },
+                };
 
                 PolarsResult::Ok(RowGroupData {
                     fetched_bytes,

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -765,6 +765,7 @@ pub fn lower_ir(
                             first_metadata: metadata_per_source.first_metadata().cloned(),
                             pipeline_budget: std::sync::OnceLock::new(),
                             shared_prefetch_wait_group_slot: Default::default(),
+                            file_read_context: std::sync::OnceLock::new(),
                             io_metrics: std::sync::OnceLock::new(),
                         },
                     ) as _,

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -4698,3 +4698,43 @@ def test_o_direct_matches_buffered(
     direct = pl.scan_parquet(path).collect()
 
     assert_frame_equal(direct, buffered)
+
+
+@pytest.mark.write_disk
+@pytest.mark.parametrize(
+    "advice",
+    ["normal", "sequential", "random", "willneed", "foo_blah"],
+)
+def test_file_posix_fadv(
+    tmp_path: Path, plmonkeypatch: PlMonkeyPatch, advice: str
+) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    path = tmp_path / f"fadv_{advice or 'empty'}.parquet"
+    expect = _write_df_mixed_offset(path, n_rows=10_000, row_group_size=997)
+
+    plmonkeypatch.setenv("POLARS_FILE_POSIX_FADV", advice)
+    assert_frame_equal(pl.scan_parquet(path).collect(), expect)
+
+
+@pytest.mark.write_disk
+@pytest.mark.parametrize("direct_io", ["0", "1"])
+def test_scan_parquet_from_file_handle(
+    tmp_path: Path, plmonkeypatch: PlMonkeyPatch, direct_io: str
+) -> None:
+    # An open file object takes a different route than a path. The reader is
+    # handed a descriptor it did not open, so it cannot add O_DIRECT to it --
+    # POLARS_DIRECT_IO=1 must degrade to buffered reads and still be correct,
+    # rather than failing.
+    tmp_path.mkdir(exist_ok=True)
+    path = tmp_path / "handle.parquet"
+    expect = _write_df_mixed_offset(path, n_rows=20_000, row_group_size=997)
+
+    plmonkeypatch.setenv("POLARS_DIRECT_IO", direct_io)
+    with path.open("rb") as f:
+        assert_frame_equal(pl.scan_parquet(f).collect(), expect)
+
+    # Trigger coalescing path
+    with path.open("rb") as f:
+        assert_frame_equal(
+            pl.scan_parquet(f).select("a", "c").collect(), expect.select("a", "c")
+        )

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -4599,3 +4599,102 @@ def test_parquet_created_by_field(df: pl.DataFrame, lazy: bool) -> None:
     assert match.group(1) == "Polars (python)"
     assert match.group(2) == pl.__version__
     assert match.group(3) == get_polars_build_commit()
+
+
+def _write_df_mixed_offset(
+    path: Path, n_rows: int, row_group_size: int
+) -> pl.DataFrame:
+    # Mix of fixed- and variable-width columns, so column chunks
+    # land at offsets that are not multiples of the block size.
+    df = pl.select(
+        a=pl.int_range(0, n_rows, dtype=pl.Int64),
+        b=pl.int_range(0, n_rows, dtype=pl.Int32),
+        # Variable-length values push subsequent chunks off any alignment.
+        c=pl.format("row-{}", pl.int_range(0, n_rows)),
+    )
+    df.write_parquet(path, row_group_size=row_group_size)
+    return df
+
+
+@pytest.mark.write_disk
+def test_o_direct_read_roundtrip(tmp_path: Path, plmonkeypatch: PlMonkeyPatch) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    path = tmp_path / "aligned.parquet"
+    expect = _write_df_mixed_offset(path, n_rows=10_000, row_group_size=1024)
+
+    plmonkeypatch.setenv("POLARS_DIRECT_IO", "1")
+    assert_frame_equal(pl.scan_parquet(path).collect(), expect)
+
+
+@pytest.mark.write_disk
+@pytest.mark.parametrize("n_rows", [1, 2, 1023, 1024, 1025, 4096, 4097])
+def test_o_direct_eof_tail(
+    tmp_path: Path, plmonkeypatch: PlMonkeyPatch, n_rows: int
+) -> None:
+    # Arbitrary offset, so the aligned span runs past EOF.
+    tmp_path.mkdir(exist_ok=True)
+    path = tmp_path / f"eof_{n_rows}.parquet"
+    expect = _write_df_mixed_offset(
+        path, n_rows=n_rows, row_group_size=max(n_rows // 2, 1)
+    )
+
+    plmonkeypatch.setenv("POLARS_DIRECT_IO", "1")
+    assert_frame_equal(pl.scan_parquet(path).collect(), expect)
+
+
+@pytest.mark.write_disk
+def test_o_direct_multi_file(tmp_path: Path, plmonkeypatch: PlMonkeyPatch) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    frames = [
+        _write_df_mixed_offset(tmp_path / f"part_{i}.parquet", 500 + i * 37, 128)
+        for i in range(8)
+    ]
+    expect = pl.concat(frames)
+
+    plmonkeypatch.setenv("POLARS_DIRECT_IO", "1")
+    got = pl.scan_parquet(tmp_path / "part_*.parquet").collect()
+    assert_frame_equal(got, expect)
+
+
+@pytest.mark.write_disk
+@pytest.mark.parametrize(
+    "projection",
+    [
+        ["a"],
+        ["c"],
+        ["a", "c"],
+        ["c", "a"],
+        ["a", "b", "c"],
+        ["a", "c", "b"],
+        ["c", "b", "a"],
+    ],
+)
+def test_o_direct_projection(
+    tmp_path: Path, plmonkeypatch: PlMonkeyPatch, projection: list[str]
+) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    path = tmp_path / "projected.parquet"
+    expect = _write_df_mixed_offset(path, n_rows=5_000, row_group_size=512)
+
+    plmonkeypatch.setenv("POLARS_DIRECT_IO", "1")
+    got = pl.scan_parquet(path).select(projection).collect()
+    assert_frame_equal(got, expect.select(projection))
+
+
+@pytest.mark.write_disk
+def test_o_direct_matches_buffered(
+    tmp_path: Path, plmonkeypatch: PlMonkeyPatch
+) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    path = tmp_path / "compare.parquet"
+    _write_df_mixed_offset(
+        path, n_rows=20_000, row_group_size=997
+    )  # prime, to avoid tidy offsets
+
+    plmonkeypatch.setenv("POLARS_DIRECT_IO", "0")
+    buffered = pl.scan_parquet(path).collect()
+
+    plmonkeypatch.setenv("POLARS_DIRECT_IO", "1")
+    direct = pl.scan_parquet(path).collect()
+
+    assert_frame_equal(direct, buffered)


### PR DESCRIPTION
Partially closes https://github.com/pola-rs/polars/issues/26368, for Parquet data reads only, metadata not included yet.

This PR replaces `mmap` for Parquet local file IO with blocking reads from the async pipeline. It introduces a new `FileByteSource`.

The PR also adds io_metrics support. 

In addition, `O_DIRECT` support is added and available on Linux systems that support it. This is off by default, enabled an internal env var. Activating `O_DIRECT` bypasses the OS page cache, making cold reads faster (up to 10-15%) and hot reads slower (as mmap is essentially free if the memory is sized sufficiently).

Performance (excluding `O_DIRECT`):
- Cold read is similar to mmap (within ~1% in test)
- Faster on low thread count (e.g., 2-4 threads) as the concurrency is higher
- Hot read is somewhat slower than mmap, as a memcpy from the page cache is now required (up to 10% slower for IO-bound queries)

Reported Max RSS drops substantially. This is somewhat cosmetic as it affects memory that would be reclaimed under cgroup pressure, e.g. before/after
```
$  EXPR=1 SF=100 /usr/bin/time -v python single.py 2>&1 | grep Max
        Maximum resident set size (kbytes): 8134980
$  EXPR=1 SF=100 /usr/bin/time -v ~/polars/.venv/bin/python single.py 2>&1 | grep Max
        Maximum resident set size (kbytes): 2425504
```
where 'before' will report as much as read unless reclaimed.

ping @nameexhaustion 