### PR TITLE
refactor(rust): Use &dyn dispatch for serde and move out of polars-python

### DIFF
--- a/crates/polars-core/src/serde/df.rs
+++ b/crates/polars-core/src/serde/df.rs
@@ -21,6 +21,14 @@ use crate::utils::accumulate_dataframes_vertical_unchecked;
 const FLAGS_KEY: PlSmallStr = PlSmallStr::from_static("_PL_FLAGS");
 
 impl DataFrame {
+    pub fn serialize_into_json(&self, writer: &mut dyn std::io::Write) -> PolarsResult<()> {
+        serde_json::to_writer(writer, self).map_err(to_compute_err)
+    }
+
+    pub fn deserialize_from_json(json: &[u8]) -> PolarsResult<Self> {
+        serde_json::from_slice(json).map_err(to_compute_err)
+    }
+
     pub fn serialize_into_writer(&mut self, writer: &mut dyn std::io::Write) -> PolarsResult<()> {
         let schema = self.schema();
 

--- a/crates/polars-plan/Cargo.toml
+++ b/crates/polars-plan/Cargo.toml
@@ -67,6 +67,7 @@ debugging = []
 python = ["dep:pyo3", "polars-utils/python", "polars-ffi", "polars-core/object", "serde"]
 serde = [
   "dep:serde",
+  "dep:serde_json",
   "polars-buffer/serde",
   "polars-config/serde",
   "polars-core/serde-lazy",

--- a/crates/polars-plan/src/dsl/arity.rs
+++ b/crates/polars-plan/src/dsl/arity.rs
@@ -67,6 +67,17 @@ impl Then {
     pub fn otherwise<E: Into<Expr>>(self, statement: E) -> Expr {
         ternary_expr(self.condition, self.statement, statement.into())
     }
+
+    /// Serialize with the compact format, not portable.
+    #[cfg(feature = "serde")]
+    pub fn serialize_compact_into(&self, writer: &mut dyn std::io::Write) -> PolarsResult<()> {
+        polars_utils::pl_serialize::serialize_into_writer::<_, _, false>(writer, self)
+    }
+
+    #[cfg(feature = "serde")]
+    pub fn deserialize_compact_from(reader: &mut dyn std::io::Read) -> PolarsResult<Self> {
+        polars_utils::pl_serialize::deserialize_from_reader::<_, _, false>(reader)
+    }
 }
 
 impl ChainedWhen {
@@ -132,6 +143,17 @@ impl ChainedThen {
         }
 
         otherwise
+    }
+
+    /// Serialize with the compact format, not portable.
+    #[cfg(feature = "serde")]
+    pub fn serialize_compact_into(&self, writer: &mut dyn std::io::Write) -> PolarsResult<()> {
+        polars_utils::pl_serialize::serialize_into_writer::<_, _, false>(writer, self)
+    }
+
+    #[cfg(feature = "serde")]
+    pub fn deserialize_compact_from(reader: &mut dyn std::io::Read) -> PolarsResult<Self> {
+        polars_utils::pl_serialize::deserialize_from_reader::<_, _, false>(reader)
     }
 }
 

--- a/crates/polars-plan/src/dsl/expr/mod.rs
+++ b/crates/polars-plan/src/dsl/expr/mod.rs
@@ -9,6 +9,8 @@ pub use datatype_fn::*;
 use polars_core::chunked_array::cast::CastOptions;
 use polars_core::error::feature_gated;
 use polars_core::prelude::*;
+#[cfg(feature = "serde")]
+use polars_error::to_compute_err;
 use polars_utils::format_pl_smallstr;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -430,6 +432,35 @@ impl Default for Expr {
 pub enum Excluded {
     Name(PlSmallStr),
     Dtype(DataType),
+}
+
+#[cfg(feature = "serde")]
+impl Expr {
+    /// Serialize with the self-describing (forward compatible) format.
+    pub fn serialize_binary_into(&self, writer: &mut dyn std::io::Write) -> PolarsResult<()> {
+        polars_utils::pl_serialize::serialize_into_writer::<_, _, true>(writer, self)
+    }
+
+    pub fn deserialize_binary_from(reader: &mut dyn std::io::Read) -> PolarsResult<Self> {
+        polars_utils::pl_serialize::deserialize_from_reader::<_, _, true>(reader)
+    }
+
+    /// Serialize with the compact format, not portable.
+    pub fn serialize_compact_into(&self, writer: &mut dyn std::io::Write) -> PolarsResult<()> {
+        polars_utils::pl_serialize::serialize_into_writer::<_, _, false>(writer, self)
+    }
+
+    pub fn deserialize_compact_from(reader: &mut dyn std::io::Read) -> PolarsResult<Self> {
+        polars_utils::pl_serialize::deserialize_from_reader::<_, _, false>(reader)
+    }
+
+    pub fn serialize_json_into(&self, writer: &mut dyn std::io::Write) -> PolarsResult<()> {
+        serde_json::to_writer(writer, self).map_err(to_compute_err)
+    }
+
+    pub fn deserialize_json_from_str(json: &str) -> PolarsResult<Self> {
+        serde_json::from_str(json).map_err(to_compute_err)
+    }
 }
 
 impl Expr {

--- a/crates/polars-plan/src/dsl/plan.rs
+++ b/crates/polars-plan/src/dsl/plan.rs
@@ -278,6 +278,18 @@ impl DslPlan {
     }
 
     #[cfg(feature = "serde")]
+    pub fn serialize_json_into(&self, writer: &mut dyn Write) -> PolarsResult<()> {
+        use polars_error::to_compute_err;
+        serde_json::to_writer(writer, self).map_err(to_compute_err)
+    }
+
+    #[cfg(feature = "serde")]
+    pub fn deserialize_json_from_str(json: &str) -> PolarsResult<Self> {
+        use polars_error::to_compute_err;
+        serde_json::from_str(json).map_err(to_compute_err)
+    }
+
+    #[cfg(feature = "serde")]
     pub fn serialize_versioned<W: Write>(
         &self,
         mut writer: W,

--- a/crates/polars-plan/src/plans/python/predicate.rs
+++ b/crates/polars-plan/src/plans/python/predicate.rs
@@ -5,7 +5,6 @@ use crate::prelude::*;
 #[cfg(feature = "serde")]
 pub fn serialize(expr: &Expr) -> PolarsResult<Option<Vec<u8>>> {
     let mut buf = vec![];
-    polars_utils::pl_serialize::serialize_into_writer::<_, _, true>(&mut buf, expr)?;
-
+    expr.serialize_binary_into(&mut buf)?;
     Ok(Some(buf))
 }

--- a/crates/polars-python/src/conversion/mod.rs
+++ b/crates/polars-python/src/conversion/mod.rs
@@ -33,7 +33,6 @@ use polars_plan::dsl::ScanSources;
 use polars_plan::dsl::default_values::IcebergDefaultFieldValues;
 use polars_plan::dsl::deletion::IcebergDeletes;
 use polars_utils::compression::{BrotliLevel, GzipLevel, ZstdLevel};
-use polars_utils::pl_serialize;
 use polars_utils::pl_str::PlSmallStr;
 use polars_utils::python_function::PythonObject;
 use polars_utils::total_ord::{TotalEq, TotalHash};
@@ -41,11 +40,9 @@ use pyo3::basic::CompareOp;
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::pybacked::{PyBackedBytes, PyBackedStr};
+use pyo3::pybacked::PyBackedStr;
 use pyo3::sync::PyOnceLock;
-use pyo3::types::{IntoPyDict, PyBytes, PyDict, PyList, PySequence, PyString};
-use serde::Serialize;
-use serde::de::DeserializeOwned;
+use pyo3::types::{IntoPyDict, PyDict, PyList, PySequence, PyString};
 
 use crate::error::PyPolarsErr;
 use crate::expr::PyExpr;
@@ -129,30 +126,6 @@ pub(crate) fn to_series(py: Python<'_>, s: PySeries) -> PyResult<Bound<'_, PyAny
     let series = pl_series(py).bind(py);
     let constructor = series.getattr(intern!(py, "_from_pyseries"))?;
     constructor.call1((s,))
-}
-
-pub(crate) fn serde_pickle<'py, T: Serialize>(
-    val: &T,
-    py: Python<'py>,
-) -> PyResult<Bound<'py, PyBytes>> {
-    // For pickling we set FC is false, as that is used for caching (compact is faster) and is not
-    // intended to be used across different versions.
-    let mut writer: Vec<u8> = vec![];
-    pl_serialize::SerializeOptions::default()
-        .serialize_into_writer::<_, _, false>(&mut writer, &val)
-        .map_err(|e| PyPolarsErr::Other(format!("{e}")))?;
-    Ok(PyBytes::new(py, &writer))
-}
-
-pub(crate) fn serde_unpickle<T: DeserializeOwned>(
-    val: &mut T,
-    state: &Bound<PyAny>,
-) -> PyResult<()> {
-    let bytes = state.extract::<PyBackedBytes>()?;
-    *val = pl_serialize::SerializeOptions::default()
-        .deserialize_from_reader::<_, _, false>(&*bytes)
-        .map_err(|e| PyPolarsErr::Other(format!("{e}")))?;
-    Ok(())
 }
 
 impl<'a, 'py> FromPyObject<'a, 'py> for Wrap<PlSmallStr> {

--- a/crates/polars-python/src/dataframe/serde.rs
+++ b/crates/polars-python/src/dataframe/serde.rs
@@ -39,9 +39,11 @@ impl PyDataFrame {
     #[cfg(feature = "json")]
     pub fn serialize_json(&self, py: Python<'_>, py_f: Py<PyAny>) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
-        let writer = BufWriter::new(file);
+        let mut writer = BufWriter::new(file);
         py.enter_polars(|| {
-            serde_json::to_writer(writer, &*self.df.read())
+            self.df
+                .read()
+                .serialize_into_json(&mut writer)
                 .map_err(|err| ComputeError::new_err(err.to_string()))
         })
     }
@@ -55,7 +57,7 @@ impl PyDataFrame {
         py.enter_polars(move || {
             let mmap_read: ReaderBytes = (&mut mmap_bytes_r).into();
             let bytes = mmap_read.deref();
-            let df = serde_json::from_slice::<DataFrame>(bytes)
+            let df = DataFrame::deserialize_from_json(bytes)
                 .map_err(|err| ComputeError::new_err(err.to_string()))?;
             PyResult::Ok(df.into())
         })

--- a/crates/polars-python/src/expr/serde.rs
+++ b/crates/polars-python/src/expr/serde.rs
@@ -1,30 +1,37 @@
 use std::io::{BufReader, BufWriter};
 
 use polars::lazy::prelude::Expr;
-use polars_utils::pl_serialize;
 use pyo3::prelude::*;
+use pyo3::pybacked::PyBackedBytes;
 use pyo3::types::PyBytes;
 
 use crate::PyExpr;
+use crate::error::PyPolarsErr;
 use crate::exceptions::ComputeError;
 use crate::file::get_file_like;
 
 #[pymethods]
 impl PyExpr {
     fn __getstate__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
-        crate::conversion::serde_pickle(&self.inner, py)
+        let mut bytes: Vec<u8> = vec![];
+        self.inner
+            .serialize_compact_into(&mut bytes)
+            .map_err(|e| PyPolarsErr::Other(format!("{e}")))?;
+        Ok(PyBytes::new(py, &bytes))
     }
 
     fn __setstate__(&mut self, state: &Bound<PyAny>) -> PyResult<()> {
-        crate::conversion::serde_unpickle(&mut self.inner, state)
+        let bytes = state.extract::<PyBackedBytes>()?;
+        self.inner = Expr::deserialize_compact_from(&mut &*bytes)
+            .map_err(|e| PyPolarsErr::Other(format!("{e}")))?;
+        Ok(())
     }
 
     /// Serialize into binary data.
     fn serialize_binary(&self, py_f: Py<PyAny>) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
-        let writer = BufWriter::new(file);
-        pl_serialize::SerializeOptions::default()
-            .serialize_into_writer::<_, _, true>(writer, &self.inner)
+        self.inner
+            .serialize_binary_into(&mut BufWriter::new(file))
             .map_err(|err| ComputeError::new_err(err.to_string()))
     }
 
@@ -32,8 +39,8 @@ impl PyExpr {
     #[cfg(feature = "json")]
     fn serialize_json(&self, py_f: Py<PyAny>) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
-        let writer = BufWriter::new(file);
-        serde_json::to_writer(writer, &self.inner)
+        self.inner
+            .serialize_json_into(&mut BufWriter::new(file))
             .map_err(|err| ComputeError::new_err(err.to_string()))
     }
 
@@ -41,9 +48,7 @@ impl PyExpr {
     #[staticmethod]
     fn deserialize_binary(py_f: Py<PyAny>) -> PyResult<PyExpr> {
         let file = get_file_like(py_f, false)?;
-        let reader = BufReader::new(file);
-        let expr: Expr = pl_serialize::SerializeOptions::default()
-            .deserialize_from_reader::<_, _, true>(reader)
+        let expr = Expr::deserialize_binary_from(&mut BufReader::new(file))
             .map_err(|err| ComputeError::new_err(err.to_string()))?;
         Ok(expr.into())
     }
@@ -67,7 +72,7 @@ impl PyExpr {
         // in this scope.
         let json = unsafe { std::mem::transmute::<&'_ str, &'static str>(json.as_str()) };
 
-        let inner: Expr = serde_json::from_str(json).map_err(|_| {
+        let inner = Expr::deserialize_json_from_str(json).map_err(|_| {
             let msg = "could not deserialize input into an expression";
             ComputeError::new_err(msg)
         })?;

--- a/crates/polars-python/src/functions/whenthen.rs
+++ b/crates/polars-python/src/functions/whenthen.rs
@@ -1,8 +1,10 @@
 use polars::lazy::dsl;
 use pyo3::prelude::*;
+use pyo3::pybacked::PyBackedBytes;
 use pyo3::types::PyBytes;
 
 use crate::PyExpr;
+use crate::error::PyPolarsErr;
 
 #[pyfunction]
 pub fn when(condition: PyExpr) -> PyWhen {
@@ -57,11 +59,18 @@ impl PyThen {
     }
 
     fn __getstate__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
-        crate::conversion::serde_pickle(&self.inner, py)
+        let mut bytes: Vec<u8> = vec![];
+        self.inner
+            .serialize_compact_into(&mut bytes)
+            .map_err(|e| PyPolarsErr::Other(format!("{e}")))?;
+        Ok(PyBytes::new(py, &bytes))
     }
 
     fn __setstate__(&mut self, state: &Bound<PyAny>) -> PyResult<()> {
-        crate::conversion::serde_unpickle(&mut self.inner, state)
+        let bytes = state.extract::<PyBackedBytes>()?;
+        self.inner = dsl::Then::deserialize_compact_from(&mut &*bytes)
+            .map_err(|e| PyPolarsErr::Other(format!("{e}")))?;
+        Ok(())
     }
 }
 
@@ -87,10 +96,17 @@ impl PyChainedThen {
     }
 
     fn __getstate__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
-        crate::conversion::serde_pickle(&self.inner, py)
+        let mut bytes: Vec<u8> = vec![];
+        self.inner
+            .serialize_compact_into(&mut bytes)
+            .map_err(|e| PyPolarsErr::Other(format!("{e}")))?;
+        Ok(PyBytes::new(py, &bytes))
     }
 
     fn __setstate__(&mut self, state: &Bound<PyAny>) -> PyResult<()> {
-        crate::conversion::serde_unpickle(&mut self.inner, state)
+        let bytes = state.extract::<PyBackedBytes>()?;
+        self.inner = dsl::ChainedThen::deserialize_compact_from(&mut &*bytes)
+            .map_err(|e| PyPolarsErr::Other(format!("{e}")))?;
+        Ok(())
     }
 }

--- a/crates/polars-python/src/lazyframe/serde.rs
+++ b/crates/polars-python/src/lazyframe/serde.rs
@@ -27,9 +27,12 @@ impl PyLazyFrame {
     #[cfg(feature = "json")]
     fn serialize_json(&self, py: Python<'_>, py_f: Py<PyAny>) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
-        let writer = BufWriter::new(file);
+        let mut writer = BufWriter::new(file);
         py.enter_polars(|| {
-            serde_json::to_writer(writer, &self.ldf.read().logical_plan)
+            self.ldf
+                .read()
+                .logical_plan
+                .serialize_json_into(&mut writer)
                 .map_err(|err| ComputeError::new_err(err.to_string()))
         })
     }
@@ -64,7 +67,7 @@ impl PyLazyFrame {
         let json = unsafe { std::mem::transmute::<&'_ str, &'static str>(json.as_str()) };
 
         let lp = py.enter_polars(|| {
-            serde_json::from_str::<DslPlan>(json)
+            DslPlan::deserialize_json_from_str(json)
                 .map_err(|err| ComputeError::new_err(err.to_string()))
         })?;
         Ok(LazyFrame::from(lp).into())

--- a/crates/polars-utils/src/pl_serialize.rs
+++ b/crates/polars-utils/src/pl_serialize.rs
@@ -3,6 +3,8 @@
 //! Currently provides two serialization scheme's.
 //! - Self-describing (and thus more forward compatible) activated with `FC: true`
 //! - Compact activated with `FC: false`
+use std::io::{Read, Write};
+
 use polars_error::{PolarsResult, to_compute_err};
 
 fn config() -> bincode::config::Configuration {
@@ -11,50 +13,12 @@ fn config() -> bincode::config::Configuration {
         .with_variable_int_encoding()
 }
 
-/// One type for both branches, so the serde machinery is monomorphized once.
-enum MaybeCompressedWriter<W: std::io::Write> {
-    Plain(W),
-    Zlib(flate2::write::ZlibEncoder<W>),
-}
-
-impl<W: std::io::Write> std::io::Write for MaybeCompressedWriter<W> {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        match self {
-            Self::Plain(w) => w.write(buf),
-            Self::Zlib(w) => w.write(buf),
-        }
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        match self {
-            Self::Plain(w) => w.flush(),
-            Self::Zlib(w) => w.flush(),
-        }
-    }
-}
-
-/// See [`MaybeCompressedWriter`].
-enum MaybeCompressedReader<R: std::io::Read> {
-    Plain(R),
-    Zlib(flate2::read::ZlibDecoder<R>),
-}
-
-impl<R: std::io::Read> std::io::Read for MaybeCompressedReader<R> {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        match self {
-            Self::Plain(r) => r.read(buf),
-            Self::Zlib(r) => r.read(buf),
-        }
-    }
-}
-
-fn serialize_impl<W, T, const FC: bool>(mut writer: W, value: &T) -> PolarsResult<()>
+fn serialize_impl<T, const FC: bool>(mut writer: &mut dyn Write, value: &T) -> PolarsResult<()>
 where
-    W: std::io::Write,
     T: serde::ser::Serialize,
 {
     if FC {
-        let mut s = rmp_serde::Serializer::new(writer).with_struct_map();
+        let mut s = rmp_serde::Serializer::new(&mut *writer).with_struct_map();
         value.serialize(&mut s).map_err(to_compute_err)
     } else {
         bincode::serde::encode_into_std_write(value, &mut writer, config())
@@ -63,13 +27,12 @@ where
     }
 }
 
-pub fn deserialize_impl<T, R, const FC: bool>(mut reader: R) -> PolarsResult<T>
+fn deserialize_impl<T, const FC: bool>(mut reader: &mut dyn Read) -> PolarsResult<T>
 where
     T: serde::de::DeserializeOwned,
-    R: std::io::Read,
 {
     if FC {
-        rmp_serde::from_read(reader).map_err(to_compute_err)
+        rmp_serde::from_read(&mut *reader).map_err(to_compute_err)
     } else {
         bincode::serde::decode_from_std_read(&mut reader, config()).map_err(to_compute_err)
     }
@@ -90,35 +53,33 @@ impl SerializeOptions {
 
     pub fn serialize_into_writer<W, T, const FC: bool>(
         &self,
-        writer: W,
+        mut writer: W,
         value: &T,
     ) -> PolarsResult<()>
     where
         W: std::io::Write,
         T: serde::ser::Serialize,
     {
-        let writer = if self.compression {
-            MaybeCompressedWriter::Zlib(flate2::write::ZlibEncoder::new(
-                writer,
-                flate2::Compression::fast(),
-            ))
+        if self.compression {
+            let mut compr_writer =
+                flate2::write::ZlibEncoder::new(writer, flate2::Compression::fast());
+            serialize_impl::<_, FC>(&mut compr_writer, value)
         } else {
-            MaybeCompressedWriter::Plain(writer)
-        };
-        serialize_impl::<_, _, FC>(writer, value)
+            serialize_impl::<_, FC>(&mut writer, value)
+        }
     }
 
-    pub fn deserialize_from_reader<T, R, const FC: bool>(&self, reader: R) -> PolarsResult<T>
+    pub fn deserialize_from_reader<T, R, const FC: bool>(&self, mut reader: R) -> PolarsResult<T>
     where
         T: serde::de::DeserializeOwned,
         R: std::io::Read,
     {
-        let reader = if self.compression {
-            MaybeCompressedReader::Zlib(flate2::read::ZlibDecoder::new(reader))
+        if self.compression {
+            let mut compr_reader = flate2::read::ZlibDecoder::new(reader);
+            deserialize_impl::<_, FC>(&mut compr_reader)
         } else {
-            MaybeCompressedReader::Plain(reader)
-        };
-        deserialize_impl::<_, _, FC>(reader)
+            deserialize_impl::<_, FC>(&mut reader)
+        }
     }
 
     pub fn serialize_to_bytes<T, const FC: bool>(&self, value: &T) -> PolarsResult<Vec<u8>>
@@ -140,20 +101,20 @@ impl Default for SerializeOptions {
     }
 }
 
-pub fn serialize_into_writer<W, T, const FC: bool>(writer: W, value: &T) -> PolarsResult<()>
+pub fn serialize_into_writer<W, T, const FC: bool>(mut writer: W, value: &T) -> PolarsResult<()>
 where
     W: std::io::Write,
     T: serde::ser::Serialize,
 {
-    serialize_impl::<_, _, FC>(MaybeCompressedWriter::Plain(writer), value)
+    serialize_impl::<_, FC>(&mut writer, value)
 }
 
-pub fn deserialize_from_reader<T, R, const FC: bool>(reader: R) -> PolarsResult<T>
+pub fn deserialize_from_reader<T, R, const FC: bool>(mut reader: R) -> PolarsResult<T>
 where
     T: serde::de::DeserializeOwned,
     R: std::io::Read,
 {
-    deserialize_impl::<_, _, FC>(MaybeCompressedReader::Plain(reader))
+    deserialize_impl::<_, FC>(&mut reader)
 }
 
 pub fn serialize_to_bytes<T, const FC: bool>(value: &T) -> PolarsResult<Vec<u8>>
@@ -161,29 +122,29 @@ where
     T: serde::ser::Serialize,
 {
     let mut v = vec![];
-
     serialize_into_writer::<_, _, FC>(&mut v, value)?;
-
     Ok(v)
 }
 
 /// Serialize function customized for `DslPlan`, with stack overflow protection.
-pub fn serialize_dsl<W, T>(writer: W, value: &T) -> PolarsResult<()>
+pub fn serialize_dsl<W, T>(mut writer: W, value: &T) -> PolarsResult<()>
 where
     W: std::io::Write,
     T: serde::ser::Serialize,
 {
+    let writer: &mut dyn std::io::Write = &mut writer;
     let mut s = rmp_serde::Serializer::new(writer).with_struct_map();
     let s = serde_stacker::Serializer::new(&mut s);
     value.serialize(s).map_err(to_compute_err)
 }
 
 /// Deserialize function customized for `DslPlan`, with stack overflow protection.
-pub fn deserialize_dsl<T, R>(reader: R) -> PolarsResult<T>
+pub fn deserialize_dsl<T, R>(mut reader: R) -> PolarsResult<T>
 where
     T: serde::de::DeserializeOwned,
     R: std::io::Read,
 {
+    let reader: &mut dyn std::io::Read = &mut reader;
     let mut de = rmp_serde::Deserializer::new(reader);
     de.set_max_depth(usize::MAX);
     let de = serde_stacker::Deserializer::new(&mut de);


### PR DESCRIPTION
This PR does two things to improve compile times:

 - Ensures we use a `&dyn Read/Write` instead of a raw `R`/`W` when going into serde to reduce duplicate monomorphizations.
 - It moves some instantiations of serialization from `polars-python` into earlier crates like `polars-core` or `polars-plan`. Since `polars-python` is one of the last crates this increases the chances of parallel compilation, and reduces the amount of work needed on a shallow recompile.

On my machine this shaves ~1 second from a `touch crates/polars-core/src/lib.rs` recompile, and it also reduces the binary size a bit.