### PR TITLE
feat(python!): Update behavior of DataFrame/LazyFrame functions on 0-width input

### DIFF
--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -1435,8 +1435,14 @@ pub fn lower_ir(
             // by with an aggregate for each column.
             let input_schema = phys_input.output_schema(phys_sm);
             if input_schema.is_empty() {
-                // Can't group (or have duplicates) if dataframe has zero-width.
-                return Ok(phys_input);
+                // With zero width every row is identical to every other row, so
+                // at most a single row remains. This matches the zero-width case
+                // of `DataFrame::unique_impl`.
+                let mut stream = build_slice_stream(phys_input, 0, 1, phys_sm);
+                if let Some((offset, length)) = options.slice {
+                    stream = build_slice_stream(stream, offset, length, phys_sm);
+                }
+                return Ok(stream);
             }
 
             // Create the key expressions.

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import io
+import operator
 import os
 from collections import defaultdict
 from collections.abc import (
@@ -1073,24 +1074,37 @@ class DataFrame:
         op: ComparisonOperator,
     ) -> DataFrame:
         """Compare a DataFrame with a non-DataFrame object."""
+        from polars.lazyframe.opt_flags import QueryOptFlags
+
         warn_null_comparison(other)
+        compare: Callable[[Expr, Any], Expr]
         if op == "eq":
-            return self.select(F.all() == other)
+            compare = operator.eq
         elif op == "neq":
-            return self.select(F.all() != other)
+            compare = operator.ne
         elif op == "gt":
-            return self.select(F.all() > other)
+            compare = operator.gt
         elif op == "lt":
-            return self.select(F.all() < other)
+            compare = operator.lt
         elif op == "gt_eq":
-            return self.select(F.all() >= other)
+            compare = operator.ge
         elif op == "lt_eq":
-            return self.select(F.all() <= other)
+            compare = operator.le
         else:
             msg = f"unexpected comparison operator {op!r}"
             raise ValueError(msg)
 
+        return (
+            self.lazy()
+            ._height_preserving_select(lambda expr: compare(expr, other))
+            ._collect_eager(optimizations=QueryOptFlags._eager())
+        )
+
     def _div(self, other: Any, *, floordiv: bool) -> DataFrame:
+        if self.width == 0:
+            # No columns to divide; the result is the input frame as-is.
+            return self.clone()
+
         if isinstance(other, pl.Series):
             if floordiv:
                 return self.select(F.all() // lit(other))
@@ -5196,7 +5210,11 @@ class DataFrame:
         │ a   ┆ 1   │
         └─────┴─────┘
         """
-        return self.select(F.col("*").reverse())
+        from polars.lazyframe.opt_flags import QueryOptFlags
+
+        return (
+            self.lazy().reverse()._collect_eager(optimizations=QueryOptFlags._eager())
+        )
 
     def rename(
         self, mapping: Mapping[str, str] | Callable[[str], str], *, strict: bool = True
@@ -10349,6 +10367,10 @@ class DataFrame:
         │ 1   ┆ x   │
         └─────┴─────┘
         """
+        if self.width == 0:
+            # With no columns every row is identical to every other row.
+            return pl.Series("", [self.height > 1] * self.height, dtype=Boolean)
+
         return wrap_s(self._df.is_duplicated())
 
     def is_unique(self) -> Series:
@@ -10386,6 +10408,10 @@ class DataFrame:
         │ 3   ┆ z   │
         └─────┴─────┘
         """
+        if self.width == 0:
+            # With no columns every row is identical to every other row.
+            return pl.Series("", [self.height <= 1] * self.height, dtype=Boolean)
+
         return wrap_s(self._df.is_unique())
 
     def lazy(self) -> LazyFrame:
@@ -11141,6 +11167,8 @@ class DataFrame:
         │ 6   ┆ 20.0 ┆ 0   │
         └─────┴──────┴─────┘
         """
+        from polars.lazyframe.opt_flags import QueryOptFlags
+
         exprs = []
         for name, dt in self.schema.items():
             if dt.is_numeric() or isinstance(dt, Boolean):
@@ -11148,7 +11176,11 @@ class DataFrame:
             else:
                 exprs.append(F.lit(None).alias(name))
 
-        return self.select(exprs)
+        return (
+            self.lazy()
+            ._aggregate_select(exprs)
+            ._collect_eager(optimizations=QueryOptFlags._eager())
+        )
 
     def quantile(
         self, quantile: float, interpolation: QuantileMethod = "nearest"
@@ -11267,6 +11299,10 @@ class DataFrame:
         │ 1     ┆ 1     ┆ b   │
         └───────┴───────┴─────┘
         """
+        if self.width == 0:
+            # No columns to encode; the result is the input frame as-is.
+            return self.clone()
+
         if columns is not None:
             columns = _expand_selectors(self, columns)
         return self._from_pydf(
@@ -11475,6 +11511,11 @@ class DataFrame:
         ... )
         3
         """
+        if subset is None and self.width == 0:
+            # With no columns all rows are identical, so there is a single
+            # distinct row for any non-empty frame.
+            return min(self.height, 1)
+
         if isinstance(subset, str):
             expr = F.col(subset)
         elif isinstance(subset, pl.Expr):
@@ -12374,7 +12415,13 @@ class DataFrame:
         │ 10.0 ┆ null ┆ 9.0      │
         └──────┴──────┴──────────┘
         """
-        return self.select(F.col("*").interpolate())
+        from polars.lazyframe.opt_flags import QueryOptFlags
+
+        return (
+            self.lazy()
+            .interpolate()
+            ._collect_eager(optimizations=QueryOptFlags._eager())
+        )
 
     def is_empty(self) -> bool:
         """

--- a/py-polars/src/polars/dataframe/frame.py
+++ b/py-polars/src/polars/dataframe/frame.py
@@ -10369,7 +10369,9 @@ class DataFrame:
         """
         if self.width == 0:
             # With no columns every row is identical to every other row.
-            return pl.Series("", [self.height > 1] * self.height, dtype=Boolean)
+            return pl.Series("", [self.height > 1], dtype=Boolean).new_from_index(
+                0, self.height
+            )
 
         return wrap_s(self._df.is_duplicated())
 
@@ -10410,7 +10412,9 @@ class DataFrame:
         """
         if self.width == 0:
             # With no columns every row is identical to every other row.
-            return pl.Series("", [self.height <= 1] * self.height, dtype=Boolean)
+            return pl.Series("", [self.height <= 1], dtype=Boolean).new_from_index(
+                0, self.height
+            )
 
         return wrap_s(self._df.is_unique())
 

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -382,54 +382,25 @@ class LazyFrame:
         return self
 
     def _with_height_column(self) -> LazyFrame:
-        """
-        Attach a placeholder column that carries the height of this frame.
-
-        Operations that derive their output height from the columns they see
-        return a 0-height result for a 0-width input, as there is no column left
-        to take the height from. A 0-field struct column holds a height without
-        holding any data, so attaching one keeps the height observable; pair this
-        with `_drop_height_column()` to remove it again afterwards.
-        """
+        """Add a private dummy column that preserves the input height."""
         return self.with_columns(F.lit({}, dtype=Struct({})).alias(_HEIGHT_COLUMN))
 
     def _drop_height_column(self) -> LazyFrame:
-        """Drop the placeholder column added by `_with_height_column()`."""
+        """Drop the dummy column added by `_with_height_column()`."""
         return self.drop(_HEIGHT_COLUMN)
 
     def _height_preserving(self, op: Callable[[LazyFrame], LazyFrame]) -> LazyFrame:
-        """
-        Apply `op` with a height-carrying placeholder column attached.
-
-        `op` sees the placeholder as an ordinary column, so it must accept a
-        0-field struct and treat it like any other column - only then does the
-        placeholder end up with the height that `op` gives its output.
-        """
+        """Apply `op` with a height-carrying dummy column attached."""
         return op(self._with_height_column())._drop_height_column()
 
     def _aggregate_select(self, exprs: Sequence[Expr]) -> LazyFrame:
-        """
-        `select()` of aggregation expressions, returning a single row.
-
-        `exprs` is empty when the frame has no columns to aggregate, which would
-        otherwise collapse the result to 0 rows; a placeholder literal keeps it
-        1 row high, as it is for any other input.
-        """
+        """`select()` of aggregation expressions, ensures result is height 1."""
         return self.select(
             F.lit({}, dtype=Struct({})).alias(_HEIGHT_COLUMN), *exprs
         ).drop(_HEIGHT_COLUMN)
 
     def _height_preserving_select(self, into_expr: Callable[[Expr], Expr]) -> LazyFrame:
-        """
-        `select()` over all columns, retaining the height of a 0-width input.
-
-        `into_expr` receives a wildcard expression matching the columns of this
-        frame; unlike a plain `col("*")` it does not match the height-carrying
-        placeholder column, so it is safe for operations that only accept
-        specific dtypes. The placeholder is passed through untouched, so
-        `into_expr` must not change the number of rows - use
-        `_height_preserving()` for operations that do.
-        """
+        """`select()` over all columns, retaining the height of a 0-width input."""
         return self._height_preserving(
             lambda lf: lf.select(
                 F.col(_HEIGHT_COLUMN), into_expr(F.exclude(_HEIGHT_COLUMN))

--- a/py-polars/src/polars/lazyframe/frame.py
+++ b/py-polars/src/polars/lazyframe/frame.py
@@ -174,6 +174,9 @@ if TYPE_CHECKING:
 
 _COLLECT_BATCHES_POOL = ThreadPoolExecutor(thread_name_prefix="pl_col_batch_")
 
+# Name of the placeholder column used by `LazyFrame._with_height_column()`.
+_HEIGHT_COLUMN = "__POLARS_INTERNAL_HEIGHT_COLUMN"
+
 
 class LazyFrame:
     """
@@ -377,6 +380,61 @@ class LazyFrame:
         self = cls.__new__(cls)
         self._ldf = ldf
         return self
+
+    def _with_height_column(self) -> LazyFrame:
+        """
+        Attach a placeholder column that carries the height of this frame.
+
+        Operations that derive their output height from the columns they see
+        return a 0-height result for a 0-width input, as there is no column left
+        to take the height from. A 0-field struct column holds a height without
+        holding any data, so attaching one keeps the height observable; pair this
+        with `_drop_height_column()` to remove it again afterwards.
+        """
+        return self.with_columns(F.lit({}, dtype=Struct({})).alias(_HEIGHT_COLUMN))
+
+    def _drop_height_column(self) -> LazyFrame:
+        """Drop the placeholder column added by `_with_height_column()`."""
+        return self.drop(_HEIGHT_COLUMN)
+
+    def _height_preserving(self, op: Callable[[LazyFrame], LazyFrame]) -> LazyFrame:
+        """
+        Apply `op` with a height-carrying placeholder column attached.
+
+        `op` sees the placeholder as an ordinary column, so it must accept a
+        0-field struct and treat it like any other column - only then does the
+        placeholder end up with the height that `op` gives its output.
+        """
+        return op(self._with_height_column())._drop_height_column()
+
+    def _aggregate_select(self, exprs: Sequence[Expr]) -> LazyFrame:
+        """
+        `select()` of aggregation expressions, returning a single row.
+
+        `exprs` is empty when the frame has no columns to aggregate, which would
+        otherwise collapse the result to 0 rows; a placeholder literal keeps it
+        1 row high, as it is for any other input.
+        """
+        return self.select(
+            F.lit({}, dtype=Struct({})).alias(_HEIGHT_COLUMN), *exprs
+        ).drop(_HEIGHT_COLUMN)
+
+    def _height_preserving_select(self, into_expr: Callable[[Expr], Expr]) -> LazyFrame:
+        """
+        `select()` over all columns, retaining the height of a 0-width input.
+
+        `into_expr` receives a wildcard expression matching the columns of this
+        frame; unlike a plain `col("*")` it does not match the height-carrying
+        placeholder column, so it is safe for operations that only accept
+        specific dtypes. The placeholder is passed through untouched, so
+        `into_expr` must not change the number of rows - use
+        `_height_preserving()` for operations that do.
+        """
+        return self._height_preserving(
+            lambda lf: lf.select(
+                F.col(_HEIGHT_COLUMN), into_expr(F.exclude(_HEIGHT_COLUMN))
+            )
+        )
 
     def __getstate__(self) -> bytes:
         return self.serialize()
@@ -6673,7 +6731,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ a   ┆ 1   │
         └─────┴─────┘
         """
-        return self._from_pyldf(self._ldf.reverse())
+        return self._height_preserving(lambda lf: lf._from_pyldf(lf._ldf.reverse()))
 
     def shift(
         self, n: int | IntoExprColumn = 1, *, fill_value: IntoExpr | None = None
@@ -6750,12 +6808,13 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 100 ┆ 100 │
         └─────┴─────┘
         """
-        if fill_value is not None:
-            fill_value_py = parse_into_expression(fill_value, str_as_lit=True)
-        else:
-            fill_value_py = None
-        n_py = parse_into_expression(n)
-        return self._from_pyldf(self._ldf.shift(n_py, fill_value_py))
+        # Equivalent to `LazyFrame::shift()` in Rust, which is itself a
+        # `select()` of shifted columns - built here so that the height-carrying
+        # placeholder column is left out of `fill_value`, which need not have a
+        # dtype the placeholder can hold.
+        return self._height_preserving_select(
+            lambda expr: expr.shift(n, fill_value=fill_value)
+        )
 
     def slice(self, offset: int, length: int | None = None) -> LazyFrame:
         """
@@ -7106,12 +7165,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 4   ┆ 8   │
         └─────┴─────┘
         """
-        return (
-            self.with_columns(
-                F.lit({}, dtype=Struct({})).alias("__POLARS_INTERNAL_HEIGHT_COLUMN")
-            )
-            .select(F.col("*").gather_every(n, offset))
-            .drop("__POLARS_INTERNAL_HEIGHT_COLUMN")
+        return self._height_preserving(
+            lambda lf: lf.select(F.col("*").gather_every(n, offset))
         )
 
     def fill_null(
@@ -7254,7 +7309,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                     F.col([*dtypes, Null]).fill_null(value, strategy, limit)
                 )
 
-        return self.select(F.all().fill_null(value, strategy, limit))
+        return self._height_preserving_select(
+            lambda expr: expr.fill_null(value, strategy, limit)
+        )
 
     def fill_nan(self, value: int | float | Expr | None) -> LazyFrame:
         """
@@ -7341,7 +7398,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 1.118034 ┆ 0.433013 │
         └──────────┴──────────┘
         """
-        return self._from_pyldf(self._ldf.std(ddof))
+        return self._height_preserving(lambda lf: lf._from_pyldf(lf._ldf.std(ddof)))
 
     def var(self, ddof: int = 1) -> LazyFrame:
         """
@@ -7383,7 +7440,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 1.25 ┆ 0.1875 │
         └──────┴────────┘
         """
-        return self._from_pyldf(self._ldf.var(ddof))
+        return self._height_preserving(lambda lf: lf._from_pyldf(lf._ldf.var(ddof)))
 
     def max(self) -> LazyFrame:
         """
@@ -7409,7 +7466,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 4   ┆ 2   │
         └─────┴─────┘
         """
-        return self._from_pyldf(self._ldf.max())
+        return self._height_preserving(lambda lf: lf._from_pyldf(lf._ldf.max()))
 
     def min(self) -> LazyFrame:
         """
@@ -7435,7 +7492,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 1   ┆ 1   │
         └─────┴─────┘
         """
-        return self._from_pyldf(self._ldf.min())
+        return self._height_preserving(lambda lf: lf._from_pyldf(lf._ldf.min()))
 
     def sum(self) -> LazyFrame:
         """
@@ -7461,7 +7518,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 10  ┆ 5   │
         └─────┴─────┘
         """
-        return self._from_pyldf(self._ldf.sum())
+        return self._height_preserving(lambda lf: lf._from_pyldf(lf._ldf.sum()))
 
     def mean(self) -> LazyFrame:
         """
@@ -7487,7 +7544,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 2.5 ┆ 1.25 │
         └─────┴──────┘
         """
-        return self._from_pyldf(self._ldf.mean())
+        return self._height_preserving(lambda lf: lf._from_pyldf(lf._ldf.mean()))
 
     def median(self) -> LazyFrame:
         """
@@ -7513,7 +7570,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 2.5 ┆ 1.0 │
         └─────┴─────┘
         """
-        return self._from_pyldf(self._ldf.median())
+        return self._height_preserving(lambda lf: lf._from_pyldf(lf._ldf.median()))
 
     def null_count(self) -> LazyFrame:
         """
@@ -7540,7 +7597,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 1   ┆ 1   ┆ 0   │
         └─────┴─────┴─────┘
         """
-        return self._from_pyldf(self._ldf.null_count())
+        return self._height_preserving(lambda lf: lf._from_pyldf(lf._ldf.null_count()))
 
     def quantile(
         self,
@@ -7578,7 +7635,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┴─────┘
         """  # noqa: W505
         quantile_py = parse_into_expression(quantile)
-        return self._from_pyldf(self._ldf.quantile(quantile_py, interpolation))
+        return self._height_preserving(
+            lambda lf: lf._from_pyldf(lf._ldf.quantile(quantile_py, interpolation))
+        )
 
     def explode(
         self,
@@ -8434,7 +8493,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 10.0 ┆ null ┆ 9.0      │
         └──────┴──────┴──────────┘
         """
-        return self.select(F.col("*").interpolate())
+        return self._height_preserving_select(lambda expr: expr.interpolate())
 
     def unnest(
         self,
@@ -8966,7 +9025,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 4   ┆ 3   ┆ 0   │
         └─────┴─────┴─────┘
         """
-        return self._from_pyldf(self._ldf.count())
+        return self._height_preserving(lambda lf: lf._from_pyldf(lf._ldf.count()))
 
     @unstable()
     def remote(

--- a/py-polars/tests/unit/dataframe/test_0_width_df.py
+++ b/py-polars/tests/unit/dataframe/test_0_width_df.py
@@ -13,9 +13,48 @@ def test_0_width_df() -> None:
     assert df.equals(df)
     assert not df.equals(pl.DataFrame())
     assert df.estimated_size() == 0
+    assert df.fill_null(0).height == 5
+    assert df.fill_null(strategy="forward").height == 5
     assert df.gather_every(1).height == 5
     assert df.gather_every(5).height == 1
+    assert df.interpolate().height == 5
     assert df.join(df, how="cross").height == 25
+    assert df.reverse().height == 5
+    assert df.shift(1).height == 5
+    assert df.to_dummies().height == 5
+    assert df.unique().height == 1
+
+    # Aggregations reduce to a single row.
+    assert df.count().height == 1
+    assert df.max().height == 1
+    assert df.mean().height == 1
+    assert df.median().height == 1
+    assert df.min().height == 1
+    assert df.null_count().height == 1
+    assert df.product().height == 1
+    assert df.quantile(0.5).height == 1
+    assert df.std().height == 1
+    assert df.sum().height == 1
+    assert df.var().height == 1
+
+    # Comparison and arithmetic operators are element-wise.
+    assert (df == 1).height == 5
+    assert (df != 1).height == 5
+    assert (df > 1).height == 5
+    assert (df < 1).height == 5
+    assert (df >= 1).height == 5
+    assert (df <= 1).height == 5
+    assert (df + 1).height == 5
+    assert (df - 1).height == 5
+    assert (df * 2).height == 5
+    assert (df / 2).height == 5
+    assert (df // 2).height == 5
+    assert (df % 2).height == 5
+
+    # With no columns every row is identical.
+    assert df.is_duplicated().to_list() == [True] * 5
+    assert df.is_unique().to_list() == [False] * 5
+    assert df.n_unique() == 1
 
     out = df.hash_rows()
     assert out.value_counts()["count"].item() == 5
@@ -32,8 +71,46 @@ def test_0_width_lf() -> None:
     assert lf.cast({}).collect().height == 5
     assert lf.drop_nans().collect().height == 5
     assert lf.drop_nulls().collect().height == 5
+    assert lf.fill_null(0).collect().height == 5
+    assert lf.fill_null(strategy="forward").collect().height == 5
     assert lf.gather_every(1).collect().height == 5
     assert lf.gather_every(5).collect().height == 1
+    assert lf.interpolate().collect().height == 5
     assert lf.join(lf, how="cross").collect().height == 25
+    assert lf.reverse().collect().height == 5
+    assert lf.shift(1).collect().height == 5
+    assert lf.unique().collect().height == 1
+
+    # Aggregations reduce to a single row.
+    assert lf.count().collect().height == 1
+    assert lf.max().collect().height == 1
+    assert lf.mean().collect().height == 1
+    assert lf.median().collect().height == 1
+    assert lf.min().collect().height == 1
+    assert lf.null_count().collect().height == 1
+    assert lf.quantile(0.5).collect().height == 1
+    assert lf.std().collect().height == 1
+    assert lf.sum().collect().height == 1
+    assert lf.var().collect().height == 1
 
     assert pl.concat([lf, lf]).collect().height == 10
+
+
+def test_0_width_0_height() -> None:
+    df = pl.DataFrame(height=0)
+
+    assert df.reverse().height == 0
+    assert df.shift(1).height == 0
+    assert df.interpolate().height == 0
+    assert df.gather_every(2).height == 0
+
+    # Aggregating an empty frame still yields a single row.
+    assert df.count().height == 1
+    assert df.max().height == 1
+    assert df.sum().height == 1
+
+    assert df.unique().height == 0
+    assert pl.LazyFrame(height=0).unique().collect().height == 0
+    assert df.is_duplicated().to_list() == []
+    assert df.is_unique().to_list() == []
+    assert df.n_unique() == 0


### PR DESCRIPTION
Autogenerated by Claude Opus 5

Example with `reverse()` -

```python
pl.DataFrame(height=5).reverse()
```

Before - shape: (0, 0)
After - shape: (5, 0)
