### PR TITLE
fix: Wrap IoError in PathIoError such that callers can extract untruncated path

### DIFF
--- a/crates/polars-io/src/utils/mkdir.rs
+++ b/crates/polars-io/src/utils/mkdir.rs
@@ -1,28 +1,54 @@
 use std::io;
+use std::path::{Path, PathBuf};
 
+use polars_error::PolarsResult;
+use polars_utils::io::_limit_path_len_io_err;
 use polars_utils::pl_path::PlRefPath;
 
-pub fn mkdir_recursive(path: &PlRefPath) -> io::Result<()> {
-    if !path.has_scheme() {
-        std::fs::DirBuilder::new().recursive(true).create(
-            path.parent()
-                .ok_or(io::Error::other("path is not a file"))?,
-        )?;
-    }
+use crate::path_utils::resolve_homedir;
 
-    Ok(())
+/// Creates the directory `path` will be written into.
+///
+/// Does nothing for paths with a scheme; object stores have no directories to create.
+pub fn mkdir_recursive(path: &PlRefPath) -> PolarsResult<()> {
+    let Some(parent) = writable_parent(path)? else {
+        return Ok(());
+    };
+
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .create(&parent)
+        .map_err(|err| _limit_path_len_io_err(&parent, err))
 }
 
-pub async fn tokio_mkdir_recursive(path: &PlRefPath) -> io::Result<()> {
-    if !path.has_scheme() {
-        tokio::fs::DirBuilder::new()
-            .recursive(true)
-            .create(
-                path.parent()
-                    .ok_or(io::Error::other("path is not a file"))?,
-            )
-            .await?;
+/// Async counterpart of [`mkdir_recursive`].
+pub async fn tokio_mkdir_recursive(path: &PlRefPath) -> PolarsResult<()> {
+    let Some(parent) = writable_parent(path)? else {
+        return Ok(());
+    };
+
+    tokio::fs::DirBuilder::new()
+        .recursive(true)
+        .create(&parent)
+        .await
+        .map_err(|err| _limit_path_len_io_err(&parent, err))
+}
+
+/// The local directory that must exist before `path` can be opened for writing, or `None`
+/// when there is nothing to create.
+fn writable_parent(path: &PlRefPath) -> PolarsResult<Option<PathBuf>> {
+    if path.has_scheme() {
+        return Ok(None);
     }
 
-    Ok(())
+    let Some(parent) = path.parent() else {
+        return Err(io::Error::other(format!("path is not a file: {path}")).into());
+    };
+
+    // A path with a single component has no directory to create.
+    if parent.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(resolve_homedir(Path::new(parent)).into_owned()))
 }

--- a/crates/polars-stream/src/nodes/io_sinks/components/file_provider.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/components/file_provider.rs
@@ -79,16 +79,10 @@ impl FileProvider {
             "provided path '{provided_path}' contained parent dir component '..'"
         );
 
-        if !path.has_scheme()
-            && let Some(path) = path.parent()
-        {
-            // Ignore errors from directory creation - the `Writable::try_new()` below will raise
-            // appropriate errors.
-            let _ = tokio::fs::DirBuilder::new()
-                .recursive(true)
-                .create(path)
-                .await;
-        }
+        // Raise errors from directory creation here, so the reason it could not be created is
+        // reported, rather than raising "No such file or directory" when we try to open the
+        // missing directory below.
+        polars_io::utils::mkdir::tokio_mkdir_recursive(&path).await?;
 
         if let Some(path_info_entry) = &path_info_entry {
             path_info_entry.set_path(path.clone());

--- a/crates/polars-utils/src/io.rs
+++ b/crates/polars-utils/src/io.rs
@@ -1,18 +1,62 @@
 use std::fs::File;
-use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::{fmt, io};
 
 use polars_error::*;
 
+/// An IO error together with the full path it occurred on.
+///
+/// The `Display` output truncates long paths so they stay readable in error messages, but
+/// the full path remains available to consumers that downcast the payload of the
+/// [`io::Error`] built by [`_limit_path_len_io_err`].
+#[derive(Debug)]
+pub struct PathIoError {
+    pub path: PathBuf,
+    pub source: io::Error,
+}
+
+impl PathIoError {
+    const MAX_DISPLAYED_PATH_CHARS: usize = 88;
+}
+
+impl fmt::Display for PathIoError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let path = self.path.to_string_lossy();
+        let n_chars = path.chars().count();
+        if n_chars > Self::MAX_DISPLAYED_PATH_CHARS && !polars_config::config().verbose() {
+            let truncated_path: String = path
+                .chars()
+                .skip(n_chars - Self::MAX_DISPLAYED_PATH_CHARS)
+                .collect();
+            write!(
+                f,
+                "{}: ...{truncated_path} (set POLARS_VERBOSE=1 to see full path)",
+                self.source
+            )
+        } else {
+            write!(f, "{}: {path}", self.source)
+        }
+    }
+}
+
+impl std::error::Error for PathIoError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+/// Attaches `path` to `err`, keeping its [`io::ErrorKind`].
+///
+/// The path is available in full through [`PathIoError`], and truncated in the message.
 pub fn _limit_path_len_io_err(path: &Path, err: io::Error) -> PolarsError {
-    let path = path.to_string_lossy();
-    let msg = if path.len() > 88 && !polars_config::config().verbose() {
-        let truncated_path: String = path.chars().skip(path.len() - 88).collect();
-        format!("{err}: ...{truncated_path} (set POLARS_VERBOSE=1 to see full path)")
-    } else {
-        format!("{err}: {path}")
-    };
-    io::Error::new(err.kind(), msg).into()
+    io::Error::new(
+        err.kind(),
+        PathIoError {
+            path: path.to_path_buf(),
+            source: err,
+        },
+    )
+    .into()
 }
 
 pub fn open_file(path: &Path) -> PolarsResult<File> {
@@ -30,4 +74,66 @@ pub fn open_file_write(path: &Path) -> PolarsResult<File> {
 
 pub fn create_file(path: &Path) -> PolarsResult<File> {
     File::create(path).map_err(|err| _limit_path_len_io_err(path, err))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn permission_denied() -> io::Error {
+        io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "Permission denied (os error 13)",
+        )
+    }
+
+    fn io_error_of(err: &PolarsError) -> &io::Error {
+        match err {
+            PolarsError::IO { error, .. } => error,
+            other => panic!("expected an IO error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn keeps_kind_and_full_path() {
+        let path = PathBuf::from(format!("/{}/file.parquet", "a".repeat(200)));
+        let err = _limit_path_len_io_err(&path, permission_denied());
+        let io_err = io_error_of(&err);
+
+        assert_eq!(io_err.kind(), io::ErrorKind::PermissionDenied);
+
+        let with_path = io_err
+            .get_ref()
+            .and_then(|e| e.downcast_ref::<PathIoError>())
+            .expect("payload should be a PathIoError");
+        assert_eq!(with_path.path, path);
+        assert_eq!(with_path.source.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn display_truncates_long_paths() {
+        let path = PathBuf::from(format!("/{}/file.parquet", "a".repeat(200)));
+        let msg = _limit_path_len_io_err(&path, permission_denied()).to_string();
+
+        assert!(
+            msg.starts_with("Permission denied (os error 13): ..."),
+            "{msg}"
+        );
+        assert!(
+            msg.ends_with("(set POLARS_VERBOSE=1 to see full path)"),
+            "{msg}"
+        );
+        assert!(!msg.contains(path.to_str().unwrap()), "{msg}");
+        assert!(msg.contains("aaa/file.parquet"), "{msg}");
+    }
+
+    #[test]
+    fn display_keeps_short_paths() {
+        let path = PathBuf::from("/tmp/out/file.parquet");
+        let msg = _limit_path_len_io_err(&path, permission_denied()).to_string();
+        assert_eq!(
+            msg,
+            "Permission denied (os error 13): /tmp/out/file.parquet"
+        );
+    }
 }

--- a/py-polars/tests/unit/io/test_sink.py
+++ b/py-polars/tests/unit/io/test_sink.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import os
+import re
 import subprocess
 import sys
 from functools import partial
@@ -65,6 +66,89 @@ def test_write_mkdir(tmp_path: Path) -> None:
     df.write_parquet(f, mkdir=True)
 
     assert_frame_equal(pl.read_parquet(f), df)
+
+
+skip_if_permissions_unenforced = pytest.mark.skipif(
+    sys.platform == "win32" or (hasattr(os, "geteuid") and os.geteuid() == 0),
+    reason="file permissions are not enforced here",
+)
+
+
+def _read_only_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A read-only directory, reachable by a relative path from the working directory.
+
+    Paths over 88 characters are truncated out of IO error messages, which `tmp_path`
+    alone already exceeds on some platforms. Sinking relative to it keeps the paths
+    short enough that the assertions below see them in full.
+    """
+    d = tmp_path / "read-only"
+    d.mkdir()
+    d.chmod(0o555)
+    monkeypatch.chdir(tmp_path)
+    return Path("read-only")
+
+
+@skip_if_permissions_unenforced
+@pytest.mark.write_disk
+def test_mkdir_permission_denied_names_the_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    df = pl.DataFrame({"a": [1, 2, 3]})
+    d = _read_only_dir(tmp_path, monkeypatch) / "a"
+
+    with pytest.raises(PermissionError) as exc_info:
+        df.lazy().sink_parquet(d / "file", mkdir=True)
+
+    # The directory that could not be created, not the file underneath it.
+    assert str(exc_info.value).endswith(str(d))
+
+
+@skip_if_permissions_unenforced
+@pytest.mark.write_disk
+def test_partitioned_mkdir_permission_denied(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The partitioned sink must report why the directory could not be made.
+
+    It used to discard that error and let the file open fail afterwards, reporting a
+    missing directory instead of the permissions that stopped it being created.
+    """
+    df = pl.DataFrame({"a": [1, 2, 3]})
+    base = _read_only_dir(tmp_path, monkeypatch) / "a"
+
+    with pytest.raises(PermissionError) as exc_info:
+        df.lazy().sink_parquet(pl.PartitionBy(base, key="a"))
+
+    # A partition directory, not a file inside one - opening the file is what used to
+    # raise, and it named `<base>/a=<key>/<part>.parquet`. Which key fails first is not
+    # deterministic.
+    assert re.search(rf"{re.escape(str(base))}/a=\d+$", str(exc_info.value))
+
+
+@pytest.mark.parametrize("partitioned", [False, True])
+@pytest.mark.write_disk
+def test_mkdir_resolves_homedir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, partitioned: bool
+) -> None:
+    """`mkdir` must create the resolved directory, not a literal `~`."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    # Any literal `~` is created relative to the working directory, so keep that inside
+    # `tmp_path` - a regression must not leave one behind in the repository.
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    df = pl.DataFrame({"a": [1, 2, 3]})
+
+    if partitioned:
+        df.lazy().sink_parquet(pl.PartitionBy("~/sink-homedir", key="a"))
+        out = pl.read_parquet(tmp_path / "sink-homedir").sort("a")
+    else:
+        df.lazy().sink_parquet("~/sink-homedir/file.parquet", mkdir=True)
+        out = pl.read_parquet(tmp_path / "sink-homedir" / "file.parquet")
+
+    assert_frame_equal(out, df)
+    assert not (cwd / "~").exists()
 
 
 @pytest.mark.parametrize(("scan", "sink"), SINKS)


### PR DESCRIPTION
Additionally fixes an inconsistency where file writers resolved "~" to the user's homedir, but the file readers did not do this. 

Co-authored by Claude Opus 5