### PR TITLE
perf: Default `posix_fadv` to `Normal`

### DIFF
--- a/crates/polars-config/src/lib.rs
+++ b/crates/polars-config/src/lib.rs
@@ -126,7 +126,7 @@ const DEFAULT_FILE_READ_CONCURRENCY: u64 = 32;
 
 /// Access pattern hint for local file reads (Linux: `posix_fadvise`).
 const FILE_POSIX_FADV: &str = "POLARS_FILE_POSIX_FADV";
-const DEFAULT_FILE_POSIX_FADV: FileAdvice = FileAdvice::Random;
+const DEFAULT_FILE_POSIX_FADV: FileAdvice = FileAdvice::Normal;
 
 static KNOWN_OPTIONS: &[&str] = &[
     // Public.


### PR DESCRIPTION
Follow-up to https://github.com/pola-rs/polars/pull/29091

This PR defaults the `posix_fadv` setting for file-based I/O to `normal`. 

Note, the best performing setting depends on the file(s) being accessed.