### PR TITLE
fix(python): Fix a `DataFrame` construction race (and generator data loss)

### DIFF
--- a/py-polars/src/polars/_utils/construction/dataframe.py
+++ b/py-polars/src/polars/_utils/construction/dataframe.py
@@ -20,7 +20,6 @@ from polars._dependencies import (
     _PYARROW_AVAILABLE,
     _check_for_numpy,
     _check_for_pandas,
-    dataclasses,
 )
 from polars._dependencies import numpy as np
 from polars._dependencies import pandas as pd
@@ -28,6 +27,7 @@ from polars._dependencies import pyarrow as pa
 from polars._utils.construction.utils import (
     contains_nested,
     get_first_non_none,
+    is_dataclass_instance,
     is_namedtuple,
     is_pydantic_model,
     is_simple_numpy_backed_pandas_series,
@@ -446,6 +446,9 @@ def _expand_dict_data(
     return expanded_data
 
 
+_resolved_sequence_handlers: dict[type, Callable[..., PyDataFrame]] = {}
+
+
 def sequence_to_pydf(
     data: Sequence[Any],
     schema: SchemaDefinition | None = None,
@@ -460,8 +463,12 @@ def sequence_to_pydf(
     if not data:
         return dict_to_pydf({}, schema=schema, schema_overrides=schema_overrides)
 
-    return _sequence_to_pydf_dispatcher(
-        get_first_non_none(data),
+    first_element = get_first_non_none(data)
+    to_pydf = _resolved_sequence_handlers.get(
+        type(first_element), _sequence_to_pydf_dispatcher
+    )
+    return to_pydf(
+        first_element,
         data=data,
         schema=schema,
         schema_overrides=schema_overrides,
@@ -487,25 +494,19 @@ def _sequence_to_pydf_dispatcher(
     # note: ONLY python-native data should participate in singledispatch registration
     # via top-level decorators, otherwise we have to import the associated module.
     # third-party libraries (such as numpy/pandas) should be identified inline (below)
-    # and THEN registered for dispatch (here) so as not to break lazy-loading behaviour.
+    # and THEN memoized (here) so as not to break lazy-loading behaviour.
 
-    common_params: dict[str, Any] = {
-        "data": data,
-        "schema": schema,
-        "schema_overrides": schema_overrides,
-        "strict": strict,
-        "orient": orient,
-        "infer_schema_length": infer_schema_length,
-        "nan_to_null": nan_to_null,
-    }
     to_pydf: Callable[..., PyDataFrame]
-    register_with_singledispatch = True
+    memo_key = type(first_element)
+    memoize = True
 
     if isinstance(first_element, Generator):
         to_pydf = _sequence_of_sequence_to_pydf
         data = [list(row) for row in data]
         first_element = data[0]
-        register_with_singledispatch = False
+        # note: rows were materialised, so resolution
+        # belongs to the call rather than to the type
+        memoize = False
 
     elif isinstance(first_element, pl.Series):
         to_pydf = _sequence_of_series_to_pydf
@@ -518,7 +519,7 @@ def _sequence_to_pydf_dispatcher(
     ):
         to_pydf = _sequence_of_pandas_to_pydf
 
-    elif dataclasses.is_dataclass(first_element):
+    elif is_dataclass_instance(first_element):
         to_pydf = _sequence_of_dataclasses_to_pydf
 
     elif is_pydantic_model(first_element):
@@ -532,11 +533,19 @@ def _sequence_to_pydf_dispatcher(
     else:
         to_pydf = _sequence_of_elements_to_pydf
 
-    if register_with_singledispatch:
-        _sequence_to_pydf_dispatcher.register(type(first_element), to_pydf)
+    if memoize:
+        _resolved_sequence_handlers[memo_key] = to_pydf
 
-    common_params["first_element"] = first_element
-    return to_pydf(**common_params)
+    return to_pydf(
+        first_element,
+        data=data,
+        schema=schema,
+        schema_overrides=schema_overrides,
+        strict=strict,
+        orient=orient,
+        infer_schema_length=infer_schema_length,
+        nan_to_null=nan_to_null,
+    )
 
 
 @_sequence_to_pydf_dispatcher.register(list)
@@ -945,7 +954,7 @@ def _establish_dataclass_or_model_schema(
         elif not unpack_nested and (tp.base_type() in (Unknown, Struct)):
             unpack_nested = contains_nested(
                 getattr(first_element, col, None),
-                is_pydantic_model if model_fields else dataclasses.is_dataclass,  # type: ignore[arg-type]
+                is_pydantic_model if model_fields else is_dataclass_instance,
             )
 
     if model_fields and len(model_fields) == len(overrides):

--- a/py-polars/src/polars/_utils/construction/series.py
+++ b/py-polars/src/polars/_utils/construction/series.py
@@ -12,17 +12,13 @@ from typing import (
 
 import polars._reexport as pl
 import polars._utils.construction as plc
-from polars._dependencies import (
-    _PYARROW_AVAILABLE,
-    _check_for_numpy,
-    dataclasses,
-)
+from polars._dependencies import _PYARROW_AVAILABLE, _check_for_numpy
 from polars._dependencies import numpy as np
-from polars._dependencies import pandas as pd
 from polars._dependencies import pyarrow as pa
 from polars._utils.construction.dataframe import _sequence_of_dict_to_pydf
 from polars._utils.construction.utils import (
     get_first_non_none,
+    is_dataclass_instance,
     is_namedtuple,
     is_pydantic_model,
     is_simple_numpy_backed_pandas_series,
@@ -111,7 +107,7 @@ def sequence_to_pyseries(
     value = get_first_non_none(values)
     if value is not None:
         if (
-            dataclasses.is_dataclass(value)
+            is_dataclass_instance(value)
             or is_pydantic_model(value)
             or is_namedtuple(value.__class__)
             or is_sqlalchemy_row(value)

--- a/py-polars/src/polars/_utils/construction/utils.py
+++ b/py-polars/src/polars/_utils/construction/utils.py
@@ -5,7 +5,7 @@ from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Final, get_type_hints
 
 import polars as pl
-from polars._dependencies import _check_for_pydantic, pydantic
+from polars._dependencies import _check_for_pydantic, dataclasses, pydantic
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -56,6 +56,11 @@ def is_namedtuple(cls: Any, *, annotated: bool = False) -> bool:
             if not annotated or len(cls.__annotations__) == len(cls._fields):
                 return all(isinstance(fld, str) for fld in cls._fields)
     return False
+
+
+def is_dataclass_instance(value: Any) -> bool:
+    """Check if value is a dataclass instance (`is_dataclass` also matches classes)."""
+    return dataclasses.is_dataclass(value) and not isinstance(value, type)
 
 
 def is_pydantic_model(value: Any) -> bool:

--- a/py-polars/tests/unit/constructors/test_dataframe.py
+++ b/py-polars/tests/unit/constructors/test_dataframe.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import dataclasses
 import enum
+import subprocess
 import sys
 from collections import OrderedDict
 from collections.abc import Mapping
@@ -10,6 +12,11 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 import polars as pl
+from polars._utils.construction.dataframe import (
+    _resolved_sequence_handlers,
+    _sequence_of_dataclasses_to_pydf,
+    _sequence_to_pydf_dispatcher,
+)
 from polars.exceptions import DataOrientationWarning, InvalidOperationError
 from polars.testing import assert_frame_equal
 
@@ -260,3 +267,98 @@ def test_bytes_scalar_broadcast_27620() -> None:
     result = pl.DataFrame({"a": b"foo", "b": "foo", "c": [10, 20, 30]})
     expected = pl.DataFrame({"a": [b"foo"] * 3, "b": ["foo"] * 3, "c": [10, 20, 30]})
     assert_frame_equal(result, expected)
+
+
+def test_df_init_from_sequence_of_generators_29121() -> None:
+    result = pl.DataFrame([(x for x in (1, 2, 3)), (x for x in (4, 5, 6))])
+    expected = pl.DataFrame({"column_0": [1, 2, 3], "column_1": [4, 5, 6]})
+    assert_frame_equal(result, expected)
+
+    result = pl.DataFrame(
+        [(x for x in (1, 2, 3)), (x for x in (4, 5, 6))],
+        schema=["a", "b", "c"],
+        orient="row",
+    )
+    expected = pl.DataFrame({"a": [1, 4], "b": [2, 5], "c": [3, 6]})
+    assert_frame_equal(result, expected)
+
+
+def test_df_init_resolution_leaves_dispatch_registry_alone_29121() -> None:
+    SomeRow = dataclasses.make_dataclass("Row29121", [("a", int)])
+    registered = set(_sequence_to_pydf_dispatcher.registry)
+
+    pl.DataFrame([SomeRow(a=1)])
+
+    assert set(_sequence_to_pydf_dispatcher.registry) == registered
+    assert _resolved_sequence_handlers[SomeRow] is _sequence_of_dataclasses_to_pydf
+
+
+def test_df_init_dataclass_class_is_not_an_instance() -> None:
+    SomeRow = dataclasses.make_dataclass("Row29121Class", [("a", int)])
+    _resolved_sequence_handlers.pop(type, None)
+
+    class Unrelated:
+        pass
+
+    assert pl.DataFrame([SomeRow]).dtypes == [pl.Object]
+    assert pl.DataFrame([Unrelated]).dtypes == [pl.Object]
+    assert pl.Series([SomeRow]).dtype == pl.Object
+
+    # instances are still unpacked into columns
+    assert pl.DataFrame([SomeRow(a=1)]).to_dict(as_series=False) == {"a": [1]}
+    assert pl.Series([SomeRow(a=1)]).dtype == pl.Struct({"a": pl.Int64})
+
+
+# Type resolution is memoized process-wide, so the first-use window this
+# exercises only exists in an interpreter that no other test has warmed up
+_CONCURRENT_INIT_SCRIPT = """\
+import dataclasses
+import sys
+import threading
+
+import polars as pl
+sys.setswitchinterval(1e-6)
+
+THREADS = 8
+ROUNDS = 25
+errors = []
+
+def build(payload, barrier):
+    barrier.wait()
+    try:
+        pl.DataFrame(payload)
+    except Exception as exc:
+        errors.append(exc)
+
+def race(payloads):
+    # time out rather than deadlock if a thread never reaches the barrier
+    barrier = threading.Barrier(len(payloads), timeout=30)
+    threads = [threading.Thread(target=build, args=(p, barrier)) for p in payloads]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+# the type from the issue report; only races on its very first use in the process
+race([[pl.Series(f"c{i}", [i])] for i in range(THREADS)])
+
+# a fresh dataclass type per round reopens the first-use window each time,
+# so the race can be exercised repeatedly instead of getting a single shot
+for r in range(ROUNDS):
+    Row = dataclasses.make_dataclass(f"Row{r}", [("a", int)])
+    race([[Row(a=i)] for i in range(THREADS)])
+
+assert not errors, f"{len(errors)} constructions failed, first: {errors[0]!r}"
+"""
+
+
+def test_df_init_concurrent_first_use_29121() -> None:
+    # resolving a type for the first time must not mutate
+    # state that a concurrent dispatch is reading
+    proc = subprocess.run(
+        [sys.executable, "-c", _CONCURRENT_INIT_SCRIPT],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert proc.returncode == 0, proc.stderr


### PR DESCRIPTION
Fixes  #29121.

* Also resolves a generator-related edge case spotted in the same function.
* Added tests to validate both fixes (including the issue's example).
