### PR TITLE
feat(rust): Propagate IO plugin `explain_name`/`explain_detail` to query-observer descriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3454,6 +3454,7 @@ dependencies = [
  "polars-compute",
  "polars-config",
  "polars-core",
+ "polars-descriptions",
  "polars-expr",
  "polars-io",
  "polars-json",

--- a/crates/polars-descriptions/src/ir.rs
+++ b/crates/polars-descriptions/src/ir.rs
@@ -165,6 +165,8 @@ pub enum IrPropsDescription {
         schema_names: Vec<String>,
         is_pure: bool,
         validate_schema: bool,
+        explain_name: Option<String>,
+        explain_detail: Option<String>,
     },
     UnoptimizedDispatch {
         num_inputs: usize,

--- a/crates/polars-descriptions/src/physical.rs
+++ b/crates/polars-descriptions/src/physical.rs
@@ -277,6 +277,8 @@ pub enum PhysicalPropsDescription {
         schema_names: Vec<String>,
         is_pure: bool,
         validate_schema: bool,
+        explain_name: Option<String>,
+        explain_detail: Option<String>,
     },
     StrptimeInfer {
         format: Option<String>,

--- a/crates/polars-lazy/Cargo.toml
+++ b/crates/polars-lazy/Cargo.toml
@@ -36,6 +36,7 @@ tokio = { workspace = true, optional = true }
 
 [dev-dependencies]
 bytes = { workspace = true }
+polars-descriptions = { workspace = true }
 serde_json = { workspace = true }
 
 [build-dependencies]

--- a/crates/polars-lazy/src/tests/observer.rs
+++ b/crates/polars-lazy/src/tests/observer.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 
 use polars_core::SINGLE_LOCK;
 use polars_core::query_result::QueryResult;
+use polars_descriptions::IrPropsDescription;
 use polars_observer::{
     NoopQueryMetrics, PlannedQuery, QueryMetricsSnapshotter, QueryObserver, QueryObserverFactory,
     register_query_observer_factory,
@@ -14,6 +15,9 @@ use super::*;
 struct Planned {
     ir_len: usize,
     has_physical: bool,
+    /// `(explain_name, explain_detail)` extracted from an `IrPropsDescription::PythonScan`
+    /// node, if the plan contains one.
+    python_scan_explain: Option<(Option<String>, Option<String>)>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -50,9 +54,18 @@ impl QueryObserver for ObserverMock {
     }
 
     fn on_query_planned(&self, query: PlannedQuery) -> Box<dyn Any + Send> {
+        let python_scan_explain = query.ir.iter().find_map(|node| match &node.properties {
+            IrPropsDescription::PythonScan {
+                explain_name,
+                explain_detail,
+                ..
+            } => Some((explain_name.clone(), explain_detail.clone())),
+            _ => None,
+        });
         self.log.lock().unwrap().push(Event::Planned(Planned {
             ir_len: query.ir.len(),
             has_physical: query.physical.is_some(),
+            python_scan_explain,
         }));
         Box::new(CloseGuard {
             log: self.log.clone(),
@@ -259,5 +272,87 @@ mod tests {
     #[test]
     fn noop_metrics_snapshot_empty() {
         assert!(NoopQueryMetrics.snapshot().is_empty());
+    }
+
+    /// Build a `PythonScan` `LazyFrame` directly from the DSL with the given
+    /// explain fields. The scan has no real Python `scan_fn`, so it plans but
+    /// cannot execute.
+    #[cfg(feature = "python")]
+    fn python_scan_lf(
+        explain_name: Option<PlSmallStr>,
+        explain_detail: Option<PlSmallStr>,
+    ) -> LazyFrame {
+        use either::Either;
+        use polars_plan::dsl::SpecialEq;
+        use polars_plan::dsl::python_dsl::{PythonOptionsDsl, PythonScanSource};
+
+        let schema: SchemaRef = Arc::new(Schema::default());
+        let options = PythonOptionsDsl {
+            scan_fn: None,
+            schema_fn: Some(SpecialEq::new(Arc::new(Either::Right(schema)))),
+            python_source: PythonScanSource::IOPlugin,
+            validate_schema: false,
+            is_pure: true,
+            explain_name,
+            explain_detail,
+        };
+        DslPlan::PythonScan { options }.into()
+    }
+
+    /// Run `lf` through the observer-instrumented in-memory engine and return the
+    /// recorded event log. Execution panics after planning because the plan has
+    /// no Python `scan_fn`; the observer's `on_query_planned` has already fired by
+    /// then. The unwind is caught inside the lock (with the panic hook silenced)
+    /// so `SINGLE_LOCK` is not poisoned for other tests.
+    #[cfg(feature = "python")]
+    fn run_observed_python_scan(lf: LazyFrame) -> Vec<Event> {
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+
+        let _guard = SINGLE_LOCK.lock().unwrap();
+        let log: Log = Arc::new(Mutex::new(Vec::new()));
+        register_query_observer_factory(Some(Arc::new(ObserverMock { log: log.clone() })));
+
+        let flags = lf.get_current_optimizations() | OptFlags::QUERY_MONITORING;
+        let lf = lf.with_optimizations(flags);
+
+        let prev_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let _ = catch_unwind(AssertUnwindSafe(|| {
+            lf.collect_with_engine(Engine::InMemory)
+        }));
+        std::panic::set_hook(prev_hook);
+
+        register_query_observer_factory(None);
+        log.lock().unwrap().clone()
+    }
+
+    #[cfg(feature = "python")]
+    fn planned(events: &[Event]) -> &Planned {
+        events
+            .iter()
+            .find_map(|e| match e {
+                Event::Planned(planned) => Some(planned),
+                _ => None,
+            })
+            .expect("no Planned event")
+    }
+
+    /// End-to-end: the `explain_name`/`explain_detail` of a `PythonScan` reach the
+    /// description handed to the `QueryObserver` (and default to `None` when unset).
+    #[cfg(feature = "python")]
+    #[test]
+    fn observer_receives_python_scan_explain_fields() {
+        let events = run_observed_python_scan(python_scan_lf(
+            Some(PlSmallStr::from_static("my_plugin")),
+            Some(PlSmallStr::from_static("scanning foo")),
+        ));
+        assert_eq!(
+            planned(&events).python_scan_explain,
+            Some((Some("my_plugin".into()), Some("scanning foo".into()))),
+            "observer did not receive the PythonScan explain fields: {events:?}"
+        );
+
+        let events = run_observed_python_scan(python_scan_lf(None, None));
+        assert_eq!(planned(&events).python_scan_explain, Some((None, None)));
     }
 }

--- a/crates/polars-plan/src/plans/to_description.rs
+++ b/crates/polars-plan/src/plans/to_description.rs
@@ -418,6 +418,8 @@ pub fn ir_props(ir: &IR, expr_arena: &Arena<AExpr>) -> IrPropsDescription {
                     predicate,
                     validate_schema,
                     is_pure,
+                    explain_name,
+                    explain_detail,
                     ..
                 },
             ..
@@ -444,6 +446,8 @@ pub fn ir_props(ir: &IR, expr_arena: &Arena<AExpr>) -> IrPropsDescription {
             schema_names: schema.iter_names().map(ToString::to_string).collect(),
             is_pure: *is_pure,
             validate_schema: *validate_schema,
+            explain_name: explain_name.as_ref().map(|s| s.to_string()),
+            explain_detail: explain_detail.as_ref().map(|s| s.to_string()),
         },
         IR::UnoptimizedDispatch {
             inputs, operation, ..

--- a/crates/polars-stream/src/physical_plan/to_description.rs
+++ b/crates/polars-stream/src/physical_plan/to_description.rs
@@ -872,6 +872,8 @@ pub fn phys_props(
                     predicate,
                     validate_schema,
                     is_pure,
+                    explain_name,
+                    explain_detail,
                     ..
                 },
             ..
@@ -899,6 +901,8 @@ pub fn phys_props(
                 schema_names: schema.iter_names().map(ToString::to_string).collect(),
                 is_pure: *is_pure,
                 validate_schema: *validate_schema,
+                explain_name: explain_name.as_ref().map(|s| s.to_string()),
+                explain_detail: explain_detail.as_ref().map(|s| s.to_string()),
             },
             vec![],
         ),
@@ -941,4 +945,44 @@ fn fmt_exprs(exprs: &[ExprIR], expr_arena: &Arena<AExpr>) -> Vec<String> {
 /// Helper to one-line [`strum_macros::IntoStaticStr`]
 fn fmt_from_static_str(x: impl Into<&'static str>) -> String {
     x.into().to_string()
+}
+
+#[cfg(all(test, feature = "python"))]
+mod tests {
+    use polars_utils::pl_str::PlSmallStr;
+
+    use super::*;
+
+    fn python_scan_explain(
+        explain_name: Option<PlSmallStr>,
+        explain_detail: Option<PlSmallStr>,
+    ) -> (Option<String>, Option<String>) {
+        let options = PythonOptions {
+            explain_name,
+            explain_detail,
+            ..Default::default()
+        };
+        let props = phys_props(&PhysNodeKind::PythonScan { options }, &Arena::new()).0;
+        let PhysicalPropsDescription::PythonScan {
+            explain_name,
+            explain_detail,
+            ..
+        } = props
+        else {
+            panic!("expected PythonScan description, got {props:?}");
+        };
+        (explain_name, explain_detail)
+    }
+
+    #[test]
+    fn python_scan_carries_explain_fields() {
+        assert_eq!(
+            python_scan_explain(
+                Some(PlSmallStr::from_static("my_plugin")),
+                Some(PlSmallStr::from_static("scanning foo")),
+            ),
+            (Some("my_plugin".into()), Some("scanning foo".into())),
+        );
+        assert_eq!(python_scan_explain(None, None), (None, None));
+    }
 }


### PR DESCRIPTION
## Summary

[#23978](https://github.com/pola-rs/polars/pull/23978) added optional `explain_name` and `explain_detail` parameters to `register_io_source(...)` and threaded them into the DSL/plan option struct `PythonOptions`, wiring them into `explain()` formatting, hashing, and equality. However, those fields never reached `crates/polars-descriptions`: the streaming `QueryObserver` does not read `PythonOptions` directly — it serialises the description structs — so `explain_name`/`explain_detail` were carried in the plan but never surfaced to observers. As a result, every custom Python IO plugin appears anonymously to a `QueryObserver`.

This PR threads the two fields from `PythonOptions` into the `PythonScan` variant of both description structs and populates them at the two sites that build descriptions from the plan.

## Changes

- Add `explain_name: Option<String>` and `explain_detail: Option<String>` to the `PythonScan` variant of:
  - `IrPropsDescription` (`crates/polars-descriptions/src/ir.rs`)
  - `PhysicalPropsDescription` (`crates/polars-descriptions/src/physical.rs`)
- Populate them from `PythonOptions` in the two description builders:
  - `ir_props` (`crates/polars-plan/src/plans/to_description.rs`)
  - `phys_props` (`crates/polars-stream/src/physical_plan/to_description.rs`)

`PlSmallStr` is kept internally and converted to `String` only at the description boundary, consistent with the existing string fields on these structs.

## Backwards compatibility

Both description enums derive `Serialize`/`Deserialize` with `#[serde(default)]`, so adding fields is backwards-compatible for existing msgpack consumers: older readers ignore unknown keys, and the new fields default to `None`. The change does not touch the DSL schema, so no schema-hash update is required.

## Result

Consumers of the streaming `QueryObserver` can now identify which Python IO plugin a `PythonScan` node corresponds to, instead of every plugin appearing anonymously.

## Tests

- A unit test for the physical description builder (`phys_props`) asserting a `PythonScan` carries the two fields, and `None` when they are omitted.
- An end-to-end test that builds a `PythonScan` via the DSL and asserts the values reach the description handed to a `QueryObserver`.

Ran `cargo fmt`, `cargo clippy`, and `cargo test` for the affected crates (`polars-descriptions`, `polars-plan`, `polars-stream`, `polars-lazy`).

## AI usage disclosure

- This change was implemented with the assistance of an AI agent: the description-struct field additions, the two population sites, the added tests, and this description are AI-generated.
- All changes have been reviewed and are believed to be relevant and correct.
- I am an AI agent, using Claude Opus 4.8.
