### PR TITLE
perf: Use adaptive concurrency for `head` requests

### DIFF
--- a/crates/polars-io/src/cloud/concurrency/mod.rs
+++ b/crates/polars-io/src/cloud/concurrency/mod.rs
@@ -21,6 +21,8 @@ mod regime;
 
 use std::num::NonZeroU64;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering::Relaxed;
 use std::time::{Duration, Instant};
 
 pub use admission::{InFlightBudget, InFlightPermit, InFlightStats};
@@ -157,11 +159,71 @@ pub fn get_floor_request_budget() -> u64 {
         .max(1)
 }
 
+/// Windowed round-trip time of 0-byte metadata (HEAD) requests.
+/// Diagnostic only, not to be used for BDP estimation.
+#[derive(Debug)]
+pub struct HeadRttChannel {
+    min_ns: AtomicU64,
+    sum_ns: AtomicU64,
+    count: AtomicU64,
+    /// Never reset, unlike `count`: distinguishes the first request of the process from
+    /// the first of a window.
+    total: AtomicU64,
+}
+
+/// One control tick's worth of [`HeadRttChannel`] observations.
+#[derive(Clone, Copy, Debug)]
+pub struct HeadRttWindow {
+    pub min: Option<Duration>,
+    pub avg: Option<Duration>,
+    pub count: u64,
+}
+
+impl HeadRttChannel {
+    fn new() -> Self {
+        Self {
+            min_ns: AtomicU64::new(u64::MAX),
+            sum_ns: AtomicU64::new(0),
+            count: AtomicU64::new(0),
+            total: AtomicU64::new(0),
+        }
+    }
+
+    /// Hot path: four relaxed ops, no queue.
+    fn record(&self, rtt: Duration) {
+        let ns = rtt.as_nanos() as u64;
+        self.min_ns.fetch_min(ns, Relaxed);
+        self.sum_ns.fetch_add(ns, Relaxed);
+        self.count.fetch_add(1, Relaxed);
+
+        if self.total.fetch_add(1, Relaxed) == 0 && polars_config::config().verbose() {
+            eprintln!(
+                "[InFlightConcurrency]: observed first RTT sample (metadata): {} ms",
+                rtt.as_millis()
+            );
+        }
+    }
+
+    /// Read and reset.
+    fn take(&self) -> HeadRttWindow {
+        let min_ns = self.min_ns.swap(u64::MAX, Relaxed);
+        let sum_ns = self.sum_ns.swap(0, Relaxed);
+        let count = self.count.swap(0, Relaxed);
+
+        HeadRttWindow {
+            min: (min_ns != u64::MAX).then(|| Duration::from_nanos(min_ns)),
+            avg: (count > 0).then(|| Duration::from_nanos(sum_ns / count)),
+            count,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct ConcurrencyController {
     config: ControllerConfig,
     sample_queue: Arc<ArrayQueue<IoSample>>,
     samples_dropped: Arc<RelaxedCell<u64>>,
+    head_rtt: Arc<HeadRttChannel>,
     inflight_budget: Arc<InFlightBudget>,
     _control_task: tokio::task::JoinHandle<()>,
 }
@@ -170,6 +232,7 @@ impl ConcurrencyController {
     pub fn new(config: ControllerConfig, pacing_budget: Option<PacingBudget>) -> Self {
         let sample_queue = Arc::new(ArrayQueue::new(SAMPLE_QUEUE_CAPACITY));
         let samples_dropped = Arc::new(RelaxedCell::new_u64(0));
+        let head_rtt = Arc::new(HeadRttChannel::new());
 
         let inflight_budget = Arc::new(InFlightBudget::new(
             config.init_byte_budget,
@@ -181,6 +244,7 @@ impl ConcurrencyController {
         let control_task = Self::spawn_control_loop(
             sample_queue.clone(),
             samples_dropped.clone(),
+            head_rtt.clone(),
             inflight_budget.clone(),
             config.clone(),
             pacing_budget,
@@ -190,6 +254,7 @@ impl ConcurrencyController {
             config,
             sample_queue,
             samples_dropped,
+            head_rtt,
             inflight_budget,
             _control_task: control_task,
         }
@@ -199,12 +264,17 @@ impl ConcurrencyController {
         &self.config
     }
 
-    /// Record a completed IO. Hot path.
+    /// Record IO for a completed data request. Hot path.
     pub fn record_io(&self, sample: IoSample) {
         if self.sample_queue.push(sample).is_err() {
             // Queue full: drop. Samples are statistics is considered acceptable.
             self.samples_dropped.fetch_add(1);
         }
+    }
+
+    /// Record the round-trip time of a completed 0-byte metadata request. Hot path.
+    pub fn record_head_rtt(&self, rtt: Duration) {
+        self.head_rtt.record(rtt);
     }
 
     pub fn inflight_budget(&self) -> &Arc<InFlightBudget> {
@@ -218,6 +288,7 @@ impl ConcurrencyController {
     fn spawn_control_loop(
         sample_queue: Arc<ArrayQueue<IoSample>>,
         samples_dropped: Arc<RelaxedCell<u64>>,
+        head_rtt: Arc<HeadRttChannel>,
         admission: Arc<InFlightBudget>,
         config: ControllerConfig,
         pacing_budget: Option<PacingBudget>,
@@ -296,6 +367,9 @@ impl ConcurrencyController {
                     }
                 }
 
+                // Drained every tick. Diagnostic only.
+                let head_rtt_window = head_rtt.take();
+
                 // Log snapshot.
                 if std::env::var("POLARS_LOG_CONCURRENCY").is_ok() {
                     let stats = admission.stats();
@@ -305,6 +379,9 @@ impl ConcurrencyController {
                         bw_avg={:.1} MB/s, \
                         rtt_min={:.1} ms, \
                         rtt_avg={:.1} ms, \
+                        head_rtt_min={:.1} ms, \
+                        head_rtt_avg={:.1} ms, \
+                        head_n={}, \
                         bdp_obs={:.1} MB, \
                         bytes_budget={:.1} MB, \
                         bytes_in_use={:.1} MB, \
@@ -318,6 +395,9 @@ impl ConcurrencyController {
                         signal.map_or(0.0, |s| s.bw_avg_bps) / 1e6,
                         signal.map_or(0, |s| s.ttfb_min.as_millis()),
                         signal.map_or(0, |s| s.ttfb_avg.as_millis()),
+                        head_rtt_window.min.map_or(0.0, |d| d.as_secs_f64() * 1e3),
+                        head_rtt_window.avg.map_or(0.0, |d| d.as_secs_f64() * 1e3),
+                        head_rtt_window.count,
                         signal.map_or(0, |s| s.bdp_bytes()) as f64 / 1e6,
                         stats.bytes_budget as f64 / 1e6,
                         stats.bytes_in_use as f64 / 1e6,

--- a/crates/polars-io/src/cloud/concurrency/model.rs
+++ b/crates/polars-io/src/cloud/concurrency/model.rs
@@ -76,7 +76,7 @@ impl Model {
             self.first_sample_time = Some(sample.completion_time);
             if polars_config::config().verbose() {
                 eprintln!(
-                    "[InFlightConcurrency]: observed first RTT sample: {} ms, for {} bytes",
+                    "[InFlightConcurrency]: observed first RTT sample (data): {} ms, for {} bytes",
                     sample.ttfb.as_millis(),
                     sample.n_bytes
                 )

--- a/crates/polars-io/src/cloud/http_rate_limit.rs
+++ b/crates/polars-io/src/cloud/http_rate_limit.rs
@@ -225,7 +225,6 @@ impl PacingBudget {
         self.horizon
     }
 
-    /// Helper so downstream doesn't have to re-implement the formula
     pub fn request_budget(&self, bdp: f64) -> f64 {
         bdp.min(self.rate() * self.horizon().as_secs_f64())
     }

--- a/crates/polars-io/src/cloud/polars_object_store.rs
+++ b/crates/polars-io/src/cloud/polars_object_store.rs
@@ -13,7 +13,7 @@ use polars_error::{PolarsError, PolarsResult};
 use polars_utils::pl_path::PlRefPath;
 use tokio::io::AsyncWriteExt;
 
-use super::concurrency::IoSample;
+use super::concurrency::{ConcurrencyController, IoSample};
 use super::concurrency_config::{ConcurrencyStrategy, FetchConfig, get_download_chunk_size};
 use crate::pl_async::{
     self, MAX_BUDGET_PER_REQUEST, get_concurrency_limit, tune_with_concurrency_budget,
@@ -521,60 +521,64 @@ impl PolarsObjectStore {
         path: &Path,
         strategy: ConcurrencyStrategy,
     ) -> PolarsResult<ObjectMeta> {
-        // TODO: Refactor for updated concurrency strategy.
-        // For now, we fall back to 'Legacy' which is fine for metadata.
-        // Since this carries an early signal, the IO Sample is of interest regardless of
-        // the strategy in use.
-        with_concurrency_budget(1, || {
-            self.exec_with_rebuild_retry_on_err(|s| {
-                async move {
+        match strategy {
+            ConcurrencyStrategy::BytesBased => {
+                let controller = self.get_or_init_concurrency();
+                let _permit = controller.acquire(0).await;
+                self.head_inner(path, Some(&**controller)).await
+            },
+            ConcurrencyStrategy::Legacy => {
+                with_concurrency_budget(1, || self.head_inner(path, None)).await
+            },
+            ConcurrencyStrategy::Unbounded => self.head_inner(path, None).await,
+        }
+    }
+
+    async fn head_inner(
+        &self,
+        path: &Path,
+        controller: Option<&ConcurrencyController>,
+    ) -> PolarsResult<ObjectMeta> {
+        self.exec_with_rebuild_retry_on_err(|s| {
+            async move {
+                let t0 = Instant::now();
+                let head_result = self.io_metrics().record_io_read(0, s.head(path)).await;
+
+                if head_result.is_err() {
                     let t0 = Instant::now();
-                    let head_result = self.io_metrics().record_io_read(0, s.head(path)).await;
-                    if let ConcurrencyStrategy::BytesBased = strategy {
-                        // self.get_or_init_concurrency().record_ttfb(ttfb);
-                        self.get_or_init_concurrency().record_io(IoSample {
-                            n_bytes: 0,
-                            ttfb: t0.elapsed(),
-                            completion_time: Instant::now(),
-                        });
-                    }
 
-                    if head_result.is_err() {
-                        let t0 = Instant::now();
-                        // Pre-signed URLs forbid the HEAD method, but we can still retrieve the header
-                        // information with a range 0-1 request.
-                        let get_range_0_1_result = self
-                            .io_metrics()
-                            .record_io_read(
-                                0,
-                                s.get_opts(
-                                    path,
-                                    object_store::GetOptions {
-                                        range: Some((0..1).into()),
-                                        ..Default::default()
-                                    },
-                                ),
-                            )
-                            .await;
+                    // Pre-signed URLs forbid the HEAD method, but we can still retrieve the header
+                    // information with a range 0-1 request.
+                    let get_range_0_1_result = self
+                        .io_metrics()
+                        .record_io_read(
+                            0,
+                            s.get_opts(
+                                path,
+                                object_store::GetOptions {
+                                    range: Some((0..1).into()),
+                                    ..Default::default()
+                                },
+                            ),
+                        )
+                        .await;
 
-                        if let ConcurrencyStrategy::BytesBased = strategy {
-                            self.get_or_init_concurrency().record_io(IoSample {
-                                n_bytes: 0,
-                                ttfb: t0.elapsed(),
-                                completion_time: Instant::now(),
-                            });
+                    if let Ok(v) = get_range_0_1_result {
+                        if let Some(controller) = controller {
+                            controller.record_head_rtt(t0.elapsed());
                         }
-
-                        if let Ok(v) = get_range_0_1_result {
-                            return Ok(v.meta);
-                        }
+                        return Ok(v.meta);
                     }
-
-                    let out = head_result?;
-
-                    Ok(out)
                 }
-            })
+
+                let out = head_result?;
+
+                if let Some(controller) = controller {
+                    controller.record_head_rtt(t0.elapsed());
+                }
+
+                Ok(out)
+            }
         })
         .await
     }

--- a/crates/polars-io/src/utils/byte_source.rs
+++ b/crates/polars-io/src/utils/byte_source.rs
@@ -116,7 +116,7 @@ impl ByteSource for ObjectStoreByteSource {
     async fn get_size(&self) -> PolarsResult<usize> {
         Ok(self
             .store
-            .head(&self.path, ConcurrencyStrategy::Legacy)
+            .head(&self.path, self.concurrency_strategy())
             .await?
             .size as usize)
     }


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/28105

This PR switches the concurrency model for `head` requests from the legacy semi-static concurrency controller to the new adaptive concurrency controller (https://github.com/pola-rs/polars/pull/27924), protected by the HTTP rate-limiter (https://github.com/pola-rs/polars/pull/28591).

Real-world improvements are mostly observable on lower thread counts, e.g. with ` POLARS_MAX_THREADS=4` and `POLARS_RESOLVE_METADATA_LEVEL=full` on `explain` with 10k small files on AWS S3:
- before (1.44.1): 21.17s
- after (this PR): 8.38s
- after (this PR, rate-limiter ~disabled*): 3.70s
(* can be accomplished via storage_options, adds risk)

At higher thread counts, the legacy concurrency is less of a concern (e.g. 64 vCPU concurrency x 20 ms RTT would give ~3k rps)
