### PR TITLE
fix: Match engine output dtype in planner for `Decimal` true division with integers

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -861,11 +861,11 @@ fn get_truediv_dtype(left_dtype: &DataType, right_dtype: &DataType) -> PolarsRes
             Decimal(DEC128_MAX_PREC, *scale_left.max(scale_right))
         },
         #[cfg(feature = "dtype-decimal")]
-        (l @ Decimal(_, _), r) if r.is_primitive_numeric() => {
-            if r.is_float() {
+        (Decimal(_, scale), dtype) | (dtype, Decimal(_, scale)) if dtype.is_primitive_numeric() => {
+            if dtype.is_float() {
                 Float64
             } else {
-                l.clone()
+                Decimal(DEC128_MAX_PREC, *scale)
             }
         },
         #[cfg(all(feature = "dtype-u8", feature = "dtype-f16"))]

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -19,6 +19,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from polars._typing import PolarsDataType
     from tests.conftest import PlMonkeyPatch
 
 
@@ -665,6 +666,25 @@ def test_decimal_arithmetic_schema_int() -> None:
     assert_series_equal((1 + s), pl.Series("literal", [2.0], dtype=pl.Decimal(38, 6)))
     assert_series_equal((s * 1), pl.Series("x", [1.0], dtype=pl.Decimal(38, 6)))
     assert_series_equal((1 * s), pl.Series("literal", [1.0], dtype=pl.Decimal(38, 6)))
+
+
+@pytest.mark.parametrize(
+    "int_dtype",
+    [pl.Int8, pl.Int16, pl.Int32, pl.Int64, pl.UInt8, pl.UInt32],
+)
+def test_decimal_truediv_int_schema_29105(int_dtype: PolarsDataType) -> None:
+    lf = pl.LazyFrame({"i": [1]}, schema={"i": int_dtype}).with_columns(
+        d=pl.lit(1).cast(pl.Decimal(18, 4))
+    )
+
+    for expr, name in (
+        (pl.col("i") / pl.col("d"), "i"),
+        (pl.col("d") / pl.col("i"), "d"),
+    ):
+        q = lf.select(expr)
+        schema = q.collect_schema()
+        assert schema == q.collect().schema
+        assert schema[name] == pl.Decimal(38, 4)
 
 
 def test_decimal_horizontal_20482() -> None:


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/29105.

The issue here was that `Operator::TrueDivide` was calling `get_truediv_field`, which internally calls `get_truediv_dtype`. In `get_truediv_dtype` there was a match arm for getting the dtype for division between decimals and primitive numeric:

```rust
#[cfg(feature = "dtype-decimal")]
(l @ Decimal(_, _), r) if r.is_primitive_numeric() => {
    if r.is_float() {
        Float64
    } else {
        l.clone()
    }
},
```

However, there we problems with this match arm: it was unilateral (only handling the situation in which we are dividing a `Decimal` dtype by a primitive numeric and not vice-versa) and it returned `l.clone()`, so it cloned the `Decimal` dtype exactly without expanding the precision to `DEC128_MAX_PREC`, like happens several times in the same file and in the engine. 

🤖 Claude Fable 5.1 for navigating code, asking questions, and writing the test based on my instructions.