### PR TITLE
fix(python): Parameterize PyArrow conversion types with `Any`

### DIFF
--- a/py-polars/src/polars/convert/general.py
+++ b/py-polars/src/polars/convert/general.py
@@ -459,8 +459,8 @@ def from_torch(
 def from_arrow(
     data: (
         pa.Table
-        | pa.Array
-        | pa.ChunkedArray
+        | pa.Array[Any]
+        | pa.ChunkedArray[Any]
         | pa.RecordBatch
         | Iterable[pa.RecordBatch | pa.Table]
         | ArrowArrayExportable

--- a/py-polars/src/polars/series/series.py
+++ b/py-polars/src/polars/series/series.py
@@ -4987,7 +4987,9 @@ class Series(metaclass=_Meta):
             removed_in="2.0",
         ),
     )
-    def to_arrow(self, *, compat_level: CompatLevel | None = None) -> pa.Array:
+    def to_arrow(
+        self, *, compat_level: CompatLevel | None = None
+    ) -> pa.Array[Any] | pa.ChunkedArray[Any]:
         """
         Return the underlying Arrow array.
 


### PR DESCRIPTION
## Summary

- annotate `from_arrow`'s `Array` and `ChunkedArray` inputs with explicit `Any` scalar parameters
- annotate `Series.to_arrow` with parameterized `Array` / `ChunkedArray` outputs
- prevent strict downstream type checkers from treating these public callables and returned arrays as partially unknown
