### PR TITLE
fix(rust): Ensure panics don't trigger POLARS_TIMEOUT_MS

### DIFF
--- a/crates/polars-python/src/timeout.rs
+++ b/crates/polars-python/src/timeout.rs
@@ -101,7 +101,21 @@ fn timeout_thread(recv: Receiver<TimeoutRequest>) {
     }
 }
 
-pub fn schedule_polars_timeout(traceback: Option<String>) -> Option<u64> {
+/// Cancels the timeout it was scheduled for when dropped.
+pub struct PolarsTimeoutGuard {
+    id: u64,
+}
+
+impl Drop for PolarsTimeoutGuard {
+    fn drop(&mut self) {
+        TIMEOUT_REQUEST_HANDLER
+            .send(TimeoutRequest::Cancel(self.id))
+            .unwrap();
+    }
+}
+
+#[must_use]
+pub fn schedule_polars_timeout(traceback: Option<String>) -> Option<PolarsTimeoutGuard> {
     static TIMEOUT_ID: RelaxedCell<u64> = RelaxedCell::new_u64(0);
 
     let timeout = get_timeout()?;
@@ -109,13 +123,5 @@ pub fn schedule_polars_timeout(traceback: Option<String>) -> Option<u64> {
     TIMEOUT_REQUEST_HANDLER
         .send(TimeoutRequest::Start(timeout, id, traceback))
         .unwrap();
-    Some(id)
-}
-
-pub fn cancel_polars_timeout(opt_id: Option<u64>) {
-    if let Some(id) = opt_id {
-        TIMEOUT_REQUEST_HANDLER
-            .send(TimeoutRequest::Cancel(id))
-            .unwrap();
-    }
+    Some(PolarsTimeoutGuard { id })
 }

--- a/crates/polars-python/src/utils.rs
+++ b/crates/polars-python/src/utils.rs
@@ -12,7 +12,7 @@ use pyo3::{PyErr, PyResult, Python};
 use crate::dataframe::PyDataFrame;
 use crate::error::PyPolarsErr;
 use crate::series::PySeries;
-use crate::timeout::{cancel_polars_timeout, is_timeout_enabled, schedule_polars_timeout};
+use crate::timeout::{is_timeout_enabled, schedule_polars_timeout};
 
 /// Calls method on downcasted ChunkedArray for all possible publicly exposed Polars dtypes.
 #[macro_export]
@@ -138,14 +138,11 @@ impl EnterPolarsExt for Python<'_> {
         T: Ungil + Send,
         E: Ungil + Send + Into<PyPolarsErr>,
     {
-        let timeout = if is_timeout_enabled() {
+        let _timeout_guard = is_timeout_enabled().then(|| {
             std::hint::cold_path();
             schedule_polars_timeout(get_traceback(self).ok())
-        } else {
-            None
-        };
+        });
         let ret = self.detach(|| catch_polars_abort(AssertUnwindSafe(f)));
-        cancel_polars_timeout(timeout);
         match ret {
             Ok(Ok(ret)) => Ok(ret),
             Ok(Err(err)) => Err(PyErr::from(err.into())),


### PR DESCRIPTION
Previously a panic could cause a `cancel_polars_timeout` call to get omitted resulting in a timeout.