### PR TITLE
fix(python): Address `read_database` Oracle regression, following introduction of Arrow fast-path

### DIFF
--- a/py-polars/src/polars/io/database/_arrow_registry.py
+++ b/py-polars/src/polars/io/database/_arrow_registry.py
@@ -65,13 +65,13 @@ ARROW_DRIVER_REGISTRY: Final[dict[str, list[ArrowDriverProperties]]] = {
             "minimum_version": None,
         }
     ],
-    "oracledb": [
+    "oracledb_proxy": [
         {
             "fetch_all": "fetch_df_all",
             "fetch_batches": "fetch_df_batches",
             "exact_batch_size": True,
             "repeat_batch_calls": False,
-            "minimum_version": "3.0.0",
+            "minimum_version": None,  # set on the proxy object (3.4.0)
         }
     ],
     "snowflake": [

--- a/py-polars/src/polars/io/database/_cursor_proxies.py
+++ b/py-polars/src/polars/io/database/_cursor_proxies.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from inspect import iscoroutinefunction
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from polars._dependencies import import_optional
+from polars._utils.various import parse_version
 from polars.io.database._utils import _run_async
 
 if TYPE_CHECKING:
@@ -154,10 +156,22 @@ class SurrealDBCursorProxy:
 class OracleCursorProxy:
     """Cursor proxy for `python-oracledb` connections."""
 
+    minimum_version: ClassVar[str] = "3.4.0"
+
     def __init__(self, connection: Any) -> None:
         self.connection = connection
         self.execute_options: dict[str, Any] = {}
         self.query: str | None = None
+
+    @classmethod
+    def supports_arrow(cls, connection: Any) -> bool:
+        """Check if the given connection can serve Arrow data through this proxy."""
+        fetch_df_all = getattr(connection, "fetch_df_all", None)
+        if fetch_df_all is None or iscoroutinefunction(fetch_df_all):
+            return False
+
+        oracledb = import_optional("oracledb")
+        return parse_version(oracledb.__version__) >= parse_version(cls.minimum_version)
 
     def close(self) -> None:
         """Close the cursor."""

--- a/py-polars/src/polars/io/database/_executor.py
+++ b/py-polars/src/polars/io/database/_executor.py
@@ -89,8 +89,13 @@ class ConnectionExecutor:
         )
         if self.driver_name == "surrealdb":
             connection = SurrealDBCursorProxy(client=connection)
-        elif self.driver_name == "oracledb" and hasattr(connection, "fetch_df_all"):
+        elif (
+            # note: only the proxy can serve Arrow data (see `_arrow_registry`)
+            self.driver_name == "oracledb"
+            and OracleCursorProxy.supports_arrow(connection)
+        ):
             connection = OracleCursorProxy(connection)
+            self.driver_name = "oracledb_proxy"
 
         self.cursor = self._normalise_cursor(connection)
         self.result: Any = None
@@ -439,13 +444,6 @@ class ConnectionExecutor:
                 elif conn.engine.driver == "duckdb_engine":
                     self.driver_name = "duckdb"
                     return conn
-                elif conn.engine.driver == "oracledb" and hasattr(
-                    raw_conn := conn.engine.raw_connection().driver_connection,
-                    "fetch_df_all",
-                ):
-                    self.driver_name = "oracledb"
-                    self.can_close_cursor = True
-                    return cast("Cursor", OracleCursorProxy(raw_conn))
                 elif self._is_alchemy_engine(conn):
                     # note: if we create it, we can close it
                     self.can_close_cursor = True
@@ -470,6 +468,20 @@ class ConnectionExecutor:
             "'execute' or 'cursor' method"
         )
         raise TypeError(msg)
+
+    def _oracle_arrow_proxy(self) -> OracleCursorProxy | None:
+        """Return an Arrow proxy for a SQLAlchemy "python-oracledb" connection."""
+        if not self._is_alchemy_async(self.cursor):
+            driver_name = getattr(getattr(self.cursor, "engine", None), "driver", None)
+            if driver_name == "oracledb" and OracleCursorProxy.supports_arrow(
+                # note: proxy the established DBAPI connection so the query
+                # is executed in the caller's own session/transaction
+                raw_conn := getattr(
+                    getattr(self.cursor, "connection", None), "driver_connection", None
+                )
+            ):
+                return OracleCursorProxy(raw_conn)
+        return None
 
     async def _sqlalchemy_async_execute(self, query: TextClause, **options: Any) -> Any:
         """Execute a query using an async SQLAlchemy connection."""
@@ -547,6 +559,18 @@ class ConnectionExecutor:
         options = options or {}
 
         if self._is_alchemy_object(self.cursor):
+            # note: the Arrow "fetch_df_*" methods take raw SQL, so the Oracle fast-path
+            # is only available for string queries; anything else must be compiled first
+            if (
+                isinstance(query, str)
+                and (oracle_proxy := self._oracle_arrow_proxy()) is not None
+            ):
+                # note: `self.cursor` is deliberately left as the SQLAlchemy connection,
+                # so that it remains open (and closeable) for the proxy's lifetime
+                self.driver_name = "oracledb_proxy"
+                self.result = oracle_proxy.execute(query, **options)
+                return self
+
             cursor_execute, options, query = self._sqlalchemy_setup(query, options)
         else:
             cursor_execute = self.cursor.execute


### PR DESCRIPTION
FYI: @ritchie46 - landing [this one](https://github.com/pola-rs/polars/pull/28902) again, following the 2.x history/merge snafu 😉 

---

Fixes #28463.

Slightly reworked interaction with the Oracle fast-path proxy object, and bumped the supported minimum `oracledb` driver version for the fast-path to 3.4.0 (when the PyCapsule support came out of prerelease).