### PR TITLE
fix: Error instead of segfault for `exp`/`log1p` on non-numeric dtypes

### DIFF
--- a/crates/polars-expr/src/dispatch/misc.rs
+++ b/crates/polars-expr/src/dispatch/misc.rs
@@ -702,14 +702,14 @@ pub(super) fn log(columns: &[Column]) -> PolarsResult<Column> {
 pub(super) fn log1p(s: &Column) -> PolarsResult<Column> {
     use polars_ops::series::LogSeries;
 
-    Ok(s.as_materialized_series().log1p().into())
+    Ok(s.as_materialized_series().log1p()?.into())
 }
 
 #[cfg(feature = "log")]
 pub(super) fn exp(s: &Column) -> PolarsResult<Column> {
     use polars_ops::series::LogSeries;
 
-    Ok(s.as_materialized_series().exp().into())
+    Ok(s.as_materialized_series().exp()?.into())
 }
 
 pub(super) fn unique(s: &Column, stable: bool) -> PolarsResult<Column> {

--- a/crates/polars-ops/src/series/ops/log.rs
+++ b/crates/polars-ops/src/series/ops/log.rs
@@ -39,8 +39,9 @@ pub trait LogSeries: SeriesSealed {
     }
 
     /// Compute the natural logarithm of all elements plus one in the input array
-    fn log1p(&self) -> Series {
+    fn log1p(&self) -> PolarsResult<Series> {
         let s = self.as_series();
+        polars_ensure!(s.dtype().is_numeric() || s.dtype().is_bool(), InvalidOperation: "expected numerical input for 'log1p'");
         if s.dtype().is_decimal() {
             return s.cast(&DataType::Float64).unwrap().log1p();
         }
@@ -53,20 +54,21 @@ pub trait LogSeries: SeriesSealed {
             dt if dt.is_integer() => {
                 with_match_physical_integer_polars_type!(s.dtype(), |$T| {
                     let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-                    log1p(ca).into_series()
+                    Ok(log1p(ca).into_series())
                 })
             },
             #[cfg(feature = "dtype-f16")]
-            Float16 => s.f16().unwrap().apply_values(|v| v.ln_1p()).into_series(),
-            Float32 => s.f32().unwrap().apply_values(|v| v.ln_1p()).into_series(),
-            Float64 => s.f64().unwrap().apply_values(|v| v.ln_1p()).into_series(),
+            Float16 => Ok(s.f16().unwrap().apply_values(|v| v.ln_1p()).into_series()),
+            Float32 => Ok(s.f32().unwrap().apply_values(|v| v.ln_1p()).into_series()),
+            Float64 => Ok(s.f64().unwrap().apply_values(|v| v.ln_1p()).into_series()),
             _ => s.cast(&DataType::Float64).unwrap().log1p(),
         }
     }
 
     /// Calculate the exponential of all elements in the input array.
-    fn exp(&self) -> Series {
+    fn exp(&self) -> PolarsResult<Series> {
         let s = self.as_series();
+        polars_ensure!(s.dtype().is_numeric() || s.dtype().is_bool(), InvalidOperation: "expected numerical input for 'exp'");
         if s.dtype().is_decimal() {
             return s.cast(&DataType::Float64).unwrap().exp();
         }
@@ -79,13 +81,13 @@ pub trait LogSeries: SeriesSealed {
             dt if dt.is_integer() => {
                 with_match_physical_integer_polars_type!(s.dtype(), |$T| {
                     let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-                    exp(ca).into_series()
+                    Ok(exp(ca).into_series())
                 })
             },
             #[cfg(feature = "dtype-f16")]
-            Float16 => s.f16().unwrap().apply_values(|v| v.exp()).into_series(),
-            Float32 => s.f32().unwrap().apply_values(|v| v.exp()).into_series(),
-            Float64 => s.f64().unwrap().apply_values(|v| v.exp()).into_series(),
+            Float16 => Ok(s.f16().unwrap().apply_values(|v| v.exp()).into_series()),
+            Float32 => Ok(s.f32().unwrap().apply_values(|v| v.exp()).into_series()),
+            Float64 => Ok(s.f64().unwrap().apply_values(|v| v.exp()).into_series()),
             _ => s.cast(&DataType::Float64).unwrap().exp(),
         }
     }

--- a/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/function_expr/schema.rs
@@ -283,7 +283,15 @@ impl IRFunctionExpr {
             #[cfg(feature = "interpolate_by")]
             InterpolateBy => mapper.map_numeric_to_float_dtype(true),
             #[cfg(feature = "log")]
-            Entropy { .. } | Log1p | Exp => mapper.map_to_float_dtype(),
+            Entropy { .. } => mapper.map_to_float_dtype(),
+            #[cfg(feature = "log")]
+            Log1p => mapper
+                .ensure_satisfies(|_, dtype| dtype.is_numeric() || dtype.is_bool(), "log1p")?
+                .map_to_float_dtype(),
+            #[cfg(feature = "log")]
+            Exp => mapper
+                .ensure_satisfies(|_, dtype| dtype.is_numeric() || dtype.is_bool(), "exp")?
+                .map_to_float_dtype(),
             #[cfg(feature = "log")]
             Log => mapper.log_dtype(),
             Unique(_) => mapper.with_same_dtype(),

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -251,6 +251,30 @@ def test_exp_log1p(dtype_in: PolarsDataType, dtype_out: PolarsDataType) -> None:
     assert result.collect_schema() == expected.schema
 
 
+@pytest.mark.parametrize(
+    "s",
+    [
+        pl.Series("a", [{"a": 1, "b": "x"}]),
+        pl.Series("a", ["1", "2", "3"]),
+        pl.Series("a", [date(2020, 1, 1), date(2021, 1, 1)]),
+        pl.Series("a", [[1, 2], [3]]),
+    ],
+)
+def test_exp_log1p_invalid_dtype_29102(s: pl.Series) -> None:
+    lf = pl.LazyFrame([s])
+
+    for expr in (pl.col("a").exp(), pl.col("a").log1p()):
+        q = lf.select(expr)
+
+        # planner: schema resolution must reject the input dtype
+        with pytest.raises(InvalidOperationError):
+            q.collect_schema()
+
+        # engine: execution must error, not segfault
+        with pytest.raises(InvalidOperationError):
+            q.collect()
+
+
 def test_dot_in_group_by() -> None:
     df = pl.DataFrame(
         {


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/29102.

As a note, I made the guard `dtype.is_numeric() || dtype.is_bool()` since Booleans were already accepted by `exp`/`log1p` before this change (cast to `Float64`), and rejecting them here would be a breaking change. This is consistent with `map_numeric_to_float_dtype` in `schema.rs`, which explicitly treats Boolean as coercible to float for `sqrt`, `cbrt`, `ewm_*`, and interpolate, and with `sum_horizontal`/`mean_horizontal`, which accept `is_bool()` alongside numeric dtypes. It also matches numpy, where `np.exp(True) == e`. 

Happy to tighten it to `is_numeric()` only if that's preferred.

Claude Fable 5.1 for navigating the code, asking questions, and helping with the test. 
