### PR TITLE
perf: Skip redundant output validity construction in all-valid arr.dot

### DIFF
--- a/crates/polars-expr/src/dispatch/array.rs
+++ b/crates/polars-expr/src/dispatch/array.rs
@@ -75,9 +75,13 @@ pub(super) fn sum(s: &Column) -> PolarsResult<Column> {
 }
 
 pub(super) fn dot(s: &[Column]) -> PolarsResult<Column> {
-    let lhs = s[0].array()?;
-    let rhs = s[1].array()?;
-    lhs.array_dot(rhs).map(Column::from)
+    let lhs = s[0].as_materialized_series_maintain_scalar();
+    let rhs = s[1].as_materialized_series_maintain_scalar();
+
+    lhs.array()?
+        .array_dot(rhs.array()?)?
+        .into_column()
+        .broadcast_owned_to(broadcast_len(s)?)
 }
 
 pub(super) fn std(s: &Column, ddof: u8) -> PolarsResult<Column> {

--- a/crates/polars-ops/src/chunked_array/array/dot.rs
+++ b/crates/polars-ops/src/chunked_array/array/dot.rs
@@ -37,8 +37,9 @@ where
 {
     /// # Safety
     ///
-    /// Row-offset calculations must not overflow. Each selected row must fit in
-    /// its value slice and optional validity bitmap.
+    /// Selected row indices must be valid for their corresponding outer
+    /// arrays. Child values and optional validity must cover each complete
+    /// fixed-width layout; `outer_len * width` must fit in `usize`.
     #[inline(always)]
     unsafe fn dot_row(&self, lhs_idx: usize, rhs_idx: usize) -> T::Sum {
         let lhs_offset = lhs_idx * self.width;
@@ -135,6 +136,18 @@ where
     let lhs_inner_validity = lhs_values.validity();
     let rhs_inner_validity = rhs_values.validity();
     let width = lhs.width();
+    debug_assert!(
+        lhs.len()
+            .checked_mul(width)
+            .is_some_and(|len| lhs_slice.len() >= len)
+    );
+    debug_assert!(
+        rhs.len()
+            .checked_mul(width)
+            .is_some_and(|len| rhs_slice.len() >= len)
+    );
+    debug_assert!(lhs_inner_validity.is_none_or(|validity| validity.len() >= lhs_slice.len()));
+    debug_assert!(rhs_inner_validity.is_none_or(|validity| validity.len() >= rhs_slice.len()));
     let row_reducer = DotRowReducer {
         lhs_slice,
         rhs_slice,
@@ -145,6 +158,8 @@ where
     let lhs_broadcast = lhs.len() == 1 && output_len != 1;
     let rhs_broadcast = rhs.len() == 1 && output_len != 1;
 
+    // An absent outer bitmap guarantees valid output rows without scanning.
+    // Child validity only filters coordinate pairs inside `DotRowReducer`.
     if lhs_array.validity().is_none() && rhs_array.validity().is_none() {
         let output = dot_outer_all_valid(&row_reducer, lhs_broadcast, rhs_broadcast, output_len);
         let output = PrimitiveArray::from_data_default(output.into(), None);

--- a/crates/polars-ops/src/chunked_array/array/dot.rs
+++ b/crates/polars-ops/src/chunked_array/array/dot.rs
@@ -1,5 +1,5 @@
 use arrow::array::{Array, PrimitiveArray};
-use arrow::bitmap::BitmapBuilder;
+use arrow::bitmap::{Bitmap, BitmapBuilder};
 use arrow::types::NativeType;
 use num_traits::Zero;
 use polars_compute::arithmetic::pl_num::PlNumArithmetic;
@@ -20,6 +20,90 @@ where
 {
     let product = PlNumArithmetic::wrapping_mul(lhs, rhs).into();
     acc.wrapping_add(&product)
+}
+
+struct DotRowReducer<'a, T> {
+    lhs_slice: &'a [T],
+    rhs_slice: &'a [T],
+    lhs_inner_validity: Option<&'a Bitmap>,
+    rhs_inner_validity: Option<&'a Bitmap>,
+    width: usize,
+}
+
+impl<T> DotRowReducer<'_, T>
+where
+    T: NativeType + PlNumArithmetic + SumCast,
+    T::Sum: WrappingAdd,
+{
+    /// # Safety
+    ///
+    /// Row-offset calculations must not overflow. Each selected row must fit in
+    /// its value slice and optional validity bitmap.
+    #[inline(always)]
+    unsafe fn dot_row(&self, lhs_idx: usize, rhs_idx: usize) -> T::Sum {
+        let lhs_offset = lhs_idx * self.width;
+        let rhs_offset = rhs_idx * self.width;
+        let (lhs_row, rhs_row) = unsafe {
+            // SAFETY: function contract guarantees both ranges are in bounds
+            // and calculations above did not overflow. Width zero yields 0..0.
+            (
+                self.lhs_slice
+                    .get_unchecked(lhs_offset..lhs_offset + self.width),
+                self.rhs_slice
+                    .get_unchecked(rhs_offset..rhs_offset + self.width),
+            )
+        };
+
+        if self.lhs_inner_validity.is_none() && self.rhs_inner_validity.is_none() {
+            lhs_row
+                .iter()
+                .zip(rhs_row)
+                .fold(T::Sum::zero(), |acc, (&lhs, &rhs)| {
+                    multiply_then_add(acc, lhs, rhs)
+                })
+        } else {
+            let mut value = T::Sum::zero();
+            for (inner_idx, (&lhs, &rhs)) in lhs_row.iter().zip(rhs_row).enumerate() {
+                let lhs_valid = self.lhs_inner_validity.is_none_or(|validity| {
+                    // SAFETY: inner_idx < width and lhs_offset + width <= validity.len().
+                    unsafe { validity.get_bit_unchecked(lhs_offset + inner_idx) }
+                });
+                let rhs_valid = self.rhs_inner_validity.is_none_or(|validity| {
+                    // SAFETY: inner_idx < width and rhs_offset + width <= validity.len().
+                    unsafe { validity.get_bit_unchecked(rhs_offset + inner_idx) }
+                });
+                if lhs_valid && rhs_valid {
+                    value = multiply_then_add(value, lhs, rhs);
+                }
+            }
+            value
+        }
+    }
+}
+
+// Keep one outer-loop call; inline `dot_row` to avoid one call per output row.
+#[inline(never)]
+fn dot_outer_all_valid<T>(
+    row_reducer: &DotRowReducer<T>,
+    lhs_broadcast: bool,
+    rhs_broadcast: bool,
+    output_len: usize,
+) -> Vec<T::Sum>
+where
+    T: NativeType + PlNumArithmetic + SumCast,
+    T::Sum: WrappingAdd,
+{
+    let mut output = Vec::with_capacity(output_len);
+
+    for output_idx in 0..output_len {
+        let lhs_idx = if lhs_broadcast { 0 } else { output_idx };
+        let rhs_idx = if rhs_broadcast { 0 } else { output_idx };
+        // SAFETY: broadcast uses row 0; otherwise validated equal lengths make
+        // `output_idx` valid for both operands.
+        output.push(unsafe { row_reducer.dot_row(lhs_idx, rhs_idx) });
+    }
+
+    output
 }
 
 fn dot_primitive<T>(
@@ -51,8 +135,21 @@ where
     let lhs_inner_validity = lhs_values.validity();
     let rhs_inner_validity = rhs_values.validity();
     let width = lhs.width();
+    let row_reducer = DotRowReducer {
+        lhs_slice,
+        rhs_slice,
+        lhs_inner_validity,
+        rhs_inner_validity,
+        width,
+    };
     let lhs_broadcast = lhs.len() == 1 && output_len != 1;
     let rhs_broadcast = rhs.len() == 1 && output_len != 1;
+
+    if lhs_array.validity().is_none() && rhs_array.validity().is_none() {
+        let output = dot_outer_all_valid(&row_reducer, lhs_broadcast, rhs_broadcast, output_len);
+        let output = PrimitiveArray::from_data_default(output.into(), None);
+        return Series::try_from((lhs.name().clone(), vec![Box::new(output) as ArrayRef]));
+    }
 
     let mut output = Vec::with_capacity(output_len);
     let mut output_validity = BitmapBuilder::with_capacity(output_len);
@@ -60,6 +157,8 @@ where
     for output_idx in 0..output_len {
         let lhs_idx = if lhs_broadcast { 0 } else { output_idx };
         let rhs_idx = if rhs_broadcast { 0 } else { output_idx };
+        // SAFETY: broadcast uses row 0; otherwise validated equal lengths make
+        // `output_idx` valid for both operands.
         let outer_valid = unsafe {
             !lhs_array.is_null_unchecked(lhs_idx) && !rhs_array.is_null_unchecked(rhs_idx)
         };
@@ -70,34 +169,9 @@ where
             continue;
         }
 
-        let lhs_offset = lhs_idx * width;
-        let rhs_offset = rhs_idx * width;
-        let lhs_row = unsafe { lhs_slice.get_unchecked(lhs_offset..lhs_offset + width) };
-        let rhs_row = unsafe { rhs_slice.get_unchecked(rhs_offset..rhs_offset + width) };
-
-        let value = if lhs_inner_validity.is_none() && rhs_inner_validity.is_none() {
-            lhs_row
-                .iter()
-                .zip(rhs_row)
-                .fold(T::Sum::zero(), |acc, (&lhs, &rhs)| {
-                    multiply_then_add(acc, lhs, rhs)
-                })
-        } else {
-            let mut value = T::Sum::zero();
-            for (inner_idx, (&lhs, &rhs)) in lhs_row.iter().zip(rhs_row).enumerate() {
-                let lhs_valid = lhs_inner_validity.is_none_or(|validity| unsafe {
-                    validity.get_bit_unchecked(lhs_offset + inner_idx)
-                });
-                let rhs_valid = rhs_inner_validity.is_none_or(|validity| unsafe {
-                    validity.get_bit_unchecked(rhs_offset + inner_idx)
-                });
-                if lhs_valid && rhs_valid {
-                    value = multiply_then_add(value, lhs, rhs);
-                }
-            }
-            value
-        };
-        output.push(value);
+        // SAFETY: broadcast uses row 0; otherwise validated equal lengths make
+        // `output_idx` valid for both operands.
+        output.push(unsafe { row_reducer.dot_row(lhs_idx, rhs_idx) });
     }
 
     let output =

--- a/py-polars/tests/unit/operations/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_array.py
@@ -329,6 +329,15 @@ def test_arr_dot_inner_nulls_without_outer_validity() -> None:
         pl.Series("a", [4.0, 0.0], dtype=pl.Float64),
     )
 
+    query = pl.Series(
+        "b",
+        [[4.0, None, 6.0]],
+        dtype=pl.Array(pl.Float64, 3),
+    )
+    expected = pl.Series("a", [22.0, 0.0], dtype=pl.Float64)
+    assert_series_equal(lhs.arr.dot(query), expected)
+    assert_series_equal(query.arr.dot(lhs), expected.rename("b"))
+
 
 def test_arr_dot_zero_width_without_outer_validity() -> None:
     zero_width = pl.Series("a", [[], []], dtype=pl.Array(pl.Float64, 0))

--- a/py-polars/tests/unit/operations/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_array.py
@@ -312,6 +312,32 @@ def test_arr_dot_nulls() -> None:
     )
 
 
+def test_arr_dot_inner_nulls_without_outer_validity() -> None:
+    lhs = pl.Series(
+        "a",
+        [[1.0, None, 3.0], [None, 2.0, None]],
+        dtype=pl.Array(pl.Float64, 3),
+    )
+    rhs = pl.Series(
+        "b",
+        [[4.0, 5.0, None], [3.0, None, 4.0]],
+        dtype=pl.Array(pl.Float64, 3),
+    )
+
+    assert_series_equal(
+        lhs.arr.dot(rhs),
+        pl.Series("a", [4.0, 0.0], dtype=pl.Float64),
+    )
+
+
+def test_arr_dot_zero_width_without_outer_validity() -> None:
+    zero_width = pl.Series("a", [[], []], dtype=pl.Array(pl.Float64, 0))
+    assert_series_equal(
+        zero_width.arr.dot(zero_width),
+        pl.Series("a", [0.0, 0.0], dtype=pl.Float64),
+    )
+
+
 @pytest.mark.parametrize("dtype", [pl.Float32, pl.Float64])
 def test_arr_dot_special_floating_values(dtype: pl.DataType) -> None:
     lhs = pl.Series(

--- a/py-polars/tests/unit/operations/test_scalar.py
+++ b/py-polars/tests/unit/operations/test_scalar.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Literal
 
 import pytest
 
@@ -152,6 +152,50 @@ def test_elementwise_over_broadcast_scalar_array(expr: pl.Expr) -> None:
     )
     assert_frame_equal(
         broadcast.select(expr).collect(), materialized.select(expr).collect()
+    )
+
+
+@pytest.mark.parametrize("engine", ["in-memory", "streaming"])
+@pytest.mark.parametrize(
+    "expr",
+    [
+        pytest.param(pl.col("lhs").arr.dot("rhs"), id="scalar-rhs"),
+        pytest.param(pl.col("rhs").arr.dot("lhs"), id="scalar-lhs"),
+    ],
+)
+def test_arr_dot_over_broadcast_scalar_array(
+    engine: Literal["in-memory", "streaming"], expr: pl.Expr
+) -> None:
+    dtype = pl.Array(pl.Int64, 3)
+    lhs = pl.Series("lhs", [[1, 2, 3], [4, None, 6], None], dtype=dtype)
+    rhs = pl.Series("rhs", [[10, None, 30]], dtype=dtype)
+    broadcast = pl.LazyFrame({"lhs": lhs}).with_columns(pl.lit(rhs).first())
+    materialized = pl.LazyFrame(
+        {
+            "lhs": lhs,
+            "rhs": pl.Series("rhs", [[10, None, 30]] * len(lhs), dtype=dtype),
+        }
+    )
+    assert_frame_equal(
+        broadcast.select(expr).collect(engine=engine),
+        materialized.select(expr).collect(engine=engine),
+    )
+
+
+@pytest.mark.parametrize("engine", ["in-memory", "streaming"])
+def test_arr_dot_over_empty_broadcast_scalar_array(
+    engine: Literal["in-memory", "streaming"],
+) -> None:
+    dtype = pl.Array(pl.Float64, 2)
+    broadcast = pl.LazyFrame(schema={"lhs": dtype}).with_columns(
+        pl.lit(pl.Series("rhs", [[10.0, 20.0]], dtype=dtype)).first()
+    )
+    materialized = pl.LazyFrame(schema={"lhs": dtype, "rhs": dtype})
+    expr = pl.col("lhs").arr.dot("rhs")
+
+    assert_frame_equal(
+        broadcast.select(expr).collect(engine=engine),
+        materialized.select(expr).collect(engine=engine),
     )
 
 


### PR DESCRIPTION
Closes #29113

Depends on #29000 merge (first commit from #29000)

When both FixedSizeList inputs have no outer validity bitmap, result validity is constructed with `None` instead of filling `BitmapBuilder` that `into_opt_validity()` discards. Any present outer validity bitmap keeps existing path. `DotRowReducer` shares numeric reduction and child-validity handling across both paths.

<img width="1152" height="1152" alt="direct-v12-vs-29000" src="https://github.com/user-attachments/assets/42ff36a1-4e42-4a90-8aa3-493eb90a0626" />

**DuckDB endpoint check**

Layout | Width | Output rows | Polars, ms | DuckDB, ms |Median Polars/DuckDB ratio| Polars lead
-- | -- | -- | -- | -- | -- | --
row-wise | 8 | 524,288 | 0.821 | 2.830 | 0.290 | 3.45×
row-wise | 768 | 5,461 | 1.811 | 3.095 | 0.590 | 1.69×
scalar RHS | 8 | 524,288 | 0.813 | 2.250 | 0.362 | 2.76×
scalar RHS | 768 | 5,461 | 1.807 | 5.694 | 0.318 | 3.14×

Each cell processed approx. 4.19M coordinate pairs: 4,194,304 at width 8 and 4,194,048 at width 768. Latency columns report medians of 8 fresh-process medians. Ratio column reports median of 8 block-paired Polars/DuckDB ratios. **Every pair favored Polars.**

<details>
<summary>Benchmark details</summary>

Apple M4 Max, one thread, Float64, Polars 2.0.0-rc.1 (`6add117`) in-memory engine versus DuckDB Python 1.6.0.dev380 with embedded core v2.0.0-dev83495 (`ee95013`) default streaming/vectorized pipeline. Polars streaming scheduling and concurrency were outside scope.

Comparison inputs contained neither outer nulls nor child nulls.

Build details:
- Polars: make build-release, runtime-32, debug disabled
- DuckDB: Release wheel, NATIVE_ARCH=OFF
- Python: 3.13.14
- NumPy: 2.5.2
- PyArrow: 25.0.1

| Operation | Polars | DuckDB |
| :--- | :--- | :--- |
| Thread limit | `POLARS_MAX_THREADS=1` | `SET threads = 1` |
| Input setup *(outside timing)* | `frame = pl.from_arrow(`<br>`arrow_table, rechunk=True)` | `CREATE TABLE input AS`<br>`SELECT * FROM arrow_input;` |
| Row-wise dot | `frame.lazy().select(`<br>`pl.col("lhs").arr.dot(pl.col("rhs"))`<br>`.sum().alias("result"))` | `SELECT sum(`<br>`array_inner_product(lhs, rhs)`<br>`) FROM input;` |
| Scalar-RHS dot | `rhs = pl.lit(`<br>`rhs_values, dtype=pl.Array(pl.Float64, width))`<br><br>`frame.lazy().select(`<br>`pl.col("lhs").arr.dot(rhs)`<br>`.sum().alias("result"))` | `SELECT sum(`<br>`array_inner_product(`<br>`lhs, [val_0, ...]::DOUBLE[width]`<br>`)) FROM input;` |
| Control | `frame.lazy().select(`<br>`pl.col("control").sum().alias("result"))` | `SELECT sum(control)`<br>`FROM input;` |
| Timed invocation | `float(`<br>`primary_query.collect(engine="in-memory")`<br>`.item(0, 0))` | `float(`<br>`connection.execute("EXECUTE primary_stmt")`<br>`.fetchone()[0])` |

Polars query expression was created before timing, each timed iteration called `collect(engine="in-memory")` and extracted scalar result. DuckDB SQL was prepared before timing, each timed iteration called `EXECUTE` and extracted scalar result.

I can run SQL-to-SQL comparison next time if this gets approval.

</details>
