### PR TITLE
feat: Update documentation analytics implementation

### DIFF
--- a/docs/source/_build/js/posthog-init.js
+++ b/docs/source/_build/js/posthog-init.js
@@ -1,0 +1,32 @@
+!function (t, e) {
+    var o, n, p, r;
+    e.__SV || (window.posthog = e, e._i = [], e.init = function (i, s, a) {
+        function g(t, e) {
+            var o = e.split(".");
+            2 == o.length && (t = t[o[0]], e = o[1]), t[e] = function () {
+                t.push([e].concat(Array.prototype.slice.call(arguments, 0)));
+            };
+        }
+
+        (p = t.createElement("script")).type = "text/javascript", p.crossOrigin = "anonymous", p.async = !0, p.src = s.api_host.replace(".i.posthog.com", "-assets.i.posthog.com") + "/static/array.js", (r = t.getElementsByTagName("script")[0]).parentNode.insertBefore(p, r);
+        var u = e;
+        for (void 0 !== a ? u = e[a] = [] : a = "posthog", u.people = u.people || [], u.toString = function (t) {
+            var e = "posthog";
+            return "posthog" !== a && (e += "." + a), t || (e += " (stub)"), e;
+        }, u.people.toString = function () {
+            return u.toString(1) + ".people (stub)";
+        }, o = "init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(" "), n = 0; n < o.length; n++) g(u, o[n]);
+        e._i.push([i, s, a]);
+    }, e.__SV = 1);
+}(document, window.posthog || []);
+
+var POSTHOG_ALLOWED_HOSTS = ["docs.pola.rs"];
+
+if (POSTHOG_ALLOWED_HOSTS.includes(location.hostname)) {
+    posthog.init("phc_uumWzEuHxsPf47UvXwi2N2TzeB3CbLURPTGGZNkyp6ZQ", {
+        api_host: "https://eu.i.posthog.com",
+        defaults: "2026-05-30",
+        cookieless_mode: "always",
+        person_profiles: "never",
+    });
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -158,6 +158,7 @@ theme:
 extra_javascript:
     - _build/js/mathjax.js
     - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+    - _build/js/posthog-init.js
 extra_css:
     - _build/css/extra.css
 extra:

--- a/py-polars/docs/source/_static/js/posthog-init.js
+++ b/py-polars/docs/source/_static/js/posthog-init.js
@@ -1,0 +1,32 @@
+!function (t, e) {
+    var o, n, p, r;
+    e.__SV || (window.posthog = e, e._i = [], e.init = function (i, s, a) {
+        function g(t, e) {
+            var o = e.split(".");
+            2 == o.length && (t = t[o[0]], e = o[1]), t[e] = function () {
+                t.push([e].concat(Array.prototype.slice.call(arguments, 0)));
+            };
+        }
+
+        (p = t.createElement("script")).type = "text/javascript", p.crossOrigin = "anonymous", p.async = !0, p.src = s.api_host.replace(".i.posthog.com", "-assets.i.posthog.com") + "/static/array.js", (r = t.getElementsByTagName("script")[0]).parentNode.insertBefore(p, r);
+        var u = e;
+        for (void 0 !== a ? u = e[a] = [] : a = "posthog", u.people = u.people || [], u.toString = function (t) {
+            var e = "posthog";
+            return "posthog" !== a && (e += "." + a), t || (e += " (stub)"), e;
+        }, u.people.toString = function () {
+            return u.toString(1) + ".people (stub)";
+        }, o = "init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(" "), n = 0; n < o.length; n++) g(u, o[n]);
+        e._i.push([i, s, a]);
+    }, e.__SV = 1);
+}(document, window.posthog || []);
+
+var POSTHOG_ALLOWED_HOSTS = ["docs.pola.rs"];
+
+if (POSTHOG_ALLOWED_HOSTS.includes(location.hostname)) {
+    posthog.init("phc_uumWzEuHxsPf47UvXwi2N2TzeB3CbLURPTGGZNkyp6ZQ", {
+        api_host: "https://eu.i.posthog.com",
+        defaults: "2026-05-30",
+        cookieless_mode: "always",
+        person_profiles: "never",
+    });
+}

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -145,6 +145,7 @@ html_js_files = [
         "https://plausible.io/js/script.js",
         {"data-domain": "docs.pola.rs,combined.pola.rs", "defer": "defer"},
     ),
+    "js/posthog-init.js",
 ]
 
 html_theme_options = {


### PR DESCRIPTION
Adding PostHog analytics to the user guide and API reference docs, alongside the existing Plausible setup for validation purposes. We are researching the option to move away from the existing Plausible implementation. The implementation remains cookieless for the docs.

- Loads PostHog via a local posthog-init.js (same pattern as mathjax.js/announcement-dismiss.js), referenced in both mkdocs.yml (user guide) and conf.py (API reference).
- Runs cookieless (cookieless_mode: "always", person_profiles: "never")
- posthog.init() is gated behind a POSTHOG_ALLOWED_HOSTS allow-list (docs.pola.rs), so local builds, etc. are not captured.

We will run Posthog and Plausible side by side till the end of September to determine which tool we keep.

In this PR, AI was used for the POSTHOG_ALLOWED_HOSTS logic to ensure we don't load the PostHog script in local environments and environments other than docs.pola.rs
