### PR TITLE
fix: Properly compute null count in parquet statistics for list of categorical/enum

### DIFF
--- a/crates/polars-parquet/src/arrow/write/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/write/dictionary.rs
@@ -386,7 +386,7 @@ fn serialize_keys_range<K: DictionaryKey>(
     array: &DictionaryArray<K>,
     type_: &PrimitiveType,
     nested: &[Nested],
-    statistics: Option<ParquetStatistics>,
+    mut statistics: Option<ParquetStatistics>,
     options: WriteOptions,
 ) -> PolarsResult<Page> {
     let mut buffer = vec![];
@@ -412,11 +412,17 @@ fn serialize_keys_range<K: DictionaryKey>(
         (nested::num_values(nested), nested[0].len())
     };
 
+    let null_count = validity.as_ref().map_or(0, Bitmap::unset_bits);
+
+    if let Some(statistics) = statistics.as_mut() {
+        statistics.null_count = options.statistics.null_count.then_some(null_count as i64);
+    }
+
     utils::build_plain_page(
         buffer,
         num_values,
         num_rows,
-        array.null_count(),
+        null_count,
         repetition_levels_byte_length,
         definition_levels_byte_length,
         statistics,
@@ -435,12 +441,11 @@ macro_rules! dyn_prim {
             primitive_encode_plain::<$from, $to>(values, EncodeNullability::new(false), vec![]);
 
         let stats: Option<ParquetStatistics> = if !$options.statistics.is_empty() {
-            let mut stats = primitive_build_statistics::<$from, $to>(
+            let stats = primitive_build_statistics::<$from, $to>(
                 values,
                 $type_.clone(),
                 &$options.statistics,
             );
-            stats.null_count = Some($array.null_count() as i64);
             Some(stats.serialize())
         } else {
             None
@@ -462,7 +467,7 @@ pub fn array_to_pages<K: DictionaryKey>(
     match encoding {
         Encoding::PlainDictionary | Encoding::RleDictionary => {
             // write DictPage
-            let (dict_page, mut statistics): (_, Option<ParquetStatistics>) = match array
+            let (dict_page, statistics): (_, Option<ParquetStatistics>) = match array
                 .values()
                 .dtype()
                 .to_storage()
@@ -601,10 +606,6 @@ pub fn array_to_pages<K: DictionaryKey>(
                     )
                 },
             };
-
-            if let Some(stats) = &mut statistics {
-                stats.null_count = Some(array.null_count() as i64)
-            }
 
             // write DataPages pointing to DictPage
             let data_pages = serialize_keys(array, type_, nested, statistics, options);

--- a/py-polars/tests/unit/io/test_partition.py
+++ b/py-polars/tests/unit/io/test_partition.py
@@ -4,6 +4,7 @@ import io
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypedDict
 
+import pyarrow.parquet as pq
 import pytest
 from hypothesis import example, given
 
@@ -343,6 +344,28 @@ def test_partition_by_file_naming_preserves_order(tmp_path: Path) -> None:
     assert len(output_files) == 100
 
     assert_frame_equal(pl.scan_parquet(output_files).collect(), df)
+
+
+@pytest.mark.parametrize("inner_dtype", [pl.Categorical, pl.Enum(["a", "b"])])
+@pytest.mark.write_disk
+def test_partitioned_parquet_nested_dictionary_null_statistics(
+    tmp_path: Path, inner_dtype: pl.DataType
+) -> None:
+    values = [["a", "b"]] * 10 + [None, ["a"]]
+    df = pl.DataFrame({"values": values}, schema={"values": pl.List(inner_dtype)})
+
+    df.lazy().sink_parquet(
+        pl.PartitionBy(tmp_path, max_rows_per_file=6),
+        row_group_size=4,
+        data_page_size=1,
+        compression="uncompressed",
+    )
+
+    metadata = pq.ParquetFile(tmp_path / "00000001.parquet").metadata
+    assert [
+        metadata.row_group(i).column(0).statistics.null_count
+        for i in range(metadata.num_row_groups)
+    ] == [0, 0]
 
 
 @pytest.mark.parametrize(("io_type"), io_types)


### PR DESCRIPTION
# Motivation

When writing parquet files with `pl.PartitionBy`, the null count for `list(enum)` and `list(cat)` are off for the last parquet file being written. This causes issues when integrating with lakehouses that validate the parquet statistics to ensure nullability constraints. This PR fixes the computation.

The code was written by Codex, this part of the codebase is a little too foreign for me. Brief codex summary:

> Dictionary null statistics were calculated before data-page slicing, so validity padding from zero-copy partition slices was counted and the result was reused across pages. The fix calculates null counts from each page’s sliced, normalized leaf validity instead and removes the obsolete global calculations.

As far as the test is concerned: before the fix, the final row group reported 40 nulls instead of the correct 0.