### PR TITLE
perf: Avoid a full fsync per file when writing Parquet

### DIFF
--- a/crates/polars-io/src/utils/file.rs
+++ b/crates/polars-io/src/utils/file.rs
@@ -182,7 +182,12 @@ impl io::Write for Writable {
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        self.sync_all()
+        match self {
+            Self::Dyn(v) => v.flush(),
+            Self::Local(v) => v.flush(),
+            #[cfg(feature = "cloud")]
+            Self::Cloud(v) => v.flush(),
+        }
     }
 }
 


### PR DESCRIPTION
`Writable::flush()` currently calls `sync_all()`, causing every parquet write to fsync even when `sync_on_close` is `None`. On macOS that's ~4 ms per file: a one-row `write_parquet` takes 3.9 ms to a path vs. 0.095 ms to a BytesIO.

This changes `flush()` to just flush, leaving durability to `close(sync_on_close)`, which every sink writer already calls per file.

Note: for cloud writers `sync_all()` was a no-op while `flush()` genuinely uploads buffered bytes, so cloud flushes now do work.