### PR TITLE
refactor(rust): Add Polars library name/version/build registry

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -344,6 +344,10 @@ jobs:
         with:
           command: build
           target: ${{ matrix.target }}
+          # `maturin-action` only forwards environment variables matching a
+          # fixed prefix allowlist into the manylinux/musllinux container, so
+          # `POLARS_BUILD_SHA` has to be passed through explicitly.
+          docker-options: -e POLARS_BUILD_SHA
           args: >
             --profile ${{ inputs.dry-run == true && 'dev' || 'dist-release' }}
             --manifest-path py-polars/runtime/${{ matrix.package }}/Cargo.toml

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -19,6 +19,7 @@ concurrency:
 
 env:
   PYTHON_VERSION: '3.10'
+  POLARS_BUILD_SHA: ${{ inputs.sha || github.sha }}
   PYTHON_VERSION_WIN_ARM64: '3.11' # ARM64 Windows doesn't have older versions
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -19,7 +19,7 @@ concurrency:
 
 env:
   PYTHON_VERSION: '3.10'
-  POLARS_BUILD_SHA: ${{ inputs.sha || github.sha }}
+  POLARS_BUILD_COMMIT: ${{ inputs.sha || github.sha }}
   PYTHON_VERSION_WIN_ARM64: '3.11' # ARM64 Windows doesn't have older versions
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
@@ -346,8 +346,8 @@ jobs:
           target: ${{ matrix.target }}
           # `maturin-action` only forwards environment variables matching a
           # fixed prefix allowlist into the manylinux/musllinux container, so
-          # `POLARS_BUILD_SHA` has to be passed through explicitly.
-          docker-options: -e POLARS_BUILD_SHA
+          # `POLARS_BUILD_COMMIT` has to be passed through explicitly.
+          docker-options: -e POLARS_BUILD_COMMIT
           args: >
             --profile ${{ inputs.dry-run == true && 'dev' || 'dist-release' }}
             --manifest-path py-polars/runtime/${{ matrix.package }}/Cargo.toml
@@ -360,7 +360,12 @@ jobs:
         if: endsWith(matrix.target, '-musl') == false
         run: |
           pip install --force-reinstall --verbose dist/*.whl
-          python -c 'import polars; polars.show_versions()'
+          python -c 'import polars; polars.show_versions()' | tee versions.txt
+
+          if ! grep -qE "^Build: +$POLARS_BUILD_COMMIT\$" versions.txt; then
+            echo "::error::show_versions() does not report build commit $POLARS_BUILD_COMMIT"
+            exit 1
+          fi
 
       - name: Upload wheel
         uses: actions/upload-artifact@v7

--- a/crates/polars-python/build.rs
+++ b/crates/polars-python/build.rs
@@ -1,5 +1,6 @@
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=POLARS_BUILD_SHA");
     let channel = version_check::Channel::read().unwrap();
     if channel.is_nightly() {
         println!("cargo:rustc-cfg=feature=\"nightly\"");

--- a/crates/polars-python/build.rs
+++ b/crates/polars-python/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-env-changed=POLARS_BUILD_SHA");
+    println!("cargo:rerun-if-env-changed=POLARS_BUILD_COMMIT");
     let channel = version_check::Channel::read().unwrap();
     if channel.is_nightly() {
         println!("cargo:rustc-cfg=feature=\"nightly\"");

--- a/crates/polars-python/src/c_api/mod.rs
+++ b/crates/polars-python/src/c_api/mod.rs
@@ -467,6 +467,7 @@ pub fn _polars_runtime(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     // Build info
     m.add("__version__", crate::PYPOLARS_VERSION)?;
     m.add("RUNTIME_REPR", RUNTIME_REPR)?;
+    m.add("_BUILD_COMMIT", crate::PYPOLARS_BUILD_COMMIT)?;
 
     // Plugins
     #[cfg(feature = "ffi_plugin")]

--- a/crates/polars-python/src/c_api/mod.rs
+++ b/crates/polars-python/src/c_api/mod.rs
@@ -1,11 +1,6 @@
 #[cfg(feature = "allocator")]
 pub mod allocator;
 
-// Since Python Polars cannot share its version into here and we need to be able to build this
-// package correctly without `py-polars`, we need to mirror the version here.
-// example: 1.35.0-beta.1
-pub static PYPOLARS_VERSION: &str = "2.0.0-rc.1";
-
 // We allow multiple features to be set simultaneously so checking with all-features
 // is possible. In the case multiple are set or none at all, we set the repr to "unknown".
 #[cfg(all(feature = "rtcompat", not(any(feature = "rt32", feature = "rt64"))))]
@@ -470,7 +465,7 @@ pub fn _polars_runtime(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
         .unwrap();
 
     // Build info
-    m.add("__version__", PYPOLARS_VERSION)?;
+    m.add("__version__", crate::PYPOLARS_VERSION)?;
     m.add("RUNTIME_REPR", RUNTIME_REPR)?;
 
     // Plugins

--- a/crates/polars-python/src/lib.rs
+++ b/crates/polars-python/src/lib.rs
@@ -53,6 +53,11 @@ pub mod utils;
 #[cfg(feature = "c_api")]
 pub mod c_api;
 
+// Since Python Polars cannot share its version into here and we need to be able to build this
+// package correctly without `py-polars`, we need to mirror the version here.
+// example: 1.35.0-beta.1
+pub static PYPOLARS_VERSION: &str = "2.0.0-rc.1";
+
 use crate::conversion::Wrap;
 
 pub type PyDataType = Wrap<polars_core::datatypes::DataType>;

--- a/crates/polars-python/src/lib.rs
+++ b/crates/polars-python/src/lib.rs
@@ -58,6 +58,12 @@ pub mod c_api;
 // example: 1.35.0-beta.1
 pub static PYPOLARS_VERSION: &str = "2.0.0-rc.1";
 
+// Set by the release CI workflow; absent for local/source builds.
+pub static PYPOLARS_BUILD_COMMIT: &str = match option_env!("POLARS_BUILD_COMMIT") {
+    Some(s) => s,
+    None => "<unknown>",
+};
+
 use crate::conversion::Wrap;
 
 pub type PyDataType = Wrap<polars_core::datatypes::DataType>;

--- a/crates/polars-python/src/on_startup.rs
+++ b/crates/polars-python/src/on_startup.rs
@@ -14,6 +14,9 @@ use polars_error::abort::register_polars_abort_mechanism;
 use polars_ffi::version_0::SeriesExport;
 use polars_plan::plans::python_df_to_rust;
 use polars_utils::python_convert_registry::{FromPythonConvertRegistry, PythonConvertRegistry};
+use polars_utils::version::{
+    set_polars_build_version, set_polars_lib_name, set_polars_lib_version,
+};
 use pyo3::IntoPyObjectExt;
 use pyo3::prelude::*;
 use pyo3::types::PyCFunction;
@@ -111,6 +114,13 @@ static WARN_FUNCTION: OnceLock<Py<PyAny>> = OnceLock::new();
 pub unsafe fn register_startup_deps(catch_keyboard_interrupt: bool, warn_function: Py<PyAny>) {
     // TODO: should we throw an error if we try to initialize while already initialized?
     POLARS_REGISTRY_INIT_LOCK.get_or_init(|| {
+        set_polars_lib_name("Polars (python)");
+        set_polars_lib_version(crate::PYPOLARS_VERSION);
+        // Set by the release CI workflow; absent for local/source builds.
+        if let Some(sha) = option_env!("POLARS_BUILD_SHA") {
+            set_polars_build_version(sha);
+        }
+
         WARN_FUNCTION.set(warn_function).unwrap();
         set_polars_allow_extension(true);
 

--- a/crates/polars-python/src/on_startup.rs
+++ b/crates/polars-python/src/on_startup.rs
@@ -14,7 +14,9 @@ use polars_error::abort::register_polars_abort_mechanism;
 use polars_ffi::version_0::SeriesExport;
 use polars_plan::plans::python_df_to_rust;
 use polars_utils::python_convert_registry::{FromPythonConvertRegistry, PythonConvertRegistry};
-use polars_utils::version::{set_polars_lib_build_commit, set_polars_lib_name, set_polars_lib_version};
+use polars_utils::version::{
+    set_polars_lib_build_commit, set_polars_lib_name, set_polars_lib_version,
+};
 use pyo3::IntoPyObjectExt;
 use pyo3::prelude::*;
 use pyo3::types::PyCFunction;

--- a/crates/polars-python/src/on_startup.rs
+++ b/crates/polars-python/src/on_startup.rs
@@ -14,9 +14,7 @@ use polars_error::abort::register_polars_abort_mechanism;
 use polars_ffi::version_0::SeriesExport;
 use polars_plan::plans::python_df_to_rust;
 use polars_utils::python_convert_registry::{FromPythonConvertRegistry, PythonConvertRegistry};
-use polars_utils::version::{
-    set_polars_build_version, set_polars_lib_name, set_polars_lib_version,
-};
+use polars_utils::version::{set_polars_lib_build_commit, set_polars_lib_name, set_polars_lib_version};
 use pyo3::IntoPyObjectExt;
 use pyo3::prelude::*;
 use pyo3::types::PyCFunction;
@@ -116,10 +114,7 @@ pub unsafe fn register_startup_deps(catch_keyboard_interrupt: bool, warn_functio
     POLARS_REGISTRY_INIT_LOCK.get_or_init(|| {
         set_polars_lib_name("Polars (python)");
         set_polars_lib_version(crate::PYPOLARS_VERSION);
-        // Set by the release CI workflow; absent for local/source builds.
-        if let Some(sha) = option_env!("POLARS_BUILD_SHA") {
-            set_polars_build_version(sha);
-        }
+        set_polars_lib_build_commit(crate::PYPOLARS_BUILD_COMMIT);
 
         WARN_FUNCTION.set(warn_function).unwrap();
         set_polars_allow_extension(true);

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -72,6 +72,7 @@ pub mod tick_counter;
 pub mod total_ord;
 pub mod unique_id;
 pub mod vec;
+pub mod version;
 pub mod with_drop;
 
 #[cfg(feature = "async-utils")]

--- a/crates/polars-utils/src/version.rs
+++ b/crates/polars-utils/src/version.rs
@@ -1,0 +1,40 @@
+use std::sync::{Arc, LazyLock, Mutex};
+
+static POLARS_NAME: LazyLock<Mutex<Arc<String>>> =
+    LazyLock::new(|| Mutex::new(Arc::new(String::from("Polars (standalone)"))));
+
+static POLARS_VERSION: LazyLock<Mutex<Arc<String>>> =
+    LazyLock::new(|| Mutex::new(Arc::new(String::from(env!("CARGO_PKG_VERSION")))));
+
+static POLARS_BUILD: LazyLock<Mutex<Arc<String>>> =
+    LazyLock::new(|| Mutex::new(Arc::new(String::from("<unknown>"))));
+
+/// Set the name Polars uses for e.g. file metadata.
+pub fn set_polars_lib_name(name: &str) {
+    *POLARS_NAME.lock().unwrap() = Arc::new(name.into());
+}
+
+/// Set the version Polars uses for e.g. file metadata.
+pub fn set_polars_lib_version(version: &str) {
+    *POLARS_VERSION.lock().unwrap() = Arc::new(version.into());
+}
+
+/// Set the build Polars uses for e.g. file metadata.
+pub fn set_polars_build_version(build: &str) {
+    *POLARS_BUILD.lock().unwrap() = Arc::new(build.into());
+}
+
+/// Get the name Polars uses for e.g. file metadata.
+pub fn get_polars_lib_name() -> Arc<String> {
+    POLARS_NAME.lock().unwrap().clone()
+}
+
+/// Get the version Polars uses for e.g. file metadata.
+pub fn get_polars_lib_version() -> Arc<String> {
+    POLARS_VERSION.lock().unwrap().clone()
+}
+
+/// Get the build Polars uses for e.g. file metadata.
+pub fn get_polars_build_version() -> Arc<String> {
+    POLARS_BUILD.lock().unwrap().clone()
+}

--- a/crates/polars-utils/src/version.rs
+++ b/crates/polars-utils/src/version.rs
@@ -6,7 +6,7 @@ static POLARS_NAME: LazyLock<Mutex<Arc<String>>> =
 static POLARS_VERSION: LazyLock<Mutex<Arc<String>>> =
     LazyLock::new(|| Mutex::new(Arc::new(String::from(env!("CARGO_PKG_VERSION")))));
 
-static POLARS_BUILD: LazyLock<Mutex<Arc<String>>> =
+static POLARS_BUILD_COMMIT: LazyLock<Mutex<Arc<String>>> =
     LazyLock::new(|| Mutex::new(Arc::new(String::from("<unknown>"))));
 
 /// Set the name Polars uses for e.g. file metadata.
@@ -19,9 +19,9 @@ pub fn set_polars_lib_version(version: &str) {
     *POLARS_VERSION.lock().unwrap() = Arc::new(version.into());
 }
 
-/// Set the build Polars uses for e.g. file metadata.
-pub fn set_polars_build_version(build: &str) {
-    *POLARS_BUILD.lock().unwrap() = Arc::new(build.into());
+/// Set the build SHA Polars uses for e.g. file metadata.
+pub fn set_polars_lib_build_commit(sha: &str) {
+    *POLARS_BUILD_COMMIT.lock().unwrap() = Arc::new(sha.into());
 }
 
 /// Get the name Polars uses for e.g. file metadata.
@@ -34,7 +34,7 @@ pub fn get_polars_lib_version() -> Arc<String> {
     POLARS_VERSION.lock().unwrap().clone()
 }
 
-/// Get the build Polars uses for e.g. file metadata.
-pub fn get_polars_build_version() -> Arc<String> {
-    POLARS_BUILD.lock().unwrap().clone()
+/// Get the build SHA Polars uses for e.g. file metadata.
+pub fn get_polars_lib_build_commit() -> Arc<String> {
+    POLARS_BUILD_COMMIT.lock().unwrap().clone()
 }

--- a/py-polars/src/polars/_plr.pyi
+++ b/py-polars/src/polars/_plr.pyi
@@ -11,6 +11,7 @@ from polars.io.scan_options._options import ScanOptions
 # This file mirrors all the definitions made in the polars-python Rust API.
 
 __version__: str
+_BUILD_COMMIT: str
 __build__: Any
 _ir_nodes: Any
 _allocator: Any

--- a/py-polars/src/polars/_utils/polars_version.py
+++ b/py-polars/src/polars/_utils/polars_version.py
@@ -2,12 +2,14 @@ try:
     import polars._plr as plr
 
     _POLARS_VERSION = plr.__version__
+    _POLARS_BUILD_COMMIT = plr._BUILD_COMMIT
 except ImportError:
     # This is only useful for documentation
     import warnings
 
     warnings.warn("Polars binary is missing!", stacklevel=2)
     _POLARS_VERSION = ""
+    _POLARS_BUILD_COMMIT = ""
 
 
 def get_polars_version() -> str:
@@ -17,3 +19,13 @@ def get_polars_version() -> str:
     If the Polars binary is missing, returns an empty string.
     """
     return _POLARS_VERSION
+
+
+def get_polars_build_commit() -> str:
+    """
+    Return the commit SHA that Polars was built from.
+
+    This is only baked in by the release CI workflow; local and source builds
+    report `<unknown>`. If the Polars binary is missing, returns an empty string.
+    """
+    return _POLARS_BUILD_COMMIT

--- a/py-polars/src/polars/meta/versions.py
+++ b/py-polars/src/polars/meta/versions.py
@@ -4,7 +4,7 @@ import re
 import sys
 
 from polars._cpu_check import get_runtime_repr
-from polars._utils.polars_version import get_polars_version
+from polars._utils.polars_version import get_polars_build_commit, get_polars_version
 from polars.meta.index_type import get_index_type
 
 
@@ -17,6 +17,7 @@ def show_versions() -> None:
     >>> pl.show_versions()  # doctest: +SKIP
     --------Version info---------
     Polars:               0.20.22
+    Build:                a1b2c3d4e5f
     Index type:           UInt32
     Platform:             macOS-14.4.1-arm64-arm-64bit
     Python:               3.11.8 (main, Feb  6 2024, 21:21:21) [Clang 15.0.0 (clang-1500.1.0.2.5)]
@@ -47,11 +48,19 @@ def show_versions() -> None:
     import platform
 
     deps = _get_dependency_list()
-    core_properties = ("Polars", "Index type", "Platform", "Python", "Runtime")
+    core_properties = (
+        "Polars",
+        "Build",
+        "Index type",
+        "Platform",
+        "Python",
+        "Runtime",
+    )
     keylen = max(len(x) for x in [*core_properties, "Azure CLI", *deps]) + 1
 
     print("--------Version info---------")
     print(f"{'Polars:':{keylen}s} {get_polars_version()}")
+    print(f"{'Build:':{keylen}s} {get_polars_build_commit()}")
     print(f"{'Index type:':{keylen}s} {get_index_type()}")
     print(f"{'Platform:':{keylen}s} {platform.platform()}")
     print(f"{'Python:':{keylen}s} {sys.version}")

--- a/py-polars/tests/unit/meta/test_init.py
+++ b/py-polars/tests/unit/meta/test_init.py
@@ -41,7 +41,7 @@ def test_version() -> None:
     rhs = importlib.metadata.version("polars")
 
     assert lhs == rhs, (
-        f"`static PYPOLARS_VERSION` ({lhs}) at `crates/polars-python/src/c_api/mod.rs` "
+        f"`static PYPOLARS_VERSION` ({lhs}) at `crates/polars-python/src/lib.rs` "
         f"does not match importlib package metadata version ({rhs})"
     )
 


### PR DESCRIPTION
Will be used to write file metadata, see https://github.com/pola-rs/polars/pull/29106. Also now adds the build commit to `pl.show_versions()`.